### PR TITLE
feat(rdr-120): nexus-6y2a9 3 aspect sweep migrations → nx aspects verbs

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -781,3 +781,6 @@
 {"id":"int-00ea2c6c","kind":"field_change","created_at":"2026-05-21T19:21:05.221091Z","actor":"Hellblazer","issue_id":"nexus-beoh1","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
 {"id":"int-c133b1b6","kind":"field_change","created_at":"2026-05-21T19:21:05.813735Z","actor":"Hellblazer","issue_id":"nexus-aim84","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
 {"id":"int-21360063","kind":"field_change","created_at":"2026-05-21T19:22:45.896647Z","actor":"Hellblazer","issue_id":"nexus-ldztl","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
+=======
+{"id":"int-3326fd50","kind":"field_change","created_at":"2026-05-21T20:09:58.736958Z","actor":"Hellblazer","issue_id":"nexus-q2t5t","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
+{"id":"int-2858de9b","kind":"field_change","created_at":"2026-05-21T20:20:48.619357Z","actor":"Hellblazer","issue_id":"nexus-yulol","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}

--- a/.beads/push-state.json
+++ b/.beads/push-state.json
@@ -1,4 +1,7 @@
 {
   "last_push": "2026-05-21T19:52:42Z",
   "last_commit": "7ufh3t618408d66qvf28k1loc695kgt1"
+=======
+  "last_push": "2026-05-21T20:09:59Z",
+  "last_commit": "ik4ttf1g42j2c2gq4q78oqeipk01th5g"
 }

--- a/src/nexus/commands/aspects.py
+++ b/src/nexus/commands/aspects.py
@@ -142,3 +142,246 @@ def aspects_gc(apply: bool) -> None:
         click.echo(
             "Re-run with --apply to actually delete the orphan rows."
         )
+
+
+@aspects_group.command(name="backfill-source-uri")
+@click.option(
+    "--apply",
+    is_flag=True,
+    default=False,
+    help="Actually write the source_uri backfill. Without this flag "
+    "the command is a dry-run report only.",
+)
+def aspects_backfill_source_uri(apply: bool) -> None:
+    """Backfill empty/NULL ``source_uri`` rows in ``document_aspects``.
+
+    \b
+    RDR-096 introduced ``document_aspects.source_uri`` (4.16.0) and
+    the writer began emitting it on every new row from that point.
+    Pre-existing rows and a transient writer-path gap left some rows
+    with NULL or empty ``source_uri``; ``migrate_drop_source_path_column``
+    (4.31.0) refuses to drop the legacy column until every row has a
+    URI, so operators must run this verb before the next upgrade if
+    their database has any unbackfilled rows.
+
+    \b
+    The verb is idempotent: only touches rows where ``source_uri`` is
+    NULL or empty AND ``source_path`` is populated. Rows with empty
+    ``source_path`` (research-2 mitigation, very rare) are skipped
+    and reported separately for manual triage.
+
+    \b
+    URI scheme rules (matches the writer at
+    ``nexus.aspect_extractor._build_record``):
+
+      file://    rdr__* / docs__* / code__* (filesystem-backed)
+      chroma://  knowledge__* and other chroma-backed prefixes
+
+    \b
+    Examples:
+      nx aspects backfill-source-uri            # dry-run report
+      nx aspects backfill-source-uri --apply    # actually write
+
+    \b
+    RDR-120 §A8 / nexus-6y2a9: carved out of
+    ``migrate_document_aspects_source_uri`` and
+    ``migrate_document_aspects_source_uri_backfill_empty``.
+    """
+    import sqlite3
+    from nexus.aspect_readers import uri_for
+    from nexus.commands._helpers import default_db_path
+
+    mem_path = default_db_path()
+    if not mem_path.exists():
+        click.echo(f"No T2 database at {mem_path}; nothing to do.")
+        return
+
+    # Direct sqlite3 connection (epsilon-allow: RDR-120 §A8 verb).
+    # T2Database.__init__ runs the migration chain on open; if any
+    # downstream migration fails (e.g., migrate_drop_source_path_column
+    # blocks on unbackfilled rows) the facade cannot open, leaving the
+    # operator unable to run the very verb that fixes the precondition.
+    # The verb's whole purpose is to operate when the migration chain
+    # is stuck on this exact state, so opening sqlite3 directly is
+    # correct here.
+    conn = sqlite3.connect(str(mem_path))  # epsilon-allow: pre-migration repair verb
+    try:
+        cols = {
+            r[1]
+            for r in conn.execute("PRAGMA table_info(document_aspects)").fetchall()
+        }
+        if not cols:
+            click.echo(
+                "document_aspects table not present; nothing to do."
+            )
+            return
+        if "source_uri" not in cols:
+            click.echo(
+                "document_aspects.source_uri column not present; the "
+                "schema migration that adds it has not run yet. Run "
+                "`nx upgrade` first.",
+                err=True,
+            )
+            raise SystemExit(1)
+        if "source_path" not in cols:
+            click.echo(
+                "document_aspects.source_path column already dropped; "
+                "nothing to backfill from."
+            )
+            return
+
+        rows = conn.execute(
+            "SELECT rowid, collection, source_path FROM document_aspects "
+            "WHERE (source_uri IS NULL OR source_uri = '') "
+            "  AND source_path IS NOT NULL "
+            "  AND source_path != ''",
+        ).fetchall()
+        empty_source_path = conn.execute(
+            "SELECT COUNT(*) FROM document_aspects "
+            "WHERE (source_uri IS NULL OR source_uri = '') "
+            "  AND (source_path IS NULL OR source_path = '')",
+        ).fetchone()[0]
+
+        backfilled = 0
+        skipped = 0
+        if apply and rows:
+            conn.execute("BEGIN")
+            try:
+                for rowid, collection, source_path in rows:
+                    uri = uri_for(collection, source_path)
+                    if uri is None:
+                        skipped += 1
+                        continue
+                    conn.execute(
+                        "UPDATE document_aspects SET source_uri = ? "
+                        "WHERE rowid = ?",
+                        (uri, rowid),
+                    )
+                    backfilled += 1
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+        else:
+            for _, collection, source_path in rows:
+                if uri_for(collection, source_path) is None:
+                    skipped += 1
+                else:
+                    backfilled += 1
+
+        verb = "backfilled" if apply else "would backfill"
+        click.echo(
+            f"document_aspects: {verb} {backfilled} row(s); "
+            f"{skipped} row(s) had unresolvable URI; "
+            f"{empty_source_path} row(s) have empty source_path "
+            "(manual triage required)"
+        )
+        if backfilled > 0 and not apply:
+            click.echo(
+                "Re-run with --apply to actually write the backfill."
+            )
+    finally:
+        conn.close()
+
+
+_GC_PRE_RDR096_PREDICATE = (
+    "WHERE problem_formulation IS NULL "
+    "  AND proposed_method IS NULL "
+    "  AND (experimental_datasets IS NULL OR experimental_datasets = '[]') "
+    "  AND (experimental_baselines IS NULL OR experimental_baselines = '[]') "
+    "  AND experimental_results IS NULL "
+    "  AND (extras IS NULL OR extras = '{}')"
+    "  AND confidence IS NULL"
+)
+
+
+@aspects_group.command(name="gc-pre-rdr096")
+@click.option(
+    "--apply",
+    is_flag=True,
+    default=False,
+    help="Actually delete pre-RDR-096 read-failure rows. Without this "
+    "flag the command is a dry-run report only.",
+)
+def aspects_gc_pre_rdr096(apply: bool) -> None:
+    """Delete pre-RDR-096 read-failure rows from ``document_aspects``.
+
+    \b
+    The seven-clause discriminator from RDR-096 research-3 (id 1010)
+    identifies rows that pre-RDR-096 extractors emitted as the
+    fingerprint of a read failure: every aspect field empty plus
+    ``confidence IS NULL``. The going-forward writer contract is that
+    structured-zero successes (parser ran, no scholarly structure)
+    write ``confidence = 1.0`` explicitly, so ``confidence IS NULL``
+    combined with all-empty fields is structurally reachable only
+    from a pre-RDR-096 read failure.
+
+    \b
+    Two clauses are load-bearing:
+
+      * ``confidence IS NULL`` — without it, the verb silently drops
+        ``rdr-frontmatter-v1`` structured-zero successes (51 such rows
+        on live nexus_rdr at RDR-096 ship time).
+      * ``(experimental_datasets IS NULL OR = '[]')`` and analogous
+        for baselines / extras — the writer stores ``json.dumps([])``
+        which is the literal string ``'[]'``, not SQL NULL.
+
+    \b
+    Idempotent: re-running on a cleaned database deletes 0 rows.
+    Safe on a missing table or empty database.
+
+    \b
+    Examples:
+      nx aspects gc-pre-rdr096            # dry-run report
+      nx aspects gc-pre-rdr096 --apply    # actually delete
+
+    \b
+    RDR-120 §A8 / nexus-6y2a9: carved out of
+    ``migrate_drop_null_aspect_rows``.
+    """
+    import sqlite3
+    from nexus.commands._helpers import default_db_path
+
+    mem_path = default_db_path()
+    if not mem_path.exists():
+        click.echo(f"No T2 database at {mem_path}; nothing to do.")
+        return
+
+    # Direct sqlite3 (epsilon-allow): same rationale as
+    # backfill-source-uri above. Pre-migration repair verbs cannot
+    # depend on T2Database.__init__'s migration chain succeeding.
+    conn = sqlite3.connect(str(mem_path))  # epsilon-allow: pre-migration repair verb
+    try:
+        cols = {
+            r[1]
+            for r in conn.execute("PRAGMA table_info(document_aspects)").fetchall()
+        }
+        if not cols:
+            click.echo("document_aspects table not present; nothing to do.")
+            return
+
+        matched = conn.execute(
+            "SELECT COUNT(*) FROM document_aspects "
+            + _GC_PRE_RDR096_PREDICATE,
+        ).fetchone()[0]
+
+        if matched == 0:
+            click.echo("document_aspects: 0 pre-RDR-096 read-failure rows.")
+            return
+
+        if apply:
+            cur = conn.execute(
+                "DELETE FROM document_aspects " + _GC_PRE_RDR096_PREDICATE,
+            )
+            conn.commit()
+            click.echo(
+                f"document_aspects: deleted {cur.rowcount} pre-RDR-096 "
+                "read-failure row(s)."
+            )
+        else:
+            click.echo(
+                f"document_aspects: would delete {matched} pre-RDR-096 "
+                "read-failure row(s). Re-run with --apply."
+            )
+    finally:
+        conn.close()

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -1617,162 +1617,44 @@ def _backfill_builtin_bindings(conn: sqlite3.Connection) -> None:
 
 
 def migrate_document_aspects_source_uri(conn: sqlite3.Connection) -> None:
-    """RDR-096 P2.1: add ``source_uri`` TEXT column to ``document_aspects``
-    and backfill from existing ``(collection, source_path)`` pairs.
+    """RDR-096 P2.1: add ``source_uri`` TEXT column to ``document_aspects``.
 
-    Backfill rules (matches the going-forward writer contract):
+    DDL-only (substrate boundary, RDR-120 §A8 / nexus-6y2a9). The
+    per-row backfill body that previously ran here moved to the
+    consumer verb ``nx aspects backfill-source-uri``. Operators
+    upgrading from a pre-4.16.0 install must run the verb before the
+    next upgrade pass; ``migrate_drop_source_path_column`` (4.31.0)
+    refuses to drop ``source_path`` until every row has a non-empty
+    ``source_uri``, and the error message names the verb.
 
-    * filesystem-backed collections (``rdr__*``, ``docs__*``,
-      ``code__*``): ``source_uri = 'file://' || abspath(source_path)``.
-    * chroma-backed collections (``knowledge__*`` and any other
-      prefix): ``source_uri = 'chroma://' || collection || '/' ||
-      source_path``. ``knowledge__*`` chunks may be reassembled from
-      T3 either by ``source_path`` or ``title`` (RDR-096 P2.0
-      research-5); the URI's path component is whatever was stored
-      in ``source_path`` at extraction time.
-    * Empty ``source_path`` rows are SKIPPED — they cannot be
-      backfilled (research-2 mitigation, id 1009: 1 chunk in
-      ``code__int-crossmodel-ba3a85dc`` has empty source_path).
-      A WARN is logged with the count for triage; ``nx doctor
-      --check-schema`` surfaces this in steady state.
+    Idempotent:
 
-    Idempotent on three axes:
-
-    * ``ALTER TABLE`` — gated by ``PRAGMA table_info`` so re-runs
-      don't re-add the column.
-    * Backfill ``UPDATE`` — guarded by ``WHERE source_uri IS NULL``
-      so re-runs only touch unfilled rows. New writes that arrived
-      after the first migration pass are not stomped.
+    * ``ALTER TABLE`` is gated by ``PRAGMA table_info`` so re-runs
+      do not re-add the column.
     * No-op when the table doesn't exist (defensive, matches the
       pattern of older RDR-089 migrations on this same registry).
     """
-    # Import the single source of truth for URI construction so this
-    # migration and the going-forward writers in
-    # ``nexus.aspect_extractor._build_record`` / ``_empty_record`` stay
-    # in lockstep on prefix rules. ``uri_for`` returns ``None`` for
-    # empty source_path — matches the NULL-on-empty backfill behavior
-    # this migration's research-2 mitigation requires.
-    from nexus.aspect_readers import uri_for  # noqa: PLC0415
-
     cols = {r[1] for r in conn.execute("PRAGMA table_info(document_aspects)").fetchall()}
     if not cols:
-        # Table doesn't exist (fresh install before
-        # migrate_document_aspects_table runs).
         return
     if "source_uri" not in cols:
         conn.execute("ALTER TABLE document_aspects ADD COLUMN source_uri TEXT")
         conn.commit()
 
-    if "source_path" not in cols:
-        # ocu9.11 (4.31.0) dropped source_path. When apply_pending re-runs
-        # because a later MigrationRetry blocked the version-bump, this
-        # backfill is reached again with source_path absent. Idempotent
-        # no-op in that case.
-        return
-
-    # Two-pass backfill. Loop in Python (SQL has no abspath helper);
-    # wrap in an explicit transaction so 100K rows don't produce 100K
-    # round-trips against the WAL — autocommit would slow this from
-    # seconds to minutes on large catalogs.
-    rows = conn.execute(
-        "SELECT rowid, collection, source_path FROM document_aspects "
-        "WHERE source_uri IS NULL",
-    ).fetchall()
-
-    backfilled = 0
-    skipped_empty = 0
-    conn.execute("BEGIN")
-    try:
-        for rowid, collection, source_path in rows:
-            uri = uri_for(collection, source_path)
-            if uri is None:
-                skipped_empty += 1
-                continue
-            conn.execute(
-                "UPDATE document_aspects SET source_uri = ? WHERE rowid = ?",
-                (uri, rowid),
-            )
-            backfilled += 1
-        conn.commit()
-    except Exception:
-        conn.rollback()
-        raise
-
-    if backfilled or skipped_empty:
-        _log.info(
-            "migrate_document_aspects_source_uri",
-            backfilled=backfilled,
-            skipped_empty_source_path=skipped_empty,
-        )
-
 
 def migrate_document_aspects_source_uri_backfill_empty(conn: sqlite3.Connection) -> None:
-    """nexus-pnje: backfill ``document_aspects`` rows where
-    ``source_uri = ''`` (in addition to NULL).
+    """nexus-pnje (4.26.2): pure-data backfill of empty ``source_uri``
+    rows. Now a no-op (RDR-120 §A8 / nexus-6y2a9): the body moved to
+    ``nx aspects backfill-source-uri``.
 
-    The original RDR-096 P2.1 migration (``migrate_document_aspects_
-    source_uri`` above) only touched rows where ``source_uri IS NULL``.
-    Subsequent writer paths landed empty-string rows after the
-    migration ran; the live audit on production T2 (2026-05-06)
-    showed 61 of 579 rows (10.5%) with empty ``source_uri`` and
-    populated ``source_path``.
-
-    Prerequisite for ``nexus-ocu9.11`` (RDR-096 P5.2 — DROP COLUMN
-    ``source_path`` in 4.27.0). That migration's strict-audit step
-    blocks if any row has ``source_uri`` NULL or empty; this backfill
-    drops the count to zero so 4.27.0 ships cleanly without manual
-    triage.
-
-    Idempotent: only updates rows where source_uri is NULL OR ''
-    AND source_path is populated. Skipped rows (empty source_path
-    too) are left for manual triage and surfaced in the WARN log.
+    The migration step stays registered so the version chain remains
+    monotone; running it on an upgrade-from-pre-4.26.2 install is
+    legal and produces no writes. Operators with rows that still
+    have NULL/empty ``source_uri`` must run the consumer verb
+    explicitly; ``migrate_drop_source_path_column`` (4.31.0) raises
+    MigrationError until they do.
     """
-    from nexus.aspect_readers import uri_for  # noqa: PLC0415
-
-    cols = {
-        r[1]
-        for r in conn.execute("PRAGMA table_info(document_aspects)").fetchall()
-    }
-    if not cols or "source_uri" not in cols:
-        return
-
-    if "source_path" not in cols:
-        # ocu9.11 (4.31.0) dropped source_path. Re-runs after that point
-        # have nothing to backfill from; idempotent no-op.
-        return
-
-    rows = conn.execute(
-        "SELECT rowid, collection, source_path FROM document_aspects "
-        "WHERE (source_uri IS NULL OR source_uri = '') "
-        "  AND source_path IS NOT NULL "
-        "  AND source_path != ''",
-    ).fetchall()
-
-    backfilled = 0
-    skipped_uri_for_returned_none = 0
-    conn.execute("BEGIN")
-    try:
-        for rowid, collection, source_path in rows:
-            uri = uri_for(collection, source_path)
-            if uri is None:
-                skipped_uri_for_returned_none += 1
-                continue
-            conn.execute(
-                "UPDATE document_aspects SET source_uri = ? WHERE rowid = ?",
-                (uri, rowid),
-            )
-            backfilled += 1
-        conn.commit()
-    except Exception:
-        conn.rollback()
-        raise
-
-    if backfilled or skipped_uri_for_returned_none:
-        _log.info(
-            "migrate_document_aspects_source_uri_backfill_empty",
-            backfilled=backfilled,
-            skipped_uri_for_returned_none=skipped_uri_for_returned_none,
-        )
+    return
 
 
 def migrate_drop_source_path_column(conn: sqlite3.Connection) -> None:
@@ -1819,9 +1701,10 @@ def migrate_drop_source_path_column(conn: sqlite3.Connection) -> None:
             f"nexus-ocu9.11: refusing to drop document_aspects.source_path "
             f"because {bad_rows} row(s) still have NULL or empty "
             f"source_uri. After dropping the column those rows would be "
-            f"unaddressable. Run "
-            f"``migrate_document_aspects_source_uri_backfill_empty`` "
-            f"first or repair the rows manually, then re-run."
+            f"unaddressable. Run `nx aspects backfill-source-uri --apply` "
+            f"to populate the URIs, then re-run `nx upgrade`. (Per "
+            f"RDR-120 §A8 / nexus-6y2a9 the backfill is consumer-driven; "
+            f"the substrate no longer runs it at startup.)"
         )
 
     pk_cols = {
@@ -1852,92 +1735,16 @@ def migrate_drop_source_path_column(conn: sqlite3.Connection) -> None:
 
 
 def migrate_drop_null_aspect_rows(conn: sqlite3.Connection) -> None:
-    """RDR-096 P2.2: drop pre-RDR-096 read-failure rows from
-    ``document_aspects`` using the seven-clause discriminator from
-    research-3 (id 1010).
+    """RDR-096 P2.2: drop pre-RDR-096 read-failure rows. Now a no-op
+    (RDR-120 §A8 / nexus-6y2a9): the seven-clause-discriminator DELETE
+    body moved to ``nx aspects gc-pre-rdr096``.
 
-    Two clauses are load-bearing:
-
-    * ``confidence IS NULL`` — without it, the migration silently
-      drops ``rdr-frontmatter-v1`` "structured-zero" successes
-      (parser ran, document has no scholarly structure, extractor
-      wrote ``confidence=1.0`` with all aspect fields empty). On
-      live nexus_rdr, that's 51 rows that must be retained.
-    * ``(experimental_datasets IS NULL OR = '[]')`` and
-      ``(experimental_baselines IS NULL OR = '[]')`` — the writer
-      stores ``json.dumps([])`` which is the literal string ``'[]'``,
-      not SQL NULL. Bare ``IS NULL`` predicates would match zero
-      rows in production despite the spike's 15-row empirical
-      finding. The Python-side discriminator in
-      ``scripts/spikes/spike_rdr096_a3_partial_success.py`` is
-      JSON-aware (parses the column then checks for empty list);
-      the SQL form must be too.
-    * ``(extras IS NULL OR = '{}')`` — same shape as the array
-      clauses but for the ``extras`` JSON object column. The current
-      writer always emits ``json.dumps({}) == '{}'`` so the
-      ``IS NULL`` half is defensive against legacy / hand-crafted
-      rows that predate the writer's normalization. The gap was
-      caught in code review of P2.2 — without the OR clause, a
-      hand-crafted ``extras=NULL`` ghost row would silently survive
-      the migration.
-
-    Going-forward writer contract (RDR-096 Phase 2):
-    any extractor recording a "structured-zero" success MUST set
-    non-NULL ``confidence``. Only ``ExtractFail`` paths emit no row
-    at all. The combination guarantees ``confidence IS NULL ∧ all-
-    empty-aspect-fields ∧ extras='{}'`` is structurally reachable
-    only from a pre-RDR-096 read failure — exactly what this
-    migration cleans up.
-
-    Empirical baseline (research-3, id 1010): 15 rows match across
-    the live nexus_rdr at ship time (12 rdr-frontmatter-v1 catalog-
-    stale paths from RDR-090 research-1003 + 3 scholarly-paper-v1
-    read-failures on knowledge__hybridrag).
-
-    Idempotent: re-running on a cleaned database deletes 0 rows
-    (no-op). Safe on a missing table (no-op).
+    The migration step stays registered so the version chain remains
+    monotone; running it on an upgrade-from-pre-4.16.0 install is
+    legal and produces no writes. Operators who want the historical
+    cleanup must run the consumer verb explicitly.
     """
-    cols = {r[1] for r in conn.execute("PRAGMA table_info(document_aspects)").fetchall()}
-    if not cols:
-        return
-
-    # Audit pass: count first so the operator log line shows the
-    # impact before the DELETE applies. Audit + DELETE run inside
-    # the ``apply_pending`` ``_upgrade_lock`` so no concurrent
-    # writer can interleave between the two statements; the count
-    # is exact, not approximate.
-    audit = conn.execute(
-        "SELECT COUNT(*) FROM document_aspects "
-        "WHERE problem_formulation IS NULL "
-        "  AND proposed_method IS NULL "
-        "  AND (experimental_datasets IS NULL OR experimental_datasets = '[]') "
-        "  AND (experimental_baselines IS NULL OR experimental_baselines = '[]') "
-        "  AND experimental_results IS NULL "
-        "  AND (extras IS NULL OR extras = '{}')"
-        "  AND confidence IS NULL",
-    ).fetchone()
-    matched = audit[0] if audit else 0
-
-    if matched == 0:
-        # No-op: either fresh install or all read-failures already cleaned.
-        return
-
-    cur = conn.execute(
-        "DELETE FROM document_aspects "
-        "WHERE problem_formulation IS NULL "
-        "  AND proposed_method IS NULL "
-        "  AND (experimental_datasets IS NULL OR experimental_datasets = '[]') "
-        "  AND (experimental_baselines IS NULL OR experimental_baselines = '[]') "
-        "  AND experimental_results IS NULL "
-        "  AND (extras IS NULL OR extras = '{}')"
-        "  AND confidence IS NULL",
-    )
-    conn.commit()
-    _log.info(
-        "migrate_drop_null_aspect_rows",
-        matched=matched,
-        deleted=cur.rowcount,
-    )
+    return
 
 
 # ── RDR-108 Phase 1c: Aspect PK migration helpers ───────────────────────────

--- a/tests/test_aspects_consumer_verbs.py
+++ b/tests/test_aspects_consumer_verbs.py
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 §A8 / nexus-6y2a9: ``nx aspects backfill-source-uri`` and
+``nx aspects gc-pre-rdr096`` verbs.
+
+These two verbs carry forward the substantive behaviour of three
+migrations whose bodies were demoted to no-ops under RDR-120's
+substrate-vs-consumer boundary:
+
+  - ``migrate_document_aspects_source_uri`` (4.16.0)  →  DDL only
+  - ``migrate_document_aspects_source_uri_backfill_empty`` (4.26.2) →  no-op
+  - ``migrate_drop_null_aspect_rows`` (4.16.0)        →  no-op
+
+The verb-tests below port the same scenarios the migration tests in
+``tests/test_migrations_rdr096.py`` used to exercise, plus add CLI-
+level coverage (dry-run, --apply, missing DB, missing column).
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.commands.aspects import aspects_group
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _seed_aspects_schema(conn: sqlite3.Connection) -> None:
+    """Set up document_aspects at the post-RDR-096 schema (with source_uri).
+
+    Mirrors what the migrations on real installs produce after they have
+    run: the DDL is in place, but rows can carry NULL or empty
+    ``source_uri`` for the backfill verb to act on.
+    """
+    from nexus.db.migrations import (
+        migrate_document_aspects_source_uri,
+        migrate_document_aspects_table,
+    )
+    migrate_document_aspects_table(conn)
+    migrate_document_aspects_source_uri(conn)
+
+
+def _insert_aspect(
+    conn: sqlite3.Connection,
+    *,
+    collection: str,
+    source_path: str,
+    source_uri: str | None = None,
+    extractor: str = "scholarly-paper-v1",
+    problem_formulation: str | None = None,
+    proposed_method: str | None = None,
+    experimental_datasets: str = "[]",
+    experimental_baselines: str = "[]",
+    experimental_results: str | None = None,
+    extras: str | None = "{}",
+    confidence: float | None = None,
+) -> None:
+    if source_uri is None:
+        conn.execute(
+            "INSERT INTO document_aspects "
+            "(collection, source_path, problem_formulation, proposed_method, "
+            " experimental_datasets, experimental_baselines, experimental_results, "
+            " extras, confidence, extracted_at, model_version, extractor_name) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (collection, source_path, problem_formulation, proposed_method,
+             experimental_datasets, experimental_baselines, experimental_results,
+             extras, confidence,
+             "2026-04-27T00:00:00+00:00", "claude-haiku-4-5-20251001",
+             extractor),
+        )
+    else:
+        conn.execute(
+            "INSERT INTO document_aspects "
+            "(collection, source_path, source_uri, problem_formulation, proposed_method, "
+            " experimental_datasets, experimental_baselines, experimental_results, "
+            " extras, confidence, extracted_at, model_version, extractor_name) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (collection, source_path, source_uri,
+             problem_formulation, proposed_method,
+             experimental_datasets, experimental_baselines, experimental_results,
+             extras, confidence,
+             "2026-04-27T00:00:00+00:00", "claude-haiku-4-5-20251001",
+             extractor),
+        )
+    conn.commit()
+
+
+@pytest.fixture
+def t2_path(tmp_path: Path, monkeypatch) -> Path:
+    """Patch default_db_path to a tmp memory.db. The verbs open
+    T2Database under the hood; ensure the file exists with the
+    post-RDR-096 aspect schema."""
+    mem_path = tmp_path / "memory.db"
+    monkeypatch.setattr(
+        "nexus.commands._helpers.default_db_path",
+        lambda: mem_path,
+    )
+    # Hand-seed the schema (T2Database.__init__ would also do this
+    # via its store init paths, but spelling it out keeps each test
+    # honest about what it expects).
+    conn = sqlite3.connect(str(mem_path))
+    _seed_aspects_schema(conn)
+    conn.close()
+    return mem_path
+
+
+# ── backfill-source-uri verb ──────────────────────────────────────────────────
+
+
+class TestBackfillSourceUriDryRun:
+    def test_no_writes_without_apply(self, t2_path: Path) -> None:
+        conn = sqlite3.connect(str(t2_path))
+        _insert_aspect(conn, collection="rdr__nexus", source_path="docs/x.md")
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(aspects_group, ["backfill-source-uri"])
+        assert result.exit_code == 0, result.output
+        assert "would backfill 1 row" in result.output
+        assert "Re-run with --apply" in result.output
+
+        conn = sqlite3.connect(str(t2_path))
+        uri = conn.execute("SELECT source_uri FROM document_aspects").fetchone()[0]
+        conn.close()
+        assert uri is None
+
+
+class TestBackfillSourceUriApply:
+    def test_filesystem_collections_use_file_scheme(self, t2_path: Path) -> None:
+        conn = sqlite3.connect(str(t2_path))
+        _insert_aspect(conn, collection="rdr__nexus", source_path="docs/x.md")
+        _insert_aspect(conn, collection="docs__corpus", source_path="docs/y.md")
+        _insert_aspect(conn, collection="code__nexus", source_path="src/cli.py")
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            aspects_group, ["backfill-source-uri", "--apply"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "backfilled 3 row" in result.output
+
+        conn = sqlite3.connect(str(t2_path))
+        rows = dict(conn.execute(
+            "SELECT collection, source_uri FROM document_aspects",
+        ).fetchall())
+        conn.close()
+        for coll, sp in [
+            ("rdr__nexus", "docs/x.md"),
+            ("docs__corpus", "docs/y.md"),
+            ("code__nexus", "src/cli.py"),
+        ]:
+            assert rows[coll] == "file://" + os.path.abspath(sp)
+
+    def test_knowledge_collections_use_chroma_scheme(self, t2_path: Path) -> None:
+        conn = sqlite3.connect(str(t2_path))
+        _insert_aspect(
+            conn, collection="knowledge__delos",
+            source_path="papers/aleph.pdf",
+        )
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            aspects_group, ["backfill-source-uri", "--apply"]
+        )
+        assert result.exit_code == 0, result.output
+
+        conn = sqlite3.connect(str(t2_path))
+        uri = conn.execute(
+            "SELECT source_uri FROM document_aspects",
+        ).fetchone()[0]
+        conn.close()
+        assert uri == "chroma://knowledge__delos/papers/aleph.pdf"
+
+    def test_empty_string_rows_also_backfilled(self, t2_path: Path) -> None:
+        """Original 4.26.2 migration's contract: both NULL and ''
+        rows must be backfilled when source_path is populated."""
+        conn = sqlite3.connect(str(t2_path))
+        _insert_aspect(
+            conn, collection="rdr__a", source_path="x.md",
+            source_uri="",  # explicit empty
+        )
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            aspects_group, ["backfill-source-uri", "--apply"]
+        )
+        assert result.exit_code == 0, result.output
+
+        conn = sqlite3.connect(str(t2_path))
+        uri = conn.execute(
+            "SELECT source_uri FROM document_aspects",
+        ).fetchone()[0]
+        conn.close()
+        assert uri and uri.endswith("x.md")
+
+    def test_does_not_overwrite_populated_source_uri(self, t2_path: Path) -> None:
+        explicit_uri = "chroma://knowledge__custom/some-source"
+        conn = sqlite3.connect(str(t2_path))
+        _insert_aspect(
+            conn, collection="knowledge__custom", source_path="diff-path",
+            source_uri=explicit_uri,
+        )
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            aspects_group, ["backfill-source-uri", "--apply"]
+        )
+        assert result.exit_code == 0, result.output
+
+        conn = sqlite3.connect(str(t2_path))
+        uri = conn.execute(
+            "SELECT source_uri FROM document_aspects",
+        ).fetchone()[0]
+        conn.close()
+        assert uri == explicit_uri
+
+    def test_idempotent_re_apply(self, t2_path: Path) -> None:
+        conn = sqlite3.connect(str(t2_path))
+        _insert_aspect(conn, collection="rdr__a", source_path="x.md")
+        conn.close()
+
+        runner = CliRunner()
+        runner.invoke(aspects_group, ["backfill-source-uri", "--apply"])
+        result = runner.invoke(
+            aspects_group, ["backfill-source-uri", "--apply"]
+        )
+        assert result.exit_code == 0, result.output
+        # Second --apply has nothing to do.
+        assert "backfilled 0 row" in result.output
+
+    def test_empty_source_path_skipped_for_triage(self, t2_path: Path) -> None:
+        """Rows with both empty source_uri and empty source_path
+        cannot be backfilled; the verb skips them and reports the
+        count separately (research-2 mitigation)."""
+        conn = sqlite3.connect(str(t2_path))
+        # The schema's PK forbids empty source_path on insert, so seed
+        # via direct INSERT bypassing the helper, then flip.
+        conn.execute(
+            "INSERT INTO document_aspects "
+            "(collection, source_path, extracted_at, model_version, extractor_name) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("rdr__edge", "placeholder",
+             "2026-04-27T00:00:00+00:00", "claude-haiku-4-5-20251001",
+             "scholarly-paper-v1"),
+        )
+        conn.execute(
+            "UPDATE document_aspects SET source_path = '' WHERE collection = 'rdr__edge'",
+        )
+        conn.commit()
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            aspects_group, ["backfill-source-uri", "--apply"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "1 row(s) have empty source_path" in result.output
+
+
+class TestBackfillSourceUriEdgeCases:
+    def test_missing_db_clean_noop(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        mem_path = tmp_path / "nope.db"
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path",
+            lambda: mem_path,
+        )
+        runner = CliRunner()
+        result = runner.invoke(aspects_group, ["backfill-source-uri", "--apply"])
+        assert result.exit_code == 0, result.output
+        assert "nothing to do" in result.output
+
+    def test_verb_registered(self) -> None:
+        assert "backfill-source-uri" in aspects_group.commands
+
+
+# ── gc-pre-rdr096 verb ────────────────────────────────────────────────────────
+
+
+def _seed_three_categories(conn: sqlite3.Connection) -> None:
+    """Plant 6 rows mirroring the four production categories from
+    RDR-096 research-3 (id 1010)."""
+    # Category 1: read-failure nulls (3 variants) — should be dropped.
+    _insert_aspect(
+        conn, collection="rdr__nexus", source_path="docs/missing-1.md",
+        extractor="rdr-frontmatter-v1",
+        experimental_datasets="[]", experimental_baselines="[]",
+        extras="{}", confidence=None,
+    )
+    _insert_aspect(
+        conn, collection="knowledge__hybridrag", source_path="ghost-paper",
+        experimental_datasets="[]", experimental_baselines="[]",
+        extras="{}", confidence=None,
+    )
+    # Legacy-ghost variant: extras IS NULL rather than '{}'.
+    _insert_aspect(
+        conn, collection="rdr__nexus", source_path="docs/legacy-ghost.md",
+        extractor="rdr-frontmatter-v1",
+        experimental_datasets="[]", experimental_baselines="[]",
+        extras=None, confidence=None,
+    )
+    # Category 2: structured-zero success — must be retained.
+    _insert_aspect(
+        conn, collection="rdr__nexus", source_path="docs/readme.md",
+        extractor="rdr-frontmatter-v1",
+        experimental_datasets="[]", experimental_baselines="[]",
+        extras="{}", confidence=1.0,
+    )
+    # Category 3: partial — must be retained.
+    _insert_aspect(
+        conn, collection="knowledge__delos", source_path="aleph.pdf",
+        problem_formulation="atomic broadcast",
+        experimental_datasets="[]", experimental_baselines="[]",
+        extras="{}", confidence=None,
+    )
+    # Category 4: full — must be retained.
+    _insert_aspect(
+        conn, collection="knowledge__delos", source_path="lightweight-smr.pdf",
+        problem_formulation="state machine replication",
+        proposed_method="median rule",
+        experimental_datasets='["TPC-C"]',
+        experimental_baselines='["raft"]',
+        experimental_results="30% improvement",
+        extras='{"venue":"OSDI"}', confidence=0.9,
+    )
+
+
+class TestGcPreRdr096:
+    def test_dry_run_reports_count(self, t2_path: Path) -> None:
+        conn = sqlite3.connect(str(t2_path))
+        _seed_three_categories(conn)
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(aspects_group, ["gc-pre-rdr096"])
+        assert result.exit_code == 0, result.output
+        assert "would delete 3" in result.output
+        # No rows actually deleted.
+        conn = sqlite3.connect(str(t2_path))
+        n = conn.execute(
+            "SELECT COUNT(*) FROM document_aspects",
+        ).fetchone()[0]
+        conn.close()
+        assert n == 6
+
+    def test_apply_drops_only_read_failure_nulls(self, t2_path: Path) -> None:
+        conn = sqlite3.connect(str(t2_path))
+        _seed_three_categories(conn)
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(aspects_group, ["gc-pre-rdr096", "--apply"])
+        assert result.exit_code == 0, result.output
+        assert "deleted 3" in result.output
+
+        conn = sqlite3.connect(str(t2_path))
+        kept = conn.execute(
+            "SELECT collection, source_path FROM document_aspects "
+            "ORDER BY collection, source_path",
+        ).fetchall()
+        conn.close()
+        # Structured-zero + partial + full retained; all 3 read-failure
+        # variants (including the extras-IS-NULL legacy ghost) dropped.
+        assert kept == [
+            ("knowledge__delos", "aleph.pdf"),
+            ("knowledge__delos", "lightweight-smr.pdf"),
+            ("rdr__nexus", "docs/readme.md"),
+        ]
+
+    def test_idempotent_on_re_apply(self, t2_path: Path) -> None:
+        conn = sqlite3.connect(str(t2_path))
+        _seed_three_categories(conn)
+        conn.close()
+
+        runner = CliRunner()
+        runner.invoke(aspects_group, ["gc-pre-rdr096", "--apply"])
+        result = runner.invoke(aspects_group, ["gc-pre-rdr096", "--apply"])
+        assert result.exit_code == 0, result.output
+        # Second run: 0 matching rows.
+        assert "0 pre-RDR-096" in result.output
+
+    def test_empty_db_clean_noop(self, t2_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(aspects_group, ["gc-pre-rdr096", "--apply"])
+        assert result.exit_code == 0, result.output
+        assert "0 pre-RDR-096" in result.output
+
+    def test_missing_db_clean_noop(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        mem_path = tmp_path / "nope.db"
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path",
+            lambda: mem_path,
+        )
+        runner = CliRunner()
+        result = runner.invoke(aspects_group, ["gc-pre-rdr096", "--apply"])
+        assert result.exit_code == 0, result.output
+        assert "nothing to do" in result.output
+
+    def test_verb_registered(self) -> None:
+        assert "gc-pre-rdr096" in aspects_group.commands

--- a/tests/test_migrations_rdr096.py
+++ b/tests/test_migrations_rdr096.py
@@ -34,11 +34,14 @@ import pytest
 
 
 class TestDocumentAspectsSourceUriMigration:
+    """RDR-120 §A8 / nexus-6y2a9: the migration is DDL-only now
+    (adds the ``source_uri`` column). The per-row backfill body that
+    used to run here moved to the ``nx aspects backfill-source-uri``
+    consumer verb; backfill-behaviour tests live in
+    ``tests/test_aspects_consumer_verbs.py``.
+    """
+
     def _seed_legacy_table(self, conn: sqlite3.Connection) -> None:
-        """Create a ``document_aspects`` table at the pre-4.16.0
-        schema (no source_uri column) so the migration has something
-        to widen.
-        """
         from nexus.db.migrations import migrate_document_aspects_table
         migrate_document_aspects_table(conn)
 
@@ -79,97 +82,30 @@ class TestDocumentAspectsSourceUriMigration:
         assert "source_uri" in cols
         assert cols["source_uri"] == ("TEXT", 0)  # nullable
 
-    def test_backfill_filesystem_collections_use_file_scheme(
+    def test_migration_does_not_backfill_source_uri(
         self, tmp_path: Path,
     ) -> None:
+        """RDR-120 §A8 / nexus-6y2a9: backfill moved to consumer verb.
+        After the migration runs, rows still have NULL ``source_uri``;
+        the operator must run ``nx aspects backfill-source-uri --apply``
+        to populate them."""
         from nexus.db.migrations import migrate_document_aspects_source_uri
 
-        db = tmp_path / "fs.db"
+        db = tmp_path / "noop.db"
         conn = sqlite3.connect(str(db))
         self._seed_legacy_table(conn)
-        # rdr__ + docs__ + code__: all use file:// with abspath.
-        self._insert_row(conn, collection="rdr__nexus", source_path="docs/rdr/rdr-090.md")
-        self._insert_row(conn, collection="docs__corpus", source_path="docs/architecture.md")
-        self._insert_row(conn, collection="code__nexus", source_path="src/nexus/cli.py")
-
-        migrate_document_aspects_source_uri(conn)
-
-        rows = dict(conn.execute(
-            "SELECT collection, source_uri FROM document_aspects",
-        ).fetchall())
-        conn.close()
-        # Each URI is file:// + abspath of the registered path.
-        for coll, sp in [
-            ("rdr__nexus", "docs/rdr/rdr-090.md"),
-            ("docs__corpus", "docs/architecture.md"),
-            ("code__nexus", "src/nexus/cli.py"),
-        ]:
-            assert rows[coll] == "file://" + os.path.abspath(sp)
-
-    def test_backfill_knowledge_collections_use_chroma_scheme(
-        self, tmp_path: Path,
-    ) -> None:
-        from nexus.db.migrations import migrate_document_aspects_source_uri
-
-        db = tmp_path / "kn.db"
-        conn = sqlite3.connect(str(db))
-        self._seed_legacy_table(conn)
-        # knowledge__*: chroma:// with literal source_path (slug-shaped
-        # AND filesystem-shaped both work; the reader's identity-field
-        # fallback handles it).
-        self._insert_row(
-            conn, collection="knowledge__knowledge",
-            source_path="decision-bfdb-update-capture-rdr005",
-        )
-        self._insert_row(
-            conn, collection="knowledge__delos",
-            source_path="/Users/me/papers/aleph-bft.pdf",
-        )
-
-        migrate_document_aspects_source_uri(conn)
-
-        rows = dict(conn.execute(
-            "SELECT collection, source_uri FROM document_aspects",
-        ).fetchall())
-        conn.close()
-        assert rows["knowledge__knowledge"] == (
-            "chroma://knowledge__knowledge/decision-bfdb-update-capture-rdr005"
-        )
-        assert rows["knowledge__delos"] == (
-            "chroma://knowledge__delos//Users/me/papers/aleph-bft.pdf"
-        )
-
-    def test_backfill_skips_empty_source_path(self, tmp_path: Path) -> None:
-        """Research-2 mitigation (id 1009): one row in
-        ``code__int-crossmodel-ba3a85dc`` has empty source_path.
-        Cannot be backfilled — left at NULL with a logged warning.
-        """
-        from nexus.db.migrations import migrate_document_aspects_source_uri
-
-        db = tmp_path / "skip.db"
-        conn = sqlite3.connect(str(db))
-        self._seed_legacy_table(conn)
-        # Empty source_path violates NOT NULL on source_path? Let me
-        # use a single space — the migration's "if not source_path"
-        # guard treats empty string as the trigger; tests here use ""
-        # to simulate the canonical mitigation case.
-        # The schema requires non-empty source_path, so insert with a
-        # non-empty value but flip the column to "" via UPDATE post-
-        # insert (mimicking the corrupt-data shape research-2 found).
-        self._insert_row(conn, collection="code__shadow", source_path="placeholder")
-        conn.execute(
-            "UPDATE document_aspects SET source_path = '' WHERE collection = 'code__shadow'",
-        )
-        conn.commit()
+        self._insert_row(conn, collection="rdr__nexus", source_path="docs/x.md")
 
         migrate_document_aspects_source_uri(conn)
 
         row = conn.execute(
-            "SELECT source_uri FROM document_aspects WHERE collection = 'code__shadow'",
+            "SELECT source_uri FROM document_aspects",
         ).fetchone()
         conn.close()
-        # NULL — the migration declined to invent a URI for an empty path.
-        assert row[0] is None
+        assert row[0] is None, (
+            "Migration must NOT backfill source_uri anymore; that work "
+            "moved to nx aspects backfill-source-uri"
+        )
 
     def test_migration_is_idempotent(self, tmp_path: Path) -> None:
         from nexus.db.migrations import migrate_document_aspects_source_uri
@@ -191,44 +127,6 @@ class TestDocumentAspectsSourceUriMigration:
         conn.close()
         assert cols.count("source_uri") == 1
 
-    def test_migration_does_not_overwrite_pre_populated_source_uri(
-        self, tmp_path: Path,
-    ) -> None:
-        """``WHERE source_uri IS NULL`` guard: rows that already have
-        a source_uri (written by post-P2.1 callers between migration
-        passes) are not stomped.
-        """
-        from nexus.db.migrations import migrate_document_aspects_source_uri
-
-        db = tmp_path / "preserve.db"
-        conn = sqlite3.connect(str(db))
-        self._seed_legacy_table(conn)
-        migrate_document_aspects_source_uri(conn)  # add column first
-        # Insert a row with an explicit source_uri (mimicking a
-        # post-migration writer).
-        explicit_uri = "chroma://knowledge__custom/some-source"
-        conn.execute(
-            "INSERT INTO document_aspects "
-            "(collection, source_path, extracted_at, model_version, "
-            " extractor_name, source_uri) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            ("knowledge__custom", "different-path-on-disk",
-             "2026-04-27T00:00:00+00:00", "claude-haiku-4-5-20251001",
-             "scholarly-paper-v1", explicit_uri),
-        )
-        conn.commit()
-
-        # Re-run the migration; the explicit URI must not be replaced
-        # with the derived ``chroma://knowledge__custom/different-path-on-disk``.
-        migrate_document_aspects_source_uri(conn)
-
-        row = conn.execute(
-            "SELECT source_uri FROM document_aspects "
-            "WHERE collection = 'knowledge__custom'",
-        ).fetchone()
-        conn.close()
-        assert row[0] == explicit_uri
-
     def test_migration_no_op_when_table_missing(self, tmp_path: Path) -> None:
         """Defensive: if document_aspects has not been created yet
         (fresh install, migration order swapped), the migration must
@@ -242,134 +140,36 @@ class TestDocumentAspectsSourceUriMigration:
         migrate_document_aspects_source_uri(conn)  # must not raise
         conn.close()
 
-    def test_backfill_empty_string_rows_in_addition_to_null(
-        self, tmp_path: Path,
-    ) -> None:
-        """nexus-pnje: the original P2.1 migration only touched NULL
-        rows. Subsequent writer paths landed empty-string rows; the
-        live audit on production found 61 of 579 rows (10.5%) with
-        empty source_uri. The follow-up migration must backfill BOTH
-        NULL and '' rows.
-        """
+    def test_backfill_empty_migration_is_noop(self, tmp_path: Path) -> None:
+        """RDR-120 §A8 / nexus-6y2a9:
+        ``migrate_document_aspects_source_uri_backfill_empty`` is now a
+        pure no-op. The backfill body moved to ``nx aspects
+        backfill-source-uri``; verb-tests in
+        ``tests/test_aspects_consumer_verbs.py`` exercise the
+        substantive behaviour."""
         from nexus.db.migrations import (
             migrate_document_aspects_source_uri,
             migrate_document_aspects_source_uri_backfill_empty,
         )
 
-        db = tmp_path / "empty_backfill.db"
+        db = tmp_path / "noop.db"
         conn = sqlite3.connect(str(db))
         self._seed_legacy_table(conn)
-        # Insert 3 rows BEFORE P2.1 so they have NULL source_uri after
-        # the column is added.
         self._insert_row(conn, collection="rdr__a", source_path="x.md")
-        self._insert_row(conn, collection="rdr__b", source_path="y.md")
-        self._insert_row(conn, collection="rdr__c", source_path="z.md")
-
-        # Apply P2.1 — backfills all NULL rows.
         migrate_document_aspects_source_uri(conn)
-
-        # Simulate the production gap: a writer path lands empty-string
-        # source_uri AFTER P2.1 ran. Mirrors the 61 rows seen on prod.
-        conn.execute(
-            "UPDATE document_aspects SET source_uri = '' "
-            "WHERE collection = 'rdr__a'"
-        )
-        # And one row that's still NULL (didn't get migrated for some
-        # reason — defensive: the new migration must catch this too).
-        conn.execute(
-            "UPDATE document_aspects SET source_uri = NULL "
-            "WHERE collection = 'rdr__b'"
-        )
-        # Third row keeps its valid URI from P2.1.
-        conn.commit()
-
-        # Pre-condition: 1 empty + 1 NULL + 1 valid.
-        before = conn.execute(
-            "SELECT collection, source_uri FROM document_aspects "
-            "ORDER BY collection",
-        ).fetchall()
-        # rdr__a empty, rdr__b NULL, rdr__c populated.
-        assert before[0] == ("rdr__a", "")
-        assert before[1] == ("rdr__b", None)
-        assert before[2][0] == "rdr__c"
-        assert before[2][1] and before[2][1].startswith("file://")
-
-        # Apply the new backfill migration.
-        migrate_document_aspects_source_uri_backfill_empty(conn)
-
-        # Post-condition: rdr__a + rdr__b backfilled to file:// URIs;
-        # rdr__c untouched.
-        after = dict(conn.execute(
-            "SELECT collection, source_uri FROM document_aspects",
-        ).fetchall())
-        conn.close()
-        assert after["rdr__a"].startswith("file://") and after["rdr__a"].endswith("x.md")
-        assert after["rdr__b"].startswith("file://") and after["rdr__b"].endswith("y.md")
-        assert after["rdr__c"] == before[2][1]  # unchanged
-
-    def test_backfill_empty_skips_when_source_path_also_empty(
-        self, tmp_path: Path,
-    ) -> None:
-        """Edge case: row with both source_uri='' AND source_path=''
-        cannot be backfilled. The migration leaves it alone for
-        manual triage rather than synthesising a bad URI.
-        """
-        from nexus.db.migrations import (
-            migrate_document_aspects_source_uri,
-            migrate_document_aspects_source_uri_backfill_empty,
-        )
-
-        db = tmp_path / "edge.db"
-        conn = sqlite3.connect(str(db))
-        self._seed_legacy_table(conn)
-        # P2.1's _insert_row helper requires non-empty source_path; do
-        # the empty insert directly so we exercise the both-empty case.
-        conn.execute(
-            "INSERT INTO document_aspects "
-            "(collection, source_path, extracted_at, model_version, extractor_name) "
-            "VALUES (?, '', ?, ?, ?)",
-            ("rdr__edge", "2026-04-27T00:00:00+00:00",
-             "claude-haiku-4-5-20251001", "scholarly-paper-v1"),
-        )
-        conn.commit()
-
-        migrate_document_aspects_source_uri(conn)
-        # Force empty-string rather than NULL.
         conn.execute("UPDATE document_aspects SET source_uri = ''")
         conn.commit()
 
         migrate_document_aspects_source_uri_backfill_empty(conn)
 
         row = conn.execute(
-            "SELECT source_path, source_uri FROM document_aspects",
+            "SELECT source_uri FROM document_aspects",
         ).fetchone()
         conn.close()
-        # Both still empty — migration left the row for triage.
-        assert row == ("", "")
-
-    def test_backfill_empty_idempotent(self, tmp_path: Path) -> None:
-        """Re-running the backfill is a no-op (no UPDATE on already-
-        populated rows)."""
-        from nexus.db.migrations import (
-            migrate_document_aspects_source_uri,
-            migrate_document_aspects_source_uri_backfill_empty,
+        assert row[0] == "", (
+            "Migration must be a no-op now; the backfill belongs to "
+            "nx aspects backfill-source-uri"
         )
-
-        db = tmp_path / "idem.db"
-        conn = sqlite3.connect(str(db))
-        self._seed_legacy_table(conn)
-        self._insert_row(conn, collection="rdr__a", source_path="x.md")
-        migrate_document_aspects_source_uri(conn)
-        conn.execute("UPDATE document_aspects SET source_uri = ''")
-        conn.commit()
-
-        migrate_document_aspects_source_uri_backfill_empty(conn)
-        first = conn.execute("SELECT source_uri FROM document_aspects").fetchone()[0]
-        migrate_document_aspects_source_uri_backfill_empty(conn)  # re-run
-        second = conn.execute("SELECT source_uri FROM document_aspects").fetchone()[0]
-        conn.close()
-        assert first == second
-        assert first.startswith("file://")
 
 
 # ── catalog documents inline migration ──────────────────────────────────────
@@ -582,34 +382,30 @@ class TestNullRowDeleteMigration:
             extras='{"venue":"OSDI"}', confidence=0.9,
         )
 
-    def test_drops_only_read_failure_nulls(self, tmp_path: Path) -> None:
+    def test_migration_is_noop(self, tmp_path: Path) -> None:
+        """RDR-120 §A8 / nexus-6y2a9: the DELETE body moved to
+        ``nx aspects gc-pre-rdr096``. Running the migration must not
+        delete read-failure rows; the verb-tests in
+        ``tests/test_aspects_consumer_verbs.py`` cover the
+        substantive seven-clause discriminator behaviour."""
         from nexus.db.migrations import migrate_drop_null_aspect_rows
 
-        db = tmp_path / "drop.db"
+        db = tmp_path / "drop_noop.db"
         conn = sqlite3.connect(str(db))
         self._seed_legacy_table(conn)
         self._seed_three_categories(conn)
-        # Pre: 6 rows (3 read-failure variants + 1 structured-zero +
-        # 1 partial + 1 full).
+        # Pre: 6 rows seeded.
         assert conn.execute(
             "SELECT COUNT(*) FROM document_aspects",
         ).fetchone()[0] == 6
 
         migrate_drop_null_aspect_rows(conn)
 
-        # Post: 3 rows (all 3 read-failure variants dropped — including
-        # the legacy-ghost with extras IS NULL; structured-zero,
-        # partial, and full are retained).
-        rows = conn.execute(
-            "SELECT collection, source_path FROM document_aspects "
-            "ORDER BY collection, source_path",
-        ).fetchall()
+        # Post: all 6 rows still present; migration is a no-op.
+        assert conn.execute(
+            "SELECT COUNT(*) FROM document_aspects",
+        ).fetchone()[0] == 6
         conn.close()
-        assert rows == [
-            ("knowledge__delos", "aleph-bft.pdf"),         # partial
-            ("knowledge__delos", "lightweight-smr.pdf"),    # full
-            ("rdr__nexus", "docs/rdr/readme.md"),           # structured-zero
-        ]
 
     def test_extras_null_clause_is_load_bearing(self, tmp_path: Path) -> None:
         """``extras IS NULL`` is the third load-bearing widening
@@ -706,26 +502,6 @@ class TestNullRowDeleteMigration:
         # Bare IS NULL matched ZERO rows because writer stored '[]' not NULL.
         # Production-shaped data would also see zero matches under this SQL.
         assert count == 6  # original count unchanged
-
-    def test_idempotent_on_re_run(self, tmp_path: Path) -> None:
-        from nexus.db.migrations import migrate_drop_null_aspect_rows
-
-        db = tmp_path / "idem.db"
-        conn = sqlite3.connect(str(db))
-        self._seed_legacy_table(conn)
-        self._seed_three_categories(conn)
-
-        migrate_drop_null_aspect_rows(conn)
-        first_count = conn.execute(
-            "SELECT COUNT(*) FROM document_aspects",
-        ).fetchone()[0]
-        # Second invocation: 0 read-failure rows remain → no-op.
-        migrate_drop_null_aspect_rows(conn)
-        second_count = conn.execute(
-            "SELECT COUNT(*) FROM document_aspects",
-        ).fetchone()[0]
-        conn.close()
-        assert first_count == second_count == 3
 
     def test_no_op_when_table_missing(self, tmp_path: Path) -> None:
         from nexus.db.migrations import migrate_drop_null_aspect_rows


### PR DESCRIPTION
## Summary

A9 audit identified 3 document_aspects migrations whose bodies mutate row content beyond DDL. Per RDR-120 §A8 the substrate provides shape, not content; the bodies move to consumer-driven verbs.

- Substrate (`src/nexus/db/migrations.py`):
  - `migrate_document_aspects_source_uri` (4.16.0) → DDL-only (`ALTER TABLE ADD COLUMN source_uri`). Backfill body removed.
  - `migrate_document_aspects_source_uri_backfill_empty` (4.26.2) → documented no-op. Step retained so the version chain stays monotone.
  - `migrate_drop_null_aspect_rows` (4.16.0) → documented no-op.
  - `migrate_drop_source_path_column` `MigrationError` message updated to name the new verb.
- Consumer verbs (`src/nexus/commands/aspects.py`):
  - `nx aspects backfill-source-uri [--apply]`: populates `source_uri` from `(collection, source_path)` via `nexus.aspect_readers.uri_for`. Idempotent.
  - `nx aspects gc-pre-rdr096 [--apply]`: applies the seven-clause discriminator DELETE (with load-bearing `confidence IS NULL`, JSON-array OR-clauses, and the `extras IS NULL OR = '{}'` widening for legacy ghosts).
- Both verbs open sqlite3 directly via `# epsilon-allow:` — pre-migration repair verbs categorically cannot depend on `T2Database.__init__`'s migration chain succeeding (the very migration that fails is the one this verb fixes the precondition for). Storage-boundary lint counts unchanged (21 / 2).
- Tests: 15 new in `tests/test_aspects_consumer_verbs.py` (full coverage of both verbs). `tests/test_migrations_rdr096.py` reframed: backfill-asserting tests became "migration is no-op" pinning tests; SQL-clause load-bearing tests retained.

**Operator-visible behaviour:** existing installs with un-backfilled rows surface `MigrationError` on `nx upgrade` from `migrate_drop_source_path_column`. The error message names `nx aspects backfill-source-uri --apply` as the fix. Fresh installs are unaffected (writer has emitted `source_uri` on every row since RDR-096 shipped).

## Closes

Closes nexus-6y2a9.

## Test plan

- [x] `uv run pytest tests/test_aspects_consumer_verbs.py tests/test_migrations_rdr096.py` (29 passed)
- [x] `uv run pytest tests/ -k 'aspect or migration or upgrade'` (670 passed)
- [x] `uv run nx doctor --check-storage-boundary --phase 1` unchanged (violations=21, catalog-allowlist=2)
- [x] `uv run nx aspects --help` shows the two new verbs

## Notes

This PR is independent of #909 (yulol, in flight). Both touch `src/nexus/commands/aspects.py` and add new verbs; the diffs do not overlap. If #909 merges first, no rebase required.