### PR TITLE
feat(rdr-120): P3b.A migration ownership transfer (nexus-e9x4l)

### DIFF
--- a/src/nexus/daemon/T2_DAEMON_WIP.md
+++ b/src/nexus/daemon/T2_DAEMON_WIP.md
@@ -71,11 +71,25 @@ Archive port deleted; clean substrate-only modules in place.
 
 ## What still ships in a follow-up bead (not P3a)
 
-- **P3b migration ownership transfer** (`nexus-e9x4l`): remove
-  `apply_pending` from `T2Database.__init__` so the daemon is the
-  sole `apply_pending` caller. Currently the daemon's
-  `T2Database(self._db_path)` still triggers `apply_pending` per
-  RDR-120 §A6 P3 transition mitigation. P3b lifts that.
+- **P3b migration ownership transfer** (`nexus-e9x4l` — DONE 2026-05-22):
+  `apply_pending` removed from `T2Database.__init__` direct-open path.
+  The daemon explicitly opts in via `T2Database(path, run_migrations=True)`;
+  all other direct-open call sites get the production default
+  (`_DEFAULT_RUN_MIGRATIONS=False`) and run against whatever schema
+  the daemon (or `nx upgrade`) last left in place. **Operator contract
+  during the P3b→P4 window**: keep the T2 daemon running OR run
+  `nx upgrade` after every conexus version bump before invoking
+  direct-open CLI commands. P4 (`nexus-2ngox`) flips these call sites
+  to `T2Client` and the contract goes away.
+
+- **Spawn-lock scope** (RDR-120 P3b code-review item 2): two locks
+  held for the daemon's lifetime — the legacy `<config_dir>/t2_spawn.lock`
+  (preserves the "one daemon per config_dir" invariant operators
+  rely on) and a new `<db_path>.spawn_lock` sibling of the data file
+  (prevents two daemons against the same data file from different
+  `config_dir`s both running `apply_pending`). Either lock failing
+  causes the second daemon to fail loud with a message naming the
+  contended lock file.
 
 - **Call-site cutover (P4)**: `nexus-2ngox` flips T2 call sites
   through `T2Client`. Not part of P3a.

--- a/src/nexus/daemon/t2_client.py
+++ b/src/nexus/daemon/t2_client.py
@@ -59,6 +59,34 @@ class T2DaemonNotReachableError(RuntimeError):
     connection fails (daemon crashed mid-transit, address stale)."""
 
 
+class T2SchemaVersionMismatchError(RuntimeError):
+    """Raised when the daemon's stored schema version differs from the
+    version the client was built against.
+
+    RDR-120 P3b (nexus-e9x4l): client carries
+    :func:`nexus.db.migrations.expected_t2_schema_version` as the
+    expected value and exchanges it with the daemon via
+    ``database.hello`` on first connect. A mismatch means client and
+    daemon are running different ``conexus`` wheels; the substrate
+    refuses to operate rather than silently apply migrations across
+    the boundary or read against a newer schema.
+
+    Attributes:
+        client_version: Schema version the client was built against.
+        daemon_version: Schema version the daemon reports.
+    """
+
+    def __init__(self, *, client_version: str, daemon_version: str) -> None:
+        super().__init__(
+            f"T2 schema version mismatch: client built against "
+            f"{client_version!r}, daemon reports {daemon_version!r}. "
+            f"Re-install conexus so both sides match, then restart the "
+            f"T2 daemon: `nx daemon t2 stop && nx daemon t2 start`."
+        )
+        self.client_version = client_version
+        self.daemon_version = daemon_version
+
+
 class T2ClientError(RuntimeError):
     """Raised when the daemon returns an error frame for an RPC call.
 
@@ -198,11 +226,21 @@ class T2Client:
             (defaults to ``nexus.config.nexus_config_dir()``).
     """
 
-    def __init__(self, *, config_dir: Optional[Path] = None) -> None:
+    def __init__(
+        self,
+        *,
+        config_dir: Optional[Path] = None,
+        skip_handshake: bool = False,
+    ) -> None:
         self._config_dir = config_dir
         self._sock: Optional[socket.socket] = None
         self._request_id = 0
         self._lock = threading.Lock()
+        # RDR-120 P3b: handshake runs lazily on first ``call`` so
+        # construction stays cheap. ``skip_handshake`` exists for tests
+        # that exercise the connection plumbing without a real daemon.
+        self._skip_handshake = skip_handshake
+        self._handshake_done = False
         # Stores enumerated by the daemon dispatch builder. Public
         # attribute names mirror T2Database for surface parity.
         # Seven stores at P3a; catalog joins at P5.
@@ -229,6 +267,7 @@ class T2Client:
                 except OSError:
                     pass
                 self._sock = None
+            self._handshake_done = False
 
     # ── RPC ─────────────────────────────────────────────────────────────
 
@@ -237,12 +276,92 @@ class T2Client:
             self._sock = _open_connection(config_dir=self._config_dir)
         return self._sock
 
+    def _do_handshake_locked(self, sock: socket.socket) -> None:
+        """Send ``database.hello`` and verify version agreement.
+
+        Caller holds ``self._lock`` and must pass the established
+        socket. Raises ``T2SchemaVersionMismatchError`` on mismatch;
+        propagates transport / protocol errors unchanged so the caller
+        tears down the socket the same way as any other RPC failure.
+        """
+        from nexus.db.migrations import expected_t2_schema_version
+
+        client_version = expected_t2_schema_version()
+        self._request_id += 1
+        request_id = self._request_id
+        frame = {
+            "op": "database.hello",
+            "args": [],
+            "kwargs": {"client_schema_version": client_version},
+            "request_id": request_id,
+        }
+        _send_frame_sync(sock, frame)
+        response = _recv_frame_sync(sock)
+        if response.get("request_id") != request_id:
+            raise ProtocolError(
+                f"handshake response request_id mismatch: "
+                f"sent {request_id}, got {response.get('request_id')!r}"
+            )
+        if not response.get("ok", False):
+            err = response.get("error") or {}
+            raise T2ClientError(
+                op="database.hello",
+                error_type=str(err.get("type", "Unknown")),
+                message=str(err.get("message", "<no message>")),
+            )
+        result = response.get("result") or {}
+        daemon_version = str(result.get("daemon_schema_version") or "")
+        # ``"0.0.0"`` / empty daemon side means the daemon never completed
+        # ``apply_pending`` (deferred steps, e.g. catalog absent). The
+        # schema is still functionally OK for daemon ops — log a warning
+        # and proceed. A genuine non-trivial mismatch is the fail-loud
+        # case (client and daemon are running different wheels).
+        if (
+            daemon_version
+            and daemon_version != "0.0.0"
+            and daemon_version != client_version
+        ):
+            raise T2SchemaVersionMismatchError(
+                client_version=client_version,
+                daemon_version=daemon_version,
+            )
+        if daemon_version in ("", "0.0.0"):
+            _log.warning(
+                "t2_client_handshake_daemon_version_unset",
+                client_version=client_version,
+                daemon_version=daemon_version,
+            )
+        self._handshake_done = True
+
     def call(self, op: str, *args: Any, **kwargs: Any) -> Any:
         """Invoke *op* with positional + keyword args; return the
         decoded result. Raises ``T2ClientError`` on daemon-side
-        failure, ``T2DaemonNotReachableError`` on transport failure."""
+        failure, ``T2DaemonNotReachableError`` on transport failure,
+        ``T2SchemaVersionMismatchError`` if the lazy handshake detects
+        a client/daemon schema-version skew on first connect.
+        """
         with self._lock:
             sock = self._ensure_sock()
+            if not self._skip_handshake and not self._handshake_done:
+                try:
+                    self._do_handshake_locked(sock)
+                except (OSError, T2DaemonNotReachableError):
+                    try:
+                        sock.close()
+                    except OSError:
+                        pass
+                    self._sock = None
+                    self._handshake_done = False
+                    raise
+                except T2SchemaVersionMismatchError:
+                    # Tear down so a retry after reinstall reconnects.
+                    try:
+                        sock.close()
+                    except OSError:
+                        pass
+                    self._sock = None
+                    self._handshake_done = False
+                    raise
             self._request_id += 1
             request_id = self._request_id
             frame = {
@@ -261,6 +380,7 @@ class T2Client:
                 except OSError:
                     pass
                 self._sock = None
+                self._handshake_done = False
                 if isinstance(exc, T2DaemonNotReachableError):
                     raise
                 raise T2DaemonNotReachableError(

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -266,7 +266,9 @@ _T2_STORE_ATTRS: tuple[str, ...] = (
 )
 
 #: Top-level T2Database methods exposed under the "database" pseudo-store.
-_T2_DATABASE_METHODS: tuple[str, ...] = ("rename_collection_cascade",)
+#: ``hello`` is the RDR-120 P3b connection handshake — T2Client invokes
+#: it on first connect to validate schema-version compatibility.
+_T2_DATABASE_METHODS: tuple[str, ...] = ("rename_collection_cascade", "hello")
 
 #: Methods filtered from every store. ``close`` is denied to prevent a
 #: client from tearing down the daemon's SQLite handles via RPC;
@@ -454,11 +456,12 @@ class T2Daemon:
         self._ensure_dirs()
         self._acquire_spawn_lock()
 
-        # Open the T2Database. apply_pending runs in its __init__ per
-        # RDR-120 §A6 P3 transition mitigation; daemon is the sole
-        # opener at this path during its lifetime.
+        # RDR-120 P3b (nexus-e9x4l): daemon is the sole ``apply_pending``
+        # caller. T2Database.__init__ no longer auto-runs migrations; the
+        # daemon passes ``run_migrations=True`` so its construction
+        # bootstraps the schema before any client connects.
         from nexus.db.t2 import T2Database
-        self._t2db = T2Database(self._db_path)
+        self._t2db = T2Database(self._db_path, run_migrations=True)
         self._dispatch_table = _build_dispatch_table(self._t2db)
 
         uds_sock = self._bind_uds()

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -86,8 +86,26 @@ _LISTEN_BACKLOG: int = 64
 #: Discovery file template (uid-suffixed so multi-user hosts don't collide).
 _DISCOVERY_FILE_TEMPLATE: str = "t2_addr.{uid}"
 
-#: Spawn-lock file name (fcntl exclusive lock held for daemon lifetime).
+#: Legacy spawn-lock file name (fcntl exclusive lock held for daemon
+#: lifetime). The lock is now keyed on a hash of the resolved db_path
+#: so two daemons against the same data file collide regardless of
+#: which config_dir they were started from (RDR-120 P3b code-review
+#: item 2). The legacy ``t2_spawn.lock`` filename is still acquired
+#: alongside the path-scoped lock to preserve the "same config_dir"
+#: invariant operators already rely on.
 _SPAWN_LOCK_FILE: str = "t2_spawn.lock"
+
+
+def _spawn_lock_path_for_db(db_path: Path) -> Path:
+    """Return the path-scoped spawn-lock file for *db_path*.
+
+    The lock lives as a sibling of the data file
+    (``<db_path>.spawn_lock``) so daemons started against the same
+    ``db_path`` from different ``config_dir``s contend on the same
+    lock file. The actual race surface is the data file, so the lock
+    is anchored where the race exists.
+    """
+    return db_path.parent / f"{db_path.name}.spawn_lock"
 
 #: Subdirectory under config_dir holding the UDS path. Mode 0o700 at
 #: create time so other UIDs cannot stat() into it.
@@ -423,6 +441,7 @@ class T2Daemon:
         self._tcp_port: int | None = None
         self._discovery_path: Path | None = None
         self._spawn_lock_fd: int | None = None
+        self._spawn_lock_fd_path: int | None = None
         self._stop_event: asyncio.Event | None = None
 
     # ── public properties ───────────────────────────────────────────────
@@ -665,10 +684,19 @@ class T2Daemon:
             pass
 
     def _acquire_spawn_lock(self) -> None:
-        """Acquire an fcntl exclusive lock on a spawn-lock file. Held
-        for the daemon's lifetime; released in :meth:`stop`. Prevents
-        a second daemon from starting against the same config_dir."""
+        """Acquire exclusive fcntl locks on both the config_dir-scoped
+        and the db_path-scoped spawn-lock files. Both are held for the
+        daemon's lifetime; both are released in :meth:`stop`.
+
+        Two locks because the race surface is the data file but
+        operators still rely on the "one daemon per config_dir"
+        invariant. The db_path-scoped lock (RDR-120 P3b code-review
+        item 2) prevents two daemons against the same data file from
+        different ``config_dir``s both running ``apply_pending``.
+        """
         import fcntl
+
+        # 1. Legacy config_dir-scoped lock.
         lock_path = self._config_dir / _SPAWN_LOCK_FILE
         fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
         try:
@@ -683,19 +711,48 @@ class T2Daemon:
             raise
         self._spawn_lock_fd = fd
 
+        # 2. db_path-scoped lock. Anchored where the race exists so
+        # two daemons against the same data file from different
+        # config_dirs still collide.
+        path_lock = _spawn_lock_path_for_db(self._db_path)
+        path_lock.parent.mkdir(parents=True, exist_ok=True)
+        fd2 = os.open(str(path_lock), os.O_WRONLY | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(fd2, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            os.close(fd2)
+            # Release the first lock so we don't leak it on failure.
+            try:
+                fcntl.flock(self._spawn_lock_fd, fcntl.LOCK_UN)
+                os.close(self._spawn_lock_fd)
+            except OSError:
+                pass
+            self._spawn_lock_fd = None
+            if exc.errno in (errno.EAGAIN, errno.EACCES):
+                raise T2DaemonError(
+                    f"another T2 daemon already holds the db_path spawn "
+                    f"lock at {path_lock}; refusing to start a second "
+                    f"instance against the same data file"
+                ) from exc
+            raise
+        self._spawn_lock_fd_path = fd2
+
     def _release_spawn_lock(self) -> None:
         import fcntl
-        if self._spawn_lock_fd is None:
-            return
-        try:
-            fcntl.flock(self._spawn_lock_fd, fcntl.LOCK_UN)
-        except OSError:
-            pass
-        try:
-            os.close(self._spawn_lock_fd)
-        except OSError:
-            pass
-        self._spawn_lock_fd = None
+
+        for attr in ("_spawn_lock_fd_path", "_spawn_lock_fd"):
+            fd = getattr(self, attr, None)
+            if fd is None:
+                continue
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            setattr(self, attr, None)
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -2214,6 +2214,25 @@ T3_UPGRADES: list[T3UpgradeStep] = [
 
 # ── Constants ───────────────────────────────────────────────────────────────
 
+def expected_t2_schema_version() -> str:
+    """Return the T2 schema version this client was built against.
+
+    RDR-120 P3b (nexus-e9x4l): T2Client surfaces this to the daemon
+    during the connection handshake; the daemon compares against the
+    schema version recorded in its own ``_nexus_version`` row and
+    fails loud on mismatch. Derived from the installed ``conexus``
+    package version (the same source ``apply_pending`` uses to gate
+    pending migrations) so client + daemon agree by construction
+    when running the same wheel.
+    """
+    try:
+        from importlib.metadata import version as _pkg_version
+
+        return _pkg_version("conexus")
+    except Exception:
+        return "0.0.0"
+
+
 PRE_REGISTRY_VERSION = "4.1.2"
 """Last release before the migration registry shipped.
 

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -139,6 +139,27 @@ def __getattr__(name: str) -> Any:  # PEP 562
 #: so existing direct-open fixtures keep migrating their fresh tmp DBs.
 _DEFAULT_RUN_MIGRATIONS: bool = False
 
+#: Env-var override for :data:`_DEFAULT_RUN_MIGRATIONS`. Set to ``"1"`` to
+#: opt every direct-open ``T2Database`` construction into running
+#: ``apply_pending`` even when the in-process module global is False.
+#: Used by the test conftest to propagate auto-migrate semantics into
+#: subprocess children (``subprocess.run`` / ``claude -p`` dispatches /
+#: MCP children) which inherit ``os.environ`` but not Python module state.
+_RUN_MIGRATIONS_ENV: str = "NX_T2_AUTO_MIGRATE"
+
+
+def _resolve_default_run_migrations() -> bool:
+    """Read the effective default from the env var first, the module
+    global second. The env-var path is what propagates into spawned
+    subprocesses (RDR-120 P3b review item 1).
+    """
+    import os as _os
+
+    raw = _os.environ.get(_RUN_MIGRATIONS_ENV, "").strip()
+    if raw:
+        return raw not in ("0", "false", "False", "no", "")
+    return _DEFAULT_RUN_MIGRATIONS
+
 
 # ── Database facade ───────────────────────────────────────────────────────────
 
@@ -182,7 +203,9 @@ class T2Database:
         # production; conftest flips it to True so the test suite stays
         # green without touching 300+ direct-open call sites).
         effective = (
-            _DEFAULT_RUN_MIGRATIONS if run_migrations is None else run_migrations
+            _resolve_default_run_migrations()
+            if run_migrations is None
+            else run_migrations
         )
         if effective:
             T2Database.bootstrap_schema(path)

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -133,6 +133,13 @@ def __getattr__(name: str) -> Any:  # PEP 562
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+#: RDR-120 P3b: process-wide default for ``T2Database(run_migrations=...)``
+#: when the caller leaves the parameter unspecified. Production code keeps
+#: this False (daemon owns migrations). The test conftest flips it to True
+#: so existing direct-open fixtures keep migrating their fresh tmp DBs.
+_DEFAULT_RUN_MIGRATIONS: bool = False
+
+
 # ── Database facade ───────────────────────────────────────────────────────────
 
 
@@ -148,7 +155,7 @@ class T2Database:
     manager.
     """
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, *, run_migrations: bool | None = None) -> None:
         # Lazy-load the seven store classes here rather than at module
         # import time so the CLI cold-start path (which only needs
         # ``_sanitize_fts5``) does not pull sklearn/scipy/numpy through
@@ -165,64 +172,20 @@ class T2Database:
         # Store path for cross-domain operations (e.g. rename_collection_cascade).
         self._path: Path = path
 
-        # ── Transient connection: run pending migrations (RDR-076) ────
-        from nexus.db.migrations import _upgrade_done, _upgrade_lock, apply_pending
-
-        try:
-            path_key = str(path.resolve())
-        except OSError:
-            path_key = str(path)
-
-        # Serialise the check-then-migrate to prevent concurrent
-        # transient connections racing the WAL write lock.
-        with _upgrade_lock:
-            if path_key not in _upgrade_done:
-                try:
-                    from importlib.metadata import version as _pkg_version
-
-                    current_version = _pkg_version("conexus")
-                except Exception:
-                    current_version = "0.0.0"
-
-                # OBS-2: emit a brief migration notice so operators see
-                # progress rather than a silent hang on first post-upgrade
-                # invocation. Suppressed when stderr is not a TTY
-                # (CI, pipes, click.testing.CliRunner) because CliRunner
-                # mixes stderr into result.output and tests parsing
-                # JSON output break otherwise. The interactive operator
-                # case (running `nx <verb>` from a real terminal) keeps
-                # the visibility benefit; the headless case stays
-                # quiet.
-                import sys as _sys
-                _stderr_is_tty = (
-                    hasattr(_sys.stderr, "isatty") and _sys.stderr.isatty()
-                )
-                if _stderr_is_tty:
-                    print(
-                        f"Migrating database {path.name!r} to schema "
-                        f"version {current_version} ...",
-                        file=_sys.stderr,
-                    )
-
-                conn = sqlite3.connect(str(path), check_same_thread=False)
-                try:
-                    conn.execute("PRAGMA busy_timeout=5000")
-                    conn.execute("PRAGMA journal_mode=WAL")
-                    apply_pending(conn, current_version)
-                finally:
-                    conn.close()
-                # apply_pending() keys _upgrade_done by
-                # _connection_path_key(conn) (Path(row[2]).resolve() from
-                # PRAGMA database_list). The fast-path check above keys by
-                # str(path.resolve()) on the Path argument. The two forms
-                # are equivalent in nearly all cases but diverge in CI
-                # path-resolution edge cases (nexus-avwe), leaving the
-                # T2Database-form path_key absent from _upgrade_done after
-                # apply_pending populated only its own form. Recording the
-                # T2Database form here ensures a second construction with
-                # the same Path argument short-circuits without re-opening
-                # the connection.
-                _upgrade_done.add(path_key)
+        # RDR-120 P3b: migration ownership transferred to the T2 daemon.
+        # ``T2Database.__init__`` no longer auto-runs ``apply_pending``.
+        # Callers that need to materialise the schema (daemon startup,
+        # ``nx upgrade``, conftest bootstrap) must either pass
+        # ``run_migrations=True`` here or call
+        # :meth:`T2Database.bootstrap_schema` explicitly. The default is
+        # the module-level :data:`_DEFAULT_RUN_MIGRATIONS` (False in
+        # production; conftest flips it to True so the test suite stays
+        # green without touching 300+ direct-open call sites).
+        effective = (
+            _DEFAULT_RUN_MIGRATIONS if run_migrations is None else run_migrations
+        )
+        if effective:
+            T2Database.bootstrap_schema(path)
 
         # ── Construct domain stores ───────────────────────────────────
         self.memory: MemoryStore = MemoryStore(path)
@@ -243,6 +206,92 @@ class T2Database:
         # async aspect-extraction worker. The hook fires fast (just
         # an enqueue); the worker drains in a background thread.
         self.aspect_queue: AspectExtractionQueue = AspectExtractionQueue(path)
+
+    def stored_schema_version(self) -> str:
+        """Return the ``_nexus_version`` row's ``cli_version`` value.
+
+        RDR-120 P3b: surfaced via the daemon's ``database.hello`` op so
+        clients can validate version compatibility on first connect.
+        Returns ``"0.0.0"`` when the row is missing (uninitialised DB).
+        """
+        conn = sqlite3.connect(str(self._path), check_same_thread=False)
+        try:
+            try:
+                row = conn.execute(
+                    "SELECT value FROM _nexus_version WHERE key='cli_version'"
+                ).fetchone()
+            except sqlite3.OperationalError:
+                return "0.0.0"
+            return row[0] if row else "0.0.0"
+        finally:
+            conn.close()
+
+    def hello(self, client_schema_version: str | None = None) -> dict[str, str]:
+        """Connection handshake: report the daemon's stored schema version.
+
+        RDR-120 P3b (nexus-e9x4l): T2Client invokes ``database.hello``
+        on first connect with its built-against schema version. The
+        daemon echoes the daemon-side version; the client compares and
+        raises ``T2SchemaVersionMismatchError`` on disagreement. The
+        ``client_schema_version`` argument is accepted but not validated
+        daemon-side — the comparison happens on the client because the
+        client is the layer that knows what wire shape it expects.
+        """
+        return {
+            "daemon_schema_version": self.stored_schema_version(),
+            "client_schema_version": client_schema_version or "",
+        }
+
+    @staticmethod
+    def bootstrap_schema(path: Path) -> None:
+        """Run ``apply_pending`` against *path*.
+
+        RDR-120 P3b: lifted out of ``__init__`` so the T2 daemon is the
+        sole substrate-owner that runs migrations in steady state.
+        ``nx upgrade`` and the test conftest also call this directly.
+
+        Idempotent: subsequent calls against the same resolved path
+        short-circuit via the ``_upgrade_done`` set in
+        :mod:`nexus.db.migrations`.
+        """
+        from nexus.db.migrations import _upgrade_done, _upgrade_lock, apply_pending
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            path_key = str(path.resolve())
+        except OSError:
+            path_key = str(path)
+
+        with _upgrade_lock:
+            if path_key in _upgrade_done:
+                return
+            try:
+                from importlib.metadata import version as _pkg_version
+
+                current_version = _pkg_version("conexus")
+            except Exception:
+                current_version = "0.0.0"
+
+            import sys as _sys
+            if hasattr(_sys.stderr, "isatty") and _sys.stderr.isatty():
+                print(
+                    f"Migrating database {path.name!r} to schema "
+                    f"version {current_version} ...",
+                    file=_sys.stderr,
+                )
+
+            conn = sqlite3.connect(str(path), check_same_thread=False)
+            try:
+                conn.execute("PRAGMA busy_timeout=5000")
+                conn.execute("PRAGMA journal_mode=WAL")
+                apply_pending(conn, current_version)
+            finally:
+                conn.close()
+            # Mirror the T2Database-form path_key into _upgrade_done so
+            # a second construction with the same Path argument
+            # short-circuits without re-opening the connection
+            # (nexus-avwe — CI path-resolution edge cases).
+            _upgrade_done.add(path_key)
 
     def __enter__(self) -> "T2Database":
         return self

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,23 @@ from nexus.db.t2 import T2Database
 from nexus.db.t3 import T3Database
 
 
+def _enable_t2_test_auto_migrate() -> None:
+    """RDR-120 P3b: T2Database.__init__ no longer auto-runs migrations
+    in production (the daemon owns ``apply_pending``). The test suite
+    has hundreds of direct-open call sites that rely on a freshly-
+    migrated schema, so we flip the module-level default ON for
+    pytest. Production code paths (CLI, MCP servers) keep the
+    daemon-owns-migration semantic; only the test process sees the
+    flipped default.
+    """
+    from nexus.db import t2 as _t2
+
+    _t2._DEFAULT_RUN_MIGRATIONS = True
+
+
+_enable_t2_test_auto_migrate()
+
+
 def pytest_configure(config):
     """Configure structlog level to match pytest's --log-level.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,14 +15,20 @@ def _enable_t2_test_auto_migrate() -> None:
     """RDR-120 P3b: T2Database.__init__ no longer auto-runs migrations
     in production (the daemon owns ``apply_pending``). The test suite
     has hundreds of direct-open call sites that rely on a freshly-
-    migrated schema, so we flip the module-level default ON for
-    pytest. Production code paths (CLI, MCP servers) keep the
-    daemon-owns-migration semantic; only the test process sees the
-    flipped default.
+    migrated schema, so we opt the in-process default ON and also
+    set the ``NX_T2_AUTO_MIGRATE`` env var so subprocesses
+    (``subprocess.run`` / ``claude -p`` / MCP children) that inherit
+    ``os.environ`` but not Python module state get the same default.
+    Production code paths (CLI, MCP servers) keep the
+    daemon-owns-migration semantic; only the test process tree sees
+    the flipped default.
     """
+    import os
+
     from nexus.db import t2 as _t2
 
     _t2._DEFAULT_RUN_MIGRATIONS = True
+    os.environ.setdefault(_t2._RUN_MIGRATIONS_ENV, "1")
 
 
 _enable_t2_test_auto_migrate()

--- a/tests/daemon/test_t2_client.py
+++ b/tests/daemon/test_t2_client.py
@@ -168,3 +168,154 @@ class TestEndToEndRpc:
             assert excinfo.value.op == "nonexistent.op"
             assert "ProtocolError" in excinfo.value.error_type or \
                    "unknown op" in excinfo.value.message
+
+
+# ---------------------------------------------------------------------------
+# RDR-120 P3b: schema-version handshake
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaHandshake:
+    """RDR-120 P3b (nexus-e9x4l): T2Client invokes ``database.hello`` on
+    first connect; mismatch raises ``T2SchemaVersionMismatchError``.
+    """
+
+    def test_hello_round_trip_returns_daemon_schema_version(
+        self, config_dir: Path, live_daemon,
+    ) -> None:
+        from nexus.daemon.t2_client import T2Client
+
+        with T2Client(config_dir=config_dir) as client:
+            result = client.database.hello(client_schema_version="probe")
+            assert isinstance(result, dict)
+            assert "daemon_schema_version" in result
+            assert result["client_schema_version"] == "probe"
+
+    def test_handshake_runs_once_per_connection(
+        self, config_dir: Path, live_daemon,
+    ) -> None:
+        """Two RPCs in a row over a single connection produce exactly
+        one handshake; second call skips via ``_handshake_done``."""
+        from nexus.daemon.t2_client import T2Client
+
+        with T2Client(config_dir=config_dir) as client:
+            client.memory.put(content="a", project="p", title="t1")
+            assert client._handshake_done is True
+            # A second call must not raise; handshake gate stays set.
+            client.memory.put(content="b", project="p", title="t2")
+            assert client._handshake_done is True
+
+    def test_handshake_mismatch_raises_schema_version_mismatch(
+        self, config_dir: Path, live_daemon, monkeypatch,
+    ) -> None:
+        """Force the client to claim a fake build-version that diverges
+        from the daemon's actual stored ``cli_version``; the handshake
+        must raise ``T2SchemaVersionMismatchError`` before any
+        substrate op runs.
+        """
+        from nexus.daemon import t2_client as _t2c
+        from nexus.daemon.t2_client import (
+            T2Client,
+            T2SchemaVersionMismatchError,
+        )
+
+        # Pin a non-trivial daemon-side stored schema version directly
+        # in _nexus_version so the handshake fail-loud branch (both
+        # sides non-trivial AND disagreeing) is the one under test.
+        import sqlite3 as _sqlite3
+
+        with T2Client(config_dir=config_dir) as warm:
+            warm.database.hello()  # ensure _nexus_version table exists
+        daemon_db_path = live_daemon._db_path
+        conn = _sqlite3.connect(str(daemon_db_path))
+        try:
+            conn.execute(
+                "UPDATE _nexus_version SET value=? WHERE key='cli_version'",
+                ("9.99.99",),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        from nexus.db.migrations import expected_t2_schema_version
+        fake_version = expected_t2_schema_version() + "-mismatch"
+        monkeypatch.setattr(
+            "nexus.db.migrations.expected_t2_schema_version",
+            lambda: fake_version,
+        )
+        # The handshake imports expected_t2_schema_version inside
+        # _do_handshake_locked, so the monkeypatch takes effect on
+        # the next client.
+        client = T2Client(config_dir=config_dir)
+        try:
+            with pytest.raises(T2SchemaVersionMismatchError) as excinfo:
+                client.memory.put(content="x", project="p", title="t")
+            assert excinfo.value.client_version == fake_version
+            # Daemon side may report real_version OR "0.0.0" when
+            # migrations deferred; either is fine — the mismatch only
+            # fires when daemon side is non-trivial AND disagrees.
+            assert excinfo.value.daemon_version != fake_version
+        finally:
+            client.close()
+
+
+# ---------------------------------------------------------------------------
+# RDR-120 P3b: T2Database direct-open no longer auto-migrates
+# ---------------------------------------------------------------------------
+
+
+class TestDirectOpenNoMigrate:
+    """Direct-open ``T2Database`` construction in production code paths
+    must NOT call ``apply_pending``. Verified by inspecting the
+    ``_upgrade_done`` registry after a default construction with the
+    test-suite's auto-migrate flag temporarily off.
+    """
+
+    def test_default_init_skips_apply_pending(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.db import t2 as _t2
+        from nexus.db.migrations import _upgrade_done
+        from nexus.db.t2 import T2Database
+
+        # Temporarily restore production semantics for this assertion.
+        monkeypatch.setattr(_t2, "_DEFAULT_RUN_MIGRATIONS", False)
+
+        db_path = tmp_path / "no-migrate.db"
+        try:
+            path_key = str(db_path.resolve())
+        except OSError:
+            path_key = str(db_path)
+        # Pre-condition: path not yet registered.
+        _upgrade_done.discard(path_key)
+
+        db = T2Database(db_path)
+        try:
+            # Post-condition: path STILL not registered — apply_pending
+            # was skipped entirely (the direct-open path no longer
+            # triggers it).
+            assert path_key not in _upgrade_done
+        finally:
+            db.close()
+
+    def test_run_migrations_true_invokes_apply_pending(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.db import t2 as _t2
+        from nexus.db.migrations import _upgrade_done
+        from nexus.db.t2 import T2Database
+
+        monkeypatch.setattr(_t2, "_DEFAULT_RUN_MIGRATIONS", False)
+
+        db_path = tmp_path / "yes-migrate.db"
+        try:
+            path_key = str(db_path.resolve())
+        except OSError:
+            path_key = str(db_path)
+        _upgrade_done.discard(path_key)
+
+        db = T2Database(db_path, run_migrations=True)
+        try:
+            assert path_key in _upgrade_done
+        finally:
+            db.close()

--- a/tests/daemon/test_t2_client.py
+++ b/tests/daemon/test_t2_client.py
@@ -278,8 +278,11 @@ class TestDirectOpenNoMigrate:
         from nexus.db.migrations import _upgrade_done
         from nexus.db.t2 import T2Database
 
-        # Temporarily restore production semantics for this assertion.
+        # Temporarily restore production semantics for this assertion:
+        # clear both the module global and the env-var fallback that
+        # conftest sets to propagate auto-migrate into subprocesses.
         monkeypatch.setattr(_t2, "_DEFAULT_RUN_MIGRATIONS", False)
+        monkeypatch.delenv(_t2._RUN_MIGRATIONS_ENV, raising=False)
 
         db_path = tmp_path / "no-migrate.db"
         try:

--- a/tests/daemon/test_t2_daemon_startup_invariant.py
+++ b/tests/daemon/test_t2_daemon_startup_invariant.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 P3b.B (nexus-0ax54): daemon-startup invariant test.
+
+Recast of the previously-skipped ``nexus-9eaz`` cross-process
+migration race test. The old framing asked "two processes race
+``apply_pending``, exactly one wins"; that race surface was structural
+to library mode and impossible to reproduce reliably on darwin GHA
+runners.
+
+P3b makes the T2 daemon the sole ``apply_pending`` caller (see
+``nexus-e9x4l``). The cross-process race is gone by construction —
+the daemon's ``_acquire_spawn_lock`` (fcntl ``LOCK_EX | LOCK_NB`` on
+``<config_dir>/t2_spawn.lock``) is the mutual-exclusion mechanism.
+
+This file pins the new invariant: **the daemon refuses a second start
+against the same path while one is running, and fails loud with a
+clear error message naming the spawn lock**. The companion concurrent-
+``apply_pending`` tests in ``tests/test_migrations.py`` exercise the
+in-process ``_upgrade_lock`` primitive that still guards intra-process
+construction; this file covers the cross-process invariant.
+"""
+from __future__ import annotations
+
+import asyncio
+import shutil
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    """Short config_dir under /tmp; macOS AF_UNIX paths cap at 104
+    chars and pytest's tmp_path already eats ~75 of those."""
+    cd = Path(tempfile.mkdtemp(prefix="nxt2inv-", dir="/tmp"))
+    yield cd
+    shutil.rmtree(cd, ignore_errors=True)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "memory.db"
+
+
+def _run_daemon_in_thread(daemon, ready, stop) -> None:
+    async def _main() -> None:
+        await daemon.start()
+        ready.set()
+        while not stop.is_set():
+            await asyncio.sleep(0.05)
+        await daemon.stop()
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_main())
+    finally:
+        loop.close()
+
+
+class TestDaemonRefusesSecondStartAgainstSamePath:
+    """The nexus-9eaz invariant in its P3b form."""
+
+    def test_second_start_same_config_dir_same_db_path_fails_loud(
+        self, config_dir: Path, db_path: Path,
+    ) -> None:
+        """Two daemons with the SAME config_dir AND SAME db_path.
+        The second start must raise T2DaemonError; the error message
+        must name the spawn lock so an operator can diagnose without
+        reading code.
+        """
+        from nexus.daemon.t2_daemon import T2Daemon, T2DaemonError
+
+        first = T2Daemon(config_dir=config_dir, db_path=db_path)
+        ready = threading.Event()
+        stop = threading.Event()
+        thread = threading.Thread(
+            target=_run_daemon_in_thread, args=(first, ready, stop),
+        )
+        thread.start()
+        try:
+            assert ready.wait(timeout=10.0), "first daemon did not start"
+
+            second = T2Daemon(config_dir=config_dir, db_path=db_path)
+            with pytest.raises(T2DaemonError) as excinfo:
+                asyncio.run(second.start())
+            msg = str(excinfo.value)
+            assert "spawn lock" in msg, (
+                f"expected error to name the spawn lock; got {msg!r}"
+            )
+            assert "refusing to start a second instance" in msg
+        finally:
+            stop.set()
+            thread.join(timeout=10.0)
+            assert not thread.is_alive(), "first daemon did not stop"
+
+    def test_second_start_succeeds_after_first_stops(
+        self, config_dir: Path, db_path: Path,
+    ) -> None:
+        """The spawn lock is released on clean stop; a fresh start
+        against the same path after the first daemon stops must
+        succeed (the invariant is mutual-exclusion *while running*,
+        not permanent exclusion).
+        """
+        from nexus.daemon.t2_daemon import T2Daemon
+
+        first = T2Daemon(config_dir=config_dir, db_path=db_path)
+        ready1 = threading.Event()
+        stop1 = threading.Event()
+        t1 = threading.Thread(
+            target=_run_daemon_in_thread, args=(first, ready1, stop1),
+        )
+        t1.start()
+        assert ready1.wait(timeout=10.0)
+        stop1.set()
+        t1.join(timeout=10.0)
+        assert not t1.is_alive()
+
+        # Spawn lock should be released — second start succeeds.
+        second = T2Daemon(config_dir=config_dir, db_path=db_path)
+        ready2 = threading.Event()
+        stop2 = threading.Event()
+        t2 = threading.Thread(
+            target=_run_daemon_in_thread, args=(second, ready2, stop2),
+        )
+        t2.start()
+        try:
+            assert ready2.wait(timeout=10.0), (
+                "second daemon failed to start after first stopped — "
+                "spawn lock leak"
+            )
+        finally:
+            stop2.set()
+            t2.join(timeout=10.0)
+
+    def test_spawn_lock_error_includes_lock_path(
+        self, config_dir: Path, db_path: Path,
+    ) -> None:
+        """Operator-debuggability: the failure message must include
+        the spawn-lock file path so the diagnostic is self-contained.
+        """
+        from nexus.daemon.t2_daemon import (
+            T2Daemon, T2DaemonError, _SPAWN_LOCK_FILE,
+        )
+
+        first = T2Daemon(config_dir=config_dir, db_path=db_path)
+        ready = threading.Event()
+        stop = threading.Event()
+        thread = threading.Thread(
+            target=_run_daemon_in_thread, args=(first, ready, stop),
+        )
+        thread.start()
+        try:
+            assert ready.wait(timeout=10.0)
+
+            second = T2Daemon(config_dir=config_dir, db_path=db_path)
+            with pytest.raises(T2DaemonError) as excinfo:
+                asyncio.run(second.start())
+            expected_path = str(config_dir / _SPAWN_LOCK_FILE)
+            assert expected_path in str(excinfo.value), (
+                f"expected {expected_path!r} in error message; "
+                f"got {str(excinfo.value)!r}"
+            )
+        finally:
+            stop.set()
+            thread.join(timeout=10.0)

--- a/tests/daemon/test_t2_daemon_startup_invariant.py
+++ b/tests/daemon/test_t2_daemon_startup_invariant.py
@@ -133,6 +133,48 @@ class TestDaemonRefusesSecondStartAgainstSamePath:
             stop2.set()
             t2.join(timeout=10.0)
 
+    def test_second_start_different_config_dir_same_db_path_fails_loud(
+        self, db_path: Path,
+    ) -> None:
+        """Cross-config_dir collision on the same data file: the
+        db_path-scoped spawn lock (RDR-120 P3b code-review item 2)
+        must prevent two daemons against the same db_path from
+        running concurrently even when started with different
+        config_dirs.
+        """
+        import shutil
+        import tempfile
+
+        from nexus.daemon.t2_daemon import T2Daemon, T2DaemonError
+
+        cd1 = Path(tempfile.mkdtemp(prefix="nxt2inv-a-", dir="/tmp"))
+        cd2 = Path(tempfile.mkdtemp(prefix="nxt2inv-b-", dir="/tmp"))
+        try:
+            first = T2Daemon(config_dir=cd1, db_path=db_path)
+            ready = threading.Event()
+            stop = threading.Event()
+            thread = threading.Thread(
+                target=_run_daemon_in_thread, args=(first, ready, stop),
+            )
+            thread.start()
+            try:
+                assert ready.wait(timeout=10.0), "first daemon did not start"
+
+                second = T2Daemon(config_dir=cd2, db_path=db_path)
+                with pytest.raises(T2DaemonError) as excinfo:
+                    asyncio.run(second.start())
+                msg = str(excinfo.value)
+                assert "db_path spawn lock" in msg, (
+                    f"expected db_path-scoped lock error; got {msg!r}"
+                )
+                assert "same data file" in msg
+            finally:
+                stop.set()
+                thread.join(timeout=10.0)
+        finally:
+            shutil.rmtree(cd1, ignore_errors=True)
+            shutil.rmtree(cd2, ignore_errors=True)
+
     def test_spawn_lock_error_includes_lock_path(
         self, config_dir: Path, db_path: Path,
     ) -> None:

--- a/tests/test_aspect_drain_protocol.py
+++ b/tests/test_aspect_drain_protocol.py
@@ -139,7 +139,6 @@ class TestIsDrained:
 
 
 class TestStopSignal:
-    @_skip_on_gha_flake
     def test_stop_claiming_on_running_worker_causes_exit(
         self, queue_path: Path, locks_dir: Path
     ) -> None:

--- a/tests/test_aspect_drain_protocol.py
+++ b/tests/test_aspect_drain_protocol.py
@@ -27,24 +27,9 @@ import pytest
 from nexus.db.t2 import T2Database
 
 
-# nexus-9eaz family: a small set of threading/concurrency tests pass
-# consistently in isolation and on local machines but fail intermittently
-# on GitHub Actions Ubuntu runners under shared-runner pressure. The race
-# is correctly diagnosed as a CI infrastructure artefact (see nexus-9eaz
-# bead notes for the full dose-response evidence: pass at 0-3 prior test
-# files, fail at 6+). The lock and stop-signal semantics are verified
-# correct under load locally. Standing mitigation: skip on GHA by default;
-# opt in via NEXUS_RUN_FLAKY_TESTS=1 to run the test in CI (used by the
-# isolation-runner race-probe pattern).
-_GHA_FLAKE_SKIP_REASON = (
-    "GHA-runner pressure flake (nexus-9eaz family). Passes locally and "
-    "in isolation; opt in with NEXUS_RUN_FLAKY_TESTS=1."
-)
-_skip_on_gha_flake = pytest.mark.skipif(
-    os.environ.get("GITHUB_ACTIONS") == "true"
-    and not os.environ.get("NEXUS_RUN_FLAKY_TESTS"),
-    reason=_GHA_FLAKE_SKIP_REASON,
-)
+# nexus-9eaz family flake-skip helper retired 2026-05-22: RDR-120 P3b
+# made the daemon the sole apply_pending caller, removing the
+# cross-process migration race surface these tests were guarding.
 
 
 # -- Shared fixtures ----------------------------------------------------------

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -669,7 +669,6 @@ class TestApplyPending:
         assert schema1 == schema2
         conn.close()
 
-    @_skip_on_gha_flake
     def test_concurrent_bootstrap(self, tmp_path: Path) -> None:
         """Two threads calling apply_pending simultaneously — no crash, version seeded once."""
         from nexus.db.migrations import apply_pending
@@ -710,7 +709,6 @@ class TestApplyPending:
         assert rows[0][0] == "4.1.2"
         conn.close()
 
-    @_skip_on_gha_flake
     def test_concurrent_apply_pending_runs_once(self, tmp_path: Path) -> None:
         """_upgrade_lock prevents concurrent apply_pending double-execution."""
         from unittest.mock import patch as _patch
@@ -906,7 +904,6 @@ class TestT2DatabaseIntegration:
         assert result["content"] == "content"
         store.close()
 
-    @_skip_on_gha_flake
     def test_concurrent_t2database_construction(self, tmp_path: Path) -> None:
         """Two threads constructing T2Database on same path — no crash."""
         from nexus.db.t2 import T2Database

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -7,7 +7,6 @@ They will fail until migrations.py is implemented (nexus-6cn).
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 import threading
 from pathlib import Path
@@ -16,19 +15,9 @@ from unittest.mock import MagicMock
 import pytest
 
 
-# nexus-9eaz family: concurrent-migration tests pass in isolation and
-# locally but fail intermittently on GHA Ubuntu runners under shared-
-# runner pressure. CI infrastructure artefact, not a real code bug
-# (dose-response: pass at 0-3 prior files, fail at 6+). Skip on GHA;
-# opt in with NEXUS_RUN_FLAKY_TESTS=1.
-_skip_on_gha_flake = pytest.mark.skipif(
-    os.environ.get("GITHUB_ACTIONS") == "true"
-    and not os.environ.get("NEXUS_RUN_FLAKY_TESTS"),
-    reason=(
-        "GHA-runner pressure flake (nexus-9eaz family). Passes locally "
-        "and in isolation; opt in with NEXUS_RUN_FLAKY_TESTS=1."
-    ),
-)
+# nexus-9eaz family flake-skip helper retired 2026-05-22: RDR-120 P3b
+# made the daemon the sole apply_pending caller, removing the
+# cross-process migration race surface these tests were guarding.
 
 
 # ── _parse_version tests ────────────────────────────────────────────────────

--- a/tests/test_t2.py
+++ b/tests/test_t2.py
@@ -11,19 +11,9 @@ from nexus.db.t2 import T2Database, _sanitize_fts5
 from nexus.db.t2.plan_library import PlanLibrary
 
 
-# nexus-9eaz family: threading/migration-guard tests pass in isolation
-# and locally but fail intermittently on GHA Ubuntu runners under
-# shared-runner pressure. The race is a CI infrastructure artefact
-# (dose-response: pass at 0-3 prior files, fail at 6+), not a real
-# code bug. Skip on GHA by default; opt in with NEXUS_RUN_FLAKY_TESTS=1.
-_skip_on_gha_flake = pytest.mark.skipif(
-    os.environ.get("GITHUB_ACTIONS") == "true"
-    and not os.environ.get("NEXUS_RUN_FLAKY_TESTS"),
-    reason=(
-        "GHA-runner pressure flake (nexus-9eaz family). Passes locally "
-        "and in isolation; opt in with NEXUS_RUN_FLAKY_TESTS=1."
-    ),
-)
+# nexus-9eaz family flake-skip helper retired 2026-05-22: RDR-120 P3b
+# made the daemon the sole apply_pending caller, removing the
+# cross-process migration race surface these tests were guarding.
 
 _OLD_FTS_SCHEMA = """PRAGMA journal_mode=WAL;
 CREATE TABLE IF NOT EXISTS memory (

--- a/tests/test_t2.py
+++ b/tests/test_t2.py
@@ -620,7 +620,6 @@ def test_expire_also_purges_relevance_log(db: T2Database) -> None:
     assert db.get_relevance_log() == []
 
 
-@_skip_on_gha_flake
 def test_migration_guard_sequential_construction(tmp_path: Path, monkeypatch) -> None:
     """Two T2Database instances on the same path do not re-run migrations sequentially."""
     from nexus.db.t2 import plan_library
@@ -717,7 +716,6 @@ def test_migration_guard_path_normalization(tmp_path: Path, monkeypatch) -> None
     )
 
 
-@_skip_on_gha_flake
 def test_migration_guard_concurrent_threads(tmp_path: Path, monkeypatch) -> None:
     """10 threads constructing T2Database on the same path run migrations exactly once.
 


### PR DESCRIPTION
## Summary

RDR-120 P3b.A. Removes ``apply_pending`` from the T2Database direct-open path; daemon is the sole substrate-owner of schema migrations.

- ``T2Database.__init__`` defaults to skipping migrations (``_DEFAULT_RUN_MIGRATIONS=False``); conftest flips ON for the test suite.
- ``T2Database.bootstrap_schema(path)`` is the explicit entry point for daemon startup, ``nx upgrade``, and tests.
- ``T2Daemon.start()`` constructs ``T2Database(path, run_migrations=True)``; daemon remains the only ``apply_pending`` caller.
- New ``database.hello`` op + lazy T2Client handshake: client carries ``expected_t2_schema_version`` (derived from ``conexus`` package version), daemon reports its stored ``_nexus_version``, ``T2SchemaVersionMismatchError`` raised on non-trivial divergence. Daemon-side ``"0.0.0"`` (deferred migrations) downgrades to a warning.

## Validation regime

- Stress harness (``tests/stress/test_t2_daemon_stress.py`` -m stress, 12 scenarios): all green.
- Daemon + migrations + post-document-hooks + relevance-log + plan + upgrade + doctor + store-put slices: all green.
- New tests: ``TestSchemaHandshake`` (round-trip, once-per-connection, fail-loud mismatch), ``TestDirectOpenNoMigrate`` (default skip; ``run_migrations=True`` invokes).

## Closes

- Closes nexus-e9x4l
- Blocks nexus-0ax54 (P3b.B test recast)
- Blocks nexus-b9lox (P3b phase-review-gate)