### PR TITLE
fix(routing): tighten phase_review_close_requires_gate trigger (GH #931)

### DIFF
--- a/nx/hooks/scripts/routing/phase_review_close_requires_gate.py
+++ b/nx/hooks/scripts/routing/phase_review_close_requires_gate.py
@@ -43,7 +43,34 @@ _BD_CLOSE_RE = re.compile(
 _RDR_RE = re.compile(r"\brdr[-_ ]?(?P<id>\d+)\b", re.IGNORECASE)
 _PHASE_RE = re.compile(r"\bphase[\s-]?(?P<phase>\d+)\b", re.IGNORECASE)
 _P_LEAF_RE = re.compile(r"\bP(?P<phase>\d+)(?:\.\d+)*\b")
-_TRIGGER_RE = re.compile(r"\b(phase|review)\b", re.IGNORECASE)
+# Trigger must match the bead TITLE line only (not the full description).
+# Implementation beads in phased plans routinely mention "phase" or "review"
+# in their description, parent epic, or rationale text. To distinguish a
+# phase-review-gate bead from an implementation bead in the same phase, the
+# trigger requires either:
+#   1. The phrase "Phase N review gate" (case-insensitive, with optional
+#      sub-phase letter or decimal, e.g. "Phase 3b" / "Phase 1.5"), OR
+#   2. The literal slash-command name "phase-review-gate" preceded by a
+#      phase prefix like "P3b" or "Phase 0".
+# A bare mention of "phase-review-gate" anywhere (e.g. in a meta-task title
+# "phase-review-gate skill: recognize ...") is intentionally NOT matched —
+# the bead must be an actual phase-N gate execution to trigger the sentinel
+# check. See GH issue #931 / bead nexus-1pr9n for the regression that
+# motivated the tighter trigger.
+_GATE_TITLE_RE = re.compile(
+    r"\b(?:phase|p)[\s-]?\d+[\w.]*\s+(?:phase[\s-]?)?review[\s-]?gate\b",
+    re.IGNORECASE,
+)
+
+
+def _bd_header_line(bd_output: str) -> str:
+    """Return the first non-empty line from ``bd show`` output (the header
+    line carrying the bead title), or empty string if none."""
+    for line in bd_output.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
 
 
 def _claude_pid() -> int:
@@ -164,8 +191,13 @@ def body(payload: dict[str, Any]) -> None:
         # than fail-closed; we have no signal to deny on.
         _lib.allow()
 
-    # Trigger heuristic: title or description contains "phase" or "review".
-    if not _TRIGGER_RE.search(bd_output):
+    # Trigger: match against the bead's TITLE line only (the first non-empty
+    # line of bd show output), and only for the narrow "Phase N ... review
+    # gate" or "Phase N ... phase-review-gate" patterns. Implementation beads
+    # in phased plans whose description / parent / rationale mentions "phase"
+    # or "review" no longer false-positive (GH #931 / nexus-1pr9n).
+    title_line = _bd_header_line(bd_output)
+    if not _GATE_TITLE_RE.search(title_line):
         _lib.allow()
 
     rdr_id, phase = _extract_rdr_phase(bd_output)

--- a/tests/test_routing_phase_review_close.py
+++ b/tests/test_routing_phase_review_close.py
@@ -178,6 +178,89 @@ def test_bd_close_on_non_phase_review_bead_allows(tmp_env):
     assert _decision(proc)["permissionDecision"] == "allow"
 
 
+# ---------------------------------------------------------------------------
+# Regression: GH #931 / nexus-1pr9n
+#
+# Implementation beads inside a phased RDR plan must not trigger the gate
+# just because the word "phase" or "review" appears in their title or
+# description. Only beads whose title matches "Phase N review gate" or
+# "Phase N phase-review-gate" should count.
+# ---------------------------------------------------------------------------
+
+
+def test_impl_bead_phase_step_title_allows(tmp_env):
+    """Implementation bead title 'Phase N Step N: ...' must NOT trigger
+    the gate (GH #931). The implementation step is not the gate bead;
+    the gate is a sibling with a distinct title."""
+    _write_bd_stub(
+        tmp_env["bin_dir"],
+        title="Phase 0 Step 0: Resolve spatial-level question (Manager + BubbleBounds co-update)",
+        description="RDR-003 §Implementation Plan Phase 0 Step 0. Closing gate is the sibling phase-review-gate bead.",
+    )
+    proc = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "bd close Luciferase-hic"}},
+        env_extra={},
+        bin_dir=tmp_env["bin_dir"],
+    )
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_meta_bead_about_phase_review_gate_skill_allows(tmp_env):
+    """A bead title ABOUT the phase-review-gate skill (e.g. a follow-on
+    task) is not a gate execution and must not trigger the sentinel
+    check. Distinguishing signal: no phase number prefix in the title."""
+    _write_bd_stub(
+        tmp_env["bin_dir"],
+        title="phase-review-gate skill: recognize phase-block sub-bullets as items (RDR-120 follow-on)",
+    )
+    proc = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "bd close nexus-4u6mt"}},
+        env_extra={},
+        bin_dir=tmp_env["bin_dir"],
+    )
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_impl_bead_description_mentioning_phase_review_gate_allows(tmp_env):
+    """An implementation bead whose DESCRIPTION mentions the phase-review-
+    gate command (because future-self will eventually run it) must not
+    trigger the gate when the title itself is an implementation step."""
+    _write_bd_stub(
+        tmp_env["bin_dir"],
+        title="P3.A Migration ownership transfer",
+        description="When P3 is complete, run /nx:phase-review-gate RDR-120 --phase 3 to close the phase.",
+    )
+    proc = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "bd close nexus-e9x4l"}},
+        env_extra={},
+        bin_dir=tmp_env["bin_dir"],
+    )
+    assert _decision(proc)["permissionDecision"] == "allow"
+
+
+def test_gate_bead_sub_phase_letter_title_triggers(tmp_env):
+    """Gate beads with sub-phase identifiers (P3b, Phase 1.5, etc.) must
+    still trigger the sentinel check."""
+    _write_bd_stub(
+        tmp_env["bin_dir"],
+        title="Phase 3b review gate: /nx:phase-review-gate RDR-120 --phase 3b",
+    )
+    # No sentinel written — expect deny.
+    proc = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "bd close nexus-b9lox"}},
+        env_extra={"NX_FAKE_CLAUDE_PID": str(os.getpid())},
+        bin_dir=tmp_env["bin_dir"],
+    )
+    _make_session_addr(tmp_env["config_dir"], os.getpid())
+    proc = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "bd close nexus-b9lox"}},
+        env_extra={"NX_FAKE_CLAUDE_PID": str(os.getpid())},
+        bin_dir=tmp_env["bin_dir"],
+    )
+    decision = _decision(proc)
+    assert decision["permissionDecision"] == "deny"
+
+
 def test_escape_token_allows_even_on_phase_review_bead(tmp_env):
     _write_bd_stub(tmp_env["bin_dir"], title="P1 phase review gate for RDR-112")
     proc = _run_hook(


### PR DESCRIPTION
## Why

GH issue #931. Hook `nx/hooks/scripts/routing/phase_review_close_requires_gate.py` previously triggered on `\b(phase|review)\b` anywhere in the full `bd show` output. Combined with `fail_closed: true` this denied `bd close` on any implementation bead in a phased plan whose text mentioned "phase" or "review" — which is most of them. The redirect message pointed users at `/nx:phase-review-gate <rdr> --phase <n>`, which is not the right action for an implementation step (the gate is a sibling bead).

Repro from the issue: `Luciferase-hic`, title `Phase 0 Step 0: Resolve spatial-level question (Manager + BubbleBounds co-update)`, denied at close time.

## Fix

Match against the bead's TITLE line only (the first non-empty line of `bd show` output), with a narrow regex:

```python
_GATE_TITLE_RE = re.compile(
    r"\b(?:phase|p)[\s-]?\d+[\w.]*\s+(?:phase[\s-]?)?review[\s-]?gate\b",
    re.IGNORECASE,
)
```

Matches gate execution beads:
- `Phase 0 review gate: /nx:phase-review-gate RDR-003 --phase 0` ✓
- `Phase 3b review gate` ✓ (sub-phase letter)
- `Phase 1.5 review gate` ✓ (decimal)
- `P3b phase-review-gate` ✓
- `RDR-112 Phase 1 review gate` ✓ (existing test fixture)

Does NOT match:
- `Phase 0 Step 0: Resolve ...` (the regression case) ✓
- `phase-review-gate skill: recognize phase-block sub-bullets...` (meta-task about the skill) ✓
- Impl beads whose description mentions `/nx:phase-review-gate` for future-self reference ✓

## Tests

Four regression tests added in `tests/test_routing_phase_review_close.py`:
- `test_impl_bead_phase_step_title_allows`
- `test_meta_bead_about_phase_review_gate_skill_allows`
- `test_impl_bead_description_mentioning_phase_review_gate_allows`
- `test_gate_bead_sub_phase_letter_title_triggers`

All 18 tests in the suite pass.

## Closes

Closes #931
Closes nexus-1pr9n