### PR TITLE
test(rdr-110/rdr-111): backfill P0 coverage gaps from 360° critique

### DIFF
--- a/tests/cockpit/test_hook_bridge_direct_fallback.py
+++ b/tests/cockpit/test_hook_bridge_direct_fallback.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Integration tests for hook_bridge._emit_direct_auto (nexus-2xxl).
+
+The direct-mode auto path is what bridge scripts hit when the RDR-112
+T2 daemon is unreachable. The daemon-routing regression test in
+``test_hook_bridge_daemon_routing.py`` patches ``_emit_direct_auto``
+out, leaving the function body itself at 0% coverage. These tests
+exercise the real implementation: config path lookup, chroma dir
+creation, registry load with the hook subdir, and the SQLite write.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nexus.cockpit import hook_bridge
+
+
+_PAYLOAD = {
+    "session_id": "direct-fallback-session",
+    "transcript_path": "/tmp/test.jsonl",
+    "cwd": "/tmp/test-project",
+    "permission_mode": "bypassPermissions",
+    "hook_event_name": "PreToolUse",
+    "tool_name": "Bash",
+    "tool_input": {"command": "echo hi"},
+}
+
+
+_TOOL_CALL_INTENT_YAML = """
+name: hook_events/tool_call_intent
+tier: project
+content_type: text
+embed_from: match_text
+dimensions:
+  actor:     { type: string, required: true }
+  session:   { type: string, required: true }
+  project:   { type: string, required: true }
+  timestamp: { type: string, required: true }
+  tool:      { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  default_lease_seconds: 60
+read:
+  default_floor: 0.0
+  default_n: 5
+tiers: [project]
+retention_seconds: 86400
+"""
+
+
+@pytest.fixture
+def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point load_config at a tmp nexus_dir and stub the builtin registry."""
+    nexus_dir = tmp_path / "nexus"
+    nexus_dir.mkdir()
+    chroma_dir = nexus_dir / "chroma"  # created lazily by _emit_direct_auto
+
+    # Stub load_config to return the tmp dir.
+    def _fake_load_config():
+        return {"nexus_dir": str(nexus_dir)}
+
+    from nexus import config as _config_mod
+    monkeypatch.setattr(_config_mod, "load_config", _fake_load_config)
+
+    # Stub default_builtin_dir to a tmp dir holding the hook event YAML.
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+    (builtin / "tool_call_intent.yml").write_text(_TOOL_CALL_INTENT_YAML)
+    # Also create the hooks subdir so _load_registry_with_hooks doesn't error.
+    (builtin / "hooks").mkdir()
+    from nexus.tuplespace import registry as _registry_mod
+    monkeypatch.setattr(
+        _registry_mod, "default_builtin_dir", lambda: builtin
+    )
+
+    monkeypatch.setenv("CLAUDECODE", "1")
+    return nexus_dir, builtin
+
+
+def _tuples_in_db(db_path: Path, subspace: str) -> list[dict]:
+    """Read tuples for a subspace via a fresh sqlite connection."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT id, subspace, content FROM tuples WHERE subspace = ?",
+            (subspace,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmitDirectAutoFallback:
+    """End-to-end coverage for _emit_direct_auto (RDR-111 nexus-2xxl)."""
+
+    def test_no_daemon_discovery_falls_through_to_direct(
+        self, isolated_config, monkeypatch
+    ) -> None:
+        """Daemon unreachable -> _emit_direct_auto persists the tuple."""
+        nexus_dir, _builtin = isolated_config
+        from nexus.daemon import discovery as _disc
+        monkeypatch.setattr(_disc, "nexus_config_dir", lambda: nexus_dir)
+
+        # No discovery file in nexus_dir -> find_t2_daemon returns None.
+        hook_bridge.emit("PreToolUse", _PAYLOAD)
+
+        tuples = _tuples_in_db(
+            nexus_dir / "tuples.db", "hook_events/tool_call_intent"
+        )
+        assert len(tuples) == 1
+        assert tuples[0]["subspace"] == "hook_events/tool_call_intent"
+
+    def test_daemon_rpc_error_falls_back_to_direct(
+        self, isolated_config, monkeypatch
+    ) -> None:
+        """Discovery succeeds but RPC raises -> direct fallback handles it."""
+        nexus_dir, _ = isolated_config
+
+        # Plant a discovery file so find_t2_daemon returns info.
+        from nexus.daemon import discovery as _disc
+        monkeypatch.setattr(_disc, "nexus_config_dir", lambda: nexus_dir)
+        import json
+        import os
+        uid = os.getuid()
+        disc_path = nexus_dir / f"t2_addr.{uid}"
+        # Use a UDS path that does not exist, forcing tcp fallback in client.
+        disc_path.write_text(json.dumps({
+            "uds_path": "/nonexistent.sock",
+            "tcp_host": "127.0.0.1",
+            "tcp_port": 1,  # any unreachable port; T2Client connection raises
+        }))
+
+        hook_bridge.emit("PreToolUse", _PAYLOAD)
+
+        tuples = _tuples_in_db(
+            nexus_dir / "tuples.db", "hook_events/tool_call_intent"
+        )
+        assert len(tuples) == 1
+
+    def test_direct_path_writes_event_row(
+        self, isolated_config, monkeypatch
+    ) -> None:
+        """Writing a tuple via direct fallback fires the events trigger."""
+        nexus_dir, _ = isolated_config
+        from nexus.daemon import discovery as _disc
+        monkeypatch.setattr(_disc, "nexus_config_dir", lambda: nexus_dir)
+
+        hook_bridge.emit("PreToolUse", _PAYLOAD)
+
+        conn = sqlite3.connect(str(nexus_dir / "tuples.db"))
+        conn.row_factory = sqlite3.Row
+        try:
+            event_count = conn.execute(
+                "SELECT COUNT(*) FROM events "
+                "WHERE subspace = 'hook_events/tool_call_intent'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert event_count == 1
+
+    def test_direct_path_persists_dimensions(
+        self, isolated_config, monkeypatch
+    ) -> None:
+        """The required dimensions land in the tuple's dimensions_json blob."""
+        import json
+
+        nexus_dir, _ = isolated_config
+        from nexus.daemon import discovery as _disc
+        monkeypatch.setattr(_disc, "nexus_config_dir", lambda: nexus_dir)
+
+        hook_bridge.emit("PreToolUse", _PAYLOAD)
+
+        conn = sqlite3.connect(str(nexus_dir / "tuples.db"))
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT dimensions_json FROM tuples "
+                "WHERE subspace = 'hook_events/tool_call_intent'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        dims = json.loads(row["dimensions_json"])
+        # route_payload populates the four required dimensions.
+        assert dims["session"] == "direct-fallback-session"
+        assert dims["project"] == "/tmp/test-project"
+        assert dims["actor"]
+        assert dims["timestamp"]
+        assert dims["tool"] == "Bash"
+
+    def test_direct_path_creates_chroma_dir_if_missing(
+        self, isolated_config, monkeypatch
+    ) -> None:
+        """PersistentClient must create ``nexus_dir/chroma`` on first use."""
+        nexus_dir, _ = isolated_config
+        chroma_dir = nexus_dir / "chroma"
+        assert not chroma_dir.exists()
+
+        from nexus.daemon import discovery as _disc
+        monkeypatch.setattr(_disc, "nexus_config_dir", lambda: nexus_dir)
+
+        hook_bridge.emit("PreToolUse", _PAYLOAD)
+
+        assert chroma_dir.exists() and chroma_dir.is_dir()

--- a/tests/tuplespace/test_api.py
+++ b/tests/tuplespace/test_api.py
@@ -632,6 +632,141 @@ class TestTakeCASRace:
 
 
 # ---------------------------------------------------------------------------
+# take — idempotent retake by same claimant (RDR-110 CA-1/CA-2, nexus-edmw)
+# ---------------------------------------------------------------------------
+
+
+class TestTakeIdempotentRetake:
+    """Same claimant re-taking a still-leased tuple must observe the same claim.
+
+    Pins the contract at ``src/nexus/tuplespace/api.py:690-713`` (the
+    read-then-update probe above the CAS): a second ``take`` from the
+    holding claimant returns the same tuple, the same ``claim_id``, and
+    writes no extra ``tuple_claim_log`` row.
+    """
+
+    def test_same_claimant_retake_returns_same_claim_id(
+        self, db_conn, index, registry
+    ):
+        from nexus.tuplespace.api import out, take
+
+        tid = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus",
+            content="idempotent retake target",
+            dimensions=_valid_task_dims(),
+        )
+
+        first = take(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="idempotent retake target",
+            claimant="agent-A",
+        )
+        assert first is not None
+        first_tuple, first_claim_id = first
+        assert first_tuple["id"] == tid
+
+        second = take(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="idempotent retake target",
+            claimant="agent-A",
+        )
+        assert second is not None
+        second_tuple, second_claim_id = second
+        assert second_tuple["id"] == tid
+        assert second_claim_id == first_claim_id
+
+    def test_retake_does_not_rotate_claim_id_on_tuples_row(
+        self, db_conn, index, registry
+    ):
+        from nexus.tuplespace.api import out, take
+
+        tid = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="no-rotation target",
+            dimensions=_valid_task_dims(),
+        )
+        first = take(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="no-rotation target",
+            claimant="agent-A",
+        )
+        assert first is not None
+        _, first_claim_id = first
+
+        # Snapshot the stored claim_id before the retake.
+        before = db_conn.execute(
+            "SELECT claim_id FROM tuples WHERE id = ?", (tid,)
+        ).fetchone()
+        assert before["claim_id"] == first_claim_id
+
+        take(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="no-rotation target",
+            claimant="agent-A",
+        )
+
+        after = db_conn.execute(
+            "SELECT claim_id FROM tuples WHERE id = ?", (tid,)
+        ).fetchone()
+        assert after["claim_id"] == first_claim_id
+
+    def test_retake_writes_exactly_one_claim_log_entry(
+        self, db_conn, index, registry
+    ):
+        from nexus.tuplespace.api import out, take
+
+        tid = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="single-log target",
+            dimensions=_valid_task_dims(),
+        )
+        take(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="single-log target",
+            claimant="agent-A",
+        )
+        take(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="single-log target",
+            claimant="agent-A",
+        )
+
+        count = db_conn.execute(
+            "SELECT COUNT(*) FROM tuple_claim_log "
+            "WHERE tuple_id = ? AND transition = 'claim'",
+            (tid,),
+        ).fetchone()[0]
+        # Exact equality — inequality is how silent-corruption tests pass.
+        assert count == 1
+
+    def test_other_claimant_take_during_lease_returns_none(
+        self, db_conn, index, registry
+    ):
+        """Counter-test: a foreign claimant must not hit the idempotent path."""
+        from nexus.tuplespace.api import out, take
+
+        out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="foreign claimant target",
+            dimensions=_valid_task_dims(),
+        )
+        first = take(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="foreign claimant target",
+            claimant="agent-A",
+        )
+        assert first is not None
+
+        intruder = take(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="foreign claimant target",
+            claimant="agent-B",
+        )
+        assert intruder is None
+
+
+# ---------------------------------------------------------------------------
 # take — exact mode (locks/<resource>)
 # ---------------------------------------------------------------------------
 

--- a/tests/tuplespace/test_api_atomicity.py
+++ b/tests/tuplespace/test_api_atomicity.py
@@ -137,3 +137,132 @@ class TestOutAtomicity:
             "Two-store invariant violated: SQLite row exists but Chroma "
             "write failed. nexus-qmrr regression."
         )
+
+    def test_sqlite_failure_after_chroma_leaves_orphan_chroma(
+        self, db_conn, index, registry
+    ):
+        """nexus-11m2: ordering asymmetry — SQLite fails AFTER Chroma succeeded.
+
+        The current contract documented at ``src/nexus/tuplespace/api.py:415-424``
+        explicitly accepts an orphan Chroma record on this failure mode:
+        Chroma upserts are idempotent on tuple_id, so the next refire
+        reclaims the orphan, and the retention sweeper picks up
+        stragglers. This test locks both halves of that contract.
+        """
+        from nexus.tuplespace.api import out
+
+        captured: dict[str, str] = {}
+
+        flaky = _FlakyConn(
+            db_conn,
+            fail_on_prefix="INSERT INTO tuples",
+            tid_sink=captured,
+        )
+
+        with pytest.raises(sqlite3.OperationalError, match="simulated sqlite outage"):
+            out(
+                conn=flaky, index=index, registry=registry,
+                subspace="tasks/nexus",
+                content="sqlite-fails-after-chroma",
+                dimensions=_valid_task_dims(),
+            )
+
+        # 1. SQLite has no row for the failed tuple_id.
+        rows = db_conn.execute(
+            "SELECT id FROM tuples WHERE content = ?",
+            ("sqlite-fails-after-chroma",),
+        ).fetchall()
+        assert rows == [], (
+            "Failed SQLite write must not leave a partial row in tuples."
+        )
+
+        # 2. Chroma DOES contain the tuple — the documented orphan state.
+        # Recover the tuple_id from index.out parameters captured by FlakyConn.
+        assert "tid" in captured, (
+            "index.out must have run before SQLite tripped; otherwise the "
+            "ordering being tested is reversed."
+        )
+        collection = index._collections["tasks/<project>"]
+        chroma_get = collection.get(ids=[captured["tid"]])
+        assert chroma_get["ids"] == [captured["tid"]], (
+            "Chroma orphan-accept contract: the prior-write upsert must "
+            "survive the SQLite failure (nexus-qmrr documented behaviour)."
+        )
+
+    def test_refire_after_sqlite_failure_recovers(
+        self, db_conn, index, registry
+    ):
+        """nexus-11m2 follow-on: a successful refire reclaims the orphan."""
+        from nexus.tuplespace.api import out
+
+        captured: dict[str, str] = {}
+        flaky = _FlakyConn(
+            db_conn,
+            fail_on_prefix="INSERT INTO tuples",
+            tid_sink=captured,
+        )
+
+        with pytest.raises(sqlite3.OperationalError):
+            out(
+                conn=flaky, index=index, registry=registry,
+                subspace="tasks/nexus",
+                content="orphan-then-recover",
+                dimensions=_valid_task_dims(),
+            )
+
+        # Second fire with identical args via the real (healthy) connection.
+        # Chroma upsert is idempotent on the deterministic tuple_id; SQLite
+        # gets its row this time.
+        tid_second = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus",
+            content="orphan-then-recover",
+            dimensions=_valid_task_dims(),
+        )
+
+        rows = db_conn.execute(
+            "SELECT id FROM tuples WHERE id = ?", (tid_second,)
+        ).fetchall()
+        assert len(rows) == 1, "refire must produce exactly one SQLite row"
+
+        collection = index._collections["tasks/<project>"]
+        chroma_get = collection.get(ids=[tid_second])
+        assert chroma_get["ids"] == [tid_second]
+
+
+class _FlakyConn:
+    """Wrapper that proxies a real ``sqlite3.Connection`` and trips one path.
+
+    sqlite3.Connection's execute is a read-only built-in attribute, so
+    monkeypatching it raises. Wrapping in a proxy gives us a Python-level
+    method we can override while keeping every other call (commit,
+    rollback, row_factory, etc.) delegating to the real connection.
+    """
+
+    def __init__(
+        self,
+        real: sqlite3.Connection,
+        *,
+        fail_on_prefix: str,
+        tid_sink: dict[str, str] | None = None,
+    ) -> None:
+        self._real = real
+        self._fail_on_prefix = fail_on_prefix
+        self._tid_sink = tid_sink
+
+    def execute(self, sql, *args, **kwargs):
+        # Capture the tuple_id parameter for the asserting side. The INSERT
+        # statement's first positional bind value is the tuple_id.
+        if (
+            self._tid_sink is not None
+            and isinstance(sql, str)
+            and sql.strip().startswith("INSERT INTO tuples")
+        ):
+            if args and isinstance(args[0], (tuple, list)) and args[0]:
+                self._tid_sink["tid"] = args[0][0]
+        if isinstance(sql, str) and sql.strip().startswith(self._fail_on_prefix):
+            raise sqlite3.OperationalError("simulated sqlite outage")
+        return self._real.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)


### PR DESCRIPTION
## Summary

Three test-only beads from the RDR-110/111/112/113 360° critique (umbrella nexus-g7yy). Source code is unchanged.

### nexus-edmw — Idempotent retake regression (RDR-110 CA-1/CA-2)

\`take()\` short-circuits at \`api.py:704-713\` when the same claimant already holds an active lease. The contract: same \`claim_id\` returned, no extra \`tuple_claim_log\` row, no rotation of \`tuples.claim_id\`. Previously untested.

\`TestTakeIdempotentRetake\` locks four assertions:
- Same \`claim_id\` returned on retake
- No rotation of \`tuples.claim_id\`
- Exactly **one** \`tuple_claim_log\` row (\`== 1\`, not \`>= 1\`)
- Counter-test: a foreign claimant during the live lease still gets \`None\`

### nexus-11m2 — Atomicity asymmetry (SQLite-fails-after-Chroma)

\`out()\` at \`api.py:415-454\` writes Chroma first then commits SQLite. \`test_api_atomicity.py\` already covered Chroma-fails-first (nexus-qmrr). This locks the reverse:

- SQLite raises after Chroma succeeded — documented orphan-Chroma state. Both halves asserted: SQLite has no row, Chroma upsert survives.
- Identical-args refire reclaims the orphan via idempotent Chroma upsert + the now-successful SQLite write.

Uses a \`_FlakyConn\` proxy because \`sqlite3.Connection.execute\` is a read-only built-in that \`monkeypatch.setattr\` cannot replace directly.

### nexus-2xxl — Production fallback coverage

\`_emit_direct_auto\` at \`hook_bridge.py:367-415\` had 0% coverage — the existing daemon-routing test patches it out. \`tests/cockpit/test_hook_bridge_direct_fallback.py\` exercises the real implementation:

- No discovery file -> direct fallback persists the tuple
- Unreachable daemon RPC -> direct fallback recovers
- Direct path fires the \`events\` trigger
- Required dimensions land in \`dimensions_json\`
- Chroma dir is created lazily on first use

## Closes

- Closes nexus-edmw
- Closes nexus-11m2
- Closes nexus-2xxl

## Refs

- nexus-g7yy (RDR-110-113 critique remediation)

## Test plan

- [x] \`uv run pytest tests/tuplespace/test_api.py::TestTakeIdempotentRetake tests/tuplespace/test_api_atomicity.py tests/cockpit/test_hook_bridge_direct_fallback.py\` — 17 new tests pass
- [x] \`uv run pytest tests/tuplespace/ tests/cockpit/\` — 280 passed
- [ ] CI green