### PR TITLE
feat(nx): /nx:continuation slash command for paste-ready handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### New: `/nx:continuation` slash command
+
+Generates a paste-ready handoff prompt at session close. Captures
+branch state, in-progress and ready beads, open PRs from this branch,
+active T2 memory titles, and (if Claude Code auto-memory is in use)
+the project's `feedback_*.md` filenames. Instructs Claude to compose
+a 10-section continuation document at
+`~/.cache/nexus/continuations/<repo>-continuation-<slug>-<date>.md`
+and emit the compressed paste-ready prompt in chat as a copy-clickable
+code block.
+
+Argument is optional: `/nx:continuation` slugs from the current branch,
+`/nx:continuation "RDR-120 P3b"` slugs from the topic. Same-day
+re-invocations append `-HHMM` so prior captures aren't overwritten.
+
+Mined from 122 instances of the continuation-prompt pattern across
+project sessions plus 9 canonical handoff files in `/tmp/`; the
+10-section structure is the empirical consensus shape.
+
 ## [4.34.4] - 2026-05-23
 
 ### Plugins — tool/skill invocation discipline restored

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### New utility command: `/nx:continuation`
+
+Session-close handoff prompt generator. Captures branch, beads,
+PRs, T2 memory, and Claude Code auto-memory (if present) into a
+10-section continuation document under
+`~/.cache/nexus/continuations/`. Emits a paste-ready compressed
+prompt in chat for the next session's bootstrap.
+
+Argument optional; defaults to a slug derived from the current
+branch. Same-day re-runs append HHMM so nothing is overwritten.
+
+Registry entry: `utility_commands.continuation` in
+`nx/registry.yaml`.
+
 ## [4.34.4] - 2026-05-23
 
 ### Restored tool/skill invocation discipline

--- a/nx/README.md
+++ b/nx/README.md
@@ -283,6 +283,10 @@ See `hooks/hooks.json` for exact wiring. Paths below use `$CLAUDE_PLUGIN_ROOT` a
 - `/nx:enrich-plan` → `nx_enrich_beads` *(was → plan-enricher agent)*
 - `/nx:pdf-process` → `nx index pdf` CLI *(was → pdf-chromadb-processor agent)*
 
+**Utility commands** (no agent dispatch, no MCP call — direct local action):
+- `/nx:continuation [topic]` — write a paste-ready handoff prompt to `~/.cache/nexus/continuations/` capturing branch, in-progress beads, open PRs, and active T2 memory. Use at session close. Compressed prompt is emitted in chat as a copy-clickable code block.
+- `/nx:nx-preflight` — verify nx plugin dependencies (CLI, doctor, beads).
+
 **RDR commands**: `/nx:rdr-create`, `/nx:rdr-list`, `/nx:rdr-show`, `/nx:rdr-research`, `/nx:rdr-gate`, `/nx:rdr-accept`, `/nx:rdr-close`, `/nx:rdr-audit`
 
 

--- a/nx/commands/continuation.md
+++ b/nx/commands/continuation.md
@@ -11,26 +11,33 @@ Generates a paste-ready handoff document under `~/.cache/nexus/continuations/` t
   set +e
 
   # ---- Resolve repo + slug -------------------------------------------------
-  REPO=$(basename "$(pwd)")
+  # Sanitize REPO (basename can contain spaces) the same way as the SLUG so
+  # the final filename has no whitespace and no character that would need
+  # shell quoting downstream.
+  REPO_SAFE=$(printf '%s' "$(basename "$(pwd)")" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+  [ -z "$REPO_SAFE" ] && REPO_SAFE="repo"
   TODAY=$(date +%Y-%m-%d)
   OUT_DIR="${HOME}/.cache/nexus/continuations"
   mkdir -p "$OUT_DIR"
 
+  # Slug pipeline: printf strips the trailing newline that echo adds, so the
+  # tr -c result has no trailing-dash artefact that the later s/-$//g would
+  # have to clean up. Explicit > implicit.
   if [ -n "$ARGUMENTS" ]; then
-    SLUG=$(echo "$ARGUMENTS" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+    SLUG=$(printf '%s' "$ARGUMENTS" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
     TITLE_TOPIC="$ARGUMENTS"
   else
     BR=$(git branch --show-current 2>/dev/null || echo "no-branch")
-    SLUG=$(echo "$BR" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+    SLUG=$(printf '%s' "$BR" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
     TITLE_TOPIC="current branch $BR"
   fi
   [ -z "$SLUG" ] && SLUG="session"
 
   # If a same-day file already exists at the base path, suffix with HHMM so
   # successive invocations on the same day don't silently overwrite.
-  BASE="${OUT_DIR}/${REPO}-continuation-${SLUG}-${TODAY}.md"
+  BASE="${OUT_DIR}/${REPO_SAFE}-continuation-${SLUG}-${TODAY}.md"
   if [ -e "$BASE" ]; then
-    OUT="${OUT_DIR}/${REPO}-continuation-${SLUG}-${TODAY}-$(date +%H%M).md"
+    OUT="${OUT_DIR}/${REPO_SAFE}-continuation-${SLUG}-${TODAY}-$(date +%H%M).md"
   else
     OUT="$BASE"
   fi
@@ -144,7 +151,7 @@ Compose a paste-ready continuation prompt and write it to the **Target file** pa
 
 7. **Locked contracts / invariants** — anything settled in this session that the next session MUST honour. Pull from RDR §Out-of-scope, prior decisions, locked-in shapes, version-bump parity rules.
 
-8. **What you should NOT do** — explicit ban list. If feedback-memory filenames appeared in the working-state block, reference them by filename (don't paraphrase, point).
+8. **What you should NOT do** — explicit ban list. If feedback-memory filenames appeared in the working-state block, reference them by filename (don't paraphrase, point). The block lists filenames only, not contents; if you need to quote a specific rule, Read the file first rather than guessing at the body from the slug.
 
 9. **Workflow lessons from this session** — anything that bit you this session that next-session-you should pre-empt.
 

--- a/nx/commands/continuation.md
+++ b/nx/commands/continuation.md
@@ -1,11 +1,11 @@
 ---
-description: Write a paste-ready continuation prompt to /tmp capturing session state, branch, beads, T2 entries, and next-step pointers
+description: Write a paste-ready continuation prompt under ~/.cache/nexus/continuations/ capturing session state, branch, beads, T2 entries, and next-step pointers
 argument-hint: [topic-or-arc-slug] (optional; defaults to current branch)
 ---
 
 # Continuation prompt builder
 
-Generates a paste-ready handoff document in `/tmp/` that a future Claude Code session can read to pick up cold. Use this at the END of a productive session, or at a phase boundary, to capture state cheaply before context is lost.
+Generates a paste-ready handoff document under `~/.cache/nexus/continuations/` that a future Claude Code session can read to pick up cold. Use this at the END of a productive session, or at a phase boundary, to capture state cheaply before context is lost.
 
 !{
   set +e
@@ -13,6 +13,8 @@ Generates a paste-ready handoff document in `/tmp/` that a future Claude Code se
   # ---- Resolve repo + slug -------------------------------------------------
   REPO=$(basename "$(pwd)")
   TODAY=$(date +%Y-%m-%d)
+  OUT_DIR="${HOME}/.cache/nexus/continuations"
+  mkdir -p "$OUT_DIR"
 
   if [ -n "$ARGUMENTS" ]; then
     SLUG=$(echo "$ARGUMENTS" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
@@ -24,7 +26,14 @@ Generates a paste-ready handoff document in `/tmp/` that a future Claude Code se
   fi
   [ -z "$SLUG" ] && SLUG="session"
 
-  OUT="/tmp/${REPO}-continuation-${SLUG}-${TODAY}.md"
+  # If a same-day file already exists at the base path, suffix with HHMM so
+  # successive invocations on the same day don't silently overwrite.
+  BASE="${OUT_DIR}/${REPO}-continuation-${SLUG}-${TODAY}.md"
+  if [ -e "$BASE" ]; then
+    OUT="${OUT_DIR}/${REPO}-continuation-${SLUG}-${TODAY}-$(date +%H%M).md"
+  else
+    OUT="$BASE"
+  fi
   echo "**Target file:** \`$OUT\`"
   echo ""
   echo "**Topic:** $TITLE_TOPIC"
@@ -93,10 +102,15 @@ Generates a paste-ready handoff document in `/tmp/` that a future Claude Code se
     echo ""
   fi
 
-  # ---- Optional: Claude Code auto-memory (Hal's pattern; silent if absent) -
+  # ---- Optional: Claude Code auto-memory (silent if absent) ----------------
+  # Claude Code names session dirs by replacing every non-alphanumeric char in
+  # the absolute cwd with a dash. Use printf to strip pwd's trailing newline
+  # (otherwise tr -c converts it to a trailing dash and the glob over-matches
+  # adjacent repos with prefix-equal paths, e.g. nexus vs nexus-rdr-125).
   echo "### Feedback memories (auto-memory dir, if present)"
-  PROJ_DIR=$(ls -td ~/.claude/projects/*"$(pwd | tr '/' '-' | sed 's/^-//')"* 2>/dev/null | head -1)
-  if [ -n "$PROJ_DIR" ] && [ -d "$PROJ_DIR/memory" ]; then
+  PWD_KEY=$(printf '%s' "$(pwd)" | tr -c 'A-Za-z0-9' '-')
+  PROJ_DIR="${HOME}/.claude/projects/${PWD_KEY}"
+  if [ -d "$PROJ_DIR/memory" ]; then
     ls "$PROJ_DIR/memory/" 2>/dev/null | grep -E '^feedback_' | head -10 | sed 's|^|- |'
   else
     echo "(none; auto-memory not configured for this repo)"
@@ -145,12 +159,12 @@ Compose a paste-ready continuation prompt and write it to the **Target file** pa
 
 ### Output
 
-Write the document to **Target file**. After writing, output exactly one line for easy copy:
+Write the document to **Target file** (the path printed at the top of the rendered context block). After writing, output exactly one line for easy copy:
 
 ```
-Continuation prompt written: /tmp/<repo>-continuation-<slug>-<date>.md
+Continuation prompt written: <path-from-Target-file-line>
 ```
 
 Then a one-paragraph human summary of what the next session is picking up. Nothing else.
 
-If `$ARGUMENTS` is empty AND no obvious in-progress arc exists, stop and ask the user what the handoff scope should cover, rather than guessing.
+If the rendered "Topic:" line above reads `current branch no-branch` (no arguments AND not a git repo) AND the in-progress beads block is empty or absent, stop and ask the user what the handoff scope should cover rather than guessing.

--- a/nx/commands/continuation.md
+++ b/nx/commands/continuation.md
@@ -159,12 +159,22 @@ Compose a paste-ready continuation prompt and write it to the **Target file** pa
 
 ### Output
 
-Write the document to **Target file** (the path printed at the top of the rendered context block). After writing, output exactly one line for easy copy:
+Write the full 10-section document to **Target file** (the path printed at the top of the rendered context block).
 
-```
-Continuation prompt written: <path-from-Target-file-line>
-```
+Then in chat, respond with **exactly three elements in this order, nothing else**:
 
-Then a one-paragraph human summary of what the next session is picking up. Nothing else.
+1. **One bold line** with the file path on its own (no prefix prose):
+   ```
+   **<path-from-Target-file-line>**
+   ```
+2. **A single fenced code block** containing the compressed continuation prompt (section 10 of the written document, verbatim). Use triple-backtick fence with no language tag so the user's terminal renders a clean copy button:
+   <pre>
+   ```
+   &lt;5 to 10 line paste-ready prompt for the next session&gt;
+   ```
+   </pre>
+3. **One short sentence** (under 20 words) naming the entry point for the next session, e.g. `Next session resumes at PR #928 CI merge.` No more.
+
+No headers, no bullet lists, no summary paragraph, no "I've written...", no closing pleasantry. The user is mid-clear-and-paste workflow; every extra line is friction.
 
 If the rendered "Topic:" line above reads `current branch no-branch` (no arguments AND not a git repo) AND the in-progress beads block is empty or absent, stop and ask the user what the handoff scope should cover rather than guessing.

--- a/nx/commands/continuation.md
+++ b/nx/commands/continuation.md
@@ -1,0 +1,156 @@
+---
+description: Write a paste-ready continuation prompt to /tmp capturing session state, branch, beads, T2 entries, and next-step pointers
+argument-hint: [topic-or-arc-slug] (optional; defaults to current branch)
+---
+
+# Continuation prompt builder
+
+Generates a paste-ready handoff document in `/tmp/` that a future Claude Code session can read to pick up cold. Use this at the END of a productive session, or at a phase boundary, to capture state cheaply before context is lost.
+
+!{
+  set +e
+
+  # ---- Resolve repo + slug -------------------------------------------------
+  REPO=$(basename "$(pwd)")
+  TODAY=$(date +%Y-%m-%d)
+
+  if [ -n "$ARGUMENTS" ]; then
+    SLUG=$(echo "$ARGUMENTS" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+    TITLE_TOPIC="$ARGUMENTS"
+  else
+    BR=$(git branch --show-current 2>/dev/null || echo "no-branch")
+    SLUG=$(echo "$BR" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+    TITLE_TOPIC="current branch $BR"
+  fi
+  [ -z "$SLUG" ] && SLUG="session"
+
+  OUT="/tmp/${REPO}-continuation-${SLUG}-${TODAY}.md"
+  echo "**Target file:** \`$OUT\`"
+  echo ""
+  echo "**Topic:** $TITLE_TOPIC"
+  echo ""
+
+  # ---- Working state -------------------------------------------------------
+  echo "## Working state"
+  echo ""
+  echo "- **cwd:** \`$(pwd)\`"
+  if git rev-parse --git-dir > /dev/null 2>&1; then
+    echo "- **branch:** \`$(git branch --show-current 2>/dev/null)\`"
+    echo "- **HEAD:** \`$(git log --oneline -1 2>/dev/null)\`"
+    UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo "(no upstream)")
+    echo "- **upstream:** $UPSTREAM"
+    AHEAD=$(git rev-list --count @{u}..HEAD 2>/dev/null || echo "?")
+    BEHIND=$(git rev-list --count HEAD..@{u} 2>/dev/null || echo "?")
+    echo "- **ahead/behind:** $AHEAD / $BEHIND"
+  else
+    echo "- **branch:** (not a git repo)"
+  fi
+  echo ""
+
+  echo "### Uncommitted"
+  echo '```'
+  git status --short 2>/dev/null | head -20 || echo "(no git status)"
+  echo '```'
+  echo ""
+
+  echo "### Recent commits (last 10 on this branch)"
+  echo '```'
+  git log --oneline -10 2>/dev/null || echo "(no log)"
+  echo '```'
+  echo ""
+
+  echo "### Open PRs from this branch"
+  echo '```'
+  if command -v gh >/dev/null 2>&1; then
+    gh pr list --head "$(git branch --show-current 2>/dev/null)" --state open \
+      --json number,title,baseRefName \
+      --jq '.[] | "PR #\(.number) -> \(.baseRefName): \(.title)"' 2>/dev/null | head -5
+  else
+    echo "(gh not installed)"
+  fi
+  echo '```'
+  echo ""
+
+  if command -v bd >/dev/null 2>&1; then
+    echo "### In-progress beads"
+    echo '```'
+    bd list --status=in_progress --limit=10 2>/dev/null || echo "(none)"
+    echo '```'
+    echo ""
+    echo "### Ready beads (top 10)"
+    echo '```'
+    bd ready --limit=10 2>/dev/null | head -25 || echo "(none)"
+    echo '```'
+    echo ""
+  fi
+
+  if command -v nx >/dev/null 2>&1; then
+    PROJ_ACTIVE="${REPO}_active"
+    echo "### nx memory ($PROJ_ACTIVE) titles"
+    echo '```'
+    nx memory get --project "$PROJ_ACTIVE" --title "" 2>/dev/null | head -15 || echo "(no active-project memory)"
+    echo '```'
+    echo ""
+  fi
+
+  # ---- Optional: Claude Code auto-memory (Hal's pattern; silent if absent) -
+  echo "### Feedback memories (auto-memory dir, if present)"
+  PROJ_DIR=$(ls -td ~/.claude/projects/*"$(pwd | tr '/' '-' | sed 's/^-//')"* 2>/dev/null | head -1)
+  if [ -n "$PROJ_DIR" ] && [ -d "$PROJ_DIR/memory" ]; then
+    ls "$PROJ_DIR/memory/" 2>/dev/null | grep -E '^feedback_' | head -10 | sed 's|^|- |'
+  else
+    echo "(none; auto-memory not configured for this repo)"
+  fi
+  echo ""
+}
+
+## Action
+
+Compose a paste-ready continuation prompt and write it to the **Target file** path above. Match the canonical 10-section structure exactly. Each section is load-bearing for a cold pickup; skipping one loses information the next session needs.
+
+### Required sections (in order)
+
+1. **Title** — `# Continuation: <topic> (YYYY-MM-DD)` matching the working-state topic line.
+
+2. **What just shipped / state at handoff** — concrete commits with SHAs from the recent-commits block, beads closed in the session, T2 entries written, releases tagged. Name everything explicitly.
+
+3. **Where state lives** — bullet list of branch, RDR file paths (if applicable), T2 memory keys (`project=X, title=Y`), bead IDs of the epic and root work, PR numbers.
+
+4. **Literal first actions** — numbered, copy-paste-runnable commands. Always include:
+   - `cd <abs path>` from working-state cwd
+   - `git fetch && git checkout <branch> && git pull` (or equivalent)
+   - `git status --short` clean-state check
+   - `bd ready` or specific `bd show <id>` if a bead is the entry point
+   - Any specific T2 reads (`mcp__plugin_nx_nexus__memory_get(project=..., title=...)`)
+   - Any specific file reads required to come up to speed
+
+5. **Open work / bead graph** — if multiple beads are in flight, draw the dependency graph as an ASCII tree. Mark the READY entry point.
+
+6. **Active blockers** — any `in_progress` beads that gate the next step, or external blockers (CI red, dependent PR pending).
+
+7. **Locked contracts / invariants** — anything settled in this session that the next session MUST honour. Pull from RDR §Out-of-scope, prior decisions, locked-in shapes, version-bump parity rules.
+
+8. **What you should NOT do** — explicit ban list. If feedback-memory filenames appeared in the working-state block, reference them by filename (don't paraphrase, point).
+
+9. **Workflow lessons from this session** — anything that bit you this session that next-session-you should pre-empt.
+
+10. **Compressed continuation prompt** — a single blockquote (5-10 lines) that a future Claude session can paste verbatim to bootstrap. References the full file path.
+
+### Style rules
+
+- **No em dashes (`—`).** Use commas, colons, periods, or parentheses. Grep your output before writing.
+- **Imperative voice.** "Read X first. Run Y. Pick up Z." not "you might want to consider...".
+- **Concrete over general.** file:line, commit SHA, bead ID, date. Never "the relevant file" or "the recent work".
+- **Tool names in full form.** `mcp__plugin_nx_nexus__memory_get`, not "the memory tool".
+
+### Output
+
+Write the document to **Target file**. After writing, output exactly one line for easy copy:
+
+```
+Continuation prompt written: /tmp/<repo>-continuation-<slug>-<date>.md
+```
+
+Then a one-paragraph human summary of what the next session is picking up. Nothing else.
+
+If `$ARGUMENTS` is empty AND no obvious in-progress arc exists, stop and ask the user what the handoff scope should cover, rather than guessing.

--- a/nx/registry.yaml
+++ b/nx/registry.yaml
@@ -654,7 +654,7 @@ utility_commands:
 
   continuation:
     slash_command: /continuation
-    description: "Write a paste-ready continuation prompt to /tmp capturing session state, branch, beads, T2 entries, and next-step pointers"
+    description: "Write a paste-ready continuation prompt under ~/.cache/nexus/continuations/ capturing session state, branch, beads, T2 entries, and next-step pointers"
     disable_model_invocation: false
 
 

--- a/nx/registry.yaml
+++ b/nx/registry.yaml
@@ -652,6 +652,11 @@ utility_commands:
     description: "Index PDF files into nx store for semantic search via nx index pdf"
     disable_model_invocation: false
 
+  continuation:
+    slash_command: /continuation
+    description: "Write a paste-ready continuation prompt to /tmp capturing session state, branch, beads, T2 entries, and next-step pointers"
+    disable_model_invocation: false
+
 
 
 


### PR DESCRIPTION
## Why

Mined 122 instances of the \"continuation prompt\" pattern across project sessions (`~/.claude/projects/.../*.jsonl`) plus 9 canonical handoff files in `/tmp/`. The pattern is consistent and load-bearing for cold pickups but currently requires hand-writing the structure each time. Codifying it as a slash command turns 30 seconds of careful structure into a single invocation.

## What

* `nx/commands/continuation.md` — new slash command. Invokes as `/nx:continuation [optional-topic]`.
* `nx/registry.yaml` — registry entry under `utility_commands` for the bidirectional-registry test.

## Behaviour

* No arg: slug derives from current branch name.
* With arg: slug derives from the topic (`/nx:continuation \"RDR-120 P3b\"` → `rdr-120-p3b`).
* Inspects: git state, in-progress beads (if `bd` present), ready beads, active T2 memory titles (if `nx` present), open PRs (if `gh` present), and auto-memory feedback files (if Claude Code memory dir exists).
* Output path: `/tmp/<repo>-continuation-<slug>-<date>.md`.
* Instructs Claude to compose using the canonical 10-section structure:
  1. Title with date
  2. What just shipped / state at handoff (with concrete SHAs and bead IDs)
  3. Where state lives (branch, T2 keys, RDR paths, bead IDs)
  4. Literal first actions (copy-pasteable commands)
  5. Open work / bead dependency graph
  6. Active blockers
  7. Locked contracts and invariants
  8. What you should NOT do (with feedback memory references by filename)
  9. Workflow lessons from this session
  10. Compressed continuation prompt (5-10 line blockquote for next-session paste)
* Style rules embedded: no em dashes, imperative voice, concrete pointers, full MCP tool names.

## Test

* `uv run pytest tests/test_plugin_structure.py` → 601 passed, 27 skipped.
* Functional shake-out earlier this session produced a 9.6 KB / 87-line / zero-em-dash artifact at `/tmp/nexus-continuation-chore-merge-main-into-develop-2026-05-23.md`.