### PR TITLE
release: conexus 5.1.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.1.2"
+        "ref": "v5.1.3"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.1.2"
+      "version": "5.1.3"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.1.2"
+        "ref": "v5.1.3"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.1.2"
+      "version": "5.1.3"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.1.3] - 2026-05-26
+
+Hotfix for a 5.1.2 regression in slash-command preambles.
+
+### Fixed
+
+- **Slash commands no longer truncate on a literal triple-backtick (nexus-61fzg).** 5.1.2 moved command preambles to fenced bash blocks, but Claude Code closes such a block at the first literal triple-backtick in the source (any position, including inside `echo` of a code fence or a Python `print`/regex), which truncated 17 of 25 commands mid-content and produced a shell error on invocation. The block sources now contain no literal triple-backtick (shell drops the cosmetic fence-echoes; the RDR Python preambles build the fence at runtime), and a latent detector exit-code bug the truncation had masked is fixed. Verified against a real Claude Code via a new cc-validation scenario; a guard rejects any in-content triple-backtick inside a command bash block. The durable fix (moving preamble logic into the `nx` CLI) is tracked in RDR-130.
+
 ## [5.1.2] - 2026-05-26
 
 Bug-fix release. Completes the nexus-t1b1k fix from 5.1.1, which did not actually take effect, and fixes project-type detection exposed by it.

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.1.3] - 2026-05-26
+
+### Fixed
+
+- **Slash-command preambles no longer truncate on a literal triple-backtick (nexus-61fzg).** The 5.1.2 fenced-block conversion broke 17/25 commands because Claude Code closes a fenced-bang block at the first literal triple-backtick in the source. Block sources are now free of literal triple-backticks (shell drops cosmetic fence-echoes; RDR Python builds the fence at runtime), verified through real Claude Code. Durable fix tracked in RDR-130 (move preamble logic into the nx CLI).
+
 ## [5.1.2] - 2026-05-26
 
 ### Fixed

--- a/conexus/commands/analyze-code.md
+++ b/conexus/commands/analyze-code.md
@@ -39,21 +39,17 @@ description: Analyze codebase using codebase-deep-analyzer agent
   _pt "build.zig" "Zig"
   _pt "dune-project" "OCaml"
   _pt "shard.yml" "Crystal"
-  [ "$_pt_found" -eq 0 ] && echo "- Unknown (no recognized build/marker file)"
+  if [ "$_pt_found" -eq 0 ]; then echo "- Unknown (no recognized build/marker file)"; fi
   echo ""
 
   # Module structure
   echo "### Top-level Structure"
-  echo '```'
   ls -d */ 2>/dev/null | head -15 || echo "No subdirectories"
-  echo '```'
   echo ""
 
   # Source locations
   echo "### Source Locations"
-  echo '```'
   find . -type d -name "src" 2>/dev/null | grep -v node_modules | grep -v target | head -10 || echo "No src directories found"
-  echo '```'
 
 ```
 

--- a/conexus/commands/architecture.md
+++ b/conexus/commands/architecture.md
@@ -19,7 +19,6 @@ description: Design architecture and create phased execution plans using archite
 
   # Project structure
   echo "### Project Structure"
-  echo '```'
   echo "**Project type:**"
   _pt_found=0
   _pt() { if compgen -G "$1" >/dev/null 2>&1; then echo "- $2"; _pt_found=1; fi; }
@@ -47,13 +46,11 @@ description: Design architecture and create phased execution plans using archite
   _pt "build.zig" "Zig"
   _pt "dune-project" "OCaml"
   _pt "shard.yml" "Crystal"
-  [ "$_pt_found" -eq 0 ] && echo "- Unknown (no recognized build/marker file)"
-  echo '```'
+  if [ "$_pt_found" -eq 0 ]; then echo "- Unknown (no recognized build/marker file)"; fi
   echo ""
 
   # Active beads context
   echo "### Active Beads"
-  echo '```'
   if command -v bd &> /dev/null; then
     bd list --status=in_progress --limit=5 2>/dev/null || echo "No in-progress beads"
     echo ""
@@ -61,7 +58,6 @@ description: Design architecture and create phased execution plans using archite
   else
     echo "Beads not available"
   fi
-  echo '```'
   echo ""
 
   echo "### Pipeline Position"

--- a/conexus/commands/continuation.md
+++ b/conexus/commands/continuation.md
@@ -74,19 +74,14 @@ Generates a handoff document under `/tmp/` that a future Claude Code session can
   echo ""
 
   echo "### Uncommitted"
-  echo '```'
   git status --short 2>/dev/null | head -20 || echo "(no git status)"
-  echo '```'
   echo ""
 
   echo "### Recent commits (last 10 on this branch)"
-  echo '```'
   git log --oneline -10 2>/dev/null || echo "(no log)"
-  echo '```'
   echo ""
 
   echo "### Open PRs from this branch"
-  echo '```'
   if command -v gh >/dev/null 2>&1; then
     gh pr list --head "$(git branch --show-current 2>/dev/null)" --state open \
       --json number,title,baseRefName \
@@ -94,28 +89,21 @@ Generates a handoff document under `/tmp/` that a future Claude Code session can
   else
     echo "(gh not installed)"
   fi
-  echo '```'
   echo ""
 
   if command -v bd >/dev/null 2>&1; then
     echo "### In-progress beads"
-    echo '```'
     bd list --status=in_progress --limit=10 2>/dev/null || echo "(none)"
-    echo '```'
     echo ""
     echo "### Ready beads (top 10)"
-    echo '```'
     bd ready --limit=10 2>/dev/null | head -25 || echo "(none)"
-    echo '```'
     echo ""
   fi
 
   if command -v nx >/dev/null 2>&1; then
     PROJ_ACTIVE="${REPO}_active"
     echo "### nx memory ($PROJ_ACTIVE) titles"
-    echo '```'
     nx memory get --project "$PROJ_ACTIVE" --title "" 2>/dev/null | head -15 || echo "(no active-project memory)"
-    echo '```'
     echo ""
   fi
 

--- a/conexus/commands/create-plan.md
+++ b/conexus/commands/create-plan.md
@@ -19,7 +19,6 @@ description: Create implementation plan using strategic-planner agent
 
   # Existing beads context
   echo "### Existing Epics/Features"
-  echo '```'
   if command -v bd &> /dev/null; then
     bd list --type=epic --limit=5 2>/dev/null || echo "No epics found"
     echo ""
@@ -27,12 +26,10 @@ description: Create implementation plan using strategic-planner agent
   else
     echo "Beads not available"
   fi
-  echo '```'
   echo ""
 
   # Architecture hints
   echo "### Project Structure"
-  echo '```'
   echo "**Project type:**"
   _pt_found=0
   _pt() { if compgen -G "$1" >/dev/null 2>&1; then echo "- $2"; _pt_found=1; fi; }
@@ -60,8 +57,7 @@ description: Create implementation plan using strategic-planner agent
   _pt "build.zig" "Zig"
   _pt "dune-project" "OCaml"
   _pt "shard.yml" "Crystal"
-  [ "$_pt_found" -eq 0 ] && echo "- Unknown (no recognized build/marker file)"
-  echo '```'
+  if [ "$_pt_found" -eq 0 ]; then echo "- Unknown (no recognized build/marker file)"; fi
 
 ```
 

--- a/conexus/commands/debug.md
+++ b/conexus/commands/debug.md
@@ -21,7 +21,6 @@ description: Debug test failures using debugger agent
 
   # Check for recent test failures
   echo "### Recent Test Failures"
-  echo '```'
   if [ -d "target/surefire-reports" ]; then
     FAILURES=$(find target/surefire-reports -name "*.txt" -exec grep -l "FAILURE\|ERROR" {} \; 2>/dev/null | head -5)
     if [ -n "$FAILURES" ]; then
@@ -36,18 +35,15 @@ description: Debug test failures using debugger agent
   else
     echo "No test output found — run the project's test command (check CLAUDE.md)"
   fi
-  echo '```'
 
   # Bead context
   echo ""
   echo "### Active Beads"
-  echo '```'
   if command -v bd &> /dev/null; then
     bd list --status=in_progress --limit=3 2>/dev/null || echo "No in-progress beads"
   else
     echo "Beads not available"
   fi
-  echo '```'
 
 ```
 

--- a/conexus/commands/deep-analysis.md
+++ b/conexus/commands/deep-analysis.md
@@ -19,13 +19,11 @@ description: Thorough analysis of complex problems using deep-analyst agent
 
   # Active beads context
   echo "### Active Beads"
-  echo '```'
   if command -v bd &> /dev/null; then
     bd list --status=in_progress --limit=5 2>/dev/null || echo "No in-progress beads"
   else
     echo "Beads not available"
   fi
-  echo '```'
   echo ""
 
   echo "### Tip"

--- a/conexus/commands/enrich-plan.md
+++ b/conexus/commands/enrich-plan.md
@@ -13,13 +13,11 @@ description: Enrich beads with execution context using mcp__plugin_conexus_nexus
 
   # Bead context
   echo "### Related Beads"
-  echo '```'
   if command -v bd &> /dev/null; then
     bd list --type=epic --status=open --limit=5 2>/dev/null || echo "No open epics"
   else
     echo "Beads not available"
   fi
-  echo '```'
 ```
 
 ## Plan to Enrich

--- a/conexus/commands/implement.md
+++ b/conexus/commands/implement.md
@@ -22,18 +22,15 @@ description: Implement feature using developer agent
 
   # Bead context
   echo "### Active Work"
-  echo '```'
   if command -v bd &> /dev/null; then
     bd list --status=in_progress --limit=5 2>/dev/null || echo "No in-progress beads"
   else
     echo "Beads not available"
   fi
-  echo '```'
   echo ""
 
   # Project type
   echo "### Project Info"
-  echo '```'
   echo "**Project type:**"
   _pt_found=0
   _pt() { if compgen -G "$1" >/dev/null 2>&1; then echo "- $2"; _pt_found=1; fi; }
@@ -61,8 +58,7 @@ description: Implement feature using developer agent
   _pt "build.zig" "Zig"
   _pt "dune-project" "OCaml"
   _pt "shard.yml" "Crystal"
-  [ "$_pt_found" -eq 0 ] && echo "- Unknown (no recognized build/marker file)"
-  echo '```'
+  if [ "$_pt_found" -eq 0 ]; then echo "- Unknown (no recognized build/marker file)"; fi
 
 ```
 

--- a/conexus/commands/knowledge-tidy.md
+++ b/conexus/commands/knowledge-tidy.md
@@ -18,13 +18,11 @@ description: Persist and organize knowledge into the T3 store using mcp__plugin_
 
   # Active beads context
   echo "### Recently Completed Beads"
-  echo '```'
   if command -v bd &> /dev/null; then
     bd list --status=done --limit=5 2>/dev/null || echo "No recently completed beads"
   else
     echo "Beads not available"
   fi
-  echo '```'
   echo ""
 
   echo "### Storage Standards"

--- a/conexus/commands/pdf-process.md
+++ b/conexus/commands/pdf-process.md
@@ -12,9 +12,7 @@ description: Index PDF files into the T3 knowledge store for semantic search
   echo ""
 
   echo "### PDF Files in Current Directory"
-  echo '```'
   find . -name "*.pdf" -not -path "./.git/*" 2>/dev/null | head -20 || echo "No PDF files found"
-  echo '```'
   echo ""
 
   echo "### Existing Indexed Collections"

--- a/conexus/commands/phase-review-gate.md
+++ b/conexus/commands/phase-review-gate.md
@@ -9,6 +9,7 @@ description: Cross-walk RDR §Approach against closing beads at a phase boundary
 NEXUS_RDR_ARGS="$ARGUMENTS" python3 <<'PYEOF'
 import os, sys, re, subprocess
 from pathlib import Path
+_F = chr(96) * 3  # nexus-61fzg: a literal triple-backtick truncates the fenced-bang command block
 
 args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
 
@@ -228,9 +229,9 @@ if not evidence_arg:
     example_parts = ','.join(f"Item{num}=nexus-xxxx" for num, _, _ in items)
     print("**Re-invoke with evidence once all items are accounted for:**")
     print()
-    print(f"```")
+    print(_F)
     print(f"/conexus:phase-review-gate {rdr_id_label} --phase {phase_arg or '1'} --evidence '{example_parts}'")
-    print(f"```")
+    print(_F)
     print()
     sys.exit(0)
 
@@ -263,9 +264,9 @@ if failures:
         f"Item{num}={evidence.get(num, 'nexus-xxxx') or 'nexus-xxxx'}"
         for num, _, _ in items
     )
-    print(f"```")
+    print(_F)
     print(f"/conexus:phase-review-gate {rdr_id_label} --phase {phase_arg or '1'} --evidence '{example_parts}'")
-    print(f"```")
+    print(_F)
     sys.exit(0)
 
 # All items covered — validation passed

--- a/conexus/commands/plan-audit.md
+++ b/conexus/commands/plan-audit.md
@@ -17,13 +17,11 @@ description: Audit a plan using mcp__plugin_conexus_nexus__nx_plan_audit (RDR-08
   # Bead context
   echo ""
   echo "### Related Beads"
-  echo '```'
   if command -v bd &> /dev/null; then
     bd list --type=epic --status=open --limit=3 2>/dev/null || echo "No open epics"
   else
     echo "Beads not available"
   fi
-  echo '```'
 ```
 
 ## Plan to Audit

--- a/conexus/commands/rdr-close.md
+++ b/conexus/commands/rdr-close.md
@@ -9,6 +9,7 @@ description: Close an RDR with optional post-mortem, bead status gate, and T3 ar
 NEXUS_RDR_ARGS="$ARGUMENTS" python3 <<'PYEOF'
 import os, sys, re, subprocess
 from pathlib import Path
+_F = chr(96) * 3  # nexus-61fzg: a literal triple-backtick truncates the fenced-bang command block
 
 args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
 
@@ -251,7 +252,7 @@ if (close_reason or '').lower() == 'implemented':
         print("**Re-invoke with per-gap closure pointers:**")
         print()
         example = ",".join(f"Gap{num}=path/to/file.py:LINE" for num, _q, _t in gap_matches)
-        print(f"```\n/conexus:rdr-close {rdr_id_label} --reason implemented --pointers '{example}'\n```")
+        print(f"{_F}\n/conexus:rdr-close {rdr_id_label} --reason implemented --pointers '{example}'\n{_F}")
         print()
         sys.exit(0)
     else:

--- a/conexus/commands/rdr-gate.md
+++ b/conexus/commands/rdr-gate.md
@@ -9,6 +9,7 @@ description: Run finalization gate on an RDR — structural, assumption audit, a
 NEXUS_RDR_ARGS="$ARGUMENTS" python3 <<'PYEOF'
 import os, sys, re, subprocess
 from pathlib import Path
+_F = chr(96) * 3  # nexus-61fzg: a literal triple-backtick truncates the fenced-bang command block
 
 args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
 
@@ -142,7 +143,7 @@ print()
 
 # Strip fenced code blocks before extracting headings (avoids # comment false positives)
 def strip_code_blocks(src):
-    return re.sub(r'```.*?```', '', src, flags=re.DOTALL)
+    return re.sub(rf'{_F}.*?{_F}', '', src, flags=re.DOTALL)
 
 
 # Gap-structure pre-check (nexus-4qpb): the close skill enforces

--- a/conexus/commands/review-code.md
+++ b/conexus/commands/review-code.md
@@ -18,34 +18,26 @@ description: Review code changes using code-review-expert agent
     echo ""
 
     echo "### Modified Files"
-    echo '```'
     git diff --name-only HEAD 2>/dev/null | head -20 || echo "No uncommitted changes"
-    echo '```'
     echo ""
 
     echo "### Diff Summary"
-    echo '```'
     git diff --stat HEAD 2>/dev/null | tail -10 || echo "No diff available"
-    echo '```'
   else
     echo "**Note:** Not a git repository"
     echo ""
     echo "### Recently Modified Files"
-    echo '```'
     find . -type f -name "*.java" -mmin -60 2>/dev/null | head -10 || echo "No recent files found"
-    echo '```'
   fi
 
   # Bead context
   echo ""
   echo "### Active Beads"
-  echo '```'
   if command -v bd &> /dev/null; then
     bd list --status=in_progress --limit=3 2>/dev/null || echo "No in-progress beads"
   else
     echo "Beads not available"
   fi
-  echo '```'
 
 ```
 

--- a/conexus/commands/substantive-critique.md
+++ b/conexus/commands/substantive-critique.md
@@ -18,21 +18,17 @@ description: Constructive critique of code, plans, designs, or documentation usi
     echo ""
 
     echo "### Modified Files"
-    echo '```'
     git diff --name-only HEAD 2>/dev/null | head -20 || echo "No uncommitted changes"
-    echo '```'
     echo ""
   fi
 
   # Active beads context
   echo "### Active Beads"
-  echo '```'
   if command -v bd &> /dev/null; then
     bd list --status=in_progress --limit=3 2>/dev/null || echo "No in-progress beads"
   else
     echo "Beads not available"
   fi
-  echo '```'
   echo ""
 
   echo "### Tip"

--- a/conexus/commands/test-validate.md
+++ b/conexus/commands/test-validate.md
@@ -13,44 +13,36 @@ description: Validate tests using test-validator agent
 
   # Find test directories
   echo "### Test Locations"
-  echo '```'
   if [ -d "src/test" ]; then
     find src/test -type f -name "*.java" 2>/dev/null | wc -l | xargs -I{} echo "{} test files in src/test"
   fi
   find . -type d \( -name "test" -o -name "tests" -o -name "__tests__" \) 2>/dev/null | grep -v node_modules | grep -v target | head -5 || echo "No test directories found"
-  echo '```'
   echo ""
 
   # Recent changes
   if git rev-parse --git-dir > /dev/null 2>&1; then
     echo "### Recently Modified Files"
-    echo '```'
     git diff --name-only HEAD~5 2>/dev/null | grep -E "\.(java|py|ts|js)$" | head -10 || echo "No recent source changes"
-    echo '```'
     echo ""
   fi
 
   # Test results
   if [ -d "target/surefire-reports" ]; then
     echo "### Last Test Run"
-    echo '```'
     TOTAL=$(find target/surefire-reports -name "TEST-*.xml" 2>/dev/null | wc -l | tr -d ' ')
     FAILED=$(find target/surefire-reports -name "TEST-*.xml" -exec grep -l 'failures="[1-9]' {} \; 2>/dev/null | wc -l | tr -d ' ')
     echo "Total test files: $TOTAL"
     echo "Files with failures: $FAILED"
-    echo '```'
   fi
 
   # Bead context
   echo ""
   echo "### Active Beads"
-  echo '```'
   if command -v bd &> /dev/null; then
     bd list --status=in_progress --limit=3 2>/dev/null || echo "No in-progress beads"
   else
     echo "Beads not available"
   fi
-  echo '```'
 
 ```
 

--- a/conexus/resources/rdr_commands/phase_review_gate.py
+++ b/conexus/resources/rdr_commands/phase_review_gate.py
@@ -10,6 +10,7 @@ matches the working echo/-c form. ARGUMENTS arrive via NEXUS_RDR_ARGS.
 """
 import os, sys, re, subprocess
 from pathlib import Path
+_F = chr(96) * 3  # nexus-61fzg: a literal triple-backtick truncates the fenced-bang command block
 
 args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
 
@@ -229,9 +230,9 @@ if not evidence_arg:
     example_parts = ','.join(f"Item{num}=nexus-xxxx" for num, _, _ in items)
     print("**Re-invoke with evidence once all items are accounted for:**")
     print()
-    print(f"```")
+    print(_F)
     print(f"/conexus:phase-review-gate {rdr_id_label} --phase {phase_arg or '1'} --evidence '{example_parts}'")
-    print(f"```")
+    print(_F)
     print()
     sys.exit(0)
 
@@ -264,9 +265,9 @@ if failures:
         f"Item{num}={evidence.get(num, 'nexus-xxxx') or 'nexus-xxxx'}"
         for num, _, _ in items
     )
-    print(f"```")
+    print(_F)
     print(f"/conexus:phase-review-gate {rdr_id_label} --phase {phase_arg or '1'} --evidence '{example_parts}'")
-    print(f"```")
+    print(_F)
     sys.exit(0)
 
 # All items covered — validation passed
@@ -299,4 +300,3 @@ try:
     write_sentinel(rdr_id_label, str(phase_arg or "1"))
 except Exception:
     pass
-

--- a/conexus/resources/rdr_commands/rdr_close.py
+++ b/conexus/resources/rdr_commands/rdr_close.py
@@ -10,6 +10,7 @@ matches the working echo/-c form. ARGUMENTS arrive via NEXUS_RDR_ARGS.
 """
 import os, sys, re, subprocess
 from pathlib import Path
+_F = chr(96) * 3  # nexus-61fzg: a literal triple-backtick truncates the fenced-bang command block
 
 args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
 
@@ -252,7 +253,7 @@ if (close_reason or '').lower() == 'implemented':
         print("**Re-invoke with per-gap closure pointers:**")
         print()
         example = ",".join(f"Gap{num}=path/to/file.py:LINE" for num, _q, _t in gap_matches)
-        print(f"```\n/conexus:rdr-close {rdr_id_label} --reason implemented --pointers '{example}'\n```")
+        print(f"{_F}\n/conexus:rdr-close {rdr_id_label} --reason implemented --pointers '{example}'\n{_F}")
         print()
         sys.exit(0)
     else:

--- a/conexus/resources/rdr_commands/rdr_gate.py
+++ b/conexus/resources/rdr_commands/rdr_gate.py
@@ -10,6 +10,7 @@ matches the working echo/-c form. ARGUMENTS arrive via NEXUS_RDR_ARGS.
 """
 import os, sys, re, subprocess
 from pathlib import Path
+_F = chr(96) * 3  # nexus-61fzg: a literal triple-backtick truncates the fenced-bang command block
 
 args = os.environ.get('NEXUS_RDR_ARGS', '').strip()
 
@@ -143,7 +144,7 @@ print()
 
 # Strip fenced code blocks before extracting headings (avoids # comment false positives)
 def strip_code_blocks(src):
-    return re.sub(r'```.*?```', '', src, flags=re.DOTALL)
+    return re.sub(rf'{_F}.*?{_F}', '', src, flags=re.DOTALL)
 
 
 # Gap-structure pre-check (nexus-4qpb): the close skill enforces

--- a/docs/rdr/rdr-130-command-preambles-via-nx-cli.md
+++ b/docs/rdr/rdr-130-command-preambles-via-nx-cli.md
@@ -1,0 +1,155 @@
+---
+title: "Command Preambles via the nx CLI: Thin Commands, Tested Logic, No Inlined Bash"
+id: RDR-130
+type: Architecture
+status: draft
+priority: high
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-26
+related_issues: [nexus-61fzg, nexus-ln9y5, nexus-t1b1k]
+related_rdrs: [RDR-120, RDR-128]
+supersedes: []
+related_tests: [tests/test_plugin_structure.py, tests/test_command_preamble_sync.py, tests/cc-validation/scenarios/19_command_bash_injection_renders.sh]
+---
+
+# RDR-130: Command Preambles via the nx CLI: Thin Commands, Tested Logic, No Inlined Bash
+
+## Problem Statement
+
+conexus slash commands gather context in a preamble that runs at invocation time
+and injects its output into the prompt. The preamble logic is **inlined** into the
+command markdown as a bash-injection block. This has proven brittle: two separate
+Claude Code fence-parser behaviors have broken it in consecutive releases.
+
+#### Gap 1: The injection block source cannot contain a literal triple-backtick
+
+Claude Code closes a fenced-bang (```` ```! ````) block at the **first literal
+triple-backtick in the source**, on any line and at any position (including inside
+`echo '<fence>'` or a Python `print`/regex). A longer (4-backtick) opening fence
+does not help (empirically confirmed). Commands whose preamble emits markdown code
+fences therefore truncate mid-content and the shell errors. Shipped in conexus
+5.1.2: 17 of 25 commands broken (nexus-61fzg).
+
+#### Gap 2: The block is bash, with all its hazards
+
+Inlined logic must survive shell quoting and heredoc parsing. The 9 RDR commands
+inline a multi-line Python heredoc; the 16 agent-relay commands inline multi-line
+shell. Both are fragile and hard to read.
+
+#### Gap 3: `$CLAUDE_PLUGIN_ROOT` is empty in command-bash context
+
+It is scoped to hooks / MCP / LSP, not slash-command bash. So a command cannot
+cleanly invoke a bundled script by path (this was the nexus-t1b1k Bug B), forcing
+the brittle inline approach in the first place.
+
+#### Gap 4: The render path is not unit-testable
+
+Only a real Claude Code exercises the injection. Static checks model the parser
+and drift from it: the nexus-ln9y5 verification checked for *bare* fence lines, the
+effect-test extracted with a CommonMark-correct regex, and cc-validation covered
+only the one safe representative. All three passed while 17 commands were broken.
+
+## Context
+
+RDR-120 split storage behind daemons; RDR-128 enforced T2 single-writer. nexus-t1b1k
+(5.1.1) tried to fix non-executing `!{ }` brace blocks by extracting heredocs to
+scripts, but kept the invalid `!{ }` wrapper. nexus-ln9y5 (5.1.2) moved all 25
+commands to the documented ```` ```! ```` fenced form and inlined the logic — which
+then hit Gap 1. The pattern across t1b1k -> ln9y5 -> 61fzg is the same: **inlining
+command logic fights the harness**, and each fix discovers a new parser edge.
+
+## Research Findings (empirically established this cycle)
+
+- Valid CC bash-injection forms: inline `` !`cmd` `` and fenced ```` ```! ````.
+  `!{ }` braces are NOT a recognized form (emit raw).
+- A fenced-bang block closes at the first literal triple-backtick in the source;
+  4-backtick fences do not change this.
+- Injected **output** is inserted as plain text and is NOT re-scanned, so a tool's
+  output may freely contain triple-backticks. The constraint is purely on the
+  `.md` source.
+- `$ARGUMENTS` is substituted by CC in the block; `$CLAUDE_PLUGIN_ROOT` is not.
+- The `nx` CLI is always on PATH (it is the package entry point).
+
+## Proposed Solution
+
+**Keep the injected bash trivial; move all preamble logic into the `nx` CLI.**
+
+Each command becomes a single-line invocation with no literal triple-backtick and
+no inlined logic, e.g.:
+
+    !`nx rdr preamble list "$ARGUMENTS"`
+
+The invoked `nx` subcommand does the work in normal, unit-tested Python and prints
+the preamble markdown (fences and all — output is not re-parsed). This eliminates
+Gaps 1-4 at once: the `.md` source has nothing for the fence parser to choke on,
+no shell quoting beyond the single arg, no `$CLAUDE_PLUGIN_ROOT` dependency, and
+the logic is testable like any CLI command.
+
+- **RDR commands (9):** port `conexus/resources/rdr_commands/*.py` into the existing
+  `nx rdr` group as `nx rdr preamble <name>` subcommands (logic already Python).
+- **Agent-relay commands (16):** port the shell preambles (working-dir, project-type
+  detection, bead/git context) into `nx` subcommands (e.g. `nx command-context
+  <name>`); the unified ~21-ecosystem detector from nexus-ln9y5 becomes Python.
+
+## Alternatives Considered
+
+- **Inline patch (strip literal fences from the 17 blocks).** Rejected: keeps the
+  brittle inline form, is whack-a-mole against CC parser edges, and is throwaway
+  work once logic moves to the CLI.
+- **Drop preambles; let the agent self-gather via `## Action` + MCP tools.**
+  Rejected as the primary path: loses pre-computed context (next RDR id, project
+  type) and adds tool-call latency per invocation. Retained as the interim P0
+  relief option (see Implementation Plan).
+- **4-backtick fence.** Rejected: empirically does not change the truncation.
+
+## Trade-offs
+
+- More upfront work than a patch, but eliminates an entire bug class.
+- Adds `nx` process-startup cost per command invocation (acceptable; commands are
+  interactive, not hot-loop).
+- Centralizes preamble logic in the CLI where it is testable and reusable.
+
+## Implementation Plan
+
+- **P0 (interim relief, optional 5.1.3):** if the broken commands need immediate
+  relief before the migration lands, strip literal triple-backticks from the 17
+  blocks (drop shell fence-wrapping; `chr(96)*3` in the 3 Python ones). Throwaway;
+  only if the P0 cannot wait for P1.
+- **P1:** RDR commands -> `nx rdr preamble <name>`. Port the 9 scripts; flip the 9
+  `.md` files to one-line `nx` invocations; delete `resources/rdr_commands/*.py`
+  and the inline-sync test.
+- **P2:** agent-relay commands -> `nx command-context <name>` (or per-group verbs).
+  Port the shell logic + the ~21-ecosystem detector to Python; flip the 16 `.md`.
+- **P3:** retire the inline machinery; the storage of preamble logic is the CLI.
+
+## Test Plan
+
+- Unit tests per `nx` preamble subcommand (deterministic, no real CC needed).
+- Static guard (`test_plugin_structure`): every command bash block is a single-line
+  `nx` invocation; reject any literal triple-backtick and any multi-line/heredoc
+  body inside an injection block. This matches CC's real parser constraint and
+  would have caught both Gap 1 and the t1b1k class.
+- cc-validation: a scenario that drives real Claude Code on a converted command
+  whose output contains code fences, asserting it renders without truncation.
+  Runnable from this repo's harness (creds refreshed 2026-05-26).
+
+## Validation
+
+Migration is validated when: all 25 commands render through real Claude Code
+without error; the static guard passes; cc-validation covers an output-with-fences
+command; full unit suite green.
+
+## Finalization Gate
+
+(pending)
+
+## References
+
+- nexus-61fzg (P0 regression: triple-backtick truncates fenced-bang block)
+- nexus-ln9y5 (5.1.2 fix that introduced Gap 1), nexus-t1b1k (5.1.1 brace-form fix)
+- RDR-120 (storage substrate split), RDR-128 (single-writer)
+
+## Revision History
+
+- 2026-05-26: Drafted after the 5.1.2 inline-preamble regression (nexus-61fzg).

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.1.2"
+version = "5.1.3"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.1.2",
+    "conexus>=5.1.3",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.1.2"
+version = "5.1.3"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/tests/cc-validation/scenarios/20_command_inner_fence_renders.sh
+++ b/tests/cc-validation/scenarios/20_command_inner_fence_renders.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Scenario 20 — nexus-61fzg: commands whose preamble previously emitted a
+# literal triple-backtick must now render through real Claude Code without
+# truncation. 5.1.2 broke 17/25 commands because CC closes a ```! block at the
+# first inner triple-backtick (e.g. inside echo '<fence>'), leaving an unmatched
+# quote. This drives a real CC on analyze-code (a previously-broken shell
+# preamble with a project detector) and asserts it executes cleanly.
+
+scenario "20 command_inner_fence_renders: previously-broken echo-fence command runs clean"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Bash"], "defaultMode": "bypassPermissions" }
+}
+EOF
+
+# Install the real (fixed) command from the repo.
+write_command "analyze-code" "$REPO_ROOT/conexus/commands/analyze-code.md"
+
+claude_start
+claude_prompt "/analyze-code"
+claude_wait 90
+
+pane="$(capture -3000)"
+# The 5.1.2 regression (nexus-61fzg) manifested as a shell error from the
+# truncated block ("Shell command failed ... unmatched"). Its ABSENCE is the
+# regression-specific signal that the inner triple-backtick no longer closes
+# the fence. (A raw heredoc/plugin-root leak would also be a failure.)
+if grep -qiE 'Shell command failed|unmatched|\(eval\):' <<<"$pane"; then
+    fail "block still errors — inner-fence truncation NOT fixed (nexus-61fzg)"
+    tail -25 <<<"$pane" | sed 's/^/    | /'
+elif grep -qE 'python3 <<|CLAUDE_PLUGIN_ROOT' <<<"$pane"; then
+    fail "raw block markers leaked into the pane"
+    tail -25 <<<"$pane" | sed 's/^/    | /'
+else
+    pass "analyze-code fenced block executed without truncation (no shell error)"
+fi
+
+claude_exit
+scenario_end

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -407,6 +407,32 @@ class TestCommandStructure:
                 "(nexus-ln9y5); inline the logic instead of invoking by path."
             )
 
+    @pytest.mark.parametrize("cmd_path", _command_params())
+    def test_no_inner_triple_backtick_in_bang_block(self, cmd_path: Path) -> None:
+        """Regression for nexus-61fzg (5.1.2 broke 17/25 commands).
+
+        Claude Code closes a ```! fenced block at the FIRST line containing a
+        triple-backtick after the opener, at any position (e.g. inside
+        ``echo '<fence>'`` or a Python ``print``/regex), not only at a bare
+        closing-fence line. A 4-backtick opening fence does not change this.
+        So the first ```-bearing line after the opener MUST be the bare closing
+        fence; any earlier in-content triple-backtick truncates the block and
+        the shell errors. The nexus-ln9y5 guard checked only for *bare* fence
+        lines and missed this; this matches CC's actual parser.
+        """
+        text = cmd_path.read_text()
+        opener = re.search(r"(?m)^```!\s*$", text)
+        if opener is None:
+            pytest.skip(f"{cmd_path.name}: no ```! block")
+        for ln in text[opener.end():].splitlines():
+            if "```" in ln:
+                assert re.match(r"^[ ]{0,3}```[ \t]*$", ln), (
+                    f"{cmd_path.name}: literal triple-backtick inside the ```! "
+                    f"block truncates it (nexus-61fzg): {ln.strip()!r}. The block "
+                    "source must contain no triple-backtick before its closing fence."
+                )
+                break  # first ```-line is the bare closer — good
+
 
 
 class TestCrossReferenceIntegrity:

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.1.2"
+version = "5.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Promotes develop to main for the **5.1.3** hotfix.

## What ships

**nexus-61fzg — slash-command preambles no longer truncate on a literal triple-backtick.** 5.1.2 moved preambles to fenced bash blocks, but Claude Code closes such a block at the first literal triple-backtick in the source, breaking 17/25 commands. Block sources now contain no literal triple-backtick (shell drops cosmetic fence-echoes; RDR Python builds the fence at runtime); a latent detector exit-code bug is also fixed.

## Verification (the step the prior two fixes skipped)

- **cc-validation scenario 20** drives **real Claude Code** on a previously-broken command and confirms no truncation. ✅
- Guard `test_no_inner_triple_backtick_in_bang_block` matches CC's actual parser.
- Full unit suite: **7755 passed**.

## Also

- **RDR-130** (draft) committed: the durable fix — move preamble logic into the `nx` CLI (one-line `` !`nx …` `` commands). This release is the interim relief.

Bead: nexus-61fzg