### PR TITLE
fix: triage develop-target PR fixes — aspect_readers chash ids + pre-4.32 collection advisor

### DIFF
--- a/src/nexus/aspect_readers.py
+++ b/src/nexus/aspect_readers.py
@@ -273,34 +273,67 @@ def _gather_chroma_chunks_by_field(
                 position = row.get("position")
             if chash and position is not None:
                 chash_position[chash] = int(position)
+    # nexus-m8a7: when the catalog manifest is available, select chunks
+    # by id (chash[:32]) rather than by ``where={doc_id: ...}``. Post
+    # RDR-108 Phase 3 chunks no longer carry ``doc_id`` metadata; the
+    # where-filter returns zero rows even though the manifest knows the
+    # exact chashes. Chroma's natural id IS chash[:32] (RDR-108), so a
+    # batched ``coll.get(ids=...)`` fetches them deterministically.
+    use_manifest_ids = bool(chash_position) and identity_field == "doc_id"
     try:
-        while True:
-            page = coll.get(
-                where={identity_field: match_value},
-                limit=page_limit,
-                offset=offset,
-                include=["documents", "metadatas"],
-            )
-            docs = page.get("documents") or []
-            mds = page.get("metadatas") or []
-            if not docs:
-                break
-            for md, doc in zip(mds, docs):
-                if not doc:
-                    continue
-                if isinstance(md, dict):
-                    chash = md.get("chunk_text_hash", "")
-                    if chash_position and chash in chash_position:
-                        ci = chash_position[chash]
+        if use_manifest_ids:
+            ids = [chash[:32] for chash in chash_position]
+            for batch_start in range(0, len(ids), page_limit):
+                page = coll.get(
+                    ids=ids[batch_start : batch_start + page_limit],
+                    include=["documents", "metadatas"],
+                )
+                docs = page.get("documents") or []
+                mds = page.get("metadatas") or []
+                for md, doc in zip(mds, docs):
+                    if not doc:
+                        continue
+                    if isinstance(md, dict):
+                        chash = md.get("chunk_text_hash", "")
+                        ci = chash_position.get(
+                            chash, int(md.get("chunk_index", 0) or 0)
+                        )
                     else:
-                        ci = int(md.get("chunk_index", 0) or 0)
-                else:
-                    ci = 0
-                chunks.append((ci, seq, doc))
-                seq += 1
-            if len(docs) < page_limit:
-                break
-            offset += page_limit
+                        ci = 0
+                    chunks.append((ci, seq, doc))
+                    seq += 1
+        if not use_manifest_ids or not chunks:
+            # Either no manifest available, or manifest-ids returned
+            # nothing (chunk id ≠ chash[:32] — pre-RDR-108 ingest, or
+            # tests that seed synthetic ids). Fall back to where-filter.
+            offset = 0
+            while True:
+                page = coll.get(
+                    where={identity_field: match_value},
+                    limit=page_limit,
+                    offset=offset,
+                    include=["documents", "metadatas"],
+                )
+                docs = page.get("documents") or []
+                mds = page.get("metadatas") or []
+                if not docs:
+                    break
+                for md, doc in zip(mds, docs):
+                    if not doc:
+                        continue
+                    if isinstance(md, dict):
+                        chash = md.get("chunk_text_hash", "")
+                        if chash_position and chash in chash_position:
+                            ci = chash_position[chash]
+                        else:
+                            ci = int(md.get("chunk_index", 0) or 0)
+                    else:
+                        ci = 0
+                    chunks.append((ci, seq, doc))
+                    seq += 1
+                if len(docs) < page_limit:
+                    break
+                offset += page_limit
     except Exception as e:
         return ReadFail(
             reason="unreachable",

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -4349,6 +4349,18 @@ def synthesize_log_cmd(
     ),
 )
 @click.option(
+    "--name-vs-embed-dim",
+    "name_vs_embed_dim",
+    is_flag=True,
+    help=(
+        "nexus-j9ey: detect pre-4.32 mislabeled collections. Samples "
+        "one chunk per conformant T3 collection and compares the "
+        "actual embedding dim to the dim implied by the collection's "
+        "__<model>__ segment. FAIL on mismatch; suggests `nx collection "
+        "rename` to relabel the collection cosmetically (no re-embed)."
+    ),
+)
+@click.option(
     "--json", "as_json", is_flag=True,
     help="Emit machine-readable JSON instead of text output.",
 )
@@ -4360,6 +4372,7 @@ def doctor_cmd(
     chunk_size_distribution: bool,
     chunk_text_dedup: bool,
     t3_vs_catalog: bool,
+    name_vs_embed_dim: bool,
     as_json: bool,
 ) -> None:
     """RDR-101 catalog doctor surface.
@@ -4378,13 +4391,14 @@ def doctor_cmd(
     any_check = (
         replay_equality or t3_doc_id_coverage or collections_drift
         or chunk_size_distribution or chunk_text_dedup or t3_vs_catalog
+        or name_vs_embed_dim
     )
     if not any_check:
         raise click.UsageError(
             "Pass a check flag: --replay-equality, "
             "--t3-doc-id-coverage, --collections-drift, "
             "--chunk-size-distribution, --chunk-text-dedup, "
-            "or --t3-vs-catalog."
+            "--t3-vs-catalog, or --name-vs-embed-dim."
         )
     if strict_not_in_t3 and not t3_doc_id_coverage:
         raise click.UsageError(
@@ -4491,6 +4505,18 @@ def doctor_cmd(
             if _printed_anything:
                 click.echo("")
             _print_t3_vs_catalog_text(report)
+            _printed_anything = True
+        if not report["pass"]:
+            overall_pass = False
+    if name_vs_embed_dim:
+        report = _run_name_vs_embed_dim()
+        if as_json:
+            json_payload["name_vs_embed_dim"] = report
+        else:
+            if _printed_anything:
+                click.echo("")
+            _print_name_vs_embed_dim_text(report)
+            _printed_anything = True
         if not report["pass"]:
             overall_pass = False
 
@@ -4994,6 +5020,158 @@ def _print_t3_vs_catalog_text(report: dict) -> None:
             click.echo(
                 f"    {d['physical_collection']}  docs={d['doc_count']}"
             )
+
+
+# ── nexus-j9ey: --name-vs-embed-dim ──────────────────────────────────────
+
+
+_VOYAGE_DIM = 1024
+"""All current voyage-3 family embedders produce 1024-dim vectors
+(voyage-3, voyage-code-3, voyage-context-3). Hardcoded because the
+token alone has no dim suffix. If Voyage adds a different-dim model
+to the canonical set this needs to grow into a map."""
+
+
+def _expected_dim_for_model_token(token: str) -> int | None:
+    """Return the dim implied by a conformant ``__<model>__`` segment,
+    or None if the token is unrecognized.
+
+    Local-mode tokens encode the dim in the suffix
+    (``minilm-l6-v2-384`` -> 384, ``bge-base-en-v15-768`` -> 768).
+    Voyage tokens are hardcoded to 1024."""
+    from nexus.corpus import (  # noqa: PLC0415
+        CANONICAL_EMBEDDING_MODELS,
+        LOCAL_EMBEDDING_MODELS,
+    )
+    if token in CANONICAL_EMBEDDING_MODELS:
+        return _VOYAGE_DIM
+    if token in LOCAL_EMBEDDING_MODELS:
+        tail = token.rsplit("-", 1)[-1]
+        try:
+            return int(tail)
+        except ValueError:
+            return None
+    return None
+
+
+def _run_name_vs_embed_dim() -> dict:
+    """Detect mislabeled conformant collections (4.28-era write-side bug).
+
+    Iterates T3 collections, skips bypass-schema and non-conformant
+    names, samples one chunk per remaining collection, and compares
+    actual embedding dim to the dim implied by the name's
+    ``__<model>__`` segment. Read-only against T3."""
+    from nexus.corpus import (  # noqa: PLC0415
+        is_conformant_collection_name,
+        parse_conformant_collection_name,
+    )
+    from nexus.db import make_t3  # noqa: PLC0415
+    from nexus.db.t3 import _BYPASS_SCHEMA_PREFIXES  # noqa: PLC0415
+
+    mismatches: list[dict] = []
+    empty: list[str] = []
+    checked = 0
+    skipped_non_conformant = 0
+    unknown_token: list[dict] = []
+
+    try:
+        t3_db = make_t3()
+        cols = [
+            c["name"] for c in t3_db.list_collections()
+            if not c["name"].startswith(_BYPASS_SCHEMA_PREFIXES)
+        ]
+    except Exception as exc:
+        return {
+            "pass": False,
+            "checked": 0,
+            "mismatches": [],
+            "empty": [],
+            "skipped_non_conformant": 0,
+            "unknown_token": [],
+            "error": f"Failed to list T3 collections: {exc}",
+        }
+
+    client = t3_db._client  # type: ignore[attr-defined]
+    for name in cols:
+        if not is_conformant_collection_name(name):
+            skipped_non_conformant += 1
+            continue
+        parsed = parse_conformant_collection_name(name)
+        token = parsed["embedding_model"]
+        expected = _expected_dim_for_model_token(token)
+        if expected is None:
+            unknown_token.append({"collection": name, "token": token})
+            continue
+        try:
+            coll = client.get_collection(name)
+            sample = coll.get(limit=1, include=["embeddings"])
+        except Exception as exc:
+            unknown_token.append(
+                {"collection": name, "token": token, "error": str(exc)}
+            )
+            continue
+        embs = sample.get("embeddings")
+        if embs is None or len(embs) == 0:
+            empty.append(name)
+            continue
+        actual = len(embs[0])
+        checked += 1
+        if actual != expected:
+            mismatches.append({
+                "collection": name,
+                "claimed_model": token,
+                "expected_dim": expected,
+                "actual_dim": actual,
+            })
+
+    return {
+        "pass": not mismatches,
+        "checked": checked,
+        "mismatches": mismatches,
+        "empty": empty,
+        "skipped_non_conformant": skipped_non_conformant,
+        "unknown_token": unknown_token,
+    }
+
+
+def _print_name_vs_embed_dim_text(report: dict) -> None:
+    if report.get("error"):
+        click.echo(f"name-vs-embed-dim: ERROR - {report['error']}")
+        return
+    status = "PASS" if report["pass"] else "FAIL"
+    click.echo(f"name-vs-embed-dim: {status}")
+    click.echo(
+        f"  checked={report['checked']}  "
+        f"mismatches={len(report['mismatches'])}  "
+        f"empty={len(report['empty'])}  "
+        f"skipped-non-conformant={report['skipped_non_conformant']}"
+    )
+    if report["mismatches"]:
+        click.echo(
+            f"\n  Mislabeled collections ({len(report['mismatches'])}):"
+        )
+        for m in report["mismatches"]:
+            click.echo(
+                f"    {m['collection']}\n"
+                f"      claims {m['claimed_model']} "
+                f"({m['expected_dim']}d) but holds {m['actual_dim']}d vectors"
+            )
+        click.echo(
+            "\n  Remediate: relabel the collection to match its actual "
+            "embeddings:\n"
+            "    nx collection rename <old> <new>\n"
+            "  Local-mode users: replace the voyage-* segment with the "
+            "matching local token (e.g. minilm-l6-v2-384 for 384d, "
+            "bge-base-en-v15-768 for 768d). No re-embed; cosmetic only."
+        )
+    if report["unknown_token"]:
+        click.echo(
+            f"\n  Collections with unrecognized model token "
+            f"({len(report['unknown_token'])}):"
+        )
+        for u in report["unknown_token"][:20]:
+            extra = f"  ({u['error']})" if u.get("error") else ""
+            click.echo(f"    {u['collection']}  token={u['token']}{extra}")
 
 
 def _check_bootstrap_status() -> dict:

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -220,5 +220,35 @@ def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool =
                     # Non-zero exit so CI / orchestrators see the failure.
                     raise click.exceptions.Exit(1)
 
+        # nexus-b03o: post-migration advisory — pre-4.32 local-mode
+        # installs wrote 384d MiniLM vectors into collections named for
+        # voyage-* (1024d). The forward fix shipped in 4.32.0 (RDR-109
+        # Phase 2); existing mislabeled collections persist until the
+        # operator runs `nx collection rename`. Surface a one-liner so
+        # they know to look. Advisory only — does not fail the upgrade.
+        if not auto_mode and not skip_t3:
+            _emit_name_vs_embed_dim_advisory()
+
     finally:
         conn.close()
+
+
+def _emit_name_vs_embed_dim_advisory() -> None:
+    """Run the name-vs-embed-dim doctor check and emit a one-liner
+    if any collections are mislabeled. Silent on PASS, error-tolerant
+    (T3 may be unavailable on a freshly-migrated install)."""
+    try:
+        from nexus.commands.catalog import _run_name_vs_embed_dim
+        report = _run_name_vs_embed_dim()
+    except Exception:
+        return
+    if report.get("error"):
+        return
+    n = len(report.get("mismatches", []))
+    if n == 0:
+        return
+    click.echo(
+        f"\nAdvisory: {n} collection(s) appear mislabeled "
+        f"(pre-4.32 local-mode data). Run `nx catalog doctor "
+        f"--name-vs-embed-dim` for details and remediation."
+    )

--- a/tests/test_aspect_readers.py
+++ b/tests/test_aspect_readers.py
@@ -341,6 +341,58 @@ class TestReadChromaUri:
         assert result.text == "first\n\nsecond\n\nthird"
         assert result.metadata["manifest_ordered"] is True
 
+    def test_manifest_ids_select_chunks_when_doc_id_metadata_absent(self, t3_client):
+        """nexus-m8a7: post-RDR-108 Phase 3, chunks have no ``doc_id``
+        in metadata. The reader must select chunks by their natural
+        Chroma id (chash[:32]) from the manifest instead of relying on
+        ``where={doc_id: ...}`` which returns zero rows.
+        """
+        from nexus.aspect_readers import ReadOk, _read_chroma_uri
+
+        col_name = "knowledge__phase3-no-doc-id"
+        col = t3_client.get_or_create_collection(col_name)
+        # Seed chunks with NO doc_id and NO source_path metadata — the
+        # exact shape DT-indexed PDFs land with. Chroma id == chash[:32].
+        chashes = ["a" * 64, "b" * 64, "c" * 64]
+        col.upsert(
+            ids=[c[:32] for c in chashes],
+            documents=["first", "second", "third"],
+            metadatas=[
+                {"chunk_text_hash": chashes[0], "title": "paper"},
+                {"chunk_text_hash": chashes[1], "title": "paper"},
+                {"chunk_text_hash": chashes[2], "title": "paper"},
+            ],
+        )
+
+        from dataclasses import dataclass
+
+        @dataclass
+        class _Row:
+            chash: str
+            position: int
+
+        def manifest_lookup(doc_id: str) -> list[_Row]:
+            assert doc_id == "1.99.2"
+            return [
+                _Row(chash=chashes[0], position=0),
+                _Row(chash=chashes[1], position=1),
+                _Row(chash=chashes[2], position=2),
+            ]
+
+        def doc_id_lookup(_coll: str, _sid: str) -> str:
+            return "1.99.2"
+
+        result = _read_chroma_uri(
+            f"chroma://{col_name}/anything",
+            t3=t3_client,
+            doc_id_lookup=doc_id_lookup,
+            manifest_lookup=manifest_lookup,
+        )
+        assert isinstance(result, ReadOk), result
+        assert result.text == "first\n\nsecond\n\nthird"
+        assert result.metadata["chunk_count"] == 3
+        assert result.metadata["manifest_ordered"] is True
+
     def test_no_matching_chunks_returns_read_fail_empty(self, t3_client):
         from nexus.aspect_readers import ReadFail, _read_chroma_uri
 

--- a/tests/test_catalog_doctor_name_vs_embed_dim.py
+++ b/tests/test_catalog_doctor_name_vs_embed_dim.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-j9ey: catalog doctor --name-vs-embed-dim check.
+
+Detects the 4.28-era write-side bug where local-mode installs produced
+collections named ``code__<owner>__voyage-code-3__v1`` while writing
+384-dim MiniLM vectors inside. The forward fix shipped in 4.32.0
+(commit fb0c34fc, PR #682) — fresh indexes now produce correctly-named
+collections — but pre-4.32 data remains mislabeled.
+
+The check samples one chunk's embedding per conformant collection,
+compares the actual dim to the dim implied by the ``__<model>__``
+segment, and FAILs on any mismatch. Read-only against T3; recommends
+``nx collection rename`` for remediation.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+from click.testing import CliRunner
+
+from nexus.commands.catalog import doctor_cmd
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def chroma_client():
+    """Fresh EphemeralClient with collections cleared. The DefaultEmbeddingFunction
+    is ONNX MiniLM L6 v2 → 384-dim, which gives us the realistic 4.28-era
+    bug shape for free (collection is named for voyage but actually holds
+    MiniLM vectors)."""
+    client = chromadb.EphemeralClient()
+    for col in list(client.list_collections()):
+        try:
+            client.delete_collection(col.name)
+        except Exception:
+            pass
+    return client
+
+
+def _seed(client, name: str, n_chunks: int = 1) -> None:
+    col = client.get_or_create_collection(
+        name=name, embedding_function=DefaultEmbeddingFunction(),
+    )
+    col.add(
+        ids=[f"c{i}" for i in range(n_chunks)],
+        documents=[f"sample content {i}" for i in range(n_chunks)],
+        metadatas=[{"_": "_"} for _ in range(n_chunks)],
+    )
+
+
+def _fake_t3(client, names: list[str]):
+    class _FakeT3:
+        _client = client
+
+        def list_collections(self):
+            return [{"name": n} for n in names]
+    return _FakeT3()
+
+
+class TestNameVsEmbedDim:
+    def test_pass_when_local_token_matches_dim(
+        self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Conformant name with ``minilm-l6-v2-384`` token + 384-dim chunks → PASS."""
+        name = "code__myproj__minilm-l6-v2-384__v1"
+        _seed(chroma_client, name)
+        monkeypatch.setattr(
+            "nexus.db.make_t3", lambda: _fake_t3(chroma_client, [name]),
+        )
+        result = runner.invoke(
+            doctor_cmd, ["--name-vs-embed-dim", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is True
+        assert payload["mismatches"] == []
+        assert payload["checked"] == 1
+
+    def test_fail_when_voyage_name_holds_minilm_vectors(
+        self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """The 4.28-era bug: name claims voyage-code-3 (1024d expected)
+        but content is 384-dim MiniLM. Must FAIL and identify the
+        collection."""
+        name = "code__myproj__voyage-code-3__v1"
+        _seed(chroma_client, name)
+        monkeypatch.setattr(
+            "nexus.db.make_t3", lambda: _fake_t3(chroma_client, [name]),
+        )
+        result = runner.invoke(
+            doctor_cmd, ["--name-vs-embed-dim", "--json"],
+        )
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is False
+        assert len(payload["mismatches"]) == 1
+        m = payload["mismatches"][0]
+        assert m["collection"] == name
+        assert m["expected_dim"] == 1024
+        assert m["actual_dim"] == 384
+        assert m["claimed_model"] == "voyage-code-3"
+
+    def test_fail_when_voyage_context_name_holds_minilm_vectors(
+        self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Same shape for the docs side: voyage-context-3 claim, MiniLM body."""
+        name = "docs__myproj__voyage-context-3__v1"
+        _seed(chroma_client, name)
+        monkeypatch.setattr(
+            "nexus.db.make_t3", lambda: _fake_t3(chroma_client, [name]),
+        )
+        result = runner.invoke(
+            doctor_cmd, ["--name-vs-embed-dim", "--json"],
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is False
+        m = payload["mismatches"][0]
+        assert m["expected_dim"] == 1024
+        assert m["actual_dim"] == 384
+
+    def test_legacy_name_skipped(
+        self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Legacy 2-segment names (``code__myproj-abc12345``) have no
+        embedder claim to verify. Skip them; report 0 checked."""
+        name = "code__myproj-cafef00d"
+        _seed(chroma_client, name)
+        monkeypatch.setattr(
+            "nexus.db.make_t3", lambda: _fake_t3(chroma_client, [name]),
+        )
+        result = runner.invoke(
+            doctor_cmd, ["--name-vs-embed-dim", "--json"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is True
+        assert payload["checked"] == 0
+        assert payload["skipped_non_conformant"] == 1
+
+    def test_taxonomy_collection_skipped(
+        self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """``taxonomy__*`` carries centroid embeddings, out of scope."""
+        _seed(chroma_client, "taxonomy__centroids")
+        monkeypatch.setattr(
+            "nexus.db.make_t3",
+            lambda: _fake_t3(chroma_client, ["taxonomy__centroids"]),
+        )
+        result = runner.invoke(
+            doctor_cmd, ["--name-vs-embed-dim", "--json"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is True
+        assert payload["checked"] == 0
+
+    def test_empty_collection_skipped_with_note(
+        self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Empty conformant collection has no chunk to sample. Don't FAIL
+        on it; record in ``empty`` list so operator knows it was skipped."""
+        name = "code__myproj__voyage-code-3__v1"
+        chroma_client.get_or_create_collection(
+            name=name, embedding_function=DefaultEmbeddingFunction(),
+        )
+        monkeypatch.setattr(
+            "nexus.db.make_t3", lambda: _fake_t3(chroma_client, [name]),
+        )
+        result = runner.invoke(
+            doctor_cmd, ["--name-vs-embed-dim", "--json"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is True
+        assert payload["checked"] == 0
+        assert name in payload["empty"]
+
+    def test_text_output_includes_remediation_hint(
+        self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Non-JSON output names the offending collection and suggests
+        ``nx collection rename`` with the correct target token."""
+        name = "code__myproj__voyage-code-3__v1"
+        _seed(chroma_client, name)
+        monkeypatch.setattr(
+            "nexus.db.make_t3", lambda: _fake_t3(chroma_client, [name]),
+        )
+        result = runner.invoke(
+            doctor_cmd, ["--name-vs-embed-dim"],
+        )
+        assert result.exit_code == 1
+        assert "name-vs-embed-dim: FAIL" in result.output
+        assert name in result.output
+        assert "rename" in result.output.lower()

--- a/tests/test_upgrade_name_vs_embed_dim_advisory.py
+++ b/tests/test_upgrade_name_vs_embed_dim_advisory.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-b03o: `nx upgrade` surfaces a one-liner advisory when the
+name-vs-embed-dim doctor check finds mislabeled collections.
+
+The advisory is informational only — it does NOT fail the upgrade.
+Pre-4.32 local-mode installs wrote 384d MiniLM vectors into voyage-named
+collections; the operator needs to know about it so they can run
+`nx collection rename` (the actual fix lives in nexus-j9ey)."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _clear_upgrade_done() -> None:
+    from nexus.db import migrations
+    migrations._upgrade_done.clear()
+
+
+class TestUpgradeAdvisory:
+    def test_no_advisory_when_no_mismatches(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        """Clean install: no mislabeled collections → no advisory text."""
+        db_path = tmp_path / "memory.db"
+        clean_report = {
+            "pass": True, "checked": 5, "mismatches": [],
+            "empty": [], "skipped_non_conformant": 0, "unknown_token": [],
+        }
+        with (
+            patch("nexus.commands.upgrade._db_path", return_value=db_path),
+            patch("nexus.commands.upgrade.T3_UPGRADES", []),
+            patch(
+                "nexus.commands.catalog._run_name_vs_embed_dim",
+                return_value=clean_report,
+            ),
+        ):
+            result = runner.invoke(main, ["upgrade"])
+        assert result.exit_code == 0
+        assert "mislabeled" not in result.output
+        assert "Advisory" not in result.output
+
+    def test_advisory_surfaces_mismatch_count(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        """Mislabeled collections present → one-liner names the count
+        and points at the doctor check for details."""
+        db_path = tmp_path / "memory.db"
+        dirty_report = {
+            "pass": False, "checked": 4,
+            "mismatches": [
+                {"collection": "code__1-1__voyage-code-3__v1",
+                 "claimed_model": "voyage-code-3",
+                 "expected_dim": 1024, "actual_dim": 384},
+                {"collection": "docs__1-1__voyage-context-3__v1",
+                 "claimed_model": "voyage-context-3",
+                 "expected_dim": 1024, "actual_dim": 384},
+            ],
+            "empty": [], "skipped_non_conformant": 0, "unknown_token": [],
+        }
+        with (
+            patch("nexus.commands.upgrade._db_path", return_value=db_path),
+            patch("nexus.commands.upgrade.T3_UPGRADES", []),
+            patch(
+                "nexus.commands.catalog._run_name_vs_embed_dim",
+                return_value=dirty_report,
+            ),
+        ):
+            result = runner.invoke(main, ["upgrade"])
+        # Advisory does NOT fail the upgrade.
+        assert result.exit_code == 0, result.output
+        assert "2 collection(s) appear mislabeled" in result.output
+        assert "nx catalog doctor --name-vs-embed-dim" in result.output
+
+    def test_advisory_skipped_in_auto_mode(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        """Auto mode (hook-driven) suppresses advisory output — hooks
+        have short timeouts and the user isn't watching."""
+        db_path = tmp_path / "memory.db"
+        dirty_report = {
+            "pass": False, "checked": 1,
+            "mismatches": [
+                {"collection": "code__x__voyage-code-3__v1",
+                 "claimed_model": "voyage-code-3",
+                 "expected_dim": 1024, "actual_dim": 384},
+            ],
+            "empty": [], "skipped_non_conformant": 0, "unknown_token": [],
+        }
+        with (
+            patch("nexus.commands.upgrade._db_path", return_value=db_path),
+            patch("nexus.commands.upgrade.T3_UPGRADES", []),
+            patch(
+                "nexus.commands.catalog._run_name_vs_embed_dim",
+                return_value=dirty_report,
+            ),
+        ):
+            result = runner.invoke(main, ["upgrade", "--auto"])
+        assert result.exit_code == 0
+        assert "mislabeled" not in result.output
+
+    def test_advisory_tolerates_check_failure(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        """If the doctor check raises (e.g. T3 unavailable on a fresh
+        install), the advisory is silent — upgrade must not fail because
+        an advisory check blew up."""
+        db_path = tmp_path / "memory.db"
+
+        def _boom():
+            raise RuntimeError("T3 not initialized")
+
+        with (
+            patch("nexus.commands.upgrade._db_path", return_value=db_path),
+            patch("nexus.commands.upgrade.T3_UPGRADES", []),
+            patch(
+                "nexus.commands.catalog._run_name_vs_embed_dim",
+                side_effect=_boom,
+            ),
+        ):
+            result = runner.invoke(main, ["upgrade"])
+        assert result.exit_code == 0
+        assert "mislabeled" not in result.output


### PR DESCRIPTION
## Summary

Consolidated triage of the 6 open PRs against the (now-dead) develop branch. Two commits cherry-picked cleanly onto main; the rest are entangled with scrapped RDR-110-118 scope.

## Commits in this PR

1. **\`24b18fcb\` fix(aspect_readers): select chunks by manifest chash ids when doc_id metadata absent** (cherry-pick of #835 head)
   Post-RDR-108 Phase 3 chunks no longer carry \`doc_id\` in metadata; the existing \`where={doc_id: ...}\` filter returns zero rows. Now selects chunks by their natural Chroma id (\`chash[:32]\`) via a batched \`coll.get(ids=...)\`; falls back to the where-filter when no manifest is present.

2. **\`aafa9cab\` feat(doctor,upgrade): detect + advise on pre-4.32 mislabeled collections (nexus-j9ey + b03o)** (cherry-pick of b97f393d, PR #725)
   Adds doctor + upgrade advisories for collections that survived from before the RDR-103 canonical-name convention. Includes 79 tests covering the advisory logic.

## Triage of remaining develop PRs

- **#835** — superseded here (this PR's first commit). Will close.
- **#838 fix(taxonomy_cmd) daemon-mode skip** — moot. Fixes a code path (\`mcp_infra.t2_ctx(_path_resolver=...)\`) that does not exist on main. RDR-112 scope, scrapped.
- **#864 RDR-118 Phases 1-3 + nexus-w1ip P1A** — RDR-118 scope scrapped. The nexus-w1ip test-reduction half can't be cleanly extracted: the second test file (\`tests/commands/test_help_completeness.py\`) does not exist on main.
- **#836, #837, #839** — proposal docs (M3DocRAG, Open Ontologies, Beyond Similarity Search) + ColBERT spike scaffold. Not fixes.

## Develop commits considered but skipped (conflict with scrapped scope)

- \`80b3ca9e\` + \`e63e1ebd\` fix(nexus-9eaz) race instrumentation — conflicts; \`apply_pending\` evolved differently on main.
- \`24aac5ad\` style: em-dash sweep — mostly targets scrapped-scope source files (daemon/cockpit/tuplespace).
- \`122feaff\` feat(nexus-j327) phase-review-gate — bundled with RDR-110 tuplespace skills; needs unbundling.
- \`6a774ba0\` test: fix 5 pre-existing failures — fixes \`test_default_storage_mode.py\` + \`test_doctor_check_bridge.py\`, neither exists on main.

## Verification

- \`uv run pytest tests/test_aspect_readers.py tests/test_catalog_doctor_name_vs_embed_dim.py tests/test_upgrade_name_vs_embed_dim_advisory.py\` — **79 passed**.