### PR TITLE
feat(mcpb): warn at startup when installed conexus is stale vs PyPI

### DIFF
--- a/mcpb/src/server.py
+++ b/mcpb/src/server.py
@@ -1,13 +1,88 @@
 #!/usr/bin/env python3
-"""Nexus MCP server entry point for the Claude Desktop .mcpb spike.
+"""Nexus MCP server entry point for the Claude Desktop .mcpb extension.
 
-RDR-126 P1. Imports and runs ``nexus.mcp.core:main``, the same entry
-point the Claude Code plugin invokes via the ``nx-mcp`` console script.
+Imports and runs ``nexus.mcp.core:main``, the same entry point the
+Claude Code plugin invokes via the ``nx-mcp`` console script. Before
+handing off, performs a best-effort stale-install check: if the
+locally installed ``conexus`` package is older than the latest on
+PyPI, emit a one-line warning to stderr naming the GitHub release URL
+to re-download.
+
+The check is intentionally non-fatal — network failures, timeouts,
+or PyPI being unreachable do not block server startup. Opt out
+entirely by setting ``NX_MCPB_SKIP_UPDATE_CHECK=1`` in the
+environment.
 """
 from __future__ import annotations
 
+import os
+import sys
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+_RELEASE_URL = "https://github.com/Hellblazer/nexus/releases/latest"
+_PYPI_URL = "https://pypi.org/pypi/conexus/json"
+_TIMEOUT_SECONDS = 3.0
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Cheap PEP 440 numeric prefix extract: '5.0.1.dev0' -> (5, 0, 1)."""
+    parts: list[int] = []
+    for chunk in v.split("."):
+        digits = ""
+        for c in chunk:
+            if c.isdigit():
+                digits += c
+            else:
+                break
+        if not digits:
+            break
+        parts.append(int(digits))
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts[:3])
+
+
+def _check_stale_install() -> None:
+    """Best-effort: warn to stderr if conexus is behind PyPI's latest.
+
+    Silent on network failure, timeout, missing package metadata, or
+    when the installed version is current. Costs one ~3s HTTPS GET.
+    """
+    if os.environ.get("NX_MCPB_SKIP_UPDATE_CHECK"):
+        return
+
+    try:
+        installed = _pkg_version("conexus")
+    except PackageNotFoundError:
+        return  # editable / unusual install layout; skip silently
+
+    try:
+        import json
+        import urllib.error
+        import urllib.request
+
+        req = urllib.request.Request(
+            _PYPI_URL,
+            headers={"User-Agent": f"conexus-mcpb/{installed}"},
+        )
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:
+            latest = json.loads(resp.read().decode("utf-8"))["info"]["version"]
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, KeyError, TimeoutError):
+        return  # offline / PyPI hiccup; skip silently
+
+    if _parse_version(installed) >= _parse_version(latest):
+        return  # current or ahead (dev install); no warning
+
+    msg = (
+        f"[conexus-mcpb] installed conexus={installed}, latest on PyPI={latest}. "
+        f"Re-download the .mcpb from {_RELEASE_URL} and re-install in Claude "
+        "Desktop to upgrade. (Set NX_MCPB_SKIP_UPDATE_CHECK=1 to silence.)"
+    )
+    print(msg, file=sys.stderr, flush=True)
+
 
 def main() -> None:
+    _check_stale_install()
     from nexus.mcp.core import main as _nx_mcp_main
     _nx_mcp_main()
 


### PR DESCRIPTION
## Summary

MCPB v0.4 has no auto-update mechanism — the `.mcpb` is a static bundle, Claude Desktop doesn't poll for new versions, and users can drift indefinitely on stale installs. Add a best-effort startup version check so the staleness is no longer silent.

## What it does

At MCP server startup (`mcpb/src/server.py:main()`), before handing off to `nexus.mcp.core:main`, compare the locally installed `conexus` package version against the latest version on PyPI's JSON API. If the local version is behind, print a one-line stderr warning naming the GitHub release URL to re-download.

```
[conexus-mcpb] installed conexus=4.34.5, latest on PyPI=5.0.1. Re-download
the .mcpb from https://github.com/Hellblazer/nexus/releases/latest and
re-install in Claude Desktop to upgrade. (Set NX_MCPB_SKIP_UPDATE_CHECK=1
to silence.)
```

The stderr stream is captured by Claude Desktop's MCP log surface.

## Non-fatal by construction

- 3-second HTTPS GET timeout
- Silent on `URLError` / `OSError` / `TimeoutError` / `JSONDecodeError` / `PackageNotFoundError`
- Silent when installed ≥ latest (covers dev installs ahead of PyPI)
- Opt out entirely via `NX_MCPB_SKIP_UPDATE_CHECK=1`

Worst case: ~3s added to server startup if PyPI is unreachable. Server startup is otherwise blocked on uv resolution (~20s cold, ~5s warm), so the check fits comfortably inside that envelope.

## Doesn't force upgrades

Still manual: user re-downloads `conexus.mcpb` from the GitHub release and double-clicks. But staleness now surfaces actively instead of silently. Acceptable until Anthropic's Connector Directory gains its own "update available" UI.

## Smoke-tested locally

- Import works
- Version parsing covers `5.0.1`, `5.0.1.dev0`, `5.0`, `5.1.0` cases
- Stale scenario emits the expected warning text
- `NX_MCPB_SKIP_UPDATE_CHECK=1` opt-out works
- Exception paths verified by inspection (no actual network failure exercised in this smoke)

## Ships in

v5.0.2.