### PR TITLE
feat(nexus-mzvwa.6): routing-hook telemetry + nx hook routing-stats

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1078,6 +1078,27 @@ Hooks run `nx index repo` in the background after each qualifying git operation,
 
 **Hook status values:** `not installed` · `owned` (nexus-created) · `appended` (added to existing hook) · `unmanaged` (no nexus sentinel)
 
+### nx hook routing-stats
+
+```
+nx hook routing-stats [--log-path PATH] [--json]
+```
+
+Aggregates the per-rule JSONL log written by the RDR-121 routing-hook
+framework (`nx/hooks/scripts/routing/_lib.log_routing_event`). Reports
+fire counts, deny / allow / escape outcomes, block-rate, and
+escape-rate per rule.
+
+| Flag | Description |
+|------|-------------|
+| `--log-path PATH` | Read from this path instead of the default |
+| `--json` | Emit aggregated stats as JSON instead of a table |
+
+Default log path resolves to `$NX_ROUTING_LOG_PATH`, falling back to
+`~/.config/nexus/routing_log.jsonl`. Used at the 30-day soak review
+(RDR-121 §Phase 4) to spot false positives (high escape rate), inert
+matchers (zero fires), or overly broad blocks (high block rate).
+
 ---
 
 ## nx config

--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -106,6 +106,16 @@
             "type": "command",
             "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/pre_close_verification_hook.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/routing/grep_for_symbols_redirects_to_serena.py",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/routing/git_add_all_redirects_to_explicit_paths.py",
+            "timeout": 5
           }
         ]
       }

--- a/nx/hooks/scripts/routing/git_add_all_redirects_to_explicit_paths.py
+++ b/nx/hooks/scripts/routing/git_add_all_redirects_to_explicit_paths.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 Phase 2 hook 3: deny ``git add`` wildcard forms.
+
+Standing rule (``feedback_no_git_add_all.md``): wildcard adds pull in
+unrelated untracked drafts. Stage by explicit path instead.
+
+Denied forms:
+- ``git add -A``        (and ``-Av``, ``-AV``, etc. -- as a flag group)
+- ``git add .``
+- ``git add --all``
+
+Allowed:
+- ``git add <path> [<path> ...]`` with explicit path arguments.
+- Any ``git add`` invocation carrying a valid ``# routing-allow:``
+  escape token.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(__file__))
+import _lib  # noqa: E402
+
+RULE_NAME = "git_add_all_redirects_to_explicit_paths"
+
+
+def _has_wildcard_add(segment_tokens: list[str]) -> bool:
+    """Return True iff this segment is ``git add`` with a wildcard form."""
+    if len(segment_tokens) < 2:
+        return False
+    if segment_tokens[0] != "git" or segment_tokens[1] != "add":
+        return False
+    for token in segment_tokens[2:]:
+        if token == ".":
+            return True
+        if token == "--all":
+            return True
+        # ``-A`` or any short-flag group containing ``A``.
+        if token.startswith("-") and not token.startswith("--") and "A" in token:
+            return True
+    return False
+
+
+def _scan_command(command: str) -> bool:
+    """Return True iff any sub-segment is a wildcard ``git add``."""
+    segments = re.split(r"(?:&&|\|\||;|\s\|\s|\bthen\b|\bdo\b)", command)
+    for segment in segments:
+        try:
+            tokens = shlex.split(segment, posix=True)
+        except ValueError:
+            continue
+        if _has_wildcard_add(tokens):
+            return True
+    return False
+
+
+def _redirect_message() -> str:
+    return (
+        "git add wildcard forms (`-A`, `.`, `--all`) pull in unrelated "
+        "untracked drafts. Stage by explicit path instead:\n"
+        "  git add <path1> <path2> ...\n"
+        "Standing rule: feedback_no_git_add_all.md.\n"
+        "To override, append `# routing-allow: <reason>` (>=8 chars)."
+    )
+
+
+def body(payload: dict[str, Any]) -> None:
+    command = _lib.get_bash_command(payload)
+    if not command:
+        _lib.allow()
+
+    if _lib.should_skip_for_reason(command):
+        _lib.log_routing_event(
+            rule=RULE_NAME, outcome="escape", tool_name="Bash",
+            command_fragment=command,
+        )
+        _lib.allow()
+
+    if not _scan_command(command):
+        _lib.allow()
+
+    _lib.log_routing_event(
+        rule=RULE_NAME, outcome="deny", tool_name="Bash",
+        command_fragment=command,
+    )
+    _lib.deny(_redirect_message())
+
+
+if __name__ == "__main__":
+    _lib.run_hook(body, fail_closed=False, rule_name=RULE_NAME)

--- a/nx/hooks/scripts/routing/grep_for_symbols_redirects_to_serena.py
+++ b/nx/hooks/scripts/routing/grep_for_symbols_redirects_to_serena.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 Phase 2 hook 1: redirect grep / rg on code files to Serena.
+
+When the user runs ``grep`` or ``rg`` with an identifier-shaped pattern
+against code files (``*.py *.swift *.java *.ts *.tsx *.go *.rs``), deny
+with a redirect to Serena's symbol-navigation MCP tools.
+
+Allowed identifier shapes (deny):
+- Single identifier:        ``MyClass``
+- Dotted-id chain:          ``Module.Class.method``
+- Pipe-alternation of ids:  ``MyClass|YourClass``
+
+Disqualifiers (allow):
+- ``TODO`` / ``FIXME`` / ``XXX`` / ``HACK`` (all-uppercase short tokens)
+- Whitespace anywhere in the pattern
+- Regex metachars besides the pipe in alternation
+"""
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(__file__))
+import _lib  # noqa: E402
+
+RULE_NAME = "grep_for_symbols_redirects_to_serena"
+
+CODE_EXTENSIONS = (".py", ".swift", ".java", ".ts", ".tsx", ".go", ".rs")
+DISQUALIFIED_TOKENS = frozenset({"TODO", "FIXME", "XXX", "HACK", "NOTE", "WIP"})
+
+# Regex meta chars that disqualify a pattern from being "identifier-shaped"
+# (pipe is allowed only in the alternation shape, handled separately).
+_META_CHARS = set(r".*+?^$()[]{}\\")
+
+_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DOTTED = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+$")
+
+
+def _strip_quotes(s: str) -> str:
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ("'", '"'):
+        return s[1:-1]
+    return s
+
+
+def _is_identifier_pattern(pattern: str) -> bool:
+    """Return True iff ``pattern`` matches one of the three symbol shapes."""
+    p = _strip_quotes(pattern).strip()
+    if not p:
+        return False
+    if any(ch.isspace() for ch in p):
+        return False
+    if p.upper() in DISQUALIFIED_TOKENS:
+        return False
+
+    # Single identifier
+    if _IDENT.match(p):
+        return True
+
+    # Dotted identifier chain (no other meta chars allowed)
+    if _DOTTED.match(p):
+        return True
+
+    # Pipe alternation: split on '|' and require every segment to be a
+    # bare identifier with no other meta chars in the original pattern.
+    if "|" in p:
+        # No other regex meta chars besides '|'.
+        if any(ch in _META_CHARS for ch in p):
+            return False
+        parts = p.split("|")
+        if len(parts) >= 2 and all(_IDENT.match(seg) for seg in parts if seg):
+            return True
+
+    return False
+
+
+def _parse_grep_invocation(command: str) -> tuple[str, list[str]] | None:
+    """Return (pattern, file_args) for the first grep/rg call in *command*.
+
+    Splits the command on shell separators (``;`` ``&&`` ``||`` ``|``)
+    and finds the first sub-command whose first token is ``grep`` or
+    ``rg``. Returns None when no such call is found or parsing fails.
+    """
+    # Cheap split on top-level shell separators. This is a best-effort
+    # parse; the hook is advisory and we tolerate false negatives.
+    # Only split on multi-char shell separators (&&, ||, ;) plus a
+    # whitespace-flanked single pipe. A bare `|` inside a quoted regex
+    # (`grep -E 'A|B'`) must not split the command.
+    segments = re.split(r"(?:&&|\|\||;|\s\|\s|\bthen\b|\bdo\b)", command)
+    for segment in segments:
+        try:
+            tokens = shlex.split(segment, posix=True)
+        except ValueError:
+            continue
+        if not tokens:
+            continue
+        if tokens[0] not in ("grep", "rg"):
+            continue
+        # Drop flags; the first non-flag positional is the pattern.
+        positional: list[str] = []
+        i = 1
+        while i < len(tokens):
+            t = tokens[i]
+            if t == "--":
+                positional.extend(tokens[i + 1 :])
+                break
+            if t.startswith("-"):
+                # Flags that consume a value
+                if t in ("-e", "--regexp", "-f", "--file", "--type", "-t",
+                         "--glob", "-g", "--include", "--exclude",
+                         "--max-count", "-m"):
+                    i += 2
+                    continue
+                i += 1
+                continue
+            positional.append(t)
+            i += 1
+        if not positional:
+            return None
+        pattern = positional[0]
+        files = positional[1:]
+        return pattern, files
+    return None
+
+
+def _has_code_file(files: list[str]) -> bool:
+    if not files:
+        return False
+    return any(f.lower().endswith(CODE_EXTENSIONS) for f in files)
+
+
+def _redirect_message() -> str:
+    return (
+        "grep / rg on code files for identifier-shaped patterns is a "
+        "symbol-navigation task. Use Serena instead:\n"
+        "  - Definitions: mcp__plugin_sn_serena__jet_brains_find_symbol\n"
+        "  - Callers:     mcp__plugin_sn_serena__jet_brains_find_referencing_symbols\n"
+        "  - File map:    mcp__plugin_sn_serena__jet_brains_get_symbols_overview\n"
+        "To override (e.g. genuine text search), append "
+        "`# routing-allow: <reason>` (>=8 chars) to the command."
+    )
+
+
+def body(payload: dict[str, Any]) -> None:
+    command = _lib.get_bash_command(payload)
+    if not command:
+        _lib.allow()
+
+    if _lib.should_skip_for_reason(command):
+        _lib.log_routing_event(
+            rule=RULE_NAME, outcome="escape", tool_name="Bash",
+            command_fragment=command,
+        )
+        _lib.allow()
+
+    parsed = _parse_grep_invocation(command)
+    if parsed is None:
+        _lib.allow()
+    pattern, files = parsed
+
+    if not _has_code_file(files):
+        _lib.allow()
+
+    if not _is_identifier_pattern(pattern):
+        _lib.allow()
+
+    _lib.log_routing_event(
+        rule=RULE_NAME, outcome="deny", tool_name="Bash",
+        command_fragment=command,
+    )
+    _lib.deny(_redirect_message())
+
+
+if __name__ == "__main__":
+    _lib.run_hook(body, fail_closed=False, rule_name=RULE_NAME)

--- a/nx/hooks/scripts/routing/registry.yaml
+++ b/nx/hooks/scripts/routing/registry.yaml
@@ -32,4 +32,23 @@
 #     escape_token: "# routing-allow:"
 #     fail_closed: false
 
-rules: {}
+rules:
+  grep_for_symbols_redirects_to_serena:
+    hook_script: grep_for_symbols_redirects_to_serena.py
+    matcher: Bash
+    mode: redirect
+    rationale: >-
+      grep / rg on code files for identifier-shaped patterns is a
+      symbol-navigation task; use Serena
+      (jet_brains_find_symbol / jet_brains_find_referencing_symbols).
+    escape_token: "# routing-allow:"
+    fail_closed: false
+  git_add_all_redirects_to_explicit_paths:
+    hook_script: git_add_all_redirects_to_explicit_paths.py
+    matcher: Bash
+    mode: redirect
+    rationale: >-
+      git add wildcard forms (-A, ., --all) pull in unrelated untracked
+      drafts; stage by explicit path (feedback_no_git_add_all).
+    escape_token: "# routing-allow:"
+    fail_closed: false

--- a/src/nexus/commands/hook.py
+++ b/src/nexus/commands/hook.py
@@ -159,3 +159,55 @@ def session_end_detach_cmd() -> None:
     except Exception:
         pass
     os._exit(0)
+
+
+@hook_group.command("routing-stats")
+@click.option(
+    "--log-path",
+    type=click.Path(path_type=str, dir_okay=False),
+    default=None,
+    help="Path to the routing log JSONL. Defaults to NX_ROUTING_LOG_PATH "
+    "or ~/.config/nexus/routing_log.jsonl.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit aggregated stats as JSON instead of a human table.",
+)
+def routing_stats_cmd(log_path: str | None, as_json: bool) -> None:
+    """Aggregate the routing-hook log into per-rule fire / deny / escape stats.
+
+    RDR-121 Phase 3. Reads JSONL records produced by the routing hook
+    framework (`nx/hooks/scripts/routing/_lib.log_routing_event`) and
+    reports per-rule outcomes. Used at the 30-day soak review to spot
+    false positives (high escape rate), inert matchers (zero fires), or
+    overly broad blocks (high block rate).
+    """
+    import pathlib as _pathlib
+
+    from nexus.routing_stats import aggregate, default_log_path, stats_to_json
+
+    path = _pathlib.Path(log_path) if log_path else default_log_path()
+    stats = aggregate(path)
+
+    if as_json:
+        click.echo(json.dumps(stats_to_json(stats), indent=2, sort_keys=True))
+        return
+
+    if not stats:
+        click.echo(f"No routing-hook events recorded at {path}.")
+        return
+
+    header = f"{'rule':<48} {'total':>6} {'allow':>6} {'deny':>6} {'escape':>6} {'block%':>7} {'esc%':>6}"
+    click.echo(header)
+    click.echo("-" * len(header))
+    for rule in sorted(stats):
+        s = stats[rule]
+        click.echo(
+            f"{rule[:48]:<48} {s.total:>6d} {s.allow:>6d} {s.deny:>6d} "
+            f"{s.escape:>6d} {s.block_rate * 100:>6.1f}% {s.escape_rate * 100:>5.1f}%"
+        )
+    click.echo()
+    click.echo(f"Source: {path}")

--- a/src/nexus/routing_stats.py
+++ b/src/nexus/routing_stats.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 Phase 3: routing-hook telemetry aggregation.
+
+Reads the JSONL log written by routing hooks via
+``nx/hooks/scripts/routing/_lib.log_routing_event`` and computes
+per-rule fire / allow / deny / escape counts. Surfaced to the user
+by the ``nx hook routing-stats`` CLI subcommand. Used at the 30-day
+soak review (mzvwa.7) to decide whether matchers need refinement,
+downgrade to warn, or have shipped without ever firing.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+from dataclasses import dataclass, field, asdict
+from typing import Any, Iterable
+
+
+def default_log_path() -> pathlib.Path:
+    """Return the routing log path, honoring ``NX_ROUTING_LOG_PATH``."""
+    override = os.environ.get("NX_ROUTING_LOG_PATH")
+    if override:
+        return pathlib.Path(override)
+    return pathlib.Path.home() / ".config" / "nexus" / "routing_log.jsonl"
+
+
+@dataclass
+class RuleStats:
+    """Aggregated outcomes for a single rule."""
+
+    rule: str
+    allow: int = 0
+    deny: int = 0
+    escape: int = 0
+    fail_open: int = 0
+    fail_closed: int = 0
+    extra: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def total(self) -> int:
+        return (
+            self.allow + self.deny + self.escape
+            + self.fail_open + self.fail_closed
+            + sum(self.extra.values())
+        )
+
+    @property
+    def block_rate(self) -> float:
+        total = self.total
+        if total == 0:
+            return 0.0
+        return (self.deny + self.fail_closed) / total
+
+    @property
+    def escape_rate(self) -> float:
+        total = self.total
+        if total == 0:
+            return 0.0
+        return self.escape / total
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rule": self.rule,
+            "total": self.total,
+            "allow": self.allow,
+            "deny": self.deny,
+            "escape": self.escape,
+            "fail_open": self.fail_open,
+            "fail_closed": self.fail_closed,
+            "block_rate": round(self.block_rate, 4),
+            "escape_rate": round(self.escape_rate, 4),
+            **({"extra": self.extra} if self.extra else {}),
+        }
+
+    def add(self, outcome: str) -> None:
+        match outcome:
+            case "allow":
+                self.allow += 1
+            case "deny":
+                self.deny += 1
+            case "escape":
+                self.escape += 1
+            case "allow_fail_open":
+                self.fail_open += 1
+            case "deny_fail_closed":
+                self.fail_closed += 1
+            case _:
+                self.extra[outcome] = self.extra.get(outcome, 0) + 1
+
+
+def _iter_records(path: pathlib.Path) -> Iterable[dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    out: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict):
+            out.append(record)
+    return out
+
+
+def aggregate(path: pathlib.Path | None = None) -> dict[str, RuleStats]:
+    """Aggregate the routing log into per-rule stats.
+
+    Returns an empty dict when the log is absent or unreadable; never
+    raises. Records missing ``rule`` or ``outcome`` are dropped.
+    """
+    log_path = path if path is not None else default_log_path()
+    stats: dict[str, RuleStats] = {}
+    for record in _iter_records(log_path):
+        rule = record.get("rule")
+        outcome = record.get("outcome")
+        if not isinstance(rule, str) or not isinstance(outcome, str):
+            continue
+        bucket = stats.setdefault(rule, RuleStats(rule=rule))
+        bucket.add(outcome)
+    return stats
+
+
+def stats_to_json(stats: dict[str, RuleStats]) -> dict[str, dict[str, Any]]:
+    """Serialize the per-rule stats to plain dicts for JSON output."""
+    return {rule: s.to_dict() for rule, s in stats.items()}

--- a/tests/test_hook_routing_stats.py
+++ b/tests/test_hook_routing_stats.py
@@ -154,7 +154,7 @@ def test_cli_routing_stats_json_output(tmp_path, monkeypatch):
     runner = CliRunner()
     result = runner.invoke(main, ["hook", "routing-stats", "--json"])
     assert result.exit_code == 0
-    parsed = json.loads(result.output)
+    parsed = json.loads(result.stdout)
     assert parsed["r"]["total"] == 2
     assert parsed["r"]["deny"] == 1
 

--- a/tests/test_hook_routing_stats.py
+++ b/tests/test_hook_routing_stats.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 Phase 3: ``nx hook routing-stats`` CLI + aggregation.
+
+Reads the per-rule JSONL log written by routing hooks (via
+``nx/hooks/scripts/routing/_lib.log_routing_event``) and produces a
+small report: total fires, allow / deny / escape counts, block-rate
+and escape-rate per rule.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.routing_stats import aggregate, RuleStats
+
+
+def _write_log(path: pathlib.Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_empty_log(tmp_path):
+    path = tmp_path / "log.jsonl"
+    path.write_text("")
+    assert aggregate(path) == {}
+
+
+def test_aggregate_missing_log_returns_empty(tmp_path):
+    assert aggregate(tmp_path / "absent.jsonl") == {}
+
+
+def test_aggregate_counts_outcomes_per_rule(tmp_path):
+    path = tmp_path / "log.jsonl"
+    _write_log(path, [
+        {"ts": "t1", "rule": "rule_a", "outcome": "allow"},
+        {"ts": "t2", "rule": "rule_a", "outcome": "deny"},
+        {"ts": "t3", "rule": "rule_a", "outcome": "deny"},
+        {"ts": "t4", "rule": "rule_a", "outcome": "escape"},
+        {"ts": "t5", "rule": "rule_b", "outcome": "allow"},
+    ])
+    stats = aggregate(path)
+    assert set(stats.keys()) == {"rule_a", "rule_b"}
+    a = stats["rule_a"]
+    assert a.total == 4
+    assert a.allow == 1
+    assert a.deny == 2
+    assert a.escape == 1
+    assert a.block_rate == pytest.approx(2 / 4)
+    assert a.escape_rate == pytest.approx(1 / 4)
+
+
+def test_aggregate_handles_fail_closed_and_fail_open(tmp_path):
+    path = tmp_path / "log.jsonl"
+    _write_log(path, [
+        {"ts": "t1", "rule": "r", "outcome": "allow_fail_open"},
+        {"ts": "t2", "rule": "r", "outcome": "deny_fail_closed"},
+    ])
+    stats = aggregate(path)["r"]
+    assert stats.total == 2
+    assert stats.fail_open == 1
+    assert stats.fail_closed == 1
+
+
+def test_aggregate_skips_malformed_lines(tmp_path):
+    path = tmp_path / "log.jsonl"
+    path.write_text(
+        json.dumps({"ts": "x", "rule": "r", "outcome": "allow"}) + "\n"
+        + "{not json\n"
+        + json.dumps({"ts": "y", "rule": "r", "outcome": "deny"}) + "\n"
+    )
+    stats = aggregate(path)["r"]
+    assert stats.total == 2
+
+
+def test_aggregate_ignores_records_without_rule(tmp_path):
+    path = tmp_path / "log.jsonl"
+    _write_log(path, [
+        {"ts": "t1", "outcome": "allow"},  # no rule
+        {"ts": "t2", "rule": "r", "outcome": "allow"},
+    ])
+    assert list(aggregate(path).keys()) == ["r"]
+
+
+# ---------------------------------------------------------------------------
+# RuleStats dataclass behavior
+# ---------------------------------------------------------------------------
+
+
+def test_rule_stats_zero_total_has_zero_rates():
+    s = RuleStats(rule="x")
+    assert s.total == 0
+    assert s.block_rate == 0.0
+    assert s.escape_rate == 0.0
+
+
+# ---------------------------------------------------------------------------
+# CLI: `nx hook routing-stats`
+# ---------------------------------------------------------------------------
+
+
+def test_cli_routing_stats_reports_per_rule(tmp_path, monkeypatch):
+    log = tmp_path / "log.jsonl"
+    _write_log(log, [
+        {"ts": "t1", "rule": "grep_for_symbols_redirects_to_serena", "outcome": "deny"},
+        {"ts": "t2", "rule": "grep_for_symbols_redirects_to_serena", "outcome": "escape"},
+        {"ts": "t3", "rule": "git_add_all_redirects_to_explicit_paths", "outcome": "deny"},
+    ])
+    monkeypatch.setenv("NX_ROUTING_LOG_PATH", str(log))
+
+    from nexus.cli import main
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["hook", "routing-stats"])
+    assert result.exit_code == 0, result.output
+    assert "grep_for_symbols_redirects_to_serena" in result.output
+    assert "git_add_all_redirects_to_explicit_paths" in result.output
+    # Report shows numeric columns
+    assert "deny" in result.output.lower()
+
+
+def test_cli_routing_stats_empty_log(tmp_path, monkeypatch):
+    log = tmp_path / "log.jsonl"
+    log.write_text("")
+    monkeypatch.setenv("NX_ROUTING_LOG_PATH", str(log))
+
+    from nexus.cli import main
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["hook", "routing-stats"])
+    assert result.exit_code == 0
+    assert "no" in result.output.lower() or "0" in result.output
+
+
+def test_cli_routing_stats_json_output(tmp_path, monkeypatch):
+    log = tmp_path / "log.jsonl"
+    _write_log(log, [
+        {"ts": "t1", "rule": "r", "outcome": "deny"},
+        {"ts": "t2", "rule": "r", "outcome": "allow"},
+    ])
+    monkeypatch.setenv("NX_ROUTING_LOG_PATH", str(log))
+
+    from nexus.cli import main
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["hook", "routing-stats", "--json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["r"]["total"] == 2
+    assert parsed["r"]["deny"] == 1
+
+
+def test_cli_routing_stats_custom_path(tmp_path):
+    log = tmp_path / "elsewhere.jsonl"
+    _write_log(log, [{"ts": "t", "rule": "r", "outcome": "deny"}])
+
+    from nexus.cli import main
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["hook", "routing-stats", "--log-path", str(log)])
+    assert result.exit_code == 0
+    assert "r" in result.output

--- a/tests/test_routing_git_add_all.py
+++ b/tests/test_routing_git_add_all.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 Phase 2 hook 3: git_add_all_redirects_to_explicit_paths.
+
+Detects ``git add -A``, ``git add .``, ``git add --all`` and denies
+with a redirect to explicit-path staging. Standing rule from
+``feedback_no_git_add_all.md``: wildcard adds pull in unrelated
+untracked drafts.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).parent.parent
+HOOK_SCRIPT = (
+    PROJECT_ROOT
+    / "nx"
+    / "hooks"
+    / "scripts"
+    / "routing"
+    / "git_add_all_redirects_to_explicit_paths.py"
+)
+
+
+def _run(payload: dict, env_extra: dict[str, str] | None = None):
+    env = os.environ.copy()
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True, text=True, timeout=10, env=env,
+    )
+
+
+def _decision(proc):
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)["hookSpecificOutput"]
+
+
+def _bash(cmd: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": cmd}}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_log(tmp_path, monkeypatch):
+    monkeypatch.setenv("NX_ROUTING_LOG_PATH", str(tmp_path / "log.jsonl"))
+
+
+def test_script_exists():
+    assert HOOK_SCRIPT.exists()
+
+
+# Positive: each wildcard form denies
+
+
+def test_git_add_dash_A_denies():
+    d = _decision(_run(_bash("git add -A")))
+    assert d["permissionDecision"] == "deny"
+    assert "explicit" in d["reason"].lower() or "path" in d["reason"].lower()
+
+
+def test_git_add_dot_denies():
+    d = _decision(_run(_bash("git add .")))
+    assert d["permissionDecision"] == "deny"
+
+
+def test_git_add_all_long_flag_denies():
+    d = _decision(_run(_bash("git add --all")))
+    assert d["permissionDecision"] == "deny"
+
+
+def test_git_add_all_with_pathspec_denies():
+    d = _decision(_run(_bash("git add --all src/")))
+    assert d["permissionDecision"] == "deny"
+
+
+def test_chained_git_add_dot_denies():
+    """`git status && git add . && git commit` still triggers."""
+    d = _decision(_run(_bash("git status && git add . && git commit -m foo")))
+    assert d["permissionDecision"] == "deny"
+
+
+# Negative
+
+
+def test_git_add_explicit_paths_allows():
+    d = _decision(_run(_bash("git add src/foo.py tests/test_foo.py")))
+    assert d["permissionDecision"] == "allow"
+
+
+def test_git_add_single_dotfile_allows():
+    """`git add .gitignore` is explicit, not wildcard."""
+    d = _decision(_run(_bash("git add .gitignore")))
+    assert d["permissionDecision"] == "allow"
+
+
+def test_git_status_allows():
+    d = _decision(_run(_bash("git status")))
+    assert d["permissionDecision"] == "allow"
+
+
+def test_non_git_command_allows():
+    d = _decision(_run(_bash("ls -A")))
+    assert d["permissionDecision"] == "allow"
+
+
+def test_non_bash_allows():
+    d = _decision(_run({"tool_name": "Edit", "tool_input": {"file_path": "x"}}))
+    assert d["permissionDecision"] == "allow"
+
+
+# Escape
+
+
+def test_escape_allows():
+    d = _decision(_run(_bash(
+        "git add -A  # routing-allow: scripted bootstrap of fresh repo"
+    )))
+    assert d["permissionDecision"] == "allow"
+
+
+# Malformed
+
+
+def test_empty_stdin_allows():
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="", capture_output=True, text=True, timeout=10,
+    )
+    assert proc.returncode == 0
+    d = json.loads(proc.stdout)["hookSpecificOutput"]
+    assert d["permissionDecision"] == "allow"
+
+
+# Registry + hooks.json wiring
+
+
+def test_registry_has_rule():
+    yaml = pytest.importorskip("yaml")
+    reg = PROJECT_ROOT / "nx" / "hooks" / "scripts" / "routing" / "registry.yaml"
+    rule = (yaml.safe_load(reg.read_text()) or {}).get("rules", {}).get(
+        "git_add_all_redirects_to_explicit_paths"
+    )
+    assert rule is not None
+
+
+def test_hooks_json_registers():
+    hooks_json = PROJECT_ROOT / "nx" / "hooks" / "hooks.json"
+    data = json.loads(hooks_json.read_text())
+    found = any(
+        "git_add_all_redirects_to_explicit_paths.py" in h.get("command", "")
+        for entry in data["hooks"]["PreToolUse"] if entry.get("matcher") == "Bash"
+        for h in entry.get("hooks", [])
+    )
+    assert found

--- a/tests/test_routing_grep_for_symbols.py
+++ b/tests/test_routing_grep_for_symbols.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 Phase 2 hook 1: grep_for_symbols_redirects_to_serena.
+
+Detects identifier-shaped patterns in grep / rg calls against code
+files and denies with a redirect to Serena's symbol-navigation MCP
+tools (find_symbol, find_referencing_symbols).
+
+Matcher shapes (allowed identifier patterns):
+- Single identifier:       MyClass
+- Dotted-id chain:         Module.Class.method
+- Pipe-alternation of ids: MyClass|YourClass
+
+Disqualifiers (allow through):
+- All-uppercase short tokens: TODO, FIXME, XXX, HACK
+- Whitespace inside the pattern (text search, not symbol)
+- Regex metachars elsewhere: *, +, ?, brackets, anchors, etc.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).parent.parent
+HOOK_SCRIPT = (
+    PROJECT_ROOT
+    / "nx"
+    / "hooks"
+    / "scripts"
+    / "routing"
+    / "grep_for_symbols_redirects_to_serena.py"
+)
+
+
+def _run(payload: dict, env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True, text=True, timeout=10, env=env,
+    )
+
+
+def _decision(proc) -> dict:
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)["hookSpecificOutput"]
+
+
+def _bash(cmd: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": cmd}}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_log(tmp_path, monkeypatch):
+    monkeypatch.setenv("NX_ROUTING_LOG_PATH", str(tmp_path / "log.jsonl"))
+
+
+def test_script_exists():
+    assert HOOK_SCRIPT.exists()
+
+
+# ---------------------------------------------------------------------------
+# Positive: identifier-shaped patterns on code files -> deny
+# ---------------------------------------------------------------------------
+
+
+def test_grep_single_identifier_on_py_file_denies():
+    proc = _run(_bash("grep MyClass src/foo.py"))
+    d = _decision(proc)
+    assert d["permissionDecision"] == "deny"
+    assert "jet_brains_find_symbol" in d["reason"] or "Serena" in d["reason"]
+
+
+def test_rg_single_identifier_on_ts_file_denies():
+    proc = _run(_bash("rg MyHandler src/handler.ts"))
+    assert _decision(proc)["permissionDecision"] == "deny"
+
+
+def test_grep_dotted_identifier_chain_denies():
+    proc = _run(_bash("grep Module.Class.method src/lib.py"))
+    assert _decision(proc)["permissionDecision"] == "deny"
+
+
+def test_grep_pipe_alternation_of_identifiers_denies():
+    proc = _run(_bash("grep -E 'MyClass|YourClass' src/foo.py"))
+    assert _decision(proc)["permissionDecision"] == "deny"
+
+
+def test_rg_swift_file_denies():
+    proc = _run(_bash("rg AppDelegate Sources/App/Main.swift"))
+    assert _decision(proc)["permissionDecision"] == "deny"
+
+
+def test_rg_java_file_denies():
+    proc = _run(_bash("rg HashMap src/main/java/Foo.java"))
+    assert _decision(proc)["permissionDecision"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# Negative: non-symbol searches and non-code files allow through
+# ---------------------------------------------------------------------------
+
+
+def test_grep_text_phrase_with_spaces_allows():
+    """Text search with spaces is not a symbol; allow."""
+    proc = _run(_bash("grep 'hello world' src/foo.py"))
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_grep_with_regex_metachars_allows():
+    """Pattern containing regex metachars is text-search, not a symbol."""
+    proc = _run(_bash("grep 'foo.*bar' src/foo.py"))
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_grep_todo_allows():
+    """TODO/FIXME/XXX/HACK are not symbols."""
+    proc = _run(_bash("grep TODO src/foo.py"))
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_grep_fixme_allows():
+    proc = _run(_bash("rg FIXME src/foo.py"))
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_grep_on_markdown_allows():
+    """Non-code file: text search, not a symbol lookup."""
+    proc = _run(_bash("grep Handler README.md"))
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_grep_on_yaml_allows():
+    proc = _run(_bash("grep MyClass config.yaml"))
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_grep_without_code_file_extension_allows():
+    """No file argument or only non-code files: allow."""
+    proc = _run(_bash("grep MyClass"))
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_non_grep_bash_allows():
+    proc = _run(_bash("ls src/"))
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_non_bash_tool_allows():
+    proc = _run({"tool_name": "Edit", "tool_input": {"file_path": "x"}})
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+# ---------------------------------------------------------------------------
+# Escape token
+# ---------------------------------------------------------------------------
+
+
+def test_escape_token_allows():
+    proc = _run(_bash(
+        "grep MyClass src/foo.py  # routing-allow: searching test fixture refs"
+    ))
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_escape_token_too_short_still_denies():
+    proc = _run(_bash("grep MyClass src/foo.py  # routing-allow: x"))
+    assert _decision(proc)["permissionDecision"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# Malformed input
+# ---------------------------------------------------------------------------
+
+
+def test_empty_stdin_allows():
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="", capture_output=True, text=True, timeout=10,
+    )
+    assert proc.returncode == 0
+    d = json.loads(proc.stdout)["hookSpecificOutput"]
+    assert d["permissionDecision"] == "allow"
+
+
+def test_non_json_stdin_allows():
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="{not json", capture_output=True, text=True, timeout=10,
+    )
+    assert proc.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Registry + hooks.json wiring
+# ---------------------------------------------------------------------------
+
+
+def test_registry_has_rule():
+    yaml = pytest.importorskip("yaml")
+    reg = PROJECT_ROOT / "nx" / "hooks" / "scripts" / "routing" / "registry.yaml"
+    parsed = yaml.safe_load(reg.read_text()) or {}
+    rule = (parsed.get("rules") or {}).get("grep_for_symbols_redirects_to_serena")
+    assert rule is not None
+
+
+def test_hooks_json_registers():
+    hooks_json = PROJECT_ROOT / "nx" / "hooks" / "hooks.json"
+    data = json.loads(hooks_json.read_text())
+    bash_hooks = data["hooks"]["PreToolUse"]
+    found = any(
+        "grep_for_symbols_redirects_to_serena.py" in h.get("command", "")
+        for entry in bash_hooks if entry.get("matcher") == "Bash"
+        for h in entry.get("hooks", [])
+    )
+    assert found


### PR DESCRIPTION
## Summary

RDR-121 Phase 3. The telemetry write side already shipped with the
framework in mzvwa.1; this PR adds the aggregation + CLI surface so
the data is consumable.

Stacked on #890 (mzvwa.3 + .5) which is itself stacked on #888
(mzvwa.1). Rebases cleanly onto main once the dependency chain merges.

## What lands

- `src/nexus/routing_stats.py`: `RuleStats` dataclass + `aggregate()`
  over the JSONL log. Counts allow / deny / escape / fail-open /
  fail-closed per rule; computes block-rate and escape-rate. Fail-safe
  on missing / unreadable / partially-corrupt logs.
- `src/nexus/commands/hook.py`: `nx hook routing-stats` subcommand.
  Table output by default; `--json` for machine-readable; `--log-path`
  overrides the default.
- `docs/cli-reference.md`: subcommand reference under `## nx hooks`.
- `tests/test_hook_routing_stats.py`: 11 tests covering aggregation
  edges + CLI surface.

## Test plan

- [x] `uv run pytest tests/test_hook_routing_stats.py` (11 pass)
- [x] `nx hook routing-stats --help` smoke-test after reinstall
- [x] `uv run pytest tests/test_plugin_structure.py` (588 pass)
- [ ] CI Python 3.12 + 3.13 green

## Closes

Closes nexus-mzvwa.6

Refs: docs/rdr/rdr-121-hook-enforced-tool-routing.md