### PR TITLE
fix(rdr-111): wire NX_BRIDGE_DISABLE + harden _build_content JSON output

### DIFF
--- a/docs/tuplespace-env.md
+++ b/docs/tuplespace-env.md
@@ -43,10 +43,17 @@ through the 4.27 to 4.28 cycle (RDR-105).
 
 ## NX_BRIDGE_DISABLE
 
-Disables the hook-to-tuple bridge (RDR-111). When set, Claude Code hook
-events stop landing in the `events/hook` subspace. The bridge is the
-upstream feed for several event subscribers; with it disabled, those
-subscribers see no input and may appear stuck.
+Disables the hook-to-tuple bridge (RDR-111). When set to any truthy
+value, Claude Code hook events stop landing in the `events/hook`
+subspace. The bridge is the upstream feed for several event subscribers;
+with it disabled, those subscribers see no input and may appear stuck.
+
+Falsy tokens (bridge runs): unset, `""`, `"0"`, `"false"`, `"False"`.
+Any other non-empty value (`"1"`, `"true"`, `"yes"`, ...) disables the
+bridge. The gate sits after the `CLAUDECODE` check in `emit()`, so it
+covers both the daemon-routed and direct-fallback paths. Hook protocol
+responses (e.g. PermissionRequest transparent-allow) are not silenced —
+disabling tuple emission must not break the user's tool flow.
 
 ## NX_HOOK_DEBUG, NX_TIMEOUT, BD_TIMEOUT
 

--- a/src/nexus/cockpit/hook_bridge.py
+++ b/src/nexus/cockpit/hook_bridge.py
@@ -260,6 +260,10 @@ def emit(
         _log.debug("hook_bridge_skip_no_claudecode", hook_type=hook_type)
         return
 
+    if _bridge_disabled():
+        _log.debug("hook_bridge_skip_disabled", hook_type=hook_type)
+        return
+
     routed = route_payload(hook_type, payload)
     if routed is None:
         _log.debug("hook_bridge_skip_unrouted", hook_type=hook_type)
@@ -538,12 +542,57 @@ def _build_match_text(hook_type: str, payload: dict[str, Any]) -> str:
             return ""
 
 
+_CONTENT_BYTE_CAP = 12000
+
+
+def _bridge_disabled() -> bool:
+    """Return True if NX_BRIDGE_DISABLE is set to a truthy value.
+
+    Falsy tokens (bridge runs): unset, ``""``, ``"0"``, ``"false"``, ``"False"``.
+    Any other non-empty value disables the bridge.
+
+    This is the documented privacy opt-out (docs/tuplespace-env.md). It
+    fires after the CLAUDECODE gate in ``emit()`` so it covers both the
+    daemon and direct-fallback paths. ``output_for_hook()`` is *not*
+    gated by this — disabling tuple emission must not break the hook
+    protocol (e.g. PermissionRequest still needs a transparent-allow
+    response).
+    """
+    val = os.environ.get("NX_BRIDGE_DISABLE", "").strip()
+    return val not in ("", "0", "false", "False")
+
+
 def _build_content(hook_type: str, payload: dict[str, Any]) -> str:
     """Build the tuple content field (stored verbatim, not embedded).
 
-    Serialises the raw payload as JSON, capped to a safe chunk size to
-    stay within ChromaDB's MAX_DOCUMENT_BYTES limit.
+    Returns a JSON-parseable string. When the full JSON exceeds the byte
+    cap, projects the payload down to a stable set of small fields with
+    a ``_truncated: true`` marker so consumers always see valid JSON
+    instead of a mid-string slice. The byte cap stays well under
+    ``SAFE_CHUNK_BYTES = 12288``.
     """
     raw = json.dumps(payload, ensure_ascii=False)
-    # Stay well within SAFE_CHUNK_BYTES = 12288
-    return raw[:12000]
+    if len(raw.encode("utf-8")) <= _CONTENT_BYTE_CAP:
+        return raw
+
+    original_bytes = len(raw.encode("utf-8"))
+
+    projection: dict[str, Any] = {
+        "_truncated": True,
+        "_original_bytes": original_bytes,
+    }
+    for key in ("session_id", "hook_event_name", "tool_name", "cwd", "permission_mode"):
+        if key in payload:
+            projection[key] = payload[key]
+    projected = json.dumps(projection, ensure_ascii=False)
+    if len(projected.encode("utf-8")) <= _CONTENT_BYTE_CAP:
+        return projected
+
+    # Last-resort: minimal envelope with just the event name. Bounded by
+    # construction (event name is a short identifier), guaranteed to fit.
+    minimal = {
+        "_truncated": True,
+        "_original_bytes": original_bytes,
+        "hook_event_name": str(payload.get("hook_event_name", ""))[:64],
+    }
+    return json.dumps(minimal, ensure_ascii=False)

--- a/tests/cockpit/test_hook_bridge.py
+++ b/tests/cockpit/test_hook_bridge.py
@@ -693,6 +693,149 @@ class TestClaudecodeGate:
 
 
 # ---------------------------------------------------------------------------
+# Tests: NX_BRIDGE_DISABLE privacy opt-out (nexus-7zvp)
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeDisableGate:
+    """NX_BRIDGE_DISABLE skips tuple emission but preserves hook protocol output."""
+
+    @pytest.fixture(autouse=True)
+    def _set_claudecode(self, monkeypatch):
+        monkeypatch.setenv("CLAUDECODE", "1")
+
+    @pytest.mark.parametrize("falsy_value", ["", "0", "false", "False"])
+    def test_falsy_values_keep_bridge_running(
+        self, monkeypatch, db_conn, hook_index, hook_registry, falsy_value: str
+    ) -> None:
+        """Documented falsy tokens leave the bridge live (no silent disable)."""
+        from nexus.cockpit import hook_bridge
+
+        monkeypatch.setenv("NX_BRIDGE_DISABLE", falsy_value)
+        called = []
+
+        def _fake_out(**kwargs):
+            called.append(kwargs)
+            return "id"
+
+        with patch("nexus.cockpit.hook_bridge._direct_out", _fake_out):
+            hook_bridge.emit(
+                "PreToolUse",
+                PRETOOLUSE_PAYLOAD,
+                conn=db_conn,
+                index=hook_index,
+                registry=hook_registry,
+            )
+
+        assert called, f"emit must run when NX_BRIDGE_DISABLE={falsy_value!r}"
+
+    @pytest.mark.parametrize("truthy_value", ["1", "true", "yes", "TRUE", " 1 "])
+    def test_truthy_values_disable_emission(
+        self, monkeypatch, db_conn, hook_index, hook_registry, truthy_value: str
+    ) -> None:
+        """Any non-falsy value silences tuple emission."""
+        from nexus.cockpit import hook_bridge
+
+        monkeypatch.setenv("NX_BRIDGE_DISABLE", truthy_value)
+        called = []
+
+        def _fake_out(**kwargs):
+            called.append(kwargs)
+            return "id"
+
+        with patch("nexus.cockpit.hook_bridge._direct_out", _fake_out):
+            hook_bridge.emit(
+                "PreToolUse",
+                PRETOOLUSE_PAYLOAD,
+                conn=db_conn,
+                index=hook_index,
+                registry=hook_registry,
+            )
+
+        assert called == [], (
+            f"_direct_out must not be called when NX_BRIDGE_DISABLE={truthy_value!r}"
+        )
+
+    def test_disabled_does_not_break_hook_protocol(self, monkeypatch) -> None:
+        """output_for_hook is pure and must keep producing the hook response."""
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        monkeypatch.setenv("NX_BRIDGE_DISABLE", "1")
+        out = output_for_hook("PermissionRequest")
+        assert out is not None
+        parsed = json.loads(out)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_content always produces parseable JSON (nexus-sv7t)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildContent:
+    """_build_content must always return JSON-parseable strings."""
+
+    def test_small_payload_round_trips(self) -> None:
+        from nexus.cockpit.hook_bridge import _build_content
+
+        out = _build_content("PreToolUse", PRETOOLUSE_PAYLOAD)
+        assert json.loads(out) == PRETOOLUSE_PAYLOAD
+
+    def test_oversized_payload_projects_and_marks_truncated(self) -> None:
+        from nexus.cockpit.hook_bridge import _build_content
+
+        big_payload = {
+            **PRETOOLUSE_PAYLOAD,
+            "tool_response": "X" * 20000,  # forces overflow
+        }
+        out = _build_content("PostToolUse", big_payload)
+        parsed = json.loads(out)
+        assert parsed["_truncated"] is True
+        assert parsed["_original_bytes"] > 12000
+        assert parsed["hook_event_name"] == "PreToolUse"
+        assert parsed["session_id"] == PRETOOLUSE_PAYLOAD["session_id"]
+        assert parsed["tool_name"] == "Bash"
+        assert parsed["cwd"] == "/projects/nexus"
+
+    def test_oversized_payload_stays_under_cap(self) -> None:
+        from nexus.cockpit.hook_bridge import _CONTENT_BYTE_CAP, _build_content
+
+        big_payload = {
+            **PRETOOLUSE_PAYLOAD,
+            "tool_response": "Y" * 20000,
+        }
+        out = _build_content("PostToolUse", big_payload)
+        assert len(out.encode("utf-8")) <= _CONTENT_BYTE_CAP
+
+    def test_unicode_payload_round_trips(self) -> None:
+        """Multi-byte UTF-8 payloads must not produce mid-codepoint slices."""
+        from nexus.cockpit.hook_bridge import _build_content
+
+        payload = {**PRETOOLUSE_PAYLOAD, "extra": "café snowman ☃ emoji \U0001f600"}
+        out = _build_content("PreToolUse", payload)
+        parsed = json.loads(out)
+        assert parsed["extra"] == "café snowman ☃ emoji \U0001f600"
+
+    def test_huge_projection_falls_back_to_minimal_envelope(self) -> None:
+        """Even pathological projected fields must still yield valid JSON."""
+        from nexus.cockpit.hook_bridge import _CONTENT_BYTE_CAP, _build_content
+
+        # Stable-projection fields themselves blown out — falls back to minimal.
+        payload = {
+            "session_id": "S" * 15000,
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": "/c",
+            "permission_mode": "ask",
+        }
+        out = _build_content("PreToolUse", payload)
+        parsed = json.loads(out)
+        assert parsed["_truncated"] is True
+        assert parsed["hook_event_name"] == "PreToolUse"
+        assert len(out.encode("utf-8")) <= _CONTENT_BYTE_CAP
+
+
+# ---------------------------------------------------------------------------
 # Tests: script exit-0 on malformed JSON
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two related hot-path fixes in `src/nexus/cockpit/hook_bridge.py` surfaced by the RDR-110/111/112/113 360° critique (umbrella nexus-g7yy).

### nexus-7zvp — Wire NX_BRIDGE_DISABLE (privacy claim violation)

The documented privacy opt-out `NX_BRIDGE_DISABLE` was referenced by `docs/tuplespace-env.md`, `nx doctor`, and `nx cockpit status`, but `emit()` never read it. Users following the documented kill-switch were still observed.

- `emit()` now consults `_bridge_disabled()` right after the `CLAUDECODE` gate, covering both daemon-routed and direct-fallback paths.
- Truthy/falsy semantics locked: unset / `""` / `"0"` / `"false"` / `"False"` mean the bridge runs; any other non-empty value disables emission.
- `output_for_hook()` stays pure; disabling tuples must not break the hook protocol (e.g. PermissionRequest transparent-allow).
- `docs/tuplespace-env.md` now spells out the recognised tokens.

### nexus-sv7t — Fix `_build_content` JSON truncation

`_build_content()` returned `raw[:12000]`, a codepoint slice that landed mid-string or mid-escape on payloads above the cap and produced unparseable JSON for downstream consumers (cockpit panels, doctor, future readers). Common trigger: Bash hook with a large `tool_response`.

- On overflow, projects to a stable small set of fields (`session_id`, `hook_event_name`, `tool_name`, `cwd`, `permission_mode`) with explicit `_truncated` / `_original_bytes` markers.
- If the projection itself overflows, falls back to a minimal envelope bounded by construction (event-name + markers).
- Byte-budget check uses `len(.encode(\"utf-8\"))`, so multi-byte payloads stay under `SAFE_CHUNK_BYTES = 12288`.

## Closes

- Closes nexus-7zvp
- Closes nexus-sv7t

## Refs

- nexus-g7yy (RDR-110/111/112/113 critique remediation)

## Test plan

- [x] `uv run pytest tests/cockpit/test_hook_bridge.py` — 61 passed (15 new)
- [x] `uv run pytest tests/cockpit/` — 123 passed
- [ ] CI green

### New tests

- `TestBridgeDisableGate`: parametrised falsy/truthy table; protocol output still emits when disabled.
- `TestBuildContent`: round-trip small payload, projected overflow, unicode round-trip, pathological projection → minimal envelope. All assert valid JSON.