### PR TITLE
docs(rdr-110-113): document tuplespace + cockpit + daemon CLI, architecture, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,110 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added: RDR-110 Semantic Tuple Space landed (2026-05-14)
+
+ORB tuplespace ships as the substrate the rest of the agentic
+substrate stands on. Subspaces declare a schema (dimensions, embed
+source, take semantics, retention) in YAML; `out`/`read`/`take`/
+`ack`/`nack` are the lifecycle primitives. `tuples.db` lives next to
+`memory.db` under the T2 daemon (RDR-112 §9) so subspaces share the
+single-writer guarantee.
+
+- **CLI** (`nx tuplespace`): `out`, `read`, `take`, `ack`, `nack`,
+  `list-subspaces`, `show-schema`, `stats`. Mutating subcommands
+  refuse to open a competing SQLite handle under
+  `NX_STORAGE_MODE=daemon`.
+- **MCP tools**: `tuplespace_out`, `tuplespace_read`,
+  `tuplespace_take`, `tuplespace_ack`, `tuplespace_nack`,
+  `tuplespace_list_subspaces`, `tuplespace_subspace_schema`,
+  `tuplespace_subspace_stats`. Routed through the daemon RPCs when
+  `NX_STORAGE_MODE=daemon`.
+- **Idempotent retake** (CA-1/CA-2): same-claimant `take` during the
+  active lease returns the existing claim, no extra `tuple_claim_log`
+  row, no rotation of `claim_id`.
+- **Two-store atomicity** (nexus-qmrr, PR #800): `api.out` writes
+  Chroma first, commits SQLite second. SQLite presence implies Chroma
+  presence; the reverse window leaves an orphan Chroma record that
+  idempotent refire reclaims.
+- **Tuple refresh on refire** (nexus-i4kd, PR #806): content-
+  identical refire refreshes `created_at`/`expires_at` so the
+  retention sweeper does not expire rows based on the first fire's
+  clock. Claim and tombstone state survive untouched.
+- **Builtin subspaces** under `nx/tuplespace/builtin/`:
+  `tasks/<project>`, `locks/<resource>`, `mailbox/<topic>`, `events`,
+  `barriers`, `layout_state`, `connection_manifest`, plus the seven
+  `hook_events/*` schemas under `hooks/`. Reserved prefixes
+  (`tuples/`, `daemon/`, builtins) cannot be minted by third-party
+  `subspace_add`.
+- **Coordination landing surface** (nexus-90pe, PR #791): four
+  consumer-facing subspaces and seven cockpit skills wired up so the
+  tuplespace has real Day-1 traffic, not just primitives waiting for
+  callers.
+
+### Added: RDR-111 ORB Hook Bridge and Cockpit landed (2026-05-15)
+
+Claude Code hook events now project onto the tuplespace, user-authored
+binding profiles react to matching events, and operators see the
+resulting state through cockpit panels. The four-RDR cockpit substrate
+(110/111/112/113) is now structurally complete on `develop`.
+
+- **Hook bridge** (nexus-y0nb, PR #784): seven `orb_bridge_*.py`
+  scripts under `nx/hooks/scripts/` drain Claude Code hooks into the
+  seven `hook_events/*` subspaces. `emit()` gates on `CLAUDECODE`
+  (RF-5: prevents contamination of non-Claude shells) plus
+  `NX_BRIDGE_DISABLE` (operator opt-out; nexus-7zvp, PR #822). The
+  `output_for_hook()` pure helper stays unconditional so disabling
+  emission cannot break the hook protocol (PermissionRequest
+  transparent-allow still fires).
+- **Daemon-mode routing** (nexus-6s8v, PR #789): bridge prefers the
+  T2 daemon's `tuplespace.out` RPC, falls back to direct mode on
+  discovery or RPC failure. Daemon-mode is now the default
+  (`_ROUTING_TBA = "daemon"`).
+- **SQLite write retry** (nexus-wf07, PR #807): `_sqlite_with_retry`
+  wraps the bridge's SQLite writes with bounded exponential backoff on
+  `OperationalError: database is locked` / `busy`.
+- **Plugin / wheel version-compat guard** (nexus-yeu8, PR #809):
+  bridge scripts embed `EXPECTED_BRIDGE_API_VERSION` and skip cleanly
+  when the installed wheel exposes a different `BRIDGE_API_VERSION`.
+  Stale scripts on a fresh wheel exit 0 instead of corrupting tuples.
+- **Cockpit `_BindingWatcher`** (nexus-0xaq, PR #787): async polling
+  reaction loop over the events table. User-authored binding profiles
+  match events by subspace/op/category and fire `python:<module:func>`
+  or `log:<marker>` actions in cursor order. Error containment: one
+  bad binding does not crash the loop or starve siblings.
+- **Cockpit panels** (nexus-ut5r, PR #802): `nx cockpit
+  {status|show|dashboard}` reads `tuples.db` and surfaces recent
+  events, active claims, and active bindings. Read-only by
+  construction; no panel writes tuples.
+- **Retention sweeper** (nexus-kk9h, PR #788): recurring 6-hour sweep
+  prunes expired tuples and claim-log rows. Best-effort SQLite-only
+  sweep in Phase 1; Chroma vector cleanup deferred.
+- **embed_from fail-loud** (nexus-zm2n, PR #800): subspace schemas
+  that reference a missing embed source raise `EmbedFromError` with a
+  precise error instead of silently writing zero-vector embeddings.
+- **Substrate hardening** (PR #803): six coordination YAML schemas
+  shipped in the wheel, `nx doctor --check-bridge` for installability
+  diagnostics, plugin/wheel packaging verified.
+
+### Added: RDR-113 Host-Trust v1 (2026-05-13)
+
+Single-user host trust boundary for the T2 daemon transports.
+
+- **UDS**: socket mode `0600`, `SO_PEERCRED` peer-credential check at
+  accept time. `bind()` then `chmod(0o600)` then `listen()` ordering
+  (A1 spike verified) closes the bind-to-chmod window: `connect()` to
+  a bound-but-not-listening UDS returns `ConnectionRefusedError`.
+- **TCP fallback**: hard-bound to `127.0.0.1`. No peer-cred check on
+  loopback (orchestrator trust per single-user host model).
+- **Admin gate**: `_ADMIN_OPS` + `_KNOWN_ADMIN_NAMES` frozensets plus
+  startup integrity check force admin RPCs to UDS only and catch any
+  drift between dispatch-table registration and the gate. Verbs:
+  `subspace_add`, `exec_raw`, `export`, plus the `admin_ping` test
+  scaffold (production never registers it).
+- **Contradiction check filled** (nexus-ycf5, PR #792): RDR-113
+  Finalization Gate Contradiction Check section completed with the
+  bind-to-chmod analysis and the loopback-TCP justification.
+
 ### Added — RDR-112 T2 Storage-as-Service Phase 1 complete (2026-05-14)
 
 T2 SQLite stores now live behind a single-writer asyncio daemon that
@@ -53,6 +157,26 @@ Out of scope here, tracked for Phase 2/3:
 - `tuplespace_*` MCP tool routing under `NX_STORAGE_MODE=daemon`
   (nexus-pce1.6, blocked on Phase 2 CatalogDB collapse).
 - Default `NX_STORAGE_MODE` flip from direct to daemon (nexus-507q P6.3).
+
+### Added: RDR-112 Phase 2 in flight (2026-05-15)
+
+- **CatalogDB collapse** (nexus-7ejx, PR #785): eight catalog tables
+  (`owners`, `documents`, `documents_fts`, `links`, `collections`,
+  `_meta`, `document_chunks`, plus supporting indexes/triggers) move
+  into `memory.db` alongside the seven domain stores. Schema
+  invariants from RDR-108 preserved: `documents` is tumbler-
+  addressable, `document_chunks` is authoritative for the chunk-to-
+  doc manifest.
+- **Daemon registry seed** (nexus-me9y, PR #801): daemon seeds the
+  subspace registry from `nx/tuplespace/builtin/` on every start
+  before sockets bind. Builtin schemas become the single source of
+  truth for reserved-prefix namespaces; YAML bumps land as UPDATEs,
+  unchanged YAMLs are no-ops.
+- **Daemon auto-start** (nexus-6w0c, PR #808): `nx daemon t2
+  install --autostart` writes the OS autostart unit (launchd plist
+  on macOS, systemd user unit on Linux). `KeepAlive: Crashed` plus
+  `SuccessExitStatus=143` cooperate so `nx daemon t2 stop` is a
+  clean SIGTERM that does not flap-respawn.
 
 ## [4.32.12] - 2026-05-13
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,7 +68,7 @@ CLI (cli.py)            MCP Server (mcp_server.py)
     │
     └── Storage tiers
           T1: ChromaDB HTTP server (session scratch, shared across agent processes)
-          T2: SQLite + FTS5 (persistent memory, project context)
+          T2: SQLite + FTS5 (persistent memory, project context, tuplespace)
           T3: ChromaDB PersistentClient + ONNX (local, zero-config)
               OR ChromaDB Cloud + Voyage AI (cloud, higher quality)
                 code__*       voyage-code-3 index + query
@@ -77,7 +77,117 @@ CLI (cli.py)            MCP Server (mcp_server.py)
                 knowledge__*  voyage-context-3 (CCE) index + query
 ```
 
-Data flows upward (T1 → T2 → T3).
+Data flows upward (T1 → T2 → T3). T2 is a pair of SQLite files:
+`memory.db` (seven domain stores, RDR-063) and `tuples.db` (the ORB
+tuplespace plus watcher state, RDR-110/111). Both live behind the T2
+daemon under `NX_STORAGE_MODE=daemon` (RDR-112); the next section
+covers that boundary.
+
+## T2 Daemon, Tuplespace, and Cockpit (RDR-110/111/112/113)
+
+The substrate that lets Claude Code hooks land in the tuplespace,
+react via user-authored bindings, and surface in operator panels lives
+across three closely-coupled module groups.
+
+### Process model and host trust (RDR-112, RDR-113)
+
+`NX_STORAGE_MODE=daemon` puts T2 behind a single-writer asyncio
+daemon. Clients reach it via JSON-RPC over Unix domain sockets
+(primary) or loopback TCP (fallback); direct sqlite connections to
+`memory.db` or `tuples.db` from any other process are then a
+boundary violation.
+
+- **Discovery**: the daemon writes
+  `<config_dir>/t2_addr.<uid>` with UDS path, TCP host/port, PID,
+  start time, protocol version, and `subspace_schema_digest`. Clients
+  call `nexus.daemon.discovery.find_t2_daemon()`; the helper PID-probes
+  via `os.kill(pid, 0)` and unlinks stale files automatically.
+- **UDS primary**: socket mode `0600` with `SO_PEERCRED` peer-credential
+  check at accept time. The `bind() → chmod(0o600) → listen()`
+  ordering verified by RDR-113 A1: a `connect()` to a bound-but-not-
+  listening UDS returns `ConnectionRefusedError`, so the bind-to-chmod
+  window is provably closed.
+- **TCP fallback**: hard-bound to `127.0.0.1`. No peer-cred check on
+  loopback (trust delegated to the orchestrator per the RDR-113
+  single-user host model).
+- **Admin RPCs are UDS-only**. The daemon enforces
+  `_ADMIN_OPS` membership at dispatch and refuses admin verbs over TCP
+  with a clear error.
+- **Migrations are daemon-owned**. The daemon runs all pending
+  migrations on `memory.db` and `tuples.db` before binding sockets, so
+  no client ever sees a partially-migrated schema.
+- **Autostart**: `nx daemon t2 install --autostart` writes a launchd
+  plist (macOS) or systemd user unit (Linux) so the daemon comes up
+  at login. `KeepAlive: Crashed` and `SuccessExitStatus=143` make
+  `nx daemon t2 stop` a clean SIGTERM that does not flap-respawn.
+
+Boundary lint: `nx doctor --check-storage-boundary` runs an AST scan
+that flags direct `sqlite3.connect` / `chromadb.PersistentClient`
+construction outside `src/nexus/db/` (RDR-112 §5). The check is the
+mechanical complement to the prose contract above.
+
+### ORB tuplespace (RDR-110)
+
+The tuplespace is a typed, content-addressed message log persisted in
+`tuples.db`. Subspaces define schemas (dimensions, embed source, take
+semantics, retention); tuples carry content plus a dimensions map.
+
+- **CLI**: `nx tuplespace {out|read|take|ack|nack|list-subspaces|show-schema|stats}`.
+- **MCP**: `tuplespace_out/read/take/ack/nack/list_subspaces/subspace_schema/subspace_stats`.
+- **Lifecycle**: `out` posts; `read` browses without claiming; `take`
+  claims with a lease; `ack` consumes; `nack` releases. Same-claimant
+  re-takes during the active lease return the existing claim
+  (idempotent retake, CA-1/CA-2).
+- **Two-store atomicity** (RDR-111 §nexus-qmrr): `out()` writes Chroma
+  first, then commits SQLite. Invariant: SQLite presence implies
+  Chroma presence. A failure in the reverse window leaves an orphan
+  Chroma record that idempotent refire reclaims; the retention sweeper
+  picks up stragglers.
+- **Builtin subspaces** ship under `nx/tuplespace/builtin/`:
+  `tasks/<project>`, `locks/<resource>`, `mailbox/<topic>`,
+  `events`, `barriers`, `layout_state`, `connection_manifest`, plus
+  the seven `hook_events/*` schemas under `hooks/`.
+- **Reserved prefixes**: `tuples/`, `daemon/`, and every builtin
+  prefix are reserved at the registry level. Third-party
+  `subspace_add` cannot mint into reserved namespaces.
+
+### Hook bridge and cockpit (RDR-111)
+
+The bridge projects Claude Code hooks onto the tuplespace and the
+cockpit panels surface the resulting state.
+
+- **`src/nexus/cockpit/hook_bridge.py`**: `emit()` is the entry point
+  each `orb_bridge_*.py` script calls with a parsed hook payload.
+  Side effects are gated by both `CLAUDECODE` (RF-5, prevents
+  contamination of non-Claude shells) and `NX_BRIDGE_DISABLE`
+  (operator opt-out, documented in
+  [`tuplespace-env.md`](tuplespace-env.md)). Routing prefers the
+  daemon's `tuplespace.out` RPC; failure paths fall back to a direct
+  SQLite + Chroma open under the nexus config.
+- **Seven hook event subspaces** map one-to-one to Claude Code hook
+  types: `tool_call_intent` (PreToolUse), `tool_call_completed`
+  (PostToolUse), `assistant_turn_ended` (Stop / StopFailure),
+  `agent_completed` (SubagentStop), `user_prompt` (UserPromptSubmit),
+  `session_lifecycle` (SessionStart / SessionEnd), `notification`.
+  `PreCompact`, `PostCompact`, and `SubagentStart` are intentionally
+  excluded (RDR-111).
+- **`src/nexus/cockpit/bindings.py`**: user-authored binding profiles
+  (YAML under `nx/tuplespace/builtin/bindings/profiles/`) react to
+  matching events. Actions are `python:<module:func>` (in-process) or
+  `log:<marker>` (structlog). The `_BindingWatcher` polls the events
+  table on the asyncio loop, dispatches actions in cursor order,
+  contains errors so one bad binding does not starve siblings, and
+  dedups via the `action_idempotency` table (RDR-111 §lines 909-942)
+  so a crash between dispatch and cursor save cannot replay python
+  actions on restart.
+- **Cockpit CLI**: `nx cockpit {status|show|dashboard}` is the
+  human-facing read surface. Panels are observation-only; they never
+  write tuples or fire bindings. The reaction loop runs inside the
+  daemon under `NX_STORAGE_MODE=daemon`; `NX_COCKPIT_BINDINGS_DISABLE`
+  is the operator opt-out for the watcher.
+
+For environment variables consumed by this substrate see
+[`docs/tuplespace-env.md`](tuplespace-env.md).
 
 ## Catalog & Link Graph
 
@@ -438,6 +548,9 @@ See `src/nexus/db/t2/__init__.py` for the facade source and
 | **Hooks** | `commands/hooks.py`, `commands/hook.py` | `hooks.py`: Git hook install/uninstall/status, sentinel-bounded stanza management. `hook.py`: Claude Code SessionStart/SessionEnd lifecycle runners |
 | **Verification** | `config.py` (verification section), `nx/hooks/scripts/stop_verification_hook.sh`, `nx/hooks/scripts/pre_close_verification_hook.sh`, `nx/hooks/scripts/read_verification_config.py` | Opt-in mechanical enforcement: Stop hook (session-end checks), PreToolUse hook (bd-close gate), standalone config reader. See [Verification config](configuration.md#verification) |
 | **MCP Servers** | `mcp/core.py`, `mcp/catalog.py`, `mcp_infra.py`, `mcp_server.py` (shim) | Dual-server FastMCP architecture (RDR-062). **Core server (`nexus`, 15 tools)**: `search`, `query`, `store_put`, `store_get`, `store_list`, `memory_put`, `memory_get`, `memory_delete`, `memory_search`, `memory_consolidate`, `scratch`, `scratch_manage`, `collection_list`, `plan_save`, `plan_search`. **Catalog server (`nexus-catalog`, 10 tools)**: `search`, `show`, `list`, `register`, `update`, `link`, `links`, `link_query`, `resolve`, `stats` (short names -- the `catalog_` prefix is dropped since the server namespace already provides context). **Demoted to CLI-only (6 tools)**: `store_delete`, `collection_info`, `collection_verify`, `catalog_unlink`, `catalog_link_audit`, `catalog_link_bulk`. Backward-compat shim at `mcp_server.py` re-exports all 30 functions. `query()` has catalog-aware routing (author, content_type, subtree, follow_links, depth). Singletons and test injection in `mcp_infra.py` |
+| **T2 Daemon** | `daemon/t2_daemon.py`, `daemon/t2_client.py`, `daemon/discovery.py`, `daemon/tuplespace_service.py`, `daemon/event_stream.py`, `daemon/subspace_registry.py`, `daemon/introspection.py`, `daemon/peer.py`, `commands/daemon.py` | Single-writer asyncio daemon owning `memory.db` + `tuples.db` (RDR-112). `t2_daemon.py` runs the dual-bind UDS+TCP transport, the binding-watcher reaction loop (RDR-111 §Phase 2 Step 6), and the retention sweeper. `tuplespace_service.py` exposes the `tuplespace.*` RPC suite via the daemon's single SQLite handle. `event_stream.py` serves `event_stream.subscribe` with rowid-cursored backfill. `subspace_registry.py` is the daemon-side schema cache with reserved-prefix validation. `introspection.py` exposes `exec_raw` / `schema` / `peek` / `stats` / `export`. `discovery.py` is the client-side helper (PID-liveness probe drops stale files); `peer.py` reads `SO_PEERCRED` for the UDS UID gate. CLI: `nx daemon t2 {start|stop|info|exec|schema|peek|stats|export|install|uninstall|subspace add}` |
+| **Tuplespace** | `tuplespace/api.py`, `tuplespace/store.py`, `tuplespace/registry.py`, `tuplespace/index.py`, `tuplespace/watcher.py`, `commands/tuplespace.py` | ORB tuple primitives (RDR-110). `api.py`: `out`/`read`/`take`/`ack`/`nack` + subspace introspection. `store.py`: `tuples.db` schema (`tuples`, `events`, `tuple_claim_log`, `watcher_state`, `subspace_registry`) plus the events trigger that feeds the binding watcher. `registry.py`: subspace YAML loader with template matching for parameterised names (`tasks/<project>`). `index.py`: per-subspace Chroma collection wrapper used by semantic `read`/`take`. `watcher.py`: rowid-cursored polling primitive shared by the cockpit binding watcher. CLI: `nx tuplespace {list-subspaces|show-schema|stats|out|read|take|ack|nack}` refuses mutating subcommands under `NX_STORAGE_MODE=daemon`. MCP: `tuplespace_out/read/take/ack/nack/list_subspaces/subspace_schema/subspace_stats` |
+| **Cockpit** | `cockpit/hook_bridge.py`, `cockpit/bindings.py`, `cockpit/panels/{recent_events,active_claims,active_bindings}.py`, `commands/cockpit.py`, `nx/hooks/scripts/orb_bridge_*.py` | Hook-bridge + reaction loop (RDR-111). `hook_bridge.py`: seven `orb_bridge_*.py` scripts call `emit()` to drain Claude Code hooks into the seven `hook_events/*` subspaces; gated by `CLAUDECODE` (RF-5) plus `NX_BRIDGE_DISABLE` (operator opt-out). Routing prefers the daemon's `tuplespace.out` RPC and falls back to direct mode on discovery / RPC failure. `bindings.py`: user-authored binding profiles, `_BindingWatcher` reaction loop, `action_idempotency` dedup gate. Started inside the daemon under `_start_binding_watcher`; `NX_COCKPIT_BINDINGS_DISABLE` is the kill switch. `panels/`: read-only operator views over `tuples.db`. CLI: `nx cockpit {status|show|dashboard}` |
 | **Enrichment** | `bib_enricher.py`, `aspect_extractor.py`, `aspect_worker.py`, `commands/enrich.py` | Two enrichment surfaces. (1) Bibliographic via Semantic Scholar (`bib_enricher.py` lookup + `nx enrich bib` CLI). (2) Structured aspects via Claude CLI (`aspect_extractor.py` synchronous extractor + `aspect_worker.py` async-queue daemon worker registered as the document-grain post-store hook + `nx enrich aspects` CLI). Aspect extraction is `knowledge__*` only in Phase 1 (RDR-089); the worker drains `aspect_extraction_queue` and writes to `document_aspects` |
 | **Health** | `health.py`, `logging_setup.py` | `health.py`: health check data model and runner used by `nx doctor` and `nx console`. `logging_setup.py`: structured logging configuration for CLI, console, MCP, and hook entry points (stderr + rotating file handler) |
 | **Support** | `config.py`, `registry.py`, `corpus.py`, `session.py`, `hooks.py`, `ttl.py`, `formatters.py`, `types.py`, `errors.py`, `retry.py`, `commands/_helpers.py`, `commands/_provision.py` | Configuration, naming, formatting, session lifecycle, transient-error retry. `_helpers.py`: shared CLI helpers (e.g. `default_db_path()`). `_provision.py`: ChromaDB Cloud database provisioning (tenant resolution, database creation) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1191,6 +1191,310 @@ Exit codes:
 
 ---
 
+## nx tuplespace
+
+CLI surface for the ORB tuplespace (RDR-110). Subspaces are namespaced
+schemas (`tasks/<project>`, `locks/<resource>`, `hook_events/...`) and
+each tuple carries content plus a dimensions map validated against the
+subspace's YAML registry. Lifecycle: `out` posts; `read` browses without
+claiming; `take` claims with a lease; `ack` consumes; `nack` releases.
+
+```
+nx tuplespace list-subspaces
+nx tuplespace show-schema tasks/nexus
+nx tuplespace stats
+nx tuplespace out tasks/nexus '{"status":"open","priority":"P2","created_by":"hal"}' --content "fix the parser bug"
+nx tuplespace read tasks/nexus --query "parser bug"
+nx tuplespace take tasks/nexus --claimant agent-A --query "parser bug"
+nx tuplespace ack <claim-id> --claimant agent-A
+nx tuplespace nack <claim-id> --claimant agent-A
+```
+
+**Daemon-mode note**: under `NX_STORAGE_MODE=daemon` the daemon owns
+`tuples.db` as the single SQLite writer (RDR-112). Mutating subcommands
+(`out`, `take`, `ack`, `nack`) refuse to open a competing connection and
+exit with an explanatory error directing callers to the daemon RPC.
+Read-only introspection (`list-subspaces`, `show-schema`, `stats`)
+loads the registry from YAML and remains available.
+
+### list-subspaces
+
+```
+nx tuplespace list-subspaces [--json]
+```
+
+Lists every registered subspace name plus its tier and content type.
+`--json` emits machine-readable output for tooling.
+
+### show-schema
+
+```
+nx tuplespace show-schema SUBSPACE [--json]
+```
+
+Dumps the resolved schema for a subspace: dimensions (with types and
+required-flag), `take` config (mode, floor, margin, default lease),
+`read` defaults, retention. Useful before calling `out` to know which
+dimensions you must provide. `--json` for tooling.
+
+### stats
+
+```
+nx tuplespace stats [SUBSPACE] [--json]
+```
+
+Row counts plus claim-state breakdown. Omit `SUBSPACE` for an overview
+across the whole tuplespace.
+
+### out
+
+```
+nx tuplespace out SUBSPACE DIMENSIONS_JSON [--content TEXT] [--match-text TEXT] [--ttl-seconds N]
+```
+
+Post a tuple. `DIMENSIONS_JSON` is a JSON object whose keys match the
+subspace's required dimensions. `--content` is the body text; some
+subspaces (`embed_from: dimensions:KEY`) embed a dimension instead, in
+which case `--content` is stored verbatim and never embedded.
+`--match-text` overrides the embed source. `--ttl-seconds` sets an
+explicit expiry; omitted, the subspace `retention_seconds` default
+applies.
+
+### read
+
+```
+nx tuplespace read SUBSPACE [--query TEXT] [--where JSON] [--floor F] [-n N]
+```
+
+Browse unclaimed, unconsumed tuples. `--query` runs the semantic search
+(omit for any-tuple browse). `--where` is a JSON filter dict over
+dimension values. `--floor` overrides the subspace floor; `-n`
+overrides the default result count. Read does not modify state.
+
+### take
+
+```
+nx tuplespace take SUBSPACE --claimant ID [--query TEXT] [--where JSON] [--floor F] [--lease-seconds N]
+```
+
+Claim the top match for exclusive processing. Returns the tuple plus a
+`claim_id` the caller must use for `ack`/`nack`. `--claimant` is the
+agent identifier; same-claimant re-takes during the active lease
+return the existing claim (idempotent retake, CA-1/CA-2). Lease defaults
+to the subspace setting; expiry rolls the claim back to unclaimed.
+
+### ack
+
+```
+nx tuplespace ack CLAIM_ID --claimant ID
+```
+
+Mark the claimed tuple as consumed. `--claimant` must match the
+claimant from `take`; mismatch fails fast.
+
+### nack
+
+```
+nx tuplespace nack CLAIM_ID --claimant ID
+```
+
+Release the claim without consuming. The tuple returns to the unclaimed
+pool so another claimant (or the same one) can `take` it again. Use
+when an agent decides not to act on a tuple after inspection.
+
+---
+
+## nx cockpit
+
+Read-only operator views over the tuplespace state (RDR-111). The
+cockpit is observation-only: it never writes tuples or fires bindings
+on its own (that is the daemon's binding watcher). Panels feed off
+`tuples.db` and surface the agentic substrate's working memory in a
+form humans can scan.
+
+```
+nx cockpit status                       # one-line activity summary
+nx cockpit show recent-events --limit 50
+nx cockpit show active-claims
+nx cockpit show active-bindings
+nx cockpit dashboard                    # multi-panel view
+```
+
+### status
+
+```
+nx cockpit status [--window 5m|1h|24h] [--db-path PATH]
+```
+
+One-line summary of cockpit activity over the chosen window: event
+count, active claims, recent bindings firings. `--db-path` overrides
+the default `tuples.db` location for testing.
+
+### show
+
+```
+nx cockpit show PANEL [--limit N] [--json]
+```
+
+Available panels:
+
+- `recent-events`: last N rows from the events table
+  (subspace, op, tuple_id, timestamp, category).
+- `active-claims`: every tuple currently claimed (claimant, claim_id,
+  lease expiry, subspace).
+- `active-bindings`: loaded binding profiles and their match
+  predicates (no firing history, just the active routing table).
+
+`--limit` defaults to 25; `--json` emits structured output.
+
+### dashboard
+
+```
+nx cockpit dashboard [--limit N] [--width N]
+```
+
+Multi-panel view stacking recent events, active claims, and active
+bindings into a single screen-friendly layout. Honours the `COLUMNS`
+environment variable for terminal width; override explicitly with
+`--width`. Intended as the "left it running in a window" status view.
+
+---
+
+## nx daemon
+
+Manage the T2 storage daemon (RDR-112). The daemon owns the SQLite
+handles for `memory.db` and `tuples.db` as the single writer; clients
+reach it via JSON-RPC over UDS (primary, mode 0600 with peer-cred
+enforced) or loopback TCP (fallback, 127.0.0.1 only). When
+`NX_STORAGE_MODE=daemon` is set the CLI and MCP route through this
+process rather than opening direct SQLite connections.
+
+```
+nx daemon t2 start --foreground       # run in foreground (recommended)
+nx daemon t2 stop                     # SIGTERM the running daemon
+nx daemon t2 info --json              # discovery file contents
+nx daemon t2 install --autostart      # launchd / systemd autostart
+```
+
+### t2 start
+
+```
+nx daemon t2 start [--config-dir DIR] [--foreground]
+```
+
+Bind UDS+TCP transports, run migrations against `memory.db` and
+`tuples.db`, write the discovery file at
+`<config_dir>/t2_addr.<uid>`, and announce on stdout. `--foreground`
+blocks until SIGTERM / SIGINT (the reliable path until the background
+fork mode ships). Without `--foreground` the process exits as soon as
+the discovery announce completes; background mode is currently
+best-effort, so prefer the autostart unit for production.
+
+### t2 stop
+
+```
+nx daemon t2 stop [--config-dir DIR]
+```
+
+Reads the discovery file, sends SIGTERM to the daemon PID, and exits.
+The daemon performs a graceful drain (cancel retention sweeper, close
+binding watcher, close servers, unlink discovery file) before exiting.
+
+### t2 info
+
+```
+nx daemon t2 info [--json] [--config-dir DIR]
+```
+
+Print the discovery file's contents: UDS path, TCP host/port, PID,
+start time, daemon version, protocol version, subspace schema digest.
+`--json` for tooling.
+
+### t2 exec
+
+```
+nx daemon t2 exec --raw "SQL" [--json] [--config-dir DIR]
+```
+
+Run a read-only SQL statement against the daemon's `memory.db`. Admin
+op, UDS-only (refuses over TCP). The daemon opens a `mode=ro`
+connection and caps rows at 50000 with a post-execution audit hash.
+`--json` emits structured output.
+
+### t2 schema
+
+```
+nx daemon t2 schema [--tables NAME] [--indexes] [--fts] [--json] [--config-dir DIR]
+```
+
+Introspect the live schema on the daemon's `memory.db`. Defaults to
+tables only; `--indexes` includes index definitions, `--fts` includes
+FTS5 virtual tables. `--tables NAME` filters to one table. `--json` for
+tooling.
+
+### t2 peek
+
+```
+nx daemon t2 peek TABLE [--offset N] [--limit N] [--json] [--config-dir DIR]
+```
+
+Sample rows from a table on the daemon. `--limit` defaults to 20 and
+is clamped to 300 by the daemon (ChromaDB quota parity). `--offset`
+paginates. `--json` for tooling.
+
+### t2 stats
+
+```
+nx daemon t2 stats [--json] [--config-dir DIR]
+```
+
+Per-table row counts plus database file size. `--json` for tooling.
+
+### t2 export
+
+```
+nx daemon t2 export [--table NAME] --format {jsonl|csv} DEST [--config-dir DIR]
+```
+
+Stream rows out of `memory.db` for backup or migration. Admin op,
+UDS-only. `--table` exports one table; omit for all tables. `--format`
+picks the on-disk shape. `DEST` is the output file path; export refuses
+paths that traverse outside the operator's home as a defense-in-depth
+against path-traversal exploits via crafted args. Streaming via
+`fetchmany(256)` keeps memory bounded on large tables.
+
+### t2 install / uninstall
+
+```
+nx daemon t2 install --autostart
+nx daemon t2 uninstall --autostart
+```
+
+Install (or remove) the OS autostart entry so the T2 daemon starts at
+login or boot. On macOS: writes
+`~/Library/LaunchAgents/com.nexus.t2.plist` and runs `launchctl
+bootstrap gui/$UID`. On Linux: writes
+`~/.config/systemd/user/nexus-t2.service` and runs `systemctl --user
+enable --now nexus-t2.service`. The plist's `KeepAlive: Crashed` and
+the unit's `SuccessExitStatus=143` cooperate so `nx daemon t2 stop`
+does not trigger an instant respawn.
+
+### t2 subspace add
+
+```
+nx daemon t2 subspace add YAML_PATH [--config-dir DIR]
+```
+
+Register a new subspace schema from `YAML_PATH` via the daemon's
+`subspace_add` admin RPC. Admin op, UDS-only. The daemon validates the
+schema against the JSON Schema for subspace definitions plus the
+reserved-prefix list (`tuples/`, `daemon/`, `tasks/`, `mailbox/`,
+`hook_events/...`); duplicate names are rejected. On success the
+discovery file is rewritten so its `subspace_schema_digest` reflects
+the new registry state.
+
+---
+
 ## nx doctor
 
 Health check for all dependencies.
@@ -1259,6 +1563,12 @@ nx doctor --check-aspect-queue       # Surface RDR-089 aspect-extraction worker 
 ```
 
 The `--check-aspect-queue` flag (introduced 4.18.0, `nexus-1pfq`) reports the `aspect_extraction_queue` row count plus per-status breakdown (`pending`, `processing`, `failed`, `completed`), the oldest non-completed `enqueued_at` as a lag indicator, and the top failed rows with their `last_error`. The same data surfaces in the `nx console` Aspect Queue card on `/health` for live monitoring. Pre-RDR-089 databases (no queue table) report cleanly as "table not present" rather than erroring.
+
+```
+nx doctor --check-bridge             # Diagnose ORB hook-bridge installability (RDR-111)
+```
+
+The `--check-bridge` flag (introduced with RDR-111 hook bridge) verifies that the seven `orb_bridge_*.py` scripts can actually fire. A wheel-only install delivers no bridge: the scripts live in `$CLAUDE_PLUGIN_ROOT/hooks/scripts/` and require both the Python wheel AND the `nx` Claude Code plugin. The check reports: (1) `CLAUDE_PLUGIN_ROOT` is set, (2) all seven bridge scripts exist under it, (3) `~/.config/nexus/tuples.db` exists and is readable, (4) the seven hook-event subspace YAMLs resolve via the registry, (5) at least one tuple has been written in the last 24 hours (sanity that emission is actually working; set `CLAUDECODE` and unset `NX_BRIDGE_DISABLE` if zero). Recommended right after `nx upgrade` or after re-installing the plugin.
 
 ---
 

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,41 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added: RDR-110/111 user-facing surfaces
+
+- **Tuplespace skills**: seven `nx:tuplespace-*` cockpit skills land
+  with the ORB tuple substrate (nexus-90pe, PR #791) so operators
+  have Day-1 entry points for `out` / `read` / `take` / `ack` /
+  `nack` workflows without needing to invent prompts each time.
+- **`nx cockpit` CLI**: three subcommands (`status`, `show`,
+  `dashboard`) plus the `recent-events` / `active-claims` /
+  `active-bindings` panels (nexus-ut5r, PR #802).
+- **Hook bridge scripts**: seven `orb_bridge_*.py` scripts under
+  `hooks/scripts/` (PreToolUse, PostToolUse, Stop, SubagentStop,
+  UserPromptSubmit, Session, Notification) projecting Claude Code
+  hooks into the seven `hook_events/*` subspaces (nexus-y0nb, PR
+  #784). `EXPECTED_BRIDGE_API_VERSION` embedded in each script for
+  plugin/wheel version-compat guard (nexus-yeu8, PR #809).
+- **Binding profiles**: `tuplespace/builtin/bindings/profiles/`
+  ships a `default` profile with two reference bindings:
+  `post_tool_use_to_derived` (in-tuplespace reaction) and
+  `notification_log_marker` (structlog side effect). User-authored
+  profiles drop in alongside.
+- **Substrate YAMLs**: six coordination subspace YAMLs
+  (connection_manifest, layout_state, mailbox, barriers, locks,
+  events) plus the seven `hook_events/*` schemas now ship in the
+  wheel-packaged plugin (PR #803).
+- **`nx daemon t2 {install,uninstall} --autostart`**: launchd
+  (macOS) and systemd (Linux) autostart units for the T2 storage
+  daemon (nexus-6w0c, PR #808).
+
+### Added: operator diagnostics
+
+- **`nx doctor --check-bridge`**: RDR-111 hook bridge installability
+  check; verifies `CLAUDE_PLUGIN_ROOT`, the seven bridge scripts,
+  `tuples.db`, the hook-event subspace registry, and recent emission
+  activity. Recommended after `nx upgrade` or plugin reinstall.
+
 ## [4.32.12] - 2026-05-13
 
 Plugin version aligned with conexus 4.32.12. No plugin-side changes


### PR DESCRIPTION
## Summary

Three docs-only beads from the RDR-110/111/112/113 360° critique. Each addresses a coverage gap the prior arc left behind: 25 CLI subcommands with zero docs, an architecture doc that predates the daemon model, and CHANGELOG entries that only mentioned RDR-112 Phase 1.

### nexus-m283 — \`docs/cli-reference.md\`

Three new top-level sections plus a doctor-flag extension:

- **\`nx tuplespace\`** — full subcommand reference: \`list-subspaces\`, \`show-schema\`, \`stats\`, \`out\`, \`read\`, \`take\`, \`ack\`, \`nack\`. Daemon-mode notes call out which subcommands refuse to open competing SQLite handles under \`NX_STORAGE_MODE=daemon\`.
- **\`nx cockpit\`** — \`status\` / \`show\` / \`dashboard\` plus the three panels (\`recent-events\`, \`active-claims\`, \`active-bindings\`) and the observation-only invariant.
- **\`nx daemon\`** — full \`t2\` subcommand tree (\`start\`, \`stop\`, \`info\`, \`exec\`, \`schema\`, \`peek\`, \`stats\`, \`export\`, \`install\` / \`uninstall --autostart\`, \`subspace add\`) with admin-RPC UDS-only callouts.
- **\`nx doctor --check-bridge\`** — extends the existing doctor section with RDR-111 hook bridge installability diagnostics.

### nexus-i9ue — \`docs/architecture.md\`

New \"T2 Daemon, Tuplespace, and Cockpit (RDR-110/111/112/113)\" section under \"How It Fits Together\". Covers:

- Process model and host trust (discovery file, UDS+TCP transport, admin-RPC UDS gate, daemon-owned migrations, autostart, \`nx doctor --check-storage-boundary\` boundary lint).
- ORB tuplespace primitives (lifecycle, two-store atomicity, builtin subspaces, reserved prefixes).
- Hook bridge + cockpit (\`emit()\` gating, seven hook event subspace mappings, \`_BindingWatcher\` reaction loop, panel surfaces).

Module Map table extended with three new rows (T2 Daemon, Tuplespace, Cockpit).

### nexus-6az5 — CHANGELOGs

- Root \`CHANGELOG.md\` Unreleased gains four new \`### Added\` blocks (RDR-110 substrate, RDR-111 hook bridge + cockpit, RDR-113 host-trust v1, RDR-112 Phase 2 in flight). Each entry cites landing PRs (#784 #787 #788 #789 #791 #792 #800 #801 #802 #803 #806 #807 #808 #809 #822) so the next release-notes pass pulls the bullets straight through.
- \`nx/CHANGELOG.md\` Unreleased gains plugin-side user-facing surfaces (tuplespace skills, \`nx cockpit\` CLI, hook bridge scripts, binding profiles, substrate YAMLs, autostart) plus \`nx doctor --check-bridge\`.

Style note: em-dashes scrubbed from new prose per the project preference. Existing entries left as-is.

## Closes

- Closes nexus-m283
- Closes nexus-i9ue
- Closes nexus-6az5

## Refs

- nexus-g7yy (RDR-110-113 critique remediation)

## Test plan

- [x] Manual read-through of all four files to confirm structure renders.
- [x] No em-dashes in new prose (\`git diff | grep '^+.*—'\` returns 0).
- [ ] CI green (markdown lint, link check).