### PR TITLE
feat(rdr-120): nexus-ut8zy P2.A T3 cutover (daemon mode unlocked)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -790,3 +790,5 @@
 =======
 {"id":"int-3326fd50","kind":"field_change","created_at":"2026-05-21T20:09:58.736958Z","actor":"Hellblazer","issue_id":"nexus-q2t5t","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
 {"id":"int-42274e77","kind":"field_change","created_at":"2026-05-21T20:56:32.881836Z","actor":"Hellblazer","issue_id":"nexus-6ret6","extra":{"field":"status","new_value":"closed","old_value":"open"}}
+{"id":"int-0278cfe4","kind":"field_change","created_at":"2026-05-21T21:15:14.571858Z","actor":"Hellblazer","issue_id":"nexus-6y2a9","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
+{"id":"int-288a4128","kind":"field_change","created_at":"2026-05-21T21:15:15.365427Z","actor":"Hellblazer","issue_id":"nexus-rv7x6","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -828,7 +828,7 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
 
         click.echo("Dry-run mode — local ONNX embeddings, no cloud writes.")
         ef = DefaultEmbeddingFunction()
-        local_t3 = make_t3(_client=chromadb.EphemeralClient(), _ef_override=ef)
+        local_t3 = make_t3(_client=chromadb.EphemeralClient(), _ef_override=ef)  # epsilon-allow: --dry-run indexing requires in-memory ephemeral client by design
 
         def _local_embed(texts: list[str], model: str) -> tuple[list[list[float]], str]:
             return [v.tolist() for v in ef(texts)], model

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -423,20 +423,25 @@ class StorageModeError(click.ClickException):
 def storage_mode() -> str:
     """Return the validated ``NX_STORAGE_MODE`` value.
 
-    RDR-120 P0.B scaffolding. Single source of truth for the storage
-    backend mode flag. Currently:
+    RDR-120 single source of truth for the storage backend mode flag:
 
     - unset / empty / whitespace -> ``"direct"`` (default)
     - ``"direct"`` (any case) -> ``"direct"``
-    - ``"daemon"`` (any case) -> raises ``StorageModeError`` with
-      "not yet supported at phase 0"
+    - ``"daemon"`` (any case) -> ``"daemon"`` (valid for T3 since
+      P2 cutover; T2 still routes library-mode until P4)
     - anything else -> raises ``StorageModeError`` naming the bad
       value and listing :data:`VALID_STORAGE_MODES`
 
-    The function exists at P0 to lock the env-var name and the
-    validation contract before any client wires the mode to actual
-    behavior. P3 / P4 will switch the daemon branch from rejection
-    to a daemon-client construction.
+    Phasing of the daemon branch:
+
+    - P0 (4.34): rejected with "not yet supported".
+    - P2 (4.35+): accepted for T3 reads/writes. ``make_t3()``
+      honours it and dispatches through ``make_t3_client()`` in
+      local mode. Cloud mode is unaffected (chromadb's CloudClient
+      is already HTTP-served; there is no local daemon to route
+      through).
+    - P4: accepted for T2 reads/writes as well; becomes the default
+      for new installs.
     """
     raw = os.environ.get("NX_STORAGE_MODE", "")
     normalized = raw.strip().lower()
@@ -445,12 +450,7 @@ def storage_mode() -> str:
     if normalized == "direct":
         return "direct"
     if normalized == "daemon":
-        raise StorageModeError(
-            "NX_STORAGE_MODE=daemon is not yet supported at phase 0 of "
-            "RDR-120 (storage substrate split). Set NX_STORAGE_MODE=direct "
-            "or unset the variable to use the current library-mode T2/T3 "
-            "backend. Daemon mode lands in P3."
-        )
+        return "daemon"
     raise StorageModeError(
         f"NX_STORAGE_MODE={raw!r} is not a recognized value. "
         f"Valid values: {', '.join(VALID_STORAGE_MODES)}."

--- a/src/nexus/db/__init__.py
+++ b/src/nexus/db/__init__.py
@@ -28,26 +28,48 @@ if TYPE_CHECKING:
 
 
 def make_t3(*, _client=None, _ef_override=None) -> "T3Database":
-    """Return a :class:`T3Database` built from the current credentials.
+    """Return a :class:`T3Database` built from the current credentials
+    and the active ``NX_STORAGE_MODE``.
 
-    In local mode (``is_local_mode()`` returns True), returns a T3Database
-    backed by ``chromadb.PersistentClient`` with a ``LocalEmbeddingFunction``.
-    No API keys required.
+    Dispatch (RDR-120 P2):
 
-    In cloud mode, returns a T3Database backed by ``chromadb.CloudClient``
-    with Voyage AI embeddings.
+    - ``NX_STORAGE_MODE=daemon`` + local mode + no injected ``_client``:
+      route via ``nexus.daemon.t3_client.make_t3_client`` to the running
+      T3 daemon (``chromadb.HttpClient`` against
+      ``~/.config/nexus/t3_addr.<uid>`` or ``NX_T3_ADDR``).
+    - ``NX_STORAGE_MODE=direct`` + local mode (or daemon mode with an
+      injected ``_client`` for tests): backed by
+      ``chromadb.PersistentClient`` with a ``LocalEmbeddingFunction``.
+      No API keys required.
+    - Cloud mode: backed by ``chromadb.CloudClient`` with Voyage AI
+      embeddings, regardless of ``NX_STORAGE_MODE``. The daemon model
+      does not apply in cloud mode; CloudClient is already HTTP-served.
 
     Keyword-only injection points (for tests):
 
-    * ``_client`` — substitute an ``EphemeralClient`` or ``MagicMock`` to
-      avoid real CloudClient connections.
+    * ``_client`` — substitute an ``EphemeralClient`` or ``MagicMock``
+      to avoid real CloudClient / HttpClient connections. Passing
+      ``_client`` short-circuits the daemon-mode dispatch.
     * ``_ef_override`` — override the embedding function (e.g.
       ``DefaultEmbeddingFunction()``) to avoid Voyage AI API calls.
     """
-    from nexus.config import is_local_mode, load_config, _default_local_path
+    from nexus.config import (
+        is_local_mode, load_config, _default_local_path, storage_mode,
+    )
     # Runtime import of T3Database (was moved out of module-scope to
     # break the eager torch-import chain during CLI startup).
     from nexus.db.t3 import T3Database
+
+    if (
+        is_local_mode()
+        and _client is None
+        and storage_mode() == "daemon"
+    ):
+        # Daemon-mode dispatch (RDR-120 P2). T3Client construction
+        # raises T3DaemonError when the daemon is unreachable; the
+        # message names ``nx daemon t3 start`` as the operator fix.
+        from nexus.daemon.t3_client import make_t3_client
+        return make_t3_client()
 
     if is_local_mode() and _client is None:
         from nexus.db.local_ef import LocalEmbeddingFunction

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -212,7 +212,20 @@ def _check_t3_local() -> list[HealthResult]:
     # a 0-chunk collection lingering after `nx store delete` of every entry.
     if path_exists:
         try:
-            client = chromadb.PersistentClient(path=str(local_path))
+            # RDR-120 P2: the probe is local-mode-by-contract (caller
+            # gated on is_local_mode()). In daemon mode the probe must
+            # NOT open a second PersistentClient against the same store
+            # because chromadb's WAL races between processes. Route
+            # through the T3 daemon's HttpClient instead. In direct
+            # mode the PersistentClient is the right call; epsilon-allow
+            # because this site is a contract-bound local probe rather
+            # than a substrate boundary violation.
+            from nexus.config import storage_mode
+            if storage_mode() == "daemon":
+                from nexus.daemon.t3_client import make_t3_client
+                client = make_t3_client()._client
+            else:
+                client = chromadb.PersistentClient(path=str(local_path))  # epsilon-allow: local-mode doctor probe by contract
             cols = client.list_collections()
             col_count = len(cols)
             empty_count = sum(1 for c in cols if c.count() == 0)
@@ -283,9 +296,12 @@ def _check_t3_cloud() -> list[HealthResult]:
     # ChromaDB reachability
     if chroma_key and chroma_database:
         try:
-            chromadb.CloudClient(
-                tenant=chroma_tenant or None, database=chroma_database, api_key=chroma_key
-            )
+            # RDR-120 P2: route through make_t3 so the reachability
+            # probe exercises the same code path the indexer takes.
+            # Daemon mode is local-only; this branch only fires in
+            # cloud mode, so make_t3 dispatches to CloudClient.
+            from nexus.db import make_t3
+            make_t3()
             results.append(HealthResult(
                 label=f"ChromaDB  ({chroma_database})", ok=True, detail="reachable",
             ))
@@ -328,9 +344,11 @@ def _check_t3_cloud() -> list[HealthResult]:
         stale_count = 0
         pipeline_results: list[HealthResult] = []
         try:
-            client = chromadb.CloudClient(
-                tenant=chroma_tenant or None, database=chroma_database, api_key=chroma_key
-            )
+            # RDR-120 P2: route through make_t3 for the cloud-mode
+            # pipeline-version sweep. Cloud-only branch; daemon does
+            # not apply.
+            from nexus.db import make_t3
+            client = make_t3()._client
             cols = client.list_collections()
             for col in cols:
                 # taxonomy__* collections are BERTopic aggregates (RDR-070),
@@ -828,9 +846,10 @@ def run_health_checks() -> tuple[list[HealthResult], bool]:
         chroma_tenant = get_credential("chroma_tenant")
         if chroma_key and chroma_database:
             try:
-                client = chromadb.CloudClient(
-                    tenant=chroma_tenant or None, database=chroma_database, api_key=chroma_key
-                )
+                # RDR-120 P2: route through make_t3. Cloud-only branch
+                # (gated by ``not _local``); daemon does not apply.
+                from nexus.db import make_t3
+                client = make_t3()._client
                 results.extend(_check_chroma_pagination(client, chroma_database))
             except Exception as exc:
                 _log.debug(

--- a/tests/test_make_t3_daemon_dispatch.py
+++ b/tests/test_make_t3_daemon_dispatch.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 P2 (nexus-ut8zy): ``make_t3()`` honours ``NX_STORAGE_MODE``.
+
+Pre-P2: ``make_t3()`` ignored ``NX_STORAGE_MODE`` and dispatched on
+``is_local_mode()`` alone (PersistentClient or CloudClient).
+
+P2: when ``NX_STORAGE_MODE=daemon`` AND local mode AND no injected
+``_client``, ``make_t3()`` dispatches through
+``nexus.daemon.t3_client.make_t3_client`` against the running T3
+daemon. Cloud mode + an injected ``_client`` short-circuit the
+daemon path so existing tests and the dry-run indexer keep working.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _pin_local_mode(monkeypatch):
+    """RDR-120 §A8 / pin_local_mode_in_cloud_tests feedback: tests
+    that depend on the local-vs-cloud branch must patch
+    ``nexus.config.is_local_mode`` (not nexus.scoring.is_local_mode).
+    The default for this file is local-mode True; cloud tests opt
+    out explicitly."""
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: True)
+
+
+class TestDaemonDispatch:
+    def test_daemon_mode_routes_through_make_t3_client(
+        self, monkeypatch
+    ) -> None:
+        """When NX_STORAGE_MODE=daemon and local, make_t3() must
+        call nexus.daemon.t3_client.make_t3_client and return its
+        result rather than building a PersistentClient."""
+        monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+        sentinel = object()
+        called = {"count": 0}
+
+        def fake_make_t3_client():
+            called["count"] += 1
+            return sentinel
+
+        monkeypatch.setattr(
+            "nexus.daemon.t3_client.make_t3_client", fake_make_t3_client
+        )
+        from nexus.db import make_t3
+
+        result = make_t3()
+        assert result is sentinel
+        assert called["count"] == 1
+
+    def test_direct_mode_does_not_route_through_daemon(
+        self, monkeypatch
+    ) -> None:
+        """NX_STORAGE_MODE=direct (the default) must NOT call
+        make_t3_client; make_t3 falls through to the PersistentClient
+        path so the existing direct-mode code path is unchanged."""
+        monkeypatch.setenv("NX_STORAGE_MODE", "direct")
+        called = {"count": 0}
+
+        def fake_make_t3_client():
+            called["count"] += 1
+            raise AssertionError(
+                "make_t3_client must not be called in direct mode"
+            )
+
+        monkeypatch.setattr(
+            "nexus.daemon.t3_client.make_t3_client", fake_make_t3_client
+        )
+        from nexus.db import make_t3
+        from nexus.db.t3 import T3Database
+
+        result = make_t3()
+        assert isinstance(result, T3Database)
+        assert called["count"] == 0
+
+    def test_injected_client_short_circuits_daemon_dispatch(
+        self, monkeypatch
+    ) -> None:
+        """An injected ``_client`` (the dry-run indexer pattern, the
+        test ephemeral-client pattern) must short-circuit the daemon
+        dispatch even when NX_STORAGE_MODE=daemon. Otherwise tests
+        and the dry-run code path would crash with T3DaemonError
+        when no daemon is running."""
+        monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+
+        def fake_make_t3_client():
+            raise AssertionError(
+                "daemon dispatch must be skipped when _client is injected"
+            )
+
+        monkeypatch.setattr(
+            "nexus.daemon.t3_client.make_t3_client", fake_make_t3_client
+        )
+        import chromadb
+        from nexus.db import make_t3
+        from nexus.db.t3 import T3Database
+
+        ephemeral = chromadb.EphemeralClient()
+        result = make_t3(_client=ephemeral)
+        assert isinstance(result, T3Database)
+        assert result._client is ephemeral
+
+    def test_cloud_mode_ignores_daemon_flag(self, monkeypatch) -> None:
+        """Cloud mode has no local daemon; the daemon flag must be
+        ignored so the cloud branch keeps using CloudClient.
+        """
+        monkeypatch.setattr("nexus.config.is_local_mode", lambda: False)
+        monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+        # Fake credentials so the cloud branch reaches the
+        # T3Database constructor without exploding on missing keys;
+        # we don't actually hit chromadb cloud because we patch the
+        # client construction.
+        monkeypatch.setattr(
+            "nexus.config.get_credential",
+            lambda key: {
+                "chroma_tenant": "t", "chroma_database": "d",
+                "chroma_api_key": "k", "voyage_api_key": "v",
+            }.get(key, ""),
+        )
+        # Also patch the db package-level shim that re-imports
+        # get_credential at function scope.
+        monkeypatch.setattr(
+            "nexus.db.get_credential",
+            lambda key: {
+                "chroma_tenant": "t", "chroma_database": "d",
+                "chroma_api_key": "k", "voyage_api_key": "v",
+            }.get(key, ""),
+        )
+
+        def fake_make_t3_client():
+            raise AssertionError(
+                "daemon dispatch must not fire in cloud mode"
+            )
+
+        monkeypatch.setattr(
+            "nexus.daemon.t3_client.make_t3_client", fake_make_t3_client
+        )
+
+        # Stub the CloudClient so we don't make a real network call.
+        class _FakeCloudClient:
+            def __init__(self, *args, **kwargs) -> None: ...
+
+        monkeypatch.setattr("chromadb.CloudClient", _FakeCloudClient)
+        # Stub voyageai so the lazy import inside T3Database.__init__
+        # doesn't try to authenticate.
+        import sys
+        import types
+        fake_voyageai = types.SimpleNamespace(
+            Client=lambda *a, **kw: object(),
+        )
+        monkeypatch.setitem(sys.modules, "voyageai", fake_voyageai)
+
+        from nexus.db import make_t3
+        result = make_t3()
+        # The fake CloudClient is what landed; make_t3 did NOT route
+        # through the daemon factory.
+        assert isinstance(result._client, _FakeCloudClient)

--- a/tests/test_storage_mode.py
+++ b/tests/test_storage_mode.py
@@ -1,11 +1,17 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""RDR-120 P0.B: NX_STORAGE_MODE cutover-flag scaffolding.
+"""RDR-120 P2: NX_STORAGE_MODE cutover-flag (T3 daemon mode unlocked).
 
-At P0 only `direct` is a valid value; `daemon` is rejected with
-"not yet supported"; any other value is rejected with the list of
-valid values. This is a no-op cutover flag — its purpose is to
-establish the single source of truth before P3 wires it to actual
-behavior.
+P0 introduced the flag as a no-op (only `direct` valid, `daemon`
+rejected with "not yet supported"). P2 (nexus-ut8zy) unblocks the
+`daemon` branch so ``make_t3()`` can dispatch through the daemon
+``T3Client`` in local + daemon mode.
+
+Validation matrix:
+
+- unset / empty / whitespace -> "direct" (default)
+- "direct" (any case) -> "direct"
+- "daemon" (any case) -> "daemon"  (P2 onward)
+- anything else -> StorageModeError naming the bad value
 """
 from __future__ import annotations
 
@@ -29,15 +35,27 @@ def test_direct_is_accepted(monkeypatch):
     assert storage_mode() == "direct"
 
 
-def test_daemon_is_rejected_at_phase_0(monkeypatch):
-    """RDR-120 P0: daemon mode rejected with explicit not-yet-supported message."""
-    monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
-    from nexus.config import StorageModeError, storage_mode
+def test_daemon_is_accepted_at_phase_2(monkeypatch):
+    """RDR-120 P2 (nexus-ut8zy): daemon mode is valid for T3 dispatch.
 
-    with pytest.raises(StorageModeError) as exc:
-        storage_mode()
-    assert "daemon" in str(exc.value).lower()
-    assert "not yet supported" in str(exc.value).lower() or "phase 0" in str(exc.value).lower()
+    Pre-P2 this asserted rejection with "not yet supported"; that
+    behaviour shipped from P0 through 4.33.1. The P2 cutover flipped
+    the rejection to acceptance so make_t3() can route through the
+    T3 daemon.
+    """
+    monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+    from nexus.config import storage_mode
+
+    assert storage_mode() == "daemon"
+
+
+def test_daemon_case_normalization(monkeypatch):
+    """`DAEMON` and `Daemon` accepted; case shouldn't trip operators."""
+    for val in ("DAEMON", "Daemon", "daemon"):
+        monkeypatch.setenv("NX_STORAGE_MODE", val)
+        from nexus.config import storage_mode
+
+        assert storage_mode() == "daemon"
 
 
 def test_unknown_value_lists_valid_options(monkeypatch):


### PR DESCRIPTION
## Summary

Unblocks \`NX_STORAGE_MODE=daemon\` for T3 reads/writes and routes the four \`chromadb\` call sites in \`health.py\` through the unified \`make_t3()\` factory.

- \`storage_mode()\` returns \`"daemon"\` instead of raising. Case normalization and unknown-value error message unchanged.
- \`make_t3()\` dispatches: local + daemon + no injected \`_client\` -> \`make_t3_client()\` (HttpClient against the running T3 daemon); local + direct -> \`PersistentClient\` (unchanged); cloud -> \`CloudClient\` regardless of mode (daemon doesn't apply; CloudClient is already HTTP-served). Injected \`_client\` always short-circuits.
- \`health.py\`: 4 sites migrated. \`_check_t3_local\` is a contract-bound local-mode probe; in daemon mode it goes through \`make_t3_client\` to avoid racing the daemon for the WAL with a second \`PersistentClient\` on the same store; in direct mode it carries an \`epsilon-allow\`. The three cloud probes go through \`make_t3()\` which dispatches to \`CloudClient\`.
- \`commands/index.py\`: epsilon-allow on the \`--dry-run\` \`EphemeralClient\` (intentional in-memory client, not a substrate bypass).
- Storage-boundary lint: violations \`21 -> 16\`; catalog-allowlist unchanged at \`2\`.

**Operator-visible change.** Setting \`NX_STORAGE_MODE=daemon\` requires \`nx daemon t3 start\` (or autostart). Otherwise \`make_t3()\` raises \`T3DaemonError\` naming the recovery step.

## Closes

Closes nexus-ut8zy.

## Test plan

- [x] \`uv run pytest tests/test_storage_mode.py tests/test_make_t3_daemon_dispatch.py\` (14 passed)
- [x] \`uv run pytest tests/ -k 'health or doctor or t3 or daemon or storage_mode'\` (701 passed)
- [x] \`uv run nx doctor --check-storage-boundary --phase 2\` shows violations=16, catalog-allowlist=2