### PR TITLE
test(rdr-112): tighten transport tests; cover event_stream error paths

### DIFF
--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -90,7 +90,13 @@ from typing import IO, Any
 
 import structlog
 
-from nexus.daemon.peer import PeerCredentials, read_peer_credentials
+# nexus-04zd: import the ``peer`` module rather than its functions so the
+# call site (`peer.read_peer_credentials(...)`) resolves through the source
+# module's binding. Tests can then patch the source attribute and have it
+# affect this daemon's lookup, instead of having to patch a local name
+# bound at this module's import time.
+from nexus.daemon import peer
+from nexus.daemon.peer import PeerCredentials
 
 _log = structlog.get_logger(__name__)
 
@@ -932,7 +938,7 @@ class T2Daemon:
         # --- Peer-cred check (UDS only) ---
         if is_uds:
             try:
-                creds: PeerCredentials = read_peer_credentials(raw_sock)
+                creds: PeerCredentials = peer.read_peer_credentials(raw_sock)
             except Exception as exc:
                 _log.error("peer_cred_read_failed", exc=str(exc))
                 write_frame(writer, {"error": "peer credential read failed"})

--- a/tests/daemon/test_event_stream.py
+++ b/tests/daemon/test_event_stream.py
@@ -700,3 +700,104 @@ async def test_event_stream_error_frame_has_typed_shape(daemon: T2Daemon) -> Non
     assert isinstance(err, dict), f"expected dict error frame, got {type(err).__name__}: {err!r}"
     assert err.get("type") == "InvalidArgument"
     assert "subspace_prefix" in err.get("message", "")
+
+
+# ---------------------------------------------------------------------------
+# (k) nexus-egok: subscribe without subspace_prefix returns InvalidArgument
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_stream_subscribe_missing_subspace_prefix(
+    daemon: T2Daemon,
+) -> None:
+    """``event_stream.subscribe`` without ``subspace_prefix`` returns InvalidArgument.
+
+    Existing coverage rejected GLOB metachars in the prefix; the absent /
+    empty prefix path (``args={}``) was untested. event_stream.py guards
+    this with the same ``{type: 'InvalidArgument', message: ...}`` error
+    frame shape as the GLOB-rejection path.
+    """
+    import asyncio as _asyncio
+    from nexus.daemon.t2_daemon import (
+        DAEMON_PROTOCOL_VERSION,
+        read_frame,
+        write_frame,
+    )
+
+    reader, writer = await _asyncio.open_unix_connection(str(daemon.uds_path))
+    try:
+        write_frame(writer, {"op": "hello", "protocol_version": DAEMON_PROTOCOL_VERSION})
+        await writer.drain()
+        await read_frame(reader)  # hello_ack
+        write_frame(writer, {"op": "event_stream.subscribe", "args": {}})
+        await writer.drain()
+        frame = await _asyncio.wait_for(read_frame(reader), timeout=2.0)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+    assert "error" in frame
+    err = frame["error"]
+    assert isinstance(err, dict), f"expected dict error frame, got {type(err).__name__}: {err!r}"
+    assert err.get("type") == "InvalidArgument"
+    assert "subspace_prefix" in err.get("message", "")
+    assert "required" in err.get("message", "")
+
+
+# ---------------------------------------------------------------------------
+# (l) nexus-a3n8: db-open failure surfaces typed error frame
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_stream_subscribe_db_open_failure_returns_error_frame(
+    daemon: T2Daemon,
+    tmp_path: Path,
+) -> None:
+    """``sqlite3.connect`` failure inside subscribe surfaces a typed error frame.
+
+    event_stream.py wraps the ``sqlite3.connect`` call in a try/except so
+    a bad tuples_db_path (one that points at a directory, a locked file,
+    or anything else SQLite cannot open) produces the standard
+    ``{error: {type, message}}`` frame instead of crashing the handler.
+    Force the failure by swapping the daemon's ``_tuples_db_path`` to a
+    directory before sending subscribe.
+    """
+    import asyncio as _asyncio
+    from nexus.daemon.t2_daemon import (
+        DAEMON_PROTOCOL_VERSION,
+        read_frame,
+        write_frame,
+    )
+
+    # sqlite3.connect on a directory raises OperationalError ("unable to
+    # open database file"); pointing the daemon there mid-flight is the
+    # most direct way to force the except branch.
+    bad_path = tmp_path / "tuples_is_a_directory_not_a_file"
+    bad_path.mkdir()
+    daemon._tuples_db_path = bad_path
+
+    reader, writer = await _asyncio.open_unix_connection(str(daemon.uds_path))
+    try:
+        write_frame(writer, {"op": "hello", "protocol_version": DAEMON_PROTOCOL_VERSION})
+        await writer.drain()
+        await read_frame(reader)  # hello_ack
+        write_frame(writer, {
+            "op": "event_stream.subscribe",
+            "args": {"subspace_prefix": "tuples/whatever"},
+        })
+        await writer.drain()
+        frame = await _asyncio.wait_for(read_frame(reader), timeout=2.0)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+    assert "error" in frame, f"expected error frame; got {frame!r}"
+    err = frame["error"]
+    assert isinstance(err, dict), f"expected dict error frame, got {type(err).__name__}: {err!r}"
+    # event_stream uses the exception class name as type; OperationalError
+    # is the most likely from sqlite3 on a directory path, but any non-empty
+    # type label is acceptable.
+    assert err.get("type"), f"error frame must carry a type; got {err!r}"
+    assert "tuples.db" in err.get("message", "") or "failed to open" in err.get("message", "").lower()

--- a/tests/daemon/test_t2_daemon_transport.py
+++ b/tests/daemon/test_t2_daemon_transport.py
@@ -155,32 +155,49 @@ async def test_two_clients_tcp(running_daemon: T2Daemon) -> None:
 
 @pytest.mark.asyncio
 async def test_uds_peer_uid_rejection(config_dir: Path) -> None:
-    """A UDS peer whose UID differs from the daemon's UID is rejected."""
+    """A UDS peer whose UID differs from the daemon's UID is rejected.
+
+    nexus-04zd: the contract is that the daemon writes a typed error frame
+    naming the rejected UID before closing the connection. A bare
+    connection-close (no frame) used to be an acceptable outcome here,
+    which silently passed if the peer-cred check were ever skipped via a
+    regression. We now hard-require the error frame.
+
+    S-7: the monkey patch targets ``nexus.daemon.peer.read_peer_credentials``
+    at source. t2_daemon imports the ``peer`` module and calls
+    ``peer.read_peer_credentials(...)``, so the source-attribute patch is
+    what the call site resolves through.
+    """
     from nexus.daemon.peer import PeerCredentials
 
     daemon = T2Daemon(config_dir=config_dir)
     await daemon.start()
     try:
-        # Patch read_peer_credentials to report a different UID than geteuid().
         foreign_uid = os.geteuid() + 1
         fake_creds = PeerCredentials(pid=9999, uid=foreign_uid, gid=9999)
 
         with patch(
-            "nexus.daemon.t2_daemon.read_peer_credentials",
+            "nexus.daemon.peer.read_peer_credentials",
             return_value=fake_creds,
         ):
             reader, writer = await _connect_uds(daemon.uds_path)
             try:
-                # The daemon should close the connection or send an error
-                # frame before or immediately after the hello.
                 write_frame(writer, {"op": "hello", "protocol_version": DAEMON_PROTOCOL_VERSION})
                 await writer.drain()
                 response = await asyncio.wait_for(read_frame(reader), timeout=2.0)
-                assert "error" in response
-                assert "uid" in response["error"].lower() or "reject" in response["error"].lower()
-            except (asyncio.IncompleteReadError, ConnectionResetError):
-                # Also acceptable: daemon just closes the connection.
-                pass
+                assert "error" in response, (
+                    f"daemon must write a typed error frame for foreign-UID "
+                    f"rejection; got {response!r}"
+                )
+                err_str = response["error"]
+                # Error frame is currently a bare string; tolerate either
+                # legacy string shape or a typed dict shape.
+                err_text = err_str.lower() if isinstance(err_str, str) else (
+                    err_str.get("message", "").lower() + err_str.get("type", "").lower()
+                )
+                assert "uid" in err_text or "reject" in err_text, (
+                    f"error frame must name 'uid' or 'reject'; got {response!r}"
+                )
             finally:
                 writer.close()
                 await writer.wait_closed()
@@ -195,17 +212,30 @@ async def test_uds_peer_uid_rejection(config_dir: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_version_mismatch_rejected(running_daemon: T2Daemon) -> None:
-    """A client with a mismatched protocol_version receives an error and is disconnected."""
+    """A client with a mismatched protocol_version receives an error and is disconnected.
+
+    nexus-04zd: the daemon contract is that an error frame is written
+    naming the version mismatch before the connection closes. A bare
+    close (no frame) is NOT an acceptable substitute; the test used to
+    silently pass on that path, which masked any regression where the
+    daemon failed to produce the error frame.
+    """
     reader, writer = await _connect_uds(running_daemon.uds_path)
     try:
-        # Send hello with an unknown version
         write_frame(writer, {"op": "hello", "protocol_version": "99.99"})
         await writer.drain()
         response = await asyncio.wait_for(read_frame(reader), timeout=2.0)
-        assert "error" in response
-        # After mismatch the connection should be closed
-    except (asyncio.IncompleteReadError, ConnectionResetError):
-        pass  # Also acceptable — daemon closed the stream
+        assert "error" in response, (
+            f"daemon must write a typed error frame for version mismatch; "
+            f"got {response!r}"
+        )
+        err = response["error"]
+        err_text = err.lower() if isinstance(err, str) else (
+            err.get("message", "").lower() + err.get("type", "").lower()
+        )
+        assert "version" in err_text or "protocol" in err_text, (
+            f"error frame must name 'version' or 'protocol'; got {response!r}"
+        )
     finally:
         writer.close()
         await writer.wait_closed()


### PR DESCRIPTION
## Summary

Bundle 3 of the RDR-110-113 P1 critique sweep. Three test-coverage items, all in the daemon test layer.

- **nexus-04zd** Foreign-UID rejection + version-mismatch tests removed their `IncompleteReadError`/`ConnectionResetError` fallback. The daemon's contract is to emit a typed error frame before closing; the lenient fallback would have silently passed any regression that produced a bare close. Also refactor `t2_daemon` to call `peer.read_peer_credentials(...)` through the imported module object so the foreign-UID test can patch the function at source (`nexus.daemon.peer.read_peer_credentials`) and have the patch affect the call site, instead of shadowing a local binding.
- **nexus-egok** New test `test_event_stream_subscribe_missing_subspace_prefix` covers the absent-key branch (existing coverage rejected GLOB metachars in the prefix but not the absent prefix entirely).
- **nexus-a3n8** New test `test_event_stream_subscribe_db_open_failure_returns_error_frame` covers the `sqlite3.connect` failure path by swapping `_tuples_db_path` to a directory before subscribe; the handler returns a typed error frame instead of crashing.

## Verification

```
uv run pytest tests/daemon/
# 238 passed (no regressions; 3 new + 2 tightened tests)
```

## Closes

- Closes nexus-04zd
- Closes nexus-egok
- Closes nexus-a3n8

Parent epic: `nexus-hwy7` (test contract correctness) — umbrella `nexus-g7yy`.