### PR TITLE
fix(aspect): route worker persist through T2 daemon (nexus-zir76)

### DIFF
--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -158,7 +158,7 @@ class AspectExtractionWorker:
         self,
         *,
         poll_interval: float = 2.0,
-        stale_timeout_seconds: int = 300,
+        stale_timeout_seconds: int = 60,
         batch_size: int = _DEFAULT_BATCH_SIZE,
     ) -> None:
         self._poll_interval = poll_interval
@@ -272,10 +272,12 @@ class AspectExtractionWorker:
                 # contending on its single WAL writer lock. This is the
                 # every-2s contention behind the recurring
                 # `aspect_worker_claim_failed` / `database is locked`
-                # incidents (memory: daemon-restart-not-worker-fix). The
-                # work-bounded persist below stays direct (t2_ctx) because
-                # document_aspects.upsert takes an AspectRecord the daemon
-                # wire protocol cannot round-trip.
+                # incidents (memory: daemon-restart-not-worker-fix).
+                # nexus-zir76: the persist path (_process_row /
+                # _process_batch) now routes too, via the daemon-side
+                # `complete_aspect` method (AspectRecord travels as an
+                # asdict() field dict). The worker no longer opens
+                # memory.db on ANY path.
                 def _poll(t2):
                     if do_reclaim:
                         t2.aspect_queue.reclaim_stale(
@@ -316,8 +318,10 @@ class AspectExtractionWorker:
         P5.1 / nexus-8g79.34 — the batch path now mirrors the
         single-doc extractor's read contract).
         """
+        import dataclasses
+
         from nexus.aspect_extractor import select_config
-        from nexus.mcp_infra import t2_ctx
+        from nexus.mcp_infra import t2_index_write
 
         # extract_aspects_batch requires every input to share a single
         # ExtractorConfig. claim_batch grabs FIFO across collections, so
@@ -360,13 +364,14 @@ class AspectExtractionWorker:
                 row_count=len(rows),
                 exc_info=True,
             )
+            # nexus-zir76: route through the daemon, never direct memory.db.
+            def _fail_all(db):  # noqa: ANN001
+                for row in rows:
+                    db.aspect_queue.mark_failed(
+                        row.collection, row.source_path, error=str(exc),
+                    )
             try:
-                with t2_ctx() as t2:
-                    for row in rows:
-                        t2.aspect_queue.mark_failed(
-                            row.collection, row.source_path,
-                            error=str(exc),
-                        )
+                t2_index_write(_fail_all)
             except Exception:
                 _log.warning(
                     "aspect_worker_batch_mark_failed_persist_failed",
@@ -374,45 +379,78 @@ class AspectExtractionWorker:
                 )
             return
 
-        try:
-            with t2_ctx() as t2:
-                for row, record in zip(rows, records):
-                    if record is None:
-                        # Unsupported collection — drop silently.
-                        t2.aspect_queue.mark_done(
-                            row.collection, row.source_path,
-                        )
-                        continue
-                    # nexus-8g79.34: ExtractFail per-row — typed read-
-                    # failure sentinel from URI-based reading. Mark
-                    # queue done so we don't retry an unreadable
-                    # source on every drain; operators re-enqueue
-                    # manually after fixing source identity (mirrors
-                    # _process_row's handling).
-                    if isinstance(record, ExtractFail):
-                        _log.info(
-                            "aspect_worker_batch_extract_skip",
-                            uri=record.uri,
-                            reason=record.reason,
-                            detail=record.detail,
-                        )
-                        t2.aspect_queue.mark_done(
-                            row.collection, row.source_path,
-                        )
-                        continue
-                    t2.document_aspects.upsert(record)
-                    t2.aspect_queue.mark_done(
+        # nexus-zir76: one routed write_fn does the whole batch's persist;
+        # each row clears via the daemon (``complete_aspect`` /
+        # ``mark_done``) instead of a direct memory.db transaction.
+        def _persist_all(db):  # noqa: ANN001
+            for row, record in zip(rows, records):
+                if record is None:
+                    # Unsupported collection — drop silently.
+                    db.aspect_queue.mark_done(
                         row.collection, row.source_path,
                     )
+                    continue
+                # nexus-8g79.34: ExtractFail per-row — typed read-failure
+                # sentinel from URI-based reading. Mark queue done so we
+                # don't retry an unreadable source on every drain;
+                # operators re-enqueue manually after fixing source
+                # identity (mirrors _process_row's handling).
+                if isinstance(record, ExtractFail):
+                    _log.info(
+                        "aspect_worker_batch_extract_skip",
+                        uri=record.uri,
+                        reason=record.reason,
+                        detail=record.detail,
+                    )
+                    db.aspect_queue.mark_done(
+                        row.collection, row.source_path,
+                    )
+                    continue
+                db.complete_aspect(dataclasses.asdict(record))
+        try:
+            t2_index_write(_persist_all)
         except Exception:
             _log.warning(
                 "aspect_worker_batch_persist_failed",
                 exc_info=True,
             )
 
+    def _mark_failed_routed(self, row, error: str) -> None:
+        """Route a queue ``mark_failed`` through the daemon (nexus-zir76).
+
+        The failure path must not open ``memory.db`` directly either: a
+        direct ``mark_failed`` losing the WAL writer race is exactly what
+        orphaned rows ``in_progress`` until the reclaim backstop. If even
+        the routed write raises (daemon down AND the direct fallback
+        contended), ``reclaim_stale`` recovers the row; we log and move on
+        without killing the worker thread.
+        """
+        from nexus.mcp_infra import t2_index_write
+        try:
+            t2_index_write(
+                lambda db: db.aspect_queue.mark_failed(
+                    row.collection, row.source_path, error=error,
+                )
+            )
+        except Exception:
+            _log.warning(
+                "aspect_worker_mark_failed_persist_failed",
+                collection=row.collection,
+                source_path=row.source_path,
+                exc_info=True,
+            )
+
     def _process_row(self, row) -> None:
-        """Run extraction on one queue row and dispatch on the result."""
-        from nexus.mcp_infra import t2_ctx
+        """Run extraction on one queue row and dispatch on the result.
+
+        nexus-zir76: every persist routes through ``t2_index_write`` (the
+        daemon when reachable, a direct fallback when not) so the worker
+        never opens ``memory.db`` directly and cannot contend with the
+        daemon for the single WAL writer lock.
+        """
+        import dataclasses
+
+        from nexus.mcp_infra import t2_index_write
         try:
             # Content was captured at enqueue time when in scope (MCP
             # store_put). For CLI rows where content was not in scope
@@ -451,52 +489,46 @@ class AspectExtractionWorker:
                 source_path=row.source_path,
                 exc_info=True,
             )
-            try:
-                with t2_ctx() as t2:
-                    t2.aspect_queue.mark_failed(
-                        row.collection, row.source_path,
-                        error=str(exc),
-                    )
-            except Exception:
-                _log.warning(
-                    "aspect_worker_mark_failed_persist_failed",
-                    exc_info=True,
-                )
+            self._mark_failed_routed(row, str(exc))
             return
 
         try:
-            with t2_ctx() as t2:
-                if record is None:
-                    # Unsupported collection — drop silently.
-                    t2.aspect_queue.mark_done(
+            if record is None:
+                # Unsupported collection — drop silently.
+                t2_index_write(
+                    lambda db: db.aspect_queue.mark_done(
                         row.collection, row.source_path,
                     )
-                    return
-                # RDR-096 P1.2: ExtractFail is the typed read-failure
-                # sentinel. No row written; mark queue done so we
-                # don't retry the unreadable source on every drain.
-                # Operators can re-enqueue manually after fixing the
-                # source identity.
-                if isinstance(record, ExtractFail):
-                    _log.info(
-                        "aspect_worker_extract_skip",
-                        uri=record.uri,
-                        reason=record.reason,
-                        detail=record.detail,
-                    )
-                    t2.aspect_queue.mark_done(
-                        row.collection, row.source_path,
-                    )
-                    return
-                # AspectRecord — either a populated record or a null-
-                # fields record from a subprocess-side failure (the
-                # extractor already retried up to 3 attempts
-                # internally for those paths). Persist and remove
-                # from the queue.
-                t2.document_aspects.upsert(record)
-                t2.aspect_queue.mark_done(
-                    row.collection, row.source_path,
                 )
+                return
+            # RDR-096 P1.2: ExtractFail is the typed read-failure
+            # sentinel. No row written; mark queue done so we
+            # don't retry the unreadable source on every drain.
+            # Operators can re-enqueue manually after fixing the
+            # source identity.
+            if isinstance(record, ExtractFail):
+                _log.info(
+                    "aspect_worker_extract_skip",
+                    uri=record.uri,
+                    reason=record.reason,
+                    detail=record.detail,
+                )
+                t2_index_write(
+                    lambda db: db.aspect_queue.mark_done(
+                        row.collection, row.source_path,
+                    )
+                )
+                return
+            # AspectRecord — either a populated record or a null-fields
+            # record from a subprocess-side failure (the extractor
+            # already retried up to 3 attempts internally for those
+            # paths). nexus-zir76: persist + clear the queue row in one
+            # daemon-routed call (``complete_aspect``) so the worker
+            # never writes memory.db directly. asdict() because the wire
+            # protocol decodes a dataclass arg to its field dict.
+            t2_index_write(
+                lambda db: db.complete_aspect(dataclasses.asdict(record))
+            )
         except Exception as exc:
             _log.warning(
                 "aspect_worker_persist_failed",
@@ -504,17 +536,7 @@ class AspectExtractionWorker:
                 source_path=row.source_path,
                 exc_info=True,
             )
-            try:
-                with t2_ctx() as t2:
-                    t2.aspect_queue.mark_failed(
-                        row.collection, row.source_path,
-                        error=str(exc),
-                    )
-            except Exception:
-                _log.warning(
-                    "aspect_worker_mark_failed_secondary_persist_failed",
-                    exc_info=True,
-                )
+            self._mark_failed_routed(row, str(exc))
 
 
 # ── Module-level singleton ──────────────────────────────────────────────────
@@ -545,18 +567,56 @@ def _worker_lock_path(locks_dir: Path | None = None) -> Path:
     return base / f"aspect_worker.{os.getpid()}"
 
 
+def _sweep_dead_worker_locks(locks_dir: Path) -> None:
+    """Remove ``aspect_worker.<pid>`` lock files whose PID is dead.
+
+    nexus-zir76: ``_remove_worker_lock`` only runs on a clean
+    ``stop_worker``; a ``-9`` or a crash leaks the file. Over many
+    sessions these accumulate unbounded (85 found in the wild on
+    2026-05-27). Sweeping dead-PID locks at worker startup bounds the
+    pileup. Live locks (including this process's own) are left intact;
+    non-PID-shaped files are ignored. Best-effort — never raises.
+    """
+    import os
+
+    if not locks_dir.exists():
+        return
+    own_pid = os.getpid()
+    for lock_file in locks_dir.glob("aspect_worker.*"):
+        try:
+            pid = int(lock_file.name.rsplit(".", 1)[-1])
+        except ValueError:
+            continue  # not a PID-suffixed lock file
+        if pid == own_pid:
+            continue
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            try:
+                lock_file.unlink(missing_ok=True)
+                _log.info("aspect_worker_stale_lock_swept", pid=pid)
+            except Exception:
+                pass
+        except PermissionError:
+            # Alive under another user — leave it.
+            continue
+
+
 def _write_worker_lock(locks_dir: Path | None = None) -> None:
     """Write a process-scoped lock file advertising this worker.
 
-    Non-fatal if the locks directory cannot be created or the file cannot
-    be written — the lock is advisory; a missing file merely means
-    ``drain_worker`` from another process will not detect this worker.
+    Sweeps dead-PID lock files first (nexus-zir76) so leaked locks from
+    crashed/killed predecessors do not accumulate. Non-fatal if the locks
+    directory cannot be created or the file cannot be written — the lock
+    is advisory; a missing file merely means ``drain_worker`` from another
+    process will not detect this worker.
     """
     import os
 
     try:
         lock = _worker_lock_path(locks_dir)
         lock.parent.mkdir(parents=True, exist_ok=True)
+        _sweep_dead_worker_locks(lock.parent)
         lock.write_text(str(os.getpid()))
     except Exception:
         _log.warning("aspect_worker_lock_write_failed", exc_info=True)
@@ -576,7 +636,7 @@ def _remove_worker_lock(locks_dir: Path | None = None) -> None:
 def ensure_worker_started(
     *,
     poll_interval: float = 2.0,
-    stale_timeout_seconds: int = 300,
+    stale_timeout_seconds: int = 60,
     _locks_dir: Path | None = None,
 ) -> AspectExtractionWorker:
     """Lazy-start the singleton worker. Returns the worker.

--- a/src/nexus/daemon/t2_client.py
+++ b/src/nexus/daemon/t2_client.py
@@ -285,6 +285,12 @@ class T2Client:
     def rename_collection_cascade(self, *args: Any, **kwargs: Any) -> Any:
         return self.database.rename_collection_cascade(*args, **kwargs)
 
+    def complete_aspect(self, *args: Any, **kwargs: Any) -> Any:
+        # nexus-zir76: aspect-worker persist (document_aspects.upsert +
+        # aspect_queue.mark_done) folded into one daemon-routable call so
+        # the worker stays off the direct memory.db write path.
+        return self.database.complete_aspect(*args, **kwargs)
+
     def put(self, *args: Any, **kwargs: Any) -> Any:
         # T2Database.put is a thin facade over memory.put; mirror it so a
         # write_fn (or a helper handed the writer, e.g. T1Database.promote)

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -433,6 +433,7 @@ _T2_STORE_ATTRS: tuple[str, ...] = (
 _T2_DATABASE_METHODS: tuple[str, ...] = (
     "rename_collection_cascade",
     "expire",
+    "complete_aspect",
     "hello",
 )
 

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -961,3 +961,31 @@ class T2Database:
             **extra,
         )
         return len(expired_ids)
+
+    def complete_aspect(self, record_fields: dict[str, Any]) -> bool:
+        """Persist an extracted aspect and clear its queue row in one call.
+
+        nexus-zir76 (RDR-128 follow-up): the aspect worker previously
+        upserted ``document_aspects`` and called ``aspect_queue.mark_done``
+        via two DIRECT ``memory.db`` writes, competing with the daemon for
+        the single WAL writer lock. When the direct ``mark_done`` (or the
+        failure path's ``mark_failed``) lost that race, the row was
+        orphaned ``in_progress`` until the ``reclaim_stale`` backstop.
+        Folding both writes into one daemon-routable method keeps the
+        worker off the direct write path and closes that window.
+
+        *record_fields* is ``dataclasses.asdict(AspectRecord)`` — a plain
+        JSON-shaped dict, because the daemon wire protocol decodes a
+        dataclass argument to its field dict (it does not reconstruct the
+        object). The ``AspectRecord`` is rebuilt here, server-side.
+
+        Returns the ``document_aspects.upsert`` result. ``mark_done`` is
+        idempotent, so a reclaim-driven re-extraction after a crash
+        between the two writes simply re-upserts — no duplicate, no stuck
+        row.
+        """
+        from nexus.db.t2.document_aspects import AspectRecord
+        record = AspectRecord(**record_fields)
+        upserted = self.document_aspects.upsert(record)
+        self.aspect_queue.mark_done(record.collection, record.source_path)
+        return upserted

--- a/tests/test_nexus_zir76_aspect_persist_daemon.py
+++ b/tests/test_nexus_zir76_aspect_persist_daemon.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-zir76: route the aspect-worker persist path through the T2 daemon.
+
+RDR-128 routed the worker's poll/claim/reclaim through the T2 daemon but
+left the *persist* path (``document_aspects.upsert`` +
+``aspect_queue.mark_done`` / ``mark_failed``) on the DIRECT ``memory.db``
+write path. That direct write competed with the daemon for the single
+WAL writer lock (``database is locked``), and a failed direct
+``mark_failed`` orphaned the row ``in_progress`` until the 300s
+``reclaim_stale`` backstop. Diagnosed 2026-05-27 (a row stuck
+``in_progress`` for ~5 minutes during DEVONthink PDF incorporation).
+
+These tests pin the fix:
+
+1. ``T2Database.complete_aspect`` upserts the record AND marks the queue
+   row done in one daemon-side call.
+2. ``complete_aspect`` is daemon-routable (``database.complete_aspect``)
+   and ``T2Client`` carries the facade-parity passthrough so a
+   ``t2_index_write(write_fn)`` body reaches it on either path.
+3. ``_process_row`` persists via ``t2_index_write`` (routed), never via
+   the direct ``t2_ctx`` path — success AND failure.
+4. Dead ``aspect_worker.<pid>`` lock files are swept at worker startup.
+5. The stuck-row reclaim backstop default dropped 300s -> 60s.
+"""
+from __future__ import annotations
+
+import dataclasses
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from nexus.db.t2 import T2Database
+from nexus.db.t2.aspect_extraction_queue import QueueRow
+from nexus.db.t2.document_aspects import AspectRecord
+
+
+def _record(collection: str, source_path: str) -> AspectRecord:
+    return AspectRecord(
+        collection=collection,
+        source_path=source_path,
+        problem_formulation="P",
+        proposed_method="M",
+        experimental_datasets=["d1"],
+        experimental_baselines=["b1"],
+        experimental_results="R",
+        extras={"venue": "V"},
+        confidence=0.9,
+        extracted_at="2026-05-27T00:00:00+00:00",
+        model_version="claude-haiku-4-5-20251001",
+        extractor_name="scholarly-paper-v1",
+        doc_id="1.2.3",
+    )
+
+
+# ── 1. complete_aspect: atomic upsert + mark_done ────────────────────────────
+
+
+def test_complete_aspect_upserts_and_marks_done(tmp_path: Path) -> None:
+    db_path = tmp_path / "t2.db"
+    coll, src = "knowledge__delos", "/p1.pdf"
+    with T2Database(db_path) as db:
+        db.aspect_queue.enqueue(coll, src)
+        assert db.aspect_queue.pending_count() == 1
+
+        ok = db.complete_aspect(dataclasses.asdict(_record(coll, src)))
+
+        assert ok is True
+        rec = db.document_aspects.get(coll, src)
+        assert rec is not None
+        assert rec.problem_formulation == "P"
+        assert rec.proposed_method == "M"
+        # mark_done DELETEs the queue row — nothing left to drain.
+        assert db.aspect_queue.conn.execute(
+            "SELECT COUNT(*) FROM aspect_extraction_queue"
+        ).fetchone()[0] == 0
+
+
+def test_complete_aspect_accepts_plain_dict_from_wire(tmp_path: Path) -> None:
+    """The worker sends ``dataclasses.asdict(record)``; the daemon wire
+    decodes a dataclass to a plain dict. ``complete_aspect`` must
+    reconstruct the ``AspectRecord`` from that dict, not require an object.
+    """
+    db_path = tmp_path / "t2.db"
+    coll, src = "knowledge__delos", "/wire.pdf"
+    fields = dataclasses.asdict(_record(coll, src))
+    assert isinstance(fields, dict) and not isinstance(fields, AspectRecord)
+    with T2Database(db_path) as db:
+        db.aspect_queue.enqueue(coll, src)
+        db.complete_aspect(fields)
+        assert db.document_aspects.get(coll, src) is not None
+
+
+# ── 2. Daemon routability + client parity ────────────────────────────────────
+
+
+def test_complete_aspect_is_daemon_routable(tmp_path: Path) -> None:
+    from nexus.daemon.t2_daemon import (
+        _T2_DATABASE_METHODS,
+        _build_dispatch_table,
+    )
+
+    assert "complete_aspect" in _T2_DATABASE_METHODS
+    with T2Database(tmp_path / "t2.db") as db:
+        table = _build_dispatch_table(db)
+    assert "database.complete_aspect" in table
+
+
+def test_t2client_exposes_complete_aspect_passthrough() -> None:
+    """``t2_index_write`` may hand the write_fn a ``T2Client``; it must
+    expose ``complete_aspect`` at the top level (delegating to
+    ``database.complete_aspect``) so the call works on either path.
+    """
+    from nexus.daemon.t2_client import T2Client
+
+    client = T2Client(skip_handshake=True)
+    forwarded: dict[str, object] = {}
+
+    class _FakeDatabaseProxy:
+        def complete_aspect(self, *args, **kwargs):
+            forwarded["args"] = args
+            forwarded["kwargs"] = kwargs
+            return True
+
+    client.database = _FakeDatabaseProxy()  # type: ignore[assignment]
+    payload = {"collection": "c", "source_path": "s"}
+    assert client.complete_aspect(payload) is True
+    assert forwarded["args"] == (payload,)
+
+
+# ── 3. _process_row routes persist through t2_index_write, not t2_ctx ─────────
+
+
+def _patch_persist_routing(monkeypatch, db_path: Path) -> list[int]:
+    """Route ``t2_index_write`` to a direct tmp DB and make ``t2_ctx``
+    fail loudly if the persist path ever opens memory.db directly.
+
+    Returns a call-count list for ``t2_index_write``.
+    """
+    import nexus.mcp_infra as infra
+
+    calls: list[int] = []
+
+    def _routed(write_fn):  # noqa: ANN001
+        calls.append(1)
+        with T2Database(db_path) as db:
+            return write_fn(db)
+
+    def _forbidden_ctx():
+        raise AssertionError(
+            "persist must route through t2_index_write, not direct t2_ctx"
+        )
+
+    monkeypatch.setattr(infra, "t2_index_write", _routed)
+    monkeypatch.setattr(infra, "t2_ctx", _forbidden_ctx)
+    return calls
+
+
+def test_process_row_success_persists_via_index_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nexus.aspect_worker import AspectExtractionWorker
+
+    db_path = tmp_path / "t2.db"
+    coll, src = "knowledge__delos", "/ok.pdf"
+    with T2Database(db_path) as db:
+        db.aspect_queue.enqueue(coll, src)
+
+    calls = _patch_persist_routing(monkeypatch, db_path)
+    monkeypatch.setattr(
+        "nexus.aspect_worker._extract_aspects",
+        lambda **_kw: _record(coll, src),
+    )
+
+    row = QueueRow(collection=coll, source_path=src, content_hash="h",
+                   content="", retry_count=0, doc_id="1.2.3")
+    AspectExtractionWorker()._process_row(row)
+
+    assert calls, "persist did not route through t2_index_write"
+    with T2Database(db_path) as db:
+        assert db.document_aspects.get(coll, src) is not None
+        assert db.aspect_queue.conn.execute(
+            "SELECT COUNT(*) FROM aspect_extraction_queue"
+        ).fetchone()[0] == 0
+
+
+def test_process_row_failure_marks_failed_via_index_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nexus.aspect_worker import AspectExtractionWorker
+
+    db_path = tmp_path / "t2.db"
+    coll, src = "knowledge__delos", "/boom.pdf"
+    with T2Database(db_path) as db:
+        db.aspect_queue.enqueue(coll, src)
+
+    calls = _patch_persist_routing(monkeypatch, db_path)
+
+    def _raise(**_kw):
+        raise RuntimeError("extract boom")
+
+    monkeypatch.setattr("nexus.aspect_worker._extract_aspects", _raise)
+
+    row = QueueRow(collection=coll, source_path=src, content_hash="h",
+                   content="", retry_count=0, doc_id="")
+    AspectExtractionWorker()._process_row(row)
+
+    assert calls, "failure path did not route through t2_index_write"
+    with T2Database(db_path) as db:
+        status = db.aspect_queue.conn.execute(
+            "SELECT status FROM aspect_extraction_queue "
+            "WHERE collection = ? AND source_path = ?",
+            (coll, src),
+        ).fetchone()
+    assert status is not None and status[0] == "failed"
+
+
+# ── 4. Startup sweep of dead lock files ──────────────────────────────────────
+
+
+def test_write_worker_lock_sweeps_dead_pid_locks(tmp_path: Path) -> None:
+    import os
+
+    from nexus.aspect_worker import _write_worker_lock
+
+    locks_dir = tmp_path / "locks"
+    locks_dir.mkdir()
+
+    # A guaranteed-dead PID: spawn a trivial child and reap it.
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    dead_pid = proc.pid
+    (locks_dir / f"aspect_worker.{dead_pid}").write_text(str(dead_pid))
+    # A non-PID-shaped file must be left untouched.
+    (locks_dir / "aspect_worker.notapid").write_text("x")
+
+    _write_worker_lock(locks_dir)
+
+    assert not (locks_dir / f"aspect_worker.{dead_pid}").exists()
+    # This process is alive, so its own lock was written and kept.
+    assert (locks_dir / f"aspect_worker.{os.getpid()}").exists()
+    assert (locks_dir / "aspect_worker.notapid").exists()
+
+
+# ── 5. Faster reclaim backstop ───────────────────────────────────────────────
+
+
+def test_reclaim_backstop_default_is_60s() -> None:
+    import inspect
+
+    from nexus.aspect_worker import (
+        AspectExtractionWorker,
+        ensure_worker_started,
+    )
+
+    assert AspectExtractionWorker()._stale_timeout_seconds == 60
+    sig = inspect.signature(ensure_worker_started)
+    assert sig.parameters["stale_timeout_seconds"].default == 60


### PR DESCRIPTION
## Problem

Diagnosed 2026-05-27 while incorporating DEVONthink PDFs: an aspect-extraction queue row sat `in_progress` for ~5 minutes before draining. Root cause is a residual hole in RDR-128's single-writer invariant.

RDR-128 routed the aspect worker's **poll/claim/reclaim** through the T2 daemon so the worker stops opening `memory.db` directly. But the **persist** path (`document_aspects.upsert` + `aspect_queue.mark_done`/`mark_failed`) stayed as direct `t2_ctx()` writes, because the wire protocol decodes a dataclass arg to a plain dict and `document_aspects.upsert` wants an `AspectRecord`. Consequences:

- The worker process competes with the daemon for `memory.db`'s single WAL writer lock → `database is locked`.
- When the direct persist loses the race, the failure handler calls `mark_failed` — *also* a direct write — which can hit the same lock, logging `aspect_worker_mark_failed_persist_failed` and leaving the row stuck `in_progress` until the 300s `reclaim_stale` backstop. That's the ~5-min stall.

## Fix

- **`T2Database.complete_aspect(record_fields)`**: reconstruct the `AspectRecord` and do `upsert` + `mark_done` in one daemon-side call. Closes both the upsert↔mark window and the double-fault orphan path. `record_fields` is `dataclasses.asdict(record)` (round-trips the wire cleanly).
- **Route it**: add `complete_aspect` to `_T2_DATABASE_METHODS` and a `T2Client` facade-parity passthrough (mirrors `expire`/`rename_collection_cascade`), so a `t2_index_write` body reaches it on either the daemon or the direct fallback.
- **`_process_row` + `_process_batch`** now persist via `t2_index_write` only — the worker never opens `memory.db` directly on any path (success, unsupported-collection, ExtractFail, or failure).
- **Startup lock GC**: sweep dead `aspect_worker.<pid>` lock files when the worker writes its own (`_remove_worker_lock` only ran on clean `stop_worker`; 85 leaked locks were found in the wild).
- **Faster backstop**: stuck-row reclaim default `300s → 60s`.

**Deliberately not touched:** the daemon "churn" is `ensure-running` cycling on *version skew* only — working as designed, and RDR-129 already hardened the collision/reap path. Touching it is pure regression risk.

This completes RDR-128's accepted design (no new RDR; bug-completion).

## Tests

New `tests/test_nexus_zir76_aspect_persist_daemon.py` (8 tests): `complete_aspect` atomicity, daemon routability + client parity, `_process_row` success/failure routing via `t2_index_write` (asserts the direct `t2_ctx` path is never taken), startup dead-lock sweep, and the 60s backstop default.

Verified green: new suite + `test_aspect_worker`, `test_aspect_drain_protocol`, `test_rdr128_p1_index_write_routing`, `test_rdr128_p3_enablers`, `test_document_aspects_store`, `tests/daemon/`, `test_hooks`, `test_enrich_aspects*`, `test_aspect_extraction_queue`, `test_storage_boundary_lint` (357 tests).

## Closes
Closes #nexus-zir76