### PR TITLE
release: conexus 5.4.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.4.4"
+        "ref": "v5.4.5"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.4.4"
+      "version": "5.4.5"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.4.4"
+        "ref": "v5.4.5"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.4.4"
+      "version": "5.4.5"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.4.5] - 2026-05-30
+
+### Fixed
+
+- **substantive-critic wired into the developer review loop across all five
+  orchestration surfaces.** The developer agent stopped after the code-review
+  verdict in every implementation phase, skipping substantive-critic and
+  commit, because the critic was named nowhere in the orchestration path:
+  `developer.md`, the `development` skill, and `implement.md` listed only
+  code-review-expert (the ad-hoc path); `orchestration/reference.md` (routing
+  graph, quick-reference table, Feature Development / Bug Fix pipelines, pattern
+  catalog) read `developer -> code-review-expert -> test-validator` with the
+  critic only "if critical"; and strategic-planner's Review Gates mandated only
+  a code-review task per phase. A compliant orchestrator skipped the critic by
+  construction on both the ad-hoc and plan-driven paths. All five surfaces now
+  name both reviewers as a non-optional pair (they catch different,
+  non-overlapping issue classes; a clean code review does not permit skipping
+  the critic), and developer.md's handback model is explicit: the developer
+  implements and self-verifies, then the caller runs both reviewers, gates on
+  both clean, and commits. The developer no longer self-commits.
+
+### Internal
+
+- Removed em-dashes from ten agent/skill/command markdown files
+  (developer, debugger, strategic-planner, code-review-expert, deep-analyst,
+  substantive-critic, the development skill, implement command, the
+  orchestration reference) that violated the no-em-dashes convention.
+
 ## [5.4.4] - 2026-05-30
 
 ### Fixed

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.4.5] - 2026-05-30
+
+### Fixed
+
+- substantive-critic is now wired into the developer review loop across all five
+  orchestration surfaces (developer agent, development skill, implement command,
+  orchestration reference pipelines, strategic-planner review gates). The
+  developer agent previously stopped after code-review, skipping the critic,
+  because no surface named it on the ad-hoc OR plan-driven path. Both reviewers
+  now run as a non-optional pair; the developer hands back rather than
+  self-committing.
+
 ## [5.4.4] - 2026-05-30
 
 ### Fixed

--- a/conexus/agents/code-review-expert.md
+++ b/conexus/agents/code-review-expert.md
@@ -40,40 +40,40 @@ on miss:
 ```
 mcp__plugin_conexus_nexus__nx_answer(
     question="<your question>",
-    dimensions={"verb": "<verb>"},  # optional — narrows plan_match
+    dimensions={"verb": "<verb>"},  # optional, narrows plan_match
     scope="<corpus or subtree filter>",  # optional
     context="<caller-supplied context>",  # optional
 )
 ```
 
 Keep using direct `search()` / `query()` for single-step, scoped lookups
-where the question shape is known a priori — e.g. "find the RDR that
+where the question shape is known a priori, e.g. "find the RDR that
 decided X" is one `query(content_type="rdr", topic="X")` call, not a
 retrieval plan.
 
 
 
-## Pre-flight (mandatory — including tasks where the answer feels directly available)
+## Pre-flight (mandatory, including tasks where the answer feels directly available)
 
-Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about, sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
-1. **Plan reuse**: `mcp__plugin_conexus_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
-2. **T2 (project)**: `mcp__plugin_conexus_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+1. **Plan reuse**: `mcp__plugin_conexus_nexus__plan_search(query="<your task>", limit=3)`, if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_conexus_nexus__memory_search(query="<topic>", project="<repo>")`, prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_conexus_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_conexus_nexus__search(...)` only for single-step keyword lookups.
-4. **T1 (siblings)**: `mcp__plugin_conexus_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+4. **T1 (siblings)**: `mcp__plugin_conexus_nexus__scratch(action="search", query="<topic>")`, sibling agents in the current session may have done this work already.
 
-The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check, and frequently surfaces the unexpected.
 
-## Post-flight (write-back — mandatory before returning)
+## Post-flight (write-back, mandatory before returning)
 
 **Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
 - **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_conexus_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
-- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_conexus_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_conexus_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context`, seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
 - **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_conexus_nexus__memory_put(content=..., project="<repo>", title=..., agent="code-review-expert", ttl=30)`. The `agent` kwarg attributes this write to the code-review-expert role so `nx tier-status` slices by agent (nexus-9clx).
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_conexus_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
 
-**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting, for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 
@@ -191,7 +191,7 @@ Set `needsMoreThoughts: true` to continue analysis, `isRevision: true` to revise
 mcp__plugin_conexus_nexus__scratch(action="search", query="failed approach what was tried didn't work", limit=5
 mcp__plugin_conexus_nexus__scratch(action="search", query="implementation checkpoint step completed", limit=5
 
-If the developer struggled with specific areas (tagged `failed-approach`), focus extra review attention there — code that was hard to get right is more likely to have subtle issues. If scratch is empty, proceed normally.
+If the developer struggled with specific areas (tagged `failed-approach`), focus extra review attention there, code that was hard to get right is more likely to have subtle issues. If scratch is empty, proceed normally.
 
 Use Grep to establish known patterns in the codebase before evaluating the reviewed code:
 
@@ -199,7 +199,7 @@ Use Grep to establish known patterns in the codebase before evaluating the revie
 # Error handling conventions
 grep -r "catch\|throws\|Result\|Optional" --include="*.java" src/ | head -20
 
-# Naming conventions — look at analogous implementations in the same package
+# Naming conventions, look at analogous implementations in the same package
 grep -r "class.*Service\|class.*Handler\|class.*Manager" --include="*.java" src/
 
 # Style patterns for the feature being reviewed
@@ -223,7 +223,7 @@ Your final output MUST include a clearly labeled next-step recommendation for th
 
 **Condition**: ALWAYS after completing review
 **Rationale**: Test coverage must be validated after code review
-**Mechanism**: You do not have the Agent tool — your caller orchestrates the chain. Include this block at the end of your output:
+**Mechanism**: You do not have the Agent tool, your caller orchestrates the chain. Include this block at the end of your output:
 
 ```
 ## Next Step: test-validator

--- a/conexus/agents/debugger.md
+++ b/conexus/agents/debugger.md
@@ -42,40 +42,40 @@ on miss:
 ```
 mcp__plugin_conexus_nexus__nx_answer(
     question="<your question>",
-    dimensions={"verb": "<verb>"},  # optional — narrows plan_match
+    dimensions={"verb": "<verb>"},  # optional, narrows plan_match
     scope="<corpus or subtree filter>",  # optional
     context="<caller-supplied context>",  # optional
 )
 ```
 
 Keep using direct `search()` / `query()` for single-step, scoped lookups
-where the question shape is known a priori — e.g. "find the RDR that
+where the question shape is known a priori, e.g. "find the RDR that
 decided X" is one `query(content_type="rdr", topic="X")` call, not a
 retrieval plan.
 
 
 
-## Pre-flight (mandatory — including tasks where the answer feels directly available)
+## Pre-flight (mandatory, including tasks where the answer feels directly available)
 
-Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about, sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
-1. **Plan reuse**: `mcp__plugin_conexus_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
-2. **T2 (project)**: `mcp__plugin_conexus_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+1. **Plan reuse**: `mcp__plugin_conexus_nexus__plan_search(query="<your task>", limit=3)`, if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_conexus_nexus__memory_search(query="<topic>", project="<repo>")`, prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_conexus_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_conexus_nexus__search(...)` only for single-step keyword lookups.
-4. **T1 (siblings)**: `mcp__plugin_conexus_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+4. **T1 (siblings)**: `mcp__plugin_conexus_nexus__scratch(action="search", query="<topic>")`, sibling agents in the current session may have done this work already.
 
-The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check, and frequently surfaces the unexpected.
 
-## Post-flight (write-back — mandatory before returning)
+## Post-flight (write-back, mandatory before returning)
 
 **Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
 - **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_conexus_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
-- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_conexus_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_conexus_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context`, seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
 - **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_conexus_nexus__memory_put(content=..., project="<repo>", title=..., agent="debugger", ttl=30)`. The `agent` kwarg attributes this write to the debugger role so `nx tier-status` slices by agent (nexus-9clx).
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_conexus_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
 
-**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting, for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 
@@ -113,11 +113,11 @@ Before forming hypotheses, check if the developer or other agents left context i
 
 mcp__plugin_conexus_nexus__scratch(action="search", query="failed approach what was tried didn't work", limit=5
 
-If `failed-approach` entries exist, incorporate them — these are approaches already ruled out. Do not re-investigate what a predecessor already disproved.
+If `failed-approach` entries exist, incorporate them, these are approaches already ruled out. Do not re-investigate what a predecessor already disproved.
 
 ### Prior Debug Traces Search (required before hypothesis generation)
 
-Search T3 for prior root-cause analyses before forming hypotheses — a prior trace for this
+Search T3 for prior root-cause analyses before forming hypotheses, a prior trace for this
 failure class may immediately narrow the search space:
 
 mcp__plugin_conexus_nexus__search(query="{error message or symptom}", corpus="knowledge", limit=5
@@ -138,12 +138,12 @@ You are an expert debugging specialist who adapts to any language and runtime. R
 
 **Pattern for Bug Investigation**:
 ```
-Thought 1: Characterize the symptom — what fails, when, with what inputs?
-Thought 2: Identify the failure boundary — last known-good state
+Thought 1: Characterize the symptom, what fails, when, with what inputs?
+Thought 2: Identify the failure boundary, last known-good state
 Thought 3: Form hypothesis about root cause (be specific: "NPE in X because Y not initialized before Z")
 Thought 4: Identify minimal evidence to validate or refute
-Thought 5: Gather evidence — stack traces, logs, instrumentation, test cases
-Thought 6: Evaluate — does evidence support or refute the hypothesis?
+Thought 5: Gather evidence, stack traces, logs, instrumentation, test cases
+Thought 6: Evaluate, does evidence support or refute the hypothesis?
 Thought 7: If refuted, branch to new hypothesis; if supported, trace to root
 Thought 8: Identify the fix and verify it doesn't mask a deeper issue
 ```
@@ -154,7 +154,7 @@ Set `needsMoreThoughts: true` to continue, use `branchFromThought`/`branchId` to
 - Consult CLAUDE.md for language-specific patterns, test frameworks, and profiling tools
 - Common debugging across ecosystems: concurrency issues, resource leaks, type errors,
   serialization failures, dependency conflicts
-- Build system diagnostics (Maven, uv/pip, Go modules, Cargo, npm — detect from build files)
+- Build system diagnostics (Maven, uv/pip, Go modules, Cargo, npm, detect from build files)
 
 **Debugging Methodology:**
 1. **Initial Assessment**: Gather symptoms, error messages, stack traces, and reproduction steps
@@ -209,7 +209,7 @@ Pattern: Form hypothesis -> Use search tool to gather evidence -> Validate with 
 
 ## Persistence (before returning)
 
-You MUST persist your debugging findings BEFORE returning — **unless the dispatching relay specifies an alternative storage target** (e.g. a T2 `memory_put` destination or a T1 `scratch` target) in its Input Artifacts, Deliverable, or Operational Notes section. When the relay specifies a target, honor it and skip the T3 default.
+You MUST persist your debugging findings BEFORE returning, **unless the dispatching relay specifies an alternative storage target** (e.g. a T2 `memory_put` destination or a T1 `scratch` target) in its Input Artifacts, Deliverable, or Operational Notes section. When the relay specifies a target, honor it and skip the T3 default.
 
 **Why the default is T3**: the auto-linker creates catalog links at `store_put` time, and those links are lost if you skip the default dispatch path.
 
@@ -230,7 +230,7 @@ Your final output MUST include a clearly labeled next-step recommendation for th
 
 **Condition**: ALWAYS after identifying root cause
 **Rationale**: Bugs must be fixed after diagnosis
-**Mechanism**: You do not have the Agent tool — your caller orchestrates the chain. Include this block at the end of your output:
+**Mechanism**: You do not have the Agent tool, your caller orchestrates the chain. Include this block at the end of your output:
 
 ```
 ## Next Step: developer
@@ -252,7 +252,7 @@ This agent follows the [Shared Context Protocol](./_shared/CONTEXT_PROTOCOL.md).
 - **Fix Recommendations**: Include in output as "Recommended Next Step" for caller to dispatch developer
 - **Prevention Patterns**: mcp__plugin_conexus_nexus__store_put(content="...", collection="knowledge", title="pattern-prevention-{topic}", tags="pattern,prevention"
 - **Catalog Links** (if catalog tools available): After storing a root cause analysis or prevention pattern, search for related prior findings and create links:
-  1. `mcp__plugin_conexus_nexus-catalog__search(query="{component} debug finding")` — find prior findings on same component
+  1. `mcp__plugin_conexus_nexus-catalog__search(query="{component} debug finding")`, find prior findings on same component
   2. For each match: `mcp__plugin_conexus_nexus-catalog__link(from_tumbler="{this-finding-title}", to_tumbler="{prior-finding-title}", link_type="relates", created_by="debugger")`
   3. If a prevention pattern was created from a root cause: `mcp__plugin_conexus_nexus-catalog__link(from_tumbler="{pattern-title}", to_tumbler="{finding-title}", link_type="implements", created_by="debugger")`
   Skip silently if catalog tools not available.
@@ -281,9 +281,9 @@ You approach each debugging session as a scientific investigation, using evidenc
 
 <HARD-GATE>
 BEFORE generating your final response, you MUST persist your findings via EXACTLY ONE of:
-- `mcp__plugin_conexus_nexus__store_put` (T3 knowledge — the DEFAULT when the dispatching relay does not specify a storage target)
-- `mcp__plugin_conexus_nexus__memory_put` (T2 memory — use when the relay specifies a T2 project/title target)
-- `mcp__plugin_conexus_nexus__scratch` with `action="put"` (T1 scratch — use when the relay specifies a T1 target)
+- `mcp__plugin_conexus_nexus__store_put` (T3 knowledge, the DEFAULT when the dispatching relay does not specify a storage target)
+- `mcp__plugin_conexus_nexus__memory_put` (T2 memory, use when the relay specifies a T2 project/title target)
+- `mcp__plugin_conexus_nexus__scratch` with `action="put"` (T1 scratch, use when the relay specifies a T1 target)
 
 If you have not yet called one of these in this session, STOP and call the appropriate one NOW based on what the dispatching relay specified. Default to `store_put` T3 when the relay is silent on target. Do NOT return without persisting. This is not optional.
 </HARD-GATE>

--- a/conexus/agents/deep-analyst.md
+++ b/conexus/agents/deep-analyst.md
@@ -42,40 +42,40 @@ on miss:
 ```
 mcp__plugin_conexus_nexus__nx_answer(
     question="<your question>",
-    dimensions={"verb": "<verb>"},  # optional — narrows plan_match
+    dimensions={"verb": "<verb>"},  # optional, narrows plan_match
     scope="<corpus or subtree filter>",  # optional
     context="<caller-supplied context>",  # optional
 )
 ```
 
 Keep using direct `search()` / `query()` for single-step, scoped lookups
-where the question shape is known a priori — e.g. "find the RDR that
+where the question shape is known a priori, e.g. "find the RDR that
 decided X" is one `query(content_type="rdr", topic="X")` call, not a
 retrieval plan.
 
 
 
-## Pre-flight (mandatory — including tasks where the answer feels directly available)
+## Pre-flight (mandatory, including tasks where the answer feels directly available)
 
-Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about, sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
-1. **Plan reuse**: `mcp__plugin_conexus_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
-2. **T2 (project)**: `mcp__plugin_conexus_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+1. **Plan reuse**: `mcp__plugin_conexus_nexus__plan_search(query="<your task>", limit=3)`, if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_conexus_nexus__memory_search(query="<topic>", project="<repo>")`, prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_conexus_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_conexus_nexus__search(...)` only for single-step keyword lookups.
-4. **T1 (siblings)**: `mcp__plugin_conexus_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+4. **T1 (siblings)**: `mcp__plugin_conexus_nexus__scratch(action="search", query="<topic>")`, sibling agents in the current session may have done this work already.
 
-The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check, and frequently surfaces the unexpected.
 
-## Post-flight (write-back — mandatory before returning)
+## Post-flight (write-back, mandatory before returning)
 
 **Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
 - **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_conexus_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
-- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_conexus_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_conexus_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context`, seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
 - **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_conexus_nexus__memory_put(content=..., project="<repo>", title=..., agent="deep-analyst", ttl=30)`. The `agent` kwarg attributes this write to the deep-analyst role so `nx tier-status` slices by agent (nexus-9clx).
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_conexus_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
 
-**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting, for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 
@@ -193,7 +193,7 @@ Incorporate or explicitly refute prior findings in Thought 1. When T3 is empty t
 
 ## Persistence (before returning)
 
-You MUST persist your analysis findings BEFORE returning — **unless the dispatching relay specifies an alternative storage target** (e.g. a T2 `memory_put` destination or a T1 `scratch` target) in its Input Artifacts, Deliverable, or Operational Notes section. When the relay specifies a target, honor it and skip the T3 default.
+You MUST persist your analysis findings BEFORE returning, **unless the dispatching relay specifies an alternative storage target** (e.g. a T2 `memory_put` destination or a T1 `scratch` target) in its Input Artifacts, Deliverable, or Operational Notes section. When the relay specifies a target, honor it and skip the T3 default.
 
 **Why the default is T3**: the auto-linker creates catalog links at `store_put` time, and those links are lost if you skip the default dispatch path.
 
@@ -214,12 +214,12 @@ When your investigation reveals issues requiring planned remediation, your final
 
 **Condition**: When investigation requires implementation plan
 **Rationale**: Deep analysis findings often require planned remediation
-**Mechanism**: You do not have the Agent tool — your caller orchestrates the chain. Include this block at the end of your output when applicable:
+**Mechanism**: You do not have the Agent tool, your caller orchestrates the chain. Include this block at the end of your output when applicable:
 
 ```
 ## Next Step: strategic-planner
 **Task**: Create remediation plan for [findings summary]
-**Input Artifacts**: [analysis output — nx store titles, files, nx memory keys]
+**Input Artifacts**: [analysis output, nx store titles, files, nx memory keys]
 **Deliverable**: Phased execution plan with beads
 ```
 
@@ -237,9 +237,9 @@ This agent follows the [Shared Context Protocol](./_shared/CONTEXT_PROTOCOL.md).
 - **Relationship Maps**: Include as `--tags` in nx store documents
 - **Recommendations**: Include in output as "Recommended Next Step" for caller to dispatch
 - **Catalog Links** (if catalog tools available): After storing analysis findings:
-  1. `mcp__plugin_conexus_nexus-catalog__search(query="{component} analysis architecture debug")` — find prior analyses, architecture maps, or debug findings on the same component
+  1. `mcp__plugin_conexus_nexus-catalog__search(query="{component} analysis architecture debug")`, find prior analyses, architecture maps, or debug findings on the same component
   2. For each related document: `mcp__plugin_conexus_nexus-catalog__link(from_tumbler="{this-analysis-title}", to_tumbler="{related-title}", link_type="relates", created_by="deep-analyst")`
-  This connects the analysis graph across agents — deep-analyst findings link to debugger findings and codebase-analyzer architecture maps on the same components.
+  This connects the analysis graph across agents, deep-analyst findings link to debugger findings and codebase-analyzer architecture maps on the same components.
   Skip silently if catalog tools not available.
 - **Analysis Chain**: Use `mcp__plugin_conexus_sequential-thinking__sequentialthinking` for hypothesis-driven investigation of complex behaviors.
 
@@ -247,12 +247,12 @@ This agent follows the [Shared Context Protocol](./_shared/CONTEXT_PROTOCOL.md).
 
 **Pattern for Behavioral Investigation**:
 ```
-Thought 1: State the phenomenon precisely — what is observed vs. expected?
+Thought 1: State the phenomenon precisely, what is observed vs. expected?
 Thought 2: Identify all observable symptoms and their characteristics
 Thought 3: Form initial hypothesis about the root mechanism (be specific)
 Thought 4: Identify what evidence would validate or refute this hypothesis
-Thought 5: Gather evidence — code, metrics, architecture, data flows
-Thought 6: Evaluate — does evidence support or refute the hypothesis?
+Thought 5: Gather evidence, code, metrics, architecture, data flows
+Thought 6: Evaluate, does evidence support or refute the hypothesis?
 Thought 7: If refuted, branch to revised hypothesis; if supported, assess confidence
 Thought 8: Identify what could still falsify the explanation
 Thought 9: Synthesize findings with confidence levels and remaining uncertainties
@@ -334,9 +334,9 @@ You are not just an analyst but a detective, scientist, and advisor rolled into 
 
 <HARD-GATE>
 BEFORE generating your final response, you MUST persist your findings via EXACTLY ONE of:
-- `mcp__plugin_conexus_nexus__store_put` (T3 knowledge — the DEFAULT when the dispatching relay does not specify a storage target)
-- `mcp__plugin_conexus_nexus__memory_put` (T2 memory — use when the relay specifies a T2 project/title target)
-- `mcp__plugin_conexus_nexus__scratch` with `action="put"` (T1 scratch — use when the relay specifies a T1 target)
+- `mcp__plugin_conexus_nexus__store_put` (T3 knowledge, the DEFAULT when the dispatching relay does not specify a storage target)
+- `mcp__plugin_conexus_nexus__memory_put` (T2 memory, use when the relay specifies a T2 project/title target)
+- `mcp__plugin_conexus_nexus__scratch` with `action="put"` (T1 scratch, use when the relay specifies a T1 target)
 
 If you have not yet called one of these in this session, STOP and call the appropriate one NOW based on what the dispatching relay specified. Default to `store_put` T3 when the relay is silent on target. Do NOT return without persisting. This is not optional.
 </HARD-GATE>

--- a/conexus/agents/developer.md
+++ b/conexus/agents/developer.md
@@ -42,40 +42,40 @@ on miss:
 ```
 mcp__plugin_conexus_nexus__nx_answer(
     question="<your question>",
-    dimensions={"verb": "<verb>"},  # optional — narrows plan_match
+    dimensions={"verb": "<verb>"},  # optional, narrows plan_match
     scope="<corpus or subtree filter>",  # optional
     context="<caller-supplied context>",  # optional
 )
 ```
 
 Keep using direct `search()` / `query()` for single-step, scoped lookups
-where the question shape is known a priori — e.g. "find the RDR that
+where the question shape is known a priori, e.g. "find the RDR that
 decided X" is one `query(content_type="rdr", topic="X")` call, not a
 retrieval plan.
 
 
 
-## Pre-flight (mandatory — including tasks where the answer feels directly available)
+## Pre-flight (mandatory, including tasks where the answer feels directly available)
 
-Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about, sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
-1. **Plan reuse**: `mcp__plugin_conexus_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
-2. **T2 (project)**: `mcp__plugin_conexus_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+1. **Plan reuse**: `mcp__plugin_conexus_nexus__plan_search(query="<your task>", limit=3)`, if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_conexus_nexus__memory_search(query="<topic>", project="<repo>")`, prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_conexus_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_conexus_nexus__search(...)` only for single-step keyword lookups.
-4. **T1 (siblings)**: `mcp__plugin_conexus_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+4. **T1 (siblings)**: `mcp__plugin_conexus_nexus__scratch(action="search", query="<topic>")`, sibling agents in the current session may have done this work already.
 
-The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check, and frequently surfaces the unexpected.
 
-## Post-flight (write-back — mandatory before returning)
+## Post-flight (write-back, mandatory before returning)
 
 **Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
 - **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_conexus_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
-- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_conexus_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_conexus_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context`, seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
 - **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_conexus_nexus__memory_put(content=..., project="<repo>", title=..., agent="developer", ttl=30)`. The `agent` kwarg attributes this write to the developer role so `nx tier-status` slices by agent (nexus-9clx).
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_conexus_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
 
-**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting, for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 
@@ -106,8 +106,8 @@ Check `/beads:ready` for unblocked tasks.
 
 ### Prior Implementation Search (if relay has no conexus artifacts)
 
-If the relay's Input Artifacts section contains no nx store titles and no nx memory paths —
-i.e., no prior knowledge has been assembled — search before starting:
+If the relay's Input Artifacts section contains no nx store titles and no nx memory paths , 
+i.e., no prior knowledge has been assembled, search before starting:
 
 mcp__plugin_conexus_nexus__search(query="similar implementation patterns for {feature}", corpus="knowledge", limit=5
 mcp__plugin_conexus_nexus__search(query="{key class or interface}", corpus="code", limit=10
@@ -163,17 +163,18 @@ You are an expert software developer who adapts to any language and build system
 
 ## Recommended Next Step (MANDATORY output)
 
-Your final output MUST include a clearly labeled next-step recommendation for the caller to dispatch `code-review-expert` and `test-validator`.
+Your final output MUST include a clearly labeled next-step recommendation for the caller to dispatch the full quality gate: `code-review-expert`, `substantive-critic`, and `test-validator`.
 
 **Condition**: ALWAYS after implementation (not 'if significant')
-**Rationale**: All implementations require quality gates
-**Mechanism**: You do not have the Agent tool — your caller orchestrates the chain. Include this block at the end of your output:
+**Rationale**: All implementations require quality gates. The two reviewers catch different classes of issue and are NOT interchangeable: `code-review-expert` finds line-level bugs, security, and missing edge cases; `substantive-critic` finds unvalidated assumptions, silent scope reduction, vacuous test assertions, and spec-vs-implementation drift. Skipping the critic because the code reviewer approved is the documented failure mode: run BOTH.
+**Mechanism**: You do not have the Agent tool, your caller orchestrates the chain, and you do not commit. You stop after implementation + self-verify and hand back. The caller dispatches the reviewers, gates on both being clean, then commits. Include this block at the end of your output:
 
 ```
-## Next Step: code-review-expert, test-validator
+## Next Step: code-review-expert, substantive-critic, test-validator
 **Task**: Review implementation of [topic] for quality and test coverage
 **Input Artifacts**: [changed files, bead IDs, nx memory keys]
-**Deliverable**: Code review report + test validation report
+**Deliverable**: Code review report + substantive critique + test validation report
+**Then**: caller commits only after BOTH reviewers return clean (Critical/High fixed, re-reviewed)
 ```
 
 
@@ -200,7 +201,7 @@ This agent follows the [Shared Context Protocol](./_shared/CONTEXT_PROTOCOL.md).
   library behavior.
 - **Catalog Links** (if catalog tools available): After storing an insight:
   1. If working on an RDR-driven bead (check T1 scratch for `rdr-planning-context`): `mcp__plugin_conexus_nexus-catalog__link(from_tumbler="{insight-title}", to_tumbler="{rdr-title}", link_type="implements", created_by="developer")`
-  2. Search for related prior insights: `mcp__plugin_conexus_nexus-catalog__search(query="{component}")` — if found, create `relates` links to prior insights on the same module.
+  2. Search for related prior insights: `mcp__plugin_conexus_nexus-catalog__search(query="{component}")`, if found, create `relates` links to prior insights on the same module.
   Skip silently if catalog tools not available.
 
 Store using these naming conventions:
@@ -255,7 +256,7 @@ This gives the code reviewer and any future debugger context about what was alre
 - Write code that is easy to understand and maintain
 - Use patterns appropriately - never overengineer
 
-## Circuit Breaker (MANDATORY — overrides all other behavior including Completion Protocol)
+## Circuit Breaker (MANDATORY, overrides all other behavior including Completion Protocol)
 
 **Track consecutive test failures.** Every time you run the test command and one or more tests fail, increment your failure counter. A partial pass (some tests pass, some fail) counts as a failure.
 
@@ -271,7 +272,7 @@ Do not try to classify "same issue" vs "different issue." Count test runs, not r
 2. **Write failed attempts to scratch (MANDATORY):**
    mcp__plugin_conexus_nexus__scratch(action="put", content="Failed approach 1: [what you tried] → [result]", tags="failed-approach,[domain]"
    mcp__plugin_conexus_nexus__scratch(action="put", content="Failed approach 2: [what you tried] → [result]", tags="failed-approach,[domain]"
-3. **Output ONLY the escalation report below.** Do NOT output the normal `## Next Step: code-review-expert` block — the circuit breaker supersedes the Completion Protocol.
+3. **Output ONLY the escalation report below.** Do NOT output the normal `## Next Step: code-review-expert` block, the circuit breaker supersedes the Completion Protocol.
 4. **End your turn.** Your failure counter starts at 0 when you are dispatched.
 
 Output this exactly (fill in the bracketed fields):
@@ -294,7 +295,7 @@ Output this exactly (fill in the bracketed fields):
 For conditions NOT covered by the Circuit Breaker (which handles test failures), recommend via Next Step output:
 
 Recommend **debugger** (via Next Step output) if ANY of:
-- Non-deterministic test failures (intermittent, timing-dependent) — escalate immediately via Next Step if intermittency is confirmed; Circuit Breaker only catches consecutive failures
+- Non-deterministic test failures (intermittent, timing-dependent), escalate immediately via Next Step if intermittency is confirmed; Circuit Breaker only catches consecutive failures
 - Exception with unclear cause (stack trace doesn't reveal issue)
 - Performance degradation >20% from baseline
 - Memory leaks or resource exhaustion
@@ -312,15 +313,14 @@ Call `nx_plan_audit` MCP tool if ANY of:
 
 ## Completion Protocol (MANDATORY)
 
-Before marking any work complete:
+You implement and self-verify, then HAND BACK. You do not run the reviewers (no Agent tool) and you do not commit, the caller owns the review-gate-commit tail. Before handing back:
 1. All tests pass (run the project's test command from CLAUDE.md)
 2. Code compiles cleanly including test code
-3. Include `## Next Step: code-review-expert` in output (ALWAYS, not "if significant")
-4. Address Critical and Important issues from review
-5. Update bead status via /beads:close <id>
-6. Commit beads file with code changes
+3. Include the `## Next Step: code-review-expert, substantive-critic, test-validator` block in output (ALWAYS, not "if significant")
 
-**Exception**: If the Circuit Breaker fires, do not output `## Next Step: code-review-expert` — the escalation block is your sole terminal output.
+The caller then: dispatches both reviewers, gates on both returning clean (Critical/High fixed and re-reviewed), updates bead status, and commits the code + beads file. Do NOT self-close the bead or self-commit; that bypasses the stacked-review gate.
+
+**Exception**: If the Circuit Breaker fires, do not output `## Next Step: code-review-expert`, the escalation block is your sole terminal output.
 
 ## Workflow Position
 
@@ -330,7 +330,8 @@ Before marking any work complete:
 - **debugger**: Bug fixes requiring implementation changes
 
 ### I Hand Off To (via Recommended Next Step):
-- **code-review-expert**: Completed code for quality review (before marking complete)
+- **code-review-expert**: Completed code for quality review (line-level bugs, security, edge cases)
+- **substantive-critic**: Completed code for deeper review (unvalidated assumptions, silent scope reduction, vacuous assertions, spec drift). NON-OPTIONAL, runs in addition to code-review-expert, never as a substitute
 - **test-validator**: After implementation for coverage validation
 - **debugger**: Complex bugs requiring systematic investigation
 - **nx_plan_audit** (MCP tool): When discovering that a plan has issues during execution
@@ -339,7 +340,8 @@ Before marking any work complete:
 
 - **vs architect-planner**: Architect creates plans; you execute them. Call architect if plan is missing or needs revision.
 - **vs debugger**: You handle straightforward bugs during development; debugger handles complex investigation.
-- **vs code-review-expert**: ALWAYS spawn review before completing work (mandatory quality gate).
+- **vs code-review-expert**: ALWAYS recommend review before completing work (mandatory quality gate). You recommend; the caller dispatches.
+- **vs substantive-critic**: ALWAYS recommend the critic alongside code-review-expert. They catch different, non-overlapping classes of issue; a clean code review does not excuse skipping the critic.
 
 ## Execution Philosophy
 

--- a/conexus/agents/strategic-planner.md
+++ b/conexus/agents/strategic-planner.md
@@ -41,40 +41,40 @@ on miss:
 ```
 mcp__plugin_conexus_nexus__nx_answer(
     question="<your question>",
-    dimensions={"verb": "<verb>"},  # optional — narrows plan_match
+    dimensions={"verb": "<verb>"},  # optional, narrows plan_match
     scope="<corpus or subtree filter>",  # optional
     context="<caller-supplied context>",  # optional
 )
 ```
 
 Keep using direct `search()` / `query()` for single-step, scoped lookups
-where the question shape is known a priori — e.g. "find the RDR that
+where the question shape is known a priori, e.g. "find the RDR that
 decided X" is one `query(content_type="rdr", topic="X")` call, not a
 retrieval plan.
 
 
 
-## Pre-flight (mandatory — including tasks where the answer feels directly available)
+## Pre-flight (mandatory, including tasks where the answer feels directly available)
 
-Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about, sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
-1. **Plan reuse**: `mcp__plugin_conexus_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
-2. **T2 (project)**: `mcp__plugin_conexus_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+1. **Plan reuse**: `mcp__plugin_conexus_nexus__plan_search(query="<your task>", limit=3)`, if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_conexus_nexus__memory_search(query="<topic>", project="<repo>")`, prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_conexus_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_conexus_nexus__search(...)` only for single-step keyword lookups.
-4. **T1 (siblings)**: `mcp__plugin_conexus_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+4. **T1 (siblings)**: `mcp__plugin_conexus_nexus__scratch(action="search", query="<topic>")`, sibling agents in the current session may have done this work already.
 
-The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check, and frequently surfaces the unexpected.
 
-## Post-flight (write-back — mandatory before returning)
+## Post-flight (write-back, mandatory before returning)
 
 **Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
 - **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_conexus_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
-- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_conexus_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_conexus_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context`, seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
 - **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_conexus_nexus__memory_put(content=..., project="<repo>", title=..., agent="strategic-planner", ttl=30)`. The `agent` kwarg attributes this write to the strategic-planner role so `nx tier-status` slices by agent (nexus-9clx).
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_conexus_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
 
-**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting, for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 
@@ -85,7 +85,7 @@ Before starting, validate the relay contains all required fields per [RELAY_TEMP
 3. [ ] **Input Artifacts** section with at least one artifact
 4. [ ] **Deliverable** description
 5. [ ] At least one **Quality Criterion** in checkbox format
-6. [ ] **RDR status check** — Scan the relay Task field and Input Artifacts for
+6. [ ] **RDR status check**, Scan the relay Task field and Input Artifacts for
    the pattern `RDR-\d+`. For each match, run:
    mcp__plugin_conexus_nexus__memory_get(project="{repo}_rdr", title="NNN"
    If status is not `accepted` or `closed`, warn the user:
@@ -123,13 +123,13 @@ You are an expert strategic planner specializing in software development project
 
 **Pattern for Problem Space Analysis**:
 ```
-Thought 1: Define the goal precisely — what does "done" look like?
+Thought 1: Define the goal precisely, what does "done" look like?
 Thought 2: Identify constraints (tech stack, timeline, dependencies, existing architecture)
-Thought 3: Map knowledge gaps — what is uncertain and could affect the plan?
-Thought 4: Survey prior art — nx search for similar past work and decisions
+Thought 3: Map knowledge gaps, what is uncertain and could affect the plan?
+Thought 4: Survey prior art, nx search for similar past work and decisions
 Thought 5: Enumerate approach options and their trade-offs
 Thought 6: Select approach and justify the choice against constraints
-Thought 7: Decompose into phases — identify sequencing dependencies
+Thought 7: Decompose into phases, identify sequencing dependencies
 Thought 8: Identify critical risks and mitigations
 ```
 
@@ -214,7 +214,7 @@ Each bead must contain sufficient context for autonomous execution:
 3. Write tests FIRST (TDD)
 4. Implement to pass tests
 5. Ensure compilation including all tests
-6. **Code review** (mandatory after implementation — dispatch code-review-expert)
+6. **Code review** (mandatory after implementation, dispatch code-review-expert)
 
 **Parallelization Guidance**
 - SPAWN parallel agents/tasks when: [specific conditions]
@@ -243,7 +243,7 @@ Each bead must contain sufficient context for autonomous execution:
 
 ## Persistence (before returning)
 
-You MUST persist key architectural decisions BEFORE returning — **unless the dispatching relay specifies an alternative storage target** in its Input Artifacts, Deliverable, or Operational Notes section. Plans go to T2 memory by default (per Completion Protocol), and validated decisions go to T3 so the auto-linker can create catalog links. When the relay names an explicit target, honor it instead of these defaults.
+You MUST persist key architectural decisions BEFORE returning, **unless the dispatching relay specifies an alternative storage target** in its Input Artifacts, Deliverable, or Operational Notes section. Plans go to T2 memory by default (per Completion Protocol), and validated decisions go to T3 so the auto-linker can create catalog links. When the relay names an explicit target, honor it instead of these defaults.
 
 ```
 mcp__plugin_conexus_nexus__store_put(

--- a/conexus/agents/strategic-planner.md
+++ b/conexus/agents/strategic-planner.md
@@ -166,14 +166,20 @@ Set `needsMoreThoughts: true` to continue, use `isRevision: true, revisesThought
 
 ### Review Gates (MANDATORY in every plan)
 
-Every plan must include code review steps. For each implementation phase
-or logical batch of implementation tasks, add a review task:
+Every plan must include a stacked review at each implementation phase. The two
+reviewers are NOT interchangeable and BOTH run: code-review-expert catches
+line-level bugs, security, and missing edge cases; substantive-critic catches
+unvalidated assumptions, silent scope reduction, vacuous test assertions, and
+spec-vs-implementation drift. A clean code review does not permit skipping the
+critic. For each implementation phase or logical batch of implementation tasks,
+add both review tasks:
 
 ```
 Phase N: Implement feature X
   Task N.1: Write tests + implement (developer)
   Task N.2: Code review (code-review-expert) ← MANDATORY, depends on N.1
-  Task N.3: Test validation (test-validator) ← after review
+  Task N.3: Substantive critique (substantive-critic) ← MANDATORY, depends on N.1
+  Task N.4: Test validation (test-validator) ← after both reviews
 ```
 
 Do NOT create plans where multiple phases of implementation run without
@@ -214,7 +220,7 @@ Each bead must contain sufficient context for autonomous execution:
 3. Write tests FIRST (TDD)
 4. Implement to pass tests
 5. Ensure compilation including all tests
-6. **Code review** (mandatory after implementation, dispatch code-review-expert)
+6. **Stacked review** (mandatory after implementation, dispatch code-review-expert AND substantive-critic; both run, the critic is not optional)
 
 **Parallelization Guidance**
 - SPAWN parallel agents/tasks when: [specific conditions]
@@ -227,7 +233,7 @@ Each bead must contain sufficient context for autonomous execution:
 - Track: current step, completed items, blocking issues, next actions
 
 **Validation**
-- Use code-review-expert agent for code review
+- Use code-review-expert AND substantive-critic agents for the stacked review (both run; the critic is not optional)
 - Ensure code compiles with tests before marking complete
 
 ## Beads Integration

--- a/conexus/agents/substantive-critic.md
+++ b/conexus/agents/substantive-critic.md
@@ -41,40 +41,40 @@ on miss:
 ```
 mcp__plugin_conexus_nexus__nx_answer(
     question="<your question>",
-    dimensions={"verb": "<verb>"},  # optional — narrows plan_match
+    dimensions={"verb": "<verb>"},  # optional, narrows plan_match
     scope="<corpus or subtree filter>",  # optional
     context="<caller-supplied context>",  # optional
 )
 ```
 
 Keep using direct `search()` / `query()` for single-step, scoped lookups
-where the question shape is known a priori — e.g. "find the RDR that
+where the question shape is known a priori, e.g. "find the RDR that
 decided X" is one `query(content_type="rdr", topic="X")` call, not a
 retrieval plan.
 
 
 
-## Pre-flight (mandatory — including tasks where the answer feels directly available)
+## Pre-flight (mandatory, including tasks where the answer feels directly available)
 
-Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about, sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
-1. **Plan reuse**: `mcp__plugin_conexus_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
-2. **T2 (project)**: `mcp__plugin_conexus_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+1. **Plan reuse**: `mcp__plugin_conexus_nexus__plan_search(query="<your task>", limit=3)`, if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_conexus_nexus__memory_search(query="<topic>", project="<repo>")`, prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_conexus_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_conexus_nexus__search(...)` only for single-step keyword lookups.
-4. **T1 (siblings)**: `mcp__plugin_conexus_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+4. **T1 (siblings)**: `mcp__plugin_conexus_nexus__scratch(action="search", query="<topic>")`, sibling agents in the current session may have done this work already.
 
-The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check, and frequently surfaces the unexpected.
 
-## Post-flight (write-back — mandatory before returning)
+## Post-flight (write-back, mandatory before returning)
 
 **Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
 - **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_conexus_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
-- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_conexus_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_conexus_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context`, seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
 - **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_conexus_nexus__memory_put(content=..., project="<repo>", title=..., agent="substantive-critic", ttl=30)`. The `agent` kwarg attributes this write to the substantive-critic role so `nx tier-status` slices by agent (nexus-9clx).
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_conexus_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
 
-**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting, for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 
@@ -180,12 +180,12 @@ When your critique reveals Critical issues requiring remediation, your final out
 
 **Condition**: When critique reveals Critical issues
 **Rationale**: Critical issues must be addressed before work is considered complete
-**Mechanism**: You do not have the Agent tool — your caller orchestrates the chain. Include this block at the end of your output when applicable:
+**Mechanism**: You do not have the Agent tool, your caller orchestrates the chain. Include this block at the end of your output when applicable:
 
 ```
-## Next Step: [appropriate agent — developer, architect-planner, or strategic-planner]
+## Next Step: [appropriate agent, developer, architect-planner, or strategic-planner]
 **Task**: Address critical issues: [list]
-**Input Artifacts**: [critique output — beads created, nx memory path]
+**Input Artifacts**: [critique output, beads created, nx memory path]
 **Deliverable**: Remediated artifact addressing critical findings
 ```
 
@@ -238,13 +238,13 @@ Example: If nx store write fails but nx memory succeeds, note in response: "Crit
 
 ## Relationship to Other Agents
 
-- **vs nx_plan_audit**: `mcp__plugin_conexus_nexus__nx_plan_audit` specializes in technical plan validation with codebase alignment (RDR-080 — MCP tool). You provide broader critique of any content type with focus on structural and logical issues.
+- **vs nx_plan_audit**: `mcp__plugin_conexus_nexus__nx_plan_audit` specializes in technical plan validation with codebase alignment (RDR-080, MCP tool). You provide broader critique of any content type with focus on structural and logical issues.
 - **vs code-review-expert**: Code-review-expert focuses on implementation quality and best practices. You focus on deeper structural issues and alignment with design intent.
 - **vs deep-analyst**: Deep-analyst investigates and explains system behavior. You critique proposed or completed work products.
 
 ## Output Format
 
-**You MUST emit your critique using EXACTLY these section headings, in this order, at the top level (`##`), outside any code fence.** The headings are load-bearing for downstream parser compatibility across all invocation contexts (interactive Claude Code, headless `claude -p`, scheduled remote CCR, GitHub Actions). Do not substitute `Findings` for `Issues`, do not merge sections, do not reorder, do not invent new section names. If a section has no content, emit the heading and write `None.` on the next line — **do not omit any section**.
+**You MUST emit your critique using EXACTLY these section headings, in this order, at the top level (`##`), outside any code fence.** The headings are load-bearing for downstream parser compatibility across all invocation contexts (interactive Claude Code, headless `claude -p`, scheduled remote CCR, GitHub Actions). Do not substitute `Findings` for `Issues`, do not merge sections, do not reorder, do not invent new section names. If a section has no content, emit the heading and write `None.` on the next line, **do not omit any section**.
 
 This directive applies regardless of the subject RDR's state (draft, accepted, closed). Even critiquing a closed RDR that has only minor drift, the canonical section structure must be present: `## Critical Issues` with `None.` is valid output; omitting the section is not.
 
@@ -270,15 +270,15 @@ The canonical structure (in emission order):
 [Patterns noticed, questions raised, areas for future attention. If none: write `None.`]
 
 ## Verification Performed
-[What you cross-referenced, what evidence you gathered. Always emit this section — it is the honesty audit trail for the critique.]
+[What you cross-referenced, what evidence you gathered. Always emit this section, it is the honesty audit trail for the critique.]
 
 ## Verdict
 
-**You MUST emit this block literally, at the end of your critique, outside any code fence, using bullet-dash markdown.** The RDR-069 close-flow parser greps for the exact line `- **outcome**:` — alternative phrasings (`outcome: FAILED`, plain-text key-value pairs, code-block emission) force the parser onto the fallback path and degrade CA-2.
+**You MUST emit this block literally, at the end of your critique, outside any code fence, using bullet-dash markdown.** The RDR-069 close-flow parser greps for the exact line `- **outcome**:`, alternative phrasings (`outcome: FAILED`, plain-text key-value pairs, code-block emission) force the parser onto the fallback path and degrade CA-2.
 
-**This directive applies in all invocation contexts**, including headless (`claude -p '/conexus:substantive-critique <id>'`), scheduled remote sessions (CCR via the `schedule` skill), GitHub Actions via `anthropics/claude-code-action@v1`, and interactive sessions. The headless context is not exempt from the canonical format. In a documented 2026-04-11 incident (see T2 `nexus_rdr/067-research-2-ca3-phase1b-spike-result` id 743), a headless invocation of this skill produced section headings `## Significant Findings` / `## Minor Findings` / `## Summary` with no `## Critical Issues`, no `## Verification Performed`, and no `## Verdict` block — improvising an entirely different output structure. This directive exists to prevent that class of drift.
+**This directive applies in all invocation contexts**, including headless (`claude -p '/conexus:substantive-critique <id>'`), scheduled remote sessions (CCR via the `schedule` skill), GitHub Actions via `anthropics/claude-code-action@v1`, and interactive sessions. The headless context is not exempt from the canonical format. In a documented 2026-04-11 incident (see T2 `nexus_rdr/067-research-2-ca3-phase1b-spike-result` id 743), a headless invocation of this skill produced section headings `## Significant Findings` / `## Minor Findings` / `## Summary` with no `## Critical Issues`, no `## Verification Performed`, and no `## Verdict` block, improvising an entirely different output structure. This directive exists to prevent that class of drift.
 
-The outcome field MUST be one of exactly three literal strings — `justified`, `partial`, or `not-justified`. Do not substitute `PASS`, `FAIL`, `FAILED`, `BLOCKED`, `APPROVED`, or any other alternative vocabulary. The parser maps only the three canonical values.
+The outcome field MUST be one of exactly three literal strings, `justified`, `partial`, or `not-justified`. Do not substitute `PASS`, `FAIL`, `FAILED`, `BLOCKED`, `APPROVED`, or any other alternative vocabulary. The parser maps only the three canonical values.
 
 Example of a correctly emitted Verdict block for a clean RDR (copy this shape exactly, vary only the values):
 
@@ -304,9 +304,9 @@ Example for an RDR with a silent-scope-reduction retcon:
 - **summary**: Gap 2 is enumerated in the Problem Statement but silently reframed as out of scope in the Proposed Solution with no ### Gap 2: addressed heading.
 ```
 
-Mapping rule: `critical_count > 0` → `not-justified`. `critical_count == 0` AND `significant_count > 0` → `partial`. Both counts zero → `justified`. Confidence is your own assessment (`high` / `medium` / `low`) based on evidence strength. Summary is ONE sentence — no line breaks, no bullet points inside the summary.
+Mapping rule: `critical_count > 0` → `not-justified`. `critical_count == 0` AND `significant_count > 0` → `partial`. Both counts zero → `justified`. Confidence is your own assessment (`high` / `medium` / `low`) based on evidence strength. Summary is ONE sentence, no line breaks, no bullet points inside the summary.
 
-> Fallback parse rule: if this Verdict block is absent or the `- **outcome**:` line cannot be located verbatim, downstream parsers count `### Issue:` headers under `## Critical Issues` and `## Significant Issues` and derive outcome mechanically. The fallback works but the canonical path is preferred — emit the block exactly as shown above.
+> Fallback parse rule: if this Verdict block is absent or the `- **outcome**:` line cannot be located verbatim, downstream parsers count `### Issue:` headers under `## Critical Issues` and `## Significant Issues` and derive outcome mechanically. The fallback works but the canonical path is preferred, emit the block exactly as shown above.
 
 ## Operating Principles
 

--- a/conexus/commands/implement.md
+++ b/conexus/commands/implement.md
@@ -47,7 +47,7 @@ Working implementation with passing tests, following TDD red-green-refactor cycl
 - [ ] Code follows project conventions (check CLAUDE.md)
 - [ ] No regressions introduced in existing tests
 
-**IMPORTANT**: After implementation completes, MUST delegate to code-review-expert for quality review.
+**IMPORTANT**: The developer agent implements and hands back; it cannot run reviewers or commit. After it returns, the development skill's orchestrator MUST drive the full tail: dispatch **code-review-expert** AND **substantive-critic** (both, they catch different issue classes), gate on both returning clean, then commit. A clean code review does not excuse skipping the critic. See the development skill's "Post-Implementation Review + Commit" section.
 ```
 
 For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/conexus/skills/development/SKILL.md
+++ b/conexus/skills/development/SKILL.md
@@ -10,13 +10,13 @@ Delegates to the **developer** agent (sonnet). See [registry.yaml](../../registr
 
 ## Code Navigation
 
-**REQUIRED SUB-SKILL:** Use **/conexus:serena-code-nav** for all symbol-level navigation — finding definitions, callers, type hierarchies, and surgical edits. Serena replaces text-pattern Grep for any symbol task.
+**REQUIRED SUB-SKILL:** Use **/conexus:serena-code-nav** for all symbol-level navigation, finding definitions, callers, type hierarchies, and surgical edits. Serena replaces text-pattern Grep for any symbol task.
 
 - **Before modifying interfaces**: `find_referencing_symbols` to find all implementers and callers
 - **Before refactoring methods**: `find_referencing_symbols` to find all callers
 - **Class structure**: `get_symbols_overview` for method/field inventory without reading the file
 - **Finding method definitions**: `find_symbol` instead of Grep
-- **Replacing a method body**: `replace_symbol_body` — no line arithmetic, immune to drift
+- **Replacing a method body**: `replace_symbol_body`, no line arithmetic, immune to drift
 
 ### Example Workflow
 ```
@@ -30,7 +30,7 @@ Delegates to the **developer** agent (sonnet). See [registry.yaml](../../registr
 
 ## When This Skill Activates
 
-- After `mcp__plugin_conexus_nexus__nx_plan_audit` validates a plan (required prerequisite — RDR-080)
+- After `mcp__plugin_conexus_nexus__nx_plan_audit` validates a plan (required prerequisite, RDR-080)
 - When a bead for an implementation task is in_progress
 - Executing tasks from an approved implementation plan
 - Writing or modifying production code
@@ -73,7 +73,7 @@ For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agen
 If the developer agent returns with `## ESCALATION: Debugger Required` in its output (detect by scanning for `<!-- ESCALATION -->` or the literal string `ESCALATION: Debugger Required`):
 
 1. **Do not re-dispatch the developer.** The circuit breaker fired for a reason.
-2. **Escalation guard — check before dispatching:**
+2. **Escalation guard, check before dispatching:**
    mcp__plugin_conexus_nexus__scratch(action="search", query="circuit-breaker-fired-for-[bead-id]", limit=1
    - **If found**: do NOT dispatch the debugger. Report to the user: "Developer circuit breaker has fired twice for bead [ID]. The debugger's fix did not resolve the issue. Human investigation recommended." **Stop here.**
    - **If not found**: write the guard entry NOW: mcp__plugin_conexus_nexus__scratch(action="put", content="circuit-breaker-fired-for-[bead-id]", tags="escalation-guard". Then proceed to step 3.
@@ -88,9 +88,9 @@ If the developer agent returns with `## ESCALATION: Debugger Required` in its ou
 ### Input Artifacts
 - Error: [Error field from escalation report]
 - Hypothesis: [Hypothesis field from escalation report]
-- What was tried: [What I tried field — both attempts]
+- What was tried: [What I tried field, both attempts]
 - Diagnostic suggestion: [Diagnostic suggestion field]
-- nx scratch: [search scratch for tag "failed-approach" — include any pre-escalation entries the developer wrote during earlier attempts]
+- nx scratch: [search scratch for tag "failed-approach", include any pre-escalation entries the developer wrote during earlier attempts]
 - Files: [files from original developer relay]
 
 ### Deliverable
@@ -127,12 +127,36 @@ Do not retry approaches listed in scratch under tag "failed-approach".
 - [ ] Remaining plan steps completed
 ```
 
-## Post-Implementation Review
+## Post-Implementation Review + Commit (orchestrator-driven, MANDATORY)
 
-Code review steps are baked into plans by the strategic planner. When
-executing a plan, follow the review tasks at the designated points.
-For ad-hoc implementation outside a plan, use `/conexus:review-code` when
-the scope warrants it.
+The developer agent CANNOT run this tail itself, it has no Agent tool and
+cannot spawn sibling agents. When the developer returns its
+`## Next Step: code-review-expert, substantive-critic, test-validator` block,
+YOU (the orchestrator running this skill) drive the loop. Do not stop at the
+developer's return; do not let the developer self-commit.
+
+Run BOTH reviewers, they catch different, non-overlapping classes of issue:
+
+1. **code-review-expert** (`/conexus:review-code`): line-level bugs, security,
+   missing edge cases, convention violations.
+2. **substantive-critic** (`/conexus:substantive-critique`): unvalidated
+   assumptions, silent scope reduction, vacuous test assertions, spec-vs-
+   implementation drift, "what does this leave undefended downstream." Brief it
+   with the locked spec (RDR `## Decision` / plan / phase boundary) so it checks
+   implementation-vs-design, not style.
+
+**This is a gate, not a suggestion.** A clean code-review-expert verdict does
+NOT permit skipping the critic, that is the documented failure mode. Iterate:
+Critical/High finding → fix → re-review the affected reviewer. Only when BOTH
+return clean do you proceed to commit.
+
+3. **Commit**: stage the code changes (explicit paths, never `git add -A`) plus
+   the beads file, commit with the bead reference, and close the bead. The
+   developer does not self-commit; the commit is the proof both gates passed.
+
+When executing a strategic plan, the planner bakes review tasks into the plan at
+designated points, follow those, and they include both reviewers. For ad-hoc
+implementation outside a plan, run the loop above directly.
 
 ## TDD Methodology
 
@@ -144,7 +168,7 @@ The developer agent follows test-driven development:
 5. Ensure all existing tests still pass
 
 **REQUIRED:** Run verification (tests pass, no regressions) before claiming any task is done.
-**REQUIRED SUB-SKILL:** Use `/conexus:review-code` after implementation for quality review.
+**REQUIRED SUB-SKILLS (both, in this order):** `/conexus:review-code` (code-review-expert) THEN `/conexus:substantive-critique` (substantive-critic) after implementation. Commit only after both return clean. See "Post-Implementation Review + Commit" above.
 
 ## Success Criteria
 
@@ -152,7 +176,9 @@ The developer agent follows test-driven development:
 - [ ] Code follows project conventions
 - [ ] No regressions in existing tests
 - [ ] Implementation matches plan requirements
-- [ ] Ready for code-review-expert relay
+- [ ] code-review-expert returned clean (Critical/High fixed, re-reviewed)
+- [ ] substantive-critic returned clean (Critical/High fixed, re-reviewed)
+- [ ] Committed only after BOTH reviewers clean (orchestrator commits; developer does not self-commit)
 
 ## Agent-Specific PRODUCE
 

--- a/conexus/skills/orchestration/reference.md
+++ b/conexus/skills/orchestration/reference.md
@@ -1,6 +1,6 @@
 # Orchestration Reference
 
-Routing tables, pipeline templates, and decision framework for multi-agent workflows. This is a reference document — no agent is dispatched.
+Routing tables, pipeline templates, and decision framework for multi-agent workflows. This is a reference document, no agent is dispatched.
 
 ## Routing Graph
 
@@ -44,7 +44,8 @@ digraph routing {
     "developer" -> "code-review-expert" [label="then"];
     "developer" -> "debugger" [label="on escalation"];
     "debugger" -> "developer" [label="fix applied, resume"];
-    "code-review-expert" -> "test-validator" [label="then"];
+    "code-review-expert" -> "substantive-critic" [label="then (always)"];
+    "substantive-critic" -> "test-validator" [label="then"];
 
     "Debug issue" -> "debugger";
     "debugger" -> "deep-analyst" [label="if cross-cutting"];
@@ -65,7 +66,7 @@ digraph routing {
 | Request Type | Primary Agent | Pipeline |
 |-------------|---------------|----------|
 | Plan a feature | strategic-planner | -> nx_plan_audit (MCP) -> architect-planner |
-| Implement code | developer | -> code-review-expert -> test-validator |
+| Implement code | developer | -> code-review-expert -> substantive-critic -> test-validator |
 | Implement code (circuit breaker fired) | debugger | [after developer stops] -> debugger -> developer resumes |
 | Debug issue | debugger | -> (if cross-cutting) deep-analyst |
 | Review code | code-review-expert | -> (if critical) substantive-critic |
@@ -92,37 +93,39 @@ If the task requires multiple stages:
 
 ### Step 3: Route or Dispatch
 - **Single Agent**: Dispatch directly with context via relay
-- **Pipeline**: Dispatch sequentially — the caller orchestrates each stage
+- **Pipeline**: Dispatch sequentially, the caller orchestrates each stage
 
 ## Standard Pipelines
 
 ### Feature Development Pipeline
 1. strategic-planner: Create plan with beads
-2. `mcp__plugin_conexus_nexus__nx_plan_audit`: Validate plan (RDR-080 — no agent spawn)
+2. `mcp__plugin_conexus_nexus__nx_plan_audit`: Validate plan (RDR-080, no agent spawn)
 3. architect-planner: Design architecture
 4. developer: Implement with TDD
-5. code-review-expert: Review implementation
-6. test-validator: Verify test coverage
+5. code-review-expert: Review implementation (line-level bugs, security, edge cases)
+6. substantive-critic: Critique implementation (assumptions, scope reduction, vacuous assertions, spec drift). Both reviewers run; a clean code review does not permit skipping the critic.
+7. test-validator: Verify test coverage
 
 ### Bug Fix Pipeline
 1. debugger: Investigate and identify root cause
 2. developer: Implement fix
 3. code-review-expert: Review fix
-4. test-validator: Verify fix and regression tests
+4. substantive-critic: Critique fix (both reviewers run)
+5. test-validator: Verify fix and regression tests
 
 ### Catalog Query Pipeline
-Use `/conexus:query` skill directly — it calls `mcp__plugin_conexus_nexus__nx_answer` internally (RDR-080).
+Use `/conexus:query` skill directly, it calls `mcp__plugin_conexus_nexus__nx_answer` internally (RDR-080).
 Route here when the question involves: specific authors, paper citations, "what cites X",
 "what research informed Y", corpus-scoped retrieval, or document provenance chains.
 
 ### Research Pipeline
 1. deep-research-synthesizer: Gather information
-2. `mcp__plugin_conexus_nexus__nx_tidy`: Consolidate findings (RDR-080 — no agent spawn needed)
+2. `mcp__plugin_conexus_nexus__nx_tidy`: Consolidate findings (RDR-080, no agent spawn needed)
 3. (optional) architect-planner: Apply findings to design
 
 ### Plan Validation Pipeline
 1. strategic-planner or architect-planner: Create plan
-2. `mcp__plugin_conexus_nexus__nx_plan_audit`: Validate technical accuracy (RDR-080 — no agent spawn needed)
+2. `mcp__plugin_conexus_nexus__nx_plan_audit`: Validate technical accuracy (RDR-080, no agent spawn needed)
 3. substantive-critic: Critique for gaps and assumptions
 
 ## Pipeline Pattern Catalog
@@ -131,10 +134,10 @@ These patterns are stored in the T2 plan library and are returned by `plan_searc
 
 | Pattern | Agents | When to Use | Prerequisites |
 |---------|--------|-------------|---------------|
-| RDR Chain | deep-research-synthesizer → `/conexus:rdr-gate` → `/conexus:rdr-accept` → strategic-planner → `nx_plan_audit` → developer → code-review-expert → test-validator | Non-trivial features needing design documentation before coding | RDR created and populated with research findings |
-| Plan-Audit-Implement | strategic-planner → `nx_plan_audit` → developer → code-review-expert → test-validator | Standard feature development with clear requirements | Requirements defined, no RDR needed |
+| RDR Chain | deep-research-synthesizer → `/conexus:rdr-gate` → `/conexus:rdr-accept` → strategic-planner → `nx_plan_audit` → developer → code-review-expert → substantive-critic → test-validator | Non-trivial features needing design documentation before coding | RDR created and populated with research findings |
+| Plan-Audit-Implement | strategic-planner → `nx_plan_audit` → developer → code-review-expert → substantive-critic → test-validator | Standard feature development with clear requirements | Requirements defined, no RDR needed |
 | Research-Synthesize | deep-research-synthesizer → `nx_tidy` | Gathering information on unfamiliar topics or comparing approaches | Topic identified |
-| Code Review | code-review-expert → test-validator | Post-implementation quality gate before merge or PR | Code changes committed |
+| Code Review | code-review-expert → substantive-critic → test-validator | Post-implementation quality gate before merge or PR | Code changes committed |
 | Debug | debugger → developer → test-validator | Test failures or non-deterministic behavior, especially after 2+ failed manual fix attempts | Reproducible failure or clear symptom |
 
 ## Agent Ecosystem
@@ -145,13 +148,13 @@ These patterns are stored in the T2 plan library and are returned by `plan_searc
 | developer | Execute implementation plans, write code with TDD |
 | architect-planner | Design architecture, create execution plans |
 | debugger | Complex bugs, non-deterministic failures, performance issues |
-| (none — use `/conexus:query`) | Analytical operations are handled by `nx_answer` internally (RDR-080) |
+| (none, use `/conexus:query`) | Analytical operations are handled by `nx_answer` internally (RDR-080) |
 
 ### Review Agents
 | Agent | When to Use |
 |-------|-------------|
 | code-review-expert | Review implemented code for quality and best practices |
-| `mcp__plugin_conexus_nexus__nx_plan_audit` | Validate plans before implementation (RDR-080 — MCP tool, not agent) |
+| `mcp__plugin_conexus_nexus__nx_plan_audit` | Validate plans before implementation (RDR-080, MCP tool, not agent) |
 | substantive-critic | Deep critique of any content (code, docs, designs) |
 
 ### Analysis Agents
@@ -164,7 +167,7 @@ These patterns are stored in the T2 plan library and are returned by `plan_searc
 | Agent | When to Use |
 |-------|-------------|
 | deep-research-synthesizer | Multi-source research across all knowledge bases |
-| query (skill: `/conexus:query`) | Author, citation, corpus, or provenance questions — catalog-aware multi-step retrieval |
+| query (skill: `/conexus:query`) | Author, citation, corpus, or provenance questions, catalog-aware multi-step retrieval |
 
 ### Infrastructure Agents
 | Agent | When to Use |

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.4.4"
+version = "5.4.5"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.4.4",
+    "conexus>=5.4.5",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.4.4"
+version = "5.4.5"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.4.4"
+version = "5.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Completes the developer review-loop fix and ships it. 5.4.5 carries everything in 5.4.4 plus the substantive-critic wiring across ALL FIVE orchestration surfaces.

## Fixed
The developer agent stopped after code-review every implementation phase, skipping substantive-critic, because no orchestration surface named it. Fixed on both the ad-hoc and plan-driven paths:
- **developer.md / development skill / implement.md** (ad-hoc path) — critic named as non-optional second reviewer; developer hands back rather than self-committing
- **orchestration/reference.md** (routing graph, quick-ref table, Feature Development + Bug Fix pipelines, pattern catalog) — critic now unconditional after every implementation pipeline
- **strategic-planner.md** Review Gates — every phase gate now mandates both reviewers (was code-review only)

A clean code review does not permit skipping the critic; the two reviewers catch different, non-overlapping issue classes.

### Internal
- Em-dash cleanup of 10 agent/skill/command md files (no-em-dashes convention).

## Supersedes
- #1018 (develop-targeted loop fix) — its commit is cherry-picked here; will close #1018 after this lands. Develop reconciliation (main->develop) follows to bring develop to 5.4.5 with everything.

## Verification
- Sandbox smoke: [done], nx 5.4.5.
- Plugin-structure tests: 496 passed.
- Seven-target parity + both changelogs: ALL CLEAR.
- Full unit suite: running (will confirm before merge).

Merge with --merge (not squash) to preserve the release SHA.