### PR TITLE
release: conexus 5.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.0.1"
+        "ref": "v5.0.2"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.0.1"
+      "version": "5.0.2"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.0.1"
+        "ref": "v5.0.2"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.0.1"
+      "version": "5.0.2"
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,11 @@ tests/fixtures/*.pdf
 .claude/scratch/
 .claude/scheduled_tasks.lock
 .serena/
-blog/
+# blog/ is local-only by default (drafts, images, .pulled.md sidecars);
+# tooling lives at blog/publish.py + blog/upload-images.sh and is tracked.
+blog/*
+!blog/publish.py
+!blog/upload-images.sh
 output/
 
 # Local exploration / scratch, never committed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.2] - 2026-05-24
+
+Post-shakeout follow-ups to the 5.0.x line. No schema changes; safe in-place upgrade from 5.0.1.
+
+### Fix: orphan T1 chromadb sweep at MCP startup (nexus-aigkb)
+
+Session-scoped T1 chromadb servers could be orphaned when an MCP process
+exited without cleaning up its child chroma (crash, SIGKILL, or a parent
+that never ran shutdown). Over many sessions these accumulated as leaked
+processes holding ports and memory. The MCP server now sweeps orphan T1
+chromadb servers at startup: any T1 chroma whose owning process is gone
+is terminated before the new session starts.
+
+### Fix: aspect_queue tolerance under WAL contention (nexus-v4m7y)
+
+`reclaim_stale` on the T2 aspect-extraction queue could raise
+`database is locked` when the indexer and the daemon contended on the
+SQLite WAL writer lock. `busy_timeout` is raised (5s to 30s) and the
+reclaim path now retries up to three times on `database is locked`
+before surfacing the error. Reduces spurious failures during concurrent
+indexing.
+
+### Feature: MCPB stale-install warning at startup
+
+The Claude Desktop `.mcpb` bundle now performs a best-effort version
+check at MCP server startup (MCPB v0.4 has no auto-update mechanism).
+When the installed `conexus` is older than the latest on PyPI, it emits
+a one-line warning to stderr naming the GitHub release URL to
+re-download. The check is non-fatal (offline or PyPI hiccup is silent)
+and opt-out via `NX_MCPB_SKIP_UPDATE_CHECK=1`.
+
+### Fix: plugin-rename drift hint requires BOTH install AND reload
+
+The `nx doctor` plugin-name-drift hint previously suggested
+`/reload-plugins` alone to migrate the renamed `nx` plugin to `conexus`.
+That is insufficient on a fresh shell: install alone leaves the new
+plugin staged but inactive, reload alone won't pick up the renamed
+plugin from marketplace.json. The hint now correctly instructs both
+`/plugin install conexus@nexus-plugins` and `/reload-plugins`.
+
+### Docs
+
+- README "Start here" callout and blog-post pointers restored (a
+  regression from the chat-first README restructure).
+- `docs/desktop-deployment.md` documents the new MCPB stale-install
+  warning and its opt-out env var under Drift detection.
+- Blog publishing helpers (`blog/publish.py`, `blog/upload-images.sh`)
+  are now tracked in git; `publish.py --batch` no longer requires a
+  placeholder `md_path`.
+
 ## [5.0.1] - 2026-05-24
 
 ### Fix: release workflow PyPI publish failure

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 **Persistent memory and semantic search for Claude.** Three storage tiers that survive across sessions, an event-sourced document catalog with typed links, and a specification-before-code workflow for tracking decisions. Local-first; no API keys required. Knowledge compounds across conversations instead of evaporating when the window closes.
 
+**Start here**: [**How I actually use Nexus**](https://tensegrity.blog/2026/04/26/how-i-actually-use-nexus/) — the conceptual overview and the shape of the substrate. Then [**Installing Nexus**](https://tensegrity.blog/2026/04/26/installing-nexus/) — a ten-minute hands-on walkthrough from `uv tool install` through your first search.
+
 ## Install for Claude
 
 Three surfaces share one host substrate. Pick the one that matches how you use Claude.
@@ -64,7 +66,9 @@ The `nx` CLI provides direct access to all storage tiers, indexing, search, the 
 | Configure or tune | [Configuration](https://github.com/Hellblazer/nexus/blob/main/docs/configuration.md) |
 | Run in containers or Cowork | [Container Integration](https://github.com/Hellblazer/nexus/blob/main/docs/container-integration.md) |
 | Browse the docs tree | [docs/README.md](https://github.com/Hellblazer/nexus/blob/main/docs/README.md) |
-| Read the long-form story | [Tensegrity blog](https://tensegrity.blog/) |
+| Read the conceptual story | [How I actually use Nexus](https://tensegrity.blog/2026/04/26/how-i-actually-use-nexus/) |
+| Walk through a fresh install | [Installing Nexus](https://tensegrity.blog/2026/04/26/installing-nexus/) |
+| Browse the full series | [Tensegrity blog](https://tensegrity.blog/) |
 
 ## Prerequisites
 

--- a/blog/publish.py
+++ b/blog/publish.py
@@ -525,7 +525,10 @@ def main() -> None:
             "Publish a markdown post to WordPress.com as Gutenberg blocks."
         )
     )
-    ap.add_argument("md_path", type=Path, help="Path to .md file")
+    ap.add_argument(
+        "md_path", type=Path, nargs="?", default=None,
+        help="Path to .md file. Required unless --batch is given.",
+    )
     ap.add_argument(
         "--post-id", type=int, default=None,
         help="Update existing post by ID (default: create new draft)",
@@ -565,6 +568,12 @@ def main() -> None:
         help="Inter-post pause in --batch mode, in seconds (default: 1.0).",
     )
     args = ap.parse_args()
+
+    # md_path is optional iff --batch is given; required otherwise.
+    if not args.batch and args.md_path is None:
+        ap.error("md_path is required unless --batch is given")
+    if args.batch and args.md_path is not None:
+        ap.error("md_path is incompatible with --batch (the batch arg carries paths)")
 
     if args.batch:
         if args.print_html or args.pull:

--- a/blog/publish.py
+++ b/blog/publish.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "beautifulsoup4>=4.12",
+# ]
+# ///
+"""Publish a markdown blog post to WordPress.com as native Gutenberg blocks.
+
+Why this exists
+---------------
+Pasting plain HTML into the WP.com block editor lands every element as a
+generic Paragraph block — code blocks become text, tables vanish, headings
+need to be re-typed. Gutenberg only honours the right block types when the
+HTML carries `<!-- wp:NAME -->` comment markers around each top-level
+element. This script converts markdown → block-wrapped HTML → SSH+wp-cli on
+the WP.com host in one shot.
+
+Why SSH+wp-cli, not REST
+------------------------
+WP.com's /wp/v2/ REST proxy doesn't accept Application Passwords with Basic
+Auth for write operations (returns "rest_cannot_create"). The only working
+non-OAuth2 path on WP.com Atomic hosting is SSH+wp-cli, which is what this
+script uses.
+
+Setup (one-time)
+----------------
+1. Site dashboard → Settings → SFTP/SSH → toggle "Enable SSH access" ON.
+2. Add an SSH key at wordpress.com/me/security/ssh-keys, then back on the
+   site's SFTP/SSH panel select it from the dropdown and click
+   "Attach SSH key to site".
+3. Save config at ~/.config/nexus-blog/config.json:
+     {
+       "site": "tensegrity.blog",
+       "ssh_user": "tensegritydotblog.wordpress.com",
+       "ssh_host": "ssh.wp.com",
+       "ssh_key": "~/.ssh/id_ed25519"
+     }
+4. pandoc must be on PATH.
+
+Usage
+-----
+  publish.py POST.md --print-html              # dry-run: dump converted HTML
+  publish.py POST.md --draft                   # create new draft, print id
+  publish.py POST.md --post-id N               # update existing post (status unchanged)
+  publish.py POST.md --post-id N --publish     # publish it
+  publish.py POST.md --post-id N --draft       # demote published post back to draft
+  publish.py POST.md --pull --post-id N        # fetch post N from WP, write to POST.pulled.md
+
+Editing loop
+------------
+First run --draft, note the post-id, preview at
+  https://wordpress.com/post/<site>/<post-id>
+then iterate with --post-id N until happy, then --publish.
+
+Round-trip from WP edits
+------------------------
+If you edit the post in the WP block editor, run --pull --post-id N to
+fetch the current WP content and write it to POST.pulled.md (sidecar, never
+clobbers the source). Diff with `diff -u POST.md POST.pulled.md` and merge
+the changes you want back into POST.md by hand. Round-trip isn't perfect:
+pandoc html→md normalises whitespace, smart quotes, and table wrapping, so
+expect cosmetic diffs alongside the substantive ones.
+
+Safety
+------
+Without --post-id this script ALWAYS creates a brand-new post. It cannot
+overwrite an existing published post by accident — you have to pass the
+target post-id explicitly. Post 1 ("Nexus by Example") on tensegrity.blog
+is post-id 1284; never pass it as --post-id unless you really mean to edit
+the live post.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from bs4 import BeautifulSoup, NavigableString, Tag
+
+CONFIG_PATH = Path.home() / ".config" / "nexus-blog" / "config.json"
+
+
+REQUIRED_KEYS = ("site", "ssh_user", "ssh_host")
+
+
+def load_config() -> dict[str, str]:
+    if not CONFIG_PATH.exists():
+        sys.exit(
+            f"Missing config at {CONFIG_PATH}.\n"
+            "See the docstring at the top of this script for setup steps."
+        )
+    cfg = json.loads(CONFIG_PATH.read_text())
+    missing = [k for k in REQUIRED_KEYS if k not in cfg or not cfg[k]]
+    if missing:
+        sys.exit(
+            f"Config at {CONFIG_PATH} missing required key(s): {missing!r}\n"
+            "See the docstring at the top of this script for setup steps."
+        )
+    cfg.setdefault("ssh_key", "~/.ssh/id_ed25519")
+    return cfg
+
+
+def md_to_html(md_path: Path) -> str:
+    """Run pandoc, return inner-body HTML (no <html>/<head> wrapper)."""
+    result = subprocess.run(
+        [
+            "pandoc",
+            "--from", "markdown+pipe_tables+task_lists+smart",
+            "--to", "html5",
+            "--no-highlight",
+            "--wrap=none",
+            str(md_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def extract_title_and_strip(md_path: Path) -> tuple[str, Path]:
+    """Pull the first `# Title` line off as the post title.
+
+    Returns (title, path-to-temp-file-without-h1). If no H1 exists, the
+    filename stem becomes the title and the original path is returned.
+    """
+    text = md_path.read_text()
+    lines = text.splitlines()
+    title = md_path.stem
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            title = stripped[2:].strip()
+            stripped_text = "\n".join(lines[:i] + lines[i + 1 :])
+            tmp = md_path.with_suffix(".__publish__.md")
+            tmp.write_text(stripped_text)
+            return title, tmp
+    return title, md_path
+
+
+def _wrap_list(el: Tag, ordered: bool) -> str:
+    """Wrap a <ul>/<ol> + each <li> in Gutenberg list / list-item blocks."""
+    new_lis: list[str] = []
+    for li in el.find_all("li", recursive=False):
+        inner = li.decode_contents().strip()
+        new_lis.append(
+            f"<!-- wp:list-item -->\n<li>{inner}</li>\n<!-- /wp:list-item -->"
+        )
+    items_html = "\n".join(new_lis)
+    attrs = ' {"ordered":true}' if ordered else ""
+    list_tag = "ol" if ordered else "ul"
+    return (
+        f"<!-- wp:list{attrs} -->\n"
+        f"<{list_tag}>\n{items_html}\n</{list_tag}>\n"
+        f"<!-- /wp:list -->"
+    )
+
+
+def wrap_blocks(html: str) -> str:
+    """Wrap top-level pandoc-emitted HTML in Gutenberg block comments."""
+    soup = BeautifulSoup(html, "html.parser")
+    parts: list[str] = []
+
+    for el in list(soup.children):
+        if isinstance(el, NavigableString):
+            text = str(el).strip()
+            if text:
+                parts.append(
+                    f"<!-- wp:paragraph -->\n<p>{text}</p>\n<!-- /wp:paragraph -->"
+                )
+            continue
+        if not isinstance(el, Tag):
+            continue
+
+        tag = el.name
+
+        if tag == "p":
+            parts.append(
+                f"<!-- wp:paragraph -->\n<p>{el.decode_contents()}</p>\n"
+                f"<!-- /wp:paragraph -->"
+            )
+        elif tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            level = int(tag[1])
+            attrs = "" if level == 2 else f' {{"level":{level}}}'
+            inner = el.decode_contents()
+            parts.append(
+                f"<!-- wp:heading{attrs} -->\n"
+                f"<{tag} class=\"wp-block-heading\">{inner}</{tag}>\n"
+                f"<!-- /wp:heading -->"
+            )
+        elif tag == "pre":
+            # Pandoc emits <pre><code class="lang">...</code></pre>; we keep
+            # the inner code text and drop the language class (WP.com Code
+            # block doesn't natively highlight; keeping classes confuses it).
+            code_el = el.find("code")
+            inner = code_el.decode_contents() if code_el else el.decode_contents()
+            parts.append(
+                f"<!-- wp:code -->\n"
+                f'<pre class="wp-block-code"><code>{inner}</code></pre>\n'
+                f"<!-- /wp:code -->"
+            )
+        elif tag == "ul":
+            parts.append(_wrap_list(el, ordered=False))
+        elif tag == "ol":
+            parts.append(_wrap_list(el, ordered=True))
+        elif tag == "blockquote":
+            inner = el.decode_contents().strip()
+            parts.append(
+                f"<!-- wp:quote -->\n"
+                f'<blockquote class="wp-block-quote">{inner}</blockquote>\n'
+                f"<!-- /wp:quote -->"
+            )
+        elif tag == "hr":
+            parts.append(
+                "<!-- wp:separator -->\n"
+                '<hr class="wp-block-separator has-alpha-channel-opacity"/>\n'
+                "<!-- /wp:separator -->"
+            )
+        elif tag == "table":
+            existing = el.get("class") or []
+            el["class"] = list(existing) + ["wp-block-table"]
+            parts.append(
+                f"<!-- wp:table -->\n"
+                f'<figure class="wp-block-table">{el}</figure>\n'
+                f"<!-- /wp:table -->"
+            )
+        elif tag == "figure":
+            # Image figure → wp:image. Lossy if pandoc emitted captions.
+            img = el.find("img")
+            if img is not None:
+                src = img.get("src", "")
+                alt = img.get("alt", "")
+                parts.append(
+                    f"<!-- wp:image -->\n"
+                    f'<figure class="wp-block-image">'
+                    f'<img src="{src}" alt="{alt}"/></figure>\n'
+                    f"<!-- /wp:image -->"
+                )
+            else:
+                parts.append(
+                    f"<!-- wp:html -->\n{el}\n<!-- /wp:html -->"
+                )
+        elif tag == "div":
+            # Pandoc sometimes wraps things in <div>. Pass through as raw HTML.
+            parts.append(f"<!-- wp:html -->\n{el}\n<!-- /wp:html -->")
+        else:
+            # Unknown top-level element: wrap in raw HTML block as a fallback
+            # so it at least round-trips cleanly through the editor.
+            parts.append(f"<!-- wp:html -->\n{el}\n<!-- /wp:html -->")
+
+    return "\n\n".join(parts)
+
+
+def _shell_quote(s: str) -> str:
+    """POSIX-safe single-quoting for embedding in a remote shell command."""
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _ssh_command(cfg: dict[str, str], remote_cmd: str) -> list[str]:
+    key = str(Path(cfg["ssh_key"]).expanduser())
+    return [
+        "ssh",
+        "-o", "BatchMode=yes",
+        "-o", "IdentitiesOnly=yes",
+        "-i", key,
+        f"{cfg['ssh_user']}@{cfg['ssh_host']}",
+        remote_cmd,
+    ]
+
+
+def fetch_post(cfg: dict[str, str], post_id: int) -> tuple[str, str]:
+    """Pull (title, content) from WP via wp-cli."""
+    remote = (
+        f"wp post get {post_id} --field=post_title; "
+        f"echo '<<<NEXUS_PUBLISH_BOUNDARY>>>'; "
+        f"wp post get {post_id} --field=post_content"
+    )
+    cmd = _ssh_command(cfg, remote)
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if proc.returncode != 0:
+        sys.exit(
+            f"wp-cli fetch failed (exit {proc.returncode}):\n"
+            f"  stderr: {proc.stderr.strip()}"
+        )
+    parts = proc.stdout.split("<<<NEXUS_PUBLISH_BOUNDARY>>>\n", 1)
+    if len(parts) != 2:
+        sys.exit(f"Unexpected wp-cli output (no boundary):\n{proc.stdout[:400]}")
+    title = parts[0].rstrip("\n")
+    content = parts[1]
+    return title, content
+
+
+_SMART_TO_ASCII = {
+    "\u2018": "'", "\u2019": "'",   # ' '
+    "\u201c": '"', "\u201d": '"',   # " "
+    "\u2013": "--",                   # –  (en dash → -- to match markdown source convention)
+    # \u2014 (em dash) intentionally left intact — already used as-is in source
+    "\u2026": "...",                  # …
+    "\u00a0": " ",                    # non-breaking → space
+}
+
+
+_HR_RE = re.compile(r"^-{20,}$", re.MULTILINE)
+_HEADING_ATTRS_RE = re.compile(r"^(#+\s+.+?)\s+\{[^}]+\}\s*$", re.MULTILINE)
+_OL_INDENT_RE = re.compile(r"^(\s*\d+\.)  +", re.MULTILINE)
+_ITALIC_RE = re.compile(r"(?<![\*\w])\*([^\s\*][^\*\n]*?[^\s\*]|\S)\*(?![\*\w])")
+_FENCE_CLASS_RE = re.compile(r"^(\s*```)\s*[\w\.\-]+\s*$", re.MULTILINE)
+
+
+def _normalize_for_diff(s: str) -> str:
+    """Squeeze cosmetic round-trip noise so real edits stand out in diff.
+
+    Pandoc html→md emits long underline rules for <hr>, attaches {#id .class}
+    blocks to every heading, indents ordered list items with two spaces, and
+    prefers *star* italic over _underscore_. The source files use the
+    opposite convention for each. Normalising on the way in matches them.
+    """
+    for k, v in _SMART_TO_ASCII.items():
+        s = s.replace(k, v)
+    s = _HR_RE.sub("---", s)
+    s = _HEADING_ATTRS_RE.sub(r"\1", s)
+    s = _OL_INDENT_RE.sub(r"\1 ", s)
+    s = _ITALIC_RE.sub(r"_\1_", s)
+    s = _FENCE_CLASS_RE.sub(r"\1", s)
+    return s
+
+
+def block_html_to_markdown(html: str) -> str:
+    """Strip Gutenberg block comments, run pandoc html→markdown.
+
+    Output flavor is plain `markdown` (not `markdown_strict`) so we get
+    fenced code blocks and underscore-italic — matches the convention the
+    source files use, minimising round-trip diff noise. Smart Unicode
+    punctuation is normalised back to ASCII for the same reason.
+    """
+    html = re.sub(r"<!--\s*/?wp:[^>]*?-->\n?", "", html)
+    proc = subprocess.run(
+        [
+            "pandoc",
+            "--from", "html",
+            "--to", "markdown+pipe_tables-smart-fancy_lists-bracketed_spans-link_attributes",
+            "--wrap=none",
+            "--no-highlight",
+            "--markdown-headings=atx",
+        ],
+        input=html,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return _normalize_for_diff(proc.stdout)
+
+
+def pull_to_sidecar(cfg: dict[str, str], md_path: Path, post_id: int) -> Path:
+    """Pull post N from WP, write to <md_path>.pulled.md, return that path."""
+    title, content_html = fetch_post(cfg, post_id)
+    body_md = block_html_to_markdown(content_html)
+    full_md = f"# {title}\n\n{body_md}"
+    out_path = md_path.with_suffix(".pulled.md")
+    out_path.write_text(full_md)
+    return out_path
+
+
+class WpcliError(RuntimeError):
+    """Raised when an SSH+wp-cli call fails. Carries stderr+stdout for surfacing."""
+
+
+def upload(
+    cfg: dict[str, str],
+    *,
+    title: str,
+    content: str,
+    status: str | None,
+    post_id: int | None,
+    slug: str | None = None,
+) -> dict[str, str]:
+    """Run wp-cli over SSH. Returns dict with at least 'id' and 'status'.
+
+    Raises WpcliError on failure (so batch callers can continue past one bad
+    push). Single-post callers in main() turn this back into sys.exit().
+    """
+    if post_id is None:
+        # Create. Title required, status defaults to draft.
+        title_arg = f"--post_title={_shell_quote(title)}"
+        status_arg = f"--post_status={_shell_quote(status or 'draft')}"
+        slug_arg = f"--post_name={_shell_quote(slug)}" if slug else ""
+        remote = (
+            f"wp post create --post_type=post {title_arg} {status_arg} {slug_arg} "
+            f"--porcelain -"
+        )
+    else:
+        # Update. Trailing "-" tells wp-cli to read post content from stdin
+        # (NOT --post_content=-, which stores the literal dash).
+        parts = [f"wp post update {post_id}", f"--post_title={_shell_quote(title)}"]
+        if status:
+            parts.append(f"--post_status={_shell_quote(status)}")
+        parts.append("-")
+        remote = " ".join(parts)
+
+    cmd = _ssh_command(cfg, remote)
+    proc = subprocess.run(
+        cmd, input=content, capture_output=True, text=True, timeout=120
+    )
+    if proc.returncode != 0:
+        raise WpcliError(
+            f"wp-cli over SSH failed (exit {proc.returncode}): "
+            f"stderr={proc.stderr.strip()!r} stdout={proc.stdout.strip()!r}"
+        )
+    out = proc.stdout.strip()
+    # On --porcelain create, stdout is just the new post-id. On update, stdout
+    # is "Success: Updated post N." — fish out the id.
+    if post_id is None:
+        new_id = out.splitlines()[-1].strip()
+        return {"id": new_id, "status": status or "draft"}
+    return {"id": str(post_id), "status": status or "(unchanged)"}
+
+
+def _build_block_html(md_path: Path) -> tuple[str, str]:
+    """Run the title-extraction + pandoc + Gutenberg-block pipeline on a file.
+
+    Returns (title, block_html). Raises FileNotFoundError if the file is gone.
+    Used by both single-post and batch-mode flows so they stay in sync.
+    """
+    if not md_path.exists():
+        raise FileNotFoundError(str(md_path))
+    title, working_path = extract_title_and_strip(md_path)
+    try:
+        html = md_to_html(working_path)
+    finally:
+        if working_path != md_path and working_path.exists():
+            working_path.unlink()
+    return title, wrap_blocks(html)
+
+
+def parse_batch_arg(arg: str) -> list[tuple[Path, int]]:
+    """Parse `FILE:ID,FILE:ID,...` into a list of (path, post_id) pairs."""
+    pairs: list[tuple[Path, int]] = []
+    for raw in arg.split(","):
+        entry = raw.strip()
+        if not entry:
+            continue
+        if ":" not in entry:
+            sys.exit(f"--batch entry missing ':id': {entry!r}")
+        path_str, id_str = entry.rsplit(":", 1)
+        try:
+            post_id = int(id_str.strip())
+        except ValueError:
+            sys.exit(f"--batch entry id is not an integer: {entry!r}")
+        pairs.append((Path(path_str.strip()), post_id))
+    if not pairs:
+        sys.exit("--batch is empty")
+    return pairs
+
+
+def run_batch(
+    cfg: dict[str, str],
+    pairs: list[tuple[Path, int]],
+    *,
+    status: str | None,
+    delay_seconds: float = 1.0,
+) -> int:
+    """Push N posts over (typically) one TCP connection. Returns exit code.
+
+    Continues past per-post failures, prints a summary table at the end.
+    Inter-iteration `delay_seconds` is a polite back-pressure default.
+    """
+    site = cfg["site"]
+    results: list[tuple[str, int, str, str]] = []  # (filename, id, state, detail)
+
+    for i, (md_path, post_id) in enumerate(pairs):
+        try:
+            title, block_html = _build_block_html(md_path)
+        except FileNotFoundError:
+            results.append((md_path.name, post_id, "FAIL", "file not found"))
+            print(f"FAIL  id={post_id}  ({md_path.name}): file not found", file=sys.stderr)
+            continue
+        except subprocess.CalledProcessError as e:
+            results.append((md_path.name, post_id, "FAIL", f"pandoc: {e}"))
+            print(f"FAIL  id={post_id}  ({md_path.name}): pandoc failure", file=sys.stderr)
+            continue
+
+        try:
+            data = upload(
+                cfg, title=title, content=block_html,
+                status=status, post_id=post_id, slug=None,
+            )
+            results.append((md_path.name, post_id, "OK", data["status"]))
+            print(
+                f"OK    status={data['status']!r}  id={data['id']}  "
+                f"({md_path.name})"
+            )
+        except WpcliError as e:
+            results.append((md_path.name, post_id, "FAIL", str(e)))
+            print(f"FAIL  id={post_id}  ({md_path.name}): {e}", file=sys.stderr)
+        except subprocess.TimeoutExpired:
+            results.append((md_path.name, post_id, "FAIL", "ssh timeout"))
+            print(f"FAIL  id={post_id}  ({md_path.name}): ssh timeout", file=sys.stderr)
+
+        if i < len(pairs) - 1 and delay_seconds > 0:
+            time.sleep(delay_seconds)
+
+    n_ok = sum(1 for r in results if r[2] == "OK")
+    n_fail = len(results) - n_ok
+    print()
+    print(f"=== Batch summary ({len(pairs)} posts) ===")
+    for name, pid, state, info in results:
+        marker = "ok" if state == "OK" else "FAIL"
+        print(f"  [{marker}] id={pid}  {name}")
+        if state != "OK":
+            print(f"         {info}")
+    print(f"\n{n_ok} succeeded, {n_fail} failed")
+    print(f"  edit: https://wordpress.com/post/{site}/<id>")
+    return 0 if n_fail == 0 else 1
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Publish a markdown post to WordPress.com as Gutenberg blocks."
+        )
+    )
+    ap.add_argument("md_path", type=Path, help="Path to .md file")
+    ap.add_argument(
+        "--post-id", type=int, default=None,
+        help="Update existing post by ID (default: create new draft)",
+    )
+    ap.add_argument(
+        "--publish", action="store_true",
+        help="Set status=publish (default: draft on create, unchanged on update)",
+    )
+    ap.add_argument(
+        "--draft", action="store_true",
+        help="Force status=draft (default behavior on create; useful with --post-id to demote a published post back to draft)",
+    )
+    ap.add_argument(
+        "--print-html", action="store_true",
+        help="Print converted block-HTML to stdout; do not upload",
+    )
+    ap.add_argument(
+        "--pull", action="store_true",
+        help="Fetch post --post-id from WP and write to POST.pulled.md (sidecar; does not overwrite source)",
+    )
+    ap.add_argument(
+        "--slug", default=None,
+        help="Post slug (post_name) to set on create. Locks the eventual published URL.",
+    )
+    ap.add_argument(
+        "--batch", default=None,
+        help=(
+            "Update multiple posts in one invocation: "
+            "FILE1:ID1,FILE2:ID2,... . Pushes are sequential with a 1s pause "
+            "between calls, but ControlMaster (if configured in ~/.ssh/config) "
+            "lets them share one TCP connection. Per-post failures are collected; "
+            "a summary table prints at the end. Mutually exclusive with md_path."
+        ),
+    )
+    ap.add_argument(
+        "--batch-delay", type=float, default=1.0,
+        help="Inter-post pause in --batch mode, in seconds (default: 1.0).",
+    )
+    args = ap.parse_args()
+
+    if args.batch:
+        if args.print_html or args.pull:
+            sys.exit("--batch is incompatible with --print-html / --pull.")
+        if args.publish and args.draft:
+            sys.exit("Pass either --publish or --draft, not both.")
+        cfg = load_config()
+        pairs = parse_batch_arg(args.batch)
+        if args.publish:
+            status = "publish"
+        elif args.draft:
+            status = "draft"
+        else:
+            status = None
+        sys.exit(run_batch(cfg, pairs, status=status, delay_seconds=args.batch_delay))
+
+    if args.pull:
+        if args.post_id is None:
+            sys.exit("--pull requires --post-id N")
+        if args.publish or args.draft or args.print_html:
+            sys.exit("--pull is read-only; cannot combine with --publish/--draft/--print-html")
+        cfg = load_config()
+        out = pull_to_sidecar(cfg, args.md_path, args.post_id)
+        diff_cmd = f"diff -u {args.md_path} {out}" if args.md_path.exists() else f"cat {out}"
+        print(f"Pulled post {args.post_id} → {out}")
+        print(f"  diff: {diff_cmd}")
+        return
+
+    try:
+        title, block_html = _build_block_html(args.md_path)
+    except FileNotFoundError:
+        sys.exit(f"Not found: {args.md_path}")
+
+    if args.print_html:
+        sys.stdout.write(block_html)
+        return
+
+    if args.publish and args.draft:
+        sys.exit("Pass either --publish or --draft, not both.")
+
+    cfg = load_config()
+    if args.post_id is None:
+        status = "publish" if args.publish else "draft"
+    elif args.publish:
+        status = "publish"
+    elif args.draft:
+        status = "draft"
+    else:
+        status = None  # leave existing post status alone on update
+
+    try:
+        data = upload(
+            cfg,
+            title=title,
+            content=block_html,
+            status=status,
+            post_id=args.post_id,
+            slug=args.slug,
+        )
+    except WpcliError as e:
+        sys.exit(str(e))
+    site = cfg["site"]
+    print(
+        f"OK  status={data['status']!r}  id={data['id']}\n"
+        f"  edit: https://wordpress.com/post/{site}/{data['id']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/blog/upload-images.sh
+++ b/blog/upload-images.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Upload local PNGs to tensegrity.blog wp-content/uploads/2026/04/
+# Skips files that are byte-identical to remote.
+# Idempotent — safe to re-run.
+
+set -euo pipefail
+
+SSH_HOST="ssh.wp.com"
+SSH_USER="tensegritydotblog.wordpress.com"
+SSH_KEY="$HOME/.ssh/id_ed25519"
+REMOTE_DIR="htdocs/wp-content/uploads/2026/04"
+
+LOCAL_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$LOCAL_DIR"
+
+SSH_OPTS=(-o BatchMode=yes -o IdentitiesOnly=yes -o ConnectTimeout=60 -i "$SSH_KEY")
+SSH_TARGET="${SSH_USER}@${SSH_HOST}"
+
+echo "── Step 1: fetch remote md5 manifest from $REMOTE_DIR"
+REMOTE_MANIFEST=$(mktemp)
+trap 'rm -f "$REMOTE_MANIFEST"' EXIT
+
+ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
+  "cd $REMOTE_DIR && md5sum *.png 2>/dev/null || true" > "$REMOTE_MANIFEST"
+echo "  remote manifest: $(wc -l < "$REMOTE_MANIFEST") files"
+echo
+
+echo "── Step 2: compare each local PNG to remote"
+TO_UPLOAD=()
+SKIPPED=()
+NEW_REMOTE=()
+
+for f in *.png; do
+  [ -f "$f" ] || continue
+  LOCAL_MD5=$(md5 -q "$f")
+  REMOTE_LINE=$(grep -E "  $f\$" "$REMOTE_MANIFEST" || true)
+  if [ -z "$REMOTE_LINE" ]; then
+    NEW_REMOTE+=("$f")
+    TO_UPLOAD+=("$f")
+    echo "  + $f  (NEW on remote)"
+  else
+    REMOTE_MD5=$(echo "$REMOTE_LINE" | awk '{print $1}')
+    if [ "$LOCAL_MD5" = "$REMOTE_MD5" ]; then
+      SKIPPED+=("$f")
+      echo "  = $f  (identical, skip)"
+    else
+      TO_UPLOAD+=("$f")
+      echo "  ~ $f  (differs, will overwrite)"
+    fi
+  fi
+done
+
+echo
+echo "── Summary"
+echo "  to upload: ${#TO_UPLOAD[@]}"
+echo "  identical: ${#SKIPPED[@]}"
+echo "  new:       ${#NEW_REMOTE[@]}"
+
+if [ "${#TO_UPLOAD[@]}" -eq 0 ]; then
+  echo
+  echo "Nothing to do."
+  exit 0
+fi
+
+echo
+read -p "Proceed with upload? [y/N] " yn
+case "$yn" in
+  [Yy]*) ;;
+  *) echo "Aborted."; exit 1 ;;
+esac
+
+echo
+echo "── Step 3: scp uploads"
+for f in "${TO_UPLOAD[@]}"; do
+  echo "  uploading $f ..."
+  scp "${SSH_OPTS[@]}" "$f" "${SSH_TARGET}:${REMOTE_DIR}/$f"
+done
+
+echo
+echo "── Step 4: verify"
+ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
+  "cd $REMOTE_DIR && md5sum $(printf '%s ' "${TO_UPLOAD[@]}")" \
+  | while IFS= read -r line; do
+      remote_md5=$(echo "$line" | awk '{print $1}')
+      remote_file=$(echo "$line" | awk '{print $2}')
+      local_md5=$(md5 -q "$remote_file")
+      if [ "$remote_md5" = "$local_md5" ]; then
+        echo "  ✓ $remote_file"
+      else
+        echo "  ✗ $remote_file  (MISMATCH local=$local_md5 remote=$remote_md5)"
+      fi
+    done
+
+echo
+echo "Done."

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.2] - 2026-05-24
+
+Plugin version aligned with conexus 5.0.2. Runtime fixes in the bundled
+MCP server (orphan T1 chromadb sweep at startup, aspect-queue WAL
+contention tolerance) plus a corrected plugin-rename drift hint. See
+root `CHANGELOG.md` § 5.0.2 for details.
+
+### Fix: plugin-rename drift hint requires BOTH install AND reload
+
+`nx doctor`'s plugin-name-drift hint now instructs both
+`/plugin install conexus@nexus-plugins` and `/reload-plugins` to
+migrate the renamed `nx` plugin. The earlier "reload alone" guidance
+was insufficient on a fresh shell.
+
 ## [5.0.1] - 2026-05-24
 
 ### Feature: tool annotations on all 41 MCP tools

--- a/docs/desktop-deployment.md
+++ b/docs/desktop-deployment.md
@@ -60,9 +60,10 @@ After upgrading conexus (`uv tool upgrade conexus`) or after the plugin rename (
 - **Plugin name drift**: the installed Claude Code plugin still has `name: "nx"` but the CLI expects `conexus`. Fix:
 
   ```
-  /plugin uninstall nx@nexus-plugins      # in Claude Code
-  /plugin install conexus@nexus-plugins   # in Claude Code
+  /reload-plugins      # in Claude Code
   ```
+
+  Claude Code re-reads the marketplace and swaps the installed plugin in place. No explicit uninstall + install needed.
 
 - **Post-commit hook stanza drift**: the installed `.git/hooks/post-commit` predates the pgrep guard fix (nexus-mkj6u 2026-05-23). Fix:
 

--- a/docs/desktop-deployment.md
+++ b/docs/desktop-deployment.md
@@ -74,6 +74,17 @@ After upgrading conexus (`uv tool upgrade conexus`) or after the plugin rename (
 
 Both warnings include the resolution commands; `nx doctor` is the single explicit-invocation surface that consolidates them.
 
+For Claude Desktop `.mcpb` users specifically, the bundle also performs a best-effort stale-install check at MCP server startup (MCPB v0.4 has no auto-update). When the installed `conexus` is older than the latest on PyPI, it emits a one-line warning to stderr naming the GitHub release URL to re-download:
+
+```
+[conexus-mcpb] installed conexus=X.Y.Z, latest on PyPI=A.B.C. Re-download
+the .mcpb from https://github.com/Hellblazer/nexus/releases/latest and
+re-install in Claude Desktop to upgrade. (Set NX_MCPB_SKIP_UPDATE_CHECK=1
+to silence.)
+```
+
+The check is non-fatal: a network failure, timeout, or unreachable PyPI never blocks startup. Set `NX_MCPB_SKIP_UPDATE_CHECK=1` in the environment to opt out entirely.
+
 ## Uninstall
 
 ### Claude Code plugin

--- a/docs/desktop-deployment.md
+++ b/docs/desktop-deployment.md
@@ -57,13 +57,14 @@ Daemon lifecycle: `nx daemon t2 status` / `nx daemon t2 start` / `nx daemon t2 i
 
 After upgrading conexus (`uv tool upgrade conexus`) or after the plugin rename (`nx` → `conexus` at v5.0.0), `nx doctor` surfaces two kinds of drift:
 
-- **Plugin name drift**: the installed Claude Code plugin still has `name: "nx"` but the CLI expects `conexus`. Fix:
+- **Plugin name drift**: the installed Claude Code plugin still has `name: "nx"` but the CLI expects `conexus`. Fix is two commands:
 
   ```
-  /reload-plugins      # in Claude Code
+  /plugin install conexus@nexus-plugins   # in Claude Code — registers the new plugin
+  /reload-plugins                          # in Claude Code — activates it
   ```
 
-  Claude Code re-reads the marketplace and swaps the installed plugin in place. No explicit uninstall + install needed.
+  Install alone leaves the new plugin staged but inactive; reload alone won't pick up the renamed plugin from marketplace.json. Both are required. Optionally `/plugin uninstall nx@nexus-plugins` after to drop the stale entry.
 
 - **Post-commit hook stanza drift**: the installed `.git/hooks/post-commit` predates the pgrep guard fix (nexus-mkj6u 2026-05-23). Fix:
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.0.1"
+version = "5.0.2"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.0.1",
+    "conexus>=5.0.2",
 ]
 
 [tool.uv]

--- a/mcpb/src/server.py
+++ b/mcpb/src/server.py
@@ -1,13 +1,88 @@
 #!/usr/bin/env python3
-"""Nexus MCP server entry point for the Claude Desktop .mcpb spike.
+"""Nexus MCP server entry point for the Claude Desktop .mcpb extension.
 
-RDR-126 P1. Imports and runs ``nexus.mcp.core:main``, the same entry
-point the Claude Code plugin invokes via the ``nx-mcp`` console script.
+Imports and runs ``nexus.mcp.core:main``, the same entry point the
+Claude Code plugin invokes via the ``nx-mcp`` console script. Before
+handing off, performs a best-effort stale-install check: if the
+locally installed ``conexus`` package is older than the latest on
+PyPI, emit a one-line warning to stderr naming the GitHub release URL
+to re-download.
+
+The check is intentionally non-fatal — network failures, timeouts,
+or PyPI being unreachable do not block server startup. Opt out
+entirely by setting ``NX_MCPB_SKIP_UPDATE_CHECK=1`` in the
+environment.
 """
 from __future__ import annotations
 
+import os
+import sys
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+_RELEASE_URL = "https://github.com/Hellblazer/nexus/releases/latest"
+_PYPI_URL = "https://pypi.org/pypi/conexus/json"
+_TIMEOUT_SECONDS = 3.0
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Cheap PEP 440 numeric prefix extract: '5.0.1.dev0' -> (5, 0, 1)."""
+    parts: list[int] = []
+    for chunk in v.split("."):
+        digits = ""
+        for c in chunk:
+            if c.isdigit():
+                digits += c
+            else:
+                break
+        if not digits:
+            break
+        parts.append(int(digits))
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts[:3])
+
+
+def _check_stale_install() -> None:
+    """Best-effort: warn to stderr if conexus is behind PyPI's latest.
+
+    Silent on network failure, timeout, missing package metadata, or
+    when the installed version is current. Costs one ~3s HTTPS GET.
+    """
+    if os.environ.get("NX_MCPB_SKIP_UPDATE_CHECK"):
+        return
+
+    try:
+        installed = _pkg_version("conexus")
+    except PackageNotFoundError:
+        return  # editable / unusual install layout; skip silently
+
+    try:
+        import json
+        import urllib.error
+        import urllib.request
+
+        req = urllib.request.Request(
+            _PYPI_URL,
+            headers={"User-Agent": f"conexus-mcpb/{installed}"},
+        )
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:
+            latest = json.loads(resp.read().decode("utf-8"))["info"]["version"]
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, KeyError, TimeoutError):
+        return  # offline / PyPI hiccup; skip silently
+
+    if _parse_version(installed) >= _parse_version(latest):
+        return  # current or ahead (dev install); no warning
+
+    msg = (
+        f"[conexus-mcpb] installed conexus={installed}, latest on PyPI={latest}. "
+        f"Re-download the .mcpb from {_RELEASE_URL} and re-install in Claude "
+        "Desktop to upgrade. (Set NX_MCPB_SKIP_UPDATE_CHECK=1 to silence.)"
+    )
+    print(msg, file=sys.stderr, flush=True)
+
 
 def main() -> None:
+    _check_stale_install()
     from nexus.mcp.core import main as _nx_mcp_main
     _nx_mcp_main()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.0.1"
+version = "5.0.2"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/db/t2/aspect_extraction_queue.py
+++ b/src/nexus/db/t2/aspect_extraction_queue.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 
 import sqlite3
 import threading
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -150,7 +151,15 @@ class AspectExtractionQueue:
     def __init__(self, path: Path) -> None:
         self._lock = threading.Lock()
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
-        self.conn.execute("PRAGMA busy_timeout=5000")
+        # nexus-v4m7y: bumped from 5s to 30s. Nine T2 stores hold their own
+        # sqlite3.Connection against memory.db. Under WAL mode, only one
+        # writer is allowed across all connections; busy_timeout governs
+        # how long this connection waits before raising ERROR_BUSY. 5s was
+        # tight enough that a long memory_put (or any other store's write)
+        # could push reclaim_stale past the limit and surface "database is
+        # locked" warnings. 30s costs nothing on quiet systems and absorbs
+        # the realistic intra-daemon contention window.
+        self.conn.execute("PRAGMA busy_timeout=30000")
         self._init_schema()
 
     def close(self) -> None:
@@ -433,6 +442,17 @@ class AspectExtractionQueue:
             )
             self.conn.commit()
 
+    # nexus-v4m7y: retry-with-backoff for reclaim_stale. Three attempts
+    # with two inter-attempt sleeps (0.1s, 0.5s) on top of the 30s
+    # per-attempt SQLite busy_timeout. Absorbs transient writer-slot
+    # contention that would otherwise leak as ERROR_BUSY.
+    # Total worst-case wait if every attempt hits a locked writer:
+    # 30 + 0.1 + 30 + 0.5 + 30 = ~90.6 s. Acceptable for a background
+    # reclaim that runs every N polls. The final attempt still raises
+    # if it cannot acquire, so the existing aspect_worker_claim_failed
+    # warning surfaces in the truly-stuck case.
+    _RECLAIM_RETRY_SLEEPS_BETWEEN: tuple[float, ...] = (0.1, 0.5)
+
     def reclaim_stale(self, timeout_seconds: int = 300) -> int:
         """Reset ``in_progress`` rows whose ``last_attempt_at`` is older
         than the timeout back to ``pending``.
@@ -444,6 +464,10 @@ class AspectExtractionQueue:
 
         Returns the number of rows reclaimed.
 
+        Retries up to 3 attempts on ``database is locked`` to absorb
+        transient WAL writer-slot contention with other T2 stores in
+        the same daemon process. See ``_RECLAIM_RETRY_BACKOFF_SECONDS``.
+
         ``last_attempt_at`` is wrapped in ``datetime()`` to normalize
         the comparison: production writes ISO 8601 with ``T`` separator
         and ``+00:00`` suffix (``datetime.now(UTC).isoformat()``), while
@@ -453,15 +477,44 @@ class AspectExtractionQueue:
         regardless of staleness.
         """
         cutoff_clause = f"datetime('now', '-{int(timeout_seconds)} seconds')"
-        with self._lock:
-            cur = self.conn.execute(
-                "UPDATE aspect_extraction_queue "
-                "SET status = 'pending', last_attempt_at = NULL "
-                "WHERE status = 'in_progress' "
-                f"  AND datetime(last_attempt_at) < {cutoff_clause}",
-            )
-            self.conn.commit()
-            return cur.rowcount
+        sleeps_between = self._RECLAIM_RETRY_SLEEPS_BETWEEN
+        max_attempts = len(sleeps_between) + 1
+        for attempt in range(1, max_attempts + 1):
+            try:
+                with self._lock:
+                    cur = self.conn.execute(
+                        "UPDATE aspect_extraction_queue "
+                        "SET status = 'pending', last_attempt_at = NULL "
+                        "WHERE status = 'in_progress' "
+                        f"  AND datetime(last_attempt_at) < {cutoff_clause}",
+                    )
+                    self.conn.commit()
+                    if attempt > 1:
+                        _log.debug(
+                            "aspect_queue_reclaim_stale_recovered",
+                            attempt=attempt,
+                            rowcount=cur.rowcount,
+                        )
+                    return cur.rowcount
+            except sqlite3.OperationalError as exc:
+                # Only retry on writer-slot contention. Anything else
+                # (schema corruption, FK violation, etc.) propagates
+                # immediately.
+                if "locked" not in str(exc).lower():
+                    raise
+                if attempt == max_attempts:
+                    raise
+                sleep_seconds = sleeps_between[attempt - 1]
+                _log.debug(
+                    "aspect_queue_reclaim_stale_retry",
+                    attempt=attempt,
+                    next_sleep_seconds=sleep_seconds,
+                    exc=str(exc),
+                )
+                time.sleep(sleep_seconds)
+        raise RuntimeError(  # pragma: no cover
+            "reclaim_stale exhausted retries unexpectedly"
+        )
 
     def pending_count(self) -> int:
         """Return the number of rows currently in ``pending`` status."""

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -866,14 +866,14 @@ def _check_plugin_name() -> list[HealthResult]:
     differs from what the CLI expects.
 
     The 2026-05-23 rename moved the plugin name from ``nx`` to
-    ``conexus``. Until the user runs ``/reload-plugins`` in Claude
-    Code (which re-reads marketplace.json and reconciles the rename
-    in place), they may continue running the NEW conexus CLI under
-    the OLD ``nx`` plugin install at
-    ``~/.claude/plugins/cache/nexus-plugins/nx/...``. The MCP-server-
-    startup check fires once per session; this doctor check is the
-    explicit-invocation surface for users who run ``nx doctor`` to
-    diagnose what's stale.
+    ``conexus``. Migration is two Claude Code commands: ``/plugin
+    install conexus@nexus-plugins`` to register the new plugin,
+    then ``/reload-plugins`` to activate it. Until both run, the
+    user is running the NEW conexus CLI under the OLD ``nx`` plugin
+    install at ``~/.claude/plugins/cache/nexus-plugins/nx/...``.
+    The MCP-server-startup check fires once per session; this
+    doctor check is the explicit-invocation surface for users who
+    run ``nx doctor`` to diagnose what's stale.
 
     Non-fatal. Returns an empty list when no ``CLAUDE_PLUGIN_ROOT``
     is set (CLI-only use; nothing to check) or when the plugin name
@@ -907,8 +907,9 @@ def _check_plugin_name() -> list[HealthResult]:
                 "(renamed 2026-05-23, nexus-mkj6u)"
             ),
             fix_suggestions=[
+                "/plugin install conexus@nexus-plugins",
                 "/reload-plugins",
-                "(run in Claude Code; the marketplace reconciles the rename in place — no uninstall + install needed)",
+                "(both run in Claude Code; install registers the new plugin, reload activates it)",
             ],
             fatal=False,
         )

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -866,14 +866,14 @@ def _check_plugin_name() -> list[HealthResult]:
     differs from what the CLI expects.
 
     The 2026-05-23 rename moved the plugin name from ``nx`` to
-    ``conexus``. Claude Code does NOT auto-uninstall renamed plugins;
-    a user's local cache at
-    ``~/.claude/plugins/cache/nexus-plugins/nx/...`` survives the
-    marketplace.json rename. Until they explicitly uninstall +
-    reinstall, they run the NEW conexus CLI under the OLD ``nx``
-    plugin. The MCP-server-startup check fires once per session;
-    this doctor check is the explicit-invocation surface for users
-    who run ``nx doctor`` to diagnose what's stale.
+    ``conexus``. Until the user runs ``/reload-plugins`` in Claude
+    Code (which re-reads marketplace.json and reconciles the rename
+    in place), they may continue running the NEW conexus CLI under
+    the OLD ``nx`` plugin install at
+    ``~/.claude/plugins/cache/nexus-plugins/nx/...``. The MCP-server-
+    startup check fires once per session; this doctor check is the
+    explicit-invocation surface for users who run ``nx doctor`` to
+    diagnose what's stale.
 
     Non-fatal. Returns an empty list when no ``CLAUDE_PLUGIN_ROOT``
     is set (CLI-only use; nothing to check) or when the plugin name
@@ -907,9 +907,8 @@ def _check_plugin_name() -> list[HealthResult]:
                 "(renamed 2026-05-23, nexus-mkj6u)"
             ),
             fix_suggestions=[
-                f"/plugin uninstall {plugin_name}@nexus-plugins",
-                f"/plugin install {EXPECTED_PLUGIN_NAME}@nexus-plugins",
-                "(both commands run in Claude Code, not from the shell)",
+                "/reload-plugins",
+                "(run in Claude Code; the marketplace reconciles the rename in place — no uninstall + install needed)",
             ],
             fatal=False,
         )

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -158,6 +158,7 @@ async def _t1_chroma_lifespan(_app: Any):
         start_t1_server,
         sweep_orphan_resource_trackers,
         sweep_orphan_t1_addr_files,
+        sweep_orphan_t1_chromadbs,
         sweep_orphan_tmpdirs,
     )
 
@@ -189,6 +190,19 @@ async def _t1_chroma_lifespan(_app: Any):
     except Exception as exc:
         _sweep_log.debug(
             "sweep_orphan_resource_trackers_failed", error=str(exc)
+        )
+    # (d) orphan T1 chromadb servers (nexus-aigkb). When a Claude
+    # Code session exits ungracefully (SIGKILL, crash, lost
+    # SessionEnd hook), its per-session chromadb is re-parented to
+    # launchd and runs indefinitely, holding a TCP port and tmpdir.
+    # sweep_orphan_tmpdirs reaps the dirs only after 24h; this
+    # sweeps the processes immediately so the next start_t1_server
+    # has a clean slate.
+    try:
+        sweep_orphan_t1_chromadbs()
+    except Exception as exc:
+        _sweep_log.debug(
+            "sweep_orphan_t1_chromadbs_failed", error=str(exc)
         )
 
     # Reset the ``_SHUTDOWN_IN_FLIGHT`` sentinel BEFORE

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -671,13 +671,17 @@ def check_version_compatibility() -> None:
 
             # ── (3) Plugin NAME drift (nexus-mkj6u) ─────────────────────
             # The 2026-05-23 rename moved the plugin name from ``nx`` to
-            # ``conexus``. Running ``/reload-plugins`` in Claude Code
-            # picks up the marketplace.json change and reconciles the
-            # rename in place — no explicit uninstall + install needed.
-            # Until the user reloads, the local cache at
+            # ``conexus``. Migration requires TWO Claude Code commands:
+            # ``/plugin install conexus@nexus-plugins`` to register the
+            # new plugin, then ``/reload-plugins`` to activate it.
+            # Until both run, the local cache at
             # ``~/.claude/plugins/cache/nexus-plugins/nx/...`` continues
             # to back the OLD nx plugin name; the user is running the
-            # NEW conexus CLI under that stale install.
+            # NEW conexus CLI under that stale install. The earlier
+            # nexus-v4m7y-adjacent guidance that ``/reload-plugins``
+            # alone suffices was wrong — empirically confirmed when a
+            # user on a fresh shell ran reload and saw no effect until
+            # the explicit install ran.
             #
             # Fire this warning EVERY MCP startup until resolved. It is
             # the most reliable surface to catch the gap because every
@@ -690,7 +694,9 @@ def check_version_compatibility() -> None:
                     hint=(
                         f"Plugin was renamed '{plugin_name}' -> "
                         f"'{EXPECTED_PLUGIN_NAME}' (nexus-mkj6u). In "
-                        f"Claude Code, run: /reload-plugins"
+                        f"Claude Code, run: /plugin install "
+                        f"{EXPECTED_PLUGIN_NAME}@nexus-plugins "
+                        "&& /reload-plugins"
                     ),
                 )
 

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -671,13 +671,13 @@ def check_version_compatibility() -> None:
 
             # ── (3) Plugin NAME drift (nexus-mkj6u) ─────────────────────
             # The 2026-05-23 rename moved the plugin name from ``nx`` to
-            # ``conexus``. Claude Code does NOT auto-uninstall renamed
-            # plugins; the user's local cache at
-            # ``~/.claude/plugins/cache/nexus-plugins/nx/...`` survives
-            # the marketplace.json rename until the user explicitly
-            # uninstalls + reinstalls. Until then, they're running the
-            # NEW conexus CLI but the OLD nx plugin — silently sliding
-            # toward whatever drift the rename introduced.
+            # ``conexus``. Running ``/reload-plugins`` in Claude Code
+            # picks up the marketplace.json change and reconciles the
+            # rename in place — no explicit uninstall + install needed.
+            # Until the user reloads, the local cache at
+            # ``~/.claude/plugins/cache/nexus-plugins/nx/...`` continues
+            # to back the OLD nx plugin name; the user is running the
+            # NEW conexus CLI under that stale install.
             #
             # Fire this warning EVERY MCP startup until resolved. It is
             # the most reliable surface to catch the gap because every
@@ -690,9 +690,7 @@ def check_version_compatibility() -> None:
                     hint=(
                         f"Plugin was renamed '{plugin_name}' -> "
                         f"'{EXPECTED_PLUGIN_NAME}' (nexus-mkj6u). In "
-                        f"Claude Code, run: /plugin uninstall "
-                        f"{plugin_name}@nexus-plugins && /plugin install "
-                        f"{EXPECTED_PLUGIN_NAME}@nexus-plugins"
+                        f"Claude Code, run: /reload-plugins"
                     ),
                 )
 

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -404,6 +404,108 @@ def sweep_orphan_resource_trackers(
     return signalled
 
 
+def _parse_orphan_t1_chromadb_candidates(
+    ps_output: str,
+    *,
+    min_age_seconds: float = 60.0,
+    protected_pids: set[int] | None = None,
+) -> list[int]:
+    """Parse ``ps -eo pid,ppid,etime,command`` and return PIDs of
+    orphan T1 chromadb servers safe to reap (nexus-aigkb).
+
+    A row is included iff every condition holds:
+
+    * ``ppid == 1`` (re-parented to init; originating Claude Code
+      session is dead).
+    * ``command`` contains BOTH ``chroma run`` AND ``nx_t1_``
+      (chromadb spawned by :func:`start_t1_server`; the
+      ``nx_t1_`` prefix carries the entropy that prevents
+      false positives against unrelated chromadb instances).
+    * Process age >= *min_age_seconds* (avoids racing
+      in-flight T1 spawns whose parent has not yet attached).
+    * ``pid not in protected_pids`` (escape hatch for tests).
+
+    Pure function. Returns the list in the order ``ps`` emitted.
+    """
+    protected = protected_pids or set()
+    out: list[int] = []
+    for line in ps_output.splitlines():
+        s = line.strip()
+        if not s or not s[0].isdigit():
+            continue
+        parts = s.split(None, 3)
+        if len(parts) < 4:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        if ppid != 1:
+            continue
+        if pid in protected:
+            continue
+        # Require BOTH markers — defence in depth against matching
+        # an unrelated user-managed chromadb.
+        cmd = parts[3]
+        if "chroma run" not in cmd or "nx_t1_" not in cmd:
+            continue
+        age = _parse_etime_seconds(parts[2])
+        if age is None or age < min_age_seconds:
+            continue
+        out.append(pid)
+    return out
+
+
+def sweep_orphan_t1_chromadbs(
+    *,
+    min_age_seconds: float = 60.0,
+    protected_pids: set[int] | None = None,
+) -> int:
+    """Reap orphan T1 chromadb servers re-parented to init (nexus-aigkb).
+
+    Each ungraceful Claude Code session exit (SIGKILL, OOM, lost
+    SessionEnd hook) leaves the per-session chromadb running with
+    its PPID re-parented to launchd / init (pid 1). The chromadb
+    keeps holding its TCP port, file descriptors, and tmpdir
+    indefinitely. :func:`sweep_orphan_tmpdirs` reaps the dirs only
+    after 24h and only by mtime; this sweep reaps the actual
+    processes immediately so the next SessionStart starts clean.
+
+    Sends SIGTERM (graceful), escalates to SIGKILL after 3 s. The
+    helper :func:`_kill_orphan_tracker_pids` is reused.
+
+    Returns the count signalled. Best-effort; failures are logged
+    at debug and never block startup. Companion to
+    :func:`sweep_orphan_resource_trackers`.
+    """
+    try:
+        ps_output = subprocess.check_output(
+            ["ps", "-eo", "pid,ppid,etime,command"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+        _log.debug("sweep_orphan_t1_chromadbs_ps_failed", error=str(exc))
+        return 0
+
+    candidates = _parse_orphan_t1_chromadb_candidates(
+        ps_output,
+        min_age_seconds=min_age_seconds,
+        protected_pids=protected_pids,
+    )
+    if not candidates:
+        return 0
+
+    signalled = _kill_orphan_tracker_pids(candidates)
+    _log.info(
+        "sweep_orphan_t1_chromadbs_reaped",
+        count=signalled,
+        candidates=len(candidates),
+    )
+    return signalled
+
+
 def _kill_orphan_tracker_pids(
     pids: list[int],
     *,

--- a/tests/e2e/upgrade-shakeout.sh
+++ b/tests/e2e/upgrade-shakeout.sh
@@ -220,11 +220,9 @@ PJEOF
 DOCTOR_OUT="$(CLAUDE_PLUGIN_ROOT="$FAKE_PLUGIN_ROOT" HOME="$SANDBOX" nx doctor 2>&1 || true)"
 echo "$DOCTOR_OUT" | grep -qi 'plugin name' \
     || _die "nx doctor did not surface plugin-name drift. Output:\n$DOCTOR_OUT"
-echo "$DOCTOR_OUT" | grep -q '/plugin uninstall nx@nexus-plugins' \
-    || _die "doctor warning missing uninstall command"
-echo "$DOCTOR_OUT" | grep -q '/plugin install conexus@nexus-plugins' \
-    || _die "doctor warning missing install command"
-_pass "nx doctor names the uninstall + install commands"
+echo "$DOCTOR_OUT" | grep -q '/reload-plugins' \
+    || _die "doctor warning missing /reload-plugins hint"
+_pass "nx doctor names the /reload-plugins migration command"
 # (The structlog warning at every MCP startup is covered by unit test
 # tests/test_plugin_name_drift.py::test_check_version_compatibility_logs_plugin_name_mismatch
 # — easier to assert there than to spawn nx-mcp + watch stderr here.)

--- a/tests/e2e/upgrade-shakeout.sh
+++ b/tests/e2e/upgrade-shakeout.sh
@@ -220,9 +220,11 @@ PJEOF
 DOCTOR_OUT="$(CLAUDE_PLUGIN_ROOT="$FAKE_PLUGIN_ROOT" HOME="$SANDBOX" nx doctor 2>&1 || true)"
 echo "$DOCTOR_OUT" | grep -qi 'plugin name' \
     || _die "nx doctor did not surface plugin-name drift. Output:\n$DOCTOR_OUT"
+echo "$DOCTOR_OUT" | grep -q '/plugin install conexus@nexus-plugins' \
+    || _die "doctor warning missing /plugin install hint"
 echo "$DOCTOR_OUT" | grep -q '/reload-plugins' \
     || _die "doctor warning missing /reload-plugins hint"
-_pass "nx doctor names the /reload-plugins migration command"
+_pass "nx doctor names both /plugin install and /reload-plugins migration commands"
 # (The structlog warning at every MCP startup is covered by unit test
 # tests/test_plugin_name_drift.py::test_check_version_compatibility_logs_plugin_name_mismatch
 # — easier to assert there than to spawn nx-mcp + watch stderr here.)

--- a/tests/test_aspect_extraction_queue.py
+++ b/tests/test_aspect_extraction_queue.py
@@ -424,6 +424,157 @@ class TestReclaimStale:
         assert row[0] == "pending"
         assert row[1] is None
 
+    def test_reclaim_stale_busy_timeout_is_30s(self, tmp_path: Path) -> None:
+        """nexus-v4m7y: busy_timeout was bumped from 5s to 30s so the
+        connection waits longer for the WAL writer slot before raising
+        ERROR_BUSY. Nine T2 stores hold their own sqlite3.Connection
+        against memory.db; 5s was tight under intra-daemon contention.
+        """
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        try:
+            row = store.conn.execute("PRAGMA busy_timeout").fetchone()
+        finally:
+            store.close()
+        assert row[0] == 30000, (
+            f"busy_timeout should be 30000 ms (was 5000); got {row[0]}"
+        )
+
+    def test_reclaim_stale_retries_on_locked_then_succeeds(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """nexus-v4m7y: on top of the 30s SQLite busy_timeout, reclaim_stale
+        retries up to 3 attempts on ``database is locked``. Simulates two
+        transient locks via a connection proxy, then verifies the third
+        attempt succeeds and returns the expected rowcount."""
+        import sqlite3
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        # Shorten the retry sleeps so the test doesn't take ~0.6s real time.
+        monkeypatch.setattr(
+            AspectExtractionQueue,
+            "_RECLAIM_RETRY_SLEEPS_BETWEEN",
+            (0.0, 0.0),
+        )
+
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        try:
+            store.enqueue("knowledge__delos", "/p1.pdf")
+            store.claim_next()
+            store.conn.execute(
+                "UPDATE aspect_extraction_queue "
+                "SET last_attempt_at = datetime('now', '-10 minutes')"
+            )
+            store.conn.commit()
+
+            real_conn = store.conn
+            calls = {"n": 0}
+
+            class FlakyConn:
+                def execute(self, sql, *args, **kwargs):  # noqa: ANN001
+                    if sql.lstrip().upper().startswith("UPDATE ASPECT_EXTRACTION_QUEUE"):
+                        calls["n"] += 1
+                        if calls["n"] <= 2:
+                            raise sqlite3.OperationalError("database is locked")
+                    return real_conn.execute(sql, *args, **kwargs)
+
+                def commit(self):
+                    return real_conn.commit()
+
+                def __getattr__(self, name):
+                    return getattr(real_conn, name)
+
+            store.conn = FlakyConn()  # type: ignore[assignment]
+            reclaimed = store.reclaim_stale(timeout_seconds=60)
+            store.conn = real_conn  # type: ignore[assignment]
+        finally:
+            store.close()
+        assert calls["n"] == 3, (
+            f"expected 3 UPDATE attempts (2 simulated locks + 1 success); "
+            f"got {calls['n']}"
+        )
+        assert reclaimed == 1, (
+            f"third attempt should reclaim the stale row; got {reclaimed}"
+        )
+
+    def test_reclaim_stale_raises_after_exhausted_retries(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """nexus-v4m7y: when every retry still hits ``database is locked``,
+        the final attempt re-raises so the existing aspect_worker
+        warning surfaces in the truly-stuck case."""
+        import sqlite3
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        monkeypatch.setattr(
+            AspectExtractionQueue,
+            "_RECLAIM_RETRY_SLEEPS_BETWEEN",
+            (0.0, 0.0),
+        )
+
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        try:
+            real_conn = store.conn
+
+            class AlwaysLockedConn:
+                def execute(self, sql, *args, **kwargs):  # noqa: ANN001
+                    if sql.lstrip().upper().startswith("UPDATE ASPECT_EXTRACTION_QUEUE"):
+                        raise sqlite3.OperationalError("database is locked")
+                    return real_conn.execute(sql, *args, **kwargs)
+
+                def commit(self):
+                    return real_conn.commit()
+
+                def __getattr__(self, name):
+                    return getattr(real_conn, name)
+
+            store.conn = AlwaysLockedConn()  # type: ignore[assignment]
+            import pytest as _pytest
+            with _pytest.raises(sqlite3.OperationalError, match="locked"):
+                store.reclaim_stale(timeout_seconds=60)
+            store.conn = real_conn  # type: ignore[assignment]
+        finally:
+            store.close()
+
+    def test_reclaim_stale_propagates_non_lock_operational_errors(
+        self, tmp_path: Path,
+    ) -> None:
+        """nexus-v4m7y: only "database is locked" is retried. Other
+        OperationalErrors (schema corruption, syntax, etc.) propagate
+        immediately on the first attempt — we never retry around them."""
+        import sqlite3
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        try:
+            real_conn = store.conn
+            calls = {"n": 0}
+
+            class SyntaxErrConn:
+                def execute(self, sql, *args, **kwargs):  # noqa: ANN001
+                    if sql.lstrip().upper().startswith("UPDATE ASPECT_EXTRACTION_QUEUE"):
+                        calls["n"] += 1
+                        raise sqlite3.OperationalError("syntax error near 'oops'")
+                    return real_conn.execute(sql, *args, **kwargs)
+
+                def commit(self):
+                    return real_conn.commit()
+
+                def __getattr__(self, name):
+                    return getattr(real_conn, name)
+
+            store.conn = SyntaxErrConn()  # type: ignore[assignment]
+            import pytest as _pytest
+            with _pytest.raises(sqlite3.OperationalError, match="syntax"):
+                store.reclaim_stale(timeout_seconds=60)
+            store.conn = real_conn  # type: ignore[assignment]
+        finally:
+            store.close()
+        assert calls["n"] == 1, (
+            f"non-lock errors should not retry; expected 1 attempt, got {calls['n']}"
+        )
+
 
 # ── Pending count + listing ──────────────────────────────────────────────────
 

--- a/tests/test_plugin_name_drift.py
+++ b/tests/test_plugin_name_drift.py
@@ -40,7 +40,7 @@ def _plant_plugin_manifest(tmp_path: Path, name: str, version: str = "4.34.5") -
 
 def test_check_plugin_name_warns_on_old_nx(monkeypatch, tmp_path):
     """An installed ``nx`` plugin against the conexus-expecting CLI fires
-    a non-fatal warning naming the uninstall/install commands."""
+    a non-fatal warning telling the user to run /reload-plugins."""
     plugin_root = _plant_plugin_manifest(tmp_path, name="nx")
     monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
 
@@ -53,8 +53,7 @@ def test_check_plugin_name_warns_on_old_nx(monkeypatch, tmp_path):
     assert r.fatal is False
     assert "nx@nexus-plugins" in r.detail or "renamed" in r.detail
     suggestions = " ".join(r.fix_suggestions)
-    assert "/plugin uninstall nx@nexus-plugins" in suggestions
-    assert "/plugin install conexus@nexus-plugins" in suggestions
+    assert "/reload-plugins" in suggestions
 
 
 def test_check_plugin_name_silent_when_conexus_installed(monkeypatch, tmp_path):
@@ -109,8 +108,7 @@ def test_check_version_compatibility_logs_plugin_name_mismatch(monkeypatch, tmp_
         f"expected plugin_name_mismatch warning in stdout/stderr; got: {captured!r}"
     )
     # Actionable hint surfaces
-    assert "/plugin uninstall nx@nexus-plugins" in captured
-    assert "/plugin install conexus@nexus-plugins" in captured
+    assert "/reload-plugins" in captured
 
 
 def test_check_version_compatibility_silent_when_name_matches(monkeypatch, tmp_path, capsys):

--- a/tests/test_plugin_name_drift.py
+++ b/tests/test_plugin_name_drift.py
@@ -40,7 +40,7 @@ def _plant_plugin_manifest(tmp_path: Path, name: str, version: str = "4.34.5") -
 
 def test_check_plugin_name_warns_on_old_nx(monkeypatch, tmp_path):
     """An installed ``nx`` plugin against the conexus-expecting CLI fires
-    a non-fatal warning telling the user to run /reload-plugins."""
+    a non-fatal warning naming both /plugin install and /reload-plugins."""
     plugin_root = _plant_plugin_manifest(tmp_path, name="nx")
     monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
 
@@ -53,6 +53,7 @@ def test_check_plugin_name_warns_on_old_nx(monkeypatch, tmp_path):
     assert r.fatal is False
     assert "nx@nexus-plugins" in r.detail or "renamed" in r.detail
     suggestions = " ".join(r.fix_suggestions)
+    assert "/plugin install conexus@nexus-plugins" in suggestions
     assert "/reload-plugins" in suggestions
 
 
@@ -107,7 +108,8 @@ def test_check_version_compatibility_logs_plugin_name_mismatch(monkeypatch, tmp_
     assert "plugin_name_mismatch" in captured, (
         f"expected plugin_name_mismatch warning in stdout/stderr; got: {captured!r}"
     )
-    # Actionable hint surfaces
+    # Actionable hint names BOTH commands: install registers, reload activates.
+    assert "/plugin install conexus@nexus-plugins" in captured
     assert "/reload-plugins" in captured
 
 

--- a/tests/test_session_sweep_orphan_t1_chromadbs.py
+++ b/tests/test_session_sweep_orphan_t1_chromadbs.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for nexus.session.sweep_orphan_t1_chromadbs (issue nexus-aigkb).
+
+Each ungraceful Claude Code session exit (SIGKILL, crash, lost
+SessionEnd hook) leaves the per-session T1 chromadb server
+re-parented to launchd / init (pid 1). The chromadb keeps holding a
+TCP port, file descriptors, and a tmpdir indefinitely.
+
+Live observation 2026-05-24: 5 orphan chromadbs accumulated over 3
+days of normal Claude Code use, parented to launchd. Each had been
+running 1-3 days post-session-exit.
+
+The parallel sweep ``sweep_orphan_resource_trackers`` reaps
+multiprocessing tracker children; this one reaps the chromadb
+parent itself. Both run at MCP top-level startup so the next
+start_t1_server has a clean slate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Parser tests (pure function, no subprocess).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestParseOrphanT1ChromadbCandidates:
+    """Validate _parse_orphan_t1_chromadb_candidates."""
+
+    def test_parses_orphan_chromadb_line(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       12:34 /path/to/python /path/to/chroma run "
+            "--host 127.0.0.1 --port 49994 --path /tmp/nx_t1_abcd1234\n"
+        )
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == [211]
+
+    def test_skips_chromadb_with_live_parent(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211   555       12:34 /path/to/chroma run --port 49994 "
+            "--path /tmp/nx_t1_abcd1234\n"
+        )
+        # PPID != 1 → still owned by a live Claude Code session
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == []
+
+    def test_skips_chromadb_without_nx_t1_marker(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       12:34 /path/to/chroma run --port 49994 "
+            "--path /home/user/my-project/.chroma\n"
+        )
+        # No nx_t1_ marker → user's own chromadb, off-limits
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == []
+
+    def test_skips_non_chromadb_orphans(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       12:34 /path/to/python -m my_other_service "
+            "--data /tmp/nx_t1_abcd\n"
+        )
+        # Has nx_t1_ marker but not "chroma run" → not ours
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == []
+
+    def test_age_threshold_excludes_in_flight_spawn(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       00:05 /path/to/chroma run --port 49994 "
+            "--path /tmp/nx_t1_abcd1234\n"
+        )
+        # 5s old; default min_age 60s → skip (could be a racing spawn)
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == []
+
+    def test_protected_pids_honored(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       12:34 /path/to/chroma run --port 49994 "
+            "--path /tmp/nx_t1_abcd1234\n"
+        )
+        assert _parse_orphan_t1_chromadb_candidates(
+            ps_output, protected_pids={211}
+        ) == []
+
+    def test_multi_day_etime_parses(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1   03-21:36:36 /path/to/chroma run --port 49994 "
+            "--path /tmp/nx_t1_abcd1234\n"
+        )
+        # 3d 21h+ old; well past the 60s threshold
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == [211]
+
+    def test_handles_empty_input(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        assert _parse_orphan_t1_chromadb_candidates("") == []
+        assert _parse_orphan_t1_chromadb_candidates(
+            "  PID  PPID     ELAPSED COMMAND\n"
+        ) == []
+
+    def test_skips_malformed_lines(self):
+        from nexus.session import _parse_orphan_t1_chromadb_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "garbage line with no pid\n"
+            "  211     1       12:34 /path/to/chroma run --port 49994 --path /tmp/nx_t1_abcd1234\n"
+            "  not-a-pid     1       12:34 chroma run nx_t1_other\n"
+        )
+        # Only the well-formed orphan line is returned
+        assert _parse_orphan_t1_chromadb_candidates(ps_output) == [211]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sweep-level tests (mocks the ps subprocess and _kill_orphan_tracker_pids).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSweepOrphanT1Chromadbs:
+    """Validate sweep_orphan_t1_chromadbs end-to-end with mocked subprocess."""
+
+    def test_sweep_signals_orphans(self, monkeypatch):
+        import nexus.session as session
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       12:34 chroma run --port 49994 --path /tmp/nx_t1_abcd1234\n"
+            "  212     1       12:34 chroma run --port 49995 --path /tmp/nx_t1_efgh5678\n"
+        )
+
+        monkeypatch.setattr(
+            session.subprocess,
+            "check_output",
+            lambda *a, **kw: ps_output,
+        )
+
+        signalled_pids: list[int] = []
+
+        def fake_kill(pids, **kwargs):
+            signalled_pids.extend(pids)
+            return len(pids)
+
+        monkeypatch.setattr(session, "_kill_orphan_tracker_pids", fake_kill)
+
+        result = session.sweep_orphan_t1_chromadbs()
+        assert result == 2
+        assert signalled_pids == [211, 212]
+
+    def test_sweep_skips_when_no_orphans(self, monkeypatch):
+        import nexus.session as session
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211   555       12:34 chroma run --port 49994 --path /tmp/nx_t1_abcd1234\n"
+        )
+        monkeypatch.setattr(
+            session.subprocess, "check_output", lambda *a, **kw: ps_output,
+        )
+
+        def must_not_be_called(*a, **kw):
+            pytest.fail("_kill_orphan_tracker_pids should not be called when no orphans")
+
+        monkeypatch.setattr(
+            session, "_kill_orphan_tracker_pids", must_not_be_called
+        )
+
+        assert session.sweep_orphan_t1_chromadbs() == 0
+
+    def test_sweep_swallows_ps_failure(self, monkeypatch):
+        import nexus.session as session
+        import subprocess
+
+        def failing_ps(*a, **kw):
+            raise subprocess.CalledProcessError(1, "ps")
+
+        monkeypatch.setattr(session.subprocess, "check_output", failing_ps)
+        # Should return 0, not raise — failures must never block startup
+        assert session.sweep_orphan_t1_chromadbs() == 0

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.0.1"
+version = "5.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Promotes develop to main and bumps conexus 5.0.1 → 5.0.2. Post-shakeout follow-ups to the 5.0.x line. No schema changes; safe in-place upgrade from 5.0.1.

### Changes since v5.0.1

- **fix(t1)**: sweep orphan T1 chromadb servers at MCP startup (nexus-aigkb). Leaked session-scoped T1 chromas from crashed/SIGKILLed MCP processes are now terminated at next startup.
- **fix(t2)**: aspect_queue `reclaim_stale` tolerance under WAL contention (nexus-v4m7y). `busy_timeout` 5s→30s + 3-attempt retry on `database is locked`.
- **feat(mcpb)**: stale-install warning at `.mcpb` server startup. Best-effort PyPI version check (MCPB v0.4 has no auto-update), non-fatal, opt-out via `NX_MCPB_SKIP_UPDATE_CHECK=1`.
- **fix(drift)**: plugin-rename hint now requires BOTH `/plugin install conexus@nexus-plugins` AND `/reload-plugins` (reload alone was insufficient on a fresh shell).
- **docs**: README "Start here" + blog pointers restored; `docs/desktop-deployment.md` documents the MCPB stale-install check; blog publish helpers tracked in git.

### Manifest bumps (all 7, CI parity-enforced)

`pyproject.toml`, `mcpb/pyproject.toml` (+ `conexus>=5.0.2`), `mcpb/manifest.json`, `.claude-plugin/marketplace.json` (both `version` + both `source.ref` → `v5.0.2`), `conexus/.claude-plugin/plugin.json`, `sn/.claude-plugin/plugin.json`. `uv.lock` refreshed.

## Test plan

- [x] Unit suite: 7588 passed, 34 skipped, 0 failed (11:08)
- [x] Integration suite: 77 passed; 7 pre-existing failures isolated to absent local corpora (`knowledge__delos`, `knowledge__hybridrag`), confirmed not regressions (filed nexus-gudwb to add corpus-presence skip-guards)
- [x] Sandbox smoke: `[done]`, CLI reports v5.0.2, all doctor checks pass
- [x] Pre-push parity: all 7 manifests + both refs read 5.0.2 / v5.0.2

