### PR TITLE
chore(release): conexus 4.33.0 — qwen offload integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.33.0] - 2026-05-16
+
 ### Added — Qwen offload integration (2026-05-15/16)
 
 Operator-readable opt-in surface for offloading selected LLM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.32.12"
+version = "4.33.0"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"


### PR DESCRIPTION
## Summary

Minor release wrapping the qwen offload integration cycle (16 PRs between 2026-05-15 and 2026-05-16). Default routing unchanged for every call site; operator opts in via env knobs documented in CHANGELOG and `docs/configuration.md`.

## Changes

- \`pyproject.toml\` version bump: 4.32.12 → 4.33.0
- \`CHANGELOG.md\`: promote \`[Unreleased]\` qwen-offload block to \`[4.33.0] - 2026-05-16\`

## Scope reminder (covered by #816 docs PR)

- **Cost telemetry**: #776
- **Named call-site routing**: #778 (topic_labeler), #779 (plan_miss_planner)
- **Aspect extractor**: #780, #790 (scholarly-paper-v2), #782, #793, #804
- **Tier-B agentic**: #796, #797, #798, #799, #805, #810, #812, #813

## Companion release

The qwen-coprocessor-stack supervisor PR #1 (pino-to-stderr) is required for any MCP-stdio client connecting to the supervisor. Operators using tier-B routing should pull and rebuild the supervisor from \`main\` to get that fix.

## Test plan

- [x] CI green on origin/main (this branch is just the version bump + CHANGELOG hoist).
- [x] No code changes — release commit only.

After merge: tag \`v4.33.0\` on the merge commit and push the tag.