### PR TITLE
fix(test): pin is_local_mode in test_rerank_retries_then_degrades — main-red after #881

### DIFF
--- a/tests/test_voyage_retry.py
+++ b/tests/test_voyage_retry.py
@@ -311,7 +311,14 @@ def test_rerank_retries_then_degrades() -> None:
     mock_client.rerank.side_effect = _ve.APIConnectionError("persistent")
     stub_t3 = MagicMock()
     stub_t3._voyage_client = mock_client
-    with patch("nexus.retry.time.sleep"):
+    # Pin cloud mode: on CI without a .env, is_local_mode() defaults to
+    # True and rerank_results dispatches to the ONNX local path instead
+    # of the cloud path under test. The migrated test (nexus-12v7c)
+    # surfaced this CI-specific vulnerability that the prior test
+    # masked via patch("nexus.config.get_credential", ...) (which
+    # happened to short-circuit is_local_mode's credential check).
+    with patch("nexus.config.is_local_mode", return_value=False), \
+         patch("nexus.retry.time.sleep"):
         returned = scoring.rerank_results(results, "query", top_k=1, t3=stub_t3)
     assert mock_client.rerank.call_count == 3
     assert returned == results


### PR DESCRIPTION
## Summary

PR #881 (singleton elimination) auto-merged with both Py3.12 and Py3.13 CI red. This fix-forward unbreaks main.

## Root cause

My migrated `test_rerank_retries_then_degrades` didn't patch `is_local_mode`. On CI runners (no `.env`, no `VOYAGE_API_KEY`) `is_local_mode()` returns True and `rerank_results` dispatches to the ONNX local path instead of the cloud path under test. `mock_client.rerank` is never invoked; `call_count` stays at 0 instead of the asserted 3.

The pre-migration test (deleted in #881) happened to mask this via its `patch("nexus.config.get_credential", return_value="test-key")` which short-circuited the credential check inside `is_local_mode` and forced cloud-mode dispatch. My migration removed the credential patch (no longer needed for the t3-attribute pattern) and incidentally removed the mode-pinning side effect.

## Fix

Add `patch("nexus.config.is_local_mode", return_value=False)` to the test's context. Minimum diff. No production code change.

## Verification

- `uv run pytest tests/test_voyage_retry.py::test_rerank_retries_then_degrades` passes locally (cloud-mode env)
- `NX_LOCAL=1 uv run pytest ...` passes (simulated CI no-key env via env override)

## Lessons (separate from this PR, worth documenting)

1. **Local test pass did NOT predict CI pass.** My darwin environment has Voyage + Chroma credentials; CI does not. Migrating cloud-path tests requires an explicit `is_local_mode=False` pin.
2. **Auto-merge fired despite both CI checks failing.** mergeStateStatus was UNKNOWN at the time auto-merge resolved. Same silent-fire pattern as the earlier #875 case. Branch protection should not have allowed this. Separately tracked.