### PR TITLE
feat(rdr-112): nexus-yfqv - CLI port for search + enrich (mcp_infra seam)

### DIFF
--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -168,13 +168,23 @@ def enrich_bib(
     Already-enriched chunks (the backend's ID field is non-empty) are
     skipped — the command is idempotent per backend.
     """
-    from nexus.db import make_t3
+    from nexus.mcp_infra import get_t3
     from nexus.retry import _chroma_with_retry
 
     backend, bib_enrich, id_field = _resolve_bib_backend(source)
     click.echo(f"Backend: {backend} (id field: {id_field})")
 
-    db = make_t3()
+    # RDR-112 P4.2 (nexus-yfqv): route through ``mcp_infra.get_t3`` so
+    # daemon mode hits ``make_t3_client`` (HttpClient) instead of
+    # opening a PersistentClient that races the daemon on the same
+    # on-disk path. Direct mode falls through ``get_t3`` →
+    # ``make_t3`` unchanged. ``RuntimeError`` from the daemon resolver
+    # (``T3DaemonError`` / ``DaemonNotRunningError``) carries a
+    # recovery hint; translate to ``ClickException`` for the CLI.
+    try:
+        db = get_t3()
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
     col = db.get_or_create_collection(collection)
 
     # nexus-sbzr: also collect source_paths per title group so we can
@@ -1560,13 +1570,19 @@ def aspects_show_cmd(tumbler_or_title: str, as_json: bool, field: str) -> None:
         # nexus-6xp2: post-drop, source_path-keyed lookup is unreliable
         # when the writer used a non-uri_for source_uri. Tumbler-keyed
         # get_by_doc_id is exact; fall back to legacy (coll, path) get
-        # only when doc_id PK isn't in place yet.
-        if db.document_aspects._has_doc_id_pk():
-            record = db.document_aspects.get_by_doc_id(str(entry.tumbler))
-        else:
-            record = db.document_aspects.get(
+        # when the doc_id PK isn't in place (yet). get_by_doc_id
+        # already returns None on the pre-migration schema (see
+        # DocumentAspects.get_by_doc_id), so a chained ``or`` is
+        # equivalent to the prior ``_has_doc_id_pk()`` branch — and it
+        # also works against the T2Client daemon-mode facade, which
+        # exposes only public methods through ``_StoreProxy`` (the
+        # underscore probe would AttributeError under daemon mode).
+        record = (
+            db.document_aspects.get_by_doc_id(str(entry.tumbler))
+            or db.document_aspects.get(
                 entry.physical_collection, entry.file_path,
             )
+        )
 
     if record is None:
         click.echo(

--- a/tests/commands/test_enrich_daemon_mode.py
+++ b/tests/commands/test_enrich_daemon_mode.py
@@ -1,0 +1,407 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 P4.2 (nexus-yfqv) — ``nx enrich`` CLI under ``NX_STORAGE_MODE=daemon``.
+
+Two subcommands need contract-pinning:
+
+* ``nx enrich bib`` — the only enrich subcommand with a direct
+  ``make_t3()`` call pre-yfqv (lines 171/177 in enrich.py). The yfqv
+  flip replaces that with ``get_t3()`` so the bib enricher hits the
+  daemon's chroma rather than racing it with a parallel
+  ``PersistentClient`` on the same on-disk path.
+* ``nx enrich aspects`` — already routes through ``t2_ctx()`` +
+  ``get_t3()`` (pre-yfqv), but we contract-pin it here so a future
+  refactor cannot silently regress.
+
+We do not exercise the live Semantic Scholar / OpenAlex API. The bib
+enricher backend is monkey-patched to return a deterministic synthetic
+bib dict, so the test exercises:
+
+1. ``get_t3()`` returns a daemon-bound HttpClient under daemon mode
+   (the yfqv flip).
+2. ``col.get(...)`` reads from the daemon's chroma.
+3. ``col.update(...)`` writes back through the daemon's chroma.
+4. An independent HttpClient (mirroring ``make_t3_client``'s
+   resolution) sees the bib_* fields after the run — proving the write
+   did NOT land in a parallel PersistentClient.
+
+The vm3t lesson applies: unit tests that mocked ``make_t3`` could pass
+forever while the bib enricher silently raced the daemon. Only an
+end-to-end CliRunner invocation against a live daemon catches this.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.daemon.t2_daemon import T2Daemon
+from nexus.db.t2 import T2Database
+
+
+# ── In-thread T2 daemon harness ─────────────────────────────────────────────
+
+
+def _run_daemon(daemon: T2Daemon) -> asyncio.AbstractEventLoop:
+    started = threading.Event()
+    loop = asyncio.new_event_loop()
+
+    def _thread() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(daemon.start())
+        started.set()
+        loop.run_forever()
+
+    t = threading.Thread(target=_thread, daemon=True)
+    t.start()
+    started.wait(timeout=5.0)
+    return loop
+
+
+def _stop_daemon(daemon: T2Daemon, loop: asyncio.AbstractEventLoop) -> None:
+    asyncio.run_coroutine_threadsafe(daemon.stop(), loop).result(timeout=5.0)
+    loop.call_soon_threadsafe(loop.stop)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def reset_t3_singleton():
+    import nexus.mcp_infra as infra
+    original_t3 = infra._t3_instance
+    original_collections = infra._collections_cache
+    infra._t3_instance = None
+    infra._collections_cache = ([], 0.0)
+    yield
+    infra._t3_instance = original_t3
+    infra._collections_cache = original_collections
+
+
+@pytest.fixture
+def t2db(tmp_path: Path) -> T2Database:
+    db = T2Database(tmp_path / "memory.db")
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    cd = tmp_path / "nexus_config"
+    cd.mkdir()
+    return cd
+
+
+@pytest.fixture
+def local_path(tmp_path: Path) -> Path:
+    p = tmp_path / "chroma_t3"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def daemon_env(monkeypatch, config_dir: Path):
+    monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+    monkeypatch.setenv("NX_LOCAL", "1")
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
+
+
+@pytest.fixture
+def live_t2_daemon(t2db: T2Database, config_dir: Path, daemon_env):
+    daemon = T2Daemon(config_dir, t2db=t2db)
+    loop = _run_daemon(daemon)
+    try:
+        yield daemon
+    finally:
+        _stop_daemon(daemon, loop)
+
+
+@pytest.fixture
+def live_t3_daemon(daemon_env, config_dir: Path, local_path: Path):
+    from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+
+    payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+    try:
+        yield payload
+    finally:
+        stop_t3_daemon(config_dir=config_dir)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _direct_http_client(payload: dict):
+    """Independent HttpClient pointed at the same daemon — used to
+    verify state without depending on the test's get_t3 singleton."""
+    import chromadb
+    return chromadb.HttpClient(host=payload["tcp_host"], port=payload["tcp_port"])
+
+
+# ── nx enrich bib ───────────────────────────────────────────────────────────
+
+
+def _seed_one_paper_chunk(
+    payload: dict,
+    *,
+    collection: str,
+    title: str,
+    source_path: str,
+    body: str,
+) -> str:
+    """Write one chunk into a conformant ``knowledge__*`` collection
+    via an independent HttpClient. Returns the chunk id.
+
+    The collection is created with a stub embedding function so the
+    daemon's HttpClient accepts the put without a Voyage round-trip
+    (this is the daemon-mode local path; the LocalEmbeddingFunction is
+    bundled with nexus and provides deterministic 384-dim vectors).
+    """
+    import chromadb
+    from nexus.db.local_ef import LocalEmbeddingFunction
+
+    client = chromadb.HttpClient(
+        host=payload["tcp_host"], port=payload["tcp_port"],
+    )
+    # Match the embedding function the daemon-mode T3Database uses under
+    # NX_LOCAL=1 (``nexus_local``) so the chunk added here resolves
+    # against the same persisted-EF identity when ``nx enrich bib``
+    # re-opens the collection via ``get_or_create_collection``.
+    ef = LocalEmbeddingFunction()
+    col = client.get_or_create_collection(
+        collection,
+        embedding_function=ef,
+        metadata={"hnsw:space": "cosine"},
+    )
+    chunk_id = "yfqv-bib-test-chunk-0"
+    col.add(
+        ids=[chunk_id],
+        documents=[body],
+        metadatas=[
+            {
+                "title": title,
+                "source_path": source_path,
+                # ``bib_openalex_id`` is pre-seeded as empty string
+                # (not absent) so the enrich loop's
+                # ``if meta.get(id_field, ""):`` skip-already-enriched
+                # check returns falsy and the chunk is processed.
+                # Post-enrich it carries the synthetic id.
+                "bib_openalex_id": "",
+            }
+        ],
+    )
+    return chunk_id
+
+
+class TestEnrichBib:
+    def test_bib_flip_writes_via_daemon(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        runner: CliRunner,
+        live_t3_daemon,
+        reset_t3_singleton,
+    ) -> None:
+        """End-to-end bib enrichment through the daemon.
+
+        Pre-yfqv: ``make_t3()`` opened a ``PersistentClient`` directly
+        at the daemon's on-disk path, racing the chroma subprocess.
+        Post-yfqv: ``get_t3()`` returns an HttpClient bound to the
+        daemon. This test seeds a chunk via an independent HttpClient,
+        runs ``nx enrich bib``, and verifies the bib_* fields landed
+        in the daemon's chroma (visible via a SECOND independent
+        HttpClient).
+        """
+        # Use a conformant collection name so the strict gate in
+        # T3Database.get_or_create_collection accepts it. The daemon
+        # was started fresh in local_path, so this is a brand-new
+        # collection from chroma's perspective.
+        collection = "knowledge__yfqv-bib__minilm-l6-v2-384__v1"
+        chunk_id = _seed_one_paper_chunk(
+            live_t3_daemon,
+            collection=collection,
+            title="Attention Is All You Need",
+            source_path="/tmp/attention.pdf",
+            body="Transformer architecture body text for yfqv smoke.",
+        )
+
+        # Replace the OpenAlex backend with a deterministic stub so the
+        # test does not hit the network. The bib enricher resolves via
+        # ``_resolve_bib_backend("openalex")`` → ``enrich`` callable.
+        # We also stub the by-DOI / by-arxiv paths because the body
+        # text contains no identifiers, but be defensive.
+        import nexus.bib_enricher_openalex as oa
+        synthetic_bib = {
+            "year": 2017,
+            "venue": "NeurIPS",
+            "authors": "Vaswani et al.",
+            "citation_count": 99999,
+            "openalex_id": "W2963446712",
+        }
+        monkeypatch.setattr(
+            oa, "enrich", lambda title: dict(synthetic_bib),
+        )
+        monkeypatch.setattr(
+            oa, "enrich_by_doi",
+            lambda doi, expected_title=None: dict(synthetic_bib),
+        )
+        monkeypatch.setattr(
+            oa, "enrich_by_arxiv_id",
+            lambda arxiv, expected_title=None: dict(synthetic_bib),
+        )
+
+        result = runner.invoke(
+            main,
+            [
+                "enrich",
+                "bib",
+                collection,
+                "--source",
+                "openalex",
+                "--delay",
+                "0",  # no inter-call sleep
+                "--limit",
+                "1",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Done: enriched 1 chunks across 1 titles" in result.output, result.output
+
+        # Verify via a second independent HttpClient (paranoia: prove
+        # the write hit THE daemon, not a parallel PersistentClient).
+        client = _direct_http_client(live_t3_daemon)
+        col = client.get_collection(
+            collection,
+            # Match the embedding-fn so the collection handle resolves.
+            embedding_function=None,
+        )
+        fetched = col.get(ids=[chunk_id], include=["metadatas"])
+        meta = fetched["metadatas"][0]
+        assert meta.get("bib_year") == 2017, meta
+        assert meta.get("bib_venue") == "NeurIPS", meta
+        assert meta.get("bib_openalex_id") == "W2963446712", meta
+
+    def test_bib_empty_collection_routes_via_daemon(
+        self,
+        runner: CliRunner,
+        live_t3_daemon,
+        reset_t3_singleton,
+    ) -> None:
+        """Even an empty collection exercises ``get_t3()`` +
+        ``get_or_create_collection`` + ``col.get(...)`` against the
+        daemon. Confirms the flip routes through the daemon when there
+        is nothing to enrich (the early-exit path)."""
+        collection = "knowledge__yfqv-bib-empty__minilm-l6-v2-384__v1"
+        # Pre-create the collection via the independent HttpClient so
+        # the empty-collection path is reached deterministically.
+        import chromadb
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        client = chromadb.HttpClient(
+            host=live_t3_daemon["tcp_host"],
+            port=live_t3_daemon["tcp_port"],
+        )
+        client.get_or_create_collection(
+            collection,
+            embedding_function=LocalEmbeddingFunction(),
+            metadata={"hnsw:space": "cosine"},
+        )
+
+        result = runner.invoke(
+            main,
+            [
+                "enrich",
+                "bib",
+                collection,
+                "--source",
+                "openalex",
+                "--delay",
+                "0",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "is empty" in result.output, result.output
+
+
+# ── nx enrich aspects ───────────────────────────────────────────────────────
+
+
+class TestEnrichAspects:
+    def test_aspects_dry_run_under_daemon(
+        self,
+        runner: CliRunner,
+        live_t2_daemon,
+        live_t3_daemon,
+        reset_t3_singleton,
+    ) -> None:
+        """``nx enrich aspects --dry-run`` against a collection with no
+        registered extractor exits cleanly. The path still imports
+        ``t2_ctx`` / ``get_t3`` at runtime; this contract-pins the
+        already-routed call sites against the live daemon."""
+        # docs__ has no registered extractor — the command should echo
+        # the "no extractor config" message and return cleanly.
+        result = runner.invoke(
+            main,
+            [
+                "enrich",
+                "aspects",
+                "docs__yfqv-aspects-nope__minilm-l6-v2-384__v1",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "No extractor config registered" in result.output
+
+
+# ── _StoreProxy hygiene (unit-level pin for the yfqv refactor) ────────────
+
+
+class TestStoreProxyHygiene:
+    def test_document_aspects_proxy_skips_underscore_methods(self) -> None:
+        """``_StoreProxy`` skips ``_``-prefixed methods at dispatch-table
+        build (proxy invariant). Pre-yfqv, ``enrich aspects-show``
+        called ``db.document_aspects._has_doc_id_pk()`` directly — that
+        call would AttributeError against the daemon facade. yfqv
+        refactored the call site to use the public ``get_by_doc_id`` +
+        chained ``or`` ``get(...)`` instead. This test pins the
+        invariant against future regressions: no underscore-prefixed
+        method may be relied on across the T2Client boundary."""
+        from nexus.daemon.t2_client import _StoreProxy
+        from nexus.db.t2.document_aspects import DocumentAspects
+
+        # Build a proxy with a None pool — we never call methods on it,
+        # we only inspect which method names were registered. The
+        # construction path is method-name-only and pool-independent.
+        proxy = _StoreProxy("document_aspects", DocumentAspects, pool=None)  # type: ignore[arg-type]
+        # The methods dict is populated at construction; both public
+        # methods must be present, the underscore probe must be absent.
+        assert "get_by_doc_id" in proxy._methods
+        assert "get" in proxy._methods
+        assert "_has_doc_id_pk" not in proxy._methods
+
+
+# ── nx enrich list (uses t2_ctx; pre-yfqv was already routed) ──────────────
+
+
+class TestEnrichList:
+    def test_list_routes_through_daemon(
+        self,
+        runner: CliRunner,
+        live_t2_daemon,
+        live_t3_daemon,
+        reset_t3_singleton,
+    ) -> None:
+        """``nx enrich list`` reads aspect rows from T2 — verifies the
+        ``t2_ctx()`` call site in enrich.py:1201 still resolves to the
+        daemon (an empty result is fine; we only assert routing)."""
+        result = runner.invoke(
+            main,
+            [
+                "enrich",
+                "list",
+                "knowledge__yfqv-list__minilm-l6-v2-384__v1",
+            ],
+        )
+        assert result.exit_code == 0, result.output

--- a/tests/commands/test_search_daemon_mode.py
+++ b/tests/commands/test_search_daemon_mode.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 P4.2 (nexus-yfqv) — ``nx search`` CLI under ``NX_STORAGE_MODE=daemon``.
+
+Spawns real T2 + T3 daemons, seeds a knowledge collection via the
+daemon-backed ``nx store put`` path, and invokes ``nx search`` via
+``CliRunner`` with the daemon-mode env in place. Verifies that the
+search path:
+
+1. Routes T3 access through ``mcp_infra.get_t3`` (i.e., the
+   ``HttpClient`` to the daemon's chroma, not a parallel
+   ``PersistentClient`` racing the daemon on the same on-disk path).
+2. Routes T2 access through ``mcp_infra.t2_ctx`` (i.e., a ``T2Client``
+   facade bound to the running daemon, with the vm3t-class proxies
+   ``taxonomy`` / ``telemetry`` exposed correctly).
+
+This is the search-side counterpart to ``test_store_daemon_mode.py``
+and ``test_memory_daemon_mode.py``. The vm3t lesson — unit tests that
+mock the daemon seams can stay green while production breaks at the
+boundary — is the only reason this file is necessary; we deliberately
+do not mock anything below the CLI surface.
+
+``search_cmd.py`` carries zero source changes for the yfqv flip: its
+T3 path goes through ``from nexus.commands.store import _t3`` (already
+daemon-aware via the idqd flip) and its T2 path through
+``from nexus.mcp_infra import t2_ctx`` (Phase 3). These tests
+contract-pin that wiring against the live daemon surface.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.daemon.t2_daemon import T2Daemon
+from nexus.db.t2 import T2Database
+
+
+# ── In-thread T2 daemon harness (matches test_memory_daemon_mode.py) ────────
+
+
+def _run_daemon(daemon: T2Daemon) -> asyncio.AbstractEventLoop:
+    started = threading.Event()
+    loop = asyncio.new_event_loop()
+
+    def _thread() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(daemon.start())
+        started.set()
+        loop.run_forever()
+
+    t = threading.Thread(target=_thread, daemon=True)
+    t.start()
+    started.wait(timeout=5.0)
+    return loop
+
+
+def _stop_daemon(daemon: T2Daemon, loop: asyncio.AbstractEventLoop) -> None:
+    asyncio.run_coroutine_threadsafe(daemon.stop(), loop).result(timeout=5.0)
+    loop.call_soon_threadsafe(loop.stop)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def reset_t3_singleton():
+    """Reset ``get_t3`` singleton + ``_collections_cache`` so daemon-mode
+    tests do not inherit a direct-mode instance from earlier in the
+    session. Mirrors the fixture in ``test_store_daemon_mode.py``."""
+    import nexus.mcp_infra as infra
+    original_t3 = infra._t3_instance
+    original_collections = infra._collections_cache
+    infra._t3_instance = None
+    infra._collections_cache = ([], 0.0)
+    yield
+    infra._t3_instance = original_t3
+    infra._collections_cache = original_collections
+
+
+@pytest.fixture
+def t2db(tmp_path: Path) -> T2Database:
+    db = T2Database(tmp_path / "memory.db")
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    cd = tmp_path / "nexus_config"
+    cd.mkdir()
+    return cd
+
+
+@pytest.fixture
+def local_path(tmp_path: Path) -> Path:
+    p = tmp_path / "chroma_t3"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def daemon_env(monkeypatch, config_dir: Path):
+    monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+    monkeypatch.setenv("NX_LOCAL", "1")
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
+
+
+@pytest.fixture
+def live_t2_daemon(t2db: T2Database, config_dir: Path, daemon_env):
+    daemon = T2Daemon(config_dir, t2db=t2db)
+    loop = _run_daemon(daemon)
+    try:
+        yield daemon
+    finally:
+        _stop_daemon(daemon, loop)
+
+
+@pytest.fixture
+def live_t3_daemon(daemon_env, config_dir: Path, local_path: Path):
+    from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+
+    payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+    try:
+        yield payload
+    finally:
+        stop_t3_daemon(config_dir=config_dir)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def seeded_collection(
+    runner: CliRunner,
+    live_t2_daemon,
+    live_t3_daemon,
+    reset_t3_singleton,
+    tmp_path: Path,
+) -> str:
+    """Seed one chunk via ``nx store put`` under the daemon so the search
+    tests have something to retrieve. Returns the auto-promoted
+    conformant collection name (e.g.
+    ``knowledge__yfqv-search__minilm-l6-v2-384__v1`` under NX_LOCAL=1)."""
+    src = tmp_path / "alpha.md"
+    src.write_text(
+        "the rare zenithpony marker for the yfqv search smoke harness"
+    )
+    put = runner.invoke(
+        main,
+        [
+            "store",
+            "put",
+            str(src),
+            "--collection",
+            "knowledge__yfqv-search",
+            "--title",
+            "alpha.md",
+        ],
+    )
+    assert put.exit_code == 0, put.output
+    # "Stored: <id>  →  <full_collection_name>" — parse the segment
+    # right of the arrow specifically (M1: safer than rsplit-by-space,
+    # which would silently misparse if store put ever prepends a
+    # warning line before the success message).
+    arrow_lines = [
+        ln for ln in put.output.strip().splitlines() if "→" in ln
+    ]
+    assert arrow_lines, f"no Stored: line in put output: {put.output!r}"
+    full_name = arrow_lines[0].split("→", 1)[1].strip()
+    assert full_name.startswith("knowledge__yfqv-search"), put.output
+    return full_name
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+
+class TestSearchVector:
+    def test_search_routes_through_daemon(
+        self,
+        runner: CliRunner,
+        seeded_collection: str,
+    ) -> None:
+        """``nx search`` must hit the daemon's chroma + the daemon's T2.
+
+        The query token (``zenithpony``) is rare enough that any non-
+        catastrophic vector backend should surface the seeded chunk in
+        the top result. We do not assert the exact distance ordering;
+        we only assert that the chunk is reachable through the daemon.
+        """
+        result = runner.invoke(
+            main,
+            [
+                "search",
+                "zenithpony",
+                "--corpus",
+                seeded_collection,
+                "--no-threshold",  # don't drop on cosine threshold
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # The store put recorded ``alpha.md`` as title; the formatter
+        # surfaces either the file path / title fragment.
+        assert "alpha.md" in result.output, result.output
+
+
+class TestSearchNoMatchingCorpus:
+    def test_search_unknown_corpus(
+        self,
+        runner: CliRunner,
+        live_t2_daemon,
+        live_t3_daemon,
+        reset_t3_singleton,
+    ) -> None:
+        """An unknown ``--corpus`` resolves to zero collections — the CLI
+        must surface that cleanly (exit 0 + ``no matching collections``)
+        without raising the daemon. Verifies the T3 ``list_collections``
+        round-trip works against the daemon's HttpClient."""
+        result = runner.invoke(
+            main,
+            [
+                "search",
+                "zenithpony",
+                "--corpus",
+                "knowledge__yfqv_nonexistent_bogus",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "no matching collections" in result.output
+
+
+class TestSearchJsonOutput:
+    def test_search_json_output_under_daemon(
+        self,
+        runner: CliRunner,
+        seeded_collection: str,
+    ) -> None:
+        """``--json`` exercises the same retrieval path but a different
+        output formatter; verifies the singleton get_t3 is safe across
+        the structured-output branch."""
+        result = runner.invoke(
+            main,
+            [
+                "search",
+                "zenithpony",
+                "--corpus",
+                seeded_collection,
+                "--no-threshold",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # nexus-84a6: parse ``result.stdout`` not ``result.output``;
+        # CliRunner interleaves stdout+stderr in Click 8.2+, which
+        # would corrupt the JSON parse if any structlog message slips
+        # past the ERROR-level filter.
+        import json
+        parsed = json.loads(result.stdout)
+        assert isinstance(parsed, list)
+        assert len(parsed) >= 1, result.output
+
+
+class TestSearchHybridMode:
+    def test_search_hybrid_under_daemon(
+        self,
+        runner: CliRunner,
+        seeded_collection: str,
+    ) -> None:
+        """``--hybrid`` calls ``get_t3()`` and ``t2_ctx()`` like the
+        non-hybrid path; the ripgrep merge runs on top. The seeded
+        collection has no ripgrep cache, so the rg branch yields zero
+        hits — we only assert the vector-side still surfaces the chunk
+        via the daemon."""
+        result = runner.invoke(
+            main,
+            [
+                "search",
+                "zenithpony",
+                "--corpus",
+                seeded_collection,
+                "--no-threshold",
+                "--hybrid",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # Vector branch must still surface ``alpha.md`` even with the
+        # hybrid scorer engaged.
+        assert "alpha.md" in result.output, result.output

--- a/tests/test_enrich_command.py
+++ b/tests/test_enrich_command.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 from nexus.commands.enrich import enrich
 
 
-@patch("nexus.db.make_t3")
+@patch("nexus.mcp_infra.get_t3")
 @patch("nexus.bib_enricher.enrich")
 def test_enrich_empty_collection(mock_bib: MagicMock, mock_t3_factory: MagicMock) -> None:
     """Empty collection prints message and exits cleanly."""
@@ -26,7 +26,7 @@ def test_enrich_empty_collection(mock_bib: MagicMock, mock_t3_factory: MagicMock
     mock_bib.assert_not_called()
 
 
-@patch("nexus.db.make_t3")
+@patch("nexus.mcp_infra.get_t3")
 @patch("nexus.bib_enricher.enrich")
 def test_enrich_skips_already_enriched(mock_bib: MagicMock, mock_t3_factory: MagicMock) -> None:
     """Chunks with bib_semantic_scholar_id are skipped (idempotency)."""
@@ -51,7 +51,7 @@ def test_enrich_skips_already_enriched(mock_bib: MagicMock, mock_t3_factory: Mag
 
 
 @patch("nexus.retry._chroma_with_retry")
-@patch("nexus.db.make_t3")
+@patch("nexus.mcp_infra.get_t3")
 @patch("nexus.bib_enricher.enrich")
 def test_enrich_updates_metadata(
     mock_bib: MagicMock, mock_t3_factory: MagicMock, mock_retry: MagicMock
@@ -92,7 +92,7 @@ def test_enrich_updates_metadata(
     assert "enriched 2 chunks across 1 titles" in result.output
 
 
-@patch("nexus.db.make_t3")
+@patch("nexus.mcp_infra.get_t3")
 @patch("nexus.bib_enricher.enrich")
 def test_enrich_no_match_increments_skipped(mock_bib: MagicMock, mock_t3_factory: MagicMock) -> None:
     """When bib_enrich returns {}, the title is counted as skipped."""
@@ -113,7 +113,7 @@ def test_enrich_no_match_increments_skipped(mock_bib: MagicMock, mock_t3_factory
     assert "1 titles had no Semantic Scholar match" in result.output
 
 
-@patch("nexus.db.make_t3")
+@patch("nexus.mcp_infra.get_t3")
 @patch("nexus.bib_enricher.enrich")
 def test_enrich_limit_option(mock_bib: MagicMock, mock_t3_factory: MagicMock) -> None:
     """--limit caps the number of titles enriched."""
@@ -142,7 +142,7 @@ def test_enrich_limit_option(mock_bib: MagicMock, mock_t3_factory: MagicMock) ->
 # ── nexus-57mk: --source flag + auto fallback + OpenAlex backend ────────────
 
 
-@patch("nexus.db.make_t3")
+@patch("nexus.mcp_infra.get_t3")
 @patch("nexus.bib_enricher_openalex.enrich")
 def test_enrich_source_openalex_routes_to_openalex_backend(
     mock_oa: MagicMock, mock_t3_factory: MagicMock,
@@ -179,7 +179,7 @@ def test_enrich_source_openalex_routes_to_openalex_backend(
     assert "bib_semantic_scholar_id" not in metas[0]
 
 
-@patch("nexus.db.make_t3")
+@patch("nexus.mcp_infra.get_t3")
 @patch("nexus.bib_enricher_openalex.enrich")
 @patch("nexus.bib_enricher.enrich")
 def test_enrich_source_auto_falls_back_to_openalex_without_s2_key(
@@ -214,7 +214,7 @@ def test_enrich_source_auto_falls_back_to_openalex_without_s2_key(
 
 @patch("nexus.bib_enricher_openalex.enrich_by_doi")
 @patch("nexus.bib_enricher_openalex.enrich")
-@patch("nexus.db.make_t3")
+@patch("nexus.mcp_infra.get_t3")
 def test_enrich_openalex_prefers_doi_over_title_search(
     mock_t3_factory: MagicMock,
     mock_title: MagicMock,
@@ -264,7 +264,7 @@ def test_enrich_openalex_prefers_doi_over_title_search(
 @patch("nexus.bib_enricher_openalex.enrich_by_arxiv_id")
 @patch("nexus.bib_enricher_openalex.enrich_by_doi")
 @patch("nexus.bib_enricher_openalex.enrich")
-@patch("nexus.db.make_t3")
+@patch("nexus.mcp_infra.get_t3")
 def test_enrich_openalex_falls_back_to_arxiv_when_no_doi(
     mock_t3_factory: MagicMock,
     mock_title: MagicMock,
@@ -305,7 +305,7 @@ def test_enrich_openalex_falls_back_to_arxiv_when_no_doi(
     assert "via DOI/arXiv ID" in result.output
 
 
-@patch("nexus.db.make_t3")
+@patch("nexus.mcp_infra.get_t3")
 @patch("nexus.bib_enricher.enrich")
 @patch("nexus.bib_enricher_openalex.enrich")
 def test_enrich_source_auto_uses_s2_when_key_present(


### PR DESCRIPTION
## Summary

Phase 4.2 of RDR-112. `nx search` and `nx enrich` now route through `mcp_infra.get_t3()` / `t2_ctx()` so daemon mode hits the HttpClient / T2Client instead of racing the daemon with a PersistentClient on the same on-disk store.

## Production diff (two hunks)

**enrich.py:171-185 - enrich_bib flip.** Replaces the only direct `make_t3()` site with `get_t3()`. RuntimeError-to-ClickException translation covers the daemon-resolver failure paths (T3DaemonError / DaemonNotRunningError both subclass RuntimeError).

**enrich.py:1573-1588 - aspects-show refactor.** Drops `db.document_aspects._has_doc_id_pk()` (a private probe that AttributeErrors against the `_StoreProxy` facade) and chains `get_by_doc_id() or get(...)`. Equivalent because `DocumentAspects.get_by_doc_id` returns None on the pre-migration schema (see db/t2/document_aspects.py:598-599).

## search_cmd.py

Zero source changes. Already routed via `from nexus.commands.store import _t3` (idqd) and `from nexus.mcp_infra import t2_ctx` (Phase 3). Contract-pinned by the new daemon-mode test file.

## Test changes

- `tests/commands/test_search_daemon_mode.py` (new, 4 tests): live T2 + T3 daemons, seeded `knowledge__yfqv-search` collection, exercises vector search, no-matching-corpus, JSON output, and `--hybrid`.
- `tests/commands/test_enrich_daemon_mode.py` (new, 5 tests): bib end-to-end via daemon (synthetic OpenAlex backend), empty-collection routing, `aspects --dry-run`, `enrich list`, and a `_StoreProxy` hygiene unit pin against future underscore-method regressions.
- `tests/test_enrich_command.py`: 10 patch sites moved from `nexus.db.make_t3` to `nexus.mcp_infra.get_t3` (matches the idqd pattern in tests/test_memory.py and tests/test_store_cmd.py).

## Filed follow-up

`nexus-qghk` captures the broader daemon-side `document_aspects.*` RPC deny-list (substrate work). The yfqv refactor moves `aspects-show` from a client-side AttributeError to a server-side T2DaemonError; the substrate fix is out of scope here.

## Code review

PASS verdict from code-review-expert with 3 Minor findings, all remediated in-place:
- M1: parse hardening for the seeded_collection fixture (split on arrow, not rsplit-by-space).
- M2: comment on the pre-seeded `bib_openalex_id: ""` clarifying the skip-already-enriched gate.
- M3: `pool=None` in the proxy hygiene unit test - already type-ignored, no action.

Also caught two test-discipline issues during the full-suite run that the review missed:
- nexus-84a6 invariant: `json.loads(result.output)` switched to `result.stdout` for Click 8.2+ stdout/stderr separation.
- RDR-109 mode lint: literal `voyage-context-3` in test sources replaced with `minilm-l6-v2-384` since tests run with NX_LOCAL=1.

## Test plan

- [x] `uv run pytest tests/commands/test_search_daemon_mode.py tests/commands/test_enrich_daemon_mode.py` - 9 passed
- [x] `uv run pytest tests/test_enrich_command.py` - 10 passed (patch-target swap)
- [x] `uv run pytest tests/test_enrich_aspects_read.py` - 12 passed (aspects-show refactor regression check)
- [x] `uv run pytest` (full suite) - 9038 passed, 5 pre-existing failures unchanged from develop baseline
- [x] Code review: PASS (3 Minor remediated)

## Closes

Closes nexus-yfqv