### PR TITLE
feat(repos): catalog-backed reader with DEBUG dual-read shim (RDR-137 Phase 2a)

### DIFF
--- a/src/nexus/repos.py
+++ b/src/nexus/repos.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-137 Phase 2a: catalog-backed repo reader with DEBUG dual-read shim.
+
+This module is the catalog-side replacement for the ``RepoRegistry.get``
+read surface. Consumers swap from
+``RepoRegistry(...).get(repo)`` to ``nexus.repos.read_dual(repo, cat=...)``
+in Phase 3 (one consumer per bead: ``nexus-tts0d.6`` to ``.13``);
+``read_dual`` returns the catalog answer when present, falls back to
+``RepoRegistry`` otherwise, and emits a structured DEBUG log line on
+fallback or disagreement so cutover-progress is observable in real
+time.
+
+The catalog-only path (``from_catalog``) is what Phase 4 will switch
+all consumers to once the auto-migration (Phase 1.5a, nexus-tts0d.1)
+has run on enough installs that the fallback rate is zero. At that
+point the shim downgrades to silent and Phase 5 deletes the registry.
+
+Per-decision references:
+
+- **A5 verdict** (gate critique 2026-05-28): DEBUG-then-WARN log
+  strategy modelled on ``catalog/catalog_docs.py:429-484
+  resolve_path``. Phase 1.5 backfill incompleteness produces
+  legitimate fallback fires during cutover; promotion to WARN
+  happens in Phase 2b (``nexus-tts0d.5``) once the threshold is hit.
+- **OQ-5 lock**: when the catalog has a ``knowledge__*`` collection
+  registered to a repo's owner, that is the canonical
+  ``docs_collection`` — the user's ``--corpus knowledge`` opt-in
+  is the most recent intent and the reader preserves it without
+  any schema change.
+
+Return shape mirrors ``RepoRegistry.get`` so consumer code can shift
+the import one PR at a time without changing field names.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:  # pragma: no cover — type-hint-only import
+    from nexus.catalog.catalog import Catalog
+
+_log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class RepoRecord:
+    """The shape ``RepoRegistry.get`` returns, frozen and typed.
+
+    All fields default to safe values so partial data (catalog-only,
+    no docs collection registered yet) still constructs a valid record.
+
+    ``collection`` is a back-compat alias for ``code_collection``;
+    every legacy caller that grabs ``rec.collection`` continues to
+    work.
+    """
+
+    name: str = ""
+    collection: str = ""
+    code_collection: str = ""
+    docs_collection: str = ""
+    rdr_collection: str = ""
+    head_hash: str = ""
+    status: str = "registered"
+
+
+def from_catalog(repo: Path, *, cat: Catalog) -> RepoRecord | None:
+    """Read a repo's collection set from the catalog.
+
+    Returns ``None`` when the catalog has no owner registered for
+    ``repo``. Returns a partial record (only fields the catalog can
+    answer for) otherwise.
+
+    OQ-5 lock: if multiple ``docs``-content-type collections are
+    registered to the owner, prefer a ``knowledge__*`` name over a
+    ``docs__*`` name — the user's ``--corpus knowledge`` opt-in is
+    the canonical intent.
+    """
+    from nexus.registry import _repo_identity_with_main  # noqa: PLC0415
+
+    name, repo_hash, _main_repo = _repo_identity_with_main(repo)
+    owner = cat.owner_for_repo(repo_hash)
+    if owner is None:
+        return None
+
+    owner_id = str(owner).replace(".", "-")
+    rows = cat._db.execute(
+        "SELECT name, content_type FROM collections WHERE owner_id = ?",
+        (owner_id,),
+    ).fetchall()
+
+    code = ""
+    docs = ""
+    rdr = ""
+    knowledge = ""
+    for col_name, content_type in rows:
+        if content_type == "code" and not code:
+            code = col_name
+        elif content_type == "rdr" and not rdr:
+            rdr = col_name
+        elif content_type == "docs" and not docs:
+            docs = col_name
+        elif content_type == "knowledge" and not knowledge:
+            knowledge = col_name
+
+    # OQ-5: knowledge wins over docs for the docs_collection slot.
+    docs_canonical = knowledge or docs
+
+    # Fetch head_hash from owners (RDR-137 Phase 1.5b column).
+    head_row = cat._db.execute(
+        "SELECT head_hash FROM owners WHERE tumbler_prefix = ?",
+        (str(owner),),
+    ).fetchone()
+    head_hash = (head_row[0] or "") if head_row else ""
+
+    return RepoRecord(
+        name=name,
+        collection=code,
+        code_collection=code,
+        docs_collection=docs_canonical,
+        rdr_collection=rdr,
+        head_hash=head_hash,
+        status="registered",
+    )
+
+
+def from_registry(
+    repo: Path, *, registry_path: Path,
+) -> RepoRecord | None:
+    """Read a repo's collection set from the legacy ``repos.json``.
+
+    Returns ``None`` when the registry file does not exist or has no
+    entry for ``repo``. The output shape is identical to
+    :func:`from_catalog` so the dual-read shim can compare them
+    field-for-field.
+    """
+    from nexus.registry import RepoRegistry  # noqa: PLC0415
+
+    if not registry_path.exists():
+        return None
+    reg = RepoRegistry(registry_path)
+    entry = reg.get(repo)
+    if entry is None:
+        return None
+    return RepoRecord(
+        name=entry.get("name", ""),
+        collection=entry.get("collection", ""),
+        code_collection=entry.get("code_collection", entry.get("collection", "")),
+        docs_collection=entry.get("docs_collection", ""),
+        rdr_collection=entry.get("rdr_collection", ""),
+        head_hash=entry.get("head_hash", ""),
+        status=entry.get("status", "registered"),
+    )
+
+
+def read_dual(
+    repo: Path, *, cat: Catalog, registry_path: Path,
+) -> RepoRecord | None:
+    """Dual-read shim: prefer catalog, fall back to registry, log both.
+
+    Resolution order:
+      1. Try ``from_catalog``. On hit, also probe the registry; if it
+         disagrees on any field, emit a DEBUG ``repos_read_dual_disagreement``
+         event naming the divergent fields. Return the catalog answer
+         regardless — catalog is authoritative.
+      2. On miss (catalog returns ``None``), call ``from_registry``.
+         If it returns something, emit a DEBUG ``repos_read_dual_fallback``
+         event. Return the registry answer.
+      3. On both-miss, return ``None``.
+
+    DEBUG level (per A5): Phase 1.5 backfill incompleteness produces
+    legitimate fallback fires during cutover; routine WARN would be
+    noise. Phase 2b (``nexus-tts0d.5``) promotes to WARN once
+    fallback rates settle.
+    """
+    cat_rec = from_catalog(repo, cat=cat)
+    reg_rec = from_registry(repo, registry_path=registry_path)
+
+    if cat_rec is not None:
+        if reg_rec is not None:
+            disagreements = _diff_fields(cat_rec, reg_rec)
+            if disagreements:
+                _log.debug(
+                    "repos_read_dual_disagreement",
+                    repo=str(repo),
+                    disagreements=disagreements,
+                )
+        return cat_rec
+
+    if reg_rec is not None:
+        _log.debug(
+            "repos_read_dual_fallback",
+            repo=str(repo),
+            fallback_branch="registry",
+            reason="catalog_owner_not_registered",
+        )
+        return reg_rec
+
+    return None
+
+
+def _diff_fields(a: RepoRecord, b: RepoRecord) -> dict[str, dict[str, str]]:
+    """Return field-by-field disagreements between two RepoRecords.
+
+    Empty fields on either side are NOT a disagreement (catalog may
+    have not registered the docs_collection yet for a code-only
+    indexed repo; that's a partial-record case, not a divergence).
+    """
+    fields = (
+        "name", "collection", "code_collection", "docs_collection",
+        "rdr_collection", "head_hash",
+    )
+    diffs: dict[str, dict[str, str]] = {}
+    for f in fields:
+        av = getattr(a, f)
+        bv = getattr(b, f)
+        if av and bv and av != bv:
+            diffs[f] = {"catalog": av, "registry": bv}
+    return diffs
+
+
+__all__ = (
+    "RepoRecord",
+    "from_catalog",
+    "from_registry",
+    "read_dual",
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -392,6 +392,10 @@ _MODE_LINT_EXCLUDE_FILES: frozenset[str] = frozenset({
     # ``code__nexus-1-1__voyage-code-3__v1``). Tests exercise pure
     # SQLite + string parsing; no Voyage call is ever made.
     "test_collections_owner_backfill.py",
+    # RDR-137 P2a (nexus-tts0d.4): same voyage-token-in-fixture pattern
+    # — the catalog-backed reader tests register synthetic conformant
+    # collection names and read them back; no Voyage call.
+    "test_repos_reader.py",
     "test_commands_dt.py",
     "test_corpus.py",
     "test_doc_indexer_hash_sync.py",

--- a/tests/test_repos_reader.py
+++ b/tests/test_repos_reader.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-137 Phase 2a: catalog-backed reader with DEBUG shim (nexus-tts0d.4).
+
+Single ``RepoRegistry``-shaped read API backed by the catalog so
+consumers can swap in one import-change PR each (Phase 3).
+
+Test coverage shape:
+- Pure unit: ``from_catalog`` returns the right fields without
+  touching ``repos.json`` at all.
+- ``--corpus knowledge`` prefix inference (OQ-5): when the catalog
+  has a ``knowledge__*`` collection registered to the owner, the
+  reader returns that as the canonical docs slot.
+- Empty-catalog fallback to ``RepoRegistry`` (the dual-read shim).
+- Shim disagreement logger fires at DEBUG when the two sources
+  diverge.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+import structlog
+from structlog.testing import capture_logs
+
+from nexus.catalog.catalog import Catalog
+from nexus.registry import RepoRegistry
+from nexus.repos import RepoRecord, from_catalog, from_registry, read_dual
+
+
+@pytest.fixture(autouse=True)
+def _enable_debug_logging():
+    """Temporarily allow DEBUG-level structlog events so capture_logs() sees them."""
+    structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG))
+    yield
+    structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.WARNING))
+
+
+@pytest.fixture
+def cat(tmp_path: Path) -> Catalog:
+    cat_dir = tmp_path / "catalog"
+    cat_dir.mkdir()
+    Catalog.init(cat_dir)
+    return Catalog(cat_dir, cat_dir / ".catalog.db")
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """Create a git repo so ``_repo_identity_with_main`` resolves cleanly."""
+    import subprocess
+    r = tmp_path / "myrepo"
+    r.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=r, check=True)
+    return r
+
+
+def _seed_owner_with_collections(
+    cat: Catalog,
+    repo: Path,
+    *,
+    code_coll: str | None = None,
+    docs_coll: str | None = None,
+) -> str:
+    """Register an owner + the collections it owns. Returns tumbler prefix.
+
+    register_collection is invoked with owner_id so the auto-migration
+    in CatalogStore.__init__ (Phase 1.5a from nexus-tts0d.1) is not
+    relied on for backfill mid-test.
+    """
+    owner = cat.ensure_owner_for_repo(repo)
+    owner_id = str(owner).replace(".", "-")
+    if code_coll:
+        cat.register_collection(
+            code_coll,
+            content_type="code",
+            owner_id=owner_id,
+            embedding_model="voyage-code-3",
+            model_version="1",
+        )
+    if docs_coll:
+        # Infer content_type from prefix for the test seed.
+        ct = docs_coll.split("__", 1)[0]
+        cat.register_collection(
+            docs_coll,
+            content_type=ct,
+            owner_id=owner_id,
+            embedding_model="voyage-context-3",
+            model_version="1",
+        )
+    return str(owner)
+
+
+class TestFromCatalog:
+    def test_returns_correct_fields_for_registered_repo(
+        self, cat: Catalog, repo: Path,
+    ) -> None:
+        owner = _seed_owner_with_collections(
+            cat, repo,
+            code_coll="code__myrepo-1-2__voyage-code-3__v1",
+            docs_coll="docs__myrepo-1-2__voyage-context-3__v1",
+        )
+        rec = from_catalog(repo, cat=cat)
+        assert isinstance(rec, RepoRecord)
+        assert rec.name == "myrepo"
+        assert rec.code_collection == "code__myrepo-1-2__voyage-code-3__v1"
+        assert rec.docs_collection == "docs__myrepo-1-2__voyage-context-3__v1"
+        # Back-compat alias.
+        assert rec.collection == rec.code_collection
+
+    def test_returns_none_when_repo_not_in_catalog(
+        self, cat: Catalog, repo: Path,
+    ) -> None:
+        assert from_catalog(repo, cat=cat) is None
+
+    def test_corpus_knowledge_prefix_inference_oq5(
+        self, cat: Catalog, repo: Path,
+    ) -> None:
+        """OQ-5 lock: when a repo's docs slot was indexed via
+        ``--corpus knowledge``, the catalog has a ``knowledge__*``
+        collection for the owner; the reader returns that as the
+        canonical docs_collection without any registry lookup.
+        """
+        _seed_owner_with_collections(
+            cat, repo,
+            code_coll="code__myrepo-1-2__voyage-code-3__v1",
+            docs_coll="knowledge__myrepo-1-2__voyage-context-3__v1",
+        )
+        rec = from_catalog(repo, cat=cat)
+        assert rec is not None
+        assert rec.docs_collection.startswith("knowledge__")
+
+    def test_prefers_knowledge_over_docs_when_both_exist(
+        self, cat: Catalog, repo: Path,
+    ) -> None:
+        """Mixed history: the user once indexed without --corpus, then
+        re-indexed with --corpus knowledge. Both collections exist for
+        the owner. The reader returns knowledge as the canonical docs
+        slot (the user's most recent intent)."""
+        owner_str = _seed_owner_with_collections(
+            cat, repo,
+            code_coll="code__myrepo-1-2__voyage-code-3__v1",
+        )
+        owner_id = owner_str.replace(".", "-")
+        cat.register_collection(
+            "docs__myrepo-1-2__voyage-context-3__v1",
+            content_type="docs", owner_id=owner_id,
+            embedding_model="voyage-context-3", model_version="1",
+        )
+        cat.register_collection(
+            "knowledge__myrepo-1-2__voyage-context-3__v1",
+            content_type="knowledge", owner_id=owner_id,
+            embedding_model="voyage-context-3", model_version="1",
+        )
+        rec = from_catalog(repo, cat=cat)
+        assert rec is not None
+        assert rec.docs_collection.startswith("knowledge__")
+
+
+class TestFromRegistry:
+    def test_round_trips_the_legacy_shape(
+        self, tmp_path: Path, repo: Path,
+    ) -> None:
+        reg = RepoRegistry(tmp_path / "repos.json")
+        reg.add(repo)
+        rec = from_registry(repo, registry_path=tmp_path / "repos.json")
+        assert rec is not None
+        assert rec.name == "myrepo"
+        # Legacy registry fields populated.
+        assert rec.collection
+        assert rec.code_collection == rec.collection
+        assert rec.docs_collection
+        assert rec.status == "registered"
+
+
+class TestReadDualShim:
+    def test_catalog_wins_when_present(
+        self, cat: Catalog, repo: Path, tmp_path: Path,
+    ) -> None:
+        """Catalog has the repo; registry is empty → catalog answer
+        returned, no fallback fire."""
+        _seed_owner_with_collections(
+            cat, repo,
+            code_coll="code__myrepo-1-2__voyage-code-3__v1",
+            docs_coll="docs__myrepo-1-2__voyage-context-3__v1",
+        )
+        rec = read_dual(
+            repo, cat=cat, registry_path=tmp_path / "missing.json",
+        )
+        assert rec is not None
+        assert rec.code_collection.startswith("code__myrepo-1-2__")
+
+    def test_registry_fallback_fires_when_catalog_empty(
+        self, cat: Catalog, repo: Path, tmp_path: Path,
+    ) -> None:
+        """Catalog has no owner for the repo → falls back to registry
+        and emits a DEBUG event."""
+        reg = RepoRegistry(tmp_path / "repos.json")
+        reg.add(repo)
+        with capture_logs() as cap:
+            rec = read_dual(
+                repo, cat=cat, registry_path=tmp_path / "repos.json",
+            )
+        assert rec is not None
+        assert rec.name == "myrepo"
+        assert any(
+            entry.get("event") == "repos_read_dual_fallback"
+            and entry.get("fallback_branch") == "registry"
+            for entry in cap
+        )
+
+    def test_disagreement_logged_when_catalog_and_registry_differ(
+        self, cat: Catalog, repo: Path, tmp_path: Path,
+    ) -> None:
+        """Catalog and registry both have the repo but disagree on the
+        code_collection — emit the disagreement log line at DEBUG."""
+        _seed_owner_with_collections(
+            cat, repo,
+            code_coll="code__myrepo-1-2__voyage-code-3__v1",
+            docs_coll="docs__myrepo-1-2__voyage-context-3__v1",
+        )
+        # Registry says a DIFFERENT code_collection (legacy hash-based
+        # name) — the kind of drift RDR-137 was filed to eliminate.
+        reg_path = tmp_path / "repos.json"
+        reg_path.write_text(json.dumps({
+            "repos": {
+                str(repo): {
+                    "name": "myrepo",
+                    "collection": "code__myrepo-FAKE",
+                    "code_collection": "code__myrepo-FAKE",
+                    "docs_collection": "docs__myrepo-FAKE",
+                    "head_hash": "",
+                    "status": "registered",
+                },
+            },
+        }))
+        with capture_logs() as cap:
+            rec = read_dual(
+                repo, cat=cat, registry_path=reg_path,
+            )
+        # Catalog wins.
+        assert rec is not None
+        assert rec.code_collection == "code__myrepo-1-2__voyage-code-3__v1"
+        # Disagreement event fired and names the divergent fields.
+        disagree_events = [
+            e for e in cap
+            if e.get("event") == "repos_read_dual_disagreement"
+        ]
+        assert len(disagree_events) == 1
+        diffs = disagree_events[0]["disagreements"]
+        assert "code_collection" in diffs
+        assert diffs["code_collection"]["catalog"] == (
+            "code__myrepo-1-2__voyage-code-3__v1"
+        )
+        assert diffs["code_collection"]["registry"] == "code__myrepo-FAKE"


### PR DESCRIPTION
## Summary

RDR-137 Phase 2a (bead \`nexus-tts0d.4\`). New \`nexus.repos\` module with the catalog-backed read API + DEBUG dual-read shim. This is the foundation Phase 3 consumer cutover beads (\`.6\` - \`.13\`) build on: each consumer replaces its \`RepoRegistry(...).get(repo)\` call with \`read_dual(repo, cat=cat, registry_path=...)\` in one PR.

## Three entry points

- \`from_catalog(repo, *, cat)\` — pure catalog read. Returns \`None\` on miss, \`RepoRecord\` on hit. Honours **OQ-5** (\`knowledge__\` collections win over \`docs__\` in the \`docs_collection\` slot).
- \`from_registry(repo, *, registry_path)\` — legacy \`repos.json\` read with the same return shape so the shim can compare field-for-field.
- \`read_dual(repo, *, cat, registry_path)\` — the cutover shim. Catalog is authoritative; emits two DEBUG structured events:
  - \`repos_read_dual_disagreement\`: both sources have the repo but disagree on at least one field. Payload includes a \`disagreements\` dict naming the divergent fields with both \`catalog\` and \`registry\` values.
  - \`repos_read_dual_fallback\`: catalog miss, registry hit. Names the fallback branch + reason.

## Why DEBUG

Per **A5 verdict** (gate critique 2026-05-28). Phase 1.5 backfill incompleteness will produce legitimate fallback fires during cutover; routine WARN would be noise. Phase 2b (\`nexus-tts0d.5\`) promotes to WARN once fallback rates settle. Template mirrors \`catalog/catalog_docs.py:429-484\` \`resolve_path\`.

## Why this shape

Same field shape as \`RepoRegistry.get(repo)\` (frozen dataclass with name / collection / code_collection / docs_collection / rdr_collection / head_hash / status). Consumer cutover is one import change + s/\`reg.get(repo)\`/\`read_dual(repo, cat=cat, registry_path=...)\`/ per PR.

## Closes

Closes nexus-tts0d.4

## Test plan

- [x] \`tests/test_repos_reader.py\` — 8 tests covering catalog-only path, OQ-5 inference, registry round-trip, shim catalog-wins path, fallback DEBUG event, disagreement DEBUG event with payload assertions.
- [x] Regression sweep: 267 / 267 green across repos_reader / mode_declarations / collections_owner_backfill / catalog_owners_head_hash / catalog_db / catalog / catalog_collection_for / registry / catalog_e2e.
- [x] \`test_repos_reader.py\` added to \`_MODE_LINT_EXCLUDE_FILES\` (synthetic voyage tokens in collection-name fixtures, no Voyage calls — same pattern as \`test_collections_owner_backfill.py\`).