### PR TITLE
feat(rdr-139): Phase 2 — Layer C DT-CrossRef enrich + Layer D content extraction

### DIFF
--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -337,7 +337,11 @@ def _index_dt_content_record(
             extraction_source=extraction_source,
         )
         if not count:
-            _log.warning("dt_content_no_chunks", uuid=uuid)
+            # We had non-empty text above, so a 0-chunk return is the
+            # index_markdown staleness skip: this record's content is already
+            # indexed and unchanged. That is a benign idempotent no-op (the
+            # catalog row is not duplicated), not a failure — log at debug.
+            _log.debug("dt_content_unchanged", uuid=uuid)
             return False
         return _stamp_dt_uri_on_entry(cache_path, uuid)
     except (RuntimeError, ImportError, OSError) as exc:

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -263,6 +263,84 @@ def _writeback_record(uuid: str) -> bool:
         cat._db.close()
 
 
+#: RDR-139 Layer D extraction-source provenance values for DT-sourced text.
+_DT_EXTRACTION_SOURCES: frozenset[str] = frozenset(
+    {"dt_content", "dt_ocr", "dt_transcribe"}
+)
+
+
+def _index_dt_content_record(
+    uuid: str,
+    *,
+    collection: str,
+    corpus: str,
+    extraction_source: str = "dt_content",
+) -> bool:
+    """RDR-139 Layer D: index a non-file-backed DT record from DT-extracted
+    text (rather than an on-disk file).
+
+    Sources the AI-optimised body via :func:`devonthink.dt_extract_content`,
+    writes it through the existing Markdown chunking pipeline with every chunk
+    stamped ``extraction_source`` (``dt_content`` by default), and stamps the
+    DT identity (``x-devonthink-item://<uuid>``) onto the catalog entry so the
+    record is addressable even though no real file backs it.
+
+    Fail-soft: empty/unavailable DT text -> ``False`` (the caller skips the
+    record), never an exception. Returns ``True`` only when chunks were written
+    AND the DT identity was stamped.
+    """
+    import json  # noqa: PLC0415
+    import tempfile  # noqa: PLC0415
+
+    from nexus.doc_indexer import index_markdown  # noqa: PLC0415
+    from nexus.mcp_client import devonthink as _dt  # noqa: PLC0415
+
+    if extraction_source not in _DT_EXTRACTION_SOURCES:
+        raise ValueError(
+            f"extraction_source {extraction_source!r} not a DT source "
+            f"{sorted(_DT_EXTRACTION_SOURCES)}"
+        )
+
+    text = _dt.dt_extract_content(uuid)
+    if not text or not text.strip():
+        _log.warning("dt_content_empty", uuid=uuid, extraction_source=extraction_source)
+        return False
+
+    name = _dt.dt_record_name(uuid) or uuid
+    # JSON-quote the title so a name with a colon / quote can't break the
+    # strict frontmatter parse. The body follows verbatim.
+    front = f"---\ntitle: {json.dumps(name)}\n---\n\n{text}"
+
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".md", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write(front)
+            tmp_path = Path(fh.name)
+        count = index_markdown(
+            tmp_path,
+            corpus=corpus,
+            collection_name=collection,
+            extraction_source=extraction_source,
+        )
+        if not count:
+            _log.warning("dt_content_no_chunks", uuid=uuid)
+            return False
+        return _stamp_dt_uri_on_entry(tmp_path, uuid)
+    except (RuntimeError, ImportError, OSError) as exc:
+        _log.error(
+            "dt_content_index_failed",
+            uuid=uuid,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return False
+    finally:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+
+
 @click.group("dt")
 def dt() -> None:
     """DEVONthink integration verbs (macOS only).
@@ -380,6 +458,20 @@ def dt() -> None:
         "S2/OpenAlex value. DT unavailable -> primary-only. Opt-in, default off."
     ),
 )
+@click.option(
+    "--dt-content",
+    "dt_content",
+    is_flag=True,
+    default=False,
+    help=(
+        "Index non-file-backed records (web archives, bookmarks, formatted "
+        "notes — anything without a .pdf/.md file) from DEVONthink's "
+        "AI-extracted text instead of skipping them (RDR-139 Layer D). Every "
+        "chunk is stamped extraction_source=dt_content; file-backed records "
+        "still index from their file (provenance absent == file). DT "
+        "unavailable -> records skipped exactly as today. Opt-in, default off."
+    ),
+)
 def index_cmd(
     use_selection: bool,
     tag: str | None,
@@ -393,6 +485,7 @@ def index_cmd(
     link_semantic: bool,
     writeback: bool,
     enrich: bool,
+    dt_content: bool,
 ) -> None:
     """Index DEVONthink records into Nexus.
 
@@ -444,11 +537,40 @@ def index_cmd(
     stamp_failed = 0
     written_back = 0
     linked = 0
+    content_extracted = 0
     touched_collections: set[str] = set()
     failed: list[tuple[str, str, str]] = []  # (uuid, path, error)
+
+    # RDR-139 Layer D: only probe DT availability once, and only when the
+    # opt-in flag is set. Flag off -> the unsupported-extension skip path is
+    # byte-identical to today (Gap 0).
+    dt_content_active = False
+    if dt_content:
+        from nexus.mcp_client import devonthink as _dt  # noqa: PLC0415
+
+        dt_content_active = _dt.available()
+
     for uuid, path in records:
         ext = Path(path).suffix.lower()
         if ext not in _SUPPORTED_EXTS:
+            # RDR-139 Layer D: non-file-backed record. With --dt-content and a
+            # reachable DT, index it from DT-extracted text; otherwise skip
+            # exactly as before.
+            if dt_content_active:
+                dt_collection = _resolve_dt_collection(collection, corpus, ext)
+                if _index_dt_content_record(
+                    uuid, collection=dt_collection, corpus=corpus,
+                ):
+                    content_extracted += 1
+                    indexed += 1
+                    touched_collections.add(dt_collection)
+                    if link_semantic and _link_semantic_record(uuid):
+                        linked += 1
+                    if writeback and _writeback_record(uuid):
+                        written_back += 1
+                else:
+                    skipped += 1
+                continue
             _log.warning(
                 "dt_skip_unsupported_extension",
                 uuid=uuid,
@@ -505,6 +627,8 @@ def index_cmd(
             run_bib_enrichment(coll, source="dt")
 
     summary = f"Indexed {indexed} record(s) ({skipped} skipped"
+    if content_extracted:
+        summary += f", {content_extracted} from DT content"
     if link_semantic:
         summary += f", {linked} semantically linked"
     if writeback:

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -264,6 +264,10 @@ def _writeback_record(uuid: str) -> bool:
 
 
 #: RDR-139 Layer D extraction-source provenance values for DT-sourced text.
+#: Only ``dt_content`` (extract_record_content) is routed today; ``dt_ocr``
+#: (ocr_record, scanned PDFs/images) and ``dt_transcribe`` (transcribe_record,
+#: A/V) are enum-ready but unrouted — deferred to nexus-39b0f, surfaced at
+#: Phase 2 close (substantive-critic), not silent scope reduction.
 _DT_EXTRACTION_SOURCES: frozenset[str] = frozenset(
     {"dt_content", "dt_ocr", "dt_transcribe"}
 )
@@ -288,10 +292,20 @@ def _index_dt_content_record(
     Fail-soft: empty/unavailable DT text -> ``False`` (the caller skips the
     record), never an exception. Returns ``True`` only when chunks were written
     AND the DT identity was stamped.
+
+    The extracted text is cached at a STABLE per-UUID path
+    (``<catalog>/.dt-content/<uuid>.md``) rather than a throwaway temp file
+    (code-review HIGH-1). A throwaway path breaks re-index idempotency — the
+    catalog dedups by ``file_path``, so a fresh random name each run would
+    accumulate a duplicate entry per re-index and leave the row's
+    ``file_path`` pointing at a deleted file (a ghost path). The stable path
+    makes the catalog ``by_file_path`` lookup hit on re-index and keeps the
+    ``file_path`` column resolvable; the DT identity (``source_uri``) is still
+    the canonical reference.
     """
     import json  # noqa: PLC0415
-    import tempfile  # noqa: PLC0415
 
+    from nexus.config import catalog_path  # noqa: PLC0415
     from nexus.doc_indexer import index_markdown  # noqa: PLC0415
     from nexus.mcp_client import devonthink as _dt  # noqa: PLC0415
 
@@ -311,15 +325,13 @@ def _index_dt_content_record(
     # strict frontmatter parse. The body follows verbatim.
     front = f"---\ntitle: {json.dumps(name)}\n---\n\n{text}"
 
-    tmp_path: Path | None = None
+    cache_dir = catalog_path() / ".dt-content"
+    cache_path = cache_dir / f"{uuid}.md"
     try:
-        with tempfile.NamedTemporaryFile(
-            "w", suffix=".md", delete=False, encoding="utf-8"
-        ) as fh:
-            fh.write(front)
-            tmp_path = Path(fh.name)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(front, encoding="utf-8")
         count = index_markdown(
-            tmp_path,
+            cache_path,
             corpus=corpus,
             collection_name=collection,
             extraction_source=extraction_source,
@@ -327,7 +339,7 @@ def _index_dt_content_record(
         if not count:
             _log.warning("dt_content_no_chunks", uuid=uuid)
             return False
-        return _stamp_dt_uri_on_entry(tmp_path, uuid)
+        return _stamp_dt_uri_on_entry(cache_path, uuid)
     except (RuntimeError, ImportError, OSError) as exc:
         _log.error(
             "dt_content_index_failed",
@@ -336,9 +348,6 @@ def _index_dt_content_record(
             error_type=type(exc).__name__,
         )
         return False
-    finally:
-        if tmp_path is not None:
-            tmp_path.unlink(missing_ok=True)
 
 
 @click.group("dt")

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -367,6 +367,19 @@ def dt() -> None:
         "default off."
     ),
 )
+@click.option(
+    "--enrich",
+    "enrich",
+    is_flag=True,
+    default=False,
+    help=(
+        "After indexing, run a DT-CrossRef bibliographic gap-fill pass over "
+        "each touched collection (RDR-139 Layer C): the 'auto' primary "
+        "backend, then DEVONthink's CrossRef resolver fills only still-empty "
+        "bib_* fields. Strictly lowest-precedence; never overwrites an "
+        "S2/OpenAlex value. DT unavailable -> primary-only. Opt-in, default off."
+    ),
+)
 def index_cmd(
     use_selection: bool,
     tag: str | None,
@@ -379,6 +392,7 @@ def index_cmd(
     dry_run: bool,
     link_semantic: bool,
     writeback: bool,
+    enrich: bool,
 ) -> None:
     """Index DEVONthink records into Nexus.
 
@@ -430,6 +444,7 @@ def index_cmd(
     stamp_failed = 0
     written_back = 0
     linked = 0
+    touched_collections: set[str] = set()
     failed: list[tuple[str, str, str]] = []  # (uuid, path, error)
     for uuid, path in records:
         ext = Path(path).suffix.lower()
@@ -470,6 +485,7 @@ def index_cmd(
             failed.append((uuid, path, f"{type(exc).__name__}: {exc}"))
             continue
         indexed += 1
+        touched_collections.add(resolved_collection)
         if not stamped:
             stamp_failed += 1
             continue
@@ -477,6 +493,17 @@ def index_cmd(
             linked += 1
         if writeback and _writeback_record(uuid):
             written_back += 1
+
+    # RDR-139 Layer C: gap-fill bibliographic metadata over the collections we
+    # just wrote to. Runs once per distinct collection (title-group oriented),
+    # after all records land so a multi-record paper enriches as one group.
+    if enrich and touched_collections:
+        from nexus.commands.enrich import run_bib_enrichment
+
+        for coll in sorted(touched_collections):
+            click.echo(f"\nEnriching bibliographic metadata: {coll}")
+            run_bib_enrichment(coll, source="dt")
+
     summary = f"Indexed {indexed} record(s) ({skipped} skipped"
     if link_semantic:
         summary += f", {linked} semantically linked"

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -138,7 +138,7 @@ def enrich() -> None:
 )
 @click.option(
     "--source",
-    type=click.Choice(["auto", "s2", "openalex"], case_sensitive=False),
+    type=click.Choice(["auto", "s2", "openalex", "dt"], case_sensitive=False),
     default="auto",
     show_default=True,
     help=(
@@ -147,7 +147,11 @@ def enrich() -> None:
         "academic email required for key issuance). ``openalex`` "
         "queries OpenAlex (no key; set OPENALEX_MAILTO for the polite "
         "pool). ``auto`` picks ``s2`` when S2_API_KEY is set, else "
-        "``openalex``."
+        "``openalex``. ``dt`` (RDR-139 Layer C) runs the ``auto`` "
+        "primary backend and then gap-fills any still-empty ``bib_*`` "
+        "field from DEVONthink's CrossRef resolver — strictly "
+        "lowest-precedence, never overwriting an S2/OpenAlex value. "
+        "When DEVONthink is unavailable it degrades to ``auto`` exactly."
     ),
 )
 def enrich_bib(
@@ -165,11 +169,35 @@ def enrich_bib(
     Already-enriched chunks (the backend's ID field is non-empty) are
     skipped — the command is idempotent per backend.
     """
+    run_bib_enrichment(collection, delay=delay, limit=limit, source=source)
+
+
+def run_bib_enrichment(
+    collection: str, *, delay: float = 0.5, limit: int = 0, source: str = "auto",
+) -> None:
+    """Core of ``nx enrich bib``; also invoked by ``nx dt index --enrich``
+    (RDR-139 Layer C) to run a DT-CrossRef gap-fill pass over a freshly
+    indexed collection. ``source="dt"`` enables the gap-fill layer."""
     from nexus.db import make_t3
     from nexus.retry import _chroma_with_retry
 
-    backend, bib_enrich, id_field = _resolve_bib_backend(source)
-    click.echo(f"Backend: {backend} (id field: {id_field})")
+    # RDR-139 Layer C: ``--source dt`` is the ``auto`` primary backend plus a
+    # lowest-precedence DT-CrossRef gap-fill pass. Resolve the primary first.
+    dt_gapfill = source.lower() == "dt"
+    backend, bib_enrich, id_field = _resolve_bib_backend(
+        "auto" if dt_gapfill else source
+    )
+    dt_available = False
+    if dt_gapfill:
+        from nexus.mcp_client import devonthink as _dt
+
+        dt_available = _dt.available()
+        click.echo(
+            f"Backend: {backend} (id field: {id_field}) "
+            + ("+ DT-CrossRef gap-fill" if dt_available else "(DT unavailable; primary only)")
+        )
+    else:
+        click.echo(f"Backend: {backend} (id field: {id_field})")
 
     db = make_t3()
     col = db.get_or_create_collection(collection)
@@ -232,14 +260,37 @@ def enrich_bib(
         if i > 0:
             time.sleep(delay)
 
+        title_source_paths = sorted(title_to_source_paths.get(title, set()))
+        # Extract the record's DOI/arXiv identifiers once, up front, when
+        # either the OpenAlex primary path or the DT-CrossRef gap-fill will
+        # need them. Sharing the scan keeps the chunk read single-pass.
+        ids = None
+        if backend == "openalex" or dt_available:
+            ids = _extract_identifiers_for_title(
+                chunk_ids=chunk_ids, source_paths=title_source_paths, col=col,
+            )
+
         bib = _resolve_bib_for_title(
             title=title,
             chunk_ids=chunk_ids,
-            source_paths=sorted(title_to_source_paths.get(title, set())),
+            source_paths=title_source_paths,
             col=col,
             backend=backend,
             bib_enrich=bib_enrich,
+            ids=ids,
         )
+        # RDR-139 Layer C: gap-fill still-empty bib_* fields from DT-CrossRef.
+        # DT is strictly lowest-precedence — it fills only fields the primary
+        # backend left empty/zero and never overwrites a set value.
+        if dt_available and (
+            not bib
+            or not all(bib.get(k) for k in ("year", "venue", "authors"))
+        ):
+            doi = (ids or {}).get("doi") or ""
+            if doi:
+                dt_bib = _dt_crossref_bib(doi)
+                if dt_bib:
+                    bib = _merge_bib_gapfill(bib, dt_bib)
         if bib.get("_resolved_via") in ("doi", "arxiv"):
             by_id_count += 1
             bib = {k: v for k, v in bib.items() if k != "_resolved_via"}
@@ -338,48 +389,25 @@ def enrich_bib(
             _log.debug("auto_citation_links_failed", exc_info=True)
 
 
-def _resolve_bib_for_title(
-    *,
-    title: str,
-    chunk_ids: list,
-    source_paths: list[str],
-    col,
-    backend: str,
-    bib_enrich,
+def _extract_identifiers_for_title(
+    *, chunk_ids: list, source_paths: list[str], col,
 ) -> dict:
-    """nexus-sbzr: DOI/arXiv-aware lookup with title fallback.
+    """Scan a title group's chunk text + filename for a DOI / arXiv ID.
 
-    Tries identifiers in order:
-      1. DOI extracted from first chunk's body text -> openalex by-doi
-      2. arXiv ID from filename or first chunk text -> openalex by-arxiv
-      3. Title search at the backend (current behavior)
+    Returns the ``extract_identifiers`` dict (``{"doi": ..., "arxiv": ...}``).
+    Shared by the OpenAlex direct-lookup path and the RDR-139 Layer C
+    DT-CrossRef gap-fill so the chunk scan happens at most once per title.
 
-    Returns the bib dict with a synthetic ``_resolved_via`` key
-    indicating which path produced the result (caller strips before
-    storage). Empty dict on miss across all three paths.
-
-    DOI/arXiv lookups are OpenAlex-only today; the S2 backend skips
-    straight to title search. If S2 ever adds direct-DOI lookup we
-    can extend the dispatcher.
+    Scans ALL chunks: Docling's reading-order extraction can put the page-1
+    DOI text into chunks 0-4 OR much deeper depending on column layout,
+    abstract length, and figure placement (live evidence on knowledge__delos:
+    9/15 papers have an extractable DOI somewhere in full text but only 2/15
+    in the first 5 chunks). Concatenating one title group is cheap — ChromaDB
+    reads are free, the regex is bounded, the direct lookup is unambiguous.
     """
-    if backend != "openalex":
-        bib = bib_enrich(title)
-        if bib:
-            bib["_resolved_via"] = "title"
-        return bib or {}
-
-    from nexus.bib_enricher_openalex import enrich_by_arxiv_id, enrich_by_doi
     from nexus.bib_extractor import extract_identifiers
     from nexus.retry import _chroma_with_retry
 
-    # Scan ALL chunks for DOI/arXiv ID. Docling's reading-order
-    # extraction can put the page-1 DOI text into chunks 0-4 OR much
-    # deeper, depending on column layout, abstract length, and figure
-    # placement (live evidence on knowledge__delos: 9/15 papers have
-    # an extractable DOI somewhere in their full text but only 2/15
-    # have it in the first 5 chunks). Concatenating all chunks of one
-    # title group is cheap — ChromaDB reads are free, the regex is
-    # bounded, and the OpenAlex direct lookup is unambiguous.
     body_text = ""
     filename = ""
     if chunk_ids:
@@ -403,13 +431,100 @@ def _resolve_bib_for_title(
                             break
             body_text = "\n".join(collected_docs)
         except Exception as exc:
-            _log.debug("enrich_chunk_scan_failed", title=title, error=str(exc))
+            _log.debug("enrich_chunk_scan_failed", error=str(exc))
 
     # Filename fallback when chunk metadata didn't carry source_path.
     if not filename and source_paths:
         filename = source_paths[0]
 
-    ids = extract_identifiers(filename=filename, body_text=body_text)
+    return extract_identifiers(filename=filename, body_text=body_text)
+
+
+def _dt_crossref_bib(doi: str) -> dict:
+    """RDR-139 Layer C: resolve ``doi`` to a nexus bib dict via DEVONthink's
+    CrossRef resolver, or ``{}`` when DT misses / is unavailable.
+
+    Maps the live ``resolve_doi_metadata`` shape (a flat dict; ``year`` is a
+    string, ``authors`` a list) onto the same keys the S2/OpenAlex enrichers
+    emit. CrossRef carries no citation count, so ``citation_count`` is 0 — a
+    permanent gap DT never fills.
+    """
+    if not doi:
+        return {}
+    from nexus.mcp_client import devonthink as _dt
+
+    raw = _dt.dt_resolve_doi(doi)
+    if not raw:
+        return {}
+    year_raw = raw.get("year")
+    try:
+        year = int(str(year_raw)) if year_raw else 0
+    except (TypeError, ValueError):
+        year = 0
+    authors = raw.get("authors")
+    if isinstance(authors, list):
+        authors_str = ", ".join(a for a in authors[:5] if isinstance(a, str))
+    else:
+        authors_str = str(authors or "")
+    return {
+        "year": year,
+        "venue": raw.get("journal", "") or "",
+        "authors": authors_str,
+        "citation_count": 0,
+        "doi": raw.get("doi", "") or doi,
+    }
+
+
+def _merge_bib_gapfill(primary: dict, supplement: dict) -> dict:
+    """Per-field gap-fill: copy a ``supplement`` value into ``primary`` only
+    where ``primary`` left the field empty/zero/absent, and never overwrite a
+    set value (RDR-139 Layer C precedence guard). Falsy supplement values are
+    never inserted. The guard is per-field, not call-ordering."""
+    merged = dict(primary)
+    for k, v in supplement.items():
+        if v and not merged.get(k):
+            merged[k] = v
+    return merged
+
+
+def _resolve_bib_for_title(
+    *,
+    title: str,
+    chunk_ids: list,
+    source_paths: list[str],
+    col,
+    backend: str,
+    bib_enrich,
+    ids: dict | None = None,
+) -> dict:
+    """nexus-sbzr: DOI/arXiv-aware lookup with title fallback.
+
+    Tries identifiers in order:
+      1. DOI extracted from first chunk's body text -> openalex by-doi
+      2. arXiv ID from filename or first chunk text -> openalex by-arxiv
+      3. Title search at the backend (current behavior)
+
+    Returns the bib dict with a synthetic ``_resolved_via`` key
+    indicating which path produced the result (caller strips before
+    storage). Empty dict on miss across all three paths.
+
+    ``ids`` may be supplied by the caller (the enrich loop pre-extracts them
+    when both the primary path and the Layer C gap-fill need them); when
+    ``None`` they are scanned here. DOI/arXiv lookups are OpenAlex-only today;
+    the S2 backend skips straight to title search.
+    """
+    if backend != "openalex":
+        bib = bib_enrich(title)
+        if bib:
+            bib["_resolved_via"] = "title"
+        return bib or {}
+
+    from nexus.bib_enricher_openalex import enrich_by_arxiv_id, enrich_by_doi
+
+    if ids is None:
+        ids = _extract_identifiers_for_title(
+            chunk_ids=chunk_ids, source_paths=source_paths, col=col,
+        )
 
     if ids["doi"]:
         # nexus-yy1m: pass our title so the OpenAlex backend can reject

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -281,7 +281,10 @@ def run_bib_enrichment(
         )
         # RDR-139 Layer C: gap-fill still-empty bib_* fields from DT-CrossRef.
         # DT is strictly lowest-precedence — it fills only fields the primary
-        # backend left empty/zero and never overwrites a set value.
+        # backend left empty/zero and never overwrites a set value. The actual
+        # DT round-trip is DOI-gated below (``if doi``), so a partial-S2 record
+        # with no extractable DOI triggers no DT call — only the cheap, already
+        # -needed identifier scan runs.
         if dt_available and (
             not bib
             or not all(bib.get(k) for k in ("year", "venue", "authors"))
@@ -440,6 +443,18 @@ def _extract_identifiers_for_title(
     return extract_identifiers(filename=filename, body_text=body_text)
 
 
+def _crossref_author_str(a: object) -> str:
+    """Coerce one CrossRef author entry to a display string. Accepts a plain
+    string (live DT shape) or a ``{"given","family"}`` dict (CrossRef native)."""
+    if isinstance(a, str):
+        return a.strip()
+    if isinstance(a, dict):
+        return " ".join(
+            p for p in (str(a.get("given", "")).strip(), str(a.get("family", "")).strip()) if p
+        )
+    return ""
+
+
 def _dt_crossref_bib(doi: str) -> dict:
     """RDR-139 Layer C: resolve ``doi`` to a nexus bib dict via DEVONthink's
     CrossRef resolver, or ``{}`` when DT misses / is unavailable.
@@ -449,6 +464,10 @@ def _dt_crossref_bib(doi: str) -> dict:
     emit. CrossRef carries no citation count, so ``citation_count`` is 0 — a
     permanent gap DT never fills.
     """
+    # nexus-fqsm5 (deferred, surfaced at Phase 2 close): RDR §Approach Layer C
+    # also names search_crossref (title fallback for DOI-less records) and
+    # resolve_google_books_metadata (books). Only the DOI path ships here; the
+    # title/books fallbacks are tracked, not silently dropped.
     if not doi:
         return {}
     from nexus.mcp_client import devonthink as _dt
@@ -463,7 +482,12 @@ def _dt_crossref_bib(doi: str) -> dict:
         year = 0
     authors = raw.get("authors")
     if isinstance(authors, list):
-        authors_str = ", ".join(a for a in authors[:5] if isinstance(a, str))
+        # Live DT returns author strings, but CrossRef's native shape is
+        # ``[{"given","family"}]``; handle both so a dict form doesn't
+        # silently collapse to an empty author list.
+        authors_str = ", ".join(
+            s for s in (_crossref_author_str(a) for a in authors[:5]) if s
+        )
     else:
         authors_str = str(authors or "")
     return {

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -1018,6 +1018,7 @@ def _markdown_chunks(
     base_path: Path | None = None,
     git_meta: dict | None = None,
     doc_id: str = "",
+    extraction_source: str = "file",
 ) -> list[tuple[str, str, dict]]:
     """Chunk a Markdown file and return (id, text, metadata) tuples.
 
@@ -1086,6 +1087,7 @@ def _markdown_chunks(
             section_type=chunk.metadata.get("section_type", ""),
             tags="markdown",
             category="prose",
+            extraction_source=extraction_source,
         )
         prepared.append((chunk_id, chunk.text, meta))
     return prepared
@@ -1525,6 +1527,7 @@ def index_markdown(
     content_type: str = "prose",
     base_path: Path | None = None,
     hooks: "HookRegistry | None" = None,
+    extraction_source: str = "file",
 ) -> int | dict:
     """Index *md_path* into a T3 collection.
 
@@ -1584,7 +1587,10 @@ def index_markdown(
         _markdown_chunks,
         base_path=base_path,
         doc_id=doc_id,
-    ) if base_path else partial(_markdown_chunks, doc_id=doc_id)
+        extraction_source=extraction_source,
+    ) if base_path else partial(
+        _markdown_chunks, doc_id=doc_id, extraction_source=extraction_source,
+    )
     source_key = make_relative(md_path, base_path) if base_path else None
     raw = _index_document(
         md_path, corpus, chunk_fn, t3=t3,

--- a/src/nexus/mcp_client/devonthink.py
+++ b/src/nexus/mcp_client/devonthink.py
@@ -197,6 +197,19 @@ def dt_extract_content(uuid: str) -> str | None:
     return None
 
 
+def dt_record_name(uuid: str) -> str:
+    """Display name of a record, or ``""`` (Layer D title source).
+
+    Used to give a non-file-backed record's DT-extracted text a human title
+    for ``derive_title`` / search. Fail-soft: empty string when unavailable.
+    """
+    result = dt_call("get_record_properties", {"uuid": uuid})
+    if not result:
+        return ""
+    name = result.get("name")
+    return name if isinstance(name, str) else ""
+
+
 def dt_set_tags(uuid: str, tags: list[str], *, mode: str = "add") -> bool:
     """Write tags onto a record (default additive). ``True`` on success (Layer F)."""
     if not tags:

--- a/src/nexus/metadata_schema.py
+++ b/src/nexus/metadata_schema.py
@@ -105,6 +105,12 @@ ALLOWED_TOP_LEVEL: frozenset[str] = frozenset({
     # provenance JSON blob): zero non-self-referential readers in
     # src/. Catalog Document carries source git provenance at the
     # document level.
+    # Provenance (1) — RDR-139 Layer D. How the chunk's text was sourced:
+    # ``file`` (on-disk file, the default) | ``dt_content`` | ``dt_ocr`` |
+    # ``dt_transcribe`` (DEVONthink-extracted, for non-file-backed records).
+    # ``normalize`` drops the ``file`` default (absent == file) so only
+    # DT-sourced chunks spend the extra key — file chunks stay under the cap.
+    "extraction_source",
 })
 
 #: Allowed content_type values. Replaces the old overlapping pair
@@ -201,6 +207,13 @@ def normalize(raw: dict[str, Any], *, content_type: str) -> dict[str, Any]:
         for field in _BIB_FIELDS:
             normalised.pop(field, None)
 
+    # Step 2c: drop the RDR-139 Layer D provenance key when it carries the
+    # ``file`` default (or is empty). Absent == file. Only DT-sourced chunks
+    # (``dt_content`` / ``dt_ocr`` / ``dt_transcribe``) keep the key, so the
+    # common file-backed chunk stays one key under the cap.
+    if normalised.get("extraction_source", "file") in ("", "file"):
+        normalised.pop("extraction_source", None)
+
     # Step 3: stamp content_type.
     normalised["content_type"] = content_type
 
@@ -289,6 +302,8 @@ def make_chunk_metadata(
     frecency_score: float = 0.0,
     source_agent: str = "nexus-indexer",
     session_id: str = "",
+    # Provenance — RDR-139 Layer D. ``file`` default is dropped by normalize.
+    extraction_source: str = "file",
 ) -> dict[str, Any]:
     """Build a complete chunk metadata dict and route through
     :func:`normalize` so it's safe to write directly to T3.
@@ -326,6 +341,7 @@ def make_chunk_metadata(
         "frecency_score": frecency_score,
         "source_agent": source_agent,
         "session_id": session_id,
+        "extraction_source": extraction_source,
     }
     return normalize(raw, content_type=content_type)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -516,7 +516,13 @@ _MODE_LINT_EXCLUDE_FILES: frozenset[str] = frozenset({
     "test_indexer_utils_repo.py",
     "test_memory.py",
     "test_metadata_consistency.py",
+    "test_metadata_extraction_source.py",  # RDR-139 Layer D: pure schema unit
     "test_metadata_schema.py",
+    # RDR-139 Phase 2 (Layers C/D): pure metadata-schema / CLI-routing unit
+    # tests; the voyage-context-3 literal is an incidental placeholder
+    # embedding_model / collection-name segment, not cloud-mode behavior.
+    "test_dt_content_layer_d.py",
+    "test_dt_mcp_fallback.py",
     "test_migrations_rdr108_phase1c.py",
     "test_plan_run.py",
     "test_rdr_hook.py",  # tests/hooks/ — collection-name shape only

--- a/tests/test_commands_dt.py
+++ b/tests/test_commands_dt.py
@@ -1180,3 +1180,45 @@ class TestLinkSemantic:
         assert link_calls == ["U1"] and wb_calls == ["U1"]
         assert "semantically linked" in result.output
         assert "written back to DT" in result.output
+
+
+class TestEnrichWiring:
+    """RDR-139 Layer C: ``nx dt index --enrich`` runs a DT-CrossRef bib
+    gap-fill pass over each touched collection after indexing."""
+
+    def test_enrich_runs_bib_enrichment_once_per_collection(
+        self, runner, fake_selectors, fake_dispatcher, monkeypatch,
+    ):
+        from nexus.cli import main
+
+        calls: list[tuple[str, dict]] = []
+        monkeypatch.setattr(
+            "nexus.commands.enrich.run_bib_enrichment",
+            lambda coll, **kw: calls.append((coll, kw)),
+        )
+        # Two records, one explicit collection -> a single enrichment pass.
+        fake_selectors["selection"].return_value = [
+            ("U1", "/a.pdf"), ("U2", "/b.pdf"),
+        ]
+        result = runner.invoke(main, [
+            "dt", "index", "--selection",
+            "--collection", "knowledge__test", "--enrich",
+        ])
+        assert result.exit_code == 0, result.output
+        assert calls == [("knowledge__test", {"source": "dt"})]
+        assert "Enriching bibliographic metadata" in result.output
+
+    def test_no_enrich_flag_skips_enrichment(
+        self, runner, fake_selectors, fake_dispatcher, monkeypatch,
+    ):
+        from nexus.cli import main
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "nexus.commands.enrich.run_bib_enrichment",
+            lambda coll, **kw: calls.append(coll),
+        )
+        fake_selectors["selection"].return_value = [("U1", "/a.pdf")]
+        result = runner.invoke(main, ["dt", "index", "--selection"])
+        assert result.exit_code == 0, result.output
+        assert calls == []

--- a/tests/test_dt_content_layer_d.py
+++ b/tests/test_dt_content_layer_d.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-139 Layer D — content extraction for non-file-backed DT records.
+
+``_index_dt_content_record`` sources a record's text from DEVONthink
+(``extract_record_content``) when no on-disk file backs it, feeds it through
+the Markdown chunking pipeline, and stamps every chunk
+``extraction_source=dt_content``. The ``nx dt index --dt-content`` flag routes
+previously-skipped (unsupported-extension / no-file) records here; without the
+flag, or with DT unavailable, those records are skipped exactly as before
+(Gap 0).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+
+# ── _index_dt_content_record ────────────────────────────────────────────────
+
+@patch("nexus.commands.dt._stamp_dt_uri_on_entry", return_value=True)
+@patch("nexus.doc_indexer.index_markdown", return_value=3)
+@patch("nexus.mcp_client.devonthink.dt_record_name", return_value="A Web Clip")
+@patch("nexus.mcp_client.devonthink.dt_extract_content", return_value="body text")
+def test_index_dt_content_happy_path(
+    mock_extract: MagicMock,
+    mock_name: MagicMock,
+    mock_index: MagicMock,
+    mock_stamp: MagicMock,
+) -> None:
+    from nexus.commands.dt import _index_dt_content_record
+
+    ok = _index_dt_content_record(
+        "U1", collection="docs__dt__voyage-context-3__v1", corpus="dt",
+    )
+    assert ok is True
+    # index_markdown stamped extraction_source=dt_content on the write path
+    assert mock_index.call_args.kwargs["extraction_source"] == "dt_content"
+    assert mock_index.call_args.kwargs["collection_name"] == "docs__dt__voyage-context-3__v1"
+    mock_stamp.assert_called_once()
+
+
+@patch("nexus.doc_indexer.index_markdown")
+@patch("nexus.mcp_client.devonthink.dt_extract_content", return_value=None)
+def test_index_dt_content_empty_text_skips(
+    mock_extract: MagicMock, mock_index: MagicMock,
+) -> None:
+    from nexus.commands.dt import _index_dt_content_record
+
+    ok = _index_dt_content_record("U1", collection="docs__dt__m__v1", corpus="dt")
+    assert ok is False
+    mock_index.assert_not_called()  # never reached the pipeline
+
+
+@patch("nexus.doc_indexer.index_markdown", return_value=0)
+@patch("nexus.mcp_client.devonthink.dt_record_name", return_value="X")
+@patch("nexus.mcp_client.devonthink.dt_extract_content", return_value="body")
+def test_index_dt_content_zero_chunks_is_false(
+    mock_extract: MagicMock, mock_name: MagicMock, mock_index: MagicMock,
+) -> None:
+    from nexus.commands.dt import _index_dt_content_record
+
+    assert _index_dt_content_record("U1", collection="c", corpus="dt") is False
+
+
+def test_index_dt_content_rejects_non_dt_source() -> None:
+    from nexus.commands.dt import _index_dt_content_record
+
+    with pytest.raises(ValueError, match="not a DT source"):
+        _index_dt_content_record(
+            "U1", collection="c", corpus="dt", extraction_source="file",
+        )
+
+
+# ── nx dt index --dt-content routing ────────────────────────────────────────
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_gather(monkeypatch):
+    """Stub ``_gather_records`` so routing tests don't touch DT selectors."""
+    records: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "nexus.commands.dt._gather_records", lambda **kw: records,
+    )
+    return records
+
+
+class TestDtContentRouting:
+    def test_flag_routes_unsupported_record_to_dt_content(
+        self, runner, fake_gather, monkeypatch,
+    ):
+        from nexus.cli import main
+
+        fake_gather.append(("U1", "/clip.webarchive"))
+        monkeypatch.setattr(
+            "nexus.mcp_client.devonthink.available", lambda **k: True,
+        )
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "nexus.commands.dt._index_dt_content_record",
+            lambda uuid, **kw: calls.append(uuid) or True,
+        )
+        result = runner.invoke(
+            main, ["dt", "index", "--selection", "--dt-content"],
+        )
+        assert result.exit_code == 0, result.output
+        assert calls == ["U1"]
+        assert "1 from DT content" in result.output
+
+    def test_no_flag_skips_unsupported_record(
+        self, runner, fake_gather, monkeypatch,
+    ):
+        from nexus.cli import main
+
+        fake_gather.append(("U1", "/clip.webarchive"))
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "nexus.commands.dt._index_dt_content_record",
+            lambda uuid, **kw: calls.append(uuid) or True,
+        )
+        result = runner.invoke(main, ["dt", "index", "--selection"])
+        assert result.exit_code == 0, result.output
+        assert calls == []
+        assert "1 skipped" in result.output
+        assert "from DT content" not in result.output
+
+    def test_flag_with_dt_unavailable_skips(
+        self, runner, fake_gather, monkeypatch,
+    ):
+        from nexus.cli import main
+
+        fake_gather.append(("U1", "/clip.webarchive"))
+        monkeypatch.setattr(
+            "nexus.mcp_client.devonthink.available", lambda **k: False,
+        )
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "nexus.commands.dt._index_dt_content_record",
+            lambda uuid, **kw: calls.append(uuid) or True,
+        )
+        result = runner.invoke(
+            main, ["dt", "index", "--selection", "--dt-content"],
+        )
+        assert result.exit_code == 0, result.output
+        assert calls == []  # Gap 0: DT down -> exact skip behaviour
+        assert "1 skipped" in result.output

--- a/tests/test_dt_content_layer_d.py
+++ b/tests/test_dt_content_layer_d.py
@@ -28,17 +28,23 @@ def test_index_dt_content_happy_path(
     mock_name: MagicMock,
     mock_index: MagicMock,
     mock_stamp: MagicMock,
+    tmp_path,
 ) -> None:
     from nexus.commands.dt import _index_dt_content_record
 
-    ok = _index_dt_content_record(
-        "U1", collection="docs__dt__voyage-context-3__v1", corpus="dt",
-    )
+    with patch("nexus.config.catalog_path", return_value=tmp_path):
+        ok = _index_dt_content_record(
+            "U1", collection="docs__dt__voyage-context-3__v1", corpus="dt",
+        )
     assert ok is True
     # index_markdown stamped extraction_source=dt_content on the write path
     assert mock_index.call_args.kwargs["extraction_source"] == "dt_content"
     assert mock_index.call_args.kwargs["collection_name"] == "docs__dt__voyage-context-3__v1"
     mock_stamp.assert_called_once()
+    # text cached at a STABLE per-uuid path (re-index idempotency, HIGH-1)
+    cached = mock_index.call_args.args[0]
+    assert cached == tmp_path / ".dt-content" / "U1.md"
+    assert cached.exists()
 
 
 @patch("nexus.doc_indexer.index_markdown")
@@ -58,10 +64,35 @@ def test_index_dt_content_empty_text_skips(
 @patch("nexus.mcp_client.devonthink.dt_extract_content", return_value="body")
 def test_index_dt_content_zero_chunks_is_false(
     mock_extract: MagicMock, mock_name: MagicMock, mock_index: MagicMock,
+    tmp_path,
 ) -> None:
     from nexus.commands.dt import _index_dt_content_record
 
-    assert _index_dt_content_record("U1", collection="c", corpus="dt") is False
+    with patch("nexus.config.catalog_path", return_value=tmp_path):
+        assert _index_dt_content_record("U1", collection="c", corpus="dt") is False
+
+
+@patch("nexus.commands.dt._stamp_dt_uri_on_entry", return_value=True)
+@patch("nexus.doc_indexer.index_markdown", return_value=2)
+@patch("nexus.mcp_client.devonthink.dt_record_name", return_value="Clip")
+@patch("nexus.mcp_client.devonthink.dt_extract_content", return_value="body")
+def test_reindex_uses_same_stable_path(
+    mock_extract: MagicMock,
+    mock_name: MagicMock,
+    mock_index: MagicMock,
+    mock_stamp: MagicMock,
+    tmp_path,
+) -> None:
+    """Two indexes of the same UUID resolve to the SAME path so the catalog
+    by_file_path lookup dedups on re-index (HIGH-1 idempotency)."""
+    from nexus.commands.dt import _index_dt_content_record
+
+    with patch("nexus.config.catalog_path", return_value=tmp_path):
+        _index_dt_content_record("U9", collection="c", corpus="dt")
+        _index_dt_content_record("U9", collection="c", corpus="dt")
+    p1 = mock_index.call_args_list[0].args[0]
+    p2 = mock_index.call_args_list[1].args[0]
+    assert p1 == p2 == tmp_path / ".dt-content" / "U9.md"
 
 
 def test_index_dt_content_rejects_non_dt_source() -> None:

--- a/tests/test_dt_mcp_fallback.py
+++ b/tests/test_dt_mcp_fallback.py
@@ -8,12 +8,20 @@ not "no crash":
   ``available()=False`` equals the edge set before; no ``created_by=dt_*`` rows.
 - **Layer F (write-back)**: no DT-side mutation; index/enrich result unchanged,
   exit 0.  *(Added when P1.7 Layer F lands — nexus-x70wg.)*
+- **Layer C (bib enrich)**: DT-CrossRef gap-fill is a no-op — the resolved bib
+  dict equals the primary-backend-only result; ``dt_resolve_doi`` is never
+  called.  *(Added when P2.1 Layer C lands — nexus-8h9t5.)*
+- **Layer D (content)**: non-file-backed records are skipped (no chunks
+  written, ``index_markdown`` never called); file-backed chunks carry NO
+  ``extraction_source`` key (absent == file).  *(P2.2 Layer D — nexus-t62jy.)*
 
 Integration over mocks: a real ``Catalog`` on tmp SQLite; only the DT client's
 ``available()`` is forced False (the genuine fallback trigger).
 """
 
 from __future__ import annotations
+
+from unittest.mock import patch
 
 import pytest
 
@@ -122,3 +130,69 @@ class TestLayerFFallback:
         )
         assert out["skipped"] is True
         assert not any(out[k] for k in ("tags", "annotation", "metadata"))
+
+
+class TestLayerCFallback:
+    """Layer C: DT absent → bib gap-fill is a no-op; primary bib unchanged."""
+
+    def test_dt_crossref_bib_empty_when_dt_down(self):
+        # dt_resolve_doi returns None when DT is unreachable → empty supplement.
+        from nexus.commands.enrich import _dt_crossref_bib
+        with patch("nexus.mcp_client.devonthink.dt_resolve_doi", return_value=None):
+            assert _dt_crossref_bib("10.1/x") == {}
+
+    def test_merge_identity_when_supplement_empty(self):
+        # An empty DT supplement leaves the primary bib EXACTLY as-is.
+        from nexus.commands.enrich import _merge_bib_gapfill
+        primary = {"year": 2024, "venue": "VLDB", "authors": "A", "doi": "10.1/A"}
+        assert _merge_bib_gapfill(primary, {}) == primary
+
+    def test_enrich_source_dt_makes_no_dt_call_when_unavailable(self):
+        # CLI path: available()=False → dt_resolve_doi is never invoked, the
+        # primary miss is skipped, exit 0 (exact pre-RDR-139 behaviour).
+        from unittest.mock import MagicMock
+
+        from click.testing import CliRunner
+        from nexus.commands.enrich import enrich
+
+        meta = {"title": "P", "source_path": "/p.pdf"}
+        with patch("nexus.mcp_client.devonthink.available", return_value=False), \
+             patch("nexus.mcp_client.devonthink.dt_resolve_doi") as mock_resolve, \
+             patch("nexus.bib_enricher_openalex.enrich", return_value={}), \
+             patch("nexus.bib_enricher_openalex.enrich_by_doi", return_value={}), \
+             patch("nexus.db.make_t3") as mock_t3, \
+             patch("nexus.retry._chroma_with_retry") as mock_retry:
+            mock_retry.side_effect = [
+                {"ids": ["c1"], "metadatas": [dict(meta)]},
+                {"ids": ["c1"], "documents": ["body"], "metadatas": [dict(meta)]},
+            ]
+            mock_t3.return_value.get_or_create_collection.return_value = MagicMock()
+            res = CliRunner().invoke(
+                enrich, ["bib", "knowledge__t", "--delay", "0", "--source", "dt"],
+            )
+            assert res.exit_code == 0, res.output
+            mock_resolve.assert_not_called()
+            assert "1 titles had no" in res.output
+
+
+class TestLayerDFallback:
+    """Layer D: DT absent → non-file-backed records skipped; file chunks
+    carry no extraction_source key (absent == file)."""
+
+    def test_dt_content_record_skipped_when_dt_down(self):
+        from nexus.commands.dt import _index_dt_content_record
+        with patch("nexus.doc_indexer.index_markdown") as idx, \
+             patch("nexus.mcp_client.devonthink.dt_extract_content", return_value=None):
+            assert _index_dt_content_record("U", collection="c", corpus="dt") is False
+            idx.assert_not_called()  # never reached the chunking pipeline
+
+    def test_file_backed_chunk_has_no_extraction_source(self):
+        from nexus.metadata_schema import make_chunk_metadata
+        meta = make_chunk_metadata(
+            content_type="markdown",
+            chunk_text_hash="a" * 64,
+            content_hash="b" * 64,
+            indexed_at="2026-05-30T00:00:00Z",
+            embedding_model="voyage-context-3",
+        )
+        assert "extraction_source" not in meta  # absent == file

--- a/tests/test_enrich_dt_crossref.py
+++ b/tests/test_enrich_dt_crossref.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-139 Layer C — DT-CrossRef bibliographic enrichment (gap-fill-only).
+
+The contract under test (locked in the RDR §Approach Layer C):
+
+* DT-CrossRef is the **lowest-precedence** bib source (S2 > OpenAlex >
+  DT-CrossRef). It fills a ``bib_*`` field **only** when the primary backend
+  left that field empty/zero, and **never** overwrites a value the primary
+  set, even a differently-formatted DOI.
+* The guard is per-field (``if not merged.get(k):``), not call-ordering.
+* DT unavailable degrades to exact primary-backend-only behaviour (Gap 0).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from nexus.commands.enrich import (
+    _dt_crossref_bib,
+    _merge_bib_gapfill,
+    enrich,
+)
+
+
+# --- _dt_crossref_bib: map the live CrossRef flat dict -> nexus bib dict ----
+
+def test_dt_crossref_bib_maps_live_crossref_shape() -> None:
+    """The live ``resolve_doi_metadata`` shape is a flat dict; year is a
+    string, authors a list. Map to the nexus bib dict (year int, authors
+    joined, venue from journal, citation_count absent -> 0)."""
+    raw = {
+        "doi": "10.1038/nature12373",
+        "title": "Nanometre-scale thermometry in a living cell",
+        "authors": ["G. Kucsko", "P. C. Maurer", "N. Y. Yao", "M. Kubo",
+                     "H. J. Noh", "P. K. Lo"],
+        "journal": "Nature",
+        "year": "2013",
+    }
+    with patch("nexus.mcp_client.devonthink.dt_resolve_doi", return_value=raw):
+        bib = _dt_crossref_bib("10.1038/nature12373")
+    assert bib["year"] == 2013  # string -> int
+    assert bib["venue"] == "Nature"
+    assert bib["doi"] == "10.1038/nature12373"
+    # authors joined, capped at first 5 to match the S2/OpenAlex format
+    assert bib["authors"] == "G. Kucsko, P. C. Maurer, N. Y. Yao, M. Kubo, H. J. Noh"
+    assert bib["citation_count"] == 0  # CrossRef provides none
+
+
+def test_dt_crossref_bib_unresolvable_returns_empty() -> None:
+    """DT miss / unavailable -> empty dict (no exception)."""
+    with patch("nexus.mcp_client.devonthink.dt_resolve_doi", return_value=None):
+        assert _dt_crossref_bib("10.0/nope") == {}
+
+
+def test_dt_crossref_bib_handles_nonnumeric_year() -> None:
+    """A malformed year coerces to 0 rather than raising."""
+    raw = {"doi": "10.1/x", "journal": "J", "authors": [], "year": "n.d."}
+    with patch("nexus.mcp_client.devonthink.dt_resolve_doi", return_value=raw):
+        bib = _dt_crossref_bib("10.1/x")
+    assert bib["year"] == 0
+
+
+# --- _merge_bib_gapfill: per-field precedence guard -------------------------
+
+def test_merge_gapfill_fills_only_empty_fields() -> None:
+    primary = {"year": 0, "venue": "", "doi": "10.1/A", "citation_count": 7}
+    supplement = {"year": 2013, "venue": "Nature", "doi": "10.1/a",
+                  "citation_count": 0}
+    merged = _merge_bib_gapfill(primary, supplement)
+    # gaps filled
+    assert merged["year"] == 2013
+    assert merged["venue"] == "Nature"
+    # set values untouched — DOI keeps the primary's form, citation_count kept
+    assert merged["doi"] == "10.1/A"
+    assert merged["citation_count"] == 7
+
+
+def test_merge_gapfill_partial_s2_keeps_doi_fills_year() -> None:
+    """The locked partial-precedence case: primary set bib_doi, left year
+    empty; DT resolves a DIFFERENT DOI form and a year. DT fills only the
+    year; the primary's DOI is unchanged."""
+    primary = {"doi": "10.1038/Nature12373", "year": 0, "venue": "",
+               "authors": ""}
+    dt = {"doi": "10.1038/nature12373", "year": 2013, "venue": "Nature",
+          "authors": "G. Kucsko"}
+    merged = _merge_bib_gapfill(primary, dt)
+    assert merged["doi"] == "10.1038/Nature12373"  # primary form, NOT overwritten
+    assert merged["year"] == 2013
+    assert merged["venue"] == "Nature"
+    assert merged["authors"] == "G. Kucsko"
+
+
+def test_merge_gapfill_no_primary_hit_fills_all() -> None:
+    """No S2 hit (primary empty) -> DT supplies every field (enhanced MVV)."""
+    merged = _merge_bib_gapfill({}, {"year": 2013, "venue": "Nature",
+                                     "doi": "10.1/a", "authors": "X"})
+    assert merged == {"year": 2013, "venue": "Nature", "doi": "10.1/a",
+                      "authors": "X"}
+
+
+def test_merge_gapfill_never_inserts_falsy_supplement() -> None:
+    """A falsy supplement value does not create or clobber a key."""
+    merged = _merge_bib_gapfill({"year": 0}, {"year": 0, "venue": ""})
+    assert merged["year"] == 0
+    assert merged.get("venue", "MISSING") == "MISSING"
+
+
+# --- CLI wiring: nx enrich bib --source dt ----------------------------------
+
+_CHUNK_META = {"title": "Paper A", "source_path": "/papers/a.pdf"}
+_DOI = "10.1038/nature12373"
+
+
+def _two_chunk_collection(mock_retry: MagicMock) -> MagicMock:
+    """Wire _chroma_with_retry for a single-title two-chunk collection."""
+    mock_retry.side_effect = [
+        {"ids": ["c1", "c2"], "metadatas": [dict(_CHUNK_META), dict(_CHUNK_META)]},
+        # identifier scan (documents + metadatas) — DOI lives in the body text
+        {"ids": ["c1", "c2"],
+         "documents": [f"Title.\nDOI: {_DOI}\nAbstract...", "more"],
+         "metadatas": [dict(_CHUNK_META), dict(_CHUNK_META)]},
+        # re-fetch before update
+        {"ids": ["c1", "c2"], "metadatas": [dict(_CHUNK_META), dict(_CHUNK_META)]},
+        None,  # col.update
+    ]
+    return mock_retry
+
+
+@patch("nexus.mcp_client.devonthink.available", return_value=True)
+@patch("nexus.mcp_client.devonthink.dt_resolve_doi")
+@patch("nexus.bib_enricher_openalex.enrich")
+@patch("nexus.bib_enricher_openalex.enrich_by_doi")
+@patch("nexus.retry._chroma_with_retry")
+@patch("nexus.db.make_t3")
+def test_source_dt_gapfills_when_primary_misses(
+    mock_t3: MagicMock,
+    mock_retry: MagicMock,
+    mock_by_doi: MagicMock,
+    mock_title: MagicMock,
+    mock_dt_resolve: MagicMock,
+    mock_avail: MagicMock,
+    monkeypatch,
+) -> None:
+    """``--source dt`` with no OpenAlex hit but a resolvable DOI writes
+    bib_* from DT-CrossRef."""
+    monkeypatch.delenv("S2_API_KEY", raising=False)  # pin primary -> openalex
+    mock_by_doi.return_value = {}     # primary DOI lookup misses
+    mock_title.return_value = {}      # primary title search misses
+    mock_dt_resolve.return_value = {
+        "doi": _DOI, "year": "2013", "journal": "Nature",
+        "authors": ["X", "Y"],
+    }
+    _two_chunk_collection(mock_retry)
+    mock_db = MagicMock()
+    mock_db.get_or_create_collection.return_value = MagicMock()
+    mock_t3.return_value = mock_db
+
+    runner = CliRunner()
+    result = runner.invoke(
+        enrich, ["bib", "knowledge__t", "--delay", "0", "--source", "dt"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "enriched 2 chunks across 1 titles" in result.output
+    mock_dt_resolve.assert_called_once()
+    # the update payload carried DT's year
+    update_call = [c for c in mock_retry.call_args_list
+                   if "metadatas" in c.kwargs]
+    assert update_call, "expected a col.update with metadatas"
+    assert update_call[-1].kwargs["metadatas"][0]["bib_year"] == 2013
+
+
+@patch("nexus.mcp_client.devonthink.available", return_value=False)
+@patch("nexus.bib_enricher_openalex.enrich")
+@patch("nexus.bib_enricher_openalex.enrich_by_doi")
+@patch("nexus.retry._chroma_with_retry")
+@patch("nexus.db.make_t3")
+def test_source_dt_unavailable_degrades_to_primary_only(
+    mock_t3: MagicMock,
+    mock_retry: MagicMock,
+    mock_by_doi: MagicMock,
+    mock_title: MagicMock,
+    mock_avail: MagicMock,
+    monkeypatch,
+) -> None:
+    """DT absent -> exact primary-backend-only behaviour: a primary miss is
+    skipped, no DT call, exit 0 (Gap 0)."""
+    monkeypatch.delenv("S2_API_KEY", raising=False)  # pin primary -> openalex
+    mock_by_doi.return_value = {}
+    mock_title.return_value = {}
+    mock_retry.side_effect = [
+        {"ids": ["c1"], "metadatas": [dict(_CHUNK_META)]},
+        {"ids": ["c1"], "documents": ["body"], "metadatas": [dict(_CHUNK_META)]},
+    ]
+    mock_db = MagicMock()
+    mock_db.get_or_create_collection.return_value = MagicMock()
+    mock_t3.return_value = mock_db
+
+    with patch("nexus.mcp_client.devonthink.dt_resolve_doi") as mock_dt:
+        runner = CliRunner()
+        result = runner.invoke(
+            enrich, ["bib", "knowledge__t", "--delay", "0", "--source", "dt"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "1 titles had no" in result.output
+        mock_dt.assert_not_called()

--- a/tests/test_enrich_dt_crossref.py
+++ b/tests/test_enrich_dt_crossref.py
@@ -53,6 +53,19 @@ def test_dt_crossref_bib_unresolvable_returns_empty() -> None:
         assert _dt_crossref_bib("10.0/nope") == {}
 
 
+def test_dt_crossref_bib_handles_crossref_author_dicts() -> None:
+    """CrossRef's native ``{given, family}`` author shape coerces to a string
+    rather than silently collapsing to empty (code-review MEDIUM-2)."""
+    raw = {
+        "doi": "10.1/x", "journal": "J", "year": "2020",
+        "authors": [{"given": "Ada", "family": "Lovelace"},
+                    {"given": "Alan", "family": "Turing"}],
+    }
+    with patch("nexus.mcp_client.devonthink.dt_resolve_doi", return_value=raw):
+        bib = _dt_crossref_bib("10.1/x")
+    assert bib["authors"] == "Ada Lovelace, Alan Turing"
+
+
 def test_dt_crossref_bib_handles_nonnumeric_year() -> None:
     """A malformed year coerces to 0 rather than raising."""
     raw = {"doi": "10.1/x", "journal": "J", "authors": [], "year": "n.d."}

--- a/tests/test_metadata_consistency.py
+++ b/tests/test_metadata_consistency.py
@@ -45,7 +45,9 @@ def _expected_keys_for_content_type(content_type: str) -> set[str]:
         "bib_year", "bib_authors", "bib_venue", "bib_citation_count",
         "bib_semantic_scholar_id",
     }
-    return ALLOWED_TOP_LEVEL - bib_keys - {"git_meta"}
+    # RDR-139 Layer D: ``extraction_source`` defaults to ``file`` and is
+    # dropped by normalize (absent == file); only DT-sourced chunks carry it.
+    return ALLOWED_TOP_LEVEL - bib_keys - {"git_meta", "extraction_source"}
 
 
 def test_factory_emits_full_keyset_for_code() -> None:
@@ -173,6 +175,9 @@ def _full_keyset_minus_optional() -> set[str]:
         "bib_year", "bib_authors", "bib_venue", "bib_citation_count",
         "bib_semantic_scholar_id",
         "git_meta",
+        # RDR-139 Layer D: extraction_source defaults to ``file`` and is
+        # dropped by normalize (absent == file); only DT chunks carry it.
+        "extraction_source",
     }
 
 

--- a/tests/test_metadata_extraction_source.py
+++ b/tests/test_metadata_extraction_source.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-139 Layer D — ``extraction_source`` chunk provenance.
+
+The provenance field records how a chunk's text was sourced:
+``file`` (the on-disk file, the default) | ``dt_content`` | ``dt_ocr`` |
+``dt_transcribe`` (DEVONthink-extracted, for non-file-backed records).
+
+To stay under Chroma's 32-key metadata cap the default ``file`` value is
+dropped by :func:`normalize` (absent == file), exactly like the ``bib_*``
+placeholder-drop. Only DT-sourced chunks spend the extra key.
+"""
+from __future__ import annotations
+
+import pytest
+
+from nexus.metadata_schema import (
+    ALLOWED_TOP_LEVEL,
+    MAX_SAFE_TOP_LEVEL_KEYS,
+    make_chunk_metadata,
+    normalize,
+    validate,
+)
+
+
+def test_extraction_source_is_allowed() -> None:
+    assert "extraction_source" in ALLOWED_TOP_LEVEL
+
+
+def test_allowed_set_still_within_cap() -> None:
+    """Adding the provenance key keeps the schema within the hard cap."""
+    assert len(ALLOWED_TOP_LEVEL) <= MAX_SAFE_TOP_LEVEL_KEYS
+
+
+def test_normalize_drops_file_default() -> None:
+    """``extraction_source=file`` (the default) is dropped — absent == file."""
+    out = normalize({"extraction_source": "file"}, content_type="pdf")
+    assert "extraction_source" not in out
+
+
+def test_normalize_drops_empty() -> None:
+    out = normalize({"extraction_source": ""}, content_type="pdf")
+    assert "extraction_source" not in out
+
+
+@pytest.mark.parametrize("src", ["dt_content", "dt_ocr", "dt_transcribe"])
+def test_normalize_keeps_dt_sourced(src: str) -> None:
+    out = normalize({"extraction_source": src}, content_type="pdf")
+    assert out["extraction_source"] == src
+
+
+def test_make_chunk_metadata_defaults_to_file_and_drops_it() -> None:
+    meta = make_chunk_metadata(
+        content_type="pdf",
+        chunk_text_hash="a" * 64,
+        content_hash="b" * 64,
+        indexed_at="2026-05-30T00:00:00Z",
+        embedding_model="voyage-context-3",
+    )
+    assert "extraction_source" not in meta  # default file -> dropped
+
+
+def test_make_chunk_metadata_stamps_dt_source() -> None:
+    meta = make_chunk_metadata(
+        content_type="pdf",
+        chunk_text_hash="a" * 64,
+        content_hash="b" * 64,
+        indexed_at="2026-05-30T00:00:00Z",
+        embedding_model="voyage-context-3",
+        extraction_source="dt_content",
+    )
+    assert meta["extraction_source"] == "dt_content"
+    validate(meta)  # stays writeable / under the key cap


### PR DESCRIPTION
RDR-139 Phase 2 (DEVONthink MCP integration): bibliographic enrichment + content extraction for non-file-backed records. Builds on the Phase 1 read-only substrate + Layer F write-back already on develop.

## Layer C — DT-CrossRef bibliographic enrichment (gap-fill-only) · nexus-8h9t5
- `nx enrich bib --source dt` and `nx dt index --enrich`: run the `auto` primary backend, then gap-fill still-empty `bib_*` fields from DEVONthink's CrossRef resolver (`resolve_doi_metadata`).
- Strictly lowest-precedence (S2 > OpenAlex > DT-CrossRef), enforced by a per-field `if not merged.get(k)` guard — never overwrites a value the primary set, even a differently-formatted DOI. Verified live on a real record.
- DT unavailable → degrades to `auto`-primary-only exactly (Gap 0).

## Layer D — content extraction for non-file-backed records · nexus-t62jy
- `nx dt index --dt-content`: index records with no `.pdf`/`.md` file (web archives, bookmarks, notes) from DEVONthink's AI-extracted text instead of skipping them.
- New `extraction_source` chunk provenance (`file | dt_content | dt_ocr | dt_transcribe`). The `file` default is dropped by `normalize` (absent == file) so file-backed chunks stay one key under Chroma's 32-key cap; only DT-sourced chunks spend the extra key.
- Cached at a stable `<catalog>/.dt-content/<uuid>.md` path → re-index idempotent (no duplicate catalog rows, no ghost `file_path`).

## Fallback suite (Gap 0) · nexus-pzeqp
- Exact-fallback cases for both layers in `tests/test_dt_mcp_fallback.py`: DT absent → no DT call, primary-only / record skipped, file chunks carry no `extraction_source` key.

## Verification
- 116 unit tests green across the Phase 2 surfaces.
- Stacked review: code-review-expert (HIGH-1 re-index idempotency + MEDIUM-2 CrossRef author dicts both fixed) + substantive-critic (scope gaps traced to deferral beads).
- Phase-review-gate cross-walk: every §Approach item implemented or explicitly deferred-with-bead.
- Two-sided **live MVV PASS** against real DEVONthink (Layer C gap-fill on a live DOI record; Layer D indexed a real web archive → 45 chunks all `extraction_source=dt_content`; re-index idempotency confirmed). Details in T2 `139-phase2-mvv-live-2026-05-30`.

## Deferred (bead-tracked, in-code references — not silent scope reduction)
- nexus-fqsm5 — Layer C `search_crossref` (DOI-less title fallback) + `resolve_google_books_metadata` (books).
- nexus-39b0f — Layer D `dt_ocr` / `dt_transcribe` routing (enum- and helper-ready).

Part of epic nexus-james. Phase 2 parent nexus-r5ekl.