### PR TITLE
feat(nexus-mzvwa.1): RDR-121 routing-hook framework

### DIFF
--- a/nx/hooks/scripts/routing/README.md
+++ b/nx/hooks/scripts/routing/README.md
@@ -1,0 +1,101 @@
+# Routing Hooks (RDR-121)
+
+PreToolUse hooks that enforce soft guidance Hal repeatedly types as
+feedback. Each hook is a Python-native script that imports ``_lib`` and
+either allows the tool call to proceed or denies it with a redirect
+message naming the preferred invocation.
+
+## Contract
+
+Every hook in this directory MUST honor:
+
+1. **Python-native**. Shebang ``#!/usr/bin/env python3``. One process
+   per hook invocation. No nested bash + python3 stacks; the per-call
+   startup budget is ~40ms and a nested shell doubles it.
+2. **JSON envelope on stdout, exit 0**. Never exit 2. The envelope shape
+   is fixed by Claude Code's PreToolUse contract:
+
+       {"hookSpecificOutput": {
+           "hookEventName": "PreToolUse",
+           "permissionDecision": "allow" | "deny",
+           "reason": "..."              # deny only
+           "additionalContext": "..."   # optional advisory text on allow
+       }}
+
+3. **Per-hook budget**: <50ms p95 (40ms python startup + ~10ms logic).
+4. **Cumulative budget**: <300ms p95 with the cap of 4 active routing
+   hooks per matcher. Bumping the cap requires a follow-on bead and a
+   budget revision in RDR-121.
+5. **Fail-open by default**; opt in to fail-closed via
+   ``run_hook(..., fail_closed=True, rule_name="...")`` AND
+   ``fail_closed: true`` in ``registry.yaml`` for that rule.
+6. **Tool-name short-circuit** at the top of the hook. If the call is
+   not for the matcher target, ``allow()`` immediately.
+7. **Honor the escape token** ``# routing-allow: <reason>=8 chars>`` on
+   every hook. Hard blocks with no escape produce hook fatigue and were
+   rejected in RDR-121 Alternative 3.
+
+## Authoring template
+
+    #!/usr/bin/env python3
+    # SPDX-License-Identifier: AGPL-3.0-or-later
+    """One-line rationale: what this hook routes and why."""
+    from __future__ import annotations
+
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(__file__))
+    import _lib
+
+    RULE_NAME = "this_rules_name"
+
+
+    def body(payload):
+        command = _lib.get_bash_command(payload)
+        if not command:
+            _lib.allow()
+        if _lib.should_skip_for_reason(command):
+            _lib.log_routing_event(
+                rule=RULE_NAME, outcome="escape", tool_name="Bash",
+                command_fragment=command,
+            )
+            _lib.allow()
+        # Rule-specific matching here.
+        if _matches(command):
+            _lib.log_routing_event(
+                rule=RULE_NAME, outcome="deny", tool_name="Bash",
+                command_fragment=command,
+            )
+            _lib.deny(
+                "Redirect message naming the preferred invocation. "
+                "Escape with `# routing-allow: <reason>` (>=8 chars)."
+            )
+        _lib.allow()
+
+
+    if __name__ == "__main__":
+        _lib.run_hook(body, fail_closed=False, rule_name=RULE_NAME)
+
+## Registry
+
+``registry.yaml`` is the authoritative list of active rules. The shape
+is documented inline in that file. Hooks may read their own entry at
+runtime, but the file is also the source for documentation, telemetry
+aggregation, and the 30-day soak review (RDR-121 §Phase 4).
+
+## Testing
+
+Every hook gets a test module under ``tests/`` that exercises:
+
+* **Positive**: an offending command produces ``deny`` with the expected
+  redirect message.
+* **Negative**: a non-offending command (or a non-matcher tool call)
+  produces ``allow``.
+* **Escape**: an offending command with a valid ``# routing-allow:``
+  token produces ``allow``.
+* **Malformed input**: empty stdin or non-JSON produces ``allow`` (or
+  ``deny`` for fail-closed rules).
+
+See ``tests/test_routing_hooks.py`` for the framework-level contract
+tests.

--- a/nx/hooks/scripts/routing/_lib.py
+++ b/nx/hooks/scripts/routing/_lib.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 routing-hook framework.
+
+Helpers every routing hook imports. The hook protocol is:
+
+* Read JSON from stdin (the Claude Code PreToolUse payload).
+* Print exactly one JSON envelope to stdout.
+* Exit 0 on every code path including unexpected exceptions.
+
+Decision envelope shape (PreToolUse):
+
+    {"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow" | "deny",
+        "reason": "..."                 # only on deny
+        "additionalContext": "..."      # only on allow with context
+    }}
+
+Fail-open is the default. Hooks opt in to fail-closed by passing
+``fail_closed=True`` to ``run_hook``; the registry.yaml ``fail_closed:
+true`` flag is the source of truth and the hook script reads its own
+rule entry to decide.
+
+Escape token: a command may include ``# routing-allow: <reason>``
+(reason >= 8 characters) to bypass any routing hook. The token is
+audited in the telemetry log so over-use is visible.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import pathlib
+import re
+import sys
+from typing import Any, Callable
+
+ESCAPE_TOKEN = "# routing-allow:"
+ESCAPE_REASON_MIN_LENGTH = 8
+
+_DEFAULT_LOG_PATH = pathlib.Path.home() / ".config" / "nexus" / "routing_log.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Envelope builders (pure — return JSON strings)
+# ---------------------------------------------------------------------------
+
+
+def allow_envelope(context: str = "") -> str:
+    """Return an allow envelope as a JSON string."""
+    payload: dict[str, Any] = {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+    }
+    if context:
+        payload["additionalContext"] = context
+    return json.dumps({"hookSpecificOutput": payload})
+
+
+def deny_envelope(reason: str) -> str:
+    """Return a deny envelope as a JSON string."""
+    payload = {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "reason": reason,
+    }
+    return json.dumps({"hookSpecificOutput": payload})
+
+
+def warn_envelope(message: str) -> str:
+    """Semantic alias for ``allow_envelope`` that signals advisory intent.
+
+    Routing hooks emit warnings when a pattern looks suspicious but the
+    command should proceed. The permission decision stays ``allow``;
+    the message rides in ``additionalContext`` so the user sees it.
+    """
+    return allow_envelope(message)
+
+
+# ---------------------------------------------------------------------------
+# Stdout writers (impure — print then exit 0)
+# ---------------------------------------------------------------------------
+
+
+def allow(context: str = "") -> None:
+    """Emit allow envelope to stdout and ``exit 0``."""
+    sys.stdout.write(allow_envelope(context) + "\n")
+    sys.stdout.flush()
+    sys.exit(0)
+
+
+def deny(reason: str) -> None:
+    """Emit deny envelope to stdout and ``exit 0`` (never exit 2)."""
+    sys.stdout.write(deny_envelope(reason) + "\n")
+    sys.stdout.flush()
+    sys.exit(0)
+
+
+def warn(message: str) -> None:
+    """Emit warn envelope (allow + additionalContext) and ``exit 0``."""
+    sys.stdout.write(warn_envelope(message) + "\n")
+    sys.stdout.flush()
+    sys.exit(0)
+
+
+# ---------------------------------------------------------------------------
+# Input parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_stdin(raw: str) -> dict[str, Any]:
+    """Parse the Claude Code hook payload; return ``{}`` on any failure."""
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def get_bash_command(payload: dict[str, Any]) -> str:
+    """Extract the Bash ``command`` field; ``""`` if not a Bash call."""
+    if payload.get("tool_name") != "Bash":
+        return ""
+    tool_input = payload.get("tool_input") or {}
+    cmd = tool_input.get("command") if isinstance(tool_input, dict) else ""
+    return cmd if isinstance(cmd, str) else ""
+
+
+# ---------------------------------------------------------------------------
+# Escape token
+# ---------------------------------------------------------------------------
+
+_ESCAPE_RE = re.compile(
+    r"#\s*routing-allow\s*:\s*(?P<reason>.+?)\s*$",
+    re.MULTILINE,
+)
+
+
+def should_skip_for_reason(command: str) -> bool:
+    """Return True iff ``command`` carries a valid ``# routing-allow:`` escape.
+
+    Valid means: token present and the trailing reason text is at least
+    ``ESCAPE_REASON_MIN_LENGTH`` characters after stripping whitespace.
+    """
+    if not command or ESCAPE_TOKEN not in command:
+        return False
+    match = _ESCAPE_RE.search(command)
+    if not match:
+        return False
+    reason = match.group("reason").strip()
+    return len(reason) >= ESCAPE_REASON_MIN_LENGTH
+
+
+# ---------------------------------------------------------------------------
+# Telemetry
+# ---------------------------------------------------------------------------
+
+
+def _log_path() -> pathlib.Path:
+    override = os.environ.get("NX_ROUTING_LOG_PATH")
+    return pathlib.Path(override) if override else _DEFAULT_LOG_PATH
+
+
+def log_routing_event(
+    rule: str,
+    outcome: str,
+    *,
+    tool_name: str = "",
+    command_fragment: str = "",
+) -> None:
+    """Append one JSON line to the routing log. Never raises."""
+    try:
+        path = _log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+            "rule": rule,
+            "outcome": outcome,
+        }
+        if tool_name:
+            record["tool_name"] = tool_name
+        if command_fragment:
+            # Cap fragment length so the log stays small.
+            record["command_fragment"] = command_fragment[:200]
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+    except Exception:
+        # Telemetry must never crash a hook. Swallow.
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Top-level runner — wraps every hook entry point
+# ---------------------------------------------------------------------------
+
+
+def run_hook(
+    body: Callable[[dict[str, Any]], None],
+    *,
+    fail_closed: bool = False,
+    rule_name: str = "",
+) -> None:
+    """Execute ``body(payload)`` under the fail-open / fail-closed contract.
+
+    ``body`` is responsible for calling ``allow()`` / ``deny()`` /
+    ``warn()`` itself; those calls ``sys.exit(0)``. If ``body`` returns
+    normally without emitting an envelope, we fall through to a default
+    allow. If ``body`` raises ``SystemExit`` (from our own emitters), we
+    re-raise — that is the normal path. Any other exception triggers
+    the fail-open / fail-closed branch.
+    """
+    raw = ""
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        raw = ""
+
+    payload = parse_stdin(raw)
+
+    try:
+        body(payload)
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001
+        if fail_closed:
+            log_routing_event(
+                rule=rule_name or "unknown",
+                outcome="deny_fail_closed",
+                tool_name=payload.get("tool_name", "") or "",
+            )
+            deny(f"cannot verify, fail-closed: {exc}")
+        else:
+            log_routing_event(
+                rule=rule_name or "unknown",
+                outcome="allow_fail_open",
+                tool_name=payload.get("tool_name", "") or "",
+            )
+            allow()
+
+    # Body returned without emitting — default allow.
+    allow()

--- a/nx/hooks/scripts/routing/registry.yaml
+++ b/nx/hooks/scripts/routing/registry.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# RDR-121 routing-hook registry.
+#
+# One entry per active routing hook. Hooks may read their own rule
+# entry at runtime to determine fail_closed behavior. Initially empty;
+# nexus-mzvwa.3 / .4 / .5 will populate this file with their rule
+# entries.
+#
+# Schema (per rule):
+#   rule_name:        unique snake_case identifier; matches the hook
+#                     script basename minus the .py extension
+#   hook_script:      path under nx/hooks/scripts/routing/ to the .py
+#                     entry point
+#   matcher:          Claude Code hook matcher pattern (Bash, Edit, etc.)
+#   mode:             redirect | block | warn  — semantic only; the hook
+#                     enforces with allow/deny envelopes
+#   rationale:        one-line user-facing rule statement
+#   escape_token:     normally `# routing-allow:`; included for
+#                     discoverability
+#   fail_closed:      bool; default false. true means hook crashes deny
+#                     the call rather than allow it. Reserve for safety-
+#                     critical invariants (phase-review close gate).
+#
+# Example shape (commented; not yet active):
+#
+# rules:
+#   grep_for_symbols_redirects_to_serena:
+#     hook_script: grep_for_symbols_redirects_to_serena.py
+#     matcher: Bash
+#     mode: redirect
+#     rationale: "grep on code files for identifier-shaped patterns should use Serena"
+#     escape_token: "# routing-allow:"
+#     fail_closed: false
+
+rules: {}

--- a/tests/test_routing_hooks.py
+++ b/tests/test_routing_hooks.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 Phase 1: routing-hook framework tests.
+
+Validates the contract every routing hook must honor:
+
+* JSON envelope shape on allow / deny / warn paths
+* ``exit 0`` on every path including unexpected exceptions
+* fail-closed opt-in semantics
+* ``# routing-allow: <reason>=8 chars>`` escape parsing
+* JSONL telemetry append
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).parent.parent
+LIB_PATH = PROJECT_ROOT / "nx" / "hooks" / "scripts" / "routing" / "_lib.py"
+REGISTRY_PATH = PROJECT_ROOT / "nx" / "hooks" / "scripts" / "routing" / "registry.yaml"
+README_PATH = PROJECT_ROOT / "nx" / "hooks" / "scripts" / "routing" / "README.md"
+
+
+def _load_lib():
+    spec = importlib.util.spec_from_file_location("nx_routing_lib", LIB_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Files exist
+# ---------------------------------------------------------------------------
+
+
+def test_lib_file_exists():
+    assert LIB_PATH.exists(), f"missing: {LIB_PATH}"
+
+
+def test_registry_file_exists():
+    assert REGISTRY_PATH.exists(), f"missing: {REGISTRY_PATH}"
+
+
+def test_readme_exists():
+    assert README_PATH.exists(), f"missing: {README_PATH}"
+
+
+# ---------------------------------------------------------------------------
+# JSON envelope shape — allow / deny / warn
+# ---------------------------------------------------------------------------
+
+
+def test_allow_envelope_shape():
+    lib = _load_lib()
+    env = json.loads(lib.allow_envelope())
+    assert env["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert env["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+def test_allow_envelope_with_context():
+    lib = _load_lib()
+    env = json.loads(lib.allow_envelope("extra context"))
+    assert env["hookSpecificOutput"]["additionalContext"] == "extra context"
+
+
+def test_deny_envelope_shape():
+    lib = _load_lib()
+    env = json.loads(lib.deny_envelope("blocked because"))
+    assert env["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert env["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert env["hookSpecificOutput"]["reason"] == "blocked because"
+
+
+def test_warn_envelope_is_allow():
+    lib = _load_lib()
+    env = json.loads(lib.warn_envelope("just a warning"))
+    # warn() is semantic alias for allow() — same decision, message in additionalContext
+    assert env["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert "just a warning" in env["hookSpecificOutput"]["additionalContext"]
+
+
+# ---------------------------------------------------------------------------
+# allow() / deny() emit JSON to stdout and exit 0
+# ---------------------------------------------------------------------------
+
+
+def _run_stub(body: str, stdin: str = "") -> subprocess.CompletedProcess:
+    """Run a Python stub that imports _lib and exercises a code path."""
+    stub = textwrap.dedent(
+        f"""
+        import sys
+        sys.path.insert(0, {str(LIB_PATH.parent)!r})
+        import _lib
+        {body}
+        """
+    )
+    return subprocess.run(
+        [sys.executable, "-c", stub],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_allow_exits_zero_with_json():
+    proc = _run_stub("_lib.allow()")
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+def test_deny_exits_zero_with_json():
+    proc = _run_stub("_lib.deny('because reasons')")
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert payload["hookSpecificOutput"]["reason"] == "because reasons"
+
+
+# ---------------------------------------------------------------------------
+# fail-open default / fail-closed opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_fail_open_on_exception_default():
+    """run_hook with fail_closed=False emits allow on exception, exits 0."""
+    proc = _run_stub(
+        "_lib.run_hook(lambda stdin: 1/0, fail_closed=False)",
+        stdin="{}",
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+def test_fail_closed_on_exception_denies():
+    """run_hook with fail_closed=True emits deny on exception, still exits 0."""
+    proc = _run_stub(
+        "_lib.run_hook(lambda stdin: 1/0, fail_closed=True, rule_name='test_rule')",
+        stdin="{}",
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "cannot verify" in payload["hookSpecificOutput"]["reason"]
+    assert "fail-closed" in payload["hookSpecificOutput"]["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Escape token parsing
+# ---------------------------------------------------------------------------
+
+
+def test_escape_token_recognized_with_long_reason():
+    lib = _load_lib()
+    cmd = "grep MyClass src/foo.py  # routing-allow: legitimate text search here"
+    assert lib.should_skip_for_reason(cmd) is True
+
+
+def test_escape_token_rejected_when_reason_too_short():
+    lib = _load_lib()
+    cmd = "grep MyClass src/foo.py  # routing-allow: short"
+    assert lib.should_skip_for_reason(cmd) is False
+
+
+def test_escape_token_rejected_when_absent():
+    lib = _load_lib()
+    cmd = "grep MyClass src/foo.py"
+    assert lib.should_skip_for_reason(cmd) is False
+
+
+def test_escape_token_rejected_when_no_colon_payload():
+    lib = _load_lib()
+    cmd = "grep MyClass src/foo.py  # routing-allow:"
+    assert lib.should_skip_for_reason(cmd) is False
+
+
+# ---------------------------------------------------------------------------
+# Telemetry JSONL append
+# ---------------------------------------------------------------------------
+
+
+def test_log_routing_event_appends_jsonl(tmp_path, monkeypatch):
+    log_path = tmp_path / "routing_log.jsonl"
+    monkeypatch.setenv("NX_ROUTING_LOG_PATH", str(log_path))
+    lib = _load_lib()
+    lib.log_routing_event(rule="rule_a", outcome="allow")
+    lib.log_routing_event(rule="rule_b", outcome="deny", tool_name="Bash")
+    lines = log_path.read_text().splitlines()
+    assert len(lines) == 2
+    first = json.loads(lines[0])
+    assert first["rule"] == "rule_a"
+    assert first["outcome"] == "allow"
+    assert "ts" in first
+    second = json.loads(lines[1])
+    assert second["rule"] == "rule_b"
+    assert second["outcome"] == "deny"
+    assert second["tool_name"] == "Bash"
+
+
+def test_log_routing_event_swallows_errors(tmp_path, monkeypatch):
+    """Telemetry must never crash the hook. Unwritable path = silent no-op."""
+    unwritable = tmp_path / "does-not-exist" / "log.jsonl"
+    monkeypatch.setenv("NX_ROUTING_LOG_PATH", str(unwritable))
+    lib = _load_lib()
+    # If this raises, the test fails — log helper must be defensive.
+    lib.log_routing_event(rule="x", outcome="allow")
+
+
+# ---------------------------------------------------------------------------
+# parse_stdin helper — defensive against malformed input
+# ---------------------------------------------------------------------------
+
+
+def test_parse_stdin_returns_empty_on_malformed():
+    lib = _load_lib()
+    data = lib.parse_stdin("{not valid json")
+    assert data == {}
+
+
+def test_parse_stdin_returns_dict_on_valid():
+    lib = _load_lib()
+    payload = '{"tool_name": "Bash", "tool_input": {"command": "ls"}}'
+    data = lib.parse_stdin(payload)
+    assert data["tool_name"] == "Bash"
+    assert data["tool_input"]["command"] == "ls"
+
+
+def test_parse_stdin_empty_string_is_empty_dict():
+    lib = _load_lib()
+    assert lib.parse_stdin("") == {}
+
+
+# ---------------------------------------------------------------------------
+# Registry shape (empty initially but parseable)
+# ---------------------------------------------------------------------------
+
+
+def test_registry_parses_as_yaml():
+    yaml = pytest.importorskip("yaml")
+    parsed = yaml.safe_load(REGISTRY_PATH.read_text()) or {}
+    # Registry is empty initially but must be a dict (or None -> dict).
+    assert isinstance(parsed, dict)
+
+
+# ---------------------------------------------------------------------------
+# Tool short-circuit helpers
+# ---------------------------------------------------------------------------
+
+
+def test_get_bash_command_returns_command():
+    lib = _load_lib()
+    payload = {"tool_name": "Bash", "tool_input": {"command": "git status"}}
+    assert lib.get_bash_command(payload) == "git status"
+
+
+def test_get_bash_command_empty_when_not_bash():
+    lib = _load_lib()
+    payload = {"tool_name": "Edit", "tool_input": {"command": "ignored"}}
+    assert lib.get_bash_command(payload) == ""
+
+
+def test_get_bash_command_empty_on_missing():
+    lib = _load_lib()
+    assert lib.get_bash_command({}) == ""


### PR DESCRIPTION
## Summary

RDR-121 Phase 1: the Python-native framework Phase 2 hooks build on.
Locks the cross-cutting contract:

- JSON envelope on stdout, `exit 0` on every code path (never `exit 2`)
- Fail-open by default; fail-closed opt-in via `run_hook(..., fail_closed=True)`
- `# routing-allow: <reason>` escape (reason >= 8 chars)
- JSONL telemetry append to `~/.config/nexus/routing_log.jsonl`
- Per-hook budget <50ms p95 (Python startup + light logic)

## Files

- `nx/hooks/scripts/routing/_lib.py`: envelope builders, stdin parsing, escape parser, telemetry logger, `run_hook` wrapper
- `nx/hooks/scripts/routing/registry.yaml`: empty registry with schema documented inline
- `nx/hooks/scripts/routing/README.md`: authoring template + contract
- `tests/test_routing_hooks.py`: 24 framework tests

No `nx/hooks/hooks.json` registration in this bead; registration ships per-hook in mzvwa.3/.4/.5.

## Test plan

- [x] `uv run pytest tests/test_routing_hooks.py` (24 pass)
- [x] `uv run pytest tests/test_plugin_structure.py` (588 pass, 27 skipped)
- [ ] Both CI jobs (Python 3.12 + 3.13) green

## Closes

Closes nexus-mzvwa.1

Refs: docs/rdr/rdr-121-hook-enforced-tool-routing.md, Approach Phase 1