### PR TITLE
feat(daemon): RDR-129 A1+A3 same-db daemon sweep + doctor multiplicity check

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -931,3 +931,4 @@
 {"id":"int-b684c95e","kind":"field_change","created_at":"2026-05-27T17:02:59.352585Z","actor":"Hellblazer","issue_id":"nexus-uq8a4","extra":{"field":"priority","new_value":"1","old_value":"3"}}
 {"id":"int-84e1c3c3","kind":"field_change","created_at":"2026-05-27T17:03:00.502201Z","actor":"Hellblazer","issue_id":"nexus-kwqhd","extra":{"field":"priority","new_value":"2","old_value":"1"}}
 {"id":"int-39261d19","kind":"field_change","created_at":"2026-05-27T17:03:02.237125Z","actor":"Hellblazer","issue_id":"nexus-70qc9.1","extra":{"field":"priority","new_value":"2","old_value":"1"}}
+{"id":"int-cf64e5bf","kind":"field_change","created_at":"2026-05-27T18:04:42.687891Z","actor":"Hellblazer","issue_id":"nexus-uq8a4","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -59,6 +59,7 @@ import signal
 import socket
 import struct
 import subprocess
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -105,6 +106,85 @@ def _is_t2_daemon_process(pid: int) -> bool:
         return False
     cmd = out.stdout.strip()
     return "daemon t2" in cmd or "t2_daemon" in cmd
+
+
+def _lsof_holder_pids(target: str) -> list[int]:
+    """Pids with *target* open, via ``lsof -t`` (macOS + any host with lsof).
+
+    ``lsof`` is not POSIX-standard but ships on macOS by default; on Linux it
+    is the fallback when ``/proc`` is unavailable. Best-effort: any failure
+    (lsof missing, non-zero exit because nothing holds the file) yields ``[]``.
+    """
+    try:
+        out = subprocess.run(
+            ["lsof", "-t", "--", target],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return []
+    pids: list[int] = []
+    for tok in out.stdout.split():
+        try:
+            pids.append(int(tok))
+        except ValueError:
+            continue
+    return pids
+
+
+def _proc_holder_pids(target: str) -> list[int]:
+    """Pids with *target* open, via a ``/proc/<pid>/fd`` symlink scan (Linux)."""
+    pids: list[int] = []
+    proc = Path("/proc")
+    try:
+        entries = list(proc.iterdir())
+    except OSError:
+        return []
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        fd_dir = entry / "fd"
+        try:
+            fds = list(fd_dir.iterdir())
+        except OSError:
+            continue  # process gone, or not ours to inspect
+        for fd in fds:
+            try:
+                if os.readlink(str(fd)) == target:
+                    pids.append(int(entry.name))
+                    break
+            except OSError:
+                continue
+    return pids
+
+
+def _open_fd_holder_pids(target: str) -> list[int]:
+    """Best-effort: every pid holding *target* open. Linux uses ``/proc``;
+    other platforms (notably darwin) use ``lsof``."""
+    if sys.platform != "darwin" and Path("/proc").is_dir():
+        return _proc_holder_pids(target)
+    return _lsof_holder_pids(target)
+
+
+def _enumerate_t2_daemon_pids_for_db(db_path: Path) -> list[int]:
+    """Live t2-daemon pids holding *db_path* open (RDR-129 A1, nexus-exa2p).
+
+    The single-daemon invariant is "exactly one t2 daemon per db path." The
+    addr file names only the canonical pid, so a side-orphan that started
+    after it is invisible to the addr-file reap. An open-fd probe on the data
+    file finds every holder regardless of how it was started (the cmdline
+    ``nx daemon t2 start`` does not name the db). Results are filtered to
+    processes whose command line looks like a t2 daemon, guarding against an
+    unrelated process that happens to hold the file.
+
+    Best-effort: returns ``[]`` when the db file does not exist (no holders
+    possible) or any probe step fails. Used by the startup sweep
+    (:meth:`T2Daemon._reap_predecessor_daemon`) and by ``nx doctor``'s
+    multiplicity check.
+    """
+    if not db_path.exists():
+        return []
+    target = str(db_path.resolve())
+    return [pid for pid in _open_fd_holder_pids(target) if _is_t2_daemon_process(pid)]
 
 
 # ---------------------------------------------------------------------------
@@ -748,36 +828,65 @@ class T2Daemon:
             pass
 
     def _reap_predecessor_daemon(self) -> None:
-        """Reap a lingering predecessor daemon named in the addr file.
+        """Sweep and reap every lingering t2 daemon for this db path.
 
         Precondition: the spawn lock is held (called from :meth:`start`
         immediately after :meth:`_acquire_spawn_lock`). Holding the lock
-        means we are the legitimate single writer, so any OTHER live pid in
-        the pre-existing discovery file is a zombie that escaped the flock
-        (e.g. across a version transition, or a released-but-alive window) and
-        must be reaped to honour RDR-128 single-writer — otherwise two daemons
-        contend on the same WAL ("FTS5: database is locked"; the 5.0.2-5.0.4
-        daemon-churn class). Run BEFORE opening T2Database so the predecessor's
-        WAL writer is gone before we migrate.
+        means we are the legitimate single writer, so any OTHER live t2 daemon
+        against this ``memory.db`` is a zombie that escaped the flock (a
+        version transition, a released-but-alive window) and must be reaped to
+        honour RDR-128 single-writer — otherwise two daemons contend on the
+        same WAL ("FTS5: database is locked"; the 5.0.2-5.0.4 daemon-churn
+        class). Run BEFORE opening ``T2Database`` so each predecessor's WAL
+        writer is gone before we migrate (and so self does not yet hold the db
+        open, keeping it out of the open-fd probe).
 
-        Best-effort and non-fatal: any failure to read the file or signal the
-        pid leaves startup to proceed (the flock already guarantees we are the
-        sole new writer).
+        Two reap targets are unioned (RDR-129 A1, nexus-exa2p):
+
+        1. The addr-file pid — the cheap, reliable signal for the common
+           takeover case (and the only one the 5.1.5 ``nexus-070e2`` reap
+           covered).
+        2. Same-db open-fd holders — a side-orphan that started AFTER the
+           canonical daemon was never the addr-file pid and is invisible to
+           (1). Enumerating holders of the data file (RF-A2 open-fd probe)
+           generalises "reap the addr-file predecessor" to "guarantee single
+           occupancy."
+
+        Best-effort and non-fatal: any failure to read the file, probe fds, or
+        signal a pid leaves startup to proceed (the flock already guarantees
+        we are the sole new writer).
         """
+        targets: list[int] = []
+
+        # 1. addr-file pid.
         disc_path = t2_discovery_path(self._config_dir)
         try:
             raw = disc_path.read_text()
-        except OSError:
-            return
-        try:
             payload = json.loads(raw) if raw.strip() else None
-        except ValueError:
-            return
-        if not isinstance(payload, dict):
-            return
-        pid = payload.get("pid")
-        if not isinstance(pid, int) or pid <= 0 or pid == os.getpid():
-            return
+        except (OSError, ValueError):
+            payload = None
+        if isinstance(payload, dict):
+            pid = payload.get("pid")
+            if isinstance(pid, int):
+                targets.append(pid)
+
+        # 2. same-db open-fd sweep (catches side-orphans absent from the addr
+        #    file).
+        targets.extend(_enumerate_t2_daemon_pids_for_db(self._db_path))
+
+        # Reap each distinct non-self target once.
+        seen: set[int] = set()
+        for pid in targets:
+            if pid <= 0 or pid == os.getpid() or pid in seen:
+                continue
+            seen.add(pid)
+            self._reap_one_daemon(pid)
+
+    def _reap_one_daemon(self, pid: int) -> None:
+        """SIGTERM (escalating to SIGKILL after ``_PREDECESSOR_REAP_TIMEOUT``)
+        a single live t2-daemon *pid*. Guarded by a liveness check and a
+        cmdline check (PID-reuse guard: refuse to kill a recycled pid whose
+        command line is not a t2 daemon). Best-effort; never raises."""
         if not _pid_is_alive(pid):
             return
         if not _is_t2_daemon_process(pid):

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -920,6 +920,53 @@ def _check_t2_dropped_writes() -> list[HealthResult]:
     )]
 
 
+def _check_t2_daemon_singleton() -> list[HealthResult]:
+    """Fail loud when more than one T2 daemon serves the same db (RDR-129 A3,
+    nexus-exa2p). Exactly one daemon per ``memory.db`` is the single-writer
+    invariant; two daemons contend on the WAL and produce the ``FTS5: database
+    is locked`` flicker. This is the **hard** census error, complementary to
+    the soft live-contention signal in ``_check_t2_integrity``: A1/A2 enforce
+    single occupancy, A3 makes a residual violation observable instead of
+    silent. Names the offending pids so an operator can act without reading
+    code.
+    """
+    db_path = default_db_path()
+    if not db_path.exists():
+        return [HealthResult(
+            label="T2 daemon singleton", ok=True, detail="no T2 database yet",
+        )]
+    try:
+        from nexus.daemon.t2_daemon import _enumerate_t2_daemon_pids_for_db
+
+        pids = sorted(set(_enumerate_t2_daemon_pids_for_db(db_path)))
+    except Exception as exc:  # pragma: no cover — defensive
+        # Absence of evidence is not evidence of multiplicity: a failed probe
+        # must not flip doctor red.
+        return [HealthResult(
+            label="T2 daemon singleton", ok=True, detail=f"probe unavailable: {exc}",
+        )]
+
+    if len(pids) <= 1:
+        detail = "1 daemon" if pids else "no daemon running"
+        return [HealthResult(label="T2 daemon singleton", ok=True, detail=detail)]
+
+    pid_list = ", ".join(str(p) for p in pids)
+    return [HealthResult(
+        label="T2 daemon singleton",
+        ok=False,
+        fatal=True,
+        detail=(
+            f"{len(pids)} daemons for {db_path.name} (pids: {pid_list}); "
+            f"single-writer invariant violated"
+        ),
+        fix_suggestions=[
+            "two T2 daemons are contending on the same memory.db (RDR-129 A3). "
+            "Stop the extras: `nx daemon t2 stop`, then "
+            "`nx daemon t2 ensure-running` to leave exactly one",
+        ],
+    )]
+
+
 def _check_chroma_pagination(client: object, db_name: str) -> list[HealthResult]:
     try:
         cols = client.list_collections()  # type: ignore[union-attr]
@@ -1142,6 +1189,7 @@ def run_health_checks() -> tuple[list[HealthResult], bool]:
     results.extend(_check_mineru_server())
     results.extend(_check_t2_integrity())
     results.extend(_check_t2_dropped_writes())
+    results.extend(_check_t2_daemon_singleton())
 
     # ChromaDB pagination audit (cloud only)
     if not _local:

--- a/tests/daemon/test_t2_daemon_startup_invariant.py
+++ b/tests/daemon/test_t2_daemon_startup_invariant.py
@@ -336,3 +336,131 @@ class TestDaemonReapsPredecessor:
         # no discovery file written
         td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
         assert kills == []
+
+
+class TestDaemonSweepsSideOrphans:
+    """RDR-129 A1 (nexus-exa2p): generalise the addr-file reap to a same-db
+    SWEEP. A side-orphan daemon that started AFTER the canonical daemon (so it
+    was never the addr-file pid) holds memory.db open but is invisible to the
+    addr-file reap. The startup sweep enumerates all live t2 daemons holding
+    THIS db open (open-fd probe) and reaps every non-self one, guaranteeing
+    single occupancy rather than just the common takeover case.
+    """
+
+    @staticmethod
+    def _write_discovery(config_dir: Path, pid: int) -> Path:
+        import json
+
+        from nexus.daemon.t2_daemon import t2_discovery_path
+
+        p = t2_discovery_path(config_dir)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"pid": pid, "tcp_port": 1234}))
+        return p
+
+    def test_sweeps_side_orphan_not_in_addr_file(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        import signal
+
+        from nexus.daemon import t2_daemon as td
+
+        # addr file names the canonical predecessor; a side-orphan holds the
+        # db open but is absent from the addr file.
+        self._write_discovery(config_dir, 111111)
+        monkeypatch.setattr(
+            td, "_enumerate_t2_daemon_pids_for_db", lambda p: [222222],
+        )
+        monkeypatch.setattr(td, "_is_t2_daemon_process", lambda pid: True)
+        state = {111111: True, 222222: True}
+        monkeypatch.setattr(td, "_pid_is_alive", lambda pid: state.get(pid, False))
+        kills: list[tuple[int, int]] = []
+
+        def fake_kill(pid: int, sig: int) -> None:
+            kills.append((pid, sig))
+            if sig == signal.SIGTERM:
+                state[pid] = False
+
+        monkeypatch.setattr(td.os, "kill", fake_kill)
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+
+        assert (111111, signal.SIGTERM) in kills, "addr-file pid not reaped"
+        assert (222222, signal.SIGTERM) in kills, "side-orphan not reaped by sweep"
+
+    def test_sweep_excludes_self(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        import os
+
+        from nexus.daemon import t2_daemon as td
+
+        # No addr file; the open-fd probe surfaces only our own pid.
+        monkeypatch.setattr(
+            td, "_enumerate_t2_daemon_pids_for_db", lambda p: [os.getpid()],
+        )
+        monkeypatch.setattr(td, "_is_t2_daemon_process", lambda pid: True)
+        monkeypatch.setattr(td, "_pid_is_alive", lambda pid: True)
+        kills: list = []
+        monkeypatch.setattr(td.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert kills == []
+
+    def test_addr_and_sweep_dedup_single_reap(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        """The addr-file pid that also surfaces in the open-fd sweep is reaped
+        exactly once, not twice."""
+        import signal
+
+        from nexus.daemon import t2_daemon as td
+
+        self._write_discovery(config_dir, 333333)
+        monkeypatch.setattr(
+            td, "_enumerate_t2_daemon_pids_for_db", lambda p: [333333],
+        )
+        monkeypatch.setattr(td, "_is_t2_daemon_process", lambda pid: True)
+        state = {333333: True}
+        monkeypatch.setattr(td, "_pid_is_alive", lambda pid: state.get(pid, False))
+        kills: list[tuple[int, int]] = []
+
+        def fake_kill(pid: int, sig: int) -> None:
+            kills.append((pid, sig))
+            if sig == signal.SIGTERM:
+                state[pid] = False
+
+        monkeypatch.setattr(td.os, "kill", fake_kill)
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert kills.count((333333, signal.SIGTERM)) == 1
+
+
+class TestEnumerateT2DaemonPids:
+    """RDR-129 A1 (nexus-exa2p): the open-fd enumeration helper used by both
+    the startup sweep and the doctor multiplicity check."""
+
+    def test_missing_db_short_circuits_empty(self, tmp_path, monkeypatch) -> None:
+        from nexus.daemon import t2_daemon as td
+
+        # A db file that does not exist can have no open-fd holders; the probe
+        # must short-circuit (and never shell out to lsof / scan /proc).
+        called = {"probe": False}
+
+        def _boom(target):  # pragma: no cover — must not run
+            called["probe"] = True
+            return [1]
+
+        monkeypatch.setattr(td, "_open_fd_holder_pids", _boom)
+        assert td._enumerate_t2_daemon_pids_for_db(tmp_path / "absent.db") == []
+        assert called["probe"] is False
+
+    def test_filters_non_daemon_holders(self, tmp_path, monkeypatch) -> None:
+        from nexus.daemon import t2_daemon as td
+
+        db = tmp_path / "memory.db"
+        db.write_text("x")  # only .exists() matters
+        monkeypatch.setattr(td, "_open_fd_holder_pids", lambda target: [10, 20, 30])
+        # 20 is some unrelated process holding the file; only daemons count.
+        monkeypatch.setattr(td, "_is_t2_daemon_process", lambda pid: pid in (10, 30))
+        assert td._enumerate_t2_daemon_pids_for_db(db) == [10, 30]

--- a/tests/test_doctor_integrity.py
+++ b/tests/test_doctor_integrity.py
@@ -13,6 +13,7 @@ from nexus.health import (
     _check_orphan_t1,
     _check_t2_integrity,
     _check_t2_dropped_writes,
+    _check_t2_daemon_singleton,
     _check_chroma_pagination,
     _check_orphan_checkpoints,
     HealthResult,
@@ -236,6 +237,64 @@ class TestCheckT2DroppedWrites:
         assert r.warn is True
         assert r.fatal is False  # never a hard fail — the metric must survive
         assert "1" in r.detail
+
+
+# ── T2 daemon singleton / multiplicity (RDR-129 A3, nexus-exa2p) ────────────
+
+class TestCheckT2DaemonSingleton:
+    def _run(self, db_path: Path) -> tuple[bool, list[HealthResult]]:
+        with patch("nexus.health.default_db_path", return_value=db_path):
+            results = _check_t2_daemon_singleton()
+        ok = all(r.ok for r in results)
+        return ok, results
+
+    def test_no_db_is_ok(self, tmp_path):
+        ok, results = self._run(tmp_path / "absent.db")
+        assert ok is True
+        assert results[0].ok is True
+
+    @pytest.mark.parametrize("pids", [[], [4242]], ids=["zero", "one"])
+    def test_zero_or_one_daemon_ok(self, tmp_path, monkeypatch, pids):
+        db = tmp_path / "memory.db"
+        db.write_text("x")
+        monkeypatch.setattr(
+            "nexus.daemon.t2_daemon._enumerate_t2_daemon_pids_for_db",
+            lambda p: list(pids),
+        )
+        ok, results = self._run(db)
+        assert ok is True
+        assert results[0].ok is True
+        assert results[0].fatal is False
+
+    def test_multiple_daemons_hard_error_names_pids(self, tmp_path, monkeypatch):
+        db = tmp_path / "memory.db"
+        db.write_text("x")
+        monkeypatch.setattr(
+            "nexus.daemon.t2_daemon._enumerate_t2_daemon_pids_for_db",
+            lambda p: [4242, 5353],
+        )
+        ok, results = self._run(db)
+        r = results[0]
+        assert ok is False
+        assert r.ok is False
+        assert r.fatal is True  # multiplicity is a HARD failure (A3), unlike B4
+        assert r.warn is False
+        assert "4242" in r.detail and "5353" in r.detail
+
+    def test_probe_failure_degrades_to_ok(self, tmp_path, monkeypatch):
+        """A probe that itself errors must not flip doctor red — absence of
+        evidence is not evidence of multiplicity."""
+        db = tmp_path / "memory.db"
+        db.write_text("x")
+
+        def _boom(p):
+            raise RuntimeError("lsof exploded")
+
+        monkeypatch.setattr(
+            "nexus.daemon.t2_daemon._enumerate_t2_daemon_pids_for_db", _boom
+        )
+        ok, results = self._run(db)
+        assert ok is True
 
 
 # ── Step 7: ChromaDB pagination ─────────────────────────────────────────────


### PR DESCRIPTION
## What

RDR-129 Layer A, beads `nexus-exa2p` (A1) **and** A3 (the doctor multiplicity check, which the RDR carries inside the A1/A2 work with no standalone bead). A3 lands **here** rather than in `nexus-kwqhd` because its daemon enumeration is the same machinery A1's sweep needs — building it once avoids a double-implement. `nexus-kwqhd` (A2) does not touch A3.

### A1 — sweep, do not just reap (`src/nexus/daemon/t2_daemon.py`)
The 5.1.5 reap (`nexus-070e2`) signalled only the addr-file pid. A side-orphan daemon that started *after* the canonical one was never the addr-file pid, survived, and contended on `memory.db`'s WAL (the `FTS5: database is locked` flicker). This generalises the startup reap from "reap the addr-file predecessor" to "guarantee single occupancy":

- `_reap_predecessor_daemon` now unions the addr-file pid with an **open-fd probe** of every live t2 daemon holding this db open, and reaps each distinct non-self target once.
- New `_enumerate_t2_daemon_pids_for_db` does the probe: Linux `/proc/<pid>/fd` symlink scan, darwin (and `/proc`-less) fallback to `lsof -t`, filtered by the existing t2-daemon cmdline guard. It short-circuits to `[]` when the db file does not exist, so the existing reap tests stay hermetic and the probe never shells out needlessly. Self is absent from the probe because the reap runs *before* `T2Database` opens the db.
- The per-pid SIGTERM→(timeout)→SIGKILL dance moves to `_reap_one_daemon`; existing behaviour is preserved verbatim.

### A3 — fail loud on multiplicity (`src/nexus/health.py`)
`nx doctor` gains a hard `T2 daemon singleton` check built on the same enumeration. More than one daemon for a db is a **fatal** error naming the offending pids. This is the hard census error complementary to the soft live-contention signal from the B4 integrity check (shipped in #982): A1/A2 enforce single occupancy, A3 makes a residual violation observable instead of silent. A failed probe degrades to `ok` — absence of evidence is not evidence of multiplicity.

## Scope notes
- This is Layer A occupancy. The release-before-exit bug (A2) and its co-dependent ensure-running interlock are `nexus-kwqhd`, a separate PR. The serving busy_timeout/retry (B1+B2) is `nexus-qi1zb`.
- Real two-process daemon races are the nexus-9eaz flake class that does not reproduce reliably on CI; following this file's established pattern, the sweep is pinned via monkeypatched primitives for determinism.

## Tests
- `TestDaemonSweepsSideOrphans`: side-orphan reaped, self excluded from sweep, addr+sweep dedup (exactly one SIGTERM).
- `TestEnumerateT2DaemonPids`: missing-db short-circuit (no shell-out), non-daemon holder filtered out.
- `TestCheckT2DaemonSingleton`: zero/one daemon ok, multiplicity hard error names pids, probe-failure degrades to ok.
- All existing `TestDaemonReapsPredecessor` tests green (the refactor preserved behaviour). Narrow suite: 56 passed.

Refs nexus-exa2p