### PR TITLE
feat(nx_plan_audit): require verification_method per finding (structural honesty enforcement)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -4089,8 +4089,32 @@ async def nx_plan_audit(
         "type": "object",
         "required": ["verdict", "findings", "summary"],
         "properties": {
-            "verdict": {"type": "string"},
-            "findings": {"type": "array", "items": {"type": "object"}},
+            "verdict": {
+                "type": "string",
+                "enum": ["pass", "fail", "partial", "skipped"],
+            },
+            "findings": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["title", "verification_method"],
+                    "properties": {
+                        "title": {"type": "string"},
+                        "severity": {"type": "string"},
+                        "detail": {"type": "string"},
+                        "verification_method": {
+                            "type": "string",
+                            "enum": [
+                                "mcp_search",
+                                "filesystem",
+                                "prompt_only",
+                                "n/a",
+                            ],
+                        },
+                        "verification_evidence": {"type": "string"},
+                    },
+                },
+            },
             "summary": {"type": "string"},
         },
     }
@@ -4100,15 +4124,37 @@ async def nx_plan_audit(
         "lookup tool like `mcp__nx__query`) to verify EACH file path cited "
         "in the plan before listing it in `findings`. An audit produced "
         "without tool calls is not a valid audit — it is speculation.\n\n"
-        "Verdict semantics:\n"
-        "  - `ok` / `fail`: you attempted verification via tool calls and "
-        "reached a conclusion.\n"
+        "Verdict semantics (enum-bound):\n"
+        "  - `pass` / `fail`: you attempted verification via tool calls "
+        "and reached a conclusion.\n"
         "  - `partial`: ONLY appropriate when tool calls were ATTEMPTED "
         "and FAILED (e.g. search returned no results, query errored). It "
         "is NOT appropriate when you simply skipped tool calls. If you "
         "return verdict=`partial`, your `findings` MUST explicitly name "
         "which tool calls failed and why (e.g. {severity: 'info', title: "
-        "'search returned 0 hits for path X', tool: 'mcp__nx__search'}).\n\n"
+        "'search returned 0 hits for path X', tool: 'mcp__nx__search'}).\n"
+        "  - `skipped`: return this when you decided NOT to call tools — "
+        "do NOT fabricate `partial` or `pass` for unverified findings. "
+        "`skipped` is the honest report for 'I did not run a real audit'; "
+        "operators can then re-run or pin to claude.\n\n"
+        "Per-finding `verification_method` (REQUIRED, enum-bound):\n"
+        "  - `mcp_search`: you called `mcp__nx__search` (or equivalent T3 "
+        "lookup) and the result substantiates the finding.\n"
+        "  - `filesystem`: you called Read / Glob / Grep or another "
+        "filesystem tool and the result substantiates the finding.\n"
+        "  - `prompt_only`: NO tool calls — finding is inferred from the "
+        "prompt content alone. This is an honest admission of "
+        "non-verification.\n"
+        "  - `n/a`: structural / dependency-ordering check that needs no "
+        "external verification (e.g. phase B references phase A by id).\n\n"
+        "HONESTY RULE: If ANY finding has `verification_method: "
+        "prompt_only`, your overall `verdict` MUST be `skipped`. That is "
+        "how you structurally report 'I did not do verification' instead "
+        "of fabricating authoritative-sounding specifics. Operators filter "
+        "on `verification_method` post-hoc.\n\n"
+        "`verification_evidence` is optional free-text: the search query "
+        "used, the file content quoted, the line number observed. "
+        "Encouraged for `mcp_search` / `filesystem` findings.\n\n"
         "Parse the plan, verify file paths exist via tool calls, check "
         "dependency ordering, identify gaps or incorrect assumptions, then "
         "emit a structured verdict grounded in the tool-call results.\n\n"
@@ -4146,7 +4192,11 @@ async def nx_plan_audit(
         findings = payload.get("findings", [])
         lines = [f"Verdict: {verdict}", summary]
         for f in findings:
-            lines.append(f"  [{f.get('severity', '?')}] {f.get('title', '')}")
+            lines.append(
+                f"  [{f.get('severity', '?')}/"
+                f"{f.get('verification_method', '?')}] "
+                f"{f.get('title', '')}"
+            )
         return "\n".join(lines)
     return str(payload)
 

--- a/tests/test_nx_plan_audit_routing.py
+++ b/tests/test_nx_plan_audit_routing.py
@@ -16,7 +16,7 @@ async def test_default_env_routes_to_claude(
 ) -> None:
     monkeypatch.delenv("NEXUS_TIER_B_DISPATCHER", raising=False)
     fake = AsyncMock(return_value={
-        "verdict": "ok", "findings": [], "summary": "s",
+        "verdict": "pass", "findings": [], "summary": "s",
     })
     with (
         patch("nexus.operators.dispatch.claude_dispatch", fake),
@@ -28,7 +28,7 @@ async def test_default_env_routes_to_claude(
         from nexus.mcp.core import nx_plan_audit
         impl = getattr(nx_plan_audit, "fn", nx_plan_audit)
         result = await impl('{"phases": []}')
-    assert "ok" in result
+    assert "pass" in result
     assert fake.await_count == 1
 
 
@@ -38,7 +38,7 @@ async def test_qwen_agent_env_routes_to_qwen_agent(
 ) -> None:
     monkeypatch.setenv("NEXUS_TIER_B_DISPATCHER", "qwen_agent")
     fake_qwen = AsyncMock(return_value={
-        "verdict": "ok", "findings": [], "summary": "qwen-summary",
+        "verdict": "pass", "findings": [], "summary": "qwen-summary",
     })
     fake_claude = AsyncMock(side_effect=AssertionError("claude must not run"))
     with (
@@ -68,3 +68,48 @@ async def test_qwen_agent_env_routes_to_qwen_agent(
     assert "You MUST call `mcp__nx__search`" in args[0]
     # `partial` verdict is gated on attempted-but-failed tool calls.
     assert "verdict=`partial`" in args[0]
+    # Structural-honesty enforcement: per-finding verification_method +
+    # `skipped` verdict for prompt_only findings (PR follow-on to #810).
+    assert "verification_method" in args[0]
+    assert "prompt_only" in args[0]
+    assert "HONESTY RULE" in args[0]
+    assert "`skipped`" in args[0]
+    # Schema carries the enum-bound verdict + per-finding shape.
+    verdict_schema = args[1]["properties"]["verdict"]
+    assert verdict_schema.get("enum") == ["pass", "fail", "partial", "skipped"]
+    findings_item = args[1]["properties"]["findings"]["items"]
+    assert "verification_method" in findings_item["required"]
+    assert findings_item["properties"]["verification_method"]["enum"] == [
+        "mcp_search", "filesystem", "prompt_only", "n/a",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rendered_output_includes_verification_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator-visible rendering surfaces verification_method per finding."""
+    monkeypatch.delenv("NEXUS_TIER_B_DISPATCHER", raising=False)
+    fake = AsyncMock(return_value={
+        "verdict": "skipped",
+        "findings": [
+            {
+                "title": "phase-A file path",
+                "severity": "info",
+                "verification_method": "prompt_only",
+            },
+            {
+                "title": "phase-B dependency",
+                "severity": "warn",
+                "verification_method": "mcp_search",
+            },
+        ],
+        "summary": "two findings",
+    })
+    with patch("nexus.operators.dispatch.claude_dispatch", fake):
+        from nexus.mcp.core import nx_plan_audit
+        impl = getattr(nx_plan_audit, "fn", nx_plan_audit)
+        result = await impl('{"phases": []}')
+    assert "[info/prompt_only] phase-A file path" in result
+    assert "[warn/mcp_search] phase-B dependency" in result
+    assert "Verdict: skipped" in result


### PR DESCRIPTION
## Summary

Schema change + prompt revision for `nx_plan_audit` (option (b) from the four-option discussion). Adds a structural backstop on top of PR #810's prompt-level mandate: force the model to structurally admit which verification method (if any) it used per finding, and gate `verdict` to an enum that includes an honest `skipped` value.

## Bench evidence

Spike-D instrumented run (2026-05-15/16) against tier-B tools confirmed `nx_plan_audit` failure mode under qwen:

- Exactly **2 assistant messages** per run: one `thinking` block + one `text` block with the final JSON.
- **Zero `tool_use` blocks.** Supervisor `tool_calls=0` counter is authoritative.
- Yet the `findings` array contained authoritative-sounding specifics like *"`src/nexus/aspect_extractor.py` — EXISTS — grep confirmed at line 22"* — fabricated, never searched.

PR #810's prompt-level "you MUST call `mcp__nx__search`" mandate is necessary but insufficient — qwen has enough surface context from the inlined `plan_json` plus the SDK's `cwd` to write plausible output without searching. The schema is the structural fix.

## Implementation

- **`verdict` enum-bound**: `{pass, fail, partial, skipped}`. `skipped` is the new value — the honest report for "I decided not to call tools".
- **Per-finding `verification_method`** (REQUIRED): `{mcp_search, filesystem, prompt_only, n/a}`. `prompt_only` is the explicit admission of no tool verification.
- **Honesty rule** in prompt: *"If ANY finding has `verification_method: prompt_only`, your overall `verdict` MUST be `skipped`."* Operators filter on `verification_method` post-hoc.
- **Optional `verification_evidence`** free-text: the search query used, the file content quoted, the line number. Encouraged for `mcp_search` / `filesystem`.
- **Rendering update**: `[severity/verification_method] title` per finding so operators see the honesty marker in the returned string.
- PR #810's "You MUST call `mcp__nx__search`" mandate retained. JSON-only finalization trailer (PR #799) retained.

## Test plan

- [x] `tests/test_nx_plan_audit_routing.py`: 3 tests (default routes to claude, qwen_agent routing with new prompt-phrase + schema-shape assertions, new render test for `verification_method` surfacing).
- [x] Focused suite: 16 passed (`test_nx_plan_audit_routing`, `test_nx_tidy_routing`, `test_nx_enrich_beads_routing`, `test_qwen_agent_dispatch`).
- [x] Broader sanity (`-k "audit or tidy or enrich or qwen_agent or plan"`): 967 passed, 7 skipped.

## Breaking change

The schema is breaking for any downstream consumer of `findings[].verdict` or free-form `verdict`. Risk is low — `nx_plan_audit`'s tier-B path shipped recently (#805), no stored audit records to migrate.

## Out of scope

- Routing changes — tier-B dispatcher selection unchanged.
- Schema migration for stored audit records — none exist.
- Bench re-run — operator-driven follow-on.

## Linked

#796, #797, #799, #804, #805, #810.