### PR TITLE
sec(rdr-113): sanitize match_text; pin is_uds via explicit handler tag

### DIFF
--- a/src/nexus/cockpit/hook_bridge.py
+++ b/src/nexus/cockpit/hook_bridge.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sqlite3
 import sys
 import time
@@ -501,11 +502,46 @@ def _build_dimensions(hook_type: str, payload: dict[str, Any]) -> dict[str, Any]
     return dims
 
 
+# nexus-es13: ANSI CSI (Control Sequence Introducer) sequences and other
+# C0/C1 control chars must not survive into match_text. The bridge embeds
+# match_text via Voyage and surfaces it in cockpit panels; a malicious
+# tool_input carrying ANSI cursor moves or terminal-control escapes would
+# otherwise be displayed verbatim (log injection / panel scramble).
+_ANSI_CSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_ANSI_OSC_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+_CTRL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def _sanitize_match_text(s: str) -> str:
+    """Strip ANSI escape sequences and disallowed control chars from *s*.
+
+    Keeps printable text, ``\\t``, ``\\n``, ``\\r`` (which are legitimate
+    whitespace), and strips:
+      * ANSI CSI sequences (``ESC [ ... <letter>``) — cursor / colour moves.
+      * ANSI OSC sequences (``ESC ] ... BEL`` or ``ESC \\``) — window-title
+        manipulation and the like.
+      * C0 control bytes 0x00..0x08, 0x0b, 0x0c, 0x0e..0x1f, plus DEL (0x7f).
+        The kept whitespace bytes (TAB 0x09, LF 0x0a, CR 0x0d) are excluded
+        from the strip class so multi-line tool input survives intact.
+
+    Returned strings are safe to embed and to render in cockpit panels.
+    """
+    if not s:
+        return s
+    s = _ANSI_OSC_RE.sub("", s)
+    s = _ANSI_CSI_RE.sub("", s)
+    s = _CTRL_CHARS_RE.sub("", s)
+    return s
+
+
 def _build_match_text(hook_type: str, payload: dict[str, Any]) -> str:
     """Extract the semantic match text for a hook event tuple.
 
     The match text is what gets embedded for semantic search. Each hook
-    type uses the most semantically rich field available.
+    type uses the most semantically rich field available. nexus-es13:
+    control characters and ANSI escape sequences are stripped before
+    returning so a malicious or careless tool_input cannot pollute log
+    output or cockpit-panel rendering.
     """
     match hook_type:
         case "PreToolUse":
@@ -515,31 +551,33 @@ def _build_match_text(hook_type: str, payload: dict[str, Any]) -> str:
                 input_summary = " ".join(str(v) for v in tool_input.values())
             else:
                 input_summary = str(tool_input)
-            return f"{tool} {input_summary}".strip()
+            raw = f"{tool} {input_summary}".strip()
 
         case "PostToolUse":
             tool = payload.get("tool_name", "")
             response = payload.get("tool_response", "")
-            return f"{tool} {response}"[:512].strip()
+            raw = f"{tool} {response}"[:512].strip()
 
         case "SubagentStop":
-            return payload.get("last_assistant_message", "")
+            raw = payload.get("last_assistant_message", "")
 
         case "UserPromptSubmit":
-            return payload.get("prompt", "")
+            raw = payload.get("prompt", "")
 
         case "Notification":
-            return payload.get("message", "")
+            raw = payload.get("message", "")
 
         case "Stop" | "StopFailure":
-            return hook_type
+            raw = hook_type
 
         case "SessionStart" | "SessionEnd":
             cwd = payload.get("cwd", "")
-            return f"{hook_type} {cwd}".strip()
+            raw = f"{hook_type} {cwd}".strip()
 
         case _:
-            return ""
+            raw = ""
+
+    return _sanitize_match_text(raw)
 
 
 _CONTENT_BYTE_CAP = 12000

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -714,10 +714,17 @@ class T2Daemon:
         uds_sock = self._bind_uds()
         tcp_sock = self._bind_tcp()
 
-        # asyncio servers from pre-bound sockets
-        handler = self._make_handler()
-        self._uds_server = await asyncio.start_unix_server(handler, sock=uds_sock)
-        self._tcp_server = await asyncio.start_server(handler, sock=tcp_sock)
+        # asyncio servers from pre-bound sockets. nexus-y6fk: each transport
+        # gets its own handler closure that carries an explicit ``is_uds``
+        # tag, so the admin-RPC gate downstream does not depend on re-
+        # deriving the transport family from ``transport.get_extra_info``
+        # (which can return None for future ssl/proxy wrappers).
+        self._uds_server = await asyncio.start_unix_server(
+            self._make_handler(is_uds=True), sock=uds_sock
+        )
+        self._tcp_server = await asyncio.start_server(
+            self._make_handler(is_uds=False), sock=tcp_sock
+        )
 
         self._write_discovery()
         self._announce_stdout()
@@ -888,8 +895,18 @@ class T2Daemon:
     # Connection handler factory
     # ------------------------------------------------------------------
 
-    def _make_handler(self):
-        """Return the asyncio stream handler coroutine (closure over self)."""
+    def _make_handler(self, *, is_uds: bool):
+        """Return the asyncio stream handler coroutine for one transport.
+
+        nexus-y6fk: the ``is_uds`` tag is captured at handler-construction
+        time (one handler per transport) rather than derived from the
+        connection's ``transport.get_extra_info("socket")`` inside the
+        request loop. Re-derivation was structurally one line away from a
+        silent regression: a future asyncio backend that returned ``None``
+        from ``get_extra_info`` (or wrapped the UDS in a proxy stream
+        whose socket family was not ``AF_UNIX``) would have flipped
+        ``is_uds`` to ``False``, opening admin RPCs to TCP callers.
+        """
 
         async def _handler(
             reader: asyncio.StreamReader, writer: asyncio.StreamWriter
@@ -898,7 +915,7 @@ class T2Daemon:
             if task is not None:
                 self._active_handlers.add(task)
             try:
-                await self._handle_connection(reader, writer)
+                await self._handle_connection(reader, writer, is_uds=is_uds)
             finally:
                 if task is not None:
                     self._active_handlers.discard(task)
@@ -914,6 +931,8 @@ class T2Daemon:
         self,
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
+        *,
+        is_uds: bool,
     ) -> None:
         """Process a single client connection.
 
@@ -922,15 +941,34 @@ class T2Daemon:
           2. Read hello frame; validate protocol_version.
           3. Respond hello_ack.
           4. Serve RPCs until client closes or daemon is stopping.
+
+        Args:
+            is_uds: True if this connection arrived on the UDS server,
+                False for TCP. Threaded from ``_make_handler`` rather than
+                derived from the transport so the admin-RPC gate is
+                immune to future asyncio backend changes (nexus-y6fk).
         """
-        # --- Derive is_uds once (P1.6 nexus-pce1.1) ---
-        # is_uds is threaded into _dispatch to gate admin-only ops.
         transport = writer.transport
         raw_sock: socket.socket | None = transport.get_extra_info("socket")
-        is_uds: bool = raw_sock is not None and raw_sock.family == socket.AF_UNIX
 
         # --- Peer-cred check (UDS only) ---
         if is_uds:
+            # Defense-in-depth: the closure tagged this handler as UDS,
+            # so the underlying transport must be an AF_UNIX socket. If
+            # asyncio surprises us with a missing or non-UNIX socket we
+            # fail closed (no RPC dispatch) rather than fall through and
+            # open admin ops to an unauthenticated peer.
+            if raw_sock is None or raw_sock.family != socket.AF_UNIX:
+                _log.error(
+                    "uds_handler_transport_mismatch",
+                    raw_sock_family=(raw_sock.family if raw_sock is not None else None),
+                )
+                write_frame(
+                    writer,
+                    {"error": "internal: UDS handler received non-UDS transport"},
+                )
+                await writer.drain()
+                return
             try:
                 creds: PeerCredentials = read_peer_credentials(raw_sock)
             except Exception as exc:

--- a/tests/cockpit/test_hook_bridge.py
+++ b/tests/cockpit/test_hook_bridge.py
@@ -950,3 +950,80 @@ class TestScriptCorrectOutput:
         )
         assert result.returncode == 0
         assert result.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# nexus-es13: match_text sanitization (control char and ANSI escape strip)
+# ---------------------------------------------------------------------------
+
+
+class TestMatchTextSanitization:
+    """``_build_match_text`` strips ANSI escape codes and control chars.
+
+    The match_text field is embedded into the tuplespace and rendered
+    inline in cockpit panels. A malicious or careless tool input
+    carrying ANSI cursor moves or terminal-control escapes would
+    otherwise pollute log output or scramble the panel display.
+    """
+
+    def test_strips_ansi_color_csi_from_pretooluse(self) -> None:
+        from nexus.cockpit.hook_bridge import route_payload
+
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "\x1b[31mDANGER\x1b[0m"},
+            "session_id": "s",
+            "cwd": "/p",
+        }
+        result = route_payload("PreToolUse", payload)
+        assert result is not None
+        _, _, match_text = result
+        assert "\x1b" not in match_text
+        assert "[31m" not in match_text
+        assert "[0m" not in match_text
+        assert "DANGER" in match_text
+
+    def test_strips_ansi_osc_from_user_prompt(self) -> None:
+        from nexus.cockpit.hook_bridge import route_payload
+
+        payload = {
+            # OSC 0 ; <title> BEL — sets window title in many terminals.
+            "prompt": "Hello\x1b]0;malicious-title\x07world",
+            "session_id": "s",
+            "cwd": "/p",
+        }
+        result = route_payload("UserPromptSubmit", payload)
+        assert result is not None
+        _, _, match_text = result
+        assert "\x1b" not in match_text
+        assert "malicious-title" not in match_text
+        assert "Hello" in match_text
+        assert "world" in match_text
+
+    def test_strips_c0_control_chars_but_keeps_whitespace(self) -> None:
+        from nexus.cockpit.hook_bridge import _sanitize_match_text
+
+        raw = "before\x00mid\x07\x08end\tspace\nnewline\rcr\x7fdel"
+        sanitized = _sanitize_match_text(raw)
+        # The stripped chars must be gone.
+        for forbidden in ("\x00", "\x07", "\x08", "\x7f"):
+            assert forbidden not in sanitized
+        # Whitespace bytes that are not control noise are preserved.
+        assert "\t" in sanitized
+        assert "\n" in sanitized
+        assert "\r" in sanitized
+        # Text fragments survive.
+        assert "before" in sanitized
+        assert "mid" in sanitized
+        assert "end" in sanitized
+
+    def test_empty_input_returns_empty(self) -> None:
+        from nexus.cockpit.hook_bridge import _sanitize_match_text
+
+        assert _sanitize_match_text("") == ""
+
+    def test_clean_input_passes_through_unchanged(self) -> None:
+        from nexus.cockpit.hook_bridge import _sanitize_match_text
+
+        clean = "ls -la /tmp"
+        assert _sanitize_match_text(clean) == clean

--- a/tests/daemon/test_t2_daemon_transport.py
+++ b/tests/daemon/test_t2_daemon_transport.py
@@ -393,3 +393,82 @@ async def test_spawn_lock_prevents_double_start(config_dir: Path) -> None:
             await d2.start()
     finally:
         await d1.stop()
+
+
+# ---------------------------------------------------------------------------
+# nexus-y6fk: is_uds tag is explicit, not derived from transport extra-info
+# ---------------------------------------------------------------------------
+
+
+def test_make_handler_threads_is_uds_tag(config_dir: Path) -> None:
+    """Each transport's handler closure captures an explicit ``is_uds`` tag.
+
+    Pre-fix, ``_handle_connection`` derived ``is_uds`` from
+    ``transport.get_extra_info("socket")`` at request time. A future
+    asyncio backend that wraps the UDS in a proxy stream (or returns
+    ``None`` from ``get_extra_info``) would have silently flipped
+    ``is_uds`` to ``False``, opening admin RPCs to TCP-shaped callers.
+
+    Post-fix, ``_make_handler(is_uds=True/False)`` is the only place the
+    tag is set; ``_handle_connection`` accepts it as a keyword arg and
+    asserts the underlying socket matches when ``is_uds`` is True.
+    """
+    import inspect
+
+    daemon = T2Daemon(config_dir=config_dir)
+    sig = inspect.signature(daemon._make_handler)
+    assert "is_uds" in sig.parameters, (
+        "_make_handler must accept is_uds as a parameter (nexus-y6fk)"
+    )
+    sig2 = inspect.signature(daemon._handle_connection)
+    assert "is_uds" in sig2.parameters, (
+        "_handle_connection must accept is_uds as a keyword arg (nexus-y6fk)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_uds_handler_rejects_non_uds_transport(config_dir: Path) -> None:
+    """Defense-in-depth: a UDS-tagged handler with a non-AF_UNIX socket fails closed.
+
+    Constructs a UDS handler closure (``is_uds=True``), then invokes
+    ``_handle_connection`` with a transport whose ``get_extra_info`` returns
+    a TCP socket. The handler must respond with an internal-error frame
+    and return without proceeding to the hello / dispatch phase.
+    """
+    daemon = T2Daemon(config_dir=config_dir)
+    # We never actually start the daemon — we drive _handle_connection
+    # directly with a fake reader/writer pair.
+
+    written: list[bytes] = []
+
+    class _FakeTransport:
+        def get_extra_info(self, name: str):
+            if name == "socket":
+                # Hand back a TCP socket (AF_INET) — wrong family for UDS.
+                return socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            return None
+
+    class _FakeWriter:
+        transport = _FakeTransport()
+
+        def write(self, data: bytes) -> None:
+            written.append(data)
+
+        async def drain(self) -> None:
+            pass
+
+        def close(self) -> None:  # pragma: no cover — not exercised here
+            pass
+
+        async def wait_closed(self) -> None:  # pragma: no cover
+            pass
+
+    class _FakeReader:
+        async def readexactly(self, n: int):  # pragma: no cover - not exercised
+            raise asyncio.IncompleteReadError(b"", n)
+
+    await daemon._handle_connection(_FakeReader(), _FakeWriter(), is_uds=True)
+    assert written, "handler must write an internal-error frame for transport mismatch"
+    # Concatenate frame payloads and check for the mismatch sentinel.
+    blob = b"".join(written)
+    assert b"non-UDS" in blob or b"transport" in blob


### PR DESCRIPTION
## Summary

Bundle 4 of the RDR-110-113 P1 critique sweep. Two security defense-in-depth items.

- **nexus-es13** `_build_match_text` strips ANSI escape sequences (CSI + OSC) and C0 control bytes from the embedded match text. Match text is what Voyage embeds AND what cockpit panels render inline; tool input carrying terminal-control escapes would otherwise scramble panel display or inject ANSI markers into operator log lines. Whitespace (TAB/LF/CR) is preserved so multi-line tool input survives.
- **nexus-y6fk** `_make_handler(is_uds=...)` captures the transport tag at handler-construction time (one closure per asyncio server) instead of re-deriving it from `transport.get_extra_info("socket")` inside the request loop. Pre-fix was structurally one line away from a silent regression where a future asyncio backend wrapping UDS in a proxy stream (or returning `None` from `get_extra_info`) would flip `is_uds` to `False` and open admin RPCs to TCP callers. Defense-in-depth assertion refuses dispatch if a UDS-tagged handler receives a non-AF_UNIX transport.

## Verification

```
uv run pytest tests/cockpit/ tests/daemon/
# 384 passed (no regressions; 7 new tests)
```

New tests:
- `tests/cockpit/test_hook_bridge.py::TestMatchTextSanitization` — 5 tests (ANSI-CSI strip, OSC strip, C0-control strip, empty input, clean-input pass-through)
- `tests/daemon/test_t2_daemon_transport.py::test_make_handler_threads_is_uds_tag`
- `tests/daemon/test_t2_daemon_transport.py::test_uds_handler_rejects_non_uds_transport`

## Closes

- Closes nexus-es13
- Closes nexus-y6fk

Parent epic: `nexus-qh9k` (security defense-in-depth) — umbrella `nexus-g7yy`.