### PR TITLE
fix(rdr-112): PID liveness probe in find_t2_daemon (stale discovery file)

### DIFF
--- a/src/nexus/daemon/discovery.py
+++ b/src/nexus/daemon/discovery.py
@@ -44,13 +44,54 @@ def find_t2_daemon(config_dir: Optional[Path] = None) -> Optional[dict[str, Any]
     Returns:
         Dict with keys ``uds_path``, ``tcp_host``, ``tcp_port``, ``pid``,
         ``daemon_version``, etc. (see ``T2Daemon._discovery_payload``).
-        ``None`` when no discovery file exists or it cannot be parsed.
+        ``None`` when no discovery file exists, cannot be parsed, or its
+        ``pid`` field refers to a process that is no longer alive.
+
+    Liveness probe (nexus-j6dj): hard reboot / SIGKILL / OOM / panic
+    between ``_write_discovery`` and ``_unlink_discovery`` leaves a stale
+    file pointing at a dead PID. Clients that trust the file route to a
+    nonexistent socket and either fall back to direct mode (with WAL
+    conflicts once a new daemon eventually binds) or hang on the connect
+    attempt. ``os.kill(pid, 0)`` is the canonical POSIX way to probe
+    liveness without delivering a signal; ``ProcessLookupError`` means
+    the PID is unallocated and the file is stale, in which case we
+    best-effort unlink it so a future check is fast. A ``PermissionError``
+    means the PID exists under a different UID — that is a sysadmin-
+    level scenario; treat as live and let the eventual connect surface
+    a clear error.
     """
     path = discovery_path(config_dir)
     if not path.exists():
         return None
     try:
-        return json.loads(path.read_text())
+        payload = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError) as exc:
         _log.warning("t2_discovery_read_failed", path=str(path), error=str(exc))
         return None
+
+    pid = payload.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        _log.warning(
+            "t2_discovery_invalid_pid", path=str(path), pid=repr(pid)
+        )
+        return None
+
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        _log.warning("t2_discovery_stale_pid", path=str(path), pid=pid)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            _log.warning(
+                "t2_discovery_unlink_failed",
+                path=str(path),
+                error=str(exc),
+            )
+        return None
+    except PermissionError:
+        # Live process under a different UID. Keep the payload — the
+        # eventual connect will give a clearer error than we can here.
+        pass
+
+    return payload

--- a/tests/daemon/test_discovery_liveness.py
+++ b/tests/daemon/test_discovery_liveness.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""PID-liveness probe in find_t2_daemon (RDR-112, nexus-j6dj).
+
+A discovery file points at the daemon's PID. After a crash the file
+survives but the PID is dead; clients that trust the file end up
+routing to a nonexistent socket. ``find_t2_daemon`` now sends
+``os.kill(pid, 0)`` and treats ``ProcessLookupError`` as "stale" —
+unlinks the file and returns ``None`` so the caller falls back cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from nexus.daemon import discovery
+
+
+def _write_payload(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload))
+
+
+def _live_payload(extras: dict | None = None) -> dict:
+    return {
+        "pid": os.getpid(),
+        "uds_path": "/tmp/nx-t2-fake.sock",
+        "tcp_host": "127.0.0.1",
+        "tcp_port": 1,
+        "daemon_version": "0.0.0",
+        "daemon_protocol_version": "1.0",
+        "start_time": "2026-05-16T00:00:00Z",
+        "subspace_schema_digest": None,
+        **(extras or {}),
+    }
+
+
+def _make_config_dir(tmp_path: Path) -> Path:
+    cd = tmp_path / "config"
+    cd.mkdir()
+    return cd
+
+
+class TestFindT2DaemonLiveness:
+    def test_live_pid_returns_payload(self, tmp_path: Path) -> None:
+        config_dir = _make_config_dir(tmp_path)
+        _write_payload(
+            discovery.discovery_path(config_dir),
+            _live_payload(),
+        )
+
+        result = discovery.find_t2_daemon(config_dir=config_dir)
+        assert result is not None
+        assert result["pid"] == os.getpid()
+
+    def test_dead_pid_returns_none_and_removes_file(
+        self, tmp_path: Path
+    ) -> None:
+        # Spawn a short-lived subprocess, capture its pid, wait for exit.
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import sys; sys.exit(0)"]
+        )
+        dead_pid = proc.pid
+        proc.wait(timeout=5)
+        # macOS keeps the PID reserved as a zombie until the parent waits;
+        # subprocess.wait above performs the wait, releasing the slot.
+        # If the kernel did reuse the pid we would see ESRCH on kill(0).
+        try:
+            os.kill(dead_pid, 0)
+        except ProcessLookupError:
+            pass
+        else:
+            pytest.skip(
+                "Kernel reused the test subprocess's PID before the probe; "
+                "rerun the test."
+            )
+
+        config_dir = _make_config_dir(tmp_path)
+        path = discovery.discovery_path(config_dir)
+        _write_payload(path, _live_payload({"pid": dead_pid}))
+
+        result = discovery.find_t2_daemon(config_dir=config_dir)
+        assert result is None
+        assert not path.exists(), (
+            "Stale discovery file must be cleaned up on liveness failure."
+        )
+
+    def test_missing_pid_field_returns_none(self, tmp_path: Path) -> None:
+        config_dir = _make_config_dir(tmp_path)
+        _write_payload(
+            discovery.discovery_path(config_dir),
+            {"uds_path": "/tmp/x.sock", "tcp_host": "127.0.0.1", "tcp_port": 1},
+        )
+
+        assert discovery.find_t2_daemon(config_dir=config_dir) is None
+
+    def test_invalid_pid_type_returns_none(self, tmp_path: Path) -> None:
+        config_dir = _make_config_dir(tmp_path)
+        _write_payload(
+            discovery.discovery_path(config_dir),
+            _live_payload({"pid": "not-an-int"}),
+        )
+
+        assert discovery.find_t2_daemon(config_dir=config_dir) is None
+
+    def test_zero_pid_returns_none(self, tmp_path: Path) -> None:
+        config_dir = _make_config_dir(tmp_path)
+        _write_payload(
+            discovery.discovery_path(config_dir),
+            _live_payload({"pid": 0}),
+        )
+
+        assert discovery.find_t2_daemon(config_dir=config_dir) is None
+
+    def test_unparseable_payload_still_returns_none(
+        self, tmp_path: Path
+    ) -> None:
+        """Existing JSON-parse error path preserved (regression guard)."""
+        config_dir = _make_config_dir(tmp_path)
+        discovery.discovery_path(config_dir).write_text("{not json")
+
+        assert discovery.find_t2_daemon(config_dir=config_dir) is None
+
+    def test_no_discovery_file_returns_none(self, tmp_path: Path) -> None:
+        config_dir = _make_config_dir(tmp_path)
+        assert discovery.find_t2_daemon(config_dir=config_dir) is None


### PR DESCRIPTION
## Summary

\`nexus-j6dj\` from the RDR-110/111/112/113 360° critique. A hard reboot, SIGKILL, OOM, or kernel panic between \`_write_discovery\` and \`_unlink_discovery\` leaves the discovery file pointing at a dead PID. Clients that trust the file route to a nonexistent socket; the hook bridge falls through to direct mode with WAL conflicts as soon as a new daemon binds.

- \`find_t2_daemon()\` now calls \`os.kill(pid, 0)\` on the discovered PID. \`ProcessLookupError\` means the slot is unallocated — log \`t2_discovery_stale_pid\`, best-effort unlink the file, return \`None\`. \`PermissionError\` means the PID is held by another UID; treat as live and let the eventual connect surface a clearer error.
- Invalid or missing \`pid\` field returns \`None\` with a warning.
- Existing \`OSError\` / \`JSONDecodeError\` paths preserved.

## Closes

- Closes nexus-j6dj

## Refs

- nexus-g7yy (RDR-110-113 critique remediation)

## Test plan

- [x] \`uv run pytest tests/daemon/test_discovery_liveness.py\` — 7 passed (new file)
- [x] \`uv run pytest tests/daemon/ tests/cockpit/\` — 345 passed
- [ ] CI green

### New regression coverage

- Live PID (\`os.getpid()\`) returns the payload
- Dead PID (\`Popen\`-then-\`wait\` subprocess) returns \`None\` and unlinks
- Missing \`pid\` field returns \`None\`
- Invalid \`pid\` type (string) returns \`None\`
- Zero \`pid\` returns \`None\`
- Unparseable JSON still returns \`None\` (regression guard)
- No discovery file returns \`None\`