### PR TITLE
release: conexus 5.4.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.4.3"
+        "ref": "v5.4.4"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.4.3"
+      "version": "5.4.4"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.4.3"
+        "ref": "v5.4.4"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.4.3"
+      "version": "5.4.4"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.4.4] - 2026-05-30
+
+### Fixed
+
+- **sn session-start banner is now backend-agnostic.** The compact Serena
+  reminder injected at session start still hardcoded the `jet_brains_` tool
+  prefix (`jet_brains_find_symbol` … `jet_brains_rename`), the same hardcoding
+  the 5.4.3 grep→Serena redirect fix removed. A 5.4.3 post-release shakeout
+  caught that the banner edit was never committed in 5.4.3 (only the grep-hook
+  message landed). The banner now uses bare capability names and notes the
+  prefix varies by backend (JetBrains prefixes `jet_brains_`, LSP is
+  unprefixed), matching the redirect message and the serena-code-nav skill.
+
 ## [5.4.3] - 2026-05-29
 
 ### Fixed

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.4.4] - 2026-05-30
+
+### Fixed
+
+- sn session-start banner made backend-agnostic (JetBrains + LSP), completing
+  the 5.4.3 backend-agnostic work. The banner edit was lost in 5.4.3 (only the
+  grep→Serena redirect message landed); a post-release shakeout caught it.
+
 ## [5.4.3] - 2026-05-29
 
 ### Fixed

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.4.3"
+version = "5.4.4"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.4.3",
+    "conexus>=5.4.4",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.4.3"
+version = "5.4.4"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/sn/hooks/scripts/session-start.sh
+++ b/sn/hooks/scripts/session-start.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# sn SessionStart hook — remind main conversation about Serena + Context7
+# sn SessionStart hook: remind main conversation about Serena + Context7
 # SubagentStart injects full tool signatures; this is a compact reminder.
 
 cat <<'SN'
 
 ## sn: Serena + Context7 (injected by sn plugin)
 
-Serena: LSP code intelligence — `jet_brains_find_symbol`, `find_referencing_symbols`, `get_symbols_overview`, `type_hierarchy`, `replace_symbol_body`, `jet_brains_rename`. Use for symbol tasks; Grep for text.
+Serena: code intelligence for symbol tasks (find_symbol, find_referencing_symbols, get_symbols_overview, type_hierarchy, replace_symbol_body, rename_symbol). Use instead of Grep for symbol work. Tool-name prefix varies by backend: JetBrains prefixes `jet_brains_`, LSP is unprefixed. Load via ToolSearch with both variants, or see the serena-code-nav skill.
 Context7: use `resolve-library-id` + `query-docs` for library/framework docs BEFORE relying on training data.
 SN

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.4.3"
+version = "5.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Patch release completing the 5.4.3 backend-agnostic work. A 5.4.3 post-release shakeout found the sn session-start banner fix was lost (only the grep→Serena redirect message landed in 5.4.3).

## Fixed
- **sn session-start banner is now backend-agnostic.** The compact Serena reminder injected at session start still hardcoded the `jet_brains_` tool prefix (`jet_brains_find_symbol` … `jet_brains_rename`) — the same hardcoding the 5.4.3 grep→Serena redirect fix removed elsewhere. Now uses bare capability names and notes the prefix varies by backend (JetBrains prefixes `jet_brains_`, LSP is unprefixed), matching the redirect message and the serena-code-nav skill. Also drops an em-dash from the script comment.

## Verification
- Full unit suite: **8276 passed, 109 skipped, 0 failed** (11m32s, local).
- Routing suite: 84 passed.
- Sandbox smoke: `[done]`, nx 5.4.4, all checks `[pass]`.
- Seven-target version parity + both changelogs: ALL CLEAR.

## Release mechanics
All seven bump targets at 5.4.4, both `source.ref` at `v5.4.4`. Merge with `--merge` (not squash) to preserve the release commit SHA for tagging.