### PR TITLE
fix(rdr-112): nexus-3vyw P2 review — C1 init guard + S1 bib_* import + S3 parity test

### DIFF
--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -3079,21 +3079,64 @@ def migrate_catalog_legacy_import(conn: sqlite3.Connection) -> None:
                 "FROM catalog_legacy.owners"
             )
 
-        # documents: import core columns; bib_* default to 0/''.
+        # documents: 15 always-imported core columns + optional bib_* columns.
+        # bib_* columns are preserved when present in the legacy DB (any user
+        # who ran ``nx enrich bib`` against catalog.db has populated values
+        # there); missing ones default to 0/'' per the destination schema.
         doc_cols = _legacy_cols("documents")
         if doc_cols:
+            # Core 15 — schema-stable across every catalog version that
+            # could plausibly appear on disk (RDR-096 P2.1 added source_uri;
+            # earlier shapes are handled by the CatalogDB ALTER migrations,
+            # which run before this point because CatalogDB also opens the
+            # legacy file briefly in some tests). COALESCE protects against
+            # NULL on the rare nullable column.
+            insert_cols = [
+                "tumbler", "title", "author", "year", "content_type",
+                "file_path", "corpus", "physical_collection", "chunk_count",
+                "head_hash", "indexed_at", "metadata", "source_mtime",
+                "alias_of", "source_uri",
+            ]
+            select_exprs = [
+                "tumbler",
+                "title",
+                "COALESCE(author, '')",
+                "COALESCE(year, 0)",
+                "COALESCE(content_type, '')",
+                "COALESCE(file_path, '')",
+                "COALESCE(corpus, '')",
+                "COALESCE(physical_collection, '')",
+                "COALESCE(chunk_count, 0)",
+                "COALESCE(head_hash, '')",
+                "COALESCE(indexed_at, '')",
+                "COALESCE(metadata, '{}')",
+                "COALESCE(source_mtime, 0.0)",
+                "COALESCE(alias_of, '')",
+                "COALESCE(source_uri, '')",
+            ]
+            # RDR-112 P2.review S1 (nexus-3vyw): preserve bib_* enrichment.
+            # The bib_* columns ship with RDR-101 Phase 1 PR D (nexus-knn3).
+            # Skipping them silently reverts every ``nx enrich bib`` result
+            # to default on the next daemon startup. Conditionally include
+            # each present-in-legacy column with the destination default.
+            bib_defaults: tuple[tuple[str, str], ...] = (
+                ("bib_year",                "0"),
+                ("bib_authors",             "''"),
+                ("bib_venue",               "''"),
+                ("bib_citation_count",      "0"),
+                ("bib_semantic_scholar_id", "''"),
+                ("bib_openalex_id",         "''"),
+                ("bib_doi",                 "''"),
+                ("bib_enriched_at",         "''"),
+            )
+            for col, default in bib_defaults:
+                if col in doc_cols:
+                    insert_cols.append(col)
+                    select_exprs.append(f"COALESCE({col}, {default})")
             conn.execute(
                 "INSERT OR IGNORE INTO documents "
-                "(tumbler, title, author, year, content_type, file_path, corpus, "
-                " physical_collection, chunk_count, head_hash, indexed_at, metadata, "
-                " source_mtime, alias_of, source_uri) "
-                "SELECT tumbler, title, COALESCE(author, ''), COALESCE(year, 0), "
-                "       COALESCE(content_type, ''), COALESCE(file_path, ''), "
-                "       COALESCE(corpus, ''), COALESCE(physical_collection, ''), "
-                "       COALESCE(chunk_count, 0), COALESCE(head_hash, ''), "
-                "       COALESCE(indexed_at, ''), COALESCE(metadata, '{}'), "
-                "       COALESCE(source_mtime, 0.0), COALESCE(alias_of, ''), "
-                "       COALESCE(source_uri, '') "
+                f"({', '.join(insert_cols)}) "
+                f"SELECT {', '.join(select_exprs)} "
                 "FROM catalog_legacy.documents"
             )
 
@@ -3352,10 +3395,19 @@ MIGRATIONS: list[Migration] = [
     # nexus-m4gm (RDR-112 P1.3): EventStream RPC substrate migrations are applied
     # directly in run_daemon_migrations (not here) because they need a tuples.db
     # connection, not a memory.db connection.
-    # nexus-7ejx (RDR-112 P2.1): catalog migrations pinned at the current
-    # installed package version (4.32.12) so apply_pending fires them on
-    # fresh installs (last_seen=0.0.0 < 4.32.12 <= current 4.32.12). Using a
-    # future version would defer execution until the next release bump.
+    # nexus-7ejx (RDR-112 P2.1): catalog migrations pinned at current installed
+    # version (4.32.12) so apply_pending fires them on fresh installs
+    # (last_seen=0.0.0 < 4.32.12 <= current 4.32.12).
+    #
+    # RDR-112 P2.review C2 (nexus-3vyw): the strict-greater filter
+    # ``m_ver > last_seen_t`` at apply_pending will SKIP these migrations
+    # for users who installed v4.32.12 from PyPI between the tag
+    # (2026-05-13) and the next release (their last_seen=4.32.12 == m_ver).
+    # The next release MUST bump these ``introduced`` strings to the next
+    # release version in the same commit that bumps pyproject.toml + the
+    # three plugin manifests + CHANGELOG.md. Verified by
+    # /tmp/smoke-version-pin-test.py: with last_seen=4.32.12,
+    # current=4.32.13, steps_run=0 — no tables, no import.
     Migration(
         "4.32.12",
         "RDR-112 P2.1: catalog tables collapsed into memory.db (nexus-7ejx)",

--- a/src/nexus/db/t2/catalog_store.py
+++ b/src/nexus/db/t2/catalog_store.py
@@ -273,12 +273,14 @@ class CatalogStore:
         the same path — without this, ``executescript`` would re-issue an
         implicit COMMIT on every new ``CatalogStore`` against an already-
         migrated DB, which can silently commit an open caller transaction.
-        Mirrors the MemoryStore pattern (``memory_store.py:291-296``).
+        Mirrors the MemoryStore pattern (``memory_store.py:321-326``): the
+        ``_migrated_paths.add`` happens AFTER schema creation succeeds, so
+        a mid-init exception leaves the path eligible for retry on the
+        next construction rather than stranding an empty connection.
         """
         with _migrated_lock:
             if path_key in _migrated_paths:
                 return
-            _migrated_paths.add(path_key)
         with self._lock:
             self._conn.executescript(_CATALOG_SCHEMA_SQL)
             # Post-schema: partial indexes and physical_collection index.
@@ -297,6 +299,8 @@ class CatalogStore:
             # yet registered in the collections table get an auto-row (mirrors
             # CatalogDB.__init__ backfill path).
             self._backfill_collections()
+        with _migrated_lock:
+            _migrated_paths.add(path_key)
 
     def _backfill_collections(self) -> None:
         """Insert legacy physical_collection values into collections (idempotent)."""

--- a/tests/daemon/test_catalog_client.py
+++ b/tests/daemon/test_catalog_client.py
@@ -309,6 +309,57 @@ class TestLegacyImport:
         conn.close()
         assert count == 0
 
+    def test_bib_columns_preserved_on_legacy_import(self, tmp_path: Path) -> None:
+        """RDR-112 P2.review S1 (nexus-3vyw): legacy import must carry bib_*
+        enrichment values from catalog.db into memory.db. Pre-fix the SELECT
+        omitted all bib_* columns; any ``nx enrich bib`` result would silently
+        revert to defaults on the next daemon startup."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        legacy_path = config_dir / "catalog.db"
+
+        # Seed a legacy catalog.db with documents carrying non-default bib_*.
+        from nexus.catalog.catalog_db import CatalogDB
+        legacy = CatalogDB(legacy_path)
+        owners = {"1.1": _make_owner()}
+        docs = {"1.1.1": _make_doc(tumbler="1.1.1", title="enriched.pdf")}
+        legacy.rebuild(owners, docs, [])
+        legacy._conn.execute(
+            "UPDATE documents SET "
+            "bib_year=?, bib_authors=?, bib_venue=?, bib_citation_count=?, "
+            "bib_semantic_scholar_id=?, bib_openalex_id=?, bib_doi=?, bib_enriched_at=? "
+            "WHERE tumbler='1.1.1'",
+            (
+                2024, "Smith, Jones", "NeurIPS", 137,
+                "s2-deadbeef", "openalex-abc123", "10.1234/abcd",
+                "2026-04-01T10:00:00Z",
+            ),
+        )
+        legacy._conn.commit()
+        legacy.close()
+
+        # Run migration; legacy rows should land in memory.db.
+        from nexus.db import migrations as mig
+        db_path = config_dir / "memory.db"
+        mig.run_if_needed(db_path)
+
+        # Verify every bib_* value survives the import.
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                "SELECT bib_year, bib_authors, bib_venue, bib_citation_count, "
+                "       bib_semantic_scholar_id, bib_openalex_id, bib_doi, "
+                "       bib_enriched_at "
+                "FROM documents WHERE tumbler='1.1.1'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row == (
+            2024, "Smith, Jones", "NeurIPS", 137,
+            "s2-deadbeef", "openalex-abc123", "10.1234/abcd",
+            "2026-04-01T10:00:00Z",
+        ), f"bib_* values lost on legacy import: row={row}"
+
 
 class TestLegacyImportAtomicRollback:
     def test_corrupt_legacy_file_leaves_no_partial_state(self, tmp_path: Path) -> None:

--- a/tests/db/test_catalog_store.py
+++ b/tests/db/test_catalog_store.py
@@ -522,3 +522,143 @@ class TestMigratedPathsGuard:
         finally:
             first.close()
             second.close()
+
+    def test_failed_init_does_not_stamp_path(self, tmp_path, monkeypatch) -> None:
+        """RDR-112 P2.review C1 (nexus-3vyw): if schema creation raises, the
+        path MUST NOT be added to _migrated_paths. Pre-fix the path was
+        stamped before executescript, so a failed init permanently stranded
+        the path as 'migrated' for the rest of the process, leaving every
+        subsequent CatalogStore call against a schema-less connection."""
+        from nexus.db.t2 import catalog_store as cs_module
+
+        db = tmp_path / "memory.db"
+        canonical = str(db.resolve())
+        cs_module._migrated_paths.discard(canonical)
+
+        original_schema_sql = cs_module._CATALOG_SCHEMA_SQL
+        monkeypatch.setattr(
+            cs_module, "_CATALOG_SCHEMA_SQL", "INVALID SQL STATEMENT;",
+        )
+        with pytest.raises(sqlite3.OperationalError):
+            CatalogStore(db)
+        assert canonical not in cs_module._migrated_paths, (
+            "failed init must leave path eligible for retry"
+        )
+
+        monkeypatch.setattr(
+            cs_module, "_CATALOG_SCHEMA_SQL", original_schema_sql,
+        )
+        store = CatalogStore(db)
+        try:
+            tables = {
+                r[0]
+                for r in store._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert "owners" in tables, "retry construction must rebuild schema"
+            assert canonical in cs_module._migrated_paths
+        finally:
+            store.close()
+
+
+class TestRebuildFieldParity:
+    """RDR-112 P2.review S3: field-by-field parity (not just count) between
+    CatalogStore and CatalogDB rebuild. Catches serialization divergences
+    (NULL vs '' for nullable columns, metadata JSON encoding, etc.) that
+    count-only assertions would silently miss.
+    """
+
+    def test_documents_row_field_parity(self, tmp_path: Path) -> None:
+        owners = {
+            "1.1": OwnerRecord(
+                owner="1.1", name="parity-repo", owner_type="repo",
+                repo_hash="hash-xyz", description="parity test",
+                repo_root="/some/root",
+            ),
+        }
+        docs = {
+            "1.1.1": DocumentRecord(
+                tumbler="1.1.1",
+                title="parity.py",
+                author="alice",
+                year=2025,
+                content_type="code",
+                file_path="src/parity.py",
+                corpus="test-corpus",
+                physical_collection="code__parity",
+                chunk_count=7,
+                head_hash="head-abc",
+                indexed_at="2026-01-15T12:34:56Z",
+                meta={"key": "value", "nested": {"a": 1}},
+                source_mtime=1234567.89,
+                alias_of="",
+                source_uri="file:///src/parity.py",
+            ),
+        }
+        links = [
+            LinkRecord(
+                from_t="1.1.1", to_t="1.1.2", link_type="cites",
+                from_span="span-from", to_span="span-to",
+                created_by="alice",
+                created_at="2026-01-15T13:00:00Z",
+                meta={"weight": 0.7},
+            ),
+        ]
+
+        legacy = CatalogDB(tmp_path / "legacy.db")
+        legacy.rebuild(owners, docs, links, consistency_mtime=42.0)
+        legacy_doc = legacy._conn.execute(
+            "SELECT tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+            "metadata, source_mtime, alias_of, source_uri "
+            "FROM documents WHERE tumbler = '1.1.1'"
+        ).fetchone()
+        legacy_owner = legacy._conn.execute(
+            "SELECT tumbler_prefix, name, owner_type, repo_hash, description, repo_root "
+            "FROM owners WHERE tumbler_prefix = '1.1'"
+        ).fetchone()
+        legacy_link = legacy._conn.execute(
+            "SELECT from_tumbler, to_tumbler, link_type, from_span, to_span, "
+            "created_by, created_at, metadata "
+            "FROM links WHERE from_tumbler = '1.1.1'"
+        ).fetchone()
+        legacy_meta = legacy._conn.execute(
+            "SELECT value FROM _meta WHERE key='last_consistency_mtime'"
+        ).fetchone()
+        legacy.close()
+
+        store = CatalogStore(tmp_path / "store.db")
+        store.rebuild(owners, docs, links, consistency_mtime=42.0)
+        store_doc = store._conn.execute(
+            "SELECT tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+            "metadata, source_mtime, alias_of, source_uri "
+            "FROM documents WHERE tumbler = '1.1.1'"
+        ).fetchone()
+        store_owner = store._conn.execute(
+            "SELECT tumbler_prefix, name, owner_type, repo_hash, description, repo_root "
+            "FROM owners WHERE tumbler_prefix = '1.1'"
+        ).fetchone()
+        store_link = store._conn.execute(
+            "SELECT from_tumbler, to_tumbler, link_type, from_span, to_span, "
+            "created_by, created_at, metadata "
+            "FROM links WHERE from_tumbler = '1.1.1'"
+        ).fetchone()
+        store_meta = store._conn.execute(
+            "SELECT value FROM _meta WHERE key='last_consistency_mtime'"
+        ).fetchone()
+        store.close()
+
+        assert store_doc == legacy_doc, (
+            f"document row diverges:\nstore={store_doc}\nlegacy={legacy_doc}"
+        )
+        assert store_owner == legacy_owner, (
+            f"owner row diverges:\nstore={store_owner}\nlegacy={legacy_owner}"
+        )
+        assert store_link == legacy_link, (
+            f"link row diverges:\nstore={store_link}\nlegacy={legacy_link}"
+        )
+        assert store_meta == legacy_meta, (
+            f"_meta row diverges:\nstore={store_meta}\nlegacy={legacy_meta}"
+        )


### PR DESCRIPTION
## Summary

Phase 2 catalog-collapse review (`nexus-3vyw`) on commit `740dfb1c` (PR #785) surfaced 2 Critical + 4 Significant findings. This PR applies the two in-place fixes that don't couple to release coordination, adds field-level parity coverage for the third, and tracks the deferred items as follow-up beads.

## Findings remediated in this PR

- **C1** — `_migrated_paths` guard ordering (`src/nexus/db/t2/catalog_store.py`): the path key was stamped BEFORE `executescript` ran, so a mid-init exception permanently marked the path migrated and stranded every subsequent `CatalogStore` against a schema-less connection. Now stamped after `_backfill_collections()` succeeds, mirroring `MemoryStore` (`memory_store.py:326`). Covered by `TestMigratedPathsGuard::test_failed_init_does_not_stamp_path` which patches the schema SQL to invalid input, verifies the path stays eligible for retry, then restores and verifies retry succeeds.
- **S1** — `bib_*` enrichment columns dropped in legacy import SELECT (`src/nexus/db/migrations.py`): pre-fix, every `nx enrich bib` result would revert to defaults on daemon startup. INSERT now dynamically includes whichever `bib_*` columns the legacy schema carries, guarded by `_legacy_cols("documents")`. Covered by `TestLegacyImport::test_bib_columns_preserved_on_legacy_import` seeding all 8 fields and asserting every value survives.
- **S3** — field-level parity coverage (`tests/db/test_catalog_store.py`): added `TestRebuildFieldParity::test_documents_row_field_parity` doing column-by-column row equality across documents + owners + links + `_meta` between `CatalogDB` and `CatalogStore` on identical input. The pre-existing parity tests only checked row counts.

## Findings deferred (follow-up beads filed)

- **C2** — Migration version pin 4.32.12 will silently skip catalog migrations for users upgrading from v4.32.12 → next release (strict-greater filter `m_ver > last_seen_t`). Verified by `/tmp/smoke-version-pin-test.py` (`steps_run=0`). Fix requires coordinated bump of `pyproject.toml` + 3 plugin manifests + 2 changelogs — a release-commit responsibility. **nexus-rch5 (P1)** tracks the release-time fix. The migration comment (`migrations.py:3357-3368`) now carries an explicit warning so the next release captain sees the hazard.
- **S2** — `CatalogStore` lacks `_backfilled_collections` attribute that `catalog.py:629` reads. **nexus-m0hi (P1)** tracks the Phase 4 prerequisite; wired as a blocker on `nexus-uar6`.
- **S4** — `T2Database.rename_collection_cascade` not extended for new catalog tables. **nexus-fe2i (P2)** tracks; wired as a blocker on `nexus-uar6`.

## Phase 3 unblock

`nexus-hpxl` (Phase 3 MCP flip behind `NX_STORAGE_MODE`) can start. C2 does not block Phase 3 mechanically — daemon `CatalogStore.__init__` creates schema on first open regardless of migration outcome. C2 only affects Phase 4 (CLI port, `nexus-uar6`) reading from `memory.db` for the narrow window of users who installed v4.32.12 between tag (2026-05-13) and next release.

## Test plan

- [x] `uv run pytest tests/db/test_catalog_store.py tests/daemon/test_catalog_client.py -v` — 52/52 pass (3 new)
- [x] Wider regression sweep — 564/564 across `tests/db/`, `tests/daemon/`, `tests/test_catalog_db.py`, `tests/test_catalog_manifest_read_api.py`, `tests/test_rdr108_phase1_remediation.py`
- [x] Manual legacy-import smoke (`/tmp/smoke-catalog-test.py`) — `NX_STORAGE_MODE=direct`, 2 docs imported, `catalog.db.imported` present, `CatalogStore.search` returns identical tumblers to legacy `CatalogDB`
- [x] Version-pin reproduction (`/tmp/smoke-version-pin-test.py`) — confirmed C2 still reproduces (`steps_run=0` for simulated 4.32.12 → 4.32.13 upgrade); locks in the regression target for `nexus-rch5`

## Closes

Bead `nexus-3vyw` (review gate); deferred work tracked under `nexus-rch5`, `nexus-m0hi`, `nexus-fe2i`.

Full T2 review at `nexus_rdr/112-phase2-review`.