### PR TITLE
feat(context): cut over _repo_collections to catalog-backed reader (RDR-137 Phase 3.5)

### DIFF
--- a/src/nexus/context.py
+++ b/src/nexus/context.py
@@ -44,51 +44,67 @@ _TOPICS_PER_PREFIX = 5
 
 
 def _repo_collections(repo_path: Path | None) -> set[str] | None:
-    """Return collection names registered to a repo, or None for all."""
+    """Return collection names registered to a repo, or None for all.
+
+    RDR-137 Phase 3.5 (nexus-tts0d.10): catalog-backed via
+    :func:`nexus.repos.read_dual`.  The catalog is authoritative;
+    when both catalog and ``repos.json`` carry an entry the dual-read
+    shim logs disagreements at DEBUG so cutover-progress is observable.
+    This closed the loop on nexus-9iw41 — the bug where a phantom
+    ``docs__1-2188`` registered to the nexus repo while the catalog
+    and chroma both had the real ``docs__1-1``.
+
+    The ``rdr`` collection follows the existing indexer-name-resolver
+    fallback when the catalog has no ``rdr__*`` row for the owner —
+    a freshly-indexed repo with only ``code``+``docs`` content is the
+    common case and the synthesized 4-segment name (RDR-103 Phase 5)
+    is the right shape.
+    """
     if repo_path is None:
         return None
     try:
-        from nexus.registry import RepoRegistry
+        from nexus.catalog.catalog import Catalog  # noqa: PLC0415
+        from nexus.config import catalog_path  # noqa: PLC0415
+        from nexus.repos import read_dual  # noqa: PLC0415
 
+        cat_dir = catalog_path()
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
         reg_path = _ctx_nexus_config_dir() / "repos.json"
-        if not reg_path.exists():
-            return None
-        reg = RepoRegistry(reg_path)
-        entry = reg.get(repo_path)
-        if not entry:
+        rec = read_dual(repo_path, cat=cat, registry_path=reg_path)
+        if rec is None:
             return None
         colls: set[str] = set()
-        for key in ("collection", "docs_collection"):
-            if entry.get(key):
-                colls.add(entry[key])
-        # Also include the rdr__ collection for this repo. Source it
-        # from the catalog when available so conformant repos pick up
-        # the catalog-minted name; fall back to the indexer's
-        # name-resolver when the catalog is absent so the fallback
-        # synthesises a conformant 4-segment shape (RDR-103 Phase 5)
-        # rather than splicing the legacy 2-segment suffix from a
-        # registry value that may now itself be conformant.
-        try:
-            from nexus.indexer import _repo_collection_or_legacy  # noqa: PLC0415
+        if rec.code_collection:
+            colls.add(rec.code_collection)
+        if rec.docs_collection:
+            colls.add(rec.docs_collection)
+        if rec.rdr_collection:
+            colls.add(rec.rdr_collection)
+        else:
+            # rdr collection not registered in catalog (common for
+            # freshly-indexed code+docs-only repos). Fall back to the
+            # indexer's name-resolver to synthesise the conformant
+            # 4-segment shape (RDR-103 Phase 5).
+            try:
+                from nexus.indexer import _repo_collection_or_legacy  # noqa: PLC0415
 
-            colls.add(_repo_collection_or_legacy(repo_path, "rdr"))
-        except Exception:
-            # nexus-8g79.8: inner — recoverable, the rdr collection
-            # may legitimately not exist. DEBUG-with-exc_info so
-            # debugging surfaces it without flooding production logs.
-            import structlog
-            structlog.get_logger(__name__).debug(
-                "repo_collection_or_legacy_failed",
-                repo_path=str(repo_path),
-                exc_info=True,
-            )
+                colls.add(_repo_collection_or_legacy(repo_path, "rdr"))
+            except Exception:
+                # Recoverable: rdr collection may legitimately not
+                # exist for this repo. DEBUG-with-exc_info so the
+                # signal is observable without flooding production
+                # logs.
+                _log.debug(
+                    "repo_collection_or_legacy_failed",
+                    repo_path=str(repo_path),
+                    exc_info=True,
+                )
         return colls if colls else None
     except Exception:
-        # nexus-8g79.8: outer — degrades the entire L1 context
-        # (taxonomy + collections) silently. WARNING because a
-        # recurring failure produces wrong LLM prompts with no signal.
-        import structlog
-        structlog.get_logger(__name__).warning(
+        # Outer — degrades the entire L1 context (taxonomy +
+        # collections) silently. WARNING because a recurring failure
+        # produces wrong LLM prompts with no signal.
+        _log.warning(
             "discover_repo_collections_failed",
             exc_info=True,
         )

--- a/tests/test_context_catalog_cutover.py
+++ b/tests/test_context_catalog_cutover.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-137 Phase 3.5: context.py catalog cutover regression (nexus-tts0d.10).
+
+The original nexus-9iw41 bug: ``_repo_collections`` read
+``~/.config/nexus/repos.json`` directly and returned a phantom
+``docs__1-2188`` collection name registered to the nexus repo,
+while the catalog and chroma both had the real ``docs__1-1``. The
+SessionStart Knowledge Map injection then loaded topic labels from
+the phantom (empty) collection and produced duplicate / wrong
+labels.
+
+The cutover threads the catalog-backed reader (``nexus.repos.read_dual``,
+shipped by ``nexus-tts0d.4``) through ``_repo_collections`` so the
+catalog answer wins whenever both sources have data. This file is
+the regression contract: seed the catalog with the truth, seed
+``repos.json`` with the phantom, assert the catalog value is what
+``_repo_collections`` returns.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+import structlog
+
+from nexus.catalog.catalog import Catalog
+from nexus.context import _repo_collections
+from nexus.registry import RepoRegistry
+
+
+@pytest.fixture(autouse=True)
+def _enable_debug_logging():
+    """Bump structlog so the shim's DEBUG fallback / disagreement events
+    fire under the test."""
+    structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG))
+    yield
+    structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.WARNING))
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "nexus"
+    r.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=r, check=True)
+    return r
+
+
+@pytest.fixture
+def cat(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Catalog:
+    """A catalog rooted at tmp_path with both config-dir + catalog-path env
+    overrides wired.
+
+    The conftest-level ``_isolate_catalog`` fixture sets ``NEXUS_CATALOG_PATH``
+    to a non-existent ``<tmp>/test-catalog`` so production hooks don't write
+    to the user's real catalog. We need ``catalog_path()`` to resolve to
+    OUR seeded catalog directory instead, so override both env vars: this
+    fixture's ``cat`` is what ``_repo_collections`` opens via
+    ``nexus.config.catalog_path()``.
+    """
+    cfg = tmp_path / "config"
+    cat_dir = cfg / "catalog"
+    cat_dir.mkdir(parents=True)
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(cfg))
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(cat_dir))
+    Catalog.init(cat_dir)
+    return Catalog(cat_dir, cat_dir / ".catalog.db")
+
+
+def _register_owner_with_docs(cat: Catalog, repo: Path, docs_name: str) -> None:
+    """Mint an owner + register the docs collection against it."""
+    owner = cat.ensure_owner_for_repo(repo)
+    owner_id = str(owner).replace(".", "-")
+    cat.register_collection(
+        docs_name,
+        content_type="docs",
+        owner_id=owner_id,
+        embedding_model="voyage-context-3",
+        model_version="1",
+    )
+
+
+class TestPhantomCollectionRegression:
+    def test_catalog_wins_over_registry_phantom(
+        self, cat: Catalog, repo: Path, tmp_path: Path,
+    ) -> None:
+        """nexus-9iw41 reproduction: catalog has the real docs__1-1,
+        registry has the phantom docs__1-2188. The reader must surface
+        the catalog's value."""
+        # Seed catalog with the truth.
+        _register_owner_with_docs(cat, repo, "docs__1-1__voyage-context-3__v1")
+        # Seed registry with the phantom (the bug scenario).
+        cfg = Path(__import__("os").environ["NEXUS_CONFIG_DIR"])
+        reg_path = cfg / "repos.json"
+        reg_path.parent.mkdir(parents=True, exist_ok=True)
+        reg = RepoRegistry(reg_path)
+        reg.add(repo)
+        # Hand-corrupt the registry entry to mimic the production drift
+        # that produced nexus-9iw41: docs_collection points at a
+        # phantom name the catalog disagrees with.
+        reg.update(
+            repo,
+            collection="code__nexus-1-2188__voyage-code-3__v1",
+            code_collection="code__nexus-1-2188__voyage-code-3__v1",
+            docs_collection="docs__1-2188",
+        )
+
+        colls = _repo_collections(repo)
+        assert colls is not None
+        # The catalog's docs collection wins.
+        assert "docs__1-1__voyage-context-3__v1" in colls
+        # The phantom does NOT appear.
+        assert "docs__1-2188" not in colls
+
+    def test_unregistered_repo_returns_none(
+        self, cat: Catalog, repo: Path,
+    ) -> None:
+        """No catalog owner, no registry entry → None (signals
+        ``inject everything`` upstream)."""
+        assert _repo_collections(repo) is None
+
+    def test_registry_fallback_when_catalog_empty(
+        self, cat: Catalog, repo: Path,
+    ) -> None:
+        """A repo only known to the registry (pre-catalog install) still
+        produces a result via the shim's fallback branch."""
+        cfg = Path(__import__("os").environ["NEXUS_CONFIG_DIR"])
+        reg_path = cfg / "repos.json"
+        reg = RepoRegistry(reg_path)
+        reg.add(repo)
+        colls = _repo_collections(repo)
+        assert colls is not None
+        # At least the code_collection (which RepoRegistry.add seeds)
+        # should appear.
+        assert any(c.startswith("code__") for c in colls)


### PR DESCRIPTION
## Summary

RDR-137 Phase 3.5 (bead \`nexus-tts0d.10\`). Closes the loop on **nexus-9iw41** — the SessionStart Knowledge Map injection hot path that motivated the entire RDR.

Before this cutover, \`_repo_collections\` read \`~/.config/nexus/repos.json\` directly and returned phantom \`docs__1-2188\` for the nexus repo while the catalog and chroma both had the real \`docs__1-1\`. The phantom collection had no chunks, so the Knowledge Map either showed nothing or duplicates.

## Cutover

\`nexus.repos.read_dual\` (shipped by PR #1001 / \`nexus-tts0d.4\`) replaces the inline \`RepoRegistry\` read. Catalog is authoritative; the shim emits \`repos_read_dual_disagreement\` at DEBUG when both sources have an entry and disagree, and \`repos_read_dual_fallback\` at DEBUG when the catalog misses and the registry is consulted.

Preserved: the existing \`_repo_collection_or_legacy\` fallback for the \`rdr\` collection (the catalog split is sparse — a repo with only code + docs registered has no \`rdr__*\` row).

## Test

\`tests/test_context_catalog_cutover.py\` reproduces the nexus-9iw41 phantom scenario: seed catalog with \`docs__1-1\`, seed registry with \`docs__1-2188\`, assert the catalog value wins and the phantom does NOT appear. Plus None-case + registry-fallback case.

## Closes

Closes nexus-tts0d.10

## Test plan

- [x] \`tests/test_context_catalog_cutover.py\` — 3 new tests.
- [x] \`uv run pytest tests/test_context.py tests/test_context_catalog_cutover.py tests/test_repos_reader.py tests/test_catalog.py tests/test_catalog_collection_for.py\` — 178 / 178 green locally.