### PR TITLE
chore: sync main -> develop after 4.34.5 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.34.4"
+      "version": "4.34.5"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.34.4"
+      "version": "4.34.5"
     }
   ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,13 @@ jobs:
         # No api-token needed — uses OIDC trusted publisher
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        # Pinned to v2.6.2 SHA after the floating @v2 tag was implicated
+        # in a "Bad credentials" failure during the 4.34.4 publish (run
+        # 26327424584, 2026-05-23). PyPI publish succeeded; only the GH
+        # release sub-step failed and was created manually. Pinning to a
+        # full-length SHA prevents silent action upgrades from re-introducing
+        # the issue. Bump deliberately when validating a newer v2.x.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
         with:
           body_path: /tmp/release_notes.md
           files: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.34.5] - 2026-05-23
+
 ### New: `/nx:continuation` slash command
 
 Generates a paste-ready handoff prompt at session close. Captures
@@ -24,6 +26,27 @@ re-invocations append `-HHMM` so prior captures aren't overwritten.
 Mined from 122 instances of the continuation-prompt pattern across
 project sessions plus 9 canonical handoff files in `/tmp/`; the
 10-section structure is the empirical consensus shape.
+
+### Fix: `phase_review_close_requires_gate` no longer false-positives on implementation beads (GH #931)
+
+The `bd close` PreToolUse hook previously triggered on `\b(phase|review)\b`
+anywhere in the full `bd show` output. Combined with `fail_closed: true`,
+this denied closing any implementation bead in a phased plan whose text
+mentioned "phase" or "review", which is most implementation beads under a
+phased RDR. The trigger now matches against the bead's TITLE line only and
+only for narrow patterns: `Phase N review gate` (with optional sub-phase
+letter or decimal) or `PN phase-review-gate`. A bare mention of
+`phase-review-gate` without a phase prefix no longer false-positives. Four
+regression tests cover the false-positive cases from #931 and the
+sub-phase-letter true-positive.
+
+### CI: pin `softprops/action-gh-release` to v2.6.2 SHA
+
+After the 4.34.4 release surfaced a `Bad credentials` failure from the
+floating `@v2` tag (PyPI publish succeeded; only the downstream GH-release
+creation failed and was created manually), the action is now pinned to
+`3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` (v2.6.2). Future drift requires
+a deliberate SHA bump.
 
 ## [4.34.4] - 2026-05-23
 

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.34.4",
+  "version": "4.34.5",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.34.5] - 2026-05-23
+
 ### New utility command: `/nx:continuation`
 
 Session-close handoff prompt generator. Captures branch, beads,
@@ -19,6 +21,16 @@ branch. Same-day re-runs append HHMM so nothing is overwritten.
 
 Registry entry: `utility_commands.continuation` in
 `nx/registry.yaml`.
+
+### Fix: `phase_review_close_requires_gate` hook trigger tightened (GH #931)
+
+The PreToolUse hook (`nx/hooks/scripts/routing/phase_review_close_requires_gate.py`)
+previously matched `\b(phase|review)\b` anywhere in the full `bd show`
+output and false-positived on implementation beads in phased plans
+whose description, parent epic, or rationale mentioned "phase" or
+"review". The trigger now matches against the title line only with a
+narrow regex requiring `Phase N review gate` or `PN phase-review-gate`.
+Four regression tests added.
 
 ## [4.34.4] - 2026-05-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.34.4"
+version = "4.34.5"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "4.34.4",
+  "version": "4.34.5",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.34.4"
+version = "4.34.5"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Why

Reconcile develop with main after the 4.34.5 release.

## Contents

- `4c1c2145` (#928) — ci(release): pin softprops/action-gh-release to v2.6.2 SHA
- `6fc06ef1` — chore: promote develop -> main for 4.34.5 (the merge commit; itself carries develop's prior content)
- `abb0e07c` — chore(release): conexus 4.34.5 (version-bump + CHANGELOG entries)

## Conflicts

None.

## Pattern

Per CLAUDE.md and the `feedback_develop_is_integration_branch.md` memory, develop is the integration branch. main carries release commits + occasional CI-infra hotfixes (PR #928 was the latter). This reconciliation flows that content back so future feature branches off develop start with the post-release state.