### PR TITLE
feat(rdr-112): nexus-s3dm — T3 daemon lifecycle + nx daemon t3 CLI

### DIFF
--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -1062,3 +1062,141 @@ def uninstall_cmd(autostart: bool) -> None:
     dest.unlink()
     click.echo(f"Removed {dest}")
 
+
+# ---------------------------------------------------------------------------
+# t3 sub-group  (RDR-112 P1.5.1, nexus-s3dm)
+# ---------------------------------------------------------------------------
+#
+# The T3 daemon is a managed ``chroma run`` subprocess. chromadb's bundled
+# HTTP server is the production-quality RPC layer (RDR-112 §A1); this group
+# owns the subprocess lifecycle + discovery file. T3Client (P1.5.3 /
+# nexus-7yd2) and ``discovery_resolve('t3')`` (P1.5.2 / nexus-n8xg) ship in
+# follow-on beads.
+
+
+@daemon_group.group("t3")
+def t3_group() -> None:
+    """T3 daemon — managed chroma run subprocess (local mode only)."""
+
+
+@t3_group.command("start")
+@click.option(
+    "--config-dir",
+    "config_dir_str",
+    default=None,
+    help="Config directory override (default: ~/.config/nexus/).",
+)
+@click.option(
+    "--local-path",
+    "local_path_str",
+    default=None,
+    help=(
+        "Override the chroma persistent path. Default: "
+        "``nexus.config._default_local_path()`` (XDG-aware, "
+        "~/.local/share/nexus/chroma)."
+    ),
+)
+@click.option(
+    "--announce-stdout",
+    "announce_stdout",
+    is_flag=True,
+    default=False,
+    help=(
+        "Emit the discovery JSON on stdout at startup. Default off "
+        "(mirrors T2 nexus-l712): the discovery file at "
+        "~/.config/nexus/t3_addr.<uid> is the primary channel."
+    ),
+)
+def t3_start_cmd(
+    config_dir_str: str | None,
+    local_path_str: str | None,
+    announce_stdout: bool,
+) -> None:
+    """Start the T3 chroma daemon (local mode only).
+
+    Idempotent on a live daemon: if a discovery file exists and its PID is
+    still alive, prints the existing discovery payload without spawning a
+    duplicate. Cloud mode (NX_LOCAL=0) fails loud — chromadb's CloudClient
+    is already HTTP-served.
+    """
+    from nexus.config import _default_local_path
+    from nexus.daemon.t3_daemon import (
+        T3CloudModeError,
+        T3StartError,
+        start_t3_daemon,
+    )
+
+    config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
+    local_path = Path(local_path_str) if local_path_str else _default_local_path()
+    try:
+        payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+    except T3CloudModeError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+    except T3StartError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
+
+    if announce_stdout:
+        click.echo(json.dumps(payload))
+        return
+    click.echo(
+        f"T3 daemon running on {payload['tcp_host']}:{payload['tcp_port']} "
+        f"(pid={payload['pid']}, local_path={payload['local_path']})."
+    )
+
+
+@t3_group.command("stop")
+@click.option(
+    "--config-dir",
+    "config_dir_str",
+    default=None,
+    help="Config directory override.",
+)
+def t3_stop_cmd(config_dir_str: str | None) -> None:
+    """Stop the running T3 daemon (graceful SIGTERM → SIGKILL escalation)."""
+    from nexus.daemon.t3_daemon import stop_t3_daemon
+
+    config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
+    pid = stop_t3_daemon(config_dir=config_dir)
+    if pid is None:
+        click.echo("No T3 daemon discovery file found — already stopped.")
+        return
+    click.echo(f"T3 daemon stopped (pid={pid}).")
+
+
+@t3_group.command("info")
+@click.option(
+    "--config-dir",
+    "config_dir_str",
+    default=None,
+    help="Config directory override.",
+)
+@click.option(
+    "--json", "as_json", is_flag=True, default=False, help="Output raw JSON."
+)
+def t3_info_cmd(config_dir_str: str | None, as_json: bool) -> None:
+    """Print the T3 daemon discovery JSON (or formatted summary)."""
+    from nexus.daemon.t3_daemon import t3_discovery_path
+
+    config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
+    disc = t3_discovery_path(config_dir)
+    if not disc.exists():
+        click.echo(
+            "No T3 daemon discovery file found — is the daemon running?",
+            err=True,
+        )
+        sys.exit(1)
+    try:
+        data = json.loads(disc.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        click.echo(f"Failed to read discovery file: {exc}", err=True)
+        sys.exit(1)
+    if as_json:
+        click.echo(json.dumps(data, indent=2))
+        return
+    click.echo("T3 Daemon Info")
+    click.echo("-" * 40)
+    for key, value in data.items():
+        click.echo(f"  {key}: {value}")
+

--- a/src/nexus/daemon/t3_daemon.py
+++ b/src/nexus/daemon/t3_daemon.py
@@ -1,0 +1,360 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-112 P1.5.1 (nexus-s3dm) — T3 daemon lifecycle.
+
+The T3 "daemon" is a managed ``chroma run`` subprocess. chromadb's bundled
+HTTP server (``chroma run``) is production-quality (RDR-112 §A1, verified
+2026-05-13) and is the RPC layer; this module owns process lifecycle and
+the on-disk discovery file at ``~/.config/nexus/t3_addr.<uid>``.
+
+Local-mode only. Cloud mode (NX_LOCAL=0) raises ``T3CloudModeError`` —
+chromadb's CloudClient is already HTTP-served, so there is no daemon to
+run. Clients in cloud mode connect directly via the CloudClient.
+
+The chroma subprocess is spawned with ``start_new_session=True`` (matches
+``start_t1_server`` in ``session.py:459-537``) so SIGTERM at shutdown
+reaches the whole process group — chroma's multiprocessing workers and
+the resource_tracker child included (nexus-dc57 / nexus-ze2a class).
+
+T1/T3 non-collision invariant (PLAN-AUDIT 2026-05-17): T1 uses
+ephemeral tempdirs + ``t1_addr.<claude_pid>``; T3 uses
+``nexus.config._default_local_path()`` + ``t3_addr.<uid>``. Both pick
+free ports via the OS allocator. Distinct addr-file naming and
+distinct chroma --path roots mean two coexisting chroma subprocesses
+on the same host do not collide.
+"""
+from __future__ import annotations
+
+import errno
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+#: chroma listens on loopback only — RDR-113 host-trust invariant. The
+#: chroma CLI default is 127.0.0.1; we pass it explicitly for clarity.
+_T3_HOST: str = "127.0.0.1"
+
+#: Discovery payload format version. Bump when the shape changes.
+_DISCOVERY_FORMAT_VERSION: int = 1
+
+#: How long to wait for the chroma subprocess to begin accepting TCP
+#: connections before declaring the start a failure. Local chroma startup
+#: is normally <1s on warm caches, ~3s on a cold venv.
+_READY_TIMEOUT: float = 10.0
+
+#: After SIGTERM, wait this long before escalating to SIGKILL.
+_GRACEFUL_STOP_TIMEOUT: float = 3.0
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class T3CloudModeError(RuntimeError):
+    """Raised when ``start_t3_daemon`` is invoked in cloud mode.
+
+    In cloud mode chromadb's CloudClient already speaks HTTP to a remote
+    service; running ``chroma run`` locally would serve nothing useful.
+    Clients in cloud mode bypass the daemon entirely (P1.5.3 / nexus-7yd2
+    enforces this on the T3Client factory side).
+    """
+
+
+class T3StartError(RuntimeError):
+    """Raised when the chroma subprocess fails to become ready."""
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def t3_discovery_path(config_dir: Path) -> Path:
+    """Return the canonical discovery-file path for the T3 daemon.
+
+    Filename is ``t3_addr.<uid>`` — distinct from T2's ``t2_addr.<uid>``
+    (T2 daemon owns a separate addr file) and from T1's
+    ``t1_addr.<claude_pid>`` (T1 chroma is per-Claude-session and uses a
+    different naming key).
+    """
+    uid = os.getuid()
+    return config_dir / f"t3_addr.{uid}"
+
+
+def _build_payload(
+    *,
+    tcp_port: int,
+    pid: int,
+    local_path: Path,
+    daemon_version: str,
+) -> dict[str, Any]:
+    return {
+        "format_version": _DISCOVERY_FORMAT_VERSION,
+        "tcp_host": _T3_HOST,
+        "tcp_port": tcp_port,
+        "pid": pid,
+        "daemon_version": daemon_version,
+        "start_time": datetime.now(timezone.utc).isoformat(),
+        "local_path": str(local_path),
+    }
+
+
+def _write_discovery_atomic(path: Path, payload: dict[str, Any]) -> None:
+    """Mirror T2's atomic-write pattern (t2_daemon.py:1706-1718)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload))
+    os.chmod(str(tmp), 0o600)
+    os.replace(str(tmp), str(path))
+
+
+def _read_discovery(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        _log.warning("t3_discovery_read_failed", path=str(path), err=str(exc))
+        return None
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Return True iff signalling pid 0 to *pid* succeeds (or hits EPERM —
+    process exists but is owned by another uid, treat as alive)."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError as exc:
+        # ESRCH = no such process; everything else implies the pid exists.
+        return exc.errno != errno.ESRCH
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Chroma binary location
+# ---------------------------------------------------------------------------
+
+
+def _find_chroma() -> str:
+    """Locate the chroma CLI co-installed with this interpreter.
+
+    Mirrors ``nexus.session._find_chroma`` (session.py:442) — chromadb is
+    a hard dependency, so the chroma entry-point lives in the same bin
+    directory as the Python interpreter. Falls back to a PATH search.
+    """
+    candidate = Path(sys.executable).parent / "chroma"
+    if candidate.is_file():
+        return str(candidate)
+    import shutil
+    found = shutil.which("chroma")
+    if not found:
+        raise T3StartError(
+            "chroma CLI not found alongside Python interpreter or on PATH. "
+            "Reinstall nexus to restore the chromadb entry-point."
+        )
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: start / stop
+# ---------------------------------------------------------------------------
+
+
+def _daemon_version() -> str:
+    """Return the conexus package version embedded in discovery payloads."""
+    try:
+        from importlib.metadata import version
+        return version("conexus")
+    except Exception:
+        return "0.0.0"
+
+
+def _allocate_free_port() -> int:
+    """Bind a free loopback port, then close it. The TOCTOU window between
+    close and chroma binding the port is negligible on loopback (same
+    rationale as ``start_t1_server`` at session.py:476-484)."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((_T3_HOST, 0))
+    port: int = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _wait_for_ready(
+    host: str, port: int, proc: subprocess.Popen[bytes], timeout: float
+) -> None:
+    """Poll until *host:port* accepts TCP or *proc* exits."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise T3StartError(
+                f"chroma run exited with code {proc.returncode} "
+                f"before becoming ready on {host}:{port}"
+            )
+        try:
+            conn = socket.create_connection((host, port), timeout=0.5)
+            conn.close()
+            return
+        except OSError:
+            time.sleep(0.2)
+    proc.kill()
+    raise T3StartError(
+        f"chroma run on {host}:{port} did not become ready within {timeout:.0f}s"
+    )
+
+
+def start_t3_daemon(*, config_dir: Path, local_path: Path) -> dict[str, Any]:
+    """Start the T3 chroma daemon (local mode only). Returns the discovery
+    payload that was written to ``t3_discovery_path(config_dir)``.
+
+    Idempotent on a live daemon: if a discovery file exists and its PID is
+    still alive, returns the existing payload without spawning a duplicate.
+
+    Raises:
+        T3CloudModeError: when ``is_local_mode()`` is False — the cloud
+            CloudClient already speaks HTTP; running chroma locally would
+            be a no-op.
+        T3StartError: when chroma cannot be located or fails to become
+            ready within ``_READY_TIMEOUT``.
+    """
+    from nexus.config import is_local_mode
+
+    if not is_local_mode():
+        raise T3CloudModeError(
+            "T3 daemon is a no-op in cloud mode. chromadb's CloudClient "
+            "is already HTTP-served; there is no local daemon to run. "
+            "Set NX_LOCAL=1 to opt into local mode."
+        )
+
+    disc_path = t3_discovery_path(config_dir)
+    existing = _read_discovery(disc_path)
+    if existing is not None:
+        existing_pid = existing.get("pid")
+        if isinstance(existing_pid, int) and _pid_is_alive(existing_pid):
+            _log.info(
+                "t3_daemon_already_running",
+                pid=existing_pid,
+                tcp_port=existing.get("tcp_port"),
+            )
+            return existing
+        # Stale discovery file — log and proceed to spawn a fresh daemon.
+        _log.info(
+            "t3_daemon_stale_discovery",
+            pid=existing_pid,
+            path=str(disc_path),
+        )
+
+    local_path.mkdir(parents=True, exist_ok=True)
+    chroma = _find_chroma()
+    port = _allocate_free_port()
+
+    proc = subprocess.Popen(
+        [
+            chroma, "run",
+            "--host", _T3_HOST,
+            "--port", str(port),
+            "--path", str(local_path),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,  # see module docstring
+    )
+
+    try:
+        _wait_for_ready(_T3_HOST, port, proc, _READY_TIMEOUT)
+    except T3StartError:
+        # Ready-poll already invoked proc.kill() on timeout; the explicit
+        # exit-code branch only raises after proc has terminated. Either
+        # way the subprocess is no longer running; clean up the (possibly
+        # half-written) discovery file lest a follow-up start trip the
+        # stale-detection branch with a confusing payload.
+        disc_path.unlink(missing_ok=True)
+        raise
+
+    payload = _build_payload(
+        tcp_port=port,
+        pid=proc.pid,
+        local_path=local_path,
+        daemon_version=_daemon_version(),
+    )
+    _write_discovery_atomic(disc_path, payload)
+    _log.info(
+        "t3_daemon_started",
+        pid=proc.pid,
+        tcp_port=port,
+        local_path=str(local_path),
+    )
+    return payload
+
+
+def stop_t3_daemon(*, config_dir: Path) -> int | None:
+    """Stop the running T3 daemon by reading the discovery file's PID,
+    sending SIGTERM (escalating to SIGKILL after _GRACEFUL_STOP_TIMEOUT),
+    and unlinking the discovery file.
+
+    Returns the PID that was signalled (or None when no discovery file
+    exists — already stopped). Process-group SIGTERM ensures chroma's
+    multiprocessing workers + resource_tracker are signalled too
+    (nexus-dc57 / nexus-ze2a class — process group is the correct
+    granularity for chroma's subtree).
+    """
+    from nexus.util.process_group import safe_killpg
+
+    disc_path = t3_discovery_path(config_dir)
+    payload = _read_discovery(disc_path)
+    if payload is None:
+        _log.info("t3_daemon_stop_noop", reason="no_discovery_file")
+        return None
+
+    pid = payload.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        _log.warning("t3_daemon_stop_invalid_pid", payload=payload)
+        disc_path.unlink(missing_ok=True)
+        return None
+
+    if not _pid_is_alive(pid):
+        _log.info("t3_daemon_stop_stale_pid", pid=pid)
+        disc_path.unlink(missing_ok=True)
+        return pid
+
+    # Graceful SIGTERM via process-group → escalate to SIGKILL.
+    if safe_killpg(pid, signal.SIGTERM):
+        deadline = time.monotonic() + _GRACEFUL_STOP_TIMEOUT
+        while time.monotonic() < deadline:
+            if not _pid_is_alive(pid):
+                break
+            time.sleep(0.1)
+        if _pid_is_alive(pid):
+            safe_killpg(pid, signal.SIGKILL)
+            # Reap zombie if it was our child; ignore if not.
+            try:
+                os.waitpid(pid, os.WNOHANG)
+            except (ChildProcessError, OSError):
+                pass
+
+    disc_path.unlink(missing_ok=True)
+    _log.info("t3_daemon_stopped", pid=pid)
+    return pid

--- a/tests/daemon/test_t3_daemon_lifecycle.py
+++ b/tests/daemon/test_t3_daemon_lifecycle.py
@@ -1,0 +1,390 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 P1.5.1 (nexus-s3dm): T3 daemon lifecycle tests.
+
+The T3 daemon is a managed ``chroma run`` subprocess — chromadb's bundled
+HTTP server is the production-quality RPC layer (RDR-112 §A1). This bead
+covers process lifecycle + discovery; T3Client is the next bead (P1.5.3).
+
+Tests cover:
+- Discovery file shape + atomic write + uid suffix
+- Daemon-start / daemon-stop happy path with HttpClient round-trip query
+- T1/T3 non-collision invariant (separate addr files, separate ports,
+  separate chroma --path roots)
+- Stale-discovery recovery (kill -9 then start)
+- Cloud-mode rejection (start fails loud when NX_LOCAL=0)
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import time
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_listening(host: str, port: int, timeout: float = 0.5) -> bool:
+    try:
+        s = socket.create_connection((host, port), timeout=timeout)
+        s.close()
+        return True
+    except OSError:
+        return False
+
+
+def _wait_pid_gone(pid: int, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    """Isolated config directory for each test."""
+    cd = tmp_path / "nexus_config"
+    cd.mkdir()
+    return cd
+
+
+@pytest.fixture
+def local_path(tmp_path: Path) -> Path:
+    """Isolated chroma persistent path for each test."""
+    p = tmp_path / "chroma_t3"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def force_local_mode(monkeypatch):
+    """Force ``is_local_mode()`` to return True regardless of test-env
+    credentials. The chroma-subprocess tests are local-mode-only by
+    design; cloud-mode rejection has its own dedicated test."""
+    monkeypatch.setenv("NX_LOCAL", "1")
+
+
+# ---------------------------------------------------------------------------
+# Discovery file shape
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryFileShape:
+    """The discovery payload contract clients rely on."""
+
+    def test_discovery_path_uses_uid_suffix(self, config_dir: Path) -> None:
+        from nexus.daemon.t3_daemon import t3_discovery_path
+
+        expected = config_dir / f"t3_addr.{os.getuid()}"
+        assert t3_discovery_path(config_dir) == expected
+
+    def test_discovery_filename_distinct_from_t1(self, config_dir: Path) -> None:
+        """T1/T3 non-collision invariant (PLAN-AUDIT 2026-05-17): both
+        shells start their own chroma; they must not collide on addr-file
+        name. T1 uses ``t1_addr.<claude_pid>``; T3 uses ``t3_addr.<uid>``."""
+        from nexus.daemon.t3_daemon import t3_discovery_path
+
+        t3_path = t3_discovery_path(config_dir)
+        # T1's pattern from session.py: t1_addr.<claude_pid>
+        assert t3_path.name.startswith("t3_addr."), (
+            f"T3 discovery filename must use t3_addr.* prefix, got {t3_path.name}"
+        )
+        assert "t1_addr" not in t3_path.name
+
+
+# ---------------------------------------------------------------------------
+# Daemon start/stop happy path (real chroma subprocess)
+# ---------------------------------------------------------------------------
+
+
+class TestStartStopHappyPath:
+    """Spawn a real chroma subprocess, verify HttpClient round-trip, then stop.
+
+    Slow tests (~3-5s per case) because chroma startup is not free.
+    """
+
+    def test_start_writes_discovery_file_then_stop_cleans_it(
+        self, config_dir: Path, local_path: Path, force_local_mode
+    ) -> None:
+        from nexus.daemon.t3_daemon import (
+            start_t3_daemon,
+            stop_t3_daemon,
+            t3_discovery_path,
+        )
+
+        disc_path = t3_discovery_path(config_dir)
+        assert not disc_path.exists()
+
+        payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+        try:
+            assert disc_path.exists(), "discovery file must exist after start"
+            assert payload["pid"] > 0
+            assert payload["tcp_host"] in ("127.0.0.1", "localhost")
+            assert isinstance(payload["tcp_port"], int)
+            assert payload["tcp_port"] > 0
+            assert payload["format_version"] == 1
+            # Disc file content matches payload
+            on_disk = json.loads(disc_path.read_text())
+            assert on_disk["pid"] == payload["pid"]
+            assert on_disk["tcp_port"] == payload["tcp_port"]
+            # Process is alive + listening
+            assert _is_listening(payload["tcp_host"], payload["tcp_port"])
+            os.kill(payload["pid"], 0)  # raises if dead
+        finally:
+            pid = stop_t3_daemon(config_dir=config_dir)
+            assert pid == payload["pid"]
+            assert _wait_pid_gone(payload["pid"]), "daemon did not exit after stop"
+            assert not disc_path.exists(), "stop must unlink discovery file"
+
+    def test_http_client_round_trip_against_running_daemon(
+        self, config_dir: Path, local_path: Path, force_local_mode
+    ) -> None:
+        """An HttpClient pointed at the daemon must list collections."""
+        from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+        import chromadb
+
+        payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+        try:
+            client = chromadb.HttpClient(
+                host=payload["tcp_host"], port=payload["tcp_port"]
+            )
+            # heartbeat is the cheapest "is this really a chroma server" check
+            client.heartbeat()
+            coll = client.get_or_create_collection("t3_smoke")
+            coll.add(documents=["alpha"], ids=["1"])
+            results = coll.query(query_texts=["alpha"], n_results=1)
+            assert results["ids"][0] == ["1"]
+        finally:
+            stop_t3_daemon(config_dir=config_dir)
+
+
+# ---------------------------------------------------------------------------
+# T1/T3 non-collision invariant
+# ---------------------------------------------------------------------------
+
+
+class TestT1T3NonCollision:
+    """Both T1 and T3 spawn chroma subprocesses; verify they pick distinct
+    ports and distinct addr-file names."""
+
+    def test_t3_port_allocator_does_not_collide_with_t1_default(
+        self, config_dir: Path, local_path: Path, force_local_mode
+    ) -> None:
+        """T3 picks a free port; T1 also picks a free port. Both go through
+        the OS port allocator so the OS guarantees distinctness."""
+        from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+
+        payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+        try:
+            # Bind a separate socket and confirm it gets a different port.
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(("127.0.0.1", 0))
+            other_port = sock.getsockname()[1]
+            sock.close()
+            assert other_port != payload["tcp_port"]
+        finally:
+            stop_t3_daemon(config_dir=config_dir)
+
+
+# ---------------------------------------------------------------------------
+# Stale discovery recovery
+# ---------------------------------------------------------------------------
+
+
+class TestStaleDiscoveryRecovery:
+    """A crashed daemon leaves a stale discovery file; the next start must
+    detect the stale PID and proceed."""
+
+    def test_stale_discovery_file_cleaned_on_next_start(
+        self, config_dir: Path, local_path: Path, force_local_mode
+    ) -> None:
+        from nexus.daemon.t3_daemon import (
+            start_t3_daemon,
+            stop_t3_daemon,
+            t3_discovery_path,
+        )
+
+        # Plant a stale discovery file pointing at a definitely-dead PID.
+        disc_path = t3_discovery_path(config_dir)
+        stale_pid = 2**31 - 1  # max int32, never a real PID
+        disc_path.write_text(
+            json.dumps(
+                {
+                    "format_version": 1,
+                    "tcp_host": "127.0.0.1",
+                    "tcp_port": 9999,
+                    "pid": stale_pid,
+                    "daemon_version": "stale",
+                    "start_time": "1970-01-01T00:00:00",
+                    "local_path": str(local_path),
+                }
+            )
+        )
+        os.chmod(str(disc_path), 0o600)
+
+        # Start should succeed despite the stale file.
+        payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+        try:
+            assert payload["pid"] != stale_pid
+            # Re-read the on-disk discovery file; it should point at the new pid.
+            on_disk = json.loads(disc_path.read_text())
+            assert on_disk["pid"] == payload["pid"]
+        finally:
+            stop_t3_daemon(config_dir=config_dir)
+
+
+# ---------------------------------------------------------------------------
+# Cloud mode rejection
+# ---------------------------------------------------------------------------
+
+
+class TestCloudModeRejection:
+    """In cloud mode, ``start_t3_daemon`` is a no-op operationally and
+    must fail loud — chroma's CloudClient is already HTTP-served."""
+
+    def test_cloud_mode_raises_runtime_error_with_clear_message(
+        self, config_dir: Path, local_path: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.t3_daemon import T3CloudModeError, start_t3_daemon
+
+        monkeypatch.setenv("NX_LOCAL", "0")
+        with pytest.raises(T3CloudModeError) as excinfo:
+            start_t3_daemon(config_dir=config_dir, local_path=local_path)
+        msg = str(excinfo.value)
+        # The message must name the substantive reason, not just "no".
+        assert "cloud" in msg.lower()
+        assert "no-op" in msg.lower() or "no t3 daemon" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Idempotent start (already running)
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotentStart:
+    """A second ``start`` against a live daemon must detect the existing
+    process and return the same discovery payload (no double-spawn)."""
+
+    def test_second_start_returns_existing_payload(
+        self, config_dir: Path, local_path: Path, force_local_mode
+    ) -> None:
+        from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+
+        first = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+        try:
+            second = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+            assert second["pid"] == first["pid"]
+            assert second["tcp_port"] == first["tcp_port"]
+        finally:
+            stop_t3_daemon(config_dir=config_dir)
+
+
+# ---------------------------------------------------------------------------
+# CLI surface (nx daemon t3 start/stop/info)
+# ---------------------------------------------------------------------------
+
+
+class TestCliSurface:
+    """Smoke-tests for the ``nx daemon t3 ...`` Click group."""
+
+    def test_t3_group_registered_under_daemon_group(self) -> None:
+        from nexus.commands.daemon import daemon_group
+
+        assert "t3" in daemon_group.commands
+        t3 = daemon_group.commands["t3"]
+        assert {"start", "stop", "info"} <= set(t3.commands)
+
+    def test_t3_info_reports_no_daemon_when_disc_missing(
+        self, config_dir: Path
+    ) -> None:
+        from click.testing import CliRunner
+
+        from nexus.commands.daemon import daemon_group
+
+        runner = CliRunner()
+        result = runner.invoke(
+            daemon_group, ["t3", "info", "--config-dir", str(config_dir)]
+        )
+        assert result.exit_code == 1
+        assert "No T3 daemon discovery file" in result.output
+
+    def test_t3_stop_is_idempotent_when_no_daemon(self, config_dir: Path) -> None:
+        from click.testing import CliRunner
+
+        from nexus.commands.daemon import daemon_group
+
+        runner = CliRunner()
+        result = runner.invoke(
+            daemon_group, ["t3", "stop", "--config-dir", str(config_dir)]
+        )
+        assert result.exit_code == 0
+        assert "already stopped" in result.output
+
+    def test_t3_start_cloud_mode_exits_nonzero(
+        self, config_dir: Path, local_path: Path, monkeypatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from nexus.commands.daemon import daemon_group
+
+        monkeypatch.setenv("NX_LOCAL", "0")
+        runner = CliRunner()
+        result = runner.invoke(
+            daemon_group,
+            [
+                "t3", "start",
+                "--config-dir", str(config_dir),
+                "--local-path", str(local_path),
+            ],
+        )
+        assert result.exit_code == 1
+        assert "cloud mode" in result.output.lower()
+
+    def test_t3_start_info_stop_round_trip(
+        self, config_dir: Path, local_path: Path, force_local_mode
+    ) -> None:
+        """Full CLI round-trip: start → info reads discovery → stop."""
+        from click.testing import CliRunner
+
+        from nexus.commands.daemon import daemon_group
+
+        runner = CliRunner()
+        start = runner.invoke(
+            daemon_group,
+            [
+                "t3", "start",
+                "--config-dir", str(config_dir),
+                "--local-path", str(local_path),
+            ],
+        )
+        try:
+            assert start.exit_code == 0, start.output
+            assert "T3 daemon running" in start.output
+
+            info = runner.invoke(
+                daemon_group,
+                ["t3", "info", "--config-dir", str(config_dir), "--json"],
+            )
+            assert info.exit_code == 0
+            payload = json.loads(info.output)
+            assert payload["pid"] > 0
+            assert payload["format_version"] == 1
+        finally:
+            stop = runner.invoke(
+                daemon_group, ["t3", "stop", "--config-dir", str(config_dir)]
+            )
+            assert stop.exit_code == 0
+            assert "T3 daemon stopped" in stop.output


### PR DESCRIPTION
## Summary

P1.5.1 of the corrective RDR-112 Phase 1.5 chain (epic \`nexus-8hy6\`). Adds the T3 daemon lifecycle module + \`nx daemon t3\` CLI surface.

The T3 daemon is a managed \`chroma run\` subprocess — chromadb's bundled HTTP server is the production-quality RPC layer (RDR-112 §A1). No separate Python event-loop wrapper; this bead owns process lifecycle + discovery file. T3Client (\`nexus-7yd2\`) and \`discovery_resolve('t3')\` (\`nexus-n8xg\`) follow in the next two beads.

## Files

- \`src/nexus/daemon/t3_daemon.py\` (new) — \`start_t3_daemon\` / \`stop_t3_daemon\` / \`t3_discovery_path\` + \`T3CloudModeError\` / \`T3StartError\`
- \`src/nexus/commands/daemon.py\` — added \`@daemon_group.group("t3")\` with \`start\`, \`stop\`, \`info\` subcommands
- \`tests/daemon/test_t3_daemon_lifecycle.py\` (new) — 13 tests

## Key design points

- **Discovery file**: \`~/.config/nexus/t3_addr.<uid>\` — distinct from T2's \`t2_addr.<uid>\` and T1's \`t1_addr.<claude_pid>\` per the PLAN-AUDIT non-collision invariant.
- **start_new_session=True** on the chroma subprocess so SIGTERM at shutdown reaches the whole process group (chroma's multiprocessing workers + resource_tracker). Mirrors \`start_t1_server\` (nexus-dc57 / nexus-ze2a class).
- **Cloud-mode fail-loud** (NX_LOCAL=0): \`T3CloudModeError\` with clear message. The factory-side gate (the canonical surface) lands in \`nexus-7yd2\` per the plan audit.
- **Idempotent start**: live discovery + alive PID returns the existing payload, no double-spawn.
- **Stale-discovery recovery**: orphaned files cleaned on next start.
- **Graceful stop**: \`safe_killpg\` SIGTERM → 3s wait → SIGKILL escalation.

## Test plan

- [x] 13/13 \`tests/daemon/test_t3_daemon_lifecycle.py\` pass (~21s, 5 real chroma spawns)
  - Discovery file shape: uid suffix + T1/T3 non-collision invariant
  - Real-chroma start/stop happy path + HttpClient round-trip query
  - Port-allocator non-collision
  - Stale-discovery recovery (kill-9 followed by start)
  - Idempotent start (second \`start\` returns existing payload)
  - Cloud-mode rejection
  - CLI surface: group registration, info/stop on missing daemon, start cloud-mode exit code, full \`start → info → stop\` round trip
- [x] Wider regression sweep: 1063 passed across \`tests/daemon/\` + \`tests/test_plugin_structure.py\`, no regressions
- [x] No new dependencies (chromadb already required)

## Phase 1.5 critical-path status

\`s3dm\` (this PR) → \`n8xg\` (discovery resolver) → \`7yd2\` (T3Client) → \`6j2f\` (review gate) → unblocks \`hpxl\` (P3.1 MCP flip).

Bead \`nexus-s3dm\` will close on merge.