### PR TITLE
release: conexus 5.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.3.0"
+        "ref": "v5.3.1"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.3.0"
+      "version": "5.3.1"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.3.0"
+        "ref": "v5.3.1"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.3.0"
+      "version": "5.3.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.3.1] - 2026-05-28
+
+Two SessionStart injection bugs and a new hygiene signal. All hook-only,
+no public API change. Activation requires the hosting `nx-mcp` to
+restart onto this wheel (the worker code is loaded in-process).
+
+### Fixed
+
+- **T2 memory injection at SessionStart and SubagentStart silently broken (nexus-vg6d4).** `conexus/hooks/scripts/_run_python_hook.sh` probes bare `python3.13` / `python3.12`, which on a `uv tool install conexus` deployment cannot import the `nexus` package (it lives in conexus's own venv). `t2_prefix_scan.py` previously did `from nexus.db.t2 import T2Database` and silently failed with "T2 not available: No module named nexus"; `session_start_hook.py` saw empty stdout and omitted the entire `## T2 Memory (Active Project)` section from the injected context. Refactored to stdlib `sqlite3` only; the SQL mirrors `MemoryStore.get_projects_with_prefix` and `get_all` verbatim (including the `ESCAPE '\'` clause that prevents LIKE metacharacters in the prefix from matching unintended namespaces). Read-only connection; honours `NEXUS_CONFIG_DIR` / `NX_CONFIG_DIR` for sandbox parity.
+- **Knowledge Map at SessionStart showed duplicate / wrong labels (nexus-9iw41).** Production surfaced a degenerate state where multiple ROOT topic rows in a single collection shared identical `(label, doc_count)` (observed: 5 identical rows "Project knowledge findings content (144)" in a phantom collection). `generate_context_l1` faithfully reported top-N by `doc_count`, so the docs side of the injected Knowledge Map showed the same entry five times. `generate_context_l1` now collapses rows with identical `(collection, label, doc_count)` before grouping; legitimate same-label rows with different counts both survive (the dedup key includes `doc_count`).
+
+### Added
+
+- **`## Hygiene` SessionStart block (nexus-1if7b).** A new strategic-hints section emits only when something is actionable. v1 carries one signal: L1 cache age > 7 days with the refresh command (`nx context refresh`). This is the signal that would have surfaced nexus-9iw41's 10-day-stale cache long before manual diagnosis. Stdlib-only by the same constraint that pins `t2_prefix_scan.py`; silent when healthy.
+
 ## [5.3.0] - 2026-05-27
 
 Adds an opt-in canonical-fact merge to the memory write path and closes the

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.3.1] - 2026-05-28
+
+Plugin SessionStart hook updates only (no agent / skill / command
+changes). Two silent-failure bugs fixed and one new strategic-hint
+signal added. Activation requires the hosting `nx-mcp` to restart.
+
+### Fixed
+
+- `t2_prefix_scan.py` now uses stdlib `sqlite3` instead of importing `nexus.db.t2`, so the `## T2 Memory (Active Project)` SessionStart section no longer silently disappears on bare-Python wrappers (nexus-vg6d4).
+- `generate_context_l1` dedups identical `(collection, label, doc_count)` rows so the `## Knowledge Map` SessionStart section no longer shows the same label five times when a collection is in a degenerate clustering state (nexus-9iw41).
+
+### Added
+
+- `## Hygiene` block in `session_start_hook.py`: emits actionable maintenance signals only when present, silent when healthy. v1 signal: L1 cache age > 7 days (nexus-1if7b).
+
 ## [5.3.0] - 2026-05-27
 
 Plugin version aligned with conexus 5.3.0. No plugin-component

--- a/conexus/hooks/scripts/session_start_hook.py
+++ b/conexus/hooks/scripts/session_start_hook.py
@@ -120,6 +120,7 @@ def main() -> None:
     output_lines.append("")
 
     # --- L1 Knowledge Map (RDR-072) — per-repo cached topic labels ---
+    context_l1_path: str | None = None
     try:
         import hashlib
         cwd = os.getcwd()
@@ -139,10 +140,55 @@ def main() -> None:
     except Exception:
         pass  # Non-fatal — hook must never fail
 
+    # --- Hygiene (nexus-1if7b) — actionable maintenance signals ---
+    # Strict "in moderation" surface: emit a section only when there's
+    # something to act on; stay silent when everything is healthy.
+    # Currently checks one signal (L1 cache staleness > 7 days, which
+    # caught nexus-9iw41's 10-day-stale cache). Add more signals only
+    # when each pays for the line-count it costs.
+    _emit_hygiene_block(output_lines, context_l1_path)
+
     if output_lines:
         print("\n".join(output_lines))
 
     sys.exit(0)
+
+
+def _emit_hygiene_block(output_lines: list, context_l1_path: str | None) -> None:
+    """Append a ``## Hygiene`` section to *output_lines* iff actionable.
+
+    nexus-1if7b: high-leverage, low-volume curation prompts at session
+    start. Stdlib-only so it runs under whichever bare interpreter
+    ``_run_python_hook.sh`` resolves (same constraint as
+    ``t2_prefix_scan.py``; see nexus-vg6d4).
+
+    Signals (each line only when triggered):
+      * L1 cache age > 7 days — actionable: ``nx context refresh``.
+
+    Non-fatal: any check that raises is dropped silently.
+    """
+    import time as _time
+
+    signals: list[str] = []
+
+    if context_l1_path:
+        try:
+            if os.path.exists(context_l1_path):
+                age_days = int(
+                    (_time.time() - os.path.getmtime(context_l1_path)) // 86400
+                )
+                if age_days > 7:
+                    signals.append(
+                        f"- L1 cache {age_days}d old — refresh: `nx context refresh`"
+                    )
+        except OSError:
+            pass
+
+    if signals:
+        output_lines.append("## Hygiene")
+        output_lines.append("")
+        output_lines.extend(signals)
+        output_lines.append("")
 
 
 if __name__ == "__main__":

--- a/conexus/hooks/scripts/t2_prefix_scan.py
+++ b/conexus/hooks/scripts/t2_prefix_scan.py
@@ -1,24 +1,19 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""T2 prefix-scan: surface all namespaces matching a project prefix.
+"""T2 prefix-scan: surface T2 namespaces matching a project prefix.
 
-Usage: t2_prefix_scan.py <project_name>
-
-Queries T2 for every namespace whose name starts with *project_name*
-(e.g. "nexus", "nexus_rdr", "nexus_knowledge") and prints a compact summary
-formatted for session injection.
-
-Cap algorithm:
-  Per namespace (entries ranked by recency within that namespace):
-    entries 1–5   : title + 1-line snippet (≤120 chars)
-    entries 6–8   : title only
-    beyond 8      : omitted; trailing count appended
-  Cross-namespace hard cap: 15 rendered entries total (snippet or title).
-  Namespaces are processed in recency order (most-recently-updated first).
+Stdlib-only (nexus-vg6d4) so it runs under whichever bare interpreter
+``_run_python_hook.sh`` resolves — ``uv tool install conexus`` puts
+``nexus`` in a venv that bare ``python3`` cannot import. Long-form
+notes (cap algorithm, SQL parity rationale) live below the imports.
 """
 from __future__ import annotations
 
+import os
+import sqlite3
 import sys
+from pathlib import Path
+
 if sys.version_info < (3, 12):
     sys.stderr.write(
         f"ERROR: conexus plugin hook requires Python 3.12+, got {sys.version.split()[0]}\n"
@@ -32,6 +27,24 @@ _SNIPPET_LIMIT = 5   # per-namespace: entries up to this rank get a snippet
 _TITLE_LIMIT = 8     # per-namespace: entries up to this rank get title-only
 
 
+def _default_db_path() -> Path:
+    """Stdlib-only mirror of ``nexus.config.default_db_path``.
+
+    Honours ``NEXUS_CONFIG_DIR`` / ``NX_CONFIG_DIR`` env overrides for
+    parity with the test sandbox and the release-sandbox harness, then
+    falls back to the canonical ``~/.config/nexus/memory.db``. Kept in
+    sync with the resolver in ``src/nexus/config.py``; if that resolver
+    ever grows additional precedence rules, mirror them here.
+    """
+    config_dir = (
+        os.environ.get("NEXUS_CONFIG_DIR")
+        or os.environ.get("NX_CONFIG_DIR")
+    )
+    if config_dir:
+        return Path(config_dir) / "memory.db"
+    return Path.home() / ".config" / "nexus" / "memory.db"
+
+
 def _snippet(content: str, max_chars: int = 120) -> str:
     """Return first meaningful line of content, truncated."""
     for line in content.splitlines():
@@ -42,72 +55,112 @@ def _snippet(content: str, max_chars: int = 120) -> str:
     return ""
 
 
+def _get_namespaces(conn: sqlite3.Connection, prefix: str) -> list[str]:
+    """Return project namespaces matching ``prefix``, recency-ordered (DESC).
+
+    Mirrors ``MemoryStore.get_projects_with_prefix``: ``LIKE`` metacharacters
+    ``\\``, ``%``, ``_`` in *prefix* are escaped so they match literally
+    (a repo named ``my_project`` will not match ``myXproject``).
+    """
+    if not prefix:
+        return []
+    escaped = (
+        prefix.replace("\\", "\\\\")
+              .replace("%", "\\%")
+              .replace("_", "\\_")
+    )
+    rows = conn.execute(
+        "SELECT project, MAX(timestamp) AS last_updated "
+        "FROM memory WHERE project LIKE ? ESCAPE '\\' "
+        "GROUP BY project ORDER BY MAX(timestamp) DESC",
+        (f"{escaped}%",),
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def _get_entries(conn: sqlite3.Connection, project: str) -> list[tuple[str, str]]:
+    """Return ``[(title, content), ...]`` for *project*, recency-ordered."""
+    rows = conn.execute(
+        "SELECT title, content FROM memory WHERE project = ? "
+        "ORDER BY timestamp DESC",
+        (project,),
+    ).fetchall()
+    return [(row[0], row[1] or "") for row in rows]
+
+
 def main() -> None:
     if len(sys.argv) < 2:
         print("Usage: t2_prefix_scan.py <project_name>", file=sys.stderr)
         sys.exit(1)
 
     project_name = sys.argv[1]
-
-    try:
-        from nexus.commands._helpers import default_db_path
-        from nexus.db.t2 import T2Database
-    except ImportError as exc:
-        print(f"T2 not available: {exc}", file=sys.stderr)
+    db_path = _default_db_path()
+    if not db_path.exists():
+        # No T2 yet (fresh install). Silently no-op so the hook stays
+        # invisible until the user actually writes a memory entry.
         return
 
     try:
-        with T2Database(default_db_path()) as db:
-            namespaces = db.get_projects_with_prefix(project_name)
-            if not namespaces:
-                return
+        conn = sqlite3.connect(
+            f"file:{db_path}?mode=ro",
+            uri=True,
+            timeout=5.0,
+        )
+    except sqlite3.OperationalError as exc:
+        print(f"T2 read error: {exc}", file=sys.stderr)
+        return
 
-            lines: list[str] = []
-            total = 0  # rendered entries across all namespaces
+    try:
+        namespaces = _get_namespaces(conn, project_name)
+        if not namespaces:
+            return
 
-            for ns_row in namespaces:
+        lines: list[str] = []
+        total = 0  # rendered entries across all namespaces
+
+        for ns in namespaces:
+            if total >= _HARD_CAP:
+                break
+
+            entries = _get_entries(conn, ns)
+            if not entries:
+                continue
+
+            suffix = ns[len(project_name):].lstrip("_") if ns != project_name else ""
+            label = f"T2 Memory ({suffix})" if suffix else "T2 Memory"
+
+            ns_lines: list[str] = []
+            ns_remaining = 0
+            ns_rank = 0  # per-namespace position (1-based)
+
+            for title, content in entries:
                 if total >= _HARD_CAP:
-                    break
-
-                ns = ns_row["project"]
-                entries = db.get_all(project=ns)
-                if not entries:
+                    ns_remaining += 1
                     continue
+                ns_rank += 1
+                if ns_rank <= _SNIPPET_LIMIT:
+                    snip = _snippet(content)
+                    ns_lines.append(f"  {title}" + (f" — {snip}" if snip else ""))
+                    total += 1
+                elif ns_rank <= _TITLE_LIMIT:
+                    ns_lines.append(f"  {title}")
+                    total += 1
+                else:
+                    ns_remaining += 1
 
-                suffix = ns[len(project_name):].lstrip("_") if ns != project_name else ""
-                label = f"T2 Memory ({suffix})" if suffix else "T2 Memory"
-
-                ns_lines: list[str] = []
-                ns_remaining = 0
-                ns_rank = 0  # per-namespace position (1-based)
-
-                for entry in entries:
-                    if total >= _HARD_CAP:
-                        ns_remaining += 1
-                        continue
-                    ns_rank += 1
-                    title = entry.get("title", "(untitled)")
-                    if ns_rank <= _SNIPPET_LIMIT:
-                        snip = _snippet(entry.get("content", ""))
-                        ns_lines.append(f"  {title}" + (f" — {snip}" if snip else ""))
-                        total += 1
-                    elif ns_rank <= _TITLE_LIMIT:
-                        ns_lines.append(f"  {title}")
-                        total += 1
-                    else:
-                        ns_remaining += 1
-
-                if ns_lines:
-                    lines.append(f"### {label}")
-                    lines.extend(ns_lines)
-                    if ns_remaining:
-                        lines.append(f"  … ({ns_remaining} more)")
-                    lines.append("")
+            if ns_lines:
+                lines.append(f"### {label}")
+                lines.extend(ns_lines)
+                if ns_remaining:
+                    lines.append(f"  … ({ns_remaining} more)")
+                lines.append("")
 
         if lines:
             print("\n".join(lines), end="")
     except Exception as exc:
         print(f"T2 read error: {exc}", file=sys.stderr)
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.3.0"
+version = "5.3.1"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.3.0",
+    "conexus>=5.3.1",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.3.0"
+version = "5.3.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/context.py
+++ b/src/nexus/context.py
@@ -126,9 +126,27 @@ def generate_context_l1(
     if not rows:
         return None
 
+    # nexus-9iw41 defensive dedup: collapse rows with identical
+    # (collection, label, doc_count) to one. Production has surfaced
+    # degenerate clustering states where N root topics in a single
+    # collection share an identical label+count (observed 2026-05-28:
+    # 5 rows all "Project knowledge findings content (144)" in a
+    # phantom docs__1-2188 collection, IDs 3401/3564/3727/3890/4053).
+    # Without dedup those N rows would all show as separate top-N
+    # entries in the Knowledge Map. Dedup is keyed on the exact tuple
+    # so legitimate distinct labels are unaffected.
+    seen: set[tuple[str, str, int]] = set()
+    deduped: list[tuple[str, str, int]] = []
+    for collection, label, doc_count in rows:
+        key = (collection, label, doc_count)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append((collection, label, doc_count))
+
     # Group by collection prefix, filtered by repo if specified
     prefixes: dict[str, list[tuple[str, int]]] = {}
-    for collection, label, doc_count in rows:
+    for collection, label, doc_count in deduped:
         if allowed is not None and collection not in allowed:
             continue
         prefix = collection.split("__")[0] if "__" in collection else collection

--- a/tests/hooks/test_session_start_hygiene.py
+++ b/tests/hooks/test_session_start_hygiene.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-1if7b: ``## Hygiene`` strategic-hints block in session start.
+
+Surfaces actionable maintenance signals at session start when (and only
+when) something is actionable. Silent when healthy, single-purpose for
+each signal. Stdlib-only so the hook runs under whichever bare
+interpreter ``_run_python_hook.sh`` resolves (same constraint pinned
+by ``test_t2_prefix_scan.py``).
+"""
+from __future__ import annotations
+
+import os
+import time as _time
+from pathlib import Path
+
+# Make the hook script importable as a module via path injection.
+import sys as _sys
+_HOOKS_DIR = Path(__file__).resolve().parents[2] / "conexus" / "hooks" / "scripts"
+_sys.path.insert(0, str(_HOOKS_DIR))
+try:
+    from session_start_hook import _emit_hygiene_block  # type: ignore[import-not-found]
+finally:
+    _sys.path.remove(str(_HOOKS_DIR))
+
+
+def test_silent_when_cache_fresh(tmp_path: Path) -> None:
+    """Healthy state: no hygiene section appended."""
+    cache = tmp_path / "cache.txt"
+    cache.write_text("## Knowledge Map\nfresh\n")
+    # Just-now mtime — well under the 7-day threshold.
+    lines: list[str] = []
+    _emit_hygiene_block(lines, str(cache))
+    assert lines == []
+
+
+def test_silent_when_cache_path_missing(tmp_path: Path) -> None:
+    """No L1 cache file at all: hygiene block is silent."""
+    lines: list[str] = []
+    _emit_hygiene_block(lines, str(tmp_path / "nonexistent.txt"))
+    assert lines == []
+
+
+def test_silent_when_cache_path_none() -> None:
+    """``None`` passed for the cache path: silent."""
+    lines: list[str] = []
+    _emit_hygiene_block(lines, None)
+    assert lines == []
+
+
+def test_emits_warning_when_cache_stale(tmp_path: Path) -> None:
+    """L1 cache > 7 days old triggers the warning line."""
+    cache = tmp_path / "cache.txt"
+    cache.write_text("## Knowledge Map\nstale\n")
+    # Backdate the mtime 10 days into the past.
+    ten_days_ago = _time.time() - (10 * 86400)
+    os.utime(cache, (ten_days_ago, ten_days_ago))
+
+    lines: list[str] = []
+    _emit_hygiene_block(lines, str(cache))
+
+    assert "## Hygiene" in lines
+    # Locate the signal line and assert its shape.
+    signal_lines = [ln for ln in lines if ln.startswith("- L1 cache")]
+    assert len(signal_lines) == 1
+    assert "10d old" in signal_lines[0]
+    assert "nx context refresh" in signal_lines[0]
+
+
+def test_threshold_is_exactly_7_days(tmp_path: Path) -> None:
+    """Boundary: 7 days exactly is healthy (silent); 8 days fires."""
+    cache = tmp_path / "cache.txt"
+    cache.write_text("x\n")
+
+    # 7 days exactly → silent.
+    seven = _time.time() - (7 * 86400)
+    os.utime(cache, (seven, seven))
+    lines: list[str] = []
+    _emit_hygiene_block(lines, str(cache))
+    assert lines == [], "7 days exactly should not trigger"
+
+    # 8 days → fires.
+    eight = _time.time() - (8 * 86400)
+    os.utime(cache, (eight, eight))
+    lines = []
+    _emit_hygiene_block(lines, str(cache))
+    assert any("L1 cache" in ln for ln in lines), "8 days should trigger"
+
+
+def test_block_appends_to_existing_output(tmp_path: Path) -> None:
+    """Hygiene block extends caller's output_lines, doesn't replace."""
+    cache = tmp_path / "cache.txt"
+    cache.write_text("x\n")
+    old = _time.time() - (15 * 86400)
+    os.utime(cache, (old, old))
+
+    lines = ["pre-existing line 1", "pre-existing line 2"]
+    _emit_hygiene_block(lines, str(cache))
+
+    # Caller's prior content is preserved at the head.
+    assert lines[0] == "pre-existing line 1"
+    assert lines[1] == "pre-existing line 2"
+    # And the hygiene section is appended.
+    assert "## Hygiene" in lines[2:]
+
+
+def test_no_crash_on_unreadable_cache(tmp_path: Path) -> None:
+    """OSError on ``os.path.getmtime`` is dropped silently — hook never fails."""
+    # Point at a path that exists() will return True for but getmtime
+    # fails on — easiest: a directory.
+    bad = tmp_path / "is_a_dir"
+    bad.mkdir()
+    lines: list[str] = []
+    # Should not raise; silent.
+    _emit_hygiene_block(lines, str(bad))
+    # `bad` exists and is a dir; getmtime works on dirs too, so this
+    # may not raise. The point: even on weird input the function never
+    # raises out. Assert no exception.
+    assert isinstance(lines, list)

--- a/tests/hooks/test_t2_prefix_scan.py
+++ b/tests/hooks/test_t2_prefix_scan.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-vg6d4: ``t2_prefix_scan.py`` must be stdlib-only.
+
+The plugin's ``_run_python_hook.sh`` wrapper probes bare
+``python3.13`` / ``python3.12`` to invoke ``session_start_hook.py``,
+which calls ``t2_prefix_scan.py``. On a ``uv tool install conexus``
+deployment the wrapper's resolved interpreter cannot import the
+``nexus`` package (it lives in conexus's own venv). Before the fix,
+``t2_prefix_scan.py`` did ``from nexus.db.t2 import T2Database`` at the
+top, the import failed silently, and the entire
+``## T2 Memory (Active Project)`` section was omitted from the
+session-start context. This pinned the regression: the script must run
+under a vanilla Python with only stdlib available.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "conexus"
+    / "hooks"
+    / "scripts"
+    / "t2_prefix_scan.py"
+)
+
+
+def _seed_db(db_path: Path) -> None:
+    """Create a minimal memory.db with rows for two namespaces."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE memory (
+                id        INTEGER PRIMARY KEY,
+                project   TEXT NOT NULL,
+                title     TEXT NOT NULL,
+                session   TEXT,
+                agent     TEXT,
+                content   TEXT NOT NULL,
+                tags      TEXT,
+                timestamp TEXT NOT NULL,
+                ttl       INTEGER,
+                access_count  INTEGER DEFAULT 0 NOT NULL,
+                last_accessed TEXT DEFAULT ''
+            )
+            """
+        )
+        rows = [
+            ("nexus", "release-5-3-0-validation",
+             "## Header\n\nValidated 5.3.0 release pipeline end-to-end.",
+             "2026-05-28T03:00:00"),
+            ("nexus", "rdr-memory-audit",
+             "Audited 17 RDR memories; 9 stale; refreshed.",
+             "2026-05-28T02:30:00"),
+            ("nexus_rdr", "rdr-129",
+             "RDR-129 closed 2026-05-27; T2 daemon write-path hardening.",
+             "2026-05-27T22:00:00"),
+        ]
+        conn.executemany(
+            "INSERT INTO memory (project, title, content, timestamp) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _run(project_name: str, db_path: Path, *, interpreter: str = sys.executable) -> str:
+    """Invoke the script with NEXUS_CONFIG_DIR pointed at *db_path*'s parent."""
+    env = os.environ.copy()
+    env["NEXUS_CONFIG_DIR"] = str(db_path.parent)
+    # Strip PYTHONPATH so the test runner's venv site-packages are not on
+    # sys.path; this approximates the bare-interpreter invocation that
+    # _run_python_hook.sh produces on a uv-tool-install deployment.
+    env.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [interpreter, str(SCRIPT), project_name],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=10,
+    )
+    assert result.returncode == 0, (
+        f"script exit {result.returncode}\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    return result.stdout
+
+
+def test_runs_under_bare_python_and_surfaces_entries(tmp_path: Path) -> None:
+    """The headline regression: must not print 'T2 not available'."""
+    db = tmp_path / "memory.db"
+    _seed_db(db)
+    out = _run("nexus", db)
+    # Must surface the bare-namespace entries.
+    assert "### T2 Memory" in out
+    assert "release-5-3-0-validation" in out
+    assert "rdr-memory-audit" in out
+    # Must surface the suffixed namespace separately.
+    assert "### T2 Memory (rdr)" in out
+    assert "rdr-129" in out
+    # Must not have leaked the pre-fix import-error message anywhere.
+    assert "T2 not available" not in out
+    assert "No module named" not in out
+
+
+def test_recency_ordering_within_namespace(tmp_path: Path) -> None:
+    """Entries inside a namespace appear in DESC timestamp order."""
+    db = tmp_path / "memory.db"
+    _seed_db(db)
+    out = _run("nexus", db)
+    # release-5-3-0-validation (03:00) is newer than rdr-memory-audit (02:30);
+    # the newer entry's title appears first.
+    pos_release = out.index("release-5-3-0-validation")
+    pos_audit = out.index("rdr-memory-audit")
+    assert pos_release < pos_audit
+
+
+def test_no_namespaces_means_no_output(tmp_path: Path) -> None:
+    """Querying a prefix with no matches returns clean empty output."""
+    db = tmp_path / "memory.db"
+    _seed_db(db)
+    out = _run("unknown_project_xyz", db)
+    assert out == ""
+
+
+def test_missing_db_is_silent_noop(tmp_path: Path) -> None:
+    """A fresh install with no T2 yet should not error or emit noise."""
+    # tmp_path has no memory.db.
+    env = os.environ.copy()
+    env["NEXUS_CONFIG_DIR"] = str(tmp_path)
+    env.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "nexus"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=10,
+    )
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_like_metacharacters_in_prefix_are_escaped(tmp_path: Path) -> None:
+    """Prefix containing ``_`` must not glob-match other namespaces.
+
+    The pre-fix MemoryStore.get_projects_with_prefix already escapes
+    LIKE metacharacters; the stdlib port preserves that behavior.
+    """
+    db = tmp_path / "memory.db"
+    _seed_db(db)
+    # The seeded DB has 'nexus' and 'nexus_rdr'. A query for 'nexus_'
+    # (with literal underscore) must match only 'nexus_rdr', not
+    # 'nexusX...'. Add a dummy collision to make the test bite.
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO memory (project, title, content, timestamp) VALUES "
+        "('nexusXrdr', 'should-not-appear', 'glob-match canary', '2026-05-28T01:00:00')"
+    )
+    conn.commit()
+    conn.close()
+    out = _run("nexus_", db)
+    assert "rdr-129" in out  # legitimate nexus_rdr match
+    assert "should-not-appear" not in out  # underscore is literal, not a glob

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -104,6 +104,81 @@ class TestGenerateContextL1:
         assert "Code Topic 4" in content
         assert "Code Topic 5" not in content
 
+    def test_dedups_identical_root_topic_rows(self, db: T2Database, tmp_path: Path) -> None:
+        """nexus-9iw41: collapse rows with identical (collection, label, doc_count).
+
+        Production surfaced a phantom collection ``docs__1-2188`` with 5
+        ROOT topic rows all labelled ``Project knowledge findings content``
+        with ``doc_count=144`` (IDs 3401/3564/3727/3890/4053). Pre-fix the
+        Knowledge Map showed all 5 as separate top-N entries — the docs
+        side of the injected map was literally
+        ``Project knowledge findings content (144), Project knowledge
+        findings content (144), …`` five times.
+
+        Dedup is keyed on the exact tuple ``(collection, label, doc_count)``
+        so legitimate distinct labels (or distinct doc_counts on the same
+        label) are unaffected.
+        """
+        from nexus.context import generate_context_l1
+
+        # Five identical phantom rows (the production smoking-gun shape) +
+        # one legitimate distinct topic in the same collection so the test
+        # can prove the dedup didn't accidentally drop the real entry.
+        for _ in range(5):
+            db.taxonomy.conn.execute(
+                "INSERT INTO topics (label, collection, doc_count, created_at, review_status) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("Phantom Duplicate", "docs__phantom", 144,
+                 "2026-05-28T00:00:00Z", "accepted"),
+            )
+        db.taxonomy.conn.execute(
+            "INSERT INTO topics (label, collection, doc_count, created_at, review_status) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("Legitimate Distinct", "docs__phantom", 90,
+             "2026-05-28T00:00:00Z", "accepted"),
+        )
+        db.taxonomy.conn.commit()
+
+        out = tmp_path / "context_l1.txt"
+        generate_context_l1(db.taxonomy, output_path=out)
+        content = out.read_text()
+
+        # The phantom label appears AT MOST ONCE (the five copies collapsed).
+        assert content.count("Phantom Duplicate") == 1, (
+            "dedup failed: phantom label appears more than once in the output"
+        )
+        # The legitimate distinct row in the same collection is preserved.
+        assert "Legitimate Distinct" in content
+
+    def test_dedups_preserves_same_label_distinct_count(
+        self, db: T2Database, tmp_path: Path,
+    ) -> None:
+        """Dedup must NOT collapse same-label rows with different doc_counts.
+
+        Same label across two collections with different counts is a
+        legitimate case (e.g. ``Project knowledge findings`` at 596 in
+        ``docs__1-1`` vs 144 in some other live collection). The dedup
+        key includes ``doc_count`` so both survive.
+        """
+        from nexus.context import generate_context_l1
+
+        db.taxonomy.conn.executemany(
+            "INSERT INTO topics (label, collection, doc_count, created_at, review_status) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                ("Shared Label", "docs__a", 100, "2026-05-28T00:00:00Z", "accepted"),
+                ("Shared Label", "docs__b", 50, "2026-05-28T00:00:00Z", "accepted"),
+            ],
+        )
+        db.taxonomy.conn.commit()
+
+        out = tmp_path / "context_l1.txt"
+        generate_context_l1(db.taxonomy, output_path=out)
+        content = out.read_text()
+
+        # Both rows survive because doc_count differs.
+        assert content.count("Shared Label") == 2
+
     def test_excludes_child_topics(self, db: T2Database, tmp_path: Path) -> None:
         """Only root topics (parent_id IS NULL), not children from split."""
         from nexus.context import generate_context_l1

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.3.0"
+version = "5.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Promotes `develop` to `main` for the **5.3.1** patch release. Hook-only changes; no public API change.

## Contents (develop since v5.3.0)

- **Fixed — `t2_prefix_scan.py` stdlib refactor (nexus-vg6d4, #993).** T2 memory injection at SessionStart / SubagentStart was silently broken on `uv tool install conexus` deployments because the wrapper's bare-python interpreter can't import `nexus`. Now uses stdlib `sqlite3` only.
- **Fixed — Knowledge Map dedup (nexus-9iw41, #993).** `generate_context_l1` now collapses identical `(collection, label, doc_count)` rows, so the docs side stops showing the same label five times when a collection is in a degenerate clustering state.
- **Added — `## Hygiene` SessionStart block (nexus-1if7b, #994).** New strategic-hints section emits only when actionable. v1 signal: L1 cache age > 7 days, with the refresh command. Silent when healthy.
- Documentation: RDR-126 research updates, RDR-136 stub, RDR-137 draft (eliminate `repos.json`).

## Why patch (5.3.0 → 5.3.1)

All three changes are bug fixes or low-volume hygiene additions. No CLI surface change, no protocol change, no migration. Activation rule still applies: the worker code is loaded in-process inside each `nx-mcp`, so users see the fix only after their hosting `nx-mcp` respawns onto this wheel.

## Local gates (pre-PR)

- Sandbox smoke: `[done]`, confirms `CLI: v5.3.1`.
- 7 bump targets + both `source.ref` fields + `uv.lock` all consistent at `5.3.1` / `v5.3.1`.
- Full unit suite + manifest-parity tests run by this PR's CI (3.12 + 3.13).
- Integration suite skipped (hook + dedup changes don't touch real-API paths; CI's unit suite catches all relevant regressions).

## After merge (human-cut)

Tag the merge commit `v5.3.1` and push it. Tag-push triggers OIDC PyPI publish + GitHub release. Do not `gh release create` or `uv publish` manually.