### PR TITLE
fix(daemon): T2 daemon reaps lingering predecessor on takeover (RDR-128 single-writer gap)

### DIFF
--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -58,6 +58,8 @@ import os
 import signal
 import socket
 import struct
+import subprocess
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -65,6 +67,44 @@ from typing import Any
 import structlog
 
 _log = structlog.get_logger(__name__)
+
+# Grace period after SIGTERM before escalating to SIGKILL when reaping a
+# lingering predecessor daemon on takeover (RDR-128 single-writer backstop).
+_PREDECESSOR_REAP_TIMEOUT: float = 5.0
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """True iff signalling pid 0 to *pid* succeeds (EPERM => exists, treat
+    as alive). Mirrors the T3 daemon's liveness probe."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError as exc:
+        return exc.errno != errno.ESRCH
+    return True
+
+
+def _is_t2_daemon_process(pid: int) -> bool:
+    """Best-effort: confirm *pid*'s command line looks like a T2 daemon.
+
+    Guards against PID reuse before we send a kill signal: the addr-file
+    pid could have been recycled by an unrelated process after the old
+    daemon died. When the command line cannot be read we return ``False``
+    (refuse to kill rather than risk collateral)."""
+    try:
+        out = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return False
+    cmd = out.stdout.strip()
+    return "daemon t2" in cmd or "t2_daemon" in cmd
 
 
 # ---------------------------------------------------------------------------
@@ -492,6 +532,12 @@ class T2Daemon:
         """Acquire spawn lock, open T2Database, bind sockets, write discovery."""
         self._ensure_dirs()
         self._acquire_spawn_lock()
+        # RDR-128 single-writer backstop (nexus-070e2): we now hold the spawn
+        # lock, so we are the legitimate single writer. Reap any predecessor
+        # daemon still named in the addr file BEFORE opening T2Database, so its
+        # WAL writer is gone before we migrate and two daemons cannot coexist
+        # when the flock was bypassed (version transition / released-but-alive).
+        self._reap_predecessor_daemon()
 
         # RDR-120 P3b (nexus-e9x4l): daemon is the sole ``apply_pending``
         # caller. T2Database.__init__ no longer auto-runs migrations; the
@@ -698,6 +744,65 @@ class T2Daemon:
         self._config_dir.mkdir(parents=True, exist_ok=True)
         try:
             self._config_dir.chmod(0o700)
+        except OSError:
+            pass
+
+    def _reap_predecessor_daemon(self) -> None:
+        """Reap a lingering predecessor daemon named in the addr file.
+
+        Precondition: the spawn lock is held (called from :meth:`start`
+        immediately after :meth:`_acquire_spawn_lock`). Holding the lock
+        means we are the legitimate single writer, so any OTHER live pid in
+        the pre-existing discovery file is a zombie that escaped the flock
+        (e.g. across a version transition, or a released-but-alive window) and
+        must be reaped to honour RDR-128 single-writer — otherwise two daemons
+        contend on the same WAL ("FTS5: database is locked"; the 5.0.2-5.0.4
+        daemon-churn class). Run BEFORE opening T2Database so the predecessor's
+        WAL writer is gone before we migrate.
+
+        Best-effort and non-fatal: any failure to read the file or signal the
+        pid leaves startup to proceed (the flock already guarantees we are the
+        sole new writer).
+        """
+        disc_path = t2_discovery_path(self._config_dir)
+        try:
+            raw = disc_path.read_text()
+        except OSError:
+            return
+        try:
+            payload = json.loads(raw) if raw.strip() else None
+        except ValueError:
+            return
+        if not isinstance(payload, dict):
+            return
+        pid = payload.get("pid")
+        if not isinstance(pid, int) or pid <= 0 or pid == os.getpid():
+            return
+        if not _pid_is_alive(pid):
+            return
+        if not _is_t2_daemon_process(pid):
+            _log.warning("t2_predecessor_pid_not_daemon_skip_reap", pid=pid)
+            return
+
+        _log.warning("t2_reaping_predecessor_daemon", pid=pid)
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        except OSError as exc:
+            _log.warning("t2_predecessor_sigterm_failed", pid=pid, err=str(exc))
+            return
+
+        deadline = time.monotonic() + _PREDECESSOR_REAP_TIMEOUT
+        while time.monotonic() < deadline:
+            if not _pid_is_alive(pid):
+                _log.info("t2_predecessor_reaped", pid=pid, via="SIGTERM")
+                return
+            time.sleep(0.1)
+
+        try:
+            os.kill(pid, signal.SIGKILL)
+            _log.warning("t2_predecessor_sigkilled", pid=pid)
         except OSError:
             pass
 

--- a/tests/daemon/test_t2_daemon_startup_invariant.py
+++ b/tests/daemon/test_t2_daemon_startup_invariant.py
@@ -206,3 +206,133 @@ class TestDaemonRefusesSecondStartAgainstSamePath:
         finally:
             stop.set()
             thread.join(timeout=10.0)
+
+
+class TestDaemonReapsPredecessor:
+    """RDR-128 single-writer backstop (nexus-070e2).
+
+    The fcntl spawn lock normally prevents a second daemon, but a
+    predecessor can survive a version transition (or a released-but-alive
+    window) WITHOUT holding the lock. When a new daemon then acquires the
+    lock it is the legitimate single writer, and must reap that lingering
+    predecessor named in the addr file rather than coexist with it (the
+    two-daemons / WAL-contention class seen in the 5.1.1->5.1.4 upgrade).
+
+    These pin ``_reap_predecessor_daemon`` directly: the real two-process
+    race is the same one the nexus-9eaz framing could not reproduce on
+    GHA, so the primitives are monkeypatched for determinism.
+    """
+
+    @staticmethod
+    def _write_discovery(config_dir: Path, pid: int) -> Path:
+        import json
+
+        from nexus.daemon.t2_daemon import t2_discovery_path
+
+        p = t2_discovery_path(config_dir)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"pid": pid, "tcp_port": 1234}))
+        return p
+
+    def test_reaps_live_predecessor_with_sigterm(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        import signal
+
+        from nexus.daemon import t2_daemon as td
+
+        self._write_discovery(config_dir, 999999)
+        monkeypatch.setattr(td, "_is_t2_daemon_process", lambda pid: True)
+        state = {"alive": True}
+        monkeypatch.setattr(td, "_pid_is_alive", lambda pid: state["alive"])
+        kills: list[tuple[int, int]] = []
+
+        def fake_kill(pid: int, sig: int) -> None:
+            kills.append((pid, sig))
+            if sig == signal.SIGTERM:
+                state["alive"] = False  # graceful predecessor exits
+
+        monkeypatch.setattr(td.os, "kill", fake_kill)
+
+        d = td.T2Daemon(config_dir=config_dir, db_path=db_path)
+        d._reap_predecessor_daemon()
+
+        assert (999999, signal.SIGTERM) in kills
+        assert (999999, signal.SIGKILL) not in kills
+
+    def test_escalates_to_sigkill_when_sigterm_ignored(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        import signal
+
+        from nexus.daemon import t2_daemon as td
+
+        self._write_discovery(config_dir, 999998)
+        monkeypatch.setattr(td, "_is_t2_daemon_process", lambda pid: True)
+        monkeypatch.setattr(td, "_pid_is_alive", lambda pid: True)  # never dies
+        monkeypatch.setattr(td, "_PREDECESSOR_REAP_TIMEOUT", 0.2)
+        kills: list[tuple[int, int]] = []
+        monkeypatch.setattr(td.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+        d = td.T2Daemon(config_dir=config_dir, db_path=db_path)
+        d._reap_predecessor_daemon()
+
+        assert (999998, signal.SIGTERM) in kills
+        assert (999998, signal.SIGKILL) in kills
+
+    def test_no_reap_when_predecessor_dead(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.daemon import t2_daemon as td
+
+        self._write_discovery(config_dir, 999997)
+        monkeypatch.setattr(td, "_pid_is_alive", lambda pid: False)
+        monkeypatch.setattr(td, "_is_t2_daemon_process", lambda pid: True)
+        kills: list = []
+        monkeypatch.setattr(td.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert kills == []
+
+    def test_no_reap_when_pid_is_self(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        import os
+
+        from nexus.daemon import t2_daemon as td
+
+        self._write_discovery(config_dir, os.getpid())
+        monkeypatch.setattr(td, "_pid_is_alive", lambda pid: True)
+        monkeypatch.setattr(td, "_is_t2_daemon_process", lambda pid: True)
+        kills: list = []
+        monkeypatch.setattr(td.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert kills == []
+
+    def test_no_reap_when_pid_not_a_t2_daemon(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        """PID-reuse guard: a live pid whose cmdline is NOT a t2 daemon must
+        not be killed (the addr-file pid may have been recycled)."""
+        from nexus.daemon import t2_daemon as td
+
+        self._write_discovery(config_dir, 999996)
+        monkeypatch.setattr(td, "_pid_is_alive", lambda pid: True)
+        monkeypatch.setattr(td, "_is_t2_daemon_process", lambda pid: False)
+        kills: list = []
+        monkeypatch.setattr(td.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert kills == []
+
+    def test_no_discovery_file_is_noop(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.daemon import t2_daemon as td
+
+        kills: list = []
+        monkeypatch.setattr(td.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+        # no discovery file written
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert kills == []


### PR DESCRIPTION
## Problem (found in the 5.1.4 prod shakeout)

Two `nx daemon t2 start` processes coexisted after the 5.1.1→5.1.4 upgrade — the canonical one in the addr file plus a ~30-min-old orphan — causing transient `FTS5: database is locked` WAL contention. The `fcntl` spawn lock (`_acquire_spawn_lock`) is the single-writer guard, but it was bypassed across the version transition (predecessor released-but-alive / older lock scheme), and `T2Daemon.start()` never reaped a predecessor. Same class as the 5.0.2–5.0.4 daemon churn / the RDR-128 root cause.

## Fix

`T2Daemon._reap_predecessor_daemon()`, called in `start()`:
- **after** `_acquire_spawn_lock()` — we hold the lock, so we are the legitimate single writer; any *other* live pid in the addr file is a zombie that escaped the flock.
- **before** `T2Database` opens — so the predecessor's WAL writer is gone before we migrate.

It reads the pre-existing addr file; if it names a live pid `!= os.getpid()` whose command line is a t2 daemon (a `ps` guard against **PID reuse** — refuses to kill an unverifiable pid), it sends `SIGTERM`, waits `_PREDECESSOR_REAP_TIMEOUT` (5s), then escalates to `SIGKILL`. Best-effort and non-fatal.

## Tests
- 6 new TDD tests in `test_t2_daemon_startup_invariant.py`: sigterm reap, sigkill escalation, and no-op for dead / self / non-daemon-cmdline / no-addr-file. The real two-process race is the unreproducible `nexus-9eaz` surface, so the reap primitive is pinned directly.
- Existing 4 single-writer invariant tests still pass; full `tests/daemon/` green (110).
- Live-checked the `ps` cmdline guard against the running daemon (true for the real daemon, false for launchd / this process / dead pid).
- Storage-boundary lint baseline unchanged (no new T2/chroma open).

## Closes
nexus-070e2

## Note
Reaches the prod daemon when a daemon starts from a build containing this fix (next release, or a local reinstall + daemon restart). The current single daemon was already reconciled manually during the shakeout.
