### PR TITLE
docs(rdr-125): close as implemented (shipped in 4.33.1)

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -140,7 +140,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-119](rdr-119-cockpit-ui-fabric.md) | Cockpit UI Fabric — Bakke Auto-Layout over A2UI Catalogs, per-Host Realization | Architecture | **Scrapped 2026-05-19** | 2026-05-18 |
 | [RDR-120](rdr-120-storage-substrate-split.md) | Storage Substrate Split: Substrate-Only Scope, No Co-Shipped Consumers | Architecture | Draft | 2026-05-19 |
 | [RDR-121](rdr-121-hook-enforced-tool-routing.md) | Hook-Enforced Tool Routing: PreToolUse as Backstop for Soft Guidance | Architecture | Closed 2026-05-20 (shipped in 4.33.0) | 2026-05-19 |
-| [RDR-125](rdr-125-routing-hook-plugin-ownership.md) | Routing-Hook Plugin Ownership: Each Plugin Ships Its Own Rules | Architecture | Accepted 2026-05-20 | 2026-05-20 |
+| [RDR-125](rdr-125-routing-hook-plugin-ownership.md) | Routing-Hook Plugin Ownership: Each Plugin Ships Its Own Rules | Architecture | Closed 2026-05-21 (shipped in 4.33.1) | 2026-05-20 |
 
 > **Scrapped 2026-05-19 (RDR-110-119 arc).** Bundled the storage-substrate split with new abstractions (tuplespace, ORB, host-trust, surfaces-as-tuples, UI fabric); scope discipline failed across nine RDRs and 67 stranded beads. Files preserved as tombstones per the "never delete RDR files" rule. Postmortem: [docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work continues as [RDR-120](rdr-120-storage-substrate-split.md) with an explicit moratorium on co-shipped consumers. Numbers RDR-114 through RDR-117 are unused on `main` (drafted on feature branches that never merged).
 

--- a/docs/rdr/rdr-125-routing-hook-plugin-ownership.md
+++ b/docs/rdr/rdr-125-routing-hook-plugin-ownership.md
@@ -2,16 +2,59 @@
 title: "Routing-Hook Plugin Ownership: Each Plugin Ships Its Own Rules"
 id: RDR-125
 type: Architecture
-status: accepted
+status: closed
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-05-20
 accepted_date: 2026-05-20
+closed_date: 2026-05-21
+close_reason: implemented
+shipped_in: 4.33.1
 related_issues: []
 related_rdrs: [RDR-121, RDR-120]
-related_tests: []
-implementation_notes: ""
+related_tests:
+  - tests/test_routing_lib_drift.py
+  - tests/test_routing_registry_aggregate_cap.py
+  - tests/test_routing_grep_for_symbols.py
+implementation_notes: |
+  Shipped in conexus 4.33.1 (2026-05-21). All seven implementation
+  beads under epic nexus-z0yd2 closed:
+  - nexus-yxywl (Bead A): vendor _lib.py + drift guard (PR #898)
+  - nexus-i7mn2 (Bead B): copy hook to sn (PR #899)
+  - nexus-o0tth (Bead C): delete from nx (PR #899)
+  - nexus-2zeva (Bead D): aggregate-cap CI lint (PR #899)
+  - nexus-hnmfr (Bead E): repoint tests (PR #899)
+  - nexus-9hfcu (Bead F): READMEs + RDR-121 frontmatter cross-ref
+    (PR #899)
+  - nexus-pwq18 (Bead G): closeout — this RDR-close PR
+
+  Problem Statement closure pointers (Pass 2):
+  - Gap 1 (nx ships rules whose targets it does not control) ->
+    sn/hooks/scripts/routing/grep_for_symbols_redirects_to_serena.py:1
+    is now the home of the rule (moved out of nx).
+  - Gap 2 (no ownership rule for routing-hook placement) ->
+    nx/hooks/scripts/routing/README.md and
+    sn/hooks/scripts/routing/README.md document the rule:
+    "hook lives in the plugin that ships the redirect target".
+  - Gap 3 (no story for cross-plugin framework consumption) ->
+    tests/test_routing_lib_drift.py enforces byte-equality between
+    nx/hooks/scripts/routing/_lib.py and
+    sn/hooks/scripts/routing/_lib.py; vendoring is now the
+    documented mechanism.
+
+  Live shakeout (2026-05-21, conexus 4.33.1):
+  - Symbol-shaped `grep MyClass src/foo.py` correctly denied; deny
+    fires from sn-side hook (nx 4.33.1 has no grep script and no
+    registration).
+  - `nx hook routing-stats` reports the rule firing.
+  - No-sn case verified by file-layout: nx 4.33.1's
+    routing/ directory has only git_add_all and phase_review_close;
+    sessions loading nx without sn get no grep enforcement.
+
+  Cross-plugin aggregate-cap (RDR-121 + RDR-125): 4 PreToolUse:Bash
+  hooks at cap; tests/test_routing_registry_aggregate_cap.py refuses
+  commits past the cap.
 ---
 
 # RDR-125: Routing-Hook Plugin Ownership: Each Plugin Ships Its Own Rules


### PR DESCRIPTION
## Summary

Status flip: \`accepted\` -> \`closed\`. RDR-125 (Routing-Hook Plugin
Ownership) shipped end-to-end in conexus 4.33.1 (PyPI live; plugin
marketplace 4.33.1 confirmed in cache).

## Live shakeout (2026-05-21)

After reload to plugin cache 4.33.1:

- \`grep MyClass src/foo.py\` correctly denied. Deny now fires from
  sn-owned hook (\`sn/hooks/scripts/routing/grep_for_symbols_redirects_to_serena.py\`).
- nx 4.33.1 plugin cache: only \`git_add_all\` + \`phase_review_close\`
  remain in \`routing/\`. No grep script, no registration in
  \`hooks.json\`.
- \`nx hook routing-stats\` reports the rule firing.
- No-sn case verified by file layout: a session loading nx without
  sn gets no grep enforcement (the architectural property the RDR
  set out to deliver).

## Problem Statement Pass 2

| Gap | Resolved at |
|-----|-------------|
| 1: nx ships rules whose targets it does not control | \`sn/hooks/scripts/routing/grep_for_symbols_redirects_to_serena.py:1\` |
| 2: no ownership rule for routing-hook placement | \`nx/hooks/scripts/routing/README.md\` + \`sn/hooks/scripts/routing/README.md\` |
| 3: no story for cross-plugin framework consumption | \`tests/test_routing_lib_drift.py\` (byte-equality vendor guard) |

## Epic close

Epic \`nexus-z0yd2\` — all 7 children closed (\`yxywl\`, \`i7mn2\`,
\`o0tth\`, \`2zeva\`, \`hnmfr\`, \`9hfcu\`, \`pwq18\`).

## T2 evidence

- \`nexus_rdr/125\` (RDR metadata)
- \`nexus_rdr/125-gate-latest\` (gate PASSED, id=1387)
- \`nexus_rdr/125-research-A1\` (id=1384)
- \`nexus_rdr/125-research-A2\` (id=1385)
- \`nexus_rdr/125-close\` (id=1394, this close)

## Test plan

Doc-only PR. 97 routing tests already passing on main.

## Closes

Closes nexus-pwq18