### PR TITLE
feat(rdr-120): nexus-beoh1 P1.B T3Client factory

### DIFF
--- a/.beads/push-state.json
+++ b/.beads/push-state.json
@@ -1,4 +1,4 @@
 {
-  "last_push": "2026-05-21T17:54:58Z",
-  "last_commit": "vfdgubq08dp1utdalu26suiva44lincr"
+  "last_push": "2026-05-21T18:30:54Z",
+  "last_commit": "segcrf26aeqa56v8qs05itqa147b9tov"
 }

--- a/src/nexus/daemon/t3_client.py
+++ b/src/nexus/daemon/t3_client.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 P1.B (nexus-beoh1) — T3Client factory.
+
+The integration seam the P2 call-site flip consumes. Returns a real
+``T3Database`` whose ``_client`` is a ``chromadb.HttpClient`` pointed at
+the running ``nx daemon t3``. Surface parity by construction: same
+class as direct-mode ``make_t3()``, no shim, no method drift.
+
+Resolution chain:
+1. ``is_local_mode()`` must be True. Cloud mode raises ``T3DaemonError``
+   because chromadb's ``CloudClient`` is already HTTP-served; running a
+   local daemon would be a no-op. The daemon-start side gate in
+   ``t3_daemon.start_t3_daemon`` is defence-in-depth.
+2. ``discovery_resolve('t3')`` resolves the daemon's address via the
+   ``NX_T3_ADDR`` env-var or the discovery file (RDR-120 C2
+   precedence: env wins when set + non-empty; file fallback when env
+   unset; a set-but-unreachable env-var surfaces at connect time).
+   Missing daemon raises ``T3DaemonError`` carrying the same recovery
+   hint as ``DaemonNotRunningError``.
+3. Construct ``chromadb.HttpClient(host, port)`` + apply the
+   ``_apply_chroma_http_timeout`` override; chromadb defaults to
+   ``httpx.Client(timeout=None)`` which hangs forever on stalled reads.
+4. Construct + inject ``LocalEmbeddingFunction``; the daemon is
+   local-only, so Voyage embeddings are not in play.
+5. Return ``T3Database(_client=httpclient, _ef_override=ef,
+   local_mode=True, local_path=<discovery payload>)``.
+
+No auto-spawn. ``nx daemon t3 start`` is the only path that spawns the
+chroma subprocess (RDR-120 §Approach C2: auto-spawn is excluded from
+P1; the explicit-start contract matches the locked phasing).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+import structlog
+
+if TYPE_CHECKING:
+    from nexus.db.t3 import T3Database
+
+_log = structlog.get_logger(__name__)
+
+
+class T3DaemonError(RuntimeError):
+    """Raised by ``make_t3_client`` when the T3 daemon is not reachable.
+
+    Two cases share this type:
+    - Cloud mode: no daemon should exist; caller should use the direct
+      ``make_t3()`` (which builds a ``CloudClient`` directly).
+    - Local mode + no daemon running: caller must ``nx daemon t3 start``
+      before retrying. Message embeds the recovery hint verbatim.
+    """
+
+
+def make_t3_client(*, config_dir: Optional[Path] = None) -> "T3Database":
+    """Return a ``T3Database`` connected to the running T3 daemon.
+
+    Args:
+        config_dir: Optional override for the discovery file location
+            (defaults to ``nexus.config.nexus_config_dir()``).
+
+    Raises:
+        T3DaemonError: when cloud mode is active OR the T3 daemon is
+            not reachable. The message names the recovery action.
+    """
+    from nexus.config import is_local_mode
+    from nexus.daemon.discovery import (
+        DaemonNotRunningError,
+        discovery_resolve,
+    )
+    from nexus.db.t3 import T3Database, _apply_chroma_http_timeout
+
+    if not is_local_mode():
+        raise T3DaemonError(
+            "T3 daemon is a no-op in cloud mode. chromadb's CloudClient "
+            "is already HTTP-served; use the direct ``make_t3()`` factory "
+            "from ``nexus.db`` for cloud access. Set NX_LOCAL=1 to opt "
+            "into the local daemon path."
+        )
+
+    try:
+        payload = discovery_resolve("t3", config_dir=config_dir)
+    except DaemonNotRunningError as exc:
+        raise T3DaemonError(str(exc)) from exc
+
+    host = payload.get("tcp_host")
+    port = payload.get("tcp_port")
+    if not isinstance(host, str) or not isinstance(port, int):
+        raise T3DaemonError(
+            f"Discovery payload missing or invalid tcp_host/tcp_port: "
+            f"host={host!r}, port={port!r}. Re-start with: "
+            f"`nx daemon t3 stop && nx daemon t3 start`."
+        )
+
+    import chromadb
+    http_client = chromadb.HttpClient(host=host, port=port)
+    _apply_chroma_http_timeout(http_client)
+
+    from nexus.db.local_ef import LocalEmbeddingFunction
+    import os
+    model_override = os.environ.get("NX_LOCAL_EMBED_MODEL", "")
+    ef = LocalEmbeddingFunction(
+        model_name=model_override if model_override else None,
+    )
+
+    local_path_str = payload.get("local_path", "")
+    _log.info(
+        "t3_client_constructed",
+        host=host,
+        port=port,
+        source=payload.get("source"),
+        local_path=local_path_str,
+    )
+    return T3Database(
+        local_mode=True,
+        local_path=local_path_str,
+        _client=http_client,
+        _ef_override=ef,
+    )

--- a/tests/daemon/test_t3_client.py
+++ b/tests/daemon/test_t3_client.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 P1.B (nexus-beoh1): T3Client factory tests.
+
+The factory is ``make_t3_client()`` returning a ``T3Database`` whose
+``_client`` is a ``chromadb.HttpClient`` pointed at the running ``nx
+daemon t3`` (per ``discovery_resolve('t3')``).
+
+Surface parity by construction: the returned ``T3Database`` IS the same
+class returned by ``make_t3()`` in direct mode — no shim, no method
+drift. The only difference is the injected client.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    cd = tmp_path / "nexus_config"
+    cd.mkdir()
+    return cd
+
+
+@pytest.fixture
+def local_path(tmp_path: Path) -> Path:
+    p = tmp_path / "chroma_t3"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def force_local_mode(monkeypatch):
+    monkeypatch.setenv("NX_LOCAL", "1")
+
+
+@pytest.fixture
+def live_t3_daemon(config_dir: Path, local_path: Path, force_local_mode):
+    """Spawn a real T3 daemon, yield the discovery payload, stop on teardown."""
+    from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+
+    payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+    try:
+        yield payload
+    finally:
+        stop_t3_daemon(config_dir=config_dir)
+
+
+class TestFailLoudOnMissingDaemon:
+    def test_no_daemon_raises_t3_daemon_error_with_recovery_hint(
+        self, config_dir: Path, force_local_mode, monkeypatch
+    ) -> None:
+        from nexus.daemon.t3_client import T3DaemonError, make_t3_client
+
+        monkeypatch.delenv("NX_T3_ADDR", raising=False)
+        with pytest.raises(T3DaemonError) as excinfo:
+            make_t3_client(config_dir=config_dir)
+        assert "nx daemon t3 start" in str(excinfo.value)
+
+    def test_no_auto_spawn(
+        self, config_dir: Path, force_local_mode, monkeypatch
+    ) -> None:
+        """No discovery file is created when the daemon is absent.
+        RDR-120 §Approach: explicit start only; no auto-spawn in P1."""
+        from nexus.daemon.discovery import discovery_path
+        from nexus.daemon.t3_client import T3DaemonError, make_t3_client
+
+        monkeypatch.delenv("NX_T3_ADDR", raising=False)
+        with pytest.raises(T3DaemonError):
+            make_t3_client(config_dir=config_dir)
+        assert not discovery_path(config_dir, tier="t3").exists()
+
+
+class TestCloudModeRejection:
+    def test_cloud_mode_raises_t3_daemon_error_with_clear_message(
+        self, config_dir: Path, monkeypatch
+    ) -> None:
+        from nexus.daemon.t3_client import T3DaemonError, make_t3_client
+
+        monkeypatch.setenv("NX_LOCAL", "0")
+        # Force is_local_mode() to actually return False; the auto-detect
+        # path returns True when cloud credentials are absent.
+        monkeypatch.setenv("CHROMA_API_KEY", "fake-for-cloud-test")
+        monkeypatch.setenv("VOYAGE_API_KEY", "fake-for-cloud-test")
+        with pytest.raises(T3DaemonError) as excinfo:
+            make_t3_client(config_dir=config_dir)
+        msg = str(excinfo.value).lower()
+        assert "cloud" in msg
+        assert "no t3 daemon" in msg or "no daemon" in msg or "no-op" in msg
+
+
+class TestHappyPathRoundTrip:
+    def test_make_t3_client_returns_t3_database_backed_by_http_client(
+        self, live_t3_daemon, config_dir: Path
+    ) -> None:
+        from nexus.daemon.t3_client import make_t3_client
+        from nexus.db.t3 import T3Database
+
+        t3 = make_t3_client(config_dir=config_dir)
+        assert isinstance(t3, T3Database)
+        # HttpClient exposes ``_server``; PersistentClient does not.
+        assert hasattr(t3._client, "_server"), (
+            "expected HttpClient-shaped _client with _server attribute"
+        )
+
+    def test_round_trip_collection_query(
+        self, live_t3_daemon, config_dir: Path
+    ) -> None:
+        from nexus.daemon.t3_client import make_t3_client
+
+        t3 = make_t3_client(config_dir=config_dir)
+        client = t3._client
+        coll = client.get_or_create_collection("t3_client_smoke")
+        coll.add(documents=["alpha doc", "beta doc"], ids=["a", "b"])
+        result = coll.query(query_texts=["alpha"], n_results=1)
+        assert result["ids"][0] == ["a"]
+
+
+class TestHttpTimeoutApplied:
+    def test_http_client_session_timeout_overridden(
+        self, live_t3_daemon, config_dir: Path
+    ) -> None:
+        """The factory must call ``_apply_chroma_http_timeout`` so the
+        daemon path inherits the read-timeout fix (chromadb ships
+        ``httpx.Client(timeout=None)`` which hangs indefinitely on
+        stalled reads)."""
+        from nexus.daemon.t3_client import make_t3_client
+        from nexus.db.t3 import CHROMA_HTTP_READ_TIMEOUT_S
+
+        t3 = make_t3_client(config_dir=config_dir)
+        server = getattr(t3._client, "_server", None)
+        assert server is not None, "HttpClient must expose _server"
+        session = getattr(server, "_session", None)
+        assert session is not None, "_server must expose _session"
+        timeout = session.timeout
+        assert timeout is not None
+        read_timeout = getattr(timeout, "read", None)
+        assert read_timeout == pytest.approx(CHROMA_HTTP_READ_TIMEOUT_S)
+
+
+class TestMalformedDiscoveryPayload:
+    """A discovery file that is otherwise valid (live PID,
+    format_version=1, no shutdown marker) but missing tcp_host /
+    tcp_port must surface T3DaemonError, not pass through silently to
+    chromadb.HttpClient(host=None, port=None)."""
+
+    def test_missing_tcp_port_raises_t3_daemon_error(
+        self, config_dir: Path, force_local_mode, monkeypatch
+    ) -> None:
+        from nexus.daemon.discovery import discovery_path
+        from nexus.daemon.t3_client import T3DaemonError, make_t3_client
+
+        monkeypatch.delenv("NX_T3_ADDR", raising=False)
+        path = discovery_path(config_dir, tier="t3")
+        path.write_text(json.dumps({
+            "format_version": 1,
+            "tcp_host": "127.0.0.1",
+            "pid": os.getpid(),
+            "daemon_version": "test",
+            "start_time": "1970-01-01T00:00:00",
+            "local_path": "/tmp/x",
+        }))
+        os.chmod(str(path), 0o600)
+        with pytest.raises(T3DaemonError) as excinfo:
+            make_t3_client(config_dir=config_dir)
+        assert "tcp_host" in str(excinfo.value) or "tcp_port" in str(excinfo.value)
+
+
+class TestEnvVarOverridesFile:
+    """RDR-120 C2 precedence: NX_T3_ADDR wins over the discovery file."""
+
+    def test_env_var_wins_when_set(
+        self, live_t3_daemon, config_dir: Path, monkeypatch
+    ) -> None:
+        # Point env at the same live daemon via host:port so the
+        # round-trip succeeds; this validates the env path actually
+        # constructs an HttpClient against the env-supplied address,
+        # not the discovery file.
+        from nexus.daemon.t3_client import make_t3_client
+
+        addr = f"{live_t3_daemon['tcp_host']}:{live_t3_daemon['tcp_port']}"
+        monkeypatch.setenv("NX_T3_ADDR", addr)
+        t3 = make_t3_client(config_dir=config_dir)
+        # Round-trip through the env-resolved client. If the env branch
+        # didn't fire, the file path would still hit the same daemon, so
+        # validate connectivity instead of source-attribution.
+        coll = t3._client.get_or_create_collection("env_path_smoke")
+        coll.add(documents=["x"], ids=["1"])
+        assert coll.query(query_texts=["x"], n_results=1)["ids"][0] == ["1"]
+
+
+class TestSurfaceParity:
+    def test_public_method_set_matches_make_t3(
+        self, live_t3_daemon, config_dir: Path
+    ) -> None:
+        """make_t3_client and make_t3 must return objects with identical
+        public surfaces (same class — T3Database — by construction).
+        Catches accidental shim-class introduction."""
+        from nexus.daemon.t3_client import make_t3_client
+        from nexus.db.t3 import T3Database
+
+        t3_client = make_t3_client(config_dir=config_dir)
+        assert type(t3_client) is T3Database
+
+        public_methods = [
+            name for name, member in inspect.getmembers(T3Database, callable)
+            if not name.startswith("_")
+        ]
+        for name in public_methods:
+            assert callable(getattr(t3_client, name)), (
+                f"{name} not callable on make_t3_client() return"
+            )


### PR DESCRIPTION
## Summary

RDR-120 Phase 1.B — T3Client factory. Ports `make_t3_client()` from the unmerged RDR-112 archive branch and adapts to RDR-120's locked C2 precedence (env wins when set + non-empty; file fallback; fail-loud on missing daemon, no auto-spawn).

- New `src/nexus/daemon/t3_client.py`: `make_t3_client(*, config_dir=None) -> T3Database`. Cloud-mode gate, `discovery_resolve('t3')`, `chromadb.HttpClient` with the `_apply_chroma_http_timeout` override, injected `LocalEmbeddingFunction`, return `T3Database(_client=httpclient, local_mode=True, ...)`. Same class as direct-mode `make_t3()` — no shim.
- 9 new tests: fail-loud (no-daemon + no-auto-spawn), cloud-mode rejection, real-chroma round-trip, HTTP read-timeout override applied, malformed discovery payload, NX_T3_ADDR env-precedence round-trip, surface parity (every public T3Database method callable on the env-resolved instance).
- All 54 `tests/daemon/` pass.

Scope: P1.B only. T3 call-site flips ship in P2; no consumer wired here. The phase-soak invariant (≥7 days on main under daemon mode before P2 opens) starts once P1.A + P1.B + P1.C MVV land.

## Closes

Closes nexus-beoh1.

## Test plan

- [x] `uv run pytest tests/daemon/test_t3_client.py` (9 passed, spawns real chroma)
- [x] `uv run pytest tests/daemon/` (54 passed, all daemon suites)
- [x] No regressions in `tests/test_plugin_structure.py` / `tests/test_cli_registration.py`