### PR TITLE
feat(rdr-120): nexus-yulol PK-swap fixture-DELETE → nx aspects gc-fixtures

### DIFF
--- a/.beads/push-state.json
+++ b/.beads/push-state.json
@@ -1,4 +1,4 @@
 {
-  "last_push": "2026-05-21T18:49:44Z",
-  "last_commit": "dciovumn3esniaasfua0vgbjtg3il3ba"
+  "last_push": "2026-05-21T19:57:30Z",
+  "last_commit": "j4chvnj6l13nn30vubcqtpl13o4qel9b"
 }

--- a/src/nexus/commands/aspects.py
+++ b/src/nexus/commands/aspects.py
@@ -4,11 +4,19 @@
 
 Subcommands:
 
-  drain   -- drain the aspect extraction queue before a PK migration.
+  drain         -- drain the aspect extraction queue before a PK migration.
+  gc            -- garbage-collect orphan aspect rows.
+  gc-fixtures   -- hard-delete test-fixture aspect rows (consumer-driven).
 
 K2 fix (RDR-108 Phase 1, nexus-lh8c): adds the ``nx aspects drain``
 operator-facing verb so upgrade docs and MigrationError messages can
 point to a concrete, runnable command.
+
+RDR-120 §A8 / nexus-yulol: ``gc-fixtures`` was carved out of the PK-swap
+migrations' Step 2 fixture-DELETE block. The substrate retains only
+the structurally-required PK swap; operators run the fixture cleanup
+explicitly against named patterns. ``_FIXTURE_COLLECTION_PATTERNS``
+lives here, not in ``nexus.db.migrations``.
 """
 from __future__ import annotations
 
@@ -16,6 +24,29 @@ import click
 import structlog
 
 _log = structlog.get_logger(__name__)
+
+
+#: Test-fixture collection prefixes/names recognised by ``gc-fixtures``.
+#: Patterns ending in ``-`` are LIKE-prefix matched; bare names are
+#: equality-matched. Operators with additional fixture collections
+#: should add them here.
+_FIXTURE_COLLECTION_PATTERNS: tuple[str, ...] = (
+    "knowledge__cli-",
+    "knowledge__nexus-integration-test",
+    "knowledge__reproducer",
+    "knowledge__pagtest",
+    "knowledge__pagend",
+)
+
+
+def _is_fixture_collection(collection: str) -> bool:
+    """Return True iff *collection* is a test-fixture name to hard-delete."""
+    for pat in _FIXTURE_COLLECTION_PATTERNS:
+        if pat.endswith("-") and collection.startswith(pat):
+            return True
+        if collection == pat:
+            return True
+    return False
 
 
 @click.group(name="aspects")
@@ -142,3 +173,98 @@ def aspects_gc(apply: bool) -> None:
         click.echo(
             "Re-run with --apply to actually delete the orphan rows."
         )
+
+
+@aspects_group.command(name="gc-fixtures")
+@click.option(
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Confirm the destructive delete. Without this flag the "
+    "command is a dry-run report only.",
+)
+def aspects_gc_fixtures(yes: bool) -> None:
+    """Hard-delete test-fixture aspect rows from document_aspects and
+    aspect_extraction_queue.
+
+    \b
+    Recognises a small allowlist of test-fixture collection prefixes
+    (``knowledge__cli-*``, ``knowledge__nexus-integration-test``,
+    ``knowledge__reproducer``, ``knowledge__pagtest``,
+    ``knowledge__pagend``) that the test suite creates and that
+    should never persist into production. The PK-swap migrations
+    (4.30.0) used to drop these unconditionally; under RDR-120 §A8
+    that fixture cleanup is consumer-driven and explicit.
+
+    \b
+    Default is dry-run: reports the per-pattern row counts without
+    writing. Pass ``--yes`` to actually delete.
+
+    \b
+    Examples:
+      nx aspects gc-fixtures            # dry-run report
+      nx aspects gc-fixtures --yes      # actually delete
+
+    \b
+    Run this before ``nx upgrade`` if the PK-swap migration reports a
+    high-volume unmapped collection that matches one of the fixture
+    patterns. RDR-120 §A8 / nexus-yulol.
+    """
+    from nexus.commands._helpers import default_db_path
+    from nexus.db.t2 import T2Database
+
+    mem_path = default_db_path()
+    if not mem_path.exists():
+        click.echo(f"No T2 database at {mem_path}; nothing to do.")
+        return
+
+    verb = "deleted" if yes else "would delete"
+    any_rows = False
+    with T2Database(mem_path) as db:
+        # Both target stores expose ``conn`` directly (matching the
+        # existing module convention; their writers go through the
+        # store's lock, but the verb's serial DELETEs do not need the
+        # finer-grained guard). The aspect_extraction_queue table is
+        # post-RDR-108; older installs may not have it yet, so guard the
+        # presence check via PRAGMA.
+        stores = [
+            ("document_aspects", db.document_aspects.conn),
+            ("aspect_extraction_queue", db.aspect_queue.conn),
+        ]
+        for table, conn in stores:
+            present = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+                (table,),
+            ).fetchone()
+            if not present:
+                continue
+            for pat in _FIXTURE_COLLECTION_PATTERNS:
+                if pat.endswith("-"):
+                    count_sql = (
+                        f"SELECT COUNT(*) FROM {table} WHERE collection LIKE ?"
+                    )
+                    delete_sql = (
+                        f"DELETE FROM {table} WHERE collection LIKE ?"
+                    )
+                    arg = pat + "%"
+                else:
+                    count_sql = (
+                        f"SELECT COUNT(*) FROM {table} WHERE collection = ?"
+                    )
+                    delete_sql = (
+                        f"DELETE FROM {table} WHERE collection = ?"
+                    )
+                    arg = pat
+
+                n = conn.execute(count_sql, (arg,)).fetchone()[0]
+                if n == 0:
+                    continue
+                any_rows = True
+                click.echo(f"  {table} / {pat}: {verb} {n} row(s)")
+                if yes:
+                    conn.execute(delete_sql, (arg,))
+                    conn.commit()
+    if not any_rows:
+        click.echo("No fixture rows found.")
+    elif not yes:
+        click.echo("Re-run with --yes to actually delete the fixture rows.")

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -1942,31 +1942,20 @@ def migrate_drop_null_aspect_rows(conn: sqlite3.Connection) -> None:
 
 # ── RDR-108 Phase 1c: Aspect PK migration helpers ───────────────────────────
 
-#: Fixture collection prefixes to hard-delete during aspect PK migration.
-#: These collections were created by the test suite and should never have
-#: persisted into production; dropping them is safe.
-_FIXTURE_COLLECTION_PATTERNS: tuple[str, ...] = (
-    "knowledge__cli-",
-    "knowledge__nexus-integration-test",
-    "knowledge__reproducer",
-    "knowledge__pagtest",
-    "knowledge__pagend",
-)
-
 #: Default row count above which an unmapped orphan collection triggers a
 #: fail-loud error rather than a silent hard-delete. Operators must curate
-#: ``collections.superseded_by`` for these before running the migration.
+#: ``collections.superseded_by`` for these (or run ``nx aspects gc-fixtures``
+#: for known test-fixture prefixes) before running the migration.
 #: OBS-4: Override at runtime with NEXUS_MIGRATION_HIGH_VOLUME_THRESHOLD
 #: env var (read fresh on each call to _check_high_volume_orphans).
+#:
+#: RDR-120 §A8 / nexus-yulol: the fixture-DELETE block that previously
+#: ran at Step 2 of each PK-swap migration was carved out to the
+#: consumer verb ``nx aspects gc-fixtures``. The substrate retains
+#: only the structurally-required PK swap; operators run the fixture
+#: cleanup explicitly against named patterns. ``_FIXTURE_COLLECTION_PATTERNS``
+#: and ``_is_fixture_collection`` moved to ``nexus.commands.aspects``.
 _HIGH_VOLUME_ORPHAN_THRESHOLD: int = 10
-
-
-def _is_fixture_collection(collection: str) -> bool:
-    """Return True iff *collection* is a test-fixture collection to hard-delete."""
-    for prefix_or_name in _FIXTURE_COLLECTION_PATTERNS:
-        if collection.startswith(prefix_or_name) or collection == prefix_or_name:
-            return True
-    return False
 
 
 def _attach_catalog(conn: sqlite3.Connection, catalog_db_path: Path) -> None:
@@ -2113,20 +2102,26 @@ def migrate_document_aspects_pk_to_doc_id(
     ``(collection, source_path)`` to ``(doc_id)``.
 
     SQLite does not support ``DROP CONSTRAINT`` or ``ADD PRIMARY KEY``, so
-    this uses the 12-step ALTER pattern:
+    this uses an ALTER pattern:
 
     1. Add ``doc_id TEXT NOT NULL DEFAULT ''`` to the existing table.
-    2. Delete test-fixture collection rows (hard-delete, safe).
-    3. Backfill ``doc_id`` via JOIN against catalog ``documents``.
+    2. Backfill ``doc_id`` via JOIN against catalog ``documents``.
        Pass 1: direct (collection, file_path) match.
        Pass 2: one-hop ``collections.superseded_by`` chain.
-    4. Raise ``MigrationError`` if any non-fixture collection has
-       >10 unmapped rows (operator must curate supersede mappings first).
-    5. Hard-delete remaining low-volume unmapped rows.
-    6. CREATE TABLE ``document_aspects_new`` with ``PRIMARY KEY (doc_id)``
+    3. Raise ``MigrationError`` if any collection has >10 unmapped rows
+       (operator must curate supersede mappings first; for known test-
+       fixture prefixes run ``nx aspects gc-fixtures --yes`` first).
+    4. Hard-delete remaining low-volume unmapped rows.
+    5. CREATE TABLE ``document_aspects_new`` with ``PRIMARY KEY (doc_id)``
        and current columns; INSERT from old (deduplicating by latest
        ``extracted_at`` when two old rows collapse to same doc_id).
-    7. DROP TABLE old; RENAME new; recreate indexes.
+    6. DROP TABLE old; RENAME new; recreate indexes.
+
+    RDR-120 §A8 (nexus-yulol): the fixture-row hard-delete that used
+    to run as Step 2 moved to the consumer verb ``nx aspects gc-fixtures``.
+    Operators with known test-fixture collections must run the verb
+    before the migration; otherwise high-volume fixture rows trip
+    Step 3.
 
     Idempotent: if ``doc_id`` is already the sole PK, returns immediately.
 
@@ -2152,31 +2147,19 @@ def migrate_document_aspects_pk_to_doc_id(
         )
         conn.commit()
 
-    # Step 2: hard-delete test-fixture rows first (before catalog JOIN)
-    for pattern in _FIXTURE_COLLECTION_PATTERNS:
-        if pattern.endswith("-"):
-            conn.execute(
-                "DELETE FROM document_aspects WHERE collection LIKE ?",
-                (pattern + "%",),
-            )
-        else:
-            conn.execute(
-                "DELETE FROM document_aspects WHERE collection = ?",
-                (pattern,),
-            )
-    conn.commit()
-
-    # Steps 3: backfill doc_id via catalog JOIN
+    # Step 2: backfill doc_id via catalog JOIN
+    # (RDR-120 §A8 / nexus-yulol: the fixture-DELETE pre-step that
+    # previously ran here moved to ``nx aspects gc-fixtures``.)
     _attach_catalog(conn, catalog_db_path)
     try:
         _backfill_doc_ids_via_catalog(conn, table="document_aspects")
 
-        # Step 4: fail-loud for high-volume unmapped collections
+        # Step 3: fail-loud for high-volume unmapped collections
         _check_high_volume_orphans(conn, table="document_aspects")
     finally:
         _detach_catalog(conn)
 
-    # Step 5: hard-delete remaining low-volume unmapped rows
+    # Step 4: hard-delete remaining low-volume unmapped rows
     dropped = _hard_delete_unmapped(conn, table="document_aspects")
     if dropped:
         _log.info(
@@ -2184,7 +2167,7 @@ def migrate_document_aspects_pk_to_doc_id(
             count=dropped,
         )
 
-    # Steps 6-7: CREATE new table with (doc_id) PK, INSERT deduped rows,
+    # Steps 5-6: CREATE new table with (doc_id) PK, INSERT deduped rows,
     # DROP old, RENAME, recreate indexes.
     #
     # K3 fix (RDR-108 Phase 1, nexus-lh8c): atomic table swap via explicit
@@ -2279,9 +2262,14 @@ def migrate_aspect_extraction_queue_pk_to_doc_id(
     PK swap and the worker would silently lose those extractions. Raises
     ``MigrationError`` if the precondition fails.
 
-    Uses the same 12-step ALTER pattern as ``migrate_document_aspects_pk_to_doc_id``.
+    Uses the same ALTER pattern as ``migrate_document_aspects_pk_to_doc_id``.
     The queue is typically empty in production at migration time, but the
     migration handles non-empty queues (of failed rows only) correctly.
+
+    RDR-120 §A8 (nexus-yulol): the fixture-row hard-delete that used
+    to run as Step 2 moved to ``nx aspects gc-fixtures``. Operators
+    with known test-fixture collections must run the verb before the
+    migration.
 
     Idempotent: if ``doc_id`` is already the sole PK, returns immediately.
 
@@ -2320,21 +2308,9 @@ def migrate_aspect_extraction_queue_pk_to_doc_id(
         )
         conn.commit()
 
-    # Step 2: hard-delete test-fixture rows
-    for pattern in _FIXTURE_COLLECTION_PATTERNS:
-        if pattern.endswith("-"):
-            conn.execute(
-                "DELETE FROM aspect_extraction_queue WHERE collection LIKE ?",
-                (pattern + "%",),
-            )
-        else:
-            conn.execute(
-                "DELETE FROM aspect_extraction_queue WHERE collection = ?",
-                (pattern,),
-            )
-    conn.commit()
-
-    # Step 3: backfill doc_id via catalog JOIN (only for failed rows at this point)
+    # Step 2: backfill doc_id via catalog JOIN (only for failed rows at this point).
+    # (RDR-120 §A8 / nexus-yulol: fixture-DELETE pre-step moved to
+    # ``nx aspects gc-fixtures``.)
     _attach_catalog(conn, catalog_db_path)
     try:
         _backfill_doc_ids_via_catalog(conn, table="aspect_extraction_queue")
@@ -2342,7 +2318,7 @@ def migrate_aspect_extraction_queue_pk_to_doc_id(
     finally:
         _detach_catalog(conn)
 
-    # Step 4: hard-delete remaining unmapped low-volume rows
+    # Step 3: hard-delete remaining unmapped low-volume rows
     dropped = _hard_delete_unmapped(conn, table="aspect_extraction_queue")
     if dropped:
         _log.info(
@@ -2350,7 +2326,7 @@ def migrate_aspect_extraction_queue_pk_to_doc_id(
             count=dropped,
         )
 
-    # Steps 5-7: CREATE new table with (doc_id) PK; dedup by latest enqueued_at.
+    # Steps 4-6: CREATE new table with (doc_id) PK; dedup by latest enqueued_at.
     #
     # K3 fix (RDR-108 Phase 1, nexus-lh8c): atomic table swap via explicit
     # conn.execute() inside "with conn:". See migrate_document_aspects_pk_to_doc_id

--- a/tests/test_aspects_gc_fixtures.py
+++ b/tests/test_aspects_gc_fixtures.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 §A8 / nexus-yulol: ``nx aspects gc-fixtures`` verb.
+
+The verb hard-deletes test-fixture rows from ``document_aspects`` and
+``aspect_extraction_queue`` against a small allowlist of collection
+prefixes that the test suite uses and that should never persist into
+production. Previously this work ran unconditionally inside the
+RDR-108 Phase 1c PK-swap migrations; carved out per RDR-120's
+substrate-vs-consumer boundary.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.commands.aspects import (
+    _FIXTURE_COLLECTION_PATTERNS,
+    _is_fixture_collection,
+    aspects_group,
+)
+
+
+# ── Allowlist sanity ──────────────────────────────────────────────────────────
+
+
+class TestFixtureMatching:
+    @pytest.mark.parametrize("name,expected", [
+        ("knowledge__cli-test", True),
+        ("knowledge__cli-abc", True),
+        ("knowledge__cli", False),  # bare 'cli' without trailing '-' not matched
+        ("knowledge__nexus-integration-test", True),
+        ("knowledge__nexus-integration-test-extra", False),  # exact-name match only
+        ("knowledge__reproducer", True),
+        ("knowledge__pagtest", True),
+        ("knowledge__pagend", True),
+        ("knowledge__production-data", False),
+        ("knowledge__delos", False),
+    ])
+    def test_is_fixture_collection(self, name: str, expected: bool) -> None:
+        assert _is_fixture_collection(name) is expected
+
+    def test_pattern_list_unchanged_shape(self) -> None:
+        """Five fixture entries (4 exact + 1 LIKE-prefix). This is the
+        same set the PK-swap migrations used pre-RDR-120; bumping it
+        is intentional (operator preference) and would require a
+        deliberate change here."""
+        assert len(_FIXTURE_COLLECTION_PATTERNS) == 5
+        assert sum(1 for p in _FIXTURE_COLLECTION_PATTERNS if p.endswith("-")) == 1
+
+
+# ── Verb behaviour against real T2 ────────────────────────────────────────────
+
+
+def _seed_aspects(db, *, collection: str, count: int = 1) -> None:
+    """Insert N rows into both document_aspects and aspect_extraction_queue.
+
+    Inserts target columns that exist in both pre-RDR-108 and post-
+    migration shapes; the PK-swap migration is skipped automatically
+    in fixture setup because there is no catalog DB, so the tables
+    retain the (collection, source_path) PK and lack a populated
+    doc_id column. The verb operates only on the ``collection``
+    column, so the rows do not need a doc_id to exercise the path.
+    """
+    da_conn = db.document_aspects.conn
+    aq_conn = db.aspect_queue.conn
+    for i in range(count):
+        da_conn.execute(
+            "INSERT INTO document_aspects "
+            "(collection, source_path, extracted_at, model_version, "
+            "extractor_name) VALUES (?, ?, ?, ?, ?)",
+            (collection, f"/doc-{i}.pdf", "2026-05-21T00:00:00",
+             "v1", "test-extractor"),
+        )
+    da_conn.commit()
+    for i in range(count):
+        aq_conn.execute(
+            "INSERT INTO aspect_extraction_queue "
+            "(collection, source_path, status, enqueued_at) "
+            "VALUES (?, ?, ?, ?)",
+            (collection, f"/doc-{i}.pdf", "failed",
+             "2026-05-21T00:00:00"),
+        )
+    aq_conn.commit()
+
+
+@pytest.fixture
+def t2_with_fixtures(tmp_path: Path, monkeypatch):
+    """Open a T2Database against a tmp memory.db; seed fixture +
+    non-fixture rows in both target tables; yield (db, mem_path).
+    Monkeypatch default_db_path so the CLI verb hits this database."""
+    from nexus.db.t2 import T2Database
+
+    mem_path = tmp_path / "memory.db"
+    monkeypatch.setattr(
+        "nexus.commands._helpers.default_db_path",
+        lambda: mem_path,
+    )
+
+    db = T2Database(mem_path)
+    try:
+        # Two fixture-pattern rows, one production-data row that must NOT
+        # be touched by the verb.
+        _seed_aspects(db, collection="knowledge__cli-test", count=1)
+        _seed_aspects(db, collection="knowledge__reproducer", count=1)
+        _seed_aspects(db, collection="knowledge__production-corpus", count=1)
+        yield db, mem_path
+    finally:
+        db.close()
+
+
+class TestGcFixturesVerb:
+    def test_dry_run_default_reports_without_deleting(self, t2_with_fixtures) -> None:
+        db, _ = t2_with_fixtures
+        runner = CliRunner()
+        result = runner.invoke(aspects_group, ["gc-fixtures"])
+        assert result.exit_code == 0, result.output
+        assert "would delete" in result.output
+        assert "Re-run with --yes" in result.output
+        # No row was actually deleted.
+        rows = db.document_aspects.conn.execute(
+            "SELECT COUNT(*) FROM document_aspects"
+        ).fetchone()[0]
+        assert rows == 3
+        qrows = db.aspect_queue.conn.execute(
+            "SELECT COUNT(*) FROM aspect_extraction_queue"
+        ).fetchone()[0]
+        assert qrows == 3
+
+    def test_yes_flag_deletes_only_fixture_rows(self, t2_with_fixtures) -> None:
+        db, _ = t2_with_fixtures
+        runner = CliRunner()
+        result = runner.invoke(aspects_group, ["gc-fixtures", "--yes"])
+        assert result.exit_code == 0, result.output
+        assert "deleted" in result.output
+        # Fixture rows deleted from both tables; production row preserved.
+        rows = db.document_aspects.conn.execute(
+            "SELECT collection FROM document_aspects"
+        ).fetchall()
+        assert [r[0] for r in rows] == ["knowledge__production-corpus"]
+        qrows = db.aspect_queue.conn.execute(
+            "SELECT collection FROM aspect_extraction_queue"
+        ).fetchall()
+        assert [r[0] for r in qrows] == ["knowledge__production-corpus"]
+
+    def test_no_fixture_rows_is_clean_noop(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Empty fixture state → exit 0 with 'No fixture rows found.'"""
+        from nexus.db.t2 import T2Database
+
+        mem_path = tmp_path / "memory.db"
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path",
+            lambda: mem_path,
+        )
+        db = T2Database(mem_path)
+        try:
+            _seed_aspects(db, collection="knowledge__production-corpus", count=2)
+        finally:
+            db.close()
+
+        runner = CliRunner()
+        result = runner.invoke(aspects_group, ["gc-fixtures", "--yes"])
+        assert result.exit_code == 0, result.output
+        assert "No fixture rows found." in result.output
+
+    def test_missing_db_is_clean_noop(self, tmp_path: Path, monkeypatch) -> None:
+        """No memory.db at all → exit 0 with the 'nothing to do' message."""
+        mem_path = tmp_path / "does_not_exist.db"
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path",
+            lambda: mem_path,
+        )
+        runner = CliRunner()
+        result = runner.invoke(aspects_group, ["gc-fixtures", "--yes"])
+        assert result.exit_code == 0, result.output
+        assert "nothing to do" in result.output
+
+    def test_verb_registered_under_aspects_group(self) -> None:
+        assert "gc-fixtures" in aspects_group.commands

--- a/tests/test_migrations_rdr108_phase1c.py
+++ b/tests/test_migrations_rdr108_phase1c.py
@@ -7,7 +7,10 @@ Tests cover:
 - Schema target: PRIMARY KEY (doc_id), denorm cache columns retained
 - Backfill via direct (collection, file_path) JOIN against catalog docs
 - Backfill via supersede-chain JOIN for legacy-but-mapped collections
-- Test-fixture rows hard-deleted (5 fixture collection prefixes)
+- Test-fixture rows: legacy behaviour was an in-migration hard-delete;
+  RDR-120 §A8 / nexus-yulol moved it to ``nx aspects gc-fixtures``.
+  The migration now treats fixture rows as ordinary unmapped orphans
+  (low-volume → silent drop via Step 4; high-volume → MigrationError).
 - High-volume unmapped rows trigger fail-loud (MigrationError)
 - Drain precondition: migration BLOCKS if queue has pending/in_progress rows
 - Drain precondition: migration RUNS if queue is empty or only has failed rows
@@ -287,10 +290,19 @@ class TestDocumentAspectsPKMigration:
         "knowledge__pagtest",
         "knowledge__pagend",
     ])
-    def test_fixture_rows_hard_deleted(
+    def test_low_volume_fixture_rows_dropped_as_orphans(
         self, tmp_path: Path, fixture_collection: str
     ) -> None:
-        """Test-fixture collections are hard-deleted, never migrated."""
+        """Low-volume fixture rows are dropped as ordinary unmapped
+        orphans by Step 4 of the PK swap.
+
+        RDR-120 §A8 / nexus-yulol: the migration's old Step 2 fixture-
+        DELETE-by-pattern block moved to ``nx aspects gc-fixtures``.
+        Fixture rows are no longer special-cased inside the migration;
+        with one row per fixture collection (below the high-volume
+        threshold of 10) Step 4's hard_delete_unmapped pass removes
+        them, so the post-migration count is still 0.
+        """
         from nexus.db.migrations import migrate_document_aspects_pk_to_doc_id
 
         mem_db = tmp_path / "memory.db"
@@ -306,6 +318,39 @@ class TestDocumentAspectsPKMigration:
             "SELECT COUNT(*) FROM document_aspects"
         ).fetchone()[0]
         assert count == 0, f"Expected 0 rows, got {count} for fixture {fixture_collection}"
+        mem_conn.close()
+
+    def test_high_volume_fixture_rows_raise_migration_error(
+        self, tmp_path: Path
+    ) -> None:
+        """High-volume fixture rows now trigger the unmapped-orphan
+        fail-loud error rather than being silently dropped.
+
+        RDR-120 §A8 / nexus-yulol changes the operator contract: the
+        substrate no longer special-cases fixture prefixes. A user with
+        >10 rows in a fixture-prefixed collection must run
+        ``nx aspects gc-fixtures --yes`` before re-running the
+        migration. This test pins the new behaviour.
+        """
+        from nexus.db.migrations import (
+            MigrationError,
+            migrate_document_aspects_pk_to_doc_id,
+        )
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        mem_conn = _make_memory_db(mem_db)
+        _make_catalog_db(cat_db)
+
+        for i in range(12):
+            _insert_aspect(
+                mem_conn,
+                collection="knowledge__cli-bulk",
+                source_path=f"/doc-{i}.pdf",
+            )
+
+        with pytest.raises(MigrationError):
+            migrate_document_aspects_pk_to_doc_id(mem_conn, catalog_db_path=cat_db)
         mem_conn.close()
 
     def test_high_volume_unmapped_raises_migration_error(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

A9 audit flagged the fixture-DELETE block inside the RDR-108 Phase 1c PK-swap migrations: the substrate hard-deleted rows by collection-name prefix, and a future user collection sharing one of those prefixes would have been silently destroyed. Per RDR-120 §A8 the substrate keeps only the structurally-required PK swap; fixture cleanup moves to a consumer verb.

- Substrate: Step 2 fixture-DELETE blocks removed from `migrate_document_aspects_pk_to_doc_id` and `migrate_aspect_extraction_queue_pk_to_doc_id`. `_FIXTURE_COLLECTION_PATTERNS` / `_is_fixture_collection` deleted from `migrations.py` (now in `nexus.commands.aspects`). Step lists renumbered in docstrings; operator hint added pointing at the new verb for the high-volume failure case.
- Consumer verb: `nx aspects gc-fixtures` with default dry-run and `--yes` flag (matches bead acceptance). Operates on both `document_aspects` and `aspect_extraction_queue` via `T2Database` (no new storage-boundary lint violation; counts 21 / 2 unchanged).
- Tests: parametrized fixture-row test reframed (now asserts the low-volume orphan drop path); new test pins the operator-contract change for high-volume fixture collections; new `tests/test_aspects_gc_fixtures.py` (5 tests) covers dry-run, --yes, empty-state, missing-db, registration.
- 789 aspect/migration/t2 tests pass.

**Operator-visible behaviour change.** A user with a high-volume (>10) fixture-prefixed collection now trips `MigrationError` rather than being silently cleaned, and must run `nx aspects gc-fixtures --yes` before re-running the PK swap. The behavior is documented in the migration docstring; the existing unmapped-orphan error message already names actionable next steps.

## Closes

Closes nexus-yulol.

## Test plan

- [x] `uv run pytest tests/test_aspects_gc_fixtures.py tests/test_migrations_rdr108_phase1c.py` (49 passed)
- [x] `uv run pytest tests/ -k 'aspect or migration or t2'` (789 passed)
- [x] `uv run nx doctor --check-storage-boundary --phase 1` shows violations=21, catalog-allowlist=2 (unchanged from P1 baseline)
- [x] `uv run nx aspects gc-fixtures --help` renders