### PR TITLE
fix(taxonomy_cmd): skip _path_resolver under NX_STORAGE_MODE=daemon

### DIFF
--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -21,8 +21,17 @@ def _t2_ctx():
     long-standing test pattern of patching
     ``nexus.commands.taxonomy_cmd._default_db_path`` via the
     ``_path_resolver`` kwarg.
+
+    nexus-qw21: under daemon mode the daemon owns the path; passing
+    ``_path_resolver`` raises in ``mcp_infra.t2_ctx``. Gate the
+    resolver on direct mode so daemon callers go through the RPC
+    shim with no path override, while the test-patch seam still
+    fires under direct mode (where tests run).
     """
+    from nexus.db import is_daemon_mode
     from nexus.mcp_infra import t2_ctx
+    if is_daemon_mode():
+        return t2_ctx()
     return t2_ctx(_path_resolver=_default_db_path)
 
 if TYPE_CHECKING:

--- a/tests/test_rdr112_p0_gate.py
+++ b/tests/test_rdr112_p0_gate.py
@@ -91,12 +91,15 @@ def test_taxonomy_cmd_t2_ctx_delegates_to_mcp_infra(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The shim must route through ``mcp_infra.t2_ctx`` so Phase-1's
-    daemon swap is honoured.
+    daemon swap is honoured. nexus-qw21: pin direct mode so the
+    resolver path is exercised; daemon-mode bypass is covered by the
+    sibling test below.
     """
     from nexus import mcp_infra
     from nexus.commands import taxonomy_cmd
 
     db_path = tmp_path / "memory.db"
+    monkeypatch.setenv("NX_STORAGE_MODE", "direct")
     monkeypatch.setattr(
         "nexus.commands.taxonomy_cmd._default_db_path", lambda: db_path,
     )
@@ -111,6 +114,42 @@ def test_taxonomy_cmd_t2_ctx_delegates_to_mcp_infra(
     call_kwargs = spy.call_args.kwargs
     assert "_path_resolver" in call_kwargs
     assert call_kwargs["_path_resolver"] is taxonomy_cmd._default_db_path
+
+
+def test_taxonomy_cmd_t2_ctx_skips_path_resolver_under_daemon_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """nexus-qw21: under daemon mode the daemon owns the path. The
+    shim must call ``mcp_infra.t2_ctx()`` with no ``_path_resolver``
+    kwarg; passing one raises ``RuntimeError`` in ``mcp_infra``.
+    """
+    from nexus import mcp_infra
+    from nexus.commands import taxonomy_cmd
+
+    monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+
+    # Patch t2_ctx to avoid actually opening a daemon RPC; just observe
+    # the call shape. Returning a no-op context manager keeps the
+    # ``with`` body unreachable but the call itself is what we assert.
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_t2_ctx(**kwargs):
+        # Capture and re-raise the guard if the wrapper accidentally
+        # forwards a resolver — this is the regression we are guarding.
+        if "_path_resolver" in kwargs and kwargs["_path_resolver"] is not None:
+            raise RuntimeError(
+                "regression: _t2_ctx forwarded _path_resolver under daemon mode"
+            )
+        yield None
+
+    with patch.object(mcp_infra, "t2_ctx", side_effect=_fake_t2_ctx) as spy:
+        with taxonomy_cmd._t2_ctx():
+            pass
+
+    spy.assert_called_once()
+    call_kwargs = spy.call_args.kwargs
+    assert "_path_resolver" not in call_kwargs or call_kwargs["_path_resolver"] is None
 
 
 def test_taxonomy_cmd_t2_ctx_respects_default_db_path_patch(


### PR DESCRIPTION
## Summary
\`nx taxonomy <subcommand>\` raised \`RuntimeError\` under \`NX_STORAGE_MODE=daemon\` (now the default after nexus-507q P6.3 cutover, 2026-05-17). Every taxonomy subcommand went through \`_t2_ctx()\` which unconditionally passed \`_path_resolver\` — \`mcp_infra.t2_ctx\` correctly rejects this under daemon mode because the daemon owns the path.

Repro:
\`\`\`
NX_STORAGE_MODE=daemon nx taxonomy review
# or simply: nx taxonomy review  (since unset → daemon post-cutover)
\`\`\`

Fix: gate \`_path_resolver\` on \`not is_daemon_mode()\` in \`_t2_ctx()\`. Daemon callers go through the RPC shim with no path override; direct-mode callers keep the test-patch seam intact.

## Test changes
- Existing \`test_taxonomy_cmd_t2_ctx_delegates_to_mcp_infra\` now explicitly pins \`NX_STORAGE_MODE=direct\` (it was relying on the pre-cutover unset==direct behaviour).
- New \`test_taxonomy_cmd_t2_ctx_skips_path_resolver_under_daemon_mode\` covers the daemon-bypass path with a guard that re-raises if \`_path_resolver\` leaks through.

## Closes
- Closes nexus-qw21

## Test plan
- [x] \`uv run pytest tests/test_rdr112_p0_gate.py\` — 17 passed
- [x] \`uv run pytest tests/test_taxonomy*.py tests/test_index_taxonomy.py\` — 157 passed