### PR TITLE
rdr-122/123/124: port three a2ui patterns to nexus

### DIFF
--- a/docs/rdr/rdr-122-llm-json-repair-pass.md
+++ b/docs/rdr/rdr-122-llm-json-repair-pass.md
@@ -1,0 +1,137 @@
+---
+title: "LLM-JSON Repair Pass: Port a2ui PayloadFixer Pattern to nx Structured-Output Parsers"
+id: RDR-122
+type: Technical
+status: draft
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-19
+accepted_date:
+related_issues: []
+related_rdrs: [RDR-119]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-122: LLM-JSON Repair Pass — Port a2ui PayloadFixer Pattern to nx Structured-Output Parsers
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+Nexus parses LLM-generated JSON in several hot paths: `plan_json` (plan library save/match), RDR frontmatter assembly, catalog payload generation, structured operator outputs (`extract`, `summarize`, `generate`). Each of these uses a fail-then-retry loop: schema validation rejects malformed output, the caller re-prompts the LLM with the error, the LLM regenerates. Retry cost is non-trivial — a regeneration of a 4k-token plan after a single trailing-comma is 4k tokens of waste plus a round trip.
+
+a2ui (Google's Agent-to-User Interface project) hit the same problem first and solved it with a `PayloadFixer` repair pass interposed between LLM output and schema validation. The fixer applies a fixed set of mechanical repairs (trailing commas, unbalanced braces, smart quotes, JSON-in-markdown extraction, common key misspellings registered in the catalog) before validation runs. Their conformance suite shows repair cuts retry rate substantially on long generations and is **strictly additive** — validation still runs after, so the contract is preserved.
+
+Nexus's parsers have no equivalent layer. Every malformed token is a full retry.
+
+## Context
+
+### Background
+
+The a2ui repository (`/Users/hal.hildebrand/git/a2ui`) ships `PayloadFixer` in both Python (`agent_sdks/python/src/a2ui/parser/payload_fixer.py`) and Kotlin SDKs. It runs after `StreamingParser` and before `A2uiValidator` (architecture analysis in T3 `architecture-a2ui-overview`). The fixer is intentionally narrow: it only repairs **mechanical** errors that the LLM produced under tokenization pressure, never **semantic** errors that would require model reasoning to fix. Semantic errors still bounce to retry.
+
+The relevant precedent in nexus is RDR-119 (cockpit UI fabric) which already adopts a2ui as the wire-level surface descriptor. Borrowing a2ui's parser-side hardening is a coherent extension — same protocol, same pre-validation layer.
+
+### Technical Environment
+
+Existing nexus parsers and their malformed-output behavior:
+
+- **`plan_save` / `plan_match`** — JSON schema validation in `nexus/db/plan_library.py`. Validation failures bounce to caller with no repair attempt.
+- **RDR frontmatter generators** — `/nx:rdr-create` skill builds YAML+JSON; the writing scripts in `nx/hooks/scripts/` are tolerant but produce silent malformed entries when LLM output is close-but-wrong.
+- **Operators `extract` / `summarize` / `generate`** — return JSON; downstream callers `json.loads` and propagate parse errors.
+- **Catalog payload assembly** — `tools/build_catalog` paths.
+
+### Constraints
+
+- **Strict additivity.** The repair pass must never change valid output. Round-trip on already-valid JSON must be a no-op.
+- **No semantic repair.** If repair requires understanding what the LLM *meant*, that's retry territory, not fixer territory.
+- **Observable.** Every repair must emit a structured event (kind, before-byte, after-byte) so we can measure repair rate per parser and tune the fixer.
+- **Cross-language parity not required.** Python-only initially; Kotlin SDK already has its own fixer if/when a Kotlin-side nexus parser appears.
+
+## Decision
+
+Introduce a `nexus.parsers.repair` module with a single entry point `repair_json(text: str, schema_id: str | None = None) -> tuple[str, list[RepairEvent]]`. Wire it into the four parsers above as a pre-validation pass. Default-on; togglable per call site via `repair=False` for parsers that need raw LLM output (eval harness, for instance).
+
+### Repair classes (v1)
+
+1. **Markdown-fence stripping** — extract JSON from triple-backtick blocks if the entire response is wrapped.
+2. **Trailing comma removal** — in objects and arrays.
+3. **Unbalanced delimiter close** — append missing `}`/`]` if the AST is otherwise parseable and the imbalance is at end-of-string.
+4. **Smart-quote → ASCII-quote** normalization (`"` `"` `'` `'` → `"`/`'`).
+5. **JS-style comment stripping** (`//` line, `/* */` block) — LLMs sometimes annotate.
+6. **Common key misspellings** when a schema_id is provided: leventshein-1 against the schema's known property names. Only triggers if the property is not a valid name in the schema.
+7. **Bare-key quoting** — JS-style object literals `{key: "value"}` → `{"key": "value"}`.
+
+Repairs are applied in fixed order, each idempotent. After all repairs run, the result is fed to `json.loads`; if that fails, return the original (not the partial repair) and emit a `repair_unrecoverable` event so the caller's retry path engages.
+
+### Wiring
+
+| Call site | Default | Toggle |
+|---|---|---|
+| `plan_save` / `plan_match` | repair on | `repair=False` env-flag for benchmark runs |
+| RDR frontmatter writers | repair on | n/a (these never want raw) |
+| Operators | repair on | per-call kwarg for eval framework |
+| Catalog payload | repair on | n/a |
+
+## Alternatives Considered
+
+### Alt 1: Tolerant JSON parser (json5, demjson3, dirty-json)
+
+A library that accepts a permissive JSON dialect. Rejected because:
+- We lose the validation gate. A tolerant parser will happily parse `{trailing: "comma",}` but downstream code expects strict JSON semantics.
+- No per-repair telemetry — we can't measure which classes of error are worth modeling differently in prompts.
+- Couples nexus to a third-party dialect rather than to a narrow internal contract.
+
+### Alt 2: Prompt-time only (better few-shot, stricter system prompts)
+
+Improving prompts so LLMs produce valid JSON more often. Rejected as **complementary, not alternative**: prompts already include schema and examples, and the residual failure rate is what motivates this RDR. Repair operates on what prompts couldn't prevent.
+
+### Alt 3: Constrained decoding (grammar-constrained sampling)
+
+Force the model to emit only schema-valid tokens. Rejected because:
+- Not available for the Claude API surface nexus uses.
+- Constrained decoding interacts badly with streaming.
+- Locks us to a specific inference backend.
+
+### Alt 4: Status quo (fail-then-retry)
+
+Current behavior. Quantified retry cost is the rejection reason — see Success Criteria for the metric we'll use to validate the change.
+
+## Consequences
+
+### Positive
+
+- Lower retry rate on `plan_save` and operator paths — direct cost reduction.
+- Structured telemetry on LLM-output failure modes feeds back into prompt iteration.
+- Pattern available for future structured-output parsers (RDR-N for tool-call argument repair, e.g.).
+
+### Negative
+
+- A new layer to maintain. Each repair class is a small temptation to add "just one more" — must keep the bar at *mechanical, fixed-set*.
+- Risk of masking a prompt regression: if a prompt change makes the LLM emit malformed output 10× more, repair hides the symptom. Mitigate via per-parser repair-rate dashboards (existing T3 telemetry channel).
+
+### Neutral
+
+- Eval framework must opt out (`repair=False`) when measuring raw LLM JSON quality.
+
+## Success Criteria
+
+- [ ] `repair_json` shipped with v1 repair classes and unit tests covering each class as both repair-applies and idempotent-on-valid.
+- [ ] Wired into `plan_save`, `plan_match`, RDR frontmatter writers, and the three operators listed above.
+- [ ] Repair telemetry emitted to T2 per-parser counters.
+- [ ] Measurable retry-rate reduction on `plan_save` in a 1-week observation window after rollout (target: ≥30% reduction in `plan_save_retry` events). If not met, RDR is wrong — iterate.
+
+## Open Questions
+
+1. **Streaming repair** — a2ui's StreamingParser handles incremental output; nexus's operators mostly return complete payloads. Worth a streaming repair API for future operators that stream? Defer to follow-up RDR.
+2. **Catalog of known schemas** — schema_id-driven repairs (class 6) need a schema registry. Use existing `nexus.schemas` or new? Defer to implementation.
+3. **Should retry path consume repair events?** — if repair *almost* worked (got to one event short of success), the retry prompt could include the partial repair as a hint. Out of v1 scope but interesting.
+
+## References
+
+- a2ui architecture analysis — T3 doc `architecture-a2ui-overview` (2026-05-19)
+- a2ui `PayloadFixer` source — `agent_sdks/python/src/a2ui/parser/payload_fixer.py` in `/Users/hal.hildebrand/git/a2ui`
+- RDR-119 — adopts a2ui as cockpit wire-level descriptor (precedent for borrowing from a2ui)

--- a/docs/rdr/rdr-123-nx-answer-a2ui-surfaces.md
+++ b/docs/rdr/rdr-123-nx-answer-a2ui-surfaces.md
@@ -1,0 +1,151 @@
+---
+title: "nx_answer A2UI Surfaces: Render Composed-Retrieval Responses as Structured Surfaces"
+id: RDR-123
+type: Architecture
+status: draft
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-19
+accepted_date:
+related_issues: []
+related_rdrs: [RDR-110, RDR-111, RDR-118, RDR-119]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-123: nx_answer A2UI Surfaces — Render Composed-Retrieval Responses as Structured Surfaces
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+`nx_answer` is the canonical entry point for analytical questions over nexus knowledge collections. Today it returns a markdown blob — citations inline as text, evidence interleaved with synthesis, follow-up questions buried at the end. Consumers (Claude Code orchestrators, future cockpit hosts, sub-agents) get a wall of prose and must re-parse it to act on individual citations or evidence items.
+
+The shape of an `nx_answer` response is **already structured**: there's a synthesis, a set of cited chunks (each with chash, collection, score), a confidence signal, optional follow-up plan steps. Flattening it to markdown discards that structure. Downstream consumers re-grep their way back to it imperfectly.
+
+A2UI v0.9 (adopted as nexus's wire-level surface descriptor in RDR-119) gives us a structured format for exactly this: a `Card` per citation, a `Text` for the synthesis, a `List` of follow-up actions, optional `Button` affordances. Rendering hosts already exist (terminal via notcurses per RDR-118, Tauri via Lumino, Claude Code via inline MCP App resources).
+
+## Context
+
+### Background
+
+RDR-118 (surfaces as tuples) and RDR-119 (cockpit UI fabric) established A2UI as the descriptor format and Bakke auto-layout as the catalog-selection policy. The plumbing is in place. What's missing is producers — and `nx_answer` is the highest-traffic producer candidate in nexus because every analytical question routes through it (per `using-nx-skills` red-flag table).
+
+Adjacent precedent: RDR-053 (Xanadu fidelity, closed) established `chash:` as the content-addressed citation primitive. `nx_answer` already emits chash references in its evidence list; rendering them as Card components with `BoundValue { kind: chash, path: "<chash>" }` makes the citation directly navigable in any A2UI host.
+
+### Technical Environment
+
+`nx_answer` today is implemented in `nexus/operators/answer.py` (entry via MCP tool `mcp__plugin_nx_nexus__nx_answer`). Internally it:
+
+1. Runs plan-match gate (RDR-080 plan library).
+2. Composes search + traverse + rank operators.
+3. Collates results into a synthesis prompt.
+4. LLM generates final answer.
+5. Returns markdown string.
+
+The structured intermediates from steps 2-3 are discarded at step 5.
+
+### Constraints
+
+- **Backward compatible.** Existing callers consume the markdown string. Surface emission must be opt-in via a `response_format="surface" | "markdown" | "both"` parameter, default `"markdown"`.
+- **Catalog discipline.** Only Basic Catalog components (per a2ui v0.9). No host-specific extensions — that's the renderer's job.
+- **No new LLM call.** Surface construction is a structured transformation of intermediates already in hand; no extra inference.
+- **Citation fidelity.** Every chash citation in the markdown variant must appear as an addressable Card in the surface variant. Lossless transformation.
+
+## Decision
+
+Add `response_format` parameter to `nx_answer`. When set to `"surface"` or `"both"`, emit an A2UI v0.9 `surfaceUpdate` payload alongside (or instead of) the markdown.
+
+### Surface schema (per nx_answer response)
+
+```
+Surface
+├── Text (id: synthesis) — the LLM-generated answer body
+├── List (id: citations)
+│   ├── Card (id: cite-{n}) — one per cited chunk
+│   │   ├── Text (chunk title + collection + score)
+│   │   ├── Text (chunk excerpt, BoundValue { kind: chash, path: <chash> })
+│   │   └── Button (id: cite-{n}-open, action: open-chash, payload: { chash })
+│   └── ...
+├── Card (id: confidence) — optional, only if confidence signal present
+│   └── Text (confidence summary + caveats)
+└── List (id: followups) — optional, only if plan-match suggested follow-up steps
+    └── Button (one per suggested next-step skill)
+```
+
+### Wiring
+
+- `nexus/operators/answer.py` gains a `_to_surface(intermediates, synthesis) -> SurfacePayload` helper.
+- MCP tool wrapper accepts `response_format` and dispatches accordingly.
+- Output envelope: for `"both"`, return `{ "markdown": "...", "surface": {...} }`; for `"surface"`, return just the surface; for `"markdown"` (default), unchanged.
+- Hosts that don't render A2UI (current Claude Code without MCP App support) keep using markdown.
+
+### Action handlers
+
+The `open-chash` action is host-side: the renderer resolves the chash via `nexus.catalog` (existing `mcp__plugin_nx_nexus-catalog__resolve` tool) and opens the resulting document/chunk. No nexus-side handler change.
+
+## Alternatives Considered
+
+### Alt 1: Surfaces as the only format (no markdown)
+
+Replace markdown entirely. Rejected because:
+- Breaks every existing caller including the Claude Code orchestrator without MCP App support.
+- Forces premature commitment to A2UI catalog stability for a producer-side change.
+- One-way doors should be deferred until the cockpit substrate is more widely deployed.
+
+### Alt 2: Markdown with embedded JSON sidecar
+
+Ship a `<!-- nx_answer_data: {...} -->` JSON block in the markdown. Rejected because:
+- Couples consumers to a nexus-specific sidecar format.
+- A2UI v0.9 already exists as the standard for exactly this.
+- Sidecar formats rot — A2UI evolves under spec governance.
+
+### Alt 3: Wait for cockpit GA before producer work
+
+Defer until RDR-118/119 ship and there's a host actually rendering surfaces. Rejected because:
+- Producer and consumer work parallelize cleanly with the `response_format` opt-in.
+- Without producers, the cockpit substrate has nothing to render — bootstrapping order matters.
+- Risk of cockpit shipping with only synthetic test surfaces and no real producer is higher than risk of producer shipping ahead of cockpit.
+
+## Consequences
+
+### Positive
+
+- First substantial A2UI producer in nexus — validates the wire format end-to-end on real content.
+- Citations become addressable and interactive in hosts that render A2UI.
+- Structured intermediates from `nx_answer` stop being thrown away.
+- Pattern generalizes: `/nx:query`, `/nx:research`, `/nx:analyze` are obvious next producers.
+
+### Negative
+
+- Two output paths to maintain (markdown + surface). Mitigated by single underlying intermediates representation — surface is a view, not a parallel pipeline.
+- Surface schema drift risk if a2ui v0.9 → v0.10 changes the relevant primitives. Mitigated by versioned producer (matching RDR-119 catalog versioning).
+
+### Neutral
+
+- Telemetry: track `response_format` distribution to measure cockpit uptake.
+
+## Success Criteria
+
+- [ ] `response_format` parameter shipped on `nx_answer`.
+- [ ] Surface emission produces a v0.9-valid `surfaceUpdate` payload for at least 5 representative nx_answer queries (test corpus in `tests/operators/nx_answer/`).
+- [ ] Every chash citation in the markdown variant has a matching Card in the surface variant (lossless transformation test).
+- [ ] One downstream consumer wired to render the surface (terminal renderer per RDR-118, or Claude Code MCP App resource).
+- [ ] No regression in `nx_answer` latency (surface construction must be < 5ms — structured transform, not inference).
+
+## Open Questions
+
+1. **Follow-up plan steps as Buttons** — currently `nx_answer`'s plan-match gate suggests follow-up skills. Should those be `Button` components with `openUrl`-style actions, or just `Text`? Buttons require the host to know how to dispatch nexus skills — couples renderer to nexus skill catalog. Defer to implementation review.
+2. **Confidence visualization** — A2UI Basic Catalog has no progress/gauge component. Use a plain `Text` for now, revisit if we need richer.
+3. **Streaming surface updates** — for long nx_answer responses, could emit `surfaceUpdate` incrementally as the LLM streams. Worth it? Defer to follow-up RDR; v1 is whole-response.
+4. **Catalog version pinning** — does the surface payload carry a `catalogVersion`? Required by a2ui v0.10, optional in v0.9. Pin to v0.9 for v1 of this RDR.
+
+## References
+
+- a2ui architecture analysis — T3 doc `architecture-a2ui-overview` (2026-05-19)
+- RDR-118 — surfaces as tuples (surface_cell subspace)
+- RDR-119 — cockpit UI fabric (catalog negotiation, Bakke auto-layout)
+- RDR-053 — Xanadu fidelity (chash as citation primitive)
+- A2UI v0.9 specification — `specification/v0_9/` in `/Users/hal.hildebrand/git/a2ui`

--- a/docs/rdr/rdr-124-subagent-result-surfaces.md
+++ b/docs/rdr/rdr-124-subagent-result-surfaces.md
@@ -1,0 +1,167 @@
+---
+title: "Subagent Result Surfaces: Return A2UI Cards from Subagents to Relieve Orchestrator Context"
+id: RDR-124
+type: Architecture
+status: draft
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-19
+accepted_date:
+related_issues: []
+related_rdrs: [RDR-118, RDR-119, RDR-123]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-124: Subagent Result Surfaces — Return A2UI Cards from Subagents to Relieve Orchestrator Context
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+Nexus subagents (codebase-deep-analyzer, deep-research-synthesizer, code-review-expert, debugger, etc.) return their findings as prose to the orchestrator. A typical run produces 600–1500 tokens of structured analysis flattened into markdown. The orchestrator then:
+
+1. Reads the whole thing into context (orchestrator-context cost).
+2. Decides what to relay to the user.
+3. Re-writes a summary, often dropping structure (filenames, line numbers, evidence chains) the subagent produced.
+
+Two distinct costs: **context-budget pressure** on the orchestrator, and **information loss** in the relay step. A 1200-word subagent report becomes a 200-word orchestrator summary; 80% of the structured detail is discarded or compressed lossily.
+
+Subagent outputs are **already structured** — codebase-deep-analyzer produces module maps, dependency graphs, open-questions lists; code-review-expert produces issue lists with file/line/severity; debugger produces hypothesis chains. Each maps cleanly onto A2UI Basic Catalog primitives (Card per finding, List for grouping, Button for follow-up actions).
+
+## Context
+
+### Background
+
+RDR-123 (concurrent draft) introduces `response_format="surface"` for `nx_answer`. This RDR extends the pattern to subagent results: a subagent can return a surface payload alongside (or instead of) prose, the orchestrator embeds the surface reference rather than the full text, and the user's host renders the surface directly when supported.
+
+Orchestrator-context relief is the load-bearing benefit. Today every subagent dispatch costs ~1500 orchestrator tokens. Surface emission lets the orchestrator hold a pointer (surface_id + summary) and let the host pull the surface from the surface_cell subspace (RDR-118) on demand.
+
+### Technical Environment
+
+Subagent dispatch flow:
+
+- Orchestrator calls `Agent` tool with subagent type + prompt.
+- Subagent runs in isolated context, produces a result.
+- Result is returned as the Agent tool's return value to the orchestrator.
+- Orchestrator must read the entire return value into context.
+
+The Agent tool's return value is a string today. Extending it to optionally carry structured surface payloads requires either:
+
+(a) wrapping the existing string return in a JSON envelope (breaking change), or
+(b) emitting the surface to a side channel (T1 scratch or surface_cell subspace per RDR-118) and returning a short pointer + summary in the string.
+
+Option (b) is reversible and doesn't break existing subagent contracts.
+
+### Constraints
+
+- **No Agent-tool contract changes.** Subagents continue to return strings. Surface side-channel is the mechanism.
+- **Pointer + summary in the return string.** The orchestrator needs *something* in context — a 2-3 sentence summary plus a surface_id is the right granularity.
+- **Producer-opt-in.** Each subagent decides whether to emit a surface. Some (code-explorer doing a one-shot lookup) don't need to; some (codebase-deep-analyzer, code-review-expert) benefit substantially.
+- **Hosts without A2UI rendering** must still get useful output. The pointer+summary is human-readable and the surface payload is fetchable via `tuplespace_read` for fallback prose rendering.
+
+## Decision
+
+Subagents that opt in emit their structured result as an A2UI surface to the `surface_cell` subspace (RDR-118) with a generated `surface_id`. The return value to the orchestrator becomes:
+
+```
+## {subagent_type} — {short title}
+
+**Surface:** `surface_cell:{surface_id}` ({N} findings, view via `/nx:surface-show {surface_id}`)
+
+{2-3 sentence summary highlighting top finding and any blocker}
+
+{Optional: 3-5 most critical findings as bullets — orchestrator can read these without fetching}
+```
+
+The full surface in `surface_cell` holds the complete structured payload. The orchestrator can choose to fetch it (`tuplespace_read`) if it needs detail, or pass the surface_id through to the user's host for direct rendering.
+
+### Subagent-side wiring
+
+A shared helper `nexus.subagents.emit_surface(findings: FindingsSchema) -> SurfaceId`:
+
+1. Builds A2UI v0.9 surface from a subagent-specific `FindingsSchema` (one per subagent type — codebase-analysis findings, code-review findings, debug findings, research findings).
+2. Writes surface to `surface_cell` subspace with TTL matching session.
+3. Returns the `surface_id` for embedding in the return string.
+
+### FindingsSchema per subagent (v1)
+
+| Subagent | Schema |
+|---|---|
+| codebase-deep-analyzer | `{ modules: [...], patterns: [...], data_flow: [...], open_questions: [...] }` |
+| code-review-expert | `{ issues: [{file, line, severity, message, suggestion}] }` |
+| debugger | `{ hypotheses: [...], evidence: [...], conclusion, fix_attempts: [...] }` |
+| deep-research-synthesizer | `{ findings: [{claim, evidence_chash, confidence}], gaps: [...] }` |
+
+Each schema serializes to a surface with the structure laid out in RDR-123 (Card per item, List for grouping, Buttons for follow-up actions like "open this file" or "run this skill").
+
+### Orchestrator-side wiring
+
+No required changes. Orchestrators that want to relay surfaces directly to user-side rendering can pass the surface_id through; orchestrators that don't can keep ignoring it and operate on the summary alone.
+
+## Alternatives Considered
+
+### Alt 1: Wrap Agent tool return value in JSON envelope
+
+`{ summary: "...", surface: {...}, raw: "..." }` instead of bare string. Rejected because:
+- Breaks every existing subagent contract.
+- Requires Agent tool changes that nexus doesn't own (Claude Code platform).
+- Side-channel via surface_cell is reversible and platform-agnostic.
+
+### Alt 2: Subagents write findings directly to T2 memory
+
+Skip A2UI; persist findings as structured memory entries. Rejected because:
+- Loses host-rendering benefit (markdown-on-fetch instead of native widgets).
+- Conflates "subagent intermediate output" with "promoted T2 finding" — those have different lifecycles.
+- A2UI surfaces are already the descriptor format per RDR-119; introducing a parallel format is unjustified.
+
+### Alt 3: Keep markdown returns, just structure the markdown better
+
+Convention-based: every subagent emits H2 headers, bullet lists with specific patterns. Rejected because:
+- Markdown structure is unparseable by hosts — they'd have to re-derive structure with heuristics.
+- Doesn't relieve orchestrator-context pressure; the full text is still in the return value.
+- Doesn't enable interactive affordances (Buttons for follow-up actions).
+
+## Consequences
+
+### Positive
+
+- Orchestrator-context pressure reduced for any subagent dispatch with structured findings — measurable in tokens-per-dispatch.
+- Findings become interactive in hosts that render A2UI (click a code-review issue → opens file at line).
+- Surface payloads live in `surface_cell` and can outlive the immediate dispatch — useful for "show me what that subagent found earlier."
+- Compounds with RDR-123: same surface infrastructure, two producer categories.
+
+### Negative
+
+- Subagent-side complexity: each opt-in subagent needs a FindingsSchema and serialization. Mitigated by shared helper and per-subagent schema (small, declarative).
+- TTL discipline: surfaces in `surface_cell` need to expire or accumulate. Use session-scoped TTL by default.
+- Debugging the relay: when a subagent emits a surface that doesn't render correctly, the failure is across two subsystems (subagent producer + host renderer). Mitigate via subagent-side surface validation against the a2ui v0.9 schema before emit.
+
+### Neutral
+
+- Telemetry: track surface-emit rate per subagent type and orchestrator-fetch rate.
+
+## Success Criteria
+
+- [ ] Shared `emit_surface` helper shipped with one FindingsSchema (codebase-deep-analyzer chosen as the pilot — highest-token subagent).
+- [ ] codebase-deep-analyzer emits a surface on dispatch; return value to orchestrator includes pointer + ≤ 200-word summary.
+- [ ] Surface payload validates against a2ui v0.9 schema in subagent-side check.
+- [ ] Measurable token-per-dispatch reduction on codebase-deep-analyzer (target: ≥40% reduction in orchestrator return-value size).
+- [ ] One downstream consumer reads the surface and renders it — terminal renderer per RDR-118, or `/nx:surface-show` skill (new).
+- [ ] If token reduction target not met or surfaces aren't being consumed, RDR is wrong — iterate before extending to other subagents.
+
+## Open Questions
+
+1. **`/nx:surface-show` skill** — a new skill that fetches a surface by id and renders it (markdown fallback for non-A2UI hosts). Required for v1, or follow-up RDR? Required for v1 — without a consumer, the surface is write-only.
+2. **Surface TTL policy** — session-scoped default, but some surfaces (a definitive architecture analysis) should be promoted to T2/T3. Use existing promote mechanism with surface-as-memory mapping? Defer to implementation.
+3. **Should the orchestrator be allowed to *edit* a surface?** — e.g., orchestrator marks issues as triaged. Out of v1 scope; surfaces are immutable on emit.
+4. **Failure mode: subagent emits invalid surface** — fall back to prose return? Or fail loudly? v1: fall back to prose, log validation error. Reconsider after rollout.
+
+## References
+
+- a2ui architecture analysis — T3 doc `architecture-a2ui-overview` (2026-05-19)
+- RDR-118 — surface_cell subspace and surfaces-as-tuples
+- RDR-119 — cockpit UI fabric and catalog negotiation
+- RDR-123 — nx_answer A2UI surfaces (sibling RDR, same surface infrastructure)


### PR DESCRIPTION
## Summary

Three new draft RDRs porting patterns from a2ui (Google's Agent-to-User Interface project) into nexus. Source: a2ui architecture analysis indexed to T3 as `architecture-a2ui-overview` (2026-05-19).

- **RDR-122** — LLM-JSON repair pass (PayloadFixer port). Pre-validation repair layer for `plan_save`/`plan_match`, RDR frontmatter writers, operators, catalog payloads. Strictly additive; no-op on valid JSON. Target: ≥30% retry-rate reduction on `plan_save`.
- **RDR-123** — `nx_answer` A2UI surfaces. `response_format` parameter emits v0.9 `surfaceUpdate` (synthesis Text + citations as chash-bound Cards) alongside markdown. First substantial A2UI producer in nexus. Builds on RDR-118/119 cockpit substrate.
- **RDR-124** — Subagent result surfaces. Opt-in subagents emit findings to `surface_cell` subspace; Agent-tool return becomes pointer + summary instead of 1200-word prose. Pilot: codebase-deep-analyzer. Target: ≥40% reduction in orchestrator return-value tokens.

All three are drafts. RDR-research / rdr-gate / rdr-accept pending.

T2 registered: `nexus_rdr/RDR-122`, `RDR-123`, `RDR-124`.

## Test plan

- [ ] `/nx:rdr-list` shows RDR-122/123/124 as draft
- [ ] `/nx:rdr-show 122` / `123` / `124` resolve via T2 + on-disk file
- [ ] Cross-references (RDR-118/119) resolve in both directions
- [ ] No CI failures from RDR-only changes (docs path)