### PR TITLE
feat(health): cut over git-hook check to catalog-backed reader (RDR-137 Phase 3.1)

### DIFF
--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -495,9 +495,9 @@ def _check_git_hooks() -> list[HealthResult]:
     from nexus import _git_hooks_meta as _ghm
     from nexus._git_hooks_meta import SENTINEL_BEGIN, SENTINEL_END
     _effective_hooks_dir = _ghm.effective_hooks_dir
-    from nexus.registry import RepoRegistry
-
-    from nexus.config import nexus_config_dir
+    from nexus.catalog.catalog import Catalog
+    from nexus.config import catalog_path, nexus_config_dir
+    from nexus.repos import list_repos_dual
 
     results: list[HealthResult] = []
     hook_names = ("post-commit", "post-merge", "post-rewrite")
@@ -529,9 +529,14 @@ def _check_git_hooks() -> list[HealthResult]:
 
     canonical = _canonical_stanza_body()
 
+    # RDR-137 Phase 3.1 (nexus-tts0d.6): catalog-backed enumeration with
+    # legacy ``repos.json`` fallback via the dual-read shim. Catalog
+    # paths come from ``owners WHERE owner_type='repo'``; the registry
+    # provides legacy installs that have not yet been re-indexed.
     try:
-        reg = RepoRegistry(registry_path)
-        repos = reg.all()
+        cat_dir = catalog_path()
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+        repos = list_repos_dual(cat=cat, registry_path=registry_path)
     except Exception as exc:
         _log.warning("doctor_registry_load_failed", error=str(exc))
         repos = []

--- a/src/nexus/repos.py
+++ b/src/nexus/repos.py
@@ -222,9 +222,55 @@ def _diff_fields(a: RepoRecord, b: RepoRecord) -> dict[str, dict[str, str]]:
     return diffs
 
 
+def list_repos_dual(
+    *, cat: Catalog, registry_path: Path,
+) -> list[str]:
+    """Enumerate every known repo path (catalog ∪ registry), sorted.
+
+    Catalog source: ``owners WHERE owner_type='repo'`` projected via
+    ``repo_root``.  Registry source: ``RepoRegistry.all()``.  Union is
+    a set merge (deterministic via ``sorted``); paths the catalog
+    knows about that the registry does NOT (or vice versa) are
+    surfaced via a single DEBUG event so cutover-progress is observable
+    without one source overriding the other.
+
+    Used by ``health.py``'s git-hook check and by any other consumer
+    that needs to iterate every registered repo.  When ``registry_path``
+    does not exist (post-Phase-5 install), returns the catalog set
+    alone; the DEBUG event is suppressed so the steady state is silent.
+    """
+    cat_paths: set[str] = set()
+    rows = cat._db.execute(
+        "SELECT repo_root FROM owners "
+        "WHERE owner_type = 'repo' AND repo_root != ''"
+    ).fetchall()
+    for (rr,) in rows:
+        if rr:
+            cat_paths.add(rr)
+
+    reg_paths: set[str] = set()
+    if registry_path.exists():
+        from nexus.registry import RepoRegistry  # noqa: PLC0415
+        reg = RepoRegistry(registry_path)
+        reg_paths = set(reg.all())
+
+    only_cat = cat_paths - reg_paths
+    only_reg = reg_paths - cat_paths
+    if registry_path.exists() and (only_cat or only_reg):
+        _log.debug(
+            "repos_list_dual_disagreement",
+            only_catalog=sorted(only_cat),
+            only_registry=sorted(only_reg),
+            both_count=len(cat_paths & reg_paths),
+        )
+
+    return sorted(cat_paths | reg_paths)
+
+
 __all__ = (
     "RepoRecord",
     "from_catalog",
     "from_registry",
+    "list_repos_dual",
     "read_dual",
 )

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -44,9 +44,24 @@ def mock_reg():
 
 def _invoke(runner, mock_reg, *, cred="sk-key", which="/usr/bin/tool",
             cloud_client=None, extra_patches=None):
+    # RDR-137 Phase 3.1 (nexus-tts0d.6): health.py now reads repos via
+    # nexus.repos.list_repos_dual instead of RepoRegistry directly.
+    # The legacy RepoRegistry patch stays for whatever doctor sub-checks
+    # still reach it (e.g. the integrity path); the new patch wires the
+    # catalog-backed reader to the same mock so existing test
+    # expectations (``/some/repo`` appears in hook output) keep
+    # holding. Once the doctor.py cutover (nexus-tts0d.12) lands the
+    # legacy patch becomes ineffective and can drop.
     patches = [
         patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.registry.RepoRegistry", return_value=mock_reg),
+        # Patch at definition site (nexus.repos) because health.py
+        # imports lazily inside _check_hooks — no module-level
+        # symbol exists to patch on nexus.health itself.
+        patch(
+            "nexus.repos.list_repos_dual",
+            side_effect=lambda **_: list(mock_reg.all()),
+        ),
     ]
     if callable(cred):
         patches.append(patch("nexus.config.get_credential",

--- a/tests/test_repos_reader.py
+++ b/tests/test_repos_reader.py
@@ -27,7 +27,13 @@ from structlog.testing import capture_logs
 
 from nexus.catalog.catalog import Catalog
 from nexus.registry import RepoRegistry
-from nexus.repos import RepoRecord, from_catalog, from_registry, read_dual
+from nexus.repos import (
+    RepoRecord,
+    from_catalog,
+    from_registry,
+    list_repos_dual,
+    read_dual,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -254,3 +260,66 @@ class TestReadDualShim:
             "code__myrepo-1-2__voyage-code-3__v1"
         )
         assert diffs["code_collection"]["registry"] == "code__myrepo-FAKE"
+
+
+class TestListReposDual:
+    def test_returns_catalog_only_paths_when_no_registry(
+        self, cat: Catalog, repo: Path, tmp_path: Path,
+    ) -> None:
+        cat.ensure_owner_for_repo(repo)
+        paths = list_repos_dual(
+            cat=cat, registry_path=tmp_path / "absent.json",
+        )
+        assert paths == [str(repo)]
+
+    def test_unions_catalog_and_registry(
+        self, cat: Catalog, repo: Path, tmp_path: Path,
+    ) -> None:
+        """Catalog has repo A, registry has repo B; result is sorted union."""
+        cat.ensure_owner_for_repo(repo)
+        other = tmp_path / "other"
+        other.mkdir()
+        import subprocess
+        subprocess.run(["git", "init", "-q"], cwd=other, check=True)
+        reg_path = tmp_path / "repos.json"
+        reg = RepoRegistry(reg_path)
+        reg.add(other)
+
+        paths = list_repos_dual(cat=cat, registry_path=reg_path)
+        assert str(repo) in paths
+        assert str(other) in paths
+        assert paths == sorted(paths)
+
+    def test_disagreement_event_fires_on_set_difference(
+        self, cat: Catalog, repo: Path, tmp_path: Path,
+    ) -> None:
+        cat.ensure_owner_for_repo(repo)
+        other = tmp_path / "registry_only"
+        other.mkdir()
+        import subprocess
+        subprocess.run(["git", "init", "-q"], cwd=other, check=True)
+        reg_path = tmp_path / "repos.json"
+        reg = RepoRegistry(reg_path)
+        reg.add(other)
+
+        with capture_logs() as cap:
+            list_repos_dual(cat=cat, registry_path=reg_path)
+
+        disagree = [
+            e for e in cap if e.get("event") == "repos_list_dual_disagreement"
+        ]
+        assert len(disagree) == 1
+        assert str(repo) in disagree[0]["only_catalog"]
+        assert str(other) in disagree[0]["only_registry"]
+
+    def test_no_disagreement_event_when_registry_absent(
+        self, cat: Catalog, repo: Path, tmp_path: Path,
+    ) -> None:
+        """Steady-state post-Phase-5 install: registry doesn't exist,
+        no DEBUG noise."""
+        cat.ensure_owner_for_repo(repo)
+        with capture_logs() as cap:
+            list_repos_dual(cat=cat, registry_path=tmp_path / "absent.json")
+        assert not any(
+            e.get("event") == "repos_list_dual_disagreement" for e in cap
+        )


### PR DESCRIPTION
## Summary

RDR-137 Phase 3.1 (bead \`nexus-tts0d.6\`). \`health.py:_check_hooks_for_known_repos\` previously enumerated repos via \`RepoRegistry(repos.json).all()\`. The cutover routes through \`nexus.repos.list_repos_dual\` which reads \`owners WHERE owner_type='repo'\` from the catalog AND unions any registry-only entries (for pre-catalog installs).

## New API

\`list_repos_dual(*, cat, registry_path) -> list[str]\` — sorted union of catalog + registry repo paths. Emits \`repos_list_dual_disagreement\` at DEBUG only when both sources exist AND disagree, so steady-state post-Phase-5 (registry absent) is silent.

## Test partition follow-through

Per the partition (\`docs/rdr/rdr-137-test-fixture-partition.md\`), \`test_doctor_cmd.py\` is class (b). The cutover threads through \`_invoke\` with one extra patch (\`patch(\"nexus.repos.list_repos_dual\", side_effect=lambda **_: list(mock_reg.all()))\`) so the existing \`/some/repo\` expectations keep holding. The legacy \`nexus.registry.RepoRegistry\` patch stays until \`nexus-tts0d.12\` (doctor cutover) makes it unreachable.

## Closes

Closes nexus-tts0d.6

## Test plan

- [x] \`tests/test_repos_reader.py\` — 4 new \`TestListReposDual\` cases (catalog-only, union, disagreement event, no-event-when-registry-absent).
- [x] 246 / 246 doctor + health + repos + catalog regression tests green locally.