### PR TITLE
feat(rdr-112): cockpit panels via daemon RPC + storage-boundary lint

### DIFF
--- a/src/nexus/commands/cockpit.py
+++ b/src/nexus/commands/cockpit.py
@@ -18,11 +18,16 @@ Daemon-mode awareness
 ---------------------
 
 When ``NX_STORAGE_MODE=daemon`` is set, the tuplespace daemon owns
-``tuples.db``. Phase 3 panels read directly from that SQLite file in
-read-only WAL mode, which is safe (the daemon never holds an exclusive
-write lock for long). A full daemon-RPC path (``T2Client.cockpit.*``)
-is a follow-up; for v1 we accept the direct-read approach and document
-the deferral in the PR body.
+``tuples.db`` as the single writer (RDR-112 §9). Panels then route
+through the daemon's ``tuplespace.list_active_claims`` and
+``tuplespace.recent_events`` RPCs instead of opening a second SQLite
+handle on the same file (nexus-x65c). Failure modes (no discovery
+file, dead PID, RPC error) surface loud rather than silently falling
+back to a direct-read; the boundary is the contract.
+
+The ``active-bindings`` panel reads binding-profile YAML, not
+SQLite, so it is unaffected by the boundary and continues to read
+profiles from disk directly.
 """
 
 from __future__ import annotations
@@ -186,20 +191,73 @@ def _render_one(panel: str, *, limit: int) -> RenderedPanel:
     raise click.UsageError(f"unknown panel: {panel}")
 
 
-def _render_active_claims() -> RenderedPanel:
-    from nexus.cockpit.panels.active_claims import fetch_active_claims
+def _is_daemon_mode() -> bool:
+    """Return True if ``NX_STORAGE_MODE=daemon`` is set."""
+    return os.environ.get("NX_STORAGE_MODE", "").strip().lower() == "daemon"
 
-    db_path = _cockpit_tuples_db()
-    if not db_path.exists():
+
+def _open_daemon_client() -> "T2Client":  # noqa: F821 — forward ref
+    """Construct a T2Client from the daemon discovery file.
+
+    Fails loud (`click.ClickException`) under daemon mode with no
+    silent fallback to direct-read — the RDR-112 §9 boundary forbids
+    a second SQLite writer.
+    """
+    from nexus.daemon.discovery import find_t2_daemon  # noqa: PLC0415
+    from nexus.daemon.t2_client import T2Client  # noqa: PLC0415
+
+    info = find_t2_daemon()
+    if info is None:
         raise click.ClickException(
-            f"tuples.db not found at {db_path}; nothing to render."
+            "NX_STORAGE_MODE=daemon is set but no T2 daemon discovery "
+            "file was found. Start the daemon "
+            "(`nx daemon t2 start --foreground` or install autostart) "
+            "or unset NX_STORAGE_MODE."
         )
-    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    conn.row_factory = sqlite3.Row
-    try:
-        result = fetch_active_claims(conn=conn)
-    finally:
-        conn.close()
+    uds = info.get("uds_path") or ""
+    uds_path = Path(uds) if uds else None
+    if uds_path is not None and uds_path.exists():
+        return T2Client(uds_path=uds_path)
+    return T2Client(tcp_addr=(info["tcp_host"], info["tcp_port"]))
+
+
+def _render_active_claims() -> RenderedPanel:
+    from nexus.cockpit.panels.active_claims import (
+        ActiveClaimsResult,
+        ClaimRow,
+        fetch_active_claims,
+    )
+
+    if _is_daemon_mode():
+        client = _open_daemon_client()
+        try:
+            rows_data = client.tuplespace.list_active_claims()
+        finally:
+            client.close()
+        result = ActiveClaimsResult(
+            rows=[
+                ClaimRow(
+                    subspace=r["subspace"],
+                    tuple_id=r["tuple_id"],
+                    claim_id=r.get("claim_id") or "",
+                    claimant=r.get("claimant") or "",
+                    ttl_remaining_seconds=r.get("ttl_remaining_seconds"),
+                )
+                for r in rows_data
+            ]
+        )
+    else:
+        db_path = _cockpit_tuples_db()
+        if not db_path.exists():
+            raise click.ClickException(
+                f"tuples.db not found at {db_path}; nothing to render."
+            )
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            result = fetch_active_claims(conn=conn)
+        finally:
+            conn.close()
 
     if not result.rows:
         return RenderedPanel(title="Active Claims", lines=[])
@@ -221,19 +279,44 @@ def _render_active_claims() -> RenderedPanel:
 
 
 def _render_recent_events(*, limit: int) -> RenderedPanel:
-    from nexus.cockpit.panels.recent_events import fetch_recent_events
+    from nexus.cockpit.panels.recent_events import (
+        EventRow,
+        RecentEventsResult,
+        fetch_recent_events,
+    )
 
-    db_path = _cockpit_tuples_db()
-    if not db_path.exists():
-        raise click.ClickException(
-            f"tuples.db not found at {db_path}; nothing to render."
+    if _is_daemon_mode():
+        client = _open_daemon_client()
+        try:
+            rows_data = client.tuplespace.recent_events(limit=limit)
+        finally:
+            client.close()
+        result = RecentEventsResult(
+            rows=[
+                EventRow(
+                    cursor=int(r["cursor"]),
+                    subspace=r["subspace"],
+                    op=r["op"],
+                    tuple_id=r["tuple_id"],
+                    ts=float(r["ts"]),
+                    payload_summary=r.get("payload_summary"),
+                    category=r.get("category"),
+                )
+                for r in rows_data
+            ]
         )
-    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    conn.row_factory = sqlite3.Row
-    try:
-        result = fetch_recent_events(conn=conn, limit=limit)
-    finally:
-        conn.close()
+    else:
+        db_path = _cockpit_tuples_db()
+        if not db_path.exists():
+            raise click.ClickException(
+                f"tuples.db not found at {db_path}; nothing to render."
+            )
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            result = fetch_recent_events(conn=conn, limit=limit)
+        finally:
+            conn.close()
 
     if not result.rows:
         return RenderedPanel(title="Recent Events", lines=[])

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -837,6 +837,101 @@ def _run_check_post_store_hooks() -> None:
     click.echo(f"\nTotal: {total} hook(s) registered across 3 chains.")
 
 
+# ── --check-storage-boundary (RDR-112 §5; nexus-b7o1) ────────────────────
+
+
+def _run_check_storage_boundary() -> int:
+    """AST-scan ``src/nexus/**/*.py`` for direct ``sqlite3.connect`` callers.
+
+    RDR-112 §5: when ``NX_STORAGE_MODE=daemon``, the daemon owns
+    ``memory.db`` and ``tuples.db`` as the single SQLite writer. Any
+    module outside ``src/nexus/daemon/`` that opens a competing
+    connection violates the boundary. Static lint instead of a runtime
+    probe so violators surface in CI / pre-merge even when no daemon is
+    running.
+
+    Severity:
+      - advisory (exit 0) when ``NX_STORAGE_MODE`` is unset or not
+        ``daemon``: print the violation list, exit 0.
+      - hard fail (exit 2) when ``NX_STORAGE_MODE=daemon``: same
+        listing, non-zero exit so CI can gate on it.
+
+    Returns the chosen exit code so callers can propagate it.
+    """
+    import ast
+    import os as _os
+    from pathlib import Path as _Path
+
+    pkg_root = _Path(__file__).resolve().parent.parent
+    if pkg_root.name != "nexus":  # pragma: no cover — defensive
+        click.echo(
+            f"check-storage-boundary: unable to locate src/nexus "
+            f"(got {pkg_root}); aborting.",
+            err=True,
+        )
+        return 2
+
+    daemon_root = pkg_root / "daemon"
+
+    def _is_sqlite_connect_call(node: ast.Call) -> bool:
+        # Match `sqlite3.connect(...)` and `*.connect(...)` where the
+        # attribute lookup is on a module imported as sqlite3.
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "connect":
+            value = func.value
+            if isinstance(value, ast.Name) and value.id in {"sqlite3", "_sqlite3"}:
+                return True
+        return False
+
+    violations: list[tuple[str, int, str]] = []
+    for py_path in sorted(pkg_root.rglob("*.py")):
+        # Anything under daemon/ is on the allowed side of the boundary.
+        try:
+            py_path.relative_to(daemon_root)
+            continue
+        except ValueError:
+            pass
+        try:
+            source = py_path.read_text()
+            tree = ast.parse(source, filename=str(py_path))
+        except (OSError, SyntaxError) as exc:
+            click.echo(
+                f"check-storage-boundary: failed to parse {py_path}: {exc}",
+                err=True,
+            )
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _is_sqlite_connect_call(node):
+                snippet = source.splitlines()[node.lineno - 1].strip()
+                rel = py_path.relative_to(pkg_root.parent.parent)
+                violations.append((str(rel), node.lineno, snippet))
+
+    daemon_mode = _os.environ.get("NX_STORAGE_MODE", "").strip().lower() == "daemon"
+    click.echo("Storage-boundary check (RDR-112 §5):")
+    if not violations:
+        click.echo(_check("no direct sqlite3.connect outside daemon/", True))
+        return 0
+
+    label = "direct sqlite3.connect outside src/nexus/daemon/"
+    click.echo(_check(label, False, f"{len(violations)} violation(s)"))
+    for path, line, snippet in violations:
+        click.echo(f"  {path}:{line}: {snippet}")
+
+    if daemon_mode:
+        click.echo("")
+        click.echo(
+            "NX_STORAGE_MODE=daemon is set; the violations above bypass "
+            "the daemon's single-writer guarantee. Exiting 2."
+        )
+        return 2
+    click.echo("")
+    click.echo(
+        "Advisory only (NX_STORAGE_MODE not 'daemon'). RDR-112 §5 calls "
+        "for staged remediation; this list scopes the remaining work."
+    )
+    return 0
+
+
 # ── --check-bridge (RDR-111 deep-review pass — bridge installability) ─────
 
 
@@ -1238,6 +1333,16 @@ def _run_check_mineru() -> None:
          "least one tuple landed in the last 24h.",
 )
 @click.option(
+    "--check-storage-boundary",
+    "check_storage_boundary",
+    is_flag=True,
+    default=False,
+    help="AST-lint src/nexus for direct sqlite3.connect calls outside "
+         "src/nexus/daemon/ (RDR-112 §5). Advisory unless "
+         "NX_STORAGE_MODE=daemon, in which case any violation exits 2. "
+         "nexus-b7o1.",
+)
+@click.option(
     "--days",
     "days",
     default=30,
@@ -1259,6 +1364,7 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
                check_aspect_queue: bool,
                check_t1: bool,
                check_bridge: bool,
+               check_storage_boundary: bool,
                check_tier_discipline: bool) -> None:
     """Verify that all required services and credentials are available."""
     if check_schema:
@@ -1316,6 +1422,12 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
 
     if check_bridge:
         _run_check_bridge()
+        return
+
+    if check_storage_boundary:
+        exit_code = _run_check_storage_boundary()
+        if exit_code != 0:
+            raise SystemExit(exit_code)
         return
 
     if check_tier_discipline:

--- a/src/nexus/daemon/t2_client.py
+++ b/src/nexus/daemon/t2_client.py
@@ -540,6 +540,27 @@ class _TuplespaceProxy:
     def subspace_stats(self, *, subspace: str) -> dict[str, Any]:
         return self._call("subspace_stats", {"subspace": subspace})
 
+    def list_active_claims(
+        self, *, now: float | None = None
+    ) -> list[dict[str, Any]]:
+        """RDR-112 cockpit-boundary RPC (nexus-x65c).
+
+        Returns active-claim rows shaped as
+        ``{"subspace": str, "tuple_id": str, "claim_id": str,
+        "claimant": str, "ttl_remaining_seconds": float | None}``.
+        """
+        return self._call("list_active_claims", {"now": now})
+
+    def recent_events(self, *, limit: int = 25) -> list[dict[str, Any]]:
+        """RDR-112 cockpit-boundary RPC (nexus-x65c).
+
+        Returns events-table rows shaped as
+        ``{"cursor": int, "subspace": str, "op": str, "tuple_id": str,
+        "ts": float, "payload_summary": str | None,
+        "category": str | None}``.
+        """
+        return self._call("recent_events", {"limit": int(limit)})
+
 
 # ---------------------------------------------------------------------------
 # T2Client

--- a/src/nexus/daemon/tuplespace_service.py
+++ b/src/nexus/daemon/tuplespace_service.py
@@ -217,6 +217,88 @@ class TuplespaceService:
             return ts_api.subspace_stats(conn=self._conn, subspace=subspace)
 
     # ------------------------------------------------------------------
+    # Read-only RPCs for cockpit panels (RDR-112 boundary; nexus-x65c)
+    # ------------------------------------------------------------------
+
+    def list_active_claims(
+        self, *, now: Optional[float] = None
+    ) -> list[dict[str, Any]]:
+        """Return active claims as a list of dicts (JSON-friendly).
+
+        Mirrors ``nexus.cockpit.panels.active_claims.fetch_active_claims``
+        so cockpit panels under ``NX_STORAGE_MODE=daemon`` can avoid
+        opening a second SQLite handle on ``tuples.db``. The daemon is
+        the single writer (RDR-112 §9); read RPCs must originate from
+        this process to preserve the boundary.
+        """
+        import time as _time
+
+        ts = _time.time() if now is None else float(now)
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT subspace, id AS tuple_id, claim_id, claimant, "
+                "claim_expires_at "
+                "FROM tuples "
+                "WHERE claim_state = 'claimed' "
+                "  AND consumed_at IS NULL "
+                "  AND (claim_expires_at IS NULL OR claim_expires_at > ?) "
+                "ORDER BY subspace, claim_expires_at",
+                (ts,),
+            )
+            rows = [dict(r) for r in cur.fetchall()]
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            expires = r.get("claim_expires_at")
+            out.append(
+                {
+                    "subspace": r["subspace"],
+                    "tuple_id": r["tuple_id"],
+                    "claim_id": r.get("claim_id") or "",
+                    "claimant": r.get("claimant") or "",
+                    "ttl_remaining_seconds": (
+                        None
+                        if expires is None
+                        else max(0.0, float(expires) - ts)
+                    ),
+                }
+            )
+        return out
+
+    def recent_events(self, *, limit: int = 25) -> list[dict[str, Any]]:
+        """Return the newest ``limit`` rows from the events table.
+
+        Mirrors ``nexus.cockpit.panels.recent_events.fetch_recent_events``
+        so cockpit panels under daemon mode read through the daemon
+        instead of opening ``tuples.db`` directly (RDR-112 boundary).
+        """
+        n = int(limit)
+        if n <= 0:
+            return []
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT rowid, subspace, op, tuple_id, payload_summary, "
+                "category, ts "
+                "FROM events "
+                "ORDER BY rowid DESC LIMIT ?",
+                (n,),
+            )
+            rows = [dict(r) for r in cur.fetchall()]
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            out.append(
+                {
+                    "cursor": int(r["rowid"]),
+                    "subspace": r["subspace"],
+                    "op": r["op"],
+                    "tuple_id": r["tuple_id"],
+                    "ts": float(r["ts"]),
+                    "payload_summary": r.get("payload_summary"),
+                    "category": r.get("category"),
+                }
+            )
+        return out
+
+    # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
@@ -256,6 +338,8 @@ def register_tuplespace_rpcs(
         "tuplespace.list_subspaces": service.list_subspaces,
         "tuplespace.subspace_schema": service.subspace_schema,
         "tuplespace.subspace_stats": service.subspace_stats,
+        "tuplespace.list_active_claims": service.list_active_claims,
+        "tuplespace.recent_events": service.recent_events,
     }
     for op, fn in handlers.items():
         rpc_table[op] = fn
@@ -274,4 +358,6 @@ TUPLESPACE_RPC_OPS: tuple[str, ...] = (
     "list_subspaces",
     "subspace_schema",
     "subspace_stats",
+    "list_active_claims",
+    "recent_events",
 )

--- a/tests/cockpit/test_panels_daemon_mode.py
+++ b/tests/cockpit/test_panels_daemon_mode.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Cockpit panels under NX_STORAGE_MODE=daemon (RDR-112 §A2, nexus-x65c).
+
+The cockpit's active-claims and recent-events panels must NOT open
+a second SQLite handle on ``tuples.db`` when a daemon owns it. Under
+``NX_STORAGE_MODE=daemon`` they route through the daemon's
+``tuplespace.list_active_claims`` / ``tuplespace.recent_events`` RPCs.
+
+Discovery failures surface as ``ClickException`` rather than a silent
+fallback to direct-read; the boundary is the contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import chromadb
+import pytest
+from click.testing import CliRunner
+
+from nexus.commands.cockpit import cockpit_group
+from nexus.daemon.t2_daemon import T2Daemon
+from nexus.daemon.tuplespace_service import TuplespaceService
+from nexus.tuplespace.api import out, take
+from nexus.tuplespace.registry import Registry
+
+
+_TASKS_YAML = """
+name: tasks/<project>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  status:     { type: enum, values: [open, in_progress, done, cancelled], required: true }
+  priority:   { type: enum, values: [P0, P1, P2, P3, P4], required: true }
+  created_by: { type: string, required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.0
+  margin: 0.0
+  default_lease_seconds: 300
+read:
+  default_floor: 0.0
+  default_n: 5
+tiers: [project]
+retention_seconds: 86400
+"""
+
+
+@pytest.fixture
+def test_registry(tmp_path: Path) -> Registry:
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+    (builtin / "tasks.yml").write_text(_TASKS_YAML)
+    return Registry.load(builtin)
+
+
+@pytest.fixture
+def chroma_client():
+    client = chromadb.EphemeralClient()
+    yield client
+    for coll in client.list_collections():
+        client.delete_collection(coll.name)
+
+
+def _run_daemon(daemon: T2Daemon) -> asyncio.AbstractEventLoop:
+    started = threading.Event()
+    loop = asyncio.new_event_loop()
+
+    def _thread() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(daemon.start())
+        started.set()
+        loop.run_forever()
+
+    t = threading.Thread(target=_thread, daemon=True)
+    t.start()
+    started.wait(timeout=5.0)
+    return loop
+
+
+def _stop_daemon(daemon: T2Daemon, loop: asyncio.AbstractEventLoop) -> None:
+    asyncio.run_coroutine_threadsafe(daemon.stop(), loop).result(timeout=5.0)
+    loop.call_soon_threadsafe(loop.stop)
+
+
+def _seed_claimed_tuple(daemon: T2Daemon) -> None:
+    """Post a tuple and immediately claim it via the daemon's service conn."""
+    service = daemon._tuplespace_service
+    tid = out(
+        conn=service._conn,
+        index=service._index,
+        registry=service._registry,
+        subspace="tasks/nexus",
+        content="active-claim target",
+        dimensions={
+            "status": "open",
+            "priority": "P2",
+            "created_by": "agent-X",
+        },
+    )
+    result = take(
+        conn=service._conn,
+        index=service._index,
+        registry=service._registry,
+        subspace="tasks/nexus",
+        query="active-claim",
+        claimant="agent-A",
+        lease_seconds=300.0,
+    )
+    assert result is not None, "seed take must succeed"
+    return tid
+
+
+# ---------------------------------------------------------------------------
+# Daemon-mode tests
+# ---------------------------------------------------------------------------
+
+
+class TestCockpitPanelsDaemonMode:
+    """Under NX_STORAGE_MODE=daemon, panels route via the daemon."""
+
+    def test_active_claims_panel_routes_through_daemon(
+        self,
+        tmp_path: Path,
+        test_registry: Registry,
+        chroma_client,
+        monkeypatch,
+    ) -> None:
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        tuples_db_path = config_dir / "tuples.db"
+
+        service = TuplespaceService(
+            tuples_db_path=tuples_db_path,
+            chroma_client=chroma_client,
+            registry=test_registry,
+        )
+        daemon = T2Daemon(
+            config_dir=config_dir,
+            tuples_db_path=tuples_db_path,
+            tuplespace_service=service,
+        )
+        loop = _run_daemon(daemon)
+
+        _seed_claimed_tuple(daemon)
+
+        from nexus.daemon import discovery as _disc
+        monkeypatch.setattr(_disc, "nexus_config_dir", lambda: config_dir)
+        monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+
+        # Direct-read fallback must NOT fire under daemon mode.
+        with patch(
+            "nexus.commands.cockpit.sqlite3.connect",
+            side_effect=AssertionError(
+                "panel opened a direct sqlite3.connect under daemon mode"
+            ),
+        ):
+            try:
+                runner = CliRunner()
+                result = runner.invoke(
+                    cockpit_group, ["show", "active-claims"]
+                )
+            finally:
+                _stop_daemon(daemon, loop)
+
+        assert result.exit_code == 0, result.output
+        assert "Active Claims" in result.output
+        assert "tasks/nexus" in result.output
+        assert "agent-A" in result.output
+
+    def test_recent_events_panel_routes_through_daemon(
+        self,
+        tmp_path: Path,
+        test_registry: Registry,
+        chroma_client,
+        monkeypatch,
+    ) -> None:
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        tuples_db_path = config_dir / "tuples.db"
+
+        service = TuplespaceService(
+            tuples_db_path=tuples_db_path,
+            chroma_client=chroma_client,
+            registry=test_registry,
+        )
+        daemon = T2Daemon(
+            config_dir=config_dir,
+            tuples_db_path=tuples_db_path,
+            tuplespace_service=service,
+        )
+        loop = _run_daemon(daemon)
+        # Posting a tuple fires the events trigger.
+        out(
+            conn=service._conn,
+            index=service._index,
+            registry=service._registry,
+            subspace="tasks/nexus",
+            content="event seed",
+            dimensions={
+                "status": "open",
+                "priority": "P1",
+                "created_by": "agent-X",
+            },
+        )
+
+        from nexus.daemon import discovery as _disc
+        monkeypatch.setattr(_disc, "nexus_config_dir", lambda: config_dir)
+        monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+
+        with patch(
+            "nexus.commands.cockpit.sqlite3.connect",
+            side_effect=AssertionError(
+                "panel opened a direct sqlite3.connect under daemon mode"
+            ),
+        ):
+            try:
+                runner = CliRunner()
+                result = runner.invoke(
+                    cockpit_group, ["show", "recent-events", "--limit", "5"]
+                )
+            finally:
+                _stop_daemon(daemon, loop)
+
+        assert result.exit_code == 0, result.output
+        assert "Recent Events" in result.output
+        assert "tasks/nexus" in result.output
+
+    def test_daemon_mode_missing_discovery_fails_loud(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """No discovery file under daemon mode -> ClickException, not silent fallback."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+
+        from nexus.daemon import discovery as _disc
+        monkeypatch.setattr(_disc, "nexus_config_dir", lambda: config_dir)
+        monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+
+        runner = CliRunner()
+        result = runner.invoke(cockpit_group, ["show", "active-claims"])
+        assert result.exit_code != 0
+        assert "discovery file" in result.output.lower() or "daemon" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Standalone-mode regression (existing direct-read path preserved)
+# ---------------------------------------------------------------------------
+
+
+class TestCockpitPanelsStandaloneMode:
+    """Without NX_STORAGE_MODE, the existing direct-read still works."""
+
+    def test_standalone_active_claims_still_uses_direct_read(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from nexus.tuplespace.store import open_tuples_db
+
+        db_path = tmp_path / "tuples.db"
+        c = open_tuples_db(db_path)
+        c.close()  # schema only — empty DB renders cleanly
+
+        monkeypatch.setenv("NX_COCKPIT_TUPLES_DB", str(db_path))
+        monkeypatch.delenv("NX_STORAGE_MODE", raising=False)
+
+        runner = CliRunner()
+        result = runner.invoke(cockpit_group, ["show", "active-claims"])
+        assert result.exit_code == 0, result.output

--- a/tests/commands/test_doctor_storage_boundary.py
+++ b/tests/commands/test_doctor_storage_boundary.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for ``nx doctor --check-storage-boundary`` (RDR-112 §5, nexus-b7o1).
+
+The lint AST-scans ``src/nexus/**/*.py`` for direct ``sqlite3.connect``
+callers outside ``src/nexus/daemon/``. Severity is environment-aware:
+advisory (exit 0) when ``NX_STORAGE_MODE`` is unset, hard fail (exit 2)
+under ``NX_STORAGE_MODE=daemon``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.commands import doctor as doctor_cmd
+
+
+def _make_synthetic_pkg(tmp_path: Path, *, with_violation: bool) -> Path:
+    pkg = tmp_path / "nexus"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    daemon = pkg / "daemon"
+    daemon.mkdir()
+    (daemon / "__init__.py").write_text("")
+    # Daemon-internal sqlite3.connect is ALWAYS allowed.
+    (daemon / "service.py").write_text(
+        "import sqlite3\n"
+        "def open_db(path):\n"
+        "    return sqlite3.connect(str(path))\n"
+    )
+    if with_violation:
+        catalog = pkg / "catalog"
+        catalog.mkdir()
+        (catalog / "__init__.py").write_text("")
+        (catalog / "open.py").write_text(
+            "import sqlite3\n"
+            "def open_catalog(path):\n"
+            "    return sqlite3.connect(str(path))\n"
+        )
+    # ``doctor.py`` location is inferred from __file__; mimic the layout.
+    cmd = pkg / "commands"
+    cmd.mkdir()
+    (cmd / "__init__.py").write_text("")
+    (cmd / "doctor.py").write_text("")
+    return pkg
+
+
+class TestCheckStorageBoundary:
+    """Static lint surfaces direct sqlite3.connect outside daemon/."""
+
+    def test_all_daemon_callers_exit_zero(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        pkg = _make_synthetic_pkg(tmp_path, with_violation=False)
+        # Reroute the lint at the synthetic package root via __file__.
+        monkeypatch.setattr(
+            doctor_cmd, "__file__", str(pkg / "commands" / "doctor.py")
+        )
+        monkeypatch.delenv("NX_STORAGE_MODE", raising=False)
+
+        exit_code = doctor_cmd._run_check_storage_boundary()
+        assert exit_code == 0
+
+    def test_violation_advisory_when_not_daemon_mode(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        pkg = _make_synthetic_pkg(tmp_path, with_violation=True)
+        monkeypatch.setattr(
+            doctor_cmd, "__file__", str(pkg / "commands" / "doctor.py")
+        )
+        monkeypatch.delenv("NX_STORAGE_MODE", raising=False)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            doctor_cmd.doctor_cmd, ["--check-storage-boundary"]
+        )
+        # Advisory: exit code is 0 even with violations.
+        assert result.exit_code == 0
+        assert "violation" in result.output.lower()
+        assert "catalog/open.py" in result.output
+
+    def test_violation_hard_fails_under_daemon_mode(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        pkg = _make_synthetic_pkg(tmp_path, with_violation=True)
+        monkeypatch.setattr(
+            doctor_cmd, "__file__", str(pkg / "commands" / "doctor.py")
+        )
+        monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            doctor_cmd.doctor_cmd, ["--check-storage-boundary"]
+        )
+        assert result.exit_code == 2
+        assert "Exiting 2" in result.output
+
+    def test_aliased_import_is_detected(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """``import sqlite3 as _sqlite3; _sqlite3.connect(...)`` counts."""
+        pkg = tmp_path / "nexus"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "daemon").mkdir()
+        (pkg / "daemon" / "__init__.py").write_text("")
+        cmd = pkg / "commands"
+        cmd.mkdir()
+        (cmd / "__init__.py").write_text("")
+        (cmd / "doctor.py").write_text("")
+        (pkg / "outside.py").write_text(
+            "import sqlite3 as _sqlite3\n"
+            "def open_db(path):\n"
+            "    return _sqlite3.connect(str(path))\n"
+        )
+
+        monkeypatch.setattr(
+            doctor_cmd, "__file__", str(pkg / "commands" / "doctor.py")
+        )
+        monkeypatch.delenv("NX_STORAGE_MODE", raising=False)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            doctor_cmd.doctor_cmd, ["--check-storage-boundary"]
+        )
+        assert result.exit_code == 0  # advisory
+        assert "outside.py" in result.output
+
+    def test_unrelated_attribute_calls_are_not_flagged(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """``obj.connect()`` where obj is not a sqlite3 import is OK."""
+        pkg = tmp_path / "nexus"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "daemon").mkdir()
+        (pkg / "daemon" / "__init__.py").write_text("")
+        cmd = pkg / "commands"
+        cmd.mkdir()
+        (cmd / "__init__.py").write_text("")
+        (cmd / "doctor.py").write_text("")
+        (pkg / "innocent.py").write_text(
+            "class Client:\n"
+            "    def connect(self): pass\n"
+            "def use():\n"
+            "    Client().connect()\n"
+        )
+
+        monkeypatch.setattr(
+            doctor_cmd, "__file__", str(pkg / "commands" / "doctor.py")
+        )
+        monkeypatch.delenv("NX_STORAGE_MODE", raising=False)
+
+        exit_code = doctor_cmd._run_check_storage_boundary()
+        assert exit_code == 0


### PR DESCRIPTION
## Summary

Two paired RDR-112 fixes from the 360° critique that close the single-writer boundary leaks the prior arc left open. Both beads sit under epic nexus-wlkf (cockpit single-writer boundary).

### nexus-x65c — Cockpit panels route through daemon under \`NX_STORAGE_MODE=daemon\`

The cockpit's \`active-claims\` and \`recent-events\` panels opened \`sqlite3.connect(f'file:{tuples.db}?mode=ro', uri=True)\` unconditionally. Under \`NX_STORAGE_MODE=daemon\` the daemon owns \`tuples.db\` as the single SQLite writer (RDR-112 §9, RDR-110 §Step 4). The panels' second connection bypassed the daemon's serialisation guarantee and risked WAL conflicts; the prior \"safe read-only\" assumption did not survive the architectural review.

- \`TuplespaceService\` grows two read RPCs (\`list_active_claims\`, \`recent_events\`) that mirror the SQL the panels run today. Returns are JSON-friendly \`list[dict]\` for wire round-trip.
- \`_TuplespaceProxy\` on \`T2Client\` gains the matching methods.
- \`cockpit.py\` \`_render_active_claims\` / \`_render_recent_events\` branch on \`NX_STORAGE_MODE\`: daemon mode goes through \`find_t2_daemon\` → \`T2Client.tuplespace.<rpc>\`, hydrating \`ClaimRow\` / \`EventRow\` from the dicts. Standalone mode keeps the direct-read path.
- Daemon mode with a missing discovery file fails loud via \`ClickException\`; no silent fallback to direct-read.
- \`active-bindings\` panel reads YAML and is unaffected.

### nexus-b7o1 — \`nx doctor --check-storage-boundary\` AST lint (RDR-112 §5)

Without a mechanical lint, future regressions sneak past review even though the runtime path is now fixed.

- AST-scans \`src/nexus/**/*.py\` for \`sqlite3.connect\` and \`_sqlite3.connect\` calls. Allowed under \`src/nexus/daemon/\`, violation everywhere else.
- Severity is environment-gated: advisory (exit 0) when \`NX_STORAGE_MODE\` is unset; hard fail (exit 2) under \`NX_STORAGE_MODE=daemon\` so CI gates can lock the boundary.
- Today's scan surfaces 34 staged-remediation sites in \`db/\`, \`tuplespace/\`, \`catalog/\`, and several commands. The bead explicitly does NOT require fixing them, only detecting.

## Closes

- Closes nexus-x65c
- Closes nexus-b7o1

## Refs

- nexus-g7yy (RDR-110-113 critique remediation)

## Test plan

- [x] \`uv run pytest tests/cockpit/test_panels_daemon_mode.py\` — 4 passed (new)
- [x] \`uv run pytest tests/commands/test_doctor_storage_boundary.py\` — 5 passed (new)
- [x] \`uv run pytest tests/cockpit/ tests/daemon/ tests/commands/test_doctor_storage_boundary.py\` — 347 passed
- [ ] CI green

### New regression coverage

- Daemon-routed \`active-claims\` and \`recent-events\` rendering (with \`patch.object\` asserting no direct \`sqlite3.connect\` under daemon mode).
- Missing-discovery fail-loud under daemon mode.
- Standalone direct-read path preserved.
- Lint synthetic-tree pass (daemon-only) and fail (with violation), aliased-import detection, advisory vs hard-fail severity, unrelated \`.connect()\` calls not flagged.