### PR TITLE
fix(daemon): RDR-129 A2 defer spawn-lock release to exit + ensure-running PID interlock

### DIFF
--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -667,6 +667,31 @@ def t2_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
 # constant so tests can shrink it without waiting the full 30s.
 _T2_CYCLE_DB_PROBE_TIMEOUT_MS: int = 30000
 
+# RDR-129 A2 (nexus-kwqhd): how long ``ensure-running`` waits for a SIGTERM'd
+# stale daemon to FULLY EXIT before cold-spawning its replacement. The wait
+# polls the predecessor's PID liveness, not the discovery file: stop() now
+# holds the spawn lock until process exit (defer-release-to-exit) but unlinks
+# the discovery file early, so a discovery-file poll would see "gone" while the
+# lock is still held and cold-spawn into an EAGAIN -> zero daemons. If the
+# predecessor outlives this window the cycle aborts and leaves it up (RDR-128
+# RF-4: never trade a working daemon for none). Module constant so tests can
+# shrink it.
+_T2_CYCLE_EXIT_TIMEOUT: float = 10.0
+
+
+def _predecessor_alive(pid: int) -> bool:
+    """True iff *pid* is alive AND still looks like a t2 daemon.
+
+    The cmdline guard (``_is_t2_daemon_process``) defends the version-cycle
+    wait against PID reuse: if the predecessor's pid is recycled to an
+    unrelated process during the wait, treat the predecessor as gone rather
+    than waiting on (or aborting for) a stranger. Used by ``ensure-running``
+    to poll the predecessor's exit (RDR-129 A2).
+    """
+    from nexus.daemon.t2_daemon import _is_t2_daemon_process, _pid_is_alive
+
+    return _pid_is_alive(pid) and _is_t2_daemon_process(pid)
+
 
 def _t2_db_write_lock_acquirable(db_path: Path, timeout_ms: int) -> bool:
     """Probe whether memory.db's single WAL writer lock is acquirable
@@ -826,12 +851,29 @@ def t2_ensure_running_cmd(
             os.kill(running_pid, signal.SIGTERM)
         except (ProcessLookupError, PermissionError):
             pass
-        cycle_deadline = _time.monotonic() + 10.0
+        # RDR-129 A2 (nexus-kwqhd): poll the predecessor's PID liveness, NOT
+        # the discovery file. stop() now holds the spawn lock until the
+        # process exits (defer-release-to-exit) while unlinking the discovery
+        # file early; a discovery-file poll would see "gone" while the pid is
+        # still alive and holding the lock, so the cold spawn below would hit
+        # EAGAIN on the spawn lock and leave ZERO daemons. Wait for the pid to
+        # actually exit (lock dropped by the OS); if it outlives the window,
+        # abort and keep the stale-but-working daemon (RF-4: never trade a
+        # working daemon for none).
+        cycle_deadline = _time.monotonic() + _T2_CYCLE_EXIT_TIMEOUT
         while _time.monotonic() < cycle_deadline:
-            if not _daemon_is_alive():
+            if not _predecessor_alive(running_pid):
                 break
             _time.sleep(0.1)
-        # fall through to cold spawn
+        else:
+            click.echo(
+                f"T2 daemon v{running_ver} (pid {running_pid}) did not exit "
+                f"within {_T2_CYCLE_EXIT_TIMEOUT}s of SIGTERM; cycle aborted, "
+                "leaving it up (will retry on next ensure-running).",
+                err=True,
+            )
+            return  # never trade a working daemon for none
+        # predecessor fully exited; its spawn lock is released — cold spawn.
 
     # Cold spawn. Use the same nx binary the operator invoked (preserves
     # PATH/virtualenv assumptions). start_new_session detaches the child

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -587,8 +587,22 @@ class T2Daemon:
         _log.info("t2_daemon_stop_requested", signal_received=True)
 
     async def stop(self) -> None:
-        """Close servers, drop discovery file, release spawn lock,
-        close T2Database."""
+        """Close servers, drop discovery file, close T2Database.
+
+        RDR-129 A2 (nexus-kwqhd): ``stop()`` deliberately does NOT release the
+        spawn lock. The lock is held for the whole process lifetime and dropped
+        by the OS when the process exits. Releasing it here (the prior
+        behaviour) opened a *released-but-alive* window: ``stop()`` runs while
+        the process is still draining/exiting, so a respawn (notably
+        ``ensure-running`` on version skew) could acquire the freed lock and
+        run alongside the still-living predecessor, violating single-writer.
+        Deferring the release to OS-on-exit closes that window: the lock stops
+        being held at exactly the moment the pid stops being alive. The
+        co-dependent ``ensure-running`` interlock (``commands/daemon.py``) now
+        waits on the predecessor's PID liveness before cold-spawning, so it
+        never spawns into the lock-still-held window. ``_release_spawn_lock``
+        remains callable for explicit teardown (tests simulate process exit).
+        """
         if self._uds_server is not None:
             self._uds_server.close()
             await self._uds_server.wait_closed()
@@ -608,7 +622,7 @@ class T2Daemon:
             except Exception as exc:  # noqa: BLE001
                 _log.warning("t2_daemon_t2db_close_failed", error=str(exc))
             self._t2db = None
-        self._release_spawn_lock()
+        # NB: spawn lock intentionally NOT released here — see docstring.
         _log.info("t2_daemon_stopped")
 
     # ── socket binding ──────────────────────────────────────────────────

--- a/tests/daemon/test_t2_daemon_startup_invariant.py
+++ b/tests/daemon/test_t2_daemon_startup_invariant.py
@@ -94,15 +94,21 @@ class TestDaemonRefusesSecondStartAgainstSamePath:
             thread.join(timeout=10.0)
             assert not thread.is_alive(), "first daemon did not stop"
 
-    def test_second_start_succeeds_after_first_stops(
+    def test_spawn_lock_held_until_release_not_just_stop(
         self, config_dir: Path, db_path: Path,
     ) -> None:
-        """The spawn lock is released on clean stop; a fresh start
-        against the same path after the first daemon stops must
-        succeed (the invariant is mutual-exclusion *while running*,
-        not permanent exclusion).
+        """RDR-129 A2 (nexus-kwqhd): ``stop()`` no longer releases the spawn
+        lock — the lock is held for the process lifetime and dropped by the OS
+        on exit. This closes the released-but-alive window where a respawn
+        could acquire the freed lock while the predecessor was still draining.
+
+        In-process (thread-based) the OS never drops the lock, so a second
+        start on the same path after ``stop()`` must FAIL; only an explicit
+        ``_release_spawn_lock()`` (the process-exit equivalent) frees the next
+        start. This is the inverse of the prior contract, which released on
+        ``stop()``.
         """
-        from nexus.daemon.t2_daemon import T2Daemon
+        from nexus.daemon.t2_daemon import T2Daemon, T2DaemonError
 
         first = T2Daemon(config_dir=config_dir, db_path=db_path)
         ready1 = threading.Event()
@@ -116,22 +122,31 @@ class TestDaemonRefusesSecondStartAgainstSamePath:
         t1.join(timeout=10.0)
         assert not t1.is_alive()
 
-        # Spawn lock should be released — second start succeeds.
+        # stop() ran but the lock is still held by this process — a
+        # same-process restart on the same path must fail loud.
         second = T2Daemon(config_dir=config_dir, db_path=db_path)
-        ready2 = threading.Event()
-        stop2 = threading.Event()
-        t2 = threading.Thread(
-            target=_run_daemon_in_thread, args=(second, ready2, stop2),
+        with pytest.raises(T2DaemonError) as excinfo:
+            asyncio.run(second.start())
+        assert "spawn lock" in str(excinfo.value)
+
+        # Explicit release (what the OS does on real process exit) frees the
+        # lock; a fresh start then succeeds.
+        first._release_spawn_lock()
+        third = T2Daemon(config_dir=config_dir, db_path=db_path)
+        ready3 = threading.Event()
+        stop3 = threading.Event()
+        t3 = threading.Thread(
+            target=_run_daemon_in_thread, args=(third, ready3, stop3),
         )
-        t2.start()
+        t3.start()
         try:
-            assert ready2.wait(timeout=10.0), (
-                "second daemon failed to start after first stopped — "
-                "spawn lock leak"
+            assert ready3.wait(timeout=10.0), (
+                "start after explicit lock release should succeed"
             )
         finally:
-            stop2.set()
-            t2.join(timeout=10.0)
+            stop3.set()
+            t3.join(timeout=10.0)
+            third._release_spawn_lock()  # tidy: drop the lock fd for this pid
 
     def test_second_start_different_config_dir_same_db_path_fails_loud(
         self, db_path: Path,

--- a/tests/daemon/test_t2_ensure_running.py
+++ b/tests/daemon/test_t2_ensure_running.py
@@ -424,6 +424,116 @@ class TestCycleInterlock:
         assert "cycle deferred" in result.output.lower()
         assert result.exit_code == 0
 
+    def test_cycle_aborts_when_predecessor_outlives_window(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """RDR-129 A2 (nexus-kwqhd): if the SIGTERM'd stale daemon does not
+        exit within the cycle window, ensure-running ABORTS — it does not
+        cold-spawn a replacement (which would EAGAIN on the still-held spawn
+        lock and leave zero daemons). The stale-but-working daemon is left up
+        (RF-4)."""
+        import signal as _signal
+
+        import nexus.commands.daemon as _daemon
+
+        _write_discovery(tmp_path, pid=424242, version="0.0.1-stale")
+        monkeypatch.setattr(
+            "importlib.metadata.version", lambda _name: "9.9.9-installed"
+        )
+        _seed_wal_db(tmp_path / "memory.db")  # exists, unlocked → probe passes
+        monkeypatch.setattr(_daemon, "_T2_CYCLE_EXIT_TIMEOUT", 0.3)
+
+        sigterms: list[int] = []
+
+        def _fake_kill(pid, sig):  # noqa: ANN001
+            if pid != 424242:
+                raise ProcessLookupError
+            if sig == _signal.SIGTERM:
+                sigterms.append(pid)
+                return
+            if sig == 0:
+                return  # predecessor never exits
+
+        monkeypatch.setattr(os, "kill", _fake_kill)
+        # The still-alive pid genuinely looks like a t2 daemon (PID-reuse guard).
+        monkeypatch.setattr(
+            "nexus.daemon.t2_daemon._is_t2_daemon_process", lambda pid: True
+        )
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda *a, **kw: pytest.fail(
+                "must NOT spawn while the predecessor is still alive"
+            ),
+        )
+
+        result = CliRunner().invoke(
+            main,
+            ["daemon", "t2", "ensure-running",
+             "--config-dir", str(tmp_path), "--timeout", "0.2"],
+        )
+        assert sigterms == [424242], "predecessor should have been SIGTERM'd"
+        assert "cycle aborted" in result.output.lower()
+        assert result.exit_code == 0  # never trade a working daemon for none
+
+    def test_cycle_waits_for_pid_exit_then_spawns(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """The cycle wait polls PID liveness, not the discovery file: even
+        after stop() unlinks the discovery file early, ensure-running waits
+        for the predecessor to actually exit and then cold-spawns exactly one
+        replacement (never zero)."""
+        import signal as _signal
+
+        import nexus.commands.daemon as _daemon
+
+        _write_discovery(tmp_path, pid=424242, version="0.0.1-stale")
+        monkeypatch.setattr(
+            "importlib.metadata.version", lambda _name: "9.9.9-installed"
+        )
+        _seed_wal_db(tmp_path / "memory.db")
+        monkeypatch.setattr(_daemon, "_T2_CYCLE_EXIT_TIMEOUT", 5.0)
+
+        disc = _discovery_path(tmp_path)
+        state = {"polls": 0}
+
+        def _fake_kill(pid, sig):  # noqa: ANN001
+            if pid != 424242:
+                raise ProcessLookupError
+            if sig == _signal.SIGTERM:
+                # stop() unlinks the discovery file BEFORE the process exits.
+                disc.unlink(missing_ok=True)
+                return
+            if sig == 0:
+                state["polls"] += 1
+                if state["polls"] >= 2:
+                    raise ProcessLookupError  # predecessor finally exits
+                return
+
+        monkeypatch.setattr(os, "kill", _fake_kill)
+        monkeypatch.setattr(
+            "nexus.daemon.t2_daemon._is_t2_daemon_process", lambda pid: True
+        )
+
+        spawned: list[list[str]] = []
+
+        class _FakePopen:
+            def __init__(self, argv, **_kw):  # noqa: ANN001
+                spawned.append(argv)
+
+        monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+
+        CliRunner().invoke(
+            main,
+            ["daemon", "t2", "ensure-running",
+             "--config-dir", str(tmp_path), "--timeout", "0.2"],
+        )
+        assert state["polls"] >= 2, (
+            "should have polled PID liveness past the unlinked discovery file"
+        )
+        assert len(spawned) == 1, (
+            "exactly one replacement spawned after the predecessor exited"
+        )
+
     def test_stale_daemon_cycled_when_db_lock_free(
         self, tmp_path, monkeypatch,
     ) -> None:


### PR DESCRIPTION
## What

RDR-129 Layer A, bead `nexus-kwqhd` (A2): close the **release-before-exit** window that let two T2 daemons coexist on the same `memory.db` in the 5.1.5 shakeout.

Per RF-A1, the db-path spawn lock was never the problem (it is already version-stable). The bug was `T2Daemon.stop()` releasing the spawn lock while the process was still draining: a respawn (notably `ensure-running` on version skew) could acquire the freed lock and run alongside the still-living predecessor, contending on the WAL (`FTS5: database is locked`).

### Two co-dependent halves (must ship together)

1. **`stop()` no longer releases the spawn lock** (`src/nexus/daemon/t2_daemon.py`). The lock is held for the process lifetime and dropped by the OS on exit, so it stops being held at exactly the moment the pid stops being alive. `_release_spawn_lock` stays callable for explicit teardown.

2. **`ensure-running`'s version-cycle wait polls PID liveness, not the discovery file** (`src/nexus/commands/daemon.py`). `stop()` unlinks the discovery file early, so the old discovery-file poll would see "gone" while the lock was still held and cold-spawn into an `EAGAIN` on the spawn lock, leaving **zero** daemons (the failure RDR-128 prevents). The new poll (`_predecessor_alive` = `_pid_is_alive` + the `_is_t2_daemon_process` cmdline guard) waits for the predecessor to actually exit before spawning; if it outlives the bounded `_T2_CYCLE_EXIT_TIMEOUT` window the cycle aborts and leaves the stale-but-working daemon up (RF-4: never trade a working daemon for none).

Deferring the release without the interlock would reintroduce the zero-daemon failure, hence one PR.

## Contract change
`stop()` previously released the lock; a same-process restart relied on that. The new contract: the lock is dropped on **process exit**, not on `stop()`. The startup-invariant test is inverted accordingly (`test_spawn_lock_held_until_release_not_just_stop`): in-process, `stop()` holds the lock and a second start fails until an explicit `_release_spawn_lock()` (the process-exit equivalent).

## Relationship to the other RDR-129 PRs
- Independent of #983 (A1 sweep + A3 doctor check) — disjoint functions in `t2_daemon.py`; the two merge in any order.
- B1+B2 (serving busy_timeout + dispatch retry) is `nexus-qi1zb`, a separate PR.

## Tests
- `test_spawn_lock_held_until_release_not_just_stop`: the inverted lock contract.
- `TestCycleWaitsOnPidLiveness::test_cycle_aborts_when_predecessor_outlives_window`: SIGTERM'd predecessor that never exits → no spawn, daemon left up, exit 0.
- `TestCycleWaitsOnPidLiveness::test_cycle_waits_for_pid_exit_then_spawns`: predecessor exits after the discovery file is unlinked → exactly one replacement spawned (never zero).
- Full `tests/daemon/` + rdr128 startup suite green: 117 passed.

Closes nexus-kwqhd