### PR TITLE
fix(aspect_readers): select chunks by manifest chash ids when doc_id metadata absent

### DIFF
--- a/src/nexus/aspect_readers.py
+++ b/src/nexus/aspect_readers.py
@@ -273,34 +273,67 @@ def _gather_chroma_chunks_by_field(
                 position = row.get("position")
             if chash and position is not None:
                 chash_position[chash] = int(position)
+    # nexus-m8a7: when the catalog manifest is available, select chunks
+    # by id (chash[:32]) rather than by ``where={doc_id: ...}``. Post
+    # RDR-108 Phase 3 chunks no longer carry ``doc_id`` metadata; the
+    # where-filter returns zero rows even though the manifest knows the
+    # exact chashes. Chroma's natural id IS chash[:32] (RDR-108), so a
+    # batched ``coll.get(ids=...)`` fetches them deterministically.
+    use_manifest_ids = bool(chash_position) and identity_field == "doc_id"
     try:
-        while True:
-            page = coll.get(
-                where={identity_field: match_value},
-                limit=page_limit,
-                offset=offset,
-                include=["documents", "metadatas"],
-            )
-            docs = page.get("documents") or []
-            mds = page.get("metadatas") or []
-            if not docs:
-                break
-            for md, doc in zip(mds, docs):
-                if not doc:
-                    continue
-                if isinstance(md, dict):
-                    chash = md.get("chunk_text_hash", "")
-                    if chash_position and chash in chash_position:
-                        ci = chash_position[chash]
+        if use_manifest_ids:
+            ids = [chash[:32] for chash in chash_position]
+            for batch_start in range(0, len(ids), page_limit):
+                page = coll.get(
+                    ids=ids[batch_start : batch_start + page_limit],
+                    include=["documents", "metadatas"],
+                )
+                docs = page.get("documents") or []
+                mds = page.get("metadatas") or []
+                for md, doc in zip(mds, docs):
+                    if not doc:
+                        continue
+                    if isinstance(md, dict):
+                        chash = md.get("chunk_text_hash", "")
+                        ci = chash_position.get(
+                            chash, int(md.get("chunk_index", 0) or 0)
+                        )
                     else:
-                        ci = int(md.get("chunk_index", 0) or 0)
-                else:
-                    ci = 0
-                chunks.append((ci, seq, doc))
-                seq += 1
-            if len(docs) < page_limit:
-                break
-            offset += page_limit
+                        ci = 0
+                    chunks.append((ci, seq, doc))
+                    seq += 1
+        if not use_manifest_ids or not chunks:
+            # Either no manifest available, or manifest-ids returned
+            # nothing (chunk id ≠ chash[:32] — pre-RDR-108 ingest, or
+            # tests that seed synthetic ids). Fall back to where-filter.
+            offset = 0
+            while True:
+                page = coll.get(
+                    where={identity_field: match_value},
+                    limit=page_limit,
+                    offset=offset,
+                    include=["documents", "metadatas"],
+                )
+                docs = page.get("documents") or []
+                mds = page.get("metadatas") or []
+                if not docs:
+                    break
+                for md, doc in zip(mds, docs):
+                    if not doc:
+                        continue
+                    if isinstance(md, dict):
+                        chash = md.get("chunk_text_hash", "")
+                        if chash_position and chash in chash_position:
+                            ci = chash_position[chash]
+                        else:
+                            ci = int(md.get("chunk_index", 0) or 0)
+                    else:
+                        ci = 0
+                    chunks.append((ci, seq, doc))
+                    seq += 1
+                if len(docs) < page_limit:
+                    break
+                offset += page_limit
     except Exception as e:
         return ReadFail(
             reason="unreachable",

--- a/tests/test_aspect_readers.py
+++ b/tests/test_aspect_readers.py
@@ -341,6 +341,58 @@ class TestReadChromaUri:
         assert result.text == "first\n\nsecond\n\nthird"
         assert result.metadata["manifest_ordered"] is True
 
+    def test_manifest_ids_select_chunks_when_doc_id_metadata_absent(self, t3_client):
+        """nexus-m8a7: post-RDR-108 Phase 3, chunks have no ``doc_id``
+        in metadata. The reader must select chunks by their natural
+        Chroma id (chash[:32]) from the manifest instead of relying on
+        ``where={doc_id: ...}`` which returns zero rows.
+        """
+        from nexus.aspect_readers import ReadOk, _read_chroma_uri
+
+        col_name = "knowledge__phase3-no-doc-id"
+        col = t3_client.get_or_create_collection(col_name)
+        # Seed chunks with NO doc_id and NO source_path metadata — the
+        # exact shape DT-indexed PDFs land with. Chroma id == chash[:32].
+        chashes = ["a" * 64, "b" * 64, "c" * 64]
+        col.upsert(
+            ids=[c[:32] for c in chashes],
+            documents=["first", "second", "third"],
+            metadatas=[
+                {"chunk_text_hash": chashes[0], "title": "paper"},
+                {"chunk_text_hash": chashes[1], "title": "paper"},
+                {"chunk_text_hash": chashes[2], "title": "paper"},
+            ],
+        )
+
+        from dataclasses import dataclass
+
+        @dataclass
+        class _Row:
+            chash: str
+            position: int
+
+        def manifest_lookup(doc_id: str) -> list[_Row]:
+            assert doc_id == "1.99.2"
+            return [
+                _Row(chash=chashes[0], position=0),
+                _Row(chash=chashes[1], position=1),
+                _Row(chash=chashes[2], position=2),
+            ]
+
+        def doc_id_lookup(_coll: str, _sid: str) -> str:
+            return "1.99.2"
+
+        result = _read_chroma_uri(
+            f"chroma://{col_name}/anything",
+            t3=t3_client,
+            doc_id_lookup=doc_id_lookup,
+            manifest_lookup=manifest_lookup,
+        )
+        assert isinstance(result, ReadOk), result
+        assert result.text == "first\n\nsecond\n\nthird"
+        assert result.metadata["chunk_count"] == 3
+        assert result.metadata["manifest_ordered"] is True
+
     def test_no_matching_chunks_returns_read_fail_empty(self, t3_client):
         from nexus.aspect_readers import ReadFail, _read_chroma_uri
 


### PR DESCRIPTION
## Summary
- Post-RDR-108 Phase 3 retired \`doc_id\` from chunk metadata; the aspect reader still selected chunks via \`coll.get(where={doc_id: ...})\` which returns zero rows for any newly-indexed knowledge document (DT-indexed PDFs, etc).
- When a \`manifest_lookup\` is provided, select chunks by ids derived from the manifest's chashes (Chroma natural id == chash[:32] per RDR-108). Falls back to the legacy where-filter when no manifest is available or selection comes up empty (pre-RDR-108 collections, synthetic-id tests).
- New regression test \`test_manifest_ids_select_chunks_when_doc_id_metadata_absent\` seeds chunks with no doc_id and no source_path metadata — the exact shape DT-indexed PDFs land with — and asserts manifest-driven id selection succeeds.

Reproducer that exercised the bug live: \`nx dt index --uuid <UUID>\` for a PDF into \`knowledge__dt-papers__voyage-context-3__v1\`, then \`nx enrich aspects\` — pre-fix returned \`reason=empty\` for every chunk; post-fix extracts cleanly.

## Closes
- Closes nexus-m8a7

## Test plan
- [x] \`uv run pytest tests/test_aspect_readers.py tests/test_aspect_extractor.py tests/test_enrich_aspects.py\` — 172 passed
- [x] Live: \`nx enrich aspects knowledge__dt-papers__voyage-context-3__v1\` extracts the previously-failing DT-indexed PDF