### PR TITLE
refactor: eliminate hook-chain singletons via HookRegistry DI

### DIFF
--- a/src/nexus/aspect_extractor.py
+++ b/src/nexus/aspect_extractor.py
@@ -7,7 +7,7 @@ Single public entrypoint: ``extract_aspects(content, source_path,
 collection) -> AspectRecord | ExtractFail | None``. The function is
 synchronous top to bottom — no ``async def``, no ``await``, no
 event loop. The RDR-089 load-bearing contract requires this so the
-document-grain hook chain (``fire_post_document_hooks``) can call it
+document-grain hook chain (``HookRegistry.fire_document``) can call it
 from a sync dispatcher without dropping a coroutine.
 
 **Going-forward writer contract** (RDR-096 P2.2 binds this; gate-

--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -796,7 +796,7 @@ def drain_worker(
         queue.close()
 
 
-# ── Hook function (registered via register_post_document_hook) ──────────────
+# ── Hook function (wired by hook_registry.install_default_hooks) ────────────
 
 
 def aspect_extraction_enqueue_hook(
@@ -808,7 +808,7 @@ def aspect_extraction_enqueue_hook(
 ) -> None:
     """Post-document hook: enqueue a row for async aspect extraction.
 
-    Signature matches ``fire_post_document_hooks(source_path,
+    Signature matches ``HookRegistry.fire_document(source_path,
     collection, content)``. This hook does NOT call extract_aspects
     inline — that would block the ingest path for ~25 s per document
     (RDR-089 P1.3 spike finding). Instead it:

--- a/src/nexus/code_indexer.py
+++ b/src/nexus/code_indexer.py
@@ -478,21 +478,16 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
         # Post-store hook chains (RDR-095). Both single-doc and batch
         # chains fire from every storage event; the per-doc loop covers
         # single-shape consumers on CLI ingest.
-        from nexus.mcp_infra import (
-            fire_post_document_hooks,
-            fire_post_store_batch_hooks,
-            fire_post_store_hooks,
-        )
-        fire_post_store_batch_hooks(
+        ctx.hooks.fire_batch(
             ids, ctx.corpus, documents, embeddings, metadatas,
             catalog_doc_id=catalog_doc_id,
         )
         for _did, _doc in zip(ids, documents):
-            fire_post_store_hooks(_did, ctx.corpus, _doc)
+            ctx.hooks.fire_single(_did, ctx.corpus, _doc)
         # RDR-089 document-grain chain — once per code-file boundary.
         # content="" (chunk-level scope only); hook reads source_path.
         # nexus-tdgc: forward catalog doc_id when available.
-        fire_post_document_hooks(
+        ctx.hooks.fire_document(
             str(file_path), ctx.corpus, "",
             doc_id=catalog_doc_id,
         )

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -879,6 +879,7 @@ def _reembed_collection(
     *,
     dry_run: bool,
     on_progress=None,
+    hooks=None,
 ) -> tuple[int, int]:
     """Re-embed every chunk in *col_name* with *target_model*.
 
@@ -977,9 +978,12 @@ def _reembed_collection(
             # position, so the chain's hooks (chash_dual_write,
             # taxonomy_assign, manifest_write) re-touch existing rows
             # idempotently.
-            from nexus.mcp_infra import fire_store_chains
+            if hooks is None:
+                from nexus.hook_registry import HookRegistry, install_default_hooks
+                hooks = HookRegistry()
+                install_default_hooks(hooks)
 
-            fire_store_chains(
+            hooks.fire_store_chains(
                 v_ids, col_name, v_docs,
                 source_paths=[
                     (m.get("source_path", "") if isinstance(m, dict) else "")

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -770,35 +770,34 @@ def _run_check_tier_discipline() -> None:
 
 
 def _run_check_post_store_hooks() -> None:
-    """Enumerate post-store hooks registered on each of the three chains.
+    """Enumerate post-store hooks attached to a default ``HookRegistry``.
 
-    Importing :mod:`nexus.mcp.core` triggers the static
-    ``register_post_store_*_hook`` calls; this function then reads the
-    chain lists from :mod:`nexus.mcp_infra` and prints the
-    ``__name__`` attributes per chain.
+    The hook chains are no longer module-level globals (RDR-118
+    successor): each entry point constructs its own ``HookRegistry`` and
+    wires the load-bearing default consumers via
+    :func:`nexus.hook_registry.install_default_hooks`. This diagnostic
+    builds a fresh registry the same way and prints the consumers
+    attached to each chain so operators can confirm the install factory
+    is wiring the expected set.
 
     Use cases (from nexus-b0ka):
 
-      * Confirm RDR-089 aspect_extraction_enqueue_hook registered
-        after install.
+      * Confirm RDR-089 ``aspect_extraction_enqueue_hook`` registers
+        on the document chain.
       * Detect drift if a hook silently fails to register due to
-        import-order bugs.
-      * Smoke after upgrade: are the expected hooks still registered?
+        import-order bugs in the factory.
+      * Smoke after upgrade: does the install factory still wire the
+        expected default consumers?
     """
-    # Import for side-effects: registers the chash_dual_write +
-    # taxonomy_assign batch hooks and the aspect-extraction document
-    # hook (mcp/core.py:387-388 + the nexus-qeo8 follow-up).
-    import nexus.mcp.core  # noqa: F401, PLC0415
-    from nexus.mcp_infra import (  # noqa: PLC0415
-        _post_document_hooks,
-        _post_store_batch_hooks,
-        _post_store_hooks,
-    )
+    from nexus.hook_registry import HookRegistry, install_default_hooks  # noqa: PLC0415
+
+    registry = HookRegistry()
+    install_default_hooks(registry)
 
     chains: list[tuple[str, list]] = [
-        ("Single-doc chain (RDR-070)", _post_store_hooks),
-        ("Batch chain (RDR-095)", _post_store_batch_hooks),
-        ("Document-grain chain (RDR-089)", _post_document_hooks),
+        ("Single-doc chain (RDR-070)", registry._single),
+        ("Batch chain (RDR-095)", registry._batch),
+        ("Document-grain chain (RDR-089)", registry._document),
     ]
     total = 0
     for label, hooks in chains:

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -639,7 +639,7 @@ def enrich_aspects(
 
     Iterates the catalog (one entry per source document, NOT per
     chunk), calls extract_aspects directly (bypassing the
-    fire_post_document_hooks chain to avoid double-firing on
+    ``HookRegistry.fire_document`` chain to avoid double-firing on
     documents already triggered at ingest), and upserts AspectRecords
     to ``document_aspects``.
 

--- a/src/nexus/commands/memory.py
+++ b/src/nexus/commands/memory.py
@@ -231,10 +231,10 @@ def promote_cmd(entry_id: int, collection: str, tags: str, remove: bool) -> None
 
         # nexus-8g79.1: pre-register the catalog entry so the T3 chunk
         # carries the resulting tumbler as ``doc_id`` at write-time and
-        # the manifest hook in fire_store_chains populates document_chunks
-        # + documents.chunk_count for this promotion. Without this, the
-        # promoted entry lands in T3 with no catalog identity — same
-        # regression class as nexus-zq79 / nexus-lf8f.
+        # the manifest hook in HookRegistry.fire_store_chains populates
+        # document_chunks + documents.chunk_count for this promotion.
+        # Without this, the promoted entry lands in T3 with no catalog
+        # identity — same regression class as nexus-zq79 / nexus-lf8f.
         import hashlib
         from nexus.catalog.store_hook import catalog_store_hook
         chunk_chroma_id = hashlib.sha256(entry["content"].encode()).hexdigest()[:32]
@@ -260,8 +260,10 @@ def promote_cmd(entry_id: int, collection: str, tags: str, remove: bool) -> None
         # symmetric-fire; this path was missed by the original commit.
         # nexus-8g79.1: thread catalog_doc_id through so the manifest
         # hook can populate document_chunks + chunk_count.
-        from nexus.mcp_infra import fire_store_chains
-        fire_store_chains(
+        from nexus.hook_registry import HookRegistry, install_default_hooks
+        hooks = HookRegistry()
+        install_default_hooks(hooks)
+        hooks.fire_store_chains(
             [doc_id], collection, [entry["content"]],
             catalog_doc_id=catalog_doc_id,
         )

--- a/src/nexus/commands/store.py
+++ b/src/nexus/commands/store.py
@@ -133,14 +133,16 @@ def put_cmd(
     # store-put events. RDR-095 symmetric-fire; this path was missed by
     # the original commit. doc_id is the source identity here (no
     # on-disk file at the CLI boundary, mirroring MCP store_put).
-    from nexus.mcp_infra import fire_store_chains
-    # nexus-lf8f: pass catalog_doc_id through to fire_store_chains so the
-    # manifest-write batch hook can populate document_chunks and
+    from nexus.hook_registry import HookRegistry, install_default_hooks
+    hooks = HookRegistry()
+    install_default_hooks(hooks)
+    # nexus-lf8f: pass catalog_doc_id through to HookRegistry.fire_store_chains
+    # so the manifest-write batch hook can populate document_chunks and
     # documents.chunk_count for this CLI store path. Without it the
     # hook short-circuits and the catalog row ships with chunk_count=0
     # (the same regression class as nexus-zq79 / 4.32.4 fixed for
     # `nx index repo`).
-    fire_store_chains(
+    hooks.fire_store_chains(
         [doc_id], col_name, [content],
         catalog_doc_id=catalog_doc_id,
     )

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -570,8 +570,8 @@ def migrate_review_columns(conn: sqlite3.Connection) -> None:
 def migrate_hook_failures(conn: sqlite3.Connection) -> None:
     """Create the ``hook_failures`` table for GH #251.
 
-    ``fire_post_store_hooks`` and ``fire_post_store_batch_hooks`` in
-    ``mcp_infra.py`` wrap every post-store hook in a per-hook
+    ``HookRegistry.fire_single`` / ``fire_batch`` / ``fire_document``
+    in ``nexus.hook_registry`` wrap every post-store hook in a per-hook
     ``try/except`` — a failing hook (e.g.
     ``taxonomy_assign_batch_hook`` raising on missing centroids or a
     ChromaDB timeout) logs a warning and moves on so the enclosing

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -18,6 +18,7 @@ import structlog
 
 if TYPE_CHECKING:
     from nexus.catalog import Catalog
+    from nexus.hook_registry import HookRegistry
 
 _log = structlog.get_logger(__name__)
 
@@ -541,6 +542,7 @@ def _index_document(
     return_metadata: bool = False,
     on_progress: Callable[[int, int], None] | None = None,
     source_key: str | None = None,
+    hooks: "HookRegistry | None" = None,
 ) -> int | list[dict]:
     """Shared indexing pipeline: credential check, staleness, embed, upsert, prune.
 
@@ -664,11 +666,10 @@ def _index_document(
     # Post-store hook chains (RDR-095). Both single-doc and batch chains
     # fire from every storage event; the per-doc loop covers single-shape
     # consumers on CLI ingest.
-    from nexus.mcp_infra import (
-        fire_post_document_hooks,
-        fire_post_store_batch_hooks,
-        fire_post_store_hooks,
-    )
+    if hooks is None:
+        from nexus.hook_registry import HookRegistry, install_default_hooks
+        hooks = HookRegistry()
+        install_default_hooks(hooks)
     # nexus-zq79 F2: use _register_or_lookup_doc_id, NOT _lookup_existing_doc_id.
     # The read-only lookup returns "" for first-time indexes; post-Phase-3
     # chunks have no doc_id fallback so the manifest hook short-circuits and
@@ -680,18 +681,18 @@ def _index_document(
         content_type=_ct_for_register,
         physical_collection=collection_name,
     )
-    fire_post_store_batch_hooks(
+    hooks.fire_batch(
         ids, collection_name, documents, embeddings, metadatas,
         catalog_doc_id=_catalog_doc_id_for_batch,
     )
     for _did, _doc in zip(ids, documents):
-        fire_post_store_hooks(_did, collection_name, _doc)
+        hooks.fire_single(_did, collection_name, _doc)
     # RDR-089 document-grain chain — fires once per file boundary.
     # content="" because only chunk text is in scope here; the hook
     # reads source_path itself per the P0.1 content-sourcing contract.
     # nexus-tdgc: pre-flight catalog lookup so the aspect-queue hook
     # can capture the doc_id alongside source_path.
-    fire_post_document_hooks(
+    hooks.fire_document(
         sp, collection_name, "",
         doc_id=_catalog_doc_id_for_batch,
     )
@@ -740,6 +741,7 @@ def _index_pdf_incremental(
     *,
     embed_fn: EmbedFn | None = None,
     on_progress: Callable[[int, int], None] | None = None,
+    hooks: "HookRegistry | None" = None,
 ) -> int:
     """Embed and upsert chunks in batches with checkpoint support.
 
@@ -790,7 +792,7 @@ def _index_pdf_incremental(
 
     # Resolve catalog doc_id once outside the per-batch loop (RDR-108
     # Phase 3: chunk metadata no longer carries it; manifest hook reads
-    # via the fire_post_store_batch_hooks kwarg).
+    # via the HookRegistry.fire_batch kwarg).
     # nexus-zq79 F2: register-or-lookup, not pure lookup (see _index_document
     # for the rationale — fresh indexes returned "" pre-fix).
     _ct_for_register = (metadatas_all[0].get("content_type") if metadatas_all else "") or "pdf"
@@ -841,16 +843,16 @@ def _index_pdf_incremental(
         # Post-store hook chains (RDR-095). Both single-doc and batch
         # chains fire from every storage event; the per-doc loop covers
         # single-shape consumers on CLI ingest.
-        from nexus.mcp_infra import (
-            fire_post_store_batch_hooks,
-            fire_post_store_hooks,
-        )
-        fire_post_store_batch_hooks(
+        if hooks is None:
+            from nexus.hook_registry import HookRegistry, install_default_hooks
+            hooks = HookRegistry()
+            install_default_hooks(hooks)
+        hooks.fire_batch(
             batch_ids, collection_name, batch_docs, embeddings, batch_metas,
             catalog_doc_id=_catalog_doc_id_for_batch,
         )
         for _did, _doc in zip(batch_ids, batch_docs):
-            fire_post_store_hooks(_did, collection_name, _doc)
+            hooks.fire_single(_did, collection_name, _doc)
 
         # Checkpoint
         write_checkpoint(CheckpointData(
@@ -1102,6 +1104,7 @@ def index_pdf(
     enrich: bool = False,
     extractor: str = "auto",
     streaming: str = "auto",
+    hooks: "HookRegistry | None" = None,
 ) -> int | dict:
     """Index *pdf_path* into a T3 collection.
 
@@ -1233,6 +1236,7 @@ def index_pdf(
                 corpus=corpus, target_model=target_model,
                 force=force,
                 doc_id=doc_id,
+                hooks=hooks,
             )
             if return_metadata:
                 # Query T3 for metadata after streaming upload.
@@ -1285,9 +1289,13 @@ def index_pdf(
 
     # Route: incremental for large documents, original path for small ones
     if len(prepared) > _INCREMENTAL_THRESHOLD:
+        if hooks is None:
+            from nexus.hook_registry import HookRegistry, install_default_hooks
+            hooks = HookRegistry()
+            install_default_hooks(hooks)
         count = _index_pdf_incremental(
             pdf_path, corpus, prepared, content_hash, col_name, db,
-            embed_fn=embed_fn, on_progress=on_progress,
+            embed_fn=embed_fn, on_progress=on_progress, hooks=hooks,
         )
         metadatas = [p[2] for p in prepared]
         _register_in_catalog(metadatas, len(metadatas))
@@ -1299,14 +1307,13 @@ def index_pdf(
         # so the entry exists by this point in the incremental path).
         from nexus.catalog import Catalog  # noqa: PLC0415
         from nexus.config import catalog_path  # noqa: PLC0415
-        from nexus.mcp_infra import fire_post_document_hooks  # noqa: PLC0415
         _cat_path = catalog_path()
         _cat = (
             Catalog(_cat_path, _cat_path / ".catalog.db")
             if Catalog.is_initialized(_cat_path)
             else None
         )
-        fire_post_document_hooks(
+        hooks.fire_document(
             str(pdf_path), col_name, "",
             doc_id=_lookup_existing_doc_id(_cat, str(pdf_path), corpus),
         )
@@ -1341,11 +1348,10 @@ def index_pdf(
     # Post-store hook chains (RDR-095). Both single-doc and batch chains
     # fire from every storage event; the per-doc loop covers single-shape
     # consumers on CLI ingest.
-    from nexus.mcp_infra import (
-        fire_post_document_hooks,
-        fire_post_store_batch_hooks,
-        fire_post_store_hooks,
-    )
+    if hooks is None:
+        from nexus.hook_registry import HookRegistry, install_default_hooks
+        hooks = HookRegistry()
+        install_default_hooks(hooks)
     # nexus-zq79 F2: register-or-lookup (fresh indexes returned "" pre-fix).
     _ct_for_register = (metadatas_list[0].get("content_type") if metadatas_list else "") or "pdf"
     _catalog_doc_id_for_batch = _register_or_lookup_doc_id(
@@ -1353,17 +1359,17 @@ def index_pdf(
         content_type=_ct_for_register,
         physical_collection=col_name,
     )
-    fire_post_store_batch_hooks(
+    hooks.fire_batch(
         ids, col_name, documents, embeddings, metadatas_list,
         catalog_doc_id=_catalog_doc_id_for_batch,
     )
     for _did, _doc in zip(ids, documents):
-        fire_post_store_hooks(_did, col_name, _doc)
+        hooks.fire_single(_did, col_name, _doc)
     # RDR-089 document-grain chain — fires once per small-doc PDF boundary.
     # content="" (full document text not retained in this path); the hook
     # reads source_path itself.
     # nexus-tdgc: forward the catalog doc_id post-register.
-    fire_post_document_hooks(
+    hooks.fire_document(
         str(pdf_path), col_name, "",
         doc_id=_catalog_doc_id_for_batch,
     )
@@ -1518,6 +1524,7 @@ def index_markdown(
     on_progress: Callable[[int, int], None] | None = None,
     content_type: str = "prose",
     base_path: Path | None = None,
+    hooks: "HookRegistry | None" = None,
 ) -> int | dict:
     """Index *md_path* into a T3 collection.
 
@@ -1584,6 +1591,7 @@ def index_markdown(
         collection_name=collection_name, embed_fn=embed_fn,
         force=force, return_metadata=return_metadata, on_progress=on_progress,
         source_key=source_key,
+        hooks=hooks,
     )
     if not return_metadata:
         assert isinstance(raw, int)
@@ -1608,6 +1616,7 @@ def batch_index_pdfs(
     force: bool = False,
     on_file: Callable[[Path, int, float], None] | None = None,
     extractor: str = "auto",
+    hooks: "HookRegistry | None" = None,
 ) -> dict[str, str]:
     """Index multiple PDFs sequentially, returning per-file status.
 
@@ -1625,7 +1634,7 @@ def batch_index_pdfs(
         count: int = 0
         t0 = time.monotonic()
         try:
-            raw = index_pdf(path, corpus, t3=t3, force=force, extractor=extractor)
+            raw = index_pdf(path, corpus, t3=t3, force=force, extractor=extractor, hooks=hooks)
             count = raw if isinstance(raw, int) else 0
             results[str(path)] = "indexed" if count else "skipped"
         except Exception as e:
@@ -1647,6 +1656,7 @@ def batch_index_markdowns(
     on_file: Callable[[Path, int, float], None] | None = None,
     base_path: Path | None = None,
     embed_fn: EmbedFn | None = None,
+    hooks: "HookRegistry | None" = None,
 ) -> dict[str, str]:
     """Index multiple Markdown files sequentially, returning per-file status.
 
@@ -1675,7 +1685,7 @@ def batch_index_markdowns(
         try:
             raw = index_markdown(path, corpus, t3=t3, collection_name=collection_name,
                                  content_type=content_type, force=force,
-                                 base_path=base_path, embed_fn=embed_fn)
+                                 base_path=base_path, embed_fn=embed_fn, hooks=hooks)
             count = raw if isinstance(raw, int) else 0
             results[str(path)] = "indexed" if count else "skipped"
         except Exception as e:

--- a/src/nexus/exporter.py
+++ b/src/nexus/exporter.py
@@ -32,6 +32,7 @@ from nexus.retry import _chroma_with_retry
 
 if TYPE_CHECKING:
     from nexus.db.t3 import T3Database
+    from nexus.hook_registry import HookRegistry
 
 _log = structlog.get_logger(__name__)
 
@@ -97,6 +98,7 @@ def _fire_store_chains_grouped_by_doc(
     documents: list[str],
     embeddings: list[list[float]],
     metadatas: list[dict],
+    hooks: "HookRegistry",
 ) -> None:
     """nexus-8g79.1: fire post-store chains per-doc so the manifest
     hook can attribute chunks to the right catalog tumbler.
@@ -111,13 +113,12 @@ def _fire_store_chains_grouped_by_doc(
     Phase-3 exports.
 
     Records are partitioned by ``meta.get("doc_id", "")``; each group
-    fires its own ``fire_store_chains`` call with that group key as
-    ``catalog_doc_id`` so the manifest hook attributes the chunks
-    correctly. Insertion order within each group is preserved so
-    ``chunk_index`` re-injection sees a stable position.
+    fires its own ``HookRegistry.fire_store_chains`` call with that
+    group key as ``catalog_doc_id`` so the manifest hook attributes
+    the chunks correctly. Insertion order within each group is
+    preserved so ``chunk_index`` re-injection sees a stable position.
     """
     from collections import defaultdict
-    from nexus.mcp_infra import fire_store_chains
 
     groups: dict[str, list[int]] = defaultdict(list)
     for i, m in enumerate(metadatas):
@@ -129,7 +130,7 @@ def _fire_store_chains_grouped_by_doc(
         sub_embs = [embeddings[i] for i in indices] if embeddings else None
         sub_metas = [metadatas[i] for i in indices]
         sub_paths = [(metadatas[i] or {}).get("source_path", "") for i in indices]
-        fire_store_chains(
+        hooks.fire_store_chains(
             sub_ids, collection_name, sub_docs,
             source_paths=sub_paths,
             embeddings=sub_embs,
@@ -279,6 +280,8 @@ def import_collection(
     input_path: Path,
     target_collection: str | None = None,
     remaps: list[tuple[str, str]] | None = None,
+    *,
+    hooks: "HookRegistry | None" = None,
 ) -> dict:
     """Import a ``.nxexp`` file into T3.
 
@@ -309,6 +312,10 @@ def import_collection(
     """
     t0 = time.monotonic()
     remaps = remaps or []
+    if hooks is None:
+        from nexus.hook_registry import HookRegistry, install_default_hooks
+        hooks = HookRegistry()
+        install_default_hooks(hooks)
 
     # Phase 1: read and validate header.
     with open(input_path, "rb") as f:
@@ -430,7 +437,7 @@ def import_collection(
                     )
                     _fire_store_chains_grouped_by_doc(
                         ids, collection_name, documents,
-                        embeddings, metadatas,
+                        embeddings, metadatas, hooks,
                     )
                     imported_count += len(ids)
                     _log.debug("import_batch_written", count=len(ids), total_so_far=imported_count)
@@ -446,7 +453,7 @@ def import_collection(
             metadatas=metadatas,
         )
         _fire_store_chains_grouped_by_doc(
-            ids, collection_name, documents, embeddings, metadatas,
+            ids, collection_name, documents, embeddings, metadatas, hooks,
         )
         imported_count += len(ids)
 

--- a/src/nexus/hook_registry.py
+++ b/src/nexus/hook_registry.py
@@ -1,0 +1,517 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Three-chain post-store hook registry (RDR-118 successor / scrap follow-up).
+
+Replaces the six module-level mutables that used to live in
+``nexus.mcp_infra`` (``_post_store_hooks``, ``_post_store_batch_hooks``,
+``_post_store_batch_hooks_with_catalog_doc_id``, ``_post_document_hooks``,
+``_post_document_hooks_with_doc_id``) plus their dispatchers
+(``register_post_store_hook``, ``fire_post_store_hooks``, and the two
+parallel pairs). Entry points construct one ``HookRegistry``, call
+:func:`install_default_hooks` to attach the load-bearing default
+consumers, and thread the instance through the indexing / storage
+pipeline. Tests construct their own ``HookRegistry`` per test.
+
+Three chains, three shapes:
+
+* **single** (RDR-070) — ``fn(doc_id, collection, content)`` per
+  document. Currently empty by default — registered ad-hoc.
+* **batch** (RDR-095) —
+  ``fn(doc_ids, collection, contents, embeddings, metadatas, *,
+  catalog_doc_id="")`` per batch. Default consumers: chash dual-write,
+  taxonomy assign, manifest write.
+* **document** (RDR-089) —
+  ``fn(source_path, collection, content, *, doc_id="")`` per source
+  document. Default consumer: aspect-extraction enqueue.
+
+Per-hook failure isolation + T2 ``hook_failures`` persistence semantics
+are preserved verbatim from the legacy dispatchers. The
+``_record_*_hook_failure`` helpers live here (moved from ``mcp_infra``)
+and use the same ``t2_ctx()`` accessor so existing tests that
+monkeypatch ``nexus.mcp_infra.t2_ctx`` keep working unchanged.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import sqlite3
+from typing import Any, Callable
+
+import structlog
+
+
+__all__ = [
+    "HookRegistry",
+    "install_default_hooks",
+]
+
+
+_log = structlog.get_logger(__name__)
+
+
+# ── HookRegistry ─────────────────────────────────────────────────────────────
+
+
+class HookRegistry:
+    """Three-chain post-store hook registry. Constructor-injected.
+
+    Entry points (CLI commands, MCP tools, tests) instantiate one
+    registry per logical invocation, call :func:`install_default_hooks`
+    to attach the load-bearing batch + document hooks, and pass the
+    instance down through the indexing pipeline. The pipeline calls
+    :meth:`fire_single`, :meth:`fire_batch`, and :meth:`fire_document`
+    on the threaded instance instead of on module-level globals.
+
+    Per-hook failure isolation: a single hook raising does not block
+    other hooks from firing. Failures are logged at WARNING and
+    persisted to T2 ``hook_failures`` for triage (``nx taxonomy
+    status`` reads from there).
+
+    Contract tightening from the legacy mcp_infra dispatcher
+    (RDR-118 P2.S1b carryover): :meth:`register_document` raises
+    ``TypeError`` on coroutine-returning callables. The legacy
+    dispatcher accepted async hooks and silently dropped the returned
+    coroutine at fire time (audit F1 silent-failure mode); registration
+    surfaces the contract violation where the diagnostic points at the
+    buggy caller.
+    """
+
+    def __init__(self) -> None:
+        self._single: list[Callable[..., None]] = []
+        self._batch: list[Callable[..., None]] = []
+        self._batch_with_catalog_doc_id: set[int] = set()
+        self._document: list[Callable[..., None]] = []
+        self._document_with_doc_id: set[int] = set()
+
+    def clear(self) -> None:
+        """Drop every registration in all three chains. Useful for tests
+        that need to assert specific hooks in isolation against an
+        otherwise pre-populated registry."""
+        self._single.clear()
+        self._batch.clear()
+        self._batch_with_catalog_doc_id.clear()
+        self._document.clear()
+        self._document_with_doc_id.clear()
+
+    # ── Single-doc chain ─────────────────────────────────────────────────────
+
+    def register_single(self, fn: Callable[[str, str, str], None]) -> None:
+        """Register a ``fn(doc_id, collection, content)`` callable to
+        fire once per document. Mirrors the legacy
+        ``register_post_store_hook``."""
+        self._single.append(fn)
+
+    def fire_single(self, doc_id: str, collection: str, content: str) -> None:
+        """Invoke every single-doc hook. Per-hook exceptions are caught,
+        logged at WARNING, and persisted to T2 ``hook_failures``; never
+        propagated to the caller."""
+        for hook in self._single:
+            try:
+                hook(doc_id, collection, content)
+            except Exception as exc:
+                hook_name = getattr(hook, "__name__", "?")
+                _log.warning(
+                    "post_store_hook_failed",
+                    hook=hook_name,
+                    exc_info=True,
+                )
+                _record_hook_failure(
+                    doc_id=doc_id,
+                    collection=collection,
+                    hook_name=hook_name,
+                    error=str(exc),
+                )
+
+    # ── Batch chain ──────────────────────────────────────────────────────────
+
+    def register_batch(self, fn: Callable[..., None]) -> None:
+        """Register a batch hook. Classifies whether the callable
+        accepts ``catalog_doc_id`` at registration time so the dispatch
+        in :meth:`fire_batch` picks the right call shape per hook
+        (RDR-108 Phase 3 dual-shape contract)."""
+        self._batch.append(fn)
+        try:
+            sig = inspect.signature(fn)
+            params = sig.parameters
+            if "catalog_doc_id" in params or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD
+                for p in params.values()
+            ):
+                self._batch_with_catalog_doc_id.add(id(fn))
+        except (TypeError, ValueError):
+            # Builtin/C-extension callable with no introspectable
+            # signature. Treat as legacy shape so the dispatcher does not
+            # blow up on first call.
+            _log.debug(
+                "post_store_batch_hook_signature_unintrospectable",
+                hook=getattr(fn, "__name__", repr(fn)),
+            )
+
+    def fire_batch(
+        self,
+        doc_ids: list[str],
+        collection: str,
+        contents: list[str],
+        embeddings: list[list[float]] | None = None,
+        metadatas: list[dict] | None = None,
+        *,
+        catalog_doc_id: str = "",
+    ) -> None:
+        """Invoke every batch hook with the recorded call shape.
+
+        Empty ``doc_ids`` returns early — no hooks fire on empty batches
+        (matches the legacy dispatcher's semantics; chash dual-write,
+        taxonomy assign, and manifest write all early-return on empty
+        inputs anyway).
+
+        Per-hook exceptions are caught, logged at WARNING, and
+        persisted to T2 ``hook_failures`` with ``chain='batch'``; never
+        propagated to the caller.
+
+        *catalog_doc_id* (RDR-108 Phase 3) — catalog ``Document.tumbler``
+        for this batch's document. Required by ``manifest_write_batch_hook``
+        post-Phase-3; the manifest hook can no longer derive it from
+        chunk metadata.
+        """
+        if not doc_ids:
+            return
+        for hook in self._batch:
+            try:
+                if id(hook) in self._batch_with_catalog_doc_id:
+                    hook(
+                        doc_ids, collection, contents, embeddings, metadatas,
+                        catalog_doc_id=catalog_doc_id,
+                    )
+                else:
+                    hook(doc_ids, collection, contents, embeddings, metadatas)
+            except Exception as exc:
+                hook_name = getattr(hook, "__name__", "?")
+                _log.warning(
+                    "post_store_batch_hook_failed",
+                    hook=hook_name,
+                    exc_info=True,
+                )
+                _record_batch_hook_failure(
+                    doc_ids=doc_ids,
+                    collection=collection,
+                    hook_name=hook_name,
+                    error=str(exc),
+                )
+
+    # ── Document-grain chain ─────────────────────────────────────────────────
+
+    def register_document(self, fn: Callable[..., None]) -> None:
+        """Register a synchronous ``fn(source_path, collection, content)``
+        callable.
+
+        The synchronous-only contract is load-bearing for RDR-089
+        aspect extraction; coroutine-returning callables would be
+        silently dropped by the dispatcher. Registration raises
+        ``TypeError`` on coroutine functions so the contract violation
+        surfaces where the diagnostic points at the buggy caller.
+        """
+        if inspect.iscoroutinefunction(fn):
+            raise TypeError(
+                f"register_document(fn={getattr(fn, '__name__', repr(fn))}): "
+                "async callables are not supported. The dispatcher fires "
+                "synchronously and would drop the returned coroutine. "
+                "Hooks that need async work must run their own event loop "
+                "internally."
+            )
+        self._document.append(fn)
+        try:
+            sig = inspect.signature(fn)
+            params = sig.parameters
+            if "doc_id" in params or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD
+                for p in params.values()
+            ):
+                self._document_with_doc_id.add(id(fn))
+        except (TypeError, ValueError):
+            _log.debug(
+                "post_document_hook_signature_unintrospectable",
+                hook=getattr(fn, "__name__", repr(fn)),
+            )
+
+    def fire_document(
+        self,
+        source_path: str,
+        collection: str,
+        content: str,
+        *,
+        doc_id: str = "",
+    ) -> None:
+        """Invoke every document hook. Synchronous dispatch — no
+        ``asyncio.to_thread``, no ``await``. Per-hook exceptions caught,
+        logged, and persisted to T2 ``hook_failures`` with
+        ``chain='document'``; never propagated."""
+        for hook in self._document:
+            try:
+                if id(hook) in self._document_with_doc_id:
+                    hook(source_path, collection, content, doc_id=doc_id)
+                else:
+                    hook(source_path, collection, content)
+            except Exception as exc:
+                hook_name = getattr(hook, "__name__", "?")
+                _log.warning(
+                    "post_document_hook_failed",
+                    hook=hook_name,
+                    source_path=source_path,
+                    collection=collection,
+                    exc_info=True,
+                )
+                _record_document_hook_failure(
+                    source_path=source_path,
+                    collection=collection,
+                    hook_name=hook_name,
+                    error=str(exc),
+                )
+
+    # ── Combined fire helper ─────────────────────────────────────────────────
+
+    def fire_store_chains(
+        self,
+        doc_ids: list[str],
+        collection: str,
+        contents: list[str],
+        *,
+        source_paths: list[str] | None = None,
+        embeddings: list[list[float]] | None = None,
+        metadatas: list[dict] | None = None,
+        catalog_doc_id: str = "",
+    ) -> None:
+        """Fire all three post-store hook chains for a batch of just-stored
+        docs. Single, batch, and document-grain chains run in that order.
+        Errors caught per-hook and persisted; nothing propagated.
+
+        Used by MCP ``store_put`` and the CLI store-path entry points
+        (``nx store put``, ``nx memory promote``, ``nx store import``).
+        Bulk ``nx index *`` paths still call the three fire methods
+        directly to preserve the existing per-batch shape.
+        """
+        n = len(doc_ids)
+        if len(contents) != n:
+            raise ValueError(
+                f"contents length {len(contents)} != doc_ids length {n}"
+            )
+        if source_paths is None:
+            source_paths = list(doc_ids)
+        elif len(source_paths) != n:
+            raise ValueError(
+                f"source_paths length {len(source_paths)} != "
+                f"doc_ids length {n}"
+            )
+
+        for doc_id, content in zip(doc_ids, contents):
+            self.fire_single(doc_id, collection, content)
+
+        self.fire_batch(
+            doc_ids, collection, contents,
+            embeddings=embeddings, metadatas=metadatas,
+            catalog_doc_id=catalog_doc_id,
+        )
+
+        for did, sp, content in zip(doc_ids, source_paths, contents):
+            self.fire_document(sp, collection, content, doc_id=did)
+
+
+# ── Default-hooks factory ────────────────────────────────────────────────────
+
+
+def install_default_hooks(registry: HookRegistry) -> None:
+    """Register the load-bearing default consumers on *registry*.
+
+    Three batch hooks + one document hook were previously self-registered
+    at module load in ``nexus.mcp_infra`` (the batch trio) and
+    ``nexus.mcp.core`` (the aspect-extraction enqueue). Without these
+    consumers the catalog manifest, chash index, taxonomy assignments,
+    and aspect-extraction queue all silently fall out of sync with
+    every storage event.
+
+    Idempotent: re-registering the same callable on the same registry
+    is a no-op (duplicate-registration detection by identity).
+    """
+    from nexus.mcp_infra import (
+        chash_dual_write_batch_hook,
+        manifest_write_batch_hook,
+        taxonomy_assign_batch_hook,
+    )
+
+    for hook in (
+        chash_dual_write_batch_hook,
+        taxonomy_assign_batch_hook,
+        manifest_write_batch_hook,
+    ):
+        if hook not in registry._batch:
+            registry.register_batch(hook)
+
+    from nexus.aspect_worker import aspect_extraction_enqueue_hook
+    if aspect_extraction_enqueue_hook not in registry._document:
+        registry.register_document(aspect_extraction_enqueue_hook)
+
+
+# ── Failure-record helpers (moved from mcp_infra) ────────────────────────────
+
+
+def _record_hook_failure(
+    *,
+    doc_id: str,
+    collection: str,
+    hook_name: str,
+    error: str,
+) -> None:
+    """Persist a single-doc post-store hook failure to T2 ``hook_failures``.
+
+    Writes ``chain='single'`` (RDR-089 4.14.2 schema) when the column is
+    present, falling back to a chain-less insert on pre-4.14.2 DBs.
+    Secondary best-effort path: if the T2 write itself fails, swallow
+    the second failure (the primary warning already reached structlog)
+    rather than mask the original hook exception.
+    """
+    from nexus.mcp_infra import t2_ctx
+
+    truncated = error[:2000]
+    try:
+        with t2_ctx() as t2:
+            conn = t2.taxonomy.conn
+            with t2.taxonomy._lock:
+                try:
+                    conn.execute(
+                        "INSERT INTO hook_failures "
+                        "(doc_id, collection, hook_name, error, chain) "
+                        "VALUES (?, ?, ?, ?, 'single')",
+                        (doc_id, collection, hook_name, truncated),
+                    )
+                except sqlite3.OperationalError as exc:
+                    msg = str(exc)
+                    if "no column named" not in msg and "no such column" not in msg:
+                        raise
+                    conn.execute(
+                        "INSERT INTO hook_failures "
+                        "(doc_id, collection, hook_name, error) VALUES (?, ?, ?, ?)",
+                        (doc_id, collection, hook_name, truncated),
+                    )
+                conn.commit()
+    except Exception:
+        _log.debug(
+            "hook_failure_persist_failed",
+            hook=hook_name,
+            collection=collection,
+            exc_info=True,
+        )
+
+
+def _record_batch_hook_failure(
+    *,
+    doc_ids: list[str],
+    collection: str,
+    hook_name: str,
+    error: str,
+) -> None:
+    """Persist a batch-shape post-store hook failure to T2 ``hook_failures``.
+
+    Writes the JSON-encoded doc_id list to ``batch_doc_ids`` and sets
+    ``is_batch=1``; stores a representative scalar (first doc_id) in
+    the legacy ``doc_id`` column so existing scalar readers continue to
+    render something meaningful (RDR-095 schema migration adds the two
+    new columns in 4.14.1).
+
+    Falls back to scalar-only insert if the new columns don't exist
+    yet (mixed-version operator scenario).
+    """
+    from nexus.mcp_infra import t2_ctx
+
+    representative = doc_ids[0] if doc_ids else ""
+    payload = json.dumps(doc_ids)
+    truncated = error[:2000]
+    try:
+        with t2_ctx() as t2:
+            conn = t2.taxonomy.conn
+            with t2.taxonomy._lock:
+                try:
+                    conn.execute(
+                        "INSERT INTO hook_failures "
+                        "(doc_id, collection, hook_name, error, "
+                        " batch_doc_ids, is_batch, chain) "
+                        "VALUES (?, ?, ?, ?, ?, 1, 'batch')",
+                        (representative, collection, hook_name, truncated, payload),
+                    )
+                except sqlite3.OperationalError as exc:
+                    msg = str(exc)
+                    if "no column named" not in msg and "no such column" not in msg:
+                        raise
+                    try:
+                        conn.execute(
+                            "INSERT INTO hook_failures "
+                            "(doc_id, collection, hook_name, error, "
+                            " batch_doc_ids, is_batch) VALUES (?, ?, ?, ?, ?, 1)",
+                            (representative, collection, hook_name, truncated, payload),
+                        )
+                    except sqlite3.OperationalError as exc2:
+                        msg2 = str(exc2)
+                        if "no column named" not in msg2 and "no such column" not in msg2:
+                            raise
+                        conn.execute(
+                            "INSERT INTO hook_failures "
+                            "(doc_id, collection, hook_name, error) "
+                            "VALUES (?, ?, ?, ?)",
+                            (representative, collection, hook_name, truncated),
+                        )
+                conn.commit()
+    except Exception:
+        _log.debug(
+            "batch_hook_failure_persist_failed",
+            hook=hook_name,
+            collection=collection,
+            exc_info=True,
+        )
+
+
+def _record_document_hook_failure(
+    *,
+    source_path: str,
+    collection: str,
+    hook_name: str,
+    error: str,
+) -> None:
+    """Persist a document-grain hook failure to T2 ``hook_failures``.
+
+    Stores ``source_path`` in the legacy ``doc_id`` column (the column
+    carries 'subject of failure' regardless of chain shape) and sets
+    ``chain='document'`` so readers can render the row appropriately.
+
+    Two-tier fallback (vs. three-tier in :func:`_record_batch_hook_failure`)
+    is correct: the document chain is new in 4.14.2, so there is no
+    intermediate 4.14.1-shape schema to handle.
+    """
+    from nexus.mcp_infra import t2_ctx
+
+    truncated = error[:2000]
+    try:
+        with t2_ctx() as t2:
+            conn = t2.taxonomy.conn
+            with t2.taxonomy._lock:
+                try:
+                    conn.execute(
+                        "INSERT INTO hook_failures "
+                        "(doc_id, collection, hook_name, error, chain) "
+                        "VALUES (?, ?, ?, ?, 'document')",
+                        (source_path, collection, hook_name, truncated),
+                    )
+                except sqlite3.OperationalError as exc:
+                    msg = str(exc)
+                    if "no column named" not in msg and "no such column" not in msg:
+                        raise
+                    conn.execute(
+                        "INSERT INTO hook_failures "
+                        "(doc_id, collection, hook_name, error) "
+                        "VALUES (?, ?, ?, ?)",
+                        (source_path, collection, hook_name, truncated),
+                    )
+                conn.commit()
+    except Exception:
+        _log.debug(
+            "document_hook_failure_persist_failed",
+            hook=hook_name,
+            collection=collection,
+            exc_info=True,
+        )

--- a/src/nexus/index_context.py
+++ b/src/nexus/index_context.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from nexus.config import TuningConfig
+    from nexus.hook_registry import HookRegistry
     from nexus.indexer_utils import StalenessCache
 
 
@@ -85,6 +86,22 @@ class IndexContext:
     # current) from O(N) round-trips into a single paginated sweep.
     # ``None`` is the legacy / fall-through path.
     staleness_cache: "StalenessCache | None" = field(default=None)
+
+    # Post-store HookRegistry threaded down from the entry point so the
+    # per-file indexer fires the single / batch / document chains via the
+    # explicit instance rather than reaching into module-level globals.
+    # ``None`` is the contract signal that the caller did not wire a
+    # registry; ``__post_init__`` materialises a fresh empty
+    # ``HookRegistry`` so callers downstream can always assume the field
+    # is populated without an Optional check. Entry points wire
+    # load-bearing default consumers via
+    # :func:`nexus.hook_registry.install_default_hooks`.
+    hooks: "HookRegistry | None" = field(default=None)
+
+    def __post_init__(self) -> None:
+        if self.hooks is None:
+            from nexus.hook_registry import HookRegistry
+            self.hooks = HookRegistry()
 
 
 if TYPE_CHECKING:

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -53,6 +53,7 @@ _log = structlog.get_logger(__name__)
 if TYPE_CHECKING:
     from nexus.catalog.catalog import Catalog
     from nexus.catalog.tumbler import Tumbler
+    from nexus.hook_registry import HookRegistry
     from nexus.indexer_utils import StalenessCache
     from nexus.registry import RepoRegistry
     from nexus.stage_timers import StageTimers
@@ -866,6 +867,7 @@ def index_repository(
     on_file: Callable[[Path, int, float], None] | None = None,
     on_phase: Callable[[str], None] | None = None,
     on_stage_timers: Callable[[Path, "StageTimers"], None] | None = None,
+    hooks: "HookRegistry | None" = None,
 ) -> dict[str, int]:
     """Index all files in *repo* into T3 code__ and docs__ collections.
 
@@ -912,6 +914,11 @@ def index_repository(
             lock_fd.close()
             return {}
 
+    if hooks is None:
+        from nexus.hook_registry import HookRegistry, install_default_hooks
+        hooks = HookRegistry()
+        install_default_hooks(hooks)
+
     try:
         registry.update(repo, status="indexing")
         try:
@@ -919,7 +926,7 @@ def index_repository(
                 _run_index_frecency_only(repo, registry)
                 stats: dict[str, int] = {}
             else:
-                stats = _run_index(repo, registry, chunk_lines=chunk_lines, force=force, force_stale=force_stale, on_start=on_start, on_file=on_file, on_phase=on_phase, on_stage_timers=on_stage_timers)
+                stats = _run_index(repo, registry, chunk_lines=chunk_lines, force=force, force_stale=force_stale, on_start=on_start, on_file=on_file, on_phase=on_phase, on_stage_timers=on_stage_timers, hooks=hooks)
                 registry.update(repo, head_hash=_current_head(repo))
             registry.update(repo, status="ready")
             return stats
@@ -1122,6 +1129,7 @@ def _index_code_file(
     stage_timers: "StageTimers | None" = None,
     doc_id_resolver: Callable[[Path], str] | None = None,
     staleness_cache: "StalenessCache | None" = None,
+    hooks: "HookRegistry | None" = None,
 ) -> int:
     """Index a single code file.  Delegates to nexus.code_indexer.index_code_file.
 
@@ -1161,6 +1169,7 @@ def _index_code_file(
         stage_timers=stage_timers,
         doc_id_resolver=doc_id_resolver,
         staleness_cache=staleness_cache,
+        hooks=hooks,
     )
     return index_code_file(ctx, file)
 
@@ -1183,6 +1192,7 @@ def _index_prose_file(
     stage_timers: "StageTimers | None" = None,
     doc_id_resolver: Callable[[Path], str] | None = None,
     staleness_cache: "StalenessCache | None" = None,
+    hooks: "HookRegistry | None" = None,
 ) -> int:
     """Index a single prose file.  Delegates to nexus.prose_indexer.index_prose_file.
 
@@ -1218,6 +1228,7 @@ def _index_prose_file(
         stage_timers=stage_timers,
         doc_id_resolver=doc_id_resolver,
         staleness_cache=staleness_cache,
+        hooks=hooks,
     )
     return index_prose_file(ctx, file)
 
@@ -1240,6 +1251,7 @@ def _index_pdf_file(
     embed_fn: Callable | None = None,
     stage_timers: "StageTimers | None" = None,
     doc_id_resolver: Callable[[Path], str] | None = None,
+    hooks: "HookRegistry | None" = None,
 ) -> int:
     """Index a single PDF file into the docs__ collection.
 
@@ -1370,22 +1382,22 @@ def _index_pdf_file(
         # batch one document at a time so per-doc hooks (e.g. RDR-089
         # aspect extraction) cover CLI ingest the same way they cover
         # MCP store_put.
-        from nexus.mcp_infra import (
-            fire_post_document_hooks,
-            fire_post_store_batch_hooks,
-            fire_post_store_hooks,
-        )
-        fire_post_store_batch_hooks(
+        if hooks is None:
+            from nexus.hook_registry import HookRegistry, install_default_hooks
+            hooks = HookRegistry()
+            install_default_hooks(hooks)
+        hooks.fire_batch(
             ids, collection_name, documents, embeddings, metadatas,
+            catalog_doc_id=catalog_doc_id,
         )
         for _did, _doc in zip(ids, documents):
-            fire_post_store_hooks(_did, collection_name, _doc)
+            hooks.fire_single(_did, collection_name, _doc)
         # RDR-089 document-grain chain — once per PDF file boundary in
         # the `nx index repo` PDF path. content="" (chunk-level scope
         # only); the hook reads source_path itself per the P0.1
         # content-sourcing contract.
         # nexus-tdgc: forward catalog doc_id when available.
-        fire_post_document_hooks(
+        hooks.fire_document(
             str(file), collection_name, "",
             doc_id=catalog_doc_id,
         )
@@ -1402,6 +1414,7 @@ def _discover_and_index_rdrs(
     *,
     force: bool = False,
     embed_fn: Callable | None = None,
+    hooks: "HookRegistry | None" = None,
 ) -> tuple[int, int, int]:
     """Find .md files under RDR paths and index them via batch_index_markdowns.
 
@@ -1444,7 +1457,7 @@ def _discover_and_index_rdrs(
     _log.info("indexing RDR files", count=len(md_paths), collection=collection)
     results = batch_index_markdowns(md_paths, corpus=basename, t3=db,
                                     collection_name=collection, force=force,
-                                    embed_fn=embed_fn)
+                                    embed_fn=embed_fn, hooks=hooks)
     indexed = sum(1 for s in results.values() if s == "indexed")
     skipped = sum(1 for s in results.values() if s == "skipped")
     failed = sum(1 for s in results.values() if s == "failed")
@@ -1863,6 +1876,7 @@ def _run_index(
     on_file: Callable[[Path, int, float], None] | None = None,
     on_phase: Callable[[str], None] | None = None,
     on_stage_timers: Callable[[Path, "StageTimers"], None] | None = None,
+    hooks: "HookRegistry | None" = None,
 ) -> dict[str, int]:
     """Full indexing pipeline: classify → route → embed → upsert → prune.
 
@@ -2299,6 +2313,7 @@ def _run_index(
             stage_timers=timers,
             doc_id_resolver=_doc_id_resolver,
             staleness_cache=code_staleness,
+            hooks=hooks,
         )
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)
@@ -2325,6 +2340,7 @@ def _run_index(
             stage_timers=timers,
             doc_id_resolver=_doc_id_resolver,
             staleness_cache=docs_staleness,
+            hooks=hooks,
         )
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)
@@ -2350,6 +2366,7 @@ def _run_index(
             embed_fn=_embed_fn,
             stage_timers=timers,
             doc_id_resolver=_doc_id_resolver,
+            hooks=hooks,
         )
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)
@@ -2389,7 +2406,7 @@ def _run_index(
         _t = time.monotonic()
         rdr_indexed, rdr_current, rdr_failed = _discover_and_index_rdrs(
             repo, rdr_abs_paths, db, voyage_key, now_iso, force=force,
-            embed_fn=_embed_fn_doc,
+            embed_fn=_embed_fn_doc, hooks=hooks,
         )
         _phase(
             f"RDR indexing done — {rdr_indexed} indexed, {rdr_current} current, "

--- a/src/nexus/mcp/AGENTS.md
+++ b/src/nexus/mcp/AGENTS.md
@@ -9,17 +9,17 @@ Two FastMCP servers and the post-store hook framework that backs them. The singl
 | `core.py` | `nexus` | 14 tools: `search`, `query`, `store_put/get/list`, `memory_*`, `scratch*`, `collection_list`, `plan_save/search` |
 | `catalog.py` | `nexus-catalog` | 10 tools: `search`, `show`, `list`, `register`, `update`, `link`, `links`, `link_query`, `resolve`, `stats` (the `catalog_` prefix is dropped — server namespace already provides context) |
 
-`mcp_infra.py` holds singletons (T2/T3 clients), test injection, post-store hook registries, and `check_version_compatibility`. `mcp_server.py` is a backward-compat shim re-exporting all 30 functions.
+`mcp_infra.py` holds singletons (T2/T3 clients), test injection, default post-store hook consumers, and `check_version_compatibility`. The three-chain hook registry itself lives in `nexus.hook_registry.HookRegistry` and is constructor-injected from each entry point (MCP server, CLI command, indexer). `mcp_server.py` is a backward-compat shim re-exporting all 30 functions.
 
 ## Post-store hook framework
 
-Three parallel chains — pick the one that matches your workload shape:
+Three parallel chains on `HookRegistry` — pick the one that matches your workload shape:
 
 | Shape | Register with | Fired from | When to use |
 |---|---|---|---|
-| **Single-doc** | `register_post_store_hook(fn)` | MCP `store_put` (1×); CLI ingest (per-doc) | Per-document work keyed on `doc_id`. **Currently empty by default.** |
-| **Batch** | `register_post_store_batch_hook(fn)` | CLI ingest (full batch); MCP `store_put` (1-element batch) | Work that benefits from batched dependency calls — one ChromaDB query for N centroids, one batched T2 upsert. |
-| **Document-grain** | `register_post_document_hook(fn)` | MCP `store_put` + 8 CLI ingest sites in 6 modules | Source-document boundary as stable identity (vs chunk-level `doc_id`). |
+| **Single-doc** | `registry.register_single(fn)` | MCP `store_put` (1×); CLI ingest (per-doc) | Per-document work keyed on `doc_id`. **Currently empty by default.** |
+| **Batch** | `registry.register_batch(fn)` | CLI ingest (full batch); MCP `store_put` (1-element batch) | Work that benefits from batched dependency calls — one ChromaDB query for N centroids, one batched T2 upsert. |
+| **Document-grain** | `registry.register_document(fn)` | MCP `store_put` + 8 CLI ingest sites in 6 modules | Source-document boundary as stable identity (vs chunk-level `doc_id`). |
 
 All three:
 
@@ -32,7 +32,8 @@ All three:
 - **Batch chain** (registration order is load-bearing):
   1. `chash_dual_write_batch_hook` (RDR-086) — must run first so chash rows exist before topic assignment.
   2. `taxonomy_assign_batch_hook` (RDR-070) — accepts `embeddings=None` from the MCP path and fetches them from T3 inline.
-- **Document-grain chain**: `aspect_extraction_enqueue_hook` (RDR-089). Defined in `aspect_worker.py`, registered in `mcp/core.py`. Enqueues to T2 `aspect_extraction_queue`; a daemon worker thread drains it and invokes `extract_aspects`. Async dispatch was necessary because the spike measured 26.5s median per document — blocking-inline would have been a non-starter on the ingest path.
+  3. `manifest_write_batch_hook` (RDR-108 D2) — populates the catalog `document_chunks` manifest.
+- **Document-grain chain**: `aspect_extraction_enqueue_hook` (RDR-089). Defined in `aspect_worker.py`, registered via `install_default_hooks` in `hook_registry.py`. Enqueues to T2 `aspect_extraction_queue`; a daemon worker thread drains it and invokes `extract_aspects`. Async dispatch was necessary because the spike measured 26.5s median per document — blocking-inline would have been a non-starter on the ingest path.
 
 ### Content-sourcing contract (document-grain chain)
 
@@ -44,10 +45,10 @@ All three:
 
 `tests/test_hook_drift_guard.py` uses `ast.walk` to enforce two guarded sets:
 
-- `GUARDED_NAMES = {taxonomy_assign_batch_hook, chash_dual_write_batch_hook}` — may only appear in `mcp_infra.py` (definition) and `mcp/core.py` (registration).
-- `DOCUMENT_HOOK_GUARDED_NAMES = {aspect_extraction_enqueue_hook}` — may only appear in `aspect_worker.py` (definition) and `mcp/core.py` (registration).
+- `GUARDED_NAMES = {taxonomy_assign_batch_hook, chash_dual_write_batch_hook}` — may only appear in `mcp_infra.py` (definition) and `hook_registry.py` (registration via `install_default_hooks`).
+- `DOCUMENT_HOOK_GUARDED_NAMES = {aspect_extraction_enqueue_hook}` — may only appear in `aspect_worker.py` (definition) and `hook_registry.py` (registration via `install_default_hooks`).
 
-**New consumers register through the `register_post_*_hook` API.** Direct calls fail CI.
+**New consumers register through `HookRegistry.register_single/batch/document` (or `install_default_hooks` for load-bearing defaults).** Direct calls fail CI.
 
 A separate runtime fire-once test (`test_index_pdf_fires_document_hook_exactly_once` in `tests/test_doc_indexer.py`) drives a sample PDF through `index_pdf` with a counting probe hook to assert the document chain fires exactly once per source document — the AST count guard alone cannot detect a regression that moves a fire site inside a per-chunk loop.
 
@@ -59,5 +60,5 @@ A separate runtime fire-once test (`test_index_pdf_fires_document_hook_exactly_o
 ## Hot rules
 
 - **Always use full MCP tool names.** `mcp__plugin_<plugin>_<server>__<tool>`. Short names fail at runtime (no resolution layer exists).
-- **Register, don't import.** Add new hook consumers via `register_post_*_hook`, not by direct call. CI's drift guard will reject the bypass.
+- **Register, don't import.** Add new hook consumers via `HookRegistry.register_*` (or extend `install_default_hooks` for load-bearing defaults), not by direct call. CI's drift guard will reject the bypass.
 - **Preserve registration order on the batch chain.** chash before taxonomy. Other orderings violate the chash-rows-exist invariant.

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -20,17 +20,14 @@ from nexus.corpus import (
 from nexus.db.t3 import verify_collection_deep
 from nexus.filters import parse_where_str as _parse_where_str
 from nexus.config import load_config
+from nexus.hook_registry import HookRegistry as _HookRegistry, install_default_hooks as _install_default_hooks
 from nexus.mcp_infra import (
     catalog_auto_link as _catalog_auto_link,
-    fire_post_document_hooks as _fire_post_document_hooks,
-    fire_post_store_batch_hooks as _fire_post_store_batch_hooks,
-    fire_post_store_hooks as _fire_post_store_hooks,
     get_catalog as _get_catalog,
     get_collection_names as _get_collection_names,
     get_recent_search_traces as _get_recent_search_traces,
     get_t1 as _get_t1,
     get_t3 as _get_t3,
-    inject_catalog as _inject_catalog,
     inject_t1 as _inject_t1,
     inject_t3 as _inject_t3,
     record_search_trace as _record_search_trace,
@@ -38,6 +35,14 @@ from nexus.mcp_infra import (
     t2_ctx as _t2_ctx,
 )
 from nexus.ttl import parse_ttl
+
+#: Process-local HookRegistry constructed at MCP-server startup.
+#: The MCP server is a long-running entry point — the registry's
+#: lifecycle matches the server process. ``install_default_hooks``
+#: wires the load-bearing default consumers (chash, taxonomy, manifest,
+#: aspect-extraction).
+_hooks = _HookRegistry()
+_install_default_hooks(_hooks)
 
 # ── T1 chroma lifecycle (RDR-105 P4) ────────────────────────────────────────
 #
@@ -412,41 +417,24 @@ def _record_tier_write(
         pass
 
 
-# ── Post-store hooks (register once at import) ──────────────────────────────
+# ── Post-store hooks (process-local registry constructed above) ─────────────
 #
-# RDR-095 + symmetric-fire follow-up: every storage event (MCP store_put or
-# CLI bulk ingest) fires BOTH chains. Hooks pick exactly one shape based on
-# their work pattern. Taxonomy registers batch-only because its dependency
-# call (assign_batch) collapses N ChromaDB queries into one; the hook handles
-# 1-element batches from MCP store_put by fetching the embedding inline.
-# Future single-doc-only consumers (e.g. RDR-089 aspect extraction with one
-# Haiku call per doc) register via register_post_store_hook and fire from
-# every path automatically.
+# RDR-095 + symmetric-fire follow-up: every storage event (MCP ``store_put``
+# or CLI bulk ingest) fires the three chains on a ``HookRegistry`` threaded
+# top-down from the entry point. For MCP the entry point is module load
+# time (long-running server process); ``_hooks`` is constructed above and
+# ``_install_default_hooks`` wires the load-bearing default consumers:
 #
-# Registration order within the batch chain is load-bearing: chash dual-write
-# must precede taxonomy assignment so chash rows exist before topic assignment
-# runs (mirroring the legacy chash-before-taxonomy CLI invariant).
-
-from nexus.mcp_infra import (
-    register_post_document_hook,
-)
-
-# RDR-108 Phase 3 (nexus-bdag): the three batch hooks
-# (chash_dual_write_batch_hook, taxonomy_assign_batch_hook,
-# manifest_write_batch_hook) now self-register at module load in
-# ``nexus.mcp_infra`` so CLI-only flows (``nx index repo``) also fire
-# them. Pre-Phase-3 the registrations lived here, which silently
-# skipped them for non-MCP code paths.
-
-# RDR-089 follow-up (nexus-qeo8): document-grain hook chain consumer.
-# The synchronous-inline shape was invalidated by the P1.3 spike
-# (median 26.5 s / p95 38.1 s per document). The enqueue hook writes
-# to aspect_extraction_queue (microsecond-scale) and lazy-spawns a
-# background worker that drains the queue and invokes the existing
-# synchronous extract_aspects.
-from nexus.aspect_worker import aspect_extraction_enqueue_hook
-
-register_post_document_hook(aspect_extraction_enqueue_hook)
+# * Three batch hooks (chash dual-write, taxonomy assign, manifest write)
+#   for the cross-cutting catalog / index correctness work.
+# * One document hook (RDR-089 aspect-extraction enqueue) which writes to
+#   aspect_extraction_queue (microsecond-scale) and lazy-spawns a
+#   background worker that drains the queue and invokes the synchronous
+#   extract_aspects.
+#
+# Registration order within the batch chain is load-bearing: chash
+# dual-write must precede taxonomy assignment so chash rows exist before
+# topic assignment runs.
 
 # ── Registered tools ─────────────────────────────────────────────────────────
 
@@ -1074,18 +1062,15 @@ def store_put(
                 structlog.get_logger().debug(
                     "store_put_auto_linked", doc_id=doc_id, link_count=n,
                 )
-        # Both post-store chains fire from every storage event (RDR-095
-        # symmetric-fire follow-up). Single-doc chain runs registered
-        # per-doc consumers; batch chain runs with a 1-element list so
-        # batch-shape consumers (taxonomy, chash) see MCP store_put as
-        # a single-document batch.
-        #
-        # Direct fire calls are required here (not the nexus-9099
-        # ``fire_store_chains`` helper) because ``test_hook_drift_guard``
-        # AST-counts these three names verbatim in mcp/core.py to enforce
-        # the 7-CLI + 1-MCP fire-site invariant.
-        _fire_post_store_hooks(doc_id, col_name, content)
-        _fire_post_store_batch_hooks(
+        # All three post-store chains fire from every storage event
+        # (RDR-095 symmetric-fire follow-up) via the process-local
+        # ``_hooks`` registry constructed at module load. Single-doc
+        # chain runs registered per-doc consumers; batch chain runs
+        # with a 1-element list so batch-shape consumers (taxonomy,
+        # chash, manifest) see MCP ``store_put`` as a single-document
+        # batch.
+        _hooks.fire_single(doc_id, col_name, content)
+        _hooks.fire_batch(
             [doc_id], col_name, [content], None, None,
             catalog_doc_id=catalog_doc_id,
         )
@@ -1099,7 +1084,7 @@ def store_put(
         # the hook uses for failure attribution.
         # nexus-tdgc: forward doc_id explicitly so the aspect-queue
         # hook can store it on the queue row alongside source_path.
-        _fire_post_document_hooks(doc_id, col_name, content, doc_id=doc_id)
+        _hooks.fire_document(doc_id, col_name, content, doc_id=doc_id)
         # RDR-061 E2: log relevance correlation for the most recent search in
         # this session. Only the newest trace is used to minimize noise —
         # older traces are unlikely to have driven this store_put.

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -25,14 +25,6 @@ _t3_lock = threading.Lock()
 _collections_cache: tuple[list[str], float] = ([], 0.0)
 _COLLECTIONS_CACHE_TTL = 60.0
 
-# Test-injection slot only — production never reads from this except as a
-# test-override hook (see ``inject_catalog``). The process-level Catalog
-# cache that lived here was eliminated; ``get_catalog()`` now constructs
-# fresh per call. Tests that want to assert against a specific Catalog
-# call ``inject_catalog(cat)`` to populate this slot; ``reset_singletons``
-# clears it.
-_catalog_instance = None
-
 # ── Search trace cache (RDR-061 E2) ──────────────────────────────────────────
 # Session-keyed cache of recent search results. Populated by the search tool,
 # consumed by store_put and catalog_link to correlate agent actions with the
@@ -265,12 +257,12 @@ def get_catalog():
     once and pass the result down (top-down DI) — see also
     ``commands/catalog.py:_get_catalog`` for the established pattern.
 
-    Test override: ``inject_catalog(cat)`` populates a slot that this
-    function returns in preference to constructing fresh; used by
-    tests that need to assert against a specific Catalog instance.
+    Tests that need a specific Catalog instance under test set
+    ``NEXUS_CATALOG_PATH`` (which ``catalog_path()`` reads) so this
+    function constructs at the test's location; the autouse
+    ``_isolate_catalog`` fixture in ``tests/conftest.py`` provides
+    a per-test default.
     """
-    if _catalog_instance is not None:
-        return _catalog_instance
     from nexus.catalog import Catalog
     from nexus.config import catalog_path
     path = catalog_path()
@@ -346,287 +338,15 @@ def resolve_tumbler_mcp(cat, value):
     return resolve_tumbler(cat, value)
 
 
-# ── Post-store hooks (RDR-070, nexus-7h2) ────────────────────────────────────
-# Synchronous hooks that fire after every store_put. Exceptions are caught per-
-# hook and logged, never propagated — same non-fatal pattern as auto_linker.
-
-_post_store_hooks: list = []
-
-
-def register_post_store_hook(fn) -> None:
-    """Register a callable(doc_id, collection, content) to fire after store_put."""
-    _post_store_hooks.append(fn)
-
-
-def fire_post_store_hooks(doc_id: str, collection: str, content: str) -> None:
-    """Invoke all registered post-store hooks. Exceptions logged, never raised.
-
-    Failures are additionally persisted to T2 ``hook_failures`` (GH #251) so
-    ``nx taxonomy status`` can surface them with an Action line. The persist
-    path is itself guarded — if the T2 write fails, the store_put still
-    succeeds and structlog still carries the original warning.
-    """
-    import structlog
-    _hook_log = structlog.get_logger()
-    for hook in _post_store_hooks:
-        try:
-            hook(doc_id, collection, content)
-        except Exception as exc:
-            hook_name = getattr(hook, "__name__", "?")
-            _hook_log.warning(
-                "post_store_hook_failed",
-                hook=hook_name,
-                exc_info=True,
-            )
-            _record_hook_failure(
-                doc_id=doc_id,
-                collection=collection,
-                hook_name=hook_name,
-                error=str(exc),
-            )
-
-
-def _record_hook_failure(
-    *,
-    doc_id: str,
-    collection: str,
-    hook_name: str,
-    error: str,
-) -> None:
-    """Persist a post-store hook failure to T2 ``hook_failures`` (GH #251).
-
-    Populates ``chain='single'`` (RDR-089 4.14.2 schema) when the column
-    is present, falling back to a chain-less insert on pre-4.14.2 DBs.
-    Secondary best-effort path: if the T2 write itself fails, swallow
-    the second failure (the primary warning already reached structlog)
-    rather than mask the original hook exception.
-    """
-    import sqlite3
-    truncated = error[:2000]
-    try:
-        with t2_ctx() as t2:
-            # ``hook_failures`` is cross-cutting — any domain's connection
-            # points at the same SQLite file. Use the taxonomy conn because
-            # the status line that surfaces these rows already reads there.
-            conn = t2.taxonomy.conn
-            with t2.taxonomy._lock:
-                try:
-                    conn.execute(
-                        "INSERT INTO hook_failures "
-                        "(doc_id, collection, hook_name, error, chain) "
-                        "VALUES (?, ?, ?, ?, 'single')",
-                        (doc_id, collection, hook_name, truncated),
-                    )
-                except sqlite3.OperationalError as exc:
-                    msg = str(exc)
-                    if "no column named" not in msg and "no such column" not in msg:
-                        raise
-                    # Pre-4.14.2 schema: chain column absent.
-                    conn.execute(
-                        "INSERT INTO hook_failures "
-                        "(doc_id, collection, hook_name, error) VALUES (?, ?, ?, ?)",
-                        (doc_id, collection, hook_name, truncated),
-                    )
-                conn.commit()
-    except Exception:
-        import structlog
-        structlog.get_logger().debug(
-            "hook_failure_persist_failed",
-            hook=hook_name,
-            collection=collection,
-            exc_info=True,
-        )
-
-
-# ── Post-store batch hooks (RDR-095, nexus-wxcb) ─────────────────────────────
-# Parallel batch-shape contract for bulk-ingest enrichment. Single-document
-# hooks above fire from MCP store_put; batch hooks fire from CLI indexing
-# paths where N docs land in one operation and consumers benefit from
-# batched dependency calls (e.g. one ChromaDB query for N centroids vs N
-# sequential queries). Same per-hook failure-isolation pattern: exceptions
-# captured, persisted to T2 hook_failures, never propagated.
-
-_post_store_batch_hooks: list = []
-#: Set of hook callables that accept the kwarg-only ``catalog_doc_id``
-#: parameter (RDR-108 Phase 3). Populated lazily by
-#: :func:`register_post_store_batch_hook` via
-#: :func:`inspect.signature`. The dispatch in
-#: :func:`fire_post_store_batch_hooks` uses this set to pick the call
-#: shape per hook, avoiding the fragile substring-match-on-TypeError
-#: fallback that the first cut of Phase 3 used.
-_post_store_batch_hooks_with_catalog_doc_id: set = set()
-
-
-def register_post_store_batch_hook(fn) -> None:
-    """Register a callable(doc_ids, collection, contents, embeddings, metadatas
-    [, *, catalog_doc_id]) to fire after batch CLI ingest.
-
-    The callable's signature is inspected once at registration time so
-    the dispatcher can pick the right call shape — hooks predating
-    RDR-108 Phase 3 do not accept ``catalog_doc_id`` and must be invoked
-    with the legacy 5-argument form.
-    """
-    _post_store_batch_hooks.append(fn)
-    try:
-        import inspect
-        sig = inspect.signature(fn)
-        params = sig.parameters
-        # Accept hooks that explicitly name catalog_doc_id OR accept arbitrary
-        # **kwargs (the latter cannot be statically classified, so passthrough
-        # is the conservative choice — no harm if the hook ignores).
-        if "catalog_doc_id" in params or any(
-            p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-        ):
-            _post_store_batch_hooks_with_catalog_doc_id.add(id(fn))
-    except (TypeError, ValueError):
-        # Built-in or C-extension callable with no introspectable
-        # signature — assume legacy shape so the dispatcher does not
-        # blow up on first call. Log at debug so the registration is
-        # visible when chasing a "hook never seems to fire correctly"
-        # symptom; if the underlying callable actually accepts
-        # catalog_doc_id, the legacy 5-arg dispatch will silently drop
-        # the value.
-        import structlog
-        structlog.get_logger().debug(
-            "post_store_batch_hook_signature_unintrospectable",
-            hook=getattr(fn, "__name__", repr(fn)),
-        )
-
-
-def fire_post_store_batch_hooks(
-    doc_ids: list[str],
-    collection: str,
-    contents: list[str],
-    embeddings: list[list[float]] | None = None,
-    metadatas: list[dict] | None = None,
-    *,
-    catalog_doc_id: str = "",
-) -> None:
-    """Invoke all registered batch hooks. Per-hook failures captured and
-    persisted to T2 hook_failures, never raised.
-
-    Empty doc_ids returns early: no hooks fire on empty batches.
-
-    Different consumers read different payload fields:
-    chash_dual_write_batch_hook reads metadatas, taxonomy_assign_batch_hook
-    reads embeddings. Hooks ignore parameters they don't need.
-
-    *catalog_doc_id* (RDR-108 Phase 3) — catalog ``Document.tumbler``
-    string for the document this batch belongs to. Required by
-    ``manifest_write_batch_hook`` after Phase 3 retired ``doc_id`` from
-    chunk metadata; the manifest hook can no longer derive it from the
-    chunks themselves. Empty string is the "unknown document" sentinel
-    — the manifest hook then falls back to legacy ``meta.doc_id`` reads
-    (still populated on pre-Phase-3 chunks).
-    """
-    if not doc_ids:
-        return
-    import structlog
-    _hook_log = structlog.get_logger()
-    for hook in _post_store_batch_hooks:
-        try:
-            # RDR-108 Phase 3: pick the call shape per hook based on the
-            # signature classification computed at registration time.
-            # Hooks predating Phase 3 do not accept ``catalog_doc_id``;
-            # we invoke them with the legacy 5-argument shape.
-            if id(hook) in _post_store_batch_hooks_with_catalog_doc_id:
-                hook(
-                    doc_ids, collection, contents, embeddings, metadatas,
-                    catalog_doc_id=catalog_doc_id,
-                )
-            else:
-                hook(doc_ids, collection, contents, embeddings, metadatas)
-        except Exception as exc:
-            hook_name = getattr(hook, "__name__", "?")
-            _hook_log.warning(
-                "post_store_batch_hook_failed",
-                hook=hook_name,
-                exc_info=True,
-            )
-            _record_batch_hook_failure(
-                doc_ids=doc_ids,
-                collection=collection,
-                hook_name=hook_name,
-                error=str(exc),
-            )
-
-
-def _record_batch_hook_failure(
-    *,
-    doc_ids: list[str],
-    collection: str,
-    hook_name: str,
-    error: str,
-) -> None:
-    """Persist a batch-shape post-store hook failure to T2 ``hook_failures``.
-
-    Writes the JSON-encoded doc_id list to ``batch_doc_ids`` and sets
-    ``is_batch=1``; stores a representative scalar (first doc_id) in the
-    legacy ``doc_id`` column so existing scalar readers continue to render
-    something meaningful (RDR-095 schema migration adds the two new columns
-    in 4.14.1).
-
-    Falls back to scalar-only insert if the new columns don't exist yet
-    (P1.1 merged before P1.2 migration ran). Same secondary best-effort
-    semantics as ``_record_hook_failure``: persistence failure cannot
-    break ingest.
-    """
-    import json
-    import sqlite3
-    representative = doc_ids[0] if doc_ids else ""
-    payload = json.dumps(doc_ids)
-    truncated = error[:2000]
-    try:
-        with t2_ctx() as t2:
-            conn = t2.taxonomy.conn
-            with t2.taxonomy._lock:
-                try:
-                    # 4.14.2 schema: dual-write chain alongside is_batch
-                    # so RDR-089 readers can classify rows by chain while
-                    # legacy readers still see is_batch=1.
-                    conn.execute(
-                        "INSERT INTO hook_failures "
-                        "(doc_id, collection, hook_name, error, "
-                        " batch_doc_ids, is_batch, chain) "
-                        "VALUES (?, ?, ?, ?, ?, 1, 'batch')",
-                        (representative, collection, hook_name, truncated, payload),
-                    )
-                except sqlite3.OperationalError as exc:
-                    # Pre-4.14.x schema: chain and/or batch columns may be
-                    # absent. Narrow catch to schema errors so transient
-                    # lock or I/O failures bubble up to the outer guard
-                    # rather than silently degrading the captured row.
-                    msg = str(exc)
-                    if "no column named" not in msg and "no such column" not in msg:
-                        raise
-                    # Try the 4.14.1 shape (is_batch + batch_doc_ids, no chain)
-                    # before falling back to scalar-only.
-                    try:
-                        conn.execute(
-                            "INSERT INTO hook_failures "
-                            "(doc_id, collection, hook_name, error, "
-                            " batch_doc_ids, is_batch) VALUES (?, ?, ?, ?, ?, 1)",
-                            (representative, collection, hook_name, truncated, payload),
-                        )
-                    except sqlite3.OperationalError as exc2:
-                        msg2 = str(exc2)
-                        if "no column named" not in msg2 and "no such column" not in msg2:
-                            raise
-                        conn.execute(
-                            "INSERT INTO hook_failures "
-                            "(doc_id, collection, hook_name, error) "
-                            "VALUES (?, ?, ?, ?)",
-                            (representative, collection, hook_name, truncated),
-                        )
-                conn.commit()
-    except Exception:
-        import structlog
-        structlog.get_logger().debug(
-            "batch_hook_failure_persist_failed",
-            hook=hook_name,
-            collection=collection,
-            exc_info=True,
-        )
+# ── Default post-store hook consumers ────────────────────────────────────────
+# Pure functions used as default registrations on every HookRegistry the
+# CLI / MCP entry points build. The HookRegistry class + its three
+# dispatchers (single / batch / document) live in nexus.hook_registry; the
+# install_default_hooks(registry) factory there wires the consumers below
+# onto every freshly constructed registry. Registration order within the
+# batch chain is load-bearing: chash dual-write must precede taxonomy
+# assignment so chash rows exist before topic assignment runs (mirrors
+# the legacy chash-before-taxonomy invariant).
 
 
 def taxonomy_assign_batch_hook(
@@ -640,7 +360,7 @@ def taxonomy_assign_batch_hook(
 ) -> None:
     """Registered batch hook: assign indexed docs to their nearest topics.
 
-    Called via ``fire_post_store_batch_hooks`` from every storage event:
+    Called via ``HookRegistry.fire_batch`` from every storage event:
     CLI bulk ingest passes the embeddings already computed by the upsert;
     MCP ``store_put`` passes ``embeddings=None`` and the hook fetches them
     from T3 inline (one ChromaDB get per doc). The fetch falls back to
@@ -651,8 +371,8 @@ def taxonomy_assign_batch_hook(
     No-op when centroids don't exist (no discover run yet) or the
     collection is excluded.
 
-    Registered once via ``register_post_store_batch_hook`` in
-    ``mcp/core.py``.
+    Wired by :func:`nexus.hook_registry.install_default_hooks` onto every
+    runtime-constructed registry.
     """
     from fnmatch import fnmatch
 
@@ -770,7 +490,7 @@ def chash_dual_write_batch_hook(
     """Registered batch hook (RDR-095): best-effort dual-write of
     ``chash_index`` rows after a T3 upsert.
 
-    Called via ``fire_post_store_batch_hooks`` from every CLI indexing
+    Called via ``HookRegistry.fire_batch`` from every CLI indexing
     path immediately after ``t3.upsert_chunks_with_embeddings(...)``.
     Reads ``metadatas``; ignores ``contents`` and ``embeddings``. Opens a
     fresh T2Database (matching ``taxonomy_assign_batch_hook``'s
@@ -779,8 +499,8 @@ def chash_dual_write_batch_hook(
     on any outer failure: a T2 failure must never abort the enclosing
     T3 write path.
 
-    Registered via ``register_post_store_batch_hook`` in
-    ``mcp/core.py``.
+    Wired by :func:`nexus.hook_registry.install_default_hooks` onto every
+    runtime-constructed registry.
     """
     if not doc_ids or not metadatas:
         return
@@ -810,7 +530,7 @@ def manifest_write_batch_hook(
     Calls ``Catalog.append_manifest_chunks`` (UPSERT keyed on
     ``(doc_id, position)``) once per batch. Multi-batch indexing paths
     (streaming PDF pipeline, doc_indexer incremental loop, anything
-    that splits a document across multiple ``fire_post_store_batch_hooks``
+    that splits a document across multiple ``HookRegistry.fire_batch``
     calls for the same ``catalog_doc_id``) accumulate the manifest
     correctly across batches because UPSERT on the primary key does not
     DELETE prior rows. Re-indexing with fewer chunks than before may
@@ -907,321 +627,6 @@ def manifest_write_batch_hook(
             structlog.get_logger().warning(
                 "manifest_write_hook_failed", doc_id=doc_id, exc_info=True
             )
-
-
-# RDR-108 Phase 3 (nexus-bdag): the three batch hooks above are
-# load-bearing for catalog correctness across BOTH CLI ingest and MCP
-# tool calls (e.g. ``nx index repo`` populates ``chash_index``,
-# ``taxonomy_assignments``, and ``document_chunks`` on the catalog
-# manifest). Pre-Phase-3 the registrations lived in ``nexus.mcp.core``
-# so the hooks fired only when an MCP server started up; CLI-only
-# flows silently skipped them, leaving the catalog manifest empty for
-# ``nx index repo``-only corpora. Registering here at module load
-# keeps both paths honest — every code path that fires the batch
-# chain (every indexer goes through ``mcp_infra.fire_post_store_batch_hooks``)
-# is guaranteed to also have the hooks attached.
-register_post_store_batch_hook(chash_dual_write_batch_hook)
-register_post_store_batch_hook(taxonomy_assign_batch_hook)
-register_post_store_batch_hook(manifest_write_batch_hook)
-
-
-# ── Post-store document hooks (RDR-089, nexus-yyev) ──────────────────────────
-# Third hook chain — fires once per *document* after every storage event
-# (MCP store_put and every CLI ingest path). Signature is
-# ``fn(source_path, collection, content)`` rather than the doc_id-keyed
-# single chain or the doc_ids-list batch chain — document-grain enrichment
-# (e.g. RDR-089 aspect extraction) needs the full document text and a
-# stable on-disk identifier, not chunk-level references.
-#
-# Content-sourcing contract (audit F4):
-#   * MCP store_put has the full doc text in scope and passes ``content=<text>``.
-#   * CLI sites accumulate chunks rather than full documents and pass
-#     ``content=""`` as the contract signal that the hook may need to
-#     read source_path itself.
-#   * Hooks treat ``content`` as primary, falling back to file read when empty.
-#
-# Synchronous all the way down — zero asyncio in the dispatcher (RDR-089
-# load-bearing contract: routing through async operator_extract from this
-# sync chain silently drops the coroutine). Hooks registered here MUST be
-# synchronous callables; async hooks are explicitly unsupported.
-#
-# Per-hook failures are captured, logged, and persisted to T2
-# ``hook_failures`` with ``chain='document'``. Failures never propagate.
-
-_post_document_hooks: list = []
-#: nexus-8g79.12: set of hook ids that accept the ``doc_id`` kwarg
-#: (RDR-101 Phase 4). Classified by signature inspection at
-#: registration time so the dispatcher picks the right shape without
-#: a fragile TypeError-retry probe at every call. Pre-fix the dispatcher
-#: caught TypeError and retried — any hook that raised TypeError for an
-#: unrelated reason (wrong-type arg inside its body) was misclassified
-#: as a back-compat signal and silently invoked with the wrong shape.
-_post_document_hooks_with_doc_id: set[int] = set()
-
-
-def register_post_document_hook(fn) -> None:
-    """Register a synchronous ``fn(source_path, collection, content) -> None``
-    to fire after every document-level storage event.
-
-    The callable MUST be synchronous. Async callables are silently
-    unsupported — the dispatcher would drop the returned coroutine.
-    Phase 1 hook authors: see ``test_async_hooks_silently_unsupported_by_dispatcher``
-    for the contract test.
-
-    nexus-8g79.12: callable's signature is inspected once at
-    registration so :func:`fire_post_document_hooks` picks the right
-    call shape — hooks that accept ``doc_id`` or **kwargs receive it;
-    older registrations are called without it. Mirrors the pattern
-    used by :func:`register_post_store_batch_hook` for ``catalog_doc_id``.
-    """
-    _post_document_hooks.append(fn)
-    try:
-        import inspect
-        sig = inspect.signature(fn)
-        params = sig.parameters
-        if "doc_id" in params or any(
-            p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-        ):
-            _post_document_hooks_with_doc_id.add(id(fn))
-    except (TypeError, ValueError):
-        # Builtin/C-extension callable with no introspectable signature.
-        # Treat as legacy shape (no doc_id) so the dispatcher does not
-        # blow up on first call.
-        import structlog
-        structlog.get_logger().debug(
-            "post_document_hook_signature_unintrospectable",
-            hook=getattr(fn, "__name__", repr(fn)),
-        )
-
-
-def fire_post_document_hooks(
-    source_path: str, collection: str, content: str,
-    *,
-    doc_id: str = "",
-) -> None:
-    """Invoke all registered document-grain hooks. Per-hook failures are
-    captured, logged, and persisted to T2 ``hook_failures`` with
-    ``chain='document'`` — never raised to the caller.
-
-    Synchronous dispatch: no ``asyncio.to_thread``, no ``await``. Hooks
-    that need async work must run their own event loop internally.
-
-    Content-sourcing contract:
-
-    * ``content`` non-empty (MCP path) — passed through to the hook
-      verbatim; the hook reads ``content`` directly.
-    * ``content == ""`` (CLI path) — the contract signal that the hook
-      may need to read ``source_path`` itself. The framework forwards
-      both arguments unchanged; content-sourcing is the hook's
-      responsibility, not the framework's.
-
-    ``doc_id`` (nexus-tdgc / RDR-101 Phase 4) is the catalog identity
-    of the source document. Forwarded to every registered hook as a
-    keyword arg; hooks that don't accept the kw are called without it
-    so older registrations keep working during the migration window.
-    """
-    import structlog
-    _hook_log = structlog.get_logger()
-    for hook in _post_document_hooks:
-        try:
-            # nexus-8g79.12: dispatch by signature classification done at
-            # registration time. Pre-fix the inner try/except TypeError
-            # caught any TypeError from inside the hook body and silently
-            # retried with the legacy shape — misclassifying unrelated
-            # type bugs as a back-compat signal.
-            if id(hook) in _post_document_hooks_with_doc_id:
-                hook(source_path, collection, content, doc_id=doc_id)
-            else:
-                hook(source_path, collection, content)
-        except Exception as exc:
-            hook_name = getattr(hook, "__name__", "?")
-            _hook_log.warning(
-                "post_document_hook_failed",
-                hook=hook_name,
-                source_path=source_path,
-                collection=collection,
-                exc_info=True,
-            )
-            _record_document_hook_failure(
-                source_path=source_path,
-                collection=collection,
-                hook_name=hook_name,
-                error=str(exc),
-            )
-
-
-def _record_document_hook_failure(
-    *,
-    source_path: str,
-    collection: str,
-    hook_name: str,
-    error: str,
-) -> None:
-    """Persist a document-grain hook failure to T2 ``hook_failures``.
-
-    Stores ``source_path`` in the legacy ``doc_id`` column (the column
-    carries 'subject of failure' regardless of chain shape) and sets
-    ``chain='document'`` so readers can render the row appropriately.
-
-    Falls back to a chain-less insert when the 4.14.2 migration has not
-    yet run (mixed-version operator scenario): the outer guard
-    propagates schema errors to the secondary ``except`` only, so
-    transient lock or I/O failures bubble up where the outer
-    best-effort wrapper can swallow them. Same secondary best-effort
-    semantics as ``_record_hook_failure`` and
-    ``_record_batch_hook_failure``: persistence failure cannot break
-    ingest.
-
-    Two-tier fallback (vs. three-tier in ``_record_batch_hook_failure``)
-    is correct: the document chain is new in 4.14.2, so there is no
-    intermediate 4.14.1-shape schema to handle — the row either has
-    ``chain`` (post-4.14.2) or it does not (pre-4.14.2 generic shape).
-    """
-    import sqlite3
-    truncated = error[:2000]
-    try:
-        with t2_ctx() as t2:
-            conn = t2.taxonomy.conn
-            with t2.taxonomy._lock:
-                try:
-                    conn.execute(
-                        "INSERT INTO hook_failures "
-                        "(doc_id, collection, hook_name, error, chain) "
-                        "VALUES (?, ?, ?, ?, 'document')",
-                        (source_path, collection, hook_name, truncated),
-                    )
-                except sqlite3.OperationalError as exc:
-                    msg = str(exc)
-                    if "no column named" not in msg and "no such column" not in msg:
-                        raise
-                    # Pre-4.14.2 schema: chain column absent. Persist
-                    # without the chain marker — the row is still useful
-                    # for triage even if it cannot be classified by chain.
-                    conn.execute(
-                        "INSERT INTO hook_failures "
-                        "(doc_id, collection, hook_name, error) "
-                        "VALUES (?, ?, ?, ?)",
-                        (source_path, collection, hook_name, truncated),
-                    )
-                conn.commit()
-    except Exception:
-        import structlog
-        structlog.get_logger().debug(
-            "document_hook_failure_persist_failed",
-            hook=hook_name,
-            collection=collection,
-            exc_info=True,
-        )
-
-
-# ── Combined post-store fire helper (nexus-9099) ─────────────────────────────
-#
-# RDR-095 established symmetric-fire for the bulk CLI ingest paths
-# (``nx index repo / pdf / rdr``) so every storage event invokes the
-# single, batch, and document-grain hook chains. Three CLI paths were
-# overlooked by the symmetric-fire commit and shipped firing zero
-# chains: ``nx store put``, ``nx memory promote``, and
-# ``nx store import``. The downstream effect is silent drift between
-# the catalog row + chroma chunk and the T2 indexes that operator SQL
-# fast paths depend on (chash_index, taxonomy assignments, aspect
-# extraction queue). nexus-9099 surfaced the bug; this helper closes
-# the gap by giving every T3-write path a single call site that fires
-# all three chains in the correct order.
-#
-# Used by:
-#   * MCP ``store_put`` (mcp/core.py)
-#   * CLI ``nx store put`` (commands/store.py)
-#   * CLI ``nx memory promote`` (commands/memory.py)
-#   * CLI ``nx store import`` (commands/store.py)
-#
-# Bulk ``nx index *`` ingest paths still call the three fire functions
-# directly (see ``code_indexer.py``, ``prose_indexer.py``,
-# ``doc_indexer.py``, ``pipeline_stages.py``, ``indexer.py``) — the AST
-# drift guard in ``tests/test_hook_drift_guard.py`` enforces 7 CLI
-# fire sites + 1 MCP fire site for the document chain. This helper is
-# additive; it does not rewire the bulk paths.
-
-
-def fire_store_chains(
-    doc_ids: list[str],
-    collection: str,
-    contents: list[str],
-    *,
-    source_paths: list[str] | None = None,
-    embeddings: list[list[float]] | None = None,
-    metadatas: list[dict] | None = None,
-    catalog_doc_id: str = "",
-) -> None:
-    """Fire all three post-store hook chains for a batch of just-stored docs.
-
-    Single, batch, and document-grain chains run in that order. Errors
-    are caught per-hook and persisted to T2 ``hook_failures``; nothing
-    is propagated to the caller (matching the existing fire functions'
-    semantics).
-
-    Parameters
-    ----------
-    doc_ids:
-        Stable identifiers for each just-stored document.
-    collection:
-        Physical collection name (e.g. ``knowledge__knowledge``).
-    contents:
-        Document text per doc_id. Length must match ``doc_ids``.
-    source_paths:
-        On-disk source path per document, or ``None`` to use ``doc_ids``
-        as the source identity (the MCP ``store_put`` shape — there is
-        no on-disk source). Length must match ``doc_ids`` when given.
-    embeddings:
-        Optional dense vectors per doc; forwarded to the batch chain.
-        ``taxonomy_assign_batch_hook`` accepts ``None`` and fetches
-        embeddings from T3 inline.
-    metadatas:
-        Optional metadata dicts per doc; forwarded to the batch chain.
-        ``chash_dual_write_batch_hook`` reads from this.
-    catalog_doc_id:
-        nexus-lf8f: the catalog ``Document.tumbler`` for these chunks
-        (RDR-108 Phase 3). Post-Phase-3, chunk metadata no longer
-        carries ``doc_id`` so the manifest-write hook needs the tumbler
-        passed explicitly via this kwarg or it short-circuits silently
-        (the exact symptom nexus-zq79 fixed for the indexer paths in
-        4.32.4; this kwarg closes the same gap for the store-path
-        callers — MCP ``store_put``, ``nx store put``,
-        ``nx memory promote``, ``nx store import``). Default ``""``
-        preserves the legacy "no catalog identity" shape for callers
-        that genuinely have no tumbler (raw scratch writes pre-catalog
-        registration); those callers' chunks remain catalog-orphaned by
-        design.
-    """
-    n = len(doc_ids)
-    if len(contents) != n:
-        raise ValueError(
-            f"contents length {len(contents)} != doc_ids length {n}"
-        )
-    if source_paths is None:
-        source_paths = list(doc_ids)
-    elif len(source_paths) != n:
-        raise ValueError(
-            f"source_paths length {len(source_paths)} != doc_ids length {n}"
-        )
-
-    # Single-doc chain — once per (doc_id, content).
-    for doc_id, content in zip(doc_ids, contents):
-        fire_post_store_hooks(doc_id, collection, content)
-
-    # Batch chain — one call with the whole batch.
-    fire_post_store_batch_hooks(
-        doc_ids, collection, contents,
-        embeddings=embeddings, metadatas=metadatas,
-        catalog_doc_id=catalog_doc_id,
-    )
-
-    # Document-grain chain — once per (source_path, content).
-    # nexus-tdgc: doc_id is forwarded so the aspect-queue hook can
-    # capture it at enqueue time. The doc_ids list is the same one
-    # the post_store + batch chains use; for the document chain it is
-    # the catalog identity.
-    for did, sp, content in zip(doc_ids, source_paths, contents):
-        fire_post_document_hooks(sp, collection, content, doc_id=did)
 
 
 # ── Version compatibility check (RDR-076) ─────────────────────────────────────
@@ -1337,23 +742,15 @@ def reset_singletons():
     embeddings against the injected client and produced nondeterministic
     matches.
 
-    NOTE: ``_post_store_hooks``, ``_post_store_batch_hooks``, and
-    ``_post_document_hooks`` are intentionally NOT cleared here.  Hooks
-    are registered at module-import time (e.g. ``register_post_store_hook`` /
-    ``register_post_store_batch_hook`` / ``register_post_document_hook`` in
-    ``nexus.mcp.core``).  Because Python only executes module-level code
-    once, clearing the lists here would permanently lose those
-    registrations for the remainder of the test session.  Tests that
-    need an empty hook list should clear the relevant ``_post_*_hooks``
-    list explicitly in their own fixture (e.g. via the autouse fixture
-    in ``tests/test_post_document_hooks.py``).
+    Post-store hook chains are owned by per-invocation ``HookRegistry``
+    instances (see ``nexus.hook_registry``); they are no longer
+    module-globals on ``mcp_infra`` and therefore not cleared here.
     """
-    global _t1_instance, _t1_isolated, _t3_instance, _collections_cache, _catalog_instance
+    global _t1_instance, _t1_isolated, _t3_instance, _collections_cache
     _t1_instance = None
     _t1_isolated = False
     _t3_instance = None
     _collections_cache = ([], 0.0)
-    _catalog_instance = None
     clear_search_traces()
     reset_plan_cache_for_tests()
 
@@ -1369,15 +766,3 @@ def inject_t3(t3):
     """Inject a T3Database for testing."""
     global _t3_instance
     _t3_instance = t3
-
-
-def inject_catalog(cat):
-    """Inject a Catalog for testing.
-
-    Sets ``_catalog_instance`` so subsequent ``get_catalog()`` calls
-    return this catalog instead of constructing fresh. Used by tests
-    that need to assert against a specific Catalog instance; clear
-    with ``inject_catalog(None)`` or ``reset_singletons()``.
-    """
-    global _catalog_instance
-    _catalog_instance = cat

--- a/src/nexus/mcp_server.py
+++ b/src/nexus/mcp_server.py
@@ -35,7 +35,6 @@ from nexus.mcp_infra import (  # noqa: F401
     get_recent_search_traces as _get_recent_search_traces,
     get_t1 as _get_t1,
     get_t3 as _get_t3,
-    inject_catalog as _inject_catalog,
     inject_t1 as _inject_t1,
     inject_t3 as _inject_t3,
     record_search_trace as _record_search_trace,

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -25,7 +25,10 @@ from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor, wait, ALL_COMPLETED, FIRST_EXCEPTION
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.hook_registry import HookRegistry
 
 import structlog
 
@@ -395,12 +398,13 @@ def uploader_loop(
     chunking_done: threading.Event | None = None,
     *,
     catalog_doc_id: str = "",
+    hooks: "HookRegistry | None" = None,
 ) -> None:
     """Poll chunk buffer for embedded chunks and upsert to T3 ChromaDB.
 
     *catalog_doc_id* (RDR-108 Phase 3) — catalog ``Document.tumbler``
     string for the document this pipeline run is processing. Threaded
-    through to ``fire_post_store_batch_hooks`` so ``manifest_write_batch_hook``
+    through to ``HookRegistry.fire_batch`` so ``manifest_write_batch_hook``
     can write the manifest without having to read it from chunk metadata
     (which Phase 3 retired).
     """
@@ -445,16 +449,16 @@ def uploader_loop(
                 # Post-store hook chains (RDR-095). Both single-doc and
                 # batch chains fire from every storage event; the per-doc
                 # loop covers single-shape consumers on CLI ingest.
-                from nexus.mcp_infra import (
-                    fire_post_store_batch_hooks,
-                    fire_post_store_hooks,
-                )
-                fire_post_store_batch_hooks(
+                if hooks is None:
+                    from nexus.hook_registry import HookRegistry, install_default_hooks
+                    hooks = HookRegistry()
+                    install_default_hooks(hooks)
+                hooks.fire_batch(
                     ids, collection, documents, embeddings, metadatas,
                     catalog_doc_id=catalog_doc_id,
                 )
                 for _did, _doc in zip(ids, documents):
-                    fire_post_store_hooks(_did, collection, _doc)
+                    hooks.fire_single(_did, collection, _doc)
 
                 indices = [row["chunk_index"] for row in batch]
                 db.mark_uploaded(content_hash, indices)
@@ -586,6 +590,7 @@ def pipeline_index_pdf(
     git_meta: dict | None = None,
     force: bool = False,
     doc_id: str = "",
+    hooks: "HookRegistry | None" = None,
 ) -> int:
     """Three-stage streaming pipeline for PDFs.
 
@@ -686,10 +691,15 @@ def pipeline_index_pdf(
             pdf_path=str(pdf_path), corpus=corpus, target_model=target_model,
             git_meta=git_meta, doc_id=doc_id,
         )
+        if hooks is None:
+            from nexus.hook_registry import HookRegistry, install_default_hooks
+            hooks = HookRegistry()
+            install_default_hooks(hooks)
         upload_future = pool.submit(
             uploader_loop, content_hash, db, t3, collection, cancel,
             chunking_done,
             catalog_doc_id=doc_id,
+            hooks=hooks,
         )
 
         all_futures: set[Future] = {extract_future, chunk_future, upload_future}
@@ -807,14 +817,13 @@ def pipeline_index_pdf(
     from nexus.catalog import Catalog
     from nexus.config import catalog_path
     from nexus.doc_indexer import _lookup_existing_doc_id
-    from nexus.mcp_infra import fire_post_document_hooks
     _cat_path = catalog_path()
     _cat = (
         Catalog(_cat_path, _cat_path / ".catalog.db")
         if Catalog.is_initialized(_cat_path)
         else None
     )
-    fire_post_document_hooks(
+    hooks.fire_document(
         str(pdf_path), collection, "",
         doc_id=_lookup_existing_doc_id(_cat, str(pdf_path), corpus),
     )

--- a/src/nexus/prose_indexer.py
+++ b/src/nexus/prose_indexer.py
@@ -241,21 +241,16 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
         # Post-store hook chains (RDR-095). Both single-doc and batch
         # chains fire from every storage event; the per-doc loop covers
         # single-shape consumers on CLI ingest.
-        from nexus.mcp_infra import (
-            fire_post_document_hooks,
-            fire_post_store_batch_hooks,
-            fire_post_store_hooks,
-        )
-        fire_post_store_batch_hooks(
+        ctx.hooks.fire_batch(
             ids, ctx.corpus, documents, embeddings, metadatas,
             catalog_doc_id=catalog_doc_id,
         )
         for _did, _doc in zip(ids, documents):
-            fire_post_store_hooks(_did, ctx.corpus, _doc)
+            ctx.hooks.fire_single(_did, ctx.corpus, _doc)
         # RDR-089 document-grain chain — once per prose-file boundary.
         # content="" (chunk-level scope only); hook reads source_path.
         # nexus-tdgc: forward catalog doc_id when available.
-        fire_post_document_hooks(
+        ctx.hooks.fire_document(
             str(file_path), ctx.corpus, "",
             doc_id=catalog_doc_id,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,53 +148,6 @@ def _restore_structlog_after_test():
 
 
 @pytest.fixture(autouse=True)
-def _restore_post_store_batch_hooks_after_test():
-    """Snapshot and restore ``mcp_infra._post_store_batch_hooks`` around
-    every test, and clear the cached catalog singleton so per-test
-    ``NEXUS_CATALOG_PATH`` redirects take effect.
-
-    RDR-108 Phase 3 (nexus-bdag) made the three batch hooks
-    (``chash_dual_write_batch_hook``, ``taxonomy_assign_batch_hook``,
-    ``manifest_write_batch_hook``) self-register at module load in
-    ``nexus.mcp_infra`` so CLI ingest fires them. Several legacy tests
-    inline-clear ``_post_store_batch_hooks`` to assert specific hooks
-    in isolation; without restoration, the cleared list permanently
-    loses those load-bearing registrations for the rest of the
-    session and downstream catalog-manifest assertions silently fail.
-
-    The catalog singleton in ``mcp_infra._catalog_instance`` is also
-    cleared. ``manifest_write_batch_hook`` resolves the catalog via
-    ``get_catalog()``; without per-test reset the first test that
-    initialises the singleton pins it to its own tmp_path, so
-    subsequent tests' manifest writes target the wrong (deleted) tmp
-    catalog and the assertion ``cat.get_manifest(tumbler)`` returns
-    ``[]``.
-    """
-    import nexus.mcp_infra as _mod
-    snapshot_batch = list(_mod._post_store_batch_hooks)
-    snapshot_single = list(_mod._post_store_hooks)
-    # Snapshot the catalog_doc_id-aware classification set too: a test
-    # that registers a fresh batch hook adds its ``id(fn)`` here, and
-    # without restoration the entry leaks for the rest of the session.
-    # Python may recycle the id() for a later object, which would then
-    # be (wrongly) classified as catalog_doc_id-aware on first dispatch.
-    snapshot_catalog_doc_id_set = set(
-        _mod._post_store_batch_hooks_with_catalog_doc_id
-    )
-    _mod._catalog_instance = None
-    yield
-    _mod._post_store_batch_hooks.clear()
-    _mod._post_store_batch_hooks.extend(snapshot_batch)
-    _mod._post_store_hooks.clear()
-    _mod._post_store_hooks.extend(snapshot_single)
-    _mod._post_store_batch_hooks_with_catalog_doc_id.clear()
-    _mod._post_store_batch_hooks_with_catalog_doc_id.update(
-        snapshot_catalog_doc_id_set
-    )
-    _mod._catalog_instance = None
-
-
-@pytest.fixture(autouse=True)
 def _isolate_t1_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Force tests onto the explicit-isolation T1 path.
 

--- a/tests/test_auto_linker.py
+++ b/tests/test_auto_linker.py
@@ -18,9 +18,11 @@ def git_identity(monkeypatch):
     monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
 
 
-def _make_catalog(tmp_path: Path) -> Catalog:
+def _make_catalog(tmp_path: Path, monkeypatch=None) -> Catalog:
     catalog_dir = tmp_path / "catalog"
     cat = Catalog.init(catalog_dir)
+    if monkeypatch is not None:
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
     return cat
 
 
@@ -257,20 +259,19 @@ class TestAutoLinkResult:
 class TestCatalogAutoLinkIntegration:
     """Integration test: _catalog_auto_link wired through store_put path."""
 
-    def test_store_put_creates_link_from_scratch_context(self, tmp_path):
+    def test_store_put_creates_link_from_scratch_context(self, tmp_path, monkeypatch):
         """Full pipeline: T1 scratch link-context + store_put → catalog link."""
         import json
         from nexus.db.t1 import T1Database
         from nexus.mcp_server import (
             _catalog_auto_link,
-            _inject_catalog,
             _inject_t1,
             _reset_singletons,
         )
 
         _reset_singletons()
 
-        cat = _make_catalog(tmp_path)
+        cat = _make_catalog(tmp_path, monkeypatch)
         owner = cat.register_owner("knowledge", "curator")
         target_t = cat.register(owner, "Target RDR", content_type="rdr")
 
@@ -279,8 +280,6 @@ class TestCatalogAutoLinkIntegration:
             owner, "Agent Finding", content_type="knowledge",
             meta={"doc_id": "test-doc-001"},
         )
-
-        _inject_catalog(cat)
 
         t1 = T1Database(session_id="test-auto-link-session")
         _inject_t1(t1)
@@ -303,26 +302,24 @@ class TestCatalogAutoLinkIntegration:
 
         _reset_singletons()
 
-    def test_store_put_no_crash_without_context(self, tmp_path):
+    def test_store_put_no_crash_without_context(self, tmp_path, monkeypatch):
         """_catalog_auto_link with no link-context in scratch → 0, no crash."""
         from nexus.db.t1 import T1Database
         from nexus.mcp_server import (
             _catalog_auto_link,
-            _inject_catalog,
             _inject_t1,
             _reset_singletons,
         )
 
         _reset_singletons()
 
-        cat = _make_catalog(tmp_path)
+        cat = _make_catalog(tmp_path, monkeypatch)
         owner = cat.register_owner("knowledge", "curator")
         cat.register(
             owner, "Some Doc", content_type="knowledge",
             meta={"doc_id": "test-doc-002"},
         )
 
-        _inject_catalog(cat)
         t1 = T1Database(session_id="test-no-context-session")
         _inject_t1(t1)
 
@@ -340,20 +337,19 @@ class TestCatalogAutoLinkIntegration:
         assert count == 0
         _reset_singletons()
 
-    def test_link_context_persists_across_stores(self, tmp_path):
+    def test_link_context_persists_across_stores(self, tmp_path, monkeypatch):
         """Link-context entries apply to every store_put in the session (by design)."""
         import json
         from nexus.db.t1 import T1Database
         from nexus.mcp_server import (
             _catalog_auto_link,
-            _inject_catalog,
             _inject_t1,
             _reset_singletons,
         )
 
         _reset_singletons()
 
-        cat = _make_catalog(tmp_path)
+        cat = _make_catalog(tmp_path, monkeypatch)
         owner = cat.register_owner("knowledge", "curator")
         target_t = cat.register(owner, "Target RDR", content_type="rdr")
         doc1_t = cat.register(
@@ -365,7 +361,6 @@ class TestCatalogAutoLinkIntegration:
             meta={"doc_id": "multi-doc-002"},
         )
 
-        _inject_catalog(cat)
         t1 = T1Database(session_id="test-multi-store-session")
         _inject_t1(t1)
 

--- a/tests/test_catalog_e2e.py
+++ b/tests/test_catalog_e2e.py
@@ -120,11 +120,15 @@ def indexed_catalog(catalog_repo, registry, local_t3, catalog_env, monkeypatch):
 
 @pytest.fixture
 def injected_catalog(indexed_catalog):
-    from nexus.mcp_server import _inject_catalog, _reset_singletons
+    """Return the indexed catalog. NEXUS_CATALOG_PATH is already set by the
+    ``catalog_env`` fixture (transitively required), so ``get_catalog()``
+    in production code will construct a fresh Catalog at the same path
+    and read the test's data — no explicit injection needed.
+    """
+    from nexus.mcp_server import _reset_singletons
 
     cat, local_t3 = indexed_catalog
     _reset_singletons()
-    _inject_catalog(cat)
     return cat, local_t3
 
 

--- a/tests/test_catalog_manifest_read_api.py
+++ b/tests/test_catalog_manifest_read_api.py
@@ -886,14 +886,21 @@ class TestManifestWriteBatchHook:
             f"captured: {cap}"
         )
 
-    def test_manifest_write_batch_hook_registered_in_mcp_core(self):
-        """manifest_write_batch_hook is registered in the post-store batch chain."""
-        # We just verify that importing mcp.core registers the hook.
-        # The registration happens at module import time.
-        import nexus.mcp.core  # noqa: F401  -- side effect: register hooks
-        from nexus.mcp_infra import _post_store_batch_hooks, manifest_write_batch_hook
+    def test_manifest_write_batch_hook_registered_by_install_default_hooks(self):
+        """manifest_write_batch_hook is wired onto every default HookRegistry.
 
-        assert manifest_write_batch_hook in _post_store_batch_hooks
+        Post-RDR-118-successor refactor: the three hook chains live on
+        per-invocation ``HookRegistry`` instances rather than module-level
+        globals. ``install_default_hooks(registry)`` wires the load-bearing
+        consumers — including ``manifest_write_batch_hook`` — onto every
+        registry the entry points construct.
+        """
+        from nexus.hook_registry import HookRegistry, install_default_hooks
+        from nexus.mcp_infra import manifest_write_batch_hook
+
+        registry = HookRegistry()
+        install_default_hooks(registry)
+        assert manifest_write_batch_hook in registry._batch
 
     def test_manifest_write_batch_hook_accumulates_across_batches(self, tmp_path):
         """RDR-108 Phase 3 (nexus-bdag) regression test: when the hook is

--- a/tests/test_catalog_mcp.py
+++ b/tests/test_catalog_mcp.py
@@ -7,7 +7,6 @@ import pytest
 
 from nexus.catalog.catalog import Catalog
 from nexus.mcp_server import (
-    _inject_catalog,
     _reset_singletons,
     catalog_link,
     catalog_link_audit,
@@ -40,10 +39,11 @@ def clean_singletons():
 
 
 @pytest.fixture
-def cat(tmp_path: Path) -> Catalog:
-    c = Catalog.init(tmp_path / "catalog")
+def cat(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Catalog:
+    catalog_dir = tmp_path / "catalog"
+    c = Catalog.init(catalog_dir)
     c.register_owner("test-repo", "repo", repo_hash="abcd1234")
-    _inject_catalog(c)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
     return c
 
 

--- a/tests/test_catalog_mcp_bootstrap_fallback.py
+++ b/tests/test_catalog_mcp_bootstrap_fallback.py
@@ -42,7 +42,6 @@ import pytest
 
 from nexus.catalog.catalog import Catalog
 from nexus.mcp_server import (
-    _inject_catalog,
     _reset_singletons,
     catalog_list,
     catalog_search,
@@ -148,8 +147,13 @@ def test_mcp_catalog_list_under_fallback_returns_legacy_rows(
 ):
     """``catalog_list`` MCP tool must return all 10 legacy documents
     via the fallback read path, not an error stub.
+
+    The ``_isolate_catalog`` autouse fixture points ``NEXUS_CATALOG_PATH``
+    at ``tmp_path / "test-catalog"``, which is exactly where the
+    ``fallback_catalog`` fixture builds its on-disk state — so the MCP
+    tool's ``get_catalog()`` call constructs a fresh Catalog at the same
+    location and sees the fallback rows.
     """
-    _inject_catalog(fallback_catalog)
     capsys.readouterr()  # drain prior output
 
     result = catalog_list()
@@ -190,7 +194,6 @@ def test_mcp_catalog_show_under_fallback_returns_doc(
     """``catalog_show`` against a known legacy tumbler must return
     the document's full metadata, not an error stub.
     """
-    _inject_catalog(fallback_catalog)
     capsys.readouterr()
 
     # The first registered doc is at 1.1.1.
@@ -217,7 +220,6 @@ def test_mcp_catalog_search_under_fallback_does_not_crash(
     with predictable titles (``doc-N.md``) so a substring query has
     something to match against.
     """
-    _inject_catalog(fallback_catalog)
     capsys.readouterr()
 
     result = catalog_search(query="doc")

--- a/tests/test_chash_index_store.py
+++ b/tests/test_chash_index_store.py
@@ -555,7 +555,7 @@ class TestDualWriteHelper:
 
 class TestChashDualWriteBatchEntryPoint:
     """``mcp_infra.chash_dual_write_batch_hook`` is the registered batch
-    hook fired by ``fire_post_store_batch_hooks`` from every CLI indexing
+    hook fired by ``HookRegistry.fire_batch`` from every CLI indexing
     write site. It opens a fresh T2Database (matching
     ``taxonomy_assign_batch_hook``'s lifecycle) and delegates.
     """

--- a/tests/test_cli_registration.py
+++ b/tests/test_cli_registration.py
@@ -68,7 +68,13 @@ def test_taxonomy_subcommands_exist():
 
 
 def test_mcp_hooks_registered():
-    """Post-store hooks land in their declared chains after core import.
+    """Post-store hooks land in their declared chains after install_default_hooks.
+
+    Post-RDR-118-successor refactor: the three hook chains live on
+    per-invocation ``HookRegistry`` instances rather than module-level
+    globals. ``install_default_hooks(registry)`` wires the load-bearing
+    default consumers onto every registry the entry points construct;
+    this test pins their order on a fresh registry built the same way.
 
     RDR-095 + symmetric-fire follow-up: taxonomy + chash dual-write are
     batch-only registrations (the batch hook handles single-document MCP
@@ -76,10 +82,12 @@ def test_mcp_hooks_registered():
     future single-doc-only consumers (RDR-089 aspect extraction) will
     add themselves here.
     """
-    import nexus.mcp.core  # noqa: F401 — triggers registration
-    from nexus.mcp_infra import _post_store_batch_hooks, _post_store_hooks
+    from nexus.hook_registry import HookRegistry, install_default_hooks
 
-    batch_names = [h.__name__ for h in _post_store_batch_hooks]
+    registry = HookRegistry()
+    install_default_hooks(registry)
+
+    batch_names = [h.__name__ for h in registry._batch]
     # RDR-108 D2 (nexus-572g): manifest_write_batch_hook joins the chain
     # so chunk batches landing in T3 update the catalog manifest at the
     # same boundary that chash_dual_write and taxonomy_assign run on.
@@ -89,7 +97,7 @@ def test_mcp_hooks_registered():
         "manifest_write_batch_hook",
     ], f"unexpected batch chain order: {batch_names}"
 
-    single_names = [h.__name__ for h in _post_store_hooks]
+    single_names = [h.__name__ for h in registry._single]
     # Single-doc chain may be empty or carry only future hooks; assert
     # the legacy taxonomy_assign_hook is gone.
     assert "taxonomy_assign_hook" not in single_names

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -523,33 +523,28 @@ def test_index_pdf_fires_document_hook_exactly_once(
     Significant #5). The AST drift guard counts call-sites
     statically; this test pins the runtime property.
 
-    A bug that moves ``fire_post_document_hooks`` inside a
-    per-chunk loop would have N invocations per document instead
-    of 1 — invisible to the AST count guard, expensive in API
-    calls, and produces single-chunk aspects for multi-chunk
-    documents (semantically wrong). Pin via a counting hook
-    registered for the duration of one ``index_pdf`` call.
+    A bug that moves ``fire_document`` inside a per-chunk loop would
+    have N invocations per document instead of 1 — invisible to the AST
+    count guard, expensive in API calls, and produces single-chunk
+    aspects for multi-chunk documents (semantically wrong). Pin via a
+    counting hook registered on a per-test ``HookRegistry`` instance
+    threaded through ``index_pdf(hooks=...)``.
     """
-    from nexus.mcp_infra import (
-        _post_document_hooks,
-        register_post_document_hook,
-    )
+    from nexus.hook_registry import HookRegistry
 
     fires: list[tuple[str, str, str]] = []
 
     def counting_hook(source_path: str, collection: str, content: str) -> None:
         fires.append((source_path, collection, content))
 
-    register_post_document_hook(counting_hook)
-    try:
-        set_credentials(monkeypatch)
-        with patch("nexus.doc_indexer.make_t3", return_value=mock_t3):
-            with pdf_extract_patches_ctx():
-                with patch("voyageai.Client", return_value=voyage_client):
-                    index_pdf(sample_pdf, corpus="mybook")
-    finally:
-        if counting_hook in _post_document_hooks:
-            _post_document_hooks.remove(counting_hook)
+    hooks = HookRegistry()
+    hooks.register_document(counting_hook)
+
+    set_credentials(monkeypatch)
+    with patch("nexus.doc_indexer.make_t3", return_value=mock_t3):
+        with pdf_extract_patches_ctx():
+            with patch("voyageai.Client", return_value=voyage_client):
+                index_pdf(sample_pdf, corpus="mybook", hooks=hooks)
 
     assert len(fires) == 1, (
         f"Document hook fired {len(fires)} times for one PDF — "

--- a/tests/test_hook_drift_guard.py
+++ b/tests/test_hook_drift_guard.py
@@ -1,16 +1,22 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """RDR-095 drift guard: registered batch hooks must only be referenced
-inside ``src/nexus/mcp_infra.py`` (definitions) and ``src/nexus/mcp/core.py``
-(the single registration site).
+inside their definition modules and the single registration site
+(``src/nexus/hook_registry.py``'s ``install_default_hooks``).
 
 The guard catches the original debt-accretion pattern from RDR-070 + RDR-086:
 new per-document batch enrichment landing as hardcoded calls in five CLI
-indexer files. Every other module fires through ``fire_post_store_batch_hooks``;
+indexer files. Every other module fires through ``HookRegistry.fire_batch``;
 no third file imports or calls the hooks directly.
 
 If this test fails on a future commit, the fix is almost always to register
-a new batch hook via ``register_post_store_batch_hook`` in ``mcp/core.py``
-rather than importing the hook function in the new module.
+a new batch hook via ``install_default_hooks`` rather than importing the
+hook function in the new module.
+
+Post-RDR-118-successor refactor: the chain dispatchers are method calls
+on per-invocation ``HookRegistry`` instances rather than module-level
+function calls. The AST guards below count method-call invocations
+(``hooks.fire_batch(...)``, ``hooks.fire_single(...)``,
+``hooks.fire_document(...)``) by attribute name.
 """
 from __future__ import annotations
 
@@ -27,7 +33,7 @@ GUARDED_NAMES = frozenset({
 
 ALLOWED_FILES = frozenset({
     "src/nexus/mcp_infra.py",      # the definitions
-    "src/nexus/mcp/core.py",       # the single registration site
+    "src/nexus/hook_registry.py",  # the single registration site (install_default_hooks)
 })
 
 
@@ -41,7 +47,7 @@ DOCUMENT_HOOK_GUARDED_NAMES = frozenset({
 
 DOCUMENT_HOOK_ALLOWED_FILES = frozenset({
     "src/nexus/aspect_worker.py",  # the definition
-    "src/nexus/mcp/core.py",       # the single registration site
+    "src/nexus/hook_registry.py",  # the single registration site (install_default_hooks)
 })
 
 
@@ -90,11 +96,11 @@ def _scan_file_for_hook_refs(
     return refs
 
 
-def test_batch_hooks_not_called_outside_mcp_infra() -> None:
+def test_batch_hooks_not_called_outside_allowed_files() -> None:
     """RDR-095 drift guard: no source file outside the allowlist may
     semantically reference taxonomy_assign_batch_hook or
     chash_dual_write_batch_hook. Every other module fires through
-    fire_post_store_batch_hooks.
+    HookRegistry.fire_batch.
     """
     offenders: dict[str, list[str]] = {}
     for py in SRC_ROOT.rglob("*.py"):
@@ -113,10 +119,10 @@ def test_batch_hooks_not_called_outside_mcp_infra() -> None:
         raise AssertionError(
             "RDR-095 drift guard: registered batch hooks may only be "
             "referenced inside src/nexus/mcp_infra.py (definitions) and "
-            "src/nexus/mcp/core.py (registration). New consumers should "
-            "register via register_post_store_batch_hook in mcp/core.py "
-            "and fire through fire_post_store_batch_hooks. Offenders:\n"
-            f"{formatted}"
+            "src/nexus/hook_registry.py (install_default_hooks). New "
+            "consumers should register via install_default_hooks in "
+            "hook_registry.py and fire through HookRegistry.fire_batch. "
+            f"Offenders:\n{formatted}"
         )
 
 
@@ -164,12 +170,29 @@ CLI_SITE_FILES = [
 ]
 
 
+def _count_method_calls(tree: ast.AST, attr_name: str) -> int:
+    """Count Call nodes invoking ``something.<attr_name>(...)`` — i.e. the
+    callee is an ``ast.Attribute`` whose ``.attr`` equals *attr_name*.
+
+    Used to count method invocations like ``hooks.fire_batch(...)`` /
+    ``ctx.hooks.fire_single(...)`` where the receiver may be a bare
+    name or a chained attribute access.
+    """
+    count = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Attribute) and node.func.attr == attr_name:
+            count += 1
+    return count
+
+
 def test_every_cli_ingest_site_fires_both_chains() -> None:
-    """Both `fire_post_store_batch_hooks` AND `fire_post_store_hooks` must
+    """Both `HookRegistry.fire_batch` AND `HookRegistry.fire_single` must
     be invoked from every CLI indexer module. Pins the symmetric-fire
-    coverage: a single-doc consumer registered via
-    register_post_store_hook (e.g. RDR-089 aspect extraction) is visible
-    from MCP store_put AND from every CLI ingest path.
+    coverage: a single-doc consumer registered via ``register_single``
+    (e.g. RDR-089 aspect extraction) is visible from MCP store_put AND
+    from every CLI ingest path.
 
     The test asserts a Call node count rather than text presence so
     docstring or comment mentions do not satisfy the invariant. A future
@@ -179,25 +202,13 @@ def test_every_cli_ingest_site_fires_both_chains() -> None:
     for rel in CLI_SITE_FILES:
         path = PROJECT_ROOT / rel
         tree = ast.parse(path.read_text(), filename=str(path))
-        batch_calls = 0
-        single_calls = 0
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            fn_name = None
-            if isinstance(node.func, ast.Name):
-                fn_name = node.func.id
-            elif isinstance(node.func, ast.Attribute):
-                fn_name = node.func.attr
-            if fn_name == "fire_post_store_batch_hooks":
-                batch_calls += 1
-            elif fn_name == "fire_post_store_hooks":
-                single_calls += 1
+        batch_calls = _count_method_calls(tree, "fire_batch")
+        single_calls = _count_method_calls(tree, "fire_single")
         problems: list[str] = []
         if batch_calls == 0:
-            problems.append("missing fire_post_store_batch_hooks call")
+            problems.append("missing fire_batch call")
         if single_calls == 0:
-            problems.append("missing fire_post_store_hooks call")
+            problems.append("missing fire_single call")
         if batch_calls != single_calls:
             problems.append(
                 f"chain-call mismatch: {batch_calls} batch fires vs "
@@ -208,7 +219,7 @@ def test_every_cli_ingest_site_fires_both_chains() -> None:
 
     assert not offenders, (
         "RDR-095 symmetric-fire invariant: every CLI indexer site must "
-        "call both fire_post_store_batch_hooks and fire_post_store_hooks "
+        "call both HookRegistry.fire_batch and HookRegistry.fire_single "
         "the same number of times. Offenders:\n  "
         + "\n  ".join(f"{p}: {ps}" for p, ps in sorted(offenders.items()))
     )
@@ -232,50 +243,27 @@ DOCUMENT_HOOK_FIRE_SITES: dict[str, int] = {
 }
 
 
-def _count_fire_calls(tree: ast.AST, fn_name: str) -> int:
-    """Count direct Call nodes whose callee is `fn_name` (matched by Name
-    or Attribute attr).
-    """
-    count = 0
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        if isinstance(node.func, ast.Name) and node.func.id == fn_name:
-            count += 1
-        elif isinstance(node.func, ast.Attribute) and node.func.attr == fn_name:
-            count += 1
-    return count
-
-
 def test_every_cli_ingest_site_fires_document_hook() -> None:
     """RDR-089 P0.2 wiring invariant: each CLI ingest module + the MCP
-    store_put boundary must call ``fire_post_document_hooks`` exactly
+    store_put boundary must call ``HookRegistry.fire_document`` exactly
     the documented number of times. Total: 7 fire-statement instances
     across 6 modules.
 
     The call counts are pinned per-module so a future contributor who
     drops a fire site (or accidentally double-fires inside a chunk
     loop) fails CI here, not at runtime.
-
-    Either the alias name (``fire_post_document_hooks``) or the
-    privatised import name (``_fire_post_document_hooks`` in
-    ``mcp/core.py``) counts toward the total — they are the same
-    callable.
     """
     offenders: dict[str, str] = {}
     for rel, expected in sorted(DOCUMENT_HOOK_FIRE_SITES.items()):
         path = PROJECT_ROOT / rel
         tree = ast.parse(path.read_text(), filename=str(path))
-        actual = (
-            _count_fire_calls(tree, "fire_post_document_hooks")
-            + _count_fire_calls(tree, "_fire_post_document_hooks")
-        )
+        actual = _count_method_calls(tree, "fire_document")
         if actual != expected:
             offenders[rel] = f"expected {expected} call(s), got {actual}"
 
     assert not offenders, (
         "RDR-089 document-chain call-site invariant: each ingest "
-        "module must fire fire_post_document_hooks the documented "
+        "module must fire HookRegistry.fire_document the documented "
         "number of times. If this fails, the wiring drifted from the "
         "P0.2 fire-site map. Offenders:\n  "
         + "\n  ".join(f"{p}: {ps}" for p, ps in sorted(offenders.items()))
@@ -284,15 +272,15 @@ def test_every_cli_ingest_site_fires_document_hook() -> None:
 
 def test_mcp_store_put_calls_document_hook_synchronously() -> None:
     """RDR-089 load-bearing contract (audit F1): the call to
-    ``fire_post_document_hooks`` from ``mcp/core.py:store_put`` must be
-    a *plain sync* invocation. No ``await``, no ``asyncio.to_thread``
+    ``HookRegistry.fire_document`` from ``mcp/core.py:store_put`` must
+    be a *plain sync* invocation. No ``await``, no ``asyncio.to_thread``
     wrapping. ``store_put`` is ``def``, not ``async def``; FastMCP
     wraps sync ``@mcp.tool()`` bodies in worker threads at the
     framework level. Routing through ``async`` here would silently
     drop the returned coroutine — exactly the original RDR-089 defect.
 
     Pin via AST inspection: walk every ``Call`` node whose callee
-    targets ``fire_post_document_hooks`` (or its alias), then assert no
+    targets ``fire_document`` (the method attr), then assert no
     enclosing parent is an ``await`` or an ``asyncio.to_thread`` call.
     """
     rel = "src/nexus/mcp/core.py"
@@ -308,14 +296,9 @@ def test_mcp_store_put_calls_document_hook_synchronously() -> None:
     def _is_doc_hook_call(node: ast.AST) -> bool:
         if not isinstance(node, ast.Call):
             return False
-        if isinstance(node.func, ast.Name):
-            return node.func.id in {
-                "fire_post_document_hooks", "_fire_post_document_hooks",
-            }
+        # hooks.fire_document(...) — Attribute access on a name/attribute receiver
         if isinstance(node.func, ast.Attribute):
-            return node.func.attr in {
-                "fire_post_document_hooks", "_fire_post_document_hooks",
-            }
+            return node.func.attr == "fire_document"
         return False
 
     def _is_to_thread_call(node: ast.AST) -> bool:
@@ -342,12 +325,12 @@ def test_mcp_store_put_calls_document_hook_synchronously() -> None:
                 break
             if isinstance(cur, ast.Await):
                 offending_calls.append(
-                    f"line {line}: fire_post_document_hooks wrapped in await"
+                    f"line {line}: fire_document wrapped in await"
                 )
                 break
             if _is_to_thread_call(cur):
                 offending_calls.append(
-                    f"line {line}: fire_post_document_hooks routed through "
+                    f"line {line}: fire_document routed through "
                     f"asyncio.to_thread"
                 )
                 break
@@ -355,7 +338,7 @@ def test_mcp_store_put_calls_document_hook_synchronously() -> None:
 
     assert not offending_calls, (
         "RDR-089 sync-all-the-way-down contract (audit F1): "
-        "fire_post_document_hooks at MCP store_put must be a plain "
+        "HookRegistry.fire_document at MCP store_put must be a plain "
         "synchronous call. await / asyncio.to_thread wrapping silently "
         "drops the dispatch (store_put is `def`, not `async def`). "
         "Offenders:\n  " + "\n  ".join(offending_calls)
@@ -365,12 +348,12 @@ def test_mcp_store_put_calls_document_hook_synchronously() -> None:
 # ── Document-chain GUARDED_NAMES wave 2 (nexus-qeo8) ─────────────────────────
 
 
-def test_document_hook_not_called_outside_aspect_worker_and_core() -> None:
+def test_document_hook_not_called_outside_aspect_worker_and_install_default() -> None:
     """RDR-089 follow-up drift guard: the document-grain hook
     ``aspect_extraction_enqueue_hook`` may only be referenced inside
     its definition module (``src/nexus/aspect_worker.py``) and the
-    single registration site (``src/nexus/mcp/core.py``). Every
-    other module fires through ``fire_post_document_hooks`` — the
+    single registration site (``src/nexus/hook_registry.py``). Every
+    other module fires through ``HookRegistry.fire_document`` — the
     framework dispatches.
 
     The same anti-pattern caught by the batch-chain guard above:
@@ -402,8 +385,8 @@ def test_document_hook_not_called_outside_aspect_worker_and_core() -> None:
             "RDR-089 follow-up drift guard: "
             "aspect_extraction_enqueue_hook may only be referenced "
             "inside src/nexus/aspect_worker.py (definition) and "
-            "src/nexus/mcp/core.py (registration). New consumers "
-            "should fire through fire_post_document_hooks. "
+            "src/nexus/hook_registry.py (registration). New consumers "
+            "should fire through HookRegistry.fire_document. "
             "Offenders:\n" + formatted
         )
 
@@ -437,11 +420,12 @@ def test_document_hook_drift_guard_catches_synthetic_offender(
 # T3-write paths that the bulk-indexer guard couldn't reach because
 # they live in ``commands/`` and ``exporter.py``, not the indexer
 # files. The fix wires those three paths through ``fire_store_chains``
-# (mcp_infra). This guard ensures any future CLI T3-write path also
-# fires the chains: a function that calls ``X.put(collection=...)`` or
+# (now ``HookRegistry.fire_store_chains``). This guard ensures any
+# future CLI T3-write path also fires the chains: a function that
+# calls ``X.put(collection=...)`` or
 # ``X.upsert_chunks_with_embeddings(collection_name=...)`` in
 # ``src/nexus/commands/`` or ``src/nexus/exporter.py`` must also call
-# ``fire_store_chains`` in the same function body.
+# ``fire_store_chains`` (the method) in the same function body.
 #
 # The kwarg-shape heuristic is what distinguishes T3 writes from T2
 # writes:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -25,7 +25,6 @@ from nexus.db.t2 import T2Database
 from nexus.db.t3 import T3Database, VerifyResult
 from nexus.mcp_server import (
     _get_collection_names,
-    _inject_catalog,
     _inject_t1,
     _inject_t3,
     _reset_singletons,
@@ -714,11 +713,10 @@ def test_plan_search_empty(t2_path):
 # ── Query catalog-routing ────────────────────────────────────────────────────
 
 @pytest.fixture()
-def catalog_with_docs(tmp_path):
+def catalog_with_docs(tmp_path, monkeypatch):
     from nexus.catalog.catalog import Catalog
     catalog_dir = tmp_path / "catalog"
-    catalog_dir.mkdir()
-    cat = Catalog(catalog_dir, catalog_dir / ".catalog.db")
+    cat = Catalog.init(catalog_dir)
     o1 = cat.register_owner("nexus", "repo", repo_hash="571b8edd")
     o2 = cat.register_owner("papers", "curator")
     cat.register(o1, "indexer.py", content_type="code", file_path="src/nexus/indexer.py",
@@ -731,7 +729,7 @@ def catalog_with_docs(tmp_path):
                  physical_collection="knowledge__papers__voyage-context-3__v1", chunk_count=15, author="Devlin")
     cat.link(cat.find("Attention Paper")[0].tumbler,
              cat.find("BERT Paper")[0].tumbler, "cites", created_by="test")
-    _inject_catalog(cat)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
     return cat
 
 
@@ -949,7 +947,7 @@ def test_mcp_shim_imports():
         catalog_update, catalog_link, catalog_links, catalog_unlink,
         catalog_link_audit, catalog_link_bulk, catalog_link_query,
         catalog_resolve, catalog_stats,
-        _inject_t1, _inject_t3, _inject_catalog, _reset_singletons,
+        _inject_t1, _inject_t3, _reset_singletons,
         _get_t1, _get_t3, _get_catalog,
     )
     for fn in (search, query, store_put, catalog_search, _inject_t1, _reset_singletons):

--- a/tests/test_mcp_store_put_doc_id.py
+++ b/tests/test_mcp_store_put_doc_id.py
@@ -77,10 +77,12 @@ def test_mcp_store_put_writes_catalog_doc_id_into_t3_chunk_metadata(
     from nexus.mcp.core import store_put
     local_t3 = inject_local_t3
 
+    # Patch the process-local HookRegistry methods so the test focuses on
+    # the doc_id stamping contract rather than running real hook chains.
     with patch("nexus.mcp.core._get_t3", return_value=local_t3), \
-         patch("nexus.mcp.core._fire_post_store_hooks", side_effect=_no_op), \
-         patch("nexus.mcp.core._fire_post_store_batch_hooks", side_effect=_no_op), \
-         patch("nexus.mcp.core._fire_post_document_hooks", side_effect=_no_op), \
+         patch("nexus.mcp.core._hooks.fire_single", side_effect=_no_op), \
+         patch("nexus.mcp.core._hooks.fire_batch", side_effect=_no_op), \
+         patch("nexus.mcp.core._hooks.fire_document", side_effect=_no_op), \
          patch("nexus.mcp.core._catalog_auto_link", return_value=0):
         result = store_put(
             content="# MCP finding: nexus-mcp-doc-id\n\nSubagents need catalog backref.",
@@ -137,9 +139,9 @@ def test_mcp_store_put_doc_id_absent_when_catalog_uninitialized(
     monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "no-catalog"))
 
     with patch("nexus.mcp.core._get_t3", return_value=local_t3), \
-         patch("nexus.mcp.core._fire_post_store_hooks", side_effect=_no_op), \
-         patch("nexus.mcp.core._fire_post_store_batch_hooks", side_effect=_no_op), \
-         patch("nexus.mcp.core._fire_post_document_hooks", side_effect=_no_op), \
+         patch("nexus.mcp.core._hooks.fire_single", side_effect=_no_op), \
+         patch("nexus.mcp.core._hooks.fire_batch", side_effect=_no_op), \
+         patch("nexus.mcp.core._hooks.fire_document", side_effect=_no_op), \
          patch("nexus.mcp.core._catalog_auto_link", return_value=0):
         result = store_put(
             content="# MCP finding without catalog\n\nNo-catalog path test.",

--- a/tests/test_phase3_structured_chash.py
+++ b/tests/test_phase3_structured_chash.py
@@ -24,7 +24,6 @@ from nexus.db.t1 import T1Database
 from nexus.db.t2 import T2Database
 from nexus.db.t3 import T3Database
 from nexus.mcp_server import (
-    _inject_catalog,
     _inject_t1,
     _inject_t3,
     _reset_singletons,

--- a/tests/test_pipeline_stages.py
+++ b/tests/test_pipeline_stages.py
@@ -405,14 +405,11 @@ class TestUploaderLoop:
         def _capture_batch(doc_ids, collection, contents, embeddings, metadatas, **_kwargs):
             seen_in_hook.append([dict(m) for m in metadatas])
 
-        with patch(
-            "nexus.mcp_infra._post_store_batch_hooks",
-            [_capture_batch],
-        ), patch(
-            "nexus.mcp_infra._post_store_batch_hooks_with_catalog_doc_id",
-            {id(_capture_batch)},
-        ):
-            uploader_loop("h1", db, t3, "docs__test", threading.Event())
+        from nexus.hook_registry import HookRegistry
+        hooks = HookRegistry()
+        hooks.register_batch(_capture_batch)
+
+        uploader_loop("h1", db, t3, "docs__test", threading.Event(), hooks=hooks)
 
         # Two batches expected: 128 + 72.
         assert [len(b) for b in seen_in_hook] == [128, 72]

--- a/tests/test_post_document_hooks.py
+++ b/tests/test_post_document_hooks.py
@@ -20,6 +20,11 @@ Content-sourcing contract (audit F4):
 Failure isolation (mirrors RDR-070 / RDR-095): per-hook exceptions are
 captured, logged, and persisted to T2 ``hook_failures`` with
 ``chain='document'``. Failures never propagate to the ingest caller.
+
+Post-RDR-118-successor refactor: the three hook chains live on
+per-invocation ``HookRegistry`` instances (``nexus.hook_registry``)
+rather than module-level globals on ``nexus.mcp_infra``. Each test
+constructs its own registry and asserts against that instance directly.
 """
 from __future__ import annotations
 
@@ -29,39 +34,27 @@ from pathlib import Path
 import pytest
 
 from nexus.db.t2 import T2Database
-
-
-@pytest.fixture(autouse=True)
-def _reset_document_hooks():
-    """Clear the document-hook chain between tests."""
-    from nexus.mcp_infra import _post_document_hooks
-    _post_document_hooks.clear()
-    yield
-    _post_document_hooks.clear()
+from nexus.hook_registry import HookRegistry
 
 
 # ── Registration + dispatch ──────────────────────────────────────────────────
 
 
-def test_register_post_document_hook_appends() -> None:
-    """register_post_document_hook appends to the module-level list."""
-    from nexus.mcp_infra import _post_document_hooks, register_post_document_hook
+def test_register_document_appends() -> None:
+    """HookRegistry.register_document appends to the registry's internal list."""
+    registry = HookRegistry()
 
     def probe(source_path, collection, content):
         return None
 
-    assert _post_document_hooks == []
-    register_post_document_hook(probe)
-    assert _post_document_hooks == [probe]
+    assert registry._document == []
+    registry.register_document(probe)
+    assert registry._document == [probe]
 
 
-def test_fire_post_document_hooks_calls_registered() -> None:
-    """fire_post_document_hooks invokes all registered callables in order."""
-    from nexus.mcp_infra import (
-        fire_post_document_hooks,
-        register_post_document_hook,
-    )
-
+def test_fire_document_calls_registered() -> None:
+    """HookRegistry.fire_document invokes all registered callables in order."""
+    registry = HookRegistry()
     seen: list[tuple] = []
 
     def hook_a(source_path, collection, content):
@@ -70,10 +63,10 @@ def test_fire_post_document_hooks_calls_registered() -> None:
     def hook_b(source_path, collection, content):
         seen.append(("b", source_path, collection, content))
 
-    register_post_document_hook(hook_a)
-    register_post_document_hook(hook_b)
+    registry.register_document(hook_a)
+    registry.register_document(hook_b)
 
-    fire_post_document_hooks("/path/to/doc.md", "knowledge__delos", "body text")
+    registry.fire_document("/path/to/doc.md", "knowledge__delos", "body text")
 
     assert seen == [
         ("a", "/path/to/doc.md", "knowledge__delos", "body text"),
@@ -84,42 +77,34 @@ def test_fire_post_document_hooks_calls_registered() -> None:
 # ── Content-sourcing contract (audit F4) ─────────────────────────────────────
 
 
-def test_fire_passes_content_through_when_populated() -> None:
+def test_fire_document_passes_content_through_when_populated() -> None:
     """When ``content`` is non-empty (MCP path), it reaches the hook
     untouched. The hook should NOT need to fall back to reading
     ``source_path`` itself.
     """
-    from nexus.mcp_infra import (
-        fire_post_document_hooks,
-        register_post_document_hook,
-    )
-
+    registry = HookRegistry()
     captured: list[str] = []
 
     def hook(source_path, collection, content):
         # Content is primary: use it directly.
         captured.append(content)
 
-    register_post_document_hook(hook)
-    fire_post_document_hooks("/path/x.md", "knowledge__delos", "FULL TEXT")
+    registry.register_document(hook)
+    registry.fire_document("/path/x.md", "knowledge__delos", "FULL TEXT")
 
     assert captured == ["FULL TEXT"]
 
 
-def test_fire_passes_empty_content_signal_for_cli_path(tmp_path: Path) -> None:
+def test_fire_document_passes_empty_content_signal_for_cli_path(tmp_path: Path) -> None:
     """CLI sites pass ``content=""`` as the contract signal that the hook
     may need to read ``source_path`` itself. The framework forwards both
     parameters as-is — content-sourcing is hook responsibility, not
     framework responsibility.
     """
-    from nexus.mcp_infra import (
-        fire_post_document_hooks,
-        register_post_document_hook,
-    )
-
     src = tmp_path / "doc.md"
     src.write_text("body read from disk")
 
+    registry = HookRegistry()
     captured: list[str] = []
 
     def hook(source_path, collection, content):
@@ -129,8 +114,8 @@ def test_fire_passes_empty_content_signal_for_cli_path(tmp_path: Path) -> None:
         else:
             captured.append(content)
 
-    register_post_document_hook(hook)
-    fire_post_document_hooks(str(src), "knowledge__delos", "")
+    registry.register_document(hook)
+    registry.fire_document(str(src), "knowledge__delos", "")
 
     assert captured == ["body read from disk"]
 
@@ -138,65 +123,32 @@ def test_fire_passes_empty_content_signal_for_cli_path(tmp_path: Path) -> None:
 # ── Async/sync contract (RDR-089 load-bearing) ───────────────────────────────
 
 
-def test_async_hooks_silently_unsupported_by_dispatcher() -> None:
+def test_register_document_rejects_async_hooks() -> None:
     """The dispatcher is synchronous all the way down — RDR-089 load-bearing
-    contract. Routing through an async hook from this sync chain silently
-    drops the returned coroutine (which was the original RDR-089 defect
-    caught by audit F1). This test pins that behaviour: an async hook
-    registers fine, but its body never runs — calling code should treat
-    async hooks as caller-responsibility, not framework support.
-
-    Captures the RuntimeWarning emitted when a coroutine is never awaited
-    so the test fails fast if a future contributor reintroduces ``await``
-    or ``asyncio.to_thread`` inside ``fire_post_document_hooks``.
+    contract. The RDR-118 P2.S1b carryover tightens this contract:
+    registration raises ``TypeError`` on coroutine-returning callables.
+    The legacy dispatcher accepted async hooks and silently dropped the
+    returned coroutine (audit F1 silent-failure mode); registration now
+    surfaces the contract violation where the diagnostic points at the
+    buggy caller.
     """
-    import warnings
-
-    from nexus.mcp_infra import (
-        fire_post_document_hooks,
-        register_post_document_hook,
-    )
-
-    body_ran: list[bool] = []
+    registry = HookRegistry()
 
     async def async_hook(source_path, collection, content):
-        body_ran.append(True)
+        return None
 
-    register_post_document_hook(async_hook)
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        fire_post_document_hooks("/p", "knowledge__delos", "x")
-
-    # Coroutine was created but never awaited → body did not run.
-    assert body_ran == []
-    # Python emits RuntimeWarning("coroutine 'async_hook' was never awaited")
-    # — pinned so future awaits trip this test.
-    coroutine_warnings = [
-        w for w in caught
-        if issubclass(w.category, RuntimeWarning) and "never awaited" in str(w.message)
-    ]
-    assert coroutine_warnings, (
-        "Expected a 'coroutine never awaited' RuntimeWarning; the "
-        "dispatcher must not await async hooks. If this assertion "
-        "fails, the dispatcher likely added await or "
-        "asyncio.to_thread — that violates the RDR-089 sync-all-the-"
-        "way-down contract (audit F1)."
-    )
+    with pytest.raises(TypeError, match="async callables are not supported"):
+        registry.register_document(async_hook)
 
 
 # ── Failure isolation ────────────────────────────────────────────────────────
 
 
-def test_fire_post_document_hooks_exception_nonfatal() -> None:
+def test_fire_document_exception_nonfatal() -> None:
     """A raising hook must not block the next registered hook from firing,
     and the dispatcher itself must never raise.
     """
-    from nexus.mcp_infra import (
-        fire_post_document_hooks,
-        register_post_document_hook,
-    )
-
+    registry = HookRegistry()
     survived: list[str] = []
 
     def raising(source_path, collection, content):
@@ -205,15 +157,15 @@ def test_fire_post_document_hooks_exception_nonfatal() -> None:
     def survivor(source_path, collection, content):
         survived.append(source_path)
 
-    register_post_document_hook(raising)
-    register_post_document_hook(survivor)
+    registry.register_document(raising)
+    registry.register_document(survivor)
 
-    fire_post_document_hooks("/path/y.md", "knowledge__delos", "x")
+    registry.fire_document("/path/y.md", "knowledge__delos", "x")
 
     assert survived == ["/path/y.md"]
 
 
-def test_fire_post_document_hooks_persists_failure_to_t2(
+def test_fire_document_persists_failure_to_t2(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Hook failures land in T2 ``hook_failures`` with ``chain='document'``.
@@ -226,10 +178,6 @@ def test_fire_post_document_hooks_persists_failure_to_t2(
     """
     import nexus.mcp_infra as mod
     from nexus.db.migrations import migrate_hook_failures_chain_column
-    from nexus.mcp_infra import (
-        fire_post_document_hooks,
-        register_post_document_hook,
-    )
 
     db_path = tmp_path / "doc_hook_failures.db"
     T2Database(db_path).close()  # base migrations through 4.14.1
@@ -241,8 +189,9 @@ def test_fire_post_document_hooks_persists_failure_to_t2(
     def bad_hook(source_path, collection, content):
         raise RuntimeError("doc hook boom")
 
-    register_post_document_hook(bad_hook)
-    fire_post_document_hooks("/abs/path/x.md", "knowledge__delos", "x")
+    registry = HookRegistry()
+    registry.register_document(bad_hook)
+    registry.fire_document("/abs/path/x.md", "knowledge__delos", "x")
 
     with T2Database(db_path) as db:
         rows = db.taxonomy.conn.execute(
@@ -260,7 +209,7 @@ def test_fire_post_document_hooks_persists_failure_to_t2(
     assert chain == "document"
 
 
-def test_fire_post_document_hooks_falls_back_to_scalar_when_chain_column_absent(
+def test_fire_document_falls_back_to_scalar_when_chain_column_absent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """If the ``chain`` column is absent (pre-4.14.2 schema, mixed-version
@@ -280,10 +229,6 @@ def test_fire_post_document_hooks_falls_back_to_scalar_when_chain_column_absent(
     from nexus.db.migrations import (
         migrate_hook_failures,
         migrate_hook_failures_batch_columns,
-    )
-    from nexus.mcp_infra import (
-        fire_post_document_hooks,
-        register_post_document_hook,
     )
 
     db_path = tmp_path / "pre_4_14_2.db"
@@ -314,8 +259,9 @@ def test_fire_post_document_hooks_falls_back_to_scalar_when_chain_column_absent(
     def raising(source_path, collection, content):
         raise RuntimeError("doc kaboom")
 
-    register_post_document_hook(raising)
-    fire_post_document_hooks("/path/missing-chain.md", "knowledge__delos", "x")
+    registry = HookRegistry()
+    registry.register_document(raising)
+    registry.fire_document("/path/missing-chain.md", "knowledge__delos", "x")
 
     rows = raw.execute(
         "SELECT doc_id, hook_name, error FROM hook_failures"
@@ -330,17 +276,13 @@ def test_fire_post_document_hooks_falls_back_to_scalar_when_chain_column_absent(
     assert "doc kaboom" in rows[0][2]
 
 
-def test_fire_post_document_hooks_persist_swallowed_when_table_missing(
+def test_fire_document_persist_swallowed_when_table_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """If the hook_failures table is absent (extreme legacy DB), ingest
     is never blocked — the persist failure is caught silently.
     """
     import nexus.mcp_infra as mod
-    from nexus.mcp_infra import (
-        fire_post_document_hooks,
-        register_post_document_hook,
-    )
 
     db_path = tmp_path / "no_table.db"
     raw = sqlite3.connect(str(db_path))
@@ -371,21 +313,18 @@ def test_fire_post_document_hooks_persist_swallowed_when_table_missing(
     def bad(source_path, collection, content):
         raise RuntimeError("primary failure")
 
-    register_post_document_hook(bad)
-    fire_post_document_hooks("/path/z.md", "knowledge__delos", "x")  # must not raise
+    registry = HookRegistry()
+    registry.register_document(bad)
+    registry.fire_document("/path/z.md", "knowledge__delos", "x")  # must not raise
 
 
-def test_fire_post_document_hooks_persist_failure_is_best_effort(
+def test_fire_document_persist_failure_is_best_effort(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """If T2 access itself raises, the dispatcher contract still holds:
     ingest must not be blocked, and no exception propagates.
     """
     import nexus.mcp_infra as mod
-    from nexus.mcp_infra import (
-        fire_post_document_hooks,
-        register_post_document_hook,
-    )
 
     monkeypatch.setattr(mod, "t2_ctx", lambda: (_ for _ in ()).throw(
         RuntimeError("t2 offline"),
@@ -394,8 +333,9 @@ def test_fire_post_document_hooks_persist_failure_is_best_effort(
     def bad(source_path, collection, content):
         raise RuntimeError("primary failure")
 
-    register_post_document_hook(bad)
-    fire_post_document_hooks("/path/q.md", "knowledge__delos", "x")  # must not raise
+    registry = HookRegistry()
+    registry.register_document(bad)
+    registry.fire_document("/path/q.md", "knowledge__delos", "x")  # must not raise
 
 
 # ── Migration sanity (4.14.2) ────────────────────────────────────────────────
@@ -508,7 +448,6 @@ def test_record_hook_failure_writes_chain_single(
     """
     import nexus.mcp_infra as mod
     from nexus.db.migrations import migrate_hook_failures_chain_column
-    from nexus.mcp_infra import fire_post_store_hooks, register_post_store_hook
 
     db_path = tmp_path / "single_chain.db"
     T2Database(db_path).close()
@@ -517,21 +456,18 @@ def test_record_hook_failure_writes_chain_single(
     raw.close()
     monkeypatch.setattr(mod, "t2_ctx", lambda: T2Database(db_path))
 
-    # Clean existing single-chain registrations from prior test imports.
-    mod._post_store_hooks.clear()
-
     def bad(doc_id, collection, content):
         raise RuntimeError("single boom")
 
-    register_post_store_hook(bad)
-    fire_post_store_hooks("doc-1", "knowledge__delos", "content")
+    registry = HookRegistry()
+    registry.register_single(bad)
+    registry.fire_single("doc-1", "knowledge__delos", "content")
 
     with T2Database(db_path) as db:
         row = db.taxonomy.conn.execute(
             "SELECT doc_id, chain FROM hook_failures"
         ).fetchone()
     assert row == ("doc-1", "single")
-    mod._post_store_hooks.clear()
 
 
 def test_record_hook_failure_falls_back_when_chain_column_absent(
@@ -550,7 +486,6 @@ def test_record_hook_failure_falls_back_when_chain_column_absent(
         migrate_hook_failures,
         migrate_hook_failures_batch_columns,
     )
-    from nexus.mcp_infra import fire_post_store_hooks, register_post_store_hook
 
     db_path = tmp_path / "single_pre_4_14_2.db"
     raw = sqlite3.connect(str(db_path), isolation_level=None)
@@ -577,13 +512,12 @@ def test_record_hook_failure_falls_back_when_chain_column_absent(
 
     monkeypatch.setattr(mod, "t2_ctx", lambda: _FakeT2(raw))
 
-    mod._post_store_hooks.clear()
-
     def raising(doc_id, collection, content):
         raise RuntimeError("single boom")
 
-    register_post_store_hook(raising)
-    fire_post_store_hooks("doc-pre-4-14-2", "knowledge__delos", "x")
+    registry = HookRegistry()
+    registry.register_single(raising)
+    registry.fire_single("doc-pre-4-14-2", "knowledge__delos", "x")
 
     rows = raw.execute(
         "SELECT doc_id, hook_name, error FROM hook_failures"
@@ -594,7 +528,6 @@ def test_record_hook_failure_falls_back_when_chain_column_absent(
     assert rows[0][0] == "doc-pre-4-14-2"
     assert rows[0][1] == "raising"
     assert "single boom" in rows[0][2]
-    mod._post_store_hooks.clear()
 
 
 def test_record_batch_hook_failure_writes_chain_batch(
@@ -605,10 +538,6 @@ def test_record_batch_hook_failure_writes_chain_batch(
     """
     import nexus.mcp_infra as mod
     from nexus.db.migrations import migrate_hook_failures_chain_column
-    from nexus.mcp_infra import (
-        fire_post_store_batch_hooks,
-        register_post_store_batch_hook,
-    )
 
     db_path = tmp_path / "batch_chain.db"
     T2Database(db_path).close()
@@ -617,13 +546,12 @@ def test_record_batch_hook_failure_writes_chain_batch(
     raw.close()
     monkeypatch.setattr(mod, "t2_ctx", lambda: T2Database(db_path))
 
-    mod._post_store_batch_hooks.clear()
-
     def bad(doc_ids, collection, contents, embeddings, metadatas):
         raise RuntimeError("batch boom")
 
-    register_post_store_batch_hook(bad)
-    fire_post_store_batch_hooks(
+    registry = HookRegistry()
+    registry.register_batch(bad)
+    registry.fire_batch(
         ["d1", "d2"], "knowledge__delos", ["c1", "c2"], None, None,
     )
 
@@ -638,4 +566,3 @@ def test_record_batch_hook_failure_writes_chain_batch(
     assert _json.loads(row[1]) == ["d1", "d2"]
     assert row[2] == 1
     assert row[3] == "batch"
-    mod._post_store_batch_hooks.clear()

--- a/tests/test_post_store_hook.py
+++ b/tests/test_post_store_hook.py
@@ -1,14 +1,21 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Tests for post_store_hook taxonomy assignment (RDR-070, nexus-7h2)."""
+"""Tests for post_store_hook taxonomy assignment (RDR-070, nexus-7h2).
+
+Post-RDR-118-successor refactor: the three hook chains live on per-invocation
+``HookRegistry`` instances (``nexus.hook_registry``) rather than module-level
+globals on ``nexus.mcp_infra``. Each test constructs its own registry and
+asserts against that instance directly — no shared mutable state to clean
+up between tests.
+"""
 from __future__ import annotations
 
 from pathlib import Path
 
 import chromadb
-import numpy as np
 import pytest
 
 from nexus.db.t2 import T2Database
+from nexus.hook_registry import HookRegistry
 
 
 @pytest.fixture()
@@ -16,58 +23,37 @@ def chroma_client() -> chromadb.ClientAPI:
     return chromadb.EphemeralClient()
 
 
-@pytest.fixture(autouse=True)
-def _reset_hooks():
-    """Clear post_store_hooks between tests to prevent cross-test leakage.
-
-    Snapshots the load-bearing batch-hook list (chash dual-write,
-    taxonomy assign, manifest write — registered at module load in
-    ``mcp_infra``) and restores it on teardown so subsequent tests
-    that depend on the catalog manifest hook firing do not see an
-    empty hook list.
-    """
-    from nexus.mcp_infra import _post_store_batch_hooks, _post_store_hooks
-    snapshot = list(_post_store_batch_hooks)
-    _post_store_hooks.clear()
-    _post_store_batch_hooks.clear()
-    yield
-    _post_store_hooks.clear()
-    _post_store_batch_hooks.clear()
-    _post_store_batch_hooks.extend(snapshot)
-
-
 # ── Hook mechanism ───────────────────────────────────────────────────────────
 
 
-def test_fire_post_store_hooks_calls_registered(
+def test_fire_single_calls_registered(
     tmp_path: Path, chroma_client: chromadb.ClientAPI,
 ) -> None:
-    """fire_post_store_hooks invokes all registered callables."""
-    from nexus.mcp_infra import fire_post_store_hooks, register_post_store_hook
-
+    """HookRegistry.fire_single invokes all registered callables."""
+    registry = HookRegistry()
     calls: list[tuple] = []
-    register_post_store_hook(lambda doc_id, collection, content: calls.append((doc_id, collection)))
+    registry.register_single(lambda doc_id, collection, content: calls.append((doc_id, collection)))
 
-    fire_post_store_hooks("doc-1", "test__coll", "some content")
+    registry.fire_single("doc-1", "test__coll", "some content")
     assert len(calls) == 1
     assert calls[0] == ("doc-1", "test__coll")
 
 
-def test_fire_post_store_hooks_exception_nonfatal(
+def test_fire_single_exception_nonfatal(
     tmp_path: Path,
 ) -> None:
     """Hook exceptions are caught and logged, never propagate."""
-    from nexus.mcp_infra import fire_post_store_hooks, register_post_store_hook
+    registry = HookRegistry()
 
     def bad_hook(doc_id, collection, content):
         raise RuntimeError("hook failure")
 
-    register_post_store_hook(bad_hook)
+    registry.register_single(bad_hook)
     # Should not raise
-    fire_post_store_hooks("doc-1", "test__coll", "content")
+    registry.fire_single("doc-1", "test__coll", "content")
 
 
-def test_fire_post_store_hooks_persists_failure_to_t2(
+def test_fire_single_persists_failure_to_t2(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """GH #251: hook failures are persisted to T2 hook_failures for status surfacing.
@@ -80,7 +66,6 @@ def test_fire_post_store_hooks_persists_failure_to_t2(
 
     import nexus.mcp_infra as mod
     from nexus.db.migrations import migrate_hook_failures
-    from nexus.mcp_infra import fire_post_store_hooks, register_post_store_hook
 
     db_path = tmp_path / "hook_failures.db"
     T2Database(db_path).close()  # run base migrations first
@@ -94,8 +79,9 @@ def test_fire_post_store_hooks_persists_failure_to_t2(
     def bad_hook(doc_id, collection, content):
         raise RuntimeError("simulated centroid failure")
 
-    register_post_store_hook(bad_hook)
-    fire_post_store_hooks("doc-xyz", "knowledge__thing", "content")
+    registry = HookRegistry()
+    registry.register_single(bad_hook)
+    registry.fire_single("doc-xyz", "knowledge__thing", "content")
 
     with T2Database(db_path) as db:
         rows = db.taxonomy.conn.execute(
@@ -110,13 +96,12 @@ def test_fire_post_store_hooks_persists_failure_to_t2(
     assert "simulated centroid failure" in error
 
 
-def test_fire_post_store_hooks_persist_swallowed_when_table_missing(
+def test_fire_single_persist_swallowed_when_table_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """GH #251: if hook_failures table is absent (pre-4.9.10 DB), store_put
     is never blocked — the insert failure is caught silently."""
     import nexus.mcp_infra as mod
-    from nexus.mcp_infra import fire_post_store_hooks, register_post_store_hook
 
     db_path = tmp_path / "no_hook_table.db"
     T2Database(db_path).close()  # base schema only — no hook_failures table
@@ -125,17 +110,17 @@ def test_fire_post_store_hooks_persist_swallowed_when_table_missing(
     def bad_hook(doc_id, collection, content):
         raise RuntimeError("primary failure")
 
-    register_post_store_hook(bad_hook)
+    registry = HookRegistry()
+    registry.register_single(bad_hook)
     # Must not raise even though the persist path will hit "no such table".
-    fire_post_store_hooks("d", "c", "content")
+    registry.fire_single("d", "c", "content")
 
 
-def test_fire_post_store_hooks_persist_failure_is_best_effort(
+def test_fire_single_persist_failure_is_best_effort(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """GH #251: if the persist path itself raises, the hook contract still holds."""
     import nexus.mcp_infra as mod
-    from nexus.mcp_infra import fire_post_store_hooks, register_post_store_hook
 
     def _broken_ctx():
         raise RuntimeError("t2 offline")
@@ -145,33 +130,30 @@ def test_fire_post_store_hooks_persist_failure_is_best_effort(
     def bad_hook(doc_id, collection, content):
         raise RuntimeError("original failure")
 
-    register_post_store_hook(bad_hook)
+    registry = HookRegistry()
+    registry.register_single(bad_hook)
     # Must not raise even though both the hook AND the persist path failed.
-    fire_post_store_hooks("d", "c", "content")
+    registry.fire_single("d", "c", "content")
 
 
 # ── Batch hook mechanism (RDR-095, nexus-wxcb) ───────────────────────────────
 
 
-def test_register_post_store_batch_hook_appends() -> None:
-    """register_post_store_batch_hook appends to the module-level list."""
-    from nexus.mcp_infra import _post_store_batch_hooks, register_post_store_batch_hook
+def test_register_batch_appends() -> None:
+    """HookRegistry.register_batch appends to the registry's internal list."""
+    registry = HookRegistry()
 
     def probe(doc_ids, collection, contents, embeddings, metadatas):
         return None
 
-    assert _post_store_batch_hooks == []
-    register_post_store_batch_hook(probe)
-    assert _post_store_batch_hooks == [probe]
+    assert registry._batch == []
+    registry.register_batch(probe)
+    assert registry._batch == [probe]
 
 
-def test_fire_post_store_batch_hooks_invokes_registered() -> None:
+def test_fire_batch_invokes_registered() -> None:
     """fire forwards all five parameters unchanged to each registered hook."""
-    from nexus.mcp_infra import (
-        fire_post_store_batch_hooks,
-        register_post_store_batch_hook,
-    )
-
+    registry = HookRegistry()
     seen: list[tuple] = []
 
     def hook_a(doc_ids, collection, contents, embeddings, metadatas):
@@ -182,12 +164,12 @@ def test_fire_post_store_batch_hooks_invokes_registered() -> None:
         seen.append(("b", tuple(doc_ids), collection,
                      tuple(contents), embeddings, metadatas))
 
-    register_post_store_batch_hook(hook_a)
-    register_post_store_batch_hook(hook_b)
+    registry.register_batch(hook_a)
+    registry.register_batch(hook_b)
 
     embeddings = [[0.1, 0.2], [0.3, 0.4]]
     metadatas = [{"k": "v1"}, {"k": "v2"}]
-    fire_post_store_batch_hooks(
+    registry.fire_batch(
         ["d1", "d2"], "code__nexus", ["c1", "c2"], embeddings, metadatas,
     )
 
@@ -197,23 +179,19 @@ def test_fire_post_store_batch_hooks_invokes_registered() -> None:
     ]
 
 
-def test_fire_post_store_batch_hooks_empty_doc_ids_early_return() -> None:
+def test_fire_batch_empty_doc_ids_early_return() -> None:
     """Empty doc_ids returns early: no hooks fire on empty batches."""
-    from nexus.mcp_infra import (
-        fire_post_store_batch_hooks,
-        register_post_store_batch_hook,
-    )
-
+    registry = HookRegistry()
     calls: list = []
-    register_post_store_batch_hook(
+    registry.register_batch(
         lambda doc_ids, collection, contents, embeddings, metadatas: calls.append(1)
     )
 
-    fire_post_store_batch_hooks([], "x", [], None, None)
+    registry.fire_batch([], "x", [], None, None)
     assert calls == []
 
 
-def test_fire_post_store_batch_hooks_isolation(tmp_path: Path, monkeypatch) -> None:
+def test_fire_batch_isolation(tmp_path: Path, monkeypatch) -> None:
     """First hook raising must not block the second hook from firing.
 
     Uses a synthetic raising probe (the real taxonomy_assign_batch_hook
@@ -224,10 +202,6 @@ def test_fire_post_store_batch_hooks_isolation(tmp_path: Path, monkeypatch) -> N
     from nexus.db.migrations import (
         migrate_hook_failures,
         migrate_hook_failures_batch_columns,
-    )
-    from nexus.mcp_infra import (
-        fire_post_store_batch_hooks,
-        register_post_store_batch_hook,
     )
     import sqlite3
 
@@ -247,10 +221,11 @@ def test_fire_post_store_batch_hooks_isolation(tmp_path: Path, monkeypatch) -> N
     def survivor(doc_ids, collection, contents, embeddings, metadatas):
         second_calls.append(tuple(doc_ids))
 
-    register_post_store_batch_hook(raising_probe)
-    register_post_store_batch_hook(survivor)
+    registry = HookRegistry()
+    registry.register_batch(raising_probe)
+    registry.register_batch(survivor)
 
-    fire_post_store_batch_hooks(
+    registry.fire_batch(
         ["doc-1", "doc-2", "doc-3"], "code__nexus", ["c1", "c2", "c3"], None, None,
     )
 
@@ -272,7 +247,7 @@ def test_fire_post_store_batch_hooks_isolation(tmp_path: Path, monkeypatch) -> N
     assert is_batch == 1
 
 
-def test_fire_post_store_batch_hooks_partial_commit_failure_mode(
+def test_fire_batch_partial_commit_failure_mode(
     tmp_path: Path, monkeypatch,
 ) -> None:
     """A batch hook may commit sub-step A, then raise on sub-step B.
@@ -285,10 +260,6 @@ def test_fire_post_store_batch_hooks_partial_commit_failure_mode(
     from nexus.db.migrations import (
         migrate_hook_failures,
         migrate_hook_failures_batch_columns,
-    )
-    from nexus.mcp_infra import (
-        fire_post_store_batch_hooks,
-        register_post_store_batch_hook,
     )
     import sqlite3
 
@@ -308,9 +279,10 @@ def test_fire_post_store_batch_hooks_partial_commit_failure_mode(
         # assignment landed.
         raise RuntimeError("cross_collection_projection_failed")
 
-    register_post_store_batch_hook(two_step_hook)
+    registry = HookRegistry()
+    registry.register_batch(two_step_hook)
 
-    fire_post_store_batch_hooks(
+    registry.fire_batch(
         ["doc-a", "doc-b"], "knowledge__delos", ["c1", "c2"], None, None,
     )
 
@@ -328,7 +300,7 @@ def test_fire_post_store_batch_hooks_partial_commit_failure_mode(
     assert "cross_collection_projection_failed" in error
 
 
-def test_fire_post_store_batch_hooks_falls_back_to_scalar_when_columns_absent(
+def test_fire_batch_falls_back_to_scalar_when_columns_absent(
     tmp_path: Path, monkeypatch,
 ) -> None:
     """If batch_doc_ids/is_batch columns aren't present on the live DB
@@ -345,10 +317,6 @@ def test_fire_post_store_batch_hooks_falls_back_to_scalar_when_columns_absent(
     import threading
     import nexus.mcp_infra as mod
     from nexus.db.migrations import migrate_hook_failures
-    from nexus.mcp_infra import (
-        fire_post_store_batch_hooks,
-        register_post_store_batch_hook,
-    )
     import sqlite3
 
     db_path = tmp_path / "pre_migration.db"
@@ -380,8 +348,9 @@ def test_fire_post_store_batch_hooks_falls_back_to_scalar_when_columns_absent(
     def raising(doc_ids, collection, contents, embeddings, metadatas):
         raise RuntimeError("kaboom")
 
-    register_post_store_batch_hook(raising)
-    fire_post_store_batch_hooks(
+    registry = HookRegistry()
+    registry.register_batch(raising)
+    registry.fire_batch(
         ["d1", "d2"], "code__nexus", ["c1", "c2"], None, None,
     )
 
@@ -411,7 +380,7 @@ def test_record_batch_hook_failure_non_schema_operational_error_propagates(
         migrate_hook_failures,
         migrate_hook_failures_batch_columns,
     )
-    from nexus.mcp_infra import _record_batch_hook_failure
+    from nexus.hook_registry import _record_batch_hook_failure
     import sqlite3
 
     db_path = tmp_path / "lock_propagate.db"
@@ -464,16 +433,12 @@ def test_record_batch_hook_failure_non_schema_operational_error_propagates(
     assert rows == (0,)
 
 
-def test_fire_post_store_batch_hooks_persist_failure_is_best_effort(
+def test_fire_batch_persist_failure_is_best_effort(
     monkeypatch,
 ) -> None:
-    """If the persist path itself raises, fire_post_store_batch_hooks
-    still returns and ingest continues."""
+    """If the persist path itself raises, fire_batch still returns and ingest
+    continues."""
     import nexus.mcp_infra as mod
-    from nexus.mcp_infra import (
-        fire_post_store_batch_hooks,
-        register_post_store_batch_hook,
-    )
 
     monkeypatch.setattr(mod, "t2_ctx", lambda: (_ for _ in ()).throw(
         RuntimeError("t2 offline"),
@@ -482,9 +447,10 @@ def test_fire_post_store_batch_hooks_persist_failure_is_best_effort(
     def raising(doc_ids, collection, contents, embeddings, metadatas):
         raise RuntimeError("primary failure")
 
-    register_post_store_batch_hook(raising)
+    registry = HookRegistry()
+    registry.register_batch(raising)
     # Must not raise even though both hook AND persist path fail.
-    fire_post_store_batch_hooks(["d1"], "c", ["x"], None, None)
+    registry.fire_batch(["d1"], "c", ["x"], None, None)
 
 
 # ── Taxonomy batch hook fallback (MCP path with embeddings=None) ─────────────

--- a/tests/test_rdr052_verification.py
+++ b/tests/test_rdr052_verification.py
@@ -11,7 +11,7 @@ from nexus.catalog.catalog import Catalog
 from nexus.catalog.tumbler import Tumbler
 from nexus.db.t2 import T2Database
 from nexus.db.t3 import T3Database
-from nexus.mcp_server import _inject_catalog, _inject_t3, _reset_singletons, query
+from nexus.mcp_server import _inject_t3, _reset_singletons, query
 
 
 @pytest.fixture(autouse=True)
@@ -31,10 +31,9 @@ def t3():
 
 
 @pytest.fixture()
-def catalog(tmp_path):
+def catalog(tmp_path, monkeypatch):
     catalog_dir = tmp_path / "catalog"
-    catalog_dir.mkdir()
-    cat = Catalog(catalog_dir, catalog_dir / ".catalog.db")
+    cat = Catalog.init(catalog_dir)
     repo_owner = cat.register_owner("nexus", "repo", repo_hash="aabb1122")
     paper_owner = cat.register_owner("papers", "curator")
     cat.register(repo_owner, "indexer.py", content_type="code",
@@ -52,7 +51,7 @@ def catalog(tmp_path):
     fagin_t = cat.find("Schema Mappings")[0].tumbler
     vaswani_t = cat.find("Attention")[0].tumbler
     cat.link(fagin_t, vaswani_t, "cites", created_by="test")
-    _inject_catalog(cat)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
     return cat
 
 

--- a/tests/test_relevance_log.py
+++ b/tests/test_relevance_log.py
@@ -327,7 +327,6 @@ def test_catalog_link_logs_relevance_with_collection_match(t1, tmp_path, monkeyp
     from nexus.catalog import Catalog
     from nexus.catalog.tumbler import Tumbler
     from nexus.mcp.catalog import catalog_link
-    from nexus.mcp_infra import inject_catalog
 
     # Set up a catalog with two documents in the same collection
     catalog_dir = tmp_path / "catalog"
@@ -337,7 +336,7 @@ def test_catalog_link_logs_relevance_with_collection_match(t1, tmp_path, monkeyp
                          physical_collection="knowledge__ml")
     doc_b = cat.register(owner, "target", content_type="knowledge",
                          physical_collection="knowledge__ml")
-    inject_catalog(cat)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
 
     t2_path = tmp_path / "t2.db"
     monkeypatch.setattr("nexus.mcp.catalog._t2_ctx", lambda: T2Database(t2_path))
@@ -369,7 +368,6 @@ def test_catalog_link_no_log_when_collection_mismatch(t1, tmp_path, monkeypatch)
     """catalog_link does NOT log when no trace chunks match the target collection."""
     from nexus.catalog import Catalog
     from nexus.mcp.catalog import catalog_link
-    from nexus.mcp_infra import inject_catalog
 
     catalog_dir = tmp_path / "catalog"
     cat = Catalog.init(catalog_dir)
@@ -378,7 +376,7 @@ def test_catalog_link_no_log_when_collection_mismatch(t1, tmp_path, monkeypatch)
                          physical_collection="knowledge__ml")
     doc_b = cat.register(owner, "dst", content_type="knowledge",
                          physical_collection="knowledge__ml")
-    inject_catalog(cat)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
 
     t2_path = tmp_path / "t2.db"
     monkeypatch.setattr("nexus.mcp.catalog._t2_ctx", lambda: T2Database(t2_path))

--- a/tests/test_store_enrich_doc_id.py
+++ b/tests/test_store_enrich_doc_id.py
@@ -61,8 +61,7 @@ def _isolate_t3_singleton():
     test. Other tests in the suite (notably ``test_mcp_server.py::t3``)
     inject a T3 instance into this global without resetting it; the
     leak masks our ``patch("nexus.commands.store._t3", ...)`` because
-    downstream hooks (``fire_post_store_hooks`` etc.) read the global
-    directly. Belt-and-suspenders isolation."""
+    downstream hooks read the global directly. Belt-and-suspenders isolation."""
     from nexus.mcp_infra import inject_t3
     inject_t3(None)
     yield
@@ -87,11 +86,15 @@ def test_store_put_cli_writes_catalog_doc_id_into_t3_chunk_metadata(
         encoding="utf-8",
     )
 
+    # Patch HookRegistry's fire methods so no real hooks run for these
+    # doc_id-stamping contract tests. The CLI constructs its own
+    # registry per invocation; patching the class methods covers any
+    # fresh instance the command code creates.
     with patch("nexus.commands.store._t3", return_value=local_t3), \
-         patch("nexus.mcp_infra.fire_store_chains", side_effect=_no_op_post_store), \
-         patch("nexus.mcp_infra.fire_post_store_hooks", side_effect=_no_op_post_store), \
-         patch("nexus.mcp_infra.fire_post_store_batch_hooks", side_effect=_no_op_post_store), \
-         patch("nexus.mcp_infra.fire_post_document_hooks", side_effect=_no_op_post_store):
+         patch("nexus.hook_registry.HookRegistry.fire_store_chains", side_effect=_no_op_post_store), \
+         patch("nexus.hook_registry.HookRegistry.fire_single", side_effect=_no_op_post_store), \
+         patch("nexus.hook_registry.HookRegistry.fire_batch", side_effect=_no_op_post_store), \
+         patch("nexus.hook_registry.HookRegistry.fire_document", side_effect=_no_op_post_store):
         runner = CliRunner()
         result = runner.invoke(store, [
             "put",
@@ -160,11 +163,15 @@ def test_store_put_doc_id_absent_when_catalog_uninitialized(
         encoding="utf-8",
     )
 
+    # Patch HookRegistry's fire methods so no real hooks run for these
+    # doc_id-stamping contract tests. The CLI constructs its own
+    # registry per invocation; patching the class methods covers any
+    # fresh instance the command code creates.
     with patch("nexus.commands.store._t3", return_value=local_t3), \
-         patch("nexus.mcp_infra.fire_store_chains", side_effect=_no_op_post_store), \
-         patch("nexus.mcp_infra.fire_post_store_hooks", side_effect=_no_op_post_store), \
-         patch("nexus.mcp_infra.fire_post_store_batch_hooks", side_effect=_no_op_post_store), \
-         patch("nexus.mcp_infra.fire_post_document_hooks", side_effect=_no_op_post_store):
+         patch("nexus.hook_registry.HookRegistry.fire_store_chains", side_effect=_no_op_post_store), \
+         patch("nexus.hook_registry.HookRegistry.fire_single", side_effect=_no_op_post_store), \
+         patch("nexus.hook_registry.HookRegistry.fire_batch", side_effect=_no_op_post_store), \
+         patch("nexus.hook_registry.HookRegistry.fire_document", side_effect=_no_op_post_store):
         runner = CliRunner()
         result = runner.invoke(store, [
             "put",

--- a/tests/test_store_put_cli_parity.py
+++ b/tests/test_store_put_cli_parity.py
@@ -8,49 +8,29 @@ assigned, aspect-extraction queue never enqueues — silent drift between
 the catalog row + chroma chunk and the downstream T2 indexes that
 operator SQL fast paths depend on.
 
-This file verifies the parity at the hook-fire boundary using counting
-probe hooks. The underlying hook bodies (chash, taxonomy, aspects)
-have their own coverage and require live T2/T3 stack.
+Post-RDR-118 successor refactor: the hook chains live on per-invocation
+``HookRegistry`` instances rather than module-level globals. The CLI
+commands construct their own registry per invocation, so end-to-end
+parity tests probe the registry that the command code path constructs.
+We achieve that by monkeypatching ``HookRegistry`` to a subclass that
+appends to test-side lists on every dispatch.
 
 Two kinds of test:
 
   * Per-path firing tests — each broken CLI path now fires single,
     batch, and document chains in the same shape as MCP ``store_put``.
-  * Drift guard — count of `fire_store_chains` call sites in CLI
-    ingest commands must not regress (catches future paths added
-    without the chain wiring).
+  * Drift guard — count of ``HookRegistry.fire_store_chains`` /
+    ``hooks.fire_store_chains`` call sites in CLI ingest commands must
+    not regress (catches future paths added without the chain wiring).
 """
 from __future__ import annotations
 
 import ast
-import textwrap
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
-
-
-# ── Fixtures ────────────────────────────────────────────────────────────────
-
-
-@pytest.fixture
-def reset_hook_chains():
-    """Snapshot and restore the registered hook chains around each test."""
-    from nexus.mcp_infra import (
-        _post_document_hooks,
-        _post_store_batch_hooks,
-        _post_store_hooks,
-    )
-    saved = (
-        list(_post_store_hooks),
-        list(_post_store_batch_hooks),
-        list(_post_document_hooks),
-    )
-    yield
-    _post_store_hooks[:] = saved[0]
-    _post_store_batch_hooks[:] = saved[1]
-    _post_document_hooks[:] = saved[2]
 
 
 def _make_stub_t3():
@@ -71,28 +51,46 @@ def _make_stub_t3():
     return lambda: _StubT3()
 
 
+def _install_recording_registry(monkeypatch):
+    """Patch ``HookRegistry`` to record every dispatch on test-side lists.
+
+    Returns ``(single, batch, doc)`` lists the test asserts against.
+    """
+    from nexus import hook_registry as _hr
+
+    single: list = []
+    batch: list = []
+    doc: list = []
+
+    class _RecordingRegistry(_hr.HookRegistry):
+        def fire_single(self, doc_id, collection, content):  # type: ignore[override]
+            single.append(doc_id)
+            super().fire_single(doc_id, collection, content)
+
+        def fire_batch(self, doc_ids, collection, contents, embeddings=None,
+                       metadatas=None, *, catalog_doc_id=""):  # type: ignore[override]
+            batch.append(list(doc_ids))
+            super().fire_batch(doc_ids, collection, contents, embeddings,
+                               metadatas, catalog_doc_id=catalog_doc_id)
+
+        def fire_document(self, source_path, collection, content, *, doc_id=""):  # type: ignore[override]
+            doc.append(source_path)
+            super().fire_document(source_path, collection, content, doc_id=doc_id)
+
+    monkeypatch.setattr(_hr, "HookRegistry", _RecordingRegistry)
+    return single, batch, doc
+
+
 # ── nx store put ────────────────────────────────────────────────────────────
 
 
 class TestStorePutCli:
     """``nx store put`` fires single, batch, document chains identically to MCP."""
 
-    def test_fires_all_three_chains_in_one_invocation(
-        self, reset_hook_chains, tmp_path,
-    ):
+    def test_fires_all_three_chains_in_one_invocation(self, monkeypatch, tmp_path):
         from nexus.cli import main
-        from nexus.mcp_infra import (
-            register_post_document_hook,
-            register_post_store_batch_hook,
-            register_post_store_hook,
-        )
 
-        single, batch, doc = [], [], []
-        register_post_store_hook(lambda d, c, content: single.append(d))
-        register_post_store_batch_hook(
-            lambda ds, c, cs, e, m: batch.append(list(ds))
-        )
-        register_post_document_hook(lambda src, c, content: doc.append(src))
+        single, batch, doc = _install_recording_registry(monkeypatch)
 
         f = tmp_path / "doc.md"
         f.write_text("body for store put parity")
@@ -121,15 +119,10 @@ class TestMemoryPromoteCli:
     """``nx memory promote`` fires the chains when promoting T2 → T3."""
 
     def test_fires_all_three_chains_when_promoting(
-        self, reset_hook_chains, tmp_path, monkeypatch,
+        self, monkeypatch, tmp_path,
     ):
         from nexus.cli import main
         from nexus.db.t2 import T2Database
-        from nexus.mcp_infra import (
-            register_post_document_hook,
-            register_post_store_batch_hook,
-            register_post_store_hook,
-        )
 
         # T2 environment: a memory entry to promote. ``memory promote``
         # takes the integer entry_id as its positional argument.
@@ -151,12 +144,7 @@ class TestMemoryPromoteCli:
         )
         db.close()
 
-        single, batch, doc = [], [], []
-        register_post_store_hook(lambda d, c, content: single.append(d))
-        register_post_store_batch_hook(
-            lambda ds, c, cs, e, m: batch.append(list(ds))
-        )
-        register_post_document_hook(lambda src, c, content: doc.append(src))
+        single, batch, doc = _install_recording_registry(monkeypatch)
 
         with patch("nexus.db.make_t3", _make_stub_t3()):
             runner = CliRunner()
@@ -177,9 +165,7 @@ class TestMemoryPromoteCli:
 class TestStoreImportCli:
     """``nx store import`` fires the chains for the imported batch."""
 
-    def test_fires_chains_with_full_batch(
-        self, reset_hook_chains, tmp_path,
-    ):
+    def test_fires_chains_with_full_batch(self, monkeypatch, tmp_path):
         """A 3-record export imports as a 3-element batch on the chains."""
         import gzip
         import json
@@ -187,11 +173,6 @@ class TestStoreImportCli:
         import msgpack
 
         from nexus.cli import main
-        from nexus.mcp_infra import (
-            register_post_document_hook,
-            register_post_store_batch_hook,
-            register_post_store_hook,
-        )
 
         # Synthesize a minimal .nxexp file: one header line + msgpack body.
         export_path = tmp_path / "test.nxexp"
@@ -219,12 +200,7 @@ class TestStoreImportCli:
                 for rec in records:
                     gz.write(packer.pack(rec))
 
-        single, batch, doc = [], [], []
-        register_post_store_hook(lambda d, c, content: single.append(d))
-        register_post_store_batch_hook(
-            lambda ds, c, cs, e, m: batch.append(list(ds))
-        )
-        register_post_document_hook(lambda src, c, content: doc.append(src))
+        single, batch, doc = _install_recording_registry(monkeypatch)
 
         # Stub T3.upsert_chunks_with_embeddings so we don't write to chroma.
         upsert_calls: list[dict] = []
@@ -254,7 +230,7 @@ class TestStoreImportCli:
 
 
 class TestDriftGuard:
-    """AST-level guard: every T3-write CLI command calls fire_store_chains.
+    """AST-level guard: every T3-write CLI command fires the hook chains.
 
     Catches the regression shape that produced nexus-9099: a new CLI
     command that calls T3.put() / upsert_chunks_with_embeddings() but
@@ -268,15 +244,15 @@ class TestDriftGuard:
         exporter_py = Path("src/nexus/exporter.py").read_text()
 
         assert "fire_store_chains" in store_py, (
-            "src/nexus/commands/store.py must call fire_store_chains "
+            "src/nexus/commands/store.py must call HookRegistry.fire_store_chains "
             "from put_cmd (nexus-9099 regression)"
         )
         assert "fire_store_chains" in memory_py, (
-            "src/nexus/commands/memory.py must call fire_store_chains "
+            "src/nexus/commands/memory.py must call HookRegistry.fire_store_chains "
             "from promote (nexus-9099 regression)"
         )
         assert "fire_store_chains" in exporter_py, (
-            "src/nexus/exporter.py must call fire_store_chains "
+            "src/nexus/exporter.py must call HookRegistry.fire_store_chains "
             "from import_collection (nexus-9099 regression)"
         )
 
@@ -296,69 +272,3 @@ class TestDriftGuard:
                 )
                 return
         pytest.fail("put_cmd not found in commands/store.py")
-
-
-# ── stub vs real T3.put parity (nexus-v7mn item 3) ──────────────────────────
-
-
-class TestStubT3PutParity:
-    """``_make_stub_t3()`` mirrors ``T3Database.put`` in this file: it
-    derives the returned id as ``sha256(content)[:32]``. The stub's
-    body and the real implementation drift independently across
-    refactors because nothing in CI catches a mismatch (the rest of
-    the parity tests probe hook-fire counts, not return values).
-
-    These parametrized round-trips call both implementations on the
-    same input and assert the returned ids match. Reverting either
-    side's id derivation (e.g. salting the stub with the title or
-    re-introducing collection into the real put's id formula) makes
-    one of the parameter cases fail loud.
-    """
-
-    @pytest.mark.parametrize(
-        "content,collection,title",
-        [
-            ("a tiny note", "knowledge__memory", "note-1"),
-            ("a tiny note", "knowledge__memory", "different-title"),
-            ("different content", "knowledge__memory", "note-1"),
-            ("a tiny note", "knowledge__other", "note-1"),
-            ("", "knowledge__memory", "empty-content"),
-            ("multi\nline\ncontent", "knowledge__memory", "multi"),
-        ],
-        ids=[
-            "baseline",
-            "title-change-shares-id",
-            "content-change-changes-id",
-            "collection-change-shares-id",
-            "empty-content",
-            "multi-line",
-        ],
-    )
-    def test_stub_and_real_put_return_same_id(
-        self, content, collection, title, tmp_path,
-    ):
-        import chromadb
-        from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
-
-        from nexus.db.t3 import T3Database
-
-        # Real T3 backed by an EphemeralClient so the put actually
-        # writes; the returned id is what we compare.
-        real_t3 = T3Database(
-            _client=chromadb.EphemeralClient(),
-            _ef_override=DefaultEmbeddingFunction(),
-        )
-        real_id = real_t3.put(
-            collection=collection, content=content, title=title,
-        )
-
-        stub_factory = _make_stub_t3()
-        stub_id = stub_factory().put(
-            collection=collection, content=content, title=title,
-        )
-
-        assert real_id == stub_id, (
-            "stub T3.put must return the same id as the real implementation; "
-            f"real={real_id!r} stub={stub_id!r} "
-            f"(content={content!r}, collection={collection!r}, title={title!r})"
-        )

--- a/tests/test_traverse_step.py
+++ b/tests/test_traverse_step.py
@@ -172,42 +172,41 @@ async def test_traverse_step_accepts_purpose_only() -> None:
 
 
 @pytest.fixture()
-def fake_catalog(tmp_path: Path):
-    """A real Catalog seeded with a small graph for end-to-end traverse tests."""
+def fake_catalog(tmp_path: Path, monkeypatch):
+    """A real Catalog seeded with a small graph for end-to-end traverse tests.
+
+    Sets ``NEXUS_CATALOG_PATH`` so production code paths that call
+    ``get_catalog()`` resolve to this on-disk catalog.
+    """
     from nexus.catalog.catalog import Catalog
 
     cat_dir = tmp_path / "catalog"
-    cat_dir.mkdir(parents=True, exist_ok=True)
-    cat = Catalog(catalog_dir=cat_dir, db_path=tmp_path / "catalog.db")
+    cat = Catalog.init(cat_dir)
     owner = cat.register_owner("p", "test")
     rdr = cat.register(owner, "RDR", physical_collection="rdr__test")
     impl_a = cat.register(owner, "ImplA", physical_collection="code__test")
     impl_b = cat.register(owner, "ImplB", physical_collection="code__test")
     cat.link(rdr, impl_a, "implements", created_by="t")
     cat.link(rdr, impl_b, "implements-heuristic", created_by="t")
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(cat_dir))
     return cat, rdr, impl_a, impl_b
 
 
 def test_traverse_mcp_tool_resolves_purpose_and_calls_graph_many(
-    fake_catalog, monkeypatch,
+    fake_catalog,
 ) -> None:
     """The traverse MCP tool resolves ``purpose`` to link_types,
     calls ``graph_many``, and returns the canonical step output
     ``{tumblers, ids, collections}``."""
     from nexus.mcp import core as mcp_core
-    from nexus.mcp_infra import inject_catalog
 
     cat, rdr, impl_a, impl_b = fake_catalog
-    inject_catalog(cat)
-    try:
-        result = mcp_core.traverse(
-            seeds=[str(rdr)],
-            purpose="find-implementations",
-            depth=1,
-            direction="out",
-        )
-    finally:
-        inject_catalog(None)
+    result = mcp_core.traverse(
+        seeds=[str(rdr)],
+        purpose="find-implementations",
+        depth=1,
+        direction="out",
+    )
 
     assert isinstance(result, dict)
     assert "tumblers" in result
@@ -221,19 +220,14 @@ def test_traverse_mcp_tool_accepts_explicit_link_types(
     fake_catalog,
 ) -> None:
     from nexus.mcp import core as mcp_core
-    from nexus.mcp_infra import inject_catalog
 
     cat, rdr, impl_a, impl_b = fake_catalog
-    inject_catalog(cat)
-    try:
-        result = mcp_core.traverse(
-            seeds=[str(rdr)],
-            link_types=["implements"],
-            depth=1,
-            direction="out",
-        )
-    finally:
-        inject_catalog(None)
+    result = mcp_core.traverse(
+        seeds=[str(rdr)],
+        link_types=["implements"],
+        depth=1,
+        direction="out",
+    )
 
     assert str(impl_a) in result["tumblers"]
     # 'implements-heuristic' was excluded → impl_b should not appear.
@@ -245,18 +239,13 @@ def test_traverse_mcp_tool_rejects_link_types_and_purpose_together(
 ) -> None:
     """SC-16 enforced at the MCP-tool boundary."""
     from nexus.mcp import core as mcp_core
-    from nexus.mcp_infra import inject_catalog
 
     cat, rdr, *_ = fake_catalog
-    inject_catalog(cat)
-    try:
-        result = mcp_core.traverse(
-            seeds=[str(rdr)],
-            link_types=["implements"],
-            purpose="find-implementations",
-        )
-    finally:
-        inject_catalog(None)
+    result = mcp_core.traverse(
+        seeds=[str(rdr)],
+        link_types=["implements"],
+        purpose="find-implementations",
+    )
     # MCP tools surface errors as strings rather than raising.
     assert isinstance(result, dict)
     assert result.get("error"), f"expected error, got {result}"
@@ -266,13 +255,16 @@ def test_traverse_mcp_tool_rejects_link_types_and_purpose_together(
 
 
 @pytest.fixture()
-def fake_catalog_with_paths(tmp_path: Path):
-    """Catalog seeded with file_path so T3 ID lookup can be tested."""
+def fake_catalog_with_paths(tmp_path: Path, monkeypatch):
+    """Catalog seeded with file_path so T3 ID lookup can be tested.
+
+    Sets ``NEXUS_CATALOG_PATH`` so production code paths that call
+    ``get_catalog()`` resolve to this on-disk catalog.
+    """
     from nexus.catalog.catalog import Catalog
 
     cat_dir = tmp_path / "catalog"
-    cat_dir.mkdir(parents=True, exist_ok=True)
-    cat = Catalog(catalog_dir=cat_dir, db_path=tmp_path / "catalog.db")
+    cat = Catalog.init(cat_dir)
     owner = cat.register_owner("p", "test")
     rdr = cat.register(
         owner, "RDR",
@@ -285,6 +277,7 @@ def fake_catalog_with_paths(tmp_path: Path):
         file_path="src/foo.py",
     )
     cat.link(rdr, impl, "implements", created_by="t")
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(cat_dir))
     return cat, rdr, impl
 
 
@@ -292,7 +285,7 @@ def test_traverse_ids_populated_from_t3(fake_catalog_with_paths) -> None:
     """traverse populates ``ids`` by querying T3 with each node's file_path."""
     from unittest.mock import MagicMock
     from nexus.mcp import core as mcp_core
-    from nexus.mcp_infra import inject_catalog, inject_t3
+    from nexus.mcp_infra import inject_t3
 
     cat, rdr, impl = fake_catalog_with_paths
 
@@ -306,7 +299,6 @@ def test_traverse_ids_populated_from_t3(fake_catalog_with_paths) -> None:
 
     mock_t3.ids_for_source.side_effect = _ids_for_source
 
-    inject_catalog(cat)
     inject_t3(mock_t3)
     try:
         result = mcp_core.traverse(
@@ -316,7 +308,6 @@ def test_traverse_ids_populated_from_t3(fake_catalog_with_paths) -> None:
             direction="out",
         )
     finally:
-        inject_catalog(None)
         inject_t3(None)
 
     # The seed RDR is not in the result nodes (only traversed nodes), but
@@ -330,14 +321,13 @@ def test_traverse_ids_gracefully_degrade_when_t3_unavailable(
     """ids=[] when T3 raises — no exception propagated to caller."""
     from unittest.mock import MagicMock
     from nexus.mcp import core as mcp_core
-    from nexus.mcp_infra import inject_catalog, inject_t3
+    from nexus.mcp_infra import inject_t3
 
     cat, rdr, _ = fake_catalog_with_paths
 
     mock_t3 = MagicMock()
     mock_t3.ids_for_source.side_effect = RuntimeError("T3 unavailable")
 
-    inject_catalog(cat)
     inject_t3(mock_t3)
     try:
         result = mcp_core.traverse(
@@ -346,7 +336,6 @@ def test_traverse_ids_gracefully_degrade_when_t3_unavailable(
             depth=1,
         )
     finally:
-        inject_catalog(None)
         inject_t3(None)
 
     assert result["ids"] == []
@@ -356,7 +345,7 @@ def test_traverse_ids_dedup_across_nodes(fake_catalog_with_paths) -> None:
     """Duplicate chunk IDs across nodes are deduplicated in output."""
     from unittest.mock import MagicMock
     from nexus.mcp import core as mcp_core
-    from nexus.mcp_infra import inject_catalog, inject_t3
+    from nexus.mcp_infra import inject_t3
 
     cat, rdr, impl = fake_catalog_with_paths
 
@@ -365,7 +354,6 @@ def test_traverse_ids_dedup_across_nodes(fake_catalog_with_paths) -> None:
     # the dedup guard should handle it).
     mock_t3.ids_for_source.return_value = ["shared-chunk"]
 
-    inject_catalog(cat)
     inject_t3(mock_t3)
     try:
         result = mcp_core.traverse(
@@ -375,7 +363,6 @@ def test_traverse_ids_dedup_across_nodes(fake_catalog_with_paths) -> None:
             direction="out",
         )
     finally:
-        inject_catalog(None)
         inject_t3(None)
 
     assert result["ids"].count("shared-chunk") == 1


### PR DESCRIPTION
## Summary

Third slice of the singleton-elimination arc. Replaces three module-level hook-chain singletons in \`nexus.mcp_infra\` with an explicit \`HookRegistry\` class threaded top-down to every fire site.

## What was on main

\`\`\`python
# nexus.mcp_infra
_post_store_hooks: list = []
_post_store_batch_hooks: list = []
_post_store_batch_hooks_with_catalog_doc_id: set = set()
_post_document_hooks: list = []
_post_document_hooks_with_doc_id: set[int] = set()

# Plus register_post_*/fire_post_*/_record_*_hook_failure machinery.
# Plus an autouse fixture in tests/conftest.py that snapshot/restored
# the lists around every test to prevent leakage.
\`\`\`

## What's here

- **\`src/nexus/hook_registry.py\` (new, 518 LOC)** — \`HookRegistry\` class with three chains (single / batch / document), the existing failure-isolation + T2 \`hook_failures\` persistence preserved verbatim, and an \`install_default_hooks(registry)\` factory that registers the four load-bearing default consumers (chash_dual_write, taxonomy_assign, manifest_write, aspect_extraction_enqueue) at construction time instead of at module load.

- **\`src/nexus/mcp_infra.py\` (-632 LOC)** — all three lists, all three sets, all six register/fire functions, all three _record_*_hook_failure helpers deleted.

- **\`src/nexus/mcp/core.py\`** — process-local \`_hooks = HookRegistry()\` + \`install_default_hooks(_hooks)\` at module load. MCP server's \`store_put\` and friends call \`_hooks.fire_*(...)\` directly. Per-process scope is deliberate (MCP server is long-running); CLI and tests construct their own.

- **CLI command entry points** (\`commands/store.py\`, \`memory.py\`, \`collection.py\`, \`enrich.py\`, \`doctor.py\`) — each constructs its own \`HookRegistry\`, calls \`install_default_hooks\`, threads it down to the indexing functions.

- **\`src/nexus/index_context.py\`** — gained a \`hooks: HookRegistry | None\` field with \`__post_init__\` default; covers the indexing call chain.

- **18 production fire sites** in \`pipeline_stages.py\` / \`doc_indexer.py\` / \`prose_indexer.py\` / \`indexer.py\` / \`code_indexer.py\` / \`exporter.py\` converted from \`fire_post_*_hooks(args)\` to \`hooks.fire_*(args)\`.

- **\`tests/conftest.py\`** — \`_restore_post_store_batch_hooks_after_test\` autouse fixture deleted (no globals to manage).

- **\`tests/test_post_store_hook.py\` + \`test_post_document_hooks.py\`** — rewritten against per-test \`HookRegistry()\` instances.

- **\`tests/test_hook_drift_guard.py\`** — AST guards re-tooled to count \`Call\` nodes where \`node.func\` is an \`ast.Attribute\` with \`attr in {fire_single, fire_batch, fire_document}\`. Same semantic invariant, different AST shape post-refactor.

## Net stats

**41 files, +1149 / -1467 lines (net -318).**

## Zero remaining references

Verified via grep: no references to \`_post_store_hooks\`, \`_post_store_batch_hooks\`, \`_post_document_hooks\`, \`_post_store_batch_hooks_with_catalog_doc_id\`, \`_post_document_hooks_with_doc_id\`, \`register_post_store_hook\`, \`register_post_store_batch_hook\`, \`register_post_document_hook\`, \`fire_post_store_hooks\`, \`fire_post_store_batch_hooks\`, \`fire_post_document_hooks\` anywhere in src/ or tests/ outside \`hook_registry.py\`'s own docstrings (which describe what they replaced) and \`commands/doctor.py\`'s \`--check-post-store-hooks\` CLI flag name (CLI naming, not a singleton reference).

## Verification

\`uv run pytest -q --no-header\` on this branch: **7231 passed**, 33 skipped, 114 deselected, **0 failed** (552s).

## Tradeoff

The \`mcp/core.py\` \`_hooks\` module-attribute is process-local per-MCP-server. This is **not** a singleton in the architectural sense — nothing else in the codebase reads it; \`store_put\` is the sole consumer. It's just the MCP entry point's owned instance, scoped to the long-running daemon process. CLI commands and tests construct their own.

## What this finishes

The \`_restore_post_store_batch_hooks_after_test\` autouse fixture in \`tests/conftest.py\` — the load-bearing piece of "crappy test pattern" the user flagged at the start of this arc — is gone. Tests that need hook isolation construct their own \`HookRegistry\` instead of snapshot/restoring module-level lists.