### PR TITLE
fix: nx→conexus plugin-name + plugin-dir refs (sn docs, CI, e2e/cc-validation harnesses)

### DIFF
--- a/.github/workflows/plan-schema-check.yml
+++ b/.github/workflows/plan-schema-check.yml
@@ -6,8 +6,8 @@ name: plan-schema
 on:
   pull_request:
     paths:
-      - "nx/plans/**/*.yml"
-      - "nx/plans/**/*.yaml"
+      - "conexus/plans/**/*.yml"
+      - "conexus/plans/**/*.yaml"
       - ".nexus/plans/**/*.yml"
       - ".nexus/plans/**/*.yaml"
       - "docs/rdr/**/plans.yml"
@@ -40,7 +40,7 @@ jobs:
           from nexus.plans.loader import ci_validate_plan_tree
 
           repo_root = Path('.').resolve()
-          plugin_root = repo_root / 'nx'
+          plugin_root = repo_root / 'conexus'
           sys.exit(ci_validate_plan_tree(
               plugin_root=plugin_root, repo_root=repo_root,
           ))

--- a/scripts/validate/04-hooks.sh
+++ b/scripts/validate/04-hooks.sh
@@ -11,7 +11,7 @@ REPO=$(git rev-parse --show-toplevel)
 HOOKS="$REPO/conexus/hooks/scripts"
 
 # Fake Claude Code hook env
-export CLAUDE_PLUGIN_ROOT="$REPO/nx"
+export CLAUDE_PLUGIN_ROOT="$REPO/conexus"
 export CLAUDE_PROJECT_DIR="$SANDBOX"
 
 # Fake SessionStart event payload

--- a/sn/README.md
+++ b/sn/README.md
@@ -75,11 +75,11 @@ sn/
 └── README.md
 ```
 
-## Relationship to nx
+## Relationship to conexus
 
-`sn` is project-agnostic — it works in any repository where Serena is configured. It lives in the same marketplace as `nx` but has no dependency on it. Install either or both.
+`sn` is project-agnostic — it works in any repository where Serena is configured. It lives in the same marketplace as `conexus` but has no dependency on it. Install either or both.
 
 | Plugin | Scope | What it provides |
 |--------|-------|-----------------|
-| `nx` | Project-specific | Knowledge management, semantic search, agents, beads, RDR tracking |
+| `conexus` | Project-specific | Knowledge management, semantic search, agents, beads, RDR tracking |
 | `sn` | Universal | MCP tool guidance for subagents (Serena + Context7) |

--- a/sn/hooks/scripts/routing/README.md
+++ b/sn/hooks/scripts/routing/README.md
@@ -1,7 +1,7 @@
 # Routing Hooks (sn) — RDR-125
 
 PreToolUse hooks shipped in the sn plugin. The framework
-(`_lib.py`, `_run_python_hook.sh`) is canonical in nx and **vendored**
+(`_lib.py`, `_run_python_hook.sh`) is canonical in conexus and **vendored**
 here byte-for-byte; `tests/test_routing_lib_drift.py` in the nexus
 monorepo refuses any divergence.
 
@@ -13,13 +13,13 @@ redirects to a tool the plugin ships. sn ships Serena MCP tools
 `grep_for_symbols_redirects_to_serena` rule lives here because its
 deny message names those tools.
 
-Installing nx without sn means this hook does not exist -- which is
+Installing conexus without sn means this hook does not exist -- which is
 the correct default. Users without Serena get no surprise denial of
 their `grep` invocations.
 
 ## Files
 
-- `_lib.py` -- vendored from nx canonical. **Do not edit in isolation.**
+- `_lib.py` -- vendored from conexus canonical. **Do not edit in isolation.**
   Updating the framework means updating both copies atomically.
 - `grep_for_symbols_redirects_to_serena.py` -- the routing rule. Uses
   the standard `sys.path.insert(0, dirname); import _lib` pattern.
@@ -27,7 +27,7 @@ their `grep` invocations.
   `conexus/hooks/scripts/routing/registry.yaml`.
 
 The `_run_python_hook.sh` wrapper at `sn/hooks/scripts/_run_python_hook.sh`
-is also vendored from nx canonical.
+is also vendored from conexus canonical.
 
 ## Cumulative-cap accounting (RDR-121 + RDR-125)
 

--- a/sn/hooks/scripts/routing/registry.yaml
+++ b/sn/hooks/scripts/routing/registry.yaml
@@ -3,18 +3,18 @@
 #
 # Per RDR-125, rules whose deny message redirects to a plugin-specific
 # tool live in the plugin that ships that tool. This file is sn's
-# registry; nx ships its own at conexus/hooks/scripts/routing/registry.yaml.
+# registry; conexus ships its own at conexus/hooks/scripts/routing/registry.yaml.
 #
 # Aggregate cap (RDR-121 + RDR-125): the union of routing rules
 # across all plugins must stay <= 4 PreToolUse:Bash entries to honor
 # the <300ms p95 cumulative budget. Current aggregate count:
-#   nx: 2 routing rules (git_add_all, phase_review_close)
+#   conexus: 2 routing rules (git_add_all, phase_review_close)
 #       + pre_close_verification_hook = 3 PreToolUse:Bash entries
 #   sn: 1 (grep_for_symbols_redirects_to_serena)
 #   total: 4, AT CAP. Adding a fifth rule in ANY plugin requires
 #   either consolidation or a budget revision in a successor RDR.
 #
-# The schema mirrors nx's registry.yaml exactly. See
+# The schema mirrors conexus's registry.yaml exactly. See
 # conexus/hooks/scripts/routing/registry.yaml for field documentation.
 
 rules:

--- a/tests/cc-validation/scenarios/12_real_nx_subagent.sh
+++ b/tests/cc-validation/scenarios/12_real_nx_subagent.sh
@@ -15,7 +15,7 @@ cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" <<EOF
   "version": 2,
   "plugins": {
     "conexus@nexus-plugins": [
-      { "scope": "user", "installPath": "$REPO_ROOT/nx", "version": "dev",
+      { "scope": "user", "installPath": "$REPO_ROOT/conexus", "version": "dev",
         "installedAt": "$NOW", "lastUpdated": "$NOW" }
     ]
   }

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -106,7 +106,7 @@ fi
 #   ~/.claude/settings.json                  — enabledPlugins + permissions
 NOW="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
 
-# Build installed_plugins.json — nx only.
+# Build installed_plugins.json (conexus only).
 cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" << PLUGINS_EOF
 {
   "version": 2,
@@ -114,7 +114,7 @@ cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" << PLUGINS_EOF
     "conexus@nexus-plugins": [
       {
         "scope": "user",
-        "installPath": "$REPO_ROOT/nx",
+        "installPath": "$REPO_ROOT/conexus",
         "version": "dev",
         "installedAt": "$NOW",
         "lastUpdated": "$NOW"

--- a/tests/e2e/scenarios/00_debug_load.sh
+++ b/tests/e2e/scenarios/00_debug_load.sh
@@ -23,8 +23,8 @@ plugins_json="$TEST_HOME/.claude/plugins/installed_plugins.json"
 if [[ ! -f "$plugins_json" ]]; then
     fail "Isolated installed_plugins.json not found at $plugins_json"
 else
-    if grep -q "$REPO_ROOT/nx" "$plugins_json"; then
-        pass "isolated installed_plugins.json points to dev repo ($REPO_ROOT/nx)"
+    if grep -q "$REPO_ROOT/conexus" "$plugins_json"; then
+        pass "isolated installed_plugins.json points to dev repo ($REPO_ROOT/conexus)"
     else
         fail "installed_plugins.json does NOT point to dev repo — may be testing v1"
         echo "    content: $(cat "$plugins_json")"
@@ -117,7 +117,7 @@ scenario_end
 scenario "00 debug-load: SubagentStart hook injects RELAY_TEMPLATE"
 
 # Run subagent-start.sh directly with CLAUDE_PLUGIN_ROOT set
-subagent_hook_out=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/nx" \
+subagent_hook_out=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/conexus" \
     HOME="$TEST_HOME" \
     PATH="$TEST_HOME/.local/bin:$PATH" \
     CLAUDE_PROJECT_DIR="$REPO_ROOT" \


### PR DESCRIPTION
## Summary

The `nx`→`conexus` plugin rename (v5.0.0) scrubbed user-facing surfaces but left two layers stale. This PR closes both.

### 1. `sn` plugin internals referred to the sibling plugin as `nx` (commit 1)
- `sn/README.md` — "Relationship to **nx**" heading, "same marketplace as `nx`", comparison-table row → `conexus`.
- `sn/hooks/scripts/routing/registry.yaml` (comments) — "nx ships its own…", "nx: 2 routing rules", "mirrors nx's registry.yaml" → `conexus`.
- `sn/hooks/scripts/routing/README.md` — "canonical in nx", "Installing nx without sn", "vendored from nx canonical" (×2) → `conexus`.

### 2. CI + test harnesses pointed at the removed `nx/` plugin directory (commit 2)
These are functional bugs — the plugin dir moved to `conexus/`, so each was operating on a path that no longer exists:
- **`.github/workflows/plan-schema-check.yml`** — trigger globs watched `nx/plans/**` (dead), and the validator invoked `ci_validate_plan_tree(plugin_root=repo_root / 'nx')`. Net effect: **plan-schema validation was a silent no-op for the plugin tier** since the rename (17 `conexus/plans` YAMLs unvalidated). Verified the corrected invocation exits 0 against `conexus/plans`.
- **`tests/e2e/run.sh`** + **`tests/e2e/scenarios/00_debug_load.sh`** — `installed_plugins.json` `installPath` and the load-assertion pointed at `$REPO_ROOT/nx`; e2e plugin-load scenarios tested against a missing dir.
- **`tests/cc-validation/scenarios/12_real_nx_subagent.sh`** — same `installPath` fix.
- **`scripts/validate/04-hooks.sh`** — exported `CLAUDE_PLUGIN_ROOT="$REPO/nx"` while sourcing hooks from `conexus/` (line 11), an internal contradiction.

## Left intentionally unchanged
- The `nx` **CLI binary** (`nx <verb>`, `nx --version`, `which('nx')`, `src/nexus/mcp/_first_run.py` sibling/`~/.local/bin/nx` lookups) — the command was not renamed.
- `tests/test_plugin_name_drift.py` — intentionally plants a manifest named `nx` to test the migration **warning**.
- `conexus/CHANGELOG.md` `/nx:` mentions — historical entries documenting the rename itself.
- `scripts/spikes/spike_rdr096_a2_results.jsonl` — frozen spike output data.
- `.claude/settings.local.json` — local, gitignored permission cruft (separate concern).

## Test plan
- [x] `test_plugin_structure.py` + `test_sn_plugin.py` + `test_routing_lib_drift.py`: 634 passed, 27 skipped.
- [x] `ci_validate_plan_tree(plugin_root=repo_root/'conexus')` exits 0 (17 plan files now actually validated).