### PR TITLE
release: conexus 5.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.0.0"
+        "ref": "v5.0.1"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.0.0"
+      "version": "5.0.1"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.0.0"
+        "ref": "v5.0.1"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.0.0"
+      "version": "5.0.1"
     }
   ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
           cd mcpb
           mcpb pack . conexus.mcpb
           ls -la conexus.mcpb
-          mv conexus.mcpb ../dist/
+          mkdir -p ../mcpb-dist && mv conexus.mcpb ../mcpb-dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -152,5 +152,5 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
-            dist/conexus.mcpb
+            mcpb-dist/conexus.mcpb
           prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.1] - 2026-05-24
+
+### Fix: release workflow PyPI publish failure
+
+The v5.0.0 release workflow built the wheel + sdist + `.mcpb` artifact
+successfully, then failed at the PyPI publish step because the `mcpb pack`
+step had moved `conexus.mcpb` into `dist/` alongside the wheel and sdist.
+Twine's pre-publish check rejects unknown distribution formats, so the
+PyPI upload never ran and no GitHub Release was created.
+
+Fix: pack `.mcpb` into a separate `mcpb-dist/` directory so `dist/` stays
+PyPI-pure. The "Create GitHub Release" step now references
+`mcpb-dist/conexus.mcpb`. v5.0.0 stays as a phantom git tag with no PyPI
+artifact; v5.0.1 is the first published 5.x release.
+
+### Feature: MCP tool annotations on all 41 tools (Connector Directory prereq)
+
+Anthropic's Connector Directory submission checklist requires every MCP
+tool to expose `title`, `readOnlyHint`, and (where applicable)
+`destructiveHint` annotations. The 31 core + 10 catalog tools all carry
+these annotations now, surfaced at runtime via the MCP `tools/list`
+response.
+
+Classification: 21 tools marked read-only (search, query, all retrieval,
+all operators), 7 write/non-destructive (store_put, memory_put,
+plan_save, scratch family, nx_enrich_beads, nx_answer), 3 destructive
+(memory_delete, memory_consolidate, nx_tidy).
+
+### Docs: privacy policy + support channels
+
+- `docs/privacy-policy.md` — local-mode data stays on the host machine;
+  cloud-mode third-party connections (Voyage AI, ChromaDB Cloud,
+  Semantic Scholar, Anthropic Claude) are user-opt-in; no telemetry sent
+  to the conexus author. Required for the Connector Directory submission.
+- `bugs` URL added to `conexus/.claude-plugin/plugin.json` and
+  `sn/.claude-plugin/plugin.json`. `support` URL added to
+  `mcpb/manifest.json`. All point to `https://github.com/Hellblazer/nexus/issues`.
+
 ## [5.0.0] - 2026-05-24
 
 ### New: Claude Desktop Extension (`.mcpb`) for chat-only users (nexus-bsjro, RDR-126)

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",
@@ -10,5 +10,6 @@
   "license": "AGPL-3.0-or-later",
   "engines": {
     "python": ">=3.12"
-  }
+  },
+  "bugs": "https://github.com/Hellblazer/nexus/issues"
 }

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.1] - 2026-05-24
+
+### Feature: tool annotations on all 41 MCP tools
+
+Every MCP tool now carries `title` and `readOnlyHint` annotations via the
+MCP `tools/list` response. Tools that mutate state additionally carry
+`destructiveHint`. This was the headline Connector Directory submission
+prerequisite. See root `CHANGELOG.md` § 5.0.1 for the read-only /
+write-non-destructive / destructive classification table.
+
+### Docs: support URL added to plugin manifest
+
+`bugs` URL added to `conexus/.claude-plugin/plugin.json` pointing to
+`https://github.com/Hellblazer/nexus/issues`. Surfaced for users seeking
+the support channel.
+
 ## [5.0.0] - 2026-05-24
 
 ### Breaking: plugin renamed `nx` → `conexus` (nexus-mkj6u)

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,62 @@
+# Privacy Policy — Conexus
+
+_Effective: 2026-05-24_
+
+Conexus is a self-hosted MCP server and Claude Code / Claude Desktop extension that indexes content on your machine and provides semantic search and persistent memory across Claude conversations. This policy describes what data Conexus handles, where it goes, and what is never collected.
+
+## 1. What Conexus stores
+
+All persistent data lives on the host machine running Conexus:
+
+- **Indexed content** — text from files you ask Conexus to index (`nx index repo`, `nx index pdf`), plus structured metadata (file paths, chunk identifiers, taxonomy assignments). Stored in:
+  - `~/.local/share/nexus/chroma/` (local mode — embeddings + chunk text)
+  - ChromaDB Cloud (cloud mode — only if you provide credentials)
+- **Memory entries** — anything you (or an agent) writes via `nx memory put` or the `memory_put` MCP tool. Stored in `~/.config/nexus/memory.db` (SQLite, FTS5).
+- **Catalog** — document registry and typed-link graph. Stored in `~/.config/nexus/catalog/` (JSONL + SQLite cache).
+- **Session scratch** — ephemeral working notes shared across agents within a session. In-memory ChromaDB; wiped at session end.
+- **Plan library** — saved query execution plans. Stored alongside memory in `memory.db`.
+- **Logs** — structured operational logs at `~/.config/nexus/logs/` (rotating, 10 MB × 5).
+
+## 2. What Conexus sends to third parties
+
+**Local mode** (default — no credentials configured):
+Nothing leaves the machine. Embeddings are computed locally via ONNX MiniLM. All search runs against on-disk ChromaDB.
+
+**Cloud mode** (you opt in by providing API keys):
+- **Voyage AI** — chunk text is sent to Voyage's embedding API for indexing and to embed query strings at search time. See https://www.voyageai.com/privacy.
+- **ChromaDB Cloud** — embeddings + chunk text are stored in your ChromaDB Cloud tenant for retrieval. See https://www.trychroma.com/privacy.
+- **Semantic Scholar** (only when you run `nx enrich bib`) — bibliographic metadata lookups for PDFs you ask Conexus to enrich. See https://www.semanticscholar.org/about/privacy.
+- **Anthropic Claude** (only when an MCP operator tool fires) — chunks passed to `claude -p` subprocesses run by `operator_*` / `nx_answer` / `nx_tidy` are sent to Anthropic's API per Anthropic's standard data policy.
+
+You control which (if any) of the above are reachable by deciding whether to set the corresponding credentials.
+
+## 3. What Conexus never collects
+
+- Conexus does not query or extract data from Claude's memory, chat history, conversation summaries, or user-uploaded files.
+- Conexus does not transmit telemetry, analytics, crash reports, or usage data to the Conexus author.
+- Conexus does not include any third-party tracking, advertising, or session-recording components.
+- Conexus does not collect personally identifiable information beyond what the user explicitly writes into the indexed content or memory.
+
+## 4. Data retention
+
+- Local-mode data persists on disk until you delete it. There is no automatic purge of T2 memory (`nx memory delete`), T3 collections (`nx store delete`), or the catalog (`nx catalog gc`).
+- Cloud-mode data persists in your ChromaDB Cloud tenant under your account's retention policy.
+- T1 session scratch is wiped automatically when the host process exits.
+
+## 5. Data export and deletion
+
+- **Export** — `nx store export <collection>` produces a `.nxexp` archive of any T3 collection. `nx memory get` returns memory entries.
+- **Delete** — `nx store delete`, `nx memory delete`, `nx catalog gc`, and `nx daemon t2 uninstall --remove-data` (full T2 wipe) all remove data permanently.
+- **Uninstall** — removing Conexus and deleting `~/.config/nexus/` plus `~/.local/share/nexus/` removes everything Conexus persisted.
+
+## 6. Children's privacy
+
+Conexus is a developer tool. It is not directed to children under 13 and is not designed for use by minors.
+
+## 7. Changes to this policy
+
+Updates to this policy ship in `docs/privacy-policy.md` with each release. The version of the policy that applies to your installation is the one shipped in that installation.
+
+## 8. Contact
+
+Issues, questions, and security reports: https://github.com/Hellblazer/nexus/issues

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {
@@ -16,52 +16,161 @@
   },
   "homepage": "https://github.com/Hellblazer/nexus",
   "license": "AGPL-3.0-or-later",
-  "keywords": ["semantic-search", "knowledge-management", "rag", "claude", "claude-desktop", "mcp"],
+  "keywords": [
+    "semantic-search",
+    "knowledge-management",
+    "rag",
+    "claude",
+    "claude-desktop",
+    "mcp"
+  ],
   "server": {
     "type": "uv",
     "entry_point": "src/server.py",
     "mcp_config": {
       "command": "uv",
-      "args": ["run", "--directory", "${__dirname}", "src/server.py"]
+      "args": [
+        "run",
+        "--directory",
+        "${__dirname}",
+        "src/server.py"
+      ]
     }
   },
   "tools": [
-    {"name": "search", "description": "Semantic + keyword search across T3 knowledge collections. Returns chunks with metadata, supports topic/cluster grouping and metadata filtering."},
-    {"name": "query", "description": "Document-level semantic search for analytical questions. Groups results by source document and returns the best-matching snippet per document with full metadata."},
-    {"name": "store_put", "description": "Store content in the T3 permanent knowledge store."},
-    {"name": "store_get", "description": "Retrieve the full content of a T3 knowledge entry by document ID or title."},
-    {"name": "store_get_many", "description": "Batch-hydrate document content by ID. Supports per-id and per-stream collection routing."},
-    {"name": "store_list", "description": "List entries in a T3 knowledge collection, paged."},
-    {"name": "memory_put", "description": "Store a memory entry in T2 (per-project SQLite). Upserts by (project, title)."},
-    {"name": "memory_get", "description": "Retrieve a memory entry by project and title, or list all entries for a project."},
-    {"name": "memory_delete", "description": "Delete a T2 memory entry by project and title."},
-    {"name": "memory_search", "description": "Full-text (FTS5) search across T2 memory entries."},
-    {"name": "memory_consolidate", "description": "Memory consolidation: find overlaps, merge entries, flag stale entries."},
-    {"name": "scratch", "description": "T1 session scratch pad. Ephemeral within-session storage shared across sibling agents."},
-    {"name": "scratch_manage", "description": "Manage scratch entries: flag for persistence or promote to T2 memory."},
-    {"name": "collection_list", "description": "List all T3 collections with document counts and embedding models."},
-    {"name": "plan_save", "description": "Save a query execution plan to the T2 plan library for reuse."},
-    {"name": "plan_search", "description": "Search the T2 plan library for similar query plans."},
-    {"name": "operator_extract", "description": "Extract structured fields from each input item via claude -p."},
-    {"name": "operator_rank", "description": "Rank items by a natural-language criterion."},
-    {"name": "operator_compare", "description": "Compare items and return a structured comparison. Supports one-sided and two-sided modes."},
-    {"name": "operator_summarize", "description": "Summarize content, optionally with citations."},
-    {"name": "operator_generate", "description": "Generate output from a template and context, optionally with citations."},
-    {"name": "operator_filter", "description": "Filter items by a natural-language criterion, returning a subset with per-item rationale."},
-    {"name": "operator_check", "description": "Check a claim's consistency across peer items. Returns structured {ok, evidence} payload."},
-    {"name": "operator_verify", "description": "Verify a single claim against a single evidence source. Returns {verified, reason, citations}."},
-    {"name": "operator_groupby", "description": "Partition items by a natural-language key. Pairs with operator_aggregate."},
-    {"name": "operator_aggregate", "description": "Reduce each group of items to a per-group summary. Pairs with operator_groupby."},
-    {"name": "traverse", "description": "Walk the catalog link graph from seed tumblers. Supports explicit link_types or named purpose aliases."},
-    {"name": "nx_answer", "description": "Answer a knowledge question using plan-match-first retrieval. Multi-step composition of search/query/operator tools under a plan-match gate."},
-    {"name": "nx_tidy", "description": "Consolidate knowledge entries on a topic. Identifies duplicates and contradictions, returns a consolidated summary."},
-    {"name": "nx_enrich_beads", "description": "Enrich a bead with execution context (file paths, code patterns, constraints, test commands)."},
-    {"name": "nx_plan_audit", "description": "Audit a plan for correctness and codebase alignment before implementation begins."}
+    {
+      "name": "search",
+      "description": "Semantic + keyword search across T3 knowledge collections. Returns chunks with metadata, supports topic/cluster grouping and metadata filtering."
+    },
+    {
+      "name": "query",
+      "description": "Document-level semantic search for analytical questions. Groups results by source document and returns the best-matching snippet per document with full metadata."
+    },
+    {
+      "name": "store_put",
+      "description": "Store content in the T3 permanent knowledge store."
+    },
+    {
+      "name": "store_get",
+      "description": "Retrieve the full content of a T3 knowledge entry by document ID or title."
+    },
+    {
+      "name": "store_get_many",
+      "description": "Batch-hydrate document content by ID. Supports per-id and per-stream collection routing."
+    },
+    {
+      "name": "store_list",
+      "description": "List entries in a T3 knowledge collection, paged."
+    },
+    {
+      "name": "memory_put",
+      "description": "Store a memory entry in T2 (per-project SQLite). Upserts by (project, title)."
+    },
+    {
+      "name": "memory_get",
+      "description": "Retrieve a memory entry by project and title, or list all entries for a project."
+    },
+    {
+      "name": "memory_delete",
+      "description": "Delete a T2 memory entry by project and title."
+    },
+    {
+      "name": "memory_search",
+      "description": "Full-text (FTS5) search across T2 memory entries."
+    },
+    {
+      "name": "memory_consolidate",
+      "description": "Memory consolidation: find overlaps, merge entries, flag stale entries."
+    },
+    {
+      "name": "scratch",
+      "description": "T1 session scratch pad. Ephemeral within-session storage shared across sibling agents."
+    },
+    {
+      "name": "scratch_manage",
+      "description": "Manage scratch entries: flag for persistence or promote to T2 memory."
+    },
+    {
+      "name": "collection_list",
+      "description": "List all T3 collections with document counts and embedding models."
+    },
+    {
+      "name": "plan_save",
+      "description": "Save a query execution plan to the T2 plan library for reuse."
+    },
+    {
+      "name": "plan_search",
+      "description": "Search the T2 plan library for similar query plans."
+    },
+    {
+      "name": "operator_extract",
+      "description": "Extract structured fields from each input item via claude -p."
+    },
+    {
+      "name": "operator_rank",
+      "description": "Rank items by a natural-language criterion."
+    },
+    {
+      "name": "operator_compare",
+      "description": "Compare items and return a structured comparison. Supports one-sided and two-sided modes."
+    },
+    {
+      "name": "operator_summarize",
+      "description": "Summarize content, optionally with citations."
+    },
+    {
+      "name": "operator_generate",
+      "description": "Generate output from a template and context, optionally with citations."
+    },
+    {
+      "name": "operator_filter",
+      "description": "Filter items by a natural-language criterion, returning a subset with per-item rationale."
+    },
+    {
+      "name": "operator_check",
+      "description": "Check a claim's consistency across peer items. Returns structured {ok, evidence} payload."
+    },
+    {
+      "name": "operator_verify",
+      "description": "Verify a single claim against a single evidence source. Returns {verified, reason, citations}."
+    },
+    {
+      "name": "operator_groupby",
+      "description": "Partition items by a natural-language key. Pairs with operator_aggregate."
+    },
+    {
+      "name": "operator_aggregate",
+      "description": "Reduce each group of items to a per-group summary. Pairs with operator_groupby."
+    },
+    {
+      "name": "traverse",
+      "description": "Walk the catalog link graph from seed tumblers. Supports explicit link_types or named purpose aliases."
+    },
+    {
+      "name": "nx_answer",
+      "description": "Answer a knowledge question using plan-match-first retrieval. Multi-step composition of search/query/operator tools under a plan-match gate."
+    },
+    {
+      "name": "nx_tidy",
+      "description": "Consolidate knowledge entries on a topic. Identifies duplicates and contradictions, returns a consolidated summary."
+    },
+    {
+      "name": "nx_enrich_beads",
+      "description": "Enrich a bead with execution context (file paths, code patterns, constraints, test commands)."
+    },
+    {
+      "name": "nx_plan_audit",
+      "description": "Audit a plan for correctness and codebase alignment before implementation begins."
+    }
   ],
   "compatibility": {
-    "platforms": ["darwin", "linux"],
+    "platforms": [
+      "darwin",
+      "linux"
+    ],
     "runtimes": {
       "python": ">=3.12"
     }
-  }
+  },
+  "support": "https://github.com/Hellblazer/nexus/issues"
 }

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.0.0"
+version = "5.0.1"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.0.0",
+    "conexus>=5.0.1",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.0.0"
+version = "5.0.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,11 +1,12 @@
 {
   "name": "sn",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",
     "url": "https://github.com/Hellblazer"
   },
   "repository": "https://github.com/Hellblazer/nexus",
-  "license": "AGPL-3.0-or-later"
+  "license": "AGPL-3.0-or-later",
+  "bugs": "https://github.com/Hellblazer/nexus/issues"
 }

--- a/src/nexus/mcp/catalog.py
+++ b/src/nexus/mcp/catalog.py
@@ -28,7 +28,11 @@ _BULK_DELETE_CONFIRM_THRESHOLD = 10
 # Note: core server also registers a "search" tool. No collision — Claude Code
 # disambiguates by server prefix (mcp__plugin_conexus_nexus-catalog__search vs
 # mcp__plugin_conexus_nexus__search).
-@mcp.tool(name="search")
+@mcp.tool(
+    name="search",
+    title="Catalog Metadata Search",
+    annotations={"readOnlyHint": True},
+)
 def catalog_search(
     query: str = "",
     content_type: str = "",
@@ -128,7 +132,11 @@ def catalog_search(
         return [{"error": str(e)}]
 
 
-@mcp.tool(name="show")
+@mcp.tool(
+    name="show",
+    title="Show Catalog Entry",
+    annotations={"readOnlyHint": True},
+)
 def catalog_show(
     tumbler: str = "",
     title: str = "",
@@ -162,7 +170,11 @@ def catalog_show(
         return {"error": str(e)}
 
 
-@mcp.tool(name="list")
+@mcp.tool(
+    name="list",
+    title="List Catalog Entries",
+    annotations={"readOnlyHint": True},
+)
 def catalog_list(
     owner: str = "",
     content_type: str = "",
@@ -224,7 +236,11 @@ def catalog_list(
         return [{"error": str(e)}]
 
 
-@mcp.tool(name="register")
+@mcp.tool(
+    name="register",
+    title="Register Document in Catalog",
+    annotations={"readOnlyHint": False, "destructiveHint": False},
+)
 def catalog_register(
     title: str,
     owner: str,
@@ -281,7 +297,11 @@ def catalog_register(
         return {"error": str(e)}
 
 
-@mcp.tool(name="update")
+@mcp.tool(
+    name="update",
+    title="Update Catalog Entry",
+    annotations={"readOnlyHint": False, "destructiveHint": False},
+)
 def catalog_update(
     tumbler: str,
     title: str = "",
@@ -321,7 +341,11 @@ def catalog_update(
         return {"error": str(e)}
 
 
-@mcp.tool(name="link")
+@mcp.tool(
+    name="link",
+    title="Create Catalog Link",
+    annotations={"readOnlyHint": False, "destructiveHint": False},
+)
 def catalog_link(
     from_tumbler: str,
     to_tumbler: str,
@@ -376,7 +400,11 @@ def catalog_link(
         return {"error": str(e)}
 
 
-@mcp.tool(name="links")
+@mcp.tool(
+    name="links",
+    title="Get Document Links",
+    annotations={"readOnlyHint": True},
+)
 def catalog_links(
     tumbler: str,
     direction: str = "both",
@@ -405,7 +433,11 @@ def catalog_links(
         return {"error": str(e)}
 
 
-@mcp.tool(name="link_query")
+@mcp.tool(
+    name="link_query",
+    title="Query Link Table",
+    annotations={"readOnlyHint": True},
+)
 def catalog_link_query(
     from_tumbler: str = "",
     to_tumbler: str = "",
@@ -448,7 +480,11 @@ def catalog_link_query(
         return [{"error": str(e)}]
 
 
-@mcp.tool(name="resolve")
+@mcp.tool(
+    name="resolve",
+    title="Resolve Identifier to Entry",
+    annotations={"readOnlyHint": True},
+)
 def catalog_resolve(
     tumbler: str = "",
     owner: str = "",
@@ -502,7 +538,11 @@ def catalog_resolve(
         return [f"Error: {e}"]
 
 
-@mcp.tool(name="stats")
+@mcp.tool(
+    name="stats",
+    title="Catalog Statistics",
+    annotations={"readOnlyHint": True},
+)
 def catalog_stats() -> dict:
     """Catalog health summary: owner/document/link counts by type."""
     cat, err = _require_catalog()

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -442,7 +442,10 @@ def _record_tier_write(
 # Note: catalog server also registers a "search" tool. No collision — Claude Code
 # disambiguates by server prefix (mcp__plugin_conexus_nexus__search vs
 # mcp__plugin_conexus_nexus-catalog__search).
-@mcp.tool()
+@mcp.tool(
+    title="Semantic Search",
+    annotations={"readOnlyHint": True},
+)
 def search(
     query: str,
     corpus: str = "knowledge,code,docs",
@@ -639,7 +642,10 @@ def search(
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Catalog-Aware Document Query",
+    annotations={"readOnlyHint": True},
+)
 def query(
     question: str,
     corpus: str = "knowledge",
@@ -970,7 +976,10 @@ def query(
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Store Knowledge Document",
+    annotations={"readOnlyHint": False, "destructiveHint": False},
+)
 def store_put(
     content: str,
     collection: str = "knowledge",
@@ -1112,7 +1121,10 @@ def store_put(
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Retrieve Knowledge Document",
+    annotations={"readOnlyHint": True},
+)
 def store_get(doc_id: str, collection: str = "knowledge") -> str:
     """Retrieve the full content and metadata of a T3 knowledge entry by document ID or title.
 
@@ -1165,7 +1177,10 @@ def store_get(doc_id: str, collection: str = "knowledge") -> str:
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Batch-Retrieve Documents",
+    annotations={"readOnlyHint": True},
+)
 def store_get_many(
     ids: str | list,
     collections: str | list = "knowledge",
@@ -1344,7 +1359,10 @@ def store_get_many(
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List Collection Documents",
+    annotations={"readOnlyHint": True},
+)
 def store_list(
     collection: str = "knowledge",
     limit: int = 20,
@@ -1452,7 +1470,10 @@ def _store_list_docs(t3, col_name: str, total: int) -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Store Memory Entry",
+    annotations={"readOnlyHint": False, "destructiveHint": False},
+)
 def memory_put(
     content: str,
     project: str,
@@ -1514,7 +1535,10 @@ def memory_put(
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Retrieve Memory Entry",
+    annotations={"readOnlyHint": True},
+)
 def memory_get(project: str, title: str = "") -> str:
     """Retrieve a memory entry by project and title.
 
@@ -1571,7 +1595,10 @@ def memory_get(project: str, title: str = "") -> str:
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Delete Memory Entry",
+    annotations={"readOnlyHint": False, "destructiveHint": True},
+)
 def memory_delete(project: str, title: str) -> str:
     """Delete a T2 memory entry by project and title.
 
@@ -1591,7 +1618,10 @@ def memory_delete(project: str, title: str) -> str:
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Search Memory Entries",
+    annotations={"readOnlyHint": True},
+)
 def memory_search(query: str, project: str = "", limit: int = 20, offset: int = 0) -> str:
     """Full-text search across T2 memory entries.
 
@@ -1627,7 +1657,10 @@ def memory_search(query: str, project: str = "", limit: int = 20, offset: int = 
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Consolidate Memory Entries",
+    annotations={"readOnlyHint": False, "destructiveHint": True},
+)
 def memory_consolidate(
     action: str,
     project: str,
@@ -1729,7 +1762,10 @@ def memory_consolidate(
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Session Scratch Pad",
+    annotations={"readOnlyHint": False, "destructiveHint": False},
+)
 def scratch(
     action: str,
     content: str = "",
@@ -1844,7 +1880,10 @@ def scratch(
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Manage Scratch Entry",
+    annotations={"readOnlyHint": False, "destructiveHint": False},
+)
 def scratch_manage(
     action: str,
     entry_id: str,
@@ -1880,7 +1919,10 @@ def scratch_manage(
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List T3 Collections",
+    annotations={"readOnlyHint": True},
+)
 def collection_list() -> str:
     """List all T3 collections with document counts and embedding models."""
     try:
@@ -1896,7 +1938,10 @@ def collection_list() -> str:
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Save Query Plan",
+    annotations={"readOnlyHint": False, "destructiveHint": False},
+)
 def plan_save(
     query: str,
     plan_json: str,
@@ -1945,7 +1990,10 @@ def plan_save(
         return f"Error: {e}"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Search Plan Library",
+    annotations={"readOnlyHint": True},
+)
 def plan_search(query: str, project: str = "", limit: int = 5, offset: int = 0) -> str:
     """Search the T2 plan library for similar query plans.
 
@@ -2079,7 +2127,10 @@ def collection_verify(name: str) -> str:
 # ── Operator tools ───────────────────────────────────────────────────────────
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Extract Structured Fields",
+    annotations={"readOnlyHint": True},
+)
 async def operator_extract(inputs: str, fields: str, timeout: float = 300.0) -> dict:
     """Extract structured fields from each input item using claude -p.
 
@@ -2107,7 +2158,10 @@ async def operator_extract(inputs: str, fields: str, timeout: float = 300.0) -> 
     return await claude_dispatch(prompt, schema, timeout=timeout)
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Rank Items by Criterion",
+    annotations={"readOnlyHint": True},
+)
 async def operator_rank(items: str, criterion: str, timeout: float = 300.0) -> dict:
     """Rank items by a criterion using claude -p.
 
@@ -2133,7 +2187,10 @@ async def operator_rank(items: str, criterion: str, timeout: float = 300.0) -> d
     return await claude_dispatch(prompt, schema, timeout=timeout)
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Compare Items",
+    annotations={"readOnlyHint": True},
+)
 async def operator_compare(
     items: str = "",
     focus: str = "",
@@ -2219,7 +2276,10 @@ async def operator_compare(
     return await claude_dispatch(prompt, schema, timeout=timeout)
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Summarize Content",
+    annotations={"readOnlyHint": True},
+)
 async def operator_summarize(
     content: str,
     cited: bool = False,
@@ -2247,7 +2307,10 @@ async def operator_summarize(
     return await claude_dispatch(prompt, schema, timeout=timeout)
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Generate from Template",
+    annotations={"readOnlyHint": True},
+)
 async def operator_generate(
     template: str,
     context: str,
@@ -2298,7 +2361,10 @@ _CHECK_EVIDENCE_ITEM_SCHEMA: dict = {
 }
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Filter Items by Criterion",
+    annotations={"readOnlyHint": True},
+)
 async def operator_filter(
     items: str,
     criterion: str,
@@ -2393,7 +2459,10 @@ async def operator_filter(
     return await claude_dispatch(prompt, schema, timeout=timeout)
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Check Cross-Item Consistency",
+    annotations={"readOnlyHint": True},
+)
 async def operator_check(
     items: str,
     check_instruction: str,
@@ -2447,7 +2516,10 @@ async def operator_check(
     return await claude_dispatch(prompt, schema, timeout=timeout)
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Verify Claim Against Evidence",
+    annotations={"readOnlyHint": True},
+)
 async def operator_verify(
     claim: str,
     evidence: str,
@@ -2499,7 +2571,10 @@ async def operator_verify(
     return await claude_dispatch(prompt, schema, timeout=timeout)
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Group Items by Key",
+    annotations={"readOnlyHint": True},
+)
 async def operator_groupby(
     items: str,
     key: str,
@@ -2608,7 +2683,10 @@ async def operator_groupby(
     return await claude_dispatch(prompt, schema, timeout=timeout)
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Aggregate Grouped Items",
+    annotations={"readOnlyHint": True},
+)
 async def operator_aggregate(
     groups: str,
     reducer: str,
@@ -2706,7 +2784,10 @@ async def operator_aggregate(
 _TRAVERSE_MAX_DEPTH: int = 3
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Walk Catalog Link Graph",
+    annotations={"readOnlyHint": True},
+)
 def traverse(
     seeds: list[str] | str,
     link_types: list[str] | None = None,
@@ -3338,7 +3419,10 @@ def _load_ad_hoc_ttl() -> int:
 # ── RDR-080 orchestration tools ───────────────────────────────────────────────
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Multi-Step Knowledge Answer",
+    annotations={"readOnlyHint": False, "destructiveHint": False},
+)
 async def nx_answer(
     question: str,
     scope: str = "",
@@ -3840,7 +3924,10 @@ async def nx_answer(
     )
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Consolidate Knowledge Topic",
+    annotations={"readOnlyHint": False, "destructiveHint": True},
+)
 async def nx_tidy(
     topic: str,
     collection: str = "knowledge",
@@ -3893,7 +3980,10 @@ async def nx_tidy(
     return "\n".join(lines)
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Enrich Bead Context",
+    annotations={"readOnlyHint": False, "destructiveHint": False},
+)
 async def nx_enrich_beads(
     bead_description: str,
     context: str = "",
@@ -3952,7 +4042,10 @@ async def nx_enrich_beads(
     )
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Audit Plan Correctness",
+    annotations={"readOnlyHint": True},
+)
 async def nx_plan_audit(
     plan_json: str,
     context: str = "",

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.0.0"
+version = "5.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Hotfix v5.0.0 + Connector Directory submission prereqs. AI prepared; human cuts.

## The bug that motivated this release

v5.0.0's release workflow failed at the PyPI publish step. `mcpb pack` moved `conexus.mcpb` into `dist/` next to the wheel and sdist; twine rejected the unknown distribution format. The PyPI upload never ran, no GitHub Release was created.

**State**: v5.0.0 git tag exists; PyPI artifact never landed. v5.0.1 is the first actually-published 5.x release.

## What v5.0.1 contains

- **Workflow fix** — pack `.mcpb` into `mcpb-dist/` so `dist/` stays PyPI-pure
- **MCP tool annotations** (PR #942) — 41 tools carry `title` + `readOnlyHint` + (where applicable) `destructiveHint`; Connector Directory prereq
- **Privacy policy** (`docs/privacy-policy.md`) — Connector Directory prereq
- **Support channel URLs** — `bugs` field in plugin.json files, `support` field in mcpb/manifest.json
- **Version bumps** — all seven version-bearing files + uv.lock + marketplace.json source.ref → v5.0.1

## Connector Directory readiness after this lands

Remaining gaps (not in this PR; human/design work):

- Logo + favicon (deferred; can ship submission with a wordmark or cropped existing image)
- Blog post-7 publish on tensegrity.blog (your action; content drafted)
- Submitting the form at https://clau.de/desktop-extention-submission (your action; form draft ready at `/tmp/conexus-directory-submission.md`)

## Human cuts the release

After CI green and your merge:

```
git checkout main && git pull
git tag -a v5.0.1 -m "conexus 5.0.1" $(git rev-parse HEAD)
git push origin v5.0.1
```

This time the workflow will publish to PyPI and create the GitHub Release with the `.mcpb` attached.