### PR TITLE
feat(rdr-112): nexus-n8xg — tier-parametric discovery resolver (T2 + T3)

### DIFF
--- a/src/nexus/daemon/discovery.py
+++ b/src/nexus/daemon/discovery.py
@@ -1,26 +1,28 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Client-side discovery helper for the T2 daemon.
+"""Client-side discovery helper for the T2 and T3 daemons.
 
-Reads the discovery file written by ``T2Daemon._write_discovery`` and
-returns the parsed JSON payload, or ``None`` when no daemon is running
-for the current UID.
+RDR-112 P1.5.2 (nexus-n8xg): generalised from T2-only to tier-parametric
+across ``t2`` and ``t3``. The validation invariants (PID-liveness,
+shutdown-marker, format_version-too-new, non-dict-shape) are shared
+across tiers via ``_validate_discovery_payload``.
 
-Used by:
-  - ``nexus.mcp.core`` to construct a ``T2Client`` under
-    ``NX_STORAGE_MODE=daemon``.
-  - ``nexus.cockpit.hook_bridge`` to route hook tuples through the
-    daemon when one is reachable.
+Discovery file paths:
+- ``<config_dir>/t2_addr.<uid>`` — T2 daemon (memory.db + tuples.db)
+- ``<config_dir>/t3_addr.<uid>`` — T3 daemon (chroma run subprocess)
 
-The discovery file lives at ``<config_dir>/t2_addr.<uid>``. The daemon
-writes it atomically (tmpfile + os.replace) so a partial read is not
-possible.
+Env-var overrides honoured by ``discovery_resolve``:
+- T2: ``NX_T2_SOCK`` (UDS path) then ``NX_T2_ADDR`` (host:port)
+- T3: ``NX_T3_ADDR`` (host:port) — TCP-only per RDR-112 §Approach §2
+
+The daemon writes the file atomically (tmpfile + os.replace) so a
+partial read is not possible.
 """
 from __future__ import annotations
 
 import json
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import structlog
 
@@ -28,81 +30,84 @@ from nexus.config import nexus_config_dir
 
 _log = structlog.get_logger(__name__)
 
-
-def discovery_path(config_dir: Optional[Path] = None) -> Path:
-    """Return the discovery file path for the current UID."""
-    cd = config_dir if config_dir is not None else nexus_config_dir()
-    return cd / f"t2_addr.{os.getuid()}"
+Tier = Literal["t2", "t3"]
+_VALID_TIERS: tuple[str, ...] = ("t2", "t3")
 
 
-def find_t2_daemon(config_dir: Optional[Path] = None) -> Optional[dict[str, Any]]:
-    """Return the daemon's discovery payload, or ``None`` if absent / unreadable.
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
 
-    Args:
-        config_dir: Optional override (defaults to ``nexus_config_dir()``).
 
-    Returns:
-        Dict with keys ``uds_path``, ``tcp_host``, ``tcp_port``, ``pid``,
-        ``daemon_version``, etc. (see ``T2Daemon._discovery_payload``).
-        ``None`` when no discovery file exists, cannot be parsed, or its
-        ``pid`` field refers to a process that is no longer alive.
-
-    Liveness probe (nexus-j6dj): hard reboot / SIGKILL / OOM / panic
-    between ``_write_discovery`` and ``_unlink_discovery`` leaves a stale
-    file pointing at a dead PID. Clients that trust the file route to a
-    nonexistent socket and either fall back to direct mode (with WAL
-    conflicts once a new daemon eventually binds) or hang on the connect
-    attempt. ``os.kill(pid, 0)`` is the canonical POSIX way to probe
-    liveness without delivering a signal; ``ProcessLookupError`` means
-    the PID is unallocated and the file is stale, in which case we
-    best-effort unlink it so a future check is fast. A ``PermissionError``
-    means the PID exists under a different UID, that is a sysadmin-
-    level scenario; treat as live and let the eventual connect surface
-    a clear error.
+class DaemonNotRunningError(RuntimeError):
+    """Raised when ``discovery_resolve(tier)`` finds neither env-var nor a
+    live discovery file. Message includes a recovery hint naming the
+    correct ``nx daemon <tier> start`` invocation.
     """
-    path = discovery_path(config_dir)
-    if not path.exists():
-        return None
-    try:
-        payload = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError) as exc:
-        _log.warning("t2_discovery_read_failed", path=str(path), error=str(exc))
-        return None
 
-    # nexus-26b7 (notable, dim-5 N1): a discovery file containing a
-    # non-dict JSON value would otherwise be returned as-is and the
-    # caller's ``payload.get(...)`` would AttributeError. Refuse.
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+def discovery_path(
+    config_dir: Optional[Path] = None, *, tier: Tier = "t2"
+) -> Path:
+    """Return the discovery file path for the given tier and current UID.
+
+    Signature note: ``config_dir`` is first-positional to preserve the
+    pre-existing callers (``discovery_path(tmp_path)`` etc.). ``tier`` is
+    keyword-only with a default of ``"t2"`` so legacy callers continue
+    to receive the T2 path.
+    """
+    if tier not in _VALID_TIERS:
+        raise ValueError(
+            f"unknown tier {tier!r}; expected one of {_VALID_TIERS}"
+        )
+    cd = config_dir if config_dir is not None else nexus_config_dir()
+    return cd / f"{tier}_addr.{os.getuid()}"
+
+
+# ---------------------------------------------------------------------------
+# Shared payload validation (PID-liveness, shutdown-marker, format check)
+# ---------------------------------------------------------------------------
+
+
+def _validate_discovery_payload(
+    payload: Any, path: Path, *, tier: Tier
+) -> Optional[dict[str, Any]]:
+    """Apply the daemon-discovery validation invariants.
+
+    Returns the payload dict on success, or ``None`` when:
+    - payload is not a dict (nexus-26b7 dim-5 N1)
+    - format_version > 1 (nexus-26b7 dim-13 N-4 — forward-incompat refusal)
+    - status == 'shutting_down' (nexus-2kld.2 HR-2 — shutdown marker)
+    - pid is missing / invalid / refers to a dead process (nexus-j6dj)
+
+    Side-effect: a stale-PID file is best-effort unlinked so the next
+    check is fast. Logs are tagged with the tier.
+    """
     if not isinstance(payload, dict):
         _log.warning(
-            "t2_discovery_unexpected_shape",
+            f"{tier}_discovery_unexpected_shape",
             path=str(path),
             type=type(payload).__name__,
         )
         return None
 
-    # nexus-26b7 (notable, dim-13 N-4): refuse a discovery file whose
-    # ``format_version`` is newer than this wheel understands. Files
-    # written before the field landed have no ``format_version`` and
-    # are accepted as v1 for backward-compat.
     discovery_format = payload.get("format_version", 1)
     if isinstance(discovery_format, int) and discovery_format > 1:
         _log.warning(
-            "t2_discovery_format_too_new",
+            f"{tier}_discovery_format_too_new",
             path=str(path),
             format_version=discovery_format,
         )
         return None
 
-    # nexus-2kld.2 (HR-2, 2026-05-17): honour the shutdown marker.
-    # ``T2Daemon._unlink_discovery`` stamps ``status: "shutting_down"``
-    # into the file before attempting unlink. Combined with the PID-
-    # liveness probe below, this closes the stale-discovery race on
-    # NFS / EROFS scenarios where the unlink itself fails: a reader
-    # that arrives during shutdown sees the marker and treats the
-    # file as stale even though the PID is still observably alive.
     if payload.get("status") == "shutting_down":
         _log.info(
-            "t2_discovery_shutdown_marker_seen",
+            f"{tier}_discovery_shutdown_marker_seen",
             path=str(path),
             shutdown_at=payload.get("shutdown_at"),
         )
@@ -111,26 +116,175 @@ def find_t2_daemon(config_dir: Optional[Path] = None) -> Optional[dict[str, Any]
     pid = payload.get("pid")
     if not isinstance(pid, int) or pid <= 0:
         _log.warning(
-            "t2_discovery_invalid_pid", path=str(path), pid=repr(pid)
+            f"{tier}_discovery_invalid_pid", path=str(path), pid=repr(pid)
         )
         return None
 
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
-        _log.warning("t2_discovery_stale_pid", path=str(path), pid=pid)
+        _log.warning(f"{tier}_discovery_stale_pid", path=str(path), pid=pid)
         try:
             path.unlink(missing_ok=True)
         except OSError as exc:
             _log.warning(
-                "t2_discovery_unlink_failed",
+                f"{tier}_discovery_unlink_failed",
                 path=str(path),
                 error=str(exc),
             )
         return None
     except PermissionError:
-        # Live process under a different UID. Keep the payload, the
-        # eventual connect will give a clearer error than we can here.
+        # Live process under a different UID — treat as alive and let
+        # the eventual connect surface a clearer error than we can here.
         pass
 
     return payload
+
+
+def _read_payload(path: Path, *, tier: Tier) -> Optional[Any]:
+    """Read + parse the discovery file. Returns the raw JSON or None."""
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        _log.warning(f"{tier}_discovery_read_failed", path=str(path), error=str(exc))
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Per-tier find_*_daemon
+# ---------------------------------------------------------------------------
+
+
+def find_t2_daemon(config_dir: Optional[Path] = None) -> Optional[dict[str, Any]]:
+    """Return the T2 daemon's discovery payload, or ``None`` if absent /
+    unreadable / stale.
+
+    See ``_validate_discovery_payload`` for the validation invariants.
+    Public signature preserved for backward-compat with existing callers
+    in ``nexus.mcp.core``, ``nexus.cockpit.hook_bridge``,
+    ``nexus.commands.cockpit``, and the test suite.
+    """
+    path = discovery_path(config_dir, tier="t2")
+    raw = _read_payload(path, tier="t2")
+    if raw is None:
+        return None
+    return _validate_discovery_payload(raw, path, tier="t2")
+
+
+def find_t3_daemon(config_dir: Optional[Path] = None) -> Optional[dict[str, Any]]:
+    """Return the T3 daemon's discovery payload, or ``None`` if absent /
+    unreadable / stale. Mirrors ``find_t2_daemon`` exactly but reads the
+    T3 discovery file. T3 payloads carry ``tcp_host`` + ``tcp_port`` (no
+    ``uds_path`` — chromadb 1.4.4's bundled HTTP server is TCP-only,
+    RDR-112 §Approach §2).
+    """
+    path = discovery_path(config_dir, tier="t3")
+    raw = _read_payload(path, tier="t3")
+    if raw is None:
+        return None
+    return _validate_discovery_payload(raw, path, tier="t3")
+
+
+# ---------------------------------------------------------------------------
+# Unified resolver — env-first, file-fallback
+# ---------------------------------------------------------------------------
+
+
+def _parse_host_port(env_value: str, *, env_name: str) -> tuple[str, int]:
+    """Parse a ``host:port`` env value. Raises ``ValueError`` on malformed
+    input — the env-var contract is explicit; surface the breakage at the
+    resolver boundary, not at connect time."""
+    if ":" not in env_value:
+        raise ValueError(
+            f"{env_name}={env_value!r} is malformed; expected 'host:port'."
+        )
+    host, _, port_str = env_value.rpartition(":")
+    try:
+        port = int(port_str)
+    except ValueError as exc:
+        raise ValueError(
+            f"{env_name}={env_value!r} has non-integer port {port_str!r}."
+        ) from exc
+    return host, port
+
+
+def discovery_resolve(
+    tier: Tier, *, config_dir: Optional[Path] = None
+) -> dict[str, Any]:
+    """Resolve the daemon-connection target for ``tier``.
+
+    Resolution order:
+        1. Honour env-var first:
+           - T2: ``NX_T2_SOCK`` (UDS path) → ``NX_T2_ADDR`` (host:port).
+           - T3: ``NX_T3_ADDR`` (host:port).
+        2. Fall back to the discovery file via ``find_t<tier>_daemon``.
+        3. Raise ``DaemonNotRunningError`` with a recovery hint.
+
+    The returned dict always carries a ``source`` key indicating the
+    resolution path: ``'env:NX_T2_SOCK' | 'env:NX_T2_ADDR' | 'env:NX_T3_ADDR'``
+    or ``'file'``. Callers do not need to inspect ``source``; it exists
+    for diagnostics and the daemon-mode-hint test surface.
+
+    Args:
+        tier: ``'t2'`` or ``'t3'``.
+        config_dir: Optional override for the file-fallback path.
+
+    Returns:
+        The discovery payload merged with a ``source`` annotation.
+
+    Raises:
+        ValueError: malformed env-var (e.g. NX_T3_ADDR missing ':port').
+        DaemonNotRunningError: neither env-var nor a live discovery file
+            resolves; recovery hint embedded in the message.
+    """
+    if tier not in _VALID_TIERS:
+        raise ValueError(
+            f"unknown tier {tier!r}; expected one of {_VALID_TIERS}"
+        )
+
+    # --- T2: NX_T2_SOCK first (UDS), then NX_T2_ADDR (TCP) ---
+    if tier == "t2":
+        sock = os.environ.get("NX_T2_SOCK", "").strip()
+        if sock:
+            return {
+                "uds_path": sock,
+                "source": "env:NX_T2_SOCK",
+            }
+        addr = os.environ.get("NX_T2_ADDR", "").strip()
+        if addr:
+            host, port = _parse_host_port(addr, env_name="NX_T2_ADDR")
+            return {
+                "tcp_host": host,
+                "tcp_port": port,
+                "source": "env:NX_T2_ADDR",
+            }
+
+    # --- T3: NX_T3_ADDR (TCP only — chromadb upstream constraint) ---
+    if tier == "t3":
+        addr = os.environ.get("NX_T3_ADDR", "").strip()
+        if addr:
+            host, port = _parse_host_port(addr, env_name="NX_T3_ADDR")
+            return {
+                "tcp_host": host,
+                "tcp_port": port,
+                "source": "env:NX_T3_ADDR",
+            }
+
+    # --- File fallback ---
+    finder = find_t2_daemon if tier == "t2" else find_t3_daemon
+    payload = finder(config_dir)
+    if payload is not None:
+        # Annotate the source for diagnostics; do not mutate the caller's
+        # view of the on-disk payload (copy first).
+        result = dict(payload)
+        result["source"] = "file"
+        return result
+
+    raise DaemonNotRunningError(
+        f"No {tier} daemon discovery resolved. Tried env-var "
+        f"({'NX_T2_SOCK / NX_T2_ADDR' if tier == 't2' else 'NX_T3_ADDR'}) "
+        f"and discovery file ({discovery_path(config_dir, tier=tier)}). "
+        f"Start with: `nx daemon {tier} start`."
+    )

--- a/tests/daemon/test_discovery.py
+++ b/tests/daemon/test_discovery.py
@@ -1,0 +1,405 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 P1.5.2 (nexus-n8xg): tier-parametric discovery resolver tests.
+
+Covers:
+- ``discovery_path()`` backward-compat for T2 + new T3 path shape.
+- ``find_t3_daemon()`` mirrors ``find_t2_daemon()`` validation
+  invariants: PID-liveness, shutdown-marker, format_version > 1 rejection,
+  non-dict shape rejection.
+- ``discovery_resolve(tier)`` env-first, file-fallback chain:
+  ``NX_T2_SOCK`` / ``NX_T2_ADDR`` for T2; ``NX_T3_ADDR`` for T3.
+- ``DaemonNotRunningError`` raised with clear recovery hint when nothing
+  resolves.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    cd = tmp_path / "nexus_config"
+    cd.mkdir()
+    return cd
+
+
+def _live_pid() -> int:
+    """Return a guaranteed-live PID for the test process."""
+    return os.getpid()
+
+
+def _write_payload(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload))
+    os.chmod(str(path), 0o600)
+
+
+# ---------------------------------------------------------------------------
+# discovery_path()
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryPath:
+    def test_default_tier_is_t2_backward_compat(self, config_dir: Path) -> None:
+        """``discovery_path(config_dir)`` returns the T2 path with no tier kwarg.
+        Backward-compat for the 6 existing positional callers."""
+        from nexus.daemon.discovery import discovery_path
+
+        expected = config_dir / f"t2_addr.{os.getuid()}"
+        assert discovery_path(config_dir) == expected
+
+    def test_explicit_tier_t2(self, config_dir: Path) -> None:
+        from nexus.daemon.discovery import discovery_path
+
+        expected = config_dir / f"t2_addr.{os.getuid()}"
+        assert discovery_path(config_dir, tier="t2") == expected
+
+    def test_explicit_tier_t3(self, config_dir: Path) -> None:
+        from nexus.daemon.discovery import discovery_path
+
+        expected = config_dir / f"t3_addr.{os.getuid()}"
+        assert discovery_path(config_dir, tier="t3") == expected
+
+    def test_unknown_tier_raises(self, config_dir: Path) -> None:
+        from nexus.daemon.discovery import discovery_path
+
+        with pytest.raises(ValueError):
+            discovery_path(config_dir, tier="t9")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# find_t3_daemon validation parity with find_t2_daemon
+# ---------------------------------------------------------------------------
+
+
+class TestFindT3Daemon:
+    def test_returns_none_when_disc_file_absent(self, config_dir: Path) -> None:
+        from nexus.daemon.discovery import find_t3_daemon
+
+        assert find_t3_daemon(config_dir) is None
+
+    def test_returns_payload_when_pid_live(self, config_dir: Path) -> None:
+        from nexus.daemon.discovery import discovery_path, find_t3_daemon
+
+        payload = {
+            "format_version": 1,
+            "tcp_host": "127.0.0.1",
+            "tcp_port": 9012,
+            "pid": _live_pid(),
+            "daemon_version": "test",
+            "start_time": "1970-01-01T00:00:00",
+            "local_path": "/tmp/chroma-t3",
+        }
+        _write_payload(discovery_path(config_dir, tier="t3"), payload)
+        result = find_t3_daemon(config_dir)
+        assert result is not None
+        assert result["pid"] == _live_pid()
+        assert result["tcp_port"] == 9012
+
+    def test_stale_pid_unlinks_and_returns_none(self, config_dir: Path) -> None:
+        from nexus.daemon.discovery import discovery_path, find_t3_daemon
+
+        path = discovery_path(config_dir, tier="t3")
+        _write_payload(
+            path,
+            {
+                "format_version": 1,
+                "tcp_host": "127.0.0.1",
+                "tcp_port": 9013,
+                "pid": 2**31 - 1,  # never a real PID
+                "daemon_version": "test",
+                "start_time": "1970-01-01T00:00:00",
+                "local_path": "/tmp/chroma-t3",
+            },
+        )
+        assert find_t3_daemon(config_dir) is None
+        assert not path.exists(), "stale discovery file must be unlinked"
+
+    def test_shutdown_marker_returns_none(self, config_dir: Path) -> None:
+        from nexus.daemon.discovery import discovery_path, find_t3_daemon
+
+        _write_payload(
+            discovery_path(config_dir, tier="t3"),
+            {
+                "format_version": 1,
+                "status": "shutting_down",
+                "shutdown_at": "1970-01-01T00:00:00",
+                "tcp_host": "127.0.0.1",
+                "tcp_port": 9014,
+                "pid": _live_pid(),
+                "daemon_version": "test",
+                "start_time": "1970-01-01T00:00:00",
+                "local_path": "/tmp/chroma-t3",
+            },
+        )
+        assert find_t3_daemon(config_dir) is None
+
+    def test_format_version_too_new_returns_none(self, config_dir: Path) -> None:
+        from nexus.daemon.discovery import discovery_path, find_t3_daemon
+
+        _write_payload(
+            discovery_path(config_dir, tier="t3"),
+            {
+                "format_version": 99,
+                "tcp_host": "127.0.0.1",
+                "tcp_port": 9015,
+                "pid": _live_pid(),
+                "daemon_version": "test",
+                "start_time": "1970-01-01T00:00:00",
+                "local_path": "/tmp/chroma-t3",
+            },
+        )
+        assert find_t3_daemon(config_dir) is None
+
+    def test_non_dict_payload_returns_none(self, config_dir: Path) -> None:
+        from nexus.daemon.discovery import discovery_path, find_t3_daemon
+
+        path = discovery_path(config_dir, tier="t3")
+        path.write_text(json.dumps(["not", "a", "dict"]))
+        assert find_t3_daemon(config_dir) is None
+
+
+# ---------------------------------------------------------------------------
+# discovery_resolve — env-first, file-fallback chain
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryResolveT3:
+    def test_env_var_wins_over_file(
+        self, config_dir: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.discovery import discovery_path, discovery_resolve
+
+        # Plant a file with one port; env-var advertises a different one.
+        _write_payload(
+            discovery_path(config_dir, tier="t3"),
+            {
+                "format_version": 1,
+                "tcp_host": "127.0.0.1",
+                "tcp_port": 9100,
+                "pid": _live_pid(),
+                "daemon_version": "test",
+                "start_time": "1970-01-01T00:00:00",
+                "local_path": "/tmp/chroma-t3",
+            },
+        )
+        monkeypatch.setenv("NX_T3_ADDR", "10.0.0.5:5555")
+        result = discovery_resolve("t3", config_dir=config_dir)
+        assert result["tcp_host"] == "10.0.0.5"
+        assert result["tcp_port"] == 5555
+        assert result["source"] == "env:NX_T3_ADDR"
+
+    def test_file_fallback_when_env_unset(
+        self, config_dir: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.discovery import discovery_path, discovery_resolve
+
+        monkeypatch.delenv("NX_T3_ADDR", raising=False)
+        _write_payload(
+            discovery_path(config_dir, tier="t3"),
+            {
+                "format_version": 1,
+                "tcp_host": "127.0.0.1",
+                "tcp_port": 9200,
+                "pid": _live_pid(),
+                "daemon_version": "test",
+                "start_time": "1970-01-01T00:00:00",
+                "local_path": "/tmp/chroma-t3",
+            },
+        )
+        result = discovery_resolve("t3", config_dir=config_dir)
+        assert result["tcp_port"] == 9200
+        assert result["source"] == "file"
+
+    def test_raises_daemon_not_running_when_nothing_resolves(
+        self, config_dir: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.discovery import (
+            DaemonNotRunningError,
+            discovery_resolve,
+        )
+
+        monkeypatch.delenv("NX_T3_ADDR", raising=False)
+        with pytest.raises(DaemonNotRunningError) as excinfo:
+            discovery_resolve("t3", config_dir=config_dir)
+        msg = str(excinfo.value)
+        # The error message must surface a recovery hint.
+        assert "nx daemon t3 start" in msg
+        assert "t3" in msg.lower()
+
+    def test_stale_pid_propagates_as_daemon_not_running(
+        self, config_dir: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.discovery import (
+            DaemonNotRunningError,
+            discovery_path,
+            discovery_resolve,
+        )
+
+        monkeypatch.delenv("NX_T3_ADDR", raising=False)
+        _write_payload(
+            discovery_path(config_dir, tier="t3"),
+            {
+                "format_version": 1,
+                "tcp_host": "127.0.0.1",
+                "tcp_port": 9300,
+                "pid": 2**31 - 1,
+                "daemon_version": "test",
+                "start_time": "1970-01-01T00:00:00",
+                "local_path": "/tmp/chroma-t3",
+            },
+        )
+        with pytest.raises(DaemonNotRunningError):
+            discovery_resolve("t3", config_dir=config_dir)
+
+    def test_shutdown_marker_propagates_as_daemon_not_running(
+        self, config_dir: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.discovery import (
+            DaemonNotRunningError,
+            discovery_path,
+            discovery_resolve,
+        )
+
+        monkeypatch.delenv("NX_T3_ADDR", raising=False)
+        _write_payload(
+            discovery_path(config_dir, tier="t3"),
+            {
+                "format_version": 1,
+                "status": "shutting_down",
+                "tcp_host": "127.0.0.1",
+                "tcp_port": 9400,
+                "pid": _live_pid(),
+                "daemon_version": "test",
+                "start_time": "1970-01-01T00:00:00",
+                "local_path": "/tmp/chroma-t3",
+            },
+        )
+        with pytest.raises(DaemonNotRunningError):
+            discovery_resolve("t3", config_dir=config_dir)
+
+    def test_malformed_env_var_raises_value_error(
+        self, config_dir: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.discovery import discovery_resolve
+
+        monkeypatch.setenv("NX_T3_ADDR", "not-a-host-port")
+        with pytest.raises(ValueError):
+            discovery_resolve("t3", config_dir=config_dir)
+
+
+class TestDiscoveryResolveT2:
+    """Regression: existing T2 callers continue to work unchanged."""
+
+    def test_t2_file_resolution_matches_find_t2_daemon(
+        self, config_dir: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.discovery import (
+            discovery_path,
+            discovery_resolve,
+            find_t2_daemon,
+        )
+
+        monkeypatch.delenv("NX_T2_SOCK", raising=False)
+        monkeypatch.delenv("NX_T2_ADDR", raising=False)
+
+        payload = {
+            "format_version": 1,
+            "uds_path": "/tmp/t2.sock",
+            "tcp_host": "127.0.0.1",
+            "tcp_port": 9500,
+            "pid": _live_pid(),
+            "daemon_version": "test",
+            "start_time": "1970-01-01T00:00:00",
+        }
+        _write_payload(discovery_path(config_dir, tier="t2"), payload)
+        via_resolve = discovery_resolve("t2", config_dir=config_dir)
+        via_find = find_t2_daemon(config_dir)
+        assert via_find is not None
+        # Same payload (modulo the ``source`` annotation added by resolve).
+        for key in ("pid", "tcp_port", "uds_path", "tcp_host"):
+            assert via_resolve[key] == via_find[key]
+        assert via_resolve["source"] == "file"
+
+    def test_nx_t2_sock_env_wins_over_file(
+        self, config_dir: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.discovery import discovery_path, discovery_resolve
+
+        _write_payload(
+            discovery_path(config_dir, tier="t2"),
+            {
+                "format_version": 1,
+                "uds_path": "/tmp/file.sock",
+                "tcp_host": "127.0.0.1",
+                "tcp_port": 9501,
+                "pid": _live_pid(),
+                "daemon_version": "test",
+                "start_time": "1970-01-01T00:00:00",
+            },
+        )
+        monkeypatch.setenv("NX_T2_SOCK", "/tmp/env.sock")
+        monkeypatch.delenv("NX_T2_ADDR", raising=False)
+        result = discovery_resolve("t2", config_dir=config_dir)
+        assert result["uds_path"] == "/tmp/env.sock"
+        assert result["source"] == "env:NX_T2_SOCK"
+
+    def test_nx_t2_addr_env_wins_over_file_when_no_sock(
+        self, config_dir: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.discovery import discovery_path, discovery_resolve
+
+        _write_payload(
+            discovery_path(config_dir, tier="t2"),
+            {
+                "format_version": 1,
+                "uds_path": "/tmp/file.sock",
+                "tcp_host": "127.0.0.1",
+                "tcp_port": 9502,
+                "pid": _live_pid(),
+                "daemon_version": "test",
+                "start_time": "1970-01-01T00:00:00",
+            },
+        )
+        monkeypatch.delenv("NX_T2_SOCK", raising=False)
+        monkeypatch.setenv("NX_T2_ADDR", "10.0.0.5:5556")
+        result = discovery_resolve("t2", config_dir=config_dir)
+        assert result["tcp_host"] == "10.0.0.5"
+        assert result["tcp_port"] == 5556
+        assert result["source"] == "env:NX_T2_ADDR"
+
+    def test_t2_raises_daemon_not_running_when_nothing_resolves(
+        self, config_dir: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.discovery import (
+            DaemonNotRunningError,
+            discovery_resolve,
+        )
+
+        monkeypatch.delenv("NX_T2_SOCK", raising=False)
+        monkeypatch.delenv("NX_T2_ADDR", raising=False)
+        with pytest.raises(DaemonNotRunningError) as excinfo:
+            discovery_resolve("t2", config_dir=config_dir)
+        assert "nx daemon t2 start" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: find_t2_daemon unchanged behavior
+# ---------------------------------------------------------------------------
+
+
+class TestFindT2DaemonBackwardCompat:
+    def test_signature_unchanged(self, config_dir: Path) -> None:
+        from nexus.daemon.discovery import find_t2_daemon
+
+        # Positional config_dir still works (existing call sites).
+        result = find_t2_daemon(config_dir)
+        assert result is None  # no discovery file → None


### PR DESCRIPTION
## Summary

P1.5.2 of the corrective RDR-112 Phase 1.5 chain (epic \`nexus-8hy6\`). Generalises \`src/nexus/daemon/discovery.py\` from T2-only to handle both T2 and T3 tiers via a shared validation helper and a unified resolver.

## New surface

- \`DaemonNotRunningError(RuntimeError)\` — raised when \`discovery_resolve\` finds neither env-var nor a live discovery file. Recovery hint embedded in message.
- \`discovery_path(config_dir, *, tier='t2') -> Path\` — keyword-only \`tier\` preserves all 6 existing positional callers (\`discovery.discovery_path(tmp_path)\` etc.).
- \`find_t3_daemon(config_dir) -> Optional[dict]\` — mirrors \`find_t2_daemon\` exactly. T3 payloads are TCP-only (no \`uds_path\` — chromadb 1.4.4 upstream constraint per RDR-112 §Approach §2).
- \`discovery_resolve(tier, *, config_dir=None) -> dict\` — env-first, file-fallback. T2 honours \`NX_T2_SOCK\` then \`NX_T2_ADDR\`; T3 honours \`NX_T3_ADDR\`. Returns dict with a \`source\` annotation (\`env:NX_T2_SOCK\` / \`env:NX_T2_ADDR\` / \`env:NX_T3_ADDR\` / \`file\`).

## Refactor

Extracted \`_validate_discovery_payload(payload, path, *, tier)\` helper carrying every existing T2 guard verbatim: non-dict-shape rejection (nexus-26b7 N1), format_version-too-new (N-4), shutdown-marker (nexus-2kld.2 HR-2), invalid-pid, stale-PID-with-best-effort-unlink (nexus-j6dj). T2 and T3 share the helper — invariants identical by construction, not by code duplication.

## Backward-compat

\`find_t2_daemon\` public signature unchanged. The 4 production callers (\`nexus.mcp.core\`, \`nexus.cockpit.hook_bridge\`, \`nexus.commands.cockpit\`, \`nexus.daemon.__init__\`) and the 14 test call sites continue to work.

## Test plan

- [x] \`tests/daemon/test_discovery.py\` — 21/21 pass in 0.08s
  - \`discovery_path\`: backward-compat T2 default, explicit \`tier='t3'\`, unknown-tier ValueError
  - \`find_t3_daemon\`: live PID, stale PID + unlink side-effect, shutdown marker, format_version > 1, non-dict payload
  - \`discovery_resolve('t3')\`: env wins over file, file fallback, DaemonNotRunningError on nothing, stale-PID propagates, shutdown marker propagates, malformed env raises ValueError
  - \`discovery_resolve('t2')\` regression: file resolution matches \`find_t2_daemon\`, NX_T2_SOCK wins, NX_T2_ADDR wins when no SOCK, DaemonNotRunningError on nothing
  - \`find_t2_daemon\` backward-compat: positional signature unchanged
- [x] Wider sweep: \`tests/daemon/\` + \`tests/cockpit/test_hook_bridge_daemon_routing.py\` — 451 passed, no regressions

## Out of scope (next bead)

\`T3Client\` wrapping \`chromadb.HttpClient\` using this resolver lands in \`nexus-7yd2\` (P1.5.3). \`hpxl\` (P3.1 MCP flip) stays blocked behind the Phase 1.5 review gate (\`nexus-6j2f\`).

Bead \`nexus-n8xg\` will close on merge.