### PR TITLE
fix: bug-bash batch (5 quick wins + e2e shakeout gate)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -73,6 +73,17 @@ Required for any change touching `pyproject.toml`, `uv.lock`, `src/nexus/db/migr
 
 Must end with `[done]` and confirm the new schema version. Halt on any failure.
 
+### 6b. Run upgrade-shakeout (~3-5 min, conditional)
+
+Required when the release touches the **upgrade path** an installed user traverses: hook stanzas (`src/nexus/commands/hooks.py`), the `nx doctor` drift checks, plugin name / marketplace.json `source.ref` pinning, or any migration touchpoint. `release-sandbox.sh smoke` tests one version in isolation; this tests `FROM_VERSION` to this branch.
+
+```bash
+./tests/e2e/upgrade-shakeout.sh run                       # latest stable -> this branch (clean-upgrade path)
+./tests/e2e/upgrade-shakeout.sh run --from-version 4.34.6 # pre-pgrep-guard baseline -> exercises drift -> reconcile
+```
+
+Runnable from any baseline (nexus-a3nqp): it detects stanza drift at runtime and cross-checks `nx doctor`'s drift claim against the actual stanza byte-diff, so a doctor false-positive/negative fails the run. Must end with `12/12 PASS`. `./tests/e2e/upgrade-shakeout.sh reset` cleans the sandbox.
+
 ### 7. Commit on a release branch + PR to main (nexus-mkj6u: replaces direct-to-main)
 
 Per the marketplace-pinned-source playbook (also used by `Hellblazer/palinex`), release commits go through a PR. CI gates the bump before it lands on main. No more direct-to-main exception.

--- a/src/nexus/catalog/orphan_backfill.py
+++ b/src/nexus/catalog/orphan_backfill.py
@@ -303,6 +303,22 @@ def classify_groups(
     return matched, low_conf, unmatched
 
 
+def _content_type_for_collection(collection: str) -> str:
+    """Infer the catalog content_type from a collection's RDR-103 prefix.
+
+    Conformant collection names are ``<content_type>__<owner>__<embed>__v<n>``
+    (RDR-103), so the leading segment IS the content_type (``code`` /
+    ``knowledge`` / ``rdr`` / ``docs`` / ...). nexus-s5le: orphan-backfill
+    previously hardcoded ``"pdf"`` on every synthesized row regardless of
+    corpus, so those rows never matched a ``content_type=`` catalog filter for
+    their real corpus (the canonical query types are code/paper/rdr/knowledge/
+    docs, not pdf). Falls back to ``"knowledge"`` for a non-conformant name
+    with no prefix.
+    """
+    prefix = collection.split("__", 1)[0].strip()
+    return prefix or "knowledge"
+
+
 def register_dt_linked(
     catalog: "Catalog",
     owner: "Tumbler",
@@ -317,7 +333,7 @@ def register_dt_linked(
         tumbler = catalog.register(
             owner,
             title=m.title,
-            content_type="pdf",
+            content_type=_content_type_for_collection(collection),
             file_path="",
             physical_collection=collection,
             chunk_count=len(m.chunks),
@@ -389,7 +405,7 @@ def register_synthetic(
             tumbler = catalog.register(
                 owner,
                 title=title,
-                content_type="pdf",
+                content_type=_content_type_for_collection(collection),
                 file_path="",
                 physical_collection=collection,
                 chunk_count=len(g.chunks),
@@ -410,7 +426,7 @@ def register_synthetic(
                 tumbler = catalog.register(
                     owner,
                     title=title,
-                    content_type="pdf",
+                    content_type=_content_type_for_collection(collection),
                     file_path="",
                     physical_collection=collection,
                     chunk_count=1,
@@ -530,7 +546,7 @@ def apply_csv(
             tumbler = catalog.register(
                 owner,
                 title=title,
-                content_type="pdf",
+                content_type=_content_type_for_collection(collection),
                 file_path="",
                 physical_collection=collection,
                 chunk_count=len(chunks),

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -503,6 +503,41 @@ def _collections_from_registry_info(info: dict) -> list[str]:
     return collections
 
 
+def _project_cross_collections(
+    taxonomy: Any,
+    collections: list[str],
+    chroma_client: Any,
+    *,
+    threshold: float = 0.85,
+) -> int:
+    """Project each collection against the others and persist the assignments.
+
+    Returns the total number of cross-collection assignments persisted.
+
+    nexus-g25dk: ``_persist_assignments`` requires ``source_collection`` as a
+    3rd positional. The previous inline call omitted it, raising a TypeError
+    that the caller's ``except`` swallowed, so the auto-discover projection
+    pass silently persisted nothing. Extracted here so the call is unit-tested
+    (the bug shipped because it was untested inline). Each collection's
+    assignments are stamped with that collection as the source.
+    """
+    from nexus.commands.taxonomy_cmd import _persist_assignments
+
+    total = 0
+    for col_name in collections:
+        others = [c for c in collections if c != col_name]
+        if not others:
+            continue
+        result = taxonomy.project_against(
+            col_name, others, chroma_client, threshold=threshold,
+        )
+        assignments = result.get("chunk_assignments", [])
+        if assignments:
+            _persist_assignments(taxonomy, assignments, col_name, quiet=True)
+            total += len(assignments)
+    return total
+
+
 def run_collection_postprocessing(
     collections: list[str],
     *,
@@ -576,18 +611,9 @@ def run_collection_postprocessing(
                     )
                 # Cross-collection projection pass (RDR-075 SC-7)
                 try:
-                    proj_total = 0
-                    for col_name in collections:
-                        others = [c for c in collections if c != col_name]
-                        if others:
-                            result = db.taxonomy.project_against(
-                                col_name, others, t3._client, threshold=0.85,
-                            )
-                            assignments = result.get("chunk_assignments", [])
-                            if assignments:
-                                from nexus.commands.taxonomy_cmd import _persist_assignments
-                                _persist_assignments(db.taxonomy, assignments, quiet=True)
-                                proj_total += len(assignments)
+                    proj_total = _project_cross_collections(
+                        db.taxonomy, collections, t3._client,
+                    )
                     if proj_total:
                         _say(f"  Project:  {proj_total} cross-collection assignments.")
                 except Exception:

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -766,12 +766,40 @@ def _catalog_hook(
 
         # Housekeeping: detect and evict orphaned catalog entries
         _progress(f"  Catalog: housekeeping…\r")
-        indexed_set = {str(abs_path.relative_to(repo)) for abs_path, _, _ in indexed_files}
+        indexed_set = _indexed_relpaths(indexed_files, repo)
         _run_housekeeping(cat, owner, indexed_set)
         _progress(f"  Catalog: done ({len(new_tumblers)} new, {links_created} links)\n")
     except Exception:
         _log.debug("catalog_hook_failed", exc_info=True)
     return file_to_doc_id
+
+
+def _indexed_relpaths(indexed_files: list, repo: "Path") -> set[str]:
+    """Repo-relative paths of the indexed files, tolerant of symlink mismatch.
+
+    nexus-f3tyz: a single ``abs_path.relative_to(repo)`` ValueError (macOS
+    symlinks ``/tmp`` -> ``/private/tmp`` and ``/var`` -> ``/private/var`` make
+    one path not literally under ``repo``) previously aborted the whole
+    housekeeping set-comprehension, so ``_run_housekeeping`` was silently
+    skipped and orphaned catalog rows never got evicted. Fall back to comparing
+    resolved paths (the relative suffix is identical, so the key stays
+    consistent with registration); skip a genuinely-outside-repo path rather
+    than abort the whole pass.
+    """
+    repo_resolved = repo.resolve()
+    out: set[str] = set()
+    for abs_path, _c1, _c2 in indexed_files:
+        try:
+            out.add(str(abs_path.relative_to(repo)))
+        except ValueError:
+            try:
+                out.add(str(abs_path.resolve().relative_to(repo_resolved)))
+            except ValueError:
+                _log.debug(
+                    "housekeeping_rel_path_skip",
+                    path=str(abs_path), repo=str(repo),
+                )
+    return out
 
 
 def _run_housekeeping(

--- a/tests/e2e/upgrade-shakeout.sh
+++ b/tests/e2e/upgrade-shakeout.sh
@@ -5,14 +5,18 @@
 #   1. Tear down + create a fresh sandbox HOME.
 #   2. uv tool install conexus==<FROM_VERSION> from PyPI (the live shipped
 #      version).
-#   3. nx hooks install — writes the OLD stanza (pre-pgrep-guard).
+#   3. nx hooks install — writes the baseline stanza (may or may not predate
+#      the pgrep guard, depending on FROM_VERSION).
 #   4. Inspect marketplace.json + hook stanza + verify pre-upgrade state.
 #   5. uv tool install --reinstall from REPO_ROOT (the upgrade-under-test).
 #   6. nx --version — confirm the new wheel is installed.
-#   7. nx doctor — verify the stanza-drift health-check surfaces a warning
-#      naming `nx hooks update`.
-#   8. nx hooks update — verify the hook stanza is refreshed with the new
-#      pgrep guard.
+#   7. nx doctor — capture whether the stanza-drift health-check fires, then
+#      run `nx hooks update` and cross-check that doctor's drift claim agrees
+#      with whether the stanza bytes actually changed (nexus-a3nqp). This
+#      makes the test runnable from any baseline: a pre-guard baseline
+#      exercises the drift→reconcile path, the latest stable exercises the
+#      clean-no-op path, and a doctor false-positive/negative fails the run.
+#   8. nx hooks update — verify the hook stanza is refreshed / idempotent.
 #   9. Inspect marketplace.json + plugin.json — verify the rename took
 #      effect (nx -> conexus).
 #  10. Final assertion summary.
@@ -38,6 +42,8 @@
 #
 # Defaults:
 #   FROM_VERSION = the highest stable conexus on PyPI at script start.
+#                  Runnable from any baseline; pass --from-version 4.34.6 to
+#                  exercise the pre-pgrep-guard drift→reconcile path explicitly.
 
 set -euo pipefail
 
@@ -118,17 +124,22 @@ uv tool install "conexus==$FROM_VERSION" --reinstall >/dev/null 2>&1 \
 _pass "installed: $(nx --version)"
 [[ "$(nx --version)" == *"$FROM_VERSION"* ]] || _die "version mismatch after install"
 
-# ── 3. Install hooks (OLD stanza) ────────────────────────────────────────────
-_step "3/10 nx hooks install (writes OLD stanza)"
+# ── 3. Install hooks (baseline stanza) ───────────────────────────────────────
+_step "3/12 nx hooks install (writes the baseline stanza)"
 # Run inside fakerepo so the hook lands in fakerepo/.git/hooks
 (cd "$FAKE_REPO" && git init -q && git config user.email t@t.invalid && git config user.name T)
 HOME="$SANDBOX" nx hooks install "$FAKE_REPO" >/dev/null
 HOOK_OLD=$(cat "$FAKE_REPO/.git/hooks/post-commit")
-echo "$HOOK_OLD" | grep -q '# >>> nexus managed begin >>>' || _die "OLD hook missing sentinel"
+echo "$HOOK_OLD" | grep -q '# >>> nexus managed begin >>>' || _die "baseline hook missing sentinel"
+# The pgrep guard shipped in 5.0.1; whether the baseline already carries it
+# depends on FROM_VERSION. Do NOT presume a pre-guard baseline — the script
+# detects stanza drift at runtime (step 7) so it stays runnable from any
+# baseline, including the latest stable. (nexus-a3nqp)
 if echo "$HOOK_OLD" | grep -q 'pgrep -f'; then
-    _die "OLD hook already has pgrep guard — wrong baseline version?"
+    _pass "baseline stanza installed (already has pgrep guard — expecting a clean upgrade)"
+else
+    _pass "baseline stanza installed (pre-pgrep-guard — expecting drift on upgrade)"
 fi
-_pass "OLD stanza installed (no pgrep guard, as expected)"
 
 # ── 4. Pre-upgrade snapshot ──────────────────────────────────────────────────
 _step "4/10 Pre-upgrade state snapshot"
@@ -147,29 +158,57 @@ NEW_VER="$(nx --version | awk '{print $NF}')"
 _pass "upgraded: $(nx --version)"
 [[ "$NEW_VER" != "$FROM_VERSION" ]] || echo "    (note: REPO_ROOT version == FROM_VERSION; rename may still differ)"
 
-# ── 6. nx doctor surfaces stanza drift ───────────────────────────────────────
-_step "6/10 nx doctor should report stanza drift"
+# ── 6. nx doctor drift report (captured; cross-checked in step 7) ─────────────
+_step "6/12 nx doctor stanza-drift report (captured for cross-check)"
 DOCTOR_OUT="$(HOME="$SANDBOX" nx doctor 2>&1 || true)"
-echo "$DOCTOR_OUT" | grep -qi 'stanza drift' \
-    || _die "nx doctor did not surface stanza drift warning. Output:\n$DOCTOR_OUT"
-echo "$DOCTOR_OUT" | grep -q 'nx hooks update' \
-    || _die "doctor warning missing 'nx hooks update' fix suggestion"
-_pass "drift warning present + names 'nx hooks update' as the fix"
+if echo "$DOCTOR_OUT" | grep -qi 'stanza drift'; then
+    DRIFT_REPORTED=1
+    echo "$DOCTOR_OUT" | grep -q 'nx hooks update' \
+        || _die "doctor reported drift but omitted the 'nx hooks update' fix suggestion"
+    _pass "doctor reports stanza drift + names 'nx hooks update' as the fix"
+else
+    DRIFT_REPORTED=0
+    _pass "doctor reports no stanza drift"
+fi
 
-# ── 7. nx hooks update refreshes stanza ──────────────────────────────────────
-_step "7/10 nx hooks update should add pgrep guard"
+# ── 7. nx hooks update + drift cross-check ───────────────────────────────────
+_step "7/12 nx hooks update refreshes the stanza in place"
 HOME="$SANDBOX" nx hooks update "$FAKE_REPO" >/dev/null
 HOOK_NEW=$(cat "$FAKE_REPO/.git/hooks/post-commit")
-echo "$HOOK_NEW" | grep -q 'pgrep -f' \
-    || _die "after update, hook stanza still missing pgrep guard"
 echo "$HOOK_NEW" | grep -q '# >>> nexus managed begin >>>' \
     || _die "after update, sentinel block missing"
 SENTINEL_COUNT=$(echo "$HOOK_NEW" | grep -c '# >>> nexus managed begin >>>' || true)
 [[ "$SENTINEL_COUNT" == "1" ]] || _die "expected 1 sentinel block, found $SENTINEL_COUNT"
-_pass "pgrep guard now present (single sentinel block, no duplication)"
+
+# Cross-check the two INDEPENDENT drift signals: what nx doctor claimed
+# (DRIFT_REPORTED, step 6) must agree with whether the stanza bytes actually
+# changed on update (STANZA_CHANGED). This catches both doctor false-negatives
+# (claims clean, stanza changed) and false-positives (claims drift, no change)
+# without presuming any particular baseline version. (nexus-a3nqp)
+if [[ "$HOOK_NEW" != "$HOOK_OLD" ]]; then STANZA_CHANGED=1; else STANZA_CHANGED=0; fi
+[[ "$STANZA_CHANGED" == "$DRIFT_REPORTED" ]] || _die \
+    "drift signal mismatch: nx doctor DRIFT_REPORTED=$DRIFT_REPORTED but actual STANZA_CHANGED=$STANZA_CHANGED"
+
+if [[ "$STANZA_CHANGED" == "1" ]]; then
+    # When the baseline predated the pgrep guard, the refreshed stanza must
+    # now carry it — the concrete 5.0.1 migration this script was born to guard.
+    if ! echo "$HOOK_OLD" | grep -q 'pgrep -f'; then
+        echo "$HOOK_NEW" | grep -q 'pgrep -f' \
+            || _die "stanza changed but pgrep guard still absent after update"
+    fi
+    _pass "stanza drift detected + reconciled (doctor and byte-diff agree)"
+else
+    _pass "no stanza drift (update is a clean no-op; doctor and byte-diff agree)"
+fi
+
+# Idempotency: a second update must not change the stanza further.
+HOME="$SANDBOX" nx hooks update "$FAKE_REPO" >/dev/null
+HOOK_NEW2=$(cat "$FAKE_REPO/.git/hooks/post-commit")
+[[ "$HOOK_NEW2" == "$HOOK_NEW" ]] || _die "nx hooks update is not idempotent (second run changed the stanza)"
+_pass "nx hooks update is idempotent"
 
 # ── 8. nx doctor: drift resolved ─────────────────────────────────────────────
-_step "8/10 nx doctor should NOT report drift after update"
+_step "8/12 nx doctor should NOT report drift after update"
 DOCTOR_OUT="$(HOME="$SANDBOX" nx doctor 2>&1 || true)"
 if echo "$DOCTOR_OUT" | grep -qi 'stanza drift'; then
     _die "drift warning persists after nx hooks update. Output:\n$DOCTOR_OUT"
@@ -177,7 +216,7 @@ fi
 _pass "drift resolved"
 
 # ── 9. Plugin rename + tag-pin surface (marketplace.json) ────────────────────
-_step "9/11 plugin marketplace.json reflects rename + tag pinning"
+_step "9/12 plugin marketplace.json reflects rename + tag pinning"
 MJ="$REPO_ROOT/.claude-plugin/marketplace.json"
 # Plugin name = conexus
 grep -q '"name": "conexus"' "$MJ" \
@@ -203,7 +242,7 @@ print('  all plugins: git-subdir source + ref pinned to v{version}')
 _pass "marketplace.json: rename (conexus) + tag pinning (git-subdir + ref=v\$version)"
 
 # ── 10. Plugin-name drift detection (nexus-mkj6u) ────────────────────────────
-_step "10/11 plugin-name drift detected when OLD nx plugin still installed"
+_step "10/12 plugin-name drift detected when OLD nx plugin still installed"
 # Simulate the user's "ran uv tool upgrade but didn't reinstall plugin"
 # state by planting a fake CLAUDE_PLUGIN_ROOT with name=nx.
 FAKE_PLUGIN_ROOT="$SANDBOX/fake_plugin_root"
@@ -250,9 +289,13 @@ fi
 # ── 12. Summary ──────────────────────────────────────────────────────────────
 _step "12/12 PASS"
 echo "  Upgrade-shakeout green: $FROM_VERSION → $NEW_VER"
-echo "  - hook stanza migrated (pgrep guard added, no pile-up risk)"
-echo "  - nx doctor drift detection works"
-echo "  - nx hooks update refreshes in-place"
+if [[ "$STANZA_CHANGED" == "1" ]]; then
+    echo "  - hook stanza drift detected + reconciled (doctor + byte-diff agree)"
+else
+    echo "  - hook stanza unchanged across upgrade (clean no-op; doctor + byte-diff agree)"
+fi
+echo "  - nx doctor drift detection works (cross-checked against actual diff)"
+echo "  - nx hooks update refreshes in-place + is idempotent"
 echo "  - plugin rename visible in marketplace.json"
 echo
 echo "Sandbox preserved at $SANDBOX (inspect, then '$0 reset' to remove)"

--- a/tests/test_catalog_graph_many.py
+++ b/tests/test_catalog_graph_many.py
@@ -29,6 +29,23 @@ def _git_identity(monkeypatch):
     monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
 
 
+@pytest.fixture(autouse=True)
+def _pin_node_cap(monkeypatch):
+    """nexus-1endg: pin the graph node cap so these boundary tests are
+    order-independent.
+
+    ``_MAX_GRAPH_NODES`` is a ``Catalog`` CLASS attribute that
+    ``graph_many`` reads via ``getattr(cat, "_MAX_GRAPH_NODES", ...)``
+    (catalog_links.py). ``test_catalog_links`` patches it to ``1`` for its
+    own assertion; under full-suite ordering that value bled into these
+    tests (which assume 500), failing the boundary count only in the
+    combined run, never in isolation. Pinning here makes every test in this
+    file see exactly 500 regardless of ambient state; ``monkeypatch.setattr``
+    restores the prior value afterwards.
+    """
+    monkeypatch.setattr(Catalog, "_MAX_GRAPH_NODES", 500)
+
+
 def _make_node(tumbler_str: str) -> MagicMock:
     """Return a fake catalog node with a .tumbler attribute."""
     node = MagicMock()
@@ -76,9 +93,11 @@ class TestGraphManyNodeCap:
         with patch.object(cat, "graph", side_effect=fake_graph):
             result = cat.graph_many(seeds, depth=1)
 
-        assert len(result["nodes"]) <= Catalog._MAX_GRAPH_NODES, (
-            f"graph_many returned {len(result['nodes'])} nodes, "
-            f"expected ≤ {Catalog._MAX_GRAPH_NODES}"
+        # Exact (not <=): 300 + 300 distinct fake nodes, deduped, capped at the
+        # pinned 500 → exactly 500. An inequality would silently pass under the
+        # leaked-cap contamination this test guards against (nexus-1endg).
+        assert len(result["nodes"]) == 500, (
+            f"graph_many returned {len(result['nodes'])} nodes, expected exactly 500"
         )
         assert call_count[0] == 2, "Both seeds must be dispatched (cap fires mid-merge)"
 

--- a/tests/test_catalog_indexer_hook.py
+++ b/tests/test_catalog_indexer_hook.py
@@ -356,3 +356,39 @@ class TestCatalogHookForeignCwd:
         # the foreign CWD.
         assert str(repo) in entry.source_uri
         assert str(foreign_cwd) not in entry.source_uri
+
+
+def test_indexed_relpaths_tolerates_symlinked_repo(tmp_path: Path) -> None:
+    """nexus-f3tyz: a symlink mismatch (file under the real dir, repo passed as
+    a symlink to it) must not abort the indexed-path set. The pre-fix
+    comprehension raised ValueError on the first such path, which the caller's
+    except swallowed, silently skipping _run_housekeeping (orphan eviction)."""
+    import os
+
+    from nexus.indexer import _indexed_relpaths
+
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "a.py").write_text("x")
+    link = tmp_path / "link"
+    os.symlink(real, link)
+
+    abs_path = real / "a.py"
+    # abs_path.relative_to(link) raises ValueError; the resolve-fallback recovers.
+    assert _indexed_relpaths([(abs_path, None, None)], link) == {"a.py"}
+
+
+def test_indexed_relpaths_skips_outside_repo_without_aborting(tmp_path: Path) -> None:
+    """A genuinely-outside-repo path is skipped, not raised — the rest of the
+    set (and thus housekeeping) still runs."""
+    from nexus.indexer import _indexed_relpaths
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "in.py").write_text("x")
+    outside = tmp_path / "elsewhere" / "out.py"
+
+    result = _indexed_relpaths(
+        [(repo / "in.py", None, None), (outside, None, None)], repo,
+    )
+    assert result == {"in.py"}

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -565,3 +565,44 @@ def test_debug_timing_absent_emits_no_breakdown(runner, repo_dir, mock_reg):
     assert result.exit_code == 0
     assert "debug-timing" not in result.output
     assert "per-stage totals" not in result.output
+
+
+def test_project_cross_collections_passes_source_collection() -> None:
+    """nexus-g25dk: the auto-discover cross-collection projection persist must
+    pass source_collection. The old inline call omitted it, so
+    _persist_assignments raised TypeError (swallowed by the caller's except)
+    and the projection silently persisted nothing."""
+    from nexus.commands.index import _project_cross_collections
+
+    recorded: list[tuple] = []
+
+    class _FakeTaxonomy:
+        def project_against(self, col, others, chroma_client, threshold=0.85):
+            # One assignment per projection call.
+            return {"chunk_assignments": [("doc-1", 7, 0.9)]}
+
+        def assign_topic(self, doc_id, topic_id, *, assigned_by,
+                         similarity, source_collection):
+            recorded.append((doc_id, topic_id, source_collection))
+
+        def refresh_projection_links(self):
+            pass
+
+    total = _project_cross_collections(
+        _FakeTaxonomy(), ["code__a", "code__b"], chroma_client=None,
+    )
+    # a-vs-b and b-vs-a each persist one assignment.
+    assert total == 2
+    # Each persisted assignment is stamped with its own source collection.
+    assert {r[2] for r in recorded} == {"code__a", "code__b"}
+
+
+def test_project_cross_collections_single_collection_noop() -> None:
+    """A lone collection has no 'others' to project against → 0, no persist."""
+    from nexus.commands.index import _project_cross_collections
+
+    class _FakeTaxonomy:
+        def project_against(self, *a, **k):  # pragma: no cover - must not be called
+            raise AssertionError("project_against should not run with no others")
+
+    assert _project_cross_collections(_FakeTaxonomy(), ["only__one"], None) == 0

--- a/tests/test_orphan_backfill.py
+++ b/tests/test_orphan_backfill.py
@@ -346,3 +346,20 @@ class TestGatherTitledChunks:
         })
         groups = ob.gather_titled_chunks(t3, "x")
         assert groups[0].chunks[0].chash == ("abcdefghij" * 4)[:32]
+
+
+def test_content_type_inferred_from_collection_prefix() -> None:
+    """nexus-s5le: synthesized orphan-backfill rows take their content_type
+    from the collection's RDR-103 leading segment, not a hardcoded 'pdf'
+    (which never matched a content_type= catalog filter for the real corpus)."""
+    from nexus.catalog.orphan_backfill import _content_type_for_collection
+
+    assert _content_type_for_collection("code__nexus__voyage-code-3__v1") == "code"
+    assert _content_type_for_collection(
+        "knowledge__delos__voyage-context-3__v1"
+    ) == "knowledge"
+    assert _content_type_for_collection("rdr__nexus__voyage-context-3__v1") == "rdr"
+    assert _content_type_for_collection("docs__corpus__voyage-context-3__v1") == "docs"
+    # Non-conformant name with an empty prefix falls back; never the old 'pdf'.
+    assert _content_type_for_collection("__weird") == "knowledge"
+    assert _content_type_for_collection("code__x") != "pdf"

--- a/tests/test_orphan_backfill.py
+++ b/tests/test_orphan_backfill.py
@@ -354,12 +354,17 @@ def test_content_type_inferred_from_collection_prefix() -> None:
     (which never matched a content_type= catalog filter for the real corpus)."""
     from nexus.catalog.orphan_backfill import _content_type_for_collection
 
-    assert _content_type_for_collection("code__nexus__voyage-code-3__v1") == "code"
+    # The embedder segment is a neutral placeholder ("embed3"), not the real
+    # voyage-*-3 model name: the function only inspects the leading "__"
+    # segment, so the embedder is incidental here, and a literal voyage token
+    # would trip the RDR-109 cloud-mode lint (test_mode_declarations_are_explicit)
+    # for a test that never touches cloud-mode state.
+    assert _content_type_for_collection("code__nexus__embed3__v1") == "code"
     assert _content_type_for_collection(
-        "knowledge__delos__voyage-context-3__v1"
+        "knowledge__delos__embed3__v1"
     ) == "knowledge"
-    assert _content_type_for_collection("rdr__nexus__voyage-context-3__v1") == "rdr"
-    assert _content_type_for_collection("docs__corpus__voyage-context-3__v1") == "docs"
+    assert _content_type_for_collection("rdr__nexus__embed3__v1") == "rdr"
+    assert _content_type_for_collection("docs__corpus__embed3__v1") == "docs"
     # Non-conformant name with an empty prefix falls back; never the old 'pdf'.
     assert _content_type_for_collection("__weird") == "knowledge"
     assert _content_type_for_collection("code__x") != "pdf"

--- a/tests/test_phase5_doc_cite.py
+++ b/tests/test_phase5_doc_cite.py
@@ -35,13 +35,30 @@ def _parse_json_payload(stdout: str) -> dict:
     one-shot through pre-consumption.
 
     Strategy: find the first ``{`` (the JSON payload always starts with
-    an object) and parse from there.
+    an object) and ``raw_decode`` from there. ``raw_decode`` parses the
+    first JSON value and ignores any trailing text, so a structlog/warning
+    line landing AFTER the payload (stderr merged into stdout under
+    CliRunner) no longer raises 'Extra data' (nexus-xdt7o); leading lines
+    are skipped by the ``find('{')`` offset.
     """
     idx = stdout.find("{")
     if idx == -1:
         # No JSON object — let json.loads raise the standard error.
         return json.loads(stdout)
-    return json.loads(stdout[idx:])
+    obj, _end = json.JSONDecoder().raw_decode(stdout[idx:])
+    return obj
+
+
+def test_parse_json_payload_tolerates_surrounding_log_lines() -> None:
+    """nexus-xdt7o: a log line BEFORE and AFTER the JSON payload must both be
+    tolerated. The pre-fix helper json.loads'd from the first '{' to EOF, so a
+    trailing structlog/warning line raised 'Extra data'."""
+    payload = (
+        "2026-01-01 warning event='leading_one_shot' level='warning'\n"
+        '{"results": [1, 2, 3], "ok": true}\n'
+        "2026-01-01 warning event='trailing_one_shot' level='warning'\n"
+    )
+    assert _parse_json_payload(payload) == {"results": [1, 2, 3], "ok": True}
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Contained, pre-existing bugs from the open-bug grooming, all TDD with regression tests. None are 5.1.0 regressions. Affected test files: 95 pass together.

| Bead | Bug | Fix |
|------|-----|-----|
| `g25dk` | `index.py` auto-discover projection passed no `source_collection` -> TypeError swallowed -> silent no-op | extracted `_project_cross_collections` (now unit-tested), pass `col_name` |
| `xdt7o` | `_parse_json_payload` choked on log lines *after* the JSON | `JSONDecoder().raw_decode` (ignores trailing text) |
| `s5le` | `orphan_backfill` hardcoded `content_type='pdf'` for all rows | infer from RDR-103 collection prefix (`_content_type_for_collection`) |
| `f3tyz` | macOS symlink `ValueError` in `relative_to` aborted housekeeping -> no orphan eviction | extracted `_indexed_relpaths` with resolve-fallback per path |
| `1endg` | order-dependent flake: `_MAX_GRAPH_NODES` patched to 1 by `test_catalog_links` bled in | autouse fixture pins cap per-test; exact `== 500` assertion |
| `a3nqp` | `upgrade-shakeout.sh` step-3 gate hard-failed on any baseline >= 5.0.1 (pgrep guard already present); FROM_VERSION defaults to latest stable so the script was unrunnable | detect stanza drift at runtime; cross-check `nx doctor`'s claim against the actual stanza byte-diff. Verified both paths: 5.1.0->5.1.0 (no-op) and 4.34.6->5.1.0 (drift), 12/12 each |

Also closed during this grooming pass: **nexus-uym4** (P2) as **stale** — its `setup_cmd` init->open_catalog TOCTOU race traces to scrapped RDR-112 and hinges on an `open_catalog` daemon-aware opener that was never built. `setup_cmd` uses a single direct `Catalog(path, .catalog.db)`; no second opener to race. No code change.

## Beads
Closes at merge: nexus-g25dk, nexus-xdt7o, nexus-s5le, nexus-f3tyz, nexus-1endg, nexus-a3nqp. (nexus-uym4 closed separately as stale.)