### PR TITLE
docs(readme): restore pointers to "How I use Nexus" + "Installing Nexus"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 **Persistent memory and semantic search for Claude.** Three storage tiers that survive across sessions, an event-sourced document catalog with typed links, and a specification-before-code workflow for tracking decisions. Local-first; no API keys required. Knowledge compounds across conversations instead of evaporating when the window closes.
 
+**Start here**: [**How I actually use Nexus**](https://tensegrity.blog/2026/04/26/how-i-actually-use-nexus/) — the conceptual overview and the shape of the substrate. Then [**Installing Nexus**](https://tensegrity.blog/2026/04/26/installing-nexus/) — a ten-minute hands-on walkthrough from `uv tool install` through your first search.
+
 ## Install for Claude
 
 Three surfaces share one host substrate. Pick the one that matches how you use Claude.
@@ -64,7 +66,9 @@ The `nx` CLI provides direct access to all storage tiers, indexing, search, the 
 | Configure or tune | [Configuration](https://github.com/Hellblazer/nexus/blob/main/docs/configuration.md) |
 | Run in containers or Cowork | [Container Integration](https://github.com/Hellblazer/nexus/blob/main/docs/container-integration.md) |
 | Browse the docs tree | [docs/README.md](https://github.com/Hellblazer/nexus/blob/main/docs/README.md) |
-| Read the long-form story | [Tensegrity blog](https://tensegrity.blog/) |
+| Read the conceptual story | [How I actually use Nexus](https://tensegrity.blog/2026/04/26/how-i-actually-use-nexus/) |
+| Walk through a fresh install | [Installing Nexus](https://tensegrity.blog/2026/04/26/installing-nexus/) |
+| Browse the full series | [Tensegrity blog](https://tensegrity.blog/) |
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Two foundational blog posts got dropped from the README in the v5.0.0 chat-first restructure. Without them, a GitHub visitor lands on install instructions with zero conceptual framing — no idea what the substrate IS or how it changes their relationship with Claude.

Restores the pointers in two surfaces:

1. **New "Start here" callout** right after the value-prop paragraph. Two inline links — conceptual overview first ("How I actually use Nexus"), then install walkthrough ("Installing Nexus"). This is the first thing a GitHub visitor sees after the badges.

2. **Two new rows in "Going deeper"** for each post, separate from the generic "Tensegrity blog" entry.

## Why

The v5.0.0 README rewrite collapsed 14 docs rows to 6 ("breadcrumb shape") and dropped the inline blog references along with them. The optimization for chat-first audiences accidentally hurt the GitHub-landing experience — visitors hit install commands with no on-ramp.

A real tutorial would be the better fix, but until that lands the blog posts are the closest thing to "what does this do and why" guided content we have.

## Ships in

Whenever — pure README change, no code impact. Could land standalone or ride in v5.0.2.