### PR TITLE
fix(indexer): PDF staleness uses cache + restore doc_id-keyed misclass prune (nexus-7kf7)

### DIFF
--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -1251,6 +1251,7 @@ def _index_pdf_file(
     embed_fn: Callable | None = None,
     stage_timers: "StageTimers | None" = None,
     doc_id_resolver: Callable[[Path], str] | None = None,
+    staleness_cache: "StalenessCache | None" = None,
     hooks: "HookRegistry | None" = None,
 ) -> int:
     """Index a single PDF file into the docs__ collection.
@@ -1288,6 +1289,7 @@ def _index_pdf_file(
     if not force and check_staleness(
         col, file, content_hash_hex, target_model,
         doc_id=catalog_doc_id_for_staleness,
+        cache=staleness_cache,
     ):
         return 0
 
@@ -1619,22 +1621,35 @@ def _prune_misclassified_in_collection(
                     count=len(present_ids),
                     doc_id_batch_size=len(batch_ids),
                 )
-    else:
-        # Legacy where-filter path: kept for catalog-absent callers
-        # (correct only for pre-Phase-3 chunks). For Phase-3 chunks
-        # this returns nothing because the where keys are gone.
+    # Legacy where-filter path: complements the manifest-chash path
+    # above. The manifest path catches Phase-3+ chunks (chroma natural-id
+    # == chash[:32], no doc_id in metadata). The where={"doc_id"} path
+    # catches Phase-2 chunks (doc_id in metadata, arbitrary chroma id)
+    # AND any chunk seeded with explicit doc_id metadata (e.g. the
+    # migration test that injects a misclassified chunk with the README
+    # tumbler as doc_id but an arbitrary string id). Catalog-absent
+    # callers (catalog is None) reach this via the doc_ids list still
+    # being populated. For Phase-3 chunks with no doc_id metadata the
+    # where-filter is a no-op (returns nothing), so running it alongside
+    # the manifest path is safe.
+    if doc_ids:
         for i in range(0, len(doc_ids), _CHROMA_PAGE_SIZE):
             batch = doc_ids[i : i + _CHROMA_PAGE_SIZE]
             if not batch:
                 continue
-            existing = _paginated_get(
-                col, include=[], where={"doc_id": {"$in": batch}},
-            )
+            try:
+                existing = _paginated_get(
+                    col, include=[], where={"doc_id": {"$in": batch}},
+                )
+            except Exception:
+                # Some Chroma deployments reject ``$in`` on absent keys;
+                # treat as empty result.
+                continue
             if existing["ids"]:
                 _batched_delete(col, existing["ids"])
                 pruned += len(existing["ids"])
                 _log.debug(
-                    f"pruned misclassified chunks from {kind} collection",
+                    f"pruned misclassified chunks from {kind} collection (doc_id-keyed)",
                     count=len(existing["ids"]),
                     doc_id_batch_size=len(batch),
                 )
@@ -2366,6 +2381,7 @@ def _run_index(
             embed_fn=_embed_fn,
             stage_timers=timers,
             doc_id_resolver=_doc_id_resolver,
+            staleness_cache=docs_staleness,
             hooks=hooks,
         )
         if on_file:


### PR DESCRIPTION
## Summary

Two independent bugs in `src/nexus/indexer.py`, both surfaced by the RDR-108 Phase 3 schema change (chunks no longer carry `doc_id` in metadata; catalog manifest is authoritative for doc-to-chunk membership). Both caused integration-test failures in `tests/test_indexer_e2e.py` that the bead `nexus-7kf7` had previously mis-diagnosed as RDR-109 Phase 2 dispatch fallout. Real root cause is unrelated; bead description's count direction was also inverted (actual: 7 → 6, not 6 → 7).

## Bug 1: `test_smart_index_staleness_check` (re-index silently deleted a chunk)

`_index_pdf_file` at `indexer.py:1288` called `check_staleness` without the `cache=` kwarg. That took the Chroma-roundtrip `content_hash`-query path (`indexer_utils.py:444`). On run 2 that query found the matching chunk and returned True; early `return 0` skipped the `manifest_write_batch_hook` for the PDF document.

Then `_prune_deleted_files` at `indexer.py:1744` saw a T3 chunk whose `chunk_text_hash[:32]` wasn't in `catalog.chashes_for_collection(...)` and classified it as orphan, deleting it. Docs collection dropped 7 → 6.

**Asymmetry**: `prose_indexer.py:56` and `code_indexer.py` both pass `cache=staleness_cache`. PDF was the only file-indexer not taking it. The resulting Chroma-roundtrip short-circuit + skipped manifest hook is the silent-data-loss path on PDF re-index.

**Fix**: thread `staleness_cache` through `_index_pdf_file` signature and its orchestrator call site.

## Bug 2: `test_migration_moves_prose_from_code_to_docs` (seed chunk not pruned)

`_prune_misclassified_in_collection` at `indexer.py:1520`, when catalog is present (line 1556 branch), used ONLY the manifest-chash deletion path. The catalog-absent `else` branch (line 1624) still had the legacy `where={"doc_id": {"$in": batch}}` path, but it never ran when a catalog was supplied.

The test's seed chunk has id `fake-prose-in-code` (not a chash) and `doc_id=readme_tumbler` in metadata. Neither id-keyed nor source-path-keyed lookup caught it.

**Regression introduced by commit `37de6d9e`** (nexus-7zcv, PR #641): the catalog-present branch REPLACED the `where={"doc_id"}` filter with the manifest-chash path instead of running BOTH paths in complement.

**Fix**: change `else` → unconditional `if doc_ids:` block so the legacy where-filter path runs alongside the manifest-chash path. For Phase-3 chunks with no doc_id metadata, the where-filter is a no-op (returns nothing), so running both is safe and idempotent.

## Verification

- `tests/test_indexer_e2e.py::test_smart_index_staleness_check` **PASS**
- `tests/test_indexer_e2e.py::test_migration_moves_prose_from_code_to_docs` **PASS**
- `tests/test_indexer_e2e.py` (full, 29 tests with `-m "integration or not integration"`) **PASS**
- `uv run pytest` (full unit suite) **7257 passed, 34 skipped, 0 failed** (9m36s)
- No regressions in `tests/test_pdf_indexer_doc_id.py`

## Closes / follow-on

- **Closes nexus-7kf7** (RDR-109 Phase 2 fallout — now correctly diagnosed as RDR-108 Phase 3 fallout via two indexer asymmetries)
- **Follow-on**: filed `nexus-f3tyz` (P3 bug) for the macOS symlink `ValueError` in `_catalog_hook` at `indexer.py:769` that silently skips `_run_housekeeping` on every macOS dev/test run. Out-of-scope for this fix; minimum-diff kept.

## Provenance

- `/nx:debug` dispatched 2026-05-20 (debugger agent)
- Prior bead investigation 2026-05-11 had correctly disproved the RDR-109 Phase 2 hypothesis; this PR resolves the real root cause
- T3 finding: `debug-indexer-pdf-staleness-manifest-orphan-and-prune-misclassified-doc-id-fallback-nexus-7kf7`

## Test plan

- [x] Both targeted tests pass locally
- [x] Full unit suite passes (7257)
- [ ] CI green on this branch (gated by the branch protection enabled earlier this session)