### PR TITLE
fix(rdr-111): bridge plugin/wheel version-compat guard (nexus-yeu8)

### DIFF
--- a/nx/hooks/scripts/orb_bridge_notification.py
+++ b/nx/hooks/scripts/orb_bridge_notification.py
@@ -25,6 +25,9 @@ if sys.version_info < (3, 12):
 
 _HOOK_TYPE = "Notification"
 
+# Plugin/wheel compat protocol (nexus-yeu8). See orb_bridge_pretooluse.py.
+EXPECTED_BRIDGE_API_VERSION = 1
+
 
 def main() -> None:
     raw = sys.stdin.read()
@@ -35,9 +38,16 @@ def main() -> None:
         payload = {}
 
     try:
-        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+        from nexus.cockpit.hook_bridge import (
+            check_bridge_api_version,
+            configure_logging_to_stderr,
+            emit,
+            output_for_hook,
+        )
 
         configure_logging_to_stderr()
+        if not check_bridge_api_version(EXPECTED_BRIDGE_API_VERSION):
+            return
         emit(_HOOK_TYPE, payload)
 
         out = output_for_hook(_HOOK_TYPE)

--- a/nx/hooks/scripts/orb_bridge_posttooluse.py
+++ b/nx/hooks/scripts/orb_bridge_posttooluse.py
@@ -22,6 +22,9 @@ if sys.version_info < (3, 12):
 
 _HOOK_TYPE = "PostToolUse"
 
+# Plugin/wheel compat protocol (nexus-yeu8). See orb_bridge_pretooluse.py.
+EXPECTED_BRIDGE_API_VERSION = 1
+
 
 def main() -> None:
     raw = sys.stdin.read()
@@ -32,9 +35,16 @@ def main() -> None:
         payload = {}
 
     try:
-        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+        from nexus.cockpit.hook_bridge import (
+            check_bridge_api_version,
+            configure_logging_to_stderr,
+            emit,
+            output_for_hook,
+        )
 
         configure_logging_to_stderr()
+        if not check_bridge_api_version(EXPECTED_BRIDGE_API_VERSION):
+            return
         emit(_HOOK_TYPE, payload)
 
         out = output_for_hook(_HOOK_TYPE)

--- a/nx/hooks/scripts/orb_bridge_pretooluse.py
+++ b/nx/hooks/scripts/orb_bridge_pretooluse.py
@@ -24,6 +24,11 @@ if sys.version_info < (3, 12):
 
 _HOOK_TYPE = "PreToolUse"
 
+# Plugin/wheel compat protocol (nexus-yeu8). Bump in lockstep with
+# nexus.cockpit.hook_bridge.BRIDGE_API_VERSION whenever the bridge's public
+# API changes incompatibly. On mismatch the script exits 0 without emitting.
+EXPECTED_BRIDGE_API_VERSION = 1
+
 
 def main() -> None:
     raw = sys.stdin.read()
@@ -34,9 +39,16 @@ def main() -> None:
         payload = {}
 
     try:
-        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+        from nexus.cockpit.hook_bridge import (
+            check_bridge_api_version,
+            configure_logging_to_stderr,
+            emit,
+            output_for_hook,
+        )
 
         configure_logging_to_stderr()
+        if not check_bridge_api_version(EXPECTED_BRIDGE_API_VERSION):
+            return
         emit(_HOOK_TYPE, payload)
 
         out = output_for_hook(_HOOK_TYPE)

--- a/nx/hooks/scripts/orb_bridge_session.py
+++ b/nx/hooks/scripts/orb_bridge_session.py
@@ -28,6 +28,9 @@ if sys.version_info < (3, 12):
 
 _SUPPORTED = frozenset({"SessionStart", "SessionEnd"})
 
+# Plugin/wheel compat protocol (nexus-yeu8). See orb_bridge_pretooluse.py.
+EXPECTED_BRIDGE_API_VERSION = 1
+
 
 def main() -> None:
     raw = sys.stdin.read()
@@ -45,9 +48,16 @@ def main() -> None:
         hook_type = "SessionStart"
 
     try:
-        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+        from nexus.cockpit.hook_bridge import (
+            check_bridge_api_version,
+            configure_logging_to_stderr,
+            emit,
+            output_for_hook,
+        )
 
         configure_logging_to_stderr()
+        if not check_bridge_api_version(EXPECTED_BRIDGE_API_VERSION):
+            return
         emit(hook_type, payload)
 
         out = output_for_hook(hook_type)

--- a/nx/hooks/scripts/orb_bridge_stop.py
+++ b/nx/hooks/scripts/orb_bridge_stop.py
@@ -24,6 +24,9 @@ if sys.version_info < (3, 12):
 
 _SUPPORTED = frozenset({"Stop", "StopFailure"})
 
+# Plugin/wheel compat protocol (nexus-yeu8). See orb_bridge_pretooluse.py.
+EXPECTED_BRIDGE_API_VERSION = 1
+
 
 def main() -> None:
     raw = sys.stdin.read()
@@ -38,9 +41,16 @@ def main() -> None:
         hook_type = "Stop"
 
     try:
-        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+        from nexus.cockpit.hook_bridge import (
+            check_bridge_api_version,
+            configure_logging_to_stderr,
+            emit,
+            output_for_hook,
+        )
 
         configure_logging_to_stderr()
+        if not check_bridge_api_version(EXPECTED_BRIDGE_API_VERSION):
+            return
         emit(hook_type, payload)
 
         out = output_for_hook(hook_type)

--- a/nx/hooks/scripts/orb_bridge_subagent_stop.py
+++ b/nx/hooks/scripts/orb_bridge_subagent_stop.py
@@ -23,6 +23,9 @@ if sys.version_info < (3, 12):
 
 _HOOK_TYPE = "SubagentStop"
 
+# Plugin/wheel compat protocol (nexus-yeu8). See orb_bridge_pretooluse.py.
+EXPECTED_BRIDGE_API_VERSION = 1
+
 
 def main() -> None:
     raw = sys.stdin.read()
@@ -33,9 +36,16 @@ def main() -> None:
         payload = {}
 
     try:
-        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+        from nexus.cockpit.hook_bridge import (
+            check_bridge_api_version,
+            configure_logging_to_stderr,
+            emit,
+            output_for_hook,
+        )
 
         configure_logging_to_stderr()
+        if not check_bridge_api_version(EXPECTED_BRIDGE_API_VERSION):
+            return
         emit(_HOOK_TYPE, payload)
 
         out = output_for_hook(_HOOK_TYPE)

--- a/nx/hooks/scripts/orb_bridge_user_prompt_submit.py
+++ b/nx/hooks/scripts/orb_bridge_user_prompt_submit.py
@@ -25,6 +25,9 @@ if sys.version_info < (3, 12):
 
 _HOOK_TYPE = "UserPromptSubmit"
 
+# Plugin/wheel compat protocol (nexus-yeu8). See orb_bridge_pretooluse.py.
+EXPECTED_BRIDGE_API_VERSION = 1
+
 
 def main() -> None:
     raw = sys.stdin.read()
@@ -35,9 +38,16 @@ def main() -> None:
         payload = {}
 
     try:
-        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+        from nexus.cockpit.hook_bridge import (
+            check_bridge_api_version,
+            configure_logging_to_stderr,
+            emit,
+            output_for_hook,
+        )
 
         configure_logging_to_stderr()
+        if not check_bridge_api_version(EXPECTED_BRIDGE_API_VERSION):
+            return
         emit(_HOOK_TYPE, payload)
 
         out = output_for_hook(_HOOK_TYPE)

--- a/src/nexus/cockpit/hook_bridge.py
+++ b/src/nexus/cockpit/hook_bridge.py
@@ -49,6 +49,63 @@ if TYPE_CHECKING:
 _log = structlog.get_logger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Plugin/wheel compatibility protocol (nexus-yeu8)
+# ---------------------------------------------------------------------------
+
+#: Bridge public-API protocol version.
+#:
+#: The nx plugin ships seven ``orb_bridge_*.py`` scripts that import this
+#: module from the installed ``conexus`` wheel. Plugin and wheel can drift
+#: in version (user upgrades one but not the other). Each script embeds an
+#: ``EXPECTED_BRIDGE_API_VERSION`` literal and calls
+#: :func:`check_bridge_api_version` before doing any hook work. On mismatch
+#: the helper logs ``hook_bridge_version_mismatch`` at ERROR level and the
+#: script exits 0 so the user's tool flow is not disrupted.
+#:
+#: Bump policy: increment ``BRIDGE_API_VERSION`` whenever the bridge's
+#: public API changes in a way that the existing scripts cannot accommodate.
+#: That includes (non-exhaustive):
+#:
+#: - incompatible signature change to :func:`emit` or :func:`output_for_hook`
+#: - removal or rename of a public symbol the scripts import
+#: - change in the contract for return values the scripts rely on
+#:
+#: Bumping this constant without also bumping the embedded
+#: ``EXPECTED_BRIDGE_API_VERSION`` in all seven scripts will trip the
+#: mismatch path on every hook fire by design: the wheel asserts the
+#: protocol shape, and stale scripts are guaranteed to skip rather than
+#: silently corrupt telemetry. The version is intentionally distinct from
+#: the package ``__version__``; package versions may bump for reasons that
+#: do not touch the bridge contract.
+BRIDGE_API_VERSION: int = 1
+
+
+def check_bridge_api_version(expected: int) -> bool:
+    """Return True if the script's expected protocol matches the wheel.
+
+    On mismatch, emits a ``hook_bridge_version_mismatch`` ERROR log with
+    both versions and returns False. Callers (bridge scripts) should exit 0
+    on False so a version skew between plugin and wheel does not crash the
+    user's tool flow; the tuple is simply not written.
+
+    Args:
+        expected: The ``EXPECTED_BRIDGE_API_VERSION`` literal embedded in
+            the calling script at plugin-author time.
+
+    Returns:
+        True on match, False on mismatch.
+    """
+    if expected == BRIDGE_API_VERSION:
+        return True
+    _log.error(
+        "hook_bridge_version_mismatch",
+        expected=expected,
+        actual=BRIDGE_API_VERSION,
+    )
+    return False
+
+
 def configure_logging_to_stderr() -> None:
     """Redirect structlog output to stderr.
 

--- a/tests/cockpit/test_bridge_version_compat.py
+++ b/tests/cockpit/test_bridge_version_compat.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Plugin/wheel version-compat guard for orb_bridge_*.py scripts (nexus-yeu8).
+
+The nx plugin scripts embed an expected ``BRIDGE_API_VERSION``; the wheel
+exports its current value via ``nexus.cockpit.hook_bridge``. On mismatch the
+helper logs an ERROR-level structlog event and returns False so the script
+can exit 0 without writing any tuple. On match the helper returns True.
+
+Tests:
+- BRIDGE_API_VERSION is exported and an int.
+- check_bridge_api_version returns True on match (no warn/error log).
+- check_bridge_api_version returns False on mismatch and logs ERROR with both versions.
+- A bridge script with a stale embedded version exits 0 and does NOT call emit().
+- A bridge script with the matching embedded version proceeds to call emit().
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import structlog
+from structlog.testing import capture_logs
+
+from nexus.cockpit import hook_bridge
+
+
+def test_bridge_api_version_exported_as_int() -> None:
+    assert isinstance(hook_bridge.BRIDGE_API_VERSION, int)
+    assert hook_bridge.BRIDGE_API_VERSION >= 1
+
+
+def test_check_bridge_api_version_match_returns_true() -> None:
+    structlog.configure()  # reset to default
+    with capture_logs() as logs:
+        assert hook_bridge.check_bridge_api_version(hook_bridge.BRIDGE_API_VERSION) is True
+    # No error or warning logs on match
+    assert not any(
+        entry.get("log_level") in ("error", "warning")
+        and entry.get("event") == "hook_bridge_version_mismatch"
+        for entry in logs
+    )
+
+
+def test_check_bridge_api_version_mismatch_returns_false_and_logs_error() -> None:
+    structlog.configure()
+    wrong = hook_bridge.BRIDGE_API_VERSION + 99
+    with capture_logs() as logs:
+        result = hook_bridge.check_bridge_api_version(wrong)
+    assert result is False
+    matching = [e for e in logs if e.get("event") == "hook_bridge_version_mismatch"]
+    assert len(matching) == 1
+    entry = matching[0]
+    assert entry["log_level"] == "error"
+    assert entry["expected"] == wrong
+    assert entry["actual"] == hook_bridge.BRIDGE_API_VERSION
+
+
+# ---------------------------------------------------------------------------
+# All seven shipped scripts must embed the current BRIDGE_API_VERSION.
+# ---------------------------------------------------------------------------
+
+_SCRIPTS = [
+    "orb_bridge_pretooluse.py",
+    "orb_bridge_posttooluse.py",
+    "orb_bridge_stop.py",
+    "orb_bridge_subagent_stop.py",
+    "orb_bridge_user_prompt_submit.py",
+    "orb_bridge_session.py",
+    "orb_bridge_notification.py",
+]
+
+
+def _scripts_dir() -> Path:
+    # tests/cockpit/test_bridge_version_compat.py -> repo root -> nx/hooks/scripts
+    return Path(__file__).resolve().parents[2] / "nx" / "hooks" / "scripts"
+
+
+@pytest.mark.parametrize("script_name", _SCRIPTS)
+def test_each_script_embeds_current_bridge_api_version(script_name: str) -> None:
+    text = (_scripts_dir() / script_name).read_text()
+    expected_literal = f"EXPECTED_BRIDGE_API_VERSION = {hook_bridge.BRIDGE_API_VERSION}"
+    assert expected_literal in text, (
+        f"{script_name} must embed EXPECTED_BRIDGE_API_VERSION = "
+        f"{hook_bridge.BRIDGE_API_VERSION}"
+    )
+    # And must call the helper
+    assert "check_bridge_api_version" in text
+
+
+@pytest.mark.parametrize("script_name", _SCRIPTS)
+def test_script_exits_0_on_version_mismatch_without_emitting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, script_name: str
+) -> None:
+    """Force a mismatch via a sitecustomize shim, run the script, assert no emit()."""
+    # Shim that monkeypatches the wheel's BRIDGE_API_VERSION to a different value
+    # and replaces emit() with a sentinel that writes to a marker file.
+    marker = tmp_path / "emit_called"
+    sitecustomize = tmp_path / "sitecustomize.py"
+    sitecustomize.write_text(
+        textwrap.dedent(
+            f"""
+            from nexus.cockpit import hook_bridge as _hb
+            _hb.BRIDGE_API_VERSION = _hb.BRIDGE_API_VERSION + 99
+
+            def _fake_emit(*a, **kw):
+                open({str(marker)!r}, "w").write("called")
+
+            _hb.emit = _fake_emit
+            """
+        )
+    )
+
+    env = {
+        **dict(__import__("os").environ),
+        "PYTHONPATH": f"{tmp_path}:" + dict(__import__("os").environ).get("PYTHONPATH", ""),
+        # Force CLAUDECODE on so emit would otherwise be attempted
+        "CLAUDECODE": "1",
+    }
+    script = _scripts_dir() / script_name
+    proc = subprocess.run(
+        [sys.executable, str(script)],
+        input="{}",
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    assert proc.returncode == 0, f"stderr={proc.stderr}"
+    assert not marker.exists(), (
+        f"emit() was called despite version mismatch (script={script_name}, "
+        f"stderr={proc.stderr})"
+    )
+
+
+def test_script_proceeds_on_version_match(tmp_path: Path) -> None:
+    """When versions match, the script calls emit() (verified via shim)."""
+    marker = tmp_path / "emit_called"
+    sitecustomize = tmp_path / "sitecustomize.py"
+    sitecustomize.write_text(
+        textwrap.dedent(
+            f"""
+            from nexus.cockpit import hook_bridge as _hb
+
+            def _fake_emit(*a, **kw):
+                open({str(marker)!r}, "w").write("called")
+
+            def _fake_output(*a, **kw):
+                return None
+
+            _hb.emit = _fake_emit
+            _hb.output_for_hook = _fake_output
+            """
+        )
+    )
+    env = {
+        **dict(__import__("os").environ),
+        "PYTHONPATH": f"{tmp_path}:" + dict(__import__("os").environ).get("PYTHONPATH", ""),
+        "CLAUDECODE": "1",
+    }
+    script = _scripts_dir() / "orb_bridge_notification.py"
+    proc = subprocess.run(
+        [sys.executable, str(script)],
+        input="{}",
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    assert proc.returncode == 0, f"stderr={proc.stderr}"
+    assert marker.exists(), f"emit() not invoked on version match; stderr={proc.stderr}"


### PR DESCRIPTION
## Summary

Add a plugin/wheel compat protocol so the seven `orb_bridge_*.py` scripts in the nx Claude plugin cannot silently break when the installed `conexus` wheel drifts in version.

- `BRIDGE_API_VERSION: int = 1` exported from `nexus.cockpit.hook_bridge` with a docstring that codifies the bump policy (incompatible changes to `emit()`, `output_for_hook()`, or the public-symbol surface).
- `check_bridge_api_version(expected) -> bool` helper: returns True on match, logs `hook_bridge_version_mismatch` at ERROR level with both versions and returns False on mismatch.
- All seven bridge scripts now embed `EXPECTED_BRIDGE_API_VERSION = 1` and call the helper before doing any hook work. On mismatch the script returns early (exit 0) so the user's tool flow is not disrupted.

## Closes

Closes nexus-yeu8
Refs epic nexus-hp9f

## Test plan

- [x] `uv run pytest tests/cockpit/test_bridge_version_compat.py` — 18 passed
- [x] `uv run pytest tests/cockpit/ tests/hooks/` — 192 passed
- [x] Each of the seven scripts embeds the literal `EXPECTED_BRIDGE_API_VERSION = 1` and calls the helper (asserted via parametrised tests).
- [x] Subprocess test forces a mismatch via a sitecustomize shim, asserts the script exits 0 without calling `emit()`.
- [x] Subprocess test on the match path asserts `emit()` is invoked.