### PR TITLE
feat(rdr-120): P4.A T2 cutover (nexus-2ngox)

### DIFF
--- a/src/nexus/_session_end_launcher.py
+++ b/src/nexus/_session_end_launcher.py
@@ -157,7 +157,7 @@ def _print_tier_status_summary() -> None:
         db_path = default_db_path()
         if not Path(db_path).exists():
             return
-        conn = sqlite3.connect(str(db_path))
+        conn = sqlite3.connect(str(db_path))  # epsilon-allow: session-end best-effort observation — must not block on daemon availability; read-only tier_writes check
         try:
             has_table = conn.execute(
                 "SELECT name FROM sqlite_master "

--- a/src/nexus/collection_audit.py
+++ b/src/nexus/collection_audit.py
@@ -367,7 +367,7 @@ def _open_catalog_conn() -> sqlite3.Connection | None:
     path = catalog_path()
     if not Catalog.is_initialized(path):
         return None
-    return sqlite3.connect(str(path / ".catalog.db"))
+    return sqlite3.connect(str(path / ".catalog.db"))  # epsilon-allow: catalog substrate (.catalog.db); P5 catalog-collapse handles cutover
 
 
 # ── Section 5: chash_index coverage (RDR-087 Phase 4.6 / nexus-c2op) ────────

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -5379,7 +5379,7 @@ def _run_replay_equality() -> dict:
     # mcp_infra.manifest_write_batch_hook.
     DOCUMENTS_EXCLUDE = ["chunk_count"]
     live_uri = f"file:{live_db_path}?mode=ro"
-    with closing(sqlite3.connect(live_uri, uri=True)) as live_conn:
+    with closing(sqlite3.connect(live_uri, uri=True)) as live_conn:  # epsilon-allow: catalog substrate live-vs-projected replay check; P5 catalog-collapse handles cutover
         live_snap = {
             "owners": _snapshot_table(live_conn, "owners"),
             "documents": _snapshot_table(
@@ -5411,7 +5411,7 @@ def _run_replay_equality() -> dict:
         finally:
             proj_db.close()
 
-        with closing(sqlite3.connect(str(projected_path))) as proj_conn:
+        with closing(sqlite3.connect(str(projected_path))) as proj_conn:  # epsilon-allow: catalog substrate projection snapshot; P5 catalog-collapse handles cutover
             projected_snap = {
                 "owners": _snapshot_table(proj_conn, "owners"),
                 "documents": _snapshot_table(

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -53,7 +53,7 @@ def _run_check_schema() -> None:
         click.echo("T2 database not found — nothing to check.")
         return
 
-    conn = sqlite3.connect(str(db_path))
+    conn = sqlite3.connect(str(db_path))  # epsilon-allow: nx doctor diagnostic — must operate when daemon offline; read-only PRAGMA/SELECT safe under WAL
     conn.execute("PRAGMA busy_timeout=5000")
     # CLI review: match the other T2 connection defaults. Opening without
     # WAL here caused immediate lock errors when a concurrent MCP tool
@@ -509,7 +509,7 @@ def _run_check_plan_library() -> None:
 
     # Context manager guards against a raise inside the count loop
     # leaking the connection (RDR-092 code-review S-3).
-    conn = sqlite3.connect(str(db_path))
+    conn = sqlite3.connect(str(db_path))  # epsilon-allow: nx doctor diagnostic — must operate when daemon offline; read-only counts safe under WAL
     try:
         conn.execute("PRAGMA busy_timeout=5000")
         conn.execute("PRAGMA journal_mode=WAL")
@@ -612,7 +612,7 @@ def _run_check_aspect_queue() -> None:
         click.echo("aspect_extraction_queue: T2 database not found.")
         return
 
-    conn = _sqlite3.connect(str(db_path))
+    conn = _sqlite3.connect(str(db_path))  # epsilon-allow: nx doctor diagnostic — must operate when daemon offline; read-only aspect-queue inspection
     try:
         # Confirm the table exists (pre-RDR-089 dbs won't have it).
         has_table = conn.execute(
@@ -717,7 +717,7 @@ def _run_check_tier_discipline() -> None:
         click.echo(f"  T2 database not found at {db_path} (skip).")
         return
 
-    conn = _sqlite3.connect(str(db_path))
+    conn = _sqlite3.connect(str(db_path))  # epsilon-allow: nx doctor diagnostic — must operate when daemon offline; read-only tier_writes inspection
     try:
         has_table = conn.execute(
             "SELECT name FROM sqlite_master "
@@ -1851,7 +1851,7 @@ def _run_check_taxonomy() -> None:
         click.echo("T2 database not found — nothing to check.")
         return
 
-    conn = sqlite3.connect(str(db_path))
+    conn = sqlite3.connect(str(db_path))  # epsilon-allow: nx doctor diagnostic — must operate when daemon offline; read-only schema inspection
     conn.execute("PRAGMA busy_timeout=5000")
     conn.execute("PRAGMA journal_mode=WAL")
 

--- a/src/nexus/commands/plan.py
+++ b/src/nexus/commands/plan.py
@@ -77,7 +77,13 @@ def _open_plans_db():
     if not db_path.exists():
         click.echo(f"T2 database not found at {db_path}; nothing to do.")
         return None
-    conn = sqlite3.connect(str(db_path))
+    # epsilon-allow: nx repair plans — ad-hoc operator-invoked
+    # backfill / migration-helper-style maintenance against the plans
+    # store. Bound to the same SQLite file the daemon serves; the
+    # daemon-RPC equivalent would require exposing every legacy
+    # repair shape, which the RDR-120 §Out of scope moratorium
+    # forbids ("migration helpers beyond apply_pending").
+    conn = sqlite3.connect(str(db_path))  # epsilon-allow: nx repair plans operator-invoked maintenance (moratorium on new migration helpers)
     conn.execute("PRAGMA busy_timeout=5000")
     conn.execute("PRAGMA journal_mode=WAL")
     return conn

--- a/src/nexus/commands/tier_status.py
+++ b/src/nexus/commands/tier_status.py
@@ -169,7 +169,7 @@ def tier_status_cmd(
                 )
             raise click.exceptions.Exit(1)
 
-    conn = sqlite3.connect(str(db_path))
+    conn = sqlite3.connect(str(db_path))  # epsilon-allow: nx tier-status diagnostic — must operate when daemon offline; read-only tier_writes count
     try:
         # Migration is lazy in the recorder path; if no writes have ever
         # been recorded the table won't exist. Treat as zero.

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -69,7 +69,12 @@ def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool =
         return
 
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    # epsilon-allow: nx upgrade is the chicken-and-egg substrate
+    # bootstrap path — schema migration cannot route through the
+    # daemon when the daemon's startup requires the schema to be
+    # migrated. Operator coordinates by stopping the daemon, running
+    # nx upgrade, restarting the daemon.
+    conn = sqlite3.connect(str(db_path), check_same_thread=False)  # epsilon-allow: nx upgrade chicken-and-egg substrate bootstrap (cannot route through daemon)
     conn.execute("PRAGMA busy_timeout=5000")
     conn.execute("PRAGMA journal_mode=WAL")
 

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -425,10 +425,9 @@ def storage_mode() -> str:
 
     RDR-120 single source of truth for the storage backend mode flag:
 
-    - unset / empty / whitespace -> ``"direct"`` (default)
-    - ``"direct"`` (any case) -> ``"direct"``
-    - ``"daemon"`` (any case) -> ``"daemon"`` (valid for T3 since
-      P2 cutover; T2 still routes library-mode until P4)
+    - unset / empty / whitespace -> ``"daemon"`` (default since P4)
+    - ``"direct"`` (any case) -> ``"direct"`` (retained as debug fallback)
+    - ``"daemon"`` (any case) -> ``"daemon"``
     - anything else -> raises ``StorageModeError`` naming the bad
       value and listing :data:`VALID_STORAGE_MODES`
 
@@ -440,13 +439,14 @@ def storage_mode() -> str:
       local mode. Cloud mode is unaffected (chromadb's CloudClient
       is already HTTP-served; there is no local daemon to route
       through).
-    - P4: accepted for T2 reads/writes as well; becomes the default
-      for new installs.
+    - P4 (4.36+): accepted for T2 reads/writes; **default for new
+      installs**. ``direct`` remains a documented debug fallback for
+      operators who explicitly opt out.
     """
     raw = os.environ.get("NX_STORAGE_MODE", "")
     normalized = raw.strip().lower()
     if not normalized:
-        return "direct"
+        return "daemon"
     if normalized == "direct":
         return "direct"
     if normalized == "daemon":

--- a/src/nexus/console/routes/health.py
+++ b/src/nexus/console/routes/health.py
@@ -128,7 +128,7 @@ def _collect_aspect_queue_data() -> dict[str, Any]:
         return {"present": False}
 
     try:
-        conn = _sqlite3.connect(str(db_path))
+        conn = _sqlite3.connect(str(db_path))  # epsilon-allow: console health probe — must operate when daemon offline; read-only schema-presence check
     except _sqlite3.Error:
         return {"present": False}
 

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -725,7 +725,7 @@ def _check_t2_integrity() -> list[HealthResult]:
         return [HealthResult(label="T2 integrity", ok=True, detail="not created yet")]
 
     try:
-        conn = sqlite3.connect(str(db_path))
+        conn = sqlite3.connect(str(db_path))  # epsilon-allow: health PRAGMA integrity_check diagnostic — must operate when daemon offline; read-only
         try:
             rows = conn.execute("PRAGMA integrity_check").fetchall()
             pragma_ok = len(rows) == 1 and rows[0][0] == "ok"

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -603,7 +603,6 @@ def check_version_compatibility() -> None:
     Never blocks startup — both checks log warnings only.
     """
     import json
-    import sqlite3
     from pathlib import Path
 
     import structlog
@@ -616,34 +615,47 @@ def check_version_compatibility() -> None:
         cli_ver = _pkg_version("conexus")
 
         # ── (1) CLI ↔ T2 schema drift ────────────────────────────────────
+        # RDR-120 P4: routed through T2Client when the daemon is reachable;
+        # silently skipped when it isn't (best-effort drift warning, not a
+        # gate). The daemon's ``database.hello`` op surfaces its stored
+        # _nexus_version row.
         db_path = default_db_path()
+        stored_ver: str | None = None
         if db_path.exists():
-            conn = sqlite3.connect(str(db_path))
             try:
-                row = conn.execute(
-                    "SELECT value FROM _nexus_version WHERE key='cli_version'"
-                ).fetchone()
-            except sqlite3.OperationalError:
-                row = None  # table doesn't exist yet — fresh install
-            finally:
-                conn.close()
-            if row is not None:
-                stored_ver = row[0]
-                cli_t = _parse_version(cli_ver)
-                stored_t = _parse_version(stored_ver)
-                # Warn on minor or major divergence, not patch.
-                # Tuple slicing is safe for short tuples — (4,)[:2] == (4,).
-                if cli_t[:2] != stored_t[:2]:
-                    if cli_t > stored_t:
-                        hint = "run 'nx upgrade' to apply pending migrations"
-                    else:
-                        hint = "DB was upgraded by a newer CLI version"
-                    log.warning(
-                        "version_mismatch",
-                        cli_version=cli_ver,
-                        stored_version=stored_ver,
-                        hint=hint,
-                    )
+                from nexus.daemon.t2_client import (
+                    T2DaemonNotReachableError,
+                    make_t2_client,
+                )
+
+                client = make_t2_client()
+                try:
+                    hello = client.database.hello()
+                    raw = (hello or {}).get("daemon_schema_version") or ""
+                    stored_ver = raw if raw and raw != "0.0.0" else None
+                finally:
+                    client.close()
+            except (T2DaemonNotReachableError, Exception):
+                # Daemon unreachable or RPC failed — drift check is
+                # best-effort. Operator can run `nx doctor` for the
+                # full diagnostic.
+                stored_ver = None
+        if stored_ver is not None:
+            cli_t = _parse_version(cli_ver)
+            stored_t = _parse_version(stored_ver)
+            # Warn on minor or major divergence, not patch.
+            # Tuple slicing is safe for short tuples — (4,)[:2] == (4,).
+            if cli_t[:2] != stored_t[:2]:
+                if cli_t > stored_t:
+                    hint = "run 'nx upgrade' to apply pending migrations"
+                else:
+                    hint = "DB was upgraded by a newer CLI version"
+                log.warning(
+                    "version_mismatch",
+                    cli_version=cli_ver,
+                    stored_version=stored_ver,
+                    hint=hint,
+                )
 
         # ── (2) Plugin ↔ CLI version drift ──────────────────────────────
         plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")

--- a/src/nexus/pipeline_buffer.py
+++ b/src/nexus/pipeline_buffer.py
@@ -99,7 +99,7 @@ class PipelineDB:
         """Return (or create) the per-thread connection."""
         conn: sqlite3.Connection | None = getattr(self._local, "conn", None)
         if conn is None:
-            conn = sqlite3.connect(str(self._path))
+            conn = sqlite3.connect(str(self._path))  # epsilon-allow: pipeline_buffer owns its own substrate (pipeline.db); distinct from T2 nexus.db — not in scope for the T2 daemon
             conn.execute("PRAGMA journal_mode=WAL")
             conn.row_factory = sqlite3.Row
             self._local.conn = conn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,6 +171,17 @@ def _restore_structlog_after_test():
 
 
 @pytest.fixture(autouse=True)
+def _pin_storage_mode_direct(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RDR-120 P4 (nexus-2ngox): production default is ``daemon`` but
+    the test suite has hundreds of T3 fixtures that expect direct-mode
+    semantics (no daemon spawned). Pin every test to ``direct`` by
+    default; daemon-mode tests (``tests/daemon/``) override via their
+    own fixtures that spin up a real daemon and set the env explicitly.
+    """
+    monkeypatch.setenv("NX_STORAGE_MODE", "direct")
+
+
+@pytest.fixture(autouse=True)
 def _isolate_t1_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Force tests onto the explicit-isolation T1 path.
 

--- a/tests/test_phase5_integration.py
+++ b/tests/test_phase5_integration.py
@@ -106,25 +106,35 @@ class TestMcpVersionCheck:
             check_version_compatibility()  # patch only — no warning
 
     def test_minor_version_divergence_warns(self, tmp_path: Path) -> None:
-        """Minor version mismatch should emit a structured warning."""
-        import structlog
+        """Minor version mismatch should emit a structured warning.
 
+        RDR-120 P4 (nexus-2ngox): the schema-version read routes
+        through ``T2Client.database.hello`` rather than a direct
+        sqlite open. Stub the daemon round trip with a fake client
+        whose ``hello`` reports the divergent version.
+        """
         from nexus.mcp_infra import check_version_compatibility
 
         db_path = tmp_path / "memory.db"
-        conn = sqlite3.connect(str(db_path))
-        conn.execute(
-            "CREATE TABLE _nexus_version (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
-        )
-        conn.execute(
-            "INSERT INTO _nexus_version VALUES ('cli_version', '4.1.2')"
-        )
-        conn.commit()
-        conn.close()
+        db_path.touch()  # check_version_compatibility gates on db_path.exists()
+
+        class _FakeStore:
+            def hello(self):
+                return {"daemon_schema_version": "4.1.2"}
+
+        class _FakeClient:
+            database = _FakeStore()
+
+            def close(self) -> None:
+                pass
 
         with (
             patch("nexus.mcp_infra.default_db_path", return_value=db_path),
             patch("importlib.metadata.version", return_value="4.2.0"),
+            patch(
+                "nexus.daemon.t2_client.make_t2_client",
+                return_value=_FakeClient(),
+            ),
             patch("structlog.get_logger") as mock_get_logger,
         ):
             mock_log = mock_get_logger.return_value

--- a/tests/test_storage_boundary_lint.py
+++ b/tests/test_storage_boundary_lint.py
@@ -43,17 +43,22 @@ def _check(extra_files=None, allowlist_prefixes=None):
 # ---------------------------------------------------------------------------
 
 
-def test_lint_reports_baseline_inventory():
-    """Against current main, the lint identifies the existing direct opens."""
+def test_lint_reports_zero_violations_after_p4_cutover():
+    """RDR-120 P4 (nexus-2ngox): after the T2 cutover, the lint reports
+    zero violations. Pre-P4 there were 16 direct opens outside ``db/``
+    and ``catalog/`` (baseline captured by P0); P4 migrated mcp_infra
+    to T2Client and epsilon-allowed the remaining operator/debug
+    paths with documented reasons. The catalog-allowlist count stays
+    at the P3b value of 2 (catalog substrate moves at P5).
+    """
     result = _check()
-    # 27 SQLite + 8 chromadb per the A5-refresh audit. The lint with the
-    # default allowlist (db/ + catalog/) should leave a known non-empty
-    # set of migration targets; that's the baseline P0 captures.
-    assert result.total_violations > 0
-    # Some of the well-known migration targets must show up.
-    files = {v.file for v in result.violations}
-    assert any("commands/doctor.py" in f for f in files)
-    assert any("health.py" in f for f in files)
+    assert result.total_violations == 0, (
+        f"expected zero violations after P4 cutover; got: "
+        f"{[(v.file, v.line, v.symbol) for v in result.violations]}"
+    )
+    # Catalog substrate is deferred to P5; allowlist count unchanged
+    # from the P3b gate recorded value.
+    assert result.catalog_allowlist_count == 2
 
 
 def test_db_directory_is_allowlisted_by_default():

--- a/tests/test_storage_mode.py
+++ b/tests/test_storage_mode.py
@@ -20,12 +20,15 @@ import os
 import pytest
 
 
-def test_default_is_direct(monkeypatch):
-    """Unset NX_STORAGE_MODE defaults to `direct`."""
+def test_default_is_daemon(monkeypatch):
+    """RDR-120 P4 (nexus-2ngox): unset NX_STORAGE_MODE defaults to
+    ``daemon``. ``direct`` is retained as a debug fallback that
+    operators opt into explicitly.
+    """
     monkeypatch.delenv("NX_STORAGE_MODE", raising=False)
     from nexus.config import storage_mode
 
-    assert storage_mode() == "direct"
+    assert storage_mode() == "daemon"
 
 
 def test_direct_is_accepted(monkeypatch):
@@ -71,17 +74,18 @@ def test_unknown_value_lists_valid_options(monkeypatch):
 
 
 def test_empty_string_treated_as_unset(monkeypatch):
+    """Empty / whitespace-only resolves to the default (``daemon`` since P4)."""
     monkeypatch.setenv("NX_STORAGE_MODE", "")
     from nexus.config import storage_mode
 
-    assert storage_mode() == "direct"
+    assert storage_mode() == "daemon"
 
 
 def test_whitespace_only_treated_as_unset(monkeypatch):
     monkeypatch.setenv("NX_STORAGE_MODE", "   ")
     from nexus.config import storage_mode
 
-    assert storage_mode() == "direct"
+    assert storage_mode() == "daemon"
 
 
 def test_case_normalization(monkeypatch):


### PR DESCRIPTION
## Summary

RDR-120 P4.A. Pragmatic interpretation: route through T2Client where clean, ``# epsilon-allow:`` with documented reason for legitimate operator/debug paths that must work when the daemon is offline.

- **Migrated** (1 site): ``src/nexus/mcp_infra.py`` schema-drift warning routes through ``T2Client.database.hello``; silently skips when daemon unreachable (best-effort).
- **Epsilon-allowed** (13 sites) with reasons:
  - ``nx upgrade`` (chicken-and-egg substrate bootstrap)
  - ``nx doctor`` ×5 (must operate when daemon offline; read-only)
  - ``nx repair plans`` (moratorium on new migration helpers)
  - ``nx tier-status`` (diagnostic; daemon-offline)
  - ``_session_end_launcher`` (best-effort)
  - ``health.py`` PRAGMA integrity_check (daemon-offline diagnostic)
  - ``console/routes/health.py`` (probe; daemon-offline)
  - ``pipeline_buffer.py`` (own substrate, distinct from T2)
  - ``collection_audit.py`` + ``commands/catalog.py`` ×2 (catalog substrate; P5)
- **Mode flip**: ``storage_mode()`` default is now ``"daemon"``. ``direct`` retained as documented debug fallback. Test conftest pins ``NX_STORAGE_MODE=direct`` for the suite; ``tests/daemon/`` opts back in via its own fixtures.

## Validation

- ``uv run nx doctor --check-storage-boundary --phase 4``: **violations=0**, catalog-allowlist=2.
- Full unit suite: **7518 passed** (excluding integration + stress).
- Stress harness: **12/12 scenarios green**.
- Updated tests: storage_mode default assertions, storage_boundary_lint post-cutover baseline, phase5 version-mismatch test (stubs ``make_t2_client``).

## Closes

- Closes nexus-2ngox
- Unblocks nexus-weqhg (P4 phase-review-gate)