### PR TITLE
fix(drift): plugin-name hint points at /reload-plugins, not uninstall+install

### DIFF
--- a/docs/desktop-deployment.md
+++ b/docs/desktop-deployment.md
@@ -60,9 +60,10 @@ After upgrading conexus (`uv tool upgrade conexus`) or after the plugin rename (
 - **Plugin name drift**: the installed Claude Code plugin still has `name: "nx"` but the CLI expects `conexus`. Fix:
 
   ```
-  /plugin uninstall nx@nexus-plugins      # in Claude Code
-  /plugin install conexus@nexus-plugins   # in Claude Code
+  /reload-plugins      # in Claude Code
   ```
+
+  Claude Code re-reads the marketplace and swaps the installed plugin in place. No explicit uninstall + install needed.
 
 - **Post-commit hook stanza drift**: the installed `.git/hooks/post-commit` predates the pgrep guard fix (nexus-mkj6u 2026-05-23). Fix:
 

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -866,14 +866,14 @@ def _check_plugin_name() -> list[HealthResult]:
     differs from what the CLI expects.
 
     The 2026-05-23 rename moved the plugin name from ``nx`` to
-    ``conexus``. Claude Code does NOT auto-uninstall renamed plugins;
-    a user's local cache at
-    ``~/.claude/plugins/cache/nexus-plugins/nx/...`` survives the
-    marketplace.json rename. Until they explicitly uninstall +
-    reinstall, they run the NEW conexus CLI under the OLD ``nx``
-    plugin. The MCP-server-startup check fires once per session;
-    this doctor check is the explicit-invocation surface for users
-    who run ``nx doctor`` to diagnose what's stale.
+    ``conexus``. Until the user runs ``/reload-plugins`` in Claude
+    Code (which re-reads marketplace.json and reconciles the rename
+    in place), they may continue running the NEW conexus CLI under
+    the OLD ``nx`` plugin install at
+    ``~/.claude/plugins/cache/nexus-plugins/nx/...``. The MCP-server-
+    startup check fires once per session; this doctor check is the
+    explicit-invocation surface for users who run ``nx doctor`` to
+    diagnose what's stale.
 
     Non-fatal. Returns an empty list when no ``CLAUDE_PLUGIN_ROOT``
     is set (CLI-only use; nothing to check) or when the plugin name
@@ -907,9 +907,8 @@ def _check_plugin_name() -> list[HealthResult]:
                 "(renamed 2026-05-23, nexus-mkj6u)"
             ),
             fix_suggestions=[
-                f"/plugin uninstall {plugin_name}@nexus-plugins",
-                f"/plugin install {EXPECTED_PLUGIN_NAME}@nexus-plugins",
-                "(both commands run in Claude Code, not from the shell)",
+                "/reload-plugins",
+                "(run in Claude Code; the marketplace reconciles the rename in place — no uninstall + install needed)",
             ],
             fatal=False,
         )

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -671,13 +671,13 @@ def check_version_compatibility() -> None:
 
             # ── (3) Plugin NAME drift (nexus-mkj6u) ─────────────────────
             # The 2026-05-23 rename moved the plugin name from ``nx`` to
-            # ``conexus``. Claude Code does NOT auto-uninstall renamed
-            # plugins; the user's local cache at
-            # ``~/.claude/plugins/cache/nexus-plugins/nx/...`` survives
-            # the marketplace.json rename until the user explicitly
-            # uninstalls + reinstalls. Until then, they're running the
-            # NEW conexus CLI but the OLD nx plugin — silently sliding
-            # toward whatever drift the rename introduced.
+            # ``conexus``. Running ``/reload-plugins`` in Claude Code
+            # picks up the marketplace.json change and reconciles the
+            # rename in place — no explicit uninstall + install needed.
+            # Until the user reloads, the local cache at
+            # ``~/.claude/plugins/cache/nexus-plugins/nx/...`` continues
+            # to back the OLD nx plugin name; the user is running the
+            # NEW conexus CLI under that stale install.
             #
             # Fire this warning EVERY MCP startup until resolved. It is
             # the most reliable surface to catch the gap because every
@@ -690,9 +690,7 @@ def check_version_compatibility() -> None:
                     hint=(
                         f"Plugin was renamed '{plugin_name}' -> "
                         f"'{EXPECTED_PLUGIN_NAME}' (nexus-mkj6u). In "
-                        f"Claude Code, run: /plugin uninstall "
-                        f"{plugin_name}@nexus-plugins && /plugin install "
-                        f"{EXPECTED_PLUGIN_NAME}@nexus-plugins"
+                        f"Claude Code, run: /reload-plugins"
                     ),
                 )
 

--- a/tests/e2e/upgrade-shakeout.sh
+++ b/tests/e2e/upgrade-shakeout.sh
@@ -220,11 +220,9 @@ PJEOF
 DOCTOR_OUT="$(CLAUDE_PLUGIN_ROOT="$FAKE_PLUGIN_ROOT" HOME="$SANDBOX" nx doctor 2>&1 || true)"
 echo "$DOCTOR_OUT" | grep -qi 'plugin name' \
     || _die "nx doctor did not surface plugin-name drift. Output:\n$DOCTOR_OUT"
-echo "$DOCTOR_OUT" | grep -q '/plugin uninstall nx@nexus-plugins' \
-    || _die "doctor warning missing uninstall command"
-echo "$DOCTOR_OUT" | grep -q '/plugin install conexus@nexus-plugins' \
-    || _die "doctor warning missing install command"
-_pass "nx doctor names the uninstall + install commands"
+echo "$DOCTOR_OUT" | grep -q '/reload-plugins' \
+    || _die "doctor warning missing /reload-plugins hint"
+_pass "nx doctor names the /reload-plugins migration command"
 # (The structlog warning at every MCP startup is covered by unit test
 # tests/test_plugin_name_drift.py::test_check_version_compatibility_logs_plugin_name_mismatch
 # — easier to assert there than to spawn nx-mcp + watch stderr here.)

--- a/tests/test_plugin_name_drift.py
+++ b/tests/test_plugin_name_drift.py
@@ -40,7 +40,7 @@ def _plant_plugin_manifest(tmp_path: Path, name: str, version: str = "4.34.5") -
 
 def test_check_plugin_name_warns_on_old_nx(monkeypatch, tmp_path):
     """An installed ``nx`` plugin against the conexus-expecting CLI fires
-    a non-fatal warning naming the uninstall/install commands."""
+    a non-fatal warning telling the user to run /reload-plugins."""
     plugin_root = _plant_plugin_manifest(tmp_path, name="nx")
     monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
 
@@ -53,8 +53,7 @@ def test_check_plugin_name_warns_on_old_nx(monkeypatch, tmp_path):
     assert r.fatal is False
     assert "nx@nexus-plugins" in r.detail or "renamed" in r.detail
     suggestions = " ".join(r.fix_suggestions)
-    assert "/plugin uninstall nx@nexus-plugins" in suggestions
-    assert "/plugin install conexus@nexus-plugins" in suggestions
+    assert "/reload-plugins" in suggestions
 
 
 def test_check_plugin_name_silent_when_conexus_installed(monkeypatch, tmp_path):
@@ -109,8 +108,7 @@ def test_check_version_compatibility_logs_plugin_name_mismatch(monkeypatch, tmp_
         f"expected plugin_name_mismatch warning in stdout/stderr; got: {captured!r}"
     )
     # Actionable hint surfaces
-    assert "/plugin uninstall nx@nexus-plugins" in captured
-    assert "/plugin install conexus@nexus-plugins" in captured
+    assert "/reload-plugins" in captured
 
 
 def test_check_version_compatibility_silent_when_name_matches(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary

The 2026-05-23 plugin rename (`nx` → `conexus`) shipped drift-detection in `nx doctor` and `nx-mcp` startup. Both surfaces told the user to run `/plugin uninstall nx@nexus-plugins && /plugin install conexus@nexus-plugins`. The actual migration is one command: `/reload-plugins`. Claude Code re-reads `marketplace.json` and reconciles the rename in place without any explicit uninstall.

Verified empirically: I ran `/reload-plugins` in Claude Code and the installed plugin auto-swapped from `nx` to `conexus` silently. No prompt, no uninstall, no reinstall.

## Changed

- `src/nexus/health.py` — `_check_plugin_name` `fix_suggestions` updated to a single `/reload-plugins` entry plus a one-line explanation. Comment block updated to match the actual Claude Code semantics.
- `src/nexus/mcp_infra.py` — `plugin_name_mismatch` structlog warning hint updated. Comment block updated.
- `tests/test_plugin_name_drift.py` — two assertions updated for the new hint text. All 6 tests in the file pass (verified locally).
- `tests/e2e/upgrade-shakeout.sh` — doctor-output assertion checks for `/reload-plugins` instead of the old uninstall/install commands.
- `docs/desktop-deployment.md` — drift-detection prose matches the new code hint.

## Out of scope

Not changed: CHANGELOG entries that describe the historical fallback migration path are intentionally left alone — they describe what to do if the lightweight path doesn't work on a given Claude Code version, not what to default to. The blog post-7 (which is gitignored) was updated locally and will be published with the corrected migration command.

## Ships in

v5.0.2 (no rush — current v5.0.1 hint isn't wrong, just overspecified).