### PR TITLE
feat(nexus-yxywl): vendor _lib.py into sn + byte-equality drift guard

### DIFF
--- a/sn/hooks/scripts/routing/_lib.py
+++ b/sn/hooks/scripts/routing/_lib.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-121 routing-hook framework.
+
+Helpers every routing hook imports. The hook protocol is:
+
+* Read JSON from stdin (the Claude Code PreToolUse payload).
+* Print exactly one JSON envelope to stdout.
+* Exit 0 on every code path including unexpected exceptions.
+
+Decision envelope shape (PreToolUse):
+
+    {"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow" | "deny",
+        "reason": "..."                 # only on deny
+        "additionalContext": "..."      # only on allow with context
+    }}
+
+Fail-open is the default. Hooks opt in to fail-closed by passing
+``fail_closed=True`` to ``run_hook``; the registry.yaml ``fail_closed:
+true`` flag is the source of truth and the hook script reads its own
+rule entry to decide.
+
+Escape token: a command may include ``# routing-allow: <reason>``
+(reason >= 8 characters) to bypass any routing hook. The token is
+audited in the telemetry log so over-use is visible.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import pathlib
+import re
+import sys
+from typing import Any, Callable
+
+ESCAPE_TOKEN = "# routing-allow:"
+ESCAPE_REASON_MIN_LENGTH = 8
+
+_DEFAULT_LOG_PATH = pathlib.Path.home() / ".config" / "nexus" / "routing_log.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Envelope builders (pure — return JSON strings)
+# ---------------------------------------------------------------------------
+
+
+def allow_envelope(context: str = "") -> str:
+    """Return an allow envelope as a JSON string."""
+    payload: dict[str, Any] = {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+    }
+    if context:
+        payload["additionalContext"] = context
+    return json.dumps({"hookSpecificOutput": payload})
+
+
+def deny_envelope(reason: str) -> str:
+    """Return a deny envelope as a JSON string."""
+    payload = {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "reason": reason,
+    }
+    return json.dumps({"hookSpecificOutput": payload})
+
+
+def warn_envelope(message: str) -> str:
+    """Semantic alias for ``allow_envelope`` that signals advisory intent.
+
+    Routing hooks emit warnings when a pattern looks suspicious but the
+    command should proceed. The permission decision stays ``allow``;
+    the message rides in ``additionalContext`` so the user sees it.
+    """
+    return allow_envelope(message)
+
+
+# ---------------------------------------------------------------------------
+# Stdout writers (impure — print then exit 0)
+# ---------------------------------------------------------------------------
+
+
+def allow(context: str = "") -> None:
+    """Emit allow envelope to stdout and ``exit 0``."""
+    sys.stdout.write(allow_envelope(context) + "\n")
+    sys.stdout.flush()
+    sys.exit(0)
+
+
+def deny(reason: str) -> None:
+    """Emit deny envelope to stdout and ``exit 0`` (never exit 2)."""
+    sys.stdout.write(deny_envelope(reason) + "\n")
+    sys.stdout.flush()
+    sys.exit(0)
+
+
+def warn(message: str) -> None:
+    """Emit warn envelope (allow + additionalContext) and ``exit 0``."""
+    sys.stdout.write(warn_envelope(message) + "\n")
+    sys.stdout.flush()
+    sys.exit(0)
+
+
+# ---------------------------------------------------------------------------
+# Input parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_stdin(raw: str) -> dict[str, Any]:
+    """Parse the Claude Code hook payload; return ``{}`` on any failure."""
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def get_bash_command(payload: dict[str, Any]) -> str:
+    """Extract the Bash ``command`` field; ``""`` if not a Bash call."""
+    if payload.get("tool_name") != "Bash":
+        return ""
+    tool_input = payload.get("tool_input") or {}
+    cmd = tool_input.get("command") if isinstance(tool_input, dict) else ""
+    return cmd if isinstance(cmd, str) else ""
+
+
+# ---------------------------------------------------------------------------
+# Escape token
+# ---------------------------------------------------------------------------
+
+_ESCAPE_RE = re.compile(
+    r"#\s*routing-allow\s*:\s*(?P<reason>.+?)\s*$",
+    re.MULTILINE,
+)
+
+
+def should_skip_for_reason(command: str) -> bool:
+    """Return True iff ``command`` carries a valid ``# routing-allow:`` escape.
+
+    Valid means: token present and the trailing reason text is at least
+    ``ESCAPE_REASON_MIN_LENGTH`` characters after stripping whitespace.
+    """
+    if not command or ESCAPE_TOKEN not in command:
+        return False
+    match = _ESCAPE_RE.search(command)
+    if not match:
+        return False
+    reason = match.group("reason").strip()
+    return len(reason) >= ESCAPE_REASON_MIN_LENGTH
+
+
+# ---------------------------------------------------------------------------
+# Telemetry
+# ---------------------------------------------------------------------------
+
+
+def _log_path() -> pathlib.Path:
+    override = os.environ.get("NX_ROUTING_LOG_PATH")
+    return pathlib.Path(override) if override else _DEFAULT_LOG_PATH
+
+
+def log_routing_event(
+    rule: str,
+    outcome: str,
+    *,
+    tool_name: str = "",
+    command_fragment: str = "",
+) -> None:
+    """Append one JSON line to the routing log. Never raises."""
+    try:
+        path = _log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+            "rule": rule,
+            "outcome": outcome,
+        }
+        if tool_name:
+            record["tool_name"] = tool_name
+        if command_fragment:
+            # Cap fragment length so the log stays small.
+            record["command_fragment"] = command_fragment[:200]
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+    except Exception:
+        # Telemetry must never crash a hook. Swallow.
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Top-level runner — wraps every hook entry point
+# ---------------------------------------------------------------------------
+
+
+def run_hook(
+    body: Callable[[dict[str, Any]], None],
+    *,
+    fail_closed: bool = False,
+    rule_name: str = "",
+) -> None:
+    """Execute ``body(payload)`` under the fail-open / fail-closed contract.
+
+    ``body`` is responsible for calling ``allow()`` / ``deny()`` /
+    ``warn()`` itself; those calls ``sys.exit(0)``. If ``body`` returns
+    normally without emitting an envelope, we fall through to a default
+    allow. If ``body`` raises ``SystemExit`` (from our own emitters), we
+    re-raise — that is the normal path. Any other exception triggers
+    the fail-open / fail-closed branch.
+    """
+    raw = ""
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        raw = ""
+
+    payload = parse_stdin(raw)
+
+    try:
+        body(payload)
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001
+        if fail_closed:
+            log_routing_event(
+                rule=rule_name or "unknown",
+                outcome="deny_fail_closed",
+                tool_name=payload.get("tool_name", "") or "",
+            )
+            deny(f"cannot verify, fail-closed: {exc}")
+        else:
+            log_routing_event(
+                rule=rule_name or "unknown",
+                outcome="allow_fail_open",
+                tool_name=payload.get("tool_name", "") or "",
+            )
+            allow()
+
+    # Body returned without emitting — default allow.
+    allow()

--- a/tests/test_routing_lib_drift.py
+++ b/tests/test_routing_lib_drift.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-125 byte-equality guard against ``_lib.py`` drift between plugins.
+
+The routing-hook framework (``nx/hooks/scripts/routing/_lib.py``) is
+vendored into each plugin that ships a routing rule. The clean import
+path is structurally blocked (RDR-125 § A2): hook scripts run under a
+system ``python3.12`` / ``python3.13`` interpreter with no
+``conexus`` venv on ``sys.path``. Vendoring is the chosen mechanism;
+this test makes the resulting drift risk loud at PR time rather than
+silent.
+
+A failure here means either:
+
+1. Someone edited one copy of ``_lib.py`` without updating the other.
+   Resolution: copy the canonical version (nx's) over the stale one
+   and re-run the test.
+2. A new plugin shipped a third copy of ``_lib.py`` without being
+   added to this test's coverage. Resolution: extend `_VENDOR_PATHS`
+   below.
+
+The framework contract is frozen per RDR-121 § Locked Contracts; the
+rate of legitimate ``_lib.py`` changes is low by design.
+
+Enforcement perimeter (RDR-125 § A3): this test runs in the nexus
+monorepo CI pipeline against a single working tree. Inside the
+monorepo, the guard is symmetric (it catches edits to either copy).
+If nx and sn ever split into separate marketplaces or separate CI
+pipelines, the guard becomes one-directional and the design needs
+revisiting.
+"""
+from __future__ import annotations
+
+import hashlib
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+CANONICAL_PATH = REPO_ROOT / "nx" / "hooks" / "scripts" / "routing" / "_lib.py"
+
+_VENDOR_PATHS: tuple[pathlib.Path, ...] = (
+    REPO_ROOT / "sn" / "hooks" / "scripts" / "routing" / "_lib.py",
+)
+
+
+def _sha256(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_canonical_lib_exists() -> None:
+    """The nx-side _lib.py is the source of truth and must exist."""
+    assert CANONICAL_PATH.exists(), (
+        f"Canonical _lib.py missing at {CANONICAL_PATH}. "
+        "Did the nx routing-hook framework move? Update this test's "
+        "CANONICAL_PATH if so."
+    )
+
+
+def test_vendored_copies_byte_equal_canonical() -> None:
+    """Every vendored copy must be byte-identical to the canonical."""
+    canonical_bytes = CANONICAL_PATH.read_bytes()
+    canonical_sha = hashlib.sha256(canonical_bytes).hexdigest()
+    failures: list[str] = []
+    for vendor in _VENDOR_PATHS:
+        if not vendor.exists():
+            failures.append(
+                f"Vendor copy missing: {vendor} "
+                "(the plugin that ships this copy hasn't been migrated yet, "
+                "or someone deleted it without updating this test)"
+            )
+            continue
+        vendor_sha = _sha256(vendor)
+        if vendor_sha != canonical_sha:
+            failures.append(
+                f"Drift detected: {vendor} (sha256={vendor_sha[:16]}...) "
+                f"differs from {CANONICAL_PATH} (sha256={canonical_sha[:16]}...). "
+                "Resolution: copy the canonical version over the vendored one "
+                "and commit, or update _lib.py in BOTH locations atomically."
+            )
+    if failures:
+        raise AssertionError(
+            "Routing-hook _lib.py drift:\n  - " + "\n  - ".join(failures)
+        )


### PR DESCRIPTION
## Summary

RDR-125 Bead A. First migration step: vendor the routing-hook
framework into sn and lock the result with a CI byte-equality guard.

## Why this shape

Per RDR-125 § A2 (T2 \`125-research-A2\`, id=1385), hook scripts run
under system \`python3\` (stdlib-only, 40ms startup budget per
RDR-121 § Locked Contracts). The clean \`import nexus.routing_hook_lib\`
path is blocked because hooks have no \`conexus\` venv on
\`sys.path\`. Vendoring is the chosen mechanism (RDR-125 § A3
revised), with the byte-equality guard converting silent drift into
a loud PR-time failure.

## Files

- \`sn/hooks/scripts/routing/_lib.py\`: byte-identical copy of
  \`nx/hooks/scripts/routing/_lib.py\`. SHA-256 verified.
- \`tests/test_routing_lib_drift.py\`: 2 tests covering canonical-
  exists and vendor-byte-equality with detailed failure messages.

## Enforcement perimeter (known limitation)

The guard is symmetric inside the nexus monorepo (single working
tree, single CI pipeline). If nx and sn ever split into separate
marketplaces or CI pipelines, the guard becomes one-directional.
Stated in the test docstring and RDR-125 § A3.

## Test plan

- [x] \`uv run pytest tests/test_routing_lib_drift.py\` (2 pass)
- [x] Negative test (inject drift, confirm failure): verified at
      authoring time
- [x] \`uv run pytest tests/test_routing_hooks.py\` (24 pass — no
      regression)
- [x] \`uv run pytest tests/test_plugin_structure.py\` (600 pass)
- [ ] CI Python 3.12 + 3.13 green

## Closes

Closes nexus-yxywl

## Next bead

\`nexus-i7mn2\` (copy grep_for_symbols hook + sn registry + sn
hooks.json PreToolUse:Bash entry) depends on this PR landing.

Refs: docs/rdr/rdr-125-routing-hook-plugin-ownership.md