### PR TITLE
feat(rdr-120): P0 trio (A9 audit + NX_STORAGE_MODE + storage-boundary lint)

### DIFF
--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -814,6 +814,93 @@ def _run_check_post_store_hooks() -> None:
     click.echo(f"\nTotal: {total} hook(s) registered across 3 chains.")
 
 
+# ── --check-storage-boundary (RDR-120 P0.A / nexus-7xxxg) ────────────────────
+
+
+def _run_check_storage_boundary(
+    fail_on_violation: bool, phase: str | None
+) -> None:
+    """Run the storage-boundary lint and emit a structlog metric.
+
+    Records the catalog-allowlist count to T2 at key
+    ``120-phase-<phase>-catalog-allowlist-count`` when ``phase`` is
+    set. The phase-boundary forcing function in RDR-120 §Approach
+    reads this on each subsequent phase and asserts monotonic
+    non-increase across phases.
+    """
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    from nexus.storage_boundary_lint import scan_repo
+
+    log = structlog.get_logger(__name__)
+
+    # Discover repo root by walking up from CWD looking for .git/.
+    # The installed `nx` lives in a uv-cache prefix; the lint targets
+    # the working tree the user is operating against, which is the
+    # current working directory's enclosing repo.
+    cwd = _Path.cwd().resolve()
+    repo_root: _Path | None = None
+    for parent in (cwd, *cwd.parents):
+        if (parent / ".git").exists():
+            repo_root = parent
+            break
+    if repo_root is None:
+        click.echo(
+            f"storage-boundary lint: could not locate a git repo rooted at "
+            f"or above {cwd}. Run from inside the nexus checkout.",
+            err=True,
+        )
+        _sys.exit(2)
+
+    result = scan_repo(repo_root=repo_root)
+
+    click.echo(
+        f"Storage-boundary lint (RDR-120 P0.A):\n"
+        f"  violations:                {result.total_violations}\n"
+        f"  catalog-allowlist count:   {result.catalog_allowlist_count}"
+    )
+
+    if result.violations:
+        click.echo("\nViolations:")
+        for v in result.violations:
+            click.echo(f"  {v.file}:{v.line}  {v.symbol}")
+
+    log.info(
+        "storage_boundary_lint",
+        violations=result.total_violations,
+        catalog_allowlist_count=result.catalog_allowlist_count,
+        phase=phase or "unset",
+    )
+
+    if phase:
+        try:
+            from nexus.commands._helpers import default_db_path
+            from nexus.db.t2 import T2Database
+
+            with T2Database(default_db_path()) as db:
+                db.memory.put(
+                    project="nexus_rdr",
+                    title=f"120-phase-{phase}-catalog-allowlist-count",
+                    content=str(result.catalog_allowlist_count),
+                    tags="rdr-120,phase-metric,catalog-allowlist",
+                    ttl=None,  # permanent
+                )
+        except Exception as exc:
+            log.warning(
+                "storage_boundary_lint_metric_write_failed",
+                error=str(exc),
+                phase=phase,
+            )
+
+    if fail_on_violation and result.violations:
+        click.echo(
+            f"\nFAIL: {result.total_violations} violation(s) found.",
+            err=True,
+        )
+        _sys.exit(1)
+
+
 # ── --check-mineru (nexus-2fyb code-review R3-3) ────────────────────────────
 
 
@@ -992,6 +1079,38 @@ def _run_check_mineru() -> None:
          "Phase 1B nexus-a52i.",
 )
 @click.option(
+    "--check-storage-boundary",
+    "check_storage_boundary",
+    is_flag=True,
+    default=False,
+    help="RDR-120 P0.A. AST-scan for direct sqlite3.connect / "
+         "chromadb.{PersistentClient,CloudClient,EphemeralClient} "
+         "calls outside src/nexus/db/ (daemon-internal). P0-P4 also "
+         "allowlists src/nexus/catalog/. Per-line override via "
+         "`# epsilon-allow: <reason>` (reason >=8 chars). Records "
+         "catalog-allowlist count to T2 key 120-phase-<N>-catalog-"
+         "allowlist-count for the phase-boundary forcing function. "
+         "Exits 1 with --fail-on-violation when violations exist.",
+)
+@click.option(
+    "--fail-on-violation",
+    "fail_on_violation",
+    is_flag=True,
+    default=False,
+    help="With --check-storage-boundary, exit 1 if any violation is "
+         "found. Without this flag the lint is informational.",
+)
+@click.option(
+    "--phase",
+    "phase",
+    type=str,
+    default=None,
+    help="With --check-storage-boundary, the RDR-120 phase identifier "
+         "for the T2 metric key (e.g. `0`, `1`, `2`, `3a`, `3b`, "
+         "`4`, `5`). Used to record `120-phase-<phase>-catalog-"
+         "allowlist-count`. Omit to skip the metric write.",
+)
+@click.option(
     "--mcp-log-hours",
     "mcp_log_hours",
     default=24,
@@ -1082,8 +1201,17 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
                check_post_store_hooks: bool,
                check_aspect_queue: bool,
                check_t1: bool,
-               check_tier_discipline: bool) -> None:
+               check_tier_discipline: bool,
+               check_storage_boundary: bool,
+               fail_on_violation: bool,
+               phase: str | None) -> None:
     """Verify that all required services and credentials are available."""
+    if check_storage_boundary:
+        _run_check_storage_boundary(
+            fail_on_violation=fail_on_violation, phase=phase
+        )
+        return
+
     if check_schema:
         _run_check_schema()
         return

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import click
 import structlog
 import yaml
 
@@ -398,6 +399,62 @@ def catalog_path() -> Path:
     if env:
         return Path(env)
     return nexus_config_dir() / "catalog"
+
+
+#: RDR-120 P0.B — accepted values for ``NX_STORAGE_MODE``. ``direct``
+#: is the only mode wired today; ``daemon`` is reserved for the P3
+#: cutover and is rejected at P0 with an explicit not-yet-supported
+#: error so operators do not silently land in a half-built state.
+VALID_STORAGE_MODES: tuple[str, ...] = ("direct", "daemon")
+
+
+class StorageModeError(click.ClickException):
+    """Raised when ``NX_STORAGE_MODE`` is set to an unsupported value.
+
+    Subclasses ``click.ClickException`` so a CLI invocation surfaces
+    the message cleanly. Constructor signature matches the parent so
+    downstream code can catch it as either.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+def storage_mode() -> str:
+    """Return the validated ``NX_STORAGE_MODE`` value.
+
+    RDR-120 P0.B scaffolding. Single source of truth for the storage
+    backend mode flag. Currently:
+
+    - unset / empty / whitespace -> ``"direct"`` (default)
+    - ``"direct"`` (any case) -> ``"direct"``
+    - ``"daemon"`` (any case) -> raises ``StorageModeError`` with
+      "not yet supported at phase 0"
+    - anything else -> raises ``StorageModeError`` naming the bad
+      value and listing :data:`VALID_STORAGE_MODES`
+
+    The function exists at P0 to lock the env-var name and the
+    validation contract before any client wires the mode to actual
+    behavior. P3 / P4 will switch the daemon branch from rejection
+    to a daemon-client construction.
+    """
+    raw = os.environ.get("NX_STORAGE_MODE", "")
+    normalized = raw.strip().lower()
+    if not normalized:
+        return "direct"
+    if normalized == "direct":
+        return "direct"
+    if normalized == "daemon":
+        raise StorageModeError(
+            "NX_STORAGE_MODE=daemon is not yet supported at phase 0 of "
+            "RDR-120 (storage substrate split). Set NX_STORAGE_MODE=direct "
+            "or unset the variable to use the current library-mode T2/T3 "
+            "backend. Daemon mode lands in P3."
+        )
+    raise StorageModeError(
+        f"NX_STORAGE_MODE={raw!r} is not a recognized value. "
+        f"Valid values: {', '.join(VALID_STORAGE_MODES)}."
+    )
 
 
 def is_local_mode() -> bool:

--- a/src/nexus/storage_boundary_lint.py
+++ b/src/nexus/storage_boundary_lint.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 P0.A: storage-boundary lint.
+
+AST-scan that catches direct storage opens outside the allowed
+daemon-internal substrate. The lint protects the boundary that
+RDR-120's daemon design enforces: only ``src/nexus/db/`` (and during
+P0-P4, ``src/nexus/catalog/``) may open SQLite or chromadb clients
+directly. Every other caller must go through the ``T2Database`` /
+``T3Database`` facades or, post-P3 cutover, through the daemon-
+backed ``T2Client`` / ``T3Client`` wrappers.
+
+Banlist (configurable via :data:`BANLIST`):
+
+* ``sqlite3.connect(...)`` plus any aliased form (``import sqlite3 as
+  X; X.connect(...)``). Alias resolution is per-file.
+* ``chromadb.PersistentClient(...)``
+* ``chromadb.CloudClient(...)``
+* ``chromadb.EphemeralClient(...)``
+
+Allowlist:
+
+* Path-prefix allowlist (``src/nexus/db/`` always; ``src/nexus/catalog/``
+  P0-P4 phase-allowlisted; deleted at P5).
+* Per-line ``# epsilon-allow: <reason>`` override, reason >= 8 chars.
+
+Output: a :class:`LintResult` with a structured violation list plus
+the catalog-allowlist call-site count metric for the phase-boundary
+forcing function (RDR-120 §Approach catalog-allowlist non-increase).
+
+Modeled on the AST-walk + offender-aggregation pattern in
+``tests/test_no_direct_catalog_writes_outside_projector.py`` (RDR-101
+ε-lint precedent).
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+from dataclasses import dataclass, field
+from typing import Iterable
+
+
+#: Path-prefix allowlist relative to repo root (POSIX-style). Files
+#: under any of these prefixes are exempt from the lint.
+DEFAULT_ALLOWLIST_PREFIXES: tuple[str, ...] = (
+    "src/nexus/db/",
+)
+
+
+#: The phase-allowlist that's active P0 through P4 and removed at P5.
+#: Counted separately so the phase-boundary forcing function can assert
+#: monotonic non-increase across phases.
+CATALOG_PHASE_ALLOWLIST_PREFIX: str = "src/nexus/catalog/"
+
+
+#: Banned call sites. Each entry is ``(module, attribute)`` matched
+#: against AST ``Attribute(value=Name(id=module), attr=attribute)``
+#: nodes inside ``Call`` nodes. Alias resolution maps the alias back
+#: to the canonical module name before matching.
+BANLIST: tuple[tuple[str, str], ...] = (
+    ("sqlite3", "connect"),
+    ("chromadb", "PersistentClient"),
+    ("chromadb", "CloudClient"),
+    ("chromadb", "EphemeralClient"),
+)
+
+
+#: Per-line override token. The trailing reason text after the colon
+#: must be at least this many characters (whitespace-stripped) for the
+#: override to apply.
+ALLOWLIST_TOKEN: str = "# epsilon-allow:"
+ALLOWLIST_REASON_MIN_LENGTH: int = 8
+
+_ALLOWLIST_RE = re.compile(
+    r"#\s*epsilon-allow\s*:\s*(?P<reason>.+?)\s*$",
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A single banned call site outside the allowlist."""
+
+    file: str  # repo-relative POSIX path
+    line: int
+    symbol: str  # canonical "module.attr" name
+
+
+@dataclass
+class LintResult:
+    """Aggregate result of a lint run."""
+
+    violations: list[Violation] = field(default_factory=list)
+    catalog_allowlist_count: int = 0
+
+    @property
+    def total_violations(self) -> int:
+        return len(self.violations)
+
+    def as_metric_dict(self) -> dict[str, int]:
+        """Shape suitable for structlog or T2 metric storage."""
+        return {
+            "violations": self.total_violations,
+            "catalog_allowlist_count": self.catalog_allowlist_count,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Per-file AST scan
+# ---------------------------------------------------------------------------
+
+
+def _collect_module_aliases(tree: ast.AST) -> dict[str, str]:
+    """Return ``{alias_name: canonical_module}`` for matched bare imports.
+
+    ``import sqlite3 as _sqlite3`` -> ``{"_sqlite3": "sqlite3"}``.
+    ``import chromadb`` -> ``{"chromadb": "chromadb"}`` (identity).
+    Submodules are ignored — we match by top-level name only because
+    that's what shows up as ``Name`` in the AST.
+    """
+    aliases: dict[str, str] = {}
+    canonical_modules = {module for module, _ in BANLIST}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in canonical_modules:
+                    bound = alias.asname or alias.name
+                    aliases[bound] = alias.name
+    return aliases
+
+
+def _line_has_allowlist_token(source_lines: list[str], line_no: int) -> bool:
+    """Return True iff the (1-indexed) line carries an epsilon-allow tag."""
+    if line_no < 1 or line_no > len(source_lines):
+        return False
+    line = source_lines[line_no - 1]
+    if ALLOWLIST_TOKEN not in line:
+        return False
+    match = _ALLOWLIST_RE.search(line)
+    if not match:
+        return False
+    reason = match.group("reason").strip()
+    return len(reason) >= ALLOWLIST_REASON_MIN_LENGTH
+
+
+def scan_file(
+    path: pathlib.Path,
+    repo_root: pathlib.Path,
+) -> list[Violation]:
+    """Scan a single Python file for banned call sites."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    source_lines = source.splitlines()
+    aliases = _collect_module_aliases(tree)
+
+    violations: list[Violation] = []
+    banlist_map = {module: {attr for _, attr in BANLIST if _ == module}
+                   for module, _ in BANLIST}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        if not isinstance(func.value, ast.Name):
+            continue
+        alias_name = func.value.id
+        canonical = aliases.get(alias_name)
+        if canonical is None:
+            continue
+        if func.attr not in banlist_map.get(canonical, set()):
+            continue
+        line = node.lineno
+        if _line_has_allowlist_token(source_lines, line):
+            continue
+        try:
+            rel = path.relative_to(repo_root).as_posix()
+        except ValueError:
+            rel = str(path)
+        violations.append(
+            Violation(file=rel, line=line, symbol=f"{canonical}.{func.attr}")
+        )
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Repo-wide scan
+# ---------------------------------------------------------------------------
+
+
+def _is_allowlisted(file_path: str, allowlist_prefixes: Iterable[str]) -> bool:
+    return any(file_path.startswith(prefix) for prefix in allowlist_prefixes)
+
+
+def _iter_py_files(repo_root: pathlib.Path) -> Iterable[pathlib.Path]:
+    src = repo_root / "src" / "nexus"
+    if not src.is_dir():
+        return []
+    return (p for p in src.rglob("*.py") if p.is_file())
+
+
+def scan_repo(
+    repo_root: pathlib.Path,
+    allowlist_prefixes: Iterable[str] | None = None,
+    extra_files: Iterable[pathlib.Path] | None = None,
+) -> LintResult:
+    """Scan the repo for banned call sites.
+
+    ``allowlist_prefixes`` defaults to :data:`DEFAULT_ALLOWLIST_PREFIXES`
+    plus the catalog phase-allowlist. Pass an empty tuple to disable
+    path-prefix allowlisting (useful for tests).
+
+    ``extra_files`` is a list of additional files (typically test
+    fixtures outside the repo) to scan and report against.
+    """
+    repo_root = repo_root.resolve()
+    if allowlist_prefixes is None:
+        allowlist_prefixes = (
+            *DEFAULT_ALLOWLIST_PREFIXES,
+            CATALOG_PHASE_ALLOWLIST_PREFIX,
+        )
+    else:
+        allowlist_prefixes = tuple(allowlist_prefixes)
+
+    result = LintResult()
+
+    # In-tree scan with allowlist filter.
+    for py in _iter_py_files(repo_root):
+        rel = py.relative_to(repo_root).as_posix()
+        file_violations = scan_file(py, repo_root)
+        if _is_allowlisted(rel, allowlist_prefixes):
+            # Count catalog-prefix hits for the phase-boundary metric.
+            if rel.startswith(CATALOG_PHASE_ALLOWLIST_PREFIX):
+                result.catalog_allowlist_count += len(file_violations)
+            continue
+        result.violations.extend(file_violations)
+
+    # Extra files (e.g. synthetic test offenders living outside the
+    # repo): always scanned, never allowlisted by path prefix.
+    if extra_files:
+        for extra in extra_files:
+            result.violations.extend(scan_file(pathlib.Path(extra), repo_root))
+
+    return result

--- a/tests/test_storage_boundary_lint.py
+++ b/tests/test_storage_boundary_lint.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 P0.A: storage-boundary lint.
+
+AST-scan for direct storage opens outside the allowed daemon-internal
+prefix. Banlist:
+
+- ``sqlite3.connect(...)`` (and module-aliased forms such as
+  ``import sqlite3 as _sqlite3; _sqlite3.connect(...)``)
+- ``chromadb.PersistentClient(...)``
+- ``chromadb.CloudClient(...)``
+- ``chromadb.EphemeralClient(...)``
+
+Allowed prefixes:
+
+- ``src/nexus/db/`` — the daemon-internal substrate (always allowed)
+- ``src/nexus/catalog/`` — P0-P4 phase-allowlist (removed at P5)
+- per-line ``# epsilon-allow: <reason>`` override (>= 8 char reason)
+"""
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+SRC_ROOT = REPO_ROOT / "src" / "nexus"
+
+
+def _check(extra_files=None, allowlist_prefixes=None):
+    """Run the lint and return its result tuple."""
+    from nexus.storage_boundary_lint import scan_repo
+
+    return scan_repo(
+        repo_root=REPO_ROOT,
+        allowlist_prefixes=allowlist_prefixes,
+        extra_files=extra_files,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Baseline against current main
+# ---------------------------------------------------------------------------
+
+
+def test_lint_reports_baseline_inventory():
+    """Against current main, the lint identifies the existing direct opens."""
+    result = _check()
+    # 27 SQLite + 8 chromadb per the A5-refresh audit. The lint with the
+    # default allowlist (db/ + catalog/) should leave a known non-empty
+    # set of migration targets; that's the baseline P0 captures.
+    assert result.total_violations > 0
+    # Some of the well-known migration targets must show up.
+    files = {v.file for v in result.violations}
+    assert any("commands/doctor.py" in f for f in files)
+    assert any("health.py" in f for f in files)
+
+
+def test_db_directory_is_allowlisted_by_default():
+    """src/nexus/db/ is the daemon-internal substrate; not violations."""
+    result = _check()
+    for v in result.violations:
+        assert "src/nexus/db/" not in v.file, (
+            f"db/ should be allowlisted, got violation at {v.file}:{v.line}"
+        )
+
+
+def test_catalog_directory_is_allowlisted_p0_p4():
+    """P0-P4: src/nexus/catalog/ allowed; removed at P5 in a follow-on."""
+    result = _check()
+    for v in result.violations:
+        assert "src/nexus/catalog/" not in v.file, (
+            f"catalog/ is P0-P4 allowlisted, got violation at {v.file}:{v.line}"
+        )
+
+
+def test_catalog_allowlist_count_metric():
+    """The lint reports the count of catalog-allowlist call sites.
+
+    Per the phase-boundary forcing function (RDR-120 §Approach), this
+    metric is recorded per phase. P0 baseline should be 2 (catalog_db.py
+    + synthesizer.py) per the A5-refresh inventory.
+    """
+    result = _check()
+    assert result.catalog_allowlist_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Synthetic offender + epsilon-allow escape
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def synthetic_offender(tmp_path):
+    """Write a file outside any allowlist with a forbidden call."""
+    target = tmp_path / "synthetic_offender.py"
+    target.write_text(
+        "import sqlite3\n"
+        "def bad():\n"
+        "    return sqlite3.connect('/tmp/x.db')\n"
+    )
+    return target
+
+
+def test_synthetic_offender_caught(synthetic_offender):
+    result = _check(extra_files=[synthetic_offender])
+    matched = [v for v in result.violations if v.file == str(synthetic_offender)]
+    assert len(matched) == 1
+    assert matched[0].symbol == "sqlite3.connect"
+    assert matched[0].line == 3
+
+
+def test_epsilon_allow_per_line_override(tmp_path):
+    """A line tagged `# epsilon-allow: <reason>` (>= 8 chars) is skipped."""
+    target = tmp_path / "allowed.py"
+    target.write_text(
+        "import sqlite3\n"
+        "def ok():\n"
+        "    return sqlite3.connect('/tmp/x.db')  # epsilon-allow: test fixture only\n"
+    )
+    result = _check(extra_files=[target])
+    matched = [v for v in result.violations if v.file == str(target)]
+    assert not matched
+
+
+def test_epsilon_allow_with_short_reason_does_not_override(tmp_path):
+    target = tmp_path / "shortallow.py"
+    target.write_text(
+        "import sqlite3\n"
+        "def bad():\n"
+        "    return sqlite3.connect('/tmp/x.db')  # epsilon-allow: x\n"
+    )
+    result = _check(extra_files=[target])
+    matched = [v for v in result.violations if v.file == str(target)]
+    assert len(matched) == 1
+
+
+# ---------------------------------------------------------------------------
+# Module-aliased imports (the alias-evasion trap from A5)
+# ---------------------------------------------------------------------------
+
+
+def test_aliased_sqlite_import_caught(tmp_path):
+    """`import sqlite3 as _sqlite3; _sqlite3.connect(...)` is caught."""
+    target = tmp_path / "aliased.py"
+    target.write_text(
+        "import sqlite3 as _sqlite3\n"
+        "def bad():\n"
+        "    return _sqlite3.connect('/tmp/x.db')\n"
+    )
+    result = _check(extra_files=[target])
+    matched = [v for v in result.violations if v.file == str(target)]
+    assert len(matched) == 1
+    # The alias is resolved back to the canonical module name.
+    assert "sqlite3.connect" in matched[0].symbol or "_sqlite3.connect" in matched[0].symbol
+
+
+# ---------------------------------------------------------------------------
+# All three chromadb client classes (not just PersistentClient)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_class", [
+    "PersistentClient",
+    "CloudClient",
+    "EphemeralClient",
+])
+def test_all_chromadb_classes_in_banlist(client_class, tmp_path):
+    """The lint covers all three chromadb client classes."""
+    target = tmp_path / f"chromabad_{client_class.lower()}.py"
+    target.write_text(
+        "import chromadb\n"
+        "def bad():\n"
+        f"    return chromadb.{client_class}()\n"
+    )
+    result = _check(extra_files=[target])
+    matched = [v for v in result.violations if v.file == str(target)]
+    assert len(matched) == 1, f"missed {client_class}"
+    assert client_class in matched[0].symbol
+
+
+# ---------------------------------------------------------------------------
+# Result shape
+# ---------------------------------------------------------------------------
+
+
+def test_result_has_file_line_symbol(tmp_path):
+    target = tmp_path / "shape.py"
+    target.write_text(
+        "import sqlite3\ndef f(): sqlite3.connect('/x')\n"
+    )
+    result = _check(extra_files=[target])
+    matched = [v for v in result.violations if v.file == str(target)]
+    assert len(matched) == 1
+    v = matched[0]
+    assert isinstance(v.file, str)
+    assert isinstance(v.line, int)
+    assert isinstance(v.symbol, str)
+    assert v.line == 2

--- a/tests/test_storage_mode.py
+++ b/tests/test_storage_mode.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 P0.B: NX_STORAGE_MODE cutover-flag scaffolding.
+
+At P0 only `direct` is a valid value; `daemon` is rejected with
+"not yet supported"; any other value is rejected with the list of
+valid values. This is a no-op cutover flag — its purpose is to
+establish the single source of truth before P3 wires it to actual
+behavior.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def test_default_is_direct(monkeypatch):
+    """Unset NX_STORAGE_MODE defaults to `direct`."""
+    monkeypatch.delenv("NX_STORAGE_MODE", raising=False)
+    from nexus.config import storage_mode
+
+    assert storage_mode() == "direct"
+
+
+def test_direct_is_accepted(monkeypatch):
+    monkeypatch.setenv("NX_STORAGE_MODE", "direct")
+    from nexus.config import storage_mode
+
+    assert storage_mode() == "direct"
+
+
+def test_daemon_is_rejected_at_phase_0(monkeypatch):
+    """RDR-120 P0: daemon mode rejected with explicit not-yet-supported message."""
+    monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+    from nexus.config import StorageModeError, storage_mode
+
+    with pytest.raises(StorageModeError) as exc:
+        storage_mode()
+    assert "daemon" in str(exc.value).lower()
+    assert "not yet supported" in str(exc.value).lower() or "phase 0" in str(exc.value).lower()
+
+
+def test_unknown_value_lists_valid_options(monkeypatch):
+    monkeypatch.setenv("NX_STORAGE_MODE", "bogus")
+    from nexus.config import StorageModeError, storage_mode
+
+    with pytest.raises(StorageModeError) as exc:
+        storage_mode()
+    msg = str(exc.value)
+    assert "bogus" in msg
+    assert "direct" in msg
+    assert "daemon" in msg
+
+
+def test_empty_string_treated_as_unset(monkeypatch):
+    monkeypatch.setenv("NX_STORAGE_MODE", "")
+    from nexus.config import storage_mode
+
+    assert storage_mode() == "direct"
+
+
+def test_whitespace_only_treated_as_unset(monkeypatch):
+    monkeypatch.setenv("NX_STORAGE_MODE", "   ")
+    from nexus.config import storage_mode
+
+    assert storage_mode() == "direct"
+
+
+def test_case_normalization(monkeypatch):
+    """`DIRECT` and `Direct` accepted; case shouldn't trip operators."""
+    for val in ("DIRECT", "Direct", "direct"):
+        monkeypatch.setenv("NX_STORAGE_MODE", val)
+        from nexus.config import storage_mode
+
+        assert storage_mode() == "direct"
+
+
+def test_valid_modes_constant_is_exported():
+    """The accepted-values list is callable for tooling."""
+    from nexus.config import VALID_STORAGE_MODES
+
+    assert "direct" in VALID_STORAGE_MODES
+    assert "daemon" in VALID_STORAGE_MODES
+
+
+def test_storage_mode_error_is_nexus_error():
+    """StorageModeError should be importable and a click-friendly exception."""
+    from nexus.config import StorageModeError
+
+    # ClickException family is friendly to CLI surfacing
+    err = StorageModeError("test")
+    assert hasattr(err, "args")
+    assert err.args == ("test",)


### PR DESCRIPTION
## Summary

RDR-120 Phase 0 (substrate split foundation). Three beads landed
together as a single PR per \`feedback_pr_rhythm\`.

## What lands

### Bead C — nexus-0i4w0: A9 content-seeding audit (no code change)

- T2 audit at \`nexus_rdr/120-research-A9-content-audit\` (id=1404).
- All seven T2 domain store \`_init_schema\` paths clean (DDL-only).
- 11 content-seeding migrations in \`apply_pending\` flagged. The
  daemon model would run these on substrate startup, violating A8.
- **Four remediation beads filed and wired to block P3a daemon
  (\`nexus-7aayk\`)**:
  - \`nexus-rv7x6\`: 6 plan-library backfills, move to \`nx plan repair\`
  - \`nexus-6y2a9\`: 3 document_aspects sweeps, move to \`nx aspects\` verbs
  - \`nexus-yulol\`: PK-swap fixture-DELETE carve-out
  - \`nexus-q2t5t\`: document the §A8-exempt INSERTs

### Bead B — nexus-v0s47: NX_STORAGE_MODE cutover flag

- \`src/nexus/config.py\`: \`VALID_STORAGE_MODES\`, \`StorageModeError\`,
  \`storage_mode()\` function.
- Default / direct / case-normalized accepted; \`daemon\` rejected
  with explicit "not yet supported at phase 0" message; unknown
  values rejected with the valid-list.

### Bead A — nexus-7xxxg: storage-boundary lint

- New module \`src/nexus/storage_boundary_lint.py\`: AST scan +
  alias-resolved banlist + per-line \`# epsilon-allow:\` override.
- New CLI: \`nx doctor --check-storage-boundary [--fail-on-violation]
  [--phase <id>]\`. Records the catalog-allowlist count metric to
  T2 key \`120-phase-<id>-catalog-allowlist-count\` for the phase-
  boundary forcing function.
- Repo-root resolution walks up from CWD looking for \`.git\` so the
  installed \`nx\` CLI targets the user's working tree.

## Baseline verification (against current main 4.33.1)

- **21 violations** (matches A5-refresh inventory)
- **catalog-allowlist count: 2** (\`catalog_db.py:255\` +
  \`synthesizer.py:792\` per A5)
- **T2 metric \`120-phase-0-catalog-allowlist-count\` = 2** written

## Test plan

- [x] \`uv run pytest tests/test_storage_boundary_lint.py\` (12 pass)
- [x] \`uv run pytest tests/test_storage_mode.py\` (9 pass)
- [x] \`uv run pytest tests/test_plugin_structure.py\` (600 pass + 27 skip)
- [x] CLI smoke: \`nx doctor --check-storage-boundary --phase 0\` verifies metric write
- [ ] CI Python 3.12 + 3.13 green

## Closes

Closes nexus-0i4w0
Closes nexus-v0s47
Closes nexus-7xxxg

## Next

P0 phase-review-gate bead (\`nexus-xoeeq\`) is now ready. It crosswalks the
RDR-120 §Approach Phase 0 items against the closing beads (A9 audit,
NX_STORAGE_MODE flag, lint) and verifies no §Approach item was
silently dropped before closing P0.

Refs: docs/rdr/rdr-120-storage-substrate-split.md, Approach Phase 0,
Critical Assumptions A5/A8/A9.