### PR TITLE
feat(operators): pin nx_plan_audit to claude (tier-B per-tool routing + bake-in pin)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -3865,6 +3865,47 @@ async def nx_answer(
     )
 
 
+# ── Tier-B dispatcher routing ─────────────────────────────────────────────────
+#
+# Tools listed here are *pinned* to ``claude_dispatch`` even when the global
+# ``NEXUS_TIER_B_DISPATCHER=qwen_agent`` is set. Mirrors the bake-in pin
+# pattern from PR #626 (which pinned ``extract`` to claude after a single
+# bench miss).
+#
+# nx_plan_audit: spike-D bench v3 (2026-05-16,
+#   /tmp/spike-d-out/parity-audit-v3-2026-05-16.jsonl) — even with PR #810
+#   (prompt mandate) and PR #812 (verification_method enum) in place, qwen
+#   emits zero ``tool_use`` blocks and fabricates findings with
+#   ``verification_method: filesystem``. The structured-honesty slot exists
+#   but qwen fills it dishonestly. Pin avoids shipping that by default;
+#   operators can opt back in per-shell via
+#   ``NEXUS_TIER_B_NX_PLAN_AUDIT_DISPATCHER=qwen_agent``.
+TIER_B_CLAUDE_PINNED: frozenset[str] = frozenset({"nx_plan_audit"})
+
+
+def _pick_tier_b_dispatcher(tool_name: str) -> str:
+    """Resolve the tier-B dispatcher for *tool_name*.
+
+    Precedence (highest first):
+      1. ``NEXUS_TIER_B_<TOOL>_DISPATCHER`` — per-tool override, wins
+         absolutely.
+      2. ``NEXUS_TIER_B_DISPATCHER`` — global mode. If ``qwen_agent`` AND
+         the tool is NOT in ``TIER_B_CLAUDE_PINNED``, routes through qwen.
+      3. ``claude`` — default.
+
+    Returns the lowercased dispatcher name (``claude`` or ``qwen_agent``).
+    """
+    env_per_tool = _os.environ.get(
+        f"NEXUS_TIER_B_{tool_name.upper()}_DISPATCHER"
+    )
+    if env_per_tool:
+        return env_per_tool.lower()
+    global_mode = _os.environ.get("NEXUS_TIER_B_DISPATCHER", "claude").lower()
+    if global_mode == "qwen_agent" and tool_name in TIER_B_CLAUDE_PINNED:
+        return "claude"
+    return global_mode
+
+
 @mcp.tool()
 async def nx_tidy(
     topic: str,
@@ -3932,9 +3973,9 @@ async def nx_tidy(
         "Begin your response with `{` and end with `}`."
     )
 
-    # Tier-B dispatcher selection — mirror of nx_enrich_beads.
-    tier_b = _os.environ.get("NEXUS_TIER_B_DISPATCHER", "claude").lower()
-    if tier_b == "qwen_agent":
+    # Tier-B dispatcher selection — via _pick_tier_b_dispatcher so
+    # per-tool overrides and pin-set semantics apply uniformly.
+    if _pick_tier_b_dispatcher("nx_tidy") == "qwen_agent":
         from nexus.operators.qwen_agent_dispatch import qwen_agent_dispatch
 
         payload = await qwen_agent_dispatch(
@@ -4028,8 +4069,7 @@ async def nx_enrich_beads(
     # ``NEXUS_TIER_B_DISPATCHER=qwen_agent`` routes through the
     # qwen-coprocessor-stack supervisor with the ``nx`` extension wired
     # in so the spawned qwen session can use search/query tools mid-loop.
-    tier_b = _os.environ.get("NEXUS_TIER_B_DISPATCHER", "claude").lower()
-    if tier_b == "qwen_agent":
+    if _pick_tier_b_dispatcher("nx_enrich_beads") == "qwen_agent":
         from nexus.operators.qwen_agent_dispatch import qwen_agent_dispatch
 
         payload = await qwen_agent_dispatch(
@@ -4169,9 +4209,9 @@ async def nx_plan_audit(
         "Begin your response with `{` and end with `}`."
     )
 
-    # Tier-B dispatcher selection — mirror of nx_enrich_beads.
-    tier_b = _os.environ.get("NEXUS_TIER_B_DISPATCHER", "claude").lower()
-    if tier_b == "qwen_agent":
+    # Tier-B dispatcher selection — pinned to claude by default; see
+    # TIER_B_CLAUDE_PINNED for the rationale and override knob.
+    if _pick_tier_b_dispatcher("nx_plan_audit") == "qwen_agent":
         from nexus.operators.qwen_agent_dispatch import qwen_agent_dispatch
 
         payload = await qwen_agent_dispatch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,6 +232,12 @@ def _isolate_dispatch_routing(monkeypatch: pytest.MonkeyPatch) -> None:
         # test off the default claude path. Same isolation reasoning as
         # NEXUS_DISPATCH_BACKEND above.
         "NEXUS_TIER_B_DISPATCHER",
+        # Per-tool tier-B overrides (PR pin-plan-audit-claude). The pin
+        # set defaults nx_plan_audit to claude even when the global var
+        # is qwen_agent; tests that exercise pin semantics must opt in.
+        "NEXUS_TIER_B_NX_PLAN_AUDIT_DISPATCHER",
+        "NEXUS_TIER_B_NX_TIDY_DISPATCHER",
+        "NEXUS_TIER_B_NX_ENRICH_BEADS_DISPATCHER",
         # Supervisor-binary override for the qwen-agent transport — kept
         # out of band so tests that exercise resolution can ``setenv`` it
         # explicitly without inheriting an operator's real supervisor

--- a/tests/test_nx_plan_audit_routing.py
+++ b/tests/test_nx_plan_audit_routing.py
@@ -33,10 +33,43 @@ async def test_default_env_routes_to_claude(
 
 
 @pytest.mark.asyncio
-async def test_qwen_agent_env_routes_to_qwen_agent(
+async def test_global_qwen_env_still_routes_to_claude_due_to_pin(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """nx_plan_audit is in TIER_B_CLAUDE_PINNED. Setting the global
+    ``NEXUS_TIER_B_DISPATCHER=qwen_agent`` MUST NOT route this tool
+    through qwen — pin wins. Operators opt back in per-tool only.
+    """
     monkeypatch.setenv("NEXUS_TIER_B_DISPATCHER", "qwen_agent")
+    monkeypatch.delenv("NEXUS_TIER_B_NX_PLAN_AUDIT_DISPATCHER", raising=False)
+    fake_claude = AsyncMock(return_value={
+        "verdict": "pass", "findings": [], "summary": "claude-ran",
+    })
+    fake_qwen = AsyncMock(side_effect=AssertionError(
+        "qwen_agent must not run — nx_plan_audit is pinned to claude"
+    ))
+    with (
+        patch("nexus.operators.dispatch.claude_dispatch", fake_claude),
+        patch(
+            "nexus.operators.qwen_agent_dispatch.qwen_agent_dispatch",
+            new=fake_qwen,
+        ),
+    ):
+        from nexus.mcp.core import nx_plan_audit
+        impl = getattr(nx_plan_audit, "fn", nx_plan_audit)
+        result = await impl('{"phases": []}')
+    assert "claude-ran" in result
+    assert fake_claude.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_per_tool_override_routes_to_qwen_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-tool override beats the pin set. Operators who want to
+    re-bench or experiment can opt back into qwen explicitly.
+    """
+    monkeypatch.setenv("NEXUS_TIER_B_NX_PLAN_AUDIT_DISPATCHER", "qwen_agent")
     fake_qwen = AsyncMock(return_value={
         "verdict": "pass", "findings": [], "summary": "qwen-summary",
     })

--- a/tests/test_pick_tier_b_dispatcher.py
+++ b/tests/test_pick_tier_b_dispatcher.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit tests for ``_pick_tier_b_dispatcher``.
+
+Covers the precedence ladder:
+  per-tool env override > global env + pin set > default ``claude``.
+
+The pin set currently contains ``nx_plan_audit`` (spike-D v3 2026-05-16
+showed qwen fabricates ``verification_method=filesystem`` with zero
+tool calls).
+"""
+from __future__ import annotations
+
+import pytest
+
+from nexus.mcp.core import TIER_B_CLAUDE_PINNED, _pick_tier_b_dispatcher
+
+
+def test_pin_set_contains_nx_plan_audit() -> None:
+    assert "nx_plan_audit" in TIER_B_CLAUDE_PINNED
+
+
+def test_default_env_returns_claude(monkeypatch: pytest.MonkeyPatch) -> None:
+    # conftest already strips NEXUS_TIER_B_* — explicit for clarity.
+    monkeypatch.delenv("NEXUS_TIER_B_DISPATCHER", raising=False)
+    assert _pick_tier_b_dispatcher("nx_enrich_beads") == "claude"
+    assert _pick_tier_b_dispatcher("nx_tidy") == "claude"
+    assert _pick_tier_b_dispatcher("nx_plan_audit") == "claude"
+
+
+def test_global_qwen_routes_non_pinned_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEXUS_TIER_B_DISPATCHER", "qwen_agent")
+    assert _pick_tier_b_dispatcher("nx_enrich_beads") == "qwen_agent"
+    assert _pick_tier_b_dispatcher("nx_tidy") == "qwen_agent"
+
+
+def test_global_qwen_skips_pinned_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin wins over global env for nx_plan_audit."""
+    monkeypatch.setenv("NEXUS_TIER_B_DISPATCHER", "qwen_agent")
+    assert _pick_tier_b_dispatcher("nx_plan_audit") == "claude"
+
+
+def test_per_tool_override_beats_pin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-tool override is absolute — operators can route pinned
+    tools through qwen for re-bench / experimentation.
+    """
+    monkeypatch.setenv("NEXUS_TIER_B_DISPATCHER", "qwen_agent")
+    monkeypatch.setenv(
+        "NEXUS_TIER_B_NX_PLAN_AUDIT_DISPATCHER", "qwen_agent",
+    )
+    assert _pick_tier_b_dispatcher("nx_plan_audit") == "qwen_agent"
+
+
+def test_per_tool_override_can_opt_in_without_global(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-tool override works standalone — no global env needed."""
+    monkeypatch.delenv("NEXUS_TIER_B_DISPATCHER", raising=False)
+    monkeypatch.setenv("NEXUS_TIER_B_NX_TIDY_DISPATCHER", "qwen_agent")
+    assert _pick_tier_b_dispatcher("nx_tidy") == "qwen_agent"
+    # Sibling tools untouched.
+    assert _pick_tier_b_dispatcher("nx_enrich_beads") == "claude"
+    assert _pick_tier_b_dispatcher("nx_plan_audit") == "claude"
+
+
+def test_per_tool_override_can_force_claude(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-tool override is symmetric: a tool can be forced back to
+    claude even when the global is qwen_agent.
+    """
+    monkeypatch.setenv("NEXUS_TIER_B_DISPATCHER", "qwen_agent")
+    monkeypatch.setenv("NEXUS_TIER_B_NX_TIDY_DISPATCHER", "claude")
+    assert _pick_tier_b_dispatcher("nx_tidy") == "claude"


### PR DESCRIPTION
## Summary

Bakes in `nx_plan_audit -> claude_dispatch` by default and adds a per-tool override surface for tier-B routing, mirroring the #626 extract-pin precedent.

- `TIER_B_CLAUDE_PINNED = frozenset({\"nx_plan_audit\"})` (module-level, in `src/nexus/mcp/core.py`).
- New `_pick_tier_b_dispatcher(tool_name)` helper centralises env resolution; the three tier-B tools (`nx_tidy`, `nx_enrich_beads`, `nx_plan_audit`) now call it instead of reading `NEXUS_TIER_B_DISPATCHER` inline.
- Per-tool override env: `NEXUS_TIER_B_<TOOL>_DISPATCHER` (e.g. `NEXUS_TIER_B_NX_PLAN_AUDIT_DISPATCHER=qwen_agent`) is absolute — beats both global env and pin set.

## Bench evidence

spike-D v3 (2026-05-16, `/tmp/spike-d-out/parity-audit-v3-2026-05-16.jsonl`): even with PR #810 (prompt mandate) and PR #812 (`verification_method` enum) in place, qwen emits zero `tool_use` blocks on `nx_plan_audit` runs and fabricates findings with `verification_method: filesystem` while supervisor telemetry shows `tool_calls=0`. The structured-honesty slot exists, but qwen fills it dishonestly. By contrast `nx_tidy` (8 + 5 real tool calls) and `nx_enrich_beads` (17-29 tool calls) both behave correctly on qwen and are NOT pinned.

## Implementation notes

- No dispatch internals (schemas, prompts, retry behaviour, `max_tool_calls`) changed — pure routing refactor.
- `_pick_tier_b_dispatcher` is the *only* place that reads tier-B env vars.
- Precedence: per-tool env > global env + pin set > `claude` default.
- `conftest._isolate_dispatch_routing` extended with three per-tool env-strip entries so the suite never inherits operator-shell overrides.

## Migration

Operators who want to route `nx_plan_audit` through qwen anyway (re-bench, experimentation) set:

```
export NEXUS_TIER_B_NX_PLAN_AUDIT_DISPATCHER=qwen_agent
```

This works whether or not the global `NEXUS_TIER_B_DISPATCHER` is set.

## Test plan

- [x] New `tests/test_pick_tier_b_dispatcher.py` — 7 cases covering pin membership, default, global qwen routes non-pinned tools, pin wins over global qwen for `nx_plan_audit`, per-tool override beats pin, per-tool standalone opt-in, per-tool force-back-to-claude.
- [x] `tests/test_nx_plan_audit_routing.py` updated: prior global-env qwen test rewritten as `test_global_qwen_env_still_routes_to_claude_due_to_pin` (asserts `claude_dispatch` called, `qwen_agent_dispatch` raises). New `test_per_tool_override_routes_to_qwen_agent` locks in the opt-out path (all existing prompt/schema assertions preserved).
- [x] `tests/test_nx_tidy_routing.py` / `tests/test_nx_enrich_beads_routing.py` unchanged and still pass (not pinned).
- [x] Targeted: 24/24 passed. Broader sweep (`-k \"tier_b or nx_plan_audit or nx_tidy or nx_enrich or dispatcher or pick_tier\"`): 53/53 passed in 50.7s.

## Out of scope

Promotion path for `nx_plan_audit`. If a future bench shows qwen reliably emitting `tool_use` blocks for plan audits, the entry is removed from `TIER_B_CLAUDE_PINNED` in a follow-on (mirroring how #626 eventually promoted `extract`).

## Linked

- #626 — pin pattern precedent (extract).
- #796 — initial tier-B routing.
- #810 — prompt mandate.
- #812 — schema honesty (`verification_method` enum).