### PR TITLE
fix(catalog): thread main-repo path through repo_root writes (nexus-nzyrh, RDR-137 gate critique)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1009,9 +1009,15 @@ class Catalog:
         :func:`nexus.registry._repo_identity`; ``description`` defaults
         to ``"Git repository: {repo_name}"``.
         """
-        from nexus.registry import _repo_identity  # noqa: PLC0415
+        from nexus.registry import _repo_identity_with_main  # noqa: PLC0415
 
-        derived_name, repo_hash = _repo_identity(repo)
+        # nexus-zr2ie (RDR-137 gate critique 2026-05-28): use the
+        # 3-tuple variant so ``repo_root`` is the canonical main-repo
+        # path even when *repo* is a worktree. Pre-fix this wrote
+        # ``str(repo)`` and contaminated the catalog on first-run-
+        # from-worktree indexing; after worktree deletion the stored
+        # path was broken for every relative-path document.
+        derived_name, repo_hash, main_repo = _repo_identity_with_main(repo)
         existing = self.owner_for_repo(repo_hash)
         if existing is not None:
             return existing
@@ -1019,7 +1025,7 @@ class Catalog:
             name=repo_name or derived_name,
             owner_type="repo",
             repo_hash=repo_hash,
-            repo_root=str(repo),
+            repo_root=str(main_repo),
             description=description or f"Git repository: {repo_name or derived_name}",
         )
 

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -633,11 +633,21 @@ def _catalog_hook(
         # existing owners short-circuit without a re-register.
         owner = cat.owner_for_repo(repo_hash)
         if owner is None:
+            # nexus-zr2ie (RDR-137 gate critique 2026-05-28): derive the
+            # canonical main-repo path so ``repo_root`` is worktree-
+            # stable. Pre-fix this wrote ``str(repo)`` and contaminated
+            # the catalog when the caller's ``repo`` argument was a
+            # worktree path; ``resolve_path`` then produced broken
+            # paths for every relative-path document under this owner
+            # once the worktree was deleted. ``_repo_identity_with_main``
+            # uses ``git rev-parse --git-common-dir`` to resolve.
+            from nexus.registry import _repo_identity_with_main  # noqa: PLC0415
+            _name, _hash, main_repo = _repo_identity_with_main(repo)
             owner = cat.register_owner(
                 name=repo_name,
                 owner_type="repo",
                 repo_hash=repo_hash,
-                repo_root=str(repo),
+                repo_root=str(main_repo),
                 description=f"Git repository: {repo_name}",
             )
             _log.info("catalog_owner_created", owner=str(owner), repo=repo_name)

--- a/src/nexus/registry.py
+++ b/src/nexus/registry.py
@@ -14,16 +14,13 @@ import structlog
 _log = structlog.get_logger()
 
 
-def _repo_identity(repo: Path) -> tuple[str, str]:
-    """Return ``(basename, hash8)`` for collection naming, stable across worktrees.
+def _resolve_main_repo(repo: Path) -> Path:
+    """Return the canonical main-repo Path for *repo*.
 
-    Uses ``git rev-parse --git-common-dir`` to resolve the main repository root
-    even when called from a worktree.  Falls back to the given *repo* path when
-    git is unavailable (not installed, not a git repo, etc.).
-
-    The hash is the first 8 hex characters of the SHA-256 digest of the
-    resolved main repo path.  Two worktrees of the same repo produce identical
-    collection names.
+    Uses ``git rev-parse --git-common-dir`` to resolve the main repository
+    root even when *repo* is a worktree path.  Falls back to the given
+    *repo* path when git is unavailable (not installed, not a git repo,
+    etc.).
     """
     try:
         result = subprocess.run(
@@ -37,15 +34,52 @@ def _repo_identity(repo: Path) -> tuple[str, str]:
             git_common = Path(result.stdout.strip())
             if not git_common.is_absolute():
                 git_common = (repo / git_common).resolve()
-            main_repo = git_common.parent
-        else:
-            main_repo = repo
+            return git_common.parent
     except (OSError, subprocess.TimeoutExpired) as exc:
         _log.debug("git rev-parse failed, using repo path directly", error=str(exc))
-        main_repo = repo
+    return repo
 
+
+def _repo_identity(repo: Path) -> tuple[str, str]:
+    """Return ``(basename, hash8)`` for collection naming, stable across worktrees.
+
+    The hash is the first 8 hex characters of the SHA-256 digest of the
+    resolved main repo path.  Two worktrees of the same repo produce
+    identical collection names.
+
+    ~15 call sites and the test-mock surface
+    (``monkeypatch.setattr("nexus.registry._repo_identity", ...)``) depend
+    on this 2-tuple signature.  New callers that need the main-repo path
+    should use :func:`_repo_identity_with_main`.
+    """
+    main_repo = _resolve_main_repo(repo)
     path_hash = hashlib.sha256(str(main_repo).encode()).hexdigest()[:8]
     return main_repo.name, path_hash
+
+
+def _repo_identity_with_main(repo: Path) -> tuple[str, str, Path]:
+    """Return ``(basename, hash8, main_repo_path)`` for *repo*.
+
+    nexus-zr2ie / RDR-137 gate critique 2026-05-28: callers that need to
+    persist the canonical main-repo path (e.g. catalog owner ``repo_root``)
+    should use this 3-tuple variant instead of writing ``str(repo)``.
+    Before this helper, ``ensure_owner_for_repo`` and ``_catalog_hook``
+    wrote ``repo_root=str(repo)``, which contaminated the catalog with
+    transient worktree paths on first-run-from-worktree indexing; after
+    worktree deletion ``resolve_path`` produced broken paths for every
+    relative-path document under that owner.
+
+    Delegates the ``(name, hash)`` pair to :func:`_repo_identity` so the
+    widely-used ``monkeypatch.setattr("nexus.registry._repo_identity", ...)``
+    test-mock pattern continues to control the lookup key for callers
+    that now route through this 3-tuple variant.  Main-repo path is
+    derived via :func:`_resolve_main_repo`, which can be mocked
+    independently when a test needs to assert what gets persisted as
+    ``repo_root``.
+    """
+    name, path_hash = _repo_identity(repo)
+    main_repo = _resolve_main_repo(repo)
+    return name, path_hash, main_repo
 
 
 def _safe_collection(

--- a/tests/test_worktree_repo_root_contamination.py
+++ b/tests/test_worktree_repo_root_contamination.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Worktree-first-run repo_root contamination (RDR-137 gate-critique finding).
+
+Pre-fix bug: ``ensure_owner_for_repo`` (catalog.py:1022) and ``_catalog_hook``
+(indexer.py:640) both wrote ``repo_root=str(repo)`` — the raw input path
+— instead of the canonical main-repo path that ``_repo_identity`` computes
+internally. When ``nx index repo`` ran first from a worktree path
+(e.g. ``.claude/worktrees/X``), the stored ``repo_root`` was the
+transient worktree directory; after worktree deletion, ``resolve_path``
+produced broken paths for all relative-path documents.
+
+Live evidence in the wild: catalog owner ``1.22`` (qmrr-zm2n) has
+``repo_root=/Users/.../.claude/worktrees/qmrr-zm2n``, the worktree
+path — even though ``_repo_identity`` would now resolve both that
+worktree and the nexus main repo to the same ``repo_hash`` (owner ``1.1``).
+
+The fix exposes a 3-tuple ``_repo_identity_with_main(repo)`` returning
+``(name, hash8, main_repo_path)``. Writers thread ``main_repo_path``
+through and write ``repo_root=str(main_repo_path)`` instead of the
+raw input. ``_repo_identity`` (2-tuple) is preserved unchanged so the
+~15 existing call sites and test mocks keep working.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog import Catalog
+
+
+@pytest.fixture()
+def cat(tmp_path: Path) -> Catalog:
+    """Fresh catalog rooted at tmp_path.
+
+    Uses ``Catalog.init`` (not just the constructor) because
+    ``_catalog_hook`` gates on ``Catalog.is_initialized`` which requires
+    both ``.git/`` and ``documents.jsonl`` to exist.
+    """
+    catalog_dir = tmp_path / "catalog"
+    catalog_dir.mkdir()
+    return Catalog.init(catalog_dir)
+
+
+def test_repo_identity_with_main_returns_three_tuple_with_main_repo_path(
+    tmp_path: Path,
+) -> None:
+    """Public contract: new 3-tuple variant returns the main-repo Path."""
+    from nexus.registry import _repo_identity_with_main
+
+    # Non-git path falls back to the input as main_repo.
+    plain = tmp_path / "no_git_here"
+    plain.mkdir()
+    name, hash8, main_repo = _repo_identity_with_main(plain)
+    assert name == "no_git_here"
+    assert len(hash8) == 8
+    assert main_repo == plain
+
+
+def test_repo_identity_two_tuple_unchanged(tmp_path: Path) -> None:
+    """Backward compat: the 2-tuple variant keeps its signature so the
+    ~15 production call sites and the existing test monkeypatches don't
+    break.
+    """
+    from nexus.registry import _repo_identity
+
+    plain = tmp_path / "no_git_here"
+    plain.mkdir()
+    result = _repo_identity(plain)
+    assert len(result) == 2
+    assert result[0] == "no_git_here"
+
+
+def test_ensure_owner_for_repo_writes_main_repo_root_not_input_path(
+    cat: Catalog, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The headline regression. When the catalog hasn't seen this repo
+    before AND the input path is a worktree, the registered owner's
+    ``repo_root`` must be the main-repo path, NOT the worktree path.
+    """
+    main_repo = tmp_path / "main_nexus"
+    main_repo.mkdir()
+    worktree = tmp_path / "main_nexus" / ".claude" / "worktrees" / "qmrr"
+    worktree.mkdir(parents=True)
+
+    # Mock _repo_identity_with_main to return main_repo as the third
+    # element regardless of which path is passed in (simulates the
+    # _git rev-parse --git-common-dir_ resolution that both worktree
+    # and main produce the same main repo).
+    monkeypatch.setattr(
+        "nexus.registry._repo_identity_with_main",
+        lambda r: ("main_nexus", "abcd1234", main_repo),
+    )
+
+    # First-run from the WORKTREE path.
+    owner = cat.ensure_owner_for_repo(worktree)
+    assert owner is not None
+
+    # owner_for_repo returns a Tumbler (just the id); _owner_repo_root
+    # returns the persisted ``repo_root`` string.
+    owner_tumbler = cat.owner_for_repo("abcd1234")
+    assert owner_tumbler is not None
+    repo_root = cat._owner_repo_root(owner_tumbler)
+    assert repo_root == str(main_repo), (
+        f"repo_root contaminated by input path: got {repo_root!r}, "
+        f"expected main repo {str(main_repo)!r}"
+    )
+    # Specifically: must NOT be the worktree path.
+    assert repo_root != str(worktree)
+
+
+def test_catalog_hook_passes_main_repo_path_to_register_owner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parallel fix for _catalog_hook (indexer.py:~640). When the hook is
+    the first registrar for a repo and the input path is a worktree,
+    ``register_owner`` must receive the canonical main-repo path as
+    ``repo_root``, NOT the worktree input path.
+
+    Verified by spying on ``Catalog.register_owner``: we capture the
+    ``repo_root`` kwarg the hook passes and assert it equals the
+    mocked ``main_repo``, never the worktree input. This sidesteps
+    the catalog projection / DB-init complexity and pins the exact
+    contract that nexus-zr2ie introduced.
+    """
+    from nexus.indexer import _catalog_hook
+
+    main_repo = tmp_path / "main_nexus"
+    main_repo.mkdir()
+    worktree = tmp_path / "main_nexus" / ".claude" / "worktrees" / "qmrr"
+    worktree.mkdir(parents=True)
+
+    # Initialize a real catalog so _catalog_hook's is_initialized gate passes.
+    catalog_dir = tmp_path / "catalog"
+    catalog_dir.mkdir()
+    Catalog.init(catalog_dir)
+    monkeypatch.setattr("nexus.config.catalog_path", lambda: catalog_dir)
+
+    # Force the hook's owner-lookup to return None so the registration
+    # branch fires.
+    monkeypatch.setattr(
+        "nexus.catalog.catalog.Catalog.owner_for_repo",
+        lambda self, repo_hash: None,
+    )
+
+    # Mock _repo_identity_with_main to return main_repo as the third
+    # element. The hook must use this value, not str(worktree).
+    monkeypatch.setattr(
+        "nexus.registry._repo_identity_with_main",
+        lambda r: ("main_nexus", "abcd1234", main_repo),
+    )
+
+    # Spy on register_owner to capture the repo_root kwarg.
+    captured: dict[str, object] = {}
+
+    def _spy(self, **kwargs):  # noqa: ANN001
+        captured.update(kwargs)
+        # Return a fake Tumbler-like object that has __str__.
+        class _FakeTumbler:
+            def __str__(self_inner) -> str:  # noqa: N805
+                return "1.1"
+        return _FakeTumbler()
+
+    monkeypatch.setattr("nexus.catalog.catalog.Catalog.register_owner", _spy)
+
+    _catalog_hook(
+        repo=worktree,
+        repo_name="main_nexus",
+        repo_hash="abcd1234",
+        head_hash="abc",
+        indexed_files=[],
+    )
+
+    assert "repo_root" in captured, "register_owner was not called"
+    assert captured["repo_root"] == str(main_repo), (
+        f"_catalog_hook contaminated repo_root: got {captured['repo_root']!r}, "
+        f"expected {str(main_repo)!r}"
+    )
+    assert captured["repo_root"] != str(worktree)


### PR DESCRIPTION
Pre-existing bug surfaced by **RDR-137 Layer 3 gate critique** (Significant Finding #2). Fix is independent of the broader RDR-137 migration — purely a `repo_root` write-correctness bug that exists today and would corrupt every worktree-first-run indexing.

## The bug

`ensure_owner_for_repo` (`catalog.py:1022`) and `_catalog_hook` (`indexer.py:640`) both wrote `repo_root=str(repo)` — the raw input path argument — instead of the canonical main-repo path that `_repo_identity` computes internally via `git rev-parse --git-common-dir`. When `nx index repo` ran first from a worktree path (`.claude/worktrees/X`), the stored `repo_root` was the transient worktree directory; after worktree deletion, `resolve_path` produced broken paths for every relative-path document under that owner.

**Live evidence**: catalog owner `1.22` (qmrr-zm2n) on this machine has `repo_root=/Users/.../.claude/worktrees/qmrr-zm2n`, even though `_repo_identity` would now resolve both that worktree and the main nexus repo to the same hash (owner `1.1`). Pure pre-RDR-103 artifact.

## The fix

`src/nexus/registry.py` refactor:
- New private `_resolve_main_repo(repo)` extracts the `git rev-parse --git-common-dir` logic.
- `_repo_identity(repo)` (2-tuple, unchanged signature) uses `_resolve_main_repo` internally. Preserves the ~15 call sites and the widely-used `monkeypatch.setattr("nexus.registry._repo_identity", ...)` test-mock pattern.
- `_repo_identity_with_main(repo)` (new, 3-tuple) returns `(name, hash8, main_repo_path)`. Delegates to `_repo_identity` for `(name, hash)` so existing 2-tuple mocks continue to control the lookup key; re-derives `main_repo` via `_resolve_main_repo`.

`src/nexus/catalog/catalog.py::ensure_owner_for_repo` and `src/nexus/indexer.py::_catalog_hook`: switch to `_repo_identity_with_main` and write `repo_root=str(main_repo)` instead of `str(repo)`.

## Tests

4 new in `tests/test_worktree_repo_root_contamination.py`:
- Unit on the 3-tuple variant.
- Backward-compat on the 2-tuple (`tuple[str, str]` shape preserved).
- Behavioral on `ensure_owner_for_repo` via `_owner_repo_root` — registers from a worktree, asserts persisted `repo_root` is `main_repo`, not the worktree path.
- Spy-based on `_catalog_hook` via `register_owner` kwarg capture — same assertion.

**299 / 299 pass** across all `nexus.registry`-touching test files: `test_registry`, `test_catalog`, `test_catalog_collection_for`, `test_catalog_e2e`, `test_indexer_modules`, `test_indexer_conformant_names`, `test_indexer_duplicate_content`, `test_indexer_e2e`, `test_repo_identity_stability`, `test_p0_regressions`, `test_collection_name_migration`, `tests/hooks/test_rdr_hook`.

## Scope clarification

The dirty data on this machine (orphan owner `1.22` with wrong `repo_root`) is **not** cleaned by this PR. That cleanup is part of the RDR-137 migration scope (Phase 4's one-time alias step); fixing the writer bug here prevents recurrence without touching existing data.

## Closes

Closes nexus-nzyrh