### PR TITLE
fix(rdr-112): pre-migration backup + recovery procedure (nexus-uvv1)

### DIFF
--- a/docs/operations/migration-recovery.md
+++ b/docs/operations/migration-recovery.md
@@ -1,0 +1,120 @@
+# Migration Recovery (RDR-112, nexus-uvv1)
+
+The T2 daemon is the sole migration runner for `memory.db` and
+`tuples.db` (RDR-112 §9). Migrations run before the daemon binds
+sockets, so no client ever sees a partially-migrated schema. A
+migration that fails partway through the registry is still survivable:
+the daemon takes a snapshot before it touches the database.
+
+## What gets backed up
+
+Before `run_daemon_migrations` calls `apply_pending`, the daemon copies
+`memory.db` to a sibling backup file:
+
+```
+~/.config/nexus/memory.db.bak-<from_version>-<unix_ms>
+```
+
+- `<from_version>` is the version stored in `_nexus_version.cli_version`
+  before any migration runs (for fresh installs it is `0.0.0`).
+- `<unix_ms>` is the wall-clock time of the snapshot in milliseconds.
+- The copy uses SQLite's `Connection.backup()` (online backup API).
+  It cooperates with WAL mode and produces a consistent snapshot of
+  every committed page.
+
+Backups are taken only when migrations would actually run, i.e. when
+`from_version != current_version`. Same-version no-op opens skip the
+snapshot.
+
+The latest three backups are kept; older ones are pruned automatically
+to cap disk use. Adjust the retention with care: each backup is
+roughly the size of the live database.
+
+## Opting out
+
+```
+export NX_MIGRATION_BACKUP=0   # also "false" / "False"
+```
+
+Tests under `tmp_path` use this to keep fixtures fast. Production
+should leave it unset.
+
+## Recovering from a failed migration
+
+If `run_daemon_migrations` raises and the daemon refuses to start, the
+log line that fired right before the failure pins which migration
+broke:
+
+```
+INFO migration_step_start  name="..." introduced="x.y.z"
+ERROR migration_step_failed ...        # or unhandled exception
+```
+
+Recovery procedure:
+
+1. **Stop the daemon** (if any process is still up):
+
+   ```
+   nx daemon t2 stop
+   ```
+
+2. **Inspect the backups** beside the live database:
+
+   ```
+   ls -lt ~/.config/nexus/memory.db.bak-*
+   ```
+
+   The newest one was taken right before the migration ran. Its
+   `from_version` tells you what schema state it captures.
+
+3. **Decide on a remedy**:
+
+   - **Roll back and downgrade `conexus`** so the registry's
+     `current_version` falls back below the failing migration. The
+     daemon now sees `from_version == current_version` and skips the
+     bad migration on next start:
+
+     ```
+     cp memory.db memory.db.failed-$(date +%s)
+     cp memory.db.bak-<from_version>-<ms> memory.db
+     uv tool install --reinstall conexus==<previous_version>
+     nx daemon t2 start --foreground
+     ```
+
+   - **Stay on the current `conexus` and fix the migration in place**
+     by editing the failing function in
+     `src/nexus/db/migrations.py`, then re-running. Keep the original
+     backup until you've verified the fix.
+
+   - **Force re-run from the backup**: `nx upgrade --force` resets the
+     stored version to `0.0.0` and reapplies the whole migration list
+     against the backup-restored database. Use only when individual
+     migrations are confirmed idempotent.
+
+4. **Verify integrity** before re-binding sockets:
+
+   ```
+   sqlite3 memory.db "PRAGMA integrity_check;"
+   sqlite3 memory.db "SELECT value FROM _nexus_version WHERE key='cli_version';"
+   ```
+
+5. **Restart the daemon** and confirm the migration log records
+   `migration_step_done` for every migration up to `to_version`.
+
+## Why an outer `BEGIN/COMMIT` is not used
+
+A wholesale transaction wrapper around the migration list looked
+tempting but several entries call `conn.commit()` mid-function (large
+backfills, `executescript` calls, DDL touching FTS5 virtual tables).
+Wrapping those in an outer transaction would either re-enter SQLite or
+fight WAL-mode invariants for `ALTER TABLE`. The hybrid approach is:
+
+- Each migration is responsible for its own atomicity boundaries.
+- A pre-migration backup gives the operator a clean rollback point if
+  any migration partial-fails.
+- `MigrationRetry` (the sanctioned partial-failure path, e.g. catalog
+  not yet present) is unchanged: it returns and asks for a retry on
+  next open without marking the run done.
+
+See `apply_pending` and `run_daemon_migrations` in
+`src/nexus/db/migrations.py` for the implementation.

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import sqlite3
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -3880,6 +3881,14 @@ def run_daemon_migrations(
         memory_conn.commit()
 
         from_version = bootstrap_version(memory_conn)
+        # nexus-uvv1 (RDR-112): snapshot memory.db before migrations run
+        # so partial-failure mid-list leaves a recoverable backup beside
+        # the live file. Skipped on same-version no-op runs (nothing to
+        # migrate) and when NX_MIGRATION_BACKUP=0 is set. The backup is
+        # taken AFTER bootstrap_version so the version table exists in
+        # the snapshot, before apply_pending touches anything else.
+        if from_version != current_version:
+            _backup_db_pre_migration(memory_db_path, from_version=from_version)
         apply_pending(memory_conn, current_version)
         # Read version after migration (may not change on same-version runs)
         row = memory_conn.execute(
@@ -3931,3 +3940,115 @@ def _pkg_version_str() -> str:
     """Return the running ``conexus`` package version string."""
     from importlib.metadata import version as _iv
     return _iv("conexus")
+
+
+# ---------------------------------------------------------------------------
+# Pre-migration backups (nexus-uvv1, RDR-112)
+# ---------------------------------------------------------------------------
+
+#: How many pre-migration backups to keep per database file.
+_MIGRATION_BACKUP_KEEP: int = 3
+
+
+def _migration_backup_disabled() -> bool:
+    """Return True if pre-migration backups are opted out.
+
+    ``NX_MIGRATION_BACKUP=0`` (or ``false`` / ``False``) skips backup
+    creation. Tests under tmp_path set this to keep fixtures fast and
+    deterministic. Production should leave it unset.
+    """
+    import os as _os
+
+    val = _os.environ.get("NX_MIGRATION_BACKUP", "").strip()
+    return val in ("0", "false", "False")
+
+
+def _backup_sqlite_db(src_path: Path, dest_path: Path) -> None:
+    """Copy a live SQLite database file using the online backup API.
+
+    SQLite's ``Connection.backup()`` is WAL-safe: it cooperates with the
+    write-ahead log and produces a consistent snapshot even with
+    concurrent readers. We open the source read-only and the destination
+    on a fresh empty connection, then call ``backup`` in a single page.
+    """
+    src = sqlite3.connect(f"file:{src_path}?mode=ro", uri=True)
+    try:
+        dest = sqlite3.connect(str(dest_path))
+        try:
+            src.backup(dest)
+        finally:
+            dest.close()
+    finally:
+        src.close()
+
+
+def _backup_db_pre_migration(
+    db_path: Path, *, from_version: str
+) -> Path | None:
+    """Snapshot ``db_path`` before a migration runs. Returns the backup path.
+
+    Backup filename: ``<db>.bak-<from_version>-<unix_ms>``. Skipped when
+    the DB file does not yet exist (fresh install) or when the operator
+    opted out via ``NX_MIGRATION_BACKUP=0``. Failures degrade open: log
+    and continue rather than block the daemon's startup migration.
+    """
+    if _migration_backup_disabled():
+        return None
+    if not db_path.exists():
+        return None
+    timestamp_ms = int(time.time() * 1000)
+    safe_from = from_version.replace("/", "_").replace("\\", "_")
+    dest = db_path.with_name(f"{db_path.name}.bak-{safe_from}-{timestamp_ms}")
+    try:
+        _backup_sqlite_db(db_path, dest)
+    except (sqlite3.Error, OSError) as exc:
+        _log.warning(
+            "migration_backup_failed",
+            db_path=str(db_path),
+            error=str(exc),
+        )
+        try:
+            dest.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return None
+    _log.info(
+        "migration_backup_created",
+        db_path=str(db_path),
+        backup_path=str(dest),
+        from_version=from_version,
+    )
+    _prune_old_backups(db_path)
+    return dest
+
+
+def _prune_old_backups(db_path: Path, *, keep: int = _MIGRATION_BACKUP_KEEP) -> int:
+    """Keep only the newest ``keep`` backups for ``db_path``. Returns count removed."""
+    prefix = f"{db_path.name}.bak-"
+    parent = db_path.parent
+    if not parent.is_dir():
+        return 0
+    candidates = sorted(
+        (p for p in parent.iterdir() if p.is_file() and p.name.startswith(prefix)),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    removed = 0
+    for stale in candidates[keep:]:
+        try:
+            stale.unlink()
+            removed += 1
+        except OSError as exc:
+            _log.warning(
+                "migration_backup_prune_failed",
+                path=str(stale),
+                error=str(exc),
+            )
+    if removed:
+        _log.info(
+            "migration_backup_pruned",
+            db_path=str(db_path),
+            kept=keep,
+            removed=removed,
+        )
+    return removed

--- a/tests/db/test_migration_backup.py
+++ b/tests/db/test_migration_backup.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Pre-migration backup helpers (RDR-112, nexus-uvv1).
+
+The T2 daemon snapshots ``memory.db`` before ``apply_pending`` runs so
+a partial-failure mid-list leaves a recoverable backup beside the live
+file. Tests cover the backup primitive, the orchestrator helper, the
+opt-out env var, and the retention pruner.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from nexus.db import migrations as migrations_mod
+
+
+def _seed_db(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+        conn.executemany(
+            "INSERT INTO t (name) VALUES (?)",
+            [("alice",), ("bob",), ("carol",)],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _count_rows(path: Path) -> int:
+    conn = sqlite3.connect(str(path))
+    try:
+        return conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+    finally:
+        conn.close()
+
+
+class TestBackupSqliteDb:
+    """The low-level backup primitive uses SQLite's online backup API."""
+
+    def test_copies_full_database(self, tmp_path: Path) -> None:
+        src = tmp_path / "src.db"
+        dst = tmp_path / "src.db.bak"
+        _seed_db(src)
+
+        migrations_mod._backup_sqlite_db(src, dst)
+        assert dst.exists()
+        assert _count_rows(dst) == 3
+
+    def test_backup_is_self_consistent_with_wal(self, tmp_path: Path) -> None:
+        """WAL mode source still produces a consistent snapshot."""
+        src = tmp_path / "src.db"
+        _seed_db(src)
+        conn = sqlite3.connect(str(src))
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("INSERT INTO t (name) VALUES ('dave')")
+            conn.commit()
+        finally:
+            conn.close()
+
+        dst = tmp_path / "wal-src.db.bak"
+        migrations_mod._backup_sqlite_db(src, dst)
+        assert _count_rows(dst) == 4
+
+
+class TestBackupDbPreMigration:
+    """The orchestrator helper applies the env gate + naming + retention."""
+
+    def test_creates_backup_with_versioned_name(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.delenv("NX_MIGRATION_BACKUP", raising=False)
+        src = tmp_path / "memory.db"
+        _seed_db(src)
+
+        result = migrations_mod._backup_db_pre_migration(
+            src, from_version="4.32.12"
+        )
+        assert result is not None
+        assert result.exists()
+        assert result.name.startswith("memory.db.bak-4.32.12-")
+        assert _count_rows(result) == 3
+
+    def test_skipped_when_env_opted_out(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("NX_MIGRATION_BACKUP", "0")
+        src = tmp_path / "memory.db"
+        _seed_db(src)
+
+        result = migrations_mod._backup_db_pre_migration(
+            src, from_version="4.32.12"
+        )
+        assert result is None
+        siblings = list(tmp_path.glob("memory.db.bak-*"))
+        assert siblings == []
+
+    @pytest.mark.parametrize("falsy", ["0", "false", "False"])
+    def test_recognises_falsy_opt_outs(
+        self, tmp_path: Path, monkeypatch, falsy: str
+    ) -> None:
+        monkeypatch.setenv("NX_MIGRATION_BACKUP", falsy)
+        src = tmp_path / "memory.db"
+        _seed_db(src)
+        assert (
+            migrations_mod._backup_db_pre_migration(src, from_version="x")
+            is None
+        )
+
+    def test_missing_db_file_skips_backup(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Fresh installs (no DB on disk yet) skip the backup cleanly."""
+        monkeypatch.delenv("NX_MIGRATION_BACKUP", raising=False)
+        src = tmp_path / "absent.db"
+        assert (
+            migrations_mod._backup_db_pre_migration(src, from_version="0.0.0")
+            is None
+        )
+
+
+class TestPruneOldBackups:
+    """Retention keeps the newest N and removes the rest."""
+
+    def test_prunes_to_keep_limit(self, tmp_path: Path) -> None:
+        src = tmp_path / "memory.db"
+        src.write_text("")  # path must exist for the .parent walk
+
+        # Create five backup files with increasing mtime.
+        for i in range(5):
+            p = tmp_path / f"memory.db.bak-old-{i}"
+            p.write_text("snapshot")
+            mtime = time.time() - (10 - i)  # earliest first
+            import os as _os
+            _os.utime(p, (mtime, mtime))
+
+        removed = migrations_mod._prune_old_backups(src, keep=2)
+        assert removed == 3
+        survivors = sorted(p.name for p in tmp_path.glob("memory.db.bak-*"))
+        # Two newest (indices 3 and 4) survive.
+        assert survivors == ["memory.db.bak-old-3", "memory.db.bak-old-4"]
+
+    def test_no_op_when_under_limit(self, tmp_path: Path) -> None:
+        src = tmp_path / "memory.db"
+        src.write_text("")
+        (tmp_path / "memory.db.bak-only-one").write_text("snapshot")
+
+        removed = migrations_mod._prune_old_backups(src, keep=3)
+        assert removed == 0
+        assert len(list(tmp_path.glob("memory.db.bak-*"))) == 1
+
+
+class TestRunDaemonMigrationsBackup:
+    """End-to-end: daemon startup snapshots memory.db before migrating."""
+
+    def test_backup_taken_when_from_version_differs(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.delenv("NX_MIGRATION_BACKUP", raising=False)
+        memory_db = tmp_path / "memory.db"
+        tuples_db = tmp_path / "tuples.db"
+
+        # Seed memory.db with the version-tracking row at an older version
+        # so apply_pending sees a non-zero from_version. We don't run actual
+        # migrations because all current MIGRATIONS list entries are >=
+        # 4.33.0 — the package version (4.32.12) keeps them filtered out.
+        conn = sqlite3.connect(str(memory_db))
+        try:
+            conn.execute(
+                "CREATE TABLE _nexus_version (key TEXT PRIMARY KEY, value TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO _nexus_version (key, value) VALUES "
+                "('cli_version', '0.0.0')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        migrations_mod.run_daemon_migrations(memory_db, tuples_db)
+
+        backups = sorted(tmp_path.glob("memory.db.bak-0.0.0-*"))
+        assert backups, "expected a backup file beside memory.db"
+        # Backup contains the original schema state.
+        bak_conn = sqlite3.connect(str(backups[0]))
+        try:
+            value = bak_conn.execute(
+                "SELECT value FROM _nexus_version WHERE key='cli_version'"
+            ).fetchone()
+        finally:
+            bak_conn.close()
+        assert value[0] == "0.0.0"
+
+    def test_no_backup_when_from_version_matches_current(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.delenv("NX_MIGRATION_BACKUP", raising=False)
+        memory_db = tmp_path / "memory.db"
+        tuples_db = tmp_path / "tuples.db"
+
+        # Set stored version equal to the current package version so
+        # apply_pending sees nothing to do.
+        current = migrations_mod._pkg_version_str()
+        conn = sqlite3.connect(str(memory_db))
+        try:
+            conn.execute(
+                "CREATE TABLE _nexus_version (key TEXT PRIMARY KEY, value TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO _nexus_version (key, value) VALUES "
+                "('cli_version', ?)",
+                (current,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        migrations_mod.run_daemon_migrations(memory_db, tuples_db)
+
+        assert list(tmp_path.glob("memory.db.bak-*")) == []
+
+    def test_opt_out_skips_backup_even_with_version_drift(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("NX_MIGRATION_BACKUP", "0")
+        memory_db = tmp_path / "memory.db"
+        tuples_db = tmp_path / "tuples.db"
+        conn = sqlite3.connect(str(memory_db))
+        try:
+            conn.execute(
+                "CREATE TABLE _nexus_version (key TEXT PRIMARY KEY, value TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO _nexus_version (key, value) VALUES "
+                "('cli_version', '0.0.0')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        migrations_mod.run_daemon_migrations(memory_db, tuples_db)
+        assert list(tmp_path.glob("memory.db.bak-*")) == []


### PR DESCRIPTION
## Summary

\`nexus-uvv1\` from the RDR-110/111/112/113 360° critique. The T2 daemon is the sole migration runner for \`memory.db\` and \`tuples.db\` (RDR-112 §9). A migration that raises mid-list previously left the database in a partially-migrated state with no operator-friendly recovery path. \`apply_pending\` wraps each individual migration with its own commit boundary but a wholesale \`BEGIN/COMMIT\` around the list is not safe (several entries call \`conn.commit()\` mid-function, and DDL inside an outer transaction fights WAL-mode invariants).

This PR takes the hybrid approach from the bead enrichment: per-migration atomicity is left to each function (already in place), plus a pre-migration snapshot via SQLite's online backup API gives the operator a clean rollback point.

### Implementation

- \`migrations.py\` grows \`_backup_sqlite_db\` (low-level wrapper around \`Connection.backup\`, WAL-safe), \`_backup_db_pre_migration\` (orchestrator helper applying the env gate and naming), and \`_prune_old_backups\` (retention to cap disk use).
- \`run_daemon_migrations\` snapshots \`memory.db\` AFTER \`bootstrap_version\` (so the version table is in the backup) and BEFORE \`apply_pending\` touches anything else. Skipped when \`from_version == current_version\` (nothing to migrate) and when \`NX_MIGRATION_BACKUP\` is set to a falsy value.
- Backup filename: \`<db>.bak-<from_version>-<unix_ms>\`. The latest 3 snapshots survive; older ones are pruned automatically.

### Docs

\`docs/operations/migration-recovery.md\` walks operators through the recovery procedure: locate the most recent backup beside the live database, restore via \`cp\` + downgrade, or apply \`nx upgrade --force\` after manual remediation. Documents why outer \`BEGIN/COMMIT\` is not used and where \`MigrationRetry\` sits in the failure model.

## Closes

- Closes nexus-uvv1

## Refs

- nexus-g7yy (RDR-110-113 critique remediation)

## Test plan

- [x] \`uv run pytest tests/db/test_migration_backup.py\` — 13 passed (new)
- [x] \`uv run pytest tests/db/ tests/daemon/\` — 263 passed
- [ ] CI green

### New regression coverage

- Low-level \`_backup_sqlite_db\` copies full database, including WAL.
- Orchestrator helper creates the versioned-name backup, respects \`NX_MIGRATION_BACKUP={0,false,False}\`, skips when source DB is absent.
- \`_prune_old_backups\` keeps newest N and removes the rest.
- \`run_daemon_migrations\` end-to-end: backup taken on version drift, skipped at same-version no-op, opt-out env honoured.