### PR TITLE
feat(rdr-112): nexus-7yd2 — T3Client factory (T3Database wrapping HttpClient)

### DIFF
--- a/src/nexus/daemon/t3_client.py
+++ b/src/nexus/daemon/t3_client.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-112 P1.5.3 (nexus-7yd2) — T3Client factory.
+
+The integration seam Phase 3 (nexus-hpxl / MCP flip) consumes. Returns
+a real ``T3Database`` whose ``_client`` is a ``chromadb.HttpClient``
+pointed at the running ``nx daemon t3``. Surface parity by construction:
+same class as direct-mode ``make_t3()``, no shim, no method drift.
+
+Resolution chain:
+1. ``is_local_mode()`` must be True. Cloud mode raises ``T3DaemonError``
+   because chromadb's ``CloudClient`` is already HTTP-served — running a
+   local daemon would be a no-op (semantic gate per PLAN-AUDIT
+   2026-05-17; the daemon-start side gate in
+   ``t3_daemon.start_t3_daemon`` is defence-in-depth).
+2. ``discovery_resolve('t3')`` resolves the daemon's address via
+   ``NX_T3_ADDR`` env-var or the discovery file. Missing daemon raises
+   ``T3DaemonError`` carrying the same recovery hint as
+   ``DaemonNotRunningError``.
+3. Construct ``chromadb.HttpClient(host, port)`` + apply the nexus-jgjw
+   read-timeout override.
+4. Construct + inject ``LocalEmbeddingFunction`` (daemon is local-only,
+   so Voyage embeddings are not in play).
+5. Return ``T3Database(_client=httpclient, _ef_override=ef,
+   local_mode=True, local_path=<discovery payload>)``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+import structlog
+
+if TYPE_CHECKING:
+    from nexus.db.t3 import T3Database
+
+_log = structlog.get_logger(__name__)
+
+
+class T3DaemonError(RuntimeError):
+    """Raised by ``make_t3_client`` when the T3 daemon is not reachable.
+
+    Two subclasses-of-cases share this type:
+    - Cloud mode: no daemon should exist; caller should use direct
+      ``make_t3()`` (which builds a ``CloudClient`` directly).
+    - Local mode + no daemon running: caller must ``nx daemon t3 start``
+      before retrying. Message embeds the recovery hint verbatim.
+    """
+
+
+def make_t3_client(*, config_dir: Optional[Path] = None) -> "T3Database":
+    """Return a ``T3Database`` connected to the running T3 daemon.
+
+    Args:
+        config_dir: Optional override for the discovery file location
+            (defaults to ``nexus.config.nexus_config_dir()``).
+
+    Raises:
+        T3DaemonError: when cloud mode is active OR the T3 daemon is
+            not reachable. The message names the recovery action.
+
+    Notes on fail-loud-on-missing-daemon: no auto-spawn. Matches the
+    T2 contract (RDR-112 §Incremental adoption: "no auto-spawn in
+    daemon mode"). The CLI ``nx daemon t3 start`` is the only path
+    that spawns the chroma subprocess.
+    """
+    from nexus.config import is_local_mode
+    from nexus.daemon.discovery import (
+        DaemonNotRunningError,
+        discovery_resolve,
+    )
+    from nexus.db.t3 import T3Database, _apply_chroma_http_timeout
+
+    if not is_local_mode():
+        raise T3DaemonError(
+            "T3 daemon is a no-op in cloud mode. chromadb's CloudClient "
+            "is already HTTP-served; use the direct ``make_t3()`` factory "
+            "from ``nexus.db`` for cloud access. Set NX_LOCAL=1 to opt "
+            "into the local daemon path."
+        )
+
+    try:
+        payload = discovery_resolve("t3", config_dir=config_dir)
+    except DaemonNotRunningError as exc:
+        # Preserve the recovery hint verbatim; DaemonNotRunningError
+        # already names ``nx daemon t3 start`` as the fix.
+        raise T3DaemonError(str(exc)) from exc
+
+    host = payload.get("tcp_host")
+    port = payload.get("tcp_port")
+    if not isinstance(host, str) or not isinstance(port, int):
+        raise T3DaemonError(
+            f"Discovery payload missing or invalid tcp_host/tcp_port: "
+            f"host={host!r}, port={port!r}. Re-start with: "
+            f"`nx daemon t3 stop && nx daemon t3 start`."
+        )
+
+    # Construct the HTTP client first so the timeout override can be
+    # applied immediately — chromadb defaults to ``httpx.Client(timeout=
+    # None)`` which hangs forever on a stalled response (nexus-jgjw).
+    import chromadb
+    http_client = chromadb.HttpClient(host=host, port=port)
+    _apply_chroma_http_timeout(http_client)
+
+    # Local-only daemon path: use the bundled ONNX MiniLM via
+    # LocalEmbeddingFunction. Voyage embeddings live in cloud mode, which
+    # this factory rejects at the top.
+    from nexus.db.local_ef import LocalEmbeddingFunction
+    import os
+    model_override = os.environ.get("NX_LOCAL_EMBED_MODEL", "")
+    ef = LocalEmbeddingFunction(
+        model_name=model_override if model_override else None,
+    )
+
+    # T3Database accepts ``_client`` injection (db/t3.py:281). When
+    # ``local_mode=True`` AND ``_client is not None``, the constructor
+    # uses the injected client and skips the PersistentClient build
+    # path. ``local_path`` is still passed through for diagnostics; the
+    # daemon owns the on-disk store.
+    local_path_str = payload.get("local_path", "")
+    _log.info(
+        "t3_client_constructed",
+        host=host,
+        port=port,
+        source=payload.get("source"),
+        local_path=local_path_str,
+    )
+    return T3Database(
+        local_mode=True,
+        local_path=local_path_str,
+        _client=http_client,
+        _ef_override=ef,
+    )

--- a/tests/daemon/test_t3_client.py
+++ b/tests/daemon/test_t3_client.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 P1.5.3 (nexus-7yd2): T3Client factory tests.
+
+Tests the integration seam Phase 3 (nexus-hpxl) will use. The factory is
+``make_t3_client()`` returning a ``T3Database`` whose ``_client`` is a
+``chromadb.HttpClient`` pointed at the running ``nx daemon t3`` (per
+``discovery_resolve('t3')`` from nexus-n8xg).
+
+Surface parity by construction: the returned ``T3Database`` IS the same
+class returned by ``make_t3()`` in direct mode — no shim, no method
+drift. The only difference is the injected client.
+"""
+from __future__ import annotations
+
+import inspect
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    cd = tmp_path / "nexus_config"
+    cd.mkdir()
+    return cd
+
+
+@pytest.fixture
+def local_path(tmp_path: Path) -> Path:
+    p = tmp_path / "chroma_t3"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def force_local_mode(monkeypatch):
+    """Force ``is_local_mode()`` to return True regardless of env credentials."""
+    monkeypatch.setenv("NX_LOCAL", "1")
+
+
+@pytest.fixture
+def live_t3_daemon(config_dir: Path, local_path: Path, force_local_mode):
+    """Spawn a real T3 daemon for the test, yield the discovery payload,
+    and stop the daemon on teardown."""
+    from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+
+    payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+    try:
+        yield payload
+    finally:
+        stop_t3_daemon(config_dir=config_dir)
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud: no daemon running
+# ---------------------------------------------------------------------------
+
+
+class TestFailLoudOnMissingDaemon:
+    def test_no_daemon_raises_t3_daemon_error_with_recovery_hint(
+        self, config_dir: Path, force_local_mode, monkeypatch
+    ) -> None:
+        from nexus.daemon.t3_client import T3DaemonError, make_t3_client
+
+        monkeypatch.delenv("NX_T3_ADDR", raising=False)
+        with pytest.raises(T3DaemonError) as excinfo:
+            make_t3_client(config_dir=config_dir)
+        msg = str(excinfo.value)
+        assert "nx daemon t3 start" in msg
+
+    def test_no_auto_spawn(
+        self, config_dir: Path, force_local_mode, monkeypatch
+    ) -> None:
+        """No discovery file is created when the daemon is absent.
+        Matches T2 contract: 'no auto-spawn in daemon mode' per RDR-112."""
+        from nexus.daemon.t3_client import T3DaemonError, make_t3_client
+        from nexus.daemon.discovery import discovery_path
+
+        monkeypatch.delenv("NX_T3_ADDR", raising=False)
+        with pytest.raises(T3DaemonError):
+            make_t3_client(config_dir=config_dir)
+        assert not discovery_path(config_dir, tier="t3").exists()
+
+
+# ---------------------------------------------------------------------------
+# Cloud mode: factory is the semantic gate (per PLAN-AUDIT)
+# ---------------------------------------------------------------------------
+
+
+class TestCloudModeRejection:
+    def test_cloud_mode_raises_t3_daemon_error_with_clear_message(
+        self, config_dir: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.t3_client import T3DaemonError, make_t3_client
+
+        monkeypatch.setenv("NX_LOCAL", "0")
+        # Sneak past the credential auto-detection by faking credentials
+        # exist; otherwise is_local_mode() defaults to True when keys are
+        # absent.
+        monkeypatch.setenv("CHROMA_API_KEY", "fake-for-cloud-test")
+        monkeypatch.setenv("VOYAGE_API_KEY", "fake-for-cloud-test")
+        with pytest.raises(T3DaemonError) as excinfo:
+            make_t3_client(config_dir=config_dir)
+        msg = str(excinfo.value).lower()
+        assert "cloud" in msg
+        assert "no t3 daemon" in msg or "no daemon" in msg or "no-op" in msg
+
+
+# ---------------------------------------------------------------------------
+# Happy path: real chroma subprocess, T3Database round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPathRoundTrip:
+    def test_make_t3_client_returns_t3_database_backed_by_http_client(
+        self, live_t3_daemon, config_dir: Path
+    ) -> None:
+        import chromadb
+
+        from nexus.daemon.t3_client import make_t3_client
+        from nexus.db.t3 import T3Database
+
+        t3 = make_t3_client(config_dir=config_dir)
+        try:
+            assert isinstance(t3, T3Database)
+            # The injected client must be an HttpClient (or at least carry
+            # an _server with _session — chromadb.HttpClient does, but
+            # PersistentClient does not).
+            assert hasattr(t3._client, "_server"), (
+                "expected HttpClient-shaped _client with _server attribute"
+            )
+        finally:
+            # T3Database has __exit__ but no close(); just let it go.
+            pass
+
+    def test_round_trip_collection_query(
+        self, live_t3_daemon, config_dir: Path
+    ) -> None:
+        """list_collections + get_or_create_collection + add + query —
+        the core happy-path Phase 3 will exercise via mcp_infra.get_t3()."""
+        from nexus.daemon.t3_client import make_t3_client
+
+        t3 = make_t3_client(config_dir=config_dir)
+        client = t3._client
+        coll = client.get_or_create_collection("t3_client_smoke")
+        coll.add(documents=["alpha doc", "beta doc"], ids=["a", "b"])
+        result = coll.query(query_texts=["alpha"], n_results=1)
+        assert result["ids"][0] == ["a"]
+
+
+# ---------------------------------------------------------------------------
+# HTTP timeout override (nexus-jgjw)
+# ---------------------------------------------------------------------------
+
+
+class TestHttpTimeoutApplied:
+    def test_http_client_session_timeout_overridden(
+        self, live_t3_daemon, config_dir: Path
+    ) -> None:
+        """The factory must call ``_apply_chroma_http_timeout`` so the
+        daemon path inherits the nexus-jgjw read-timeout fix (chromadb
+        ships ``httpx.Client(timeout=None)`` which hangs indefinitely
+        on a stalled response)."""
+        from nexus.daemon.t3_client import make_t3_client
+        from nexus.db.t3 import CHROMA_HTTP_READ_TIMEOUT_S
+
+        t3 = make_t3_client(config_dir=config_dir)
+        server = getattr(t3._client, "_server", None)
+        assert server is not None, "HttpClient must expose _server"
+        session = getattr(server, "_session", None)
+        assert session is not None, "_server must expose _session"
+        timeout = session.timeout
+        assert timeout is not None, "session.timeout must not be None"
+        # httpx.Timeout exposes .read; confirm it matches the constant.
+        read_timeout = getattr(timeout, "read", None)
+        assert read_timeout == pytest.approx(CHROMA_HTTP_READ_TIMEOUT_S)
+
+
+# ---------------------------------------------------------------------------
+# Surface parity vs make_t3() (direct-mode T3Database)
+# ---------------------------------------------------------------------------
+
+
+class TestSurfaceParity:
+    def test_public_method_set_matches_make_t3(
+        self, live_t3_daemon, config_dir: Path
+    ) -> None:
+        """make_t3_client and make_t3 must return objects with identical
+        public method sets (same class — T3Database — by construction).
+        Catches accidental shim-class introduction."""
+        from nexus.daemon.t3_client import make_t3_client
+        from nexus.db.t3 import T3Database
+
+        t3_client = make_t3_client(config_dir=config_dir)
+        # Both objects are T3Database; same class → same public surface.
+        assert type(t3_client) is T3Database
+
+        # Belt-and-suspenders: enumerate public methods of T3Database and
+        # confirm every one is callable on the returned instance.
+        public_methods = [
+            name for name, member in inspect.getmembers(T3Database, callable)
+            if not name.startswith("_")
+        ]
+        for name in public_methods:
+            assert callable(getattr(t3_client, name)), (
+                f"{name} not callable on make_t3_client() return"
+            )


### PR DESCRIPTION
## Summary

P1.5.3 of the corrective RDR-112 Phase 1.5 chain (epic \`nexus-8hy6\`). Adds the integration-seam factory Phase 3 (\`nexus-hpxl\` / MCP flip) consumes.

## New surface

- \`T3DaemonError(RuntimeError)\` — single typed exception covering cloud-mode rejection and missing-daemon cases. Recovery hint preserved verbatim from \`DaemonNotRunningError\`.
- \`make_t3_client(*, config_dir=None) -> T3Database\` — factory chain:
  1. Cloud-mode rejection (NX_LOCAL=0): CloudClient already speaks HTTP; daemon is a no-op there.
  2. \`discovery_resolve('t3')\` resolves the address (env-first via \`NX_T3_ADDR\`, then discovery file).
  3. \`chromadb.HttpClient(host, port)\` + apply nexus-jgjw read-timeout override via \`_apply_chroma_http_timeout\`.
  4. \`LocalEmbeddingFunction\` (daemon is local-only).
  5. Return \`T3Database(local_mode=True, _client=httpclient, _ef_override=ef, local_path=<discovery payload>)\`.

## Surface parity by construction

Returns the same \`T3Database\` class as direct-mode \`make_t3()\`. The injected \`_client\` is \`HttpClient\` instead of \`PersistentClient\`; every public method works identically because the \`chromadb.ClientAPI\` surface is the same. No shim, no method drift — Phase 3 can flip \`mcp_infra.get_t3()\` by swapping the constructor only.

## Fail-loud-on-missing-daemon

No auto-spawn. Matches the T2 contract per RDR-112 §Incremental adoption ("no auto-spawn in daemon mode"). The CLI \`nx daemon t3 start\` is the only spawn path.

## Test plan

- [x] \`tests/daemon/test_t3_client.py\` — 7/7 pass in ~14s
  - Fail-loud: \`T3DaemonError\` raised with recovery hint; no auto-spawn (discovery file stays absent)
  - Cloud-mode rejection: clear message naming the alternative
  - Happy path: real \`chroma run\` subprocess, returned T3Database is HttpClient-backed, collection \`add\` + \`query\` round-trip
  - HTTP timeout override: assert \`session.timeout.read == CHROMA_HTTP_READ_TIMEOUT_S\`
  - Surface parity: \`type(make_t3_client()) is T3Database\`, every public method on T3Database callable on the returned instance
- [x] Wider sweep: \`tests/daemon/\` + \`tests/cockpit/test_hook_bridge_daemon_routing.py\` — 458 passed, no regressions

## Phase 1.5 progress

All four impl beads of Phase 1.5 either shipped or in flight:
- ✓ \`nexus-s3dm\` (P1.5.1) — T3 daemon lifecycle + CLI
- ✓ \`nexus-n8xg\` (P1.5.2) — Tier-parametric discovery resolver
- **this PR** \`nexus-7yd2\` (P1.5.3) — T3Client factory
- ○ \`nexus-v5hb\` (P1.5.4, P2) — autostart install (still open)
- ○ \`nexus-6j2f\` (P1.5.review) — closeout gate

After this merges + \`v5hb\` lands, the review gate (\`6j2f\`) can run; once it passes, \`hpxl\` unblocks.

Bead \`nexus-7yd2\` will close on merge.