### PR TITLE
release: conexus 5.0.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.0.3"
+        "ref": "v5.0.4"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.0.3"
+      "version": "5.0.4"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.0.3"
+        "ref": "v5.0.4"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.0.3"
+      "version": "5.0.4"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fix: install/upgrade paths now bring a stale T2 daemon to current (nexus-5ldk1)
+
+The long-lived T2 daemon froze its code version at process start, so an
+upgrade (`uv tool upgrade conexus`, `nx upgrade`, a reinstall) left a
+stale daemon running old code until a manual `nx daemon t2 stop && start`.
+`nx daemon t2 ensure-running` is now version-aware: it leaves a current
+daemon alone and gracefully cycles one whose version differs from the
+installed tool (SIGTERM drains in-flight RPC, then respawns). This is
+wired into every install path: `nx upgrade` and `scripts/reinstall-tool.sh`
+call it after installing, and the plugin / `.mcpb` session-start hooks
+already invoke it. An upgrade is now live without a manual daemon restart.
+
 ## [5.0.3] - 2026-05-25
 
 ### Fix: T2 daemon observability + stale-state detection (nexus-n8sbw)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.4] - 2026-05-25
+
+### Docs: Claude Desktop `.mcpb` update procedure + lifecycle
+
+`docs/desktop-deployment.md` gains an "Updating the Desktop Extension"
+section: why the bundle does not auto-update (MCPB v0.4 has no update
+mechanism; the extension venv is pinned at install and `uv run` reuses
+it), the manual re-install steps, what the update leaves untouched, and
+the expected connector-vs-daemon version skew.
+
 ### Fix: install/upgrade paths now bring a stale T2 daemon to current (nexus-5ldk1)
 
 The long-lived T2 daemon froze its code version at process start, so an

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.4] - 2026-05-25
+
+Plugin version aligned with conexus 5.0.4. The release wires the
+version-aware `nx daemon t2 ensure-running` into install/upgrade paths
+(nexus-5ldk1) so a stale T2 daemon is brought to the installed version
+without a manual restart; the plugin's session-start hook already calls
+`ensure-running`, so it self-heals on install. See root `CHANGELOG.md`
+§ 5.0.4.
+
 ## [5.0.3] - 2026-05-25
 
 Plugin version aligned with conexus 5.0.3. No plugin-side changes; the

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1407,6 +1407,15 @@ Stale discovery files left behind by crashed daemons trigger a
 fresh spawn rather than a false-positive — the probe is
 `os.kill(pid, 0)` against the discovery-file PID.
 
+Version-aware (nexus-5ldk1): a live daemon whose `daemon_version`
+differs from the installed `conexus` is treated as stale. The command
+gracefully cycles it (SIGTERM drains in-flight RPC, then respawns) so
+the running daemon matches the installed code. This is why `nx upgrade`,
+`scripts/reinstall-tool.sh`, and the plugin / `.mcpb` session-start
+hooks all call `ensure-running` after an install: the daemon comes up on
+the new version without a manual restart. A daemon already matching the
+installed version is left untouched.
+
 | Flag | Description |
 |------|-------------|
 | `--config-dir PATH` | Config directory override |

--- a/docs/desktop-deployment.md
+++ b/docs/desktop-deployment.md
@@ -85,6 +85,21 @@ to silence.)
 
 The check is non-fatal: a network failure, timeout, or unreachable PyPI never blocks startup. Set `NX_MCPB_SKIP_UPDATE_CHECK=1` in the environment to opt out entirely.
 
+## Updating the Desktop Extension
+
+The `.mcpb` does **not** auto-update. MCPB v0.4 has no update mechanism, and the extension's Python environment is pinned at install time: Claude Desktop builds a `uv` venv under `~/Library/Application Support/Claude/Claude Extensions/local.mcpb.<id>.conexus/.venv` from the bundle's `pyproject.toml` (`conexus>=X.Y.Z`), and every launch runs `uv run` against **that existing venv**. `uv run` reuses the resolved venv rather than re-resolving against PyPI, so a newer published conexus is not picked up until the bundle is re-installed and the venv is rebuilt.
+
+So the update is a manual, idempotent re-install:
+
+1. **Download** the new `conexus.mcpb` from the [latest release](https://github.com/Hellblazer/nexus/releases/latest) (the same asset attached to every GitHub release alongside the wheel and sdist).
+2. **Double-click it** (or Claude Desktop → Settings → Connectors → Desktop → install). Claude Desktop replaces the existing "Conexus" extension in place; you do not need to uninstall first.
+3. **First launch resolves the new version.** `uv` rebuilds the venv from the new manifest's `conexus>=X.Y.Z` pin (~20s cold, ~5s warm), pulling the new conexus from PyPI. The stale-install warning stops firing once installed == latest.
+4. **Verify** (optional): the installed version is the `version` field in the extension's `manifest.json`, and the resolved package is `<ext>/.venv/bin/python -c "from importlib.metadata import version; print(version('conexus'))"`.
+
+What the update does **not** touch: the host T2 daemon, the T3 store, the catalog, and all stored data are owned by the OS / user account and shared across the CLI, the Claude Code plugin, and the Desktop extension. Re-installing the bundle swaps only the bundle files and its venv. The daemon is not restarted by an extension update.
+
+**Version skew is expected and tolerated.** The Desktop connector (its venv) and the host T2 daemon are independent installs that can briefly differ, since they update on different triggers (a `.mcpb` re-install vs `uv tool upgrade conexus` / a CLI reinstall). The connector talks to the daemon over RPC within a major version; align them by updating whichever is behind. After a release, update both: the CLI/daemon via `uv tool upgrade conexus` (then restart the daemon), and the Desktop extension via the re-install above.
+
 ## Uninstall
 
 ### Claude Code plugin

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.0.3"
+version = "5.0.4"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.0.3",
+    "conexus>=5.0.4",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.0.3"
+version = "5.0.4"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/scripts/reinstall-tool.sh
+++ b/scripts/reinstall-tool.sh
@@ -60,3 +60,13 @@ if [[ -d "$TOOL_BIN" ]]; then
         fi
     done
 fi
+
+# nexus-5ldk1: a running T2 daemon froze its code at start and now predates
+# this reinstall. Bring it to the freshly-installed version so the reinstall
+# is live, not pending a manual `nx daemon t2 stop && ensure-running`.
+# ensure-running is version-aware: no-op on a current daemon, graceful cycle
+# on a stale one. Best-effort; never fails the reinstall.
+if command -v nx >/dev/null 2>&1; then
+    nx daemon t2 ensure-running --quiet --timeout=10 2>/dev/null || \
+        echo "(note: daemon cycle skipped/failed; run 'nx daemon t2 ensure-running' manually)"
+fi

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -704,27 +704,70 @@ def t2_ensure_running_cmd(
     config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
     disc = t2_discovery_path(config_dir)
 
-    def _daemon_is_alive() -> bool:
+    def _running_daemon() -> tuple[int, str] | None:
+        """Return (pid, daemon_version) of the live daemon, or None.
+
+        Probes the recorded PID via ``os.kill(pid, 0)``; stale discovery
+        files outlive crashed daemons, so a readable file is not proof of
+        life.
+        """
         if not disc.exists():
-            return False
+            return None
         try:
             data = json.loads(disc.read_text())
         except (OSError, json.JSONDecodeError):
-            return False
+            return None
         pid = data.get("pid")
         if not isinstance(pid, int):
-            return False
-        # Probe the PID — stale discovery files outlive crashed daemons.
+            return None
         try:
             os.kill(pid, 0)
         except (ProcessLookupError, PermissionError):
-            return False
-        return True
+            return None
+        return pid, str(data.get("daemon_version") or "")
 
-    if _daemon_is_alive():
+    def _daemon_is_alive() -> bool:
+        return _running_daemon() is not None
+
+    def _installed_version() -> str:
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as _pkg_version
+
+        try:
+            return _pkg_version("conexus")
+        except PackageNotFoundError:
+            return ""
+
+    running = _running_daemon()
+    if running is not None:
+        running_pid, running_ver = running
+        installed = _installed_version()
+        # A live daemon whose version matches the installed tool (or whose
+        # installed version can't be determined) is left alone (idempotent).
+        if not installed or running_ver == installed:
+            if not quiet:
+                click.echo("T2 daemon already running.")
+            return
+        # Version skew: the daemon froze its code at start and predates the
+        # last upgrade (nexus-5ldk1). "Ensure running" means ensure a
+        # CURRENT daemon; gracefully cycle the stale one and respawn below.
+        # SIGTERM lets the daemon drain in-flight RPC (stop() awaits
+        # wait_closed) and remove its discovery file before we respawn.
         if not quiet:
-            click.echo("T2 daemon already running.")
-        return
+            click.echo(
+                f"T2 daemon is stale (running {running_ver}, installed "
+                f"{installed}); cycling to current."
+            )
+        try:
+            os.kill(running_pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+        cycle_deadline = _time.monotonic() + 10.0
+        while _time.monotonic() < cycle_deadline:
+            if not _daemon_is_alive():
+                break
+            _time.sleep(0.1)
+        # fall through to cold spawn
 
     # Cold spawn. Use the same nx binary the operator invoked (preserves
     # PATH/virtualenv assumptions). start_new_session detaches the child

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -52,6 +52,36 @@ def upgrade(dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool) -> None:
             _log.warning("upgrade_auto_error", exc_info=True)
             return
         raise
+    # nexus-5ldk1: a running T2 daemon froze its code at start and now
+    # predates this upgrade. Bring it to the just-installed version so the
+    # upgrade is live rather than pending a manual daemon restart.
+    # ensure-running is version-aware: no-op on a current daemon, graceful
+    # cycle on a stale one. Best-effort, non-dry-run only.
+    if not dry_run:
+        _cycle_daemon_to_current()
+
+
+def _cycle_daemon_to_current() -> None:
+    """Bring a stale T2 daemon to the just-installed version (best-effort).
+
+    Shells out to ``nx daemon t2 ensure-running --quiet``, the same
+    version-aware primitive the plugin/mcpb session-start hooks use. Never
+    raises: a daemon nudge must not fail the upgrade.
+    """
+    import subprocess
+
+    try:
+        from nexus.commands.daemon import _resolve_nx_bin
+
+        subprocess.run(
+            [*_resolve_nx_bin(), "daemon", "t2", "ensure-running", "--quiet"],
+            timeout=30,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("upgrade_daemon_cycle_failed", error=str(exc))
 
 
 def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool = False) -> None:

--- a/tests/daemon/test_t2_ensure_running.py
+++ b/tests/daemon/test_t2_ensure_running.py
@@ -34,15 +34,30 @@ def _discovery_path(config_dir: Path) -> Path:
     return t2_discovery_path(config_dir)
 
 
-def _write_discovery(config_dir: Path, pid: int) -> None:
-    """Pre-seed a discovery file shaped like the real daemon writes."""
+def _installed_conexus_version() -> str:
+    from importlib.metadata import version as _v
+
+    try:
+        return _v("conexus")
+    except Exception:
+        return "0.0.0"
+
+
+def _write_discovery(config_dir: Path, pid: int, version: str | None = None) -> None:
+    """Pre-seed a discovery file shaped like the real daemon writes.
+
+    ``version`` defaults to the installed conexus version so the
+    "already running, current" path is exercised; pass an older string
+    to simulate a stale daemon that ensure-running should cycle
+    (nexus-5ldk1).
+    """
     payload = {
         "format_version": 1,
         "uds_path": str(config_dir / "sockets" / "t2.sock"),
         "tcp_host": "127.0.0.1",
         "tcp_port": 12345,
         "pid": pid,
-        "daemon_version": "4.34.1",
+        "daemon_version": version if version is not None else _installed_conexus_version(),
         "start_time": "2026-05-22T19:00:00+00:00",
     }
     dest = _discovery_path(config_dir)
@@ -74,6 +89,74 @@ class TestEnsureRunning:
         assert result.exit_code == 0, result.output
         assert "already running" in result.output
         assert spawn_calls == []
+
+    def test_stale_version_daemon_is_cycled_then_respawned(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """nexus-5ldk1: a LIVE daemon whose version != installed tool is
+        stale (froze old code at start). ensure-running must SIGTERM it
+        and respawn a current one, rather than leaving the stale daemon."""
+        import signal as _signal
+
+        # Live daemon at an older version than the installed tool.
+        _write_discovery(tmp_path, pid=424242, version="0.0.1-stale")
+        monkeypatch.setattr(
+            "importlib.metadata.version", lambda _name: "9.9.9-installed"
+        )
+
+        # Stateful os.kill: pid is alive until it receives SIGTERM, then
+        # dead. Guards the test process: we never signal a real pid.
+        state = {"terminated": False}
+
+        def _fake_kill(pid, sig):  # noqa: ANN001
+            if pid != 424242:
+                raise ProcessLookupError
+            if sig == 0:
+                if state["terminated"]:
+                    raise ProcessLookupError
+                return
+            if sig == _signal.SIGTERM:
+                state["terminated"] = True
+                return
+
+        monkeypatch.setattr(os, "kill", _fake_kill)
+
+        spawn_calls: list[list[str]] = []
+
+        class _FakePopen:
+            def __init__(self, argv, **_kw):  # noqa: ANN001
+                spawn_calls.append(argv)
+
+        monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+        result = CliRunner().invoke(
+            main,
+            ["daemon", "t2", "ensure-running",
+             "--config-dir", str(tmp_path), "--timeout", "0.2"],
+        )
+        # Stale daemon was SIGTERM'd and a respawn was attempted.
+        assert state["terminated"] is True, "stale daemon was not cycled"
+        assert len(spawn_calls) == 1, "no respawn after cycling stale daemon"
+        assert "stale" in result.output.lower()
+
+    def test_current_version_daemon_not_cycled(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """A live daemon whose version == installed tool is left alone."""
+        _write_discovery(tmp_path, pid=424242, version="9.9.9-installed")
+        monkeypatch.setattr(
+            "importlib.metadata.version", lambda _name: "9.9.9-installed"
+        )
+        monkeypatch.setattr(os, "kill", lambda pid, sig: None)  # pid "alive"
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda *a, **kw: pytest.fail("must not cycle a current daemon"),
+        )
+        result = CliRunner().invoke(
+            main,
+            ["daemon", "t2", "ensure-running", "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "already running" in result.output
 
     def test_already_running_quiet_suppresses_output(
         self, tmp_path, monkeypatch,

--- a/tests/test_upgrade_cmd.py
+++ b/tests/test_upgrade_cmd.py
@@ -29,6 +29,15 @@ def _tmp_db(tmp_path: Path) -> Path:
     return tmp_path / "memory.db"
 
 
+@pytest.fixture(autouse=True)
+def _no_real_daemon_nudge():
+    """Patch the post-upgrade daemon cycle (nexus-5ldk1) for all upgrade
+    tests so they never shell out to the real host T2 daemon. Yields the
+    mock so tests can assert whether the nudge fired."""
+    with patch("nexus.commands.upgrade._cycle_daemon_to_current") as m:
+        yield m
+
+
 class TestUpgradeCommand:
     """Tests for the ``nx upgrade`` CLI command."""
 
@@ -52,6 +61,33 @@ class TestUpgradeCommand:
             result = runner.invoke(main, ["upgrade", "--dry-run"])
         assert result.exit_code == 0
         assert "dry-run" in result.output.lower() or "pending" in result.output.lower()
+
+    def test_upgrade_cycles_daemon_on_success(
+        self, runner: CliRunner, tmp_path: Path, _no_real_daemon_nudge,
+    ) -> None:
+        """nexus-5ldk1: a successful (non-dry-run) upgrade brings a stale
+        daemon to the just-installed version."""
+        db_path = tmp_path / "memory.db"
+        with (
+            patch("nexus.commands.upgrade._db_path", return_value=db_path),
+            patch("nexus.commands.upgrade.T3_UPGRADES", []),
+        ):
+            result = runner.invoke(main, ["upgrade"])
+        assert result.exit_code == 0
+        assert _no_real_daemon_nudge.called, "upgrade did not cycle the daemon"
+
+    def test_upgrade_dry_run_does_not_cycle_daemon(
+        self, runner: CliRunner, tmp_path: Path, _no_real_daemon_nudge,
+    ) -> None:
+        """--dry-run installs nothing, so it must not touch the daemon."""
+        db_path = tmp_path / "memory.db"
+        with (
+            patch("nexus.commands.upgrade._db_path", return_value=db_path),
+            patch("nexus.commands.upgrade.T3_UPGRADES", []),
+        ):
+            result = runner.invoke(main, ["upgrade", "--dry-run"])
+        assert result.exit_code == 0
+        assert not _no_real_daemon_nudge.called, "dry-run must not cycle the daemon"
 
     def test_upgrade_force(self, runner: CliRunner, tmp_path: Path) -> None:
         """--force resets version gate to 0.0.0 and re-runs."""

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.0.3"
+version = "5.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Promotes develop to main and bumps conexus 5.0.3 → 5.0.4. Patch release: T2 daemon lifecycle control + Desktop update-procedure docs. No schema changes; safe in-place upgrade from 5.0.3.

### Changes since v5.0.3

- **fix(daemon): install/upgrade paths bring a stale T2 daemon to current (nexus-5ldk1).** The daemon froze its code version at start, so an upgrade left a stale daemon until a manual restart. `nx daemon t2 ensure-running` is now version-aware (leaves a current daemon alone; gracefully cycles a stale one via SIGTERM-drain + respawn), and it's wired into every install path: `nx upgrade`, `scripts/reinstall-tool.sh`, and the plugin/`.mcpb` session-start hooks (which already call it). An upgrade is now live without a manual `nx daemon t2 stop && start`.
- **docs:** `docs/desktop-deployment.md` documents the `.mcpb` update procedure + lifecycle; `docs/cli-reference.md` documents the version-aware `ensure-running` cycling.

### Manifest bumps (all 7, CI parity-enforced)

`pyproject.toml`, `mcpb/pyproject.toml` (+ `conexus>=5.0.4`), `mcpb/manifest.json`, `.claude-plugin/marketplace.json` (both `version` + both `source.ref` → `v5.0.4`), `conexus/.claude-plugin/plugin.json`, `sn/.claude-plugin/plugin.json`. `uv.lock` refreshed.

## Test plan

- [x] Unit suite: 7595 passed; 1 order-dependent flake (`test_catalog_graph_many::test_node_cap_fires_at_boundary`) confirmed unrelated — passes isolated + as module, untouched by this release, green on #957 CI (filed as a test-isolation bead)
- [x] Integration suite: 77 passed, 30 skipped, **0 failed** (gudwb skip-guards hold)
- [x] Sandbox smoke: `[done]`, all doctor checks pass
- [x] Pre-push parity: all 7 manifests + both refs read 5.0.4 / v5.0.4

## Closes

nexus-5ldk1 (daemon lifecycle control; doctor skew-check sub-item deferred per the bead).