### PR TITLE
feat(rdr-112): first-run autostart nudge + nx doctor --check-autostart

### DIFF
--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -149,6 +149,12 @@ def main(ctx: click.Context, verbose: bool) -> None:
     from nexus.commands._migration_prompt import maybe_emit_bootstrap_prompt
     maybe_emit_bootstrap_prompt()
 
+    # nexus-mf91 (RDR-112): first-run TTY nudge to install the T2
+    # daemon autostart unit. Silent in CI / subagent / non-TTY contexts
+    # and after the first nudge per machine.
+    from nexus.commands._autostart_prompt import maybe_emit_autostart_prompt
+    maybe_emit_autostart_prompt()
+
 
 main.add_command(catalog)
 main.add_command(cockpit_group, name="cockpit")

--- a/src/nexus/commands/_autostart_prompt.py
+++ b/src/nexus/commands/_autostart_prompt.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 first-run autostart nudge (nexus-mf91).
+
+The T2 daemon's autostart unit (launchd plist on macOS, systemd user
+unit on Linux) ships under ``nx daemon t2 install --autostart``. There
+is no post-install hook (pip wheels don't run them), no plugin-side
+SessionStart prompt, and no doctor auto-remediation. First-time users
+silently get direct-mode SQLite opens with no cross-process state
+sharing, and bridge writes during the manual-start window contend with
+the daemon when one is eventually started.
+
+This module is the human-visible nudge layer. On a TTY, when:
+
+  - the autostart unit is not installed,
+  - the operator has not opted out (``NX_STORAGE_MODE=direct`` or the
+    ``no_autostart_nudge`` marker file),
+  - this is not a CI / subagent / non-interactive context,
+
+``maybe_emit_autostart_prompt()`` prints a single actionable warning to
+stderr naming ``nx daemon t2 install --autostart`` and writes the
+marker file so subsequent invocations stay quiet. The same diagnostic
+is also available on demand via ``nx doctor --check-autostart`` for
+ongoing visibility.
+
+Auto-install with consent prompt was considered (bead Option A) and
+declined: modifying ``~/Library/LaunchAgents`` or
+``~/.config/systemd/user`` from an arbitrary CLI invocation is too
+invasive. The strongly-worded warning + explicit command-name route
+respects operator agency.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import click
+
+# Module-scoped sentinel — fire the prompt at most once per process.
+_PROMPTED: bool = False
+
+# Operator escape hatches (any non-empty value disables; "0"/"false" do
+# not). NEXUS_NO_PROMPTS matches the existing bootstrap prompt.
+_NO_PROMPTS_ENV = "NEXUS_NO_PROMPTS"
+_NUDGE_MARKER_NAME = "no_autostart_nudge"
+
+
+def _stderr_is_tty() -> bool:
+    """Wrapper that swallows AttributeError/ValueError from edge cases.
+
+    Factored out of ``maybe_emit_autostart_prompt`` so tests can mock
+    the TTY check cleanly without wrestling with pytest's ``capsys``
+    redirection of ``sys.stderr``.
+    """
+    try:
+        return bool(sys.stderr.isatty())
+    except (AttributeError, ValueError):
+        return False
+
+
+def _is_supported_platform() -> bool:
+    return sys.platform == "darwin" or sys.platform.startswith("linux")
+
+
+def _autostart_unit_path() -> Path | None:
+    """Return the per-OS autostart unit path, or ``None`` on unsupported OS."""
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "LaunchAgents" / "com.nexus.t2.plist"
+    if sys.platform.startswith("linux"):
+        return (
+            Path.home()
+            / ".config"
+            / "systemd"
+            / "user"
+            / "nexus-t2.service"
+        )
+    return None
+
+
+def _is_autostart_installed() -> bool:
+    """True if the per-OS autostart unit file is present on disk."""
+    path = _autostart_unit_path()
+    return path is not None and path.exists()
+
+
+def _nudge_marker_path() -> Path:
+    """Marker that records 'operator has been nudged once'."""
+    from nexus.config import nexus_config_dir
+
+    return nexus_config_dir() / _NUDGE_MARKER_NAME
+
+
+def _looks_like_subagent() -> bool:
+    """Heuristic: a subagent / MCP-spawned ``nx`` invocation.
+
+    Per the mf91 enrichment, prompting from a Claude Code subagent's
+    tool call is noise — the operator is not at the terminal even
+    though stderr may technically be a TTY. ``CLAUDECODE`` is set by
+    Claude Code's harness; ``NX_T1_HOST`` is set when a parent process
+    has already addressed a per-session T1 chroma server (subagents
+    inherit it).
+    """
+    if os.environ.get("CLAUDECODE", "").strip():
+        return True
+    if os.environ.get("NX_T1_HOST", "").strip():
+        return True
+    return False
+
+
+def _looks_like_ci() -> bool:
+    """Standard CI-environment heuristic.
+
+    ``CI=true`` is set by GitHub Actions, CircleCI, GitLab, Travis,
+    Buildkite, and most other runners. We accept any non-empty
+    ``CI`` value as a CI signal.
+    """
+    return bool(os.environ.get("CI", "").strip())
+
+
+def autostart_status() -> dict[str, object]:
+    """Structured status of the autostart subsystem.
+
+    Used by ``nx doctor --check-autostart`` to render the same
+    information the prompt surfaces, on demand. Safe to call from any
+    context (no TTY / env / marker gating).
+    """
+    path = _autostart_unit_path()
+    return {
+        "platform_supported": _is_supported_platform(),
+        "unit_path": str(path) if path is not None else None,
+        "installed": _is_autostart_installed(),
+        "marker_present": _nudge_marker_path().exists()
+        if _is_supported_platform()
+        else False,
+        "storage_mode": os.environ.get("NX_STORAGE_MODE", "").strip().lower()
+        or None,
+    }
+
+
+def maybe_emit_autostart_prompt() -> None:
+    """Emit the autostart nudge to stderr if every gate clears.
+
+    Best-effort: any exception during the gate logic suppresses the
+    prompt rather than disrupting the CLI invocation. The prompt is
+    advisory; the underlying state is available through
+    ``nx doctor --check-autostart``.
+
+    Gate order is cheap-to-expensive: the in-process ``_PROMPTED``
+    sentinel runs first, then env-only checks, then the
+    filesystem-touching ones.
+    """
+    global _PROMPTED
+    if _PROMPTED:
+        return
+
+    if not _is_supported_platform():
+        return
+
+    # TTY gate: stderr must be a TTY (operator at a real terminal).
+    if not _stderr_is_tty():
+        return
+
+    # NEXUS_NO_PROMPTS escape hatch (shared with the bootstrap prompt).
+    raw = os.environ.get(_NO_PROMPTS_ENV, "").strip().lower()
+    if raw in ("1", "true", "yes", "on"):
+        return
+
+    # NX_STORAGE_MODE=direct is the documented opt-out: the operator
+    # explicitly chose direct mode and does not want a daemon at all.
+    storage_mode = os.environ.get("NX_STORAGE_MODE", "").strip().lower()
+    if storage_mode == "direct":
+        return
+
+    # CI / subagent contexts: humans are not watching stderr.
+    if _looks_like_ci() or _looks_like_subagent():
+        return
+
+    # Filesystem gates last. Marker present means we already nudged on
+    # this machine; autostart installed means there is nothing to nudge.
+    try:
+        marker = _nudge_marker_path()
+        if marker.exists():
+            return
+        if _is_autostart_installed():
+            return
+    except OSError:
+        return
+
+    _PROMPTED = True
+    click.echo(
+        "WARNING: T2 daemon autostart not installed.\n"
+        "  Cross-process state sharing (cockpit panels, bindings, daemon-\n"
+        "  routed tuplespace) is degraded to direct-mode SQLite opens.\n"
+        "  Run `nx daemon t2 install --autostart` to install the launchd\n"
+        "  (macOS) or systemd user (Linux) unit so the daemon comes up at\n"
+        "  login. Suppress this nudge with NEXUS_NO_PROMPTS=1, or set\n"
+        "  NX_STORAGE_MODE=direct to opt out of the daemon entirely.",
+        err=True,
+    )
+
+    # Best-effort marker write so we only nudge once per machine. A
+    # write failure (read-only home, full disk) is logged and ignored;
+    # the worst-case repeat is one more nudge next invocation.
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("nudged\n")
+    except OSError:
+        pass

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -837,6 +837,61 @@ def _run_check_post_store_hooks() -> None:
     click.echo(f"\nTotal: {total} hook(s) registered across 3 chains.")
 
 
+# ── --check-autostart (RDR-112; nexus-mf91) ──────────────────────────────
+
+
+def _run_check_autostart(*, json_out: bool = False) -> None:
+    """Report whether the T2 daemon autostart unit is installed.
+
+    Complements the first-run TTY nudge in
+    ``nexus.commands._autostart_prompt``: tells the operator the same
+    thing the nudge says, on demand, with no TTY / marker gating. Use
+    when the nudge has already been silenced or the operator wants the
+    state without rerunning ``nx daemon t2 install --autostart``.
+    """
+    import json as _json
+
+    from nexus.commands._autostart_prompt import autostart_status
+
+    status = autostart_status()
+
+    if json_out:
+        click.echo(_json.dumps(status))
+        return
+
+    click.echo("Autostart status (RDR-112):")
+    if not status["platform_supported"]:
+        click.echo(
+            _check(
+                "platform supported",
+                False,
+                f"sys.platform={sys.platform!r} (only darwin and linux are supported)",
+            )
+        )
+        return
+    click.echo(_check("platform supported", True))
+    click.echo(f"  unit path: {status['unit_path']}")
+    click.echo(_check("autostart installed", bool(status["installed"])))
+    click.echo(
+        _check(
+            "nudge marker written",
+            bool(status["marker_present"]),
+            "operator has been nudged once"
+            if status["marker_present"]
+            else "no nudge fired yet on this machine",
+        )
+    )
+    if status["storage_mode"]:
+        click.echo(f"  NX_STORAGE_MODE: {status['storage_mode']}")
+    if not status["installed"]:
+        click.echo("")
+        click.echo(
+            "Hint: `nx daemon t2 install --autostart` to install the "
+            "launchd plist (macOS) or systemd user unit (Linux) so the "
+            "daemon comes up at login."
+        )
+
+
 # ── --check-bridge (RDR-111 deep-review pass — bridge installability) ─────
 
 
@@ -1238,6 +1293,16 @@ def _run_check_mineru() -> None:
          "least one tuple landed in the last 24h.",
 )
 @click.option(
+    "--check-autostart",
+    "check_autostart",
+    is_flag=True,
+    default=False,
+    help="Report T2 daemon autostart unit status (RDR-112 nexus-mf91): "
+         "platform support, unit path, whether the launchd plist or "
+         "systemd user unit is installed, and whether the once-per-"
+         "machine nudge marker has fired.",
+)
+@click.option(
     "--days",
     "days",
     default=30,
@@ -1259,6 +1324,7 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
                check_aspect_queue: bool,
                check_t1: bool,
                check_bridge: bool,
+               check_autostart: bool,
                check_tier_discipline: bool) -> None:
     """Verify that all required services and credentials are available."""
     if check_schema:
@@ -1316,6 +1382,10 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
 
     if check_bridge:
         _run_check_bridge()
+        return
+
+    if check_autostart:
+        _run_check_autostart(json_out=json_out)
         return
 
     if check_tier_discipline:

--- a/tests/commands/test_autostart_prompt.py
+++ b/tests/commands/test_autostart_prompt.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""First-run autostart nudge (RDR-112, nexus-mf91).
+
+Tests cover the gate logic (TTY, env opt-outs, marker, CI, subagent),
+the marker write side effect, and the structured ``autostart_status``
+helper used by ``nx doctor --check-autostart``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nexus.commands import _autostart_prompt as ap
+
+
+@pytest.fixture(autouse=True)
+def _reset_prompted_sentinel():
+    """Reset the once-per-process sentinel between tests."""
+    ap._PROMPTED = False
+    yield
+    ap._PROMPTED = False
+
+
+@pytest.fixture
+def isolated_config(tmp_path: Path, monkeypatch):
+    """Point nexus_config_dir() at a tmp dir so the marker write is sandboxed."""
+    monkeypatch.setattr(
+        "nexus.config.nexus_config_dir", lambda: tmp_path / "nexus"
+    )
+    return tmp_path / "nexus"
+
+
+@pytest.fixture
+def tty_stderr(monkeypatch):
+    """Make the module's TTY gate report True."""
+    monkeypatch.setattr(ap, "_stderr_is_tty", lambda: True)
+
+
+def _clean_env(monkeypatch) -> None:
+    """Clear every env var the gate logic consults."""
+    for name in (
+        "NEXUS_NO_PROMPTS",
+        "NX_STORAGE_MODE",
+        "CI",
+        "CLAUDECODE",
+        "NX_T1_HOST",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeEmitAutostartPrompt:
+    """Gate-by-gate semantics of the once-per-machine nudge."""
+
+    def test_prompts_when_all_gates_clear(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        capsys,
+        isolated_config,
+        tty_stderr,
+    ) -> None:
+        _clean_env(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(
+            ap, "_is_autostart_installed", lambda: False
+        )
+
+        ap.maybe_emit_autostart_prompt()
+        err = capsys.readouterr().err
+        assert "T2 daemon autostart not installed" in err
+        # Marker file should be written.
+        assert (isolated_config / ap._NUDGE_MARKER_NAME).exists()
+
+    def test_does_not_prompt_when_already_prompted_in_process(
+        self, monkeypatch, capsys, isolated_config, tty_stderr
+    ) -> None:
+        _clean_env(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(ap, "_is_autostart_installed", lambda: False)
+
+        ap.maybe_emit_autostart_prompt()
+        first = capsys.readouterr().err
+        ap.maybe_emit_autostart_prompt()
+        second = capsys.readouterr().err
+
+        assert "autostart not installed" in first
+        assert second == ""
+
+    def test_does_not_prompt_when_stderr_not_a_tty(
+        self, monkeypatch, capsys, isolated_config
+    ) -> None:
+        _clean_env(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(ap, "_is_autostart_installed", lambda: False)
+        monkeypatch.setattr(ap, "_stderr_is_tty", lambda: False)
+
+        ap.maybe_emit_autostart_prompt()
+        assert capsys.readouterr().err == ""
+        assert not (isolated_config / ap._NUDGE_MARKER_NAME).exists()
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on"])
+    def test_nexus_no_prompts_suppresses(
+        self,
+        monkeypatch,
+        capsys,
+        isolated_config,
+        tty_stderr,
+        value: str,
+    ) -> None:
+        _clean_env(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(ap, "_is_autostart_installed", lambda: False)
+        monkeypatch.setenv("NEXUS_NO_PROMPTS", value)
+
+        ap.maybe_emit_autostart_prompt()
+        assert capsys.readouterr().err == ""
+
+    def test_nx_storage_mode_direct_suppresses(
+        self, monkeypatch, capsys, isolated_config, tty_stderr
+    ) -> None:
+        _clean_env(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(ap, "_is_autostart_installed", lambda: False)
+        monkeypatch.setenv("NX_STORAGE_MODE", "direct")
+
+        ap.maybe_emit_autostart_prompt()
+        assert capsys.readouterr().err == ""
+
+    def test_ci_env_suppresses(
+        self, monkeypatch, capsys, isolated_config, tty_stderr
+    ) -> None:
+        _clean_env(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(ap, "_is_autostart_installed", lambda: False)
+        monkeypatch.setenv("CI", "true")
+
+        ap.maybe_emit_autostart_prompt()
+        assert capsys.readouterr().err == ""
+
+    @pytest.mark.parametrize("var", ["CLAUDECODE", "NX_T1_HOST"])
+    def test_subagent_env_suppresses(
+        self,
+        monkeypatch,
+        capsys,
+        isolated_config,
+        tty_stderr,
+        var: str,
+    ) -> None:
+        _clean_env(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(ap, "_is_autostart_installed", lambda: False)
+        monkeypatch.setenv(var, "1")
+
+        ap.maybe_emit_autostart_prompt()
+        assert capsys.readouterr().err == ""
+
+    def test_unsupported_platform_skips(
+        self, monkeypatch, capsys, isolated_config, tty_stderr
+    ) -> None:
+        _clean_env(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "win32")
+
+        ap.maybe_emit_autostart_prompt()
+        assert capsys.readouterr().err == ""
+
+    def test_marker_present_suppresses(
+        self, monkeypatch, capsys, isolated_config, tty_stderr
+    ) -> None:
+        _clean_env(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(ap, "_is_autostart_installed", lambda: False)
+        # Pre-seed the marker so the nudge has already fired once.
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        (isolated_config / ap._NUDGE_MARKER_NAME).write_text("nudged\n")
+
+        ap.maybe_emit_autostart_prompt()
+        assert capsys.readouterr().err == ""
+
+    def test_already_installed_suppresses(
+        self, monkeypatch, capsys, isolated_config, tty_stderr
+    ) -> None:
+        _clean_env(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(ap, "_is_autostart_installed", lambda: True)
+
+        ap.maybe_emit_autostart_prompt()
+        assert capsys.readouterr().err == ""
+
+
+# ---------------------------------------------------------------------------
+# autostart_status helper (consumed by `nx doctor --check-autostart`)
+# ---------------------------------------------------------------------------
+
+
+class TestAutostartStatus:
+    def test_darwin_path_shape(self, monkeypatch) -> None:
+        monkeypatch.setattr(sys, "platform", "darwin")
+        status = ap.autostart_status()
+        assert status["platform_supported"] is True
+        assert status["unit_path"].endswith(
+            "/Library/LaunchAgents/com.nexus.t2.plist"
+        )
+
+    def test_linux_path_shape(self, monkeypatch) -> None:
+        monkeypatch.setattr(sys, "platform", "linux")
+        status = ap.autostart_status()
+        assert status["platform_supported"] is True
+        assert status["unit_path"].endswith(
+            "/.config/systemd/user/nexus-t2.service"
+        )
+
+    def test_unsupported_platform(self, monkeypatch) -> None:
+        monkeypatch.setattr(sys, "platform", "win32")
+        status = ap.autostart_status()
+        assert status["platform_supported"] is False
+        assert status["unit_path"] is None
+        assert status["installed"] is False
+
+    def test_storage_mode_surfaced(self, monkeypatch) -> None:
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+        assert ap.autostart_status()["storage_mode"] == "daemon"


### PR DESCRIPTION
## Summary

\`nexus-mf91\` closes the autostart discovery gap from the RDR-110/111/112/113 360° critique. The autostart machinery has shipped (nexus-6w0c) but nothing surfaces the missing unit to first-time users; they silently get direct-mode SQLite opens and cross-process state sharing is quietly degraded. With ooxh + o6g9 now landed (PR #823), the install path is correct and we can safely point users at it.

**Approach**: strongly-worded TTY warning naming the exact command, firing once per machine, with a doctor flag for ongoing visibility. Auto-install with consent prompt (bead Option A) was declined as too invasive for an arbitrary CLI invocation.

### What ships

- **\`src/nexus/commands/_autostart_prompt.py\`** mirrors the existing \`_migration_prompt.py\` pattern. Probes the per-OS autostart unit path (\`darwin\`: \`~/Library/LaunchAgents/com.nexus.t2.plist\`; \`linux\`: \`~/.config/systemd/user/nexus-t2.service\`). When every gate clears, emits a stderr WARNING naming the install command and writes a \`no_autostart_nudge\` marker to \`~/.config/nexus/\` so subsequent invocations stay quiet.
- **Gates** (cheap-to-expensive): once-per-process sentinel, supported platform, stderr-is-TTY, \`NEXUS_NO_PROMPTS\`, \`NX_STORAGE_MODE=direct\`, \`CI\` env, subagent heuristic (\`CLAUDECODE\` / \`NX_T1_HOST\`), marker file, autostart installed. Filesystem checks last; any exception is swallowed rather than disrupting the CLI.
- **\`cli.py\` \`main()\`** calls \`maybe_emit_autostart_prompt()\` right after \`maybe_emit_bootstrap_prompt()\` so both nudges share the same fire-once-per-invocation TTY context.
- **\`doctor.py\`** grows \`_run_check_autostart\` and the \`--check-autostart\` flag. Returns the same structured status the nudge surfaces, on demand, with no TTY / marker / env gating. \`--json\` supported for tooling.

## Closes

- Closes nexus-mf91

## Refs

- nexus-g7yy (RDR-110-113 critique remediation)
- Builds on PR #823 (ooxh + o6g9 autostart fixes — merged)

## Test plan

- [x] \`uv run pytest tests/commands/test_autostart_prompt.py\` — 18 passed (new)
- [x] \`uv run pytest tests/commands/\` — 52 passed
- [ ] CI green

### Test coverage

- Happy path emits the warning and writes the marker.
- Once-per-process sentinel suppresses the second call.
- Each of these individually suppresses: stderr-not-TTY, \`NEXUS_NO_PROMPTS={1,true,yes,on}\`, \`NX_STORAGE_MODE=direct\`, \`CI\`, \`CLAUDECODE\`, \`NX_T1_HOST\`, unsupported-platform (win32), marker-present, autostart-already-installed.
- \`autostart_status()\` returns the right unit path for darwin / linux, marks win32 unsupported, surfaces \`NX_STORAGE_MODE\`.