### PR TITLE
feat(rdr-120): nexus-rv7x6 6 plan migrations → nx plan repair verbs

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -781,3 +781,5 @@
 {"id":"int-00ea2c6c","kind":"field_change","created_at":"2026-05-21T19:21:05.221091Z","actor":"Hellblazer","issue_id":"nexus-beoh1","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
 {"id":"int-c133b1b6","kind":"field_change","created_at":"2026-05-21T19:21:05.813735Z","actor":"Hellblazer","issue_id":"nexus-aim84","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
 {"id":"int-21360063","kind":"field_change","created_at":"2026-05-21T19:22:45.896647Z","actor":"Hellblazer","issue_id":"nexus-ldztl","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
+=======
+{"id":"int-3326fd50","kind":"field_change","created_at":"2026-05-21T20:09:58.736958Z","actor":"Hellblazer","issue_id":"nexus-q2t5t","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}

--- a/.beads/push-state.json
+++ b/.beads/push-state.json
@@ -1,4 +1,7 @@
 {
   "last_push": "2026-05-21T19:52:42Z",
   "last_commit": "7ufh3t618408d66qvf28k1loc695kgt1"
+=======
+  "last_push": "2026-05-21T20:09:59Z",
+  "last_commit": "ik4ttf1g42j2c2gq4q78oqeipk01th5g"
 }

--- a/src/nexus/commands/plan.py
+++ b/src/nexus/commands/plan.py
@@ -52,49 +52,72 @@ def plan() -> None:
     """Plan library maintenance commands."""
 
 
-@plan.command("repair")
-def repair_cmd() -> None:
-    """Re-run plan-dimension backfill and list low-conf rows for review.
+@plan.group("repair")
+def repair() -> None:
+    """Consumer-side content-repair verbs for the plan library.
 
-    Idempotent: once every plan row has a populated ``dimensions``
-    column, subsequent runs report "0 backfilled" and exit cleanly.
-    Low-confidence rows (those that reached the wh-fallback during the
-    RDR-092 Phase 0d.1 backfill heuristic) are listed with their
-    inferred verb so the operator can update them via SQL or future
-    editor commands.
+    Under RDR-120 §A8 the substrate's migration chain runs DDL only;
+    legacy backfills that mutated row content moved out of
+    ``apply_pending`` and into these explicit consumer-driven
+    subcommands. Operators run them after `nx upgrade` (or whenever
+    legacy rows surface that need repair). Each subcommand is
+    idempotent.
+
+    See RDR-120 §A8-exempt table for which substrate writes still
+    stay in the migration chain.
     """
+
+
+def _open_plans_db():
+    """Open memory.db with WAL pragmas. Returns the connection, or
+    None when the database does not exist."""
     from nexus.commands._helpers import default_db_path
-    from nexus.db.migrations import _backfill_plan_dimensions
 
     db_path = default_db_path()
     if not db_path.exists():
-        click.echo(
-            f"T2 database not found at {db_path}; nothing to do."
-        )
-        return
-
-    # Context manager guards against a raise in _backfill_plan_dimensions
-    # leaking the connection (RDR-092 code-review S-3).
+        click.echo(f"T2 database not found at {db_path}; nothing to do.")
+        return None
     conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+@repair.command("scope-tags")
+def repair_scope_tags_cmd() -> None:
+    """Backfill empty ``scope_tags`` rows and rewash legacy ``'all'`` sentinels.
+
+    Combines the substantive work of the pre-RDR-120 4.8.0 and 4.8.1
+    migrations into one idempotent pass.
+    """
+    from nexus.plans.repair import repair_scope_tags
+
+    conn = _open_plans_db()
+    if conn is None:
+        return
     try:
-        conn.execute("PRAGMA busy_timeout=5000")
-        conn.execute("PRAGMA journal_mode=WAL")
+        result = repair_scope_tags(conn)
+    finally:
+        conn.close()
+    _emit(result)
 
-        # Count NULL-dimension rows before the run so the report reflects
-        # reality even when the migration itself is a no-op.
-        pending_before = conn.execute(
-            "SELECT COUNT(*) FROM plans WHERE dimensions IS NULL"
-        ).fetchone()[0]
 
-        _backfill_plan_dimensions(conn)
+@repair.command("dimensions")
+def repair_dimensions_cmd() -> None:
+    """Backfill verb / name / dimensions on NULL-dimension plan rows.
 
-        pending_after = conn.execute(
-            "SELECT COUNT(*) FROM plans WHERE dimensions IS NULL"
-        ).fetchone()[0]
-        backfilled = pending_before - pending_after
+    Heuristic verb inference; rows that reached the wh-fallback are
+    tagged ``backfill-low-conf`` for operator review. Re-runs report
+    "0 backfilled" once every row carries dimensions.
+    """
+    from nexus.plans.repair import repair_dimensions
 
-        # Surface low-confidence rows for operator review, oldest first so
-        # a re-run reports a stable order.
+    conn = _open_plans_db()
+    if conn is None:
+        return
+    try:
+        result = repair_dimensions(conn)
+        # Surface low-confidence rows for operator review.
         low_conf_rows = conn.execute(
             "SELECT id, query, verb FROM plans "
             "WHERE tags LIKE '%backfill-low-conf%' "
@@ -102,11 +125,7 @@ def repair_cmd() -> None:
         ).fetchall()
     finally:
         conn.close()
-
-    click.echo(f"{backfilled} backfilled")
-    if backfilled == 0 and pending_before == 0:
-        click.echo("Nothing to do; every plan already carries dimensions.")
-
+    _emit(result)
     if low_conf_rows:
         click.echo(
             f"\n{len(low_conf_rows)} low-conf row(s) need review "
@@ -119,6 +138,87 @@ def repair_cmd() -> None:
             )
     else:
         click.echo("\n0 rows need review.")
+
+
+@repair.command("match-text")
+def repair_match_text_cmd() -> None:
+    """Populate ``plans.match_text`` (and refresh ``plans_fts``) for rows
+    with empty ``match_text``. The schema (column + FTS5 table +
+    triggers) was created by ``apply_pending``; this verb fills in
+    the content the legacy migration used to populate.
+    """
+    from nexus.plans.repair import repair_match_text
+
+    conn = _open_plans_db()
+    if conn is None:
+        return
+    try:
+        result = repair_match_text(conn)
+    finally:
+        conn.close()
+    _emit(result)
+
+
+@repair.command("retire-legacy")
+def repair_retire_legacy_cmd() -> None:
+    """Delete plan rows whose ``plan_json`` uses the pre-RDR-078
+    ``operation`` shape. Such rows cannot be dispatched by ``plan_run``
+    and only pollute plan-match results.
+    """
+    from nexus.plans.repair import repair_retire_legacy
+
+    conn = _open_plans_db()
+    if conn is None:
+        return
+    try:
+        result = repair_retire_legacy(conn)
+    finally:
+        conn.close()
+    _emit(result)
+
+
+@repair.command("builtin-bindings")
+def repair_builtin_bindings_cmd() -> None:
+    """Patch ``required_bindings`` / ``optional_bindings`` into builtin
+    plan rows whose stored ``plan_json`` predates the 4.10.1 seed
+    loader fix.
+    """
+    from nexus.plans.repair import repair_builtin_bindings
+
+    conn = _open_plans_db()
+    if conn is None:
+        return
+    try:
+        result = repair_builtin_bindings(conn)
+    finally:
+        conn.close()
+    _emit(result)
+
+
+@repair.command("all")
+def repair_all_cmd() -> None:
+    """Run every repair pass in dependency order."""
+    from nexus.plans.repair import repair_all
+
+    conn = _open_plans_db()
+    if conn is None:
+        return
+    try:
+        results = repair_all(conn)
+    finally:
+        conn.close()
+    for name, result in results.items():
+        click.echo(f"[{name}]")
+        _emit(result, indent="  ")
+
+
+def _emit(result: dict, *, indent: str = "") -> None:
+    """Pretty-print a repair-verb result dict."""
+    if not result:
+        click.echo(f"{indent}(no-op)")
+        return
+    for key, value in result.items():
+        click.echo(f"{indent}{key}: {value}")
 
 
 @plan.command("list")

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -1020,31 +1020,15 @@ def _add_plan_disabled_at(conn: sqlite3.Connection) -> None:
 
 
 def _add_plan_scope_tags(conn: sqlite3.Connection) -> None:
-    """Add the ``scope_tags`` column to ``plans`` and backfill default rows.
+    """Add the ``scope_tags`` column to ``plans``.
 
-    RDR-091 Phase 2a (bead ``nexus-x6pr``). ``scope_tags`` captures which
-    corpora / collections a plan actually touched — a comma-separated,
-    sorted, deduplicated, hash-suffix-normalized string. Phase 2b consumes
-    this column during match-time re-ranking; this migration only ensures
-    the column exists and carries a best-effort value for every row.
+    RDR-091 Phase 2a (bead ``nexus-x6pr``). DDL-only now (RDR-120 §A8
+    / nexus-rv7x6): the per-row inference backfill body moved to
+    ``nx plan repair scope-tags``. Operators upgrading from pre-4.8.0
+    must run the verb to populate the column.
 
-    The backfill intentionally guards on ``WHERE scope_tags = ''`` so
-    explicitly-authored values (passed via ``save_plan(scope_tags=...)``)
-    survive process restarts. Without this guard (RDR-091 critic
-    follow-up, nexus-dfok), every process start would overwrite
-    explicit tags with inference output, defeating the explicit-override
-    path documented in the authoring guide.
-
-    Idempotent via a ``PRAGMA table_info`` column guard. The backfill is
-    safe to re-run because inference is deterministic.
-
-    No-op on a DB that has no ``plans`` table (fresh install without
-    :mod:`nexus.db.t2.plan_library` ever instantiated).
-
-    The ``DEFAULT ''`` at column-creation time is load-bearing: any code
-    path that inserts into ``plans`` without naming ``scope_tags`` (pre
-    the plan_library update in the same PR) produces ``""``, not ``NULL``,
-    which Phase 2b treats as the scope-agnostic marker.
+    Idempotent via the column guard. No-op on a DB without a
+    ``plans`` table.
     """
     has_table = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='plans'"
@@ -1058,266 +1042,32 @@ def _add_plan_scope_tags(conn: sqlite3.Connection) -> None:
         conn.execute(
             "ALTER TABLE plans ADD COLUMN scope_tags TEXT NOT NULL DEFAULT ''"
         )
-
-    # Backfill only rows where scope_tags is still the default ''.
-    # Explicit values survive; partial-failure retries pick up where
-    # they left off.
-    from nexus.plans.scope import _infer_scope_tags
-
-    rows = conn.execute(
-        "SELECT id, plan_json FROM plans WHERE scope_tags = ''"
-    ).fetchall()
-    for row_id, plan_json in rows:
-        inferred = _infer_scope_tags(plan_json or "")
-        if inferred:
-            conn.execute(
-                "UPDATE plans SET scope_tags = ? WHERE id = ? AND scope_tags = ''",
-                (inferred, row_id),
-            )
-    conn.commit()
-
-
-def _rewash_plan_scope_tags_all_sentinel(conn: sqlite3.Connection) -> None:
-    """Rewash rows whose ``scope_tags`` contains ``'all'`` from pre-fix backfill.
-
-    RDR-091 critic follow-up (bead ``nexus-dfok``). The first-cut
-    ``_infer_scope_tags`` treated ``corpus: "all"`` as a concrete
-    scope tag, so the 4.8.0 backfill wrote ``scope_tags='all'`` onto
-    every builtin plan that uses ``corpus: all`` (7 of 9 builtins).
-    At match time those plans prefix-matched no real scope and were
-    filtered out of the candidate pool — inverting RDR-091's whole
-    purpose for any scoped ``nx_answer`` call.
-
-    The inference fix (``"all"`` is now a skipped sentinel) takes
-    effect on new saves, but existing rows carry the broken value.
-    This migration re-runs inference on any row whose ``scope_tags``
-    contains the token ``all``, replacing it with the corrected value
-    (typically ``""`` for agnostic plans, or the subset of real tags
-    when a multi-corpus plan mixed ``all`` with specific corpora).
-
-    No-op on fresh installs or on DBs where every row already has
-    clean tags. Idempotent: a second run finds no matching rows.
-    """
-    has_table = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='plans'"
-    ).fetchone()
-    if not has_table:
-        return
-
-    cols = {row[1] for row in conn.execute("PRAGMA table_info(plans)").fetchall()}
-    if "scope_tags" not in cols:
-        return
-
-    from nexus.plans.scope import _infer_scope_tags
-
-    rows = conn.execute(
-        """
-        SELECT id, plan_json FROM plans
-        WHERE scope_tags = 'all'
-           OR scope_tags LIKE 'all,%'
-           OR scope_tags LIKE '%,all'
-           OR scope_tags LIKE '%,all,%'
-        """
-    ).fetchall()
-    for row_id, plan_json in rows:
-        inferred = _infer_scope_tags(plan_json or "")
-        conn.execute(
-            "UPDATE plans SET scope_tags = ? WHERE id = ?",
-            (inferred, row_id),
-        )
-    if rows:
-        _log.info("Rewashed plan scope_tags 'all' sentinel", row_count=len(rows))
         conn.commit()
 
 
-# ── RDR-092 Phase 0d.1 (plan-dimensions backfill) ──────────────────────────
-
-
-#: Verb-from-stem dictionary (29 stems across 5 verb families). Keyed
-#: on lowercased tokens that commonly appear in plan ``query`` text.
-#: A match is high-confidence (tagged ``backfill``); zero matches fall
-#: through to the wh-fallback and get tagged ``backfill-low-conf``.
-_BACKFILL_VERB_STEMS: dict[str, str] = {
-    # research family (8 stems)
-    "find": "research", "search": "research", "list": "research",
-    "get": "research", "show": "research", "enumerate": "research",
-    "fetch": "research", "retrieve": "research",
-    # analyze family (8 stems)
-    "analyze": "analyze", "analyse": "analyze",
-    "compare": "analyze", "contrast": "analyze",
-    "rank": "analyze", "synthesize": "analyze",
-    "summarize": "analyze", "summarise": "analyze",
-    # review family (5 stems)
-    "review": "review", "audit": "review",
-    "evaluate": "review", "critique": "review",
-    "assess": "review",
-    # debug family (5 stems)
-    "debug": "debug", "trace": "debug",
-    "investigate": "debug", "fix": "debug",
-    "troubleshoot": "debug",
-    # document family (3 stems)
-    "document": "document", "describe": "document",
-    "explain": "document",
-}
-
-#: Wh-fallback table. Low confidence because a wh-question can map to
-#: any verb; the best guess is research for explanatory questions,
-#: review for causal "why" questions.
-_BACKFILL_WH_FALLBACK: dict[str, str] = {
-    "how": "research", "what": "research",
-    "why": "review",
-    "when": "research", "where": "research", "who": "research",
-    "which": "research",
-}
-
-#: Stop-words skipped when deriving the plan ``name`` from query text.
-_BACKFILL_NAME_STOP_WORDS: frozenset[str] = frozenset({
-    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
-    "to", "of", "for", "in", "on", "at", "by", "with", "from", "about",
-    "and", "or", "but", "so", "as",
-    "how", "what", "why", "when", "where", "who", "which",
-    "do", "does", "did", "can", "could", "should", "would", "will",
-    "this", "that", "these", "those",
-    "i", "we", "you", "they", "it", "he", "she",
-})
-
-
-def _infer_plan_verb_from_query(query: str) -> tuple[str, bool]:
-    """Heuristic verb classifier for RDR-092 plan-dimension backfill.
-
-    Returns ``(verb, is_confident)``. High-confidence matches come
-    from :data:`_BACKFILL_VERB_STEMS`; wh-fallback matches are
-    low-confidence; the ultimate default is ``("research", False)``.
+def _rewash_plan_scope_tags_all_sentinel(conn: sqlite3.Connection) -> None:
+    """RDR-091 critic follow-up (``nexus-dfok``). Pure data rewash;
+    moved to ``nx plan repair scope-tags`` (RDR-120 §A8 / nexus-rv7x6).
+    No-op now; step retained so the version chain remains monotone.
     """
-    import re
-
-    tokens = re.findall(r"[a-z][a-z-]+", (query or "").lower())
-    for token in tokens:
-        if token in _BACKFILL_VERB_STEMS:
-            return _BACKFILL_VERB_STEMS[token], True
-    for token in tokens:
-        if token in _BACKFILL_WH_FALLBACK:
-            return _BACKFILL_WH_FALLBACK[token], False
-    return "research", False
+    return
 
 
-def _derive_plan_name_from_query(query: str, *, max_words: int = 5) -> str:
-    """Kebab-case name from the first 3-5 content tokens of *query*."""
-    import re
-
-    tokens = re.findall(r"[a-zA-Z0-9][a-zA-Z0-9_]*", (query or "").lower())
-    content = [t for t in tokens if t not in _BACKFILL_NAME_STOP_WORDS]
-    take = content[:max_words] if content else tokens[:max_words]
-    return "-".join(take) or "backfilled-plan"
+# ── RDR-092 Phase 0d.1 (plan-dimensions backfill) ──────────────────────────
+#
+# RDR-120 §A8 / nexus-rv7x6: the inference helpers
+# (_BACKFILL_VERB_STEMS, _infer_plan_verb_from_query,
+# _derive_plan_name_from_query, etc.) moved to nexus.plans.repair
+# alongside the dispatch body. The migration step below is a no-op
+# now; the verb owns the work.
 
 
 def _backfill_plan_dimensions(conn: sqlite3.Connection) -> None:
-    """Backfill verb / name / dimensions on NULL-dimension plan rows.
-
-    RDR-092 Phase 0d.1. Touches only rows where ``dimensions IS NULL``;
-    authored rows (shipped YAML seeds, already-dimensional grown
-    plans, previously-backfilled rows) are left alone. The
-    :func:`_infer_plan_verb_from_query` heuristic decides the verb,
-    and :func:`_derive_plan_name_from_query` supplies the name. Rows
-    whose verb came from a stem match get tagged ``backfill``; rows
-    that fell through to the wh-fallback get tagged
-    ``backfill-low-conf`` so ``nx plan repair`` can prioritise them.
-
-    The canonical dimensions JSON is ``{"scope":<scope>,"strategy":
-    <name>,"verb":<verb>}`` where ``<scope>`` is ``"personal"`` for
-    tagged grown rows and ``"global"`` for everything else (legacy
-    builtin shapes pre-RDR-078). Idempotent: a second run skips rows
-    whose ``dimensions`` is no longer NULL.
-
-    **Collision handling (RDR-092 code-review C-1).** Two NULL-
-    dimension rows in the same project whose queries collapse to the
-    same kebab name produce identical canonical dimensions JSON and
-    would violate the partial UNIQUE ``(project, dimensions) WHERE
-    dimensions IS NOT NULL`` index on the second UPDATE. The loop
-    catches :class:`sqlite3.IntegrityError` and retries the row with
-    the strategy suffixed by the row id (which is monotonic + stable
-    within a DB, preserving idempotency across reruns).
+    """RDR-092 Phase 0d.1. Pure data backfill; moved to
+    ``nx plan repair dimensions`` (RDR-120 §A8 / nexus-rv7x6).
+    No-op now; step retained so the version chain remains monotone.
     """
-    has_table = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='plans'"
-    ).fetchone()
-    if not has_table:
-        return
-
-    cols = {row[1] for row in conn.execute("PRAGMA table_info(plans)").fetchall()}
-    if "dimensions" not in cols:
-        return
-
-    rows = conn.execute(
-        "SELECT id, query, tags FROM plans WHERE dimensions IS NULL"
-    ).fetchall()
-    if not rows:
-        return
-
-    from nexus.plans.schema import canonical_dimensions_json
-
-    backfilled = 0
-    low_conf = 0
-    collisions = 0
-    # Track identities set during this run so within-loop collisions
-    # also get the row_id suffix treatment (the DB-level partial
-    # UNIQUE index would only catch cross-run collisions because the
-    # legacy rows all share dimensions IS NULL until we write).
-    claimed: set[tuple[str, str]] = set()
-    for row_id, query, tags in rows:
-        verb, confident = _infer_plan_verb_from_query(query or "")
-        base_name = _derive_plan_name_from_query(query or "")
-        scope = "personal" if (tags or "").find("grown") >= 0 else "global"
-        project = ""  # Backfill applies to the legacy global project.
-
-        def _dims(name_value: str) -> str:
-            return canonical_dimensions_json({
-                "scope": scope,
-                "strategy": name_value,
-                "verb": verb,
-            })
-
-        # Pre-check for collision against both already-persisted rows
-        # and rows we updated earlier in this same loop.
-        name = base_name
-        dims_json = _dims(name)
-        key = (project, dims_json)
-        db_hit = conn.execute(
-            "SELECT 1 FROM plans "
-            "WHERE project = ? AND dimensions = ? AND id != ? LIMIT 1",
-            (project, dims_json, row_id),
-        ).fetchone()
-        if db_hit or key in claimed:
-            # RDR-092 code-review C-1: resolve via a deterministic
-            # row-id suffix so reruns produce the same identity.
-            name = f"{base_name}-{row_id}"
-            dims_json = _dims(name)
-            key = (project, dims_json)
-            collisions += 1
-        claimed.add(key)
-
-        tag_flag = "backfill" if confident else "backfill-low-conf"
-        existing_tags = [t for t in (tags or "").split(",") if t]
-        if tag_flag not in existing_tags:
-            existing_tags.append(tag_flag)
-        new_tags = ",".join(existing_tags)
-
-        conn.execute(
-            "UPDATE plans SET verb = ?, scope = ?, name = ?, "
-            "dimensions = ?, tags = ? WHERE id = ?",
-            (verb, scope, name, dims_json, new_tags, row_id),
-        )
-        if confident:
-            backfilled += 1
-        else:
-            low_conf += 1
-
-    conn.commit()
-    _log.info(
-        "Backfilled plan dimensions",
-        backfilled=backfilled, low_conf=low_conf,
-        total_rows=len(rows), collisions=collisions,
-    )
+    return
 
 
 # ── RDR-092 Phase 3.1 (plans.match_text column + FTS rebuild) ──────────────
@@ -1383,35 +1133,19 @@ def _add_plan_match_text_column(conn: sqlite3.Connection) -> None:
             "ALTER TABLE plans ADD COLUMN match_text TEXT NOT NULL DEFAULT ''"
         )
 
-    # Drop the legacy triggers + FTS table up-front so the backfill
-    # UPDATE below does not fan out into an external-content FTS that
-    # is about to be rebuilt anyway.
+    # Drop legacy triggers + FTS table; recreate against match_text.
+    # RDR-120 §A8 / nexus-rv7x6: the per-row backfill UPDATE that
+    # populated match_text from query/verb/name/scope moved to
+    # ``nx plan repair match-text``. After this migration runs the
+    # column exists at DEFAULT '' and the FTS rebuild produces empty
+    # entries; the verb populates rows on the consumer's terms and
+    # the AFTER UPDATE trigger refreshes FTS per row.
     conn.executescript("""
         DROP TRIGGER IF EXISTS plans_ai;
         DROP TRIGGER IF EXISTS plans_ad;
         DROP TRIGGER IF EXISTS plans_au;
         DROP TABLE  IF EXISTS plans_fts;
-    """)
 
-    # Backfill existing rows from query / verb / name / scope using the
-    # same hybrid shape save_plan produces on new inserts.
-    from nexus.db.t2.plan_library import _synthesize_match_text
-
-    rows = conn.execute(
-        "SELECT id, query, verb, name, scope FROM plans"
-    ).fetchall()
-    for row_id, query, verb, name, scope in rows:
-        synthesised = _synthesize_match_text(
-            description=query, verb=verb, name=name, scope=scope,
-        )
-        conn.execute(
-            "UPDATE plans SET match_text = ? WHERE id = ?",
-            (synthesised, row_id),
-        )
-
-    # Recreate plans_fts + triggers on the populated match_text column
-    # and rebuild the FTS index from existing rows.
-    conn.executescript("""
         CREATE VIRTUAL TABLE plans_fts USING fts5(
             match_text, tags, project,
             content=plans, content_rowid='id'
@@ -1434,186 +1168,25 @@ def _add_plan_match_text_column(conn: sqlite3.Connection) -> None:
     """)
     conn.execute("INSERT INTO plans_fts(plans_fts) VALUES('rebuild')")
     conn.commit()
-    _log.info(
-        "plans.match_text migration complete",
-        backfilled=len(rows),
-    )
+    _log.info("plans.match_text DDL migration complete")
 
 
 def _retire_legacy_operation_shape_plans(conn: sqlite3.Connection) -> None:
-    """Delete plans whose plan_json uses the pre-RDR-078 ``operation`` shape.
-
-    RDR-092 Phase 0a retired the ``_PLAN_TEMPLATES`` seed array but did
-    not migrate the rows it had previously seeded. Those rows — plus
-    user ad-hoc plans saved before the RDR-078 runner landed — carry
-    step dicts like ``{"step": 1, "operation": "search", "params":
-    {...}}`` rather than the current ``{"tool": "search", "args":
-    {...}}``. ``plan_run`` cannot dispatch them; they exist only to
-    pollute plan-match results and mask modern replacements (e.g.
-    legacy ``find-documents-author`` beating the YAML builtin
-    ``find-by-author``).
-
-    Idempotent: after the first run, no legacy-shape rows remain; the
-    guarded SELECT returns 0 rows on retry.
+    """RDR-092 Phase 0a legacy-shape DELETE. Pure data sweep; moved
+    to ``nx plan repair retire-legacy`` (RDR-120 §A8 / nexus-rv7x6).
+    No-op now; step retained so the version chain remains monotone.
     """
-    import json as _json
-
-    candidates = conn.execute(
-        "SELECT id, plan_json FROM plans WHERE plan_json LIKE '%\"operation\"%'"
-    ).fetchall()
-    if not candidates:
-        return
-
-    legacy_ids: list[int] = []
-    for row_id, plan_json_text in candidates:
-        try:
-            parsed = _json.loads(plan_json_text or "{}")
-        except _json.JSONDecodeError:
-            continue
-        steps = parsed.get("steps") if isinstance(parsed, dict) else None
-        if not isinstance(steps, list) or not steps:
-            continue
-        # Legacy shape: any step has "operation" key AND no step has
-        # "tool" key. A plan_json that happens to mention "operation"
-        # inside an args payload but uses "tool" correctly is not
-        # legacy — the check above (LIKE) is a pre-filter only.
-        has_operation = any(
-            isinstance(s, dict) and "operation" in s for s in steps
-        )
-        has_tool = any(
-            isinstance(s, dict) and "tool" in s for s in steps
-        )
-        if has_operation and not has_tool:
-            legacy_ids.append(int(row_id))
-
-    if not legacy_ids:
-        return
-
-    placeholders = ",".join("?" * len(legacy_ids))
-    conn.execute(
-        f"DELETE FROM plans WHERE id IN ({placeholders})",
-        legacy_ids,
-    )
-    conn.commit()
-    _log.info(
-        "retired_legacy_operation_shape_plans",
-        deleted=len(legacy_ids),
-        ids=legacy_ids,
-    )
+    return
 
 
 def _backfill_builtin_bindings(conn: sqlite3.Connection) -> None:
-    """Patch required_bindings/optional_bindings into existing builtin rows.
-
-    The 4.10.1 seed_loader fix (nexus-80tk) merges YAML binding
-    declarations into plan_json at save_plan time, but rows seeded
-    before 4.10.1 short-circuit the seed loader on re-run because
-    their ``(project, dimensions)`` pair already exists. Without
-    this backfill, ``_validate_bindings`` still sees an empty list
-    on upgraded installs and unresolved ``$var`` literals leak into
-    operator prompts.
-
-    For each builtin row whose plan_json lacks a ``required_bindings``
-    key, resolve the shipping YAML by ``(verb, scope, strategy)``
-    and patch the binding lists into the stored JSON. Idempotent
-    via the ``NOT LIKE '%required_bindings%'`` pre-filter.
-
-    Silent no-op when the shipping YAMLs are unreachable (exotic
-    install layouts) — the seed loader's fail-loud guard at
-    ``nx catalog setup`` is the escalation path for that case.
+    """RDR-091 nexus-80tk follow-up. Patches required_bindings /
+    optional_bindings into legacy builtin rows. Pure data backfill;
+    moved to ``nx plan repair builtin-bindings`` (RDR-120 §A8 /
+    nexus-rv7x6). No-op now; step retained so the version chain
+    remains monotone.
     """
-    import json as _json
-
-    try:
-        import yaml as _yaml
-        from importlib.resources import as_file, files
-    except ModuleNotFoundError:
-        return
-
-    rows = conn.execute(
-        "SELECT id, plan_json, dimensions FROM plans "
-        "WHERE tags LIKE '%builtin%' "
-        "AND plan_json NOT LIKE '%required_bindings%'"
-    ).fetchall()
-    if not rows:
-        return
-
-    # Resolve the shipping YAML directory via package resources, with
-    # a repo-root fallback for dev-mode runs. Mirrors
-    # ``catalog._resolve_plugin_root`` but inlined so this migration
-    # stays in the db layer.
-    yaml_dir = None
-    try:
-        resource = files("nexus") / "_resources" / "plans" / "builtin"
-        with as_file(resource) as resolved:
-            from pathlib import Path as _Path
-            if _Path(resolved).is_dir():
-                yaml_dir = _Path(resolved)
-    except (ModuleNotFoundError, FileNotFoundError, TypeError):
-        pass
-    if yaml_dir is None:
-        from pathlib import Path as _Path
-        repo_candidate = _Path(__file__).resolve().parents[3] / "nx" / "plans" / "builtin"
-        if repo_candidate.is_dir():
-            yaml_dir = repo_candidate
-    if yaml_dir is None:
-        _log.warning(
-            "backfill_builtin_bindings_skip",
-            reason="shipping YAMLs unreachable; run 'nx catalog setup' to re-seed",
-        )
-        return
-
-    bindings_index: dict[tuple[str, str, str], tuple[list, list]] = {}
-    for entry in yaml_dir.iterdir():
-        if not entry.is_file() or entry.suffix not in (".yml", ".yaml"):
-            continue
-        try:
-            template = _yaml.safe_load(entry.read_text()) or {}
-        except Exception:
-            continue
-        dims = template.get("dimensions") or {}
-        key = (
-            str(dims.get("verb", "")),
-            str(dims.get("scope", "")),
-            str(dims.get("strategy", "")),
-        )
-        required = list(template.get("required_bindings") or [])
-        optional = list(template.get("optional_bindings") or [])
-        if required or optional:
-            bindings_index[key] = (required, optional)
-
-    if not bindings_index:
-        return
-
-    backfilled = 0
-    for row_id, plan_json_text, dims_text in rows:
-        try:
-            parsed = _json.loads(plan_json_text or "{}")
-            dims = _json.loads(dims_text or "{}")
-        except _json.JSONDecodeError:
-            continue
-        key = (
-            str(dims.get("verb", "")),
-            str(dims.get("scope", "")),
-            str(dims.get("strategy", "")),
-        )
-        bindings = bindings_index.get(key)
-        if not bindings:
-            continue
-        required, optional = bindings
-        if required:
-            parsed["required_bindings"] = required
-        if optional:
-            parsed["optional_bindings"] = optional
-        conn.execute(
-            "UPDATE plans SET plan_json = ? WHERE id = ?",
-            (_json.dumps(parsed), row_id),
-        )
-        backfilled += 1
-
-    if backfilled:
-        conn.commit()
-        _log.info("backfill_builtin_bindings", rows=backfilled)
+    return
 
 
 def migrate_document_aspects_source_uri(conn: sqlite3.Connection) -> None:

--- a/src/nexus/plans/repair.py
+++ b/src/nexus/plans/repair.py
@@ -1,0 +1,446 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 §A8 / nexus-rv7x6: plan-library content-repair helpers.
+
+Six legacy migrations carried per-row content backfills in
+``src/nexus/db/migrations.py``. Per RDR-120 the substrate runs DDL
+only; content backfill is consumer-driven via these helpers, dispatched
+from ``nx plan repair`` subcommands.
+
+Each ``repair_*`` function:
+
+  * Takes an open sqlite3.Connection to ``memory.db``.
+  * Is idempotent (re-runs do not corrupt or double-apply).
+  * Returns a per-call diagnostic dict the CLI surfaces.
+  * Tolerates missing tables / columns (returns immediately with a
+    "skipped" reason so the CLI can report cleanly).
+
+The migration functions in ``nexus.db.migrations`` retain the
+schema portion (ALTER TABLE / FTS rebuild) for the cases where DDL
+is the substrate's job; bodies that only mutate rows are no-ops now.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+
+def _plans_table_exists(conn: sqlite3.Connection) -> bool:
+    return bool(conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='plans'"
+    ).fetchone())
+
+
+def _plan_columns(conn: sqlite3.Connection) -> set[str]:
+    return {row[1] for row in conn.execute("PRAGMA table_info(plans)").fetchall()}
+
+
+# ── 1. scope_tags (RDR-091) ────────────────────────────────────────────────
+
+
+def repair_scope_tags(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Backfill empty ``plans.scope_tags`` rows, then rewash any row
+    whose value still contains the literal ``'all'`` sentinel.
+
+    Combines the substantive bodies of the former
+    ``_add_plan_scope_tags`` (4.8.0) and
+    ``_rewash_plan_scope_tags_all_sentinel`` (4.8.1) migrations.
+    Idempotent on three axes: empty rows get inferred values once;
+    pre-populated values are not stomped; ``'all'`` sentinel rows
+    are re-inferred on every call until they are clean.
+    """
+    if not _plans_table_exists(conn):
+        return {"skipped": "no plans table"}
+    if "scope_tags" not in _plan_columns(conn):
+        return {"skipped": "scope_tags column missing"}
+
+    from nexus.plans.scope import _infer_scope_tags
+
+    backfilled = 0
+    rewashed = 0
+
+    rows = conn.execute(
+        "SELECT id, plan_json FROM plans WHERE scope_tags = ''"
+    ).fetchall()
+    for row_id, plan_json in rows:
+        inferred = _infer_scope_tags(plan_json or "")
+        if inferred:
+            conn.execute(
+                "UPDATE plans SET scope_tags = ? WHERE id = ? AND scope_tags = ''",
+                (inferred, row_id),
+            )
+            backfilled += 1
+
+    sentinel_rows = conn.execute(
+        """
+        SELECT id, plan_json FROM plans
+        WHERE scope_tags = 'all'
+           OR scope_tags LIKE 'all,%'
+           OR scope_tags LIKE '%,all'
+           OR scope_tags LIKE '%,all,%'
+        """
+    ).fetchall()
+    for row_id, plan_json in sentinel_rows:
+        inferred = _infer_scope_tags(plan_json or "")
+        conn.execute(
+            "UPDATE plans SET scope_tags = ? WHERE id = ?",
+            (inferred, row_id),
+        )
+        rewashed += 1
+
+    if backfilled or rewashed:
+        conn.commit()
+    return {"backfilled": backfilled, "rewashed": rewashed}
+
+
+# ── 2. dimensions (RDR-092 Phase 0d.1) ─────────────────────────────────────
+
+
+_VERB_STEMS: dict[str, str] = {
+    "find": "research", "search": "research", "list": "research",
+    "get": "research", "show": "research", "enumerate": "research",
+    "fetch": "research", "retrieve": "research",
+    "analyze": "analyze", "analyse": "analyze",
+    "compare": "analyze", "contrast": "analyze",
+    "rank": "analyze", "synthesize": "analyze",
+    "summarize": "analyze", "summarise": "analyze",
+    "review": "review", "audit": "review",
+    "evaluate": "review", "critique": "review",
+    "assess": "review",
+    "debug": "debug", "trace": "debug",
+    "investigate": "debug", "fix": "debug",
+    "troubleshoot": "debug",
+    "document": "document", "describe": "document",
+    "explain": "document",
+}
+
+_WH_FALLBACK: dict[str, str] = {
+    "how": "research", "what": "research",
+    "why": "review",
+    "when": "research", "where": "research", "who": "research",
+    "which": "research",
+}
+
+_NAME_STOP_WORDS: frozenset[str] = frozenset({
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+    "to", "of", "for", "in", "on", "at", "by", "with", "from", "about",
+    "and", "or", "but", "so", "as",
+    "how", "what", "why", "when", "where", "who", "which",
+    "do", "does", "did", "can", "could", "should", "would", "will",
+    "this", "that", "these", "those",
+    "i", "we", "you", "they", "it", "he", "she",
+})
+
+
+def _infer_plan_verb_from_query(query: str) -> tuple[str, bool]:
+    import re
+    tokens = re.findall(r"[a-z][a-z-]+", (query or "").lower())
+    for token in tokens:
+        if token in _VERB_STEMS:
+            return _VERB_STEMS[token], True
+    for token in tokens:
+        if token in _WH_FALLBACK:
+            return _WH_FALLBACK[token], False
+    return "research", False
+
+
+def _derive_plan_name_from_query(query: str, *, max_words: int = 5) -> str:
+    import re
+    tokens = re.findall(r"[a-zA-Z0-9][a-zA-Z0-9_]*", (query or "").lower())
+    content = [t for t in tokens if t not in _NAME_STOP_WORDS]
+    take = content[:max_words] if content else tokens[:max_words]
+    return "-".join(take) or "backfilled-plan"
+
+
+def repair_dimensions(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Backfill verb / name / dimensions on NULL-dimension plan rows.
+
+    Body of the former ``_backfill_plan_dimensions`` (4.9.12) migration.
+    Touches only rows where ``dimensions IS NULL``; authored rows
+    (shipped YAML seeds, already-dimensional grown plans, previously-
+    backfilled rows) are left alone. Collision-resolved via a
+    deterministic row-id suffix when two NULL-dimension rows in the
+    same project would collapse to the same canonical dimensions JSON.
+    """
+    if not _plans_table_exists(conn):
+        return {"skipped": "no plans table"}
+    if "dimensions" not in _plan_columns(conn):
+        return {"skipped": "dimensions column missing"}
+
+    rows = conn.execute(
+        "SELECT id, query, tags FROM plans WHERE dimensions IS NULL"
+    ).fetchall()
+    if not rows:
+        return {"backfilled": 0, "low_conf": 0, "collisions": 0, "total_rows": 0}
+
+    from nexus.plans.schema import canonical_dimensions_json
+
+    backfilled = 0
+    low_conf = 0
+    collisions = 0
+    claimed: set[tuple[str, str]] = set()
+    for row_id, query, tags in rows:
+        verb, confident = _infer_plan_verb_from_query(query or "")
+        base_name = _derive_plan_name_from_query(query or "")
+        scope = "personal" if (tags or "").find("grown") >= 0 else "global"
+        project = ""
+
+        def _dims(name_value: str) -> str:
+            return canonical_dimensions_json({
+                "scope": scope,
+                "strategy": name_value,
+                "verb": verb,
+            })
+
+        name = base_name
+        dims_json = _dims(name)
+        key = (project, dims_json)
+        db_hit = conn.execute(
+            "SELECT 1 FROM plans "
+            "WHERE project = ? AND dimensions = ? AND id != ? LIMIT 1",
+            (project, dims_json, row_id),
+        ).fetchone()
+        if db_hit or key in claimed:
+            name = f"{base_name}-{row_id}"
+            dims_json = _dims(name)
+            key = (project, dims_json)
+            collisions += 1
+        claimed.add(key)
+
+        tag_flag = "backfill" if confident else "backfill-low-conf"
+        existing_tags = [t for t in (tags or "").split(",") if t]
+        if tag_flag not in existing_tags:
+            existing_tags.append(tag_flag)
+        new_tags = ",".join(existing_tags)
+
+        conn.execute(
+            "UPDATE plans SET verb = ?, scope = ?, name = ?, "
+            "dimensions = ?, tags = ? WHERE id = ?",
+            (verb, scope, name, dims_json, new_tags, row_id),
+        )
+        if confident:
+            backfilled += 1
+        else:
+            low_conf += 1
+
+    conn.commit()
+    return {
+        "backfilled": backfilled, "low_conf": low_conf,
+        "collisions": collisions, "total_rows": len(rows),
+    }
+
+
+# ── 3. match_text (RDR-092 Phase 3.1) ──────────────────────────────────────
+
+
+def repair_match_text(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Populate ``plans.match_text`` and refresh ``plans_fts`` for all
+    rows whose ``match_text`` is empty.
+
+    The DDL parts of the former ``_add_plan_match_text_column`` (4.9.13)
+    migration (column add, FTS drop+recreate, trigger setup, FTS
+    rebuild) remain in the substrate because they are schema-level.
+    Only the per-row UPDATE that synthesises ``match_text`` from
+    ``query`` / ``verb`` / ``name`` / ``scope`` moves to this verb;
+    the AFTER UPDATE trigger then refreshes ``plans_fts`` per row.
+
+    Idempotent: only touches rows where ``match_text`` is empty.
+    """
+    if not _plans_table_exists(conn):
+        return {"skipped": "no plans table"}
+    if "match_text" not in _plan_columns(conn):
+        return {"skipped": "match_text column missing"}
+
+    from nexus.db.t2.plan_library import _synthesize_match_text
+
+    rows = conn.execute(
+        "SELECT id, query, verb, name, scope FROM plans WHERE match_text = ''"
+    ).fetchall()
+    backfilled = 0
+    for row_id, query, verb, name, scope in rows:
+        synthesised = _synthesize_match_text(
+            description=query, verb=verb, name=name, scope=scope,
+        )
+        conn.execute(
+            "UPDATE plans SET match_text = ? WHERE id = ?",
+            (synthesised, row_id),
+        )
+        backfilled += 1
+    if backfilled:
+        conn.commit()
+    return {"backfilled": backfilled}
+
+
+# ── 4. retire legacy operation-shape plans (RDR-092 Phase 0a) ──────────────
+
+
+def repair_retire_legacy(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Delete plan rows whose ``plan_json`` uses the pre-RDR-078
+    ``operation`` shape.
+
+    Body of the former ``_retire_legacy_operation_shape_plans`` (4.10.1)
+    migration. Legacy shape: a step dict has ``operation`` key AND no
+    step has ``tool`` key. Idempotent: after the first --apply, no
+    legacy-shape rows remain.
+    """
+    candidates = conn.execute(
+        "SELECT id, plan_json FROM plans WHERE plan_json LIKE '%\"operation\"%'"
+    ).fetchall()
+    if not candidates:
+        return {"deleted": 0, "ids": []}
+
+    legacy_ids: list[int] = []
+    for row_id, plan_json_text in candidates:
+        try:
+            parsed = json.loads(plan_json_text or "{}")
+        except json.JSONDecodeError:
+            continue
+        steps = parsed.get("steps") if isinstance(parsed, dict) else None
+        if not isinstance(steps, list) or not steps:
+            continue
+        has_operation = any(
+            isinstance(s, dict) and "operation" in s for s in steps
+        )
+        has_tool = any(
+            isinstance(s, dict) and "tool" in s for s in steps
+        )
+        if has_operation and not has_tool:
+            legacy_ids.append(int(row_id))
+
+    if not legacy_ids:
+        return {"deleted": 0, "ids": []}
+
+    placeholders = ",".join("?" * len(legacy_ids))
+    conn.execute(
+        f"DELETE FROM plans WHERE id IN ({placeholders})",
+        legacy_ids,
+    )
+    conn.commit()
+    return {"deleted": len(legacy_ids), "ids": legacy_ids}
+
+
+# ── 5. builtin bindings (RDR-091 / nexus-80tk follow-up) ───────────────────
+
+
+def repair_builtin_bindings(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Patch ``required_bindings`` / ``optional_bindings`` into existing
+    builtin plan rows whose stored ``plan_json`` predates the seed
+    loader's binding-merge fix (4.10.1).
+
+    Body of the former ``_backfill_builtin_bindings`` (4.10.2)
+    migration. For each builtin row whose ``plan_json`` lacks a
+    ``required_bindings`` key, resolves the shipping YAML by
+    ``(verb, scope, strategy)`` and patches the lists in. Silent
+    no-op when the shipping YAMLs are unreachable (exotic install
+    layouts); ``nx catalog setup`` is the escalation path.
+    """
+    if not _plans_table_exists(conn):
+        return {"skipped": "no plans table"}
+
+    try:
+        import yaml as _yaml
+        from importlib.resources import as_file, files
+    except ModuleNotFoundError:
+        return {"skipped": "PyYAML missing"}
+
+    rows = conn.execute(
+        "SELECT id, plan_json, dimensions FROM plans "
+        "WHERE tags LIKE '%builtin%' "
+        "AND plan_json NOT LIKE '%required_bindings%'"
+    ).fetchall()
+    if not rows:
+        return {"backfilled": 0}
+
+    yaml_dir = None
+    try:
+        resource = files("nexus") / "_resources" / "plans" / "builtin"
+        with as_file(resource) as resolved:
+            from pathlib import Path as _Path
+            if _Path(resolved).is_dir():
+                yaml_dir = _Path(resolved)
+    except (ModuleNotFoundError, FileNotFoundError, TypeError):
+        pass
+    if yaml_dir is None:
+        from pathlib import Path as _Path
+        repo_candidate = _Path(__file__).resolve().parents[3] / "nx" / "plans" / "builtin"
+        if repo_candidate.is_dir():
+            yaml_dir = repo_candidate
+    if yaml_dir is None:
+        return {"skipped": "shipping YAMLs unreachable"}
+
+    bindings_index: dict[tuple[str, str, str], tuple[list, list]] = {}
+    for entry in yaml_dir.iterdir():
+        if not entry.is_file() or entry.suffix not in (".yml", ".yaml"):
+            continue
+        try:
+            template = _yaml.safe_load(entry.read_text()) or {}
+        except Exception:
+            continue
+        dims = template.get("dimensions") or {}
+        key = (
+            str(dims.get("verb", "")),
+            str(dims.get("scope", "")),
+            str(dims.get("strategy", "")),
+        )
+        required = list(template.get("required_bindings") or [])
+        optional = list(template.get("optional_bindings") or [])
+        if required or optional:
+            bindings_index[key] = (required, optional)
+
+    if not bindings_index:
+        return {"backfilled": 0}
+
+    backfilled = 0
+    for row_id, plan_json_text, dims_text in rows:
+        try:
+            parsed = json.loads(plan_json_text or "{}")
+            dims = json.loads(dims_text or "{}")
+        except json.JSONDecodeError:
+            continue
+        key = (
+            str(dims.get("verb", "")),
+            str(dims.get("scope", "")),
+            str(dims.get("strategy", "")),
+        )
+        bindings = bindings_index.get(key)
+        if not bindings:
+            continue
+        required, optional = bindings
+        if required:
+            parsed["required_bindings"] = required
+        if optional:
+            parsed["optional_bindings"] = optional
+        conn.execute(
+            "UPDATE plans SET plan_json = ? WHERE id = ?",
+            (json.dumps(parsed), row_id),
+        )
+        backfilled += 1
+
+    if backfilled:
+        conn.commit()
+    return {"backfilled": backfilled}
+
+
+# ── Bundle ─────────────────────────────────────────────────────────────────
+
+
+def repair_all(conn: sqlite3.Connection) -> dict[str, dict[str, Any]]:
+    """Run every repair pass in dependency order. Order matters:
+
+      1. scope_tags        (independent)
+      2. dimensions        (writes verb/name/scope used by match_text)
+      3. match_text        (reads verb/name/scope from step 2)
+      4. retire-legacy     (deletes pre-RDR-078 rows)
+      5. builtin-bindings  (patches surviving builtin rows)
+    """
+    return {
+        "scope_tags": repair_scope_tags(conn),
+        "dimensions": repair_dimensions(conn),
+        "match_text": repair_match_text(conn),
+        "retire_legacy": repair_retire_legacy(conn),
+        "builtin_bindings": repair_builtin_bindings(conn),
+    }

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1255,10 +1255,7 @@ class TestMigrateChashIndex:
         with the legacy ``doc_id`` column, the rename migration renames
         it to ``chunk_chroma_id``. Test reflects the production end state.
         """
-        from nexus.db.migrations import (
-            migrate_chash_index,
-            migrate_chash_index_rename_doc_id,
-        )
+        from nexus.db.migrations import migrate_chash_index, migrate_chash_index_rename_doc_id
 
         conn = sqlite3.connect(":memory:")
         migrate_chash_index(conn)
@@ -1283,10 +1280,7 @@ class TestMigrateChashIndex:
         Issue 1: knowledge__delos + knowledge__delos_docling both ingest a
         paper; every chunk's SHA-256 is identical.
         """
-        from nexus.db.migrations import (
-            migrate_chash_index,
-            migrate_chash_index_rename_doc_id,
-        )
+        from nexus.db.migrations import migrate_chash_index, migrate_chash_index_rename_doc_id
 
         conn = sqlite3.connect(":memory:")
         migrate_chash_index(conn)
@@ -1378,10 +1372,7 @@ class TestMigrateChashIndex:
         idempotent so a re-attempted upgrade after a partial failure
         does not double-mutate.
         """
-        from nexus.db.migrations import (
-            migrate_chash_index,
-            migrate_chash_index_rename_doc_id,
-        )
+        from nexus.db.migrations import migrate_chash_index, migrate_chash_index_rename_doc_id
 
         conn = sqlite3.connect(":memory:")
         migrate_chash_index(conn)
@@ -1410,10 +1401,7 @@ class TestMigrateChashIndex:
         idempotency contract: table present with legacy ``doc_id`` column
         → ALTER TABLE renames in place.
         """
-        from nexus.db.migrations import (
-            migrate_chash_index,
-            migrate_chash_index_rename_doc_id,
-        )
+        from nexus.db.migrations import migrate_chash_index, migrate_chash_index_rename_doc_id
 
         conn = sqlite3.connect(":memory:")
         # Install creates the legacy ``doc_id`` column.
@@ -1462,11 +1450,7 @@ class TestMigrateChashIndex:
         ``chunk_chroma_id`` column from the post-rename schema. Other
         columns and the secondary index are preserved; data on remaining
         columns survives."""
-        from nexus.db.migrations import (
-            _drop_chash_index_chunk_chroma_id,
-            migrate_chash_index,
-            migrate_chash_index_rename_doc_id,
-        )
+        from nexus.db.migrations import _drop_chash_index_chunk_chroma_id, migrate_chash_index, migrate_chash_index_rename_doc_id
 
         conn = sqlite3.connect(":memory:")
         migrate_chash_index(conn)
@@ -1504,11 +1488,7 @@ class TestMigrateChashIndex:
     def test_chash_index_drop_chunk_chroma_id_idempotent_and_absent_safe(self) -> None:
         """The drop migration is a no-op when the column is already gone
         and when the table itself does not exist."""
-        from nexus.db.migrations import (
-            _drop_chash_index_chunk_chroma_id,
-            migrate_chash_index,
-            migrate_chash_index_rename_doc_id,
-        )
+        from nexus.db.migrations import _drop_chash_index_chunk_chroma_id, migrate_chash_index, migrate_chash_index_rename_doc_id
 
         # No table → no-op.
         conn1 = sqlite3.connect(":memory:")
@@ -1769,7 +1749,7 @@ class TestMigrateHookFailuresBatchColumns:
         )
 
 
-# ── _backfill_plan_dimensions (RDR-092 Phase 0d.1) ──────────────────────────
+# ── repair_dimensions (RDR-092 Phase 0d.1) ──────────────────────────
 
 
 def _make_plans_schema(conn: sqlite3.Connection) -> None:
@@ -1827,7 +1807,7 @@ class TestBackfillPlanDimensions:
 
     def test_backfill_plan_dimensions_infers_verb(self) -> None:
         """Stem matches select the expected verb for each rule family."""
-        from nexus.db.migrations import _backfill_plan_dimensions
+        from nexus.plans.repair import repair_dimensions
 
         conn = sqlite3.connect(":memory:")
         _make_plans_schema(conn)
@@ -1845,7 +1825,7 @@ class TestBackfillPlanDimensions:
         for query, _verb, label in fixtures:
             ids[label] = _insert_plan(conn, query=query)
 
-        _backfill_plan_dimensions(conn)
+        repair_dimensions(conn)
 
         for query, expected_verb, label in fixtures:
             row = conn.execute(
@@ -1861,13 +1841,13 @@ class TestBackfillPlanDimensions:
 
     def test_backfill_plan_dimensions_idempotent(self) -> None:
         """Re-running the migration is a no-op on already-backfilled rows."""
-        from nexus.db.migrations import _backfill_plan_dimensions
+        from nexus.plans.repair import repair_dimensions
 
         conn = sqlite3.connect(":memory:")
         _make_plans_schema(conn)
         rid = _insert_plan(conn, query="analyze the ranker output")
 
-        _backfill_plan_dimensions(conn)
+        repair_dimensions(conn)
         first = conn.execute(
             "SELECT verb, name, dimensions, tags FROM plans WHERE id = ?",
             (rid,),
@@ -1876,7 +1856,7 @@ class TestBackfillPlanDimensions:
         assert "backfill" in (first[3] or "")
 
         # Second run: state must be stable and tags must not duplicate.
-        _backfill_plan_dimensions(conn)
+        repair_dimensions(conn)
         second = conn.execute(
             "SELECT verb, name, dimensions, tags FROM plans WHERE id = ?",
             (rid,),
@@ -1887,7 +1867,7 @@ class TestBackfillPlanDimensions:
 
     def test_backfill_preserves_authored_verbs(self) -> None:
         """Rows with dimensions IS NOT NULL are untouched."""
-        from nexus.db.migrations import _backfill_plan_dimensions
+        from nexus.plans.repair import repair_dimensions
 
         conn = sqlite3.connect(":memory:")
         _make_plans_schema(conn)
@@ -1902,7 +1882,7 @@ class TestBackfillPlanDimensions:
             dimensions='{"scope":"global","verb":"research"}',
         )
 
-        _backfill_plan_dimensions(conn)
+        repair_dimensions(conn)
 
         row = conn.execute(
             "SELECT verb, name, dimensions, tags FROM plans WHERE id = ?",
@@ -1917,14 +1897,14 @@ class TestBackfillPlanDimensions:
 
     def test_backfill_low_conf_flagging(self) -> None:
         """Rows that hit only the wh-fallback carry backfill-low-conf."""
-        from nexus.db.migrations import _backfill_plan_dimensions
+        from nexus.plans.repair import repair_dimensions
 
         conn = sqlite3.connect(":memory:")
         _make_plans_schema(conn)
         # A query with no stem match — only the wh-word triggers.
         rid = _insert_plan(conn, query="what about the graph")
 
-        _backfill_plan_dimensions(conn)
+        repair_dimensions(conn)
 
         row = conn.execute(
             "SELECT verb, tags FROM plans WHERE id = ?", (rid,),
@@ -1955,7 +1935,7 @@ class TestBackfillPlanDimensions:
         The second row lands with its strategy suffixed by row id
         so both rows land with distinct, deterministic identities.
         """
-        from nexus.db.migrations import _backfill_plan_dimensions
+        from nexus.plans.repair import repair_dimensions
 
         conn = sqlite3.connect(":memory:")
         _make_plans_schema(conn)
@@ -1964,7 +1944,7 @@ class TestBackfillPlanDimensions:
         rid1 = _insert_plan(conn, query="find the documents for author")
         rid2 = _insert_plan(conn, query="find documents by author")
 
-        _backfill_plan_dimensions(conn)  # must not raise
+        repair_dimensions(conn)  # must not raise
 
         rows = conn.execute(
             "SELECT id, name, dimensions FROM plans ORDER BY id ASC"
@@ -1991,7 +1971,7 @@ class TestBackfillPlanDimensions:
         queries whose raw-token fallback still differed; replace with
         queries whose ``tokens`` list is actually empty).
         """
-        from nexus.db.migrations import _backfill_plan_dimensions
+        from nexus.plans.repair import repair_dimensions
 
         conn = sqlite3.connect(":memory:")
         _make_plans_schema(conn)
@@ -2001,7 +1981,7 @@ class TestBackfillPlanDimensions:
         rid2 = _insert_plan(conn, query="...")
         rid3 = _insert_plan(conn, query="???")
 
-        _backfill_plan_dimensions(conn)
+        repair_dimensions(conn)
 
         rows = conn.execute(
             "SELECT id, name, dimensions FROM plans ORDER BY id ASC"
@@ -2026,7 +2006,7 @@ class TestBackfillPlanDimensions:
         SELECT pre-check runs, so the ``key in claimed`` branch is
         the one that catches the 3rd.
         """
-        from nexus.db.migrations import _backfill_plan_dimensions
+        from nexus.plans.repair import repair_dimensions
 
         conn = sqlite3.connect(":memory:")
         _make_plans_schema(conn)
@@ -2036,7 +2016,7 @@ class TestBackfillPlanDimensions:
         _insert_plan(conn, query="find documents by author")
         _insert_plan(conn, query="find documents about author")
 
-        _backfill_plan_dimensions(conn)
+        repair_dimensions(conn)
 
         rows = conn.execute(
             "SELECT dimensions FROM plans ORDER BY id ASC"
@@ -2051,20 +2031,20 @@ class TestBackfillPlanDimensions:
         collision-resolved row must leave the suffixed identity
         unchanged: the NULL-dimension filter skips it entirely.
         """
-        from nexus.db.migrations import _backfill_plan_dimensions
+        from nexus.plans.repair import repair_dimensions
 
         conn = sqlite3.connect(":memory:")
         _make_plans_schema(conn)
         _insert_plan(conn, query="find the documents for author")
         rid2 = _insert_plan(conn, query="find documents by author")
 
-        _backfill_plan_dimensions(conn)
+        repair_dimensions(conn)
         first = conn.execute(
             "SELECT name, dimensions, tags FROM plans WHERE id = ?",
             (rid2,),
         ).fetchone()
 
-        _backfill_plan_dimensions(conn)
+        repair_dimensions(conn)
         second = conn.execute(
             "SELECT name, dimensions, tags FROM plans WHERE id = ?",
             (rid2,),
@@ -2159,7 +2139,11 @@ class TestAddPlanMatchTextColumn:
         )
         conn.commit()
 
+        from nexus.plans.repair import repair_match_text
+
         _add_plan_match_text_column(conn)
+        # RDR-120 §A8 / nexus-rv7x6: per-row backfill is consumer-side.
+        repair_match_text(conn)
 
         dimensional = conn.execute(
             "SELECT match_text FROM plans WHERE name = 'find-by-author'"
@@ -2191,10 +2175,14 @@ class TestAddPlanMatchTextColumn:
         )
         conn.commit()
 
+        from nexus.plans.repair import repair_match_text
+
         _add_plan_match_text_column(conn)
+        repair_match_text(conn)
         first = conn.execute("SELECT match_text FROM plans").fetchone()[0]
 
         _add_plan_match_text_column(conn)
+        repair_match_text(conn)
         second = conn.execute("SELECT match_text FROM plans").fetchone()[0]
 
         assert first == second
@@ -2266,9 +2254,13 @@ class TestAddPlanMatchTextColumn:
         ).fetchone()
         assert row[0] == "", "setup invariant: match_text must be ''"
 
-        # Re-run the migration. The has_fts guard should detect the
-        # mid-state and fall through to rebuild FTS + backfill.
+        # Re-run the migration. The has_fts guard detects the mid-state
+        # and falls through to rebuild FTS. Per RDR-120 §A8 the per-row
+        # match_text backfill is the consumer verb's responsibility, so
+        # we drive both legs here to validate end-to-end recovery.
+        from nexus.plans.repair import repair_match_text
         _add_plan_match_text_column(conn)
+        repair_match_text(conn)
 
         fts_row = conn.execute(
             "SELECT name FROM sqlite_master "
@@ -2285,7 +2277,7 @@ class TestAddPlanMatchTextColumn:
         )
 
 
-# ── _retire_legacy_operation_shape_plans (nexus-4m9b) ────────────────────────
+# ── repair_retire_legacy (nexus-4m9b) ────────────────────────
 
 
 class TestRetireLegacyOperationShapePlans:
@@ -2311,7 +2303,7 @@ class TestRetireLegacyOperationShapePlans:
         conn.commit()
 
     def test_deletes_legacy_operation_shape(self) -> None:
-        from nexus.db.migrations import _retire_legacy_operation_shape_plans
+        from nexus.plans.repair import repair_retire_legacy
 
         conn = sqlite3.connect(":memory:")
         self._schema(conn)
@@ -2333,7 +2325,7 @@ class TestRetireLegacyOperationShapePlans:
         )
         conn.commit()
 
-        _retire_legacy_operation_shape_plans(conn)
+        repair_retire_legacy(conn)
 
         remaining = [r[0] for r in conn.execute(
             "SELECT query FROM plans ORDER BY id"
@@ -2341,7 +2333,7 @@ class TestRetireLegacyOperationShapePlans:
         assert remaining == ["modern"]
 
     def test_idempotent(self) -> None:
-        from nexus.db.migrations import _retire_legacy_operation_shape_plans
+        from nexus.plans.repair import repair_retire_legacy
 
         conn = sqlite3.connect(":memory:")
         self._schema(conn)
@@ -2352,8 +2344,8 @@ class TestRetireLegacyOperationShapePlans:
         )
         conn.commit()
 
-        _retire_legacy_operation_shape_plans(conn)
-        _retire_legacy_operation_shape_plans(conn)  # no raise
+        repair_retire_legacy(conn)
+        repair_retire_legacy(conn)  # no raise
 
         count = conn.execute("SELECT COUNT(*) FROM plans").fetchone()[0]
         assert count == 0
@@ -2363,7 +2355,7 @@ class TestRetireLegacyOperationShapePlans:
         ``operation`` (e.g. a ``purpose: reference-operation`` string)
         must not be retired. The post-parse ``has_tool`` check decides.
         """
-        from nexus.db.migrations import _retire_legacy_operation_shape_plans
+        from nexus.plans.repair import repair_retire_legacy
 
         conn = sqlite3.connect(":memory:")
         self._schema(conn)
@@ -2379,7 +2371,7 @@ class TestRetireLegacyOperationShapePlans:
         )
         conn.commit()
 
-        _retire_legacy_operation_shape_plans(conn)
+        repair_retire_legacy(conn)
 
         count = conn.execute("SELECT COUNT(*) FROM plans").fetchone()[0]
         assert count == 1
@@ -2399,7 +2391,7 @@ class TestRetireLegacyOperationShapePlans:
         )
 
 
-# ── _backfill_builtin_bindings (nexus-uyc6) ──────────────────────────────────
+# ── repair_builtin_bindings (nexus-uyc6) ──────────────────────────────────
 
 
 class TestBackfillBuiltinBindings:
@@ -2444,7 +2436,7 @@ class TestBackfillBuiltinBindings:
         path.write_text(_yaml.safe_dump(doc))
 
     def test_backfills_matching_row_by_dimensions(self, tmp_path, monkeypatch):
-        from nexus.db.migrations import _backfill_builtin_bindings
+        from nexus.plans.repair import repair_builtin_bindings
 
         yaml_dir = tmp_path / "nx" / "plans" / "builtin"
         yaml_dir.mkdir(parents=True)
@@ -2523,7 +2515,7 @@ class TestBackfillBuiltinBindings:
         )
         conn.commit()
 
-        _backfill_builtin_bindings(conn)
+        repair_builtin_bindings(conn)
 
         row = conn.execute(
             "SELECT plan_json FROM plans WHERE name='default'"
@@ -2533,7 +2525,7 @@ class TestBackfillBuiltinBindings:
         assert parsed["optional_bindings"] == ["limit"]
 
     def test_idempotent_when_row_already_has_bindings(self, tmp_path, monkeypatch):
-        from nexus.db.migrations import _backfill_builtin_bindings
+        from nexus.plans.repair import repair_builtin_bindings
 
         conn = sqlite3.connect(":memory:")
         self._schema(conn)
@@ -2551,7 +2543,7 @@ class TestBackfillBuiltinBindings:
         )
         conn.commit()
 
-        _backfill_builtin_bindings(conn)
+        repair_builtin_bindings(conn)
 
         row = conn.execute(
             "SELECT plan_json FROM plans WHERE name='default'"
@@ -2562,7 +2554,7 @@ class TestBackfillBuiltinBindings:
         """User ad-hoc rows (no ``builtin`` in tags) must not be touched
         even if a dimension match exists in the shipping YAMLs.
         """
-        from nexus.db.migrations import _backfill_builtin_bindings
+        from nexus.plans.repair import repair_builtin_bindings
 
         conn = sqlite3.connect(":memory:")
         self._schema(conn)
@@ -2579,7 +2571,7 @@ class TestBackfillBuiltinBindings:
 
         # Even with missing YAMLs the migration should no-op cleanly
         # on non-builtin rows. Call it without fixture YAMLs.
-        _backfill_builtin_bindings(conn)
+        repair_builtin_bindings(conn)
 
         row = conn.execute(
             "SELECT plan_json FROM plans WHERE name='default'"

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -69,7 +69,7 @@ class TestPlanRepair:
         with patch(
             "nexus.commands._helpers.default_db_path", return_value=db_path,
         ):
-            first = runner.invoke(main, ["plan", "repair"])
+            first = runner.invoke(main, ["plan", "repair", "dimensions"])
         assert first.exit_code == 0, first.output
         assert "backfilled" in first.output.lower()
 
@@ -77,11 +77,13 @@ class TestPlanRepair:
         with patch(
             "nexus.commands._helpers.default_db_path", return_value=db_path,
         ):
-            second = runner.invoke(main, ["plan", "repair"])
+            second = runner.invoke(main, ["plan", "repair", "dimensions"])
         assert second.exit_code == 0, second.output
         # "nothing to do" / "0 backfilled" — must not assert the exact
         # phrasing, but the number must be zero.
-        assert "0 backfilled" in second.output.lower() or (
+        assert "backfilled: 0" in second.output.lower() or (
+            "0 backfilled" in second.output.lower()
+        ) or (
             "nothing" in second.output.lower()
         )
 
@@ -100,7 +102,7 @@ class TestPlanRepair:
         with patch(
             "nexus.commands._helpers.default_db_path", return_value=db_path,
         ):
-            result = runner.invoke(main, ["plan", "repair"])
+            result = runner.invoke(main, ["plan", "repair", "dimensions"])
         assert result.exit_code == 0, result.output
         output = result.output.lower()
         # The low-conf row is named and appears in the review section.
@@ -108,7 +110,11 @@ class TestPlanRepair:
         assert "what about the graph" in output
         # The high-conf row is counted but not individually listed in
         # the review surface.
-        assert "1 low-conf row" in output or "1 row needs review" in output
+        assert (
+            "1 low-conf row" in output
+            or "1 row needs review" in output
+            or "low_conf: 1" in output
+        )
 
     def test_repair_no_db_file(
         self, runner: CliRunner, tmp_path: Path,
@@ -120,7 +126,7 @@ class TestPlanRepair:
         with patch(
             "nexus.commands._helpers.default_db_path", return_value=db_path,
         ):
-            result = runner.invoke(main, ["plan", "repair"])
+            result = runner.invoke(main, ["plan", "repair", "dimensions"])
         assert result.exit_code == 0
         assert "not found" in result.output.lower()
 

--- a/tests/test_plan_library.py
+++ b/tests/test_plan_library.py
@@ -498,13 +498,16 @@ def test_save_plan_scope_tags_column_default_empty(plan_db: T2Database) -> None:
 
 
 def test_migration_idempotent_on_populated_table(tmp_path: Path) -> None:
-    """Running the scope_tags migration twice is a no-op on the second run."""
+    """RDR-120 §A8: the migration adds the column; the backfill body
+    runs via ``nx plan repair scope-tags`` (``repair_scope_tags``).
+    Both layers are idempotent.
+    """
     import sqlite3
 
     from nexus.db.migrations import _add_plan_scope_tags
+    from nexus.plans.repair import repair_scope_tags
 
     db_path = tmp_path / "mig.db"
-    # Seed an older-schema plans table (pre-scope_tags).
     conn = sqlite3.connect(str(db_path))
     conn.executescript(
         """
@@ -531,13 +534,15 @@ def test_migration_idempotent_on_populated_table(tmp_path: Path) -> None:
     )
     conn.commit()
 
+    # Substrate (migration): DDL only, adds the column.
     _add_plan_scope_tags(conn)
+    repair_scope_tags(conn)
     first = conn.execute("SELECT scope_tags FROM plans WHERE query='q'").fetchone()
     assert first[0] == "rdr__arcaneum"
 
-    # Second run is a no-op: column already present, backfill re-runs
-    # safely because inference is deterministic.
+    # Re-running both is a no-op (idempotent).
     _add_plan_scope_tags(conn)
+    repair_scope_tags(conn)
     second = conn.execute("SELECT scope_tags FROM plans WHERE query='q'").fetchone()
     assert second[0] == "rdr__arcaneum"
 
@@ -672,7 +677,7 @@ def test_rewash_migration_fixes_all_sentinel_rows(tmp_path: Path) -> None:
     pre-fix backfill."""
     import sqlite3
 
-    from nexus.db.migrations import _rewash_plan_scope_tags_all_sentinel
+    from nexus.plans.repair import repair_scope_tags
 
     db_path = tmp_path / "rewash.db"
     conn = sqlite3.connect(str(db_path))
@@ -712,7 +717,7 @@ def test_rewash_migration_fixes_all_sentinel_rows(tmp_path: Path) -> None:
     )
     conn.commit()
 
-    _rewash_plan_scope_tags_all_sentinel(conn)
+    repair_scope_tags(conn)
 
     q1 = conn.execute("SELECT scope_tags FROM plans WHERE query='q1'").fetchone()
     q2 = conn.execute("SELECT scope_tags FROM plans WHERE query='q2'").fetchone()
@@ -722,7 +727,7 @@ def test_rewash_migration_fixes_all_sentinel_rows(tmp_path: Path) -> None:
     assert q3[0] == "rdr__delos", "clean row must be untouched"
 
     # Idempotent: running again finds nothing to rewash.
-    _rewash_plan_scope_tags_all_sentinel(conn)
+    repair_scope_tags(conn)
     q1 = conn.execute("SELECT scope_tags FROM plans WHERE query='q1'").fetchone()
     assert q1[0] == ""
     conn.close()
@@ -732,7 +737,7 @@ def test_rewash_migration_no_op_when_no_all_rows(tmp_path: Path) -> None:
     """Rewash migration is a safe no-op when no row contains 'all'."""
     import sqlite3
 
-    from nexus.db.migrations import _rewash_plan_scope_tags_all_sentinel
+    from nexus.plans.repair import repair_scope_tags
 
     db_path = tmp_path / "clean.db"
     conn = sqlite3.connect(str(db_path))
@@ -751,7 +756,7 @@ def test_rewash_migration_no_op_when_no_all_rows(tmp_path: Path) -> None:
         """
     )
     conn.commit()
-    _rewash_plan_scope_tags_all_sentinel(conn)  # must not crash
+    repair_scope_tags(conn)  # must not crash
     conn.close()
 
 
@@ -790,7 +795,7 @@ def test_rewash_migration_fixes_trailing_all_variant(tmp_path: Path) -> None:
     '%,all' branch (RDR-091 code-review finding I-7)."""
     import sqlite3
 
-    from nexus.db.migrations import _rewash_plan_scope_tags_all_sentinel
+    from nexus.plans.repair import repair_scope_tags
 
     db_path = tmp_path / "trailing_all.db"
     conn = sqlite3.connect(str(db_path))
@@ -823,7 +828,7 @@ def test_rewash_migration_fixes_trailing_all_variant(tmp_path: Path) -> None:
         ),
     )
     conn.commit()
-    _rewash_plan_scope_tags_all_sentinel(conn)
+    repair_scope_tags(conn)
     row = conn.execute("SELECT scope_tags FROM plans WHERE query='q'").fetchone()
     assert row[0] == "rdr__arcaneum"
     conn.close()
@@ -833,11 +838,11 @@ def test_rewash_migration_no_op_without_plans_table(tmp_path: Path) -> None:
     """Rewash migration is a safe no-op on a DB without a plans table."""
     import sqlite3
 
-    from nexus.db.migrations import _rewash_plan_scope_tags_all_sentinel
+    from nexus.plans.repair import repair_scope_tags
 
     db_path = tmp_path / "empty.db"
     conn = sqlite3.connect(str(db_path))
-    _rewash_plan_scope_tags_all_sentinel(conn)  # must not crash
+    repair_scope_tags(conn)  # must not crash
     conn.close()
 
 

--- a/tests/test_plan_repair_verbs.py
+++ b/tests/test_plan_repair_verbs.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 §A8 / nexus-rv7x6: ``nx plan repair`` subcommand tests.
+
+Six legacy migrations whose bodies mutated row content moved out of
+``apply_pending`` and into ``nexus.plans.repair`` helpers, dispatched
+from new ``nx plan repair`` subcommands. The substrate keeps only the
+DDL portions; these tests cover the verb-side behaviour the migrations
+used to ship.
+
+The helper-level tests in ``tests/test_migrations.py`` and
+``tests/test_plan_library.py`` exercise the underlying
+``repair_*`` functions directly. This file focuses on the CLI
+surface: each subcommand registered, runs against the patched
+``default_db_path``, and emits the diagnostic payload.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.commands.plan import plan as plan_cmd
+
+
+def _seed_plans_schema(db_path: Path) -> sqlite3.Connection:
+    """Open *db_path* and seed the full post-RDR-092 plans schema with
+    the columns each repair verb touches."""
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE plans (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project TEXT NOT NULL DEFAULT '',
+            query TEXT NOT NULL,
+            plan_json TEXT NOT NULL,
+            outcome TEXT DEFAULT 'success',
+            tags TEXT DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            ttl INTEGER,
+            verb TEXT DEFAULT '',
+            scope TEXT DEFAULT 'global',
+            name TEXT DEFAULT '',
+            dimensions TEXT,
+            scope_tags TEXT NOT NULL DEFAULT '',
+            match_text TEXT NOT NULL DEFAULT ''
+        );
+        """
+    )
+    conn.commit()
+    return conn
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "memory.db"
+
+
+class TestRepairGroupRegistration:
+    def test_repair_is_a_group(self) -> None:
+        repair = plan_cmd.commands["repair"]
+        assert hasattr(repair, "commands"), "nx plan repair must be a group"
+        for sub in (
+            "scope-tags", "dimensions", "match-text",
+            "retire-legacy", "builtin-bindings", "all",
+        ):
+            assert sub in repair.commands, f"missing subcommand: {sub}"
+
+
+class TestRepairScopeTags:
+    def test_backfills_empty_scope_tags(
+        self, runner: CliRunner, db_path: Path,
+    ) -> None:
+        conn = _seed_plans_schema(db_path)
+        conn.execute(
+            "INSERT INTO plans (query, plan_json, created_at) VALUES (?, ?, ?)",
+            (
+                "q",
+                '{"steps":[{"tool":"search","args":{"corpus":"rdr__arcaneum"}}]}',
+                "2026-05-21T00:00:00Z",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        with patch(
+            "nexus.commands._helpers.default_db_path", return_value=db_path,
+        ):
+            result = runner.invoke(plan_cmd, ["repair", "scope-tags"])
+        assert result.exit_code == 0, result.output
+        assert "backfilled: 1" in result.output
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT scope_tags FROM plans WHERE query='q'").fetchone()
+        conn.close()
+        assert row[0] == "rdr__arcaneum"
+
+    def test_rewashes_all_sentinel(
+        self, runner: CliRunner, db_path: Path,
+    ) -> None:
+        conn = _seed_plans_schema(db_path)
+        conn.execute(
+            "INSERT INTO plans (query, plan_json, scope_tags, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("q", '{"steps":[]}', "all", "2026-05-21T00:00:00Z"),
+        )
+        conn.commit()
+        conn.close()
+
+        with patch(
+            "nexus.commands._helpers.default_db_path", return_value=db_path,
+        ):
+            result = runner.invoke(plan_cmd, ["repair", "scope-tags"])
+        assert result.exit_code == 0, result.output
+        assert "rewashed: 1" in result.output
+
+
+class TestRepairDimensions:
+    def test_backfills_null_dimension_rows(
+        self, runner: CliRunner, db_path: Path,
+    ) -> None:
+        conn = _seed_plans_schema(db_path)
+        conn.execute(
+            "INSERT INTO plans (query, plan_json, created_at) VALUES (?, ?, ?)",
+            ("analyze the ranker", "{}", "2026-05-21T00:00:00Z"),
+        )
+        conn.commit()
+        conn.close()
+
+        with patch(
+            "nexus.commands._helpers.default_db_path", return_value=db_path,
+        ):
+            result = runner.invoke(plan_cmd, ["repair", "dimensions"])
+        assert result.exit_code == 0, result.output
+        assert "backfilled: 1" in result.output
+        assert "0 rows need review" in result.output
+
+
+class TestRepairMatchText:
+    def test_backfills_match_text(
+        self, runner: CliRunner, db_path: Path,
+    ) -> None:
+        conn = _seed_plans_schema(db_path)
+        conn.execute(
+            "INSERT INTO plans (query, plan_json, verb, scope, name, created_at) "
+            "VALUES (?, '{}', 'analyze', 'global', 'default', ?)",
+            ("Analyze foo", "2026-05-21T00:00:00Z"),
+        )
+        conn.commit()
+        conn.close()
+
+        with patch(
+            "nexus.commands._helpers.default_db_path", return_value=db_path,
+        ):
+            result = runner.invoke(plan_cmd, ["repair", "match-text"])
+        assert result.exit_code == 0, result.output
+        assert "backfilled: 1" in result.output
+
+
+class TestRepairRetireLegacy:
+    def test_deletes_operation_shape_rows(
+        self, runner: CliRunner, db_path: Path,
+    ) -> None:
+        conn = _seed_plans_schema(db_path)
+        legacy = json.dumps({"steps": [{"step": 1, "operation": "search"}]})
+        modern = json.dumps({"steps": [{"tool": "search"}]})
+        conn.execute(
+            "INSERT INTO plans (query, plan_json, created_at) VALUES (?, ?, ?)",
+            ("legacy", legacy, "2026-05-21T00:00:00Z"),
+        )
+        conn.execute(
+            "INSERT INTO plans (query, plan_json, created_at) VALUES (?, ?, ?)",
+            ("modern", modern, "2026-05-21T00:00:00Z"),
+        )
+        conn.commit()
+        conn.close()
+
+        with patch(
+            "nexus.commands._helpers.default_db_path", return_value=db_path,
+        ):
+            result = runner.invoke(plan_cmd, ["repair", "retire-legacy"])
+        assert result.exit_code == 0, result.output
+        assert "deleted: 1" in result.output
+
+        conn = sqlite3.connect(str(db_path))
+        kept = [r[0] for r in conn.execute(
+            "SELECT query FROM plans ORDER BY query"
+        ).fetchall()]
+        conn.close()
+        assert kept == ["modern"]
+
+
+class TestRepairBuiltinBindings:
+    def test_dry_no_op_when_no_legacy_rows(
+        self, runner: CliRunner, db_path: Path,
+    ) -> None:
+        _seed_plans_schema(db_path).close()
+        with patch(
+            "nexus.commands._helpers.default_db_path", return_value=db_path,
+        ):
+            result = runner.invoke(plan_cmd, ["repair", "builtin-bindings"])
+        assert result.exit_code == 0, result.output
+        # No matching rows => backfilled:0 or skipped reason.
+        assert "backfilled: 0" in result.output or "skipped" in result.output
+
+
+class TestRepairAll:
+    def test_runs_every_subcommand_in_order(
+        self, runner: CliRunner, db_path: Path,
+    ) -> None:
+        _seed_plans_schema(db_path).close()
+        with patch(
+            "nexus.commands._helpers.default_db_path", return_value=db_path,
+        ):
+            result = runner.invoke(plan_cmd, ["repair", "all"])
+        assert result.exit_code == 0, result.output
+        # Each pass announces itself with [name].
+        for name in (
+            "scope_tags", "dimensions", "match_text",
+            "retire_legacy", "builtin_bindings",
+        ):
+            assert f"[{name}]" in result.output
+
+
+class TestNoDbFile:
+    def test_each_verb_clean_noop_when_no_db(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        missing = tmp_path / "nope.db"
+        with patch(
+            "nexus.commands._helpers.default_db_path", return_value=missing,
+        ):
+            for sub in ("scope-tags", "dimensions", "match-text",
+                        "retire-legacy", "builtin-bindings", "all"):
+                result = runner.invoke(plan_cmd, ["repair", sub])
+                assert result.exit_code == 0, (sub, result.output)
+                assert "not found" in result.output, (sub, result.output)


### PR DESCRIPTION
## Summary

A9 audit identified 6 plan-library migrations whose bodies backfill content beyond DDL. Per RDR-120 §A8 the substrate provides shape only; under the daemon model these run on substrate startup and cross the boundary. Bodies move to consumer-driven verbs.

- New module \`src/nexus/plans/repair.py\` hosts 5 idempotent helpers plus \`repair_all\` (dependency-ordered fan-out). Verb inference constants, kebab-name derivation, JSON parsing, YAML-resolver — all relocate from \`migrations.py\`.
- Substrate (\`src/nexus/db/migrations.py\`):
  - \`_add_plan_scope_tags\`: ALTER ADD COLUMN only; backfill removed.
  - \`_rewash_plan_scope_tags_all_sentinel\`, \`_backfill_plan_dimensions\`, \`_retire_legacy_operation_shape_plans\`, \`_backfill_builtin_bindings\`: documented no-ops (registry slots retained for monotone version chain).
  - \`_add_plan_match_text_column\`: keeps column add + FTS drop/recreate + trigger setup + FTS rebuild (schema); per-row UPDATE removed.
- CLI (\`src/nexus/commands/plan.py\`): \`nx plan repair\` becomes a group with six subcommands — \`scope-tags\`, \`dimensions\`, \`match-text\`, \`retire-legacy\`, \`builtin-bindings\`, \`all\`. Each emits a diagnostic payload; \`all\` runs the dependency chain.
- Tests:
  - New \`tests/test_plan_repair_verbs.py\` (11 tests): CLI surface coverage.
  - Existing migration tests rewritten via mechanical rename + drive both legs (migration DDL + repair body) so end-to-end semantics still cover the same scenarios.
- 906 plan/migration/upgrade tests pass; lint unchanged (21 / 2).

**Operator-visible behaviour change.** After \`nx upgrade\` operators with legacy plan rows must run \`nx plan repair all\` (or per-subcommand). The migration's match_text DDL leaves the column at DEFAULT '' until the verb runs; plan-match's FTS lane returns no hits for legacy rows until then.

## Closes

Closes nexus-rv7x6.

## Test plan

- [x] \`uv run pytest tests/test_plan_repair_verbs.py tests/test_plan_library.py tests/test_migrations.py tests/test_plan_cmd.py\` (196 passed)
- [x] \`uv run pytest tests/ -k 'plan or migration or upgrade'\` (906 passed)
- [x] \`uv run nx doctor --check-storage-boundary --phase 1\` unchanged (violations=21, catalog-allowlist=2)
- [x] \`uv run nx plan repair --help\` shows the six subcommands

## Notes

Independent of #910 (6y2a9) and the merged yulol (#909) / q2t5t (#908). Aspects + plans are separate modules; no overlap.