### PR TITLE
feat(rdr-139): Phase 1 read-only DEVONthink MCP substrate (P1.1-P1.5, P1.8 partial)

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -154,6 +154,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-136](rdr-136-messagedisplay-projection-substrate.md) | Display Projection via the MessageDisplay Hook: One-Way Output Mirroring and Routing-Marker Hiding | Architecture | Draft | 2026-05-27 |
 | [RDR-137](rdr-137-eliminate-repos-json.md) | Eliminate repos.json: Catalog as the Canonical Repo→Collection Source of Truth | Architecture | Closed | 2026-05-28 |
 | [RDR-138](rdr-138-rename-cascade-aspect-worker-coordination.md) | Rename-Cascade / Aspect-Worker Coordination: Serialize T2 Collection Rename Against In-Flight Aspect Extraction | Architecture | Accepted | 2026-05-29 |
+| [RDR-139](rdr-139-devonthink-mcp-semantic-linking-sync.md) | DEVONthink MCP Integration: Semantic Linking, Bibliographic Enrichment, Content Extraction, Bidirectional Sync, and Capture | Architecture | Accepted | 2026-05-30 |
 
 > **Scrapped 2026-05-19 (RDR-110-119 arc).** Bundled the storage-substrate split with new abstractions (tuplespace, ORB, host-trust, surfaces-as-tuples, UI fabric); scope discipline failed across nine RDRs and 67 stranded beads. Files preserved as tombstones per the "never delete RDR files" rule. Postmortem: [docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work continues as [RDR-120](rdr-120-storage-substrate-split.md) with an explicit moratorium on co-shipped consumers. Numbers RDR-114 through RDR-117 are unused on `main` (drafted on feature branches that never merged).
 

--- a/docs/rdr/rdr-139-devonthink-mcp-semantic-linking-sync.md
+++ b/docs/rdr/rdr-139-devonthink-mcp-semantic-linking-sync.md
@@ -2,12 +2,12 @@
 title: "DEVONthink MCP Integration: Semantic Linking, Bibliographic Enrichment, Content Extraction, Bidirectional Sync, and Capture"
 id: RDR-139
 type: Architecture
-status: draft
+status: accepted
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-05-29
-accepted_date:
+accepted_date: 2026-05-30
 related_issues: [nexus-qtbuh, nexus-lxy5n]
 related_rdrs: [RDR-099, RDR-126, RDR-049, RDR-051, RDR-089]
 ---

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1754,6 +1754,10 @@ class Catalog:
         """Delegates to ``_DocumentOps.by_file_path`` (nexus-mbm)."""
         return self._docs.by_file_path(owner, file_path)
 
+    def by_source_uri(self, uri: str) -> CatalogEntry | None:
+        """Delegates to ``_DocumentOps.by_source_uri`` (RDR-139 P1.4)."""
+        return self._docs.by_source_uri(uri)
+
     def by_owner(self, owner: Tumbler) -> list[CatalogEntry]:
         """Delegates to ``_DocumentOps.by_owner`` (nexus-mbm)."""
         return self._docs.by_owner(owner)

--- a/src/nexus/catalog/catalog_docs.py
+++ b/src/nexus/catalog/catalog_docs.py
@@ -579,6 +579,43 @@ class _DocumentOps:
             source_uri=row[13] or "",
         )
 
+    def by_source_uri(self, uri: str) -> CatalogEntry | None:
+        """Inverse lookup ``documents.source_uri`` -> entry (RDR-139 P1.4).
+
+        Global (not owner-scoped): ``source_uri`` is globally unique by
+        construction, so a DEVONthink neighbour's ``x-devonthink-item://<UUID>``
+        resolves directly. Returns ``None`` for an empty URI or an unindexed
+        neighbour, so the semantic-linking caller skips rather than links.
+        """
+        if not uri:
+            return None
+        cat = self._cat
+        from nexus.catalog.catalog import CatalogEntry
+        row = cat._db.execute(
+            "SELECT tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime, source_uri "
+            "FROM documents WHERE source_uri = ?",
+            (uri,),
+        ).fetchone()
+        if not row:
+            return None
+        return CatalogEntry(
+            tumbler=Tumbler.parse(row[0]),
+            title=row[1],
+            author=row[2],
+            year=row[3],
+            content_type=row[4],
+            file_path=row[5],
+            corpus=row[6],
+            physical_collection=row[7],
+            chunk_count=row[8],
+            head_hash=row[9],
+            indexed_at=row[10],
+            meta=json.loads(row[11]) if row[11] else {},
+            source_mtime=row[12] or 0.0,
+            source_uri=row[13] or "",
+        )
+
     def by_owner(self, owner: Tumbler) -> list[CatalogEntry]:
         cat = self._cat
         from nexus.catalog.catalog import CatalogEntry

--- a/src/nexus/catalog/dt_link_generator.py
+++ b/src/nexus/catalog/dt_link_generator.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""DEVONthink semantic + structural link generation (RDR-139 Layer B).
+
+A new generator alongside :mod:`nexus.catalog.link_generator` and
+:mod:`nexus.catalog.auto_linker` — it does NOT modify them. Given a just-indexed
+record's tumbler and its DEVONthink UUID, it pulls two neighbour sources off the
+DT MCP server and writes ``relates`` edges into the catalog:
+
+- **Similarity** (``dt_find_similar``, DT 'See Also') → ``created_by='dt_similar'``.
+- **Explicit links** (``dt_record_links``, author-curated item links, higher
+  precision) → ``created_by='dt_link'``, deduped against similarity edges so a
+  pair already joined by similarity is not re-counted.
+
+Every neighbour UUID is mapped through ``Catalog.by_source_uri`` — neighbours
+that are not indexed in nexus resolve to ``None`` and are silently skipped. The
+whole layer is gated on :func:`devonthink.available`: DT down → zero new edges,
+exit clean (Gap 0). ``classify_record`` proposals are advisory-only (logged,
+no edges) since they suggest groups, not record-to-record links.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.tumbler import Tumbler
+from nexus.mcp_client import devonthink as _devonthink
+
+log = structlog.get_logger(__name__)
+
+#: Default similarity floor for ``dt_find_similar`` (live DT scores ~0.5-0.6).
+DEFAULT_SIMILARITY_FLOOR = 0.5
+
+#: Default per-source neighbour cap.
+DEFAULT_LIMIT = 25
+
+
+def _dt_uri(uuid: str) -> str:
+    return f"x-devonthink-item://{uuid}"
+
+
+def generate_dt_links(
+    cat: Catalog,
+    this: Tumbler,
+    dt_uuid: str,
+    *,
+    floor: float = DEFAULT_SIMILARITY_FLOOR,
+    limit: int = DEFAULT_LIMIT,
+    classify: bool = False,
+    dt_client=_devonthink,
+) -> dict[str, int]:
+    """Generate DT-derived ``relates`` edges for one record.
+
+    Returns counts ``{"similar": n, "link": m}`` of genuinely-new edges. When DT
+    is unavailable returns zeros and logs a single skip line — the tested
+    fallback for this layer (zero new edges).
+
+    ``dt_client`` is injectable for testing; it defaults to the real
+    :mod:`nexus.mcp_client.devonthink` module.
+    """
+    counts = {"similar": 0, "link": 0}
+    if not dt_client.available():
+        log.info("dt_link_skipped_unavailable", tumbler=str(this), dt_uuid=dt_uuid)
+        return counts
+
+    linked: set[Tumbler] = set()
+
+    # Similarity neighbours (DT 'See Also').
+    for n in dt_client.dt_find_similar(dt_uuid, limit=limit, floor=floor):
+        entry = cat.by_source_uri(_dt_uri(n["uuid"]))
+        if entry is None or entry.tumbler == this or entry.tumbler in linked:
+            continue
+        if cat.link_if_absent(this, entry.tumbler, "relates", created_by="dt_similar"):
+            counts["similar"] += 1
+        linked.add(entry.tumbler)
+
+    # Explicit DT item links (higher precision); dedup against similarity edges.
+    for n in dt_client.dt_record_links(dt_uuid):
+        entry = cat.by_source_uri(_dt_uri(n["uuid"]))
+        if entry is None or entry.tumbler == this or entry.tumbler in linked:
+            continue
+        if cat.link_if_absent(this, entry.tumbler, "relates", created_by="dt_link"):
+            counts["link"] += 1
+        linked.add(entry.tumbler)
+
+    if classify:
+        proposals = dt_client.dt_call("classify_record", {"uuid": dt_uuid}) or {}
+        log.info(
+            "dt_classify_advisory",
+            tumbler=str(this),
+            dt_uuid=dt_uuid,
+            proposal_count=len(proposals) if isinstance(proposals, dict) else 0,
+        )
+
+    log.info(
+        "dt_links_generated",
+        tumbler=str(this),
+        dt_uuid=dt_uuid,
+        similar=counts["similar"],
+        link=counts["link"],
+    )
+    return counts

--- a/src/nexus/catalog/dt_link_generator.py
+++ b/src/nexus/catalog/dt_link_generator.py
@@ -60,6 +60,8 @@ def generate_dt_links(
     :mod:`nexus.mcp_client.devonthink` module.
     """
     counts = {"similar": 0, "link": 0}
+    if not dt_uuid:
+        return counts
     if not dt_client.available():
         log.info("dt_link_skipped_unavailable", tumbler=str(this), dt_uuid=dt_uuid)
         return counts
@@ -86,11 +88,14 @@ def generate_dt_links(
 
     if classify:
         proposals = dt_client.dt_call("classify_record", {"uuid": dt_uuid}) or {}
+        # core._parse_result wraps a JSON array as {"result": [...]}; the actual
+        # group-proposal count is the length of that list, not the dict.
+        groups = proposals.get("result", proposals.get("proposals", [])) if isinstance(proposals, dict) else []
         log.info(
             "dt_classify_advisory",
             tumbler=str(this),
             dt_uuid=dt_uuid,
-            proposal_count=len(proposals) if isinstance(proposals, dict) else 0,
+            proposal_count=len(groups) if isinstance(groups, list) else 0,
         )
 
     log.info(

--- a/src/nexus/db/t2/catalog.py
+++ b/src/nexus/db/t2/catalog.py
@@ -552,6 +552,20 @@ class CatalogStore:
                     "ON documents(physical_collection)"
                 )
 
+        # RDR-139 P1.4 (nexus-ft2i1): index documents.source_uri for existing
+        # databases so the DT inverse-lookup join is not a full table scan.
+        # Probe-guarded for legacy schemas lacking the column.
+        try:
+            self._conn.execute("SELECT source_uri FROM documents LIMIT 0")
+        except sqlite3.OperationalError:
+            pass
+        else:
+            with self._conn:
+                self._conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_documents_source_uri "
+                    "ON documents(source_uri) WHERE source_uri != ''"
+                )
+
         # RDR-108 K1 (nexus-lh8c): add ON DELETE CASCADE to document_chunks
         # for existing databases that were created before this constraint was
         # declared in the schema. SQLite cannot ALTER a FK constraint in place;

--- a/src/nexus/mcp_client/__init__.py
+++ b/src/nexus/mcp_client/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""MCP client substrate for outbound calls to external MCP servers (RDR-139).
+
+Distinct from :mod:`nexus.mcp`, which hosts the nexus MCP *server*. This
+package is the *client* side: nexus reaching out to other MCP servers (the
+DEVONthink built-in server first; RDR-126 daemon-held connections later).
+
+Layer A of the RDR-139 design lives here. ``core`` holds the shared transport
+and a fail-soft ``call_tool`` seam; per-server wrappers (e.g. ``devonthink``)
+build on it.
+"""

--- a/src/nexus/mcp_client/core.py
+++ b/src/nexus/mcp_client/core.py
@@ -136,14 +136,20 @@ async def open_session(endpoint: MCPEndpoint) -> AsyncIterator[Any]:
     are local so importing this module never costs the ``mcp`` SDK transport
     machinery until a connection is actually opened.
     """
+    import httpx
     from mcp import ClientSession
-    from mcp.client.streamable_http import streamablehttp_client
+    from mcp.client.streamable_http import streamable_http_client
+    from mcp.shared._httpx_utils import create_mcp_http_client
 
-    async with streamablehttp_client(
-        endpoint.url,
+    http_client = create_mcp_http_client(
         headers=dict(endpoint.headers) or None,
-        timeout=endpoint.timeout_s,
-    ) as (read_stream, write_stream, _get_session_id):
+        timeout=httpx.Timeout(endpoint.timeout_s),
+    )
+    async with streamable_http_client(endpoint.url, http_client=http_client) as (
+        read_stream,
+        write_stream,
+        _get_session_id,
+    ):
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
             yield session

--- a/src/nexus/mcp_client/core.py
+++ b/src/nexus/mcp_client/core.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Shared MCP-client core: transport connect + fail-soft ``call_tool`` (RDR-139 Layer A).
+
+This is the substrate seam shared with RDR-126. It provides two things and
+deliberately decides nothing about lifecycle:
+
+- :func:`open_session` — an async context manager that connects to a
+  streamable-HTTP MCP endpoint and yields an initialized
+  :class:`mcp.ClientSession`. The *caller* chooses the lifecycle: RDR-139's
+  per-call wrapper opens and closes one per tool call; RDR-126's daemon holds
+  one open. Do not bake either policy in here.
+- :func:`call_tool` — the result-or-``None`` call contract. Every failure
+  (transport error, ``isError`` result, unparseable payload) is swallowed into
+  a structured-log warning and a ``None`` return. No MCP failure may propagate
+  to a caller; that is what makes every layer's fallback provable (Gap 0).
+
+Secrets in tool arguments are redacted before any value is logged.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+#: Placeholder substituted for any argument value whose key looks secret.
+REDACTED = "***redacted***"
+
+#: Argument keys (lowercased) whose values are redacted from log events.
+_SECRET_KEYS = frozenset(
+    {"authorization", "auth", "token", "api_key", "apikey", "password", "secret"}
+)
+
+
+@runtime_checkable
+class ToolCaller(Protocol):
+    """Structural type for the slice of ``ClientSession`` that :func:`call_tool` uses."""
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any] | None = None
+    ) -> Any: ...
+
+
+@dataclass(frozen=True)
+class MCPEndpoint:
+    """Connection coordinates for a streamable-HTTP MCP server.
+
+    ``url`` is the full endpoint (e.g. ``http://localhost:8420/mcp``). ``headers``
+    carries optional transport headers; ``timeout_s`` bounds the connect/read.
+    """
+
+    url: str
+    headers: Mapping[str, str] = field(default_factory=dict)
+    timeout_s: float = 30.0
+
+
+def _redact(arguments: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``arguments`` with secret-looking values masked."""
+    return {
+        key: (REDACTED if key.lower() in _SECRET_KEYS else value)
+        for key, value in arguments.items()
+    }
+
+
+def _parse_result(result: Any) -> dict[str, Any] | None:
+    """Coerce a ``CallToolResult`` into a plain dict, or ``None`` if not parseable.
+
+    Preference order: ``structuredContent`` (already a dict) → the first text
+    content block parsed as JSON → a ``{"text": ...}`` wrapper of joined text.
+    """
+    structured = getattr(result, "structuredContent", None)
+    if isinstance(structured, dict):
+        return structured
+
+    content = getattr(result, "content", None) or []
+    texts = [getattr(block, "text", None) for block in content]
+    texts = [t for t in texts if isinstance(t, str)]
+    if not texts:
+        return None
+
+    joined = "\n".join(texts)
+    try:
+        parsed = json.loads(joined)
+    except (ValueError, TypeError):
+        return {"text": joined}
+    return parsed if isinstance(parsed, dict) else {"result": parsed}
+
+
+async def call_tool(
+    session: ToolCaller,
+    name: str,
+    arguments: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Call an MCP tool fail-soft: parsed dict on success, ``None`` on any failure.
+
+    A raised transport error, an ``isError`` result, or an unparseable payload
+    all collapse to ``None`` plus a single structured warning. The exception is
+    never re-raised: callers rely on ``None`` to take their tested fallback path.
+    """
+    args = dict(arguments or {})
+    try:
+        result = await session.call_tool(name, args)
+    except Exception as exc:  # fail-soft: no MCP failure may propagate
+        log.warning(
+            "mcp_call_tool_failed",
+            tool=name,
+            args=_redact(args),
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return None
+
+    if getattr(result, "isError", False):
+        log.warning("mcp_call_tool_is_error", tool=name, args=_redact(args))
+        return None
+
+    parsed = _parse_result(result)
+    if parsed is None:
+        log.warning("mcp_call_tool_unparseable", tool=name, args=_redact(args))
+    return parsed
+
+
+@asynccontextmanager
+async def open_session(endpoint: MCPEndpoint) -> AsyncIterator[Any]:
+    """Connect to ``endpoint`` over streamable HTTP and yield an initialized session.
+
+    The transport and session are torn down on exit. Lifecycle policy lives with
+    the caller: open one per call (RDR-139) or hold one open (RDR-126). Imports
+    are local so importing this module never costs the ``mcp`` SDK transport
+    machinery until a connection is actually opened.
+    """
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    async with streamablehttp_client(
+        endpoint.url,
+        headers=dict(endpoint.headers) or None,
+        timeout=endpoint.timeout_s,
+    ) as (read_stream, write_stream, _get_session_id):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            yield session

--- a/src/nexus/mcp_client/devonthink.py
+++ b/src/nexus/mcp_client/devonthink.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Per-call DEVONthink MCP client over the shared core seam (RDR-139 Layer A).
+
+The DEVONthink 4 built-in MCP server is an always-on localhost HTTP endpoint
+(``http://localhost:8420/mcp``, no spawn/teardown). This module is the
+**CLI-path-only** face: each :func:`dt_call` opens a session, runs one tool,
+and closes it. Async callers (the aspect worker, any future daemon path) must
+NOT use this module — they use the Layer A′ server face. :func:`dt_call`
+enforces that contract with a running-loop guard.
+
+Every helper is fail-soft: a missing/unreachable DT, an excluded record, or a
+malformed result yields ``[]`` / ``None`` / ``False`` and a structured log
+line, never an exception. The :func:`available` gate lets each layer fall back
+to its tested pre-RDR-139 behaviour (Gap 0).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, TypedDict
+
+import structlog
+
+from nexus.config import load_config
+from nexus.mcp_client.core import MCPEndpoint, call_tool, open_session
+
+log = structlog.get_logger(__name__)
+
+#: Default DEVONthink built-in MCP endpoint (spike-verified, RDR-139).
+DEFAULT_DT_MCP_URL = "http://localhost:8420/mcp"
+
+#: Module-level availability cache; ``None`` = not yet probed.
+_AVAIL_CACHE: bool | None = None
+
+
+class Neighbour(TypedDict):
+    """A DEVONthink record adjacent to a query record (similarity or link)."""
+
+    uuid: str
+    score: float
+    name: str
+
+
+def dt_mcp_url() -> str:
+    """Resolve the DT MCP endpoint URL (config ``devonthink.mcp.url``, else default)."""
+    cfg = load_config()
+    url = (
+        cfg.get("devonthink", {}).get("mcp", {}).get("url")
+        if isinstance(cfg.get("devonthink"), dict)
+        else None
+    )
+    return url or DEFAULT_DT_MCP_URL
+
+
+def reset_availability_cache() -> None:
+    """Clear the cached :func:`available` result (tests; long-lived processes)."""
+    global _AVAIL_CACHE
+    _AVAIL_CACHE = None
+
+
+def dt_call(tool: str, args: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    """Run one DT MCP tool synchronously, fail-soft (``None`` on any failure).
+
+    Bridges the async ``mcp`` SDK into the synchronous CLI via ``asyncio.run``.
+    A running event loop is a contract violation (Layer A is CLI-path-only):
+    calling ``asyncio.run`` from one raises an opaque ``RuntimeError`` that the
+    fail-soft contract would otherwise mask as a benign ``None``. The guard
+    logs a DISTINCT ``dt_asyncio_context_error`` so the misuse is visible.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass  # expected: no running loop, asyncio.run is safe
+    else:
+        log.error(
+            "dt_asyncio_context_error",
+            tool=tool,
+            hint="nexus.mcp_client.devonthink is CLI-path-only; use the Layer A' server face from async contexts",
+        )
+        return None
+
+    endpoint = MCPEndpoint(url=dt_mcp_url())
+
+    async def _run() -> dict[str, Any] | None:
+        async with open_session(endpoint) as session:
+            return await call_tool(session, tool, args or {})
+
+    try:
+        return asyncio.run(_run())
+    except Exception as exc:  # connect/transport failure → fail-soft
+        log.warning("dt_call_failed", tool=tool, error=str(exc), error_type=type(exc).__name__)
+        return None
+
+
+def available(*, refresh: bool = False) -> bool:
+    """Whether DEVONthink is reachable and running (cached).
+
+    Probes the ``is_running`` tool (``{running: bool, ...}``). Unreachable
+    server or ``running=False`` → ``False``. The result is cached; pass
+    ``refresh=True`` to re-probe.
+    """
+    global _AVAIL_CACHE
+    if not refresh and _AVAIL_CACHE is not None:
+        return _AVAIL_CACHE
+    result = dt_call("is_running")
+    _AVAIL_CACHE = bool(result) and bool(result.get("running"))
+    return _AVAIL_CACHE
+
+
+def dt_find_similar(uuid: str, *, limit: int = 25, floor: float = 0.0) -> list[Neighbour]:
+    """Similarity neighbours of ``uuid`` (DT 'See Also'), filtered by ``floor``.
+
+    ``floor`` is also passed to the server as ``min_score`` for an early prune;
+    the client-side filter is a defensive backstop. Entries without a UUID are
+    dropped. Empty list when DT is unavailable or returns nothing.
+    """
+    result = dt_call(
+        "find_similar_records",
+        {"mode": "record", "uuid": uuid, "limit": limit, "min_score": floor},
+    )
+    if not result:
+        return []
+    out: list[Neighbour] = []
+    for r in result.get("results", []) or []:
+        ruuid = r.get("uuid")
+        score = float(r.get("score", 0.0) or 0.0)
+        if not ruuid or score < floor:
+            continue
+        out.append(Neighbour(uuid=ruuid, score=score, name=r.get("name", "")))
+    return out
+
+
+def dt_record_links(uuid: str) -> list[Neighbour]:
+    """DEVONthink's own deliberate link neighbours (item links, both directions).
+
+    Higher precision than similarity: these are author-curated references. Score
+    is fixed at ``1.0`` to mark them as deliberate. Empty list when unavailable.
+    """
+    result = dt_call("get_record_links", {"uuid": uuid, "direction": "both", "kind": "item"})
+    if not result:
+        return []
+    entries: list[dict[str, Any]] = []
+    for key in ("incoming", "outgoing"):
+        value = result.get(key)
+        if isinstance(value, list):
+            entries.extend(value)
+    seen: set[str] = set()
+    out: list[Neighbour] = []
+    for r in entries:
+        ruuid = r.get("uuid")
+        if not ruuid or ruuid in seen:
+            continue
+        seen.add(ruuid)
+        out.append(Neighbour(uuid=ruuid, score=1.0, name=r.get("name", "")))
+    return out
+
+
+def dt_resolve_doi(doi: str) -> dict[str, Any] | None:
+    """Resolve a DOI to CrossRef bibliographic fields, or ``None`` (Layer C source)."""
+    if not doi:
+        return None
+    return dt_call("resolve_doi_metadata", {"doi": doi})
+
+
+def dt_extract_content(uuid: str) -> str | None:
+    """AI-optimised text body of a record, or ``None`` (Layer D, non-file-backed records).
+
+    Joins a sectioned/paged result into one string; returns ``None`` when no
+    text is available (or the record is excluded from AI access).
+    """
+    result = dt_call("extract_record_content", {"uuid": uuid})
+    if not result:
+        return None
+    text = result.get("text")
+    if isinstance(text, str) and text:
+        return text
+    sections = result.get("sections") or result.get("pages")
+    if isinstance(sections, list):
+        parts = [s.get("text", "") for s in sections if isinstance(s, dict)]
+        joined = "\n".join(p for p in parts if p)
+        return joined or None
+    return None
+
+
+def dt_set_tags(uuid: str, tags: list[str], *, mode: str = "add") -> bool:
+    """Write tags onto a record (default additive). ``True`` on success (Layer F)."""
+    if not tags:
+        return False
+    result = dt_call("set_record_tags", {"uuid": uuid, "tags": tags, "mode": mode})
+    return result is not None
+
+
+def dt_set_custom_metadata(uuid: str, fields: dict[str, Any], *, mode: str = "merge") -> bool:
+    """Write custom-metadata fields onto a record (default merge). ``True`` on success (Layer F)."""
+    if not fields:
+        return False
+    result = dt_call(
+        "set_record_custom_metadata", {"uuid": uuid, "metadata": fields, "mode": mode}
+    )
+    return result is not None

--- a/src/nexus/mcp_client/devonthink.py
+++ b/src/nexus/mcp_client/devonthink.py
@@ -191,6 +191,20 @@ def dt_set_tags(uuid: str, tags: list[str], *, mode: str = "add") -> bool:
     return result is not None
 
 
+def dt_set_annotation(uuid: str, text: str, *, mode: str = "append") -> bool:
+    """Write an annotation note onto a record. ``True`` on success (Layer F backlink).
+
+    The RDR Layer F design uses this to stamp a backlink to the nexus tumbler.
+    Defaults to ``mode="append"`` so a nexus backlink never clobbers an existing
+    annotation (no-clobber; DEVONthink also auto-checkpoints prior content when
+    the host DB has versioning enabled). Empty text short-circuits to ``False``.
+    """
+    if not text:
+        return False
+    result = dt_call("set_record_annotation", {"uuid": uuid, "text": text, "mode": mode})
+    return result is not None
+
+
 def dt_set_custom_metadata(uuid: str, fields: dict[str, Any], *, mode: str = "merge") -> bool:
     """Write custom-metadata fields onto a record (default merge). ``True`` on success (Layer F)."""
     if not fields:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1426,3 +1426,32 @@ class TestOwnerRepoRootDefensive:
         result = cat._owner_repo_root(owner)
         assert os.path.isabs(result)
         assert result == os.path.abspath("relative/path")
+
+
+class TestBySourceUri:
+    """RDR-139 P1.4: inverse lookup documents.source_uri -> CatalogEntry.
+
+    Backs the DT semantic-linking join: a DEVONthink neighbour's
+    ``x-devonthink-item://<UUID>`` resolves to its catalog entry (or None
+    when the neighbour is not indexed, so the caller skips it). Global
+    lookup (no owner scope) — source_uri is globally unique by construction.
+    """
+
+    def test_known_uri_returns_entry(self, cat_with_owner):
+        cat, owner = cat_with_owner
+        uri = "x-devonthink-item://8EDC855D-213F-40AD-A9CF-9543CC76476B"
+        doc = cat.register(
+            owner, "graph-rag", content_type="paper", file_path="", source_uri=uri,
+        )
+        entry = cat.by_source_uri(uri)
+        assert entry is not None
+        assert entry.tumbler == doc
+        assert entry.source_uri == uri
+
+    def test_unknown_uri_returns_none(self, cat_with_owner):
+        cat, _owner = cat_with_owner
+        assert cat.by_source_uri("x-devonthink-item://does-not-exist") is None
+
+    def test_empty_uri_returns_none(self, cat_with_owner):
+        cat, _owner = cat_with_owner
+        assert cat.by_source_uri("") is None

--- a/tests/test_dt_link_generator.py
+++ b/tests/test_dt_link_generator.py
@@ -105,6 +105,23 @@ def test_unavailable_makes_zero_edges(indexed):
     assert cat.links_from(this) == []
 
 
+def test_empty_dt_uuid_makes_no_edges_and_no_calls(indexed):
+    cat, _owner, this, _a, _b = indexed
+    dt = _FakeDT(similar=[{"uuid": "A", "score": 0.9, "name": "alpha"}])
+    counts = generate_dt_links(cat, this, "", dt_client=dt)
+    assert counts == {"similar": 0, "link": 0}
+    assert cat.links_from(this) == []
+
+
+def test_classify_is_advisory_only_no_edges(indexed):
+    cat, _owner, this, _a, _b = indexed
+    dt = _FakeDT(similar=[])
+    counts = generate_dt_links(cat, this, "THIS", classify=True, dt_client=dt)
+    # classify produces no edges (it suggests groups, not record links).
+    assert counts == {"similar": 0, "link": 0}
+    assert dt.classify_calls == 1
+
+
 def test_floor_filters_low_similarity(indexed):
     cat, _owner, this, a, b = indexed
     dt = _FakeDT(similar=[

--- a/tests/test_dt_link_generator.py
+++ b/tests/test_dt_link_generator.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""P1.5 contracts for DEVONthink Layer B link generation (RDR-139).
+
+Pins (real Catalog on tmp SQLite, fake DT client injected):
+- 2 of 3 similarity neighbours catalog-known → exactly 2 ``relates`` edges;
+  the unindexed neighbour is skipped with no error.
+- re-run is idempotent (no new edges the second time).
+- an explicit DT link to a pair already joined by similarity is deduped
+  (not double-counted); a fresh DT-link pair creates one ``dt_link`` edge.
+- DT unavailable → zero new edges, no exception (Gap 0 fallback).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.dt_link_generator import generate_dt_links
+
+
+@pytest.fixture
+def cat(tmp_path):
+    d = tmp_path / "catalog"
+    d.mkdir()
+    return Catalog(d, d / ".catalog.db")
+
+
+def _uri(uuid: str) -> str:
+    return f"x-devonthink-item://{uuid}"
+
+
+class _FakeDT:
+    """Injectable stand-in for nexus.mcp_client.devonthink."""
+
+    def __init__(self, *, available=True, similar=None, links=None):
+        self._available = available
+        self._similar = similar or []
+        self._links = links or []
+        self.classify_calls = 0
+
+    def available(self, *, refresh=False):
+        return self._available
+
+    def dt_find_similar(self, uuid, *, limit=25, floor=0.0):
+        return [n for n in self._similar if n["score"] >= floor]
+
+    def dt_record_links(self, uuid):
+        return self._links
+
+    def dt_call(self, tool, args=None):
+        self.classify_calls += 1
+        return {}
+
+
+@pytest.fixture
+def indexed(cat):
+    """Register a 'this' record plus two indexed DT neighbours; return ids."""
+    owner = cat.register_owner("nexus", "repo", repo_hash="571b8edd")
+    this = cat.register(owner, "this", content_type="paper", file_path="", source_uri=_uri("THIS"))
+    a = cat.register(owner, "alpha", content_type="paper", file_path="", source_uri=_uri("A"))
+    b = cat.register(owner, "beta", content_type="paper", file_path="", source_uri=_uri("B"))
+    return cat, owner, this, a, b
+
+
+def test_two_of_three_neighbours_known_make_two_edges(indexed):
+    cat, _owner, this, a, b = indexed
+    dt = _FakeDT(similar=[
+        {"uuid": "A", "score": 0.9, "name": "alpha"},
+        {"uuid": "B", "score": 0.8, "name": "beta"},
+        {"uuid": "UNINDEXED", "score": 0.95, "name": "ghost"},
+    ])
+    counts = generate_dt_links(cat, this, "THIS", dt_client=dt)
+    assert counts == {"similar": 2, "link": 0}
+    # Verify two relates edges exist from `this`.
+    out = cat.links_from(this, "relates")
+    assert {str(e.to_tumbler) for e in out} == {str(a), str(b)}
+
+
+def test_idempotent_on_rerun(indexed):
+    cat, _owner, this, a, b = indexed
+    dt = _FakeDT(similar=[{"uuid": "A", "score": 0.9, "name": "alpha"}])
+    first = generate_dt_links(cat, this, "THIS", dt_client=dt)
+    second = generate_dt_links(cat, this, "THIS", dt_client=dt)
+    assert first == {"similar": 1, "link": 0}
+    assert second == {"similar": 0, "link": 0}
+
+
+def test_explicit_link_deduped_against_similarity(indexed):
+    cat, _owner, this, a, b = indexed
+    # A appears in BOTH similarity and explicit links → only the similarity edge counts.
+    # B appears only as an explicit link → one dt_link edge.
+    dt = _FakeDT(
+        similar=[{"uuid": "A", "score": 0.9, "name": "alpha"}],
+        links=[{"uuid": "A", "score": 1.0, "name": "alpha"}, {"uuid": "B", "score": 1.0, "name": "beta"}],
+    )
+    counts = generate_dt_links(cat, this, "THIS", dt_client=dt)
+    assert counts == {"similar": 1, "link": 1}
+
+
+def test_unavailable_makes_zero_edges(indexed):
+    cat, _owner, this, _a, _b = indexed
+    dt = _FakeDT(available=False, similar=[{"uuid": "A", "score": 0.9, "name": "alpha"}])
+    counts = generate_dt_links(cat, this, "THIS", dt_client=dt)
+    assert counts == {"similar": 0, "link": 0}
+    assert cat.links_from(this) == []
+
+
+def test_floor_filters_low_similarity(indexed):
+    cat, _owner, this, a, b = indexed
+    dt = _FakeDT(similar=[
+        {"uuid": "A", "score": 0.9, "name": "alpha"},
+        {"uuid": "B", "score": 0.3, "name": "beta"},
+    ])
+    counts = generate_dt_links(cat, this, "THIS", floor=0.5, dt_client=dt)
+    assert counts == {"similar": 1, "link": 0}

--- a/tests/test_dt_mcp_fallback.py
+++ b/tests/test_dt_mcp_fallback.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Gap-0 fallback suite: every DT layer degrades EXACTLY when DT is absent (RDR-139).
+
+The contract (RDR §Optionality and Fallback Contract) is per-layer and EXACT,
+not "no crash":
+
+- **Layer B (linking)**: zero new edges — the catalog edge set after a run with
+  ``available()=False`` equals the edge set before; no ``created_by=dt_*`` rows.
+- **Layer F (write-back)**: no DT-side mutation; index/enrich result unchanged,
+  exit 0.  *(Added when P1.7 Layer F lands — nexus-x70wg.)*
+
+Integration over mocks: a real ``Catalog`` on tmp SQLite; only the DT client's
+``available()`` is forced False (the genuine fallback trigger).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.dt_link_generator import generate_dt_links
+
+
+@pytest.fixture
+def cat(tmp_path):
+    d = tmp_path / "catalog"
+    d.mkdir()
+    return Catalog(d, d / ".catalog.db")
+
+
+class _UnavailableDT:
+    """DT client whose server is down. Any read/write helper would be a bug to call."""
+
+    def available(self, *, refresh=False):
+        return False
+
+    def dt_find_similar(self, *a, **k):  # pragma: no cover - must not be reached
+        raise AssertionError("dt_find_similar called despite available()=False")
+
+    def dt_record_links(self, *a, **k):  # pragma: no cover
+        raise AssertionError("dt_record_links called despite available()=False")
+
+    def dt_call(self, *a, **k):  # pragma: no cover
+        raise AssertionError("dt_call called despite available()=False")
+
+
+@pytest.fixture
+def indexed(cat):
+    owner = cat.register_owner("nexus", "repo", repo_hash="571b8edd")
+    this = cat.register(
+        owner, "this", content_type="paper", file_path="",
+        source_uri="x-devonthink-item://THIS",
+    )
+    other = cat.register(
+        owner, "other", content_type="paper", file_path="",
+        source_uri="x-devonthink-item://A",
+    )
+    # A pre-existing non-DT edge: the fallback must leave it untouched.
+    cat.link_if_absent(this, other, "relates", created_by="auto_linker")
+    return cat, this, other
+
+
+def _edge_snapshot(cat: Catalog, tumbler):
+    return sorted(
+        (str(e.from_tumbler), str(e.to_tumbler), e.link_type, e.created_by)
+        for e in cat.links_from(tumbler)
+    )
+
+
+class TestLayerBFallback:
+    """Layer B: DT absent → zero new edges; pre-existing edge set unchanged."""
+
+    def test_zero_new_edges_when_unavailable(self, indexed):
+        cat, this, _other = indexed
+        before = _edge_snapshot(cat, this)
+        counts = generate_dt_links(cat, this, "THIS", dt_client=_UnavailableDT())
+        after = _edge_snapshot(cat, this)
+        assert counts == {"similar": 0, "link": 0}
+        assert after == before  # EXACT: edge set unchanged, not merely "no crash"
+
+    def test_no_dt_attributed_rows_added(self, indexed):
+        cat, this, _other = indexed
+        generate_dt_links(cat, this, "THIS", dt_client=_UnavailableDT())
+        assert cat.link_query(created_by="dt_similar") == []
+        assert cat.link_query(created_by="dt_link") == []
+
+    def test_no_read_helper_invoked_when_unavailable(self, indexed):
+        # _UnavailableDT raises if any read helper is called; reaching here proves
+        # the available() gate short-circuits before any DT read.
+        cat, this, _other = indexed
+        generate_dt_links(cat, this, "THIS", dt_client=_UnavailableDT())
+
+
+# Layer F fallback (no DT-side mutation, index/enrich unchanged, exit 0) is added
+# with P1.7 write-back (nexus-x70wg). Placed here intentionally so the Gap-0
+# contract lives in one suite — see module docstring.

--- a/tests/test_mcp_client_core.py
+++ b/tests/test_mcp_client_core.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""P1.2 contracts for the shared MCP-client core seam (RDR-139 Layer A).
+
+`core.call_tool` is the fail-soft result-or-None primitive shared with
+RDR-126. These pins exercise the contract against a fake `ClientSession`
+so no real MCP server is needed:
+
+- success → parsed dict (structuredContent preferred, text-JSON fallback)
+- isError result → None + structured warning
+- raised exception → None + structured warning (never propagates)
+- secrets in arguments are redacted from the log event
+
+Lifecycle (per-call vs daemon-held-open) is deliberately NOT decided here;
+`core` only provides the connect primitive and the call contract.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import structlog
+
+from nexus.mcp_client import core
+
+
+@dataclass
+class _FakeContent:
+    text: str
+    type: str = "text"
+
+
+@dataclass
+class _FakeResult:
+    structuredContent: dict[str, Any] | None = None
+    content: list[Any] | None = None
+    isError: bool = False
+
+
+class _FakeSession:
+    """Minimal ClientSession stand-in: records the call, returns a canned result."""
+
+    def __init__(self, result: Any = None, *, raises: Exception | None = None) -> None:
+        self._result = result
+        self._raises = raises
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> Any:
+        self.calls.append((name, dict(arguments or {})))
+        if self._raises is not None:
+            raise self._raises
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_call_tool_prefers_structured_content() -> None:
+    session = _FakeSession(_FakeResult(structuredContent={"count": 2, "results": []}))
+    out = await core.call_tool(session, "find_similar_records", {"uuid": "X"})
+    assert out == {"count": 2, "results": []}
+    assert session.calls == [("find_similar_records", {"uuid": "X"})]
+
+
+@pytest.mark.asyncio
+async def test_call_tool_parses_text_json_fallback() -> None:
+    payload = {"ok": True}
+    session = _FakeSession(_FakeResult(content=[_FakeContent(json.dumps(payload))]))
+    out = await core.call_tool(session, "get_record_links", {"uuid": "X"})
+    assert out == payload
+
+
+@pytest.mark.asyncio
+async def test_call_tool_is_error_returns_none(caplog: pytest.LogCaptureFixture) -> None:
+    session = _FakeSession(_FakeResult(content=[_FakeContent("boom")], isError=True))
+    out = await core.call_tool(session, "set_record_tags", {"uuid": "X"})
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_call_tool_swallows_exception() -> None:
+    session = _FakeSession(raises=RuntimeError("transport down"))
+    out = await core.call_tool(session, "anything", {})
+    assert out is None  # fail-soft: no DT failure may propagate
+
+
+@pytest.mark.asyncio
+async def test_call_tool_redacts_secret_args() -> None:
+    events: list[dict[str, Any]] = []
+
+    def _capture(logger, method_name, event_dict):  # structlog processor
+        events.append(dict(event_dict))
+        raise structlog.DropEvent
+
+    structlog.configure(processors=[_capture])
+    try:
+        session = _FakeSession(raises=RuntimeError("x"))
+        await core.call_tool(session, "t", {"uuid": "U", "authorization": "Bearer sekret"})
+    finally:
+        structlog.reset_defaults()
+
+    assert events, "expected a structured log event on failure"
+    logged_args = next((e.get("args") for e in events if "args" in e), {})
+    assert logged_args.get("uuid") == "U"
+    assert logged_args.get("authorization") == core.REDACTED

--- a/tests/test_mcp_client_devonthink.py
+++ b/tests/test_mcp_client_devonthink.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""P1.3 contracts for the DEVONthink per-call MCP client (RDR-139 Layer A).
+
+Pins:
+- ``dt_call`` running-loop guard fires + logs a DISTINCT
+  ``dt_asyncio_context_error`` and returns ``None`` (CLI-path-only contract).
+- ``available()`` gate: True only when ``is_running.running`` is truthy;
+  False on unreachable DT; cached, refreshable.
+- typed helpers map results correctly and degrade to ``[]`` / ``None`` /
+  ``False`` when DT is unavailable (Gap 0 fail-soft).
+
+No live DEVONthink server is touched: ``dt_call`` is monkeypatched for the
+helper/gate pins; the loop-guard pin exercises the real ``dt_call`` (the guard
+returns before any connection is attempted).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import structlog
+
+from nexus.mcp_client import devonthink as dt
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    dt.reset_availability_cache()
+    yield
+    dt.reset_availability_cache()
+
+
+@pytest.mark.asyncio
+async def test_dt_call_running_loop_guard_logs_distinctly() -> None:
+    events: list[dict[str, Any]] = []
+
+    def _capture(logger, method_name, event_dict):
+        events.append(dict(event_dict))
+        raise structlog.DropEvent
+
+    structlog.configure(processors=[_capture])
+    try:
+        # We ARE inside a running loop (async test) — the guard must fire.
+        out = dt.dt_call("is_running")
+    finally:
+        structlog.reset_defaults()
+
+    assert out is None
+    assert any(e.get("event") == "dt_asyncio_context_error" for e in events)
+
+
+def test_available_true_when_running(monkeypatch) -> None:
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: {"running": True})
+    assert dt.available(refresh=True) is True
+
+
+def test_available_false_when_not_running(monkeypatch) -> None:
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: {"running": False})
+    assert dt.available(refresh=True) is False
+
+
+def test_available_false_when_unreachable(monkeypatch) -> None:
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: None)
+    assert dt.available(refresh=True) is False
+
+
+def test_available_is_cached(monkeypatch) -> None:
+    calls = {"n": 0}
+
+    def _fake(tool, args=None):
+        calls["n"] += 1
+        return {"running": True}
+
+    monkeypatch.setattr(dt, "dt_call", _fake)
+    assert dt.available(refresh=True) is True
+    assert dt.available() is True  # served from cache
+    assert calls["n"] == 1
+
+
+def test_dt_find_similar_maps_and_applies_floor(monkeypatch) -> None:
+    payload = {
+        "count": 3,
+        "results": [
+            {"uuid": "A", "score": 0.9, "name": "alpha"},
+            {"uuid": "B", "score": 0.4, "name": "below-floor"},
+            {"score": 0.95, "name": "no-uuid"},
+        ],
+    }
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: payload)
+    out = dt.dt_find_similar("Q", limit=10, floor=0.5)
+    assert out == [{"uuid": "A", "score": 0.9, "name": "alpha"}]
+
+
+def test_dt_record_links_merges_and_dedups(monkeypatch) -> None:
+    payload = {
+        "incoming": [{"uuid": "A", "name": "a"}],
+        "outgoing": [{"uuid": "A", "name": "a"}, {"uuid": "B", "name": "b"}],
+    }
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: payload)
+    out = dt.dt_record_links("Q")
+    assert [n["uuid"] for n in out] == ["A", "B"]
+    assert all(n["score"] == 1.0 for n in out)
+
+
+def test_helpers_fail_soft_when_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: None)
+    assert dt.dt_find_similar("Q") == []
+    assert dt.dt_record_links("Q") == []
+    assert dt.dt_resolve_doi("10.1/x") is None
+    assert dt.dt_extract_content("Q") is None
+    assert dt.dt_set_tags("Q", ["nx-related"]) is False
+    assert dt.dt_set_custom_metadata("Q", {"x": "y"}) is False
+
+
+def test_write_helpers_true_on_success(monkeypatch) -> None:
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: {"uuid": "Q", "tags": ["nx-related"]})
+    assert dt.dt_set_tags("Q", ["nx-related"]) is True
+    assert dt.dt_set_custom_metadata("Q", {"mddoi": "10.1/x"}) is True
+
+
+def test_write_helpers_reject_empty_input(monkeypatch) -> None:
+    # Empty tags/fields short-circuit without a call.
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: pytest.fail("should not call"))
+    assert dt.dt_set_tags("Q", []) is False
+    assert dt.dt_set_custom_metadata("Q", {}) is False
+    assert dt.dt_resolve_doi("") is None

--- a/tests/test_mcp_client_devonthink.py
+++ b/tests/test_mcp_client_devonthink.py
@@ -111,12 +111,27 @@ def test_helpers_fail_soft_when_unavailable(monkeypatch) -> None:
     assert dt.dt_extract_content("Q") is None
     assert dt.dt_set_tags("Q", ["nx-related"]) is False
     assert dt.dt_set_custom_metadata("Q", {"x": "y"}) is False
+    assert dt.dt_set_annotation("Q", "note") is False
 
 
-def test_write_helpers_true_on_success(monkeypatch) -> None:
-    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: {"uuid": "Q", "tags": ["nx-related"]})
+def test_write_helpers_true_on_success_and_pass_no_clobber_mode(monkeypatch) -> None:
+    seen: list[tuple[str, dict]] = []
+
+    def _capture(tool, args=None):
+        seen.append((tool, dict(args or {})))
+        return {"uuid": "Q"}
+
+    monkeypatch.setattr(dt, "dt_call", _capture)
     assert dt.dt_set_tags("Q", ["nx-related"]) is True
     assert dt.dt_set_custom_metadata("Q", {"mddoi": "10.1/x"}) is True
+    assert dt.dt_set_annotation("Q", "see nx tumbler 1.2.3") is True
+
+    by_tool = {tool: args for tool, args in seen}
+    # CA5 no-clobber: writes must be additive/merge, never replace the user's data.
+    assert by_tool["set_record_tags"]["mode"] == "add"
+    assert by_tool["set_record_custom_metadata"]["mode"] == "merge"
+    assert by_tool["set_record_annotation"]["mode"] == "append"
+    assert by_tool["set_record_annotation"]["text"] == "see nx tumbler 1.2.3"
 
 
 def test_write_helpers_reject_empty_input(monkeypatch) -> None:
@@ -124,4 +139,5 @@ def test_write_helpers_reject_empty_input(monkeypatch) -> None:
     monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: pytest.fail("should not call"))
     assert dt.dt_set_tags("Q", []) is False
     assert dt.dt_set_custom_metadata("Q", {}) is False
+    assert dt.dt_set_annotation("Q", "") is False
     assert dt.dt_resolve_doi("") is None

--- a/tests/test_mcp_client_scaffold.py
+++ b/tests/test_mcp_client_scaffold.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""P1.1 scaffold pins for the RDR-139 MCP client substrate.
+
+These are deliberately minimal: they assert the `mcp` SDK dependency is
+importable in the venv and that the new `nexus.mcp_client` package exists.
+Behavioural contracts (fail-soft call_tool, availability gate) land in later
+Phase 1 beads with their own test modules.
+"""
+
+import importlib
+
+
+def test_mcp_streamable_http_importable() -> None:
+    """The `mcp` SDK (pyproject.toml: mcp>=1.0) exposes the streamable-HTTP client."""
+    mod = importlib.import_module("mcp.client.streamable_http")
+    assert mod is not None
+
+
+def test_mcp_client_package_importable() -> None:
+    """The new nexus.mcp_client package is present and distinct from nexus.mcp."""
+    client_pkg = importlib.import_module("nexus.mcp_client")
+    server_pkg = importlib.import_module("nexus.mcp")
+    assert client_pkg.__name__ == "nexus.mcp_client"
+    assert client_pkg.__name__ != server_pkg.__name__


### PR DESCRIPTION
## RDR-139 Phase 1 — read-only DEVONthink MCP substrate

Implements the read-path half of RDR-139 Phase 1 (`docs/rdr/rdr-139-devonthink-mcp-semantic-linking-sync.md`). The write-back half (P1.6 CA5 live verification, P1.7 Layer F) is intentionally deferred pending live-DB authorization; this PR is a self-contained, reviewable increment.

### What landed
- **P1.1** `nexus.mcp_client` package scaffold (distinct from the `nexus.mcp` server). `mcp>=1.0` verified present.
- **P1.2** `mcp_client/core.py` — shared MCP-client seam: `open_session` (streamable-HTTP connect) + fail-soft `call_tool` (result-or-None, structured log, secret-arg redaction). Lifecycle deliberately not baked in (shared seam with RDR-126).
- **P1.3** `mcp_client/devonthink.py` — per-call DT client: cached `available()` gate, `dt_call` asyncio bridge with a running-loop guard logging a distinct `dt_asyncio_context_error` (CLI-path-only contract), typed helpers incl. write helpers (no-clobber modes).
- **P1.4** `Catalog.by_source_uri` inverse lookup + probe-guarded `idx_documents_source_uri` migration.
- **P1.5** `catalog/dt_link_generator.py` — Layer B: maps DT `find_similar` / `get_record_links` neighbours via `by_source_uri` to `relates` edges (`created_by` `dt_similar`/`dt_link`), deduped; DT down → zero edges.
- **P1.8 (partial)** `tests/test_dt_mcp_fallback.py` — Gap-0 Layer B exact-fallback (edge set unchanged, no `dt_*` rows, no read helper invoked). Layer F portion lands with P1.7.

### Review
Stacked reviewers (code-review-expert + substantive-critic) ran clean of Criticals; all 3 Significant findings addressed in `3071dff1` (deprecated-transport migration, `source_uri` index, missing `dt_set_annotation` helper, CA5 no-clobber-mode unit assertions).

### Tests
New: `test_mcp_client_scaffold/core/devonthink`, `test_dt_link_generator`, `test_dt_mcp_fallback`, `TestBySourceUri`. Full catalog + migration subset green (1538 passed).

### Beads
Closes (beads): nexus-lcmkg, nexus-m21ns, nexus-jpyf0, nexus-ft2i1, nexus-08puh. nexus-mxcsm (P1.8) remains open for the Layer F portion.

RDR: docs/rdr/rdr-139-devonthink-mcp-semantic-linking-sync.md (accepted).
