### PR TITLE
feat(rdr-112): nexus-uar6 - CLI port for catalog + index (T3 daemon seam) + substrate (m0hi/fe2i)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -341,13 +341,12 @@ def backfill_collections_cmd(dry_run: bool) -> None:
       nx catalog backfill-collections --dry-run
       nx catalog backfill-collections
     """
-    from nexus.db import make_t3  # noqa: PLC0415
     from nexus.db.t3 import _BYPASS_SCHEMA_PREFIXES  # noqa: PLC0415
 
     cat = _get_catalog()
 
     try:
-        t3_db = make_t3()
+        t3_db = _make_t3()
         # nexus-o6aa.14: skip bypass-schema collections (``taxonomy__*``)
         # to keep the projection in sync with the drift check at
         # ``_run_collections_drift`` which excludes the same prefixes.
@@ -714,10 +713,9 @@ def rename_collection_cmd(
         is_conformant_collection_name,
         parse_conformant_collection_name,
     )
-    from nexus.db import make_t3  # noqa: PLC0415
 
     cat = _get_catalog()
-    t3_db = make_t3()
+    t3_db = _make_t3()
 
     if not is_conformant_collection_name(new) and not allow_legacy:
         raise click.ClickException(
@@ -3160,8 +3158,45 @@ def link_generate_cmd(ctx: click.Context, dry_run: bool) -> None:
 
 
 def _make_t3():
-    from nexus.db import make_t3
-    return make_t3()
+    """RDR-112 P4.4 (nexus-uar6): daemon-aware T3 factory.
+
+    Routes through ``mcp_infra.get_t3`` so under
+    ``NX_STORAGE_MODE=daemon`` the returned ``T3Database`` wraps an
+    ``HttpClient`` to the live daemon (no race with the daemon writer
+    on the on-disk chroma path). Direct mode falls through to
+    ``make_t3`` unchanged. ``RuntimeError`` from the daemon resolver
+    (``T3DaemonError`` / ``DaemonNotRunningError``) carries a recovery
+    hint; translate to ``ClickException`` for the CLI.
+
+    Cloud-mode credential pre-check: skipped under daemon mode
+    (``make_t3_client`` rejects cloud with the same recovery hint),
+    enforced under direct + cloud. Mirrors ``commands.store._t3``.
+    """
+    from nexus.config import get_credential, is_local_mode
+    from nexus.db import is_daemon_mode
+    from nexus.mcp_infra import get_t3
+
+    if not is_daemon_mode() and not is_local_mode():
+        database = get_credential("chroma_database")
+        api_key = get_credential("chroma_api_key")
+        voyage_api_key = get_credential("voyage_api_key")
+
+        if not api_key:
+            raise click.ClickException(
+                "chroma_api_key not set — run: nx config set chroma_api_key <value>"
+            )
+        if not voyage_api_key:
+            raise click.ClickException(
+                "voyage_api_key not set — run: nx config set voyage_api_key <value>"
+            )
+        if not database:
+            raise click.ClickException(
+                "chroma_database not set — run: nx config init"
+            )
+    try:
+        return get_t3()
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def _make_registry():
@@ -4508,12 +4543,11 @@ def _run_collections_drift() -> dict:
     absent from T3 (post-rename state). Bypass-schema collections
     (``taxonomy__*``) are out of scope for this check.
     """
-    from nexus.db import make_t3  # noqa: PLC0415
     from nexus.db.t3 import _BYPASS_SCHEMA_PREFIXES  # noqa: PLC0415
 
     cat = _get_catalog()
     try:
-        t3_db = make_t3()
+        t3_db = _make_t3()
         t3_names = {
             c["name"] for c in t3_db.list_collections()
             if not c["name"].startswith(_BYPASS_SCHEMA_PREFIXES)
@@ -4646,12 +4680,11 @@ def _run_chunk_size_distribution() -> dict:
     carry centroid embeddings, not chunked text, so size stats
     aren't meaningful.
     """
-    from nexus.db import make_t3  # noqa: PLC0415
     from nexus.db.t3 import _BYPASS_SCHEMA_PREFIXES  # noqa: PLC0415
     from nexus.db.chroma_quotas import QUOTAS  # noqa: PLC0415
 
     try:
-        t3 = make_t3()
+        t3 = _make_t3()
         collections = [
             c["name"] for c in t3.list_collections()
             if not c["name"].startswith(_BYPASS_SCHEMA_PREFIXES)
@@ -4761,12 +4794,11 @@ def _run_chunk_text_dedup() -> dict:
     Returns
     ``{"pass": bool, "within": {coll: {...}}, "cross": [{...}]}``.
     """
-    from nexus.db import make_t3  # noqa: PLC0415
     from nexus.db.t3 import _BYPASS_SCHEMA_PREFIXES  # noqa: PLC0415
     from nexus.db.chroma_quotas import QUOTAS  # noqa: PLC0415
 
     try:
-        t3 = make_t3()
+        t3 = _make_t3()
         collections = [
             c["name"] for c in t3.list_collections()
             if not c["name"].startswith(_BYPASS_SCHEMA_PREFIXES)
@@ -4886,12 +4918,11 @@ def _run_t3_vs_catalog() -> dict:
     All read-only. PASS when all three lists are empty. Bypass-schema
     collections (``taxonomy__*``) are skipped from all three.
     """
-    from nexus.db import make_t3  # noqa: PLC0415
     from nexus.db.t3 import _BYPASS_SCHEMA_PREFIXES  # noqa: PLC0415
 
     cat = _get_catalog()
     try:
-        t3_db = make_t3()
+        t3_db = _make_t3()
         t3_listing = {
             c["name"]: c for c in t3_db.list_collections()
             if not c["name"].startswith(_BYPASS_SCHEMA_PREFIXES)
@@ -5036,7 +5067,6 @@ def _run_name_vs_embed_dim() -> dict:
         is_conformant_collection_name,
         parse_conformant_collection_name,
     )
-    from nexus.db import make_t3  # noqa: PLC0415
     from nexus.db.t3 import _BYPASS_SCHEMA_PREFIXES  # noqa: PLC0415
 
     mismatches: list[dict] = []
@@ -5046,7 +5076,7 @@ def _run_name_vs_embed_dim() -> dict:
     unknown_token: list[dict] = []
 
     try:
-        t3_db = make_t3()
+        t3_db = _make_t3()
         cols = [
             c["name"] for c in t3_db.list_collections()
             if not c["name"].startswith(_BYPASS_SCHEMA_PREFIXES)
@@ -5541,7 +5571,6 @@ def _run_t3_doc_id_coverage(
     from nexus.catalog.event_log import EventLog
     from nexus.catalog import events as ev
     from nexus.config import catalog_path
-    from nexus.db import make_t3
 
     cat_dir = catalog_path()
     if not Catalog.is_initialized(cat_dir):
@@ -5587,7 +5616,7 @@ def _run_t3_doc_id_coverage(
         expected.setdefault(coll, {})[cid] = event.payload.doc_id
 
     try:
-        t3 = make_t3()
+        t3 = _make_t3()
     except Exception as exc:
         raise click.ClickException(
             f"Failed to open T3 client: {exc}. Check ChromaDB credentials."
@@ -6071,7 +6100,6 @@ def chash_reconcile_cmd(apply: bool) -> None:
     Filed under nexus-w9vq (RDR-108 Phase 5 follow-up).
     """
     from nexus.commands._helpers import default_db_path
-    from nexus.db import make_t3
     from nexus.db.t2.chash_index import ChashIndex
 
     db_path = default_db_path()
@@ -6083,7 +6111,7 @@ def chash_reconcile_cmd(apply: bool) -> None:
         raise SystemExit(1)
 
     try:
-        t3 = make_t3()
+        t3 = _make_t3()
         # nexus-l1yt: chromadb's list_collections shape varies by
         # backend version (Collection objects vs string names).
         # Every other call site in nexus uses the same defensive
@@ -6213,12 +6241,11 @@ def collection_gc_cmd(apply: bool) -> None:
     \b
     Filed under nexus-ks40 (catalog/T3 hygiene).
     """
-    from nexus.db import make_t3
     from nexus.db.t3 import _BYPASS_SCHEMA_PREFIXES
 
     cat = _get_catalog()
     try:
-        t3_db = make_t3()
+        t3_db = _make_t3()
         t3_collections = t3_db.list_collections()
     except Exception as exc:
         click.echo(f"Failed to list T3 collections: {exc}", err=True)
@@ -6396,13 +6423,12 @@ def dt_link_cmd(
     """
     from nexus.catalog import orphan_backfill as ob  # noqa: PLC0415
     from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
-    from nexus.db import make_t3  # noqa: PLC0415
 
     if not owner:
         owner = _get_owner_for(collection)
     owner_tumbler = Tumbler.parse(owner)
     cat = _get_catalog()
-    t3 = make_t3()
+    t3 = _make_t3()
 
     click.echo(f"Gathering chunks from T3 {collection}...")
     groups = ob.gather_titled_chunks(t3, collection)
@@ -6461,13 +6487,12 @@ def synthetic_cmd(
     """
     from nexus.catalog import orphan_backfill as ob  # noqa: PLC0415
     from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
-    from nexus.db import make_t3  # noqa: PLC0415
 
     if not owner:
         owner = _get_owner_for(collection)
     owner_tumbler = Tumbler.parse(owner)
     cat = _get_catalog()
-    t3 = make_t3()
+    t3 = _make_t3()
 
     click.echo(f"Gathering chunks from T3 {collection}...")
     groups = ob.gather_titled_chunks(t3, collection)
@@ -6514,7 +6539,6 @@ def dump_csv_cmd(
     """
     from nexus.catalog import orphan_backfill as ob  # noqa: PLC0415
     from nexus.config import nexus_config_dir  # noqa: PLC0415
-    from nexus.db import make_t3  # noqa: PLC0415
 
     out_path = (
         Path(out_dir) if out_dir
@@ -6522,7 +6546,7 @@ def dump_csv_cmd(
     )
     out_path.mkdir(parents=True, exist_ok=True)
 
-    t3 = make_t3()
+    t3 = _make_t3()
     click.echo(f"Gathering chunks from T3 {collection}...")
     groups = ob.gather_titled_chunks(t3, collection)
     click.echo(f"  {len(groups)} distinct titles")
@@ -6560,13 +6584,12 @@ def apply_csv_cmd(
     """
     from nexus.catalog import orphan_backfill as ob  # noqa: PLC0415
     from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
-    from nexus.db import make_t3  # noqa: PLC0415
 
     if not owner:
         owner = _get_owner_for(collection)
     owner_tumbler = Tumbler.parse(owner)
     cat = _get_catalog()
-    t3 = make_t3()
+    t3 = _make_t3()
 
     click.echo(f"Re-gathering T3 chunks for {collection} (chunk_lookup)...")
     groups = ob.gather_titled_chunks(t3, collection)
@@ -6627,10 +6650,9 @@ def link_existing_cmd(
     """
     from nexus.catalog import orphan_backfill as ob  # noqa: PLC0415
     from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
-    from nexus.db import make_t3  # noqa: PLC0415
 
     cat = _get_catalog()
-    t3 = make_t3()
+    t3 = _make_t3()
 
     if dry_run:
         # Dry-run only: count without writing.

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -530,16 +530,21 @@ def run_collection_postprocessing(
         return
 
     from nexus.config import load_config as _load_cfg
-    from nexus.db import make_t3
-    from nexus.mcp_infra import t2_ctx
+    from nexus.mcp_infra import get_t3, t2_ctx
 
     def _say(msg: str) -> None:
         if not quiet:
             click.echo(msg)
 
     cfg = _load_cfg()
+    # RDR-112 P4.4 (nexus-uar6): route through ``mcp_infra.get_t3``
+    # so daemon mode hits the HttpClient instead of racing the daemon
+    # on the on-disk path. Direct mode is unchanged.
     try:
-        t3 = make_t3()
+        try:
+            t3 = get_t3()
+        except RuntimeError as exc:
+            raise click.ClickException(str(exc)) from exc
         total_topics = 0
         with t2_ctx() as db:
             for col_name in collections:

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -258,6 +258,9 @@ class T2Database:
             ``taxonomy_meta.collection``
           - ``search_telemetry.collection``
           - ``hook_failures.collection`` (if table exists)
+          - ``documents.physical_collection`` (catalog; nexus-fe2i)
+          - ``collections.name`` (catalog; nexus-fe2i, with collision-defense
+            DELETE; PRIMARY KEY rename)
 
         Returns a dict with counts per table. Raises on any failure --
         the SQLite transaction is rolled back automatically.
@@ -283,6 +286,9 @@ class T2Database:
             "tax_meta": 0,
             "search_telemetry": 0,
             "hook_failures": 0,
+            # nexus-fe2i (RDR-112 P2.review S4): catalog tables.
+            "catalog_documents": 0,
+            "catalog_collections": 0,
         }
 
         # Open a dedicated connection to the shared database file. All
@@ -384,6 +390,54 @@ class T2Database:
                     (new, old),
                 )
                 counts["hook_failures"] = cur.rowcount
+
+            # nexus-fe2i (RDR-112 P2.review S4): catalog tables.
+            # ``documents.physical_collection`` and ``collections.name``
+            # both move when a collection is renamed; Phase 4 (uar6)
+            # CLI flips read the catalog through ``T2Client.catalog``
+            # so a partial rename would leave the catalog projection
+            # stale relative to the rest of T2.
+            #
+            # Both UPDATEs run inside the existing BEGIN/COMMIT so the
+            # rename stays atomic across all eight stores.
+            #
+            # ``collections`` table is optional: tests that wire a
+            # T2Database against a bare memory.db skip the
+            # CatalogStore schema. Probe before issuing the UPDATEs
+            # so legacy / minimal fixtures still work.
+            collections_exists = conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='collections'"
+            ).fetchone()[0]
+            documents_exists = conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='documents'"
+            ).fetchone()[0]
+
+            if documents_exists:
+                # ``documents.physical_collection`` is not unique per
+                # document (many documents share one collection), so
+                # no collision defense is required.
+                cur = conn.execute(
+                    "UPDATE documents SET physical_collection = ? "
+                    "WHERE physical_collection = ?",
+                    (new, old),
+                )
+                counts["catalog_documents"] = cur.rowcount
+
+            if collections_exists:
+                # ``collections.name`` is PRIMARY KEY. Drop the target
+                # row first so the rename does not collide with an
+                # existing entry (mirrors the chash_index pattern).
+                conn.execute(
+                    "DELETE FROM collections WHERE name = ?",
+                    (new,),
+                )
+                cur = conn.execute(
+                    "UPDATE collections SET name = ? WHERE name = ?",
+                    (new, old),
+                )
+                counts["catalog_collections"] = cur.rowcount
 
             conn.commit()
 

--- a/src/nexus/db/t2/catalog_store.py
+++ b/src/nexus/db/t2/catalog_store.py
@@ -303,11 +303,41 @@ class CatalogStore:
             _migrated_paths.add(path_key)
 
     def _backfill_collections(self) -> None:
-        """Insert legacy physical_collection values into collections (idempotent)."""
+        """Insert legacy physical_collection values into collections (idempotent).
+
+        nexus-m0hi (RDR-112 P2.review S2): mirrors the CatalogDB contract
+        — compute the candidate set BEFORE the INSERT (the post-INSERT
+        view would include pre-existing rows that we did not insert)
+        and stash it on ``self._backfilled_collections``. Catalog's
+        ``_emit_backfilled_collection_events`` reads this set
+        immediately after construction so the synthetic
+        ``CollectionCreated`` events with ``legacy_grandfathered=True``
+        survive ``Catalog.rebuild()`` (which truncates ``collections``
+        and replays from JSONL). Without the exposed set the Phase 4
+        catalog-port flip would silently drop the synthetic events and
+        lose the projection-replay invariant.
+        """
+        self._backfilled_collections: set[str] = set()
         with self._lock:
             try:
                 self._conn.execute("SELECT physical_collection FROM documents LIMIT 0")
             except sqlite3.OperationalError:
+                return
+            # Compute candidates BEFORE the INSERT: ``INSERT OR IGNORE``
+            # silently skips rows whose ``collections.name`` PK already
+            # exists, so a post-INSERT enumeration would include them
+            # too and emit duplicate events on the Catalog side.
+            candidates = {
+                row[0]
+                for row in self._conn.execute(
+                    "SELECT DISTINCT physical_collection FROM documents "
+                    "WHERE physical_collection IS NOT NULL "
+                    "  AND physical_collection != '' "
+                    "  AND physical_collection NOT IN "
+                    "      (SELECT name FROM collections)"
+                ).fetchall()
+            }
+            if not candidates:
                 return
             self._conn.execute(
                 "INSERT OR IGNORE INTO collections "
@@ -321,10 +351,28 @@ class CatalogStore:
                 "  AND physical_collection != ''",
             )
             self._conn.commit()
+            self._backfilled_collections = candidates
 
     # -------------------------------------------------------------------------
     # Public API (identical signatures to CatalogDB)
     # -------------------------------------------------------------------------
+
+    def backfilled_collections(self) -> list[str]:
+        """Return the names backfilled by the most recent ``_backfill_collections`` call.
+
+        nexus-m0hi (RDR-112 P2.review S2): the underscore-prefixed
+        attribute ``_backfilled_collections`` mirrors the CatalogDB
+        contract used by ``Catalog._emit_backfilled_collection_events``,
+        which reads it directly when CatalogStore is constructed
+        in-process. Under Phase 4 the same emission path must work
+        when Catalog reads from ``T2Client.catalog`` (a daemon proxy
+        that skips underscore-prefixed methods by design — see
+        ``_StoreProxy`` in ``nexus.daemon.t2_client``); this public
+        accessor is the RPC-dispatchable equivalent. Returns a list
+        (not a set) so the JSON-RPC encoder has a native type;
+        callers convert back to a set as needed.
+        """
+        return list(self._backfilled_collections)
 
     def rebuild(
         self,

--- a/src/nexus/db/t2/catalog_store.py
+++ b/src/nexus/db/t2/catalog_store.py
@@ -247,6 +247,16 @@ class CatalogStore:
         # RLock: callers inside transaction() context re-acquire from the same
         # thread (same pattern as CatalogDB with its reentrant lock).
         self._lock = threading.RLock()
+        # nexus-m0hi (RDR-112 P2.review S2): initialize the backfill
+        # tracker BEFORE ``_init_schema`` so a second CatalogStore
+        # construction against the same path (which hits the
+        # ``_migrated_paths`` fast-path and skips ``_init_schema``,
+        # therefore skips ``_backfill_collections``) still has the
+        # attribute. Mirrors the CatalogDB pattern at catalog_db.py:522
+        # which sets this unconditionally in ``__init__``. The accessor
+        # ``backfilled_collections()`` reads this attribute; without
+        # init-time setup the second construction would AttributeError.
+        self._backfilled_collections: set[str] = set()
         self._conn = sqlite3.connect(str(path), check_same_thread=False)
         self._conn.execute("PRAGMA busy_timeout=5000")
         self._conn.execute("PRAGMA journal_mode=WAL")
@@ -316,8 +326,11 @@ class CatalogStore:
         and replays from JSONL). Without the exposed set the Phase 4
         catalog-port flip would silently drop the synthetic events and
         lose the projection-replay invariant.
+
+        ``self._backfilled_collections`` is initialized in ``__init__``
+        so a CatalogStore on a path that already migrated (and thus
+        skips this method) still has the attribute.
         """
-        self._backfilled_collections: set[str] = set()
         with self._lock:
             try:
                 self._conn.execute("SELECT physical_collection FROM documents LIMIT 0")
@@ -371,8 +384,14 @@ class CatalogStore:
         accessor is the RPC-dispatchable equivalent. Returns a list
         (not a set) so the JSON-RPC encoder has a native type;
         callers convert back to a set as needed.
+
+        ``self._lock`` guards the read so a concurrent
+        ``_backfill_collections`` call (only fires during
+        construction, but defensive nonetheless) cannot publish a
+        torn intermediate value.
         """
-        return list(self._backfilled_collections)
+        with self._lock:
+            return list(self._backfilled_collections)
 
     def rebuild(
         self,

--- a/tests/commands/test_catalog_daemon_mode.py
+++ b/tests/commands/test_catalog_daemon_mode.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 P4.4 (nexus-uar6) — ``nx catalog`` CLI under
+``NX_STORAGE_MODE=daemon``.
+
+Scope: this file covers the T3-side catalog port. Several ``nx
+catalog`` subcommands call ``_make_t3()`` (now daemon-aware via
+``mcp_infra.get_t3``) to enumerate or write T3 collections. Without
+the daemon-aware seam, the legacy ``make_t3()`` factory opens a
+``PersistentClient`` on the same on-disk path the T3 daemon owns —
+the chroma writer cannot tolerate two live processes on the same
+DuckDB+Parquet store.
+
+Out of scope (filed as a follow-up): the higher-level ``Catalog``
+class still wraps a local ``CatalogDB`` opened against
+``.catalog.db``. The Phase 4 spec calls for those reads/writes to
+route through ``T2Client.catalog`` (a ``_StoreProxy`` over the eighth
+T2 domain store, ``CatalogStore``). That refactor would move
+``Catalog`` methods (``find``, ``resolve``, ``get_manifest``, …) onto
+``CatalogStore`` so the daemon dispatches them; it is substrate work
+beyond the strict yfqv-shaped scope and tracked separately.
+
+We exercise the T3 routing via ``nx catalog backfill-collections
+--dry-run`` (read-only path that lists T3 collections through
+``_make_t3``) and verify the daemon-mode invocation does not race the
+chroma writer.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def reset_t3_singleton():
+    import nexus.mcp_infra as infra
+    original_t3 = infra._t3_instance
+    original_collections = infra._collections_cache
+    infra._t3_instance = None
+    infra._collections_cache = ([], 0.0)
+    yield
+    infra._t3_instance = original_t3
+    infra._collections_cache = original_collections
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    cd = tmp_path / "nexus_config"
+    cd.mkdir()
+    return cd
+
+
+@pytest.fixture
+def local_path(tmp_path: Path) -> Path:
+    p = tmp_path / "chroma_t3"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def catalog_dir(tmp_path: Path, monkeypatch) -> Path:
+    """Initialize a real catalog under tmp_path and route
+    ``nexus.config.catalog_path`` at it for the test."""
+    from nexus.catalog import Catalog
+    cd = tmp_path / "catalog"
+    cd.mkdir()
+    Catalog.init(cd)
+    monkeypatch.setattr(
+        "nexus.config.catalog_path",
+        lambda: cd,
+    )
+    monkeypatch.setattr(
+        "nexus.commands.catalog.catalog_path",
+        lambda: cd,
+        raising=False,
+    )
+    return cd
+
+
+@pytest.fixture
+def daemon_env(monkeypatch, config_dir: Path):
+    monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+    monkeypatch.setenv("NX_LOCAL", "1")
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
+
+
+@pytest.fixture
+def live_t3_daemon(daemon_env, config_dir: Path, local_path: Path):
+    from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+
+    payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+    try:
+        yield payload
+    finally:
+        stop_t3_daemon(config_dir=config_dir)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+
+class TestCatalogBackfillCollections:
+    def test_backfill_dry_run_under_daemon(
+        self,
+        runner: CliRunner,
+        live_t3_daemon,
+        reset_t3_singleton,
+        catalog_dir: Path,
+    ) -> None:
+        """``nx catalog backfill-collections --dry-run`` calls
+        ``_make_t3().list_collections()`` to enumerate T3 collections,
+        then reads the catalog ``documents.physical_collection`` column
+        to compute the union. Under daemon mode, the T3 call routes
+        through ``mcp_infra.get_t3`` to the live daemon.
+
+        The test does not need any pre-seeded T3 collections; an empty
+        list is the correct dry-run output (\"Nothing to backfill\")
+        and proves the T3 round-trip works."""
+        result = runner.invoke(
+            main, ["catalog", "backfill-collections", "--dry-run"],
+        )
+        assert result.exit_code == 0, result.output
+        # Either "Nothing to backfill" (empty T3 + empty catalog) or
+        # a candidate list — both indicate the T3 round-trip succeeded
+        # without racing the daemon.
+        assert (
+            "Nothing to backfill" in result.output
+            or "Would register" in result.output
+            or "candidates" in result.output.lower()
+        ), result.output

--- a/tests/commands/test_index_daemon_mode.py
+++ b/tests/commands/test_index_daemon_mode.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 P4.4 (nexus-uar6) — ``nx index`` CLI under
+``NX_STORAGE_MODE=daemon``.
+
+Scope: the single direct ``make_t3()`` call in ``nx index`` lives
+inside ``run_collection_postprocessing`` (post-index taxonomy +
+projection + topic-link chain). The yfqv/uar6 port flipped that
+import to ``mcp_infra.get_t3`` so daemon mode hits the HttpClient
+instead of racing the daemon on the on-disk chroma path.
+
+We do not exercise the full ``nx index repo`` end-to-end pipeline in
+this file because:
+
+1. Indexing requires real file content + tree-sitter + embeddings,
+   which is slow and brittle for a routing-correctness test.
+2. The flip's blast radius is the ``get_t3()`` resolution call inside
+   ``run_collection_postprocessing``; we can exercise that path
+   directly with a fake collections list and a live T2 + T3 daemon
+   pair without indexing anything.
+
+Per-collection exceptions inside the chain are swallowed by design
+(non-fatal failures must not take down the post-index sweep), so the
+test asserts the routing call resolves without crashing the host
+process. A subsequent integration test against a real indexed
+collection (out of scope for uar6) would validate the discovery
+results.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+import pytest
+
+from nexus.daemon.t2_daemon import T2Daemon
+from nexus.db.t2 import T2Database
+
+
+# ── In-thread T2 daemon harness (matches the yfqv/idqd pattern) ────────────
+
+
+def _run_daemon(daemon: T2Daemon) -> asyncio.AbstractEventLoop:
+    started = threading.Event()
+    loop = asyncio.new_event_loop()
+
+    def _thread() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(daemon.start())
+        started.set()
+        loop.run_forever()
+
+    t = threading.Thread(target=_thread, daemon=True)
+    t.start()
+    started.wait(timeout=5.0)
+    return loop
+
+
+def _stop_daemon(daemon: T2Daemon, loop: asyncio.AbstractEventLoop) -> None:
+    asyncio.run_coroutine_threadsafe(daemon.stop(), loop).result(timeout=5.0)
+    loop.call_soon_threadsafe(loop.stop)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def reset_t3_singleton():
+    import nexus.mcp_infra as infra
+    original_t3 = infra._t3_instance
+    original_collections = infra._collections_cache
+    infra._t3_instance = None
+    infra._collections_cache = ([], 0.0)
+    yield
+    infra._t3_instance = original_t3
+    infra._collections_cache = original_collections
+
+
+@pytest.fixture
+def t2db(tmp_path: Path) -> T2Database:
+    db = T2Database(tmp_path / "memory.db")
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    cd = tmp_path / "nexus_config"
+    cd.mkdir()
+    return cd
+
+
+@pytest.fixture
+def local_path(tmp_path: Path) -> Path:
+    p = tmp_path / "chroma_t3"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def daemon_env(monkeypatch, config_dir: Path):
+    monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+    monkeypatch.setenv("NX_LOCAL", "1")
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
+
+
+@pytest.fixture
+def live_t2_daemon(t2db: T2Database, config_dir: Path, daemon_env):
+    daemon = T2Daemon(config_dir, t2db=t2db)
+    loop = _run_daemon(daemon)
+    try:
+        yield daemon
+    finally:
+        _stop_daemon(daemon, loop)
+
+
+@pytest.fixture
+def live_t3_daemon(daemon_env, config_dir: Path, local_path: Path):
+    from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+
+    payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+    try:
+        yield payload
+    finally:
+        stop_t3_daemon(config_dir=config_dir)
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+
+class TestPostIndexTaxonomyRouting:
+    def test_postprocessing_resolves_t3_via_daemon(
+        self,
+        live_t2_daemon,
+        live_t3_daemon,
+        reset_t3_singleton,
+    ) -> None:
+        """``run_collection_postprocessing`` is the only ``index`` site
+        that calls ``_make_t3()`` (now ``get_t3()``). Under daemon mode
+        the resolver returns a T3Database wrapping the daemon's
+        HttpClient. We pass a single non-existent collection name so
+        the per-collection chain steps fail gracefully (the function
+        wraps each step in ``try/except`` per its docstring), proving:
+
+        1. ``get_t3()`` resolves to the daemon without raising.
+        2. The function does not race the chroma writer on the on-disk
+           path (we never opened a parallel ``PersistentClient``).
+
+        A future end-to-end test against a real indexed collection
+        will assert the chain's outputs; the contract under test here
+        is the daemon-routing seam."""
+        from nexus.commands.index import run_collection_postprocessing
+        # quiet=True suppresses the human-facing ``click.echo`` lines
+        # that would otherwise hit a non-Click context and explode.
+        run_collection_postprocessing(
+            collections=["knowledge__uar6-postindex-smoke"],
+            quiet=True,
+        )
+
+    def test_postprocessing_empty_collections_is_noop(
+        self,
+        live_t2_daemon,
+        live_t3_daemon,
+        reset_t3_singleton,
+    ) -> None:
+        """Empty list early-exits before any T3 resolution. Confirms
+        the noop branch is undisturbed by the daemon-routing change."""
+        from nexus.commands.index import run_collection_postprocessing
+        run_collection_postprocessing(collections=[], quiet=True)

--- a/tests/daemon/test_catalog_client.py
+++ b/tests/daemon/test_catalog_client.py
@@ -241,6 +241,38 @@ class TestCatalogClientRpc:
         results = client.catalog.search("zzznomatch")
         assert results == []
 
+    def test_backfilled_collections_via_rpc(
+        self, t2db: T2Database, daemon_and_client,
+    ) -> None:
+        """nexus-m0hi (RDR-112 P2.review S2): the public
+        ``backfilled_collections()`` accessor is RPC-dispatchable so
+        the Phase 4 catalog port (nexus-uar6) can read the synthetic-
+        event seed set from ``T2Client.catalog`` without reaching for
+        an underscore attribute that ``_StoreProxy`` would not
+        expose."""
+        _daemon, client = daemon_and_client
+        # Seed a legacy document via the daemon's T2Database directly
+        # so the backfill path runs at next CatalogStore construction.
+        # We re-trigger init by clearing the process-level migrated-
+        # paths cache and accessing the catalog store one more time.
+        t2db.catalog._conn.execute(
+            "INSERT INTO documents (tumbler, title, physical_collection) "
+            "VALUES (?, ?, ?)",
+            ("9.9.9", "m0hi-legacy", "code__m0hi-rpc-smoke"),
+        )
+        t2db.catalog._conn.commit()
+        # Force a re-init so the backfill captures the newly-seeded row.
+        from nexus.db.t2 import catalog_store as cs_module
+        cs_module._migrated_paths.clear()
+        t2db.catalog._backfill_collections()
+
+        names = client.catalog.backfilled_collections()
+        assert isinstance(names, list)
+        assert "code__m0hi-rpc-smoke" in names, (
+            f"expected the legacy collection to surface via RPC, "
+            f"got {names!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Legacy catalog.db import

--- a/tests/db/test_catalog_store.py
+++ b/tests/db/test_catalog_store.py
@@ -662,3 +662,109 @@ class TestRebuildFieldParity:
         assert store_meta == legacy_meta, (
             f"_meta row diverges:\nstore={store_meta}\nlegacy={legacy_meta}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Backfilled collections (nexus-m0hi, RDR-112 P2.review S2)
+# ---------------------------------------------------------------------------
+
+
+class TestBackfilledCollections:
+    """``CatalogStore._backfilled_collections`` mirror of the CatalogDB
+    contract (catalog_db.py:516-589). When ``_backfill_collections``
+    inserts rows for legacy ``physical_collection`` values that lacked
+    a ``collections`` row, the inserted names are stashed on
+    ``self._backfilled_collections`` so ``Catalog._emit_backfilled_
+    collection_events`` can emit synthetic ``CollectionCreated`` events
+    with ``legacy_grandfathered=True`` (otherwise the rows vanish on
+    ``Catalog.rebuild()``).
+
+    Phase 4 (nexus-uar6) reads the same set through
+    ``T2Client.catalog`` so the public ``backfilled_collections()``
+    method is also covered."""
+
+    def test_backfilled_set_populated_when_legacy_doc_seeded(
+        self, tmp_path: Path,
+    ) -> None:
+        db = tmp_path / "memory.db"
+        # Seed via a first CatalogStore so the documents schema is
+        # in place; then write a legacy row whose physical_collection
+        # has no matching collections row.
+        seed = CatalogStore(db)
+        try:
+            seed._conn.execute(
+                "INSERT INTO documents (tumbler, title, physical_collection) "
+                "VALUES (?, ?, ?)",
+                ("1.1.1", "legacy-doc", "code__legacy-m0hi"),
+            )
+            seed._conn.commit()
+        finally:
+            seed.close()
+
+        # Force a second migration on the same path by purging the
+        # process-level cache (init normally runs once per path).
+        from nexus.db.t2 import catalog_store as cs_module
+        cs_module._migrated_paths.clear()
+
+        store = CatalogStore(db)
+        try:
+            assert "code__legacy-m0hi" in store._backfilled_collections, (
+                f"expected the legacy collection in _backfilled_collections, "
+                f"got {store._backfilled_collections!r}"
+            )
+            # Public accessor returns the same set as a list (RPC-safe
+            # native type).
+            via_method = store.backfilled_collections()
+            assert isinstance(via_method, list)
+            assert set(via_method) == store._backfilled_collections
+        finally:
+            store.close()
+
+    def test_backfilled_set_empty_when_no_unregistered_collection(
+        self, tmp_path: Path,
+    ) -> None:
+        store = CatalogStore(tmp_path / "memory.db")
+        try:
+            assert store._backfilled_collections == set()
+            assert store.backfilled_collections() == []
+        finally:
+            store.close()
+
+    def test_backfilled_set_excludes_already_registered(
+        self, tmp_path: Path,
+    ) -> None:
+        """A legacy doc whose physical_collection already has a
+        ``collections`` row must NOT appear in
+        ``_backfilled_collections``. The ``INSERT OR IGNORE`` would
+        skip the row, so the set must skip it too — otherwise the
+        Catalog event emitter would double-emit
+        ``CollectionCreated`` for an already-known collection."""
+        db = tmp_path / "memory.db"
+        seed = CatalogStore(db)
+        try:
+            # Pre-register the collection so it exists.
+            seed._conn.execute(
+                "INSERT INTO collections (name, content_type, owner_id, "
+                "embedding_model, model_version, display_name, "
+                "legacy_grandfathered, superseded_by, superseded_at, "
+                "created_at) VALUES (?, '', '', '', '', '', 0, '', '', '')",
+                ("code__pre-registered",),
+            )
+            seed._conn.execute(
+                "INSERT INTO documents (tumbler, title, physical_collection) "
+                "VALUES (?, ?, ?)",
+                ("1.1.1", "doc-a", "code__pre-registered"),
+            )
+            seed._conn.commit()
+        finally:
+            seed.close()
+
+        from nexus.db.t2 import catalog_store as cs_module
+        cs_module._migrated_paths.clear()
+
+        store = CatalogStore(db)
+        try:
+            assert "code__pre-registered" not in store._backfilled_collections
+            assert store.backfilled_collections() == []
+        finally:
+            store.close()

--- a/tests/db/test_catalog_store.py
+++ b/tests/db/test_catalog_store.py
@@ -730,6 +730,40 @@ class TestBackfilledCollections:
         finally:
             store.close()
 
+    def test_second_construction_without_clearing_migrated_paths(
+        self, tmp_path: Path,
+    ) -> None:
+        """Second ``CatalogStore`` against the same path hits the
+        ``_migrated_paths`` fast-path and skips ``_init_schema``, which
+        also skips ``_backfill_collections``. The accessor must still
+        work — i.e. ``self._backfilled_collections`` must be
+        initialized in ``__init__`` not inside the migration step.
+
+        Pre-fix (review C1): the second construction left the attribute
+        unset, so ``backfilled_collections()`` raised ``AttributeError``.
+        This regression test pins the fix."""
+        db = tmp_path / "memory.db"
+        # First construction: migrates, populates _migrated_paths.
+        store1 = CatalogStore(db)
+        try:
+            assert hasattr(store1, "_backfilled_collections")
+        finally:
+            store1.close()
+
+        # Second construction WITHOUT clearing _migrated_paths.
+        # This is the path that any reopen in a long-running process
+        # (e.g. the daemon's own MCP server pool, a CLI inside an MCP
+        # subagent, a test that just reopens by handle) takes.
+        store2 = CatalogStore(db)
+        try:
+            # Must not AttributeError.
+            assert store2.backfilled_collections() == []
+            # And the underscore-attribute is still present for legacy
+            # internal callers like Catalog._emit_backfilled_collection_events.
+            assert store2._backfilled_collections == set()
+        finally:
+            store2.close()
+
     def test_backfilled_set_excludes_already_registered(
         self, tmp_path: Path,
     ) -> None:

--- a/tests/test_catalog_backfill_collections.py
+++ b/tests/test_catalog_backfill_collections.py
@@ -82,7 +82,7 @@ def test_backfill_registers_t3_and_catalog_collections(catalog, runner):
     )
     _seed_document(catalog, tumbler="1.1.1", collection="docs__nexus-571b8edd")
 
-    with patch("nexus.db.make_t3", return_value=fake_t3), \
+    with patch("nexus.mcp_infra.get_t3", return_value=fake_t3), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(main, ["catalog", "backfill-collections", "--no-dry-run"])
 
@@ -108,7 +108,7 @@ def test_backfill_marks_legacy_via_projector(catalog, runner):
         ]
     )
 
-    with patch("nexus.db.make_t3", return_value=fake_t3), \
+    with patch("nexus.mcp_infra.get_t3", return_value=fake_t3), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(main, ["catalog", "backfill-collections", "--no-dry-run"])
 
@@ -123,7 +123,7 @@ def test_backfill_idempotent(catalog, runner):
     """
     fake_t3 = _FakeT3(names=["knowledge__delos"])
 
-    with patch("nexus.db.make_t3", return_value=fake_t3), \
+    with patch("nexus.mcp_infra.get_t3", return_value=fake_t3), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         runner.invoke(main, ["catalog", "backfill-collections", "--no-dry-run"])
         result = runner.invoke(main, ["catalog", "backfill-collections", "--no-dry-run"])
@@ -140,7 +140,7 @@ def test_backfill_dry_run_no_writes(catalog, runner):
     """``--dry-run`` reports the candidates and writes nothing."""
     fake_t3 = _FakeT3(names=["knowledge__delos", "docs__nexus-571b8edd"])
 
-    with patch("nexus.db.make_t3", return_value=fake_t3), \
+    with patch("nexus.mcp_infra.get_t3", return_value=fake_t3), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(
             main, ["catalog", "backfill-collections", "--dry-run"],
@@ -158,7 +158,7 @@ def test_backfill_empty_t3_and_catalog(catalog, runner):
     """Nothing to backfill produces a clean zero summary."""
     fake_t3 = _FakeT3(names=[])
 
-    with patch("nexus.db.make_t3", return_value=fake_t3), \
+    with patch("nexus.mcp_infra.get_t3", return_value=fake_t3), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(main, ["catalog", "backfill-collections", "--no-dry-run"])
 
@@ -172,7 +172,7 @@ def test_backfill_skips_already_registered(catalog, runner):
     catalog.register_collection("knowledge__delos")
     fake_t3 = _FakeT3(names=["knowledge__delos", "docs__nexus-571b8edd"])
 
-    with patch("nexus.db.make_t3", return_value=fake_t3), \
+    with patch("nexus.mcp_infra.get_t3", return_value=fake_t3), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(main, ["catalog", "backfill-collections", "--no-dry-run"])
 
@@ -198,7 +198,7 @@ def test_backfill_aborts_on_t3_failure(catalog, runner):
 
     _seed_document(catalog, tumbler="1.1.1", collection="docs__nexus-571b8edd")
 
-    with patch("nexus.db.make_t3", return_value=_BrokenT3()), \
+    with patch("nexus.mcp_infra.get_t3", return_value=_BrokenT3()), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(
             main, ["catalog", "backfill-collections", "--no-dry-run"],

--- a/tests/test_catalog_doctor_collections_drift.py
+++ b/tests/test_catalog_doctor_collections_drift.py
@@ -86,7 +86,7 @@ def test_doctor_collections_drift_passes_when_aligned(t3_db, catalog, runner):
     _seed_t3(t3_db, "knowledge__delos")
     _seed_doc(catalog, tumbler="1.1.1", collection="knowledge__delos")
 
-    with patch("nexus.db.make_t3", return_value=t3_db), \
+    with patch("nexus.mcp_infra.get_t3", return_value=t3_db), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(
             main, ["catalog", "doctor", "--collections-drift"],
@@ -101,7 +101,7 @@ def test_doctor_collections_drift_fails_on_t3_not_in_projection(
     """A T3 collection without a projection row is drift → FAIL."""
     _seed_t3(t3_db, "knowledge__delos")  # no register_collection call
 
-    with patch("nexus.db.make_t3", return_value=t3_db), \
+    with patch("nexus.mcp_infra.get_t3", return_value=t3_db), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(
             main, ["catalog", "doctor", "--collections-drift"],
@@ -117,7 +117,7 @@ def test_doctor_collections_drift_fails_on_doc_collection_not_in_projection(
     """A documents.physical_collection without a projection row is drift."""
     _seed_doc(catalog, tumbler="1.1.1", collection="docs__nexus-571b8edd")
 
-    with patch("nexus.db.make_t3", return_value=t3_db), \
+    with patch("nexus.mcp_infra.get_t3", return_value=t3_db), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(
             main, ["catalog", "doctor", "--collections-drift"],
@@ -146,7 +146,7 @@ def test_doctor_collections_drift_orphan_warning_with_superseded_skip(
     # Note: knowledge__delos NOT in T3 (gone post-rename) but is
     # superseded_by, so should NOT count as drift.
 
-    with patch("nexus.db.make_t3", return_value=t3_db), \
+    with patch("nexus.mcp_infra.get_t3", return_value=t3_db), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(
             main, ["catalog", "doctor", "--collections-drift"],
@@ -164,7 +164,7 @@ def test_doctor_collections_drift_orphan_without_supersede_fails(
     catalog.register_collection("knowledge__delos")
     # knowledge__delos in projection but NOT in T3 and NOT superseded.
 
-    with patch("nexus.db.make_t3", return_value=t3_db), \
+    with patch("nexus.mcp_infra.get_t3", return_value=t3_db), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(
             main, ["catalog", "doctor", "--collections-drift"],
@@ -183,7 +183,7 @@ def test_doctor_collections_drift_handles_t3_failure(catalog, runner):
         def list_collections(self):
             raise RuntimeError("t3 unreachable")
 
-    with patch("nexus.db.make_t3", return_value=_BrokenT3()), \
+    with patch("nexus.mcp_infra.get_t3", return_value=_BrokenT3()), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(
             main, ["catalog", "doctor", "--collections-drift"],
@@ -196,7 +196,7 @@ def test_doctor_collections_drift_json_payload(t3_db, catalog, runner):
     """``--json`` emits machine-readable shape."""
     _seed_t3(t3_db, "knowledge__delos")
 
-    with patch("nexus.db.make_t3", return_value=t3_db), \
+    with patch("nexus.mcp_infra.get_t3", return_value=t3_db), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
         result = runner.invoke(
             main, ["catalog", "doctor", "--collections-drift", "--json"],

--- a/tests/test_catalog_doctor_name_vs_embed_dim.py
+++ b/tests/test_catalog_doctor_name_vs_embed_dim.py
@@ -73,7 +73,7 @@ class TestNameVsEmbedDim:
         name = "code__myproj__minilm-l6-v2-384__v1"
         _seed(chroma_client, name)
         monkeypatch.setattr(
-            "nexus.db.make_t3", lambda: _fake_t3(chroma_client, [name]),
+            "nexus.mcp_infra.get_t3", lambda: _fake_t3(chroma_client, [name]),
         )
         result = runner.invoke(
             doctor_cmd, ["--name-vs-embed-dim", "--json"],
@@ -93,7 +93,7 @@ class TestNameVsEmbedDim:
         name = "code__myproj__voyage-code-3__v1"
         _seed(chroma_client, name)
         monkeypatch.setattr(
-            "nexus.db.make_t3", lambda: _fake_t3(chroma_client, [name]),
+            "nexus.mcp_infra.get_t3", lambda: _fake_t3(chroma_client, [name]),
         )
         result = runner.invoke(
             doctor_cmd, ["--name-vs-embed-dim", "--json"],
@@ -115,7 +115,7 @@ class TestNameVsEmbedDim:
         name = "docs__myproj__voyage-context-3__v1"
         _seed(chroma_client, name)
         monkeypatch.setattr(
-            "nexus.db.make_t3", lambda: _fake_t3(chroma_client, [name]),
+            "nexus.mcp_infra.get_t3", lambda: _fake_t3(chroma_client, [name]),
         )
         result = runner.invoke(
             doctor_cmd, ["--name-vs-embed-dim", "--json"],
@@ -135,7 +135,7 @@ class TestNameVsEmbedDim:
         name = "code__myproj-cafef00d"
         _seed(chroma_client, name)
         monkeypatch.setattr(
-            "nexus.db.make_t3", lambda: _fake_t3(chroma_client, [name]),
+            "nexus.mcp_infra.get_t3", lambda: _fake_t3(chroma_client, [name]),
         )
         result = runner.invoke(
             doctor_cmd, ["--name-vs-embed-dim", "--json"],
@@ -152,7 +152,7 @@ class TestNameVsEmbedDim:
         """``taxonomy__*`` carries centroid embeddings, out of scope."""
         _seed(chroma_client, "taxonomy__centroids")
         monkeypatch.setattr(
-            "nexus.db.make_t3",
+            "nexus.mcp_infra.get_t3",
             lambda: _fake_t3(chroma_client, ["taxonomy__centroids"]),
         )
         result = runner.invoke(
@@ -173,7 +173,7 @@ class TestNameVsEmbedDim:
             name=name, embedding_function=DefaultEmbeddingFunction(),
         )
         monkeypatch.setattr(
-            "nexus.db.make_t3", lambda: _fake_t3(chroma_client, [name]),
+            "nexus.mcp_infra.get_t3", lambda: _fake_t3(chroma_client, [name]),
         )
         result = runner.invoke(
             doctor_cmd, ["--name-vs-embed-dim", "--json"],
@@ -192,7 +192,7 @@ class TestNameVsEmbedDim:
         name = "code__myproj__voyage-code-3__v1"
         _seed(chroma_client, name)
         monkeypatch.setattr(
-            "nexus.db.make_t3", lambda: _fake_t3(chroma_client, [name]),
+            "nexus.mcp_infra.get_t3", lambda: _fake_t3(chroma_client, [name]),
         )
         result = runner.invoke(
             doctor_cmd, ["--name-vs-embed-dim"],

--- a/tests/test_catalog_doctor_new_checks.py
+++ b/tests/test_catalog_doctor_new_checks.py
@@ -111,7 +111,7 @@ class TestChunkSizeDistribution:
             def list_collections(self):
                 return [{"name": "code__ok"}]
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--chunk-size-distribution", "--json"],
         )
@@ -148,7 +148,7 @@ class TestChunkSizeDistribution:
             def list_collections(self):
                 return [{"name": "code__micros"}]
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--chunk-size-distribution", "--json"],
         )
@@ -183,7 +183,7 @@ class TestChunkSizeDistribution:
             def list_collections(self):
                 return [{"name": "code__big"}]
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--chunk-size-distribution", "--json"],
         )
@@ -214,7 +214,7 @@ class TestChunkSizeDistribution:
             def list_collections(self):
                 return [{"name": "taxonomy__centroids"}]
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--chunk-size-distribution", "--json"],
         )
@@ -245,7 +245,7 @@ class TestChunkTextDedup:
             def list_collections(self):
                 return [{"name": "code__cleanup"}]
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--chunk-text-dedup", "--json"],
         )
@@ -281,7 +281,7 @@ class TestChunkTextDedup:
             def list_collections(self):
                 return [{"name": "code__bug"}]
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--chunk-text-dedup", "--json"],
         )
@@ -316,7 +316,7 @@ class TestChunkTextDedup:
             def list_collections(self):
                 return [{"name": "code__a"}, {"name": "code__b"}]
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--chunk-text-dedup", "--json"],
         )
@@ -362,7 +362,7 @@ class TestT3VsCatalog:
             def list_collections(self):
                 return [{"name": "docs__clean"}]
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-vs-catalog", "--json"],
         )
@@ -396,7 +396,7 @@ class TestT3VsCatalog:
             def list_collections(self):
                 return [{"name": "code__orphan"}]
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-vs-catalog", "--json"],
         )
@@ -435,7 +435,7 @@ class TestT3VsCatalog:
             def list_collections(self):
                 return []  # no T3 collections at all
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-vs-catalog", "--json"],
         )

--- a/tests/test_catalog_doctor_t3_coverage.py
+++ b/tests/test_catalog_doctor_t3_coverage.py
@@ -116,7 +116,7 @@ class TestCoveragePasses:
                 return chroma_client.get_collection(name)
 
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )
@@ -145,7 +145,7 @@ class TestCoveragePasses:
                 return chroma_client.get_collection(name)
 
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )
@@ -178,7 +178,7 @@ class TestCoverageFails:
                 return chroma_client.get_collection(name)
 
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )
@@ -207,7 +207,7 @@ class TestCoverageFails:
                 return chroma_client.get_collection(name)
 
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )
@@ -244,7 +244,7 @@ class TestCoverageFails:
                 return chroma_client.get_collection(name)
 
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd,
             ["--t3-doc-id-coverage", "--strict-not-in-t3", "--json"],
@@ -287,7 +287,7 @@ class TestCombined:
                 return chroma_client.get_collection(name)
 
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd,
             ["--replay-equality", "--t3-doc-id-coverage", "--json"],
@@ -355,7 +355,7 @@ class TestOrphanRatioSurface:
             def get_collection(self, name):
                 return chroma_client.get_collection(name)
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
 
         # Text output assertions
         text_result = runner.invoke(doctor_cmd, ["--t3-doc-id-coverage"])
@@ -427,7 +427,7 @@ class TestOrphanRatioSurface:
             def get_collection(self, name):
                 return chroma_client.get_collection(name)
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
 
         text_result = runner.invoke(doctor_cmd, ["--t3-doc-id-coverage"])
         assert text_result.exit_code == 0, text_result.output
@@ -458,7 +458,7 @@ class TestOrphanRatioSurface:
             def get_collection(self, name):
                 return chroma_client.get_collection(name)
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
 
         json_result = runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
@@ -528,7 +528,7 @@ class TestPhase3ManifestFallback:
                 return chroma_client.get_collection(name)
 
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
 
         result = runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
@@ -581,7 +581,7 @@ class TestBypassSchemaSkipped:
                 return chroma_client.get_collection(name)
 
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )
@@ -635,7 +635,7 @@ class TestSupersededSkip:
                 return chroma_client.get_collection(name)
 
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )

--- a/tests/test_chash_reconcile.py
+++ b/tests/test_chash_reconcile.py
@@ -108,7 +108,7 @@ class TestChashReconcileCLI:
         import nexus.commands._helpers as h
         monkeypatch.setattr("nexus.config.default_db_path", lambda: mem_db)
         monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: mem_db)
-        monkeypatch.setattr("nexus.db.make_t3", lambda: t3_db)
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: t3_db)
         return mem_db
 
     def test_no_ghosts_clean_summary(
@@ -296,7 +296,7 @@ class TestChashReconcileCLI:
         import nexus.commands._helpers as h
         monkeypatch.setattr("nexus.config.default_db_path", lambda: mem_db)
         monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: mem_db)
-        monkeypatch.setattr("nexus.db.make_t3", lambda: t3)
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: t3)
 
         result = runner.invoke(main, ["catalog", "chash-reconcile"])
 

--- a/tests/test_collection_gc.py
+++ b/tests/test_collection_gc.py
@@ -92,7 +92,7 @@ class TestCollectionGCCli:
                 metadatas=[{"title": "seed.md"}],
             )
 
-        monkeypatch.setattr("nexus.db.make_t3", lambda: t3_db)
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: t3_db)
 
     def test_no_zombies_clean_summary(
         self, monkeypatch, runner, t3_db, catalog_env,
@@ -214,7 +214,7 @@ class TestCollectionGCCli:
             ("9.9.9", empty_referenced),
         )
         catalog_env._db.commit()
-        monkeypatch.setattr("nexus.db.make_t3", lambda: t3_db)
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: t3_db)
 
         result = runner.invoke(main, ["catalog", "collection-gc", "--apply"])
         assert result.exit_code == 0, result.output
@@ -238,7 +238,7 @@ class TestCollectionGCCli:
         )
         # Plus one zombie that SHOULD be swept.
         t3_db._client.get_or_create_collection("rdr__zombie")
-        monkeypatch.setattr("nexus.db.make_t3", lambda: t3_db)
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: t3_db)
 
         result = runner.invoke(main, ["catalog", "collection-gc", "--apply"])
 
@@ -271,7 +271,7 @@ class TestCollectionGCCli:
         monkeypatch.setattr(
             "nexus.commands.catalog._get_catalog", lambda: fake_cat,
         )
-        monkeypatch.setattr("nexus.db.make_t3", lambda: t3_db)
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: t3_db)
 
         result = runner.invoke(main, ["catalog", "collection-gc"])
 

--- a/tests/test_index_taxonomy.py
+++ b/tests/test_index_taxonomy.py
@@ -22,7 +22,7 @@ def test_index_repo_triggers_taxonomy_discover(tmp_path) -> None:
         stack.enter_context(patch("nexus.commands.index._discover_taxonomy", side_effect=fake_discover))
         stack.enter_context(patch("nexus.indexer.index_repository", return_value={"code_indexed": 5}))
         stack.enter_context(patch("nexus.commands.index.tqdm", side_effect=lambda **kw: None))
-        stack.enter_context(patch("nexus.db.make_t3"))
+        stack.enter_context(patch("nexus.mcp_infra.get_t3"))
         stack.enter_context(patch("nexus.db.t2.T2Database"))
         # Disable auto-label to prevent taxonomy_cmd import from poisoning T2Database
         stack.enter_context(patch("nexus.config.load_config", return_value={"taxonomy": {"auto_label": False, "local_exclude_collections": []}}))
@@ -86,7 +86,7 @@ def test_index_repo_taxonomy_failure_nonfatal(tmp_path) -> None:
         stack.enter_context(patch("nexus.commands.index._discover_taxonomy", side_effect=bad_discover))
         stack.enter_context(patch("nexus.indexer.index_repository", return_value={"code_indexed": 1}))
         stack.enter_context(patch("nexus.commands.index.tqdm", side_effect=lambda **kw: None))
-        stack.enter_context(patch("nexus.db.make_t3"))
+        stack.enter_context(patch("nexus.mcp_infra.get_t3"))
         stack.enter_context(patch("nexus.db.t2.T2Database"))
         stack.enter_context(patch("nexus.config.load_config", return_value={"taxonomy": {"auto_label": False, "local_exclude_collections": []}}))
         mock_reg = stack.enter_context(patch("nexus.commands.index._registry"))

--- a/tests/test_store_put_cli_parity.py
+++ b/tests/test_store_put_cli_parity.py
@@ -158,7 +158,7 @@ class TestMemoryPromoteCli:
         )
         register_post_document_hook(lambda src, c, content: doc.append(src))
 
-        with patch("nexus.db.make_t3", _make_stub_t3()):
+        with patch("nexus.mcp_infra.get_t3", _make_stub_t3()):
             runner = CliRunner()
             result = runner.invoke(main, [
                 "memory", "promote", str(entry_id),

--- a/tests/test_t2_rename_cascade.py
+++ b/tests/test_t2_rename_cascade.py
@@ -191,3 +191,179 @@ def test_rename_cascade_owned_conn_closes_after_success(seeded_db: Path) -> None
     finally:
         raw.close()
     assert row[0] == "code__new"
+
+
+# -- nexus-fe2i: catalog table parity ----------------------------------------
+
+
+@pytest.fixture
+def seeded_db_with_catalog(tmp_path: Path) -> Path:
+    """Seed a memory.db that has BOTH the legacy six-store rows AND
+    catalog tables populated. Phase 4 (uar6) reads the catalog through
+    ``T2Client.catalog`` so the rename must keep both sides in sync."""
+    db_path = tmp_path / "memory.db"
+    with T2Database(db_path) as t2:
+        # Six-store seed (same as ``seeded_db``).
+        t2.chash_index.upsert(chash="aa", collection="code__old")
+        t2.taxonomy.conn.execute(
+            "INSERT INTO topics (label, collection, centroid_hash, doc_count, "
+            "terms, created_at) "
+            "VALUES ('T', 'code__old', 'h1', 1, '[]', '2026-05-13T00:00:00Z')"
+        )
+        t2.taxonomy.conn.execute(
+            "INSERT INTO taxonomy_meta (collection, last_discover_at) "
+            "VALUES ('code__old', '2026-05-13T00:00:00Z')"
+        )
+        t2.taxonomy.conn.commit()
+        # Catalog seed: one document row + matching collections row.
+        t2.catalog._conn.execute(
+            "INSERT INTO documents (tumbler, title, physical_collection) "
+            "VALUES (?, ?, ?)",
+            ("1.1.1", "doc-fe2i", "code__old"),
+        )
+        t2.catalog._conn.execute(
+            "INSERT INTO collections (name, content_type, owner_id, "
+            "embedding_model, model_version, display_name, "
+            "legacy_grandfathered, superseded_by, superseded_at, "
+            "created_at) VALUES (?, '', '', '', '', '', 0, '', '', '')",
+            ("code__old",),
+        )
+        t2.catalog._conn.commit()
+    return db_path
+
+
+def test_rename_cascade_updates_catalog_documents_and_collections(
+    seeded_db_with_catalog: Path,
+) -> None:
+    """A rename updates ``documents.physical_collection`` and
+    ``collections.name`` in lockstep with the legacy six stores."""
+    with T2Database(seeded_db_with_catalog) as t2:
+        counts = t2.rename_collection_cascade(
+            old="code__old", new="code__new",
+        )
+    assert counts["catalog_documents"] == 1, counts
+    assert counts["catalog_collections"] == 1, counts
+    # Verify the rows actually moved.
+    raw = sqlite3.connect(str(seeded_db_with_catalog))
+    try:
+        doc_coll = raw.execute(
+            "SELECT physical_collection FROM documents WHERE tumbler='1.1.1'"
+        ).fetchone()[0]
+        old_count = raw.execute(
+            "SELECT COUNT(*) FROM collections WHERE name='code__old'"
+        ).fetchone()[0]
+        new_count = raw.execute(
+            "SELECT COUNT(*) FROM collections WHERE name='code__new'"
+        ).fetchone()[0]
+    finally:
+        raw.close()
+    assert doc_coll == "code__new"
+    assert old_count == 0
+    assert new_count == 1
+
+
+def test_rename_cascade_collections_collision_defense(
+    seeded_db_with_catalog: Path,
+) -> None:
+    """If ``collections.<new>`` already exists, the cascade drops it
+    first so the PRIMARY KEY UPDATE on ``collections.name`` does not
+    raise. Mirrors the chash_index DELETE-then-UPDATE pattern."""
+    # Pre-create a row for the NEW name so the rename collides.
+    raw = sqlite3.connect(str(seeded_db_with_catalog))
+    try:
+        raw.execute(
+            "INSERT INTO collections (name, content_type, owner_id, "
+            "embedding_model, model_version, display_name, "
+            "legacy_grandfathered, superseded_by, superseded_at, "
+            "created_at) VALUES (?, '', '', '', '', '', 0, '', '', '')",
+            ("code__new",),
+        )
+        raw.commit()
+    finally:
+        raw.close()
+
+    with T2Database(seeded_db_with_catalog) as t2:
+        t2.rename_collection_cascade(old="code__old", new="code__new")
+
+    raw = sqlite3.connect(str(seeded_db_with_catalog))
+    try:
+        rows = raw.execute(
+            "SELECT name FROM collections ORDER BY name"
+        ).fetchall()
+    finally:
+        raw.close()
+    # Only the renamed row remains; the pre-existing colliding row was
+    # dropped by the cascade's collision-defense DELETE.
+    assert rows == [("code__new",)], rows
+
+
+def test_rename_cascade_atomicity_includes_catalog(
+    seeded_db_with_catalog: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mid-cascade failure rolls back the catalog UPDATEs too. Uses the
+    same bombing-connection pattern as the document_aspects atomicity
+    test, but targets the LATER catalog statements so we know the
+    rollback unwinds the whole transaction (not just the post-failure
+    statements)."""
+    real_connect = sqlite3.connect
+
+    class _BombingConnection:
+        def __init__(self, real: sqlite3.Connection) -> None:
+            self._real = real
+            self._fail_armed = False
+
+        def execute(self, sql: str, params=(), **kw):
+            stripped = sql.strip()
+            if stripped.upper() == "BEGIN":
+                self._fail_armed = True
+                return self._real.execute(sql, params, **kw)
+            if (
+                self._fail_armed
+                and "collections" in stripped
+                and "UPDATE collections SET name" in stripped
+            ):
+                raise RuntimeError("simulated mid-cascade failure on catalog")
+            return self._real.execute(sql, params, **kw)
+
+        def rollback(self):
+            return self._real.rollback()
+
+        def commit(self):
+            return self._real.commit()
+
+        def close(self):
+            return self._real.close()
+
+    def _spawn_bombing(path: str, *args, **kwargs):
+        return _BombingConnection(real_connect(path, *args, **kwargs))
+
+    import nexus.db.t2 as t2_mod
+    with T2Database(seeded_db_with_catalog) as t2:
+        monkeypatch.setattr(t2_mod.sqlite3, "connect", _spawn_bombing)
+        with pytest.raises(RuntimeError, match="catalog"):
+            t2.rename_collection_cascade(old="code__old", new="code__new")
+
+    # Every table must still carry the OLD name — rollback unwound
+    # the earlier UPDATEs (chash, documents.physical_collection,
+    # collections insertions) as well as the failed one.
+    raw = real_connect(str(seeded_db_with_catalog))
+    try:
+        chash = raw.execute(
+            "SELECT physical_collection FROM chash_index WHERE chash='aa'"
+        ).fetchone()
+        doc = raw.execute(
+            "SELECT physical_collection FROM documents WHERE tumbler='1.1.1'"
+        ).fetchone()
+        old_coll = raw.execute(
+            "SELECT COUNT(*) FROM collections WHERE name='code__old'"
+        ).fetchone()
+        new_coll = raw.execute(
+            "SELECT COUNT(*) FROM collections WHERE name='code__new'"
+        ).fetchone()
+    finally:
+        raw.close()
+    assert chash[0] == "code__old", "chash_index must roll back"
+    assert doc[0] == "code__old", "documents.physical_collection must roll back"
+    assert old_coll[0] == 1, "collections row for old must still exist"
+    assert new_coll[0] == 0, "collections row for new must not have been created"

--- a/tests/test_t2_rename_cascade.py
+++ b/tests/test_t2_rename_cascade.py
@@ -290,11 +290,17 @@ def test_rename_cascade_collections_collision_defense(
         rows = raw.execute(
             "SELECT name FROM collections ORDER BY name"
         ).fetchall()
+        # S1 from the uar6 review: assert the documents row moved too,
+        # so the two catalog tables stay consistent post-collision.
+        doc_row = raw.execute(
+            "SELECT physical_collection FROM documents WHERE tumbler='1.1.1'"
+        ).fetchone()
     finally:
         raw.close()
     # Only the renamed row remains; the pre-existing colliding row was
     # dropped by the cascade's collision-defense DELETE.
     assert rows == [("code__new",)], rows
+    assert doc_row[0] == "code__new"
 
 
 def test_rename_cascade_atomicity_includes_catalog(


### PR DESCRIPTION
## Summary

Phase 4.4 of RDR-112. The T3-side of the catalog + index CLI port lands here along with its two substrate prerequisites (m0hi, fe2i) plus review remediation. Five commits, one logical unit, one PR.

## Commits

1. **bb68763e** `nexus-m0hi` - Expose ``_backfilled_collections`` on CatalogStore + public ``backfilled_collections()`` accessor so the catalog flip can read the synthetic-event seed set through ``T2Client.catalog`` without reaching for a ``_StoreProxy``-skipped underscore method.
2. **d95342f2** `nexus-fe2i` - Extend ``T2Database.rename_collection_cascade`` to update ``documents.physical_collection`` and ``collections.name`` in the same transaction as the legacy six stores. Without it, a Phase 4 rename would leave the catalog projection stale.
3. **7de2b06e** Review remediation (C1 / I1 / S1) on the substrate commits. C1 was Critical: second CatalogStore on the same path skipped ``_init_schema`` (and thus ``_backfill_collections``), so the accessor raised AttributeError. Initialize the set in ``__init__`` so the fast-path is safe; lock the accessor (I1); add the missing ``documents`` assertion to the collision-defense test (S1).
4. **8bb69be9** `nexus-uar6` - The actual flip. ``commands/catalog.py`` ``_make_t3()`` helper rewritten to route through ``mcp_infra.get_t3`` with the same credential pre-check ``store.py`` and ``enrich.py`` use. All 15 direct ``make_t3()`` callers in catalog.py flipped to use the helper. Single ``make_t3()`` site in ``commands/index.py`` flipped. 6 test files swapped from ``nexus.db.make_t3`` to ``nexus.mcp_infra.get_t3``. Two new daemon-mode test files.
5. **181a0f75** Three catalog-doctor test files still held the old patch target (singleton pollution under a full-suite run). Swapped.

## Production diff

**commands/catalog.py:** the ``_make_t3()`` helper that 5 callers already used is now daemon-aware; the remaining 15 direct ``make_t3()`` callers are pointed at the helper. Net: one daemon-aware seam, zero per-callsite imports, 22 call sites routed through the daemon under ``NX_STORAGE_MODE=daemon``.

**commands/index.py:** the single direct ``make_t3()`` call inside ``run_collection_postprocessing`` (post-index taxonomy + projection + topic-link chain) flips to ``get_t3()`` with the same RuntimeError-to-ClickException translation.

## Substrate

**catalog_store.py** picks up the ``_backfilled_collections`` set + public accessor (m0hi). **db/t2/__init__.py** ``rename_collection_cascade`` adds two atomic UPDATEs for ``documents.physical_collection`` + ``collections.name`` with collision-defense DELETE (fe2i).

## Filed follow-up

``nexus-6shq`` captures the residual scope: the higher-level ``nexus.catalog.Catalog`` wrapper still opens a local ``CatalogDB`` against ``.catalog.db`` (four sites in CLI). Flipping ``Catalog -> T2Client.catalog`` (or replacing CLI usage with direct CatalogStore access) is substrate refactor work beyond uar6's scope. The four ``Catalog(...)`` opens listed in the bead description are tracked there; ``nx catalog show / link / search`` end-to-end daemon-mode tests will land with that follow-up.

The ``CatalogDB(projected_path)`` open inside doctor replay (catalog.py:5400) stays as-is per the existing ``storage-boundary-allow`` marker (tmp file, not the canonical store).

## Code review

PASS-after-remediation. Initial pass was BLOCKED on C1 (real bug, captured + fixed); I1 + S1 also remediated in-place. The reviewer flagged the uar6 commit was missing from the branch at the time (working-tree state); commit 8bb69be9 closes that gap.

## Test plan

- [x] ``uv run pytest tests/db/test_catalog_store.py::TestBackfilledCollections tests/test_t2_rename_cascade.py tests/daemon/test_catalog_client.py::TestCatalogClientRpc`` - 19/19 substrate tests pass
- [x] ``uv run pytest tests/commands/test_catalog_daemon_mode.py tests/commands/test_index_daemon_mode.py`` - 3/3 new daemon-mode tests pass
- [x] ``uv run pytest tests/test_catalog_doctor_t3_coverage.py tests/test_catalog_doctor_name_vs_embed_dim.py tests/test_catalog_doctor_new_checks.py`` - 38/38 doctor tests pass post patch-target swap
- [x] Catalog + index sweep (28 files): 617/617 pass
- [ ] Full suite confirmation run in flight - prior run showed 19 failures (14 from the patches now swapped + 5 pre-existing baseline); post-swap should be back to baseline 5

## Closes

Closes nexus-m0hi
Closes nexus-fe2i
Closes nexus-uar6