### PR TITLE
feat(rdr-112): daemon hardening (non-blocking startup, install errors, rotated logs)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1466,7 +1466,7 @@ against path-traversal exploits via crafted args. Streaming via
 ### t2 install / uninstall
 
 ```
-nx daemon t2 install --autostart
+nx daemon t2 install --autostart [--force]
 nx daemon t2 uninstall --autostart
 ```
 
@@ -1478,6 +1478,24 @@ bootstrap gui/$UID`. On Linux: writes
 enable --now nexus-t2.service`. The plist's `KeepAlive: Crashed` and
 the unit's `SuccessExitStatus=143` cooperate so `nx daemon t2 stop`
 does not trigger an instant respawn.
+
+| Flag | Description |
+|------|-------------|
+| `--autostart` | Required. Selects the autostart install mode. |
+| `--force` | Treat supervisor activation failures (`launchctl` / `systemctl` exit non-zero, or binary missing on PATH) as warnings instead of errors. The plist/unit file is still written. Useful in CI or shells without a GUI session where `launchctl bootstrap` cannot complete. |
+
+Exit codes: `0` on success or on activation failure with `--force`;
+`1` if the plist/unit file was written but supervisor activation
+failed without `--force` (so CI / scripts that check `$?` see the
+failure instead of silently continuing with non-functional autostart).
+
+Daemon logging: the launchd plist and systemd unit append daemon
+stderr to `__LOG_DIR__/nexus-t2.log` (and `.err`). That file is the
+supervisor crash-diagnostics stream and is not rotated by launchd /
+systemd. The bounded primary daemon log is
+`~/.config/nexus/logs/daemon.log` (10 MB rotation, 5 backups), where
+steady-state telemetry (retention sweep, RPC accept, binding watcher
+reactions) lands via the in-process `RotatingFileHandler`.
 
 ### t2 subspace add
 

--- a/nx/daemon/com.nexus.t2.plist
+++ b/nx/daemon/com.nexus.t2.plist
@@ -5,6 +5,14 @@
   Installed by ``nx daemon t2 install --autostart``. The ``__NX_BIN__``
   placeholder is substituted at install time with the resolved absolute
   path to the ``nx`` executable.
+
+  nexus-uuuh: ``StandardOutPath`` / ``StandardErrorPath`` here are the
+  launchd-captured supervisor stream — used for interpreter crash
+  diagnostics (tracebacks, fork failures). The bounded primary daemon
+  log is ``~/.config/nexus/logs/daemon.log`` (10 MB rotation, 5 backups,
+  written via nexus.logging_setup.configure_logging("daemon")). launchd
+  does not rotate its capture file; if it grows large, the rotated log
+  is the canonical source of recent events.
 -->
 <plist version="1.0">
 <dict>

--- a/nx/daemon/nexus-t2.service
+++ b/nx/daemon/nexus-t2.service
@@ -2,6 +2,14 @@
 ## Installed by ``nx daemon t2 install --autostart``. The ``__NX_BIN__``
 ## placeholder is substituted at install time with the resolved absolute
 ## path to the ``nx`` executable.
+##
+## nexus-uuuh: ``StandardOutput`` / ``StandardError`` below capture the
+## supervisor stream — used for interpreter crash diagnostics. The
+## bounded primary daemon log is at ``~/.config/nexus/logs/daemon.log``
+## (10 MB rotation, 5 backups, written via
+## nexus.logging_setup.configure_logging("daemon")). systemd-journald
+## or ``append:`` capture has no built-in rotation; the rotated log is
+## the canonical source of recent events.
 
 [Unit]
 Description=Nexus T2 daemon (memory + tuplespace)

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -86,11 +86,19 @@ def start_cmd(config_dir_str: str | None, foreground: bool) -> None:
     With --foreground the process blocks until SIGTERM or SIGINT.
     Without --foreground (default) the process daemonises and returns
     immediately with the discovery JSON printed to stdout.
+
+    nexus-uuuh: configures a RotatingFileHandler at
+    ``~/.config/nexus/logs/daemon.log`` (10 MB, 5 backups). The
+    launchd/systemd-captured stderr stream becomes a crash-diagnostics
+    log only; steady-state telemetry is bounded by the rotation here.
     """
     from nexus.daemon.subspace_registry import RegistryStore
     from nexus.daemon.t2_daemon import T2Daemon
     from nexus.daemon.tuplespace_service import TuplespaceService
     from nexus.db.t2 import T2Database
+    from nexus.logging_setup import configure_logging
+
+    configure_logging("daemon")
 
     config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
     memory_db_path = config_dir / "memory.db"
@@ -728,7 +736,18 @@ def _autostart_filename() -> str:
         "unit on Linux) so the T2 daemon starts at login / boot."
     ),
 )
-def install_cmd(autostart: bool) -> None:
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help=(
+        "Treat supervisor activation failures (launchctl/systemctl exit "
+        "non-zero, or binary missing on PATH) as warnings instead of "
+        "errors. The plist/unit file is still written. Useful for CI "
+        "or shells without a GUI session where bootstrap fails."
+    ),
+)
+def install_cmd(autostart: bool, force: bool) -> None:
     """Install the T2 daemon autostart entry for the current user.
 
     macOS: writes ~/Library/LaunchAgents/com.nexus.t2.plist and bootstraps
@@ -736,6 +755,13 @@ def install_cmd(autostart: bool) -> None:
 
     Linux: writes ~/.config/systemd/user/nexus-t2.service and enables it
     via ``systemctl --user enable --now nexus-t2.service``.
+
+    Exit codes:
+      0 - install + activation both succeeded, or activation failed under
+          ``--force`` (warning emitted, file still on disk).
+      1 - file installed but supervisor activation failed (no ``--force``).
+          Operators or CI scripts that check ``$?`` see the failure and can
+          react instead of silently continuing with non-functional autostart.
     """
     if not autostart:  # pragma: no cover -- click enforces required=True
         raise click.UsageError("--autostart is required")
@@ -764,20 +790,25 @@ def install_cmd(autostart: bool) -> None:
         cmd = ["launchctl", "bootstrap", f"gui/{uid}", str(dest)]
     else:
         cmd = ["systemctl", "--user", "enable", "--now", template_name]
+    label = "Warning" if force else "Error"
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     except FileNotFoundError as exc:
         click.echo(
-            f"Warning: {cmd[0]} not found on PATH; file installed but not activated ({exc}).",
+            f"{label}: {cmd[0]} not found on PATH; file installed but not activated ({exc}).",
             err=True,
         )
+        if not force:
+            sys.exit(1)
         return
     if result.returncode != 0:
         click.echo(
-            f"Warning: {' '.join(cmd)} exited {result.returncode}: "
+            f"{label}: {' '.join(cmd)} exited {result.returncode}: "
             f"{result.stderr.strip() or result.stdout.strip()}",
             err=True,
         )
+        if not force:
+            sys.exit(1)
         return
     click.echo(f"Activated via: {' '.join(cmd)}")
 

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -607,6 +607,11 @@ class T2Daemon:
         # Started in start(); cancelled in stop().
         self._retention_task: asyncio.Task | None = None  # type: ignore[type-arg]
 
+        # nexus-r7dy: startup-sweep future (dispatched in start() via
+        # run_in_executor). Held so stop() can wait for it briefly during
+        # graceful shutdown without re-entering it.
+        self._startup_sweep_future: asyncio.Future[Any] | None = None
+
         # nexus-9eiw (RDR-111 §Phase 2 Step 6): binding watcher reaction loop.
         # Constructed in start() when NX_COCKPIT_BINDINGS_DISABLE is not set
         # and at least one binding profile is loaded. Stopped in stop().
@@ -724,11 +729,15 @@ class T2Daemon:
 
         # nexus-kk9h: run one retention sweep at startup and schedule a
         # recurring 6-hour sweep. Done after sockets bind so clients can
-        # connect immediately; the sweep itself is short and SQLite-only.
-        try:
-            self._run_retention_sweep_sync()
-        except Exception as exc:  # pragma: no cover — defensive
-            _log.warning("retention_sweep_startup_failed", error=str(exc))
+        # connect immediately. nexus-r7dy: dispatch the startup sweep via
+        # ``run_in_executor`` and do not await it; on a ``tuples.db`` with
+        # weeks of expired rows the DELETE can block socket-bind completion
+        # for seconds-to-minutes. The future is held only so the daemon
+        # can surface failures in the scheduled-loop's warning path.
+        loop = asyncio.get_running_loop()
+        self._startup_sweep_future = loop.run_in_executor(
+            None, self._run_retention_sweep_sync
+        )
         self._retention_task = asyncio.create_task(self._retention_loop())
 
         # nexus-9eiw (RDR-111 §Phase 2 Step 6): start the binding watcher

--- a/src/nexus/logging_setup.py
+++ b/src/nexus/logging_setup.py
@@ -43,7 +43,7 @@ def _resolve_level(mode: str, verbose: bool) -> int:
 
 
 def configure_logging(
-    mode: Literal["cli", "console", "mcp", "hook", "watchdog"],
+    mode: Literal["cli", "console", "mcp", "hook", "watchdog", "daemon"],
     verbose: bool = False,
 ) -> None:
     """Configure logging for the given nexus entry point.
@@ -58,10 +58,15 @@ def configure_logging(
     Modes:
       * ``cli``: stderr only, WARNING default. Kept legacy-compatible so
         the human-facing CLI does not gain noise from this change.
-      * ``console`` / ``mcp`` / ``hook`` / ``watchdog``: stderr +
-        RotatingFileHandler at ``<config_dir>/logs/<mode>.log``, INFO
-        default. Lifecycle events, tool dispatches, and structured
-        warnings now land in the log file.
+      * ``console`` / ``mcp`` / ``hook`` / ``watchdog`` / ``daemon``:
+        stderr + RotatingFileHandler at ``<config_dir>/logs/<mode>.log``,
+        INFO default. Lifecycle events, tool dispatches, and structured
+        warnings now land in the log file. ``daemon`` (nexus-uuuh) is the
+        bounded primary log for the T2 daemon — launchd/systemd capture
+        of stderr is retained for interpreter crash diagnostics, but
+        steady-state telemetry (retention sweep, RPC accept, binding
+        watcher reactions) is rotated here so the supervisor-captured
+        file does not grow unbounded.
 
     The level is overridable via the ``NEXUS_LOG_LEVEL`` env var; useful
     for one-off DEBUG runs without code changes.

--- a/tests/commands/test_daemon_autostart.py
+++ b/tests/commands/test_daemon_autostart.py
@@ -256,3 +256,106 @@ def test_install_without_autostart_flag_errors() -> None:
     runner = CliRunner()
     result = runner.invoke(daemon_cmd.daemon_group, ["t2", "install"])
     assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# nexus-xqos: subprocess activation failures propagate as non-zero exit
+# ---------------------------------------------------------------------------
+
+
+def test_install_autostart_exits_nonzero_on_launchctl_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """nexus-xqos: ``launchctl bootstrap`` failure must surface as non-zero exit.
+
+    Pre-fix the warning was printed and the command exited 0; CI/automation
+    pipelines checking ``$?`` saw success and moved on with non-functional
+    autostart.
+    """
+    _set_platform(monkeypatch, "darwin")
+    monkeypatch.setattr(daemon_cmd, "_autostart_install_dir", lambda: tmp_path / "LaunchAgents")
+    monkeypatch.setattr(daemon_cmd, "_autostart_log_dir", lambda: tmp_path / "logs")
+    monkeypatch.setattr(daemon_cmd, "_resolve_nx_bin", lambda: ["/opt/nx/bin/nx"])
+
+    with patch.object(daemon_cmd.subprocess, "run") as mock_run:
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = "Bootstrap failed: 5: Input/output error"
+        mock_run.return_value.stdout = ""
+        runner = CliRunner()
+        result = runner.invoke(
+            daemon_cmd.daemon_group, ["t2", "install", "--autostart"]
+        )
+
+    assert result.exit_code != 0, result.output
+    # stderr from the subprocess is surfaced in the user-facing error.
+    assert "Bootstrap failed" in result.output
+
+
+def test_install_autostart_exits_nonzero_on_systemctl_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """nexus-xqos: ``systemctl --user enable`` failure must surface as non-zero exit."""
+    _set_platform(monkeypatch, "linux")
+    monkeypatch.setattr(daemon_cmd, "_autostart_install_dir", lambda: tmp_path / "systemd")
+    monkeypatch.setattr(daemon_cmd, "_autostart_log_dir", lambda: tmp_path / "logs")
+    monkeypatch.setattr(daemon_cmd, "_resolve_nx_bin", lambda: ["/opt/nx/bin/nx"])
+
+    with patch.object(daemon_cmd.subprocess, "run") as mock_run:
+        mock_run.return_value.returncode = 5
+        mock_run.return_value.stderr = "Failed to enable unit: Unit nexus-t2.service not found."
+        mock_run.return_value.stdout = ""
+        runner = CliRunner()
+        result = runner.invoke(
+            daemon_cmd.daemon_group, ["t2", "install", "--autostart"]
+        )
+
+    assert result.exit_code != 0, result.output
+    assert "Failed to enable unit" in result.output
+
+
+def test_install_autostart_force_downgrades_failure_to_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--force`` flag preserves the legacy warn-and-continue behaviour.
+
+    Some CI runners cannot bootstrap launchd jobs (no GUI session); operators
+    who only want the plist on disk can pass ``--force`` to suppress the
+    activation failure.
+    """
+    _set_platform(monkeypatch, "darwin")
+    monkeypatch.setattr(daemon_cmd, "_autostart_install_dir", lambda: tmp_path / "LaunchAgents")
+    monkeypatch.setattr(daemon_cmd, "_autostart_log_dir", lambda: tmp_path / "logs")
+    monkeypatch.setattr(daemon_cmd, "_resolve_nx_bin", lambda: ["/opt/nx/bin/nx"])
+
+    with patch.object(daemon_cmd.subprocess, "run") as mock_run:
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = "Bootstrap failed"
+        mock_run.return_value.stdout = ""
+        runner = CliRunner()
+        result = runner.invoke(
+            daemon_cmd.daemon_group, ["t2", "install", "--autostart", "--force"]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Warning" in result.output or "warning" in result.output
+
+
+def test_install_autostart_filenotfound_still_exits_nonzero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """nexus-xqos: missing supervisor binary (FileNotFoundError) is also a failure."""
+    _set_platform(monkeypatch, "darwin")
+    monkeypatch.setattr(daemon_cmd, "_autostart_install_dir", lambda: tmp_path / "LaunchAgents")
+    monkeypatch.setattr(daemon_cmd, "_autostart_log_dir", lambda: tmp_path / "logs")
+    monkeypatch.setattr(daemon_cmd, "_resolve_nx_bin", lambda: ["/opt/nx/bin/nx"])
+
+    def _raise_fnf(*args, **kwargs):
+        raise FileNotFoundError("[Errno 2] launchctl: not found")
+
+    with patch.object(daemon_cmd.subprocess, "run", side_effect=_raise_fnf):
+        runner = CliRunner()
+        result = runner.invoke(
+            daemon_cmd.daemon_group, ["t2", "install", "--autostart"]
+        )
+
+    assert result.exit_code != 0, result.output

--- a/tests/daemon/test_t2_daemon_transport.py
+++ b/tests/daemon/test_t2_daemon_transport.py
@@ -393,3 +393,46 @@ async def test_spawn_lock_prevents_double_start(config_dir: Path) -> None:
             await d2.start()
     finally:
         await d1.stop()
+
+
+# ---------------------------------------------------------------------------
+# nexus-r7dy: startup retention sweep is non-blocking
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_startup_retention_sweep_is_non_blocking(
+    config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``start()`` must not await the startup retention sweep (nexus-r7dy).
+
+    Pre-fix, the sweep ran synchronously inline. On a ``tuples.db`` with weeks
+    of expired rows that DELETE blocked socket binding completion.
+
+    Post-fix, the sweep is dispatched via ``loop.run_in_executor`` without
+    being awaited, so ``start()`` returns promptly while the sweep runs in
+    the daemon's default executor.
+    """
+    import threading
+
+    sweep_called = threading.Event()
+    can_finish = threading.Event()
+    sweep_finished = threading.Event()
+
+    def _slow_sweep(self):
+        sweep_called.set()
+        can_finish.wait(timeout=15.0)
+        sweep_finished.set()
+        return 0
+
+    monkeypatch.setattr(T2Daemon, "_run_retention_sweep_sync", _slow_sweep)
+    daemon = T2Daemon(config_dir=config_dir)
+    try:
+        await asyncio.wait_for(daemon.start(), timeout=5.0)
+        assert sweep_called.wait(timeout=2.0), "sweep was never dispatched"
+        assert not sweep_finished.is_set(), (
+            "start() should not have awaited the sweep to completion"
+        )
+    finally:
+        can_finish.set()
+        await daemon.stop()

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -82,6 +82,31 @@ def test_mcp_mode_creates_file_handler(tmp_path, monkeypatch):
         h.close()
 
 
+def test_daemon_mode_creates_rotating_file_handler(tmp_path, monkeypatch):
+    """nexus-uuuh: daemon mode wires a RotatingFileHandler at logs/daemon.log.
+
+    The launchd plist and systemd unit append daemon stderr to an unbounded
+    log file. Without an in-process rotating handler, steady-state INFO on
+    every retention sweep + RPC accept grew that file unbounded. The daemon
+    mode mirrors mcp/console: 10 MB rotation, 5 backups, INFO default.
+    """
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+    configure_logging("daemon")
+    log_path = tmp_path / "logs" / "daemon.log"
+    root = logging.getLogger()
+    file_handlers = [
+        h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
+    ]
+    assert len(file_handlers) == 1
+    assert file_handlers[0].baseFilename == str(log_path)
+    assert file_handlers[0].maxBytes == 10 * 1024 * 1024
+    assert file_handlers[0].backupCount == 5
+    # Cleanup
+    for h in file_handlers:
+        root.removeHandler(h)
+        h.close()
+
+
 def test_noisy_loggers_suppressed():
     configure_logging("cli")
     for name in ("httpx", "httpcore", "chromadb.telemetry", "opentelemetry"):


### PR DESCRIPTION
## Summary

Bundle 2 of the RDR-110-113 P1 critique sweep. Three operational-hardening items, all touching the daemon lifecycle and install surface:

- **nexus-r7dy** Dispatch the startup retention sweep via `loop.run_in_executor` and do not await it. Pre-fix the sweep ran synchronously inline; on a `tuples.db` with weeks of expired rows the DELETE blocked socket binding for seconds-to-minutes.
- **nexus-xqos** `nx daemon t2 install --autostart` now exits non-zero when `launchctl bootstrap` or `systemctl --user enable` fails. Previously the warning was emitted but the command exited 0, so CI saw success with non-functional autostart. New `--force` flag preserves the legacy warn-and-continue behaviour for headless runners.
- **nexus-uuuh** New `"daemon"` mode in `configure_logging` wires a `RotatingFileHandler` at `~/.config/nexus/logs/daemon.log` (10 MB rotation by 5 backups). launchd/systemd capture of stderr remains for interpreter crash diagnostics; steady-state telemetry now rotates so the supervisor-captured file does not grow unbounded.

## Verification

```
uv run pytest tests/daemon/ tests/commands/test_daemon_autostart.py \
              tests/commands/test_tuplespace_cli.py tests/test_logging_setup.py \
              tests/cockpit/ tests/commands/test_autostart_prompt.py tests/test_doctor_cmd.py
# 498 passed (no regressions, 5 new tests added)
```

New tests:
- `tests/daemon/test_t2_daemon_transport.py::test_startup_retention_sweep_is_non_blocking`
- `tests/commands/test_daemon_autostart.py::test_install_autostart_exits_nonzero_on_launchctl_failure`
- `tests/commands/test_daemon_autostart.py::test_install_autostart_exits_nonzero_on_systemctl_failure`
- `tests/commands/test_daemon_autostart.py::test_install_autostart_force_downgrades_failure_to_warning`
- `tests/commands/test_daemon_autostart.py::test_install_autostart_filenotfound_still_exits_nonzero`
- `tests/test_logging_setup.py::test_daemon_mode_creates_rotating_file_handler`

## Closes

- Closes nexus-r7dy
- Closes nexus-xqos
- Closes nexus-uuuh

Parent epic: `nexus-gdb3` (daemon hardening) — umbrella `nexus-g7yy`.