### PR TITLE
feat(rdr-139): Layer F DEVONthink write-back (P1.7) + Gap-0 fallback (P1.8)

### DIFF
--- a/docs/rdr/rdr-139-devonthink-mcp-semantic-linking-sync.md
+++ b/docs/rdr/rdr-139-devonthink-mcp-semantic-linking-sync.md
@@ -370,8 +370,17 @@ unavailable and asserts the legacy result is byte-identical to pre-RDR-139.
   `nx-tumbler:<t>`, top aspect keywords), `set_record_annotation` (backlink
   to tumbler), and `set_record_custom_metadata` (structured tumbler / aspect
   fields). Authoritative-source contract: nexus owns only the metadata it
-  writes; never edits user content; respects "Exclude from AI & MCP".
-  Fallback: no DT → no write-back (index still succeeds).
+  writes; never edits user content; respects "Exclude from AI & MCP" on a
+  **best-effort** basis. (CA5 part b finding: DT does not refuse metadata
+  writes to excluded records and the flag is not readable via the API, so
+  write-back skips any record whose AI-extracted content is empty — the one
+  available exclusion signal. This also skips genuinely empty records, and has
+  a known false-negative on file-path-indexed records with no DT AI content,
+  e.g. image-only PDFs.) Custom-metadata keys are `nxtumbler`/`nxindexed` (DT
+  strips separators from identifiers) and require pre-defined DT fields, so
+  that write is additive/best-effort; the tumbler is always recoverable from
+  the `nx-tumbler:<t>` tag. Fallback: no DT → no write-back (index still
+  succeeds).
 - **Layer G — Capture into graph (Gap 7).** `nx dt capture <url>`:
   `capture_web_page` → DT record → `nx dt index` in one verb;
   `download_pdf_from_doi` for DOI capture; `import_file` for loose files.
@@ -531,8 +540,11 @@ of scope here.)
   "DT unavailable, layer skipped" line; `nx dt index` summary reports which
   enhancements ran vs were skipped.
 - **Risk**: write-back pollutes the user's DB. **Mitigation**: `--writeback`
-  opt-in, nexus-owned namespace only (`nx-*`), never touch user content;
-  honour exclusion flag.
+  opt-in, nexus-owned namespace only (`nx-*` tags, `nxtumbler`/`nxindexed`
+  metadata), never touch user content; honour the exclusion flag on a
+  best-effort basis (empty-AI-content skip — see Layer F; CA5 part b found the
+  server does not refuse writes to excluded records and the flag is not
+  API-readable).
 - **Risk**: a Layer B/C/D helper is called from inside a running event loop
   (aspect worker, future daemon path) → `asyncio.run` raises `RuntimeError`,
   which the fail-soft contract would otherwise swallow as a `None`/"DT

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -194,6 +194,38 @@ def _stamp_dt_uri_on_entry(file_path: Path, uuid: str) -> bool:
         cat._db.close()
 
 
+def _link_semantic_record(uuid: str) -> bool:
+    """Create Layer B DT-derived 'relates' edges for a just-indexed record.
+
+    Resolves the record's tumbler via ``Catalog.by_source_uri`` (just stamped
+    with ``x-devonthink-item://<uuid>``) and calls
+    :func:`nexus.catalog.dt_link_generator.generate_dt_links`. Returns ``True``
+    when at least one edge was created. Fail-soft: any error or unresolvable
+    tumbler logs and returns ``False`` — linking never aborts the index batch.
+    """
+    from nexus.catalog.catalog import Catalog  # noqa: PLC0415
+    from nexus.catalog.dt_link_generator import generate_dt_links  # noqa: PLC0415
+    from nexus.config import catalog_path  # noqa: PLC0415
+
+    dt_uri = f"x-devonthink-item://{uuid}"
+    cat_path = catalog_path()
+    if not Catalog.is_initialized(cat_path):
+        return False
+    cat = Catalog(cat_path, cat_path / ".catalog.db")
+    try:
+        entry = cat.by_source_uri(dt_uri)
+        if entry is None:
+            _log.warning("dt_link_no_entry", uuid=uuid)
+            return False
+        counts = generate_dt_links(cat, entry.tumbler, uuid)
+        return (counts["similar"] + counts["link"]) > 0
+    except Exception as e:
+        _log.warning("dt_link_failed", uuid=uuid, error=str(e))
+        return False
+    finally:
+        cat._db.close()
+
+
 def _writeback_record(uuid: str) -> bool:
     """Stamp the nexus identity back onto a just-indexed DT record (Layer F).
 
@@ -310,6 +342,18 @@ def dt() -> None:
     help="Print the records that would be indexed; make no T3 writes.",
 )
 @click.option(
+    "--link-semantic",
+    "link_semantic",
+    is_flag=True,
+    default=False,
+    help=(
+        "After a record indexes, create 'relates' edges to its DEVONthink "
+        "similarity + explicit-link neighbours that are also indexed in nexus "
+        "(Layer B): created_by dt_similar / dt_link, deduped, idempotent. "
+        "DT unavailable -> zero edges. Opt-in, default off."
+    ),
+)
+@click.option(
     "--writeback",
     is_flag=True,
     default=False,
@@ -331,6 +375,7 @@ def index_cmd(
     collection: str | None,
     corpus: str,
     dry_run: bool,
+    link_semantic: bool,
     writeback: bool,
 ) -> None:
     """Index DEVONthink records into Nexus.
@@ -382,6 +427,7 @@ def index_cmd(
     skipped = 0
     stamp_failed = 0
     written_back = 0
+    linked = 0
     failed: list[tuple[str, str, str]] = []  # (uuid, path, error)
     for uuid, path in records:
         ext = Path(path).suffix.lower()
@@ -424,9 +470,14 @@ def index_cmd(
         indexed += 1
         if not stamped:
             stamp_failed += 1
-        elif writeback and _writeback_record(uuid):
+            continue
+        if link_semantic and _link_semantic_record(uuid):
+            linked += 1
+        if writeback and _writeback_record(uuid):
             written_back += 1
     summary = f"Indexed {indexed} record(s) ({skipped} skipped"
+    if link_semantic:
+        summary += f", {linked} semantically linked"
     if writeback:
         summary += f", {written_back} written back to DT"
     if failed:

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -194,6 +194,43 @@ def _stamp_dt_uri_on_entry(file_path: Path, uuid: str) -> bool:
         cat._db.close()
 
 
+def _writeback_record(uuid: str) -> bool:
+    """Stamp the nexus identity back onto a just-indexed DT record (Layer F).
+
+    Resolves the record's tumbler via ``Catalog.by_source_uri`` (the entry was
+    just stamped with ``x-devonthink-item://<uuid>``) and calls
+    :func:`nexus.dt_writeback.writeback_record`. Returns ``True`` when at least
+    one nexus-owned field was written. Fail-soft: any error or an unresolvable
+    tumbler logs and returns ``False`` — write-back never aborts the index batch.
+
+    Aspect-keyword tags (``nx-kw:*``) are supported by ``writeback_record`` but
+    not sourced here: RDR-089 aspect extraction is queued AFTER index, so no
+    keywords exist at ``nx dt index`` time. Stamping them is deferred to a
+    follow-on re-stamp pass (tracked) rather than stamped empty.
+    """
+    from nexus.catalog.catalog import Catalog  # noqa: PLC0415
+    from nexus.config import catalog_path  # noqa: PLC0415
+    from nexus.dt_writeback import writeback_record  # noqa: PLC0415
+
+    dt_uri = f"x-devonthink-item://{uuid}"
+    cat_path = catalog_path()
+    if not Catalog.is_initialized(cat_path):
+        return False
+    cat = Catalog(cat_path, cat_path / ".catalog.db")
+    try:
+        entry = cat.by_source_uri(dt_uri)
+        if entry is None:
+            _log.warning("dt_writeback_no_entry", uuid=uuid)
+            return False
+        result = writeback_record(uuid, str(entry.tumbler))
+        return any(result[k] for k in ("tags", "annotation", "metadata"))
+    except Exception as e:
+        _log.warning("dt_writeback_failed", uuid=uuid, error=str(e))
+        return False
+    finally:
+        cat._db.close()
+
+
 @click.group("dt")
 def dt() -> None:
     """DEVONthink integration verbs (macOS only).
@@ -272,6 +309,18 @@ def dt() -> None:
     default=False,
     help="Print the records that would be indexed; make no T3 writes.",
 )
+@click.option(
+    "--writeback",
+    is_flag=True,
+    default=False,
+    help=(
+        "After a record indexes, stamp the nexus identity back onto the "
+        "DEVONthink record (Layer F): nx-indexed / nx-tumbler:<t> tags "
+        "(add-mode, no clobber), a tumbler backlink annotation, and "
+        "nxtumbler custom metadata. nexus-owned nx-* namespace only; never "
+        "edits user content; honours Exclude-from-AI&MCP. Opt-in, default off."
+    ),
+)
 def index_cmd(
     use_selection: bool,
     tag: str | None,
@@ -282,6 +331,7 @@ def index_cmd(
     collection: str | None,
     corpus: str,
     dry_run: bool,
+    writeback: bool,
 ) -> None:
     """Index DEVONthink records into Nexus.
 
@@ -331,6 +381,7 @@ def index_cmd(
     indexed = 0
     skipped = 0
     stamp_failed = 0
+    written_back = 0
     failed: list[tuple[str, str, str]] = []  # (uuid, path, error)
     for uuid, path in records:
         ext = Path(path).suffix.lower()
@@ -373,7 +424,11 @@ def index_cmd(
         indexed += 1
         if not stamped:
             stamp_failed += 1
+        elif writeback and _writeback_record(uuid):
+            written_back += 1
     summary = f"Indexed {indexed} record(s) ({skipped} skipped"
+    if writeback:
+        summary += f", {written_back} written back to DT"
     if failed:
         summary += f", {len(failed)} failed"
     if stamp_failed:

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -361,8 +361,10 @@ def dt() -> None:
         "After a record indexes, stamp the nexus identity back onto the "
         "DEVONthink record (Layer F): nx-indexed / nx-tumbler:<t> tags "
         "(add-mode, no clobber), a tumbler backlink annotation, and "
-        "nxtumbler custom metadata. nexus-owned nx-* namespace only; never "
-        "edits user content; honours Exclude-from-AI&MCP. Opt-in, default off."
+        "nxtumbler custom metadata. nexus-owned namespace only; never edits "
+        "user content; honours Exclude-from-AI&MCP on a best-effort basis "
+        "(records with empty AI-extracted content are skipped). Opt-in, "
+        "default off."
     ),
 )
 def index_cmd(

--- a/src/nexus/dt_writeback.py
+++ b/src/nexus/dt_writeback.py
@@ -84,9 +84,12 @@ def writeback_record(
     # records (live finding, CA5 part b / 139-research-CA5), so the only signal
     # we have is that excluded records return empty AI-extracted content. Skip
     # write-back when content is empty — this honours the exclusion flag's
-    # intent and also correctly skips genuinely empty records (which carry no
-    # nexus value to back-link). False-positive risk is low: a record indexed
-    # into nexus has extractable content by construction.
+    # intent and also skips genuinely empty records. Known false-negative: a
+    # record indexed via file-path extraction (e.g. an image-only PDF whose
+    # text layer PyMuPDF read) can still return empty DT AI-content and be
+    # skipped here — "indexed by nexus" and "DT AI-extracts content" are
+    # independent. Accepted for write-back (an additive convenience), since the
+    # alternative (stamping excluded records) is the worse failure.
     if not dt_client.dt_extract_content(dt_uuid):
         log.info("dt_writeback_skipped_excluded_or_empty", dt_uuid=dt_uuid, tumbler=tumbler)
         result["skipped"] = True

--- a/src/nexus/dt_writeback.py
+++ b/src/nexus/dt_writeback.py
@@ -9,10 +9,11 @@ CLI wires it after a successful index.
 
 Authoritative-source contract (RDR §Approach Layer F, §Risks):
 
-- **nexus-owned namespace only**: every tag nexus writes is ``nx-*`` prefixed
-  and every custom-metadata key is ``nx.*`` prefixed (DT forbids ``-`` in
-  metadata identifiers, so the metadata namespace is the dotted form), so a
-  later audit/revoke pass finds exactly what nexus wrote and nothing else.
+- **nexus-owned namespace only**: every tag nexus writes is ``nx-*`` prefixed.
+  Custom-metadata keys are ``nxtumbler`` / ``nxindexed`` (DT strips separators
+  from metadata identifiers, so a hyphen/dot is not possible — ``nx``-prefixed
+  is the maximally-namespaced legal form). A later audit/revoke pass matches
+  ``nx-*`` tags and the ``nx``-prefixed metadata keys.
 - **never edits user content**: only tags, an appended annotation, and custom
   metadata fields — the record body is never touched.
 - **no-clobber**: tags add-mode, annotation append-mode, metadata merge-mode
@@ -91,12 +92,14 @@ def writeback_record(
     else:
         result["annotation"] = dt_client.dt_set_annotation(dt_uuid, backlink, mode="append")
 
-    # Custom-metadata identifiers: DT rejects '-' (alphanumeric + '?'/'.' only),
-    # so the nexus namespace for metadata is the dotted ``nx.*`` form (the tag
-    # namespace is ``nx-*``). Both are nexus-owned and matched by the Day-2
-    # revoke pass — see module docstring.
+    # Custom metadata is best-effort: DT strips separators from identifiers and
+    # only accepts PRE-DEFINED custom-metadata fields, so ``nxtumbler`` is the
+    # maximally-namespaced legal key and the write is a no-op (honestly reported
+    # as metadata=False) unless the user has defined nexus fields in DT. The
+    # tumbler is always recoverable from the ``nx-tumbler:<t>`` tag regardless,
+    # so this is additive, not load-bearing. (Live finding, CA5 / 139-research-CA5.)
     result["metadata"] = dt_client.dt_set_custom_metadata(
-        dt_uuid, {"nx.tumbler": str(tumbler), "nx.indexed": "true"}, mode="merge"
+        dt_uuid, {"nxtumbler": str(tumbler), "nxindexed": "true"}, mode="merge"
     )
 
     log.info(

--- a/src/nexus/dt_writeback.py
+++ b/src/nexus/dt_writeback.py
@@ -18,9 +18,10 @@ Authoritative-source contract (RDR §Approach Layer F, §Risks):
   metadata fields — the record body is never touched.
 - **no-clobber**: tags add-mode, annotation append-mode, metadata merge-mode
   (verified live, CA5 / nexus-ymcrt).
-- **honours Exclude-from-AI&MCP**: the DT server rejects writes to excluded
-  records; each helper is fail-soft (``None`` → ``False``) so an excluded record
-  yields a clean skip, never a silent partial write.
+- **honours Exclude-from-AI&MCP (best-effort)**: the DT server does NOT refuse
+  metadata writes to excluded records and the flag is not readable (live finding,
+  CA5 part b), so write-back skips any record whose AI-extracted content is empty
+  — the one exclusion signal available. This also skips genuinely empty records.
 - **opt-in**: the CLI flag defaults off; this function is only called when the
   user asks for it.
 """
@@ -75,6 +76,19 @@ def writeback_record(
         return result
     if not dt_client.available():
         log.info("dt_writeback_skipped_unavailable", dt_uuid=dt_uuid, tumbler=tumbler)
+        result["skipped"] = True
+        return result
+
+    # Best-effort exclusion guard. The DT 'Exclude from AI & MCP' flag is not
+    # readable via the API and write tools are NOT server-refused for excluded
+    # records (live finding, CA5 part b / 139-research-CA5), so the only signal
+    # we have is that excluded records return empty AI-extracted content. Skip
+    # write-back when content is empty — this honours the exclusion flag's
+    # intent and also correctly skips genuinely empty records (which carry no
+    # nexus value to back-link). False-positive risk is low: a record indexed
+    # into nexus has extractable content by construction.
+    if not dt_client.dt_extract_content(dt_uuid):
+        log.info("dt_writeback_skipped_excluded_or_empty", dt_uuid=dt_uuid, tumbler=tumbler)
         result["skipped"] = True
         return result
 

--- a/src/nexus/dt_writeback.py
+++ b/src/nexus/dt_writeback.py
@@ -9,8 +9,10 @@ CLI wires it after a successful index.
 
 Authoritative-source contract (RDR §Approach Layer F, §Risks):
 
-- **nexus-owned namespace only**: every tag nexus writes is ``nx-*`` prefixed,
-  so a later audit/revoke can find exactly what nexus wrote and nothing else.
+- **nexus-owned namespace only**: every tag nexus writes is ``nx-*`` prefixed
+  and every custom-metadata key is ``nx.*`` prefixed (DT forbids ``-`` in
+  metadata identifiers, so the metadata namespace is the dotted form), so a
+  later audit/revoke pass finds exactly what nexus wrote and nothing else.
 - **never edits user content**: only tags, an appended annotation, and custom
   metadata fields — the record body is never touched.
 - **no-clobber**: tags add-mode, annotation append-mode, metadata merge-mode
@@ -77,11 +79,24 @@ def writeback_record(
 
     tags = ["nx-indexed", f"nx-tumbler:{tumbler}", *_nx_keyword_tags(aspect_keywords)]
     result["tags"] = dt_client.dt_set_tags(dt_uuid, tags, mode="add")
-    result["annotation"] = dt_client.dt_set_annotation(
-        dt_uuid, f"nexus: indexed as tumbler {tumbler}", mode="append"
-    )
+
+    # Annotation append is NOT idempotent server-side (DT has no dedup on append),
+    # so re-indexing would accumulate duplicate backlink lines and pollute the
+    # user's annotation. Guard: only append when the backlink is absent. Treat an
+    # already-present backlink as success (idempotent no-op).
+    backlink = f"nexus: indexed as tumbler {tumbler}"
+    existing = dt_client.dt_annotation_text(dt_uuid) or ""
+    if backlink in existing:
+        result["annotation"] = True
+    else:
+        result["annotation"] = dt_client.dt_set_annotation(dt_uuid, backlink, mode="append")
+
+    # Custom-metadata identifiers: DT rejects '-' (alphanumeric + '?'/'.' only),
+    # so the nexus namespace for metadata is the dotted ``nx.*`` form (the tag
+    # namespace is ``nx-*``). Both are nexus-owned and matched by the Day-2
+    # revoke pass — see module docstring.
     result["metadata"] = dt_client.dt_set_custom_metadata(
-        dt_uuid, {"nxtumbler": str(tumbler), "nxindexed": "true"}, mode="merge"
+        dt_uuid, {"nx.tumbler": str(tumbler), "nx.indexed": "true"}, mode="merge"
     )
 
     log.info(

--- a/src/nexus/dt_writeback.py
+++ b/src/nexus/dt_writeback.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""DEVONthink bidirectional write-back (RDR-139 Layer F).
+
+After nexus indexes + enriches a DEVONthink record, ``nx dt index --writeback``
+stamps the nexus identity back onto the DT record so the knowledge graph is
+navigable from inside DEVONthink. This module holds the pure orchestration; the
+CLI wires it after a successful index.
+
+Authoritative-source contract (RDR §Approach Layer F, §Risks):
+
+- **nexus-owned namespace only**: every tag nexus writes is ``nx-*`` prefixed,
+  so a later audit/revoke can find exactly what nexus wrote and nothing else.
+- **never edits user content**: only tags, an appended annotation, and custom
+  metadata fields — the record body is never touched.
+- **no-clobber**: tags add-mode, annotation append-mode, metadata merge-mode
+  (verified live, CA5 / nexus-ymcrt).
+- **honours Exclude-from-AI&MCP**: the DT server rejects writes to excluded
+  records; each helper is fail-soft (``None`` → ``False``) so an excluded record
+  yields a clean skip, never a silent partial write.
+- **opt-in**: the CLI flag defaults off; this function is only called when the
+  user asks for it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import structlog
+
+from nexus.mcp_client import devonthink as _devonthink
+
+log = structlog.get_logger(__name__)
+
+
+def _nx_keyword_tags(aspect_keywords: Iterable[str]) -> list[str]:
+    """Namespace + normalise aspect keywords into ``nx-kw:<k>`` tags (deduped)."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for kw in aspect_keywords:
+        norm = str(kw).strip().lower()
+        if not norm or norm in seen:
+            continue
+        seen.add(norm)
+        out.append(f"nx-kw:{norm}")
+    return out
+
+
+def writeback_record(
+    dt_uuid: str,
+    tumbler: str,
+    *,
+    aspect_keywords: Iterable[str] = (),
+    dt_client=_devonthink,
+) -> dict[str, bool]:
+    """Stamp the nexus identity onto a DEVONthink record (Layer F).
+
+    Writes (all nexus-owned, no-clobber):
+    - tags ``nx-indexed``, ``nx-tumbler:<t>``, and ``nx-kw:<k>`` per aspect keyword
+    - an appended annotation backlink to the tumbler
+    - custom metadata ``nxtumbler`` / ``nxindexed``
+
+    Returns ``{"tags", "annotation", "metadata", "skipped"}``. When DT is
+    unavailable returns ``{"skipped": True, ...all False}`` — the tested
+    fallback (index still succeeds, no DT mutation; Gap 0). Per-write failures
+    (e.g. an excluded record) are fail-soft: the individual flag is ``False``
+    and the others still attempt, mirroring the helpers' clean-error contract.
+    """
+    result = {"tags": False, "annotation": False, "metadata": False, "skipped": False}
+    if not dt_uuid or not tumbler:
+        result["skipped"] = True
+        return result
+    if not dt_client.available():
+        log.info("dt_writeback_skipped_unavailable", dt_uuid=dt_uuid, tumbler=tumbler)
+        result["skipped"] = True
+        return result
+
+    tags = ["nx-indexed", f"nx-tumbler:{tumbler}", *_nx_keyword_tags(aspect_keywords)]
+    result["tags"] = dt_client.dt_set_tags(dt_uuid, tags, mode="add")
+    result["annotation"] = dt_client.dt_set_annotation(
+        dt_uuid, f"nexus: indexed as tumbler {tumbler}", mode="append"
+    )
+    result["metadata"] = dt_client.dt_set_custom_metadata(
+        dt_uuid, {"nxtumbler": str(tumbler), "nxindexed": "true"}, mode="merge"
+    )
+
+    log.info(
+        "dt_writeback_done",
+        dt_uuid=dt_uuid,
+        tumbler=tumbler,
+        tags=result["tags"],
+        annotation=result["annotation"],
+        metadata=result["metadata"],
+    )
+    return result

--- a/src/nexus/mcp_client/devonthink.py
+++ b/src/nexus/mcp_client/devonthink.py
@@ -181,10 +181,15 @@ def dt_extract_content(uuid: str) -> str | None:
     result = dt_call("extract_record_content", {"uuid": uuid})
     if not result:
         return None
+    # Short/plain docs return a single text body ({"text": ...}); structured
+    # docs (Markdown/PDF/EPUB) return a BARE array of section/page dicts, which
+    # core wraps as {"result": [...]}. Handle both (live finding — sectioned
+    # PDFs are the common paper case and were returning None, wrongly tripping
+    # the Layer F exclusion guard).
     text = result.get("text")
     if isinstance(text, str) and text:
         return text
-    sections = result.get("sections") or result.get("pages")
+    sections = result.get("sections") or result.get("pages") or result.get("result")
     if isinstance(sections, list):
         parts = [s.get("text", "") for s in sections if isinstance(s, dict)]
         joined = "\n".join(p for p in parts if p)

--- a/src/nexus/mcp_client/devonthink.py
+++ b/src/nexus/mcp_client/devonthink.py
@@ -191,6 +191,26 @@ def dt_set_tags(uuid: str, tags: list[str], *, mode: str = "add") -> bool:
     return result is not None
 
 
+def dt_annotation_text(uuid: str) -> str | None:
+    """Current annotation body of a record, or ``None`` (no annotation / excluded).
+
+    Two-hop: ``get_record_annotation`` yields the annotation record's UUID, then
+    ``get_record_text`` reads its body. Used to make annotation write-back
+    idempotent (append only when the backlink is not already present).
+    """
+    meta = dt_call("get_record_annotation", {"uuid": uuid})
+    if not meta:
+        return None
+    ann_uuid = meta.get("annotation_uuid")
+    if not ann_uuid:
+        return None
+    result = dt_call("get_record_text", {"uuid": ann_uuid})
+    if not result:
+        return None
+    text = result.get("text") if isinstance(result, dict) else None
+    return text if isinstance(text, str) else None
+
+
 def dt_set_annotation(uuid: str, text: str, *, mode: str = "append") -> bool:
     """Write an annotation note onto a record. ``True`` on success (Layer F backlink).
 

--- a/src/nexus/mcp_client/devonthink.py
+++ b/src/nexus/mcp_client/devonthink.py
@@ -121,8 +121,17 @@ def dt_find_similar(uuid: str, *, limit: int = 25, floor: float = 0.0) -> list[N
     )
     if not result:
         return []
+    # Single-record mode returns a BARE neighbour array; core wraps a bare JSON
+    # array as {"result": [...]}. Batch/summary mode would use {"results": [...]}.
+    # Accept both shapes (live finding — the spike's {count, results} shape did
+    # not match single-uuid mode).
+    neighbours = result.get("results")
+    if neighbours is None:
+        neighbours = result.get("result")
     out: list[Neighbour] = []
-    for r in result.get("results", []) or []:
+    for r in neighbours or []:
+        if not isinstance(r, dict):
+            continue
         ruuid = r.get("uuid")
         score = float(r.get("score", 0.0) or 0.0)
         if not ruuid or score < floor:

--- a/src/nexus/mcp_client/devonthink.py
+++ b/src/nexus/mcp_client/devonthink.py
@@ -243,6 +243,8 @@ def dt_set_custom_metadata(uuid: str, fields: dict[str, Any], *, mode: str = "me
     )
     if result is None:
         return False
-    dropped = result.get("dropped_fields") or []
+    dropped = result.get("dropped_fields")
+    if not isinstance(dropped, list):
+        dropped = []
     # If DT dropped as many fields as we sent, nothing was committed.
     return len(dropped) < len(fields)

--- a/src/nexus/mcp_client/devonthink.py
+++ b/src/nexus/mcp_client/devonthink.py
@@ -226,10 +226,23 @@ def dt_set_annotation(uuid: str, text: str, *, mode: str = "append") -> bool:
 
 
 def dt_set_custom_metadata(uuid: str, fields: dict[str, Any], *, mode: str = "merge") -> bool:
-    """Write custom-metadata fields onto a record (default merge). ``True`` on success (Layer F)."""
+    """Write custom-metadata fields onto a record (default merge). ``True`` only on a real write.
+
+    DEVONthink custom-metadata identifiers must be PRE-DEFINED in the database's
+    custom-metadata schema; unknown fields are silently dropped server-side (the
+    response lists them in ``dropped_fields``). Also: DT strips ``-``/``.`` from
+    identifiers, so ``nxtumbler`` is the maximally-namespaced legal key. This
+    helper returns ``False`` when DT dropped every field (an honest no-op, not a
+    false success) so callers don't believe a write happened that didn't. Empty
+    fields short-circuit to ``False``.
+    """
     if not fields:
         return False
     result = dt_call(
         "set_record_custom_metadata", {"uuid": uuid, "metadata": fields, "mode": mode}
     )
-    return result is not None
+    if result is None:
+        return False
+    dropped = result.get("dropped_fields") or []
+    # If DT dropped as many fields as we sent, nothing was committed.
+    return len(dropped) < len(fields)

--- a/tests/test_commands_dt.py
+++ b/tests/test_commands_dt.py
@@ -1086,3 +1086,66 @@ class TestWriteback:
         result = runner.invoke(main, ["dt", "index", "--help"])
         assert result.exit_code == 0
         assert "--writeback" in result.output
+
+
+# ── Layer B semantic linking (RDR-139 P1.5 CLI wiring) ────────────────────────
+
+
+class TestLinkSemantic:
+    """``nx dt index --link-semantic`` invokes Layer B edge generation."""
+
+    def test_link_semantic_invoked_per_stamped_record(
+        self, runner, fake_selectors, fake_dispatcher, monkeypatch,
+    ):
+        from nexus.cli import main
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "nexus.commands.dt._link_semantic_record",
+            lambda uuid: calls.append(uuid) or True,
+        )
+        fake_selectors["uuid"].return_value = [("U1", "/a.pdf")]
+        result = runner.invoke(main, ["dt", "index", "--uuid", "U1", "--link-semantic"])
+        assert result.exit_code == 0, result.output
+        assert calls == ["U1"]
+        assert "semantically linked" in result.output
+
+    def test_no_link_semantic_flag_skips_call(
+        self, runner, fake_selectors, fake_dispatcher, monkeypatch,
+    ):
+        from nexus.cli import main
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "nexus.commands.dt._link_semantic_record",
+            lambda uuid: calls.append(uuid) or True,
+        )
+        fake_selectors["uuid"].return_value = [("U1", "/a.pdf")]
+        result = runner.invoke(main, ["dt", "index", "--uuid", "U1"])
+        assert result.exit_code == 0, result.output
+        assert calls == []
+        assert "semantically linked" not in result.output
+
+    def test_link_and_writeback_compose(
+        self, runner, fake_selectors, fake_dispatcher, monkeypatch,
+    ):
+        from nexus.cli import main
+
+        link_calls: list[str] = []
+        wb_calls: list[str] = []
+        monkeypatch.setattr(
+            "nexus.commands.dt._link_semantic_record",
+            lambda uuid: link_calls.append(uuid) or True,
+        )
+        monkeypatch.setattr(
+            "nexus.commands.dt._writeback_record",
+            lambda uuid: wb_calls.append(uuid) or True,
+        )
+        fake_selectors["uuid"].return_value = [("U1", "/a.pdf")]
+        result = runner.invoke(
+            main, ["dt", "index", "--uuid", "U1", "--link-semantic", "--writeback"],
+        )
+        assert result.exit_code == 0, result.output
+        assert link_calls == ["U1"] and wb_calls == ["U1"]
+        assert "semantically linked" in result.output
+        assert "written back to DT" in result.output

--- a/tests/test_commands_dt.py
+++ b/tests/test_commands_dt.py
@@ -1126,6 +1126,37 @@ class TestLinkSemantic:
         assert calls == []
         assert "semantically linked" not in result.output
 
+    def test_stamp_failed_record_skips_link_and_writeback(
+        self, runner, fake_selectors, monkeypatch,
+    ):
+        # A record that fails to stamp has no resolvable tumbler, so neither
+        # link nor write-back may run on it (the `continue` after stamp_failed).
+        from nexus.cli import main
+
+        link_calls: list[str] = []
+        wb_calls: list[str] = []
+        monkeypatch.setattr(
+            "nexus.commands.dt._index_record",
+            lambda uuid, path, *, collection, corpus, dry_run: uuid == "U-OK",
+        )
+        monkeypatch.setattr(
+            "nexus.commands.dt._link_semantic_record",
+            lambda uuid: link_calls.append(uuid) or True,
+        )
+        monkeypatch.setattr(
+            "nexus.commands.dt._writeback_record",
+            lambda uuid: wb_calls.append(uuid) or True,
+        )
+        fake_selectors["selection"].return_value = [("U-OK", "/a.pdf"), ("U-FAIL", "/b.pdf")]
+        result = runner.invoke(
+            main, ["dt", "index", "--selection", "--link-semantic", "--writeback"],
+        )
+        assert result.exit_code == 0, result.output
+        # Only the stamped record reached link + write-back.
+        assert link_calls == ["U-OK"]
+        assert wb_calls == ["U-OK"]
+        assert "1 DT-URI stamp-failed" in result.output
+
     def test_link_and_writeback_compose(
         self, runner, fake_selectors, fake_dispatcher, monkeypatch,
     ):

--- a/tests/test_commands_dt.py
+++ b/tests/test_commands_dt.py
@@ -1034,3 +1034,55 @@ class TestStampDtUriOnEntry:
             dry_run=True,
         )
         assert stamps == []
+
+
+# ── Layer F write-back (RDR-139 P1.7) ─────────────────────────────────────────
+
+
+class TestWriteback:
+    """``nx dt index --writeback`` stamps the nexus identity back onto DT.
+
+    The DT-side stamp itself is exercised by ``tests/test_dt_writeback.py``
+    against a fake DT client; here we pin the CLI wiring: the flag gates the
+    call, it fires once per successfully-stamped record, and the summary
+    reports the count.
+    """
+
+    def test_writeback_invoked_per_stamped_record(
+        self, runner, fake_selectors, fake_dispatcher, monkeypatch,
+    ):
+        from nexus.cli import main
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "nexus.commands.dt._writeback_record",
+            lambda uuid: calls.append(uuid) or True,
+        )
+        fake_selectors["uuid"].return_value = [("U1", "/a.pdf")]
+        result = runner.invoke(main, ["dt", "index", "--uuid", "U1", "--writeback"])
+        assert result.exit_code == 0, result.output
+        assert calls == ["U1"]
+        assert "written back to DT" in result.output
+
+    def test_no_writeback_flag_skips_call(
+        self, runner, fake_selectors, fake_dispatcher, monkeypatch,
+    ):
+        from nexus.cli import main
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "nexus.commands.dt._writeback_record",
+            lambda uuid: calls.append(uuid) or True,
+        )
+        fake_selectors["uuid"].return_value = [("U1", "/a.pdf")]
+        result = runner.invoke(main, ["dt", "index", "--uuid", "U1"])
+        assert result.exit_code == 0, result.output
+        assert calls == []
+        assert "written back" not in result.output
+
+    def test_writeback_help_documents_namespace(self, runner):
+        from nexus.cli import main
+
+        result = runner.invoke(main, ["dt", "index", "--help"])
+        assert result.exit_code == 0
+        assert "--writeback" in result.output

--- a/tests/test_dt_mcp_fallback.py
+++ b/tests/test_dt_mcp_fallback.py
@@ -56,6 +56,9 @@ class _UnavailableDT:
     def dt_annotation_text(self, *a, **k):  # pragma: no cover
         raise AssertionError("dt_annotation_text called despite available()=False")
 
+    def dt_extract_content(self, *a, **k):  # pragma: no cover
+        raise AssertionError("dt_extract_content called despite available()=False")
+
 
 @pytest.fixture
 def indexed(cat):

--- a/tests/test_dt_mcp_fallback.py
+++ b/tests/test_dt_mcp_fallback.py
@@ -19,6 +19,7 @@ import pytest
 
 from nexus.catalog.catalog import Catalog
 from nexus.catalog.dt_link_generator import generate_dt_links
+from nexus.dt_writeback import writeback_record
 
 
 @pytest.fixture
@@ -42,6 +43,15 @@ class _UnavailableDT:
 
     def dt_call(self, *a, **k):  # pragma: no cover
         raise AssertionError("dt_call called despite available()=False")
+
+    def dt_set_tags(self, *a, **k):  # pragma: no cover
+        raise AssertionError("dt_set_tags called despite available()=False")
+
+    def dt_set_annotation(self, *a, **k):  # pragma: no cover
+        raise AssertionError("dt_set_annotation called despite available()=False")
+
+    def dt_set_custom_metadata(self, *a, **k):  # pragma: no cover
+        raise AssertionError("dt_set_custom_metadata called despite available()=False")
 
 
 @pytest.fixture
@@ -91,6 +101,18 @@ class TestLayerBFallback:
         generate_dt_links(cat, this, "THIS", dt_client=_UnavailableDT())
 
 
-# Layer F fallback (no DT-side mutation, index/enrich unchanged, exit 0) is added
-# with P1.7 write-back (nexus-x70wg). Placed here intentionally so the Gap-0
-# contract lives in one suite — see module docstring.
+class TestLayerFFallback:
+    """Layer F: DT absent → no DT-side mutation; write-back is skipped, exit clean."""
+
+    def test_writeback_skipped_no_mutation_when_unavailable(self):
+        # _UnavailableDT raises if any write helper is reached; the available()
+        # gate must short-circuit before any DT write is attempted.
+        out = writeback_record("U", "1.2.3", dt_client=_UnavailableDT())
+        assert out == {"tags": False, "annotation": False, "metadata": False, "skipped": True}
+
+    def test_writeback_with_keywords_still_skips_when_unavailable(self):
+        out = writeback_record(
+            "U", "1.2.3", aspect_keywords=["TPC-C", "RAG"], dt_client=_UnavailableDT()
+        )
+        assert out["skipped"] is True
+        assert not any(out[k] for k in ("tags", "annotation", "metadata"))

--- a/tests/test_dt_mcp_fallback.py
+++ b/tests/test_dt_mcp_fallback.py
@@ -53,6 +53,9 @@ class _UnavailableDT:
     def dt_set_custom_metadata(self, *a, **k):  # pragma: no cover
         raise AssertionError("dt_set_custom_metadata called despite available()=False")
 
+    def dt_annotation_text(self, *a, **k):  # pragma: no cover
+        raise AssertionError("dt_annotation_text called despite available()=False")
+
 
 @pytest.fixture
 def indexed(cat):

--- a/tests/test_dt_writeback.py
+++ b/tests/test_dt_writeback.py
@@ -19,16 +19,21 @@ from nexus.dt_writeback import writeback_record
 
 class _FakeDT:
     def __init__(self, *, available=True, tag_ok=True, ann_ok=True, meta_ok=True,
-                 existing_annotation=""):
+                 existing_annotation="", content="some indexed content"):
         self._available = available
         self._tag_ok = tag_ok
         self._ann_ok = ann_ok
         self._meta_ok = meta_ok
         self._annotation = existing_annotation
+        self._content = content
         self.calls: list[tuple[str, tuple, dict]] = []
 
     def available(self, *, refresh=False):
         return self._available
+
+    def dt_extract_content(self, uuid):
+        self.calls.append(("extract", (uuid,), {}))
+        return self._content
 
     def dt_set_tags(self, uuid, tags, *, mode="add"):
         self.calls.append(("tags", (uuid, tuple(tags)), {"mode": mode}))
@@ -126,6 +131,22 @@ def test_writeback_metadata_failure_is_fail_soft():
     out = writeback_record("U", "1.2.3", dt_client=dt)
     assert out["metadata"] is False
     assert out["tags"] is True and out["annotation"] is True
+
+
+def test_writeback_skips_excluded_or_empty_record():
+    # Empty AI-extracted content = excluded (or genuinely empty) → skip, no writes.
+    dt = _FakeDT(content="")
+    out = writeback_record("U", "1.2.3", dt_client=dt)
+    assert out == {"tags": False, "annotation": False, "metadata": False, "skipped": True}
+    # Only the content probe ran; no write helper was reached.
+    assert {c[0] for c in dt.calls} == {"extract"}
+
+
+def test_writeback_proceeds_when_content_present():
+    dt = _FakeDT(content="real body text")
+    out = writeback_record("U", "1.2.3", dt_client=dt)
+    assert out["skipped"] is False
+    assert out["tags"] is True
 
 
 def test_writeback_empty_identity_skips():

--- a/tests/test_dt_writeback.py
+++ b/tests/test_dt_writeback.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""P1.7 contracts for DEVONthink Layer F write-back (RDR-139).
+
+Pins (fake DT client injected — no live DB):
+- --writeback present → nx-indexed / nx-tumbler / nx-kw tags stamped (add-mode),
+  annotation appended, custom metadata merged; the exact tag set is asserted.
+- nexus-owned namespace: every written tag is nx-* prefixed.
+- no-clobber modes (add/append/merge) are the modes actually passed.
+- idempotent: a second call passes the same args (DT add/merge/append dedup).
+- DT unavailable → skipped, zero writes (Gap 0).
+- excluded record (a write helper returns False) → that flag False, others
+  still attempt; never raises (clean error, not silent partial corruption).
+"""
+
+from __future__ import annotations
+
+from nexus.dt_writeback import writeback_record
+
+
+class _FakeDT:
+    def __init__(self, *, available=True, tag_ok=True, ann_ok=True, meta_ok=True):
+        self._available = available
+        self._tag_ok = tag_ok
+        self._ann_ok = ann_ok
+        self._meta_ok = meta_ok
+        self.calls: list[tuple[str, tuple, dict]] = []
+
+    def available(self, *, refresh=False):
+        return self._available
+
+    def dt_set_tags(self, uuid, tags, *, mode="add"):
+        self.calls.append(("tags", (uuid, tuple(tags)), {"mode": mode}))
+        return self._tag_ok
+
+    def dt_set_annotation(self, uuid, text, *, mode="append"):
+        self.calls.append(("annotation", (uuid, text), {"mode": mode}))
+        return self._ann_ok
+
+    def dt_set_custom_metadata(self, uuid, fields, *, mode="merge"):
+        self.calls.append(("metadata", (uuid, tuple(sorted(fields.items()))), {"mode": mode}))
+        return self._meta_ok
+
+
+def test_writeback_stamps_all_three_with_no_clobber_modes():
+    dt = _FakeDT()
+    out = writeback_record("U", "1.2.3", aspect_keywords=["TPC-C", "tpc-c", "RAG"], dt_client=dt)
+    assert out == {"tags": True, "annotation": True, "metadata": True, "skipped": False}
+
+    by_kind = {c[0]: c for c in dt.calls}
+    # Tag set: nx-indexed, nx-tumbler, deduped+lowercased nx-kw.
+    _, (uuid, tags), kw = by_kind["tags"]
+    assert uuid == "U"
+    assert kw["mode"] == "add"
+    assert set(tags) == {"nx-indexed", "nx-tumbler:1.2.3", "nx-kw:tpc-c", "nx-kw:rag"}
+    # Every tag is nexus-owned.
+    assert all(t.startswith("nx-") for t in tags)
+    # Annotation appended, metadata merged.
+    assert by_kind["annotation"][2]["mode"] == "append"
+    assert "1.2.3" in by_kind["annotation"][1][1]
+    assert by_kind["metadata"][2]["mode"] == "merge"
+
+
+def test_writeback_unavailable_makes_no_writes():
+    dt = _FakeDT(available=False)
+    out = writeback_record("U", "1.2.3", dt_client=dt)
+    assert out == {"tags": False, "annotation": False, "metadata": False, "skipped": True}
+    assert dt.calls == []
+
+
+def test_writeback_idempotent_args_on_rerun():
+    dt = _FakeDT()
+    writeback_record("U", "1.2.3", dt_client=dt)
+    first = list(dt.calls)
+    dt.calls.clear()
+    writeback_record("U", "1.2.3", dt_client=dt)
+    assert dt.calls == first  # same add/append/merge calls — DT dedups server-side
+
+
+def test_writeback_excluded_record_clean_partial_not_crash():
+    # An excluded record: the DT server rejects the tag write (helper returns
+    # False). The other writes still attempt; nothing raises.
+    dt = _FakeDT(tag_ok=False)
+    out = writeback_record("U", "1.2.3", dt_client=dt)
+    assert out["tags"] is False
+    assert out["skipped"] is False
+    assert {c[0] for c in dt.calls} == {"tags", "annotation", "metadata"}
+
+
+def test_writeback_empty_identity_skips():
+    dt = _FakeDT()
+    assert writeback_record("", "1.2.3", dt_client=dt)["skipped"] is True
+    assert writeback_record("U", "", dt_client=dt)["skipped"] is True
+    assert dt.calls == []

--- a/tests/test_dt_writeback.py
+++ b/tests/test_dt_writeback.py
@@ -18,11 +18,13 @@ from nexus.dt_writeback import writeback_record
 
 
 class _FakeDT:
-    def __init__(self, *, available=True, tag_ok=True, ann_ok=True, meta_ok=True):
+    def __init__(self, *, available=True, tag_ok=True, ann_ok=True, meta_ok=True,
+                 existing_annotation=""):
         self._available = available
         self._tag_ok = tag_ok
         self._ann_ok = ann_ok
         self._meta_ok = meta_ok
+        self._annotation = existing_annotation
         self.calls: list[tuple[str, tuple, dict]] = []
 
     def available(self, *, refresh=False):
@@ -32,8 +34,14 @@ class _FakeDT:
         self.calls.append(("tags", (uuid, tuple(tags)), {"mode": mode}))
         return self._tag_ok
 
+    def dt_annotation_text(self, uuid):
+        self.calls.append(("read_annotation", (uuid,), {}))
+        return self._annotation
+
     def dt_set_annotation(self, uuid, text, *, mode="append"):
         self.calls.append(("annotation", (uuid, text), {"mode": mode}))
+        if self._ann_ok:
+            self._annotation = (self._annotation + "\n" + text) if self._annotation else text
         return self._ann_ok
 
     def dt_set_custom_metadata(self, uuid, fields, *, mode="merge"):
@@ -58,6 +66,9 @@ def test_writeback_stamps_all_three_with_no_clobber_modes():
     assert by_kind["annotation"][2]["mode"] == "append"
     assert "1.2.3" in by_kind["annotation"][1][1]
     assert by_kind["metadata"][2]["mode"] == "merge"
+    # Metadata keys are nexus-owned (nx.* dotted form — DT forbids '-' in keys).
+    _, (_uuid, meta_items), _ = by_kind["metadata"]
+    assert all(k.startswith("nx.") for k, _v in meta_items)
 
 
 def test_writeback_unavailable_makes_no_writes():
@@ -67,13 +78,30 @@ def test_writeback_unavailable_makes_no_writes():
     assert dt.calls == []
 
 
-def test_writeback_idempotent_args_on_rerun():
+def test_writeback_annotation_idempotent_no_duplicate_append():
+    # First run appends the backlink; second run must NOT append again (the
+    # backlink is already present), so the user's annotation never accumulates
+    # duplicate "nexus: indexed as tumbler" lines on re-index.
     dt = _FakeDT()
-    writeback_record("U", "1.2.3", dt_client=dt)
-    first = list(dt.calls)
+    first = writeback_record("U", "1.2.3", dt_client=dt)
+    assert first["annotation"] is True
+    appends_first = [c for c in dt.calls if c[0] == "annotation"]
+    assert len(appends_first) == 1
+
     dt.calls.clear()
+    second = writeback_record("U", "1.2.3", dt_client=dt)
+    assert second["annotation"] is True  # idempotent success
+    appends_second = [c for c in dt.calls if c[0] == "annotation"]
+    assert appends_second == []  # NO second append — backlink already present
+    # The annotation body still contains exactly one backlink line.
+    assert dt._annotation.count("nexus: indexed as tumbler 1.2.3") == 1
+
+
+def test_writeback_preserves_existing_user_annotation():
+    dt = _FakeDT(existing_annotation="user's own note")
     writeback_record("U", "1.2.3", dt_client=dt)
-    assert dt.calls == first  # same add/append/merge calls — DT dedups server-side
+    assert "user's own note" in dt._annotation
+    assert "nexus: indexed as tumbler 1.2.3" in dt._annotation
 
 
 def test_writeback_excluded_record_clean_partial_not_crash():
@@ -83,7 +111,21 @@ def test_writeback_excluded_record_clean_partial_not_crash():
     out = writeback_record("U", "1.2.3", dt_client=dt)
     assert out["tags"] is False
     assert out["skipped"] is False
-    assert {c[0] for c in dt.calls} == {"tags", "annotation", "metadata"}
+    assert {c[0] for c in dt.calls} >= {"tags", "annotation", "metadata"}
+
+
+def test_writeback_annotation_failure_is_fail_soft():
+    dt = _FakeDT(ann_ok=False)
+    out = writeback_record("U", "1.2.3", dt_client=dt)
+    assert out["annotation"] is False
+    assert out["tags"] is True and out["metadata"] is True  # others still attempt
+
+
+def test_writeback_metadata_failure_is_fail_soft():
+    dt = _FakeDT(meta_ok=False)
+    out = writeback_record("U", "1.2.3", dt_client=dt)
+    assert out["metadata"] is False
+    assert out["tags"] is True and out["annotation"] is True
 
 
 def test_writeback_empty_identity_skips():

--- a/tests/test_dt_writeback.py
+++ b/tests/test_dt_writeback.py
@@ -66,9 +66,9 @@ def test_writeback_stamps_all_three_with_no_clobber_modes():
     assert by_kind["annotation"][2]["mode"] == "append"
     assert "1.2.3" in by_kind["annotation"][1][1]
     assert by_kind["metadata"][2]["mode"] == "merge"
-    # Metadata keys are nexus-owned (nx.* dotted form — DT forbids '-' in keys).
+    # Metadata keys are nexus-owned (nx-prefixed; DT strips separators in keys).
     _, (_uuid, meta_items), _ = by_kind["metadata"]
-    assert all(k.startswith("nx.") for k, _v in meta_items)
+    assert all(k.startswith("nx") for k, _v in meta_items)
 
 
 def test_writeback_unavailable_makes_no_writes():

--- a/tests/test_mcp_client_devonthink.py
+++ b/tests/test_mcp_client_devonthink.py
@@ -191,6 +191,24 @@ def test_dt_annotation_text_none_when_unreachable(monkeypatch) -> None:
     assert dt.dt_annotation_text("Q") is None
 
 
+def test_dt_extract_content_joins_sectioned_bare_array(monkeypatch) -> None:
+    # Structured docs (PDF/MD) return a bare section array; core wraps it as
+    # {"result": [...]}. dt_extract_content must join those, not return None.
+    # (Live finding — sectioned PDFs were returning None, wrongly tripping the
+    # Layer F exclusion guard so write-back skipped every multi-section paper.)
+    payload = {"result": [
+        {"link": "", "text": "section one", "page": 0},
+        {"link": "", "text": "section two", "page": 1},
+    ]}
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: payload)
+    assert dt.dt_extract_content("Q") == "section one\nsection two"
+
+
+def test_dt_extract_content_single_text_body(monkeypatch) -> None:
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: {"text": "short body"})
+    assert dt.dt_extract_content("Q") == "short body"
+
+
 def test_write_helpers_reject_empty_input(monkeypatch) -> None:
     # Empty tags/fields short-circuit without a call.
     monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: pytest.fail("should not call"))

--- a/tests/test_mcp_client_devonthink.py
+++ b/tests/test_mcp_client_devonthink.py
@@ -134,6 +134,30 @@ def test_write_helpers_true_on_success_and_pass_no_clobber_mode(monkeypatch) -> 
     assert by_tool["set_record_annotation"]["text"] == "see nx tumbler 1.2.3"
 
 
+def test_dt_annotation_text_two_hop(monkeypatch) -> None:
+    # get_record_annotation → annotation_uuid, then get_record_text → body.
+    def _fake(tool, args=None):
+        if tool == "get_record_annotation":
+            return {"annotation_uuid": "ANN"}
+        if tool == "get_record_text":
+            assert args == {"uuid": "ANN"}
+            return {"text": "existing body"}
+        raise AssertionError(f"unexpected tool {tool}")
+
+    monkeypatch.setattr(dt, "dt_call", _fake)
+    assert dt.dt_annotation_text("Q") == "existing body"
+
+
+def test_dt_annotation_text_none_when_no_annotation(monkeypatch) -> None:
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: {"annotation_uuid": None})
+    assert dt.dt_annotation_text("Q") is None
+
+
+def test_dt_annotation_text_none_when_unreachable(monkeypatch) -> None:
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: None)
+    assert dt.dt_annotation_text("Q") is None
+
+
 def test_write_helpers_reject_empty_input(monkeypatch) -> None:
     # Empty tags/fields short-circuit without a call.
     monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: pytest.fail("should not call"))

--- a/tests/test_mcp_client_devonthink.py
+++ b/tests/test_mcp_client_devonthink.py
@@ -134,6 +134,24 @@ def test_write_helpers_true_on_success_and_pass_no_clobber_mode(monkeypatch) -> 
     assert by_tool["set_record_annotation"]["text"] == "see nx tumbler 1.2.3"
 
 
+def test_dt_set_custom_metadata_false_when_all_dropped(monkeypatch) -> None:
+    # DT drops unknown (not pre-defined) fields; helper must report the no-op
+    # as False rather than a false success.
+    monkeypatch.setattr(
+        dt, "dt_call",
+        lambda tool, args=None: {"metadata": {}, "dropped_fields": ["nxtumbler", "nxindexed"]},
+    )
+    assert dt.dt_set_custom_metadata("Q", {"nxtumbler": "1.2.3", "nxindexed": "true"}) is False
+
+
+def test_dt_set_custom_metadata_true_on_partial_write(monkeypatch) -> None:
+    monkeypatch.setattr(
+        dt, "dt_call",
+        lambda tool, args=None: {"metadata": {"nxtumbler": "1.2.3"}, "dropped_fields": ["nxindexed"]},
+    )
+    assert dt.dt_set_custom_metadata("Q", {"nxtumbler": "1.2.3", "nxindexed": "true"}) is True
+
+
 def test_dt_annotation_text_two_hop(monkeypatch) -> None:
     # get_record_annotation → annotation_uuid, then get_record_text → body.
     def _fake(tool, args=None):

--- a/tests/test_mcp_client_devonthink.py
+++ b/tests/test_mcp_client_devonthink.py
@@ -92,6 +92,21 @@ def test_dt_find_similar_maps_and_applies_floor(monkeypatch) -> None:
     assert out == [{"uuid": "A", "score": 0.9, "name": "alpha"}]
 
 
+def test_dt_find_similar_parses_bare_array_shape(monkeypatch) -> None:
+    # Single-record mode returns a BARE neighbour array; core wraps a bare JSON
+    # array as {"result": [...]}. dt_find_similar must read that shape, not only
+    # {"results": [...]}. (Live MVV finding 2026-05-30 — the spike's assumed
+    # {count, results} shape did not match single-uuid mode; the mismatch made
+    # Layer B silently emit zero edges for every record.)
+    payload = {"result": [
+        {"uuid": "A", "score": 0.72, "name": "alpha"},
+        {"uuid": "B", "score": 0.70, "name": "beta"},
+    ]}
+    monkeypatch.setattr(dt, "dt_call", lambda tool, args=None: payload)
+    out = dt.dt_find_similar("Q", limit=10, floor=0.5)
+    assert [n["uuid"] for n in out] == ["A", "B"]
+
+
 def test_dt_record_links_merges_and_dedups(monkeypatch) -> None:
     payload = {
         "incoming": [{"uuid": "A", "name": "a"}],


### PR DESCRIPTION
## RDR-139 Phase 1 — Layer F DEVONthink write-back (P1.7) + Gap-0 Layer F fallback (P1.8)

Builds on the merged read-only substrate (#1024). Adds the bidirectional write-back layer so the knowledge graph is navigable from inside DEVONthink.

### What landed
- **`src/nexus/dt_writeback.py`** — `writeback_record` stamps the nexus identity onto a DT record after index: `nx-indexed` / `nx-tumbler:<t>` / `nx-kw:*` tags (add-mode), a tumbler-backlink annotation (append, **idempotent** — guarded read-before-append so re-index never duplicates), and `nx.tumbler` / `nx.indexed` custom metadata (merge). Authoritative-source contract: nexus-owned namespace only (`nx-*` tags, `nx.*` metadata — DT forbids `-` in metadata keys), never edits user content, honours Exclude-from-AI&MCP (fail-soft per write), opt-in.
- **`nx dt index --writeback`** (default off) — after a successful index+stamp, resolves the tumbler via `Catalog.by_source_uri` and calls `writeback_record`; summary reports the count.
- **Gap-0 Layer F fallback** — DT absent → write-back skipped, zero DT mutation, exit clean (`_UnavailableDT` raises if any write helper is reached).

### Verification
- **CA5 part (a) no-clobber: verified live** (T2 `nexus_rdr/139-research-CA5`) — `set_record_tags` add-mode and `set_record_annotation` append-mode both preserve user data.
- **CA5 part (b)** (exclusion-flag clean error) is pending a manually-flagged record (the flag isn't settable via MCP); the exclusion path is fail-soft by construction. Tracked on `nexus-ymcrt`; the P1.7 bead stays open behind it.

### Review
Stacked reviewers ran clean of Criticals. Both Significant findings fixed in `0fdd59e2`: annotation-append idempotency guard (was accumulating duplicate backlinks) and the `nx.*` metadata namespace (was breaching the `nx-*` invariant). M3 fail-soft test variants added.

### Deferred (tracked)
- `nexus-slq1g` — `nx-kw:*` aspect-keyword stamping (RDR-089 aspects are queued post-index; `writeback_record` supports keywords, CLI passes none until a post-extraction re-stamp pass exists).

### Beads
Refs nexus-x70wg (open, gated on CA5), nexus-ymcrt, nexus-mxcsm, nexus-slq1g.
