### PR TITLE
fix(rdr-112): repair launchd/systemd autostart for multi-token nx + clean SIGTERM

### DIFF
--- a/nx/daemon/com.nexus.t2.plist
+++ b/nx/daemon/com.nexus.t2.plist
@@ -22,8 +22,8 @@
     <true/>
     <key>KeepAlive</key>
     <dict>
-        <key>SuccessfulExit</key>
-        <false/>
+        <key>Crashed</key>
+        <true/>
     </dict>
     <key>ProcessType</key>
     <string>Background</string>

--- a/nx/daemon/nexus-t2.service
+++ b/nx/daemon/nexus-t2.service
@@ -13,6 +13,10 @@ Type=simple
 ExecStart=__NX_BIN__ daemon t2 start --foreground
 Restart=on-failure
 RestartSec=5s
+## nexus-o6g9: SIGTERM-induced exits surface as code 143. Mark them as
+## success so ``nx daemon t2 stop`` (which sends SIGTERM) does not
+## immediately respawn through Restart=on-failure.
+SuccessExitStatus=143
 Environment=PATH=__PATH_ENV__
 StandardOutput=append:__LOG_DIR__/nexus-t2.log
 StandardError=append:__LOG_DIR__/nexus-t2.err

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -16,11 +16,14 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
+import shlex
 import shutil
 import signal
 import subprocess
 import sys
 from pathlib import Path
+from xml.sax.saxutils import escape as _xml_escape
 
 import click
 
@@ -645,26 +648,70 @@ def _read_template(name: str) -> str:
         return Path(resolved).read_text()
 
 
-def _render_template(name: str, *, nx_bin: str, log_dir: str, path_env: str) -> str:
+_PLIST_NX_BIN_LINE_RE = re.compile(r"^(?P<indent>[ \t]*)<string>__NX_BIN__</string>\s*$")
+
+
+def _substitute_plist_argv(body: str, nx_bin: list[str]) -> str:
+    """Expand the ``<string>__NX_BIN__</string>`` line into one entry per token.
+
+    The plist's ``ProgramArguments`` array gives launchd one ``<string>``
+    per argv element. A multi-token fallback (``["/path/python", "-m",
+    "nexus.cli"]``) must therefore render as multiple ``<string>``
+    siblings, not a single space-joined string — launchd treats one
+    ``<string>`` slot as a single executable name, so a single
+    ``"<string>python -m nexus.cli</string>"`` makes ``posix_spawn``
+    fail with ENOENT.
+    """
+    out_lines: list[str] = []
+    for line in body.splitlines(keepends=True):
+        match = _PLIST_NX_BIN_LINE_RE.match(line.rstrip("\n"))
+        if match is None:
+            out_lines.append(line)
+            continue
+        indent = match.group("indent")
+        trailing_nl = "\n" if line.endswith("\n") else ""
+        for token in nx_bin:
+            out_lines.append(f"{indent}<string>{_xml_escape(token)}</string>{trailing_nl}")
+    return "".join(out_lines)
+
+
+def _render_template(name: str, *, nx_bin: list[str], log_dir: str, path_env: str) -> str:
+    """Substitute placeholders in a shipped autostart template.
+
+    ``nx_bin`` is a token list. The plist substitutes the
+    ``<string>__NX_BIN__</string>`` line into one ``<string>`` per
+    token; the systemd unit's ``ExecStart=__NX_BIN__ ...`` line uses
+    ``shlex.join`` so multi-token argvs survive systemd's
+    whitespace-split parser.
+    """
     body = _read_template(name)
+    if name.endswith(".plist"):
+        body = _substitute_plist_argv(body, nx_bin)
+    else:
+        body = body.replace("__NX_BIN__", shlex.join(nx_bin))
     return (
-        body.replace("__NX_BIN__", nx_bin)
+        body
         .replace("__LOG_DIR__", log_dir)
         .replace("__PATH_ENV__", path_env)
     )
 
 
-def _resolve_nx_bin() -> str:
-    """Resolve the absolute path to the ``nx`` executable.
+def _resolve_nx_bin() -> list[str]:
+    """Resolve the argv prefix for invoking ``nx``.
 
-    Prefer ``shutil.which("nx")``. If unavailable (rare; uv-tool installs
-    expose ``nx`` on PATH), fall back to ``<python> -m nexus.cli`` which
-    works for any wheel install. We do not hardcode ``/usr/local/bin/nx``.
+    Returns a single-element list when ``nx`` is on ``$PATH`` (the
+    common case for ``uv tool install``). Falls back to a three-element
+    list ``[python, "-m", "nexus.cli"]`` when ``shutil.which("nx")``
+    returns ``None``. Callers must respect the token boundaries when
+    rendering into platform autostart formats: a multi-element list
+    cannot be flattened into a single ``<string>`` plist slot, and the
+    systemd ``ExecStart=`` line must shlex-quote each token so paths
+    with spaces stay one argument.
     """
     found = shutil.which("nx")
     if found:
-        return found
-    return f"{sys.executable} -m nexus.cli"
+        return [found]
+    return [sys.executable, "-m", "nexus.cli"]
 
 
 def _autostart_filename() -> str:
@@ -699,9 +746,10 @@ def install_cmd(autostart: bool) -> None:
     log_dir.mkdir(parents=True, exist_ok=True)
 
     template_name = _autostart_filename()
+    nx_bin = _resolve_nx_bin()
     rendered = _render_template(
         template_name,
-        nx_bin=_resolve_nx_bin(),
+        nx_bin=nx_bin,
         log_dir=str(log_dir),
         path_env=os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
     )

--- a/tests/commands/test_daemon_autostart.py
+++ b/tests/commands/test_daemon_autostart.py
@@ -11,6 +11,7 @@ substitution and file placement are exercised for real.
 
 from __future__ import annotations
 
+import shlex
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -40,20 +41,23 @@ def test_template_files_ship_in_resources() -> None:
 def test_render_template_substitutes_placeholders(tmp_path: Path) -> None:
     rendered = daemon_cmd._render_template(
         "com.nexus.t2.plist",
-        nx_bin="/opt/nx/bin/nx",
+        nx_bin=["/opt/nx/bin/nx"],
         log_dir=str(tmp_path / "logs"),
         path_env="/usr/local/bin:/usr/bin",
     )
-    assert "__NX_BIN__" not in rendered
+    # ProgramArguments slot is real (the placeholder in the file header
+    # comment is left untouched and is harmless — launchd ignores XML
+    # comments).
+    assert "<string>__NX_BIN__</string>" not in rendered
     assert "__LOG_DIR__" not in rendered
     assert "__PATH_ENV__" not in rendered
-    assert "/opt/nx/bin/nx" in rendered
+    assert "<string>/opt/nx/bin/nx</string>" in rendered
     assert str(tmp_path / "logs") in rendered
 
 
 def test_resolve_nx_bin_uses_which(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(daemon_cmd.shutil, "which", lambda name: "/opt/uv/bin/nx")
-    assert daemon_cmd._resolve_nx_bin() == "/opt/uv/bin/nx"
+    assert daemon_cmd._resolve_nx_bin() == ["/opt/uv/bin/nx"]
 
 
 def test_resolve_nx_bin_falls_back_to_python_module(
@@ -61,9 +65,66 @@ def test_resolve_nx_bin_falls_back_to_python_module(
 ) -> None:
     monkeypatch.setattr(daemon_cmd.shutil, "which", lambda name: None)
     resolved = daemon_cmd._resolve_nx_bin()
-    # Falls back to ``<python> -m nexus.cli``; both tokens present.
-    assert sys.executable in resolved
-    assert "nexus.cli" in resolved
+    assert resolved == [sys.executable, "-m", "nexus.cli"]
+
+
+def test_render_plist_multi_token_expands_to_one_string_per_token(
+    tmp_path: Path,
+) -> None:
+    """nexus-ooxh: multi-token nx_bin must produce N <string> elements, not one space-joined slot."""
+    rendered = daemon_cmd._render_template(
+        "com.nexus.t2.plist",
+        nx_bin=["/opt/python/bin/python3.12", "-m", "nexus.cli"],
+        log_dir=str(tmp_path / "logs"),
+        path_env="/usr/bin",
+    )
+    assert "<string>/opt/python/bin/python3.12</string>" in rendered
+    assert "<string>-m</string>" in rendered
+    assert "<string>nexus.cli</string>" in rendered
+    # No single mashed-together slot.
+    assert "<string>/opt/python/bin/python3.12 -m nexus.cli</string>" not in rendered
+    # daemon argv survives.
+    assert "<string>daemon</string>" in rendered
+    assert "<string>--foreground</string>" in rendered
+
+
+def test_render_systemd_multi_token_uses_shlex_join(tmp_path: Path) -> None:
+    """nexus-ooxh: multi-token nx_bin in systemd ExecStart must shlex-quote tokens."""
+    rendered = daemon_cmd._render_template(
+        "nexus-t2.service",
+        nx_bin=["/opt/python with spaces/python3.12", "-m", "nexus.cli"],
+        log_dir=str(tmp_path / "logs"),
+        path_env="/usr/bin",
+    )
+    # Pull the ExecStart line.
+    exec_lines = [line for line in rendered.splitlines() if line.startswith("ExecStart=")]
+    assert len(exec_lines) == 1
+    exec_line = exec_lines[0].removeprefix("ExecStart=")
+    parsed = shlex.split(exec_line)
+    assert parsed[:3] == [
+        "/opt/python with spaces/python3.12",
+        "-m",
+        "nexus.cli",
+    ]
+    assert parsed[3:] == ["daemon", "t2", "start", "--foreground"]
+
+
+def test_plist_keepalive_uses_crashed_not_successfulexit() -> None:
+    """nexus-o6g9: plist KeepAlive must be ``Crashed: true`` so clean SIGTERM stops respawn."""
+    plist = daemon_cmd._read_template("com.nexus.t2.plist")
+    # Old broken semantic was ``<key>SuccessfulExit</key><false/>``.
+    assert "SuccessfulExit" not in plist
+    # New semantic: respawn on crash only.
+    assert "<key>Crashed</key>" in plist
+    crashed_index = plist.index("<key>Crashed</key>")
+    snippet = plist[crashed_index : crashed_index + 80]
+    assert "<true/>" in snippet
+
+
+def test_systemd_unit_marks_sigterm_exit_as_success() -> None:
+    """nexus-o6g9: systemd unit must include ``SuccessExitStatus=143`` (SIGTERM)."""
+    service = daemon_cmd._read_template("nexus-t2.service")
+    assert "SuccessExitStatus=143" in service
 
 
 def test_install_autostart_macos_writes_plist(
@@ -72,7 +133,7 @@ def test_install_autostart_macos_writes_plist(
     _set_platform(monkeypatch, "darwin")
     monkeypatch.setattr(daemon_cmd, "_autostart_install_dir", lambda: tmp_path / "LaunchAgents")
     monkeypatch.setattr(daemon_cmd, "_autostart_log_dir", lambda: tmp_path / "logs")
-    monkeypatch.setattr(daemon_cmd, "_resolve_nx_bin", lambda: "/opt/nx/bin/nx")
+    monkeypatch.setattr(daemon_cmd, "_resolve_nx_bin", lambda: ["/opt/nx/bin/nx"])
 
     with patch.object(daemon_cmd.subprocess, "run") as mock_run:
         mock_run.return_value.returncode = 0
@@ -85,8 +146,8 @@ def test_install_autostart_macos_writes_plist(
     plist_path = tmp_path / "LaunchAgents" / "com.nexus.t2.plist"
     assert plist_path.exists()
     body = plist_path.read_text()
-    assert "/opt/nx/bin/nx" in body
-    assert "__NX_BIN__" not in body
+    assert "<string>/opt/nx/bin/nx</string>" in body
+    assert "<string>__NX_BIN__</string>" not in body
     # File permissions: 0o644 (world-readable, owner-writable).
     mode = plist_path.stat().st_mode & 0o777
     assert mode == 0o644
@@ -102,7 +163,7 @@ def test_install_autostart_linux_writes_service(
     _set_platform(monkeypatch, "linux")
     monkeypatch.setattr(daemon_cmd, "_autostart_install_dir", lambda: tmp_path / "systemd")
     monkeypatch.setattr(daemon_cmd, "_autostart_log_dir", lambda: tmp_path / "logs")
-    monkeypatch.setattr(daemon_cmd, "_resolve_nx_bin", lambda: "/opt/nx/bin/nx")
+    monkeypatch.setattr(daemon_cmd, "_resolve_nx_bin", lambda: ["/opt/nx/bin/nx"])
 
     with patch.object(daemon_cmd.subprocess, "run") as mock_run:
         mock_run.return_value.returncode = 0


### PR DESCRIPTION
## Summary

Two paired autostart fixes from the RDR-110/111/112/113 360° critique (umbrella nexus-g7yy). They unblock nexus-mf91 (auto-prompt for install --autostart) which must not nudge users toward an install that produces invalid plists or flap-loops on stop.

### nexus-ooxh — Multi-token \`nx\` fallback

\`_resolve_nx_bin()\` returned \`'python -m nexus.cli'\` as a single string. The plist \`<string>__NX_BIN__</string>\` slot treats that as one executable name, so \`launchctl bootstrap\` silently fails on every machine without \`nx\` on \`PATH\`. The systemd unit happens to whitespace-split correctly today but is fragile under any path containing spaces.

- \`_resolve_nx_bin()\` now returns \`list[str]\`: \`['nx']\` for the PATH case, \`[python, '-m', 'nexus.cli']\` for the fallback.
- Plist substitution expands \`<string>__NX_BIN__</string>\` into N \`<string>\` siblings.
- Systemd substitution uses \`shlex.join\` so multi-token argvs survive systemd's whitespace-split parser, and paths with spaces stay one argument.

### nexus-o6g9 — Flap loop on \`nx daemon t2 stop\`

SIGTERM-induced exits on supervised daemons triggered an instant respawn under both supervisors:

- launchd plist \`KeepAlive\` was \`{ SuccessfulExit: false }\` — any non-zero exit code respawned. Now \`{ Crashed: true }\`: respawn only on abnormal signal termination, never on clean exit.
- systemd unit had \`Restart=on-failure\` with no \`SuccessExitStatus\`. Added \`SuccessExitStatus=143\` so SIGTERM exits are counted as success and not retried.

## Closes

- Closes nexus-ooxh
- Closes nexus-o6g9

## Refs

- nexus-g7yy (RDR-110-113 critique remediation)
- Unblocks nexus-mf91 (autostart auto-prompt)

## Test plan

- [x] \`uv run pytest tests/commands/test_daemon_autostart.py\` — 15 passed (4 new)
- [x] \`uv run pytest tests/commands/ tests/daemon/\` — 249 passed
- [ ] CI green

### New regression tests

- \`test_render_plist_multi_token_expands_to_one_string_per_token\` — N \`<string>\` elements, no space-joined slot.
- \`test_render_systemd_multi_token_uses_shlex_join\` — ExecStart round-trips through \`shlex.split\`.
- \`test_plist_keepalive_uses_crashed_not_successfulexit\` — \`{ Crashed: true }\`, no \`SuccessfulExit\`.
- \`test_systemd_unit_marks_sigterm_exit_as_success\` — \`SuccessExitStatus=143\`.