### PR TITLE
docs(qwen-offload): operator-facing documentation for qwen offload (CHANGELOG + README + configuration.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,99 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added — Qwen offload integration (2026-05-15/16)
+
+Operator-readable opt-in surface for offloading selected LLM
+workloads onto a local Qwen3.6-35B-A3B coprocessor running behind
+the [qwen-coprocessor-stack](https://github.com/Hellblazer/qwen-coprocessor-stack)
+supervisor. Sixteen merged PRs cover three call-site tiers:
+bundleable operators (already qwen-default since 4.32.x), named
+operator-tier call sites (`topic_labeler`, `plan_miss_planner`),
+the aspect extractor (`nx enrich aspects`), and tier-B agentic
+tools (`nx_enrich_beads`, `nx_tidy`, `nx_plan_audit`). Nothing
+changes for operators who do not set the env knobs — claude
+remains the default for every newly-routable surface except the
+10 bundleable operators that were already migrated. Bench evidence
+and per-call-site verdicts live in the qwen-coprocessor-stack
+`docs/integrations/qwen-offload-2026-05-session-summary.md`.
+
+**Operator-tier routing**
+
+- `operator_dispatch_cost` structured-log emitted by both the
+  claude and qwen dispatchers; per-call cost attribution plus a
+  would-have-cost estimate, so post-hoc accounting works from
+  logs alone, no separate telemetry pipeline required. (PR #776.)
+- `pick_dispatcher_for(call_site)` primitive added to the
+  operator dispatch layer; `topic_labeler` migrated to call it,
+  picking up `NEXUS_DISPATCH_QWEN_OPERATORS` /
+  `NEXUS_DISPATCH_CLAUDE_OPERATORS` pin lists in addition to the
+  global `NEXUS_DISPATCH_BACKEND` mode. (PR #778.)
+- `plan_miss_planner` route-flipped onto the same primitive so the
+  planner side of `nx_answer` participates in per-call-site
+  routing. (PR #779.)
+
+**Aspect extractor (`nx enrich aspects`)**
+
+- Path-B adapter behind `NEXUS_ASPECT_BACKEND={claude,qwen}`. Same
+  output schema, same downstream T2 enrichment path; the only
+  difference operators see is the backend on the wire. Default
+  remains claude. Validated via the spike_c A/B parity harness.
+  (PRs #780, #782.)
+- `scholarly-paper-v2` prompt revision opt-in via
+  `NEXUS_SCHOLARLY_PAPER_VERSION=v2`. Tightens the per-field
+  schema and recovers the small field-completeness gap qwen
+  showed against v1; recommended whenever
+  `NEXUS_ASPECT_BACKEND=qwen`. Spike_c grew a semantic-
+  equivalence judge so per-field comparisons no longer reject on
+  cosmetic phrasing differences. (PRs #790, #793.)
+
+**Tier-B agentic tools**
+
+- `qwen_agent_dispatch` adapter targeting the qwen-coprocessor
+  supervisor's `qwen_oneshot` MCP, plus opt-in routing for
+  `nx_enrich_beads` via `NEXUS_TIER_B_DISPATCHER=qwen_agent`.
+  Default remains claude. Includes the extensions wire-shape fix
+  (`{only: [...]}` per supervisor contract), prompt tightening,
+  and `max_tool_calls=50` for enrich-beads on qwen. (PRs #796,
+  #797, #798, #799.)
+- `nx_tidy` and `nx_plan_audit` opted into the same routing
+  primitive. Both ship with tool-use-mandate prompts so qwen's
+  tool-call discipline matches claude's. Spike_d's parity judge
+  was generalized to cover both spike_c (operator-tier) and
+  spike_d (tier-B). (PRs #804, #805, #810.)
+- `verification_method` enum added to `nx_plan_audit` finding
+  schema so downstream consumers can branch on how each finding
+  was reached. (PR #812.)
+- `nx_plan_audit` **pinned to claude by default** via the
+  `TIER_B_CLAUDE_PINNED` constant — bench surfaced a structural
+  hallucination class on qwen that prompt-tightening did not fix.
+  Per-tool override surface (`NEXUS_TIER_B_<TOOL>_DISPATCHER`)
+  added in the same PR so the pin can be lifted for re-benching
+  without disturbing the global mode. The per-tool override wins
+  absolutely over the global setting. (PR #813.)
+
+**Env activation surface**
+
+| Knob | Values | Default | Effect |
+|---|---|---|---|
+| `NEXUS_DISPATCH_BACKEND` | `claude` / `qwen` / `auto` | `auto` | Global mode for bundleable operators + named operator-tier call sites |
+| `NEXUS_DISPATCH_QWEN_OPERATORS` | comma list | unset | Pin specific operators / call sites to qwen |
+| `NEXUS_DISPATCH_CLAUDE_OPERATORS` | comma list | unset | Pin specific operators / call sites to claude (wins over qwen list) |
+| `NEXUS_QWEN_CONCURRENCY` | integer | `1` | Module-level semaphore on `qwen_dispatch` concurrent in-flight calls |
+| `NEXUS_ASPECT_BACKEND` | `claude` / `qwen` | `claude` | `nx enrich aspects` backend |
+| `NEXUS_SCHOLARLY_PAPER_VERSION` | `v1` / `v2` | `v1` | Aspect-extractor prompt revision |
+| `NEXUS_TIER_B_DISPATCHER` | `claude` / `qwen_agent` | `claude` | Global mode for tier-B agentic tools |
+| `NEXUS_TIER_B_NX_TIDY_DISPATCHER` | `claude` / `qwen_agent` | (inherits global) | Per-tool override for `nx_tidy` |
+| `NEXUS_TIER_B_NX_ENRICH_BEADS_DISPATCHER` | `claude` / `qwen_agent` | (inherits global) | Per-tool override for `nx_enrich_beads` |
+| `NEXUS_TIER_B_NX_PLAN_AUDIT_DISPATCHER` | `claude` / `qwen_agent` | `claude` (pinned) | Per-tool override; bake-in pin can be lifted for re-benching |
+| `QWEN_BACKEND_URL` | URL | (supervisor default) | OpenAI-compatible endpoint for `qwen_dispatch` |
+| `QWEN_MODEL` | model id | (supervisor default) | Model id served by `QWEN_BACKEND_URL` |
+| `QWEN_AGENT_SUPERVISOR` | command | (supervisor default) | Supervisor binary invoked by `qwen_agent_dispatch` |
+
+See `docs/configuration.md` § Qwen Offload for per-knob detail,
+bench-evidence references, and the prerequisite Qwen Code
+extension wiring.
+
 ## [4.32.12] - 2026-05-13
 
 Patch on 4.32.11. Two CI-correctness fixes plus substantial RDR

--- a/README.md
+++ b/README.md
@@ -147,6 +147,27 @@ The `nx` command provides direct access to all storage tiers, indexing, and sear
 
 Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs/cli-reference.md).
 
+## Qwen offload (optional)
+
+Nexus can offload selected LLM workloads onto a local Qwen3.6-35B-A3B coprocessor running behind the [qwen-coprocessor-stack](https://github.com/Hellblazer/qwen-coprocessor-stack) supervisor. The coprocessor is opt-in across three call-site tiers: bundleable operators (already qwen-default), named operator-tier sites (`topic_labeler`, `plan_miss_planner`), the aspect extractor (`nx enrich aspects`), and tier-B agentic tools (`nx_enrich_beads`, `nx_tidy`, `nx_plan_audit`). Claude remains the default everywhere except the 10 bundleable operators; nothing changes unless you set the env knobs below.
+
+```bash
+# Operator-tier — schema-bounded oneshot, low risk
+export NEXUS_DISPATCH_BACKEND=auto
+export NEXUS_DISPATCH_QWEN_OPERATORS=topic_labeler,plan_miss_planner
+
+# Aspect extractor — pair with the v2 prompt
+export NEXUS_ASPECT_BACKEND=qwen
+export NEXUS_SCHOLARLY_PAPER_VERSION=v2
+
+# Tier-B agentic — enrich + tidy on qwen; nx_plan_audit stays on claude
+export NEXUS_TIER_B_DISPATCHER=qwen_agent
+```
+
+**Bench summary (2026-05 session):** operator-tier 1.03× latency parity with 100% oracle agreement; aspect extractor 5–12× slower than claude but a clear cost-savings story (~$0.18/paper saved); tier-B mixed — `nx_enrich_beads` + `nx_tidy` viable on qwen, `nx_plan_audit` pinned to claude by default after a structural hallucination class survived prompt-tightening. Full evidence in the qwen-coprocessor-stack [`docs/integrations/qwen-offload-2026-05-session-summary.md`](https://github.com/Hellblazer/qwen-coprocessor-stack/blob/main/docs/integrations/qwen-offload-2026-05-session-summary.md).
+
+Per-knob detail, defaults, and the prerequisite Qwen Code extension wiring live in [Configuration § Qwen Offload](https://github.com/Hellblazer/nexus/blob/main/docs/configuration.md#qwen-offload). Supervisor setup (install, backends, sessions, MCP wiring) lives in the [qwen-coprocessor-stack](https://github.com/Hellblazer/qwen-coprocessor-stack) repo.
+
 ## Documentation
 
 | Document | What it covers |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,6 +231,84 @@ If no marker file is found and no command is configured, the test check is skipp
 
 **bd-close gate** (`on_close: true`): Fires before `bd close` or `bd done` commands. Advisory only — warns when no review marker found in T1 scratch (from `/nx:review-code`). Never blocks.
 
+## Qwen Offload
+
+Optional opt-in surface for routing selected LLM workloads onto a local Qwen3.6-35B-A3B coprocessor running behind the [qwen-coprocessor-stack](https://github.com/Hellblazer/qwen-coprocessor-stack) supervisor. Three call-site tiers are independently routable: bundleable operators (already qwen-default), named operator-tier sites (`topic_labeler`, `plan_miss_planner`), the aspect extractor, and tier-B agentic tools (`nx_enrich_beads`, `nx_tidy`, `nx_plan_audit`). Claude is the default everywhere except the 10 bundleable operators that were already migrated; nothing routes to qwen unless the relevant knob is set.
+
+Full bench evidence and per-call-site verdicts live in the qwen-coprocessor-stack [`docs/integrations/qwen-offload-2026-05-session-summary.md`](https://github.com/Hellblazer/qwen-coprocessor-stack/blob/main/docs/integrations/qwen-offload-2026-05-session-summary.md). Supervisor install + backend configuration lives in the same repo.
+
+### Prerequisite — Qwen Code extension (tier-B only)
+
+Tier-B routing (`NEXUS_TIER_B_DISPATCHER=qwen_agent`) spawns the qwen CLI with an `nx` extension that wires the `nx-mcp` MCP server into the session so qwen can call `memory_*`, `store_*`, etc. The extension manifest must exist at `~/.qwen/extensions/nx/qwen-extension.json`. The full snippet plus install instructions live in the qwen-coprocessor-stack [`docs/integrations/qwen-dispatch-nexus.md`](https://github.com/Hellblazer/qwen-coprocessor-stack/blob/main/docs/integrations/qwen-dispatch-nexus.md). Operator-tier and aspect-extractor routing do not need it — those paths use schema-bounded oneshot dispatch via `QWEN_BACKEND_URL` directly.
+
+### Operator-tier routing
+
+#### `NEXUS_DISPATCH_BACKEND`
+
+- **Default:** `auto`
+- **Allowed:** `claude` / `qwen` / `auto`
+- **Effect:** Global mode for the 10 bundleable operators and for named operator-tier call sites that opt into `pick_dispatcher_for(...)` (currently `topic_labeler` and `plan_miss_planner`). `auto` picks per-operator from bake-in routing tables; `claude` and `qwen` force-pin everything in scope.
+- **Bench:** Validated in nexus#623 (bundleables, 100% oracle agreement, 1.03× latency parity) and nexus#778/#779 (named call sites, 5/5 each).
+
+#### `NEXUS_DISPATCH_QWEN_OPERATORS` / `NEXUS_DISPATCH_CLAUDE_OPERATORS`
+
+- **Default:** unset
+- **Allowed:** comma-separated list of operator / call-site names (e.g. `topic_labeler,plan_miss_planner`)
+- **Effect:** Per-operator pin lists overlaid on `NEXUS_DISPATCH_BACKEND`. The CLAUDE list wins over the QWEN list when an operator appears in both. Empty / unset = inherit the global mode.
+- **Notes:** Recognised call-site names are the keys consumed by `pick_dispatcher_for(call_site)`; the canonical list is in the dispatcher module. Misspellings are silently ignored.
+
+#### `NEXUS_QWEN_CONCURRENCY`
+
+- **Default:** `1`
+- **Allowed:** positive integer
+- **Effect:** Module-level semaphore on `qwen_dispatch` — caps concurrent in-flight calls to the qwen backend so a single host with a single GPU does not get serialised in surprising ways. Raise only if the backend can genuinely serve concurrent requests.
+
+#### `QWEN_BACKEND_URL` / `QWEN_MODEL`
+
+- **Default:** supervisor-provided
+- **Effect:** OpenAI-compatible endpoint and model id used by `qwen_dispatch` (the schema-bounded oneshot path). Operators with the supervisor running on the default port will not normally set these; override when running against a non-default backend or model. Validated end-to-end in nexus#623.
+
+### Aspect extractor
+
+#### `NEXUS_ASPECT_BACKEND`
+
+- **Default:** `claude`
+- **Allowed:** `claude` / `qwen`
+- **Effect:** Selects the backend for `nx enrich aspects`. Same output schema, same downstream T2 enrichment path; the only operator-visible difference is the engine on the wire and the latency/cost profile.
+- **Bench:** Validated by spike_c (nexus#782, nexus#793) on the Grossberg-lab cognitive-modeling corpus (10 PDFs). Aspect on qwen is **5–12× slower** than claude; the win is cost (~$0.18/paper saved), not latency.
+- **Notes:** When set to `qwen`, pair with `NEXUS_SCHOLARLY_PAPER_VERSION=v2` — the v1 prompt has a small field-completeness gap that v2 closes.
+
+#### `NEXUS_SCHOLARLY_PAPER_VERSION`
+
+- **Default:** `v1`
+- **Allowed:** `v1` / `v2`
+- **Effect:** Aspect-extractor prompt revision. `v2` tightens the per-field schema and recovers the field-completeness gap qwen showed against v1.
+- **Bench:** Validated alongside `NEXUS_ASPECT_BACKEND=qwen` in nexus#790, nexus#793.
+- **Notes:** Recommended whenever `NEXUS_ASPECT_BACKEND=qwen`. Has no negative effect on claude — operators on claude can opt in too if they want the tighter schema.
+
+### Tier-B agentic tools
+
+#### `NEXUS_TIER_B_DISPATCHER`
+
+- **Default:** `claude`
+- **Allowed:** `claude` / `qwen_agent`
+- **Effect:** Global mode for tier-B agentic tools (`nx_enrich_beads`, `nx_tidy`, `nx_plan_audit`). `qwen_agent` routes through `qwen_agent_dispatch`, which spawns the qwen CLI with the `nx-mcp` extension active.
+- **Bench:** Validated by spike_d (nexus#797, generalized judge in nexus#804). `nx_enrich_beads` 3/3 PASS, `nx_tidy` 2/2 PASS, `nx_plan_audit` mixed (see per-tool override below).
+- **Notes:** Requires the Qwen Code extension at `~/.qwen/extensions/nx/qwen-extension.json` (see prerequisite above). Per-tool overrides win absolutely over this global setting.
+
+#### `NEXUS_TIER_B_NX_TIDY_DISPATCHER` / `NEXUS_TIER_B_NX_ENRICH_BEADS_DISPATCHER` / `NEXUS_TIER_B_NX_PLAN_AUDIT_DISPATCHER`
+
+- **Default:** inherits `NEXUS_TIER_B_DISPATCHER`, except `NX_PLAN_AUDIT` which is **pinned to `claude`** via the `TIER_B_CLAUDE_PINNED` constant regardless of the global mode (see caveat).
+- **Allowed:** `claude` / `qwen_agent`
+- **Effect:** Per-tool override. The override wins absolutely — if `NEXUS_TIER_B_DISPATCHER=qwen_agent` but `NEXUS_TIER_B_NX_TIDY_DISPATCHER=claude`, `nx_tidy` runs on claude.
+- **Caveat — `nx_plan_audit`:** Pinned to claude by default. Bench surfaced a structural hallucination class on qwen that prompt-tightening (nexus#810) did not fix; the `verification_method` enum (nexus#812) makes the failure mode addressable but does not eliminate it. The per-tool override surface (nexus#813) is provided so the pin can be lifted for re-benching — set `NEXUS_TIER_B_NX_PLAN_AUDIT_DISPATCHER=qwen_agent` only if you are deliberately re-running the spike.
+
+#### `QWEN_AGENT_SUPERVISOR`
+
+- **Default:** supervisor-provided
+- **Allowed:** command string (path to supervisor binary or `qwen` wrapper)
+- **Effect:** Command invoked by `qwen_agent_dispatch` to launch the qwen CLI session. Operators with the standard supervisor install will not normally set this; override when running a custom supervisor build or when the binary is not on `PATH`. Introduced in nexus#796.
+
 ## File Locations
 
 | File | Purpose |


### PR DESCRIPTION
## Summary

Operator-facing documentation for the 16-PR qwen offload integration that landed 2026-05-15/16. Docs-only — no code changes, no new RDR.

**Files touched:**
- `CHANGELOG.md` — new `### Added — Qwen offload integration (2026-05-15/16)` block under `[Unreleased]`, grouped by call-site tier (operator-tier routing, aspect extractor, tier-B agentic), with a full env-activation table.
- `README.md` — new "Qwen offload (optional)" section placed between "CLI Reference" and "Documentation", with activation snippet, one-line bench summary, and pointers to `docs/configuration.md` and the qwen-coprocessor-stack supervisor repo.
- `docs/configuration.md` — new "Qwen Offload" reference section before "File Locations", with per-knob documentation (default / allowed values / effect / bench evidence / caveats) for all eleven env knobs plus the tier-B Qwen Code extension prerequisite.

## Scope — 16 PRs covered

Phase 1: #776. Phase 2: #778, #779. Phase 3: #780, #782, #790, #793. Phase 4: #796, #797, #798, #799, #804, #805, #810, #812, #813.

Ground-truth bench numbers and per-call-site verdicts: qwen-coprocessor-stack [`docs/integrations/qwen-offload-2026-05-session-summary.md`](https://github.com/Hellblazer/qwen-coprocessor-stack/blob/main/docs/integrations/qwen-offload-2026-05-session-summary.md).

## Test plan

- [ ] CHANGELOG `[Unreleased]` block renders cleanly on GitHub
- [ ] README "Qwen offload (optional)" section links resolve
- [ ] `docs/configuration.md` § Qwen Offload anchor (`#qwen-offload`) matches the README cross-reference
- [ ] No code paths touched; CI docs-only path is green