### PR TITLE
ci: cache the actual UV_CACHE_DIR setup-uv@v5 uses (nexus-2ivn)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,26 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-          # nexus-2fyb: cache ~/.cache/uv to avoid cold-downloading torch
-          # (~2.8 GB CPU wheel) every CI run. mineru[all] was promoted to
-          # a default dep, so without cache the install + sync takes ~10m
-          # and risks exceeding the job timeout. Key on uv.lock.
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          # nexus-2ivn: setup-uv's bundled enable-cache only restored
+          # ~1 MB of metadata in practice; the actual wheel cache was
+          # missing and torch (~847 MB) re-downloaded on every run.
+          # Disable the bundled cache and target the directory setup-uv
+          # actually uses (UV_CACHE_DIR = ${{ runner.temp }}/setup-uv-
+          # cache, not ~/.cache/uv) with an explicit actions/cache@v4
+          # step below.
+          enable-cache: false
+
+      - name: Cache uv wheel cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/setup-uv-cache
+          # Key on uv.lock so a dep change rebuilds; restore-keys
+          # falls back to the last cache for the same python so a
+          # uv.lock bump still seeds most of the wheels and only
+          # the changed packages re-download.
+          key: uv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ matrix.python-version }}-
 
       - name: Cache ChromaDB ONNX model
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,18 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-          # nexus-2fyb: see ci.yml for rationale (cache torch et al.).
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          # nexus-2ivn: see ci.yml. Bundled enable-cache caches metadata
+          # only; the wheel cache lives at ${{ runner.temp }}/setup-uv-
+          # cache and needs an explicit actions/cache@v4 step.
+          enable-cache: false
+
+      - name: Cache uv wheel cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/setup-uv-cache
+          key: uv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ matrix.python-version }}-
 
       - name: Cache ChromaDB ONNX model
         uses: actions/cache@v4
@@ -64,8 +73,18 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          # nexus-2ivn: see ci.yml. Bundled enable-cache caches metadata
+          # only; explicit actions/cache@v4 step below targets the
+          # wheel-cache directory setup-uv actually uses.
+          enable-cache: false
+
+      - name: Cache uv wheel cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/setup-uv-cache
+          key: uv-${{ runner.os }}-3.12-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-3.12-
 
       - name: Verify tag matches pyproject.toml version
         run: |


### PR DESCRIPTION
## Summary

setup-uv@v5's bundled `enable-cache` only restored ~1 MB of metadata in practice; the actual wheel cache was missing and torch (~847 MB) re-downloaded on every CI run. This is why CI has been taking 13-16 minutes for a 9-minute test suite — most of the wall clock is wheel-rehydration cost.

**Root cause**: setup-uv@v5 overrides `UV_CACHE_DIR` to `${RUNNER_TEMP}/setup-uv-cache` regardless of `enable-cache`. The bundled cache action targeted the wrong directory; the wheel cache was never actually persisted between runs.

## Fix

- Disable setup-uv's bundled cache (`enable-cache: false`)
- Add explicit `actions/cache@v4` step targeting `${{ runner.temp }}/setup-uv-cache` (the directory setup-uv actually uses)
- Key on `uv.lock` so dep changes rebuild; `restore-keys` falls back to the last cache for the same Python version so a `uv.lock` bump still seeds most wheels and only the changed packages re-download

## Files changed

| File | Jobs fixed |
|---|---|
| `.github/workflows/ci.yml` | `test` (Py3.12 + 3.13 matrix) |
| `.github/workflows/release.yml` | `test` (Py3.12 + 3.13 matrix) + `publish` |

`release.yml` had the same broken bundled-cache on both its jobs; the v4.32.13 Release ran 14+ minutes for the same root cause.

## Expected impact

- **First run after merge**: cache miss, full cold download (~847 MB torch + deps, +10 min vs current)
- **Subsequent runs on same `uv.lock`**: cache hit, install in seconds rather than minutes
- **`uv.lock` bumps**: restore-keys partial hit, only changed packages re-download

## Out of scope

The archive's `ci.yml` had three other changes that I deliberately did not port:

1. **Test partition split (core / daemon)**. Only relevant once RDR-120 P3 ships the T2 daemon and daemon-mode tests exist.
2. **`migration-race-probe` job**. With `NEXUS_RUN_FLAKY_TESTS=1` already wired into the skip markers (PR #876), an isolation runner could layer on but isn't blocking.
3. **`storage-boundary-lint` job**. Depends on `nx doctor --check-storage-boundary` which is RDR-120 P0 work.

This PR ships the caching fix alone. The other three changes can land later as needed.

## Precedent

- Archive commit `58b0ac56` documents the same fix on `archive/develop-2026-05-19`; never reached main
- Earlier attempt nexus-2fyb targeted `~/.cache/uv` (Linux default), but setup-uv overrides to `${RUNNER_TEMP}/setup-uv-cache` so that attempt cached an empty directory

## Test plan

- [ ] CI runs on this branch (first run is cache miss; ~13-16 min as before)
- [ ] **Push a no-op commit after merge** to confirm cache hit on the next run (target: <5 min for the install + sync step)
- [ ] Subsequent `uv.lock` bump triggers `restore-keys` partial hit (~1-2 min for the changed packages)