### PR TITLE
test: reap detached daemons leaked by in-process nx upgrade tests

### DIFF
--- a/tests/_daemon_leak_guard.py
+++ b/tests/_daemon_leak_guard.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Backstop reaper for T2/T3 daemons a test spawned under its own
+isolated ``NEXUS_CONFIG_DIR`` (nexus-scoo5).
+
+A test that drives a real ``nx upgrade`` (or any path that calls ``nx
+daemon t2 ensure-running``) spawns a *detached* ``nx daemon t2 start``
+bound to the per-test ``NEXUS_CONFIG_DIR``. ``subprocess.run`` returns as
+soon as the daemon is up, so the process outlives the test body. The
+autouse ``_isolate_config_dir`` fixture contains the *db location* (a tmp
+dir, never the user's real ``~/.config/nexus``) but nothing reaps the
+*process*. Result: orphan ``nx daemon t2 start`` processes accumulate,
+each holding a now-deleted tmp db dir open.
+
+This is the process-level analog of the ``pytest_sessionfinish``
+cache-file leak guard. It is scoped *strictly* to the per-test tmp config
+dir its caller passes, and double-guarded by a cmdline check, so it can
+never signal the user's real daemon (whose discovery file lives under
+``~/.config/nexus``, never under ``tmp_path``).
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+
+def _read_daemon_pid(config_dir: Path, tier: str) -> int | None:
+    """Return the recorded daemon pid from *config_dir*'s discovery file
+    for *tier*, or ``None`` when absent/unparseable."""
+    from nexus.daemon.discovery import discovery_path
+
+    disc = discovery_path(config_dir, tier=tier)
+    if not disc.exists():
+        return None
+    try:
+        pid = json.loads(disc.read_text()).get("pid")
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    return pid if isinstance(pid, int) and pid > 0 else None
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _cmdline_is_nx_daemon(pid: int) -> bool:
+    """True when *pid*'s command line looks like an ``nx daemon`` process.
+
+    Guards against PID reuse: between reading the discovery file and
+    signalling, the recorded pid could have died and been recycled by an
+    unrelated process. We only ever signal a pid whose live cmdline still
+    names the nx daemon. Works on both macOS and Linux ``ps``.
+    """
+    try:
+        out = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return "daemon" in out and ("nx" in out or "nexus" in out)
+
+
+def reap_tmp_daemons(
+    config_dir: Path, *, tiers: tuple[str, ...] = ("t2", "t3"),
+) -> list[int]:
+    """SIGTERM (escalating to SIGKILL) any daemon recorded in *config_dir*'s
+    discovery files. Returns the pids that were signalled.
+
+    Best-effort and bounded; never raises. Only signals a pid whose live
+    cmdline still names the nx daemon (PID-reuse guard).
+    """
+    reaped: list[int] = []
+    for tier in tiers:
+        pid = _read_daemon_pid(config_dir, tier)
+        if pid is None or not _pid_alive(pid):
+            continue
+        if not _cmdline_is_nx_daemon(pid):
+            continue
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            continue
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and _pid_alive(pid):
+            time.sleep(0.05)
+        if _pid_alive(pid):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+        reaped.append(pid)
+    return reaped

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,6 +311,39 @@ def _reset_aspect_worker_singleton() -> None:
     reset_worker_for_tests()
 
 
+@pytest.fixture(autouse=True)
+def _reap_spawned_daemons(tmp_path: Path):
+    """nexus-scoo5: reap any T2/T3 daemon a test spawned under its own
+    isolated tmp ``NEXUS_CONFIG_DIR``.
+
+    A test that drives a real ``nx upgrade`` (non-``--auto``) reaches
+    ``upgrade._cycle_daemon_to_current()``, which shells out to ``nx daemon
+    t2 ensure-running`` and spawns a *detached* ``nx daemon t2 start`` bound
+    to the per-test config dir. ``subprocess.run`` returns once the daemon
+    is up, so the process outlives the test body and lingers as an orphan
+    after pytest GCs the tmp dir (observed: three orphan daemons on
+    ``garbage-*/test_force0/.config/nexus/memory.db``).
+
+    The autouse ``_isolate_config_dir`` fixture sets ``NEXUS_CONFIG_DIR`` to
+    ``tmp_path / ".config" / "nexus"``, so a spawned daemon's discovery file
+    lands there. This teardown is the process-level analog of the
+    ``pytest_sessionfinish`` cache-file leak guard: it is scoped strictly to
+    that per-test tmp path (and double-guarded by a cmdline check in
+    ``reap_tmp_daemons``), so it can never signal the user's real daemon,
+    whose discovery file lives under ``~/.config/nexus``.
+
+    Best-effort; never raises. Tests that suppress the spawn at source
+    (patching ``_cycle_daemon_to_current``) make this a no-op.
+    """
+    yield
+    from tests._daemon_leak_guard import reap_tmp_daemons
+
+    try:
+        reap_tmp_daemons(tmp_path / ".config" / "nexus")
+    except Exception:  # noqa: BLE001 — teardown guard must never fail a test
+        pass
+
+
 def set_credentials(monkeypatch) -> None:
     """Set required T3/Voyage credential env vars for tests that call _has_credentials().
 

--- a/tests/test_daemon_teardown_reaper.py
+++ b/tests/test_daemon_teardown_reaper.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Regression tests for the test-teardown daemon-leak guard (nexus-scoo5).
+
+Locks in the behaviour of ``tests._daemon_leak_guard.reap_tmp_daemons`` and
+verifies the autouse backstop fixture is wired into the root conftest.
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from nexus.daemon.discovery import discovery_path
+from tests._daemon_leak_guard import reap_tmp_daemons
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _write_discovery(config_dir: Path, tier: str, pid: int) -> None:
+    disc = discovery_path(config_dir, tier=tier)
+    disc.parent.mkdir(parents=True, exist_ok=True)
+    disc.write_text(json.dumps({"format_version": 1, "pid": pid}))
+
+
+def _spawn_daemon_like(argv0: str) -> subprocess.Popen:
+    """Spawn a long-lived process whose argv0 mimics an nx daemon, so the
+    reaper's cmdline PID-reuse guard recognises it. ``exec -a`` rewrites
+    argv0 in place; the resulting pid is the sleeper itself."""
+    return subprocess.Popen(["bash", "-c", f"exec -a '{argv0}' sleep 30"])
+
+
+@pytest.fixture
+def _reap_residue() -> list[subprocess.Popen]:
+    """Kill any sleeper a test forgot to clean up, so the test file itself
+    never leaks (the very class it guards)."""
+    procs: list[subprocess.Popen] = []
+    yield procs
+    for p in procs:
+        if p.poll() is None:
+            p.kill()
+            p.wait(timeout=5)
+
+
+def test_reaps_live_daemon_recorded_in_discovery(
+    tmp_path: Path, _reap_residue: list[subprocess.Popen],
+) -> None:
+    config_dir = tmp_path / ".config" / "nexus"
+    proc = _spawn_daemon_like("nx daemon t2 start")
+    _reap_residue.append(proc)
+    # Let exec -a settle so ps reports the spoofed argv0.
+    time.sleep(0.3)
+    _write_discovery(config_dir, "t2", proc.pid)
+
+    reaped = reap_tmp_daemons(config_dir)
+
+    assert reaped == [proc.pid]
+    # The sleeper is a direct child of pytest, so after termination it is a
+    # zombie until waited (``os.kill(pid, 0)`` still succeeds on a zombie).
+    # ``proc.wait`` reaps it and confirms it was killed by a signal
+    # (negative returncode). In production the daemon is detached/reparented
+    # to init, so this zombie window does not arise.
+    ret = proc.wait(timeout=3)
+    assert ret != 0, f"expected signal-termination, got returncode {ret}"
+
+
+def test_skips_pid_reuse_unrelated_process(
+    tmp_path: Path, _reap_residue: list[subprocess.Popen],
+) -> None:
+    """A recorded pid recycled by an unrelated process must NOT be killed."""
+    config_dir = tmp_path / ".config" / "nexus"
+    # Plain sleep — argv0 is 'sleep', not an nx daemon.
+    proc = subprocess.Popen(["sleep", "30"])
+    _reap_residue.append(proc)
+    time.sleep(0.2)
+    _write_discovery(config_dir, "t2", proc.pid)
+
+    reaped = reap_tmp_daemons(config_dir)
+
+    assert reaped == []
+    assert _pid_alive(proc.pid), "unrelated process must survive the guard"
+
+
+def test_noop_when_no_discovery_file(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".config" / "nexus"
+    assert reap_tmp_daemons(config_dir) == []
+
+
+def test_noop_when_pid_already_dead(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".config" / "nexus"
+    proc = subprocess.Popen(["sleep", "0.01"])
+    proc.wait(timeout=5)
+    _write_discovery(config_dir, "t2", proc.pid)
+    assert reap_tmp_daemons(config_dir) == []
+
+
+def test_autouse_backstop_fixture_is_registered() -> None:
+    """The conftest must expose the autouse teardown reaper, scoped to the
+    per-test tmp config dir (nexus-scoo5 backstop layer)."""
+    import inspect
+
+    import tests.conftest as conftest
+
+    fn = getattr(conftest, "_reap_spawned_daemons", None)
+    assert fn is not None, "conftest is missing _reap_spawned_daemons"
+    src = inspect.getsource(fn)
+    # Strictly scoped to tmp_path so it can never touch the real ~/.config.
+    assert "tmp_path" in src
+    assert "reap_tmp_daemons" in src

--- a/tests/test_upgrade_e2e.py
+++ b/tests/test_upgrade_e2e.py
@@ -32,6 +32,25 @@ def _clear_module_state() -> None:
     catalog_taxonomy._migrated_paths.clear()
 
 
+@pytest.fixture(autouse=True)
+def _no_real_daemon_nudge():
+    """nexus-scoo5: stop in-process ``nx upgrade`` tests from spawning a real
+    detached T2 daemon under the per-test config dir.
+
+    ``upgrade._cycle_daemon_to_current()`` shells out to ``nx daemon t2
+    ensure-running`` (spawning a detached ``nx daemon t2 start``), and
+    ``_quiesce_daemon()`` shells out to ``nx daemon t2 stop``. Neither
+    belongs in these migration-logic/exit-code e2e tests; the spawn was the
+    source of the leaked ``test_force0`` orphan daemons. Mirrors
+    ``test_upgrade_cmd._no_real_daemon_nudge``. The conftest
+    ``_reap_spawned_daemons`` backstop covers anything that slips through."""
+    with (
+        patch("nexus.commands.upgrade._cycle_daemon_to_current"),
+        patch("nexus.commands.upgrade._quiesce_daemon"),
+    ):
+        yield
+
+
 # ── SC-1: _nexus_version table ──────────────────────────────────────────────
 
 

--- a/tests/test_upgrade_name_vs_embed_dim_advisory.py
+++ b/tests/test_upgrade_name_vs_embed_dim_advisory.py
@@ -28,6 +28,20 @@ def _clear_upgrade_done() -> None:
     migrations._upgrade_done.clear()
 
 
+@pytest.fixture(autouse=True)
+def _no_real_daemon_nudge():
+    """nexus-scoo5: these in-process ``nx upgrade`` invocations would
+    otherwise reach ``_cycle_daemon_to_current()`` and spawn a detached T2
+    daemon under the per-test config dir that nothing reaps. Suppress the
+    daemon cycle at source (mirrors ``test_upgrade_cmd._no_real_daemon_nudge``)
+    — these tests assert advisory text + exit code, not the daemon nudge."""
+    with (
+        patch("nexus.commands.upgrade._cycle_daemon_to_current"),
+        patch("nexus.commands.upgrade._quiesce_daemon"),
+    ):
+        yield
+
+
 class TestUpgradeAdvisory:
     def test_no_advisory_when_no_mismatches(
         self, runner: CliRunner, tmp_path: Path,


### PR DESCRIPTION
## Problem

Surfaced during the v5.4.1/5.4.2 shakeout: three orphaned `nx daemon t2 start` processes were found bound to pytest tmp dirs (`garbage-*/test_force0/.config/nexus/memory.db`).

Root cause: in-process `nx upgrade` (non-`--auto`, via `CliRunner`) reaches `upgrade._cycle_daemon_to_current()`, which shells out to `nx daemon t2 ensure-running` and spawns a **detached** `nx daemon t2 start` bound to the per-test `NEXUS_CONFIG_DIR`. `subprocess.run` returns as soon as the daemon is up, so the process outlives the test body and lingers after pytest GCs the tmp dir.

The autouse `_isolate_config_dir` fixture contained the **db location** (tmp, never prod — which is why doctor's singleton check stayed green), but nothing reaped the **process**. The existing `pytest_sessionfinish` guard catches leaked cache *files*, not *processes*.

The codebase already had the right convention (`test_upgrade_cmd._no_real_daemon_nudge`); two upgrade-test files just never adopted it:
- `test_upgrade_e2e.py::TestSC3UpgradeFlags::test_force` (the empirically-confirmed leaker)
- `test_upgrade_name_vs_embed_dim_advisory.py` (confirmed by inspection)

## Fix — two layers

1. **Source:** add the `_no_real_daemon_nudge` autouse patch to both leakers, suppressing the daemon cycle/quiesce subprocesses entirely.
2. **Backstop:** conftest autouse `_reap_spawned_daemons` teardown reaps any daemon recorded under the per-test tmp `NEXUS_CONFIG_DIR`. Scoped strictly to `tmp_path` and double-guarded by a cmdline PID-reuse check, so it can never signal the user's real daemon under `~/.config/nexus`. This is the process-level analog of the cache-file leak guard.

Reaper logic in `tests/_daemon_leak_guard.py` with deterministic regression tests (`tests/test_daemon_teardown_reaper.py`).

## Verification

- `tests/test_daemon_teardown_reaper.py`: 5 passed (live reap, PID-reuse skip, no-discovery no-op, dead-pid no-op, fixture registration).
- Running both former leakers (20 tests) leaves the daemon count unchanged and produces **zero** garbage daemons.
- Daemon-suite regression sweep: 147 passed, zero garbage daemons.

## Closes

Closes #nexus-scoo5