### PR TITLE
fix(hook): T2 injection stdlib + Knowledge Map dedup (nexus-vg6d4 + nexus-9iw41)

### DIFF
--- a/conexus/hooks/scripts/t2_prefix_scan.py
+++ b/conexus/hooks/scripts/t2_prefix_scan.py
@@ -8,6 +8,21 @@ Queries T2 for every namespace whose name starts with *project_name*
 (e.g. "nexus", "nexus_rdr", "nexus_knowledge") and prints a compact summary
 formatted for session injection.
 
+**Stdlib-only** (nexus-vg6d4): this script must run under whatever bare
+Python interpreter ``_run_python_hook.sh`` resolves (probes
+``python3.13`` → ``python3.12`` → ``python3``), which on a
+``uv tool install conexus`` deployment is the system Python that
+cannot import the ``nexus`` package (it lives in conexus's own venv).
+Importing ``nexus.db.t2`` would silently fail and the entire
+``## T2 Memory (Active Project)`` section would be omitted from the
+session-start context. Using ``sqlite3`` directly keeps the hook
+portable across the wrapper's interpreter probe.
+
+The SQL mirrors ``MemoryStore.get_projects_with_prefix`` and
+``MemoryStore.get_all`` verbatim (including the ``ESCAPE '\\'`` clause
+that prevents ``LIKE`` metacharacters in the prefix from matching
+unintended namespaces).
+
 Cap algorithm:
   Per namespace (entries ranked by recency within that namespace):
     entries 1–5   : title + 1-line snippet (≤120 chars)
@@ -18,7 +33,11 @@ Cap algorithm:
 """
 from __future__ import annotations
 
+import os
+import sqlite3
 import sys
+from pathlib import Path
+
 if sys.version_info < (3, 12):
     sys.stderr.write(
         f"ERROR: conexus plugin hook requires Python 3.12+, got {sys.version.split()[0]}\n"
@@ -32,6 +51,24 @@ _SNIPPET_LIMIT = 5   # per-namespace: entries up to this rank get a snippet
 _TITLE_LIMIT = 8     # per-namespace: entries up to this rank get title-only
 
 
+def _default_db_path() -> Path:
+    """Stdlib-only mirror of ``nexus.config.default_db_path``.
+
+    Honours ``NEXUS_CONFIG_DIR`` / ``NX_CONFIG_DIR`` env overrides for
+    parity with the test sandbox and the release-sandbox harness, then
+    falls back to the canonical ``~/.config/nexus/memory.db``. Kept in
+    sync with the resolver in ``src/nexus/config.py``; if that resolver
+    ever grows additional precedence rules, mirror them here.
+    """
+    config_dir = (
+        os.environ.get("NEXUS_CONFIG_DIR")
+        or os.environ.get("NX_CONFIG_DIR")
+    )
+    if config_dir:
+        return Path(config_dir) / "memory.db"
+    return Path.home() / ".config" / "nexus" / "memory.db"
+
+
 def _snippet(content: str, max_chars: int = 120) -> str:
     """Return first meaningful line of content, truncated."""
     for line in content.splitlines():
@@ -42,72 +79,112 @@ def _snippet(content: str, max_chars: int = 120) -> str:
     return ""
 
 
+def _get_namespaces(conn: sqlite3.Connection, prefix: str) -> list[str]:
+    """Return project namespaces matching ``prefix``, recency-ordered (DESC).
+
+    Mirrors ``MemoryStore.get_projects_with_prefix``: ``LIKE`` metacharacters
+    ``\\``, ``%``, ``_`` in *prefix* are escaped so they match literally
+    (a repo named ``my_project`` will not match ``myXproject``).
+    """
+    if not prefix:
+        return []
+    escaped = (
+        prefix.replace("\\", "\\\\")
+              .replace("%", "\\%")
+              .replace("_", "\\_")
+    )
+    rows = conn.execute(
+        "SELECT project, MAX(timestamp) AS last_updated "
+        "FROM memory WHERE project LIKE ? ESCAPE '\\' "
+        "GROUP BY project ORDER BY MAX(timestamp) DESC",
+        (f"{escaped}%",),
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def _get_entries(conn: sqlite3.Connection, project: str) -> list[tuple[str, str]]:
+    """Return ``[(title, content), ...]`` for *project*, recency-ordered."""
+    rows = conn.execute(
+        "SELECT title, content FROM memory WHERE project = ? "
+        "ORDER BY timestamp DESC",
+        (project,),
+    ).fetchall()
+    return [(row[0], row[1] or "") for row in rows]
+
+
 def main() -> None:
     if len(sys.argv) < 2:
         print("Usage: t2_prefix_scan.py <project_name>", file=sys.stderr)
         sys.exit(1)
 
     project_name = sys.argv[1]
-
-    try:
-        from nexus.commands._helpers import default_db_path
-        from nexus.db.t2 import T2Database
-    except ImportError as exc:
-        print(f"T2 not available: {exc}", file=sys.stderr)
+    db_path = _default_db_path()
+    if not db_path.exists():
+        # No T2 yet (fresh install). Silently no-op so the hook stays
+        # invisible until the user actually writes a memory entry.
         return
 
     try:
-        with T2Database(default_db_path()) as db:
-            namespaces = db.get_projects_with_prefix(project_name)
-            if not namespaces:
-                return
+        conn = sqlite3.connect(
+            f"file:{db_path}?mode=ro",
+            uri=True,
+            timeout=5.0,
+        )
+    except sqlite3.OperationalError as exc:
+        print(f"T2 read error: {exc}", file=sys.stderr)
+        return
 
-            lines: list[str] = []
-            total = 0  # rendered entries across all namespaces
+    try:
+        namespaces = _get_namespaces(conn, project_name)
+        if not namespaces:
+            return
 
-            for ns_row in namespaces:
+        lines: list[str] = []
+        total = 0  # rendered entries across all namespaces
+
+        for ns in namespaces:
+            if total >= _HARD_CAP:
+                break
+
+            entries = _get_entries(conn, ns)
+            if not entries:
+                continue
+
+            suffix = ns[len(project_name):].lstrip("_") if ns != project_name else ""
+            label = f"T2 Memory ({suffix})" if suffix else "T2 Memory"
+
+            ns_lines: list[str] = []
+            ns_remaining = 0
+            ns_rank = 0  # per-namespace position (1-based)
+
+            for title, content in entries:
                 if total >= _HARD_CAP:
-                    break
-
-                ns = ns_row["project"]
-                entries = db.get_all(project=ns)
-                if not entries:
+                    ns_remaining += 1
                     continue
+                ns_rank += 1
+                if ns_rank <= _SNIPPET_LIMIT:
+                    snip = _snippet(content)
+                    ns_lines.append(f"  {title}" + (f" — {snip}" if snip else ""))
+                    total += 1
+                elif ns_rank <= _TITLE_LIMIT:
+                    ns_lines.append(f"  {title}")
+                    total += 1
+                else:
+                    ns_remaining += 1
 
-                suffix = ns[len(project_name):].lstrip("_") if ns != project_name else ""
-                label = f"T2 Memory ({suffix})" if suffix else "T2 Memory"
-
-                ns_lines: list[str] = []
-                ns_remaining = 0
-                ns_rank = 0  # per-namespace position (1-based)
-
-                for entry in entries:
-                    if total >= _HARD_CAP:
-                        ns_remaining += 1
-                        continue
-                    ns_rank += 1
-                    title = entry.get("title", "(untitled)")
-                    if ns_rank <= _SNIPPET_LIMIT:
-                        snip = _snippet(entry.get("content", ""))
-                        ns_lines.append(f"  {title}" + (f" — {snip}" if snip else ""))
-                        total += 1
-                    elif ns_rank <= _TITLE_LIMIT:
-                        ns_lines.append(f"  {title}")
-                        total += 1
-                    else:
-                        ns_remaining += 1
-
-                if ns_lines:
-                    lines.append(f"### {label}")
-                    lines.extend(ns_lines)
-                    if ns_remaining:
-                        lines.append(f"  … ({ns_remaining} more)")
-                    lines.append("")
+            if ns_lines:
+                lines.append(f"### {label}")
+                lines.extend(ns_lines)
+                if ns_remaining:
+                    lines.append(f"  … ({ns_remaining} more)")
+                lines.append("")
 
         if lines:
             print("\n".join(lines), end="")
     except Exception as exc:
         print(f"T2 read error: {exc}", file=sys.stderr)
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/conexus/hooks/scripts/t2_prefix_scan.py
+++ b/conexus/hooks/scripts/t2_prefix_scan.py
@@ -1,35 +1,11 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""T2 prefix-scan: surface all namespaces matching a project prefix.
+"""T2 prefix-scan: surface T2 namespaces matching a project prefix.
 
-Usage: t2_prefix_scan.py <project_name>
-
-Queries T2 for every namespace whose name starts with *project_name*
-(e.g. "nexus", "nexus_rdr", "nexus_knowledge") and prints a compact summary
-formatted for session injection.
-
-**Stdlib-only** (nexus-vg6d4): this script must run under whatever bare
-Python interpreter ``_run_python_hook.sh`` resolves (probes
-``python3.13`` → ``python3.12`` → ``python3``), which on a
-``uv tool install conexus`` deployment is the system Python that
-cannot import the ``nexus`` package (it lives in conexus's own venv).
-Importing ``nexus.db.t2`` would silently fail and the entire
-``## T2 Memory (Active Project)`` section would be omitted from the
-session-start context. Using ``sqlite3`` directly keeps the hook
-portable across the wrapper's interpreter probe.
-
-The SQL mirrors ``MemoryStore.get_projects_with_prefix`` and
-``MemoryStore.get_all`` verbatim (including the ``ESCAPE '\\'`` clause
-that prevents ``LIKE`` metacharacters in the prefix from matching
-unintended namespaces).
-
-Cap algorithm:
-  Per namespace (entries ranked by recency within that namespace):
-    entries 1–5   : title + 1-line snippet (≤120 chars)
-    entries 6–8   : title only
-    beyond 8      : omitted; trailing count appended
-  Cross-namespace hard cap: 15 rendered entries total (snippet or title).
-  Namespaces are processed in recency order (most-recently-updated first).
+Stdlib-only (nexus-vg6d4) so it runs under whichever bare interpreter
+``_run_python_hook.sh`` resolves — ``uv tool install conexus`` puts
+``nexus`` in a venv that bare ``python3`` cannot import. Long-form
+notes (cap algorithm, SQL parity rationale) live below the imports.
 """
 from __future__ import annotations
 

--- a/src/nexus/context.py
+++ b/src/nexus/context.py
@@ -126,9 +126,27 @@ def generate_context_l1(
     if not rows:
         return None
 
+    # nexus-9iw41 defensive dedup: collapse rows with identical
+    # (collection, label, doc_count) to one. Production has surfaced
+    # degenerate clustering states where N root topics in a single
+    # collection share an identical label+count (observed 2026-05-28:
+    # 5 rows all "Project knowledge findings content (144)" in a
+    # phantom docs__1-2188 collection, IDs 3401/3564/3727/3890/4053).
+    # Without dedup those N rows would all show as separate top-N
+    # entries in the Knowledge Map. Dedup is keyed on the exact tuple
+    # so legitimate distinct labels are unaffected.
+    seen: set[tuple[str, str, int]] = set()
+    deduped: list[tuple[str, str, int]] = []
+    for collection, label, doc_count in rows:
+        key = (collection, label, doc_count)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append((collection, label, doc_count))
+
     # Group by collection prefix, filtered by repo if specified
     prefixes: dict[str, list[tuple[str, int]]] = {}
-    for collection, label, doc_count in rows:
+    for collection, label, doc_count in deduped:
         if allowed is not None and collection not in allowed:
             continue
         prefix = collection.split("__")[0] if "__" in collection else collection

--- a/tests/hooks/test_t2_prefix_scan.py
+++ b/tests/hooks/test_t2_prefix_scan.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-vg6d4: ``t2_prefix_scan.py`` must be stdlib-only.
+
+The plugin's ``_run_python_hook.sh`` wrapper probes bare
+``python3.13`` / ``python3.12`` to invoke ``session_start_hook.py``,
+which calls ``t2_prefix_scan.py``. On a ``uv tool install conexus``
+deployment the wrapper's resolved interpreter cannot import the
+``nexus`` package (it lives in conexus's own venv). Before the fix,
+``t2_prefix_scan.py`` did ``from nexus.db.t2 import T2Database`` at the
+top, the import failed silently, and the entire
+``## T2 Memory (Active Project)`` section was omitted from the
+session-start context. This pinned the regression: the script must run
+under a vanilla Python with only stdlib available.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "conexus"
+    / "hooks"
+    / "scripts"
+    / "t2_prefix_scan.py"
+)
+
+
+def _seed_db(db_path: Path) -> None:
+    """Create a minimal memory.db with rows for two namespaces."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE memory (
+                id        INTEGER PRIMARY KEY,
+                project   TEXT NOT NULL,
+                title     TEXT NOT NULL,
+                session   TEXT,
+                agent     TEXT,
+                content   TEXT NOT NULL,
+                tags      TEXT,
+                timestamp TEXT NOT NULL,
+                ttl       INTEGER,
+                access_count  INTEGER DEFAULT 0 NOT NULL,
+                last_accessed TEXT DEFAULT ''
+            )
+            """
+        )
+        rows = [
+            ("nexus", "release-5-3-0-validation",
+             "## Header\n\nValidated 5.3.0 release pipeline end-to-end.",
+             "2026-05-28T03:00:00"),
+            ("nexus", "rdr-memory-audit",
+             "Audited 17 RDR memories; 9 stale; refreshed.",
+             "2026-05-28T02:30:00"),
+            ("nexus_rdr", "rdr-129",
+             "RDR-129 closed 2026-05-27; T2 daemon write-path hardening.",
+             "2026-05-27T22:00:00"),
+        ]
+        conn.executemany(
+            "INSERT INTO memory (project, title, content, timestamp) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _run(project_name: str, db_path: Path, *, interpreter: str = sys.executable) -> str:
+    """Invoke the script with NEXUS_CONFIG_DIR pointed at *db_path*'s parent."""
+    env = os.environ.copy()
+    env["NEXUS_CONFIG_DIR"] = str(db_path.parent)
+    # Strip PYTHONPATH so the test runner's venv site-packages are not on
+    # sys.path; this approximates the bare-interpreter invocation that
+    # _run_python_hook.sh produces on a uv-tool-install deployment.
+    env.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [interpreter, str(SCRIPT), project_name],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=10,
+    )
+    assert result.returncode == 0, (
+        f"script exit {result.returncode}\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    return result.stdout
+
+
+def test_runs_under_bare_python_and_surfaces_entries(tmp_path: Path) -> None:
+    """The headline regression: must not print 'T2 not available'."""
+    db = tmp_path / "memory.db"
+    _seed_db(db)
+    out = _run("nexus", db)
+    # Must surface the bare-namespace entries.
+    assert "### T2 Memory" in out
+    assert "release-5-3-0-validation" in out
+    assert "rdr-memory-audit" in out
+    # Must surface the suffixed namespace separately.
+    assert "### T2 Memory (rdr)" in out
+    assert "rdr-129" in out
+    # Must not have leaked the pre-fix import-error message anywhere.
+    assert "T2 not available" not in out
+    assert "No module named" not in out
+
+
+def test_recency_ordering_within_namespace(tmp_path: Path) -> None:
+    """Entries inside a namespace appear in DESC timestamp order."""
+    db = tmp_path / "memory.db"
+    _seed_db(db)
+    out = _run("nexus", db)
+    # release-5-3-0-validation (03:00) is newer than rdr-memory-audit (02:30);
+    # the newer entry's title appears first.
+    pos_release = out.index("release-5-3-0-validation")
+    pos_audit = out.index("rdr-memory-audit")
+    assert pos_release < pos_audit
+
+
+def test_no_namespaces_means_no_output(tmp_path: Path) -> None:
+    """Querying a prefix with no matches returns clean empty output."""
+    db = tmp_path / "memory.db"
+    _seed_db(db)
+    out = _run("unknown_project_xyz", db)
+    assert out == ""
+
+
+def test_missing_db_is_silent_noop(tmp_path: Path) -> None:
+    """A fresh install with no T2 yet should not error or emit noise."""
+    # tmp_path has no memory.db.
+    env = os.environ.copy()
+    env["NEXUS_CONFIG_DIR"] = str(tmp_path)
+    env.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "nexus"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=10,
+    )
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_like_metacharacters_in_prefix_are_escaped(tmp_path: Path) -> None:
+    """Prefix containing ``_`` must not glob-match other namespaces.
+
+    The pre-fix MemoryStore.get_projects_with_prefix already escapes
+    LIKE metacharacters; the stdlib port preserves that behavior.
+    """
+    db = tmp_path / "memory.db"
+    _seed_db(db)
+    # The seeded DB has 'nexus' and 'nexus_rdr'. A query for 'nexus_'
+    # (with literal underscore) must match only 'nexus_rdr', not
+    # 'nexusX...'. Add a dummy collision to make the test bite.
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO memory (project, title, content, timestamp) VALUES "
+        "('nexusXrdr', 'should-not-appear', 'glob-match canary', '2026-05-28T01:00:00')"
+    )
+    conn.commit()
+    conn.close()
+    out = _run("nexus_", db)
+    assert "rdr-129" in out  # legitimate nexus_rdr match
+    assert "should-not-appear" not in out  # underscore is literal, not a glob

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -104,6 +104,81 @@ class TestGenerateContextL1:
         assert "Code Topic 4" in content
         assert "Code Topic 5" not in content
 
+    def test_dedups_identical_root_topic_rows(self, db: T2Database, tmp_path: Path) -> None:
+        """nexus-9iw41: collapse rows with identical (collection, label, doc_count).
+
+        Production surfaced a phantom collection ``docs__1-2188`` with 5
+        ROOT topic rows all labelled ``Project knowledge findings content``
+        with ``doc_count=144`` (IDs 3401/3564/3727/3890/4053). Pre-fix the
+        Knowledge Map showed all 5 as separate top-N entries — the docs
+        side of the injected map was literally
+        ``Project knowledge findings content (144), Project knowledge
+        findings content (144), …`` five times.
+
+        Dedup is keyed on the exact tuple ``(collection, label, doc_count)``
+        so legitimate distinct labels (or distinct doc_counts on the same
+        label) are unaffected.
+        """
+        from nexus.context import generate_context_l1
+
+        # Five identical phantom rows (the production smoking-gun shape) +
+        # one legitimate distinct topic in the same collection so the test
+        # can prove the dedup didn't accidentally drop the real entry.
+        for _ in range(5):
+            db.taxonomy.conn.execute(
+                "INSERT INTO topics (label, collection, doc_count, created_at, review_status) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("Phantom Duplicate", "docs__phantom", 144,
+                 "2026-05-28T00:00:00Z", "accepted"),
+            )
+        db.taxonomy.conn.execute(
+            "INSERT INTO topics (label, collection, doc_count, created_at, review_status) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("Legitimate Distinct", "docs__phantom", 90,
+             "2026-05-28T00:00:00Z", "accepted"),
+        )
+        db.taxonomy.conn.commit()
+
+        out = tmp_path / "context_l1.txt"
+        generate_context_l1(db.taxonomy, output_path=out)
+        content = out.read_text()
+
+        # The phantom label appears AT MOST ONCE (the five copies collapsed).
+        assert content.count("Phantom Duplicate") == 1, (
+            "dedup failed: phantom label appears more than once in the output"
+        )
+        # The legitimate distinct row in the same collection is preserved.
+        assert "Legitimate Distinct" in content
+
+    def test_dedups_preserves_same_label_distinct_count(
+        self, db: T2Database, tmp_path: Path,
+    ) -> None:
+        """Dedup must NOT collapse same-label rows with different doc_counts.
+
+        Same label across two collections with different counts is a
+        legitimate case (e.g. ``Project knowledge findings`` at 596 in
+        ``docs__1-1`` vs 144 in some other live collection). The dedup
+        key includes ``doc_count`` so both survive.
+        """
+        from nexus.context import generate_context_l1
+
+        db.taxonomy.conn.executemany(
+            "INSERT INTO topics (label, collection, doc_count, created_at, review_status) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                ("Shared Label", "docs__a", 100, "2026-05-28T00:00:00Z", "accepted"),
+                ("Shared Label", "docs__b", 50, "2026-05-28T00:00:00Z", "accepted"),
+            ],
+        )
+        db.taxonomy.conn.commit()
+
+        out = tmp_path / "context_l1.txt"
+        generate_context_l1(db.taxonomy, output_path=out)
+        content = out.read_text()
+
+        # Both rows survive because doc_count differs.
+        assert content.count("Shared Label") == 2
+
     def test_excludes_child_topics(self, db: T2Database, tmp_path: Path) -> None:
         """Only root topics (parent_id IS NULL), not children from split."""
         from nexus.context import generate_context_l1


### PR DESCRIPTION
Two session-start injection bugs that silently broke context loading, diagnosed during the 2026-05-27 audit. Both P1 bugs that caused future sessions to read either an incomplete (T2 missing) or corrupted (Knowledge Map duplicates) startup context.

## nexus-vg6d4 — T2 memory injection silently broken

`conexus/hooks/scripts/_run_python_hook.sh` probes bare `python3.13` / `python3.12` to invoke `session_start_hook.py`, which calls `t2_prefix_scan.py`. On a `uv tool install conexus` deployment the wrapper's resolved interpreter cannot import the `nexus` package (it lives in conexus's own venv).

- Before: `t2_prefix_scan.py` did `from nexus.db.t2 import T2Database` at the top, the import failed with `T2 not available: No module named nexus`, `session_start_hook.py` saw empty stdout, and the entire `## T2 Memory (Active Project)` section was silently omitted from the injected context. Every T2 memory entry was invisible at session start and subagent start.
- After: stdlib-`sqlite3`-only refactor of `t2_prefix_scan.py`. SQL mirrors `MemoryStore.get_projects_with_prefix` and `get_all` verbatim (including the `ESCAPE '\'` clause). Read-only connection (`mode=ro`). Honours `NEXUS_CONFIG_DIR` / `NX_CONFIG_DIR` env overrides for test-sandbox parity.

Verified: `python3.13 conexus/hooks/scripts/t2_prefix_scan.py nexus` now returns 153 actual T2 entries (previously: `T2 not available`). End-to-end `session_start_hook.py` output now contains `## T2 Memory (Active Project)` with the active project's namespaces.

## nexus-9iw41 — Knowledge Map showed 5 identical duplicate labels

A phantom collection `docs__1-2188__voyage-context-3__v1` had accreted 815 ROOT topics in the T2 `topics` table; the 5 highest by `doc_count` were 5 identical rows `Project knowledge findings content (144)` (IDs 3401/3564/3727/3890/4053). The collection doesn't exist in T3 chroma — pure taxonomy pollution. `generate_context_l1` faithfully reports top-N by `doc_count`, so the docs side of the injected Knowledge Map showed the same label/count repeated 5 times.

- Defensive fix: `generate_context_l1` now collapses rows with identical `(collection, label, doc_count)` before grouping. Key includes `doc_count` so legitimate same-label-different-count rows both survive.
- One-off cleanup: 815 phantom rows deleted from `topics` (operator-applied, separate from this commit).

## Tests

19 / 19 passing (5 new in `tests/hooks/test_t2_prefix_scan.py`, 2 new in `tests/test_context.py`, 12 existing). The new t2_prefix_scan tests strip `PYTHONPATH` before invoking via subprocess to approximate the bare-interpreter path the wrapper resolves on production.

## Separate follow-up (NOT in this PR)

While investigating, surfaced: `_repo_collections(nexus)` registers the phantom `docs__1-2188` to nexus repo but not the real `docs__1-1` (88 root topics, 3190 chunks). The catalog-registration writer that created the phantom mapping needs investigation. Worth a P2 bead; the Knowledge Map docs side will remain empty for nexus until that's fixed, but the duplicate-labels bug — the user-facing pain — is resolved.

## Closes

Closes nexus-vg6d4
Closes nexus-9iw41