### PR TITLE
fix(aspect_worker): respect NEXUS_CONFIG_DIR for locks directory

### DIFF
--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -66,6 +66,7 @@ from nexus.aspect_extractor import (
     extract_aspects as _extract_aspects,
     extract_aspects_batch as _extract_aspects_batch,
 )
+from nexus.config import nexus_config_dir
 
 _log = structlog.get_logger(__name__)
 
@@ -109,7 +110,8 @@ class DrainBlockedByActiveWorker(RuntimeError):
          ``nx upgrade``).
 
     SIG-5 (nexus-1091): lock-file path is
-    ``~/.config/nexus/locks/aspect_worker.<pid>``.
+    ``<nexus_config_dir>/locks/aspect_worker.<pid>`` — respects
+    ``NEXUS_CONFIG_DIR``; defaults to ``~/.config/nexus/locks``.
     """
 
     def __init__(self, blocking_pid: int, lock_file: Path) -> None:
@@ -515,7 +517,7 @@ def _worker_lock_path(locks_dir: Path | None = None) -> Path:
     import os
 
     base = locks_dir if locks_dir is not None else (
-        Path.home() / ".config" / "nexus" / "locks"
+        nexus_config_dir() / "locks"
     )
     return base / f"aspect_worker.{os.getpid()}"
 
@@ -711,7 +713,8 @@ def drain_worker(
         poll_interval: Seconds between is_drained() checks (default 0.1).
         _locks_dir: Override the locks directory for testing.  Production
             code should leave this as None (resolved to
-            ``~/.config/nexus/locks``).
+            ``nexus_config_dir() / "locks"`` — respects
+            ``NEXUS_CONFIG_DIR``).
 
     Raises:
         DrainBlockedByActiveWorker: An active MCP-process worker was
@@ -734,7 +737,7 @@ def drain_worker(
     # queue independently; the migration must not run while that worker is
     # alive or it will race against in_progress rows it cannot see.
     locks_dir = _locks_dir if _locks_dir is not None else (
-        Path.home() / ".config" / "nexus" / "locks"
+        nexus_config_dir() / "locks"
     )
     _check_mcp_worker_lock(locks_dir)
 


### PR DESCRIPTION
## Summary

Fixes the pre-existing failure in \`tests/test_rdr108_lh8c_migration_plumbing.py::TestK2DrainCLI::test_aspects_drain_empty_queue_exits_0\`.

## Root cause

\`src/nexus/aspect_worker.py\` resolved the locks directory by hardcoding \`Path.home() / \".config\" / \"nexus\" / \"locks\"\` at two sites (lines 518 and 737), ignoring \`NEXUS_CONFIG_DIR\`. The failing test set \`NEXUS_CONFIG_DIR=tmp_path\` — which correctly steered \`default_db_path()\` — but \`drain_worker\`'s pre-flight \`_check_mcp_worker_lock\` still scanned the real \`~/.config/nexus/locks/\`. Any live \`aspect_worker.<pid>\` lock left by a real (non-test) process triggered \`DrainBlockedByActiveWorker\` and the CLI exited 1.

## Fix

Both sites now use \`nexus_config_dir() / \"locks\"\` — the same pattern \`src/nexus/indexer.py:187\` already uses for the per-repo locks.

- \`NEXUS_CONFIG_DIR\` unset: behaviour identical to before (\`~/.config/nexus/locks\`).
- \`NEXUS_CONFIG_DIR\` set: locks dir follows the rest of the config footprint (tests, sandboxes, multi-profile installs).

Total change: +7 / -4 lines in \`src/nexus/aspect_worker.py\`.

## Verification

- \`uv run pytest\` on this branch: **7280 passed**, 34 skipped, 114 deselected, **0 failed** (vs. main baseline 7279 passed + 1 failed).
- \`tests/test_rdr108_lh8c_migration_plumbing.py::TestK2DrainCLI\` — 3/3 pass.
- 124 adjacent aspect-related tests (\`test_aspect_worker\`, \`test_enrich_aspects\`, \`test_document_aspects_*\`, etc.) — all pass.
- \`test_aspect_drain_protocol.py\` unaffected — it passes \`_locks_dir=\` explicitly; the override path takes precedence over the default lookup.