### PR TITLE
fix(daemon): RDR-129 B1+B2 serving busy_timeout 30s + dispatch lock-retry

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -932,3 +932,5 @@
 {"id":"int-84e1c3c3","kind":"field_change","created_at":"2026-05-27T17:03:00.502201Z","actor":"Hellblazer","issue_id":"nexus-kwqhd","extra":{"field":"priority","new_value":"2","old_value":"1"}}
 {"id":"int-39261d19","kind":"field_change","created_at":"2026-05-27T17:03:02.237125Z","actor":"Hellblazer","issue_id":"nexus-70qc9.1","extra":{"field":"priority","new_value":"2","old_value":"1"}}
 {"id":"int-cf64e5bf","kind":"field_change","created_at":"2026-05-27T18:04:42.687891Z","actor":"Hellblazer","issue_id":"nexus-uq8a4","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-e052b686","kind":"field_change","created_at":"2026-05-27T19:00:20.141737Z","actor":"Hellblazer","issue_id":"nexus-exa2p","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-d8713ea0","kind":"field_change","created_at":"2026-05-27T19:00:22.072422Z","actor":"Hellblazer","issue_id":"nexus-kwqhd","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -57,6 +57,7 @@ import json
 import os
 import signal
 import socket
+import sqlite3
 import struct
 import subprocess
 import sys
@@ -72,6 +73,25 @@ _log = structlog.get_logger(__name__)
 # Grace period after SIGTERM before escalating to SIGKILL when reaping a
 # lingering predecessor daemon on takeover (RDR-128 single-writer backstop).
 _PREDECESSOR_REAP_TIMEOUT: float = 5.0
+
+# RDR-129 B2 (nexus-qi1zb): bounded lock-retry for the serving dispatch.
+# Mirrors the bootstrap-migration retry
+# (``nexus.db.t2._apply_pending_with_lock_retry``): three attempts with two
+# inter-attempt async sleeps. The per-store ``busy_timeout``
+# (``SERVING_BUSY_TIMEOUT_MS`` = 30s) already absorbs most cross-store WAL
+# contention, so this only fires when a window exceeds the timeout; it turns a
+# >30s contention spike into a wait rather than a dropped best-effort write.
+# Module constant so tests can shrink the sleeps.
+_DISPATCH_RETRY_SLEEPS: tuple[float, ...] = (0.1, 0.25)
+
+
+def _is_locked_error(exc: BaseException) -> bool:
+    """True when *exc* is transient WAL writer-lock contention
+    (``database is locked`` / ``database is busy``), not a structural error.
+    Mirrors the discriminator in
+    ``nexus.db.t2._apply_pending_with_lock_retry``."""
+    msg = str(exc).lower()
+    return "locked" in msg or "busy" in msg
 
 
 def _pid_is_alive(pid: int) -> bool:
@@ -814,7 +834,29 @@ class T2Daemon:
         callable_ = self._dispatch_table[op]
         # All current dispatch methods are sync; offload to a thread so
         # the event loop doesn't block on SQLite writes.
-        return await asyncio.to_thread(callable_, *args, **kwargs)
+        #
+        # RDR-129 B2 (nexus-qi1zb): retry on transient WAL writer-lock
+        # contention so a cross-store contention window past the per-store
+        # busy_timeout becomes a wait, not a dropped best-effort write (the
+        # shakeout drop class). Non-lock errors propagate on the first attempt;
+        # the final attempt re-raises so a genuinely stuck lock still surfaces
+        # (logged upstream as t2_daemon_dispatch_failed). Re-running the whole
+        # op is safe: SQLITE_BUSY fires at lock acquisition before the
+        # statement executes, and the store writes are upserts / single
+        # transactions that roll back cleanly on failure.
+        sleeps = _DISPATCH_RETRY_SLEEPS
+        max_attempts = len(sleeps) + 1
+        for attempt in range(1, max_attempts + 1):
+            try:
+                return await asyncio.to_thread(callable_, *args, **kwargs)
+            except sqlite3.OperationalError as exc:
+                if not _is_locked_error(exc) or attempt == max_attempts:
+                    raise
+                _log.warning(
+                    "t2_daemon_dispatch_lock_retry",
+                    op=op, attempt=attempt, exc=str(exc),
+                )
+                await asyncio.sleep(sleeps[attempt - 1])
 
     @staticmethod
     def _send_error(

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -66,6 +66,8 @@ import sqlite3
 
 import structlog
 
+from nexus.db.t2._tuning import SERVING_BUSY_TIMEOUT_MS
+
 # Cheap import only: ``_sanitize_fts5`` is needed by
 # ``nexus.catalog.catalog_db`` at module import time, and the
 # memory_store module's top-level imports are stdlib + structlog only
@@ -549,7 +551,7 @@ class T2Database:
         conn: sqlite3.Connection
         if owned:
             conn = sqlite3.connect(str(self._path), check_same_thread=False)
-            conn.execute("PRAGMA busy_timeout=5000")
+            conn.execute(f"PRAGMA busy_timeout={SERVING_BUSY_TIMEOUT_MS}")
             conn.execute("PRAGMA journal_mode=WAL")
         else:
             conn = _conn  # type: ignore[assignment]

--- a/src/nexus/db/t2/_tuning.py
+++ b/src/nexus/db/t2/_tuning.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Shared T2 connection-tuning constants (RDR-129 B1, nexus-qi1zb).
+
+Leaf module: no intra-``nexus.db.t2`` imports, so every domain store and the
+package facade can import it without a cycle.
+"""
+from __future__ import annotations
+
+#: ``busy_timeout`` for every daemon-owned domain-store serving connection.
+#: 30s matches the startup-migration window
+#: (:data:`nexus.db.t2._BOOTSTRAP_BUSY_TIMEOUT_MS`) and absorbs the cross-store
+#: WAL contention that otherwise drops best-effort writes under heavy
+#: concurrent indexing (RDR-129 RF-B1). The prior 5s was falsified by two
+#: production shakeouts. Paired with the daemon ``_dispatch`` lock-retry (B2)
+#: so a contention window longer than the timeout still becomes a wait, not a
+#: drop. NB: connections that must fail fast (memory_store's best-effort
+#: access-count update, ``_ACCESS_TRACK_BUSY_MS = 0``) intentionally do NOT use
+#: this value.
+SERVING_BUSY_TIMEOUT_MS: int = 30000

--- a/src/nexus/db/t2/catalog.py
+++ b/src/nexus/db/t2/catalog.py
@@ -42,6 +42,7 @@ from typing import TYPE_CHECKING, Any, Iterator
 
 import structlog
 
+from nexus.db.t2._tuning import SERVING_BUSY_TIMEOUT_MS
 from nexus.db.t2.memory_store import _sanitize_fts5
 
 if TYPE_CHECKING:  # pragma: no cover — import for type hints only
@@ -325,7 +326,7 @@ class CatalogStore:
         # (5 s busy_timeout + WAL) so cross-process writers don't immediately
         # raise ``OperationalError: database is locked`` when the CLI races
         # an indexing writer.
-        self._conn.execute("PRAGMA busy_timeout=5000")
+        self._conn.execute(f"PRAGMA busy_timeout={SERVING_BUSY_TIMEOUT_MS}")
         self._conn.execute("PRAGMA journal_mode=WAL")
         # RDR-108 D2 + D5 (nexus-mydi): enable foreign-key enforcement
         # so the document_chunks manifest cannot reference a deleted

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -38,6 +38,8 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 import numpy as np
 import structlog
 
+from nexus.db.t2._tuning import SERVING_BUSY_TIMEOUT_MS
+
 if TYPE_CHECKING:
     from nexus.db.t2.memory_store import MemoryStore
 
@@ -239,7 +241,7 @@ class CatalogTaxonomy:
         self._memory = memory
         self._lock = threading.Lock()
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
-        self.conn.execute("PRAGMA busy_timeout=5000")
+        self.conn.execute(f"PRAGMA busy_timeout={SERVING_BUSY_TIMEOUT_MS}")
         # RDR-077 Phase 3 (nexus-qab): register `log2` as a SQLite scalar
         # function so the ICF aggregation query can use LOG2() inline.
         # Null-safe: returns NULL when x is NULL, 0, or negative.

--- a/src/nexus/db/t2/chash_index.py
+++ b/src/nexus/db/t2/chash_index.py
@@ -50,6 +50,8 @@ from typing import Any
 
 import structlog
 
+from nexus.db.t2._tuning import SERVING_BUSY_TIMEOUT_MS
+
 _log = structlog.get_logger()
 
 
@@ -81,7 +83,7 @@ class ChashIndex:
     def __init__(self, path: Path) -> None:
         self._lock = threading.Lock()
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
-        self.conn.execute("PRAGMA busy_timeout=5000")
+        self.conn.execute(f"PRAGMA busy_timeout={SERVING_BUSY_TIMEOUT_MS}")
         self._init_schema()
 
     def close(self) -> None:

--- a/src/nexus/db/t2/document_aspects.py
+++ b/src/nexus/db/t2/document_aspects.py
@@ -52,6 +52,8 @@ from pathlib import Path
 
 import structlog
 
+from nexus.db.t2._tuning import SERVING_BUSY_TIMEOUT_MS
+
 _log = structlog.get_logger()
 
 
@@ -199,7 +201,7 @@ class DocumentAspects:
     def __init__(self, path: Path) -> None:
         self._lock = threading.Lock()
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
-        self.conn.execute("PRAGMA busy_timeout=5000")
+        self.conn.execute(f"PRAGMA busy_timeout={SERVING_BUSY_TIMEOUT_MS}")
         self._init_schema()
 
     def close(self) -> None:

--- a/src/nexus/db/t2/memory_store.py
+++ b/src/nexus/db/t2/memory_store.py
@@ -38,6 +38,7 @@ from typing import Any, Literal
 
 import structlog
 
+from nexus.db.t2._tuning import SERVING_BUSY_TIMEOUT_MS
 from nexus.session import read_claude_session_id as _read_session_id
 
 _log = structlog.get_logger()
@@ -176,10 +177,12 @@ _COLUMNS = (
 )
 
 
-# Default busy_timeout for the memory store's connection. 5 seconds is
-# well beyond any schema-creation or migration window and absorbs normal
-# cross-domain write-lock contention.
-_DEFAULT_BUSY_MS = 5000
+# Default busy_timeout for the memory store's connection. RDR-129 B1
+# (nexus-qi1zb) raised this 5000 -> 30000 (the shared
+# ``SERVING_BUSY_TIMEOUT_MS``, matching the bootstrap window): two shakeouts
+# showed 5s was too short to absorb cross-store WAL contention under heavy
+# concurrent indexing.
+_DEFAULT_BUSY_MS = SERVING_BUSY_TIMEOUT_MS
 
 # Disabled busy_timeout used only around the best-effort access-count
 # UPDATE in ``search(access="track")`` and ``get()``. The access counter

--- a/src/nexus/db/t2/plan_library.py
+++ b/src/nexus/db/t2/plan_library.py
@@ -33,6 +33,7 @@ from typing import Any
 
 import structlog
 
+from nexus.db.t2._tuning import SERVING_BUSY_TIMEOUT_MS
 from nexus.db.t2.memory_store import _sanitize_fts5
 # Scope-tag helpers live in ``nexus.plans.scope`` to break the
 # ``migrations -> plan_library -> migrations`` circular import path
@@ -221,7 +222,7 @@ class PlanLibrary:
     def __init__(self, path: Path) -> None:
         self._lock = threading.Lock()
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
-        self.conn.execute("PRAGMA busy_timeout=5000")
+        self.conn.execute(f"PRAGMA busy_timeout={SERVING_BUSY_TIMEOUT_MS}")
         # Public read-only attribute so callers (e.g. the mtime-guarded
         # plan cache in mcp_infra) can stat the underlying file without
         # peeking through ``self.conn`` internals (nexus-qgjr).

--- a/src/nexus/db/t2/telemetry.py
+++ b/src/nexus/db/t2/telemetry.py
@@ -55,6 +55,8 @@ from typing import Any
 
 import structlog
 
+from nexus.db.t2._tuning import SERVING_BUSY_TIMEOUT_MS
+
 _log = structlog.get_logger()
 
 
@@ -126,7 +128,7 @@ class Telemetry:
     def __init__(self, path: Path) -> None:
         self._lock = threading.Lock()
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
-        self.conn.execute("PRAGMA busy_timeout=5000")
+        self.conn.execute(f"PRAGMA busy_timeout={SERVING_BUSY_TIMEOUT_MS}")
         self._init_schema()
 
     def close(self) -> None:

--- a/tests/daemon/test_t2_daemon_lifecycle.py
+++ b/tests/daemon/test_t2_daemon_lifecycle.py
@@ -342,3 +342,88 @@ class TestPublicSurface:
         from nexus.daemon.t2_daemon import ProtocolError
 
         assert issubclass(ProtocolError, Exception)
+
+
+# ---------------------------------------------------------------------------
+# RDR-129 B2 (nexus-qi1zb): serving-dispatch lock retry
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchLockRetry:
+    """The serving ``_dispatch`` retries on transient WAL writer-lock
+    contention so a window past the per-store busy_timeout becomes a wait, not
+    a dropped best-effort write. Non-lock errors are not retried; the final
+    attempt re-raises so a genuinely stuck lock still surfaces.
+    """
+
+    @staticmethod
+    def _daemon(config_dir: Path, db_path: Path):
+        from nexus.daemon.t2_daemon import T2Daemon
+
+        return T2Daemon(config_dir=config_dir, db_path=db_path)
+
+    @staticmethod
+    def _frame(op: str = "probe") -> dict:
+        return {"op": op, "args": [], "kwargs": {}}
+
+    def test_retries_then_succeeds(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        import sqlite3
+
+        from nexus.daemon import t2_daemon as td
+
+        monkeypatch.setattr(td, "_DISPATCH_RETRY_SLEEPS", (0.0, 0.0))
+        calls = {"n": 0}
+
+        def flaky(*_a, **_k):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise sqlite3.OperationalError("database is locked")
+            return "ok"
+
+        d = self._daemon(config_dir, db_path)
+        d._dispatch_table = {"probe": flaky}
+        result = asyncio.run(d._dispatch(self._frame(), is_uds=True))
+        assert result == "ok"
+        assert calls["n"] == 3  # two retries then success
+
+    def test_exhausts_retries_then_raises(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        import sqlite3
+
+        from nexus.daemon import t2_daemon as td
+
+        monkeypatch.setattr(td, "_DISPATCH_RETRY_SLEEPS", (0.0, 0.0))
+        calls = {"n": 0}
+
+        def always_locked(*_a, **_k):
+            calls["n"] += 1
+            raise sqlite3.OperationalError("database is locked")
+
+        d = self._daemon(config_dir, db_path)
+        d._dispatch_table = {"probe": always_locked}
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            asyncio.run(d._dispatch(self._frame(), is_uds=True))
+        assert calls["n"] == 3  # len(_DISPATCH_RETRY_SLEEPS) + 1
+
+    def test_non_lock_error_not_retried(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        import sqlite3
+
+        from nexus.daemon import t2_daemon as td
+
+        monkeypatch.setattr(td, "_DISPATCH_RETRY_SLEEPS", (0.0, 0.0))
+        calls = {"n": 0}
+
+        def bad_schema(*_a, **_k):
+            calls["n"] += 1
+            raise sqlite3.OperationalError("no such table: foo")
+
+        d = self._daemon(config_dir, db_path)
+        d._dispatch_table = {"probe": bad_schema}
+        with pytest.raises(sqlite3.OperationalError, match="no such table"):
+            asyncio.run(d._dispatch(self._frame(), is_uds=True))
+        assert calls["n"] == 1  # structural error surfaces on the first attempt

--- a/tests/test_t2_concurrency.py
+++ b/tests/test_t2_concurrency.py
@@ -536,3 +536,46 @@ def test_memory_search_under_concurrent_write_load(tmp_path: Path) -> None:
         f"baseline_p95={baseline_p95:.2f}ms load_p95={load_p95:.2f}ms "
         f"ratio={ratio:.2f}x (threshold 3.0x)"
     )
+
+
+# ── RDR-129 B1 (nexus-qi1zb): serving busy_timeout raised 5000 -> 30000 ──────
+
+
+import pytest as _pytest
+
+
+def test_serving_busy_timeout_constant_matches_bootstrap() -> None:
+    """The shared serving timeout is 30s and equals the bootstrap-migration
+    window (RDR-129 B1 'matching the bootstrap path')."""
+    from nexus.db.t2 import _BOOTSTRAP_BUSY_TIMEOUT_MS
+    from nexus.db.t2._tuning import SERVING_BUSY_TIMEOUT_MS
+
+    assert SERVING_BUSY_TIMEOUT_MS == 30000
+    assert SERVING_BUSY_TIMEOUT_MS == _BOOTSTRAP_BUSY_TIMEOUT_MS
+
+
+@_pytest.mark.parametrize(
+    "store_attr,conn_attr",
+    [
+        ("memory", "conn"),
+        ("plans", "conn"),
+        ("chash_index", "conn"),
+        ("taxonomy", "conn"),
+        ("telemetry", "conn"),
+        ("document_aspects", "conn"),
+        ("catalog", "_conn"),
+    ],
+)
+def test_every_serving_store_connection_uses_30s_busy_timeout(
+    tmp_path: Path, store_attr: str, conn_attr: str,
+) -> None:
+    """Each daemon-owned domain-store connection applies the 30s serving
+    busy_timeout. A partial bump would leave some stores at 5s and re-open the
+    cross-store contention drop class, so every store is pinned."""
+    from nexus.db.t2._tuning import SERVING_BUSY_TIMEOUT_MS
+
+    with T2Database(tmp_path / "memory.db") as db:
+        store = getattr(db, store_attr)
+        conn = getattr(store, conn_attr)
+        got = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        assert got == SERVING_BUSY_TIMEOUT_MS == 30000


### PR DESCRIPTION
## What

RDR-129 Layer B, bead `nexus-qi1zb` (B1+B2 bundled): make the one daemon internally tolerant of cross-store WAL contention. RDR-063 gives each domain store its own connection + lock; cross-store writes coordinate only via SQLite's file lock + `busy_timeout`, and two shakeouts showed the 5s serving timeout was too short, dropping best-effort chash writes (`t2_daemon_dispatch_failed op='chash_index.upsert_many'`).

### B1 — raise the serving busy_timeout (5000 → 30000)
All eight daemon-owned domain-store connections now wait 30s, matching the bootstrap-migration window. A new leaf module `nexus.db.t2._tuning.SERVING_BUSY_TIMEOUT_MS` is the single source of truth, imported by every store (`memory_store`, `plan_library`, `telemetry`, `chash_index`, `catalog_taxonomy`, `document_aspects`, `catalog`) plus the `T2Database` facade. A partial bump would leave some stores at 5s and re-open the drop class, so all are pinned to one constant. `memory_store` keeps its intentional `_ACCESS_TRACK_BUSY_MS=0` fail-fast for the best-effort access-count update.

**B1 prerequisite verified** (RF-B1(a)): `t2_client._connect_tcp` sets the 5s timeout for the *connect* only, then `sock.settimeout(None)`, so per-call reads block indefinitely. A 30s daemon-side wait therefore surfaces as the real `database is locked`, not an RPC timeout of a different type.

### B2 — bounded lock-retry on the serving dispatch
`_dispatch` now retries on `database is locked`/`busy` (three attempts, two async backoff sleeps), mirroring the bootstrap-migration retry. A contention window past the busy_timeout becomes a wait, not a drop. Non-lock (structural) errors propagate on the first attempt; the final attempt re-raises so a genuinely stuck lock still surfaces. Re-running the op is safe — `SQLITE_BUSY` fires at lock acquisition before the statement executes, and store writes are upserts / single transactions that roll back cleanly.

## On the deterministic multi-writer load test (RDR Test Plan #4) and B3
The B1+B2 *mechanism* is covered deterministically here (busy_timeout value applied per store; dispatch retry/exhaust/non-lock behaviour). The "N concurrent routed writers → zero unrecovered drops" *load/soak* form is intentionally not a one-shot CI test (it is the nexus-9eaz flake class this daemon suite avoids); its production instrument is the B4 drop meter (`nx doctor` "T2 best-effort writes", shipped in #982), which makes unrecovered drops observable in the real multi-writer environment. The **B3** decision (`nexus-izpcb`, daemon-internal write serialization, which trades away RDR-063 cross-store parallelism) will be settled at the phase-review gate on that basis — it is built only if the meter shows residual unrecovered drops post-P2. This disposition is surfaced explicitly at the phase gate, not silently dropped.

## Tests
- `test_serving_busy_timeout_constant_matches_bootstrap`: the constant is 30000 and equals `_BOOTSTRAP_BUSY_TIMEOUT_MS`.
- `test_every_serving_store_connection_uses_30s_busy_timeout` (7 stores): each connection reports `busy_timeout=30000`.
- `TestDispatchLockRetry`: retries-then-succeeds, exhausts-then-raises, non-lock-error-not-retried.
- T2 + daemon regression: 329 passed.

Closes nexus-qi1zb