### PR TITLE
chore: nx→conexus namespace cleanup + RDR-128 root-cause RDR (consolidates #959/#960/#961)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Use when cutting a release, bumping version, tagging, or publishing to PyPI. Enforces the full release checklist from CLAUDE.md § Release Process. Also surfaces as /nx:release.
+description: Use when cutting a release, bumping version, tagging, or publishing to PyPI. Enforces the full release checklist from CLAUDE.md § Release Process. Also surfaces as /conexus:release.
 ---
 
 # Release Checklist
@@ -34,11 +34,13 @@ Cross-walk against:
 
 Update any drift before bumping version. Doc audit is what catches "we changed the wire format but forgot to document it."
 
-### 3. Bump version in ALL FIVE bump targets
+### 3. Bump version in ALL SEVEN bump targets
 
-CI enforces parity. Missing any one of these fails the marketplace-version-matches-pyproject test or the marketplace-source-ref-matches-pyproject test.
+CI enforces parity. Missing any one of these fails the marketplace-version-matches-pyproject test, the marketplace-source-ref-matches-pyproject test, or the mcpb-manifest-version-matches-pyproject test.
 
 - `pyproject.toml`: `version = "X.Y.Z"` (canonical source of truth)
+- `mcpb/pyproject.toml`: `version` **and** the `conexus>=X.Y.Z` dependency pin
+- `mcpb/manifest.json`: `version`
 - `.claude-plugin/marketplace.json`: **both `version` fields** (one for conexus, one for sn)
 - `.claude-plugin/marketplace.json`: **both `plugins[].source.ref` fields** — must be `"vX.Y.Z"` (the tag form). Easy to forget. This is what decouples installed users from main HEAD: plugin installs follow the pinned tag, not whatever main currently is. **CRITICAL: nexus-mkj6u 2026-05-23**
 - `conexus/.claude-plugin/plugin.json`: `version`
@@ -51,7 +53,7 @@ Semver: MAJOR for breaking, MINOR for new features, PATCH for bug fixes.
 ### 4. Update both changelogs
 
 - `CHANGELOG.md` (root): move `## [Unreleased]` content into a new `## [X.Y.Z] - YYYY-MM-DD` section. Leave a fresh empty `## [Unreleased]` at the top.
-- `nx/CHANGELOG.md` (plugin changelog): always update, even if no plugin changes (note: "Plugin version aligned with conexus X.Y.Z. No plugin-side changes." is acceptable).
+- `conexus/CHANGELOG.md` (plugin changelog): always update, even if no plugin changes (note: "Plugin version aligned with conexus X.Y.Z. No plugin-side changes." is acceptable).
 
 ### 5. Refresh `uv.lock`
 
@@ -63,7 +65,7 @@ The lock file MUST be committed. CI also checks this.
 
 ### 6. Run sandbox smoke (~2 min)
 
-Required for any change touching `pyproject.toml`, `uv.lock`, `src/nexus/db/migrations.py`, `src/nexus/mcp/**`, `nx/**`, `.claude-plugin/**`, `src/nexus/commands/{doctor,upgrade}.py`.
+Required for any change touching `pyproject.toml`, `uv.lock`, `src/nexus/db/migrations.py`, `src/nexus/mcp/**`, `conexus/**`, `.claude-plugin/**`, `src/nexus/commands/{doctor,upgrade}.py`.
 
 ```bash
 ./tests/e2e/release-sandbox.sh smoke
@@ -186,7 +188,7 @@ nx --version                 # must print X.Y.Z
 
 - **Bumping only `pyproject.toml` and missing the four plugin manifests.** CI parity check catches this late. Run the Step 8 pre-push check.
 - **Skipping the integration suite.** Unit-only is what CI runs; integration is your last gate against keyed-API regressions before tag-push.
-- **Skipping sandbox smoke when `nx/**` or `pyproject.toml` changed.** The smoke catches plugin-load + db-migration regressions that unit tests miss.
+- **Skipping sandbox smoke when `conexus/**` or `pyproject.toml` changed.** The smoke catches plugin-load + db-migration regressions that unit tests miss.
 - **Using `gh release create` after `git push origin vX.Y.Z`.** Duplicate release. The Release workflow already creates one.
 - **Forgetting `uv sync`.** `uv.lock` not updated; CI fails or local install resolves differently.
 - **Forgetting `scripts/reinstall-tool.sh` after tag-push.** Local `nx` stays on old version; the post-merge "verify locally" step lies.

--- a/.github/workflows/plan-schema-check.yml
+++ b/.github/workflows/plan-schema-check.yml
@@ -6,8 +6,8 @@ name: plan-schema
 on:
   pull_request:
     paths:
-      - "nx/plans/**/*.yml"
-      - "nx/plans/**/*.yaml"
+      - "conexus/plans/**/*.yml"
+      - "conexus/plans/**/*.yaml"
       - ".nexus/plans/**/*.yml"
       - ".nexus/plans/**/*.yaml"
       - "docs/rdr/**/plans.yml"
@@ -40,7 +40,7 @@ jobs:
           from nexus.plans.loader import ci_validate_plan_tree
 
           repo_root = Path('.').resolve()
-          plugin_root = repo_root / 'nx'
+          plugin_root = repo_root / 'conexus'
           sys.exit(ci_validate_plan_tree(
               plugin_root=plugin_root, repo_root=repo_root,
           ))

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -143,7 +143,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-125](rdr-125-routing-hook-plugin-ownership.md) | Routing-Hook Plugin Ownership: Each Plugin Ships Its Own Rules | Architecture | Closed 2026-05-21 (shipped in 4.33.1) | 2026-05-20 |
 | [RDR-126](rdr-126-claude-desktop-deployment-unified-chat-cowork.md) | Claude Desktop Deployment: Unified Chat and Cowork Surface | Architecture | Draft | 2026-05-23 |
 | [RDR-127](rdr-127-substrate-decoupled-surface-rendering.md) | Substrate-Decoupled Surface Rendering | Architecture | Draft | 2026-05-24 |
-| [RDR-128](rdr-128-t2-single-writer-enforcement.md) | T2 Single-Writer Enforcement: One Owner for memory.db, or an Enforced Lock Discipline | Architecture | Draft | 2026-05-25 |
+| [RDR-128](rdr-128-t2-single-writer-enforcement.md) | T2 Single-Writer Enforcement: One Owner for memory.db, or an Enforced Lock Discipline | Architecture | Accepted 2026-05-25 (gate PASSED) | 2026-05-25 |
 
 > **Scrapped 2026-05-19 (RDR-110-119 arc).** Bundled the storage-substrate split with new abstractions (tuplespace, ORB, host-trust, surfaces-as-tuples, UI fabric); scope discipline failed across nine RDRs and 67 stranded beads. Files preserved as tombstones per the "never delete RDR files" rule. Postmortem: [docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work continues as [RDR-120](rdr-120-storage-substrate-split.md) with an explicit moratorium on co-shipped consumers. Numbers RDR-114 through RDR-117 are unused on `main` (drafted on feature branches that never merged).
 

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -142,6 +142,8 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-121](rdr-121-hook-enforced-tool-routing.md) | Hook-Enforced Tool Routing: PreToolUse as Backstop for Soft Guidance | Architecture | Closed 2026-05-20 (shipped in 4.33.0) | 2026-05-19 |
 | [RDR-125](rdr-125-routing-hook-plugin-ownership.md) | Routing-Hook Plugin Ownership: Each Plugin Ships Its Own Rules | Architecture | Closed 2026-05-21 (shipped in 4.33.1) | 2026-05-20 |
 | [RDR-126](rdr-126-claude-desktop-deployment-unified-chat-cowork.md) | Claude Desktop Deployment: Unified Chat and Cowork Surface | Architecture | Draft | 2026-05-23 |
+| [RDR-127](rdr-127-substrate-decoupled-surface-rendering.md) | Substrate-Decoupled Surface Rendering | Architecture | Draft | 2026-05-24 |
+| [RDR-128](rdr-128-t2-single-writer-enforcement.md) | T2 Single-Writer Enforcement: One Owner for memory.db, or an Enforced Lock Discipline | Architecture | Draft | 2026-05-25 |
 
 > **Scrapped 2026-05-19 (RDR-110-119 arc).** Bundled the storage-substrate split with new abstractions (tuplespace, ORB, host-trust, surfaces-as-tuples, UI fabric); scope discipline failed across nine RDRs and 67 stranded beads. Files preserved as tombstones per the "never delete RDR files" rule. Postmortem: [docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work continues as [RDR-120](rdr-120-storage-substrate-split.md) with an explicit moratorium on co-shipped consumers. Numbers RDR-114 through RDR-117 are unused on `main` (drafted on feature branches that never merged).
 

--- a/docs/rdr/rdr-128-t2-single-writer-enforcement.md
+++ b/docs/rdr/rdr-128-t2-single-writer-enforcement.md
@@ -91,16 +91,29 @@ the indexer-writer starves the daemon's *startup-migration* writer; aigkb = the
 unowned-lifecycle sibling. The pattern is not coincidence; it is the predictable
 consequence of N writers on one WAL lock.
 
-**RF-3 — contention hardening is inconsistent across paths.** v4m7y added
-`busy_timeout`+retry to `reclaim_stale`, but the daemon's **startup migration**
-(`apply_pending` via `T2Database.bootstrap_schema`, t2_daemon.py:493) has no such
-tolerance — it crashes hard on a locked DB. So even the band-aid was applied to
-one path and not the structurally-identical one next to it.
+**RF-3 — contention hardening is inconsistent across paths. VERIFIED 2026-05-25.**
+v4m7y added `busy_timeout`+retry to `reclaim_stale`, but the daemon's **startup
+migration** (`apply_pending` via `T2Database.bootstrap_schema`) has no such
+tolerance. Confirmed by reading the source: `bootstrap_schema`
+(`db/t2/__init__.py`) opens its connection with `PRAGMA busy_timeout=5000` (5s)
+and no lock-retry (`apply_pending`'s `MigrationRetry` handles migration-internal
+signals, not SQLite `database is locked`), whereas `reclaim_stale`
+(`aspect_extraction_queue.py:162`) uses `busy_timeout=30000` (30s) + bounded
+retry. Under the observed 10+ minute indexer lock the 5s timeout expires and the
+daemon crashes — matching the live traceback. **P0 spec:** give `bootstrap_schema`
+`busy_timeout>=30000` and wrap `apply_pending` in a lock-retry, mirroring
+`reclaim_stale`.
 
-**RF-4 — the 5.0.4 lifecycle cycle has no safety interlock.** `ensure-running`'s
-version-aware cycle SIGTERMs a running daemon without first confirming the
-replacement can acquire the DB. Trading a working-but-stale daemon for no daemon
-is strictly worse; the cycle needs a precondition.
+**RF-4 — the 5.0.4 lifecycle cycle has no safety interlock. VERIFIED 2026-05-25.**
+Confirmed in `commands/daemon.py`: on version skew `ensure-running` calls
+`os.kill(running_pid, SIGTERM)` **unconditionally**, waits ≤10s for the old daemon
+to die, then falls through to cold spawn — with no precondition that a replacement
+can acquire the DB lock. **RF-3 × RF-4 is the exact amplification mechanism of the
+live incident:** the cycle tears down the healthy daemon (RF-4); the respawn's
+5s-no-retry startup migration crashes on the indexer's lock (RF-3); `ensure-running`
+is one-shot, so the daemon is left down. **P0 spec:** do not SIGTERM a healthy
+daemon for a version-cycle unless the DB is confirmed acquirable (or make the cycle
+atomic — only tear down once the replacement is confirmed startable).
 
 **RF-5 — the boundary is already recognized and linted; this is a tightening
 exercise.** `src/nexus/storage_boundary_lint.py` already flags direct
@@ -226,3 +239,9 @@ Pending — to be run via `/conexus:rdr-gate` after research findings are verifi
   storage_boundary_lint wired into `nx doctor --check-storage-boundary`). Added
   the construction-site lint-coverage gap and a second live contention incident.
   T2 findings: nexus_rdr/128-research-1, /128-research-1-verified.
+- 2026-05-25: RF-3 and RF-4 verified from source (bootstrap_schema 5s/no-retry vs
+  reclaim_stale 30s+retry; ensure-running unconditional SIGTERM). RF-3 × RF-4
+  pinned as the exact amplification mechanism; P0 specs recorded on each. A third
+  live `database is locked` contention hit while recording these findings. T2:
+  nexus_rdr/128-research-2, /128-research-3. All outstanding RFs (1,3,4,5) now
+  verified; RF-2 corroborated by the three live incidents + the RF-3 traceback.

--- a/docs/rdr/rdr-128-t2-single-writer-enforcement.md
+++ b/docs/rdr/rdr-128-t2-single-writer-enforcement.md
@@ -172,26 +172,55 @@ retry — RDR-128's thesis demonstrated twice in one session.
 
 ## Proposed Solution
 
-Enforce the single-writer invariant. Direction (to be refined in research/gate):
+Enforce the single-writer invariant. Specifications (tightened at gate, 2026-05-25,
+in response to the Layer-3 critique):
 
 1. **Route the worst offenders' writes through the daemon.** Keystone: the
    indexer (kg8sj) writes T2 (catalog manifest, chash index, telemetry) via the
-   daemon RPC instead of a direct connection. Then audit `nx upgrade` and the
-   `aspect_worker` similarly.
-2. **For paths that genuinely cannot route** (the `nx upgrade` chicken-and-egg:
-   it migrates the schema the daemon needs before the daemon can own it), define
-   and enforce a **cross-process lock discipline** — e.g. the daemon must be
-   stopped for the migration window, or a documented advisory file-lock both the
-   daemon and `nx upgrade` honor — replacing the implicit WAL free-for-all.
-3. **Make every remaining direct DB path lock-tolerant**, starting with the
-   daemon startup migration (the same `busy_timeout`+retry v4m7y gave
-   `reclaim_stale`), so a transient lock causes a wait, not a crash.
-4. **Add the lifecycle interlock**: `ensure-running` must not SIGTERM a healthy
-   daemon to cycle it unless the replacement can acquire the DB lock first.
+   daemon RPC instead of a direct connection. Then `aspect_worker` and the
+   operator/CLI construction sites (see item 5).
 
-The first principle is "one writer." Where that is impossible, the second
-principle is "explicit, enforced, documented lock discipline" — never the
-current implicit contention.
+2. **A concrete cross-process lock discipline for the bootstrap chicken-and-egg.**
+   `nx upgrade` and the daemon's own startup both migrate the schema, so they
+   cannot both hold open connections during a migration. The discipline (both
+   sides honor it): a dedicated advisory lock file
+   `~/.config/nexus/t2_migration.lock`, taken with an **exclusive `fcntl.flock`**
+   before any schema write. Protocol: (a) `nx upgrade` acquires the migration
+   lock; (b) it signals the running daemon to **quiesce** (stop accepting RPC
+   writes and close its T2 connections — a new daemon RPC `pause_for_migration`,
+   or, simplest, `nx daemon t2 stop`); (c) runs `apply_pending` under the lock;
+   (d) releases the lock; (e) `ensure-running` brings the daemon back. The
+   daemon's *own* startup migration takes the **same** lock, so daemon-start and
+   `nx upgrade` serialize against each other instead of racing on the WAL. This
+   replaces the implicit WAL free-for-all with one explicit, documented lock.
+
+3. **Make the daemon startup migration lock-tolerant (P0).** `bootstrap_schema`
+   gets `busy_timeout >= 30000` and wraps `apply_pending` in a bounded
+   lock-retry, mirroring `reclaim_stale` (RF-3). A transient foreign lock causes
+   a bounded wait, not a crash.
+
+4. **Lifecycle interlock with a specified timeout and fallback (P0, CRITICAL).**
+   Before `ensure-running` SIGTERMs a healthy daemon to version-cycle it, it
+   probes DB-acquirability with a **bounded timeout (30s, matching the migration
+   busy_timeout)**. On success it proceeds with the cycle. **On timeout it ABORTS
+   the cycle**: the stale-but-running daemon is left running, and a one-line
+   deferral warning is logged ("daemon vX stale but DB locked; cycle deferred").
+   This never trades a working daemon for none (the failure the un-interlocked
+   5.0.4 cycle caused) and never hangs indefinitely (the failure a naive
+   try-acquire would cause). The version-cycle is best-effort and re-attempted on
+   the next `ensure-running` invocation.
+
+5. **Extend the boundary lint to construction sites, and baseline (P0).**
+   `storage_boundary_lint` today flags raw `sqlite3.connect` but not direct
+   `T2Database(...)` construction outside daemon-internal code — the 53-site
+   surface that dominates the 20 raw-connect sites (RF-5). Extend the
+   banned-call/-construction set to flag direct `T2Database(...)` outside an
+   allowlisted daemon module, and baseline both counts at P0 so progress is
+   measurable from the start.
+
+The first principle is "one writer." Where that is impossible (the bootstrap
+chicken-and-egg), the second principle is the explicit advisory-lock discipline
+in item 2 — never the current implicit contention.
 
 ## Alternatives Considered
 
@@ -218,18 +247,28 @@ patch-per-incident cycle plus user-facing daemon outages.
 
 ## Implementation Plan
 
-Phased; P0 stops the bleeding, P1 removes the keystone, P2 closes the rest.
+Phased; P0 stops the bleeding and establishes the metric, P1 removes the keystone,
+P2 specifies+builds the bootstrap lock, P3 closes the remaining surface.
 
-- **P0 (crash-loop stop, patch-shippable):** (a) startup migration gets
-  `busy_timeout`+retry (RF-3); (b) `ensure-running` lifecycle interlock (RF-4).
-  These are small, self-contained, and end the self-inflicted amplification. They
-  remain mitigations, not the cure.
+- **P0 (crash-loop stop + baseline, patch-shippable):** (a) startup migration
+  gets `busy_timeout >= 30000` + bounded lock-retry (Proposed Solution §3 / RF-3);
+  (b) `ensure-running` interlock with the 30s-timeout / abort-cycle fallback
+  (§4 / RF-4); (c) extend `storage_boundary_lint` to flag direct `T2Database(...)`
+  construction and **baseline both populations** (20 raw-connect + 53 construction)
+  via `nx doctor --check-storage-boundary` (§5). (a)+(b) end the self-inflicted
+  amplification; (c) makes the cure measurable from day one.
 - **P1 (keystone, nexus-kg8sj):** route `nx index repo` T2 writes through the
-  daemon. The single highest-value change; removes the most frequent, longest-held
-  lock.
-- **P2 (close the invariant):** audit `nx upgrade`, `aspect_worker`, `nx doctor`;
-  route or place each under the enforced lock discipline; remove the
-  `epsilon-allow` exemptions or convert them to documented, locked exceptions.
+  daemon. The single highest-value change; removes the most frequent,
+  longest-held lock. Drives the construction-site count down.
+- **P2 (bootstrap lock discipline):** implement the advisory-`flock` migration
+  lock + daemon quiesce protocol (Proposed Solution §2) so `nx upgrade` and
+  daemon startup serialize. This is the hard residual — built as its own phase,
+  not hand-waved.
+- **P3 (close the invariant):** route or lock-discipline the remaining direct
+  writers (`aspect_worker`, operator/CLI `T2Database(...)` sites) and reduce
+  `nx doctor`'s reader connections; drive **both** lint populations to the
+  documented-irreducible set, removing each `epsilon-allow` / construction
+  exemption or converting it to a documented, locked exception.
 
 ## Test Plan
 
@@ -245,10 +284,20 @@ Phased; P0 stops the bleeding, P1 removes the keystone, P2 closes the rest.
 
 ## Validation
 
-The disease is cured when a full release cycle (the kind that produced this RDR)
-can run — many commits firing the post-commit indexer, an upgrade, a daemon
-restart — without a single `database is locked` daemon incident, and with no new
-daemon band-aid bead filed.
+Two acceptance criteria, one qualitative and one quantitative (the latter covers
+**both** bypass populations, per the gate critique):
+
+- **Qualitative:** a full release cycle (the kind that produced this RDR) — many
+  commits firing the post-commit indexer, an upgrade, a daemon restart — runs
+  without a single `database is locked` daemon incident, and no new daemon
+  band-aid bead is filed.
+- **Quantitative (from `nx doctor --check-storage-boundary`):** both lint
+  populations reach their documented-irreducible set — the raw `sqlite3.connect`
+  `epsilon-allow` count (baseline 20) and the direct `T2Database(...)`
+  construction count (baseline 53) each reduced to the small set of genuinely
+  daemon-internal or bootstrap-locked sites, with every remaining exemption
+  carrying a documented lock-discipline justification. The metric is emitted
+  today, so progress is trackable from P0's baseline.
 
 ## Finalization Gate
 
@@ -275,3 +324,10 @@ Pending — to be run via `/conexus:rdr-gate` after research findings are verifi
   live `database is locked` contention hit while recording these findings. T2:
   nexus_rdr/128-research-2, /128-research-3. All outstanding RFs (1,3,4,5) now
   verified; RF-2 corroborated by the three live incidents + the RF-3 traceback.
+- 2026-05-25: Gate run 1 BLOCKED (1 CRITICAL + 3 SIGNIFICANT, substantive-critic).
+  Remediated all four: P0(b) interlock now specifies a 30s probe + abort-cycle
+  fallback (never hang, never trade a working daemon for none); `nx upgrade` lock
+  discipline fully specified (advisory `flock` migration lock + daemon quiesce,
+  P2); construction-site linting + dual-population baseline added to P0; Validation
+  acceptance now covers both the raw-connect and T2Database-construction
+  populations. T2 gate: nexus_rdr/128-gate-latest. Re-gating.

--- a/docs/rdr/rdr-128-t2-single-writer-enforcement.md
+++ b/docs/rdr/rdr-128-t2-single-writer-enforcement.md
@@ -78,7 +78,12 @@ every `nx-mcp` process (per the `daemon-restart-not-worker-fix` finding, the
 worker opens its own short-lived SQLite connection); (e) `nx doctor` (multiple
 `epsilon-allow` read-only diagnostic connections). The `epsilon-allow` comments
 are themselves an audit trail of where the single-writer invariant was knowingly
-broken.
+broken. **Verified 2026-05-25 (codebase grep, develop @ 5.0.4): 20 `epsilon-allow`
+sites and 53 direct `T2Database(...)` constructions outside the daemon and the
+store implementations** — far more than five. The worst writers beyond the
+indexer: `nx upgrade`, `nx repair plans`, `nx aspects` repair verbs, and ~10
+operator/CLI paths in `enrich.py`, `operators/aspect_sql.py`, `mcp_infra.py`,
+`merge_candidates.py`, and the `collection_*` modules.
 
 **RF-2 — every daemon incident is a contention symptom.** v4m7y = writer-vs-writer
 collision; kg8sj = the indexer-writer starves others; the 2026-05-25 crash-loop =
@@ -96,6 +101,18 @@ one path and not the structurally-identical one next to it.
 version-aware cycle SIGTERMs a running daemon without first confirming the
 replacement can acquire the DB. Trading a working-but-stale daemon for no daemon
 is strictly worse; the cycle needs a precondition.
+
+**RF-5 — the boundary is already recognized and linted; this is a tightening
+exercise.** `src/nexus/storage_boundary_lint.py` already flags direct
+`sqlite3.connect` / T2 opens and requires a per-line `# epsilon-allow: <reason>`
+(reason >= 8 chars); `nx doctor` surfaces violations. So RDR-128 introduces no new
+concept — the single-writer boundary exists and is enforced-by-lint, but the
+exemption list has proliferated (RF-1: 20 sites). This gives the cure a built-in
+**metric** (the `epsilon-allow` count) and a built-in **gate** (the lint): route
+the writers so their exemptions can be deleted, and reserve exemptions for the
+genuinely-irreducible bootstrap cases (the `nx upgrade` chicken-and-egg) under an
+explicit lock discipline. Acceptance = the exemption count reduced to that
+documented-irreducible set.
 
 ## Proposed Solution
 

--- a/docs/rdr/rdr-128-t2-single-writer-enforcement.md
+++ b/docs/rdr/rdr-128-t2-single-writer-enforcement.md
@@ -1,0 +1,194 @@
+---
+title: "T2 Single-Writer Enforcement: One Owner for memory.db, or an Enforced Lock Discipline"
+id: RDR-128
+type: Architecture
+status: draft
+priority: high
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-25
+accepted_date:
+related_issues: [nexus-kg8sj, nexus-v4m7y, nexus-aigkb, nexus-n8sbw, nexus-5ldk1]
+related_rdrs: [RDR-105, RDR-120]
+supersedes: []
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-128: T2 Single-Writer Enforcement: One Owner for memory.db, or an Enforced Lock Discipline
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+RDR-120 introduced the T2 daemon on the premise that it is the **single writer**
+of `memory.db` — one long-lived process owns the SQLite handles, and all other
+consumers reach T2 through it via RPC. That invariant is asserted but **not
+enforced**. In practice `memory.db` is a plain SQLite file that at least five
+independent code paths open directly with their own connections. SQLite in WAL
+mode permits many concurrent readers but exactly **one** writer; with multiple
+direct writers, lock contention is structural rather than incidental, and it has
+surfaced as a string of daemon incidents patched one symptom at a time across
+three consecutive patch releases.
+
+The releases 5.0.2, 5.0.3, and 5.0.4 each shipped a daemon "fix." None addressed
+the contention itself. Within minutes of shipping 5.0.4, the daemon entered a
+crash-loop on `sqlite3.OperationalError: database is locked` during its startup
+migration, because a post-commit-hook indexer held the WAL lock. This RDR exists
+to stop the patch-per-incident cycle by fixing the root cause: enforce a single
+writer, or replace the WAL free-for-all with a real cross-process lock discipline.
+
+## Context
+
+The piecemeal history, all tracing to the same invariant:
+
+- **5.0.2 / nexus-v4m7y**: `aspect_queue.reclaim_stale` raised "database is locked"
+  under WAL contention. Fix: `busy_timeout` 5s→30s + 3-attempt retry on that one
+  code path.
+- **5.0.2 / nexus-aigkb**: orphan T1 chromadb servers leaked across sessions. Fix:
+  sweep them at MCP startup. (The T1 sibling of the same disease — substrate
+  process lifecycle is not owned by one authority.)
+- **5.0.3 / nexus-n8sbw**: the daemon ran with stdout/stderr → DEVNULL and no log
+  sink, so its deaths were undiagnosable. Fix: file logging + status pid-liveness.
+  This was not the disease; it was that we were *blind* to the disease.
+- **5.0.4 / nexus-5ldk1**: the daemon froze its code version at start, so an
+  upgrade left a stale daemon. Fix: version-aware `ensure-running` that cycles a
+  stale daemon.
+- **OPEN / nexus-kg8sj** (deferred to 5.1.x): `nx index repo` bypasses the daemon
+  and opens `memory.db` directly, holding the WAL lock. This is the keystone
+  offender: frequent (fires from the post-commit hook on every commit) and
+  long-running.
+
+**The live incident that motivated this RDR (2026-05-25):** immediately after
+the 5.0.4 publish, `nx daemon t2 ensure-running` (the new 5.0.4 primitive)
+SIGTERM'd a healthy daemon to cycle it onto the new version; the respawn's startup
+migration hit the indexer's WAL lock and crashed; ensure-running is one-shot, so
+the daemon was left **down**. The 5.0.4 lifecycle fix, composed with kg8sj and an
+un-retried startup-migration path, converted "stale-but-running daemon" into "no
+daemon at all." We amplified the failure with the patch meant to fix lifecycle.
+
+## Research Findings
+
+**RF-1 — `memory.db` has 5+ direct accessors, not one.** Confirmed direct openers:
+(a) the T2 daemon (serving + startup migration); (b) `nx index repo` (kg8sj); (c)
+`nx upgrade` (explicit `epsilon-allow: nx upgrade chicken-and-egg substrate
+bootstrap (cannot route through daemon)`); (d) the `aspect_worker` thread inside
+every `nx-mcp` process (per the `daemon-restart-not-worker-fix` finding, the
+worker opens its own short-lived SQLite connection); (e) `nx doctor` (multiple
+`epsilon-allow` read-only diagnostic connections). The `epsilon-allow` comments
+are themselves an audit trail of where the single-writer invariant was knowingly
+broken.
+
+**RF-2 — every daemon incident is a contention symptom.** v4m7y = writer-vs-writer
+collision; kg8sj = the indexer-writer starves others; the 2026-05-25 crash-loop =
+the indexer-writer starves the daemon's *startup-migration* writer; aigkb = the
+unowned-lifecycle sibling. The pattern is not coincidence; it is the predictable
+consequence of N writers on one WAL lock.
+
+**RF-3 — contention hardening is inconsistent across paths.** v4m7y added
+`busy_timeout`+retry to `reclaim_stale`, but the daemon's **startup migration**
+(`apply_pending` via `T2Database.bootstrap_schema`, t2_daemon.py:493) has no such
+tolerance — it crashes hard on a locked DB. So even the band-aid was applied to
+one path and not the structurally-identical one next to it.
+
+**RF-4 — the 5.0.4 lifecycle cycle has no safety interlock.** `ensure-running`'s
+version-aware cycle SIGTERMs a running daemon without first confirming the
+replacement can acquire the DB. Trading a working-but-stale daemon for no daemon
+is strictly worse; the cycle needs a precondition.
+
+## Proposed Solution
+
+Enforce the single-writer invariant. Direction (to be refined in research/gate):
+
+1. **Route the worst offenders' writes through the daemon.** Keystone: the
+   indexer (kg8sj) writes T2 (catalog manifest, chash index, telemetry) via the
+   daemon RPC instead of a direct connection. Then audit `nx upgrade` and the
+   `aspect_worker` similarly.
+2. **For paths that genuinely cannot route** (the `nx upgrade` chicken-and-egg:
+   it migrates the schema the daemon needs before the daemon can own it), define
+   and enforce a **cross-process lock discipline** — e.g. the daemon must be
+   stopped for the migration window, or a documented advisory file-lock both the
+   daemon and `nx upgrade` honor — replacing the implicit WAL free-for-all.
+3. **Make every remaining direct DB path lock-tolerant**, starting with the
+   daemon startup migration (the same `busy_timeout`+retry v4m7y gave
+   `reclaim_stale`), so a transient lock causes a wait, not a crash.
+4. **Add the lifecycle interlock**: `ensure-running` must not SIGTERM a healthy
+   daemon to cycle it unless the replacement can acquire the DB lock first.
+
+The first principle is "one writer." Where that is impossible, the second
+principle is "explicit, enforced, documented lock discipline" — never the
+current implicit contention.
+
+## Alternatives Considered
+
+- **A. Keep patching per-incident.** Rejected — this is the status quo that
+  produced three releases of band-aids and a crash-loop. Each new code path that
+  touches `memory.db` is a new contention source and a new patch.
+- **B. Cross-process advisory lock only, no routing.** A shared advisory lock all
+  writers honor, without funnelling writes through the daemon. Lighter than full
+  routing; preserves the "many writers" topology but serializes them explicitly.
+  Viable for paths that can't route (upgrade), insufficient alone for the hot path
+  (indexer) where routing also buys batching + back-pressure.
+- **C. Full single-writer routing (all writes via daemon RPC).** The cleanest
+  realization of RDR-120's premise, highest implementation cost (every direct
+  writer must gain an RPC path, including the bootstrap chicken-and-egg). Likely
+  the end state; phase toward it.
+
+## Trade-offs
+
+Routing through the daemon adds RPC latency and a hard dependency on the daemon
+being up for writes that today degrade to direct access. The mitigation is that
+the daemon is *supposed* to be the authority anyway, and the 5.0.4 work already
+makes it self-heal on install. The cost of NOT doing this is the demonstrated
+patch-per-incident cycle plus user-facing daemon outages.
+
+## Implementation Plan
+
+Phased; P0 stops the bleeding, P1 removes the keystone, P2 closes the rest.
+
+- **P0 (crash-loop stop, patch-shippable):** (a) startup migration gets
+  `busy_timeout`+retry (RF-3); (b) `ensure-running` lifecycle interlock (RF-4).
+  These are small, self-contained, and end the self-inflicted amplification. They
+  remain mitigations, not the cure.
+- **P1 (keystone, nexus-kg8sj):** route `nx index repo` T2 writes through the
+  daemon. The single highest-value change; removes the most frequent, longest-held
+  lock.
+- **P2 (close the invariant):** audit `nx upgrade`, `aspect_worker`, `nx doctor`;
+  route or place each under the enforced lock discipline; remove the
+  `epsilon-allow` exemptions or convert them to documented, locked exceptions.
+
+## Test Plan
+
+- Reproduce the contention deterministically: hold a write lock on `memory.db`
+  (simulated indexer) and assert the daemon startup *waits and succeeds* rather
+  than crashing.
+- Assert `ensure-running` does not tear down a healthy daemon when the DB lock
+  is unavailable.
+- Concurrency test: N simulated writers (indexer + upgrade + worker) against one
+  daemon, assert no `database is locked` surfaces to a caller.
+- Regression guard that no new code path opens `memory.db` directly without going
+  through the routing/lock helper (lint or test over `epsilon-allow` sites).
+
+## Validation
+
+The disease is cured when a full release cycle (the kind that produced this RDR)
+can run — many commits firing the post-commit indexer, an upgrade, a daemon
+restart — without a single `database is locked` daemon incident, and with no new
+daemon band-aid bead filed.
+
+## Finalization Gate
+
+Pending — to be run via `/conexus:rdr-gate` after research findings are verified.
+
+## References
+
+- RDR-120 (Storage Substrate Split — asserted single-writer; this RDR enforces it)
+- RDR-105 (T1 sub-agent contract — sibling substrate-lifecycle discipline)
+- Beads: nexus-kg8sj (keystone), nexus-v4m7y, nexus-aigkb, nexus-n8sbw, nexus-5ldk1
+- Memory: `daemon-restart-not-worker-fix` (aspect_worker opens its own SQLite conn)
+
+## Revision History
+
+- 2026-05-25: Created (draft). Root-cause RDR motivated by the 5.0.4 post-publish
+  daemon crash-loop and the three-patch band-aid pattern Hal flagged.

--- a/docs/rdr/rdr-128-t2-single-writer-enforcement.md
+++ b/docs/rdr/rdr-128-t2-single-writer-enforcement.md
@@ -301,7 +301,13 @@ Two acceptance criteria, one qualitative and one quantitative (the latter covers
 
 ## Finalization Gate
 
-Pending — to be run via `/conexus:rdr-gate` after research findings are verified.
+- **Run 1 (2026-05-25): BLOCKED** — 1 CRITICAL (P0(b) interlock under-specified) +
+  3 SIGNIFICANT (construction-site lint gap, unspecified `nx upgrade` lock
+  discipline, single-population acceptance criterion).
+- **Run 2 (2026-05-25): PASSED** — all four remediated and re-confirmed resolved
+  by the substantive-critic (0 critical, 0 significant). Layers 1 (structure: 4
+  gaps, all sections) and 2 (assumptions: all RFs verified from source) passed.
+  T2: `nexus_rdr/128-gate-latest`.
 
 ## References
 

--- a/docs/rdr/rdr-128-t2-single-writer-enforcement.md
+++ b/docs/rdr/rdr-128-t2-single-writer-enforcement.md
@@ -39,6 +39,36 @@ migration, because a post-commit-hook indexer held the WAL lock. This RDR exists
 to stop the patch-per-incident cycle by fixing the root cause: enforce a single
 writer, or replace the WAL free-for-all with a real cross-process lock discipline.
 
+The problem decomposes into four gaps (each maps to a verified research finding):
+
+#### Gap 1: The single-writer invariant is unenforced
+
+RDR-120 declared the daemon the single writer, but `memory.db` has many direct
+writers — verified 20 `epsilon-allow` `sqlite3.connect` sites and 53 direct
+`T2Database(...)` constructions outside the daemon (RF-1). They contend on
+SQLite's one WAL writer lock, so contention is structural. The keystone offender
+is the indexer (`nx index repo`, nexus-kg8sj): frequent (every commit's
+post-commit hook) and long-running.
+
+#### Gap 2: Contention hardening is inconsistent across DB paths
+
+v4m7y gave `reclaim_stale` a 30s `busy_timeout` + bounded retry, but the daemon's
+startup migration (`bootstrap_schema` → `apply_pending`) still uses a 5s
+`busy_timeout` and no lock-retry (RF-3). Under a sustained foreign lock the 5s
+expires and the daemon crashes — the proximate cause of the 2026-05-25 crash-loop.
+
+#### Gap 3: The lifecycle cycle has no DB-acquire interlock
+
+The 5.0.4 version-aware `ensure-running` SIGTERMs a healthy daemon unconditionally
+to cycle it (RF-4). Composed with Gap 2, it tears down a working daemon and the
+respawn crashes on a held lock — converting "stale-but-running" into "no daemon."
+
+#### Gap 4: The boundary lint is partial
+
+`storage_boundary_lint` (already wired into `nx doctor --check-storage-boundary`)
+flags raw `sqlite3.connect` but not direct `T2Database(...)` construction (RF-5).
+Closing only the raw-connect surface pushes the bypass into the construction form.
+
 ## Context
 
 The piecemeal history, all tracing to the same invariant:

--- a/docs/rdr/rdr-128-t2-single-writer-enforcement.md
+++ b/docs/rdr/rdr-128-t2-single-writer-enforcement.md
@@ -114,6 +114,19 @@ genuinely-irreducible bootstrap cases (the `nx upgrade` chicken-and-egg) under a
 explicit lock discipline. Acceptance = the exemption count reduced to that
 documented-irreducible set.
 
+**RF-1 and RF-5 VERIFIED 2026-05-25** (independent recount + reading the lint
+source): counts reproduce exactly (20 / 53); `storage_boundary_lint.py` is wired
+into `nx doctor --check-storage-boundary` (RDR-120 P0.A / nexus-7xxxg), which
+emits a `storage_boundary_lint` structlog metric — so the acceptance gate and
+metric already exist and can be baselined. **Refinement:** the lint keys on raw
+`sqlite3.connect` only; it does NOT flag direct `T2Database(...)` construction
+(the 53 sites). The implementation must therefore extend the banned-call set to
+construction sites, or routing the raw connects merely pushes the bypass into the
+`T2Database()` form. Second live contention incident recorded the same day: an
+`nx memory put` (recording this very finding) failed with `database is locked`
+because a post-commit `nx index repo` held the WAL lock, succeeding only on
+retry — RDR-128's thesis demonstrated twice in one session.
+
 ## Proposed Solution
 
 Enforce the single-writer invariant. Direction (to be refined in research/gate):
@@ -209,3 +222,7 @@ Pending — to be run via `/conexus:rdr-gate` after research findings are verifi
 
 - 2026-05-25: Created (draft). Root-cause RDR motivated by the 5.0.4 post-publish
   daemon crash-loop and the three-patch band-aid pattern Hal flagged.
+- 2026-05-25: RF-1 and RF-5 verified (20 epsilon-allow + 53 direct T2Database;
+  storage_boundary_lint wired into `nx doctor --check-storage-boundary`). Added
+  the construction-site lint-coverage gap and a second live contention incident.
+  T2 findings: nexus_rdr/128-research-1, /128-research-1-verified.

--- a/docs/rdr/rdr-128-t2-single-writer-enforcement.md
+++ b/docs/rdr/rdr-128-t2-single-writer-enforcement.md
@@ -2,12 +2,12 @@
 title: "T2 Single-Writer Enforcement: One Owner for memory.db, or an Enforced Lock Discipline"
 id: RDR-128
 type: Architecture
-status: draft
+status: accepted
 priority: high
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-05-25
-accepted_date:
+accepted_date: 2026-05-25
 related_issues: [nexus-kg8sj, nexus-v4m7y, nexus-aigkb, nexus-n8sbw, nexus-5ldk1]
 related_rdrs: [RDR-105, RDR-120]
 supersedes: []

--- a/scripts/validate/04-hooks.sh
+++ b/scripts/validate/04-hooks.sh
@@ -11,7 +11,7 @@ REPO=$(git rev-parse --show-toplevel)
 HOOKS="$REPO/conexus/hooks/scripts"
 
 # Fake Claude Code hook env
-export CLAUDE_PLUGIN_ROOT="$REPO/nx"
+export CLAUDE_PLUGIN_ROOT="$REPO/conexus"
 export CLAUDE_PROJECT_DIR="$SANDBOX"
 
 # Fake SessionStart event payload

--- a/sn/README.md
+++ b/sn/README.md
@@ -75,11 +75,11 @@ sn/
 └── README.md
 ```
 
-## Relationship to nx
+## Relationship to conexus
 
-`sn` is project-agnostic — it works in any repository where Serena is configured. It lives in the same marketplace as `nx` but has no dependency on it. Install either or both.
+`sn` is project-agnostic — it works in any repository where Serena is configured. It lives in the same marketplace as `conexus` but has no dependency on it. Install either or both.
 
 | Plugin | Scope | What it provides |
 |--------|-------|-----------------|
-| `nx` | Project-specific | Knowledge management, semantic search, agents, beads, RDR tracking |
+| `conexus` | Project-specific | Knowledge management, semantic search, agents, beads, RDR tracking |
 | `sn` | Universal | MCP tool guidance for subagents (Serena + Context7) |

--- a/sn/hooks/scripts/routing/README.md
+++ b/sn/hooks/scripts/routing/README.md
@@ -1,7 +1,7 @@
 # Routing Hooks (sn) — RDR-125
 
 PreToolUse hooks shipped in the sn plugin. The framework
-(`_lib.py`, `_run_python_hook.sh`) is canonical in nx and **vendored**
+(`_lib.py`, `_run_python_hook.sh`) is canonical in conexus and **vendored**
 here byte-for-byte; `tests/test_routing_lib_drift.py` in the nexus
 monorepo refuses any divergence.
 
@@ -13,13 +13,13 @@ redirects to a tool the plugin ships. sn ships Serena MCP tools
 `grep_for_symbols_redirects_to_serena` rule lives here because its
 deny message names those tools.
 
-Installing nx without sn means this hook does not exist -- which is
+Installing conexus without sn means this hook does not exist -- which is
 the correct default. Users without Serena get no surprise denial of
 their `grep` invocations.
 
 ## Files
 
-- `_lib.py` -- vendored from nx canonical. **Do not edit in isolation.**
+- `_lib.py` -- vendored from conexus canonical. **Do not edit in isolation.**
   Updating the framework means updating both copies atomically.
 - `grep_for_symbols_redirects_to_serena.py` -- the routing rule. Uses
   the standard `sys.path.insert(0, dirname); import _lib` pattern.
@@ -27,7 +27,7 @@ their `grep` invocations.
   `conexus/hooks/scripts/routing/registry.yaml`.
 
 The `_run_python_hook.sh` wrapper at `sn/hooks/scripts/_run_python_hook.sh`
-is also vendored from nx canonical.
+is also vendored from conexus canonical.
 
 ## Cumulative-cap accounting (RDR-121 + RDR-125)
 

--- a/sn/hooks/scripts/routing/registry.yaml
+++ b/sn/hooks/scripts/routing/registry.yaml
@@ -3,18 +3,18 @@
 #
 # Per RDR-125, rules whose deny message redirects to a plugin-specific
 # tool live in the plugin that ships that tool. This file is sn's
-# registry; nx ships its own at conexus/hooks/scripts/routing/registry.yaml.
+# registry; conexus ships its own at conexus/hooks/scripts/routing/registry.yaml.
 #
 # Aggregate cap (RDR-121 + RDR-125): the union of routing rules
 # across all plugins must stay <= 4 PreToolUse:Bash entries to honor
 # the <300ms p95 cumulative budget. Current aggregate count:
-#   nx: 2 routing rules (git_add_all, phase_review_close)
+#   conexus: 2 routing rules (git_add_all, phase_review_close)
 #       + pre_close_verification_hook = 3 PreToolUse:Bash entries
 #   sn: 1 (grep_for_symbols_redirects_to_serena)
 #   total: 4, AT CAP. Adding a fifth rule in ANY plugin requires
 #   either consolidation or a budget revision in a successor RDR.
 #
-# The schema mirrors nx's registry.yaml exactly. See
+# The schema mirrors conexus's registry.yaml exactly. See
 # conexus/hooks/scripts/routing/registry.yaml for field documentation.
 
 rules:

--- a/tests/cc-validation/scenarios/12_real_nx_subagent.sh
+++ b/tests/cc-validation/scenarios/12_real_nx_subagent.sh
@@ -15,7 +15,7 @@ cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" <<EOF
   "version": 2,
   "plugins": {
     "conexus@nexus-plugins": [
-      { "scope": "user", "installPath": "$REPO_ROOT/nx", "version": "dev",
+      { "scope": "user", "installPath": "$REPO_ROOT/conexus", "version": "dev",
         "installedAt": "$NOW", "lastUpdated": "$NOW" }
     ]
   }

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -106,7 +106,7 @@ fi
 #   ~/.claude/settings.json                  — enabledPlugins + permissions
 NOW="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
 
-# Build installed_plugins.json — nx only.
+# Build installed_plugins.json (conexus only).
 cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" << PLUGINS_EOF
 {
   "version": 2,
@@ -114,7 +114,7 @@ cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" << PLUGINS_EOF
     "conexus@nexus-plugins": [
       {
         "scope": "user",
-        "installPath": "$REPO_ROOT/nx",
+        "installPath": "$REPO_ROOT/conexus",
         "version": "dev",
         "installedAt": "$NOW",
         "lastUpdated": "$NOW"

--- a/tests/e2e/scenarios/00_debug_load.sh
+++ b/tests/e2e/scenarios/00_debug_load.sh
@@ -23,8 +23,8 @@ plugins_json="$TEST_HOME/.claude/plugins/installed_plugins.json"
 if [[ ! -f "$plugins_json" ]]; then
     fail "Isolated installed_plugins.json not found at $plugins_json"
 else
-    if grep -q "$REPO_ROOT/nx" "$plugins_json"; then
-        pass "isolated installed_plugins.json points to dev repo ($REPO_ROOT/nx)"
+    if grep -q "$REPO_ROOT/conexus" "$plugins_json"; then
+        pass "isolated installed_plugins.json points to dev repo ($REPO_ROOT/conexus)"
     else
         fail "installed_plugins.json does NOT point to dev repo — may be testing v1"
         echo "    content: $(cat "$plugins_json")"
@@ -117,7 +117,7 @@ scenario_end
 scenario "00 debug-load: SubagentStart hook injects RELAY_TEMPLATE"
 
 # Run subagent-start.sh directly with CLAUDE_PLUGIN_ROOT set
-subagent_hook_out=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/nx" \
+subagent_hook_out=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/conexus" \
     HOME="$TEST_HOME" \
     PATH="$TEST_HOME/.local/bin:$PATH" \
     CLAUDE_PROJECT_DIR="$REPO_ROOT" \


### PR DESCRIPTION
Consolidates three in-flight PRs into one (per batch-to-develop preference). No file overlap; 11 commits, 11 files.

## 1. RDR-128 — T2 single-writer enforcement (root-cause RDR) — was #960
Accepted, gate PASSED (run 2, all findings remediated). Root-causes the recurring daemon `database is locked` contention that was patched piecemeal across 5.0.2/5.0.3/5.0.4: RDR-120 asserted the T2 daemon as memory.db's single writer but never enforced it (20 epsilon-allow raw connects + 53 direct `T2Database()` constructions contend on one WAL writer lock). Adds RF-1..RF-5 verification, 4-gap Problem Statement, P0-P3 plan, dual-population acceptance. Doc only — implementation tracked in beads (epic nexus-sbxbe).

## 2. release-skill namespace fix — was #959
`.claude/skills/release/SKILL.md`: `nx/`→`conexus/` plugin paths, FIVE→SEVEN bump targets (adds the mcpb `pyproject.toml` + `manifest.json` targets that CI parity already enforces).

## 3. nx→conexus plugin-name + plugin-dir refs — was #961
- `sn/` internals (README, routing registry.yaml, routing README) referred to the sibling plugin by its pre-5.0.0 name `nx`.
- **CI/harness bug**: `.github/workflows/plan-schema-check.yml` watched the removed `nx/plans/**` and invoked the validator with `plugin_root=repo_root/'nx'` — plan-schema validation had been a silent no-op for the plugin tier since the rename (17 `conexus/plans` YAMLs unvalidated). Verified the corrected invocation exits 0.
- `tests/e2e/run.sh`, `tests/e2e/scenarios/00_debug_load.sh`, `tests/cc-validation/scenarios/12_real_nx_subagent.sh`, `scripts/validate/04-hooks.sh`: `installPath`/`CLAUDE_PLUGIN_ROOT` pointed at the removed `nx/` dir.

Left unchanged: the `nx` CLI binary, `test_plugin_name_drift.py` (tests the migration warning), historical CHANGELOG `/nx:` entries.

## Test plan
- [x] plugin-structure + sn-plugin + routing-drift: 634 passed, 27 skipped
- [x] `ci_validate_plan_tree(plugin_root=repo_root/'conexus')` exits 0