### PR TITLE
fix(rdr-112): nexus-6j2f P1.5 review gate — S1 + S2 + 5 test gaps

### DIFF
--- a/src/nexus/daemon/discovery.py
+++ b/src/nexus/daemon/discovery.py
@@ -137,6 +137,26 @@ def _validate_discovery_payload(
         # Live process under a different UID — treat as alive and let
         # the eventual connect surface a clearer error than we can here.
         pass
+    except OSError as exc:
+        # nexus-6j2f review S2 fix: on some Linux kernels, ``os.kill(pid, 0)``
+        # surfaces ``OSError(errno=ESRCH)`` instead of ``ProcessLookupError``
+        # for an unallocated PID. Treat ESRCH identically to
+        # ProcessLookupError; treat every other OSError (EINVAL, EFAULT, etc.)
+        # as "process exists, we can't probe" — matches the ``_pid_is_alive``
+        # behavior in t3_daemon.py:147-151.
+        import errno as _errno
+        if exc.errno == _errno.ESRCH:
+            _log.warning(f"{tier}_discovery_stale_pid", path=str(path), pid=pid)
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as unlink_exc:
+                _log.warning(
+                    f"{tier}_discovery_unlink_failed",
+                    path=str(path),
+                    error=str(unlink_exc),
+                )
+            return None
+        # Unprobable but exists: treat as alive.
 
     return payload
 

--- a/src/nexus/daemon/t3_daemon.py
+++ b/src/nexus/daemon/t3_daemon.py
@@ -93,9 +93,14 @@ def t3_discovery_path(config_dir: Path) -> Path:
     (T2 daemon owns a separate addr file) and from T1's
     ``t1_addr.<claude_pid>`` (T1 chroma is per-Claude-session and uses a
     different naming key).
+
+    Delegates to ``nexus.daemon.discovery.discovery_path(tier='t3')`` so
+    the daemon's WRITE side and the client's READ side derive the path
+    from the same single source (nexus-6j2f review S1 fix — was a silent
+    drift risk when this module re-derived the path inline).
     """
-    uid = os.getuid()
-    return config_dir / f"t3_addr.{uid}"
+    from nexus.daemon.discovery import discovery_path as _disc_path
+    return _disc_path(config_dir, tier="t3")
 
 
 def _build_payload(

--- a/tests/daemon/test_t3_client.py
+++ b/tests/daemon/test_t3_client.py
@@ -182,6 +182,37 @@ class TestHttpTimeoutApplied:
 # ---------------------------------------------------------------------------
 
 
+class TestMalformedDiscoveryPayload:
+    """nexus-6j2f review TV4: a discovery file that is otherwise valid
+    (live PID, format_version=1, no shutdown marker) but missing
+    tcp_host / tcp_port must surface T3DaemonError, not pass through
+    silently to chromadb.HttpClient(host=None, port=None)."""
+
+    def test_missing_tcp_port_raises_t3_daemon_error(
+        self, config_dir: Path, force_local_mode, monkeypatch
+    ) -> None:
+        import json
+        import os as _os
+        from nexus.daemon.discovery import discovery_path
+        from nexus.daemon.t3_client import T3DaemonError, make_t3_client
+
+        monkeypatch.delenv("NX_T3_ADDR", raising=False)
+        path = discovery_path(config_dir, tier="t3")
+        # Live PID, valid format, but tcp_port omitted entirely.
+        path.write_text(json.dumps({
+            "format_version": 1,
+            "tcp_host": "127.0.0.1",
+            "pid": _os.getpid(),
+            "daemon_version": "test",
+            "start_time": "1970-01-01T00:00:00",
+            "local_path": "/tmp/x",
+        }))
+        _os.chmod(str(path), 0o600)
+        with pytest.raises(T3DaemonError) as excinfo:
+            make_t3_client(config_dir=config_dir)
+        assert "tcp_host" in str(excinfo.value) or "tcp_port" in str(excinfo.value)
+
+
 class TestSurfaceParity:
     def test_public_method_set_matches_make_t3(
         self, live_t3_daemon, config_dir: Path

--- a/tests/daemon/test_t3_daemon_lifecycle.py
+++ b/tests/daemon/test_t3_daemon_lifecycle.py
@@ -293,6 +293,79 @@ class TestIdempotentStart:
 
 
 # ---------------------------------------------------------------------------
+# Stop-time defensive paths (nexus-6j2f review TV1/TV2/TV3)
+# ---------------------------------------------------------------------------
+
+
+class TestStopEdgeCases:
+    """Cover the defensive paths in stop_t3_daemon and start_t3_daemon."""
+
+    def test_stop_with_non_integer_pid_unlinks_and_returns_none(
+        self, config_dir: Path
+    ) -> None:
+        from nexus.daemon.t3_daemon import stop_t3_daemon, t3_discovery_path
+
+        path = t3_discovery_path(config_dir)
+        path.write_text(json.dumps({
+            "format_version": 1,
+            "tcp_host": "127.0.0.1",
+            "tcp_port": 9999,
+            "pid": "not-an-int",  # malformed
+            "daemon_version": "test",
+            "start_time": "1970-01-01T00:00:00",
+            "local_path": "/tmp/x",
+        }))
+        os.chmod(str(path), 0o600)
+        assert stop_t3_daemon(config_dir=config_dir) is None
+        assert not path.exists(), "malformed-pid file must be unlinked"
+
+    def test_stop_when_pid_already_dead_unlinks_and_returns_pid(
+        self, config_dir: Path
+    ) -> None:
+        from nexus.daemon.t3_daemon import stop_t3_daemon, t3_discovery_path
+
+        path = t3_discovery_path(config_dir)
+        dead_pid = 2**31 - 1  # never a real PID
+        path.write_text(json.dumps({
+            "format_version": 1,
+            "tcp_host": "127.0.0.1",
+            "tcp_port": 9999,
+            "pid": dead_pid,
+            "daemon_version": "test",
+            "start_time": "1970-01-01T00:00:00",
+            "local_path": "/tmp/x",
+        }))
+        os.chmod(str(path), 0o600)
+        assert stop_t3_daemon(config_dir=config_dir) == dead_pid
+        assert not path.exists(), "stale-PID file must be unlinked at stop"
+
+    def test_start_skips_unparseable_discovery_file(
+        self, config_dir: Path, local_path: Path, force_local_mode
+    ) -> None:
+        """A discovery file containing non-JSON garbage must not crash
+        start_t3_daemon — the file is treated as absent (read warns +
+        returns None), a fresh daemon spawns, and the (now-valid)
+        discovery payload is written."""
+        from nexus.daemon.t3_daemon import (
+            start_t3_daemon,
+            stop_t3_daemon,
+            t3_discovery_path,
+        )
+
+        path = t3_discovery_path(config_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("<<< not json >>>")
+        os.chmod(str(path), 0o600)
+
+        payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+        try:
+            on_disk = json.loads(path.read_text())
+            assert on_disk["pid"] == payload["pid"]
+        finally:
+            stop_t3_daemon(config_dir=config_dir)
+
+
+# ---------------------------------------------------------------------------
 # CLI surface (nx daemon t3 start/stop/info)
 # ---------------------------------------------------------------------------
 

--- a/tests/daemon/test_t3_install.py
+++ b/tests/daemon/test_t3_install.py
@@ -280,3 +280,34 @@ class TestGroupRegistration:
         t3 = daemon_cmd.daemon_group.commands["t3"]
         assert "install" in t3.commands
         assert "uninstall" in t3.commands
+
+
+class TestSymlinkGuard:
+    """nexus-6j2f review S3: install refuses to overwrite through a
+    symlink (FS-7 TOCTOU mitigation, mirrors T2 install behaviour)."""
+
+    def test_install_refuses_when_target_is_symlink(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_platform(monkeypatch, "darwin")
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_install_dir",
+            lambda: tmp_path / "LaunchAgents",
+        )
+        monkeypatch.setattr(
+            daemon_cmd, "_autostart_log_dir", lambda: tmp_path / "Logs",
+        )
+        (tmp_path / "LaunchAgents").mkdir()
+        target = tmp_path / "real-plist-file"
+        target.write_text("<!-- real file -->\n")
+        symlink = tmp_path / "LaunchAgents" / "com.nexus.t3.plist"
+        symlink.symlink_to(target)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            daemon_cmd.daemon_group, ["t3", "install", "--autostart"]
+        )
+        assert result.exit_code == 1
+        assert "symlink" in result.output.lower()
+        # The symlink target is untouched.
+        assert target.read_text() == "<!-- real file -->\n"


### PR DESCRIPTION
## Summary

Phase 1.5 closeout review gate (\`nexus-6j2f\`) returned PASS-WITH-FOLLOWUPS from both code-review-expert and test-validator. This commit closes the actionable items in-place so the gate passes cleanly.

## Findings remediated

**Code fixes**:
- **S1** (silent-drift debt): \`t3_discovery_path\` in \`t3_daemon.py\` now delegates to \`discovery.discovery_path(tier='t3')\`. WRITE side and READ side derive the path from one source — previously both sites re-implemented the same formula independently.
- **S2** (Linux kernel edge case): \`_validate_discovery_payload\` in \`discovery.py\` now catches \`OSError\` with \`errno=ESRCH\` (some kernels surface ESRCH as generic \`OSError\` instead of \`ProcessLookupError\`). Matches \`_pid_is_alive\` behaviour in \`t3_daemon.py:147-151\`.

**Test gaps closed** (52 → 57):
- **TV1**: \`stop_t3_daemon\` with non-int pid → unlinks + returns None
- **TV2**: \`stop_t3_daemon\` with already-dead pid → unlinks + returns dead pid
- **TV3**: \`start_t3_daemon\` over unparseable discovery JSON → treats as absent, fresh spawn
- **TV4**: \`make_t3_client\` with valid PID but missing \`tcp_port\` → raises T3DaemonError (does NOT pass through to \`HttpClient(host=None, port=None)\`)
- **S3**: \`install --autostart\` refuses to overwrite through a symlink (FS-7 TOCTOU, parity with T2 test)

## Cross-walk gate evidence (already PASSED)

\`/nx:phase-review-gate 112 --phase 1.5\` cross-walk against RDR-112 §Approach §2 returned PASSED earlier in the review:

| §Approach item | Evidence |
|---|---|
| Item2 (T3 service) | \`nexus-s3dm\` |
| Item6 (Discovery dual-primary) | \`nexus-n8xg\` |
| Item7 (EventStream) | \`nexus-m4gm\` (T2 Phase 1; T3 has no event stream per RDR) |
| Item9 (Schema migration) | \`nexus-w0et\` (T2 Phase 1; T3 has no schema migrations) |
| Items 4, 5, 10 | \`none\` (T1 stays put / future-store rule / lifecycle hooks) |

No silent scope reduction detected.

## Out-of-scope follow-ups (filed-or-noted, NOT in this commit)

- **M1** (concurrent double-start TOCTOU): documented limitation, matches T2's same design gap.
- **M2** (cloud-mode test couples to \`is_local_mode()\` internals): minor test-rigour polish.
- \`t3_daemon.py\` defensive-path coverage in \`_find_chroma\` fallback, \`_wait_for_ready\` failure paths, \`stop_t3_daemon\` SIGKILL escalation — would need root or process-injection setups that don't fit unit tests cleanly.

## Test plan

- [x] 57/57 pass across \`tests/daemon/test_t3_daemon_lifecycle.py\`, \`test_discovery.py\`, \`test_t3_client.py\`, \`test_t3_install.py\` (~38s, 5 real chroma subprocesses)
- [x] 1141 passed wider sweep across \`tests/daemon/\` + \`tests/cockpit/\` + \`tests/commands/\` + \`tests/test_plugin_structure.py\` — no regressions
- [x] End-to-end smoke verified earlier in the review: start → info → \`make_t3_client\` round-trip → stop → no orphans → cloud-mode rejection

After this merges, \`nexus-6j2f\` closes and \`nexus-hpxl\` (P3.1 MCP flip) unblocks.

Bead \`nexus-6j2f\` will close on merge.