### PR TITLE
fix(drift): plugin-rename migration needs BOTH install AND reload-plugins

### DIFF
--- a/docs/desktop-deployment.md
+++ b/docs/desktop-deployment.md
@@ -57,13 +57,14 @@ Daemon lifecycle: `nx daemon t2 status` / `nx daemon t2 start` / `nx daemon t2 i
 
 After upgrading conexus (`uv tool upgrade conexus`) or after the plugin rename (`nx` → `conexus` at v5.0.0), `nx doctor` surfaces two kinds of drift:
 
-- **Plugin name drift**: the installed Claude Code plugin still has `name: "nx"` but the CLI expects `conexus`. Fix:
+- **Plugin name drift**: the installed Claude Code plugin still has `name: "nx"` but the CLI expects `conexus`. Fix is two commands:
 
   ```
-  /reload-plugins      # in Claude Code
+  /plugin install conexus@nexus-plugins   # in Claude Code — registers the new plugin
+  /reload-plugins                          # in Claude Code — activates it
   ```
 
-  Claude Code re-reads the marketplace and swaps the installed plugin in place. No explicit uninstall + install needed.
+  Install alone leaves the new plugin staged but inactive; reload alone won't pick up the renamed plugin from marketplace.json. Both are required. Optionally `/plugin uninstall nx@nexus-plugins` after to drop the stale entry.
 
 - **Post-commit hook stanza drift**: the installed `.git/hooks/post-commit` predates the pgrep guard fix (nexus-mkj6u 2026-05-23). Fix:
 

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -866,14 +866,14 @@ def _check_plugin_name() -> list[HealthResult]:
     differs from what the CLI expects.
 
     The 2026-05-23 rename moved the plugin name from ``nx`` to
-    ``conexus``. Until the user runs ``/reload-plugins`` in Claude
-    Code (which re-reads marketplace.json and reconciles the rename
-    in place), they may continue running the NEW conexus CLI under
-    the OLD ``nx`` plugin install at
-    ``~/.claude/plugins/cache/nexus-plugins/nx/...``. The MCP-server-
-    startup check fires once per session; this doctor check is the
-    explicit-invocation surface for users who run ``nx doctor`` to
-    diagnose what's stale.
+    ``conexus``. Migration is two Claude Code commands: ``/plugin
+    install conexus@nexus-plugins`` to register the new plugin,
+    then ``/reload-plugins`` to activate it. Until both run, the
+    user is running the NEW conexus CLI under the OLD ``nx`` plugin
+    install at ``~/.claude/plugins/cache/nexus-plugins/nx/...``.
+    The MCP-server-startup check fires once per session; this
+    doctor check is the explicit-invocation surface for users who
+    run ``nx doctor`` to diagnose what's stale.
 
     Non-fatal. Returns an empty list when no ``CLAUDE_PLUGIN_ROOT``
     is set (CLI-only use; nothing to check) or when the plugin name
@@ -907,8 +907,9 @@ def _check_plugin_name() -> list[HealthResult]:
                 "(renamed 2026-05-23, nexus-mkj6u)"
             ),
             fix_suggestions=[
+                "/plugin install conexus@nexus-plugins",
                 "/reload-plugins",
-                "(run in Claude Code; the marketplace reconciles the rename in place — no uninstall + install needed)",
+                "(both run in Claude Code; install registers the new plugin, reload activates it)",
             ],
             fatal=False,
         )

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -671,13 +671,17 @@ def check_version_compatibility() -> None:
 
             # ── (3) Plugin NAME drift (nexus-mkj6u) ─────────────────────
             # The 2026-05-23 rename moved the plugin name from ``nx`` to
-            # ``conexus``. Running ``/reload-plugins`` in Claude Code
-            # picks up the marketplace.json change and reconciles the
-            # rename in place — no explicit uninstall + install needed.
-            # Until the user reloads, the local cache at
+            # ``conexus``. Migration requires TWO Claude Code commands:
+            # ``/plugin install conexus@nexus-plugins`` to register the
+            # new plugin, then ``/reload-plugins`` to activate it.
+            # Until both run, the local cache at
             # ``~/.claude/plugins/cache/nexus-plugins/nx/...`` continues
             # to back the OLD nx plugin name; the user is running the
-            # NEW conexus CLI under that stale install.
+            # NEW conexus CLI under that stale install. The earlier
+            # nexus-v4m7y-adjacent guidance that ``/reload-plugins``
+            # alone suffices was wrong — empirically confirmed when a
+            # user on a fresh shell ran reload and saw no effect until
+            # the explicit install ran.
             #
             # Fire this warning EVERY MCP startup until resolved. It is
             # the most reliable surface to catch the gap because every
@@ -690,7 +694,9 @@ def check_version_compatibility() -> None:
                     hint=(
                         f"Plugin was renamed '{plugin_name}' -> "
                         f"'{EXPECTED_PLUGIN_NAME}' (nexus-mkj6u). In "
-                        f"Claude Code, run: /reload-plugins"
+                        f"Claude Code, run: /plugin install "
+                        f"{EXPECTED_PLUGIN_NAME}@nexus-plugins "
+                        "&& /reload-plugins"
                     ),
                 )
 

--- a/tests/e2e/upgrade-shakeout.sh
+++ b/tests/e2e/upgrade-shakeout.sh
@@ -220,9 +220,11 @@ PJEOF
 DOCTOR_OUT="$(CLAUDE_PLUGIN_ROOT="$FAKE_PLUGIN_ROOT" HOME="$SANDBOX" nx doctor 2>&1 || true)"
 echo "$DOCTOR_OUT" | grep -qi 'plugin name' \
     || _die "nx doctor did not surface plugin-name drift. Output:\n$DOCTOR_OUT"
+echo "$DOCTOR_OUT" | grep -q '/plugin install conexus@nexus-plugins' \
+    || _die "doctor warning missing /plugin install hint"
 echo "$DOCTOR_OUT" | grep -q '/reload-plugins' \
     || _die "doctor warning missing /reload-plugins hint"
-_pass "nx doctor names the /reload-plugins migration command"
+_pass "nx doctor names both /plugin install and /reload-plugins migration commands"
 # (The structlog warning at every MCP startup is covered by unit test
 # tests/test_plugin_name_drift.py::test_check_version_compatibility_logs_plugin_name_mismatch
 # — easier to assert there than to spawn nx-mcp + watch stderr here.)

--- a/tests/test_plugin_name_drift.py
+++ b/tests/test_plugin_name_drift.py
@@ -40,7 +40,7 @@ def _plant_plugin_manifest(tmp_path: Path, name: str, version: str = "4.34.5") -
 
 def test_check_plugin_name_warns_on_old_nx(monkeypatch, tmp_path):
     """An installed ``nx`` plugin against the conexus-expecting CLI fires
-    a non-fatal warning telling the user to run /reload-plugins."""
+    a non-fatal warning naming both /plugin install and /reload-plugins."""
     plugin_root = _plant_plugin_manifest(tmp_path, name="nx")
     monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
 
@@ -53,6 +53,7 @@ def test_check_plugin_name_warns_on_old_nx(monkeypatch, tmp_path):
     assert r.fatal is False
     assert "nx@nexus-plugins" in r.detail or "renamed" in r.detail
     suggestions = " ".join(r.fix_suggestions)
+    assert "/plugin install conexus@nexus-plugins" in suggestions
     assert "/reload-plugins" in suggestions
 
 
@@ -107,7 +108,8 @@ def test_check_version_compatibility_logs_plugin_name_mismatch(monkeypatch, tmp_
     assert "plugin_name_mismatch" in captured, (
         f"expected plugin_name_mismatch warning in stdout/stderr; got: {captured!r}"
     )
-    # Actionable hint surfaces
+    # Actionable hint names BOTH commands: install registers, reload activates.
+    assert "/plugin install conexus@nexus-plugins" in captured
     assert "/reload-plugins" in captured
 
 


### PR DESCRIPTION
## Summary

Empirical correction. The earlier guidance (PR #944, merged via #948) said \`/reload-plugins\` alone suffices for the \`nx\` → \`conexus\` migration. **Wrong**: verified by direct experience that \`/reload-plugins\` by itself does not pick up the renamed plugin.

The actual required sequence is:

\`\`\`
/plugin install conexus@nexus-plugins   # registers the new plugin
/reload-plugins                          # activates it
\`\`\`

Install alone leaves the plugin staged but inactive; reload alone won't register a renamed plugin from marketplace.json. **Both are required.**

## What I learned wrong

Earlier in the session I observed that \`/reload-plugins\` on a particular machine appeared to migrate the install without an explicit \`/plugin install\` step. That was either machine-state-specific (a quirk of an older marketplace cache) or my misread. Today's verification on a fresh shell required both commands; Claude Code's own response after \`/plugin install\` literally says \"Run /reload-plugins to apply.\"

## Surfaces corrected

- \`src/nexus/health.py\`: \`fix_suggestions\` now lists both commands
- \`src/nexus/mcp_infra.py\`: structlog hint emits \"/plugin install ... && /reload-plugins\"; comment block calls out the empirical correction
- \`tests/test_plugin_name_drift.py\`: assertions verify BOTH commands appear in fix_suggestions and captured stderr (6 tests pass locally)
- \`tests/e2e/upgrade-shakeout.sh\`: doctor-output grep checks for both hints
- \`docs/desktop-deployment.md\`: drift-detection remediation prose lists both commands and explains why each alone fails
- \`blog/post-7-conexus-5-0.md\` (gitignored): same correction, re-pushed to tensegrity.blog via \`publish.py\`

## Validation

- \`tests/test_plugin_name_drift.py\`: 6/6 pass locally with the new assertions
- \`tests/e2e/upgrade-shakeout.sh\`: blocked locally by accumulated process-table exhaustion in this shell session; the unit tests assert the exact same hint-text content the sandbox greps for. Sandbox can be run manually in a fresh terminal.

## Ships in

v5.0.2 — gets bundled with the rest of the in-flight follow-ups already merged to develop.