### PR TITLE
fix(commands): close apostrophe residual + e2e shell-quoting verification

### DIFF
--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -15,14 +15,27 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `(eval):1: unmatched "`. Hit in practice by `/conexus:architecture` with a
   prose task description. Fix: the 16 `command-context` commands (which ignore
   their args) and `rdr-create` / `rdr-list` (preamble ignores args; title is
-  free-form) drop the arg entirely; the 7 arg-consuming `rdr preamble`
-  commands switch to single-quoted `'$ARGUMENTS'` (behaviourally identical —
-  the preamble re-joins args — but immune to every metacharacter except a
-  literal apostrophe, which cannot occur in an RDR id / flag / bead id). A new
-  static guard (`test_no_command_file_double_quotes_arguments_in_backtick`)
-  locks the safe form across every command surface. Hooks were audited and are
-  clean (they escape stdin via `python3 … json.dumps`, never splicing untrusted
-  input into a shell line).
+  free-form) drop the arg entirely. The 5 `rdr preamble` commands whose arg is
+  a pure token (`rdr-show`, `rdr-gate`, `rdr-accept`, `rdr-research`,
+  `rdr-audit` — id / `add N` / project name) switch to single-quoted
+  `'$ARGUMENTS'`: behaviourally identical (the preamble re-joins args), immune
+  to every metacharacter, and the token form cannot contain the lone
+  single-quote residual (a literal apostrophe). The 2 commands that can carry
+  free-form text (`rdr-close --reason`, `phase-review-gate` deferral
+  justifications) drop the arg from the shell line entirely and instead parse
+  the id from `$ARGUMENTS` in the body, then load targeted context by invoking
+  the preamble via the Bash tool with the id as a real argv token — closing the
+  apostrophe residual completely.
+- Verified end-to-end, not just by reasoning: `test_command_shell_quoting_e2e`
+  reproduces Claude Code's textual-substitution + shell `eval` against hostile
+  inputs (quotes, parens, backticks, `$(…)`, `&&`) in both bash and zsh, and
+  asserts dropped-arg commands survive every input while single-quoted commands
+  pass injection payloads through INERT (the program receives one intact literal
+  token; no subshell/operator executes). A static guard
+  (`test_no_command_file_double_quotes_arguments_in_backtick`) locks the safe
+  form across every command surface. Hooks were audited and are clean (they
+  escape stdin via `python3 … json.dumps`, never splicing untrusted input into a
+  shell line).
 
 ## [5.4.1] - 2026-05-28
 

--- a/conexus/commands/phase-review-gate.md
+++ b/conexus/commands/phase-review-gate.md
@@ -5,7 +5,7 @@ description: Cross-walk RDR §Approach against closing beads at a phase boundary
 
 # Phase Review Gate
 
-!`nx rdr preamble phase-review-gate -- '$ARGUMENTS'`
+!`nx rdr preamble phase-review-gate`
 
 ## Phase Review Gate
 
@@ -13,9 +13,11 @@ $ARGUMENTS
 
 ## Action
 
-All data is pre-loaded above. The preamble has enumerated (Pass 1) or validated (Pass 2) the §Approach cross-walk.
+The preamble above shows usage and what this gate does (no id was passed to it). Parse the **RDR id** and `--phase N` from `$ARGUMENTS`, then drive the gate by invoking the preamble via the Bash tool — constructing the argv yourself so evidence/justification text (which may contain quotes or apostrophes) is passed as real argv tokens, never spliced into a shell-quoted line.
 
-**After Pass 1**: collect evidence pointers from the user for each §Approach item, then re-invoke with `--evidence`.
+**Pass 1 — enumerate**: run, via the Bash tool, `nx rdr preamble phase-review-gate -- <ID> --phase <N>`. This lists the §Approach items to cross-walk. Collect an evidence pointer (bead id, or `none` + justification) from the user for each item.
+
+**Pass 2 — validate**: run, via the Bash tool, `nx rdr preamble phase-review-gate -- <ID> --phase <N> --evidence "Item1=<ptr>,Item2=<ptr>,…"`, building the `--evidence` value as a single Bash-tool argument.
 
 **After Pass 2 PASSED**: proceed to close the phase. Remind the user: evidence pointers are not semantically verified — review each one manually.
 

--- a/conexus/commands/rdr-close.md
+++ b/conexus/commands/rdr-close.md
@@ -5,7 +5,7 @@ description: Close an RDR with optional post-mortem, bead status gate, and T3 ar
 
 # RDR Close
 
-!`nx rdr preamble rdr-close -- '$ARGUMENTS'`
+!`nx rdr preamble rdr-close`
 
 ## RDR to Close
 
@@ -13,11 +13,11 @@ $ARGUMENTS
 
 ## Action
 
-All data is pre-loaded above — no additional tool calls needed.
-
-- RDR directory is shown above (from `.nexus.yml` `indexing.rdr_paths[0]`).
-- Parse RDR ID and close reason from `$ARGUMENTS` (e.g. `003 --reason implemented`).
-- Pre-check warning is shown above if status is not Final when reason is Implemented.
+- The preamble above lists the open/draft RDRs and usage (no id was passed to it).
+- Parse the RDR ID and close reason from `$ARGUMENTS` (e.g. `003 --reason implemented`).
+- Load the targeted close context: run, via the Bash tool, `nx rdr preamble rdr-close -- <ID>` with the parsed **numeric ID** as a literal argument (e.g. `nx rdr preamble rdr-close -- 003`). The Bash tool passes the id as a real argv token, so free-form text in `$ARGUMENTS` (a reason containing quotes, parens, or apostrophes) never reaches a shell-quoted line. Do NOT pass the raw close reason on this command line — you already have it from `$ARGUMENTS`.
+- RDR directory is shown in that targeted output (from `.nexus.yml` `indexing.rdr_paths[0]`).
+- The pre-check warning (status not Final when reason is Implemented) appears in the targeted output.
 - **Implemented**: review for divergences, optionally create post-mortem, gate on open bead status.
 - **Reverted / Abandoned**: offer post-mortem.
 - **Superseded**: prompt for superseding RDR ID, cross-link both files.

--- a/tests/test_command_shell_quoting_e2e.py
+++ b/tests/test_command_shell_quoting_e2e.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""End-to-end shell-quoting verification for slash-command preamble lines.
+
+The unit tests in ``test_command_context_command.py`` and
+``test_rdr_preamble.py`` invoke the CLI with *pre-split* argv
+(``["rdr-show", "--", "1"]``). That is NOT the path that broke: Claude Code
+substitutes ``$ARGUMENTS`` **textually** into the ``!`…`` backtick line and
+then a shell ``eval``s it. The original ``(eval):1: unmatched "`` failure lived
+entirely in that substitution+eval step, which pre-split argv never exercises.
+
+This module reproduces the real pipeline: take the exact backtick body from each
+command ``.md``, textually substitute ``$ARGUMENTS`` with hostile inputs, replace
+the ``nx`` program with a probe that prints the argv it receives, and ``eval`` the
+result in a real shell. It asserts:
+
+  1. Dropped-arg commands survive EVERY metacharacter (including a literal
+     apostrophe) — the user input never reaches the shell line.
+  2. Single-quoted commands neutralise injection: ``$(...)`` / backticks / shell
+     operators arrive as INERT literal text in a single intact argv token, not
+     executed. (Their one boundary — a literal apostrophe — is documented in the
+     command bodies; token-only args cannot contain one.)
+
+bead: follow-up to the RDR-130 command shell-quoting fix (#1007).
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_CMD_DIR = Path(__file__).parent.parent / "conexus" / "commands"
+
+# Inputs a user could plausibly type after a slash command. Each is a shell
+# minefield; none should ever break the line or execute.
+_INJECTION = [
+    '003 --reason "fixed (the) broken thing"',  # double quotes + parens
+    "`whoami`",                                   # backtick command substitution
+    "$(whoami)",                                  # $() command substitution
+    "$HOME && echo PWNED",                        # var expansion + shell operator
+]
+_APOSTROPHE = "it's done"  # the single-quote boundary
+
+_BACKTICK_LINE = re.compile(r"^!`(nx (?:command-context|rdr preamble) [^`]+)`$")
+
+
+def _probe(tmp_path: Path) -> Path:
+    """A stand-in for `nx` that prints each argv token, one per line."""
+    p = tmp_path / "argv_probe"
+    p.write_text('#!/usr/bin/env bash\nfor a in "$@"; do printf "ARGV<%s>\\n" "$a"; done\n')
+    p.chmod(0o755)
+    return p
+
+
+def _command_lines() -> dict[str, str]:
+    """Map each command file to its backtick preamble body (sans the `!` and ticks)."""
+    out: dict[str, str] = {}
+    for md in sorted(_CMD_DIR.glob("*.md")):
+        for line in md.read_text().splitlines():
+            m = _BACKTICK_LINE.match(line)
+            if m:
+                out[md.name] = m.group(1)
+    return out
+
+
+def _render_and_eval(body: str, argument: str, probe: Path, shell: str) -> subprocess.CompletedProcess:
+    """Mimic CC: textually substitute $ARGUMENTS, swap `nx`->probe, eval in `shell`."""
+    rendered = body.replace("$ARGUMENTS", argument).replace("nx ", f"{probe} ", 1)
+    return subprocess.run([shell, "-c", rendered], capture_output=True, text=True)
+
+
+def _argv_after_terminator(stdout: str) -> list[str]:
+    toks = re.findall(r"ARGV<(.*)>", stdout)
+    return toks[toks.index("--") + 1:] if "--" in toks else []
+
+
+def _assert_no_leaked_output(stdout: str) -> None:
+    """Every non-empty stdout line must be a probe ``ARGV<…>`` line. A bare line
+    (e.g. ``PWNED`` from an executed ``&& echo``, or a ``$(whoami)`` result) would
+    prove the shell executed an injected payload rather than passing it inert."""
+    leaked = [ln for ln in stdout.splitlines() if ln.strip() and not ln.startswith("ARGV<")]
+    assert leaked == [], f"injected payload produced shell output: {leaked!r}"
+
+
+_SHELLS = [s for s in ("bash", "zsh") if shutil.which(s)]
+
+_LINES = _command_lines()
+_DROPPED = {n: b for n, b in _LINES.items() if "$ARGUMENTS" not in b}
+_SINGLE_QUOTED = {n: b for n, b in _LINES.items() if "'$ARGUMENTS'" in b}
+
+
+def test_inventory_is_sane() -> None:
+    """Guards against the regex silently matching nothing (which would make the
+    parametrised tests vacuously pass)."""
+    assert len(_LINES) == 25, sorted(_LINES)
+    # No command may double-quote $ARGUMENTS (mirrors the static guard).
+    assert not [n for n, b in _LINES.items() if '"$ARGUMENTS"' in b]
+    assert len(_DROPPED) >= 18
+    assert set(_SINGLE_QUOTED) == {
+        "rdr-show.md", "rdr-gate.md", "rdr-accept.md", "rdr-research.md", "rdr-audit.md",
+    }, sorted(_SINGLE_QUOTED)
+
+
+@pytest.mark.skipif(not _SHELLS, reason="no bash/zsh available")
+@pytest.mark.parametrize("shell", _SHELLS)
+@pytest.mark.parametrize("name", sorted(_DROPPED))
+@pytest.mark.parametrize("arg", [*_INJECTION, _APOSTROPHE])
+def test_dropped_arg_commands_survive_every_metacharacter(
+    name: str, arg: str, shell: str, tmp_path: Path
+) -> None:
+    """Commands that drop the arg never let user text reach the shell line, so
+    EVERY input — including a literal apostrophe — evals cleanly."""
+    r = _render_and_eval(_DROPPED[name], arg, _probe(tmp_path), shell)
+    assert r.returncode == 0, f"{name} [{shell}] arg={arg!r}: {r.stderr.strip()}"
+    assert "unmatched" not in r.stderr and "(eval)" not in r.stderr
+    _assert_no_leaked_output(r.stdout)  # no operator/subshell executed
+    # The arg is dropped, so nothing appears after a `--` terminator.
+    assert _argv_after_terminator(r.stdout) == []
+
+
+@pytest.mark.skipif(not _SHELLS, reason="no bash/zsh available")
+@pytest.mark.parametrize("shell", _SHELLS)
+@pytest.mark.parametrize("name", sorted(_SINGLE_QUOTED))
+@pytest.mark.parametrize("arg", _INJECTION)
+def test_single_quoted_commands_neutralize_injection(
+    name: str, arg: str, shell: str, tmp_path: Path
+) -> None:
+    """Single-quoted commands pass injection payloads through INERT: the shell
+    neither breaks nor executes them, and the program receives the payload as one
+    intact argv token after `--`."""
+    r = _render_and_eval(_SINGLE_QUOTED[name], arg, _probe(tmp_path), shell)
+    assert r.returncode == 0, f"{name} [{shell}] arg={arg!r}: {r.stderr.strip()}"
+    assert "unmatched" not in r.stderr and "(eval)" not in r.stderr
+    # No operator/subshell executed: every stdout line is a probe ARGV line, so
+    # no `echo PWNED` / `$(whoami)` output leaked alongside the argv.
+    _assert_no_leaked_output(r.stdout)
+    # And the payload arrives as ONE intact literal token verbatim ($HOME, `…`,
+    # $(…) all unexpanded) — the definitive proof it was inert.
+    assert _argv_after_terminator(r.stdout) == [arg], (
+        f"{name} [{shell}]: expected intact literal token, got {_argv_after_terminator(r.stdout)!r}"
+    )


### PR DESCRIPTION
Follow-up to #1007, prompted by the question: *how did we actually verify the rewrite is correct and won't hit further escape issues?*

## The validation gap (and how it's closed)

The #1007 unit tests all invoked the CLI with **pre-split argv** (`["rdr-show", "--", "1"]`). That never exercised the real path — Claude Code substitutes `$ARGUMENTS` **textually**, then a shell `eval`s the line. The original break lived entirely in that step.

`tests/test_command_shell_quoting_e2e.py` reproduces the real pipeline (textual substitution → `eval` in **bash and zsh** → inspect received argv) against hostile inputs: `"x (y)"`, `` `whoami` ``, `$(whoami)`, `$HOME && echo PWNED`, `it's done`.

Findings (empirical, both shells):
- **Dropped-arg commands** survive *every* input including a literal apostrophe — user text never reaches the shell line.
- **Single-quoted commands** pass injection payloads through **inert**: the program receives one intact literal argv token; `$HOME`/`` `…` ``/`$(…)` are unexpanded and no operator executes. Their lone boundary is a literal apostrophe.
- **Correctness**: the preamble parses the single substituted blob (`'130 --phase 1'`) identically to pre-split tokens — it re-parses internally, never relying on the shell to split flags.

## Closing the apostrophe residual

5 of the 7 single-quoted commands take pure tokens (id / `add N` / project name) that cannot contain an apostrophe → provably complete, left as-is. The 2 that can carry free-form text — `rdr-close --reason` and `phase-review-gate` deferral justifications — now **drop the arg from the shell line entirely**; the body parses the id from `$ARGUMENTS` and loads targeted context by invoking the preamble via the **Bash tool** with the id as a real argv token. Zero residual.

## Tests
708 unit + 241 e2e (bash+zsh) green locally. Static double-quote guard from #1007 still enforced.