### PR TITLE
feat(rdr-120): P5.A.1 T2 catalog store skeleton (nexus-9zmpl)

### DIFF
--- a/src/nexus/daemon/t2_client.py
+++ b/src/nexus/daemon/t2_client.py
@@ -243,10 +243,11 @@ class T2Client:
         self._handshake_done = False
         # Stores enumerated by the daemon dispatch builder. Public
         # attribute names mirror T2Database for surface parity.
-        # Seven stores at P3a; catalog joins at P5.
+        # Eight stores as of RDR-120 P5.A.1 (nexus-9zmpl):
+        # seven shared-nexus.db stores + catalog (its own .catalog.db).
         for store_name in (
             "memory", "plans", "chash_index", "taxonomy", "telemetry",
-            "document_aspects", "aspect_queue", "database",
+            "document_aspects", "aspect_queue", "catalog", "database",
         ):
             setattr(self, store_name, _StoreProxy(self, store_name))
 

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -269,10 +269,9 @@ async def read_frame(reader: asyncio.StreamReader) -> dict[str, Any]:
 #: table. Order matters: client expectations follow the documented
 #: store list in src/nexus/db/t2/__init__.py.
 #:
-#: Seven stores at P3a. The ``catalog`` eighth store is added at P5
-#: (catalog collapse into T2); the entry is intentionally absent here
-#: so the dispatch table reflects what the daemon can actually serve
-#: today.
+#: Eight stores as of RDR-120 P5.A.1 (nexus-9zmpl): the seven shared-
+#: nexus.db stores plus the catalog store (which uniquely opens
+#: ``.catalog.db`` under ``catalog_path()``).
 _T2_STORE_ATTRS: tuple[str, ...] = (
     "memory",
     "plans",
@@ -281,6 +280,7 @@ _T2_STORE_ATTRS: tuple[str, ...] = (
     "telemetry",
     "document_aspects",
     "aspect_queue",
+    "catalog",
 )
 
 #: Top-level T2Database methods exposed under the "database" pseudo-store.
@@ -294,15 +294,25 @@ _T2_DATABASE_METHODS: tuple[str, ...] = ("rename_collection_cascade", "hello")
 _RPC_DENY_METHODS: frozenset[str] = frozenset({"close"})
 
 #: Per-op denylist (qualified ``<store>.<method>``). Methods whose
-#: signature accepts a typed dataclass instance can't round-trip JSON
-#: until a typed-arg reconstructor lands. (The catalog @contextmanager
-#: methods are not on this list yet because the catalog isn't in
-#: :data:`_T2_STORE_ATTRS` until P5; re-add when the eighth store
-#: lands.)
+#: signature or return type don't round-trip framed JSON (typed
+#: dataclasses, context managers, raw ``sqlite3.Cursor`` handles).
 _RPC_DENY_OPS: frozenset[str] = frozenset({
     "document_aspects.upsert",
     "document_aspects.get",
     "document_aspects.get_by_doc_id",
+    # RDR-120 P5.A.1 (nexus-9zmpl) — catalog op denylist:
+    # ``execute`` returns a live ``sqlite3.Cursor`` that cannot be
+    # serialised across the framed-JSON boundary. ``transaction`` and
+    # ``bulk_load_documents`` are ``@contextmanager`` generators that
+    # likewise have no JSON shape — clients that need them must hold
+    # a local CatalogStore instance (the P5.A.2 shim will route
+    # local-mode catalog operations directly without going over RPC).
+    "catalog.execute",
+    "catalog.transaction",
+    "catalog.bulk_load_documents",
+    # ``rebuild`` is event-replay scoped to the catalog process tree
+    # and not suitable for RPC mediation — keep it client-local.
+    "catalog.rebuild",
 })
 
 

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -81,6 +81,7 @@ if TYPE_CHECKING:
     # nexus.catalog.catalog_db -> from nexus.db.t2 import _sanitize_fts5)
     # therefore stops here without pulling sklearn -> scipy -> numpy
     # via CatalogTaxonomy.
+    from nexus.db.t2.catalog import CatalogStore
     from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
     from nexus.db.t2.chash_index import ChashIndex
     from nexus.db.t2.memory_store import AccessPolicy, MemoryStore
@@ -96,6 +97,7 @@ _log = structlog.get_logger()
 __all__ = [
     "AccessPolicy",
     "AspectExtractionQueue",
+    "CatalogStore",
     "CatalogTaxonomy",
     "ChashIndex",
     "DocumentAspects",
@@ -117,6 +119,7 @@ def __getattr__(name: str) -> Any:  # PEP 562
     _MAP = {
         "AccessPolicy":          "nexus.db.t2.memory_store",
         "AspectExtractionQueue": "nexus.db.t2.aspect_extraction_queue",
+        "CatalogStore":          "nexus.db.t2.catalog",
         "MemoryStore":           "nexus.db.t2.memory_store",
         "CatalogTaxonomy":       "nexus.db.t2.catalog_taxonomy",
         "ChashIndex":            "nexus.db.t2.chash_index",
@@ -167,16 +170,34 @@ def _resolve_default_run_migrations() -> bool:
 class T2Database:
     """T2 SQLite memory bank with FTS5 full-text search.
 
-    Pure composition over the seven domain stores (``memory``,
-    ``plans``, ``taxonomy``, ``telemetry``, ``chash_index``,
-    ``document_aspects``, ``aspect_queue``). Each store owns its own
-    connection, lock, schema init, and migration guard; the facade
-    forwards legacy public methods to the appropriate store and owns
-    only the cross-domain ``expire()`` composition and the context
-    manager.
+    Composition over eight domain stores (``memory``, ``plans``,
+    ``taxonomy``, ``telemetry``, ``chash_index``, ``document_aspects``,
+    ``aspect_queue``, ``catalog``). Each store owns its own connection,
+    lock, schema init, and migration guard; the facade forwards legacy
+    public methods to the appropriate store and owns only the
+    cross-domain ``expire()`` composition and the context manager.
+
+    The seven domain stores share the single ``nexus.db`` SQLite file
+    passed at construction. The eighth — ``catalog`` — is unique in
+    that it opens a separate ``.catalog.db`` file under
+    ``catalog_path()``. The path split is preserved through P5.A.1 by
+    the Hal-approved thin-shim design; collapsing the files is
+    explicitly out of scope.
+
+    The ``catalog`` store is constructed lazily on first attribute
+    access (RDR-120 P5.A.1) so tests that never touch the catalog do
+    not eagerly open ``.catalog.db`` and contend with separately-
+    constructed ``CatalogDB`` instances during the P5.A.1 to P5.A.2
+    cutover window.
     """
 
-    def __init__(self, path: Path, *, run_migrations: bool | None = None) -> None:
+    def __init__(
+        self,
+        path: Path,
+        *,
+        run_migrations: bool | None = None,
+        catalog_db_path: Path | None = None,
+    ) -> None:
         # Lazy-load the seven store classes here rather than at module
         # import time so the CLI cold-start path (which only needs
         # ``_sanitize_fts5``) does not pull sklearn/scipy/numpy through
@@ -229,6 +250,36 @@ class T2Database:
         # async aspect-extraction worker. The hook fires fast (just
         # an enqueue); the worker drains in a background thread.
         self.aspect_queue: AspectExtractionQueue = AspectExtractionQueue(path)
+
+        # RDR-120 P5.A.1 (nexus-9zmpl): catalog is the eighth domain
+        # store. Constructed lazily via the ``catalog`` property so
+        # the ``.catalog.db`` file is not opened on every T2Database
+        # construction (tests that never touch the catalog stay
+        # isolated). Caller may pin ``catalog_db_path`` explicitly to
+        # avoid the default resolution through ``nexus.config``.
+        self._catalog_db_path_override: Path | None = catalog_db_path
+        self._catalog: Any = None
+
+    @property
+    def catalog(self) -> "CatalogStore":
+        """Lazy-construct the eighth domain store on first access.
+
+        Resolution order for the catalog file path:
+
+        1. Explicit ``catalog_db_path`` argument passed to
+           :meth:`T2Database.__init__`.
+        2. ``nexus.config.catalog_path()/.catalog.db`` (production default).
+        """
+        if self._catalog is None:
+            from nexus.db.t2.catalog import CatalogStore as _CatalogStore
+
+            if self._catalog_db_path_override is not None:
+                db_path = self._catalog_db_path_override
+            else:
+                from nexus.config import catalog_path as _catalog_path
+                db_path = _catalog_path() / ".catalog.db"
+            self._catalog = _CatalogStore(db_path)
+        return self._catalog
 
     def stored_schema_version(self) -> str:
         """Return the ``_nexus_version`` row's ``cli_version`` value.
@@ -323,12 +374,21 @@ class T2Database:
         self.close()
 
     def close(self) -> None:
-        """Close all seven domain connections.
+        """Close all eight domain connections.
 
         Each store closes its own connection under its own lock. The
-        close order is reverse of construction so that the most
-        recently opened connection (aspect_queue) is released first.
+        close order is reverse of construction so the most recently
+        opened connection is released first. The ``catalog`` store
+        is only closed when it was actually constructed (lazy
+        property — never opened means never to close).
         """
+        # RDR-120 P5.A.1: close catalog only if it was materialised.
+        if self._catalog is not None:
+            try:
+                self._catalog.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._catalog = None
         self.aspect_queue.close()
         self.document_aspects.close()
         self.chash_index.close()

--- a/src/nexus/db/t2/catalog.py
+++ b/src/nexus/db/t2/catalog.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""T2 catalog store — eighth domain store (RDR-120 P5.A.1).
+
+Ports the ``CatalogDB`` read/write surface into the T2 substrate. This
+is the **skeleton phase**: ``CatalogStore`` wraps an internal
+``CatalogDB`` instance and delegates every public method. Production
+catalog code in ``src/nexus/catalog/`` keeps using ``CatalogDB``
+directly; P5.A.2 inverts the wrapping so ``CatalogDB`` becomes a thin
+shim around ``CatalogStore`` (and the raw ``sqlite3.connect`` moves
+under ``src/nexus/db/`` where it is allowlisted).
+
+File layout (per Hal-approved P5.A grooming): the catalog file
+(``.catalog.db``) stays separate from the seven-store nexus.db.
+``CatalogStore`` is the only T2 store that opens a different SQLite
+file; the others share ``nexus.db``.
+
+RDR-108 invariants preserved by construction (the wrapped
+``CatalogDB`` is the existing implementation):
+
+- ``Document.tumbler`` is doc identity.
+- Chunk natural ID = ``sha256(chunk_text)[:32]``.
+- ``document_chunks`` manifest is authoritative for doc->chunk joins.
+
+§A8-exempt content writes are inherited from ``CatalogDB.__init__``
+(see ``nexus_rdr / 120-research-A9-catalog-extension``):
+
+1. collections auto-backfill (structurally-bound-to-event-sourcing).
+2. owners PK-swap (structurally-bound-to-schema).
+3. document_chunks PK-swap (structurally-bound-to-schema).
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterator
+
+if TYPE_CHECKING:  # pragma: no cover - import for type hints only
+    from nexus.catalog.catalog_db import CatalogDB
+
+
+class CatalogStore:
+    """T2 domain store backing the catalog substrate.
+
+    Public surface mirrors ``CatalogDB`` — see that class for method
+    semantics. Method bodies delegate to an internal ``CatalogDB``
+    instance during the P5.A.1 skeleton phase; P5.A.2 will invert
+    the wrapping so this class owns the SQLite handle.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        # Local import: ``CatalogDB`` lives in ``nexus.catalog`` which
+        # has its own heavy import chain. Deferring the import keeps
+        # the T2 module-load surface cheap (the seven existing stores
+        # all hew to this discipline).
+        from nexus.catalog.catalog_db import CatalogDB as _CatalogDB
+
+        self._path: Path = db_path
+        # The other seven domain stores all live under the nexus
+        # config dir which ``nexus_config_dir()`` materialises on
+        # first access. The catalog file lives under
+        # ``catalog_path()`` which is NOT auto-created in production
+        # (Catalog initialisation is the gate). Materialise the
+        # parent here so daemon startup can open the file even when
+        # the catalog has not yet been initialised by a consumer.
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._db: "CatalogDB" = _CatalogDB(db_path)
+
+    # ── identity ──────────────────────────────────────────────────────
+
+    @property
+    def path(self) -> Path:
+        """Path to the underlying ``.catalog.db`` file."""
+        return self._path
+
+    @property
+    def backfilled_collections(self) -> set[str]:
+        """Pass-through to ``CatalogDB._backfilled_collections``.
+
+        Catalog rebuild emits synthetic ``CollectionCreated`` events
+        for these names so the event-sourced projection stays bit-equal
+        with the live SQLite state (see RDR-101 §A8 carve-out).
+        """
+        return self._db._backfilled_collections
+
+    # ── document-number sequence ──────────────────────────────────────
+
+    def next_document_number(self, owner_prefix: str) -> int:
+        return self._db.next_document_number(owner_prefix)
+
+    # ── search / traversal ────────────────────────────────────────────
+
+    def search(
+        self, query: str, *, content_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        return self._db.search(query, content_type=content_type)
+
+    def descendants(self, prefix: str) -> list[dict[str, Any]]:
+        return self._db.descendants(prefix)
+
+    # ── raw SQL passthrough (used by Projector and audit verbs) ───────
+
+    def execute(
+        self, sql: str, params: tuple[Any, ...] | list[Any] = (),
+    ) -> sqlite3.Cursor:
+        return self._db.execute(sql, params)
+
+    def commit(self) -> None:
+        self._db.commit()
+
+    @contextmanager
+    def transaction(self) -> Iterator[None]:
+        with self._db.transaction():
+            yield
+
+    @contextmanager
+    def bulk_load_documents(self) -> Iterator[None]:
+        with self._db.bulk_load_documents():
+            yield
+
+    # ── rebuild (event-replay path) ───────────────────────────────────
+
+    def rebuild(self, *args: Any, **kwargs: Any) -> Any:
+        return self._db.rebuild(*args, **kwargs)
+
+    # ── lifecycle ─────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        with self._lock:
+            try:
+                self._db.close()
+            except Exception:  # noqa: BLE001
+                pass

--- a/tests/db/test_t2_catalog_store.py
+++ b/tests/db/test_t2_catalog_store.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 P5.A.1 (nexus-9zmpl): T2 catalog store skeleton tests.
+
+Pins the eighth-domain-store invariants without depending on the
+P5.A.2 shim conversion:
+
+- ``CatalogStore`` exists in ``nexus.db.t2`` and is lazy-importable.
+- ``T2Database.catalog`` lazy-constructs on first access; never
+  materialised when not touched (no .catalog.db file appears).
+- Daemon dispatch table includes ``catalog.*`` ops.
+- T2Client has a ``client.catalog`` proxy attribute.
+- ``catalog.execute`` / ``transaction`` / ``bulk_load_documents`` /
+  ``rebuild`` are denylisted at the RPC boundary (their shapes do
+  not round-trip framed JSON).
+- Surface parity: every public method on the underlying
+  ``CatalogDB`` that production code uses round-trips through
+  ``CatalogStore``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class TestModuleSurface:
+    def test_catalog_store_lazy_importable_from_t2_package(self) -> None:
+        """``nexus.db.t2.CatalogStore`` resolves via PEP 562 __getattr__."""
+        from nexus.db.t2 import CatalogStore
+
+        assert CatalogStore.__module__ == "nexus.db.t2.catalog"
+
+    def test_catalog_store_listed_in_all(self) -> None:
+        import nexus.db.t2 as t2
+
+        assert "CatalogStore" in t2.__all__
+
+
+class TestT2DatabaseLazyCatalog:
+    def test_catalog_not_materialised_until_accessed(
+        self, tmp_path: Path,
+    ) -> None:
+        """Touching only the seven shared-nexus.db stores must not
+        open ``.catalog.db``."""
+        from nexus.db.t2 import T2Database
+
+        nexus_db = tmp_path / "memory.db"
+        catalog_db = tmp_path / "catalog" / ".catalog.db"
+        db = T2Database(nexus_db, catalog_db_path=catalog_db)
+        try:
+            # Force one of the existing seven stores.
+            db.memory.put("p", "t", "content")
+            # Catalog file must not exist yet — lazy property
+            # never fired.
+            assert not catalog_db.exists()
+            assert db._catalog is None
+        finally:
+            db.close()
+
+    def test_catalog_property_materialises_store(
+        self, tmp_path: Path,
+    ) -> None:
+        from nexus.db.t2 import T2Database
+        from nexus.db.t2.catalog import CatalogStore
+
+        nexus_db = tmp_path / "memory.db"
+        catalog_db = tmp_path / "catalog" / ".catalog.db"
+        db = T2Database(nexus_db, catalog_db_path=catalog_db)
+        try:
+            store = db.catalog
+            assert isinstance(store, CatalogStore)
+            assert store.path == catalog_db
+            # Second access returns the same instance (no double-open).
+            assert db.catalog is store
+        finally:
+            db.close()
+
+    def test_catalog_db_path_parent_auto_created(
+        self, tmp_path: Path,
+    ) -> None:
+        """Daemon-startup path: catalog dir may not exist; the store
+        materialises the parent on construction."""
+        from nexus.db.t2 import T2Database
+
+        nexus_db = tmp_path / "memory.db"
+        catalog_db = tmp_path / "fresh-catalog-dir" / ".catalog.db"
+        assert not catalog_db.parent.exists()
+        db = T2Database(nexus_db, catalog_db_path=catalog_db)
+        try:
+            _ = db.catalog
+            assert catalog_db.parent.is_dir()
+            assert catalog_db.exists()
+        finally:
+            db.close()
+
+
+class TestDaemonDispatch:
+    def test_catalog_registered_in_store_attrs(self) -> None:
+        from nexus.daemon.t2_daemon import _T2_STORE_ATTRS
+
+        assert "catalog" in _T2_STORE_ATTRS
+        assert _T2_STORE_ATTRS[-1] == "catalog", (
+            "catalog must be the eighth (last) store per RDR-120 P5"
+        )
+
+    def test_catalog_rpc_denyops_include_unserialisable_methods(
+        self,
+    ) -> None:
+        from nexus.daemon.t2_daemon import _RPC_DENY_OPS
+
+        for op in (
+            "catalog.execute",
+            "catalog.transaction",
+            "catalog.bulk_load_documents",
+            "catalog.rebuild",
+        ):
+            assert op in _RPC_DENY_OPS, (
+                f"{op!r} must be denylisted — its shape does not "
+                f"round-trip framed JSON"
+            )
+
+    def test_dispatch_table_builds_with_catalog_store(
+        self, tmp_path: Path,
+    ) -> None:
+        """End-to-end: a real T2Database with catalog property
+        registered builds a dispatch table that includes catalog ops
+        for the methods that DO round-trip JSON.
+        """
+        from nexus.daemon.t2_daemon import _build_dispatch_table
+        from nexus.db.t2 import T2Database
+
+        db = T2Database(
+            tmp_path / "memory.db",
+            catalog_db_path=tmp_path / "catalog" / ".catalog.db",
+        )
+        try:
+            table = _build_dispatch_table(db)
+            # next_document_number / search / descendants ARE valid
+            # RPC ops (return JSON-shaped values).
+            assert "catalog.next_document_number" in table
+            assert "catalog.search" in table
+            assert "catalog.descendants" in table
+            # Denylisted ops MUST be absent.
+            for op in (
+                "catalog.execute",
+                "catalog.transaction",
+                "catalog.bulk_load_documents",
+                "catalog.rebuild",
+            ):
+                assert op not in table, f"{op!r} should be denylisted"
+        finally:
+            db.close()
+
+
+class TestT2ClientProxy:
+    def test_t2client_has_catalog_proxy(self) -> None:
+        from nexus.daemon.t2_client import T2Client
+
+        client = T2Client(skip_handshake=True)
+        try:
+            assert hasattr(client, "catalog")
+            # Method names build the right op via __getattr__.
+            method = client.catalog.search
+            assert callable(method)
+        finally:
+            client.close()
+
+
+class TestCatalogStoreSurfaceParity:
+    """Every public ``CatalogDB`` method that production code uses
+    must round-trip through ``CatalogStore``.
+    """
+
+    @pytest.fixture
+    def store(self, tmp_path: Path):
+        from nexus.db.t2.catalog import CatalogStore
+
+        s = CatalogStore(tmp_path / "catalog" / ".catalog.db")
+        yield s
+        s.close()
+
+    def test_next_document_number_round_trip(self, store) -> None:
+        # Fresh owner_prefix with no documents — MAX(...) is NULL,
+        # so (NULL or 0) + 1 = 1. The method does not allocate the
+        # number, just reports what the next free slot is.
+        assert store.next_document_number("nexus-test1") == 1
+        # Repeat without inserting documents — still 1.
+        assert store.next_document_number("nexus-test1") == 1
+
+    def test_search_returns_list(self, store) -> None:
+        rows = store.search("nonexistent")
+        assert rows == []
+
+    def test_descendants_returns_list(self, store) -> None:
+        rows = store.descendants("nexus-zzzz")
+        assert rows == []
+
+    def test_execute_returns_cursor(self, store) -> None:
+        import sqlite3
+
+        cur = store.execute("SELECT 1")
+        assert isinstance(cur, sqlite3.Cursor)
+        assert cur.fetchone() == (1,)
+
+    def test_transaction_context_manager(self, store) -> None:
+        # Just confirm the context manager protocol works; behaviour
+        # parity is locked by the underlying CatalogDB tests.
+        with store.transaction():
+            store.execute("SELECT 1")
+
+    def test_backfilled_collections_attribute_present(self, store) -> None:
+        # Fresh store: no collections to backfill.
+        assert store.backfilled_collections == set()


### PR DESCRIPTION
## Summary

RDR-120 P5.A.1 — eighth domain store. Skeleton phase: ``CatalogStore`` wraps an internal ``CatalogDB`` and delegates every public method. P5.A.2 will invert so ``CatalogStore`` owns the SQLite handle.

- New file ``src/nexus/db/t2/catalog.py`` with ``CatalogStore``. Lazy parent-dir materialisation so daemon-startup against a fresh install doesn't fail before the catalog dir exists.
- ``T2Database`` gets ``catalog_db_path`` ctor arg + lazy ``catalog`` property. ``close()`` only closes the catalog when materialised.
- Daemon: ``_T2_STORE_ATTRS`` extended to 8 stores. RPC denylist adds the four catalog ops whose shapes don't round-trip framed JSON (``execute``, ``transaction``, ``bulk_load_documents``, ``rebuild``).
- ``T2Client`` gets ``client.catalog`` proxy.
- New ``tests/db/test_t2_catalog_store.py`` (15 scenarios).

File layout per Hal-approved grooming: ``.catalog.db`` stays separate from ``nexus.db``. Single-file collapse is explicitly out of scope.

RDR-108 invariants preserved by construction (the wrapped CatalogDB is the existing impl): ``Document.tumbler`` is doc identity; chunk natural ID = ``sha256(chunk_text)[:32]``; document_chunks manifest is authoritative.

## Validation

- ``tests/db/`` + ``tests/daemon/`` + ``tests/test_catalog.py`` + ``tests/test_storage_boundary_lint.py`` + ``tests/test_t2.py`` + ``tests/test_migrations.py``: **428 passed**.
- Stress harness (12/12 scenarios): green.
- Storage-boundary lint unchanged: ``violations=0``, ``catalog_allowlist=2``.

## Closes

- Closes nexus-9zmpl
- Unblocks nexus-2t7o5 (P5.A.2 — CatalogDB shim conversion)