### PR TITLE
docs(nx): encode review-prompt-rigour lesson into skills + agent

### DIFF
--- a/nx/agents/code-review-expert.md
+++ b/nx/agents/code-review-expert.md
@@ -15,6 +15,20 @@ effort: high
 
 ---
 
+## Output depth tracks prompt depth
+
+If the relay you receive is a friendly "review the diff, flag Critical / Significant / Minor" without naming concrete suspect categories, the routine output will be friendly too — and you will miss boundary-spanning defects that live between two files rather than inside either. This is documented behaviour from RDR-112 Phase 1.5: a first sonnet pass on the same code returned 3 Significant + 2 Minor; a second pass on the same code with an explicit "harder critique" prompt naming subprocess + OS-supervisor + integration-boundary categories returned BLOCKED on a Critical (broken launchd / systemd templates pointing at a non-blocking CLI command). Same model, same diff — only the prompt shape changed.
+
+Before substantive review, audit the relay:
+
+1. **Categories named?** A boundary-spanning diff (CLI ↔ daemon, daemon ↔ OS supervisor, env-var ↔ network constructor) should have suspect categories spelled out — process-group safety, race windows, security boundaries, integration-boundary defects, lifecycle. If the relay is silent on these, the diff likely warrants them anyway. Extrapolate from the diff shape.
+2. **Friendly framing?** "Routine review" / "look for issues" / "general best practices" are warning signs that the relay was generated reflexively. State your suspicion in the report: "the prompt did not name X but the diff touches X; here is what I found."
+3. **First-pass or second-pass?** If the relay says "first pass" on a phase-review-gate close, assume the prompt is the friendly default. Push depth even when not asked.
+
+Your job is not to satisfy the relay literally — it is to find the defects the diff would let through. A prompt that under-specifies is itself a finding worth surfacing in the report.
+
+---
+
 
 ## nx Tool Reference
 

--- a/nx/skills/code-review/SKILL.md
+++ b/nx/skills/code-review/SKILL.md
@@ -10,12 +10,30 @@ Delegates to the **code-review-expert** agent.
 
 ## Model Selection
 
-Default: **haiku**. Escalate via `model` parameter on the Agent tool:
+The agent's frontmatter sets `model: sonnet`. Omit the `model` parameter on the Agent tool and you get sonnet. Override only when a faster model is acceptable for a routine glance (`model="haiku"` for a < 50 LOC docs-only diff, etc.) — never override upward; the agent is already at the workhorse tier.
 
-| Task Shape | Model | When |
-|-----------|-------|------|
-| Small diff, routine review | haiku (default) | <200 LOC, no security concerns |
-| Security-sensitive, >500 LOC, or architectural | sonnet | Auth code, crypto, API boundaries |
+A previous version of this skill claimed `Default: haiku`; that was wrong and is the kind of doc drift that lets silent regressions through. The agent has been sonnet-default since nx 4.x.
+
+## Prompt rigour (the actual variance lever)
+
+Within the sonnet-class tier, **prompt depth, not model selection, drives review depth**. A friendly "review the diff" relay returns a friendly review; the agent does not invent suspect categories the prompt did not name.
+
+Concrete lesson, RDR-112 Phase 1.5 (2026-05-17): two sonnet-class reviews of the same five commits. The first relayed a routine "review for Critical/Significant/Minor" framing and returned PASS-WITH-FOLLOWUPS (3 Significant + 2 Minor). The second relayed an explicit harder-critique framing that named concrete suspect categories (security boundary, process-group safety, race conditions beyond the named M1, API ergonomics, supervisor lifecycle) and returned BLOCKED on a Critical the first pass missed: the launchd / systemd templates pointed at a CLI command that did not block, so `KeepAlive.Crashed` / `Restart=on-failure` would never fire — a fully broken supervisor model that lived at the boundary between CLI and OS-supervisor config and was invisible to a line-by-line read.
+
+When you relay this agent, include explicit suspect categories appropriate to the diff:
+
+- **Subprocess / OS supervisor**: launchd plist / systemd unit interaction, process-group SIGTERM propagation, `start_new_session=True` consequences, exit-code semantics versus crash recovery
+- **Concurrency**: race windows beyond the named ones, TOCTOU between filesystem checks and writes, signal delivery timing, PID recycling
+- **Security boundary**: symlink races on parent directories not just direct targets, path-injection via CLI args, env-var content reaching network constructors (CRLF, request smuggling), discovery-file world-readable windows
+- **API ergonomics**: typed exceptions vs single string-discriminated type, missing constructor-injection points for testability, surface parity (real class vs shim)
+- **Integration boundary**: defects that live *between* two files and are invisible to either alone — CLI + plist, env-var resolver + factory consumer, daemon writer + client racing the same file
+- **Lifecycle**: singleton cache survival across upstream restarts, supervisor crash-recovery semantics, idempotent re-init paths
+
+The agent's prompt template (below in `Agent Invocation`) is the friendly default. For boundary-spanning changes, append a "What to scrutinise" section listing the suspect categories you want this specific diff probed against. The relay is the lever; the model is already set.
+
+## Second-pass discipline
+
+If a gate first-pass returns PASS or PASS-WITH-FOLLOWUPS on a boundary-spanning change (CLI ↔ daemon, daemon ↔ supervisor, anything spanning process boundaries) and the relay used the routine template, dispatch a second pass before treating the gate as cleared. The second pass costs ~3 minutes; the silent-defect cost discovered later is days.
 
 ## When This Skill Activates
 

--- a/nx/skills/phase-review-gate/SKILL.md
+++ b/nx/skills/phase-review-gate/SKILL.md
@@ -118,6 +118,11 @@ Invoke before closing any phase-review bead — especially when:
 - The gate validates **coverage**, not **correctness**: `Item2=nexus-t3xx` passes even if nexus-t3xx's acceptance criteria are weak. The reviewer must verify the evidence manually.
 - The gate parses `N. **Label**: ...` formatted items. §Approach sections with non-standard numbering (e.g. roman numerals, lettered items) are not parsed. Use standard `1.` numbering in §Approach.
 - `none` is a valid evidence value. Over-use of `none` (e.g. `none` for every item) defeats the purpose; the reviewer is accountable for each `none` they supply.
+- The gate verifies §Approach items are accounted for; it does NOT verify the boundary-spanning code paths between accounted-for items work end-to-end. RDR-112 Phase 3 (2026-05-18) demonstrated this: the cross-walk PASSED on items (Item1 T2 service / Item2 T3 service / Item6 Discovery all evidence-pointed to nexus-hpxl), and a first-pass code review of the same nexus-hpxl diff returned PASS-WITH-FOLLOWUPS. A second-pass code review with explicit boundary-spanning prompt categories (see `/nx:code-review` § Prompt rigour) caught two Significant defects the first pass missed — including a production regression where `taxonomy_cmd._t2_ctx()` raised on every invocation under the new daemon default. The gate is a coverage check, not a code review; pair it with a boundary-spanning code-review-expert dispatch when the diff spans CLI ↔ daemon, daemon ↔ OS supervisor, or any process-boundary surface.
+
+## Recommended companion: boundary-spanning code review
+
+At a phase boundary that ships integration-seam code (process-spawning, supervisor interaction, RPC wiring, env-var resolution), the cross-walk alone is insufficient. After Pass 2 of this gate passes, dispatch `code-review-expert` with explicit suspect categories from `/nx:code-review` § Prompt rigour — process-group safety, race windows, security boundary, integration-boundary defects, lifecycle. The lesson the RDR-112 spine paid for is: friendly relays return friendly reviews; the suspect categories must be named in the prompt for the agent to probe them.
 
 ## Success Criteria
 


### PR DESCRIPTION
Encodes the lesson from the Phase 1.5 second-pass + Phase 3 first-pass reviews: within sonnet-class, prompt rigour drives review depth, not model selection. The earlier 'haiku vs sonnet' framing was wrong — the SKILL.md `Default: haiku` claim was doc drift; the agent frontmatter has been `model: sonnet` since nx 4.x. Fixes the misleading doc, adds the prompt-rigour checklist + second-pass discipline to the skill, adds prompt-depth-tracking guidance to the agent body, extends phase-review-gate with the boundary-spanning companion note. Global feedback memory and T2 review report updated. 645/645 plugin-structure tests pass. Merged locally as 9977a12d.