### PR TITLE
fix(commands): close $ARGUMENTS shell-quoting hazard across all 25 slash commands

### DIFF
--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Shell-quoting safety for all 25 slash commands.** `$ARGUMENTS` is
+  substituted textually into the `` !`…` `` preamble line *before* the shell
+  parses it (confirmed against Claude Code skills docs), so any prompt
+  containing a double-quote, backtick, paren, or `$` broke the command with
+  `(eval):1: unmatched "`. Hit in practice by `/conexus:architecture` with a
+  prose task description. Fix: the 16 `command-context` commands (which ignore
+  their args) and `rdr-create` / `rdr-list` (preamble ignores args; title is
+  free-form) drop the arg entirely; the 7 arg-consuming `rdr preamble`
+  commands switch to single-quoted `'$ARGUMENTS'` (behaviourally identical —
+  the preamble re-joins args — but immune to every metacharacter except a
+  literal apostrophe, which cannot occur in an RDR id / flag / bead id). A new
+  static guard (`test_no_command_file_double_quotes_arguments_in_backtick`)
+  locks the safe form across every command surface. Hooks were audited and are
+  clean (they escape stdin via `python3 … json.dumps`, never splicing untrusted
+  input into a shell line).
+
 ## [5.4.1] - 2026-05-28
 
 Plugin version aligned with conexus 5.4.1. No plugin-side changes; the

--- a/conexus/commands/analyze-code.md
+++ b/conexus/commands/analyze-code.md
@@ -5,7 +5,7 @@ description: Analyze codebase using codebase-deep-analyzer agent
 
 # Codebase Analysis Request
 
-!`nx command-context analyze-code -- "$ARGUMENTS"`
+!`nx command-context analyze-code`
 
 ### Project Context
 

--- a/conexus/commands/architecture.md
+++ b/conexus/commands/architecture.md
@@ -5,7 +5,7 @@ description: Design architecture and create phased execution plans using archite
 
 # Architecture Request
 
-!`nx command-context architecture -- "$ARGUMENTS"`
+!`nx command-context architecture`
 
 ### Project Context
 

--- a/conexus/commands/continuation.md
+++ b/conexus/commands/continuation.md
@@ -8,7 +8,7 @@ argument-hint: [topic-or-arc-slug] (optional; defaults to current branch)
 
 Generates a handoff document under `/tmp/` that a future Claude Code session can read to pick up cold. Stores under `/tmp` (purged on reboot by macOS) so we don't accumulate stale handoffs in `~/.cache`. The chat response is one literal line: `cat <Target file>`. The user copies that line (mouse-select + cmd-C, or whatever their terminal supports), runs `/clear`, pastes, hits return. The new session reads the handoff and resumes.
 
-!`nx command-context continuation -- "$ARGUMENTS"`
+!`nx command-context continuation`
 
 ## Action
 

--- a/conexus/commands/create-plan.md
+++ b/conexus/commands/create-plan.md
@@ -5,7 +5,7 @@ description: Create implementation plan using strategic-planner agent
 
 # Planning Request
 
-!`nx command-context create-plan -- "$ARGUMENTS"`
+!`nx command-context create-plan`
 
 ### Project Context
 

--- a/conexus/commands/debug.md
+++ b/conexus/commands/debug.md
@@ -5,7 +5,7 @@ description: Debug test failures using debugger agent
 
 # Debug Request
 
-!`nx command-context debug -- "$ARGUMENTS"`
+!`nx command-context debug`
 
 ## Issue
 

--- a/conexus/commands/deep-analysis.md
+++ b/conexus/commands/deep-analysis.md
@@ -5,7 +5,7 @@ description: Thorough analysis of complex problems using deep-analyst agent
 
 # Deep Analysis Request
 
-!`nx command-context deep-analysis -- "$ARGUMENTS"`
+!`nx command-context deep-analysis`
 
 ### Project Context
 

--- a/conexus/commands/enrich-plan.md
+++ b/conexus/commands/enrich-plan.md
@@ -5,7 +5,7 @@ description: Enrich beads with execution context using mcp__plugin_conexus_nexus
 
 # Enrich Plan
 
-!`nx command-context enrich-plan -- "$ARGUMENTS"`
+!`nx command-context enrich-plan`
 
 ## Plan to Enrich
 

--- a/conexus/commands/implement.md
+++ b/conexus/commands/implement.md
@@ -5,7 +5,7 @@ description: Implement feature using developer agent
 
 # Implementation Request
 
-!`nx command-context implement -- "$ARGUMENTS"`
+!`nx command-context implement`
 
 ### Project Context
 

--- a/conexus/commands/knowledge-tidy.md
+++ b/conexus/commands/knowledge-tidy.md
@@ -5,7 +5,7 @@ description: Persist and organize knowledge into the T3 store using mcp__plugin_
 
 # Knowledge Tidying Request
 
-!`nx command-context knowledge-tidy -- "$ARGUMENTS"`
+!`nx command-context knowledge-tidy`
 
 ### Project Context
 

--- a/conexus/commands/nx-preflight.md
+++ b/conexus/commands/nx-preflight.md
@@ -4,7 +4,7 @@ description: Check that all conexus plugin dependencies are correctly installed 
 disable-model-invocation: false
 ---
 
-!`nx command-context nx-preflight -- "$ARGUMENTS"`
+!`nx command-context nx-preflight`
 
 ## Summary
 

--- a/conexus/commands/pdf-process.md
+++ b/conexus/commands/pdf-process.md
@@ -5,7 +5,7 @@ description: Index PDF files into the T3 knowledge store for semantic search
 
 # PDF Processing Request
 
-!`nx command-context pdf-process -- "$ARGUMENTS"`
+!`nx command-context pdf-process`
 
 ## PDFs to Process
 

--- a/conexus/commands/phase-review-gate.md
+++ b/conexus/commands/phase-review-gate.md
@@ -5,7 +5,7 @@ description: Cross-walk RDR §Approach against closing beads at a phase boundary
 
 # Phase Review Gate
 
-!`nx rdr preamble phase-review-gate -- "$ARGUMENTS"`
+!`nx rdr preamble phase-review-gate -- '$ARGUMENTS'`
 
 ## Phase Review Gate
 

--- a/conexus/commands/plan-audit.md
+++ b/conexus/commands/plan-audit.md
@@ -5,7 +5,7 @@ description: Audit a plan using mcp__plugin_conexus_nexus__nx_plan_audit (RDR-08
 
 # Plan Audit Request
 
-!`nx command-context plan-audit -- "$ARGUMENTS"`
+!`nx command-context plan-audit`
 
 ## Plan to Audit
 

--- a/conexus/commands/rdr-accept.md
+++ b/conexus/commands/rdr-accept.md
@@ -5,7 +5,7 @@ description: Accept a gated RDR — verifies gate PASSED in T2, updates status t
 
 # RDR Accept
 
-!`nx rdr preamble rdr-accept -- "$ARGUMENTS"`
+!`nx rdr preamble rdr-accept -- '$ARGUMENTS'`
 
 ## RDR to Accept
 

--- a/conexus/commands/rdr-audit.md
+++ b/conexus/commands/rdr-audit.md
@@ -5,7 +5,7 @@ description: Audit a project's RDR lifecycle for silent-scope-reduction base rat
 
 # RDR Audit
 
-!`nx rdr preamble rdr-audit -- "$ARGUMENTS"`
+!`nx rdr preamble rdr-audit -- '$ARGUMENTS'`
 
 ## Arguments
 

--- a/conexus/commands/rdr-close.md
+++ b/conexus/commands/rdr-close.md
@@ -5,7 +5,7 @@ description: Close an RDR with optional post-mortem, bead status gate, and T3 ar
 
 # RDR Close
 
-!`nx rdr preamble rdr-close -- "$ARGUMENTS"`
+!`nx rdr preamble rdr-close -- '$ARGUMENTS'`
 
 ## RDR to Close
 

--- a/conexus/commands/rdr-create.md
+++ b/conexus/commands/rdr-create.md
@@ -5,7 +5,7 @@ description: Create a new RDR — scaffold from template, assign sequential ID, 
 
 # New RDR
 
-!`nx rdr preamble rdr-create -- "$ARGUMENTS"`
+!`nx rdr preamble rdr-create`
 
 ## Title / Details
 

--- a/conexus/commands/rdr-gate.md
+++ b/conexus/commands/rdr-gate.md
@@ -5,7 +5,7 @@ description: Run finalization gate on an RDR — structural, assumption audit, a
 
 # RDR Gate
 
-!`nx rdr preamble rdr-gate -- "$ARGUMENTS"`
+!`nx rdr preamble rdr-gate -- '$ARGUMENTS'`
 
 ## RDR to Gate
 

--- a/conexus/commands/rdr-list.md
+++ b/conexus/commands/rdr-list.md
@@ -5,7 +5,7 @@ description: List all RDRs with status, type, and priority
 
 # RDR List
 
-!`nx rdr preamble rdr-list -- "$ARGUMENTS"`
+!`nx rdr preamble rdr-list`
 
 ## Filters
 

--- a/conexus/commands/rdr-research.md
+++ b/conexus/commands/rdr-research.md
@@ -5,7 +5,7 @@ description: Add, track, or verify structured research findings for an active RD
 
 # RDR Research
 
-!`nx rdr preamble rdr-research -- "$ARGUMENTS"`
+!`nx rdr preamble rdr-research -- '$ARGUMENTS'`
 
 ## Subcommand and Arguments
 

--- a/conexus/commands/rdr-show.md
+++ b/conexus/commands/rdr-show.md
@@ -5,7 +5,7 @@ description: Show detailed information about a specific RDR including content, r
 
 # RDR Show
 
-!`nx rdr preamble rdr-show -- "$ARGUMENTS"`
+!`nx rdr preamble rdr-show -- '$ARGUMENTS'`
 
 ## RDR to Show
 

--- a/conexus/commands/research.md
+++ b/conexus/commands/research.md
@@ -5,7 +5,7 @@ description: Research topic using deep-research-synthesizer agent
 
 # Research Request
 
-!`nx command-context research -- "$ARGUMENTS"`
+!`nx command-context research`
 
 ### Project Context
 

--- a/conexus/commands/review-code.md
+++ b/conexus/commands/review-code.md
@@ -5,7 +5,7 @@ description: Review code changes using code-review-expert agent
 
 # Code Review Request
 
-!`nx command-context review-code -- "$ARGUMENTS"`
+!`nx command-context review-code`
 
 ### Project Context
 

--- a/conexus/commands/substantive-critique.md
+++ b/conexus/commands/substantive-critique.md
@@ -5,7 +5,7 @@ description: Constructive critique of code, plans, designs, or documentation usi
 
 # Deep Critique Request
 
-!`nx command-context substantive-critique -- "$ARGUMENTS"`
+!`nx command-context substantive-critique`
 
 ### Project Context
 

--- a/conexus/commands/test-validate.md
+++ b/conexus/commands/test-validate.md
@@ -5,7 +5,7 @@ description: Validate tests using test-validator agent
 
 # Test Validation Request
 
-!`nx command-context test-validate -- "$ARGUMENTS"`
+!`nx command-context test-validate`
 
 ### Project Context
 

--- a/tests/cc-validation/scenarios/23_rdr130_flipped_command_renders.sh
+++ b/tests/cc-validation/scenarios/23_rdr130_flipped_command_renders.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Scenario 23 — RDR-130 P1.7: a FLIPPED RDR command renders via real Claude Code.
-# rdr-list.md now injects via `!`nx rdr preamble rdr-list -- "$ARGUMENTS"`` (P1.4);
+# rdr-list.md now injects via `!`nx rdr preamble rdr-list`` (P1.4);
 # the nx subcommand (P1.2) reads T2 with a file fallback and prints the RDR table.
 # This proves the full chain — inline injection -> nx subgroup -> markdown output —
 # works end to end (requires the repo nx with the preamble subgroup on PATH).

--- a/tests/cc-validation/scenarios/24_rdr130_agent_relay_renders.sh
+++ b/tests/cc-validation/scenarios/24_rdr130_agent_relay_renders.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Scenario 24 — RDR-130 P2.5/P2.6: the migrated AGENT-RELAY injection form renders
 # its preamble via real Claude Code. P2.5 flipped the 16 agent-relay commands to a
-# single-line `!`nx command-context <name> -- "$ARGUMENTS"`` call; the nx subcommand
+# single-line `!`nx command-context <name>`` call; the nx subcommand
 # (P2.2) prints the shared preamble (## Context, project-type table, top-level
 # structure, source locations). This isolates exactly what P2 changed — the
 # injection line — using the proven minimal-probe mechanism (scenarios 21/22), not
@@ -26,7 +26,7 @@ description: RDR-130 P2 agent-relay preamble probe
 
 # Agent-relay Preamble Probe
 
-!`nx command-context analyze-code -- "$ARGUMENTS"`
+!`nx command-context analyze-code`
 
 Report verbatim whether the "### Source Locations" heading and the "**Project type:**" list appear above.
 EOF

--- a/tests/test_command_context_command.py
+++ b/tests/test_command_context_command.py
@@ -1866,19 +1866,31 @@ def test_continuation_target_file_is_in_tmp(
 
 # ---------------------------------------------------------------------------
 # (g) Shell-quoting safety: command .md files must NOT splice $ARGUMENTS into
-#     the `!`...`` backtick line. Claude Code substitutes $ARGUMENTS textually
-#     BEFORE the shell runs, so any prompt containing ", `, ( etc. breaks the
-#     double-quoted argument ((eval):1: unmatched "). The args are unused by
-#     every command-context subcommand (continuation falls back to branch),
-#     so the passthrough is both vestigial and a shell-injection hazard.
+#     a `!`...`` backtick line inside DOUBLE quotes. Claude Code substitutes
+#     $ARGUMENTS textually BEFORE the shell parses the line, so a prompt
+#     containing ", `, (, ), $ etc. breaks the double-quoted argument
+#     ((eval):1: unmatched "). No shell escaping survives textual
+#     substitution (confirmed against Claude Code skills docs).
+#
+#     Two safe forms:
+#       - drop the arg entirely (when the preamble ignores it, or the arg is
+#         free-form prose that has no safe form), or
+#       - single-quote it (`'$ARGUMENTS'`) when the arg is a shell-safe token
+#         (RDR id / flag / bead id) that can never contain a literal apostrophe.
+#         Single-quoting is behaviourally identical (the preamble re-joins
+#         args) but immune to every metacharacter except a literal '.
 # ---------------------------------------------------------------------------
 
 import re as _re
 
 
-def _command_md_files() -> list[Path]:
+def _all_command_md_files() -> list[Path]:
     cmd_dir = Path(__file__).parent.parent / "conexus" / "commands"
-    return sorted(p for p in cmd_dir.glob("*.md") if "nx command-context" in p.read_text())
+    return sorted(cmd_dir.glob("*.md"))
+
+
+def _command_md_files() -> list[Path]:
+    return [p for p in _all_command_md_files() if "nx command-context" in p.read_text()]
 
 
 def test_command_files_exist() -> None:
@@ -1886,12 +1898,11 @@ def test_command_files_exist() -> None:
     assert len(_command_md_files()) == 16
 
 
-def test_no_command_file_splices_arguments_into_shell() -> None:
-    """No `!`nx command-context ...`` line may interpolate $ARGUMENTS.
+def test_no_command_context_file_passes_arguments() -> None:
+    """command-context preamble lines never reference $ARGUMENTS.
 
-    Regression for the (eval):1: unmatched " failure: $ARGUMENTS is
-    substituted textually before the shell, so passing it inside a
-    double-quoted arg breaks on any shell metacharacter in the prompt.
+    The command-context subcommands ignore their args entirely (analyze-code
+    and continuation included), so the passthrough is purely a hazard.
     """
     offenders: list[str] = []
     pat = _re.compile(r"!`nx command-context [a-z-]+.*\$ARGUMENTS.*`")
@@ -1902,4 +1913,27 @@ def test_no_command_file_splices_arguments_into_shell() -> None:
     assert offenders == [], (
         "command-context backtick lines must not splice $ARGUMENTS:\n"
         + "\n".join(offenders)
+    )
+
+
+def test_no_command_file_double_quotes_arguments_in_backtick() -> None:
+    """No `!`...`` backtick line in ANY command .md may put $ARGUMENTS inside
+    double quotes.
+
+    Textual substitution means a double-quoted $ARGUMENTS breaks on the first
+    quote/backtick/paren in the user's input. This guard covers every command
+    surface (command-context AND rdr preamble), so a new command can never
+    re-introduce the (eval):1: unmatched " class. Single-quoted '$ARGUMENTS'
+    is permitted for shell-safe token args.
+    """
+    offenders: list[str] = []
+    # A backtick command line that contains a double-quoted $ARGUMENTS.
+    pat = _re.compile(r'!`[^`]*"\s*\$ARGUMENTS\s*"[^`]*`')
+    for p in _all_command_md_files():
+        for i, line in enumerate(p.read_text().splitlines(), 1):
+            if pat.search(line):
+                offenders.append(f"{p.name}:{i}: {line.strip()}")
+    assert offenders == [], (
+        'command .md backtick lines must not splice "$ARGUMENTS" (double-quoted); '
+        "drop the arg or single-quote it:\n" + "\n".join(offenders)
     )

--- a/tests/test_command_context_command.py
+++ b/tests/test_command_context_command.py
@@ -1862,3 +1862,44 @@ def test_continuation_target_file_is_in_tmp(
 
     result = runner.invoke(main, ["command-context", "continuation"])
     assert "/tmp/nexus-continuation-" in result.output
+
+
+# ---------------------------------------------------------------------------
+# (g) Shell-quoting safety: command .md files must NOT splice $ARGUMENTS into
+#     the `!`...`` backtick line. Claude Code substitutes $ARGUMENTS textually
+#     BEFORE the shell runs, so any prompt containing ", `, ( etc. breaks the
+#     double-quoted argument ((eval):1: unmatched "). The args are unused by
+#     every command-context subcommand (continuation falls back to branch),
+#     so the passthrough is both vestigial and a shell-injection hazard.
+# ---------------------------------------------------------------------------
+
+import re as _re
+
+
+def _command_md_files() -> list[Path]:
+    cmd_dir = Path(__file__).parent.parent / "conexus" / "commands"
+    return sorted(p for p in cmd_dir.glob("*.md") if "nx command-context" in p.read_text())
+
+
+def test_command_files_exist() -> None:
+    """Sanity: the command-context command files are discoverable."""
+    assert len(_command_md_files()) == 16
+
+
+def test_no_command_file_splices_arguments_into_shell() -> None:
+    """No `!`nx command-context ...`` line may interpolate $ARGUMENTS.
+
+    Regression for the (eval):1: unmatched " failure: $ARGUMENTS is
+    substituted textually before the shell, so passing it inside a
+    double-quoted arg breaks on any shell metacharacter in the prompt.
+    """
+    offenders: list[str] = []
+    pat = _re.compile(r"!`nx command-context [a-z-]+.*\$ARGUMENTS.*`")
+    for p in _command_md_files():
+        for i, line in enumerate(p.read_text().splitlines(), 1):
+            if pat.search(line):
+                offenders.append(f"{p.name}:{i}: {line.strip()}")
+    assert offenders == [], (
+        "command-context backtick lines must not splice $ARGUMENTS:\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Problem

Invoking `/conexus:architecture` (or any command-context command) with a prompt containing shell metacharacters — `"`, backtick, `(`, `'`, `$` — failed with:

```
(eval):1: unmatched "
```

Root cause (confirmed against Claude Code skills docs): `$ARGUMENTS` is substituted **textually** into the `` !`…` `` preamble line *before* the shell parses it. No shell quoting survives arbitrary substituted text. The same hazard existed in the 9 `rdr preamble` commands — e.g. `/conexus:rdr-close 3 --reason "fixed (the) thing"` or an `rdr-create` title with parens.

## Audit scope

Swept every plugin surface for the class:
- **command-context commands (16)** — args ignored by every subcommand → **fixed by dropping the arg**.
- **rdr preamble commands (9)** — `rdr-create`/`rdr-list` ignore args (and `rdr-create`'s title is free-form) → **drop**; the 7 arg-consuming commands (`rdr-show`, `rdr-gate`, `rdr-accept`, `rdr-close`, `rdr-research`, `rdr-audit`, `phase-review-gate`) take shell-safe ID/keyword/flag tokens → **single-quote `'$ARGUMENTS'`** (behaviourally identical, the preamble re-joins args; immune to every metacharacter except a literal apostrophe, which cannot occur in those tokens).
- **hooks (conexus + sn)** — audited, **clean**: they escape stdin via `python3 … json.dumps`, never splicing untrusted input into a shell line. No `eval`/`sh -c` on user data.
- **skills** — no `!`…`` shell lines reference `$ARGUMENTS` (only prose body refs).

## Tests

- New static guard `test_no_command_file_double_quotes_arguments_in_backtick` forbids double-quoted `$ARGUMENTS` in any command `.md` backtick line (both families) so this can never re-enter.
- `test_no_command_context_file_passes_arguments` keeps command-context arg-free.
- cc-validation scenarios 23/24 updated to the fixed form.
- 212 command/preamble tests + 496 plugin-structure tests green locally.

## Note

Per the pinned-source release model, installed conexus consumers pick this up only when a release is cut.