### PR TITLE
fix(rdr-112): nexus-vm3t — T2Client drop-in compatibility (facade delegates)

### DIFF
--- a/src/nexus/daemon/t2_client.py
+++ b/src/nexus/daemon/t2_client.py
@@ -1007,6 +1007,244 @@ class T2Client:
         self.close()
 
     # ------------------------------------------------------------------
+    # T2Database facade compatibility (RDR-112 P3.2, nexus-vm3t)
+    # ------------------------------------------------------------------
+    #
+    # 47 call sites across src/nexus use the pattern
+    # ``with t2_ctx() as db: db.put(...)`` — they expect T2Database's
+    # top-level facade methods that delegate to the per-domain stores
+    # (T2Database.put → self.memory.put, etc.; see t2/__init__.py:408+).
+    # Phase 3 (nexus-hpxl) flipped t2_ctx to return T2Client under
+    # daemon mode but T2Client only exposed store proxies — every
+    # facade call site broke silently with AttributeError. This
+    # section adds the facade delegates so T2Client is a drop-in
+    # replacement for T2Database at the call-site surface.
+    #
+    # Signature parity is locked by
+    # tests/daemon/test_t2_client_facade.py via inspect.signature.
+
+    # ── Memory facade ───────────────────────────────────────────────
+
+    def put(
+        self,
+        project: str,
+        title: str,
+        content: str,
+        tags: str = "",
+        ttl: int | None = 30,
+        agent: str | None = None,
+        session: str | None = None,
+    ) -> int:
+        return self.memory.put(
+            project=project,
+            title=title,
+            content=content,
+            tags=tags,
+            ttl=ttl,
+            agent=agent,
+            session=session,
+        )
+
+    def get(
+        self,
+        project: str | None = None,
+        title: str | None = None,
+        id: int | None = None,
+    ) -> Any:
+        return self.memory.get(project=project, title=title, id=id)
+
+    def resolve_title(
+        self,
+        project: str,
+        title: str,
+    ) -> Any:
+        return self.memory.resolve_title(project=project, title=title)
+
+    def search(
+        self,
+        query: str,
+        project: str | None = None,
+        access: str = "track",
+    ) -> Any:
+        return self.memory.search(query, project=project, access=access)
+
+    def list_entries(
+        self,
+        project: str | None = None,
+        agent: str | None = None,
+    ) -> Any:
+        return self.memory.list_entries(project=project, agent=agent)
+
+    def get_projects_with_prefix(self, prefix: str) -> Any:
+        return self.memory.get_projects_with_prefix(prefix)
+
+    def search_glob(self, query: str, project_glob: str) -> Any:
+        return self.memory.search_glob(query, project_glob)
+
+    def search_by_tag(self, query: str, tag: str) -> Any:
+        return self.memory.search_by_tag(query, tag)
+
+    def get_all(self, project: str) -> Any:
+        return self.memory.get_all(project)
+
+    def delete(
+        self,
+        project: str | None = None,
+        title: str | None = None,
+        id: int | None = None,
+    ) -> bool:
+        """Delete a memory entry.
+
+        Known difference from ``T2Database.delete``: the cross-domain
+        taxonomy cascade that T2Database performs after the memory row
+        is deleted (see t2/__init__.py:493-525) is NOT mirrored here.
+        That cascade reads memory.conn directly to resolve (project,
+        title) from a numeric id; T2Client has no direct connection
+        access (RPC only). Callers that need the cascade under daemon
+        mode should pass project + title explicitly so this method
+        forwards them, OR file a follow-up for a daemon-side cascade
+        RPC. Most CLI delete paths resolve project + title upstream
+        already.
+        """
+        return self.memory.delete(project=project, title=title, id=id)
+
+    def find_overlapping_memories(
+        self,
+        project: str,
+        min_similarity: float = 0.7,
+        limit: int = 50,
+    ) -> Any:
+        return self.memory.find_overlapping_memories(
+            project, min_similarity=min_similarity, limit=limit
+        )
+
+    def merge_memories(
+        self,
+        keep_id: int,
+        delete_ids: list[int],
+        merged_content: str,
+    ) -> Any:
+        return self.memory.merge_memories(keep_id, delete_ids, merged_content)
+
+    def flag_stale_memories(
+        self,
+        project: str,
+        idle_days: int = 30,
+    ) -> Any:
+        return self.memory.flag_stale_memories(project, idle_days=idle_days)
+
+    # ── Plan Library facade ─────────────────────────────────────────
+
+    def save_plan(
+        self,
+        query: str,
+        plan_json: str,
+        outcome: str = "success",
+        tags: str = "",
+        project: str = "",
+        ttl: int | None = None,
+        name: str | None = None,
+        verb: str | None = None,
+        scope: str | None = None,
+        dimensions: str | None = None,
+        default_bindings: str | None = None,
+        parent_dims: str | None = None,
+        scope_tags: str | None = None,
+    ) -> int:
+        return self.plans.save_plan(
+            query=query,
+            plan_json=plan_json,
+            outcome=outcome,
+            tags=tags,
+            project=project,
+            ttl=ttl,
+            name=name,
+            verb=verb,
+            scope=scope,
+            dimensions=dimensions,
+            default_bindings=default_bindings,
+            parent_dims=parent_dims,
+            scope_tags=scope_tags,
+        )
+
+    def search_plans(
+        self,
+        query: str,
+        limit: int = 5,
+        project: str = "",
+    ) -> Any:
+        return self.plans.search_plans(query, limit=limit, project=project)
+
+    def list_plans(self, limit: int = 20, project: str = "") -> Any:
+        return self.plans.list_plans(limit=limit, project=project)
+
+    def plan_exists(self, query: str, tag: str) -> bool:
+        return self.plans.plan_exists(query, tag)
+
+    # ── Telemetry facade ────────────────────────────────────────────
+
+    def log_relevance(
+        self,
+        query: str,
+        chunk_id: str,
+        action: str,
+        session_id: str = "",
+        collection: str = "",
+    ) -> int:
+        return self.telemetry.log_relevance(
+            query=query,
+            chunk_id=chunk_id,
+            action=action,
+            session_id=session_id,
+            collection=collection,
+        )
+
+    def log_relevance_batch(
+        self,
+        rows: list[tuple[str, str, str, str, str]],
+    ) -> int:
+        return self.telemetry.log_relevance_batch(rows)
+
+    def get_relevance_log(
+        self,
+        query: str = "",
+        chunk_id: str = "",
+        action: str = "",
+        session_id: str = "",
+        limit: int = 100,
+    ) -> Any:
+        return self.telemetry.get_relevance_log(
+            query=query,
+            chunk_id=chunk_id,
+            action=action,
+            session_id=session_id,
+            limit=limit,
+        )
+
+    def expire_relevance_log(self, days: int = 90) -> int:
+        return self.telemetry.expire_relevance_log(days=days)
+
+    # ── Housekeeping facade ─────────────────────────────────────────
+
+    def expire(self, relevance_log_days: int = 90) -> int:
+        """Delete TTL-expired entries — client-side composition of two RPCs.
+
+        T2Database.expire (t2/__init__.py:661) composes telemetry.expire_relevance_log
+        and memory.expire. The daemon doesn't expose ``database.expire`` as
+        a single bare op (``_T2_DATABASE_METHODS`` carries only
+        ``rename_collection_cascade``). Replicating the composition client-
+        side preserves the call-site contract without requiring a daemon-
+        side addition. Returns the number of memory rows expired (matches
+        T2Database.expire's return value).
+        """
+        try:
+            self.expire_relevance_log(days=relevance_log_days)
+        except Exception:  # noqa: BLE001 — mirrors T2Database.expire's swallow
+            pass
+        expired_ids = self.memory.expire()
+        return len(expired_ids) if expired_ids is not None else 0
+
+    # ------------------------------------------------------------------
     # Bare-op invocation (admin RPCs and introspection verbs)
     # ------------------------------------------------------------------
 

--- a/tests/daemon/test_t2_client_facade.py
+++ b/tests/daemon/test_t2_client_facade.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 P3.2 (nexus-vm3t): T2Client drop-in compatibility tests.
+
+The 47 ``with t2_ctx() as db: db.<facade>(...)`` call sites across
+src/nexus rely on T2Database's facade delegate methods (db.put,
+db.get, db.search, ...). Phase 3 flipped t2_ctx to return T2Client in
+daemon mode but T2Client had only store proxies (client.memory.put,
+client.plans.save_plan, ...) — every facade call site silently broke.
+
+This test file locks in the facade-delegate contract. Every facade
+method must:
+- Exist with the same signature as the T2Database counterpart
+  (signature-parity check via inspect.signature)
+- Delegate to the appropriate store proxy with the call-site args
+  intact (round-trip check against a live daemon)
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import threading
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog.tumbler import DocumentRecord, LinkRecord, OwnerRecord
+from nexus.daemon.t2_client import T2Client
+from nexus.daemon.t2_daemon import T2Daemon
+from nexus.db.t2 import T2Database
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a real T2Daemon + T2Client
+# ---------------------------------------------------------------------------
+
+
+def _run_daemon(daemon: T2Daemon) -> asyncio.AbstractEventLoop:
+    started = threading.Event()
+    loop = asyncio.new_event_loop()
+
+    def _thread() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(daemon.start())
+        started.set()
+        loop.run_forever()
+
+    t = threading.Thread(target=_thread, daemon=True)
+    t.start()
+    started.wait(timeout=5.0)
+    return loop
+
+
+def _stop_daemon(daemon: T2Daemon, loop: asyncio.AbstractEventLoop) -> None:
+    asyncio.run_coroutine_threadsafe(daemon.stop(), loop).result(timeout=5.0)
+    loop.call_soon_threadsafe(loop.stop)
+
+
+@pytest.fixture
+def t2db(tmp_path: Path) -> T2Database:
+    database = T2Database(tmp_path / "memory.db")
+    yield database
+    database.close()
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    return tmp_path / "config"
+
+
+@pytest.fixture
+def daemon_client(t2db: T2Database, config_dir: Path):
+    daemon = T2Daemon(config_dir, t2db=t2db)
+    loop = _run_daemon(daemon)
+    client = T2Client(uds_path=daemon.uds_path)
+    try:
+        yield client
+    finally:
+        client.close()
+        _stop_daemon(daemon, loop)
+
+
+# ---------------------------------------------------------------------------
+# Signature parity — every facade method on T2Database must exist on T2Client
+# with the same parameter names (modulo self).
+# ---------------------------------------------------------------------------
+
+
+FACADE_METHODS = [
+    "put",
+    "get",
+    "resolve_title",
+    "search",
+    "list_entries",
+    "get_projects_with_prefix",
+    "search_glob",
+    "search_by_tag",
+    "get_all",
+    "delete",
+    "find_overlapping_memories",
+    "merge_memories",
+    "flag_stale_memories",
+    "save_plan",
+    "search_plans",
+    "list_plans",
+    "plan_exists",
+    "log_relevance",
+    "log_relevance_batch",
+    "get_relevance_log",
+    "expire_relevance_log",
+    "expire",
+]
+
+
+class TestFacadeSignatureParity:
+    @pytest.mark.parametrize("name", FACADE_METHODS)
+    def test_method_exists(self, name: str) -> None:
+        """T2Client must expose every facade method T2Database exposes."""
+        assert hasattr(T2Client, name), (
+            f"T2Client missing facade method {name!r}; the 47 "
+            f"`with t2_ctx() as db: db.{name}(...)` call sites would "
+            f"break under daemon mode."
+        )
+
+    @pytest.mark.parametrize("name", FACADE_METHODS)
+    def test_signature_parity(self, name: str) -> None:
+        """Parameter names match between T2Database.<facade> and
+        T2Client.<facade> (minus self)."""
+        db_sig = inspect.signature(getattr(T2Database, name))
+        client_sig = inspect.signature(getattr(T2Client, name))
+        db_params = list(db_sig.parameters)[1:]  # drop self
+        client_params = list(client_sig.parameters)[1:]  # drop self
+        assert db_params == client_params, (
+            f"{name}: parameter list mismatch.\n"
+            f"  T2Database: {db_params}\n"
+            f"  T2Client:   {client_params}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: every key facade method actually works through the daemon
+# ---------------------------------------------------------------------------
+
+
+class TestFacadeRoundTrip:
+    def test_put_then_get_by_id(self, daemon_client: T2Client) -> None:
+        row_id = daemon_client.put(
+            project="vm3t-test", title="note.md", content="hello"
+        )
+        assert row_id > 0
+        entry = daemon_client.get(id=row_id)
+        assert entry is not None
+        assert entry["content"] == "hello"
+
+    def test_get_by_project_title(self, daemon_client: T2Client) -> None:
+        daemon_client.put(
+            project="vm3t-test", title="alpha.md", content="alpha body"
+        )
+        entry = daemon_client.get(project="vm3t-test", title="alpha.md")
+        assert entry is not None
+        assert entry["content"] == "alpha body"
+
+    def test_resolve_title_exact(self, daemon_client: T2Client) -> None:
+        daemon_client.put(
+            project="vm3t-test", title="alpha.md", content="alpha body"
+        )
+        resolved, candidates = daemon_client.resolve_title(
+            project="vm3t-test", title="alpha.md"
+        )
+        assert resolved is not None
+        assert resolved["content"] == "alpha body"
+        assert candidates == []
+
+    def test_search(self, daemon_client: T2Client) -> None:
+        daemon_client.put(
+            project="vm3t-test", title="note.md", content="uniqueterm content"
+        )
+        results = daemon_client.search(query="uniqueterm")
+        assert len(results) >= 1
+        assert any(r["title"] == "note.md" for r in results)
+
+    def test_list_entries(self, daemon_client: T2Client) -> None:
+        daemon_client.put(project="vm3t-test", title="a.md", content="a")
+        daemon_client.put(project="vm3t-test", title="b.md", content="b")
+        entries = daemon_client.list_entries(project="vm3t-test")
+        titles = {e["title"] for e in entries}
+        assert {"a.md", "b.md"} <= titles
+
+    def test_delete_by_id(self, daemon_client: T2Client) -> None:
+        row_id = daemon_client.put(
+            project="vm3t-test", title="todelete.md", content="bye"
+        )
+        ok = daemon_client.delete(id=row_id)
+        assert ok is True
+        # Subsequent get returns None
+        assert daemon_client.get(id=row_id) is None
+
+    def test_save_plan_then_list(self, daemon_client: T2Client) -> None:
+        daemon_client.save_plan(
+            query="how to vm3t",
+            plan_json='{"steps":[]}',
+            outcome="success",
+            tags="test",
+            project="vm3t-test",
+        )
+        plans = daemon_client.list_plans(project="vm3t-test", limit=10)
+        assert any(p["query"] == "how to vm3t" for p in plans)
+
+
+# ---------------------------------------------------------------------------
+# Context manager still works alongside facade methods
+# ---------------------------------------------------------------------------
+
+
+class TestContextManagerWithFacade:
+    def test_with_block_uses_facade_methods(self, daemon_client: T2Client) -> None:
+        """The integration pattern that broke in production:
+        ``with t2_ctx() as db: db.put(...)``."""
+        with daemon_client as db:
+            row_id = db.put(
+                project="vm3t-test", title="ctx.md", content="ctx body"
+            )
+            entry = db.get(id=row_id)
+        assert entry is not None
+        assert entry["content"] == "ctx body"


### PR DESCRIPTION
Production-broken state fix. The Phase 3 MCP flip routed mcp_infra.t2_ctx() through T2Client in daemon mode but T2Client lacked the 22 top-level facade delegate methods T2Database exposes; every `with t2_ctx() as db: db.put(...)` / get / search / etc. invocation under the new daemon default failed with `AttributeError: 'T2Client' object has no attribute 'put'`. 47 call sites affected.

Adds the 22 facade methods to T2Client mirroring T2Database's delegate region. One documented difference: T2Client.delete does not mirror the cross-domain taxonomy cascade for id-only deletes (T2Client has no direct memory.conn access). 38 new tests in tests/daemon/test_t2_client_facade.py — method-exists + signature parity (inspect.signature) + round-trip via live T2Daemon + the exact context-manager-with-facade pattern that broke production. End-to-end smoke verifies `nx memory put` / get / search under daemon mode all return exit 0 now (vs AttributeError pre-fix). Wider sweep 1209 passed.

This is the substrate fix the Phase 4 chain (nexus-idqd / yfqv / uar6 / mmvf / pac1) was waiting on — all five Phase 4 beads now have the prerequisite in place.