### PR TITLE
docs(rdr-120): nexus-q2t5t §A8-exempt substrate-owned writes

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -769,6 +769,7 @@
 {"id":"int-04599112","kind":"field_change","created_at":"2026-05-21T17:00:10.089352Z","actor":"Hellblazer","issue_id":"nexus-7xxxg","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-589030b1","kind":"field_change","created_at":"2026-05-21T17:48:23.915269Z","actor":"Hellblazer","issue_id":"nexus-xoeeq","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
 =======
+=======
 {"id":"int-25b4abd1","kind":"field_change","created_at":"2026-05-21T10:00:54.016373Z","actor":"Hellblazer","issue_id":"nexus-yxywl","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-af840d20","kind":"field_change","created_at":"2026-05-21T10:19:49.691977Z","actor":"Hellblazer","issue_id":"nexus-i7mn2","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-a418e017","kind":"field_change","created_at":"2026-05-21T10:19:50.070305Z","actor":"Hellblazer","issue_id":"nexus-o0tth","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
@@ -776,3 +777,7 @@
 {"id":"int-445a00dd","kind":"field_change","created_at":"2026-05-21T10:19:50.826573Z","actor":"Hellblazer","issue_id":"nexus-hnmfr","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-185d5191","kind":"field_change","created_at":"2026-05-21T10:19:51.194857Z","actor":"Hellblazer","issue_id":"nexus-9hfcu","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-e0447563","kind":"field_change","created_at":"2026-05-21T11:06:42.43156Z","actor":"Hellblazer","issue_id":"nexus-pwq18","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-9a49fbaa","kind":"field_change","created_at":"2026-05-21T19:21:01.00172Z","actor":"Hellblazer","issue_id":"nexus-41unl","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
+{"id":"int-00ea2c6c","kind":"field_change","created_at":"2026-05-21T19:21:05.221091Z","actor":"Hellblazer","issue_id":"nexus-beoh1","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
+{"id":"int-c133b1b6","kind":"field_change","created_at":"2026-05-21T19:21:05.813735Z","actor":"Hellblazer","issue_id":"nexus-aim84","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
+{"id":"int-21360063","kind":"field_change","created_at":"2026-05-21T19:22:45.896647Z","actor":"Hellblazer","issue_id":"nexus-ldztl","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}

--- a/.beads/push-state.json
+++ b/.beads/push-state.json
@@ -1,4 +1,4 @@
 {
-  "last_push": "2026-05-21T18:49:44Z",
-  "last_commit": "dciovumn3esniaasfua0vgbjtg3il3ba"
+  "last_push": "2026-05-21T19:52:42Z",
+  "last_commit": "7ufh3t618408d66qvf28k1loc695kgt1"
 }

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -75,6 +75,14 @@ for the map.
    path (the existing stores show the pattern — a module-level
    `_migrated_paths: set[str]` guard + `_migrated_lock`, checked
    in `__init__`).
+   - **Substrate boundary (RDR-120 §A8):** the migration body must
+     ship DDL only. Any work beyond DDL (per-row backfills, sweeps,
+     content seeding) belongs in a consumer verb under the matching
+     `nx <area>` command group, not in `migrations.py`. The narrow
+     set of exceptions lives in RDR-120 §Research Findings ("§A8-
+     exempt substrate-owned writes"); if your migration is not on
+     that list, it ships DDL-only and the data work moves to a
+     consumer verb.
 3. If external callers should be able to use the method via the
    `T2Database` facade for backward compatibility, add a one-line
    delegate on `T2Database` in `src/nexus/db/t2/__init__.py`.

--- a/docs/rdr/rdr-120-storage-substrate-split.md
+++ b/docs/rdr/rdr-120-storage-substrate-split.md
@@ -579,6 +579,55 @@ process discipline actually failed.
   fixture-corpus standup work; this finding records the architectural
   lesson: substrate provides handle, consumer owns content.
 
+### §A8-exempt substrate-owned writes (authoritative list)
+
+Recorded 2026-05-21 from `nexus-q2t5t` following the A9 content audit
+(`120-research-A9-content-audit`, T2 id=1404). This is the canonical
+authority list: any future migration that would write rows beyond DDL
+must either land on this table with explicit justification or be
+rejected at gate-review time. The list is the symmetric companion to
+the §A9 remediation beads (`nexus-rv7x6`, `nexus-6y2a9`, `nexus-yulol`):
+the remediation beads move 10 substrate-violating migrations out to
+consumer verbs; the exemption table below names the writes that stay
+in the substrate and why.
+
+| Site (file:line) | Class | Justification |
+|---|---|---|
+| `src/nexus/db/migrations.py:2900-2938` (`_bootstrap_version` `INSERT OR IGNORE` of the `cli_version` singleton into `_nexus_version`) | substrate-required, deterministic-from-package | `apply_pending` cannot operate without this singleton row. Value is derived from package metadata, not from corpus state, so daemon-startup writes are reproducible across hosts. Singleton + `INSERT OR IGNORE` makes repeated startup writes idempotent. |
+| `migrate_document_aspects_pk_to_doc_id` PK-swap body proper (`src/nexus/db/migrations.py` v4.30.0; **excluding** the fixture-DELETE block at lines 1948-1954) | structurally-bound-to-schema | The new primary key cannot be populated without the catalog-JOIN backfill of `doc_id`; the backfill is structurally bound to the schema change in the same step. The fixture-DELETE block carved out separately under `nexus-yulol` is not exempt and ships as `nx aspects gc-fixtures`. |
+| `migrate_aspect_extraction_queue_pk_to_doc_id` PK-swap body proper (companion to the above, same release) | structurally-bound-to-schema | Same justification class. The backfill is structurally bound to the PK change. |
+| `migrate_hook_failures_chain_column` (`src/nexus/db/migrations.py` v4.14.2): `UPDATE` chain backfill bound to the `ADD COLUMN` step | structurally-bound-to-schema (marginal) | The chain-id backfill computes deterministically from existing row state at the same step that adds the column. Audited as a marginal case; kept exempt because the backfill cannot succeed at a later consumer-verb point: the new column would be NULL for the pre-existing rows and downstream consumers would have to defend against the NULL forever. Idempotent on re-run. |
+| `migrate_drop_source_path_column` (`src/nexus/db/migrations.py` v4.31.0): pre-flight audit-only abort | structural-gate-no-mutation | The step reads to detect unmigrated rows and refuses to proceed if any exist; it never mutates content. Counted under §A8 as a structural safeguard rather than a content write. |
+
+**Justification class glossary:**
+
+- *substrate-required*: `apply_pending` cannot complete its own work
+  without the write (typically a singleton bootstrap row).
+- *deterministic-from-package*: the written value derives from package
+  metadata or build artifacts, not from corpus / user / runtime state.
+  Reproducible across hosts.
+- *structurally-bound-to-schema*: the write is in the same step as a
+  DDL change and the DDL cannot ship without the data movement (e.g.,
+  populating a new PK column from a JOIN before the constraint is
+  enforced).
+- *structural-gate-no-mutation*: read-only audit pass that aborts the
+  step if a precondition fails. Counted as substrate work because it
+  guards substrate operations.
+
+**Authoring rule for future migrations.** A migration that wants to
+land a write beyond DDL must:
+
+1. Justify the write against one of the four classes above and PR-
+   open a patch to this table naming the site, the class, and the
+   reason in the same diff that introduces the migration.
+2. If no class fits, the write does not belong in `migrations.py`:
+   the work moves to a consumer verb (`nx <area> <verb>`) and the
+   migration ships DDL-only.
+
+Storage-boundary lint (`nx doctor --check-storage-boundary`) does not
+currently parse this table; enforcement is reviewer discipline at gate
+time until tooling closes the gap.
+
 ## Proposed Solution
 
 ### Approach


### PR DESCRIPTION
## Summary

Authority list for substrate-owned writes that pass §A8. The A9 audit (T2 \`120-research-A9-content-audit\` id=1404) identified 10 substrate-violating migrations being remediated under \`nexus-rv7x6\` / \`nexus-6y2a9\` / \`nexus-yulol\`, plus a small set of writes the audit recommends keeping. The latter was undocumented; gate-review had no authority list to check future migrations against.

- New §A8-exempt table under RDR-120 §Research Findings: 5 entries with file:line + one of four justification classes (substrate-required, deterministic-from-package, structurally-bound-to-schema, structural-gate-no-mutation). Glossary defines each class.
- Authoring rule: future migrations either land on this table with an explicit class in the same diff or ship DDL-only with the data work moved to a consumer verb.
- Pointer added in \`docs/contributing.md\` so the substrate boundary surfaces at authoring time, not just at gate-review.
- No code changes. Tests unchanged.

## Closes

Closes nexus-q2t5t.

## Test plan

- [x] No em-dashes in inserted prose
- [x] \`uv run pytest tests/ -k 'rdr or contributing'\` (737 passed, 5 skipped)
- [x] RDR section anchors and frontmatter unchanged