### PR TITLE
docs(rdr-139): accept DEVONthink MCP Integration

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -154,6 +154,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-136](rdr-136-messagedisplay-projection-substrate.md) | Display Projection via the MessageDisplay Hook: One-Way Output Mirroring and Routing-Marker Hiding | Architecture | Draft | 2026-05-27 |
 | [RDR-137](rdr-137-eliminate-repos-json.md) | Eliminate repos.json: Catalog as the Canonical Repo→Collection Source of Truth | Architecture | Closed | 2026-05-28 |
 | [RDR-138](rdr-138-rename-cascade-aspect-worker-coordination.md) | Rename-Cascade / Aspect-Worker Coordination: Serialize T2 Collection Rename Against In-Flight Aspect Extraction | Architecture | Accepted | 2026-05-29 |
+| [RDR-139](rdr-139-devonthink-mcp-semantic-linking-sync.md) | DEVONthink MCP Integration: Semantic Linking, Bibliographic Enrichment, Content Extraction, Bidirectional Sync, and Capture | Architecture | Accepted | 2026-05-30 |
 
 > **Scrapped 2026-05-19 (RDR-110-119 arc).** Bundled the storage-substrate split with new abstractions (tuplespace, ORB, host-trust, surfaces-as-tuples, UI fabric); scope discipline failed across nine RDRs and 67 stranded beads. Files preserved as tombstones per the "never delete RDR files" rule. Postmortem: [docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work continues as [RDR-120](rdr-120-storage-substrate-split.md) with an explicit moratorium on co-shipped consumers. Numbers RDR-114 through RDR-117 are unused on `main` (drafted on feature branches that never merged).
 

--- a/docs/rdr/rdr-139-devonthink-mcp-semantic-linking-sync.md
+++ b/docs/rdr/rdr-139-devonthink-mcp-semantic-linking-sync.md
@@ -2,12 +2,12 @@
 title: "DEVONthink MCP Integration: Semantic Linking, Bibliographic Enrichment, Content Extraction, Bidirectional Sync, and Capture"
 id: RDR-139
 type: Architecture
-status: draft
+status: accepted
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-05-29
-accepted_date:
+accepted_date: 2026-05-30
 related_issues: [nexus-qtbuh, nexus-lxy5n]
 related_rdrs: [RDR-099, RDR-126, RDR-049, RDR-051, RDR-089]
 ---


### PR DESCRIPTION
Accepts RDR-139 (gate PASSED 2026-05-30, 0 crit / 0 sig).

- Frontmatter `draft -> accepted`, `accepted_date: 2026-05-30`
- README index row added
- T2 `nexus_rdr/139` flipped to accepted

Planning chain complete: strategic-planner created epic **nexus-james** + 21 task beads (4 phases), `nx_plan_audit` **PASS**, beads enriched. Phase 1 is the MVV (substrate + linking + write-back + Gap-0 fallback). Note: `mcp>=1.0` already in pyproject.toml:62.

Refs nexus-qtbuh, nexus-lxy5n