### PR TITLE
release: conexus 5.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.4.0"
+        "ref": "v5.4.1"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.4.0"
+      "version": "5.4.1"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.4.0"
+        "ref": "v5.4.1"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.4.0"
+      "version": "5.4.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.4.1] - 2026-05-28
+
+### Fixed
+
+- **`nx index repo` on a never-cataloged repo no longer crashes (nexus-5ut2a).** A `repos.json` entry carrying a pre-RDR-103 legacy 2-segment collection name (`code__<basename>-<hash8>`) for a repo with no catalog owner reached the strict conformant-name guard in `get_or_create_collection` and aborted the whole index with `ValueError: ... is not conformant`. The catalog owner is registered later in the run, and the Phase-4 migration is a no-op without an owner, so the legacy name was used verbatim for collection creation and the first index of such a repo could never complete. `_run_index` now re-routes any non-conformant `code_collection` / `docs_collection` through the path-derived conformant synth (`code__<owner>__<model>__v1`), which needs no registered owner and self-adjusts the model segment to local/cloud mode. Pre-existing since v4.23.0; surfaced during the 5.4.0 post-release shakeout while indexing a repo to complete the RDR-137 `repos.json` migration.
+
 ## [5.4.0] - 2026-05-28
 
 ### Changed

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.4.1] - 2026-05-28
+
+Plugin version aligned with conexus 5.4.1. No plugin-side changes; the
+release is a single nx CLI fix (`nx index repo` crash on a never-cataloged
+repo with a legacy `repos.json` collection name, nexus-5ut2a).
+
 ## [5.4.0] - 2026-05-28
 
 Plugin version aligned with conexus 5.4.0. One plugin-side change; the

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.4.0"
+version = "5.4.1"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.4.0",
+    "conexus>=5.4.1",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.4.0"
+version = "5.4.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -2006,6 +2006,21 @@ def _run_index(
     # these with conformant names before the indexer reads from T3.
     code_collection = info.get("code_collection", info["collection"])
     docs_collection = info.get("docs_collection") or _repo_collection_or_legacy(repo, "docs")
+    # nexus-5ut2a: the registry value can carry a legacy 2-segment name
+    # (``code__<owner>``) when repos.json holds a pre-RDR-103 entry for a
+    # repo that has no catalog owner yet (e.g. a stale entry from a prior
+    # failed run, or the RDR-137 migration's un-cataloged residue). The
+    # Phase-4 migration below is a no-op without an owner, so an
+    # un-reconciled legacy name would reach the strict get_or_create_collection
+    # guard (db/t3.py) and crash the whole index. Re-route any
+    # non-conformant value through the path-derived conformant synth, which
+    # builds ``code__<owner>__<model>__v1`` without needing a registered
+    # owner (model segment self-adjusts to local/cloud mode).
+    from nexus.corpus import is_conformant_collection_name  # noqa: PLC0415
+    if not is_conformant_collection_name(code_collection):
+        code_collection = _repo_collection_or_legacy(repo, "code")
+    if not is_conformant_collection_name(docs_collection):
+        docs_collection = _repo_collection_or_legacy(repo, "docs")
     _migrated_names: dict[str, str] = {}
 
     # Load config (picks up per-repo .nexus.yml if present)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -363,11 +363,19 @@ def test_run_index_excludes_rdr_paths_from_docs(tmp_path):
     with _patches(db, extra={"nexus.doc_indexer._embed_with_fallback": {"return_value": ([[0.1]*10], "voyage-context-3")},
                               "nexus.doc_indexer.batch_index_markdowns": {}}) as mocks:
         _run_index(repo, _reg())
-    if "docs__repo" in ups:
-        # RDR-102 D2: source_path is gone; title carries
-        # "{relpath}:chunk-{i}" per prose_indexer.py:96.
-        paths = [m.get("title", "") for m in ups["docs__repo"]]
-        assert any("README.md" in p for p in paths) and not any("ADR-001" in p for p in paths)
+    # nexus-5ut2a: _run_index re-routes the non-conformant fake registry
+    # name (code__repo/docs__repo) through the conformant synth, so key by
+    # content-type prefix rather than the literal legacy name.
+    docs_paths = [
+        m.get("title", "")
+        for k, v in ups.items() if k.startswith("docs__") for m in v
+    ]
+    assert docs_paths, "no docs collection received chunks"
+    # RDR-102 D2: source_path is gone; title carries
+    # "{relpath}:chunk-{i}" per prose_indexer.py:96.
+    assert any("README.md" in p for p in docs_paths) and not any(
+        "ADR-001" in p for p in docs_paths
+    )
     mb = mocks["batch_index_markdowns"]; mb.assert_called_once()
     assert any("ADR-001.md" in str(p) for p in mb.call_args[0][0])
 
@@ -419,8 +427,12 @@ def test_run_index_mixed_repo(tmp_path):
         _run_index(repo, _reg())
     # RDR-102 D2: source_path is gone; title carries
     # "{relpath}:chunk-{i}" per code_indexer.py:393 / prose_indexer.py:96.
-    assert any("main.py" in m.get("title", "") for m in ups["code__repo"])
-    dp = {m.get("title", "") for m in ups["docs__repo"]}
+    # nexus-5ut2a: key by content-type prefix — _run_index re-routes the
+    # non-conformant fake name (code__repo) through the conformant synth.
+    code_ups = [m for k, v in ups.items() if k.startswith("code__") for m in v]
+    docs_ups = [m for k, v in ups.items() if k.startswith("docs__") for m in v]
+    assert any("main.py" in m.get("title", "") for m in code_ups)
+    dp = {m.get("title", "") for m in docs_ups}
     assert any("README.md" in p for p in dp) and any("notes.rst" in p for p in dp)
     assert not any("data.txt" in p for p in dp), ".txt files should be SKIP"
 

--- a/tests/test_indexer_e2e.py
+++ b/tests/test_indexer_e2e.py
@@ -192,6 +192,56 @@ def test_index_does_not_write_repo_status(
     assert registry.get(mini_repo)["status"] == "registered"
 
 
+def test_index_legacy_registry_name_no_catalog_owner_succeeds(
+    mini_repo: Path, registry: RepoRegistry, local_t3: T3Database
+) -> None:
+    """nexus-5ut2a: a repos.json entry carrying a pre-RDR-103 legacy
+    2-segment collection name (``code__<basename>-<hash8>``) for a repo
+    with NO catalog owner must not crash on the strict conformant-name
+    guard. ``_run_index`` re-routes the non-conformant registry value
+    through the path-derived conformant synth, so the first index of a
+    never-cataloged / stale-entry repo succeeds and creates a conformant
+    collection.
+
+    Reproduces the arcaneum post-release shakeout crash (pre-existing
+    since v4.23.0): before the fix, ``db.get_or_create_collection`` got the
+    legacy 2-segment name and raised ``ValueError: ... is not conformant``.
+    """
+    from nexus.corpus import is_conformant_collection_name
+    from nexus.indexer import _legacy_collection_name
+
+    # RepoRegistry.add now mints conformant names; force the entry to the
+    # legacy 2-segment shape to simulate a pre-RDR-103 repos.json entry.
+    legacy_code = _legacy_collection_name(mini_repo, "code")
+    legacy_docs = _legacy_collection_name(mini_repo, "docs")
+    assert not is_conformant_collection_name(legacy_code), (
+        "fixture precondition: the seeded name must be genuinely legacy"
+    )
+    entry = registry._data["repos"][str(mini_repo)]
+    entry["collection"] = legacy_code
+    entry["code_collection"] = legacy_code
+    entry["docs_collection"] = legacy_docs
+    registry._save()
+
+    # No catalog owner in this tmp env → the no-owner fallback path that
+    # crashed for arcaneum. Must complete without raising.
+    _index(mini_repo, registry, local_t3)
+
+    # Every code collection this repo created must be conformant — the fix
+    # re-routed the legacy name through the synth.
+    from nexus.repo_identity import _repo_identity
+    _, path_hash = _repo_identity(mini_repo)
+    code_cols = [
+        e["name"]
+        for e in local_t3.list_collections()
+        if path_hash in e["name"] and e["name"].startswith("code__")
+    ]
+    assert code_cols, f"index created no code collection (path_hash={path_hash})"
+    assert all(is_conformant_collection_name(c) for c in code_cols), (
+        f"index created a non-conformant code collection: {code_cols}"
+    )
+
+
 @pytest.mark.parametrize("expected_file", ["ttl.py", "session.py"])
 def test_index_chunks_carry_source_path(
     mini_repo: Path, registry: RepoRegistry, local_t3: T3Database, expected_file: str

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.4.0"
+version = "5.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## conexus 5.4.1

Patch release: a single fix for a pre-existing `nx index repo` crash surfaced during the 5.4.0 post-release shakeout.

### Fixed
- **`nx index repo` on a never-cataloged repo no longer crashes (nexus-5ut2a).** A `repos.json` entry with a pre-RDR-103 legacy 2-segment collection name (`code__<basename>-<hash8>`) for a repo with no catalog owner hit the strict conformant-name guard in `get_or_create_collection` and aborted the whole index. `_run_index` now re-routes any non-conformant `code_collection`/`docs_collection` through the path-derived conformant synth (needs no registered owner; model segment self-adjusts to local/cloud mode). **Pre-existing since v4.23.0 — not a 5.4.0 regression.**

### Tests
- New e2e regression test (legacy `repos.json` name + no catalog owner → index succeeds, conformant collection created).
- `test_indexer.py` `_run_index` assertions made name-agnostic (key `ups` by content-type prefix), which also un-weakened a previously silently-skipped docs assertion.

### Verified
- End-to-end on the real repro: `nx index repo ~/git/arcaneum` succeeds, `nx upgrade` then deleted `repos.json` (catalog parity confirmed).
- Integration suite 78 passed / 0 failed; sandbox smoke `[done]`; upgrade-shakeout 12/12 PASS (5.4.0 → 5.4.1).
- All 7 manifests + both `source.ref` at 5.4.1 / v5.4.1.

Human cuts: merge (`--merge`), then tag `v5.4.1` on the merge commit and push.