### PR TITLE
feat(catalog): backfill collections.owner_id (RDR-137 Phase 1.5a)

### DIFF
--- a/src/nexus/catalog/collections_owner_backfill.py
+++ b/src/nexus/catalog/collections_owner_backfill.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-137 Phase 1.5a: backfill ``collections.owner_id`` (nexus-tts0d.1).
+
+The ``collections`` projection table (RDR-103) carries an ``owner_id``
+column that any catalog-backed reader joins against
+``owners.tumbler_prefix`` to resolve repo → collection. Legacy rows
+synthesised by the RDR-108 auto-backfill at ``CatalogStore.__init__``
+land with ``owner_id=''``, making the join return nothing — the root
+of the RDR-137 phantom-collection symptom.
+
+This module exposes :func:`backfill_owner_id`, a self-contained pass
+that populates owner_id from two complementary sources:
+
+1. **Conformant collection name** (auto, idempotent, always safe).
+   RDR-103 names have shape ``<content_type>__<owner_id>__<model>__v<n>``;
+   the 2nd segment IS the owner_id. Parsing failures fall through.
+
+2. **Documents-table fallback** (opt-in, CLI-only). For rows whose
+   name cannot be parsed (legacy 2-segment names like
+   ``knowledge__delos``), look up documents registered against the
+   collection and derive owner_id from the document tumblers via
+   :func:`nexus.catalog.collection_name.owner_segment_for_tumbler`
+   (the canonical hyphen form ``1.7.42 -> 1-7`` — matches the format
+   queried by ``Catalog.collection_for``). Multiple distinct owners
+   → ambiguous, row left empty for operator review.
+
+The auto-migration in ``CatalogStore.__init__`` invokes this with
+``include_documents_fallback=False`` so the safe path runs on every
+DB open. The CLI verb ``nx catalog backfill-owner-id`` calls it with
+the fallback enabled so legacy names also get covered after operator
+review.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+import structlog
+
+from nexus.catalog.collection_name import owner_segment_for_tumbler
+
+_log = structlog.get_logger()
+
+
+@dataclass(frozen=True, slots=True)
+class BackfillResult:
+    """Counts emitted by :func:`backfill_owner_id`.
+
+    Sum of ``updated_from_name + updated_from_documents +
+    skipped_ambiguous + skipped_unresolvable`` equals
+    ``total_empty`` — every row with ``owner_id=''`` at entry is
+    accounted for.
+    """
+
+    total_empty: int
+    updated_from_name: int
+    updated_from_documents: int
+    skipped_ambiguous: int
+    skipped_unresolvable: int
+
+
+def backfill_owner_id(
+    conn: sqlite3.Connection,
+    *,
+    include_documents_fallback: bool = False,
+    dry_run: bool = False,
+) -> BackfillResult:
+    """Populate ``collections.owner_id`` for empty rows.
+
+    Iterates ``collections WHERE owner_id = ''`` and updates each
+    row's owner_id via the conformant-name path. When
+    ``include_documents_fallback`` is true, rows that the name path
+    cannot resolve get a second attempt via the documents-table
+    inference.
+
+    Idempotent: rows with non-empty owner_id are not re-examined.
+    Re-running on a fully-backfilled DB returns zero counts.
+
+    ``dry_run`` suppresses the UPDATE statements but still emits the
+    result counters so an operator can preview the change set.
+    """
+    from nexus.corpus import parse_conformant_collection_name  # noqa: PLC0415
+
+    rows: list[tuple[str]] = conn.execute(
+        "SELECT name FROM collections WHERE owner_id = ''"
+    ).fetchall()
+    total = len(rows)
+    updated_from_name = 0
+    updated_from_documents = 0
+    skipped_ambiguous = 0
+    skipped_unresolvable = 0
+
+    remaining: list[str] = []
+
+    # Pass 1 — conformant name.
+    for (name,) in rows:
+        try:
+            parsed = parse_conformant_collection_name(name)
+        except (ValueError, KeyError):
+            remaining.append(name)
+            continue
+        owner_id = parsed.get("owner_id", "")
+        if not owner_id:
+            remaining.append(name)
+            continue
+        if not dry_run:
+            conn.execute(
+                "UPDATE collections SET owner_id = ? WHERE name = ?",
+                (owner_id, name),
+            )
+        updated_from_name += 1
+        _log.info(
+            "collections_owner_backfill_from_name",
+            name=name, owner_id=owner_id, dry_run=dry_run,
+        )
+
+    # Pass 2 — documents-table fallback (opt-in).
+    if include_documents_fallback:
+        for name in remaining:
+            owners = {
+                owner_segment_for_tumbler(row[0])
+                for row in conn.execute(
+                    "SELECT DISTINCT tumbler FROM documents "
+                    "WHERE physical_collection = ?",
+                    (name,),
+                ).fetchall()
+            }
+            # Strip empty owner prefixes (malformed tumblers); they
+            # cannot identify an owner and should not be counted as
+            # candidates.
+            owners.discard("")
+            if not owners:
+                skipped_unresolvable += 1
+                _log.warning(
+                    "collections_owner_backfill_no_documents",
+                    name=name,
+                )
+                continue
+            if len(owners) > 1:
+                skipped_ambiguous += 1
+                _log.warning(
+                    "collections_owner_backfill_ambiguous_multi_owner",
+                    name=name, candidates=sorted(owners),
+                )
+                continue
+            owner_id = next(iter(owners))
+            if not dry_run:
+                conn.execute(
+                    "UPDATE collections SET owner_id = ? WHERE name = ?",
+                    (owner_id, name),
+                )
+            updated_from_documents += 1
+            _log.info(
+                "collections_owner_backfill_from_documents",
+                name=name, owner_id=owner_id, dry_run=dry_run,
+            )
+    else:
+        skipped_unresolvable += len(remaining)
+
+    return BackfillResult(
+        total_empty=total,
+        updated_from_name=updated_from_name,
+        updated_from_documents=updated_from_documents,
+        skipped_ambiguous=skipped_ambiguous,
+        skipped_unresolvable=skipped_unresolvable,
+    )

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -406,6 +406,72 @@ def backfill_collections_cmd(dry_run: bool) -> None:
     )
 
 
+@catalog.command("backfill-owner-id")
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=True,
+    help="Report-only (default). Use --no-dry-run to actually update. "
+    "Matches the safe-default convention of the other Phase 6 verbs.",
+)
+@click.option(
+    "--from-documents/--no-from-documents",
+    default=True,
+    help="Use the documents-table fallback to recover owner_id for legacy "
+    "2-segment names (default). Disable to restrict the backfill to "
+    "the auto-migration's conformant-name path only.",
+)
+def backfill_owner_id_cmd(dry_run: bool, from_documents: bool) -> None:
+    """Populate ``collections.owner_id`` for empty rows (RDR-137 P1.5a).
+
+    \b
+    The CatalogStore's auto-migration handles conformant RDR-103
+    four-segment names on every DB open. This verb adds the documents-
+    table fallback that recovers owner_id for legacy 2-segment names
+    (e.g. ``knowledge__delos``) by inferring owner from documents that
+    are physically registered against the collection.
+
+    \b
+    Ambiguous rows (documents from multiple distinct owners) are
+    skipped with a warning. The auto-migration is idempotent — running
+    this with ``--from-documents=false`` is equivalent to opening any
+    CatalogStore connection.
+
+    \b
+    Examples:
+      nx catalog backfill-owner-id --dry-run
+      nx catalog backfill-owner-id --no-dry-run
+      nx catalog backfill-owner-id --no-dry-run --no-from-documents
+    """
+    from nexus.catalog.collections_owner_backfill import (  # noqa: PLC0415
+        backfill_owner_id,
+    )
+
+    cat = _get_catalog()
+    with cat._db:
+        result = backfill_owner_id(
+            cat._db,
+            include_documents_fallback=from_documents,
+            dry_run=dry_run,
+        )
+
+    verb = "would update" if dry_run else "updated"
+    click.echo(
+        f"{verb} {result.updated_from_name} via name + "
+        f"{result.updated_from_documents} via documents fallback "
+        f"(total empty: {result.total_empty})"
+    )
+    if result.skipped_ambiguous:
+        click.echo(
+            f"  skipped {result.skipped_ambiguous} ambiguous "
+            f"(multi-owner) collection(s)"
+        )
+    if result.skipped_unresolvable:
+        click.echo(
+            f"  skipped {result.skipped_unresolvable} unresolvable "
+            f"collection(s) — manual review required"
+        )
+
+
 @catalog.command("migrate-fallback")
 @click.argument("source")
 @click.option(

--- a/src/nexus/db/t2/catalog.py
+++ b/src/nexus/db/t2/catalog.py
@@ -651,6 +651,20 @@ class CatalogStore:
                     )
                 self._backfilled_collections = candidates
 
+        # RDR-137 Phase 1.5a (nexus-tts0d.1): follow-on pass that
+        # populates ``collections.owner_id`` for rows synthesised above
+        # (and any pre-existing row with empty owner_id). The
+        # conformant-name path is the only one enabled here — it
+        # parses RDR-103 four-segment names and extracts the 2nd
+        # segment, which is always correct when the name is well-formed.
+        # Documents-table fallback for legacy 2-segment names is
+        # operator-driven via ``nx catalog backfill-owner-id``.
+        from nexus.catalog.collections_owner_backfill import (  # noqa: PLC0415
+            backfill_owner_id,
+        )
+        with self._conn:
+            backfill_owner_id(self._conn, include_documents_fallback=False)
+
     # ── identity ──────────────────────────────────────────────────────
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -387,6 +387,11 @@ _MODE_LINT_EXCLUDE_FILES: frozenset[str] = frozenset({
     "test_checkpoint.py",
     "test_collection_gc.py",
     "test_collection_name_migration.py",
+    # RDR-137 P1.5a: voyage tokens appear in synthetic conformant
+    # collection names used as backfill fixtures (e.g.
+    # ``code__nexus-1-1__voyage-code-3__v1``). Tests exercise pure
+    # SQLite + string parsing; no Voyage call is ever made.
+    "test_collections_owner_backfill.py",
     "test_commands_dt.py",
     "test_corpus.py",
     "test_doc_indexer_hash_sync.py",

--- a/tests/test_collections_owner_backfill.py
+++ b/tests/test_collections_owner_backfill.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-137 Phase 1.5a: backfill collections.owner_id (nexus-tts0d.1).
+
+The collections projection table has an ``owner_id`` column (RDR-103)
+that is empty on every legacy/grandfathered row. Any catalog-backed
+reader (Phase 2) doing ``collections JOIN owners`` returns nothing
+until owner_id is populated.
+
+Two backfill paths:
+
+- **Conformant-name** (auto, idempotent, safe): parse RDR-103
+  four-segment names (``<content_type>__<owner_id>__<model>__v<n>``)
+  and extract owner_id from the 2nd segment.
+- **Documents-table fallback** (opt-in, CLI-only): for collections that
+  have no conformant shape but DO have documents registered against
+  them, derive owner_id from the documents' tumblers using
+  ``_owner_prefix_of``. Skipped on ambiguity (multiple distinct owners).
+
+Both paths run inside ``backfill_owner_id``; the auto migration in
+``CatalogStore.__init__`` invokes it with ``include_documents_fallback=False``.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from nexus.catalog.collections_owner_backfill import (
+    BackfillResult,
+    backfill_owner_id,
+)
+from nexus.db.t2.catalog import CatalogStore
+
+
+def _open_raw_with_schema(
+    db_path: Path,
+    *,
+    collections: list[tuple[str, str]],  # (name, owner_id)
+    documents: list[tuple[str, str]] = [],  # (tumbler, physical_collection)
+) -> sqlite3.Connection:
+    """Open a raw sqlite3 connection with the minimal schema seeded.
+
+    This bypasses ``CatalogStore.__init__`` so unit tests of the
+    backfill function exercise it on the *pre-migration* state without
+    the auto-migration firing first. The caller owns the returned
+    connection and is responsible for ``close``.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE collections (
+            name TEXT PRIMARY KEY,
+            content_type TEXT NOT NULL DEFAULT '',
+            owner_id TEXT NOT NULL DEFAULT '',
+            embedding_model TEXT NOT NULL DEFAULT '',
+            model_version TEXT NOT NULL DEFAULT '',
+            display_name TEXT NOT NULL DEFAULT '',
+            legacy_grandfathered INTEGER NOT NULL DEFAULT 0,
+            superseded_by TEXT NOT NULL DEFAULT '',
+            superseded_at TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE documents (
+            tumbler TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            content_type TEXT,
+            file_path TEXT,
+            physical_collection TEXT,
+            chunk_count INTEGER,
+            indexed_at TEXT,
+            metadata JSON
+        );
+        """
+    )
+    for name, owner_id in collections:
+        conn.execute(
+            "INSERT INTO collections (name, owner_id, legacy_grandfathered) "
+            "VALUES (?, ?, 1)",
+            (name, owner_id),
+        )
+    for tumbler, coll in documents:
+        conn.execute(
+            "INSERT INTO documents "
+            "(tumbler, title, content_type, file_path, physical_collection, "
+            " chunk_count, indexed_at, metadata) VALUES "
+            "(?, ?, 'paper', '', ?, 0, '', '{}')",
+            (tumbler, f"doc-{tumbler}", coll),
+        )
+    conn.commit()
+    return conn
+
+
+def _row_owner_id(conn: sqlite3.Connection, name: str) -> str | None:
+    row = conn.execute(
+        "SELECT owner_id FROM collections WHERE name = ?", (name,)
+    ).fetchone()
+    return None if row is None else row[0]
+
+
+class TestConformantNameBackfill:
+    def test_extracts_owner_id_from_rdr103_name(self, tmp_path: Path) -> None:
+        conn = _open_raw_with_schema(
+            tmp_path / "cat.db",
+            collections=[("code__nexus-1-1__voyage-code-3__v1", "")],
+        )
+        try:
+            result = backfill_owner_id(conn)
+            conn.commit()
+            assert isinstance(result, BackfillResult)
+            assert result.updated_from_name == 1
+            assert result.updated_from_documents == 0
+            assert result.skipped_ambiguous == 0
+            assert result.skipped_unresolvable == 0
+            assert (
+                _row_owner_id(conn, "code__nexus-1-1__voyage-code-3__v1")
+                == "nexus-1-1"
+            )
+        finally:
+            conn.close()
+
+    def test_skips_already_populated_rows(self, tmp_path: Path) -> None:
+        """Idempotency contract: rows with non-empty owner_id are untouched."""
+        conn = _open_raw_with_schema(
+            tmp_path / "cat.db",
+            collections=[("code__nexus-1-1__voyage-code-3__v1", "already-set")],
+        )
+        try:
+            result = backfill_owner_id(conn)
+            conn.commit()
+            assert result.updated_from_name == 0
+            assert (
+                _row_owner_id(conn, "code__nexus-1-1__voyage-code-3__v1")
+                == "already-set"
+            )
+        finally:
+            conn.close()
+
+    def test_skips_legacy_two_segment_name_without_documents_fallback(
+        self, tmp_path: Path,
+    ) -> None:
+        """Legacy 2-segment names cannot be parsed; without the documents
+        fallback (auto-migration mode) they stay empty."""
+        conn = _open_raw_with_schema(
+            tmp_path / "cat.db",
+            collections=[("knowledge__delos", "")],
+        )
+        try:
+            result = backfill_owner_id(conn)
+            assert result.updated_from_name == 0
+            assert result.skipped_unresolvable == 1
+            assert _row_owner_id(conn, "knowledge__delos") == ""
+        finally:
+            conn.close()
+
+    def test_double_run_is_noop(self, tmp_path: Path) -> None:
+        conn = _open_raw_with_schema(
+            tmp_path / "cat.db",
+            collections=[("docs__art-1-2__voyage-context-3__v1", "")],
+        )
+        try:
+            backfill_owner_id(conn)
+            conn.commit()
+            second = backfill_owner_id(conn)
+            conn.commit()
+            assert second.updated_from_name == 0
+            assert second.updated_from_documents == 0
+        finally:
+            conn.close()
+
+
+class TestDocumentsFallback:
+    def test_recovers_owner_id_from_unique_document(self, tmp_path: Path) -> None:
+        """Legacy collection name (cannot parse) with one document
+        belonging to a known owner → owner_id derived from tumbler."""
+        conn = _open_raw_with_schema(
+            tmp_path / "cat.db",
+            collections=[("knowledge__delos", "")],
+            documents=[("3.4.1", "knowledge__delos")],
+        )
+        try:
+            result = backfill_owner_id(conn, include_documents_fallback=True)
+            conn.commit()
+            assert result.updated_from_documents == 1
+            assert _row_owner_id(conn, "knowledge__delos") == "3-4"
+        finally:
+            conn.close()
+
+    def test_skips_ambiguous_multi_owner_collection(self, tmp_path: Path) -> None:
+        """Documents from two distinct owners → ambiguous, skipped with
+        the row left empty for operator review."""
+        conn = _open_raw_with_schema(
+            tmp_path / "cat.db",
+            collections=[("knowledge__shared", "")],
+            documents=[
+                ("3.4.1", "knowledge__shared"),
+                ("4.5.1", "knowledge__shared"),
+            ],
+        )
+        try:
+            result = backfill_owner_id(conn, include_documents_fallback=True)
+            conn.commit()
+            assert result.skipped_ambiguous == 1
+            assert result.updated_from_documents == 0
+            assert _row_owner_id(conn, "knowledge__shared") == ""
+        finally:
+            conn.close()
+
+    def test_dry_run_reports_but_does_not_write(self, tmp_path: Path) -> None:
+        conn = _open_raw_with_schema(
+            tmp_path / "cat.db",
+            collections=[("code__nexus-1-1__voyage-code-3__v1", "")],
+        )
+        try:
+            result = backfill_owner_id(conn, dry_run=True)
+            conn.commit()
+            assert result.updated_from_name == 1
+            assert (
+                _row_owner_id(conn, "code__nexus-1-1__voyage-code-3__v1") == ""
+            )
+        finally:
+            conn.close()
+
+
+class TestAutoMigrationInStoreInit:
+    def test_construction_backfills_conformant_collections(
+        self, tmp_path: Path,
+    ) -> None:
+        """A fresh CatalogStore opens, applies the auto-migration, and
+        the conformant-named row gets its owner_id populated without an
+        explicit call.
+
+        This wires the migration end-to-end: the collections row exists
+        from the RDR-108 D2 auto-backfill (line 642 in catalog.py) with
+        owner_id='', and the RDR-137 Phase 1.5a follow-on pass populates
+        it.
+        """
+        db_path = tmp_path / "cat.db"
+        store = CatalogStore(db_path)
+        # Seed a document that triggers the existing RDR-108 auto-backfill
+        # of a collections row (with owner_id=''). The follow-on backfill
+        # should then populate it from the conformant name.
+        store._conn.execute(
+            "INSERT INTO documents "
+            "(tumbler, title, content_type, file_path, physical_collection, "
+            " chunk_count, indexed_at, metadata) VALUES "
+            "('5.7.3', 'doc', 'paper', '', "
+            "'code__example-5-7__voyage-code-3__v1', 0, '', '{}')"
+        )
+        store._conn.commit()
+        store._conn.close()
+
+        # Reopen — auto-backfill of collections row fires first, then
+        # the owner_id backfill follow-on populates it.
+        store = CatalogStore(db_path)
+        owner = _row_owner_id(
+            store._conn, "code__example-5-7__voyage-code-3__v1",
+        )
+        store._conn.close()
+        assert owner == "example-5-7"


### PR DESCRIPTION
## Summary

RDR-137 Phase 1.5a (bead \`nexus-tts0d.1\`). Populates the long-empty \`collections.owner_id\` column so the Phase 2 catalog-backed reader (\`nexus-tts0d.4\`) can join \`collections\` to \`owners\` instead of returning empty results.

Root cause of the \`docs__1-2188\` phantom-collection symptom (nexus-9iw41 Knowledge Map duplicate labels): the RDR-108 auto-backfill at \`CatalogStore.__init__\` synthesizes a \`collections\` row for every \`documents.physical_collection\` value not already in the projection — and writes \`owner_id=''\` for all of them.

## Two backfill paths

- **Conformant-name** (auto, idempotent, safe). Parses RDR-103 four-segment names \`<content_type>__<owner_id>__<model>__v<n>\` and extracts \`owner_id\` from the 2nd segment. Wired into \`CatalogStore.__init__\` as a follow-on pass after the existing RDR-108 D2 backfill.
- **Documents-table fallback** (opt-in, CLI-only). For legacy 2-segment names (\`knowledge__delos\`), derives \`owner_id\` from \`documents.tumbler\` via \`owner_segment_for_tumbler\`. Multi-owner ambiguity is skipped with a warning.

## CLI

\`nx catalog backfill-owner-id [--dry-run] [--from-documents]\` matches the safe-default convention of the other Phase 6 verbs (\`backfill-collections\`, \`migrate-fallback\`). Both flags default to the safe shape so the verb both reports and recovers maximum data when run without flags.

OQ-6 of the RDR resolved: both surfaces (auto + CLI) provided.

## Closes

Closes nexus-tts0d.1

## Test plan

- [x] \`tests/test_collections_owner_backfill.py\` — 8 tests covering conformant path, idempotency, legacy-name behaviour with and without fallback, ambiguity skip, dry-run, and end-to-end auto-migration.
- [x] \`uv run pytest tests/test_collections_owner_backfill.py tests/test_catalog_db.py tests/test_catalog_source_mtime.py tests/test_catalog.py tests/test_catalog_collection_for.py tests/test_catalog_collections.py tests/test_catalog_collections_rebuild.py tests/test_catalog_audit_membership.py tests/test_catalog_e2e.py tests/test_catalog_backfill_collections.py tests/test_catalog_cli.py tests/test_indexer_e2e.py tests/test_doctor_cmd.py\` — 449 / 449 green locally.
- [x] \`nx catalog backfill-owner-id --help\` resolves via the installed shim.