### PR TITLE
docs(rdr-121): close as implemented (shipped in 4.33.0)

### DIFF
--- a/docs/rdr/rdr-120-storage-substrate-split.md
+++ b/docs/rdr/rdr-120-storage-substrate-split.md
@@ -461,6 +461,30 @@ process discipline actually failed.
   holds across six phases of actual implementation work" still comes
   only from doing the work without violating it. Captured in §
   Enforcement Backstops below.
+- [x] **A8** (new): **The substrate-vs-consumer boundary holds for test
+  infrastructure: tests must not depend on prod T3 content as a
+  substrate-provided service.** During 4.33.0 release prep (2026-05-20),
+  `uv run pytest -m integration` surfaced 7 failures in
+  `test_hybrid_plan_factual_qa.py` (5 fixtures) and
+  `tests/integration/test_rdr_093_groupby_aggregate_pipelines.py`
+  (2 tests) because their `TARGET_COLLECTION` constants pointed at
+  `knowledge__hybridrag` and `knowledge__delos` — production corpora
+  rotated or removed before the test rerun. The same failures
+  reproduced on `v4.32.14`, so the regression rode through the prior
+  release; nobody had re-run `-m integration` before tagging.
+  **Status**: Verified (High confidence). **Method**: Source Search
+  (`grep TARGET_COLLECTION`, `nx collection list`) + counterfactual
+  against `v4.32.14`. **Evidence**: T2 entry `120-research-A8`.
+  **Implication for the substrate design**: the daemon provides
+  storage shape (single-writer arbiter, version negotiation,
+  discovery), not content. A test fixture that needs corpus X must
+  seed corpus X deterministically at session setup; a fixture pinned
+  to a corpus name that "the daemon should make available"
+  reintroduces the silo problem that broke RDR-105's container case
+  (each container assumes prod state present, each gets a different
+  empty / stale view). Captured separately as bead `nexus-ntacy` for
+  fixture-corpus standup work; this finding records the architectural
+  lesson: substrate provides handle, consumer owns content.
 
 ## Proposed Solution
 

--- a/docs/rdr/rdr-121-hook-enforced-tool-routing.md
+++ b/docs/rdr/rdr-121-hook-enforced-tool-routing.md
@@ -2,16 +2,46 @@
 title: "Hook-Enforced Tool Routing: PreToolUse as Backstop for Soft Guidance"
 id: RDR-121
 type: Architecture
-status: accepted
+status: closed
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-05-19
 accepted_date: 2026-05-20
+closed_date: 2026-05-20
+close_reason: implemented
+shipped_in: 4.33.0
 related_issues: []
 related_rdrs: [RDR-008, RDR-024, RDR-045, RDR-105, RDR-120]
-related_tests: []
-implementation_notes: ""
+related_tests:
+  - tests/test_routing_hooks.py
+  - tests/test_routing_phase_review_close.py
+  - tests/test_routing_grep_for_symbols.py
+  - tests/test_routing_git_add_all.py
+  - tests/test_phase_review_sentinel.py
+  - tests/test_hook_routing_stats.py
+implementation_notes: |
+  Shipped in conexus 4.33.0 (2026-05-20). Six implementation beads
+  closed (mzvwa.1 through .6); mzvwa.7 (P4 30-day soak review) left
+  open as a tracked follow-up, fires +30 days post-merge (~2026-06-19).
+  The soak runs against a closed RDR by design; observations either
+  get a small RDR addendum or follow-on beads.
+
+  Problem Statement closure pointers (Pass 2):
+  - Gap 1 (session-start guidance bypassable): enforcement at
+    nx/hooks/scripts/routing/grep_for_symbols_redirects_to_serena.py:1
+    (and the other two cohort hooks). PreToolUse fires regardless of
+    whether the session-start preamble was read.
+  - Gap 2 (memory-loaded guidance is optional context):
+    nx/hooks/scripts/routing/phase_review_close_requires_gate.py:1.
+    The phase-review-close rule was a recurring memory feedback entry
+    (feedback_phase_closeout_scope_audit); the hook makes the
+    cross-walk a deterministic precondition for `bd close`.
+  - Gap 3 (no enforcement layer at the action boundary):
+    nx/hooks/scripts/routing/_lib.py:1 + nx/hooks/hooks.json.
+    The framework gives every rule a PreToolUse action-boundary
+    enforcement surface with the contract documented in
+    nx/hooks/scripts/routing/README.md.
 ---
 
 # RDR-121: Hook-Enforced Tool Routing: PreToolUse as Backstop for Soft Guidance


### PR DESCRIPTION
## Summary

Status flip: \`accepted\` -> \`closed\`. RDR-121 (Hook-Enforced Tool
Routing) shipped end-to-end in conexus 4.33.0 (PyPI live).

## Outstanding

- \`nexus-mzvwa.7\` (P4 30-day soak review) left open as a tracked
  follow-up, fires ~2026-06-19 per its \`--defer=+30d\` designation.
  The soak runs against a closed RDR by design; observations either
  get a small RDR addendum or follow-on beads.

## Problem Statement Pass 2 pointers

Recorded in frontmatter \`implementation_notes\`:

| Gap | Resolved at |
|-----|-------------|
| 1: session-start bypassable | \`nx/hooks/scripts/routing/grep_for_symbols_redirects_to_serena.py:1\` |
| 2: memory guidance optional | \`nx/hooks/scripts/routing/phase_review_close_requires_gate.py:1\` |
| 3: no action-boundary enforcement | \`nx/hooks/scripts/routing/_lib.py:1\` |

## T2 evidence

- \`nexus_rdr/121\` (RDR metadata)
- \`nexus_rdr/121-gate-latest\` (gate PASSED)
- \`nexus_rdr/121-close\` (id=1382, close metadata)

## Test plan

Doc-only change. 97 tests for the implementation already passing on main.