### PR TITLE
feat(catalog): add owners.head_hash column (RDR-137 Phase 1.5b)

### DIFF
--- a/src/nexus/db/t2/catalog.py
+++ b/src/nexus/db/t2/catalog.py
@@ -94,6 +94,15 @@ CREATE TABLE IF NOT EXISTS owners (
     repo_hash TEXT,
     description TEXT,
     repo_root TEXT DEFAULT '',
+    -- RDR-137 Phase 1.5b (nexus-tts0d.2): per-repo git HEAD identity,
+    -- previously held by ~/.config/nexus/repos.json. The indexer's
+    -- staleness skip compares the running repo's git HEAD against this
+    -- column; A1 verdict rejected documents.source_mtime as equivalent
+    -- because a repo HEAD can advance without any tracked file's mtime
+    -- changing (remote-only merge, ff-only pull of tag-only commits).
+    -- NULL on pre-migration rows AND on owners without a tracked HEAD
+    -- (e.g. ``curator`` owners minted by ``nx index pdf --corpus name``).
+    head_hash TEXT,
     -- nexus-7vuw: name UNIQUE was a too-strict invariant. A repo and a
     -- curator are different namespaces, so a repo named "nexus" should
     -- coexist with a curator named "nexus" (e.g. ``nx index pdf
@@ -357,6 +366,15 @@ class CatalogStore:
         except sqlite3.OperationalError:
             with self._conn:
                 self._conn.execute("ALTER TABLE owners ADD COLUMN repo_root TEXT DEFAULT ''")
+
+        # RDR-137 Phase 1.5b (nexus-tts0d.2): add owners.head_hash for per-
+        # repo git HEAD identity. NULL on pre-migration rows; populated by
+        # writers wired in Phase 3 (indexer cutover bead nexus-tts0d.13).
+        try:
+            self._conn.execute("SELECT head_hash FROM owners LIMIT 0")
+        except sqlite3.OperationalError:
+            with self._conn:
+                self._conn.execute("ALTER TABLE owners ADD COLUMN head_hash TEXT")
 
         # nexus-7vuw: drop the legacy single-column UNIQUE(name) index
         # on owners (replaced with composite UNIQUE(name, owner_type) in

--- a/tests/test_catalog_owners_head_hash.py
+++ b/tests/test_catalog_owners_head_hash.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-137 Phase 1.5b: owners.head_hash column + migration (nexus-tts0d.2).
+
+Adds a nullable ``head_hash TEXT`` column to the ``owners`` table so the
+catalog can carry per-repo git HEAD identity (previously held by
+``~/.config/nexus/repos.json``).  A1-verdict mitigation: switching to
+``documents.source_mtime`` is NOT equivalent because a repo HEAD can
+advance without any tracked file's mtime changing (remote-only merge,
+ff-only pull of tag-only commits, merge with changes in submodule /
+untracked dir).
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from nexus.db.t2.catalog import CatalogStore
+
+
+class TestCatalogOwnersHeadHashSchema:
+    def test_fresh_install_has_column(self, tmp_path: Path) -> None:
+        """New databases include owners.head_hash with NULL default."""
+        store = CatalogStore(tmp_path / "cat.db")
+        cols = {
+            r[1]: r
+            for r in store._conn.execute("PRAGMA table_info(owners)").fetchall()
+        }
+        assert "head_hash" in cols
+        # cid, name, type, notnull, dflt_value, pk
+        _, _, col_type, notnull, _, _ = cols["head_hash"]
+        assert col_type == "TEXT"
+        assert notnull == 0  # nullable
+
+    def test_migration_adds_column_to_pre_tts0d_db(self, tmp_path: Path) -> None:
+        """ALTER-on-open must patch a pre-migration owners table that lacks
+        head_hash. Verifies the try/SELECT guard runs the ALTER instead of
+        silently skipping it."""
+        db_path = tmp_path / "cat.db"
+        conn = sqlite3.connect(str(db_path))
+        # Legacy schema — no head_hash column. Matches the post-nexus-7vuw
+        # composite-unique shape (the most recent owners schema before
+        # nexus-tts0d.2).
+        conn.execute(
+            """
+            CREATE TABLE owners (
+                tumbler_prefix TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                owner_type TEXT NOT NULL,
+                repo_hash TEXT,
+                description TEXT,
+                repo_root TEXT DEFAULT '',
+                UNIQUE(name, owner_type)
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO owners (tumbler_prefix, name, owner_type, repo_hash, "
+            "description, repo_root) VALUES "
+            "('1.1', 'nexus', 'repo', 'abc123', '', '/path/to/nexus')"
+        )
+        conn.commit()
+        conn.close()
+
+        # Re-open via CatalogStore — migration should kick in.
+        store = CatalogStore(db_path)
+        cols = [
+            r[1] for r in store._conn.execute("PRAGMA table_info(owners)").fetchall()
+        ]
+        assert "head_hash" in cols
+        # Legacy row survives; pre-existing rows get the NULL default.
+        row = store._conn.execute(
+            "SELECT name, head_hash FROM owners WHERE tumbler_prefix = ?",
+            ("1.1",),
+        ).fetchone()
+        assert row == ("nexus", None)
+
+    def test_migration_is_idempotent(self, tmp_path: Path) -> None:
+        """Re-opening an already-migrated DB is a no-op (no exception, no
+        duplicate column add).  The idempotency contract every CatalogStore
+        ALTER migration honours via the SELECT-then-except guard."""
+        db_path = tmp_path / "cat.db"
+        # First open creates the schema with the column.
+        store1 = CatalogStore(db_path)
+        store1._conn.close()
+        # Second open should be a no-op.
+        store2 = CatalogStore(db_path)
+        cols = [
+            r[1] for r in store2._conn.execute("PRAGMA table_info(owners)").fetchall()
+        ]
+        assert cols.count("head_hash") == 1
+
+
+class TestCatalogOwnersHeadHashWrites:
+    def test_head_hash_column_accepts_writes(self, tmp_path: Path) -> None:
+        """Direct UPDATE writes a value; reads round-trip."""
+        store = CatalogStore(tmp_path / "cat.db")
+        store._conn.execute(
+            "INSERT INTO owners (tumbler_prefix, name, owner_type, repo_root) "
+            "VALUES ('1.5', 'sample', 'repo', '/tmp/sample')"
+        )
+        store._conn.execute(
+            "UPDATE owners SET head_hash = ? WHERE tumbler_prefix = ?",
+            ("deadbeef" * 5, "1.5"),
+        )
+        store._conn.commit()
+        row = store._conn.execute(
+            "SELECT head_hash FROM owners WHERE tumbler_prefix = ?", ("1.5",)
+        ).fetchone()
+        assert row == ("deadbeef" * 5,)


### PR DESCRIPTION
## Summary

RDR-137 Phase 1.5b (bead `nexus-tts0d.2`). Adds nullable `owners.head_hash TEXT` column to the catalog SQLite schema so per-repo git HEAD identity (currently in `~/.config/nexus/repos.json`) has a home in the catalog.

This is the schema prerequisite for:
- Phase 2 catalog-backed reader (`nexus-tts0d.4`).
- Phase 3 indexer cutover (`nexus-tts0d.13`).

## Why head_hash, not source_mtime

A1 verdict from the RDR-137 gate critique (2026-05-28) explicitly rejected `documents.source_mtime` as equivalent. A repo HEAD can advance without any tracked file's mtime changing:
- remote-only merge
- ff-only pull of tag-only commits
- merge with changes in submodule / untracked dir

The source_mtime path would silently pass the indexer's staleness skip in those cases.

## Scope

**Schema-only.** Writers (indexer, `nx index repo` status writes) are NOT rewired in this PR. That belongs to `nexus-tts0d.13` (Phase 3 indexer cutover).

## Migration shape

Idempotent ALTER guarded by the `SELECT ... LIMIT 0` / `except OperationalError` pattern matching `repo_root`, `source_mtime`, `alias_of`, `source_uri`, and `bib_*` migrations elsewhere in `CatalogStore.__init__`. NULL on pre-migration rows AND on owners without a tracked HEAD (`curator` owners minted by `nx index pdf --corpus name`).

## Closes

Closes nexus-tts0d.2

## Test plan

- [x] `tests/test_catalog_owners_head_hash.py` — 4 tests covering fresh install, ALTER-on-open from legacy schema with row-survival, idempotency on re-open, direct write round-trip.
- [x] `uv run pytest tests/test_catalog_db.py tests/test_catalog_source_mtime.py tests/test_catalog.py tests/test_catalog_collection_for.py tests/test_catalog_collections.py tests/test_catalog_audit_membership.py tests/test_catalog_e2e.py` — 286 / 286 green locally.