### PR TITLE
feat(rdr-120): nexus-aim84 P1.C MVV — two-subprocess T3 round trip

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -768,3 +768,11 @@
 {"id":"int-40649d69","kind":"field_change","created_at":"2026-05-21T17:00:04.669233Z","actor":"Hellblazer","issue_id":"nexus-v0s47","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-04599112","kind":"field_change","created_at":"2026-05-21T17:00:10.089352Z","actor":"Hellblazer","issue_id":"nexus-7xxxg","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-589030b1","kind":"field_change","created_at":"2026-05-21T17:48:23.915269Z","actor":"Hellblazer","issue_id":"nexus-xoeeq","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+=======
+{"id":"int-25b4abd1","kind":"field_change","created_at":"2026-05-21T10:00:54.016373Z","actor":"Hellblazer","issue_id":"nexus-yxywl","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-af840d20","kind":"field_change","created_at":"2026-05-21T10:19:49.691977Z","actor":"Hellblazer","issue_id":"nexus-i7mn2","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-a418e017","kind":"field_change","created_at":"2026-05-21T10:19:50.070305Z","actor":"Hellblazer","issue_id":"nexus-o0tth","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-28009103","kind":"field_change","created_at":"2026-05-21T10:19:50.449419Z","actor":"Hellblazer","issue_id":"nexus-2zeva","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-445a00dd","kind":"field_change","created_at":"2026-05-21T10:19:50.826573Z","actor":"Hellblazer","issue_id":"nexus-hnmfr","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-185d5191","kind":"field_change","created_at":"2026-05-21T10:19:51.194857Z","actor":"Hellblazer","issue_id":"nexus-9hfcu","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-e0447563","kind":"field_change","created_at":"2026-05-21T11:06:42.43156Z","actor":"Hellblazer","issue_id":"nexus-pwq18","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/.beads/push-state.json
+++ b/.beads/push-state.json
@@ -1,4 +1,4 @@
 {
-  "last_push": "2026-05-21T18:30:54Z",
-  "last_commit": "segcrf26aeqa56v8qs05itqa147b9tov"
+  "last_push": "2026-05-21T18:49:44Z",
+  "last_commit": "dciovumn3esniaasfua0vgbjtg3il3ba"
 }

--- a/scripts/rdr120_p1_mvv.py
+++ b/scripts/rdr120_p1_mvv.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 P1.C MVV (nexus-aim84) — two-subprocess T3 daemon round trip.
+
+Operator-runnable demo. Spawns a T3 daemon, then two Python subprocesses
+that each connect via NX_T3_ADDR using make_t3_client(). Subprocess A
+writes documents to a shared collection; subprocess B reads them back.
+Validates discovery + transport + daemon supervision end-to-end against
+a real subprocess pair (NOT in-process Task dispatches).
+
+The bead description says "two claude -p subprocesses". The substantive
+contract is "two separate OS processes both reaching the same daemon
+via NX_T3_ADDR"; we use bare ``python -c`` subprocesses because the
+``claude`` CLI is not installed in CI and the subprocess-isolation
+property is what we are validating, not anything model-specific.
+
+Usage::
+
+    python scripts/rdr120_p1_mvv.py [--keep-daemon]
+
+Exits 0 on success; non-zero with an explanatory line on failure.
+``--keep-daemon`` leaves the daemon running for follow-up manual probes.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+
+
+WRITER_SCRIPT = dedent("""
+    import json, sys
+    from nexus.daemon.t3_client import make_t3_client
+    t3 = make_t3_client()
+    coll = t3._client.get_or_create_collection("rdr120_p1_mvv")
+    coll.upsert(
+        documents=["alpha from writer", "beta from writer"],
+        ids=["alpha", "beta"],
+    )
+    print(json.dumps({"role": "writer", "count": coll.count()}))
+""")
+
+READER_SCRIPT = dedent("""
+    import json, sys
+    from nexus.daemon.t3_client import make_t3_client
+    t3 = make_t3_client()
+    coll = t3._client.get_collection("rdr120_p1_mvv")
+    res = coll.query(query_texts=["alpha"], n_results=2)
+    print(json.dumps({"role": "reader", "ids": res["ids"][0]}))
+""")
+
+
+def _run_subprocess(label: str, script: str, env: dict[str, str]) -> dict:
+    """Run *script* via ``python -c`` with *env*; parse stdout as JSON."""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{label} subprocess exited {result.returncode}\n"
+            f"stdout: {result.stdout!r}\n"
+            f"stderr: {result.stderr!r}"
+        )
+    try:
+        return json.loads(result.stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, IndexError) as exc:
+        raise RuntimeError(
+            f"{label} subprocess produced non-JSON output: "
+            f"stdout={result.stdout!r}, err={result.stderr!r}"
+        ) from exc
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--keep-daemon",
+        action="store_true",
+        help="Leave the T3 daemon running after the demo (default: stop).",
+    )
+    args = ap.parse_args()
+
+    from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+
+    os.environ["NX_LOCAL"] = "1"
+    tmp = Path(tempfile.mkdtemp(prefix="rdr120-mvv-"))
+    config_dir = tmp / "config"
+    local_path = tmp / "chroma"
+    config_dir.mkdir()
+    local_path.mkdir()
+
+    print(f"[demo] starting T3 daemon (config={config_dir}, data={local_path})")
+    payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+    addr = f"{payload['tcp_host']}:{payload['tcp_port']}"
+    print(f"[demo] daemon listening on {addr} (pid={payload['pid']})")
+
+    sub_env = {
+        **os.environ,
+        "NX_LOCAL": "1",
+        "NX_T3_ADDR": addr,
+    }
+
+    failures: list[str] = []
+    try:
+        print("[demo] subprocess A (writer) connecting via NX_T3_ADDR")
+        writer_result = _run_subprocess("writer", WRITER_SCRIPT, sub_env)
+        print(f"[demo]   writer -> {writer_result}")
+        if writer_result.get("count") != 2:
+            failures.append(
+                f"writer count={writer_result.get('count')} expected 2"
+            )
+
+        print("[demo] subprocess B (reader) connecting via NX_T3_ADDR")
+        reader_result = _run_subprocess("reader", READER_SCRIPT, sub_env)
+        print(f"[demo]   reader -> {reader_result}")
+        ids = reader_result.get("ids") or []
+        if sorted(ids) != ["alpha", "beta"]:
+            failures.append(
+                f"reader ids={ids} expected ['alpha', 'beta']"
+            )
+    finally:
+        if args.keep_daemon:
+            print(f"[demo] leaving daemon running; NX_T3_ADDR={addr}")
+        else:
+            print("[demo] stopping T3 daemon")
+            stop_t3_daemon(config_dir=config_dir)
+
+    if failures:
+        for f in failures:
+            print(f"[demo] FAIL: {f}", file=sys.stderr)
+        return 1
+    print("[demo] OK — RDR-120 P1.C MVV round trip succeeded")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rdr120_p1_mvv.py
+++ b/scripts/rdr120_p1_mvv.py
@@ -33,25 +33,27 @@ from pathlib import Path
 from textwrap import dedent
 
 
+# Exercise T3Database public surface (put / search) over the daemon,
+# not the raw chromadb.HttpClient — the MVV's value is verifying the
+# P1.B surface-parity claim end-to-end, which is invisible if the
+# scripts unwrap to the underlying client.
 WRITER_SCRIPT = dedent("""
-    import json, sys
+    import json
     from nexus.daemon.t3_client import make_t3_client
     t3 = make_t3_client()
-    coll = t3._client.get_or_create_collection("rdr120_p1_mvv")
-    coll.upsert(
-        documents=["alpha from writer", "beta from writer"],
-        ids=["alpha", "beta"],
-    )
-    print(json.dumps({"role": "writer", "count": coll.count()}))
+    id_a = t3.put("knowledge__rdr120_p1_mvv", "alpha doc from writer", title="alpha")
+    id_b = t3.put("knowledge__rdr120_p1_mvv", "beta doc from writer", title="beta")
+    info = t3.collection_info("knowledge__rdr120_p1_mvv")
+    print(json.dumps({"role": "writer", "count": info["count"], "ids": [id_a, id_b]}))
 """)
 
 READER_SCRIPT = dedent("""
-    import json, sys
+    import json
     from nexus.daemon.t3_client import make_t3_client
     t3 = make_t3_client()
-    coll = t3._client.get_collection("rdr120_p1_mvv")
-    res = coll.query(query_texts=["alpha"], n_results=2)
-    print(json.dumps({"role": "reader", "ids": res["ids"][0]}))
+    hits = t3.search("alpha", ["knowledge__rdr120_p1_mvv"], n_results=2)
+    titles = sorted([h.get("title", "") for h in hits])
+    print(json.dumps({"role": "reader", "count": len(hits), "titles": titles}))
 """)
 
 
@@ -121,10 +123,10 @@ def main() -> int:
         print("[demo] subprocess B (reader) connecting via NX_T3_ADDR")
         reader_result = _run_subprocess("reader", READER_SCRIPT, sub_env)
         print(f"[demo]   reader -> {reader_result}")
-        ids = reader_result.get("ids") or []
-        if sorted(ids) != ["alpha", "beta"]:
+        titles = reader_result.get("titles") or []
+        if titles != ["alpha", "beta"]:
             failures.append(
-                f"reader ids={ids} expected ['alpha', 'beta']"
+                f"reader titles={titles} expected ['alpha', 'beta']"
             )
     finally:
         if args.keep_daemon:

--- a/src/nexus/daemon/t3_client.py
+++ b/src/nexus/daemon/t3_client.py
@@ -104,7 +104,18 @@ def make_t3_client(*, config_dir: Optional[Path] = None) -> "T3Database":
         model_name=model_override if model_override else None,
     )
 
-    local_path_str = payload.get("local_path", "")
+    # Discovery payloads from the file branch carry the daemon's
+    # actual on-disk path; the env branch (NX_T3_ADDR) does not, since
+    # the operator may be pointing at a daemon under a foreign data
+    # path or even a remote-bridged loopback. Fall back to the
+    # configured XDG default so T3Database's defensive ``local_path``
+    # mkdir does not receive an empty string and silently chmod cwd.
+    # The daemon owns the on-disk store; T3Database.local_path is
+    # diagnostic-only when ``_client`` is injected.
+    local_path_str = payload.get("local_path") or ""
+    if not local_path_str:
+        from nexus.config import _default_local_path
+        local_path_str = str(_default_local_path())
     _log.info(
         "t3_client_constructed",
         host=host,

--- a/src/nexus/daemon/t3_daemon.py
+++ b/src/nexus/daemon/t3_daemon.py
@@ -178,10 +178,15 @@ def _daemon_version() -> str:
 
 
 def _allocate_free_port() -> int:
-    """Bind a free loopback port, then close it. The TOCTOU window
-    between close and chroma binding the port is negligible on loopback."""
+    """Bind a free loopback port, then close it.
+
+    No ``SO_REUSEADDR`` on the probe: with REUSEADDR another listener
+    can steal the same port between close and chroma's bind. The probe
+    is closed immediately so the kernel TIME_WAIT window suffices to
+    guard against double-allocation; the TOCTOU window between close
+    and chroma binding the port is negligible on loopback.
+    """
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind((_T3_HOST, 0))
     port: int = sock.getsockname()[1]
     sock.close()
@@ -332,6 +337,26 @@ def stop_t3_daemon(*, config_dir: Path) -> int | None:
                 os.waitpid(pid, os.WNOHANG)
             except (ChildProcessError, OSError):
                 pass
+            # Confirm SIGKILL took effect before removing the discovery
+            # file. If the process survives a brief window (Linux
+            # uninterruptible sleep, foreign-uid race), unlinking would
+            # orphan a chroma still bound to its port: the next ``start``
+            # would allocate a fresh port and the old daemon would leak.
+            # Brief polling, then leave the discovery file in place and
+            # surface a loud warning.
+            confirm_deadline = time.monotonic() + 1.0
+            while time.monotonic() < confirm_deadline:
+                if not _pid_is_alive(pid):
+                    break
+                time.sleep(0.05)
+            if _pid_is_alive(pid):
+                _log.warning(
+                    "t3_daemon_stop_kill_failed",
+                    pid=pid,
+                    msg="SIGKILL did not reap process; discovery file "
+                        "preserved to avoid orphaning a bound port",
+                )
+                return pid
 
     disc_path.unlink(missing_ok=True)
     _log.info("t3_daemon_stopped", pid=pid)

--- a/tests/daemon/test_t3_mvv.py
+++ b/tests/daemon/test_t3_mvv.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 P1.C (nexus-aim84) — T3 daemon MVV: two-subprocess round trip.
+
+Minimum Viable Validation for Phase 1: end-to-end demo that two
+separate OS processes, each reaching the daemon via NX_T3_ADDR through
+``make_t3_client()``, share a T3 collection round trip.
+
+The bead description references "two claude -p subprocesses"; the
+substantive contract is "two separate processes connecting via
+NX_T3_ADDR" (not in-process Task dispatches). We use bare
+``python -c`` subprocesses because the ``claude`` CLI is not installed
+in CI and what we are validating is OS-level process isolation +
+discovery + transport, not anything model-specific.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+
+WRITER = dedent("""
+    import json
+    from nexus.daemon.t3_client import make_t3_client
+    t3 = make_t3_client()
+    coll = t3._client.get_or_create_collection("rdr120_p1c_mvv")
+    coll.upsert(
+        documents=["alpha from writer", "beta from writer"],
+        ids=["alpha", "beta"],
+    )
+    print(json.dumps({"role": "writer", "count": coll.count()}))
+""")
+
+READER = dedent("""
+    import json
+    from nexus.daemon.t3_client import make_t3_client
+    t3 = make_t3_client()
+    coll = t3._client.get_collection("rdr120_p1c_mvv")
+    res = coll.query(query_texts=["alpha"], n_results=2)
+    print(json.dumps({"role": "reader", "ids": res["ids"][0]}))
+""")
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    cd = tmp_path / "nexus_config"
+    cd.mkdir()
+    return cd
+
+
+@pytest.fixture
+def local_path(tmp_path: Path) -> Path:
+    p = tmp_path / "chroma_t3"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def force_local_mode(monkeypatch):
+    monkeypatch.setenv("NX_LOCAL", "1")
+
+
+@pytest.fixture
+def live_daemon(config_dir, local_path, force_local_mode):
+    from nexus.daemon.t3_daemon import start_t3_daemon, stop_t3_daemon
+
+    payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
+    try:
+        yield payload
+    finally:
+        stop_t3_daemon(config_dir=config_dir)
+
+
+def _run(script: str, env: dict[str, str], label: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"{label} exited {result.returncode}: stdout={result.stdout!r}, "
+        f"stderr={result.stderr!r}"
+    )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+class TestTwoSubprocessRoundTrip:
+    """Acceptance for nexus-aim84: writer + reader subprocesses both
+    connect via NX_T3_ADDR and share collection state."""
+
+    def test_writer_then_reader_share_collection_via_env(
+        self, live_daemon, monkeypatch
+    ) -> None:
+        addr = f"{live_daemon['tcp_host']}:{live_daemon['tcp_port']}"
+        # Mirror parent env to subprocesses + override NX_T3_ADDR.
+        import os
+        env = {**os.environ, "NX_LOCAL": "1", "NX_T3_ADDR": addr}
+
+        writer_out = _run(WRITER, env, "writer")
+        assert writer_out["role"] == "writer"
+        assert writer_out["count"] == 2
+
+        reader_out = _run(READER, env, "reader")
+        assert reader_out["role"] == "reader"
+        assert sorted(reader_out["ids"]) == ["alpha", "beta"]
+
+    def test_subprocesses_fail_loud_without_env_or_file(
+        self, force_local_mode, tmp_path
+    ) -> None:
+        """RDR-120 C2: with no NX_T3_ADDR and no discovery file in
+        view, ``make_t3_client()`` must raise T3DaemonError naming
+        ``nx daemon t3 start`` as the fix. The subprocess should exit
+        non-zero with the recovery hint on stderr."""
+        import os
+
+        # Point the subprocess at an empty config dir so the discovery
+        # file lookup misses (NEXUS_CONFIG_DIR override).
+        empty_config = tmp_path / "empty_config"
+        empty_config.mkdir()
+        env = {
+            **os.environ,
+            "NX_LOCAL": "1",
+            "NEXUS_CONFIG_DIR": str(empty_config),
+        }
+        env.pop("NX_T3_ADDR", None)
+
+        script = dedent("""
+            from nexus.daemon.t3_client import make_t3_client
+            make_t3_client()
+        """)
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode != 0
+        assert "nx daemon t3 start" in result.stderr

--- a/tests/daemon/test_t3_mvv.py
+++ b/tests/daemon/test_t3_mvv.py
@@ -23,25 +23,28 @@ from textwrap import dedent
 import pytest
 
 
+# The MVV exercises T3Database's public surface (put / search) over
+# the daemon, not the raw chromadb.HttpClient. P1.B's surface-parity
+# claim is that make_t3_client returns the same T3Database class as
+# direct-mode make_t3; the MVV is the end-to-end check that the
+# claim holds when the injected _client is an HttpClient.
 WRITER = dedent("""
     import json
     from nexus.daemon.t3_client import make_t3_client
     t3 = make_t3_client()
-    coll = t3._client.get_or_create_collection("rdr120_p1c_mvv")
-    coll.upsert(
-        documents=["alpha from writer", "beta from writer"],
-        ids=["alpha", "beta"],
-    )
-    print(json.dumps({"role": "writer", "count": coll.count()}))
+    id_a = t3.put("knowledge__rdr120_p1c_mvv", "alpha doc from writer", title="alpha")
+    id_b = t3.put("knowledge__rdr120_p1c_mvv", "beta doc from writer", title="beta")
+    info = t3.collection_info("knowledge__rdr120_p1c_mvv")
+    print(json.dumps({"role": "writer", "count": info["count"], "ids": [id_a, id_b]}))
 """)
 
 READER = dedent("""
     import json
     from nexus.daemon.t3_client import make_t3_client
     t3 = make_t3_client()
-    coll = t3._client.get_collection("rdr120_p1c_mvv")
-    res = coll.query(query_texts=["alpha"], n_results=2)
-    print(json.dumps({"role": "reader", "ids": res["ids"][0]}))
+    hits = t3.search("alpha", ["knowledge__rdr120_p1c_mvv"], n_results=2)
+    titles = sorted([h.get("title", "") for h in hits])
+    print(json.dumps({"role": "reader", "count": len(hits), "titles": titles}))
 """)
 
 
@@ -108,7 +111,8 @@ class TestTwoSubprocessRoundTrip:
 
         reader_out = _run(READER, env, "reader")
         assert reader_out["role"] == "reader"
-        assert sorted(reader_out["ids"]) == ["alpha", "beta"]
+        assert reader_out["count"] == 2
+        assert reader_out["titles"] == ["alpha", "beta"]
 
     def test_subprocesses_fail_loud_without_env_or_file(
         self, force_local_mode, tmp_path


### PR DESCRIPTION
## Summary

RDR-120 Phase 1.C — Minimum Viable Validation. Two separate OS processes connect to the running T3 daemon via NX_T3_ADDR through `make_t3_client()`; subprocess A writes documents to a shared collection, subprocess B reads them back.

The bead references "two claude -p subprocesses". The substantive contract is process isolation + discovery + transport (not in-process Task dispatches); we use bare `python -c` subprocesses because `claude` is not installed in CI and what's being validated is OS-level isolation, not anything model-specific.

- `scripts/rdr120_p1_mvv.py`: operator-runnable demo. Spawns the daemon to a tmp dir, runs writer + reader, prints OK/FAIL, stops the daemon. `--keep-daemon` leaves the daemon running for follow-up probes.
- `tests/daemon/test_t3_mvv.py` (2 tests): writer+reader share a collection via NX_T3_ADDR; missing daemon + empty config dir surfaces the `nx daemon t3 start` recovery hint on stderr (RDR-120 C2 fail-loud end-to-end).
- All 56 `tests/daemon/` tests pass locally.

Scope: P1.C only. P1 phase-review-gate (nexus-ldztl) and ≥7-day soak (nexus-6ret6) follow before P2 opens.

## Closes

Closes nexus-aim84.

## Test plan

- [x] `uv run python scripts/rdr120_p1_mvv.py` prints `[demo] OK — RDR-120 P1.C MVV round trip succeeded`
- [x] `uv run pytest tests/daemon/test_t3_mvv.py` (2 passed)
- [x] `uv run pytest tests/daemon/` (56 passed)