### PR TITLE
docs(rdr): RDR-130 research findings + output-fence cc-validation probe

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -145,6 +145,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-127](rdr-127-substrate-decoupled-surface-rendering.md) | Substrate-Decoupled Surface Rendering | Architecture | Draft | 2026-05-24 |
 | [RDR-128](rdr-128-t2-single-writer-enforcement.md) | T2 Single-Writer Enforcement: One Owner for memory.db, or an Enforced Lock Discipline | Architecture | Closed 2026-05-25 (implemented, shipped 5.1.0) | 2026-05-25 |
 | [RDR-129](rdr-129-t2-daemon-serving-path-cross-store-contention.md) | T2 Daemon Serving-Path Internal Cross-Store WAL Contention | Architecture | Draft | 2026-05-25 |
+| [RDR-130](rdr-130-command-preambles-via-nx-cli.md) | Command Preambles via the nx CLI: Thin Commands, Tested Logic, No Inlined Bash | Architecture | Accepted 2026-05-26 | 2026-05-26 |
 
 > **Scrapped 2026-05-19 (RDR-110-119 arc).** Bundled the storage-substrate split with new abstractions (tuplespace, ORB, host-trust, surfaces-as-tuples, UI fabric); scope discipline failed across nine RDRs and 67 stranded beads. Files preserved as tombstones per the "never delete RDR files" rule. Postmortem: [docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work continues as [RDR-120](rdr-120-storage-substrate-split.md) with an explicit moratorium on co-shipped consumers. Numbers RDR-114 through RDR-117 are unused on `main` (drafted on feature branches that never merged).
 

--- a/docs/rdr/rdr-130-command-preambles-via-nx-cli.md
+++ b/docs/rdr/rdr-130-command-preambles-via-nx-cli.md
@@ -59,17 +59,32 @@ commands to the documented ```` ```! ```` fenced form and inlined the logic — 
 then hit Gap 1. The pattern across t1b1k -> ln9y5 -> 61fzg is the same: **inlining
 command logic fights the harness**, and each fix discovers a new parser edge.
 
-## Research Findings (empirically established this cycle)
+## Research Findings
+
+Empirically established this cycle and verified against real Claude Code via the
+`tests/cc-validation` harness (scenarios 19, 20, 21; fresh creds 2026-05-26).
 
 - Valid CC bash-injection forms: inline `` !`cmd` `` and fenced ```` ```! ````.
-  `!{ }` braces are NOT a recognized form (emit raw).
+  `!{ }` braces are NOT a recognized form (emit raw) — confirmed by scenario 19
+  Part B (negative control).
 - A fenced-bang block closes at the first literal triple-backtick in the source;
-  4-backtick fences do not change this.
-- Injected **output** is inserted as plain text and is NOT re-scanned, so a tool's
-  output may freely contain triple-backticks. The constraint is purely on the
-  `.md` source.
-- `$ARGUMENTS` is substituted by CC in the block; `$CLAUDE_PLUGIN_ROOT` is not.
+  4-backtick fences do not change this (probe-confirmed). The block source must
+  therefore contain zero triple-backticks before its closing fence — this is the
+  nexus-61fzg root cause.
+- **Critical assumption, VERIFIED (scenario 21):** injected **output** containing
+  triple-backticks is inserted as plain text and is NOT re-parsed. A `` ```! ``
+  block whose source has no literal triple-backtick (built via `printf` octal
+  `\140`) but whose output emits ` ``` ` fences rendered intact. RDR-130 rests on
+  this — the `nx` preamble subcommands emit markdown tables / fences in their
+  output, and that is now confirmed safe rather than merely doc-claimed.
+- `$ARGUMENTS` is substituted by CC in the block; `$CLAUDE_PLUGIN_ROOT` is empty
+  in command-bash context (scoped to hooks/MCP/LSP) — so commands must call an
+  on-PATH binary (`nx`), not a plugin-relative script.
 - The `nx` CLI is always on PATH (it is the package entry point).
+
+Conclusion: the RDR-130 design (one-line `nx` invocation per command; logic in
+the `nx` CLI emitting markdown) is mechanically sound and de-risked. Full T2
+record: `nexus_rdr/130-research-1`.
 
 ## Proposed Solution
 

--- a/docs/rdr/rdr-130-command-preambles-via-nx-cli.md
+++ b/docs/rdr/rdr-130-command-preambles-via-nx-cli.md
@@ -62,9 +62,11 @@ command logic fights the harness**, and each fix discovers a new parser edge.
 ## Research Findings
 
 Empirically established this cycle and verified against real Claude Code via the
-`tests/cc-validation` harness (scenarios 19, 20, 21; fresh creds 2026-05-26).
+`tests/cc-validation` harness (scenarios 19, 20, 21, 22; fresh creds 2026-05-26).
 
 - Valid CC bash-injection forms: inline `` !`cmd` `` and fenced ```` ```! ````.
+  The inline single-line form — which every RDR-130 command uses — executes and
+  injects its stdout (VERIFIED scenario 22, real CC, PATH-independent probe).
   `!{ }` braces are NOT a recognized form (emit raw) — confirmed by scenario 19
   Part B (negative control).
 - A fenced-bang block closes at the first literal triple-backtick in the source;
@@ -93,19 +95,37 @@ record: `nexus_rdr/130-research-1`.
 Each command becomes a single-line invocation with no literal triple-backtick and
 no inlined logic, e.g.:
 
-    !`nx rdr preamble list "$ARGUMENTS"`
+    !`nx rdr preamble list -- "$ARGUMENTS"`
 
 The invoked `nx` subcommand does the work in normal, unit-tested Python and prints
 the preamble markdown (fences and all — output is not re-parsed). This eliminates
 Gaps 1-4 at once: the `.md` source has nothing for the fence parser to choke on,
-no shell quoting beyond the single arg, no `$CLAUDE_PLUGIN_ROOT` dependency, and
-the logic is testable like any CLI command.
+no `$CLAUDE_PLUGIN_ROOT` dependency, and the logic is testable like any CLI command.
 
-- **RDR commands (9):** port `conexus/resources/rdr_commands/*.py` into the existing
-  `nx rdr` group as `nx rdr preamble <name>` subcommands (logic already Python).
-- **Agent-relay commands (16):** port the shell preambles (working-dir, project-type
-  detection, bead/git context) into `nx` subcommands (e.g. `nx command-context
-  <name>`); the unified ~21-ecosystem detector from nexus-ln9y5 becomes Python.
+**Argument passing.** CC substitutes `$ARGUMENTS` and the double-quotes prevent
+word-splitting; the `--` terminator stops `nx` option-parsing so a leading-dash
+argument is treated as a positional. This does NOT escape embedded quotes /
+backticks / `$` in the argument value, so Gap 2 is *narrowed*, not eliminated. In
+practice RDR command arguments are numeric IDs and flags (safe); agent-relay
+commands that accept freeform text must document the constraint or pass the raw
+arg through without shell re-evaluation.
+
+**Command inventory (25).** The migration covers all 25 `conexus/commands/*.md`:
+
+- **RDR-lifecycle (9):** rdr-create, rdr-list, rdr-show, rdr-gate, rdr-accept,
+  rdr-close, rdr-research, rdr-audit, phase-review-gate. Logic already Python in
+  `conexus/resources/rdr_commands/*.py`; port to `nx rdr preamble <name>`.
+- **Agent-relay (16):** analyze-code, architecture, create-plan, implement, debug,
+  deep-analysis, enrich-plan, knowledge-tidy, pdf-process, plan-audit, research,
+  review-code, substantive-critique, test-validate, nx-preflight, continuation.
+  Port the shell preambles (working-dir, the unified ~21-ecosystem project-type
+  detector from nexus-ln9y5, bead/git context) into `nx` subcommands (e.g.
+  `nx command-context <name>`).
+- **Special case — `continuation`:** its preamble is a file-WRITER (writes a dated
+  handoff doc to `/tmp` and emits a `cat <path>` line), not a context-printer. It
+  needs its own subcommand contract (e.g. `nx command-context continuation` that
+  writes the file as a side effect and prints the retrieval line), distinct from
+  the read-and-print pattern. Flagged so P2 does not discover it mid-sprint.
 
 ## Alternatives Considered
 
@@ -121,21 +141,33 @@ the logic is testable like any CLI command.
 ## Trade-offs
 
 - More upfront work than a patch, but eliminates an entire bug class.
-- Adds `nx` process-startup cost per command invocation (acceptable; commands are
-  interactive, not hot-loop).
+- Adds `nx` process-startup cost per command invocation (Click + module import is
+  ~200-500ms cold; acceptable for interactive commands, not a hot loop). Measure
+  once during P1 to confirm across slow hardware.
+- Reduces the shell-quoting surface to single-arg `$ARGUMENTS` expansion (Gap 2
+  narrowed, not eliminated — see Proposed Solution §Argument passing).
 - Centralizes preamble logic in the CLI where it is testable and reusable.
 
 ## Implementation Plan
 
-- **P0 (interim relief, optional 5.1.3):** if the broken commands need immediate
-  relief before the migration lands, strip literal triple-backticks from the 17
-  blocks (drop shell fence-wrapping; `chr(96)*3` in the 3 Python ones). Throwaway;
-  only if the P0 cannot wait for P1.
+- **P0 — DONE (shipped in 5.1.3, nexus-61fzg):** stripped literal triple-backticks
+  from the 17 affected blocks (dropped shell fence-echoes; `chr(96)*3` in the 3
+  Python ones) as interim relief. P1 begins from the 5.1.3 state, not the broken
+  5.1.2 state.
 - **P1:** RDR commands -> `nx rdr preamble <name>`. Port the 9 scripts; flip the 9
   `.md` files to one-line `nx` invocations; delete `resources/rdr_commands/*.py`
-  and the inline-sync test.
+  and the inline-sync test. **Storage-boundary lint (RDR-128, live on CI):** the
+  ported logic moves into `src/nexus/commands/rdr.py`, which IS in the lint scan
+  scope (unlike the `conexus/` resources today). The existing scripts open
+  `T2Database` directly; in `src/nexus/` that is a new construction site the lint
+  will flag. For each preamble subcommand that reads T2, either route through the
+  T2 daemon (`T2Client`) or annotate `# epsilon-allow: short-lived read-only
+  preamble CLI` and acknowledge the epsilon-allow count delta vs the RDR-128
+  baseline. Resolve this per subcommand or P1 CI fails.
 - **P2:** agent-relay commands -> `nx command-context <name>` (or per-group verbs).
   Port the shell logic + the ~21-ecosystem detector to Python; flip the 16 `.md`.
+  Handle `continuation` as the file-writer special case (see Proposed Solution).
+  Same storage-boundary-lint rule applies to any T2/T3 reads.
 - **P3:** retire the inline machinery; the storage of preamble logic is the CLI.
 
 ## Test Plan
@@ -145,9 +177,12 @@ the logic is testable like any CLI command.
   `nx` invocation; reject any literal triple-backtick and any multi-line/heredoc
   body inside an injection block. This matches CC's real parser constraint and
   would have caught both Gap 1 and the t1b1k class.
-- cc-validation: a scenario that drives real Claude Code on a converted command
-  whose output contains code fences, asserting it renders without truncation.
-  Runnable from this repo's harness (creds refreshed 2026-05-26).
+- cc-validation (real Claude Code; runnable from this repo's harness): the
+  mechanism is already covered — scenario 21 (output-with-fences renders intact),
+  scenario 22 (inline `` !`cmd` `` executes + injects stdout), scenario 20
+  (previously-broken command runs clean). P1/P2 add a scenario per migrated
+  command category that asserts the `` !`nx …` `` form renders the expected
+  preamble output.
 
 ## Validation
 
@@ -157,7 +192,17 @@ command; full unit suite green.
 
 ## Finalization Gate
 
-(pending)
+**PASSED — 2026-05-26.** Layer 1 (structural) and Layer 2 (assumption audit) pass;
+all assumptions are evidenced by cc-validation, none left "Assumed" without risk
+notes. Layer 3 (substantive-critic): 0 Critical, 5 Significant, 3 Observations.
+All 5 Significant findings were resolved in-place before accept:
+1. Inline `` !`nx …` `` execution — VERIFIED (added scenario 22).
+2. Storage-boundary lint collision on the `src/nexus/` move — addressed in P1
+   (epsilon-allow or `T2Client` per preamble subcommand; acknowledge baseline delta).
+3. 25-command inventory enumerated; `continuation` flagged as a file-writer special case.
+4. P0 corrected to DONE (shipped in 5.1.3).
+5. `$ARGUMENTS` quoting residual documented (`--` terminator; Gap 2 narrowed, not eliminated).
+Gate result in T2: `nexus_rdr/130-gate-latest`.
 
 ## References
 
@@ -168,3 +213,6 @@ command; full unit suite green.
 ## Revision History
 
 - 2026-05-26: Drafted after the 5.1.2 inline-preamble regression (nexus-61fzg).
+- 2026-05-26: Gate PASSED (0 critical, 5 significant resolved in-place). Inline
+  form verified (scenario 22); P1 storage-boundary-lint step, 25-command
+  inventory, continuation special case, P0-done, and `$ARGUMENTS` quoting added.

--- a/docs/rdr/rdr-130-command-preambles-via-nx-cli.md
+++ b/docs/rdr/rdr-130-command-preambles-via-nx-cli.md
@@ -2,11 +2,12 @@
 title: "Command Preambles via the nx CLI: Thin Commands, Tested Logic, No Inlined Bash"
 id: RDR-130
 type: Architecture
-status: draft
+status: accepted
 priority: high
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-05-26
+accepted_date: 2026-05-26
 related_issues: [nexus-61fzg, nexus-ln9y5, nexus-t1b1k]
 related_rdrs: [RDR-120, RDR-128]
 supersedes: []

--- a/tests/cc-validation/scenarios/21_rdr130_output_fence_safe.sh
+++ b/tests/cc-validation/scenarios/21_rdr130_output_fence_safe.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Scenario 21 — RDR-130 critical-assumption probe: command bash-injection OUTPUT
+# that contains a triple-backtick is injected as plain text and NOT re-parsed
+# by Claude Code. RDR-130 moves preamble logic into the nx CLI; those nx
+# subcommands emit markdown (tables, code fences) whose OUTPUT will contain
+# triple-backticks. The block SOURCE here has none (built via octal \140), so
+# CC cannot truncate the fence; the only triple-backticks are in the OUTPUT.
+# If the model sees the full fenced output, the assumption holds.
+
+scenario "21 rdr130_output_fence_safe: injected OUTPUT triple-backticks are not re-parsed"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Bash"], "defaultMode": "bypassPermissions" }
+}
+EOF
+
+# Source has NO literal triple-backtick (octal \140 builds it at runtime).
+write_command "outfence-probe" /dev/stdin <<'EOF'
+---
+allowed-tools: Bash
+description: RDR-130 CA probe — output triple-backtick safety
+---
+
+# Output Fence Probe
+
+```!
+printf 'OUTFENCE-START\n'
+printf '\140\140\140\n'
+printf 'inside-output-fence\n'
+printf '\140\140\140\n'
+printf 'OUTFENCE-END-%s\n' "$((6*7))"
+```
+
+Report verbatim whether the marker OUTFENCE-END-42 and the fenced block appear above.
+EOF
+
+claude_start
+claude_prompt "/outfence-probe"
+claude_wait 60
+
+pane="$(capture -2000)"
+if grep -qiE 'Shell command failed|unmatched|\(eval\):' <<<"$pane"; then
+    fail "block errored — output-fence source not safe"
+    tail -25 <<<"$pane" | sed 's/^/    | /'
+elif grep -qF 'OUTFENCE-END-42' <<<"$pane"; then
+    pass "output containing triple-backticks rendered intact (RDR-130 CA holds)"
+else
+    fail "no OUTFENCE-END-42 in pane — output may have been mangled"
+    tail -25 <<<"$pane" | sed 's/^/    | /'
+fi
+
+claude_exit
+scenario_end

--- a/tests/cc-validation/scenarios/22_inline_backtick_executes.sh
+++ b/tests/cc-validation/scenarios/22_inline_backtick_executes.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Scenario 22 — RDR-130 delivery-mechanism probe: the INLINE !`cmd` form (which
+# every RDR-130 command will use: !`nx <preamble> "$ARGUMENTS"`) executes and its
+# stdout is injected. Prior scenarios (19/20/21) only exercised the fenced ```!
+# form; the inline single-backtick form was assumed, not verified (gate finding).
+# PATH-independent: uses printf so it does not depend on nx being on the test PATH.
+
+scenario "22 inline_backtick_executes: inline !\`cmd\` runs and injects stdout"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Bash"], "defaultMode": "bypassPermissions" }
+}
+EOF
+
+write_command "inline-probe" /dev/stdin <<'EOF'
+---
+allowed-tools: Bash
+description: RDR-130 inline-form probe
+---
+
+# Inline Probe
+
+Marker: !`printf 'INLINE-OK-%s' "$((6*7))"`
+
+Report the marker above verbatim.
+EOF
+
+claude_start
+claude_prompt "/inline-probe"
+claude_wait 60
+
+pane="$(capture -2000)"
+if grep -qiE 'Shell command failed|unmatched|\(eval\):' <<<"$pane"; then
+    fail "inline form errored"
+    tail -20 <<<"$pane" | sed 's/^/    | /'
+elif grep -qF 'INLINE-OK-42' <<<"$pane"; then
+    pass "inline !\`cmd\` executed — stdout injected (INLINE-OK-42 present)"
+else
+    fail "INLINE-OK-42 absent — inline form did not execute/inject"
+    tail -20 <<<"$pane" | sed 's/^/    | /'
+fi
+
+claude_exit
+scenario_end


### PR DESCRIPTION
Records RDR-130 research: verified its load-bearing critical assumption (injected command **output** containing triple-backticks is not re-parsed by Claude Code) against the real harness via new cc-validation scenario 21. De-risks the RDR-130 design (the nx preamble subcommands emit markdown safely). Full T2 record: nexus_rdr/130-research-1.

Bead: nexus-61fzg (closed). RDR-130 next step is the gate.
