### PR TITLE
release: conexus 5.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.1.1"
+        "ref": "v5.1.2"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.1.1"
+      "version": "5.1.2"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.1.1"
+        "ref": "v5.1.2"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.1.1"
+      "version": "5.1.2"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.1.2] - 2026-05-26
+
+Bug-fix release. Completes the nexus-t1b1k fix from 5.1.1, which did not actually take effect, and fixes project-type detection exposed by it.
+
+### Fixed
+
+- **conexus slash commands execute their context preamble again (nexus-ln9y5).** Every command injected its preamble via a `!{ ... }` brace block. That is not a Claude Code bash-injection syntax: only inline backtick `` !`cmd` `` and the multi-line fenced ` ```! ` block execute, and the brace form is emitted as raw source. The 5.1.1 fix (nexus-t1b1k) kept the `!{ }` wrapper and only moved heredocs to scripts, so the preambles still never ran; the by-path form additionally failed because `$CLAUDE_PLUGIN_ROOT` is empty in the command-bash context. All 25 commands now use the documented fenced form. The 9 RDR-lifecycle preambles inline their script, kept byte-synced to `resources/rdr_commands/*.py`. Validated end to end against a real Claude Code (cc-validation scenario 19).
+- **Agent-relay project-type detection covers ~21 ecosystems (nexus-ln9y5).** `analyze-code`, `architecture`, `create-plan`, and `implement` carried four inconsistent detectors that recognized only Maven, Gradle, and Node, so they labeled Python repos "Unknown" or emitted nothing. They now share one marker-file detector (Python, Rust, Go, Node/TypeScript, Java/Kotlin Maven and Gradle, Ruby, PHP, C#/.NET, C/C++, Swift, Elixir, Scala, Dart/Flutter, Clojure, Haskell, Julia, R, Zig, OCaml, Crystal) that lists every match.
+
+### Internal / test hardening
+
+- Render-path coverage the prior fix lacked: cc-validation scenario 19 drives a real Claude Code and asserts the fenced block renders while a `!{ }` probe does not. `test_command_preamble_sync` enforces md-to-script sync and executes every block; `test_command_bash_uses_documented_syntax` replaces the vacuous heredoc guard; `test_project_detector_identifies_python` locks in the detector fix.
+
 ## [5.1.1] - 2026-05-26
 
 Bug-fix rollup of post-5.1.0 shakeout and grooming. No new features, no breaking changes.

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.1.2] - 2026-05-26
+
+### Fixed
+
+- **All slash commands execute their context preamble again (nexus-ln9y5).** The 5.1.1 fix (nexus-t1b1k) did not take effect: every command still wrapped its preamble in a `!{ ... }` brace block, which is not a recognized Claude Code bash-injection syntax (only inline backtick `` !`cmd` `` and the fenced ` ```! ` block execute), so the brace form was emitted as raw source and the preamble never ran. Moving heredocs to scripts in 5.1.1 also introduced a by-path failure because `$CLAUDE_PLUGIN_ROOT` is empty in the command-bash context. All 25 commands now use the documented fenced form; the 9 RDR-lifecycle preambles inline their script (byte-synced to `resources/rdr_commands/*.py`). Verified against a real Claude Code by cc-validation scenario 19.
+- **Project-type detection in `analyze-code`, `architecture`, `create-plan`, and `implement` now spans ~21 ecosystems (nexus-ln9y5).** The four ad-hoc detectors recognized only Maven, Gradle, and Node, mislabeling Python projects "Unknown". One shared marker-file detector now lists every detected stack.
+
 ## [5.1.1] - 2026-05-26
 
 ### Fixed

--- a/conexus/commands/analyze-code.md
+++ b/conexus/commands/analyze-code.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Analyze codebase using codebase-deep-analyzer agent
 ---
 
 # Codebase Analysis Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -44,7 +45,7 @@ description: Analyze codebase using codebase-deep-analyzer agent
   find . -type d -name "src" 2>/dev/null | grep -v node_modules | grep -v target | head -10 || echo "No src directories found"
   echo '```'
 
-}
+```
 
 ### Project Context
 

--- a/conexus/commands/analyze-code.md
+++ b/conexus/commands/analyze-code.md
@@ -12,24 +12,34 @@ description: Analyze codebase using codebase-deep-analyzer agent
   echo ""
 
   # Project type detection
-  if [ -f "pom.xml" ]; then
-    echo "**Project type:** Maven"
-    echo '```'
-    grep -E "<artifactId>|<groupId>" pom.xml 2>/dev/null | head -4 || echo "Could not parse pom.xml"
-    echo '```'
-  elif [ -f "build.gradle" ] || [ -f "build.gradle.kts" ]; then
-    echo "**Project type:** Gradle"
-    echo '```'
-    head -10 build.gradle* 2>/dev/null || echo "Could not read build.gradle"
-    echo '```'
-  elif [ -f "package.json" ]; then
-    echo "**Project type:** Node.js"
-    echo '```'
-    grep -E '"name"|"version"' package.json 2>/dev/null | head -2 || echo "Could not parse package.json"
-    echo '```'
-  else
-    echo "**Project type:** Unknown"
-  fi
+  echo "**Project type:**"
+  _pt_found=0
+  _pt() { if compgen -G "$1" >/dev/null 2>&1; then echo "- $2"; _pt_found=1; fi; }
+  _pt "pyproject.toml" "Python"
+  _pt "setup.py" "Python (setup.py)"
+  _pt "Cargo.toml" "Rust"
+  _pt "go.mod" "Go"
+  _pt "package.json" "Node.js / TypeScript"
+  _pt "pom.xml" "Java/Kotlin (Maven)"
+  _pt "build.gradle*" "Java/Kotlin (Gradle)"
+  _pt "Gemfile" "Ruby"
+  _pt "composer.json" "PHP"
+  _pt "*.csproj" "C#/.NET"
+  _pt "CMakeLists.txt" "C/C++ (CMake)"
+  _pt "Package.swift" "Swift"
+  _pt "mix.exs" "Elixir"
+  _pt "build.sbt" "Scala (sbt)"
+  _pt "pubspec.yaml" "Dart/Flutter"
+  _pt "deps.edn" "Clojure"
+  _pt "project.clj" "Clojure (Leiningen)"
+  _pt "*.cabal" "Haskell"
+  _pt "stack.yaml" "Haskell (Stack)"
+  _pt "Project.toml" "Julia"
+  _pt "DESCRIPTION" "R"
+  _pt "build.zig" "Zig"
+  _pt "dune-project" "OCaml"
+  _pt "shard.yml" "Crystal"
+  [ "$_pt_found" -eq 0 ] && echo "- Unknown (no recognized build/marker file)"
   echo ""
 
   # Module structure

--- a/conexus/commands/architecture.md
+++ b/conexus/commands/architecture.md
@@ -20,23 +20,34 @@ description: Design architecture and create phased execution plans using archite
   # Project structure
   echo "### Project Structure"
   echo '```'
-  if [ -f "pom.xml" ]; then
-    echo "Maven project with modules:"
-    find . -name "pom.xml" -not -path "./target/*" 2>/dev/null | head -10
-  elif [ -f "build.gradle" ] || [ -f "build.gradle.kts" ]; then
-    echo "Gradle project"
-    find . -name "build.gradle*" -not -path "./.gradle/*" -not -path "./build/*" 2>/dev/null | head -10
-  elif [ -f "pyproject.toml" ]; then
-    echo "Python project"
-  elif [ -f "go.mod" ]; then
-    echo "Go project"
-  elif [ -f "Cargo.toml" ]; then
-    echo "Rust project"
-  elif [ -f "package.json" ]; then
-    echo "Node.js/TypeScript project"
-  else
-    echo "Check CLAUDE.md for project type"
-  fi
+  echo "**Project type:**"
+  _pt_found=0
+  _pt() { if compgen -G "$1" >/dev/null 2>&1; then echo "- $2"; _pt_found=1; fi; }
+  _pt "pyproject.toml" "Python"
+  _pt "setup.py" "Python (setup.py)"
+  _pt "Cargo.toml" "Rust"
+  _pt "go.mod" "Go"
+  _pt "package.json" "Node.js / TypeScript"
+  _pt "pom.xml" "Java/Kotlin (Maven)"
+  _pt "build.gradle*" "Java/Kotlin (Gradle)"
+  _pt "Gemfile" "Ruby"
+  _pt "composer.json" "PHP"
+  _pt "*.csproj" "C#/.NET"
+  _pt "CMakeLists.txt" "C/C++ (CMake)"
+  _pt "Package.swift" "Swift"
+  _pt "mix.exs" "Elixir"
+  _pt "build.sbt" "Scala (sbt)"
+  _pt "pubspec.yaml" "Dart/Flutter"
+  _pt "deps.edn" "Clojure"
+  _pt "project.clj" "Clojure (Leiningen)"
+  _pt "*.cabal" "Haskell"
+  _pt "stack.yaml" "Haskell (Stack)"
+  _pt "Project.toml" "Julia"
+  _pt "DESCRIPTION" "R"
+  _pt "build.zig" "Zig"
+  _pt "dune-project" "OCaml"
+  _pt "shard.yml" "Crystal"
+  [ "$_pt_found" -eq 0 ] && echo "- Unknown (no recognized build/marker file)"
   echo '```'
   echo ""
 

--- a/conexus/commands/architecture.md
+++ b/conexus/commands/architecture.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Design architecture and create phased execution plans using architect-planner agent
 ---
 
 # Architecture Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -60,7 +61,7 @@ description: Design architecture and create phased execution plans using archite
   echo ""
   echo "The agent uses the search tool with corpus='code' and hybrid=true (30-50 results) for discovery,"
   echo "then LSP for precision navigation (documentSymbol, goToImplementation, findReferences)."
-}
+```
 
 ### Project Context
 

--- a/conexus/commands/continuation.md
+++ b/conexus/commands/continuation.md
@@ -1,4 +1,5 @@
 ---
+allowed-tools: Bash
 description: Write a handoff document under /tmp capturing session state, branch, beads, T2 entries, and next-step pointers. Chat response is `cat <path>`; user copies it and pastes after /clear to bootstrap the next session.
 argument-hint: [topic-or-arc-slug] (optional; defaults to current branch)
 ---
@@ -7,7 +8,7 @@ argument-hint: [topic-or-arc-slug] (optional; defaults to current branch)
 
 Generates a handoff document under `/tmp/` that a future Claude Code session can read to pick up cold. Stores under `/tmp` (purged on reboot by macOS) so we don't accumulate stale handoffs in `~/.cache`. The chat response is one literal line: `cat <Target file>`. The user copies that line (mouse-select + cmd-C, or whatever their terminal supports), runs `/clear`, pastes, hits return. The new session reads the handoff and resumes.
 
-!{
+```!
   set +e
 
   # ---- Resolve repo + slug -------------------------------------------------
@@ -132,7 +133,7 @@ Generates a handoff document under `/tmp/` that a future Claude Code session can
     echo "(none; auto-memory not configured for this repo)"
   fi
   echo ""
-}
+```
 
 ## Action
 

--- a/conexus/commands/create-plan.md
+++ b/conexus/commands/create-plan.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Create implementation plan using strategic-planner agent
 ---
 
 # Planning Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -40,7 +41,7 @@ description: Create implementation plan using strategic-planner agent
   fi
   echo '```'
 
-}
+```
 
 ### Project Context
 

--- a/conexus/commands/create-plan.md
+++ b/conexus/commands/create-plan.md
@@ -33,12 +33,34 @@ description: Create implementation plan using strategic-planner agent
   # Architecture hints
   echo "### Project Structure"
   echo '```'
-  if [ -f "pom.xml" ]; then
-    echo "Maven project with modules:"
-    find . -name "pom.xml" -not -path "./target/*" 2>/dev/null | head -10
-  elif [ -f "build.gradle" ] || [ -f "build.gradle.kts" ]; then
-    echo "Gradle project"
-  fi
+  echo "**Project type:**"
+  _pt_found=0
+  _pt() { if compgen -G "$1" >/dev/null 2>&1; then echo "- $2"; _pt_found=1; fi; }
+  _pt "pyproject.toml" "Python"
+  _pt "setup.py" "Python (setup.py)"
+  _pt "Cargo.toml" "Rust"
+  _pt "go.mod" "Go"
+  _pt "package.json" "Node.js / TypeScript"
+  _pt "pom.xml" "Java/Kotlin (Maven)"
+  _pt "build.gradle*" "Java/Kotlin (Gradle)"
+  _pt "Gemfile" "Ruby"
+  _pt "composer.json" "PHP"
+  _pt "*.csproj" "C#/.NET"
+  _pt "CMakeLists.txt" "C/C++ (CMake)"
+  _pt "Package.swift" "Swift"
+  _pt "mix.exs" "Elixir"
+  _pt "build.sbt" "Scala (sbt)"
+  _pt "pubspec.yaml" "Dart/Flutter"
+  _pt "deps.edn" "Clojure"
+  _pt "project.clj" "Clojure (Leiningen)"
+  _pt "*.cabal" "Haskell"
+  _pt "stack.yaml" "Haskell (Stack)"
+  _pt "Project.toml" "Julia"
+  _pt "DESCRIPTION" "R"
+  _pt "build.zig" "Zig"
+  _pt "dune-project" "OCaml"
+  _pt "shard.yml" "Crystal"
+  [ "$_pt_found" -eq 0 ] && echo "- Unknown (no recognized build/marker file)"
   echo '```'
 
 ```

--- a/conexus/commands/debug.md
+++ b/conexus/commands/debug.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Debug test failures using debugger agent
 ---
 
 # Debug Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -48,7 +49,7 @@ description: Debug test failures using debugger agent
   fi
   echo '```'
 
-}
+```
 
 ### Project Context
 

--- a/conexus/commands/deep-analysis.md
+++ b/conexus/commands/deep-analysis.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Thorough analysis of complex problems using deep-analyst agent
 ---
 
 # Deep Analysis Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -32,7 +33,7 @@ description: Thorough analysis of complex problems using deep-analyst agent
   echo "The deep-analyst uses mcp__plugin_conexus_sequential-thinking__sequentialthinking: hypothesis → evidence → evaluation → conclusion."
   echo "For cross-cutting issues, this agent explores multiple components before converging on root cause."
 
-}
+```
 
 ### Project Context
 

--- a/conexus/commands/enrich-plan.md
+++ b/conexus/commands/enrich-plan.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Enrich beads with execution context using mcp__plugin_conexus_nexus__nx_enrich_beads (RDR-080)
 ---
 
 # Enrich Plan
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -19,7 +20,7 @@ description: Enrich beads with execution context using mcp__plugin_conexus_nexus
     echo "Beads not available"
   fi
   echo '```'
-}
+```
 
 ## Plan to Enrich
 

--- a/conexus/commands/implement.md
+++ b/conexus/commands/implement.md
@@ -34,19 +34,34 @@ description: Implement feature using developer agent
   # Project type
   echo "### Project Info"
   echo '```'
-  if [ -f "pom.xml" ]; then
-    echo "Maven project - use ./mvnw for builds"
-  elif [ -f "build.gradle" ] || [ -f "build.gradle.kts" ]; then
-    echo "Gradle project - use ./gradlew for builds"
-  elif [ -f "pyproject.toml" ]; then
-    echo "Python project - check CLAUDE.md for build/test commands"
-  elif [ -f "go.mod" ]; then
-    echo "Go project - use go build/test"
-  elif [ -f "Cargo.toml" ]; then
-    echo "Rust project - use cargo build/test"
-  elif [ -f "package.json" ]; then
-    echo "Node.js/TypeScript project - check CLAUDE.md for build/test commands"
-  fi
+  echo "**Project type:**"
+  _pt_found=0
+  _pt() { if compgen -G "$1" >/dev/null 2>&1; then echo "- $2"; _pt_found=1; fi; }
+  _pt "pyproject.toml" "Python"
+  _pt "setup.py" "Python (setup.py)"
+  _pt "Cargo.toml" "Rust"
+  _pt "go.mod" "Go"
+  _pt "package.json" "Node.js / TypeScript"
+  _pt "pom.xml" "Java/Kotlin (Maven)"
+  _pt "build.gradle*" "Java/Kotlin (Gradle)"
+  _pt "Gemfile" "Ruby"
+  _pt "composer.json" "PHP"
+  _pt "*.csproj" "C#/.NET"
+  _pt "CMakeLists.txt" "C/C++ (CMake)"
+  _pt "Package.swift" "Swift"
+  _pt "mix.exs" "Elixir"
+  _pt "build.sbt" "Scala (sbt)"
+  _pt "pubspec.yaml" "Dart/Flutter"
+  _pt "deps.edn" "Clojure"
+  _pt "project.clj" "Clojure (Leiningen)"
+  _pt "*.cabal" "Haskell"
+  _pt "stack.yaml" "Haskell (Stack)"
+  _pt "Project.toml" "Julia"
+  _pt "DESCRIPTION" "R"
+  _pt "build.zig" "Zig"
+  _pt "dune-project" "OCaml"
+  _pt "shard.yml" "Crystal"
+  [ "$_pt_found" -eq 0 ] && echo "- Unknown (no recognized build/marker file)"
   echo '```'
 
 ```

--- a/conexus/commands/implement.md
+++ b/conexus/commands/implement.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Implement feature using developer agent
 ---
 
 # Implementation Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -48,7 +49,7 @@ description: Implement feature using developer agent
   fi
   echo '```'
 
-}
+```
 
 ### Project Context
 

--- a/conexus/commands/knowledge-tidy.md
+++ b/conexus/commands/knowledge-tidy.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Persist and organize knowledge into the T3 store using mcp__plugin_conexus_nexus__nx_tidy (RDR-080)
 ---
 
 # Knowledge Tidying Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -30,7 +31,7 @@ description: Persist and organize knowledge into the T3 store using mcp__plugin_
   echo ""
   echo "Title conventions: research-{topic}, decision-{component}-{name}, pattern-{name}, debug-{component}-{issue}"
   echo "All entries stored via store_put tool: collection='knowledge'"
-}
+```
 
 ### Project Context
 

--- a/conexus/commands/nx-preflight.md
+++ b/conexus/commands/nx-preflight.md
@@ -1,9 +1,10 @@
 ---
+allowed-tools: Bash
 description: Check that all conexus plugin dependencies are correctly installed and configured
 disable-model-invocation: false
 ---
 
-!{
+```!
   echo "## conexus Plugin Preflight Check"
   echo ""
 
@@ -124,7 +125,7 @@ disable-model-invocation: false
     echo "See: https://docs.anthropic.com/en/docs/claude-code/memory#claudemd"
   fi
   echo ""
-}
+```
 
 ## Summary
 

--- a/conexus/commands/pdf-process.md
+++ b/conexus/commands/pdf-process.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Index PDF files into the T3 knowledge store for semantic search
 ---
 
 # PDF Processing Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -25,7 +26,7 @@ description: Index PDF files into the T3 knowledge store for semantic search
   echo ""
   echo "Specify PDF paths or a directory. nx index pdf extracts text, chunks content,"
   echo "and indexes into T3 for semantic search via the search tool."
-}
+```
 
 ## PDFs to Process
 

--- a/conexus/commands/phase-review-gate.md
+++ b/conexus/commands/phase-review-gate.md
@@ -1,12 +1,305 @@
 ---
+allowed-tools: Bash
 description: Cross-walk RDR §Approach against closing beads at a phase boundary — blocks silent scope reduction
 ---
 
 # Phase Review Gate
 
-!{
-NEXUS_RDR_ARGS="${ARGUMENTS:-}" python3 "$CLAUDE_PLUGIN_ROOT/resources/rdr_commands/phase_review_gate.py"
-}
+```!
+NEXUS_RDR_ARGS="$ARGUMENTS" python3 <<'PYEOF'
+import os, sys, re, subprocess
+from pathlib import Path
+
+args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
+
+# Repo root and name
+try:
+    repo_root = subprocess.check_output(
+        ['git', 'rev-parse', '--show-toplevel'],
+        stderr=subprocess.DEVNULL, text=True).strip()
+    repo_name = os.path.basename(repo_root)
+except Exception:
+    repo_root = os.getcwd()
+    repo_name = os.path.basename(repo_root)
+
+# Allow test harness to override RDR directory location.
+rdr_dir_override = os.environ.get('NEXUS_RDR_DIR_OVERRIDE', '').strip()
+if rdr_dir_override:
+    rdr_path = Path(rdr_dir_override)
+    repo_root = str(rdr_path.parent.parent) if rdr_path.name == 'rdr' else repo_root
+else:
+    # Resolve RDR directory from .nexus.yml (default: docs/rdr)
+    rdr_dir = 'docs/rdr'
+    nexus_yml = Path(repo_root) / '.nexus.yml'
+    if nexus_yml.exists():
+        content = nexus_yml.read_text()
+        try:
+            import yaml
+            d = yaml.safe_load(content) or {}
+            paths = (d.get('indexing') or {}).get('rdr_paths', ['docs/rdr'])
+            rdr_dir = paths[0] if paths else 'docs/rdr'
+        except ImportError:
+            m_yml = (re.search(r'rdr_paths[^\[]*\[([^\]]+)\]', content) or
+                     re.search(r'rdr_paths:\s*\n\s+-\s*(.+)', content))
+            if m_yml:
+                v = m_yml.group(1)
+                parts = re.findall(r'[a-z][a-z0-9/_-]+', v)
+                rdr_dir = parts[0] if parts else 'docs/rdr'
+    rdr_path = Path(repo_root) / rdr_dir
+
+
+def parse_frontmatter(filepath):
+    text = filepath.read_text(errors='replace')
+    meta = {}
+    if text.startswith('---'):
+        parts = text.split('---', 2)
+        if len(parts) >= 3:
+            block = parts[1]
+            try:
+                import yaml; meta = yaml.safe_load(block) or {}
+            except Exception:
+                for line in block.splitlines():
+                    if ':' in line:
+                        k, _, v = line.partition(':')
+                        meta[k.strip().lower()] = v.strip()
+    if 'title' not in meta and 'name' not in meta:
+        h1 = re.search(r'^#\s+(.+)', text, re.MULTILINE)
+        if h1:
+            meta['title'] = h1.group(1).strip()
+    return meta, text
+
+
+def find_rdr_file(rdr_path, id_str):
+    m = re.search(r'\d+', id_str)
+    if not m:
+        return None
+    num_int = int(m.group(0))
+    for f in sorted(rdr_path.glob('*.md')):
+        nums = re.findall(r'\d+', f.stem)
+        if nums and int(nums[0]) == num_int:
+            return f
+    return None
+
+
+def extract_approach_section(text):
+    """Extract content under §Approach (handles '### Approach' and variants)."""
+    # Match heading with optional parenthetical qualifier
+    for pat in [
+        r'\n### Approach[^\n]*\n',
+        r'\n## Approach[^\n]*\n',
+        r'\n#### Approach[^\n]*\n',
+    ]:
+        m = re.search(pat, text)
+        if m:
+            start = m.end()
+            # End at the next heading of same or higher level
+            heading_depth = len(re.match(r'(#+)', m.group(0).strip()).group(1))
+            end_pat = r'\n#{1,' + str(heading_depth) + r'} '
+            nxt = re.search(end_pat, text[start:])
+            return text[start : start + nxt.start()] if nxt else text[start:]
+    return ''
+
+
+def parse_approach_items(approach_text):
+    """Parse numbered list items from §Approach.
+
+    Returns list of (item_num: int, label: str, summary: str).
+    Label is the bold text after the number; summary is the first line.
+    Handles multi-line continuation paragraphs.
+    """
+    items = []
+    # Split on numbered list starters: lines matching /^\d+\. /
+    lines = approach_text.splitlines()
+    current_num = None
+    current_label = ''
+    current_lines = []
+
+    for line in lines:
+        m = re.match(r'^(\d+)\.\s+\*\*([^*]+)\*\*[:\s]*(.*)', line)
+        if m:
+            if current_num is not None:
+                items.append((current_num, current_label, ' '.join(current_lines).strip()))
+            current_num = int(m.group(1))
+            current_label = m.group(2).strip()
+            current_lines = [m.group(3).strip()] if m.group(3).strip() else []
+        elif current_num is not None:
+            stripped = line.strip()
+            if stripped and not stripped.startswith('-'):
+                current_lines.append(stripped)
+
+    if current_num is not None:
+        items.append((current_num, current_label, ' '.join(current_lines).strip()))
+
+    return items
+
+
+def parse_evidence(evidence_str):
+    """Parse 'Item1=val1,Item2=val2,...' into {1: 'val1', 2: 'val2'}."""
+    out = {}
+    for tok in evidence_str.split(','):
+        tok = tok.strip()
+        if not tok:
+            continue
+        if '=' in tok:
+            k, _, v = tok.partition('=')
+            k = k.strip()
+            v = v.strip()
+            # Accept ItemN or item N (case-insensitive)
+            num_m = re.search(r'(\d+)', k)
+            if num_m:
+                out[int(num_m.group(1))] = v
+    return out
+
+
+# Parse flags
+phase_match = re.search(r'--phase\s+(\S+)', args)
+phase_arg = phase_match.group(1) if phase_match else None
+
+evidence_match = (re.search(r"--evidence\s+'([^']+)'", args)
+                  or re.search(r'--evidence\s+"([^"]+)"', args)
+                  or re.search(r'--evidence\s+(\S+)', args))
+evidence_arg = evidence_match.group(1) if evidence_match else None
+
+# Strip flags to find RDR ID
+args_clean = re.sub(r'--phase\s+\S+', '', args)
+args_clean = re.sub(r"--evidence\s+'[^']+'", '', args_clean)
+args_clean = re.sub(r'--evidence\s+"[^"]+"', '', args_clean)
+args_clean = re.sub(r'--evidence\s+\S+', '', args_clean).strip()
+
+id_match = re.search(r'\d+', args_clean)
+
+if not id_match:
+    print("> **Usage**: `/conexus:phase-review-gate <id> --phase <N> [--evidence 'Item1=bead-id,...']`")
+    print()
+    print("### What this gate does")
+    print()
+    print("At each phase-review boundary, cross-walk the RDR §Approach sub-items")
+    print("against the closing beads. Pass 1 enumerates items; Pass 2 validates evidence.")
+    print()
+    print("**Pass 1** (no --evidence): list approach items for the phase.")
+    print("**Pass 2** (with --evidence): validate every item has an evidence pointer.")
+    print()
+    print("Evidence format: `Item1=nexus-abc1,Item2=nexus-xyz2,Item3=none`")
+    print("Use `none` for items explicitly deferred or acknowledged as out-of-phase scope.")
+    sys.exit(0)
+
+rdr_file = find_rdr_file(rdr_path, id_match.group(0))
+if not rdr_file:
+    print(f"> **ERROR**: RDR not found for ID: `{id_match.group(0)}`")
+    print(f"> Looked in: `{rdr_path}`")
+    sys.exit(0)
+
+fm, text = parse_frontmatter(rdr_file)
+title = fm.get('title', fm.get('name', rdr_file.stem))
+rdr_num_m = re.search(r'\d+', rdr_file.stem)
+rdr_id_label = rdr_num_m.group(0) if rdr_num_m else rdr_file.stem
+
+print(f"**Repo:** `{repo_name}`  **RDR:** `{rdr_file.name}`")
+print(f"**Title:** {title}")
+print(f"**Phase:** {phase_arg or '(not specified)'}")
+print()
+
+# Extract §Approach items
+approach_text = extract_approach_section(text)
+if not approach_text.strip():
+    print("> **ERROR**: No `### Approach` section found in this RDR.")
+    print("> Phase-review gate requires §Approach to cross-walk against closing beads.")
+    sys.exit(0)
+
+items = parse_approach_items(approach_text)
+if not items:
+    print("> **ERROR**: §Approach section found but no numbered items parsed.")
+    print("> Expected format: `N. **Label**: description`")
+    sys.exit(0)
+
+# === PASS 1: enumerate approach items ===
+if not evidence_arg:
+    print(f"### §Approach Cross-Walk — Phase {phase_arg or '?'}")
+    print()
+    print("Enumerate each numbered §Approach item below, then provide an evidence pointer")
+    print("for each item: the closing bead ID (e.g. `nexus-abc1`) or `none` if the item")
+    print("is explicitly deferred or not in scope for this phase.")
+    print()
+    print("| # | Label | Evidence needed |")
+    print("|---|-------|-----------------|")
+    for num, label, _summary in items:
+        print(f"| Item{num} | **{label}** | (provide bead-id or `none`) |")
+    print()
+    example_parts = ','.join(f"Item{num}=nexus-xxxx" for num, _, _ in items)
+    print("**Re-invoke with evidence once all items are accounted for:**")
+    print()
+    print(f"```")
+    print(f"/conexus:phase-review-gate {rdr_id_label} --phase {phase_arg or '1'} --evidence '{example_parts}'")
+    print(f"```")
+    print()
+    sys.exit(0)
+
+# === PASS 2: validate evidence coverage ===
+evidence = parse_evidence(evidence_arg)
+failures = []
+covered = []
+
+for num, label, _summary in items:
+    val = evidence.get(num, '').strip()
+    if not val:
+        failures.append((num, label, "no evidence pointer supplied"))
+    else:
+        covered.append((num, label, val))
+
+if failures:
+    print(f"> **BLOCKED** — Phase {phase_arg or '?'} cross-walk incomplete.")
+    print(f"> {len(failures)} of {len(items)} approach item(s) have no evidence pointer.")
+    print()
+    print("### Missing Evidence")
+    print()
+    for num, label, reason in failures:
+        print(f"- **Item{num}** ({label}): {reason}")
+    print()
+    print("These items must be accounted for before closing this phase.")
+    print("Provide a closing bead ID or `none` with an acknowledgement for deferred items.")
+    print()
+    print("**Re-invoke once all items are covered:**")
+    example_parts = ','.join(
+        f"Item{num}={evidence.get(num, 'nexus-xxxx') or 'nexus-xxxx'}"
+        for num, _, _ in items
+    )
+    print(f"```")
+    print(f"/conexus:phase-review-gate {rdr_id_label} --phase {phase_arg or '1'} --evidence '{example_parts}'")
+    print(f"```")
+    sys.exit(0)
+
+# All items covered — validation passed
+print(f"### APPROACH CROSS-WALK PASSED — Phase {phase_arg or '?'}")
+print()
+print(f"All {len(items)} §Approach items accounted for:")
+print()
+for num, label, val in covered:
+    print(f"- Item{num} ({label}) → `{val}`")
+print()
+print("> The gate verifies every §Approach item has a named evidence pointer.")
+print("> It does NOT verify that the evidence is semantically complete.")
+print("> Review each pointer manually before allowing the phase close to proceed.")
+print()
+# Write T1 scratch marker so downstream hooks can check cross-walk completion
+try:
+    subprocess.run(
+        ['nx', 'scratch', 'put',
+         f'phase-review-gate PASSED: RDR-{rdr_id_label} Phase {phase_arg}',
+         '--tags', f'phase-review-passed,rdr-{rdr_id_label},phase-{phase_arg}'],
+        capture_output=True, timeout=5)
+except Exception:
+    pass
+
+# RDR-121 P2 co-requirement: write the PASSED sentinel that the
+# phase_review_close_requires_gate PreToolUse hook reads. Sweep dead-pid
+# sentinels as a side effect. Best-effort; never raises.
+try:
+    from nexus.phase_review_sentinel import write_sentinel
+    write_sentinel(rdr_id_label, str(phase_arg or "1"))
+except Exception:
+    pass
+PYEOF
+```
 
 ## Phase Review Gate
 

--- a/conexus/commands/plan-audit.md
+++ b/conexus/commands/plan-audit.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Audit a plan using mcp__plugin_conexus_nexus__nx_plan_audit (RDR-080)
 ---
 
 # Plan Audit Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -23,7 +24,7 @@ description: Audit a plan using mcp__plugin_conexus_nexus__nx_plan_audit (RDR-08
     echo "Beads not available"
   fi
   echo '```'
-}
+```
 
 ## Plan to Audit
 

--- a/conexus/commands/rdr-accept.md
+++ b/conexus/commands/rdr-accept.md
@@ -1,12 +1,203 @@
 ---
+allowed-tools: Bash
 description: Accept a gated RDR — verifies gate PASSED in T2, updates status to accepted
 ---
 
 # RDR Accept
 
-!{
-NEXUS_RDR_ARGS="${ARGUMENTS:-}" python3 "$CLAUDE_PLUGIN_ROOT/resources/rdr_commands/rdr_accept.py"
-}
+```!
+NEXUS_RDR_ARGS="$ARGUMENTS" python3 <<'PYEOF'
+import os, sys, re, subprocess
+from pathlib import Path
+
+args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
+
+# Repo root and name
+try:
+    repo_root = subprocess.check_output(
+        ['git', 'rev-parse', '--show-toplevel'],
+        stderr=subprocess.DEVNULL, text=True).strip()
+    repo_name = os.path.basename(repo_root)
+except Exception:
+    repo_root = os.getcwd()
+    repo_name = os.path.basename(repo_root)
+
+# Resolve RDR directory from .nexus.yml (default: docs/rdr)
+rdr_dir = 'docs/rdr'
+nexus_yml = Path(repo_root) / '.nexus.yml'
+if nexus_yml.exists():
+    content = nexus_yml.read_text()
+    try:
+        import yaml
+        d = yaml.safe_load(content) or {}
+        paths = (d.get('indexing') or {}).get('rdr_paths', ['docs/rdr'])
+        rdr_dir = paths[0] if paths else 'docs/rdr'
+    except ImportError:
+        m_yml = (re.search(r'rdr_paths[^\[]*\[([^\]]+)\]', content) or
+                 re.search(r'rdr_paths:\s*\n\s+-\s*(.+)', content))
+        if m_yml:
+            v = m_yml.group(1)
+            parts = re.findall(r'[a-z][a-z0-9/_-]+', v)
+            rdr_dir = parts[0] if parts else 'docs/rdr'
+
+rdr_path = Path(repo_root) / rdr_dir
+
+print(f"**Repo:** `{repo_name}`  **RDR directory:** `{rdr_dir}`")
+print()
+
+
+def parse_frontmatter(filepath):
+    text = filepath.read_text(errors='replace')
+    meta = {}
+    if text.startswith('---'):
+        parts = text.split('---', 2)
+        if len(parts) >= 3:
+            block = parts[1]
+            try:
+                import yaml; meta = yaml.safe_load(block) or {}
+            except Exception:
+                for line in block.splitlines():
+                    if ':' in line:
+                        k, _, v = line.partition(':')
+                        meta[k.strip().lower()] = v.strip()
+    if 'title' not in meta and 'name' not in meta:
+        h1 = re.search(r'^#\s+(.+)', text, re.MULTILINE)
+        if h1:
+            meta['title'] = h1.group(1).strip()
+    return meta, text
+
+
+def find_rdr_file(rdr_path, id_str):
+    m = re.search(r'\d+', id_str)
+    if not m:
+        return None
+    num_int = int(m.group(0))
+    for f in sorted(rdr_path.glob('*.md')):
+        nums = re.findall(r'\d+', f.stem)
+        if nums and int(nums[0]) == num_int:
+            return f
+    return None
+
+
+EXCLUDED = {'readme.md', 'template.md', 'index.md', 'overview.md', 'workflow.md', 'templates.md'}
+
+def get_all_rdrs(rdr_path):
+    """Return list of dicts for all RDRs in the directory."""
+    all_md = sorted(rdr_path.glob('*.md'))
+    rdrs = []
+    for f in all_md:
+        if f.name.lower() in EXCLUDED:
+            continue
+        fm, text = parse_frontmatter(f)
+        rtype = fm.get('type', '?')
+        doc_status = fm.get('status', '?')
+        if doc_status == '?' and rtype == '?':
+            continue
+        rdrs.append({
+            'file': f.name,
+            'path': f,
+            'title': fm.get('title', fm.get('name', f.stem)),
+            'status': doc_status,
+            'rtype': rtype,
+            'priority': fm.get('priority', '?'),
+        })
+    return rdrs
+
+
+if not rdr_path.exists():
+    print(f"> No RDRs found — `{rdr_dir}` does not exist in this repo.")
+    sys.exit(0)
+
+id_match = re.search(r'\d+', args)
+
+if not id_match:
+    print("> **Usage**: `/conexus:rdr-accept <id>` — e.g. `/conexus:rdr-accept 003` or `/conexus:rdr-accept RDR-003`")
+    print()
+    rdrs = get_all_rdrs(rdr_path)
+    draft_rdrs = [r for r in rdrs if r['status'].lower() == 'draft']
+    print("### Draft RDRs (eligible for acceptance)")
+    print()
+    if draft_rdrs:
+        print("| File | Title | Status | Type |")
+        print("|------|-------|--------|------|")
+        for r in draft_rdrs:
+            print(f"| {r['file']} | {r['title']} | {r['status']} | {r['rtype']} |")
+    else:
+        print("No Draft RDRs found. Only Draft RDRs can be accepted.")
+    sys.exit(0)
+
+rdr_file = find_rdr_file(rdr_path, id_match.group(0))
+if not rdr_file:
+    print(f"> RDR not found for ID: `{id_match.group(0)}`")
+    sys.exit(0)
+
+fm, text = parse_frontmatter(rdr_file)
+title = fm.get('title', fm.get('name', rdr_file.stem))
+current_status = fm.get('status', '?')
+rdr_type = fm.get('type', '?')
+rdr_num = re.search(r'\d+', rdr_file.stem)
+t2_key = rdr_num.group(0) if rdr_num else rdr_file.stem
+
+print(f"### RDR: {rdr_file.name}")
+print(f"**RDR ID:** {t2_key}  **Title:** {title}  **Type:** {rdr_type}  **File Status:** {current_status}")
+print()
+
+# Accepted status is allowed — agent handles idempotency in Step 1
+if current_status.lower() not in ('draft', 'accepted'):
+    print(f"> **BLOCKED**: RDR status is `{current_status}`. Only Draft RDRs can be accepted.")
+    sys.exit(0)
+
+# T2 lookups — agent must call these MCP tools and use the results in the Action section
+print("### T2 Lookups (call these before executing Action steps)")
+print()
+print(f"1. **T2 metadata**: Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}\"")
+print(f"2. **T2 gate result**: Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}-gate-latest\"")
+print(f"   If no gate record exists, run `/conexus:rdr-gate {t2_key}` first.")
+print()
+print(f"**RDR file path:** `{rdr_file}`")
+print()
+
+# Step count auto-detection for planning handoff
+# Look for any planning-like section, not just "## Implementation Plan"
+plan_headers = [
+    r'^## Implementation Plan',
+    r'^## Approach',
+    r'^## Plan',
+    r'^## Design',
+    r'^## Steps',
+    r'^## Execution',
+]
+plan_section = None
+for hdr in plan_headers:
+    m = re.search(hdr + r'\s*\n(.*?)(?=^## |\Z)', text, re.MULTILINE | re.DOTALL)
+    if m:
+        plan_section = m.group(1)
+        break
+
+step_count = 0
+has_plan = plan_section is not None
+if has_plan:
+    # Count any numbered sub-headings: Phase, Step, Stage, Part
+    step_count = len(re.findall(
+        r'^### (?:Phase|Step|Stage|Part)\s', plan_section, re.MULTILINE))
+    # Also count ### with leading numbers: ### 1., ### 2.
+    if step_count == 0:
+        step_count = len(re.findall(r'^### \d', plan_section, re.MULTILINE))
+
+print("### Planning Handoff")
+print(f"**Step count detected:** {step_count}")
+print(f"**Has plan section:** {'yes' if has_plan else 'no'}")
+if step_count >= 2:
+    print("**Recommendation:** Invoke strategic planner (multi-step RDR)")
+    print("**Default:** yes")
+else:
+    # Default to YES — false positives (unnecessary planning) are cheap,
+    # false negatives (skipping planning on complex work) are expensive
+    print("**Recommendation:** Invoke strategic planner")
+    print("**Default:** yes")
+print()
+PYEOF
+```
 
 ## RDR to Accept
 

--- a/conexus/commands/rdr-audit.md
+++ b/conexus/commands/rdr-audit.md
@@ -1,12 +1,128 @@
 ---
+allowed-tools: Bash
 description: Audit a project's RDR lifecycle for silent-scope-reduction base rate, or inspect/manage scheduled periodic audits
 ---
 
 # RDR Audit
 
-!{
-NEXUS_RDR_ARGS="${ARGUMENTS:-}" NEXUS_PROJECT_ROOTS="${NEXUS_PROJECT_ROOTS:-}" python3 "$CLAUDE_PLUGIN_ROOT/resources/rdr_commands/rdr_audit.py"
-}
+```!
+NEXUS_RDR_ARGS="$ARGUMENTS" NEXUS_PROJECT_ROOTS="${NEXUS_PROJECT_ROOTS:-}" python3 <<'PYEOF'
+import os, subprocess
+from pathlib import Path
+
+args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
+
+# Derive current project name (precedence: git remote → pwd basename).
+# Note: the skill documents a third fallback of prompting the user when the
+# derivation is ambiguous — that interactive step is handled in the skill body,
+# not in this Python preamble (which must be safe for headless `claude -p` use
+# where no TTY is available for prompts).
+def derive_project_name():
+    try:
+        url = subprocess.check_output(
+            ['git', 'remote', 'get-url', 'origin'],
+            stderr=subprocess.DEVNULL, text=True).strip()
+        if url:
+            name = url.rsplit('/', 1)[-1]
+            if name.endswith('.git'):
+                name = name[:-4]
+            if name:
+                return name
+    except Exception:
+        pass
+    try:
+        root = subprocess.check_output(
+            ['git', 'rev-parse', '--show-toplevel'],
+            stderr=subprocess.DEVNULL, text=True).strip()
+        if root:
+            return os.path.basename(root)
+    except Exception:
+        pass
+    return os.path.basename(os.getcwd())
+
+current_project = derive_project_name()
+
+READONLY_SUBCOMMANDS = {'list', 'status', 'history'}
+PRINTONLY_SUBCOMMANDS = {'schedule', 'unschedule'}
+SUBCOMMANDS = READONLY_SUBCOMMANDS | PRINTONLY_SUBCOMMANDS
+
+first_token = args.split()[0] if args else ''
+if first_token in SUBCOMMANDS:
+    mode = 'management'
+    subcommand = first_token
+    target = args[len(first_token):].strip() or (current_project if subcommand != 'list' else '')
+    safety_class = 'read-only' if subcommand in READONLY_SUBCOMMANDS else 'print-only'
+    print(f"**Mode:** management subcommand `{subcommand}` ({safety_class})")
+    if target:
+        print(f"**Target project:** `{target}`")
+    else:
+        print(f"**Scope:** all scheduled audits on this machine")
+    print()
+    if safety_class == 'read-only':
+        print(f"> `{subcommand}` is read-only — no OS state mutation, no T2 state mutation.")
+        print(f"> The skill body shells out to `launchctl list` / `crontab -l` / `memory_search` / `memory_get` only.")
+    else:
+        print(f"> `{subcommand}` is print-only — prints install/uninstall instructions for user review.")
+        print(f"> The skill body does NOT run `launchctl load/unload`, does NOT write plist files, does NOT edit crontab.")
+        print(f"> All system-level installs are the user's explicit manual step.")
+    print()
+else:
+    mode = 'audit'
+    target = first_token or current_project
+    print(f"**Mode:** audit dispatch (default)")
+    print(f"**Target project:** `{target}`" + (" (derived from current repo)" if not first_token else ""))
+    print()
+
+    # Probe for the target project's worktree on the local machine.
+    # Precedence:
+    #   1. NEXUS_PROJECT_ROOTS env var — colon-separated list of directories under which
+    #      the user keeps project worktrees (e.g. "$HOME/src:$HOME/work")
+    #   2. Default candidate roots — common conventions, none assumed authoritative
+    home = Path.home()
+    roots_env = os.environ.get('NEXUS_PROJECT_ROOTS', '').strip()
+    if roots_env:
+        roots = [Path(os.path.expanduser(r)) for r in roots_env.split(':') if r]
+        roots_source = 'NEXUS_PROJECT_ROOTS'
+    else:
+        roots = [
+            home / 'git',
+            home / 'src',
+            home / 'projects',
+            home / 'code',
+            home / 'work',
+            home / 'dev',
+            home / 'Documents' / 'git',
+        ]
+        roots_source = 'default candidates (set NEXUS_PROJECT_ROOTS to override)'
+    candidate_paths = [r / target for r in roots if r.is_dir()]
+    found_path = next((p for p in candidate_paths if p.exists() and p.is_dir()), None)
+    if found_path:
+        print(f"**Worktree found:** `{found_path}`")
+        postmortem_dir = found_path / 'docs' / 'rdr' / 'post-mortem'
+        if postmortem_dir.exists():
+            count = len(list(postmortem_dir.glob('*.md')))
+            print(f"**Post-mortems available:** {count} files in `{postmortem_dir}`")
+        else:
+            print(f"> No `docs/rdr/post-mortem/` directory found at `{found_path}`. The audit will fall back to alternate paths per the canonical prompt.")
+    else:
+        probed = ', '.join(str(r) for r in roots if r.is_dir()) or '(no existing roots)'
+        print(f"> No local worktree found for `{target}`. Probed roots ({roots_source}): {probed}.")
+        print(f"> Set `NEXUS_PROJECT_ROOTS` (colon-separated) to the directory(ies) where you keep project worktrees, or pass an explicit absolute path as the project argument.")
+        print(f"> The audit will proceed with T2 `rdr_process` evidence only.")
+
+    # Check for session transcripts
+    claude_projects = home / '.claude' / 'projects'
+    if claude_projects.exists():
+        # The directory-mangled naming scheme varies; glob for any matching token
+        match_candidates = list(claude_projects.glob(f'*{target}*'))
+        if match_candidates:
+            print(f"**Session transcripts available:** {len(match_candidates)} matching directory entries in `~/.claude/projects/`")
+        else:
+            print(f"> No session transcripts found for `{target}` under `~/.claude/projects/`. The main-session transcript pre-step will use the fast path (empty excerpt block).")
+
+print()
+PYEOF
+```
 
 ## Arguments
 

--- a/conexus/commands/rdr-close.md
+++ b/conexus/commands/rdr-close.md
@@ -1,12 +1,344 @@
 ---
+allowed-tools: Bash
 description: Close an RDR with optional post-mortem, bead status gate, and T3 archival
 ---
 
 # RDR Close
 
-!{
-NEXUS_RDR_ARGS="${ARGUMENTS:-}" python3 "$CLAUDE_PLUGIN_ROOT/resources/rdr_commands/rdr_close.py"
-}
+```!
+NEXUS_RDR_ARGS="$ARGUMENTS" python3 <<'PYEOF'
+import os, sys, re, subprocess
+from pathlib import Path
+
+args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
+
+# Repo root and name
+try:
+    repo_root = subprocess.check_output(
+        ['git', 'rev-parse', '--show-toplevel'],
+        stderr=subprocess.DEVNULL, text=True).strip()
+    repo_name = os.path.basename(repo_root)
+except Exception:
+    repo_root = os.getcwd()
+    repo_name = os.path.basename(repo_root)
+
+# Resolve RDR directory from .nexus.yml (default: docs/rdr)
+rdr_dir = 'docs/rdr'
+nexus_yml = Path(repo_root) / '.nexus.yml'
+if nexus_yml.exists():
+    content = nexus_yml.read_text()
+    try:
+        import yaml
+        d = yaml.safe_load(content) or {}
+        paths = (d.get('indexing') or {}).get('rdr_paths', ['docs/rdr'])
+        rdr_dir = paths[0] if paths else 'docs/rdr'
+    except ImportError:
+        m_yml = (re.search(r'rdr_paths[^\[]*\[([^\]]+)\]', content) or
+                 re.search(r'rdr_paths:\s*\n\s+-\s*(.+)', content))
+        if m_yml:
+            v = m_yml.group(1)
+            parts = re.findall(r'[a-z][a-z0-9/_-]+', v)
+            rdr_dir = parts[0] if parts else 'docs/rdr'
+
+rdr_path = Path(repo_root) / rdr_dir
+
+print(f"**Repo:** `{repo_name}`  **RDR directory:** `{rdr_dir}`")
+print()
+
+
+def parse_frontmatter(filepath):
+    text = filepath.read_text(errors='replace')
+    meta = {}
+    if text.startswith('---'):
+        parts = text.split('---', 2)
+        if len(parts) >= 3:
+            block = parts[1]
+            try:
+                import yaml; meta = yaml.safe_load(block) or {}
+            except Exception:
+                for line in block.splitlines():
+                    if ':' in line:
+                        k, _, v = line.partition(':')
+                        meta[k.strip().lower()] = v.strip()
+    if 'title' not in meta and 'name' not in meta:
+        h1 = re.search(r'^#\s+(.+)', text, re.MULTILINE)
+        if h1:
+            meta['title'] = h1.group(1).strip()
+    return meta, text
+
+
+def find_rdr_file(rdr_path, id_str):
+    m = re.search(r'\d+', id_str)
+    if not m:
+        return None
+    num_int = int(m.group(0))
+    for f in sorted(rdr_path.glob('*.md')):
+        nums = re.findall(r'\d+', f.stem)
+        if nums and int(nums[0]) == num_int:
+            return f
+    return None
+
+
+EXCLUDED = {'readme.md', 'template.md', 'index.md', 'overview.md', 'workflow.md', 'templates.md'}
+
+def get_all_rdrs(rdr_path):
+    """Return list of dicts for all RDRs in the directory."""
+    all_md = sorted(rdr_path.glob('*.md'))
+    rdrs = []
+    for f in all_md:
+        if f.name.lower() in EXCLUDED:
+            continue
+        fm, text = parse_frontmatter(f)
+        rtype = fm.get('type', '?')
+        doc_status = fm.get('status', '?')
+        if doc_status == '?' and rtype == '?':
+            continue  # prose doc, not an RDR
+        rdrs.append({
+            'file': f.name,
+            'path': f,
+            'text': text,
+            'title': fm.get('title', fm.get('name', f.stem)),
+            'status': doc_status,
+            'rtype': rtype,
+            'priority': fm.get('priority', '?'),
+        })
+    return rdrs
+
+
+if not rdr_path.exists():
+    print(f"> No RDRs found — `{rdr_dir}` does not exist in this repo.")
+    sys.exit(0)
+
+# Strip flags from args before extracting ID
+reason_match = re.search(r'--reason\s+(\S+)', args)
+close_reason = reason_match.group(1) if reason_match else None
+# --force MUST use negative lookahead (not \b) so `--force-implemented` does not match.
+# `\b` fires between `e` and `-` (word/non-word boundary) and incorrectly matches the
+# audit-override flag. Verified: re.search(r'--force\b', '--force-implemented') is True.
+# See RDR-069 plan-auditor SIG-1 / nexus-ctq.2 acceptance criteria.
+force = bool(re.search(r'--force(?!-)', args))
+# --pointers may be single-quoted, double-quoted, or a single unquoted token
+pointers_match = (re.search(r"--pointers\s+'([^']+)'", args)
+                  or re.search(r'--pointers\s+"([^"]+)"', args)
+                  or re.search(r'--pointers\s+(\S+)', args))
+pointers_arg = pointers_match.group(1) if pointers_match else None
+# --force-implemented "<reason>" — audit-trail override for critic blocks (RDR-069).
+# Reason must be non-empty; an empty string is rejected at the preamble gate.
+force_implemented_match = (re.search(r"--force-implemented\s+'([^']*)'", args)
+                            or re.search(r'--force-implemented\s+"([^"]*)"', args)
+                            or re.search(r'--force-implemented\s+(\S+)', args))
+force_implemented_reason = force_implemented_match.group(1) if force_implemented_match else None
+if force_implemented_match is not None and not (force_implemented_reason or '').strip():
+    print("> **ERROR**: `--force-implemented` requires a non-empty reason string.")
+    print("> Example: `/conexus:rdr-close 069 --reason implemented --force-implemented 'critic false positive — gap addressed at src/foo.py:42'`")
+    sys.exit(0)
+args_clean = re.sub(r'--reason\s+\S+', '', args)
+# Strip --force-implemented BEFORE --force so the negative-lookahead strip below
+# has no `--force-implemented` to (correctly) skip and no residual tail to confuse
+# the ID extractor.
+args_clean = re.sub(r"--force-implemented\s+'[^']*'", '', args_clean)
+args_clean = re.sub(r'--force-implemented\s+"[^"]*"', '', args_clean)
+args_clean = re.sub(r'--force-implemented\s+\S+', '', args_clean)
+args_clean = re.sub(r'--force(?!-)', '', args_clean)
+args_clean = re.sub(r"--pointers\s+'[^']+'", '', args_clean)
+args_clean = re.sub(r'--pointers\s+"[^"]+"', '', args_clean)
+args_clean = re.sub(r'--pointers\s+\S+', '', args_clean).strip()
+
+id_match = re.search(r'\d+', args_clean)
+
+if not id_match:
+    print("> **Usage**: `/conexus:rdr-close <id> [--reason implemented|reverted|abandoned|superseded]`")
+    print()
+    rdrs = get_all_rdrs(rdr_path)
+    print("### Open/Draft RDRs")
+    print()
+    if rdrs:
+        print("| File | Title | Status | Type |")
+        print("|------|-------|--------|------|")
+        for r in rdrs:
+            print(f"| {r['file']} | {r['title']} | {r['status']} | {r['rtype']} |")
+    else:
+        print(f"No RDRs found in `{rdr_dir}`")
+    sys.exit(0)
+
+rdr_file = find_rdr_file(rdr_path, id_match.group(0))
+if not rdr_file:
+    print(f"> RDR not found for ID: `{id_match.group(0)}`")
+    sys.exit(0)
+
+fm, text = parse_frontmatter(rdr_file)
+title = fm.get('title', fm.get('name', rdr_file.stem))
+current_status = fm.get('status', '?')
+rdr_num = re.search(r'\d+', rdr_file.stem)
+t2_key = rdr_num.group(0) if rdr_num else rdr_file.stem
+
+print(f"### RDR: {rdr_file.name}")
+print(f"**Title:** {title}  **Current Status:** {current_status}")
+if close_reason:
+    print(f"**Close Reason:** {close_reason}")
+if force_implemented_reason:
+    print(f"**Force Implemented (audit):** {force_implemented_reason}")
+print()
+
+# Hard-block: refuse to close unless status is accepted or final (P1 from RDR-001)
+if current_status.lower() not in ('accepted', 'final'):
+    if force:
+        print(f"> **Override**: RDR status is `{current_status}` (not accepted/final). Proceeding with `--force`.")
+        print()
+    else:
+        print(f"> **BLOCKED**: RDR status is `{current_status}`. Close requires status `accepted` or `final`.")
+        print(f"> Run `/conexus:rdr-gate` to validate, or use `--force` to override.")
+        print()
+        sys.exit(0)
+
+# === Gap 1: Two-pass Problem Statement Replay (RDR-065) ===
+# HARD ENFORCEMENT SURFACE per HA-5: this preamble — not SKILL.md text — is the
+# only place an agent cannot reason past. Pass 1 enumerates gaps; Pass 2 validates
+# per-gap file:line pointers. Grandfathering is ID-based (rdr_id_int < 65), never
+# date-based — see CA-4 in docs/rdr/rdr-065-close-time-funnel-hardening.md.
+if (close_reason or '').lower() == 'implemented':
+    def _extract_section(doc, *headings):
+        """Extract content under the first matching heading variant."""
+        for heading in headings:
+            idx = doc.find(heading)
+            if idx != -1:
+                rest = doc[idx + len(heading):]
+                nxt = re.search(r'\n## ', rest)
+                return rest[:nxt.start()] if nxt else rest
+        return ''
+
+    def _parse_pointers(s):
+        out = {}
+        for tok in s.split(','):
+            tok = tok.strip()
+            if '=' in tok:
+                k, _, v = tok.partition('=')
+                out[k.strip()] = v.strip()
+        return out
+
+    try:
+        rdr_id_int = int(t2_key)
+    except ValueError:
+        rdr_id_int = -1
+    rdr_id_label = t2_key
+    # Search for both heading variants — RDRs use either form.
+    problem_stmt = _extract_section(text, '## Problem Statement', '## Problem')
+    # Regex permits parenthetical context between number and colon
+    # (e.g., `#### Gap 4 (prerequisite for Gap 1): <title>`) — author convenience.
+    # Also matches `###` (3 hashes) and `#####` (5 hashes) for resilience.
+    gap_matches = re.findall(r'^#{3,5} Gap (\d+)([^\n:]*):\s*(.*)$', problem_stmt, re.MULTILINE)
+    gap_count = len(gap_matches)
+
+    if rdr_id_int < 65 and gap_count == 0:
+        # GRANDFATHERING: legacy RDR with no structured gaps — warn and proceed.
+        print("> **WARN**: This RDR predates structured gaps; no action required — gate does not apply.")
+        print()
+    elif rdr_id_int >= 65 and gap_count == 0:
+        # MALFORMED-NEW: post-policy RDR is missing the required gap headings — block.
+        print(f"> **ERROR**: RDR-{rdr_id_label} has no `#### Gap N: <title>` headings in `## Problem Statement` or `## Problem`.")
+        print(r"> Expected format: `#### Gap 1: <gap title>` (regex: `^#{3,5} Gap \d+:`)")
+        print()
+        sys.exit(0)
+    elif gap_count > 0 and not pointers_arg:
+        # PASS 1: enumerate gaps and instruct re-invoke with --pointers.
+        print("### Problem Statement Gaps")
+        print()
+        for num, qual, title in gap_matches:
+            qual_str = qual.strip()
+            qual_disp = f" {qual_str}" if qual_str else ""
+            print(f"- Gap{num}{qual_disp}: {title.strip()}")
+        print()
+        print("**Re-invoke with per-gap closure pointers:**")
+        print()
+        example = ",".join(f"Gap{num}=path/to/file.py:LINE" for num, _q, _t in gap_matches)
+        print(f"```\n/conexus:rdr-close {rdr_id_label} --reason implemented --pointers '{example}'\n```")
+        print()
+        sys.exit(0)
+    else:
+        # PASS 2: validate that every gap has a pointer and the file exists.
+        # Shape enforcement (RDR-065 6b review fix): the pointer MUST be in
+        # `file:line` shape — a colon followed by at least one digit. A bare
+        # filename like `Gap1=README.md` would otherwise game the gate.
+        pointers = _parse_pointers(pointers_arg)
+        failures = []
+        for num, _qual, _title in gap_matches:
+            gap_key = f"Gap{num}"
+            if gap_key not in pointers:
+                failures.append(f"{gap_key}: no pointer supplied")
+                continue
+            ptr = pointers[gap_key]
+            file_part, sep, line_part = ptr.partition(':')
+            if not sep:
+                failures.append(f"{gap_key}: pointer '{ptr}' missing ':LINE' — expected file:line shape")
+                continue
+            if not re.match(r'^\d+', line_part):
+                failures.append(f"{gap_key}: pointer '{ptr}' has no line number after ':' — expected file:line shape")
+                continue
+            if not (Path(repo_root) / file_part).exists():
+                failures.append(f"{gap_key}: file '{file_part}' does not exist in repo")
+        if failures:
+            print("> **ERROR**: Problem Statement pointer validation failed:")
+            for f in failures:
+                print(f">   - {f}")
+            print(">")
+            print("> The gate verifies you have committed to a specific file:line pointer per gap.")
+            print("> It does not verify the pointer is semantically correct.")
+            print()
+            sys.exit(0)
+        # Validation passed — emit framing and set T1 active-close marker.
+        print("### PROBLEM STATEMENT REPLAY: validation passed")
+        print()
+        for gap_key, ptr in sorted(pointers.items()):
+            print(f"- {gap_key} → {ptr}")
+        print()
+        print("> The gate verifies you have committed to a specific file:line pointer per gap.")
+        print("> It does not verify the pointer is semantically correct. Correctness is your responsibility.")
+        print()
+        try:
+            subprocess.run(
+                ['nx', 'scratch', 'put', rdr_id_label,
+                 '--tags', f'rdr-close-active,rdr-{rdr_id_label}'],
+                capture_output=True, timeout=5)
+        except Exception:
+            pass
+
+# T2 metadata (current status)
+print("### T2 Metadata (current status)")
+print(f"Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}\" to retrieve T2 metadata.")
+print()
+
+# Bead status gate
+print("### Bead Status Advisory")
+print(f"Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}\" to check for `epic_bead` field.")
+print(f"If `epic_bead` exists, run `bd show <epic-id>` to display child bead statuses.")
+print(f"If no `epic_bead`, check command output for open beads listed below.")
+print()
+
+# Active beads — check for open beads linked to this RDR's epic
+has_open_beads = False
+print("### Active Beads")
+try:
+    # Check epic bead children first
+    result = subprocess.run(
+        ['bd', 'list', '--status=open,in_progress', '--limit=20'],
+        capture_output=True, text=True, timeout=10)
+    bd_out = (result.stdout or '').strip()
+    if bd_out and bd_out != "No issues found.":
+        has_open_beads = True
+        print(bd_out)
+    else:
+        print("No open or in-progress beads.")
+except Exception as exc:
+    print(f"Beads not available: {exc}")
+
+if has_open_beads:
+    print()
+    print("> **⚠ WARNING: Open beads exist.** You MUST ask the user for explicit")
+    print("> confirmation before closing this RDR. Do NOT proceed without their approval.")
+    print("> Show them the open beads above and ask: \"Close RDR with these beads still open?\"")
+    print()
+PYEOF
+```
 
 ## RDR to Close
 

--- a/conexus/commands/rdr-create.md
+++ b/conexus/commands/rdr-create.md
@@ -1,12 +1,187 @@
 ---
+allowed-tools: Bash
 description: Create a new RDR — scaffold from template, assign sequential ID, register in T2
 ---
 
 # New RDR
 
-!{
-NEXUS_RDR_ARGS="${ARGUMENTS:-}" python3 "$CLAUDE_PLUGIN_ROOT/resources/rdr_commands/rdr_create.py"
-}
+```!
+NEXUS_RDR_ARGS="$ARGUMENTS" python3 <<'PYEOF'
+import os, sys, re, subprocess
+from pathlib import Path
+
+args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
+
+# Repo root and name
+try:
+    repo_root = subprocess.check_output(
+        ['git', 'rev-parse', '--show-toplevel'],
+        stderr=subprocess.DEVNULL, text=True).strip()
+    repo_name = os.path.basename(repo_root)
+except Exception:
+    repo_root = os.getcwd()
+    repo_name = os.path.basename(repo_root)
+
+# Resolve RDR directory from .nexus.yml (default: docs/rdr)
+rdr_dir = 'docs/rdr'
+nexus_yml = Path(repo_root) / '.nexus.yml'
+if nexus_yml.exists():
+    content = nexus_yml.read_text()
+    try:
+        import yaml
+        d = yaml.safe_load(content) or {}
+        paths = (d.get('indexing') or {}).get('rdr_paths', ['docs/rdr'])
+        rdr_dir = paths[0] if paths else 'docs/rdr'
+    except ImportError:
+        m_yml = (re.search(r'rdr_paths[^\[]*\[([^\]]+)\]', content) or
+                 re.search(r'rdr_paths:\s*\n\s+-\s*(.+)', content))
+        if m_yml:
+            v = m_yml.group(1)
+            parts = re.findall(r'[a-z][a-z0-9/_-]+', v)
+            rdr_dir = parts[0] if parts else 'docs/rdr'
+
+rdr_path = Path(repo_root) / rdr_dir
+
+print(f"**Repo:** `{repo_name}`  **RDR directory:** `{rdr_dir}`")
+print()
+
+
+def parse_frontmatter(filepath):
+    text = filepath.read_text(errors='replace')
+    meta = {}
+    if text.startswith('---'):
+        parts = text.split('---', 2)
+        if len(parts) >= 3:
+            block = parts[1]
+            try:
+                import yaml; meta = yaml.safe_load(block) or {}
+            except Exception:
+                for line in block.splitlines():
+                    if ':' in line:
+                        k, _, v = line.partition(':')
+                        meta[k.strip().lower()] = v.strip()
+    else:
+        m = re.search(r'^## Metadata\s*\n(.*?)(?=^##|\Z)', text, re.MULTILINE | re.DOTALL)
+        if m:
+            for line in m.group(1).splitlines():
+                kv = re.match(r'-?\s*\*\*(\w[\w\s]*?)\*\*:\s*(.+)', line.strip())
+                if kv:
+                    meta[kv.group(1).strip().lower()] = kv.group(2).strip()
+    if 'title' not in meta and 'name' not in meta:
+        h1 = re.search(r'^#\s+(.+)', text, re.MULTILINE)
+        if h1:
+            meta['title'] = h1.group(1).strip()
+    return meta, text
+
+
+def find_rdr_file(rdr_path, id_str):
+    m = re.search(r'\d+', id_str)
+    if not m:
+        return None
+    num_int = int(m.group(0))
+    for f in sorted(rdr_path.glob('*.md')):
+        nums = re.findall(r'\d+', f.stem)
+        if nums and int(nums[0]) == num_int:
+            return f
+    return None
+
+
+EXCLUDED = {'readme.md', 'template.md', 'index.md', 'overview.md', 'workflow.md', 'templates.md'}
+
+def get_all_rdrs(rdr_path):
+    """Return list of dicts for all RDRs in the directory."""
+    all_md = sorted(rdr_path.glob('*.md'))
+    rdrs = []
+    for f in all_md:
+        if f.name.lower() in EXCLUDED:
+            continue
+        fm, text = parse_frontmatter(f)
+        rtype = fm.get('type', '?')
+        doc_status = fm.get('status', '?')
+        if doc_status == '?' and rtype == '?':
+            continue  # prose doc, not an RDR
+        rdrs.append({
+            'file': f.name,
+            'path': f,
+            'text': text,
+            'title': fm.get('title', fm.get('name', f.stem)),
+            'status': doc_status,
+            'rtype': rtype,
+            'priority': fm.get('priority', '?'),
+        })
+    return rdrs
+
+
+if not rdr_path.exists():
+    print(f"> RDR directory `{rdr_dir}` does not exist — bootstrap required.")
+    print()
+    print("**Next ID:** `RDR-001`")
+    print("**ID style detected:** `RDR-NNN-kebab-title.md` (default — no existing files)")
+    print()
+    print("### Existing RDRs (0 found)")
+    print()
+    print("None — this will be the first RDR.")
+else:
+    rdrs = get_all_rdrs(rdr_path)
+
+    # Detect ID style from existing files
+    rdr_prefix_style = False
+    numeric_style = False
+    for r in rdrs:
+        if re.match(r'^RDR-\d+', r['file']):
+            rdr_prefix_style = True
+            break
+        elif re.match(r'^\d+', r['file']):
+            numeric_style = True
+
+    if rdr_prefix_style:
+        id_style = 'RDR-NNN-kebab-title.md'
+    elif numeric_style:
+        id_style = 'NNN-kebab-title.md'
+    else:
+        id_style = 'RDR-NNN-kebab-title.md'  # default for new repos
+
+    # Compute next sequential ID
+    max_num = 0
+    for r in rdrs:
+        nums = re.findall(r'\d+', r['file'])
+        if nums:
+            max_num = max(max_num, int(nums[0]))
+    next_num = max_num + 1
+
+    if rdr_prefix_style:
+        next_id = f"RDR-{next_num:03d}"
+    else:
+        next_id = f"{next_num:03d}"
+
+    print(f"**Next ID:** `{next_id}`")
+    print(f"**ID style detected:** `{id_style}`")
+    print()
+    print(f"### Existing RDRs ({len(rdrs)} found)")
+    print()
+    if rdrs:
+        print("| File | Title | Status |")
+        print("|------|-------|--------|")
+        for r in rdrs:
+            print(f"| {r['file']} | {r['title']} | {r['status']} |")
+    else:
+        print("None — this will be the first RDR.")
+
+print()
+
+# Active beads (for Related Issues field)
+print("### Active Beads (for Related Issues field)")
+try:
+    result = subprocess.run(
+        ['bd', 'list', '--status=in_progress', '--limit=5'],
+        capture_output=True, text=True, timeout=10)
+    bd_out = (result.stdout or '').strip()
+    print(bd_out if bd_out else "No in-progress beads")
+except Exception as exc:
+    print(f"Beads not available: {exc}")
+print()
+PYEOF
+```
 
 ## Title / Details
 

--- a/conexus/commands/rdr-gate.md
+++ b/conexus/commands/rdr-gate.md
@@ -1,12 +1,228 @@
 ---
+allowed-tools: Bash
 description: Run finalization gate on an RDR — structural, assumption audit, and AI critique
 ---
 
 # RDR Gate
 
-!{
-NEXUS_RDR_ARGS="${ARGUMENTS:-}" python3 "$CLAUDE_PLUGIN_ROOT/resources/rdr_commands/rdr_gate.py"
-}
+```!
+NEXUS_RDR_ARGS="$ARGUMENTS" python3 <<'PYEOF'
+import os, sys, re, subprocess
+from pathlib import Path
+
+args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
+
+# Repo root and name
+try:
+    repo_root = subprocess.check_output(
+        ['git', 'rev-parse', '--show-toplevel'],
+        stderr=subprocess.DEVNULL, text=True).strip()
+    repo_name = os.path.basename(repo_root)
+except Exception:
+    repo_root = os.getcwd()
+    repo_name = os.path.basename(repo_root)
+
+# Resolve RDR directory from .nexus.yml (default: docs/rdr)
+rdr_dir = 'docs/rdr'
+nexus_yml = Path(repo_root) / '.nexus.yml'
+if nexus_yml.exists():
+    content = nexus_yml.read_text()
+    try:
+        import yaml
+        d = yaml.safe_load(content) or {}
+        paths = (d.get('indexing') or {}).get('rdr_paths', ['docs/rdr'])
+        rdr_dir = paths[0] if paths else 'docs/rdr'
+    except ImportError:
+        m_yml = (re.search(r'rdr_paths[^\[]*\[([^\]]+)\]', content) or
+                 re.search(r'rdr_paths:\s*\n\s+-\s*(.+)', content))
+        if m_yml:
+            v = m_yml.group(1)
+            parts = re.findall(r'[a-z][a-z0-9/_-]+', v)
+            rdr_dir = parts[0] if parts else 'docs/rdr'
+
+rdr_path = Path(repo_root) / rdr_dir
+
+print(f"**Repo:** `{repo_name}`  **RDR directory:** `{rdr_dir}`")
+print()
+
+
+def parse_frontmatter(filepath):
+    text = filepath.read_text(errors='replace')
+    meta = {}
+    if text.startswith('---'):
+        parts = text.split('---', 2)
+        if len(parts) >= 3:
+            block = parts[1]
+            try:
+                import yaml; meta = yaml.safe_load(block) or {}
+            except Exception:
+                for line in block.splitlines():
+                    if ':' in line:
+                        k, _, v = line.partition(':')
+                        meta[k.strip().lower()] = v.strip()
+    if 'title' not in meta and 'name' not in meta:
+        h1 = re.search(r'^#\s+(.+)', text, re.MULTILINE)
+        if h1:
+            meta['title'] = h1.group(1).strip()
+    return meta, text
+
+
+def find_rdr_file(rdr_path, id_str):
+    m = re.search(r'\d+', id_str)
+    if not m:
+        return None
+    num_int = int(m.group(0))
+    for f in sorted(rdr_path.glob('*.md')):
+        nums = re.findall(r'\d+', f.stem)
+        if nums and int(nums[0]) == num_int:
+            return f
+    return None
+
+
+EXCLUDED = {'readme.md', 'template.md', 'index.md', 'overview.md', 'workflow.md', 'templates.md'}
+
+def get_all_rdrs(rdr_path):
+    """Return list of dicts for all RDRs in the directory."""
+    all_md = sorted(rdr_path.glob('*.md'))
+    rdrs = []
+    for f in all_md:
+        if f.name.lower() in EXCLUDED:
+            continue
+        fm, text = parse_frontmatter(f)
+        rtype = fm.get('type', '?')
+        doc_status = fm.get('status', '?')
+        if doc_status == '?' and rtype == '?':
+            continue  # prose doc, not an RDR
+        rdrs.append({
+            'file': f.name,
+            'path': f,
+            'text': text,
+            'title': fm.get('title', fm.get('name', f.stem)),
+            'status': doc_status,
+            'rtype': rtype,
+            'priority': fm.get('priority', '?'),
+        })
+    return rdrs
+
+
+if not rdr_path.exists():
+    print(f"> No RDRs found — `{rdr_dir}` does not exist in this repo.")
+    sys.exit(0)
+
+id_match = re.search(r'\d+', args)
+
+if not id_match:
+    print("> **Usage**: `/conexus:rdr-gate <id>` — e.g. `/conexus:rdr-gate 003` or `/conexus:rdr-gate RDR-003`")
+    print()
+    rdrs = get_all_rdrs(rdr_path)
+    print("### Available RDRs")
+    print()
+    if rdrs:
+        print("| File | Title | Status | Type |")
+        print("|------|-------|--------|------|")
+        for r in rdrs:
+            print(f"| {r['file']} | {r['title']} | {r['status']} | {r['rtype']} |")
+    else:
+        print(f"No RDRs found in `{rdr_dir}`")
+    sys.exit(0)
+
+rdr_file = find_rdr_file(rdr_path, id_match.group(0))
+if not rdr_file:
+    print(f"> RDR not found for ID: `{id_match.group(0)}`")
+    sys.exit(0)
+
+fm, text = parse_frontmatter(rdr_file)
+title = fm.get('title', fm.get('name', rdr_file.stem))
+rdr_num = re.search(r'\d+', rdr_file.stem)
+t2_key = rdr_num.group(0) if rdr_num else rdr_file.stem
+
+print(f"### RDR File: {rdr_file.name}")
+print(f"**Title:** {title}  **Status:** {fm.get('status', '?')}  **Type:** {fm.get('type', '?')}")
+print()
+
+# Strip fenced code blocks before extracting headings (avoids # comment false positives)
+def strip_code_blocks(src):
+    return re.sub(r'```.*?```', '', src, flags=re.DOTALL)
+
+
+# Gap-structure pre-check (nexus-4qpb): the close skill enforces
+# `#### Gap N: <title>` headings in Problem Statement for post-65 RDRs.
+# Enforcing it only at close meant authors could gate, accept, and
+# then discover the rule at the worst possible time. Shift left: block
+# the gate here so missing gaps can't survive to close. Matches the
+# close skill's regex and grandfathering threshold (id < 65).
+_skip_gaps = '--skip-gaps' in args
+_problem_idx = text.find('## Problem Statement')
+if _problem_idx == -1:
+    _problem_idx = text.find('## Problem')
+_problem_section = ''
+if _problem_idx != -1:
+    _rest = text[_problem_idx:]
+    _nxt = re.search(r'\n## ', _rest[1:])
+    _problem_section = _rest[:_nxt.start() + 1] if _nxt else _rest
+_gap_headings = re.findall(r'^#{3,5} Gap (\d+)([^\n:]*):\s*(.*)$', _problem_section, re.MULTILINE)
+try:
+    _rdr_id_int = int(t2_key)
+except ValueError:
+    _rdr_id_int = -1
+
+if _rdr_id_int >= 65 and len(_gap_headings) == 0 and not _skip_gaps:
+    print(f"> **BLOCKED** (Layer 1 — gap structure): RDR-{t2_key} has no `#### Gap N: <title>` "
+          f"headings in `## Problem Statement` or `## Problem`.")
+    print(r"> Expected format: `#### Gap 1: <gap title>` (regex: `^#{3,5} Gap \d+:`).")
+    print(">")
+    print("> The close skill enforces the same structure and will block `/conexus:rdr-close "
+          "--reason implemented`. Add the headings now before accept, or re-run the gate "
+          "with `--skip-gaps` to record an intentional override in the audit trail.")
+    sys.exit(0)
+elif _rdr_id_int >= 65 and len(_gap_headings) > 0:
+    print(f"#### Gap structure: {len(_gap_headings)} gap heading(s) present")
+    print()
+    for _num, _qual, _title in _gap_headings:
+        _qual_str = _qual.strip()
+        _qual_disp = f" {_qual_str}" if _qual_str else ""
+        print(f"- Gap{_num}{_qual_disp}: {_title.strip()}")
+    print()
+elif _rdr_id_int < 65 and len(_gap_headings) == 0:
+    print(f"> **Note**: RDR-{t2_key} predates the gap-structure convention (id < 65) — "
+          "skipping the Layer 1 gap check.")
+    print()
+
+clean = strip_code_blocks(text)
+
+# Section headings (structural completeness check — Layer 1)
+headings = re.findall(r'^(#{1,3} .+)', clean, re.MULTILINE)
+print("#### Section Structure (for completeness check)")
+print()
+for h in headings:
+    print(h)
+print()
+
+# Section summaries: first non-empty, non-heading line of each ## section
+print("#### Section Summaries")
+print()
+sections = re.split(r'^(## .+)', clean, flags=re.MULTILINE)
+for i in range(1, len(sections) - 1, 2):
+    heading = sections[i].strip()
+    body = sections[i + 1]
+    first_lines = [l.strip() for l in body.splitlines()
+                   if l.strip() and not l.strip().startswith('#')]
+    summary = first_lines[0][:120] if first_lines else '_empty_'
+    print(f"**{heading}**: {summary}")
+print()
+
+# T2 metadata
+print("### T2 Metadata")
+print(f"Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}\" to retrieve T2 metadata.")
+print()
+
+# T2 research findings
+print("### T2 Research Findings")
+print(f"Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"\" to list all entries, then filter for {t2_key}-research* titles.")
+print(f"If no research findings exist, run `/conexus:rdr-research add {t2_key}` to record findings before gating.")
+print(f"Use `--skip-research` in your gate command to override.")
+PYEOF
+```
 
 ## RDR to Gate
 

--- a/conexus/commands/rdr-list.md
+++ b/conexus/commands/rdr-list.md
@@ -1,12 +1,160 @@
 ---
+allowed-tools: Bash
 description: List all RDRs with status, type, and priority
 ---
 
 # RDR List
 
-!{
-NEXUS_RDR_ARGS="${ARGUMENTS:-}" python3 "$CLAUDE_PLUGIN_ROOT/resources/rdr_commands/rdr_list.py"
-}
+```!
+NEXUS_RDR_ARGS="$ARGUMENTS" python3 <<'PYEOF'
+import os, sys, re, subprocess
+from pathlib import Path
+
+args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
+
+# Repo root and name
+try:
+    repo_root = subprocess.check_output(
+        ['git', 'rev-parse', '--show-toplevel'],
+        stderr=subprocess.DEVNULL, text=True).strip()
+    repo_name = os.path.basename(repo_root)
+except Exception:
+    repo_root = os.getcwd()
+    repo_name = os.path.basename(repo_root)
+
+# Resolve RDR directory from .nexus.yml (default: docs/rdr)
+rdr_dir = 'docs/rdr'
+nexus_yml = Path(repo_root) / '.nexus.yml'
+if nexus_yml.exists():
+    content = nexus_yml.read_text()
+    try:
+        import yaml
+        d = yaml.safe_load(content) or {}
+        paths = (d.get('indexing') or {}).get('rdr_paths', ['docs/rdr'])
+        rdr_dir = paths[0] if paths else 'docs/rdr'
+    except ImportError:
+        m_yml = (re.search(r'rdr_paths[^\[]*\[([^\]]+)\]', content) or
+                 re.search(r'rdr_paths:\s*\n\s+-\s*(.+)', content))
+        if m_yml:
+            v = m_yml.group(1)
+            parts = re.findall(r'[a-z][a-z0-9/_-]+', v)
+            rdr_dir = parts[0] if parts else 'docs/rdr'
+
+rdr_path = Path(repo_root) / rdr_dir
+
+print(f"**Repo:** `{repo_name}`  **RDR directory:** `{rdr_dir}`")
+print()
+
+if not rdr_path.exists():
+    print(f"> No RDRs found — `{rdr_dir}` does not exist in this repo.")
+    sys.exit(0)
+
+
+def _parse_t2_field(content, field):
+    """Extract a field value from T2 content."""
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(f"{field}:"):
+            val = stripped.split(":", 1)[1].strip().strip('"').strip("'")
+            return val
+    return None
+
+
+def get_rdrs_from_t2(repo_name):
+    """Read RDR list from T2 (process authority) using batch API. Returns list of dicts."""
+    rdrs = []
+    try:
+        from nexus.commands._helpers import default_db_path
+        from nexus.db.t2 import T2Database
+
+        with T2Database(default_db_path()) as db:
+            entries = db.get_all(project=f"{repo_name}_rdr")
+            for entry in entries:
+                title = entry.get("title", "")
+                if not re.match(r'^\d+$', title):
+                    continue  # skip gate-latest, research, etc.
+                content = entry.get("content", "")
+                rdrs.append({
+                    'id': title,
+                    'title': _parse_t2_field(content, 'title') or title,
+                    'status': _parse_t2_field(content, 'status') or '?',
+                    'rtype': _parse_t2_field(content, 'type') or '?',
+                    'priority': _parse_t2_field(content, 'priority') or '?',
+                    'file_path': _parse_t2_field(content, 'file_path') or f'{rdr_dir}/{title}-*.md',
+                })
+    except Exception:
+        pass
+    return rdrs
+
+
+def parse_frontmatter(filepath):
+    text = filepath.read_text(errors='replace')
+    meta = {}
+    if text.startswith('---'):
+        parts = text.split('---', 2)
+        if len(parts) >= 3:
+            block = parts[1]
+            try:
+                import yaml; meta = yaml.safe_load(block) or {}
+            except Exception:
+                for line in block.splitlines():
+                    if ':' in line:
+                        k, _, v = line.partition(':')
+                        meta[k.strip().lower()] = v.strip()
+    if 'title' not in meta and 'name' not in meta:
+        h1 = re.search(r'^#\s+(.+)', text, re.MULTILINE)
+        if h1:
+            meta['title'] = h1.group(1).strip()
+    return meta, text
+
+
+EXCLUDED = {'readme.md', 'template.md', 'index.md', 'overview.md', 'workflow.md', 'templates.md'}
+
+
+def get_all_rdrs_from_files(rdr_path):
+    """Fallback: read RDR list from files."""
+    all_md = sorted(rdr_path.glob('*.md'))
+    rdrs = []
+    for f in all_md:
+        if f.name.lower() in EXCLUDED:
+            continue
+        fm, text = parse_frontmatter(f)
+        rtype = fm.get('type', '?')
+        doc_status = fm.get('status', '?')
+        if doc_status == '?' and rtype == '?':
+            continue
+        nums = re.findall(r'\d+', f.stem)
+        rdrs.append({
+            'id': nums[0] if nums else f.stem,
+            'file': f.name,
+            'title': fm.get('title', fm.get('name', f.stem)),
+            'status': doc_status,
+            'rtype': rtype,
+            'priority': fm.get('priority', '?'),
+        })
+    return rdrs
+
+
+# Primary: read from T2
+rdrs = get_rdrs_from_t2(repo_name)
+source = 'T2'
+
+# Fallback: read from files if T2 is empty
+if not rdrs:
+    rdrs = get_all_rdrs_from_files(rdr_path)
+    source = 'files'
+
+print(f"### RDRs ({len(rdrs)} found, source: {source})")
+print()
+if rdrs:
+    print("| ID | Title | Status | Type | Priority |")
+    print("|----|-------|--------|------|----------|")
+    for r in rdrs:
+        print(f"| {r['id']} | {r['title']} | {r['status']} | {r['rtype']} | {r['priority']} |")
+else:
+    print(f"No RDRs found in `{rdr_dir}`")
+PYEOF
+```
 
 ## Filters
 

--- a/conexus/commands/rdr-research.md
+++ b/conexus/commands/rdr-research.md
@@ -1,12 +1,190 @@
 ---
+allowed-tools: Bash
 description: Add, track, or verify structured research findings for an active RDR
 ---
 
 # RDR Research
 
-!{
-NEXUS_RDR_ARGS="${ARGUMENTS:-}" python3 "$CLAUDE_PLUGIN_ROOT/resources/rdr_commands/rdr_research.py"
-}
+```!
+NEXUS_RDR_ARGS="$ARGUMENTS" python3 <<'PYEOF'
+import os, sys, re, subprocess
+from pathlib import Path
+
+args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
+
+# Repo root and name
+try:
+    repo_root = subprocess.check_output(
+        ['git', 'rev-parse', '--show-toplevel'],
+        stderr=subprocess.DEVNULL, text=True).strip()
+    repo_name = os.path.basename(repo_root)
+except Exception:
+    repo_root = os.getcwd()
+    repo_name = os.path.basename(repo_root)
+
+# Resolve RDR directory from .nexus.yml (default: docs/rdr)
+rdr_dir = 'docs/rdr'
+nexus_yml = Path(repo_root) / '.nexus.yml'
+if nexus_yml.exists():
+    content = nexus_yml.read_text()
+    try:
+        import yaml
+        d = yaml.safe_load(content) or {}
+        paths = (d.get('indexing') or {}).get('rdr_paths', ['docs/rdr'])
+        rdr_dir = paths[0] if paths else 'docs/rdr'
+    except ImportError:
+        m_yml = (re.search(r'rdr_paths[^\[]*\[([^\]]+)\]', content) or
+                 re.search(r'rdr_paths:\s*\n\s+-\s*(.+)', content))
+        if m_yml:
+            v = m_yml.group(1)
+            parts = re.findall(r'[a-z][a-z0-9/_-]+', v)
+            rdr_dir = parts[0] if parts else 'docs/rdr'
+
+rdr_path = Path(repo_root) / rdr_dir
+
+print(f"**Repo:** `{repo_name}`  **RDR directory:** `{rdr_dir}`")
+print()
+
+
+def parse_frontmatter(filepath):
+    text = filepath.read_text(errors='replace')
+    meta = {}
+    if text.startswith('---'):
+        parts = text.split('---', 2)
+        if len(parts) >= 3:
+            block = parts[1]
+            try:
+                import yaml; meta = yaml.safe_load(block) or {}
+            except Exception:
+                for line in block.splitlines():
+                    if ':' in line:
+                        k, _, v = line.partition(':')
+                        meta[k.strip().lower()] = v.strip()
+    else:
+        m = re.search(r'^## Metadata\s*\n(.*?)(?=^##|\Z)', text, re.MULTILINE | re.DOTALL)
+        if m:
+            for line in m.group(1).splitlines():
+                kv = re.match(r'-?\s*\*\*(\w[\w\s]*?)\*\*:\s*(.+)', line.strip())
+                if kv:
+                    meta[kv.group(1).strip().lower()] = kv.group(2).strip()
+    if 'title' not in meta and 'name' not in meta:
+        h1 = re.search(r'^#\s+(.+)', text, re.MULTILINE)
+        if h1:
+            meta['title'] = h1.group(1).strip()
+    return meta, text
+
+
+def find_rdr_file(rdr_path, id_str):
+    m = re.search(r'\d+', id_str)
+    if not m:
+        return None
+    num_int = int(m.group(0))
+    for f in sorted(rdr_path.glob('*.md')):
+        nums = re.findall(r'\d+', f.stem)
+        if nums and int(nums[0]) == num_int:
+            return f
+    return None
+
+
+EXCLUDED = {'readme.md', 'template.md', 'index.md', 'overview.md', 'workflow.md', 'templates.md'}
+
+def get_all_rdrs(rdr_path):
+    """Return list of dicts for all RDRs in the directory."""
+    all_md = sorted(rdr_path.glob('*.md'))
+    rdrs = []
+    for f in all_md:
+        if f.name.lower() in EXCLUDED:
+            continue
+        fm, text = parse_frontmatter(f)
+        rtype = fm.get('type', '?')
+        doc_status = fm.get('status', '?')
+        if doc_status == '?' and rtype == '?':
+            continue  # prose doc, not an RDR
+        rdrs.append({
+            'file': f.name,
+            'path': f,
+            'text': text,
+            'title': fm.get('title', fm.get('name', f.stem)),
+            'status': doc_status,
+            'rtype': rtype,
+            'priority': fm.get('priority', '?'),
+        })
+    return rdrs
+
+
+if not rdr_path.exists():
+    print(f"> No RDRs found — `{rdr_dir}` does not exist in this repo.")
+    sys.exit(0)
+
+# Extract numeric ID from args (skip subcommand words like "add", "status", "verify")
+id_match = re.search(r'\d+', args)
+
+if id_match:
+    rdr_file = find_rdr_file(rdr_path, id_match.group(0))
+    if rdr_file:
+        fm, text = parse_frontmatter(rdr_file)
+        title = fm.get('title', fm.get('name', rdr_file.stem))
+        rdr_num = re.search(r'\d+', rdr_file.stem)
+        t2_key = rdr_num.group(0) if rdr_num else rdr_file.stem
+
+        print(f"### RDR {t2_key}: {title}")
+        print(f"**File:** `{rdr_file.name}`")
+        print()
+
+        # Show the Research Findings section from the file
+        rf_match = re.search(
+            r'^## Research Findings\s*\n(.*?)(?=^## |\Z)',
+            text, re.MULTILINE | re.DOTALL)
+        print("#### Research Findings (from file)")
+        print()
+        if rf_match:
+            section = rf_match.group(1).strip()
+            print(section if section else "_No content in Research Findings section yet._")
+        else:
+            print("_No `## Research Findings` section found in this RDR._")
+        print()
+
+        # T2 research findings
+        print("### Existing Research Findings (T2)")
+        try:
+            result = subprocess.run(
+                ['nx', 'memory', 'list', '--project', f'{repo_name}_rdr'],
+                capture_output=True, text=True, timeout=10)
+            list_out = (result.stdout or '').strip()
+            research_lines = [l for l in list_out.splitlines()
+                              if re.match(rf'^{t2_key}-research', l)]
+            print('\n'.join(research_lines) if research_lines else "No research findings recorded yet")
+        except Exception as exc:
+            print(f"T2 not available: {exc}")
+    else:
+        print(f"> RDR not found for ID: `{id_match.group(0)}`")
+        print()
+        rdrs = get_all_rdrs(rdr_path)
+        print("### Available RDRs")
+        print()
+        if rdrs:
+            print("| File | Title | Status | Type |")
+            print("|------|-------|--------|------|")
+            for r in rdrs:
+                print(f"| {r['file']} | {r['title']} | {r['status']} | {r['rtype']} |")
+        else:
+            print(f"No RDRs found in `{rdr_dir}`")
+else:
+    # No ID — show available RDRs
+    rdrs = get_all_rdrs(rdr_path)
+    print("### Available RDRs")
+    print()
+    if rdrs:
+        print("| File | Title | Status | Type |")
+        print("|------|-------|--------|------|")
+        for r in rdrs:
+            print(f"| {r['file']} | {r['title']} | {r['status']} | {r['rtype']} |")
+    else:
+        print(f"No RDRs found in `{rdr_dir}`")
+    print()
+    print("> **Usage**: `/conexus:rdr-research <id>` or `/conexus:rdr-research add <id>` or `/conexus:rdr-research verify <id> <seq>`")
+PYEOF
+```
 
 ## Subcommand and Arguments
 

--- a/conexus/commands/rdr-show.md
+++ b/conexus/commands/rdr-show.md
@@ -1,12 +1,249 @@
 ---
+allowed-tools: Bash
 description: Show detailed information about a specific RDR including content, research findings, and linked beads
 ---
 
 # RDR Show
 
-!{
-NEXUS_RDR_ARGS="${ARGUMENTS:-}" python3 "$CLAUDE_PLUGIN_ROOT/resources/rdr_commands/rdr_show.py"
-}
+```!
+NEXUS_RDR_ARGS="$ARGUMENTS" python3 <<'PYEOF'
+import os, sys, re, subprocess
+from pathlib import Path
+
+args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
+
+# Repo root and name
+try:
+    repo_root = subprocess.check_output(
+        ['git', 'rev-parse', '--show-toplevel'],
+        stderr=subprocess.DEVNULL, text=True).strip()
+    repo_name = os.path.basename(repo_root)
+except Exception:
+    repo_root = os.getcwd()
+    repo_name = os.path.basename(repo_root)
+
+# Resolve RDR directory from .nexus.yml (default: docs/rdr)
+rdr_dir = 'docs/rdr'
+nexus_yml = Path(repo_root) / '.nexus.yml'
+if nexus_yml.exists():
+    content = nexus_yml.read_text()
+    try:
+        import yaml
+        d = yaml.safe_load(content) or {}
+        paths = (d.get('indexing') or {}).get('rdr_paths', ['docs/rdr'])
+        rdr_dir = paths[0] if paths else 'docs/rdr'
+    except ImportError:
+        m_yml = (re.search(r'rdr_paths[^\[]*\[([^\]]+)\]', content) or
+                 re.search(r'rdr_paths:\s*\n\s+-\s*(.+)', content))
+        if m_yml:
+            v = m_yml.group(1)
+            parts = re.findall(r'[a-z][a-z0-9/_-]+', v)
+            rdr_dir = parts[0] if parts else 'docs/rdr'
+
+rdr_path = Path(repo_root) / rdr_dir
+
+print(f"**Repo:** `{repo_name}`  **RDR directory:** `{rdr_dir}`")
+print()
+
+
+def parse_frontmatter(filepath):
+    text = filepath.read_text(errors='replace')
+    meta = {}
+    if text.startswith('---'):
+        parts = text.split('---', 2)
+        if len(parts) >= 3:
+            block = parts[1]
+            try:
+                import yaml; meta = yaml.safe_load(block) or {}
+            except Exception:
+                for line in block.splitlines():
+                    if ':' in line:
+                        k, _, v = line.partition(':')
+                        meta[k.strip().lower()] = v.strip()
+    else:
+        m = re.search(r'^## Metadata\s*\n(.*?)(?=^##|\Z)', text, re.MULTILINE | re.DOTALL)
+        if m:
+            for line in m.group(1).splitlines():
+                kv = re.match(r'-?\s*\*\*(\w[\w\s]*?)\*\*:\s*(.+)', line.strip())
+                if kv:
+                    meta[kv.group(1).strip().lower()] = kv.group(2).strip()
+    if 'title' not in meta and 'name' not in meta:
+        h1 = re.search(r'^#\s+(.+)', text, re.MULTILINE)
+        if h1:
+            meta['title'] = h1.group(1).strip()
+    return meta, text
+
+
+def find_rdr_file(rdr_path, id_str):
+    m = re.search(r'\d+', id_str)
+    if not m:
+        return None
+    num_int = int(m.group(0))
+    for f in sorted(rdr_path.glob('*.md')):
+        nums = re.findall(r'\d+', f.stem)
+        if nums and int(nums[0]) == num_int:
+            return f
+    return None
+
+
+def get_excerpt(text):
+    # Strip frontmatter or metadata section, return 250-char excerpt
+    if text.startswith('---'):
+        parts = text.split('---', 2)
+        text = parts[2] if len(parts) >= 3 else text
+    else:
+        m = re.search(r'^## Metadata\s*\n.*?(?=^##)', text, re.MULTILINE | re.DOTALL)
+        if m:
+            text = text[m.end():]
+    lines = [l.strip() for l in text.splitlines() if l.strip() and not l.startswith('#')]
+    return ' '.join(lines)[:250]
+
+
+EXCLUDED = {'readme.md', 'template.md', 'index.md', 'overview.md', 'workflow.md', 'templates.md'}
+
+def get_all_rdrs(rdr_path):
+    """Return list of dicts for all RDRs in the directory."""
+    all_md = sorted(rdr_path.glob('*.md'))
+    rdrs = []
+    for f in all_md:
+        if f.name.lower() in EXCLUDED:
+            continue
+        fm, text = parse_frontmatter(f)
+        rtype = fm.get('type', '?')
+        doc_status = fm.get('status', '?')
+        if doc_status == '?' and rtype == '?':
+            continue  # prose doc, not an RDR
+        rdrs.append({
+            'file': f.name,
+            'path': f,
+            'text': text,
+            'title': fm.get('title', fm.get('name', f.stem)),
+            'status': doc_status,
+            'rtype': rtype,
+            'priority': fm.get('priority', '?'),
+        })
+    return rdrs
+
+
+if not rdr_path.exists():
+    print(f"> No RDRs found — `{rdr_dir}` does not exist in this repo.")
+    sys.exit(0)
+
+if args:
+    # Show specific RDR
+    rdr_file = find_rdr_file(rdr_path, args)
+    if rdr_file:
+        fm, text = parse_frontmatter(rdr_file)
+        print(f"### RDR: {rdr_file.name}")
+        print()
+
+        # Metadata table
+        print("#### Metadata")
+        print()
+        print("| Field | Value |")
+        print("|-------|-------|")
+        for key in ('status', 'type', 'priority', 'title', 'author', 'date', 'supersedes', 'superseded-by'):
+            val = fm.get(key)
+            if val:
+                print(f"| {key.title()} | {val} |")
+        print()
+
+        # Full content
+        print("#### Content")
+        print()
+        print(text)
+        print()
+
+        # T2 metadata
+        print("### T2 Metadata")
+        rdr_num = re.search(r'\d+', rdr_file.stem)
+        t2_key = rdr_num.group(0) if rdr_num else rdr_file.stem
+        try:
+            result = subprocess.run(
+                ['nx', 'memory', 'get', '--project', f'{repo_name}_rdr', '--title', t2_key],
+                capture_output=True, text=True, timeout=10)
+            t2_out = (result.stdout or '').strip()
+            print(t2_out if t2_out else f"No T2 record for RDR {t2_key}")
+        except Exception as exc:
+            print(f"T2 not available: {exc}")
+        print()
+
+        # T2 research findings
+        print("### T2 Research Findings")
+        try:
+            result = subprocess.run(
+                ['nx', 'memory', 'list', '--project', f'{repo_name}_rdr'],
+                capture_output=True, text=True, timeout=10)
+            list_out = (result.stdout or '').strip()
+            research_lines = [l for l in list_out.splitlines()
+                              if re.match(rf'^{t2_key}-research', l)]
+            print('\n'.join(research_lines) if research_lines else "No research findings recorded")
+        except Exception as exc:
+            print(f"T2 not available: {exc}")
+        print()
+
+        # Linked beads
+        print("### Linked Beads")
+        try:
+            result = subprocess.run(
+                ['bd', 'list', '--status=open', '--limit=20'],
+                capture_output=True, text=True, timeout=10)
+            bd_out = (result.stdout or '').strip()
+            matching = [l for l in bd_out.splitlines()
+                        if re.search(rf'rdr.*{t2_key}|{t2_key}.*rdr', l, re.IGNORECASE)]
+            print('\n'.join(matching) if matching else "No beads linked (check epic_bead in T2)")
+        except Exception as exc:
+            print(f"Beads not available: {exc}")
+    else:
+        print(f"> RDR not found for: `{args}`")
+        print()
+        print("Available RDRs:")
+        rdrs = get_all_rdrs(rdr_path)
+        if rdrs:
+            print()
+            print("| File | Title | Status | Type | Priority |")
+            print("|------|-------|--------|------|----------|")
+            for r in rdrs:
+                print(f"| {r['file']} | {r['title']} | {r['status']} | {r['rtype']} | {r['priority']} |")
+else:
+    # No ID — show list (most recently modified first) + content index
+    all_md = [f for f in rdr_path.glob('*.md') if f.name.lower() not in EXCLUDED]
+    all_md_sorted = sorted(all_md, key=lambda f: f.stat().st_mtime, reverse=True)
+
+    rdrs = []
+    for f in all_md_sorted:
+        fm, text = parse_frontmatter(f)
+        rtype = fm.get('type', '?')
+        doc_status = fm.get('status', '?')
+        if doc_status == '?' and rtype == '?':
+            continue
+        rdrs.append({
+            'file': f.name,
+            'path': f,
+            'text': text,
+            'title': fm.get('title', fm.get('name', f.stem)),
+            'status': doc_status,
+            'rtype': rtype,
+            'priority': fm.get('priority', '?'),
+        })
+
+    print(f"### RDR Files ({len(rdrs)} found, most recently modified first)")
+    print()
+    if rdrs:
+        print("| File | Title | Status | Type | Priority |")
+        print("|------|-------|--------|------|----------|")
+        for r in rdrs:
+            print(f"| {r['file']} | {r['title']} | {r['status']} | {r['rtype']} | {r['priority']} |")
+        print()
+        print("### Content Index (for keyword and topic filtering)")
+        print()
+        for r in rdrs:
+            excerpt = get_excerpt(r['text'])
+            print(f"**{r['file']}**: {excerpt}")
+    else:
+        print(f"No RDR files found in `{rdr_dir}`")
+PYEOF
+```
 
 ## RDR to Show
 

--- a/conexus/commands/research.md
+++ b/conexus/commands/research.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Research topic using deep-research-synthesizer agent
 ---
 
 # Research Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -24,7 +25,7 @@ description: Research topic using deep-research-synthesizer agent
   echo "The agent will first search the T3 store for existing research on this topic."
   echo "Prior findings will be incorporated into the synthesis."
 
-}
+```
 
 ### Project Context
 

--- a/conexus/commands/review-code.md
+++ b/conexus/commands/review-code.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Review code changes using code-review-expert agent
 ---
 
 # Code Review Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -46,7 +47,7 @@ description: Review code changes using code-review-expert agent
   fi
   echo '```'
 
-}
+```
 
 ### Project Context
 

--- a/conexus/commands/substantive-critique.md
+++ b/conexus/commands/substantive-critique.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Constructive critique of code, plans, designs, or documentation using substantive-critic agent
 ---
 
 # Deep Critique Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -39,7 +40,7 @@ description: Constructive critique of code, plans, designs, or documentation usi
   echo "The substantive-critic analyzes structure, logical consistency, completeness, and spec conformance."
   echo "Findings are prioritized: Critical > Significant > Minor."
 
-}
+```
 
 ### Project Context
 

--- a/conexus/commands/test-validate.md
+++ b/conexus/commands/test-validate.md
@@ -1,10 +1,11 @@
 ---
+allowed-tools: Bash
 description: Validate tests using test-validator agent
 ---
 
 # Test Validation Request
 
-!{
+```!
   echo "## Context"
   echo ""
   echo "**Working directory:** $(pwd)"
@@ -51,7 +52,7 @@ description: Validate tests using test-validator agent
   fi
   echo '```'
 
-}
+```
 
 ### Project Context
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.1.1"
+version = "5.1.2"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.1.1",
+    "conexus>=5.1.2",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.1.1"
+version = "5.1.2"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/tests/cc-validation/runner.sh
+++ b/tests/cc-validation/runner.sh
@@ -52,7 +52,7 @@ trap cleanup EXIT
 
 echo "Setting up isolated test home at $TEST_HOME..."
 rm -rf "$TEST_HOME"
-mkdir -p "$TEST_HOME/.claude/plugins" "$TEST_HOME/.claude/agents" "$TEST_HOME/.claude/skills"
+mkdir -p "$TEST_HOME/.claude/plugins" "$TEST_HOME/.claude/agents" "$TEST_HOME/.claude/skills" "$TEST_HOME/.claude/commands"
 
 cp "$AUTH_DIR/.credentials.json" "$TEST_HOME/.claude/.credentials.json"
 if [[ -f "$AUTH_DIR/claude.json" ]]; then
@@ -92,8 +92,8 @@ reset_scenario_state() {
     rm -f "$TEST_HOME/.claude/settings.json" \
           "$TEST_HOME/.claude/.mcp.json" \
           "$STUB_LOG" "$HOOK_LOG"
-    rm -rf "$TEST_HOME/.claude/agents" "$TEST_HOME/.claude/skills"
-    mkdir -p "$TEST_HOME/.claude/agents" "$TEST_HOME/.claude/skills"
+    rm -rf "$TEST_HOME/.claude/agents" "$TEST_HOME/.claude/skills" "$TEST_HOME/.claude/commands"
+    mkdir -p "$TEST_HOME/.claude/agents" "$TEST_HOME/.claude/skills" "$TEST_HOME/.claude/commands"
     # Restore the dangerous-mode bypass — every scenario needs it.
     echo '{"skipDangerousModePermissionPrompt": true}' > "$TEST_HOME/.claude/settings.json"
 }
@@ -122,6 +122,15 @@ write_skill() {
     cp "$src" "$TEST_HOME/.claude/skills/$name/SKILL.md"
 }
 export -f write_skill
+
+# write_command <name> <src>: install a slash command (.claude/commands/<name>.md)
+# for the next claude_start. Used by scenario 19 (nexus-ln9y5) to validate that a
+# command's ```! bash-injection block actually renders.
+write_command() {
+    local name="$1" src="$2"
+    cp "$src" "$TEST_HOME/.claude/commands/$name.md"
+}
+export -f write_command
 
 # ─── Start tmux ───────────────────────────────────────────────────────────────
 

--- a/tests/cc-validation/scenarios/19_command_bash_injection_renders.sh
+++ b/tests/cc-validation/scenarios/19_command_bash_injection_renders.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Scenario 19 — nexus-ln9y5: command bash-injection RENDER PATH.
+#
+# This is the layer that no pytest can reach and that let conexus 5.1.1 ship a
+# non-working "fix": Claude Code only executes command bash injection in the
+# documented ```! fenced form (or inline !`cmd`). The legacy !{ } brace form —
+# used by every conexus command through 5.1.1 — emits as raw source and never
+# runs. This scenario drives a real Claude Code and proves:
+#
+#   Part A (positive): the converted rdr-list command's ```! block EXECUTES —
+#                      the RDR table renders in the pane.
+#   Part B (negative control): a !{ } brace-form probe does NOT execute — its
+#                      sentinel arithmetic is emitted verbatim, never evaluated.
+#
+# Part B is what makes Part A meaningful: it shows the test discriminates the
+# working syntax from the broken one. If a future CC starts honoring !{ },
+# Part B will flip and tell us the landscape changed.
+
+scenario "19 command_bash_injection_renders: fenced-bang executes, brace does not"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Bash"], "defaultMode": "bypassPermissions" }
+}
+EOF
+
+# Part A: the real converted command (inlines its Python into a ```! block).
+write_command "rdr-list" "$REPO_ROOT/conexus/commands/rdr-list.md"
+
+# Part B: a minimal brace-form probe. If !{ } executed, the pane would show
+# "BRACE-EXECUTED-2"; if emitted raw (expected), it shows the literal
+# "BRACE-EXECUTED-$((1+1))".
+write_command "brace-probe" /dev/stdin <<'EOF'
+---
+allowed-tools: Bash
+description: nexus-ln9y5 negative control — !{ } must NOT execute
+---
+
+# Brace Probe
+
+!{
+echo "BRACE-EXECUTED-$((1+1))"
+}
+
+Report whether the marker above is a literal or an evaluated number.
+EOF
+
+claude_start
+
+# ── Part A: the fenced-bang block must EXECUTE and render the RDR table ──────
+# The preamble scans docs/rdr and injects the RDR table; the model then
+# reformats it (so the literal "### RDRs (" header is reworded — do not grep
+# for it). Distinctive verbatim RDR titles prove the preamble executed and its
+# data flowed: the model cannot produce these without the injected output.
+# Raw-failure markers (unexpanded heredoc / $CLAUDE_PLUGIN_ROOT / auth error /
+# empty-scan) must be absent.
+claude_prompt "/rdr-list"
+claude_wait 90
+paneA="$(capture -3000)"
+if grep -qF 'Single-Writer Enforcement' <<<"$paneA" \
+   && grep -qF 'Storage Substrate Split' <<<"$paneA" \
+   && ! grep -qE 'python3 <<|CLAUDE_PLUGIN_ROOT|API Error|No RDRs found' <<<"$paneA"; then
+    pass "A: fenced-bang block executed — RDR data rendered, no raw/failure markers"
+else
+    fail "A: fenced-bang block did NOT render the RDR data (fix regressed?)"
+    tail -30 <<<"$paneA" | sed 's/^/    | /'
+fi
+
+# ── Part B: the brace form must NOT execute (negative control) ───────────────
+# If !{ } had been preprocessed, the body would show BRACE-EXECUTED-2 and the
+# literal $((1+1)) would be GONE. Its survival proves the brace form did not
+# execute. (Do NOT grep for BRACE-EXECUTED-2 — the model quotes it in prose
+# while explaining it was NOT produced.)
+claude_prompt "/brace-probe"
+claude_wait 30
+if capture -400 | grep -qF '$((1+1))'; then
+    pass "B: brace form did not execute — literal \$((1+1)) survived (negative control holds)"
+else
+    fail "B: literal \$((1+1)) absent — brace form may have executed (revisit nexus-ln9y5)"
+fi
+
+claude_exit
+scenario_end

--- a/tests/test_command_preamble_sync.py
+++ b/tests/test_command_preamble_sync.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-ln9y5: keep RDR command preambles in sync with their source scripts.
+
+The 9 RDR-lifecycle slash commands inline their Python preamble into a
+documented ```! fenced block via a ``python3 <<'PYEOF'`` heredoc (the brace
+``!{ }`` form never executed; the by-path ``$CLAUDE_PLUGIN_ROOT`` form failed
+because that var is empty in command bash). The canonical, directly-unit-tested
+code lives in ``conexus/resources/rdr_commands/<name>.py``; the ``.md`` inlines
+its code-after-docstring verbatim. This test enforces md-body == .py code so the
+two never drift, and runs each inlined body to prove it executes (Layer 1).
+"""
+from __future__ import annotations
+
+import ast
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+CMD = REPO_ROOT / "conexus" / "commands"
+RES = REPO_ROOT / "conexus" / "resources" / "rdr_commands"
+
+# command stem -> script stem
+RDR_COMMANDS = {
+    "rdr-list": "rdr_list",
+    "rdr-show": "rdr_show",
+    "rdr-gate": "rdr_gate",
+    "rdr-accept": "rdr_accept",
+    "rdr-close": "rdr_close",
+    "rdr-create": "rdr_create",
+    "rdr-research": "rdr_research",
+    "rdr-audit": "rdr_audit",
+    "phase-review-gate": "phase_review_gate",
+}
+
+_FENCED = re.compile(r"(?ms)^```!\n(?P<body>.*?)\n```[ \t]*$")
+_HEREDOC = re.compile(r"(?ms)<<'PYEOF'\n(?P<code>.*?)\nPYEOF$")
+
+
+def _code_after_docstring(py_text: str) -> str:
+    """Source with shebang/SPDX/module-docstring stripped (matches transformer)."""
+    tree = ast.parse(py_text)
+    body = tree.body
+    start = 0
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(getattr(body[0], "value", None), ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        start = body[0].end_lineno
+    return "\n".join(py_text.splitlines()[start:]).strip("\n")
+
+
+def _inlined_code(md_text: str) -> str:
+    fenced = _FENCED.search(md_text)
+    assert fenced, "no ```! fenced block"
+    hd = _HEREDOC.search(fenced.group("body"))
+    assert hd, "no python3 <<'PYEOF' heredoc inside the ```! block"
+    return hd.group("code")
+
+
+@pytest.mark.parametrize("cmd,script", sorted(RDR_COMMANDS.items()))
+def test_md_heredoc_matches_script_source(cmd: str, script: str) -> None:
+    md = (CMD / f"{cmd}.md").read_text()
+    py = (RES / f"{script}.py").read_text()
+    assert _inlined_code(md) == _code_after_docstring(py), (
+        f"{cmd}.md inlined body has drifted from {script}.py. "
+        "Re-inline the script's code-after-docstring (nexus-ln9y5)."
+    )
+
+
+@pytest.mark.parametrize("cmd,script", sorted(RDR_COMMANDS.items()))
+def test_inlined_body_executes(cmd: str, script: str) -> None:
+    """The inlined code runs and prints output (no NameError from a bad strip)."""
+    code = _inlined_code((CMD / f"{cmd}.md").read_text())
+    # Args that exercise the happy path without mutating state.
+    env = {**os.environ, "NEXUS_RDR_ARGS": "129"}
+    r = subprocess.run(
+        [sys.executable, "-c", code], input="", capture_output=True, text=True, env=env
+    )
+    assert r.returncode == 0, f"{cmd} inlined body crashed:\n{r.stderr}"
+    assert r.stdout.strip(), f"{cmd} inlined body produced no output"

--- a/tests/test_command_preamble_sync.py
+++ b/tests/test_command_preamble_sync.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import ast
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -85,3 +86,35 @@ def test_inlined_body_executes(cmd: str, script: str) -> None:
     )
     assert r.returncode == 0, f"{cmd} inlined body crashed:\n{r.stderr}"
     assert r.stdout.strip(), f"{cmd} inlined body produced no output"
+
+
+def _all_fenced_commands() -> list[Path]:
+    return sorted(p for p in CMD.glob("*.md") if _FENCED.search(p.read_text()))
+
+
+@pytest.mark.parametrize(
+    "cmd_path", _all_fenced_commands(), ids=lambda p: p.stem
+)
+def test_fenced_block_executes_with_output(cmd_path: Path) -> None:
+    """Every command's ```! block actually runs and emits output (nexus-ln9y5).
+
+    This is the effect check, not a format check: it runs the WHOLE fenced bash
+    block as the harness would (env prefix + `python3 <<'PYEOF'` heredoc for the
+    RDR commands, plain shell for the rest) and asserts a clean exit with real
+    output. The legacy !{ } commands never executed at all; the t1b1k by-path
+    form exited non-zero (empty $CLAUDE_PLUGIN_ROOT). Both would fail here.
+    The blocks are written defensively against absent tools (nx/bd), so a clean
+    exit holds even on a minimal CI runner.
+    """
+    if shutil.which("bash") is None:
+        pytest.skip("bash not available")
+    body = _FENCED.search(cmd_path.read_text()).group("body")
+    env = {**os.environ, "ARGUMENTS": "", "NEXUS_RDR_ARGS": "", "NEXUS_PROJECT_ROOTS": ""}
+    r = subprocess.run(
+        ["bash", "-c", body], capture_output=True, text=True, timeout=120, env=env
+    )
+    assert r.returncode == 0, (
+        f"{cmd_path.name}: ```! block exited {r.returncode} (nexus-ln9y5):\n"
+        f"{r.stderr[:800]}"
+    )
+    assert r.stdout.strip(), f"{cmd_path.name}: ```! block produced no output"

--- a/tests/test_command_preamble_sync.py
+++ b/tests/test_command_preamble_sync.py
@@ -88,6 +88,31 @@ def test_inlined_body_executes(cmd: str, script: str) -> None:
     assert r.stdout.strip(), f"{cmd} inlined body produced no output"
 
 
+DETECTOR_COMMANDS = ["analyze-code", "architecture", "create-plan", "implement"]
+
+
+@pytest.mark.parametrize("cmd", DETECTOR_COMMANDS)
+def test_project_detector_identifies_python(cmd: str) -> None:
+    """The agent-relay project-type detector must identify nexus as Python.
+
+    Correctness check (nexus-ln9y5): the original four detectors knew only
+    Maven/Gradle/Node, so they labeled this Python repo 'Unknown' (analyze-code)
+    or emitted nothing (create-plan). The unified marker-file detector covers
+    ~21 ecosystems and lists all matches. This guards against regressing to the
+    JVM/Node-only logic. Runs from the repo root, where pyproject.toml lives.
+    """
+    if shutil.which("bash") is None:
+        pytest.skip("bash not available")
+    body = _FENCED.search((CMD / f"{cmd}.md").read_text()).group("body")
+    env = {**os.environ, "ARGUMENTS": "", "NEXUS_RDR_ARGS": "", "NEXUS_PROJECT_ROOTS": ""}
+    r = subprocess.run(
+        ["bash", "-c", body], capture_output=True, text=True, timeout=120, env=env
+    )
+    assert r.returncode == 0, f"{cmd}: detector block exited {r.returncode}"
+    assert "- Python" in r.stdout, f"{cmd}: did not detect nexus as Python:\n{r.stdout[:600]}"
+    assert "Unknown" not in r.stdout, f"{cmd}: reported Unknown for a Python repo"
+
+
 def _all_fenced_commands() -> list[Path]:
     return sorted(p for p in CMD.glob("*.md") if _FENCED.search(p.read_text()))
 

--- a/tests/test_phase_review_gate.py
+++ b/tests/test_phase_review_gate.py
@@ -111,15 +111,19 @@ class TestCommandFileStructure:
         assert COMMAND_FILE.exists(), f"Missing: {COMMAND_FILE}"
 
     def test_command_has_preamble_block(self) -> None:
-        # nexus-t1b1k: the Python preamble moved out of a !{ } heredoc into an
-        # extracted script invoked by path (a heredoc inside !{ } is emitted as
-        # raw source instead of executing). The block must invoke the script
-        # and contain no heredoc.
+        # nexus-ln9y5: the preamble runs inside a documented ```! fenced block
+        # via an inline `python3 <<'PYEOF'` heredoc. The earlier !{ } brace form
+        # (nexus-t1b1k) never executed, and the by-path `$CLAUDE_PLUGIN_ROOT`
+        # form failed because that var is empty in command bash context. The
+        # script file remains the source of truth (kept in sync by
+        # tests/test_command_preamble_sync.py); the .md inlines its code.
         text = COMMAND_FILE.read_text()
-        assert "python3 << 'PYEOF'" not in text, "heredoc form must be gone (nexus-t1b1k)"
-        assert "resources/rdr_commands/phase_review_gate.py" in text, \
-            "command must invoke the extracted preamble script by path"
-        assert SCRIPT_FILE.exists(), f"Missing extracted preamble script: {SCRIPT_FILE}"
+        assert "!{" not in text, "invalid !{ } brace form must be gone (nexus-ln9y5)"
+        assert "$CLAUDE_PLUGIN_ROOT" not in text, \
+            "$CLAUDE_PLUGIN_ROOT is empty in command bash; must not be referenced (nexus-ln9y5)"
+        assert "```!" in text, "preamble must use the documented ```! fenced form"
+        assert "python3 <<'PYEOF'" in text, "preamble must inline the script via a heredoc"
+        assert SCRIPT_FILE.exists(), f"Missing source-of-truth preamble script: {SCRIPT_FILE}"
 
     def test_command_has_nexus_rdr_args_env(self) -> None:
         text = COMMAND_FILE.read_text()

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -333,17 +333,27 @@ class TestSkillDescriptionCSO:
 
 
 
+def _command_bash_block(text: str) -> str | None:
+    """Return the body of the documented ```! fenced bash block, or None.
+
+    nexus-ln9y5: command preambles inject bash via a ```! fenced block (Claude
+    Code's documented multi-line form). The legacy !{ } brace form never
+    executed; it is forbidden by test_command_bash_uses_documented_syntax.
+    """
+    m = re.search(r"(?ms)^```!\n(.*?)\n```[ \t]*$", text)
+    return m.group(1) if m else None
+
+
 class TestCommandStructure:
 
     @pytest.mark.parametrize("cmd_path", _command_params())
     def test_bash_block_syntax(self, cmd_path: Path) -> None:
         if shutil.which("bash") is None:
             pytest.skip("bash not available")
-        text = cmd_path.read_text()
-        match = re.search(r"^!\{$(.*?)^}", text, re.MULTILINE | re.DOTALL)
-        if not match:
-            pytest.skip(f"{cmd_path.name}: no !{{}} bash block found")
-        result = subprocess.run(["bash", "-n"], input=match.group(1), capture_output=True, text=True)
+        body = _command_bash_block(cmd_path.read_text())
+        if body is None:
+            pytest.skip(f"{cmd_path.name}: no ```! bash block found")
+        result = subprocess.run(["bash", "-n"], input=body, capture_output=True, text=True)
         assert result.returncode == 0, f"{cmd_path.name}: bash syntax error:\n{result.stderr}"
 
     @pytest.mark.parametrize("cmd_path", _command_params())
@@ -353,47 +363,49 @@ class TestCommandStructure:
 
     @pytest.mark.parametrize("cmd_path", _command_params())
     def test_nx_commands_guarded(self, cmd_path: Path) -> None:
-        text = cmd_path.read_text()
-        match = re.search(r"^!\{$(.*?)^}", text, re.MULTILINE | re.DOTALL)
-        if not match:
-            pytest.skip(f"{cmd_path.name}: no !{{}} bash block found")
+        body = _command_bash_block(cmd_path.read_text())
+        if body is None:
+            pytest.skip(f"{cmd_path.name}: no ```! bash block found")
         nx_calls = [
-            line.strip() for line in match.group(1).splitlines()
+            line.strip() for line in body.splitlines()
             if re.match(r"\s+nx\s+", line) and "2>/dev/null" not in line
             and "command -v nx" not in line
         ]
         assert len(nx_calls) < 5, \
-            f"{cmd_path.name}: {len(nx_calls)} unguarded 'nx' calls in !{{}} block"
+            f"{cmd_path.name}: {len(nx_calls)} unguarded 'nx' calls in ```! block"
 
     @pytest.mark.parametrize("cmd_path", _command_params())
-    def test_no_heredoc_in_bang_block(self, cmd_path: Path) -> None:
-        """Regression for nexus-t1b1k.
+    def test_command_bash_uses_documented_syntax(self, cmd_path: Path) -> None:
+        """Regression for nexus-ln9y5 (supersedes the nexus-t1b1k heredoc guard).
 
-        Claude Code's slash-command runner emits a ``!{ }`` block that wraps a
-        heredoc (``python3 << 'PYEOF' ... PYEOF``) as raw source instead of
-        executing it, so the block's intended output never renders. Long
-        scripts must live under ``conexus/resources/`` and be invoked by path
-        (``python3 "$CLAUDE_PLUGIN_ROOT/resources/.../<name>.py"``). Guard
-        against any reintroduction of the heredoc form.
+        Claude Code only executes command bash injection in the documented
+        forms: inline ``!`cmd``` or a multi-line fenced ````` ```! ````` block.
+        The legacy ``!{ ... }`` brace form (used by every conexus command
+        through 5.1.1) is NOT a recognized syntax and emits as raw source — the
+        preamble never runs. Additionally, ``$CLAUDE_PLUGIN_ROOT`` is empty in
+        the command-bash context (it is scoped to hooks/MCP/LSP), so by-path
+        script invocation fails. This guard would have caught both bugs; it is
+        what the t1b1k guard should have been.
+
+        Static check only. The render path itself is covered by the
+        cc-validation harness (the layer no unit test can reach).
         """
         text = cmd_path.read_text()
-        match = re.search(r"^!\{$(.*?)^}", text, re.MULTILINE | re.DOTALL)
-        if not match:
-            pytest.skip(f"{cmd_path.name}: no !{{}} bash block found")
-        # A heredoc intro: exactly two `<` (lookarounds exclude here-strings
-        # `<<<word`), optional `-`/`~`, optional quote, a delimiter word, at
-        # end of line. The leading-letter/underscore requirement excludes
-        # arithmetic shifts (`<< 2`).
-        heredocs = re.findall(
-            r"^.*?(?<!<)<<(?!<)[-~]?\s*['\"]?[A-Za-z_]\w*['\"]?\s*$",
-            match.group(1),
-            re.MULTILINE,
+        assert "!{" not in text, (
+            f"{cmd_path.name}: forbidden !{{ }} brace bash form (nexus-ln9y5). "
+            "It does not execute. Use a documented ```! fenced block."
         )
-        assert not heredocs, (
-            f"{cmd_path.name}: heredoc inside !{{}} block (nexus-t1b1k): {heredocs}. "
-            "Extract the script to conexus/resources/ and invoke it by path: "
-            'python3 "$CLAUDE_PLUGIN_ROOT/resources/.../<name>.py".'
-        )
+        body = _command_bash_block(text)
+        # An inline !`...` form is also acceptable; only enforce de-rooting and
+        # the fence rule for files that actually carry a bash block.
+        inline = re.search(r"(?<!\\)!`[^`]+`", text)
+        if body is None and inline is None:
+            pytest.skip(f"{cmd_path.name}: no bash injection block")
+        if body is not None:
+            assert "$CLAUDE_PLUGIN_ROOT" not in body, (
+                f"{cmd_path.name}: $CLAUDE_PLUGIN_ROOT is empty in command bash "
+                "(nexus-ln9y5); inline the logic instead of invoking by path."
+            )
 
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.1.1"
+version = "5.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Promotes develop to main for the **5.1.2** patch release.

## What ships

**nexus-ln9y5 — conexus slash commands actually execute their preamble now.** Completes the nexus-t1b1k fix from 5.1.1, which did not take effect. Every command used a `!{ ... }` brace block, which is not a Claude Code bash-injection syntax (only inline `` !`cmd` `` and fenced ` ```! ` execute). All 25 commands converted to the documented fenced form; the 9 RDR preambles inline their script (byte-synced to `resources/rdr_commands/*.py`). Also unifies project-type detection across ~21 ecosystems in the 4 agent-relay commands (was Maven/Gradle/Node-only).

## Validation

- Full unit suite green on the merged SHA (CI on #970: 7701 passed, both 3.12 and 3.13).
- Render path proven end-to-end against a real Claude Code: `tests/cc-validation/scenarios/19` (2/2).
- Effect verified: every command block executes and emits correct output; project detector identifies nexus as Python.
- Sandbox smoke `[done]`, schema v5.1.2.

## Release mechanics

- All 7 version targets bumped to 5.1.2 (`source.ref` = `v5.1.2`), `uv.lock` refreshed, both changelogs updated.
- Merge (not squash) so the release commit SHA is preserved for the tag.

Bead: nexus-ln9y5