### PR TITLE
chore: merge main → develop (4.34.1/2/3/4 + RDR-120 substrate work)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.34.2"
+      "version": "4.34.3"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.34.2"
+      "version": "4.34.3"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.34.3"
+      "version": "4.34.4"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.34.3"
+      "version": "4.34.4"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.34.0"
+      "version": "4.34.1"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.34.0"
+      "version": "4.34.1"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.34.1"
+      "version": "4.34.2"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.34.1"
+      "version": "4.34.2"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.34.2] - 2026-05-22
+
+UX patch release. Closes the daemon-not-running cliff that 4.34.1
+introduced: a fresh `pip install conexus` + `/plugin install nx`
+now produces a working substrate on first session without any
+manual `nx daemon t2 start` incantation.
+
 ### Added
 
 - `nx daemon t2 ensure-running` (nexus-qnrvn): idempotent
@@ -47,12 +54,16 @@ or systemd user-unit (Linux) with `KeepAlive=true` /
 - Moratorium-lift criterion superseded (nexus-57pwo): the
   RDR-120 §Approach Phase 6 "30 days on main" calendar window is
   replaced by an empirical stress-validation matrix. Five
-  scenario scripts at `tests/stress/test_substrate_validation_*.py`
-  cover multi-container fan-in, mixed-workload concurrency, hard-
-  kill recovery under load, schema-handshake mismatch under
-  load, and catalog rebuild under T2 contention. When all five
-  pass with T2 receipts under `120-stress-<scenario>-receipt`,
-  the substrate is empirically validated; consumer RDRs may file.
+  scenario scripts at `tests/stress/substrate_validation/` cover
+  multi-container fan-in, mixed-workload concurrency, hard-kill
+  recovery under load, schema-handshake mismatch under load, and
+  catalog rebuild under T2 contention. All five passed
+  2026-05-22; the substrate is empirically validated and
+  consumer RDRs may file regardless of calendar date.
+- `test_migration_guard_path_normalization` marked
+  `@_skip_on_gha_flake` — same nexus-9eaz family GHA-runner
+  pressure flake its two siblings already wear. Passes locally;
+  opt back in with `NEXUS_RUN_FLAKY_TESTS=1`.
 
 ## [4.34.1] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.34.3] - 2026-05-22
+
+Documentation-only release. Sweep of user-facing surfaces for the
+RDR-120 storage substrate shift that shipped in 4.34.0/4.34.1/4.34.2.
+
+Pre-audit the docs were silent on the daemon model — README,
+getting-started, cli-reference, contributing, configuration, and
+mcp-servers had zero mentions. New users hitting
+``T2DaemonNotReachableError`` on first install had no documentation
+to fall back on.
+
+This release closes the gap:
+
+- **README.md**: Quick Start includes ``nx daemon t2 install
+  --autostart``; at-a-glance table notes daemon-mediated storage;
+  CLI commands table gets an ``nx daemon`` row; Documentation
+  table cross-links Container Integration and Upgrading to 4.34.x.
+- **docs/getting-started.md**: New "First-time setup: the T2
+  daemon" section between Install and Update. Three new
+  Troubleshooting entries (``T2DaemonNotReachableError``,
+  ``T2SchemaVersionMismatchError``, the launchctl-bootout-race
+  for "discovery file not found") with copy-paste recovery commands.
+- **docs/cli-reference.md**: Complete ``nx daemon`` section
+  documenting all 11 subcommands (t2 + t3 start/stop/status,
+  ensure-running, install/uninstall --autostart), with flags,
+  exit codes, log paths, and the LaunchAgent / systemd unit
+  filenames.
+- **docs/configuration.md**: New "Daemon environment variables"
+  section covering ``NX_T2_ADDR`` / ``NX_T2_SOCK`` / ``NX_T3_ADDR``
+  / ``NX_LOCAL`` with operator-facing semantics and discovery-file
+  fallback rules.
+- **docs/storage-tiers.md**: Rewrote the canonical tier table to
+  add a Daemon column and Transport column; added "one
+  arbitrator per tier" callout explaining the multi-process
+  arbitration model.
+- **docs/mcp-servers.md**: Substrate-dependency callout right
+  after the two-servers intro.
+- **docs/contributing.md**: Development Setup updated with the
+  daemon-install step + "hacking on the daemon itself" foreground
+  workflow.
+- **nx/README.md**: SessionStart-hook explainer + cross-link to
+  Container Integration.
+- **docs/migration/upgrading-to-4.34.md**: NEW comprehensive
+  upgrade guide. TL;DR is one command; full explainer covers
+  what changed, what happens if you skip the upgrade step,
+  container/Cowork integration, schema-version handshake,
+  empirical validation receipts, and rollback procedure.
+- **docs/migration/README.md**: split into "Active operator-facing
+  guides" and "Historical forensic records" sections.
+
+No code changes. Existing 4.34.2 installations continue working;
+this release exists to notify operators that the substrate-shift
+docs are now comprehensive.
+
 ## [4.34.2] - 2026-05-22
 
 UX patch release. Closes the daemon-not-running cliff that 4.34.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `nx daemon t2 ensure-running` (nexus-qnrvn): idempotent
+  daemon-spawn helper. Silent no-op if a T2 daemon is already
+  running on the named config_dir; otherwise spawns one in the
+  background and polls the discovery file until reachable
+  (or `--timeout`, default 5s, expires with exit 1 + a log-
+  pointer message). The probe is `os.kill(pid, 0)` against the
+  discovery-file PID, so stale discovery files left behind by
+  crashed daemons trigger a fresh spawn rather than a false-
+  positive.
+
+- nx plugin `SessionStart` hook runs the new
+  `ensure-running --quiet` on every Claude Code session start
+  (`startup|resume|clear|compact`). This closes the
+  daemon-not-running cliff that 4.34.1 introduced: a fresh
+  `pip install conexus` + `/plugin install nx` now produces a
+  working substrate on first session without any manual
+  daemon-start incantation.
+
+For users who want a durable always-running daemon independent
+of Claude Code (recommended for any host with regular nx use):
+`nx daemon t2 install --autostart` writes a LaunchAgent (macOS)
+or systemd user-unit (Linux) with `KeepAlive=true` /
+`Restart=on-failure`. This install path was already shipped in
+4.34.0; 4.34.1 documents it explicitly in
+`docs/container-integration.md`.
+
 ### Docs
 
 - `docs/container-integration.md` (nexus-ai5ic): operator-facing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Docs
+
+- `docs/container-integration.md` (nexus-ai5ic): operator-facing
+  guide covering the three container-to-host connection paths
+  (TCP loopback, UDS mount, operator-side forward) + the Claude
+  Cowork SDK-transport pattern + a diagnostic recipe table.
+  Linked from `docs/architecture.md` § Storage tiers.
+
+### Process
+
+- Moratorium-lift criterion superseded (nexus-57pwo): the
+  RDR-120 §Approach Phase 6 "30 days on main" calendar window is
+  replaced by an empirical stress-validation matrix. Five
+  scenario scripts at `tests/stress/test_substrate_validation_*.py`
+  cover multi-container fan-in, mixed-workload concurrency, hard-
+  kill recovery under load, schema-handshake mismatch under
+  load, and catalog rebuild under T2 contention. When all five
+  pass with T2 receipts under `120-stress-<scenario>-receipt`,
+  the substrate is empirically validated; consumer RDRs may file.
+
 ## [4.34.1] - 2026-05-22
 
 Patch release. RDR-120 P6 follow-up (nexus-w6txl): the user-facing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,74 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.34.1] - 2026-05-22
+
+Patch release. RDR-120 P6 follow-up (nexus-w6txl): the user-facing
+``nx memory put / get / search / list / delete / expire / promote``
+CLI commands now route through ``T2Client`` and the running T2
+daemon instead of opening the SQLite file directly.
+
+### Architecture (RDR-120 follow-up)
+
+4.34.0 shipped the substrate split (daemon-mediated storage) but
+left the user-facing CLI memory commands on direct ``T2Database``
+opens with ``# epsilon-allow`` annotations. The lint count went to
+zero but the daemon's runtime arbitration was only exercised by
+the MCP server path. The container smoke surfaced the gap:
+``nx memory put`` from a Docker container with ``NX_T2_ADDR`` set
+silently wrote to a container-local SQLite file (row id=1) and
+never touched the host daemon.
+
+This release closes the gap.
+
+- New ``nexus.commands._helpers.t2_handle()`` context manager
+  returns a ``T2Client`` connected to the running T2 daemon.
+  Raises ``T2DaemonNotReachableError`` with the
+  ``nx daemon t2 start`` operator hint if the daemon isn't
+  running — same UX as T3's daemon-required model.
+- ``src/nexus/commands/memory.py``: every command migrated from
+  ``T2Database(default_db_path())`` to ``t2_handle()``. Call sites
+  use ``.memory.<method>`` (works identically against ``T2Client``
+  and ``T2Database``).
+- Cross-domain cascades (memory + taxonomy on ``delete``,
+  memory + telemetry on ``expire``) now run client-side via two
+  store-level calls. Pre-migration, the ``T2Database.delete``
+  facade did the cascade in-process; ``T2Client.database`` doesn't
+  expose the facade, so the CLI drives both stores explicitly.
+
+### Validated end-to-end
+
+Container ↔ host shared state via the CLI:
+
+```
+# Host
+$ nx daemon t2 start
+$ # daemon listens on 127.0.0.1:<port>
+
+# Container (python:3.13-slim + pip install conexus==4.34.1)
+$ NX_T2_ADDR=host.docker.internal:<port> \
+    nx memory put -p nexus_rdr -t example "from container"
+Stored: nexus_rdr/example (id=1443)            ← host id-space
+
+# Host
+$ nx memory get -p nexus_rdr -t example
+from container
+```
+
+Row IDs land in the host's id-space (vs. id=1 in the pre-fix
+container-local DB), confirming the write reached the host's
+nexus.db via the daemon.
+
+### Out of scope (still open follow-ups)
+
+- ``nx plan repair *`` (uses raw ``execute()`` — needs separate
+  RPC method additions for the migration-helper-style backfills).
+- ``nx tier-status`` (read-only diagnostic; low priority).
+- Operator/debug paths (``nx upgrade``, ``nx doctor``, the
+  session-end launcher, ``nx health`` PRAGMA integrity_check)
+  stay on direct ``T2Database`` with ``# epsilon-allow`` — those
+  legitimately must work when the daemon is offline.
+
 ## [4.34.0] - 2026-05-22
 
 RDR-120 Storage Substrate Split — the full P0 → P6 substrate-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.34.4] - 2026-05-23
+
+### Plugins — tool/skill invocation discipline restored
+
+Two compounding upstream changes have collapsed ambient tool and skill
+invocation for plugin-heavy users:
+
+- **Claude Code v2.1.69** extended MCP-style schema-deferral to
+  built-in tools. Out-of-sight tools don't get invoked. Reported in
+  [anthropics/claude-code#31002][cc-31002].
+- **Opus 4.7** (April 2026 model card, [whats-new-claude-4-7][opus47])
+  reduced default tool calls and subagent dispatch, and made
+  instruction-following more literal. Soft hints ("if a skill plausibly
+  applies, invoke it") no longer survive.
+
+Mitigations in this release:
+
+- `nx/.mcp.json` and `sn/.mcp.json` set `alwaysLoad: true` on all five
+  MCP servers (`sequential-thinking`, `nexus`, `nexus-catalog`,
+  `serena`, `context7`). Claude Code v2.1.121+ honours this per-server
+  flag to skip tool-search deferral. Tradeoff: added session-start
+  context in exchange for guaranteed tool visibility.
+- The two routing-gate skills (`nx/skills/using-nx-skills`,
+  `nx/skills/plan-first`) now use MUST-form imperatives in their
+  descriptions and bodies. The `"Use when"` prefix convention enforced
+  by `TestSkillDescriptionCSO` is preserved.
+
+If you observe specific MCP tools or skills still being skipped after
+upgrading Claude Code, file an issue and we'll widen the audit.
+
+[cc-31002]: https://github.com/anthropics/claude-code/issues/31002
+[opus47]: https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+
 ## [4.34.3] - 2026-05-22
 
 Documentation-only release. Sweep of user-facing surfaces for the
@@ -186,7 +219,6 @@ nexus.db via the daemon.
   session-end launcher, ``nx health`` PRAGMA integrity_check)
   stay on direct ``T2Database`` with ``# epsilon-allow`` — those
   legitimately must work when the daemon is offline.
-
 ## [4.34.0] - 2026-05-22
 
 RDR-120 Storage Substrate Split — the full P0 → P6 substrate-only

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The four-paragraph version is on the Tensegrity blog: [**How I actually use Nexu
 
 | | What you get |
 |---|---|
-| **Storage** | T1 ephemeral session scratch (in-memory ChromaDB) · T2 SQLite + FTS5 for memory / plans / taxonomy / telemetry · T3 ChromaDB persistent + Voyage AI in cloud mode, ONNX MiniLM in local mode |
+| **Storage** | T1 ephemeral session scratch (in-memory ChromaDB) · T2 SQLite + FTS5 for memory / plans / catalog / taxonomy / telemetry · T3 ChromaDB persistent + Voyage AI in cloud mode, ONNX MiniLM in local mode · daemon-mediated (RDR-120, 4.34.0+) so host CLI + Cowork agents + dev containers + the MCP server all share one arbitrated writer |
 | **Indexing** | Tree-sitter AST chunking (23 languages) · CCE prose chunking (`voyage-context-3`) · PDF auto-routing (Docling → MinerU → PyMuPDF) · git frecency scoring · automatic topic discovery via HDBSCAN |
 | **Search** | Semantic · keyword · hybrid · taxonomy-boosted · catalog-aware · plan-driven via `nx_answer`. Metadata filtering via `--where bib_year>=2024 --where chunk_type=table_page` and similar |
 | **Catalog** | Event-sourced (`events.jsonl` canonical, SQLite is a deterministic projection) · typed links (`cites`, `implements`, `supersedes`, …) · Tumbler addressing inspired by Ted Nelson's Xanadu |
@@ -53,14 +53,23 @@ nx taxonomy review                                  # accept, rename, merge, spl
 Requires Python 3.12–3.13 and [uv](https://docs.astral.sh/uv/).
 
 ```bash
-uv tool install conexus          # install the nx CLI
-nx doctor                        # verify installation
-nx index repo .                  # index your repo + discover topics (no API keys needed)
-nx search "what does X do"       # semantic search with topic grouping, fully local
-nx taxonomy status               # see discovered topics
+uv tool install conexus                  # install the nx CLI
+nx daemon t2 install --autostart         # register the T2 daemon (launchd / systemd)
+nx doctor                                # verify installation
+nx index repo .                          # index your repo + discover topics (no API keys needed)
+nx search "what does X do"               # semantic search with topic grouping, fully local
+nx taxonomy status                       # see discovered topics
 ```
 
 Update: `uv tool update conexus`
+
+Since 4.34.0 (RDR-120), persistent storage is daemon-mediated so the
+CLI, the Claude Code plugin's MCP server, and dev containers all
+share one arbitrated SQLite writer. `nx daemon t2 install --autostart`
+writes a LaunchAgent (macOS) or systemd user-unit (Linux) so the
+daemon starts at login and respawns on crash. The Claude Code plugin
+also auto-spawns the daemon on each session start, so it's a one-time
+setup. See [Container Integration](https://github.com/Hellblazer/nexus/blob/main/docs/container-integration.md) for the multi-process / container story.
 
 Works immediately with local ONNX embeddings: no accounts, no API keys. For higher-quality cloud embeddings (Voyage AI), see the [cloud setup instructions](https://github.com/Hellblazer/nexus/blob/main/docs/getting-started.md#cloud-mode-optional).
 
@@ -144,6 +153,7 @@ The `nx` command provides direct access to all storage tiers, indexing, and sear
 | `nx taxonomy` | Topic taxonomy: discover, project across collections, review, merge, split |
 | `nx context` | Project context cache: topic map for agent cold-start acceleration |
 | `nx mineru` | MinerU server lifecycle (start/stop/status) for PDF extraction |
+| `nx daemon` | T2 / T3 daemon lifecycle: `start`, `stop`, `status`, `ensure-running`, and `install --autostart` (LaunchAgent on macOS, systemd user-unit on Linux). One-time setup; daemons persist across reboots. |
 
 Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs/cli-reference.md).
 
@@ -158,6 +168,8 @@ Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs
 | [Repo Indexing](https://github.com/Hellblazer/nexus/blob/main/docs/repo-indexing.md) | File classification, chunking pipeline, frecency scoring |
 | [Configuration](https://github.com/Hellblazer/nexus/blob/main/docs/configuration.md) | Config hierarchy, .nexus.yml, tuning parameters |
 | [Architecture](https://github.com/Hellblazer/nexus/blob/main/docs/architecture.md) | Module map, design decisions |
+| [Container Integration](https://github.com/Hellblazer/nexus/blob/main/docs/container-integration.md) | Daemon model, TCP / UDS / Claude Cowork SDK paths, diagnostic recipes |
+| [Upgrading to 4.34.x](https://github.com/Hellblazer/nexus/blob/main/docs/migration/upgrading-to-4.34.md) | RDR-120 substrate shift: one new command after upgrade, schema-handshake, container/Cowork integration |
 | [Contributing](https://github.com/Hellblazer/nexus/blob/main/docs/contributing.md) | Dev setup, testing, code style |
 | [How I actually use Nexus](https://tensegrity.blog/2026/04/26/how-i-actually-use-nexus/) | Blog overview: the substrate as a control surface for developers, teams, and agents |
 | [Installing Nexus](https://tensegrity.blog/2026/04/26/installing-nexus/) | Blog install walkthrough: prerequisites, CLI, plugin, short tour |

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ Nexus provides persistent memory and semantic search for AI coding agents. Begin
 - [Memory and Tasks](memory-and-tasks.md) — T2 memory, beads integration, session context
 - [MCP Servers](mcp-servers.md) — The two bundled MCP servers (`nexus` + `nexus-catalog`), tool reference, and the 6 CLI-only operations
 - [Repo Indexing](repo-indexing.md) — File classification, tree-sitter chunking, frecency scoring
-- [Configuration](configuration.md) — Config hierarchy, `.nexus.yml`, settings
+- [Configuration](configuration.md) — Config hierarchy, `.nexus.yml`, daemon env-vars, settings
+- [Container Integration](container-integration.md) — Daemon model (RDR-120, 4.34.0+) for dev containers, Claude Cowork, and multi-process / multi-host setups
 
 ## RDR (Research-Design-Review)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,6 +112,10 @@ MVV) but NOT through Docker Desktop's macOS/Windows VM file-
 sharing layer (returns ``ENOTSUP``); use the TCP path when the
 host is macOS or Windows.
 
+For the full container-integration story (operator-facing setup,
+Claude Cowork SDK transport, diagnostic recipes, failure-mode
+table) see [`docs/container-integration.md`](container-integration.md).
+
 Data flows upward (T1 → T2 → T3).
 
 ## Catalog & Link Graph

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1320,6 +1320,153 @@ Introduced 4.18.0 (`nexus-mrzp`). `disable` flips `outcome=disabled` on the plan
 
 ---
 
+## nx daemon
+
+T2 and T3 daemon lifecycle (RDR-120). Since conexus 4.34.0, all
+user-facing CLI commands that touch persistent state (`nx memory`,
+`nx index`, `nx store`, `nx catalog`, `nx_answer` and the MCP
+tools) route through the T2 daemon process so multi-process
+consumers — host CLI + Cowork sessions + dev containers + the
+nx-mcp server — share one arbitrated SQLite writer instead of
+each opening their own connection.
+
+The daemons are infrastructure: start them once at login and
+leave them running. For a brand-new install the recommended setup
+sequence is:
+
+```
+uv tool install conexus
+nx daemon t2 install --autostart           # writes LaunchAgent/systemd unit
+nx daemon t2 status                        # confirm running
+# (local-mode T3 only)
+nx daemon t3 install --autostart
+```
+
+Cloud-mode T3 uses HTTP transport directly to ChromaDB Cloud and
+has no daemon; only `t2` is needed in that configuration.
+
+When the nx Claude Code plugin is installed, the plugin's
+SessionStart hook auto-spawns the T2 daemon via
+`nx daemon t2 ensure-running` on every Claude Code session start,
+so first-session-after-install works without any manual incantation.
+For long-lived background daemons that survive across reboots
+independent of Claude Code, use `install --autostart` as above.
+
+### nx daemon t2 start
+
+Start the T2 daemon in the foreground. The daemon IS this Python
+process (asyncio event loop until SIGTERM/SIGINT). Run under
+launchd / systemd via `nx daemon t2 install --autostart` for
+production use; direct foreground invocation is for debugging or
+explicit one-shot starts.
+
+| Flag | Description |
+|------|-------------|
+| `--config-dir PATH` | Config directory override (default: `~/.config/nexus/`) |
+| `--db-path PATH` | Override the memory.db path (default: `nexus.config.default_db_path()`) |
+
+Fails fast with `T2DaemonError` if another T2 daemon already holds
+the spawn lock on the same config_dir.
+
+### nx daemon t2 stop
+
+Send SIGTERM to the running T2 daemon. Reads the PID from the
+discovery file at `~/.config/nexus/t2_addr.<uid>` and signals it.
+Idempotent — exits cleanly if no daemon is running.
+
+| Flag | Description |
+|------|-------------|
+| `--config-dir PATH` | Config directory override |
+
+### nx daemon t2 status
+
+Print the T2 daemon discovery JSON: PID, UDS path, TCP host/port,
+daemon version, start time.
+
+| Flag | Description |
+|------|-------------|
+| `--config-dir PATH` | Config directory override |
+| `--json` | Output raw JSON (default: pretty-print) |
+
+Exit code 1 if no daemon is running.
+
+### nx daemon t2 ensure-running
+
+Idempotent: silent no-op if the T2 daemon is already running on the
+named config_dir, otherwise spawns it in the background (detached
+subprocess) and polls the discovery file until reachable (or the
+timeout expires).
+
+Stale discovery files left behind by crashed daemons trigger a
+fresh spawn rather than a false-positive — the probe is
+`os.kill(pid, 0)` against the discovery-file PID.
+
+| Flag | Description |
+|------|-------------|
+| `--config-dir PATH` | Config directory override |
+| `--timeout SECONDS` | Wait up to N seconds for spawn (default: 5.0) |
+| `--quiet` | Suppress "already running" / "spawned" messages; only print errors |
+
+Exit codes:
+- `0`: reachable (already running OR successfully spawned)
+- `1`: spawned but did not become reachable within `--timeout`
+
+Used by the nx plugin's SessionStart hook; safe to invoke from any
+post-install script that needs the daemon up before running other
+commands.
+
+### nx daemon t2 install --autostart
+
+Write a launchd plist (macOS) or systemd user unit (Linux) so the
+T2 daemon starts at login / boot and respawns on crash.
+
+| Flag | Description |
+|------|-------------|
+| `--autostart` | Required. Confirms intent to write an OS autostart entry. |
+| `--force` | Overwrite an existing plist / unit file when its content differs from the freshly rendered template. |
+
+The plist / unit file lands in the per-user autostart directory:
+
+- macOS: `~/Library/LaunchAgents/com.nexus.t2.plist` (`KeepAlive=true`, `RunAtLoad=true`)
+- Linux: `~/.config/systemd/user/nexus-t2.service` (`Restart=on-failure`, `WantedBy=default.target`)
+
+After write, the command activates the unit:
+
+- macOS: `launchctl bootstrap gui/<uid> ~/Library/LaunchAgents/com.nexus.t2.plist`
+- Linux: `systemctl --user enable --now nexus-t2.service`
+
+Logs:
+- macOS: `~/Library/Logs/nexus-t2.log` / `nexus-t2.err`
+- Linux: `journalctl --user -u nexus-t2.service`
+
+Idempotent — running twice doesn't duplicate the plist or the
+service unit. Re-render and re-activate on `conexus` upgrades by
+running `nx daemon t2 install --autostart` again (the rendered
+template's `__NX_BIN__` resolves to the current `nx` binary path).
+
+### nx daemon t2 uninstall --autostart
+
+Reverse of `install --autostart`: deactivate via
+`launchctl bootout` (macOS) / `systemctl --user disable --now`
+(Linux) then unlink the plist / unit file.
+
+| Flag | Description |
+|------|-------------|
+| `--autostart` | Required. |
+
+### nx daemon t3 start / stop / status / install / uninstall
+
+Same shape as the `t2` subcommands, applies to the T3 daemon.
+**Only used in local mode (`NX_LOCAL=1` or no cloud credentials).**
+Cloud-mode T3 talks directly to ChromaDB Cloud via HTTP and has no
+daemon process — `nx daemon t3` is a no-op there.
+
+Local-mode T3 wraps the upstream `chroma run` server lifecycle
+under launchd / systemd supervision; templates ship as
+`com.nexus.t3.plist` / `nexus-t3.service`.
+
+---
+
 ## nx upgrade
 
 Run pending database migrations and T3 upgrade steps.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,6 +130,28 @@ taxonomy:
 | `local_exclude_collections` | `["code__*"]` | Glob patterns for collections to skip in local mode. Cloud mode (Voyage embeddings) ignores this — set to `[]` to enable all collections locally. |
 | `collection_prefixes` | `["docs", "code", "knowledge", "rdr"]` | Prefix whitelist for `nx taxonomy validate-refs`. Extend this when your project adds a new user-facing collection prefix (e.g. `"custom"`). Internal-prefix collections (`taxonomy__*`, `plans__*`) are implementation-fixed and intentionally excluded. |
 
+## Daemon environment variables
+
+Since conexus 4.34.0 (RDR-120 storage substrate split), the CLI and
+MCP server route through the T2 and (local-mode) T3 daemons. The
+daemons publish their address via discovery files at
+`~/.config/nexus/t2_addr.<uid>` and `t3_addr.<uid>`; clients also
+honour these env-var overrides:
+
+| Variable | Effect | Default |
+|----------|--------|---------|
+| `NX_T2_ADDR` | TCP `host:port` for the T2 daemon (e.g. `host.docker.internal:55459`). Used by dev containers reaching the host's loopback. | discovery file |
+| `NX_T2_SOCK` | UDS path for the T2 daemon (Linux-only when bind-mounted from the host into a container). Mutually exclusive with `NX_T2_ADDR`. | discovery file |
+| `NX_T3_ADDR` | TCP `host:port` for the local-mode T3 daemon. Cloud-mode T3 ignores this. | discovery file |
+| `NX_LOCAL` | Force local-mode T3 (ONNX MiniLM) even when cloud credentials exist. Local mode requires the T3 daemon. | unset (cloud mode if credentials present) |
+
+When all env vars are unset, the client falls back to the discovery
+file. If no daemon is reachable, the CLI raises
+`T2DaemonNotReachableError` with a hint to run
+`nx daemon t2 ensure-running` or `install --autostart`. See
+[Container Integration](container-integration.md) for the full
+operator-facing matrix of transport choices per platform.
+
 ## Tuning Parameters
 
 The `[tuning]` section in `~/.config/nexus/config.yml` controls search scoring, chunking, and timeout behavior. All values have sensible defaults — only override what you need.

--- a/docs/container-integration.md
+++ b/docs/container-integration.md
@@ -1,0 +1,303 @@
+# Container integration
+
+Running nexus from inside a container — Docker dev container, Claude
+Cowork VM, CI agent, multi-agent Co-Work session — and sharing T2 /
+T3 state with the host CLI Claude and any other nexus consumers.
+
+This page assumes RDR-120 4.34.1+ is installed on the host. Earlier
+releases ran every consumer against its own SQLite file and silently
+diverged across containers; the daemon model in 4.34.x is what makes
+shared state real.
+
+## TL;DR
+
+The integration model has **one rule**: every nexus consumer talks to
+the host's T2 / T3 daemons. The container reaches the daemons either
+via loopback TCP, a mounted Unix socket, or via Anthropic's SDK
+transport (Claude Cowork). The CLI commands in 4.34.1+ honour this
+automatically; tests that previously opened the SQLite file directly
+have been migrated to route through `T2Client`.
+
+Picking a path:
+
+| Host platform | Container runtime | Use |
+|---|---|---|
+| any | **Claude Cowork** | SDK transport (zero config; see § Cowork below) |
+| Linux | Docker / Podman, host-network | TCP loopback (`--network=host` + `NX_T2_ADDR=127.0.0.1:<port>`) |
+| Linux | Docker / Podman, default-bridge | TCP via host-gateway (`--add-host=host.docker.internal:host-gateway`) |
+| Linux | Docker / Podman, network-isolated | UDS mount (`--user $(id -u):$(id -g)` + `NX_T2_SOCK=...`) |
+| macOS | Docker Desktop | TCP via `host.docker.internal` (UDS unsupported across the macOS↔VM kernel boundary) |
+| Windows | Docker Desktop (WSL2) | TCP via `host.docker.internal` (UDS unsupported across the WSL2 boundary) |
+
+## Prerequisites on the host
+
+```
+# Always
+nx daemon t2 start
+
+# Local-mode T3 only (cloud-mode T3 is already HTTP-served; no daemon)
+nx daemon t3 start
+```
+
+Confirm the daemons:
+
+```
+$ nx daemon t2 status
+T2 Daemon Status
+  format_version: 1
+  uds_path:       /Users/<user>/.config/nexus/sockets/t2.sock
+  tcp_host:       127.0.0.1
+  tcp_port:       49177       ← the dynamic port the container will reach
+  pid:            12345
+  daemon_version: 4.34.1
+```
+
+The TCP port is dynamic — read it via `nx daemon t2 status` or
+`cat ~/.config/nexus/t2_addr.$(id -u)`. The container needs that
+value.
+
+## Path A: TCP loopback (most portable)
+
+The T2 daemon binds `127.0.0.1:<port>` (always) and a Unix socket at
+`<config-dir>/sockets/t2.sock`. For container-to-host traffic the
+TCP loopback is the simplest path; it's the only one that works on
+macOS / Windows Docker Desktop.
+
+### macOS Docker Desktop
+
+```bash
+PORT=$(nx daemon t2 status | grep tcp_port | awk '{print $2}')
+docker run --rm \
+    -e NX_T2_ADDR=host.docker.internal:$PORT \
+    -e NX_T3_ADDR=host.docker.internal:<t3_port>   # local-mode T3 only
+    <image-with-conexus>
+```
+
+`--network=host` does NOT work on macOS Docker Desktop — the
+container's `127.0.0.1` stays in the container's own namespace.
+Docker Desktop's built-in `host.docker.internal` DNS name reaches
+the macOS host's loopback through the VM gateway.
+
+### Linux (default-bridge network)
+
+```bash
+docker run --rm \
+    --add-host=host.docker.internal:host-gateway \
+    -e NX_T2_ADDR=host.docker.internal:$PORT \
+    <image>
+```
+
+The `--add-host=host.docker.internal:host-gateway` flag is the
+documented Docker pattern that synthesizes the same DNS name the
+macOS Desktop runtime provides natively.
+
+### Linux (host-network mode)
+
+```bash
+docker run --rm --network=host \
+    -e NX_T2_ADDR=127.0.0.1:$PORT \
+    <image>
+```
+
+The container shares the host's network namespace. Simplest from a
+networking standpoint, but the container loses network isolation;
+prefer default-bridge unless you have a specific reason for
+host-network.
+
+## Path B: Unix-socket mount (Linux native)
+
+The T2 daemon's UDS at `~/.config/nexus/sockets/t2.sock` is created
+mode `0o600` owned by the daemon-process UID. Mounting it into a
+container is the safer transport (kernel-level UID gate; no TCP
+attack surface) but requires that the container runs as the same
+UID as the daemon process and that the host kernel can pass UDS
+state into the container.
+
+**Working only on native Linux Docker.** Docker Desktop on macOS /
+Windows uses a Linux VM under the hood; the macOS / Windows kernel
+cannot transmit `connect()` calls across the file-sharing layer
+(returns `ENOTSUP` / errno 95).
+
+```bash
+docker run --rm \
+    --user $(id -u):$(id -g) \
+    -v ~/.config/nexus/sockets:/host-nexus-sockets \
+    -e NX_T2_SOCK=/host-nexus-sockets/t2.sock \
+    <image-with-conexus>
+```
+
+`--user $(id -u):$(id -g)` is non-negotiable. Without it the
+container runs as UID 0 (root) inside its user namespace, and the
+socket's `0o600` permission gate fires `EACCES` (errno 13). The
+CLI's error message names the fix.
+
+T3 has no UDS path; the T3 daemon is HTTP-only (chromadb upstream
+contract). Use the TCP path for T3 even when T2 goes through UDS.
+
+## Path C: Operator-side forward (fallback)
+
+When neither host-gateway nor UDS-mount is acceptable, an operator
+can forward the host's loopback port into the container via
+`socat`, `ssh -L`, or a sidecar proxy:
+
+```bash
+# socat sidecar listening on a routable address
+socat TCP-LISTEN:9999,fork,bind=172.17.0.1 TCP:127.0.0.1:$PORT
+
+# Container points at the forwarded endpoint
+docker run --rm \
+    -e NX_T2_ADDR=172.17.0.1:9999 \
+    <image>
+```
+
+This is documented for completeness; if you're reaching for this,
+prefer one of the supported paths first. Non-loopback TCP from the
+daemon itself is on RDR-120's §Out of scope banlist (no auth model
+exists yet) — Path C uses a host-side forwarder, not a daemon
+binding change.
+
+## Claude Cowork (special case)
+
+Claude Cowork runs a Linux VM via Apple's Virtualization Framework
+on macOS. The VM has a **strict network allowlist** — only
+`api.anthropic.com`, `pypi.org`, and `registry.npmjs.org` are
+reachable. The TCP loopback and UDS-mount paths above **do not
+apply** to Cowork: the VM cannot reach `127.0.0.1`,
+`host.docker.internal`, or mount arbitrary host paths.
+
+**The integration model for Cowork is the MCP SDK transport, not
+the network.**
+
+What works:
+
+1. Install the nx plugin in your Claude Code installation:
+   `/plugin install nx`. The plugin registers `nx-mcp` as an MCP
+   server in your Claude Desktop config.
+2. Start the daemons on the host: `nx daemon t2 start` (and
+   `nx daemon t3 start` if local-mode).
+3. Open a Cowork session. Claude Desktop **passes the configured
+   MCP servers into the VM via `--mcp-config` with
+   `"type": "sdk"`** — the MCP server itself stays running on the
+   host; the VM agent's tool calls are bridged back through the
+   Anthropic SDK channel, not through the network.
+4. Inside the VM, the Cowork agent has
+   `mcp__plugin_nx_nexus__memory_put`, `mcp__plugin_nx_nexus__search`,
+   etc. available. Every call round-trips: VM agent → SDK bridge →
+   host nx-mcp → host T2/T3 daemons → shared state.
+
+State is shared bidirectionally with the host CLI Claude (which
+routes through the same daemons via w6txl's CLI migration) and any
+other Co-Work sessions or dev containers running against the same
+host daemons.
+
+You cannot run `nx memory put` from the **shell** inside a Cowork
+VM and expect it to reach the host's daemons — the VM has no
+network path to them. Use the MCP tools from the agent, not the
+CLI from the shell.
+
+## Environment variable reference
+
+| Variable | Effect | Default |
+|---|---|---|
+| `NX_T2_ADDR` | TCP host:port for the T2 daemon | discovery file |
+| `NX_T2_SOCK` | UDS path for the T2 daemon | discovery file |
+| `NX_T3_ADDR` | TCP host:port for the T3 daemon | discovery file |
+| `NX_PYTEST_DAEMON_MODE` | (tests only) skip the conftest direct-mode pin | unset |
+
+`NX_T2_ADDR` and `NX_T2_SOCK` are mutually exclusive — set one or
+the other. When both env vars are unset, the T2 client falls back
+to the discovery file at `~/.config/nexus/t2_addr.<uid>` (mounted
+into the container if the operator chooses, otherwise unreachable).
+
+## T1 (scratch) isolation across containers
+
+T1 is **process-local by design** (RDR-105). Each container runs
+its own per-process ephemeral chromadb backend. Cross-container T1
+sharing is **not supported** — containers must use T2
+(`memory_put` / `memory_get`) for any state they want visible
+across processes.
+
+This is the right model for the use cases T1 was built for
+(session scratch, per-agent working memory). If two Cowork agents
+need to coordinate, they coordinate through T2; T1 is for the
+single-agent process's own short-term notes.
+
+## Diagnostic recipes
+
+### "Is the container reaching the host daemon?"
+
+```bash
+# Inside the container
+nx daemon t2 status              # discovers via env var or addr file
+nx memory put -p _diag -t ping "test" --ttl=1d
+nx memory get -p _diag -t ping   # should round-trip
+```
+
+```bash
+# On the host
+nx memory get -p _diag -t ping   # must see the container's write
+```
+
+If the host can't see what the container just wrote, the container
+is talking to a different (container-local) SQLite. Check that the
+container's `NX_T2_ADDR` / `NX_T2_SOCK` is actually set, and that
+the daemon's address matches.
+
+### Common failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `T2DaemonNotReachableError` from CLI | Container has no path to daemon | Set `NX_T2_ADDR` to the host's daemon TCP port |
+| `[Errno 95] Operation not supported` on UDS | macOS/Windows Docker Desktop VM-boundary limit | Switch to the TCP path |
+| `[Errno 13] Permission denied` on UDS | UID mismatch | `--user $(id -u):$(id -g)` |
+| `[Errno 111] Connection refused` on TCP | Daemon not running, or wrong port | `nx daemon t2 status` on the host; verify port matches `NX_T2_ADDR` |
+| Container writes succeed but host can't see them | Container falling back to local SQLite | (4.34.0 only) Upgrade to 4.34.1+; verify CLI is using `t2_handle()` |
+| Cowork agent's `mcp_*` tool returns error | Host daemon down or nx plugin not enabled | Start daemons; `/plugin list` to confirm nx plugin is active |
+
+### `T2SchemaVersionMismatchError`
+
+The CLI handshakes with the daemon on first connect (RDR-120 P3b).
+A mismatch means the container's installed `conexus` version
+differs from the host daemon's version:
+
+```
+T2 schema version mismatch: client built against '4.34.1',
+daemon reports '4.32.0'. Re-install conexus so both sides match,
+then restart the T2 daemon: `nx daemon t2 stop && nx daemon t2 start`.
+```
+
+Pin the same conexus version in your container image as on the
+host:
+
+```dockerfile
+# Container image
+FROM python:3.13-slim
+RUN pip install --no-cache-dir conexus==4.34.1
+```
+
+```bash
+# Host
+nx --version    # must match the container's pinned version
+```
+
+## Why non-loopback TCP isn't a path
+
+The T2 daemon binds 127.0.0.1 exclusively. Binding to 0.0.0.0
+would let any host on the network reach the daemon — and the
+substrate has **no authentication model**. RDR-120 §Out of scope
+puts both "non-loopback TCP" and "network auth" on the moratorium
+banlist; they would require an RDR addressing the security model
+(at minimum: peer credentials, mutual TLS, or HMAC-signed frames).
+
+If you need cross-host nexus access (CI runners reaching a
+shared daemon, multi-machine teams), the right primitive is an
+SSH tunnel or VPN that turns the cross-host traffic into a
+loopback connection at the daemon end. That's Path C above.
+
+## Related
+
+- `docs/architecture.md` § Storage tiers — daemon-mediated substrate diagram
+- `docs/rdr/rdr-120-storage-substrate-split.md` — the design + soak phasing
+- `CHANGELOG.md` [4.34.0] / [4.34.1] — substrate split release notes
+- Container MVV receipts in T2 — `120-container-mvv-tcp-receipt`,
+  `120-container-mvv-uds-receipt`, `120-container-pypi-smoke-receipt`

--- a/docs/container-integration.md
+++ b/docs/container-integration.md
@@ -31,6 +31,8 @@ Picking a path:
 
 ## Prerequisites on the host
 
+For one-shot starts:
+
 ```
 # Always
 nx daemon t2 start
@@ -38,6 +40,27 @@ nx daemon t2 start
 # Local-mode T3 only (cloud-mode T3 is already HTTP-served; no daemon)
 nx daemon t3 start
 ```
+
+For durable always-running daemons (recommended for any host that
+runs Claude Code regularly):
+
+```
+nx daemon t2 install --autostart          # writes the LaunchAgent / systemd unit
+nx daemon t3 install --autostart          # local-mode T3 only
+```
+
+This installs `~/Library/LaunchAgents/com.nexus.t2.plist` on macOS or
+`~/.config/systemd/user/nexus-t2.service` on Linux, with `KeepAlive=true`
+/ `Restart=on-failure` so the daemon survives crashes and reboots.
+Uninstall with `nx daemon t2 uninstall --autostart`.
+
+When Claude Code is the primary consumer, the nx plugin's
+**SessionStart hook** also runs `nx daemon t2 ensure-running --quiet`
+on every Claude session start, so the daemon is auto-spawned on the
+first session after `pip install conexus` even if you haven't yet
+run `nx daemon t2 install`. The hook is idempotent — when the daemon
+is already running (from the LaunchAgent or a manual start) it's a
+silent no-op.
 
 Confirm the daemons:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,8 +6,33 @@
 git clone https://github.com/Hellblazer/nexus.git
 cd nexus
 uv sync
-scripts/reinstall-tool.sh   # install nx CLI (preserves optional extras)
-nx hooks install             # auto-index this repo on every commit
+scripts/reinstall-tool.sh           # install nx CLI (preserves optional extras)
+nx daemon t2 install --autostart    # T2 daemon at login (RDR-120, 4.34.0+)
+nx hooks install                     # auto-index this repo on every commit
+```
+
+The `nx daemon t2 install --autostart` step writes a LaunchAgent (macOS)
+or systemd user-unit (Linux) so the T2 daemon starts at login and
+survives across dev-machine reboots. Without it the unit suite and
+many CLI commands fail loud with `T2DaemonNotReachableError`. For an
+explicit one-shot start, use `nx daemon t2 ensure-running` instead.
+
+If you're hacking on the daemon itself, you'll want to manually stop
+the LaunchAgent-managed instance and run `nx daemon t2 start` in the
+foreground:
+
+```bash
+launchctl bootout gui/$(id -u)/com.nexus.t2     # macOS
+# or
+systemctl --user stop nexus-t2.service          # Linux
+nx daemon t2 start                              # foreground, ^C to stop
+```
+
+After every conexus version bump (including local edits), restart the
+LaunchAgent-managed daemon so it picks up the new code:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nexus.t2
 ```
 
 ## Running Tests

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,11 +43,63 @@ If you don't intend to index math PDFs and want to skip the download, run with `
 nx index pdf --extractor docling some.pdf
 ```
 
+## First-time setup: the T2 daemon
+
+Since conexus 4.34.0 (RDR-120 storage substrate split), all
+user-facing CLI commands that touch persistent state — `nx memory`,
+`nx index`, `nx store`, `nx catalog`, the MCP server, and everything
+the Claude Code plugin does — route through the **T2 daemon**, a
+single arbitrating SQLite-writer process. This is the substrate
+fix that lets host CLI usage, multiple Claude Code sessions, Claude
+Cowork agents, and dev containers all share state without racing on
+the database file.
+
+Register the daemon to start at login (one-time setup):
+
+```bash
+nx daemon t2 install --autostart
+nx daemon t2 status                # confirm running
+```
+
+This writes a LaunchAgent (macOS, `~/Library/LaunchAgents/com.nexus.t2.plist`)
+or systemd user-unit (Linux, `~/.config/systemd/user/nexus-t2.service`)
+with `KeepAlive=true` / `Restart=on-failure`, so the daemon survives
+crashes and reboots. Uninstall with `nx daemon t2 uninstall --autostart`.
+
+If you skip this step, the nx Claude Code plugin's SessionStart hook
+will auto-spawn the daemon on every session start anyway, so plugin
+users still get a working substrate. The autostart path is recommended
+if you also use `nx` directly from the shell.
+
+**Local-mode T3 only**: the T3 daemon wraps a local ChromaDB process.
+Register it the same way:
+
+```bash
+nx daemon t3 install --autostart   # only when NX_LOCAL=1 / no cloud creds
+```
+
+Cloud-mode T3 talks directly to ChromaDB Cloud over HTTP and has no
+daemon — `nx daemon t3` is a no-op in that configuration.
+
+See [docs/container-integration.md](https://github.com/Hellblazer/nexus/blob/main/docs/container-integration.md) for the full daemon-model story
+including TCP / UDS / Cowork transport details.
+
 ## Update
 
 ```bash
 uv tool update conexus
 ```
+
+After upgrading conexus, restart the daemon so it picks up the new
+binary:
+
+```bash
+nx daemon t2 stop && nx daemon t2 start    # or: launchctl kickstart -k gui/<uid>/com.nexus.t2
+```
+
+The schema-version handshake (RDR-120 P3b) fails loud on
+client/daemon version mismatch, so stale daemons fail closed rather
+than silently corrupting state.
 
 ## Use it (no API keys needed)
 
@@ -221,6 +273,29 @@ Note: `uv tool update` reuses the existing environment's Python — it won't swi
 **First index is slow or hits a rate limit** — Large repos may take a few minutes. Add `--monitor` for per-file progress. Re-running is safe — unchanged files are skipped.
 
 **`nx search` returns no results** — Run `nx doctor` to verify connectivity. If indexing was interrupted, re-run `nx index repo .` to resume.
+
+**`T2DaemonNotReachableError: No T2 daemon discovery resolved`** — Since 4.34.0 the CLI routes through the T2 daemon. Start it (one of):
+
+```bash
+nx daemon t2 ensure-running              # one-shot spawn (idempotent)
+nx daemon t2 install --autostart         # durable LaunchAgent / systemd unit
+```
+
+If `ensure-running` succeeds but the next command still errors, check
+the daemon's log:
+
+- macOS: `~/Library/Logs/nexus-t2.err`
+- Linux: `journalctl --user -u nexus-t2.service`
+
+**`T2SchemaVersionMismatchError`** — The client's conexus version differs from the running daemon's. Restart the daemon so it picks up the new binary:
+
+```bash
+nx daemon t2 stop && nx daemon t2 start
+# or under launchd:
+launchctl kickstart -k gui/$(id -u)/com.nexus.t2
+```
+
+**Daemon is up but the CLI says "discovery file not found"** — Race between `launchctl bootout` / `systemctl stop` and the next CLI call. The daemon's spawn-lock release lags briefly behind process termination. Wait 2–3 seconds and retry, or use `nx daemon t2 ensure-running --timeout=10`.
 
 **Upgrading from an earlier version — topics missing from search** — Topic discovery runs automatically on new indexes. To populate topics for collections indexed before this feature was added, run:
 

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -221,6 +221,29 @@ The rule of thumb: **content** (chunks, documents, notes) is on `nexus`,
 on `nexus-catalog`. `query` is the one core-server tool that crosses the
 boundary — it uses catalog metadata to scope a content search.
 
+## Heads-up: `alwaysLoad` and Claude Code v2.1.69+ tool deferral
+
+Starting in Claude Code **v2.1.69**, schema-deferral was extended from
+MCP tools (deferred since the `ToolSearch` rollout) to most built-in
+tools as well. Only ~10 core tools load eagerly — everything else,
+including all MCP servers, becomes discoverable via `ToolSearch` only.
+The space saving is real (~14k tokens), but the behavioural side effect
+is that the model often skips the `ToolSearch` step and answers without
+ever loading the MCP schemas. Combined with **Opus 4.7**'s documented
+"fewer tool calls by default" and "more literal instruction following"
+disposition, plugin-heavy users see Serena, sequential-thinking, and
+nexus only fire when explicitly named.
+
+Both nx and sn plugin `.mcp.json` files ship with
+`"alwaysLoad": true` on every server. Claude Code v2.1.121+ honours
+this per-server flag and skips the deferral, so schemas load eagerly
+again. If you fork or customise these files, keep the flag — otherwise
+you'll see the same regression.
+
+References:
+- [anthropics/claude-code#31002](https://github.com/anthropics/claude-code/issues/31002) — built-in tool deferral
+- [Opus 4.7 model card](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7) — disposition shifts
+
 ## References
 
 - [Architecture § Module Map (MCP Servers row)](architecture.md#module-map) — developer-oriented internals

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -38,6 +38,16 @@ Both servers are bundled in the `nx` plugin's `.mcp.json`. Installing the
 plugin (`/plugin install nx@nexus-plugins`) registers both with Claude Code
 automatically. No separate install step.
 
+**Substrate dependency**: Since conexus 4.34.0 (RDR-120), the MCP servers'
+storage tools route through the T2 daemon (and the T3 daemon in local mode).
+The plugin's SessionStart hook auto-spawns `nx daemon t2 ensure-running` on
+every Claude Code session start, so first-call-after-install works without
+any manual setup. For a daemon that survives reboots independent of Claude
+Code, run `nx daemon t2 install --autostart` once. See
+[Container Integration](container-integration.md) for the multi-process /
+multi-host story (host CLI + multiple Claude Code sessions + Cowork agents +
+dev containers all sharing one arbitrated SQLite writer).
+
 ## `nexus` — retrieval + storage (26 tools)
 
 Full tool names follow Claude Code's convention: `mcp__plugin_nx_nexus__<tool>`.

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,6 +1,14 @@
-# Migration directory: HISTORICAL forensic records
+# Migration directory
 
-Everything in this directory is a frozen engineering artifact from the RDR-101 event-sourced catalog migration (Phases 0-6, shipped April-May 2026). The migration is complete; the verbs these docs reference (`synthesize-log`, `t3-backfill-doc-id`, `repair-orphan-chunks`, `prune-deprecated-keys`, `migrate`) were retired in nexus-iftc (PR #496+#497).
+## Active operator-facing guides
+
+- **[Upgrading to 4.34.x](upgrading-to-4.34.md)** — RDR-120 storage
+  substrate split: the daemon model, the one new command after upgrade,
+  schema-version handshake, container/Cowork integration, rollback.
+
+## Historical forensic records
+
+Everything below is a frozen engineering artifact from the RDR-101 event-sourced catalog migration (Phases 0-6, shipped April-May 2026). The migration is complete; the verbs these docs reference (`synthesize-log`, `t3-backfill-doc-id`, `repair-orphan-chunks`, `prune-deprecated-keys`, `migrate`) were retired in nexus-iftc (PR #496+#497).
 
 ## What's here
 

--- a/docs/migration/upgrading-to-4.34.md
+++ b/docs/migration/upgrading-to-4.34.md
@@ -1,0 +1,147 @@
+# Upgrading to conexus 4.34.x — RDR-120 storage substrate split
+
+**TL;DR — one new command after upgrading:**
+
+```bash
+uv tool update conexus
+nx daemon t2 install --autostart       # NEW — register T2 daemon at login
+# (local-mode T3 only)
+nx daemon t3 install --autostart       # NEW — register T3 daemon at login
+```
+
+If you use the `nx` plugin in Claude Code, the SessionStart hook
+auto-spawns the daemon on every session start. The `install --autostart`
+command above is still recommended if you also use `nx` directly from
+the shell, because it survives across reboots independent of Claude
+Code lifecycle.
+
+That's it for the user-facing upgrade. The rest of this page explains
+**why** the change happened and what it means for multi-process and
+container scenarios.
+
+## What changed
+
+Pre-4.34.0, every nexus consumer (CLI, MCP server, dev containers,
+multiple Claude Code sessions) opened its own SQLite connection to the
+T2 database and relied on SQLite's WAL to arbitrate writes. This worked
+for single-host single-process usage but had real failure modes:
+
+- Two Claude Code sessions racing on the same T2 → SQLite busy retries,
+  occasional SQLITE_BUSY escapes under load.
+- A dev container with conexus installed couldn't share state with the
+  host — each side opened a different SQLite file.
+- Claude Cowork agents had no path to host state at all.
+
+RDR-120 split storage into daemon processes:
+
+- **T2 daemon** (`nx daemon t2`): one process owning all SQLite writes
+  to memory.db. Every consumer talks to it via UDS (Linux) or 127.0.0.1
+  TCP loopback (macOS Docker Desktop / Linux default-bridge / cross-
+  process on the same host).
+- **T3 daemon** (`nx daemon t3`, local mode only): wraps the ChromaDB
+  server lifecycle so multiple consumers share the same vector store.
+  Cloud-mode T3 already used HTTP transport; no change there.
+- Both daemons publish their address via discovery files at
+  `~/.config/nexus/t2_addr.<uid>` / `t3_addr.<uid>`. The client honours
+  `NX_T2_ADDR` / `NX_T2_SOCK` / `NX_T3_ADDR` env-var overrides for
+  container scenarios.
+
+## What you'll see if you skip the upgrade step
+
+If you upgrade conexus but don't run `nx daemon t2 install --autostart`,
+the very next CLI command (or MCP tool call from Claude Code) will
+fail with:
+
+```
+T2DaemonNotReachableError: No t2 daemon discovery resolved.
+Tried env-var (NX_T2_ADDR) and discovery file (~/.config/nexus/t2_addr.<uid>).
+Start with: `nx daemon t2 start`.
+```
+
+The recovery is exactly what the error message says:
+
+```bash
+nx daemon t2 ensure-running             # one-shot spawn (idempotent)
+# OR for durable autostart:
+nx daemon t2 install --autostart
+```
+
+Both options work; the `install --autostart` path is the recommended
+one because it survives reboots and crashes (`KeepAlive=true` on
+macOS LaunchAgent, `Restart=on-failure` on Linux systemd user-unit).
+
+## Container and Claude Cowork users
+
+The substrate split is what makes container ↔ host state sharing
+actually work. Before 4.34.x, you got two copies of state; after,
+you get one arbitrated copy.
+
+- **Dev container with conexus installed** (e.g., `python:3.13-slim
+  + pip install conexus==4.34.2`): set `NX_T2_ADDR=host.docker.internal:<port>`
+  (read the port from `nx daemon t2 status` on the host) and CLI / MCP
+  calls round-trip through the host daemon. Symmetric state with host
+  CLI Claude.
+
+- **Claude Cowork**: zero config. Cowork's MCP-SDK transport bridges
+  the host's `nx-mcp` server into the VM, so agents inside Cowork call
+  MCP tools that round-trip through host's daemons. Same state as host
+  CLI Claude + dev containers + multiple Cowork sessions.
+
+See [Container Integration](../container-integration.md) for the full
+operator-facing matrix (TCP / UDS / SDK-bridge per platform).
+
+## Version compatibility
+
+Conexus 4.34.x clients refuse to talk to mismatched daemons via the
+**schema-version handshake** (RDR-120 P3b). A 4.34.0 client against a
+4.33.x daemon gets:
+
+```
+T2SchemaVersionMismatchError: Client version X does not match daemon Y.
+Restart the daemon: `nx daemon t2 stop && nx daemon t2 start`.
+```
+
+After `uv tool update conexus`, **always restart the daemon** so it
+picks up the new binary. The LaunchAgent / systemd unit will respawn
+the daemon at the new version automatically when stopped:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nexus.t2     # macOS
+# or
+systemctl --user restart nexus-t2.service             # Linux
+```
+
+## Empirical validation
+
+The substrate has been stress-tested under realistic load before this
+upgrade went GA:
+
+- 10,000 monotonic-contiguous writes across 10 parallel cross-process
+  workers (scenario 1).
+- 7,000 mixed put/get/search/delete ops across host CLI + simulated
+  container clients (scenario 2).
+- 53,793 pre-kill writes durable across `kill -9 + restart` (scenario 3).
+- Schema-handshake mismatch handled correctly under load (scenario 4).
+- Catalog rebuild + concurrent T2 writers; catalog projection
+  bit-equal to source (scenario 5).
+
+Receipts in T2 under `nexus_rdr / 120-stress-*-receipt`. See RDR-120
+§Phase 6 for the matrix details.
+
+## Rollback
+
+If you need to roll back to a pre-4.34 version, the schema is
+backward-compatible (no on-disk format change — only the access
+arbitration changed). Stop the daemon, uninstall the autostart unit,
+and downgrade:
+
+```bash
+nx daemon t2 stop
+nx daemon t2 uninstall --autostart
+uv tool install conexus==4.33.1 --force
+```
+
+Your existing T2 / T3 / catalog data is preserved across the
+downgrade. Note that 4.33.x and earlier did NOT have multi-process
+arbitration, so post-rollback you regain the original WAL-race
+behaviour.

--- a/docs/storage-tiers.md
+++ b/docs/storage-tiers.md
@@ -4,12 +4,14 @@ Nexus organizes data across three tiers with increasing durability. Data flows u
 
 **Two access paths**: Humans use the `nx` CLI. Agents use MCP tools (`mcp__plugin_nx_nexus__*`) which call the same Python APIs directly — no Bash dependency. MCP tools that return lists (`search`, `store_list`, `memory_search`) are paged — pass `offset=N` for subsequent pages. See [nx/README.md](../nx/README.md#mcp-servers) for MCP tool details.
 
-| Tier | Storage | Network | Durability | Use |
-|------|---------|---------|------------|-----|
-| T1 -- scratch | ChromaDB HTTP server (per-session) | Localhost only | Session only | Working notes, hypotheses |
-| T2 -- memory | SQLite + FTS5 (WAL) | None | Survives restarts | Per-project notes, session context |
-| T3 -- knowledge | Local ChromaDB (default) or ChromaDB Cloud + Voyage AI | Local: none / Cloud: required | Permanent | Semantic search, indexed code/docs |
-| Catalog | Git-backed JSONL + SQLite | None (optional git remote) | Permanent | Document registry, typed link graph, provenance |
+**One arbitrator per tier**: Since conexus 4.34.0 (RDR-120), both T2 and (local-mode) T3 are wrapped in dedicated daemon processes. Every consumer — host CLI, the MCP server, multiple Claude Code sessions, Claude Cowork agents (via SDK transport), dev containers (via TCP loopback or UDS mount) — routes through the same daemon, so the underlying SQLite / ChromaDB instance has exactly one writer. Start the daemons once via `nx daemon t2 install --autostart` (and `nx daemon t3 install --autostart` in local mode); the Claude Code plugin's SessionStart hook also auto-spawns them on each session start.
+
+| Tier | Storage | Daemon | Transport | Durability | Use |
+|------|---------|--------|-----------|------------|-----|
+| T1 -- scratch | ChromaDB EphemeralClient (per-MCP-process) | none | Process-local | Session only | Working notes, hypotheses |
+| T2 -- memory | SQLite + FTS5 (WAL) | T2 daemon (`nx daemon t2`) | UDS + 127.0.0.1 loopback | Survives restarts | Per-project notes, session context |
+| T3 -- knowledge | Local ChromaDB or ChromaDB Cloud + Voyage AI | local: T3 daemon; cloud: direct HTTPS | local: localhost / cloud: required | Permanent | Semantic search, indexed code/docs |
+| Catalog | T2-store-backed (eighth domain store; RDR-120 P5.A) + events.jsonl (canonical) | shared with T2 daemon | UDS + 127.0.0.1 loopback | Permanent | Document registry, typed link graph, provenance |
 
 The catalog sits alongside T3 as a metadata layer. While T3 stores document *content* as embeddings, the catalog stores document *metadata* and *relationships*. See [Document Catalog](catalog.md).
 

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.34.0",
+  "version": "4.34.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.34.3",
+  "version": "4.34.4",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.34.2",
+  "version": "4.34.3",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.34.1",
+  "version": "4.34.2",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/.mcp.json
+++ b/nx/.mcp.json
@@ -1,20 +1,23 @@
 {
   "sequential-thinking": {
     "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+    "alwaysLoad": true
   },
   "nexus": {
     "command": "nx-mcp",
     "args": [],
     "env": {
       "CLAUDE_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}"
-    }
+    },
+    "alwaysLoad": true
   },
   "nexus-catalog": {
     "command": "nx-mcp-catalog",
     "args": [],
     "env": {
       "CLAUDE_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}"
-    }
+    },
+    "alwaysLoad": true
   }
 }

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,19 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.34.2] - 2026-05-22
+
+Plugin SessionStart hook now runs
+`nx daemon t2 ensure-running --quiet --timeout=5` so the T2 daemon
+auto-spawns on every Claude Code session start. Closes the
+daemon-not-running cliff 4.34.1 introduced: fresh
+`pip install conexus` + `/plugin install nx` produces a working
+substrate on first session without any manual incantation.
+
+The hook is idempotent — when the daemon is already running (from
+`nx daemon t2 install --autostart` or a manual start) it's a
+silent no-op (~5ms).
+
 ## [4.34.1] - 2026-05-22
 
 Plugin version aligned with conexus 4.34.1. No plugin-side changes;

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.34.4] - 2026-05-23
+
+### Restored tool/skill invocation discipline
+
+Tuning for Claude Code v2.1.69+ (built-in tool deferral) and Opus 4.7
+(literal instruction-following + reduced default tool calls). Without
+these changes, plugin-heavy users were seeing Serena, sequential-thinking,
+and nexus only fire when explicitly told.
+
+- `nx/.mcp.json`: added `"alwaysLoad": true` to `sequential-thinking`,
+  `nexus`, and `nexus-catalog`. Claude Code v2.1.121+ honours this per
+  server to skip tool-search deferral so schemas load eagerly.
+- `nx/skills/using-nx-skills/SKILL.md` and `nx/skills/plan-first/SKILL.md`:
+  rewrote descriptions and opening rules as MUST-form imperatives.
+  Opus 4.7 reads soft hints as suggestions; explicit "MUST" / "defect"
+  language survives the literalism shift. The `"Use when"` prefix
+  required by `tests/test_plugin_structure.py::TestSkillDescriptionCSO`
+  is preserved.
+
+References: [anthropics/claude-code#31002](https://github.com/anthropics/claude-code/issues/31002),
+[Opus 4.7 model card](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7).
+
 ## [4.34.3] - 2026-05-22
 
 Plugin version aligned with conexus 4.34.3 — documentation-only
@@ -36,7 +58,6 @@ Plugin version aligned with conexus 4.34.1. No plugin-side changes;
 this is a substrate patch release fixing the CLI-vs-daemon gap
 that 4.34.0 left open. See the conexus 4.34.1 entry in the root
 CHANGELOG for the full RDR-120 P6 follow-up details.
-
 ## [4.34.0] - 2026-05-22
 
 Plugin version aligned with conexus 4.34.0. No plugin-side changes

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.34.3] - 2026-05-22
+
+Plugin version aligned with conexus 4.34.3 — documentation-only
+release. ``nx/README.md`` gains a SessionStart-hook explainer
+showing how the plugin auto-spawns the T2 daemon on every Claude
+Code session start, plus a cross-link to ``docs/container-integration.md``
+for the full multi-process / Claude Cowork integration story.
+
+No agent / skill / hook / MCP-server changes. See the conexus
+4.34.3 entry in the root CHANGELOG for the full doc-sweep details.
+
 ## [4.34.2] - 2026-05-22
 
 Plugin SessionStart hook now runs

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.34.1] - 2026-05-22
+
+Plugin version aligned with conexus 4.34.1. No plugin-side changes;
+this is a substrate patch release fixing the CLI-vs-daemon gap
+that 4.34.0 left open. See the conexus 4.34.1 entry in the root
+CHANGELOG for the full RDR-120 P6 follow-up details.
+
 ## [4.34.0] - 2026-05-22
 
 Plugin version aligned with conexus 4.34.0. No plugin-side changes

--- a/nx/README.md
+++ b/nx/README.md
@@ -28,6 +28,17 @@ The `nx` CLI and plugin work independently, but the plugin's full agent and skil
 
 Run `/nx:nx-preflight` after installing to verify all dependencies are present.
 
+The plugin's SessionStart hook auto-spawns the T2 daemon (`nx daemon
+t2 ensure-running --quiet`) on every Claude Code session start, so a
+fresh `pip install conexus` + `/plugin install nx@nexus-plugins`
+yields a working substrate on first session without any manual
+`nx daemon t2 start` incantation. For a daemon that survives
+across reboots independent of Claude Code (recommended for any host
+with regular `nx` CLI use), run `nx daemon t2 install --autostart`
+once after install. See [Container Integration](../docs/container-integration.md)
+for the full story including dev-container TCP and Claude Cowork
+SDK-bridge transport.
+
 **Companion plugin:**
 - **[sn](../sn/README.md)** — Serena (LSP code intelligence) + Context7 (library docs) with SubagentStart guidance injection. Install separately: `/plugin install sn@nexus-plugins`.
 

--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -11,6 +11,11 @@
           },
           {
             "type": "command",
+            "command": "nx daemon t2 ensure-running --quiet --timeout=5 2>/dev/null || true",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/preflight.py",
             "timeout": 5
           },

--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -11,13 +11,13 @@
           },
           {
             "type": "command",
-            "command": "nx daemon t2 ensure-running --quiet --timeout=5 2>/dev/null || true",
-            "timeout": 10
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/preflight.py",
+            "timeout": 5
           },
           {
             "type": "command",
-            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/preflight.py",
-            "timeout": 5
+            "command": "nx daemon t2 ensure-running --quiet --timeout=5 2>/dev/null || true",
+            "timeout": 10
           },
           {
             "type": "command",

--- a/nx/skills/plan-first/SKILL.md
+++ b/nx/skills/plan-first/SKILL.md
@@ -1,20 +1,16 @@
 ---
 name: plan-first
-description: Use when starting any retrieval task — the gate that tries plan_match first, executes via plan_run if a match clears the threshold, and falls through to /nx:query only on a miss
+description: Use when starting any retrieval task — you MUST call `mcp__plugin_nx_nexus__plan_match` first; if a match clears the threshold you MUST execute it via `mcp__plugin_nx_nexus__plan_run`. Falling through to `/nx:query` is permitted only on a confirmed miss. Skipping this gate is a defect.
 effort: low
 ---
 
 # plan-first
 
-**Gate skill.** Every retrieval-shaped task starts here. The plan
-library exists so agents don't re-derive pipelines that have already
-been authored; this skill is the discipline that enforces it.
+**Hard gate.** Every retrieval-shaped task starts here. **You MUST call `plan_match` before decomposing or dispatching anything else.** The plan library exists so agents don't re-derive pipelines that have already been authored; this skill is the enforcement, not a suggestion.
 
 ## Rule
 
-Before decomposing any retrieval task, call `plan_match` first. If a
-match clears `min_confidence`, execute the returned plan via
-`plan_run`. Only dispatch `/nx:query` when no plan matches.
+Before decomposing any retrieval task, you MUST call `mcp__plugin_nx_nexus__plan_match` first. If a match clears `min_confidence`, you MUST execute the returned plan via `mcp__plugin_nx_nexus__plan_run`. Dispatching `/nx:query` without first checking is a defect.
 
 ## Flow
 

--- a/nx/skills/using-nx-skills/SKILL.md
+++ b/nx/skills/using-nx-skills/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: using-nx-skills
-description: Use when starting any conversation or task — establishes that nx skills must be checked before every response, including clarifying questions. If a skill plausibly applies, invoke it.
+description: Use when starting any turn — you MUST scan the available nx skill list and invoke `Skill` for any matching skill BEFORE producing any other response (clarifying questions, code, or prose included). Direct answers without first invoking a matching skill are a defect. False positives are cheap; misses cost real time.
 effort: low
 ---
 
 # Using nx Skills
 
-If a skill plausibly applies, invoke it. False positives are cheap; misses cost time. Skills evolve — read the current version, don't rely on memory.
+**You MUST invoke `Skill` for any plausibly-matching nx skill before producing any other response.** This is not a hint or a preference — it is a hard rule. Skipping a matching skill is a defect, not an optimization. False positives are cheap; misses cost real time. Skills evolve — read the current version, don't rely on memory.
 
 ## Plan Reuse
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.34.1"
+version = "4.34.2"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.34.2"
+version = "4.34.3"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.34.0"
+version = "4.34.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.34.3"
+version = "4.34.4"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "4.34.3",
+  "version": "4.34.4",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "4.34.0",
+  "version": "4.34.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "4.34.2",
+  "version": "4.34.3",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "4.34.1",
+  "version": "4.34.2",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/sn/.mcp.json
+++ b/sn/.mcp.json
@@ -1,10 +1,12 @@
 {
   "serena": {
     "command": "uvx",
-    "args": ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server", "--context", "claude-code", "--project-from-cwd"]
+    "args": ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server", "--context", "claude-code", "--project-from-cwd"],
+    "alwaysLoad": true
   },
   "context7": {
     "command": "npx",
-    "args": ["-y", "@upstash/context7-mcp"]
+    "args": ["-y", "@upstash/context7-mcp"],
+    "alwaysLoad": true
   }
 }

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -637,6 +637,106 @@ def t2_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
         click.echo(f"  {key}: {value}")
 
 
+@t2_group.command("ensure-running")
+@click.option(
+    "--config-dir",
+    "config_dir_str",
+    default=None,
+    help="Config directory override.",
+)
+@click.option(
+    "--timeout",
+    default=5.0,
+    type=float,
+    help=(
+        "Seconds to wait for the daemon to become reachable after a "
+        "cold spawn. Default: 5.0. macOS Docker Desktop boot adds "
+        "VM-layer latency; raise this to 10+ on slow hosts."
+    ),
+)
+@click.option(
+    "--quiet",
+    is_flag=True,
+    default=False,
+    help="Suppress 'already running' / 'spawned' messages; print only errors.",
+)
+def t2_ensure_running_cmd(
+    config_dir_str: str | None, timeout: float, quiet: bool,
+) -> None:
+    """Ensure the T2 daemon is running; spawn it in the background if not.
+
+    Idempotent — safe to invoke from session-start hooks, post-install
+    scripts, or as a defensive prelude to any operation that needs the
+    daemon. The daemon's own spawn-lock arbitrates concurrent invocations
+    so a race between the plugin hook and a manual ``nx daemon t2 start``
+    can't double-start.
+
+    Exit codes:
+      0 — daemon is reachable (already running, or successfully spawned).
+      1 — daemon was spawned but did not become reachable within ``--timeout``.
+    """
+    import time as _time
+    from nexus.daemon.t2_daemon import t2_discovery_path
+
+    config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
+    disc = t2_discovery_path(config_dir)
+
+    def _daemon_is_alive() -> bool:
+        if not disc.exists():
+            return False
+        try:
+            data = json.loads(disc.read_text())
+        except (OSError, json.JSONDecodeError):
+            return False
+        pid = data.get("pid")
+        if not isinstance(pid, int):
+            return False
+        # Probe the PID — stale discovery files outlive crashed daemons.
+        try:
+            os.kill(pid, 0)
+        except (ProcessLookupError, PermissionError):
+            return False
+        return True
+
+    if _daemon_is_alive():
+        if not quiet:
+            click.echo("T2 daemon already running.")
+        return
+
+    # Cold spawn. Use the same nx binary the operator invoked (preserves
+    # PATH/virtualenv assumptions). start_new_session detaches the child
+    # so this command can exit while the daemon keeps running.
+    nx_bin = _resolve_nx_bin()
+    argv = [*nx_bin, "daemon", "t2", "start"]
+    if config_dir_str is not None:
+        argv.extend(["--config-dir", config_dir_str])
+    if not quiet:
+        click.echo(f"Spawning T2 daemon: {' '.join(argv)}")
+    subprocess.Popen(
+        argv,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    deadline = _time.monotonic() + timeout
+    while _time.monotonic() < deadline:
+        if _daemon_is_alive():
+            if not quiet:
+                click.echo("T2 daemon is reachable.")
+            return
+        _time.sleep(0.1)
+
+    click.echo(
+        f"Warning: T2 daemon did not become reachable within {timeout}s. "
+        "Check ~/Library/Logs/nexus-t2.err (macOS) or "
+        "`journalctl --user -u nexus-t2.service` (Linux) for the failure.",
+        err=True,
+    )
+    sys.exit(1)
+
+
 @t2_group.command("install")
 @click.option(
     "--autostart",

--- a/tests/daemon/test_t2_ensure_running.py
+++ b/tests/daemon/test_t2_ensure_running.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-120 P6 follow-up (nexus-qnrvn): ``nx daemon t2 ensure-running``.
+
+The command is idempotent: silent no-op if a daemon is already running
+on the named config_dir, otherwise spawn a fresh one in the background
+and poll the discovery file until the new daemon is reachable (or the
+timeout expires).
+
+Spawn is mocked — we exercise the discovery-file probe + the spawn-
+argv shape + the timeout path without actually forking a daemon.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+
+
+def _write_discovery(config_dir: Path, pid: int) -> None:
+    """Pre-seed a discovery file shaped like the real daemon writes."""
+    payload = {
+        "format_version": 1,
+        "uds_path": str(config_dir / "sockets" / "t2.sock"),
+        "tcp_host": "127.0.0.1",
+        "tcp_port": 12345,
+        "pid": pid,
+        "daemon_version": "4.34.1",
+        "start_time": "2026-05-22T19:00:00+00:00",
+    }
+    (config_dir / "t2_addr.501").write_text(json.dumps(payload))
+
+
+class TestEnsureRunning:
+    def test_already_running_is_idempotent_silent_no_spawn(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        # Seed the discovery file with the current process's PID — the
+        # probe checks via os.kill(pid, 0) which succeeds for any
+        # running process the caller can signal.
+        _write_discovery(tmp_path, os.getpid())
+
+        spawn_calls: list[list[str]] = []
+
+        def _no_spawn(argv, **_kw):  # noqa: ANN001
+            spawn_calls.append(argv)
+            raise AssertionError("ensure-running must not spawn when daemon is alive")
+
+        monkeypatch.setattr(subprocess, "Popen", _no_spawn)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["daemon", "t2", "ensure-running", "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "already running" in result.output
+        assert spawn_calls == []
+
+    def test_already_running_quiet_suppresses_output(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        _write_discovery(tmp_path, os.getpid())
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda *a, **kw: pytest.fail("must not spawn"),
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["daemon", "t2", "ensure-running",
+             "--config-dir", str(tmp_path), "--quiet"],
+        )
+        assert result.exit_code == 0
+        assert result.output == ""
+
+    def test_stale_discovery_pid_dead_triggers_spawn(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """PID 1 is init (always alive). Use PID 2**31 - 1 which can't
+        be a real PID on any supported platform — os.kill(pid, 0) raises
+        ProcessLookupError, and the probe treats that as 'daemon dead'."""
+        _write_discovery(tmp_path, 2**31 - 1)
+
+        spawn_calls: list[list[str]] = []
+
+        class _FakePopen:
+            def __init__(self, argv, **_kw):  # noqa: ANN001
+                spawn_calls.append(argv)
+
+        monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+        runner = CliRunner()
+        # timeout=0.2 — we expect the spawn to fire but the new daemon
+        # won't actually start (Popen is mocked), so the timeout path
+        # exits 1.
+        result = runner.invoke(
+            main,
+            ["daemon", "t2", "ensure-running",
+             "--config-dir", str(tmp_path), "--timeout", "0.2"],
+        )
+        assert result.exit_code == 1
+        assert len(spawn_calls) == 1
+        argv = spawn_calls[0]
+        # The spawn invokes the nx CLI's ``daemon t2 start`` subcommand
+        # with the same --config-dir the operator passed in. The first
+        # element is the resolved nx binary (or python -m fallback) so
+        # we tail-match on the well-known suffix.
+        assert argv[-4:] == ["daemon", "t2", "start", "--config-dir"] or \
+               argv[-5:] == ["daemon", "t2", "start", "--config-dir", str(tmp_path)]
+
+    def test_missing_discovery_file_triggers_spawn(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        # No discovery file pre-seeded; ensure-running must spawn.
+        spawn_calls: list[list[str]] = []
+
+        class _FakePopen:
+            def __init__(self, argv, **_kw):  # noqa: ANN001
+                spawn_calls.append(argv)
+
+        monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["daemon", "t2", "ensure-running",
+             "--config-dir", str(tmp_path), "--timeout", "0.2"],
+        )
+        # Spawn fired; mock didn't produce a discovery file so timeout=1.
+        assert result.exit_code == 1
+        assert len(spawn_calls) == 1
+        assert "did not become reachable" in result.output
+
+    def test_corrupt_discovery_file_triggers_spawn(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        # Discovery file present but not valid JSON — probe treats as dead.
+        (tmp_path / "t2_addr.501").write_text("not json {{{")
+
+        spawn_calls: list[list[str]] = []
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda argv, **kw: spawn_calls.append(argv) or type(
+                "P", (), {"__init__": lambda self: None}
+            )(),
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["daemon", "t2", "ensure-running",
+             "--config-dir", str(tmp_path), "--timeout", "0.2"],
+        )
+        assert result.exit_code == 1
+        assert len(spawn_calls) == 1
+
+    def test_timeout_message_names_log_paths(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """The timeout warning must point the operator at the launchd /
+        systemd log so they can self-diagnose without spelunking."""
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda argv, **kw: type("P", (), {"__init__": lambda self: None})(),
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["daemon", "t2", "ensure-running",
+             "--config-dir", str(tmp_path), "--timeout", "0.2"],
+        )
+        assert result.exit_code == 1
+        # Both platform-specific log hints appear (the command doesn't
+        # know which platform the operator is on, so it names both).
+        assert "nexus-t2.err" in result.output
+        assert "journalctl --user -u nexus-t2.service" in result.output

--- a/tests/daemon/test_t2_ensure_running.py
+++ b/tests/daemon/test_t2_ensure_running.py
@@ -24,6 +24,16 @@ from click.testing import CliRunner
 from nexus.cli import main
 
 
+def _discovery_path(config_dir: Path) -> Path:
+    """Mirror ``nexus.daemon.t2_daemon.t2_discovery_path`` — the
+    discovery file is keyed by the current UID, not a hardcoded
+    501. macOS dev UIDs are usually 501; Linux GHA runner UIDs are
+    1001. Hardcoding either fails on the other.
+    """
+    from nexus.daemon.t2_daemon import t2_discovery_path
+    return t2_discovery_path(config_dir)
+
+
 def _write_discovery(config_dir: Path, pid: int) -> None:
     """Pre-seed a discovery file shaped like the real daemon writes."""
     payload = {
@@ -35,7 +45,9 @@ def _write_discovery(config_dir: Path, pid: int) -> None:
         "daemon_version": "4.34.1",
         "start_time": "2026-05-22T19:00:00+00:00",
     }
-    (config_dir / "t2_addr.501").write_text(json.dumps(payload))
+    dest = _discovery_path(config_dir)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(payload))
 
 
 class TestEnsureRunning:
@@ -140,7 +152,9 @@ class TestEnsureRunning:
         self, tmp_path, monkeypatch,
     ) -> None:
         # Discovery file present but not valid JSON — probe treats as dead.
-        (tmp_path / "t2_addr.501").write_text("not json {{{")
+        dest = _discovery_path(tmp_path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text("not json {{{")
 
         spawn_calls: list[list[str]] = []
         monkeypatch.setattr(

--- a/tests/stress/substrate_validation/.gitignore
+++ b/tests/stress/substrate_validation/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+receipts/

--- a/tests/stress/substrate_validation/_lib.py
+++ b/tests/stress/substrate_validation/_lib.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Shared infrastructure for the RDR-120 substrate-validation
+stress matrix (nexus-57pwo).
+
+Each scenario script spawns N worker subprocesses (separate Python
+interpreters — true cross-process isolation, what the daemon's
+substrate contract is for) and exercises the daemon under load.
+Receipts are written as JSON files under
+``tests/stress/substrate_validation/receipts/`` for the coordinator
+to aggregate into a final T2 entry.
+
+NOT Docker-based. Docker adds container-namespace isolation but
+no new failure modes vs separate Python interpreters; the daemon's
+arbitration contract is process-agnostic. The container TCP path
+is separately validated by nexus-wkyt7 / nexus-3d1ph / nexus-cm0az
+receipts; here we exercise the substrate's concurrency contract
+at high op-count under controlled conditions.
+
+Run a single scenario directly:
+    uv run python tests/stress/substrate_validation/scenario_1_fan_in.py
+
+Run the full matrix:
+    bash tests/stress/substrate_validation/run_all.sh
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+
+HERE = Path(__file__).parent
+RECEIPTS_DIR = HERE / "receipts"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# ---------------------------------------------------------------------------
+# Daemon lifecycle (isolated per scenario)
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def isolated_daemon() -> Iterator[tuple[Path, int]]:
+    """Spawn a T2 daemon in an isolated config dir; yield
+    ``(config_dir, tcp_port)``; tear down on exit.
+
+    Uses a fresh tempdir per scenario so scenarios cannot poison
+    each other's state. The daemon binds a dynamic TCP port.
+    """
+    tmp_root = Path(tempfile.mkdtemp(prefix="substrate-validation-"))
+    config_dir = tmp_root / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "sockets").mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env["NEXUS_CONFIG_DIR"] = str(config_dir)
+    env["NX_T2_AUTO_MIGRATE"] = "1"  # tests inherit the conftest opt-in
+    # Strip any prior daemon-discovery env so the daemon writes
+    # its OWN addr file under our isolated config dir.
+    for k in ("NX_T2_ADDR", "NX_T2_SOCK", "NX_T3_ADDR"):
+        env.pop(k, None)
+
+    log_file = open(tmp_root / "daemon.log", "w")
+    proc = subprocess.Popen(
+        ["uv", "run", "nx", "daemon", "t2", "start"],
+        env=env,
+        stdout=log_file,
+        stderr=log_file,
+        cwd=REPO_ROOT,
+    )
+
+    # Wait for the discovery file to appear (daemon ready).
+    uid = os.getuid()
+    addr_path = config_dir / f"t2_addr.{uid}"
+    deadline = time.time() + 30.0
+    while time.time() < deadline:
+        if addr_path.exists():
+            try:
+                payload = json.loads(addr_path.read_text())
+                tcp_port = int(payload.get("tcp_port") or 0)
+                if tcp_port > 0:
+                    break
+            except (json.JSONDecodeError, OSError):
+                pass
+        time.sleep(0.1)
+    else:
+        proc.terminate()
+        proc.wait(timeout=5)
+        log_file.close()
+        raise RuntimeError(
+            f"daemon failed to start within 30s; log at {tmp_root / 'daemon.log'}",
+        )
+
+    try:
+        yield config_dir, tcp_port
+    finally:
+        # Best-effort SIGTERM + cleanup.
+        subprocess.run(
+            ["uv", "run", "nx", "daemon", "t2", "stop"],
+            env=env,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            timeout=10,
+        )
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        log_file.close()
+        shutil.rmtree(tmp_root, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# T2Client framed-JSON protocol (stdlib-only; matches mvv_client.py)
+# ---------------------------------------------------------------------------
+
+
+def send_frame(sock: socket.socket, payload: dict[str, Any]) -> None:
+    body = json.dumps(payload).encode("utf-8")
+    header = struct.pack(">I", len(body))
+    sock.sendall(header + body + b"\n")
+
+
+def recv_exactly(sock: socket.socket, n: int) -> bytes:
+    out = bytearray()
+    while len(out) < n:
+        chunk = sock.recv(n - len(out))
+        if not chunk:
+            raise RuntimeError("peer closed mid-frame")
+        out.extend(chunk)
+    return bytes(out)
+
+
+def recv_frame(sock: socket.socket) -> dict[str, Any]:
+    header = recv_exactly(sock, 4)
+    length = struct.unpack(">I", header)[0]
+    body = recv_exactly(sock, length + 1)
+    return json.loads(body[:-1].decode("utf-8"))
+
+
+def call(sock: socket.socket, op: str, request_id: int, **kwargs: Any) -> Any:
+    send_frame(sock, {
+        "op": op, "args": [], "kwargs": kwargs, "request_id": request_id,
+    })
+    response = recv_frame(sock)
+    if response.get("request_id") != request_id:
+        raise RuntimeError(
+            f"request_id mismatch: sent {request_id}, "
+            f"got {response.get('request_id')!r}",
+        )
+    if not response.get("ok", False):
+        err = response.get("error") or {}
+        raise RuntimeError(
+            f"daemon error on {op}: {err.get('type')}: {err.get('message')}",
+        )
+    return response.get("result")
+
+
+# ---------------------------------------------------------------------------
+# Receipts
+# ---------------------------------------------------------------------------
+
+
+def write_receipt(scenario: str, verdict: dict[str, Any]) -> Path:
+    """Write a JSON receipt for the scenario. Coordinator reads
+    these and aggregates into a single T2 entry.
+    """
+    RECEIPTS_DIR.mkdir(exist_ok=True)
+    path = RECEIPTS_DIR / f"{scenario}.json"
+    verdict_with_meta = {
+        "scenario": scenario,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "host_platform": sys.platform,
+        **verdict,
+    }
+    path.write_text(json.dumps(verdict_with_meta, indent=2) + "\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Worker subprocess helpers
+# ---------------------------------------------------------------------------
+
+
+def worker_script_writer(
+    *,
+    addr: str,
+    count: int,
+    project: str,
+    worker_id: int,
+) -> str:
+    """Return a Python program (as a string) that writes ``count``
+    memory rows to the daemon at ``addr`` using framed JSON, then
+    prints a JSON summary of (ops_ok, ops_err, ids).
+    """
+    return f'''
+import json, socket, struct, sys, time
+
+def send(sock, payload):
+    body = json.dumps(payload).encode("utf-8")
+    header = struct.pack(">I", len(body))
+    sock.sendall(header + body + b"\\n")
+
+def recv_exactly(sock, n):
+    out = bytearray()
+    while len(out) < n:
+        chunk = sock.recv(n - len(out))
+        if not chunk:
+            raise RuntimeError("peer closed")
+        out.extend(chunk)
+    return bytes(out)
+
+def recv_frame(sock):
+    header = recv_exactly(sock, 4)
+    length = struct.unpack(">I", header)[0]
+    return json.loads(recv_exactly(sock, length + 1)[:-1].decode("utf-8"))
+
+host, port = {addr!r}.rsplit(":", 1)
+sock = socket.create_connection((host, int(port)), timeout=30.0)
+sock.settimeout(60.0)
+
+ok, err, ids = 0, 0, []
+for i in range({count}):
+    rid = i + 1
+    try:
+        send(sock, {{
+            "op": "memory.put",
+            "args": [],
+            "kwargs": {{
+                "project": {project!r},
+                "title": f"worker-{worker_id}-op-{{i}}",
+                "content": f"worker {worker_id} op {{i}} ts {{time.time()}}",
+                "ttl": 1,
+            }},
+            "request_id": rid,
+        }})
+        resp = recv_frame(sock)
+        if resp.get("ok"):
+            ok += 1
+            ids.append(resp.get("result"))
+        else:
+            err += 1
+    except Exception as e:
+        err += 1
+        sys.stderr.write(f"worker {worker_id} op {{i}}: {{type(e).__name__}}: {{e}}\\n")
+
+sock.close()
+print(json.dumps({{"worker_id": {worker_id}, "ok": ok, "err": err, "ids": ids}}))
+'''
+
+
+def spawn_workers(
+    *,
+    addr: str,
+    n_workers: int,
+    count_per_worker: int,
+    project: str,
+    timeout: float = 600.0,
+) -> list[dict[str, Any]]:
+    """Spawn N worker subprocesses concurrently; collect their JSON
+    summaries. Each worker runs in its own Python interpreter —
+    true cross-process isolation."""
+    procs = []
+    for wid in range(n_workers):
+        script = worker_script_writer(
+            addr=addr, count=count_per_worker, project=project, worker_id=wid,
+        )
+        p = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        procs.append(p)
+
+    results = []
+    for p in procs:
+        try:
+            out, err = p.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            out, err = p.communicate()
+            results.append({"timeout": True, "stderr": err})
+            continue
+        try:
+            results.append(json.loads(out.strip().splitlines()[-1]))
+        except (json.JSONDecodeError, IndexError):
+            results.append({"parse_error": True, "stdout": out, "stderr": err})
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Scenario runner protocol
+# ---------------------------------------------------------------------------
+
+
+def emit_scenario_result(scenario: str, result: dict[str, Any]) -> None:
+    """Print the receipt path + a one-line verdict to stdout so the
+    coordinator can scrape pass/fail."""
+    receipt_path = write_receipt(scenario, result)
+    verdict = "PASS" if result.get("pass") else "FAIL"
+    print(f"\n[{scenario}] {verdict}  receipt: {receipt_path}")
+    if not result.get("pass"):
+        print(f"[{scenario}] details: {json.dumps(result, indent=2)}")
+        sys.exit(1)

--- a/tests/stress/substrate_validation/run_all.sh
+++ b/tests/stress/substrate_validation/run_all.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Run the full substrate-validation stress matrix (nexus-57pwo).
+# Sequential, not parallel — per the project's no-parallel-tests rule.
+# Total wallclock ~30 sec on a fast machine; longer if pip caches are cold.
+set -e
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cd "$(git -C "$HERE" rev-parse --show-toplevel)"
+
+mkdir -p "$HERE/receipts"
+# Clean prior receipts so re-runs don't show stale state.
+rm -f "$HERE/receipts/"*.json
+
+echo "═══════════════════════════════════════════════════════════════════════"
+echo "   RDR-120 substrate-validation stress matrix (nexus-57pwo)"
+echo "   Replaces the §Approach Phase 6 30-day calendar soak."
+echo "   5 scenarios, sequential, ~30-90s total wallclock."
+echo "═══════════════════════════════════════════════════════════════════════"
+
+for scenario in \
+    scenario_1_fan_in \
+    scenario_2_mixed_workload \
+    scenario_3_kill9_recovery \
+    scenario_4_schema_mismatch \
+    scenario_5_catalog_rebuild
+do
+    echo ""
+    echo "── running $scenario ─────────────────────────────────────────────"
+    uv run python "$HERE/$scenario.py"
+done
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════════════"
+echo "All 5 scenarios green."
+echo "Receipts: $HERE/receipts/*.json"
+echo ""
+echo "Substrate is empirically validated. Per the moratorium-lift policy"
+echo "(T2: 120-moratorium-lift-criterion-stress-not-calendar), consumer"
+echo "RDRs may file regardless of calendar date."
+echo "═══════════════════════════════════════════════════════════════════════"

--- a/tests/stress/substrate_validation/scenario_1_fan_in.py
+++ b/tests/stress/substrate_validation/scenario_1_fan_in.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Scenario 1 — multi-process fan-in write storm (nexus-57pwo).
+
+10 worker subprocesses (separate Python interpreters), each
+performing 1000 ``memory.put`` operations against one isolated T2
+daemon over framed-JSON TCP. Sustained ~30-60s.
+
+Asserts:
+- Total writes = 10,000 (every worker reports ops_ok == 1000).
+- Zero subprocess errors (no SQLITE_BUSY escapes that the daemon's
+  busy_timeout couldn't absorb).
+- All returned row IDs are monotonically increasing without gaps
+  in the full set (SQLite's INTEGER PRIMARY KEY autoincrement
+  invariant under concurrent writes through the daemon's single-
+  writer arbitration).
+- Final SELECT MAX(id) from the daemon's memory table matches the
+  number of writes plus the initial _nexus_version bootstrap row.
+- Daemon process is still alive at end (no crash / OOM).
+"""
+from __future__ import annotations
+
+import socket
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _lib import (  # noqa: E402
+    call,
+    emit_scenario_result,
+    isolated_daemon,
+    spawn_workers,
+)
+
+
+N_WORKERS = 10
+OPS_PER_WORKER = 1000
+PROJECT = "nexus_stress_fan_in"
+
+
+def main() -> None:
+    started = time.monotonic()
+    with isolated_daemon() as (config_dir, tcp_port):
+        addr = f"127.0.0.1:{tcp_port}"
+        wait_setup_elapsed = time.monotonic() - started
+
+        t0 = time.monotonic()
+        results = spawn_workers(
+            addr=addr,
+            n_workers=N_WORKERS,
+            count_per_worker=OPS_PER_WORKER,
+            project=PROJECT,
+        )
+        worker_elapsed = time.monotonic() - t0
+
+        # Aggregate worker stats.
+        total_ok = sum(r.get("ok", 0) for r in results)
+        total_err = sum(r.get("err", 0) for r in results)
+        timed_out = [r for r in results if r.get("timeout")]
+        parse_errors = [r for r in results if r.get("parse_error")]
+
+        # Verify monotonic IDs across all workers (no gaps in the
+        # full set of returned row IDs).
+        all_ids: list[int] = []
+        for r in results:
+            all_ids.extend(r.get("ids") or [])
+        all_ids_sorted = sorted(all_ids)
+        ids_strictly_monotonic = all(
+            all_ids_sorted[i] < all_ids_sorted[i + 1]
+            for i in range(len(all_ids_sorted) - 1)
+        )
+        ids_contiguous = (
+            len(all_ids_sorted) > 0
+            and all_ids_sorted[-1] - all_ids_sorted[0] + 1 == len(all_ids_sorted)
+        )
+
+        # Confirm the daemon is still alive by hello.
+        sock = socket.create_connection(("127.0.0.1", tcp_port), timeout=5.0)
+        try:
+            hello = call(sock, "database.hello", 1, client_schema_version="probe")
+            daemon_alive = hello is not None
+        finally:
+            sock.close()
+
+        # Sanity: ask the daemon's memory store for the total row count.
+        sock = socket.create_connection(("127.0.0.1", tcp_port), timeout=5.0)
+        try:
+            db_rows = call(
+                sock, "memory.list_entries", 2, project=PROJECT,
+            )
+            stored_rows = len(db_rows) if isinstance(db_rows, list) else -1
+        finally:
+            sock.close()
+
+        passed = (
+            total_ok == N_WORKERS * OPS_PER_WORKER
+            and total_err == 0
+            and not timed_out
+            and not parse_errors
+            and ids_strictly_monotonic
+            and ids_contiguous
+            and daemon_alive
+            and stored_rows == N_WORKERS * OPS_PER_WORKER
+        )
+
+        emit_scenario_result("scenario_1_fan_in", {
+            "pass": passed,
+            "n_workers": N_WORKERS,
+            "ops_per_worker": OPS_PER_WORKER,
+            "expected_total": N_WORKERS * OPS_PER_WORKER,
+            "total_ok": total_ok,
+            "total_err": total_err,
+            "timed_out_workers": len(timed_out),
+            "parse_error_workers": len(parse_errors),
+            "ids_strictly_monotonic": ids_strictly_monotonic,
+            "ids_contiguous": ids_contiguous,
+            "ids_min": min(all_ids) if all_ids else None,
+            "ids_max": max(all_ids) if all_ids else None,
+            "daemon_alive_after_storm": daemon_alive,
+            "stored_rows_in_project": stored_rows,
+            "wait_setup_seconds": round(wait_setup_elapsed, 2),
+            "worker_elapsed_seconds": round(worker_elapsed, 2),
+            "throughput_ops_per_sec": round(
+                total_ok / max(worker_elapsed, 0.001), 1,
+            ),
+        })
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/stress/substrate_validation/scenario_2_mixed_workload.py
+++ b/tests/stress/substrate_validation/scenario_2_mixed_workload.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Scenario 2 — mixed-workload concurrency (nexus-57pwo).
+
+10 worker subprocesses, each cycling put/get/search/delete on a
+shared project against one isolated T2 daemon. Models the
+realistic Co-Work shape (multiple agents + host CLI + dev-container
+CLI all hitting the daemon).
+
+Each worker does:
+- 200 puts (own title namespace)
+- 200 gets (its own writes)
+- 100 searches (the shared project)
+- 100 deletes (its own writes; then re-puts)
+
+Total ~6000 mixed operations.
+
+Asserts:
+- All workers complete (no deadlock, no timeout).
+- Final row count matches net writes (puts - deletes).
+- Search returns consistent shape during concurrent writes (no
+  partial-FTS results that look corrupt).
+- Daemon alive at end.
+"""
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _lib import (  # noqa: E402
+    call,
+    emit_scenario_result,
+    isolated_daemon,
+)
+
+
+N_WORKERS = 10
+PUTS = 200
+GETS = 200
+SEARCHES = 100
+DELETES = 100  # of the worker's own puts; then re-puts
+PROJECT = "nexus_stress_mixed"
+
+
+def worker_script(*, addr: str, worker_id: int) -> str:
+    return f'''
+import json, socket, struct, sys, time
+
+def send(sock, payload):
+    body = json.dumps(payload).encode("utf-8")
+    sock.sendall(struct.pack(">I", len(body)) + body + b"\\n")
+
+def recv_exactly(sock, n):
+    out = bytearray()
+    while len(out) < n:
+        chunk = sock.recv(n - len(out))
+        if not chunk:
+            raise RuntimeError("peer closed")
+        out.extend(chunk)
+    return bytes(out)
+
+def recv_frame(sock):
+    header = recv_exactly(sock, 4)
+    length = struct.unpack(">I", header)[0]
+    return json.loads(recv_exactly(sock, length + 1)[:-1].decode("utf-8"))
+
+def call(sock, op, rid, **kw):
+    send(sock, {{"op": op, "args": [], "kwargs": kw, "request_id": rid}})
+    return recv_frame(sock)
+
+host, port = {addr!r}.rsplit(":", 1)
+sock = socket.create_connection((host, int(port)), timeout=30.0)
+sock.settimeout(120.0)
+
+stats = {{"put_ok": 0, "put_err": 0, "get_ok": 0, "get_err": 0,
+         "search_ok": 0, "search_err": 0, "delete_ok": 0, "delete_err": 0}}
+rid = 0
+
+WID = {worker_id}
+# Phase 1: puts (workers id-spaced so titles don't collide)
+for i in range({PUTS}):
+    rid += 1
+    r = call(sock, "memory.put", rid, project={PROJECT!r},
+             title=f"w{{WID}}-put-{{i}}",
+             content=f"worker {{WID}} put {{i}} ts {{time.time()}}",
+             ttl=1)
+    stats["put_ok" if r.get("ok") else "put_err"] += 1
+
+# Phase 2: gets of own writes
+for i in range({GETS}):
+    rid += 1
+    r = call(sock, "memory.get", rid, project={PROJECT!r},
+             title=f"w{{WID}}-put-{{i % {PUTS}}}")
+    stats["get_ok" if r.get("ok") else "get_err"] += 1
+
+# Phase 3: searches against the shared project
+for i in range({SEARCHES}):
+    rid += 1
+    r = call(sock, "memory.search", rid, query=f"worker {{WID % 3}}",
+             project={PROJECT!r})
+    stats["search_ok" if r.get("ok") else "search_err"] += 1
+
+# Phase 4: deletes (of own puts), then re-puts so the row count
+# math is: net writes = PUTS (deletes are paired with re-puts).
+for i in range({DELETES}):
+    rid += 1
+    r = call(sock, "memory.delete", rid, project={PROJECT!r},
+             title=f"w{{WID}}-put-{{i}}")
+    stats["delete_ok" if r.get("ok") else "delete_err"] += 1
+    rid += 1
+    r2 = call(sock, "memory.put", rid, project={PROJECT!r},
+              title=f"w{{WID}}-put-{{i}}",
+              content=f"re-put after delete worker {{WID}} op {{i}}",
+              ttl=1)
+    stats["put_ok" if r2.get("ok") else "put_err"] += 1
+
+sock.close()
+print(json.dumps({{"worker_id": WID, "stats": stats}}))
+'''
+
+
+def main() -> None:
+    started = time.monotonic()
+    with isolated_daemon() as (config_dir, tcp_port):
+        addr = f"127.0.0.1:{tcp_port}"
+        wait_setup_elapsed = time.monotonic() - started
+
+        t0 = time.monotonic()
+        procs = []
+        for wid in range(N_WORKERS):
+            script = worker_script(addr=addr, worker_id=wid)
+            p = subprocess.Popen(
+                [sys.executable, "-c", script],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            procs.append(p)
+
+        results = []
+        for p in procs:
+            try:
+                out, err = p.communicate(timeout=600)
+            except subprocess.TimeoutExpired:
+                p.kill()
+                out, err = p.communicate()
+                results.append({"timeout": True})
+                continue
+            try:
+                results.append(json.loads(out.strip().splitlines()[-1]))
+            except (json.JSONDecodeError, IndexError):
+                results.append({"parse_error": True, "stdout": out, "stderr": err})
+        worker_elapsed = time.monotonic() - t0
+
+        # Aggregate.
+        agg = {"put_ok": 0, "put_err": 0, "get_ok": 0, "get_err": 0,
+               "search_ok": 0, "search_err": 0, "delete_ok": 0, "delete_err": 0}
+        for r in results:
+            s = r.get("stats") or {}
+            for k in agg:
+                agg[k] += s.get(k, 0)
+
+        # Expected: each worker does (PUTS + DELETES) puts and DELETES deletes.
+        # Net writes = N_WORKERS * PUTS (deletes/re-puts cancel).
+        expected_puts = N_WORKERS * (PUTS + DELETES)
+        expected_gets = N_WORKERS * GETS
+        expected_searches = N_WORKERS * SEARCHES
+        expected_deletes = N_WORKERS * DELETES
+        expected_net_rows = N_WORKERS * PUTS
+
+        # Verify final row count in the project matches net writes.
+        sock = socket.create_connection(("127.0.0.1", tcp_port), timeout=5.0)
+        try:
+            db_rows = call(sock, "memory.list_entries", 1, project=PROJECT)
+            stored_rows = len(db_rows) if isinstance(db_rows, list) else -1
+        finally:
+            sock.close()
+
+        # Verify daemon alive.
+        sock = socket.create_connection(("127.0.0.1", tcp_port), timeout=5.0)
+        try:
+            hello = call(sock, "database.hello", 2, client_schema_version="probe")
+            daemon_alive = hello is not None
+        finally:
+            sock.close()
+
+        passed = (
+            agg["put_ok"] == expected_puts
+            and agg["put_err"] == 0
+            and agg["get_ok"] == expected_gets
+            and agg["get_err"] == 0
+            and agg["search_ok"] == expected_searches
+            and agg["search_err"] == 0
+            and agg["delete_ok"] == expected_deletes
+            and agg["delete_err"] == 0
+            and stored_rows == expected_net_rows
+            and daemon_alive
+            and not any(r.get("timeout") or r.get("parse_error") for r in results)
+        )
+
+        emit_scenario_result("scenario_2_mixed_workload", {
+            "pass": passed,
+            "n_workers": N_WORKERS,
+            "stats": agg,
+            "expected_puts": expected_puts,
+            "expected_gets": expected_gets,
+            "expected_searches": expected_searches,
+            "expected_deletes": expected_deletes,
+            "expected_net_rows": expected_net_rows,
+            "stored_rows": stored_rows,
+            "daemon_alive_after_mix": daemon_alive,
+            "wait_setup_seconds": round(wait_setup_elapsed, 2),
+            "worker_elapsed_seconds": round(worker_elapsed, 2),
+            "total_ops": sum(agg.values()),
+            "throughput_ops_per_sec": round(
+                sum(agg.values()) / max(worker_elapsed, 0.001), 1,
+            ),
+        })
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/stress/substrate_validation/scenario_3_kill9_recovery.py
+++ b/tests/stress/substrate_validation/scenario_3_kill9_recovery.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Scenario 3 — daemon-failure-recovery under load (nexus-57pwo).
+
+Spawns 5 worker subprocesses doing steady ``memory.put`` load.
+At t=10s the test SIGKILLs the daemon (`kill -9`). Workers in the
+middle of an operation see their socket close mid-frame and the
+client raises. At t=15s the test starts a NEW daemon at the same
+config dir. Surviving workers don't auto-reconnect (each worker
+uses one connection); their remaining ops fail. A fresh post-restart
+client confirms the daemon is healthy and the SQLite is intact.
+
+Asserts:
+- During-kill ops fail loud (the worker's socket sees peer-closed,
+  Python raises, the worker records err).
+- Post-restart: a fresh client can hello + put + get cleanly.
+- Pre-kill writes are durable across the restart (they're committed
+  to the SQLite file, not lost on daemon crash).
+- PRAGMA integrity_check on the post-restart database is "ok"
+  (verified via memory.list_entries succeeding, which would error
+  on a torn database).
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _lib import (  # noqa: E402
+    call,
+    emit_scenario_result,
+    isolated_daemon,
+)
+
+
+N_WORKERS = 5
+PROJECT = "nexus_stress_kill9"
+
+
+def worker_script(*, addr: str, worker_id: int, duration: float) -> str:
+    return f'''
+import json, socket, struct, sys, time
+
+def send(sock, payload):
+    body = json.dumps(payload).encode("utf-8")
+    sock.sendall(struct.pack(">I", len(body)) + body + b"\\n")
+
+def recv_exactly(sock, n):
+    out = bytearray()
+    while len(out) < n:
+        chunk = sock.recv(n - len(out))
+        if not chunk:
+            raise RuntimeError("peer closed")
+        out.extend(chunk)
+    return bytes(out)
+
+def recv_frame(sock):
+    header = recv_exactly(sock, 4)
+    length = struct.unpack(">I", header)[0]
+    return json.loads(recv_exactly(sock, length + 1)[:-1].decode("utf-8"))
+
+WID = {worker_id}
+host, port = {addr!r}.rsplit(":", 1)
+sock = socket.create_connection((host, int(port)), timeout=5.0)
+sock.settimeout(5.0)
+
+ok, err, first_err_ts = 0, 0, None
+start = time.monotonic()
+i = 0
+while time.monotonic() - start < {duration}:
+    i += 1
+    try:
+        send(sock, {{
+            "op": "memory.put", "args": [],
+            "kwargs": {{
+                "project": {PROJECT!r},
+                "title": f"w{{WID}}-op-{{i}}",
+                "content": f"worker {{WID}} op {{i}} ts {{time.time()}}",
+                "ttl": 1,
+            }},
+            "request_id": i,
+        }})
+        resp = recv_frame(sock)
+        if resp.get("ok"):
+            ok += 1
+        else:
+            err += 1
+            if first_err_ts is None:
+                first_err_ts = time.monotonic() - start
+    except Exception as exc:
+        err += 1
+        if first_err_ts is None:
+            first_err_ts = time.monotonic() - start
+        break  # connection broken; stop trying
+
+sock.close()
+print(json.dumps({{
+    "worker_id": WID, "ok": ok, "err": err,
+    "first_err_seconds": first_err_ts, "total_attempts": i,
+}}))
+'''
+
+
+def main() -> None:
+    started = time.monotonic()
+    with isolated_daemon() as (config_dir, tcp_port):
+        addr = f"127.0.0.1:{tcp_port}"
+
+        # Read the daemon PID from the discovery file.
+        uid = os.getuid()
+        addr_path = config_dir / f"t2_addr.{uid}"
+        payload = json.loads(addr_path.read_text())
+        daemon_pid_pre = int(payload.get("pid") or 0)
+
+        # Spawn workers; they run for 30 seconds.
+        WORKER_DURATION = 30.0
+        KILL_AT = 8.0
+        t0 = time.monotonic()
+        procs = []
+        for wid in range(N_WORKERS):
+            script = worker_script(
+                addr=addr, worker_id=wid, duration=WORKER_DURATION,
+            )
+            p = subprocess.Popen(
+                [sys.executable, "-c", script],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            procs.append(p)
+
+        # Wait, then SIGKILL the daemon.
+        time.sleep(KILL_AT)
+        os.kill(daemon_pid_pre, signal.SIGKILL)
+        kill_wall = time.monotonic() - t0
+
+        # Wait for workers to finish (they should exit on socket
+        # error within seconds of the kill).
+        results = []
+        for p in procs:
+            try:
+                out, err = p.communicate(timeout=WORKER_DURATION + 10)
+            except subprocess.TimeoutExpired:
+                p.kill()
+                out, err = p.communicate()
+                results.append({"timeout": True})
+                continue
+            try:
+                results.append(json.loads(out.strip().splitlines()[-1]))
+            except (json.JSONDecodeError, IndexError):
+                results.append({"parse_error": True, "stdout": out, "stderr": err})
+
+        total_ok = sum(r.get("ok", 0) for r in results)
+        total_err = sum(r.get("err", 0) for r in results)
+
+        # Daemon should be dead now (the kill -9 took it down and
+        # nothing respawned automatically).
+        try:
+            os.kill(daemon_pid_pre, 0)  # signal 0 = check existence
+            daemon_dead_after_kill = False
+        except OSError:
+            daemon_dead_after_kill = True
+
+        # Restart the daemon by hand. Same config dir, same db file.
+        env = os.environ.copy()
+        env["NEXUS_CONFIG_DIR"] = str(config_dir)
+        env["NX_T2_AUTO_MIGRATE"] = "1"
+        # Remove the stale discovery file so the new daemon's start
+        # is unambiguous.
+        try:
+            addr_path.unlink()
+        except FileNotFoundError:
+            pass
+        repo_root = Path(__file__).resolve().parents[3]
+        restart_proc = subprocess.Popen(
+            ["uv", "run", "nx", "daemon", "t2", "start"],
+            env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            cwd=repo_root,
+        )
+
+        # Wait for the new daemon's discovery file.
+        deadline = time.monotonic() + 30.0
+        new_port = None
+        while time.monotonic() < deadline:
+            if addr_path.exists():
+                try:
+                    new_payload = json.loads(addr_path.read_text())
+                    new_port = int(new_payload.get("tcp_port") or 0)
+                    if new_port > 0:
+                        break
+                except (json.JSONDecodeError, OSError):
+                    pass
+            time.sleep(0.1)
+
+        post_restart_ok = False
+        rows_after_restart = -1
+        if new_port:
+            # Verify hello + post-restart write + read.
+            try:
+                sock = socket.create_connection(
+                    ("127.0.0.1", new_port), timeout=5.0,
+                )
+                try:
+                    hello = call(
+                        sock, "database.hello", 1,
+                        client_schema_version="probe",
+                    )
+                    # Confirm pre-kill writes are durable: query
+                    # the project's rows.
+                    rows = call(
+                        sock, "memory.list_entries", 2, project=PROJECT,
+                    )
+                    rows_after_restart = (
+                        len(rows) if isinstance(rows, list) else -1
+                    )
+                    # Post-restart write.
+                    new_id = call(
+                        sock, "memory.put", 3,
+                        project=PROJECT,
+                        title="post-restart-canary",
+                        content="written after kill-9 + restart",
+                        ttl=1,
+                    )
+                    got = call(
+                        sock, "memory.get", 4,
+                        project=PROJECT, title="post-restart-canary",
+                    )
+                    post_restart_ok = (
+                        hello is not None
+                        and isinstance(new_id, int) and new_id > 0
+                        and got is not None
+                        and "written after kill-9" in (got.get("content") or "")
+                    )
+                finally:
+                    sock.close()
+            except Exception:
+                post_restart_ok = False
+
+        # Stop the manually-spawned restart daemon. The
+        # ``isolated_daemon`` context manager's stop also fires on
+        # exit; that's harmless because the daemon is keyed by
+        # config dir.
+        subprocess.run(
+            ["uv", "run", "nx", "daemon", "t2", "stop"],
+            env=env, capture_output=True, timeout=10, cwd=repo_root,
+        )
+
+        passed = (
+            total_ok > 0  # some writes succeeded pre-kill
+            and total_err > 0  # some failed loud post-kill
+            and daemon_dead_after_kill
+            and post_restart_ok
+            and rows_after_restart >= total_ok  # pre-kill rows durable
+        )
+
+        emit_scenario_result("scenario_3_kill9_recovery", {
+            "pass": passed,
+            "n_workers": N_WORKERS,
+            "kill_at_seconds": KILL_AT,
+            "kill_wall_seconds": round(kill_wall, 2),
+            "total_ok_pre_kill": total_ok,
+            "total_err_post_kill": total_err,
+            "daemon_dead_after_kill": daemon_dead_after_kill,
+            "post_restart_handshake_and_write_ok": post_restart_ok,
+            "rows_visible_after_restart": rows_after_restart,
+            "pre_kill_writes_durable": rows_after_restart >= total_ok,
+        })
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/stress/substrate_validation/scenario_4_schema_mismatch.py
+++ b/tests/stress/substrate_validation/scenario_4_schema_mismatch.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Scenario 4 — schema-version handshake mismatch under load (nexus-57pwo).
+
+Models the version-skew failure mode: an operator runs an old client
+against a new daemon (or vice versa) and the substrate must refuse
+to operate rather than silently writing against an unexpected
+schema.
+
+Sequence:
+1. Start daemon at the current schema version (auto-bootstrapped).
+2. Spawn 3 worker subprocesses running steady put load for 5 seconds.
+3. Stop the daemon. Edit ``_nexus_version`` directly in the SQLite
+   to a "future" version. Restart the daemon.
+4. New clients connect; the framed-JSON ``database.hello`` op
+   returns the future version. A client coded against the actual
+   build version should raise ``T2SchemaVersionMismatchError`` and
+   refuse to proceed.
+
+This scenario uses the framed-JSON protocol directly + the
+``T2SchemaVersionMismatchError`` check we ship in ``T2Client``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _lib import (  # noqa: E402
+    call,
+    emit_scenario_result,
+    isolated_daemon,
+)
+
+
+N_WORKERS = 3
+PROJECT = "nexus_stress_schema"
+FAKE_FUTURE_VERSION = "999.999.999"
+
+
+def worker_loop_script(*, addr: str, worker_id: int, duration: float) -> str:
+    return f'''
+import json, socket, struct, sys, time
+
+def send(sock, payload):
+    body = json.dumps(payload).encode("utf-8")
+    sock.sendall(struct.pack(">I", len(body)) + body + b"\\n")
+
+def recv_exactly(sock, n):
+    out = bytearray()
+    while len(out) < n:
+        chunk = sock.recv(n - len(out))
+        if not chunk:
+            raise RuntimeError("peer closed")
+        out.extend(chunk)
+    return bytes(out)
+
+def recv_frame(sock):
+    header = recv_exactly(sock, 4)
+    length = struct.unpack(">I", header)[0]
+    return json.loads(recv_exactly(sock, length + 1)[:-1].decode("utf-8"))
+
+WID = {worker_id}
+host, port = {addr!r}.rsplit(":", 1)
+sock = socket.create_connection((host, int(port)), timeout=5.0)
+sock.settimeout(5.0)
+ok, err = 0, 0
+start = time.monotonic()
+i = 0
+while time.monotonic() - start < {duration}:
+    i += 1
+    try:
+        send(sock, {{
+            "op": "memory.put", "args": [],
+            "kwargs": {{"project": {PROJECT!r},
+                       "title": f"w{{WID}}-{{i}}",
+                       "content": f"pre-mismatch worker {{WID}} op {{i}}",
+                       "ttl": 1}},
+            "request_id": i,
+        }})
+        resp = recv_frame(sock)
+        if resp.get("ok"):
+            ok += 1
+        else:
+            err += 1
+    except Exception:
+        err += 1
+        break
+
+sock.close()
+print(json.dumps({{"worker_id": WID, "ok": ok, "err": err}}))
+'''
+
+
+def main() -> None:
+    started = time.monotonic()
+    with isolated_daemon() as (config_dir, tcp_port):
+        addr = f"127.0.0.1:{tcp_port}"
+
+        # Phase 1: steady load for 5 seconds against the current
+        # daemon. Confirms normal operation.
+        t0 = time.monotonic()
+        procs = []
+        for wid in range(N_WORKERS):
+            script = worker_loop_script(
+                addr=addr, worker_id=wid, duration=5.0,
+            )
+            p = subprocess.Popen(
+                [sys.executable, "-c", script],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            procs.append(p)
+
+        pre_results = []
+        for p in procs:
+            out, err = p.communicate(timeout=30)
+            try:
+                pre_results.append(json.loads(out.strip().splitlines()[-1]))
+            except (json.JSONDecodeError, IndexError):
+                pre_results.append({"parse_error": True})
+        pre_ok = sum(r.get("ok", 0) for r in pre_results)
+        pre_err = sum(r.get("err", 0) for r in pre_results)
+        pre_phase_elapsed = time.monotonic() - t0
+
+        # Phase 2: stop the daemon, edit _nexus_version to a future
+        # value, restart, then probe with a fresh client.
+        env = os.environ.copy()
+        env["NEXUS_CONFIG_DIR"] = str(config_dir)
+        env["NX_T2_AUTO_MIGRATE"] = "1"
+        repo_root = Path(__file__).resolve().parents[3]
+        subprocess.run(
+            ["uv", "run", "nx", "daemon", "t2", "stop"],
+            env=env, capture_output=True, timeout=10, cwd=repo_root,
+        )
+        # Wait for the discovery file to vanish.
+        uid = os.getuid()
+        addr_path = config_dir / f"t2_addr.{uid}"
+        deadline = time.time() + 10.0
+        while addr_path.exists() and time.time() < deadline:
+            time.sleep(0.1)
+
+        # Edit _nexus_version directly.
+        db_path = config_dir / "memory.db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                "UPDATE _nexus_version SET value = ? WHERE key = 'cli_version'",
+                (FAKE_FUTURE_VERSION,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Restart the daemon with the modified version row.
+        restart_proc = subprocess.Popen(
+            ["uv", "run", "nx", "daemon", "t2", "start"],
+            env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            cwd=repo_root,
+        )
+        deadline = time.monotonic() + 30.0
+        new_port = None
+        while time.monotonic() < deadline:
+            if addr_path.exists():
+                try:
+                    p = json.loads(addr_path.read_text())
+                    new_port = int(p.get("tcp_port") or 0)
+                    if new_port > 0:
+                        break
+                except (json.JSONDecodeError, OSError):
+                    pass
+            time.sleep(0.1)
+
+        # Phase 3: hello against the modified daemon. Verify the
+        # daemon's reported version is the future value AND a real
+        # T2Client raises T2SchemaVersionMismatchError.
+        daemon_reports_future = False
+        client_raises_mismatch = False
+        client_actual_version: str | None = None
+
+        if new_port:
+            # Raw framed-JSON probe — confirm the daemon really
+            # reports the future version.
+            try:
+                sock = socket.create_connection(
+                    ("127.0.0.1", new_port), timeout=5.0,
+                )
+                try:
+                    hello = call(
+                        sock, "database.hello", 1,
+                        client_schema_version="raw-probe",
+                    )
+                    daemon_reports_future = (
+                        hello.get("daemon_schema_version") == FAKE_FUTURE_VERSION
+                    )
+                finally:
+                    sock.close()
+            except Exception:
+                pass
+
+            # Real T2Client should raise T2SchemaVersionMismatchError
+            # on first call (the lazy handshake fires there).
+            try:
+                from nexus.daemon.t2_client import (
+                    T2Client,
+                    T2SchemaVersionMismatchError,
+                )
+                from nexus.db.migrations import expected_t2_schema_version
+                client_actual_version = expected_t2_schema_version()
+
+                # Construct the T2Client and force a call; this
+                # triggers the lazy handshake.
+                import os as _os
+                _os.environ["NX_T2_ADDR"] = f"127.0.0.1:{new_port}"
+                client = T2Client(config_dir=config_dir)
+                try:
+                    client.memory.put(
+                        content="should-not-land",
+                        project=PROJECT,
+                        title="post-mismatch-canary",
+                        ttl=1,
+                    )
+                    # Should not reach here.
+                except T2SchemaVersionMismatchError:
+                    client_raises_mismatch = True
+                except Exception:
+                    pass
+                finally:
+                    client.close()
+                _os.environ.pop("NX_T2_ADDR", None)
+            except Exception:
+                pass
+
+        subprocess.run(
+            ["uv", "run", "nx", "daemon", "t2", "stop"],
+            env=env, capture_output=True, timeout=10, cwd=repo_root,
+        )
+
+        passed = (
+            pre_ok > 0
+            and pre_err == 0
+            and daemon_reports_future
+            and client_raises_mismatch
+            and client_actual_version != FAKE_FUTURE_VERSION
+        )
+
+        emit_scenario_result("scenario_4_schema_mismatch", {
+            "pass": passed,
+            "n_workers": N_WORKERS,
+            "pre_phase_elapsed_seconds": round(pre_phase_elapsed, 2),
+            "pre_ok": pre_ok,
+            "pre_err": pre_err,
+            "fake_future_version": FAKE_FUTURE_VERSION,
+            "daemon_reports_future_version": daemon_reports_future,
+            "client_actual_version": client_actual_version,
+            "client_raises_T2SchemaVersionMismatchError": client_raises_mismatch,
+        })
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/stress/substrate_validation/scenario_5_catalog_rebuild.py
+++ b/tests/stress/substrate_validation/scenario_5_catalog_rebuild.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Scenario 5 — catalog rebuild under concurrent T2 traffic (nexus-57pwo).
+
+Cross-domain isolation check: ``Catalog.rebuild()`` DELETEs four
+tables (owners, documents, links, collections), disables FK
+enforcement, and replays from JSONL. Under RDR-120 P5.A's
+collapse, the catalog and T2 share the same daemon process; this
+scenario asserts the catalog rebuild does NOT corrupt T2 memory
+writes that are concurrent with it.
+
+Sequence:
+1. Set up an isolated catalog directory with a tiny manifest
+   (some owners + documents + links written via JSONL).
+2. Start a daemon. Drive 4 workers doing steady T2 memory writes
+   to a project unrelated to the catalog.
+3. On the host, invoke ``Catalog.rebuild()`` directly (the
+   replay-equality machinery) while writes are in flight.
+4. Stop the workers. Verify:
+   - All T2 writes succeeded (no errors from catalog-rebuild
+     contention).
+   - The catalog projection matches the JSONL source after
+     rebuild.
+   - The T2 row count is exactly what the workers wrote.
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _lib import (  # noqa: E402
+    call,
+    emit_scenario_result,
+    isolated_daemon,
+)
+
+
+N_WORKERS = 4
+PROJECT = "nexus_stress_catalog"
+
+
+def worker_loop_script(*, addr: str, worker_id: int, duration: float) -> str:
+    return f'''
+import json, socket, struct, sys, time
+
+def send(sock, payload):
+    body = json.dumps(payload).encode("utf-8")
+    sock.sendall(struct.pack(">I", len(body)) + body + b"\\n")
+
+def recv_exactly(sock, n):
+    out = bytearray()
+    while len(out) < n:
+        chunk = sock.recv(n - len(out))
+        if not chunk:
+            raise RuntimeError("peer closed")
+        out.extend(chunk)
+    return bytes(out)
+
+def recv_frame(sock):
+    header = recv_exactly(sock, 4)
+    length = struct.unpack(">I", header)[0]
+    return json.loads(recv_exactly(sock, length + 1)[:-1].decode("utf-8"))
+
+WID = {worker_id}
+host, port = {addr!r}.rsplit(":", 1)
+sock = socket.create_connection((host, int(port)), timeout=5.0)
+sock.settimeout(10.0)
+ok, err = 0, 0
+start = time.monotonic()
+i = 0
+while time.monotonic() - start < {duration}:
+    i += 1
+    try:
+        send(sock, {{
+            "op": "memory.put", "args": [],
+            "kwargs": {{
+                "project": {PROJECT!r},
+                "title": f"w{{WID}}-{{i}}",
+                "content": f"during-rebuild worker {{WID}} op {{i}}",
+                "ttl": 1,
+            }},
+            "request_id": i,
+        }})
+        resp = recv_frame(sock)
+        if resp.get("ok"):
+            ok += 1
+        else:
+            err += 1
+    except Exception:
+        err += 1
+        break
+
+sock.close()
+print(json.dumps({{"worker_id": WID, "ok": ok, "err": err}}))
+'''
+
+
+def seed_catalog(catalog_dir: Path) -> tuple[int, int, int]:
+    """Materialise a small JSONL-backed catalog. Returns
+    (n_owners, n_docs, n_links)."""
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    # Init the catalog: write a tiny JSONL set.
+    owners = [
+        {"owner": "nexus-stress-r", "name": "stress-r", "owner_type": "repo",
+         "repo_root": "/tmp/x", "repo_hash": "deadbeef", "description": ""},
+    ]
+    docs = [
+        {"tumbler": f"1.1.{i}", "title": f"doc-{i}.md", "author": "",
+         "year": 0, "content_type": "code", "file_path": f"doc-{i}.md",
+         "corpus": "", "physical_collection": "code__test",
+         "chunk_count": 1, "head_hash": "", "indexed_at": "",
+         "metadata": "{}", "source_mtime": 0.0, "alias_of": "",
+         "source_uri": ""}
+        for i in range(1, 11)
+    ]
+    links = [
+        {"from_t": "1.1.1", "to_t": "1.1.2", "link_type": "cites",
+         "from_span": "", "to_span": "",
+         "created_by": "test", "created_at": "", "metadata": "{}"},
+        {"from_t": "1.1.2", "to_t": "1.1.3", "link_type": "cites",
+         "from_span": "", "to_span": "",
+         "created_by": "test", "created_at": "", "metadata": "{}"},
+    ]
+    (catalog_dir / "owners.jsonl").write_text(
+        "\n".join(json.dumps(o) for o in owners) + "\n",
+    )
+    (catalog_dir / "documents.jsonl").write_text(
+        "\n".join(json.dumps(d) for d in docs) + "\n",
+    )
+    (catalog_dir / "links.jsonl").write_text(
+        "\n".join(json.dumps(l) for l in links) + "\n",  # noqa: E741
+    )
+    return len(owners), len(docs), len(links)
+
+
+def main() -> None:
+    started = time.monotonic()
+    with isolated_daemon() as (config_dir, tcp_port):
+        addr = f"127.0.0.1:{tcp_port}"
+
+        # Seed the catalog. Match the path nexus.config.catalog_path()
+        # resolves under our isolated config dir.
+        catalog_dir = config_dir / "catalog"
+        n_owners, n_docs, n_links = seed_catalog(catalog_dir)
+
+        # Spawn workers doing steady T2 writes (unrelated project).
+        WORKER_DURATION = 6.0
+        t0 = time.monotonic()
+        procs = []
+        for wid in range(N_WORKERS):
+            script = worker_loop_script(
+                addr=addr, worker_id=wid, duration=WORKER_DURATION,
+            )
+            p = subprocess.Popen(
+                [sys.executable, "-c", script],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            procs.append(p)
+
+        # While the workers are running, drive a Catalog.rebuild()
+        # via a subprocess so we use the same isolated config dir.
+        time.sleep(1.5)  # let workers ramp up
+        rebuild_script = f'''
+import os, sys
+os.environ["NEXUS_CONFIG_DIR"] = {str(config_dir)!r}
+os.environ["NX_T2_AUTO_MIGRATE"] = "1"
+sys.path.insert(0, {str(Path(__file__).resolve().parents[3] / "src")!r})
+
+from pathlib import Path
+from nexus.catalog.catalog import Catalog
+
+cat_dir = Path({str(catalog_dir)!r})
+cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+# Trigger the rebuild path explicitly.
+cat.rebuild()
+# Verify projection.
+db = cat._db
+docs = db.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+owners = db.execute("SELECT COUNT(*) FROM owners").fetchone()[0]
+links = db.execute("SELECT COUNT(*) FROM links").fetchone()[0]
+import json
+print(json.dumps({{"docs": docs, "owners": owners, "links": links}}))
+'''
+        rebuild_proc = subprocess.run(
+            [sys.executable, "-c", rebuild_script],
+            capture_output=True, text=True, timeout=60,
+        )
+
+        # Wait for the T2 workers.
+        worker_results = []
+        for p in procs:
+            try:
+                out, err = p.communicate(timeout=WORKER_DURATION + 30)
+            except subprocess.TimeoutExpired:
+                p.kill()
+                out, err = p.communicate()
+                worker_results.append({"timeout": True})
+                continue
+            try:
+                worker_results.append(json.loads(out.strip().splitlines()[-1]))
+            except (json.JSONDecodeError, IndexError):
+                worker_results.append({"parse_error": True, "stdout": out})
+        worker_elapsed = time.monotonic() - t0
+
+        # Parse the catalog rebuild result.
+        rebuild_ok = rebuild_proc.returncode == 0
+        rebuild_counts = {}
+        if rebuild_ok:
+            try:
+                rebuild_counts = json.loads(
+                    rebuild_proc.stdout.strip().splitlines()[-1]
+                )
+            except (json.JSONDecodeError, IndexError):
+                rebuild_ok = False
+
+        # T2 worker aggregate.
+        total_ok = sum(r.get("ok", 0) for r in worker_results)
+        total_err = sum(r.get("err", 0) for r in worker_results)
+
+        # Verify the T2 row count survives the catalog rebuild.
+        sock = socket.create_connection(("127.0.0.1", tcp_port), timeout=5.0)
+        try:
+            db_rows = call(sock, "memory.list_entries", 1, project=PROJECT)
+            stored_rows = len(db_rows) if isinstance(db_rows, list) else -1
+        finally:
+            sock.close()
+
+        catalog_projection_matches = (
+            rebuild_ok
+            and rebuild_counts.get("owners") == n_owners
+            and rebuild_counts.get("docs") == n_docs
+            and rebuild_counts.get("links") == n_links
+        )
+
+        passed = (
+            total_ok > 0
+            and total_err == 0
+            and stored_rows == total_ok
+            and rebuild_ok
+            and catalog_projection_matches
+            and not any(r.get("timeout") or r.get("parse_error") for r in worker_results)
+        )
+
+        emit_scenario_result("scenario_5_catalog_rebuild", {
+            "pass": passed,
+            "n_workers": N_WORKERS,
+            "worker_duration_seconds": WORKER_DURATION,
+            "total_t2_writes_ok": total_ok,
+            "total_t2_writes_err": total_err,
+            "t2_stored_rows": stored_rows,
+            "t2_durable_during_rebuild": stored_rows == total_ok,
+            "expected_catalog_counts": {
+                "owners": n_owners, "docs": n_docs, "links": n_links,
+            },
+            "rebuilt_catalog_counts": rebuild_counts,
+            "catalog_rebuild_ok": rebuild_ok,
+            "catalog_projection_matches_source": catalog_projection_matches,
+            "rebuild_stderr_tail": (
+                rebuild_proc.stderr[-500:] if rebuild_proc.stderr else None
+            ),
+            "worker_elapsed_seconds": round(worker_elapsed, 2),
+        })
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -49,7 +49,28 @@ def runner() -> CliRunner:
 
 @pytest.fixture
 def isolated_home(tmp_path, monkeypatch):
+    """Isolate T2 path + bypass the daemon for CLI memory commands.
+
+    RDR-120 P6 follow-up (nexus-w6txl): ``nx memory`` commands route
+    through ``t2_handle()`` -> T2 daemon. Integration tests don't
+    spawn a daemon; patch ``t2_handle`` to inject an in-process
+    ``T2Database`` backed by ``tmp_path``. Tests that don't invoke
+    nx memory commands are unaffected.
+    """
+    from contextlib import contextmanager
+    from nexus.db.t2 import T2Database
+
     monkeypatch.setenv("HOME", str(tmp_path))
+
+    @contextmanager
+    def _stub_t2_handle():
+        db = T2Database(tmp_path / "memory.db")
+        try:
+            yield db
+        finally:
+            db.close()
+
+    monkeypatch.setattr("nexus.commands.memory.t2_handle", _stub_t2_handle)
     return tmp_path
 
 

--- a/tests/test_store_put_cli_parity.py
+++ b/tests/test_store_put_cli_parity.py
@@ -126,12 +126,6 @@ class TestMemoryPromoteCli:
 
         # T2 environment: a memory entry to promote. ``memory promote``
         # takes the integer entry_id as its positional argument.
-        # NEXUS_CONFIG_DIR is the documented isolation knob — patching
-        # ``nexus.commands._helpers.default_db_path`` does NOT reach
-        # ``memory._default_db_path`` because memory.py captures the
-        # function via ``from … import … as`` at module-load time.
-        # Setting the env var is read at call time inside
-        # ``nexus_config_dir()``, so it isolates every CLI subcommand.
         monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
         monkeypatch.setattr(
             "nexus.config.is_local_mode", lambda: True,
@@ -142,11 +136,18 @@ class TestMemoryPromoteCli:
             project="proj-test", title="m-1", content="memory body",
             tags="", ttl=None,
         )
-        db.close()
 
+        # RDR-120 P6 follow-up (nexus-w6txl): ``memory promote`` (and
+        # every other nx memory command) now routes through
+        # ``t2_handle()`` -> ``T2Client``. Tests inject a T2Database
+        # by patching the helper to return the test fixture as the
+        # context-managed handle.
         single, batch, doc = _install_recording_registry(monkeypatch)
 
-        with patch("nexus.db.make_t3", _make_stub_t3()):
+        with (
+            patch("nexus.db.make_t3", _make_stub_t3()),
+            patch("nexus.commands.memory.t2_handle", return_value=db),
+        ):
             runner = CliRunner()
             result = runner.invoke(main, [
                 "memory", "promote", str(entry_id),

--- a/tests/test_t2.py
+++ b/tests/test_t2.py
@@ -663,6 +663,7 @@ def test_migration_guard_sequential_construction(tmp_path: Path, monkeypatch) ->
     )
 
 
+@_skip_on_gha_flake
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="os.symlink requires admin/developer mode on Windows",

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.34.2"
+version = "4.34.3"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.34.3"
+version = "4.34.4"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.34.0"
+version = "4.34.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.34.1"
+version = "4.34.2"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Why

Develop was 13 commits behind main (12 substantive + this merge). Per the project memory feedback note about develop being the integration branch, periodic reconciliation prevents the gap from growing painful.

## What's coming back

- 4.34.1 / 4.34.2 / 4.34.3 / 4.34.4 release commits (manifest bumps + changelog rows)
- `feat(rdr-120)`: nx daemon t2 ensure-running + SessionStart auto-spawn (685a9cda)
- `test(rdr-120)`: substrate stress-validation matrix (53139169) — full 5-scenario test suite
- `docs`: RDR-120 substrate sweep + container-integration guide (90868a4a) + new `docs/migration/upgrading-to-4.34.md`
- `fix(nx-plugin)`: order T2 ensure-running after preflight in SessionStart (4cb9cb4b)
- `test`: mark test_migration_guard_path_normalization as gha-flake (6b2cd4ca)
- 4.34.4 substance: `alwaysLoad: true` MCP servers + skill imperative descriptions
- Misc test patches + integration tweaks

## Conflicts

None — clean merge.

## Out of scope

PR #928 (workflow action SHA pin) is still in flight against main. Once it merges, a second reconciliation will be needed — but that single one-line workflow change isn't worth blocking on.