### PR TITLE
feat(daemon): restart a stale T2 daemon on install/upgrade (nexus-5ldk1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fix: install/upgrade paths now bring a stale T2 daemon to current (nexus-5ldk1)
+
+The long-lived T2 daemon froze its code version at process start, so an
+upgrade (`uv tool upgrade conexus`, `nx upgrade`, a reinstall) left a
+stale daemon running old code until a manual `nx daemon t2 stop && start`.
+`nx daemon t2 ensure-running` is now version-aware: it leaves a current
+daemon alone and gracefully cycles one whose version differs from the
+installed tool (SIGTERM drains in-flight RPC, then respawns). This is
+wired into every install path: `nx upgrade` and `scripts/reinstall-tool.sh`
+call it after installing, and the plugin / `.mcpb` session-start hooks
+already invoke it. An upgrade is now live without a manual daemon restart.
+
 ## [5.0.3] - 2026-05-25
 
 ### Fix: T2 daemon observability + stale-state detection (nexus-n8sbw)

--- a/docs/desktop-deployment.md
+++ b/docs/desktop-deployment.md
@@ -85,6 +85,21 @@ to silence.)
 
 The check is non-fatal: a network failure, timeout, or unreachable PyPI never blocks startup. Set `NX_MCPB_SKIP_UPDATE_CHECK=1` in the environment to opt out entirely.
 
+## Updating the Desktop Extension
+
+The `.mcpb` does **not** auto-update. MCPB v0.4 has no update mechanism, and the extension's Python environment is pinned at install time: Claude Desktop builds a `uv` venv under `~/Library/Application Support/Claude/Claude Extensions/local.mcpb.<id>.conexus/.venv` from the bundle's `pyproject.toml` (`conexus>=X.Y.Z`), and every launch runs `uv run` against **that existing venv**. `uv run` reuses the resolved venv rather than re-resolving against PyPI, so a newer published conexus is not picked up until the bundle is re-installed and the venv is rebuilt.
+
+So the update is a manual, idempotent re-install:
+
+1. **Download** the new `conexus.mcpb` from the [latest release](https://github.com/Hellblazer/nexus/releases/latest) (the same asset attached to every GitHub release alongside the wheel and sdist).
+2. **Double-click it** (or Claude Desktop → Settings → Connectors → Desktop → install). Claude Desktop replaces the existing "Conexus" extension in place; you do not need to uninstall first.
+3. **First launch resolves the new version.** `uv` rebuilds the venv from the new manifest's `conexus>=X.Y.Z` pin (~20s cold, ~5s warm), pulling the new conexus from PyPI. The stale-install warning stops firing once installed == latest.
+4. **Verify** (optional): the installed version is the `version` field in the extension's `manifest.json`, and the resolved package is `<ext>/.venv/bin/python -c "from importlib.metadata import version; print(version('conexus'))"`.
+
+What the update does **not** touch: the host T2 daemon, the T3 store, the catalog, and all stored data are owned by the OS / user account and shared across the CLI, the Claude Code plugin, and the Desktop extension. Re-installing the bundle swaps only the bundle files and its venv. The daemon is not restarted by an extension update.
+
+**Version skew is expected and tolerated.** The Desktop connector (its venv) and the host T2 daemon are independent installs that can briefly differ, since they update on different triggers (a `.mcpb` re-install vs `uv tool upgrade conexus` / a CLI reinstall). The connector talks to the daemon over RPC within a major version; align them by updating whichever is behind. After a release, update both: the CLI/daemon via `uv tool upgrade conexus` (then restart the daemon), and the Desktop extension via the re-install above.
+
 ## Uninstall
 
 ### Claude Code plugin

--- a/scripts/reinstall-tool.sh
+++ b/scripts/reinstall-tool.sh
@@ -60,3 +60,13 @@ if [[ -d "$TOOL_BIN" ]]; then
         fi
     done
 fi
+
+# nexus-5ldk1: a running T2 daemon froze its code at start and now predates
+# this reinstall. Bring it to the freshly-installed version so the reinstall
+# is live, not pending a manual `nx daemon t2 stop && ensure-running`.
+# ensure-running is version-aware: no-op on a current daemon, graceful cycle
+# on a stale one. Best-effort; never fails the reinstall.
+if command -v nx >/dev/null 2>&1; then
+    nx daemon t2 ensure-running --quiet --timeout=10 2>/dev/null || \
+        echo "(note: daemon cycle skipped/failed; run 'nx daemon t2 ensure-running' manually)"
+fi

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -704,27 +704,70 @@ def t2_ensure_running_cmd(
     config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
     disc = t2_discovery_path(config_dir)
 
-    def _daemon_is_alive() -> bool:
+    def _running_daemon() -> tuple[int, str] | None:
+        """Return (pid, daemon_version) of the live daemon, or None.
+
+        Probes the recorded PID via ``os.kill(pid, 0)``; stale discovery
+        files outlive crashed daemons, so a readable file is not proof of
+        life.
+        """
         if not disc.exists():
-            return False
+            return None
         try:
             data = json.loads(disc.read_text())
         except (OSError, json.JSONDecodeError):
-            return False
+            return None
         pid = data.get("pid")
         if not isinstance(pid, int):
-            return False
-        # Probe the PID — stale discovery files outlive crashed daemons.
+            return None
         try:
             os.kill(pid, 0)
         except (ProcessLookupError, PermissionError):
-            return False
-        return True
+            return None
+        return pid, str(data.get("daemon_version") or "")
 
-    if _daemon_is_alive():
+    def _daemon_is_alive() -> bool:
+        return _running_daemon() is not None
+
+    def _installed_version() -> str:
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as _pkg_version
+
+        try:
+            return _pkg_version("conexus")
+        except PackageNotFoundError:
+            return ""
+
+    running = _running_daemon()
+    if running is not None:
+        running_pid, running_ver = running
+        installed = _installed_version()
+        # A live daemon whose version matches the installed tool (or whose
+        # installed version can't be determined) is left alone (idempotent).
+        if not installed or running_ver == installed:
+            if not quiet:
+                click.echo("T2 daemon already running.")
+            return
+        # Version skew: the daemon froze its code at start and predates the
+        # last upgrade (nexus-5ldk1). "Ensure running" means ensure a
+        # CURRENT daemon; gracefully cycle the stale one and respawn below.
+        # SIGTERM lets the daemon drain in-flight RPC (stop() awaits
+        # wait_closed) and remove its discovery file before we respawn.
         if not quiet:
-            click.echo("T2 daemon already running.")
-        return
+            click.echo(
+                f"T2 daemon is stale (running {running_ver}, installed "
+                f"{installed}); cycling to current."
+            )
+        try:
+            os.kill(running_pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+        cycle_deadline = _time.monotonic() + 10.0
+        while _time.monotonic() < cycle_deadline:
+            if not _daemon_is_alive():
+                break
+            _time.sleep(0.1)
+        # fall through to cold spawn
 
     # Cold spawn. Use the same nx binary the operator invoked (preserves
     # PATH/virtualenv assumptions). start_new_session detaches the child

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -52,6 +52,36 @@ def upgrade(dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool) -> None:
             _log.warning("upgrade_auto_error", exc_info=True)
             return
         raise
+    # nexus-5ldk1: a running T2 daemon froze its code at start and now
+    # predates this upgrade. Bring it to the just-installed version so the
+    # upgrade is live rather than pending a manual daemon restart.
+    # ensure-running is version-aware: no-op on a current daemon, graceful
+    # cycle on a stale one. Best-effort, non-dry-run only.
+    if not dry_run:
+        _cycle_daemon_to_current()
+
+
+def _cycle_daemon_to_current() -> None:
+    """Bring a stale T2 daemon to the just-installed version (best-effort).
+
+    Shells out to ``nx daemon t2 ensure-running --quiet``, the same
+    version-aware primitive the plugin/mcpb session-start hooks use. Never
+    raises: a daemon nudge must not fail the upgrade.
+    """
+    import subprocess
+
+    try:
+        from nexus.commands.daemon import _resolve_nx_bin
+
+        subprocess.run(
+            [*_resolve_nx_bin(), "daemon", "t2", "ensure-running", "--quiet"],
+            timeout=30,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("upgrade_daemon_cycle_failed", error=str(exc))
 
 
 def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool = False) -> None:

--- a/tests/daemon/test_t2_ensure_running.py
+++ b/tests/daemon/test_t2_ensure_running.py
@@ -34,15 +34,30 @@ def _discovery_path(config_dir: Path) -> Path:
     return t2_discovery_path(config_dir)
 
 
-def _write_discovery(config_dir: Path, pid: int) -> None:
-    """Pre-seed a discovery file shaped like the real daemon writes."""
+def _installed_conexus_version() -> str:
+    from importlib.metadata import version as _v
+
+    try:
+        return _v("conexus")
+    except Exception:
+        return "0.0.0"
+
+
+def _write_discovery(config_dir: Path, pid: int, version: str | None = None) -> None:
+    """Pre-seed a discovery file shaped like the real daemon writes.
+
+    ``version`` defaults to the installed conexus version so the
+    "already running, current" path is exercised; pass an older string
+    to simulate a stale daemon that ensure-running should cycle
+    (nexus-5ldk1).
+    """
     payload = {
         "format_version": 1,
         "uds_path": str(config_dir / "sockets" / "t2.sock"),
         "tcp_host": "127.0.0.1",
         "tcp_port": 12345,
         "pid": pid,
-        "daemon_version": "4.34.1",
+        "daemon_version": version if version is not None else _installed_conexus_version(),
         "start_time": "2026-05-22T19:00:00+00:00",
     }
     dest = _discovery_path(config_dir)
@@ -74,6 +89,74 @@ class TestEnsureRunning:
         assert result.exit_code == 0, result.output
         assert "already running" in result.output
         assert spawn_calls == []
+
+    def test_stale_version_daemon_is_cycled_then_respawned(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """nexus-5ldk1: a LIVE daemon whose version != installed tool is
+        stale (froze old code at start). ensure-running must SIGTERM it
+        and respawn a current one, rather than leaving the stale daemon."""
+        import signal as _signal
+
+        # Live daemon at an older version than the installed tool.
+        _write_discovery(tmp_path, pid=424242, version="0.0.1-stale")
+        monkeypatch.setattr(
+            "importlib.metadata.version", lambda _name: "9.9.9-installed"
+        )
+
+        # Stateful os.kill: pid is alive until it receives SIGTERM, then
+        # dead. Guards the test process: we never signal a real pid.
+        state = {"terminated": False}
+
+        def _fake_kill(pid, sig):  # noqa: ANN001
+            if pid != 424242:
+                raise ProcessLookupError
+            if sig == 0:
+                if state["terminated"]:
+                    raise ProcessLookupError
+                return
+            if sig == _signal.SIGTERM:
+                state["terminated"] = True
+                return
+
+        monkeypatch.setattr(os, "kill", _fake_kill)
+
+        spawn_calls: list[list[str]] = []
+
+        class _FakePopen:
+            def __init__(self, argv, **_kw):  # noqa: ANN001
+                spawn_calls.append(argv)
+
+        monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+        result = CliRunner().invoke(
+            main,
+            ["daemon", "t2", "ensure-running",
+             "--config-dir", str(tmp_path), "--timeout", "0.2"],
+        )
+        # Stale daemon was SIGTERM'd and a respawn was attempted.
+        assert state["terminated"] is True, "stale daemon was not cycled"
+        assert len(spawn_calls) == 1, "no respawn after cycling stale daemon"
+        assert "stale" in result.output.lower()
+
+    def test_current_version_daemon_not_cycled(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """A live daemon whose version == installed tool is left alone."""
+        _write_discovery(tmp_path, pid=424242, version="9.9.9-installed")
+        monkeypatch.setattr(
+            "importlib.metadata.version", lambda _name: "9.9.9-installed"
+        )
+        monkeypatch.setattr(os, "kill", lambda pid, sig: None)  # pid "alive"
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda *a, **kw: pytest.fail("must not cycle a current daemon"),
+        )
+        result = CliRunner().invoke(
+            main,
+            ["daemon", "t2", "ensure-running", "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "already running" in result.output
 
     def test_already_running_quiet_suppresses_output(
         self, tmp_path, monkeypatch,

--- a/tests/test_upgrade_cmd.py
+++ b/tests/test_upgrade_cmd.py
@@ -29,6 +29,15 @@ def _tmp_db(tmp_path: Path) -> Path:
     return tmp_path / "memory.db"
 
 
+@pytest.fixture(autouse=True)
+def _no_real_daemon_nudge():
+    """Patch the post-upgrade daemon cycle (nexus-5ldk1) for all upgrade
+    tests so they never shell out to the real host T2 daemon. Yields the
+    mock so tests can assert whether the nudge fired."""
+    with patch("nexus.commands.upgrade._cycle_daemon_to_current") as m:
+        yield m
+
+
 class TestUpgradeCommand:
     """Tests for the ``nx upgrade`` CLI command."""
 
@@ -52,6 +61,33 @@ class TestUpgradeCommand:
             result = runner.invoke(main, ["upgrade", "--dry-run"])
         assert result.exit_code == 0
         assert "dry-run" in result.output.lower() or "pending" in result.output.lower()
+
+    def test_upgrade_cycles_daemon_on_success(
+        self, runner: CliRunner, tmp_path: Path, _no_real_daemon_nudge,
+    ) -> None:
+        """nexus-5ldk1: a successful (non-dry-run) upgrade brings a stale
+        daemon to the just-installed version."""
+        db_path = tmp_path / "memory.db"
+        with (
+            patch("nexus.commands.upgrade._db_path", return_value=db_path),
+            patch("nexus.commands.upgrade.T3_UPGRADES", []),
+        ):
+            result = runner.invoke(main, ["upgrade"])
+        assert result.exit_code == 0
+        assert _no_real_daemon_nudge.called, "upgrade did not cycle the daemon"
+
+    def test_upgrade_dry_run_does_not_cycle_daemon(
+        self, runner: CliRunner, tmp_path: Path, _no_real_daemon_nudge,
+    ) -> None:
+        """--dry-run installs nothing, so it must not touch the daemon."""
+        db_path = tmp_path / "memory.db"
+        with (
+            patch("nexus.commands.upgrade._db_path", return_value=db_path),
+            patch("nexus.commands.upgrade.T3_UPGRADES", []),
+        ):
+            result = runner.invoke(main, ["upgrade", "--dry-run"])
+        assert result.exit_code == 0
+        assert not _no_real_daemon_nudge.called, "dry-run must not cycle the daemon"
 
     def test_upgrade_force(self, runner: CliRunner, tmp_path: Path) -> None:
         """--force resets version gate to 0.0.0 and re-runs."""


### PR DESCRIPTION
## Summary

Closes the daemon-lifecycle gap surfaced across the 5.0.2/5.0.3 work: the long-lived T2 daemon freezes its code version at process start, so an upgrade leaves a **stale daemon running old code** until a manual `nx daemon t2 stop && start`. We hit it three ways (aspect_worker WAL fix inactive until restart; version-string skew; pre-n8sbw silent death).

The fix is one version-aware primitive routed through every install path:

- **`nx daemon t2 ensure-running` is now version-aware** — it compares the running daemon's `daemon_version` to the installed tool, leaves a current daemon alone (idempotent), and gracefully cycles a stale one (SIGTERM drains in-flight RPC via `stop()`'s `wait_closed`, then respawns). This is the primitive: *ensure a CURRENT daemon is running*.
- **`nx upgrade`** calls it after a successful (non-dry-run) upgrade — replaces the manual "stop the daemon, run nx upgrade, restart" its own code comment described.
- **`scripts/reinstall-tool.sh`** calls it after reinstalling (the dev path).
- **plugin / `.mcpb` session-start hooks** already invoke `ensure-running` (`mcp/_first_run.py`, `conexus/hooks/hooks.json`), so they self-heal automatically now that it is version-aware — i.e. restart-on-install for the most common path with no further wiring.

### Why version-aware ensure-running (the tradeoff)

The daemon is shared (CLI + plugin + Desktop) and stateful (SQLite WAL, aspect queue, in-flight RPC). The cycle only fires on a real version mismatch (the post-upgrade case) and uses a graceful SIGTERM so `stop()` drains open connections before exit. No thrash: a single host has one installed version, and `ensure-running` is called at session boundaries, not in a loop.

## Test plan

- [x] `ensure-running`: stale-version → cycle + respawn; current-version → no cycle (new tests, mocked `os.kill`/version so no real pid is signalled)
- [x] `nx upgrade`: cycles daemon on success; dry-run does not; autouse fixture isolates all upgrade tests from the real host daemon
- [x] Full unit suite: **7596 passed, 0 failed**

## Deferred (fast-follow)

`nx doctor` skew-check (daemon_version vs tool version) — visibility for the bare `uv tool upgrade conexus` path that bypasses `nx upgrade`. Kept this PR tight on the control; tracked on nexus-5ldk1.

## Closes

nexus-5ldk1 (control portion; doctor skew-check deferred and noted on the bead).