### PR TITLE
fix(nexus-9eaz): promote apply_pending race instrumentation to INFO

### DIFF
--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -3581,7 +3581,7 @@ def apply_pending(conn: sqlite3.Connection, current_version: str) -> None:
         # nexus-9eaz instrumentation: every check-then-add observed under
         # _upgrade_lock. If two threads both report "membership=False" for
         # the same path_key, the lock is not actually serializing.
-        _log.debug(
+        _log.info(
             "upgrade_done_check",
             path_key=path_key,
             membership=_membership,
@@ -3666,7 +3666,7 @@ def apply_pending(conn: sqlite3.Connection, current_version: str) -> None:
         # succeeded — record the path as done.
         _upgrade_done.add(path_key)
         # nexus-9eaz instrumentation: log every successful add with thread id.
-        _log.debug(
+        _log.info(
             "upgrade_done_add",
             path_key=path_key,
             thread_id=_threading.get_ident(),


### PR DESCRIPTION
Follow-up to #811. The DEBUG events I added there sit below the default WARNING threshold in `tests/conftest.py:25`, so the CI log buffer never sees them. Promoting both `upgrade_done_check` and `upgrade_done_add` to INFO so any apply_pending invocation under contention surfaces the path_key + thread_id + done_size trio in CI output.

## Volume

Each `apply_pending` invocation emits exactly one `upgrade_done_check` plus (at most) one `upgrade_done_add`. The `_auto_migrate_t2_in_tests` autouse fixture invokes `run_if_needed` once per test that constructs `T2Database`, capped by `_upgrade_done`'s fast-path. Two extra INFO lines per such test. Manageable.

## What this enables

When `test_concurrent_apply_pending_*` is eventually un-skipped (after we have evidence), or when any other test in the wild exercises the apply_pending path concurrently and fails, the log lines will tell us whether two threads both reported `membership=False` for the same `path_key` (lock truly failed) or whether `_upgrade_done` was cleared mid-run by something we missed.

`nexus-9eaz` stays open until evidence + fix lands.