### PR TITLE
chore(release): conexus 4.34.4 — restore tool/skill discipline under Opus 4.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.34.3"
+      "version": "4.34.4"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.34.3"
+      "version": "4.34.4"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.34.4] - 2026-05-23
+
 ### Plugins — tool/skill invocation discipline restored
 
 Two compounding upstream changes have collapsed ambient tool and skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Plugins — tool/skill invocation discipline restored
+
+Two compounding upstream changes have collapsed ambient tool and skill
+invocation for plugin-heavy users:
+
+- **Claude Code v2.1.69** extended MCP-style schema-deferral to
+  built-in tools. Out-of-sight tools don't get invoked. Reported in
+  [anthropics/claude-code#31002][cc-31002].
+- **Opus 4.7** (April 2026 model card, [whats-new-claude-4-7][opus47])
+  reduced default tool calls and subagent dispatch, and made
+  instruction-following more literal. Soft hints ("if a skill plausibly
+  applies, invoke it") no longer survive.
+
+Mitigations in this release:
+
+- `nx/.mcp.json` and `sn/.mcp.json` set `alwaysLoad: true` on all five
+  MCP servers (`sequential-thinking`, `nexus`, `nexus-catalog`,
+  `serena`, `context7`). Claude Code v2.1.121+ honours this per-server
+  flag to skip tool-search deferral. Tradeoff: added session-start
+  context in exchange for guaranteed tool visibility.
+- The two routing-gate skills (`nx/skills/using-nx-skills`,
+  `nx/skills/plan-first`) now use MUST-form imperatives in their
+  descriptions and bodies. The `"Use when"` prefix convention enforced
+  by `TestSkillDescriptionCSO` is preserved.
+
+If you observe specific MCP tools or skills still being skipped after
+upgrading Claude Code, file an issue and we'll widen the audit.
+
+[cc-31002]: https://github.com/anthropics/claude-code/issues/31002
+[opus47]: https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+
 ## [4.34.3] - 2026-05-22
 
 Documentation-only release. Sweep of user-facing surfaces for the
@@ -186,7 +217,6 @@ nexus.db via the daemon.
   session-end launcher, ``nx health`` PRAGMA integrity_check)
   stay on direct ``T2Database`` with ``# epsilon-allow`` — those
   legitimately must work when the daemon is offline.
-
 ## [4.34.0] - 2026-05-22
 
 RDR-120 Storage Substrate Split — the full P0 → P6 substrate-only

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -221,6 +221,29 @@ The rule of thumb: **content** (chunks, documents, notes) is on `nexus`,
 on `nexus-catalog`. `query` is the one core-server tool that crosses the
 boundary — it uses catalog metadata to scope a content search.
 
+## Heads-up: `alwaysLoad` and Claude Code v2.1.69+ tool deferral
+
+Starting in Claude Code **v2.1.69**, schema-deferral was extended from
+MCP tools (deferred since the `ToolSearch` rollout) to most built-in
+tools as well. Only ~10 core tools load eagerly — everything else,
+including all MCP servers, becomes discoverable via `ToolSearch` only.
+The space saving is real (~14k tokens), but the behavioural side effect
+is that the model often skips the `ToolSearch` step and answers without
+ever loading the MCP schemas. Combined with **Opus 4.7**'s documented
+"fewer tool calls by default" and "more literal instruction following"
+disposition, plugin-heavy users see Serena, sequential-thinking, and
+nexus only fire when explicitly named.
+
+Both nx and sn plugin `.mcp.json` files ship with
+`"alwaysLoad": true` on every server. Claude Code v2.1.121+ honours
+this per-server flag and skips the deferral, so schemas load eagerly
+again. If you fork or customise these files, keep the flag — otherwise
+you'll see the same regression.
+
+References:
+- [anthropics/claude-code#31002](https://github.com/anthropics/claude-code/issues/31002) — built-in tool deferral
+- [Opus 4.7 model card](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7) — disposition shifts
+
 ## References
 
 - [Architecture § Module Map (MCP Servers row)](architecture.md#module-map) — developer-oriented internals

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.34.3",
+  "version": "4.34.4",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/.mcp.json
+++ b/nx/.mcp.json
@@ -1,20 +1,23 @@
 {
   "sequential-thinking": {
     "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+    "alwaysLoad": true
   },
   "nexus": {
     "command": "nx-mcp",
     "args": [],
     "env": {
       "CLAUDE_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}"
-    }
+    },
+    "alwaysLoad": true
   },
   "nexus-catalog": {
     "command": "nx-mcp-catalog",
     "args": [],
     "env": {
       "CLAUDE_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}"
-    }
+    },
+    "alwaysLoad": true
   }
 }

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.34.4] - 2026-05-23
+
 ### Restored tool/skill invocation discipline
 
 Tuning for Claude Code v2.1.69+ (built-in tool deferral) and Opus 4.7

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,26 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Restored tool/skill invocation discipline
+
+Tuning for Claude Code v2.1.69+ (built-in tool deferral) and Opus 4.7
+(literal instruction-following + reduced default tool calls). Without
+these changes, plugin-heavy users were seeing Serena, sequential-thinking,
+and nexus only fire when explicitly told.
+
+- `nx/.mcp.json`: added `"alwaysLoad": true` to `sequential-thinking`,
+  `nexus`, and `nexus-catalog`. Claude Code v2.1.121+ honours this per
+  server to skip tool-search deferral so schemas load eagerly.
+- `nx/skills/using-nx-skills/SKILL.md` and `nx/skills/plan-first/SKILL.md`:
+  rewrote descriptions and opening rules as MUST-form imperatives.
+  Opus 4.7 reads soft hints as suggestions; explicit "MUST" / "defect"
+  language survives the literalism shift. The `"Use when"` prefix
+  required by `tests/test_plugin_structure.py::TestSkillDescriptionCSO`
+  is preserved.
+
+References: [anthropics/claude-code#31002](https://github.com/anthropics/claude-code/issues/31002),
+[Opus 4.7 model card](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7).
+
 ## [4.34.3] - 2026-05-22
 
 Plugin version aligned with conexus 4.34.3 — documentation-only
@@ -36,7 +56,6 @@ Plugin version aligned with conexus 4.34.1. No plugin-side changes;
 this is a substrate patch release fixing the CLI-vs-daemon gap
 that 4.34.0 left open. See the conexus 4.34.1 entry in the root
 CHANGELOG for the full RDR-120 P6 follow-up details.
-
 ## [4.34.0] - 2026-05-22
 
 Plugin version aligned with conexus 4.34.0. No plugin-side changes

--- a/nx/skills/plan-first/SKILL.md
+++ b/nx/skills/plan-first/SKILL.md
@@ -1,20 +1,16 @@
 ---
 name: plan-first
-description: Use when starting any retrieval task — the gate that tries plan_match first, executes via plan_run if a match clears the threshold, and falls through to /nx:query only on a miss
+description: Use when starting any retrieval task — you MUST call `mcp__plugin_nx_nexus__plan_match` first; if a match clears the threshold you MUST execute it via `mcp__plugin_nx_nexus__plan_run`. Falling through to `/nx:query` is permitted only on a confirmed miss. Skipping this gate is a defect.
 effort: low
 ---
 
 # plan-first
 
-**Gate skill.** Every retrieval-shaped task starts here. The plan
-library exists so agents don't re-derive pipelines that have already
-been authored; this skill is the discipline that enforces it.
+**Hard gate.** Every retrieval-shaped task starts here. **You MUST call `plan_match` before decomposing or dispatching anything else.** The plan library exists so agents don't re-derive pipelines that have already been authored; this skill is the enforcement, not a suggestion.
 
 ## Rule
 
-Before decomposing any retrieval task, call `plan_match` first. If a
-match clears `min_confidence`, execute the returned plan via
-`plan_run`. Only dispatch `/nx:query` when no plan matches.
+Before decomposing any retrieval task, you MUST call `mcp__plugin_nx_nexus__plan_match` first. If a match clears `min_confidence`, you MUST execute the returned plan via `mcp__plugin_nx_nexus__plan_run`. Dispatching `/nx:query` without first checking is a defect.
 
 ## Flow
 

--- a/nx/skills/using-nx-skills/SKILL.md
+++ b/nx/skills/using-nx-skills/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: using-nx-skills
-description: Use when starting any conversation or task — establishes that nx skills must be checked before every response, including clarifying questions. If a skill plausibly applies, invoke it.
+description: Use when starting any turn — you MUST scan the available nx skill list and invoke `Skill` for any matching skill BEFORE producing any other response (clarifying questions, code, or prose included). Direct answers without first invoking a matching skill are a defect. False positives are cheap; misses cost real time.
 effort: low
 ---
 
 # Using nx Skills
 
-If a skill plausibly applies, invoke it. False positives are cheap; misses cost time. Skills evolve — read the current version, don't rely on memory.
+**You MUST invoke `Skill` for any plausibly-matching nx skill before producing any other response.** This is not a hint or a preference — it is a hard rule. Skipping a matching skill is a defect, not an optimization. False positives are cheap; misses cost real time. Skills evolve — read the current version, don't rely on memory.
 
 ## Plan Reuse
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.34.3"
+version = "4.34.4"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "4.34.3",
+  "version": "4.34.4",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/sn/.mcp.json
+++ b/sn/.mcp.json
@@ -1,10 +1,12 @@
 {
   "serena": {
     "command": "uvx",
-    "args": ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server", "--context", "claude-code", "--project-from-cwd"]
+    "args": ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server", "--context", "claude-code", "--project-from-cwd"],
+    "alwaysLoad": true
   },
   "context7": {
     "command": "npx",
-    "args": ["-y", "@upstash/context7-mcp"]
+    "args": ["-y", "@upstash/context7-mcp"],
+    "alwaysLoad": true
   }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.34.3"
+version = "4.34.4"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Problem

Two compounding upstream changes collapsed ambient tool/skill/agent invocation. Multiple users reporting Serena, sequential-thinking, and nexus only fire when explicitly told; skills and agents don't seem to be considered at all.

1. **Claude Code v2.1.69** extended schema-deferral to built-in tools (MCP tools have been deferred since the `ToolSearch` rollout). Out-of-sight tools don't get invoked. Refs: [#31002](https://github.com/anthropics/claude-code/issues/31002), [#32485](https://github.com/anthropics/claude-code/issues/32485).
2. **Opus 4.7** (Apr 2026 model card) intentionally reduced default tool calls + subagent dispatch + ambient thinking; made instruction-following more literal. Soft hints now read as suggestions, not generalised behaviour. Ref: [whats-new-claude-4-7](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7).

## Changes

* **`nx/.mcp.json` + `sn/.mcp.json`** — set `alwaysLoad: true` on all five MCP servers (`sequential-thinking`, `nexus`, `nexus-catalog`, `serena`, `context7`). CC v2.1.121+ honours this per-server to skip tool-search deferral. Tradeoff: ~adds tool schemas to every session start in exchange for guaranteed visibility.
* **`nx/skills/using-nx-skills/SKILL.md`** — description and opening rewritten from "if a skill plausibly applies, invoke it" → "you MUST invoke `Skill` for any matching skill before any other response. Direct answers are a defect."
* **`nx/skills/plan-first/SKILL.md`** — description and rule rewritten with explicit MUST + full MCP tool names; "skipping is a defect" replaces softer phrasing.
* Convention preserved: descriptions still start with "Use when" as enforced by `tests/test_plugin_structure.py::TestSkillDescriptionCSO`.

## Test

* `uv run pytest tests/test_plugin_structure.py` → 596 passed, 27 skipped.

## Closes

Closes nexus-g92o1
Closes nexus-nqcci
Closes nexus-ml84b