### PR TITLE
fix(rdr-112): nexus-6j2f second-pass C1+S1 — supervisor lifecycle + tmp-file race

### DIFF
--- a/nx/daemon/com.nexus.t3.plist
+++ b/nx/daemon/com.nexus.t3.plist
@@ -26,6 +26,7 @@
         <string>daemon</string>
         <string>t3</string>
         <string>start</string>
+        <string>--foreground</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/nx/daemon/nexus-t3.service
+++ b/nx/daemon/nexus-t3.service
@@ -13,7 +13,7 @@ PartOf=default.target
 
 [Service]
 Type=simple
-ExecStart=__NX_BIN__ daemon t3 start
+ExecStart=__NX_BIN__ daemon t3 start --foreground
 Restart=on-failure
 RestartSec=5s
 ## nexus-o6g9 lesson (T2): SIGTERM-induced exits surface as code 143.

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -1107,10 +1107,24 @@ def t3_group() -> None:
         "~/.config/nexus/t3_addr.<uid> is the primary channel."
     ),
 )
+@click.option(
+    "--foreground",
+    is_flag=True,
+    default=False,
+    help=(
+        "Block until SIGTERM/SIGINT or chroma exits. Required when "
+        "launched under a supervisor (launchd, systemd) so the "
+        "supervisor sees the daemon stay up. Without this flag the "
+        "CLI exits after writing the discovery file, leaving chroma "
+        "as a session-detached subprocess (the supervisor sees a "
+        "zero-exit and never triggers KeepAlive / Restart=on-failure)."
+    ),
+)
 def t3_start_cmd(
     config_dir_str: str | None,
     local_path_str: str | None,
     announce_stdout: bool,
+    foreground: bool,
 ) -> None:
     """Start the T3 chroma daemon (local mode only).
 
@@ -1118,12 +1132,22 @@ def t3_start_cmd(
     still alive, prints the existing discovery payload without spawning a
     duplicate. Cloud mode (NX_LOCAL=0) fails loud — chromadb's CloudClient
     is already HTTP-served.
+
+    Without ``--foreground`` the CLI exits as soon as the chroma
+    subprocess is listening on its TCP port. ``--foreground`` blocks
+    until SIGTERM/SIGINT arrives (or chroma exits on its own); used by
+    the launchd/systemd autostart templates so the supervisor observes
+    a long-running foreground process and can react to crashes via
+    ``KeepAlive.Crashed`` / ``Restart=on-failure``. (nexus-6j2f
+    review C1.)
     """
     from nexus.config import _default_local_path
     from nexus.daemon.t3_daemon import (
         T3CloudModeError,
         T3StartError,
+        _pid_is_alive,
         start_t3_daemon,
+        stop_t3_daemon,
     )
 
     config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
@@ -1139,11 +1163,49 @@ def t3_start_cmd(
 
     if announce_stdout:
         click.echo(json.dumps(payload))
+    else:
+        click.echo(
+            f"T3 daemon running on {payload['tcp_host']}:{payload['tcp_port']} "
+            f"(pid={payload['pid']}, local_path={payload['local_path']})."
+        )
+
+    if not foreground:
         return
-    click.echo(
-        f"T3 daemon running on {payload['tcp_host']}:{payload['tcp_port']} "
-        f"(pid={payload['pid']}, local_path={payload['local_path']})."
-    )
+
+    # ── --foreground: supervisor-friendly blocking loop ──────────────────
+    # The chroma subprocess is in its OWN session (start_new_session=True
+    # in start_t3_daemon), so SIGTERM delivered to this CLI process does
+    # NOT propagate to chroma automatically. The signal handler below
+    # explicitly calls stop_t3_daemon to clean up.
+    import threading
+    import time
+    stop_requested = threading.Event()
+
+    def _on_signal(_signum, _frame) -> None:
+        stop_requested.set()
+
+    signal.signal(signal.SIGTERM, _on_signal)
+    signal.signal(signal.SIGINT, _on_signal)
+
+    pid = payload["pid"]
+    while not stop_requested.is_set():
+        if not _pid_is_alive(pid):
+            # Chroma exited on its own — return non-zero so the
+            # supervisor's crash-handler (launchd KeepAlive.Crashed
+            # / systemd Restart=on-failure) fires.
+            click.echo(
+                f"T3 chroma subprocess (pid={pid}) exited unexpectedly; "
+                "the supervisor will restart it.",
+                err=True,
+            )
+            sys.exit(3)
+        time.sleep(0.5)
+
+    # Graceful shutdown path: stop_t3_daemon signals the chroma session
+    # group and unlinks the discovery file. Exit 0 so the supervisor
+    # treats this as an operator-requested stop, not a crash.
+    stop_t3_daemon(config_dir=config_dir)
+    sys.exit(0)
 
 
 @t3_group.command("stop")

--- a/src/nexus/daemon/t3_daemon.py
+++ b/src/nexus/daemon/t3_daemon.py
@@ -122,11 +122,32 @@ def _build_payload(
 
 
 def _write_discovery_atomic(path: Path, payload: dict[str, Any]) -> None:
-    """Mirror T2's atomic-write pattern (t2_daemon.py:1706-1718)."""
+    """Atomically write *path* with 0o600 permissions.
+
+    nexus-6j2f review S1 fix: a prior implementation called
+    ``tmp.write_text(...)`` (creating the file with umask-applied mode,
+    typically 0o644) and *then* ``os.chmod(0o600)``. In the brief
+    window between create and chmod, the tmp file was world-readable
+    in a 0o755 ``~/.config/nexus/`` parent directory; on multi-user
+    hosts this leaked the PID and TCP port to any local user.
+
+    Fix: create the file at mode 0o600 via ``os.open`` so the file is
+    never world-readable on disk. Then write + close + replace.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(payload))
-    os.chmod(str(tmp), 0o600)
+    body = json.dumps(payload).encode("utf-8")
+    # O_CREAT|O_TRUNC|O_WRONLY with mode 0o600 at create time; umask
+    # is applied as a SUBSET mask so 0o600 is preserved.
+    fd = os.open(
+        str(tmp),
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+        0o600,
+    )
+    try:
+        os.write(fd, body)
+    finally:
+        os.close(fd)
     os.replace(str(tmp), str(path))
 
 

--- a/tests/daemon/test_t3_daemon_lifecycle.py
+++ b/tests/daemon/test_t3_daemon_lifecycle.py
@@ -19,6 +19,8 @@ import json
 import os
 import signal
 import socket
+import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -74,6 +76,25 @@ def force_local_mode(monkeypatch):
     credentials. The chroma-subprocess tests are local-mode-only by
     design; cloud-mode rejection has its own dedicated test."""
     monkeypatch.setenv("NX_LOCAL", "1")
+
+
+def _wait_for_path(path: Path, timeout: float = 10.0) -> bool:
+    """Poll until *path* exists or *timeout* elapses."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def _wait_for_path_gone(path: Path, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not path.exists():
+            return True
+        time.sleep(0.1)
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -290,6 +311,80 @@ class TestIdempotentStart:
             assert second["tcp_port"] == first["tcp_port"]
         finally:
             stop_t3_daemon(config_dir=config_dir)
+
+
+# ---------------------------------------------------------------------------
+# --foreground supervisor-friendly blocking mode (nexus-6j2f review C1)
+# ---------------------------------------------------------------------------
+
+
+class TestForegroundBlocking:
+    """The --foreground flag is mandatory under launchd/systemd
+    supervision: the CLI must stay alive so the supervisor sees a
+    long-running foreground process. Without it, the supervisor sees
+    the CLI exit 0 and never triggers KeepAlive.Crashed /
+    Restart=on-failure on chroma death.
+    """
+
+    def test_foreground_blocks_until_sigterm(
+        self, config_dir: Path, local_path: Path, tmp_path: Path
+    ) -> None:
+        """Spawn ``nx daemon t3 start --foreground`` as a subprocess;
+        verify it stays alive past the discovery-write point and exits
+        cleanly (code 0) only after SIGTERM.
+
+        Uses a small driver script that calls ``main()`` directly
+        because ``nexus.cli`` has no ``if __name__ == '__main__'`` guard
+        (``python -m nexus.cli`` is a no-op). Matches what the installed
+        ``nx`` entry-point does.
+        """
+        from nexus.daemon.t3_daemon import t3_discovery_path
+
+        driver = tmp_path / "nx_driver.py"
+        driver.write_text(
+            "from nexus.cli import main\nif __name__ == '__main__':\n    main()\n"
+        )
+
+        env = {**os.environ, "NX_LOCAL": "1"}
+        proc = subprocess.Popen(
+            [
+                sys.executable, str(driver),
+                "daemon", "t3", "start", "--foreground",
+                "--config-dir", str(config_dir),
+                "--local-path", str(local_path),
+            ],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        try:
+            # Wait for the discovery file to appear (chroma is up).
+            disc_path = t3_discovery_path(config_dir)
+            assert _wait_for_path(disc_path, timeout=15.0), (
+                f"discovery file did not appear at {disc_path} within 15s"
+            )
+
+            # CLI must STILL be running (this is the C1 guarantee — the
+            # CLI does not exit after writing discovery).
+            assert proc.poll() is None, (
+                "CLI exited prematurely; launchd/systemd would see no "
+                "supervised process. C1 regression."
+            )
+
+            # Send SIGTERM and verify graceful exit + cleanup.
+            proc.terminate()
+            return_code = proc.wait(timeout=10.0)
+            assert return_code == 0, (
+                f"--foreground CLI must exit 0 on SIGTERM; got {return_code}"
+            )
+            assert _wait_for_path_gone(disc_path, timeout=5.0), (
+                "discovery file should be unlinked after graceful stop"
+            )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/daemon/test_t3_install.py
+++ b/tests/daemon/test_t3_install.py
@@ -39,6 +39,10 @@ class TestTemplatesShipped:
         assert "RunAtLoad" in body
         # T3 unit invokes the t3 subcommand, not t2.
         assert "<string>t3</string>" in body
+        # nexus-6j2f review C1: launchd template MUST pass --foreground
+        # so the supervisor sees a long-running foreground process and
+        # can trigger KeepAlive.Crashed on chroma death.
+        assert "<string>--foreground</string>" in body
 
     def test_t3_service_template_present_with_placeholders(self) -> None:
         body = daemon_cmd._read_template("nexus-t3.service")
@@ -47,6 +51,9 @@ class TestTemplatesShipped:
         assert "Restart=on-failure" in body
         # T3 unit invokes the t3 subcommand.
         assert "daemon t3 start" in body
+        # nexus-6j2f review C1: systemd unit MUST pass --foreground so
+        # Restart=on-failure / SuccessExitStatus=143 actually fire.
+        assert "--foreground" in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

\`/nx:code-review\` second-pass (sonnet model) on the Phase 1.5 work returned **BLOCKED** on one Critical and one Significant defect that the first-pass haiku review missed. Both fixed in-place.

## C1 — Supervisor lifecycle was broken

\`t3_start_cmd\` did NOT block. The CLI exited with code 0 after writing the discovery file. Both launchd plist and systemd unit pointed at \`nx daemon t3 start\` as the supervised process — that process always exited 0.

Consequences (silent):
- \`KeepAlive.Crashed=true\` (launchd) fires only on non-zero exit → never fired.
- \`Restart=on-failure\` (systemd) — same.
- \`SuccessExitStatus=143\` was unreachable dead config.
- Operators trusting these semantics had **no** supervision of chroma crashes.

Fix:
1. Added \`--foreground\` flag to \`t3_start_cmd\`. After discovery write: SIGTERM/SIGINT handler installed, then poll \`_pid_is_alive(chroma_pid)\` every 500ms.
2. Chroma exits on its own → CLI returns exit code 3 → supervisor crash handler fires.
3. SIGTERM/SIGINT received → \`stop_t3_daemon\` cleans up chroma + discovery file → exit 0 (clean shutdown).
4. Updated launchd plist + systemd unit to pass \`--foreground\`.

The comment claiming "start already blocks until SIGTERM" was false. T2's plist passes \`--foreground\` for exactly this reason; T3 now matches.

## S1 — Discovery tmp-file permissions race

\`_write_discovery_atomic\` was \`tmp.write_text(...)\` (created at umask-applied 0o644) followed by \`os.chmod(0o600)\`. Brief window where the tmp file was world-readable in a 0o755 parent directory. Content: PID + TCP port. On multi-user hosts this leaked enough info for a local \`kill -9 <pid>\` by another user.

Fix: \`os.open(tmp, O_WRONLY|O_CREAT|O_TRUNC, 0o600)\` + \`os.write\` + \`os.close\`. File is never world-readable on disk.

## Test plan

- [x] New regression test: \`TestForegroundBlocking::test_foreground_blocks_until_sigterm\` — spawns \`nx daemon t3 start --foreground\` subprocess, waits for discovery file, asserts \`proc.poll() is None\` at that point (the C1 regression target), sends SIGTERM, asserts exit 0 + discovery unlinked
- [x] New template assertions: \`<string>--foreground</string>\` in plist; \`--foreground\` in systemd unit
- [x] 58/58 Phase 1.5 tests pass (~43s)
- [x] Wider sweep: 1142 passed across \`tests/daemon/\` + \`tests/cockpit/\` + \`tests/commands/\` + \`tests/test_plugin_structure.py\` — no regressions

## Deferred

M1 (\`@pytest.mark.slow\` on chroma-subprocess tests) intentionally deferred — pyproject markers don't currently use \`slow\` on integration tests; adding it now would re-shape wider test selection.

Bead \`nexus-6j2f\` reopened then re-closed on this merge.