### PR TITLE
release: conexus 5.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.0.4"
+        "ref": "v5.1.0"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.0.4"
+      "version": "5.1.0"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.0.4"
+        "ref": "v5.1.0"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.0.4"
+      "version": "5.1.0"
     }
   ]
 }

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Use when cutting a release, bumping version, tagging, or publishing to PyPI. Enforces the full release checklist from CLAUDE.md § Release Process. Also surfaces as /nx:release.
+description: Use when cutting a release, bumping version, tagging, or publishing to PyPI. Enforces the full release checklist from CLAUDE.md § Release Process. Also surfaces as /conexus:release.
 ---
 
 # Release Checklist
@@ -34,11 +34,13 @@ Cross-walk against:
 
 Update any drift before bumping version. Doc audit is what catches "we changed the wire format but forgot to document it."
 
-### 3. Bump version in ALL FIVE bump targets
+### 3. Bump version in ALL SEVEN bump targets
 
-CI enforces parity. Missing any one of these fails the marketplace-version-matches-pyproject test or the marketplace-source-ref-matches-pyproject test.
+CI enforces parity. Missing any one of these fails the marketplace-version-matches-pyproject test, the marketplace-source-ref-matches-pyproject test, or the mcpb-manifest-version-matches-pyproject test.
 
 - `pyproject.toml`: `version = "X.Y.Z"` (canonical source of truth)
+- `mcpb/pyproject.toml`: `version` **and** the `conexus>=X.Y.Z` dependency pin
+- `mcpb/manifest.json`: `version`
 - `.claude-plugin/marketplace.json`: **both `version` fields** (one for conexus, one for sn)
 - `.claude-plugin/marketplace.json`: **both `plugins[].source.ref` fields** — must be `"vX.Y.Z"` (the tag form). Easy to forget. This is what decouples installed users from main HEAD: plugin installs follow the pinned tag, not whatever main currently is. **CRITICAL: nexus-mkj6u 2026-05-23**
 - `conexus/.claude-plugin/plugin.json`: `version`
@@ -51,7 +53,7 @@ Semver: MAJOR for breaking, MINOR for new features, PATCH for bug fixes.
 ### 4. Update both changelogs
 
 - `CHANGELOG.md` (root): move `## [Unreleased]` content into a new `## [X.Y.Z] - YYYY-MM-DD` section. Leave a fresh empty `## [Unreleased]` at the top.
-- `nx/CHANGELOG.md` (plugin changelog): always update, even if no plugin changes (note: "Plugin version aligned with conexus X.Y.Z. No plugin-side changes." is acceptable).
+- `conexus/CHANGELOG.md` (plugin changelog): always update, even if no plugin changes (note: "Plugin version aligned with conexus X.Y.Z. No plugin-side changes." is acceptable).
 
 ### 5. Refresh `uv.lock`
 
@@ -63,7 +65,7 @@ The lock file MUST be committed. CI also checks this.
 
 ### 6. Run sandbox smoke (~2 min)
 
-Required for any change touching `pyproject.toml`, `uv.lock`, `src/nexus/db/migrations.py`, `src/nexus/mcp/**`, `nx/**`, `.claude-plugin/**`, `src/nexus/commands/{doctor,upgrade}.py`.
+Required for any change touching `pyproject.toml`, `uv.lock`, `src/nexus/db/migrations.py`, `src/nexus/mcp/**`, `conexus/**`, `.claude-plugin/**`, `src/nexus/commands/{doctor,upgrade}.py`.
 
 ```bash
 ./tests/e2e/release-sandbox.sh smoke
@@ -186,7 +188,7 @@ nx --version                 # must print X.Y.Z
 
 - **Bumping only `pyproject.toml` and missing the four plugin manifests.** CI parity check catches this late. Run the Step 8 pre-push check.
 - **Skipping the integration suite.** Unit-only is what CI runs; integration is your last gate against keyed-API regressions before tag-push.
-- **Skipping sandbox smoke when `nx/**` or `pyproject.toml` changed.** The smoke catches plugin-load + db-migration regressions that unit tests miss.
+- **Skipping sandbox smoke when `conexus/**` or `pyproject.toml` changed.** The smoke catches plugin-load + db-migration regressions that unit tests miss.
 - **Using `gh release create` after `git push origin vX.Y.Z`.** Duplicate release. The Release workflow already creates one.
 - **Forgetting `uv sync`.** `uv.lock` not updated; CI fails or local install resolves differently.
 - **Forgetting `scripts/reinstall-tool.sh` after tag-push.** Local `nx` stays on old version; the post-merge "verify locally" step lies.

--- a/.github/workflows/plan-schema-check.yml
+++ b/.github/workflows/plan-schema-check.yml
@@ -6,8 +6,8 @@ name: plan-schema
 on:
   pull_request:
     paths:
-      - "nx/plans/**/*.yml"
-      - "nx/plans/**/*.yaml"
+      - "conexus/plans/**/*.yml"
+      - "conexus/plans/**/*.yaml"
       - ".nexus/plans/**/*.yml"
       - ".nexus/plans/**/*.yaml"
       - "docs/rdr/**/plans.yml"
@@ -40,7 +40,7 @@ jobs:
           from nexus.plans.loader import ci_validate_plan_tree
 
           repo_root = Path('.').resolve()
-          plugin_root = repo_root / 'nx'
+          plugin_root = repo_root / 'conexus'
           sys.exit(ci_validate_plan_tree(
               plugin_root=plugin_root, repo_root=repo_root,
           ))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.1.0] - 2026-05-25
+
+### Fixed: T2 single-writer enforcement, root-cause fix for the daemon crash-loop (RDR-128)
+
+RDR-120 made the T2 daemon `memory.db`'s single writer, but the invariant
+was asserted and never enforced: 20+ code paths opened the WAL database
+directly and contended on its one writer lock. That contention surfaced as
+a string of `database is locked` daemon incidents band-aided across 5.0.2,
+5.0.3, and 5.0.4, culminating in a startup crash-loop minutes after 5.0.4
+shipped (the version-cycle lifecycle fix amplified it). RDR-128 fixes the
+root cause rather than the symptom:
+
+- **Routing.** The hot and automated writers now go through the daemon via
+  `mcp_infra.t2_index_write`: the indexer (`nx index repo`), the
+  aspect-extraction worker's poll loop, the SessionEnd flush, and the
+  routable CLI writers (`nx scratch promote`, `nx collection delete`/`rename`,
+  `nx enrich aspects delete`, the `nx doctor` phase metric). A dead or slow
+  writer can no longer strand the WAL lock for the daemon.
+- **Lock-tolerant startup.** The daemon's startup migration now uses
+  `busy_timeout=30000` plus bounded retry, so a transient foreign lock makes
+  it wait rather than crash.
+- **Lifecycle interlock.** `nx daemon t2 ensure-running` probes
+  DB-acquirability (30s bound) before cycling a stale daemon and aborts the
+  cycle on timeout, so it never trades a working daemon for none.
+- **Bootstrap lock discipline.** `nx upgrade` and the daemon's own startup
+  serialize their schema migrations through an exclusive `fcntl.flock` on
+  `~/.config/nexus/t2_migration.lock`.
+- **Enforced boundary.** `nx doctor --check-storage-boundary` now hard-fails
+  any new direct `memory.db` open (raw `sqlite3.connect` or a direct
+  `T2Database(...)` construction) outside the daemon substrate that lacks a
+  documented `# epsilon-allow:` justification. The surviving irreducible
+  opens (bootstrap `nx upgrade`, the daemon-unreachable fallback, read-only
+  diagnostics, the taxonomy CLI factory) each carry one.
+
+No CLI flags changed; the fix is internal to the storage substrate and the
+daemon lifecycle. Installed users get a daemon that self-heals on the
+contention that previously crash-looped it.
+
 ## [5.0.4] - 2026-05-25
 
 ### Docs: Claude Desktop `.mcpb` update procedure + lifecycle

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.1.0] - 2026-05-25
+
+Plugin version aligned with conexus 5.1.0. No plugin-side changes. The
+release is RDR-128 (T2 single-writer enforcement), a root-cause fix for
+the `database is locked` daemon crash-loop band-aided across 5.0.2 to
+5.0.4: the hot and automated writers now route through the T2 daemon, the
+daemon's startup migration is lock-tolerant, `ensure-running` aborts a
+version-cycle when the DB lock is held, and `nx doctor
+--check-storage-boundary` hard-fails any new direct `memory.db` open
+without a documented justification. See root `CHANGELOG.md`.
+
 ## [5.0.4] - 2026-05-25
 
 Plugin version aligned with conexus 5.0.4. The release wires the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -428,6 +428,42 @@ Phase 2 consequences:
   own `threading.Lock` plus the SQLite file-level write lock -- callers
   never see `OperationalError: database is locked`.
 
+### Cross-process single writer (RDR-120 / RDR-128)
+
+The per-store `busy_timeout` above absorbs *within-process* cross-domain
+contention. *Across* processes, `memory.db` has a single owner: the **T2
+daemon** (RDR-120). Other processes reach T2 through it over a local RPC
+(`nexus.daemon.t2_client.T2Client`) rather than opening the WAL writer
+lock directly.
+
+RDR-128 enforces that invariant after it had drifted (20+ direct openers
+contended on the one WAL writer lock and produced a string of `database
+is locked` daemon incidents):
+
+- **Routing.** `mcp_infra.t2_index_write(write_fn)` runs a write through
+  the daemon when reachable (decided by an up-front `database.hello()`
+  probe), else a direct `T2Database` fallback. The hot/automated writers
+  route through it: the indexer (chash + taxonomy persist + aspect
+  enqueue), the `aspect_worker` poll (`reclaim_stale` + `claim_batch`),
+  the SessionEnd flush, and the routable CLI writers. The daemon RPC wire
+  protocol decodes dataclasses to plain dicts, so methods taking/returning
+  a dataclass the caller introspects (`document_aspects.upsert`,
+  `aspect_queue.claim_batch`) either stay direct or reconstruct on the
+  client side.
+- **Enforcement.** `nexus.storage_boundary_lint` (wired into `nx doctor
+  --check-storage-boundary`) hard-fails any raw `sqlite3.connect` or
+  direct `T2Database(...)` construction outside `src/nexus/db/` +
+  `src/nexus/daemon/` that lacks a documented `# epsilon-allow:
+  <reason>` override. The genuinely-irreducible direct opens (bootstrap
+  `nx upgrade`, the daemon-unreachable fallback, read-only diagnostics,
+  the taxonomy CLI factory whose read-only subcommands need raw cursors)
+  each carry that justification.
+- **Bootstrap serialization.** `nx upgrade` and the daemon's own startup
+  migration take an exclusive `fcntl.flock` on
+  `~/.config/nexus/t2_migration.lock` before any schema write, and the
+  startup migration is lock-tolerant (`busy_timeout=30000` + bounded
+  retry) so a transient foreign lock waits rather than crashes.
+
 **Migration Registry** (RDR-076): All T2 schema migrations are centralised in
 `src/nexus/db/migrations.py`. The `MIGRATIONS` list contains version-tagged
 `Migration(introduced, name, fn)` entries. `apply_pending(conn, current_version)`

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -142,6 +142,8 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-121](rdr-121-hook-enforced-tool-routing.md) | Hook-Enforced Tool Routing: PreToolUse as Backstop for Soft Guidance | Architecture | Closed 2026-05-20 (shipped in 4.33.0) | 2026-05-19 |
 | [RDR-125](rdr-125-routing-hook-plugin-ownership.md) | Routing-Hook Plugin Ownership: Each Plugin Ships Its Own Rules | Architecture | Closed 2026-05-21 (shipped in 4.33.1) | 2026-05-20 |
 | [RDR-126](rdr-126-claude-desktop-deployment-unified-chat-cowork.md) | Claude Desktop Deployment: Unified Chat and Cowork Surface | Architecture | Draft | 2026-05-23 |
+| [RDR-127](rdr-127-substrate-decoupled-surface-rendering.md) | Substrate-Decoupled Surface Rendering | Architecture | Draft | 2026-05-24 |
+| [RDR-128](rdr-128-t2-single-writer-enforcement.md) | T2 Single-Writer Enforcement: One Owner for memory.db, or an Enforced Lock Discipline | Architecture | Accepted 2026-05-25 (gate PASSED) | 2026-05-25 |
 
 > **Scrapped 2026-05-19 (RDR-110-119 arc).** Bundled the storage-substrate split with new abstractions (tuplespace, ORB, host-trust, surfaces-as-tuples, UI fabric); scope discipline failed across nine RDRs and 67 stranded beads. Files preserved as tombstones per the "never delete RDR files" rule. Postmortem: [docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work continues as [RDR-120](rdr-120-storage-substrate-split.md) with an explicit moratorium on co-shipped consumers. Numbers RDR-114 through RDR-117 are unused on `main` (drafted on feature branches that never merged).
 

--- a/docs/rdr/post-mortem/128-t2-single-writer-enforcement.md
+++ b/docs/rdr/post-mortem/128-t2-single-writer-enforcement.md
@@ -1,0 +1,85 @@
+# Post-mortem: RDR-128 T2 Single-Writer Enforcement
+
+**Closed:** 2026-05-25 (implemented)
+**Epic:** nexus-sbxbe (P0 nexus-sbxbe.1, P1 keystone nexus-kg8sj, P2 nexus-sbxbe.2, P3 nexus-sbxbe.3)
+
+## What it fixed
+
+RDR-120 declared the T2 daemon the single writer of `memory.db` but never
+enforced it. 20+ `epsilon-allow` raw connects and 30+ direct `T2Database(...)`
+constructions opened the WAL database outside the daemon and contended on its
+one writer lock. The contention surfaced as `database is locked` incidents
+band-aided across 5.0.2 / 5.0.3 / 5.0.4, culminating in a startup-migration
+crash-loop minutes after 5.0.4 shipped (the 5.0.4 lifecycle "fix" amplified it).
+
+## How it was closed (per Problem-Statement gap)
+
+- **Gap 1 (invariant unenforced):** the hot/automated writers now route through
+  the daemon via `mcp_infra.t2_index_write` (indexer, aspect_worker poll,
+  session-end flush, collection rename, scratch promote, doctor metric, enrich
+  delete, collection delete). `src/nexus/mcp_infra.py:158`.
+- **Gap 2 (contention hardening inconsistent):** `bootstrap_schema` got
+  `busy_timeout=30000` + bounded lock-retry (P0). `src/nexus/db/t2/__init__.py:393`.
+- **Gap 3 (lifecycle no interlock):** `ensure-running` probes DB-acquirability
+  with a 30s bound and ABORTS the version-cycle on timeout rather than tearing
+  down a working daemon (P0). `src/nexus/commands/daemon.py:811`.
+- **Gap 4 (boundary lint partial):** the lint was extended to flag direct
+  `T2Database(...)` construction and **flipped from counted-only to enforcing**
+  in P3, so an un-annotated construction outside `db/`+`daemon/` is a hard CI
+  failure. `src/nexus/storage_boundary_lint.py:384`.
+
+## Acceptance
+
+- **Quantitative (met):** both lint populations at the documented-irreducible
+  set: 0 un-annotated violations / 30 documented constructions (each carrying an
+  `epsilon-allow` lock-discipline justification) / 16 raw-connect exceptions.
+  `nx doctor --check-storage-boundary` reports both.
+- **Qualitative (evidenced, pending live confirmation):** the deterministic
+  stress gate `TestRdr128P3SingleWriterRouting` drives 60 mixed routed writers
+  (indexer + worker + session-end) against one daemon with **zero**
+  `database is locked` and no lost writes. Final confirmation expected over the
+  next live release cycle (5.1.x): many post-commit indexer fires + an upgrade +
+  a daemon restart with no new daemon band-aid bead.
+
+## Key design decisions
+
+1. **Hard-fail lint, not counted-only.** A new direct writer can no longer merge
+   silently; it either routes or carries a written `epsilon-allow` justification.
+2. **The daemon RPC wire protocol decodes dataclasses to plain dicts**
+   (`t2_daemon._t2_decode`), not reconstructed objects. Consequences:
+   `document_aspects.upsert(AspectRecord)` cannot route (stays a documented-
+   irreducible direct write); the aspect_worker reconstructs `QueueRow(**dict)`
+   after a routed `claim_batch`.
+3. **Taxonomy core-discovery restructure was deliberately NOT done.** The shared
+   `_T2Database` wrapper (`commands/taxonomy_cmd.py`) is permanent: 6+ read-only
+   subcommands issue raw `taxonomy.conn` SELECTs that cannot cross the daemon
+   RPC. Restructuring `discover_topics`/`rebuild_taxonomy`/`split_topic` to route
+   their writes would yield zero lint reduction (the wrapper survives for the
+   readers) at high correctness risk, so the wrapper was annotated instead.
+
+## Irreducible-by-design survivors (documented)
+
+The daemon-unreachable fallback in `t2_index_write`; the `aspect_worker` persist
+(`document_aspects.upsert`); bootstrap `nx upgrade`; raw-DDL/raw-cursor writers
+(`enrich` promote, `aspects` gc-fixtures); read-only diagnostics/CLI reads; the
+taxonomy CLI factory. Each carries an `epsilon-allow` reason at its site.
+
+## Follow-ups filed (not blocking)
+
+- **nexus-g25dk** (P2 bug): `index.py` auto-discover projection pass silently
+  broken (`_persist_assignments` missing `source_collection`, swallowed by an
+  `except`). Pre-existing; found while annotating.
+- **nexus-izpcb** (P3): `nx upgrade` keeps the `apply_pending` migration conn and
+  the T3-steps `T2Database` open in-process simultaneously. Pre-existing, benign
+  (single-threaded sequential writes), tracked for consolidation.
+- **nexus-fkq5q** (P1): "route indexer taxonomy discover writes (compute/persist
+  split)" — now SUPERSEDED by the P3 decision to annotate the auto-discover path
+  as documented-irreducible (ChromaDB client cannot cross the RPC). Disposition
+  pending.
+
+## Lesson reinforced
+
+Three consecutive patch releases to one subsystem was the signal to root-cause
+rather than ship patch N+1. The root cause was an asserted-but-unenforced
+invariant; the cure was enforcement (the lint flip) plus routing, not another
+contention band-aid.

--- a/docs/rdr/rdr-128-t2-single-writer-enforcement.md
+++ b/docs/rdr/rdr-128-t2-single-writer-enforcement.md
@@ -1,0 +1,339 @@
+---
+title: "T2 Single-Writer Enforcement: One Owner for memory.db, or an Enforced Lock Discipline"
+id: RDR-128
+type: Architecture
+status: accepted
+priority: high
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-25
+accepted_date: 2026-05-25
+related_issues: [nexus-kg8sj, nexus-v4m7y, nexus-aigkb, nexus-n8sbw, nexus-5ldk1]
+related_rdrs: [RDR-105, RDR-120]
+supersedes: []
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-128: T2 Single-Writer Enforcement: One Owner for memory.db, or an Enforced Lock Discipline
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+RDR-120 introduced the T2 daemon on the premise that it is the **single writer**
+of `memory.db` — one long-lived process owns the SQLite handles, and all other
+consumers reach T2 through it via RPC. That invariant is asserted but **not
+enforced**. In practice `memory.db` is a plain SQLite file that at least five
+independent code paths open directly with their own connections. SQLite in WAL
+mode permits many concurrent readers but exactly **one** writer; with multiple
+direct writers, lock contention is structural rather than incidental, and it has
+surfaced as a string of daemon incidents patched one symptom at a time across
+three consecutive patch releases.
+
+The releases 5.0.2, 5.0.3, and 5.0.4 each shipped a daemon "fix." None addressed
+the contention itself. Within minutes of shipping 5.0.4, the daemon entered a
+crash-loop on `sqlite3.OperationalError: database is locked` during its startup
+migration, because a post-commit-hook indexer held the WAL lock. This RDR exists
+to stop the patch-per-incident cycle by fixing the root cause: enforce a single
+writer, or replace the WAL free-for-all with a real cross-process lock discipline.
+
+The problem decomposes into four gaps (each maps to a verified research finding):
+
+#### Gap 1: The single-writer invariant is unenforced
+
+RDR-120 declared the daemon the single writer, but `memory.db` has many direct
+writers — verified 20 `epsilon-allow` `sqlite3.connect` sites and 53 direct
+`T2Database(...)` constructions outside the daemon (RF-1). They contend on
+SQLite's one WAL writer lock, so contention is structural. The keystone offender
+is the indexer (`nx index repo`, nexus-kg8sj): frequent (every commit's
+post-commit hook) and long-running.
+
+#### Gap 2: Contention hardening is inconsistent across DB paths
+
+v4m7y gave `reclaim_stale` a 30s `busy_timeout` + bounded retry, but the daemon's
+startup migration (`bootstrap_schema` → `apply_pending`) still uses a 5s
+`busy_timeout` and no lock-retry (RF-3). Under a sustained foreign lock the 5s
+expires and the daemon crashes — the proximate cause of the 2026-05-25 crash-loop.
+
+#### Gap 3: The lifecycle cycle has no DB-acquire interlock
+
+The 5.0.4 version-aware `ensure-running` SIGTERMs a healthy daemon unconditionally
+to cycle it (RF-4). Composed with Gap 2, it tears down a working daemon and the
+respawn crashes on a held lock — converting "stale-but-running" into "no daemon."
+
+#### Gap 4: The boundary lint is partial
+
+`storage_boundary_lint` (already wired into `nx doctor --check-storage-boundary`)
+flags raw `sqlite3.connect` but not direct `T2Database(...)` construction (RF-5).
+Closing only the raw-connect surface pushes the bypass into the construction form.
+
+## Context
+
+The piecemeal history, all tracing to the same invariant:
+
+- **5.0.2 / nexus-v4m7y**: `aspect_queue.reclaim_stale` raised "database is locked"
+  under WAL contention. Fix: `busy_timeout` 5s→30s + 3-attempt retry on that one
+  code path.
+- **5.0.2 / nexus-aigkb**: orphan T1 chromadb servers leaked across sessions. Fix:
+  sweep them at MCP startup. (The T1 sibling of the same disease — substrate
+  process lifecycle is not owned by one authority.)
+- **5.0.3 / nexus-n8sbw**: the daemon ran with stdout/stderr → DEVNULL and no log
+  sink, so its deaths were undiagnosable. Fix: file logging + status pid-liveness.
+  This was not the disease; it was that we were *blind* to the disease.
+- **5.0.4 / nexus-5ldk1**: the daemon froze its code version at start, so an
+  upgrade left a stale daemon. Fix: version-aware `ensure-running` that cycles a
+  stale daemon.
+- **OPEN / nexus-kg8sj** (deferred to 5.1.x): `nx index repo` bypasses the daemon
+  and opens `memory.db` directly, holding the WAL lock. This is the keystone
+  offender: frequent (fires from the post-commit hook on every commit) and
+  long-running.
+
+**The live incident that motivated this RDR (2026-05-25):** immediately after
+the 5.0.4 publish, `nx daemon t2 ensure-running` (the new 5.0.4 primitive)
+SIGTERM'd a healthy daemon to cycle it onto the new version; the respawn's startup
+migration hit the indexer's WAL lock and crashed; ensure-running is one-shot, so
+the daemon was left **down**. The 5.0.4 lifecycle fix, composed with kg8sj and an
+un-retried startup-migration path, converted "stale-but-running daemon" into "no
+daemon at all." We amplified the failure with the patch meant to fix lifecycle.
+
+## Research Findings
+
+**RF-1 — `memory.db` has 5+ direct accessors, not one.** Confirmed direct openers:
+(a) the T2 daemon (serving + startup migration); (b) `nx index repo` (kg8sj); (c)
+`nx upgrade` (explicit `epsilon-allow: nx upgrade chicken-and-egg substrate
+bootstrap (cannot route through daemon)`); (d) the `aspect_worker` thread inside
+every `nx-mcp` process (per the `daemon-restart-not-worker-fix` finding, the
+worker opens its own short-lived SQLite connection); (e) `nx doctor` (multiple
+`epsilon-allow` read-only diagnostic connections). The `epsilon-allow` comments
+are themselves an audit trail of where the single-writer invariant was knowingly
+broken. **Verified 2026-05-25 (codebase grep, develop @ 5.0.4): 20 `epsilon-allow`
+sites and 53 direct `T2Database(...)` constructions outside the daemon and the
+store implementations** — far more than five. The worst writers beyond the
+indexer: `nx upgrade`, `nx repair plans`, `nx aspects` repair verbs, and ~10
+operator/CLI paths in `enrich.py`, `operators/aspect_sql.py`, `mcp_infra.py`,
+`merge_candidates.py`, and the `collection_*` modules.
+
+**RF-2 — every daemon incident is a contention symptom.** v4m7y = writer-vs-writer
+collision; kg8sj = the indexer-writer starves others; the 2026-05-25 crash-loop =
+the indexer-writer starves the daemon's *startup-migration* writer; aigkb = the
+unowned-lifecycle sibling. The pattern is not coincidence; it is the predictable
+consequence of N writers on one WAL lock.
+
+**RF-3 — contention hardening is inconsistent across paths. VERIFIED 2026-05-25.**
+v4m7y added `busy_timeout`+retry to `reclaim_stale`, but the daemon's **startup
+migration** (`apply_pending` via `T2Database.bootstrap_schema`) has no such
+tolerance. Confirmed by reading the source: `bootstrap_schema`
+(`db/t2/__init__.py`) opens its connection with `PRAGMA busy_timeout=5000` (5s)
+and no lock-retry (`apply_pending`'s `MigrationRetry` handles migration-internal
+signals, not SQLite `database is locked`), whereas `reclaim_stale`
+(`aspect_extraction_queue.py:162`) uses `busy_timeout=30000` (30s) + bounded
+retry. Under the observed 10+ minute indexer lock the 5s timeout expires and the
+daemon crashes — matching the live traceback. **P0 spec:** give `bootstrap_schema`
+`busy_timeout>=30000` and wrap `apply_pending` in a lock-retry, mirroring
+`reclaim_stale`.
+
+**RF-4 — the 5.0.4 lifecycle cycle has no safety interlock. VERIFIED 2026-05-25.**
+Confirmed in `commands/daemon.py`: on version skew `ensure-running` calls
+`os.kill(running_pid, SIGTERM)` **unconditionally**, waits ≤10s for the old daemon
+to die, then falls through to cold spawn — with no precondition that a replacement
+can acquire the DB lock. **RF-3 × RF-4 is the exact amplification mechanism of the
+live incident:** the cycle tears down the healthy daemon (RF-4); the respawn's
+5s-no-retry startup migration crashes on the indexer's lock (RF-3); `ensure-running`
+is one-shot, so the daemon is left down. **P0 spec:** do not SIGTERM a healthy
+daemon for a version-cycle unless the DB is confirmed acquirable (or make the cycle
+atomic — only tear down once the replacement is confirmed startable).
+
+**RF-5 — the boundary is already recognized and linted; this is a tightening
+exercise.** `src/nexus/storage_boundary_lint.py` already flags direct
+`sqlite3.connect` / T2 opens and requires a per-line `# epsilon-allow: <reason>`
+(reason >= 8 chars); `nx doctor` surfaces violations. So RDR-128 introduces no new
+concept — the single-writer boundary exists and is enforced-by-lint, but the
+exemption list has proliferated (RF-1: 20 sites). This gives the cure a built-in
+**metric** (the `epsilon-allow` count) and a built-in **gate** (the lint): route
+the writers so their exemptions can be deleted, and reserve exemptions for the
+genuinely-irreducible bootstrap cases (the `nx upgrade` chicken-and-egg) under an
+explicit lock discipline. Acceptance = the exemption count reduced to that
+documented-irreducible set.
+
+**RF-1 and RF-5 VERIFIED 2026-05-25** (independent recount + reading the lint
+source): counts reproduce exactly (20 / 53); `storage_boundary_lint.py` is wired
+into `nx doctor --check-storage-boundary` (RDR-120 P0.A / nexus-7xxxg), which
+emits a `storage_boundary_lint` structlog metric — so the acceptance gate and
+metric already exist and can be baselined. **Refinement:** the lint keys on raw
+`sqlite3.connect` only; it does NOT flag direct `T2Database(...)` construction
+(the 53 sites). The implementation must therefore extend the banned-call set to
+construction sites, or routing the raw connects merely pushes the bypass into the
+`T2Database()` form. Second live contention incident recorded the same day: an
+`nx memory put` (recording this very finding) failed with `database is locked`
+because a post-commit `nx index repo` held the WAL lock, succeeding only on
+retry — RDR-128's thesis demonstrated twice in one session.
+
+## Proposed Solution
+
+Enforce the single-writer invariant. Specifications (tightened at gate, 2026-05-25,
+in response to the Layer-3 critique):
+
+1. **Route the worst offenders' writes through the daemon.** Keystone: the
+   indexer (kg8sj) writes T2 (catalog manifest, chash index, telemetry) via the
+   daemon RPC instead of a direct connection. Then `aspect_worker` and the
+   operator/CLI construction sites (see item 5).
+
+2. **A concrete cross-process lock discipline for the bootstrap chicken-and-egg.**
+   `nx upgrade` and the daemon's own startup both migrate the schema, so they
+   cannot both hold open connections during a migration. The discipline (both
+   sides honor it): a dedicated advisory lock file
+   `~/.config/nexus/t2_migration.lock`, taken with an **exclusive `fcntl.flock`**
+   before any schema write. Protocol: (a) `nx upgrade` acquires the migration
+   lock; (b) it signals the running daemon to **quiesce** (stop accepting RPC
+   writes and close its T2 connections — a new daemon RPC `pause_for_migration`,
+   or, simplest, `nx daemon t2 stop`); (c) runs `apply_pending` under the lock;
+   (d) releases the lock; (e) `ensure-running` brings the daemon back. The
+   daemon's *own* startup migration takes the **same** lock, so daemon-start and
+   `nx upgrade` serialize against each other instead of racing on the WAL. This
+   replaces the implicit WAL free-for-all with one explicit, documented lock.
+
+3. **Make the daemon startup migration lock-tolerant (P0).** `bootstrap_schema`
+   gets `busy_timeout >= 30000` and wraps `apply_pending` in a bounded
+   lock-retry, mirroring `reclaim_stale` (RF-3). A transient foreign lock causes
+   a bounded wait, not a crash.
+
+4. **Lifecycle interlock with a specified timeout and fallback (P0, CRITICAL).**
+   Before `ensure-running` SIGTERMs a healthy daemon to version-cycle it, it
+   probes DB-acquirability with a **bounded timeout (30s, matching the migration
+   busy_timeout)**. On success it proceeds with the cycle. **On timeout it ABORTS
+   the cycle**: the stale-but-running daemon is left running, and a one-line
+   deferral warning is logged ("daemon vX stale but DB locked; cycle deferred").
+   This never trades a working daemon for none (the failure the un-interlocked
+   5.0.4 cycle caused) and never hangs indefinitely (the failure a naive
+   try-acquire would cause). The version-cycle is best-effort and re-attempted on
+   the next `ensure-running` invocation.
+
+5. **Extend the boundary lint to construction sites, and baseline (P0).**
+   `storage_boundary_lint` today flags raw `sqlite3.connect` but not direct
+   `T2Database(...)` construction outside daemon-internal code — the 53-site
+   surface that dominates the 20 raw-connect sites (RF-5). Extend the
+   banned-call/-construction set to flag direct `T2Database(...)` outside an
+   allowlisted daemon module, and baseline both counts at P0 so progress is
+   measurable from the start.
+
+The first principle is "one writer." Where that is impossible (the bootstrap
+chicken-and-egg), the second principle is the explicit advisory-lock discipline
+in item 2 — never the current implicit contention.
+
+## Alternatives Considered
+
+- **A. Keep patching per-incident.** Rejected — this is the status quo that
+  produced three releases of band-aids and a crash-loop. Each new code path that
+  touches `memory.db` is a new contention source and a new patch.
+- **B. Cross-process advisory lock only, no routing.** A shared advisory lock all
+  writers honor, without funnelling writes through the daemon. Lighter than full
+  routing; preserves the "many writers" topology but serializes them explicitly.
+  Viable for paths that can't route (upgrade), insufficient alone for the hot path
+  (indexer) where routing also buys batching + back-pressure.
+- **C. Full single-writer routing (all writes via daemon RPC).** The cleanest
+  realization of RDR-120's premise, highest implementation cost (every direct
+  writer must gain an RPC path, including the bootstrap chicken-and-egg). Likely
+  the end state; phase toward it.
+
+## Trade-offs
+
+Routing through the daemon adds RPC latency and a hard dependency on the daemon
+being up for writes that today degrade to direct access. The mitigation is that
+the daemon is *supposed* to be the authority anyway, and the 5.0.4 work already
+makes it self-heal on install. The cost of NOT doing this is the demonstrated
+patch-per-incident cycle plus user-facing daemon outages.
+
+## Implementation Plan
+
+Phased; P0 stops the bleeding and establishes the metric, P1 removes the keystone,
+P2 specifies+builds the bootstrap lock, P3 closes the remaining surface.
+
+- **P0 (crash-loop stop + baseline, patch-shippable):** (a) startup migration
+  gets `busy_timeout >= 30000` + bounded lock-retry (Proposed Solution §3 / RF-3);
+  (b) `ensure-running` interlock with the 30s-timeout / abort-cycle fallback
+  (§4 / RF-4); (c) extend `storage_boundary_lint` to flag direct `T2Database(...)`
+  construction and **baseline both populations** (20 raw-connect + 53 construction)
+  via `nx doctor --check-storage-boundary` (§5). (a)+(b) end the self-inflicted
+  amplification; (c) makes the cure measurable from day one.
+- **P1 (keystone, nexus-kg8sj):** route `nx index repo` T2 writes through the
+  daemon. The single highest-value change; removes the most frequent,
+  longest-held lock. Drives the construction-site count down.
+- **P2 (bootstrap lock discipline):** implement the advisory-`flock` migration
+  lock + daemon quiesce protocol (Proposed Solution §2) so `nx upgrade` and
+  daemon startup serialize. This is the hard residual — built as its own phase,
+  not hand-waved.
+- **P3 (close the invariant):** route or lock-discipline the remaining direct
+  writers (`aspect_worker`, operator/CLI `T2Database(...)` sites) and reduce
+  `nx doctor`'s reader connections; drive **both** lint populations to the
+  documented-irreducible set, removing each `epsilon-allow` / construction
+  exemption or converting it to a documented, locked exception.
+
+## Test Plan
+
+- Reproduce the contention deterministically: hold a write lock on `memory.db`
+  (simulated indexer) and assert the daemon startup *waits and succeeds* rather
+  than crashing.
+- Assert `ensure-running` does not tear down a healthy daemon when the DB lock
+  is unavailable.
+- Concurrency test: N simulated writers (indexer + upgrade + worker) against one
+  daemon, assert no `database is locked` surfaces to a caller.
+- Regression guard that no new code path opens `memory.db` directly without going
+  through the routing/lock helper (lint or test over `epsilon-allow` sites).
+
+## Validation
+
+Two acceptance criteria, one qualitative and one quantitative (the latter covers
+**both** bypass populations, per the gate critique):
+
+- **Qualitative:** a full release cycle (the kind that produced this RDR) — many
+  commits firing the post-commit indexer, an upgrade, a daemon restart — runs
+  without a single `database is locked` daemon incident, and no new daemon
+  band-aid bead is filed.
+- **Quantitative (from `nx doctor --check-storage-boundary`):** both lint
+  populations reach their documented-irreducible set — the raw `sqlite3.connect`
+  `epsilon-allow` count (baseline 20) and the direct `T2Database(...)`
+  construction count (baseline 53) each reduced to the small set of genuinely
+  daemon-internal or bootstrap-locked sites, with every remaining exemption
+  carrying a documented lock-discipline justification. The metric is emitted
+  today, so progress is trackable from P0's baseline.
+
+## Finalization Gate
+
+- **Run 1 (2026-05-25): BLOCKED** — 1 CRITICAL (P0(b) interlock under-specified) +
+  3 SIGNIFICANT (construction-site lint gap, unspecified `nx upgrade` lock
+  discipline, single-population acceptance criterion).
+- **Run 2 (2026-05-25): PASSED** — all four remediated and re-confirmed resolved
+  by the substantive-critic (0 critical, 0 significant). Layers 1 (structure: 4
+  gaps, all sections) and 2 (assumptions: all RFs verified from source) passed.
+  T2: `nexus_rdr/128-gate-latest`.
+
+## References
+
+- RDR-120 (Storage Substrate Split — asserted single-writer; this RDR enforces it)
+- RDR-105 (T1 sub-agent contract — sibling substrate-lifecycle discipline)
+- Beads: nexus-kg8sj (keystone), nexus-v4m7y, nexus-aigkb, nexus-n8sbw, nexus-5ldk1
+- Memory: `daemon-restart-not-worker-fix` (aspect_worker opens its own SQLite conn)
+
+## Revision History
+
+- 2026-05-25: Created (draft). Root-cause RDR motivated by the 5.0.4 post-publish
+  daemon crash-loop and the three-patch band-aid pattern Hal flagged.
+- 2026-05-25: RF-1 and RF-5 verified (20 epsilon-allow + 53 direct T2Database;
+  storage_boundary_lint wired into `nx doctor --check-storage-boundary`). Added
+  the construction-site lint-coverage gap and a second live contention incident.
+  T2 findings: nexus_rdr/128-research-1, /128-research-1-verified.
+- 2026-05-25: RF-3 and RF-4 verified from source (bootstrap_schema 5s/no-retry vs
+  reclaim_stale 30s+retry; ensure-running unconditional SIGTERM). RF-3 × RF-4
+  pinned as the exact amplification mechanism; P0 specs recorded on each. A third
+  live `database is locked` contention hit while recording these findings. T2:
+  nexus_rdr/128-research-2, /128-research-3. All outstanding RFs (1,3,4,5) now
+  verified; RF-2 corroborated by the three live incidents + the RF-3 traceback.
+- 2026-05-25: Gate run 1 BLOCKED (1 CRITICAL + 3 SIGNIFICANT, substantive-critic).
+  Remediated all four: P0(b) interlock now specifies a 30s probe + abort-cycle
+  fallback (never hang, never trade a working daemon for none); `nx upgrade` lock
+  discipline fully specified (advisory `flock` migration lock + daemon quiesce,
+  P2); construction-site linting + dual-population baseline added to P0; Validation
+  acceptance now covers both the raw-connect and T2Database-construction
+  populations. T2 gate: nexus_rdr/128-gate-latest. Re-gating.

--- a/docs/rdr/rdr-128-t2-single-writer-enforcement.md
+++ b/docs/rdr/rdr-128-t2-single-writer-enforcement.md
@@ -2,17 +2,18 @@
 title: "T2 Single-Writer Enforcement: One Owner for memory.db, or an Enforced Lock Discipline"
 id: RDR-128
 type: Architecture
-status: accepted
+status: closed
 priority: high
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-05-25
 accepted_date: 2026-05-25
+closed_date: 2026-05-25
 related_issues: [nexus-kg8sj, nexus-v4m7y, nexus-aigkb, nexus-n8sbw, nexus-5ldk1]
 related_rdrs: [RDR-105, RDR-120]
 supersedes: []
-related_tests: []
-implementation_notes: ""
+related_tests: [tests/test_storage_boundary_lint.py, tests/test_rdr128_p3_enablers.py, tests/stress/test_t2_daemon_stress.py]
+implementation_notes: "Closed implemented 2026-05-25. P0-P3 merged to develop. Post-mortem: docs/rdr/post-mortem/128-t2-single-writer-enforcement.md"
 ---
 
 # RDR-128: T2 Single-Writer Enforcement: One Owner for memory.db, or an Enforced Lock Discipline

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.0.4"
+version = "5.1.0"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.0.4",
+    "conexus>=5.1.0",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.0.4"
+version = "5.1.0"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/scripts/validate/04-hooks.sh
+++ b/scripts/validate/04-hooks.sh
@@ -11,7 +11,7 @@ REPO=$(git rev-parse --show-toplevel)
 HOOKS="$REPO/conexus/hooks/scripts"
 
 # Fake Claude Code hook env
-export CLAUDE_PLUGIN_ROOT="$REPO/nx"
+export CLAUDE_PLUGIN_ROOT="$REPO/conexus"
 export CLAUDE_PROJECT_DIR="$SANDBOX"
 
 # Fake SessionStart event payload

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/sn/README.md
+++ b/sn/README.md
@@ -75,11 +75,11 @@ sn/
 └── README.md
 ```
 
-## Relationship to nx
+## Relationship to conexus
 
-`sn` is project-agnostic — it works in any repository where Serena is configured. It lives in the same marketplace as `nx` but has no dependency on it. Install either or both.
+`sn` is project-agnostic — it works in any repository where Serena is configured. It lives in the same marketplace as `conexus` but has no dependency on it. Install either or both.
 
 | Plugin | Scope | What it provides |
 |--------|-------|-----------------|
-| `nx` | Project-specific | Knowledge management, semantic search, agents, beads, RDR tracking |
+| `conexus` | Project-specific | Knowledge management, semantic search, agents, beads, RDR tracking |
 | `sn` | Universal | MCP tool guidance for subagents (Serena + Context7) |

--- a/sn/hooks/scripts/routing/README.md
+++ b/sn/hooks/scripts/routing/README.md
@@ -1,7 +1,7 @@
 # Routing Hooks (sn) — RDR-125
 
 PreToolUse hooks shipped in the sn plugin. The framework
-(`_lib.py`, `_run_python_hook.sh`) is canonical in nx and **vendored**
+(`_lib.py`, `_run_python_hook.sh`) is canonical in conexus and **vendored**
 here byte-for-byte; `tests/test_routing_lib_drift.py` in the nexus
 monorepo refuses any divergence.
 
@@ -13,13 +13,13 @@ redirects to a tool the plugin ships. sn ships Serena MCP tools
 `grep_for_symbols_redirects_to_serena` rule lives here because its
 deny message names those tools.
 
-Installing nx without sn means this hook does not exist -- which is
+Installing conexus without sn means this hook does not exist -- which is
 the correct default. Users without Serena get no surprise denial of
 their `grep` invocations.
 
 ## Files
 
-- `_lib.py` -- vendored from nx canonical. **Do not edit in isolation.**
+- `_lib.py` -- vendored from conexus canonical. **Do not edit in isolation.**
   Updating the framework means updating both copies atomically.
 - `grep_for_symbols_redirects_to_serena.py` -- the routing rule. Uses
   the standard `sys.path.insert(0, dirname); import _lib` pattern.
@@ -27,7 +27,7 @@ their `grep` invocations.
   `conexus/hooks/scripts/routing/registry.yaml`.
 
 The `_run_python_hook.sh` wrapper at `sn/hooks/scripts/_run_python_hook.sh`
-is also vendored from nx canonical.
+is also vendored from conexus canonical.
 
 ## Cumulative-cap accounting (RDR-121 + RDR-125)
 

--- a/sn/hooks/scripts/routing/registry.yaml
+++ b/sn/hooks/scripts/routing/registry.yaml
@@ -3,18 +3,18 @@
 #
 # Per RDR-125, rules whose deny message redirects to a plugin-specific
 # tool live in the plugin that ships that tool. This file is sn's
-# registry; nx ships its own at conexus/hooks/scripts/routing/registry.yaml.
+# registry; conexus ships its own at conexus/hooks/scripts/routing/registry.yaml.
 #
 # Aggregate cap (RDR-121 + RDR-125): the union of routing rules
 # across all plugins must stay <= 4 PreToolUse:Bash entries to honor
 # the <300ms p95 cumulative budget. Current aggregate count:
-#   nx: 2 routing rules (git_add_all, phase_review_close)
+#   conexus: 2 routing rules (git_add_all, phase_review_close)
 #       + pre_close_verification_hook = 3 PreToolUse:Bash entries
 #   sn: 1 (grep_for_symbols_redirects_to_serena)
 #   total: 4, AT CAP. Adding a fifth rule in ANY plugin requires
 #   either consolidation or a budget revision in a successor RDR.
 #
-# The schema mirrors nx's registry.yaml exactly. See
+# The schema mirrors conexus's registry.yaml exactly. See
 # conexus/hooks/scripts/routing/registry.yaml for field documentation.
 
 rules:

--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -255,20 +255,43 @@ class AspectExtractionWorker:
         All exceptions inside the loop are caught and recorded; the
         worker thread itself never dies from a row's failure.
         """
-        from nexus.mcp_infra import t2_ctx
+        from nexus.db.t2.aspect_extraction_queue import QueueRow
+        from nexus.mcp_infra import t2_index_write
         while not self._stop_event.is_set():
             # Increment unconditionally so a sustained T2 unavailability
             # does not pin _poll_count at a multiple of
             # _RECLAIM_EVERY_N_POLLS and amplify the reclaim UPDATE
             # against an already-stressed database.
             self._poll_count += 1
+            do_reclaim = self._poll_count % self._RECLAIM_EVERY_N_POLLS == 0
             try:
-                with t2_ctx() as t2:
-                    if self._poll_count % self._RECLAIM_EVERY_N_POLLS == 0:
+                # RDR-128 P3 (nexus-sbxbe.3): route the hot poll block
+                # (reclaim + claim, every ~poll_interval seconds) through
+                # the T2 daemon so this worker — which runs inside every
+                # nx-mcp process — stops opening memory.db directly and
+                # contending on its single WAL writer lock. This is the
+                # every-2s contention behind the recurring
+                # `aspect_worker_claim_failed` / `database is locked`
+                # incidents (memory: daemon-restart-not-worker-fix). The
+                # work-bounded persist below stays direct (t2_ctx) because
+                # document_aspects.upsert takes an AspectRecord the daemon
+                # wire protocol cannot round-trip.
+                def _poll(t2):
+                    if do_reclaim:
                         t2.aspect_queue.reclaim_stale(
                             timeout_seconds=self._stale_timeout_seconds,
                         )
-                    rows = t2.aspect_queue.claim_batch(self._batch_size)
+                    return t2.aspect_queue.claim_batch(self._batch_size)
+
+                rows = t2_index_write(_poll)
+                # The daemon RPC decodes QueueRow to a plain dict; the
+                # direct-fallback path returns QueueRow objects. Normalise
+                # so downstream attribute access (row.collection, ...) is
+                # uniform regardless of which path served the claim.
+                rows = [
+                    r if isinstance(r, QueueRow) else QueueRow(**r)
+                    for r in rows
+                ]
             except Exception:
                 _log.warning("aspect_worker_claim_failed", exc_info=True)
                 self._stop_event.wait(self._poll_interval)

--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -837,13 +837,16 @@ def aspect_extraction_enqueue_hook(
     from nexus.aspect_extractor import select_config
     if select_config(collection) is None:
         return  # No extractor for this collection — nothing to enqueue.
-    from nexus.mcp_infra import t2_ctx
+    from nexus.mcp_infra import t2_index_write
     try:
-        with t2_ctx() as t2:
-            t2.aspect_queue.enqueue(
+        # RDR-128 P1 (kg8sj): route the enqueue through the daemon so the
+        # indexer process does not open memory.db directly to write it.
+        t2_index_write(
+            lambda t2: t2.aspect_queue.enqueue(
                 collection, source_path, content=content,
                 doc_id=doc_id,
             )
+        )
     except Exception:
         _log.warning(
             "aspect_extraction_enqueue_failed",

--- a/src/nexus/collection_audit.py
+++ b/src/nexus/collection_audit.py
@@ -352,7 +352,7 @@ def _open_t2():
     db_path = default_db_path()
     if not db_path.exists():
         return None
-    return T2Database(db_path)
+    return T2Database(db_path)  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
 
 
 def _open_catalog_conn() -> sqlite3.Connection | None:

--- a/src/nexus/collection_health.py
+++ b/src/nexus/collection_health.py
@@ -163,7 +163,7 @@ def _open_t2():
     db_path = default_db_path()
     if not db_path.exists():
         return None
-    return T2Database(db_path)
+    return T2Database(db_path)  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
 
 
 def _default_telemetry_stats_fn(col: str) -> dict[str, Any]:

--- a/src/nexus/collection_rename.py
+++ b/src/nexus/collection_rename.py
@@ -82,20 +82,25 @@ def rename_collection_data_plane(
     # ── T2 cascade FIRST (reversible) ────────────────────────────────────────
     # Failure here raises ClickException -- T3 rename has not yet run so the
     # system remains fully consistent. Operator can diagnose and retry.
-    from nexus.config import default_db_path  # noqa: PLC0415
-    from nexus.db.t2 import T2Database  # noqa: PLC0415
+    # RDR-128 P3 (nexus-sbxbe.3): route the multi-store cascade through the
+    # daemon so this command does not open memory.db directly. The op is on
+    # the daemon's database-pseudo-store allowlist and its dict return
+    # round-trips framed JSON; T2Client's facade passthrough makes the
+    # write_fn body work whether routed or degraded to a direct T2Database.
+    from nexus.mcp_infra import t2_index_write  # noqa: PLC0415
 
     try:
-        with T2Database(default_db_path()) as t2db:
-            cascade = t2db.rename_collection_cascade(old=old, new=new)
-            counts["tax_topics"] = cascade.get("tax_topics", 0)
-            counts["tax_assignments"] = cascade.get("tax_assignments", 0)
-            counts["tax_meta"] = cascade.get("tax_meta", 0)
-            counts["chash"] = cascade.get("chash", 0)
-            counts["aspects"] = cascade.get("aspects", 0)
-            counts["aspect_queue"] = cascade.get("aspect_queue", 0)
-            counts["search_telemetry"] = cascade.get("search_telemetry", 0)
-            counts["hook_failures"] = cascade.get("hook_failures", 0)
+        cascade = t2_index_write(
+            lambda t2db: t2db.rename_collection_cascade(old=old, new=new)
+        )
+        counts["tax_topics"] = cascade.get("tax_topics", 0)
+        counts["tax_assignments"] = cascade.get("tax_assignments", 0)
+        counts["tax_meta"] = cascade.get("tax_meta", 0)
+        counts["chash"] = cascade.get("chash", 0)
+        counts["aspects"] = cascade.get("aspects", 0)
+        counts["aspect_queue"] = cascade.get("aspect_queue", 0)
+        counts["search_telemetry"] = cascade.get("search_telemetry", 0)
+        counts["hook_failures"] = cascade.get("hook_failures", 0)
     except Exception as exc:
         raise click.ClickException(
             f"T2 cascade failed before T3 rename -- collection {old!r} is "

--- a/src/nexus/commands/aspects.py
+++ b/src/nexus/commands/aspects.py
@@ -155,7 +155,7 @@ def aspects_gc(apply: bool) -> None:
         )
         raise SystemExit(1)
 
-    with T2Database(mem_path) as db:
+    with T2Database(mem_path) as db:  # epsilon-allow: aspects gc delete_orphans cross-DB ATTACHes the catalog database; not a routable single-store op (RDR-128 P3 documented-irreducible)
         orphans, total = db.document_aspects.delete_orphans(
             cat_db, dry_run=not apply,
         )
@@ -220,7 +220,7 @@ def aspects_gc_fixtures(yes: bool) -> None:
 
     verb = "deleted" if yes else "would delete"
     any_rows = False
-    with T2Database(mem_path) as db:
+    with T2Database(mem_path) as db:  # epsilon-allow: gc-fixtures issues raw multi-store DELETE via live cursors, no store method to route (RDR-128 P3 documented-irreducible)
         # Both target stores expose ``conn`` directly (matching the
         # existing module convention; their writers go through the
         # store's lock, but the verb's serial DELETEs do not need the

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -84,7 +84,7 @@ def _seed_plan_templates() -> int:
     from nexus.db.t2 import T2Database
 
     seeded = 0
-    with T2Database(default_db_path()) as db:
+    with T2Database(default_db_path()) as db:  # epsilon-allow: one-shot `nx catalog setup` plan-seed loader passes Plan dataclasses not in the daemon RPC wire allowlist; not a contention hot path (RDR-128 P3 documented-irreducible)
         from nexus.indexer_utils import find_repo_root
         from nexus.plans.loader import load_all_tiers
 
@@ -1602,7 +1602,7 @@ def _taxonomy_stats() -> dict | None:
         return None
 
     try:
-        with T2Database(db_path) as db:
+        with T2Database(db_path) as db:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
             conn = db.taxonomy.conn
             with db.taxonomy._lock:
                 topic_total = conn.execute(

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -128,12 +128,18 @@ def delete_cmd(name: str, yes: bool) -> None:
     taxonomy_counts: dict[str, int] | None = None
     chash_deleted = 0
     try:
-        from nexus.commands._helpers import default_db_path
-        from nexus.db.t2 import T2Database
+        # RDR-128 P3 (nexus-sbxbe.3): route the cascade through the daemon.
+        # Both purge_collection and delete_collection are routable store
+        # ops (str arg, dict/int return).
+        from nexus.mcp_infra import t2_index_write
 
-        with T2Database(default_db_path()) as db:
-            taxonomy_counts = db.taxonomy.purge_collection(name)
-            chash_deleted = db.chash_index.delete_collection(name)
+        def _cascade(db):
+            return (
+                db.taxonomy.purge_collection(name),
+                db.chash_index.delete_collection(name),
+            )
+
+        taxonomy_counts, chash_deleted = t2_index_write(_cascade)
     except Exception as exc:
         prefix = "absent" if t3_absent else "succeeded"
         click.echo(

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -660,6 +660,51 @@ def t2_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
     click.echo("  status: running")
 
 
+# RDR-128 P0b (RF-4): bounded timeout for the pre-cycle DB-acquirability
+# probe. Matches the startup-migration busy_timeout (db/t2/__init__.py
+# _BOOTSTRAP_BUSY_TIMEOUT_MS) — there is no point cycling to a daemon whose
+# first act (the startup migration) would block longer than this. Module
+# constant so tests can shrink it without waiting the full 30s.
+_T2_CYCLE_DB_PROBE_TIMEOUT_MS: int = 30000
+
+
+def _t2_db_write_lock_acquirable(db_path: Path, timeout_ms: int) -> bool:
+    """Probe whether memory.db's single WAL writer lock is acquirable
+    within ``timeout_ms``, without holding it destructively (RDR-128 P0b).
+
+    Opens a throwaway connection and attempts ``BEGIN IMMEDIATE`` — the same
+    write lock the daemon's startup migration needs — then immediately rolls
+    back. Returns:
+
+    * ``True``  — the lock was acquired within the bounded busy_timeout (or
+      the file does not exist yet, so there is nothing to contend with);
+    * ``False`` — it stayed locked/busy for the whole timeout (another
+      process, typically ``nx index repo``, is holding it).
+
+    Bounded by construction: ``busy_timeout`` caps the ``BEGIN IMMEDIATE``
+    wait, so this never hangs. Non-lock ``OperationalError``\\s propagate.
+    """
+    import sqlite3
+
+    if not db_path.exists():
+        return True
+    # A raw connection is the point of this probe: routing through
+    # T2Database would open eight connections and defeat a single-lock test.
+    conn = sqlite3.connect(str(db_path), timeout=timeout_ms / 1000.0)  # epsilon-allow: RDR-128 P0b raw lock probe
+    try:
+        conn.execute(f"PRAGMA busy_timeout={int(timeout_ms)}")
+        conn.execute("BEGIN IMMEDIATE")
+        conn.rollback()
+        return True
+    except sqlite3.OperationalError as exc:
+        msg = str(exc).lower()
+        if "locked" in msg or "busy" in msg:
+            return False
+        raise
+    finally:
+        conn.close()
+
+
 @t2_group.command("ensure-running")
 @click.option(
     "--config-dir",
@@ -753,6 +798,25 @@ def t2_ensure_running_cmd(
         # CURRENT daemon; gracefully cycle the stale one and respawn below.
         # SIGTERM lets the daemon drain in-flight RPC (stop() awaits
         # wait_closed) and remove its discovery file before we respawn.
+        #
+        # RDR-128 P0b (RF-4): but do NOT SIGTERM a healthy (if stale) daemon
+        # while memory.db's WAL writer lock is held — the respawn's startup
+        # migration would race the holder (typically `nx index repo`) and
+        # could crash-loop, and because ensure-running is one-shot we'd be
+        # left with NO daemon. Probe the lock with a bounded timeout; on
+        # timeout, ABORT the cycle: leave the stale-but-working daemon up and
+        # defer to the next ensure-running. Never hang; never trade a working
+        # daemon for none.
+        db_path = config_dir / "memory.db"
+        if not _t2_db_write_lock_acquirable(
+            db_path, timeout_ms=_T2_CYCLE_DB_PROBE_TIMEOUT_MS
+        ):
+            click.echo(
+                f"T2 daemon v{running_ver} stale but memory.db write lock "
+                f"held; cycle deferred (will retry on next ensure-running).",
+                err=True,
+            )
+            return  # leave the stale daemon up — best-effort, retried later
         if not quiet:
             click.echo(
                 f"T2 daemon is stale (running {running_ver}, installed "

--- a/src/nexus/commands/doc.py
+++ b/src/nexus/commands/doc.py
@@ -105,7 +105,7 @@ def render_cmd(
     # install, no db), fall back to bead + RDR resolvers only.
     db: T2Database | None = None
     try:
-        db = T2Database(default_db_path())
+        db = T2Database(default_db_path())  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
     except Exception:
         db = None
 
@@ -230,7 +230,7 @@ def validate_cmd(paths: tuple[Path, ...], project_root: Path | None) -> None:
 
     db: T2Database | None = None
     try:
-        db = T2Database(default_db_path())
+        db = T2Database(default_db_path())  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
     except Exception:
         db = None
 
@@ -573,7 +573,7 @@ def _phase4_t2_taxonomy():
 
     @contextmanager
     def _taxonomy_ctx():
-        db = T2Database(default_db_path())
+        db = T2Database(default_db_path())  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
         try:
             yield db.taxonomy
         finally:

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -879,17 +879,20 @@ def _run_check_storage_boundary(
 
     if phase:
         try:
-            from nexus.commands._helpers import default_db_path
-            from nexus.db.t2 import T2Database
+            # RDR-128 P3 (nexus-sbxbe.3): route the phase-metric write
+            # through the daemon so `nx doctor` does not open memory.db
+            # directly. memory.put is a routable store op.
+            from nexus.mcp_infra import t2_index_write
 
-            with T2Database(default_db_path()) as db:
-                db.memory.put(
+            t2_index_write(
+                lambda db: db.memory.put(
                     project="nexus_rdr",
                     title=f"120-phase-{phase}-catalog-allowlist-count",
                     content=str(result.catalog_allowlist_count),
                     tags="rdr-120,phase-metric,catalog-allowlist",
                     ttl=None,  # permanent
                 )
+            )
         except Exception as exc:
             log.warning(
                 "storage_boundary_lint_metric_write_failed",

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -856,9 +856,11 @@ def _run_check_storage_boundary(
     result = scan_repo(repo_root=repo_root)
 
     click.echo(
-        f"Storage-boundary lint (RDR-120 P0.A):\n"
+        f"Storage-boundary lint (RDR-120 P0.A / RDR-128 P0c):\n"
         f"  violations:                {result.total_violations}\n"
-        f"  catalog-allowlist count:   {result.catalog_allowlist_count}"
+        f"  catalog-allowlist count:   {result.catalog_allowlist_count}\n"
+        f"  epsilon-allow connects:    {result.epsilon_allow_connects}\n"
+        f"  T2Database constructions:  {result.t2database_constructions}"
     )
 
     if result.violations:
@@ -870,6 +872,8 @@ def _run_check_storage_boundary(
         "storage_boundary_lint",
         violations=result.total_violations,
         catalog_allowlist_count=result.catalog_allowlist_count,
+        epsilon_allow_connects=result.epsilon_allow_connects,
+        t2database_constructions=result.t2database_constructions,
         phase=phase or "unset",
     )
 

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -744,7 +744,7 @@ def _select_entries(
         # Filter to entries whose existing aspect row has model_version
         # below the threshold. Rows without an existing aspect entry
         # are also included (they need first-time extraction).
-        with T2Database(default_db_path()) as db:
+        with T2Database(default_db_path()) as db:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
             outdated_paths = {
                 r.source_path
                 for r in db.document_aspects.list_by_extractor_version(
@@ -967,7 +967,7 @@ def _run_extraction(
     manifest_lookup = _build_catalog_manifest_lookup()
 
     db_path = default_db_path()
-    with T2Database(db_path) as db:
+    with T2Database(db_path) as db:  # epsilon-allow: document_aspects.upsert takes an AspectRecord arg the daemon RPC wire protocol decodes to a dict server-side; not routable (RDR-128 P3 documented-irreducible)
         for i, entry in enumerate(entries, 1):
             source_path = entry.file_path or entry.title
             if not source_path:
@@ -1195,7 +1195,7 @@ def enrich_aspects_list(collection: str, limit: int, scheme: str) -> None:
     from nexus.commands._helpers import default_db_path
     from nexus.db.t2 import T2Database
 
-    with T2Database(default_db_path()) as db:
+    with T2Database(default_db_path()) as db:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
         records = db.document_aspects.list_by_collection(
             collection, limit=limit if limit > 0 else None,
         )
@@ -1242,7 +1242,7 @@ def enrich_aspects_info(collection: str, source_path: str) -> None:
     from nexus.commands._helpers import default_db_path
     from nexus.db.t2 import T2Database
 
-    with T2Database(default_db_path()) as db:
+    with T2Database(default_db_path()) as db:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
         record = db.document_aspects.get(collection, source_path)
 
     if record is None:
@@ -1305,8 +1305,13 @@ def enrich_aspects_delete(
             abort=True,
         )
 
-    with T2Database(default_db_path()) as db:
-        deleted = db.document_aspects.delete(collection, source_path)
+    # RDR-128 P3 (nexus-sbxbe.3): route the delete through the daemon.
+    # document_aspects.delete (str/str args, int return) is routable —
+    # distinct from document_aspects.upsert, which is RPC-denied.
+    from nexus.mcp_infra import t2_index_write
+    deleted = t2_index_write(
+        lambda db: db.document_aspects.delete(collection, source_path)
+    )
 
     if deleted:
         click.echo(
@@ -1376,7 +1381,7 @@ def enrich_aspects_promote_field(
     from nexus.db.t2 import T2Database
 
     if history:
-        with T2Database(default_db_path()) as db:
+        with T2Database(default_db_path()) as db:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
             entries = list_promotions(db)
         if not entries:
             click.echo("No promotion history.")
@@ -1390,7 +1395,7 @@ def enrich_aspects_promote_field(
             )
         return
 
-    with T2Database(default_db_path()) as db:
+    with T2Database(default_db_path()) as db:  # epsilon-allow: promote_extras_field runs raw DDL plus aspect_promotion_log writes on the live connection; not a routable store op (RDR-128 P3 documented-irreducible)
         try:
             result = promote_extras_field(
                 db, field_name,
@@ -1547,7 +1552,7 @@ def aspects_show_cmd(tumbler_or_title: str, as_json: bool, field: str) -> None:
         )
         return
 
-    with T2Database(default_db_path()) as db:
+    with T2Database(default_db_path()) as db:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
         # nexus-6xp2: post-drop, source_path-keyed lookup is unreliable
         # when the writer used a non-uri_for source_uri. Tumbler-keyed
         # get_by_doc_id is exact; fall back to legacy (coll, path) get
@@ -1616,7 +1621,7 @@ def aspects_list_cmd(
             )
         cat = Catalog(cat_path, cat_path / ".catalog.db")
         entries = cat.list_by_collection(collection)
-        with T2Database(default_db_path()) as db:
+        with T2Database(default_db_path()) as db:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
             existing = {
                 r.source_path for r in db.document_aspects.list_by_collection(
                     collection,
@@ -1649,7 +1654,7 @@ def aspects_list_cmd(
             click.echo(f"  ... and {len(gaps) - limit} more.")
         return
 
-    with T2Database(default_db_path()) as db:
+    with T2Database(default_db_path()) as db:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
         records = db.document_aspects.list_by_collection(
             collection, limit=(limit if limit else None),
         )

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -542,7 +542,7 @@ def run_collection_postprocessing(
     try:
         t3 = make_t3()
         total_topics = 0
-        with T2Database(default_db_path()) as db:
+        with T2Database(default_db_path()) as db:  # epsilon-allow: auto-discover runs discover_topics/project_against, which interleave ChromaDB centroid writes keyed on T2-generated topic_ids and need a live chroma client; cannot cross the daemon RPC (RDR-128 P3 documented-irreducible)
             for col_name in collections:
                 try:
                     n = _discover_taxonomy(col_name, db.taxonomy, t3._client)

--- a/src/nexus/commands/scratch.py
+++ b/src/nexus/commands/scratch.py
@@ -4,9 +4,7 @@ from typing import Any
 
 import click
 
-from nexus.commands._helpers import default_db_path as _default_db_path
 from nexus.db.t1 import T1Database
-from nexus.db.t2 import T2Database
 
 
 def _t1() -> T1Database:
@@ -130,12 +128,19 @@ def unflag_cmd(entry_id: str) -> None:
 @click.option("--title", "-t", required=True, help="Target T2 title")
 def promote_cmd(entry_id: str, project: str, title: str) -> None:
     """Copy a scratch entry to T2 immediately."""
+    from nexus.mcp_infra import t2_index_write
+
     t1 = _t1()
-    with T2Database(_default_db_path()) as t2:
-        try:
-            report = t1.promote(entry_id, project=project, title=title, t2=t2)
-        except KeyError as exc:
-            raise click.ClickException(str(exc)) from exc
+    try:
+        # RDR-128 P3 (nexus-sbxbe.3): route the T2 write through the daemon.
+        # T1Database.promote calls ``t2.put(...)``; T2Client's facade
+        # passthrough makes that work on the routed client (memory.put RPC)
+        # or the direct-fallback T2Database.
+        report = t2_index_write(
+            lambda t2: t1.promote(entry_id, project=project, title=title, t2=t2)
+        )
+    except KeyError as exc:
+        raise click.ClickException(str(exc)) from exc
     click.echo(f"Promoted {entry_id} -> {project}/{title} (action={report.action})")
 
 

--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -309,7 +309,7 @@ def search_cmd(
         # Pass taxonomy for topic grouping + topic boost (RDR-070)
         from nexus.commands._helpers import default_db_path as _db_path
         from nexus.db.t2 import T2Database
-        with T2Database(_db_path()) as _t2:
+        with T2Database(_db_path()) as _t2:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
             raw = search_cross_corpus(
                 q, target_collections, n_results=n, t3=db,
                 where=where_filter, link_boost=False,

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -12,9 +12,21 @@ from nexus.commands._helpers import default_db_path as _default_db_path
 
 
 def _T2Database(path):
-    """Lazy T2Database constructor (avoids module-level import poisoning by test mocks)."""
+    """Lazy T2Database constructor (avoids module-level import poisoning by test mocks).
+
+    RDR-128 P3 (nexus-sbxbe.3): this factory backs ~17 ``nx taxonomy``
+    subcommands and is the single construction site the lint sees for all
+    of them. It is irreducible: the read-only subcommands (``status`` /
+    ``list`` / ``show`` / ``hubs`` / ``audit`` / ``links``) issue raw
+    ``db.taxonomy.conn.execute(...)`` SELECTs, and a raw SQLite cursor
+    cannot cross the daemon RPC boundary; while ``discover`` / ``rebuild``
+    / ``split`` / ``project`` interleave a ChromaDB centroid write with the
+    T2-generated ``topic_id`` inside one lock, which likewise cannot route.
+    The reads do not contend on the WAL writer lock; the writes are
+    infrequent operator commands, not the automated hot path.
+    """
     from nexus.db.t2 import T2Database
-    return T2Database(path)
+    return T2Database(path)  # epsilon-allow: taxonomy CLI factory — read-only subcommands need raw-cursor SELECTs (no WAL writer contention) and discover/rebuild/split interleave chroma-centroid writes keyed on T2-generated topic_ids; neither can cross the daemon RPC (RDR-128 P3 documented-irreducible)
 
 if TYPE_CHECKING:
     from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
@@ -1834,7 +1846,7 @@ def backfill_source_collection_cmd(apply_: bool) -> None:
     if not db_path.exists():
         raise click.ClickException(f"T2 database not found: {db_path}")
 
-    t2 = T2Database(db_path)
+    t2 = T2Database(db_path)  # epsilon-allow: backfill passes the taxonomy store across a fn boundary for a read-then-UPDATE under its _lock; not a routable single-store RPC op (RDR-128 P3 documented-irreducible)
     try:
         # Pass the store (not the raw conn) so _lock is held for the
         # read + UPDATE sequence (review gate C-1).

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -283,33 +283,41 @@ def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool =
                 applied = 0
                 any_failed = False
                 try:
-                    t3_db = make_t3()
-                    t2_db = T2Database(default_db_path())
-                    for step in unapplied:
-                        click.echo(f"  T3: [{step.introduced}] {step.name}")
-                        try:
-                            step.fn(t3_db, t2_db.taxonomy)
-                        except Exception as step_exc:
-                            any_failed = True
-                            _log.warning(
-                                "t3_upgrade_step_failed",
-                                introduced=step.introduced,
-                                name=step.name,
-                                error=str(step_exc),
-                                exc_info=True,
+                    # RDR-128 P3 (nexus-sbxbe.3): the T3 steps mutate T2
+                    # (taxonomy) data and write _nexus_t3_steps. Hold the
+                    # same cross-process migration flock that guards
+                    # apply_pending above (it was released by the time we
+                    # get here) so a session-start-respawned daemon's
+                    # startup migration WAITS rather than racing these
+                    # writes on the single WAL writer lock.
+                    with t2_migration_flock(db_path.parent):
+                        t3_db = make_t3()
+                        t2_db = T2Database(default_db_path())  # epsilon-allow: nx upgrade bootstrap chicken-and-egg — T3 steps need a live chroma client + taxonomy store; serialized under the migration flock, daemon quiesced (RDR-128 P3 documented-irreducible)
+                        for step in unapplied:
+                            click.echo(f"  T3: [{step.introduced}] {step.name}")
+                            try:
+                                step.fn(t3_db, t2_db.taxonomy)
+                            except Exception as step_exc:
+                                any_failed = True
+                                _log.warning(
+                                    "t3_upgrade_step_failed",
+                                    introduced=step.introduced,
+                                    name=step.name,
+                                    error=str(step_exc),
+                                    exc_info=True,
+                                )
+                                click.echo(
+                                    f"    FAILED: {step_exc} — will retry on next `nx upgrade`",
+                                    err=True,
+                                )
+                                continue
+                            conn.execute(
+                                "INSERT OR REPLACE INTO _nexus_t3_steps "
+                                "(introduced, name, applied_at) VALUES (?, ?, datetime('now'))",
+                                (step.introduced, step.name),
                             )
-                            click.echo(
-                                f"    FAILED: {step_exc} — will retry on next `nx upgrade`",
-                                err=True,
-                            )
-                            continue
-                        conn.execute(
-                            "INSERT OR REPLACE INTO _nexus_t3_steps "
-                            "(introduced, name, applied_at) VALUES (?, ?, datetime('now'))",
-                            (step.introduced, step.name),
-                        )
-                        conn.commit()
-                        applied += 1
+                            conn.commit()
+                            applied += 1
                 finally:
                     if t2_db is not None:
                         t2_db.close()

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -18,6 +18,7 @@ from nexus.db.migrations import (
     _upgrade_done,
     apply_pending,
     bootstrap_version,
+    t2_migration_flock,
 )
 
 _log = structlog.get_logger()
@@ -45,20 +46,78 @@ def _current_version() -> str:
 @click.option("--skip-t3", is_flag=True, help="Skip T3 upgrade steps (e.g., cross-collection projection backfill). Useful for fast T2-only migrations.")
 def upgrade(dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool) -> None:
     """Run pending database migrations and upgrade steps."""
+    # RDR-128 P2: quiesce the daemon BEFORE migrating so its live T2
+    # connections are released — the migration flock serializes the two
+    # MIGRATOR processes, but only quiescing frees the daemon's serving
+    # connections so the migration DDL has clear access. try/finally brings
+    # the daemon back even if the upgrade fails (a failed upgrade must not
+    # leave the daemon down; its startup migration is idempotent + flocked).
     try:
+        if not dry_run:
+            _quiesce_daemon()
         _run_upgrade(dry_run=dry_run, force=force, auto_mode=auto_mode, skip_t3=skip_t3)
     except Exception:
         if auto_mode:
             _log.warning("upgrade_auto_error", exc_info=True)
             return
         raise
-    # nexus-5ldk1: a running T2 daemon froze its code at start and now
-    # predates this upgrade. Bring it to the just-installed version so the
-    # upgrade is live rather than pending a manual daemon restart.
-    # ensure-running is version-aware: no-op on a current daemon, graceful
-    # cycle on a stale one. Best-effort, non-dry-run only.
-    if not dry_run:
-        _cycle_daemon_to_current()
+    finally:
+        # nexus-5ldk1: a running T2 daemon froze its code at start and now
+        # predates this upgrade. Bring it to the just-installed version so
+        # the upgrade is live rather than pending a manual daemon restart.
+        # ensure-running is version-aware: no-op on a current daemon,
+        # graceful cycle on a stale one. Best-effort, non-dry-run only.
+        if not dry_run:
+            _cycle_daemon_to_current()
+
+
+def _quiesce_daemon() -> None:
+    """RDR-128 P2: stop the running T2 daemon and WAIT for it to exit, so it
+    has released its eight T2 connections before ``nx upgrade`` migrates.
+
+    ``nx daemon t2 stop`` only *sends* SIGTERM; the daemon then drains and
+    closes connections asynchronously, so we poll the recorded pid until it
+    is gone (bounded) to close the signal-to-shutdown race. Best-effort:
+    never raises — the migration flock + busy_timeout still protect
+    correctness if a straggler connection lingers.
+    """
+    import json
+    import os
+    import subprocess
+    import time as _time
+
+    try:
+        from nexus.commands.daemon import _resolve_nx_bin
+        from nexus.config import nexus_config_dir
+        from nexus.daemon.t2_daemon import t2_discovery_path
+
+        disc = t2_discovery_path(nexus_config_dir())
+        pid: int | None = None
+        if disc.exists():
+            try:
+                pid = json.loads(disc.read_text()).get("pid")
+            except (OSError, json.JSONDecodeError):
+                pid = None
+
+        subprocess.run(
+            [*_resolve_nx_bin(), "daemon", "t2", "stop"],
+            timeout=30,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        # Wait for the daemon process to actually exit (release its conns).
+        if isinstance(pid, int) and pid > 0:
+            deadline = _time.monotonic() + 10.0
+            while _time.monotonic() < deadline:
+                try:
+                    os.kill(pid, 0)
+                except (ProcessLookupError, PermissionError):
+                    break  # gone
+                _time.sleep(0.1)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("upgrade_daemon_quiesce_failed", error=str(exc))
 
 
 def _cycle_daemon_to_current() -> None:
@@ -176,7 +235,12 @@ def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool =
         path_key = str(Path(db_path).resolve())
         _upgrade_done.discard(path_key)
 
-        apply_pending(conn, current)
+        # RDR-128 P2: serialize against the daemon's startup migration via
+        # the cross-process flock (the daemon was quiesced above, but a
+        # session-start hook could respawn it mid-upgrade; the flock makes
+        # that respawn's migration WAIT rather than race the WAL).
+        with t2_migration_flock(db_path.parent):
+            apply_pending(conn, current)
 
         if not auto_mode:
             if pending_t2:

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -292,7 +292,7 @@ def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool =
                     # writes on the single WAL writer lock.
                     with t2_migration_flock(db_path.parent):
                         t3_db = make_t3()
-                        t2_db = T2Database(default_db_path())  # epsilon-allow: nx upgrade bootstrap chicken-and-egg — T3 steps need a live chroma client + taxonomy store; serialized under the migration flock, daemon quiesced (RDR-128 P3 documented-irreducible)
+                        t2_db = T2Database(default_db_path())  # epsilon-allow: nx upgrade is the bootstrap chicken-and-egg (it migrates the schema the daemon serves, so it cannot route through the daemon); daemon quiesced during upgrade, the migration flock serializes a respawned daemon's startup migration cross-process. NOTE: shares the process with the apply_pending migration conn (pre-existing, single-threaded sequential writes, tracked by nexus-izpcb) (RDR-128 P3 documented-irreducible)
                         for step in unapplied:
                             click.echo(f"  T3: [{step.introduced}] {step.name}")
                             try:

--- a/src/nexus/context.py
+++ b/src/nexus/context.py
@@ -192,7 +192,7 @@ def refresh_context_l1(
     from nexus.db.t2 import T2Database
 
     path = db_path or default_db_path()
-    with T2Database(path) as db:
+    with T2Database(path) as db:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
         return generate_context_l1(
             db.taxonomy, output_path=output_path, repo_path=repo_path,
         )

--- a/src/nexus/daemon/t2_client.py
+++ b/src/nexus/daemon/t2_client.py
@@ -270,6 +270,27 @@ class T2Client:
                 self._sock = None
             self._handshake_done = False
 
+    # ── Facade-parity passthroughs (RDR-128 P3) ─────────────────────────
+    # T2Database exposes ``expire`` / ``rename_collection_cascade`` at the
+    # top level (they span multiple stores), whereas the daemon dispatches
+    # them under the ``database`` pseudo-store. These thin forwards give
+    # T2Client the same top-level surface as T2Database, so a
+    # ``t2_index_write(write_fn)`` body can call ``db.expire()`` /
+    # ``db.rename_collection_cascade(old, new)`` uniformly regardless of
+    # whether the daemon is reachable (routed client) or not (direct DB).
+
+    def expire(self, *args: Any, **kwargs: Any) -> Any:
+        return self.database.expire(*args, **kwargs)
+
+    def rename_collection_cascade(self, *args: Any, **kwargs: Any) -> Any:
+        return self.database.rename_collection_cascade(*args, **kwargs)
+
+    def put(self, *args: Any, **kwargs: Any) -> Any:
+        # T2Database.put is a thin facade over memory.put; mirror it so a
+        # write_fn (or a helper handed the writer, e.g. T1Database.promote)
+        # can call db.put(...) on either a routed client or a direct DB.
+        return self.memory.put(*args, **kwargs)
+
     # ── RPC ─────────────────────────────────────────────────────────────
 
     def _ensure_sock(self) -> socket.socket:

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -286,7 +286,15 @@ _T2_STORE_ATTRS: tuple[str, ...] = (
 #: Top-level T2Database methods exposed under the "database" pseudo-store.
 #: ``hello`` is the RDR-120 P3b connection handshake — T2Client invokes
 #: it on first connect to validate schema-version compatibility.
-_T2_DATABASE_METHODS: tuple[str, ...] = ("rename_collection_cascade", "hello")
+#: ``expire`` (RDR-128 P3) is the multi-store TTL sweep (memory rows +
+#: relevance_log); routing it lets the SessionEnd flush hook reach the
+#: daemon instead of opening memory.db directly. Its ``int`` arg and
+#: ``int`` return round-trip framed JSON cleanly.
+_T2_DATABASE_METHODS: tuple[str, ...] = (
+    "rename_collection_cascade",
+    "expire",
+    "hello",
+)
 
 #: Methods filtered from every store. ``close`` is denied to prevent a
 #: client from tearing down the daemon's SQLite handles via RPC;

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -11,11 +11,14 @@ RDR-076 (nexus-6cn).
 """
 from __future__ import annotations
 
+import fcntl
+import os
 import sqlite3
 import threading
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Iterator
 
 import structlog
 
@@ -2248,6 +2251,45 @@ _upgrade_done: set[str] = set()
 Checked by ``T2Database.__init__()`` before opening any connection.
 Distinct from per-domain ``_migrated_paths`` sets in each store.
 """
+
+#: RDR-128 P2: filename of the cross-process migration lock, in the same
+#: directory as ``memory.db`` (the config dir).
+T2_MIGRATION_LOCK_FILE: str = "t2_migration.lock"
+
+
+@contextmanager
+def t2_migration_flock(lock_dir: Path) -> Iterator[None]:
+    """Exclusive, cross-process advisory lock for T2 schema migration (RDR-128 P2).
+
+    Both ``nx upgrade`` and the daemon's own startup migration
+    (``T2Database.bootstrap_schema``) take this lock before running
+    ``apply_pending``, so the two migration paths SERIALIZE instead of
+    racing on SQLite's single WAL writer lock — the structural contention
+    that produced the 5.0.2-5.0.4 daemon incidents and the post-5.0.4
+    crash-loop.
+
+    Blocking ``LOCK_EX``: a second migrator WAITS for the first rather than
+    failing. The lock is bound to the open file descriptor, so the OS
+    releases it automatically when the fd is closed — including on process
+    death. A migrator that crashes mid-run therefore never strands the
+    lock; the next migrator acquires it and re-runs (``apply_pending`` is
+    idempotent and only records completion on success).
+
+    The lock file lives at ``<lock_dir>/t2_migration.lock``; both callers
+    pass the directory containing ``memory.db`` so they share one lock.
+    """
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / T2_MIGRATION_LOCK_FILE
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)  # blocking — serialize against the other migrator
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
 
 _upgrade_lock = threading.RLock()
 """Serialises the check-then-add on ``_upgrade_done``.

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -2280,15 +2280,19 @@ def t2_migration_flock(lock_dir: Path) -> Iterator[None]:
     """
     lock_dir.mkdir(parents=True, exist_ok=True)
     lock_path = lock_dir / T2_MIGRATION_LOCK_FILE
-    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    fd = -1
     try:
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
         fcntl.flock(fd, fcntl.LOCK_EX)  # blocking — serialize against the other migrator
         try:
             yield
         finally:
             fcntl.flock(fd, fcntl.LOCK_UN)
     finally:
-        os.close(fd)
+        # Guard: if os.open itself raised, fd is still -1 (nothing to close,
+        # and we must not raise NameError from the finally and mask it).
+        if fd >= 0:
+            os.close(fd)
 
 
 _upgrade_lock = threading.RLock()

--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 from uuid import uuid4
+
+if TYPE_CHECKING:
+    from nexus.daemon.t2_client import T2Client
 
 import structlog
 
@@ -594,8 +597,17 @@ class T1Database:
 
     # ── Promote ───────────────────────────────────────────────────────────────
 
-    def promote(self, id: str, project: str, title: str, t2: T2Database) -> "PromotionReport":
+    def promote(
+        self, id: str, project: str, title: str, t2: T2Database | T2Client,
+    ) -> "PromotionReport":
         """Copy T1 entry *id* to T2 immediately. Returns a PromotionReport.
+
+        *t2* may be a direct ``T2Database`` or a daemon-backed ``T2Client``
+        (RDR-128 P3): ``nx scratch promote`` routes through
+        ``mcp_infra.t2_index_write``, so the overlap-detection ``memory.search``
+        read and the ``put`` write both go over the daemon RPC when one is
+        reachable. Both types expose the ``.put`` / ``.memory`` surface this
+        method uses.
 
         Overlap detection (RDR-057): pulls the first few non-stopword content
         tokens from the scratch entry and FTS5-searches T2 for any existing

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -413,46 +413,58 @@ class T2Database:
         except OSError:
             path_key = str(path)
 
+        # Fast path: already migrated in this process. Cheap check under the
+        # in-process lock only — no cross-process flock needed.
         with _upgrade_lock:
             if path_key in _upgrade_done:
                 return
-            try:
-                from importlib.metadata import version as _pkg_version
 
-                current_version = _pkg_version("conexus")
-            except Exception:
-                current_version = "0.0.0"
+        # RDR-128 P2: acquire the cross-process migration flock BEFORE the
+        # in-process ``_upgrade_lock`` so the lock order matches ``nx upgrade``
+        # (flock -> _upgrade_lock, via apply_pending). Consistent ordering
+        # means the daemon-startup and upgrade migration paths cannot deadlock
+        # even if ever run concurrently in one process (code-review finding).
+        # The flock also serializes the two paths cross-process, replacing the
+        # old WAL free-for-all.
+        with t2_migration_flock(path.parent):
+            with _upgrade_lock:
+                # Double-check: another thread may have completed the migration
+                # while we blocked on the flock.
+                if path_key in _upgrade_done:
+                    return
+                try:
+                    from importlib.metadata import version as _pkg_version
 
-            import sys as _sys
-            if hasattr(_sys.stderr, "isatty") and _sys.stderr.isatty():
-                print(
-                    f"Migrating database {path.name!r} to schema "
-                    f"version {current_version} ...",
-                    file=_sys.stderr,
-                )
+                    current_version = _pkg_version("conexus")
+                except Exception:
+                    current_version = "0.0.0"
 
-            conn = sqlite3.connect(str(path), check_same_thread=False)
-            try:
-                # RDR-128 P0a (RF-3): tolerate a concurrent writer (e.g.
-                # `nx index repo`) holding the WAL writer lock — wait it out
-                # via a 30s busy_timeout plus a bounded retry, rather than
-                # crashing the daemon on `database is locked`.
-                # busy_timeout is a connection-local pragma that never blocks;
-                # journal_mode=WAL + apply_pending run inside the retry helper
-                # since both can take the writer lock (RDR-128 P0a).
-                conn.execute(f"PRAGMA busy_timeout={_BOOTSTRAP_BUSY_TIMEOUT_MS}")
-                # RDR-128 P2: take the cross-process migration flock so the
-                # daemon's startup migration serializes against `nx upgrade`
-                # (and vice-versa) instead of racing on the WAL writer lock.
-                with t2_migration_flock(path.parent):
+                import sys as _sys
+                if hasattr(_sys.stderr, "isatty") and _sys.stderr.isatty():
+                    print(
+                        f"Migrating database {path.name!r} to schema "
+                        f"version {current_version} ...",
+                        file=_sys.stderr,
+                    )
+
+                conn = sqlite3.connect(str(path), check_same_thread=False)
+                try:
+                    # RDR-128 P0a (RF-3): tolerate a concurrent writer (e.g.
+                    # `nx index repo`) holding the WAL writer lock — wait it
+                    # out via a 30s busy_timeout plus a bounded retry, rather
+                    # than crashing on `database is locked`. busy_timeout is a
+                    # connection-local pragma that never blocks; journal_mode
+                    # =WAL + apply_pending run inside the retry helper since
+                    # both can take the writer lock.
+                    conn.execute(f"PRAGMA busy_timeout={_BOOTSTRAP_BUSY_TIMEOUT_MS}")
                     _apply_pending_with_lock_retry(conn, current_version)
-            finally:
-                conn.close()
-            # Mirror the T2Database-form path_key into _upgrade_done so
-            # a second construction with the same Path argument
-            # short-circuits without re-opening the connection
-            # (nexus-avwe — CI path-resolution edge cases).
-            _upgrade_done.add(path_key)
+                finally:
+                    conn.close()
+                # Mirror the T2Database-form path_key into _upgrade_done so
+                # a second construction with the same Path argument
+                # short-circuits without re-opening the connection
+                # (nexus-avwe — CI path-resolution edge cases).
+                _upgrade_done.add(path_key)
 
     def __enter__(self) -> "T2Database":
         return self

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -90,6 +90,73 @@ if TYPE_CHECKING:
 
 _log = structlog.get_logger()
 
+
+# RDR-128 P0a (RF-3): the daemon's startup migration must tolerate another
+# process holding memory.db's single WAL writer lock (typically ``nx index
+# repo``). ``busy_timeout`` governs how long each statement waits for the
+# lock before raising ``database is locked``; the old 5s was tight enough
+# that a concurrent indexer could trip a migration step and crash the
+# freshly-spawned daemon. 30s matches the intra-host contention window
+# already used by aspect_extraction_queue (nexus-v4m7y) and costs nothing
+# on a quiet database.
+_BOOTSTRAP_BUSY_TIMEOUT_MS: int = 30000
+
+# Bounded Python-level retry around ``apply_pending``, layered on top of the
+# busy_timeout. Mirrors aspect_extraction_queue.reclaim_stale: three attempts
+# with two inter-attempt sleeps. ``apply_pending`` is idempotent (per-migration
+# existence guards) and only records the path as done on success, so a retry
+# after a mid-run ``database is locked`` safely re-runs from bootstrap_version.
+# Worst case if every attempt blocks the full busy_timeout: 30 + 0.5 + 30 +
+# 1.0 + 30 = ~91.5s, after which the final attempt re-raises so a genuinely
+# stuck lock still surfaces rather than hanging the daemon forever.
+_BOOTSTRAP_RETRY_SLEEPS_BETWEEN: tuple[float, ...] = (0.5, 1.0)
+
+
+def _apply_pending_with_lock_retry(
+    conn: sqlite3.Connection, current_version: str
+) -> None:
+    """Run ``apply_pending`` with a bounded retry on ``database is locked``.
+
+    Only WAL writer-slot contention is retried; any other
+    ``OperationalError`` (schema corruption, FK violation, ...) propagates
+    on the first attempt. The final attempt re-raises so the failure is
+    never silently swallowed.
+    """
+    import time
+
+    from nexus.db.migrations import apply_pending
+
+    sleeps_between = _BOOTSTRAP_RETRY_SLEEPS_BETWEEN
+    max_attempts = len(sleeps_between) + 1
+    for attempt in range(1, max_attempts + 1):
+        try:
+            apply_pending(conn, current_version)
+            if attempt > 1:
+                _log.info(
+                    "t2_bootstrap_migration_recovered",
+                    attempt=attempt,
+                )
+            return
+        except sqlite3.OperationalError as exc:
+            if "locked" not in str(exc).lower():
+                raise
+            # Clear any partial transaction left by the failed step so the
+            # retry re-runs from a clean connection state.
+            try:
+                conn.rollback()
+            except sqlite3.Error:
+                pass
+            if attempt == max_attempts:
+                raise
+            sleep_seconds = sleeps_between[attempt - 1]
+            _log.warning(
+                "t2_bootstrap_migration_lock_retry",
+                attempt=attempt,
+                next_sleep_seconds=sleep_seconds,
+                exc=str(exc),
+            )
+            time.sleep(sleep_seconds)
+
 # Re-export surface for backward compatibility. Resolution happens
 # lazily through the module-level ``__getattr__`` below; the eager
 # imports were pulling sklearn/scipy/numpy through CatalogTaxonomy on
@@ -328,7 +395,7 @@ class T2Database:
         short-circuit via the ``_upgrade_done`` set in
         :mod:`nexus.db.migrations`.
         """
-        from nexus.db.migrations import _upgrade_done, _upgrade_lock, apply_pending
+        from nexus.db.migrations import _upgrade_done, _upgrade_lock
 
         path.parent.mkdir(parents=True, exist_ok=True)
         try:
@@ -356,9 +423,13 @@ class T2Database:
 
             conn = sqlite3.connect(str(path), check_same_thread=False)
             try:
-                conn.execute("PRAGMA busy_timeout=5000")
+                # RDR-128 P0a (RF-3): tolerate a concurrent writer (e.g.
+                # `nx index repo`) holding the WAL writer lock — wait it out
+                # via a 30s busy_timeout plus a bounded retry, rather than
+                # crashing the daemon on `database is locked`.
+                conn.execute(f"PRAGMA busy_timeout={_BOOTSTRAP_BUSY_TIMEOUT_MS}")
                 conn.execute("PRAGMA journal_mode=WAL")
-                apply_pending(conn, current_version)
+                _apply_pending_with_lock_retry(conn, current_version)
             finally:
                 conn.close()
             # Mirror the T2Database-form path_key into _upgrade_done so

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -115,12 +115,16 @@ _BOOTSTRAP_RETRY_SLEEPS_BETWEEN: tuple[float, ...] = (0.5, 1.0)
 def _apply_pending_with_lock_retry(
     conn: sqlite3.Connection, current_version: str
 ) -> None:
-    """Run ``apply_pending`` with a bounded retry on ``database is locked``.
+    """Run the startup migration (``PRAGMA journal_mode=WAL`` + ``apply_pending``)
+    with a bounded retry on ``database is locked`` / ``database is busy``.
 
-    Only WAL writer-slot contention is retried; any other
-    ``OperationalError`` (schema corruption, FK violation, ...) propagates
-    on the first attempt. The final attempt re-raises so the failure is
-    never silently swallowed.
+    ``journal_mode=WAL`` is inside the retry because it is itself a write
+    that takes the writer lock when the file is not already in WAL mode —
+    leaving it outside would let a held lock crash the daemon before
+    ``apply_pending`` ever runs (code-review finding, RDR-128 P0a). Only
+    writer-slot contention is retried; any other ``OperationalError``
+    (schema corruption, FK violation, ...) propagates on the first attempt.
+    The final attempt re-raises so the failure is never silently swallowed.
     """
     import time
 
@@ -130,6 +134,7 @@ def _apply_pending_with_lock_retry(
     max_attempts = len(sleeps_between) + 1
     for attempt in range(1, max_attempts + 1):
         try:
+            conn.execute("PRAGMA journal_mode=WAL")
             apply_pending(conn, current_version)
             if attempt > 1:
                 _log.info(
@@ -138,7 +143,8 @@ def _apply_pending_with_lock_retry(
                 )
             return
         except sqlite3.OperationalError as exc:
-            if "locked" not in str(exc).lower():
+            msg = str(exc).lower()
+            if "locked" not in msg and "busy" not in msg:
                 raise
             # Clear any partial transaction left by the failed step so the
             # retry re-runs from a clean connection state.
@@ -427,8 +433,10 @@ class T2Database:
                 # `nx index repo`) holding the WAL writer lock — wait it out
                 # via a 30s busy_timeout plus a bounded retry, rather than
                 # crashing the daemon on `database is locked`.
+                # busy_timeout is a connection-local pragma that never blocks;
+                # journal_mode=WAL + apply_pending run inside the retry helper
+                # since both can take the writer lock (RDR-128 P0a).
                 conn.execute(f"PRAGMA busy_timeout={_BOOTSTRAP_BUSY_TIMEOUT_MS}")
-                conn.execute("PRAGMA journal_mode=WAL")
                 _apply_pending_with_lock_retry(conn, current_version)
             finally:
                 conn.close()

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -401,7 +401,11 @@ class T2Database:
         short-circuit via the ``_upgrade_done`` set in
         :mod:`nexus.db.migrations`.
         """
-        from nexus.db.migrations import _upgrade_done, _upgrade_lock
+        from nexus.db.migrations import (
+            _upgrade_done,
+            _upgrade_lock,
+            t2_migration_flock,
+        )
 
         path.parent.mkdir(parents=True, exist_ok=True)
         try:
@@ -437,7 +441,11 @@ class T2Database:
                 # journal_mode=WAL + apply_pending run inside the retry helper
                 # since both can take the writer lock (RDR-128 P0a).
                 conn.execute(f"PRAGMA busy_timeout={_BOOTSTRAP_BUSY_TIMEOUT_MS}")
-                _apply_pending_with_lock_retry(conn, current_version)
+                # RDR-128 P2: take the cross-process migration flock so the
+                # daemon's startup migration serializes against `nx upgrade`
+                # (and vice-versa) instead of racing on the WAL writer lock.
+                with t2_migration_flock(path.parent):
+                    _apply_pending_with_lock_retry(conn, current_version)
             finally:
                 conn.close()
             # Mirror the T2Database-form path_key into _upgrade_done so

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -2103,24 +2103,29 @@ class CatalogTaxonomy:
         distance = float(results["distances"][0][0])
         return AssignResult(topic_id=topic_id, similarity=1.0 - distance)
 
-    def assign_batch(
-        self,
+    @staticmethod
+    def compute_assignments(
         collection_name: str,
         doc_ids: list[str],
         embeddings: list[list[float]],
         chroma_client: Any,
         *,
         cross_collection: bool = False,
-    ) -> int:
-        """Assign multiple docs to their nearest topics via centroid ANN.
+    ) -> list[dict[str, Any]]:
+        """Compute nearest-topic assignments via centroid ANN — the
+        chroma-coupled COMPUTE half of :meth:`assign_batch`.
 
-        When *cross_collection* is False (default), queries only centroids
-        for *collection_name*.  When True, queries only FOREIGN centroids
-        (``$ne collection_name``) — used for cross-collection projection
-        (RDR-075 SC-6).
+        RDR-128 P1 (nexus-fkq5q): split out so the indexer can compute
+        assignments *client-side* (where the ChromaDB client lives) and
+        route only the serializable RESULT to the daemon for persistence —
+        the chroma client cannot cross the JSON-RPC boundary, which is why
+        ``assign_batch`` itself was never daemon-routable.
 
-        Returns the number of docs successfully assigned.  No-op (returns 0)
-        when centroids don't exist or dimensions mismatch.
+        Returns a list of serializable assignment dicts (the kwargs for
+        :meth:`persist_assignments` / :meth:`assign_topic`). Empty list on
+        any no-op condition (no centroids, dimension mismatch, query
+        failure) — identical short-circuit conditions to the old
+        ``assign_batch`` returning 0.
         """
         try:
             centroid_coll = chroma_client.get_collection(
@@ -2128,17 +2133,17 @@ class CatalogTaxonomy:
                 embedding_function=None,
             )
         except Exception:
-            return 0
+            return []
 
         if centroid_coll.count() == 0:
-            return 0
+            return []
 
         # Dimension check once for the batch (all embeddings share dimension)
         if embeddings:
             first_emb = embeddings[0]
             sample = np.array(first_emb) if not isinstance(first_emb, np.ndarray) else first_emb
             if not _check_centroid_dimension(sample, centroid_coll):
-                return 0
+                return []
 
         base_kwargs: dict[str, Any] = {"n_results": 1}
         if cross_collection:
@@ -2157,30 +2162,87 @@ class CatalogTaxonomy:
                 **base_kwargs,
             )
         except Exception:
-            return 0
+            return []
 
         by = "projection" if cross_collection else "centroid"
         # RDR-077 C-1: capture per-row distance → similarity; source_collection
         # is the caller's *collection_name* (that's where the doc lives).
-        assigned = 0
+        out: list[dict[str, Any]] = []
         for i, doc_id in enumerate(doc_ids):
             if not results["ids"][i]:
                 continue
             topic_id = int(results["metadatas"][i][0]["topic_id"])
             if by == "projection":
                 distance = float(results["distances"][i][0])
-                self.assign_topic(
-                    doc_id,
-                    topic_id,
-                    assigned_by=by,
-                    similarity=1.0 - distance,
-                    source_collection=collection_name,
-                )
+                out.append({
+                    "doc_id": doc_id,
+                    "topic_id": topic_id,
+                    "assigned_by": by,
+                    "similarity": 1.0 - distance,
+                    "source_collection": collection_name,
+                })
             else:
-                self.assign_topic(doc_id, topic_id, assigned_by=by)
-            assigned += 1
+                out.append({
+                    "doc_id": doc_id,
+                    "topic_id": topic_id,
+                    "assigned_by": by,
+                    "similarity": None,
+                    "source_collection": None,
+                })
+        return out
 
-        return assigned
+    def persist_assignments(self, assignments: list[dict[str, Any]]) -> int:
+        """Persist pre-computed topic assignments — the serializable PERSIST
+        half of :meth:`assign_batch`, daemon-routable (RDR-128 P1, fkq5q).
+
+        ``assignments`` is a list of dicts as produced by
+        :meth:`compute_assignments`. Returns the number persisted. Each is
+        written via :meth:`assign_topic`, preserving its projection-UPSERT /
+        centroid-INSERT-OR-IGNORE semantics and doc_count resync.
+        """
+        for a in assignments:
+            self.assign_topic(
+                a["doc_id"],
+                int(a["topic_id"]),
+                assigned_by=a.get("assigned_by", "centroid"),
+                similarity=a.get("similarity"),
+                source_collection=a.get("source_collection"),
+            )
+        return len(assignments)
+
+    def assign_batch(
+        self,
+        collection_name: str,
+        doc_ids: list[str],
+        embeddings: list[list[float]],
+        chroma_client: Any,
+        *,
+        cross_collection: bool = False,
+    ) -> int:
+        """Assign multiple docs to their nearest topics via centroid ANN.
+
+        When *cross_collection* is False (default), queries only centroids
+        for *collection_name*.  When True, queries only FOREIGN centroids
+        (``$ne collection_name``) — used for cross-collection projection
+        (RDR-075 SC-6).
+
+        Returns the number of docs successfully assigned.  No-op (returns 0)
+        when centroids don't exist or dimensions mismatch.
+
+        Composes :meth:`compute_assignments` (chroma) + :meth:`persist_assignments`
+        (T2). Direct callers keep the one-shot behaviour; the indexer hook
+        splits the two halves to route persistence through the daemon
+        (RDR-128 P1, nexus-fkq5q).
+        """
+        return self.persist_assignments(
+            self.compute_assignments(
+                collection_name,
+                doc_ids,
+                embeddings,
+                chroma_client,
+                cross_collection=cross_collection,
+            )
+        )
 
     # ── Cross-collection projection (RDR-075 Phase 2) ──────────────
 

--- a/src/nexus/db/t2/chash_index.py
+++ b/src/nexus/db/t2/chash_index.py
@@ -164,6 +164,41 @@ class ChashIndex:
             )
             self.conn.commit()
 
+    def upsert_many(self, *, chashes: list[str], collection: str) -> None:
+        """Register many ``chashes`` in one ``collection`` in a single
+        statement + commit.
+
+        RDR-128 P1 (kg8sj): the indexer's per-chunk dual-write previously
+        looped :meth:`upsert` (one statement+commit per chunk). Batching
+        collapses a chunk-batch to one ``executemany`` — and, crucially,
+        to one daemon RPC when routed through ``T2Client``, instead of one
+        round-trip per chunk.
+
+        ``INSERT OR REPLACE`` semantics per :meth:`upsert`. Blank/whitespace
+        ``chashes`` entries are skipped (the dual-write helper already
+        filters, but the batch API is defensive). Raises ``ValueError`` on
+        an empty ``collection`` (a caller-side bug); an empty ``chashes``
+        list is a silent no-op.
+        """
+        if not collection:
+            raise ValueError("collection must not be empty")
+        now = datetime.now(UTC).isoformat()
+        rows = [
+            (c, collection, now)
+            for c in chashes
+            if isinstance(c, str) and c.strip()
+        ]
+        if not rows:
+            return
+        with self._lock:
+            self.conn.executemany(
+                "INSERT OR REPLACE INTO chash_index "
+                "(chash, physical_collection, created_at) "
+                "VALUES (?, ?, ?)",
+                rows,
+            )
+            self.conn.commit()
+
     def lookup(self, chash: str) -> list[dict[str, Any]]:
         """Return all (collection, created_at) rows for ``chash``.
 
@@ -370,16 +405,23 @@ def dual_write_chash_index(
     """
     if chash_index is None or not ids or not metadatas:
         return
-    for meta in metadatas:
-        chash = meta.get("chunk_text_hash", "") if isinstance(meta, dict) else ""
-        if not chash:
-            continue
-        try:
-            chash_index.upsert(chash=chash, collection=collection)
-        except Exception as exc:
-            _log.warning(
-                "chash_index_dual_write_failed",
-                collection=collection,
-                chash_prefix=chash[:16],
-                error=str(exc),
-            )
+    chashes = [
+        meta.get("chunk_text_hash", "")
+        for meta in metadatas
+        if isinstance(meta, dict)
+    ]
+    chashes = [c for c in chashes if c]
+    if not chashes:
+        return
+    # RDR-128 P1 (kg8sj): one batch call (one daemon RPC when routed via
+    # T2Client) instead of a per-chunk upsert loop. Still best-effort — a
+    # T2 failure logs but never aborts the successful T3 write.
+    try:
+        chash_index.upsert_many(chashes=chashes, collection=collection)
+    except Exception as exc:
+        _log.warning(
+            "chash_index_dual_write_failed",
+            collection=collection,
+            count=len(chashes),
+            error=str(exc),
+        )

--- a/src/nexus/db/t2/chash_index.py
+++ b/src/nexus/db/t2/chash_index.py
@@ -179,6 +179,13 @@ class ChashIndex:
         filters, but the batch API is defensive). Raises ``ValueError`` on
         an empty ``collection`` (a caller-side bug); an empty ``chashes``
         list is a silent no-op.
+
+        All-or-nothing: the batch is one ``executemany`` + ``commit``, so a
+        failure rolls back the whole batch (unlike the prior per-row loop,
+        where one bad row was logged and the rest continued). Callers that
+        need best-effort partial progress should pre-validate the batch;
+        ``dual_write_chash_index`` accepts this since it is best-effort and
+        wrapped at the hook level.
         """
         if not collection:
             raise ValueError("collection must not be empty")

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import structlog
 
-from nexus.db.t2 import T2Database
 from nexus.session import (
     generate_session_id,
     write_claude_session_id,
@@ -23,13 +22,13 @@ _log = structlog.get_logger()
 # -- Helpers ------------------------------------------------------------------
 
 def _default_db_path() -> Path:
+    # RDR-128 P3: no longer opens T2 directly (session_end_flush routes its
+    # writes through the daemon via mcp_infra.t2_index_write). Retained as
+    # the config-dir-isolation canary asserted by
+    # test_config_dir_isolation.TestT2IsolatedUnderOverride.
     from nexus.config import nexus_config_dir
 
     return nexus_config_dir() / "memory.db"
-
-
-def _open_t2() -> T2Database:
-    return T2Database(_default_db_path())
 
 
 def _open_t1():
@@ -112,29 +111,44 @@ def session_end_flush() -> str:
     expired = 0
 
     try:
-        with _open_t2() as db:
-            try:
-                t1 = _open_t1()
-            except Exception as exc:
-                _log.warning(
-                    "session_end_flush_t1_unavailable",
-                    error=str(exc),
-                    message="flagged scratch entries were not flushed",
-                )
-                t1 = None
-            if t1 is not None:
-                for entry in t1.flagged_entries():
-                    db.put(
-                        project=entry["flush_project"],
-                        title=entry["flush_title"],
-                        content=entry["content"],
-                        tags=entry.get("tags", ""),
-                        ttl=None,
-                    )
-                    flushed += 1
-                t1.clear()
+        try:
+            t1 = _open_t1()
+        except Exception as exc:
+            _log.warning(
+                "session_end_flush_t1_unavailable",
+                error=str(exc),
+                message="flagged scratch entries were not flushed",
+            )
+            t1 = None
+        # T1 access is process-local; snapshot the flagged entries here so
+        # only the T2 writes cross the daemon boundary below.
+        entries = list(t1.flagged_entries()) if t1 is not None else []
 
-            expired = db.expire()
+        def _flush_and_expire(db):
+            n = 0
+            for entry in entries:
+                db.memory.put(
+                    project=entry["flush_project"],
+                    title=entry["flush_title"],
+                    content=entry["content"],
+                    tags=entry.get("tags", ""),
+                    ttl=None,
+                )
+                n += 1
+            # Flushed entries are permanent (ttl=None); the expire sweep
+            # below only reaps already-expired rows, so flush-then-expire
+            # ordering is safe.
+            return n, db.expire()
+
+        # RDR-128 P3 (nexus-sbxbe.3): route the flush + TTL sweep through the
+        # T2 daemon so the detached SessionEnd grandchild does not open
+        # memory.db directly and contend on its single WAL writer lock.
+        # t2_index_write falls back to a direct T2Database when the daemon
+        # is unreachable (the grandchild can outlive the MCP lifespan).
+        from nexus.mcp_infra import t2_index_write
+        flushed, expired = t2_index_write(_flush_and_expire)
+        if t1 is not None:
+            t1.clear()
     except (sqlite3.Error, OSError) as exc:
         _log.warning("session_end: storage error during flush/expire", error=str(exc))
 

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -394,24 +394,33 @@ def taxonomy_assign_batch_hook(
             return
 
     try:
-        with t2_ctx() as db:
-            chroma_client = get_t3()._client
-            # Same-collection assignment
-            db.taxonomy.assign_batch(
-                collection, doc_ids, embeddings, chroma_client,
+        # RDR-128 P1 (nexus-fkq5q): compute assignments client-side (the
+        # ChromaDB client can't cross the RPC boundary), then persist the
+        # serializable result through the daemon so the indexer does not
+        # open memory.db directly.
+        from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
+
+        chroma_client = get_t3()._client
+        same = CatalogTaxonomy.compute_assignments(
+            collection, doc_ids, embeddings, chroma_client,
+            cross_collection=False,
+        )
+        cross = CatalogTaxonomy.compute_assignments(
+            collection, doc_ids, embeddings, chroma_client,
+            cross_collection=True,
+        )
+        assignments = same + cross
+        if assignments:
+            t2_index_write(
+                lambda db: db.taxonomy.persist_assignments(assignments)
             )
-            # Cross-collection projection (RDR-075 SC-6)
-            cross_assigned = db.taxonomy.assign_batch(
-                collection, doc_ids, embeddings, chroma_client,
-                cross_collection=True,
+        if cross:
+            import structlog
+            structlog.get_logger().debug(
+                "taxonomy_cross_collection_batch",
+                collection=collection,
+                cross_assigned=len(cross),
             )
-            if cross_assigned:
-                import structlog
-                structlog.get_logger().debug(
-                    "taxonomy_cross_collection_batch",
-                    collection=collection,
-                    cross_assigned=cross_assigned,
-                )
     except Exception:
         import structlog
         structlog.get_logger().debug("taxonomy_assign_batch_failed", exc_info=True)

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -146,6 +146,52 @@ def t2_ctx():
     return T2Database(default_db_path())
 
 
+def t2_index_write(write_fn) -> None:
+    """Run one indexer T2 write through the daemon (``T2Client``) if it is
+    reachable, else a direct ``T2Database`` (RDR-128 P1, nexus-kg8sj).
+
+    Routing keeps the ``nx index repo`` process from opening ``memory.db``
+    directly and holding its single WAL writer slot — the daemon becomes
+    the writer, so a dead/slow indexer can no longer strand the lock for
+    other processes. The direct-``T2Database`` fallback preserves
+    functionality when the daemon is down (at the cost of the old
+    direct-lock behavior), and is logged so the degraded path is visible.
+
+    ``write_fn(db)`` receives the writer (``T2Client`` or ``T2Database``;
+    both expose the same ``db.<store>.<method>(...)`` surface). Reachability
+    is decided by an explicit up-front probe (``database.hello()``) rather
+    than by catching an error *out of* ``write_fn`` — because some writers
+    (e.g. the best-effort ``dual_write_chash_index``) swallow their own
+    exceptions internally, which would otherwise hide the unreachable
+    signal and silently drop the write. ``write_fn`` is therefore invoked
+    against exactly one writer, never re-run, so there is no double-write
+    risk regardless of how it handles errors.
+    """
+    from nexus.daemon.t2_client import T2DaemonNotReachableError, make_t2_client
+
+    client = None
+    try:
+        client = make_t2_client()
+        client.database.hello()  # force the lazy connect; raises if down
+    except T2DaemonNotReachableError:
+        if client is not None:
+            client.close()
+        client = None
+
+    if client is not None:
+        try:
+            write_fn(client)
+        finally:
+            client.close()
+        return
+
+    import structlog
+    structlog.get_logger().debug("t2_index_write_daemon_unreachable_fallback")
+    from nexus.db.t2 import T2Database
+    with T2Database(default_db_path()) as db:
+        write_fn(db)
+
+
 # ── T1 plan session cache (RDR-078) ──────────────────────────────────────────
 # Plan-cache wrappers. The cache state itself lives in
 # nexus.mcp.plan_cache_registry.PlanCacheRegistry as a single module-
@@ -450,8 +496,13 @@ def chash_dual_write_batch_hook(
     try:
         from nexus.db.t2.chash_index import dual_write_chash_index
 
-        with t2_ctx() as db:
-            dual_write_chash_index(db.chash_index, collection, doc_ids, metadatas)
+        # RDR-128 P1 (kg8sj): route through the daemon so the indexer does
+        # not hold memory.db's writer lock; dual_write batches to one RPC.
+        t2_index_write(
+            lambda db: dual_write_chash_index(
+                db.chash_index, collection, doc_ids, metadatas
+            )
+        )
     except Exception:
         import structlog
         structlog.get_logger().debug("chash_dual_write_batch_failed", exc_info=True)

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -141,14 +141,29 @@ def get_collection_names() -> list[str]:
 
 
 def t2_ctx():
-    """Return a T2Database context manager — fresh per call."""
+    """Return a T2Database context manager — fresh per call.
+
+    Reserved for the paths that genuinely cannot route through the daemon
+    (RDR-128 P3): the ``aspect_worker`` persist block, whose
+    ``document_aspects.upsert(record)`` takes an ``AspectRecord`` argument
+    that the daemon wire protocol decodes to a plain dict server-side
+    (``t2_daemon._t2_decode``), so the method would receive a dict and
+    break on attribute access. The hot every-poll path routes via
+    ``t2_index_write``; only the work-bounded persist falls back here.
+    """
     from nexus.db.t2 import T2Database
-    return T2Database(default_db_path())
+    return T2Database(default_db_path())  # epsilon-allow: aspect_worker persist (document_aspects.upsert AspectRecord arg cannot round-trip the daemon RPC); not the every-poll hot path (RDR-128 P3)
 
 
-def t2_index_write(write_fn) -> None:
-    """Run one indexer T2 write through the daemon (``T2Client``) if it is
-    reachable, else a direct ``T2Database`` (RDR-128 P1, nexus-kg8sj).
+def t2_index_write(write_fn):
+    """Run one T2 write through the daemon (``T2Client``) if it is
+    reachable, else a direct ``T2Database`` (RDR-128 P1, nexus-kg8sj;
+    generalized to all routable writers in P3, nexus-sbxbe.3).
+
+    Returns ``write_fn``'s result so callers that need the write's return
+    value (e.g. the aspect_worker's ``claim_batch`` rows, or
+    ``rename_collection_cascade``'s per-store row counts) can route too;
+    fire-and-forget callers simply ignore the return.
 
     Routing keeps the ``nx index repo`` process from opening ``memory.db``
     directly and holding its single WAL writer slot — the daemon becomes
@@ -187,10 +202,9 @@ def t2_index_write(write_fn) -> None:
 
     if client is not None:
         try:
-            write_fn(client)
+            return write_fn(client)
         finally:
             client.close()
-        return
 
     # Degraded path: this is the direct-lock behavior RDR-128 exists to
     # eliminate, so log it at warning (not debug) — a persistently
@@ -201,8 +215,8 @@ def t2_index_write(write_fn) -> None:
         hint="start the T2 daemon (`nx daemon t2 start`) to route indexer writes",
     )
     from nexus.db.t2 import T2Database
-    with T2Database(default_db_path()) as db:
-        write_fn(db)
+    with T2Database(default_db_path()) as db:  # epsilon-allow: by-design daemon-unreachable fallback so writes degrade to direct rather than failing (RDR-128 P3 documented-irreducible)
+        return write_fn(db)
 
 
 # ── T1 plan session cache (RDR-078) ──────────────────────────────────────────

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -167,13 +167,20 @@ def t2_index_write(write_fn) -> None:
     against exactly one writer, never re-run, so there is no double-write
     risk regardless of how it handles errors.
     """
-    from nexus.daemon.t2_client import T2DaemonNotReachableError, make_t2_client
+    from nexus.daemon.t2_client import (
+        T2DaemonNotReachableError,
+        T2SchemaVersionMismatchError,
+        make_t2_client,
+    )
 
     client = None
     try:
         client = make_t2_client()
         client.database.hello()  # force the lazy connect; raises if down
-    except T2DaemonNotReachableError:
+    except (T2DaemonNotReachableError, T2SchemaVersionMismatchError):
+        # Daemon down OR version-skewed (e.g. just after a daemon upgrade,
+        # before the indexer is restarted). Either way it cannot serve this
+        # write; close the half-open client and degrade to a direct write.
         if client is not None:
             client.close()
         client = None
@@ -185,8 +192,14 @@ def t2_index_write(write_fn) -> None:
             client.close()
         return
 
+    # Degraded path: this is the direct-lock behavior RDR-128 exists to
+    # eliminate, so log it at warning (not debug) — a persistently
+    # unreachable daemon during indexing is operator-actionable.
     import structlog
-    structlog.get_logger().debug("t2_index_write_daemon_unreachable_fallback")
+    structlog.get_logger().warning(
+        "t2_index_write_daemon_unreachable_fallback",
+        hint="start the T2 daemon (`nx daemon t2 start`) to route indexer writes",
+    )
     from nexus.db.t2 import T2Database
     with T2Database(default_db_path()) as db:
         write_fn(db)

--- a/src/nexus/merge_candidates.py
+++ b/src/nexus/merge_candidates.py
@@ -145,7 +145,7 @@ def _open_t2():
     db_path = default_db_path()
     if not db_path.exists():
         return None
-    return T2Database(db_path)
+    return T2Database(db_path)  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
 
 
 # ── CLI entry point ─────────────────────────────────────────────────────────

--- a/src/nexus/operators/aspect_sql.py
+++ b/src/nexus/operators/aspect_sql.py
@@ -535,7 +535,7 @@ def _query_filter(
     if ident_to_uri:
         # Batch in 300s to leave plenty of headroom under SQLite's
         # 999-param default cap.
-        with T2Database(default_db_path()) as db:
+        with T2Database(default_db_path()) as db:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
             conn = db.document_aspects.conn
             uri_list = list(ident_to_uri.values())
             for chunk_start in range(0, len(uri_list), 300):
@@ -613,7 +613,7 @@ def _query_groupby(
         ident_to_uri[(c, sp)] = u
         uri_to_ident[u] = (c, sp)
 
-    with T2Database(default_db_path()) as db:
+    with T2Database(default_db_path()) as db:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
         conn = db.document_aspects.conn
         uri_list = list(ident_to_uri.values())
         for chunk_start in range(0, len(uri_list), 300):
@@ -689,7 +689,7 @@ def _query_confidence_aggregate(
         if u:
             uris_for_query.append(u)
 
-    with T2Database(default_db_path()) as db:
+    with T2Database(default_db_path()) as db:  # epsilon-allow: read-only T2 access, no WAL writer contention (RDR-128 P3)
         conn = db.document_aspects.conn
         for chunk_start in range(0, len(uris_for_query), 300):
             batch = uris_for_query[chunk_start:chunk_start + 300]

--- a/src/nexus/storage_boundary_lint.py
+++ b/src/nexus/storage_boundary_lint.py
@@ -111,7 +111,10 @@ class LintResult:
     catalog_allowlist_count: int = 0
     #: RDR-128 P0c population 2: direct ``T2Database(...)`` constructions
     #: outside the construction-allowlist (db/ + daemon/). Baseline metric;
-    #: P1/P3 drive it toward the documented-irreducible set.
+    #: P1/P3 drive it toward the documented-irreducible set. Counts SYNTACTIC
+    #: construction sites: a local wrapper like commands/taxonomy_cmd.py's
+    #: ``_T2Database`` is counted once (at its ``return T2Database(...)`` body),
+    #: not at each of its call sites — the wrapper body is the boundary.
     t2database_constructions: int = 0
     #: RDR-128 P0c population 1: ``sqlite3.connect`` sites outside the
     #: connect-allowlist that carry a valid ``# epsilon-allow:`` override.

--- a/src/nexus/storage_boundary_lint.py
+++ b/src/nexus/storage_boundary_lint.py
@@ -53,11 +53,15 @@ DEFAULT_ALLOWLIST_PREFIXES: tuple[str, ...] = (
 CATALOG_PHASE_ALLOWLIST_PREFIX: str = "src/nexus/catalog/"
 
 
-#: RDR-128 P0c (RF-5): class names whose *direct construction* outside
+#: RDR-128 (RF-5): class names whose *direct construction* outside
 #: daemon-internal code is a single-writer-invariant offender. Each
 #: ``T2Database(...)`` outside the daemon opens eight SQLite connections
-#: that contend on memory.db's one WAL writer lock. Counted (not failed)
-#: as a baseline population so P1/P3 can drive it down measurably.
+#: that contend on memory.db's one WAL writer lock. P0c counted these as
+#: a baseline population; P3 (nexus-sbxbe.3) flipped the lint to ENFORCE —
+#: an un-annotated construction outside the construction-allowlist is now
+#: a hard violation, while one carrying ``# epsilon-allow: <reason>`` is a
+#: documented exception (counted in ``t2database_constructions``). Mirrors
+#: the ``sqlite3.connect`` treatment exactly.
 BANNED_CONSTRUCTORS: tuple[str, ...] = ("T2Database",)
 
 
@@ -109,12 +113,18 @@ class LintResult:
 
     violations: list[Violation] = field(default_factory=list)
     catalog_allowlist_count: int = 0
-    #: RDR-128 P0c population 2: direct ``T2Database(...)`` constructions
-    #: outside the construction-allowlist (db/ + daemon/). Baseline metric;
-    #: P1/P3 drive it toward the documented-irreducible set. Counts SYNTACTIC
-    #: construction sites: a local wrapper like commands/taxonomy_cmd.py's
-    #: ``_T2Database`` is counted once (at its ``return T2Database(...)`` body),
-    #: not at each of its call sites — the wrapper body is the boundary.
+    #: RDR-128 P3 population 2 (DOCUMENTED): direct ``T2Database(...)``
+    #: constructions outside the construction-allowlist (db/ + daemon/)
+    #: that carry a valid ``# epsilon-allow: <reason>`` override. At P0c
+    #: this counted ALL constructions (baseline metric); P3 flipped the
+    #: lint to enforce, so it now counts only the ANNOTATED survivors —
+    #: the documented-irreducible set, each carrying a lock-discipline
+    #: justification. Un-annotated constructions are hard violations
+    #: (see ``violations``), mirroring the ``sqlite3.connect`` treatment.
+    #: Counts SYNTACTIC construction sites: a local wrapper like
+    #: commands/taxonomy_cmd.py's ``_T2Database`` is counted once (at its
+    #: ``return T2Database(...)`` body), not at each call site — the
+    #: wrapper body is the boundary.
     t2database_constructions: int = 0
     #: RDR-128 P0c population 1: ``sqlite3.connect`` sites outside the
     #: connect-allowlist that carry a valid ``# epsilon-allow:`` override.
@@ -140,8 +150,13 @@ class FileScan:
     """Per-file scan result feeding :func:`scan_repo`'s aggregation."""
 
     violations: list[Violation] = field(default_factory=list)
-    #: ``T2Database(...)`` construction sites (symbol == "T2Database").
-    t2database_constructions: list[Violation] = field(default_factory=list)
+    #: RDR-128 P3: ``T2Database(...)`` construction sites carrying a valid
+    #: ``# epsilon-allow: <reason>`` (the documented-irreducible survivors).
+    t2database_constructions_documented: list[Violation] = field(default_factory=list)
+    #: RDR-128 P3: ``T2Database(...)`` construction sites WITHOUT a valid
+    #: override. Promoted to hard violations in :func:`scan_repo` when the
+    #: file is outside the construction-allowlist (db/ + daemon/).
+    t2database_constructions_undocumented: list[Violation] = field(default_factory=list)
     #: Count of epsilon-allow'd ``sqlite3.connect`` sites in this file.
     epsilon_allow_connects: int = 0
 
@@ -266,9 +281,15 @@ def _scan_file_full(
         elif isinstance(func, ast.Attribute) and func.attr in BANNED_CONSTRUCTORS:
             ctor = func.attr
         if ctor is not None:
-            scan.t2database_constructions.append(
-                Violation(file=_rel(), line=line, symbol=ctor)
-            )
+            v = Violation(file=_rel(), line=line, symbol=ctor)
+            # RDR-128 P3: an annotated construction is a documented
+            # exception (counted, not failed); an un-annotated one is a
+            # hard violation once scoped by the construction-allowlist in
+            # scan_repo. Mirrors the sqlite3.connect epsilon-allow split.
+            if _line_has_allowlist_token(source_lines, line):
+                scan.t2database_constructions_documented.append(v)
+            else:
+                scan.t2database_constructions_undocumented.append(v)
 
     return scan
 
@@ -354,9 +375,13 @@ def scan_repo(
             result.epsilon_allow_connects += scan.epsilon_allow_connects
 
         # Population 2 (T2Database constructions): scoped by the separate
-        # construction-allowlist (db/ + daemon/).
+        # construction-allowlist (db/ + daemon/). RDR-128 P3 enforces:
+        # annotated -> documented population; un-annotated -> hard violation.
         if not _is_allowlisted(rel, construction_allowlist_prefixes):
-            result.t2database_constructions += len(scan.t2database_constructions)
+            result.t2database_constructions += len(
+                scan.t2database_constructions_documented
+            )
+            result.violations.extend(scan.t2database_constructions_undocumented)
 
     # Extra files: always scanned, never allowlisted by path prefix.
     if extra_files:
@@ -364,6 +389,9 @@ def scan_repo(
             scan = _scan_file_full(pathlib.Path(extra), repo_root)
             result.violations.extend(scan.violations)
             result.epsilon_allow_connects += scan.epsilon_allow_connects
-            result.t2database_constructions += len(scan.t2database_constructions)
+            result.t2database_constructions += len(
+                scan.t2database_constructions_documented
+            )
+            result.violations.extend(scan.t2database_constructions_undocumented)
 
     return result

--- a/src/nexus/storage_boundary_lint.py
+++ b/src/nexus/storage_boundary_lint.py
@@ -53,6 +53,24 @@ DEFAULT_ALLOWLIST_PREFIXES: tuple[str, ...] = (
 CATALOG_PHASE_ALLOWLIST_PREFIX: str = "src/nexus/catalog/"
 
 
+#: RDR-128 P0c (RF-5): class names whose *direct construction* outside
+#: daemon-internal code is a single-writer-invariant offender. Each
+#: ``T2Database(...)`` outside the daemon opens eight SQLite connections
+#: that contend on memory.db's one WAL writer lock. Counted (not failed)
+#: as a baseline population so P1/P3 can drive it down measurably.
+BANNED_CONSTRUCTORS: tuple[str, ...] = ("T2Database",)
+
+
+#: Prefixes allowed to construct ``T2Database`` directly: the substrate
+#: that defines it and the daemon that runs it as the single writer.
+#: Distinct from the connect-allowlist (which includes ``catalog/`` P0-P4
+#: but not ``daemon/``).
+T2DATABASE_CONSTRUCTION_ALLOWLIST_PREFIXES: tuple[str, ...] = (
+    "src/nexus/db/",
+    "src/nexus/daemon/",
+)
+
+
 #: Banned call sites. Each entry is ``(module, attribute)`` matched
 #: against AST ``Attribute(value=Name(id=module), attr=attribute)``
 #: nodes inside ``Call`` nodes. Alias resolution maps the alias back
@@ -91,6 +109,14 @@ class LintResult:
 
     violations: list[Violation] = field(default_factory=list)
     catalog_allowlist_count: int = 0
+    #: RDR-128 P0c population 2: direct ``T2Database(...)`` constructions
+    #: outside the construction-allowlist (db/ + daemon/). Baseline metric;
+    #: P1/P3 drive it toward the documented-irreducible set.
+    t2database_constructions: int = 0
+    #: RDR-128 P0c population 1: ``sqlite3.connect`` sites outside the
+    #: connect-allowlist that carry a valid ``# epsilon-allow:`` override.
+    #: The deliberate raw-connect exceptions to the substrate boundary.
+    epsilon_allow_connects: int = 0
 
     @property
     def total_violations(self) -> int:
@@ -101,7 +127,20 @@ class LintResult:
         return {
             "violations": self.total_violations,
             "catalog_allowlist_count": self.catalog_allowlist_count,
+            "t2database_constructions": self.t2database_constructions,
+            "epsilon_allow_connects": self.epsilon_allow_connects,
         }
+
+
+@dataclass
+class FileScan:
+    """Per-file scan result feeding :func:`scan_repo`'s aggregation."""
+
+    violations: list[Violation] = field(default_factory=list)
+    #: ``T2Database(...)`` construction sites (symbol == "T2Database").
+    t2database_constructions: list[Violation] = field(default_factory=list)
+    #: Count of epsilon-allow'd ``sqlite3.connect`` sites in this file.
+    epsilon_allow_connects: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -128,6 +167,23 @@ def _collect_module_aliases(tree: ast.AST) -> dict[str, str]:
     return aliases
 
 
+def _collect_constructor_aliases(tree: ast.AST) -> dict[str, str]:
+    """Return ``{bound_name: canonical_class}`` for ``from`` imports of a
+    banned constructor.
+
+    ``from nexus.db.t2 import T2Database`` -> ``{"T2Database": "T2Database"}``.
+    ``from nexus.db.t2 import T2Database as DB`` -> ``{"DB": "T2Database"}``.
+    """
+    aliases: dict[str, str] = {}
+    banned = set(BANNED_CONSTRUCTORS)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name in banned:
+                    aliases[alias.asname or alias.name] = alias.name
+    return aliases
+
+
 def _line_has_allowlist_token(source_lines: list[str], line_no: int) -> bool:
     """Return True iff the (1-indexed) line carries an epsilon-allow tag."""
     if line_no < 1 or line_no > len(source_lines):
@@ -142,52 +198,89 @@ def _line_has_allowlist_token(source_lines: list[str], line_no: int) -> bool:
     return len(reason) >= ALLOWLIST_REASON_MIN_LENGTH
 
 
-def scan_file(
+def _scan_file_full(
     path: pathlib.Path,
     repo_root: pathlib.Path,
-) -> list[Violation]:
-    """Scan a single Python file for banned call sites."""
+) -> FileScan:
+    """Single-pass AST scan returning hard violations plus the two
+    RDR-128 P0c baseline populations (epsilon-allow'd ``sqlite3.connect``
+    sites and direct ``T2Database(...)`` constructions)."""
+    scan = FileScan()
     try:
         source = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
-        return []
+        return scan
     try:
         tree = ast.parse(source)
     except SyntaxError:
-        return []
+        return scan
 
     source_lines = source.splitlines()
     aliases = _collect_module_aliases(tree)
+    constructor_aliases = _collect_constructor_aliases(tree)
 
-    violations: list[Violation] = []
     banlist_map = {module: {attr for _, attr in BANLIST if _ == module}
                    for module, _ in BANLIST}
+
+    def _rel() -> str:
+        try:
+            return path.relative_to(repo_root).as_posix()
+        except ValueError:
+            return str(path)
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         func = node.func
-        if not isinstance(func, ast.Attribute):
-            continue
-        if not isinstance(func.value, ast.Name):
-            continue
-        alias_name = func.value.id
-        canonical = aliases.get(alias_name)
-        if canonical is None:
-            continue
-        if func.attr not in banlist_map.get(canonical, set()):
-            continue
         line = node.lineno
-        if _line_has_allowlist_token(source_lines, line):
-            continue
-        try:
-            rel = path.relative_to(repo_root).as_posix()
-        except ValueError:
-            rel = str(path)
-        violations.append(
-            Violation(file=rel, line=line, symbol=f"{canonical}.{func.attr}")
-        )
-    return violations
+
+        # ── Banned module.attr calls: sqlite3.connect, chromadb.* ──
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+            canonical = aliases.get(func.value.id)
+            if canonical is not None and func.attr in banlist_map.get(
+                canonical, set()
+            ):
+                if _line_has_allowlist_token(source_lines, line):
+                    # Deliberate, documented exception. Count raw-connect
+                    # overrides as the population-1 baseline instead of
+                    # silently skipping them.
+                    if (canonical, func.attr) == ("sqlite3", "connect"):
+                        scan.epsilon_allow_connects += 1
+                else:
+                    scan.violations.append(
+                        Violation(
+                            file=_rel(),
+                            line=line,
+                            symbol=f"{canonical}.{func.attr}",
+                        )
+                    )
+                continue
+
+        # ── Banned constructor calls: T2Database(...) ──
+        ctor: str | None = None
+        if isinstance(func, ast.Name):
+            ctor = constructor_aliases.get(func.id)
+        elif isinstance(func, ast.Attribute) and func.attr in BANNED_CONSTRUCTORS:
+            ctor = func.attr
+        if ctor is not None:
+            scan.t2database_constructions.append(
+                Violation(file=_rel(), line=line, symbol=ctor)
+            )
+
+    return scan
+
+
+def scan_file(
+    path: pathlib.Path,
+    repo_root: pathlib.Path,
+) -> list[Violation]:
+    """Scan a single Python file for banned call sites (hard violations).
+
+    Backward-compatible thin wrapper over :func:`_scan_file_full`; callers
+    that need the RDR-128 baseline populations use :func:`_scan_file_full`
+    (or read them off the aggregated :class:`LintResult`).
+    """
+    return _scan_file_full(path, repo_root).violations
 
 
 # ---------------------------------------------------------------------------
@@ -210,15 +303,23 @@ def scan_repo(
     repo_root: pathlib.Path,
     allowlist_prefixes: Iterable[str] | None = None,
     extra_files: Iterable[pathlib.Path] | None = None,
+    construction_allowlist_prefixes: Iterable[str] | None = None,
 ) -> LintResult:
-    """Scan the repo for banned call sites.
+    """Scan the repo for banned call sites and the RDR-128 baseline
+    populations.
 
     ``allowlist_prefixes`` defaults to :data:`DEFAULT_ALLOWLIST_PREFIXES`
-    plus the catalog phase-allowlist. Pass an empty tuple to disable
-    path-prefix allowlisting (useful for tests).
+    plus the catalog phase-allowlist; it scopes the hard ``sqlite3.connect``
+    / ``chromadb.*`` violations and the epsilon-allow'd-connect count. Pass
+    an empty tuple to disable path-prefix allowlisting (useful for tests).
+
+    ``construction_allowlist_prefixes`` defaults to
+    :data:`T2DATABASE_CONSTRUCTION_ALLOWLIST_PREFIXES` and scopes the
+    ``T2Database(...)`` construction count (db/ defines it, daemon/ runs it).
 
     ``extra_files`` is a list of additional files (typically test
-    fixtures outside the repo) to scan and report against.
+    fixtures outside the repo) to scan and report against; they are never
+    allowlisted by path prefix.
     """
     repo_root = repo_root.resolve()
     if allowlist_prefixes is None:
@@ -228,24 +329,38 @@ def scan_repo(
         )
     else:
         allowlist_prefixes = tuple(allowlist_prefixes)
+    if construction_allowlist_prefixes is None:
+        construction_allowlist_prefixes = T2DATABASE_CONSTRUCTION_ALLOWLIST_PREFIXES
+    else:
+        construction_allowlist_prefixes = tuple(construction_allowlist_prefixes)
 
     result = LintResult()
 
-    # In-tree scan with allowlist filter.
+    # In-tree scan with allowlist filters.
     for py in _iter_py_files(repo_root):
         rel = py.relative_to(repo_root).as_posix()
-        file_violations = scan_file(py, repo_root)
-        if _is_allowlisted(rel, allowlist_prefixes):
-            # Count catalog-prefix hits for the phase-boundary metric.
-            if rel.startswith(CATALOG_PHASE_ALLOWLIST_PREFIX):
-                result.catalog_allowlist_count += len(file_violations)
-            continue
-        result.violations.extend(file_violations)
+        scan = _scan_file_full(py, repo_root)
 
-    # Extra files (e.g. synthetic test offenders living outside the
-    # repo): always scanned, never allowlisted by path prefix.
+        # Population 0 (hard violations) + population 1 (epsilon connects):
+        # scoped by the connect-allowlist.
+        if _is_allowlisted(rel, allowlist_prefixes):
+            if rel.startswith(CATALOG_PHASE_ALLOWLIST_PREFIX):
+                result.catalog_allowlist_count += len(scan.violations)
+        else:
+            result.violations.extend(scan.violations)
+            result.epsilon_allow_connects += scan.epsilon_allow_connects
+
+        # Population 2 (T2Database constructions): scoped by the separate
+        # construction-allowlist (db/ + daemon/).
+        if not _is_allowlisted(rel, construction_allowlist_prefixes):
+            result.t2database_constructions += len(scan.t2database_constructions)
+
+    # Extra files: always scanned, never allowlisted by path prefix.
     if extra_files:
         for extra in extra_files:
-            result.violations.extend(scan_file(pathlib.Path(extra), repo_root))
+            scan = _scan_file_full(pathlib.Path(extra), repo_root)
+            result.violations.extend(scan.violations)
+            result.epsilon_allow_connects += scan.epsilon_allow_connects
+            result.t2database_constructions += len(scan.t2database_constructions)
 
     return result

--- a/tests/cc-validation/scenarios/12_real_nx_subagent.sh
+++ b/tests/cc-validation/scenarios/12_real_nx_subagent.sh
@@ -15,7 +15,7 @@ cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" <<EOF
   "version": 2,
   "plugins": {
     "conexus@nexus-plugins": [
-      { "scope": "user", "installPath": "$REPO_ROOT/nx", "version": "dev",
+      { "scope": "user", "installPath": "$REPO_ROOT/conexus", "version": "dev",
         "installedAt": "$NOW", "lastUpdated": "$NOW" }
     ]
   }

--- a/tests/daemon/test_t2_ensure_running.py
+++ b/tests/daemon/test_t2_ensure_running.py
@@ -275,3 +275,196 @@ class TestEnsureRunning:
         # know which platform the operator is on, so it names both).
         assert "nexus-t2.err" in result.output
         assert "journalctl --user -u nexus-t2.service" in result.output
+
+
+# ---------------------------------------------------------------------------
+# RDR-128 P0b (RF-4): pre-cycle DB-acquirability interlock
+# ---------------------------------------------------------------------------
+
+
+def _seed_wal_db(path) -> None:
+    """Create a WAL-mode memory.db so a competing writer lock is meaningful."""
+    import sqlite3
+
+    c = sqlite3.connect(str(path))
+    c.execute("PRAGMA journal_mode=WAL")
+    c.execute("CREATE TABLE _t (x INTEGER)")
+    c.commit()
+    c.close()
+
+
+class TestDbProbe:
+    """The bounded ``_t2_db_write_lock_acquirable`` probe."""
+
+    def test_missing_file_is_acquirable(self, tmp_path) -> None:
+        from nexus.commands.daemon import _t2_db_write_lock_acquirable
+
+        assert _t2_db_write_lock_acquirable(
+            tmp_path / "absent.db", timeout_ms=200
+        ) is True
+
+    def test_free_lock_is_acquirable(self, tmp_path) -> None:
+        from nexus.commands.daemon import _t2_db_write_lock_acquirable
+
+        db = tmp_path / "memory.db"
+        _seed_wal_db(db)
+        assert _t2_db_write_lock_acquirable(db, timeout_ms=200) is True
+
+    def test_held_writer_lock_is_not_acquirable_and_is_bounded(
+        self, tmp_path,
+    ) -> None:
+        """A competing ``BEGIN IMMEDIATE`` makes the probe return False
+        within ~timeout_ms — it waits the bounded window, never forever."""
+        import sqlite3
+        import threading
+        import time
+
+        from nexus.commands.daemon import _t2_db_write_lock_acquirable
+
+        db = tmp_path / "memory.db"
+        _seed_wal_db(db)
+
+        locked = threading.Event()
+        release = threading.Event()
+
+        def _holder() -> None:
+            h = sqlite3.connect(str(db))
+            h.execute("PRAGMA busy_timeout=10000")
+            h.execute("BEGIN IMMEDIATE")
+            h.execute("INSERT INTO _t VALUES (1)")
+            locked.set()
+            release.wait(timeout=15)
+            h.rollback()
+            h.close()
+
+        holder = threading.Thread(target=_holder)
+        holder.start()
+        assert locked.wait(timeout=5), "holder failed to take the writer lock"
+
+        start = time.monotonic()
+        acquirable = _t2_db_write_lock_acquirable(db, timeout_ms=200)
+        elapsed = time.monotonic() - start
+
+        release.set()
+        holder.join()
+
+        assert acquirable is False
+        assert elapsed < 5.0, "probe must be bounded by busy_timeout, not hang"
+
+
+class TestCycleInterlock:
+    """ensure-running must defer the version-cycle when memory.db is locked,
+    and proceed when it is free."""
+
+    def test_stale_daemon_not_cycled_when_db_lock_held(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        import signal as _signal
+        import sqlite3
+        import threading
+
+        import nexus.commands.daemon as _daemon
+
+        _write_discovery(tmp_path, pid=424242, version="0.0.1-stale")
+        monkeypatch.setattr(
+            "importlib.metadata.version", lambda _name: "9.9.9-installed"
+        )
+
+        # Real, locked memory.db at the config dir.
+        db = tmp_path / "memory.db"
+        _seed_wal_db(db)
+        locked = threading.Event()
+        release = threading.Event()
+
+        def _holder() -> None:
+            h = sqlite3.connect(str(db))
+            h.execute("PRAGMA busy_timeout=15000")
+            h.execute("BEGIN IMMEDIATE")
+            h.execute("INSERT INTO _t VALUES (1)")
+            locked.set()
+            release.wait(timeout=20)
+            h.rollback()
+            h.close()
+
+        holder = threading.Thread(target=_holder)
+        holder.start()
+        assert locked.wait(timeout=5)
+
+        # Fast probe so the deferral path returns quickly.
+        monkeypatch.setattr(_daemon, "_T2_CYCLE_DB_PROBE_TIMEOUT_MS", 200)
+
+        signals: list[tuple[int, int]] = []
+
+        def _fake_kill(pid, sig):  # noqa: ANN001
+            if sig == 0:
+                if pid == 424242:
+                    return  # alive
+                raise ProcessLookupError
+            signals.append((pid, sig))
+
+        monkeypatch.setattr(os, "kill", _fake_kill)
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda *a, **kw: pytest.fail("must not respawn when cycle deferred"),
+        )
+
+        result = CliRunner().invoke(
+            main,
+            ["daemon", "t2", "ensure-running",
+             "--config-dir", str(tmp_path), "--timeout", "0.2"],
+        )
+
+        release.set()
+        holder.join()
+
+        # The healthy-but-stale daemon was LEFT UP (never SIGTERM'd).
+        assert not any(sig == _signal.SIGTERM for _, sig in signals), (
+            "stale daemon must NOT be cycled while memory.db is locked"
+        )
+        assert "cycle deferred" in result.output.lower()
+        assert result.exit_code == 0
+
+    def test_stale_daemon_cycled_when_db_lock_free(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """Mirror of the deferral test: an existing but UNLOCKED memory.db
+        lets the probe pass, so the stale daemon is cycled as before."""
+        import signal as _signal
+
+        _write_discovery(tmp_path, pid=424242, version="0.0.1-stale")
+        monkeypatch.setattr(
+            "importlib.metadata.version", lambda _name: "9.9.9-installed"
+        )
+        _seed_wal_db(tmp_path / "memory.db")  # exists, not locked
+
+        state = {"terminated": False}
+
+        def _fake_kill(pid, sig):  # noqa: ANN001
+            if pid != 424242:
+                raise ProcessLookupError
+            if sig == 0:
+                if state["terminated"]:
+                    raise ProcessLookupError
+                return
+            if sig == _signal.SIGTERM:
+                state["terminated"] = True
+
+        monkeypatch.setattr(os, "kill", _fake_kill)
+
+        spawned: list[list[str]] = []
+
+        class _FakePopen:
+            def __init__(self, argv, **_kw):  # noqa: ANN001
+                spawned.append(argv)
+
+        monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+
+        result = CliRunner().invoke(
+            main,
+            ["daemon", "t2", "ensure-running",
+             "--config-dir", str(tmp_path), "--timeout", "0.2"],
+        )
+
+        assert state["terminated"] is True, "free lock should allow the cycle"
+        assert len(spawned) == 1
+        assert "cycling to current" in result.output.lower()

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -106,7 +106,7 @@ fi
 #   ~/.claude/settings.json                  — enabledPlugins + permissions
 NOW="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
 
-# Build installed_plugins.json — nx only.
+# Build installed_plugins.json (conexus only).
 cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" << PLUGINS_EOF
 {
   "version": 2,
@@ -114,7 +114,7 @@ cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" << PLUGINS_EOF
     "conexus@nexus-plugins": [
       {
         "scope": "user",
-        "installPath": "$REPO_ROOT/nx",
+        "installPath": "$REPO_ROOT/conexus",
         "version": "dev",
         "installedAt": "$NOW",
         "lastUpdated": "$NOW"

--- a/tests/e2e/scenarios/00_debug_load.sh
+++ b/tests/e2e/scenarios/00_debug_load.sh
@@ -23,8 +23,8 @@ plugins_json="$TEST_HOME/.claude/plugins/installed_plugins.json"
 if [[ ! -f "$plugins_json" ]]; then
     fail "Isolated installed_plugins.json not found at $plugins_json"
 else
-    if grep -q "$REPO_ROOT/nx" "$plugins_json"; then
-        pass "isolated installed_plugins.json points to dev repo ($REPO_ROOT/nx)"
+    if grep -q "$REPO_ROOT/conexus" "$plugins_json"; then
+        pass "isolated installed_plugins.json points to dev repo ($REPO_ROOT/conexus)"
     else
         fail "installed_plugins.json does NOT point to dev repo — may be testing v1"
         echo "    content: $(cat "$plugins_json")"
@@ -117,7 +117,7 @@ scenario_end
 scenario "00 debug-load: SubagentStart hook injects RELAY_TEMPLATE"
 
 # Run subagent-start.sh directly with CLAUDE_PLUGIN_ROOT set
-subagent_hook_out=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/nx" \
+subagent_hook_out=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/conexus" \
     HOME="$TEST_HOME" \
     PATH="$TEST_HOME/.local/bin:$PATH" \
     CLAUDE_PROJECT_DIR="$REPO_ROOT" \

--- a/tests/stress/test_t2_daemon_stress.py
+++ b/tests/stress/test_t2_daemon_stress.py
@@ -576,3 +576,107 @@ class TestRepeatedTerminate:
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 12: RDR-128 P3 single-writer routing — no `database is locked`
+# ---------------------------------------------------------------------------
+
+
+class TestRdr128P3SingleWriterRouting:
+    """RDR-128 P3 (nexus-sbxbe.3) quantitative acceptance gate.
+
+    The whole RDR exists because N independent writers contending on
+    ``memory.db``'s single SQLite WAL writer lock produced a string of
+    ``database is locked`` daemon incidents. P3 routes the writers through
+    the daemon (``mcp_infra.t2_index_write``) so the daemon is the single
+    writer and contention cannot surface.
+
+    This scenario drives the three real writer shapes — indexer
+    (``chash_index.upsert_many``), aspect-worker (``aspect_queue.enqueue``),
+    and SessionEnd flush (``memory.put``) — concurrently, EACH through
+    ``t2_index_write``, against ONE daemon, and asserts that NO caller ever
+    sees ``database is locked`` (nor any other error) and that every write
+    lands. This is the deterministic analogue of the qualitative
+    release-cycle shakeout in the RDR's Validation section.
+    """
+
+    def test_mixed_routed_writers_never_surface_database_is_locked(
+        self, config_dir: Path, monkeypatch,
+    ) -> None:
+        # Daemon DB == default_db_path() under this config dir, so the
+        # routed path and the (unused-here) direct fallback agree.
+        db_path = config_dir / "memory.db"
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
+
+        proc = _spawn_daemon_subprocess(config_dir, db_path)
+        try:
+            _wait_for_discovery(config_dir)
+
+            from nexus.mcp_infra import t2_index_write
+
+            errors: list[tuple[str, int, str]] = []
+            n = 20
+
+            def _indexer(i: int) -> None:
+                try:
+                    t2_index_write(
+                        lambda db: db.chash_index.upsert_many(
+                            chashes=[f"h{i}_{j}" for j in range(5)],
+                            collection="code__stress",
+                        )
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(("indexer", i, repr(exc)))
+
+            def _worker(i: int) -> None:
+                try:
+                    t2_index_write(
+                        lambda db: db.aspect_queue.enqueue(
+                            "knowledge__stress", f"/p{i}.pdf",
+                        )
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(("worker", i, repr(exc)))
+
+            def _session(i: int) -> None:
+                try:
+                    t2_index_write(
+                        lambda db: db.memory.put(
+                            project="nexus_stress",
+                            title=f"s{i}",
+                            content="session flush entry",
+                            ttl=None,
+                        )
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(("session", i, repr(exc)))
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=30) as pool:
+                futures = []
+                for i in range(n):
+                    futures.append(pool.submit(_indexer, i))
+                    futures.append(pool.submit(_worker, i))
+                    futures.append(pool.submit(_session, i))
+                for f in futures:
+                    f.result(timeout=90.0)
+
+            locked = [e for e in errors if "database is locked" in e[2].lower()]
+            assert not locked, (
+                f"routing did NOT prevent WAL contention: {locked[:5]}"
+            )
+            # No caller saw ANY error at all (routing serializes cleanly).
+            assert errors == [], f"routed writers surfaced errors: {errors[:5]}"
+
+            # Every write landed via the daemon's single writer.
+            from nexus.db.t2 import T2Database
+
+            with T2Database(db_path) as db:
+                sessions = db.memory.search(
+                    "session flush entry", project="nexus_stress",
+                )
+            assert len(sessions) == n, (
+                f"expected all {n} session writes to land; got {len(sessions)}"
+            )
+        finally:
+            _terminate_daemon(proc)

--- a/tests/test_aspect_drain_protocol.py
+++ b/tests/test_aspect_drain_protocol.py
@@ -295,8 +295,16 @@ class TestWorkerDrainIntegration:
         from nexus.aspect_worker import drain_worker, ensure_worker_started
 
         original_t2_ctx = infra_mod.t2_ctx
+        original_t2_index_write = infra_mod.t2_index_write
         original_extract = extractor_mod.extract_aspects
         infra_mod.t2_ctx = lambda: T2Database(queue_path)
+        # RDR-128 P3: the worker's hot poll (reclaim + claim) now routes
+        # through t2_index_write; point it at the test queue DB so the
+        # restarted worker claims the row enqueued below (no daemon in tests).
+        def _direct_poll(write_fn):  # noqa: ANN001
+            with T2Database(queue_path) as db:
+                return write_fn(db)
+        infra_mod.t2_index_write = _direct_poll
         # Stub extraction: return None (unsupported-collection short-circuit)
         # so the worker calls mark_done without real Claude calls.
         extractor_mod.extract_aspects = lambda **_kw: None
@@ -334,6 +342,7 @@ class TestWorkerDrainIntegration:
             )
         finally:
             infra_mod.t2_ctx = original_t2_ctx
+            infra_mod.t2_index_write = original_t2_index_write
             extractor_mod.extract_aspects = original_extract
 
     def test_worker_not_running_drain_is_just_is_drained(

--- a/tests/test_aspect_worker.py
+++ b/tests/test_aspect_worker.py
@@ -65,8 +65,10 @@ def _isolate_t2(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(infra, "t2_ctx", lambda: T2Database(db_path))
 
     def _direct_index_write(write_fn):  # noqa: ANN001
+        # RDR-128 P3: t2_index_write returns write_fn's result so the
+        # worker's routed poll can consume claim_batch's rows. Mirror that.
         with T2Database(db_path) as db:
-            write_fn(db)
+            return write_fn(db)
 
     monkeypatch.setattr(infra, "t2_index_write", _direct_index_write)
     return db_path
@@ -117,6 +119,35 @@ class TestWorkerDrain:
         assert rec is not None
         assert rec.problem_formulation == "P"
         assert rec.proposed_method == "M"
+
+    def test_queuerow_roundtrips_through_daemon_wire_shape(self) -> None:
+        """RDR-128 P3: routed through the daemon, ``claim_batch`` rows arrive
+        as plain dicts (``t2_daemon._t2_decode`` returns a dataclass's fields
+        as a dict, not a reconstructed object). The worker's poll relies on
+        ``QueueRow(**wire_dict)`` to restore object attribute access. Pin that
+        round-trip so a QueueRow field change can't silently break the routed
+        worker (the direct-fallback path returns objects and would mask it)."""
+        import dataclasses
+
+        from nexus.db.t2.aspect_extraction_queue import QueueRow
+
+        original = QueueRow(
+            collection="knowledge__delos",
+            source_path="/p1.pdf",
+            content_hash="abc123",
+            content="",
+            retry_count=2,
+            doc_id="1.2.3",
+        )
+        # The daemon wire protocol hands the client the dataclass's fields
+        # as a plain dict; reconstruct exactly as the worker poll does.
+        wire_dict = dataclasses.asdict(original)
+        assert not isinstance(wire_dict, QueueRow)
+        restored = QueueRow(**wire_dict)
+        assert restored == original
+        assert restored.collection == "knowledge__delos"
+        assert restored.retry_count == 2
+        assert restored.doc_id == "1.2.3"
 
     def test_worker_unsupported_collection_drops_silently(
         self, _isolate_t2: Path,

--- a/tests/test_aspect_worker.py
+++ b/tests/test_aspect_worker.py
@@ -51,11 +51,24 @@ def _reset_worker():
 
 @pytest.fixture(autouse=True)
 def _isolate_t2(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Point t2_ctx at a tmp_path-scoped DB so worker and test
-    share the same SQLite file."""
+    """Point the indexer's T2 write paths at a tmp_path-scoped DB so worker
+    and test share the same SQLite file.
+
+    RDR-128 P1 (kg8sj): the enqueue hook now routes through
+    ``t2_index_write`` (daemon-or-direct), so isolate that too — here it
+    writes directly to the tmp DB (daemon routing is covered by
+    ``tests/test_rdr128_p1_index_write_routing.py``). ``t2_ctx`` stays
+    patched for the tests that open the queue directly.
+    """
     import nexus.mcp_infra as infra
     db_path = tmp_path / "worker_t2.db"
     monkeypatch.setattr(infra, "t2_ctx", lambda: T2Database(db_path))
+
+    def _direct_index_write(write_fn):  # noqa: ANN001
+        with T2Database(db_path) as db:
+            write_fn(db)
+
+    monkeypatch.setattr(infra, "t2_index_write", _direct_index_write)
     return db_path
 
 

--- a/tests/test_chash_index_store.py
+++ b/tests/test_chash_index_store.py
@@ -138,6 +138,85 @@ class TestChashIndexStoreBasics:
             store.close()
 
 
+# ── Batch upsert (RDR-128 P1 kg8sj) ──────────────────────────────────────────
+
+
+class TestChashIndexUpsertMany:
+    """``upsert_many`` writes a whole batch in one statement+commit so the
+    indexer's dual-write is a single daemon RPC, not one per chunk."""
+
+    def test_batch_inserts_all_rows(self, tmp_path: Path) -> None:
+        from nexus.db.t2.chash_index import ChashIndex
+
+        store = ChashIndex(tmp_path / "t2.db")
+        try:
+            store.upsert_many(
+                chashes=["a1", "b2", "c3"], collection="code__foo"
+            )
+            rows = sorted(store.conn.execute(
+                "SELECT chash, physical_collection FROM chash_index"
+            ).fetchall())
+            assert rows == [
+                ("a1", "code__foo"), ("b2", "code__foo"), ("c3", "code__foo"),
+            ]
+        finally:
+            store.close()
+
+    def test_empty_list_is_noop(self, tmp_path: Path) -> None:
+        from nexus.db.t2.chash_index import ChashIndex
+
+        store = ChashIndex(tmp_path / "t2.db")
+        try:
+            store.upsert_many(chashes=[], collection="code__foo")
+            assert store.conn.execute(
+                "SELECT COUNT(*) FROM chash_index"
+            ).fetchone()[0] == 0
+        finally:
+            store.close()
+
+    def test_blank_chashes_are_skipped(self, tmp_path: Path) -> None:
+        from nexus.db.t2.chash_index import ChashIndex
+
+        store = ChashIndex(tmp_path / "t2.db")
+        try:
+            store.upsert_many(chashes=["a1", "", "  ", "b2"], collection="c")
+            rows = sorted(
+                r[0] for r in store.conn.execute(
+                    "SELECT chash FROM chash_index"
+                ).fetchall()
+            )
+            assert rows == ["a1", "b2"]
+        finally:
+            store.close()
+
+    def test_empty_collection_raises(self, tmp_path: Path) -> None:
+        from nexus.db.t2.chash_index import ChashIndex
+
+        store = ChashIndex(tmp_path / "t2.db")
+        try:
+            with pytest.raises(ValueError, match="collection"):
+                store.upsert_many(chashes=["a1"], collection="")
+        finally:
+            store.close()
+
+    def test_batch_is_insert_or_replace(self, tmp_path: Path) -> None:
+        """Re-upserting an existing chash refreshes rather than erroring."""
+        from nexus.db.t2.chash_index import ChashIndex
+
+        store = ChashIndex(tmp_path / "t2.db")
+        try:
+            store.upsert_many(chashes=["a1", "b2"], collection="c")
+            store.upsert_many(chashes=["a1", "c3"], collection="c")  # a1 repeats
+            rows = sorted(
+                r[0] for r in store.conn.execute(
+                    "SELECT chash FROM chash_index"
+                ).fetchall()
+            )
+            assert rows == ["a1", "b2", "c3"]
+        finally:
+            store.close()
+
+
 # ── Concurrency ──────────────────────────────────────────────────────────────
 
 

--- a/tests/test_collection_rename.py
+++ b/tests/test_collection_rename.py
@@ -698,6 +698,7 @@ class TestAspectCascadeIntegration:
         fake.rename_collection = MagicMock()
 
         with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
              patch("nexus.config.default_db_path", return_value=db_path), \
              patch("nexus.config.catalog_path", return_value=cat_dir):
             counts = rename_collection_data_plane("code__old", "code__new")
@@ -1120,6 +1121,7 @@ class TestK9CascadeIncludesTelemetry:
         fake.rename_collection = MagicMock()
 
         with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
              patch("nexus.config.default_db_path", return_value=db_path), \
              patch("nexus.config.catalog_path", return_value=cat_dir):
             counts = rename_collection_data_plane("code__old", "code__new")
@@ -1176,6 +1178,7 @@ class TestRenameOrdering:
         fake.rename_collection = _t3_rename_bomb
 
         with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
              patch("nexus.config.default_db_path", return_value=db_path), \
              patch("nexus.config.catalog_path", return_value=cat_dir):
             with pytest.raises((RuntimeError, click.ClickException)):

--- a/tests/test_enrich_aspects.py
+++ b/tests/test_enrich_aspects.py
@@ -96,6 +96,18 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     import nexus.commands._helpers as h
     monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
 
+    # RDR-128 P3: the `enrich aspects delete` command now routes through
+    # mcp_infra.t2_index_write, whose direct-fallback opens
+    # T2Database(mcp_infra.default_db_path()). Force that fallback (no
+    # daemon in tests) at the test db_path so the routed write lands here.
+    monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
+
+    def _no_daemon(**_kwargs):
+        from nexus.daemon.t2_client import T2DaemonNotReachableError
+        raise T2DaemonNotReachableError("no daemon in tests")
+
+    monkeypatch.setattr("nexus.daemon.t2_client.make_t2_client", _no_daemon)
+
     return catalog_dir, db_path, cat
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -10,6 +10,16 @@ import pytest
 from nexus.hooks import session_end, session_end_flush, session_start
 
 
+def _no_daemon(**_kwargs):
+    """Force ``t2_index_write``'s direct-fallback path (RDR-128 P3).
+
+    SessionEnd flush routes its T2 writes through the daemon; tests have
+    no daemon, so make the reachability probe fail and let the write land
+    on the autouse-isolated tmp ``memory.db``."""
+    from nexus.daemon.t2_client import T2DaemonNotReachableError
+    raise T2DaemonNotReachableError("no daemon in tests")
+
+
 # ── session_start ────────────────────────────────────────────────────────────
 #
 # RDR-094 Phase F (4.13.0 / nexus-2lm0) deleted the hook-side chroma
@@ -120,13 +130,20 @@ def test_session_start_falls_back_to_generated_uuid(tmp_path, monkeypatch) -> No
 
 
 def test_session_end_db_error_doesnt_crash(tmp_path: Path) -> None:
-    """Storage errors during flush are caught gracefully."""
+    """Storage errors during flush are caught gracefully.
+
+    RDR-128 P3: session_end_flush now routes its writes through
+    ``mcp_infra.t2_index_write``; force a storage error out of that path
+    and assert the hook still returns its summary rather than crashing."""
+    import sqlite3
+
     sessions = tmp_path / "sessions"
     sessions.mkdir()
 
-    with (
-        patch("nexus.hooks._default_db_path", return_value=tmp_path / "nonexistent_dir" / "memory.db"),
-    ):
+    def _boom(_write_fn):
+        raise sqlite3.OperationalError("disk I/O error")
+
+    with patch("nexus.mcp_infra.t2_index_write", _boom):
         output = session_end()
 
     assert "Session ended" in output
@@ -146,9 +163,7 @@ class TestSessionEndFlush:
         sessions.mkdir()
         monkeypatch.delenv("NX_SESSION_ID", raising=False)
 
-        with (
-            patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
-        ):
+        with patch("nexus.daemon.t2_client.make_t2_client", _no_daemon):
             output = session_end_flush()
 
         assert "Flushed 0" in output
@@ -175,9 +190,7 @@ def test_session_end_flush_cli_subcommand(tmp_path, monkeypatch):
     sessions.mkdir()
     monkeypatch.delenv("NX_SESSION_ID", raising=False)
 
-    with (
-        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
-    ):
+    with patch("nexus.daemon.t2_client.make_t2_client", _no_daemon):
         runner = CliRunner()
         result = runner.invoke(hook_group, ["session-end-flush"])
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -107,13 +107,19 @@ def test_session_start_outputs_session_id(
 
 
 def test_session_end_runs_expire(runner: CliRunner, fake_home: Path) -> None:
-    """SessionEnd runs T2 expire."""
+    """SessionEnd routes its T2 flush + expire through the daemon
+    (mcp_infra.t2_index_write) and still runs the TTL expire sweep
+    (RDR-128 P3 — the flush no longer opens memory.db directly)."""
     mock_t2 = MagicMock()
     mock_t2.expire.return_value = 3
+    mock_t2.memory.put.return_value = 1
 
-    _t2_cm = MagicMock(__enter__=MagicMock(return_value=mock_t2))
+    def _run(write_fn):
+        # Stand in for the daemon route: run the write_fn against the mock.
+        return write_fn(mock_t2)
+
     with patch("nexus.hooks._open_t1", return_value=MagicMock(flagged_entries=lambda: [])):
-        with patch("nexus.hooks.T2Database", return_value=_t2_cm):
+        with patch("nexus.mcp_infra.t2_index_write", _run):
             result = runner.invoke(main, ["hook", "session-end"])
 
     mock_t2.expire.assert_called_once()

--- a/tests/test_rdr128_p0_startup_migration.py
+++ b/tests/test_rdr128_p0_startup_migration.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-128 P0a (RF-3): startup-migration lock tolerance.
+
+The T2 daemon's startup migration (``T2Database.bootstrap_schema`` ->
+``apply_pending``) must tolerate another process (typically ``nx index
+repo``) holding memory.db's single WAL writer lock. Before this fix the
+migration connection used a 5s ``busy_timeout`` with no retry, so a
+concurrent indexer could push a migration step past the limit and crash
+the freshly-spawned daemon on ``database is locked`` — and because
+``ensure-running`` is one-shot, the daemon was then left down (the
+post-5.0.4 crash-loop, RF-3 x RF-4).
+
+Two layers of tolerance, both tested here:
+
+* a >= 30s ``busy_timeout`` so each statement waits out the realistic
+  intra-host contention window (mirrors aspect_extraction_queue,
+  nexus-v4m7y);
+* a bounded Python-level retry around ``apply_pending`` so a migration
+  that still trips ``database is locked`` is re-attempted (idempotent)
+  rather than crashing.
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from nexus.db.t2 import (
+    _BOOTSTRAP_BUSY_TIMEOUT_MS,
+    T2Database,
+    _apply_pending_with_lock_retry,
+)
+
+
+def test_busy_timeout_constant_is_at_least_30s() -> None:
+    """RDR-128 P0a spec: busy_timeout >= 30000 ms."""
+    assert _BOOTSTRAP_BUSY_TIMEOUT_MS >= 30000
+
+
+def test_retry_recovers_after_one_transient_lock() -> None:
+    """A single ``database is locked`` is absorbed; the second attempt
+    succeeds and ``apply_pending`` is not retried further."""
+    calls = {"n": 0}
+
+    def _fake_apply_pending(conn, current_version):  # noqa: ANN001
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise sqlite3.OperationalError("database is locked")
+
+    # Patch the symbol the helper imports lazily.
+    import nexus.db.migrations as _mig
+
+    orig = _mig.apply_pending
+    _mig.apply_pending = _fake_apply_pending  # type: ignore[assignment]
+    try:
+        # No real sleep delay needed for correctness, but the helper does
+        # sleep between attempts; keep it tiny by patching the sleep table.
+        import nexus.db.t2 as _t2
+
+        orig_sleeps = _t2._BOOTSTRAP_RETRY_SLEEPS_BETWEEN
+        _t2._BOOTSTRAP_RETRY_SLEEPS_BETWEEN = (0.0, 0.0)  # type: ignore[attr-defined]
+        try:
+            _apply_pending_with_lock_retry(sqlite3.connect(":memory:"), "9.9.9")
+        finally:
+            _t2._BOOTSTRAP_RETRY_SLEEPS_BETWEEN = orig_sleeps  # type: ignore[attr-defined]
+    finally:
+        _mig.apply_pending = orig  # type: ignore[assignment]
+
+    assert calls["n"] == 2, "expected exactly one retry then success"
+
+
+def test_retry_exhausts_and_reraises_on_persistent_lock() -> None:
+    """A lock that never clears re-raises after the bounded attempts —
+    the helper must NOT hang indefinitely."""
+    calls = {"n": 0}
+
+    def _always_locked(conn, current_version):  # noqa: ANN001
+        calls["n"] += 1
+        raise sqlite3.OperationalError("database is locked")
+
+    import nexus.db.migrations as _mig
+    import nexus.db.t2 as _t2
+
+    orig = _mig.apply_pending
+    orig_sleeps = _t2._BOOTSTRAP_RETRY_SLEEPS_BETWEEN
+    _mig.apply_pending = _always_locked  # type: ignore[assignment]
+    _t2._BOOTSTRAP_RETRY_SLEEPS_BETWEEN = (0.0, 0.0)  # type: ignore[attr-defined]
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            _apply_pending_with_lock_retry(sqlite3.connect(":memory:"), "9.9.9")
+    finally:
+        _mig.apply_pending = orig  # type: ignore[assignment]
+        _t2._BOOTSTRAP_RETRY_SLEEPS_BETWEEN = orig_sleeps  # type: ignore[attr-defined]
+
+    assert calls["n"] == len(orig_sleeps) + 1, "must try exactly max_attempts times"
+
+
+def test_non_lock_operational_error_propagates_immediately() -> None:
+    """A non-lock OperationalError (e.g. schema corruption) is not a
+    contention signal — propagate on the first attempt, no retry."""
+    calls = {"n": 0}
+
+    def _schema_error(conn, current_version):  # noqa: ANN001
+        calls["n"] += 1
+        raise sqlite3.OperationalError("no such table: bogus")
+
+    import nexus.db.migrations as _mig
+
+    orig = _mig.apply_pending
+    _mig.apply_pending = _schema_error  # type: ignore[assignment]
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="no such table"):
+            _apply_pending_with_lock_retry(sqlite3.connect(":memory:"), "9.9.9")
+    finally:
+        _mig.apply_pending = orig  # type: ignore[assignment]
+
+    assert calls["n"] == 1, "non-lock errors must not be retried"
+
+
+def test_bootstrap_schema_waits_for_held_writer_lock_then_succeeds(
+    tmp_path: Path,
+) -> None:
+    """Integration: a competing connection holds memory.db's writer lock
+    when bootstrap_schema starts; bootstrap_schema must WAIT for the lock
+    to free and then complete the migration, not crash."""
+    db = tmp_path / "memory.db"
+
+    # Seed the file in WAL mode (closed before threading — a sqlite3
+    # connection can only be used from its creating thread).
+    seed = sqlite3.connect(str(db))
+    seed.execute("PRAGMA journal_mode=WAL")
+    seed.execute("CREATE TABLE _seed (x INTEGER)")
+    seed.commit()
+    seed.close()
+
+    hold_seconds = 0.4
+    locked = threading.Event()
+    release = threading.Event()
+
+    def _holder() -> None:
+        # Own connection, own thread: acquire the single WAL writer lock,
+        # signal that it's held, wait for the release cue, then free it.
+        h = sqlite3.connect(str(db))
+        h.execute("PRAGMA busy_timeout=30000")
+        h.execute("BEGIN IMMEDIATE")
+        h.execute("INSERT INTO _seed VALUES (1)")
+        locked.set()
+        release.wait(timeout=10)
+        h.rollback()
+        h.close()
+
+    holder = threading.Thread(target=_holder)
+    holder.start()
+    assert locked.wait(timeout=5), "holder thread failed to acquire writer lock"
+
+    def _release_after() -> None:
+        time.sleep(hold_seconds)
+        release.set()
+
+    releaser = threading.Thread(target=_release_after)
+    releaser.start()
+
+    start = time.monotonic()
+    T2Database.bootstrap_schema(db)  # must wait ~hold_seconds, then succeed
+    elapsed = time.monotonic() - start
+
+    releaser.join()
+    holder.join()
+
+    # It genuinely waited for the lock rather than failing fast.
+    assert elapsed >= hold_seconds - 0.1
+    # And the migration actually ran: a real T2 table now exists.
+    check = sqlite3.connect(str(db))
+    try:
+        tables = {
+            r[0]
+            for r in check.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    finally:
+        check.close()
+    assert "_nexus_version" in tables, f"migration did not run; tables={tables}"

--- a/tests/test_rdr128_p1_index_write_routing.py
+++ b/tests/test_rdr128_p1_index_write_routing.py
@@ -135,3 +135,53 @@ def test_non_unreachable_error_propagates_no_fallback(
 
     with pytest.raises(RuntimeError, match="daemon-side RPC error"):
         t2_index_write(_write)
+
+
+def test_dual_write_calls_upsert_many_exactly_once() -> None:
+    """The batch dual-write must be ONE store call (one daemon RPC when
+    routed), not one per chunk — pins the batching, not just end-state."""
+    from nexus.db.t2.chash_index import dual_write_chash_index
+
+    class _SpyChash:
+        def __init__(self) -> None:
+            self.many = 0
+            self.single = 0
+            self.seen: tuple | None = None
+
+        def upsert_many(self, *, chashes, collection) -> None:  # noqa: ANN001
+            self.many += 1
+            self.seen = (list(chashes), collection)
+
+        def upsert(self, *, chash, collection) -> None:  # noqa: ANN001
+            self.single += 1
+
+    spy = _SpyChash()
+    metas = [{"chunk_text_hash": f"h{i}"} for i in range(5)]
+    dual_write_chash_index(spy, "code__c", [f"d{i}" for i in range(5)], metas)
+
+    assert spy.many == 1, "must batch into a single upsert_many call"
+    assert spy.single == 0, "must NOT loop per-row upsert"
+    assert spy.seen == (["h0", "h1", "h2", "h3", "h4"], "code__c")
+
+
+def test_chash_hook_delegates_to_t2_index_write(monkeypatch) -> None:
+    """chash_dual_write_batch_hook routes through t2_index_write (the daemon
+    path), not a raw t2_ctx/T2Database open."""
+    import nexus.mcp_infra as mi
+
+    calls: list[object] = []
+    monkeypatch.setattr(mi, "t2_index_write", lambda write_fn: calls.append(write_fn))
+    monkeypatch.setattr(
+        mi, "t2_ctx",
+        lambda: pytest.fail("hook must route via t2_index_write, not t2_ctx"),
+    )
+
+    mi.chash_dual_write_batch_hook(
+        doc_ids=["d1"],
+        collection="code__c",
+        contents=["x"],
+        embeddings=None,
+        metadatas=[{"chunk_text_hash": "h1"}],
+    )
+
+    assert len(calls) == 1, "chash hook must delegate exactly one write to t2_index_write"

--- a/tests/test_rdr128_p1_index_write_routing.py
+++ b/tests/test_rdr128_p1_index_write_routing.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-128 P1 (nexus-kg8sj): route indexer T2 writes through the daemon.
+
+`t2_index_write` funnels an indexer T2 write through the T2 daemon
+(`T2Client`) when it is reachable, so the `nx index repo` process never
+opens `memory.db` directly and cannot strand its single WAL writer slot.
+When the daemon is unreachable it falls back to a direct `T2Database` so
+indexing still works (degraded, logged).
+
+Reachability is decided by an up-front `database.hello()` probe (not by
+catching an error out of `write_fn`, which some best-effort writers
+swallow). `write_fn` runs against exactly one writer — never re-run — so
+there is no double-write risk.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class _FakeDatabaseProxy:
+    """Stand-in for ``T2Client.database`` with a ``hello()`` probe."""
+
+    def __init__(self, reachable: bool) -> None:
+        self._reachable = reachable
+
+    def hello(self) -> dict:
+        if not self._reachable:
+            from nexus.daemon.t2_client import T2DaemonNotReachableError
+            raise T2DaemonNotReachableError("daemon down")
+        return {"daemon_schema_version": "9.9.9"}
+
+
+def test_routes_through_daemon_client_when_reachable(monkeypatch) -> None:
+    import nexus.daemon.t2_client as t2c
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.closed = False
+            self.database = _FakeDatabaseProxy(reachable=True)
+
+        def close(self) -> None:
+            self.closed = True
+
+    fake = _FakeClient()
+    monkeypatch.setattr(t2c, "make_t2_client", lambda **_kw: fake)
+
+    # If we fell through to the direct path, this would blow up the test.
+    import nexus.mcp_infra as mi
+    monkeypatch.setattr(
+        mi, "default_db_path",
+        lambda: pytest.fail("must not open a direct T2Database when daemon is reachable"),
+    )
+
+    from nexus.mcp_infra import t2_index_write
+
+    received: list[object] = []
+    t2_index_write(received.append)
+
+    assert received == [fake], "write_fn must run against the daemon client"
+    assert fake.closed is True, "client must be closed after the write"
+
+
+def test_falls_back_to_direct_t2database_when_unreachable(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    import nexus.daemon.t2_client as t2c
+
+    class _DeadClient:
+        def __init__(self) -> None:
+            self.database = _FakeDatabaseProxy(reachable=False)
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    dead = _DeadClient()
+    monkeypatch.setattr(t2c, "make_t2_client", lambda **_kw: dead)
+
+    import nexus.mcp_infra as mi
+    db_path = tmp_path / "memory.db"
+    monkeypatch.setattr(mi, "default_db_path", lambda: db_path)
+
+    from nexus.mcp_infra import t2_index_write
+
+    seen_types: list[str] = []
+
+    def _write(db) -> None:  # noqa: ANN001
+        seen_types.append(type(db).__name__)
+        # Single store call; runs only on the direct writer here.
+        db.chash_index.upsert_many(chashes=["x1", "x2"], collection="code__c")
+
+    t2_index_write(_write)
+
+    # Probe failed → write_fn ran ONCE, against the direct T2Database only.
+    assert seen_types == ["T2Database"]
+    assert dead.closed is True, "unreachable client must be closed after probe"
+
+    # And the fallback write actually landed.
+    from nexus.db.t2 import T2Database
+
+    with T2Database(db_path) as db:
+        assert db.chash_index.lookup("x1"), "fallback write did not persist"
+        assert db.chash_index.lookup("x2")
+
+
+def test_non_unreachable_error_propagates_no_fallback(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """A daemon-side error that is NOT unreachability must propagate, not
+    silently fall back to a direct write (which could double-write or mask
+    a real bug)."""
+    import nexus.daemon.t2_client as t2c
+
+    class _Client:
+        def __init__(self) -> None:
+            self.database = _FakeDatabaseProxy(reachable=True)
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(t2c, "make_t2_client", lambda **_kw: _Client())
+
+    import nexus.mcp_infra as mi
+    monkeypatch.setattr(
+        mi, "default_db_path",
+        lambda: pytest.fail("must not fall back on a non-unreachable error"),
+    )
+
+    from nexus.mcp_infra import t2_index_write
+
+    def _write(db) -> None:  # noqa: ANN001
+        raise RuntimeError("daemon-side RPC error")
+
+    with pytest.raises(RuntimeError, match="daemon-side RPC error"):
+        t2_index_write(_write)

--- a/tests/test_rdr128_p2_migration_flock.py
+++ b/tests/test_rdr128_p2_migration_flock.py
@@ -236,3 +236,108 @@ def test_quiesce_daemon_shells_t2_stop(monkeypatch, tmp_path: Path) -> None:
 
     assert len(calls) == 1
     assert calls[0][-3:] == ["daemon", "t2", "stop"]
+
+
+def test_quiesce_daemon_waits_for_recorded_pid_to_exit(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """_quiesce_daemon polls the recorded pid via os.kill(pid,0) until the
+    process is gone — closing the SIGTERM-to-shutdown race (the poll loop
+    that test_quiesce_daemon_shells_t2_stop does not exercise)."""
+    import json
+    import os
+    import subprocess
+
+    import nexus.commands.upgrade as up
+    from nexus.daemon.t2_daemon import t2_discovery_path
+
+    monkeypatch.setattr("nexus.config.nexus_config_dir", lambda: tmp_path)
+    disc = t2_discovery_path(tmp_path)
+    disc.parent.mkdir(parents=True, exist_ok=True)
+    disc.write_text(json.dumps({"pid": 999999, "daemon_version": "x"}))
+
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda argv, **kw: subprocess.CompletedProcess(argv, 0),
+    )
+
+    # The daemon is "alive" for the first two polls, then exits.
+    state = {"polls": 0}
+    real_kill = os.kill
+
+    def _fake_kill(pid, sig):  # noqa: ANN001
+        if pid == 999999 and sig == 0:
+            state["polls"] += 1
+            if state["polls"] >= 3:
+                raise ProcessLookupError
+            return
+        return real_kill(pid, sig)
+
+    monkeypatch.setattr(os, "kill", _fake_kill)
+
+    up._quiesce_daemon()
+
+    assert state["polls"] >= 3, "must poll the pid until the process exits"
+
+
+# ── Acceptance criterion: two real migrators don't collide ───────────────────
+
+
+def test_two_real_migration_paths_serialize_no_database_locked(
+    tmp_path: Path,
+) -> None:
+    """The literal acceptance criterion: the daemon-startup migration
+    (``bootstrap_schema``) and an ``nx upgrade``-style ``apply_pending``
+    (flock-wrapped) racing on the SAME memory.db both complete without a
+    ``database is locked`` error.
+
+    (Cross-process flock serialization itself is proven by
+    ``test_flock_serializes_two_holders``; this exercises the two real
+    migration paths integrated on one DB.)
+    """
+    from nexus.db.migrations import apply_pending, t2_migration_flock
+    from nexus.db.t2 import T2Database
+
+    db = tmp_path / "memory.db"
+    errors: list[tuple[str, Exception]] = []
+    start = threading.Barrier(2)
+
+    def _daemon_startup_path() -> None:
+        try:
+            start.wait(timeout=5)
+            T2Database.bootstrap_schema(db)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(("daemon", exc))
+
+    def _upgrade_path() -> None:
+        try:
+            start.wait(timeout=5)
+            conn = sqlite3.connect(str(db))
+            conn.execute("PRAGMA busy_timeout=30000")
+            try:
+                with t2_migration_flock(tmp_path):
+                    apply_pending(conn, "9.9.9")
+            finally:
+                conn.close()
+        except Exception as exc:  # noqa: BLE001
+            errors.append(("upgrade", exc))
+
+    t1 = threading.Thread(target=_daemon_startup_path)
+    t2 = threading.Thread(target=_upgrade_path)
+    t1.start()
+    t2.start()
+    t1.join(timeout=20)
+    t2.join(timeout=20)
+
+    assert not errors, f"migration paths collided: {errors}"
+    # Schema is present and consistent.
+    check = sqlite3.connect(str(db))
+    try:
+        tables = {
+            r[0] for r in check.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    finally:
+        check.close()
+    assert "_nexus_version" in tables

--- a/tests/test_rdr128_p2_migration_flock.py
+++ b/tests/test_rdr128_p2_migration_flock.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-128 P2: cross-process migration flock + daemon quiesce.
+
+`nx upgrade` and the daemon's own startup migration both run `apply_pending`.
+Before P2 they could race on SQLite's single WAL writer lock (the structural
+contention behind the 5.0.2-5.0.4 incidents + the post-5.0.4 crash-loop).
+P2 serializes them with an exclusive `fcntl.flock` on
+`<config_dir>/t2_migration.lock`, taken by BOTH paths, and quiesces the
+daemon (stop + wait) during `nx upgrade`'s migration so its live connections
+don't contend with the migration DDL.
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+# ── flock mechanics ──────────────────────────────────────────────────────────
+
+
+def test_flock_serializes_two_holders(tmp_path: Path) -> None:
+    """A second acquirer of the same lock dir BLOCKS until the first
+    releases — the core serialization guarantee."""
+    from nexus.db.migrations import t2_migration_flock
+
+    order: list[str] = []
+    a_holding = threading.Event()
+    a_may_release = threading.Event()
+
+    def holder_a() -> None:
+        with t2_migration_flock(tmp_path):
+            order.append("A-enter")
+            a_holding.set()
+            a_may_release.wait(timeout=5)
+            order.append("A-exit")
+
+    def holder_b() -> None:
+        a_holding.wait(timeout=5)  # ensure A holds the lock first
+        with t2_migration_flock(tmp_path):
+            order.append("B-enter")
+
+    ta = threading.Thread(target=holder_a)
+    tb = threading.Thread(target=holder_b)
+    ta.start()
+    tb.start()
+
+    assert a_holding.wait(timeout=5)
+    # B is now blocked on the flock while A holds it.
+    time.sleep(0.3)
+    assert order == ["A-enter"], "B must NOT enter while A holds the lock"
+
+    a_may_release.set()  # let A release
+    ta.join(timeout=5)
+    tb.join(timeout=5)
+
+    assert order == ["A-enter", "A-exit", "B-enter"], (
+        "B must enter only after A exits"
+    )
+
+
+def test_flock_released_on_context_exit_is_reacquirable(tmp_path: Path) -> None:
+    """The lock is freed on context exit, so a subsequent acquire succeeds
+    without blocking."""
+    from nexus.db.migrations import t2_migration_flock
+
+    with t2_migration_flock(tmp_path):
+        pass
+    # Second acquisition must not hang (guard with a thread + timeout).
+    done = threading.Event()
+
+    def _acquire() -> None:
+        with t2_migration_flock(tmp_path):
+            done.set()
+
+    t = threading.Thread(target=_acquire)
+    t.start()
+    t.join(timeout=5)
+    assert done.is_set(), "lock was not released on context exit"
+
+
+def test_flock_not_stranded_after_holder_thread_finishes(tmp_path: Path) -> None:
+    """After a holder thread completes its with-block, the lock is free."""
+    from nexus.db.migrations import t2_migration_flock
+
+    def _hold_briefly() -> None:
+        with t2_migration_flock(tmp_path):
+            time.sleep(0.05)
+
+    h = threading.Thread(target=_hold_briefly)
+    h.start()
+    h.join(timeout=5)
+
+    acquired = threading.Event()
+
+    def _reacquire() -> None:
+        with t2_migration_flock(tmp_path):
+            acquired.set()
+
+    r = threading.Thread(target=_reacquire)
+    r.start()
+    r.join(timeout=5)
+    assert acquired.is_set()
+
+
+# ── bootstrap_schema honors the flock ────────────────────────────────────────
+
+
+def test_bootstrap_schema_waits_on_held_migration_flock(tmp_path: Path) -> None:
+    """The daemon's startup migration (bootstrap_schema) takes the same
+    flock — while an external holder holds it, bootstrap_schema BLOCKS, then
+    completes once the lock frees."""
+    from nexus.db.migrations import t2_migration_flock
+    from nexus.db.t2 import T2Database
+
+    db = tmp_path / "memory.db"
+    hold_seconds = 0.4
+    holding = threading.Event()
+    release = threading.Event()
+
+    def _external_holder() -> None:
+        with t2_migration_flock(tmp_path):  # same dir as db
+            holding.set()
+            release.wait(timeout=10)
+
+    holder = threading.Thread(target=_external_holder)
+    holder.start()
+    assert holding.wait(timeout=5)
+
+    def _release_after() -> None:
+        time.sleep(hold_seconds)
+        release.set()
+
+    rel = threading.Thread(target=_release_after)
+    rel.start()
+
+    start = time.monotonic()
+    T2Database.bootstrap_schema(db)  # must wait for the flock, then succeed
+    elapsed = time.monotonic() - start
+
+    rel.join(timeout=5)
+    holder.join(timeout=5)
+
+    assert elapsed >= hold_seconds - 0.1, "bootstrap_schema did not wait on the flock"
+    # Migration actually ran.
+    check = sqlite3.connect(str(db))
+    try:
+        tables = {
+            r[0] for r in check.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    finally:
+        check.close()
+    assert "_nexus_version" in tables
+
+
+# ── nx upgrade quiesce ordering ──────────────────────────────────────────────
+
+
+def _patch_upgrade_phases(monkeypatch) -> list[str]:
+    import nexus.commands.upgrade as up
+
+    order: list[str] = []
+    monkeypatch.setattr(up, "_quiesce_daemon", lambda: order.append("quiesce"))
+    monkeypatch.setattr(
+        up, "_run_upgrade", lambda **kw: order.append("migrate"),
+    )
+    monkeypatch.setattr(
+        up, "_cycle_daemon_to_current", lambda: order.append("restore"),
+    )
+    return order
+
+
+def test_upgrade_quiesces_before_migrating_and_restores_after(monkeypatch) -> None:
+    from nexus.cli import main
+
+    order = _patch_upgrade_phases(monkeypatch)
+    result = CliRunner().invoke(main, ["upgrade"])
+    assert result.exit_code == 0, result.output
+    assert order == ["quiesce", "migrate", "restore"]
+
+
+def test_upgrade_dry_run_does_not_touch_daemon(monkeypatch) -> None:
+    from nexus.cli import main
+
+    order = _patch_upgrade_phases(monkeypatch)
+    result = CliRunner().invoke(main, ["upgrade", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert order == ["migrate"], "dry-run must not stop or restart the daemon"
+
+
+def test_upgrade_restores_daemon_even_when_migration_fails(monkeypatch) -> None:
+    import nexus.commands.upgrade as up
+    from nexus.cli import main
+
+    order: list[str] = []
+    monkeypatch.setattr(up, "_quiesce_daemon", lambda: order.append("quiesce"))
+
+    def _boom(**kw):  # noqa: ANN001
+        order.append("migrate")
+        raise RuntimeError("migration boom")
+
+    monkeypatch.setattr(up, "_run_upgrade", _boom)
+    monkeypatch.setattr(
+        up, "_cycle_daemon_to_current", lambda: order.append("restore"),
+    )
+
+    result = CliRunner().invoke(main, ["upgrade"])
+    assert result.exit_code != 0  # non-auto mode re-raises
+    # finally-clause must still bring the daemon back.
+    assert order == ["quiesce", "migrate", "restore"]
+
+
+def test_quiesce_daemon_shells_t2_stop(monkeypatch, tmp_path: Path) -> None:
+    """_quiesce_daemon issues `nx daemon t2 stop` (best-effort, never raises)."""
+    import subprocess
+
+    import nexus.commands.upgrade as up
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda argv, **kw: calls.append(argv) or subprocess.CompletedProcess(argv, 0),
+    )
+    # No discovery file under a tmp config dir → no pid → no wait loop.
+    monkeypatch.setattr(
+        "nexus.config.nexus_config_dir", lambda: tmp_path,
+    )
+
+    up._quiesce_daemon()
+
+    assert len(calls) == 1
+    assert calls[0][-3:] == ["daemon", "t2", "stop"]

--- a/tests/test_rdr128_p3_enablers.py
+++ b/tests/test_rdr128_p3_enablers.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-128 P3 (nexus-sbxbe.3) routing enablers.
+
+Three small substrate additions let the remaining writers route through
+the daemon:
+
+* ``t2_index_write`` now RETURNS ``write_fn``'s result, so writers that
+  need the value (aspect_worker ``claim_batch`` rows, ``rename_collection_
+  cascade`` counts) can route, not just fire-and-forget writers.
+* ``T2Client`` grows facade-parity passthroughs (``expire``,
+  ``rename_collection_cascade``) so a ``write_fn`` body calls them
+  uniformly on a routed client or a direct ``T2Database``.
+* The daemon dispatches ``database.expire`` so the SessionEnd flush hook
+  reaches the daemon instead of opening ``memory.db`` directly.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class _FakeDatabaseProxy:
+    def __init__(self, reachable: bool) -> None:
+        self._reachable = reachable
+
+    def hello(self) -> dict:
+        if not self._reachable:
+            from nexus.daemon.t2_client import T2DaemonNotReachableError
+            raise T2DaemonNotReachableError("daemon down")
+        return {"daemon_schema_version": "9.9.9"}
+
+
+def test_t2_index_write_returns_value_routed(monkeypatch) -> None:
+    """The routed path returns write_fn's result (RDR-128 P3)."""
+    import nexus.daemon.t2_client as t2c
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.database = _FakeDatabaseProxy(reachable=True)
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    fake = _FakeClient()
+    monkeypatch.setattr(t2c, "make_t2_client", lambda **_kw: fake)
+    import nexus.mcp_infra as mi
+    monkeypatch.setattr(
+        mi, "default_db_path",
+        lambda: pytest.fail("must not open a direct T2Database when reachable"),
+    )
+
+    from nexus.mcp_infra import t2_index_write
+
+    result = t2_index_write(lambda db: ["row1", "row2"])
+    assert result == ["row1", "row2"], "routed path must return write_fn's value"
+    assert fake.closed is True
+
+
+def test_t2_index_write_returns_value_fallback(monkeypatch, tmp_path: Path) -> None:
+    """The direct-fallback path also returns write_fn's result."""
+    import nexus.daemon.t2_client as t2c
+
+    class _DeadClient:
+        def __init__(self) -> None:
+            self.database = _FakeDatabaseProxy(reachable=False)
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(t2c, "make_t2_client", lambda **_kw: _DeadClient())
+    import nexus.mcp_infra as mi
+    monkeypatch.setattr(mi, "default_db_path", lambda: tmp_path / "memory.db")
+
+    from nexus.mcp_infra import t2_index_write
+
+    result = t2_index_write(lambda db: type(db).__name__)
+    assert result == "T2Database", "fallback path must return write_fn's value"
+
+
+def test_t2client_expire_forwards_to_database_op() -> None:
+    """T2Client.expire forwards to the ``database.expire`` RPC op."""
+    from nexus.daemon.t2_client import T2Client
+
+    client = T2Client(skip_handshake=True)
+    captured: list[tuple] = []
+    client.call = lambda op, *a, **kw: captured.append((op, a, kw)) or 7  # type: ignore[assignment]
+
+    result = client.expire(90)
+    assert captured == [("database.expire", (90,), {})]
+    assert result == 7
+
+
+def test_t2client_rename_cascade_forwards_to_database_op() -> None:
+    """T2Client.rename_collection_cascade forwards to the database op."""
+    from nexus.daemon.t2_client import T2Client
+
+    client = T2Client(skip_handshake=True)
+    captured: list[tuple] = []
+    client.call = lambda op, *a, **kw: captured.append((op, a, kw)) or {"memory": 3}  # type: ignore[assignment]
+
+    result = client.rename_collection_cascade(old="a", new="b")
+    assert captured == [("database.rename_collection_cascade", (), {"old": "a", "new": "b"})]
+    assert result == {"memory": 3}
+
+
+def test_daemon_dispatch_table_includes_database_expire(tmp_path: Path) -> None:
+    """The daemon dispatches ``database.expire`` (RDR-128 P3) so the
+    SessionEnd flush can route its TTL sweep."""
+    from nexus.daemon.t2_daemon import _build_dispatch_table
+    from nexus.db.t2 import T2Database
+
+    with T2Database(tmp_path / "memory.db") as db:
+        table = _build_dispatch_table(db)
+
+    assert "database.expire" in table, (
+        "expire must be dispatchable so session_end can route it"
+    )
+    assert "database.rename_collection_cascade" in table
+    assert "database.hello" in table

--- a/tests/test_storage_boundary_lint.py
+++ b/tests/test_storage_boundary_lint.py
@@ -317,6 +317,14 @@ def test_dual_population_baseline_locked():
     assert result.epsilon_allow_connects == 16, (
         f"raw-connect epsilon-allow baseline moved: {result.epsilon_allow_connects}"
     )
-    assert result.t2database_constructions == 35, (
+    # 36 = 35 (P0c baseline) + 1: RDR-128 P1 (kg8sj-A) added the
+    # ``t2_index_write`` daemon-unreachable FALLBACK in mcp_infra.py, which
+    # must construct a direct T2Database by design (the degraded path when
+    # the daemon is down). Net direction is still correct — kg8sj-A routes
+    # the *hot-path* writes through the daemon; the single fallback site is
+    # the documented-irreducible cost of graceful degradation. The taxonomy
+    # residual (nexus-fkq5q) will drive the remaining indexer-path
+    # constructions down further.
+    assert result.t2database_constructions == 36, (
         f"T2Database construction baseline moved: {result.t2database_constructions}"
     )

--- a/tests/test_storage_boundary_lint.py
+++ b/tests/test_storage_boundary_lint.py
@@ -27,14 +27,16 @@ REPO_ROOT = pathlib.Path(__file__).parent.parent
 SRC_ROOT = REPO_ROOT / "src" / "nexus"
 
 
-def _check(extra_files=None, allowlist_prefixes=None):
-    """Run the lint and return its result tuple."""
+def _check(extra_files=None, allowlist_prefixes=None,
+           construction_allowlist_prefixes=None):
+    """Run the lint and return its result."""
     from nexus.storage_boundary_lint import scan_repo
 
     return scan_repo(
         repo_root=REPO_ROOT,
         allowlist_prefixes=allowlist_prefixes,
         extra_files=extra_files,
+        construction_allowlist_prefixes=construction_allowlist_prefixes,
     )
 
 
@@ -211,3 +213,110 @@ def test_result_has_file_line_symbol(tmp_path):
     assert isinstance(v.line, int)
     assert isinstance(v.symbol, str)
     assert v.line == 2
+
+
+# ---------------------------------------------------------------------------
+# RDR-128 P0c (RF-5): T2Database construction detection + dual baseline
+# ---------------------------------------------------------------------------
+#
+# The lint counts two baseline populations so the single-writer cure
+# (P1/P3) is measurable from day one:
+#   * population 1 — ``sqlite3.connect`` sites carrying a deliberate
+#     ``# epsilon-allow:`` override (the raw-connect exceptions);
+#   * population 2 — direct ``T2Database(...)`` syntactic constructions
+#     outside the db/ + daemon/ construction-allowlist.
+#
+# RDR-128 RF-1 cited 20 / 53 from a *codebase grep* (RDR §RF-1, line
+# "Verified ... codebase grep"). That grep over-counts: ``grep
+# 'T2Database('`` substring-matches the 16 ``_T2Database(...)`` wrapper
+# call sites in commands/taxonomy_cmd.py plus several doc-comments. The
+# AST lint counts true syntactic constructions (the taxonomy_cmd wrapper
+# body is one site, reused 16×), giving the authoritative baseline below.
+
+
+def test_t2database_construction_flagged(tmp_path):
+    """A direct ``T2Database(...)`` construction is counted (population 2)."""
+    base = _check().t2database_constructions
+    target = tmp_path / "ctor_offender.py"
+    target.write_text(
+        "from nexus.db.t2 import T2Database\n"
+        "def bad():\n"
+        "    return T2Database('/tmp/x.db')\n"
+    )
+    assert _check(extra_files=[target]).t2database_constructions == base + 1
+
+
+def test_t2database_construction_aliased_import_flagged(tmp_path):
+    """``from ... import T2Database as DB; DB(...)`` is resolved + counted."""
+    base = _check().t2database_constructions
+    target = tmp_path / "ctor_aliased.py"
+    target.write_text(
+        "from nexus.db.t2 import T2Database as DB\n"
+        "def bad():\n"
+        "    return DB('/tmp/x.db')\n"
+    )
+    assert _check(extra_files=[target]).t2database_constructions == base + 1
+
+
+def test_t2database_attribute_form_flagged(tmp_path):
+    """``module.T2Database(...)`` (attribute access) is also counted."""
+    base = _check().t2database_constructions
+    target = tmp_path / "ctor_attr.py"
+    target.write_text(
+        "import nexus.db.t2 as t2mod\n"
+        "def bad():\n"
+        "    return t2mod.T2Database('/tmp/x.db')\n"
+    )
+    assert _check(extra_files=[target]).t2database_constructions == base + 1
+
+
+def test_epsilon_allow_connect_counted_as_population(tmp_path):
+    """An epsilon-allow'd ``sqlite3.connect`` is counted (population 1),
+    not silently dropped, and is NOT a hard violation."""
+    base = _check()
+    target = tmp_path / "eps_connect.py"
+    target.write_text(
+        "import sqlite3\n"
+        "def ok():\n"
+        "    return sqlite3.connect('/tmp/x.db')  # epsilon-allow: documented exception\n"
+    )
+    result = _check(extra_files=[target])
+    assert result.epsilon_allow_connects == base.epsilon_allow_connects + 1
+    # Still not a hard violation (the override suppresses that).
+    assert [v for v in result.violations if v.file == str(target)] == []
+
+
+def test_daemon_construction_is_allowlisted(tmp_path):
+    """db/ AND daemon/ are construction-allowlisted (the daemon is the
+    legitimate single writer). Removing daemon/ from the allowlist must
+    reveal strictly more constructions."""
+    default = _check().t2database_constructions
+    db_only = _check(
+        construction_allowlist_prefixes=("src/nexus/db/",)
+    ).t2database_constructions
+    assert db_only > default, (
+        "daemon/ T2Database construction(s) should be excluded by default"
+    )
+
+
+def test_dual_population_baseline_locked():
+    """Exact baseline lock (silent-corruption guard, RDR-128 P0c).
+
+    These are the AST-authoritative counts on develop @ 5.0.4 + this P0
+    change. Locked as ``== N`` (never ``>=``): a regression that adds a
+    raw connect or a T2Database construction outside the daemon trips the
+    assertion, forcing either a daemon route (P1/P3) or a deliberate
+    baseline bump with justification.
+
+    Divergence from RDR RF-1's grep figures (20 / 53) is expected and
+    documented in this module's header — the AST count is authoritative.
+    """
+    result = _check()
+    # 16 = 15 pre-existing raw-connect exceptions + the RDR-128 P0b
+    # lock-acquirability probe (daemon.py), itself a deliberate raw connect.
+    assert result.epsilon_allow_connects == 16, (
+        f"raw-connect epsilon-allow baseline moved: {result.epsilon_allow_connects}"
+    )
+    assert result.t2database_constructions == 35, (
+        f"T2Database construction baseline moved: {result.t2database_constructions}"
+    )

--- a/tests/test_storage_boundary_lint.py
+++ b/tests/test_storage_boundary_lint.py
@@ -168,7 +168,7 @@ def test_aliased_sqlite_import_caught(tmp_path):
     matched = [v for v in result.violations if v.file == str(target)]
     assert len(matched) == 1
     # The alias is resolved back to the canonical module name.
-    assert "sqlite3.connect" in matched[0].symbol or "_sqlite3.connect" in matched[0].symbol
+    assert matched[0].symbol in ("sqlite3.connect", "_sqlite3.connect")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_storage_boundary_lint.py
+++ b/tests/test_storage_boundary_lint.py
@@ -234,8 +234,15 @@ def test_result_has_file_line_symbol(tmp_path):
 # body is one site, reused 16×), giving the authoritative baseline below.
 
 
-def test_t2database_construction_flagged(tmp_path):
-    """A direct ``T2Database(...)`` construction is counted (population 2)."""
+def test_t2database_construction_unannotated_is_violation(tmp_path):
+    """RDR-128 P3: a direct un-annotated ``T2Database(...)`` outside the
+    construction-allowlist is now a HARD VIOLATION.
+
+    At P0c it was counted-only (baseline metric). P3 flips the lint to
+    enforce: an un-annotated construction is a violation exactly like an
+    un-annotated ``sqlite3.connect``. It must NOT inflate the documented
+    ``t2database_constructions`` population (that population is the
+    annotated survivors only)."""
     base = _check().t2database_constructions
     target = tmp_path / "ctor_offender.py"
     target.write_text(
@@ -243,31 +250,82 @@ def test_t2database_construction_flagged(tmp_path):
         "def bad():\n"
         "    return T2Database('/tmp/x.db')\n"
     )
-    assert _check(extra_files=[target]).t2database_constructions == base + 1
+    result = _check(extra_files=[target])
+    matched = [
+        v for v in result.violations
+        if v.file == str(target) and v.symbol == "T2Database"
+    ]
+    assert len(matched) == 1
+    assert matched[0].line == 3
+    assert result.t2database_constructions == base
 
 
-def test_t2database_construction_aliased_import_flagged(tmp_path):
-    """``from ... import T2Database as DB; DB(...)`` is resolved + counted."""
-    base = _check().t2database_constructions
+def test_t2database_construction_aliased_import_is_violation(tmp_path):
+    """``from ... import T2Database as DB; DB(...)`` resolves to a violation."""
     target = tmp_path / "ctor_aliased.py"
     target.write_text(
         "from nexus.db.t2 import T2Database as DB\n"
         "def bad():\n"
         "    return DB('/tmp/x.db')\n"
     )
-    assert _check(extra_files=[target]).t2database_constructions == base + 1
+    result = _check(extra_files=[target])
+    matched = [
+        v for v in result.violations
+        if v.file == str(target) and v.symbol == "T2Database"
+    ]
+    assert len(matched) == 1
 
 
-def test_t2database_attribute_form_flagged(tmp_path):
-    """``module.T2Database(...)`` (attribute access) is also counted."""
-    base = _check().t2database_constructions
+def test_t2database_attribute_form_is_violation(tmp_path):
+    """``module.T2Database(...)`` (attribute access) resolves to a violation."""
     target = tmp_path / "ctor_attr.py"
     target.write_text(
         "import nexus.db.t2 as t2mod\n"
         "def bad():\n"
         "    return t2mod.T2Database('/tmp/x.db')\n"
     )
-    assert _check(extra_files=[target]).t2database_constructions == base + 1
+    result = _check(extra_files=[target])
+    matched = [
+        v for v in result.violations
+        if v.file == str(target) and v.symbol == "T2Database"
+    ]
+    assert len(matched) == 1
+
+
+def test_t2database_construction_annotated_is_documented(tmp_path):
+    """RDR-128 P3: a ``T2Database(...)`` carrying a valid ``# epsilon-allow:``
+    is counted into the documented population (``t2database_constructions``)
+    and is NOT a hard violation — the exact mirror of the ``sqlite3.connect``
+    epsilon-allow treatment. This is how an irreducible direct construction
+    (read-only diagnostic, bootstrap chicken-and-egg, by-design daemon
+    fallback) declares its lock-discipline justification."""
+    base = _check().t2database_constructions
+    target = tmp_path / "ctor_documented.py"
+    target.write_text(
+        "from nexus.db.t2 import T2Database\n"
+        "def ok():\n"
+        "    return T2Database('/tmp/x.db')  "
+        "# epsilon-allow: read-only diagnostic, no WAL writer contention\n"
+    )
+    result = _check(extra_files=[target])
+    assert result.t2database_constructions == base + 1
+    assert [v for v in result.violations if v.file == str(target)] == []
+
+
+def test_t2database_construction_short_reason_is_violation(tmp_path):
+    """An epsilon-allow with a too-short (<8 char) reason does NOT suppress
+    the violation — same reason-length floor as the connect override."""
+    target = tmp_path / "ctor_shortreason.py"
+    target.write_text(
+        "from nexus.db.t2 import T2Database\n"
+        "def bad():\n"
+        "    return T2Database('/tmp/x.db')  # epsilon-allow: x\n"
+    )
+    result = _check(extra_files=[target])
+    assert [
+        v for v in result.violations
+        if v.file == str(target) and v.symbol == "T2Database"
+    ]
 
 
 def test_epsilon_allow_connect_counted_as_population(tmp_path):
@@ -288,43 +346,64 @@ def test_epsilon_allow_connect_counted_as_population(tmp_path):
 
 def test_daemon_construction_is_allowlisted(tmp_path):
     """db/ AND daemon/ are construction-allowlisted (the daemon is the
-    legitimate single writer). Removing daemon/ from the allowlist must
-    reveal strictly more constructions."""
-    default = _check().t2database_constructions
+    legitimate single writer). Under the RDR-128 P3 enforcement flip,
+    removing daemon/ from the allowlist must reveal strictly more
+    VIOLATIONS — the daemon's own (un-annotated) ``T2Database(...)``
+    constructions become hard violations once unallowlisted."""
+    default = _check().total_violations
     db_only = _check(
         construction_allowlist_prefixes=("src/nexus/db/",)
-    ).t2database_constructions
+    ).total_violations
     assert db_only > default, (
-        "daemon/ T2Database construction(s) should be excluded by default"
+        "daemon/ T2Database construction(s) should be exempt by default"
     )
 
 
 def test_dual_population_baseline_locked():
-    """Exact baseline lock (silent-corruption guard, RDR-128 P0c).
+    """Exact baseline lock (silent-corruption guard, RDR-128 P0c → P3 close).
 
-    These are the AST-authoritative counts on develop @ 5.0.4 + this P0
-    change. Locked as ``== N`` (never ``>=``): a regression that adds a
-    raw connect or a T2Database construction outside the daemon trips the
-    assertion, forcing either a daemon route (P1/P3) or a deliberate
-    baseline bump with justification.
+    AST-authoritative counts. Locked as ``== N`` (never ``>=``): a
+    regression that adds a raw connect or an un-annotated ``T2Database(...)``
+    construction outside the daemon trips the assertion (the un-annotated
+    case via ``total_violations``), forcing either a daemon route or a
+    deliberate ``# epsilon-allow:`` exemption with justification.
 
-    Divergence from RDR RF-1's grep figures (20 / 53) is expected and
-    documented in this module's header — the AST count is authoritative.
+    RDR-128 P3 (nexus-sbxbe.3) flipped the lint from counted-only to
+    ENFORCING: ``t2database_constructions`` now counts the DOCUMENTED
+    survivors (annotated direct constructions), and any un-annotated
+    construction is a hard violation. The close drove un-annotated
+    constructions to ZERO — every surviving direct construction carries a
+    lock-discipline justification (the acceptance criterion's
+    "documented-irreducible set").
     """
     result = _check()
     # 16 = 15 pre-existing raw-connect exceptions + the RDR-128 P0b
-    # lock-acquirability probe (daemon.py), itself a deliberate raw connect.
+    # lock-acquirability probe (daemon.py). Unchanged by P3: the P3 routing
+    # added no raw sqlite3.connect sites (the migration-flock extension in
+    # upgrade.py uses fcntl.flock, not a connect), and the T2Database
+    # constructions it removed were not raw connects.
     assert result.epsilon_allow_connects == 16, (
         f"raw-connect epsilon-allow baseline moved: {result.epsilon_allow_connects}"
     )
-    # 36 = 35 (P0c baseline) + 1: RDR-128 P1 (kg8sj-A) added the
-    # ``t2_index_write`` daemon-unreachable FALLBACK in mcp_infra.py, which
-    # must construct a direct T2Database by design (the degraded path when
-    # the daemon is down). Net direction is still correct — kg8sj-A routes
-    # the *hot-path* writes through the daemon; the single fallback site is
-    # the documented-irreducible cost of graceful degradation. The taxonomy
-    # residual (nexus-fkq5q) will drive the remaining indexer-path
-    # constructions down further.
-    assert result.t2database_constructions == 36, (
-        f"T2Database construction baseline moved: {result.t2database_constructions}"
+    # P3 endpoint: ZERO un-annotated direct T2Database constructions outside
+    # db/ + daemon/. A new direct writer that lands without routing or an
+    # epsilon-allow justification fails CI here — the enforcement teeth that
+    # "close" the single-writer invariant.
+    assert result.total_violations == 0, (
+        "un-annotated T2Database construction(s) or raw connect(s) outside "
+        f"the allowlist: {[(v.file, v.line, v.symbol) for v in result.violations]}"
+    )
+    # 30 = the documented-irreducible survivor set after the P3 close. P0c
+    # baselined 36 (all constructions, counted-only). P3 routed the hot-path
+    # and routable writers away (indexer/worker-poll/session-end/rename/
+    # scratch-promote/doctor-metric/aspect-delete/collection-delete) and
+    # annotated the genuinely-irreducible remainder with documented
+    # justifications: the daemon-unreachable fallback + t2_ctx worker-persist
+    # (mcp_infra), the bootstrap upgrade path, document_aspects.upsert /
+    # raw-DDL / raw-cursor writers, the read-only diagnostic/CLI reads, and
+    # the taxonomy CLI factory (raw-cursor reads + chroma-interleaved writes
+    # that cannot cross the daemon RPC). Each survivor's ``# epsilon-allow:``
+    # reason states why it cannot route.
+    assert result.t2database_constructions == 30, (
+        f"T2Database documented-construction baseline moved: {result.t2database_constructions}"
     )

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -94,6 +94,112 @@ def test_discover_topics_creates_topics_and_centroids(
     assert meta["collection"] == "test__coll"
 
 
+# ── RDR-128 P1 (fkq5q): assign_batch compute/persist split ───────────────────
+
+
+def _seed_centroids(db: T2Database, chroma_client) -> list[str]:
+    """discover topics so taxonomy__centroids exists; return the doc_ids."""
+    rng = np.random.default_rng(7)
+    embeddings = rng.standard_normal((60, 384)).astype(np.float32) * 0.1
+    embeddings[:30, 0] += 3.0
+    embeddings[30:, 1] += 3.0
+    doc_ids = [f"sd-{i}" for i in range(60)]
+    texts = (
+        [f"machine learning neural network gradient {i}" for i in range(30)]
+        + [f"database query indexing sql schema {i}" for i in range(30)]
+    )
+    db.taxonomy.discover_topics("split__coll", doc_ids, embeddings, texts, chroma_client)
+    return doc_ids
+
+
+def test_compute_assignments_returns_json_serializable_dicts(
+    db: T2Database, chroma_client: chromadb.ClientAPI,
+) -> None:
+    """The COMPUTE half returns plain dicts (no chroma objects) that survive
+    JSON — i.e. they can cross the daemon RPC boundary, which is the whole
+    point of the split."""
+    import json
+
+    from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
+
+    _seed_centroids(db, chroma_client)
+    new_embs = [
+        (np.random.default_rng(1).standard_normal(384).astype(np.float32) * 0.1
+         + np.array([3.0] + [0.0] * 383, dtype=np.float32)).tolist()
+        for _ in range(3)
+    ]
+    out = CatalogTaxonomy.compute_assignments(
+        "split__coll", ["a", "b", "c"], new_embs, chroma_client,
+        cross_collection=False,
+    )
+    assert out, "expected at least one assignment against seeded centroids"
+    # Plain, JSON-round-trippable dicts with the persist contract's keys.
+    json.dumps(out)  # must not raise
+    for a in out:
+        assert set(a) == {"doc_id", "topic_id", "assigned_by", "similarity", "source_collection"}
+        assert isinstance(a["topic_id"], int)
+        assert a["assigned_by"] == "centroid"
+
+
+def test_persist_assignments_writes_rows(
+    db: T2Database, chroma_client: chromadb.ClientAPI,
+) -> None:
+    """The PERSIST half writes the computed dicts to topic_assignments."""
+    from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
+
+    _seed_centroids(db, chroma_client)
+    new_embs = [
+        (np.random.default_rng(2).standard_normal(384).astype(np.float32) * 0.1
+         + np.array([3.0] + [0.0] * 383, dtype=np.float32)).tolist()
+    ]
+    out = CatalogTaxonomy.compute_assignments(
+        "split__coll", ["persist-doc"], new_embs, chroma_client,
+    )
+    n = db.taxonomy.persist_assignments(out)
+    assert n == len(out)
+    row = db.taxonomy.conn.execute(
+        "SELECT doc_id FROM topic_assignments WHERE doc_id='persist-doc'"
+    ).fetchone()
+    assert row is not None
+
+
+def test_assign_batch_still_composes_compute_and_persist(
+    db: T2Database, chroma_client: chromadb.ClientAPI,
+) -> None:
+    """Back-compat: assign_batch == compute_assignments + persist_assignments,
+    same return + same persisted rows (direct callers unchanged)."""
+    from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
+
+    _seed_centroids(db, chroma_client)
+    new_embs = [
+        (np.random.default_rng(3).standard_normal(384).astype(np.float32) * 0.1
+         + np.array([3.0] + [0.0] * 383, dtype=np.float32)).tolist()
+    ]
+    expected = CatalogTaxonomy.compute_assignments(
+        "split__coll", ["batch-doc"], new_embs, chroma_client,
+    )
+    assigned = db.taxonomy.assign_batch(
+        "split__coll", ["batch-doc"], new_embs, chroma_client,
+    )
+    assert assigned == len(expected)
+    row = db.taxonomy.conn.execute(
+        "SELECT doc_id FROM topic_assignments WHERE doc_id='batch-doc'"
+    ).fetchone()
+    assert row is not None
+
+
+def test_compute_assignments_empty_when_no_centroids(
+    db: T2Database, chroma_client: chromadb.ClientAPI,
+) -> None:
+    """No centroids for the collection → empty (the old no-op-returns-0 case)."""
+    from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
+
+    out = CatalogTaxonomy.compute_assignments(
+        "never__discovered", ["x"], [[0.1] * 384], chroma_client,
+    )
+    assert out == []
+
+
 def test_assign_topic(db: T2Database) -> None:
     """Assign a doc_id to a topic."""
     # Create a topic first

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -182,10 +182,15 @@ def test_assign_batch_still_composes_compute_and_persist(
         "split__coll", ["batch-doc"], new_embs, chroma_client,
     )
     assert assigned == len(expected)
+    # Verify the persisted row matches what compute_assignments produced —
+    # not just that "a row exists" (guards against a drift where assign_batch
+    # silently computed something different).
     row = db.taxonomy.conn.execute(
-        "SELECT doc_id FROM topic_assignments WHERE doc_id='batch-doc'"
+        "SELECT topic_id, assigned_by FROM topic_assignments WHERE doc_id='batch-doc'"
     ).fetchone()
     assert row is not None
+    assert row[0] == expected[0]["topic_id"]
+    assert row[1] == expected[0]["assigned_by"]
 
 
 def test_compute_assignments_empty_when_no_centroids(
@@ -198,6 +203,65 @@ def test_compute_assignments_empty_when_no_centroids(
         "never__discovered", ["x"], [[0.1] * 384], chroma_client,
     )
     assert out == []
+
+
+def test_taxonomy_hook_routes_persist_through_t2_index_write(monkeypatch) -> None:
+    """The rerouted taxonomy_assign_batch_hook must compute client-side and
+    persist via t2_index_write (the daemon path), NOT a direct t2_ctx open.
+
+    Without this the hook's new routing is untested — the pre-existing
+    t2_ctx-patching hook tests pass vacuously after the reroute (they don't
+    invoke this hook), so a lambda-scoping / wiring regression would slip
+    through (test-validator finding, fkq5q gate).
+    """
+    import nexus.mcp_infra as mi
+    from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
+
+    computed = [{
+        "doc_id": "d1", "topic_id": 7, "assigned_by": "centroid",
+        "similarity": None, "source_collection": None,
+    }]
+
+    # Bypass chroma: same-collection returns the known list, cross returns [].
+    monkeypatch.setattr(
+        CatalogTaxonomy, "compute_assignments",
+        staticmethod(lambda *a, **k: [] if k.get("cross_collection") else computed),
+    )
+    # The hook does `from nexus.config import is_local_mode` at call time,
+    # so patch the source module (not mcp_infra).
+    import nexus.config as _cfg
+    monkeypatch.setattr(_cfg, "is_local_mode", lambda: False)  # skip exclude gate
+    monkeypatch.setattr(
+        mi, "get_t3", lambda: type("T", (), {"_client": object()})(),
+    )
+
+    captured: dict = {}
+
+    class _FakeTaxonomy:
+        def persist_assignments(self, assignments):  # noqa: ANN001
+            captured["assignments"] = assignments
+            return len(assignments)
+
+    class _FakeDb:
+        taxonomy = _FakeTaxonomy()
+
+    def _spy_index_write(write_fn):  # noqa: ANN001
+        captured["routed"] = True
+        write_fn(_FakeDb())
+
+    monkeypatch.setattr(mi, "t2_index_write", _spy_index_write)
+    monkeypatch.setattr(
+        mi, "t2_ctx",
+        lambda: pytest.fail("hook must route via t2_index_write, not t2_ctx"),
+    )
+
+    mi.taxonomy_assign_batch_hook(
+        doc_ids=["d1"], collection="code__c", contents=["x"],
+        embeddings=[[0.1] * 384], metadatas=None,
+    )
+
+    assert captured.get("routed") is True, "hook must call t2_index_write"
+    assert captured.get("assignments") == computed, "must persist the computed assignments"
 
 
 def test_assign_topic(db: T2Database) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.0.4"
+version = "5.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Promotes `develop` to `main` and bumps to **5.1.0**. The 19 commits since v5.0.4 are entirely **RDR-128: T2 single-writer enforcement** — the root-cause fix for the `database is locked` daemon crash-loop that was band-aided across 5.0.2, 5.0.3, and 5.0.4.

## What changed

- **Routing.** Hot/automated writers now go through the T2 daemon via `mcp_infra.t2_index_write`: the indexer, the aspect-worker poll loop, the SessionEnd flush, and the routable CLI writers (`scratch promote`, `collection delete`/`rename`, `enrich aspects delete`, the `doctor` phase metric). A dead/slow writer can no longer strand the WAL lock for the daemon.
- **Lock-tolerant startup** (P0): the daemon's startup migration uses `busy_timeout=30000` + bounded retry instead of crashing on a transient foreign lock.
- **Lifecycle interlock** (P0): `nx daemon t2 ensure-running` probes DB-acquirability (30s bound) before cycling a stale daemon and aborts on timeout, never trading a working daemon for none.
- **Bootstrap lock discipline** (P2): `nx upgrade` and daemon startup serialize their schema migrations through an exclusive `fcntl.flock`.
- **Enforced boundary** (P3): `nx doctor --check-storage-boundary` now hard-fails any new direct `memory.db` open (raw `sqlite3.connect` or a `T2Database(...)` construction) outside the daemon substrate without a documented `# epsilon-allow:` justification.

No CLI flags changed; the fix is internal to the storage substrate and daemon lifecycle.

## Release prep (this PR)

- Version bumped to 5.1.0 across all 7 manifests + `source.ref` (parity-checked).
- `CHANGELOG.md` + `conexus/CHANGELOG.md` updated; `architecture.md` gains a cross-process single-writer section.
- `uv.lock` refreshed.
- Unit suite (7645 passed) + integration suite (77 passed) green; sandbox smoke `[done]` (37 T2 migrations apply; nx 5.1.0 loads; doctor checks pass).

## Closes

Closes the RDR-128 epic (already closed in beads: nexus-sbxbe). RDR-128 closed implemented.

After merge: tag `v5.1.0` on the merge commit and push (triggers the PyPI publish via OIDC).