### PR TITLE
ci(nexus-9eaz): isolated migration-race-probe job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,51 @@ jobs:
 
       - name: Run tests
         run: uv run pytest tests/ -v
+
+  migration-race-probe:
+    # nexus-9eaz: the two concurrent-migration tests below are skip-marked
+    # in the main suite because they fail intermittently when the full
+    # 6800-test pytest session is in flight. This job runs them in
+    # isolation (their own pytest invocation, no prior test pollution)
+    # so we can tell whether the race is intrinsic to the apply_pending
+    # lock semantics on Linux or whether it is process-state pollution.
+    #
+    # Outcome:
+    #   - probe passes consistently: race is process-pollution from
+    #     earlier tests; root-cause lives in the test harness, not in
+    #     apply_pending.
+    #   - probe fails: race is intrinsic to apply_pending under Linux/CI;
+    #     INFO-level instrumentation in #811 + #814 captures evidence
+    #     in the log output.
+    #
+    # Job is non-blocking on the main suite (continue-on-error) so a
+    # flake here does not red-bar PRs while the investigation is open.
+    name: migration race probe (nexus-9eaz, non-blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install project + dev deps
+        run: uv sync --group dev
+
+      - name: Run isolated concurrent-migration tests (un-skip override)
+        # NEXUS_RUN_FLAKY_MIGRATION_TESTS=1 instructs the skip markers
+        # in tests/test_migrations.py to no-op. The tests then run in
+        # this fresh pytest process with no prior test pollution.
+        env:
+          NEXUS_RUN_FLAKY_MIGRATION_TESTS: "1"
+        run: |
+          uv run pytest \
+            tests/test_migrations.py::TestApplyPending::test_concurrent_apply_pending_runs_once \
+            tests/test_migrations.py::TestApplyPending::test_concurrent_apply_pending_stress \
+            -v \
+            --log-cli-level=INFO

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -7,6 +7,7 @@ They will fail until migrations.py is implemented (nexus-6cn).
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import threading
 from pathlib import Path
@@ -693,12 +694,15 @@ class TestApplyPending:
         assert rows[0][0] == "4.1.2"
         conn.close()
 
-    @pytest.mark.skip(
+    @pytest.mark.skipif(
+        not os.environ.get("NEXUS_RUN_FLAKY_MIGRATION_TESTS"),
         reason="Same race family as test_concurrent_apply_pending_stress. "
         "Tracked in nexus-9eaz: bootstrap_version called twice despite "
         "_upgrade_lock; CI Linux only, not reproducible on darwin in 100 "
         "iterations. Instrumentation added to apply_pending so the next "
-        "real failure surfaces thread-id + path_key evidence."
+        "real failure surfaces thread-id + path_key evidence. "
+        "Run with NEXUS_RUN_FLAKY_MIGRATION_TESTS=1 (the migration-race-probe "
+        "CI job in .github/workflows/ci.yml) to exercise in isolation."
     )
     def test_concurrent_apply_pending_runs_once(self, tmp_path: Path) -> None:
         """_upgrade_lock prevents concurrent apply_pending double-execution."""
@@ -746,10 +750,13 @@ class TestApplyPending:
         # it already present and returns early before calling bootstrap_version.
         assert call_count["n"] == 1
 
-    @pytest.mark.skip(
+    @pytest.mark.skipif(
+        not os.environ.get("NEXUS_RUN_FLAKY_MIGRATION_TESTS"),
         reason="Flaky on Linux CI (~iteration 45 of 50). Tracked in nexus-9eaz: "
         "bootstrap_version called twice despite _upgrade_lock; passes on darwin. "
-        "Skip while the real race is investigated so the rest of the suite can run."
+        "Skip while the real race is investigated so the rest of the suite can run. "
+        "Run with NEXUS_RUN_FLAKY_MIGRATION_TESTS=1 (the migration-race-probe CI "
+        "job in .github/workflows/ci.yml) to exercise in isolation."
     )
     def test_concurrent_apply_pending_stress(self, tmp_path: Path) -> None:
         """Stress-test _upgrade_lock: 50 independent concurrent pairs, each must


### PR DESCRIPTION
Adds a non-blocking GHA job that runs the two skip-marked concurrent-migration tests (`test_concurrent_apply_pending_runs_once`, `test_concurrent_apply_pending_stress`) in a fresh pytest process — no prior test-session pollution.

## Why

Empirical reproduction confirmed the lock semantics are correct everywhere we could measure:
- darwin local + standalone replica + full nexus stack: 0/100, 0/500, 0/100 fails
- Linux Docker python:3.12-slim, full nexus: 0/100 fails
- Linux Docker matched to GHA shape (`--cpus=2 --memory=7g`): 0/200 fails

The race only surfaces when these tests run at ~51% into the 6800-test pytest session on GitHub Actions. This isolation job tells us which:
- **passes**: race is process-pollution from earlier tests
- **fails**: race is intrinsic to `apply_pending` under Linux/GHA scheduling; INFO-level instrumentation from #811 + #814 captures evidence

`continue-on-error: true` keeps the probe non-blocking. Closes nothing — `nexus-9eaz` stays open until the probe gives us evidence.