### PR TITLE
fix: two 5.1.0 shakeout bugs (find-overlaps recall, threshold zero-hit footer)

### DIFF
--- a/src/nexus/db/t2/memory_store.py
+++ b/src/nexus/db/t2/memory_store.py
@@ -247,6 +247,15 @@ class MemoryStore:
         }
     )
 
+    # nexus-uul2r: at or below this entry count, find_overlapping_memories
+    # compares ALL pairs directly (full recall). Above it, the FTS5 candidate
+    # prefilter (a scaling optimization with bounded recall) kicks in. A single
+    # consolidation project carries well under this many entries, so the common
+    # case always gets full-recall all-pairs; the O(n^2) cost on cached word
+    # sets is milliseconds-to-seconds at this scale and the tool is invoked
+    # deliberately, not in a hot path.
+    _ALL_PAIRS_MAX_ENTRIES = 1000
+
     def __init__(self, path: Path) -> None:
         self._lock = threading.Lock()
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
@@ -757,12 +766,39 @@ class MemoryStore:
                 if len(w) > 2 and w.lower() not in self._STOPWORDS
             }
 
-        seen: set[tuple[int, int]] = set()
+        # Cache each entry's content word-set once (used by both paths).
+        word_sets: list[tuple[dict[str, Any], set[str]]] = [
+            (e, _words(e.get("content", ""))) for e in entries
+        ]
+        word_sets = [(e, w) for e, w in word_sets if w]
+
         pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
 
-        for e1 in entries:
-            # Use first few content words for FTS5 candidate retrieval — AND-of-terms
-            # means too many words kills recall. Jaccard on full content handles precision.
+        # nexus-uul2r: full-recall all-pairs path for normal-sized projects.
+        # The FTS5 prefilter below built an AND-query from each entry's first
+        # 3 non-stopword words, so an overlap whose shared tokens were not
+        # among those leading words was never retrieved as a candidate and
+        # its Jaccard was never computed (5.1.0 shakeout: distinctive shared
+        # token sat at the end of the content). Comparing all pairs directly
+        # restores recall; precision is still the min_similarity Jaccard gate.
+        if len(word_sets) <= self._ALL_PAIRS_MAX_ENTRIES:
+            for i in range(len(word_sets)):
+                e1, w1 = word_sets[i]
+                for j in range(i + 1, len(word_sets)):
+                    e2, w2 = word_sets[j]
+                    jaccard = len(w1 & w2) / len(w1 | w2)
+                    if jaccard >= min_similarity:
+                        pairs.append((e1, e2))
+                        if len(pairs) >= limit:
+                            return pairs
+            return pairs
+
+        # Large-project scaling path: FTS5 candidate prefilter. Recall is
+        # bounded by the candidate snippet (the nexus-uul2r limitation above),
+        # accepted here only because all-pairs would be O(n^2) at this scale.
+        by_id: dict[Any, set[str]] = {e["id"]: w for e, w in word_sets}
+        seen: set[tuple[int, int]] = set()
+        for e1, w1 in word_sets:
             words = [
                 w
                 for w in e1.get("content", "").split()[:5]
@@ -777,9 +813,6 @@ class MemoryStore:
                 candidates = self.search(snippet, project=project, access="silent")
             except ValueError:
                 continue
-            w1 = _words(e1.get("content", ""))
-            if not w1:
-                continue
             for e2 in candidates:
                 if e2["id"] == e1["id"]:
                     continue
@@ -787,7 +820,7 @@ class MemoryStore:
                 if pair_key in seen:
                     continue
                 seen.add(pair_key)
-                w2 = _words(e2.get("content", ""))
+                w2 = by_id.get(e2["id"])
                 if not w2:
                     continue
                 jaccard = len(w1 & w2) / len(w1 | w2)

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -453,6 +453,33 @@ def _record_tier_write(
 # ── Registered tools ─────────────────────────────────────────────────────────
 
 
+def _no_results_message(diagnostics: list, *, base: str = "No results.") -> str:
+    """Surface a threshold-drop instead of a silent zero-hit (nexus-uro6c).
+
+    When the distance threshold dropped EVERY candidate of some collection
+    (``SearchDiagnostics.worst_offender``), report the closest dropped
+    distance + the threshold that blocked it, so the caller can relax the
+    ``threshold`` knob rather than conclude "nothing matched". Falls back to
+    *base* when nothing was dropped — a genuine miss (raw candidate count 0).
+
+    Pure function of the diagnostics list populated by
+    ``search_cross_corpus(diagnostics_out=...)``; the engine itself never
+    emits this (MCP does not write stderr).
+    """
+    if not diagnostics:
+        return base
+    worst = diagnostics[0].worst_offender()
+    if worst is None:
+        return base
+    name, threshold, top_distance = worst
+    thr = f"{threshold:.4f}" if threshold is not None else "the per-corpus default"
+    return (
+        f"{base} Closest candidate was dropped at distance {top_distance:.4f} "
+        f"(threshold {thr}, collection {name}). Re-run with "
+        f"threshold={top_distance + 0.05:.2f} (or higher) to include it."
+    )
+
+
 # Note: catalog server also registers a "search" tool. No collision — Claude Code
 # disambiguates by server prefix (mcp__plugin_conexus_nexus__search vs
 # mcp__plugin_conexus_nexus-catalog__search).
@@ -543,9 +570,11 @@ def search(
         clustered = bool(cluster_by)
         # Always pass taxonomy for topic grouping + topic boost (RDR-070).
         # Wrapped in context manager to avoid connection leak.
+        # nexus-uro6c: capture threshold-filter diagnostics so a silent
+        # zero-hit can surface the closest dropped candidate (the MCP tool
+        # turns it into an actionable message; the engine still emits no stderr).
+        diag: list = []
         with _t2_ctx() as _t2_db:
-            # Note: no ``diagnostics_out`` — MCP does not emit stderr
-            # (RDR-087 Phase 1 scope is CLI-only).
             # ``telemetry`` wired for RDR-087 Phase 2.2 hot-path logging;
             # opt-out via ``telemetry.search_enabled=false`` in .nexus.yml.
             results = search_cross_corpus(
@@ -557,6 +586,7 @@ def search(
                 topic=topic or None,
                 threshold_override=threshold,
                 telemetry=_t2_db.telemetry,
+                diagnostics_out=diag,
             )
         # Only sort by distance for flat (non-clustered) results.
         # Clustered results arrive in cluster-grouped order from search_engine.
@@ -569,7 +599,7 @@ def search(
                     "collections": [], "chunk_collections": [],
                     "chunk_text_hash": [],
                 }
-            return "No results."
+            return _no_results_message(diag)
 
         # Apply pagination
         total = len(results)
@@ -818,6 +848,9 @@ def query(
 
         # Over-fetch chunks to ensure good document coverage
         fetch_n = limit * 10
+        # nexus-uro6c: capture threshold-filter diagnostics to surface a
+        # threshold drop on a zero-hit (same rationale as the search tool).
+        qdiag: list = []
         with _t2_ctx() as _t2_db:
             results = search_cross_corpus(
                 question, target, n_results=fetch_n, t3=t3, where=where_dict,
@@ -825,6 +858,7 @@ def query(
                 link_boost=True,
                 taxonomy=_t2_db.taxonomy,
                 telemetry=_t2_db.telemetry,
+                diagnostics_out=qdiag,
             )
         results.sort(key=lambda r: r.distance)
         if not results:
@@ -834,7 +868,7 @@ def query(
                     "collections": [], "chunk_collections": [],
                     "chunk_text_hash": [],
                 }
-            return "No documents found."
+            return _no_results_message(qdiag, base="No documents found.")
 
         if structured:
             page = results[:limit]

--- a/tests/test_distance_thresholds.py
+++ b/tests/test_distance_thresholds.py
@@ -133,3 +133,40 @@ class TestSearchCrossCorpusThresholdFiltering:
         )
         ids = {r.id for r in results}
         assert ids == {"c1", "k1"}
+
+
+class TestNoResultsMessage:
+    """nexus-uro6c (5.1.0 shakeout): a zero-hit search must surface a
+    threshold drop instead of an undifferentiated 'No results.'."""
+
+    def test_footer_when_all_candidates_dropped(self) -> None:
+        from nexus.mcp.core import _no_results_message
+        from nexus.search_engine import SearchDiagnostics
+
+        # knowledge__papers: raw=3, all 3 dropped, threshold 0.65, closest
+        # dropped candidate at distance 0.5515 (the shakeout's recovered match).
+        diag = SearchDiagnostics(
+            per_collection={"knowledge__papers": (3, 3, 0.65, 0.5515)},
+            total_dropped=3,
+            total_raw=3,
+        )
+        msg = _no_results_message([diag])
+        assert "0.5515" in msg                 # closest dropped distance
+        assert "0.6500" in msg                 # the blocking threshold
+        assert "knowledge__papers" in msg      # which collection
+        assert "threshold=0.60" in msg         # 0.5515 + 0.05 relax hint
+
+    def test_plain_when_no_diagnostics(self) -> None:
+        from nexus.mcp.core import _no_results_message
+
+        assert _no_results_message([]) == "No results."
+
+    def test_plain_when_nothing_dropped(self) -> None:
+        from nexus.mcp.core import _no_results_message
+        from nexus.search_engine import SearchDiagnostics
+
+        # raw=0 => genuine miss, no candidate to surface => base message.
+        diag = SearchDiagnostics(
+            per_collection={"code__x": (0, 0, 0.45, None)},
+        )
+        assert _no_results_message([diag]) == "No results."

--- a/tests/test_memory_consolidation.py
+++ b/tests/test_memory_consolidation.py
@@ -44,6 +44,36 @@ def test_find_overlapping_respects_threshold(db: T2Database) -> None:
     assert len(pairs) == 0
 
 
+def test_find_overlapping_when_shared_tokens_not_in_leading_words(
+    db: T2Database,
+) -> None:
+    """nexus-uul2r (5.1.0 shakeout): overlap must be detected even when the
+    distinctive shared tokens are NOT among an entry's leading words.
+
+    The pre-fix candidate retrieval built an FTS5 AND-query from each
+    entry's first 3 non-stopword words, so an overlapping entry that did
+    not contain those specific leading words was never retrieved as a
+    candidate and its Jaccard was never computed. Here the entries share a
+    high-overlap TAIL ('shared distinctive tokens trail zephyranth orchard
+    meadow') but have disjoint leading words, so the old code returned
+    empty.
+    """
+    db.put(
+        project="proj", title="alpha",
+        content="Leading words here padding clause. "
+                "Shared distinctive tokens trail: zephyranth orchard meadow.",
+    )
+    db.put(
+        project="proj", title="beta",
+        content="Different opening segment altogether. "
+                "Shared distinctive tokens trail: zephyranth orchard meadow.",
+    )
+    # The shared tail gives Jaccard well above 0.3 on the content word sets.
+    pairs = db.find_overlapping_memories("proj", min_similarity=0.3)
+    assert len(pairs) == 1
+    assert {pairs[0][0]["title"], pairs[0][1]["title"]} == {"alpha", "beta"}
+
+
 # ── merge ───────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Two pre-existing bugs surfaced by the Desktop-chat 5.1.0 shakeout (neither an RDR-128/5.1.0 regression). Fixes are TDD-first; targeted suites green (consolidation 29, thresholds 17, plus search-engine/mcp-server/memory/search-cmd/t2 adjacent — 168+ pass).

## Issue 1 — `memory_consolidate find-overlaps` missed real overlaps (`nexus-uul2r`)
`find_overlapping_memories` built an FTS5 AND-query from each entry's first 3 non-stopword words and only ran Jaccard on those candidates, so an overlap whose shared tokens weren't among the leading words was never retrieved (shakeout: distinctive token sat at the end of the content). Added a full-recall all-pairs path for projects ≤ `_ALL_PAIRS_MAX_ENTRIES` (1000); kept the FTS prefilter only as a large-project scaling fallback. Test: shared tokens in the tail, disjoint leading words.

## Issue 2 — silent threshold zero-hit (`nexus-uro6c`)
`search`/`query` returned a bare "No results." when the distance threshold dropped every candidate. Now capture `SearchDiagnostics` and surface the closest dropped distance + the blocking threshold + collection, with a `threshold=` re-run hint (`_no_results_message` helper, wired into both tools). Falls back to the plain message on a genuine miss (raw=0). Test: helper logic over a worst-offender diagnostic.

## Closes
Closes #nexus-uul2r, #nexus-uro6c (bead refs; T2 report nexus/shakeout-510-issues)