### PR TITLE
docs(rdr): tombstone RDR-110-119 + draft RDR-120 (substrate split)

### DIFF
--- a/docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md
+++ b/docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md
@@ -1,0 +1,108 @@
+# Postmortem: RDR-110/111/112/113 deep-review remediation chain
+
+**Date**: 2026-05-16
+**Severity**: N/A — planned remediation arc, not an incident
+**Scope**: Cockpit + tuplespace + daemon substrate, post-PR #786 review fallout
+**Outcome**: Epic nexus-hp9f closed 16/16; 18 PRs landed; one open canary (nexus-9eaz)
+
+## Summary
+
+A continuation handoff identified PR #786 (y0nb audit follow-ups) plus a 16-bead epic of P0-P3 remediations surfaced by a five-critic deep review of the RDR-110/111/112/113 cockpit work. Over a single session the 16 beads landed via 17 substantive PRs plus one follow-up instrumentation PR. PR #786 itself was closed as superseded after the daughter PRs carried its uniquely load-bearing content (extracted as #803). One concurrent-migration race (nexus-9eaz) remains open with instrumentation in place but no reproducer.
+
+## What landed
+
+### Substrate (cockpit + tuplespace + daemon)
+
+- **Write path**: hook bridge → daemon tuplespace RPCs → tuples.db. Daemon-mode cutover live (PR #789), bridge SQLite retry on locked/busy (#807), Chroma-first atomicity (#800), wheel-resolvable builtin dir (#803).
+- **Reactive layer**: `_BindingWatcher` reaction loop + bindings subspace (#787).
+- **Consumer surface**: seven `nx` skills (`nx:tuplespace-{tasks,mailbox,lock,events,barriers,list,stats}`), `nx tuplespace` CLI, session banner (#791), Phase 3 cockpit panels + dashboard (#802), `nx doctor --check-bridge` (#803).
+- **Correctness invariants**: api.out two-store atomicity (#800), `embed_from` fail-loud (#800), tuple refire refreshes `expires_at`/`created_at` (#806), bridge plugin↔wheel version-compat guard (#809), daemon registry single source-of-truth with 12 reserved prefixes (#801).
+- **Lifecycle**: retention sweeper (#788), `run_until_signal` stop-event hoist (#795), daemon auto-start (launchd + systemd) (#808).
+- **Diagnostic**: chroma multi-process race spike — real init-race found (#794), RDR-113 contradiction-check fill (#792), `apply_pending` race instrumentation (#811 + INFO bump #814).
+
+### Numbers
+
+- **18 PRs landed**; PR #786 closed as superseded
+- **16/16 epic beads closed** (3 P0, 5 P1, 6 P2, 2 P3); one follow-up bead `nexus-9eaz` open
+- **~250 new tests** across the chain (binding watcher, retention sweeper, daemon RPCs, CLI, panels, bridge retry, version compat, autostart, dedup refresh)
+- **Develop CI fixed**: seven pre-existing failing tests repaired in #795 (migration ordering, hook bridge tests stale-indexed after y0nb prepended bridge entries, hooks.json structure tests, session_end timeout)
+
+## What went wrong, and what it cost
+
+### The hang that ate the chain (most expensive single bug)
+
+The first three daughter PRs (#787, #788, #789) all hung CI at the 20-minute timeout immediately after `test_sigterm_unlinks_discovery_file`. Three full CI cycles wasted (~60 minutes) before tracing the cause.
+
+Root cause: `T2Daemon.run_until_signal()` created a **local** `stop_event` only the SIGTERM/SIGINT signal handlers could set. Tests calling `daemon.stop()` directly never woke that event. On darwin the test passed in 89 seconds via pytest-asyncio teardown cancellation; on Linux CI it hung the full 20 minutes. Fix in #795 hoisted `stop_event` to an instance attribute that `stop()` also sets.
+
+The fix took five minutes once located. The diagnosis took longer because the failing branch was three PRs deep and the failure looked identical across them, suggesting a sibling-PR-introduced regression rather than a latent develop bug. Always check develop's own CI history before assuming a daughter PR caused the failure — develop's last green CI was hours earlier, the smoking gun.
+
+### Pre-existing develop failures masquerading as PR-introduced
+
+After #795, develop CI still failed on seven tests. None were caused by the signal-event fix. They were latent failures from a prior y0nb merge that prepended `orb_bridge_*` entries to every event in `nx/hooks/hooks.json` without updating the tests asserting on the original hook positions. Five hook-related tests + migration ordering + session-end timeout, all in the same PR (#795). Time cost was modest because once the pattern was clear, the fixes were rote, but the lesson is the same: develop CI green is a prerequisite for any new PR to be diagnosable.
+
+### The CLAUDECODE gate that only failed on Linux CI
+
+`tests/cockpit/test_hook_bridge.py::TestEmit::test_*_emit_calls_out` failed only on CI. The bridge's `emit()` early-returns when `CLAUDECODE` is unset (RF-5). Claude Code itself sets `CLAUDECODE` in dev shells, so the tests passed locally on every darwin machine. CI runners had no `CLAUDECODE`, so `emit()` no-op'd and `called_args` stayed empty. Fixed by an autouse `monkeypatch.setenv("CLAUDECODE", "1")` fixture on the test class. Generalised lesson: any contract gated on an environment variable needs explicit fixture coverage; do not rely on inherited dev environment.
+
+### Cross-contamination via shared worktrees
+
+The retention-sweeper PR (#788) inadvertently carried the entire `tuplespace_service` plumbing from PR #789 because the agents ran in worktrees that briefly shared a workdir. The agent staged only its own files (good discipline) but the underlying branch state had the sibling's work present. When #788 rebased against develop after #789 landed, git's 3-way merge saw both branches add the same code and auto-resolved it. Only one cosmetic comment-wording difference required manual resolution. The conflict was trivial; the bigger lesson is to verify worktree isolation before dispatching parallel agents on adjacent files.
+
+### The 30-file PR you can't rebase
+
+PR #786 ended up with 29 files / 1870 insertions / 89 deletions against a develop that had moved through ten daughter PRs. ~70% overlap with merged work, ~30% still uniquely load-bearing (6 coordination subspace YAMLs, wheel packaging, `nx doctor --check-bridge`). Rebasing meant resolving heavy conflict zones in `hook_bridge.py`, `cockpit.py`, `subspace_registry.py`, `registry.py`, `store.py`, `mcp/core.py`, and an 824-line test file. Extracting the unique 30% as a fresh PR (#803) and closing #786 as superseded was the cleaner path — 250 lines vs 1870, zero conflicts. When the daughter chain diverges this far from a parent, treat the parent as a checkpoint, not a destination.
+
+## What didn't get fixed
+
+### nexus-9eaz — concurrent migration race
+
+`tests/test_migrations.py::TestApplyPending::test_concurrent_apply_pending_stress` and `test_concurrent_apply_pending_runs_once` periodically fail on Linux CI with `bootstrap_version called twice despite _upgrade_lock`. The code under inspection is correct on paper: `threading.RLock` serialises the check-then-add on `_upgrade_done`. 100 local iterations on darwin produced zero failures.
+
+What we tried:
+- Static analysis of `apply_pending` lock semantics: clean.
+- Search for monkey-patching of `_upgrade_lock` or `_upgrade_done`: only `with`-block reentrant uses in tests, no leak vectors.
+- 100-iteration stress on darwin: no reproductions.
+- Audit of autouse fixtures and conftest.py: no concurrent mutation paths.
+- Cross-test pollution check: confirmed `_clear_upgrade_done()` autouse fixtures are module-scoped.
+
+What's in place:
+- Both flaky tests skipped with explicit pointer to `nexus-9eaz`.
+- INFO-level structlog instrumentation added to `apply_pending`'s lock-protected window: `upgrade_done_check` and `upgrade_done_add` emit `path_key`, `thread_id`, `done_size`, and membership at every check-then-add (#811 + #814).
+- Bead `nexus-9eaz` stays open until the next CI failure surfaces the evidence.
+
+The instrumentation is the right shape: when two threads both report `membership=False` for the same `path_key`, we'll know the lock genuinely failed. When only one does, the race is elsewhere (test counter race, set mutation during the lock-protected window, or environmental).
+
+## Operational notes
+
+### CI cycle costs
+
+A full CI run on this repo takes 13-16 minutes per push. Branch protection requires up-to-date with base on merge, so every time develop advanced through one PR, the other in-flight PRs had to re-sync. Across the chain that meant roughly eight sync-and-rerun cycles. Two practical mitigations were applied:
+
+- **Auto-merge armed early**: every PR got `gh pr merge $pr --auto --squash` immediately after opening. The auto-merge fired the moment CI cleared, regardless of when the human checked.
+- **Sync, don't rebase, when possible**: for the orthogonal PRs, `git merge develop --no-edit` into the branch (preserving the agent's commit history) was cheaper than rebasing. Force-pushes happened only when the rebase actually subsumed a conflict.
+
+### Worktree hygiene
+
+Several agents reported confusion about worktree isolation. The pattern that worked: spawn the agent with `isolation: "worktree"`, let the agent claim and branch off `develop`, and instruct it to stage by explicit path. Drift between the agent's worktree and the main repo only mattered when the agent inherited stale staged files from a sibling — the cross-contamination noted above. Add an early `git status --short` check to the agent's process to surface inherited state.
+
+### Beads as work-tracking
+
+The full epic was tracked in `bd` with a parent-child hierarchy. Closing a bead requires that the corresponding PR merged (verified via `git log --grep` if needed). The `Closes nexus-X` keyword in PR bodies is recognised by the merge automation as a hint but does not auto-close beads — manual `bd close <id>` was required after each merge.
+
+## Action items
+
+| # | Action | Owner | Bead |
+|---|---|---|---|
+| 1 | Investigate `_upgrade_lock` race once CI surfaces instrumented evidence | unassigned | nexus-9eaz |
+| 2 | Add a pre-dispatch worktree-isolation check that aborts if the worktree has staged files inherited from a sibling | unassigned | — (filed if pattern recurs) |
+| 3 | Document the `nx daemon t2 install --autostart` flow in the user-facing docs (#808 shipped the CLI; user docs not updated) | unassigned | — |
+| 4 | Verify the chroma multi-process race protections cited in the #794 spike: daemon-routed bridge (already shipped via #789), flock-guarded `PersistentClient` construction, `nx doctor` pre-warm | unassigned | — (consider filing) |
+
+## Provenance
+
+- Initial handoff: `/tmp/nexus-continuation-pr786-2026-05-15.md` (see umbrella memory `session-handoff-2026-05-15-pr786-deep-review-state`)
+- Epic: `nexus-hp9f` (closed)
+- Open follow-up: `nexus-9eaz`
+- PRs: #787, #788, #789, #791, #792, #794, #795, #800, #801, #802, #803, #806, #807, #808, #809, #811, #814
+- Superseded: #786

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -132,6 +132,14 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-107](rdr-107-t3-chunk-soft-delete.md) | T3 Chunk Soft-Delete via Tombstone Metadata | Architecture | Superseded by RDR-108 | 2026-05-08 |
 | [RDR-108](rdr-108-graph-identity-normalization.md) | Graph Identity Normalization: Catalog Holds the Tree, T3 is a Content-Addressed Blob Store | Architecture | Accepted | 2026-05-08 |
 | [RDR-109](rdr-109-honest-naming-and-cross-encoder-salience.md) | Honest Local-Mode Naming and Cross-Encoder Salience: Two Naming/Scoring Designs Touching the Same Test-Suite Mode-Default Surface | Architecture | Accepted | 2026-05-10 |
+| [RDR-110](rdr-110-semantic-tuple-space.md) | Semantic Tuple Space: Unified Coordination Primitive over ChromaDB + SQLite | Architecture | **Scrapped 2026-05-19** | 2026-05-09 |
+| [RDR-111](rdr-111-orb-agentic-cockpit-substrate.md) | The ORB: Observable Relay Bus — Hook Projection, Bindings, and C2 Cockpit Substrate | Architecture | **Scrapped 2026-05-19** | 2026-05-11 |
+| [RDR-112](rdr-112-storage-as-service-container-boundary.md) | Storage-as-Service: Every Persistent Shared-State Store Behind a Daemon, T1 Stays In-Container | Architecture | **Scrapped 2026-05-19** (superseded by RDR-120) | 2026-05-12 |
+| [RDR-113](rdr-113-host-trust-model.md) | Host-Trust Model for nexus Daemons: UDS Permissions, Peer Credentials, Single-User v1 | Architecture | **Scrapped 2026-05-19** | 2026-05-13 |
+| [RDR-118](rdr-118-surfaces-as-tuples.md) | Surfaces as Tuples — The ORB is the Portal Broker (A2UI Adoption + Xanadu Inheritance) | Architecture | **Scrapped 2026-05-19** | 2026-05-17 |
+| [RDR-119](rdr-119-cockpit-ui-fabric.md) | Cockpit UI Fabric — Bakke Auto-Layout over A2UI Catalogs, per-Host Realization | Architecture | **Scrapped 2026-05-19** | 2026-05-18 |
+
+> **Scrapped 2026-05-19 (RDR-110-119 arc).** Bundled the storage-substrate split with new abstractions (tuplespace, ORB, host-trust, surfaces-as-tuples, UI fabric); scope discipline failed across nine RDRs and 67 stranded beads. Files preserved as tombstones per the "never delete RDR files" rule. Postmortem: [docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work continues as [RDR-120](rdr-120-storage-substrate-split.md) with an explicit moratorium on co-shipped consumers. Numbers RDR-114 through RDR-117 are unused on `main` (drafted on feature branches that never merged).
 
 ---
 

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -138,6 +138,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-113](rdr-113-host-trust-model.md) | Host-Trust Model for nexus Daemons: UDS Permissions, Peer Credentials, Single-User v1 | Architecture | **Scrapped 2026-05-19** | 2026-05-13 |
 | [RDR-118](rdr-118-surfaces-as-tuples.md) | Surfaces as Tuples — The ORB is the Portal Broker (A2UI Adoption + Xanadu Inheritance) | Architecture | **Scrapped 2026-05-19** | 2026-05-17 |
 | [RDR-119](rdr-119-cockpit-ui-fabric.md) | Cockpit UI Fabric — Bakke Auto-Layout over A2UI Catalogs, per-Host Realization | Architecture | **Scrapped 2026-05-19** | 2026-05-18 |
+| [RDR-120](rdr-120-storage-substrate-split.md) | Storage Substrate Split: Substrate-Only Scope, No Co-Shipped Consumers | Architecture | Draft | 2026-05-19 |
 
 > **Scrapped 2026-05-19 (RDR-110-119 arc).** Bundled the storage-substrate split with new abstractions (tuplespace, ORB, host-trust, surfaces-as-tuples, UI fabric); scope discipline failed across nine RDRs and 67 stranded beads. Files preserved as tombstones per the "never delete RDR files" rule. Postmortem: [docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work continues as [RDR-120](rdr-120-storage-substrate-split.md) with an explicit moratorium on co-shipped consumers. Numbers RDR-114 through RDR-117 are unused on `main` (drafted on feature branches that never merged).
 

--- a/docs/rdr/rdr-110-semantic-tuple-space.md
+++ b/docs/rdr/rdr-110-semantic-tuple-space.md
@@ -1,0 +1,2177 @@
+---
+title: "Semantic Tuple Space: Unified Coordination Primitive over ChromaDB + SQLite"
+id: RDR-110
+type: Architecture
+status: scrapped
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-09
+accepted_date: 2026-05-09
+scrapped_date: 2026-05-19
+scrap_reason: "Part of the RDR-110/111/112/113/118/119 arc that bundled the storage-substrate split with new abstractions (tuplespace, ORB cockpit, host-trust, surfaces-as-tuples, UI fabric). Scope discipline failed across nine RDRs and 67 stranded beads. Substrate work continues under RDR-120 with an explicit moratorium on co-shipped consumers. Postmortem: docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md."
+related_issues: []
+related_rdrs: [RDR-004, RDR-041, RDR-077, RDR-078, RDR-079, RDR-087, RDR-092, RDR-105, RDR-106, RDR-107, RDR-108, RDR-112, RDR-113, RDR-120]
+related_tests: []
+implementation_notes: ""
+---
+
+> **TOMBSTONE 2026-05-19.** This RDR is preserved as historical reference. The arc was scrapped due to scope entanglement; see frontmatter `scrap_reason` and the [postmortem](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work: [RDR-120](rdr-120-storage-substrate-split.md). Do not implement against this design.
+
+---
+
+
+# RDR-110: Semantic Tuple Space: Unified Coordination Primitive over ChromaDB + SQLite
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+Nexus has accreted three retrieval surfaces that are structurally the
+same abstraction with different names: `plan_match` over the plan
+library, T1 scratch over per-session ChromaDB, and T2 memory over
+SQLite + FTS. Each has its own dimensions/tags vocabulary, its own
+threshold-tuning story, its own match semantics, and its own mental
+model. The shared shape is *"post a typed payload that gets indexed
+for semantic retrieval; later, query by associative match with
+optional structural filters."* That shape has a name in distributed
+computing — Linda's tuple space — but nexus has neither the name nor
+the unified primitive.
+
+The cost is twofold. First, three parallel implementations means
+schema drift, three sets of threshold-tuning bugs (RDR-077, RDR-087,
+RDR-092 each addressed the same calibration problem in different
+surfaces), and N+1 cognitive load when a developer wants to add a
+fourth surface. Second, and more material, **none of the existing
+surfaces support atomic destructive read**. Plans are read-only.
+Scratch is read-multiple. Memory is read-multiple. The Linda
+operation `in` — atomic take — is missing. Without it, agentic
+patterns that need coordination (work-stealing pools, inter-agent
+mailboxes, mutexes/leases, barriers, request-reply) cannot be
+expressed without ad-hoc SQL or external infrastructure.
+
+The fix is structural: name the abstraction, ship it as a primitive,
+and treat the existing surfaces as instances. A semantic tuple space
+generalises Linda's typed-template matching to typed-structural-filter
+plus associative-similarity match, runs over nexus's existing
+ChromaDB + SQLite + tier model, and adds atomic destructive read via
+a SQLite claim ledger. The three existing surfaces become subspaces
+in the same registry. Net result: one primitive, one mental model,
+one calibration story, and a coordination layer that didn't previously
+exist.
+
+### Enumerated gaps to close
+
+#### Gap 1: No atomic destructive read primitive
+
+Plans, scratch, and memory all expose `query`/`search` operations
+that return matches without consuming them. Two consumers querying
+the same scratch entry both see it. There is no operation analogous
+to Linda's `in` — match, claim atomically, return to exactly one
+caller. Agentic patterns that depend on this (work-stealing,
+mailboxes, mutexes, barriers) are unbuildable on the current
+surfaces without external coordination.
+
+#### Gap 2: Three parallel implementations of the same abstraction
+
+`plan_match` (`src/nexus/plans/match.py`), T1 scratch
+(`src/nexus/db/t1.py` + `src/nexus/commands/scratch.py`), and T2
+memory (`src/nexus/db/t2/memory_store.py`) each implement: post a
+typed payload → embed → store with metadata → query semantically
+with metadata filter. Three parallel code paths, three sets of
+threshold-tuning bugs, three vocabulary registries (plan dimensions
+in YAML; scratch tags as informal RDR-041 vocabulary; memory
+collections as freeform strings).
+
+#### Gap 3: Threshold calibration is per-surface, ad-hoc, and inconsistent
+
+RDR-079 P5 set plan-match `min_confidence` floor at 0.40. RDR-077
+calibrated topic-projection thresholds against per-collection
+distance distributions. RDR-087 surfaced that default `docs`
+threshold (0.65) filtered all candidates from PDF collections with
+~0.81 distance floors. Each surface re-discovered the same calibration
+problem. There is no shared mechanism for declaring "the right floor
+for this kind of payload" once and reusing it.
+
+#### Gap 4: Tag/dimension vocabularies drift without a registry
+
+RDR-041 defined a standard scratch tag vocabulary
+(`impl`, `checkpoint`, `failed-approach`, `hypothesis`, `discovery`,
+`decision`) as SHOULD-not-MUST guidance. In practice, agents use
+ad-hoc tags. Plans avoid this because plan dimensions ARE registered
+(verb / scope / strategy / object / domain) and validated at seed
+time — a violation raises. Scratch and memory have no equivalent
+enforcement; the registry concept exists for one surface and not the
+others.
+
+#### Gap 5: No coordination layer for cross-process agentic patterns
+
+Work-stealing across N parallel agents, request-reply between agents,
+mutex on a shared resource, N-way barriers — none have a primitive in
+nexus today. Beads provides a project-scoped task queue but with very
+different semantics (manual claim, no semantic match, dependency
+graph). Beads is the right answer for human-curated multi-session
+work; it is the wrong answer for ephemeral intra-session coordination
+between agents that need to discover each other by intent rather than
+by ID.
+
+## Context
+
+### Background
+
+Three closely related decisions over the last two months frame this
+RDR:
+
+- **RDR-105 (closed 2026-05-08)** restructured T1 around hybrid
+  discovery (env-var passdown for MCP-dispatched subprocesses,
+  single-writer address file for Claude-Code-dispatched siblings).
+  Critically, RDR-105 designated **T2 as "the shared bus across all
+  processes" tier** — the multi-process-safe SQLite + WAL backbone.
+  Any coordination primitive that needs to serialise writes across
+  processes belongs in T2.
+- **RDR-108 (accepted 2026-05-08)** ruled that natural IDs must be
+  content-derived, not position-derived, and that catalog holds
+  normalised identity with foreign-key references rather than
+  denormalised name copies. Tuple IDs in this RDR follow that rule:
+  `sha256(canonical(subspace + content + dimensions))`. `out`
+  becomes naturally idempotent — the same content+dimensions produces
+  the same ID, and `INSERT … ON CONFLICT DO NOTHING` collapses
+  duplicates.
+- **RDR-078 / RDR-079 / RDR-092** built the plan-centric retrieval
+  trunk: `match_text` payloads, dimensional plan identity, T1 cosine
+  + T2 FTS5 cascade, calibrated `min_confidence` per verb. The plan
+  library is already a tuple space in disguise; this RDR names it.
+
+The user-facing observation that triggered this RDR: a design
+conversation about persistent addressable surfaces in agentic UIs
+(MCP Apps, MCP-UI, OpenAI Apps SDK, A2UI) noted that none of them
+have a story for long-lived multi-writer surfaces that survive
+agentic boundary crossings. The architectural sketch that fell out
+— surfaces as CRDTs / event logs with associative retrieval — is
+strictly a special case of a tuple space. The tuple-space primitive
+is the natural foundation; surfaces are a Phase 4 application of it.
+
+### Technical Environment
+
+- **T1**: Per-session ChromaDB HTTP server, post-RDR-105 hybrid
+  discovery, owned by `nx-mcp` lifespan. Multi-process via HttpClient.
+- **T2**: SQLite + WAL at `~/.config/nexus/memory.db` (and adjacent
+  DBs). Multi-process safe by storage design. Hosts plans, memory,
+  catalog, claim ledger.
+- **T3**: ChromaDB Cloud, four-database split per RDR-004
+  (`{base}_code`, `{base}_docs`, `{base}_rdr`, `{base}_knowledge`).
+  No per-row CAS — `take` is structurally disabled at this tier.
+- **Existing dimension registry**: `nx/plans/builtin/*.yml` declares
+  plan templates with `(verb, scope, strategy, object, domain)`
+  schemas. Validated at seed time. Pattern this RDR generalises.
+- **Existing claim-table prior art**: beads' issue claim flow
+  (SQLite `claimed_at` + `assignee` columns) is the closest existing
+  pattern. Different semantics (manual claim, no lease, no semantic
+  match) but the SQLite-as-CAS shape is proven.
+
+## Research Findings
+
+### Investigation
+
+This RDR is the product of a multi-turn design dialogue. The
+investigation was structural rather than empirical: enumerate
+agentic patterns that the abstraction must serve, validate them
+against existing nexus surfaces, identify load-bearing decisions,
+push hard on each. Twelve sequential-thinking iterations resolved
+the design surface (claim `take` semantics, confidence floors,
+schema registry, tier routing).
+
+#### Dependency Source Verification
+
+| Dependency | Source Searched? | Key Findings |
+| --- | --- | --- |
+| ChromaDB local persistent collection | Yes — `src/nexus/db/t2/*` already uses this pattern | Concurrent reads + serialised writes within a single MCP process; metadata `where` filters are O(log n) on indexed fields; no multi-collection transactions. |
+| SQLite WAL CAS | Yes — beads + RDR-105 patterns | `INSERT … ON CONFLICT DO NOTHING RETURNING …` gives single-statement CAS; UNIQUE constraint serialises concurrent claimants correctly. |
+| chash-derived natural IDs | Yes — RDR-108 | `sha256(canonical(...))` is the house standard. Stable across re-embedding and rechunking. |
+| Tier-cascade read | Yes — `plan_match` already implements T1-cosine → T2-FTS5 fallback (`src/nexus/plans/match.py`) | Pattern is proven; this RDR generalises it across N tiers per subspace. |
+
+### Key Discoveries
+
+- **Verified** — Plans, scratch, and memory share the same
+  abstraction with different vocabulary. Refactoring them as
+  subspaces is structural renaming, not new logic. (Source:
+  `src/nexus/plans/match.py`, `src/nexus/db/t1.py`,
+  `src/nexus/db/t2/memory_store.py`.)
+- **Verified** — Linda's `in` superpower is **atomicity**, not
+  destructive read. Six concrete agentic patterns (work-stealing,
+  mailboxes, mutexes, barriers, audit-by-consumption, backpressure)
+  collapse without atomic claim. Replacing destructive read with
+  read-and-mark-handled preserves the audit trail and matches
+  RDR-106 / RDR-107's tombstone house style.
+- **Verified** — Confidence floors for destructive reads are a
+  *safety* concern, not a quality one. False-positive `take` leaks
+  intended-for-someone-else tuples; false-negative `take` returns
+  None and the caller polls. Bias must be toward false-negatives.
+  Floor + margin (top-1 vs top-2 gap) is the right shape; calibrated
+  per subspace, not globally.
+- **Verified** — RDR-105 designated T2 as the shared-bus tier. The
+  claim ledger therefore lives in T2 (SQLite + WAL), not in T1
+  (per-session) or T3 (no CAS). This is non-negotiable.
+- **Verified** — RDR-108 mandates content-derived natural IDs as
+  a principle. RDR-110 follows the principle but uses its own
+  formula: `sha256(canonical(subspace + content + dimensions_json
+  + match_text_or_empty))[:32]`. Routing metadata and the
+  embedding-text override participate in the hash because they
+  distinguish logically distinct tuples. RDR-108 chunk IDs and
+  RDR-110 tuple IDs are separate namespaces stored in separate
+  chroma collections. `out` is idempotent for the same
+  `(subspace, content, dimensions, match_text)` quadruple;
+  callers wanting bit-identical duplicates add a nonce dimension.
+- **Documented** — JavaSpaces' lease-and-renewal pattern handles
+  crash recovery cleanly. Lease + idempotent retry on
+  `(tuple_id, claimant)` is the right at-least-once delivery model
+  for agents that may crash and replay.
+- **Assumed** — Per-template Chroma collection layout (one collection
+  per registered subspace template, with concrete subspace string
+  in metadata) scales to ~50 templates without operational pain.
+  *Status*: Unverified — *Method*: Source Search (existing four-
+  database split per RDR-004 already runs ~150 collections in T3
+  without incident; this is a smaller fan-out at T2.)
+- **Assumed** — Synchronous (non-blocking) `take` is sufficient for
+  v1; polling is acceptable for the agentic workloads enumerated.
+  *Status*: Unverified — *Method*: Spike (Phase 1 work-stealing
+  smoke test will surface whether polling latency is intolerable.)
+
+### Critical Assumptions
+
+- [x] **CA #1: SQLite single-writer lock guarantees `UPDATE …
+      RETURNING` atomicity for concurrent claimants on the same
+      tuple.** — *Status*: Verified — *Method*: Source Search +
+      honker production reference. The original two-statement
+      design (`INSERT into tuple_claims` + re-check) had a
+      documented race under WAL DEFERRED isolation per Layer 3
+      critique. The revised single-statement design (`UPDATE
+      tuples SET claim_state='claimed' WHERE … RETURNING` per
+      RF-9) is atomic under SQLite's single-writer lock by
+      construction: writes serialise globally, and `RETURNING`
+      reflects the row state observed by the writer. Honker's
+      queue implementation runs this exact pattern in
+      production. The Phase 1 stress test below confirms
+      behaviour empirically against the deployment harness.
+- [ ] **CA #2: The Phase 1 stress test exercises the actual race
+      window, not just the happy path.** — *Status*: Unverified —
+      *Method*: Spike. Per Layer 3 critique observation O2: a
+      naive 10-parallel-worker test will frequently pass even
+      with a broken algorithm because WAL serialises commits and
+      most real interleavings work. The stress harness must
+      inject a controlled sleep between candidate-selection and
+      UPDATE to force the race window to manifest, then assert
+      exactly-one-winner under that interleaving.
+- [x] **CA #3: chash-derived tuple IDs do not collide for distinct
+      `(subspace, content, dimensions, match_text)` quadruples
+      in practice.** — *Status*: Verified — *Method*: Source
+      Search. Same primitive (sha256 truncated to 32 hex chars)
+      that RDR-108 ships for chunks with 99.02% coverage and
+      zero observed collisions across 290k chunks. The 32-hex
+      truncation gives 128 bits of address space; collision
+      probability under birthday-paradox math is negligible at
+      any realistic tuple population.
+- [ ] **CA #4: Per-subspace `take.floor` + `take.margin`
+      calibration prevents false-positive destructive reads
+      under realistic query paraphrase distributions.** —
+      *Status*: Unverified — *Method*: Spike. Phase 1 includes a
+      paraphrase-fuzz test against the `mailbox/<agent>` and
+      `tasks/<project>` subspaces asserting no false-positive
+      takes across 100 paraphrased queries per intended target.
+- [ ] **CA #5: Polling-based `take` (default `block=False`) is
+      workable for v1 agentic patterns; blocking `take`
+      (`block=True`) on the data_version wake mechanism
+      delivers ~1-2ms median cross-process wake latency.** —
+      *Status*: Unverified — *Method*: Spike. Phase 1
+      work-stealing smoke test reports both polling and blocking
+      median + tail latency. Honker's published benchmarks claim
+      "1-2 ms median on M-series"; spike validates this on the
+      deployment hardware.
+- [x] **CA #6: `PRAGMA data_version` polling at 1ms cadence has
+      negligible CPU cost on the deployment hardware.** —
+      *Status*: Verified — *Method*: Source Search. SQLite's
+      `PRAGMA data_version` is a single integer read from
+      database header memory; cost is bounded by syscall
+      overhead. Honker's production deployment confirms
+      negligible cost. One thread per `tuples.db` connection;
+      worst case ~1000 reads/sec/database with no I/O.
+
+**Renumbering note (post-re-gate)**: prior versions referred to
+the same assumptions as CA #1, #1.5, #2, #3, #4, #5. Under the
+final numbering, prior CA #1.5 becomes CA #2, prior CA #2-#5
+shift to CA #3-#6. Cross-references throughout the document
+(Prerequisites, Step 7 spike list, Revision History) use the
+current numbering.
+
+### RF-1: Four distinct consumers each need a different "right time, right place"
+
+The user-facing leverage of this RDR depends on the abstraction
+being slicker to use than the three parallel surfaces it replaces.
+"Slicker" is not one thing — it is four things, one per consumer
+class. Each has a different discovery channel and a different
+friction profile.
+
+| Consumer | Discovery surface today | Friction shape |
+|---|---|---|
+| **Agent** (Claude Code session running tools) | MCP tool list + skill registry + `nx/agents/_shared/CONTEXT_PROTOCOL.md` + per-agent prompt + `CLAUDE.md` | Three parallel surfaces (`scratch` / `memory_put` / `store_put`) with overlapping intent — agent must guess which tier suits the finding's lifetime. RDR-041 documented this; tag-vocabulary drift confirms it persists. |
+| **Session** (the coordination context itself) | Session-start hook output + agent-loaded T1/T2/T3 banner | Lifetime semantics are implicit. T1 dies on session-end; agent has no warning before it does. T2 survives but agent doesn't know which T2 entries are session-scoped vs project-scoped vs permanent. |
+| **User** (human at terminal running `nx`) | `nx --help`, `docs/`, shell completion | Six different subcommands for tuple-shaped operations (`nx scratch put/search/list`, `nx memory put/search/list`, `nx store put/get/list`, `nx plan ...`). User must internalise three taxonomies. |
+| **Script** (hooks, CI, automation) | Env vars (`NX_T1_HOST`, `NX_SESSION_ID`, `NEXUS_SKIP_T1`) + CLI invocation | Discovery is fragile — RDR-105's six-bug class came from script-vs-hook coordination on T1 specifically. Scripts have no introspection: a script can't ask "what subspaces exist and what do they accept?" |
+
+**Implication for the design**: each consumer's discovery channel
+must explicitly route to the new primitive. Not enough to ship the
+API; the discovery surfaces have to recommend it at the right
+moment. Skill rewrites, prompt updates, CLI subsumption, and
+script-introspection tools are not optional polish — they are the
+load-bearing UX of the migration.
+
+**Persisted**: this RF lives in the RDR file; T2 entry deferred
+until research synthesis stabilises.
+
+### RF-2: Existing surfaces overlap by intent, not by tier
+
+The naive view is that `scratch` / `memory` / `store` differ by
+storage tier (T1 / T2 / T3) and that's the choice point. The
+empirical view is that **agents pick by intent** ("is this a
+working hypothesis or a permanent finding?") and the tier is
+downstream of intent. The current architecture forces agents to
+make the tier choice explicit, which is the wrong axis to
+foreground.
+
+Examples of the friction:
+
+- An agent forms a hypothesis. Should it go to `scratch` (session
+  ephemeral) or `memory_put` (project persistent)? The honest
+  answer is "scratch first, promote to memory if it pans out" —
+  but no operation expresses that lifecycle. The agent picks one
+  and moves on; promotion is a manual `scratch_manage flag` plus
+  a separate `memory_put`.
+- An agent finds a cross-project pattern. Should it go to `memory`
+  (`project=…`) or `store_put` (knowledge T3)? Both work. The
+  guidance is split across CONTEXT_PROTOCOL and agent files;
+  agents pick by feel.
+- An agent wants to coordinate with a sibling agent. **No
+  surface answers this.** Scratch is multi-reader but not
+  destructive; memory is project-scoped but persists past the
+  coordination need; store is permanent. Agents end up using
+  scratch with conventional tags (RDR-041's pattern) and reading
+  via semantic search — which is exactly an unnamed `read`
+  operation against an unnamed subspace, just without the schema
+  discipline.
+
+**Implication for the design**: the tuple-space API foregrounds
+*intent* (what subspace) over *tier* (where it lives). Tier becomes
+a property of the subspace, not a per-call decision. Agents pick
+"this is a `scratch/<session>` finding" or "this is a
+`memory/<project>` decision"; the tier follows. This is a different
+mental model and the migration must explicitly teach it.
+
+### RF-3: CONTEXT_PROTOCOL is the single highest-leverage prompt surface
+
+`nx/agents/_shared/CONTEXT_PROTOCOL.md` is loaded by every
+proactive-search and relay-reliant agent and dictates the search
+order across T1/T2/T3 (RDR-041's surface). It is the canonical
+guidance for "when to use which tier" today. If RDR-110's API
+ships and this file isn't rewritten, agents will continue using
+the parallel surfaces because the prompt tells them to.
+
+The rewrite is structurally simple: replace the per-tier guidance
+with per-subspace guidance, plus a fallthrough rule. Pseudo-form:
+
+```
+For working hypotheses, failed approaches, in-flight findings:
+  → out(subspace="scratch/<session>", ...)
+For project decisions, cross-session context:
+  → out(subspace="memory/<project>", ...)
+For coordination with sibling agents:
+  → out(subspace="mailbox/<agent>", ...)  or
+    out(subspace="tasks/<project>", ...)
+For permanent knowledge across all projects:
+  → defer to /nx:knowledge-tidy (T3 promotion)
+```
+
+The proactive-search-agents-vs-relay-reliant-agents split survives
+intact — the search order changes from "T1 first, T2 fallback,
+T3 deepest" to "scratch subspace, then memory subspace, then
+permanent subspaces" — same shape, named differently, with the
+parallel-implementation seam removed.
+
+**Implication for cutover**: CONTEXT_PROTOCOL is rewritten in
+Phase 3 (when the wrappers exist), not Phase 1 (when only the new
+core subspaces exist). Premature rewrite confuses agents because
+the recommended subspaces wouldn't yet have wrappers; Phase 1
+agents still use scratch/memory directly.
+
+### RF-4: Skill rewrites — the discovery layer for agent-side intent
+
+Skills are the user-invokable middle layer between MCP tools and
+agent prompts. The current shape (per the system reminder
+inventory at session start) includes ~80 skills, of which ~15 are
+directly tuple-space-shaped:
+
+- Storage: `nx:nexus`, `beads:beads` (catalog of skills exposing
+  storage)
+- Knowledge: `nx:knowledge-tidy`, `nx:knowledge-tidying`
+- Plans: `nx:plan-author`, `nx:plan-validation`, `nx:plan-promote`,
+  `nx:plan-inspect`, `nx:plan-first`
+- Search/answer: `nx:query`, `nx:research`, `nx:analyze`,
+  `nx:review`, `nx:document`, `nx:debug`
+- Coordination (mostly absent today — this is the gap): nothing
+  for work-stealing, mailboxes, locks, barriers, events.
+
+The rewrite proposal:
+
+1. **Add coordination skills** (Phase 1, alongside the API):
+   `nx:tuplespace-tasks`, `nx:tuplespace-mailbox`,
+   `nx:tuplespace-lock`, `nx:tuplespace-events`,
+   `nx:tuplespace-barriers`. Each is a thin shell pointing the
+   agent at the right subspace + canonical patterns. These are
+   *new* skills filling a gap, not replacements.
+2. **Update existing skills to mention the unified API** (Phase 3):
+   `nx:nexus` describes T1/T2/T3 today; rewrite to describe
+   subspace-scoped tuple operations with tier as a property.
+   `nx:plan-first` and `nx:query` mention `plan_match`; rewrite
+   to mention `read(subspace="plans/<verb>")` (behavior unchanged
+   under the wrapper, language updated).
+3. **Add introspection skills** (Phase 1):
+   `nx:tuplespace-list` and `nx:tuplespace-stats` are the
+   discovery primitives. Used by both agents (in CONTEXT_PROTOCOL)
+   and humans (via `nx tuplespace list`).
+4. **Deprecate parallel-vocabulary skills** (Phase 4):
+   `nx:knowledge-tidy` becomes a thin wrapper over a `take`
+   from `scratch/<session>` followed by `out` to permanent-tier
+   subspaces. The skill stays (the *workflow* is real); the
+   internals change.
+
+The skill registry is the right rewrite target because skills are
+the lowest-friction recommendation surface — an agent invoking
+`/nx:tuplespace-tasks` gets the work-stealing pattern in its
+context window with one tool call. No CONTEXT_PROTOCOL paragraph
+to read, no MCP tool list to scan.
+
+### RF-5: Cutover precedent from RDR-105 / RDR-094 / RDR-062
+
+Three recent migrations bound the cutover-pattern design space.
+This RDR should follow the RDR-105 pattern (it is the most
+recent, most relevant — both are agent-facing infrastructure
+rewrites under the MCP-server lifecycle), with one structural
+adaptation.
+
+**RDR-105 pattern** (T1 hybrid discovery, shipped 4.27.0):
+- Five phases over ~1 week elapsed time.
+- Single feature flag (`NX_T1_NEW_DISCOVERY=1`) gating the entire
+  new path.
+- Mutual-exclusion contract: any one MCP server runs entirely
+  on flag-on or flag-off; no mixed paths within a process.
+- Phase 3 default flip after Phase 2 spike clears.
+- Phase 4 deletes the legacy code paths once flag stays default-on.
+- Sandbox shakedown: real Claude Code session with multiple
+  Agent-tool sub-agents + `claude -p` dispatch + 10-parallel
+  stress test before flag removal.
+- Net: ~5000 LOC deleted in Phase 4.
+
+**RDR-094 pattern** (MCP-owned T1 lifecycle): four phases, three
+spikes (Spike A lifecycle 40-run probe, Spike B subagent race,
+Spike C mid-session SIGTERM observation). Critical Assumptions
+were spike-gated, not just docs-only.
+
+**RDR-062 pattern** (`nx-mcp` + `nx-mcp-catalog` split): single-
+shot tooling refactor; no feature flag because the change was
+client-side discovery only. Not the right precedent for RDR-110.
+
+**RDR-105's adaptation for RDR-110**: the feature flag
+(`NX_TUPLESPACE_V1=1`?) gates whether the *new core API* is
+available, NOT whether the *existing surfaces* use it. The new
+API is purely additive in Phase 1 — agents that don't know about
+it cannot break. The wrapper migration in Phase 3 needs its own
+flag (`NX_TUPLESPACE_WRAPPED_PLANS=1`,
+`NX_TUPLESPACE_WRAPPED_SCRATCH=1`,
+`NX_TUPLESPACE_WRAPPED_MEMORY=1`) so each surface can be flipped
+independently and rolled back independently. RDR-105's "single
+flag" model would couple three independent migrations.
+
+**Implication for the implementation plan**: Phase 1 ships
+unflagged (additive, no risk to existing callers). Phase 3
+introduces three independent flags, one per wrapper. Phase 4
+removes flags after all three default-flip cycles complete.
+
+### RF-6: The four-consumer matrix maps to four concrete deliverables
+
+Putting RF-1 / RF-2 / RF-3 / RF-4 together: each consumer class
+gets one explicit deliverable that lands the new primitive at its
+discovery surface.
+
+| Consumer | Deliverable | Phase | What it lands |
+|---|---|---|---|
+| **Agent** | CONTEXT_PROTOCOL rewrite + 5 new coordination skills + tuplespace introspection skills | 1 (skills) + 3 (CONTEXT_PROTOCOL) | Subspace-by-intent vocabulary; coordination patterns previously absent. |
+| **Session** | Lifetime documentation in MCP tool docstrings + a session-start banner pointing at `nx tuplespace list --tier=ephemeral` | 1 | Explicit "what dies when" semantics surfaced at session start. |
+| **User** | `nx tuplespace` CLI subcommand subsuming `out` / `read` / `take` / `list` / `stats` / `schema` | 1 | One verb (`nx tuplespace`) replaces three (`scratch` / `memory` / `store`) for the unified ops. Existing CLIs deprecate in Phase 4. |
+| **Script** | Env-var contract (`NX_TUPLESPACE_SUBSPACE`, `NX_TUPLESPACE_CLAIMANT`, etc.) + `nx tuplespace --schema-json` for introspection | 1 | Scripts can introspect available subspaces and post programmatically. |
+
+The session-start banner is the smallest of these but the
+highest-leverage for agent UX: every Claude Code session begins
+with a banner telling the agent which subspaces exist in this
+project and which are ephemeral-vs-persistent. RDR-041's pain
+point ("agents don't know what's in scratch from prior sessions")
+is exactly the discovery gap this fixes — but generalised to all
+subspaces, not just scratch.
+
+### RF-7: Compatibility contract for the v1 → v3 transition
+
+The migration must not break:
+
+- **Existing skill invocations**: agents calling `/nx:knowledge-tidy`
+  or `/nx:plan-first` continue to work unchanged across all phases.
+  Skills are the public contract; their internals can be rewritten
+  freely.
+- **Existing MCP tool calls**: `scratch`, `memory_put`,
+  `memory_search`, `store_put`, `store_get`, `store_list`,
+  `plan_save`, `plan_search` keep their signatures and behavior
+  through Phase 3. Phase 4 marks them deprecated (warning); Phase
+  5 (separate RDR) removes them.
+- **CLI subcommands**: `nx scratch put/search/list`,
+  `nx memory put/search/list`, `nx store put/get/list` keep
+  working through Phase 3. Phase 4 prints deprecation banners.
+- **Hook contracts**: `SessionStart` and `SessionEnd` hooks that
+  call `scratch` continue to work — the wrapper is at the MCP-tool
+  layer, not the CLI layer they use.
+- **External-script contracts**: `NX_T1_HOST` / `NX_T1_PORT` /
+  `NX_T1_ISOLATED` (RDR-105) keep their semantics; tuple-space
+  operations route through the existing T1 server when
+  `tier="ephemeral"`, so script-level T1 access stays compatible.
+
+What CAN break, with explicit deprecation:
+
+- **Scratch tag vocabulary** (RDR-041): the `failed-approach` /
+  `checkpoint` / `hypothesis` / `discovery` / `decision` informal
+  tags become the registered enum on `scratch/<session>`. Agents
+  using ad-hoc tags get a `SubspaceSchemaError` warning at Phase 3
+  cutover; Phase 4 promotes warning to error. Migration path:
+  agents update their prompts to use registered tags or set
+  `tags=` to one of the new values.
+
+- **Scratch / memory entry-ID format** (S2 fix). Today's
+  `scratch put` returns a chroma-assigned UUID; today's
+  `memory_put` returns a `(project, title)` natural key. After
+  the wrapper flips (`NX_TUPLESPACE_WRAPPED_SCRATCH=1`,
+  `NX_TUPLESPACE_WRAPPED_MEMORY=1`), both return chash-derived
+  tuple IDs (`sha256(canonical(...))[:32]` hex strings). Agents
+  or scripts that cache returned entry IDs across the flip will
+  hold stale-format IDs. **Resolution**: explicit carve-out, not
+  a forwarding table. The compatibility contract for these two
+  surfaces is "signatures and semantics hold, ID format does not."
+  Documented in CHANGELOG; `nx doctor --check-tuplespace-migration`
+  (Phase 4 Step 3) flags caller code that pattern-matches against
+  the legacy ID format. Agents that don't cache IDs across
+  invocations are unaffected. The forwarding-table alternative
+  was rejected because (a) it requires persisting a UUID→chash
+  mapping that itself violates the compatibility contract on
+  external storage shape, and (b) the agentic workloads of
+  interest don't cache scratch/memory IDs across sessions in
+  practice.
+- **Plan-match `min_confidence` floor**: today defaults to 0.40
+  (RDR-079 P5). Tuple-space `read.default_floor` for
+  `plans/<verb>` matches 0.40 to preserve behavior. No drift.
+- **Memory `permanence` field**: today three values
+  (permanent / project / session). Becomes a registered enum
+  dimension on `memory/<project>`. Same values, validated.
+
+The transition is cooperative: each surface migrates on its own
+flag, each can roll back independently, and the public surfaces
+(skills, CLIs, tools) hold their contracts through Phase 3.
+
+### RF-9: Honker's `PRAGMA data_version` polling enables blocking `take` without long-poll infrastructure; `UPDATE … RETURNING` resolves the v1-draft CAS race
+
+Honker (https://github.com/russellromney/honker) is a SQLite-only
+queue/pub-sub library that solves the same coordination problem
+this RDR addresses for queues, with two patterns nexus should
+adopt directly:
+
+**Pattern 1 — `PRAGMA data_version` as wake source.** Honker runs
+one thread per `Database` polling `PRAGMA data_version` every
+~1ms. The counter "increments on every commit in every journal
+mode and is visible across processes" — single integer read,
+1-2ms median wake latency, no kernel events / file watches /
+sockets / signal handlers. CPU cost is one integer read per
+millisecond per database.
+
+This eliminates the v1-draft argument for removing `block` from
+the `take` API. The original objection ("MCP transport can't
+honor long-blocking calls without server-side wait queues plus
+cancellation on client disconnect") assumed a per-subspace wait
+queue. Honker shows the wait queue is a single shared condition
+variable per database that the polling thread fires on commit.
+Operationally trivial; bounded timeout (≤30s, well within MCP
+request budgets) keeps it within the transport contract.
+
+**Pattern 2 — single-statement claim via `UPDATE … RETURNING`.**
+Honker's claim is "one `UPDATE … RETURNING` via a partial
+index" gated by `WHERE state='pending'`. Atomic under SQLite's
+single-writer lock by construction — no two-step "insert claim
+row, then re-check for another claimant" pattern. This is
+precisely the C1 fix the gate critic identified. The v1 draft's
+"INSERT into `tuple_claims` ON CONFLICT DO NOTHING, then re-check
+who's the open claimer" is genuinely broken under WAL DEFERRED
+isolation; honker's pattern is genuinely correct and faster
+(no join required).
+
+**Pattern 3 — partial index on working set.** Honker's index is
+`(queue, priority DESC, run_at, id) WHERE state IN ('pending',
+'processing')`. Tombstones don't slow the claim path because
+they're excluded from the index. Direct port: our claim index
+becomes `(subspace, …) WHERE consumed_at IS NULL AND
+(claim_state IS NULL OR claim_expires_at < now)`.
+
+**What this changes in RDR-110's design:**
+
+- `take` re-acquires `block: bool = False, timeout_seconds:
+  float | None = None` parameters, with `timeout_seconds`
+  capped at 30s (MCP request-budget guard). The implementation
+  uses a single `data_version` polling thread per database +
+  per-blocking-call `threading.Event` woken by the poller.
+- The claim algorithm becomes a single statement of the form
+  `UPDATE tuples SET claim_state='claimed', claimant=?,
+  claim_id=?, claim_expires_at=? WHERE id = (SELECT id FROM
+  tuples WHERE id IN (chroma top-K) AND consumed_at IS NULL
+  AND (claim_state IS NULL OR claim_expires_at < ?) ORDER BY
+  created_at LIMIT 1) RETURNING id`. The `LIMIT 1` lives inside
+  the SELECT (universally supported); the outer UPDATE
+  atomically claims that one row. Single SQL statement, no
+  INSERT-into-separate-table, no re-check. Atomic by SQLite's
+  single-writer lock. (`LIMIT` directly on UPDATE requires
+  `SQLITE_ENABLE_UPDATE_DELETE_LIMIT` which is not set in
+  CPython's stdlib `sqlite3`; the subquery form is portable.)
+- The `tuple_claims` table merges into the `tuples` table as
+  state columns (`claim_state` / `claimant` / `claim_id` /
+  `claim_expires_at`) plus tombstone columns (`consumed_at` /
+  `consumed_by`). Schema simpler; one fewer index.
+- **Ack/nack are captured as `tuple_claim_log` transitions, not
+  as columns on `tuples`** (N-S2 fix). `ack(claim_id)` sets
+  `consumed_at` + `consumed_by` on the tuple AND inserts a
+  `transition='ack'` row in `tuple_claim_log`. `nack(claim_id)`
+  clears the claim state on the tuple AND inserts a
+  `transition='nack'` row. The append-only `tuple_claim_log`
+  table preserves claim history for audit (every state
+  transition: claim, ack, nack, expire). This is what the
+  original `tuple_claims` table was implicitly doing for audit;
+  making it append-only-log instead of CAS-target removes the
+  race surface from the audit data.
+
+**What does NOT change**: subspace registry, schema validation,
+chash IDs, tier model, the eight-function API surface (modulo
+`block`/`timeout_seconds` re-introduced on `take`), the four-
+consumer landing surface in Phase 1.
+
+**Persisted prior art**: honker's nine-language binding model
+(Python, Node, Ruby, Go, Elixir, etc. wrapping a Rust core) is
+not relevant for nexus's Python-only context. The interesting
+inheritance is the SQLite-internal wake mechanism, not the
+binding strategy.
+
+**Confidence**: High on patterns 1 + 2 + 3. The `data_version`
+mechanism is a documented SQLite feature with well-understood
+cross-process semantics; the `UPDATE … RETURNING` pattern is the
+canonical SQLite work-stealing primitive. Both are
+production-proven by honker.
+
+### RF-8: One open question — should `take` ship in the v2 wrappers?
+
+The v1 wrappers in Phase 3 are behavior-preserving: scratch's
+`promote` flow becomes `take` from `scratch/<session>` followed
+by `out` to `memory/<project>`, but only because the underlying
+semantics already exist. For plans (read-only) and memory
+(no destructive read in current API), `take` is *not* available
+through the wrappers in v2 — even though the underlying tuple
+space supports it.
+
+This is conservative but possibly leaves leverage on the floor.
+Two options:
+
+**A. Conservative (recommended for v2)**: wrappers expose only
+the existing surface area. New consumers wanting `take` against
+plans or memory must use the raw tuple-space API
+(`take(subspace="memory/<project>", ...)`). Net: zero risk to
+existing callers.
+
+**B. Aggressive**: extend memory's surface to include `take`
+(e.g. as a new `memory_take(...)` tool). Lets existing memory
+consumers adopt coordination patterns without learning the
+tuple-space vocabulary. Net: small surface-area growth,
+small adoption-friction reduction.
+
+Recommend (A) for v2 → v3. (B) is a follow-up RDR if a real
+consumer asks for `memory_take`.
+
+## Proposed Solution
+
+### Approach
+
+Ship a semantic tuple space as a v1 primitive with three core
+operations (`out` / `read` / `take`), two claim-lifecycle operations
+(`ack` / `nack`), and three discovery operations (`list_subspaces` /
+`subspace_schema` / `subspace_stats`). Total surface: 8 functions.
+Tuples live in tier-appropriate backends (T1 / T2 / T3); the claim
+ledger lives in T2 SQLite. Subspaces are registered via static YAML
+in `nx/tuplespace/builtin/*.yml`, validated at MCP startup, and
+discovered at runtime via `list_subspaces`. Existing surfaces (plans,
+scratch, memory) are NOT migrated in v1; v2 wraps them as subspaces
+behavior-preservingly.
+
+### Technical Design
+
+**Tuple shape:**
+
+```text
+Tuple(
+    id: str                        # sha256(canonical(subspace + content + dimensions_json + match_text_or_empty))[:32]
+    subspace: str                  # concrete, e.g. "tasks/nexus"
+    template_name: str             # registered, e.g. "tasks/<project>"
+    content: str                   # body
+    dimensions: dict[str, str]     # validated against subspace schema
+    embed_text: str                # what was embedded; resolved per schema.embed_from
+    match_text: str | None         # optional override for embedding source; participates in id
+    tier: Literal["ephemeral", "project", "permanent"]
+    created_at: float
+    expires_at: float | None
+    consumed_at: float | None      # tombstone; NULL = available
+    consumed_by: str | None        # claimant who acked
+)
+```
+
+**Tuple ID formula (C3 fix):** the canonical-bytes input to
+`sha256` includes `match_text` when non-None. Two `out` calls
+with identical `(subspace, content, dimensions)` but different
+`match_text` produce different IDs and are stored as distinct
+tuples — this is correct because their retrieval embeddings
+differ. Empty/None `match_text` is normalised to the empty
+string before hashing so callers can omit the parameter without
+ID drift. Callers wanting bit-identical idempotency must
+ensure `match_text` is stable across re-submissions.
+
+**Core API (illustrative — verify signatures during implementation):**
+
+```text
+out(*, subspace, content, dimensions=None, match_text=None,
+    tier=None, ttl_seconds=None) -> tuple_id
+read(*, subspace, query, where=None, n=1, min_confidence=None,
+     tier=None) -> list[Tuple]
+take(*, subspace, query, claimant, where=None, min_confidence=None,
+     lease_seconds=None,
+     block=False, timeout_seconds=None) -> (Tuple, claim_id) | None
+ack(claim_id) -> None              # commits the take
+nack(claim_id) -> None             # releases the claim
+list_subspaces() -> list[SubspaceSchema]
+subspace_schema(name) -> SubspaceSchema
+subspace_stats(name) -> SubspaceStats
+```
+
+`block=True` causes `take` to wait on a `PRAGMA data_version`
+counter (per RF-9) until either a candidate appears or
+`timeout_seconds` elapses. `timeout_seconds` is capped at 30s by
+the MCP transport budget; values above the cap raise
+`InvalidTimeoutError`. The default `block=False` returns
+immediately with `None` if no candidate clears floor + margin.
+
+**Subspace schema (YAML, registered statically):**
+
+Each `nx/tuplespace/builtin/*.yml` declares a template:
+
+```yaml
+name: tasks/<project>              # single-segment param
+tier: project                      # default; out can override
+content_type: text                 # text | json
+embed_from: content                # content | match_text | dimensions:<key>
+dimensions:
+  status:    { type: enum, values: [open, in_progress, done, cancelled], required: true }
+  priority:  { type: enum, values: [P0, P1, P2, P3, P4], required: true }
+  assignee:  { type: string, required: false }
+  created_by:{ type: string, required: true }
+take:
+  enabled: true
+  mode: semantic                   # semantic (default) | exact
+  floor: 0.55                      # absolute cosine floor (1 - distance) — semantic mode only
+  margin: 0.08                     # required gap between top-1 and top-2 — semantic mode only
+  match_keys: [...]                # required for exact mode — see locks subspace below
+  default_lease_seconds: 600
+read:
+  default_floor: 0.40
+  default_n: 5
+tiers: [project]                   # cascade order; each subspace declares
+retention_seconds: 7776000         # 90 days; tombstone GC after this
+```
+
+**`take.mode` (C2 fix):** declares whether the candidate-selection
+step uses semantic similarity (`semantic`, default) or exact
+match on a declared dimension key set (`exact`). Mode `exact`
+bypasses the chroma query entirely and selects candidates via
+SQL `WHERE subspace = ? AND <dimension equality conditions>`.
+Floor and margin do not apply under `exact`; the take is
+deterministic on the dimension keys. The schema's `match_keys`
+array names which dimensions form the exact-match key (typically
+a single key for lock-style subspaces).
+
+Lock subspaces (mutex / lease patterns) use `mode: exact`
+because semantic match cannot guarantee exclusion — a query
+semantically distant from the lock's content could falsely
+return `None` ("lock held"), or a query semantically close to
+two distinct lock resources could match the wrong one. Linda's
+`in` over a typed-template-with-exact-match is the correct
+primitive here, not Linda's-with-similarity.
+
+Validation rules:
+- At `out`: dimension keys must be in the registered set; required
+  dimensions must be present; enum values validated; type-conformance
+  enforced. Breach raises `SubspaceSchemaError` before any write.
+- At `read`/`take`: `where` keys must be registered dimensions;
+  enum-typed where-values must be registered. Unknown subspace raises
+  `UnknownSubspaceError`.
+- Schema evolution: additive only in v1. Adding dimensions or enum
+  values is forward-compatible. Removing or renaming requires a
+  migration RDR.
+
+**Five canonical v1 subspaces** (`tasks`, `mailbox`, `locks`,
+`events`, `barriers`) ship with the registry. Three v2 wrappers
+(`plans`, `scratch`, `memory`) are sketched in the registry but not
+wired until Phase 3.
+
+**SQL schema (T2; new database `~/.config/nexus/tuples.db` to keep
+operational separation):**
+
+The schema was revised post-Layer-3 critique to absorb honker's
+single-table-with-state-column pattern (RF-9). The original
+two-table design (`tuples` + `tuple_claims`) had a CAS race
+under WAL DEFERRED isolation between two distinct claimants.
+The single-table pattern with `UPDATE … RETURNING` is atomic
+under SQLite's single-writer lock by construction. Claim
+history moves to an append-only `tuple_claim_log` for audit.
+
+```text
+-- Body store + claim state; the source of truth.
+-- Chroma is a derived index over (id, embed_text, dimensions_json) per RDR-108.
+CREATE TABLE tuples (
+    id              TEXT PRIMARY KEY,
+    subspace        TEXT NOT NULL,
+    template_name   TEXT NOT NULL,
+    content         TEXT NOT NULL,
+    dimensions_json TEXT NOT NULL,
+    embed_text      TEXT NOT NULL,
+    created_at      REAL NOT NULL,
+    expires_at      REAL,                           -- TTL; NULL = no expiry
+    -- Claim state (formerly tuple_claims). Atomic via UPDATE … RETURNING.
+    claim_state     TEXT,                           -- NULL = available; 'claimed' = in-flight
+    claimant        TEXT,                           -- set with claim_state
+    claim_id        TEXT,                           -- the value returned by take()
+    claim_expires_at REAL,                          -- lease expiry; NULL when claim_state IS NULL
+    -- Tombstone state (RDR-106 / RDR-107 style).
+    consumed_at     REAL,                           -- NULL = available
+    consumed_by     TEXT
+);
+-- Working-set partial index per honker's pattern (RF-9).
+-- Tombstones don't slow the claim path because they're excluded.
+CREATE INDEX idx_tuples_avail
+    ON tuples (subspace, expires_at) 
+    WHERE consumed_at IS NULL 
+      AND (claim_state IS NULL OR claim_expires_at < unixepoch());
+CREATE INDEX idx_tuples_claimed
+    ON tuples (claim_id) WHERE claim_state = 'claimed';
+CREATE INDEX idx_tuples_expires
+    ON tuples (expires_at)  WHERE expires_at IS NOT NULL AND consumed_at IS NULL;
+
+-- Append-only claim history for audit. Insert-only; never updated.
+-- Records every state transition (claim, ack, nack, expiry-release).
+CREATE TABLE tuple_claim_log (
+    log_id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    tuple_id        TEXT NOT NULL,
+    claim_id        TEXT NOT NULL,
+    claimant        TEXT NOT NULL,
+    transition      TEXT NOT NULL,                  -- 'claim' | 'ack' | 'nack' | 'expire'
+    at              REAL NOT NULL
+);
+CREATE INDEX idx_claim_log_tuple ON tuple_claim_log (tuple_id, at);
+CREATE INDEX idx_claim_log_claimant ON tuple_claim_log (claimant, at);
+```
+
+The `tuple_claim_log` table is purely informational — sweeps and
+queries do not consult it. Audit consumers (`subspace_stats`,
+`nx tuplespace stats`, post-mortem queries) read from it but
+never mutate it. Its growth is bounded by retention policy
+(separate from tuple retention; default 30 days).
+
+**Chroma collection layout (project tier):**
+
+One persistent local collection per template, named
+`tuples__<template_slug>` where the slug replaces `/` with `_` and
+strips `<>` from parameterised segments. Concrete subspace strings
+live in chroma metadata, alongside the validated dimensions. A
+`read(subspace="tasks/nexus", where={status:"open"})` becomes a
+chroma `query` against `tuples__tasks` with metadata filter
+`{$and: [{subspace: "tasks/nexus"}, {status: "open"}]}` followed by
+a SQL post-filter that drops tuples with `consumed_at IS NOT NULL`
+or with an open claim row.
+
+**`take` algorithm (single-statement CAS via `UPDATE … RETURNING`):**
+
+The algorithm uses honker's single-statement claim pattern (RF-9).
+Atomicity is structural: `UPDATE … WHERE state-is-available …
+RETURNING` runs under SQLite's single-writer lock, so two
+concurrent claimants cannot both succeed on the same row. No
+re-check is needed.
+
+```text
+# Illustrative — verify against implementation.
+def take(*, subspace, query, claimant, where=None,
+         min_confidence=None, lease_seconds=None,
+         block=False, timeout_seconds=None):
+    schema = registry.get_schema_for(subspace)         # raises UnknownSubspaceError
+    if not schema.take.enabled: raise TakeDisabledError(subspace)
+    schema.validate_where(where or {})
+    if timeout_seconds and timeout_seconds > 30:
+        raise InvalidTimeoutError("timeout_seconds capped at 30 by MCP transport budget")
+
+    floor   = min_confidence or schema.take.floor
+    margin  = schema.take.margin
+    lease_s = lease_seconds  or schema.take.default_lease_seconds
+
+    deadline = time.time() + (timeout_seconds or 0) if block else None
+    mode = schema.take.mode  # 'semantic' (default) or 'exact' (C2 fix)
+
+    while True:
+        if mode == 'exact':
+            # (C2 fix) Bypass chroma. Candidate selection is pure SQL on
+            # match_keys. Floor and margin do not apply.
+            #
+            # Column names (`schema.match_keys`) are registered at
+            # schema-load time, never caller-supplied, so interpolating
+            # them into the SQL fragment is safe. Values are bound via
+            # placeholders. No `exact_match_sql` helper — the pattern is
+            # explicit here so the parameterisation is auditable in one
+            # place. Validation: every match_key must be present and
+            # non-empty in `where`; missing keys raise SubspaceSchemaError.
+            for k in schema.match_keys:
+                if k not in (where or {}):
+                    raise SubspaceSchemaError(f"missing required match_key: {k}")
+            match_clause = " AND ".join(f"{k} = ?" for k in schema.match_keys)
+            match_values = tuple(where[k] for k in schema.match_keys)
+            top_ids = [r["id"] for r in db.execute(f"""
+                SELECT id FROM tuples
+                WHERE subspace = ?
+                  AND consumed_at IS NULL
+                  AND (claim_state IS NULL OR claim_expires_at < ?)
+                  AND {match_clause}
+                ORDER BY created_at
+                LIMIT 1
+            """, (subspace, time.time(), *match_values)).fetchall()]
+        else:
+            # Semantic mode (default). chroma → floor → margin → top-K IDs.
+            candidates = chroma_query(schema.collection, subspace, query,
+                                      where, n=max(5, schema.read.default_n))
+            top_ids = []
+            if candidates and (1 - candidates[0].distance) >= floor:
+                margin_ok = (
+                    len(candidates) == 1
+                    or (candidates[1].distance - candidates[0].distance) >= margin
+                )
+                if margin_ok:
+                    top_ids = [c.tuple_id for c in candidates
+                               if (1 - c.distance) >= floor]
+
+        if top_ids:
+            # Single-statement CAS over candidate IDs.
+            # Atomic by SQLite's single-writer lock; no re-check needed.
+            # Portable form: `LIMIT 1` lives in the inner SELECT (universally
+            # supported), the outer UPDATE atomically claims that one row.
+            # `LIMIT 1` directly in UPDATE requires SQLITE_ENABLE_UPDATE_DELETE_LIMIT
+            # which is not set in CPython's stdlib sqlite3 build.
+            now = time.time(); expires = now + lease_s
+            claim_id = chash_id(claimant, top_ids[0], now)
+            placeholders = ",".join("?" * len(top_ids))
+            row = db.execute(f"""
+                UPDATE tuples
+                SET claim_state='claimed',
+                    claimant=?, claim_id=?, claim_expires_at=?
+                WHERE id = (
+                    SELECT id FROM tuples
+                    WHERE id IN ({placeholders})
+                      AND consumed_at IS NULL
+                      AND (claim_state IS NULL OR claim_expires_at < ?)
+                    ORDER BY created_at
+                    LIMIT 1
+                )
+                RETURNING id
+            """, (claimant, claim_id, expires, *top_ids, now)).fetchone()
+            if row:
+                db.execute(
+                    "INSERT INTO tuple_claim_log "
+                    "(tuple_id, claim_id, claimant, transition, at) "
+                    "VALUES (?, ?, ?, 'claim', ?)",
+                    (row["id"], claim_id, claimant, now))
+                return load_tuple(row["id"]), claim_id
+            # No row matched — candidates raced. Loop or return.
+
+        # No candidate cleared the gates. Block or return.
+        if not block: return None
+        remaining = deadline - time.time()
+        if remaining <= 0: return None
+        # Wait on data_version counter (per RF-9). Wakes on any commit
+        # to tuples.db; we re-attempt the candidate scan on each wake.
+        wake_event.wait(timeout=min(remaining, 1.0))
+```
+
+**Idempotent retake by same claimant**: handled by the
+`(claim_state IS NULL OR claim_expires_at < ?)` guard in the
+UPDATE. If the same claimant retakes within their lease, the
+guard fails (claim_state='claimed' AND claim_expires_at > now)
+and the UPDATE returns no row. Caller treats this as "I still
+hold the claim from before"; lookup via `claim_id` recovers the
+existing claim. Implementation detail: same-claimant retake is a
+two-statement read-then-update because the simpler pattern
+above conflates same-claimant retake with foreign-claimant
+contention. Documented; not in the pseudocode for clarity.
+
+**`data_version` polling thread** (`NX_STORAGE_MODE=direct` only):
+a single `_TupleSpaceWatcher` thread per `tuples.db` connection
+runs `PRAGMA data_version` every 1ms, fires `wake_event` on
+increment. Started at MCP lifespan start (per RDR-094), stopped
+at lifespan finally. CPU cost: one integer read per millisecond
+per database. All blocking `take` calls share the same wake_event;
+spurious wakes (commits not relevant to this caller's subspace)
+cost one extra UPDATE attempt that returns no row.
+
+**Under `NX_STORAGE_MODE=daemon` (RDR-112)**, the watcher is
+*daemon-internal* — the daemon owns the single `tuples.db`
+connection (one process, one lock, one `data_version`) and exposes
+client-side waiting via the **blocking-take RPC** and the
+**`EventStream(subspace_prefix, since_cursor) → Stream<Event>`
+RPC** (RDR-112 Approach §7). Clients never hold a `tuples.db`
+connection in daemon mode; doing so would fork the WAL (RDR-112
+§A2) and is forbidden by the `nx doctor --check-storage-boundary`
+lint (RDR-112 §5). The in-process watcher described above is the
+direct-mode path only.
+
+**Tier routing:**
+
+| Operation | ephemeral (T1) | project (T2) | permanent (T3) |
+|---|---|---|---|
+| Body store | T1 chroma collection metadata | `tuples` SQL table | T3 collection metadata |
+| Vector index | T1 chroma per-subspace collection | T2 chroma persistent local | T3 cloud collection |
+| Claim ledger | In-memory dict per MCP process | Claim state on `tuples` row + append-only `tuple_claim_log` | N/A — `take` raises |
+| `take` enabled | yes | yes | no (registry-load-time check) |
+
+Cross-tier `read` cascades in registry-declared order, dedups by
+chash ID, applies the highest tier's floor across results.
+
+**Compaction sweeps** (piggyback on existing periodic GC in
+`mcp/core.py`). Schema revised post-RF-9 to single-table state.
+
+```text
+sweep_expired_claims():   # release stale claims (lease expired without ack/nack)
+    db.execute("""
+        UPDATE tuples
+        SET claim_state = NULL, claimant = NULL,
+            claim_id = NULL, claim_expires_at = NULL
+        WHERE claim_state = 'claimed' AND claim_expires_at < unixepoch()
+        RETURNING id, claim_id, claimant
+    """)
+    # log each transition to tuple_claim_log with transition='expire'
+
+sweep_tombstones():       # hard-delete consumed tuples past retention
+    for each schema with retention_seconds:
+        ids = SELECT id FROM tuples
+              WHERE template_name = schema.name
+                AND consumed_at IS NOT NULL
+                AND consumed_at < unixepoch() - schema.retention_seconds
+        chroma.delete(ids); DELETE FROM tuples WHERE id IN ids
+
+sweep_claim_log():        # bound the audit log size
+    DELETE FROM tuple_claim_log WHERE at < unixepoch() - 30*24*3600
+```
+
+### Existing Infrastructure Audit
+
+| Proposed Component | Existing Module | Decision |
+| --- | --- | --- |
+| Subspace registry (YAML loader, schema validation) | `nx/plans/builtin/*.yml` + plan dimension registry | **Reuse pattern, new registry module.** Plans' registry is plan-specific; tuple-space registry generalises it but does not subsume it in v1. |
+| Body store (T2 SQLite tables) | `~/.config/nexus/memory.db` | **New database `tuples.db`.** Operational separation per RDR-004 logic; tuples are a different access pattern from memory. |
+| Vector index (per-template chroma collection) | RDR-004 four-database split for T3 | **Reuse pattern.** Per-template chroma collection at T2 (local persistent) and T3 (cloud, `take`-disabled). |
+| Claim ledger CAS | beads SQLite claim flow + RDR-105's claims approach + honker `UPDATE … RETURNING` pattern | **Claim state columns on `tuples` + append-only `tuple_claim_log` for audit.** Beads' claim flow is human-curated, no lease, no semantic match — wrong fit. SQLite WAL + honker's single-statement claim is the load-bearing pattern; see RF-9. |
+| Tier cascade for `read` | `src/nexus/plans/match.py` (T1 cosine → T2 FTS5) | **Generalise.** Pattern proven; lift to a tier-cascade helper used by `read` for any subspace declaring `tiers: [...]`. |
+| chash natural IDs | RDR-108 chunk natural-ID scheme | **Follows the principle, not the formula** (S3 fix). RDR-108 hashes raw content bytes only (`sha256(chunk_text_bytes)`) for chunks. RDR-110 hashes content + routing metadata + match-text override (`sha256(canonical(subspace + content + dimensions_json + match_text_or_empty))[:32]`) because tuple identity must include subspace and dimensions to distinguish logically distinct tuples. The two are distinct ID namespaces — RDR-108 chunk IDs and RDR-110 tuple IDs do not collide because they live in different chroma collections (`code__*` / `docs__*` / `rdr__*` / `knowledge__*` for chunks; `tuples__*` for tuples). Cross-tier `read` dedup operates within the RDR-110 tuple-ID namespace only; chunk and tuple namespaces never merge. |
+| Tombstone soft-delete | RDR-106 + RDR-107 | **Reuse pattern.** `consumed_at` + `consumed_by` columns; periodic compaction sweep. |
+| Periodic GC sweeps | `src/nexus/mcp/core.py` orphan-reaper + tmpdir sweep | **Extend.** Add `sweep_expired_claims` and `sweep_tombstones` to the same loop. |
+| MCP tool surface | `src/nexus/mcp/core.py` FastMCP tool registry | **Extend.** Eight new tools for the v1 surface; future migration of plans/scratch/memory subsumes their existing tools. |
+
+### Decision Rationale
+
+The shape of the abstraction is structural — three existing surfaces
+already implement it informally. Naming it explicitly and shipping a
+single primitive does three things at once:
+
+1. **Eliminates parallel-implementation drift.** v2 wraps plans /
+   scratch / memory as subspaces; v3 deletes the parallel APIs. Same
+   pattern RDR-105 used to consolidate T1's discovery layer.
+2. **Adds a coordination primitive (`take`) that didn't exist.** Six
+   agentic patterns become buildable on the existing tier model with
+   no new infrastructure beyond a SQLite claim table.
+3. **Provides a foundation for persistent addressable surfaces.**
+   The original design conversation (multi-writer agentic UI surfaces
+   surviving boundary crossings) reduces to a Phase 4 application of
+   this primitive: a surface is a tuple subspace; the renderer is a
+   `read`-based projection over the tuple stream. No new mechanism
+   needed beyond what this RDR ships.
+
+The decision to ship `take` in v1 (rather than `out`/`read` only) is
+deliberate: without atomic destructive read, the abstraction degrades
+to "another `query` API" with no leverage over what already exists.
+With `take`, the leverage is the six concrete patterns enumerated
+above, each unblockable today.
+
+The decision to register subspaces statically (YAML in code, not
+runtime) follows from RDR-041's lesson: SHOULD-not-MUST vocabularies
+drift. Static registration catches schema breach at MCP startup
+rather than at first-write, which keeps "what does this subspace
+mean" answerable from `git log` alone.
+
+## Alternatives Considered
+
+### Alternative 1: Status quo — keep plans, scratch, memory as parallel implementations
+
+**Description**: Continue maintaining three independent retrieval
+surfaces. Add a fourth surface (e.g. inter-agent mailboxes) as
+another parallel implementation when a real consumer asks.
+
+**Pros**:
+- Zero migration cost, zero risk to existing surfaces.
+- Each surface stays optimised for its specific use case.
+
+**Cons**:
+- Three threshold-tuning stories continue diverging (RDR-077 / RDR-087
+  / RDR-092 keep re-discovering the same calibration problem).
+- Agentic coordination patterns (work-stealing, mailboxes, mutexes)
+  remain unbuildable without external infrastructure.
+- The persistent-addressable-surface design problem stays unsolved
+  because there's no underlying primitive.
+
+**Reason for rejection**: The cost of NOT having a unified primitive
+compounds. Each new surface re-pays the threshold-tuning tax and adds
+a fourth vocabulary to keep coherent. The coordination gap is real
+and growing as agentic patterns mature.
+
+### Alternative 2: Build coordination as a separate primitive (job queue / pub-sub)
+
+**Description**: Ship a Linda-free job queue (or Redis-style pub-sub
+layer) for coordination, leave plans/scratch/memory untouched.
+
+**Pros**:
+- Clean separation of concerns: retrieval is one thing, coordination
+  is another.
+- Can use specialised infrastructure (Redis, RabbitMQ) tuned for
+  queue semantics.
+
+**Cons**:
+- Doesn't reuse semantic match — work-stealing on natural-language
+  task descriptions wants the same vector index plans/scratch already
+  have.
+- Adds an external dependency (Redis or equivalent) for what should
+  be a SQLite + chroma feature.
+- Mailboxes / request-reply benefit from semantic match too: "give
+  me the response to my last auth-related question" is a vector
+  query, not a queue pop.
+
+**Reason for rejection**: The whole leverage of the proposal is that
+semantic match composes with coordination. Splitting them duplicates
+infrastructure and loses the composition.
+
+### Alternative 3: Ship `out`/`read` only in v1, defer `take`
+
+**Description**: v1 is append-only with semantic retrieval. `take`
+ships in v2 once a real consumer needs it.
+
+**Pros**:
+- Smaller v1 surface, less to verify.
+- No claim-table design needed yet.
+
+**Cons**:
+- The leverage from "leveraging the heck out of this" disappears.
+  v1 becomes "another `query` API" with no agentic-coordination
+  payoff.
+- `take`'s atomicity story is the design crux; deferring it means
+  v2 has to re-design half the schema (claim table, idempotent
+  retake, lease semantics, confidence floors as safety knobs vs
+  quality knobs).
+
+**Reason for rejection**: The user explicitly opted in to `take` in
+v1 because the coordination patterns are the point. Shipping without
+it produces a surface that solves Gap 2 but not Gap 1 or Gap 5.
+
+### Briefly Rejected
+
+- **Runtime subspace registration via a `subspaces` meta-subspace**:
+  introduces chicken-and-egg (validating the `subspaces` registration
+  needs the `subspaces` schema). Defer to v2 once a real use case
+  surfaces. Static YAML is what plans already do and works.
+- **Multi-valued dimensions in v1**: chroma metadata is single-valued.
+  Multi-value would need a normalised side-table or JSON-array
+  convention. The v2 scratch wrapper needs it; v1 core subspaces
+  don't. Defer.
+- **`block=True` synchronous waiting on `take`** *(initially
+  rejected; superseded by RF-9)*: the v1-draft rejected `block`
+  on the basis that "MCP transport can't honour long-blocking
+  calls without server-side wait queues plus cancellation on
+  client disconnect." RF-9's honker absorption reversed this:
+  `PRAGMA data_version` polling provides cross-process wake at
+  1-2ms median latency via a single shared condition variable
+  per database (one watcher thread per `tuples.db`). Bounded
+  timeout (≤30s) keeps the call within MCP request budgets.
+  `block=True` ships in v1; the rejection rationale is preserved
+  here as the historical alternative considered.
+- **Hard-delete consumed tuples instead of tombstoning**: tombstone
+  matches RDR-106 / RDR-107 house style; the audit trail (who
+  consumed what, when) comes free.
+
+## Trade-offs
+
+### Consequences
+
+- **Positive**: One mental model for plans/scratch/memory plus the
+  five new coordination subspaces. Eight tools instead of three
+  per-surface tool sets in v2/v3.
+- **Positive**: `take` unblocks six concrete agentic patterns
+  (work-stealing, mailboxes, mutexes, barriers, audit-by-consumption,
+  backpressure) with no new infrastructure.
+- **Positive**: Persistent addressable surfaces become a Phase 4
+  application of this primitive rather than a separate subsystem.
+- **Positive**: chash-derived IDs make `out` idempotent for free
+  (same content+dimensions = same ID).
+- **Negative**: New SQLite database + N new chroma collections (one
+  per registered template) at MCP startup. Operational footprint
+  grows.
+- **Negative**: Per-subspace threshold calibration is a real cost.
+  Each new subspace requires picking floor + margin against a
+  representative paraphrase distribution.
+- **Negative**: v2 migration of plans/scratch/memory is mechanical
+  but touches multiple surfaces; behavior-preservation requires care.
+- **Negative**: Agents must learn a new surface alongside the
+  existing ones during the v1 → v3 transition.
+
+### Risks and Mitigations
+
+- **Risk**: Confidence-floor calibration is wrong for some subspace,
+  causing systematic false-positive takes that leak intended-for-X
+  tuples to Y.
+  **Mitigation**: Critical Assumption #3 spike with paraphrase fuzz.
+  Default schema floor + margin are conservative (0.55 / 0.08) for
+  generic subspaces; lock-style subspaces use ~0.95 / 0.10 for
+  near-exact match. `nx doctor --check-tuplespace` proposed (Phase 1)
+  that scores per-subspace claim distributions and flags drift.
+- **Risk**: Claim-table contention under heavy concurrent take load
+  produces SQLite lock errors.
+  **Mitigation**: SQLite WAL handles writer serialisation correctly
+  and the lock window is microseconds (one CAS insert + one read).
+  Phase 1 stress test (10-parallel-worker race) verifies. If
+  contention surfaces, batched-claim or per-subspace claim-DB
+  partitioning are escape hatches.
+- **Risk**: Tombstone GC sweeps run too rarely → table bloat; or too
+  often → wasted churn.
+  **Mitigation**: Tombstone count threshold (e.g. >10k consumed-but-
+  unswept) plus age threshold (e.g. age > min(retention_seconds /
+  10, 1 hour)) trigger sweep. Reuse `mcp/core.py` periodic-GC pattern
+  from RDR-105.
+- **Risk**: Per-template chroma collection fan-out grows unbounded
+  as new subspaces ship.
+  **Mitigation**: Subspaces are statically registered; growth is
+  proportional to RDR cadence. RDR-004 already runs ~150 collections
+  in T3 without operational pain. Re-evaluate at >50 templates.
+- **Risk**: Subspace schema breaches at `out` time block legitimate
+  work because the schema is too strict.
+  **Mitigation**: Additive-only evolution rule means schemas can
+  always be widened without a migration. `nx doctor` reports recent
+  `SubspaceSchemaError`s so over-strict schemas surface fast.
+
+### Failure Modes
+
+- **Visible**: `out` rejects a payload with `SubspaceSchemaError`
+  before any write. Caller sees the field/reason; no tuple is
+  created. Standard.
+- **Visible**: `take` returns `None` when no candidate clears
+  floor+margin. Caller polls or surfaces "no work available."
+- **Visible**: Periodic sweep logs `claims_expired` /
+  `tombstones_swept` counters via structlog.
+- **Silent (resolved in design)**: Crash-mid-take leaves a claim row
+  with no ack/nack. Lease expiry releases it; idempotent retake by
+  same claimant returns the same tuple on replay. At-least-once
+  delivery; explicit in the `take` contract.
+- **Silent (resolved in design)**: Two claimants race for the same
+  tuple. UNIQUE constraint on `(tuple_id, claimant)` plus the
+  open-claim re-check inside the SQL transaction ensures exactly
+  one wins; the loser falls through to the next candidate.
+- **Silent (open until spike)**: False-positive take on an ambiguous
+  match. Margin gate guards against this but the calibration of
+  floor + margin is per-subspace and depends on the paraphrase
+  distribution. Mitigation: spike (CA #4); per-subspace tuning at
+  Phase 1.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] All Critical Assumptions verified. CA #1, #3, #6 are
+      Verified (source-search). CA #2, #4, #5 are spike-gated
+      and bundled into Phase 1 Step 7 — Steps 8-12 of Phase 1
+      cannot ship before these clear.
+- [ ] RDR-108 Phase 2 (chunk natural-ID migration) does not need to
+      complete before this RDR ships; the `chash_id` primitive is
+      already available.
+- [ ] No outstanding RDR-105 fixes in flight that would conflict
+      with new T2 SQL schema additions.
+
+### Minimum Viable Validation
+
+A 10-parallel-worker work-stealing harness pulls tasks from a
+populated `tasks/<project>` subspace via `take`. After completion:
+
+- Every task is `consumed_by` exactly one worker (no double-claim).
+- No task remains available unless all workers have failed it (no
+  starvation).
+- Tombstone count after sweep matches consumed task count.
+- Median `take` latency under 100ms; tail p99 under 500ms.
+
+### Phase 1: Core API, project tier, and four-consumer landing surface
+
+Phase 1 is intentionally large. Per RF-1 / RF-6 the four consumer
+classes (agent / session / user / script) each need an explicit
+deliverable that lands the new primitive at its discovery surface;
+shipping the API without the discovery surfaces would leave the
+slickness gap unfilled. Phase 1 is additive only — no existing
+caller can break because no existing surface changes.
+
+#### Step 1: Schema registry module
+
+Create `src/nexus/tuplespace/registry.py` that loads
+`nx/tuplespace/builtin/*.yml` at MCP startup, validates each schema
+against a JSON Schema for the registry format itself, exposes
+`get_schema_for(subspace)` with parameterised-name matching.
+
+#### Step 2: Body store + claim ledger
+
+Create `src/nexus/tuplespace/store.py` with the `tuples` and
+`tuple_claim_log` tables in a new `~/.config/nexus/tuples.db`. Add
+SQLite migration to create on first MCP startup post-upgrade.
+
+#### Step 3: Chroma collection layout (project tier)
+
+One persistent local chroma collection per registered template. Add
+`src/nexus/tuplespace/index.py` with thin wrappers for
+`out`/`read` against (collection, metadata) — caller doesn't see
+chroma directly.
+
+#### Step 4: Core API + `data_version` watcher
+
+Implement `out`/`read`/`take`/`ack`/`nack`/`list_subspaces`/
+`subspace_schema`/`subspace_stats` in `src/nexus/tuplespace/api.py`.
+Wire into `nx-mcp` as eight new MCP tools. `take` accepts
+`block`/`timeout_seconds` per RF-9.
+
+In the same step, add `src/nexus/tuplespace/watcher.py` —
+a `_TupleSpaceWatcher` thread per `tuples.db` connection that
+polls `PRAGMA data_version` every 1ms and fires a shared
+`threading.Event` (the `wake_event` referenced in the `take`
+algorithm) on any increment. Started at MCP lifespan start
+(per RDR-094 / RDR-105 lifecycle pattern), stopped at lifespan
+finally. Honker's production cadence is the reference (1-2ms
+median wake latency).
+
+**Mode split — daemon vs direct (RDR-112)**: the watcher described
+above is the **`NX_STORAGE_MODE=direct`** path only (same-host,
+single-filesystem deployments). Under
+**`NX_STORAGE_MODE=daemon`**, the MCP server is a client of the T2
+daemon (RDR-112 D1) and does **not** hold a `tuples.db`
+connection — the watcher runs daemon-side, owned by the single
+process that owns the SQLite file. Client-side `block=True`
+calls into `take` route through the daemon's **blocking-take
+RPC**; client-side observers (RDR-111's `_BindingWatcher`,
+cockpit panels) subscribe via the daemon's
+**`EventStream(subspace_prefix, since_cursor)`** RPC (RDR-112
+Approach §7). Holding a client-side `tuples.db` connection
+under daemon mode is forbidden by the
+`nx doctor --check-storage-boundary` lint (RDR-112 §5) and would
+fork the WAL across the overlayfs boundary (RDR-112 §A2).
+`block=True` ships feature-flagged in Step 4 and is enabled when
+daemon mode is the default, per the sequencing constraint in
+the Revision-History "Further-revised scope (2026-05-13)" block.
+
+#### Step 5: Periodic sweeps
+
+Add `sweep_expired_claims`, `sweep_tombstones`, and
+`sweep_claim_log` to the existing `mcp/core.py` periodic-GC loop.
+Trigger thresholds: claim sweep on 30s cadence; tombstone sweep
+on count > 10k or age > min(retention/10, 1h); claim-log sweep
+nightly. The expired-claims sweep is the recovery path for
+crashed claimants (lease lapses; sweep clears `claim_state`,
+appends `transition='expire'` to `tuple_claim_log`).
+
+#### Step 6: Five canonical v1 subspaces
+
+Ship `tasks/<project>`, `mailbox/<agent>`, `locks/<resource>`,
+`events/<topic>`, `barriers/<barrier_id>` YAML files in
+`nx/tuplespace/builtin/`.
+
+#### Step 7: Critical Assumption spikes (gates Steps 8-12)
+
+Per Layer 3 critique S1, the four-consumer landing surface
+(Steps 8-12 below) cannot ship before CA #2, #4, and #5 clear
+(the three spike-gated assumptions). Critical assumptions about
+`take` atomicity and wake-mechanism behaviour must validate
+against the deployment harness before agent-facing surfaces
+document the API contract.
+
+- 10-parallel-worker take-on-same-tuple stress test (CA #1 + #2).
+  Per the prior re-gate observation: harness must inject a
+  controlled sleep between candidate-selection and UPDATE to
+  force the race window; assert exactly-one-winner under that
+  interleaving.
+- 100-paraphrase fuzz test against `mailbox` and `tasks`
+  subspaces (CA #4).
+- Polling-latency observation harness on a 10-worker work
+  queue, both `block=False` and `block=True` paths (CA #5).
+- `data_version` cost measurement on the deployment hardware
+  (CA #6; honker reports 1-2ms median; verify on M-series and
+  Linux x86_64).
+
+If any spike fails, design returns to revision (e.g. UPDATE-
+WHERE-NOT-EXISTS variant of the claim pattern, or slower
+`data_version` cadence). Steps 8-12 are blocked until spikes
+clear.
+
+#### Step 8: Agent-consumer landing — five new coordination skills
+
+Per RF-4, ship five new skill files in `nx/skills/` (or wherever the
+plugin's skill registry lives):
+
+- `nx:tuplespace-tasks` — work-stealing pattern; points at
+  `tasks/<project>` with `out` / `take` / `ack` examples.
+- `nx:tuplespace-mailbox` — request-reply pattern; points at
+  `mailbox/<agent>` with correlation_id usage.
+- `nx:tuplespace-lock` — mutex / lease pattern.
+- `nx:tuplespace-events` — append-only telemetry pattern;
+  read-only consumers.
+- `nx:tuplespace-barriers` — N-way coordination.
+
+Each skill is a thin wrapper that brings the canonical pattern into
+the agent's context window in one tool call. Skills are *additive*
+in Phase 1 — they recommend the new primitive but do not replace
+or deprecate existing skills (`nx:nexus`, `nx:knowledge-tidy`, etc.).
+The deprecation/rewrite of existing skills is Phase 3.
+
+**O1 mitigation — CONTEXT_PROTOCOL forward reference**: alongside
+the new skills, prepend a one-paragraph note to
+`nx/agents/_shared/CONTEXT_PROTOCOL.md` naming the five
+coordination skills and stating: *"Use these for cross-agent
+coordination patterns (work-stealing, mailboxes, mutexes,
+barriers, events). The canonical tier-vs-subspace guidance below
+is unchanged for now and will be rewritten in Phase 3 once the
+plans/scratch/memory wrappers ship."* This closes the
+confused-agent window between new skills landing in Phase 1 and
+the full CONTEXT_PROTOCOL rewrite in Phase 3 Step 8.
+
+#### Step 9: Agent-consumer landing — introspection skills
+
+Two skills that double as MCP tools for agent-side discovery:
+
+- `nx:tuplespace-list` — wraps `list_subspaces`; returns the registry
+  formatted for agent context.
+- `nx:tuplespace-stats` — wraps `subspace_stats`; per-subspace counts
+  and dimension distributions.
+
+These are the "I don't know what's available" answer for agents that
+join a session mid-flight or after compaction.
+
+#### Step 10: Session-consumer landing — session-start banner
+
+Per RF-1 / RF-6, the session-start hook (post-RDR-105) emits a
+banner. Extend it with a one-line tuplespace summary:
+
+```
+T1 ephemeral subspaces: scratch, mailbox, locks, barriers (3 active, 12 entries)
+Project subspaces:      tasks, events, memory (47 open tuples)
+```
+
+Cost: one extra `subspace_stats` call at session start. Surfaces
+the "what's available right now" question agents currently can't
+answer.
+
+#### Step 11: User-consumer landing — `nx tuplespace` CLI
+
+Per RF-6, ship a unified CLI subcommand that subsumes the
+operations across surfaces:
+
+- `nx tuplespace list [--tier=...]`
+- `nx tuplespace show <subspace>` (schema, current stats)
+- `nx tuplespace put <subspace> [-d key=value]... <content>`
+- `nx tuplespace get <subspace> --query=... [-d key=value]...`
+- `nx tuplespace take <subspace> --claimant=... --query=...`
+- `nx tuplespace ack <claim_id>` / `nack <claim_id>`
+- `nx tuplespace stats <subspace>`
+
+Existing CLIs (`nx scratch`, `nx memory`, `nx store`) are NOT
+modified in Phase 1 — they keep working unchanged. Phase 4 adds
+deprecation banners.
+
+#### Step 12: Script-consumer landing — env-var contract + JSON schema
+
+Per RF-1, scripts need introspection. Provide:
+
+- `nx tuplespace list --json` — machine-parseable subspace list.
+- `nx tuplespace show <subspace> --schema-json` — JSON schema for
+  the subspace's dimensions, suitable for client-side validation.
+- Env-var contract: `NX_TUPLESPACE_SUBSPACE` + `NX_TUPLESPACE_CLAIMANT`
+  set automatically when scripts are dispatched from the MCP layer
+  (analogous to how RDR-105's dispatcher sets `NX_T1_HOST/PORT`).
+
+### Phase 2: Ephemeral and permanent tiers
+
+#### Step 1: Ephemeral tier (T1)
+
+T1 chroma per-subspace collection on the per-session HTTP server.
+Claim ledger as in-memory dict keyed by `(tuple_id, claimant)` per
+MCP process. Lifecycle bound to MCP lifespan per RDR-105.
+
+#### Step 2: Permanent tier (T3)
+
+T3 chroma collection per subspace under a new `{base}_tuples`
+database (extends RDR-004's split). Registry validation rejects
+`take.enabled: true` for any subspace with permanent in `tiers:`.
+
+#### Step 3: Tier cascade for `read`
+
+Generalise `plan_match`'s T1-cosine → T2-FTS5 fallback to
+N-tier cascade. Per-subspace `tiers: [a, b, c]` declares order.
+Dedup by chash ID; floor evaluated per tier.
+
+### Phase 3: v2 wrappers (behavior-preserving migration with independent flags)
+
+Per RF-5, three independent feature flags gate the three wrapper
+migrations. Each flag flips on its own schedule, each rolls back
+independently, none couples to the others.
+
+| Flag | Wraps | Default off through | Default on starting |
+|---|---|---|---|
+| `NX_TUPLESPACE_WRAPPED_PLANS=1` | `plan_match`, `plan_save`, `plan_search` | Phase 3 Step 2 land | Phase 3 Step 5 default-flip |
+| `NX_TUPLESPACE_WRAPPED_SCRATCH=1` | `scratch` MCP tool, `nx scratch` CLI | Phase 3 Step 3 land | Phase 3 Step 6 default-flip |
+| `NX_TUPLESPACE_WRAPPED_MEMORY=1` | `memory_put`, `memory_search`, `memory_get`, `memory_consolidate`, `memory_delete` | Phase 3 Step 4 land | Phase 3 Step 7 default-flip |
+
+The flag-isolation contract from RDR-105 applies: a given MCP
+server runs each surface entirely on flag-on or flag-off; tests
+target one path per process per surface.
+
+#### Step 1: Schema rollout for wrapped subspaces
+
+Ship `nx/tuplespace/builtin/plans.yml`, `scratch.yml`, `memory.yml`
+schemas in the registry. These are inert until their respective
+flags flip — registered but no callers yet.
+
+#### Step 2: Wrap `plan_match` as `read(subspace="plans/<verb>")`
+
+Refactor `src/nexus/plans/match.py` internals to call the
+tuple-space API behind `NX_TUPLESPACE_WRAPPED_PLANS`. Keep public
+function signatures unchanged. Both flag paths exercised in CI.
+
+#### Step 3: Wrap T1 scratch behind `NX_TUPLESPACE_WRAPPED_SCRATCH`
+
+Refactor `src/nexus/db/t1.py` and `src/nexus/commands/scratch.py`.
+The promote-to-T2 flow (`scratch_manage flag` + flush) becomes
+`take` from `scratch/<session>` followed by `out` to
+`memory/<project>`. RDR-041's tag vocabulary lands as the
+registered enum on `scratch/<session>` — agents using ad-hoc tags
+get a structured warning when the flag flips on (Phase 3 Step 6).
+
+#### Step 4: Wrap T2 memory behind `NX_TUPLESPACE_WRAPPED_MEMORY`
+
+`memory_put`/`memory_search`/`memory_get`/`memory_consolidate`/
+`memory_delete` become thin wrappers over `out`/`read`/`take`
+(disabled)/etc. Memory's `permanence` field becomes a registered
+enum dimension.
+
+#### Step 5: Default-flip wrapped plans
+
+Sandbox shakedown (real Claude Code session running plan-matched
+queries via `nx_answer`); zero behavior delta vs flag-off baseline.
+Flip default. Hold for one release cycle before Step 6.
+
+#### Step 6: Default-flip wrapped scratch
+
+Same shakedown shape. Phase 3 introduces the tag-vocabulary
+warning at flip time (RDR-041's enum becomes enforced). Hold one
+release cycle before Step 7.
+
+#### Step 7: Default-flip wrapped memory
+
+Final wrapper flip. After this, all three legacy surfaces route
+through the tuple-space primitive internally.
+
+#### Step 8: CONTEXT_PROTOCOL rewrite
+
+Per RF-3, after all three wrappers default-on, rewrite
+`nx/agents/_shared/CONTEXT_PROTOCOL.md` from per-tier guidance to
+per-subspace guidance. Update agent files in `nx/agents/*.md` that
+quote tier-specific guidance. The proactive-search-vs-relay-reliant
+agent split survives unchanged; only the tier-vocabulary changes.
+
+#### Step 9: Existing skill rewrites
+
+Update `nx:nexus`, `nx:knowledge-tidy`, `nx:plan-first`,
+`nx:query`, `nx:research`, `nx:analyze`, `nx:review`, `nx:document`,
+`nx:debug` to describe the new subspace-by-intent vocabulary.
+Skills' public contracts (skill names + invocation shapes) hold;
+internals update to recommend `out(subspace=…)` patterns.
+
+### Phase 4: Deprecation cycle
+
+After Phase 3 default-flips have stabilised across one release cycle:
+
+#### Step 1: Deprecation warnings on legacy MCP tools
+
+Add `DeprecationWarning` to `scratch`, `memory_put`, `memory_search`,
+`memory_get`, `store_put`, `store_get`, `store_list`, `plan_save`,
+`plan_search`. Each warning points at the equivalent
+`nx tuplespace` operation.
+
+#### Step 2: Deprecation banners on legacy CLIs
+
+`nx scratch`, `nx memory`, `nx store` print one-line deprecation
+banners pointing at `nx tuplespace`. Existing scripts continue to
+work — banner is informational.
+
+#### Step 3: `nx doctor --check-tuplespace-migration`
+
+Audit hook that flags codebase usage of legacy tools/CLIs and
+suggests the equivalent tuple-space invocation. Helps users find
+migration work in their own scripts.
+
+#### Step 4: Documentation cutover
+
+`docs/architecture.md` rewritten to describe tuple-space as the
+primitive, with plans/scratch/memory presented as canonical
+subspace examples. `docs/cli-reference.md` foregrounds
+`nx tuplespace`. `docs/memory-and-tasks.md` retitled or replaced.
+
+### Phase 5: Persistent addressable surfaces (separate RDR)
+
+Out of scope for this RDR. The surfaces application is a separate
+design that builds on this primitive: a surface is a tuple subspace;
+the renderer is a `read`-based projection over the tuple stream;
+multi-writer support comes from append-only `out` + projection-based
+read. RDR-1NN to be authored once Phase 4 stabilises.
+
+### Phase 6: Removal (separate RDR)
+
+Removal of legacy MCP tools, CLI subcommands, and Python public
+APIs is gated on a separate RDR after Phase 4 stabilises across
+multiple release cycles. Following RDR-105's ~one-month observation
+window between deprecation and removal as precedent. Out of scope
+for this RDR.
+
+### Day 2 Operations
+
+| Resource | List | Info | Delete | Verify | Backup |
+| --- | --- | --- | --- | --- | --- |
+| Subspace registry | `nx tuplespace list` | `nx tuplespace show <name>` | N/A (delete via PR) | `nx doctor --check-tuplespace` | git (YAML in repo) |
+| `tuples.db` SQLite database | `ls ~/.config/nexus/tuples.db` | `sqlite3 ... .schema` | manual (rebuild from chroma) | `nx doctor` | sqlite3 backup |
+| Per-template chroma collections | `nx tuplespace list` | `nx tuplespace stats <name>` | sweep on subspace removal | `nx doctor` | rebuilt from `tuples.db` |
+| Claim ledger | `nx tuplespace stats <name>` shows open/expired/acked counts | per-claim via `tuple_claim_log` SQL (transition history) | N/A (sweep-managed) | `nx doctor` | covered by `tuples.db` backup |
+| Tombstones | `nx tuplespace stats <name>` | counts by age | sweep | `nx doctor --check-tuplespace` | covered |
+
+`nx tuplespace` is a new CLI subcommand bundled with Phase 1.
+
+### New Dependencies
+
+None. ChromaDB and SQLite are existing deps. PyYAML is already used
+for plan registry. ULID is dropped in favour of chash IDs (RDR-108
+compliance).
+
+## Test Plan
+
+- **Scenario**: `out` with valid dimensions → tuple stored, ID
+  returned. — **Verify**: `tuples` row exists; chroma collection
+  has one document; ID matches `sha256(canonical(...))`.
+- **Scenario**: `out` with same content+dimensions twice → second
+  call is idempotent. — **Verify**: Same ID returned both times;
+  `tuples` table has exactly one row.
+- **Scenario**: `out` with invalid enum value → raises
+  `SubspaceSchemaError`. — **Verify**: No row written; no chroma
+  document added; structured error mentions field + reason.
+- **Scenario**: `read` returns top-k matches above floor with
+  metadata filter. — **Verify**: Distance ranked ascending; all
+  returned items satisfy `where`; floor enforced.
+- **Scenario**: `read` filters out consumed tuples. — **Verify**:
+  Tuples with `consumed_at IS NOT NULL` not returned even if their
+  embedding matches.
+- **Scenario**: `take` succeeds → returns `(Tuple, claim_id)`,
+  claim row inserted with `expires_at` correctly set. — **Verify**:
+  Claim row exists; tuple body reachable; subsequent `read` filters
+  it out.
+- **Scenario**: `take` ambiguous (top-1 vs top-2 gap < margin) →
+  returns `None`. — **Verify**: No claim row inserted; logged at
+  DEBUG.
+- **Scenario**: 10 parallel `take` calls on a single tuple →
+  exactly one wins. — **Verify**: One claim row inserted; nine
+  losers fall through to next candidate or return `None`. CA #1 + #2.
+- **Scenario**: `take` then crash before `ack` → lease expires →
+  next `take` succeeds. — **Verify**: Tuple's `claim_expires_at <
+  now` until sweep runs; `sweep_expired_claims` clears the tuple's
+  claim state and appends `transition='expire'` to
+  `tuple_claim_log`; subsequent `take` returns the tuple to a new
+  claimant.
+- **Scenario**: `take` by same claimant twice within lease →
+  returns the same `(Tuple, claim_id)` pair (idempotent). —
+  **Verify**: Tuple's claim_state remains `'claimed'` with
+  matching `claimant`; UPDATE finds no eligible row (guard fails);
+  caller's lookup-by-claim_id recovers the existing claim.
+- **Scenario**: `ack(claim_id)` → sets `consumed_at` +
+  `consumed_by` on the tuple and inserts `transition='ack'` row
+  into `tuple_claim_log`. — **Verify**: `SELECT consumed_at FROM
+  tuples WHERE claim_id=?` is non-NULL; `SELECT 1 FROM
+  tuple_claim_log WHERE claim_id=? AND transition='ack'` returns
+  one row; subsequent `read` excludes the tuple; tombstone count
+  increments.
+- **Scenario**: `nack(claim_id)` → tuple becomes available again. —
+  **Verify**: Subsequent `take` (different claimant) succeeds.
+- **Scenario**: Permanent-tier subspace with `take.enabled: true`
+  in YAML → registry load fails. — **Verify**: MCP startup raises
+  with clear error.
+- **Scenario**: Tier cascade `read` against `tiers: [ephemeral,
+  project]` → ephemeral matches returned first; falls through to
+  project if below floor. — **Verify**: Result ordering matches
+  cascade declaration.
+- **Scenario**: Tombstone sweep removes consumed tuples past
+  `retention_seconds`. — **Verify**: SQL row gone; chroma document
+  gone.
+- **Scenario**: 100-paraphrase fuzz → no false-positive take across
+  intended-target / paraphrased-but-different-subject pairs. CA #4.
+- **Scenario**: Subspace registration with `<param>` → concrete
+  subspaces match the template. — **Verify**: `tasks/nexus` and
+  `tasks/conexus` resolve to the same template, distinct concrete
+  metadata.
+
+## Validation
+
+### Testing Strategy
+
+- **Unit tests**: schema validation, chash computation, take CAS
+  algorithm, tier routing logic. Target: 90%+ coverage on
+  `src/nexus/tuplespace/`.
+- **Integration tests**: end-to-end `out`/`read`/`take`/`ack`/`nack`
+  against real SQLite + local chroma. Each canonical subspace has
+  at least one happy-path and one failure-path test.
+- **Concurrency tests**: 10-parallel-worker stress on `take` with
+  injected sleep (CA #1 + #2); paraphrase fuzz on take-floor
+  (CA #4).
+- **Migration tests** (Phase 3): all existing plans / scratch /
+  memory tests pass without modification after the wrapper refactor.
+- **Smoke tests**: a representative agentic pattern (work-stealing
+  pool with 5 workers, 50 tasks) executes end-to-end and the
+  expected throughput / completion semantics hold.
+
+### Performance Expectations
+
+Empirical baseline only. The architecture reuses existing chroma +
+SQLite primitives; no novel performance claims. Phase 1 spike
+records median + tail latency for `out`/`read`/`take` against the
+project tier and informs whether `block` becomes necessary in v2.
+
+## Finalization Gate
+
+> Complete each item with a written response before marking this
+> RDR as **Accepted**.
+
+### Contradiction Check
+
+_To be completed during /nx:rdr-gate._
+
+### Assumption Verification
+
+_To be completed during /nx:rdr-gate. CA #2, #4, #5 are
+spike-gated; CA #1, #3, #6 are Verified via source search +
+honker production reference._
+
+#### API Verification
+
+| API Call | Library | Verification |
+| --- | --- | --- |
+| `chromadb.PersistentClient.get_or_create_collection` | chromadb | Source Search (existing T2 catalog usage) |
+| `chromadb.Collection.query(query_texts=, where=, n_results=)` | chromadb | Source Search (existing search engine usage) |
+| `sqlite3.execute("INSERT … ON CONFLICT (…) DO NOTHING")` | sqlite3 | Source Search (existing beads + RDR-105 usage) |
+| `hashlib.sha256(canonical_bytes).hexdigest()[:32]` | stdlib | Source Search (RDR-108 chunk natural ID) |
+| FastMCP tool registration | mcp.server.fastmcp.FastMCP | Source Search (existing nx-mcp tool registry) |
+
+### Scope Verification
+
+_To be completed during /nx:rdr-gate. The MVV (10-parallel-worker
+work-stealing harness) is in scope and bundled into Phase 1 Step 7._
+
+### Cross-Cutting Concerns
+
+- **Versioning**: Schemas evolve additively in v1 (adding dimensions
+  / enum values is forward-compatible). Removing or renaming
+  requires a migration RDR.
+- **Build tool compatibility**: N/A.
+- **Licensing**: No new dependencies.
+- **Deployment model**: Schema YAML ships in the conexus package
+  alongside plan templates; loaded at MCP startup.
+- **IDE compatibility**: N/A.
+- **Incremental adoption**: v1 ships alongside existing surfaces;
+  no callers forced to migrate. v2 wraps existing surfaces
+  behavior-preservingly. v3 deprecates parallel APIs.
+- **Secret/credential lifecycle**: N/A in the tuple-space layer
+  itself. The trust boundary for agent-private subspaces (notably
+  `mailbox/<agent>`) is inherited from the storage substrate: under
+  `NX_STORAGE_MODE=daemon`, **RDR-113** (host-trust model — UDS
+  `chmod 0600` + peer-credential check, single-user v1) ensures
+  only the daemon-owner UID can read/write any subspace through the
+  daemon. Under `direct` mode, host filesystem permissions on
+  `tuples.db` are the gate (same-host single-user assumption).
+- **Memory management**: Per-template chroma collections at T2 are
+  bounded by `retention_seconds`. Tombstone sweep enforces ceiling.
+  Claim ledger is bounded by lease expiry + sweep cadence.
+
+### Proportionality
+
+_To be completed during /nx:rdr-gate. The document is scoped at the
+"new architectural primitive with phased migration" level; sections
+match RDRs 094 / 105 / 108._
+
+## References
+
+- RDR-004 — Four-Store T3 Architecture (operational separation
+  rationale).
+- RDR-041 — T1 Scratch Inter-Agent Context Sharing (tag vocabulary
+  drift lesson).
+- RDR-077 — Projection Quality / Threshold Tuning (per-collection
+  calibration prior art).
+- RDR-078 — Unified Context Graph and Retrieval (plan-centric
+  retrieval trunk).
+- RDR-079 — Operator Dispatch + Calibration (`min_confidence` floor
+  precedent).
+- RDR-087 — Collection Observability and Curation Surfaces
+  (threshold-mismatch failure shape).
+- RDR-092 — Plan-Match Text from Dimensional Identity (`match_text`
+  payload shape).
+- RDR-105 — T1 Chroma Architecture Env-Passdown (T2-as-shared-bus
+  designation; hybrid discovery pattern).
+- RDR-106 — Soft-Delete Tombstone Column (tombstone house style).
+- RDR-107 — T3 Chunk Soft-Delete (superseded by RDR-108 but
+  contributes the soft-delete pattern).
+- RDR-108 — Graph Identity Normalization (content-derived natural
+  IDs; FK-not-string-copy normalisation rule).
+- `src/nexus/plans/match.py` — existing plan-match implementation
+  (refactor target in Phase 3).
+- `src/nexus/db/t1.py` — existing T1 scratch implementation
+  (refactor target in Phase 3).
+- `src/nexus/db/t2/memory_store.py` — existing T2 memory
+  implementation (refactor target in Phase 3).
+- Linda / tuple-space prior art:
+  https://en.wikipedia.org/wiki/Tuple_space ;
+  Gelernter & Carriero, "Generative Communication in Linda", 1985.
+- JavaSpaces specification — lease + atomic-take + leased-write
+  semantics that inform the at-least-once delivery model.
+- Klaim — multiple named tuple spaces with locality, the
+  inspiration for subspaces.
+- Honker (https://github.com/russellromney/honker) — SQLite-only
+  durable queue + pub/sub + stream library. Source for RF-9's
+  three load-bearing patterns: `PRAGMA data_version` polling
+  for cross-process wake (1-2ms median latency), single-statement
+  `UPDATE … RETURNING` claim under SQLite's single-writer lock,
+  and partial-index-on-working-set for tombstone-isolated claim
+  performance. The wake mechanism specifically resolves the v1-
+  draft objection to a `block` parameter on `take`. Honker's
+  multi-language binding strategy is not relevant to nexus's
+  Python-only runtime.
+
+## Revision History
+
+### Layer 3 critique 2026-05-09 — BLOCKED (3 critical, 3 significant, 3 observations)
+
+Substantive-critic dispatch surfaced three critical defects in
+the v1-draft design plus three significant phasing/compatibility
+issues. Critical findings summarised below; significant + observations
+unchanged from gate report.
+
+- **C1 — `take` CAS two-winner race under concurrent distinct
+  claimants.** Two-statement INSERT-then-recheck pattern broke
+  under WAL DEFERRED isolation. **Resolved by RF-9 absorption
+  (this revision):** schema collapses `tuples` + `tuple_claims`
+  into a single table with state columns; claim becomes
+  single-statement `UPDATE … RETURNING` atomic under SQLite's
+  single-writer lock. Append-only `tuple_claim_log` preserves
+  audit history. Honker's production reference confirms the
+  pattern.
+- **C2 — `locks/<resource>` mutual exclusion broken under
+  semantic-match.** Margin gate skipped for single-candidate
+  case; floor 0.95 over name-derived embeddings doesn't deliver
+  exact-match. **Pending fix in next revision.**
+- **C3 — `match_text` excluded from chash formula collapses
+  logically distinct tuples.** Two `out` calls with identical
+  content+dimensions but different `match_text` collide on tuple
+  ID; second's embedding silently discarded. **Pending fix in
+  next revision** (include `match_text` in canonical-bytes input
+  to `sha256`).
+
+Significant findings (S1: Phase 1 sequencing, S2: scratch wrapper
+ID format change, S3: "mirrors RDR-108" overstatement) and three
+observations remain pending.
+
+### Honker absorption 2026-05-09 — RF-9 + design revisions
+
+External prior art review (https://github.com/russellromney/honker)
+surfaced three patterns that materially improve v1:
+
+1. `PRAGMA data_version` polling enables blocking `take` without
+   long-poll infrastructure. `block`/`timeout_seconds` parameters
+   re-introduced on `take`; one watcher thread per `tuples.db`
+   connection drives a shared wake event. CPU cost: one integer
+   read per millisecond.
+2. Single-statement `UPDATE … RETURNING` claim resolves C1.
+   Schema collapses to one table with state columns plus an
+   append-only audit log. Working-set partial index keeps claim
+   performance bounded by active tuples, not history.
+3. Visibility timeout = lease (terminology equivalence noted).
+
+Implementation plan Step 4 expanded to include the
+`_TupleSpaceWatcher`. Step 5 sweep set extended with
+`sweep_claim_log`. References extended with honker reference.
+CA #1 status upgraded to Verified (source-search + production
+reference); new CA #6 added for `data_version` cost.
+
+### Gate-finding closeout 2026-05-09 (post-honker absorption)
+
+All Critical and Significant findings from the Layer 3 critique
+are now resolved in-document:
+
+- **C1 — `take` CAS race**: resolved by RF-9 honker absorption
+  (single-statement `UPDATE … RETURNING`; collapsed schema).
+- **C2 — locks mutex**: resolved. `take.mode: enum (semantic |
+  exact)` added to subspace schema. Locks subspace declares
+  `mode: exact` and bypasses chroma similarity entirely; SQL-only
+  candidate selection on `match_keys`. Take algorithm pseudocode
+  updated to branch on mode.
+- **C3 — match_text in chash**: resolved. Tuple ID formula
+  updated to `sha256(canonical(subspace + content + dimensions_json
+  + match_text_or_empty))[:32]`. Tuple-shape definition, Key
+  Discoveries entry, and §"Tuple ID formula" callout updated.
+- **S1 — Phase 1 sequencing**: resolved. Spikes lifted from
+  Step 12 to Step 7; agent-facing surfaces (Steps 8-12)
+  explicitly gated on spike clearance. Steps 8-12 cannot ship if
+  CA #2, #4, or #5 fail.
+- **S2 — scratch wrapper ID format change**: resolved. RF-7
+  amended with explicit carve-out: signatures and semantics hold,
+  ID format does not. CHANGELOG documents; `nx doctor
+  --check-tuplespace-migration` flags caller code that
+  pattern-matches against legacy ID format. Forwarding-table
+  alternative rejected with documented rationale.
+- **S3 — "mirrors RDR-108" overstatement + cross-tier dedup
+  semantics**: resolved. Existing Infrastructure Audit row
+  rewritten to "Follows the principle, not the formula" with
+  explicit namespace separation note. Key Discoveries entry on
+  RDR-108 also clarified. Cross-tier dedup explicitly scoped to
+  RDR-110 tuple-ID namespace only; chunk and tuple namespaces
+  never merge.
+- **O1 — confused-agent window**: resolved. Phase 1 Step 8
+  (coordination skills) now ships a forward-reference paragraph
+  in CONTEXT_PROTOCOL alongside the new skills, naming them and
+  pointing forward to the Phase 3 rewrite.
+- **O2 — spike test depth**: resolved. CA #2 (was CA #1.5 in
+  the prior numbering) added explicitly
+  for race-window-injection harness; Step 7 spike list updated
+  to require sleep injection between candidate-selection and
+  UPDATE.
+- **O3 — cross-tier dedup semantics**: resolved as part of S3
+  (namespace separation explicit; cross-tier dedup scoped to
+  RDR-110 namespace).
+
+### Re-gate Layer 3 critique 2026-05-09 — partial (1 critical, 3 significant, 2 observations)
+
+Re-gate verified all nine prior findings genuinely resolved;
+identified four new issues introduced by the fixes themselves.
+All four resolved in a follow-up pass:
+
+- **N-C1 — `LIMIT 1` in `UPDATE … RETURNING` requires non-default
+  SQLite compile flag** (`SQLITE_ENABLE_UPDATE_DELETE_LIMIT`,
+  not enabled in CPython stdlib `sqlite3`). **Resolved** by
+  rewriting the take's CAS UPDATE to use a portable subquery
+  form: `WHERE id = (SELECT id FROM tuples WHERE … ORDER BY …
+  LIMIT 1)`. `LIMIT` lives inside the SELECT (universally
+  supported); the outer UPDATE atomically claims that one row.
+- **N-S1 — `exact_match_sql`/`exact_match_args` unspecified;
+  potential SQL injection surface.** **Resolved** by replacing
+  the opaque method calls in the pseudocode with the explicit
+  pattern: `match_clause = " AND ".join(f"{k} = ?" for k in
+  schema.match_keys)`, `match_values = tuple(where[k] for k in
+  schema.match_keys)`. Column names come from the registered
+  `match_keys` (controlled at schema-load), not caller input.
+  Validation that all match_keys are present is explicit. No
+  injection surface; no undocumented helper methods.
+- **N-S2 — `acked_at`/`nacked_at` referenced inconsistently
+  with the new schema.** **Resolved** by clarifying that ack/nack
+  are captured as `tuple_claim_log` transitions
+  (`transition='ack'` / `transition='nack'`), not as columns on
+  `tuples`. Tuples table tombstones via `consumed_at` +
+  `consumed_by` only. Test plan updated to read from
+  `tuple_claim_log` for ack/nack verification.
+- **N-S3 — stale "Briefly Rejected" entry for `block=True`
+  contradicts shipped design.** **Resolved** by rewriting the
+  bullet to record both the original rejection reasoning and the
+  RF-9 reversal, with a forward reference to the honker absorption.
+
+**Re-gate observations (also resolved):**
+
+- **N-O1 — CA #1.5 not in numbered Critical Assumptions
+  section.** Resolved by renumbering: prior CA #1.5 → CA #2;
+  prior CA #2/#3/#4/#5 → CA #3/#4/#5/#6. All cross-references
+  throughout the document (Step 7 spike list, Test Plan,
+  Concurrency tests, Validation, Revision History) updated.
+- **N-O2 — Two stale `tuple_claims` references survived the C1
+  schema collapse** (tier-routing table + Existing
+  Infrastructure Audit row). Both updated to reflect the
+  collapsed schema.
+
+### Third Layer 3 critique 2026-05-09 — partial (0 critical, 1 significant, 0 observations)
+
+Single Significant: RF-9 prose at lines 619-647 still showed the
+non-portable `RETURNING id LIMIT 1` directly inside the UPDATE
+clause, contradicting the corrected subquery pseudocode at
+lines 970-990. **Resolved** by rewriting the RF-9 narrative
+bullet to use the portable subquery form
+(`WHERE id = (SELECT id … LIMIT 1) RETURNING id`) with explicit
+portability rationale referencing CPython's stdlib `sqlite3`
+build configuration.
+
+### Fourth Layer 3 critique 2026-05-09 — PASSED (0/0/0)
+
+Verdict: justified. Zero critical, zero significant, zero
+observations. RF-9 prose verified to use the portable subquery
+form with explicit portability rationale inline. Pseudocode
+consistent. No stale outer-UPDATE `LIMIT 1` form survives
+anywhere in the document. End-to-end coherence across all four
+revision rounds verified. Total findings closed across four
+passes: 16 (3 critical → 0; 7 significant → 0; 6 observations →
+0). RDR-110 ready for `/nx:rdr-accept`.
+
+### Post-acceptance cross-reference 2026-05-12 — RDR-112 (Storage-as-Service)
+
+RDR-110's atomic-take primitive is built on SQLite WAL multi-process
+safety (Critical Assumptions #1 and #2, both Verified for the
+same-host POSIX-filesystem case). RDR-112 (draft 2026-05-12) found
+this guarantee **does not extend across container overlayfs bind
+mounts** — WAL requires `mmap` semantics that overlayfs blocks, so
+a SQLite handle opened from inside a container against a host-mounted
+path forks into a per-container WAL. The Linda `in` primitive
+would silently break (or worse, silently double-claim) in that
+configuration.
+
+**This does not invalidate RDR-110.** The atomic-take CAS primitive
+itself is correct; only its *call site* shifts. Under RDR-112, T2 is
+owned by `nx daemon t2` (single process, single SQLite handle,
+single WAL — exactly the configuration RDR-110's CAs assume).
+Containerised clients call atomic-take via UDS/TCP RPC to the
+daemon; the daemon executes the same
+`UPDATE … RETURNING … WHERE id = (SELECT id … LIMIT 1)`
+pattern against its local handle. The CAS is unchanged.
+
+**Sequencing implication for planning**: RDR-110's planning chain
+has two ordering options.
+
+1. **Ship 110 first against direct-file T2** (current `T2Database`
+   facade). Same-host atomic-take works immediately. RDR-112's
+   daemon later wraps the existing CAS as an RPC; call sites
+   move from `T2Database.take(...)` to `T2Client.take(...)` with
+   no semantic change.
+2. **Sequence 112's daemon before 110's atomic-take call sites**
+   so the call sites are written once.
+
+**Original preference (2026-05-12, since revised)**: Option 1. The
+CAS primitive is independent of where it runs; the daemon is a
+transport wrapper, not a redesign.
+
+**Revised preference (2026-05-13, RDR-112 gate round 2)**: a
+hybrid is required for the `block=True` path. RDR-112 gate
+round 1 surfaced that the `data_version`-polling mechanism in
+§RF-9 / §CA #6 — which underwrites `block=True` cross-process
+wake — depends on the same `mmap` semantics that RDR-112 §A2
+verified are broken across container overlayfs bind mounts.
+
+**Further-revised scope (2026-05-13, RDR-110/111/112 triad
+analysis)**: the round-2 carve-out was too narrow. The overlayfs
+`mmap` failure is a **class** of bug, not specifically about
+`data_version`. SQLite's single-writer lock — the foundation of
+*every* RDR-110 operation, including the `block=False` CAS at
+§RF-9 — relies on the same `mmap` semantics. Across overlayfs
+bind mounts, two containers each open their own SQLite handle
+that resolves to a forked WAL with its own single-writer lock.
+**Two `block=False` claimants in different containers can both
+win the CAS.** Sweeps (`sweep_expired_claims`,
+`sweep_tombstones`) run against each container's forked WAL and
+produce inconsistent tombstones. The `tuple_claim_log` audit
+captures only its container's view.
+
+**Definitive ordering (D3 from the triad rework)**:
+
+- **Single-host, single-filesystem** (no container boundaries):
+  direct-file T2 access is correct for both `block=False` and
+  `block=True`. CA #1, CA #2, CA #5, CA #6 hold as Verified for
+  this scope only.
+- **Multi-container or any deployment that crosses an overlayfs
+  bind mount**: all RDR-110 operations require
+  `NX_STORAGE_MODE=daemon`. The daemon owns the single SQLite
+  handle (single lock, single WAL, single `data_version`), and
+  clients call atomic-take / sweep / audit via RPC. `block=True`
+  is implemented daemon-side as a blocking-take RPC.
+- **Phase 1 Step 4** ships the CAS implementation and the
+  same-host watcher as designed. The `block=True` call sites
+  land feature-flagged off until `NX_STORAGE_MODE=daemon` is
+  available; `block=False` ships unconditionally and is correct
+  same-host. **Multi-container deployments must run in daemon
+  mode regardless of `block` value.**
+
+The CAS primitive itself is unchanged in any path; only the
+container-vs-daemon boundary determines correctness.
+
+**No changes to RDR-110's design surface.** `related_rdrs`
+frontmatter includes RDR-112; this revision-history note
+records the cross-reference and the full sequencing constraint.
+
+### 5x5 alignment pass 2026-05-13
+
+After RDR-111 (PASSED R9), RDR-112 (PASSED light re-gate), and
+RDR-113 (PASSED R1) all completed their gates, a focused
+critic alignment check (`a25b97d1aac1d8523`) flagged one
+significant + three observations against RDR-110. Closeouts in
+this revision (no design-surface change; record-keeping only):
+
+- **S** (significant): Technical Design `data_version` polling
+  thread description (lines ~1025) and Implementation Plan
+  Step 4 watcher description (lines ~1368) said the
+  `_TupleSpaceWatcher` runs in-process against `tuples.db` —
+  correct in `NX_STORAGE_MODE=direct`, but under
+  `NX_STORAGE_MODE=daemon` (RDR-112) the watcher is
+  daemon-internal and clients subscribe via the daemon's
+  `EventStream` / blocking-take RPCs. Holding a client-side
+  `tuples.db` connection in daemon mode is forbidden by
+  `nx doctor --check-storage-boundary` (RDR-112 §5 lint).
+  Both sites now carry a "Mode split — daemon vs direct"
+  note pointing at RDR-112 Approach §7 and §A2. The
+  in-process watcher path remains correct as the direct-mode
+  implementation; daemon-mode adds the RPC indirection.
+- **O1**: Frontmatter `related_rdrs` did not include RDR-113.
+  Added.
+- **O2**: Body prose had no cite for RDR-113's host-trust
+  model on `mailbox/<agent>` and other agent-private
+  subspaces. Added a paragraph in §Cross-Cutting Concerns
+  §Secret/credential lifecycle naming RDR-113 as the trust
+  boundary under daemon mode.
+- **O3**: (RDR-111 Proposed Solution panel descriptions had
+  stale "same process, direct SQL appropriate" justification
+  — fixed in RDR-111 alongside this RDR's edits, not in
+  RDR-110.)
+
+No re-gate required — these are documentation-tracking
+corrections, not design changes.

--- a/docs/rdr/rdr-111-orb-agentic-cockpit-substrate.md
+++ b/docs/rdr/rdr-111-orb-agentic-cockpit-substrate.md
@@ -1,0 +1,1196 @@
+---
+title: "The ORB: Observable Relay Bus — Hook Projection, Bindings, and C2 Cockpit Substrate"
+id: RDR-111
+type: Architecture
+status: scrapped
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-11
+accepted_date: 2026-05-13
+scrapped_date: 2026-05-19
+scrap_reason: "Part of the RDR-110/111/112/113/118/119 arc that bundled the storage-substrate split with new abstractions (tuplespace, ORB cockpit, host-trust, surfaces-as-tuples, UI fabric). Scope discipline failed across nine RDRs and 67 stranded beads. Substrate work continues under RDR-120 with an explicit moratorium on co-shipped consumers; cockpit/ORB work, if revived, files a separate post-substrate RDR. Postmortem: docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md."
+related_issues: []
+related_rdrs: [RDR-105, RDR-110, RDR-112, RDR-113, RDR-120]
+related_tests: []
+implementation_notes: ""
+---
+
+> **TOMBSTONE 2026-05-19.** This RDR is preserved as historical reference. The arc was scrapped due to scope entanglement; see frontmatter `scrap_reason` and the [postmortem](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work: [RDR-120](rdr-120-storage-substrate-split.md). Do not implement against this design.
+
+---
+
+
+# RDR-111: The ORB: Observable Relay Bus — Hook Projection, Bindings, and C2 Cockpit Substrate
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+The agentic harness ships a remarkably complete coordination
+substrate — hooks at every lifecycle point (`PreToolUse`,
+`PostToolUse`, `Stop`, `SubagentStop`, `SessionStart`, `SessionEnd`,
+`UserPromptSubmit`, `PreCompact`, `Notification`), background
+supervision, inter-agent messaging, scheduled wakeups, worktree
+isolation, permission modes, and MCP server composition. But these
+capabilities are **opaque by default**. An agent runs; things happen;
+the user has no situational awareness unless they inspect tool output
+line by line. The hook bus fires but its events vanish. Coordination
+state — which agent holds what resource, what tasks are in flight,
+what just completed — is invisible unless each agent individually
+surfaces it, in ad-hoc ways, with no shared model.
+
+Three concrete gaps:
+
+### Gap 1: Hook events are fire-and-forget, not observable state
+
+`PreToolUse` and its siblings fire a shell script or nothing.
+There is no mechanism to observe these events as data — to query
+them, subscribe to them, aggregate them, or react to them
+declaratively. The hook bus is the right shape for an event
+backbone; it is wired to exactly one consumer (the script) and
+exposes nothing to other actors or surfaces.
+
+### Gap 2: No user-authored composition layer
+
+There is no way for a user — or an LLM acting on the user's behalf
+— to say "when event X happens, do Y and show Z." Reactions to
+events are hard-coded in hooks or in agent prompts. The composition
+is in code, not in data. Adding a new reaction requires a code
+change. Removing one requires finding it. There is no management
+surface, no toggle, no profile.
+
+### Gap 3: No situational awareness surface
+
+There is no panel, status line, or ambient display that answers
+"what is running right now, what does it hold, what just happened."
+The user context-switches between terminal windows, reads raw
+output, and loses track of what each background agent is doing.
+The cockpit metaphor is exactly right: this is a cockpit with no
+instruments.
+
+The ORB addresses all three gaps with minimal new mechanism,
+leveraging the semantic tuple space (RDR-110) as the backbone.
+
+## Context
+
+### The two architectural moves (from `docs/agentic-cockpit.md`)
+
+The design exploration in `docs/agentic-cockpit.md` identifies two
+load-bearing moves that turn the latent substrate into a C2 cockpit:
+
+**Move 1** — The RDR-110 semantic tuple space is the common
+coordination model. Everything that wants to coordinate uses it as a
+switchboard, not a bandwidth medium. Tuples describe state, declare
+connections, claim resources, and post milestones. Actual payload
+flows on direct peer-to-peer connections brokered by manifest tuples.
+
+**Move 2** — Hook events are projected into the tuple space as
+semantically-typed tuples (semantic events), making them composable,
+queryable, and addressable by intent. These are milestones —
+`PreToolUse` fires once per tool call, producing one tuple, not one
+per stdout byte. Granularity is the discipline.
+
+The ORB is the implementation of Move 2, built on the foundation of
+Move 1 (RDR-110). Three independently shippable pieces:
+
+1. **Hook → tuple bridge.** A hook adapter that projects each harness
+   lifecycle event into the tuple space as a typed semantic event.
+2. **Bindings primitive.** A tuple type that encodes a declarative
+   trigger/action/surface triple, plus CRUD management.
+3. **C2 cockpit surfaces.** Three minimal panels that make the
+   substrate visible: active claims, recent events, active bindings.
+
+### Prior art grounding
+
+- **Linda tuple spaces** (Gelernter & Carriero, 1986): `out`/`in`/`rd`
+  as the coordination primitives. RDR-110 provides these (as `out`/
+  `take`/`read`); the ORB uses `out` for event projection and `read`
+  for subscription.
+- **Blackboard architectures** (Hayes-Roth et al., Hearsay-II, 1970s):
+  specialists post hypotheses to a shared knowledge base; others
+  refine. Each actor in the system — LLM, user, surface, background
+  worker — is a specialist on the blackboard.
+- **WeakAuras** (WoW addons, 2004–): the richest consumer-grade example
+  of cooperating active surfaces over shared world-state. A
+  declarative trigger/display/action triple, user-authored without
+  code. The existence proof that this pattern is learnable.
+- **Bakke, Karger & Miller** (InfoVis 2013): automatic layout of
+  structured hierarchical reports via schema-driven hybrid layouts.
+  The binding-type registry is the stylesheet; layout decisions are
+  per schema node, applied uniformly to every instance.
+- **SCADA / DCS / mission control** (1960s–): tag-based data models,
+  alarm systems, runbook integration. The dashboards that don't suck.
+- **SIP/WebRTC signaling**: the connection manifest pattern —
+  signaling brokers connections without carrying the payload. Manifest
+  tuples declare direct peer-to-peer streams; nexus tracks the
+  lifecycle without seeing the data.
+
+### Relationship to RDR-110
+
+RDR-110 ships the tuple space primitive: `out`/`read`/`take`/`ack`/
+`nack`, the claim ledger, the subspace registry, five canonical
+subspaces, and the four-consumer landing surface. The ORB extends
+the subspace registry with seven new subspace types (semantic event
+types from the hook bus), adds the `bindings`, `layout_state`, and
+`connection_manifest` subspaces. The ORB's surfaces consume the tuple
+space via `read` queries; they do not require new storage.
+
+RDR-111 is **blocked on RDR-110 Phase 1 Step 4** (core API + MCP
+tools). The hook bridge needs `out`; the cockpit panels need `read`.
+
+**API name mapping** (Linda academic terms → RDR-110 concrete API):
+
+| Linda | RDR-110 | Notes |
+|-------|---------|-------|
+| `out` | `out` | identical |
+| `rd` / read-without-consuming | `read` | pattern-match query; tuple stays |
+| `in` / read-and-consume | `take` | atomic claim + consume |
+
+Linda terminology (`rd`, `in`) is used in prior-art and conceptual
+sections of this RDR. Implementation-facing sections use the RDR-110
+names (`read`, `take`).
+
+**RDR-110 coordination required (CA-9)**: The ORB's seven hook-event
+subspaces and `bindings/<profile>` subspace must be registered in
+RDR-110's subspace registry (the YAML subspace registry defined in
+RDR-110 Phase 1 Step 6). This RDR adds entries to that registry; the
+RDR-110 implementation must expose a registration mechanism for
+third-party subspaces (i.e., subspaces not defined in RDR-110 itself).
+This is a **definitive prerequisite** (CA-9), not a conditional: the
+RDR-110 implementor must be notified before Phase 1 Step 6 ships so
+that open registration is included in scope. Without this, the ORB's
+Phase 1 Step 1 (hook-event subspace schema registration) cannot proceed.
+
+### Relationship to RDR-112
+
+RDR-112 ships the storage-as-service daemons that own `tuples.db`,
+`memory.db`, the T3 chroma store, and CatalogDB. Under RDR-112 the
+MCP server is a **client** of the daemons, not the daemon itself —
+the ORB's `_BindingWatcher` and cockpit surface code all run in the
+client process and reach storage exclusively through daemon RPCs.
+
+Specific RDR-112 surfaces RDR-111 consumes:
+
+- **`EventStream(subspace_prefix, since_cursor)`** streaming RPC
+  (RDR-112 Approach §7) — `_BindingWatcher` consumes
+  `tuples/<subspace>` events instead of the direct-SQL `rowid > N`
+  query the pre-rework draft used. The `rowid` cursor protocol is
+  preserved as the wire-level cursor; only the transport changes.
+- **Failure-category demux** on the event stream (`category ∈
+  {data, schema, substrate}`, per RDR-112 §7) — `_BindingWatcher`'s
+  failure-isolation logic depends on this to avoid auto-disabling
+  user bindings when the daemon hiccups (see §Step 6 Watcher
+  failure isolation).
+- **Subspace registry validation is daemon-side** (RDR-112 Approach
+  §8) — the ORB-supplied subspaces (per CA-9) land via
+  `nx daemon t2 subspace add <yaml>` rather than client-side
+  runtime registration.
+- **Migration ownership is daemon-side** (RDR-112 Approach §9) —
+  the `watcher_state` table and the `action_idempotency` table are
+  applied by the daemon at startup, not by the MCP client (CA-10
+  language adjusted accordingly in the gate revision).
+- **Cockpit panel direct-SQL queries** (Steps 8 + 9 + the
+  active-claims and recent-events surfaces) — under RDR-112 these
+  re-route through daemon read RPCs (or the introspection surface
+  `nx daemon t2 exec --raw` for ad-hoc analytical queries; see
+  RDR-112 §Nexus-in-its-own-container). The query shapes are
+  unchanged; only the substrate boundary moves.
+- **Host-trust model** is inherited from RDR-113 (UDS chmod, peer
+  credentials, single-user v1). Cockpit projections respect the
+  same trust boundary as every other daemon client — only the
+  daemon-owner UID sees other-agent tuples and mailbox traffic.
+
+RDR-111 is **blocked on RDR-112 Phase 1** (T2 daemon with
+EventStream RPC) for the binding-watcher pieces. The cockpit
+surfaces that only query (not subscribe) can ship earlier against
+the daemon's read RPCs.
+
+## Research Findings
+
+### Investigation
+
+Structural analysis of the harness hook contract, the RDR-110 API
+surface, and the `docs/agentic-cockpit.md` design exploration. The
+findings below are verified against those sources.
+
+### Key Discoveries
+
+- **Verified** — The harness hook contract is stable and machine-
+  readable. Each hook fires with a well-defined JSON payload; the
+  mapping to a semantic event tuple is mechanical and ~100 LoC.
+  The hook adapter is additive — no existing hook handler changes.
+- **Verified** — A binding is a tuple type: trigger template (a
+  subspace query + optional structural filters), action descriptor
+  (tool call, tuple post, `SendMessage`, or workflow ref), surface
+  descriptor (level + payload shape + optional stream endpoint).
+  Bindings are managed via `out`/`take` on a `bindings/<profile>`
+  subspace. No new storage required.
+- **Verified** — The three minimum cockpit panels (active claims,
+  recent events, active bindings) are each a single `read` query over
+  the tuple space with a light formatting layer. No new primitives.
+  A tmux pane or ext-apps iframe rendering the query result is the
+  fulfillment layer.
+- **Verified** — Control plane / data plane separation is the load-
+  bearing discipline. Tuples describe and broker connections; they do
+  not carry payload. A `connection_manifest` tuple declares a direct
+  peer-to-peer stream (SSE, WebSocket, pipe, file-fd); the actual
+  bandwidth flows between peers without touching nexus. This keeps
+  nexus as a switchboard, never a bottleneck.
+- **Verified** — The auto-layout engine (Bakke's Measure /
+  Auto-Style / Layout pipeline, adapted for live event streams) sits
+  on the binding-type registry. Layout disposition is a property of
+  the registered event type, not of individual event tuples. Online
+  re-layout, temporal decay, priority preemption, and the
+  horizontal-budget demotion cascade are the four extensions the
+  static-report algorithm needs for the dynamic case.
+- **Revised** — Cross-instance liveness must use **T2 (SQLite),
+  not the tuple space**. The tuple space is scoped to a single
+  `nx-mcp` process (T1 or the process's local SQLite shard); a
+  tuple posted by one process is not visible to another process's
+  `read` query unless the tuple space itself has a cross-process
+  backend (which RDR-110 does not provide in Phase 1). Per RDR-105,
+  T2 (SQLite WAL mode) is the defined cross-process shared bus.
+  The correct implementation: a `liveness` table in the T2 SQLite
+  database with `(pid, machine, user, session, project,
+  focus, activity_summary, last_seen)`, upserted every 30s by
+  each `nx-mcp` process and swept by a background thread for rows
+  where `last_seen < now - 60s`. `nx instances` queries this
+  T2 table directly. This adds ~80 LoC (T2 schema migration +
+  upsert + sweep + CLI command), slightly more than the 50 LoC
+  originally estimated for the tuple-space approach.
+
+### Research Finding RF-1: Hook payload shapes — verified inventory
+
+Sourced from `nx/hooks/scripts/`, `tests/hooks/`, and the LangSmith Claude Agent SDK
+integration (`_hooks.py`). All fields below are verified against production code or
+test fixtures. Fields marked `[inferred]` are from community documentation and GitHub
+issues; no production hook in this repo reads them yet.
+
+**Common base fields** (present in all or most hook types):
+`session_id`, `hook_event_name`, `transcript_path` (path to JSONL), `cwd`
+
+| Hook type | Additional stdin fields | Output contract |
+|---|---|---|
+| `PreToolUse` | `tool_name`, `tool_input` (object with tool args, e.g. `command`, `file_path`) | **Required**: `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"\|"block", "additionalContext": "..."}}` — malformed output blocks tool calls |
+| `PostToolUse` | `tool_name`, `tool_input`, `tool_response` (tool output, any JSON type) | `{"hookSpecificOutput": {"hookEventName": "PostToolUse", "permissionDecision": "allow", "additionalContext": "..."}}` — advisory, never blocks |
+| `PermissionRequest` | `tool_name` | **Required**: `{"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": {"behavior": "allow"}}}` — malformed output blocks tool |
+| `Stop` | `stop_hook_active` (bool) | `{"decision": "approve", "reason": "..."}` — top-level `decision`, NOT `hookSpecificOutput` |
+| `StopFailure` | `error` (type string: rate_limit \| authentication_failed \| billing_error \| invalid_request \| server_error \| max_output_tokens \| unknown), `error_details` (string), `last_assistant_message` | Output **ignored** by harness; side-effects only |
+| `SubagentStart` | `task` (description), `prompt` (agent prompt text) | `{"hookSpecificOutput": {"hookEventName": "SubagentStart", "additionalContext": "..."}}` — injected into subagent context |
+| `SubagentStop` | `stop_hook_active` (bool), `permission_mode` [inferred] | `{"hookSpecificOutput": {"decision": {"behavior": "allow"\|"stop"}}}` [inferred] |
+| `SessionStart` | `claude_session_id` (UUID string) | Raw text/markdown — injected into Claude's context window |
+| `SessionEnd` | (no type-specific fields beyond base) | Output ignored; side-effects only |
+| `PostCompact` | `trigger` ("manual"\|"auto"), `compact_summary` (text), `permission_mode` | Raw text/markdown — injected into Claude's context window |
+| `PreCompact` | `trigger` ("manual"\|"auto"), `compact_summary`, `estimated_tokens`, `token_limit` [inferred] | Output ignored (`hooks.json` has empty `[]` for this type — not currently used) |
+| `UserPromptSubmit` | `prompt` (the user's message text) [inferred] | `{"hookSpecificOutput": {"decision": {"behavior": "allow"\|"stop"}}}` [inferred] |
+| `Notification` | `message`, `notification_type` [inferred] | Output ignored (informational only) |
+
+**Critical output divergence** (`Stop` vs `PreToolUse`): `Stop` uses top-level `{"decision":
+"approve"}` while `PreToolUse` uses `{"hookSpecificOutput": {"permissionDecision":
+"allow"}}`. These are **not interchangeable**. Each per-hook-type bridge script must
+emit exactly the contract for its hook type.
+
+**Gap note**: `SubagentStop`, `UserPromptSubmit`, `PreCompact`, and `Notification` payload
+shapes are partially inferred from community docs and GitHub issues (no production script
+in this repo reads them). CA-6 below gates on empirical verification before the bridge
+scripts for these types are written.
+
+**Implication for CA-2**: The hook payload shape is clear and already depended upon by
+multiple production hook scripts for the 9 verified types. CA-2 is substantially
+de-risked for those types; the bridge mapping table can be written today for them.
+
+### Research Finding RF-2: Hook output semantics vary by type — bridge must be transparent
+
+This is a critical design constraint not surfaced in the original draft.
+
+Hook scripts that respond with `hookSpecificOutput` JSON **affect Claude's behaviour**:
+
+- `PreToolUse` response: `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"|"block", "additionalContext": "..."}}`
+  — if the bridge outputs malformed JSON here, tool calls are blocked.
+- `PermissionRequest` response: same shape with `permissionDecision`.
+- `SubagentStart` response: `{"hookSpecificOutput": {"hookEventName": "SubagentStart", "additionalContext": "..."}}` — injects content into the subagent's initial context.
+- `Stop` / `StopFailure`: output and exit codes are **ignored** by the harness.
+- `SessionStart` / `SessionEnd`: output is injected as context; exit code matters.
+
+**Design correction**: The bridge cannot simply write to stdout for all hook types.
+For hooks with decision semantics (`PreToolUse`, `PermissionRequest`), the bridge must
+emit a permissive `hookSpecificOutput` JSON (pass-through allow) while posting the
+tuple as a side effect. For `SubagentStart`, it must either emit no stdout (to avoid
+interfering with the context-injection chain) or be registered *before* the existing
+hook so the existing hook's `additionalContext` arrives last. The safest shape:
+
+```python
+# For PreToolUse / PermissionRequest:
+import json, sys
+payload = json.loads(sys.stdin.read())
+out_to_tuple_space(payload)   # side effect only; errors caught and logged
+# emit transparent allow — never block on bridge failure
+print(json.dumps({"hookSpecificOutput": {
+    "hookEventName": payload.get("hookEventName", "PreToolUse"),
+    "permissionDecision": "allow"
+}}))
+sys.exit(0)
+
+# For Stop / StopFailure / SessionEnd:
+out_to_tuple_space(payload)
+sys.exit(0)  # no stdout needed
+```
+
+This constraint affects the bridge architecture: it is **not** a single handler
+for all hook types, but a **family of thin per-hook-type scripts**, each with the
+correct output contract, all sharing the `out` call.
+
+### Research Finding RF-3: Hook chaining is already in use — bridge is additive
+
+`nx/hooks/hooks.json` shows multiple hooks registered per event type (e.g.,
+`SessionStart` chains 6 commands). The bridge adds one more entry per type.
+Hook chaining has no ordering guarantee across entries at the same level, but
+output from all entries is collected. **The bridge must never be the last
+`PreToolUse` handler that determines the allow/block decision** — register it
+first in the chain, emit `allow`, and let the existing decision hooks follow.
+
+### Research Finding RF-4: No existing tmux surface integration — genuinely new territory
+
+Searching the codebase (`find + grep tmux`) shows tmux references only in:
+- E2E test runner scripts (`tests/e2e/*.sh`) — use tmux to drive test scenarios
+- Documentation (`docs/agentic-cockpit.md`, `rdr-111`) — design only
+
+There is no existing `status-right` update path, no pane management code, no
+tmux IPC in any Python source. The tmux fulfillment adapter is net-new code with
+no prior art to reuse within the repo. CA-4 (tmux refresh cadence) remains
+spike-gated and unverified.
+
+### Research Finding RF-5: `CLAUDECODE=1` env var gates production side-effects
+
+Existing hooks (`stop_failure_hook.py`) skip side-effects unless `CLAUDECODE=1`
+is set. The bridge should follow the same pattern: if `CLAUDECODE` is not set,
+skip the `out` call and exit 0 silently. This makes the bridge safe to invoke
+in test harnesses, linting, and local dev without polluting the tuple space.
+
+### Critical Assumptions
+
+| # | Assumption | Status | How to verify | Risk if wrong | Phase gate |
+|---|---|---|---|---|---|
+| CA-1 | RDR-110 Phase 1 Step 4 ships before this RDR begins implementation | Open | RDR-110 status check | Blocked; cannot proceed | P1 |
+| CA-2 | Hook payload JSON for the 9 verified hook types is stable across harness versions | **De-risked (RF-1)** | Schema validated against production scripts; 4 types (`SubagentStop`, `UserPromptSubmit`, `PreCompact`, `Notification`) still require empirical verification (CA-6) | Low for verified types; medium for inferred types | P1 |
+| CA-3 | `read` query latency over T2 is < 50ms at 10k tuples | Open | Benchmark after RDR-110 ships | Panel refresh sluggish; may need materialised view | **P2 gate** |
+| CA-4 | tmux `status-right` update at 1-2s cadence has no perceptible lag | Open | Manual test on target hardware | Increase to 5s cadence + stale indicator | **P3 gate** |
+| CA-5 | Binding reaction end-to-end < 200ms at 10 concurrent active bindings | Open | Benchmark after bridge + watcher ship | Move watcher to dedicated process | **P2 gate** |
+| CA-6 | `SubagentStop`, `UserPromptSubmit`, `PreCompact`, `Notification` payload shapes match inferred schemas | Open — **spike required before bridge scripts for these types are written** | Register a minimal logging hook for each type; capture real payload from a live session; compare against RF-1 table. Spike ≤ 2h. | Bridge scripts emit wrong field names → tuples have missing/null dimensions | P1 (bridge for these 4 types) |
+| CA-7 | The Bakke Measure/Auto-Style/Layout adaptation is ≤ 300 LoC and can be implemented by a single developer in < 1 week | Open — **novel work, no prior art in repo** | Prototype the three pipeline phases on a static binding set before committing to Phase 3 | Layout engine becomes the long pole; delays Phase 3 by 2–4 weeks | **P2 gate** |
+| CA-8 | Multi-`PreToolUse`-hook ordering: when two hooks are registered, the first-registered "allow" does not preempt subsequent hooks' ability to "block" | Open — **empirically unverified** | Run `tests/cc-validation/scenarios/` harness with two PreToolUse hooks: hook-A returns `allow`, hook-B returns `block`; observe which wins. See scenario 07 for PermissionRequest precedent. **Fallback design if first-wins confirmed**: the bridge cannot be registered first as an unconditional `allow` emitter without neutralising legitimate block hooks. Fallback: bridge registers as a *last* entry using a separate `PostToolUse`-adjacent hook that fires after the decision hooks have run, or bridge emits no `permissionDecision` key at all (only `additionalContext`) and relies on the harness's default allow. Fallback design must be documented before Phase 2. | Bridge registered first could silently neutralise a legitimate block hook; or a block hook registered first could stall the bridge chain | P1 (bridge registration ordering) |
+| CA-9 | RDR-110's subspace registry exposes a registration mechanism for third-party subspaces not defined in the canonical five, AND (per RDR-112 Approach §8) the T2 daemon validates subspace schemas daemon-side and accepts third-party registration via the `nx daemon t2 subspace add <yaml>` admin RPC | **Definitive prerequisite — must be flagged before RDR-110 Phase 1 Step 6 ships AND before RDR-112 daemon's admin RPC surface is locked** | Two coordinations required: (a) confirm that RDR-110 Phase 1 Step 6 ships with open registration (additional YAML dirs discoverable at startup), not a closed allow-list; AND (b) confirm that the RDR-112 T2 daemon implements the `subspace add` admin RPC and accepts the ORB-supplied YAML schemas. Both are required before ORB Phase 1 Step 1 can proceed. If RDR-110 ships closed-registry, an extension mechanism must be added before ORB Phase 1 Step 1. If the daemon admin RPC is missing, the ORB cannot register at runtime even with open-registry on the file side. | Without this, the seven hook-event subspaces and `bindings/<profile>` cannot be registered; the tuple space bridge is blocked | P1 |
+| CA-10 | The T2 daemon's startup migration sequence (per RDR-112 Approach §9, daemon is sole migration runner) includes the `watcher_state` table (see schema in Phase 2 Step 6) | **Coordination required before Phase 2 Step 6** | Notify RDR-112 implementor before the daemon migration manifest is finalised; confirm `watcher_state` DDL appears in the daemon's migration sequence and is applied before the daemon accepts client connections. Gate criterion: confirmed presence of `watcher_state` CREATE TABLE in the T2 daemon's migration manifest (post-RDR-112 rework — pre-rework draft pointed at RDR-110's migration file, which is no longer the migration owner). If the daemon migration ships without it, the ORB must ship an upgrade migration via the daemon's admin RPC (with schema-version guard) before Phase 2. | Phase 2 Step 6 fails at first run with "no such table: watcher_state" (now surfaced as a daemon RPC error, not a local sqlite3 error) | P2 |
+
+## Proposed Solution
+
+### The seven semantic event subspaces
+
+Seven new subspace YAML files in `nx/tuplespace/builtin/hooks/`:
+
+```
+hook_events/tool_call_intent      ← PreToolUse
+hook_events/tool_call_completed   ← PostToolUse
+hook_events/agent_completed       ← SubagentStop
+hook_events/assistant_turn_ended  ← Stop, StopFailure
+hook_events/user_prompt           ← UserPromptSubmit
+hook_events/session_lifecycle     ← SessionStart, SessionEnd
+hook_events/notification          ← Notification
+```
+
+Note: `PostCompact` is intentionally excluded — it fires after context is
+rebuilt and injecting a tuple at that point would be redundant (the compact
+summary is already injected into Claude's context window by the hook output).
+`PreCompact` is also excluded — its output is currently unused (empty `[]` in
+`hooks.json`). If either is needed in future, a new subspace can be added.
+`StopFailure` is merged into `assistant_turn_ended` (error variant) rather
+than given its own subspace, since both represent a session turn boundary.
+
+Each subspace schema carries:
+- Required dimensions: `actor`, `session`, `project`, `timestamp`
+- Optional dimensions: `tool`, `workflow`, `intent`, `priority`
+- `match_text` field: a short semantic description of the event
+  (e.g. "deployed frontend via k8s.apply") for associative query
+- Layout disposition: default surface level, decay profile,
+  priority class, `preempts` list
+
+### The hook → tuple bridge
+
+**Revised per RF-2**: not a single handler but a family of thin per-hook-type
+scripts in `nx/hooks/scripts/orb_bridge_*.py`, all sharing a common
+`src/nexus/cockpit/hook_bridge.py` library for the `out` call and
+mapping table.
+
+Each script:
+1. Reads hook payload JSON from stdin
+2. Maps to the appropriate subspace + dimensions + `match_text`
+3. Calls `out` on the tuple space (skipped if `CLAUDECODE` not set — RF-5)
+4. Emits the correct stdout for that hook type (RF-2):
+   - `PreToolUse` / `PermissionRequest`: emit transparent `allow` JSON
+   - `SubagentStart`: emit no stdout (bridge registered first; existing hook follows)
+   - `Stop` / `StopFailure` / `SessionEnd`: emit nothing
+5. Exits 0 unconditionally — bridge errors are logged to stderr, never propagated
+
+Registered in `nx/hooks/hooks.json` as the **first** entry for each hook type
+(before existing decision hooks) — **provisional pending CA-8 spike**. If the
+CA-8 spike (now gated before Step 2 — see Step 7a below) confirms first-wins
+semantics (i.e., the first hook's `allow` prevents subsequent hooks from
+blocking), registration must change to **last-in-chain** or the bridge must emit
+no `permissionDecision` key (only `additionalContext`). Step 2 implementation
+must use a feature flag or configuration entry for registration order so the
+CA-8 outcome can be applied without a code change. Default before CA-8 result:
+register first.
+
+Estimated: ~150 LoC in the shared library + ~20 LoC per hook-type script (7 types
+= ~140 LoC scripts). Total ~290 LoC. Larger than originally estimated due to
+per-type output contract requirements.
+
+### The bindings primitive
+
+A new subspace `bindings/<profile>` with schema:
+
+```yaml
+bindings:
+  dimensions:
+    - name: profile        # mission context name
+    - name: enabled        # true/false; default false during async creation
+    - name: status         # pending | active | failed (lifecycle for async binding_create)
+    - name: task_id        # UUID issued at binding_create time; used to poll creation progress
+    - name: priority       # integer, for demotion cascade ordering
+    - name: min_surface    # floor for demotion cascade
+  match_text_field: description
+  content_fields:
+    - trigger_subspace     # which subspace(s) to watch
+    - trigger_filters      # structural filter on the event tuple
+    - trigger_similarity   # optional semantic query for associative match
+    - action_type          # tool_call | tuple_out | send_message | workflow
+    - action_descriptor    # action-type-specific payload (must include idempotency_key)
+    - surface_level        # status-line | notification | panel | full-screen
+    - surface_payload      # how to render the event
+    - surface_stream       # optional: declare a connection_manifest instead
+```
+
+`task_id` is a registered dimension (not an MCP-layer side channel) so that callers can filter `binding_list(where={"task_id": "<uuid>"})` to check creation progress. `status` transitions: `pending` (background task running) → `active` (binding live, `_BindingWatcher` will match it) → `failed` (NLP parse or `out` call failed; error in `action_descriptor`). `enabled` starts `false` during async creation and is set to `true` atomically with the `pending → active` transition.
+
+CRUD operations: `out` to create/update, `take` to delete, `read` to list.
+A binding is enabled by setting `enabled=true`; disabled bindings are
+kept (tombstoned per RDR-106 pattern) rather than deleted.
+
+### The connection manifest subspace
+
+A new subspace `connection_manifest` for declaring direct peer-to-peer
+streams:
+
+```yaml
+connection_manifest:
+  dimensions:
+    - name: producer       # actor-id
+    - name: consumer       # actor-id or "any-subscriber"
+    - name: conn_type      # stream | pipe | websocket | sse | file-fd
+    - name: payload_type   # semantic type of the stream content
+    - name: ttl_seconds    # heartbeat interval; expired = teardown
+  content_fields:
+    - endpoint             # transport-specific address
+```
+
+Producer posts manifest after endpoint is ready. Consumer reads and
+connects directly. Heartbeats refresh the tuple's TTL via `out` with
+the same ID (idempotent). `take` or TTL expiry signals teardown.
+
+### The layout_state subspace
+
+A new subspace `layout_state/<profile>` for the auto-layout engine's
+stylesheet output. One tuple per binding-type (keyed by `event_type`
+and `profile`), written by the layout engine and read by all cockpit
+surfaces to know which slot and level to use for each event type.
+
+```yaml
+layout_state:
+  dimensions:
+    - name: profile        # mission context name
+    - name: event_type     # subspace path, e.g. hook_events/tool_call_intent
+  content_fields:
+    - surface_level        # status-line | notification | panel | full-screen
+    - demotion_level       # current effective level after cascade
+    - ttl_seconds          # on-screen display TTL for events of this type
+    - pinned               # bool; true = user override, skip auto-layout
+```
+
+The layout engine writes one `out` per event_type per profile per debounce
+window (250ms). Cockpit surfaces call `read(subspace="layout_state/<profile>")`
+to get the current stylesheet before rendering. Schema ships in Phase 1
+Step 1 alongside the hook-event subspace schemas (even though Step 11
+is Phase 3) so producers can register and write to it without waiting for
+the layout engine implementation.
+
+### The three minimum cockpit surfaces
+
+**Active-claims panel** — direct SQL query on `~/.config/nexus/tuples.db`
+(RDR-110's tuple-space database):
+
+```sql
+SELECT * FROM tuples
+WHERE claim_state = 'claimed'
+  AND claim_expires_at > unixepoch()
+ORDER BY claim_expires_at ASC;
+```
+
+Formatted as a table: actor (extracted via `json_extract(t.dimensions_json,
+'$.actor')` — `actor` is a registered dimension stored inside
+`dimensions_json`, not a top-level column on `tuples`), subspace, tuple
+summary, claimed_at (from `tuple_claim_log` via `JOIN tuple_claim_log tcl
+ON t.id = tcl.tuple_id WHERE tcl.transition = 'claim'`; `tuples` has no
+`claimed_at` column directly), TTL remaining
+(= `claim_expires_at - unixepoch()`). The expiry filter
+(`claim_expires_at > unixepoch()`) excludes expired leases not yet swept
+— without it, crashed-agent claims would appear as active until the next
+sweep. `claim_state` is an internal column on the `tuples` table (per
+RDR-110 claim ledger schema), not a registered dimension; it is not
+accessible via `read()` and must be queried directly. **Routing under
+RDR-112**: under `NX_STORAGE_MODE=daemon` (the supported deployment),
+the cockpit surface is a *client* of the T2 daemon — direct
+`sqlite3.connect(tuples.db)` from the cockpit client process is
+**forbidden** (RDR-112 §5 lint). The query shape above runs daemon-side
+via a dedicated read RPC or via `nx daemon t2 exec --raw` (RDR-112
+§Nexus-in-its-own-container introspection surface). See Implementation
+Plan Step 8 for the concrete call form. Rendered as a tmux pane or
+ext-apps iframe.
+
+**Recent-events panel** — direct SQL query on `~/.config/nexus/tuples.db`
+for time-ordered display (RDR-110's `read()` has no `sort_by` or
+`since_cursor` parameter — time ordering requires direct SQL):
+
+```sql
+SELECT * FROM tuples
+WHERE subspace LIKE 'hook_events/%'
+  AND created_at > unixepoch() - ?   -- decay_window from subspace registry
+ORDER BY created_at DESC
+LIMIT 50;
+```
+
+With temporal decay: events older than their subspace `decay_profile`
+window are excluded by the `created_at` filter. Supports structural
+filtering by `actor`, `session`, `project` dimensions (additional WHERE
+clauses). For semantic filtering by intent, call `read()` on the
+subspace with a query string, then display results sorted client-side by
+the `timestamp` dimension (required on all hook-event subspaces — see
+schema above; `timestamp` is a registered dimension accessible in the
+`read()` response, unlike `created_at` which is an internal `tuples`
+table column not exposed by the API). This trades time-ordering guarantee
+for semantic relevance. The default display is SQL (time-ordered); semantic
+filter is an opt-in mode. **Routing under RDR-112**: same as the
+active-claims panel above — under daemon mode the cockpit is a daemon
+client; the query runs via a daemon read RPC or `nx daemon t2 exec
+--raw`. Direct `sqlite3.connect(tuples.db)` from the client process is
+forbidden (RDR-112 §5 lint). See Implementation Plan Step 9 for the
+concrete call form.
+
+**Active-bindings panel** — `read(subspace="bindings/<current_profile>",
+where={"enabled": "true"})`. Shows trigger, action, surface, enabled state.
+Toggle via `take` (remove) + `out` (re-post with `enabled` flipped). Edit
+via a form rendered in the panel itself.
+
+### The auto-layout engine
+
+A `src/nexus/cockpit/layout.py` module implementing the three phases:
+
+**Measure** — traverse the active binding set, read layout disposition
+from the subspace registry for each event type (surface level, decay
+profile, priority class, typical event rate).
+
+**Auto-Style** — produce a stylesheet tuple (one `out` to
+`layout_state/<profile>`): for each binding, which surface slot,
+which on-screen TTL, which demotion level. Respects the display budget
+(terminal width, active pane count) and mission-context profile.
+
+**Layout** — apply the stylesheet to actual events: render status line,
+populate panels, fire notifications, raise full-screen for checkpoints.
+
+The demotion cascade, applied when the display budget shrinks:
+```
+full-screen → panel → status-line → notification-only → suppressed
+```
+Per-binding `min_surface` prevents critical bindings from falling
+below their floor. Manual pin overrides auto-layout for that binding.
+
+**Write-storm guard**: the auto-layout engine must debounce its
+`layout_state/<profile>` tuple writes. Hook events may arrive in
+bursts (e.g., 10 `PostToolUse` events in < 100ms). A naive re-layout
+on every event would produce a write-per-event flood. The engine must
+batch events over a 250ms debounce window before re-running the
+Measure/Auto-Style/Layout pipeline. Only one `layout_state` write
+per debounce window is allowed.
+
+### Cross-instance liveness
+
+**Implementation: T2 table, not the tuple space.** Although project-tier
+T2 subspaces in RDR-110 are cross-process (SQLite WAL mode is multi-writer
+safe), raw T2 is the correct choice for liveness for three reasons: (a) no
+semantic matching is needed — liveness is a pure key-value keep-alive
+requiring only primary-key lookup by `(pid, machine)`; (b) no subspace
+schema registration overhead (liveness has no `match_text` or vector
+embedding); (c) no tombstone semantics — rows are hard-deleted on expiry,
+not soft-deleted with `data_version` ticks as required by the tuple space
+claim ledger. T2 (SQLite WAL, via `src/nexus/db/`) is the correct tier per
+RDR-105.
+
+T2 `liveness` table added via a new migration entry in
+`src/nexus/db/migrations.py` (actual migration number assigned at
+implementation time — add as the next integer after the current
+highest-numbered migration):
+
+```sql
+CREATE TABLE liveness (
+    pid          INTEGER NOT NULL,
+    machine      TEXT    NOT NULL,
+    user_id      TEXT    NOT NULL,
+    session      TEXT,
+    project      TEXT,
+    focus        TEXT,
+    activity     TEXT,
+    last_seen    REAL    NOT NULL,  -- epoch seconds
+    PRIMARY KEY (pid, machine)
+);
+```
+
+Each `nx-mcp` process upserts its row at startup and every 30s via the
+FastMCP lifespan background task (per RDR-094 pattern). A sweep thread
+deletes rows where `last_seen < epoch() - 60`. `nx instances` queries
+the T2 table directly and formats the result as a table.
+
+The `~/.config/nexus/t1_addr.<pid>` file mechanism (RDR-105) is
+retained for T1 bootstrap; `liveness` replaces it only for the
+cross-instance visibility use-case.
+
+## Alternatives Considered
+
+### A: Separate event store (not the tuple space)
+
+A dedicated SQLite table for hook events, separate from the tuple
+space. Rejected: the whole point is one query model for coordination
+metadata. A separate store means two mental models, two
+calibration stories, two debug surfaces. The tuple space is
+already the right shape.
+
+### B: Push notifications via the existing Notification hook
+
+Use `Notification` to push events to the user rather than projecting
+into the tuple space. Rejected: `Notification` is a one-way push to
+the current session. It has no queryability, no persistence, no
+subscription model. It is not composable. The ORB adds a composable
+layer; `Notification` remains a valid *sink* for a binding's action.
+
+### C: Separate binding engine process
+
+A dedicated process that watches the tuple space and dispatches
+binding reactions. Rejected for Phase 1: the hook bridge can dispatch
+binding reactions synchronously (or via a lightweight background
+thread) without a separate process. A separate process adds
+deployment complexity that isn't justified until binding volume or
+latency requirements force it.
+
+### D: Visual wiring UX (LabVIEW-style)
+
+A drag-and-drop wiring interface for bindings. Rejected as the entry
+point: form-based binding authoring is closer to what's been proven
+learnable (WeakAuras, Streamdeck plugins). Wiring may be useful for
+advanced users in a later phase but is not the starting point.
+
+## Trade-offs
+
+| Decision | Trade-off |
+|---|---|
+| Semantic events as tuples (not a separate event log) | One query model, one persistence story — but tuple space volume grows with hook frequency. Mitigated by per-subspace TTL/decay. |
+| Bindings dispatched in-process by the bridge | Simple, no extra process — but binding reaction latency is bounded by bridge execution time. A slow binding can delay the next hook. Mitigated by timeout on action dispatch. |
+| Auto-layout drives from the binding set, not from events | Layout is stable and predictable — but a binding with no recent events still occupies a layout slot. Mitigated by `decay_profile` on the registry entry. |
+| Connection manifests declared in the tuple space | Every direct connection is visible and debuggable — but manifest heartbeating adds a small overhead per active stream. Acceptable at expected connection counts. |
+| tmux as the first fulfillment target | Terminal users get the full cockpit immediately — but GUI (ext-apps iframe) and headless adapters are deferred. Each is ~200 LoC and independently shippable. |
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] RDR-110 Phase 1 Step 4 shipped (core API: `out`/`read`/`take`/
+      `ack`/`nack` as MCP tools, `data_version` watcher, `block`
+      support on `take`).
+- [ ] RDR-110 Phase 1 Step 5 shipped (periodic sweeps for TTL/tombstone
+      cleanup — required for liveness TTL and event decay to work).
+- [ ] RDR-110 Phase 1 Step 6 shipped (five canonical subspaces — the
+      `events/<topic>` and `locks/<resource>` patterns are prior art
+      for the new hook-event and bindings subspaces).
+
+### Phase 1: Hook bridge + seven event subspaces
+
+#### Step 1: Seven hook-event subspace schemas
+
+Add `nx/tuplespace/builtin/hooks/*.yml` with the seven hook-event subspace
+definitions, plus `nx/tuplespace/builtin/connection_manifest.yml` and
+`nx/tuplespace/builtin/layout_state.yml` (schema defined in Proposed
+Solution). Register layout disposition fields on each hook-event subspace
+(surface level, decay profile, priority class, `preempts` list).
+No code changes — schema-only. `layout_state` ships now so the layout
+engine (Step 11, Phase 3) can write to a registered subspace without a
+schema-migration step later.
+
+#### Step 1b: CA-8 spike (PreToolUse ordering — required before Step 2)
+
+Run the CA-8 multi-hook ordering experiment **before writing any bridge
+code**. Use the cc-validation harness pattern from
+`scenarios/07_perms_preempt_hook.sh`: register two PreToolUse hooks —
+bridge first (emits `allow`), then an existing decision hook (may emit
+`block`). Determine whether first-registered `allow` preempts the second
+hook's `block`, or all hooks run and the last `block` wins. Record the
+result in T2 (`111-ca8-spike-result`) and update Step 2's registration
+order accordingly before any bridge code is written. (≤ 1h)
+
+#### Step 2: Hook → tuple bridge
+
+`src/nexus/cockpit/hook_bridge.py`: reads hook payload from stdin,
+maps to subspace + dimensions + match_text, calls `out` via the
+MCP tool (or directly against the store if in-process), exits 0.
+Register in `nx/hooks/hooks.json` (the canonical hook registration
+location per RF-3) for the **seven projected hook types**: `PreToolUse`,
+`PostToolUse`, `Stop`/`StopFailure` (→ `assistant_turn_ended`),
+`SubagentStop`, `UserPromptSubmit`, `SessionStart`/`SessionEnd`
+(→ `session_lifecycle`), `Notification`. **Not registered**:
+`SubagentStart` (carries no semantic event worth projecting — the
+subagent's task description is already in the prompt),
+`PermissionRequest` (ephemeral permission handshake, no durable
+coordination state), `PreCompact` (output unused), and `PostCompact`
+(redundant with the compact summary already injected into context — see
+Proposed Solution, "The seven semantic event subspaces").
+
+Unit tests: mock `out`; assert correct subspace, dimensions, and
+match_text for each hook type. One test per hook type + one for
+malformed payload (must exit 0).
+
+#### Step 3: T2 liveness table + heartbeat
+
+Add `liveness` table via `src/nexus/db/migrations.py` migration (manages
+`~/.config/nexus/memory.db` — see schema above). Wire upsert into the
+`nx-mcp` FastMCP lifespan background task (startup upsert + 30s periodic
+upsert via `asyncio.create_task`, matching the pattern in RDR-094). Add
+sweep logic to delete stale rows (`last_seen < epoch() - 60`) in the
+same background task. Add `nx instances` CLI command: queries the
+`liveness` table in `memory.db` directly and formats as a table. No
+tuple-space subspace YAML required for liveness.
+
+Note: `watcher_state` (cursor table for `_BindingWatcher`) is added in
+`tuples.db` as part of the RDR-110 implementation (not here), so that the
+cursor and tuple reads are in the same database for genuine atomicity. See
+Phase 2 Step 6.
+
+### Phase 2: Bindings primitive
+
+#### Step 4: Bindings subspace schema
+
+Add `nx/tuplespace/builtin/bindings.yml`. Include all fields from
+the proposed solution above. Add `profile` as a first-class
+dimension so `read(subspace="bindings/<profile>")` is the query
+for the active profile's bindings.
+
+#### Step 5: Binding CRUD path + MCP tools
+
+`src/nexus/cockpit/bindings.py`: `binding_create`, `binding_list`,
+`binding_toggle`, `binding_delete`. Wire as four new MCP tools.
+`binding_create` **returns a `task_id` immediately** (async task
+pattern): it enqueues the binding creation work (NLP parse + `out` call)
+and returns `{"task_id": "<uuid>", "status": "pending"}` to the caller
+without waiting for completion. A background `asyncio.Task` does the
+actual work and updates the binding's `status` dimension from `pending`
+to `active` when done. This keeps `binding_create` non-blocking from
+the MCP caller's perspective. The LLM-assisted authoring path (calling
+`nx_answer` to parse a natural-language binding description into a
+structured tuple) runs inside this background task and is `await`-ed
+there. If `nx_answer` is currently synchronous, wrap it in
+`asyncio.run_in_executor` with a dedicated executor — do not block the
+MCP event loop. Callers poll status via `binding_list` filtering on
+`task_id` or register a binding-completion notification.
+
+#### Step 6: Binding reaction loop
+
+A `_BindingWatcher` background task (integrated with the FastMCP
+lifespan async task group per RDR-094; **must be `asyncio.create_task`,
+not `threading.Thread`** — the MCP server is async and thread-pool
+dispatch creates reentrancy risk) that consumes new events via the
+**RDR-112 daemon `EventStream` RPC** on the `tuples/<subspace>`
+namespace.
+
+**Retrieval mechanism — RDR-112 EventStream RPC**: under RDR-112 the
+T2 daemon owns the SQLite handle for `tuples.db`; the MCP server is a
+*client* of the daemon (RDR-112 §Proposed Solution §1 + Approach §7).
+Direct SQL access from inside `nx-mcp` is daemon-internal-only and
+forbidden to clients. The watcher subscribes via:
+
+```python
+# Pseudocode — verify signature during implementation.
+async for event in t2_client.event_stream(
+    subspace_prefix="tuples/<subspace>",
+    since_cursor=last_rowid,   # 0 on first connect; persisted across restarts
+):
+    # event = {cursor: rowid, subspace, op, payload_summary, category, ts}
+    ...
+```
+
+The daemon's EventStream RPC carries the same monotonic `rowid` cursor
+the original direct-SQL pattern used, so the at-least-once semantics
+(below) survive verbatim — only the transport changes. On disconnect,
+the watcher reconnects from its last-acked cursor. `EventStream` is the
+*only* way clients observe tuple changes; the RDR-110 `read()` API
+remains the surface for associative / structural queries by external
+callers.
+
+A `watcher_state` table records the per-subspace cursor (last-seen
+`rowid`). **Database placement**: `watcher_state` lives in `tuples.db`
+alongside the tuple data. Under RDR-112, this table is owned by the T2
+daemon (single SQLite handle); the client-side watcher reads and writes
+its cursor via a dedicated daemon RPC pair (`watcher_state.get`,
+`watcher_state.set`) rather than direct SQL. The schema (owned by
+RDR-110's tuple-space migration, applied daemon-side per RDR-112
+Approach §9):
+
+```sql
+-- in tuples.db migration (RDR-110 implementation, daemon-applied)
+CREATE TABLE IF NOT EXISTS watcher_state (
+    subspace   TEXT NOT NULL,
+    profile    TEXT NOT NULL,
+    last_rowid INTEGER NOT NULL DEFAULT 0,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (subspace, profile)
+);
+```
+
+**Cursor persistence and restart semantics** (required for correctness):
+
+- The watcher's cursor position (`rowid` of the last processed tuple)
+  is persisted to `watcher_state` (daemon-owned, accessed via
+  `t2_client.watcher_state_set` RPC) after every successfully
+  dispatched batch. The correct sequence is:
+
+  ```python
+  # 1. Receive events from the daemon's streaming RPC.
+  #    The stream yields events monotonically by rowid; the watcher's
+  #    cursor is the last rowid it has *successfully* dispatched and
+  #    acked.
+  async for event in t2_client.event_stream(
+      subspace_prefix=f"tuples/{subspace}",
+      since_cursor=cursor,
+  ):
+
+      # 2. Dispatch action — outside any cursor-advance RPC.
+      #    Dispatch is an async network call (tool_call / out /
+      #    send_message); the cursor RPC must not be entangled with
+      #    it because dispatch can fail or hang and we still need
+      #    deterministic cursor semantics.
+      await dispatch_action(event, idempotency_key=...)
+
+      # 3. Advance cursor via daemon RPC — separate, committed after
+      #    dispatch succeeds. The daemon performs the UPDATE
+      #    watcher_state internally; the client only names the new
+      #    rowid.
+      await t2_client.watcher_state_set(
+          subspace=subspace,
+          profile=profile,
+          last_rowid=event.rowid,
+      )
+  ```
+
+  Steps 2 and 3 are **not** in the same atomic RPC — they cannot be:
+  the dispatch is an async network call to a different target
+  (tool / out / send_message). The delivery guarantee is
+  **at-least-once**: if the watcher crashes between step 2 and
+  step 3, the event is replayed on restart from the last-acked
+  cursor (`watcher_state.last_rowid`, fetched on reconnect via
+  `t2_client.watcher_state_get`). The `idempotency_key` mechanism in
+  the action descriptor handles duplicate deliveries.
+
+  `watcher_state` and `tuples` are in the same database (`tuples.db`)
+  daemon-side, which lets the daemon implement the cursor RPC against
+  the same connection it serves event-stream reads from — but the
+  client never holds a `tuples.db` connection.
+- **Delivery guarantee: at-least-once.** The cursor advances only
+  after the action is dispatched (not before). Duplicate deliveries
+  are possible on crash-restart. Actions must therefore be idempotent:
+  the `action_descriptor` schema must include an `idempotency_key`
+  field (e.g. `sha256(binding_id + event_tuple_id)`); action handlers
+  must be no-ops if the key has been seen in a T2 dedup table within
+  the action's TTL window (default 5 minutes).
+- **At-most-once is not the guarantee.** Do not design actions that
+  must fire exactly once without a separate dedup mechanism.
+
+**Idempotency dedup table** (home: `memory.db`, added via
+`src/nexus/db/migrations.py`, same migration entry as `liveness`):
+
+```sql
+CREATE TABLE IF NOT EXISTS action_idempotency (
+    idempotency_key TEXT PRIMARY KEY,
+    expires_at      REAL NOT NULL   -- epoch seconds; TTL default 300s
+);
+```
+
+Action handlers check `SELECT 1 FROM action_idempotency WHERE
+idempotency_key = ?` before executing; if found, skip and return
+success. On first execution, insert the key. Sweep during the liveness
+sweep task: `DELETE FROM action_idempotency WHERE expires_at <
+unixepoch()`.
+
+Action dispatch: `tool_call` type dispatches via the MCP tool API
+(must be `await` — no `asyncio.run_in_executor` for tool calls);
+`tuple_out` calls `out` directly; `send_message` uses the harness
+`SendMessage` tool. All dispatch is bounded by a `action_timeout_s`
+field on the action descriptor (default 10s); timeout fires the next
+cursor advance regardless.
+
+**Watcher failure isolation** — must distinguish failure categories
+to compose correctly with the RDR-112 daemon:
+
+- **Action failure** (the dispatched tool call / `out` / send_message
+  raised). Caught, logged via `structlog.get_logger(__name__)`, cursor
+  advances past the failed event to prevent livelock. Consecutive-
+  failure counter (kept in T2 via `memory_put`) increments; after 5
+  consecutive failures on the same binding the binding is
+  auto-disabled with an error annotation. This is "the user's binding
+  is broken" — the original failure-isolation path, unchanged.
+- **Substrate failure** (RDR-112 daemon down, EventStream RPC
+  disconnect, transient transport error). Logged at WARN; cursor does
+  **not** advance; consecutive-failure counter does **not** increment
+  toward auto-disable. The watcher reconnects with exponential
+  back-off (capped at 30s) and resumes from the last-acked cursor.
+  Substrate hiccups must not silently auto-disable user bindings.
+- **Schema failure** (event payload doesn't match the binding's
+  expected shape — e.g. a registry version mismatch). Logged at ERROR
+  with the binding ID, cursor advances, counter increments. Treated
+  as an action failure: the binding is wrong relative to the current
+  schema and the user needs to fix it.
+
+**Two distinct uses of "category"** — disambiguation required:
+
+- The EventStream event record carries an optional `category ∈
+  {data, schema, substrate}` field (per RDR-112 Approach §7). This
+  is the **event's** category as published by the daemon:
+  - `data` is the normal case — a tuple was added/updated/taken;
+    the watcher dispatches the action through its usual path.
+  - `schema` events are out-of-band notifications that the
+    daemon's schema for this subspace changed; they are *not*
+    dispatch targets in v1 and the watcher should advance its
+    cursor past them without invoking the binding action.
+  - `substrate` events are out-of-band notifications about
+    substrate state changes (rare; mostly used by daemon-internal
+    consumers).
+- The **watcher's** failure classification (action / substrate /
+  schema, the three bullets above) is a separate axis describing
+  *how dispatch went wrong*, not how the event was classified by
+  the daemon. The two axes are independent — an event with
+  `category=data` can still cause an action-failure (the dispatched
+  tool raised) or a substrate-failure (the transport dropped
+  mid-dispatch).
+
+For transport-level errors the watcher classifies as substrate-
+failure directly from the exception type (e.g. `BrokenPipeError`,
+`ConnectionResetError`, gRPC-equivalent in the chosen transport),
+without needing daemon cooperation.
+
+#### Step 7: Phase 1 CA spikes (gate Phase 2)
+
+These spikes must complete before Phase 2 begins:
+
+- **CA-6**: Empirically capture real payload for `SubagentStop`,
+  `UserPromptSubmit`, `PreCompact`, `Notification` hooks by running
+  a logging hook in a live session. Update RF-1 table with verified
+  schemas. Write bridge scripts for these 4 types only after payloads
+  are confirmed. (≤ 2h)
+
+Note: **CA-8** (PreToolUse multi-hook ordering) was completed in Step 1b,
+before Step 2. Its result has already been applied to bridge registration
+order. It is not repeated here.
+
+#### Step 7b: Phase 2 CA spikes (gate Phase 3)
+
+- **CA-3**: Benchmark `read` query latency at 10k, 50k, 100k tuples.
+  If > 50ms, add a materialised view (SQLite view or summary table).
+- **CA-5**: Benchmark binding reaction end-to-end latency (hook fire →
+  action dispatch) at 10 concurrent active bindings. If > 200ms,
+  move binding watcher to a dedicated process.
+- **CA-7**: Prototype Bakke Measure/Auto-Style/Layout on a static
+  binding set. Estimate LoC and developer-days. If > 300 LoC or
+  > 1 week, scope Phase 3 accordingly or defer layout engine to a
+  follow-on RDR.
+
+#### Step 7c: Phase 3 CA spike (gate finalization)
+
+- **CA-4**: Measure tmux `status-right` update cadence on target
+  hardware. If noticeable lag, increase refresh interval to 5s and
+  add a stale indicator.
+
+### Phase 3: C2 cockpit surfaces
+
+#### Step 8: Active-claims panel
+
+`src/nexus/cockpit/surfaces/claims.py`: routes through the **T2
+daemon read RPC** (per RDR-112 D1, MCP is a client of the daemon).
+Two implementation options for the query path:
+
+- **Preferred**: a dedicated `t2_client.active_claims(subspace=…,
+  ttl_floor=now)` RPC that the daemon implements with the SQL
+  shape `SELECT … WHERE claim_state = 'claimed' AND
+  claim_expires_at > unixepoch()` (expiry filter required to
+  exclude expired leases not yet swept — see Proposed Solution
+  for the full query and rationale). Returns rows ready for
+  panel rendering.
+- **Acceptable v1**: `nx daemon t2 exec --raw <sql>` (RDR-112
+  §Nexus-in-its-own-container) carrying the same SQL string.
+  Faster to ship but loses the typed-DTO benefit.
+
+Formats as a table: actor (extracted via `json_extract(t.dimensions_json,
+'$.actor')`), subspace, tuple summary, claimed_at (via join on
+`tuple_claim_log`), TTL remaining. **No direct `sqlite3.connect`
+on `tuples.db` from the cockpit client process** — that would
+violate D1 and break under daemon mode. tmux fulfillment: update
+a named pane on a 2s cadence. ext-apps fulfillment: render as an
+iframe via `ui://claims`.
+
+#### Step 9: Recent-events panel
+
+`src/nexus/cockpit/surfaces/events.py`: routes through the **T2
+daemon read RPC**. Two implementation options paralleling Step 8:
+
+- **Preferred**: `t2_client.recent_events(subspace=…, limit=…,
+  order_by="created_at desc")` RPC that the daemon implements
+  with the SQL ordering on its internal `created_at` column
+  (which is not exposed via `read()` because `created_at` is an
+  internal `tuples` table column not in the DTO).
+- **Acceptable v1**: `nx daemon t2 exec --raw <sql>` for default
+  time-ordered display.
+
+For semantic filtering, falls back to `read()` with client-side
+sort by the `timestamp` dimension (registered on all hook-event
+subspaces, present in the `read()` response — unlike `created_at`).
+Supports structural params (`actor`, `session`, `project`) as
+additional `where` clauses on either the read RPC or the
+introspection RPC. **No direct `sqlite3.connect` on `tuples.db`
+from the cockpit client process.** tmux + ext-apps fulfillment as
+above.
+
+#### Step 10: Active-bindings management panel
+
+`src/nexus/cockpit/surfaces/bindings.py`: `read(subspace=
+"bindings/<profile>", where={"enabled": "true"})`. Toggle via
+`take` + `out` (remove then re-post with `enabled` flipped). Edit
+in-panel; the edit form is itself a binding-create form rendered inline.
+
+#### Step 11: Auto-layout engine
+
+`src/nexus/cockpit/layout.py`: Measure / Auto-Style / Layout
+pipeline. Reads the subspace registry for layout dispositions.
+Writes a `layout_state/<profile>` tuple. Triggers on:
+binding-set change, profile switch, display-budget change
+(terminal resize signal, pane count change). Implements the
+demotion cascade and `min_surface` floor.
+
+#### Step 12: First end-to-end mission profile
+
+Pick a real workflow (RDR creation, build watching, incident
+response). Author the bindings, the layout, the permission mode.
+Run it. Measure what's awkward. Iterate.
+
+### Connection manifest (Phase 4 — deferred)
+
+The `connection_manifest` subspace schema ships in Phase 1 (Step 1)
+so producers can use it. The fulfillment adapters that *consume*
+manifests to open direct streaming connections are deferred to
+Phase 4 (ext-apps iframe work, covered in the workflow-engine doc
+handed off separately).
+
+## Test Plan
+
+### Unit tests
+
+- Hook bridge: one test per hook type for correct subspace/dimensions
+  mapping. One test for malformed payload (must exit 0 and log).
+- Bindings CRUD: create / list / toggle / delete round-trip.
+- Binding reaction: mock event tuple → assert correct action dispatch.
+- Layout engine: given a binding set and display budget, assert
+  correct stylesheet tuple. Test demotion cascade at N bindings
+  exceeding budget.
+- Liveness: heartbeat emitted at startup; `nx instances` returns
+  the expected row; TTL expiry removes the row.
+
+### Integration tests
+
+- Bridge → tuple space end-to-end: fire a real hook, assert the
+  tuple appears in the `hook_events/*` subspace with correct fields.
+- Binding reaction end-to-end: register a binding; fire a hook;
+  assert the action was dispatched within 200ms.
+- Cockpit panel queries (active-claims, recent-events) return correct
+  results at 1k, 10k event volumes via the daemon read RPC (or a
+  daemon test double — never a direct `sqlite3.connect(tuples.db)`
+  from the test process). Active-bindings panel `read()` returns
+  correct results at 1k bindings.
+
+## Validation
+
+The ORB is validated when:
+
+1. A `PreToolUse` hook fires and the corresponding tuple appears in
+   `hook_events/tool_call_intent` within 100ms.
+2. A user-authored binding ("when a tool call completes, update the
+   status line with the tool name and duration") fires correctly
+   for 10 consecutive tool calls with no missed events.
+3. The active-claims panel accurately reflects all currently-claimed
+   tuples, updating within the refresh cadence.
+4. `nx instances` returns the correct set of live processes on a
+   machine running two `claude` sessions simultaneously.
+5. A mission profile (chosen in Step 12) runs end-to-end with all
+   three cockpit panels providing correct situational awareness,
+   and the user can toggle a binding on/off from the panel without
+   restarting any process.
+
+## Finalization Gate
+
+Phase-gated CA clearance:
+- [ ] **Before Phase 1 begins**: CA-9 cleared = RDR-110 Phase 1 Step 6 confirmed shipped with open-registry registration mechanism (or RDR-110 amended to add one), verified by checking the Step 6 implementation. Notification of the RDR-110 implementor is the action to take; a confirmed open-registry implementation is the gate criterion.
+- [ ] **Before Phase 1 Step 2**: CA-8 (PreToolUse multi-hook ordering determined; Step 2 registration order updated per result; fallback design implemented as feature flag).
+- [ ] **Before Phase 2**: CA-6 (4 inferred hook payload shapes verified empirically).
+- [ ] **Before Phase 2 Step 6**: CA-10 (`watcher_state` table confirmed in RDR-110 tuples.db migration).
+- [ ] **Before Phase 3**: CA-3 (`read` latency benchmark) + CA-5 (binding reaction latency benchmark) + CA-7 (Bakke layout engine LoC estimate).
+- [ ] **Before finalisation**: CA-4 (tmux cadence verified on target hardware) + CA-1 (RDR-110 prerequisite steps shipped).
+
+Other gates:
+- [ ] Unit + integration test suite passes.
+- [ ] First end-to-end mission profile runs cleanly (Step 12).
+- [ ] `docs/agentic-cockpit.md` updated to note implementation
+      status of each section.
+- [ ] `docs/cli-reference.md` updated with `nx instances` and
+      `nx bindings` commands.
+- [ ] RDR-110 implementor notified of subspace registry extension
+      requirement (per Relationship to RDR-110 section).
+
+## References
+
+- `docs/agentic-cockpit.md` — Design exploration; source for all
+  architectural decisions in this RDR.
+- `docs/rdr/rdr-110-semantic-tuple-space.md` — Foundation primitive.
+- `docs/rdr/rdr-105-t1-chroma-architecture-env-passdown.md` — T1/T2
+  tier discipline and process lifecycle patterns.
+- Gelernter & Carriero, "Linda in Context" (1992).
+- Bakke, Karger & Miller, "Automatic Layout of Structured Hierarchical
+  Reports" (InfoVis 2013).
+- WeakAuras project documentation (wago.io).
+
+## Revision History
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-05-11 | Hal Hildebrand | Initial draft |
+| 2026-05-11 | Hal Hildebrand | Post-gate revision: expanded RF-1 to complete verified payload inventory for all 13 hook types; revised liveness from tuple-space to T2 table (cross-process visibility requirement); added _BindingWatcher restart semantics, cursor persistence, at-least-once delivery + idempotency_key requirement; added CA-6 (inferred payload empirical spike), CA-7 (Bakke LoC estimate), CA-8 (PreToolUse ordering empirical spike); restructured CA phase gates to P1/P2/P3; added debounce to auto-layout engine; added binding_create async requirement; added RDR-110 subspace registry extension coordination note |
+| 2026-05-11 | Hal Hildebrand | Post-gate-2 revision (all gate-2 BLOCKED issues addressed): (C-NEW-1) _BindingWatcher retrieval mechanism changed from `rd()` with offset cursor to direct T2 SQL on `tuples` table by `rowid` — intentional internal bypass, RDR-110 `read()` has no ordered-retrieval parameter; (C-NEW-2) Active-claims panel changed from `rd(claim_state=claimed)` to direct T2 SQL — `claim_state` is an internal column not a registered dimension; (S1) T2 migration added to `src/nexus/db/migrations.py`, `watcher_state` table added to same migration as `liveness`; (S2) corrected false liveness rationale — project-tier T2 subspaces ARE cross-process, liveness uses raw T2 for semantic/schema/tombstone reasons; (S3) registry extension CA-9 added as definitive prerequisite, registry section changed from conditional "if" to CA-9; (S4) CA-8 fallback design documented (no-permissionDecision or last-in-chain if first-wins confirmed); (S5) `binding_create` changed to return `task_id` immediately with async task pattern |
+| 2026-05-11 | Hal Hildebrand | Post-gate-4 revision (all gate-4 BLOCKED issues addressed): (C-G4-1) corrected cursor-advance pseudocode — dispatch is now outside SQLite transaction (async dispatch cannot be wrapped in synchronous sqlite3 BEGIN/COMMIT); removed "genuinely atomic" claim; clarified same-database placement enables one connection, not transactional atomicity between dispatch and commit; (S-G4-1) switched recent-events semantic fallback sort from `tuple.created_at` (internal column not in read() DTO) to `timestamp` dimension (registered, accessible in read() response); (S-G4-2) removed CA-8 from Step 7 spike list — now only in Step 1b where it belongs; added cross-reference note; (S-G4-3) added CA-10 for `watcher_state` table coordination with RDR-110 implementor; added to Finalization Gate; (O-G4-2) fixed Step 2 registration path from `.claude/hooks/` to `nx/hooks/hooks.json` |
+| 2026-05-11 | Hal Hildebrand | Post-gate-5 revision (no criticals; 3 significant fixed pre-accept): (SIG-1) removed residual "enabling a genuine single-transaction cursor advance" claim from watcher_state rationale — replaced with accurate "one connection" language; (SIG-2) corrected Step 9 semantic fallback sort from `created_at` (internal column, not in read() DTO) to `timestamp` dimension; (SIG-3) added `action_idempotency` table schema, migration reference (memory.db), and sweep hook to Phase 2 Step 6 |
+| 2026-05-11 | Hal Hildebrand | Post-gate-6 revision (no criticals; all significant and observation issues addressed pre-accept): (SIG-A) replaced `rd`/`in` Linda aliases with `read`/`take` throughout all implementation-facing sections — Bindings CRUD, active-bindings panel, Step 10, Relationship to RDR-110 surfaces sentence, Key Discoveries (bindings, surfaces, cross-process), CA-3 across all references (assumption table, Step 7b spike, Finalization Gate), and the Linda bullet's "ORB uses" clause; added Linda→RDR-110 API name mapping table and usage rule to Relationship to RDR-110 section; (SIG-B) added `layout_state/<profile>` subspace schema block (dimensions: profile, event_type; content: surface_level, demotion_level, ttl_seconds, pinned) to Proposed Solution; added `layout_state.yml` and `connection_manifest.yml` to Step 1 file list; (OBS-1) added `tuple_claim_log` join note for `claimed_at` display field — `tuples` has no `claimed_at` column; (OBS-2) `connection_manifest.yml` now explicit in Step 1; (OBS-3) integration test 3 corrected to distinguish SQL-based panels (active-claims, recent-events) from `read()`-based panel (active-bindings); (OBS-4) Step 2 explicitly documents which hook types are projected (7) and which are excluded (SubagentStart, PermissionRequest) with rationale |
+| 2026-05-11 | Hal Hildebrand | Post-gate-3 revision (all gate-3 BLOCKED issues addressed): (C-G3-1) Added `task_id` (string) and `status` (enum: pending/active/failed) dimensions to bindings subspace schema YAML; documented enabled/status/task_id lifecycle; (S-G3-1) moved `watcher_state` table to `tuples.db` (not `memory.db`) for genuine single-transaction cursor atomicity; corrected "atomic" language; (S-G3-2) added `claim_expires_at > unixepoch()` filter to active-claims panel query in Proposed Solution and Step 8 to exclude expired leases; (S-G3-3) flagged Step 2 bridge registration order as provisional pending CA-8; moved CA-8 spike to new Step 1b (before Step 2); added feature-flag requirement for registration order; (S-G3-4) changed recent-events panel from `rd()` (no time ordering) to direct SQL on `tuples.db` ordered by `created_at DESC`; semantic filter noted as opt-in mode; (S-G3-5) replaced "direct T2 SQL via src/nexus/db/" with explicit `tuples.db` database references throughout; (O1) corrected "six" to "seven" subspaces; (O2) documented PostCompact/PreCompact exclusion with rationale; (O3) updated CA-9 gate condition to outcome-based (confirmed open-registry shipping) not action-based (notification sent) |
+| 2026-05-11 | Hal Hildebrand | Post-gate-7 revision (1 critical + 2 significant + 2 observations all addressed pre-accept): (C-G7-1) removed `PostCompact` from Step 2 bridge registration list — was contradicted by Proposed Solution's explicit exclusion; added `PreCompact` and `PostCompact` to the not-registered list with rationale cross-reference; (SIG-G7-1) replaced three residual `rd()` aliases with `read()` — Step 4 bindings dimension example, Step 6 `_BindingWatcher` rationale paragraph (header + two body references); (SIG-G7-2) corrected "six" → "seven" hook-event subspaces at four remaining sites (Relationship to RDR-110 summary, CA-9 description, CA-9 risk-if-wrong, Phase 1 section header); added `layout_state` to the Relationship-section subspace enumeration; (OBS-G7-1) active-claims display now explicitly extracts `actor` via `json_extract(t.dimensions_json, '$.actor')` — `actor` lives inside `dimensions_json`, not a top-level column; (OBS-G7-2) watcher failure isolation now logs via `structlog` (not "T2 scratch" — category error, scratch is T1); failure counter kept in T2 as before |
+| 2026-05-13 | Hal Hildebrand | **Triad rework (RDR-110/111/112 composition gaps, deep-analyst `a56172936d63fd480`)**: added §Relationship to RDR-112; rewrote §Step 6 binding-watcher to consume RDR-112 `EventStream(subspace_prefix, since_cursor)` RPC instead of direct SQL on `tuples.db` (cursor protocol and at-least-once semantics preserved verbatim; only transport changes); rewrote §Step 6 Watcher failure isolation to distinguish action / substrate / schema failure categories so daemon hiccups do not silently auto-disable user bindings (closes G5); updated `watcher_state` placement to record that the table is daemon-owned and read/written via dedicated RPCs (closes G4 wrt RDR-111 dependency); `related_rdrs` frontmatter extended to include RDR-112 and RDR-113. RDR-111 is now blocked on RDR-112 Phase 1 for the binding-watcher; query-only cockpit surfaces unaffected. |
+| 2026-05-13 | Hal Hildebrand | **Gate round 8 closeout** (substantive-critic `a3da714a7d21b75ee`, 1C/2S/2O on the triad-rework PR): (C-G8-1) Steps 8 + 9 cockpit panels rewritten to route through T2 daemon read RPCs (`t2_client.active_claims()`, `t2_client.recent_events()`) or `nx daemon t2 exec --raw` introspection; explicit ban on direct `sqlite3.connect(tuples.db)` from cockpit client process. The §Relationship to RDR-112 subsection had committed this; Steps 8/9 prose now matches. (S-G8-1) CA-10 description and gate criterion updated to reference the T2 daemon migration manifest (RDR-112 Approach §9), not RDR-110 migration file — the migration owner moved daemon-side and the criterion has to point there. (S-G8-2) CA-9 extended with the second-half coordination: ORB Phase 1 Step 1 also gates on the RDR-112 daemon `subspace add` admin RPC existing, not just RDR-110 shipping open-registry. (OBS-G8-1) Step 6 cursor-persistence pseudocode rewritten to use `t2_client.watcher_state_set` / `watcher_state_get` RPCs and `t2_client.event_stream` async-for loop, removing the bare `conn_tuples.execute(UPDATE watcher_state ...)` that contradicted the surrounding prose. (OBS-G8-2) Watcher failure isolation disambiguates the two uses of "category" — RDR-112 event `category ∈ {data, schema, substrate}` published by the daemon is independent of the watcher-side action/substrate/schema failure classification. |
+| 2026-05-13 | Hal Hildebrand | **5x5 alignment pass (alignment check `a25b97d1aac1d8523`)**: Proposed Solution panel descriptions (Active-claims, Recent-events) carried a pre-rework justification ("internal component in the same process, so direct access to `tuples.db` is appropriate") that contradicts Implementation Plan Steps 8 + 9 (which were corrected in the round-8 closeout to route through daemon RPCs). Added "Routing under RDR-112" notes to both Proposed Solution panel paragraphs pointing at Steps 8 + 9 and the RDR-112 §5 lint, closing the internal inconsistency. No design change. |

--- a/docs/rdr/rdr-112-storage-as-service-container-boundary.md
+++ b/docs/rdr/rdr-112-storage-as-service-container-boundary.md
@@ -1,0 +1,958 @@
+---
+title: "Storage-as-Service: Every Persistent Shared-State Store Behind a Daemon, T1 Stays In-Container"
+id: RDR-112
+type: Architecture
+status: scrapped
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-12
+accepted_date: 2026-05-13
+scrapped_date: 2026-05-19
+scrap_reason: "Substrate design was largely sound (dual-primary discovery, UDS+TCP transport, sub-ms RPC overhead per A3 spike, storage-boundary lint, NX_STORAGE_MODE cutover) but shipped intertwined with RDR-110/111/113/118/119 consumer abstractions. The arc lacked a moratorium on co-shipped consumers, so the substrate's correctness was a moving target while tuplespace/cockpit/ORB/host-trust evolved on top of it. Research evidence (A1 chroma run quality, A2 WAL/overlayfs, A3 RPC spike, A4 PID-namespace discovery refutation) preserved here for citation by RDR-120, which restarts the substrate work alone. Postmortem: docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md."
+related_issues: []
+related_rdrs: [RDR-004, RDR-041, RDR-105, RDR-108, RDR-110, RDR-111, RDR-113, RDR-120]
+related_tests: []
+implementation_notes: ""
+---
+
+> **TOMBSTONE 2026-05-19.** This RDR is preserved as historical reference. The substrate design (T2/T3 daemon split, UDS+TCP, dual-primary discovery, lint, cutover flag) and the A1-A4 research findings are reusable; the arc-level scope was not. See frontmatter `scrap_reason` and the [postmortem](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work: [RDR-120](rdr-120-storage-substrate-split.md), which cites this RDR's research evidence by reference. Do not implement against this RDR directly.
+
+---
+
+
+# RDR-112: Storage-as-Service: Every Persistent Shared-State Store Behind a Daemon, T1 Stays In-Container
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+Nexus's three storage tiers are accessed today as **library-mode
+file handles** — `sqlite3.connect(path)` for T2, `chromadb.PersistentClient(path)`
+for T3, `EphemeralClient()` or per-session HTTP for T1. That worked when
+the only consumer was a single `nx` CLI process plus its in-tree MCP
+server. It breaks the moment work runs **inside a sandbox container**
+(Claude Desktop's bundled MCP runtime, ext-app sandboxes, `claude -p`
+sub-processes with their own filesystem view, future agentic co-work
+peers running on the same host but in distinct containers).
+
+In a container, "open the file at `~/.nexus/t2.sqlite`" resolves to a
+*copy or an empty path*, not the host's database. The container gets
+its own sqlite, its own chroma collections, its own memory tier — and
+silently fragments knowledge across silos. T1 is fine in that world
+(per-session by design). T2 and T3 are not — they are the *cross-session,
+cross-instance* tiers, and their entire value proposition is that
+co-workers see the same state.
+
+### Enumerated gaps to close
+
+#### Gap 1: T2 and T3 leak the storage substrate as a file path
+
+`T2Database` and the T3 chroma client are opened by direct filesystem
+path. Any process with read access to the path is a peer writer. Inside
+a sandbox container that path either does not exist (silent fork to an
+empty DB) or resolves to a bind-mounted copy (silent fork to a stale
+DB). There is no enforced single-writer boundary, no liveness check,
+no version negotiation — just `open(path)` and hope.
+
+#### Gap 2: Multi-instance co-work fragments knowledge into silos
+
+When Claude Desktop, a `claude -p` sub-process, and a separate IDE
+agent all run on the same host, each opens its own T2/T3 handles. T2
+writes from one instance are invisible to the others until/unless they
+re-open the file (and even then, WAL behavior across containers is not
+guaranteed). Memory put in one cockpit is unreachable from another.
+This is the same fragmentation problem RDR-105 solved for T1 with env
+passdown — but T1 fragmentation is *desired* (per-process working
+memory), while T2/T3 fragmentation is *broken-by-design*.
+
+#### Gap 3: No lifecycle, liveness, or event hooks at the storage edge
+
+Because the storage layer is a file handle, there is nowhere to hang
+the things RDR-110 (tuple-space `in`/`out`/`rd`) and RDR-111 (ORB hook
+projection) actually need: a process owns the data; that process
+publishes events on write; clients subscribe; leases time out when
+holders die; barriers wake when N participants arrive. None of that
+is expressible against `sqlite3.connect(path)` — it needs a process
+that *owns* the data and mediates access.
+
+#### Gap 4: T1's existing service shape is the proof-of-concept, but it's not generalised
+
+RDR-105's `NX_T1_HOST`/`NX_T1_PORT` env passdown already establishes
+that nexus can run a tier as a host-process service and have container
+clients connect to it. That pattern exists for T1 but was deliberately
+*not* extended to T2/T3 because T1 had the unique problem (per-session
+isolation with sibling visibility). T2 and T3 have a *different* but
+equally clear service-shape problem: single writer, many readers,
+cross-container shared truth. The substrate is the same; only the
+sharing discipline differs.
+
+## Context
+
+### Background
+
+Three recent RDRs make this RDR's question unavoidable:
+
+- **RDR-105** moved T1 from on-disk session records to env-passdown of
+  a host-local chroma. Settled the "T1 is per-process working memory"
+  question and proved the host-service-plus-env-discovery pattern.
+- **RDR-110** named the unified abstraction over plan-match / T1 / T2
+  as a semantic tuple space and added Linda's atomic `in` operation.
+  Atomic destructive read requires a *single arbiter* — which a shared
+  file handle is not.
+- **RDR-111** projects hooks onto the tuple space as observable state
+  and adds a user-authored composition layer. Projection requires a
+  publishing point — which a file handle does not have.
+
+Both RDR-110 and RDR-111 land cleanly *if* there is a process that
+owns T2 and a process that owns T3 and they expose typed RPCs. They
+land messily otherwise: every reader has to poll, every writer has to
+trust filesystem locking, and `in` has to be implemented as advisory
+SQLite locks across containers — which does not work.
+
+Independently, Claude Desktop's container model and the proliferation
+of `claude -p` sub-processes and ext-app sandboxes have made the
+container-vs-host filesystem split a daily operational fact, not an
+edge case. Every "I can't see my memory" report from co-work
+configurations traces back to this gap.
+
+### Technical Environment
+
+**Scope is universal**: every persistent shared-state store in
+nexus moves behind a daemon — not just T2 and T3. The container/silo
+problem is structural to *any* file-backed store opened by direct
+path; cherry-picking only T2/T3 would leave the same class of bug
+sitting under another name (today: `catalog.db`; tomorrow: any new
+domain store added without thinking about the boundary).
+
+Inventory of in-scope stores (every direct file open under
+`src/nexus/`):
+
+- **T2 (seven domain stores)** behind `T2Database` facade:
+  `memory_store`, `plan_library`, `chash_index`, `catalog_taxonomy`,
+  `aspect_extraction_queue`, `document_aspects`, `telemetry`. SQLite
+  + FTS5, WAL enabled. Each opens its own `sqlite3.Connection`.
+- **T3 local mode**: `chromadb.PersistentClient(path)` + local ONNX
+  embedder.
+- **T3 cloud mode**: `chromadb.CloudClient` — already service-shaped;
+  no daemon needed (it's a remote service), but its access goes
+  through the same `T3Client` abstraction for symmetry.
+- **CatalogDB** (`src/nexus/catalog/catalog_db.py:250-255`): own
+  SQLite file, own `sqlite3.connect()`. Structurally identical to a
+  T2 domain store and equally vulnerable to the container silo
+  problem. **In scope.**
+- **Any future shared-state store** — the architecture must make the
+  daemon boundary the *default* way to add persistent state, not an
+  option developers have to remember to use.
+- **T1**: `chromadb.EphemeralClient` in-process or per-session HTTP
+  via RDR-105 env passdown. Per-process isolation is *correct* for
+  T1; **explicitly out of scope** and stays as-is.
+
+Direct-file-open call sites under `src/nexus/` total roughly 80
+files (grepping `sqlite3.connect` + `PersistentClient`). The
+impact-analysis inventory (T2 entry `nexus_rdr/112-research-impact-inventory`)
+breaks these down by surface and refactor cost.
+
+**MCP boundary**: every nexus tool consumer talks to storage through
+`nexus.mcp.*` handlers today; those handlers open T2/T3/CatalogDB
+directly. A service split puts a thin client there instead. The MCP
+server becomes a *client* of the daemons even when co-located on
+the same host.
+
+## Research Findings
+
+### Investigation
+
+Conducted 2026-05-12 via deep-research-synthesizer (T2: 112-research-A1..A4).
+Primary sources: installed chromadb package, sqlite.org docs, nexus T1
+implementation (`src/nexus/db/t1.py`, `src/nexus/db/session.py`),
+T2 facade and stores (`src/nexus/db/t2/`, `src/nexus/db/memory_store.py`,
+`src/nexus/db/plan_library.py`, `src/nexus/db/chash_index.py`).
+
+### Key Discoveries
+
+- **Verified**: T2 daemon is *structurally required* for the
+  container case — Docker overlayfs blocks the `mmap` semantics SQLite
+  WAL requires, so a bind-mounted host path opened from inside a
+  container produces a separate WAL per process (or outright failure).
+  This is the silent silo failure mode the RDR set out to fix.
+- **Verified**: T1's existing service shape (chroma HTTP over loopback,
+  spawned at `session.py:494-504`, discovered via `~/.config/nexus/
+  t1_addr.<pid>` + PPID walk at `session.py:634-703`) is a live
+  production precedent for the T2/T3 daemon pattern.
+- **Documented**: `chroma run` is FastAPI + uvicorn with a configurable
+  thread pool (`chroma_server_thread_pool_size`, default 40). chromadb's
+  own "not for production" disclaimer attaches to `EphemeralClient` /
+  `PersistentClient`; `HttpClient` is explicitly the "recommended
+  production configuration" (`chromadb/__init__.py:326`).
+- **Refuted (partially)**: The RDR-105 PPID-walk + discovery-file
+  pattern *does not work* in PID-namespace-isolated containers — the
+  walk terminates at container init (PID 1) and `~/.config` is not
+  bind-mounted in typical sandbox configurations. The `NX_T2_ADDR` /
+  `NX_T3_ADDR` env-var override must be the *primary* path for
+  sandboxed consumers, not a fallback. Discovery protocol needs a
+  dual-primary design.
+- **Inconclusive**: RPC overhead is directionally acceptable —
+  T3 store ops are dominated by embedding latency (ONNX 10-50 ms,
+  Voyage 100-300 ms) and the hop disappears in noise; T2 `memory_get`
+  is the tightest case (0.5-2 ms direct, +10-25% over loopback) and
+  needs a spike with `timeit` against a real fixture to lock the
+  number. UDS will be faster than the loopback TCP T1 already uses.
+
+#### Dependency Source Verification
+
+| Dependency | Source Searched? | Key Findings |
+| --- | --- | --- |
+| chromadb (`chroma run`, FastAPI app) | Yes | uvicorn-backed; 40-thread pool; HttpClient is recommended prod config. T1 already uses this pattern. |
+| sqlite3 WAL | Yes (sqlite.org/wal.html + T2 stores) | WAL cannot use mmap across overlayfs bind mounts → container case broken. Same-host WAL fine. |
+| RDR-105 discovery (`session.py`) | Yes | PPID walk + `~/.config/nexus/t1_addr.<pid>` file. Works for host-native and `claude -p`; fails in PID-namespaced containers. |
+
+### Critical Assumptions
+
+- [x] **A1**: chromadb's bundled HTTP server (`chroma run`) is
+  production-quality enough to be our T3 service, not just a dev
+  convenience. — **Status**: Documented (High confidence) —
+  **Method**: Source Search — see T2 `112-research-A1`.
+- [x] **A2** (qualified): SQLite cross-process write concurrency under
+  WAL is *not* an acceptable substitute for a single-writer daemon —
+  **Verified for the container case** (overlayfs breaks WAL mmap);
+  **Inconclusive for same-host multi-process**, where WAL +
+  `busy_timeout` is the existing T2 design and works correctly. The
+  daemon is structurally required for containers, architecturally
+  necessary for RDR-110/111, and a discipline win same-host. —
+  **Method**: Source Search + sqlite.org/wal.html — see T2
+  `112-research-A2`.
+- [x] **A3**: A daemon-per-tier architecture imposes acceptable
+  latency overhead on the common-case read path. — **Status**:
+  **Verified** (High confidence) — **Method**: Spike
+  (`/tmp/rdr112_a3_spike.py`, 2000 iters on real `MemoryStore`).
+  Results in µs: direct p50=85 / p99=286; UDS p50=100 / p99=300
+  (+15 µs); TCP loopback p50=114 / p99=620 (+29 µs, doubled tail).
+  All sub-millisecond. **Design implication**: T2 daemon binds both
+  UDS and loopback TCP. Clients prefer UDS (faster, bypasses TCP
+  stack, free unix file permissions) but fall back to TCP whenever
+  the socket file is unreachable — Windows VM-based co-work,
+  containerised Claude Desktop, port-allow-listing sandboxes. The
+  ~14 µs gap between transports is well under budget so the fallback
+  is essentially free. T3 transport hop is below noise (embedding
+  dominates). See T2 `112-research-A3-spike`.
+- [x] **A4** (refuted): Discovery via per-host UID file (RDR-105
+  pattern) does **not** work universally — it fails in
+  PID-namespace-isolated containers where `/proc` and `ps` show only
+  container processes and `~/.config` is not bind-mounted. Mitigation:
+  promote `NX_T2_ADDR`/`NX_T3_ADDR` env-var to co-primary discovery
+  path, with daemon emitting its address on stdout for orchestrator
+  capture-and-inject. Proposed Solution will be revised to reflect
+  dual-primary discovery. — **Method**: Source Search of
+  `session.py:634-703` + container semantics — see T2 `112-research-A4`.
+
+## Proposed Solution
+
+### Approach (sketch — to be refined)
+
+1. **T2 service**: introduce `nx daemon t2` — a long-lived process
+   that owns the SQLite handle and exposes the seven domain-store
+   operations over **both UDS and loopback TCP** listeners. The
+   daemon always binds both. The **client** picks: UDS first (faster,
+   bypasses the TCP stack, gets unix file permissions for free), TCP
+   fallback when UDS is unreachable. UDS-unreachable is the expected
+   case for (a) Windows VM-based co-work, (b) containerised Claude
+   Desktop variants, (c) any orchestrator that allow-lists ports but
+   not socket files, and (d) ext-app sandboxes that can do network
+   policy but not bind mounts. A3 spike: UDS p50=100 µs, TCP p50=114
+   µs — both well under budget, so making TCP the fallback (not the
+   exclusion) costs us nothing and buys cross-environment reach.
+   Clients link `T2Client` instead of `T2Database`; the facade API
+   is unchanged.
+2. **T3 service**: run `chroma run` as a managed subprocess under
+   `nx daemon t3`. **Note**: chromadb 1.4.4's HTTP server is loopback
+   TCP, not UDS — we accept the TCP hop for T3 because (a) it's an
+   upstream constraint we don't control, and (b) T3 reads are
+   dominated by embedding latency (ONNX 10–50 ms, Voyage 100–300 ms)
+   so the transport hop is below noise. Local-mode T3 stops being
+   "open the directory directly" and becomes "connect to the managed
+   local server."
+3. **CatalogDB collapses into T2**: `CatalogDB`
+   (`src/nexus/catalog/catalog_db.py:250-255`) is structurally
+   identical to a T2 domain store — own `sqlite3.connect`, own file,
+   same threading discipline. Its schema-evolution cadence aligns
+   with T2's (RDR-101 / RDR-103 / RDR-104 all touched both surfaces
+   in lockstep), and `catalog_taxonomy` already lives in T2 as one
+   of the seven domain stores. **Decision**: CatalogDB becomes the
+   eighth T2 domain store, served from `nx daemon t2`. One daemon,
+   one introspection surface, one discovery file. **Escape hatch**:
+   if planning surfaces a concrete crash-isolation or hot-path
+   contention reason to separate, the decision flips to a third
+   daemon (`nx daemon catalog`) — but the burden of proof is on
+   the separation, not on the collapse. The transport, discovery,
+   and introspection design is the same either way.
+4. **T1 stays put**: RDR-105's env passdown is already correct for T1.
+   No change.
+5. **Any future persistent store** is added as a domain inside an
+   existing daemon (preferred) or as a new daemon (only if a
+   first-class operational separation is needed). Direct
+   `sqlite3.connect()` / `chromadb.PersistentClient()` outside
+   `src/nexus/db/` daemon-internal code becomes a lint-checked
+   anti-pattern. **Enforcement (committed)**:
+   - **Tool**: `nx doctor --check-storage-boundary` — an AST-based
+     scan modelled on the existing
+     `tests/test_no_direct_catalog_writes_outside_projector.py`
+     ε-lint (RDR-101 Phase 3 ε). The implementation lives at
+     `src/nexus/commands/doctor.py` (a new check function) and
+     scans `src/nexus/` for `sqlite3.connect(...)` and
+     `chromadb.PersistentClient(...)` call sites outside the
+     allowlisted prefix `src/nexus/db/`.
+   - **Trigger**: `nx doctor` runs the check as part of its
+     default audit pass; CI invokes `nx doctor
+     --check-storage-boundary --fail-on-violation` as a
+     dedicated step in the existing pytest workflow.
+   - **Surfacing**: violations are listed by `file:line` with the
+     offending call shape, mirroring the ε-lint output format.
+     Exit code 1 from CI fails the build.
+   - **Escape hatch**: a `# storage-boundary-allow: <reason>`
+     line marker, ≥8-char reason, parallels the
+     `# epsilon-allow:` mechanism already in the catalog lint.
+6. **Discovery (dual-primary)**: each daemon writes **both** its
+   UDS socket path and its TCP `host:port` to
+   `~/.config/nexus/<tier>_addr.<host_uid>` (single file, both
+   addresses) for host-native consumers with shared filesystem. For
+   sandboxed/containerised consumers where the discovery file is
+   unreachable (PID-namespaced containers per the A4 finding,
+   Windows-VM co-work, or containerised Claude Desktop), the
+   orchestrator injects `NX_T2_SOCK` and/or `NX_T2_ADDR` (and the T3
+   / catalog equivalents) into the container's environment. Daemon
+   emits both addresses on stdout at startup for orchestrator
+   capture. **Client transport selection**: if `NX_T2_SOCK` is set
+   and the socket is reachable → UDS. Else if `NX_T2_ADDR` is set →
+   TCP. Else read the discovery file and try UDS first, TCP second.
+   Fail loud if neither reaches a live daemon.
+7. **Event stream (wire contract)**: each daemon exposes a
+   streaming RPC `EventStream(subspace_prefix, since_cursor) →
+   Stream<Event>` over the same UDS/TCP transport as the regular
+   RPCs. Event records carry `{cursor: rowid, subspace, op,
+   payload_summary, ts}`. Cursor is monotonic `rowid > N` within
+   a subspace; consumers persist their last-acked cursor and
+   reconnect from there after a disconnect (at-least-once
+   delivery). Subspace-prefix matching is glob-style (e.g.
+   `tuples/*`, `daemon/*/lifecycle`). The stream is the **only**
+   way clients observe change — direct SQL polling on the
+   underlying SQLite is daemon-internal and forbidden to clients.
+
+   **Reserved subspaces**:
+   - `tuples/<subspace>` — tuple-space change events (RDR-110
+     consumers; the projection RDR-111 §Step 6 watcher consumes).
+   - `daemon/<name>/lifecycle` — substrate operational events
+     (started, stopping, migration-applied, client-connected,
+     client-disconnected, sweep-fired). First-class so a cockpit
+     binding "show me when the daemon restarts" is expressible
+     on the same bus as any other observation.
+
+   **Failure-category demux**: events carry an optional
+   `category ∈ {data, schema, substrate}` field. Consumers
+   distinguish substrate failures (transport/daemon faults) from
+   action failures (their own dispatch errors) — RDR-111
+   §Watcher failure isolation depends on this demux to avoid
+   auto-disabling user bindings when the daemon hiccups.
+
+8. **Subspace registry — daemon validates**: tuple-space
+   subspace schemas (RDR-110 §Subspace registry) ship with each
+   daemon and are validated daemon-side at startup, not in the
+   MCP client. The daemon-client version handshake carries a
+   subspace-schema digest; client refuses to connect on
+   mismatch. Rationale: the daemon owns the data and must
+   enforce its own invariants regardless of which client
+   connects. RDR-111's plugin-supplied subspaces (RDR-111 CA-9)
+   land via the daemon's `nx daemon t2 subspace add <yaml>`
+   admin RPC, not by the client registering at runtime.
+
+9. **Schema migration ownership**: the daemon is the **sole
+   migration runner**. On startup the daemon checks its own
+   schema version and applies pending migrations against its
+   single SQLite handle before accepting client connections.
+   Clients carry an expected-schema-version constant; on
+   connect, the handshake compares and fails loud if the daemon
+   is behind (instruct user to `nx daemon t2 migrate`) or ahead
+   (instruct user to upgrade the client). The MCP server stops
+   driving migrations entirely (per RDR-110 Phase 1 Step 2 needs
+   updating).
+
+10. **Original "Lifecycle hooks" promise**: superseded by items
+    7–9 above, which spell out the event-stream protocol,
+    failure demux, registry validation, and migration ownership
+    explicitly. T2, CatalogDB, and T3 all participate in the
+    EventStream RPC; same wire contract per daemon.
+
+### Existing Infrastructure Audit
+
+| Proposed Component | Existing Module | Decision |
+| --- | --- | --- |
+| `nx daemon t2` | `nexus.db.t2.T2Database` (seven domain stores) | Extend — wrap existing facade in a socket server; do not rewrite store logic. |
+| `nx daemon t3` (local mode) | `nexus.db.t3.T3Database` (PersistentClient) | Replace — direct PersistentClient becomes managed `chroma run` subprocess. |
+| CatalogDB serving (in scope) | `nexus.catalog.catalog_db.CatalogDB` (`sqlite3.connect` at `:255`) | Decide during planning: collapse into T2 as eighth domain store (preferred), or ship as separate `nx daemon catalog`. Either way, direct file access goes away. |
+| Client-side `T2Client` | `T2Database` facade | New — thin RPC client mirroring the facade signature, so call sites do not change. |
+| Client-side `CatalogClient` | `CatalogDB` public API | New — same pattern; whether it shares the `T2Client` connection depends on the daemon-collapse decision. |
+| Discovery file | `~/.config/nexus/t1_addr.<claude_pid>` (RDR-105) | Extend pattern — same mechanism, one address file per daemon. |
+| **Lint rule**: ban direct `sqlite3.connect` / `PersistentClient` outside `src/nexus/db/` daemon-internal code | (new) | Prevents regression: future stores must go through a daemon by default. |
+
+### Decision Rationale
+
+The discipline this RDR imposes — *no direct DB access outside the
+owning process* — is what unlocks RDR-110's atomic-take and RDR-111's
+event projection. It also closes a class of co-work bugs that today
+present as "memory I saved isn't there" and are diagnosed individually
+each time. The cost is a daemon to keep alive; the discovery+auto-spawn
+pattern from RDR-105 already shows that cost is tolerable.
+
+### Sequencing constraint vs RDR-110 — `block=True` gates on the daemon
+
+RDR-110's blocking `take` semantics (`block=True`) depend on
+`PRAGMA data_version` polling against the `tuples.db` SQLite file
+(RDR-110 §RF-9, §CA #6 Verified). The cross-process wake claim in
+CA #6 is correct for same-host shared filesystem; it is **not**
+correct across container overlayfs bind mounts — the same `mmap`
+constraint RDR-112 §A2 verified for WAL writes also blocks
+`data_version`'s cross-process visibility. Naively shipping
+RDR-110 against direct-file T2 first (the obvious "least
+disruptive" sequencing) would silently break blocking `take` for
+containerised consumers — Claude Desktop bundled MCP,
+`claude -p`, ext-app sandboxes — with no diagnostic, because each
+container would observe its own forked `data_version`.
+
+**The corrected sequencing**:
+
+1. RDR-110 Phase 1 ships with `block=False` only (polling-based
+   take). Same-host same-process correctness, no container
+   exposure to the `data_version` failure mode.
+2. RDR-110's `block=True` is gated behind
+   `NX_STORAGE_MODE=daemon` (see Cross-Cutting Concerns §
+   Incremental adoption) and ships only after the T2 daemon's
+   blocking-take RPC is in place. The daemon implements
+   `data_version` polling internally against its single-process
+   SQLite handle, then delivers the wake to clients over UDS/TCP.
+3. Non-blocking `take` (`block=False`) is safe under both modes
+   and ships as part of RDR-110 Phase 1 unchanged.
+
+This constraint is **load-bearing for RDR-110's correctness** in
+the containerised case and must be communicated to RDR-110's
+planning chain before Phase 1 Step 4 (the blocking-take
+implementation) ships. The constraint costs RDR-110 nothing
+operationally — `block=False` is the v1 default already; this RDR
+merely defers the optional `block=True` path to when the
+substrate supports it.
+
+## Alternatives Considered
+
+### Alternative 1: Status quo — direct file access, hope WAL holds
+
+**Description**: Keep opening T2 and T3 by path; rely on SQLite WAL
+and chroma's filesystem locking to mediate cross-process access.
+
+**Pros**:
+
+- No new daemon to operate.
+- No discovery problem.
+
+**Cons**:
+
+- Does not work across container boundaries (the central problem).
+- No place to hang RDR-110 atomic-take or RDR-111 event projection.
+- Silent fork-into-empty-DB failure mode persists.
+
+**Reason for rejection**: Does not solve the stated problem.
+
+### Alternative 2: Single mega-daemon owning all three tiers
+
+**Description**: One `nx daemon` process owns T1+T2+T3.
+
+**Pros**:
+
+- One process to manage, one discovery file.
+
+**Cons**:
+
+- T1 must stay per-session — collapsing it into a shared daemon
+  breaks RDR-105's sibling-visibility model.
+- T2 and T3 have very different scaling and crash-isolation profiles;
+  a chroma OOM should not take down memory.
+
+**Reason for rejection**: Conflates tiers that RDR-105 deliberately
+separated.
+
+### Briefly Rejected
+
+- **Database-as-MCP-server only**: making the daemon a full MCP server
+  rather than a tier-internal RPC would conflate the storage boundary
+  with the tool boundary. The tool layer already exists; we want a
+  layer *below* it.
+- **Cloud-only T3**: would solve the boundary problem but reintroduces
+  the local-mode-required-for-air-gapped-work constraint.
+
+## Trade-offs
+
+### Consequences
+
+- (+) Closes the cross-container silo class of bugs structurally.
+- (+) Gives RDR-110 and RDR-111 a real publishing/arbitrating point.
+- (+) Forces discipline that future tiers (T4? cross-host?) will need
+  anyway.
+- (+) Multi-user host isolation is free (UDS filesystem permissions);
+  no in-process auth code in v1.
+- (−) Two new long-lived processes to keep alive on every nexus install.
+- (−) Adds an RPC hop to every T2/T3 call — measured at +15 µs p50
+  (UDS) / +29 µs p50 (TCP loopback) in the A3 spike; both sub-ms.
+- (−) Daemon ↔ client version handshake is a new operational concern.
+- (−) Containerised consumers require an orchestration step (UDS
+  bind-mount or TCP port allow-list + env-var injection) at
+  container launch. Documented in Day 2 Ops.
+- (−) Cross-host co-work is explicitly *not* addressed; a future RDR
+  layers federation on top of the local daemon.
+- (−) **Ad-hoc DB access disappears when nexus runs inside its own
+  container** — see "Nexus-in-its-own-container" subsection below.
+
+### Nexus-in-its-own-container — interaction model shift
+
+One deployment mode RDR-112 enables (and which the agentic-cockpit
+roadmap anticipates) is **packaging nexus itself as a container** —
+daemons, MCP server, CLI, and config inside a single OCI image that
+consumers attach to via UDS bind-mount or TCP. In that configuration
+**no out-of-band process on the host can reach the underlying SQLite
+file or chroma directory**: `sqlite3 ~/.nexus/t2.db`, `chroma utils
+info`, DBeaver, Datasette, ad-hoc `SELECT ... FROM memory WHERE ...`
+are all unavailable without `docker exec`-ing into the nexus
+container and even then constrained by what the image ships.
+
+Today these out-of-band paths are heavily used. Debugging a stuck
+indexer, sampling raw memory rows, inspecting a chroma collection,
+running one-off analytical SQL across the seven domain stores — all
+happen against the file directly. Containerising nexus closes those
+paths by design. The daemon-as-arbiter discipline is the whole
+point, but it means the daemon must **expose first-class
+introspection surfaces** to replace what ad-hoc DB access provides
+today.
+
+**Anticipated surfaces** (to be specified during planning, not
+locked here):
+
+- `nx daemon t2 exec <SQL>` — execute a parameterised read-only
+  query via RPC, output as JSON or table. Read-only by default;
+  explicit `--write` flag for destructive ops gated on a
+  confirmation prompt. Replaces `sqlite3 <file>` for the 90% case.
+- `nx daemon t3 peek <collection>` — paged inspection of a
+  collection's documents / metadata / embeddings. Replaces
+  `chromadb` CLI inspection.
+- `nx daemon t2 schema` / `nx daemon t3 schema` — print live schema
+  (T2 tables, T3 collection metadata) so external tooling can be
+  code-generated against the current shape.
+- `nx daemon t2 export [--table N] [--format jsonl|csv|sqlite]` —
+  snapshot dump to a path the daemon writes (mounted volume in
+  container mode). Replaces sqlite3's `.dump`.
+- `nx daemon t2 import` — reverse operation; required for backup
+  restore parity.
+- **Streaming event log** — RDR-111's ORB projection of T2 change
+  events is the principled answer to "tail -f the database":
+  subscribe to `T2.changed` events filtered by table/project,
+  rendered in the cockpit UI or via `nx daemon t2 events --follow`.
+- **Read-only side-channel socket** — optional second UDS bound to
+  a `readonly` group, exposing only the read surface. Lets external
+  tooling (Grafana, DataDog SQL exporter, custom dashboards) attach
+  without write capability or in-daemon auth code.
+
+**What this RDR commits to**: the introspection surface must be
+**at least as expressive as `sqlite3 <file>` is today for read
+paths** before nexus-in-a-container ships as a supported deployment
+mode. Without that commitment, containerising nexus regresses
+operational visibility — the opposite of what this RDR exists to
+do.
+
+**How the commitment is kept**: `nx daemon t2 exec --raw <SQL>`
+forwards an arbitrary read-only SQL string through to the daemon's
+SQLite handle and streams results back as JSON or tabular output.
+The `--raw` flag is the audit-trail marker that opts out of the
+parameterised-query path. Read-only is enforced by the daemon
+opening a second connection in `mode=ro` for `--raw` execution,
+not by SQL pattern matching (which is brittle). This closes the
+long tail — recursive CTEs, `EXPLAIN QUERY PLAN`, anything the
+underlying SQLite supports — at the cost of one extra read-only
+connection per `--raw` invocation. `ATTACH DATABASE` for cross-DB
+joins is **out of scope** for v1 (would require the daemon to
+expose multiple file paths to clients, which conflicts with the
+"daemon owns the substrate" discipline); follow-on RDR if needed.
+
+**What this RDR explicitly defers**: an *interactive REPL* surface
+(`nx daemon t2 repl` for a sqlite3-like prompt) is nice-to-have for
+power users but not required for correctness. Planning picks it up
+if cheap; otherwise it falls to a follow-on RDR. The pipe-friendly
+`exec` subcommand is sufficient for scripted workflows.
+
+### Risks and Mitigations
+
+- **Risk**: Daemon crashes leave clients hanging.
+  **Mitigation**: Health-check + auto-respawn; clients fail loud with
+  recovery instructions rather than silent fallback to direct file.
+- **Risk**: Auto-spawn races between concurrent first-use clients.
+  **Mitigation**: Filesystem-lock-mediated spawn (the spawner takes
+  a lock on the discovery file before forking).
+- **Risk**: Sandbox containers with no host filesystem visibility at
+  all cannot read the discovery file.
+  **Mitigation**: `NX_T2_SOCK` / `NX_T2_ADDR` / `NX_T3_ADDR` env-var
+  injection is a co-primary discovery path per the A4 finding —
+  orchestrator captures the daemon's stdout-announced addresses and
+  passes them into the container at launch. T2 daemon binds both UDS
+  and loopback TCP so the orchestrator can pick whichever the
+  container can actually reach: bind-mount the UDS path for OCI
+  containers that allow mounts; rely on TCP for Windows-VM co-work,
+  containerised Claude Desktop, or sandboxes that allow-list ports
+  but not socket files. Cross-host co-work is still out of scope
+  (TCP listener is loopback-only by default; binding non-loopback
+  would require auth and is deferred to a future RDR).
+
+### Failure Modes
+
+- **Daemon down, client connects**: fail loud, suggest `nx daemon
+  start`. Do not silently degrade.
+- **Version mismatch**: client refuses to connect; report both versions.
+- **Daemon healthy, data corrupt**: same as today (SQLite/chroma
+  surface their own errors); the daemon does not mask them.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] RDR-110 accepted (defines the atomic-take primitive the T2
+  daemon must implement).
+- [x] RDR-110 planning chain notified of the `block=True` sequencing
+  constraint — recorded 2026-05-13 in RDR-110 §Revision History
+  ("Post-acceptance cross-reference 2026-05-12" subsection,
+  "Revised preference (2026-05-13, RDR-112 gate round 2)" block).
+  RDR-110 Phase 1 Step 4 ships `block=False` unconditionally and
+  `block=True` feature-flagged off until `NX_STORAGE_MODE=daemon`.
+- [x] All Critical Assumptions verified (A1 Documented, A2 Verified
+  for containers, A3 Verified via spike, A4 Refuted-then-redesigned).
+
+### Minimum Viable Validation
+
+A single end-to-end demo: two `claude -p` sub-processes on the same
+host, started in different working directories. One writes a memory
+via `memory_put`; the other reads it via `memory_get`. Today this
+fails (each gets its own T2). With this RDR, it succeeds.
+
+### Phase 1: Code Implementation
+
+To be expanded during `/nx:create-plan`.
+
+### Phase 2: Operational Activation
+
+To be expanded.
+
+### Day 2 Operations
+
+| Resource | List | Info | Delete | Verify | Backup |
+| --- | --- | --- | --- | --- | --- |
+| T2 daemon | `nx daemon list` | `nx daemon info t2` | `nx daemon stop t2` | health-check RPC | snapshot of underlying SQLite |
+| T3 daemon | `nx daemon list` | `nx daemon info t3` | `nx daemon stop t3` | health-check RPC | snapshot of underlying chroma dir |
+| Discovery files | `ls ~/.config/nexus/*_addr.*` | `cat <file>` | rm on daemon stop | daemon-startup writes | n/a (ephemeral) |
+
+### New Dependencies
+
+Probably none — stdlib `socketserver` / `multiprocessing.connection`
+for T2; chromadb itself for T3 (already a dep). To be confirmed.
+
+## Test Plan
+
+- **Scenario**: Two processes, distinct working dirs, same host —
+  memory_put in one, memory_get in the other. — **Verify**: value
+  is read back.
+- **Scenario**: Daemon killed mid-operation. — **Verify**: client
+  reports a clear error and does not silently fall back to direct
+  file.
+- **Scenario**: Two clients race to auto-spawn the daemon. —
+  **Verify**: exactly one daemon runs; the loser connects to the
+  winner.
+- **Scenario**: Client built against daemon version N+1 connects to
+  daemon version N. — **Verify**: handshake refuses with a clear
+  version message.
+- **Scenario**: RDR-110 atomic-take from two clients on the same
+  template. — **Verify**: exactly one wins; the other blocks or
+  fails per spec.
+
+## Validation
+
+### Testing Strategy
+
+1. **Scenario**: cross-process memory visibility (MVV).
+   **Expected**: visible.
+2. **Scenario**: cross-*container* memory visibility (Claude Desktop
+   ↔ host `nx` CLI).
+   **Expected**: visible.
+3. **Scenario**: daemon restart preserves data and notifies clients.
+   **Expected**: clients reconnect transparently or fail-loud per
+   policy.
+
+### Performance Expectations
+
+The RPC overhead on `memory_get` / `search` / `store_get` was the
+load-bearing performance question; the A3 spike closed it. Results
+(2000 iters over real `MemoryStore` on a tmp SQLite, 500 rows):
+direct in-process p50 = 85 µs; UDS p50 = 100 µs (+15 µs); TCP
+loopback p50 = 114 µs (+29 µs). All sub-millisecond. T3 store ops
+are dominated by embedding latency (ONNX 10–50 ms, Voyage
+100–300 ms); the transport hop is below noise. Full data in T2
+`nexus_rdr/112-research-A3-spike`.
+
+## Finalization Gate
+
+> Complete each item with a written response before marking this RDR
+> as **Accepted**.
+
+### Contradiction Check
+
+**One tension surfaced and resolved.** RDR-110 §CA #6 (Verified)
+states that SQLite `PRAGMA data_version` is "visible across
+processes" — true for same-host shared filesystem. RDR-112 §A2
+(Verified) establishes that container overlayfs bind mounts break
+the `mmap` semantics WAL relies on, which equally breaks
+`data_version`'s cross-process visibility. The two claims are
+both correct within their respective scopes; the apparent
+contradiction is a scope-tightening, not a refutation. **Resolved
+by sequencing constraint** in §Decision Rationale: RDR-110's
+`block=True` (the only consumer of `data_version` polling) gates
+on `NX_STORAGE_MODE=daemon` and ships only after the T2 daemon's
+blocking-take RPC. `block=False` and the rest of RDR-110 are
+unaffected. No other contradictions found between Research
+Findings, Proposed Solution, and the cross-referenced RDRs
+(110, 111, 105, 108).
+
+### Assumption Verification
+
+All four Critical Assumptions are closed:
+
+- **A1** (`chroma run` production quality): **Documented** (High
+  confidence) — Source Search of `chromadb/app.py` (FastAPI +
+  uvicorn, 40-thread pool) and live precedent in nexus T1
+  (`session.py:494-504`). T2 entry `112-research-A1`.
+- **A2** (WAL not a substitute): **Verified** for containers
+  (High confidence) — overlayfs blocks WAL `mmap`; same-host
+  remains correct. T2 entry `112-research-A2`.
+- **A3** (RPC overhead acceptable): **Verified** (High
+  confidence) — spike (`/tmp/rdr112_a3_spike.py`, 2000 iters):
+  UDS +15 µs p50, TCP loopback +29 µs p50. Both sub-ms. T2
+  entries `112-research-A3` and `112-research-A3-spike`.
+- **A4** (per-host UID discovery file works universally):
+  **Partially Refuted** (High confidence) — fails in
+  PID-namespaced containers. Design revised to dual-primary
+  (file + env var) co-equal paths. T2 entry `112-research-A4`.
+
+No load-bearing assumption remains Unverified.
+
+### Scope Verification
+
+Minimum Viable Validation (two `claude -p` sub-processes on the
+same host share memory via `memory_put` / `memory_get`) is in
+scope, not deferred. The cross-process T2 visibility test is the
+single end-to-end proof and ships with the daemon.
+
+### Cross-Cutting Concerns
+
+- **Versioning**: daemon-client handshake required; encoded in
+  the discovery file's `version` field. Mismatch fails loud.
+- **Build tool compatibility**: no new build-time deps
+  anticipated; stdlib `socketserver` / `multiprocessing.connection`
+  cover the T2 transport.
+- **Licensing**: no new third-party libs anticipated.
+- **Deployment model**: daemons run on the host; clients run
+  anywhere with a route to the host's UDS path or loopback TCP.
+- **IDE compatibility**: N/A.
+- **Incremental adoption**: rollout gates on
+  `NX_STORAGE_MODE=daemon|direct`. Semantics:
+  `direct` retains pre-112 file-handle behaviour (debug /
+  migration only); `daemon` requires a running daemon (fail-loud
+  if absent — **no auto-spawn in daemon mode** to avoid silent
+  ambiguity about which mode the client is in). Default is
+  `direct` until MVV passes, then flips to `daemon`. The flip is
+  the cutover marker; a `direct` fallback remains available
+  indefinitely for debugging but is not the recommended path
+  post-cutover.
+- **Secret/credential lifecycle**: N/A in v1 — local daemons,
+  UDS uses unix file permissions (`chmod 0600` + peer-credential
+  check on accept; see **RDR-113** for the v1 host-trust model),
+  TCP listeners are loopback-only. Future cross-host RDR will
+  introduce token-based auth.
+- **Memory management**: daemon long-lived; needs a memory
+  budget (to be set during planning based on expected concurrent
+  client count and result-set sizes).
+
+### Proportionality
+
+Document covers a structural shift in how every persistent
+shared-state store is accessed; size is justified. Research
+findings, assumption ledger, impact inventory, and gate
+finalisation are all evidence-backed. The remaining "to be
+expanded during `/nx:create-plan`" markers in §Implementation
+Plan Phase 1 / Phase 2 are appropriate — phase decomposition is
+the planner's job, not this RDR's.
+
+## Open Questions
+
+- **Authentication**: v1 assumes localhost-only and trusts every
+  local user. Is that the right call, or do we need a per-user UID
+  check on connect?
+- **Cross-host**: every assumption here is single-host. What's the
+  story when a co-worker runs nexus on a different machine? Out of
+  scope for this RDR but worth naming.
+- **Daemon-as-MCP**: should the T2 daemon eventually *be* the MCP
+  server, collapsing two layers? Or are they intentionally distinct?
+- **Migration**: how do existing on-disk T2/T3 stores get picked up
+  by the new daemons? Presumably "the daemon opens the same path the
+  old direct client did" — but worth being explicit.
+- **Container image surface**: if nexus ships as a container, which
+  external paths must remain available — `/tmp` for downloads, the
+  user's git repos for indexing, an output volume for `export`? The
+  container's filesystem contract is part of the introspection story.
+
+## References
+
+- RDR-004: Four-Store Architecture (the original tier definitions)
+- RDR-041: T1 Scratch Inter-Agent Context
+- RDR-105: T1 Chroma Architecture — Env Passdown (the proof-of-concept
+  for host-service-plus-discovery)
+- RDR-108: Graph Identity Normalization (relies on a single catalog
+  source-of-truth that this RDR's T2 daemon would arbitrate)
+- RDR-110: Semantic Tuple Space (needs an arbiter to implement `in`)
+- RDR-111: ORB — Observable Relay Bus (needs a publishing point at the
+  storage edge)
+
+## Revision History
+
+- 2026-05-12 — Initial draft. Hal.
+- 2026-05-12 — Research phase: A1 Documented (High), A2 Verified for
+  containers / Inconclusive same-host (High/Med), A3 Inconclusive
+  pending spike (Med), A4 Partially Refuted (High) — discovery needs
+  dual-primary design. Findings in T2 `nexus_rdr/112-research-A{1..4}`.
+- 2026-05-12 — A3 spike executed: UDS overhead +15 µs p50 on
+  `memory_get`, TCP loopback +29 µs p50 with doubled p99 tail.
+  A3 promoted to Verified.
+- 2026-05-12 — Design: T2 daemon binds **both UDS and loopback TCP**.
+  Client preference order is UDS → TCP. Reversed an earlier UDS-only
+  lock after considering Windows-VM co-work, containerised Claude
+  Desktop, and port-allow-listing sandboxes where UDS bind-mounts
+  aren't an option. The A3 spike's ~14 µs gap between transports
+  makes the fallback essentially free. T3 keeps loopback TCP
+  (upstream chromadb constraint). TCP listeners are loopback-only;
+  cross-host co-work is still a future RDR.
+- 2026-05-12 — Added **Nexus-in-its-own-container** trade-off
+  subsection anticipating the deployment mode where nexus itself is
+  the container. Ad-hoc DB access (`sqlite3 <file>`, DBeaver, etc.)
+  becomes unavailable; the daemon must therefore expose first-class
+  introspection surfaces (`exec`, `peek`, `schema`, `export`,
+  streaming events, optional read-only side socket) that are at
+  least as expressive as direct-file reads. Cross-references RDR-110
+  (atomic-take CAS unchanged — same SQLite handle, single process,
+  daemon hosts it) and RDR-111 (event-streaming surface).
+- 2026-05-12 — **Scope generalised**: RDR-112 covers *every*
+  persistent shared-state store, not just T2 and T3. Initial draft
+  scoped narrowly out of caution; an impact analysis (T2:
+  `nexus_rdr/112-research-impact-inventory`) revealed `CatalogDB`
+  (`src/nexus/catalog/catalog_db.py:250-255`) is structurally
+  identical to a T2 domain store and equally vulnerable. Cherry-picking
+  only T2/T3 would leave the same silo bug under another name and
+  invite future stores to repeat the pattern. Title updated;
+  Technical Environment lists in-scope stores explicitly;
+  Existing Infrastructure Audit adds CatalogDB and a lint rule
+  banning direct `sqlite3.connect` / `PersistentClient` outside
+  daemon-internal code. Approach §3 names two planning-time options
+  for CatalogDB (collapse into T2, or ship as third daemon).
+  Discovery and lifecycle hooks (§6, §7) renumbered to reflect.
+- 2026-05-13 — **Gate round 1 BLOCKED** (substantive-critic
+  `a67d3d730415cb2c8`): 2 critical, 3 significant, 3 observations.
+  Round-1 closeout this revision:
+  - C1 (RDR-110 `block=True` sequencing creates container soak-bug
+    via `data_version` overlayfs failure): **resolved** by new
+    §Decision Rationale "Sequencing constraint vs RDR-110"
+    subsection and Implementation Plan Prerequisites — `block=True`
+    gates on `NX_STORAGE_MODE=daemon`, Phase 1 ships `block=False`
+    only. RDR-110 planning chain to be notified.
+  - C2 (Finalization Gate boilerplate contradicted body):
+    **resolved** by rewriting Contradiction Check, Assumption
+    Verification, Scope Verification, Cross-Cutting Concerns, and
+    Proportionality with current-state evidence.
+  - S1 (CatalogDB punt lacked criteria): **resolved** by §Proposed
+    Solution §3 committing to collapse into T2 as eighth domain
+    store; planning-time flip allowed only on concrete crash/
+    contention evidence.
+  - S2 (introspection commitment under-backed): **resolved** by
+    `nx daemon t2 exec --raw` commitment plus read-only-connection
+    enforcement; `ATTACH DATABASE` explicitly out of v1. Open
+    Question retired.
+  - S3 (`NX_STORAGE_MODE` underspecified): **resolved** in
+    Cross-Cutting Concerns — `direct` retains pre-112 behaviour,
+    `daemon` fails loud (no auto-spawn), default flips post-MVV.
+  - O1, O2, O3 (RDR-111 consistency, read-only side socket loopback
+    constraint, stale "Spike A3 pending" forward reference):
+    Performance Expectations rewritten with measured A3 data;
+    other two folded into existing prose. No structural changes
+    needed.
+- 2026-05-13 — **Gate round 2 BLOCKED** (substantive-critic
+  `a737a8c724835c148`): 1 critical, 1 significant, 3 observations
+  (closeout verifications). Round-2 closeout this revision:
+  - C1' (round-2): RDR-112's "ship `block=True` only behind
+    daemon" claim contradicted RDR-110's existing revision-history
+    preference for Option 1 (ship direct-file first); the C1
+    closeout had written one side of the constraint without
+    updating the other. **Resolved** by editing RDR-110's
+    "Post-acceptance cross-reference" subsection to record the
+    revised hybrid ordering (`block=False` ships in Phase 1
+    unconditionally; `block=True` lands as feature-flagged code
+    gated behind `NX_STORAGE_MODE=daemon`). The CAS primitive is
+    unchanged in either path. Both documents now agree.
+  - S1' (round-2): Implementation Plan prerequisite bullet
+    "RDR-110 planning chain notified" was unchecked.
+    **Resolved** — RDR-110 revision history updated 2026-05-13;
+    bullet checked with a forward reference to the specific
+    subsection.
+  - All round-1 closeouts (C2/S1/S2/S3/O1/O2/O3) verified clean
+    by round-2 critic; no regressions introduced by round-1
+    edits.
+- 2026-05-13 — **Triad rework (110/111/112 composition gaps)**:
+  deep-analyst pass `a56172936d63fd480` surfaced 10 gaps between
+  the three RDRs that local gates couldn't see. User chose deep
+  rework (option D). Three load-bearing decisions:
+  - **D1**: MCP server is a **client** of the daemon, not the
+    daemon itself. Recorded here; closes G10. RDR-110/111
+    watcher placement updates follow.
+  - **D2**: Event bus is the `EventStream(subspace_prefix,
+    since_cursor)` streaming RPC on the daemon (new Approach
+    §7 above). Closes G2 (RDR-111 watcher subscription protocol)
+    and G8 (daemon lifecycle events first-class on same bus).
+  - **D3**: Under `NX_STORAGE_MODE=daemon`, **no client ever
+    touches the SQLite file**. Direct-file mode is single-host
+    single-filesystem only. Recorded in RDR-110 revision-history
+    "Further-revised scope" block. Closes G1 (overlayfs
+    correctness extends past `data_version` to the entire CAS
+    primitive, sweeps, audit).
+  This revision also adds Approach §8 (subspace registry —
+  daemon validates, closing G3), Approach §9 (daemon is sole
+  migration runner, closing G4), failure-category demux on the
+  event stream (closing G5 with the matching consumer-side
+  change in RDR-111), and forward-references RDR-113 for host
+  trust / UDS auth (closing G6). G7 closes via a one-line
+  forward-reference in `docs/workflow-engine-synthesis.md`. G9
+  (cross-triad integration test) becomes a planning-time bead.
+- 2026-05-13 — **Light re-gate post-triad-rework PASSED**
+  (substantive-critic `abbc3adfbe8d94ca2`, 0C/1S/1O). Critic
+  confirmed §7-§10 integrate cleanly with §1-§6; cross-RDR
+  consistency with RDR-111 (EventStream signature, CA-9, CA-10)
+  solid; R3 PASSED items intact. Closeouts in this revision:
+  - S1 (Approach §5 lint-rule enforcement was an unresolved
+    disjunction predating the rework): committed to
+    `nx doctor --check-storage-boundary` as the concrete tool,
+    AST-scan modelled on the existing RDR-101 Phase 3 ε-lint at
+    `tests/test_no_direct_catalog_writes_outside_projector.py`.
+    Trigger (CI step + `nx doctor` default audit), surfacing
+    (file:line + exit 1), and escape hatch
+    (`# storage-boundary-allow: <reason>`, ≥8-char) all named.
+  - O1 (RDR-113 forward-reference lived only in revision
+    history + frontmatter): added a body-prose cite in
+    Cross-Cutting Concerns §Secret/credential lifecycle so the
+    cross-reference is navigable without a revision-history
+    dig.

--- a/docs/rdr/rdr-113-host-trust-model.md
+++ b/docs/rdr/rdr-113-host-trust-model.md
@@ -1,0 +1,468 @@
+---
+title: "Host-Trust Model for nexus Daemons: UDS Permissions, Peer Credentials, Single-User v1"
+id: RDR-113
+type: Architecture
+status: scrapped
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-13
+accepted_date: 2026-05-13
+scrapped_date: 2026-05-19
+scrap_reason: "Part of the RDR-110/111/112/113/118/119 arc that bundled the storage-substrate split with new abstractions. Host-trust model was a consumer-of-substrate design rather than substrate itself; deferred until after RDR-120 substrate ships and stabilizes. Single-user UDS-permissions baseline carries forward as RDR-120's v1 assumption. Postmortem: docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md."
+related_issues: []
+related_rdrs: [RDR-105, RDR-110, RDR-111, RDR-112, RDR-120]
+related_tests: []
+implementation_notes: ""
+---
+
+> **TOMBSTONE 2026-05-19.** This RDR is preserved as historical reference. The arc was scrapped due to scope entanglement; see frontmatter `scrap_reason` and the [postmortem](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work: [RDR-120](rdr-120-storage-substrate-split.md). Multi-user / cross-host trust is deferred to a post-substrate RDR. Do not implement against this design.
+
+---
+
+
+# RDR-113: Host-Trust Model for nexus Daemons: UDS Permissions, Peer Credentials, Single-User v1
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+RDR-112 puts T2, T3, and CatalogDB behind daemons that accept
+connections over a unix-domain socket (UDS-primary) or loopback
+TCP (fallback). The v1 framing in RDR-112 §Cross-Cutting Concerns
+says "no auth in v1 — local daemons, UDS uses unix file
+permissions, TCP listeners are loopback-only." That sentence is
+load-bearing for cross-RDR safety claims but no concrete trust
+model is committed: the UDS `chmod` value is unspecified, the
+TCP listener's bind address is not pinned, and there is no
+explicit answer to "who can attach to my daemon?"
+
+RDR-111's ORB cockpit raises the stakes. Its panels project
+*every host agent's state* — running tools, pending bindings,
+hook events. RDR-110's tuple space carries `mailbox/<agent>`
+subspaces (agent-to-agent direct messaging). If a second user
+on the same host can attach to the daemon, that user can read
+every memory entry, every in-flight tuple, every hook event,
+and every mailbox — and can post messages impersonating any
+agent.
+
+For nexus's actual deployment model — single-user developer
+laptops, occasionally a shared dev VM — the threat is small but
+real. For the daemon model to be defensible at all, the trust
+boundary needs to be named and enforced, not assumed.
+
+### Enumerated gaps to close
+
+#### Gap 1: UDS socket file mode is unspecified
+
+RDR-112 references "unix file permissions" but never commits to
+a value. The default umask on most systems is `0022`, which
+would create the socket as `0755` (world-readable, owner-write).
+Any local user could `connect()` to the daemon. The fix is a
+specific `chmod` value, applied by the daemon at bind time
+before announcing the address.
+
+#### Gap 2: TCP fallback bind address is not pinned
+
+RDR-112 says "TCP listeners are loopback-only" in prose but
+does not commit to `127.0.0.1` (vs `0.0.0.0`) in the design
+artefact. Future planning could read the prose as advisory and
+bind a routable interface. A binding-time commitment prevents
+the silent regression.
+
+#### Gap 3: No peer-credential check on connect
+
+UDS supports `SO_PEERCRED` (Linux) and `LOCAL_PEERCRED` (macOS),
+which return the connecting peer's UID. The daemon currently
+performs no check. On a multi-user host (rare but real for dev
+VMs), file permissions alone may be circumventable — for
+instance, if the socket path traverses a directory the second
+user controls. A peer-UID check at accept time is cheap and
+closes the residual gap.
+
+#### Gap 4: No commitment on what v1 *does not* protect against
+
+"Single-user v1" needs a written boundary. Threats RDR-113
+explicitly does *not* address: a malicious local process
+running as the same user (it can read the SQLite file directly
+if the daemon is down, and can connect to the UDS regardless);
+a compromised parent process injecting `NX_T2_ADDR` env vars;
+cross-host attacks (out of scope per RDR-112). Naming the
+boundary prevents over-claiming.
+
+## Context
+
+### Background
+
+This RDR was spun out of the RDR-110/111/112 triad rework
+(2026-05-13) as the closure for gap G6. The triad analysis
+flagged that RDR-112's auth deferral was vague enough that
+"no auth in v1" could be read as "we'll get to it later," when
+the actual stance — for the daemon model to compose safely with
+RDR-110's mailbox tuples and RDR-111's cockpit projection —
+needs to be "v1 enforces single-user host trust via UDS
+permissions and peer credentials." That stance is small enough
+to land in a mini-RDR, large enough to deserve its own gate.
+
+### Technical Environment
+
+- **UDS sockets**: stdlib `socketserver` / `multiprocessing.connection`.
+  `socket.bind()` creates the path with current umask; daemon
+  must `os.chmod()` after bind to set the desired mode.
+- **TCP fallback**: stdlib `socketserver` with `server_address =
+  ('127.0.0.1', 0)` for explicit loopback bind.
+- **Peer credentials**: `socket.SO_PEERCRED` (Linux), via
+  `getsockopt(SOL_SOCKET, SO_PEERCRED, ...)`; `LOCAL_PEERCRED`
+  (macOS), via `getsockopt(SOL_LOCAL, LOCAL_PEERCRED, ...)`.
+  Both available without third-party deps.
+
+## Research Findings
+
+### Investigation
+
+- **Inherited pattern from RDR-105**: The T1 chroma server
+  spawned at `session.py:494-504` is a similar host-local
+  daemon. Inspecting its current bind-time behaviour: TCP only,
+  port 0 (dynamic), bound to whatever interface chromadb's HTTP
+  server defaults to (loopback in practice, but not enforced).
+  RDR-113 tightens this pattern rather than inventing one from
+  scratch.
+- **Docker socket precedent**: `/var/run/docker.sock` ships
+  `0660` with `root:docker` ownership; users in the `docker`
+  group connect. nexus's analogue: `0600` with the running
+  user's UID; no group ACL in v1.
+- **PostgreSQL UDS precedent**: peer authentication via
+  `pg_hba.conf` checks `SO_PEERCRED` UID against database role.
+  nexus v1 is simpler: peer UID must equal the daemon's UID, no
+  multi-user mapping.
+
+### Key Discoveries
+
+- **Verified**: `os.chmod(socket_path, 0o600)` after
+  `socket.bind()` is the standard way to restrict UDS access to
+  the owner. Verified against stdlib docs and a quick spike.
+- **Documented**: `SO_PEERCRED` returns `(pid, uid, gid)` on
+  Linux; `LOCAL_PEERCRED` returns `xucred` on macOS. Both work
+  without setting any flag on the listening socket beforehand.
+- **Assumed**: TCP loopback peers cannot be reliably identified.
+  `SO_PEERCRED` does not apply to TCP. The v1 stance accepts
+  this — TCP fallback is for orchestrator-injected access
+  (containers, VMs), where the orchestrator is the trust
+  boundary, not the daemon.
+
+### Critical Assumptions
+
+- [x] **A1**: `os.chmod(0o600)` on the UDS path is honored
+  before any client `connect()` attempt — i.e., there is no
+  race window between `bind()` and `chmod()` where a fast peer
+  could attach with default-umask permissions.
+  — **Status**: **Verified** (2026-05-13 spike at
+  `/tmp/rdr113_a1_spike.py`; T2 entry
+  `nexus_rdr/113-research-A1-spike`) — **Method**: Spike.
+  **Finding**: `bind()` alone does not enable connections —
+  `connect()` to a bound-but-not-listening UDS returns
+  `ConnectionRefusedError`. The actual gate is `listen()`, not
+  `bind()`. Ordering `bind() → chmod(0o600) → listen()` closes
+  the race window to zero: during the bind→chmod gap (~13 µs in
+  the spike), no peer can connect because no backlog exists.
+  Defense-in-depth via parent-dir `0o700` is preserved as
+  belt-and-braces. The §Risks "temp-path + atomic-rename"
+  mitigation is unnecessary given this finding and is retired
+  below.
+- [ ] **A2**: `SO_PEERCRED` / `LOCAL_PEERCRED` reliably return
+  the *originator* of the connection, not a forwarding proxy
+  (relevant if the user later puts the daemon behind a
+  socket-relay).
+  — **Status**: Unverified — **Method**: Docs Only is
+  sufficient for v1; revisit if proxying is introduced.
+
+## Proposed Solution
+
+### Approach
+
+**v1 trust model: single-user host, daemon owner == client owner.**
+
+1. **UDS bind discipline** (T2, T3, CatalogDB daemons) —
+   ordering matters, A1-verified:
+   - `socket.bind(path)` → `os.chmod(path, 0o600)` →
+     `sock.listen(backlog)`, in that order. Per A1, `connect()`
+     against a bound-but-not-listening UDS returns
+     `ConnectionRefusedError`, so the bind→chmod window is
+     closed by `listen()` not having been called yet. The mode
+     is restricted before any peer can establish a connection.
+   - Daemon refuses to start if `os.geteuid() != os.stat(path).st_uid`
+     after chmod (sanity check).
+   - Socket directory (`~/.config/nexus/sockets/` or similar)
+     created with `0o700` if not present. Defense-in-depth: even
+     if the socket inode somehow ends up at default mode (e.g.
+     chmod silently failed on an exotic filesystem), the parent
+     dir gates path traversal.
+
+2. **TCP bind discipline**:
+   - `server_address = ('127.0.0.1', port)`. Hard-coded
+     loopback; never `0.0.0.0`, never the host's external IP,
+     never a `--bind-host` flag in v1.
+   - `port=0` for dynamic allocation; actual port goes into
+     discovery file and stdout announcement.
+
+3. **Peer-UID check on accept**:
+   - For UDS connections: read `SO_PEERCRED` / `LOCAL_PEERCRED`;
+     reject with a clear error if peer UID ≠ daemon UID.
+   - For TCP connections: no UID check (loopback only; trust
+     boundary is the orchestrator).
+   - Rejection is logged at INFO with peer PID + UID for audit.
+
+4. **No in-protocol auth in v1**:
+   - No tokens, no challenge/response, no TLS. The UDS/TCP
+     bind discipline plus peer-cred check is the entire trust
+     mechanism.
+   - Future RDR will add token-based auth for cross-host /
+     multi-user / federated deployments.
+
+5. **Explicit non-goals (named in §Threat Model below)**:
+   - Same-user malicious processes (they own the socket and the
+     SQLite file directly; defence against this is outside
+     nexus's trust boundary).
+   - Compromised parent processes injecting `NX_T2_ADDR`.
+   - Cross-host attacks (RDR-112 out of scope).
+
+### Threat Model
+
+| Threat | Mitigation | Residual risk |
+| --- | --- | --- |
+| Second user on host attaches to my UDS | `chmod 0600` + peer-UID check | None (v1) |
+| Second user crafts TCP connection to my daemon | Loopback bind + peer cannot reach loopback as another user | None (single-host) |
+| Same-user malicious process | **Not addressed in v1** | Accepted — user owns the data |
+| Daemon impersonation by same-user rogue process | **Not addressed in v1** (subsumed by "same-user malicious process" non-goal — a process running as the daemon's UID can bind any path the daemon could) | Accepted — user owns the host |
+| Cross-host attacker | **Not addressed in v1** | RDR-112 out of scope |
+| TCP listener reaches the network | Hard-coded `127.0.0.1` bind, no flag to override | None (v1) |
+
+### Decision Rationale
+
+Minimum-viable trust model that closes the visible gap (G6)
+without inventing auth code we don't yet need. The threat model
+matches nexus's actual deployment (single-user developer
+laptop), names the cases it explicitly doesn't protect against,
+and leaves a clean seam for a future auth RDR if/when the
+threat model expands.
+
+## Alternatives Considered
+
+### Alternative 1: Token-based auth in v1
+
+**Description**: Daemon generates a token at startup, writes it
+to the discovery file alongside the socket address; clients
+must present the token on every RPC.
+
+**Pros**:
+- Closes the same-user-malicious-process threat (process needs
+  read access to the discovery file *and* the socket).
+- Forward-compatible with cross-host auth.
+
+**Cons**:
+- The discovery file is in the same place the malicious process
+  would already have read access to. Net protection is small.
+- Adds RPC overhead and token-rotation lifecycle for marginal
+  benefit at v1 scale.
+
+**Reason for rejection**: Cost-benefit doesn't justify v1.
+Token auth lands when the threat model justifies it (multi-user
+or cross-host).
+
+### Briefly Rejected
+
+- **mTLS**: Heavy; appropriate for cross-host, not single-host.
+- **Group-based UDS ACLs** (`chmod 0660` + group): unnecessary
+  generalisation for single-user v1; can land later if shared
+  dev VMs become a supported deployment.
+
+## Trade-offs
+
+### Consequences
+
+- (+) Closes G6 (multi-user host exposure) at full v1 scope.
+- (+) Threat model written down — over-claiming prevented.
+- (−) Same-user malicious process is explicitly out of scope;
+  if a user's threat model includes that, RDR-113 doesn't help.
+- (−) Peer-cred check adds one `getsockopt()` per accept;
+  negligible.
+
+### Risks and Mitigations
+
+- **Risk** (retired): Race window between `bind()` and
+  `chmod()`. **Disposition**: A1 spike verified the window is
+  effectively zero given `bind() → chmod() → listen()`
+  ordering, because `connect()` to a bound-but-not-listening
+  UDS returns `ConnectionRefusedError`. No temp-path-plus-
+  atomic-rename mitigation required. Defense-in-depth via
+  parent-dir `0o700` is retained.
+- **Risk**: macOS `LOCAL_PEERCRED` quirks (different struct
+  shape from Linux `SO_PEERCRED`).
+  **Mitigation**: platform-specific accessor in `nexus.daemon.peer`;
+  unit tests on both OS.
+
+### Failure Modes
+
+- **UDS chmod fails** (e.g., filesystem doesn't support it):
+  daemon fails to start with a clear error. No silent fallback.
+- **Peer-cred rejection**: client sees a `PermissionDenied`
+  RPC error with a message naming the daemon's expected UID and
+  the peer's actual UID. Logged daemon-side.
+- **`getsockopt(SO_PEERCRED / LOCAL_PEERCRED)` itself raises**
+  (unexpected platform, sandbox restriction, kernel version
+  gap): daemon closes the connection with a clear error and
+  logs at ERROR. **No fallback to "accept with warning"** —
+  consistent with the chmod-failure handling above; the trust
+  model is fail-loud.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] RDR-112 accepted (this RDR layers onto its daemon model).
+- [ ] A1 verified (no `bind()`-to-`chmod()` race).
+
+### Minimum Viable Validation
+
+Two users on the same host. User A starts `nx daemon t2`. User
+B tries to `nx memory get` against User A's socket path. The
+attempt must fail loud with a peer-UID rejection message — not
+hang, not silently fall back, not return a stale read.
+
+### Phase 1: Daemon-side enforcement
+
+To be expanded during `/nx:create-plan`.
+
+### Day 2 Operations
+
+| Resource | List | Info | Delete | Verify | Backup |
+| --- | --- | --- | --- | --- | --- |
+| UDS socket file | `ls -la <path>` | `stat <path>` | daemon stop | `stat` mode == `0600` | n/a |
+| TCP bind address | `ss -tlnp | grep nx-daemon` | discovery file | daemon stop | bind == `127.0.0.1:N` | n/a |
+
+### New Dependencies
+
+None. Stdlib `socket`, `os`, `getsockopt`.
+
+## Test Plan
+
+- **Scenario**: Daemon binds UDS; check `os.stat(path).st_mode & 0o777 == 0o600`. — **Verify**: passes.
+- **Scenario**: User B (different UID) connects to User A's UDS. — **Verify**: connect fails or accept rejects with clear message.
+- **Scenario**: Daemon TCP bind. — **Verify**: `ss -tln` shows `127.0.0.1:N`, not `0.0.0.0:N`.
+- **Scenario**: `LOCAL_PEERCRED` path on macOS. — **Verify**: peer UID parsed correctly.
+- **Scenario**: After `bind() → chmod() → listen()` ordering, assert `os.stat(socket_path).st_mode & 0o777 == 0o600` is observable before the listening backlog opens — i.e. between `chmod()` and `listen()` calls. (A1 spike already proved that `connect()` against a bound-but-not-listening UDS refuses, so no peer-side race test can fire; this scenario instead asserts the mode invariant the spike relies on.)
+
+## Validation
+
+### Testing Strategy
+
+1. Unit tests for the peer-cred accessor on Linux + macOS.
+2. Integration test: two-user MVV scenario (CI uses sudo or
+   `unshare -U` to fake a second UID).
+3. Negative test: TCP bind never exposes a non-loopback
+   interface.
+
+### Performance Expectations
+
+`getsockopt(SO_PEERCRED)` is a single syscall on accept;
+negligible. No measurable overhead expected.
+
+## Finalization Gate
+
+> Complete each item with a written response before marking
+> this RDR as **Accepted**.
+
+### Contradiction Check
+
+To be filled at gate time. Pre-check: this RDR layers cleanly
+on RDR-112 (no contradiction); RDR-110 and RDR-111 inherit the
+trust boundary without changes (they observe via the daemon,
+which now performs the peer check).
+
+### Assumption Verification
+
+- **A1**: **Verified** (2026-05-13). Spike at
+  `/tmp/rdr113_a1_spike.py` confirmed that `connect()` against a
+  bound-but-not-listening UDS returns `ConnectionRefusedError`.
+  The required ordering — `bind() → chmod(0o600) → listen()` —
+  closes the race window to zero. Bind→chmod gap measured at
+  ~13 µs; irrelevant because no peer can connect before
+  `listen()`. T2 entry: `nexus_rdr/113-research-A1-spike`.
+- **A2**: **Documented** (Docs Only is sufficient per the
+  Critical Assumptions table). Revisit only if a socket-relay
+  is introduced.
+
+### Scope Verification
+
+MVV (cross-user rejection) is in scope, not deferred. Single
+end-to-end test using two host UIDs.
+
+### Cross-Cutting Concerns
+
+- **Versioning**: trust model is invariant across daemon
+  versions; no handshake field needed.
+- **Build tool compatibility**: stdlib only.
+- **Licensing**: N/A.
+- **Deployment model**: single-user host (named explicitly).
+- **IDE compatibility**: N/A.
+- **Incremental adoption**: enforced from daemon v1; no flag.
+- **Secret/credential lifecycle**: N/A (no secrets in v1).
+- **Memory management**: N/A.
+
+### Proportionality
+
+Mini-RDR; right-sized for a single closure of G6.
+
+## Open Questions
+
+- **Future auth surface**: when the threat model expands
+  (cross-host, multi-user, federated), token-based auth lands
+  in a follow-on RDR. RDR-113's discipline survives that change
+  as the host-local v1 path.
+- **`docker:docker` group analogue**: if shared dev VMs become
+  supported, RDR-113 v2 may add group-based ACLs (`chmod 0660`).
+  Deferred.
+
+## References
+
+- RDR-105: T1 Chroma Architecture — Env Passdown (the
+  precedent for host-local daemon spawning).
+- RDR-110: Semantic Tuple Space (mailbox subspaces inherit the
+  trust boundary).
+- RDR-111: ORB Observable Relay Bus (cockpit projection
+  inherits the trust boundary).
+- RDR-112: Storage-as-Service (this RDR closes its G6 gap).
+- POSIX `socket(7)`, `unix(7)`, `SO_PEERCRED` Linux man page.
+
+## Revision History
+
+- 2026-05-13 — Initial draft. Spun out of RDR-110/111/112 triad
+  rework as the closure for gap G6.
+- 2026-05-13 — A1 spike executed. Verified that `bind() →
+  chmod(0o600) → listen()` ordering closes the race window
+  because `connect()` against a bound-but-not-listening UDS
+  returns `ConnectionRefusedError`. §Proposed Solution §1 UDS
+  bind discipline updated to record the required ordering;
+  §Risks "Race window between bind() and chmod()" retired;
+  §Finalization Gate Assumption Verification updated. T2:
+  `nexus_rdr/113-research-A1-spike`.
+- 2026-05-13 — **Gate round 1 PASSED** (substantive-critic
+  `ad665ee8c98897352`, 0C/2S/2O). Significant closeouts in this
+  revision:
+  - S1 (T2 spike record cited but critic couldn't find it):
+    record exists at `nexus_rdr/113-research-A1-spike` (critic
+    searched the wrong project `nexus`); confirmed present.
+  - S2 (daemon-impersonation row committed to unspiked
+    mitigation): row reworded to "not addressed in v1" —
+    subsumed by the same-user-malicious-process non-goal, since
+    a same-UID rogue can bind any path the legitimate daemon
+    could. No new spike or assumption needed.
+  Observations:
+  - Obs1: §Failure Modes extended — `getsockopt` itself raising
+    is now explicitly fail-loud, no silent fallback.
+  - Obs2: Test Plan scenario 5 reframed — A1 already proved
+    no peer-side race test can fire, so the scenario instead
+    asserts the mode-invariant the spike relies on.
+  - Obs3 (macOS `LOCAL_PEERCRED` quirks): kept as-is, critic
+    confirmed proportional for mini-RDR.

--- a/docs/rdr/rdr-118-surfaces-as-tuples.md
+++ b/docs/rdr/rdr-118-surfaces-as-tuples.md
@@ -1,0 +1,694 @@
+---
+title: "Surfaces as Tuples — The ORB is the Portal Broker (A2UI Adoption + Xanadu Inheritance)"
+id: RDR-118
+type: Architecture
+status: scrapped
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-17
+revised: 2026-05-18
+accepted_date:
+scrapped_date: 2026-05-19
+scrap_reason: "Draft never gated. Built atop the RDR-110/111/112/113 arc which itself was scrapped for scope entanglement. Surfaces-as-tuples is a multi-layer consumer (tuplespace + ORB + portal broker) and is structurally not eligible until substrate work (RDR-120) ships and the moratorium lifts. Postmortem: docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md."
+related_issues: []
+related_rdrs: [RDR-053, RDR-108, RDR-110, RDR-111, RDR-112, RDR-113, RDR-120]
+related_external: [a2ui-v0.8-spec, a2ui-v0.9-draft, ag-ui, a2a-protocol, mcp]
+reactivates_beads: [nexus-kkh2, nexus-0rws, nexus-kgo4]
+related_tests: []
+---
+
+> **TOMBSTONE 2026-05-19.** This RDR is preserved as historical reference. Never gated; built atop a scrapped arc. See frontmatter `scrap_reason` and the [postmortem](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work: [RDR-120](rdr-120-storage-substrate-split.md). Do not implement against this design.
+
+---
+
+
+# RDR-118: Surfaces as Tuples — The ORB is the Portal Broker
+
+> Third iteration. The first two sketches re-derived layers that already
+> exist. This one names the inheritance honestly and limits itself to the
+> delta nexus actually adds.
+
+## Problem Statement
+
+RDR-111 ships the cockpit substrate (surface levels, bindings primitive,
+auto-layout engine, layout_state subspace, three reference panels). RDR-110
+ships the semantic tuple space — the broker. RDR-053 ships Xanadu fidelity
+(`chash://` content-addressed spans, tumbler comparison, link survivability)
+at the catalog layer. A2UI v0.8 (Google, 2026, Apache 2.0) ships the
+canonical surface descriptor protocol — explicitly anticipated by
+`agentic-cockpit.md` lines 813–815 as the mature target format.
+
+What's missing is the **small discipline that wires these layers together**
+so a cell can be (a) heterogeneous content from an arbitrary producer,
+(b) recursively composable, (c) capability-negotiated with the host,
+(d) referenced by stable content address, and (e) trust-scoped under the
+existing daemon boundary. That wiring is this RDR.
+
+This RDR adopts A2UI v0.8 as the descriptor format, inherits RDR-053's
+`chash://` transclusion stack, reuses RDR-111's `layout_state` placement
+protocol, and adds four small things: a `surface_cell` subspace, a
+sibling-surface recursion convention, `chash://` as a BoundValue path,
+and producer discipline for HATEOAS-style action affordances.
+
+### Enumerated gaps to close
+
+#### Gap 1: No published cell-as-tuple schema bridging `bindings/<profile>` to A2UI
+
+RDR-111 ships `bindings/<profile>` with an opaque `surface_payload` field.
+A2UI ships a structured `surfaceUpdate` event. There is no documented
+mapping between them. Without it, producers and hosts coordinate ad-hoc,
+which forks.
+
+#### Gap 2: No recursion convention (A2UI doesn't cover nested surfaces)
+
+A2UI supports multiple `surfaceId`s but no nested-surface composition. A
+cell that hosts another surface is undocumented. Sibling-surface
+coordination via tuple is the smallest extension that preserves the
+recursive-surfaces ambition.
+
+#### Gap 3: No first-class transclusion path
+
+RDR-053 ships `chash://<hash>[#span]` as the catalog-layer content
+address. Cells should be able to render content by referencing a chash —
+without inventing a new URI scheme or new resolution path. A2UI's
+`BoundValue.path` field is the natural attachment point.
+
+#### Gap 4: No per-cell origin refinement of RDR-113
+
+RDR-113 sets trust at the daemon boundary. A2UI v0.9 carries identity via
+`iconUrl` and `agentDisplayName`. We need a per-cell `origin` dimension on
+`surface_cell` that refines RDR-113 (the daemon decides who can attach;
+`origin` labels who's currently rendering inside that boundary). Not new
+trust — finer labeling within existing trust.
+
+## Context
+
+### Animating principle (preserved across iterations)
+
+The nexus thesis is that producers and consumers should bind by **meaning**
+— RDR-110 semantic tuple space, `match_text` fields, NLP-parsed bindings.
+The ORB is the broker; the substrate already does capability negotiation.
+A2UI's *catalog* abstraction is the protocol-level realization of the same
+discipline: clients hold pre-approved component catalogs; agents request
+from them; the negotiation IS the capability handshake.
+
+We do **not** invent a parallel decider, MIME registry, or capability
+bundle. The tuple space + A2UI catalogs together cover this.
+
+### Inheritance map (zero new substrate code)
+
+| Concern | Inherited from | Notes |
+|---|---|---|
+| Surface descriptor schema | A2UI v0.8 (Stable) | `surfaceId`, `surfaceUpdate`, `dataModelUpdate`, `userAction`, `BoundValue`. |
+| Component catalogs | A2UI + RDR-110 dimension registry | Catalogs register as subspaces; per-host catalogs publish capabilities. |
+| Catalog negotiation | A2UI v0.8 two-step (v0.9 transport-level) | Server advertises supported catalogs; client declares its set; server picks. |
+| Coordination substrate | RDR-110 tuple space | Log-structured, offset-tracking subscribers, semantic match. |
+| Placement-plan transport | RDR-111 `layout_state/<profile>` subspace | Bakke auto-layout writes; surfaces read; 250ms debounce. |
+| Auto-layout engine | RDR-111 `src/nexus/cockpit/layout.py` | Vertical-stack + demotion cascade (shipped). |
+| Static surface render | RDR-111 binding payload | One tuple → one render, cheap, low-latency. |
+| Streaming surface render | RDR-111 connection_manifest (Phase 4, deferred) | Manifest tuple declares pipe; peers connect direct. |
+| Trust boundary | RDR-113 | Daemon-level. Per-cell `origin` is a label refinement. |
+| Daemon SQL RPC | RDR-112 | Canonical pattern for ordered/temporal retrieval. |
+| Content-addressed transclusion | RDR-053 + RDR-108 | `chash://<hex>` resolves via catalog manifest → ChromaDB chunk. |
+| Tumbler arithmetic / span overlap | RDR-053 D6 | Comparison-only (no ADD/SUBTRACT). Sufficient for our use. |
+| Identity attribution | A2UI v0.9 (`iconUrl`, `agentDisplayName`) | Maps to RDR-110 `actor` dimension. Orchestrator validates per A2UI. |
+
+### What the source documents explicitly anticipated
+
+`agentic-cockpit.md` lines 813–815, in §Open Questions:
+
+> Surface descriptor format. Need to settle on a small, stable shape (level
+> + payload + optional layout hints). Earliest version can be a JSON
+> Schema; **mature version maps to A2UI or similar declarative component
+> intent.**
+
+A2UI shipped in 2026. This RDR is the "mature version" landing.
+
+### Phase 4 reactivation
+
+RDR-111 deferred two beads explicitly:
+
+- **`nexus-kkh2`** (P4.1) — tmux pane fulfillment adapter (connection_manifest consumer)
+- **`nexus-0rws`** (P4.2) — ext-apps iframe fulfillment adapter (connection_manifest consumer)
+
+And one consumer-driven bead:
+
+- **`nexus-kgo4`** (P3.5) — first end-to-end mission profile
+
+RDR-118 + RDR-119 are the reactivation work for all three. The MVP mission
+profile (§Implementation Plan) is an RDR audit cockpit.
+
+### Enumerated gaps closed (sources)
+
+- Gap 1 closure: §"Surface_cell subspace schema" + §"A2UI mapping"
+- Gap 2 closure: §"Sibling-surface recursion convention"
+- Gap 3 closure: §"chash:// as BoundValue path"
+- Gap 4 closure: §"Per-cell origin discipline"
+
+## Research Findings
+
+### Investigation
+
+Read in full: `agentic-cockpit.md` (889 lines), RDR-110, RDR-111 (1198
+lines) + post-mortem, RDR-053 (Xanadu fidelity, closed), RDR-108 (T3
+chunk soft-delete), RDR-112 + RDR-113 (trust + daemon). Fetched A2UI v0.8
+specification, A2UI v0.9 draft, Google Developers introduction blog.
+Ingested four T3 entries (`a2ui-v08-surface-descriptor-schema`,
+`a2ui-v09-draft-changes`, `a2ui-design-philosophy-stack-positioning`,
+`a2ui-nexus-synthesis-cockpit-mapping`) with cross-references.
+
+#### Dependency Source Verification
+
+| Dependency | Source Searched? | Key Findings |
+|---|---|---|
+| A2UI v0.8 schema | Yes (a2ui.org/specification/v0.8-a2ui) | `surfaceUpdate`, `dataModelUpdate`, `userAction`, `BoundValue` (literal\|path), two-step catalog negotiation, Container.children = explicitList \| template |
+| A2UI v0.9 draft | Yes (a2ui.org/specification/v0.9-a2ui) | Transport-level catalog negotiation, JSON-pointer dataModel updates, two-way input binding, no nested-surface recursion documented |
+| A2UI Google intro | Yes (developers.googleblog.com) | Apache 2.0, complementary to A2A/AG-UI/MCP, security-first declarative-only |
+| RDR-053 Xanadu fidelity | Yes (full read) | `chash:<sha256>` canonical, `_SPAN_PATTERN` accepts `chash:[0-9a-f]{64}`, `link_audit(t3=...)` detects stale spans, tumbler comparison via -1 sentinel padding |
+| RDR-108 T3 chunk soft-delete | Partial | T3 chunk natural ID is `chunk_text_hash[:32]`; catalog `document_chunks` manifest gives `(doc_id, position) → chash` |
+| RDR-111 shipped surfaces | Yes (post-mortem + src/nexus/cockpit/) | hook_bridge.py:239 (emit), bindings.py:137 (Binding/BindingProfile), layout.py:79 (render_text), three panels under panels/ |
+| RDR-111 deferred work | Yes (post-mortem) | nexus-kkh2 (tmux pane fulfillment), nexus-0rws (ext-apps iframe fulfillment), nexus-kgo4 (first mission profile) all dormant |
+
+### Key Discoveries
+
+- **Verified (RDR-111 §Open Questions line 813-815)**: A2UI was explicitly
+  named as the mature surface descriptor format. This RDR is that landing.
+- **Verified (A2UI spec)**: surface vocabulary is *literally* the same word
+  and concept. Near-1:1 mapping to existing nexus concepts.
+- **Verified (A2UI repo + blog)**: pre-approved component catalogs make
+  A2UI *capability-based UI* by construction. This is the trust-under-
+  recursion property we wanted, off the shelf.
+- **Verified (RDR-053)**: `chash://` resolution path runs through the
+  existing catalog manifest and ChromaDB. `link_audit(t3=...)` extends
+  cleanly to detect stale transclusions.
+- **Documented (A2UI v0.9 draft)**: catalog negotiation moved to
+  transport-level metadata (A2A Agent Cards, MCP `initialize`). Better fit
+  for our MCP transport.
+- **Verified (A2UI v0.9 draft)**: no nested-surface recursion model. The
+  single nexus-specific extension we ship.
+- **Verified (RDR-111 post-mortem)**: phase-4 work was deferred with
+  explicit reactivation triggers; this RDR is that reactivation.
+
+### Critical Assumptions
+
+- [ ] **A1** — A2UI catalog negotiation through MCP `initialize`
+  (v0.9 transport-level mode) is reachable without forking the protocol.
+  **Status**: Unverified. **Method**: Paper design + small spike against
+  the A2UI reference implementation.
+- [ ] **A2** — Sibling-surface coordination via tuple gives correct
+  recursion semantics through three nesting levels (no name collision,
+  no infinite-loop risk, deterministic teardown).
+  **Status**: Unverified. **Method**: Spike — three-level nested surface
+  with mixed content; verify under resize, focus, dispose.
+- [ ] **A3** — `chash://` is a valid `BoundValue.path` value in A2UI
+  v0.8/v0.9 (or can be rendered via a small renderer-side resolver).
+  **Status**: Unverified. **Method**: Spike — render a cell whose path
+  is a chash; verify catalog → ChromaDB → A2UI fragment pipeline.
+- [ ] **A4** — Per-cell `origin` is a strict refinement of RDR-113.
+  **Status**: Unverified. **Method**: Source search + RDR-113 author
+  confirmation.
+- [ ] **A5** — Per-host A2UI catalogs (`nexus.lumino.v1`,
+  `nexus.notcurses.v1`) can each cover the cockpit's reference panels
+  without compromise.
+  **Status**: Unverified. **Method**: Build both catalogs minimally for
+  the MVP mission profile.
+
+## Proposed Solution
+
+### Approach
+
+Adopt A2UI v0.8 (Stable) as the surface descriptor format. Track v0.9.
+Add four small nexus-specific extensions (cell tuple schema, sibling
+recursion convention, `chash://` path, origin discipline). Reuse
+RDR-111's layout_state for placement plans. Inherit RDR-053's
+transclusion stack. Reactivate three dormant beads as deliverables.
+
+### Technical Design
+
+#### 1. `surface_cell/<surface_id>` subspace
+
+A new subspace whose tuples *declare* what should be in each slot of a
+surface. Each tuple is the **materialized rendering state** for one
+slot — distinct from `layout_state` (which carries Bakke's per-binding-
+type stylesheet) and from individual binding events (which carry
+content instances).
+
+```yaml
+surface_cell:
+  dimensions:
+    - name: surface_id      # composition: which parent surface (A2UI surfaceId)
+    - name: slot            # composition: named layout slot
+    - name: origin          # trust label: URL origin | peer-cred+container
+                            # | binding profile name (RDR-113 refinement)
+    - name: child_subspace  # recursion: name of nested surface's subspace
+                            # (null for leaf cells)
+    - name: a2ui_catalog_id # which A2UI catalog this cell is shaped against
+  match_text_field: description  # natural-language capability description
+  content_fields:
+    - representation_type   # short discriminator: a2ui-component | chash |
+                            # connection-manifest-ref | lumino-widget |
+                            # notcurses-plane | nexus-surface
+    - data_ref              # inline | URI | subspace-name | chash:// |
+                            # manifest-id
+    - data_ref_kind         # inline | uri | subspace | transclusion |
+                            # manifest | a2ui-component-inline
+    - actions               # optional: A2UI userAction descriptors
+                            # (HATEOAS-style per-cell affordances)
+```
+
+A *cell* is one tuple in this subspace. A *surface* is the set of cells
+with the same `surface_id`. A *sub-surface* is a cell whose
+`child_subspace` is non-null — the host instantiates a nested layout
+engine bound to that subspace.
+
+**Default representation**: `a2ui-component` with `data_ref_kind: inline`
+carrying an A2UI component JSON fragment. This is the cheap common case.
+
+#### 2. A2UI mapping
+
+| A2UI concept | Nexus realization |
+|---|---|
+| `surfaceId` | `surface_cell.surface_id` |
+| `surfaceUpdate` | binding action writes `surface_cell` tuple |
+| `component` | `surface_cell.data_ref` when `data_ref_kind=a2ui-component-inline` |
+| `BoundValue.literalString` | inline payload |
+| `BoundValue.path` | `chash://<hex>[#span]` (transclusion) or `tuple://<subspace>/<id>` (subspace ref) |
+| `dataModelUpdate` | tuple `out` to `surface_cell` (incremental) |
+| `userAction` | tuple `out` to `cell_input/<surface_id>` |
+| `deleteSurface` | tuple `take` on all `surface_cell` for the surface_id |
+| Container.children (explicitList) | named cells in the same `surface_id` |
+| Container.children (template) | binding fires per matching event in a trigger subspace |
+| Catalog id | `a2ui_catalog_id` dimension |
+| Catalog negotiation | MCP `initialize` (per A2UI v0.9 transport-level) |
+
+#### 3. Sibling-surface recursion convention
+
+A2UI has no nested-surface model. Nexus adds:
+
+- A cell with `child_subspace = <sub_id>` declares "render a sub-surface
+  here." The host treats this as an A2UI Container whose body is the set
+  of `surface_cell` tuples in `surface_cell/<sub_id>`.
+- Sub-surface composition is by **sibling surfaceId** with a parent-child
+  reference dimension, not by literal A2UI nesting. The renderer
+  instantiates a nested layout engine bound to the child subspace.
+- Trust re-evaluation at every nesting level: the child surface inherits
+  no capability from its parent. `origin` is per-cell.
+- Cycle detection: host tracks the subspace-reference path; refuses to
+  recurse into a subspace already on the path. Depth cap (default 8) as
+  belt-and-braces.
+
+If A2UI later defines a nested-surface model, contribute upstream and
+deprecate this convention.
+
+#### 4. `chash://` as A2UI `BoundValue.path`
+
+A cell can render content by reference:
+
+```json
+{
+  "Text": {
+    "text": { "path": "chash://b5e2a8c9...3f1" }
+  }
+}
+```
+
+The renderer-side resolver:
+
+1. Recognizes `chash://` scheme.
+2. Resolves the chunk via the catalog (`Catalog.resolve_chunk()` from
+   RDR-053).
+3. Substitutes the chunk text (or image bytes, for image components) as
+   the rendered value.
+
+`link_audit(t3=...)` from RDR-053 already detects stale chash spans.
+Reuse.
+
+For document-level transclusion: `chash://<doc_hash>` resolves via the
+`document_chunks` manifest's `(doc_id, position) → chash` mapping
+(RDR-108).
+
+#### 5. Per-cell `origin` discipline
+
+`origin` is a *label*, not a *capability*. RDR-113 daemon-level trust
+gates daemon access. `origin` filters within that boundary:
+
+| Producer kind | `origin` value |
+|---|---|
+| Local binding (default) | binding profile name (e.g., `cockpit.local`) |
+| Foreign iframe content | URL origin (e.g., `https://docs.example.com`) |
+| PTY content | `pty:peer-cred+container-id` (when daemonized) |
+| Transcluded content | `chash:` (label propagates from the chash source's origin) |
+| A2UI agent | `a2ui:<agent_did>` (when A2UI v0.9 identity validated) |
+
+Orchestrator (the binding watcher) validates `iconUrl` /
+`agentDisplayName` against `origin` per A2UI v0.9 anti-impersonation
+discipline. No new identity layer.
+
+#### 6. Layout / input / focus subspaces
+
+Already shipped in RDR-111 (`hook_events/*`, bindings, `layout_state`).
+This RDR names two new conventional subspaces:
+
+- `cell_layout/<surface_id>` — resize, visibility, damage events.
+  Damage clipped at cell rectangle (recursion-safe).
+- `cell_input/<surface_id>` — pointer/key events in cell-local
+  coordinates. Carries A2UI `userAction` shape.
+- `cell_focus/<root_surface_id>` — single focus-path tuple. DFS by
+  default; per-container overrides allowed via cell `actions` field.
+
+### Existing Infrastructure Audit
+
+| Proposed Component | Existing Module | Decision |
+|---|---|---|
+| Surface descriptor schema | A2UI v0.8 (external) | **Adopt entire** |
+| `surface_cell` subspace | none | **New** (this RDR) — registers via RDR-112 admin RPC |
+| `cell_layout` / `cell_input` / `cell_focus` | RDR-110 subspace registry | **New schemas** (this RDR) |
+| Sibling-surface recursion | none | **New convention** (this RDR) |
+| `chash://` BoundValue path | RDR-053 catalog + RDR-108 manifest | **Extend** — add renderer-side resolver (~50 LoC) |
+| Per-cell `origin` | RDR-113 | **Refine** — label dimension; no trust expansion |
+| Capability negotiation | A2UI catalog negotiation + RDR-110 registry | **Reuse entire** |
+| Placement-plan transport | RDR-111 `layout_state/<profile>` subspace | **Reuse entire** |
+| Auto-layout engine | RDR-111 `src/nexus/cockpit/layout.py` | **Reuse entire** |
+| Direct SQL RPC for ordered retrieval | RDR-112 | **Reuse entire** |
+| HATEOAS action affordances | A2UI `userAction` already supports this | **Producer discipline only** |
+| Per-host catalog implementation | none | **Deferred to RDR-119** — `nexus.lumino.v1`, `nexus.notcurses.v1` |
+
+### Decision Rationale
+
+Three forces:
+
+1. **The substrate already does the work.** RDR-110/111 are the broker;
+   A2UI is the descriptor protocol. Re-inventing either is duplication.
+   RDR-053 already shipped Xanadu fidelity at the catalog layer; we
+   inherit.
+2. **Cells-as-tuples is symmetric across nesting** under sibling-surface
+   recursion. Composition is automatic.
+3. **No new vocabulary** beyond the four nexus-specific extensions.
+   Producers describe themselves once in `match_text` + `description`;
+   hosts negotiate via A2UI catalogs; nothing else to invent.
+
+## Alternatives Considered
+
+### Alternative 1: Invent a parallel MIME-bundle + decider (abandoned)
+
+The first sketch of this RDR. Rejected because RDR-110 is already the
+broker; A2UI is already the catalog protocol. Adding a parallel decider
+would have duplicated both.
+
+### Alternative 2: Adapt MCP `ui://` resource model
+
+MCP treats UI as a sandboxed HTML resource. **Pros**: existing MCP
+plumbing. **Cons**: HTML is executable; loses A2UI's capability-based
+discipline; doesn't compose cleanly with the cockpit's surface-level
+discipline. **Reason for rejection**: A2UI explicitly positions itself
+as the *native-first* alternative to MCP `ui://` for exactly this
+case.
+
+### Alternative 3: Extend A2UI upstream with nested-surface recursion
+
+Add a `NestedSurface` component to the standard A2UI catalog and
+contribute the spec change upstream. **Pros**: standardized recursion.
+**Cons**: blocks our v1 on upstream acceptance; slow.
+
+**Reason for deferral**: ship sibling-surface coordination first; if it
+proves load-bearing, contribute upstream as v2.
+
+### Briefly Rejected
+
+- **Invent a tuple:// URI scheme for transclusion**: RDR-053's
+  `chash://` already exists; using a parallel scheme would fork the
+  address space.
+- **New transport for cell payloads**: tuple bodies + A2UI BoundValue
+  already work; no new mechanism needed.
+- **NestedSurface as our own catalog component, not a convention**:
+  defer to v2 after sibling-surface convention proves out.
+
+## Trade-offs
+
+### Consequences
+
+- (+) Contract is tiny: one new subspace schema + three convention
+  subspaces + a renderer-side chash resolver.
+- (+) Recursion is genuinely composable (sub-surfaces are first-class
+  values, addressable by subspace name).
+- (+) Capability evolution is free — A2UI catalogs are the existing
+  protocol mechanism.
+- (+) Forward-compatible: A2UI v0.9 transport-level negotiation fits
+  MCP naturally.
+- (+) Cross-host portability is a protocol-level property; the same
+  cell can render on Lumino, notcurses, or any A2UI client.
+- (+) Reactivates three previously-dormant beads (`nexus-kkh2`,
+  `nexus-0rws`, `nexus-kgo4`).
+- (−) v1 commits to A2UI v0.8 (Stable) and tracks v0.9 (Draft) —
+  protocol may evolve under us.
+- (−) Sibling-surface recursion is a nexus-specific extension to A2UI;
+  may have to migrate if/when A2UI ships a nested-surface model.
+- (−) Match-quality at the broker becomes a correctness concern for
+  cockpit rendering, not just retrieval. Threshold tuning matters.
+
+### Risks and Mitigations
+
+- **Risk**: A2UI v0.8 deprecated faster than expected.
+  **Mitigation**: track v0.9 in parallel; the descriptor shape is
+  stable across versions (catalog negotiation changed transport, not
+  semantics).
+
+- **Risk**: Sibling-surface coordination cycles.
+  **Mitigation**: subspace-reference path tracking + depth cap;
+  refuse to recurse into a subspace already on the path.
+
+- **Risk**: `chash://` resolution latency on render path.
+  **Mitigation**: catalog cache + chunk metadata pre-fetch; resolution
+  is at binding-activation cadence (Auto-Style), not per event.
+
+- **Risk**: `origin` misused as backdoor to RDR-113 trust.
+  **Mitigation**: spec discipline — `origin` is label-only; RDR-113
+  daemon trust still gates access.
+
+- **Risk**: Per-host catalog drift (`nexus.lumino.v1` and
+  `nexus.notcurses.v1` diverge in semantics).
+  **Mitigation**: shared catalog spec (RDR-119); cross-host
+  conformance tests.
+
+### Failure Modes
+
+- *Visible*: cell renders wrong representation (catalog negotiation
+  bug); cell renders wrong size (`layout_state` mismatch); transclusion
+  resolves to stale content (RDR-053 `link_audit` flags).
+- *Silent*: focus desync under deep nesting; sub-surface buffer leak on
+  dispose; recursive cycle without depth cap.
+- *Recovery*: portal-inspector cell (built using the contract itself)
+  shows for any selected cell — A2UI catalog id, capability match
+  trace, origin, recent layout_state entries, top-k semantic matches
+  with scores.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] A1–A5 verified via spikes.
+- [ ] A2UI v0.8 reference renderer evaluated (Lit on web, GenUI SDK on
+      Flutter).
+- [ ] RDR-111 layout_state subspace confirmed read-accessible from
+      Phase 4 fulfillment adapter.
+- [ ] RDR-053 `Catalog.resolve_chunk()` exposed via daemon RPC for
+      renderer-side chash resolution.
+
+### Minimum Viable Validation
+
+**MVP mission profile: RDR audit cockpit.** A three-level surface that:
+
+1. Outer surface = list of all open RDRs (top-level panel).
+2. Each RDR item is a sub-surface containing problem-statement,
+   research-findings, design, and gate sub-cells.
+3. Each sub-cell can transclude (via `chash://`) from another RDR or
+   the catalog.
+
+Renders on both backends from RDR-119 (Lumino-in-Tauri and notcurses).
+Inner surfaces use only `surface_cell` subspace operations — no
+medium-specific API. Reactivates `nexus-kgo4`.
+
+### Phase 1: Schemas and conventions
+
+#### Step 1: Land subspace YAML schemas
+
+- `nx/tuplespace/builtin/surface_cell.yml`
+- `nx/tuplespace/builtin/cell_layout.yml`
+- `nx/tuplespace/builtin/cell_input.yml`
+- `nx/tuplespace/builtin/cell_focus.yml`
+
+Register via RDR-112 admin RPC. Document the sibling-surface recursion
+convention in the `surface_cell.yml` header.
+
+#### Step 2: `chash://` BoundValue resolver
+
+Renderer-side library (~50 LoC): recognizes `chash://` scheme, calls
+`Catalog.resolve_chunk()` via daemon RPC, returns chunk text/bytes for
+A2UI substitution. Cache resolved values at the cell's
+`a2ui_catalog_id` scope.
+
+#### Step 3: A2UI catalog negotiation through MCP
+
+Document the handshake: cockpit hosts advertise supported A2UI catalog
+IDs via MCP `initialize` (per A2UI v0.9 transport-level mode);
+producers query via the existing MCP capability discovery.
+
+### Phase 2: Reactivation of fulfillment adapters
+
+Hand off to RDR-119 for the per-host catalog implementations:
+
+- **Reactivate `nexus-kkh2`** — tmux pane fulfillment adapter using
+  `nexus.notcurses.v1` catalog.
+- **Reactivate `nexus-0rws`** — ext-apps iframe fulfillment adapter
+  using `nexus.lumino.v1` catalog (in Tauri shell).
+
+### Phase 3: First end-to-end mission profile
+
+- **Reactivate `nexus-kgo4`** — RDR audit cockpit MVP (above).
+- Author bindings, layout disposition, permission mode.
+- Run on both backends.
+- Measure what's awkward; iterate.
+
+### Day 2 Operations
+
+- New subspaces inherit RDR-110 dimension-registry operations and
+  RDR-112 daemon admin RPCs (`list-subspaces`, `show-schema`, `stats`,
+  `out`, `read`, `take`, `ack`, `nack`).
+- `chash://` validation extends `link_audit` (already in RDR-053).
+
+### New Dependencies
+
+- A2UI v0.8 reference renderer (Lit / GenUI SDK / CopilotKit) — adoption,
+  not in-tree.
+- No new Python/Rust dependencies for the substrate side.
+
+## Test Plan
+
+- **Scenario**: A2UI catalog negotiation through MCP initialize.
+  **Verify**: cockpit host's `nexus.lumino.v1` advertised in
+  `MCP initialize` response; producer can request rendering against it.
+- **Scenario**: Three-level nested surface renders identically on
+  Lumino and notcurses backends.
+  **Verify**: same `surface_cell` tuples; rendered output differs only
+  in medium-specific component realization.
+- **Scenario**: `chash://` BoundValue path resolves correctly.
+  **Verify**: cell with `BoundValue.path = chash://<hex>` renders the
+  chunk text; `link_audit` flags stale spans.
+- **Scenario**: Sibling-surface recursion cycle prevention.
+  **Verify**: a `child_subspace` referencing an ancestor surface is
+  refused with a clear error; depth cap (8) terminates pathological
+  recursion.
+- **Scenario**: Origin filtering.
+  **Verify**: a cell with `origin=foreign-iframe` cannot post to its
+  parent's `cell_input` subspace; RDR-113 daemon trust unchanged.
+- **Scenario**: HATEOAS-style action affordances render and dispatch.
+  **Verify**: a cell carrying A2UI `userAction` triggers a binding fire
+  with correct `surfaceId`/`sourceComponentId`.
+- **Scenario**: Match-quality threshold floor.
+  **Verify**: when no producer-tuple matches a host's catalog query
+  above threshold, host renders a documented placeholder with the
+  query for diagnosis.
+
+## Validation
+
+### Testing Strategy
+
+1. **Scenario**: Reference RDR audit cockpit (three levels, mixed
+   content per level) renders identically on Lumino-in-Tauri and
+   notcurses backends.
+   **Expected**: pass with the same `surface_cell` tuples; chosen
+   A2UI components differ per host catalog; no medium-specific code
+   in the producer.
+
+### Performance Expectations
+
+Negotiation cost = A2UI catalog handshake at MCP initialize (once per
+session). Capability match cost = one RDR-110 semantic-match query per
+cell per Auto-Style tick. Cached at the binding watcher. Per-event
+Layout cost unchanged. `chash://` resolution = one catalog →
+ChromaDB lookup per cell mount, cached.
+
+## Finalization Gate
+
+(deferred — sketch only)
+
+### Contradiction Check
+
+(deferred)
+
+### Assumption Verification
+
+(deferred — A1–A5 unverified; spikes required)
+
+### Scope Verification
+
+(deferred)
+
+### Cross-Cutting Concerns
+
+- **Versioning**: A2UI is versioned externally (v0.8 Stable, v0.9
+  Draft); per-host catalog versions namespaced (`nexus.lumino.v1`,
+  `nexus.notcurses.v1`).
+- **Build tool compatibility**: N/A at spec stage.
+- **Licensing**: A2UI is Apache 2.0; compatible with nexus.
+- **Deployment model**: per-host catalogs ship independently; sibling-
+  surface recursion convention documented in `surface_cell.yml`.
+- **IDE compatibility**: VS Code webview ships as single-cell host in
+  v1 (no nested webviews — explicit deferral, same as RDR-119).
+- **Incremental adoption**: legacy RDR-111 `surface_payload` strings
+  continue to work — they are one form of tuple body. Migration to
+  `surface_cell` subspace is opt-in per binding.
+- **Secret/credential lifecycle**: `origin` labels cells; RDR-113
+  daemon trust gates access. Secrets never cross cell boundaries by
+  default.
+- **Memory management**: dispose is `take`; RDR-110 retention sweeper
+  releases bodies; sub-surface teardown closes any held resources.
+
+### Proportionality
+
+Small RDR. The substrate is RDR-110/111; the descriptor protocol is
+A2UI; the Xanadu inheritance is RDR-053. This RDR is the discipline
+that wires them. Resist the urge to grow it.
+
+## References
+
+- A2UI v0.8 spec — https://a2ui.org/specification/v0.8-a2ui/
+- A2UI v0.9 draft — https://a2ui.org/specification/v0.9-a2ui/
+- A2UI Google introduction —
+  https://developers.googleblog.com/introducing-a2ui-an-open-project-for-agent-driven-interfaces/
+- A2UI repo (Apache 2.0) — https://github.com/google/a2ui
+- T3 entries: `a2ui-v08-surface-descriptor-schema`,
+  `a2ui-v09-draft-changes`,
+  `a2ui-design-philosophy-stack-positioning`,
+  `a2ui-nexus-synthesis-cockpit-mapping`
+- `docs/agentic-cockpit.md` (especially §Surfaces lines 593–738, §Open
+  Questions lines 813–815)
+- RDR-053: Xanadu Fidelity — Tumbler Arithmetic and Content-Addressed
+  Spans
+- RDR-108: T3 Chunk Soft-Delete (chunk_text_hash as natural ID)
+- RDR-110: Semantic Tuple Space
+- RDR-111: ORB Cockpit Substrate + post-mortem
+- RDR-112: Storage-as-Service Container Boundary
+- RDR-113: Host-Trust Model
+- `docs/a2ui-summary.md` (this worktree) — reader-friendly A2UI
+  summary for review
+
+## Revision History
+
+_2026-05-17 — initial sketch under wrong framing (MIME-bundle + decider
+indirection). Built a parallel decider over the existing semantic
+broker._
+
+_2026-05-17 — abandoned and rewritten. The ORB is the broker; cells
+are tuples; recursion is a subspace reference. Contract collapsed to
+four subspace schemas + query template._
+
+_2026-05-18 — third iteration after thorough audit: read full
+`agentic-cockpit.md`, RDR-111 + post-mortem, RDR-053, RDR-108; fetched
+and ingested A2UI v0.8/v0.9 specs and Google announcement. Adopted
+A2UI v0.8 as the descriptor format (explicitly anticipated by
+cockpit.md lines 813-815); inherited RDR-053 `chash://` transclusion;
+named sibling-surface coordination as the one nexus-specific
+extension; reactivates dormant beads `nexus-kkh2`, `nexus-0rws`,
+`nexus-kgo4`. This is the current document._

--- a/docs/rdr/rdr-119-cockpit-ui-fabric.md
+++ b/docs/rdr/rdr-119-cockpit-ui-fabric.md
@@ -1,0 +1,705 @@
+---
+title: "Cockpit UI Fabric — Bakke Auto-Layout over A2UI Catalogs, per-Host Realization"
+id: RDR-119
+type: Architecture
+status: scrapped
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-18
+accepted_date:
+scrapped_date: 2026-05-19
+scrap_reason: "Draft never gated. UI fabric is a third-order consumer (sits atop RDR-118 surfaces-as-tuples which sits atop RDR-111 ORB which sits atop RDR-112 substrate). The whole stack is deferred until substrate work (RDR-120) ships. Postmortem: docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md."
+related_issues: []
+related_rdrs: [RDR-110, RDR-111, RDR-112, RDR-113, RDR-053, RDR-118, RDR-120]
+related_external: [a2ui-v0.8-spec, a2ui-v0.9-draft, lumino, notcurses, tauri]
+reactivates_beads: [nexus-kkh2, nexus-0rws]
+related_tests: []
+---
+
+> **TOMBSTONE 2026-05-19.** This RDR is preserved as historical reference. Never gated; built atop a scrapped multi-layer consumer stack. See frontmatter `scrap_reason` and the [postmortem](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work: [RDR-120](rdr-120-storage-substrate-split.md). Do not implement against this design.
+
+---
+
+
+# RDR-119: Cockpit UI Fabric
+
+> Sketch. Companion to RDR-118. Defines the **per-host realization** of
+> A2UI catalogs that RDR-118 adopts, the policy layer that drives them
+> (Bakke auto-layout already shipped in RDR-111), and the cross-platform
+> shell (Tauri 2).
+
+## Problem Statement
+
+RDR-118 adopts A2UI as the surface descriptor format and inherits the
+RDR-110/111 substrate. What's still open is the **per-host fabric** —
+the concrete realization that takes A2UI surface descriptors and renders
+them as a usable, accessible, keyboard-navigable cockpit on each
+medium.
+
+The cockpit substrate (RDR-111) shipped a vertical-stack Bakke engine and
+three reference panels rendered as tmux output. Phase 4 explicitly
+deferred the *fulfillment adapters* that consume connection manifests
+and render A2UI surfaces on real hosts:
+
+- **`nexus-kkh2`** (deferred, P4.1) — tmux pane fulfillment adapter
+- **`nexus-0rws`** (deferred, P4.2) — ext-apps iframe fulfillment adapter
+
+RDR-119 is the reactivation of both. It also addresses the
+*UI fabric* concerns RDR-118 names but doesn't settle: focus, navigation,
+layout containers, modal stack, accessibility, keyboard discipline.
+
+### Enumerated gaps to close
+
+#### Gap 1: No per-host A2UI catalog implementations
+
+A2UI ships as a protocol. Each host needs a concrete catalog
+(`nexus.lumino.v1` for web/Tauri, `nexus.notcurses.v1` for tty) that
+maps A2UI components to native rendering primitives. Without these, no
+cell renders.
+
+#### Gap 2: UI fabric concerns are unsettled
+
+Tab order, focus traversal, modal stack, layout containers, accessibility
+relationships, keyboard discipline, cross-surface navigation gestures —
+all unaddressed by RDR-111 / RDR-118 alone. The cockpit's organizing
+principle is Bakke auto-layout (already shipped), but the *fabric* that
+gives it ergonomics is open.
+
+#### Gap 3: No cross-platform shell decision
+
+RDR-118 names Tauri as the recommended shell. RDR-119 commits the
+decision and addresses the consequences (Tauri 2 supports web + mobile +
+desktop; native webview per platform).
+
+#### Gap 4: First end-to-end mission profile is dormant
+
+RDR-111 `nexus-kgo4` (first mission profile) was left consumer-driven.
+RDR-118 names "RDR audit cockpit" as the MVP profile. RDR-119 builds it
+across both backends.
+
+## Context
+
+### What the source already nails (do not re-derive)
+
+- **Layout policy**: Bakke auto-layout engine (RDR-111
+  `src/nexus/cockpit/layout.py:79`). Vertical stack + demotion cascade.
+  Three phases: Measure → Auto-Style → Layout. 250ms debounce.
+- **Placement-plan transport**: `layout_state/<profile>` subspace
+  (RDR-111).
+- **Surface descriptor format**: A2UI v0.8 (Stable). Per RDR-118.
+- **Cell substrate**: `surface_cell/<surface_id>` subspace (per RDR-118).
+- **Trust boundary**: RDR-113 daemon-level + per-cell `origin` label.
+- **Ordered retrieval**: direct T2 SQL via RDR-112 daemon RPC.
+- **Reference panels**: active-claims, recent-events, active-bindings
+  (shipped in RDR-111).
+
+### What we adopt (zero new framework code)
+
+- **Lumino** (formerly Phosphor) — JupyterLab's TypeScript widget
+  framework. `DockPanel`, `MenuBar`, `CommandRegistry`, `FocusTracker`,
+  token-based service plugins. *Battle-tested* recursive composable web
+  fabric.
+- **notcurses** — z-ordered plane API for tty. Already cited in RDR-118.
+- **Tauri 2** — Rust + native webview shell. ~10–20× smaller than
+  Electron; supports web + iOS + Android + desktop.
+- **A2UI catalog negotiation through MCP `initialize`** — per A2UI v0.9
+  transport-level mode. Per RDR-118.
+
+### The framing tension and its resolution
+
+`agentic-cockpit.md` line 791 explicitly states:
+
+> Not building, intentionally: A new component / widget framework.
+
+Adopting Lumino is not building a framework; it is **choosing** an
+existing one to fill the GUI adapter slot the source deferred. Two
+honest framings, both correct:
+
+(a) Lumino is *the GUI fulfillment adapter* RDR-111 deferred (`nexus-0rws`).
+(b) Lumino is *the harness's rendering substrate* for GUI hosts, same role
+    tmux/notcurses fills for terminal hosts.
+
+We pick (b) as the official framing.
+
+## Research Findings
+
+### Investigation
+
+Audit of `agentic-cockpit.md` (§What we build vs leverage, lines 739-797;
+§Surfaces, lines 593-738), RDR-111 (§Auto-layout engine, post-mortem),
+A2UI v0.8/v0.9 specs (per RDR-118 ingestion), survey of Lumino /
+notcurses / Tauri / Adaptive Cards / Croquet / tldraw (per
+brainstorm-research-synthesis 2026-05-17).
+
+#### Dependency Source Verification
+
+| Dependency | Source Searched? | Key Findings |
+|---|---|---|
+| Lumino architecture | Yes (lumino.readthedocs.io, jupyterlab repo) | DockPanel, MenuBar, CommandRegistry, FocusTracker, token-based service plugins; production-grade across JupyterLab ecosystem |
+| notcurses planes | Yes (github.com/dankamongmen/notcurses) | z-ordered rectangles, EGC-aware cells, OSC 4 palette query, multimedia support |
+| Tauri 2 | Yes (PkgPulse 2026 comparison) | Native webview per platform; ~10–20× smaller than Electron; supports web + mobile + desktop; Rust core |
+| Bakke shipped engine | Yes (src/nexus/cockpit/layout.py + post-mortem) | Vertical-stack + demotion cascade only at v1; simpler than spec described |
+| Phase 4 deferred beads | Yes (RDR-111 post-mortem) | nexus-kkh2 (tmux), nexus-0rws (iframe) — both dormant under closed epic, explicit reactivation triggers |
+| A2UI catalog model | Yes (per RDR-118 ingestion) | Pre-approved catalogs; orchestrator validates identity; framework-agnostic |
+
+### Key Discoveries
+
+- **Verified (RDR-111 shipped)**: Bakke engine is vertical-stack-only
+  in v1. RDR-119 inherits this; extension to multi-column / dock-tree
+  is future work.
+- **Verified (A2UI)**: per-host catalogs (`nexus.lumino.v1`,
+  `nexus.notcurses.v1`) are the established A2UI extension pattern.
+- **Verified (Lumino architecture)**: DockPanel + CommandRegistry +
+  FocusTracker collectively cover focus/nav/modal/accessibility
+  concerns we'd been worried about — Lumino solves these natively for
+  the web side.
+- **Documented (Tauri 2)**: mobile support (iOS, Android) ships in
+  Tauri 2; web/desktop/mobile via the same Lumino fabric.
+- **Assumed**: notcurses input + plane APIs cover focus/nav for the
+  tty side with comparable ergonomics to Lumino. Spike needed.
+
+### Critical Assumptions
+
+- [ ] **A1** — Lumino's DockPanel and CommandRegistry compose under
+  A2UI catalog rendering without architectural conflict. **Status**:
+  Unverified. **Method**: Spike — render a `nexus.lumino.v1` catalog
+  example with three components in a DockPanel.
+- [ ] **A2** — notcurses planes + input handling give comparable
+  focus/nav ergonomics to Lumino on tty. **Status**: Unverified.
+  **Method**: Spike — render the same three-component example via
+  `nexus.notcurses.v1`; cross-test keyboard discipline.
+- [ ] **A3** — Bakke vertical-stack output maps cleanly onto Lumino
+  DockPanel rows/columns. **Status**: Unverified. **Method**: Spike —
+  drive Lumino layout from a `layout_state` tuple stream.
+- [ ] **A4** — Tauri 2 native webview hosts Lumino reliably across
+  macOS WebKit, Windows WebView2, Linux WebKitGTK. **Status**:
+  Unverified. **Method**: Spike — Tauri app shells with Lumino DockPanel
+  + 10-tab smoke.
+- [ ] **A5** — Per-host catalogs can advertise capabilities via MCP
+  `initialize` per A2UI v0.9 transport-level mode without forking the
+  protocol. **Status**: Carries from RDR-118 A1. Same spike.
+- [ ] **A6** — The "RDR audit cockpit" MVP mission profile (RDR-118
+  §MVP) exercises all four fabric concerns (focus, nav, container,
+  modal) sufficiently to validate the design. **Status**: Unverified.
+  **Method**: Build it; measure.
+- [ ] **A7** — Mission-context profiles couple to permission modes
+  (WoW combat-lockdown analog) explicitly, not implicitly. **Status**:
+  Unverified. **Method**: Paper design + RDR-111 author confirm.
+- [ ] **A8** — Per-cell Yjs as opt-in cell type (for editable surfaces)
+  composes with A2UI catalog rendering. **Status**: Unverified.
+  **Method**: Defer until a surface explicitly needs it.
+
+## Proposed Solution
+
+### Approach
+
+Bakke auto-layout is the policy layer (already shipped). Lumino and
+notcurses are passive rendering primitives that consume placement plans
+(`layout_state` tuples). Tauri 2 hosts Lumino. Each host publishes an
+A2UI catalog (`nexus.lumino.v1`, `nexus.notcurses.v1`) that maps A2UI
+components to native primitives. UI fabric concerns (focus, nav, modal,
+accessibility) are owned by the rendering primitive — Lumino on web,
+notcurses on tty.
+
+### Technical Design
+
+#### 1. Three-layer fabric
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Policy:  Bakke auto-layout (RDR-111, shipped)             │
+│          Measure → Auto-Style → Layout, demotion cascade  │
+│          Writes: layout_state/<profile> subspace          │
+└──────────────────────────────────────────────────────────┘
+                          │
+                          ▼ (subscribers read)
+┌──────────────────────────────────────────────────────────┐
+│ Substrate:  RDR-110 tuple space subspaces (RDR-118)       │
+│             surface_cell/<id>, cell_layout, cell_input,   │
+│             cell_focus, layout_state                      │
+└──────────────────────────────────────────────────────────┘
+                          │
+                          ▼ (renderers consume)
+┌──────────────────────────────────────────────────────────┐
+│ Primitives:  Lumino (web/Tauri) | notcurses (tty)         │
+│              A2UI catalog: nexus.lumino.v1 |              │
+│              nexus.notcurses.v1                           │
+│              Owns: focus, nav, container, modal, a11y     │
+└──────────────────────────────────────────────────────────┘
+```
+
+#### 2. `nexus.lumino.v1` A2UI catalog
+
+Maps standard A2UI components to Lumino widgets:
+
+| A2UI component | Lumino widget |
+|---|---|
+| `Column` / `Row` | `BoxPanel` (vertical/horizontal) |
+| `Card` | `Widget` with title bar |
+| `Text` | DOM `<div>` with text content |
+| `Image` | DOM `<img>` |
+| `List` | `Widget` with template-driven children |
+| `Button` | DOM `<button>` with `userAction` dispatch |
+| `Container.children.template` | `Widget` rebuilt on data binding |
+| `Modal` (v0.9) | `Dialog` widget with focus trap |
+| `Slider` (v0.9) | DOM input range |
+| Nexus extension: `NestedSurface` | Child `DockPanel` bound to subspace |
+
+Catalog id: `nexus.lumino.v1` (semver). Hosted at
+`https://nexus.dev/a2ui/catalogs/lumino-v1.json` (eventually).
+
+**Layout containers map onto Lumino DockPanel**: each named slot in a
+panel is a Lumino dock area. The Bakke engine writes
+`layout_state/<profile>` tuples; the Lumino adapter reads them and calls
+`DockPanel.addWidget` / `moveWidget` minimally.
+
+**Focus, keyboard discipline, modal stack** are owned by Lumino's
+`CommandRegistry` + `FocusTracker`. The A2UI Button's `userAction` field
+provides the action handler; Lumino dispatches it via tuple `out` to
+`cell_input/<surface_id>`.
+
+#### 3. `nexus.notcurses.v1` A2UI catalog
+
+Symmetric for tty:
+
+| A2UI component | notcurses primitive |
+|---|---|
+| `Column` / `Row` | Stacked / side-by-side planes |
+| `Card` | Plane with border |
+| `Text` | Plane with text |
+| `Image` | Plane with half-block / sextant pixel rendering |
+| `List` | Plane with row iteration |
+| `Button` | Highlighted plane with mouse/key bind |
+| `Container.children.template` | Plane rebuilt per data binding |
+| `Modal` (v0.9) | Top z-order plane with focus trap |
+| Nexus extension: `NestedSurface` | Nested plane bound to child subspace |
+
+Catalog id: `nexus.notcurses.v1`. Same advertisement path via MCP
+`initialize`.
+
+#### 4. Tauri 2 shell
+
+The web/desktop/mobile host. Tauri 2 wraps the platform's native webview
+(WebKit on macOS/iOS, WebView2 on Windows, WebKitGTK on Linux,
+WebView on Android). Lumino runs inside the webview.
+
+**Build target**: a small Tauri app that:
+1. Connects to the local nexus daemon (RDR-112) via MCP.
+2. Performs A2UI catalog negotiation on `initialize`.
+3. Hosts a Lumino `DockPanel` as the cockpit root.
+4. Subscribes to `layout_state/<profile>` and `surface_cell/*` subspaces.
+5. Renders A2UI components per `nexus.lumino.v1` mappings.
+6. Posts `userAction` events back via `cell_input/<surface_id>`.
+
+#### 5. Catalog negotiation via MCP `initialize`
+
+Per A2UI v0.9 transport-level mode. The MCP server initialization
+response includes:
+
+```json
+{
+  "a2uiClientCapabilities": {
+    "supportedCatalogIds": [
+      "https://nexus.dev/a2ui/catalogs/lumino-v1.json",
+      "https://nexus.dev/a2ui/catalogs/notcurses-v1.json",
+      "https://a2ui.org/specification/v0_8/standard_catalog_definition.json"
+    ],
+    "acceptsInlineCatalogs": false
+  }
+}
+```
+
+Producers query supported catalogs through the existing MCP capability
+discovery. No new transport.
+
+#### 6. UI fabric concerns ownership
+
+| Concern | Owned by | Notes |
+|---|---|---|
+| Tab order / focus traversal | Lumino `FocusTracker` (web) / notcurses input (tty) | DFS default; override via cell's `focus_priority` registry field. |
+| Keyboard shortcuts | Lumino `CommandRegistry` (web) / notcurses keybind (tty) | A2UI Button `userAction` is the dispatch target. |
+| Modal stack | Lumino `Dialog` widget (web) / top z-plane (tty) | Bakke `surface_level=full-screen` with `preempts=[*]`. |
+| Layout containers | Lumino `DockPanel/BoxPanel` (web) / notcurses planes (tty) | Driven by Bakke `layout_state` tuples. |
+| Accessibility (ARIA/labels) | Lumino's DOM (web) / notcurses' tags (tty) | A2UI components carry semantic role; renderer translates. |
+| Cross-surface navigation | A2UI `userAction` → binding fires `surface-swap` action | Action types: `surface-swap`, `drill-in`, `surface-back`. |
+| Drag-and-drop | Lumino DockPanel built-in (web) / N/A (tty) | Manual pin via dragging; auto-layout respects. |
+| Pointer / mouse | Lumino DOM events (web) / notcurses mouse (tty) | Translated to `cell_input` tuples. |
+
+#### 7. Mission-context × permission-mode coupling
+
+A mission-context profile is the tuple `mission_context/<name>` carrying:
+
+```yaml
+mission_context:
+  dimensions:
+    - profile_name
+    - permission_mode  # plan | acceptEdits | auto | default | bypassPermissions
+  content_fields:
+    - active_bindings    # list of binding ids
+    - active_catalogs    # list of A2UI catalog ids
+    - active_layout      # layout_state profile id
+    - recent_events_filter
+```
+
+Switching mission contexts is `out`ting a new `current_mission_context`
+tuple; subscribed surfaces react (per RDR-111). Permission mode is part
+of the bundle; the harness honors it (WoW combat-lockdown analog).
+
+### Existing Infrastructure Audit
+
+| Proposed Component | Existing Module | Decision |
+|---|---|---|
+| Bakke auto-layout policy | RDR-111 `src/nexus/cockpit/layout.py` | **Reuse entire** |
+| Placement-plan transport | RDR-111 `layout_state/<profile>` subspace | **Reuse entire** |
+| Cell substrate | RDR-118 `surface_cell` + cell_layout/input/focus subspaces | **Reuse entire** |
+| Reference panels (claims, events, bindings) | RDR-111 panels | **Reuse**; rewrap as `nexus.lumino.v1` / `nexus.notcurses.v1` catalog components |
+| Lumino | external (Apache-2.0 / BSD) | **Adopt whole** |
+| notcurses | external (Apache-2.0) | **Adopt whole** |
+| Tauri 2 | external (Apache-2.0 / MIT) | **Adopt whole** |
+| A2UI v0.8 protocol | external (Apache-2.0) | **Adopt entire** |
+| `nexus.lumino.v1` catalog | none | **New** (this RDR) |
+| `nexus.notcurses.v1` catalog | none | **New** (this RDR) |
+| Tauri shell binary | none | **New** (this RDR) |
+| MCP `initialize` catalog advertisement | RDR-110/112 MCP path | **Extend** — add `a2uiClientCapabilities` field |
+| `mission_context` subspace | none | **New** (this RDR) |
+| Per-cell Yjs | external (MIT) | **Deferred** — adopt selectively per cell type that needs it |
+
+### Decision Rationale
+
+Three forces:
+
+1. **The substrate is shipped.** RDR-110/111 + RDR-118 cover everything
+   below the per-host realization. Building anything else would
+   duplicate.
+2. **Lumino + notcurses cover the UI fabric.** Focus/nav/modal/a11y
+   are decades-old problems with mature solutions. Adopt.
+3. **A2UI's catalog model is the integration seam.** Per-host catalogs
+   are A2UI's *intended extension pattern* — we extend along the
+   protocol's grain, not against it.
+
+## Alternatives Considered
+
+### Alternative 1: Build a bespoke widget framework (rejected)
+
+`agentic-cockpit.md` line 791 explicitly says "Not building." Reasons
+remain valid. Lumino + notcurses are the better answer.
+
+### Alternative 2: Electron instead of Tauri
+
+**Pros**: most mature, JS-everywhere ecosystem, identical Chromium
+across platforms.
+**Cons**: 10–20× larger bundle, higher RAM, larger attack surface, no
+native mobile.
+**Reason for deferral**: Tauri 2 wins for nexus's profile (developer
+tool, security-sensitive substrate, eventual mobile). Reconsider only
+if Tauri's per-platform webview drift bites.
+
+### Alternative 3: Adaptive Cards as the catalog format
+
+A real option — Adaptive Cards is a peer to A2UI for semantic
+component-intent rendering. **Pros**: even more mature, Microsoft-
+maintained, large renderer ecosystem.
+**Cons**: not surface-shaped (single-card rendering), not
+multi-component-coordinated.
+**Reason for rejection**: A2UI is *surface-native*; Adaptive Cards is
+*card-native*. The cockpit needs surfaces.
+
+### Alternative 4: Croquet OS for fabric collab
+
+Bit-identical shared VM with reflector. **Pros**: zero merge logic,
+deterministic.
+**Cons**: paradigm shift (no side effects in Model code), overlaps
+RDR-110 at layer 1, narrower ecosystem than Yjs.
+**Reason for rejection**: covered in research synthesis 2026-05-17.
+Tuple space already does coarse-grained collab; Yjs adopted per cell
+type that needs fine-grained collab.
+
+### Briefly Rejected
+
+- **Pure DOM (no Lumino)**: re-invents DockPanel, FocusTracker,
+  CommandRegistry. Not worth the cost.
+- **Web Components only, no Lumino**: viable but no DockPanel
+  equivalent matches Lumino's ergonomics; same rejection reason.
+- **Visual binding-authoring UX**: explicitly rejected by RDR-111
+  (Alternative D). Form-based + LLM-assisted only.
+
+## Trade-offs
+
+### Consequences
+
+- (+) v1 build budget is small — per-host catalog implementations only.
+- (+) Lumino's ecosystem (extensions, themes, layouts) becomes
+  available essentially for free.
+- (+) Tauri 2 gives web + desktop + mobile from one codebase.
+- (+) A2UI catalog negotiation is the existing protocol mechanism;
+  no new vocabulary.
+- (+) Reactivates two deferred beads with clear MVP gating.
+- (−) Lumino is a non-trivial dependency to vendor; upstream churn
+  becomes a concern.
+- (−) Tauri 2's native webview drift across platforms is a real risk.
+- (−) Bakke's vertical-stack-only v1 limits initial layouts; multi-
+  column / nested-dock is future work.
+- (−) notcurses + Lumino catalogs must stay semantically aligned;
+  drift is the failure mode.
+
+### Risks and Mitigations
+
+- **Risk**: per-platform Tauri webview drift breaks Lumino rendering.
+  **Mitigation**: cross-platform smoke suite at every release; pin
+  Tauri 2.x.
+
+- **Risk**: notcurses + Lumino catalogs drift in semantics.
+  **Mitigation**: shared catalog spec doc; conformance tests run on
+  every catalog change.
+
+- **Risk**: A2UI v0.8 → v0.9 migration disrupts catalog format.
+  **Mitigation**: v0.8 schema is stable; v0.9 is largely a transport-
+  level change. Per-host catalogs versioned (`v1` first).
+
+- **Risk**: Lumino vendor lock-in.
+  **Mitigation**: catalog mapping is one of N possible web realizations
+  of A2UI; alternative renderers (Lit, React) can replace Lumino if
+  needed.
+
+- **Risk**: Bakke vertical-stack-only is too limited for real
+  cockpits.
+  **Mitigation**: extend to multi-column / dock-tree under a separate
+  RDR; v1 ships with the shipped engine.
+
+### Failure Modes
+
+- *Visible*: cell renders wrong widget (catalog mapping bug);
+  layout doesn't fit on screen (Bakke demotion cascade).
+- *Silent*: focus desync between Lumino and notcurses backends; modal
+  trap leaks; mission-context switch doesn't persist.
+- *Recovery*: portal-inspector cell (from RDR-118) shows the catalog
+  id, the requested A2UI component, the mapped Lumino/notcurses
+  widget, and the focus path. Diagnosis is one click.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] RDR-118 schemas landed (`surface_cell`, `cell_layout`,
+      `cell_input`, `cell_focus`).
+- [ ] `chash://` BoundValue resolver shipped per RDR-118 Phase 1 Step 2.
+- [ ] A2UI v0.8 reference implementation chosen for each host
+      (`@a2ui/lit` for Lumino web, custom for notcurses).
+- [ ] A1–A8 verified via spikes.
+
+### Minimum Viable Validation
+
+**MVP mission profile: RDR audit cockpit** (shared with RDR-118).
+
+Three-level recursive surface, rendered on both backends:
+
+1. Outer surface: list of all RDRs (Lumino `DockPanel` rows / notcurses
+   stacked planes).
+2. Each RDR is a sub-surface with problem / research / design / gate
+   sub-cells.
+3. Each sub-cell can transclude (`chash://`) into another RDR or the
+   catalog.
+
+Validates: A2UI catalog negotiation, Bakke layout, focus/nav,
+recursion, transclusion, cross-host rendering. Reactivates `nexus-kgo4`.
+
+### Phase 1: `nexus.notcurses.v1` catalog
+
+Reactivates `nexus-kkh2` (tmux pane fulfillment adapter).
+
+#### Step 1: Define catalog mapping
+
+Author `nexus.notcurses.v1.json` mapping A2UI standard catalog
+components to notcurses primitives. Reuse RDR-111's tmux adapter as
+starting code; rebuild around notcurses planes per A2UI catalog.
+
+#### Step 2: notcurses fulfillment adapter
+
+In `src/nexus/cockpit/notcurses_adapter.py`:
+- Subscribe to `surface_cell/*` + `cell_layout/*` + `layout_state/*`.
+- Resolve each cell's `representation_type` → A2UI component →
+  notcurses primitive per catalog mapping.
+- Translate notcurses input events → `cell_input` tuples.
+- Honor Bakke demotion cascade.
+
+Estimated ~600 LoC (3× RDR-111's estimate per shipped-code calibration).
+
+#### Step 3: Smoke test against RDR-111 reference panels
+
+The three reference panels (active-claims, recent-events,
+active-bindings) must render via the new catalog with feature parity.
+
+### Phase 2: `nexus.lumino.v1` catalog + Tauri shell
+
+Reactivates `nexus-0rws` (ext-apps iframe fulfillment adapter).
+
+#### Step 4: Define catalog mapping
+
+Author `nexus.lumino.v1.json` mapping A2UI components to Lumino
+widgets. Use `@lumino/widgets` + `@lumino/commands` packages.
+
+#### Step 5: Tauri shell scaffold
+
+In `crates/nexus-cockpit-tauri/` (new):
+- Tauri 2 app with Rust main.
+- Embeds `dist/lumino-app/` (TypeScript Lumino frontend).
+- Connects to local nexus daemon (RDR-112) via MCP over UDS.
+- Performs A2UI catalog negotiation on `initialize`.
+
+Estimated ~1000 LoC Rust + ~1500 LoC TypeScript.
+
+#### Step 6: Lumino fulfillment adapter
+
+In `dist/lumino-app/src/cockpit-adapter.ts`:
+- Same shape as notcurses adapter but for Lumino DockPanel.
+- Subscribes to subspaces via daemon WebSocket or MCP.
+- Renders A2UI components → Lumino widgets per catalog.
+- Translates Lumino events → `cell_input` tuples.
+
+### Phase 3: MVP mission profile
+
+Reactivates `nexus-kgo4`.
+
+#### Step 7: RDR audit cockpit bindings
+
+Author the bindings that produce the RDR audit surfaces. Use existing
+RDR-111 bindings primitive.
+
+#### Step 8: Cross-host parity tests
+
+Same `surface_cell` tuples must render meaningfully on both backends.
+Differences are in medium-specific catalog component mappings, never
+in cell content or composition.
+
+#### Step 9: Measure and iterate
+
+Per RDR-111's discipline: "Run it. Measure what's awkward. Iterate."
+
+### Day 2 Operations
+
+- Per-host catalog JSON files versioned (`v1`, `v2` ...) per A2UI
+  catalog conventions.
+- Tauri shell auto-update via Tauri's built-in updater.
+- notcurses adapter ships as part of `nx` CLI.
+- MCP `initialize` advertises catalogs; producers cache.
+
+### New Dependencies
+
+- `@lumino/widgets`, `@lumino/commands`, `@lumino/coreutils` (web)
+- `notcurses` (Apache-2.0; C with Python bindings)
+- `tauri@2.x` (Apache-2.0 / MIT; Rust)
+- `@a2ui/lit` or comparable A2UI renderer (Apache-2.0)
+
+## Test Plan
+
+- **Scenario**: Tauri shell launches, advertises catalogs via
+  `initialize`.
+  **Verify**: MCP response includes `a2uiClientCapabilities` with
+  `nexus.lumino.v1`.
+- **Scenario**: Three-level recursive surface renders on Lumino.
+  **Verify**: nested DockPanels with correct focus path.
+- **Scenario**: Same three-level surface renders on notcurses.
+  **Verify**: nested planes; equivalent focus path; cross-host
+  semantic parity.
+- **Scenario**: A2UI Button `userAction` dispatches.
+  **Verify**: Lumino click → `cell_input` tuple; binding fires.
+- **Scenario**: Bakke demotion cascade under narrow terminal.
+  **Verify**: panel → status-line → notification → suppressed as width
+  shrinks.
+- **Scenario**: Mission-context switch updates layout + permission
+  mode.
+  **Verify**: new `current_mission_context` tuple; surfaces re-render;
+  harness permission mode changes.
+- **Scenario**: `chash://` transclusion resolves on both backends.
+  **Verify**: same chunk text rendered.
+- **Scenario**: Modal stack works (RDR audit gate dialog).
+  **Verify**: focus trap on Lumino `Dialog`; equivalent on notcurses
+  top-z plane.
+
+## Validation
+
+### Testing Strategy
+
+1. **Scenario**: RDR audit cockpit MVP runs end-to-end on both
+   backends.
+   **Expected**: full mission profile completes; reviewer can navigate,
+   inspect, transclude, and act on RDRs without medium-specific
+   awareness.
+
+### Performance Expectations
+
+- Tauri shell cold start: < 1 s on M-series Mac.
+- Lumino render of 50-cell surface: < 100 ms.
+- notcurses render of 50-cell surface: < 50 ms.
+- A2UI catalog negotiation: < 10 ms (cached after first session).
+- `chash://` resolve cache hit: < 1 ms.
+
+## Finalization Gate
+
+(deferred — sketch only)
+
+### Contradiction Check
+
+(deferred)
+
+### Assumption Verification
+
+(deferred — A1–A8 unverified; spikes required)
+
+### Scope Verification
+
+(deferred — RDR audit cockpit is MVP; multi-column Bakke, mobile
+Tauri, per-cell Yjs are post-MVP)
+
+### Cross-Cutting Concerns
+
+- **Versioning**: A2UI external; Lumino external; per-host catalogs
+  versioned (`v1`). Tauri shell follows semver.
+- **Build tool compatibility**: TypeScript via npm/pnpm; Rust via
+  cargo; Python (notcurses adapter) via existing nexus build.
+- **Licensing**: Lumino (BSD-3), notcurses (Apache-2.0), Tauri (MIT/
+  Apache-2.0), A2UI (Apache-2.0). All compatible.
+- **Deployment model**: Tauri shell distributed as native binaries per
+  platform; notcurses adapter ships with `nx` CLI.
+- **IDE compatibility**: VS Code webview hosts the Lumino frontend
+  without modification; nested-webview prohibition means VS Code is a
+  single-cell host (explicit limitation).
+- **Incremental adoption**: legacy RDR-111 surfaces (rendered via
+  the shipped tmux output path) continue to work; migration to
+  `nexus.notcurses.v1` is opt-in per binding.
+- **Secret/credential lifecycle**: Tauri shell connects to daemon via
+  UDS (RDR-112); no credentials in the webview.
+- **Memory management**: Lumino widget dispose on cell `take`;
+  notcurses plane teardown likewise.
+
+### Proportionality
+
+Right-sized. The substrate is RDR-110/111/118; A2UI is the protocol;
+Lumino/notcurses/Tauri are external. This RDR ships ~3000 LoC of
+adapter + shell code total — large but bounded.
+
+## References
+
+- A2UI v0.8 spec — https://a2ui.org/specification/v0.8-a2ui/
+- A2UI v0.9 draft — https://a2ui.org/specification/v0.9-a2ui/
+- Lumino — https://github.com/jupyterlab/lumino
+- notcurses — https://github.com/dankamongmen/notcurses
+- Tauri 2 — https://tauri.app/
+- RDR-111: ORB Cockpit Substrate (especially §Auto-layout engine)
+- RDR-118: Surfaces as Tuples (cell substrate this RDR realizes)
+- `docs/agentic-cockpit.md` §What we build vs leverage (lines 739–797),
+  §Surfaces (lines 593–738)
+- `docs/a2ui-summary.md` (this worktree)
+- T3 knowledge entries: `a2ui-v08-surface-descriptor-schema`,
+  `a2ui-v09-draft-changes`, `a2ui-design-philosophy-stack-positioning`,
+  `a2ui-nexus-synthesis-cockpit-mapping`
+- RDR-111 post-mortem (deferred beads, reactivation triggers)
+
+## Revision History
+
+_2026-05-18 — initial sketch as the per-host realization companion to
+RDR-118. Reactivates deferred beads `nexus-kkh2` (tmux pane
+fulfillment) and `nexus-0rws` (ext-apps iframe fulfillment). MVP
+mission profile shared with RDR-118 (RDR audit cockpit, reactivates
+`nexus-kgo4`)._

--- a/docs/rdr/rdr-120-storage-substrate-split.md
+++ b/docs/rdr/rdr-120-storage-substrate-split.md
@@ -1,0 +1,730 @@
+---
+title: "Storage Substrate Split: Substrate-Only Scope, No Co-Shipped Consumers"
+id: RDR-120
+type: Architecture
+status: draft
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-19
+accepted_date:
+related_issues: []
+related_rdrs: [RDR-004, RDR-041, RDR-105, RDR-108, RDR-112]
+supersedes: [RDR-112]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-120: Storage Substrate Split: Substrate-Only Scope, No Co-Shipped Consumers
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+T2 and T3 are opened today as **library-mode file handles**. Inside a sandbox
+container (Claude Desktop's bundled MCP runtime, ext-app sandboxes, `claude
+-p` sub-processes with their own filesystem view), "open the file at
+`~/.nexus/t2.sqlite`" silently resolves to a copy or an empty path. Each
+container gets its own SQLite, its own chroma collections, its own memory
+tier, and knowledge fragments invisibly across silos. T1 is correct as-is
+(per-process working memory, RDR-105). T2 and T3 are the cross-session,
+cross-instance tiers whose entire value proposition is that co-located
+processes see the same state.
+
+This RDR addresses **exactly that problem and nothing else**. The previous
+attempt (RDR-110/111/112/113/118/119, scrapped 2026-05-19) bundled the
+substrate split with a tuplespace, an event-projection cockpit, a host-trust
+model, and a UI fabric. Six weeks in, the substrate's correctness was a
+moving target because new abstractions kept landing on top of it. Tombstoned
+designs preserved as historical reference; postmortem at
+[`docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md`](../postmortem/2026-05-16-rdr110-113-remediation-chain.md).
+
+### Enumerated gaps to close
+
+#### Gap 1: T2 and T3 leak the storage substrate as a file path
+
+`T2Database` and the T3 chroma client are opened by direct filesystem path.
+Any process with read access to the path is a peer writer. Inside a sandbox
+container that path either does not exist (silent fork to an empty DB) or
+resolves to a bind-mounted copy (silent fork to a stale DB). No enforced
+single-writer boundary, no liveness check, no version negotiation.
+
+#### Gap 2: Multi-instance co-work fragments knowledge into silos
+
+When Claude Desktop, a `claude -p` sub-process, and a separate IDE agent all
+run on the same host, each opens its own T2/T3 handles. T2 writes from one
+instance are invisible to the others until/unless they re-open the file
+(and WAL behavior across containers is not guaranteed). Memory put in one
+cockpit is unreachable from another. This is the same fragmentation problem
+RDR-105 solved for T1 with env passdown, except that T1 fragmentation is
+desired and T2/T3 fragmentation is broken by design.
+
+#### Gap 3: No single-writer arbiter for future concurrency primitives
+
+The previous attempt named several primitives this substrate would unlock
+(atomic take, blocking take with `data_version` wake, event projection,
+subspace registry). Those primitives are **out of scope** for this RDR by
+design; the moratorium below blocks them. The relevant fact for *this* RDR
+is that the file-handle access pattern leaves no place to hang them later
+either. Establishing a daemon owner is a precondition; building anything on
+top is a follow-on, after the substrate proves itself.
+
+## Context
+
+### Background
+
+Three RDRs frame the problem:
+
+- **RDR-105** moved T1 from on-disk session records to env-passdown of a
+  host-local chroma. Settled the per-process working-memory question and
+  proved the host-service-plus-env-discovery pattern.
+- **RDR-108** locked the catalog-as-tree / T3-as-content-addressed-blob
+  identity model. Doc identity is `Document.tumbler`; chunk natural ID is
+  `sha256(chunk_text)[:32]`. Boundary work needs to preserve this.
+- **RDR-112 (scrapped)** designed a service split with dual-primary
+  discovery, UDS+TCP transport, storage-boundary lint, and an
+  `NX_STORAGE_MODE` cutover flag. The design was sound; the arc around it
+  was not. This RDR inherits the substrate design wholesale and discards
+  the arc.
+
+### Technical Environment
+
+In scope: every persistent shared-state store opened by direct file path
+under `src/nexus/`:
+
+- **T2 (seven domain stores)** behind the `T2Database` facade:
+  `memory_store`, `plan_library`, `chash_index`, `catalog_taxonomy`,
+  `aspect_extraction_queue`, `document_aspects`, `telemetry`. SQLite +
+  FTS5, WAL enabled.
+- **T3 local mode**: `chromadb.PersistentClient(path)` + local ONNX
+  embedder.
+- **T3 cloud mode**: `chromadb.CloudClient`. Already service-shaped (remote
+  HTTPS). Goes through the same `T3Client` abstraction for symmetry; no
+  daemon needed.
+- **CatalogDB** (`src/nexus/catalog/catalog_db.py:255`): own SQLite file,
+  own `sqlite3.connect()`. Structurally identical to a T2 domain store and
+  equally vulnerable to the container silo problem. **In scope** as P5.
+
+Out of scope explicitly:
+
+- **T1** stays per-process. RDR-105's env passdown is correct.
+- **Cross-host federation**. TCP listeners are loopback-only by default;
+  cross-host is a future RDR after substrate ships.
+- **All RDR-110/111/113/118/119 consumer abstractions.** See [§ Scope
+  Boundaries](#scope-boundaries) below.
+
+Direct-file-open call sites under `src/nexus/` outside `src/nexus/db/`
+(grepping `sqlite3.connect` + `PersistentClient`):
+
+- `src/nexus/commands/{tier_status,upgrade,plan}.py`
+- `src/nexus/{health,mcp_infra,search_engine,collection_audit,pipeline_buffer,_session_end_launcher}.py`
+- `src/nexus/catalog/{catalog_db.py,synthesizer.py}`
+
+P0's lint pass enumerates the full list and locks the inventory for P2/P4
+migration.
+
+## Scope Boundaries
+
+This is the most important section of this RDR. It is **load-bearing**: the
+2026-05-19 scrap happened because the prior arc lacked an explicit
+moratorium and accreted consumer abstractions onto an in-flight substrate.
+
+### In scope (P0 through P6)
+
+- T2 daemon: long-lived process owning the seven domain-store SQLite
+  handle(s). Exposes the existing `T2Database` facade API over UDS + TCP.
+- T3 daemon: managed `chroma run` subprocess. Exposes the existing chroma
+  client API via `HttpClient`.
+- Discovery: dual-primary (file at `~/.config/nexus/<tier>_addr.<uid>` and
+  env vars `NX_T2_SOCK` / `NX_T2_ADDR` / `NX_T3_ADDR`).
+- Thin `T2Client` / `T3Client` mirroring the existing facade signatures.
+  Call sites do not change beyond constructor injection.
+- Daemon-owned schema migration. The daemon is the sole migration runner.
+- `NX_STORAGE_MODE=direct|daemon` cutover flag. `direct` retains library
+  mode for P0-P5 migration safety; deleted in P6.
+- Storage-boundary lint (`nx doctor --check-storage-boundary`): AST scan
+  that fails CI on `sqlite3.connect` / `PersistentClient` outside
+  `src/nexus/db/` daemon-internal code.
+- Day-2 introspection minimum: `nx daemon t2 exec --raw <SQL>` for
+  read-only SQL inspection.
+- CatalogDB collapses into T2 as the eighth domain store (P5).
+- MVV: two `claude -p` sub-processes in different working directories share
+  a `memory_put` / `memory_get` round trip.
+
+### Out of scope, blocked by moratorium until P6+30 days
+
+All of the following are valid future work. **None lands while substrate
+work is in flight.** Each requires its own RDR filed *after* the substrate
+has been on `main` continuously for ≥30 days under `NX_STORAGE_MODE=daemon`.
+
+- Tuple-space primitives: atomic `in`/`out`/`rd`, blocking `take`,
+  `data_version` polling wake (RDR-110 substance).
+- Event-stream RPC: `EventStream(subspace_prefix, since_cursor) →
+  Stream<Event>`, glob subspace matching, lifecycle events (RDR-110/111
+  substance).
+- Subspace registry: schema-validated tuple types, version handshake on
+  subspace digest, plugin-supplied subspaces.
+- Hook bridge writing into a daemon-owned tuplespace (RDR-111 substance).
+- Cockpit panels reading off the event stream (RDR-111/119 substance).
+- ORB bindings watcher reacting to tuples (RDR-111 substance).
+- Host-trust model: peer-credential check on accept, multi-user UID
+  separation, token-based auth (RDR-113 substance).
+- Surfaces-as-tuples generalization (RDR-118 substance).
+- UI fabric / A2UI realization (RDR-119 substance).
+- Adding a new T2 domain store beyond the existing seven plus catalog
+  (eight total).
+- Adding a new RPC method to the daemon beyond what the existing facades
+  already expose.
+- Cross-host federation, non-loopback TCP bind, network auth.
+
+### Enforcement
+
+- **§ Scope Boundaries is part of the Finalization Gate.** The gate
+  rejects any scope drift.
+- **PR-level**: any PR touching `src/nexus/db/` or the daemon entry points
+  that adds a method not present in the pre-RDR `T2Database` /
+  `chromadb.api` surface fails review.
+- **Bead-level**: no bead may reference RDR-110/111/113/118/119 substance
+  while RDR-120 is in flight. Such beads are filed as deferred against a
+  future RDR.
+- **Calendar-level**: the moratorium lifts P6 + 30 days, marked by a
+  follow-on RDR if any consumer is wanted.
+
+The moratorium is not a suggestion. It is the only structural difference
+between this attempt and the scrapped one.
+
+## Research Findings
+
+### Investigation
+
+RDR-112's research (conducted 2026-05-12 via deep-research-synthesizer,
+preserved in T2 entries `112-research-A1..A4` and `112-research-A3-spike`)
+covers the substrate-substantive questions and is cited here rather than
+re-conducted. This RDR adds a postmortem-derived findings layer on what
+process discipline actually failed.
+
+### Key Discoveries (substrate, cited from tombstoned RDR-112)
+
+- T2 daemon is structurally required for the container case: Docker
+  overlayfs blocks the `mmap` semantics SQLite WAL requires, so a
+  bind-mounted host path opened from inside a container produces a
+  separate WAL per process. Silent silo failure mode.
+- T1's existing service shape (chroma HTTP over loopback, spawned at
+  `session.py:494-504`, discovered via `~/.config/nexus/t1_addr.<pid>`
+  + PPID walk) is a live production precedent.
+- `chroma run` is FastAPI + uvicorn with a configurable thread pool
+  (default 40). chromadb's "not for production" disclaimer attaches to
+  `EphemeralClient` / `PersistentClient`; `HttpClient` is explicitly the
+  "recommended production configuration."
+- RDR-105's PPID-walk + discovery-file pattern fails in
+  PID-namespace-isolated containers. The walk terminates at container
+  init (PID 1) and `~/.config` is not bind-mounted in typical sandbox
+  configurations. `NX_T2_ADDR` / `NX_T3_ADDR` env-var override is a
+  co-primary discovery path, not a fallback.
+
+### Key Discoveries (process, from 2026-05-16 postmortem)
+
+- **`run_until_signal()` hang** (60 minutes lost, 3 CI cycles): a local
+  `stop_event` only signal handlers could set wasn't shared with
+  `daemon.stop()`. Fix landed in PR #795. Lock-in: any daemon stop signal
+  must be hoisted to an instance attribute reachable from both signal
+  handlers and direct callers, or replaced with `asyncio.Event` shared
+  between them.
+- **CLAUDECODE env-var gate**: bridge `emit()` early-returned when env
+  var unset. All darwin dev shells had it; no CI runner did. Tests passed
+  locally, failed only on CI, looked PR-introduced. Lock-in: any test
+  that asserts on env-gated behavior must explicitly set the env via
+  fixture.
+- **Cross-contamination via worktrees**: parallel agents working on
+  adjacent files in worktrees produced sibling PRs (#787, #788, #789)
+  carrying portions of each other's code via git 3-way merge auto-resolve.
+  Lock-in: substrate work runs on a single branch, serial commits, no
+  parallel-agent fan-out across worktrees.
+- **The 30-file unrebaseable PR (#786)**: y0nb audit follow-ups grew to
+  1870 insertions while develop moved through ten daughter PRs. 70%
+  overlap with merged work; extracted (#803) and closed as superseded.
+  Lock-in: phase boundary = PR boundary. A PR that's still growing closes
+  no phase.
+- **Pre-existing develop failures masquerading as PR-introduced** (seven
+  tests dragged in by y0nb merge artifacts). Lock-in: every substrate PR
+  is gated on green CI on the base branch before the PR opens.
+- **Migration race (`nexus-9eaz`)**: `_upgrade_lock` semantics under
+  concurrent multi-process daemon startup, un-reproducible on darwin.
+  Skipped, instrumented, never bottomed. Lock-in: daemon is the **sole**
+  migration runner from day one. Multi-process migration concurrency is
+  not a problem the daemon design has to solve, because by design only
+  one process ever runs migrations.
+
+### Critical Assumptions
+
+- [x] **A1**: `chroma run` is production-quality enough to be the T3
+  service. **Status**: Documented (High confidence). **Method**:
+  Source Search of `chromadb/app.py` plus live T1 precedent. **Evidence
+  reused from**: tombstoned RDR-112 §A1.
+- [x] **A2**: SQLite WAL is not an acceptable substitute for a
+  single-writer daemon in the container case. **Status**: Verified
+  (High confidence). **Method**: Source Search +
+  sqlite.org/wal.html. **Evidence reused from**: tombstoned RDR-112 §A2.
+- [x] **A3**: Daemon-per-tier latency overhead is acceptable for common
+  reads. **Status**: Verified (High confidence). **Method**: Spike
+  (`/tmp/rdr112_a3_spike.py`, 2000 iters on real `MemoryStore`). Results:
+  direct p50=85 µs / p99=286 µs; UDS p50=100 µs / p99=300 µs (+15 µs);
+  TCP loopback p50=114 µs / p99=620 µs (+29 µs). All sub-ms. **Evidence
+  reused from**: tombstoned RDR-112 §A3 (T2 entry
+  `112-research-A3-spike`).
+- [x] **A4**: Discovery via per-host UID file is universally adequate.
+  **Status**: Refuted (High confidence). Mitigation: dual-primary file +
+  env-var discovery. **Evidence reused from**: tombstoned RDR-112 §A4.
+- [ ] **A5** (new): **Storage-boundary lint catches every regression
+  vector.** AST scan of `sqlite3.connect` and `PersistentClient` outside
+  `src/nexus/db/` is sufficient to prevent new direct-open call sites
+  during P2-P5 migration. **Status**: Unverified. **Method**: Spike
+  in P0; run the lint against a known-bad fixture and a known-good
+  fixture; confirm zero false negatives on the seven existing patterns
+  in `commands/`, `catalog/`, and top-level `nexus/`.
+- [ ] **A6** (new): **A daemon as sole migration runner eliminates the
+  `_upgrade_lock` race class.** With a single daemon process holding the
+  SQLite handle for the lifetime of the tier, multi-process migration
+  concurrency cannot arise; the `nexus-9eaz` instrumentation is
+  unnecessary in daemon mode. **Status**: Unverified. **Method**:
+  Source Search of `apply_pending` once daemon owns the connection;
+  confirm no path exists for a second process to enter the lock-protected
+  window.
+- [ ] **A7** (new): **The moratorium is enforceable through finalization
+  gates and review.** A written scope-boundary section plus a
+  Finalization Gate scope-verification step is sufficient to block scope
+  drift across the six phases. **Status**: Unverified (this is the
+  novel discipline this RDR is testing). **Method**: Per-phase
+  cross-walk of merged PRs against § Scope Boundaries at each phase
+  closeout; lock the result in the phase's review gate before the next
+  phase opens.
+
+## Proposed Solution
+
+### Approach
+
+Six phases. Each ships as one branch, one PR, one cutover. Each phase must
+be on `main` for **≥7 days** under real usage before the next opens.
+Linear, not parallel. The release of each phase is its own validation
+point.
+
+**Phase 0: Lint + cutover flag scaffolding**
+
+- Implement `nx doctor --check-storage-boundary`: AST scan of
+  `sqlite3.connect` + `PersistentClient` outside an allowlisted prefix
+  (`src/nexus/db/`). Modeled on
+  `tests/test_no_direct_catalog_writes_outside_projector.py` (RDR-101
+  Phase 3 ε-lint).
+- Add `NX_STORAGE_MODE` env-var honor as a **no-op** (only `direct` is a
+  valid value at this phase; `daemon` is rejected with "not yet
+  supported").
+- CI step runs the lint with `--fail-on-violation`. Initial run reports
+  the existing 30+ direct-open sites; baseline is recorded as the
+  allowlist for P1-P5 migration progress.
+- No client API changes. No daemon code yet.
+
+**Phase 1: T3 daemon (managed `chroma run`)**
+
+- `nx daemon t3 {start,stop,status,install,uninstall}` CLI verbs.
+- Daemon process: spawn-and-supervise `chroma run` with explicit port and
+  data path. Loopback TCP only (chromadb upstream constraint).
+- Discovery file: `~/.config/nexus/t3_addr.<uid>` containing the chroma
+  HTTP address. Env override: `NX_T3_ADDR`.
+- `T3Client` factory: returns an `HttpClient`-backed wrapper whose API
+  signature matches the current `T3Database` PersistentClient surface.
+- T3 call sites do **not** flip yet. `NX_STORAGE_MODE=direct` remains the
+  only valid value; daemon mode is exercised via direct construction in
+  the daemon-mode E2E test.
+- MVV variant: two `claude -p` sub-processes, both pointing at the
+  running T3 daemon via `NX_T3_ADDR`, share a T3 collection round trip.
+
+**Phase 2: T3 cutover**
+
+- All T3 call sites use `T3Client`. The `PersistentClient` direct opens
+  inside `src/nexus/db/t3.py` are deleted (or fenced behind
+  daemon-internal access).
+- `NX_STORAGE_MODE=daemon` becomes valid for T3 reads/writes.
+- Full pytest + integration suite green under `NX_STORAGE_MODE=daemon`.
+- ≥7 days on `main` under real usage before P3 opens.
+
+**Phase 3: T2 daemon**
+
+- `nx daemon t2 {start,stop,status,install,uninstall}` CLI verbs.
+- Daemon process: owns the seven domain-store SQLite handles (one per
+  store path, all under the daemon's process). Binds both UDS
+  (`~/.config/nexus/t2.sock`) and loopback TCP (announced via discovery
+  file).
+- Discovery: `~/.config/nexus/t2_addr.<uid>` carries both UDS path and
+  TCP host:port. Env overrides: `NX_T2_SOCK`, `NX_T2_ADDR`.
+- `T2Client`: thin RPC client mirroring the existing `T2Database` facade.
+  UDS preferred, TCP fallback when UDS unreachable.
+- **Daemon owns migration**. On startup, checks schema version, applies
+  pending, then accepts connections. Clients carry an
+  expected-schema-version constant; handshake fails loud on mismatch.
+- T2 call sites do not flip yet. Daemon mode exercised via the daemon
+  E2E suite.
+- MVV: two `claude -p` sub-processes in different working dirs share
+  `memory_put` / `memory_get`.
+
+**Phase 4: T2 cutover**
+
+- All T2 call sites use `T2Client`. Direct `sqlite3.connect` outside
+  `src/nexus/db/` daemon-internal becomes a hard lint violation (was
+  allowlisted in P0; allowlist removed for all migrated sites).
+- `NX_STORAGE_MODE=daemon` is the default for new installs; `direct` is
+  retained as a debug fallback.
+- 7-day soak under daemon mode.
+
+**Phase 5: Catalog collapse into T2**
+
+- `CatalogDB` (`src/nexus/catalog/catalog_db.py`) ports its schema and
+  read/write surface into T2 as the eighth domain store. Catalog client
+  goes through `T2Client`.
+- Direct `sqlite3.connect` in `catalog_db.py:255` and `synthesizer.py:792`
+  deleted.
+- Catalog test suite plus indexer-pipeline dogfood validates.
+
+**Phase 6: Decommission `direct` mode**
+
+- `NX_STORAGE_MODE` flag removed. Library-mode code paths deleted.
+- Release. The substrate ships.
+- **The moratorium lifts 30 days after P6 ships on `main`.** Any consumer
+  RDR may then be filed.
+
+### Existing Infrastructure Audit
+
+| Proposed Component | Existing Module | Decision |
+|---|---|---|
+| `nx daemon t3` | `chromadb` upstream `chroma run` | Wrap and supervise; no new HTTP code. |
+| `nx daemon t2` | `nexus.db.t2.T2Database` (seven domain stores) | Extend: wrap existing facade in a socket server; do not rewrite store logic. |
+| `T2Client` | `T2Database` facade | New: thin RPC client mirroring facade signature. |
+| `T3Client` | `T3Database` PersistentClient surface | New: `HttpClient`-backed wrapper. |
+| Discovery file | RDR-105's `~/.config/nexus/t1_addr.<claude_pid>` | Extend pattern; one address file per tier. |
+| Storage-boundary lint | `tests/test_no_direct_catalog_writes_outside_projector.py` (RDR-101 ε-lint) | Extend pattern; new check function in `commands/doctor.py`. |
+| Migration ownership | `nexus.db.migrations.apply_pending` | Move call site to daemon startup only; remove client-side `apply_pending` invocations. |
+| `nx daemon t2 exec --raw` | (none) | New: read-only SQL pass-through over RPC. |
+| Catalog into T2 (P5) | `nexus.catalog.catalog_db.CatalogDB` | Migrate schema; reuse store-internal patterns; delete `CatalogDB`. |
+
+### Decision Rationale
+
+**T3 ships first because the upstream gives us a free service.** `chroma
+run` is a documented, vendored, production-recommended HTTP server. Our
+P1 work is spawn-and-supervise + discovery + client wrapper. Zero novel
+concurrency. Zero new SQLite semantics. Zero migration ownership
+question. We prove the discovery mechanism, the cutover flag, and the
+client-shim pattern against a substrate we don't own. Then T2 ships into
+the same shape against a substrate where the concurrency story is ours.
+
+**T2 second because the migration race is solved by construction once
+the daemon owns the SQLite handle.** The `nexus-9eaz` `_upgrade_lock`
+race that the previous attempt could not bottom is a problem only if
+multiple processes can race on `apply_pending`. The daemon model makes
+that impossible: one process, one connection, one migration runner. The
+race class disappears; the instrumentation is unnecessary.
+
+**Catalog third because it's the largest blast radius.** 22k lines
+across the catalog package, the most heavily-used code in the project.
+Migrating after T2 daemon is proven means catalog gets a substrate that's
+been on `main` for ≥14 days under real usage before the catalog flip
+begins.
+
+**Serial PR chain, not parallel-agent fan-out.** Cross-contamination via
+shared worktrees is one of the documented failure modes from the
+previous attempt. Substrate commits land on one branch in order. Parallel
+agents may only work on orthogonal consumers of the substrate, after the
+substrate is merged.
+
+**Cutover, not dual-mode forever.** `NX_STORAGE_MODE=direct` is a
+migration safety valve, deleted in P6. The previous attempt's open-ended
+dual-mode is what kept schema-blindness in the inline planner alive.
+
+**No new primitives.** This is the moratorium. It is the only structural
+difference between this attempt and the scrapped one. Without it, the
+substrate's correctness becomes a moving target again.
+
+## Alternatives Considered
+
+### Alternative 1: Resurrect RDR-112 as the live design
+
+**Description**: Restore RDR-112 from git history, amend its scope to drop
+the RDR-110/111/113 consumer prerequisites, accept and implement against
+that document.
+
+**Pros**:
+- Less writing upfront.
+- Preserves the A1-A4 research findings as part of an accepted RDR.
+
+**Cons**:
+- RDR-112's prose is structurally entangled with the scrapped peers.
+  Problem Statement, Decision Rationale, Approach §7 (event stream), §8
+  (subspace registry), and the "Sequencing constraint vs RDR-110"
+  subsection exist specifically to serve RDR-110's atomic-take and
+  RDR-111's event projection. Stripping those leaves a different
+  document.
+- The new attempt's discipline (substrate-only scope, moratorium on
+  co-shipped consumers) is the single most important property. It must
+  be in the title and Problem Statement, not a §Revision History
+  footnote.
+- Phase 1/2 placeholders ("to be expanded during /nx:create-plan") are
+  exactly the softness that let scope creep in. The new RDR encodes
+  P0-P6 phasing and the ≥7-day cadence as RDR-level commitments.
+
+**Reason for rejection**: The most load-bearing change is the
+*discipline*. A fresh document carries it visibly; an amended document
+relegates it to a revision note.
+
+### Alternative 2: Status quo, hope WAL holds across containers
+
+**Description**: Keep opening T2 and T3 by path; rely on SQLite WAL and
+chroma's filesystem locking.
+
+**Cons**: Does not work across container boundaries; overlayfs blocks
+WAL `mmap`. Silent fork-into-empty-DB persists. The container fragmentation
+class of bugs (every "memory I saved isn't there" report) continues.
+
+**Reason for rejection**: Does not solve the stated problem.
+
+### Alternative 3: Single mega-daemon owning T1+T2+T3
+
+**Cons**: T1 must stay per-session; collapsing it breaks RDR-105's
+sibling-visibility model. T2 and T3 have very different scaling and
+crash-isolation profiles; a chroma OOM should not take down memory.
+
+**Reason for rejection**: Conflates tiers that RDR-105 deliberately
+separated.
+
+### Alternative 4: Cloud-only T3 (skip the T3 daemon, mandate `CloudClient`)
+
+**Cons**: Reintroduces a network-required dependency for local
+development; breaks air-gapped use cases; T3 cloud mode requires Voyage
+API credentials.
+
+**Reason for rejection**: Local mode is a first-class requirement.
+
+### Briefly Rejected
+
+- **Database-as-MCP-server only**: conflates the storage boundary with the
+  tool boundary. The tool layer already exists; we want a layer below it.
+- **Co-ship a minimal tuplespace primitive in P3**: this is the previous
+  attempt's failure mode in miniature. Hard no.
+
+## Trade-offs
+
+### Consequences
+
+- (+) Closes the cross-container silo class of bugs structurally.
+- (+) Forces the discipline future tiers (T4? cross-host?) will need
+  anyway.
+- (+) Multi-user host isolation is free via UDS file permissions; no
+  in-process auth code in v1.
+- (+) Migration race class (`_upgrade_lock`) disappears by construction.
+- (−) Two new long-lived processes per nexus install.
+- (−) Adds an RPC hop to every T2/T3 call: +15 µs p50 (UDS) / +29 µs p50
+  (TCP loopback) per A3 spike. Both sub-ms.
+- (−) Daemon ↔ client version handshake is a new operational concern.
+- (−) Containerised consumers require an orchestration step (UDS
+  bind-mount or TCP port allow-list + env-var injection).
+- (−) Ad-hoc DB access (`sqlite3 ~/.nexus/t2.db`, DBeaver, Datasette)
+  disappears when nexus runs in its own container. `nx daemon t2 exec
+  --raw <SQL>` is the supported replacement.
+- (−) Six phases × ≥7 days each = ~6 weeks calendar minimum. Slower than
+  the previous attempt's intended pace by ~2x, and ~10x more confident.
+
+### Risks and Mitigations
+
+- **Risk**: Daemon crash leaves clients hanging.
+  **Mitigation**: Health-check + auto-respawn; clients fail loud with
+  recovery instructions, no silent fallback to direct file.
+- **Risk**: Auto-spawn races between concurrent first-use clients.
+  **Mitigation**: Filesystem-lock-mediated spawn (spawner takes a lock
+  on the discovery file before forking).
+- **Risk**: Sandbox containers with no host filesystem visibility.
+  **Mitigation**: `NX_T2_SOCK` / `NX_T2_ADDR` / `NX_T3_ADDR` env-var
+  injection as co-primary discovery; daemon binds both UDS and TCP and
+  announces both on stdout for orchestrator capture.
+- **Risk**: A consumer slips through the moratorium.
+  **Mitigation**: § Scope Boundaries is part of the Finalization Gate;
+  per-phase cross-walk at each phase closeout; a written rule reviewers
+  can cite when rejecting drift.
+
+### Failure Modes
+
+- **Daemon down, client connects**: fail loud, suggest `nx daemon start`.
+  Do not silently degrade.
+- **Version mismatch**: client refuses to connect; report both versions.
+- **Daemon healthy, data corrupt**: same as today (SQLite/chroma surface
+  their own errors); daemon does not mask them.
+- **Phase exceeds ≥7-day soak with a regression**: do not open the next
+  phase; fix or revert.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [x] RDR-112 tombstoned (this RDR's parent). Done 2026-05-19.
+- [x] Postmortem available on `main`. Done 2026-05-19 (this PR).
+- [ ] CI baseline: green on `main` at PR-open time. Tooling-level gate.
+- [ ] Storage-boundary lint passes against the current main without
+  daemon-internal allowlist (P0 baseline).
+
+### Minimum Viable Validation
+
+A single end-to-end demo, per phase:
+
+| Phase | MVV |
+|---|---|
+| P0 | Lint detects all 30+ direct-open sites; `direct` mode unchanged. |
+| P1 | Two `claude -p` sub-processes pointing at `NX_T3_ADDR` share a T3 round trip. |
+| P2 | Full pytest + integration green under `NX_STORAGE_MODE=daemon` for T3. |
+| P3 | Two `claude -p` sub-processes in different working dirs share `memory_put` / `memory_get`. |
+| P4 | Full pytest + integration green under `NX_STORAGE_MODE=daemon` for T2. |
+| P5 | Catalog read/write round trip through the T2 daemon; indexer pipeline dogfood. |
+| P6 | `NX_STORAGE_MODE` removed; full suite green. |
+
+### Day 2 Operations
+
+| Resource | List | Info | Stop | Verify | Backup |
+|---|---|---|---|---|---|
+| T2 daemon | `nx daemon list` | `nx daemon info t2` | `nx daemon stop t2` | health-check RPC | snapshot of underlying SQLite |
+| T3 daemon | `nx daemon list` | `nx daemon info t3` | `nx daemon stop t3` | health-check RPC | snapshot of chroma dir |
+| Discovery files | `ls ~/.config/nexus/*_addr.*` | `cat <file>` | rm on daemon stop | daemon startup writes | n/a |
+
+`nx daemon t2 exec --raw <SQL>` is the read-only inspection surface. A
+second `mode=ro` SQLite connection is opened by the daemon for `--raw`
+execution; SQL pattern matching is brittle and not used. Write surfaces
+(`exec --write`, `export`, `import`) are deferred to a follow-on RDR.
+
+### New Dependencies
+
+Probably none. Stdlib `socketserver` / `multiprocessing.connection` for
+T2 transport; `chromadb` itself for T3 (already a dep). Confirm in P0.
+
+## Test Plan
+
+- **Scenario**: Two processes, distinct working dirs, same host:
+  `memory_put` in one, `memory_get` in the other. **Verify**: value
+  reads back. *(Original MVV, the proof-of-correctness.)*
+- **Scenario**: Daemon killed mid-operation. **Verify**: client reports
+  a clear error, no silent fallback to direct file.
+- **Scenario**: Two clients race to auto-spawn. **Verify**: exactly one
+  daemon runs; the loser connects to the winner.
+- **Scenario**: Client built against daemon version N+1 connects to
+  daemon version N. **Verify**: handshake refuses with clear version
+  message.
+- **Scenario**: Cross-*container* memory visibility (Claude Desktop ↔
+  host `nx` CLI). **Verify**: visible.
+- **Scenario**: Daemon restart preserves data and notifies clients.
+  **Verify**: clients reconnect transparently or fail-loud per policy.
+- **Scenario**: Storage-boundary lint against a known-bad fixture (a
+  test file with a fresh `sqlite3.connect` outside `src/nexus/db/`).
+  **Verify**: lint fails with `file:line` of the violation. *(A5
+  verification.)*
+- **Scenario**: Migration race regression test. Spawn two
+  daemon-startup attempts in parallel against the same data path.
+  **Verify**: exactly one applies the migration; the other refuses to
+  start. *(A6 verification.)*
+- **Scenario**: Scope-boundary cross-walk per phase. After each
+  phase's PR merges, run a diff of merged code against § Scope
+  Boundaries. **Verify**: no out-of-scope work landed. *(A7
+  verification.)*
+
+## Validation
+
+### Testing Strategy
+
+1. **Scenario**: cross-process memory visibility (MVV). **Expected**:
+   visible.
+2. **Scenario**: cross-*container* memory visibility (Claude Desktop ↔
+   host `nx` CLI). **Expected**: visible.
+3. **Scenario**: daemon restart preserves data and notifies clients.
+   **Expected**: clients reconnect transparently or fail-loud per
+   policy.
+
+### Performance Expectations
+
+RPC overhead measured in RDR-112 §A3 spike: direct in-process p50 = 85
+µs; UDS p50 = 100 µs (+15 µs); TCP loopback p50 = 114 µs (+29 µs). All
+sub-millisecond. T3 store ops dominated by embedding latency (ONNX
+10-50 ms, Voyage 100-300 ms); transport hop below noise. Full data in
+T2 `nexus_rdr/112-research-A3-spike`.
+
+## Finalization Gate
+
+> Complete each item with a written response before marking this RDR as
+> **Accepted**.
+
+### Contradiction Check
+
+To be completed during gate.
+
+### Assumption Verification
+
+All four pre-existing assumptions (A1-A4) closed by RDR-112's gate; cited
+by reference. Three new assumptions added: A5 (lint coverage), A6
+(migration race elimination by construction), A7 (moratorium
+enforceability). All must reach Verified status before acceptance.
+
+### Scope Verification
+
+The Minimum Viable Validation (two `claude -p` sub-processes on the same
+host share memory via `memory_put` / `memory_get`) is in scope, not
+deferred.
+
+**§ Scope Boundaries is itself a gate item.** Gate must explicitly verify
+that no out-of-scope work has been added to the proposed solution. This
+gate item recurs at each phase closeout, not only at RDR acceptance.
+
+### Cross-Cutting Concerns
+
+- **Versioning**: daemon-client handshake required; mismatch fails loud.
+- **Build tool compatibility**: no new build-time deps anticipated.
+- **Licensing**: no new third-party libs anticipated.
+- **Deployment model**: daemons run on host; clients run anywhere with a
+  route to the host's UDS path or loopback TCP.
+- **IDE compatibility**: N/A.
+- **Incremental adoption**: `NX_STORAGE_MODE=direct|daemon`; `direct` is
+  the default during P0-P5 and is deleted in P6.
+- **Secret/credential lifecycle**: N/A in v1. Localhost-only, UDS uses
+  unix file permissions, TCP loopback-only. Multi-user trust deferred to
+  a post-substrate RDR.
+- **Memory management**: daemon long-lived; needs a budget (set during
+  planning based on expected concurrent client count and result-set
+  sizes).
+
+### Proportionality
+
+Document covers a structural shift in how every persistent shared-state
+store is accessed. Size justified. § Scope Boundaries is the
+proportionality control: it bounds what this RDR commits to and what it
+explicitly defers. The previous attempt's six-week scope creep is the
+counterfactual.
+
+## Open Questions
+
+- **Authentication beyond v1**: localhost-only + UDS permissions covers
+  single-user single-host. Multi-user and cross-host trust is deferred
+  to a post-substrate RDR. Naming it explicitly here so the deferral is
+  documented, not implicit.
+- **Daemon-as-MCP-server**: should the T2 daemon eventually *be* the MCP
+  server, collapsing two layers? Out of scope for this RDR; flagged for
+  a follow-on.
+- **Existing on-disk migration**: how do existing on-disk T2/T3 stores
+  get picked up by the new daemons? Presumably "the daemon opens the
+  same path the old direct client did," verified in P1 and P3.
+- **What signals lifting the moratorium**: P6 + 30 days under real
+  usage is the floor. Any other criteria? Open for the gate to settle.
+
+## References
+
+- Tombstoned RDR-112: [`docs/rdr/rdr-112-storage-as-service-container-boundary.md`](rdr-112-storage-as-service-container-boundary.md): substrate design source and A1-A4 research evidence.
+- Postmortem: [`docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md`](../postmortem/2026-05-16-rdr110-113-remediation-chain.md): what failed and why.
+- Tombstoned RDR-110/111/113/118/119: same directory: historical record
+  of the consumer arc that was scrapped alongside RDR-112.
+- RDR-105: T1 chroma architecture; live precedent for the
+  host-service-plus-env-discovery pattern this RDR generalizes.
+- RDR-108: Catalog/T3 identity model that P5 must preserve.
+
+## Revision History
+
+- 2026-05-19: Draft. Authored on `feature/rdr-120-storage-substrate-tombstones` immediately after tombstoning RDR-110/111/112/113/118/119.

--- a/docs/rdr/rdr-120-storage-substrate-split.md
+++ b/docs/rdr/rdr-120-storage-substrate-split.md
@@ -283,14 +283,27 @@ process discipline actually failed.
   in P0; run the lint against a known-bad fixture and a known-good
   fixture; confirm zero false negatives on the seven existing patterns
   in `commands/`, `catalog/`, and top-level `nexus/`.
-- [ ] **A6** (new): **A daemon as sole migration runner eliminates the
+- [x] **A6** (new): **A daemon as sole migration runner eliminates the
   `_upgrade_lock` race class.** With a single daemon process holding the
   SQLite handle for the lifetime of the tier, multi-process migration
   concurrency cannot arise; the `nexus-9eaz` instrumentation is
-  unnecessary in daemon mode. **Status**: Unverified. **Method**:
-  Source Search of `apply_pending` once daemon owns the connection;
-  confirm no path exists for a second process to enter the lock-protected
-  window.
+  unnecessary in daemon mode. **Status**: Verified (High confidence).
+  **Method**: Source Search. **Evidence**: T2 entry `120-research-A6`.
+  Summary: `_upgrade_lock` is `threading.RLock` (process-local) at
+  `src/nexus/db/migrations.py:2877`; `_bootstrap_lock` docstring at
+  `:2886-2894` explicitly: "Process-level only". Caller pattern at
+  `src/nexus/db/t2/__init__.py:178-225` invokes `apply_pending` per
+  T2Database construction, so N processes opening T2 concurrently = N
+  concurrent migration runners with N independent locks. The nexus-9eaz
+  failure is the cross-process case; the thread-case test at
+  `tests/test_migrations.py:696-740` passes by construction because
+  RLock works within a process. In daemon mode the daemon calls
+  `apply_pending` once at startup before accepting connections; clients
+  never call it. Cross-process race surface is structurally absent.
+  P3 implementation: move `apply_pending` from `t2/__init__.py:211` to
+  daemon startup; remove from `T2Client` construction; reframe the
+  skipped stress test as a daemon-startup invariant ("daemon refuses
+  second start against the same path").
 - [ ] **A7** (new): **The moratorium is enforceable through finalization
   gates and review.** A written scope-boundary section plus a
   Finalization Gate scope-verification step is sufficient to block scope

--- a/docs/rdr/rdr-120-storage-substrate-split.md
+++ b/docs/rdr/rdr-120-storage-substrate-split.md
@@ -115,14 +115,31 @@ Out of scope explicitly:
   Boundaries](#scope-boundaries) below.
 
 Direct-file-open call sites under `src/nexus/` outside `src/nexus/db/`
-(grepping `sqlite3.connect` + `PersistentClient`):
+(enumerated via grep + verified during A5; full inventory in T2 entry
+`120-research-A5`):
 
-- `src/nexus/commands/{tier_status,upgrade,plan}.py`
-- `src/nexus/{health,mcp_infra,search_engine,collection_audit,pipeline_buffer,_session_end_launcher}.py`
-- `src/nexus/catalog/{catalog_db.py,synthesizer.py}`
+- `src/nexus/commands/{plan,catalog,tier_status,upgrade,doctor,index}.py`
+  (9 SQLite + 1 chromadb)
+- `src/nexus/{health,mcp_infra,collection_audit,pipeline_buffer,_session_end_launcher}.py`
+  (5 SQLite + 4 chromadb)
+- `src/nexus/console/routes/health.py` (1 SQLite via `_sqlite3` alias)
+- `src/nexus/catalog/{catalog_db.py,synthesizer.py}` (2 SQLite, P0-P4
+  allowlisted, deleted at P5 cutover)
 
-P0's lint pass enumerates the full list and locks the inventory for P2/P4
-migration.
+Three current sites use module-aliased imports (`import sqlite3 as
+_sqlite3`): `commands/doctor.py` (lines 615, 720) and
+`console/routes/health.py:131`. The lint must track module aliases at
+import time, not only direct attribute references.
+
+The lint banlist covers all three chromadb client classes
+(`PersistentClient`, `CloudClient`, `EphemeralClient`) outside
+`src/nexus/db/`, not only `PersistentClient`. Cloud-mode T3 goes
+through the same `T3Client` abstraction for symmetry.
+
+P0's lint pass locks this inventory as the baseline. CI asserts the
+expected post-phase count of remaining direct opens at each phase
+boundary (P2: chromadb sites drop to 3; P4: SQLite outside `db/` and
+`catalog/` drops to 2; P5: SQLite outside `db/` drops to 0).
 
 ## Scope Boundaries
 
@@ -276,13 +293,29 @@ process discipline actually failed.
 - [x] **A4**: Discovery via per-host UID file is universally adequate.
   **Status**: Refuted (High confidence). Mitigation: dual-primary file +
   env-var discovery. **Evidence reused from**: tombstoned RDR-112 §A4.
-- [ ] **A5** (new): **Storage-boundary lint catches every regression
-  vector.** AST scan of `sqlite3.connect` and `PersistentClient` outside
-  `src/nexus/db/` is sufficient to prevent new direct-open call sites
-  during P2-P5 migration. **Status**: Unverified. **Method**: Spike
-  in P0; run the lint against a known-bad fixture and a known-good
-  fixture; confirm zero false negatives on the seven existing patterns
-  in `commands/`, `catalog/`, and top-level `nexus/`.
+- [~] **A5** (new): **Storage-boundary lint catches every regression
+  vector.** AST scan of `sqlite3.connect` (including module-aliased
+  forms like `_sqlite3.connect`), `chromadb.PersistentClient`,
+  `chromadb.CloudClient`, and `chromadb.EphemeralClient` outside
+  `src/nexus/db/`, with a phase-gated `src/nexus/catalog/` allowlist
+  removed at P5 cutover. **Status**: Partially Verified (High
+  confidence in feasibility and refinements). **Method**: Source Search
+  (ε-lint precedent + grep enumeration of call sites). **Evidence**:
+  T2 entry `120-research-A5`. Summary: the existing AST-lint at
+  `tests/test_no_direct_catalog_writes_outside_projector.py` is a 1:1
+  structural precedent (path-prefix allowlist, `# epsilon-allow:
+  <reason>` per-line override, alias-evasion handling). Current
+  inventory: 27 SQLite call sites (9 in `db/` allowlisted, 2 in
+  `catalog/` P0-P4 allowlisted then deleted at P5, 9 in `commands/`,
+  5 top-level, 1 in `console/routes/`, 1 missed in the original §
+  Technical Environment list); 8 chromadb call sites (3 in `db/`
+  allowlisted, 4 in `health.py`, 1 in `commands/index.py`). Three
+  refinements folded into the scope-boundary text above: cover all
+  three chromadb client classes (not just PersistentClient), implement
+  catalog two-phase allowlist (P0-P4 vs P5), track module-aliased
+  imports (`import sqlite3 as _sqlite3` used by 3 current sites).
+  Remaining 5% confidence gap: live spike against known-bad and
+  known-good fixtures; assigned to P0 implementation.
 - [x] **A6** (new): **A daemon as sole migration runner eliminates the
   `_upgrade_lock` race class.** With a single daemon process holding the
   SQLite handle for the lifetime of the tier, multi-process migration

--- a/docs/rdr/rdr-120-storage-substrate-split.md
+++ b/docs/rdr/rdr-120-storage-substrate-split.md
@@ -227,18 +227,32 @@ cannot catch.
   RDR-120 §Scope Boundaries first. Solo-author is single-point-of-
   awareness as well as single-point-of-failure; the moratorium being in
   the title and Problem Statement makes it hard to miss.
-- **Per-phase cross-walk.** At each phase-close review gate, the
-  reviewer (the author, in solo context) cross-walks closing PRs and
-  beads against §Scope Boundaries. Catches both scope loss (X' ⊂ X) per
-  the documented protocol in
-  `feedback_phase_closeout_scope_audit.md`, and scope gain (X' ⊃ X via
-  "while we're in here" additions) which RDR-120 adds as a symmetric
-  check.
+- **`/nx:phase-review-gate` cross-walk (tooled).** At each phase
+  closeout, the reviewer runs `/nx:phase-review-gate 120 --phase N`.
+  Pass 1 enumerates all §Approach items; Pass 2 validates each item has
+  a closing-bead pointer or explicit `none` deferral. BLOCKED on any
+  unaccounted item. This is a hard-enforcement preamble (Python script
+  the agent cannot reason past) modeled on the RDR-065 Problem
+  Statement Replay gate. Built as bead `nexus-j327` (commit
+  `122feaff`, 791 LOC + 312 LOC tests). The regression test covers the
+  actual `nexus-52lb` / RDR-112 Phase 1 silent-drop incident; the gate
+  would have blocked that close. **Currently lives only on
+  `archive/develop-2026-05-19`**; P0 prerequisite is restoring it to
+  main before any phase opens.
+- **Symmetric scope-gain check (manual).** `/nx:phase-review-gate`
+  catches scope LOSS (§Approach item with no closing bead) by design.
+  Scope GAIN (closing bead that implements something from § Out of
+  scope) is not currently tooled. RDR-120 adds a manual symmetric
+  step: at each phase close, the reviewer also lists every closing
+  bead and grep-matches its title and description against the §Out of
+  scope banned-topic list. A bead matching a banned topic blocks the
+  phase close until it is removed or the moratorium is explicitly
+  amended.
 - **PR-level review.** Each PR's diff is read against §Scope Boundaries.
   Any new method on `T2Database` / `chromadb.api` beyond the pre-RDR
   surface fails. In solo context, the author re-reads their own diff.
 - **Bead-level enforcement.** `bd create` for substrate work requires
-  the author to confirm the bead's substance is not in §Out of scope.
+  the author to confirm the bead's substance is not in § Out of scope.
 
 **Tooling gaps (block multi-author adoption):**
 
@@ -253,6 +267,12 @@ cannot catch.
   the gate while violating a peer's moratorium. Follow-on: extend the
   Layer 3 relay's Input Artifacts to include "active in-flight RDRs'
   §Scope Boundaries sections."
+- **`/nx:phase-review-gate` is scope-loss-only.** Catches §Approach
+  items missing closing beads (silent scope reduction). Does NOT catch
+  closing beads that implement § Out of scope work (silent scope
+  expansion). Follow-on: a Pass 3 that enumerates closing beads and
+  matches their descriptions against the active RDR's § Out of scope
+  list. Until then, the symmetric check is manual reviewer discipline.
 - **`bd create` does not grep description against moratorium banned-
   topic lists.** Bead-level enforcement is currently author discipline
   only.
@@ -261,6 +281,15 @@ These gaps are dormant during RDR-120's solo-author implementation
 window. If substrate-adjacent work passes to another author, or if
 moratorium discipline is generalized as a project pattern beyond
 RDR-120, the tooling gaps must be closed first.
+
+**P0 prerequisite: restore `/nx:phase-review-gate` from archive.**
+The skill exists at `archive/develop-2026-05-19` commit `122feaff`.
+Files to restore: `nx/commands/phase-review-gate.md` (307 LOC),
+`nx/skills/phase-review-gate/SKILL.md` (128 LOC),
+`tests/test_phase_review_gate.py` (312 LOC), entries in
+`nx/registry.yaml` (11 LOC), `tests/test_plugin_structure.py` (4 LOC),
+`docs/rdr/AGENTS.md` (2 LOC), `nx/CHANGELOG.md` (16 LOC). Restoration
+is a docs-and-tooling PR independent of any substrate work.
 
 **Residual confidence gap.** A7 carries a 30% residual gap that no
 ex-ante verification can close: "moratorium discipline holds across
@@ -396,27 +425,42 @@ process discipline actually failed.
   skipped stress test as a daemon-startup invariant ("daemon refuses
   second start against the same path").
 - [~] **A7** (new): **The moratorium is enforceable through written
-  scope boundaries, per-phase cross-walks, and author self-policing,
-  scoped to solo-author work.** A multi-mechanism enforcement chain
-  (§ Scope Boundaries in the RDR + per-phase cross-walk of PRs against
-  the boundaries at each phase closeout + PR/bead-level author review)
-  is sufficient to block scope drift across six phases under solo
-  authorship. The general (multi-author) case has unaddressed tooling
-  gaps. **Status**: Partially Verified (Medium-High confidence at solo-
-  author scope; Unverified for multi-author general case). **Method**:
-  Counterfactual Analysis (4 of 4 documented scope-drift events from
-  the scrapped RDR-110-119 arc would have been blocked by §Scope
-  Boundaries + author self-check before filing) + Tooling Inspection
-  (rdr-gate skill at nx plugin 4.32.12). **Evidence**: T2 entry
-  `120-research-A7`. **Tooling gaps named**: (i) `/nx:rdr-create` has
-  no awareness of in-flight moratoriums; (ii) `/nx:rdr-gate` Layer 3
-  critique is scoped to single RDR and does not cross-check against
-  active in-flight others; (iii) `bd create` does not grep against
-  active moratorium banned-topic lists. These are dormant in solo-
-  author context but block general adoption of the pattern.
-  **Residual 30% confidence gap**: only proof of "moratorium holds
-  across six phases of actual implementation work" is doing the work
-  without violating it. Captured in § Enforcement Backstops below.
+  scope boundaries, per-phase cross-walks (tooled), and author self-
+  policing, scoped to solo-author work.** A multi-mechanism enforcement
+  chain (§ Scope Boundaries in the RDR + `/nx:phase-review-gate`
+  hard-enforcement cross-walk at each phase closeout + PR/bead-level
+  author review) is sufficient to block scope drift across six phases
+  under solo authorship. The general (multi-author) case has
+  unaddressed tooling gaps (cross-RDR moratorium awareness in
+  scaffolding and gating). **Status**: Partially Verified (Medium-High
+  confidence at solo-author scope; Unverified for multi-author general
+  case). **Method**: Counterfactual Analysis (4 of 4 documented
+  scope-drift events from the scrapped RDR-110-119 arc would have been
+  blocked by §Scope Boundaries + author self-check before filing) +
+  Tooling Inspection (rdr-gate skill at nx plugin 4.32.12 +
+  `/nx:phase-review-gate` skill at `archive/develop-2026-05-19`
+  commit `122feaff`). **Evidence**: T2 entry `120-research-A7`.
+  **Tooling that exists**: `/nx:phase-review-gate` (bead `nexus-j327`,
+  791 LOC + 312 LOC tests including a regression for the nexus-52lb
+  silent-drop incident) implements a two-pass hard-enforcement
+  cross-walk: Pass 1 enumerates §Approach items; Pass 2 validates
+  evidence per item; BLOCKED if any item lacks closing-bead pointer
+  or explicit `none` deferral. Currently on `archive/develop-2026-05-19`
+  only; not on main. P0 prerequisite: restore this skill to main
+  before any phase opens. **Tooling gaps remaining**: (i)
+  `/nx:rdr-create` has no awareness of in-flight moratoriums;
+  (ii) `/nx:rdr-gate` Layer 3 critique is scoped to single RDR and
+  does not cross-check against active in-flight others; (iii) `bd
+  create` does not grep against active moratorium banned-topic lists;
+  (iv) `/nx:phase-review-gate` catches scope LOSS (§Approach item with
+  no closing bead) but not scope GAIN (closing bead that lands work
+  from § Out of scope). The first three are dormant in solo-author
+  context; (iv) is partially mitigated by author re-reading the diff
+  but is a real residual gap. **Residual 25% confidence gap** (down
+  from 30% with phase-review-gate accounted for): proof of "moratorium
+  holds across six phases of actual implementation work" still comes
+  only from doing the work without violating it. Captured in §
+  Enforcement Backstops below.
 
 ## Proposed Solution
 
@@ -682,6 +726,10 @@ API credentials.
 
 - [x] RDR-112 tombstoned (this RDR's parent). Done 2026-05-19.
 - [x] Postmortem available on `main`. Done 2026-05-19 (this PR).
+- [ ] `/nx:phase-review-gate` skill restored from
+  `archive/develop-2026-05-19` (commit `122feaff`, bead `nexus-j327`)
+  to main. Required for the per-phase cross-walk discipline encoded in
+  A7's enforcement chain. Docs-and-tooling PR; ships before P0 opens.
 - [ ] CI baseline: green on `main` at PR-open time. Tooling-level gate.
 - [ ] Storage-boundary lint passes against the current main without
   daemon-internal allowlist (P0 baseline).

--- a/docs/rdr/rdr-120-storage-substrate-split.md
+++ b/docs/rdr/rdr-120-storage-substrate-split.md
@@ -197,8 +197,10 @@ has been on `main` continuously for ≥30 days under `NX_STORAGE_MODE=daemon`.
 
 ### Enforcement
 
-- **§ Scope Boundaries is part of the Finalization Gate.** The gate
-  rejects any scope drift.
+- **§ Scope Boundaries is part of the Finalization Gate.** The gate's
+  Layer 3 substantive-critic relay evaluates "Scope Verification:
+  pass/warn/fail" against this section. Layer 1 structurally validates
+  that the section exists and is non-placeholder.
 - **PR-level**: any PR touching `src/nexus/db/` or the daemon entry points
   that adds a method not present in the pre-RDR `T2Database` /
   `chromadb.api` surface fails review.
@@ -210,6 +212,62 @@ has been on `main` continuously for ≥30 days under `NX_STORAGE_MODE=daemon`.
 
 The moratorium is not a suggestion. It is the only structural difference
 between this attempt and the scrapped one.
+
+### Enforcement backstops (and known tooling gaps)
+
+A7's verification (T2 entry `120-research-A7`) surfaced that the
+enforcement chain rests on four working mechanisms and three tooling
+gaps. Recording both so the discipline is honest about what it can and
+cannot catch.
+
+**Working mechanisms (solo-author context):**
+
+- **Author self-policing.** Hal authored the moratorium. Before
+  scaffolding any new substrate-adjacent RDR during P0-P5, Hal reads
+  RDR-120 §Scope Boundaries first. Solo-author is single-point-of-
+  awareness as well as single-point-of-failure; the moratorium being in
+  the title and Problem Statement makes it hard to miss.
+- **Per-phase cross-walk.** At each phase-close review gate, the
+  reviewer (the author, in solo context) cross-walks closing PRs and
+  beads against §Scope Boundaries. Catches both scope loss (X' ⊂ X) per
+  the documented protocol in
+  `feedback_phase_closeout_scope_audit.md`, and scope gain (X' ⊃ X via
+  "while we're in here" additions) which RDR-120 adds as a symmetric
+  check.
+- **PR-level review.** Each PR's diff is read against §Scope Boundaries.
+  Any new method on `T2Database` / `chromadb.api` beyond the pre-RDR
+  surface fails. In solo context, the author re-reads their own diff.
+- **Bead-level enforcement.** `bd create` for substrate work requires
+  the author to confirm the bead's substance is not in §Out of scope.
+
+**Tooling gaps (block multi-author adoption):**
+
+- **`/nx:rdr-create` has no awareness of in-flight moratoriums.** A new
+  RDR scaffolds without checking other active RDRs' §Scope Boundaries
+  for topic matches. Mitigation in solo context: author self-check.
+  Follow-on: add a `moratorium_blocks: <topic-list>` frontmatter field
+  to active RDRs and have the skill grep new RDR's content against it.
+- **`/nx:rdr-gate` Layer 3 critique is single-RDR-scoped.** The
+  substantive-critic receives only the RDR being gated; it does not
+  enumerate active in-flight others. A new RDR can land cleanly through
+  the gate while violating a peer's moratorium. Follow-on: extend the
+  Layer 3 relay's Input Artifacts to include "active in-flight RDRs'
+  §Scope Boundaries sections."
+- **`bd create` does not grep description against moratorium banned-
+  topic lists.** Bead-level enforcement is currently author discipline
+  only.
+
+These gaps are dormant during RDR-120's solo-author implementation
+window. If substrate-adjacent work passes to another author, or if
+moratorium discipline is generalized as a project pattern beyond
+RDR-120, the tooling gaps must be closed first.
+
+**Residual confidence gap.** A7 carries a 30% residual gap that no
+ex-ante verification can close: "moratorium discipline holds across
+six phases of actual implementation work." The previous attempt's
+baseline was one new substrate-adjacent RDR every 3-5 days; RDR-120's
+success criterion is zero such RDRs across P0-P5. Closed only by
+doing the work.
 
 ## Research Findings
 
@@ -337,14 +395,28 @@ process discipline actually failed.
   daemon startup; remove from `T2Client` construction; reframe the
   skipped stress test as a daemon-startup invariant ("daemon refuses
   second start against the same path").
-- [ ] **A7** (new): **The moratorium is enforceable through finalization
-  gates and review.** A written scope-boundary section plus a
-  Finalization Gate scope-verification step is sufficient to block scope
-  drift across the six phases. **Status**: Unverified (this is the
-  novel discipline this RDR is testing). **Method**: Per-phase
-  cross-walk of merged PRs against § Scope Boundaries at each phase
-  closeout; lock the result in the phase's review gate before the next
-  phase opens.
+- [~] **A7** (new): **The moratorium is enforceable through written
+  scope boundaries, per-phase cross-walks, and author self-policing,
+  scoped to solo-author work.** A multi-mechanism enforcement chain
+  (§ Scope Boundaries in the RDR + per-phase cross-walk of PRs against
+  the boundaries at each phase closeout + PR/bead-level author review)
+  is sufficient to block scope drift across six phases under solo
+  authorship. The general (multi-author) case has unaddressed tooling
+  gaps. **Status**: Partially Verified (Medium-High confidence at solo-
+  author scope; Unverified for multi-author general case). **Method**:
+  Counterfactual Analysis (4 of 4 documented scope-drift events from
+  the scrapped RDR-110-119 arc would have been blocked by §Scope
+  Boundaries + author self-check before filing) + Tooling Inspection
+  (rdr-gate skill at nx plugin 4.32.12). **Evidence**: T2 entry
+  `120-research-A7`. **Tooling gaps named**: (i) `/nx:rdr-create` has
+  no awareness of in-flight moratoriums; (ii) `/nx:rdr-gate` Layer 3
+  critique is scoped to single RDR and does not cross-check against
+  active in-flight others; (iii) `bd create` does not grep against
+  active moratorium banned-topic lists. These are dormant in solo-
+  author context but block general adoption of the pattern.
+  **Residual 30% confidence gap**: only proof of "moratorium holds
+  across six phases of actual implementation work" is doing the work
+  without violating it. Captured in § Enforcement Backstops below.
 
 ## Proposed Solution
 
@@ -760,6 +832,12 @@ counterfactual.
   same path the old direct client did," verified in P1 and P3.
 - **What signals lifting the moratorium**: P6 + 30 days under real
   usage is the floor. Any other criteria? Open for the gate to settle.
+- **Cross-RDR moratorium tooling**: should the nx plugin gain a
+  `moratorium_blocks: <topic-list>` frontmatter field on active RDRs
+  plus a pre-scaffold check in `/nx:rdr-create` and a cross-check in
+  `/nx:rdr-gate` Layer 3? Required before multi-author substrate work
+  in any future RDR; dormant for RDR-120's solo-author implementation
+  window. File as a follow-on bead against the nx plugin if pursued.
 
 ## References
 


### PR DESCRIPTION
## Summary

Restores six RDR files deleted by the 2026-05-19 scrap commits as tombstones (`status: scrapped`, `scrapped_date`, `scrap_reason`, TOMBSTONE banner). Honors the standing "never delete RDR files" rule; the deletion was a direct-instruction exception, lifecycle correctness restores them as tombstones.

Drafts **RDR-120: Storage Substrate Split — Substrate-Only Scope, No Co-Shipped Consumers** as the clean-slate successor to the scrapped arc. Five structural differences from the previous attempt:

1. **Substrate-only scope** — T2/T3 daemon split only. No tuplespace primitives, no event-stream RPC, no cockpit, no host-trust model. The whole arc that bundled all of those (RDR-110/111/112/113/118/119) is what failed.
2. **Explicit moratorium** as a § Scope Boundaries section. Enforced by Finalization Gate, per-phase cross-walks, PR-level review, and bead-level checks. The single structural difference between this attempt and the scrapped one.
3. **Six sequential phases, ≥7 days each on main**. P0 (lint + cutover flag) → P1 (T3 daemon) → P2 (T3 cutover) → P3 (T2 daemon) → P4 (T2 cutover) → P5 (catalog into T2) → P6 (decommission direct mode). T3 first because `chroma run` gives us a free service.
4. **Research evidence cited from tombstoned RDR-112** rather than repeated. A1-A4 closed by reference; A5/A6/A7 are new and verified in this branch.
5. **Process locks-in from the postmortem**: daemon-as-sole-migration-runner from day one, asyncio.Event for stop signals, no parallel worktree fan-out on substrate, phase boundary = PR boundary, green base-branch CI as precondition.

Also restores `docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md` to main (was orphaned on a feature branch, never reconciled).

## Critical Assumptions verified in-branch

| ID | Status | Evidence |
|---|---|---|
| A1-A4 | `[x]` Verified | Cited from tombstoned RDR-112 |
| A5 | `[~]` Partially Verified | Source Search of ε-lint precedent + grep enumeration; T2 `120-research-A5` |
| A6 | `[x]` Verified | Source Search confirms `_upgrade_lock` race class is process-local; daemon model eliminates by construction; T2 `120-research-A6` |
| A7 | `[~]` Partially Verified | Counterfactual (4 of 4 scrap events caught) + Tooling Inspection; T2 `120-research-A7` |

A6 has a notable consequence: nexus-9eaz is no longer load-bearing for substrate work. The race surface is cross-process; the daemon model collapses it to one process.

## Commits

- `7e61df5a` Tombstones (6 RDR files + postmortem + README index)
- `bda54ed7` RDR-120 draft (730 lines, P0-P6 phasing locked in the RDR)
- `84e84740` A6 verified
- `bdddb9aa` A5 partially verified
- `1026225b` A7 partially verified (counterfactual + tooling audit)
- `20845474` A7 revised after discovering `/nx:phase-review-gate` exists on archive

## Related branches

- `feature/restore-phase-review-gate` (companion PR): restores `/nx:phase-review-gate` from archive + ships as conexus 4.32.13. Cited in RDR-120 § Implementation Plan Prerequisites as a P0 prerequisite. Once that PR lands, the 6 `TestRDR112Regression` tests stop skipping (RDR-112 file is now present as tombstone).
- `feature/rdr-121-hook-enforced-tool-routing` (follow-on PR): drafts RDR-121, the meta-pattern for which `/nx:phase-review-gate` is one instance.

## Test plan

- [ ] Docs build / link check (no code changes; nothing to test in pytest)
- [ ] Visual review of RDR-120 § Scope Boundaries (the load-bearing section)
- [ ] Confirm 6 tombstone frontmatters all have `status: scrapped` + `scrapped_date: 2026-05-19` + `scrap_reason`
- [ ] Confirm README index re-adds the six entries with **Scrapped 2026-05-19** markers
- [ ] Confirm postmortem reachable at `docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md`

## Notes

- Reference branch `archive/develop-2026-05-19` (pushed) memorializes the 175 commits of scrapped substrate implementation work. Tombstones link to it.
- No gate run per instruction. RDR-120 is `status: draft`; gate via `/nx:rdr-gate 120` when ready.