### PR TITLE
Revert "chore(release): conexus 4.33.0" — release was premature, rolling back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [4.33.0] - 2026-05-16
-
 ### Added — Qwen offload integration (2026-05-15/16)
 
 Operator-readable opt-in surface for offloading selected LLM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.33.0"
+version = "4.32.12"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"


### PR DESCRIPTION
Reverts #817. The v4.33.0 tag + GitHub release have already been deleted; pypi was untouched (release workflow failed before publish, so version 4.33.0 is preserved for a proper future release).

Restores `pyproject.toml` to 4.32.12 and moves the qwen offload CHANGELOG block back under `[Unreleased]`. The #816 docs PR (CHANGELOG entries, README section, configuration.md reference) is untouched — those additions are correct on their own and stay in place under the [Unreleased] header.

No code changes. Pure release-prep rollback.