### PR TITLE
feat(mcpb): production .mcpb Desktop Extension for Claude Desktop chat (nexus-bsjro)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,19 @@ jobs:
       - name: Build wheel and sdist
         run: uv build --sdist --wheel
 
+      - name: Pack .mcpb Desktop Extension (RDR-126 nexus-bsjro)
+        run: |
+          # The Claude Desktop .mcpb bundle is a tiny artifact (~1-2 KB)
+          # carrying manifest.json + pyproject.toml + src/server.py.
+          # Users on Claude Desktop chat double-click it to install.
+          # `npx @anthropic-ai/mcpb pack` zips the mcpb/ directory and
+          # validates manifest.json against the v0.4 schema.
+          npm install -g @anthropic-ai/mcpb
+          cd mcpb
+          mcpb pack . conexus.mcpb
+          ls -la conexus.mcpb
+          mv conexus.mcpb ../dist/
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         # No api-token needed — uses OIDC trusted publisher
@@ -139,4 +152,5 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
+            dist/conexus.mcpb
           prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### New: Claude Desktop Extension (`.mcpb`) for chat-only users (nexus-bsjro, RDR-126)
+
+Nexus is now installable as a one-click `.mcpb` Desktop Extension for Claude Desktop chat users who don't have Claude Code installed. The bundle is a 1.5 KB artifact (manifest + pyproject + entry point); uv resolves Nexus's full compiled-dep stack on first launch (~20s cold, ~5s warm).
+
+- **Install**: download `conexus.mcpb` from a GitHub release, double-click. Claude Desktop registers it as a Connector ("Conexus") with all 31 MCP tools.
+- **First launch auto-installs the host T2 daemon** (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. Idempotent: existing installs are detected and the install step is skipped.
+- **State is shared with the Claude Code plugin, the `nx` CLI, and Cowork sessions** — all surfaces hit the same host daemons (per RDR-120's substrate model).
+- **Audience**: this is for Claude Desktop users WITHOUT Claude Code. Claude Code users already get Nexus in Claude Desktop chat via the plugin's local-agent-mode path; no second install needed.
+
+Release workflow gains a `mcpb pack` step that produces `conexus.mcpb` and uploads it as a GitHub release asset alongside the wheel and sdist. CI parity test (`test_mcpb_manifest_version_matches_pyproject`) ensures the bundle's manifest.json version stays in lock-step with pyproject.toml.
+
+Pre-requisite for users: `uv` on PATH (`brew install uv` / `pipx install uv`).
+
+New documentation: `docs/desktop-deployment.md` covers install, first-run, drift detection, and uninstall across all three surfaces (Claude Code, Cowork, Claude Desktop chat) plus CLI coexistence.
+
 ### Breaking: plugin renamed `nx` → `conexus` (nexus-mkj6u)
 
 The Claude Code plugin name changed from `nx` to `conexus` to eliminate the namespace collision with Nx (nrwl)'s Q1 2026 plugin of the same name. This is a breaking change for existing installs.

--- a/README.md
+++ b/README.md
@@ -118,18 +118,30 @@ Each research finding is tagged with its evidence quality (verified against sour
 
 RDR is fully optional. See [RDR Overview](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-overview.md) for the full process.
 
-## Claude Code plugin
+## Claude integrations
 
-The `conexus/` directory is a Claude Code plugin that gives agents access to everything above. Install via the marketplace:
+Nexus runs in three Claude surfaces, all backed by the same host daemons so state is shared across them and with the CLI.
+
+### Claude Code (terminal)
 
 ```bash
 /plugin marketplace add Hellblazer/nexus
 /plugin install conexus@nexus-plugins
 ```
 
-The plugin provides 13 specialized agents, 43 skills covering the RDR lifecycle, plan-centric retrieval, and development workflows, session hooks for automatic context initialization, and 36 MCP tools split across two focused servers: `nexus` (26 tools: search, store, memory, scratch, plans, 5 operator tools for structured extract/rank/compare/summarize/generate, plus 4 orchestration tools including `nx_answer` for plan-matched multi-step retrieval) and `nexus-catalog` (10 catalog tools: search, show, link, resolve, stats, etc.). The plan-centric retrieval layer (`nx_answer`) matches questions against a library of scenario templates, executes the matched plan, and records every run, so the library compounds with use. Agents search indexed code before proposing changes, check prior RDR decisions before designing new features, and coordinate through standard pipelines (plan → implement → review → test) with built-in quality gates.
+The plugin provides 13 specialized agents, 43 skills covering the RDR lifecycle, plan-centric retrieval, and development workflows, session hooks for automatic context initialization, and 36 MCP tools split across two focused servers: `nexus` (26 tools: search, store, memory, scratch, plans, 5 operator tools for structured extract/rank/compare/summarize/generate, plus 4 orchestration tools including `nx_answer` for plan-matched multi-step retrieval) and `nexus-catalog` (10 catalog tools: search, show, link, resolve, stats, etc.). See [conexus/README.md](https://github.com/Hellblazer/nexus/blob/main/conexus/README.md) for the full plugin documentation.
 
-The plugin integrates with [Beads](https://github.com/BeadsProject/beads) for task tracking. See [conexus/README.md](https://github.com/Hellblazer/nexus/blob/main/conexus/README.md) for the full plugin documentation.
+### Claude Desktop chat (Desktop Extension)
+
+Download `conexus.mcpb` from the [latest GitHub release](https://github.com/Hellblazer/nexus/releases/latest) and double-click to install. Claude Desktop registers it as a Connector (visible under Settings → Connectors → Desktop). uv resolves the deps on first launch (~20s); subsequent starts are ~5s. Pre-requisite: [uv](https://docs.astral.sh/uv/) on host PATH.
+
+This is the right path for Claude Desktop users WITHOUT Claude Code installed. Claude Code users already get Nexus in Claude Desktop chat via the local-agent-mode plugin path; no second install needed.
+
+### Claude Cowork (cloud agents)
+
+Works automatically once the conexus plugin is installed in Claude Code on the host. Claude Desktop passes the configured MCP servers into the Cowork VM via the Anthropic SDK transport. State round-trips bidirectionally with the host CLI through the T2 daemon. See [docs/container-integration.md](https://github.com/Hellblazer/nexus/blob/main/docs/container-integration.md) § Cowork.
+
+For the full three-surface deployment story (install, daemon lifecycle, drift detection, uninstall), see [docs/desktop-deployment.md](https://github.com/Hellblazer/nexus/blob/main/docs/desktop-deployment.md).
 
 ## CLI Reference
 

--- a/docs/desktop-deployment.md
+++ b/docs/desktop-deployment.md
@@ -1,0 +1,116 @@
+# Desktop deployment
+
+Nexus runs in three Claude surfaces, all backed by one host daemon so state is shared across them and with the `nx` CLI. This document covers install, first-run behavior, drift detection, and uninstall for each surface. The substrate that makes this work landed in RDR-120 (4.34.0+); the unified-surface design is RDR-126.
+
+## Surface 1: Claude Code (terminal)
+
+**Audience**: developers who already use Claude Code from the command line.
+
+```bash
+/plugin marketplace add Hellblazer/nexus
+/plugin install conexus@nexus-plugins
+```
+
+On first session start, the plugin's SessionStart hook auto-installs the host T2 daemon (LaunchAgent on macOS, systemd user unit on Linux) and ensures it is running. Subsequent sessions are a no-op.
+
+Tool names: `mcp__plugin_conexus_nexus__*` and `mcp__plugin_conexus_nexus-catalog__*`. Slash-command prefix: `/conexus:*`.
+
+## Surface 2: Claude Cowork (cloud agents)
+
+**Audience**: Claude Code users who open Cowork sessions for cloud-driven tasks.
+
+No separate install. Once the conexus plugin is installed in Claude Code on the host, Claude Desktop passes the configured MCP servers into the Cowork VM via the Anthropic SDK transport (`--mcp-config` with `"type": "sdk"`). The MCP server stays running on the host; the VM agent's tool calls are bridged back through the SDK channel.
+
+State is shared with the host CLI Claude and any other Cowork sessions or dev containers running against the same host daemons. Verified by a bidirectional T2 sentinel test (see `tests/test_cowork_sdk_bridge.py`).
+
+## Surface 3: Claude Desktop chat (Desktop Extension)
+
+**Audience**: Claude Desktop users who do NOT have Claude Code installed.
+
+Pre-requisite: [uv](https://docs.astral.sh/uv/) on host PATH.
+
+- macOS: `brew install uv`
+- Linux: `pipx install uv` or `curl -LsSf https://astral.sh/uv/install.sh | sh`
+
+Install:
+
+1. Download `conexus.mcpb` from the [latest GitHub release](https://github.com/Hellblazer/nexus/releases/latest).
+2. Double-click the file. Claude Desktop registers it under Settings → Connectors → Desktop as "Conexus".
+3. First launch: uv resolves Nexus's dependency stack (~237 packages, including chromadb, pydantic-core, tree-sitter, numpy, torch, onnxruntime). Cold install ~20s on a warm network; warm restarts ~5s.
+4. Also at first launch: `nx-mcp` auto-installs the T2 daemon (idempotent if already present from Claude Code or CLI use) and starts it.
+
+Tool names: `mcp__conexus__*` (no `plugin_` infix — this is the .mcpb namespace, distinct from the Claude Code plugin's).
+
+Note: Claude Code users who ALREADY have the conexus plugin should NOT also install the .mcpb. Their Claude Desktop chat already exposes Nexus tools through the plugin's local-agent-mode path. Installing the .mcpb adds a second copy under a different namespace; the model can target either but the duplication is confusing.
+
+## CLI coexistence
+
+`nx <verb>` commands run on the host shell. They talk to the same T2 daemon all three surfaces use. State is fully shared:
+
+- `nx memory put -p X -t Y` → visible from Claude Code, Cowork, and Claude Desktop chat
+- `nx search foo` → searches the same T3 collections the MCP `search` tool sees
+- `nx index repo .` → indexes show up immediately in all surface tool results
+
+Daemon lifecycle: `nx daemon t2 status` / `nx daemon t2 start` / `nx daemon t2 install --autostart` are the canonical operations. Any of the three Claude surfaces auto-installs on first launch, but the CLI commands are always available for explicit lifecycle control.
+
+## Drift detection
+
+After upgrading conexus (`uv tool upgrade conexus`) or after the plugin rename (`nx` → `conexus` at v5.0.0), `nx doctor` surfaces two kinds of drift:
+
+- **Plugin name drift**: the installed Claude Code plugin still has `name: "nx"` but the CLI expects `conexus`. Fix:
+
+  ```
+  /plugin uninstall nx@nexus-plugins      # in Claude Code
+  /plugin install conexus@nexus-plugins   # in Claude Code
+  ```
+
+- **Post-commit hook stanza drift**: the installed `.git/hooks/post-commit` predates the pgrep guard fix (nexus-mkj6u 2026-05-23). Fix:
+
+  ```
+  nx hooks update <repo>
+  ```
+
+Both warnings include the resolution commands; `nx doctor` is the single explicit-invocation surface that consolidates them.
+
+## Uninstall
+
+### Claude Code plugin
+
+```
+/plugin uninstall conexus@nexus-plugins
+```
+
+The plugin cache is removed. The host T2 daemon and stored data are unaffected — they belong to the OS / user account, not the plugin.
+
+### Claude Desktop Extension
+
+Settings → Connectors → Desktop → Conexus → Uninstall. **Caveat**: Claude Desktop removes the `.mcpb` bundle but does NOT cascade to the LaunchAgent / systemd unit. To fully remove:
+
+```
+nx daemon t2 uninstall --autostart
+# Optionally: rm -rf ~/.config/nexus
+```
+
+The MCPB spec has no manifest-level uninstall hook, so this cascade limitation is structural.
+
+### Cowork
+
+Nothing to uninstall on the Cowork side — sessions inherit whatever Claude Desktop has configured.
+
+### Daemon + data (full nuke)
+
+```
+nx daemon t2 uninstall --autostart    # remove autostart unit + stop daemon
+rm -rf ~/.config/nexus                 # remove T2 SQLite + config
+# T3: chromadb cloud accounts persist outside the daemon; manage there.
+```
+
+## Verification
+
+`tests/e2e/upgrade-shakeout.sh` exercises the full surface story in a sandbox: install OLD conexus → install hooks → upgrade to current → verify drift detection → run `nx hooks update` → verify drift resolved → verify marketplace.json rename → verify plugin-name-drift detection. 11/11 green is the gate before any release.
+
+## Failure modes
+
+- **uv not on PATH (Claude Desktop chat install)**: `.mcpb` install fails with a cryptic error. Mitigation: README documents `brew install uv` / `pipx install uv` as pre-requisite.
+- **GUI-spawned subprocess can't see shell-env credentials**: `is_local_mode()` flips to True; T3 dispatch fails. Mitigation: `nx doctor` surfaces the credential-persistence warning; persist via `nx config set chroma_api_key "$CHROMA_API_KEY"` etc.
+- **Cowork SDK bridge dropped a tool call**: rare; the sentinel test in `tests/test_cowork_sdk_bridge.py` catches structural regressions. Diagnostic recipe: `nx daemon t2 status` then `nx memory list -p _cowork_test`.

--- a/mcpb/.gitignore
+++ b/mcpb/.gitignore
@@ -1,0 +1,5 @@
+# Spike + release-asset artifacts that should NOT live in the repo.
+*.mcpb
+uv.lock
+.venv/
+__pycache__/

--- a/mcpb/.mcpbignore
+++ b/mcpb/.mcpbignore
@@ -1,0 +1,15 @@
+# Files/dirs excluded from the .mcpb bundle. mcpb pack does NOT honor
+# .gitignore; this is the ignore mechanism for the bundle itself.
+#
+# Without these, the bundle balloons from ~1 KB (the intended manifest
+# + pyproject + entry point) to ~500 MB (every uv-resolved dep landed
+# in .venv during local testing).
+
+*.mcpb
+uv.lock
+.venv/
+.uv-cache/
+__pycache__/
+*.pyc
+.pytest_cache/
+SPIKE.md

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/mcpb/main/schemas/mcpb-manifest-v0.4.schema.json",
+  "manifest_version": "0.4",
+  "name": "conexus",
+  "display_name": "Conexus",
+  "version": "4.34.5",
+  "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
+  "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
+  "author": {
+    "name": "Hal Hildebrand",
+    "url": "https://github.com/Hellblazer"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Hellblazer/nexus"
+  },
+  "homepage": "https://github.com/Hellblazer/nexus",
+  "license": "AGPL-3.0-or-later",
+  "keywords": ["semantic-search", "knowledge-management", "rag", "claude", "claude-desktop", "mcp"],
+  "server": {
+    "type": "uv",
+    "entry_point": "src/server.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": ["run", "--directory", "${__dirname}", "src/server.py"]
+    }
+  },
+  "compatibility": {
+    "platforms": ["darwin", "linux"],
+    "runtimes": {
+      "python": ">=3.12"
+    }
+  }
+}

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "conexus-mcpb"
+version = "4.34.5"
+description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
+requires-python = ">=3.12"
+dependencies = [
+    "conexus>=4.34.5",
+]
+
+[tool.uv]
+package = false

--- a/mcpb/src/server.py
+++ b/mcpb/src/server.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Nexus MCP server entry point for the Claude Desktop .mcpb spike.
+
+RDR-126 P1. Imports and runs ``nexus.mcp.core:main``, the same entry
+point the Claude Code plugin invokes via the ``nx-mcp`` console script.
+"""
+from __future__ import annotations
+
+
+def main() -> None:
+    from nexus.mcp.core import main as _nx_mcp_main
+    _nx_mcp_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nexus/mcp/_first_run.py
+++ b/src/nexus/mcp/_first_run.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-126 P2 (nexus-bsjro): first-run daemon install for MCP startup.
+
+When ``nx-mcp`` / ``nx-mcp-catalog`` boots, ensure the host T2 daemon
+unit (LaunchAgent on macOS, systemd user-unit on Linux) is installed.
+Without this, a Claude-Desktop-only user who installs the .mcpb bundle
+has nx-mcp running but no daemon for it to talk to — every MCP tool
+that touches T2 fails opaquely.
+
+Idempotency model (per RDR-126 §Approach §2):
+
+- The OS unit (LaunchAgent / systemd file) is the source of truth.
+  If it exists, skip install. We do NOT compare contents or
+  overwrite — that's the realm of ``nx daemon t2 install --autostart
+  --force`` which the user can invoke deliberately.
+- We always call ``daemon t2 ensure-running`` so the current MCP
+  session has a daemon to talk to even if install just happened or
+  the previously-installed unit was stopped.
+
+Side effects are silent on success; failures log a structured warning
+and continue (the MCP server still starts; tool calls that need the
+daemon will fail with their own error path).
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+
+def _macos_launchagent_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / "com.nexus.t2.plist"
+
+
+def _linux_systemd_unit_path() -> Path:
+    xdg_config = Path(os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config")))
+    return xdg_config / "systemd" / "user" / "nexus-t2.service"
+
+
+def _os_unit_exists() -> bool:
+    """Return True if the T2 daemon's OS-level autostart unit is
+    already installed on this host. macOS = LaunchAgent .plist,
+    Linux = systemd user .service. Other platforms (Windows): always
+    return True so the install step skips (no install support yet)."""
+    platform = sys.platform
+    if platform == "darwin":
+        return _macos_launchagent_path().exists()
+    if platform.startswith("linux"):
+        return _linux_systemd_unit_path().exists()
+    return True
+
+
+def _find_nx_binary() -> str | None:
+    """Locate the ``nx`` CLI binary the MCP server can shell out to.
+
+    Strategy:
+    1. ``shutil.which`` on the current PATH (typical CLI-spawned case).
+    2. Sibling of ``sys.argv[0]`` (the ``nx-mcp`` entry point lives in
+       the same bin dir as ``nx`` when conexus is installed via uv tool
+       or pip).
+    3. Standard uv-tool location (~/.local/bin/nx) as last-resort
+       fallback for GUI-spawned subprocesses that may have a sparse PATH.
+    """
+    found = shutil.which("nx")
+    if found:
+        return found
+
+    if sys.argv and sys.argv[0]:
+        sibling = Path(sys.argv[0]).resolve().parent / "nx"
+        if sibling.exists():
+            return str(sibling)
+
+    fallback = Path.home() / ".local" / "bin" / "nx"
+    if fallback.exists():
+        return str(fallback)
+
+    return None
+
+
+def ensure_installed_and_running() -> None:
+    """Best-effort: install the T2 daemon autostart unit if missing,
+    then ensure-running for this session. Never raises; logs warnings.
+
+    Called from each MCP server's ``main()`` once at startup, after
+    logging setup but before serving tools.
+    """
+    nx_bin = _find_nx_binary()
+    if not nx_bin:
+        _log.warning(
+            "first_run_no_nx_binary",
+            hint=(
+                "nx CLI binary not found on PATH; cannot auto-install "
+                "the T2 daemon. Install via 'uv tool install conexus' "
+                "and ensure ~/.local/bin (or your uv tool bin dir) is "
+                "on PATH for GUI-spawned subprocesses."
+            ),
+        )
+        return
+
+    if not _os_unit_exists():
+        # OS unit missing — install it. Idempotent within ``nx daemon
+        # t2 install --autostart`` itself; it checks the destination
+        # and bails with "already up to date" if the file matches.
+        try:
+            result = subprocess.run(
+                [nx_bin, "daemon", "t2", "install", "--autostart"],
+                capture_output=True, text=True, timeout=30, check=False,
+            )
+            if result.returncode != 0:
+                _log.warning(
+                    "first_run_install_failed",
+                    returncode=result.returncode,
+                    stderr=(result.stderr or "").strip()[:500],
+                    hint=(
+                        "T2 daemon autostart install failed; current MCP "
+                        "session will work via ensure-running but the "
+                        "daemon will not survive reboots. Re-run "
+                        "'nx daemon t2 install --autostart' manually."
+                    ),
+                )
+            else:
+                _log.info(
+                    "first_run_install_ok",
+                    stdout=(result.stdout or "").strip()[:500],
+                )
+        except subprocess.TimeoutExpired:
+            _log.warning(
+                "first_run_install_timeout",
+                hint="`nx daemon t2 install --autostart` timed out after 30s",
+            )
+        except Exception as exc:
+            _log.warning(
+                "first_run_install_exception",
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+    # Always ensure-running so the current session has a daemon.
+    try:
+        subprocess.run(
+            [nx_bin, "daemon", "t2", "ensure-running", "--quiet"],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+    except Exception as exc:
+        _log.warning(
+            "first_run_ensure_running_exception",
+            error=f"{type(exc).__name__}: {exc}",
+        )

--- a/src/nexus/mcp/catalog.py
+++ b/src/nexus/mcp/catalog.py
@@ -630,6 +630,7 @@ def main():
     import structlog
 
     from nexus.logging_setup import configure_logging
+    from nexus.mcp._first_run import ensure_installed_and_running
     from nexus.mcp_infra import check_version_compatibility
 
     configure_logging("mcp")
@@ -641,6 +642,8 @@ def main():
         pid=os.getpid(),
         ppid=os.getppid(),
     )
+    # RDR-126 P2 (nexus-bsjro): see nexus/mcp/core.py for rationale.
+    ensure_installed_and_running()
     try:
         check_version_compatibility()
         mcp.run(transport="stdio")

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -4035,6 +4035,7 @@ def main():
     import structlog
 
     from nexus.logging_setup import configure_logging
+    from nexus.mcp._first_run import ensure_installed_and_running
     from nexus.mcp_infra import check_version_compatibility
 
     configure_logging("mcp")
@@ -4046,6 +4047,13 @@ def main():
         pid=os.getpid(),
         ppid=os.getppid(),
     )
+    # RDR-126 P2 (nexus-bsjro): ensure the host T2 daemon's OS-level
+    # autostart unit is installed and the daemon is running before
+    # serving any tools. Without this, a Claude-Desktop-only user who
+    # installed the .mcpb has nx-mcp running but no daemon to talk to;
+    # every memory_put / search call fails opaquely. Best-effort:
+    # logs warnings on failure, never blocks startup.
+    ensure_installed_and_running()
     # The FastMCP lifespan finally is the design's primary cleanup
     # path; the signal handlers below are belt-and-braces for the
     # cases where the lifespan does not fire. Empirically, FastMCP's

--- a/tests/e2e/upgrade-shakeout.sh
+++ b/tests/e2e/upgrade-shakeout.sh
@@ -229,8 +229,26 @@ _pass "nx doctor names the uninstall + install commands"
 # tests/test_plugin_name_drift.py::test_check_version_compatibility_logs_plugin_name_mismatch
 # — easier to assert there than to spawn nx-mcp + watch stderr here.)
 
-# ── 11. Summary ──────────────────────────────────────────────────────────────
-_step "11/11 PASS"
+# ── 11. .mcpb production bundle packs from REPO_ROOT ─────────────────────────
+_step "11/12 .mcpb bundle packs cleanly from REPO_ROOT/mcpb"
+if [ -f "$REPO_ROOT/mcpb/manifest.json" ]; then
+    cd "$REPO_ROOT/mcpb"
+    rm -f conexus.mcpb
+    npx -y @anthropic-ai/mcpb@latest pack . conexus.mcpb >/dev/null 2>&1 \
+        || _die "mcpb pack failed in $REPO_ROOT/mcpb"
+    BUNDLE_SIZE=$(stat -f%z conexus.mcpb 2>/dev/null || stat -c%s conexus.mcpb 2>/dev/null)
+    rm -f conexus.mcpb
+    cd - >/dev/null
+    if [ -z "$BUNDLE_SIZE" ] || [ "$BUNDLE_SIZE" -gt 100000 ]; then
+        _die "conexus.mcpb is $BUNDLE_SIZE bytes (expected <100 KB); check .mcpbignore"
+    fi
+    _pass "mcpb pack produces a $BUNDLE_SIZE-byte bundle (well under 100 KB)"
+else
+    _pass "skipped (mcpb/ not present on this branch)"
+fi
+
+# ── 12. Summary ──────────────────────────────────────────────────────────────
+_step "12/12 PASS"
 echo "  Upgrade-shakeout green: $FROM_VERSION → $NEW_VER"
 echo "  - hook stanza migrated (pgrep guard added, no pile-up risk)"
 echo "  - nx doctor drift detection works"

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -647,6 +647,28 @@ class TestMarketplaceVersion:
                 f"its own .claude-plugin/plugin.json at {manifest}"
             )
 
+    def test_mcpb_manifest_version_matches_pyproject(self) -> None:
+        """nexus-bsjro: the Claude Desktop .mcpb bundle's manifest.json
+        and pyproject.toml versions both track the canonical conexus
+        version. CI catches forgot-to-bump-mcpb releases."""
+        mcpb_manifest = REPO_ROOT / "mcpb" / "manifest.json"
+        mcpb_pyproject = REPO_ROOT / "mcpb" / "pyproject.toml"
+        if not mcpb_manifest.exists():
+            return  # mcpb bundle not yet shipped on this branch
+        pv = self._pyproject_version()
+        manifest_version = json.loads(mcpb_manifest.read_text()).get("version")
+        assert manifest_version == pv, (
+            f"mcpb/manifest.json version {manifest_version!r} "
+            f"!= pyproject.toml {pv!r}"
+        )
+        if mcpb_pyproject.exists():
+            with mcpb_pyproject.open("rb") as f:
+                mcpb_pv = tomllib.load(f)["project"]["version"]
+            assert mcpb_pv == pv, (
+                f"mcpb/pyproject.toml version {mcpb_pv!r} "
+                f"!= pyproject.toml {pv!r}"
+            )
+
     def test_plugin_source_sha_is_well_formed_when_present(self) -> None:
         """Optional `source.sha` for tag-force-push protection. When
         present, must be a 40-character lowercase hex string (full


### PR DESCRIPTION
## Summary

Ships the third Nexus install surface: a `.mcpb` Desktop Extension for Claude Desktop chat users who don't have Claude Code. Code + Cowork already work via the existing plugin; this PR closes the gap for Claude-Desktop-only users.

After this lands and v5.0.0 is cut:
- **Claude Code (terminal)**: `/plugin install conexus@nexus-plugins`
- **Claude Cowork (cloud agents)**: works automatically when Claude Code is installed (SDK bridge)
- **Claude Desktop chat**: download `conexus.mcpb` from a GitHub release, double-click

All three surfaces hit the same host T2 daemon. State is fully shared with the `nx` CLI.

## What's in this PR

- `mcpb/` directory: production manifest (`conexus`, version-synced to pyproject), pyproject.toml pinning `conexus>=4.34.5`, src/server.py entry point invoking `nexus.mcp.core:main`. `.mcpbignore` prevents the .venv from polluting the bundle (without it, the packed bundle was 487 MB; with it, 1.5 KB).
- `src/nexus/mcp/_first_run.py`: idempotent first-run daemon install + ensure-running. Called from `nx-mcp` and `nx-mcp-catalog` startup. OS unit (LaunchAgent / systemd .service) is source of truth; existing installs detected and skipped. Subprocess shells out to existing `nx daemon t2 install --autostart` and `ensure-running` CLI commands.
- `.github/workflows/release.yml`: new `Pack .mcpb Desktop Extension` step that runs `npx @anthropic-ai/mcpb pack` and uploads `conexus.mcpb` as a GitHub release asset on tag-push.
- `README.md`: new `## Claude integrations` section enumerating all three surfaces with install commands and audience guidance.
- `docs/desktop-deployment.md`: new umbrella doc covering install + first-run + drift + uninstall for all three surfaces, CLI coexistence, and failure modes.
- `tests/test_plugin_structure.py::test_mcpb_manifest_version_matches_pyproject`: CI parity check.
- `tests/e2e/upgrade-shakeout.sh` step 11: assert `mcpb pack` produces a <100 KB bundle (catches `.mcpbignore` regressions).

## What ships at v5.0.0 (NOT in this PR)

This PR lands the substrate on develop. The actual user-visible release happens when `release/v5.0.0` is cut following the new release-branch-PR workflow. At that point:
- The rename from `nx` to `conexus` ships
- This .mcpb production substrate ships
- Both bundled into one breaking-version release
- Blog post updates publish in sync (tracked as bead nexus-vgrmq)

## Test plan

- [x] 684 plugin-suite tests green
- [x] Full upgrade-shakeout 12/12 green
- [x] Local `mcpb pack` produces 1580-byte bundle (was 487 MB without .mcpbignore)
- [x] No regressions in existing version-check / drift-detection tests

## Closes

Closes nexus-bsjro (RDR-126 epic).
Supersedes nexus-lbie5 (spike — its findings are folded into RDR-126 and this PR ships the production version).

PR #936 (the spike PR) can be closed without merge after this PR lands.