### PR TITLE
chore(release): conexus 4.33.0 (RDR-121 routing hooks + resolve_corpus fix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.32.14"
+      "version": "4.33.0"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.32.14"
+      "version": "4.33.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,52 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.33.0] - 2026-05-20
+
+Minor release. RDR-121 hook-enforced tool routing: a PreToolUse backstop
+that converts repeatedly-violated guidance ("use Serena for symbol
+search", "don't `git add -A`", "phase-review beads need a passed gate
+before close") into deterministic Claude Code hooks. Plus a UX fix for
+the post-RDR-103 collection-name shape.
+
+### Added (nexus-mzvwa, RDR-121)
+
+- Routing-hook framework at `nx/hooks/scripts/routing/`:
+  - `_lib.py`: shared envelope builders (`allow` / `deny` / `warn`),
+    stdin parser, `# routing-allow:` escape token parser, JSONL
+    telemetry, and a fail-open / fail-closed `run_hook` wrapper.
+  - `registry.yaml`: per-rule metadata including the `fail_closed`
+    opt-in flag.
+  - `README.md`: authoring template + contract documentation.
+- Three PreToolUse Bash hooks registered in `nx/hooks/hooks.json`:
+  - `grep_for_symbols_redirects_to_serena.py`: detects identifier-
+    shaped patterns in `grep` / `rg` against code files and redirects
+    to Serena's `find_symbol` / `find_referencing_symbols` MCP tools.
+  - `git_add_all_redirects_to_explicit_paths.py`: blocks `git add -A`
+    / `git add .` / `git add --all` and asks for explicit paths.
+  - `phase_review_close_requires_gate.py` (fail-closed): blocks
+    `bd close` on phase-review beads unless `/nx:phase-review-gate`
+    has written a fresh PASSED sentinel for the `(rdr-id, phase)`
+    tuple. The sentinel writer lives in
+    `nx/skills/phase-review-gate/SKILL.md` via
+    `src/nexus/phase_review_sentinel.py`. Closes the silent-scope-
+    reduction class that surfaced on RDR-112 Phase 1.
+- `nx hook routing-stats`: aggregates the per-rule JSONL log into a
+  table (or `--json`) with allow / deny / escape counts, block-rate,
+  and escape-rate per rule. Used for the 30-day soak review.
+
+### Fixed (post-RDR-103 UX)
+
+- `resolve_corpus` now falls back to prefix match when an exact match
+  on a `__`-containing argument yields nothing. Lets users keep
+  typing the legacy two-segment name (`knowledge__foo`) when the
+  on-disk collection is the conformant four-segment auto-promoted
+  form (`knowledge__foo__voyage-context-3__v1`). Previously
+  `nx search --corpus knowledge__foo` and `nx collection verify
+  knowledge__foo` both emitted "no collections match" / "collection
+  not found" even though the collection existed. `nx collection
+  verify` gets the same fallback so the two surfaces stay in sync.
+
 ## [4.32.14] - 2026-05-20
 
 Patch on 4.32.13. Singleton elimination, PDF-indexer correctness fix,

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.32.14",
+  "version": "4.33.0",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.33.0] - 2026-05-20
+
+Plugin version aligned with conexus 4.33.0. RDR-121 lands the routing-
+hook substrate in `nx/hooks/scripts/routing/` plus three PreToolUse
+hooks and a sentinel writer in `nx/skills/phase-review-gate/`. See
+the top-level CHANGELOG for the full list.
+
+### Added (RDR-121)
+
+- `nx/hooks/scripts/routing/_lib.py` and `registry.yaml`: framework
+  for Python-native PreToolUse routing hooks.
+- `nx/hooks/scripts/routing/grep_for_symbols_redirects_to_serena.py`:
+  redirects `grep` / `rg` of symbol-shaped patterns on code files to
+  the Serena `find_symbol` / `find_referencing_symbols` MCP tools.
+- `nx/hooks/scripts/routing/git_add_all_redirects_to_explicit_paths.py`:
+  blocks `git add -A` / `git add .` / `git add --all`.
+- `nx/hooks/scripts/routing/phase_review_close_requires_gate.py`
+  (fail-closed): blocks `bd close` on phase-review beads unless
+  `/nx:phase-review-gate` has written a PASSED sentinel for the
+  bead's `(rdr-id, phase)`.
+- `nx/skills/phase-review-gate/SKILL.md` and the command preamble
+  now write the PASSED sentinel that the routing hook reads.
+
+### Notes
+
+- All three routing hooks honor the `# routing-allow: <reason>=8 chars>`
+  escape token. The escape is logged for audit.
+
 ## [4.32.14] - 2026-05-20
 
 Plugin version aligned with conexus 4.32.14. One repo-local skill

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.32.14"
+version = "4.33.0"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "4.32.14",
+  "version": "4.33.0",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -566,7 +566,21 @@ def verify_cmd(name: str, deep: bool) -> None:
     cols = db.list_collections()
     match = next((c for c in cols if c["name"] == name), None)
     if match is None:
-        raise click.ClickException(f"collection not found: {name!r} — use: nx collection list")
+        # RDR-103 follow-up: a legacy two-segment name should still
+        # resolve when the on-disk collection is the conformant
+        # auto-promoted form (``foo__voyage-context-3__v1``). Same
+        # fallback as ``resolve_corpus`` in nexus.corpus.
+        from nexus.corpus import resolve_corpus
+
+        candidates = resolve_corpus(name, [c["name"] for c in cols])
+        if len(candidates) == 1:
+            resolved = candidates[0]
+            match = next(c for c in cols if c["name"] == resolved)
+            name = resolved
+        else:
+            raise click.ClickException(
+                f"collection not found: {name!r} — use: nx collection list"
+            )
 
     if not deep:
         click.echo(f"Collection '{name}': {match['count']} chunks — OK")

--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -393,15 +393,33 @@ def t3_collection_name(user_arg: str, *, t3: object | None = None) -> str:
 def resolve_corpus(corpus: str, all_collections: list[str]) -> list[str]:
     """Resolve a --corpus argument to a list of matching collection names.
 
-    If *corpus* contains ``__`` it is treated as an exact collection name.
-    Otherwise it is treated as a prefix — all collections starting with
-    ``{corpus}__`` are returned.
+    Three-stage match:
+
+    1. Exact match (covers fully-qualified conformant names from RDR-103,
+       e.g. ``knowledge__foo__voyage-context-3__v1``).
+    2. Prefix match if *corpus* does not contain ``__`` (covers the
+       short-form ``knowledge__foo`` typed by humans -- wait, this case
+       has ``__`` -- so see step 3).
+    3. Prefix match if *corpus* DOES contain ``__`` but exact returned
+       nothing. This is the post-RDR-103 case: a user types
+       ``knowledge__foo`` expecting the legacy name; the on-disk
+       collection is now ``knowledge__foo__voyage-context-3__v1``.
+       Treating the partial form as a prefix recovers the intent
+       without forcing users to know the embedder + version suffix.
+
+    The structlog debug record reports which stage matched, useful when
+    tracing why a corpus argument resolved to a particular collection.
     """
-    if "__" in corpus:
-        matches = [c for c in all_collections if c == corpus]
-    else:
-        prefix = f"{corpus}__"
-        matches = [c for c in all_collections if c.startswith(prefix)]
+    # Stage 1: exact match.
+    matches = [c for c in all_collections if c == corpus]
+    if matches:
+        return matches
+
+    # Stage 2 + 3: prefix match. The conformant name shape always
+    # introduces ``__`` between segments, so ``{corpus}__`` is the
+    # invariant boundary whether *corpus* itself contains ``__`` or not.
+    prefix = f"{corpus}__"
+    matches = [c for c in all_collections if c.startswith(prefix)]
     if not matches:
         structlog.get_logger().debug("resolve_corpus: no collections matched", corpus=corpus)
     return matches

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -93,6 +93,31 @@ def test_resolve_corpus_docs_prefix() -> None:
     assert resolve_corpus("docs", all_cols) == ["docs__papers", "docs__books"]
 
 
+def test_resolve_corpus_two_segment_matches_conformant_suffix() -> None:
+    """RDR-103 follow-up: a user typing the legacy two-segment name
+    (`knowledge__security`) should still match the conformant
+    `knowledge__security__voyage-context-3__v1` collection that the
+    store auto-promotes to. Without this fallback, `nx store put` and
+    `nx search` disagree on the name and the search silently misses.
+    """
+    all_cols = [
+        "knowledge__security__voyage-context-3__v1",
+        "knowledge__other__voyage-context-3__v1",
+    ]
+    assert resolve_corpus("knowledge__security", all_cols) == [
+        "knowledge__security__voyage-context-3__v1",
+    ]
+
+
+def test_resolve_corpus_exact_wins_over_prefix() -> None:
+    """When an exact match exists, it is preferred and prefix is not used."""
+    all_cols = [
+        "knowledge__foo",
+        "knowledge__foo__voyage-context-3__v1",
+    ]
+    assert resolve_corpus("knowledge__foo", all_cols) == ["knowledge__foo"]
+
+
 # ── validate_collection_name ──────────────────────────────────────────────────
 
 def test_validate_collection_name_valid() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.32.14"
+version = "4.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Release 4.33.0 minor. Ships RDR-121 (hook-enforced tool routing —
already merged across PRs #888 / #889 / #890 / #891) plus a UX fix for
the post-RDR-103 collection name shape that the integration suite
surfaced during release preparation.

## Bundled fix

The integration suite revealed that `nx search --corpus knowledge__foo`
and `nx collection verify knowledge__foo` emitted "no collections match"
when the store had auto-promoted the on-disk name to
`knowledge__foo__voyage-context-3__v1` (RDR-103 conformant form). Root
cause: `resolve_corpus` exact-matched any `__`-containing argument
without falling back to prefix.

- `src/nexus/corpus.py`: `resolve_corpus` now exact-then-prefix.
- `src/nexus/commands/collection.py`: `verify` uses the same fallback.
- `tests/test_corpus.py`: two new unit tests cover the fallback and the
  exact-wins-over-prefix tiebreak.

## Version bump

All five manifests bumped to 4.33.0:
- `pyproject.toml`
- `.claude-plugin/marketplace.json` (both `version` fields)
- `nx/.claude-plugin/plugin.json`
- `sn/.claude-plugin/plugin.json`

Plus `uv.lock` refresh and CHANGELOG entries in both root + `nx/`.

## Test plan

- [x] `uv run pytest` (7369 pass, 34 skip, 114 deselected)
- [x] `uv run pytest -m integration` (77 pass, 23 skip; 7 remaining failures are pre-existing environmental — they require `knowledge__hybridrag` and `knowledge__delos` corpora that aren't indexed locally, and were failing on v4.32.14 as well)
- [x] `./tests/e2e/release-sandbox.sh smoke` (`[done]`, schema v4.33.0 confirmed)
- [ ] CI green
- [ ] Tag `v4.33.0` after merge

## Closes

Closes nexus-mzvwa.1 through .6 are already closed via PRs #888-#891.

This PR carries the version bump and the resolve_corpus fix.