### PR TITLE
docs(rdr-118,rdr-119): portal contract + UI fabric drafts; A2UI summary

### DIFF
--- a/docs/a2ui-summary.md
+++ b/docs/a2ui-summary.md
@@ -1,0 +1,488 @@
+# A2UI Summary — Reader's Brief for Nexus Adoption
+
+> **Purpose**: a self-contained reader-friendly summary of A2UI as it
+> applies to the nexus cockpit substrate. Companion to RDR-118 and
+> RDR-119. Locally reviewable before committing to the adoption path.
+
+---
+
+## 1. What A2UI Is
+
+**A2UI (Agent-to-UI)** is an open protocol — Apache 2.0 — for letting
+**LLM agents describe user interfaces declaratively**, with the *client*
+rendering using its own native, pre-approved components.
+
+- **Released**: 2026, Google-led, with active contributions from
+  CopilotKit, Oracle, Flutter team.
+- **Stable version**: v0.8 (production).
+- **Draft version**: v0.9 (transport-level catalog negotiation).
+- **Spec home**: <https://a2ui.org/specification/v0.8-a2ui/>
+- **Repo**: <https://github.com/google/a2ui>
+- **License**: Apache 2.0.
+
+The core move: agents emit JSON describing **intent** (this is a button
+labelled "Submit" with this action). Clients render it with their own
+trusted UI primitives (a native Flutter widget, a Lumino DOM node, a
+SwiftUI view, …). No HTML eval, no remote scripts, no iframe sandboxing.
+
+## 2. Where A2UI Sits in the 2026 Agent Stack
+
+```
+┌───────────────────────────────────────────┐
+│  A2UI       — agent ↔ user (UI intent)    │   ← Adoption target
+├───────────────────────────────────────────┤
+│  AG-UI      — agent ↔ runtime (events)    │   ← Compatible scaffold
+├───────────────────────────────────────────┤
+│  A2A        — agent ↔ agent (messaging)   │   ← Compatible (some overlap)
+├───────────────────────────────────────────┤
+│  MCP        — agent ↔ tool                │   ← Already in nexus
+└───────────────────────────────────────────┘
+```
+
+Complementary, not overlapping. A2UI deliberately leaves transport to
+A2A/AG-UI/MCP; nexus's MCP plumbing carries A2UI without modification.
+
+## 3. The Surface Concept
+
+> A **Surface** is "a contiguous portion of screen real estate into
+> which an A2UI UI can be rendered."
+
+Each surface has:
+
+- A unique `surfaceId`.
+- A separate root component hierarchy.
+- An independent data model (`Map<String, dynamic>`).
+
+The `surfaceId` appears in messages: `beginRendering`, `surfaceUpdate`,
+`dataModelUpdate`, `deleteSurface`.
+
+**Why this matters for nexus**: the vocabulary is *literally* the same
+word nexus has been using since `agentic-cockpit.md`. RDR-111 surface
+levels (status-line / notification / panel / full-screen) are
+realizable as A2UI surfaces.
+
+## 4. The Five Message Types
+
+### 4.1 `beginRendering`
+
+Server tells client to start rendering a surface. Names the
+`surfaceId`, the `catalogId`, and the `root` component id.
+
+```json
+{
+  "beginRendering": {
+    "surfaceId": "main_content_area",
+    "catalogId": "https://nexus.dev/a2ui/catalogs/lumino-v1.json",
+    "root": "outer-rdr-list"
+  }
+}
+```
+
+### 4.2 `surfaceUpdate`
+
+Server sends a list of components for a surface. **Flat adjacency list,
+not nested tree** (LLM-friendly + incremental).
+
+```json
+{
+  "surfaceUpdate": {
+    "surfaceId": "main_content_area",
+    "components": [
+      { "id": "outer-rdr-list",
+        "component": {
+          "Column": {
+            "children": { "explicitList": ["rdr-card-118", "rdr-card-119"] }
+          }
+        }
+      },
+      { "id": "rdr-card-118",
+        "component": {
+          "Card": {
+            "child": "rdr-card-118-text"
+          }
+        }
+      },
+      { "id": "rdr-card-118-text",
+        "component": {
+          "Text": { "text": { "literalString": "RDR-118: Surfaces as Tuples" } }
+        }
+      }
+    ]
+  }
+}
+```
+
+Children reference siblings by `id`. The client reconstructs the tree
+at render time.
+
+### 4.3 `dataModelUpdate`
+
+Patches to the surface's data model, keyed by JSON-pointer paths.
+
+```json
+{
+  "dataModelUpdate": {
+    "surfaceId": "main_content_area",
+    "path": "/rdrs/118",
+    "contents": [
+      { "key": "title", "valueString": "Surfaces as Tuples" },
+      { "key": "status", "valueString": "draft" }
+    ]
+  }
+}
+```
+
+### 4.4 `userAction` (client → server)
+
+Triggered when the user interacts with a component carrying an `action`
+property. Client resolves the action's context values against the data
+model, sends:
+
+```json
+{
+  "userAction": {
+    "name": "open_rdr",
+    "surfaceId": "main_content_area",
+    "sourceComponentId": "rdr-card-118",
+    "timestamp": "2026-05-18T10:30:00Z",
+    "context": { "rdrId": "RDR-118" }
+  }
+}
+```
+
+Server responds with a fresh `surfaceUpdate` / `dataModelUpdate`.
+
+### 4.5 `deleteSurface`
+
+Removes a surface entirely.
+
+## 5. The Component Catalog
+
+Components are **catalog-defined and extensible**. Each component wraps
+exactly one typed property:
+
+```json
+{
+  "Text": {
+    "text": { "literalString": "Hello" },
+    "usageHint": "h3"
+  }
+}
+```
+
+### 5.1 Standard catalog (v0.8 base)
+
+`Column`, `Row` — containers with alignment.
+`Card` — wraps a child with styling.
+`Text` — text display with `usageHint` (h1/h2/h3/body).
+`Image` — image display.
+`List` — iterable list.
+`Button` — interactive with `action` property.
+`Container` — children via `explicitList` or `template`.
+
+### 5.2 v0.9 additions
+
+`AudioPlayer`, `DateTimeInput`, `Modal`, `Slider`.
+
+### 5.3 Custom catalogs
+
+Apps publish their own catalogs (e.g., `nexus.lumino.v1`,
+`nexus.notcurses.v1`). Catalog IDs are URIs; each catalog defines its
+component set as JSON Schema.
+
+## 6. The Catalog Negotiation Handshake
+
+This is where A2UI's **capability-based security** lives.
+
+### 6.1 v0.8 (Message-based, two-step)
+
+**Step 1 — Server advertises** via A2A Agent Card extension:
+
+```json
+{
+  "capabilities": {
+    "extensions": [{
+      "uri": "https://a2ui.org/a2a-extension/a2ui/v0.8",
+      "params": {
+        "supportedCatalogIds": [
+          "https://a2ui.org/specification/v0_8/standard_catalog_definition.json"
+        ],
+        "acceptsInlineCatalogs": true
+      }
+    }]
+  }
+}
+```
+
+**Step 2 — Client declares; server chooses**: client includes
+`a2uiClientCapabilities.supportedCatalogIds` in every message; server
+picks via `beginRendering.catalogId`.
+
+### 6.2 v0.9 (Transport-level metadata)
+
+The negotiation moves out of protocol messages and into the **transport
+metadata** layer:
+
+- `a2uiClientCapabilities` — advertises supported catalogs.
+- `a2uiClientDataModel` — transmits surface data model via transport
+  metadata.
+- Exchange happens via transport-specific handshakes: A2A metadata,
+  Agent Cards, MCP `initialize`.
+
+**Why this matters for nexus**: nexus already uses MCP. The v0.9
+handshake fits naturally — cockpit hosts advertise their supported
+catalogs on MCP `initialize`. Producers cache.
+
+### 6.3 The capability discipline
+
+Clients hold a **pre-approved catalog** of trusted components. Agents
+can request only what the client offers. This is *capability-based UI
+by construction* — no agent can request a component the client hasn't
+approved. The whole "trust under recursion" question we wrestled with
+in RDR-118 is *built into the protocol*.
+
+## 7. Data Binding — `BoundValue`
+
+Any place a value can appear, A2UI accepts a `BoundValue`:
+
+```json
+{ "literalString": "static text" }
+```
+
+```json
+{ "path": "/user/name" }
+```
+
+```json
+{ "literalString": "Bob",   // both forms = static init that
+  "path": "/user/name" }    // also seeds the data model
+```
+
+- `literalString` / `literalNumber` / `literalBoolean` / `literalImage`:
+  static values.
+- `path`: JSON-pointer into the data model. The renderer subscribes to
+  the path; updates re-render.
+
+**v0.9 addition: relative paths**. Inside a template iterating over
+`/users`, a relative `firstName` resolves to `/users/0/firstName`,
+`/users/1/firstName`, etc.
+
+**Two-way input binding (v0.9)**: input components implement read/write
+contracts. User interactions immediately update local data model;
+server sync only on explicit `userAction`.
+
+### 7.1 Nexus extension: `chash://` as a path
+
+RDR-118 adopts `chash://<hex>[#span]` as a valid `BoundValue.path`.
+The renderer-side resolver:
+
+1. Recognizes `chash://`.
+2. Calls `Catalog.resolve_chunk()` via the daemon (RDR-053).
+3. Substitutes the chunk content into the component.
+
+This is how transclusion lands. See RDR-118 §"`chash://` as A2UI
+`BoundValue.path`".
+
+## 8. Container Children — `explicitList` vs `template`
+
+Containers (`Column`, `Row`, `Card`, etc.) declare children one of two
+ways:
+
+### 8.1 explicitList (named children)
+
+```json
+{
+  "children": {
+    "explicitList": ["child-id-1", "child-id-2", "child-id-3"]
+  }
+}
+```
+
+### 8.2 template (data-driven iteration)
+
+```json
+{
+  "children": {
+    "template": {
+      "dataBinding": "/items",
+      "componentId": "item-template"
+    }
+  }
+}
+```
+
+Renders `item-template` once per item in `/items`. With v0.9 relative
+paths, the template can reference per-item fields without absolute
+paths.
+
+## 9. Security Model
+
+### 9.1 Declarative-only
+
+A2UI is **data, not code**. No script execution, no eval, no remote
+loading. Clients can only do what their pre-approved catalog allows.
+
+### 9.2 Identity attribution (v0.9)
+
+Identity carried via theme properties:
+
+- `iconUrl` — agent's icon.
+- `agentDisplayName` — agent's display name.
+
+In **multi-agent systems, the orchestrator validates** these fields to
+prevent impersonation. No explicit sandboxing model beyond identity
+spoofing prevention.
+
+### 9.3 Nexus mapping
+
+| A2UI concept | Nexus mapping |
+|---|---|
+| Orchestrator validates identity | RDR-111 binding watcher validates `iconUrl` / `agentDisplayName` against per-cell `origin` |
+| Pre-approved catalog | RDR-110 dimension registry + per-host catalog files (`nexus.lumino.v1`, `nexus.notcurses.v1`) |
+| Capability scope | RDR-113 daemon trust + per-cell `origin` label |
+
+The capability discipline composes cleanly with RDR-113 single-user
+v1; multi-user (future) lands on top with no schema change.
+
+## 10. Renderer Ecosystem (May 2026)
+
+### 10.1 Web
+
+- **Lit** — Google's lightweight web components library. Reference
+  renderer.
+- **React** — via AG-UI / CopilotKit integration.
+- **Angular** — community renderer.
+
+### 10.2 Mobile
+
+- **Flutter** — via GenUI SDK.
+- **iOS (SwiftUI)** — planned for v1.0+.
+- **Android (Jetpack Compose)** — planned for v1.0+.
+
+### 10.3 Nexus-specific (RDR-119)
+
+- **`nexus.lumino.v1`** — Lumino DockPanel + widgets in a Tauri shell.
+  Covers web + desktop + (Tauri 2) mobile.
+- **`nexus.notcurses.v1`** — notcurses planes for tty hosts.
+
+Both ship as part of RDR-119 deliverables. Same A2UI catalog
+negotiation; same `surface_cell` tuple substrate from RDR-118.
+
+## 11. What Nexus Inherits from A2UI
+
+| Inherit | Notes |
+|---|---|
+| Surface descriptor schema | `surfaceId` / `surfaceUpdate` / `dataModelUpdate` / `userAction` / `deleteSurface`. Verbatim. |
+| Component catalog model | RDR-118 `representation_type` = A2UI catalog id. |
+| Catalog negotiation | RDR-118 capability handshake = A2UI catalog negotiation. |
+| BoundValue (literal | path) | RDR-118 `data_ref_kind: inline | uri` ↔ A2UI. |
+| Container templates | Bakke iteration over event types maps onto A2UI templates. |
+| Security model | Capability-based UI = the trust-under-recursion property we wanted. |
+| Identity (v0.9) | `iconUrl` / `agentDisplayName` ↔ RDR-110 `actor` dimension. |
+
+## 12. What Nexus Adds on Top (the Honest Delta)
+
+| Addition | RDR | Rationale |
+|---|---|---|
+| `surface_cell` subspace (cells-as-tuples) | RDR-118 | Materialized per-slot rendering state; substrate for declarative cells. |
+| Sibling-surface recursion convention | RDR-118 | A2UI has no nested-surface model. Sub-surfaces as sibling-surfaceIds coordinated by tuple. |
+| `chash://` as BoundValue path | RDR-118 | Transclusion via RDR-053 inheritance. |
+| Per-cell `origin` discipline | RDR-118 | RDR-113 refinement; labels who's rendering inside daemon trust boundary. |
+| HATEOAS-style action affordances | RDR-118 | A2UI `userAction` already supports this; producer discipline only. |
+| `nexus.lumino.v1` catalog | RDR-119 | Per-host A2UI catalog for web/desktop/mobile. |
+| `nexus.notcurses.v1` catalog | RDR-119 | Per-host A2UI catalog for tty. |
+| Tauri 2 shell | RDR-119 | Cross-platform native webview host for Lumino. |
+| Bakke-driven `layout_state` | RDR-111 (shipped) | Already there. The fabric reads it; A2UI components fill the slots. |
+| `mission_context` subspace | RDR-119 | Profile bundle (active bindings, catalogs, layout, permission mode). |
+
+## 13. The Honest Gap (Nexus-Specific Extension)
+
+A2UI v0.9 supports multiple surfaces via distinct `surfaceId`s but has
+**no nested-surface recursion model**. RDR-118 ships:
+
+> **Sibling-surface recursion convention**: a cell with
+> `child_subspace = <sub_id>` declares "render a sub-surface here." The
+> host treats this as an A2UI Container whose body is the set of
+> `surface_cell` tuples in `surface_cell/<sub_id>`. The renderer
+> instantiates a nested layout engine bound to the child subspace.
+
+If A2UI later ships a nested-surface model, we contribute the spec
+change upstream and deprecate our convention.
+
+## 14. Recommended Adoption Path
+
+### 14.1 v1 — Adopt A2UI v0.8 (Stable)
+
+- Target the Stable schema.
+- Use two-step catalog negotiation initially; migrate to v0.9
+  transport-level when v0.9 stabilizes.
+- Ship `nexus.lumino.v1` and `nexus.notcurses.v1` catalogs.
+- Add `chash://` BoundValue path and sibling-surface recursion as
+  nexus-specific extensions documented in `surface_cell.yml`.
+
+### 14.2 v1.5 — Track A2UI v0.9
+
+- Migrate catalog negotiation to MCP `initialize` (v0.9 transport-level).
+- Adopt v0.9 components: `Modal`, `DateTimeInput`, `Slider`,
+  `AudioPlayer`.
+- Adopt relative-path resolution in templates.
+
+### 14.3 v2 — Contribute upstream
+
+- If sibling-surface recursion proves load-bearing, propose
+  `NestedSurface` as an A2UI standard component.
+- Contribute `chash://` BoundValue path as a content-addressed
+  reference extension.
+
+## 15. Quick-Reference Checklist for Reviewers
+
+- [ ] Read §1–§6 for the protocol overview.
+- [ ] Read §11–§13 for the nexus mapping and the one honest gap.
+- [ ] Cross-reference RDR-118 §Technical Design for the cell substrate.
+- [ ] Cross-reference RDR-119 §Technical Design for the per-host
+      realization.
+- [ ] Validate adoption rationale (§14) against your priorities.
+- [ ] Flag anything that needs spike before commitment (A2UI
+      catalog-through-MCP negotiation, `chash://` path, sibling-
+      surface recursion).
+
+## 16. References
+
+### Primary sources
+
+- A2UI v0.8 spec — <https://a2ui.org/specification/v0.8-a2ui/>
+- A2UI v0.9 draft — <https://a2ui.org/specification/v0.9-a2ui/>
+- A2UI repo — <https://github.com/google/a2ui>
+- Google Developers introduction —
+  <https://developers.googleblog.com/introducing-a2ui-an-open-project-for-agent-driven-interfaces/>
+
+### Nexus context
+
+- `docs/agentic-cockpit.md` (especially §Surfaces lines 593–738, §Open
+  Questions lines 813–815 — explicitly anticipates A2UI)
+- RDR-053: Xanadu Fidelity (`chash://` content-addressed spans)
+- RDR-108: T3 Chunk Soft-Delete (chunk_text_hash as natural ID)
+- RDR-110: Semantic Tuple Space
+- RDR-111: ORB Cockpit Substrate (+ post-mortem)
+- RDR-112: Storage-as-Service Container Boundary
+- RDR-113: Host-Trust Model
+- RDR-118: Surfaces as Tuples (companion)
+- RDR-119: Cockpit UI Fabric (companion)
+
+### Nexus T3 knowledge entries
+
+- `a2ui-v08-surface-descriptor-schema` — full schema details
+- `a2ui-v09-draft-changes` — v0.9 diffs
+- `a2ui-design-philosophy-stack-positioning` — Google's design rationale
+- `a2ui-nexus-synthesis-cockpit-mapping` — the synthesis behind RDR-118 + RDR-119
+
+Recover via `nx_answer "What is A2UI and how does it map onto nexus?"`
+or `nx search a2ui`.
+
+---
+
+**Status of this document**: companion to RDR-118 + RDR-119 draft.
+Reader-friendly; intended for local review before commitment to the
+adoption path. Not normative — the RDRs are.
+
+**Date**: 2026-05-18.

--- a/docs/rdr/rdr-118-surfaces-as-tuples.md
+++ b/docs/rdr/rdr-118-surfaces-as-tuples.md
@@ -1,0 +1,687 @@
+---
+title: "Surfaces as Tuples — The ORB is the Portal Broker (A2UI Adoption + Xanadu Inheritance)"
+id: RDR-118
+type: Architecture
+status: draft
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-17
+revised: 2026-05-18
+accepted_date:
+related_issues: []
+related_rdrs: [RDR-053, RDR-108, RDR-110, RDR-111, RDR-112, RDR-113]
+related_external: [a2ui-v0.8-spec, a2ui-v0.9-draft, ag-ui, a2a-protocol, mcp]
+reactivates_beads: [nexus-kkh2, nexus-0rws, nexus-kgo4]
+related_tests: []
+---
+
+# RDR-118: Surfaces as Tuples — The ORB is the Portal Broker
+
+> Third iteration. The first two sketches re-derived layers that already
+> exist. This one names the inheritance honestly and limits itself to the
+> delta nexus actually adds.
+
+## Problem Statement
+
+RDR-111 ships the cockpit substrate (surface levels, bindings primitive,
+auto-layout engine, layout_state subspace, three reference panels). RDR-110
+ships the semantic tuple space — the broker. RDR-053 ships Xanadu fidelity
+(`chash://` content-addressed spans, tumbler comparison, link survivability)
+at the catalog layer. A2UI v0.8 (Google, 2026, Apache 2.0) ships the
+canonical surface descriptor protocol — explicitly anticipated by
+`agentic-cockpit.md` lines 813–815 as the mature target format.
+
+What's missing is the **small discipline that wires these layers together**
+so a cell can be (a) heterogeneous content from an arbitrary producer,
+(b) recursively composable, (c) capability-negotiated with the host,
+(d) referenced by stable content address, and (e) trust-scoped under the
+existing daemon boundary. That wiring is this RDR.
+
+This RDR adopts A2UI v0.8 as the descriptor format, inherits RDR-053's
+`chash://` transclusion stack, reuses RDR-111's `layout_state` placement
+protocol, and adds four small things: a `surface_cell` subspace, a
+sibling-surface recursion convention, `chash://` as a BoundValue path,
+and producer discipline for HATEOAS-style action affordances.
+
+### Enumerated gaps to close
+
+#### Gap 1: No published cell-as-tuple schema bridging `bindings/<profile>` to A2UI
+
+RDR-111 ships `bindings/<profile>` with an opaque `surface_payload` field.
+A2UI ships a structured `surfaceUpdate` event. There is no documented
+mapping between them. Without it, producers and hosts coordinate ad-hoc,
+which forks.
+
+#### Gap 2: No recursion convention (A2UI doesn't cover nested surfaces)
+
+A2UI supports multiple `surfaceId`s but no nested-surface composition. A
+cell that hosts another surface is undocumented. Sibling-surface
+coordination via tuple is the smallest extension that preserves the
+recursive-surfaces ambition.
+
+#### Gap 3: No first-class transclusion path
+
+RDR-053 ships `chash://<hash>[#span]` as the catalog-layer content
+address. Cells should be able to render content by referencing a chash —
+without inventing a new URI scheme or new resolution path. A2UI's
+`BoundValue.path` field is the natural attachment point.
+
+#### Gap 4: No per-cell origin refinement of RDR-113
+
+RDR-113 sets trust at the daemon boundary. A2UI v0.9 carries identity via
+`iconUrl` and `agentDisplayName`. We need a per-cell `origin` dimension on
+`surface_cell` that refines RDR-113 (the daemon decides who can attach;
+`origin` labels who's currently rendering inside that boundary). Not new
+trust — finer labeling within existing trust.
+
+## Context
+
+### Animating principle (preserved across iterations)
+
+The nexus thesis is that producers and consumers should bind by **meaning**
+— RDR-110 semantic tuple space, `match_text` fields, NLP-parsed bindings.
+The ORB is the broker; the substrate already does capability negotiation.
+A2UI's *catalog* abstraction is the protocol-level realization of the same
+discipline: clients hold pre-approved component catalogs; agents request
+from them; the negotiation IS the capability handshake.
+
+We do **not** invent a parallel decider, MIME registry, or capability
+bundle. The tuple space + A2UI catalogs together cover this.
+
+### Inheritance map (zero new substrate code)
+
+| Concern | Inherited from | Notes |
+|---|---|---|
+| Surface descriptor schema | A2UI v0.8 (Stable) | `surfaceId`, `surfaceUpdate`, `dataModelUpdate`, `userAction`, `BoundValue`. |
+| Component catalogs | A2UI + RDR-110 dimension registry | Catalogs register as subspaces; per-host catalogs publish capabilities. |
+| Catalog negotiation | A2UI v0.8 two-step (v0.9 transport-level) | Server advertises supported catalogs; client declares its set; server picks. |
+| Coordination substrate | RDR-110 tuple space | Log-structured, offset-tracking subscribers, semantic match. |
+| Placement-plan transport | RDR-111 `layout_state/<profile>` subspace | Bakke auto-layout writes; surfaces read; 250ms debounce. |
+| Auto-layout engine | RDR-111 `src/nexus/cockpit/layout.py` | Vertical-stack + demotion cascade (shipped). |
+| Static surface render | RDR-111 binding payload | One tuple → one render, cheap, low-latency. |
+| Streaming surface render | RDR-111 connection_manifest (Phase 4, deferred) | Manifest tuple declares pipe; peers connect direct. |
+| Trust boundary | RDR-113 | Daemon-level. Per-cell `origin` is a label refinement. |
+| Daemon SQL RPC | RDR-112 | Canonical pattern for ordered/temporal retrieval. |
+| Content-addressed transclusion | RDR-053 + RDR-108 | `chash://<hex>` resolves via catalog manifest → ChromaDB chunk. |
+| Tumbler arithmetic / span overlap | RDR-053 D6 | Comparison-only (no ADD/SUBTRACT). Sufficient for our use. |
+| Identity attribution | A2UI v0.9 (`iconUrl`, `agentDisplayName`) | Maps to RDR-110 `actor` dimension. Orchestrator validates per A2UI. |
+
+### What the source documents explicitly anticipated
+
+`agentic-cockpit.md` lines 813–815, in §Open Questions:
+
+> Surface descriptor format. Need to settle on a small, stable shape (level
+> + payload + optional layout hints). Earliest version can be a JSON
+> Schema; **mature version maps to A2UI or similar declarative component
+> intent.**
+
+A2UI shipped in 2026. This RDR is the "mature version" landing.
+
+### Phase 4 reactivation
+
+RDR-111 deferred two beads explicitly:
+
+- **`nexus-kkh2`** (P4.1) — tmux pane fulfillment adapter (connection_manifest consumer)
+- **`nexus-0rws`** (P4.2) — ext-apps iframe fulfillment adapter (connection_manifest consumer)
+
+And one consumer-driven bead:
+
+- **`nexus-kgo4`** (P3.5) — first end-to-end mission profile
+
+RDR-118 + RDR-119 are the reactivation work for all three. The MVP mission
+profile (§Implementation Plan) is an RDR audit cockpit.
+
+### Enumerated gaps closed (sources)
+
+- Gap 1 closure: §"Surface_cell subspace schema" + §"A2UI mapping"
+- Gap 2 closure: §"Sibling-surface recursion convention"
+- Gap 3 closure: §"chash:// as BoundValue path"
+- Gap 4 closure: §"Per-cell origin discipline"
+
+## Research Findings
+
+### Investigation
+
+Read in full: `agentic-cockpit.md` (889 lines), RDR-110, RDR-111 (1198
+lines) + post-mortem, RDR-053 (Xanadu fidelity, closed), RDR-108 (T3
+chunk soft-delete), RDR-112 + RDR-113 (trust + daemon). Fetched A2UI v0.8
+specification, A2UI v0.9 draft, Google Developers introduction blog.
+Ingested four T3 entries (`a2ui-v08-surface-descriptor-schema`,
+`a2ui-v09-draft-changes`, `a2ui-design-philosophy-stack-positioning`,
+`a2ui-nexus-synthesis-cockpit-mapping`) with cross-references.
+
+#### Dependency Source Verification
+
+| Dependency | Source Searched? | Key Findings |
+|---|---|---|
+| A2UI v0.8 schema | Yes (a2ui.org/specification/v0.8-a2ui) | `surfaceUpdate`, `dataModelUpdate`, `userAction`, `BoundValue` (literal\|path), two-step catalog negotiation, Container.children = explicitList \| template |
+| A2UI v0.9 draft | Yes (a2ui.org/specification/v0.9-a2ui) | Transport-level catalog negotiation, JSON-pointer dataModel updates, two-way input binding, no nested-surface recursion documented |
+| A2UI Google intro | Yes (developers.googleblog.com) | Apache 2.0, complementary to A2A/AG-UI/MCP, security-first declarative-only |
+| RDR-053 Xanadu fidelity | Yes (full read) | `chash:<sha256>` canonical, `_SPAN_PATTERN` accepts `chash:[0-9a-f]{64}`, `link_audit(t3=...)` detects stale spans, tumbler comparison via -1 sentinel padding |
+| RDR-108 T3 chunk soft-delete | Partial | T3 chunk natural ID is `chunk_text_hash[:32]`; catalog `document_chunks` manifest gives `(doc_id, position) → chash` |
+| RDR-111 shipped surfaces | Yes (post-mortem + src/nexus/cockpit/) | hook_bridge.py:239 (emit), bindings.py:137 (Binding/BindingProfile), layout.py:79 (render_text), three panels under panels/ |
+| RDR-111 deferred work | Yes (post-mortem) | nexus-kkh2 (tmux pane fulfillment), nexus-0rws (ext-apps iframe fulfillment), nexus-kgo4 (first mission profile) all dormant |
+
+### Key Discoveries
+
+- **Verified (RDR-111 §Open Questions line 813-815)**: A2UI was explicitly
+  named as the mature surface descriptor format. This RDR is that landing.
+- **Verified (A2UI spec)**: surface vocabulary is *literally* the same word
+  and concept. Near-1:1 mapping to existing nexus concepts.
+- **Verified (A2UI repo + blog)**: pre-approved component catalogs make
+  A2UI *capability-based UI* by construction. This is the trust-under-
+  recursion property we wanted, off the shelf.
+- **Verified (RDR-053)**: `chash://` resolution path runs through the
+  existing catalog manifest and ChromaDB. `link_audit(t3=...)` extends
+  cleanly to detect stale transclusions.
+- **Documented (A2UI v0.9 draft)**: catalog negotiation moved to
+  transport-level metadata (A2A Agent Cards, MCP `initialize`). Better fit
+  for our MCP transport.
+- **Verified (A2UI v0.9 draft)**: no nested-surface recursion model. The
+  single nexus-specific extension we ship.
+- **Verified (RDR-111 post-mortem)**: phase-4 work was deferred with
+  explicit reactivation triggers; this RDR is that reactivation.
+
+### Critical Assumptions
+
+- [ ] **A1** — A2UI catalog negotiation through MCP `initialize`
+  (v0.9 transport-level mode) is reachable without forking the protocol.
+  **Status**: Unverified. **Method**: Paper design + small spike against
+  the A2UI reference implementation.
+- [ ] **A2** — Sibling-surface coordination via tuple gives correct
+  recursion semantics through three nesting levels (no name collision,
+  no infinite-loop risk, deterministic teardown).
+  **Status**: Unverified. **Method**: Spike — three-level nested surface
+  with mixed content; verify under resize, focus, dispose.
+- [ ] **A3** — `chash://` is a valid `BoundValue.path` value in A2UI
+  v0.8/v0.9 (or can be rendered via a small renderer-side resolver).
+  **Status**: Unverified. **Method**: Spike — render a cell whose path
+  is a chash; verify catalog → ChromaDB → A2UI fragment pipeline.
+- [ ] **A4** — Per-cell `origin` is a strict refinement of RDR-113.
+  **Status**: Unverified. **Method**: Source search + RDR-113 author
+  confirmation.
+- [ ] **A5** — Per-host A2UI catalogs (`nexus.lumino.v1`,
+  `nexus.notcurses.v1`) can each cover the cockpit's reference panels
+  without compromise.
+  **Status**: Unverified. **Method**: Build both catalogs minimally for
+  the MVP mission profile.
+
+## Proposed Solution
+
+### Approach
+
+Adopt A2UI v0.8 (Stable) as the surface descriptor format. Track v0.9.
+Add four small nexus-specific extensions (cell tuple schema, sibling
+recursion convention, `chash://` path, origin discipline). Reuse
+RDR-111's layout_state for placement plans. Inherit RDR-053's
+transclusion stack. Reactivate three dormant beads as deliverables.
+
+### Technical Design
+
+#### 1. `surface_cell/<surface_id>` subspace
+
+A new subspace whose tuples *declare* what should be in each slot of a
+surface. Each tuple is the **materialized rendering state** for one
+slot — distinct from `layout_state` (which carries Bakke's per-binding-
+type stylesheet) and from individual binding events (which carry
+content instances).
+
+```yaml
+surface_cell:
+  dimensions:
+    - name: surface_id      # composition: which parent surface (A2UI surfaceId)
+    - name: slot            # composition: named layout slot
+    - name: origin          # trust label: URL origin | peer-cred+container
+                            # | binding profile name (RDR-113 refinement)
+    - name: child_subspace  # recursion: name of nested surface's subspace
+                            # (null for leaf cells)
+    - name: a2ui_catalog_id # which A2UI catalog this cell is shaped against
+  match_text_field: description  # natural-language capability description
+  content_fields:
+    - representation_type   # short discriminator: a2ui-component | chash |
+                            # connection-manifest-ref | lumino-widget |
+                            # notcurses-plane | nexus-surface
+    - data_ref              # inline | URI | subspace-name | chash:// |
+                            # manifest-id
+    - data_ref_kind         # inline | uri | subspace | transclusion |
+                            # manifest | a2ui-component-inline
+    - actions               # optional: A2UI userAction descriptors
+                            # (HATEOAS-style per-cell affordances)
+```
+
+A *cell* is one tuple in this subspace. A *surface* is the set of cells
+with the same `surface_id`. A *sub-surface* is a cell whose
+`child_subspace` is non-null — the host instantiates a nested layout
+engine bound to that subspace.
+
+**Default representation**: `a2ui-component` with `data_ref_kind: inline`
+carrying an A2UI component JSON fragment. This is the cheap common case.
+
+#### 2. A2UI mapping
+
+| A2UI concept | Nexus realization |
+|---|---|
+| `surfaceId` | `surface_cell.surface_id` |
+| `surfaceUpdate` | binding action writes `surface_cell` tuple |
+| `component` | `surface_cell.data_ref` when `data_ref_kind=a2ui-component-inline` |
+| `BoundValue.literalString` | inline payload |
+| `BoundValue.path` | `chash://<hex>[#span]` (transclusion) or `tuple://<subspace>/<id>` (subspace ref) |
+| `dataModelUpdate` | tuple `out` to `surface_cell` (incremental) |
+| `userAction` | tuple `out` to `cell_input/<surface_id>` |
+| `deleteSurface` | tuple `take` on all `surface_cell` for the surface_id |
+| Container.children (explicitList) | named cells in the same `surface_id` |
+| Container.children (template) | binding fires per matching event in a trigger subspace |
+| Catalog id | `a2ui_catalog_id` dimension |
+| Catalog negotiation | MCP `initialize` (per A2UI v0.9 transport-level) |
+
+#### 3. Sibling-surface recursion convention
+
+A2UI has no nested-surface model. Nexus adds:
+
+- A cell with `child_subspace = <sub_id>` declares "render a sub-surface
+  here." The host treats this as an A2UI Container whose body is the set
+  of `surface_cell` tuples in `surface_cell/<sub_id>`.
+- Sub-surface composition is by **sibling surfaceId** with a parent-child
+  reference dimension, not by literal A2UI nesting. The renderer
+  instantiates a nested layout engine bound to the child subspace.
+- Trust re-evaluation at every nesting level: the child surface inherits
+  no capability from its parent. `origin` is per-cell.
+- Cycle detection: host tracks the subspace-reference path; refuses to
+  recurse into a subspace already on the path. Depth cap (default 8) as
+  belt-and-braces.
+
+If A2UI later defines a nested-surface model, contribute upstream and
+deprecate this convention.
+
+#### 4. `chash://` as A2UI `BoundValue.path`
+
+A cell can render content by reference:
+
+```json
+{
+  "Text": {
+    "text": { "path": "chash://b5e2a8c9...3f1" }
+  }
+}
+```
+
+The renderer-side resolver:
+
+1. Recognizes `chash://` scheme.
+2. Resolves the chunk via the catalog (`Catalog.resolve_chunk()` from
+   RDR-053).
+3. Substitutes the chunk text (or image bytes, for image components) as
+   the rendered value.
+
+`link_audit(t3=...)` from RDR-053 already detects stale chash spans.
+Reuse.
+
+For document-level transclusion: `chash://<doc_hash>` resolves via the
+`document_chunks` manifest's `(doc_id, position) → chash` mapping
+(RDR-108).
+
+#### 5. Per-cell `origin` discipline
+
+`origin` is a *label*, not a *capability*. RDR-113 daemon-level trust
+gates daemon access. `origin` filters within that boundary:
+
+| Producer kind | `origin` value |
+|---|---|
+| Local binding (default) | binding profile name (e.g., `cockpit.local`) |
+| Foreign iframe content | URL origin (e.g., `https://docs.example.com`) |
+| PTY content | `pty:peer-cred+container-id` (when daemonized) |
+| Transcluded content | `chash:` (label propagates from the chash source's origin) |
+| A2UI agent | `a2ui:<agent_did>` (when A2UI v0.9 identity validated) |
+
+Orchestrator (the binding watcher) validates `iconUrl` /
+`agentDisplayName` against `origin` per A2UI v0.9 anti-impersonation
+discipline. No new identity layer.
+
+#### 6. Layout / input / focus subspaces
+
+Already shipped in RDR-111 (`hook_events/*`, bindings, `layout_state`).
+This RDR names two new conventional subspaces:
+
+- `cell_layout/<surface_id>` — resize, visibility, damage events.
+  Damage clipped at cell rectangle (recursion-safe).
+- `cell_input/<surface_id>` — pointer/key events in cell-local
+  coordinates. Carries A2UI `userAction` shape.
+- `cell_focus/<root_surface_id>` — single focus-path tuple. DFS by
+  default; per-container overrides allowed via cell `actions` field.
+
+### Existing Infrastructure Audit
+
+| Proposed Component | Existing Module | Decision |
+|---|---|---|
+| Surface descriptor schema | A2UI v0.8 (external) | **Adopt entire** |
+| `surface_cell` subspace | none | **New** (this RDR) — registers via RDR-112 admin RPC |
+| `cell_layout` / `cell_input` / `cell_focus` | RDR-110 subspace registry | **New schemas** (this RDR) |
+| Sibling-surface recursion | none | **New convention** (this RDR) |
+| `chash://` BoundValue path | RDR-053 catalog + RDR-108 manifest | **Extend** — add renderer-side resolver (~50 LoC) |
+| Per-cell `origin` | RDR-113 | **Refine** — label dimension; no trust expansion |
+| Capability negotiation | A2UI catalog negotiation + RDR-110 registry | **Reuse entire** |
+| Placement-plan transport | RDR-111 `layout_state/<profile>` subspace | **Reuse entire** |
+| Auto-layout engine | RDR-111 `src/nexus/cockpit/layout.py` | **Reuse entire** |
+| Direct SQL RPC for ordered retrieval | RDR-112 | **Reuse entire** |
+| HATEOAS action affordances | A2UI `userAction` already supports this | **Producer discipline only** |
+| Per-host catalog implementation | none | **Deferred to RDR-119** — `nexus.lumino.v1`, `nexus.notcurses.v1` |
+
+### Decision Rationale
+
+Three forces:
+
+1. **The substrate already does the work.** RDR-110/111 are the broker;
+   A2UI is the descriptor protocol. Re-inventing either is duplication.
+   RDR-053 already shipped Xanadu fidelity at the catalog layer; we
+   inherit.
+2. **Cells-as-tuples is symmetric across nesting** under sibling-surface
+   recursion. Composition is automatic.
+3. **No new vocabulary** beyond the four nexus-specific extensions.
+   Producers describe themselves once in `match_text` + `description`;
+   hosts negotiate via A2UI catalogs; nothing else to invent.
+
+## Alternatives Considered
+
+### Alternative 1: Invent a parallel MIME-bundle + decider (abandoned)
+
+The first sketch of this RDR. Rejected because RDR-110 is already the
+broker; A2UI is already the catalog protocol. Adding a parallel decider
+would have duplicated both.
+
+### Alternative 2: Adapt MCP `ui://` resource model
+
+MCP treats UI as a sandboxed HTML resource. **Pros**: existing MCP
+plumbing. **Cons**: HTML is executable; loses A2UI's capability-based
+discipline; doesn't compose cleanly with the cockpit's surface-level
+discipline. **Reason for rejection**: A2UI explicitly positions itself
+as the *native-first* alternative to MCP `ui://` for exactly this
+case.
+
+### Alternative 3: Extend A2UI upstream with nested-surface recursion
+
+Add a `NestedSurface` component to the standard A2UI catalog and
+contribute the spec change upstream. **Pros**: standardized recursion.
+**Cons**: blocks our v1 on upstream acceptance; slow.
+
+**Reason for deferral**: ship sibling-surface coordination first; if it
+proves load-bearing, contribute upstream as v2.
+
+### Briefly Rejected
+
+- **Invent a tuple:// URI scheme for transclusion**: RDR-053's
+  `chash://` already exists; using a parallel scheme would fork the
+  address space.
+- **New transport for cell payloads**: tuple bodies + A2UI BoundValue
+  already work; no new mechanism needed.
+- **NestedSurface as our own catalog component, not a convention**:
+  defer to v2 after sibling-surface convention proves out.
+
+## Trade-offs
+
+### Consequences
+
+- (+) Contract is tiny: one new subspace schema + three convention
+  subspaces + a renderer-side chash resolver.
+- (+) Recursion is genuinely composable (sub-surfaces are first-class
+  values, addressable by subspace name).
+- (+) Capability evolution is free — A2UI catalogs are the existing
+  protocol mechanism.
+- (+) Forward-compatible: A2UI v0.9 transport-level negotiation fits
+  MCP naturally.
+- (+) Cross-host portability is a protocol-level property; the same
+  cell can render on Lumino, notcurses, or any A2UI client.
+- (+) Reactivates three previously-dormant beads (`nexus-kkh2`,
+  `nexus-0rws`, `nexus-kgo4`).
+- (−) v1 commits to A2UI v0.8 (Stable) and tracks v0.9 (Draft) —
+  protocol may evolve under us.
+- (−) Sibling-surface recursion is a nexus-specific extension to A2UI;
+  may have to migrate if/when A2UI ships a nested-surface model.
+- (−) Match-quality at the broker becomes a correctness concern for
+  cockpit rendering, not just retrieval. Threshold tuning matters.
+
+### Risks and Mitigations
+
+- **Risk**: A2UI v0.8 deprecated faster than expected.
+  **Mitigation**: track v0.9 in parallel; the descriptor shape is
+  stable across versions (catalog negotiation changed transport, not
+  semantics).
+
+- **Risk**: Sibling-surface coordination cycles.
+  **Mitigation**: subspace-reference path tracking + depth cap;
+  refuse to recurse into a subspace already on the path.
+
+- **Risk**: `chash://` resolution latency on render path.
+  **Mitigation**: catalog cache + chunk metadata pre-fetch; resolution
+  is at binding-activation cadence (Auto-Style), not per event.
+
+- **Risk**: `origin` misused as backdoor to RDR-113 trust.
+  **Mitigation**: spec discipline — `origin` is label-only; RDR-113
+  daemon trust still gates access.
+
+- **Risk**: Per-host catalog drift (`nexus.lumino.v1` and
+  `nexus.notcurses.v1` diverge in semantics).
+  **Mitigation**: shared catalog spec (RDR-119); cross-host
+  conformance tests.
+
+### Failure Modes
+
+- *Visible*: cell renders wrong representation (catalog negotiation
+  bug); cell renders wrong size (`layout_state` mismatch); transclusion
+  resolves to stale content (RDR-053 `link_audit` flags).
+- *Silent*: focus desync under deep nesting; sub-surface buffer leak on
+  dispose; recursive cycle without depth cap.
+- *Recovery*: portal-inspector cell (built using the contract itself)
+  shows for any selected cell — A2UI catalog id, capability match
+  trace, origin, recent layout_state entries, top-k semantic matches
+  with scores.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] A1–A5 verified via spikes.
+- [ ] A2UI v0.8 reference renderer evaluated (Lit on web, GenUI SDK on
+      Flutter).
+- [ ] RDR-111 layout_state subspace confirmed read-accessible from
+      Phase 4 fulfillment adapter.
+- [ ] RDR-053 `Catalog.resolve_chunk()` exposed via daemon RPC for
+      renderer-side chash resolution.
+
+### Minimum Viable Validation
+
+**MVP mission profile: RDR audit cockpit.** A three-level surface that:
+
+1. Outer surface = list of all open RDRs (top-level panel).
+2. Each RDR item is a sub-surface containing problem-statement,
+   research-findings, design, and gate sub-cells.
+3. Each sub-cell can transclude (via `chash://`) from another RDR or
+   the catalog.
+
+Renders on both backends from RDR-119 (Lumino-in-Tauri and notcurses).
+Inner surfaces use only `surface_cell` subspace operations — no
+medium-specific API. Reactivates `nexus-kgo4`.
+
+### Phase 1: Schemas and conventions
+
+#### Step 1: Land subspace YAML schemas
+
+- `nx/tuplespace/builtin/surface_cell.yml`
+- `nx/tuplespace/builtin/cell_layout.yml`
+- `nx/tuplespace/builtin/cell_input.yml`
+- `nx/tuplespace/builtin/cell_focus.yml`
+
+Register via RDR-112 admin RPC. Document the sibling-surface recursion
+convention in the `surface_cell.yml` header.
+
+#### Step 2: `chash://` BoundValue resolver
+
+Renderer-side library (~50 LoC): recognizes `chash://` scheme, calls
+`Catalog.resolve_chunk()` via daemon RPC, returns chunk text/bytes for
+A2UI substitution. Cache resolved values at the cell's
+`a2ui_catalog_id` scope.
+
+#### Step 3: A2UI catalog negotiation through MCP
+
+Document the handshake: cockpit hosts advertise supported A2UI catalog
+IDs via MCP `initialize` (per A2UI v0.9 transport-level mode);
+producers query via the existing MCP capability discovery.
+
+### Phase 2: Reactivation of fulfillment adapters
+
+Hand off to RDR-119 for the per-host catalog implementations:
+
+- **Reactivate `nexus-kkh2`** — tmux pane fulfillment adapter using
+  `nexus.notcurses.v1` catalog.
+- **Reactivate `nexus-0rws`** — ext-apps iframe fulfillment adapter
+  using `nexus.lumino.v1` catalog (in Tauri shell).
+
+### Phase 3: First end-to-end mission profile
+
+- **Reactivate `nexus-kgo4`** — RDR audit cockpit MVP (above).
+- Author bindings, layout disposition, permission mode.
+- Run on both backends.
+- Measure what's awkward; iterate.
+
+### Day 2 Operations
+
+- New subspaces inherit RDR-110 dimension-registry operations and
+  RDR-112 daemon admin RPCs (`list-subspaces`, `show-schema`, `stats`,
+  `out`, `read`, `take`, `ack`, `nack`).
+- `chash://` validation extends `link_audit` (already in RDR-053).
+
+### New Dependencies
+
+- A2UI v0.8 reference renderer (Lit / GenUI SDK / CopilotKit) — adoption,
+  not in-tree.
+- No new Python/Rust dependencies for the substrate side.
+
+## Test Plan
+
+- **Scenario**: A2UI catalog negotiation through MCP initialize.
+  **Verify**: cockpit host's `nexus.lumino.v1` advertised in
+  `MCP initialize` response; producer can request rendering against it.
+- **Scenario**: Three-level nested surface renders identically on
+  Lumino and notcurses backends.
+  **Verify**: same `surface_cell` tuples; rendered output differs only
+  in medium-specific component realization.
+- **Scenario**: `chash://` BoundValue path resolves correctly.
+  **Verify**: cell with `BoundValue.path = chash://<hex>` renders the
+  chunk text; `link_audit` flags stale spans.
+- **Scenario**: Sibling-surface recursion cycle prevention.
+  **Verify**: a `child_subspace` referencing an ancestor surface is
+  refused with a clear error; depth cap (8) terminates pathological
+  recursion.
+- **Scenario**: Origin filtering.
+  **Verify**: a cell with `origin=foreign-iframe` cannot post to its
+  parent's `cell_input` subspace; RDR-113 daemon trust unchanged.
+- **Scenario**: HATEOAS-style action affordances render and dispatch.
+  **Verify**: a cell carrying A2UI `userAction` triggers a binding fire
+  with correct `surfaceId`/`sourceComponentId`.
+- **Scenario**: Match-quality threshold floor.
+  **Verify**: when no producer-tuple matches a host's catalog query
+  above threshold, host renders a documented placeholder with the
+  query for diagnosis.
+
+## Validation
+
+### Testing Strategy
+
+1. **Scenario**: Reference RDR audit cockpit (three levels, mixed
+   content per level) renders identically on Lumino-in-Tauri and
+   notcurses backends.
+   **Expected**: pass with the same `surface_cell` tuples; chosen
+   A2UI components differ per host catalog; no medium-specific code
+   in the producer.
+
+### Performance Expectations
+
+Negotiation cost = A2UI catalog handshake at MCP initialize (once per
+session). Capability match cost = one RDR-110 semantic-match query per
+cell per Auto-Style tick. Cached at the binding watcher. Per-event
+Layout cost unchanged. `chash://` resolution = one catalog →
+ChromaDB lookup per cell mount, cached.
+
+## Finalization Gate
+
+(deferred — sketch only)
+
+### Contradiction Check
+
+(deferred)
+
+### Assumption Verification
+
+(deferred — A1–A5 unverified; spikes required)
+
+### Scope Verification
+
+(deferred)
+
+### Cross-Cutting Concerns
+
+- **Versioning**: A2UI is versioned externally (v0.8 Stable, v0.9
+  Draft); per-host catalog versions namespaced (`nexus.lumino.v1`,
+  `nexus.notcurses.v1`).
+- **Build tool compatibility**: N/A at spec stage.
+- **Licensing**: A2UI is Apache 2.0; compatible with nexus.
+- **Deployment model**: per-host catalogs ship independently; sibling-
+  surface recursion convention documented in `surface_cell.yml`.
+- **IDE compatibility**: VS Code webview ships as single-cell host in
+  v1 (no nested webviews — explicit deferral, same as RDR-119).
+- **Incremental adoption**: legacy RDR-111 `surface_payload` strings
+  continue to work — they are one form of tuple body. Migration to
+  `surface_cell` subspace is opt-in per binding.
+- **Secret/credential lifecycle**: `origin` labels cells; RDR-113
+  daemon trust gates access. Secrets never cross cell boundaries by
+  default.
+- **Memory management**: dispose is `take`; RDR-110 retention sweeper
+  releases bodies; sub-surface teardown closes any held resources.
+
+### Proportionality
+
+Small RDR. The substrate is RDR-110/111; the descriptor protocol is
+A2UI; the Xanadu inheritance is RDR-053. This RDR is the discipline
+that wires them. Resist the urge to grow it.
+
+## References
+
+- A2UI v0.8 spec — https://a2ui.org/specification/v0.8-a2ui/
+- A2UI v0.9 draft — https://a2ui.org/specification/v0.9-a2ui/
+- A2UI Google introduction —
+  https://developers.googleblog.com/introducing-a2ui-an-open-project-for-agent-driven-interfaces/
+- A2UI repo (Apache 2.0) — https://github.com/google/a2ui
+- T3 entries: `a2ui-v08-surface-descriptor-schema`,
+  `a2ui-v09-draft-changes`,
+  `a2ui-design-philosophy-stack-positioning`,
+  `a2ui-nexus-synthesis-cockpit-mapping`
+- `docs/agentic-cockpit.md` (especially §Surfaces lines 593–738, §Open
+  Questions lines 813–815)
+- RDR-053: Xanadu Fidelity — Tumbler Arithmetic and Content-Addressed
+  Spans
+- RDR-108: T3 Chunk Soft-Delete (chunk_text_hash as natural ID)
+- RDR-110: Semantic Tuple Space
+- RDR-111: ORB Cockpit Substrate + post-mortem
+- RDR-112: Storage-as-Service Container Boundary
+- RDR-113: Host-Trust Model
+- `docs/a2ui-summary.md` (this worktree) — reader-friendly A2UI
+  summary for review
+
+## Revision History
+
+_2026-05-17 — initial sketch under wrong framing (MIME-bundle + decider
+indirection). Built a parallel decider over the existing semantic
+broker._
+
+_2026-05-17 — abandoned and rewritten. The ORB is the broker; cells
+are tuples; recursion is a subspace reference. Contract collapsed to
+four subspace schemas + query template._
+
+_2026-05-18 — third iteration after thorough audit: read full
+`agentic-cockpit.md`, RDR-111 + post-mortem, RDR-053, RDR-108; fetched
+and ingested A2UI v0.8/v0.9 specs and Google announcement. Adopted
+A2UI v0.8 as the descriptor format (explicitly anticipated by
+cockpit.md lines 813-815); inherited RDR-053 `chash://` transclusion;
+named sibling-surface coordination as the one nexus-specific
+extension; reactivates dormant beads `nexus-kkh2`, `nexus-0rws`,
+`nexus-kgo4`. This is the current document._

--- a/docs/rdr/rdr-119-cockpit-ui-fabric.md
+++ b/docs/rdr/rdr-119-cockpit-ui-fabric.md
@@ -1,0 +1,698 @@
+---
+title: "Cockpit UI Fabric — Bakke Auto-Layout over A2UI Catalogs, per-Host Realization"
+id: RDR-119
+type: Architecture
+status: draft
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-18
+accepted_date:
+related_issues: []
+related_rdrs: [RDR-110, RDR-111, RDR-112, RDR-113, RDR-053, RDR-118]
+related_external: [a2ui-v0.8-spec, a2ui-v0.9-draft, lumino, notcurses, tauri]
+reactivates_beads: [nexus-kkh2, nexus-0rws]
+related_tests: []
+---
+
+# RDR-119: Cockpit UI Fabric
+
+> Sketch. Companion to RDR-118. Defines the **per-host realization** of
+> A2UI catalogs that RDR-118 adopts, the policy layer that drives them
+> (Bakke auto-layout already shipped in RDR-111), and the cross-platform
+> shell (Tauri 2).
+
+## Problem Statement
+
+RDR-118 adopts A2UI as the surface descriptor format and inherits the
+RDR-110/111 substrate. What's still open is the **per-host fabric** —
+the concrete realization that takes A2UI surface descriptors and renders
+them as a usable, accessible, keyboard-navigable cockpit on each
+medium.
+
+The cockpit substrate (RDR-111) shipped a vertical-stack Bakke engine and
+three reference panels rendered as tmux output. Phase 4 explicitly
+deferred the *fulfillment adapters* that consume connection manifests
+and render A2UI surfaces on real hosts:
+
+- **`nexus-kkh2`** (deferred, P4.1) — tmux pane fulfillment adapter
+- **`nexus-0rws`** (deferred, P4.2) — ext-apps iframe fulfillment adapter
+
+RDR-119 is the reactivation of both. It also addresses the
+*UI fabric* concerns RDR-118 names but doesn't settle: focus, navigation,
+layout containers, modal stack, accessibility, keyboard discipline.
+
+### Enumerated gaps to close
+
+#### Gap 1: No per-host A2UI catalog implementations
+
+A2UI ships as a protocol. Each host needs a concrete catalog
+(`nexus.lumino.v1` for web/Tauri, `nexus.notcurses.v1` for tty) that
+maps A2UI components to native rendering primitives. Without these, no
+cell renders.
+
+#### Gap 2: UI fabric concerns are unsettled
+
+Tab order, focus traversal, modal stack, layout containers, accessibility
+relationships, keyboard discipline, cross-surface navigation gestures —
+all unaddressed by RDR-111 / RDR-118 alone. The cockpit's organizing
+principle is Bakke auto-layout (already shipped), but the *fabric* that
+gives it ergonomics is open.
+
+#### Gap 3: No cross-platform shell decision
+
+RDR-118 names Tauri as the recommended shell. RDR-119 commits the
+decision and addresses the consequences (Tauri 2 supports web + mobile +
+desktop; native webview per platform).
+
+#### Gap 4: First end-to-end mission profile is dormant
+
+RDR-111 `nexus-kgo4` (first mission profile) was left consumer-driven.
+RDR-118 names "RDR audit cockpit" as the MVP profile. RDR-119 builds it
+across both backends.
+
+## Context
+
+### What the source already nails (do not re-derive)
+
+- **Layout policy**: Bakke auto-layout engine (RDR-111
+  `src/nexus/cockpit/layout.py:79`). Vertical stack + demotion cascade.
+  Three phases: Measure → Auto-Style → Layout. 250ms debounce.
+- **Placement-plan transport**: `layout_state/<profile>` subspace
+  (RDR-111).
+- **Surface descriptor format**: A2UI v0.8 (Stable). Per RDR-118.
+- **Cell substrate**: `surface_cell/<surface_id>` subspace (per RDR-118).
+- **Trust boundary**: RDR-113 daemon-level + per-cell `origin` label.
+- **Ordered retrieval**: direct T2 SQL via RDR-112 daemon RPC.
+- **Reference panels**: active-claims, recent-events, active-bindings
+  (shipped in RDR-111).
+
+### What we adopt (zero new framework code)
+
+- **Lumino** (formerly Phosphor) — JupyterLab's TypeScript widget
+  framework. `DockPanel`, `MenuBar`, `CommandRegistry`, `FocusTracker`,
+  token-based service plugins. *Battle-tested* recursive composable web
+  fabric.
+- **notcurses** — z-ordered plane API for tty. Already cited in RDR-118.
+- **Tauri 2** — Rust + native webview shell. ~10–20× smaller than
+  Electron; supports web + iOS + Android + desktop.
+- **A2UI catalog negotiation through MCP `initialize`** — per A2UI v0.9
+  transport-level mode. Per RDR-118.
+
+### The framing tension and its resolution
+
+`agentic-cockpit.md` line 791 explicitly states:
+
+> Not building, intentionally: A new component / widget framework.
+
+Adopting Lumino is not building a framework; it is **choosing** an
+existing one to fill the GUI adapter slot the source deferred. Two
+honest framings, both correct:
+
+(a) Lumino is *the GUI fulfillment adapter* RDR-111 deferred (`nexus-0rws`).
+(b) Lumino is *the harness's rendering substrate* for GUI hosts, same role
+    tmux/notcurses fills for terminal hosts.
+
+We pick (b) as the official framing.
+
+## Research Findings
+
+### Investigation
+
+Audit of `agentic-cockpit.md` (§What we build vs leverage, lines 739-797;
+§Surfaces, lines 593-738), RDR-111 (§Auto-layout engine, post-mortem),
+A2UI v0.8/v0.9 specs (per RDR-118 ingestion), survey of Lumino /
+notcurses / Tauri / Adaptive Cards / Croquet / tldraw (per
+brainstorm-research-synthesis 2026-05-17).
+
+#### Dependency Source Verification
+
+| Dependency | Source Searched? | Key Findings |
+|---|---|---|
+| Lumino architecture | Yes (lumino.readthedocs.io, jupyterlab repo) | DockPanel, MenuBar, CommandRegistry, FocusTracker, token-based service plugins; production-grade across JupyterLab ecosystem |
+| notcurses planes | Yes (github.com/dankamongmen/notcurses) | z-ordered rectangles, EGC-aware cells, OSC 4 palette query, multimedia support |
+| Tauri 2 | Yes (PkgPulse 2026 comparison) | Native webview per platform; ~10–20× smaller than Electron; supports web + mobile + desktop; Rust core |
+| Bakke shipped engine | Yes (src/nexus/cockpit/layout.py + post-mortem) | Vertical-stack + demotion cascade only at v1; simpler than spec described |
+| Phase 4 deferred beads | Yes (RDR-111 post-mortem) | nexus-kkh2 (tmux), nexus-0rws (iframe) — both dormant under closed epic, explicit reactivation triggers |
+| A2UI catalog model | Yes (per RDR-118 ingestion) | Pre-approved catalogs; orchestrator validates identity; framework-agnostic |
+
+### Key Discoveries
+
+- **Verified (RDR-111 shipped)**: Bakke engine is vertical-stack-only
+  in v1. RDR-119 inherits this; extension to multi-column / dock-tree
+  is future work.
+- **Verified (A2UI)**: per-host catalogs (`nexus.lumino.v1`,
+  `nexus.notcurses.v1`) are the established A2UI extension pattern.
+- **Verified (Lumino architecture)**: DockPanel + CommandRegistry +
+  FocusTracker collectively cover focus/nav/modal/accessibility
+  concerns we'd been worried about — Lumino solves these natively for
+  the web side.
+- **Documented (Tauri 2)**: mobile support (iOS, Android) ships in
+  Tauri 2; web/desktop/mobile via the same Lumino fabric.
+- **Assumed**: notcurses input + plane APIs cover focus/nav for the
+  tty side with comparable ergonomics to Lumino. Spike needed.
+
+### Critical Assumptions
+
+- [ ] **A1** — Lumino's DockPanel and CommandRegistry compose under
+  A2UI catalog rendering without architectural conflict. **Status**:
+  Unverified. **Method**: Spike — render a `nexus.lumino.v1` catalog
+  example with three components in a DockPanel.
+- [ ] **A2** — notcurses planes + input handling give comparable
+  focus/nav ergonomics to Lumino on tty. **Status**: Unverified.
+  **Method**: Spike — render the same three-component example via
+  `nexus.notcurses.v1`; cross-test keyboard discipline.
+- [ ] **A3** — Bakke vertical-stack output maps cleanly onto Lumino
+  DockPanel rows/columns. **Status**: Unverified. **Method**: Spike —
+  drive Lumino layout from a `layout_state` tuple stream.
+- [ ] **A4** — Tauri 2 native webview hosts Lumino reliably across
+  macOS WebKit, Windows WebView2, Linux WebKitGTK. **Status**:
+  Unverified. **Method**: Spike — Tauri app shells with Lumino DockPanel
+  + 10-tab smoke.
+- [ ] **A5** — Per-host catalogs can advertise capabilities via MCP
+  `initialize` per A2UI v0.9 transport-level mode without forking the
+  protocol. **Status**: Carries from RDR-118 A1. Same spike.
+- [ ] **A6** — The "RDR audit cockpit" MVP mission profile (RDR-118
+  §MVP) exercises all four fabric concerns (focus, nav, container,
+  modal) sufficiently to validate the design. **Status**: Unverified.
+  **Method**: Build it; measure.
+- [ ] **A7** — Mission-context profiles couple to permission modes
+  (WoW combat-lockdown analog) explicitly, not implicitly. **Status**:
+  Unverified. **Method**: Paper design + RDR-111 author confirm.
+- [ ] **A8** — Per-cell Yjs as opt-in cell type (for editable surfaces)
+  composes with A2UI catalog rendering. **Status**: Unverified.
+  **Method**: Defer until a surface explicitly needs it.
+
+## Proposed Solution
+
+### Approach
+
+Bakke auto-layout is the policy layer (already shipped). Lumino and
+notcurses are passive rendering primitives that consume placement plans
+(`layout_state` tuples). Tauri 2 hosts Lumino. Each host publishes an
+A2UI catalog (`nexus.lumino.v1`, `nexus.notcurses.v1`) that maps A2UI
+components to native primitives. UI fabric concerns (focus, nav, modal,
+accessibility) are owned by the rendering primitive — Lumino on web,
+notcurses on tty.
+
+### Technical Design
+
+#### 1. Three-layer fabric
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Policy:  Bakke auto-layout (RDR-111, shipped)             │
+│          Measure → Auto-Style → Layout, demotion cascade  │
+│          Writes: layout_state/<profile> subspace          │
+└──────────────────────────────────────────────────────────┘
+                          │
+                          ▼ (subscribers read)
+┌──────────────────────────────────────────────────────────┐
+│ Substrate:  RDR-110 tuple space subspaces (RDR-118)       │
+│             surface_cell/<id>, cell_layout, cell_input,   │
+│             cell_focus, layout_state                      │
+└──────────────────────────────────────────────────────────┘
+                          │
+                          ▼ (renderers consume)
+┌──────────────────────────────────────────────────────────┐
+│ Primitives:  Lumino (web/Tauri) | notcurses (tty)         │
+│              A2UI catalog: nexus.lumino.v1 |              │
+│              nexus.notcurses.v1                           │
+│              Owns: focus, nav, container, modal, a11y     │
+└──────────────────────────────────────────────────────────┘
+```
+
+#### 2. `nexus.lumino.v1` A2UI catalog
+
+Maps standard A2UI components to Lumino widgets:
+
+| A2UI component | Lumino widget |
+|---|---|
+| `Column` / `Row` | `BoxPanel` (vertical/horizontal) |
+| `Card` | `Widget` with title bar |
+| `Text` | DOM `<div>` with text content |
+| `Image` | DOM `<img>` |
+| `List` | `Widget` with template-driven children |
+| `Button` | DOM `<button>` with `userAction` dispatch |
+| `Container.children.template` | `Widget` rebuilt on data binding |
+| `Modal` (v0.9) | `Dialog` widget with focus trap |
+| `Slider` (v0.9) | DOM input range |
+| Nexus extension: `NestedSurface` | Child `DockPanel` bound to subspace |
+
+Catalog id: `nexus.lumino.v1` (semver). Hosted at
+`https://nexus.dev/a2ui/catalogs/lumino-v1.json` (eventually).
+
+**Layout containers map onto Lumino DockPanel**: each named slot in a
+panel is a Lumino dock area. The Bakke engine writes
+`layout_state/<profile>` tuples; the Lumino adapter reads them and calls
+`DockPanel.addWidget` / `moveWidget` minimally.
+
+**Focus, keyboard discipline, modal stack** are owned by Lumino's
+`CommandRegistry` + `FocusTracker`. The A2UI Button's `userAction` field
+provides the action handler; Lumino dispatches it via tuple `out` to
+`cell_input/<surface_id>`.
+
+#### 3. `nexus.notcurses.v1` A2UI catalog
+
+Symmetric for tty:
+
+| A2UI component | notcurses primitive |
+|---|---|
+| `Column` / `Row` | Stacked / side-by-side planes |
+| `Card` | Plane with border |
+| `Text` | Plane with text |
+| `Image` | Plane with half-block / sextant pixel rendering |
+| `List` | Plane with row iteration |
+| `Button` | Highlighted plane with mouse/key bind |
+| `Container.children.template` | Plane rebuilt per data binding |
+| `Modal` (v0.9) | Top z-order plane with focus trap |
+| Nexus extension: `NestedSurface` | Nested plane bound to child subspace |
+
+Catalog id: `nexus.notcurses.v1`. Same advertisement path via MCP
+`initialize`.
+
+#### 4. Tauri 2 shell
+
+The web/desktop/mobile host. Tauri 2 wraps the platform's native webview
+(WebKit on macOS/iOS, WebView2 on Windows, WebKitGTK on Linux,
+WebView on Android). Lumino runs inside the webview.
+
+**Build target**: a small Tauri app that:
+1. Connects to the local nexus daemon (RDR-112) via MCP.
+2. Performs A2UI catalog negotiation on `initialize`.
+3. Hosts a Lumino `DockPanel` as the cockpit root.
+4. Subscribes to `layout_state/<profile>` and `surface_cell/*` subspaces.
+5. Renders A2UI components per `nexus.lumino.v1` mappings.
+6. Posts `userAction` events back via `cell_input/<surface_id>`.
+
+#### 5. Catalog negotiation via MCP `initialize`
+
+Per A2UI v0.9 transport-level mode. The MCP server initialization
+response includes:
+
+```json
+{
+  "a2uiClientCapabilities": {
+    "supportedCatalogIds": [
+      "https://nexus.dev/a2ui/catalogs/lumino-v1.json",
+      "https://nexus.dev/a2ui/catalogs/notcurses-v1.json",
+      "https://a2ui.org/specification/v0_8/standard_catalog_definition.json"
+    ],
+    "acceptsInlineCatalogs": false
+  }
+}
+```
+
+Producers query supported catalogs through the existing MCP capability
+discovery. No new transport.
+
+#### 6. UI fabric concerns ownership
+
+| Concern | Owned by | Notes |
+|---|---|---|
+| Tab order / focus traversal | Lumino `FocusTracker` (web) / notcurses input (tty) | DFS default; override via cell's `focus_priority` registry field. |
+| Keyboard shortcuts | Lumino `CommandRegistry` (web) / notcurses keybind (tty) | A2UI Button `userAction` is the dispatch target. |
+| Modal stack | Lumino `Dialog` widget (web) / top z-plane (tty) | Bakke `surface_level=full-screen` with `preempts=[*]`. |
+| Layout containers | Lumino `DockPanel/BoxPanel` (web) / notcurses planes (tty) | Driven by Bakke `layout_state` tuples. |
+| Accessibility (ARIA/labels) | Lumino's DOM (web) / notcurses' tags (tty) | A2UI components carry semantic role; renderer translates. |
+| Cross-surface navigation | A2UI `userAction` → binding fires `surface-swap` action | Action types: `surface-swap`, `drill-in`, `surface-back`. |
+| Drag-and-drop | Lumino DockPanel built-in (web) / N/A (tty) | Manual pin via dragging; auto-layout respects. |
+| Pointer / mouse | Lumino DOM events (web) / notcurses mouse (tty) | Translated to `cell_input` tuples. |
+
+#### 7. Mission-context × permission-mode coupling
+
+A mission-context profile is the tuple `mission_context/<name>` carrying:
+
+```yaml
+mission_context:
+  dimensions:
+    - profile_name
+    - permission_mode  # plan | acceptEdits | auto | default | bypassPermissions
+  content_fields:
+    - active_bindings    # list of binding ids
+    - active_catalogs    # list of A2UI catalog ids
+    - active_layout      # layout_state profile id
+    - recent_events_filter
+```
+
+Switching mission contexts is `out`ting a new `current_mission_context`
+tuple; subscribed surfaces react (per RDR-111). Permission mode is part
+of the bundle; the harness honors it (WoW combat-lockdown analog).
+
+### Existing Infrastructure Audit
+
+| Proposed Component | Existing Module | Decision |
+|---|---|---|
+| Bakke auto-layout policy | RDR-111 `src/nexus/cockpit/layout.py` | **Reuse entire** |
+| Placement-plan transport | RDR-111 `layout_state/<profile>` subspace | **Reuse entire** |
+| Cell substrate | RDR-118 `surface_cell` + cell_layout/input/focus subspaces | **Reuse entire** |
+| Reference panels (claims, events, bindings) | RDR-111 panels | **Reuse**; rewrap as `nexus.lumino.v1` / `nexus.notcurses.v1` catalog components |
+| Lumino | external (Apache-2.0 / BSD) | **Adopt whole** |
+| notcurses | external (Apache-2.0) | **Adopt whole** |
+| Tauri 2 | external (Apache-2.0 / MIT) | **Adopt whole** |
+| A2UI v0.8 protocol | external (Apache-2.0) | **Adopt entire** |
+| `nexus.lumino.v1` catalog | none | **New** (this RDR) |
+| `nexus.notcurses.v1` catalog | none | **New** (this RDR) |
+| Tauri shell binary | none | **New** (this RDR) |
+| MCP `initialize` catalog advertisement | RDR-110/112 MCP path | **Extend** — add `a2uiClientCapabilities` field |
+| `mission_context` subspace | none | **New** (this RDR) |
+| Per-cell Yjs | external (MIT) | **Deferred** — adopt selectively per cell type that needs it |
+
+### Decision Rationale
+
+Three forces:
+
+1. **The substrate is shipped.** RDR-110/111 + RDR-118 cover everything
+   below the per-host realization. Building anything else would
+   duplicate.
+2. **Lumino + notcurses cover the UI fabric.** Focus/nav/modal/a11y
+   are decades-old problems with mature solutions. Adopt.
+3. **A2UI's catalog model is the integration seam.** Per-host catalogs
+   are A2UI's *intended extension pattern* — we extend along the
+   protocol's grain, not against it.
+
+## Alternatives Considered
+
+### Alternative 1: Build a bespoke widget framework (rejected)
+
+`agentic-cockpit.md` line 791 explicitly says "Not building." Reasons
+remain valid. Lumino + notcurses are the better answer.
+
+### Alternative 2: Electron instead of Tauri
+
+**Pros**: most mature, JS-everywhere ecosystem, identical Chromium
+across platforms.
+**Cons**: 10–20× larger bundle, higher RAM, larger attack surface, no
+native mobile.
+**Reason for deferral**: Tauri 2 wins for nexus's profile (developer
+tool, security-sensitive substrate, eventual mobile). Reconsider only
+if Tauri's per-platform webview drift bites.
+
+### Alternative 3: Adaptive Cards as the catalog format
+
+A real option — Adaptive Cards is a peer to A2UI for semantic
+component-intent rendering. **Pros**: even more mature, Microsoft-
+maintained, large renderer ecosystem.
+**Cons**: not surface-shaped (single-card rendering), not
+multi-component-coordinated.
+**Reason for rejection**: A2UI is *surface-native*; Adaptive Cards is
+*card-native*. The cockpit needs surfaces.
+
+### Alternative 4: Croquet OS for fabric collab
+
+Bit-identical shared VM with reflector. **Pros**: zero merge logic,
+deterministic.
+**Cons**: paradigm shift (no side effects in Model code), overlaps
+RDR-110 at layer 1, narrower ecosystem than Yjs.
+**Reason for rejection**: covered in research synthesis 2026-05-17.
+Tuple space already does coarse-grained collab; Yjs adopted per cell
+type that needs fine-grained collab.
+
+### Briefly Rejected
+
+- **Pure DOM (no Lumino)**: re-invents DockPanel, FocusTracker,
+  CommandRegistry. Not worth the cost.
+- **Web Components only, no Lumino**: viable but no DockPanel
+  equivalent matches Lumino's ergonomics; same rejection reason.
+- **Visual binding-authoring UX**: explicitly rejected by RDR-111
+  (Alternative D). Form-based + LLM-assisted only.
+
+## Trade-offs
+
+### Consequences
+
+- (+) v1 build budget is small — per-host catalog implementations only.
+- (+) Lumino's ecosystem (extensions, themes, layouts) becomes
+  available essentially for free.
+- (+) Tauri 2 gives web + desktop + mobile from one codebase.
+- (+) A2UI catalog negotiation is the existing protocol mechanism;
+  no new vocabulary.
+- (+) Reactivates two deferred beads with clear MVP gating.
+- (−) Lumino is a non-trivial dependency to vendor; upstream churn
+  becomes a concern.
+- (−) Tauri 2's native webview drift across platforms is a real risk.
+- (−) Bakke's vertical-stack-only v1 limits initial layouts; multi-
+  column / nested-dock is future work.
+- (−) notcurses + Lumino catalogs must stay semantically aligned;
+  drift is the failure mode.
+
+### Risks and Mitigations
+
+- **Risk**: per-platform Tauri webview drift breaks Lumino rendering.
+  **Mitigation**: cross-platform smoke suite at every release; pin
+  Tauri 2.x.
+
+- **Risk**: notcurses + Lumino catalogs drift in semantics.
+  **Mitigation**: shared catalog spec doc; conformance tests run on
+  every catalog change.
+
+- **Risk**: A2UI v0.8 → v0.9 migration disrupts catalog format.
+  **Mitigation**: v0.8 schema is stable; v0.9 is largely a transport-
+  level change. Per-host catalogs versioned (`v1` first).
+
+- **Risk**: Lumino vendor lock-in.
+  **Mitigation**: catalog mapping is one of N possible web realizations
+  of A2UI; alternative renderers (Lit, React) can replace Lumino if
+  needed.
+
+- **Risk**: Bakke vertical-stack-only is too limited for real
+  cockpits.
+  **Mitigation**: extend to multi-column / dock-tree under a separate
+  RDR; v1 ships with the shipped engine.
+
+### Failure Modes
+
+- *Visible*: cell renders wrong widget (catalog mapping bug);
+  layout doesn't fit on screen (Bakke demotion cascade).
+- *Silent*: focus desync between Lumino and notcurses backends; modal
+  trap leaks; mission-context switch doesn't persist.
+- *Recovery*: portal-inspector cell (from RDR-118) shows the catalog
+  id, the requested A2UI component, the mapped Lumino/notcurses
+  widget, and the focus path. Diagnosis is one click.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] RDR-118 schemas landed (`surface_cell`, `cell_layout`,
+      `cell_input`, `cell_focus`).
+- [ ] `chash://` BoundValue resolver shipped per RDR-118 Phase 1 Step 2.
+- [ ] A2UI v0.8 reference implementation chosen for each host
+      (`@a2ui/lit` for Lumino web, custom for notcurses).
+- [ ] A1–A8 verified via spikes.
+
+### Minimum Viable Validation
+
+**MVP mission profile: RDR audit cockpit** (shared with RDR-118).
+
+Three-level recursive surface, rendered on both backends:
+
+1. Outer surface: list of all RDRs (Lumino `DockPanel` rows / notcurses
+   stacked planes).
+2. Each RDR is a sub-surface with problem / research / design / gate
+   sub-cells.
+3. Each sub-cell can transclude (`chash://`) into another RDR or the
+   catalog.
+
+Validates: A2UI catalog negotiation, Bakke layout, focus/nav,
+recursion, transclusion, cross-host rendering. Reactivates `nexus-kgo4`.
+
+### Phase 1: `nexus.notcurses.v1` catalog
+
+Reactivates `nexus-kkh2` (tmux pane fulfillment adapter).
+
+#### Step 1: Define catalog mapping
+
+Author `nexus.notcurses.v1.json` mapping A2UI standard catalog
+components to notcurses primitives. Reuse RDR-111's tmux adapter as
+starting code; rebuild around notcurses planes per A2UI catalog.
+
+#### Step 2: notcurses fulfillment adapter
+
+In `src/nexus/cockpit/notcurses_adapter.py`:
+- Subscribe to `surface_cell/*` + `cell_layout/*` + `layout_state/*`.
+- Resolve each cell's `representation_type` → A2UI component →
+  notcurses primitive per catalog mapping.
+- Translate notcurses input events → `cell_input` tuples.
+- Honor Bakke demotion cascade.
+
+Estimated ~600 LoC (3× RDR-111's estimate per shipped-code calibration).
+
+#### Step 3: Smoke test against RDR-111 reference panels
+
+The three reference panels (active-claims, recent-events,
+active-bindings) must render via the new catalog with feature parity.
+
+### Phase 2: `nexus.lumino.v1` catalog + Tauri shell
+
+Reactivates `nexus-0rws` (ext-apps iframe fulfillment adapter).
+
+#### Step 4: Define catalog mapping
+
+Author `nexus.lumino.v1.json` mapping A2UI components to Lumino
+widgets. Use `@lumino/widgets` + `@lumino/commands` packages.
+
+#### Step 5: Tauri shell scaffold
+
+In `crates/nexus-cockpit-tauri/` (new):
+- Tauri 2 app with Rust main.
+- Embeds `dist/lumino-app/` (TypeScript Lumino frontend).
+- Connects to local nexus daemon (RDR-112) via MCP over UDS.
+- Performs A2UI catalog negotiation on `initialize`.
+
+Estimated ~1000 LoC Rust + ~1500 LoC TypeScript.
+
+#### Step 6: Lumino fulfillment adapter
+
+In `dist/lumino-app/src/cockpit-adapter.ts`:
+- Same shape as notcurses adapter but for Lumino DockPanel.
+- Subscribes to subspaces via daemon WebSocket or MCP.
+- Renders A2UI components → Lumino widgets per catalog.
+- Translates Lumino events → `cell_input` tuples.
+
+### Phase 3: MVP mission profile
+
+Reactivates `nexus-kgo4`.
+
+#### Step 7: RDR audit cockpit bindings
+
+Author the bindings that produce the RDR audit surfaces. Use existing
+RDR-111 bindings primitive.
+
+#### Step 8: Cross-host parity tests
+
+Same `surface_cell` tuples must render meaningfully on both backends.
+Differences are in medium-specific catalog component mappings, never
+in cell content or composition.
+
+#### Step 9: Measure and iterate
+
+Per RDR-111's discipline: "Run it. Measure what's awkward. Iterate."
+
+### Day 2 Operations
+
+- Per-host catalog JSON files versioned (`v1`, `v2` ...) per A2UI
+  catalog conventions.
+- Tauri shell auto-update via Tauri's built-in updater.
+- notcurses adapter ships as part of `nx` CLI.
+- MCP `initialize` advertises catalogs; producers cache.
+
+### New Dependencies
+
+- `@lumino/widgets`, `@lumino/commands`, `@lumino/coreutils` (web)
+- `notcurses` (Apache-2.0; C with Python bindings)
+- `tauri@2.x` (Apache-2.0 / MIT; Rust)
+- `@a2ui/lit` or comparable A2UI renderer (Apache-2.0)
+
+## Test Plan
+
+- **Scenario**: Tauri shell launches, advertises catalogs via
+  `initialize`.
+  **Verify**: MCP response includes `a2uiClientCapabilities` with
+  `nexus.lumino.v1`.
+- **Scenario**: Three-level recursive surface renders on Lumino.
+  **Verify**: nested DockPanels with correct focus path.
+- **Scenario**: Same three-level surface renders on notcurses.
+  **Verify**: nested planes; equivalent focus path; cross-host
+  semantic parity.
+- **Scenario**: A2UI Button `userAction` dispatches.
+  **Verify**: Lumino click → `cell_input` tuple; binding fires.
+- **Scenario**: Bakke demotion cascade under narrow terminal.
+  **Verify**: panel → status-line → notification → suppressed as width
+  shrinks.
+- **Scenario**: Mission-context switch updates layout + permission
+  mode.
+  **Verify**: new `current_mission_context` tuple; surfaces re-render;
+  harness permission mode changes.
+- **Scenario**: `chash://` transclusion resolves on both backends.
+  **Verify**: same chunk text rendered.
+- **Scenario**: Modal stack works (RDR audit gate dialog).
+  **Verify**: focus trap on Lumino `Dialog`; equivalent on notcurses
+  top-z plane.
+
+## Validation
+
+### Testing Strategy
+
+1. **Scenario**: RDR audit cockpit MVP runs end-to-end on both
+   backends.
+   **Expected**: full mission profile completes; reviewer can navigate,
+   inspect, transclude, and act on RDRs without medium-specific
+   awareness.
+
+### Performance Expectations
+
+- Tauri shell cold start: < 1 s on M-series Mac.
+- Lumino render of 50-cell surface: < 100 ms.
+- notcurses render of 50-cell surface: < 50 ms.
+- A2UI catalog negotiation: < 10 ms (cached after first session).
+- `chash://` resolve cache hit: < 1 ms.
+
+## Finalization Gate
+
+(deferred — sketch only)
+
+### Contradiction Check
+
+(deferred)
+
+### Assumption Verification
+
+(deferred — A1–A8 unverified; spikes required)
+
+### Scope Verification
+
+(deferred — RDR audit cockpit is MVP; multi-column Bakke, mobile
+Tauri, per-cell Yjs are post-MVP)
+
+### Cross-Cutting Concerns
+
+- **Versioning**: A2UI external; Lumino external; per-host catalogs
+  versioned (`v1`). Tauri shell follows semver.
+- **Build tool compatibility**: TypeScript via npm/pnpm; Rust via
+  cargo; Python (notcurses adapter) via existing nexus build.
+- **Licensing**: Lumino (BSD-3), notcurses (Apache-2.0), Tauri (MIT/
+  Apache-2.0), A2UI (Apache-2.0). All compatible.
+- **Deployment model**: Tauri shell distributed as native binaries per
+  platform; notcurses adapter ships with `nx` CLI.
+- **IDE compatibility**: VS Code webview hosts the Lumino frontend
+  without modification; nested-webview prohibition means VS Code is a
+  single-cell host (explicit limitation).
+- **Incremental adoption**: legacy RDR-111 surfaces (rendered via
+  the shipped tmux output path) continue to work; migration to
+  `nexus.notcurses.v1` is opt-in per binding.
+- **Secret/credential lifecycle**: Tauri shell connects to daemon via
+  UDS (RDR-112); no credentials in the webview.
+- **Memory management**: Lumino widget dispose on cell `take`;
+  notcurses plane teardown likewise.
+
+### Proportionality
+
+Right-sized. The substrate is RDR-110/111/118; A2UI is the protocol;
+Lumino/notcurses/Tauri are external. This RDR ships ~3000 LoC of
+adapter + shell code total — large but bounded.
+
+## References
+
+- A2UI v0.8 spec — https://a2ui.org/specification/v0.8-a2ui/
+- A2UI v0.9 draft — https://a2ui.org/specification/v0.9-a2ui/
+- Lumino — https://github.com/jupyterlab/lumino
+- notcurses — https://github.com/dankamongmen/notcurses
+- Tauri 2 — https://tauri.app/
+- RDR-111: ORB Cockpit Substrate (especially §Auto-layout engine)
+- RDR-118: Surfaces as Tuples (cell substrate this RDR realizes)
+- `docs/agentic-cockpit.md` §What we build vs leverage (lines 739–797),
+  §Surfaces (lines 593–738)
+- `docs/a2ui-summary.md` (this worktree)
+- T3 knowledge entries: `a2ui-v08-surface-descriptor-schema`,
+  `a2ui-v09-draft-changes`, `a2ui-design-philosophy-stack-positioning`,
+  `a2ui-nexus-synthesis-cockpit-mapping`
+- RDR-111 post-mortem (deferred beads, reactivation triggers)
+
+## Revision History
+
+_2026-05-18 — initial sketch as the per-host realization companion to
+RDR-118. Reactivates deferred beads `nexus-kkh2` (tmux pane
+fulfillment) and `nexus-0rws` (ext-apps iframe fulfillment). MVP
+mission profile shared with RDR-118 (RDR audit cockpit, reactivates
+`nexus-kgo4`)._


### PR DESCRIPTION
## Summary

Three draft documents for the cockpit's portal/surface evolution. Sketches — not yet gated.

- **RDR-118 — Surfaces as Tuples (third iteration)**: adopts **A2UI v0.8** as the surface descriptor format (explicitly anticipated by \`agentic-cockpit.md\` lines 813–815). Inherits **RDR-053** \`chash://\` transclusion. Adds four small extensions on top of the existing substrate: \`surface_cell\` subspace, sibling-surface recursion convention, \`chash://\` as A2UI \`BoundValue.path\`, per-cell \`origin\` discipline. Reactivates dormant beads \`nexus-kkh2\`, \`nexus-0rws\`, \`nexus-kgo4\`.
- **RDR-119 — Cockpit UI Fabric**: per-host realization of A2UI catalogs. \`nexus.lumino.v1\` for Lumino-in-Tauri 2 (web + desktop + mobile); \`nexus.notcurses.v1\` for tty. Bakke auto-layout (RDR-111, shipped) is the policy layer; Lumino/notcurses are passive rendering primitives that consume placement plans. UI fabric concerns (focus, nav, modal, a11y) owned by the rendering primitives.
- **\`docs/a2ui-summary.md\`** — reader-friendly A2UI brief for local review (16 sections; protocol position, surface model, 5 message types, catalog negotiation, BoundValue, security, ecosystem, nexus mapping, the one honest gap, adoption path).

## Honest framing

This is the **third iteration**. The first two sketches re-derived layers that already exist (RDR-110 broker, RDR-111 cockpit, RDR-053 Xanadu fidelity, A2UI protocol). After a thorough audit (\`agentic-cockpit.md\` full read, RDR-111 + post-mortem, RDR-053, A2UI v0.8/v0.9 specs ingested into T3), the contract collapsed to a small delta. ~70% of what we were designing was already designed.

Both RDRs are explicit sketches: critical assumptions A1–A5 (RDR-118) and A1–A8 (RDR-119) are unverified. Spikes required before finalization.

## Reactivated beads

- \`nexus-kkh2\` (P4.1, deferred) — tmux pane fulfillment adapter → realized as \`nexus.notcurses.v1\` catalog
- \`nexus-0rws\` (P4.2, deferred) — ext-apps iframe fulfillment adapter → realized as \`nexus.lumino.v1\` catalog
- \`nexus-kgo4\` (P3.5, dormant) — first end-to-end mission profile → realized as RDR audit cockpit MVP

## Test plan

- [ ] Review \`docs/a2ui-summary.md\` for protocol clarity
- [ ] Validate RDR-118 vocabulary alignment against RDR-111 shipped code
- [ ] Validate RDR-119 fabric ownership table against agentic-cockpit.md §Surfaces
- [ ] Confirm RDR-053 \`chash://\` inheritance path is implementable as described
- [ ] Confirm A2UI v0.8 catalog negotiation via MCP \`initialize\` is reachable (RDR-118 A1, RDR-119 A5 — same spike)
- [ ] Confirm sibling-surface recursion convention is the right v1 choice (RDR-118 A2)

## T3 knowledge entries (ingested)

- \`a2ui-v08-surface-descriptor-schema\`
- \`a2ui-v09-draft-changes\`
- \`a2ui-design-philosophy-stack-positioning\`
- \`a2ui-nexus-synthesis-cockpit-mapping\`

Recoverable via \`nx_answer\` or \`nx search\`.