### PR TITLE
feat(rdr-139): Layer E — DEVONthink highlights/mentions as tumbler-attached notes (P3.1)

### DIFF
--- a/docs/rdr/rdr-139-devonthink-mcp-semantic-linking-sync.md
+++ b/docs/rdr/rdr-139-devonthink-mcp-semantic-linking-sync.md
@@ -362,9 +362,17 @@ unavailable and asserts the legacy result is byte-identical to pre-RDR-139.
   file-path extraction only, all chunks `extraction_source=file` (today's
   behaviour; non-file-backed records skipped as today).
 - **Layer E — Annotations & highlights (Gap 6).** `extract_record_highlights`
-  / `summarize_record_highlights` and `*_mentions` → ingested as
-  highlight-aspects / notes attached to the document's tumbler. Fallback: no
-  DT → no highlight ingest (today's behaviour).
+  and `extract_record_mentions` → ingested as a markdown note attached to the
+  document's tumbler. **Storage (settled P3.1):** a dedicated
+  `document_highlights` T2 table keyed by tumbler, NOT `document_aspects`.
+  `extract_record_highlights` returns a markdown blob (not structured
+  per-span fields), and `document_aspects` is confidence-gated, scholarly-
+  shaped, and `INSERT OR REPLACE` under the aspect worker (a clobber-race
+  hazard, RDR-128); a separate table sidesteps both. Surface: `nx dt index
+  --highlights` ingests, `nx dt highlights <tumbler|uuid>` reads back. The
+  `summarize_*` variants (which create a summary artifact INSIDE DEVONthink)
+  are write-back territory and out of Layer E's read-only ingest scope.
+  Fallback: no DT → no highlight ingest (today's behaviour).
 - **Layer F — Bidirectional write-back (Gap 2).** After a successful
   index+enrich (`--writeback`): `set_record_tags` (`nx-indexed`,
   `nx-tumbler:<t>`, top aspect keywords), `set_record_annotation` (backlink
@@ -475,7 +483,7 @@ capture`, which is DT-bound by definition and exits cleanly).
 | Semantic-link generator | `link_generator.py` / `auto_linker.py` | Extend pattern (new generator), don't modify existing |
 | Bib enrichment | `nx enrich bib` (Semantic Scholar) | Extend: DT CrossRef as fallback `--source dt` |
 | Content extraction | `nx index pdf|md` chunking | Extend: DT-sourced text for non-file-backed records |
-| Aspect/highlight ingest | RDR-089 aspects | Extend: highlight-aspects from DT annotations |
+| Highlight ingest | (none — `document_aspects` is scholarly/confidence-gated) | **New** `document_highlights` T2 table (tumbler-keyed markdown blobs); NOT `document_aspects` (avoids the aspect-worker clobber race) |
 | UUID↔tumbler join (forward) | `dt.py:_select_dt_uri_from_entry` | Reuse |
 | UUID↔tumbler join (inverse) | (none — `Catalog` has `by_file_path` / `by_doc_id` but no `source_uri` lookup) | **New** `Catalog.by_source_uri(uri: str) -> CatalogEntry \| None` (SQL `SELECT … FROM documents WHERE source_uri = ?`); assigned to **Phase 1**. Returns `None` for un-indexed neighbours → caller skips |
 | Selectors/CRUD | `devonthink.py:_run_osascript` | Keep (gjz52) |

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -263,6 +263,66 @@ def _writeback_record(uuid: str) -> bool:
         cat._db.close()
 
 
+def _ingest_highlights_record(uuid: str) -> bool:
+    """RDR-139 Layer E: ingest a just-indexed record's DEVONthink highlights +
+    mentions as a note attached to its catalog tumbler.
+
+    Resolves the tumbler via ``Catalog.by_source_uri`` (the entry was just
+    stamped with ``x-devonthink-item://<uuid>``), pulls the markdown blobs via
+    :func:`devonthink.dt_extract_highlights` / ``dt_extract_mentions``, and
+    upserts a :class:`HighlightRecord` into the dedicated ``document_highlights``
+    T2 table. Returns ``True`` only when at least one blob had content AND the
+    row was written. Fail-soft: no tumbler / no highlights / any error -> log +
+    ``False``; highlight ingest never aborts the index batch.
+    """
+    from nexus.catalog.catalog import Catalog  # noqa: PLC0415
+    from nexus.config import catalog_path  # noqa: PLC0415
+    from nexus.db.t2.document_highlights import (  # noqa: PLC0415
+        DocumentHighlights,
+        HighlightRecord,
+    )
+    from nexus.mcp_client import devonthink as _dt  # noqa: PLC0415
+
+    dt_uri = f"x-devonthink-item://{uuid}"
+    cat_path = catalog_path()
+    if not Catalog.is_initialized(cat_path):
+        return False
+    cat = Catalog(cat_path, cat_path / ".catalog.db")
+    try:
+        entry = cat.by_source_uri(dt_uri)
+        if entry is None:
+            _log.warning("dt_highlights_no_entry", uuid=uuid)
+            return False
+        highlights_md = _dt.dt_extract_highlights(uuid) or ""
+        mentions_md = _dt.dt_extract_mentions(uuid) or ""
+        if not (highlights_md or mentions_md):
+            _log.debug("dt_highlights_none", uuid=uuid)
+            return False
+        # One-shot CLI ingest of a new, cascade-free store: construct the
+        # DocumentHighlights store directly (not the daemon RPC path, which
+        # has no highlights method, and not T2Database, which the storage
+        # boundary lint reserves for the daemon). Low contention: one write
+        # per indexed record, not a long-lived worker (RDR-128 hazard N/A).
+        from nexus.config import default_db_path  # noqa: PLC0415
+
+        store = DocumentHighlights(default_db_path())
+        from datetime import datetime, timezone  # noqa: PLC0415
+
+        return store.upsert(HighlightRecord(
+            doc_id=str(entry.tumbler),
+            source_uri=dt_uri,
+            collection=getattr(entry, "physical_collection", "") or "",
+            highlights_md=highlights_md,
+            mentions_md=mentions_md,
+            ingested_at=datetime.now(timezone.utc).isoformat(),
+        ))
+    except Exception as e:
+        _log.warning("dt_highlights_failed", uuid=uuid, error=str(e))
+        return False
+    finally:
+        cat._db.close()
+
+
 #: RDR-139 Layer D extraction-source provenance values for DT-sourced text.
 #: Only ``dt_content`` (extract_record_content) is routed today; ``dt_ocr``
 #: (ocr_record, scanned PDFs/images) and ``dt_transcribe`` (transcribe_record,
@@ -485,6 +545,19 @@ def dt() -> None:
         "unavailable -> records skipped exactly as today. Opt-in, default off."
     ),
 )
+@click.option(
+    "--highlights",
+    "highlights",
+    is_flag=True,
+    default=False,
+    help=(
+        "After a record indexes, ingest its DEVONthink highlights + mentions "
+        "(extract_record_highlights / extract_record_mentions) as a markdown "
+        "note attached to the record's catalog tumbler in the document_highlights "
+        "T2 table (RDR-139 Layer E). DT unavailable or no highlights -> nothing "
+        "ingested. Opt-in, default off."
+    ),
+)
 def index_cmd(
     use_selection: bool,
     tag: str | None,
@@ -499,6 +572,7 @@ def index_cmd(
     writeback: bool,
     enrich: bool,
     dt_content: bool,
+    highlights: bool,
 ) -> None:
     """Index DEVONthink records into Nexus.
 
@@ -551,6 +625,7 @@ def index_cmd(
     written_back = 0
     linked = 0
     content_extracted = 0
+    highlighted = 0
     touched_collections: set[str] = set()
     failed: list[tuple[str, str, str]] = []  # (uuid, path, error)
 
@@ -581,6 +656,8 @@ def index_cmd(
                         linked += 1
                     if writeback and _writeback_record(uuid):
                         written_back += 1
+                    if highlights and _ingest_highlights_record(uuid):
+                        highlighted += 1
                 else:
                     skipped += 1
                 continue
@@ -628,6 +705,8 @@ def index_cmd(
             linked += 1
         if writeback and _writeback_record(uuid):
             written_back += 1
+        if highlights and _ingest_highlights_record(uuid):
+            highlighted += 1
 
     # RDR-139 Layer C: gap-fill bibliographic metadata over the collections we
     # just wrote to. Runs once per distinct collection (title-group oriented),
@@ -646,6 +725,8 @@ def index_cmd(
         summary += f", {linked} semantically linked"
     if writeback:
         summary += f", {written_back} written back to DT"
+    if highlights:
+        summary += f", {highlighted} highlights ingested"
     if failed:
         summary += f", {len(failed)} failed"
     if stamp_failed:
@@ -823,6 +904,40 @@ def open_cmd(tumbler_or_uuid: str) -> None:
         )
 
     subprocess.run(["open", uri], check=True)  # noqa: S603,S607
+
+
+@dt.command("highlights")
+@click.argument("tumbler_or_uuid")
+def highlights_cmd(tumbler_or_uuid: str) -> None:
+    """Show the DEVONthink highlights + mentions ingested for a record (Layer E).
+
+    Accepts a tumbler (``1.2.3``) or a DEVONthink UUID. Reads the
+    ``document_highlights`` T2 table populated by ``nx dt index --highlights``.
+    This is a pure T2 read — DEVONthink need not be running.
+    """
+    from nexus.config import default_db_path  # noqa: PLC0415
+    from nexus.db.t2.document_highlights import DocumentHighlights  # noqa: PLC0415
+
+    store = DocumentHighlights(default_db_path())
+    if _UUID_RE.match(tumbler_or_uuid):
+        rec = store.get_by_source_uri(f"x-devonthink-item://{tumbler_or_uuid}")
+    elif _TUMBLER_RE.match(tumbler_or_uuid):
+        rec = store.get(tumbler_or_uuid)
+    else:
+        raise click.ClickException(
+            "argument is neither a tumbler (e.g. 1.2.3) nor a UUID.",
+        )
+    if rec is None:
+        raise click.ClickException(
+            f"no ingested highlights for {tumbler_or_uuid} "
+            "(run 'nx dt index --highlights' first).",
+        )
+    click.echo(f"# Highlights for tumbler {rec.doc_id}")
+    click.echo(f"source: {rec.source_uri}  (ingested {rec.ingested_at})")
+    if rec.highlights_md:
+        click.echo("\n" + rec.highlights_md)
+    if rec.mentions_md:
+        click.echo("\n## Mentions\n" + rec.mentions_md)
 
 
 # ── DT-side AppleScript installer (nexus-tv5u) ────────────────────────────────

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -759,6 +759,34 @@ def migrate_document_aspects_table(conn: sqlite3.Connection) -> None:
     _log.info("Migrated: created document_aspects table (RDR-089)")
 
 
+def migrate_document_highlights_table(conn: sqlite3.Connection) -> None:
+    """Create the ``document_highlights`` table for RDR-139 Layer E.
+
+    Per-document DEVONthink highlight / mention markdown notes, keyed by the
+    catalog tumbler (``doc_id``). Deliberately separate from ``document_aspects``
+    so free-text highlights do not contend with the aspect worker's whole-row
+    overwrite or its confidence gate.
+
+    Idempotent: ``CREATE IF NOT EXISTS``. The ``DocumentHighlights`` store also
+    self-creates this table on construction, so fresh installs and tests get it
+    without waiting on this migration (mirrors ``document_aspects``).
+    """
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS document_highlights (
+            doc_id        TEXT PRIMARY KEY,
+            source_uri    TEXT,
+            collection    TEXT,
+            highlights_md TEXT,
+            mentions_md   TEXT,
+            ingested_at   TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_document_highlights_source_uri
+            ON document_highlights(source_uri);
+    """)
+    conn.commit()
+    _log.info("Migrated: created document_highlights table (RDR-139 Layer E)")
+
+
 def migrate_aspect_extraction_queue_table(conn: sqlite3.Connection) -> None:
     """Create the ``aspect_extraction_queue`` table for RDR-089
     follow-up (nexus-qeo8).
@@ -2075,6 +2103,11 @@ MIGRATIONS: list[Migration] = [
         "RDR-109 Phase 5: add document_aspects.salient_sentences column",
         lambda conn: _migrate_add_aspects_salient_sentences(conn),
     ),
+    Migration(
+        "5.5.0",
+        "RDR-139 Layer E: add document_highlights table",
+        migrate_document_highlights_table,
+    ),
 ]
 
 
@@ -2100,6 +2133,7 @@ def _migrate_add_aspects_salient_sentences(conn: sqlite3.Connection) -> None:
         "ALTER TABLE document_aspects ADD COLUMN salient_sentences TEXT"
     )
     conn.commit()
+
 
 # ── T3 upgrade steps ────────────────────────────────────────────────────────
 # Separate from T2 migrations: these require a ChromaDB client, not sqlite3.

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -518,7 +518,7 @@ class T2Database:
         self.close()
 
     def close(self) -> None:
-        """Close all eight domain connections.
+        """Close all domain connections.
 
         Each store closes its own connection under its own lock. The
         close order is reverse of construction so the most recently
@@ -533,6 +533,9 @@ class T2Database:
             except Exception:  # noqa: BLE001
                 pass
             self._catalog = None
+        # Reverse-construction order: document_highlights was built after
+        # aspect_queue (RDR-139 Layer E), so it closes first.
+        self.document_highlights.close()
         self.aspect_queue.close()
         self.document_aspects.close()
         self.chash_index.close()
@@ -600,6 +603,7 @@ class T2Database:
             "chash": 0,
             "aspects": 0,
             "aspect_queue": 0,
+            "highlights": 0,
             "tax_topics": 0,
             "tax_assignments": 0,
             "tax_meta": 0,
@@ -669,6 +673,15 @@ class T2Database:
                 (new, old),
             )
             counts["aspect_queue"] = cur.rowcount
+
+            # document_highlights (RDR-139 Layer E). PK is doc_id (tumbler),
+            # so the denorm collection column cannot collide on rename — a
+            # plain UPDATE suffices (no collision-defense DELETE needed).
+            cur = conn.execute(
+                "UPDATE document_highlights SET collection = ? WHERE collection = ?",
+                (new, old),
+            )
+            counts["highlights"] = cur.rowcount
 
             # taxonomy (three sub-tables)
             cur = conn.execute(

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -282,6 +282,7 @@ class T2Database:
         from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
         from nexus.db.t2.chash_index import ChashIndex
         from nexus.db.t2.document_aspects import DocumentAspects
+        from nexus.db.t2.document_highlights import DocumentHighlights
         from nexus.db.t2.memory_store import MemoryStore
         from nexus.db.t2.plan_library import PlanLibrary
         from nexus.db.t2.telemetry import Telemetry
@@ -362,6 +363,11 @@ class T2Database:
         self.aspect_queue: AspectExtractionQueue = AspectExtractionQueue(
             path, rename_lock=self.RENAME_LOCK
         )
+        # RDR-139 Layer E: per-document DEVONthink highlight/mention notes,
+        # keyed by tumbler. Dedicated table (NOT document_aspects) so
+        # free-text highlights never contend with the aspect worker's
+        # whole-row overwrite or its confidence gate.
+        self.document_highlights: DocumentHighlights = DocumentHighlights(path)
 
         # RDR-120 P5.A.1 (nexus-9zmpl): catalog is the eighth domain
         # store. Constructed lazily via the ``catalog`` property so

--- a/src/nexus/db/t2/document_highlights.py
+++ b/src/nexus/db/t2/document_highlights.py
@@ -166,3 +166,7 @@ class DocumentHighlights:
             )
             self.conn.commit()
             return cur.rowcount > 0
+
+    def close(self) -> None:
+        with self._lock:
+            self.conn.close()

--- a/src/nexus/db/t2/document_highlights.py
+++ b/src/nexus/db/t2/document_highlights.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""DocumentHighlights — T2 store for DEVONthink highlight/mention notes (RDR-139 Layer E).
+
+Owns one SQLite table, ``document_highlights``, holding the markdown blob that
+DEVONthink's ``extract_record_highlights`` (and ``extract_record_mentions``)
+produce for a record, keyed by the document's catalog tumbler:
+
+    PRIMARY KEY (doc_id)
+
+This is deliberately SEPARATE from ``document_aspects``. Highlights are
+user-authored annotations rendered as a single markdown blob, not the
+scholarly-paper structured fields the aspect extractor produces. Folding them
+into ``document_aspects`` would (a) overload a confidence-gated, scholarly-
+shaped table with free-text notes, and (b) contend with the aspect worker's
+whole-row ``INSERT OR REPLACE`` (the RDR-128 single-writer hazard) — a Layer E
+ingest and an aspect re-extraction would clobber each other. A dedicated table
+sidesteps both.
+
+Upsert semantics: COMPLETE IDEMPOTENT OVERWRITE keyed on ``doc_id`` — a fresh
+Layer E ingest replaces the prior blob verbatim. A record with neither a
+highlights blob nor a mentions blob is a no-op (nothing to store).
+
+The schema is duplicated here as ``CREATE IF NOT EXISTS`` so a fresh store
+construction creates the table before any migration runs (mirrors
+``DocumentAspects``). Identical shape to the migration entry.
+
+Lock convention (mirrors ``DocumentAspects`` / ``ChashIndex``):
+  * Public methods acquire ``self._lock`` themselves.
+  * ``_init_schema`` runs under ``self._lock`` during ``__init__``.
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+import structlog
+
+from nexus.db.t2._tuning import SERVING_BUSY_TIMEOUT_MS
+
+_log = structlog.get_logger()
+
+
+_DOCUMENT_HIGHLIGHTS_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS document_highlights (
+    doc_id        TEXT PRIMARY KEY,
+    source_uri    TEXT,
+    collection    TEXT,
+    highlights_md TEXT,
+    mentions_md   TEXT,
+    ingested_at   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_document_highlights_source_uri
+    ON document_highlights(source_uri);
+"""
+
+
+@dataclass
+class HighlightRecord:
+    """A document's DEVONthink-sourced highlight + mention notes (RDR-139 Layer E).
+
+    ``doc_id`` is the catalog tumbler of the source document. ``source_uri`` is
+    the ``x-devonthink-item://<uuid>`` identity. ``highlights_md`` /
+    ``mentions_md`` are the markdown blobs from ``extract_record_highlights`` /
+    ``extract_record_mentions`` (either may be empty).
+    """
+
+    doc_id: str
+    source_uri: str
+    collection: str
+    highlights_md: str
+    mentions_md: str
+    ingested_at: str
+
+
+def _row_to_record(row: sqlite3.Row | tuple) -> HighlightRecord:
+    return HighlightRecord(
+        doc_id=row[0],
+        source_uri=row[1] or "",
+        collection=row[2] or "",
+        highlights_md=row[3] or "",
+        mentions_md=row[4] or "",
+        ingested_at=row[5] or "",
+    )
+
+
+_SELECT = (
+    "SELECT doc_id, source_uri, collection, highlights_md, mentions_md, "
+    "ingested_at FROM document_highlights"
+)
+
+
+class DocumentHighlights:
+    """T2 store for per-document DEVONthink highlight/mention notes (RDR-139 Layer E)."""
+
+    def __init__(self, path: Path) -> None:
+        self._lock = threading.Lock()
+        self.conn = sqlite3.connect(str(path), check_same_thread=False)
+        self.conn.execute(f"PRAGMA busy_timeout={SERVING_BUSY_TIMEOUT_MS}")
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        with self._lock:
+            self.conn.executescript("PRAGMA journal_mode=WAL;")
+            self.conn.executescript(_DOCUMENT_HIGHLIGHTS_SCHEMA_SQL)
+            self.conn.commit()
+
+    def upsert(self, record: HighlightRecord) -> bool:
+        """Persist *record* — complete overwrite if ``doc_id`` already exists.
+
+        Returns ``True`` when a row was written, ``False`` when the record
+        carried neither a highlights blob nor a mentions blob (nothing to
+        store). Raises ``ValueError`` on an empty ``doc_id``.
+        """
+        if not record.doc_id:
+            raise ValueError("doc_id must not be empty")
+        if not record.ingested_at:
+            raise ValueError("ingested_at must not be empty")
+        if not (record.highlights_md or record.mentions_md):
+            return False
+        with self._lock:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO document_highlights "
+                "(doc_id, source_uri, collection, highlights_md, mentions_md, "
+                " ingested_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    record.doc_id,
+                    record.source_uri,
+                    record.collection,
+                    record.highlights_md,
+                    record.mentions_md,
+                    record.ingested_at,
+                ),
+            )
+            self.conn.commit()
+        return True
+
+    def get(self, doc_id: str) -> HighlightRecord | None:
+        with self._lock:
+            row = self.conn.execute(
+                f"{_SELECT} WHERE doc_id=?", (doc_id,)
+            ).fetchone()
+        return _row_to_record(row) if row else None
+
+    def get_by_source_uri(self, source_uri: str) -> HighlightRecord | None:
+        with self._lock:
+            row = self.conn.execute(
+                f"{_SELECT} WHERE source_uri=? LIMIT 1", (source_uri,)
+            ).fetchone()
+        return _row_to_record(row) if row else None
+
+    def list(self, *, limit: int = 50, offset: int = 0) -> list[HighlightRecord]:
+        with self._lock:
+            rows = self.conn.execute(
+                f"{_SELECT} ORDER BY ingested_at DESC LIMIT ? OFFSET ?",
+                (limit, offset),
+            ).fetchall()
+        return [_row_to_record(r) for r in rows]
+
+    def delete(self, doc_id: str) -> bool:
+        with self._lock:
+            cur = self.conn.execute(
+                "DELETE FROM document_highlights WHERE doc_id=?", (doc_id,)
+            )
+            self.conn.commit()
+            return cur.rowcount > 0

--- a/src/nexus/mcp_client/devonthink.py
+++ b/src/nexus/mcp_client/devonthink.py
@@ -210,6 +210,50 @@ def dt_record_name(uuid: str) -> str:
     return name if isinstance(name, str) else ""
 
 
+#: Prefixes DT returns when a record carries zero annotations/mentions. These
+#: are status messages, not content — treated as "no highlights" (None).
+_NO_CONTENT_PREFIXES: tuple[str, ...] = (
+    "no highlights found",
+    "no mentions found",
+    "no annotations",
+)
+
+
+def _dt_markdown_or_none(result: dict[str, Any] | None) -> str | None:
+    """Pull a markdown body from a DT highlights/mentions result, or ``None``.
+
+    ``extract_record_highlights`` / ``extract_record_mentions`` return either
+    the markdown text (success) or a "No highlights found ..." status string
+    (zero annotations). core wraps a plain-text content as ``{"text": ...}``;
+    partial-success returns ``{"markdown": ..., ...}``. Accept both keys and
+    map any no-content status message to ``None`` so callers don't store it.
+    """
+    if not result:
+        return None
+    text = result.get("text")
+    if not isinstance(text, str) or not text:
+        md = result.get("markdown")
+        text = md if isinstance(md, str) else None
+    if not text or not text.strip():
+        return None
+    if text.strip().lower().startswith(_NO_CONTENT_PREFIXES):
+        return None
+    return text
+
+
+def dt_extract_highlights(uuid: str) -> str | None:
+    """Markdown summary of a record's annotations/highlights, or ``None`` (Layer E).
+
+    Maps DT's zero-annotation status message to ``None``. Fail-soft.
+    """
+    return _dt_markdown_or_none(dt_call("extract_record_highlights", {"uuid": uuid}))
+
+
+def dt_extract_mentions(uuid: str) -> str | None:
+    """Markdown summary of a record's mentions, or ``None`` (Layer E). Fail-soft."""
+    return _dt_markdown_or_none(dt_call("extract_record_mentions", {"uuid": uuid}))
+
+
 def dt_set_tags(uuid: str, tags: list[str], *, mode: str = "add") -> bool:
     """Write tags onto a record (default additive). ``True`` on success (Layer F)."""
     if not tags:

--- a/src/nexus/mcp_client/devonthink.py
+++ b/src/nexus/mcp_client/devonthink.py
@@ -210,13 +210,19 @@ def dt_record_name(uuid: str) -> str:
     return name if isinstance(name, str) else ""
 
 
-#: Prefixes DT returns when a record carries zero annotations/mentions. These
-#: are status messages, not content — treated as "no highlights" (None).
+#: Status messages DT returns when a record carries zero annotations/mentions.
+#: These are not content — a result that IS one of these (the whole stripped
+#: body starts with the phrase AND is short) maps to None. The full-phrase form
+#: ("...found") plus a length guard avoids false-positives on a real highlight
+#: blob that merely opens with "No annotations ..." prose.
 _NO_CONTENT_PREFIXES: tuple[str, ...] = (
     "no highlights found",
     "no mentions found",
-    "no annotations",
+    "no annotations found",
 )
+#: A body longer than this is treated as real content even if it opens with a
+#: sentinel-looking phrase (the status messages are short, one-liners).
+_NO_CONTENT_MAX_LEN: int = 200
 
 
 def _dt_markdown_or_none(result: dict[str, Any] | None) -> str | None:
@@ -234,9 +240,16 @@ def _dt_markdown_or_none(result: dict[str, Any] | None) -> str | None:
     if not isinstance(text, str) or not text:
         md = result.get("markdown")
         text = md if isinstance(md, str) else None
-    if not text or not text.strip():
+    stripped = text.strip() if text else ""
+    if not stripped:
         return None
-    if text.strip().lower().startswith(_NO_CONTENT_PREFIXES):
+    # A short body that opens with a "No ... found" status phrase is the
+    # zero-annotation sentinel; a long body that merely mentions the phrase is
+    # real content and is kept.
+    if (
+        len(stripped) <= _NO_CONTENT_MAX_LEN
+        and stripped.lower().startswith(_NO_CONTENT_PREFIXES)
+    ):
         return None
     return text
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -518,11 +518,14 @@ _MODE_LINT_EXCLUDE_FILES: frozenset[str] = frozenset({
     "test_metadata_consistency.py",
     "test_metadata_extraction_source.py",  # RDR-139 Layer D: pure schema unit
     "test_metadata_schema.py",
-    # RDR-139 Phase 2 (Layers C/D): pure metadata-schema / CLI-routing unit
-    # tests; the voyage-context-3 literal is an incidental placeholder
-    # embedding_model / collection-name segment, not cloud-mode behavior.
+    # RDR-139 Phase 2/3 (Layers C/D/E): pure metadata-schema / CLI-routing /
+    # T2-store unit tests; the voyage-context-3 literal is an incidental
+    # placeholder embedding_model / collection-name segment, not cloud-mode
+    # behavior.
     "test_dt_content_layer_d.py",
     "test_dt_mcp_fallback.py",
+    "test_document_highlights.py",
+    "test_dt_highlights_layer_e.py",
     "test_migrations_rdr108_phase1c.py",
     "test_plan_run.py",
     "test_rdr_hook.py",  # tests/hooks/ — collection-name shape only

--- a/tests/test_document_highlights.py
+++ b/tests/test_document_highlights.py
@@ -85,6 +85,37 @@ def test_get_missing_returns_none(store) -> None:
     assert store.get("9.9.9") is None
 
 
+def test_close_releases_connection(store) -> None:
+    store.upsert(_rec())
+    store.close()
+    import sqlite3
+    with pytest.raises(sqlite3.ProgrammingError):
+        store.conn.execute("SELECT 1")
+
+
+def test_rename_cascade_updates_highlights_collection(tmp_path) -> None:
+    """HIGH-2: rename_collection_cascade must carry document_highlights rows."""
+    from nexus.db.t2 import T2Database
+
+    db = T2Database(tmp_path / "memory.db")
+    try:
+        db.document_highlights.upsert(HighlightRecord(
+            doc_id="1.2.3", source_uri="x-devonthink-item://A",
+            collection="docs__old__voyage-context-3__v1",
+            highlights_md="## h", mentions_md="",
+            ingested_at="2026-05-30T00:00:00Z",
+        ))
+        counts = db.rename_collection_cascade(
+            old="docs__old__voyage-context-3__v1",
+            new="docs__new__voyage-context-3__v1",
+        )
+        assert counts["highlights"] == 1
+        rec = db.document_highlights.get("1.2.3")
+        assert rec.collection == "docs__new__voyage-context-3__v1"
+    finally:
+        db.close()
+
+
 def test_list_and_delete(store) -> None:
     store.upsert(_rec(doc_id="1.1.1", source_uri="x-devonthink-item://A"))
     store.upsert(_rec(doc_id="1.1.2", source_uri="x-devonthink-item://B"))

--- a/tests/test_document_highlights.py
+++ b/tests/test_document_highlights.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-139 Layer E — DocumentHighlights T2 store.
+
+A dedicated tumbler-keyed table for DEVONthink-sourced highlight/mention
+markdown blobs. Separate from ``document_aspects`` by design: highlights are
+user-authored notes (a markdown blob, not structured fields), and must not
+contend with the confidence-gated, INSERT-OR-REPLACE, aspect-worker-owned
+aspects row.
+"""
+from __future__ import annotations
+
+import pytest
+
+from nexus.db.t2.document_highlights import DocumentHighlights, HighlightRecord
+
+
+@pytest.fixture
+def store(tmp_path) -> DocumentHighlights:
+    return DocumentHighlights(tmp_path / "memory.db")
+
+
+def _rec(**kw) -> HighlightRecord:
+    base = dict(
+        doc_id="1.14.4",
+        source_uri="x-devonthink-item://ABC",
+        collection="knowledge__dt-papers__voyage-context-3__v1",
+        highlights_md="## Highlights\n- a point\n- another",
+        mentions_md="",
+        ingested_at="2026-05-30T00:00:00Z",
+    )
+    base.update(kw)
+    return HighlightRecord(**base)
+
+
+def test_table_self_created_on_init(store) -> None:
+    # _init_schema ran in __init__ (fresh DBs/tests need no migration).
+    cols = {r[1] for r in store.conn.execute(
+        "PRAGMA table_info(document_highlights)"
+    ).fetchall()}
+    assert {"doc_id", "source_uri", "collection", "highlights_md",
+            "mentions_md", "ingested_at"} <= cols
+
+
+def test_upsert_then_get_roundtrips(store) -> None:
+    assert store.upsert(_rec()) is True
+    got = store.get("1.14.4")
+    assert got is not None
+    assert got.highlights_md.startswith("## Highlights")
+    assert got.source_uri == "x-devonthink-item://ABC"
+    assert got.collection.startswith("knowledge__")
+
+
+def test_upsert_is_complete_overwrite_by_doc_id(store) -> None:
+    store.upsert(_rec(highlights_md="old"))
+    store.upsert(_rec(highlights_md="new", mentions_md="@someone"))
+    got = store.get("1.14.4")
+    assert got.highlights_md == "new"
+    assert got.mentions_md == "@someone"
+    # still exactly one row for the doc_id
+    n = store.conn.execute(
+        "SELECT COUNT(*) FROM document_highlights WHERE doc_id=?", ("1.14.4",)
+    ).fetchone()[0]
+    assert n == 1
+
+
+def test_empty_record_is_rejected(store) -> None:
+    # nothing to store when both blobs are empty
+    assert store.upsert(_rec(highlights_md="", mentions_md="")) is False
+    assert store.get("1.14.4") is None
+
+
+def test_empty_doc_id_raises(store) -> None:
+    with pytest.raises(ValueError, match="doc_id"):
+        store.upsert(_rec(doc_id=""))
+
+
+def test_get_by_source_uri(store) -> None:
+    store.upsert(_rec())
+    got = store.get_by_source_uri("x-devonthink-item://ABC")
+    assert got is not None and got.doc_id == "1.14.4"
+    assert store.get_by_source_uri("x-devonthink-item://NOPE") is None
+
+
+def test_get_missing_returns_none(store) -> None:
+    assert store.get("9.9.9") is None
+
+
+def test_list_and_delete(store) -> None:
+    store.upsert(_rec(doc_id="1.1.1", source_uri="x-devonthink-item://A"))
+    store.upsert(_rec(doc_id="1.1.2", source_uri="x-devonthink-item://B"))
+    rows = store.list()
+    assert {r.doc_id for r in rows} == {"1.1.1", "1.1.2"}
+    assert store.delete("1.1.1") is True
+    assert store.get("1.1.1") is None
+    assert store.delete("1.1.1") is False  # already gone

--- a/tests/test_dt_highlights_layer_e.py
+++ b/tests/test_dt_highlights_layer_e.py
@@ -44,6 +44,28 @@ def test_extract_highlights_empty_text_is_none() -> None:
         assert dt_extract_highlights("U") is None
 
 
+def test_short_no_content_sentinel_is_none() -> None:
+    from nexus.mcp_client.devonthink import dt_extract_highlights
+    with patch("nexus.mcp_client.devonthink.dt_call",
+               return_value={"text": "No annotations found across 1 source record(s)"}):
+        assert dt_extract_highlights("U") is None
+
+
+def test_long_body_opening_with_sentinel_phrase_is_kept() -> None:
+    """MEDIUM-2: a real highlight blob that merely opens with 'No annotations'
+    prose must NOT be discarded as a no-content sentinel."""
+    from nexus.mcp_client.devonthink import dt_extract_highlights
+    body = (
+        "No annotations were strictly required, but the author's key claim, "
+        "that paged attention dominates throughput, is highlighted here, "
+        "along with twelve supporting passages spanning the whole paper and "
+        "several margin notes the reader added during a second close reading."
+    )
+    assert len(body) > 200
+    with patch("nexus.mcp_client.devonthink.dt_call", return_value={"text": body}):
+        assert dt_extract_highlights("U") == body
+
+
 # ── _ingest_highlights_record ───────────────────────────────────────────────
 
 def _patch_catalog(monkeypatch, tmp_path, tumbler="1.2.3", collection="c"):

--- a/tests/test_dt_highlights_layer_e.py
+++ b/tests/test_dt_highlights_layer_e.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-139 Layer E — DT highlight helpers + nx dt index --highlights wiring."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+
+# ── DT helpers: no-content filtering + key handling ─────────────────────────
+
+def test_extract_highlights_returns_markdown() -> None:
+    from nexus.mcp_client.devonthink import dt_extract_highlights
+    with patch("nexus.mcp_client.devonthink.dt_call",
+               return_value={"text": "## Highlights\n- a point"}):
+        assert dt_extract_highlights("U") == "## Highlights\n- a point"
+
+
+def test_extract_highlights_no_content_message_is_none() -> None:
+    from nexus.mcp_client.devonthink import dt_extract_highlights
+    with patch("nexus.mcp_client.devonthink.dt_call",
+               return_value={"text": "No highlights found across 1 source record(s)"}):
+        assert dt_extract_highlights("U") is None
+
+
+def test_extract_highlights_unavailable_is_none() -> None:
+    from nexus.mcp_client.devonthink import dt_extract_highlights
+    with patch("nexus.mcp_client.devonthink.dt_call", return_value=None):
+        assert dt_extract_highlights("U") is None
+
+
+def test_extract_mentions_reads_markdown_key() -> None:
+    # partial-success envelope carries the body under "markdown"
+    from nexus.mcp_client.devonthink import dt_extract_mentions
+    with patch("nexus.mcp_client.devonthink.dt_call",
+               return_value={"markdown": "@alice mentioned", "succeeded": 1}):
+        assert dt_extract_mentions("U") == "@alice mentioned"
+
+
+def test_extract_highlights_empty_text_is_none() -> None:
+    from nexus.mcp_client.devonthink import dt_extract_highlights
+    with patch("nexus.mcp_client.devonthink.dt_call", return_value={"text": "   "}):
+        assert dt_extract_highlights("U") is None
+
+
+# ── _ingest_highlights_record ───────────────────────────────────────────────
+
+def _patch_catalog(monkeypatch, tmp_path, tumbler="1.2.3", collection="c"):
+    """Patch nexus.catalog.catalog.Catalog (lazy-imported inside the helper)."""
+    entry = MagicMock()
+    entry.tumbler = tumbler
+    entry.physical_collection = collection
+    cat = MagicMock()
+    cat.by_source_uri.return_value = entry
+    cat._db = MagicMock()
+    CatalogMock = MagicMock(return_value=cat)
+    CatalogMock.is_initialized = staticmethod(lambda p: True)
+    monkeypatch.setattr("nexus.catalog.catalog.Catalog", CatalogMock)
+    monkeypatch.setattr("nexus.config.catalog_path", lambda: tmp_path)
+    return cat
+
+
+def test_ingest_highlights_record_writes_store(tmp_path, monkeypatch) -> None:
+    from nexus.commands import dt as dt_mod
+    from nexus.db.t2.document_highlights import DocumentHighlights
+
+    _patch_catalog(monkeypatch, tmp_path,
+                   collection="knowledge__dt__voyage-context-3__v1")
+    monkeypatch.setattr("nexus.config.default_db_path", lambda: tmp_path / "memory.db")
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_extract_highlights",
+                        lambda u: "## Highlights\n- x")
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_extract_mentions",
+                        lambda u: None)
+
+    assert dt_mod._ingest_highlights_record("ABC") is True
+    rec = DocumentHighlights(tmp_path / "memory.db").get("1.2.3")
+    assert rec is not None
+    assert rec.highlights_md == "## Highlights\n- x"
+    assert rec.source_uri == "x-devonthink-item://ABC"
+
+
+def test_ingest_highlights_record_no_highlights_is_false(tmp_path, monkeypatch) -> None:
+    from nexus.commands import dt as dt_mod
+
+    _patch_catalog(monkeypatch, tmp_path)
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_extract_highlights", lambda u: None)
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_extract_mentions", lambda u: None)
+
+    assert dt_mod._ingest_highlights_record("ABC") is False
+
+
+# ── nx dt index --highlights routing + nx dt highlights show ────────────────
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_gather(monkeypatch):
+    records: list[tuple[str, str]] = []
+    monkeypatch.setattr("nexus.commands.dt._gather_records", lambda **kw: records)
+    return records
+
+
+def test_index_highlights_flag_routes_and_summarizes(runner, fake_gather, monkeypatch) -> None:
+    from nexus.cli import main
+
+    fake_gather.append(("U1", "/a.pdf"))
+    monkeypatch.setattr("nexus.commands.dt._index_record",
+                        lambda uuid, path, *, collection, corpus, dry_run: True)
+    calls: list[str] = []
+    monkeypatch.setattr("nexus.commands.dt._ingest_highlights_record",
+                        lambda uuid: calls.append(uuid) or True)
+    result = runner.invoke(main, ["dt", "index", "--uuid", "U1", "--highlights"])
+    assert result.exit_code == 0, result.output
+    assert calls == ["U1"]
+    assert "1 highlights ingested" in result.output
+
+
+def test_no_highlights_flag_skips_ingest(runner, fake_gather, monkeypatch) -> None:
+    from nexus.cli import main
+
+    fake_gather.append(("U1", "/a.pdf"))
+    monkeypatch.setattr("nexus.commands.dt._index_record",
+                        lambda uuid, path, *, collection, corpus, dry_run: True)
+    calls: list[str] = []
+    monkeypatch.setattr("nexus.commands.dt._ingest_highlights_record",
+                        lambda uuid: calls.append(uuid) or True)
+    result = runner.invoke(main, ["dt", "index", "--uuid", "U1"])
+    assert result.exit_code == 0, result.output
+    assert calls == []
+    assert "highlights ingested" not in result.output
+
+
+def test_highlights_show_command(runner, tmp_path, monkeypatch) -> None:
+    from nexus.cli import main
+    from nexus.db.t2.document_highlights import DocumentHighlights, HighlightRecord
+
+    db = tmp_path / "memory.db"
+    DocumentHighlights(db).upsert(HighlightRecord(
+        doc_id="1.2.3", source_uri="x-devonthink-item://ABC", collection="c",
+        highlights_md="## Highlights\n- the point", mentions_md="",
+        ingested_at="2026-05-30T00:00:00Z",
+    ))
+    monkeypatch.setattr("nexus.config.default_db_path", lambda: db)
+    result = runner.invoke(main, ["dt", "highlights", "1.2.3"])
+    assert result.exit_code == 0, result.output
+    assert "the point" in result.output
+    # unknown tumbler -> clean error
+    miss = runner.invoke(main, ["dt", "highlights", "9.9.9"])
+    assert miss.exit_code != 0
+    assert "no ingested highlights" in miss.output

--- a/tests/test_dt_mcp_fallback.py
+++ b/tests/test_dt_mcp_fallback.py
@@ -196,3 +196,18 @@ class TestLayerDFallback:
             embedding_model="voyage-context-3",
         )
         assert "extraction_source" not in meta  # absent == file
+
+
+class TestLayerEFallback:
+    """Layer E: DT absent → no highlight ingest (dt_call yields None, so the
+    highlight/mention helpers yield None and nothing is stored)."""
+
+    def test_extract_highlights_none_when_dt_down(self):
+        from nexus.mcp_client.devonthink import dt_extract_highlights
+        with patch("nexus.mcp_client.devonthink.dt_call", return_value=None):
+            assert dt_extract_highlights("U") is None
+
+    def test_extract_mentions_none_when_dt_down(self):
+        from nexus.mcp_client.devonthink import dt_extract_mentions
+        with patch("nexus.mcp_client.devonthink.dt_call", return_value=None):
+            assert dt_extract_mentions("U") is None


### PR DESCRIPTION
RDR-139 Phase 3, Layer E (`nexus-yv78m`): ingest a DEVONthink record's highlights and mentions as a markdown note attached to its catalog tumbler.

## What ships
- **`nx dt index --highlights`** — after a record indexes, pull `extract_record_highlights` + `extract_record_mentions` and store the markdown into a new `document_highlights` T2 table keyed by the record's tumbler.
- **`nx dt highlights <tumbler|uuid>`** — read the ingested notes back (pure T2 read, DT not required).

## Storage decision (settled with the user)
A **dedicated `document_highlights` T2 table**, NOT `document_aspects`. `extract_record_highlights` returns a markdown blob (not structured fields), and `document_aspects` is confidence-gated, scholarly-shaped, and `INSERT OR REPLACE` under the aspect worker — folding highlights in would risk a clobber race (RDR-128). The store self-creates its schema on init (fresh DBs/tests need no migration), mirroring `DocumentAspects`; a `5.5.0` migration entry covers existing-DB upgrades.

## Gap 0
DT unavailable or no highlights → nothing ingested, exit 0. The DT helpers return `None` when `dt_call` returns `None`; DT's "No highlights found" status string maps to `None` (verified live).

## Verification
- 80 unit tests green across the store, helpers, CLI, rename-cascade, and daemon-lifecycle suites; storage-boundary + mode-lint green.
- Stacked review (both reviewers): code-review-expert HIGH-1 (`close()` leak) + HIGH-2 (rename-cascade gap) + MEDIUM-2 (sentinel false-positive) all fixed; substantive-critic SIG-1 (RDR terminology synced), SIG-2 (live shape verified: flat `{text: ...}`), OBS-2 tracked as `nexus-kpnqy`.
- Live shape check against real DEVONthink confirmed the `{text: ...}` envelope and the sentinel→None mapping. Details in T2 `139-layer-e-review-mvv-2026-05-30`.

## Tracked follow-ons
- `nexus-kpnqy` — wire `document_highlights` into retrieval (currently write-only, read only by `nx dt highlights`).

Part of epic `nexus-james`, Phase 3 parent `nexus-ubmed`.