### PR TITLE
ci: bump pytest timeout to 25m + trim ~180s of fixed-teardown waste

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,10 @@ jobs:
   test:
     name: pytest (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 25m: the suite runs ~16m on the runners and the post-job cache-save
+    # step counts toward this budget. At 20m a v5.4.2 release run timed
+    # out DURING the cache upload (tests had already passed). See release.yml.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -65,4 +68,4 @@ jobs:
         run: uv sync --group dev
 
       - name: Run tests
-        run: uv run pytest tests/ -v
+        run: uv run pytest tests/ -q --durations=25

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,12 @@ jobs:
     # v4.18.0 tag-push hit it: pytest 3.13 ran 36+ min before manual
     # cancel. 4.32.1 hit a different boundary — Python 3.12 ran 15m22s
     # while 3.13 ran 11m33s. The suite grew under RDR-109 (cross-
-    # encoder substrate; lazy ONNX-runtime imports). Bumped to 20m to
-    # match ``ci.yml`` while still catching genuine hangs.
-    timeout-minutes: 20
+    # encoder substrate; lazy ONNX-runtime imports). 20m was then too
+    # tight: the v5.4.2 tag-push run passed both pytest matrices (~16m)
+    # but timed out DURING the post-job cache-save upload, which counts
+    # toward this budget. Bumped to 25m — still well under the 36m
+    # genuine-hang signature, with headroom for the cache upload.
+    timeout-minutes: 25
     strategy:
       fail-fast: true
       matrix:
@@ -56,7 +59,7 @@ jobs:
         run: uv sync --group dev
 
       - name: Run tests
-        run: uv run pytest tests/ -v
+        run: uv run pytest tests/ -q --durations=25
 
   publish:
     name: Build and publish to PyPI

--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -52,6 +52,7 @@ worker spawn).
 """
 from __future__ import annotations
 
+import os
 import threading
 import time
 from pathlib import Path
@@ -941,4 +942,16 @@ def aspect_extraction_enqueue_hook(
         # The document_aspects row will simply not be populated until
         # a manual re-enqueue triggers extraction.
         return
-    ensure_worker_started()
+    # Auto-spawn gate (nexus test-suite trim): the enqueue hook lazy-spawns
+    # the singleton polling worker for every supported-collection document.
+    # The unit suite sets ``NX_ASPECT_WORKER_AUTOSTART=0`` (conftest) so a
+    # store_put / index test does NOT spawn a worker it never asserts on —
+    # which otherwise costs a fixed ~5s teardown per test (the stop() join
+    # waits on a worker stuck mid ``t2_index_write`` poll). This also removes
+    # the leaked-singleton hazard (nexus-u0u8a) at its root for those tests.
+    # Production leaves it unset → default-on. Worker-specific tests call
+    # ``ensure_worker_started()`` directly, which ignores this gate.
+    if os.environ.get("NX_ASPECT_WORKER_AUTOSTART", "1") not in (
+        "0", "false", "False", "no", "",
+    ):
+        ensure_worker_started()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,29 @@ def _enable_t2_test_auto_migrate() -> None:
     os.environ.setdefault(_t2._RUN_MIGRATIONS_ENV, "1")
 
 
+def _disable_aspect_worker_autostart() -> None:
+    """Stop the aspect-extraction-enqueue hook from lazy-spawning the
+    singleton polling worker during the unit suite.
+
+    A ``store_put`` / index / MCP test that touches a supported collection
+    fires ``aspect_extraction_enqueue_hook``, which (in production)
+    auto-spawns the polling worker. The worker then gets stuck mid
+    ``t2_index_write`` poll, so the autouse ``_reset_aspect_worker_singleton``
+    teardown's ``stop()`` join waits its full 5s timeout — a fixed ~5s tax on
+    every such test (≥140s across the suite). The worker is never asserted on
+    by those tests, and leaving it unspawned also removes the leaked-singleton
+    hazard (nexus-u0u8a) at its root. Worker-specific tests call
+    ``ensure_worker_started()`` directly, which ignores this gate, or
+    ``monkeypatch.setenv("NX_ASPECT_WORKER_AUTOSTART", "1")`` to exercise the
+    hook path. ``setdefault`` so an explicit opt-in set before import wins.
+    """
+    import os
+
+    os.environ.setdefault("NX_ASPECT_WORKER_AUTOSTART", "0")
+
+
 _enable_t2_test_auto_migrate()
+_disable_aspect_worker_autostart()
 
 
 def pytest_configure(config):

--- a/tests/test_aspect_worker.py
+++ b/tests/test_aspect_worker.py
@@ -466,10 +466,14 @@ class TestEnqueueHook:
         assert get_worker() is None  # no lazy start either
 
     def test_hook_starts_worker_on_first_supported_enqueue(
-        self, _isolate_t2: Path,
+        self, _isolate_t2: Path, monkeypatch,
     ) -> None:
         """The hook lazy-starts the worker on the first supported
         enqueue. Subsequent enqueues do not re-start."""
+        # Exercises the hook's auto-spawn path specifically, so opt back into
+        # autostart (conftest disables it suite-wide to drop the per-test
+        # worker-stop teardown tax — nexus test-suite trim).
+        monkeypatch.setenv("NX_ASPECT_WORKER_AUTOSTART", "1")
         from nexus.aspect_worker import (
             aspect_extraction_enqueue_hook,
             get_worker,

--- a/tests/test_phase3_structured_chash.py
+++ b/tests/test_phase3_structured_chash.py
@@ -172,6 +172,7 @@ class TestNxAnswerStructuredEnvelope:
         ))
         assert isinstance(result, str), f"expected str, got {type(result)}"
 
+    @pytest.mark.slow  # ~40s: real nx_answer plan executing claude -p operator composition
     def test_nx_answer_structured_true_single_step_returns_envelope(
         self, t3, t1,
     ):


### PR DESCRIPTION
## ci: bump pytest timeout to 25m + trim ~180s of fixed-teardown waste

### Why
The v5.4.2 tag-push Release run passed both pytest matrices (~16m) but timed out at the 20m job ceiling **during the post-job cache-save upload** (the cache step counts toward `timeout-minutes`). Bumping to 25m gives headroom; trimming reduces the underlying excess.

### Changes
- **Timeout 20→25m** in `ci.yml` + `release.yml` (still well under the 36m genuine-hang signature).
- **R1 — worker autostart gate (~140s).** The aspect-extraction enqueue hook auto-spawned the singleton polling worker for every `store_put`/index test; the worker got stuck mid-`t2_index_write` poll, so the autouse `_reset_aspect_worker_singleton` teardown's `stop()` join waited its full **5s** timeout on ≥28 tests that never assert on the worker. New `NX_ASPECT_WORKER_AUTOSTART` env (default-on in production); conftest disables it suite-wide. Also removes the leaked-singleton hazard (nexus-u0u8a) at its root for those tests. `test_hook_starts_worker_on_first_supported_enqueue` opts back in via monkeypatch.
- **R2 — mark the 40s `nx_answer` structured-envelope test `slow`.** It runs a real plan with `claude -p` operator composition (an integration test in the unit suite); now deselected by default, runnable via `-m slow`.
- **R3 — `pytest -v` → `-q --durations=25`.** Cuts 8272 per-test log lines to dots; keeps slow-test visibility every run.

Deferred **R4** (upgrade-test trim ~94s) to `nexus-w1ip` — release-critical path, deserves its own scrutiny.

### Validation (local)
Profiled 8272 tests at 939s. Affected files green; the uniform 5.01s teardowns are gone (slowest now real work). Worker tests unaffected (44 passed; slow test deselected).
