### PR TITLE
docs(release-skill): nx→conexus namespace + add mcpb bump targets

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Use when cutting a release, bumping version, tagging, or publishing to PyPI. Enforces the full release checklist from CLAUDE.md § Release Process. Also surfaces as /nx:release.
+description: Use when cutting a release, bumping version, tagging, or publishing to PyPI. Enforces the full release checklist from CLAUDE.md § Release Process. Also surfaces as /conexus:release.
 ---
 
 # Release Checklist
@@ -34,11 +34,13 @@ Cross-walk against:
 
 Update any drift before bumping version. Doc audit is what catches "we changed the wire format but forgot to document it."
 
-### 3. Bump version in ALL FIVE bump targets
+### 3. Bump version in ALL SEVEN bump targets
 
-CI enforces parity. Missing any one of these fails the marketplace-version-matches-pyproject test or the marketplace-source-ref-matches-pyproject test.
+CI enforces parity. Missing any one of these fails the marketplace-version-matches-pyproject test, the marketplace-source-ref-matches-pyproject test, or the mcpb-manifest-version-matches-pyproject test.
 
 - `pyproject.toml`: `version = "X.Y.Z"` (canonical source of truth)
+- `mcpb/pyproject.toml`: `version` **and** the `conexus>=X.Y.Z` dependency pin
+- `mcpb/manifest.json`: `version`
 - `.claude-plugin/marketplace.json`: **both `version` fields** (one for conexus, one for sn)
 - `.claude-plugin/marketplace.json`: **both `plugins[].source.ref` fields** — must be `"vX.Y.Z"` (the tag form). Easy to forget. This is what decouples installed users from main HEAD: plugin installs follow the pinned tag, not whatever main currently is. **CRITICAL: nexus-mkj6u 2026-05-23**
 - `conexus/.claude-plugin/plugin.json`: `version`
@@ -51,7 +53,7 @@ Semver: MAJOR for breaking, MINOR for new features, PATCH for bug fixes.
 ### 4. Update both changelogs
 
 - `CHANGELOG.md` (root): move `## [Unreleased]` content into a new `## [X.Y.Z] - YYYY-MM-DD` section. Leave a fresh empty `## [Unreleased]` at the top.
-- `nx/CHANGELOG.md` (plugin changelog): always update, even if no plugin changes (note: "Plugin version aligned with conexus X.Y.Z. No plugin-side changes." is acceptable).
+- `conexus/CHANGELOG.md` (plugin changelog): always update, even if no plugin changes (note: "Plugin version aligned with conexus X.Y.Z. No plugin-side changes." is acceptable).
 
 ### 5. Refresh `uv.lock`
 
@@ -63,7 +65,7 @@ The lock file MUST be committed. CI also checks this.
 
 ### 6. Run sandbox smoke (~2 min)
 
-Required for any change touching `pyproject.toml`, `uv.lock`, `src/nexus/db/migrations.py`, `src/nexus/mcp/**`, `nx/**`, `.claude-plugin/**`, `src/nexus/commands/{doctor,upgrade}.py`.
+Required for any change touching `pyproject.toml`, `uv.lock`, `src/nexus/db/migrations.py`, `src/nexus/mcp/**`, `conexus/**`, `.claude-plugin/**`, `src/nexus/commands/{doctor,upgrade}.py`.
 
 ```bash
 ./tests/e2e/release-sandbox.sh smoke
@@ -186,7 +188,7 @@ nx --version                 # must print X.Y.Z
 
 - **Bumping only `pyproject.toml` and missing the four plugin manifests.** CI parity check catches this late. Run the Step 8 pre-push check.
 - **Skipping the integration suite.** Unit-only is what CI runs; integration is your last gate against keyed-API regressions before tag-push.
-- **Skipping sandbox smoke when `nx/**` or `pyproject.toml` changed.** The smoke catches plugin-load + db-migration regressions that unit tests miss.
+- **Skipping sandbox smoke when `conexus/**` or `pyproject.toml` changed.** The smoke catches plugin-load + db-migration regressions that unit tests miss.
 - **Using `gh release create` after `git push origin vX.Y.Z`.** Duplicate release. The Release workflow already creates one.
 - **Forgetting `uv sync`.** `uv.lock` not updated; CI fails or local install resolves differently.
 - **Forgetting `scripts/reinstall-tool.sh` after tag-push.** Local `nx` stays on old version; the post-merge "verify locally" step lies.


### PR DESCRIPTION
## Summary

Scrubs stale `nx`-namespace references from the release skill (`.claude/skills/release/SKILL.md`) and fixes its incomplete bump-target list — the recurring release friction surfaced this session.

- **Namespace** (the plugin moved `nx/` → `conexus/` at v5.0.0): `nx/CHANGELOG.md` → `conexus/CHANGELOG.md`; `/nx:release` → `/conexus:release`; `nx/**` → `conexus/**` (sandbox-smoke trigger lists). The CLI binary `nx` is unchanged and left as-is.
- **Completeness**: Step 3 said "ALL FIVE bump targets" but it's seven — added `mcpb/pyproject.toml` (version + `conexus>=X.Y.Z` dep pin) and `mcpb/manifest.json`, which CI's `mcpb-manifest-version-matches-pyproject` test enforces. Each release this session required pulling the mcpb targets from the continuation rather than the skill.

Companion local-memory cleanup (not in this PR — they're personal `~/.claude` memory): the forward-looking feedback memories (`feedback_version_bump_manifests`, `feedback_release_discipline`, `feedback_invoke_release_skill`, etc.) were scrubbed of the same stale `nx/` paths and the 5→7 manifest count. CLAUDE.md / AGENTS.md were already clean.

## Test plan

- [x] Docs-only change (a skill markdown file); no code touched.
- [x] Verified no stale `nx/`, `/nx:`, or `mcp__plugin_nx_` refs remain in the skill; CLI `nx` refs preserved.