### PR TITLE
feat(phase-review-gate): restore skill + ship as conexus 4.32.13

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.32.12"
+      "version": "4.32.13"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.32.12"
+      "version": "4.32.13"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.32.13] - 2026-05-19
+
+Plugin-only patch on 4.32.12. Restores the `/nx:phase-review-gate`
+slash command from the archived develop branch (built as bead
+`nexus-j327`, commit `122feaff`, 2026-05-17). The skill enforces a
+two-pass cross-walk of RDR §Approach items against closing beads at
+every phase boundary, blocking phase close when any item is
+unaccounted for. Originally lost to main when the develop branch was
+memorialized as `archive/develop-2026-05-19` before reconciliation.
+
+Restoration is a P0 prerequisite of RDR-120 (storage substrate split
+with co-shipped-consumer moratorium), which cites this skill in
+§ Enforcement Backstops as a load-bearing per-phase cross-walk
+mechanism. The skill itself is substrate-agnostic; useful for any
+RDR with a numbered §Approach section.
+
+No root-package code changes. Plugin files only: skill + command +
+tests + registry/structure entries + hook-injection updates to
+session-start and subagent-start surfaces.
+
+See `nx/CHANGELOG.md` § 4.32.13 for the full restoration footprint.
+
 ## [4.32.12] - 2026-05-13
 
 Patch on 4.32.11. Two CI-correctness fixes plus substantial RDR

--- a/docs/rdr/AGENTS.md
+++ b/docs/rdr/AGENTS.md
@@ -38,6 +38,8 @@ If you need to find an RDR by topic, prefer the index in `docs/rdr/README.md` ov
 
 Use the lifecycle skills: `/nx:rdr-create` → `/nx:rdr-research` → `/nx:rdr-gate` → `/nx:rdr-accept` → `/nx:rdr-close`. List existing with `/nx:rdr-list`; show one with `/nx:rdr-show NNN`.
 
+At each phase boundary inside the implementation arc, run `/nx:phase-review-gate <id> --phase N` before closing the phase-review bead. This cross-walks the RDR §Approach sub-items against the closing beads and blocks the phase close if any planned work was silently dropped. Root cause it prevents: scope reduction discovered mid-implementation (RDR-112 Phase 1, nexus-52lb, 2026-05-15: T3 daemon silently dropped from a 6-bead phase close, found three phases later).
+
 The numbering is monotonic; pick the next unused integer. The frontmatter shape is enforced by `/nx:rdr-audit`.
 
 ## Frontmatter quoting — `#` is comment-start in YAML

--- a/docs/rdr/AGENTS.md
+++ b/docs/rdr/AGENTS.md
@@ -38,8 +38,6 @@ If you need to find an RDR by topic, prefer the index in `docs/rdr/README.md` ov
 
 Use the lifecycle skills: `/nx:rdr-create` → `/nx:rdr-research` → `/nx:rdr-gate` → `/nx:rdr-accept` → `/nx:rdr-close`. List existing with `/nx:rdr-list`; show one with `/nx:rdr-show NNN`.
 
-At each phase boundary inside the implementation arc, run `/nx:phase-review-gate <id> --phase N` before closing the phase-review bead. This cross-walks the RDR §Approach sub-items against the closing beads and blocks the phase close if any planned work was silently dropped. Root cause it prevents: scope reduction discovered mid-implementation (RDR-112 Phase 1, nexus-52lb, 2026-05-15: T3 daemon silently dropped from a 6-bead phase close, found three phases later).
-
 The numbering is monotonic; pick the next unused integer. The frontmatter shape is enforced by `/nx:rdr-audit`.
 
 ## Frontmatter quoting — `#` is comment-start in YAML

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.32.12",
+  "version": "4.32.13",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added: phase-review-gate (restored from archive/develop-2026-05-19)
+
+- **`/nx:phase-review-gate` slash command**: two-pass cross-walk gate
+  for RDR §Approach items at phase boundaries. Pass 1 enumerates all
+  numbered §Approach items; Pass 2 validates each has a bead-shaped
+  evidence pointer. Blocks phase close when any approach item is
+  unaccounted for. Modeled on the RDR-065 Problem Statement Replay
+  gate (same Pass-1/Pass-2 preamble shape).
+- **Regression test**: `tests/test_phase_review_gate.py` includes a
+  direct regression against the actual RDR-112 Phase 1 (nexus-52lb,
+  2026-05-15) closing-bead set; the gate blocks because §Approach
+  item 2 (T3 daemon) had no closing bead, which is exactly the silent
+  scope reduction that was discovered three phases later.
+- **`docs/rdr/AGENTS.md`** updated to point operators at
+  `/nx:phase-review-gate` at every phase boundary.
+- Originally built as bead `nexus-j327` on the (now scrapped) RDR-112
+  arc (commit `122feaff`, 2026-05-17). Skill itself is substrate-
+  agnostic and applies to any RDR. Restored to `main` as a P0
+  prerequisite of RDR-120 (storage substrate split with co-shipped-
+  consumer moratorium); RDR-120 §Enforcement Backstops cites this
+  skill as a load-bearing per-phase cross-walk mechanism.
+
 ## [4.32.12] - 2026-05-13
 
 Plugin version aligned with conexus 4.32.12. No plugin-side changes

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.32.13] - 2026-05-19
+
 ### Added: phase-review-gate (restored from archive/develop-2026-05-19)
 
 - **`/nx:phase-review-gate` slash command**: two-pass cross-walk gate
@@ -18,9 +20,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   direct regression against the actual RDR-112 Phase 1 (nexus-52lb,
   2026-05-15) closing-bead set; the gate blocks because §Approach
   item 2 (T3 daemon) had no closing bead, which is exactly the silent
-  scope reduction that was discovered three phases later.
-- **`docs/rdr/AGENTS.md`** updated to point operators at
-  `/nx:phase-review-gate` at every phase boundary.
+  scope reduction that was discovered three phases later. Six tests
+  in `TestRDR112Regression` skip with an explicit reason when the
+  RDR-112 file is absent from `main` (e.g. before the companion
+  tombstone PR merges); they auto-reactivate once the file is present.
+- **`nx/skills/using-nx-skills/SKILL.md`** updated with a phase-
+  boundary paragraph in the RDR-lifecycle section, catted at
+  SessionStart by `nx/hooks/hooks.json`.
+- **`nx/hooks/scripts/subagent-start.sh`** updated with a conditional
+  injection that fires on tasks matching phase/close/review-gate/
+  cross-walk patterns, surfacing the gate to subagents doing phase-
+  adjacent work.
 - Originally built as bead `nexus-j327` on the (now scrapped) RDR-112
   arc (commit `122feaff`, 2026-05-17). Skill itself is substrate-
   agnostic and applies to any RDR. Restored to `main` as a P0

--- a/nx/commands/phase-review-gate.md
+++ b/nx/commands/phase-review-gate.md
@@ -1,0 +1,307 @@
+---
+description: Cross-walk RDR §Approach against closing beads at a phase boundary — blocks silent scope reduction
+---
+
+# Phase Review Gate
+
+!{
+NEXUS_RDR_ARGS="${ARGUMENTS:-}" python3 << 'PYEOF'
+import os, sys, re, subprocess
+from pathlib import Path
+
+args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
+
+# Repo root and name
+try:
+    repo_root = subprocess.check_output(
+        ['git', 'rev-parse', '--show-toplevel'],
+        stderr=subprocess.DEVNULL, text=True).strip()
+    repo_name = os.path.basename(repo_root)
+except Exception:
+    repo_root = os.getcwd()
+    repo_name = os.path.basename(repo_root)
+
+# Allow test harness to override RDR directory location.
+rdr_dir_override = os.environ.get('NEXUS_RDR_DIR_OVERRIDE', '').strip()
+if rdr_dir_override:
+    rdr_path = Path(rdr_dir_override)
+    repo_root = str(rdr_path.parent.parent) if rdr_path.name == 'rdr' else repo_root
+else:
+    # Resolve RDR directory from .nexus.yml (default: docs/rdr)
+    rdr_dir = 'docs/rdr'
+    nexus_yml = Path(repo_root) / '.nexus.yml'
+    if nexus_yml.exists():
+        content = nexus_yml.read_text()
+        try:
+            import yaml
+            d = yaml.safe_load(content) or {}
+            paths = (d.get('indexing') or {}).get('rdr_paths', ['docs/rdr'])
+            rdr_dir = paths[0] if paths else 'docs/rdr'
+        except ImportError:
+            m_yml = (re.search(r'rdr_paths[^\[]*\[([^\]]+)\]', content) or
+                     re.search(r'rdr_paths:\s*\n\s+-\s*(.+)', content))
+            if m_yml:
+                v = m_yml.group(1)
+                parts = re.findall(r'[a-z][a-z0-9/_-]+', v)
+                rdr_dir = parts[0] if parts else 'docs/rdr'
+    rdr_path = Path(repo_root) / rdr_dir
+
+
+def parse_frontmatter(filepath):
+    text = filepath.read_text(errors='replace')
+    meta = {}
+    if text.startswith('---'):
+        parts = text.split('---', 2)
+        if len(parts) >= 3:
+            block = parts[1]
+            try:
+                import yaml; meta = yaml.safe_load(block) or {}
+            except Exception:
+                for line in block.splitlines():
+                    if ':' in line:
+                        k, _, v = line.partition(':')
+                        meta[k.strip().lower()] = v.strip()
+    if 'title' not in meta and 'name' not in meta:
+        h1 = re.search(r'^#\s+(.+)', text, re.MULTILINE)
+        if h1:
+            meta['title'] = h1.group(1).strip()
+    return meta, text
+
+
+def find_rdr_file(rdr_path, id_str):
+    m = re.search(r'\d+', id_str)
+    if not m:
+        return None
+    num_int = int(m.group(0))
+    for f in sorted(rdr_path.glob('*.md')):
+        nums = re.findall(r'\d+', f.stem)
+        if nums and int(nums[0]) == num_int:
+            return f
+    return None
+
+
+def extract_approach_section(text):
+    """Extract content under §Approach (handles '### Approach' and variants)."""
+    # Match heading with optional parenthetical qualifier
+    for pat in [
+        r'\n### Approach[^\n]*\n',
+        r'\n## Approach[^\n]*\n',
+        r'\n#### Approach[^\n]*\n',
+    ]:
+        m = re.search(pat, text)
+        if m:
+            start = m.end()
+            # End at the next heading of same or higher level
+            heading_depth = len(re.match(r'(#+)', m.group(0).strip()).group(1))
+            end_pat = r'\n#{1,' + str(heading_depth) + r'} '
+            nxt = re.search(end_pat, text[start:])
+            return text[start : start + nxt.start()] if nxt else text[start:]
+    return ''
+
+
+def parse_approach_items(approach_text):
+    """Parse numbered list items from §Approach.
+
+    Returns list of (item_num: int, label: str, summary: str).
+    Label is the bold text after the number; summary is the first line.
+    Handles multi-line continuation paragraphs.
+    """
+    items = []
+    # Split on numbered list starters: lines matching /^\d+\. /
+    lines = approach_text.splitlines()
+    current_num = None
+    current_label = ''
+    current_lines = []
+
+    for line in lines:
+        m = re.match(r'^(\d+)\.\s+\*\*([^*]+)\*\*[:\s]*(.*)', line)
+        if m:
+            if current_num is not None:
+                items.append((current_num, current_label, ' '.join(current_lines).strip()))
+            current_num = int(m.group(1))
+            current_label = m.group(2).strip()
+            current_lines = [m.group(3).strip()] if m.group(3).strip() else []
+        elif current_num is not None:
+            stripped = line.strip()
+            if stripped and not stripped.startswith('-'):
+                current_lines.append(stripped)
+
+    if current_num is not None:
+        items.append((current_num, current_label, ' '.join(current_lines).strip()))
+
+    return items
+
+
+def parse_evidence(evidence_str):
+    """Parse 'Item1=val1,Item2=val2,...' into {1: 'val1', 2: 'val2'}."""
+    out = {}
+    for tok in evidence_str.split(','):
+        tok = tok.strip()
+        if not tok:
+            continue
+        if '=' in tok:
+            k, _, v = tok.partition('=')
+            k = k.strip()
+            v = v.strip()
+            # Accept ItemN or item N (case-insensitive)
+            num_m = re.search(r'(\d+)', k)
+            if num_m:
+                out[int(num_m.group(1))] = v
+    return out
+
+
+# Parse flags
+phase_match = re.search(r'--phase\s+(\S+)', args)
+phase_arg = phase_match.group(1) if phase_match else None
+
+evidence_match = (re.search(r"--evidence\s+'([^']+)'", args)
+                  or re.search(r'--evidence\s+"([^"]+)"', args)
+                  or re.search(r'--evidence\s+(\S+)', args))
+evidence_arg = evidence_match.group(1) if evidence_match else None
+
+# Strip flags to find RDR ID
+args_clean = re.sub(r'--phase\s+\S+', '', args)
+args_clean = re.sub(r"--evidence\s+'[^']+'", '', args_clean)
+args_clean = re.sub(r'--evidence\s+"[^"]+"', '', args_clean)
+args_clean = re.sub(r'--evidence\s+\S+', '', args_clean).strip()
+
+id_match = re.search(r'\d+', args_clean)
+
+if not id_match:
+    print("> **Usage**: `/nx:phase-review-gate <id> --phase <N> [--evidence 'Item1=bead-id,...']`")
+    print()
+    print("### What this gate does")
+    print()
+    print("At each phase-review boundary, cross-walk the RDR §Approach sub-items")
+    print("against the closing beads. Pass 1 enumerates items; Pass 2 validates evidence.")
+    print()
+    print("**Pass 1** (no --evidence): list approach items for the phase.")
+    print("**Pass 2** (with --evidence): validate every item has an evidence pointer.")
+    print()
+    print("Evidence format: `Item1=nexus-abc1,Item2=nexus-xyz2,Item3=none`")
+    print("Use `none` for items explicitly deferred or acknowledged as out-of-phase scope.")
+    sys.exit(0)
+
+rdr_file = find_rdr_file(rdr_path, id_match.group(0))
+if not rdr_file:
+    print(f"> **ERROR**: RDR not found for ID: `{id_match.group(0)}`")
+    print(f"> Looked in: `{rdr_path}`")
+    sys.exit(0)
+
+fm, text = parse_frontmatter(rdr_file)
+title = fm.get('title', fm.get('name', rdr_file.stem))
+rdr_num_m = re.search(r'\d+', rdr_file.stem)
+rdr_id_label = rdr_num_m.group(0) if rdr_num_m else rdr_file.stem
+
+print(f"**Repo:** `{repo_name}`  **RDR:** `{rdr_file.name}`")
+print(f"**Title:** {title}")
+print(f"**Phase:** {phase_arg or '(not specified)'}")
+print()
+
+# Extract §Approach items
+approach_text = extract_approach_section(text)
+if not approach_text.strip():
+    print("> **ERROR**: No `### Approach` section found in this RDR.")
+    print("> Phase-review gate requires §Approach to cross-walk against closing beads.")
+    sys.exit(0)
+
+items = parse_approach_items(approach_text)
+if not items:
+    print("> **ERROR**: §Approach section found but no numbered items parsed.")
+    print("> Expected format: `N. **Label**: description`")
+    sys.exit(0)
+
+# === PASS 1: enumerate approach items ===
+if not evidence_arg:
+    print(f"### §Approach Cross-Walk — Phase {phase_arg or '?'}")
+    print()
+    print("Enumerate each numbered §Approach item below, then provide an evidence pointer")
+    print("for each item: the closing bead ID (e.g. `nexus-abc1`) or `none` if the item")
+    print("is explicitly deferred or not in scope for this phase.")
+    print()
+    print("| # | Label | Evidence needed |")
+    print("|---|-------|-----------------|")
+    for num, label, _summary in items:
+        print(f"| Item{num} | **{label}** | (provide bead-id or `none`) |")
+    print()
+    example_parts = ','.join(f"Item{num}=nexus-xxxx" for num, _, _ in items)
+    print("**Re-invoke with evidence once all items are accounted for:**")
+    print()
+    print(f"```")
+    print(f"/nx:phase-review-gate {rdr_id_label} --phase {phase_arg or '1'} --evidence '{example_parts}'")
+    print(f"```")
+    print()
+    sys.exit(0)
+
+# === PASS 2: validate evidence coverage ===
+evidence = parse_evidence(evidence_arg)
+failures = []
+covered = []
+
+for num, label, _summary in items:
+    val = evidence.get(num, '').strip()
+    if not val:
+        failures.append((num, label, "no evidence pointer supplied"))
+    else:
+        covered.append((num, label, val))
+
+if failures:
+    print(f"> **BLOCKED** — Phase {phase_arg or '?'} cross-walk incomplete.")
+    print(f"> {len(failures)} of {len(items)} approach item(s) have no evidence pointer.")
+    print()
+    print("### Missing Evidence")
+    print()
+    for num, label, reason in failures:
+        print(f"- **Item{num}** ({label}): {reason}")
+    print()
+    print("These items must be accounted for before closing this phase.")
+    print("Provide a closing bead ID or `none` with an acknowledgement for deferred items.")
+    print()
+    print("**Re-invoke once all items are covered:**")
+    example_parts = ','.join(
+        f"Item{num}={evidence.get(num, 'nexus-xxxx') or 'nexus-xxxx'}"
+        for num, _, _ in items
+    )
+    print(f"```")
+    print(f"/nx:phase-review-gate {rdr_id_label} --phase {phase_arg or '1'} --evidence '{example_parts}'")
+    print(f"```")
+    sys.exit(0)
+
+# All items covered — validation passed
+print(f"### APPROACH CROSS-WALK PASSED — Phase {phase_arg or '?'}")
+print()
+print(f"All {len(items)} §Approach items accounted for:")
+print()
+for num, label, val in covered:
+    print(f"- Item{num} ({label}) → `{val}`")
+print()
+print("> The gate verifies every §Approach item has a named evidence pointer.")
+print("> It does NOT verify that the evidence is semantically complete.")
+print("> Review each pointer manually before allowing the phase close to proceed.")
+print()
+# Write T1 scratch marker so downstream hooks can check cross-walk completion
+try:
+    subprocess.run(
+        ['nx', 'scratch', 'put',
+         f'phase-review-gate PASSED: RDR-{rdr_id_label} Phase {phase_arg}',
+         '--tags', f'phase-review-passed,rdr-{rdr_id_label},phase-{phase_arg}'],
+        capture_output=True, timeout=5)
+except Exception:
+    pass
+
+PYEOF
+}
+
+## Phase Review Gate
+
+$ARGUMENTS
+
+## Action
+
+All data is pre-loaded above. The preamble has enumerated (Pass 1) or validated (Pass 2) the §Approach cross-walk.
+
+**After Pass 1**: collect evidence pointers from the user for each §Approach item, then re-invoke with `--evidence`.
+
+**After Pass 2 PASSED**: proceed to close the phase. Remind the user: evidence pointers are not semantically verified — review each one manually.
+
+**After Pass 2 BLOCKED**: the phase cannot close until all §Approach items have evidence. Work with the user to identify the missing work or explicitly defer with `none` + justification.

--- a/nx/hooks/scripts/subagent-start.sh
+++ b/nx/hooks/scripts/subagent-start.sh
@@ -186,6 +186,18 @@ If link-context already in scratch (sibling agent did 1+2), skip to step 3.
 AGENT TAG: pass agent="<your-role>" to memory_put so nx tier-status slices writes by agent (nexus-9clx).
 NX_AUTOLINK
 
+# Phase boundary enforcement: inject for tasks that close, review, or
+# audit phase work. Hard-enforcement preamble at gate invocation; this
+# block tells the subagent the gate exists and when to invoke it.
+if echo "$TASK_TEXT" | grep -qiE "close.*phase|phase.*clos|phase.*review|review.*gate|approach.*cross.walk|cross.walk.*approach|phase.*close|closeout|rdr.*phase|phase.*rdr|silent.scope|scope.reduc"; then
+cat <<'PHASE_GATE'
+
+## Phase Boundary Gate (mandatory)
+
+If your task closes a phase-review bead, run `/nx:phase-review-gate <rdr-id> --phase N` BEFORE close. Pass 1 enumerates §Approach items; Pass 2 validates each has a closing-bead pointer (`ItemN=nexus-xxxx`) or explicit `none`. BLOCKED on any unaccounted item; phase close is gated on PASSED. Skipping the gate is the silent-scope-reduction failure mode that cost RDR-112 Phase 1 (nexus-52lb, 2026-05-15) 2-3 days of replanning when T3 daemon was silently dropped and discovered three phases later.
+PHASE_GATE
+fi
+
 # L1 Knowledge Map (per-repo, RDR-072) — outside the heredoc so $(…) expands
 CONTEXT_DIR="$HOME/.config/nexus/context"
 REPO_HASH=$(echo -n "$(pwd -P)" | shasum -a 1 | cut -c1-8)

--- a/nx/registry.yaml
+++ b/nx/registry.yaml
@@ -333,6 +333,17 @@ rdr_skills:
       - "periodic audit"
     dispatches_to: [deep-research-synthesizer]
 
+  phase-review-gate:
+    slash_command: /phase-review-gate
+    command_file: commands/phase-review-gate.md
+    description: "Cross-walk RDR §Approach against closing beads at a phase boundary; blocks silent scope reduction"
+    triggers:
+      - "phase review gate"
+      - "cross-walk approach"
+      - "close phase"
+      - "phase closeout"
+      - "verify phase scope"
+
   rdr-list:
     slash_command: /rdr-list
     command_file: commands/rdr-list.md

--- a/nx/skills/phase-review-gate/SKILL.md
+++ b/nx/skills/phase-review-gate/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: phase-review-gate
+description: Use when a phase boundary is being closed — cross-walk RDR §Approach against closing beads to block silent scope reduction before it is discovered mid-implementation
+effort: low
+---
+
+# Phase Review Gate Skill
+
+Enforces the §Approach cross-walk at every phase-review boundary. Before a phase can be declared closed, every numbered item in the RDR's §Approach section must have an evidence pointer (closing bead ID or explicit deferral acknowledgement).
+
+This is the phase-level analogue of the RDR-065 Problem Statement Replay gate: the RDR-065 gate verifies problem gaps are addressed at close time; this gate verifies approach items are addressed at each phase boundary.
+
+**Root cause it prevents**: silent scope reduction discovered mid-implementation. RDR-112 Phase 1 (nexus-52lb, 2026-05-15) shipped T2-only work; §Approach item 2 (T3 daemon) was silently dropped. Discovered three closed phases later when a bead acceptance criterion (`mcp_infra.get_t3() -> T3Client`) could not compile. Cost: 2-3 days of replanning. The gate would have blocked the close in 15 minutes.
+
+## When This Skill Activates
+
+- User says "phase review gate", "cross-walk the approach", "close phase N"
+- User invokes `/nx:phase-review-gate`
+- A phase-review bead (title contains "P{N}.review" or "Phase {N} gate") is about to close
+- Any time phases are being closed and the closer wants to verify no work was silently dropped
+
+## Input
+
+- **RDR ID** (required) — e.g., `112`
+- **Phase number** (required) — `--phase 1`
+- **Evidence** (Pass 2 only) — `--evidence 'Item1=nexus-abc1,Item2=nexus-xyz2,Item3=none'`
+
+## Two-Pass Contract
+
+### Pass 1 — Enumerate (no --evidence supplied)
+
+The preamble script reads §Approach from the RDR file, parses all numbered items, and prints them as a table. It instructs the reviewer to provide an evidence pointer per item and re-invoke with `--evidence`.
+
+Output format:
+```
+| # | Label | Evidence needed |
+|---|-------|-----------------|
+| Item1 | T2 service | (provide bead-id or `none`) |
+| Item2 | T3 service | (provide bead-id or `none`) |
+...
+```
+
+### Pass 2 — Validate (--evidence supplied)
+
+The preamble validates that every enumerated item has a non-empty evidence pointer. Evidence values:
+- **Bead ID** (`nexus-abc1`): the closing bead whose acceptance criteria cover this approach item.
+- **`none`**: explicit deferral — the reviewer acknowledges this item is not in scope for this phase. Use this for items like "T1 stays put" (no work needed) or genuinely deferred sub-work.
+
+**BLOCKED**: any item missing from --evidence, or with an empty value, causes the gate to emit BLOCKED and exit. The missing items are named explicitly.
+
+**PASSED**: all items covered. The gate emits the evidence table and a T1 scratch marker tagged `phase-review-passed,rdr-NNN,phase-N`.
+
+## Evidence Format
+
+```
+Item1=nexus-61x6,Item2=nexus-t3xx,Item3=nexus-7ejx,Item4=none,Item5=nexus-lint1
+```
+
+- Keys are `ItemN` (case-insensitive, numeric suffix required)
+- Values are bead IDs or `none`
+- Comma-separated, no spaces required around `=` or `,`
+
+## Worked Example — RDR-112 Phase 1
+
+RDR-112 has 9 §Approach items. Phase 1 closed beads covered items 1, 3, 6, 7, 8, 9. Items 2 (T3 service) and 5 (storage boundary lint) had no closing beads.
+
+**Pass 1 invocation:**
+```
+/nx:phase-review-gate 112 --phase 1
+```
+
+**Pass 1 output** (abridged):
+```
+| Item1 | T2 service | (provide bead-id or `none`) |
+| Item2 | T3 service | (provide bead-id or `none`) |
+...
+```
+
+**Pass 2 invocation (with the nexus-52lb gap — would BLOCK):**
+```
+/nx:phase-review-gate 112 --phase 1 --evidence 'Item1=nexus-61x6,Item3=nexus-7ejx,...'
+```
+
+Output:
+```
+> BLOCKED — Phase 1 cross-walk incomplete.
+> 2 of 9 approach items have no evidence pointer.
+
+### Missing Evidence
+- Item2 (T3 service): no evidence pointer supplied
+- Item5 (Any future persistent store): no evidence pointer supplied
+```
+
+**Pass 2 invocation (complete — would PASS):**
+```
+/nx:phase-review-gate 112 --phase 1 --evidence 'Item1=nexus-61x6,Item2=nexus-t3xx,...,Item9=nexus-w0et'
+```
+
+## Relationship to Other Gates
+
+| Gate | Scope | When |
+|------|-------|------|
+| `/nx:rdr-gate` | Whole RDR structure + assumptions + AI critique | Before RDR acceptance |
+| `/nx:rdr-close --reason implemented` | Problem Statement gaps (file:line pointers) | At RDR close time |
+| `/nx:phase-review-gate` | §Approach items (bead pointers) | At each phase boundary |
+
+Phase review gate is NOT a substitute for rdr-close's Problem Statement Replay. Both gates run at their respective lifecycle points.
+
+## When to Invoke
+
+Invoke before closing any phase-review bead — especially when:
+- A phase spans multiple beads and the review gate bead has a title like "Phase N review gate" or "P{N}.review"
+- The implementation plan changed during the phase (the most common time for silent drops)
+- A phase was paused and resumed weeks later
+
+## Limitations
+
+- The gate validates **coverage**, not **correctness**: `Item2=nexus-t3xx` passes even if nexus-t3xx's acceptance criteria are weak. The reviewer must verify the evidence manually.
+- The gate parses `N. **Label**: ...` formatted items. §Approach sections with non-standard numbering (e.g. roman numerals, lettered items) are not parsed. Use standard `1.` numbering in §Approach.
+- `none` is a valid evidence value. Over-use of `none` (e.g. `none` for every item) defeats the purpose; the reviewer is accountable for each `none` they supply.
+- The gate verifies §Approach items are accounted for; it does NOT verify the boundary-spanning code paths between accounted-for items work end-to-end. RDR-112 Phase 3 (2026-05-18) demonstrated this: the cross-walk PASSED on items (Item1 T2 service / Item2 T3 service / Item6 Discovery all evidence-pointed to nexus-hpxl), and a first-pass code review of the same nexus-hpxl diff returned PASS-WITH-FOLLOWUPS. A second-pass code review with explicit boundary-spanning prompt categories (see `/nx:code-review` § Prompt rigour) caught two Significant defects the first pass missed — including a production regression where `taxonomy_cmd._t2_ctx()` raised on every invocation under the new daemon default. The gate is a coverage check, not a code review; pair it with a boundary-spanning code-review-expert dispatch when the diff spans CLI ↔ daemon, daemon ↔ OS supervisor, or any process-boundary surface.
+
+## Recommended companion: boundary-spanning code review
+
+At a phase boundary that ships integration-seam code (process-spawning, supervisor interaction, RPC wiring, env-var resolution), the cross-walk alone is insufficient. After Pass 2 of this gate passes, dispatch `code-review-expert` with explicit suspect categories from `/nx:code-review` § Prompt rigour — process-group safety, race windows, security boundary, integration-boundary defects, lifecycle. The lesson the RDR-112 spine paid for is: friendly relays return friendly reviews; the suspect categories must be named in the prompt for the agent to probe them.
+
+## Success Criteria
+
+- [ ] Pass 1: all §Approach items enumerated, re-invoke instruction emitted
+- [ ] Pass 2: BLOCKED when any item has no evidence pointer; PASSED when all covered
+- [ ] BLOCKED output names the specific missing items
+- [ ] PASSED output shows evidence table and T1 scratch marker
+- [ ] Regression: RDR-112 Phase 1 with nexus-52lb evidence set returns BLOCKED

--- a/nx/skills/using-nx-skills/SKILL.md
+++ b/nx/skills/using-nx-skills/SKILL.md
@@ -54,7 +54,9 @@ After a successful pipeline:
 - 3+ validated findings to keep → `/nx:knowledge-tidy`
 - PDF to index → `/nx:pdf-process`
 
-**RDR lifecycle:** `/nx:rdr-create` → `/nx:rdr-research` → `/nx:rdr-gate` → `/nx:rdr-accept` → `/nx:rdr-close`. List/show: `/nx:rdr-list`, `/nx:rdr-show NNN`. Audit: `/nx:rdr-audit`.
+**RDR lifecycle:** `/nx:rdr-create` → `/nx:rdr-research` → `/nx:rdr-gate` → `/nx:rdr-accept` → (implementation phases) → `/nx:rdr-close`. List/show: `/nx:rdr-list`, `/nx:rdr-show NNN`. Audit: `/nx:rdr-audit`.
+
+**Phase boundary inside an implementation arc:** every phase-review bead, before close, runs `/nx:phase-review-gate <rdr-id> --phase N`. Pass 1 enumerates the RDR's numbered §Approach items; Pass 2 validates each has a closing-bead pointer (`ItemN=nexus-xxxx`) or explicit `none` deferral. BLOCKED on any unaccounted item. Not optional. Prevents the silent scope reduction class (RDR-112 Phase 1 / nexus-52lb, 2026-05-15: T3 daemon silently dropped from a 6-bead close, found three phases later, 2-3 days of replanning).
 
 **Git:** isolation → `/nx:git-worktrees`. Done → `/nx:finishing-branch`. Receiving review → `/nx:receiving-review`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.32.12"
+version = "4.32.13"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "4.32.12",
+  "version": "4.32.13",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/tests/test_phase_review_gate.py
+++ b/tests/test_phase_review_gate.py
@@ -1,0 +1,325 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the /nx:phase-review-gate preamble (nexus-j327).
+
+The gate has two enforcement paths:
+
+  Pass 1: enumerate §Approach items in scope for the named phase;
+          emit them and request re-invocation with --evidence.
+
+  Pass 2: validate that every enumerated item has an evidence pointer
+          (bead-id or text description) supplied via --evidence; block
+          on any missing or empty pointer.
+
+Regression test: the actual RDR-112 Phase 1 closeout (nexus-52lb)
+would have been blocked because §Approach §2 (T3 service) was
+silently dropped from the closing-bead set.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+COMMAND_FILE = REPO_ROOT / "nx" / "commands" / "phase-review-gate.md"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_preamble(args: str, *, rdr_dir: Path | None = None) -> str:
+    """Execute the preamble embedded in phase-review-gate.md.
+
+    Extracts the Python block between ``!{`` / ``PYEOF`` and runs it
+    in a subprocess so the same isolation level as the real slash command
+    applies.  Returns combined stdout+stderr.
+    """
+    text = COMMAND_FILE.read_text()
+    m = re.search(r"python3\s+<<\s+'PYEOF'\n(.*?)PYEOF", text, re.DOTALL)
+    assert m, "No PYEOF block found in phase-review-gate.md"
+    script = m.group(1)
+
+    env = os.environ.copy()
+    env["NEXUS_RDR_ARGS"] = args
+    if rdr_dir is not None:
+        env["NEXUS_RDR_DIR_OVERRIDE"] = str(rdr_dir)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True, text=True, env=env,
+        timeout=15,
+    )
+    return (result.stdout + result.stderr).strip()
+
+
+def _make_minimal_rdr(tmp_path: Path, rdr_id: int, approach_items: list[str],
+                      status: str = "accepted") -> Path:
+    """Write a minimal RDR markdown with numbered §Approach items."""
+    rdr_dir = tmp_path / "docs" / "rdr"
+    rdr_dir.mkdir(parents=True)
+    items_lines = "\n".join(
+        f"{i + 1}. **Item {i + 1}**: {item}" for i, item in enumerate(approach_items)
+    )
+    # Build content without textwrap.dedent so indentation stays consistent
+    content = (
+        f"---\n"
+        f"id: {rdr_id:03d}\n"
+        f"title: Test RDR\n"
+        f"status: {status}\n"
+        f"type: implementation\n"
+        f"---\n"
+        f"\n"
+        f"# Test RDR\n"
+        f"\n"
+        f"## Problem Statement\n"
+        f"\n"
+        f"#### Gap 1: test gap\n"
+        f"A gap for testing.\n"
+        f"\n"
+        f"## Proposed Solution\n"
+        f"\n"
+        f"### Approach\n"
+        f"\n"
+        f"{items_lines}\n"
+        f"\n"
+        f"## Implementation Plan\n"
+        f"\n"
+        f"### Phase 1: Implementation\n"
+        f"\n"
+        f"Phase 1 description.\n"
+        f"\n"
+        f"## Finalization Gate\n"
+        f"\n"
+        f"Responses here.\n"
+    )
+    rdr_file = rdr_dir / f"{rdr_id:03d}-test-rdr.md"
+    rdr_file.write_text(content)
+    return rdr_dir
+
+
+# ---------------------------------------------------------------------------
+# Structural tests
+# ---------------------------------------------------------------------------
+
+class TestCommandFileStructure:
+    """The command file must exist and have the required preamble shape."""
+
+    def test_command_file_exists(self) -> None:
+        assert COMMAND_FILE.exists(), f"Missing: {COMMAND_FILE}"
+
+    def test_command_has_preamble_block(self) -> None:
+        text = COMMAND_FILE.read_text()
+        assert "python3 << 'PYEOF'" in text, "No Python preamble block found"
+        assert "PYEOF" in text, "Preamble block not closed"
+
+    def test_command_has_nexus_rdr_args_env(self) -> None:
+        text = COMMAND_FILE.read_text()
+        assert "NEXUS_RDR_ARGS" in text, "Preamble must read args via NEXUS_RDR_ARGS"
+
+    def test_skill_file_exists(self) -> None:
+        skill_file = REPO_ROOT / "nx" / "skills" / "phase-review-gate" / "SKILL.md"
+        assert skill_file.exists(), f"Missing: {skill_file}"
+
+
+# ---------------------------------------------------------------------------
+# Pass 1 tests — enumerate approach items
+# ---------------------------------------------------------------------------
+
+class TestPass1Enumerate:
+    """Pass 1: no --evidence supplied. Preamble enumerates approach items."""
+
+    def test_no_args_shows_usage(self, tmp_path: pytest.fixture) -> None:
+        """Invocation with no RDR ID prints usage and exits cleanly."""
+        rdr_dir = _make_minimal_rdr(tmp_path, 99, ["T2 service", "T3 service"])
+        out = _run_preamble("", rdr_dir=rdr_dir)
+        assert "Usage" in out or "phase-review-gate" in out.lower()
+
+    def test_pass1_lists_approach_items(self, tmp_path: pytest.fixture) -> None:
+        """Pass 1 enumerates numbered §Approach items for the named phase."""
+        _make_minimal_rdr(tmp_path, 99, ["T2 service", "T3 service", "CatalogDB collapse"])
+        out = _run_preamble("99 --phase 1", rdr_dir=tmp_path / "docs" / "rdr")
+        # Should list at least the approach items by number
+        assert "1." in out or "Item 1" in out
+        assert "2." in out or "Item 2" in out
+
+    def test_pass1_instructs_reinvoke_with_evidence(self, tmp_path: pytest.fixture) -> None:
+        """Pass 1 must tell the user to re-invoke with --evidence."""
+        _make_minimal_rdr(tmp_path, 99, ["T2 service", "T3 service"])
+        out = _run_preamble("99 --phase 1", rdr_dir=tmp_path / "docs" / "rdr")
+        assert "--evidence" in out
+
+    def test_pass1_exits_before_skill_body(self, tmp_path: pytest.fixture) -> None:
+        """Pass 1 must exit cleanly; it must NOT emit 'validation passed'."""
+        _make_minimal_rdr(tmp_path, 99, ["T2 service", "T3 service"])
+        out = _run_preamble("99 --phase 1", rdr_dir=tmp_path / "docs" / "rdr")
+        assert "validation passed" not in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# Pass 2 tests — validate evidence pointers
+# ---------------------------------------------------------------------------
+
+class TestPass2Validate:
+    """Pass 2: --evidence supplied. Preamble validates coverage."""
+
+    def test_pass2_all_covered_emits_passed(self, tmp_path: pytest.fixture) -> None:
+        """When all approach items have evidence, emit validation passed."""
+        _make_minimal_rdr(tmp_path, 99, ["T2 service", "T3 service"])
+        evidence = "Item1=nexus-abc1,Item2=nexus-def2"
+        out = _run_preamble(
+            f"99 --phase 1 --evidence '{evidence}'",
+            rdr_dir=tmp_path / "docs" / "rdr",
+        )
+        assert "validation passed" in out.lower() or "PASSED" in out
+
+    def test_pass2_missing_item_blocks(self, tmp_path: pytest.fixture) -> None:
+        """When an approach item has no evidence, emit BLOCKED."""
+        _make_minimal_rdr(tmp_path, 99, ["T2 service", "T3 service"])
+        evidence = "Item1=nexus-abc1"  # Item2 missing
+        out = _run_preamble(
+            f"99 --phase 1 --evidence '{evidence}'",
+            rdr_dir=tmp_path / "docs" / "rdr",
+        )
+        assert "BLOCKED" in out or "blocked" in out.lower() or "ERROR" in out
+
+    def test_pass2_empty_evidence_value_blocks(self, tmp_path: pytest.fixture) -> None:
+        """An empty string evidence value must be rejected."""
+        _make_minimal_rdr(tmp_path, 99, ["T2 service", "T3 service"])
+        evidence = "Item1=nexus-abc1,Item2="
+        out = _run_preamble(
+            f"99 --phase 1 --evidence '{evidence}'",
+            rdr_dir=tmp_path / "docs" / "rdr",
+        )
+        assert "BLOCKED" in out or "ERROR" in out or "empty" in out.lower()
+
+    def test_pass2_names_the_missing_item(self, tmp_path: pytest.fixture) -> None:
+        """Blocked output must name which approach item is missing evidence."""
+        _make_minimal_rdr(tmp_path, 99, ["T2 service", "T3 service"])
+        evidence = "Item1=nexus-abc1"
+        out = _run_preamble(
+            f"99 --phase 1 --evidence '{evidence}'",
+            rdr_dir=tmp_path / "docs" / "rdr",
+        )
+        # Must mention Item2 by number
+        assert "Item2" in out or "item 2" in out.lower() or "2" in out
+
+
+# ---------------------------------------------------------------------------
+# Regression test — RDR-112 Phase 1 / nexus-52lb silent T3 drop
+# ---------------------------------------------------------------------------
+
+_RDR112_FILE = (
+    REPO_ROOT / "docs" / "rdr"
+    / "rdr-112-storage-as-service-container-boundary.md"
+)
+
+
+@pytest.mark.skipif(
+    not _RDR112_FILE.exists(),
+    reason=(
+        "RDR-112 file not present on main (scrapped 2026-05-19). "
+        "Regression test re-activates automatically once the tombstone "
+        "restoration of RDR-112 lands. See RDR-120 § Implementation "
+        "Plan Prerequisites and the tombstone PR (feature/rdr-120-"
+        "storage-substrate-tombstones)."
+    ),
+)
+class TestRDR112Regression:
+    """Gate MUST block the actual nexus-52lb closing-bead set.
+
+    nexus-52lb closed Phase 1 with T2-only beads (nexus-08i1, nexus-61x6,
+    nexus-m4gm, nexus-qy0u, nexus-w0et, nexus-x98k).  RDR-112 §Approach
+    item 2 explicitly specifies T3 service (nx daemon t3) but no bead
+    covered that item.  The gate must detect this gap and BLOCK.
+    """
+
+    RDR112_FILE = _RDR112_FILE
+
+    # The six Phase 1 closing beads from nexus-52lb (all T2-focused).
+    # Item2 (T3 service) is deliberately absent.
+    NEXUS_52LB_EVIDENCE = (
+        "Item1=nexus-61x6,"   # P1.1 — T2 daemon process scaffold
+        "Item3=nexus-7ejx,"   # P2.1 CatalogDB — only partial Phase 1 mention
+        "Item4=none,"         # T1 stays put — acknowledged no work needed
+        "Item6=nexus-61x6,"   # Discovery — covered by P1.1 daemon scaffold
+        "Item7=nexus-m4gm,"   # EventStream RPC
+        "Item8=nexus-x98k,"   # Subspace registry
+        "Item9=nexus-w0et,"   # Schema migration ownership
+        "Item10=none"         # Lifecycle hooks — superseded by items 7-9
+        # Item2 (T3 service) intentionally absent — this is the bug
+        # Item5 (storage boundary lint) intentionally absent — separate concern
+    )
+
+    def test_rdr112_file_exists(self) -> None:
+        assert self.RDR112_FILE.exists(), (
+            f"RDR-112 file not found at {self.RDR112_FILE}. "
+            "Regression test requires the actual RDR file."
+        )
+
+    def test_rdr112_approach_section_present(self) -> None:
+        text = self.RDR112_FILE.read_text()
+        assert "### Approach" in text, "RDR-112 §Approach section not found"
+
+    def test_rdr112_approach_has_t3_item(self) -> None:
+        text = self.RDR112_FILE.read_text()
+        # Verify item 2 is the T3 service item that was silently dropped.
+        assert "T3 service" in text or "chroma run" in text, (
+            "RDR-112 should mention T3 service / chroma run in §Approach"
+        )
+
+    def test_gate_would_block_nexus_52lb_partial_evidence(self) -> None:
+        """Gate blocks when T3 (Item2) and storage-boundary lint (Item5) have no evidence.
+
+        This is the regression: Phase 1 shipped only T2 work; the gate
+        should have caught that Item2 (T3 daemon) had no closing bead.
+        """
+        rdr_dir = self.RDR112_FILE.parent
+        out = _run_preamble(
+            f"112 --phase 1 --evidence '{self.NEXUS_52LB_EVIDENCE}'",
+            rdr_dir=rdr_dir,
+        )
+        # The gate must block because Item2 is absent from the evidence
+        assert "BLOCKED" in out or "ERROR" in out or "missing" in out.lower(), (
+            f"Gate should have BLOCKED due to missing Item2 (T3 service). "
+            f"Got: {out[:500]}"
+        )
+
+    def test_gate_passes_when_all_items_covered(self) -> None:
+        """If all items have evidence (including T3), the gate passes."""
+        rdr_dir = self.RDR112_FILE.parent
+        full_evidence = (
+            "Item1=nexus-61x6,"
+            "Item2=nexus-t3xx,"   # T3 bead — would have prevented the bug
+            "Item3=nexus-7ejx,"
+            "Item4=none,"
+            "Item5=nexus-lint1,"
+            "Item6=nexus-61x6,"
+            "Item7=nexus-m4gm,"
+            "Item8=nexus-x98k,"
+            "Item9=nexus-w0et,"
+            "Item10=none"         # Lifecycle hooks superseded by items 7-9
+        )
+        out = _run_preamble(
+            f"112 --phase 1 --evidence '{full_evidence}'",
+            rdr_dir=rdr_dir,
+        )
+        assert "validation passed" in out.lower() or "PASSED" in out, (
+            f"Gate should PASS when all 10 approach items have evidence. "
+            f"Got: {out[:500]}"
+        )
+
+    def test_pass1_enumerates_all_10_approach_items(self) -> None:
+        """Pass 1 on RDR-112 must enumerate all 10 §Approach sub-items."""
+        rdr_dir = self.RDR112_FILE.parent
+        out = _run_preamble("112 --phase 1", rdr_dir=rdr_dir)
+        # Items are numbered 1-10 in §Approach
+        for item_num in range(1, 11):
+            assert f"Item{item_num}" in out or f"item {item_num}" in out.lower(), (
+                f"Pass 1 output should enumerate Item{item_num}. "
+                f"Got:\n{out[:600]}"
+            )

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -39,6 +39,11 @@ _STANDALONE_SKILLS = {
     # RDR-078 verb skills — dispatch plan_match + plan_run directly, no agent relay
     "research", "review", "analyze", "debug", "document",
     "plan-author", "plan-inspect", "plan-promote", "plan-first",
+    # nexus-j327 — phase closeout cross-walk gate. Pointer skill with Python
+    # preamble; no agent dispatch. Enforces §Approach coverage at phase
+    # boundaries. Restored from archive/develop-2026-05-19 as RDR-120 P0
+    # prerequisite (2026-05-19).
+    "phase-review-gate",
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.32.12"
+version = "4.32.13"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Restores the `/nx:phase-review-gate` slash command from `archive/develop-2026-05-19` (commit `122feaff`, bead `nexus-j327`, built 2026-05-17 in response to the nexus-52lb / RDR-112 Phase 1 silent T3-daemon drop incident). Never reached main; develop was memorialized as the archive branch before reconciliation.

The skill is a two-pass hard-enforcement preamble (modeled on RDR-065 Problem Statement Replay) that cross-walks RDR §Approach items against closing beads at every phase boundary:

- **Pass 1**: enumerates all numbered §Approach items from the target RDR
- **Pass 2**: validates each has a closing-bead pointer (`ItemN=nexus-xxxx`) or explicit `none` deferral
- **BLOCKED** if any item lacks evidence

Substrate-agnostic: useful for any RDR with a numbered §Approach section, not just storage substrate work.

Also injects guidance at the two channels that actually reach agents:

- `nx/skills/using-nx-skills/SKILL.md` — catted at SessionStart; every new session and clear/compact/resume sees the phase-boundary paragraph in the RDR-lifecycle section.
- `nx/hooks/scripts/subagent-start.sh` — conditional injection that fires on subagent tasks matching `close.*phase|phase.*clos|phase.*review|review.*gate|approach.*cross.walk|cross.walk.*approach|closeout|rdr.*phase|phase.*rdr|silent.scope|scope.reduc` patterns. Subagents on unrelated work don't see it.

`docs/rdr/AGENTS.md` is reverted to pre-restoration shape; that file is project documentation for humans, not a distribution channel for agent context. The hook injection is the load-bearing channel.

## Release: conexus 4.32.13

Plugin-only patch. Version bumped across all four manifests (CI enforces parity):

- `pyproject.toml`
- `.claude-plugin/marketplace.json` (both entries)
- `nx/.claude-plugin/plugin.json`
- `sn/.claude-plugin/plugin.json`

`uv.lock` refreshed (conexus 4.32.12 → 4.32.13). Both changelogs updated; `nx/CHANGELOG.md` entry moved from Unreleased to 4.32.13 with date.

**Post-merge** (separate, on main, in this order):

```bash
git tag -a v4.32.13 -m "conexus 4.32.13"
git push origin v4.32.13           # triggers Release workflow + PyPI auto-publish via OIDC
scripts/reinstall-tool.sh && nx --version    # verify local nx picks up the bump
```

Do not run `gh release create` manually; the workflow handles it.

## Commits

- `f144aaca` Restore phase-review-gate skill + tests + plugin entries (757 LOC source + 312 LOC tests)
- `97e07794` Hook injection (SessionStart using-nx-skills + SubagentStart conditional); revert AGENTS.md drop
- `790600d0` `chore(release): conexus 4.32.13` (version bump in 4 manifests + uv.lock + both CHANGELOGs)

## Restoration footprint

| File | LOC | Origin |
|---|---|---|
| `nx/commands/phase-review-gate.md` | 307 | Restored from `archive/develop-2026-05-19` |
| `nx/skills/phase-review-gate/SKILL.md` | 133 | Restored (includes 9977a12d review-prompt-rigour update) |
| `tests/test_phase_review_gate.py` | 322 | Restored; `TestRDR112Regression` class gained `@pytest.mark.skipif` guard to ship independently of RDR-120 tombstone PR |
| `nx/registry.yaml` | +11 | `phase-review-gate` entry in `rdr_skills` |
| `tests/test_plugin_structure.py` | +4 | `phase-review-gate` added to `_STANDALONE_SKILLS` |
| `nx/CHANGELOG.md` | +18 | Unreleased → 4.32.13 entry |
| `CHANGELOG.md` | +22 | 4.32.13 patch entry |
| Version manifests (4 files) | +5 | 4.32.12 → 4.32.13 |
| `uv.lock` | +/-1 | conexus version bump |

## Test plan

- [x] **Sandbox smoke**: `./tests/e2e/release-sandbox.sh smoke` → `[done]`, schema version `v4.32.13` confirmed, all `nx doctor` checks pass
- [x] **Full unit suite**: `uv run pytest` → `7251 passed, 40 skipped, 0 failed` (~9 min)
- [x] **Restored tests**: 18 `test_phase_review_gate.py` tests; 12 pass + 6 skip on this branch (the 6 `TestRDR112Regression` tests skip with explicit reason since RDR-112 file is absent on main)
- [x] **Structure tests**: `test_plugin_structure.py` 588 passed, 27 skipped (unchanged from baseline)
- [ ] After RDR-120 tombstone PR (#873) merges: the 6 skipped regression tests auto-reactivate on next CI run

## Related

- **Companion**: PR #873 (RDR-120 tombstones). Once merged, the 6 `TestRDR112Regression` tests stop skipping. Order doesn't strictly matter; either-first works.
- **Follow-on**: PR for `feature/rdr-121-hook-enforced-tool-routing` (RDR-121 meta-pattern for routing enforcement; `/nx:phase-review-gate` cited as one instance).
- **RDR-120 § Implementation Plan Prerequisites** cites this restoration as a P0 prerequisite.

## Notes

- `TestRDR112Regression.skipif` guard is the only adaptation from the archive version; everything else is byte-for-byte. Skip reason points at RDR-120 § Prerequisites and this branch for context.
- No new dependencies. No production code changed; plugin files only.