### PR TITLE
fix: code-review follow-ups from PR #881 (Critical wrong-path test + Significant populate suppression + degradation coverage)

### DIFF
--- a/src/nexus/mcp/plan_cache_registry.py
+++ b/src/nexus/mcp/plan_cache_registry.py
@@ -137,9 +137,24 @@ class PlanCacheRegistry:
                     or (current_mtime > 0.0 and current_mtime > self._mtime)
                 )
                 if stale:
+                    # Only mark populated/mtime on success. Pre-refactor
+                    # code used `try/finally` which permanently suppressed
+                    # populate failures (a transient network blip during
+                    # plan-embedding would set `_populated = True` and
+                    # `_mtime = current_mtime`, so the next call saw
+                    # stale=False and never retried). The fix keeps the
+                    # cache instance available (we don't reset
+                    # `self._cache`) but leaves `_populated` / `_mtime`
+                    # unchanged so the next call retries the populate.
                     try:
                         self._cache.populate(populate_from)
-                    finally:
+                    except Exception:
+                        _log.warning(
+                            "plan_cache_populate_failed",
+                            library=str(populate_from),
+                            exc_info=True,
+                        )
+                    else:
                         self._populated = True
                         self._mtime = current_mtime
         return self._cache

--- a/tests/test_plan_cache_mtime_invalidation.py
+++ b/tests/test_plan_cache_mtime_invalidation.py
@@ -175,3 +175,41 @@ def test_missing_path_attr_falls_back_safely(tmp_path: Path) -> None:
     # Without a path → no mtime tracking → behaves like the legacy
     # populate-once contract. Acceptable fallback.
     assert fake_cache.populate.call_count == 1
+
+
+def test_populate_failure_does_not_suppress_retry(tmp_path: Path) -> None:
+    """Transient populate failure must NOT permanently mark the cache populated.
+
+    Regression test for code-review finding 2 on PR #881: the pre-
+    refactor try/finally suppressed populate exceptions while still
+    setting _populated=True and _mtime=current_mtime, so the NEXT call
+    saw stale=False and never retried. A network blip during the
+    first populate became permanent for the server process lifetime.
+
+    The fix (plan_cache_registry.PlanCacheRegistry.get) only updates
+    state on success; failures log and leave _populated/_mtime
+    unchanged so the next call retries.
+    """
+    from nexus.db.t2.plan_library import PlanLibrary
+    from nexus.mcp_infra import get_t1_plan_cache
+
+    db_path = tmp_path / "plans.sqlite"
+    lib = PlanLibrary(path=db_path)
+
+    fake_cache = MagicMock()
+    fake_cache.populate.side_effect = [RuntimeError("transient"), 0]
+    with patch("nexus.mcp_infra.get_t1", return_value=_stub_t1()), \
+         patch("nexus.plans.session_cache.PlanSessionCache",
+               return_value=fake_cache):
+        # First call: populate raises; cache returned anyway (instance
+        # still valid, only the populate failed). _populated/_mtime
+        # must remain unset so next call retries.
+        get_t1_plan_cache(populate_from=lib)
+        # Second call: populate succeeds; same library, same mtime,
+        # but stale=True because _populated never got set.
+        get_t1_plan_cache(populate_from=lib)
+
+    assert fake_cache.populate.call_count == 2, (
+        f"expected retry on the second call after first failure, "
+        f"got {fake_cache.populate.call_count}"
+    )

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -75,13 +75,41 @@ def test_rerank_empty():
 
 
 @pytest.mark.parametrize("exc", [Exception("API error"), RuntimeError("timeout")])
-def test_rerank_degrades_on_error(exc):
+def test_rerank_degrades_on_error(exc, cloud_mode):
+    """Cloud reranker degrades to input order when the Voyage call raises.
+
+    Uses the ``cloud_mode`` fixture (tests/conftest.py:250) to pin
+    is_local_mode=False. Without that pin, CI runners with no .env
+    fall into the ONNX local path and never call mock_client.rerank;
+    the assertion on len(results) alone passes for the wrong reason.
+    The ``assert mock_client.rerank.called`` check below is the
+    boundary-spanning probe that catches the wrong-path regression.
+    """
     mock_client = MagicMock()
     mock_client.rerank.side_effect = exc
     stub_t3 = MagicMock()
     stub_t3._voyage_client = mock_client
     results = rerank_results([_r()], "query", top_k=1, t3=stub_t3)
     assert len(results) == 1
+    assert mock_client.rerank.called, (
+        "mock_client.rerank was not called; the cloud rerank path did "
+        "not run. Likely cause: is_local_mode is not pinned and the "
+        "ONNX local fallback ran instead. See "
+        "feedback_pin_local_mode_in_cloud_tests.md."
+    )
+
+
+def test_rerank_cloud_mode_no_t3_degrades(cloud_mode):
+    """Cloud path with t3=None degrades to input order with a warning log.
+
+    Documents the intentional behavior change from the _voyage_instance
+    elimination (nexus-12v7c): rerank_results no longer constructs a
+    Voyage client itself. Cloud-mode callers must pass t3; missing t3
+    is not an exception path but a degraded-pass-through.
+    """
+    results = [_r(), _r(), _r()]
+    out = rerank_results(results, "query", top_k=2, t3=None)
+    assert out == results[:2]
 
 
 # ── round_robin_interleave ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Post-merge code review on PR #881 (`/nx:review-code` 2026-05-20, rigour-focused relay) surfaced three findings. All three addressed here.

## Finding 1 (Critical): `test_rerank_degrades_on_error` covered the wrong path

Confirmed empirically. Under `NX_LOCAL=1` (simulated CI): the test passed with `mock_client.rerank.call_count == 0`. `is_local_mode()` returns True without pinned credentials → `rerank_results` dispatches to `_rerank_local` → ONNX raises (no model on CI) → except returns `results[:top_n]` → `len(results) == 1` passes for the wrong reason.

**This is worse than the #881 CI red on `test_rerank_retries_then_degrades`**: that one had a strong assertion (`call_count == 3`) and surfaced as a red check. This one had a weak assertion (`len == 1`) and would have silently covered **nothing forever**.

Fix:
- Add `cloud_mode` fixture (existing at `tests/conftest.py:250`)
- Add `assert mock_client.rerank.called` as a boundary probe that catches wrong-path regressions explicitly

## Finding 2 (Significant): populate failure permanently suppressed

`PlanCacheRegistry.get` used `try`/`finally` that set `_populated=True` and `_mtime=current_mtime` even when `populate` raised. A transient network blip during PlanLibrary embedding would become permanent — next call saw `stale=False` and never retried.

Not a regression introduced by the encapsulation refactor (same behavior in the pre-refactor `mcp_infra.py`), but the fix is clean now that the logic lives in a class method.

Fix:
- Change `try`/`finally` to `try`/`except`: only set `_populated`/`_mtime` on success; log + leave state unchanged on exception so next call retries
- Add `test_populate_failure_does_not_suppress_retry` as the regression test

## Finding 3 (Significant): no test for `t3=None` degradation

The `_voyage_instance` elimination (nexus-12v7c) introduced a new graceful-degradation path: cloud mode + `t3=None` returns input order with a warning log rather than raising. Documented in the docstring but no test asserted it.

Fix:
- Add `test_rerank_cloud_mode_no_t3_degrades`

## Verification

- 60 plan-cache + scoring tests pass
- **Full pytest: 7257 passed, 34 skipped, 0 failed** (8m37s; 2 new tests added)
- `NX_LOCAL=1 uv run pytest tests/test_scoring.py`: still passes (cloud_mode fixture pins `is_local_mode=False` under simulated CI)
- Em-dash audit clean in new prose

## Branch protection note

This is the **first PR gated by the new branch protection** (`pytest 3.12` + `pytest 3.13` required, enabled 2026-05-20 after the #881 silent-merge incident). If CI fails, the merge will block — no more silent fires.

## Process provenance

- Code review dispatched via `/nx:review-code` with rigour-focused relay naming suspect categories per `feedback_review_prompt_rigour.md` (avoid friendly reviews that miss boundary defects)
- Memory entry `feedback_pin_local_mode_in_cloud_tests.md` already saved earlier this session (the #881 red was the first instance of the same class)
- T2: T1 scratch entry from the review agent linked at `d43c1b7b-125c-46f5-aedf-c8477423a4d7`