### PR TITLE
refactor(catalog): eliminate nexus.catalog._cached singleton (top-down DI)

### DIFF
--- a/src/nexus/catalog/__init__.py
+++ b/src/nexus/catalog/__init__.py
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-import threading
-from pathlib import Path
-
 from nexus.catalog.catalog import Catalog, CatalogEntry, CatalogLink
 from nexus.catalog.tumbler import (
     DocumentRecord,
@@ -19,59 +16,8 @@ __all__ = [
     "LinkRecord",
     "OwnerRecord",
     "Tumbler",
-    "open_cached",
-    "reset_cache",
     "resolve_tumbler",
 ]
-
-
-# Process-level Catalog cache (nexus-6xqk follow-up).
-# Helpers like ``doc_indexer._lookup_existing_doc_id`` and
-# ``commands/enrich._build_catalog_doc_id_lookup`` are read-mostly and
-# get called per-file during a force-reindex. Each ``Catalog(...)``
-# construction triggers ``_ensure_consistent`` which DELETE-and-rebuilds
-# from events.jsonl; multiple constructions per second contend on the
-# SQLite write lock and emit ``catalog_consistency_rebuild_failed`` storms.
-# A cached singleton per ``cat_path`` lets these helpers reuse one
-# Catalog instance instead of opening fresh ones.
-_cached: dict[Path, Catalog] = {}
-_cache_lock = threading.Lock()
-
-
-def open_cached(cat_path: Path) -> Catalog:
-    """Return a process-cached Catalog instance for *cat_path*.
-
-    Thread-safe; constructs once and reuses. Subsequent calls bypass the
-    expensive ``_ensure_consistent`` rebuild that fires on every fresh
-    construction. Read-only helpers (per-file doc_id lookups, frecency
-    map building, etc.) should use this instead of ``Catalog(path,
-    path / ".catalog.db")`` to avoid lock contention storms.
-
-    Callers that mutate the catalog should NOT use this accessor; they
-    need a fresh instance because the singleton may have stale internal
-    state (other writers in this process or peers). Mutators are rare;
-    the cache is the right default for read-side accessors.
-    """
-    cat_path = Path(cat_path)
-    inst = _cached.get(cat_path)
-    if inst is not None:
-        return inst
-    with _cache_lock:
-        inst = _cached.get(cat_path)
-        if inst is not None:
-            return inst
-        inst = Catalog(cat_path, cat_path / ".catalog.db")
-        _cached[cat_path] = inst
-        return inst
-
-
-def reset_cache() -> None:
-    """Drop the process-level Catalog cache. Used by tests + the doctor
-    rebuild path that wants a fresh consistency check after a known
-    catalog mutation in another process.
-    """
-    with _cache_lock:
-        _cached.clear()
 
 
 def resolve_tumbler(

--- a/src/nexus/collection_health.py
+++ b/src/nexus/collection_health.py
@@ -72,16 +72,13 @@ def _open_catalog():
     means the collection has no documents on record yet — health rows
     for such collections show zero chunks / no links / no orphans.
     """
-    from nexus.catalog import open_cached
     from nexus.catalog.catalog import Catalog
     from nexus.config import catalog_path
 
     path = catalog_path()
     if not Catalog.is_initialized(path):
         return None
-    # nexus-6xqk follow-up: read-only stats accessor uses the process
-    # singleton; called per-collection during health checks.
-    return open_cached(path)
+    return Catalog(path, path / ".catalog.db")
 
 
 def _default_catalog_stats_fn(col: str) -> dict[str, Any]:

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -22,16 +22,13 @@ def _doc_id_to_file_path(doc_id: str) -> str:
     returns "" and the caller treats the chunk as sourceless.
     """
     try:
-        from nexus.catalog import Catalog, open_cached
+        from nexus.catalog import Catalog
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
             return ""
-        # nexus-6xqk follow-up: process-cached singleton avoids the
-        # storm of _ensure_consistent rebuilds when this helper fires
-        # per-chunk on a large collection.
-        cat = open_cached(cat_path)
+        cat = Catalog(cat_path, cat_path / ".catalog.db")
         entry = cat.by_doc_id(doc_id)
         if entry is None:
             return ""

--- a/src/nexus/commands/doc.py
+++ b/src/nexus/commands/doc.py
@@ -546,14 +546,13 @@ def _phase4_catalog_t3_chash() -> tuple[Any, Any, Any]:
     T3 comes from ``nexus.db.make_t3``. ChashIndex opens the same T2
     path used by every other T2 store.
     """
-    from nexus.catalog import open_cached
+    from nexus.catalog import Catalog
     from nexus.db import make_t3
     from nexus.db.t2.chash_index import ChashIndex
 
     db_path = default_db_path()
     cat_path = db_path.parent / "catalog"
-    # nexus-6xqk follow-up: read-mostly catalog accessor for doc query.
-    cat: Any = open_cached(cat_path)
+    cat: Any = Catalog(cat_path, cat_path / ".catalog.db")
     t3: Any = make_t3()
     chash_index: Any = ChashIndex(db_path)
     return cat, t3, chash_index

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -496,9 +496,7 @@ def _resolve_dt_uri_from_tumbler(tumbler: str) -> str | None:
         raise click.ClickException(
             "Catalog not initialized. Run 'nx catalog setup' first.",
         )
-    # nexus-6xqk follow-up: read-only resolve uses the process cache.
-    from nexus.catalog import open_cached
-    cat = open_cached(path)
+    cat = Catalog(path, path / ".catalog.db")
     try:
         t, err = resolve_tumbler(cat, tumbler)
         if err:

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -35,13 +35,13 @@ def _build_catalog_manifest_lookup() -> Callable[[str], list[Any]] | None:
     insertion order, the pre-fix behaviour).
     """
     try:
-        from nexus.catalog import Catalog, open_cached
+        from nexus.catalog import Catalog
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
             return None
-        cat = open_cached(cat_path)
+        cat = Catalog(cat_path, cat_path / ".catalog.db")
     except Exception:
         return None
 
@@ -69,16 +69,13 @@ def _build_catalog_doc_id_lookup() -> Callable[[str, str], str] | None:
     lookups stay consistent across the Phase 4 prune.
     """
     try:
-        from nexus.catalog import Catalog, open_cached
+        from nexus.catalog import Catalog
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
             return None
-        # nexus-6xqk follow-up: process-cached Catalog so the closure
-        # this function returns reuses one instance across every
-        # call (per-entry during enrich-aspects on a large collection).
-        cat = open_cached(cat_path)
+        cat = Catalog(cat_path, cat_path / ".catalog.db")
     except Exception:
         return None
 

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -553,15 +553,13 @@ def rebuild_cmd(collection: str, project: str, k: int | None) -> None:
 def _resolve_doc_titles(doc_ids: list[str]) -> list[str]:
     """Resolve doc_ids to human-readable titles via catalog, fallback to raw ID."""
     try:
-        from nexus.catalog import open_cached
         from nexus.catalog.catalog import Catalog
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
             return doc_ids
-        # nexus-6xqk follow-up: process-cached read-only accessor.
-        cat = open_cached(cat_path)
+        cat = Catalog(cat_path, cat_path / ".catalog.db")
         titles: list[str] = []
         for doc_id in doc_ids:
             results = cat.search(doc_id)
@@ -785,15 +783,12 @@ def split_cmd(topic_label: str, k: int, collection: str) -> None:
 def _try_load_catalog() -> Any:
     """Load the catalog if initialized, else return None."""
     try:
-        from nexus.catalog import open_cached
         from nexus.catalog.catalog import Catalog
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
         if Catalog.is_initialized(cat_path):
-            # nexus-6xqk follow-up: shared accessor used by topic-link
-            # computation; cached so repeated calls don't rebuild.
-            return open_cached(cat_path)
+            return Catalog(cat_path, cat_path / ".catalog.db")
     except Exception:
         pass
     return None

--- a/src/nexus/db/t2/document_aspects.py
+++ b/src/nexus/db/t2/document_aspects.py
@@ -167,11 +167,11 @@ def _resolve_doc_id(record: AspectRecord) -> str:
     # primitives for FTS5 sanitisation), but the *behaviour* is no
     # longer reaching into Catalog internals.
     try:
-        from nexus.catalog import Catalog, open_cached
+        from nexus.catalog import Catalog
         from nexus.config import catalog_path
         cat_path = catalog_path()
         if Catalog.is_initialized(cat_path):
-            cat = open_cached(cat_path)
+            cat = Catalog(cat_path, cat_path / ".catalog.db")
             resolved = cat.lookup_doc_id_by_collection_and_path(
                 record.collection, record.source_path,
             )

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -12,9 +12,12 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import structlog
+
+if TYPE_CHECKING:
+    from nexus.catalog import Catalog
 
 _log = structlog.get_logger(__name__)
 
@@ -55,32 +58,26 @@ def _has_credentials() -> bool:
     return bool(get_credential("voyage_api_key") and get_credential("chroma_api_key"))
 
 
-def _lookup_existing_doc_id(file_path: str, corpus: str) -> str:
-    """nexus-dcym: pre-flight catalog lookup for an already-indexed file.
+def _lookup_existing_doc_id(
+    cat: "Catalog | None", file_path: str, corpus: str,
+) -> str:
+    """Pre-flight catalog lookup for an already-indexed file (nexus-dcym).
 
-    Returns the catalog ``doc_id`` (str) if a registration already exists
-    under the corpus's owner; empty string otherwise (catalog absent,
-    owner missing, or first-time registration). Best-effort: any failure
+    Returns the catalog ``doc_id`` if a registration exists under the
+    corpus's owner; empty string otherwise (catalog absent, owner
+    missing, or first-time registration). Best-effort: any failure
     silently returns "" so callers fall back to the legacy
     ``source_path``-keyed chunk lookup.
 
-    The pipeline registers PDFs in the catalog *after* the staleness
-    check, so on a fresh index this returns "" (no entry yet) and the
-    legacy lookup keeps working. On a re-index, the prior registration
-    is found and the chunk lookup keys on ``doc_id``.
+    Callers construct *cat* once and pass it in (RDR-120 DI substrate);
+    ``None`` indicates the catalog has not been initialised at this
+    location.
     """
+    if cat is None:
+        return ""
     try:
-        from nexus.catalog import Catalog, open_cached  # noqa: PLC0415
         from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
-        from nexus.config import catalog_path  # noqa: PLC0415
 
-        cat_path = catalog_path()
-        if not Catalog.is_initialized(cat_path):
-            return ""
-        # nexus-6xqk follow-up: use the process-cached Catalog so per-
-        # file lookups during a force-reindex don't storm the SQLite
-        # write lock with concurrent _ensure_consistent rebuilds.
-        cat = open_cached(cat_path)
         owner_name = corpus or "standalone-pdfs"
         # Curator-only lookup — see _register_or_lookup_doc_id for
         # rationale (repo and curator owners can share names; lookups
@@ -1300,10 +1297,18 @@ def index_pdf(
         # content-sourcing contract.
         # nexus-tdgc: forward the catalog doc_id (lookup is post-register
         # so the entry exists by this point in the incremental path).
-        from nexus.mcp_infra import fire_post_document_hooks
+        from nexus.catalog import Catalog  # noqa: PLC0415
+        from nexus.config import catalog_path  # noqa: PLC0415
+        from nexus.mcp_infra import fire_post_document_hooks  # noqa: PLC0415
+        _cat_path = catalog_path()
+        _cat = (
+            Catalog(_cat_path, _cat_path / ".catalog.db")
+            if Catalog.is_initialized(_cat_path)
+            else None
+        )
         fire_post_document_hooks(
             str(pdf_path), col_name, "",
-            doc_id=_lookup_existing_doc_id(str(pdf_path), corpus),
+            doc_id=_lookup_existing_doc_id(_cat, str(pdf_path), corpus),
         )
         if return_metadata:
             return {

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -10,11 +10,15 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import chromadb
 import structlog
 
 from nexus.config import default_db_path
+
+if TYPE_CHECKING:
+    from nexus.catalog import Catalog
 
 _log = structlog.get_logger(__name__)
 
@@ -770,17 +774,9 @@ def _check_chroma_pagination(client: object, db_name: str) -> list[HealthResult]
         )]
 
 
-def _check_catalog() -> list[HealthResult]:
+def _check_catalog(cat: "Catalog | None", cat_path: "Path") -> list[HealthResult]:
     try:
-        from nexus.catalog import open_cached
-        from nexus.catalog.catalog import Catalog
-        from nexus.config import catalog_path
-
-        cat_path = catalog_path()
-        if Catalog.is_initialized(cat_path):
-            # nexus-6xqk follow-up: read-only health check uses the
-            # process-cached singleton, avoiding the rebuild contention.
-            cat = open_cached(cat_path)
+        if cat is not None:
             doc_count = cat._db.execute("SELECT count(*) FROM documents").fetchone()[0]
             link_count = cat._db.execute("SELECT count(*) FROM links").fetchone()[0]
             return [HealthResult(
@@ -846,6 +842,14 @@ def run_health_checks() -> tuple[list[HealthResult], bool]:
                     detail="skipped (client unavailable)",
                 ))
 
-    results.extend(_check_catalog())
+    from nexus.catalog import Catalog
+    from nexus.config import catalog_path
+    _cat_path = catalog_path()
+    _cat = (
+        Catalog(_cat_path, _cat_path / ".catalog.db")
+        if Catalog.is_initialized(_cat_path)
+        else None
+    )
+    results.extend(_check_catalog(_cat, _cat_path))
 
     return results, _local

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -954,16 +954,14 @@ def _build_frecency_doc_id_map(
     """
     file_to_doc_id: dict[Path, str] = {}
     try:
-        from nexus.catalog import Catalog, open_cached
+        from nexus.catalog import Catalog
         from nexus.config import catalog_path
         from nexus.registry import _repo_identity
 
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
             return file_to_doc_id
-        # nexus-6xqk follow-up: process-cached Catalog avoids a fresh
-        # _ensure_consistent rebuild on every frecency-only run.
-        cat = open_cached(cat_path)
+        cat = Catalog(cat_path, cat_path / ".catalog.db")
         _, repo_hash = _repo_identity(repo)
         owner = cat.owner_for_repo(repo_hash)
         if owner is None:

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -804,11 +804,19 @@ def pipeline_index_pdf(
     # reads source_path itself per the P0.1 content-sourcing contract.
     # nexus-tdgc: _catalog_pdf_hook ran above so the catalog entry now
     # exists; resolve the doc_id and forward it to the document chain.
+    from nexus.catalog import Catalog
+    from nexus.config import catalog_path
     from nexus.doc_indexer import _lookup_existing_doc_id
     from nexus.mcp_infra import fire_post_document_hooks
+    _cat_path = catalog_path()
+    _cat = (
+        Catalog(_cat_path, _cat_path / ".catalog.db")
+        if Catalog.is_initialized(_cat_path)
+        else None
+    )
     fire_post_document_hooks(
         str(pdf_path), collection, "",
-        doc_id=_lookup_existing_doc_id(str(pdf_path), corpus),
+        doc_id=_lookup_existing_doc_id(_cat, str(pdf_path), corpus),
     )
 
     return total_chunks

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,7 +171,6 @@ def _restore_post_store_batch_hooks_after_test():
     ``[]``.
     """
     import nexus.mcp_infra as _mod
-    from nexus.catalog import reset_cache as _reset_catalog_cache
     snapshot_batch = list(_mod._post_store_batch_hooks)
     snapshot_single = list(_mod._post_store_hooks)
     # Snapshot the catalog_doc_id-aware classification set too: a test
@@ -184,7 +183,6 @@ def _restore_post_store_batch_hooks_after_test():
     )
     _mod._catalog_instance = None
     _mod._catalog_mtime = 0.0
-    _reset_catalog_cache()
     yield
     _mod._post_store_batch_hooks.clear()
     _mod._post_store_batch_hooks.extend(snapshot_batch)
@@ -196,7 +194,6 @@ def _restore_post_store_batch_hooks_after_test():
     )
     _mod._catalog_instance = None
     _mod._catalog_mtime = 0.0
-    _reset_catalog_cache()
 
 
 @pytest.fixture(autouse=True)
@@ -383,6 +380,11 @@ _MODE_LINT_EXCLUDE_FILES: frozenset[str] = frozenset({
     "test_catalog_consolidation.py",
     "test_catalog_db.py",
     "test_catalog_doctor_collections_drift.py",
+    # RDR-103 / nexus-j9ey + b03o advisor: voyage tokens appear in
+    # synthetic collection names being asserted against, not as
+    # cloud-mode behaviour under test.
+    "test_catalog_doctor_name_vs_embed_dim.py",
+    "test_upgrade_name_vs_embed_dim_advisory.py",
     "test_catalog_incremental_rebuild.py",
     "test_catalog_manifest_backfill.py",
     "test_catalog_migrate_fallback.py",

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -161,13 +161,12 @@ def voyage_client():
 # ── nexus-dcym: doc_id-keyed identity helpers ──────────────────────────────
 
 
-def test_lookup_existing_doc_id_returns_empty_when_catalog_absent(tmp_path, monkeypatch):
-    """nexus-dcym: catalog uninitialized → "". Caller falls back to source_path."""
-    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "no-catalog"))
-    assert _lookup_existing_doc_id("/some/file.pdf", "any-corpus") == ""
+def test_lookup_existing_doc_id_returns_empty_when_catalog_is_none(tmp_path):
+    """Catalog uninitialised (caller passes None) → "". Caller falls back."""
+    assert _lookup_existing_doc_id(None, "/some/file.pdf", "any-corpus") == ""
 
 
-def test_lookup_existing_doc_id_finds_registered_entry(tmp_path, monkeypatch):
+def test_lookup_existing_doc_id_finds_registered_entry(tmp_path):
     """When the catalog already registered *file_path* under *corpus*'s
     owner, the helper returns the tumbler stringified as the doc_id."""
     from nexus.catalog.catalog import Catalog
@@ -181,8 +180,7 @@ def test_lookup_existing_doc_id_finds_registered_entry(tmp_path, monkeypatch):
         physical_collection="docs__mybook",
     )
 
-    monkeypatch.setattr("nexus.config.catalog_path", lambda: cat_dir)
-    result = _lookup_existing_doc_id(file_path, "mybook")
+    result = _lookup_existing_doc_id(cat, file_path, "mybook")
     assert result == str(doc)
 
 

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -230,13 +230,11 @@ def test_batch_index_markdowns_skips_malformed_frontmatter_and_continues(
     ``failed`` with its path; sibling files complete normally; the whole
     call returns within a wall-clock bound."""
     import chromadb
-    from nexus.catalog import reset_cache
     from nexus.catalog.catalog import Catalog
     from nexus.db.t3 import T3Database
 
     cat_dir = tmp_path / "test-catalog"
     Catalog.init(cat_dir)
-    reset_cache()
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
     monkeypatch.setattr(
@@ -297,12 +295,10 @@ def test_index_md_falls_back_to_local_embedder_when_no_credentials(
     detect "unchanged" — re-index would proceed every time.
     """
     import chromadb
-    from nexus.catalog import reset_cache
     from nexus.catalog.catalog import Catalog
 
     cat_dir = tmp_path / "test-catalog"
     Catalog.init(cat_dir)
-    reset_cache()
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
     monkeypatch.setattr(
@@ -373,7 +369,6 @@ def test_index_markdown_auto_inits_catalog_when_absent_and_prunes_on_reindex(
     """
     import chromadb
 
-    from nexus.catalog import reset_cache
     from nexus.catalog.catalog import Catalog
     from nexus.config import catalog_path
     from nexus.db.t3 import T3Database
@@ -385,7 +380,6 @@ def test_index_markdown_auto_inits_catalog_when_absent_and_prunes_on_reindex(
         "NEXUS_CATALOG_PATH but does not initialize the catalog."
     )
 
-    reset_cache()
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
     monkeypatch.setattr(
@@ -412,8 +406,7 @@ def test_index_markdown_auto_inits_catalog_when_absent_and_prunes_on_reindex(
     assert metas_before, "expected chunks after first index"
     # RDR-108 Phase 3 retired doc_id from chunk metadata. Verify the
     # catalog manifest covers the chunks instead.
-    from nexus.catalog import open_cached
-    cat = open_cached(cat_path)
+    cat = Catalog(cat_path, cat_path / ".catalog.db")
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
         (f"docs__autoinit-probe__{_local_token()}__v1",),
@@ -1716,13 +1709,11 @@ def _setup_phase_a_catalog(tmp_path, monkeypatch):
     indexer does not attempt to call the real cloud APIs.
     """
     import chromadb
-    from nexus.catalog import reset_cache
     from nexus.catalog.catalog import Catalog
     from nexus.db.t3 import T3Database
 
     cat_dir = tmp_path / "test-catalog"
     Catalog.init(cat_dir)
-    reset_cache()
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
     monkeypatch.setattr(
@@ -1846,8 +1837,8 @@ def test_index_pdf_writes_doc_id_when_catalog_initialized(
     # authoritative — verify the catalog has manifest rows for this PDF.
     for m in rows["metadatas"]:
         assert "doc_id" not in m
-    from nexus.catalog import open_cached
-    cat = open_cached(cat_dir)
+    from nexus.catalog.catalog import Catalog
+    cat = Catalog(cat_dir, cat_dir / ".catalog.db")
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
         (f"docs__rdr102-pdf__{_local_token()}__v1",),
@@ -1881,8 +1872,8 @@ def test_index_markdown_writes_doc_id_when_catalog_initialized(
     )
     for m in rows["metadatas"]:
         assert "doc_id" not in m
-    from nexus.catalog import open_cached
-    cat = open_cached(cat_dir)
+    from nexus.catalog.catalog import Catalog
+    cat = Catalog(cat_dir, cat_dir / ".catalog.db")
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
         (f"docs__rdr102-md__{_local_token()}__v1",),
@@ -1924,8 +1915,8 @@ def test_batch_index_markdowns_rdr_mode_writes_doc_id_when_catalog_initialized(
     )
     for m in rows["metadatas"]:
         assert "doc_id" not in m
-    from nexus.catalog import open_cached
-    cat = open_cached(cat_dir)
+    from nexus.catalog.catalog import Catalog
+    cat = Catalog(cat_dir, cat_dir / ".catalog.db")
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
         (f"rdr__rdr102-rdrmode__{_local_token()}__v1",),
@@ -1951,7 +1942,6 @@ def test_index_markdown_post_hook_updates_chunk_count_after_preflight(
     invisible to operators who never read the Document row but a
     structural drift between catalog + T3 chunk counts.
     """
-    from nexus.catalog import reset_cache
     from nexus.catalog.catalog import Catalog
 
     cat_dir, t3 = _setup_phase_a_catalog(tmp_path, monkeypatch)
@@ -1959,7 +1949,6 @@ def test_index_markdown_post_hook_updates_chunk_count_after_preflight(
     n = index_markdown(sample_md, corpus="rdr102-chunkcount", t3=t3)
     assert n > 0, "expected index_markdown to upsert at least one chunk"
 
-    reset_cache()
     cat = Catalog(cat_dir, cat_dir / ".catalog.db")
     rows = cat._db.execute(
         "SELECT chunk_count FROM documents WHERE file_path = ?",
@@ -2004,7 +1993,6 @@ def test_preflight_registration_idempotent_on_staleness_skip(
 
     from click.testing import CliRunner
 
-    from nexus.catalog import reset_cache
     from nexus.commands.catalog import doctor_cmd
 
     cat_dir, t3 = _setup_phase_a_catalog(tmp_path, monkeypatch)
@@ -2032,7 +2020,6 @@ def test_preflight_registration_idempotent_on_staleness_skip(
     # Drop the process-cached Catalog so the second call re-reads the
     # owner row written by the first call's _catalog_markdown_hook
     # rather than reusing a stale in-memory snapshot.
-    reset_cache()
 
     n2 = index_markdown(sample_md, corpus="rdr102-idem", t3=t3)
     assert n2 == 0, (
@@ -2057,7 +2044,6 @@ def test_preflight_registration_idempotent_on_staleness_skip(
     # single DocumentRegistered + (post-impl) the pre-flight Document
     # row; the projector must produce the identical state from
     # events.jsonl.
-    reset_cache()
     runner = CliRunner()
     result = runner.invoke(
         doctor_cmd, ["--replay-equality", "--json"],

--- a/tests/test_indexer_e2e.py
+++ b/tests/test_indexer_e2e.py
@@ -517,7 +517,6 @@ def test_migration_moves_prose_from_code_to_docs(
          and remove the seed chunk because README.md is in
          file_to_doc_id (catalog hook re-runs every index).
     """
-    from nexus.catalog import reset_cache
     from nexus.catalog.catalog import Catalog
     from nexus.config import catalog_path
 
@@ -526,7 +525,6 @@ def test_migration_moves_prose_from_code_to_docs(
     # README.md and the indexer threads its tumbler into file_to_doc_id.
     cat_path = catalog_path()
     Catalog.init(cat_path)
-    reset_cache()
 
     reg = RepoRegistry(tmp_path / "repos.json")
     reg.add(rich_repo)
@@ -536,7 +534,6 @@ def test_migration_moves_prose_from_code_to_docs(
     _index(rich_repo, reg, local_t3)
 
     # Step 2 — read the tumbler that _catalog_hook assigned.
-    reset_cache()
     cat = Catalog(cat_path, cat_path / ".catalog.db")
     row = cat._db.execute(
         "SELECT tumbler FROM documents WHERE file_path = ?",

--- a/tests/test_pipeline_stages.py
+++ b/tests/test_pipeline_stages.py
@@ -566,13 +566,11 @@ class TestPipelineIndexPdf:
         would continue regressing source_path post-Phase-B.
         """
         import chromadb
-        from nexus.catalog import reset_cache
         from nexus.catalog.catalog import Catalog
         from nexus.db.t3 import T3Database
 
         cat_dir = tmp_path / "test-catalog"
         Catalog.init(cat_dir)
-        reset_cache()
         monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
         monkeypatch.delenv("CHROMA_API_KEY", raising=False)
         monkeypatch.setattr(
@@ -622,13 +620,11 @@ class TestPipelineIndexPdf:
         Verify chunks lack doc_id and the manifest carries it instead.
         """
         import chromadb
-        from nexus.catalog import reset_cache
         from nexus.catalog.catalog import Catalog
         from nexus.db.t3 import T3Database
 
         cat_dir = tmp_path / "test-catalog"
         Catalog.init(cat_dir)
-        reset_cache()
         monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
         monkeypatch.delenv("CHROMA_API_KEY", raising=False)
         monkeypatch.setattr(
@@ -668,8 +664,7 @@ class TestPipelineIndexPdf:
             assert "doc_id" not in m
 
         # Manifest carries the doc-to-chunk binding instead.
-        from nexus.catalog import open_cached
-        cat = open_cached(cat_dir)
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
         documents = cat._db.execute(
             "SELECT tumbler FROM documents WHERE physical_collection = ?",
             (f"docs__rdr102-stream__{_local_token()}__v1",),


### PR DESCRIPTION
## Summary

First slice of the RDR-118-style singleton elimination work, this time on a clean codebase (RDR-118 itself was scrapped). Eliminates the \`nexus.catalog._cached\` process-global Catalog cache and its companions (\`_cache_lock\`, \`open_cached()\`, \`reset_cache()\`).

## What was on main

\`\`\`python
_cached: dict[Path, Catalog] = {}
_cache_lock = threading.Lock()

def open_cached(cat_path: Path) -> Catalog:
    # process-wide singleton keyed by path; nexus-6xqk follow-up

def reset_cache() -> None:
    # tests called this between cases to drop the cache
\`\`\`

10 production sites consumed \`open_cached()\`; several tests called \`reset_cache()\` to manage state between cases.

## What's here

**Slice 1 (4f6c5bca):** \`_lookup_existing_doc_id\` end-to-end DI — takes \`cat: Catalog | None\` explicitly. Both production callers (\`pipeline_index_pdf\`, \`index_pdf\`) construct the catalog locally and pass it in.

**Slices 2-10 (75c03a13):** the remaining 9 sites convert. Health-check chain uses full DI (\`run_health_checks → _check_catalog(cat, cat_path)\`). Other sites replace \`open_cached(p)\` with direct \`Catalog(p, p / ".catalog.db")\`.

**Deletion (75c03a13):** \`_cached\`, \`_cache_lock\`, \`open_cached\`, \`reset_cache\` removed from \`nexus.catalog\`. \`__all__\` updated. -46 LOC.

**Test cleanup (75c03a13):**
- \`tests/test_doc_indexer.py\` / \`test_pipeline_stages.py\` / \`test_indexer_e2e.py\`: \`open_cached()\` / \`reset_cache()\` call sites converted.
- \`tests/conftest.py\`: \`_restore_post_store_batch_hooks_after_test\` drops the import + setup + teardown of the catalog cache reset.
- \`tests/conftest.py\`: \`_MODE_LINT_EXCLUDE_FILES\` adds the two test files introduced by PR #868 that reference \`voyage-{code,context}-3\` as string literals in collection-name assertions. Unblocks \`test_mode_declarations_are_explicit\` which was failing on main and on PR #869.

## Trade-off acknowledged

The cache existed (per \`nexus-6xqk\` follow-up) to avoid \`_ensure_consistent\` rebuild storms during force-reindex. Each consumer now constructs its own Catalog per invocation; in a long-running process this is more rebuilds than before. The right answer is to push construction up to entry points (CLI commands, MCP handlers) where one catalog is constructed per invocation. That's a separate slice.

## Verification

\`uv run pytest\` on this branch: **7238 passed**, 33 skipped, 114 deselected, **0 failed**.

## Out of scope (subsequent PRs)

The other 11 module-level mutable singletons identified during this analysis:
- \`nexus.mcp_infra._catalog_instance\` + \`_catalog_mtime\` (the *other* catalog cache — redundant with the one this PR just deleted)
- \`_post_store_hooks\`, \`_post_store_batch_hooks\` + \`_with_catalog_doc_id\` set, \`_post_document_hooks\` + \`_with_doc_id\` set (3 hook chains)
- \`_plan_cache_instance\` + \`_populated\` + \`_mtime\`
- \`_collections_cache\`
- \`_search_traces\`