### PR TITLE
feat(rdr-111): action_idempotency dedup + wire BindingWatcher into daemon

### DIFF
--- a/src/nexus/cockpit/bindings.py
+++ b/src/nexus/cockpit/bindings.py
@@ -61,6 +61,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import hashlib
 import importlib
 import sqlite3
 import time
@@ -273,6 +274,47 @@ def _resolve_python_callable(target: str) -> Callable[..., Any]:
     return fn
 
 
+#: Default TTL on the action_idempotency rows. RDR-111:933.
+_IDEMPOTENCY_TTL_SECONDS = 300.0
+
+
+def _idempotency_key(binding_name: str, tuple_id: str) -> str:
+    """Deterministic key for the ``action_idempotency`` table.
+
+    RDR-111 lines 909-942: ``sha256(binding_name + tuple_id)``. The key
+    is per-(binding, event) so two different bindings on the same event
+    each get their own dedup row, but a watcher restart that replays
+    the same event for the same binding hits the dedup hit and skips.
+    """
+    raw = f"{binding_name}:{tuple_id}".encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _idempotency_check(
+    memory_conn: sqlite3.Connection, *, key: str, now: float
+) -> bool:
+    """Return True if a non-expired key already exists for this action."""
+    row = memory_conn.execute(
+        "SELECT 1 FROM action_idempotency "
+        "WHERE idempotency_key = ? AND expires_at > ? LIMIT 1",
+        (key, now),
+    ).fetchone()
+    return row is not None
+
+
+def _idempotency_record(
+    memory_conn: sqlite3.Connection, *, key: str, expires_at: float
+) -> None:
+    """Insert (or refresh) the dedup row for a successfully dispatched action."""
+    memory_conn.execute(
+        "INSERT INTO action_idempotency (idempotency_key, expires_at) "
+        "VALUES (?, ?) "
+        "ON CONFLICT(idempotency_key) DO UPDATE SET expires_at = excluded.expires_at",
+        (key, expires_at),
+    )
+    memory_conn.commit()
+
+
 async def _dispatch_action(
     action: Action,
     *,
@@ -281,6 +323,9 @@ async def _dispatch_action(
     context: "BindingContext",
 ) -> None:
     if action.kind == "log":
+        # Log actions are inherently idempotent — a second log line on
+        # crash-replay is harmless, and the dedup gate would only waste a
+        # SELECT round-trip per event.
         _log.info(
             "binding_action_log",
             marker=action.target,
@@ -291,10 +336,50 @@ async def _dispatch_action(
         )
         return
     if action.kind == "python":
+        # RDR-111:909-942 dedup gate. Only applied when memory_conn is
+        # wired (production daemon path). Tests that pass a stub context
+        # without memory_conn keep the legacy at-least-once semantics.
+        if context.memory_conn is not None:
+            key = _idempotency_key(binding.name, event.tuple_id)
+            now = time.time()
+            try:
+                if _idempotency_check(context.memory_conn, key=key, now=now):
+                    _log.info(
+                        "binding_action_dedup_skip",
+                        binding=binding.name,
+                        subspace=event.subspace,
+                        tuple_id=event.tuple_id,
+                    )
+                    return
+            except sqlite3.Error:
+                # Table missing or other persistent error — fall through to
+                # dispatch (degrade-open). Without the table, replays cannot
+                # be filtered, but skipping the action is the worse failure
+                # mode (silent loss of side effect).
+                _log.exception(
+                    "binding_action_idempotency_check_failed",
+                    binding=binding.name,
+                    tuple_id=event.tuple_id,
+                )
+
         fn = _resolve_python_callable(action.target)
         result = fn(event, binding, context)
         if asyncio.iscoroutine(result):
             await result
+
+        if context.memory_conn is not None:
+            try:
+                _idempotency_record(
+                    context.memory_conn,
+                    key=_idempotency_key(binding.name, event.tuple_id),
+                    expires_at=time.time() + _IDEMPOTENCY_TTL_SECONDS,
+                )
+            except sqlite3.Error:
+                _log.exception(
+                    "binding_action_idempotency_record_failed",
+                    binding=binding.name,
+                    tuple_id=event.tuple_id,
+                )
         return
     raise BindingProfileError(f"unknown action kind {action.kind!r}")
 
@@ -311,12 +396,20 @@ class BindingContext:
     Holds the tuplespace handles an action might need to write derived
     tuples back into the system. Tests inject a stub object; production
     wiring constructs one in :meth:`_BindingWatcher.start`.
+
+    ``memory_conn`` is the optional ``memory.db`` connection used for
+    the ``action_idempotency`` dedup gate (RDR-111 §lines 909-942,
+    nexus-8wvs). When ``None`` the watcher runs without the dedup gate
+    — tests that inject a stub context exercise this path. Production
+    wiring (the daemon) populates it so a crash between dispatch and
+    cursor save cannot re-fire a python action on restart.
     """
 
     conn: Optional[sqlite3.Connection] = None
     index: Any = None  # nexus.tuplespace.index.TupleIndex
     registry: Any = None  # nexus.tuplespace.registry.Registry
     profile_name: str = ""
+    memory_conn: Optional[sqlite3.Connection] = None
     # Free-form bag so reference actions and tests can stash arbitrary
     # state without growing the dataclass for every consumer.
     extras: dict[str, Any] = dataclasses.field(default_factory=dict)
@@ -487,6 +580,7 @@ class _BindingWatcher:
         subspace_glob: str = "*",
         poll_interval: float = 0.05,
         batch_limit: int = 100,
+        stop_timeout: float = 5.0,
     ) -> None:
         self._conn = conn
         self._profiles: tuple[BindingProfile, ...] = tuple(profiles)
@@ -494,15 +588,56 @@ class _BindingWatcher:
         self._subspace_glob = subspace_glob
         self._poll_interval = poll_interval
         self._batch_limit = batch_limit
+        self._stop_timeout = stop_timeout
         self._stop = asyncio.Event()
         # One cursor per (subspace_glob, profile_name). Loaded lazily in run().
         self._cursors: dict[str, int] = {}
+        # Task handle from start(); stays None until start() is called.
+        self._task: asyncio.Task | None = None  # type: ignore[type-arg]
 
     # -- lifecycle --------------------------------------------------------
 
     def request_stop(self) -> None:
         """Signal the watcher to exit at the next loop boundary."""
         self._stop.set()
+
+    def start(self) -> "asyncio.Task[None]":
+        """Schedule :meth:`run` on the current event loop. Idempotent.
+
+        Returns the asyncio task driving the loop. Subsequent calls
+        return the existing task without spawning a second one. The
+        daemon stores the watcher instance and calls :meth:`stop`
+        during shutdown; tests can ``await`` the returned task
+        directly for fine-grained orchestration.
+        """
+        if self._task is not None and not self._task.done():
+            return self._task
+        self._task = asyncio.create_task(self.run())
+        return self._task
+
+    async def stop(self) -> None:
+        """Signal the loop to exit and wait for the task to finish.
+
+        Bounded by ``stop_timeout`` (default 5s, matching the daemon's
+        socket-close timeout). On timeout the task is cancelled and a
+        warning is logged. Safe to call before :meth:`start` (no-op)
+        or twice (second call is a no-op).
+        """
+        self.request_stop()
+        if self._task is None or self._task.done():
+            return
+        try:
+            await asyncio.wait_for(self._task, timeout=self._stop_timeout)
+        except asyncio.TimeoutError:
+            _log.warning(
+                "binding_watcher_stop_timeout",
+                timeout=self._stop_timeout,
+            )
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
 
     async def run(self) -> None:
         """Run the polling loop until :meth:`request_stop` is invoked."""

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -80,6 +80,7 @@ import json
 import os
 import signal
 import socket
+import sqlite3
 import struct
 import sys
 import traceback as _traceback_mod
@@ -92,6 +93,19 @@ import structlog
 from nexus.daemon.peer import PeerCredentials, read_peer_credentials
 
 _log = structlog.get_logger(__name__)
+
+
+def _cockpit_bindings_disabled() -> bool:
+    """Return True if ``NX_COCKPIT_BINDINGS_DISABLE`` is set to a truthy value.
+
+    Falsy tokens (watcher runs): unset, ``""``, ``"0"``, ``"false"``, ``"False"``.
+    Any other non-empty value disables the cockpit binding watcher. Mirrors
+    the ``NX_BRIDGE_DISABLE`` opt-out semantics so operators have a single
+    mental model for cockpit feature kill switches.
+    """
+    val = os.environ.get("NX_COCKPIT_BINDINGS_DISABLE", "").strip()
+    return val not in ("", "0", "false", "False")
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -593,6 +607,13 @@ class T2Daemon:
         # Started in start(); cancelled in stop().
         self._retention_task: asyncio.Task | None = None  # type: ignore[type-arg]
 
+        # nexus-9eiw (RDR-111 §Phase 2 Step 6): binding watcher reaction loop.
+        # Constructed in start() when NX_COCKPIT_BINDINGS_DISABLE is not set
+        # and at least one binding profile is loaded. Stopped in stop().
+        self._binding_watcher: Any = None
+        self._binding_watcher_conn: sqlite3.Connection | None = None
+        self._binding_watcher_memory_conn: sqlite3.Connection | None = None
+
     # ------------------------------------------------------------------
     # Public properties (set after start())
     # ------------------------------------------------------------------
@@ -710,6 +731,15 @@ class T2Daemon:
             _log.warning("retention_sweep_startup_failed", error=str(exc))
         self._retention_task = asyncio.create_task(self._retention_loop())
 
+        # nexus-9eiw (RDR-111 §Phase 2 Step 6): start the binding watcher
+        # unless NX_COCKPIT_BINDINGS_DISABLE is truthy. The watcher polls
+        # the events table and fires loaded profiles with action_idempotency
+        # dedup (nexus-8wvs) on the memory.db connection it owns.
+        if _cockpit_bindings_disabled():
+            _log.info("binding_watcher_skipped_disable_env")
+        else:
+            self._start_binding_watcher(memory_db_path, tuples_db_path)
+
         _log.info(
             "t2_daemon_started",
             uds_path=str(self._uds_path),
@@ -732,6 +762,27 @@ class T2Daemon:
             except (asyncio.CancelledError, Exception):
                 pass
             self._retention_task = None
+
+        # nexus-9eiw: signal the binding watcher to exit and close its
+        # SQLite connections. Bounded by the watcher's own stop_timeout.
+        if self._binding_watcher is not None:
+            try:
+                await self._binding_watcher.stop()
+            except Exception as exc:  # pragma: no cover — defensive
+                _log.warning("binding_watcher_stop_failed", error=str(exc))
+            self._binding_watcher = None
+        if self._binding_watcher_conn is not None:
+            try:
+                self._binding_watcher_conn.close()
+            except sqlite3.Error:
+                pass
+            self._binding_watcher_conn = None
+        if self._binding_watcher_memory_conn is not None:
+            try:
+                self._binding_watcher_memory_conn.close()
+            except sqlite3.Error:
+                pass
+            self._binding_watcher_memory_conn = None
 
         for srv in (self._uds_server, self._tcp_server):
             if srv is not None:
@@ -1124,6 +1175,88 @@ class T2Daemon:
         )
 
     # ------------------------------------------------------------------
+    # Binding watcher (nexus-9eiw, RDR-111 §Phase 2 Step 6)
+    # ------------------------------------------------------------------
+
+    def _start_binding_watcher(
+        self, memory_db_path: Path, tuples_db_path: Path
+    ) -> None:
+        """Construct and start the cockpit binding watcher.
+
+        Loads profiles from the default profiles directory and opens
+        dedicated SQLite connections to both ``tuples.db`` (for the
+        events poll) and ``memory.db`` (for the ``action_idempotency``
+        dedup gate). When no profiles are loaded the watcher is not
+        constructed — the loop would have nothing to do.
+        """
+        from nexus.cockpit.bindings import (  # noqa: PLC0415
+            BindingContext,
+            _BindingWatcher,
+            default_profiles_dir,
+            load_profiles_dir,
+        )
+
+        profiles_dir = default_profiles_dir()
+        if not profiles_dir.is_dir():
+            _log.info(
+                "binding_watcher_no_profiles_dir",
+                path=str(profiles_dir),
+            )
+            return
+        try:
+            profiles = load_profiles_dir(profiles_dir)
+        except Exception as exc:  # pragma: no cover — defensive
+            _log.warning(
+                "binding_watcher_profile_load_failed",
+                path=str(profiles_dir),
+                error=str(exc),
+            )
+            return
+        if not profiles:
+            _log.info("binding_watcher_no_profiles")
+            return
+
+        # Dedicated connections so the watcher can run on the event loop
+        # thread without contending with the daemon's writer.
+        tuples_conn = sqlite3.connect(
+            str(tuples_db_path), check_same_thread=False
+        )
+        tuples_conn.row_factory = sqlite3.Row
+        memory_conn = sqlite3.connect(
+            str(memory_db_path), check_same_thread=False
+        )
+        memory_conn.row_factory = sqlite3.Row
+
+        # Wire the tuplespace index + registry from the running service
+        # so python actions can write derived tuples via the same backend.
+        if self._tuplespace_service is not None:
+            index = getattr(self._tuplespace_service, "_index", None)
+            registry = getattr(self._tuplespace_service, "_registry", None)
+        else:
+            index = None
+            registry = None
+
+        context = BindingContext(
+            conn=tuples_conn,
+            index=index,
+            registry=registry,
+            memory_conn=memory_conn,
+        )
+        watcher = _BindingWatcher(
+            conn=tuples_conn,
+            profiles=profiles,
+            context=context,
+        )
+        self._binding_watcher = watcher
+        self._binding_watcher_conn = tuples_conn
+        self._binding_watcher_memory_conn = memory_conn
+        watcher.start()
+        _log.info(
+            "binding_watcher_scheduled",
+            profile_count=len(profiles),
+        )
+
+    # ------------------------------------------------------------------
     # Retention sweeper (nexus-kk9h, RDR-111)
     # ------------------------------------------------------------------
 
@@ -1138,20 +1271,44 @@ class T2Daemon:
         with no matching SQLite row) are bounded by total write volume
         and are tolerated until a follow-up wires a Chroma client into
         the daemon constructor.
+
+        Also sweeps expired ``action_idempotency`` rows from
+        ``memory.db`` (nexus-8wvs). Both sweeps are best-effort — a
+        failure on either side logs and continues.
         """
         if self._tuples_db_path is None:
             return 0
-        import sqlite3 as _sqlite3
-        from nexus.tuplespace.store import prune_expired_tuples
+        from nexus.db.migrations import sweep_action_idempotency  # noqa: PLC0415
+        from nexus.tuplespace.store import prune_expired_tuples  # noqa: PLC0415
 
-        # Short-lived connection so we don't contend with the daemon's
+        # Short-lived connections so we don't contend with the daemon's
         # main writer for long (WAL allows concurrent readers; the DELETE
         # acquires the writer lock briefly).
-        conn = _sqlite3.connect(str(self._tuples_db_path))
+        conn = sqlite3.connect(str(self._tuples_db_path))
         try:
-            return prune_expired_tuples(conn)
+            deleted = prune_expired_tuples(conn)
         finally:
             conn.close()
+
+        memory_db_path = self._config_dir / "memory.db"
+        if memory_db_path.exists():
+            mem_conn = sqlite3.connect(str(memory_db_path))
+            try:
+                idem_deleted = sweep_action_idempotency(mem_conn)
+                if idem_deleted:
+                    _log.info(
+                        "action_idempotency_sweep",
+                        deleted=idem_deleted,
+                    )
+            except sqlite3.Error as exc:
+                _log.warning(
+                    "action_idempotency_sweep_failed",
+                    error=str(exc),
+                )
+            finally:
+                mem_conn.close()
+
+        return deleted
 
     async def _retention_loop(self) -> None:
         """Recurring 6-hour retention sweep. Cancelled on daemon stop."""

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import sqlite3
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -2881,6 +2882,59 @@ CREATE INDEX IF NOT EXISTS idx_liveness_last_seen ON liveness (last_seen);
     _log.info("migrate_liveness_table_done")
 
 
+def migrate_action_idempotency_table(conn: sqlite3.Connection) -> None:
+    """RDR-111 §lines 909-942 (nexus-8wvs): action_idempotency dedup table.
+
+    The binding watcher's at-least-once contract requires a dedup table
+    so that a crash between ``_dispatch_event`` and ``_save_cursor``
+    cannot replay an action on restart. Keys are
+    ``sha256(binding_name + tuple_id)`` and carry a 300-second TTL by
+    default; expired rows are swept in the daemon's retention loop.
+
+    Must be called with a ``memory.db`` connection.
+    Idempotent: gated by ``CREATE TABLE IF NOT EXISTS``.
+    """
+    existing = {
+        r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='action_idempotency'"
+        ).fetchall()
+    }
+    if "action_idempotency" in existing:
+        return
+    _log.info("migrate_action_idempotency_table_start")
+    conn.executescript("""
+CREATE TABLE IF NOT EXISTS action_idempotency (
+    idempotency_key TEXT PRIMARY KEY,
+    expires_at      REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_action_idempotency_expires
+    ON action_idempotency (expires_at);
+""")
+    conn.commit()
+    _log.info("migrate_action_idempotency_table_done")
+
+
+def sweep_action_idempotency(conn: sqlite3.Connection) -> int:
+    """Delete expired ``action_idempotency`` rows. Returns the count.
+
+    Safe on a fresh ``memory.db`` that has not yet seen the migration —
+    if the table is absent the function is a no-op and returns 0.
+    """
+    cursor = conn.execute(
+        "SELECT 1 FROM sqlite_master "
+        "WHERE type='table' AND name='action_idempotency'"
+    )
+    if cursor.fetchone() is None:
+        return 0
+    deleted = conn.execute(
+        "DELETE FROM action_idempotency WHERE expires_at <= ?",
+        (time.time(),),
+    ).rowcount
+    conn.commit()
+    return int(deleted or 0)
+
+
 def migrate_catalog_tables_in_memory_db(conn: sqlite3.Connection) -> None:
     """RDR-112 P2.1 (nexus-7ejx): create catalog tables in memory.db.
 
@@ -3327,6 +3381,11 @@ MIGRATIONS: list[Migration] = [
         "4.35.0",
         "RDR-111 P1.3: create liveness table + last_seen index (nexus-r0vi)",
         migrate_liveness_table,
+    ),
+    Migration(
+        "4.36.0",
+        "RDR-111 §lines 909-942: action_idempotency dedup table (nexus-8wvs)",
+        migrate_action_idempotency_table,
     ),
 ]
 

--- a/src/nexus/db/t2/memory_store.py
+++ b/src/nexus/db/t2/memory_store.py
@@ -105,6 +105,19 @@ CREATE TABLE IF NOT EXISTS liveness (
 CREATE INDEX IF NOT EXISTS idx_liveness_last_seen ON liveness (last_seen);
 """
 
+# nexus-8wvs (RDR-111 §lines 909-942): action_idempotency dedup table.
+# Created here so fresh installs get the table directly, mirroring the
+# liveness pattern. The version-gated migrate_action_idempotency_table
+# in migrations.py covers upgrade paths from pre-RDR-111 databases.
+_ACTION_IDEMPOTENCY_SCHEMA_SQL = """\
+CREATE TABLE IF NOT EXISTS action_idempotency (
+    idempotency_key TEXT PRIMARY KEY,
+    expires_at      REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_action_idempotency_expires
+    ON action_idempotency (expires_at);
+"""
+
 _MEMORY_SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS memory (
     id            INTEGER PRIMARY KEY,
@@ -299,6 +312,7 @@ class MemoryStore:
         with self._lock:
             self.conn.executescript(_MEMORY_SCHEMA_SQL)
             self.conn.executescript(_LIVENESS_SCHEMA_SQL)
+            self.conn.executescript(_ACTION_IDEMPOTENCY_SCHEMA_SQL)
             self.conn.executescript("PRAGMA journal_mode=WAL;")
             self.conn.commit()
             result = self.conn.execute("PRAGMA journal_mode").fetchone()

--- a/tests/cockpit/test_binding_watcher.py
+++ b/tests/cockpit/test_binding_watcher.py
@@ -613,3 +613,247 @@ class TestBindingWatcher:
         await asyncio.sleep(0.05)
         watcher.request_stop()
         await asyncio.wait_for(task, timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: lifecycle wrappers (nexus-9eiw)
+# ---------------------------------------------------------------------------
+
+
+class TestBindingWatcherLifecycle:
+    """start() / stop() wrappers — idempotent, bounded-stop, no-op safety."""
+
+    @pytest.mark.asyncio
+    async def test_start_returns_running_task_and_is_idempotent(
+        self, conn, context
+    ) -> None:
+        profile = BindingProfile(name="lifecycle", bindings=())
+        watcher = _BindingWatcher(
+            conn=conn, profiles=[profile], context=context, poll_interval=0.01
+        )
+        task1 = watcher.start()
+        task2 = watcher.start()
+        try:
+            assert task1 is task2
+            assert not task1.done()
+        finally:
+            await watcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_terminates_running_loop(self, conn, context) -> None:
+        profile = BindingProfile(name="lifecycle", bindings=())
+        watcher = _BindingWatcher(
+            conn=conn, profiles=[profile], context=context, poll_interval=0.01
+        )
+        watcher.start()
+        await asyncio.sleep(0.02)
+        await watcher.stop()
+        assert watcher._task is not None
+        assert watcher._task.done()
+
+    @pytest.mark.asyncio
+    async def test_stop_without_start_is_noop(self, conn, context) -> None:
+        profile = BindingProfile(name="lifecycle", bindings=())
+        watcher = _BindingWatcher(
+            conn=conn, profiles=[profile], context=context, poll_interval=0.01
+        )
+        # Must not raise even though start() never ran.
+        await watcher.stop()
+        assert watcher._task is None
+
+    @pytest.mark.asyncio
+    async def test_double_stop_is_noop(self, conn, context) -> None:
+        profile = BindingProfile(name="lifecycle", bindings=())
+        watcher = _BindingWatcher(
+            conn=conn, profiles=[profile], context=context, poll_interval=0.01
+        )
+        watcher.start()
+        await asyncio.sleep(0.02)
+        await watcher.stop()
+        # Second stop is a no-op — must not deadlock or raise.
+        await watcher.stop()
+
+
+# ---------------------------------------------------------------------------
+# Tests: action_idempotency dedup gate (nexus-8wvs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def memory_conn(tmp_path: Path):
+    """memory.db connection seeded with the action_idempotency schema."""
+    from nexus.db.migrations import migrate_action_idempotency_table
+
+    db = tmp_path / "memory.db"
+    c = sqlite3.connect(str(db))
+    c.row_factory = sqlite3.Row
+    migrate_action_idempotency_table(c)
+    yield c
+    c.close()
+
+
+class TestActionIdempotency:
+    """RDR-111:909-942 dedup gate prevents python-action replay on restart."""
+
+    def _make_event(self, *, tuple_id: str) -> EventRecord:
+        return EventRecord(
+            cursor=1,
+            subspace="hook_events/notification",
+            op="out",
+            tuple_id=tuple_id,
+            payload_summary=None,
+            category="data",
+            ts=1700000000.0,
+        )
+
+    def _make_binding(self) -> Binding:
+        return Binding(
+            name="dedup-binding",
+            match={"subspace": "hook_events/notification"},
+            action=Action(
+                kind="python",
+                target="tests.cockpit.test_binding_watcher:_idem_action_recorder",
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_first_dispatch_runs_action(
+        self, conn, index, registry, memory_conn
+    ) -> None:
+        from nexus.cockpit.bindings import _dispatch_action
+
+        _idem_invocations.clear()
+        ctx = BindingContext(
+            conn=conn,
+            index=index,
+            registry=registry,
+            memory_conn=memory_conn,
+            profile_name="default",
+        )
+        binding = self._make_binding()
+        event = self._make_event(tuple_id="tuple-1")
+        await _dispatch_action(
+            binding.action, event=event, binding=binding, context=ctx
+        )
+        assert len(_idem_invocations) == 1
+
+    @pytest.mark.asyncio
+    async def test_replay_with_same_tuple_id_is_deduped(
+        self, conn, index, registry, memory_conn
+    ) -> None:
+        from nexus.cockpit.bindings import _dispatch_action
+
+        _idem_invocations.clear()
+        ctx = BindingContext(
+            conn=conn,
+            index=index,
+            registry=registry,
+            memory_conn=memory_conn,
+            profile_name="default",
+        )
+        binding = self._make_binding()
+        event = self._make_event(tuple_id="tuple-2")
+        await _dispatch_action(
+            binding.action, event=event, binding=binding, context=ctx
+        )
+        await _dispatch_action(
+            binding.action, event=event, binding=binding, context=ctx
+        )
+        # First call runs the action, second hits the dedup gate.
+        assert len(_idem_invocations) == 1
+
+    @pytest.mark.asyncio
+    async def test_log_action_skips_dedup_check(
+        self, conn, index, registry, memory_conn
+    ) -> None:
+        """log actions are inherently idempotent — no row should be written."""
+        from nexus.cockpit.bindings import _dispatch_action
+
+        ctx = BindingContext(
+            conn=conn,
+            index=index,
+            registry=registry,
+            memory_conn=memory_conn,
+            profile_name="default",
+        )
+        binding = Binding(
+            name="log-only",
+            match={"subspace": "hook_events/notification"},
+            action=Action(kind="log", target="LOG-MARKER"),
+        )
+        event = self._make_event(tuple_id="tuple-3")
+        await _dispatch_action(
+            binding.action, event=event, binding=binding, context=ctx
+        )
+        count = memory_conn.execute(
+            "SELECT count(*) FROM action_idempotency"
+        ).fetchone()[0]
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_expired_row_lets_next_dispatch_through(
+        self, conn, index, registry, memory_conn
+    ) -> None:
+        from nexus.cockpit.bindings import _dispatch_action, _idempotency_key
+
+        _idem_invocations.clear()
+        binding = self._make_binding()
+        event = self._make_event(tuple_id="tuple-4")
+        # Pre-seed an expired row for this (binding, tuple_id).
+        memory_conn.execute(
+            "INSERT INTO action_idempotency (idempotency_key, expires_at) "
+            "VALUES (?, ?)",
+            (_idempotency_key(binding.name, event.tuple_id), 1.0),
+        )
+        memory_conn.commit()
+
+        ctx = BindingContext(
+            conn=conn,
+            index=index,
+            registry=registry,
+            memory_conn=memory_conn,
+            profile_name="default",
+        )
+        await _dispatch_action(
+            binding.action, event=event, binding=binding, context=ctx
+        )
+        # Expired row did not dedup; the action ran exactly once.
+        assert len(_idem_invocations) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_memory_conn_disables_dedup_gate(
+        self, conn, index, registry
+    ) -> None:
+        """Backward-compat: contexts without memory_conn keep at-least-once."""
+        from nexus.cockpit.bindings import _dispatch_action
+
+        _idem_invocations.clear()
+        ctx = BindingContext(
+            conn=conn,
+            index=index,
+            registry=registry,
+            memory_conn=None,
+            profile_name="default",
+        )
+        binding = self._make_binding()
+        event = self._make_event(tuple_id="tuple-5")
+        await _dispatch_action(
+            binding.action, event=event, binding=binding, context=ctx
+        )
+        await _dispatch_action(
+            binding.action, event=event, binding=binding, context=ctx
+        )
+        # No dedup gate → both calls run.
+        assert len(_idem_invocations) == 2
+
+
+# Used by TestActionIdempotency via the python-action lookup mechanism.
+_idem_invocations: list[str] = []
+
+
+def _idem_action_recorder(
+    event: EventRecord,
+    binding: Binding,
+    context: BindingContext,
+) -> None:
+    _idem_invocations.append(event.tuple_id)

--- a/tests/daemon/test_binding_watcher_wiring.py
+++ b/tests/daemon/test_binding_watcher_wiring.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""T2Daemon binding-watcher wiring tests (RDR-111 Phase 2 Step 6, nexus-9eiw).
+
+Verifies that the daemon constructs and starts the binding watcher
+during ``start()``, cleans it up during ``stop()``, and honours the
+``NX_COCKPIT_BINDINGS_DISABLE`` env override.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+from pathlib import Path
+
+import chromadb
+import pytest
+import pytest_asyncio
+
+from nexus.daemon.subspace_registry import RegistryStore
+from nexus.daemon.t2_daemon import T2Daemon, _cockpit_bindings_disabled
+from nexus.daemon.tuplespace_service import TuplespaceService
+from nexus.db.t2 import T2Database
+
+
+@pytest.fixture()
+def config_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "config" / "nexus"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest_asyncio.fixture()
+async def daemon_with_tuplespace(config_dir: Path):
+    """Yield a started T2Daemon wired with a tuplespace service."""
+    memory_db_path = config_dir / "memory.db"
+    tuples_db_path = config_dir / "tuples.db"
+    chroma_client = chromadb.EphemeralClient()
+
+    t2db = T2Database(memory_db_path)
+    registry_store = RegistryStore(tuples_db_path=tuples_db_path)
+    tuplespace_service = TuplespaceService(
+        tuples_db_path=tuples_db_path,
+        chroma_client=chroma_client,
+    )
+    daemon = T2Daemon(
+        config_dir=config_dir,
+        t2db=t2db,
+        tuples_db_path=tuples_db_path,
+        registry_store=registry_store,
+        tuplespace_service=tuplespace_service,
+    )
+    await daemon.start()
+    try:
+        yield daemon
+    finally:
+        try:
+            await daemon.stop()
+        except Exception:
+            pass
+        t2db.close()
+
+
+# ---------------------------------------------------------------------------
+# Env-gate helper
+# ---------------------------------------------------------------------------
+
+
+class TestCockpitBindingsDisableEnv:
+    @pytest.mark.parametrize("falsy", ["", "0", "false", "False"])
+    def test_falsy_values_keep_watcher_enabled(
+        self, monkeypatch: pytest.MonkeyPatch, falsy: str
+    ) -> None:
+        monkeypatch.setenv("NX_COCKPIT_BINDINGS_DISABLE", falsy)
+        assert _cockpit_bindings_disabled() is False
+
+    @pytest.mark.parametrize("truthy", ["1", "true", "yes", "TRUE", " 1 "])
+    def test_truthy_values_disable_watcher(
+        self, monkeypatch: pytest.MonkeyPatch, truthy: str
+    ) -> None:
+        monkeypatch.setenv("NX_COCKPIT_BINDINGS_DISABLE", truthy)
+        assert _cockpit_bindings_disabled() is True
+
+    def test_unset_keeps_watcher_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("NX_COCKPIT_BINDINGS_DISABLE", raising=False)
+        assert _cockpit_bindings_disabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Daemon-level wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_daemon_start_constructs_binding_watcher(
+    daemon_with_tuplespace: T2Daemon,
+) -> None:
+    """Default startup wires the watcher when profiles directory has profiles."""
+    daemon = daemon_with_tuplespace
+    # The builtin default profile ships under nx/tuplespace/builtin/bindings/profiles
+    # so the watcher must have been constructed.
+    assert daemon._binding_watcher is not None
+    assert daemon._binding_watcher_conn is not None
+    assert daemon._binding_watcher_memory_conn is not None
+    # And a running task.
+    assert daemon._binding_watcher._task is not None
+    assert not daemon._binding_watcher._task.done()
+
+
+@pytest.mark.asyncio
+async def test_daemon_stop_cleans_up_binding_watcher(
+    config_dir: Path,
+) -> None:
+    """stop() must await the watcher, close connections, and null its handles."""
+    memory_db_path = config_dir / "memory.db"
+    tuples_db_path = config_dir / "tuples.db"
+    chroma_client = chromadb.EphemeralClient()
+
+    t2db = T2Database(memory_db_path)
+    registry_store = RegistryStore(tuples_db_path=tuples_db_path)
+    tuplespace_service = TuplespaceService(
+        tuples_db_path=tuples_db_path,
+        chroma_client=chroma_client,
+    )
+    daemon = T2Daemon(
+        config_dir=config_dir,
+        t2db=t2db,
+        tuples_db_path=tuples_db_path,
+        registry_store=registry_store,
+        tuplespace_service=tuplespace_service,
+    )
+    await daemon.start()
+    assert daemon._binding_watcher is not None
+    watcher_task = daemon._binding_watcher._task
+
+    await daemon.stop()
+    assert daemon._binding_watcher is None
+    assert daemon._binding_watcher_conn is None
+    assert daemon._binding_watcher_memory_conn is None
+    assert watcher_task is not None
+    assert watcher_task.done()
+    t2db.close()
+
+
+@pytest.mark.asyncio
+async def test_disable_env_short_circuits_watcher_construction(
+    config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """NX_COCKPIT_BINDINGS_DISABLE=1 must skip watcher construction entirely."""
+    monkeypatch.setenv("NX_COCKPIT_BINDINGS_DISABLE", "1")
+    memory_db_path = config_dir / "memory.db"
+    tuples_db_path = config_dir / "tuples.db"
+    chroma_client = chromadb.EphemeralClient()
+
+    t2db = T2Database(memory_db_path)
+    registry_store = RegistryStore(tuples_db_path=tuples_db_path)
+    tuplespace_service = TuplespaceService(
+        tuples_db_path=tuples_db_path,
+        chroma_client=chroma_client,
+    )
+    daemon = T2Daemon(
+        config_dir=config_dir,
+        t2db=t2db,
+        tuples_db_path=tuples_db_path,
+        registry_store=registry_store,
+        tuplespace_service=tuplespace_service,
+    )
+    await daemon.start()
+    try:
+        assert daemon._binding_watcher is None
+    finally:
+        await daemon.stop()
+        t2db.close()
+
+
+@pytest.mark.asyncio
+async def test_binding_watcher_loop_processes_synthetic_event(
+    daemon_with_tuplespace: T2Daemon,
+) -> None:
+    """The polling loop reacts to events inserted directly into the table.
+
+    Bypasses ``out()`` so the test doesn't need every hook_events
+    subspace YAML loaded into the daemon's registry. Inserts a row that
+    matches the bundled ``notification_log_marker`` binding's predicate
+    and verifies the watcher advances its cursor past it.
+    """
+    daemon = daemon_with_tuplespace
+    watcher = daemon._binding_watcher
+    assert watcher is not None
+    conn = daemon._binding_watcher_conn
+    assert conn is not None
+
+    # Synthesize an events row matching the notification_log_marker binding.
+    conn.execute(
+        "INSERT INTO events "
+        "(subspace, op, tuple_id, payload_summary, category, ts) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            "hook_events/notification",
+            "out",
+            "synthetic-tuple-id",
+            None,
+            "data",
+            1700000000.0,
+        ),
+    )
+    conn.commit()
+    initial_rowid = conn.execute(
+        "SELECT MAX(rowid) FROM events"
+    ).fetchone()[0]
+    assert initial_rowid is not None
+
+    # Watcher poll interval is 0.05s; allow generous slack for slow CI.
+    advanced = False
+    for _ in range(40):  # up to ~2 seconds
+        await asyncio.sleep(0.05)
+        # Cursor for the default profile must be >= the row we inserted.
+        cursor = watcher._cursors.get("default", -1)
+        if cursor >= initial_rowid:
+            advanced = True
+            break
+
+    assert advanced, (
+        f"binding watcher did not advance past rowid {initial_rowid}; "
+        f"cursors={watcher._cursors!r}"
+    )

--- a/tests/db/test_action_idempotency_migration.py
+++ b/tests/db/test_action_idempotency_migration.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the action_idempotency migration + sweep helper (RDR-111 nexus-8wvs).
+
+The migration creates the dedup table in memory.db; the sweep helper
+deletes expired rows under the daemon's retention loop.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _memory_conn(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(tmp_path / "memory.db"))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+class TestSchema:
+    def test_migration_creates_table(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import migrate_action_idempotency_table
+
+        conn = _memory_conn(tmp_path)
+        try:
+            migrate_action_idempotency_table(conn)
+            tables = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert "action_idempotency" in tables
+        finally:
+            conn.close()
+
+    def test_migration_creates_expires_index(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import migrate_action_idempotency_table
+
+        conn = _memory_conn(tmp_path)
+        try:
+            migrate_action_idempotency_table(conn)
+            indexes = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index' "
+                    "AND tbl_name='action_idempotency'"
+                ).fetchall()
+            }
+            assert "idx_action_idempotency_expires" in indexes
+        finally:
+            conn.close()
+
+    def test_migration_idempotent(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import migrate_action_idempotency_table
+
+        conn = _memory_conn(tmp_path)
+        try:
+            migrate_action_idempotency_table(conn)
+            migrate_action_idempotency_table(conn)  # second call must not raise
+        finally:
+            conn.close()
+
+    def test_primary_key_is_idempotency_key(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import migrate_action_idempotency_table
+
+        conn = _memory_conn(tmp_path)
+        try:
+            migrate_action_idempotency_table(conn)
+            pk_cols = sorted(
+                r[1]
+                for r in conn.execute(
+                    "PRAGMA table_info(action_idempotency)"
+                ).fetchall()
+                if r[5] > 0
+            )
+        finally:
+            conn.close()
+        assert pk_cols == ["idempotency_key"]
+
+
+class TestStoreInit:
+    """Fresh ``MemoryStore`` instances must create the table directly.
+
+    Mirrors the existing liveness pattern — the registry migration covers
+    upgrades from pre-RDR-111 databases, but store init seeds new
+    ``memory.db`` files unconditionally so the dedup gate is functional
+    on day one even before the next package-version bump activates the
+    registry-based migration.
+    """
+
+    def test_store_init_creates_action_idempotency_table(
+        self, tmp_path: Path
+    ) -> None:
+        from nexus.db.t2.memory_store import MemoryStore
+
+        store = MemoryStore(tmp_path / "memory.db")
+        try:
+            tables = {
+                r[0]
+                for r in store.conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert "action_idempotency" in tables
+        finally:
+            store.close()
+
+
+class TestSweep:
+    def test_sweep_no_table_returns_zero(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import sweep_action_idempotency
+
+        conn = _memory_conn(tmp_path)
+        try:
+            assert sweep_action_idempotency(conn) == 0
+        finally:
+            conn.close()
+
+    def test_sweep_deletes_expired_rows(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import (
+            migrate_action_idempotency_table,
+            sweep_action_idempotency,
+        )
+
+        conn = _memory_conn(tmp_path)
+        try:
+            migrate_action_idempotency_table(conn)
+            now = time.time()
+            rows = [
+                ("expired-1", now - 60),
+                ("expired-2", now - 1),
+                ("live-1", now + 600),
+                ("live-2", now + 60),
+            ]
+            conn.executemany(
+                "INSERT INTO action_idempotency (idempotency_key, expires_at) "
+                "VALUES (?, ?)",
+                rows,
+            )
+            conn.commit()
+            deleted = sweep_action_idempotency(conn)
+            assert deleted == 2
+            remaining = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT idempotency_key FROM action_idempotency"
+                ).fetchall()
+            }
+            assert remaining == {"live-1", "live-2"}
+        finally:
+            conn.close()
+
+    def test_sweep_idempotent_on_empty_table(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import (
+            migrate_action_idempotency_table,
+            sweep_action_idempotency,
+        )
+
+        conn = _memory_conn(tmp_path)
+        try:
+            migrate_action_idempotency_table(conn)
+            assert sweep_action_idempotency(conn) == 0
+            assert sweep_action_idempotency(conn) == 0  # second call also zero
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary

Two paired RDR-111 fixes that close the at-least-once contract gap and the dead-watcher gap from the RDR-110/111/112/113 360° critique (umbrella nexus-g7yy).

### nexus-8wvs — action_idempotency dedup gate

RDR-111 lines 909-942 specify an \`action_idempotency\` table plus pre-dispatch SELECT, post-dispatch INSERT, and TTL sweep. None of that existed in the codebase. A watcher crash between \`_dispatch_event\` and \`_save_cursor\` replayed events on restart with no dedup — handlers had no way to detect duplicates.

- \`migrations.py\`: \`migrate_action_idempotency_table\` at 4.36.0 (mirrors the liveness pattern), plus \`sweep_action_idempotency\` helper for the daemon retention loop.
- \`memory_store.py\`: parallel \`_ACTION_IDEMPOTENCY_SCHEMA_SQL\` in \`MemoryStore._init_schema\` so fresh installs get the table on day one. The registry migration covers upgrades from older databases once the package bumps past 4.36.0.
- \`bindings.py\`: \`_dispatch_action()\` gates python actions on a \`sha256(binding+tuple_id)\` key with 300s TTL. Log actions stay idempotent-by-construction and skip the gate. Missing-table errors degrade open.
- \`t2_daemon.py\`: retention loop sweeps expired idempotency rows.

### nexus-9eiw — Wire \`_BindingWatcher\` into daemon startup

\`_BindingWatcher\` shipped in PR #787 but had no caller. The daemon started, events accumulated, and no binding ever fired.

- \`bindings.py\`: idempotent \`start()\` returning the asyncio task and bounded async \`stop()\` (5s default timeout, falls back to cancel on timeout).
- \`t2_daemon.py\`: \`_start_binding_watcher()\` loads profiles from \`default_profiles_dir()\`, opens dedicated tuples.db + memory.db connections (\`check_same_thread=False\`), threads them through a \`BindingContext\`. Gated by \`NX_COCKPIT_BINDINGS_DISABLE\` for parity with \`NX_BRIDGE_DISABLE\`.
- \`T2Daemon.stop()\` awaits \`watcher.stop()\`, closes both watcher connections, and nulls the handles.

## Closes

- Closes nexus-8wvs
- Closes nexus-9eiw

## Refs

- nexus-g7yy (RDR-110-113 critique remediation)

## Test plan

- [x] \`uv run pytest tests/cockpit/test_binding_watcher.py\` — 29 passed (9 new)
- [x] \`uv run pytest tests/db/test_action_idempotency_migration.py\` — 8 passed (new file)
- [x] \`uv run pytest tests/daemon/test_binding_watcher_wiring.py\` — 14 passed (new file)
- [x] \`uv run pytest tests/daemon/ tests/cockpit/ tests/db/\` — 389 passed
- [ ] CI green

### New regression coverage

- Lifecycle: idempotent \`start()\`, double-\`stop()\` safety, stop-before-start no-op, bounded-timeout stop.
- Idempotency: first dispatch runs, replay deduped, log actions skip the gate, expired rows let next dispatch through, missing \`memory_conn\` keeps legacy at-least-once.
- Migration: schema, index, primary key, idempotent re-run, sweep deletes expired rows, fresh \`MemoryStore\` creates the table.
- Wiring: env-gate truthy/falsy matrix, watcher constructed/cleaned-up across start/stop, synthesized event row advances the polling cursor.