### PR TITLE
refactor: eliminate _voyage_instance + encapsulate _plan_cache_instance singletons (nexus-12v7c + nexus-sl69o)

### DIFF
--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -437,7 +437,7 @@ def search_cmd(
     from nexus.config import is_local_mode
     if not no_rerank and not is_local_mode() and len(set(r.collection for r in results)) > 1:
         try:
-            results = rerank_results(results, query=query, model=reranker_model, top_k=n)
+            results = rerank_results(results, query=query, model=reranker_model, top_k=n, t3=db)
         except Exception as exc:
             click.echo(f"Warning: reranking failed ({exc}), using raw order", err=True)
     else:

--- a/src/nexus/mcp/plan_cache_registry.py
+++ b/src/nexus/mcp/plan_cache_registry.py
@@ -1,0 +1,180 @@
+"""Process-scoped registry for the T1 plan-session cache (nexus-sl69o).
+
+Encapsulates the five module-level names that previously lived in
+``nexus.mcp_infra``:
+- ``_plan_cache_instance`` (the cache or sentinel)
+- ``_plan_cache_lock``
+- ``_plan_cache_populated``
+- ``_plan_cache_mtime``
+- ``_PLAN_CACHE_UNAVAILABLE`` sentinel
+
+into a single :class:`PlanCacheRegistry` held as one module-level
+singleton via :func:`get_plan_cache_registry`. Public API contracts are
+preserved at ``nexus.mcp_infra.get_t1_plan_cache`` and
+``nexus.mcp_infra.reset_plan_cache_for_tests``; this module is the
+implementation backing store.
+
+**Scope honesty**: this is encapsulation, not "DI top-down" in the
+strict sense. The cache must be process-scoped (its whole purpose is
+to amortize PlanLibrary-population cost across MCP tool calls within
+one server process). Nexus's MCP handlers are top-level functions
+registered with FastMCP, not methods on a server class, so there's no
+server-instance to attach the registry to via constructor injection.
+Strict DI would require restructuring the MCP handler surface into a
+class; out of scope for nexus-sl69o.
+
+What IS achieved here:
+- One named module-level singleton (the registry) instead of five
+- Cache state cohesive in a class with proper methods
+- Test substitution via :func:`reset_plan_cache_registry_for_tests`
+  (same shape as the prior ``reset_plan_cache_for_tests``, cleaner
+  internals)
+- The nexus-qgjr mtime-guarded refresh contract preserved as
+  :meth:`PlanCacheRegistry.get`'s populate-when-stale logic
+
+See ``nx memory get nexus/design-singleton-elimination-voyage-and-plan-cache.md``
+for the approved design and the honest scoping note.
+"""
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+
+# Sentinel distinct from None: stored on the registry when init fails so
+# subsequent get() calls short-circuit without re-attempting under the
+# lock. Matches the prior _PLAN_CACHE_UNAVAILABLE semantics.
+_UNAVAILABLE = object()
+
+
+def _plan_library_mtime(library: Any) -> float:
+    """Return the SQLite file mtime for *library*, or 0.0 when unknown.
+
+    Falls back to 0.0 when the library does not expose a ``path``
+    attribute (in-memory or test-stub libraries) or when the file is
+    missing; both produce a stable repopulate-never-runs fallback that
+    matches the legacy single-populate contract.
+    """
+    path = getattr(library, "path", None)
+    if path is None:
+        return 0.0
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+class PlanCacheRegistry:
+    """Process-scoped registry around the T1 plan-session cache.
+
+    Lifecycle:
+    - Constructed once per MCP server process via
+      :func:`get_plan_cache_registry`.
+    - First :meth:`get` lazy-initialises the underlying
+      :class:`nexus.plans.session_cache.PlanSessionCache` from the
+      live T1 client (via ``nexus.mcp_infra.get_t1``).
+    - On init failure, the registry's ``cache`` slot is set to the
+      ``_UNAVAILABLE`` sentinel; subsequent :meth:`get` calls
+      short-circuit and return None without re-entering the lock.
+    - When ``populate_from`` is supplied, the cache is repopulated
+      whenever the underlying PlanLibrary SQLite file mtime advances
+      (nexus-qgjr mtime-guarded refresh).
+
+    Test isolation: :func:`reset_plan_cache_registry_for_tests` drops
+    the module-level singleton so the next ``get_plan_cache_registry()``
+    constructs a fresh registry.
+    """
+
+    def __init__(self) -> None:
+        self._cache: Any = None  # PlanSessionCache | _UNAVAILABLE sentinel | None
+        self._lock = threading.Lock()
+        self._populated: bool = False
+        self._mtime: float = 0.0  # SQLite file mtime captured at most recent populate
+
+    def get(self, *, populate_from: Any = None) -> Any:
+        """Return the T1 ``plans__session`` cache, lazy-populated on first call.
+
+        When *populate_from* (a PlanLibrary) is supplied, the cache is
+        populated from its rows on first call and repopulated whenever
+        the underlying SQLite file mtime advances (nexus-qgjr). The
+        mtime check mirrors the catalog's ``_last_consistency_mtime``
+        pattern at ``catalog.py:405``: cheap when nothing changed,
+        rebuilds when a write moves the file's stat-time.
+
+        Libraries without a ``path`` attribute fall back to populate-
+        once semantics; the mtime tier costs them nothing.
+
+        Returns ``None`` when no T1 client is reachable; the matcher
+        falls back to FTS5 in that case. Subsequent calls after an
+        init failure return ``None`` immediately without re-entering
+        the lock (see ``_UNAVAILABLE`` sentinel).
+        """
+        if self._cache is _UNAVAILABLE:
+            return None
+        if self._cache is None:
+            with self._lock:
+                if self._cache is None:
+                    try:
+                        from nexus.mcp_infra import get_t1
+                        from nexus.plans.session_cache import PlanSessionCache
+                        t1, _ = get_t1()
+                        self._cache = PlanSessionCache(
+                            client=t1._client, session_id=t1.session_id,
+                        )
+                    except Exception:
+                        self._cache = _UNAVAILABLE
+        if self._cache is _UNAVAILABLE:
+            return None
+        if populate_from is not None:
+            current_mtime = _plan_library_mtime(populate_from)
+            with self._lock:
+                stale = (
+                    not self._populated
+                    or (current_mtime > 0.0 and current_mtime > self._mtime)
+                )
+                if stale:
+                    try:
+                        self._cache.populate(populate_from)
+                    finally:
+                        self._populated = True
+                        self._mtime = current_mtime
+        return self._cache
+
+    def clear(self) -> None:
+        """Drop the cache state. Used by ``reset_plan_cache_registry_for_tests``."""
+        with self._lock:
+            self._cache = None
+            self._populated = False
+            self._mtime = 0.0
+
+
+# Module-level singleton. The cache MUST be process-scoped (the whole
+# point is to amortize PlanLibrary population across MCP tool calls),
+# so a module-level holder is unavoidable in nexus's current MCP
+# architecture. See module docstring for the honest scoping note.
+_registry: PlanCacheRegistry | None = None
+_registry_lock = threading.Lock()
+
+
+def get_plan_cache_registry() -> PlanCacheRegistry:
+    """Return the process-scoped :class:`PlanCacheRegistry`, lazy-creating on first call."""
+    global _registry
+    if _registry is None:
+        with _registry_lock:
+            if _registry is None:
+                _registry = PlanCacheRegistry()
+    return _registry
+
+
+def reset_plan_cache_registry_for_tests() -> None:
+    """Test helper: drop the registry singleton so the next call constructs fresh.
+
+    Public surface ``nexus.mcp_infra.reset_plan_cache_for_tests`` delegates here.
+    """
+    global _registry
+    with _registry_lock:
+        _registry = None

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -147,42 +147,11 @@ def t2_ctx():
 
 
 # ── T1 plan session cache (RDR-078) ──────────────────────────────────────────
-# Singleton wrapper around PlanSessionCache; shared across MCP tool calls in
-# one process.  reset_plan_cache_for_tests() tears it down between test cases.
-#
-# Three states:
-#   None                      — not yet initialised, eligible for init attempt
-#   _PLAN_CACHE_UNAVAILABLE   — init failed; callers short-circuit to FTS5
-#                               without taking the lock on every call
-#   PlanSessionCache instance — healthy, available for matching
-
-_PLAN_CACHE_UNAVAILABLE = object()  # sentinel — distinct from None
-
-_plan_cache_instance = None
-_plan_cache_lock = threading.Lock()
-_plan_cache_populated: bool = False
-#: SQLite file mtime captured at the most recent populate. Used by the
-#: mtime-guarded refresh in :func:`get_t1_plan_cache` to detect plan
-#: library mutation (a re-seeded builtin, an added or deleted row)
-#: without requiring an MCP-server restart. nexus-qgjr.
-_plan_cache_mtime: float = 0.0
-
-
-def _plan_library_mtime(library) -> float:
-    """Return the SQLite file mtime for *library*, or 0.0 when unknown.
-
-    Falls back to 0.0 when the library does not expose a ``path``
-    attribute (in-memory or test-stub libraries) or when the file is
-    missing — both produce a stable repopulate-never-runs fallback that
-    matches the legacy single-populate contract.
-    """
-    path = getattr(library, "path", None)
-    if path is None:
-        return 0.0
-    try:
-        return path.stat().st_mtime
-    except OSError:
-        return 0.0
+# Plan-cache wrappers. The cache state itself lives in
+# nexus.mcp.plan_cache_registry.PlanCacheRegistry as a single module-
+# level singleton (nexus-sl69o, 2026-05-20). These two functions
+# preserve the historical public API; new code may prefer
+# get_plan_cache_registry().get(...) directly.
 
 
 def get_t1_plan_cache(*, populate_from=None):
@@ -192,56 +161,30 @@ def get_t1_plan_cache(*, populate_from=None):
     populated from its rows on first call and **repopulated whenever
     the underlying SQLite file mtime advances** (nexus-qgjr). The mtime
     check mirrors the catalog's ``_last_consistency_mtime`` pattern at
-    ``catalog.py:405`` — cheap when nothing changed, rebuilds when a
+    ``catalog.py:405``: cheap when nothing changed, rebuilds when a
     write moves the file's stat-time.
 
     Libraries without a ``path`` attribute fall back to populate-once
     semantics; the mtime tier costs them nothing.
 
-    Returns ``None`` when no T1 client is reachable — the matcher falls
+    Returns ``None`` when no T1 client is reachable; the matcher falls
     back to FTS5 in that case. Subsequent calls after an init failure
-    return ``None`` immediately without re-entering the lock (see
-    sentinel above).
+    return ``None`` immediately without re-entering the lock.
+
+    Backed by :class:`nexus.mcp.plan_cache_registry.PlanCacheRegistry`.
     """
-    global _plan_cache_instance, _plan_cache_populated, _plan_cache_mtime
-    if _plan_cache_instance is _PLAN_CACHE_UNAVAILABLE:
-        return None
-    if _plan_cache_instance is None:
-        with _plan_cache_lock:
-            if _plan_cache_instance is None:
-                try:
-                    t1, _ = get_t1()
-                    from nexus.plans.session_cache import PlanSessionCache
-                    _plan_cache_instance = PlanSessionCache(
-                        client=t1._client, session_id=t1.session_id,
-                    )
-                except Exception:
-                    _plan_cache_instance = _PLAN_CACHE_UNAVAILABLE
-    if _plan_cache_instance is _PLAN_CACHE_UNAVAILABLE:
-        return None
-    if populate_from is not None:
-        current_mtime = _plan_library_mtime(populate_from)
-        with _plan_cache_lock:
-            stale = (
-                not _plan_cache_populated
-                or (current_mtime > 0.0 and current_mtime > _plan_cache_mtime)
-            )
-            if stale:
-                try:
-                    _plan_cache_instance.populate(populate_from)
-                finally:
-                    _plan_cache_populated = True
-                    _plan_cache_mtime = current_mtime
-    return _plan_cache_instance
+    from nexus.mcp.plan_cache_registry import get_plan_cache_registry
+    return get_plan_cache_registry().get(populate_from=populate_from)
 
 
 def reset_plan_cache_for_tests() -> None:
-    """Test helper: drop the cache singleton so the next call re-init."""
-    global _plan_cache_instance, _plan_cache_populated, _plan_cache_mtime
-    with _plan_cache_lock:
-        _plan_cache_instance = None
-        _plan_cache_populated = False
-        _plan_cache_mtime = 0.0
+    """Test helper: drop the cache so the next call re-initialises.
+
+    Backed by
+    :func:`nexus.mcp.plan_cache_registry.reset_plan_cache_registry_for_tests`.
+    """
+    from nexus.mcp.plan_cache_registry import reset_plan_cache_registry_for_tests
+    reset_plan_cache_registry_for_tests()
 
 
 # ── Catalog management ────────────────────────────────────────────────────────

--- a/src/nexus/scoring.py
+++ b/src/nexus/scoring.py
@@ -2,7 +2,6 @@
 """Pure scoring primitives: normalization, hybrid scoring, reranking, interleaving."""
 from __future__ import annotations
 
-import threading
 from typing import Any
 
 import structlog
@@ -368,46 +367,23 @@ def apply_topic_boost(
     return results
 
 
-_voyage_instance: object | None = None
-_voyage_lock = threading.Lock()
-
-
-def _voyage_client():
-    """Return a cached voyageai.Client instance."""
-    global _voyage_instance
-    if _voyage_instance is not None:
-        return _voyage_instance
-    with _voyage_lock:
-        if _voyage_instance is None:
-            import voyageai
-            from nexus.config import get_credential, load_config
-            timeout = load_config().get("voyageai", {}).get("read_timeout_seconds", 120.0)
-            _voyage_instance = voyageai.Client(
-                api_key=get_credential("voyage_api_key"),
-                timeout=timeout,
-                max_retries=0,
-            )
-    return _voyage_instance
-
-
-def _reset_voyage_client() -> None:
-    """Reset the cached Voyage AI client singleton (for test isolation only)."""
-    global _voyage_instance
-    with _voyage_lock:
-        _voyage_instance = None
-
-
 def rerank_results(
     results: list[SearchResult],
     query: str,
     model: str = _RERANK_MODEL,
     top_k: int | None = None,
+    *,
+    t3: Any = None,
 ) -> list[SearchResult]:
     """Rerank *results* by cross-encoder relevance for *query*.
 
     RDR-109 Phase 3 mode-aware dispatch:
 
-    - Cloud mode: Voyage AI reranker (``rerank-2.5``).
+    - Cloud mode: Voyage AI reranker (``rerank-2.5``). Requires *t3*,
+      a T3Database whose ``_voyage_client`` attribute is the
+      constructed ``voyageai.Client`` (set by ``T3Database.__init__``
+      when ``voyage_api_key`` is provided). Cloud-mode call sites
+      MUST pass ``t3``; without it the cloud reranker fails loud.
     - Local mode: ONNX cross-encoder via
       :class:`nexus.cross_encoder.LocalCrossEncoder` (default
       ``cross-encoder/ms-marco-MiniLM-L-6-v2``, ~80MB lazy download).
@@ -428,7 +404,7 @@ def rerank_results(
 
     if is_local_mode():
         return _rerank_local(results, query, documents, n)
-    return _rerank_cloud(results, query, documents, model, n)
+    return _rerank_cloud(results, query, documents, model, n, t3=t3)
 
 
 def _rerank_cloud(
@@ -437,10 +413,25 @@ def _rerank_cloud(
     documents: list[str],
     model: str,
     top_n: int,
+    *,
+    t3: Any = None,
 ) -> list[SearchResult]:
     """Cloud reranker via Voyage AI. Best-effort: any exception falls
-    back to the original order truncated to *top_n*."""
-    client = _voyage_client()
+    back to the original order truncated to *top_n*.
+
+    The Voyage client is sourced from ``t3._voyage_client`` (set by
+    ``T3Database.__init__`` when configured in cloud mode). Callers
+    in cloud mode must pass *t3*; without it the reranker logs a
+    warning and returns the input order unchanged.
+    """
+    client = getattr(t3, "_voyage_client", None) if t3 is not None else None
+    if client is None:
+        _log.warning(
+            "rerank_skipped_no_voyage_client",
+            reason="cloud reranker requires t3 with a configured _voyage_client; "
+                   "caller did not pass t3 or t3._voyage_client is None",
+        )
+        return results[:top_n]
     try:
         rerank_response = _voyage_with_retry(
             client.rerank,

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -151,9 +151,11 @@ def test_rerank_routes_to_cloud_in_cloud_mode(cloud_mode, monkeypatch) -> None:
         def rerank(self, **kw):
             return fake_rerank(**kw)
 
-    monkeypatch.setattr("nexus.scoring._voyage_client", lambda: _FakeClient())
+    from unittest.mock import MagicMock as _MM
+    stub_t3 = _MM()
+    stub_t3._voyage_client = _FakeClient()
 
-    out = scoring.rerank_results(results, query="q")
+    out = scoring.rerank_results(results, query="q", t3=stub_t3)
     assert [r.id for r in out] == ["r2", "r0", "r1"]
     assert captured["model"] == "rerank-2.5"
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -78,8 +78,9 @@ def test_rerank_empty():
 def test_rerank_degrades_on_error(exc):
     mock_client = MagicMock()
     mock_client.rerank.side_effect = exc
-    with patch("nexus.scoring._voyage_client", return_value=mock_client):
-        results = rerank_results([_r()], "query", top_k=1)
+    stub_t3 = MagicMock()
+    stub_t3._voyage_client = mock_client
+    results = rerank_results([_r()], "query", top_k=1, t3=stub_t3)
     assert len(results) == 1
 
 

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -100,8 +100,9 @@ def test_rerank_results_returns_unified_ranking(cloud_mode):
             MagicMock(index=1, relevance_score=0.3),
         ]
     )
-    with patch("nexus.scoring._voyage_client", return_value=mock_client):
-        reranked = rerank_results(results, query="test", model="rerank-2.5", top_k=3)
+    stub_t3 = MagicMock()
+    stub_t3._voyage_client = mock_client
+    reranked = rerank_results(results, query="test", model="rerank-2.5", top_k=3, t3=stub_t3)
     assert reranked[0].id == "3"
     assert reranked[1].id == "1"
     assert reranked[2].id == "2"

--- a/tests/test_voyage_retry.py
+++ b/tests/test_voyage_retry.py
@@ -217,16 +217,12 @@ def test_embed_with_fallback_voyage_client_has_timeout() -> None:
         mock_ctor.assert_called_once_with(api_key="test-key", timeout=75.0, max_retries=0)
 
 
-def test_scoring_voyage_client_has_timeout() -> None:
-    import nexus.scoring as scoring
-    scoring._reset_voyage_client()
-    with patch("voyageai.Client") as mock_ctor, \
-         patch("nexus.config.get_credential", return_value="test-key"), \
-         patch("nexus.config.load_config", return_value={"voyageai": {"read_timeout_seconds": 55}}):
-        mock_ctor.return_value = MagicMock()
-        scoring._voyage_client()
-        mock_ctor.assert_called_once_with(api_key="test-key", timeout=55, max_retries=0)
-    scoring._reset_voyage_client()
+# Note: test_scoring_voyage_client_has_timeout removed as part of the
+# _voyage_instance singleton elimination (nexus-12v7c). The Voyage client
+# is now constructed by T3Database.__init__ from voyage_api_key + config
+# timeout; test_t3_voyage_client_has_timeout above covers that path. The
+# scoring module no longer constructs its own client; it reads
+# t3._voyage_client from the T3Database passed by the caller.
 
 
 # ── _voyage_with_retry wraps all call sites ─────────────────────────────────
@@ -309,31 +305,22 @@ def test_index_code_file_embed_retries(tmp_path) -> None:
 
 def test_rerank_retries_then_degrades() -> None:
     import nexus.scoring as scoring
-    scoring._reset_voyage_client()
     from nexus.types import SearchResult
     results = [SearchResult(id="1", content="text", collection="code__repo", distance=0.1, metadata={})]
     mock_client = MagicMock()
     mock_client.rerank.side_effect = _ve.APIConnectionError("persistent")
-    with patch("voyageai.Client", return_value=mock_client), \
-         patch("nexus.config.get_credential", return_value="test-key"), \
-         patch("nexus.config.load_config", return_value={"voyageai": {"read_timeout_seconds": 120}}), \
-         patch("nexus.retry.time.sleep"):
-        returned = scoring.rerank_results(results, "query", top_k=1)
+    stub_t3 = MagicMock()
+    stub_t3._voyage_client = mock_client
+    with patch("nexus.retry.time.sleep"):
+        returned = scoring.rerank_results(results, "query", top_k=1, t3=stub_t3)
     assert mock_client.rerank.call_count == 3
     assert returned == results
-    scoring._reset_voyage_client()
 
 
-# ── _reset_voyage_client singleton ──────────────────────────────────────────
-
-def test_reset_clears_singleton() -> None:
-    import nexus.scoring as scoring
-    scoring._reset_voyage_client()
-    assert scoring._voyage_instance is None
-    scoring._voyage_instance = sentinel = MagicMock()
-    assert scoring._voyage_instance is sentinel
-    scoring._reset_voyage_client()
-    assert scoring._voyage_instance is None
+# Note: test_reset_clears_singleton removed as part of the
+# _voyage_instance singleton elimination (nexus-12v7c). No singleton
+# to reset; tests construct stub T3 instances with a mocked
+# _voyage_client attribute and pass them explicitly to rerank_results.
 
 
 # ── Integration: propagation and exhaustion ─────────────────────────────────


### PR DESCRIPTION
## Summary

Continuation of the singleton-elimination arc (PRs #870 / #871 / #872). Two remaining `_instance` singletons on main, both addressed here in one branch / one PR / one CI cycle.

| Bead | Singleton | Result |
|---|---|---|
| **nexus-12v7c** (P2) | `_voyage_instance` in `scoring.py` | **Eliminated** via top-down DI through `T3Database._voyage_client` |
| **nexus-sl69o** (P3) | `_plan_cache_instance` in `mcp_infra.py` | **Encapsulated** as `PlanCacheRegistry` (single named singleton replacing 5 module-level names); strict DI deferred — see honesty note below |

## nexus-12v7c — eliminate `_voyage_instance` (commit `13d1f778`)

**Surprise from prior-art search**: `T3Database._voyage_client` is already an instance attribute (`src/nexus/db/t3.py:324`, `:333`). The cloud-mode T3 path has been using top-down DI for the Voyage client all along. `scoring._voyage_instance` was an orphan that constructed a SECOND `voyageai.Client` in parallel.

The elimination isn't "introduce top-down DI" — it's "stop the duplicate construction and use the T3 one that's already in scope at the call site."

Changes:
- `src/nexus/scoring.py`: delete `_voyage_instance`, `_voyage_lock`, `_voyage_client()`, `_reset_voyage_client()`. Add `t3` keyword parameter to `rerank_results()` and `_rerank_cloud()`. Cloud mode reads `t3._voyage_client`; missing/None t3 logs `rerank_skipped_no_voyage_client` and returns input order (degraded).
- `src/nexus/commands/search_cmd.py`: single production caller passes `t3=db` (already in scope).
- Tests migrated to the `t3._voyage_client = mock` stub pattern already used by 5+ existing tests.
- Deleted two singleton-specific tests in `test_voyage_retry.py` (covered by existing T3-attribute tests).

## nexus-sl69o — encapsulate `_plan_cache_instance` (commit `5212bf41`)

### Honest scoping deviation

Original design proposed **PlanCacheRegistry on the MCP server instance** mirroring the #872 HookRegistry DI pattern. On implementation that turned out to be wrong: nexus's MCP handlers are top-level functions registered with FastMCP, not methods on a server class, so there's no server-instance to attach the registry to via constructor injection.

For HookRegistry the analog held because `HookRegistry()` is cheap; every call site constructs fresh. Plan cache can't do that — populating the cache (embedding PlanLibrary rows) is expensive; that amortization across MCP tool calls IS why the cache exists.

User confirmed scope reduction during implementation: ship **encapsulation now**; defer strict DI to a separate bead requiring the MCP-handler-class restructure.

### What this commit ships

The five module-level names in `mcp_infra` (`_plan_cache_instance`, `_plan_cache_lock`, `_plan_cache_populated`, `_plan_cache_mtime`, `_PLAN_CACHE_UNAVAILABLE` sentinel) collapse into a single `PlanCacheRegistry` class held as one module-level singleton.

Wins:
- **One named singleton** instead of five
- Cache state cohesive in a class with proper methods (`get`, `clear`)
- Test substitution via `reset_plan_cache_registry_for_tests` (same shape, cleaner internals)
- The nexus-qgjr mtime-guarded refresh contract preserved as `PlanCacheRegistry.get`'s populate-when-stale logic
- `_UNAVAILABLE` sentinel scoped to the registry module rather than bleeding into `mcp_infra`'s namespace

### Limitations (documented in the registry module docstring)

- Still a module-level singleton; not DI in the strict sense
- The cache MUST be process-scoped (amortization is its purpose); no way around that in nexus's current MCP architecture
- Strict elimination requires restructuring MCP handlers into a class — file a follow-on bead if pursued

### Public API preservation

- `get_t1_plan_cache(populate_from=None)`: unchanged signature/semantics; delegates to `get_plan_cache_registry().get(...)`
- `reset_plan_cache_for_tests()`: unchanged; delegates to `reset_plan_cache_registry_for_tests()`

Callers in `mcp/core.py:3466` and `:3807` unchanged. Tests using these unchanged.

## Verification

- **Full unit suite after bead 1**: 7255 passed, 34 skipped, 0 failed (~9m)
- **Full unit suite after bead 2**: 7255 passed, 34 skipped, 0 failed (~9.5m)
- **Plan-cache touched tests** (5 files, 125 tests): all pass
- `grep -rn _voyage_instance src/nexus/`: zero hits
- `grep -rn _plan_cache_instance src/nexus/`: zero hits outside the new registry module
- `grep -rn _PLAN_CACHE_UNAVAILABLE src/nexus/ tests/`: zero hits
- Em-dash audit clean in new prose

## Closes

Closes nexus-12v7c
Closes nexus-sl69o

## Design

T2: `nx memory get nexus/design-singleton-elimination-voyage-and-plan-cache.md`

## Test plan

- [ ] CI green (with the recent uv-cache fix from PR #879, this should benefit from cache hit on `uv.lock` unchanged)
- [ ] Visual review of `PlanCacheRegistry` honesty notes in `src/nexus/mcp/plan_cache_registry.py` module docstring
- [ ] Confirm zero orphan references to old singleton names