### PR TITLE
feat(catalog): excise RepoRegistry fallback from resolve_path (RDR-137 Phase 3.6, OQ-11)

### DIFF
--- a/src/nexus/catalog/catalog_docs.py
+++ b/src/nexus/catalog/catalog_docs.py
@@ -32,16 +32,15 @@ from nexus.corpus import (
     LOCAL_EMBEDDING_MODELS,
     effective_embedding_model_for_writes,
 )
-from nexus.registry import RepoRegistry, _repo_identity
+from nexus.registry import _repo_identity
 
-# ``CatalogEntry`` and ``_default_registry_path`` are imported
-# lazily inside the methods that need them. ``catalog.py`` imports
-# this module from inside ``Catalog.__init__`` (instance time,
-# after ``catalog`` finishes loading), so a top-level
-# ``from nexus.catalog.catalog import ...`` would also work — but
-# the lazy form keeps the import direction one-way
-# (catalog → catalog_docs only at instantiation), which makes the
-# dependency easier to read.
+# ``CatalogEntry`` is imported lazily inside the methods that need
+# it. ``catalog.py`` imports this module from inside
+# ``Catalog.__init__`` (instance time, after ``catalog`` finishes
+# loading), so a top-level ``from nexus.catalog.catalog import ...``
+# would also work — but the lazy form keeps the import direction
+# one-way (catalog → catalog_docs only at instantiation), which
+# makes the dependency easier to read.
 if TYPE_CHECKING:
     from nexus.catalog.catalog import Catalog, CatalogEntry
 
@@ -432,18 +431,23 @@ class _DocumentOps:
         Resolution order:
         1. Look up entry via cat.resolve(tumbler)
         2. If entry not found: return None
-        3. Find owner: tumbler.owner_address() -> str, look up in JSONL
+        3. Find owner: tumbler.owner_address() -> str, look up in SQLite
         4. If owner not found or owner.owner_type == "curator": return None
         5. If entry.file_path is already absolute: return Path(entry.file_path)
         6. If owner.repo_root is non-empty: return Path(owner.repo_root) / entry.file_path
-        7. Fallback: iterate registry to find path matching owner.repo_hash
-        8. If fallback found: return Path(repo_path) / entry.file_path
-        9. Otherwise: return None
+        7. Otherwise: log ``catalog_resolve_path_legacy_owner_missing_repo_root``
+           at DEBUG and return None.
+
+        RDR-137 Phase 3.6 (nexus-tts0d.11, OQ-11): the previous
+        legacy-registry fallback (iterate registry rows matching
+        repo_hash) is removed. Post-nexus-nzyrh every freshly-registered owner
+        gets a canonical main_repo path in ``repo_root``; any
+        ``repo_root=''`` row in the live catalog is a pre-RDR-137
+        artifact that the next ``nx index repo`` run on the same
+        repo will heal. The DEBUG event surfaces which owners still
+        need that healing pass.
         """
         cat = self._cat
-        import hashlib
-
-        from nexus.registry import RepoRegistry
 
         entry = cat.resolve(tumbler)
         if not entry:
@@ -472,17 +476,16 @@ class _DocumentOps:
         if repo_root:
             return Path(repo_root) / entry.file_path
 
-        # Fallback: find repo_root from registry by matching repo_hash
-        if repo_hash:
-            from nexus.catalog.catalog import _default_registry_path
-            registry_path = _default_registry_path()
-            if registry_path.exists():
-                reg = RepoRegistry(registry_path)
-                for path_str in reg.all_info():
-                    path_hash = hashlib.sha256(path_str.encode()).hexdigest()[:8]
-                    if path_hash == repo_hash:
-                        return Path(path_str) / entry.file_path
-
+        # Post-RDR-137 P3.6: no registry fallback. Legacy owners with
+        # empty repo_root cannot be resolved without a re-index pass.
+        _log.debug(
+            "catalog_resolve_path_legacy_owner_missing_repo_root",
+            tumbler=str(tumbler),
+            owner_prefix=owner_prefix,
+            repo_hash=repo_hash,
+            file_path=entry.file_path,
+            hint="re-run 'nx index repo' on the source repo to backfill repo_root",
+        )
         return None
 
     def descendants(self, prefix: str) -> list[dict]:

--- a/tests/test_catalog_path.py
+++ b/tests/test_catalog_path.py
@@ -163,29 +163,68 @@ class TestResolvePath:
         ):
             assert cat.resolve_path(tumbler) is None
 
-    def test_resolve_path_fallback_to_registry(self, tmp_path: Path) -> None:
-        """repo_root empty but registry has matching hash -> resolve via registry."""
+    def test_resolve_path_empty_repo_root_returns_none_no_registry_consult(
+        self, tmp_path: Path,
+    ) -> None:
+        """RDR-137 Phase 3.6 (nexus-tts0d.11, OQ-11): legacy owners with
+        empty ``repo_root`` no longer fall back to ``repos.json``. The
+        previous RepoRegistry-iteration path is excised; the function
+        now returns ``None`` and emits a DEBUG event so the legacy
+        owner is observable for re-index.
+        """
+        import logging
+        import structlog
+        from structlog.testing import capture_logs
+
         repo_dir = tmp_path / "myrepo"
         repo_dir.mkdir()
         repo_hash = hashlib.sha256(str(repo_dir).encode()).hexdigest()[:8]
 
-        db_path = tmp_path / "db"
-        db_path.mkdir()
-        registry_data = {
-            "repos": {str(repo_dir): {"name": "myrepo", "collection": "code__myrepo"}},
-        }
-        (db_path / "repos.json").write_text(json.dumps(registry_data))
-
-        cat = self._make_catalog(tmp_path)
-        owner = cat.register_owner("test-repo", "repo", repo_hash=repo_hash)
-        tumbler = cat.register(
-            owner, "test.py", content_type="code", file_path="src/test.py",
+        # Bump structlog so the DEBUG event fires under capture_logs.
+        structlog.configure(
+            wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG),
         )
-        with patch(
-            "nexus.catalog.catalog._default_registry_path",
-            return_value=db_path / "repos.json",
-        ):
-            assert cat.resolve_path(tumbler) == repo_dir / "src" / "test.py"
+        try:
+            cat = self._make_catalog(tmp_path)
+            owner = cat.register_owner("test-repo", "repo", repo_hash=repo_hash)
+            tumbler = cat.register(
+                owner, "test.py", content_type="code", file_path="src/test.py",
+            )
+            with capture_logs() as cap:
+                result = cat.resolve_path(tumbler)
+            assert result is None
+            # DEBUG event names the owner and gives a hint.
+            assert any(
+                e.get("event") == "catalog_resolve_path_legacy_owner_missing_repo_root"
+                and e.get("repo_hash") == repo_hash
+                for e in cap
+            )
+        finally:
+            structlog.configure(
+                wrapper_class=structlog.make_filtering_bound_logger(
+                    logging.WARNING,
+                ),
+            )
+
+    def test_resolve_path_no_RepoRegistry_import_in_module(self) -> None:
+        """RDR-137 Phase 3.6 OQ-11 acceptance gate: ``RepoRegistry`` is
+        no longer imported in ``catalog_docs.py`` after this cutover.
+
+        Note: ``_repo_identity`` (a pure helper, not registry-coupled)
+        stays for now — it migrates with the other helpers in
+        ``nexus-tts0d.21`` (relocation to ``nexus.repo_identity``).
+        Phase 5's lint guard fires on ``RepoRegistry`` and
+        ``repos.json`` re-introduction, not on the helpers.
+        """
+        from pathlib import Path as _Path
+
+        src = _Path(__file__).resolve().parent.parent / (
+            "src/nexus/catalog/catalog_docs.py"
+        )
+        text = src.read_text()
+        assert "RepoRegistry" not in text
+        assert "_default_registry_path" not in text
+        assert "repos.json" not in text
 
 
 # ── make_relative (nexus-1p4g.3) ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

RDR-137 Phase 3.6 (bead \`nexus-tts0d.11\`, OQ-11 closeout dependency). \`Catalog._DocumentOps.resolve_path\` no longer consults \`repos.json\` when an owner row has empty \`repo_root\`.

## Why now

Post-nexus-nzyrh + Phase 1.5b every freshly-registered owner gets the canonical \`main_repo\` path in \`repo_root\`. Any owner with \`repo_root=''\` in a live catalog is a pre-RDR-137 artifact that the next \`nx index repo\` on the same repo heals. The new DEBUG event \`catalog_resolve_path_legacy_owner_missing_repo_root\` surfaces those owners so operators can target a re-index.

## Module-level changes

- Drop the top-level \`from nexus.registry import RepoRegistry\` import. \`_repo_identity\` (pure helper) stays — migrates with the other helpers in \`nexus-tts0d.21\`.
- Clean up the comment that mentioned \`_default_registry_path\`.

## Tests

- \`test_resolve_path_fallback_to_registry\` → renamed and rewritten as \`test_resolve_path_empty_repo_root_returns_none_no_registry_consult\` (asserts None + DEBUG event payload).
- New \`test_resolve_path_no_RepoRegistry_import_in_module\` greps the source for \`RepoRegistry\`, \`_default_registry_path\`, \`repos.json\` — all must be absent post-cutover. Phase 5's CI lint guard will enforce this globally; this test pins it locally so a regression surfaces before CI.

## Acceptance

\`grep RepoRegistry src/nexus/catalog/catalog_docs.py\` returns zero matches.

## Closes

Closes nexus-tts0d.11

## Test plan

- [x] 216 / 216 green across test_catalog_path / test_catalog / test_catalog_e2e / test_catalog_collection_for / test_repos_reader / test_worktree_repo_root_contamination.