### PR TITLE
fix(daemon): T2 daemon observability + stale-state detection (nexus-n8sbw)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fix: T2 daemon observability + stale-state detection (nexus-n8sbw)
+
+The T2 daemon was spawned with stdout/stderr routed to `DEVNULL` and had
+no structlog file sink, so a crash or signal-kill left no record (a
+0-byte `daemon.log`) and the cause was undiagnosable. Three fixes:
+
+- `run_t2_daemon` now routes the daemon's structlog events to a rotating
+  file at `<config_dir>/logs/t2_daemon.log` via `configure_logging`, with
+  an asyncio loop exception handler and a last-resort crash logger. A
+  graceful stop leaves a `t2_daemon_stop_requested` breadcrumb; a death
+  without the matching `t2_daemon_stopped` is now diagnosable.
+- `nx daemon t2 status` probes the recorded pid for liveness and reports
+  a stale discovery file (dead pid) as `STALE` with a non-zero exit,
+  instead of printing it as if the daemon were running.
+- `python -m nexus.cli` now invokes the CLI (added the `__main__` guard).
+  This is the fallback argv `_resolve_nx_bin` emits when the `nx` console
+  script is not on PATH; without the guard that fallback ran nothing and
+  exited 0, so daemon autostart could silently never start.
+
 ## [5.0.2] - 2026-05-24
 
 Post-shakeout follow-ups to the 5.0.x line. No schema changes; safe in-place upgrade from 5.0.1.

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -111,3 +111,12 @@ main.add_command(taxonomy)
 main.add_command(tier_status_cmd, name="tier-status")
 main.add_command(aspects_group, name="aspects")
 main.add_command(upgrade)
+
+
+if __name__ == "__main__":
+    # Enables ``python -m nexus.cli``, the fallback argv that
+    # ``nexus.commands.daemon._resolve_nx_bin`` emits when the ``nx``
+    # console script is not on PATH (e.g. launchd/systemd autostart
+    # environments). Without this guard that fallback ran nothing and
+    # exited 0, so daemon autostart silently never started (nexus-n8sbw).
+    main()

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -628,13 +628,36 @@ def t2_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
     except (OSError, _json.JSONDecodeError) as exc:
         click.echo(f"Failed to read discovery file: {exc}", err=True)
         sys.exit(1)
+    # Probe the recorded pid for liveness. A discovery file can outlive
+    # its daemon (e.g. an interrupted graceful stop left the file while
+    # the process died, or a crash). Reporting such a file as "running"
+    # masks a dead daemon (nexus-n8sbw).
+    pid = data.get("pid")
+    alive = False
+    if isinstance(pid, int) and pid > 0:
+        try:
+            os.kill(pid, 0)
+            alive = True
+        except (ProcessLookupError, PermissionError):
+            alive = False
+
     if as_json:
-        click.echo(_json.dumps(data, indent=2))
+        click.echo(_json.dumps({**data, "alive": alive}, indent=2))
+        if not alive:
+            sys.exit(1)
         return
+
     click.echo("T2 Daemon Status")
     click.echo("-" * 40)
     for key, value in data.items():
         click.echo(f"  {key}: {value}")
+    if not alive:
+        click.echo(
+            f"  status: STALE (recorded pid {pid} is not running). "
+            f"Run 'nx daemon t2 start' to respawn."
+        )
+        sys.exit(1)
+    click.echo("  status: running")
 
 
 @t2_group.command("ensure-running")

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -780,8 +780,26 @@ def run_t2_daemon(
     Called by ``nx daemon t2 start --foreground``. Synchronous wrapper
     that owns the asyncio event loop; the caller is the supervisor
     (launchd / systemd / shell) and treats this process as the daemon.
+
+    Routes the daemon's structlog events to a rotating file at
+    ``<config_dir>/logs/t2_daemon.log`` (nexus-n8sbw). Without this the
+    daemon was spawned with stdout/stderr -> DEVNULL and produced no
+    log, so a crash or signal-kill left no record and the cause was
+    undiagnosable.
     """
+    from nexus.logging_setup import configure_logging
+
+    configure_logging("t2_daemon", config_dir=config_dir)
+
     async def _main() -> None:
+        loop = asyncio.get_running_loop()
+        loop.set_exception_handler(
+            lambda _loop, ctx: _log.error(
+                "t2_daemon_loop_exception",
+                message=ctx.get("message"),
+                exception=repr(ctx.get("exception")),
+            )
+        )
         daemon = T2Daemon(config_dir=config_dir, db_path=db_path)
         await daemon.start()
         try:
@@ -789,4 +807,11 @@ def run_t2_daemon(
         finally:
             await daemon.stop()
 
-    asyncio.run(_main())
+    try:
+        asyncio.run(_main())
+    except Exception:
+        # Last-resort: an exception escaping the loop (e.g. start()
+        # raising before the handler is installed) must hit the log
+        # file, not a DEVNULL'd stderr.
+        _log.exception("t2_daemon_crashed")
+        raise

--- a/src/nexus/logging_setup.py
+++ b/src/nexus/logging_setup.py
@@ -43,8 +43,9 @@ def _resolve_level(mode: str, verbose: bool) -> int:
 
 
 def configure_logging(
-    mode: Literal["cli", "console", "mcp", "hook", "watchdog"],
+    mode: Literal["cli", "console", "mcp", "hook", "watchdog", "t2_daemon"],
     verbose: bool = False,
+    config_dir: Path | None = None,
 ) -> None:
     """Configure logging for the given nexus entry point.
 
@@ -58,10 +59,16 @@ def configure_logging(
     Modes:
       * ``cli``: stderr only, WARNING default. Kept legacy-compatible so
         the human-facing CLI does not gain noise from this change.
-      * ``console`` / ``mcp`` / ``hook`` / ``watchdog``: stderr +
-        RotatingFileHandler at ``<config_dir>/logs/<mode>.log``, INFO
-        default. Lifecycle events, tool dispatches, and structured
+      * ``console`` / ``mcp`` / ``hook`` / ``watchdog`` / ``t2_daemon``:
+        stderr + RotatingFileHandler at ``<config_dir>/logs/<mode>.log``,
+        INFO default. Lifecycle events, tool dispatches, and structured
         warnings now land in the log file.
+
+    *config_dir* overrides the log directory root (default:
+    ``NEXUS_CONFIG_DIR`` env or ``~/.config/nexus``). The T2 daemon
+    passes its own ``config_dir`` so a ``--config-dir`` override (or a
+    tmp dir under test) logs to the right place rather than the global
+    default.
 
     The level is overridable via the ``NEXUS_LOG_LEVEL`` env var; useful
     for one-off DEBUG runs without code changes.
@@ -118,7 +125,7 @@ def configure_logging(
         return  # stderr only — zero behaviour change for the CLI entry point
 
     # Non-CLI modes get a rotating file handler at <config>/logs/<mode>.log.
-    logs_dir = _config_dir() / "logs"
+    logs_dir = (config_dir or _config_dir()) / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     log_path = logs_dir / f"{mode}.log"
 

--- a/tests/daemon/test_t2_daemon_observability.py
+++ b/tests/daemon/test_t2_daemon_observability.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-n8sbw: T2 daemon observability + stale-state detection.
+
+The T2 daemon historically ran with stdout/stderr -> DEVNULL and no
+structlog file sink, so a crash or signal-kill left no record (the
+``daemon.log`` was a 0-byte file and the death cause was
+undiagnosable). These tests pin two fixes:
+
+1. ``run_t2_daemon`` routes the daemon's structlog events to a rotating
+   file at ``<config_dir>/logs/t2_daemon.log`` (via ``configure_logging``),
+   so the daemon's lifecycle is recorded regardless of how it was
+   launched. A SIGTERM that begins a graceful stop now leaves a
+   ``t2_daemon_stop_requested`` breadcrumb; a death without
+   ``t2_daemon_stopped`` is therefore diagnosable.
+
+2. ``nx daemon t2 status`` probes the recorded pid for liveness and
+   reports a stale discovery file (dead pid) as such, instead of
+   printing it as if the daemon were alive.
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.daemon.t2_daemon import t2_discovery_path
+
+
+def _write_discovery(config_dir: Path, pid: int) -> Path:
+    payload = {
+        "format_version": 1,
+        "uds_path": str(config_dir / "sockets" / "t2.sock"),
+        "tcp_host": "127.0.0.1",
+        "tcp_port": 12345,
+        "pid": pid,
+        "daemon_version": "5.0.2",
+        "start_time": "2026-05-25T00:00:00+00:00",
+    }
+    dest = t2_discovery_path(config_dir)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(payload))
+    return dest
+
+
+def _dead_pid() -> int:
+    """Return a pid that is reliably not running: fork a trivial child
+    and reap it. Reuse within the test window is vanishingly unlikely."""
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: daemon logging (the death is no longer invisible)
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonLogging:
+    def test_run_t2_daemon_writes_lifecycle_log_to_config_dir(
+        self, tmp_path: Path,
+    ) -> None:
+        """A real daemon subprocess records start + stop-request
+        breadcrumbs to ``<config_dir>/logs/t2_daemon.log``."""
+        import shutil
+        import tempfile
+
+        # Short config_dir: macOS caps AF_UNIX socket paths at 104 chars.
+        config_dir = Path(tempfile.mkdtemp(prefix="nxt2obs-", dir="/tmp"))
+        db_path = config_dir / "memory.db"
+        log_path = config_dir / "logs" / "t2_daemon.log"
+        proc: subprocess.Popen | None = None
+        try:
+            proc = subprocess.Popen(
+                [
+                    sys.executable, "-m", "nexus.cli",
+                    "daemon", "t2", "start",
+                    "--config-dir", str(config_dir),
+                    "--db-path", str(db_path),
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            disc = t2_discovery_path(config_dir)
+            deadline = time.monotonic() + 15.0
+            while time.monotonic() < deadline:
+                if disc.exists():
+                    break
+                if proc.poll() is not None:
+                    raise AssertionError(
+                        f"daemon exited early (code {proc.returncode})"
+                    )
+                time.sleep(0.1)
+            assert disc.exists(), "daemon did not write discovery file in 15s"
+
+            # The log file must exist and record the start event; the
+            # whole point: the daemon is no longer silent.
+            assert log_path.exists(), (
+                "daemon produced no log file; it is still silent"
+            )
+            assert "t2_daemon_started" in log_path.read_text()
+
+            # Graceful stop leaves a breadcrumb. Its presence (and the
+            # later absence of t2_daemon_stopped on a hard kill) is the
+            # diagnostic signal nexus-n8sbw was about.
+            proc.send_signal(signal.SIGTERM)
+            proc.wait(timeout=15.0)
+            stop_deadline = time.monotonic() + 5.0
+            text = ""
+            while time.monotonic() < stop_deadline:
+                text = log_path.read_text()
+                if "t2_daemon_stop_requested" in text:
+                    break
+                time.sleep(0.1)
+            assert "t2_daemon_stop_requested" in text
+        finally:
+            if proc is not None and proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=10.0)
+            shutil.rmtree(config_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: status reports stale discovery (dead pid) instead of "running"
+# ---------------------------------------------------------------------------
+
+
+class TestStatusLiveness:
+    def test_status_reports_stale_when_pid_dead(self, tmp_path: Path) -> None:
+        _write_discovery(tmp_path, _dead_pid())
+        result = CliRunner().invoke(
+            main, ["daemon", "t2", "status", "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code != 0, result.output
+        assert "stale" in result.output.lower()
+
+    def test_status_reports_running_when_pid_alive(self, tmp_path: Path) -> None:
+        _write_discovery(tmp_path, os.getpid())
+        result = CliRunner().invoke(
+            main, ["daemon", "t2", "status", "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert str(os.getpid()) in result.output
+
+    def test_status_absent_discovery_unchanged(self, tmp_path: Path) -> None:
+        """No discovery file still exits non-zero with the existing message."""
+        result = CliRunner().invoke(
+            main, ["daemon", "t2", "status", "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code != 0
+        assert "no t2 daemon discovery file" in result.output.lower()


### PR DESCRIPTION
## Summary

Fixes the daemon-observability gap surfaced during the v5.0.2 post-release shakedown: the T2 daemon ran with `stdout/stderr` → `DEVNULL` and no structlog file sink, so when a daemon died abnormally (leaving `{discovery file removed, stale socket}`), there was **no log to explain it** (`daemon.log` was 0 bytes). Investigation: nexus-n8sbw.

Three fixes:

- **Daemon logging (the enabler):** `run_t2_daemon` routes the daemon's structlog events to a rotating file at `<config_dir>/logs/t2_daemon.log` via `configure_logging` (new `"t2_daemon"` mode + optional `config_dir` param), plus an asyncio loop exception handler and a last-resort crash logger. A graceful stop now leaves a `t2_daemon_stop_requested` breadcrumb; a death **without** the matching `t2_daemon_stopped` is the diagnostic signal that the daemon was hard-killed mid-shutdown.
- **Status liveness:** `nx daemon t2 status` probes the recorded pid (`os.kill(pid, 0)`) and reports a stale discovery file (dead pid) as `STALE` with a non-zero exit, instead of printing it as if the daemon were running.
- **`python -m nexus.cli` guard (latent bug):** added the `__main__` guard. This is the fallback argv `_resolve_nx_bin` emits when the `nx` console script is not on PATH; without the guard that fallback ran nothing and exited 0, so daemon autostart could **silently never start** on such hosts.

## Why not fix the stop() cleanup ordering

The residual stale socket from an interrupted `stop()` is benign: the next `_bind_uds` unlinks it before binding. `ensure-running`'s `_daemon_is_alive()` already probes the pid and self-heals stale discovery. So the actionable gaps were observability + status honesty, not cleanup ordering. The death's *trigger* remains unidentified — but with fix #1 it becomes observable on recurrence.

## Test plan

- [x] New `tests/daemon/test_t2_daemon_observability.py` (4 tests): real-subprocess daemon writes lifecycle log; status reports STALE on dead pid / running on live pid / unchanged on absent discovery.
- [x] Daemon + logging_setup suites: 108 passed.
- [x] Full unit suite: 7592 passed, 0 failed.
- [x] Live smoke: `python -m nexus.cli --version` works; status shows `running` on the live daemon and `STALE` on a fabricated dead-pid discovery.

## Closes

Addresses nexus-n8sbw (observability + status portions; stop()-ordering deemed benign and out of scope).