### PR TITLE
fix(rdr-112): nexus-8qat P3 review — S1 taxonomy regression + S2 mode validation

### DIFF
--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -21,8 +21,18 @@ def _t2_ctx():
     long-standing test pattern of patching
     ``nexus.commands.taxonomy_cmd._default_db_path`` via the
     ``_path_resolver`` kwarg.
+
+    RDR-112 P3 second-pass review S1 (nexus-8qat, 2026-05-18): under
+    daemon mode the daemon owns the path; passing ``_path_resolver``
+    would trip the safety guard in ``mcp_infra.t2_ctx`` and raise
+    ``RuntimeError`` on every invocation. Now we skip the kwarg in
+    daemon mode (test-pattern compatibility is direct-mode only, which
+    is when patching ``_default_db_path`` makes sense at all).
     """
+    from nexus.db import is_daemon_mode
     from nexus.mcp_infra import t2_ctx
+    if is_daemon_mode():
+        return t2_ctx()
     return t2_ctx(_path_resolver=_default_db_path)
 
 if TYPE_CHECKING:

--- a/src/nexus/db/__init__.py
+++ b/src/nexus/db/__init__.py
@@ -37,8 +37,12 @@ def default_storage_mode() -> str:
     debug fallback by setting ``NX_STORAGE_MODE=direct`` explicitly.
 
     Returns the env value (lowercased + stripped) when set, else
-    ``"daemon"``. Unknown values pass through unchanged; callers
-    compare against the literals ``"daemon"`` and ``"direct"``.
+    ``"daemon"``. Anything other than ``"direct"`` / ``"daemon"`` is a
+    typo and raises ``ValueError`` (RDR-112 P3.review S2 fix,
+    nexus-8qat 2026-05-18): the acceptance criterion is "anything
+    other than direct|daemon fails loud". Pre-fix an operator who
+    typo'd ``NX_STORAGE_MODE=damon`` would silently get direct-mode
+    routing because ``is_daemon_mode()`` compares against the literal.
 
     nexus-mlmu.7 (DR-7, 2026-05-17): the prior implementation included
     an unreachable ``if raw is None`` guard (``os.environ.get(...)``
@@ -47,6 +51,11 @@ def default_storage_mode() -> str:
     normalised = os.environ.get("NX_STORAGE_MODE", "").strip().lower()
     if not normalised:
         return "daemon"
+    if normalised not in ("direct", "daemon"):
+        raise ValueError(
+            f"NX_STORAGE_MODE={normalised!r} is invalid; expected "
+            f"'direct' or 'daemon' (unset for the default 'daemon')."
+        )
     return normalised
 
 

--- a/tests/test_rdr112_p0_gate.py
+++ b/tests/test_rdr112_p0_gate.py
@@ -70,18 +70,22 @@ def test_run_if_needed_runs_when_storage_mode_direct(
     assert db_path.exists()
 
 
-def test_run_if_needed_runs_under_non_daemon_storage_mode(
+def test_unknown_storage_mode_raises_value_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Other ``NX_STORAGE_MODE`` values (e.g. ``in-process``) do not skip."""
-    from nexus.db import migrations
+    """nexus-8qat P3.review S2 (2026-05-18): ``NX_STORAGE_MODE`` values
+    other than ``direct`` / ``daemon`` (or unset) fail loud at the
+    ``default_storage_mode`` boundary. Previously a typo'd value
+    (e.g. ``in-process``) silently routed as direct mode because
+    ``is_daemon_mode()`` compares against the literal ``"daemon"``."""
+    from nexus.db import default_storage_mode
 
-    db_path = tmp_path / "memory.db"
     monkeypatch.setenv("NX_STORAGE_MODE", "in-process")
-    migrations._upgrade_done.clear()
-
-    migrations.run_if_needed(db_path)
-    assert db_path.exists()
+    with pytest.raises(ValueError) as excinfo:
+        default_storage_mode()
+    msg = str(excinfo.value)
+    assert "in-process" in msg
+    assert "direct" in msg or "daemon" in msg
 
 
 # ── nexus-cy3o: taxonomy_cmd._t2_ctx delegates to mcp_infra.t2_ctx ─────────
@@ -237,13 +241,18 @@ def test_reject_under_daemon_mode_noop_when_direct(
     reject_under_daemon_mode("test op")  # must NOT raise
 
 
-def test_reject_under_daemon_mode_noop_when_other_mode(
+def test_reject_under_daemon_mode_propagates_value_error_on_invalid(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """nexus-8qat P3.review S2: ``reject_under_daemon_mode`` consults
+    ``is_daemon_mode``; an invalid env value (e.g. ``in-process``)
+    raises ``ValueError`` at the resolution boundary rather than
+    silently treating-as-direct."""
     from nexus.db import reject_under_daemon_mode
 
     monkeypatch.setenv("NX_STORAGE_MODE", "in-process")
-    reject_under_daemon_mode("test op")  # must NOT raise
+    with pytest.raises(ValueError):
+        reject_under_daemon_mode("test op")
 
 
 def test_t2_ctx_rejects_path_resolver_under_daemon_mode(


### PR DESCRIPTION
Phase 3 closeout review (sonnet) caught two Significant findings; both fixed in-place. S1: taxonomy_cmd._t2_ctx() passed _path_resolver= unconditionally — production-broken under default-daemon mode. S2: NX_STORAGE_MODE silently fell through on typos. 27/27 + 1157 wider sweep pass. Merged locally as 2ef73700 — this PR is the audit record.