### PR TITLE
feat(rdr-112): nexus-v5hb — nx daemon t3 install/uninstall (launchd/systemd autostart)

### DIFF
--- a/nx/daemon/com.nexus.t3.plist
+++ b/nx/daemon/com.nexus.t3.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd agent for the nexus T3 daemon (RDR-112 P1.5.4, nexus-v5hb).
+  Installed by ``nx daemon t3 install --autostart``. The T3 daemon is a
+  managed ``chroma run`` subprocess; ``nx daemon t3 start --foreground``
+  spawns chroma and blocks until SIGTERM, so launchd's supervision is
+  the canonical lifecycle owner.
+
+  The ``__NX_BIN__`` placeholder is substituted at install time with the
+  resolved absolute path to the ``nx`` executable. ``__LOG_DIR__`` and
+  ``__PATH_ENV__`` are substituted at install time as well.
+
+  ``StandardOutPath`` / ``StandardErrorPath`` capture the launchd-
+  supervised stream (interpreter crash diagnostics, chroma run stderr).
+  No bounded rotation here — let it grow under inspection, then the
+  operator truncates.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nexus.t3</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__NX_BIN__</string>
+        <string>daemon</string>
+        <string>t3</string>
+        <string>start</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/nexus-t3.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/nexus-t3.err</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__PATH_ENV__</string>
+    </dict>
+</dict>
+</plist>

--- a/nx/daemon/nexus-t3.service
+++ b/nx/daemon/nexus-t3.service
@@ -1,0 +1,29 @@
+## systemd user unit for the nexus T3 daemon (RDR-112 P1.5.4, nexus-v5hb).
+## Installed by ``nx daemon t3 install --autostart``. The T3 daemon is a
+## managed ``chroma run`` subprocess; ``nx daemon t3 start`` blocks until
+## SIGTERM so systemd's supervision is the canonical lifecycle owner.
+##
+## ``StandardOutput`` / ``StandardError`` capture the supervisor stream
+## (interpreter crash diagnostics, chroma run stderr).
+
+[Unit]
+Description=Nexus T3 daemon (managed chroma run subprocess)
+After=network.target
+PartOf=default.target
+
+[Service]
+Type=simple
+ExecStart=__NX_BIN__ daemon t3 start
+Restart=on-failure
+RestartSec=5s
+## nexus-o6g9 lesson (T2): SIGTERM-induced exits surface as code 143.
+## ``nx daemon t3 stop`` sends SIGTERM; mark 143 as success so
+## Restart=on-failure does not immediately respawn after an operator
+## stop.
+SuccessExitStatus=143
+Environment=PATH=__PATH_ENV__
+StandardOutput=append:__LOG_DIR__/nexus-t3.log
+StandardError=append:__LOG_DIR__/nexus-t3.err
+
+[Install]
+WantedBy=default.target

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -1200,3 +1200,178 @@ def t3_info_cmd(config_dir_str: str | None, as_json: bool) -> None:
     for key, value in data.items():
         click.echo(f"  {key}: {value}")
 
+
+# ---------------------------------------------------------------------------
+# T3 autostart install / uninstall  (RDR-112 P1.5.4, nexus-v5hb)
+# ---------------------------------------------------------------------------
+#
+# Mirrors the T2 install/uninstall flow at daemon.py:896-1064. Templates
+# ship under src/nexus/_resources/daemon/com.nexus.t3.plist (macOS) and
+# nexus-t3.service (Linux). The launchd plist + systemd unit shape is
+# the battle-tested T2 template adapted for the T3 subcommand: the
+# supervisor invokes ``nx daemon t3 start`` instead of ``nx daemon t2
+# start --foreground``, because the T3 daemon's ``start`` already
+# blocks until SIGTERM (it foregrounds the chroma run subprocess).
+
+_T3_PLIST_NAME = "com.nexus.t3.plist"
+_T3_SERVICE_NAME = "nexus-t3.service"
+_T3_LAUNCHD_LABEL = "com.nexus.t3"
+
+
+def _autostart_filename_t3() -> str:
+    return _T3_PLIST_NAME if _autostart_platform() == "darwin" else _T3_SERVICE_NAME
+
+
+@t3_group.command("install")
+@click.option(
+    "--autostart",
+    is_flag=True,
+    required=True,
+    help=(
+        "Install OS autostart entry (launchd on macOS, systemd user "
+        "unit on Linux) so the T3 daemon starts at login / boot."
+    ),
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help=(
+        "Overwrite an existing plist/unit file even when its content "
+        "differs from the freshly rendered template; treat supervisor "
+        "activation failures as warnings instead of errors."
+    ),
+)
+def t3_install_cmd(autostart: bool, force: bool) -> None:
+    """Install the T3 daemon autostart entry for the current user.
+
+    macOS: writes ~/Library/LaunchAgents/com.nexus.t3.plist and
+    bootstraps it via ``launchctl bootstrap gui/$UID``.
+
+    Linux: writes ~/.config/systemd/user/nexus-t3.service and enables
+    it via ``systemctl --user enable --now nexus-t3.service``.
+
+    The shipped templates point the supervisor at ``nx daemon t3 start``;
+    the T3 ``start`` command spawns the managed chroma run subprocess
+    and the daemon-start helper exits once chroma is listening (process
+    group survives via ``start_new_session=True``).
+    """
+    if not autostart:  # pragma: no cover -- click enforces required=True
+        raise click.UsageError("--autostart is required")
+
+    install_dir = _autostart_install_dir()
+    install_dir.mkdir(parents=True, exist_ok=True)
+    log_dir = _autostart_log_dir()
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    template_name = _autostart_filename_t3()
+    nx_bin = _resolve_nx_bin()
+    rendered = _render_template(
+        template_name,
+        nx_bin=nx_bin,
+        log_dir=str(log_dir),
+        path_env=os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+    )
+    dest = install_dir / template_name
+
+    # Symlink + overwrite-guard semantics mirror T2's install_cmd
+    # (daemon.py:957-990) exactly; the operator-customisation
+    # preservation contract is identical for T3.
+    if dest.is_symlink():
+        click.echo(
+            f"Error: {dest} is a symlink; refusing to install autostart "
+            "through it. Remove the symlink first and re-run.",
+            err=True,
+        )
+        sys.exit(1)
+    if dest.exists():
+        try:
+            existing = dest.read_text()
+        except OSError:
+            existing = None
+        if existing == rendered:
+            click.echo(f"{dest} already up to date; no changes")
+            return
+        if not force and existing is not None:
+            click.echo(
+                f"Error: {dest} exists and its content differs from the "
+                "rendered template; refusing to overwrite. Re-run with "
+                "--force to replace the existing file (your customisations "
+                "will be lost), or remove the file first.",
+                err=True,
+            )
+            sys.exit(1)
+
+    dest.write_text(rendered)
+    dest.chmod(0o644)
+    click.echo(f"Wrote {dest}")
+
+    platform = _autostart_platform()
+    if platform == "darwin":
+        uid = os.getuid()
+        cmd = ["launchctl", "bootstrap", f"gui/{uid}", str(dest)]
+    else:
+        cmd = ["systemctl", "--user", "enable", "--now", template_name]
+    label = "Warning" if force else "Error"
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except FileNotFoundError as exc:
+        click.echo(
+            f"{label}: {cmd[0]} not found on PATH; file installed but not activated ({exc}).",
+            err=True,
+        )
+        if not force:
+            sys.exit(1)
+        return
+    if result.returncode != 0:
+        click.echo(
+            f"{label}: {' '.join(cmd)} exited {result.returncode}: "
+            f"{result.stderr.strip() or result.stdout.strip()}",
+            err=True,
+        )
+        if not force:
+            sys.exit(1)
+        return
+    click.echo(f"Activated via: {' '.join(cmd)}")
+
+
+@t3_group.command("uninstall")
+@click.option(
+    "--autostart",
+    is_flag=True,
+    required=True,
+    help="Remove OS autostart entry installed by ``install --autostart``.",
+)
+def t3_uninstall_cmd(autostart: bool) -> None:
+    """Remove the T3 daemon autostart entry for the current user."""
+    if not autostart:  # pragma: no cover
+        raise click.UsageError("--autostart is required")
+
+    install_dir = _autostart_install_dir()
+    template_name = _autostart_filename_t3()
+    dest = install_dir / template_name
+
+    if not dest.exists():
+        click.echo(f"Autostart not installed (nothing at {dest}).")
+        return
+
+    platform = _autostart_platform()
+    if platform == "darwin":
+        uid = os.getuid()
+        cmd = ["launchctl", "bootout", f"gui/{uid}/{_T3_LAUNCHD_LABEL}"]
+    else:
+        cmd = ["systemctl", "--user", "disable", "--now", template_name]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            click.echo(
+                f"Warning: {' '.join(cmd)} exited {result.returncode}: "
+                f"{result.stderr.strip() or result.stdout.strip()}",
+                err=True,
+            )
+    except FileNotFoundError as exc:
+        click.echo(f"Warning: {cmd[0]} not found ({exc}); removing file anyway.", err=True)
+
+    dest.unlink()
+    click.echo(f"Removed {dest}")
+

--- a/tests/daemon/test_t3_install.py
+++ b/tests/daemon/test_t3_install.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 P1.5.4 (nexus-v5hb): ``nx daemon t3 install/uninstall --autostart`` tests.
+
+Mirrors the T2 autostart tests at ``tests/commands/test_daemon_autostart.py``.
+Templates ship under ``src/nexus/_resources/daemon/``; the CLI
+substitutes ``__NX_BIN__`` / ``__LOG_DIR__`` / ``__PATH_ENV__`` at
+install time and drops the rendered file into the per-OS autostart
+location.
+
+Shell-out to ``launchctl`` / ``systemctl`` is mocked; the template
+substitution + file placement are exercised for real.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.commands import daemon as daemon_cmd
+
+
+def _set_platform(monkeypatch: pytest.MonkeyPatch, platform: str) -> None:
+    monkeypatch.setattr(daemon_cmd, "_autostart_platform", lambda: platform)
+
+
+# ---------------------------------------------------------------------------
+# Templates ship in resources
+# ---------------------------------------------------------------------------
+
+
+class TestTemplatesShipped:
+    def test_t3_plist_template_present_with_placeholders(self) -> None:
+        body = daemon_cmd._read_template("com.nexus.t3.plist")
+        assert "__NX_BIN__" in body
+        assert "com.nexus.t3" in body
+        assert "RunAtLoad" in body
+        # T3 unit invokes the t3 subcommand, not t2.
+        assert "<string>t3</string>" in body
+
+    def test_t3_service_template_present_with_placeholders(self) -> None:
+        body = daemon_cmd._read_template("nexus-t3.service")
+        assert "__NX_BIN__" in body
+        assert "WantedBy=default.target" in body
+        assert "Restart=on-failure" in body
+        # T3 unit invokes the t3 subcommand.
+        assert "daemon t3 start" in body
+
+
+# ---------------------------------------------------------------------------
+# Filename helper
+# ---------------------------------------------------------------------------
+
+
+class TestAutostartFilenameT3:
+    def test_macos_filename(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_platform(monkeypatch, "darwin")
+        assert daemon_cmd._autostart_filename_t3() == "com.nexus.t3.plist"
+
+    def test_linux_filename(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_platform(monkeypatch, "linux")
+        assert daemon_cmd._autostart_filename_t3() == "nexus-t3.service"
+
+
+# ---------------------------------------------------------------------------
+# install + uninstall flow (macOS)
+# ---------------------------------------------------------------------------
+
+
+class TestInstallMacOS:
+    def test_install_writes_plist_and_calls_launchctl(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_platform(monkeypatch, "darwin")
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_install_dir",
+            lambda: tmp_path / "LaunchAgents",
+        )
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_log_dir", lambda: tmp_path / "Logs",
+        )
+        monkeypatch.setattr(daemon_cmd, "_resolve_nx_bin", lambda: ["/opt/nx/bin/nx"])
+
+        with patch.object(daemon_cmd.subprocess, "run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stderr = ""
+            mock_run.return_value.stdout = ""
+            runner = CliRunner()
+            result = runner.invoke(
+                daemon_cmd.daemon_group,
+                ["t3", "install", "--autostart"],
+            )
+
+        assert result.exit_code == 0, result.output
+        dest = tmp_path / "LaunchAgents" / "com.nexus.t3.plist"
+        assert dest.exists()
+        body = dest.read_text()
+        assert "<string>/opt/nx/bin/nx</string>" in body
+        assert "<string>t3</string>" in body
+        # ProgramArguments slot substituted (the comment may legitimately
+        # mention __NX_BIN__ in prose; test the substantive slot).
+        assert "<string>__NX_BIN__</string>" not in body
+        # launchctl bootstrap was invoked
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "launchctl" and cmd[1] == "bootstrap"
+        assert cmd[-1] == str(dest)
+
+    def test_uninstall_removes_plist_and_calls_launchctl_bootout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_platform(monkeypatch, "darwin")
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_install_dir",
+            lambda: tmp_path / "LaunchAgents",
+        )
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_log_dir", lambda: tmp_path / "Logs",
+        )
+        monkeypatch.setattr(daemon_cmd, "_resolve_nx_bin", lambda: ["/opt/nx/bin/nx"])
+
+        # First install so there is something to uninstall.
+        with patch.object(daemon_cmd.subprocess, "run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stderr = ""
+            mock_run.return_value.stdout = ""
+            runner = CliRunner()
+            runner.invoke(daemon_cmd.daemon_group, ["t3", "install", "--autostart"])
+        dest = tmp_path / "LaunchAgents" / "com.nexus.t3.plist"
+        assert dest.exists()
+
+        with patch.object(daemon_cmd.subprocess, "run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stderr = ""
+            mock_run.return_value.stdout = ""
+            result = runner.invoke(
+                daemon_cmd.daemon_group, ["t3", "uninstall", "--autostart"]
+            )
+        assert result.exit_code == 0, result.output
+        assert not dest.exists()
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "launchctl" and cmd[1] == "bootout"
+        # Label MUST be the T3 label, not the T2 one.
+        assert "com.nexus.t3" in cmd[2]
+        assert "com.nexus.t2" not in cmd[2]
+
+    def test_uninstall_when_missing_is_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_platform(monkeypatch, "darwin")
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_install_dir",
+            lambda: tmp_path / "LaunchAgents",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            daemon_cmd.daemon_group, ["t3", "uninstall", "--autostart"]
+        )
+        assert result.exit_code == 0
+        assert "not installed" in result.output
+
+
+# ---------------------------------------------------------------------------
+# install flow (Linux)
+# ---------------------------------------------------------------------------
+
+
+class TestInstallLinux:
+    def test_install_writes_unit_and_calls_systemctl(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_platform(monkeypatch, "linux")
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_install_dir",
+            lambda: tmp_path / "systemd-user",
+        )
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_log_dir",
+            lambda: tmp_path / "state",
+        )
+        monkeypatch.setattr(daemon_cmd, "_resolve_nx_bin", lambda: ["/opt/nx/bin/nx"])
+
+        with patch.object(daemon_cmd.subprocess, "run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stderr = ""
+            mock_run.return_value.stdout = ""
+            runner = CliRunner()
+            result = runner.invoke(
+                daemon_cmd.daemon_group, ["t3", "install", "--autostart"]
+            )
+
+        assert result.exit_code == 0, result.output
+        dest = tmp_path / "systemd-user" / "nexus-t3.service"
+        assert dest.exists()
+        body = dest.read_text()
+        # ExecStart points at the t3 subcommand
+        assert "/opt/nx/bin/nx daemon t3 start" in body
+        # Substantive ExecStart slot substituted (comment lines may
+        # legitimately mention __NX_BIN__ in prose).
+        assert "ExecStart=__NX_BIN__" not in body
+        # systemctl --user enable --now nexus-t3.service was invoked
+        cmd = mock_run.call_args[0][0]
+        assert cmd == [
+            "systemctl", "--user", "enable", "--now", "nexus-t3.service",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Overwrite guard + --force semantics
+# ---------------------------------------------------------------------------
+
+
+class TestOverwriteGuard:
+    def test_install_refuses_when_file_differs_without_force(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_platform(monkeypatch, "darwin")
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_install_dir",
+            lambda: tmp_path / "LaunchAgents",
+        )
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_log_dir", lambda: tmp_path / "Logs",
+        )
+        (tmp_path / "LaunchAgents").mkdir()
+        # Plant a customised file.
+        dest = tmp_path / "LaunchAgents" / "com.nexus.t3.plist"
+        dest.write_text("<!-- operator customisation -->\n")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            daemon_cmd.daemon_group, ["t3", "install", "--autostart"]
+        )
+        assert result.exit_code == 1
+        assert "refusing to overwrite" in result.output
+        # File preserved as the operator left it.
+        assert dest.read_text() == "<!-- operator customisation -->\n"
+
+    def test_install_overwrites_with_force(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_platform(monkeypatch, "darwin")
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_install_dir",
+            lambda: tmp_path / "LaunchAgents",
+        )
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_log_dir", lambda: tmp_path / "Logs",
+        )
+        monkeypatch.setattr(daemon_cmd, "_resolve_nx_bin", lambda: ["/opt/nx/bin/nx"])
+        (tmp_path / "LaunchAgents").mkdir()
+        dest = tmp_path / "LaunchAgents" / "com.nexus.t3.plist"
+        dest.write_text("<!-- old customisation -->\n")
+
+        with patch.object(daemon_cmd.subprocess, "run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stderr = ""
+            mock_run.return_value.stdout = ""
+            runner = CliRunner()
+            result = runner.invoke(
+                daemon_cmd.daemon_group,
+                ["t3", "install", "--autostart", "--force"],
+            )
+
+        assert result.exit_code == 0, result.output
+        # File replaced with the rendered template.
+        assert "<string>/opt/nx/bin/nx</string>" in dest.read_text()
+        assert "<!-- old customisation -->" not in dest.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Group registration
+# ---------------------------------------------------------------------------
+
+
+class TestGroupRegistration:
+    def test_t3_group_exposes_install_and_uninstall(self) -> None:
+        t3 = daemon_cmd.daemon_group.commands["t3"]
+        assert "install" in t3.commands
+        assert "uninstall" in t3.commands


### PR DESCRIPTION
## Summary

P1.5.4 of the corrective RDR-112 Phase 1.5 chain (epic \`nexus-8hy6\`). T2 had install/uninstall at \`daemon.py:896-1064\`; T3 now has parity so production deployments survive reboot.

## What landed

**Templates (\`nx/daemon/\`, force-included into wheel)**:
- \`com.nexus.t3.plist\` — launchd agent invoking \`nx daemon t3 start\`
- \`nexus-t3.service\` — systemd user unit invoking \`nx daemon t3 start\`

Both ship with the same supervisor patterns as T2: \`KeepAlive\` on crash (launchd) / \`Restart=on-failure\` (systemd), \`SuccessExitStatus=143\` so SIGTERM-induced stops don't immediately respawn, capture stdout/stderr for crash diagnostics.

**CLI**: \`nx daemon t3 install --autostart\` / \`nx daemon t3 uninstall --autostart\`. Mirrors T2 behavior: symlink-refuse guard (FS-7), byte-identical-no-op, overwrite-refusal with diagnostic, launchctl-not-found warn-with-force / error-without-force.

**New constants** (alongside T2's in \`daemon.py\`):
- \`_T3_PLIST_NAME\` / \`_T3_SERVICE_NAME\` / \`_T3_LAUNCHD_LABEL\`
- \`_autostart_filename_t3()\`

## Test plan

- [x] \`tests/daemon/test_t3_install.py\` — 11/11 pass in 0.07s
  - Templates ship via \`_read_template\` + carry expected placeholders + invoke the t3 subcommand (not t2)
  - \`_autostart_filename_t3\` returns correct name per platform
  - macOS install writes plist + invokes \`launchctl bootstrap\` with rendered file path
  - macOS uninstall removes plist + invokes \`launchctl bootout\` against the **T3 label** (not T2)
  - Linux install writes unit + invokes \`systemctl --user enable --now nexus-t3.service\`
  - Idempotent uninstall when file is absent
  - Overwrite-guard: refuses without \`--force\` when operator-customised, overwrites with \`--force\`
  - Group registration: \`t3.install\` and \`t3.uninstall\` both wired
- [x] Wider sweep: \`tests/daemon/\` + \`tests/commands/test_daemon_autostart.py\` + \`tests/test_plugin_structure.py\` — 1124 passed, no regressions

## Phase 1.5 status after merge

| Bead | Phase | State |
|---|---|---|
| \`nexus-s3dm\` | P1.5.1 — T3 daemon lifecycle + CLI | ✓ shipped |
| \`nexus-n8xg\` | P1.5.2 — Tier-parametric discovery resolver | ✓ shipped |
| \`nexus-7yd2\` | P1.5.3 — T3Client factory | ✓ shipped |
| \`nexus-v5hb\` | P1.5.4 — Autostart install/uninstall (this PR) | **ready to ship** |
| \`nexus-6j2f\` | P1.5.review — Closeout review gate | ready after this merges |
| \`nexus-hpxl\` | P3.1 — MCP flip | unblocks after \`6j2f\` passes |

After this merges, all four Phase 1.5 impl beads are closed and the closeout review gate \`nexus-6j2f\` can run.

Bead \`nexus-v5hb\` will close on merge.