### PR TITLE
feat(hook): SessionStart hygiene block — L1 cache staleness warning (nexus-1if7b)

### DIFF
--- a/conexus/hooks/scripts/session_start_hook.py
+++ b/conexus/hooks/scripts/session_start_hook.py
@@ -120,6 +120,7 @@ def main() -> None:
     output_lines.append("")
 
     # --- L1 Knowledge Map (RDR-072) — per-repo cached topic labels ---
+    context_l1_path: str | None = None
     try:
         import hashlib
         cwd = os.getcwd()
@@ -139,10 +140,55 @@ def main() -> None:
     except Exception:
         pass  # Non-fatal — hook must never fail
 
+    # --- Hygiene (nexus-1if7b) — actionable maintenance signals ---
+    # Strict "in moderation" surface: emit a section only when there's
+    # something to act on; stay silent when everything is healthy.
+    # Currently checks one signal (L1 cache staleness > 7 days, which
+    # caught nexus-9iw41's 10-day-stale cache). Add more signals only
+    # when each pays for the line-count it costs.
+    _emit_hygiene_block(output_lines, context_l1_path)
+
     if output_lines:
         print("\n".join(output_lines))
 
     sys.exit(0)
+
+
+def _emit_hygiene_block(output_lines: list, context_l1_path: str | None) -> None:
+    """Append a ``## Hygiene`` section to *output_lines* iff actionable.
+
+    nexus-1if7b: high-leverage, low-volume curation prompts at session
+    start. Stdlib-only so it runs under whichever bare interpreter
+    ``_run_python_hook.sh`` resolves (same constraint as
+    ``t2_prefix_scan.py``; see nexus-vg6d4).
+
+    Signals (each line only when triggered):
+      * L1 cache age > 7 days — actionable: ``nx context refresh``.
+
+    Non-fatal: any check that raises is dropped silently.
+    """
+    import time as _time
+
+    signals: list[str] = []
+
+    if context_l1_path:
+        try:
+            if os.path.exists(context_l1_path):
+                age_days = int(
+                    (_time.time() - os.path.getmtime(context_l1_path)) // 86400
+                )
+                if age_days > 7:
+                    signals.append(
+                        f"- L1 cache {age_days}d old — refresh: `nx context refresh`"
+                    )
+        except OSError:
+            pass
+
+    if signals:
+        output_lines.append("## Hygiene")
+        output_lines.append("")
+        output_lines.extend(signals)
+        output_lines.append("")
 
 
 if __name__ == "__main__":

--- a/tests/hooks/test_session_start_hygiene.py
+++ b/tests/hooks/test_session_start_hygiene.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-1if7b: ``## Hygiene`` strategic-hints block in session start.
+
+Surfaces actionable maintenance signals at session start when (and only
+when) something is actionable. Silent when healthy, single-purpose for
+each signal. Stdlib-only so the hook runs under whichever bare
+interpreter ``_run_python_hook.sh`` resolves (same constraint pinned
+by ``test_t2_prefix_scan.py``).
+"""
+from __future__ import annotations
+
+import os
+import time as _time
+from pathlib import Path
+
+# Make the hook script importable as a module via path injection.
+import sys as _sys
+_HOOKS_DIR = Path(__file__).resolve().parents[2] / "conexus" / "hooks" / "scripts"
+_sys.path.insert(0, str(_HOOKS_DIR))
+try:
+    from session_start_hook import _emit_hygiene_block  # type: ignore[import-not-found]
+finally:
+    _sys.path.remove(str(_HOOKS_DIR))
+
+
+def test_silent_when_cache_fresh(tmp_path: Path) -> None:
+    """Healthy state: no hygiene section appended."""
+    cache = tmp_path / "cache.txt"
+    cache.write_text("## Knowledge Map\nfresh\n")
+    # Just-now mtime — well under the 7-day threshold.
+    lines: list[str] = []
+    _emit_hygiene_block(lines, str(cache))
+    assert lines == []
+
+
+def test_silent_when_cache_path_missing(tmp_path: Path) -> None:
+    """No L1 cache file at all: hygiene block is silent."""
+    lines: list[str] = []
+    _emit_hygiene_block(lines, str(tmp_path / "nonexistent.txt"))
+    assert lines == []
+
+
+def test_silent_when_cache_path_none() -> None:
+    """``None`` passed for the cache path: silent."""
+    lines: list[str] = []
+    _emit_hygiene_block(lines, None)
+    assert lines == []
+
+
+def test_emits_warning_when_cache_stale(tmp_path: Path) -> None:
+    """L1 cache > 7 days old triggers the warning line."""
+    cache = tmp_path / "cache.txt"
+    cache.write_text("## Knowledge Map\nstale\n")
+    # Backdate the mtime 10 days into the past.
+    ten_days_ago = _time.time() - (10 * 86400)
+    os.utime(cache, (ten_days_ago, ten_days_ago))
+
+    lines: list[str] = []
+    _emit_hygiene_block(lines, str(cache))
+
+    assert "## Hygiene" in lines
+    # Locate the signal line and assert its shape.
+    signal_lines = [ln for ln in lines if ln.startswith("- L1 cache")]
+    assert len(signal_lines) == 1
+    assert "10d old" in signal_lines[0]
+    assert "nx context refresh" in signal_lines[0]
+
+
+def test_threshold_is_exactly_7_days(tmp_path: Path) -> None:
+    """Boundary: 7 days exactly is healthy (silent); 8 days fires."""
+    cache = tmp_path / "cache.txt"
+    cache.write_text("x\n")
+
+    # 7 days exactly → silent.
+    seven = _time.time() - (7 * 86400)
+    os.utime(cache, (seven, seven))
+    lines: list[str] = []
+    _emit_hygiene_block(lines, str(cache))
+    assert lines == [], "7 days exactly should not trigger"
+
+    # 8 days → fires.
+    eight = _time.time() - (8 * 86400)
+    os.utime(cache, (eight, eight))
+    lines = []
+    _emit_hygiene_block(lines, str(cache))
+    assert any("L1 cache" in ln for ln in lines), "8 days should trigger"
+
+
+def test_block_appends_to_existing_output(tmp_path: Path) -> None:
+    """Hygiene block extends caller's output_lines, doesn't replace."""
+    cache = tmp_path / "cache.txt"
+    cache.write_text("x\n")
+    old = _time.time() - (15 * 86400)
+    os.utime(cache, (old, old))
+
+    lines = ["pre-existing line 1", "pre-existing line 2"]
+    _emit_hygiene_block(lines, str(cache))
+
+    # Caller's prior content is preserved at the head.
+    assert lines[0] == "pre-existing line 1"
+    assert lines[1] == "pre-existing line 2"
+    # And the hygiene section is appended.
+    assert "## Hygiene" in lines[2:]
+
+
+def test_no_crash_on_unreadable_cache(tmp_path: Path) -> None:
+    """OSError on ``os.path.getmtime`` is dropped silently — hook never fails."""
+    # Point at a path that exists() will return True for but getmtime
+    # fails on — easiest: a directory.
+    bad = tmp_path / "is_a_dir"
+    bad.mkdir()
+    lines: list[str] = []
+    # Should not raise; silent.
+    _emit_hygiene_block(lines, str(bad))
+    # `bad` exists and is a dir; getmtime works on dirs too, so this
+    # may not raise. The point: even on weird input the function never
+    # raises out. Assert no exception.
+    assert isinstance(lines, list)


### PR DESCRIPTION
Implements the strategic-hints hygiene block requested 2026-05-28: high-leverage, low-volume curation signal at session start.

## What

`session_start_hook.py` gains a `_emit_hygiene_block(output_lines, context_l1_path)` helper. It appends a `## Hygiene` section to the injected session context **only when actionable**, silent otherwise.

v1 signal: **L1 cache age > 7 days**. When triggered, emits:

```
## Hygiene

- L1 cache 12d old — refresh: `nx context refresh`
```

This is the signal that would have surfaced nexus-9iw41's corrupted-cache state 10 days before it was diagnosed by hand.

## Why this one signal first

"In moderation" + "high leverage" = pay for each line. L1 cache staleness is:
- The signal that already caught a real bug in this exact codebase.
- Trivially actionable (single command).
- Cheap to compute (stat one file).
- Zero false positives at the 7-day threshold.

Add more signals (audit recency, memory drift, T2 size) only after each proves it pays for the bytes it costs.

## Constraints

- **Stdlib only** — runs under whichever bare interpreter `_run_python_hook.sh` resolves, same constraint that pinned `t2_prefix_scan.py` in nexus-vg6d4. No `import nexus.*`.
- **Non-fatal** — any check that raises is dropped silently. The hook never blocks session start on hygiene.
- **`## Hygiene` heading only when content present** — silent state produces zero output, including no heading.

## Tests

7 new in `tests/hooks/test_session_start_hygiene.py`:
- silent when cache fresh
- silent when cache path missing
- silent when cache path `None`
- emits warning when cache is 10d old
- threshold boundary: 7 days = silent, 8 days = fires
- block appends to caller's output_lines (doesn't replace)
- no crash on weird input (directory passed as cache path)

Existing `tests/test_plugin_structure.py::TestHooks` still passes (the `__future__` guard check that bit PR #993's first attempt).

## Closes

Closes nexus-1if7b