### PR TITLE
release: conexus 5.0.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.0.2"
+        "ref": "v5.0.3"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.0.2"
+      "version": "5.0.3"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.0.2"
+        "ref": "v5.0.3"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.0.2"
+      "version": "5.0.3"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fix: T2 daemon observability + stale-state detection (nexus-n8sbw)
+
+The T2 daemon was spawned with stdout/stderr routed to `DEVNULL` and had
+no structlog file sink, so a crash or signal-kill left no record (a
+0-byte `daemon.log`) and the cause was undiagnosable. Three fixes:
+
+- `run_t2_daemon` now routes the daemon's structlog events to a rotating
+  file at `<config_dir>/logs/t2_daemon.log` via `configure_logging`, with
+  an asyncio loop exception handler and a last-resort crash logger. A
+  graceful stop leaves a `t2_daemon_stop_requested` breadcrumb; a death
+  without the matching `t2_daemon_stopped` is now diagnosable.
+- `nx daemon t2 status` probes the recorded pid for liveness and reports
+  a stale discovery file (dead pid) as `STALE` with a non-zero exit,
+  instead of printing it as if the daemon were running.
+- `python -m nexus.cli` now invokes the CLI (added the `__main__` guard).
+  This is the fallback argv `_resolve_nx_bin` emits when the `nx` console
+  script is not on PATH; without the guard that fallback ran nothing and
+  exited 0, so daemon autostart could silently never start.
+
 ## [5.0.2] - 2026-05-24
 
 Post-shakeout follow-ups to the 5.0.x line. No schema changes; safe in-place upgrade from 5.0.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.3] - 2026-05-25
+
 ### Fix: T2 daemon observability + stale-state detection (nexus-n8sbw)
 
 The T2 daemon was spawned with stdout/stderr routed to `DEVNULL` and had
@@ -24,6 +26,17 @@ no structlog file sink, so a crash or signal-kill left no record (a
   This is the fallback argv `_resolve_nx_bin` emits when the `nx` console
   script is not on PATH; without the guard that fallback ran nothing and
   exited 0, so daemon autostart could silently never start.
+
+### Tests: integration suite skips on absent corpus (nexus-gudwb)
+
+The RDR-097 hybrid-retrieval and RDR-093 groupby/aggregate integration
+tests require local-dev corpora (`knowledge__hybridrag`, `knowledge__delos`)
+that are absent on most machines and on CI. They previously hard-failed
+with a misleading "zero hits" / "<2 hits corpus health" assertion when the
+corpus was missing. They now probe T3 for the corpus (existence + >=2 docs)
+and `pytest.skip` when it is absent, matching their existing API-key /
+claude-auth skip-guards. When the corpus IS provisioned the real
+assertions still run; a missing dev corpus is no longer a spurious failure.
 
 ## [5.0.2] - 2026-05-24
 

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.3] - 2026-05-25
+
+Plugin version aligned with conexus 5.0.3. No plugin-side changes; the
+release carries a T2 daemon observability fix (nexus-n8sbw) and an
+integration-test corpus skip-guard (nexus-gudwb) in the core package.
+See root `CHANGELOG.md` § 5.0.3.
+
 ## [5.0.2] - 2026-05-24
 
 Plugin version aligned with conexus 5.0.2. Runtime fixes in the bundled

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1390,7 +1390,11 @@ daemon version, start time.
 | `--config-dir PATH` | Config directory override |
 | `--json` | Output raw JSON (default: pretty-print) |
 
-Exit code 1 if no daemon is running.
+The recorded PID is probed for liveness (`os.kill(pid, 0)`). A discovery
+file whose PID is no longer running is reported as `STALE` (with `--json`,
+an `"alive": false` field) and exits 1, so a daemon that died leaving a
+stale discovery file is not reported as running. Exit code 1 also when no
+discovery file exists.
 
 ### nx daemon t2 ensure-running
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -277,6 +277,7 @@ Central configuration: `src/nexus/logging_setup.py` — `configure_logging(mode,
 | `nx-mcp` (core MCP) | `mcp` | `~/.config/nexus/logs/mcp.log` | RotatingFileHandler 10 MB × 5 |
 | `nx-mcp-catalog` | `mcp` | `~/.config/nexus/logs/mcp.log` | Shares log with core MCP |
 | `nx console` | `console` | `~/.config/nexus/logs/console.log` | RotatingFileHandler 10 MB × 5 |
+| T2 daemon (`nx daemon t2 start`) | `t2_daemon` | `<config_dir>/logs/t2_daemon.log` | RotatingFileHandler 10 MB × 5; honours `--config-dir` |
 
 ### Log Files
 
@@ -286,6 +287,7 @@ Central configuration: `src/nexus/logging_setup.py` — `configure_logging(mode,
 | `~/.config/nexus/dolt-server.log` | Dolt server process | Dolt native format |
 | `~/.config/nexus/logs/mcp.log` | MCP servers (via `logging_setup`) | `%(asctime)s %(name)s %(levelname)s %(message)s` |
 | `~/.config/nexus/logs/console.log` | Console server (via `logging_setup`) | Same as above |
+| `~/.config/nexus/logs/t2_daemon.log` | T2 daemon (via `logging_setup`) | Same as above; records `t2_daemon_started` / `t2_daemon_stop_requested` / `t2_daemon_stopped` lifecycle + crashes |
 
 ### Suppressed Loggers
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.0.2"
+version = "5.0.3"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.0.2",
+    "conexus>=5.0.3",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.0.2"
+version = "5.0.3"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -111,3 +111,12 @@ main.add_command(taxonomy)
 main.add_command(tier_status_cmd, name="tier-status")
 main.add_command(aspects_group, name="aspects")
 main.add_command(upgrade)
+
+
+if __name__ == "__main__":
+    # Enables ``python -m nexus.cli``, the fallback argv that
+    # ``nexus.commands.daemon._resolve_nx_bin`` emits when the ``nx``
+    # console script is not on PATH (e.g. launchd/systemd autostart
+    # environments). Without this guard that fallback ran nothing and
+    # exited 0, so daemon autostart silently never started (nexus-n8sbw).
+    main()

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -628,13 +628,36 @@ def t2_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
     except (OSError, _json.JSONDecodeError) as exc:
         click.echo(f"Failed to read discovery file: {exc}", err=True)
         sys.exit(1)
+    # Probe the recorded pid for liveness. A discovery file can outlive
+    # its daemon (e.g. an interrupted graceful stop left the file while
+    # the process died, or a crash). Reporting such a file as "running"
+    # masks a dead daemon (nexus-n8sbw).
+    pid = data.get("pid")
+    alive = False
+    if isinstance(pid, int) and pid > 0:
+        try:
+            os.kill(pid, 0)
+            alive = True
+        except (ProcessLookupError, PermissionError):
+            alive = False
+
     if as_json:
-        click.echo(_json.dumps(data, indent=2))
+        click.echo(_json.dumps({**data, "alive": alive}, indent=2))
+        if not alive:
+            sys.exit(1)
         return
+
     click.echo("T2 Daemon Status")
     click.echo("-" * 40)
     for key, value in data.items():
         click.echo(f"  {key}: {value}")
+    if not alive:
+        click.echo(
+            f"  status: STALE (recorded pid {pid} is not running). "
+            f"Run 'nx daemon t2 start' to respawn."
+        )
+        sys.exit(1)
+    click.echo("  status: running")
 
 
 @t2_group.command("ensure-running")

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -780,8 +780,26 @@ def run_t2_daemon(
     Called by ``nx daemon t2 start --foreground``. Synchronous wrapper
     that owns the asyncio event loop; the caller is the supervisor
     (launchd / systemd / shell) and treats this process as the daemon.
+
+    Routes the daemon's structlog events to a rotating file at
+    ``<config_dir>/logs/t2_daemon.log`` (nexus-n8sbw). Without this the
+    daemon was spawned with stdout/stderr -> DEVNULL and produced no
+    log, so a crash or signal-kill left no record and the cause was
+    undiagnosable.
     """
+    from nexus.logging_setup import configure_logging
+
+    configure_logging("t2_daemon", config_dir=config_dir)
+
     async def _main() -> None:
+        loop = asyncio.get_running_loop()
+        loop.set_exception_handler(
+            lambda _loop, ctx: _log.error(
+                "t2_daemon_loop_exception",
+                message=ctx.get("message"),
+                exception=repr(ctx.get("exception")),
+            )
+        )
         daemon = T2Daemon(config_dir=config_dir, db_path=db_path)
         await daemon.start()
         try:
@@ -789,4 +807,11 @@ def run_t2_daemon(
         finally:
             await daemon.stop()
 
-    asyncio.run(_main())
+    try:
+        asyncio.run(_main())
+    except Exception:
+        # Last-resort: an exception escaping the loop (e.g. start()
+        # raising before the handler is installed) must hit the log
+        # file, not a DEVNULL'd stderr.
+        _log.exception("t2_daemon_crashed")
+        raise

--- a/src/nexus/logging_setup.py
+++ b/src/nexus/logging_setup.py
@@ -43,8 +43,9 @@ def _resolve_level(mode: str, verbose: bool) -> int:
 
 
 def configure_logging(
-    mode: Literal["cli", "console", "mcp", "hook", "watchdog"],
+    mode: Literal["cli", "console", "mcp", "hook", "watchdog", "t2_daemon"],
     verbose: bool = False,
+    config_dir: Path | None = None,
 ) -> None:
     """Configure logging for the given nexus entry point.
 
@@ -58,10 +59,16 @@ def configure_logging(
     Modes:
       * ``cli``: stderr only, WARNING default. Kept legacy-compatible so
         the human-facing CLI does not gain noise from this change.
-      * ``console`` / ``mcp`` / ``hook`` / ``watchdog``: stderr +
-        RotatingFileHandler at ``<config_dir>/logs/<mode>.log``, INFO
-        default. Lifecycle events, tool dispatches, and structured
+      * ``console`` / ``mcp`` / ``hook`` / ``watchdog`` / ``t2_daemon``:
+        stderr + RotatingFileHandler at ``<config_dir>/logs/<mode>.log``,
+        INFO default. Lifecycle events, tool dispatches, and structured
         warnings now land in the log file.
+
+    *config_dir* overrides the log directory root (default:
+    ``NEXUS_CONFIG_DIR`` env or ``~/.config/nexus``). The T2 daemon
+    passes its own ``config_dir`` so a ``--config-dir`` override (or a
+    tmp dir under test) logs to the right place rather than the global
+    default.
 
     The level is overridable via the ``NEXUS_LOG_LEVEL`` env var; useful
     for one-off DEBUG runs without code changes.
@@ -118,7 +125,7 @@ def configure_logging(
         return  # stderr only — zero behaviour change for the CLI entry point
 
     # Non-CLI modes get a rotating file handler at <config>/logs/<mode>.log.
-    logs_dir = _config_dir() / "logs"
+    logs_dir = (config_dir or _config_dir()) / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     log_path = logs_dir / f"{mode}.log"
 

--- a/tests/daemon/test_t2_daemon_observability.py
+++ b/tests/daemon/test_t2_daemon_observability.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-n8sbw: T2 daemon observability + stale-state detection.
+
+The T2 daemon historically ran with stdout/stderr -> DEVNULL and no
+structlog file sink, so a crash or signal-kill left no record (the
+``daemon.log`` was a 0-byte file and the death cause was
+undiagnosable). These tests pin two fixes:
+
+1. ``run_t2_daemon`` routes the daemon's structlog events to a rotating
+   file at ``<config_dir>/logs/t2_daemon.log`` (via ``configure_logging``),
+   so the daemon's lifecycle is recorded regardless of how it was
+   launched. A SIGTERM that begins a graceful stop now leaves a
+   ``t2_daemon_stop_requested`` breadcrumb; a death without
+   ``t2_daemon_stopped`` is therefore diagnosable.
+
+2. ``nx daemon t2 status`` probes the recorded pid for liveness and
+   reports a stale discovery file (dead pid) as such, instead of
+   printing it as if the daemon were alive.
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.daemon.t2_daemon import t2_discovery_path
+
+
+def _write_discovery(config_dir: Path, pid: int) -> Path:
+    payload = {
+        "format_version": 1,
+        "uds_path": str(config_dir / "sockets" / "t2.sock"),
+        "tcp_host": "127.0.0.1",
+        "tcp_port": 12345,
+        "pid": pid,
+        "daemon_version": "5.0.2",
+        "start_time": "2026-05-25T00:00:00+00:00",
+    }
+    dest = t2_discovery_path(config_dir)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(payload))
+    return dest
+
+
+def _dead_pid() -> int:
+    """Return a pid that is reliably not running: fork a trivial child
+    and reap it. Reuse within the test window is vanishingly unlikely."""
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: daemon logging (the death is no longer invisible)
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonLogging:
+    def test_run_t2_daemon_writes_lifecycle_log_to_config_dir(
+        self, tmp_path: Path,
+    ) -> None:
+        """A real daemon subprocess records start + stop-request
+        breadcrumbs to ``<config_dir>/logs/t2_daemon.log``."""
+        import shutil
+        import tempfile
+
+        # Short config_dir: macOS caps AF_UNIX socket paths at 104 chars.
+        config_dir = Path(tempfile.mkdtemp(prefix="nxt2obs-", dir="/tmp"))
+        db_path = config_dir / "memory.db"
+        log_path = config_dir / "logs" / "t2_daemon.log"
+        proc: subprocess.Popen | None = None
+        try:
+            proc = subprocess.Popen(
+                [
+                    sys.executable, "-m", "nexus.cli",
+                    "daemon", "t2", "start",
+                    "--config-dir", str(config_dir),
+                    "--db-path", str(db_path),
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            disc = t2_discovery_path(config_dir)
+            deadline = time.monotonic() + 15.0
+            while time.monotonic() < deadline:
+                if disc.exists():
+                    break
+                if proc.poll() is not None:
+                    raise AssertionError(
+                        f"daemon exited early (code {proc.returncode})"
+                    )
+                time.sleep(0.1)
+            assert disc.exists(), "daemon did not write discovery file in 15s"
+
+            # The log file must exist and record the start event; the
+            # whole point: the daemon is no longer silent.
+            assert log_path.exists(), (
+                "daemon produced no log file; it is still silent"
+            )
+            assert "t2_daemon_started" in log_path.read_text()
+
+            # Graceful stop leaves a breadcrumb. Its presence (and the
+            # later absence of t2_daemon_stopped on a hard kill) is the
+            # diagnostic signal nexus-n8sbw was about.
+            proc.send_signal(signal.SIGTERM)
+            proc.wait(timeout=15.0)
+            stop_deadline = time.monotonic() + 5.0
+            text = ""
+            while time.monotonic() < stop_deadline:
+                text = log_path.read_text()
+                if "t2_daemon_stop_requested" in text:
+                    break
+                time.sleep(0.1)
+            assert "t2_daemon_stop_requested" in text
+        finally:
+            if proc is not None and proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=10.0)
+            shutil.rmtree(config_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: status reports stale discovery (dead pid) instead of "running"
+# ---------------------------------------------------------------------------
+
+
+class TestStatusLiveness:
+    def test_status_reports_stale_when_pid_dead(self, tmp_path: Path) -> None:
+        _write_discovery(tmp_path, _dead_pid())
+        result = CliRunner().invoke(
+            main, ["daemon", "t2", "status", "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code != 0, result.output
+        assert "stale" in result.output.lower()
+
+    def test_status_reports_running_when_pid_alive(self, tmp_path: Path) -> None:
+        _write_discovery(tmp_path, os.getpid())
+        result = CliRunner().invoke(
+            main, ["daemon", "t2", "status", "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert str(os.getpid()) in result.output
+
+    def test_status_absent_discovery_unchanged(self, tmp_path: Path) -> None:
+        """No discovery file still exits non-zero with the existing message."""
+        result = CliRunner().invoke(
+            main, ["daemon", "t2", "status", "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code != 0
+        assert "no t2 daemon discovery file" in result.output.lower()

--- a/tests/integration/test_rdr_093_groupby_aggregate_pipelines.py
+++ b/tests/integration/test_rdr_093_groupby_aggregate_pipelines.py
@@ -80,6 +80,34 @@ def _t3_reachable() -> bool:
         return False
 
 
+#: Corpus these pipelines retrieve against (local-dev prerequisite).
+DELOS_COLLECTION = "knowledge__delos"
+
+
+def _corpus_indexed(prefix: str, min_docs: int = 2) -> bool:
+    """True iff a T3 collection under *prefix* exists with >= *min_docs*.
+
+    ``knowledge__delos`` is a local-dev prerequisite absent on most
+    machines and on CI. When it is not indexed these pipelines must
+    ``pytest.skip`` rather than hard-fail on the "<2 hits" corpus-health
+    assertion (nexus-gudwb); a missing dev corpus is not a regression.
+    Called only after the T3-reachable gate, so ``make_t3`` is live.
+    """
+    try:
+        from nexus.db import make_t3
+
+        t3 = make_t3()
+        for c in t3.list_collections():
+            name = c.get("name", "")
+            if (name == prefix or name.startswith(prefix + "__")) and c.get(
+                "count", 0
+            ) >= min_docs:
+                return True
+        return False
+    except Exception:
+        return False
+
+
 @pytest_asyncio.fixture(autouse=True)
 async def _reset_singletons_between_tests():
     yield
@@ -147,6 +175,11 @@ class TestPhase3MVVPipeline:
             pytest.skip("claude auth not available")
         if not _t3_reachable():
             pytest.skip("T3 not reachable")
+        if not _corpus_indexed(DELOS_COLLECTION):
+            pytest.skip(
+                f"{DELOS_COLLECTION} not indexed in T3 (>=2 docs); "
+                "corpus prerequisite missing (nexus-gudwb)"
+            )
 
     @pytest.mark.asyncio
     async def test_search_filter_groupby_aggregate_end_to_end(self) -> None:
@@ -293,6 +326,11 @@ class TestC1InlineItemsRegressionGuard:
             pytest.skip("claude auth not available")
         if not _t3_reachable():
             pytest.skip("T3 not reachable")
+        if not _corpus_indexed(DELOS_COLLECTION):
+            pytest.skip(
+                f"{DELOS_COLLECTION} not indexed in T3 (>=2 docs); "
+                "corpus prerequisite missing (nexus-gudwb)"
+            )
 
     @pytest.mark.asyncio
     async def test_aggregate_summaries_reference_inline_body_content(

--- a/tests/test_hybrid_plan_factual_qa.py
+++ b/tests/test_hybrid_plan_factual_qa.py
@@ -96,6 +96,32 @@ requires_t3_only = pytest.mark.skipif(
 TARGET_COLLECTION = "knowledge__hybridrag"
 
 
+def _corpus_indexed(prefix: str, min_docs: int = 2) -> bool:
+    """True iff a T3 collection under *prefix* exists with >= *min_docs*.
+
+    ``knowledge__hybridrag`` is a local-dev prerequisite (bead
+    nexus-qlfa) that is absent on most machines and on CI. When it is
+    not indexed these tests must ``pytest.skip`` rather than hard-fail
+    with a misleading "zero hits" assertion (nexus-gudwb); a missing
+    dev corpus is not a code regression. When the corpus IS present the
+    real assertions still run. Called only after the API-key gate, so
+    ``make_t3`` is reachable.
+    """
+    try:
+        from nexus.db import make_t3
+
+        t3 = make_t3()
+        for c in t3.list_collections():
+            name = c.get("name", "")
+            if (name == prefix or name.startswith(prefix + "__")) and c.get(
+                "count", 0
+            ) >= min_docs:
+                return True
+        return False
+    except Exception:
+        return False
+
+
 #: 5 question fixtures from the bead. The placeholder values below are
 #: structurally complete (the harness runs against them) but the
 #: ``expected_tumblers`` lists need to be populated with real corpus
@@ -316,6 +342,11 @@ def test_vector_only_baseline_runs(fixture: dict[str, Any]) -> None:
     the hybrid path has something to compare against. Asserts the
     baseline retrieves at least one chunk.
     """
+    if not _corpus_indexed(TARGET_COLLECTION):
+        pytest.skip(
+            f"{TARGET_COLLECTION} not indexed in T3 (>=2 docs); "
+            "corpus prerequisite missing (nexus-gudwb)"
+        )
     out = _vector_only_baseline(fixture["question"])
     assert out["ids"], (
         f"Baseline returned zero hits for {fixture['id']!r}; corpus "
@@ -355,6 +386,11 @@ async def test_hybrid_not_worse_than_baseline(
     cross-run diff can answer "did the change regress recall on
     fixture X at budget Y" without re-running the whole suite.
     """
+    if not _corpus_indexed(TARGET_COLLECTION):
+        pytest.skip(
+            f"{TARGET_COLLECTION} not indexed in T3 (>=2 docs); "
+            "corpus prerequisite missing (nexus-gudwb)"
+        )
     vector_budget, graph_budget = budget
 
     t0 = time.perf_counter()

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.0.2"
+version = "5.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Promotes develop to main and bumps conexus 5.0.2 → 5.0.3. Patch release: T2 daemon observability fix + integration-test corpus skip-guards. No schema changes; safe in-place upgrade from 5.0.2.

### Changes since v5.0.2

- **fix(daemon): T2 daemon observability + stale-state detection (nexus-n8sbw).** The daemon ran with `stdout/stderr` → `DEVNULL` and no structlog file sink, so a crash/signal-kill left no record (0-byte `daemon.log`). Now: `run_t2_daemon` routes structlog to a rotating `<config_dir>/logs/t2_daemon.log` (+ asyncio loop exception handler + last-resort crash logger); `nx daemon t2 status` probes the recorded pid and reports a dead daemon as `STALE` (non-zero exit) instead of "running"; added the `__main__` guard to `nexus.cli` so the `python -m nexus.cli` autostart fallback actually starts the daemon.
- **test: integration suite skips on absent corpus (nexus-gudwb).** RDR-097 hybrid + RDR-093 groupby/aggregate tests now probe T3 for their local-dev corpus (`knowledge__hybridrag` / `knowledge__delos`) and `pytest.skip` when absent, instead of hard-failing on a misleading "zero hits" assertion. Real assertions still run when the corpus is provisioned.
- **docs:** `configuration.md` documents the new `t2_daemon.log`; `cli-reference.md` documents the status pid-liveness / `STALE` behaviour.

### Manifest bumps (all 7, CI parity-enforced)

`pyproject.toml`, `mcpb/pyproject.toml` (+ `conexus>=5.0.3`), `mcpb/manifest.json`, `.claude-plugin/marketplace.json` (both `version` + both `source.ref` → `v5.0.3`), `conexus/.claude-plugin/plugin.json`, `sn/.claude-plugin/plugin.json`. `uv.lock` refreshed.

## Test plan

- [x] Unit suite: 7592 passed, 0 failed
- [x] Integration suite: 77 passed, 30 skipped, **0 failed** (the 7 corpus tests now skip cleanly instead of failing — the gudwb fix)
- [x] Sandbox smoke: `[done]`, CLI reports v5.0.3, all doctor checks pass
- [x] Pre-push parity: all 7 manifests + both refs read 5.0.3 / v5.0.3

## Closes

Closes #nexus-n8sbw (daemon observability) and #nexus-gudwb (corpus skip-guards) on merge + tag.