### PR TITLE
test: fix 5 pre-existing baseline failures (nexus-8qat drift + conftest config-dir override)

### DIFF
--- a/tests/test_default_storage_mode.py
+++ b/tests/test_default_storage_mode.py
@@ -40,13 +40,18 @@ class TestDefaultResolver:
         monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
         assert default_storage_mode() == "daemon"
 
-    def test_unknown_value_returns_as_is(
+    def test_unknown_value_raises_value_error(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Unknown values pass through (callers compare to 'daemon'/'direct')."""
+        """Unknown values fail loud per the nexus-8qat strict-validation
+        contract (RDR-112 P3.review S2). Pre-fix an operator who typo'd
+        ``NX_STORAGE_MODE=damon`` would silently get direct-mode routing
+        because ``is_daemon_mode()`` compares against the literal; now
+        anything other than direct|daemon raises ``ValueError``."""
         from nexus.db import default_storage_mode
         monkeypatch.setenv("NX_STORAGE_MODE", "in-process")
-        assert default_storage_mode() == "in-process"
+        with pytest.raises(ValueError, match="invalid"):
+            default_storage_mode()
 
     def test_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from nexus.db import default_storage_mode
@@ -72,10 +77,16 @@ class TestIsDaemonMode:
         monkeypatch.setenv("NX_STORAGE_MODE", "direct")
         assert is_daemon_mode() is False
 
-    def test_unknown_is_not_daemon(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_unknown_value_raises_value_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``is_daemon_mode`` delegates to ``default_storage_mode`` so an
+        unknown env value raises ``ValueError`` (nexus-8qat strict
+        validation), not silently returns False."""
         from nexus.db import is_daemon_mode
         monkeypatch.setenv("NX_STORAGE_MODE", "in-process")
-        assert is_daemon_mode() is False
+        with pytest.raises(ValueError, match="invalid"):
+            is_daemon_mode()
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +148,9 @@ class TestMcpFailLoudOnMissingDaemon:
         _core._TUPLESPACE.clear()
         # The discovery probe consults find_t2_daemon(); when the discovery
         # file is missing it returns None, and the bootstrap is supposed to
-        # raise RuntimeError with the migration hint.
-        with pytest.raises(RuntimeError, match="NX_STORAGE_MODE=daemon"):
+        # raise RuntimeError with the migration hint. The error message
+        # surfaces both the active mode ("Storage mode is 'daemon'") and
+        # the opt-out hint ("NX_STORAGE_MODE=direct") — match the active
+        # mode phrase, which is the load-bearing diagnostic.
+        with pytest.raises(RuntimeError, match=r"Storage mode is 'daemon'"):
             _core._get_tuplespace()

--- a/tests/test_doctor_check_bridge.py
+++ b/tests/test_doctor_check_bridge.py
@@ -118,12 +118,18 @@ def test_check_bridge_under_daemon_mode_skips_tuples_readback(
 
     # Create a tuples.db at the path the check looks for so the readback
     # branch is actually reachable absent the daemon-mode gate.
+    # NEXUS_CONFIG_DIR is the resolved path for ``nexus_config_dir()``
+    # (the autouse ``_isolate_config_dir`` fixture in conftest.py sets
+    # it to ``tmp_path/.config/nexus``). Seed tuples.db at THAT path so
+    # the doctor's ``tuples_db.exists()`` probe finds it.
     fake_home = tmp_path / "home"
-    fake_tuples = fake_home / ".config" / "nexus" / "tuples.db"
+    config_dir = tmp_path / ".config" / "nexus"
+    fake_tuples = config_dir / "tuples.db"
     _make_tuples_db(fake_tuples)
 
     monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
     monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
     monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
 
     runner = CliRunner()
@@ -146,17 +152,25 @@ def test_check_bridge_direct_mode_opens_tuples_readback(
     an explicit opt-in; this test sets the env explicitly. The default
     (env unset) resolves to daemon mode, which skips the readback per
     nexus-1xip.
+
+    Seed tuples.db at the ``NEXUS_CONFIG_DIR`` location (autouse
+    ``_isolate_config_dir`` fixture in conftest.py sets it to
+    ``tmp_path/.config/nexus``) so the doctor's existence probe finds
+    it. The legacy ``HOME``-only redirect is not enough because
+    ``nexus_config_dir()`` honours ``NEXUS_CONFIG_DIR`` first.
     """
     plugin_root = tmp_path / "plugin"
     _stub_bridge_scripts(plugin_root)
     _write_plugin_manifest(plugin_root, "0.0.0-stale")
 
     fake_home = tmp_path / "home"
-    fake_tuples = fake_home / ".config" / "nexus" / "tuples.db"
+    config_dir = tmp_path / ".config" / "nexus"
+    fake_tuples = config_dir / "tuples.db"
     _make_tuples_db(fake_tuples)
 
     monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
     monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
     monkeypatch.setenv("NX_STORAGE_MODE", "direct")
 
     runner = CliRunner()


### PR DESCRIPTION
## Summary

Eliminates the 5 long-standing baseline failures on develop. Suite goes from ``9049 passed + 5 failed`` to ``9054 passed + 0 failed``.

## Root causes

**Family 1 - tests/test_default_storage_mode.py (3 failures):** stale vs the nexus-8qat strict-validation contract (RDR-112 P3.review S2).

- ``default_storage_mode()`` now raises ``ValueError`` on unknown env values (acceptance: "anything other than direct|daemon fails loud"). Pre-fix an operator who typo'd ``NX_STORAGE_MODE=damon`` would silently get direct-mode routing. Two tests still expected the lenient pass-through; renamed + assert the ``ValueError``.
- ``_get_tuplespace`` error message was updated to mention both the active mode (``Storage mode is 'daemon'``) and the opt-out hint (``NX_STORAGE_MODE=direct``). The regex still matched the old ``NX_STORAGE_MODE=daemon`` literal. Updated to match the active-mode phrase, which is the load-bearing diagnostic.

**Family 2 - tests/test_doctor_check_bridge.py (2 failures):** autouse ``_isolate_config_dir`` fixture in conftest.py sets ``NEXUS_CONFIG_DIR=tmp_path/.config/nexus``. The two failing tests seeded ``tuples.db`` at ``fake_home/.config/nexus/tuples.db`` (with ``HOME=fake_home``), but ``nexus_config_dir()`` honours ``NEXUS_CONFIG_DIR`` FIRST. The doctor's ``tuples_db.exists()`` probe landed on the autouse-fixture path, never found the seeded db, and the readback branch (which emits ``recent hook events``) never fired.

Fix: write ``tuples.db`` at the autouse-fixture path and explicitly ``setenv NEXUS_CONFIG_DIR`` to that path so resolution is consistent regardless of conftest ordering.

## Test plan

- [x] ``uv run pytest tests/test_default_storage_mode.py tests/test_doctor_check_bridge.py -v`` — 26/26 pass
- [x] ``uv run pytest --tb=no -q`` (full suite) — 9054 passed, 0 failed, 44 skipped, 118 deselected

## No production changes

Test-only diff. Two files, ``+37 / -9``.