### PR TITLE
feat(nexus-mzvwa.2 + .4): phase-review sentinel writer + fail-closed reader hook

### DIFF
--- a/nx/commands/phase-review-gate.md
+++ b/nx/commands/phase-review-gate.md
@@ -289,6 +289,15 @@ try:
 except Exception:
     pass
 
+# RDR-121 P2 co-requirement: write the PASSED sentinel that the
+# phase_review_close_requires_gate PreToolUse hook reads. Sweep dead-pid
+# sentinels as a side effect. Best-effort; never raises.
+try:
+    from nexus.phase_review_sentinel import write_sentinel
+    write_sentinel(rdr_id_label, str(phase_arg or "1"))
+except Exception:
+    pass
+
 PYEOF
 }
 

--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -116,6 +116,11 @@
             "type": "command",
             "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/routing/git_add_all_redirects_to_explicit_paths.py",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/routing/phase_review_close_requires_gate.py",
+            "timeout": 5
           }
         ]
       }

--- a/nx/hooks/scripts/routing/phase_review_close_requires_gate.py
+++ b/nx/hooks/scripts/routing/phase_review_close_requires_gate.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 Phase 2 hook 2: phase-review close requires a PASSED gate.
+
+Denies ``bd close <bead-id>`` for phase-review beads (title contains
+``phase`` or ``review``) unless a fresh PASSED sentinel exists for the
+bead's ``(rdr-id, phase)`` tuple. Fail-closed: an exception while
+verifying the gate denies the close instead of allowing it. This is
+the safety-critical instance of the framework's fail-closed opt-in;
+see ``_lib.run_hook(fail_closed=True)``.
+
+Sentinel path: ``${TMPDIR:-/tmp}/nx-phase-gate-sentinel/<claude_pid>-<rdr-id>-<phase>.json``
+
+Three checks (all must hold for ``allow``):
+  (a) sentinel file exists
+  (b) sentinel mtime is newer than the session-start time (ctime of
+      ``~/.config/nexus/t1_addr.<claude_pid>``)
+  (c) sentinel content reports ``outcome: PASSED``
+
+Escape token ``# routing-allow: <reason>=8 chars>`` allows the close to
+proceed, audited in the routing log.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+# Hook framework lives next to this script.
+sys.path.insert(0, os.path.dirname(__file__))
+import _lib  # noqa: E402
+
+RULE_NAME = "phase_review_close_requires_gate"
+
+_BD_CLOSE_RE = re.compile(
+    r"\bbd\s+(?:close|done)\s+(?P<bead_id>[A-Za-z0-9._-]+)",
+)
+_RDR_RE = re.compile(r"\brdr[-_ ]?(?P<id>\d+)\b", re.IGNORECASE)
+_PHASE_RE = re.compile(r"\bphase[\s-]?(?P<phase>\d+)\b", re.IGNORECASE)
+_P_LEAF_RE = re.compile(r"\bP(?P<phase>\d+)(?:\.\d+)*\b")
+_TRIGGER_RE = re.compile(r"\b(phase|review)\b", re.IGNORECASE)
+
+
+def _claude_pid() -> int:
+    """Resolve the active Claude PID; tests override via NX_FAKE_CLAUDE_PID."""
+    fake = os.environ.get("NX_FAKE_CLAUDE_PID")
+    if fake:
+        try:
+            return int(fake)
+        except ValueError:
+            pass
+    try:
+        from nexus.session import find_immediate_claude_pid
+
+        return find_immediate_claude_pid()
+    except Exception:
+        return os.getppid()
+
+
+def _session_start_time(claude_pid: int) -> float | None:
+    """Return ctime of the t1_addr.<pid> file, or None if unavailable."""
+    base = os.environ.get("NEXUS_CONFIG_DIR")
+    if base:
+        addr = pathlib.Path(base) / f"t1_addr.{claude_pid}"
+    else:
+        addr = pathlib.Path.home() / ".config" / "nexus" / f"t1_addr.{claude_pid}"
+    if not addr.exists():
+        return None
+    try:
+        return addr.stat().st_ctime
+    except OSError:
+        return None
+
+
+def _bd_show(bead_id: str) -> str:
+    """Return raw output of ``bd show <bead_id>``; empty string on failure."""
+    if not shutil.which("bd"):
+        return ""
+    try:
+        proc = subprocess.run(
+            ["bd", "show", bead_id],
+            capture_output=True, text=True, timeout=5,
+        )
+        return proc.stdout or ""
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+
+
+def _extract_rdr_phase(text: str) -> tuple[str | None, str | None]:
+    """Best-effort extraction of (rdr_id, phase) from bead title + description."""
+    rdr_m = _RDR_RE.search(text)
+    phase_m = _PHASE_RE.search(text) or _P_LEAF_RE.search(text)
+    rdr_id = rdr_m.group("id") if rdr_m else None
+    phase = phase_m.group("phase") if phase_m else None
+    return rdr_id, phase
+
+
+def _sentinel_path(claude_pid: int, rdr_id: str, phase: str) -> pathlib.Path:
+    base = os.environ.get("TMPDIR", "/tmp").rstrip("/")
+    return pathlib.Path(base) / "nx-phase-gate-sentinel" / f"{claude_pid}-{rdr_id}-{phase}.json"
+
+
+def _check_sentinel(
+    claude_pid: int, rdr_id: str, phase: str
+) -> tuple[bool, str]:
+    """Return (ok, reason). reason explains why the gate denied."""
+    path = _sentinel_path(claude_pid, rdr_id, phase)
+    if not path.exists():
+        return False, "sentinel absent"
+    try:
+        stat = path.stat()
+    except OSError as exc:
+        return False, f"sentinel unreadable: {exc}"
+    session_start = _session_start_time(claude_pid)
+    if session_start is not None and stat.st_mtime < session_start:
+        return False, "sentinel stale (predates current session)"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return False, f"sentinel content corrupt: {exc}"
+    outcome = payload.get("outcome") if isinstance(payload, dict) else None
+    if outcome != "PASSED":
+        return False, f"sentinel outcome != PASSED (got {outcome!r})"
+    return True, ""
+
+
+def _redirect_message(rdr_id: str | None, phase: str | None, reason: str) -> str:
+    rdr_part = rdr_id if rdr_id else "<rdr-id>"
+    phase_part = phase if phase else "N"
+    return (
+        f"Phase-review close blocked: {reason}. Run the gate first:\n"
+        f"  /nx:phase-review-gate {rdr_part} --phase {phase_part}\n"
+        f"Then re-run `bd close ...`. To override, append "
+        f"`# routing-allow: <reason>` (>=8 chars) to the command."
+    )
+
+
+def body(payload: dict[str, Any]) -> None:
+    command = _lib.get_bash_command(payload)
+    if not command:
+        _lib.allow()
+
+    match = _BD_CLOSE_RE.search(command)
+    if not match:
+        _lib.allow()
+
+    # Escape token takes precedence; audit and pass through.
+    if _lib.should_skip_for_reason(command):
+        _lib.log_routing_event(
+            rule=RULE_NAME, outcome="escape", tool_name="Bash",
+            command_fragment=command,
+        )
+        _lib.allow()
+
+    bead_id = match.group("bead_id")
+    bd_output = _bd_show(bead_id)
+    if not bd_output:
+        # Cannot determine if this is a phase-review bead. Allow rather
+        # than fail-closed; we have no signal to deny on.
+        _lib.allow()
+
+    # Trigger heuristic: title or description contains "phase" or "review".
+    if not _TRIGGER_RE.search(bd_output):
+        _lib.allow()
+
+    rdr_id, phase = _extract_rdr_phase(bd_output)
+    if not rdr_id or not phase:
+        # We know it is a phase-review bead but cannot resolve the
+        # (rdr-id, phase) tuple. Fail-closed: deny rather than guess.
+        reason = "cannot resolve (rdr-id, phase) from bead title or description"
+        _lib.log_routing_event(
+            rule=RULE_NAME, outcome="deny", tool_name="Bash",
+            command_fragment=command,
+        )
+        _lib.deny(_redirect_message(rdr_id, phase, reason))
+
+    claude_pid = _claude_pid()
+    ok, reason = _check_sentinel(claude_pid, rdr_id, phase)
+    if not ok:
+        _lib.log_routing_event(
+            rule=RULE_NAME, outcome="deny", tool_name="Bash",
+            command_fragment=command,
+        )
+        _lib.deny(_redirect_message(rdr_id, phase, reason))
+
+    _lib.log_routing_event(
+        rule=RULE_NAME, outcome="allow", tool_name="Bash",
+        command_fragment=command,
+    )
+    _lib.allow(
+        f"phase-review close approved by sentinel (RDR-{rdr_id} phase {phase})"
+    )
+
+
+if __name__ == "__main__":
+    _lib.run_hook(body, fail_closed=True, rule_name=RULE_NAME)

--- a/nx/hooks/scripts/routing/registry.yaml
+++ b/nx/hooks/scripts/routing/registry.yaml
@@ -52,3 +52,14 @@ rules:
       drafts; stage by explicit path (feedback_no_git_add_all).
     escape_token: "# routing-allow:"
     fail_closed: false
+  phase_review_close_requires_gate:
+    hook_script: phase_review_close_requires_gate.py
+    matcher: Bash
+    mode: block
+    rationale: >-
+      bd close on a phase-review bead requires a fresh PASSED
+      /nx:phase-review-gate sentinel; the cross-walk catches silent
+      scope reduction that test-validator and code-review-expert miss
+      by construction (see feedback_phase_closeout_scope_audit).
+    escape_token: "# routing-allow:"
+    fail_closed: true

--- a/nx/skills/phase-review-gate/SKILL.md
+++ b/nx/skills/phase-review-gate/SKILL.md
@@ -48,7 +48,7 @@ The preamble validates that every enumerated item has a non-empty evidence point
 
 **BLOCKED**: any item missing from --evidence, or with an empty value, causes the gate to emit BLOCKED and exit. The missing items are named explicitly.
 
-**PASSED**: all items covered. The gate emits the evidence table and a T1 scratch marker tagged `phase-review-passed,rdr-NNN,phase-N`.
+**PASSED**: all items covered. The gate emits the evidence table, a T1 scratch marker tagged `phase-review-passed,rdr-NNN,phase-N`, and a sentinel file at `${TMPDIR:-/tmp}/nx-phase-gate-sentinel/<claude_pid>-<rdr-id>-<phase>.json`. The sentinel is consumed by the `phase_review_close_requires_gate` PreToolUse routing hook (RDR-121) which fail-closed-denies a phase-review `bd close` when the sentinel is absent, stale, or non-PASSED. Dead-pid sentinels are swept on every PASSED write.
 
 ## Evidence Format
 

--- a/src/nexus/phase_review_sentinel.py
+++ b/src/nexus/phase_review_sentinel.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 phase-review-gate sentinel.
+
+The /nx:phase-review-gate command writes a sentinel file on a PASSED
+outcome. The phase_review_close_requires_gate routing hook reads the
+sentinel before allowing a phase-review bead close. Sentinel + reader
+must ship together (RDR-121 P2 hard coupling).
+
+Sentinel path: ``${TMPDIR:-/tmp}/nx-phase-gate-sentinel/<claude_pid>-<rdr-id>-<phase>.json``
+
+Sentinel JSON shape::
+
+    {
+        "outcome": "PASSED",
+        "rdr_id": "112",
+        "phase": "1",
+        "claude_pid": 12345,
+        "timestamp": "2026-05-20T10:42:00+00:00"
+    }
+
+Sweep-on-write cleanup: best-effort drop of sentinels whose claude_pid
+is no longer alive. Cheap (one kill(0) per file) and bounded (file
+count grows with phase-review pass count per session).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import pathlib
+from typing import Any
+
+
+def sentinel_dir() -> pathlib.Path:
+    """Return the directory holding sentinel files.
+
+    ``${TMPDIR:-/tmp}/nx-phase-gate-sentinel/``. Honors ``TMPDIR`` so
+    tests can redirect via ``monkeypatch.setenv("TMPDIR", str(tmp))``.
+    """
+    base = os.environ.get("TMPDIR", "/tmp").rstrip("/")
+    return pathlib.Path(base) / "nx-phase-gate-sentinel"
+
+
+def sentinel_path(claude_pid: int, rdr_id: str, phase: str) -> pathlib.Path:
+    """Return the sentinel file path for ``(claude_pid, rdr_id, phase)``."""
+    return sentinel_dir() / f"{claude_pid}-{rdr_id}-{phase}.json"
+
+
+def find_claude_pid() -> int:
+    """Resolve the nearest Claude Code ancestor PID.
+
+    Delegates to :func:`nexus.session.find_immediate_claude_pid` so the
+    sentinel keys against the same PID the T1 discovery surface uses.
+    Falls back to ``os.getppid()`` if nexus.session import fails (e.g.
+    running outside a real Claude shell during tests).
+    """
+    try:
+        from nexus.session import find_immediate_claude_pid
+
+        return find_immediate_claude_pid()
+    except Exception:
+        return os.getppid()
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True iff ``kill(pid, 0)`` succeeds."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # PermissionError means the pid exists but we cannot signal it.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def sweep_dead_sentinels() -> int:
+    """Delete sentinel files whose ``<claude_pid>`` is no longer alive.
+
+    Returns the number of files deleted. Never raises; sweep is best-
+    effort and any IO error is silently ignored.
+    """
+    deleted = 0
+    sd = sentinel_dir()
+    if not sd.exists():
+        return 0
+    for path in sd.iterdir():
+        if not path.is_file() or not path.name.endswith(".json"):
+            continue
+        pid_str = path.name.split("-", 1)[0]
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            continue
+        if not _pid_alive(pid):
+            try:
+                path.unlink()
+                deleted += 1
+            except OSError:
+                pass
+    return deleted
+
+
+def write_sentinel(rdr_id: str, phase: str, *, claude_pid: int | None = None) -> pathlib.Path:
+    """Write the PASSED sentinel and sweep dead-pid stale ones.
+
+    Returns the path written. Caller is responsible for only invoking
+    this on the PASSED branch; we do not store ``outcome`` other than
+    ``"PASSED"`` because the hook reads the file's existence + content
+    as a PASSED claim.
+    """
+    pid = claude_pid if claude_pid is not None else find_claude_pid()
+    sd = sentinel_dir()
+    sd.mkdir(parents=True, exist_ok=True)
+
+    sweep_dead_sentinels()
+
+    target = sentinel_path(pid, rdr_id, phase)
+    record: dict[str, Any] = {
+        "outcome": "PASSED",
+        "rdr_id": rdr_id,
+        "phase": phase,
+        "claude_pid": pid,
+        "timestamp": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+    }
+    target.write_text(json.dumps(record), encoding="utf-8")
+    return target
+
+
+def read_sentinel(claude_pid: int, rdr_id: str, phase: str) -> dict[str, Any] | None:
+    """Read sentinel for ``(claude_pid, rdr_id, phase)`` or return None.
+
+    Returns the parsed payload dict on success, ``None`` if the file is
+    absent, unreadable, or non-JSON.
+    """
+    path = sentinel_path(claude_pid, rdr_id, phase)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None

--- a/tests/test_phase_review_gate.py
+++ b/tests/test_phase_review_gate.py
@@ -197,6 +197,63 @@ class TestPass2Validate:
         )
         assert "BLOCKED" in out or "ERROR" in out or "empty" in out.lower()
 
+
+# ---------------------------------------------------------------------------
+# RDR-121 P2 co-requirement: PASSED writes a sentinel; BLOCKED does not.
+# ---------------------------------------------------------------------------
+
+class TestSentinelSideEffect:
+    """The PASSED path writes the sentinel the routing hook reads."""
+
+    def _run_with_tmpdir(self, args: str, *, rdr_dir, tmpdir) -> str:
+        text = COMMAND_FILE.read_text()
+        m = re.search(r"python3\s+<<\s+'PYEOF'\n(.*?)PYEOF", text, re.DOTALL)
+        assert m
+        script = m.group(1)
+        env = os.environ.copy()
+        env["NEXUS_RDR_ARGS"] = args
+        env["NEXUS_RDR_DIR_OVERRIDE"] = str(rdr_dir)
+        env["TMPDIR"] = str(tmpdir)
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True, text=True, env=env, timeout=15,
+        )
+        return (result.stdout + result.stderr).strip()
+
+    def test_passed_writes_sentinel(self, tmp_path):
+        rdr_dir = _make_minimal_rdr(tmp_path, 99, ["T2 service", "T3 service"])
+        sentinels = tmp_path / "sentinels"
+        sentinels.mkdir()
+        out = self._run_with_tmpdir(
+            "99 --phase 1 --evidence 'Item1=nexus-a,Item2=nexus-b'",
+            rdr_dir=rdr_dir, tmpdir=sentinels,
+        )
+        assert "PASSED" in out or "validation passed" in out.lower()
+        sentinel_dir = sentinels / "nx-phase-gate-sentinel"
+        assert sentinel_dir.exists(), "PASSED outcome must create sentinel dir"
+        files = list(sentinel_dir.glob("*-099-1.json"))
+        assert len(files) == 1, f"expected one sentinel for RDR-99 phase 1, got {files}"
+        import json as _json
+        payload = _json.loads(files[0].read_text())
+        assert payload["outcome"] == "PASSED"
+        assert payload["rdr_id"] == "099"
+        assert payload["phase"] == "1"
+
+    def test_blocked_does_not_write_sentinel(self, tmp_path):
+        rdr_dir = _make_minimal_rdr(tmp_path, 99, ["T2 service", "T3 service"])
+        sentinels = tmp_path / "sentinels"
+        sentinels.mkdir()
+        out = self._run_with_tmpdir(
+            "99 --phase 1 --evidence 'Item1=nexus-a'",  # Item2 missing
+            rdr_dir=rdr_dir, tmpdir=sentinels,
+        )
+        assert "BLOCKED" in out or "blocked" in out.lower()
+        sentinel_dir = sentinels / "nx-phase-gate-sentinel"
+        if sentinel_dir.exists():
+            assert not list(sentinel_dir.glob("*-099-1.json")), (
+                "BLOCKED outcome must not write a sentinel"
+            )
+
     def test_pass2_names_the_missing_item(self, tmp_path: pytest.fixture) -> None:
         """Blocked output must name which approach item is missing evidence."""
         _make_minimal_rdr(tmp_path, 99, ["T2 service", "T3 service"])

--- a/tests/test_phase_review_sentinel.py
+++ b/tests/test_phase_review_sentinel.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 P2: phase-review-gate sentinel writer + sweep.
+
+Coupled with the phase_review_close_requires_gate routing hook (nexus-mzvwa.4).
+The writer ships in this bead (mzvwa.2); the reader ships in mzvwa.4
+on the same PR.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from nexus.phase_review_sentinel import (
+    read_sentinel,
+    sentinel_dir,
+    sentinel_path,
+    sweep_dead_sentinels,
+    write_sentinel,
+)
+
+
+@pytest.fixture
+def tmp_sentinel_dir(tmp_path, monkeypatch):
+    """Redirect TMPDIR so sentinel writes land in tmp_path."""
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    return tmp_path / "nx-phase-gate-sentinel"
+
+
+def test_sentinel_dir_honors_tmpdir(tmp_sentinel_dir):
+    assert sentinel_dir() == tmp_sentinel_dir
+
+
+def test_sentinel_path_format(tmp_sentinel_dir):
+    path = sentinel_path(12345, "112", "1")
+    assert path.name == "12345-112-1.json"
+    assert path.parent == tmp_sentinel_dir
+
+
+def test_write_sentinel_creates_file_with_correct_shape(tmp_sentinel_dir):
+    path = write_sentinel("112", "1", claude_pid=99999)
+    assert path.exists()
+    payload = json.loads(path.read_text())
+    assert payload["outcome"] == "PASSED"
+    assert payload["rdr_id"] == "112"
+    assert payload["phase"] == "1"
+    assert payload["claude_pid"] == 99999
+    assert "timestamp" in payload
+
+
+def test_write_sentinel_creates_directory(tmp_sentinel_dir):
+    assert not tmp_sentinel_dir.exists()
+    write_sentinel("121", "1", claude_pid=11111)
+    assert tmp_sentinel_dir.is_dir()
+
+
+def test_read_sentinel_round_trip(tmp_sentinel_dir):
+    write_sentinel("112", "2", claude_pid=22222)
+    data = read_sentinel(22222, "112", "2")
+    assert data is not None
+    assert data["outcome"] == "PASSED"
+    assert data["rdr_id"] == "112"
+
+
+def test_read_sentinel_returns_none_when_absent(tmp_sentinel_dir):
+    assert read_sentinel(33333, "999", "9") is None
+
+
+def test_read_sentinel_returns_none_on_malformed(tmp_sentinel_dir):
+    tmp_sentinel_dir.mkdir(parents=True)
+    bad = sentinel_path(44444, "999", "9")
+    bad.write_text("not json{{{")
+    assert read_sentinel(44444, "999", "9") is None
+
+
+def test_sweep_removes_dead_pid_sentinels(tmp_sentinel_dir):
+    """Sentinel keyed on a definitely-dead PID is reaped; alive is kept."""
+    dead_pid = 999_999_999
+    tmp_sentinel_dir.mkdir(parents=True)
+    # Manually plant a dead-pid sentinel + an alive-pid sentinel, bypassing
+    # write_sentinel so its internal sweep does not pre-empt this test.
+    dead_path = sentinel_path(dead_pid, "112", "1")
+    dead_path.write_text(json.dumps({"outcome": "PASSED", "claude_pid": dead_pid}))
+    alive_path = sentinel_path(os.getpid(), "112", "2")
+    alive_path.write_text(json.dumps({"outcome": "PASSED", "claude_pid": os.getpid()}))
+
+    deleted = sweep_dead_sentinels()
+    assert deleted == 1
+    assert not dead_path.exists()
+    assert alive_path.exists()
+
+
+def test_sweep_with_no_dir_returns_zero(tmp_sentinel_dir):
+    assert not tmp_sentinel_dir.exists()
+    assert sweep_dead_sentinels() == 0
+
+
+def test_sweep_runs_on_write(tmp_sentinel_dir):
+    """write_sentinel sweeps as a side effect."""
+    dead_pid = 999_999_999
+    # Manually create a sentinel keyed on a dead PID without going through
+    # write_sentinel (so we know the first call has stale state to sweep).
+    tmp_sentinel_dir.mkdir(parents=True)
+    stale = sentinel_path(dead_pid, "old", "1")
+    stale.write_text(json.dumps({"outcome": "PASSED"}))
+
+    write_sentinel("new", "1", claude_pid=os.getpid())
+
+    assert not stale.exists(), "sweep should have removed dead-pid sentinel"
+
+
+def test_sweep_ignores_non_json_files(tmp_sentinel_dir):
+    """Files in sentinel dir that are not .json are left alone."""
+    tmp_sentinel_dir.mkdir(parents=True)
+    intruder = tmp_sentinel_dir / "README.txt"
+    intruder.write_text("not a sentinel")
+    sweep_dead_sentinels()
+    assert intruder.exists()
+
+
+def test_sweep_ignores_malformed_filenames(tmp_sentinel_dir):
+    """File whose stem does not start with an integer pid is left alone."""
+    tmp_sentinel_dir.mkdir(parents=True)
+    weird = tmp_sentinel_dir / "notapid-foo-1.json"
+    weird.write_text("{}")
+    sweep_dead_sentinels()
+    assert weird.exists()

--- a/tests/test_routing_phase_review_close.py
+++ b/tests/test_routing_phase_review_close.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 Phase 2 hook 2: phase_review_close_requires_gate.
+
+The hook denies ``bd close <bead-id>`` for phase-review beads unless a
+fresh PASSED sentinel exists for the bead's ``(rdr-id, phase)`` tuple.
+
+Five enforcement scenarios per RDR-121, Test Plan:
+
+1. Sentinel present, fresh, PASSED -> allow.
+2. Sentinel absent -> deny.
+3. Sentinel mtime older than session-start -> deny.
+4. Sentinel outcome != PASSED -> deny.
+5. Sentinel unreadable (corrupt JSON) -> deny (fail-closed).
+
+Plus contract:
+- Non-phase-review bead close -> allow (short-circuit on title).
+- Non-Bash tool -> allow.
+- Bash command without ``bd close`` -> allow.
+- ``# routing-allow: <reason>`` escape -> allow.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).parent.parent
+HOOK_SCRIPT = (
+    PROJECT_ROOT
+    / "nx"
+    / "hooks"
+    / "scripts"
+    / "routing"
+    / "phase_review_close_requires_gate.py"
+)
+
+
+@pytest.fixture
+def tmp_env(tmp_path, monkeypatch):
+    """Redirect TMPDIR, NEXUS_CONFIG_DIR, and PATH for an isolated hook run."""
+    sentinel_root = tmp_path / "sentinels"
+    config_dir = tmp_path / "nexus_config"
+    bin_dir = tmp_path / "bin"
+    sentinel_root.mkdir()
+    config_dir.mkdir()
+    bin_dir.mkdir()
+    monkeypatch.setenv("TMPDIR", str(sentinel_root))
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("NX_ROUTING_LOG_PATH", str(tmp_path / "log.jsonl"))
+    return {
+        "tmp": tmp_path,
+        "sentinel_root": sentinel_root,
+        "sentinel_dir": sentinel_root / "nx-phase-gate-sentinel",
+        "config_dir": config_dir,
+        "bin_dir": bin_dir,
+    }
+
+
+def _write_bd_stub(bin_dir: pathlib.Path, *, title: str, description: str = "") -> None:
+    """Install a fake ``bd`` on PATH that returns canned bd show output."""
+    stub = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env python3
+        import sys
+        if len(sys.argv) >= 2 and sys.argv[1] == "show":
+            print({title!r})
+            print()
+            print("DESCRIPTION")
+            print({description!r})
+            sys.exit(0)
+        sys.exit(0)
+        """
+    )
+    bd_path = bin_dir / "bd"
+    bd_path.write_text(stub)
+    bd_path.chmod(0o755)
+
+
+def _run_hook(payload: dict, env_extra: dict[str, str], bin_dir: pathlib.Path | None = None) -> subprocess.CompletedProcess:
+    """Invoke the hook with the given Claude PreToolUse payload on stdin."""
+    env = os.environ.copy()
+    env.update(env_extra)
+    if bin_dir is not None:
+        env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+    )
+    return proc
+
+
+def _decision(proc: subprocess.CompletedProcess) -> dict:
+    assert proc.returncode == 0, f"hook must exit 0; got {proc.returncode}; stderr={proc.stderr}"
+    payload = json.loads(proc.stdout)
+    return payload["hookSpecificOutput"]
+
+
+def _make_session_addr(config_dir: pathlib.Path, claude_pid: int) -> pathlib.Path:
+    """Create a t1_addr file representing a live Claude session."""
+    p = config_dir / f"t1_addr.{claude_pid}"
+    p.write_text(f"127.0.0.1:8000\n{claude_pid}")
+    return p
+
+
+def _make_sentinel(
+    sentinel_dir: pathlib.Path,
+    *,
+    claude_pid: int,
+    rdr_id: str,
+    phase: str,
+    outcome: str = "PASSED",
+    mtime: float | None = None,
+) -> pathlib.Path:
+    sentinel_dir.mkdir(parents=True, exist_ok=True)
+    p = sentinel_dir / f"{claude_pid}-{rdr_id}-{phase}.json"
+    p.write_text(json.dumps({
+        "outcome": outcome,
+        "rdr_id": rdr_id,
+        "phase": phase,
+        "claude_pid": claude_pid,
+    }))
+    if mtime is not None:
+        os.utime(p, (mtime, mtime))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Hook script exists
+# ---------------------------------------------------------------------------
+
+
+def test_hook_script_exists():
+    assert HOOK_SCRIPT.exists()
+
+
+def test_hook_script_executable_shebang():
+    assert HOOK_SCRIPT.read_text().startswith("#!/usr/bin/env python3")
+
+
+# ---------------------------------------------------------------------------
+# Short-circuit paths
+# ---------------------------------------------------------------------------
+
+
+def test_non_bash_tool_allows(tmp_env):
+    proc = _run_hook(
+        {"tool_name": "Edit", "tool_input": {"file_path": "x.py"}},
+        env_extra={},
+    )
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_bash_non_bd_command_allows(tmp_env):
+    proc = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "git status"}},
+        env_extra={},
+    )
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_bd_close_on_non_phase_review_bead_allows(tmp_env):
+    _write_bd_stub(tmp_env["bin_dir"], title="Add some feature thing")
+    proc = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "bd close nexus-xyz"}},
+        env_extra={},
+        bin_dir=tmp_env["bin_dir"],
+    )
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_escape_token_allows_even_on_phase_review_bead(tmp_env):
+    _write_bd_stub(tmp_env["bin_dir"], title="P1 phase review gate for RDR-112")
+    proc = _run_hook(
+        {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": (
+                    "bd close nexus-abc  # routing-allow: closing manually "
+                    "with explicit operator approval"
+                )
+            },
+        },
+        env_extra={},
+        bin_dir=tmp_env["bin_dir"],
+    )
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+# ---------------------------------------------------------------------------
+# Five sentinel scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_present_fresh_passed_allows(tmp_env):
+    pid = os.getpid()
+    _write_bd_stub(
+        tmp_env["bin_dir"],
+        title="RDR-112 Phase 1 review gate",
+        description="Cross-walk close for Phase 1 of RDR-112.",
+    )
+    _make_session_addr(tmp_env["config_dir"], pid)
+    # Sentinel slightly newer than addr file
+    _make_sentinel(
+        tmp_env["sentinel_dir"],
+        claude_pid=pid, rdr_id="112", phase="1",
+        outcome="PASSED",
+        mtime=time.time(),
+    )
+    proc = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "bd close nexus-abc"}},
+        env_extra={"NX_FAKE_CLAUDE_PID": str(pid)},
+        bin_dir=tmp_env["bin_dir"],
+    )
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_sentinel_absent_denies(tmp_env):
+    pid = os.getpid()
+    _write_bd_stub(
+        tmp_env["bin_dir"],
+        title="RDR-112 Phase 1 review gate",
+    )
+    _make_session_addr(tmp_env["config_dir"], pid)
+    # No sentinel written.
+    proc = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "bd close nexus-abc"}},
+        env_extra={"NX_FAKE_CLAUDE_PID": str(pid)},
+        bin_dir=tmp_env["bin_dir"],
+    )
+    decision = _decision(proc)
+    assert decision["permissionDecision"] == "deny"
+    assert "/nx:phase-review-gate" in decision["reason"]
+
+
+def test_sentinel_stale_denies(tmp_env):
+    pid = os.getpid()
+    _write_bd_stub(
+        tmp_env["bin_dir"],
+        title="RDR-112 Phase 1 review gate",
+    )
+    addr = _make_session_addr(tmp_env["config_dir"], pid)
+    # Force session ctime to NOW; sentinel mtime in the past.
+    addr_ctime = addr.stat().st_ctime
+    _make_sentinel(
+        tmp_env["sentinel_dir"],
+        claude_pid=pid, rdr_id="112", phase="1",
+        outcome="PASSED",
+        mtime=addr_ctime - 3600,  # one hour before session start
+    )
+    proc = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "bd close nexus-abc"}},
+        env_extra={"NX_FAKE_CLAUDE_PID": str(pid)},
+        bin_dir=tmp_env["bin_dir"],
+    )
+    decision = _decision(proc)
+    assert decision["permissionDecision"] == "deny"
+
+
+def test_sentinel_outcome_non_passed_denies(tmp_env):
+    pid = os.getpid()
+    _write_bd_stub(
+        tmp_env["bin_dir"],
+        title="RDR-112 Phase 1 review gate",
+    )
+    _make_session_addr(tmp_env["config_dir"], pid)
+    _make_sentinel(
+        tmp_env["sentinel_dir"],
+        claude_pid=pid, rdr_id="112", phase="1",
+        outcome="BLOCKED",
+        mtime=time.time(),
+    )
+    proc = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "bd close nexus-abc"}},
+        env_extra={"NX_FAKE_CLAUDE_PID": str(pid)},
+        bin_dir=tmp_env["bin_dir"],
+    )
+    decision = _decision(proc)
+    assert decision["permissionDecision"] == "deny"
+
+
+def test_sentinel_corrupt_json_denies(tmp_env):
+    pid = os.getpid()
+    _write_bd_stub(
+        tmp_env["bin_dir"],
+        title="RDR-112 Phase 1 review gate",
+    )
+    _make_session_addr(tmp_env["config_dir"], pid)
+    tmp_env["sentinel_dir"].mkdir(parents=True, exist_ok=True)
+    bad = tmp_env["sentinel_dir"] / f"{pid}-112-1.json"
+    bad.write_text("{not json")
+    proc = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "bd close nexus-abc"}},
+        env_extra={"NX_FAKE_CLAUDE_PID": str(pid)},
+        bin_dir=tmp_env["bin_dir"],
+    )
+    decision = _decision(proc)
+    assert decision["permissionDecision"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed contract: hook crash denies (not allows)
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_stdin_fails_closed(tmp_env):
+    """Empty / non-JSON stdin: hook should still emit valid JSON and exit 0.
+
+    For non-phase-review semantics we cannot tell what the user intended,
+    so the safe default is allow (cannot block what we cannot identify).
+    Fail-closed only kicks in once we know we are looking at a phase-
+    review close that lacks a valid sentinel.
+    """
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="",
+        capture_output=True, text=True, timeout=10,
+    )
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["hookSpecificOutput"]["permissionDecision"] in ("allow", "deny")
+
+
+# ---------------------------------------------------------------------------
+# Registry has the rule with fail_closed: true
+# ---------------------------------------------------------------------------
+
+
+def test_registry_lists_rule_with_fail_closed():
+    yaml = pytest.importorskip("yaml")
+    reg = PROJECT_ROOT / "nx" / "hooks" / "scripts" / "routing" / "registry.yaml"
+    parsed = yaml.safe_load(reg.read_text()) or {}
+    rules = parsed.get("rules") or {}
+    rule = rules.get("phase_review_close_requires_gate")
+    assert rule is not None, "rule must be registered"
+    assert rule.get("fail_closed") is True
+
+
+# ---------------------------------------------------------------------------
+# hooks.json registers the hook on Bash matcher
+# ---------------------------------------------------------------------------
+
+
+def test_hooks_json_registers_routing_hook():
+    hooks_json = PROJECT_ROOT / "nx" / "hooks" / "hooks.json"
+    data = json.loads(hooks_json.read_text())
+    bash_hooks = data["hooks"]["PreToolUse"]
+    found = False
+    for entry in bash_hooks:
+        if entry.get("matcher") != "Bash":
+            continue
+        for hook in entry.get("hooks", []):
+            if "phase_review_close_requires_gate.py" in hook.get("command", ""):
+                found = True
+    assert found, "phase_review_close_requires_gate.py must be registered"


### PR DESCRIPTION
## Summary

RDR-121 Phase 2 hook 2 plus its co-required sentinel writer. Coupled
shipment per RDR-121, Implementation Plan Prerequisites: shipping the
reader without the writer would deny every phase-review close.

Stacked on top of #888 (mzvwa.1 framework). This branch includes the
framework commit; once #888 merges, this branch should be rebased onto
main and the duplicate commit will drop out via three-way merge. If
#888 merges first, this PR auto-resolves.

## What lands

### mzvwa.2 (sentinel writer)
- `src/nexus/phase_review_sentinel.py`: `write_sentinel`, `read_sentinel`, `sweep_dead_sentinels`, `find_claude_pid`
- `nx/commands/phase-review-gate.md`: PASSED branch writes sentinel + sweeps dead-pid stale ones
- `nx/skills/phase-review-gate/SKILL.md`: documents the sentinel contract and routing-hook consumer
- 12 unit tests + 2 integration tests covering sentinel side effect on PASSED vs BLOCKED

### mzvwa.4 (fail-closed reader hook)
- `nx/hooks/scripts/routing/phase_review_close_requires_gate.py`: Python-native PreToolUse hook
- `registry.yaml`: rule entry with `fail_closed: true`
- `hooks.json`: registers hook on PreToolUse Bash matcher (additive, coexists with `pre_close_verification_hook.sh`)
- 14 hook tests covering five sentinel scenarios + short-circuit paths + escape token + registry/hooks.json wiring

### Three sentinel checks (all must hold for allow)
1. Sentinel file exists for `(claude_pid, rdr-id, phase)`
2. Sentinel mtime newer than session ctime (`~/.config/nexus/t1_addr.<pid>`)
3. Payload `outcome == "PASSED"`

Any failure: hook emits `deny` with redirect message naming the exact gate invocation `/nx:phase-review-gate <rdr-id> --phase N`. Escape via `# routing-allow: <reason>=8 chars>`.

## Test plan

- [x] `uv run pytest tests/test_phase_review_sentinel.py` (12 pass)
- [x] `uv run pytest tests/test_routing_phase_review_close.py` (14 pass)
- [x] `uv run pytest tests/test_phase_review_gate.py` (sentinel side-effect tests added; 33 pass)
- [x] `uv run pytest tests/test_plugin_structure.py` (588 pass, 27 skipped)
- [ ] CI Python 3.12 + 3.13 green

## Closes

Closes nexus-mzvwa.2
Closes nexus-mzvwa.4

Refs: docs/rdr/rdr-121-hook-enforced-tool-routing.md