### PR TITLE
fix(t1): sweep orphan T1 chromadb servers at MCP startup (nexus-aigkb)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -158,6 +158,7 @@ async def _t1_chroma_lifespan(_app: Any):
         start_t1_server,
         sweep_orphan_resource_trackers,
         sweep_orphan_t1_addr_files,
+        sweep_orphan_t1_chromadbs,
         sweep_orphan_tmpdirs,
     )
 
@@ -189,6 +190,19 @@ async def _t1_chroma_lifespan(_app: Any):
     except Exception as exc:
         _sweep_log.debug(
             "sweep_orphan_resource_trackers_failed", error=str(exc)
+        )
+    # (d) orphan T1 chromadb servers (nexus-aigkb). When a Claude
+    # Code session exits ungracefully (SIGKILL, crash, lost
+    # SessionEnd hook), its per-session chromadb is re-parented to
+    # launchd and runs indefinitely, holding a TCP port and tmpdir.
+    # sweep_orphan_tmpdirs reaps the dirs only after 24h; this
+    # sweeps the processes immediately so the next start_t1_server
+    # has a clean slate.
+    try:
+        sweep_orphan_t1_chromadbs()
+    except Exception as exc:
+        _sweep_log.debug(
+            "sweep_orphan_t1_chromadbs_failed", error=str(exc)
         )
 
     # Reset the ``_SHUTDOWN_IN_FLIGHT`` sentinel BEFORE

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -404,6 +404,108 @@ def sweep_orphan_resource_trackers(
     return signalled
 
 
+def _parse_orphan_t1_chromadb_candidates(
+    ps_output: str,
+    *,
+    min_age_seconds: float = 60.0,
+    protected_pids: set[int] | None = None,
+) -> list[int]:
+    """Parse ``ps -eo pid,ppid,etime,command`` and return PIDs of
+    orphan T1 chromadb servers safe to reap (nexus-aigkb).
+
+    A row is included iff every condition holds:
+
+    * ``ppid == 1`` (re-parented to init; originating Claude Code
+      session is dead).
+    * ``command`` contains BOTH ``chroma run`` AND ``nx_t1_``
+      (chromadb spawned by :func:`start_t1_server`; the
+      ``nx_t1_`` prefix carries the entropy that prevents
+      false positives against unrelated chromadb instances).
+    * Process age >= *min_age_seconds* (avoids racing
+      in-flight T1 spawns whose parent has not yet attached).
+    * ``pid not in protected_pids`` (escape hatch for tests).
+
+    Pure function. Returns the list in the order ``ps`` emitted.
+    """
+    protected = protected_pids or set()
+    out: list[int] = []
+    for line in ps_output.splitlines():
+        s = line.strip()
+        if not s or not s[0].isdigit():
+            continue
+        parts = s.split(None, 3)
+        if len(parts) < 4:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        if ppid != 1:
+            continue
+        if pid in protected:
+            continue
+        # Require BOTH markers — defence in depth against matching
+        # an unrelated user-managed chromadb.
+        cmd = parts[3]
+        if "chroma run" not in cmd or "nx_t1_" not in cmd:
+            continue
+        age = _parse_etime_seconds(parts[2])
+        if age is None or age < min_age_seconds:
+            continue
+        out.append(pid)
+    return out
+
+
+def sweep_orphan_t1_chromadbs(
+    *,
+    min_age_seconds: float = 60.0,
+    protected_pids: set[int] | None = None,
+) -> int:
+    """Reap orphan T1 chromadb servers re-parented to init (nexus-aigkb).
+
+    Each ungraceful Claude Code session exit (SIGKILL, OOM, lost
+    SessionEnd hook) leaves the per-session chromadb running with
+    its PPID re-parented to launchd / init (pid 1). The chromadb
+    keeps holding its TCP port, file descriptors, and tmpdir
+    indefinitely. :func:`sweep_orphan_tmpdirs` reaps the dirs only
+    after 24h and only by mtime; this sweep reaps the actual
+    processes immediately so the next SessionStart starts clean.
+
+    Sends SIGTERM (graceful), escalates to SIGKILL after 3 s. The
+    helper :func:`_kill_orphan_tracker_pids` is reused.
+
+    Returns the count signalled. Best-effort; failures are logged
+    at debug and never block startup. Companion to
+    :func:`sweep_orphan_resource_trackers`.
+    """
+    try:
+        ps_output = subprocess.check_output(
+            ["ps", "-eo", "pid,ppid,etime,command"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+        _log.debug("sweep_orphan_t1_chromadbs_ps_failed", error=str(exc))
+        return 0
+
+    candidates = _parse_orphan_t1_chromadb_candidates(
+        ps_output,
+        min_age_seconds=min_age_seconds,
+        protected_pids=protected_pids,
+    )
+    if not candidates:
+        return 0
+
+    signalled = _kill_orphan_tracker_pids(candidates)
+    _log.info(
+        "sweep_orphan_t1_chromadbs_reaped",
+        count=signalled,
+        candidates=len(candidates),
+    )
+    return signalled
+
+
 def _kill_orphan_tracker_pids(
     pids: list[int],
     *,

--- a/tests/test_session_sweep_orphan_t1_chromadbs.py
+++ b/tests/test_session_sweep_orphan_t1_chromadbs.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for nexus.session.sweep_orphan_t1_chromadbs (issue nexus-aigkb).
+
+Each ungraceful Claude Code session exit (SIGKILL, crash, lost
+SessionEnd hook) leaves the per-session T1 chromadb server
+re-parented to launchd / init (pid 1). The chromadb keeps holding a
+TCP port, file descriptors, and a tmpdir indefinitely.
+
+Live observation 2026-05-24: 5 orphan chromadbs accumulated over 3
+days of normal Claude Code use, parented to launchd. Each had been
+running 1-3 days post-session-exit.
+
+The parallel sweep ``sweep_orphan_resource_trackers`` reaps
+multiprocessing tracker children; this one reaps the chromadb
+parent itself. Both run at MCP top-level startup so the next
+start_t1_server has a clean slate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Parser tests (pure function, no subprocess).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestParseOrphanT1ChromadbCandidates:
+    """Validate _parse_orphan_t1_chromadb_candidates."""
+
+    def test_parses_orphan_chromadb_line(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       12:34 /path/to/python /path/to/chroma run "
+            "--host 127.0.0.1 --port 49994 --path /tmp/nx_t1_abcd1234\n"
+        )
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == [211]
+
+    def test_skips_chromadb_with_live_parent(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211   555       12:34 /path/to/chroma run --port 49994 "
+            "--path /tmp/nx_t1_abcd1234\n"
+        )
+        # PPID != 1 → still owned by a live Claude Code session
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == []
+
+    def test_skips_chromadb_without_nx_t1_marker(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       12:34 /path/to/chroma run --port 49994 "
+            "--path /home/user/my-project/.chroma\n"
+        )
+        # No nx_t1_ marker → user's own chromadb, off-limits
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == []
+
+    def test_skips_non_chromadb_orphans(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       12:34 /path/to/python -m my_other_service "
+            "--data /tmp/nx_t1_abcd\n"
+        )
+        # Has nx_t1_ marker but not "chroma run" → not ours
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == []
+
+    def test_age_threshold_excludes_in_flight_spawn(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       00:05 /path/to/chroma run --port 49994 "
+            "--path /tmp/nx_t1_abcd1234\n"
+        )
+        # 5s old; default min_age 60s → skip (could be a racing spawn)
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == []
+
+    def test_protected_pids_honored(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       12:34 /path/to/chroma run --port 49994 "
+            "--path /tmp/nx_t1_abcd1234\n"
+        )
+        assert _parse_orphan_t1_chromadb_candidates(
+            ps_output, protected_pids={211}
+        ) == []
+
+    def test_multi_day_etime_parses(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1   03-21:36:36 /path/to/chroma run --port 49994 "
+            "--path /tmp/nx_t1_abcd1234\n"
+        )
+        # 3d 21h+ old; well past the 60s threshold
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == [211]
+
+    def test_handles_empty_input(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        assert _parse_orphan_t1_chromadb_candidates("") == []
+        assert _parse_orphan_t1_chromadb_candidates(
+            "  PID  PPID     ELAPSED COMMAND\n"
+        ) == []
+
+    def test_skips_malformed_lines(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "garbage line with no pid\n"
+            "  211     1       12:34 /path/to/chroma run --port 49994 --path /tmp/nx_t1_abcd1234\n"
+            "  not-a-pid     1       12:34 chroma run nx_t1_other\n"
+        )
+        # Only the well-formed orphan line is returned
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == [211]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sweep-level tests (mocks the ps subprocess and _kill_orphan_tracker_pids).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSweepOrphanT1Chromadbs:
+    """Validate sweep_orphan_t1_chromadbs end-to-end with mocked subprocess."""
+
+    def test_sweep_signals_orphans(self, monkeypatch):
+        import nexus.session as session
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       12:34 chroma run --port 49994 --path /tmp/nx_t1_abcd1234\n"
+            "  212     1       12:34 chroma run --port 49995 --path /tmp/nx_t1_efgh5678\n"
+        )
+
+        monkeypatch.setattr(
+            session.subprocess,
+            "check_output",
+            lambda *a, **kw: ps_output,
+        )
+
+        signalled_pids: list[int] = []
+
+        def fake_kill(pids, **kwargs):
+            signalled_pids.extend(pids)
+            return len(pids)
+
+        monkeypatch.setattr(session, "_kill_orphan_tracker_pids", fake_kill)
+
+        result = session.sweep_orphan_t1_chromadbs()
+        assert result == 2
+        assert signalled_pids == [211, 212]
+
+    def test_sweep_skips_when_no_orphans(self, monkeypatch):
+        import nexus.session as session
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211   555       12:34 chroma run --port 49994 --path /tmp/nx_t1_abcd1234\n"
+        )
+        monkeypatch.setattr(
+            session.subprocess, "check_output", lambda *a, **kw: ps_output,
+        )
+
+        def must_not_be_called(*a, **kw):
+            pytest.fail("_kill_orphan_tracker_pids should not be called when no orphans")
+
+        monkeypatch.setattr(
+            session, "_kill_orphan_tracker_pids", must_not_be_called
+        )
+
+        assert session.sweep_orphan_t1_chromadbs() == 0
+
+    def test_sweep_swallows_ps_failure(self, monkeypatch):
+        import nexus.session as session
+        import subprocess
+
+        def failing_ps(*a, **kw):
+            raise subprocess.CalledProcessError(1, "ps")
+
+        monkeypatch.setattr(session.subprocess, "check_output", failing_ps)
+        # Should return 0, not raise — failures must never block startup
+        assert session.sweep_orphan_t1_chromadbs() == 0


### PR DESCRIPTION
## Summary

Closes nexus-aigkb. Adds a new sweep that reaps orphan T1 chromadb servers — companion to the existing \`sweep_orphan_tmpdirs\` (dirs by mtime) and \`sweep_orphan_resource_trackers\` (multiprocessing tracker children). The chromadb parent itself was untouched until now.

## Symptom

Live observation 2026-05-24: **5 orphan chromadbs** accumulated over 3 days of normal Claude Code use, parented to launchd, ranging 1d 6h to 12d 19h old. Each held a TCP port, file descriptors, and a /tmp/nx_t1_* directory.

Cause: when Claude Code exits ungracefully (SIGKILL, crash, force-quit), the SessionEnd hook doesn't run. The per-session chromadb subprocess is re-parented to launchd and never cleaned up. Nothing reaps it until the host reboots.

## Implementation

\`sweep_orphan_t1_chromadbs\` mirrors the existing \`sweep_orphan_resource_trackers\` pattern:

- **Parser** (\`_parse_orphan_t1_chromadb_candidates\`, pure function): walks \`ps -eo pid,ppid,etime,command\` and returns PIDs where:
  - \`ppid == 1\` (orphaned)
  - Command contains BOTH \`chroma run\` AND \`nx_t1_\` (defence in depth — won't touch user-managed chromadbs)
  - Age >= 60s (avoids racing in-flight spawns)
  - PID not in protected_pids (test escape hatch)

- **Sweep**: calls ps, parses, SIGTERMs the candidates, escalates to SIGKILL after 3s. Reuses \`_kill_orphan_tracker_pids\` (existing helper).

Wired into \`mcp/core.py\` startup sweep cascade as (d) alongside the three existing sweeps. Best-effort; failures logged at debug, never block startup.

## Tests (12 new, all pass)

- Parser: orphan chromadb line, live parent, no nx_t1_ marker, non-chromadb orphan with nx_t1_ marker, age threshold, protected_pids, multi-day etime parse, empty input, malformed lines
- Sweep: signals orphans, skips when none, swallows ps failure

## Ships in

v5.0.2 alongside the other shake-out followups already on develop.