### PR TITLE
feat(rdr-112): nexus-mmvf - CLI port for taxonomy + doc (T3 daemon seam)

### DIFF
--- a/src/nexus/commands/doc.py
+++ b/src/nexus/commands/doc.py
@@ -548,18 +548,29 @@ def _phase4_catalog_t3_chash() -> tuple[Any, Any, Any]:
 
     The Catalog is constructed from the conventional catalog path under
     ``default_db_path()``'s parent, matching ``mcp_infra.get_catalog``.
-    T3 comes from ``nexus.db.make_t3``. ChashIndex opens the same T2
-    path used by every other T2 store.
+    T3 comes via ``mcp_infra.get_t3`` so daemon mode hits the live
+    daemon's HttpClient rather than racing it on the on-disk path.
+    ChashIndex opens the same T2 path used by every other T2 store.
+
+    RDR-112 P4.3 (nexus-mmvf) flipped the T3 source. The ChashIndex
+    direct open is tracked separately under the broader catalog-port
+    follow-up (nexus-6shq): it opens T2's chash table directly and
+    would race the daemon writer under daemon mode. Reads currently
+    work but the write path needs the same Catalog -> T2Client.catalog
+    refactor.
     """
     from nexus.catalog import open_cached
-    from nexus.db import make_t3
     from nexus.db.t2.chash_index import ChashIndex
+    from nexus.mcp_infra import get_t3
 
     db_path = default_db_path()
     cat_path = db_path.parent / "catalog"
     # nexus-6xqk follow-up: read-mostly catalog accessor for doc query.
     cat: Any = open_cached(cat_path)
-    t3: Any = make_t3()
+    try:
+        t3: Any = get_t3()
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
     chash_index: Any = ChashIndex(db_path)
     return cat, t3, chash_index
 

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -1724,6 +1724,12 @@ def validate_refs_cmd(paths, tolerance, strict, prefixes, fmt):
 
     try:
         t3 = _make_t3()
+    except click.ClickException:
+        # nexus-mmvf review S1: ``_make_t3()`` raises ``ClickException``
+        # under daemon-resolver failure. Let Click's own error formatter
+        # render it (exit code 1, "Error: <hint>") rather than wrapping
+        # it again with our exit-2 fallback below.
+        raise
     except Exception as exc:
         click.echo(f"Error: T3 unavailable: {exc}", err=True)
         raise click.exceptions.Exit(2)

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -35,6 +35,26 @@ def _t2_ctx():
         return t2_ctx()
     return t2_ctx(_path_resolver=_default_db_path)
 
+
+def _make_t3():
+    """RDR-112 P4.3 (nexus-mmvf): daemon-aware T3 factory.
+
+    Routes through ``mcp_infra.get_t3`` so under
+    ``NX_STORAGE_MODE=daemon`` the returned ``T3Database`` wraps an
+    ``HttpClient`` to the live daemon; direct mode falls through to
+    ``make_t3`` unchanged. ``RuntimeError`` from the daemon resolver
+    (``T3DaemonError`` / ``DaemonNotRunningError``) carries a recovery
+    hint; translate to ``ClickException`` for the CLI. Mirrors the
+    ``_make_t3`` helpers in ``commands.catalog`` (uar6) and the
+    ``_t3`` helper in ``commands.store`` (idqd).
+    """
+    from nexus.mcp_infra import get_t3
+    try:
+        return get_t3()
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
 if TYPE_CHECKING:
     from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
 
@@ -404,7 +424,6 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
     from fnmatch import fnmatch
 
     from nexus.config import is_local_mode, load_config
-    from nexus.db import make_t3
 
     if not collection and not discover_all:
         click.echo("Specify --collection <name> or --all.")
@@ -415,7 +434,7 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
         cfg.get("taxonomy", {}).get("local_exclude_collections", [])
         if is_local_mode() else []
     )
-    t3 = make_t3()
+    t3 = _make_t3()
 
     if discover_all:
         colls = t3.list_collections()
@@ -506,7 +525,6 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
 @click.option("-k", default=None, type=int, hidden=True, help="Deprecated: cluster count is automatic")
 def rebuild_cmd(collection: str, project: str, k: int | None) -> None:
     """Rebuild topic taxonomy from scratch (alias for discover --force)."""
-    from nexus.db import make_t3
 
     # Backward compat: old --project flag maps to --collection
     if project and not collection:
@@ -524,7 +542,7 @@ def rebuild_cmd(collection: str, project: str, k: int | None) -> None:
         click.echo("Note: -k is deprecated. Cluster count is now automatic (HDBSCAN).")
 
     with _t2_ctx() as db:
-        t3 = make_t3()
+        t3 = _make_t3()
         count = discover_for_collection(
             collection, db.taxonomy, t3._client, force=True,
         )
@@ -743,14 +761,13 @@ def merge_cmd(source_label: str, target_label: str, collection: str) -> None:
 @click.option("--collection", "-c", default="", help="Collection scope for label lookup")
 def split_cmd(topic_label: str, k: int, collection: str) -> None:
     """Split a topic into k sub-topics via KMeans clustering."""
-    from nexus.db import make_t3
 
     with _t2_ctx() as db:
         topic_id = db.taxonomy.resolve_label(topic_label, collection=collection)
         if topic_id is None:
             click.echo(f"Topic '{topic_label}' not found.")
             return
-        t3 = make_t3()
+        t3 = _make_t3()
         child_count = db.taxonomy.split_topic(topic_id, k=k, chroma_client=t3._client)
         click.echo(f"Split '{topic_label}' into {child_count} sub-topics.")
         if child_count:
@@ -1250,10 +1267,9 @@ def project_cmd(
       nx taxonomy project --backfill --persist
     """
     from nexus.corpus import default_projection_threshold
-    from nexus.db import make_t3
 
     db = _t2_ctx()
-    t3 = make_t3()
+    t3 = _make_t3()
 
     # Resolve threshold: explicit flag wins; otherwise per-corpus default
     # (defaults applied at the per-source level inside _run_backfill).
@@ -1699,7 +1715,6 @@ def validate_refs_cmd(paths, tolerance, strict, prefixes, fmt):
     import json
     import sys
 
-    from nexus.db import make_t3
     from nexus.doc.ref_scanner import (
         VERDICT_DRIFT, VERDICT_MISSING, VERDICT_OK,
         scan_markdown, validate,
@@ -1708,7 +1723,7 @@ def validate_refs_cmd(paths, tolerance, strict, prefixes, fmt):
     resolved_prefixes = _resolve_prefixes(prefixes)
 
     try:
-        t3 = make_t3()
+        t3 = _make_t3()
     except Exception as exc:
         click.echo(f"Error: T3 unavailable: {exc}", err=True)
         raise click.exceptions.Exit(2)

--- a/tests/commands/test_doc_daemon_mode.py
+++ b/tests/commands/test_doc_daemon_mode.py
@@ -99,10 +99,14 @@ class TestDocPhase4Factory:
         the T3 client class."""
         from nexus.commands.doc import _phase4_catalog_t3_chash
         _cat, t3, _chash = _phase4_catalog_t3_chash()
-        client_cls_name = type(t3._client).__name__
-        assert "Http" in client_cls_name or "Client" in client_cls_name, (
-            f"expected an HTTP-style client under daemon mode, got "
-            f"{type(t3._client).__module__}.{client_cls_name}"
+        # nexus-mmvf review Minor: chromadb factories return the same
+        # Client class; use the client identifier (host:port vs path)
+        # as the daemon-vs-persistent discriminator.
+        client_id = getattr(t3._client, "_identifier", "") or ""
+        assert "/" not in client_id, (
+            f"client identifier {client_id!r} looks like a filesystem "
+            f"path — the seam likely returned a PersistentClient under "
+            f"daemon mode, racing the daemon writer."
         )
         # The helper's T3 read surface must work end-to-end against
         # the daemon (empty list is the correct answer for a fresh

--- a/tests/commands/test_doc_daemon_mode.py
+++ b/tests/commands/test_doc_daemon_mode.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 P4.3 (nexus-mmvf) — ``nx doc`` CLI under
+``NX_STORAGE_MODE=daemon``.
+
+``commands/doc.py`` has one direct T3 site, inside the
+``_phase4_catalog_t3_chash`` factory helper (~line 564). Every
+``nx doc render`` / ``nx doc cite`` invocation that needs T3 goes
+through this helper. The mmvf flip routes the helper's T3 source
+through ``mcp_infra.get_t3`` so daemon mode returns the daemon's
+``HttpClient``.
+
+The helper also constructs a Catalog (``open_cached``) and a
+``ChashIndex`` directly off ``default_db_path()``. Those two direct
+opens race the daemon under daemon mode and are tracked separately
+under nexus-6shq (the broader Catalog -> T2Client.catalog refactor);
+mmvf flips only the T3 source here.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def reset_t3_singleton():
+    import nexus.mcp_infra as infra
+    original_t3 = infra._t3_instance
+    original_collections = infra._collections_cache
+    infra._t3_instance = None
+    infra._collections_cache = ([], 0.0)
+    yield
+    infra._t3_instance = original_t3
+    infra._collections_cache = original_collections
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    cd = tmp_path / "nexus_config"
+    cd.mkdir()
+    return cd
+
+
+@pytest.fixture
+def local_path(tmp_path: Path) -> Path:
+    p = tmp_path / "chroma_t3"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def daemon_env(monkeypatch, config_dir: Path):
+    monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+    monkeypatch.setenv("NX_LOCAL", "1")
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
+
+
+@pytest.fixture
+def live_t3_daemon(daemon_env, config_dir: Path, local_path: Path):
+    from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+
+    payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+    try:
+        yield payload
+    finally:
+        stop_t3_daemon(config_dir=config_dir)
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def initialized_catalog(config_dir: Path):
+    """``_phase4_catalog_t3_chash`` opens a catalog at
+    ``default_db_path().parent / catalog``. Under the test's
+    ``NEXUS_CONFIG_DIR`` override that resolves to
+    ``config_dir / catalog``. The factory does NOT auto-create the
+    catalog dir; pre-initialize one so the smoke test reaches the
+    T3 branch without choking on a missing ``.catalog.db``."""
+    from nexus.catalog import Catalog
+    cat_dir = config_dir / "catalog"
+    cat_dir.mkdir(parents=True, exist_ok=True)
+    Catalog.init(cat_dir)
+    return cat_dir
+
+
+class TestDocPhase4Factory:
+    def test_phase4_factory_resolves_t3_via_daemon(
+        self,
+        live_t3_daemon,
+        reset_t3_singleton,
+        initialized_catalog: Path,
+    ) -> None:
+        """``_phase4_catalog_t3_chash`` returns a ``(catalog, t3,
+        chash_index)`` trio. Under daemon mode the ``t3`` slot must be
+        a ``T3Database`` whose underlying client is the daemon's
+        ``HttpClient``. The catalog + chash_index slots are out-of-
+        scope for mmvf (tracked under nexus-6shq); we only assert on
+        the T3 client class."""
+        from nexus.commands.doc import _phase4_catalog_t3_chash
+        _cat, t3, _chash = _phase4_catalog_t3_chash()
+        client_cls_name = type(t3._client).__name__
+        assert "Http" in client_cls_name or "Client" in client_cls_name, (
+            f"expected an HTTP-style client under daemon mode, got "
+            f"{type(t3._client).__module__}.{client_cls_name}"
+        )
+        # The helper's T3 read surface must work end-to-end against
+        # the daemon (empty list is the correct answer for a fresh
+        # daemon with no collections).
+        cols = t3.list_collections()
+        assert isinstance(cols, list)

--- a/tests/commands/test_taxonomy_daemon_mode.py
+++ b/tests/commands/test_taxonomy_daemon_mode.py
@@ -147,13 +147,22 @@ class TestTaxonomyMakeT3Seam:
         future versions."""
         from nexus.commands.taxonomy_cmd import _make_t3
         t3 = _make_t3()
-        client_cls_name = type(t3._client).__name__
-        # HttpClient is what ``make_t3_client`` returns under daemon
-        # mode; a PersistentClient would indicate the flip did not
-        # take effect.
-        assert "Http" in client_cls_name or "Client" in client_cls_name, (
-            f"expected an HTTP-style client under daemon mode, got "
-            f"{type(t3._client).__module__}.{client_cls_name}"
+        # nexus-mmvf review Minor: chromadb's HttpClient and
+        # PersistentClient factories both wrap the same
+        # ``chromadb.api.client.Client`` class — ``type(...).__name__``
+        # is ``Client`` in both cases. Assert the regression shape
+        # via the module path of the underlying transport: an
+        # HttpClient's identifier reaches into ``chromadb.api.fastapi``
+        # while a PersistentClient uses ``chromadb.api.segment`` /
+        # local persistence. Pragmatic check: confirm the client
+        # answers ``list_collections()`` without raising (covered by
+        # the next test) and that the identifier does NOT name a
+        # filesystem path (an HttpClient's identifier is host:port).
+        client_id = getattr(t3._client, "_identifier", "") or ""
+        assert "/" not in client_id, (
+            f"client identifier {client_id!r} looks like a filesystem "
+            f"path — the seam likely returned a PersistentClient under "
+            f"daemon mode, racing the daemon writer."
         )
 
     def test_make_t3_list_collections_via_daemon(
@@ -169,6 +178,52 @@ class TestTaxonomyMakeT3Seam:
         t3 = _make_t3()
         cols = t3.list_collections()
         assert isinstance(cols, list)
+
+
+class TestValidateRefsClickExceptionPassthrough:
+    def test_validate_refs_propagates_make_t3_click_exception(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """nexus-mmvf review S1: ``validate_refs`` historically caught
+        ``Exception`` from ``make_t3()`` (which raised RuntimeError /
+        OSError) and emitted its own "T3 unavailable" + exit 2. After
+        the mmvf flip ``_make_t3()`` raises ``ClickException`` on the
+        daemon-resolver failure path; the outer handler would
+        previously have swallowed it, defeating Click's normal
+        error-formatter (exit code 1 with the recovery hint). The
+        in-place fix re-raises ``ClickException`` ahead of the generic
+        ``Exception`` arm.
+
+        This test pins the contract: when ``_make_t3()`` raises
+        ``ClickException``, ``validate_refs`` must let Click handle
+        it (exit code 1, message echoed by Click's formatter) rather
+        than re-wrapping with exit code 2.
+        """
+        import click as _click
+        from nexus.commands import taxonomy_cmd as _tax
+
+        def _raise_click(*_a, **_kw):
+            raise _click.ClickException("synthetic daemon-resolver failure")
+
+        monkeypatch.setattr(_tax, "_make_t3", _raise_click)
+
+        # validate-refs requires a markdown file argument (PATHS is
+        # ``dir_okay=False``). _make_t3 fires inside the command body
+        # before we reach any scan; an empty stub file is enough for
+        # the Click arg-gate to pass.
+        stub = tmp_path / "stub.md"
+        stub.write_text("# stub\n")
+        result = runner.invoke(
+            main, ["taxonomy", "validate-refs", str(stub)],
+        )
+        # Click's default ClickException formatter exits with code 1
+        # and writes "Error: <message>" to stderr. The regression
+        # would have been exit code 2 ("T3 unavailable: ...").
+        assert result.exit_code == 1, result.output
+        assert "synthetic daemon-resolver failure" in result.output
 
 
 class TestTaxonomyCliReadPath:

--- a/tests/commands/test_taxonomy_daemon_mode.py
+++ b/tests/commands/test_taxonomy_daemon_mode.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 P4.3 (nexus-mmvf) — ``nx taxonomy`` CLI under
+``NX_STORAGE_MODE=daemon``.
+
+Five subcommands in ``commands/taxonomy_cmd.py`` call ``_make_t3()``
+(now daemon-aware via ``mcp_infra.get_t3``):
+
+* ``discover`` (line ~437)
+* ``rebuild`` (line ~545)
+* ``split`` (line ~770)
+* ``project`` (line ~1272)
+* ``validate-refs`` (line ~1726)
+
+All of them open a real T3 client; under daemon mode the seam routes
+through the HttpClient to the live daemon instead of opening a
+``PersistentClient`` racing the daemon on the on-disk path.
+
+We exercise the seam directly (``_make_t3()`` call) plus a CliRunner
+invocation of ``nx taxonomy list`` to confirm the broader command
+group registration + ``_t2_ctx`` path also resolves under daemon mode.
+``nx taxonomy list`` does not call ``_make_t3`` so it does not pin the
+flip; the direct seam call does that.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.daemon.t2_daemon import T2Daemon
+from nexus.db.t2 import T2Database
+
+
+# ── In-thread T2 daemon harness (matches the yfqv / uar6 pattern) ──────────
+
+
+def _run_daemon(daemon: T2Daemon) -> asyncio.AbstractEventLoop:
+    started = threading.Event()
+    loop = asyncio.new_event_loop()
+
+    def _thread() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(daemon.start())
+        started.set()
+        loop.run_forever()
+
+    t = threading.Thread(target=_thread, daemon=True)
+    t.start()
+    started.wait(timeout=5.0)
+    return loop
+
+
+def _stop_daemon(daemon: T2Daemon, loop: asyncio.AbstractEventLoop) -> None:
+    asyncio.run_coroutine_threadsafe(daemon.stop(), loop).result(timeout=5.0)
+    loop.call_soon_threadsafe(loop.stop)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def reset_t3_singleton():
+    import nexus.mcp_infra as infra
+    original_t3 = infra._t3_instance
+    original_collections = infra._collections_cache
+    infra._t3_instance = None
+    infra._collections_cache = ([], 0.0)
+    yield
+    infra._t3_instance = original_t3
+    infra._collections_cache = original_collections
+
+
+@pytest.fixture
+def t2db(tmp_path: Path) -> T2Database:
+    db = T2Database(tmp_path / "memory.db")
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    cd = tmp_path / "nexus_config"
+    cd.mkdir()
+    return cd
+
+
+@pytest.fixture
+def local_path(tmp_path: Path) -> Path:
+    p = tmp_path / "chroma_t3"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def daemon_env(monkeypatch, config_dir: Path):
+    monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+    monkeypatch.setenv("NX_LOCAL", "1")
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
+
+
+@pytest.fixture
+def live_t2_daemon(t2db: T2Database, config_dir: Path, daemon_env):
+    daemon = T2Daemon(config_dir, t2db=t2db)
+    loop = _run_daemon(daemon)
+    try:
+        yield daemon
+    finally:
+        _stop_daemon(daemon, loop)
+
+
+@pytest.fixture
+def live_t3_daemon(daemon_env, config_dir: Path, local_path: Path):
+    from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+
+    payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+    try:
+        yield payload
+    finally:
+        stop_t3_daemon(config_dir=config_dir)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+
+class TestTaxonomyMakeT3Seam:
+    def test_make_t3_resolves_to_daemon_under_daemon_mode(
+        self,
+        live_t3_daemon,
+        reset_t3_singleton,
+    ) -> None:
+        """``_make_t3()`` is the single seam every taxonomy T3 caller
+        consumes. Under daemon mode it must return a ``T3Database``
+        whose underlying client is the daemon's ``HttpClient``, not a
+        ``PersistentClient`` racing the on-disk store.
+
+        We assert on the client class name rather than identity so the
+        test stays valid if chromadb's internal class is wrapped in
+        future versions."""
+        from nexus.commands.taxonomy_cmd import _make_t3
+        t3 = _make_t3()
+        client_cls_name = type(t3._client).__name__
+        # HttpClient is what ``make_t3_client`` returns under daemon
+        # mode; a PersistentClient would indicate the flip did not
+        # take effect.
+        assert "Http" in client_cls_name or "Client" in client_cls_name, (
+            f"expected an HTTP-style client under daemon mode, got "
+            f"{type(t3._client).__module__}.{client_cls_name}"
+        )
+
+    def test_make_t3_list_collections_via_daemon(
+        self,
+        live_t3_daemon,
+        reset_t3_singleton,
+    ) -> None:
+        """End-to-end smoke: the helper's return value works for the
+        canonical ``t3.list_collections()`` call that every taxonomy
+        subcommand starts from. Empty list is the correct answer
+        against a fresh daemon."""
+        from nexus.commands.taxonomy_cmd import _make_t3
+        t3 = _make_t3()
+        cols = t3.list_collections()
+        assert isinstance(cols, list)
+
+
+class TestTaxonomyCliReadPath:
+    def test_taxonomy_list_under_daemon(
+        self,
+        runner: CliRunner,
+        live_t2_daemon,
+        live_t3_daemon,
+        reset_t3_singleton,
+    ) -> None:
+        """``nx taxonomy list`` reads from T2 via ``_t2_ctx`` (already
+        daemon-aware). The taxonomy table is empty against a fresh
+        daemon so the subcommand reports the empty state. This
+        contract-pins the CLI registration + T2 routing under daemon
+        mode; the T3 routing (``_make_t3``) is covered by the seam
+        tests above."""
+        result = runner.invoke(
+            main, ["taxonomy", "list", "--collection", "code__mmvf-not-real"],
+        )
+        assert result.exit_code == 0, result.output
+        # Empty taxonomy: the "no topics" hint surfaces with the
+        # ``nx taxonomy discover`` remediation pointer.
+        assert "no topics" in result.output.lower(), result.output

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -2864,7 +2864,7 @@ class TestManualOpsCLI:
                 return_value=db_path,
             ),
             patch(
-                "nexus.db.make_t3",
+                "nexus.mcp_infra.get_t3",
                 return_value=mock_t3,
             ),
             patch(
@@ -2917,7 +2917,7 @@ class TestManualOpsCLI:
                 "nexus.commands.taxonomy_cmd._default_db_path",
                 return_value=db_path,
             ),
-            patch("nexus.db.make_t3", return_value=mock_t3),
+            patch("nexus.mcp_infra.get_t3", return_value=mock_t3),
             patch(
                 "nexus.db.t2.catalog_taxonomy.CatalogTaxonomy.split_topic",
                 MagicMock(return_value=3),
@@ -2952,7 +2952,7 @@ class TestManualOpsCLI:
                 "nexus.commands.taxonomy_cmd._default_db_path",
                 return_value=db_path,
             ),
-            patch("nexus.db.make_t3", return_value=MagicMock()),
+            patch("nexus.mcp_infra.get_t3", return_value=MagicMock()),
             patch(
                 "nexus.db.t2.catalog_taxonomy.CatalogTaxonomy.split_topic",
                 MagicMock(return_value=0),
@@ -3867,7 +3867,7 @@ class TestProjectCmd:
         with (
             patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=tmp_path / "memory.db"),
             patch("nexus.commands.taxonomy_cmd._t2_ctx", return_value=db),
-            patch("nexus.db.make_t3") as mock_t3,
+            patch("nexus.mcp_infra.get_t3") as mock_t3,
         ):
             mock_t3.return_value._client = chroma_client
             result = runner.invoke(taxonomy, [
@@ -3911,7 +3911,7 @@ class TestProjectCmd:
         with (
             patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=tmp_path / "memory.db"),
             patch("nexus.commands.taxonomy_cmd._t2_ctx", return_value=db),
-            patch("nexus.db.make_t3") as mock_t3,
+            patch("nexus.mcp_infra.get_t3") as mock_t3,
         ):
             mock_t3.return_value._client = chroma_client
             result = runner.invoke(taxonomy, [
@@ -3973,7 +3973,7 @@ class TestProjectCmd:
             patch("nexus.commands.taxonomy_cmd._default_db_path",
                   return_value=tmp_path / "db.sqlite"),
             patch("nexus.commands.taxonomy_cmd._t2_ctx", return_value=db),
-            patch("nexus.db.make_t3") as mock_t3,
+            patch("nexus.mcp_infra.get_t3") as mock_t3,
         ):
             mock_t3.return_value._client = chroma_client
             result = runner.invoke(taxonomy, ["project", src, "--threshold", "0.5"])


### PR DESCRIPTION
## Summary

Phase 4.3 of RDR-112. ``nx taxonomy`` and ``nx doc`` now route every T3 access through ``mcp_infra.get_t3`` so daemon mode hits the live daemon's HttpClient instead of opening a PersistentClient that races the daemon writer. T2 side already daemon-aware (both modules used ``mcp_infra.t2_ctx``).

## Commits

1. **fb61ce07** ``nexus-mmvf`` — The flip. New ``_make_t3()`` helper in ``taxonomy_cmd.py`` (sibling to ``_t2_ctx``); 5 callers wired through it (discover, rebuild, split, project, validate-refs). The single T3 site in ``doc.py:_phase4_catalog_t3_chash`` inlined with try/except. 6 mock targets in ``test_taxonomy.py`` swapped from ``nexus.db.make_t3`` to ``nexus.mcp_infra.get_t3``.

2. **f33ed6c4** Review remediation. S1 (Significant) + 2 Minors fixed in-place; I1 (cloud-credential gate parity) deferred as ``nexus-ar01``.

## S1 — what the review caught

``taxonomy_cmd.py:validate_refs`` wraps ``_make_t3()`` in ``try/except Exception``. Pre-flip ``make_t3()`` raised ``RuntimeError`` / ``OSError`` which the handler echoed as exit-code-2 ("T3 unavailable"). Post-flip ``_make_t3()`` raises ``ClickException`` for daemon-resolver failure; the outer ``except Exception`` swallowed it, defeating Click's normal error formatter (exit 1 with the recovery hint). Fix: re-raise ``ClickException`` before the generic ``Exception`` arm. Added a CliRunner regression test that stubs ``_make_t3`` to raise ``ClickException`` and asserts exit_code 1, which would have failed against the pre-fix code path.

## Minors fixed in-place

- Client-class assertion in daemon tests was vacuous (chromadb factories both return ``Client`` instances). Replaced with a discriminator on the client's ``_identifier`` attribute (``host:port`` vs filesystem path).
- The CliRunner regression test for S1 doubles as the end-to-end coverage gap fix.

## Filed follow-up

``nexus-ar01`` (P3) — factor the cloud-credential gate into a shared ``commands/_helpers.py`` helper so the four ``_make_t3`` helpers (idqd, yfqv, uar6, mmvf inline) stop drifting.

## Test plan

- [x] ``uv run pytest tests/commands/test_taxonomy_daemon_mode.py tests/commands/test_doc_daemon_mode.py`` — 5/5 pass (seam direct + S1 regression + CLI smoke + doc factory)
- [x] ``uv run pytest tests/test_taxonomy.py tests/test_phase4_doc_commands.py tests/test_phase5_doc_cite.py`` — 153/153 pass post mock-swap
- [x] ``uv run pytest tests/commands/`` (wider sweep) — 663/663 pass
- [ ] Full suite confirmation run in flight against the remediation commit — baseline target 9058+ passed, 0 failed

## Closes

Closes nexus-mmvf