### PR TITLE
fix(t2): aspect_queue reclaim_stale tolerance under WAL contention (nexus-v4m7y)

### DIFF
--- a/src/nexus/db/t2/aspect_extraction_queue.py
+++ b/src/nexus/db/t2/aspect_extraction_queue.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 
 import sqlite3
 import threading
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -150,7 +151,15 @@ class AspectExtractionQueue:
     def __init__(self, path: Path) -> None:
         self._lock = threading.Lock()
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
-        self.conn.execute("PRAGMA busy_timeout=5000")
+        # nexus-v4m7y: bumped from 5s to 30s. Nine T2 stores hold their own
+        # sqlite3.Connection against memory.db. Under WAL mode, only one
+        # writer is allowed across all connections; busy_timeout governs
+        # how long this connection waits before raising ERROR_BUSY. 5s was
+        # tight enough that a long memory_put (or any other store's write)
+        # could push reclaim_stale past the limit and surface "database is
+        # locked" warnings. 30s costs nothing on quiet systems and absorbs
+        # the realistic intra-daemon contention window.
+        self.conn.execute("PRAGMA busy_timeout=30000")
         self._init_schema()
 
     def close(self) -> None:
@@ -433,6 +442,17 @@ class AspectExtractionQueue:
             )
             self.conn.commit()
 
+    # nexus-v4m7y: retry-with-backoff for reclaim_stale. Three attempts
+    # with two inter-attempt sleeps (0.1s, 0.5s) on top of the 30s
+    # per-attempt SQLite busy_timeout. Absorbs transient writer-slot
+    # contention that would otherwise leak as ERROR_BUSY.
+    # Total worst-case wait if every attempt hits a locked writer:
+    # 30 + 0.1 + 30 + 0.5 + 30 = ~90.6 s. Acceptable for a background
+    # reclaim that runs every N polls. The final attempt still raises
+    # if it cannot acquire, so the existing aspect_worker_claim_failed
+    # warning surfaces in the truly-stuck case.
+    _RECLAIM_RETRY_SLEEPS_BETWEEN: tuple[float, ...] = (0.1, 0.5)
+
     def reclaim_stale(self, timeout_seconds: int = 300) -> int:
         """Reset ``in_progress`` rows whose ``last_attempt_at`` is older
         than the timeout back to ``pending``.
@@ -444,6 +464,10 @@ class AspectExtractionQueue:
 
         Returns the number of rows reclaimed.
 
+        Retries up to 3 attempts on ``database is locked`` to absorb
+        transient WAL writer-slot contention with other T2 stores in
+        the same daemon process. See ``_RECLAIM_RETRY_BACKOFF_SECONDS``.
+
         ``last_attempt_at`` is wrapped in ``datetime()`` to normalize
         the comparison: production writes ISO 8601 with ``T`` separator
         and ``+00:00`` suffix (``datetime.now(UTC).isoformat()``), while
@@ -453,15 +477,44 @@ class AspectExtractionQueue:
         regardless of staleness.
         """
         cutoff_clause = f"datetime('now', '-{int(timeout_seconds)} seconds')"
-        with self._lock:
-            cur = self.conn.execute(
-                "UPDATE aspect_extraction_queue "
-                "SET status = 'pending', last_attempt_at = NULL "
-                "WHERE status = 'in_progress' "
-                f"  AND datetime(last_attempt_at) < {cutoff_clause}",
-            )
-            self.conn.commit()
-            return cur.rowcount
+        sleeps_between = self._RECLAIM_RETRY_SLEEPS_BETWEEN
+        max_attempts = len(sleeps_between) + 1
+        for attempt in range(1, max_attempts + 1):
+            try:
+                with self._lock:
+                    cur = self.conn.execute(
+                        "UPDATE aspect_extraction_queue "
+                        "SET status = 'pending', last_attempt_at = NULL "
+                        "WHERE status = 'in_progress' "
+                        f"  AND datetime(last_attempt_at) < {cutoff_clause}",
+                    )
+                    self.conn.commit()
+                    if attempt > 1:
+                        _log.debug(
+                            "aspect_queue_reclaim_stale_recovered",
+                            attempt=attempt,
+                            rowcount=cur.rowcount,
+                        )
+                    return cur.rowcount
+            except sqlite3.OperationalError as exc:
+                # Only retry on writer-slot contention. Anything else
+                # (schema corruption, FK violation, etc.) propagates
+                # immediately.
+                if "locked" not in str(exc).lower():
+                    raise
+                if attempt == max_attempts:
+                    raise
+                sleep_seconds = sleeps_between[attempt - 1]
+                _log.debug(
+                    "aspect_queue_reclaim_stale_retry",
+                    attempt=attempt,
+                    next_sleep_seconds=sleep_seconds,
+                    exc=str(exc),
+                )
+                time.sleep(sleep_seconds)
+        raise RuntimeError(  # pragma: no cover
+            "reclaim_stale exhausted retries unexpectedly"
+        )
 
     def pending_count(self) -> int:
         """Return the number of rows currently in ``pending`` status."""

--- a/tests/test_aspect_extraction_queue.py
+++ b/tests/test_aspect_extraction_queue.py
@@ -424,6 +424,157 @@ class TestReclaimStale:
         assert row[0] == "pending"
         assert row[1] is None
 
+    def test_reclaim_stale_busy_timeout_is_30s(self, tmp_path: Path) -> None:
+        """nexus-v4m7y: busy_timeout was bumped from 5s to 30s so the
+        connection waits longer for the WAL writer slot before raising
+        ERROR_BUSY. Nine T2 stores hold their own sqlite3.Connection
+        against memory.db; 5s was tight under intra-daemon contention.
+        """
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        try:
+            row = store.conn.execute("PRAGMA busy_timeout").fetchone()
+        finally:
+            store.close()
+        assert row[0] == 30000, (
+            f"busy_timeout should be 30000 ms (was 5000); got {row[0]}"
+        )
+
+    def test_reclaim_stale_retries_on_locked_then_succeeds(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """nexus-v4m7y: on top of the 30s SQLite busy_timeout, reclaim_stale
+        retries up to 3 attempts on ``database is locked``. Simulates two
+        transient locks via a connection proxy, then verifies the third
+        attempt succeeds and returns the expected rowcount."""
+        import sqlite3
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        # Shorten the retry sleeps so the test doesn't take ~0.6s real time.
+        monkeypatch.setattr(
+            AspectExtractionQueue,
+            "_RECLAIM_RETRY_SLEEPS_BETWEEN",
+            (0.0, 0.0),
+        )
+
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        try:
+            store.enqueue("knowledge__delos", "/p1.pdf")
+            store.claim_next()
+            store.conn.execute(
+                "UPDATE aspect_extraction_queue "
+                "SET last_attempt_at = datetime('now', '-10 minutes')"
+            )
+            store.conn.commit()
+
+            real_conn = store.conn
+            calls = {"n": 0}
+
+            class FlakyConn:
+                def execute(self, sql, *args, **kwargs):  # noqa: ANN001
+                    if sql.lstrip().upper().startswith("UPDATE ASPECT_EXTRACTION_QUEUE"):
+                        calls["n"] += 1
+                        if calls["n"] <= 2:
+                            raise sqlite3.OperationalError("database is locked")
+                    return real_conn.execute(sql, *args, **kwargs)
+
+                def commit(self):
+                    return real_conn.commit()
+
+                def __getattr__(self, name):
+                    return getattr(real_conn, name)
+
+            store.conn = FlakyConn()  # type: ignore[assignment]
+            reclaimed = store.reclaim_stale(timeout_seconds=60)
+            store.conn = real_conn  # type: ignore[assignment]
+        finally:
+            store.close()
+        assert calls["n"] == 3, (
+            f"expected 3 UPDATE attempts (2 simulated locks + 1 success); "
+            f"got {calls['n']}"
+        )
+        assert reclaimed == 1, (
+            f"third attempt should reclaim the stale row; got {reclaimed}"
+        )
+
+    def test_reclaim_stale_raises_after_exhausted_retries(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """nexus-v4m7y: when every retry still hits ``database is locked``,
+        the final attempt re-raises so the existing aspect_worker
+        warning surfaces in the truly-stuck case."""
+        import sqlite3
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        monkeypatch.setattr(
+            AspectExtractionQueue,
+            "_RECLAIM_RETRY_SLEEPS_BETWEEN",
+            (0.0, 0.0),
+        )
+
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        try:
+            real_conn = store.conn
+
+            class AlwaysLockedConn:
+                def execute(self, sql, *args, **kwargs):  # noqa: ANN001
+                    if sql.lstrip().upper().startswith("UPDATE ASPECT_EXTRACTION_QUEUE"):
+                        raise sqlite3.OperationalError("database is locked")
+                    return real_conn.execute(sql, *args, **kwargs)
+
+                def commit(self):
+                    return real_conn.commit()
+
+                def __getattr__(self, name):
+                    return getattr(real_conn, name)
+
+            store.conn = AlwaysLockedConn()  # type: ignore[assignment]
+            import pytest as _pytest
+            with _pytest.raises(sqlite3.OperationalError, match="locked"):
+                store.reclaim_stale(timeout_seconds=60)
+            store.conn = real_conn  # type: ignore[assignment]
+        finally:
+            store.close()
+
+    def test_reclaim_stale_propagates_non_lock_operational_errors(
+        self, tmp_path: Path,
+    ) -> None:
+        """nexus-v4m7y: only "database is locked" is retried. Other
+        OperationalErrors (schema corruption, syntax, etc.) propagate
+        immediately on the first attempt — we never retry around them."""
+        import sqlite3
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        try:
+            real_conn = store.conn
+            calls = {"n": 0}
+
+            class SyntaxErrConn:
+                def execute(self, sql, *args, **kwargs):  # noqa: ANN001
+                    if sql.lstrip().upper().startswith("UPDATE ASPECT_EXTRACTION_QUEUE"):
+                        calls["n"] += 1
+                        raise sqlite3.OperationalError("syntax error near 'oops'")
+                    return real_conn.execute(sql, *args, **kwargs)
+
+                def commit(self):
+                    return real_conn.commit()
+
+                def __getattr__(self, name):
+                    return getattr(real_conn, name)
+
+            store.conn = SyntaxErrConn()  # type: ignore[assignment]
+            import pytest as _pytest
+            with _pytest.raises(sqlite3.OperationalError, match="syntax"):
+                store.reclaim_stale(timeout_seconds=60)
+            store.conn = real_conn  # type: ignore[assignment]
+        finally:
+            store.close()
+        assert calls["n"] == 1, (
+            f"non-lock errors should not retry; expected 1 attempt, got {calls['n']}"
+        )
+
 
 # ── Pending count + listing ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes nexus-v4m7y. The `aspect_worker_claim_failed` warnings flagged in v5.0.1 shake-out trace to SQLite WAL writer-slot contention inside the T2 daemon: nine T2 stores each hold their own `sqlite3.Connection`, but WAL allows only one writer across all connections. When another store holds the slot for longer than the 5s `busy_timeout`, `reclaim_stale`'s UPDATE returns ERROR_BUSY.

Ships fixes **(a)** and **(c)** from the bead. **(b)** (shared per-daemon writer connection) is deferred to a v5.1.x architecture pass.

## (a) Bump `busy_timeout` from 5s to 30s

`AspectExtractionQueue.__init__` now sets `PRAGMA busy_timeout=30000`. Covers the realistic intra-daemon contention window. Costs nothing on quiet systems; absorbs the windows where a `memory_put` or other store holds the writer for several seconds.

## (c) Retry-with-backoff in `reclaim_stale`

Wraps the UPDATE in a 3-attempt loop:

```
attempt 1 → sleep 0.1s → attempt 2 → sleep 0.5s → attempt 3 → raise
```

Only `database is locked` triggers retry; other `OperationalError`s (schema, syntax, FK violations) propagate immediately on the first attempt. The final attempt still raises so the existing `aspect_worker_claim_failed` warning surfaces in the truly-stuck case.

Worst-case wait if every attempt hits a locked writer: 30 + 0.1 + 30 + 0.5 + 30 = ~90.6 s. Acceptable for a background reclaim that runs every N polls.

## Tests

Four new tests in `TestReclaimStale`:

- `test_reclaim_stale_busy_timeout_is_30s` — verifies PRAGMA bump
- `test_reclaim_stale_retries_on_locked_then_succeeds` — 2 simulated locks + 1 success; verifies 3 attempts and correct rowcount
- `test_reclaim_stale_raises_after_exhausted_retries` — all 3 attempts locked re-raises `OperationalError`
- `test_reclaim_stale_propagates_non_lock_operational_errors` — syntax errors don't retry

All 31 aspect_extraction_queue tests pass locally.

## Ships in

v5.0.2 alongside #944 (drift hint), #945 (blog scripts), #946 (stale-install warning).