### PR TITLE
feat(rdr-139): Layer G — nx dt capture (the one DT-bound verb) (P3.3)

### DIFF
--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -940,6 +940,112 @@ def highlights_cmd(tumbler_or_uuid: str) -> None:
         click.echo("\n## Mentions\n" + rec.mentions_md)
 
 
+@dt.command("capture")
+@click.argument("url", required=False)
+@click.option("--doi", default=None, help="Capture by DOI: download the open-access PDF (Unpaywall).")
+@click.option("--file", "file_path", default=None, help="Capture a loose file from this POSIX path.")
+@click.option(
+    "--type",
+    "capture_type",
+    type=click.Choice(["html", "webarchive", "markdown", "pdf"], case_sensitive=False),
+    default="webarchive",
+    show_default=True,
+    help="Web-capture format (URL captures only). pdf is file-backed; the others are not.",
+)
+@click.option(
+    "--contact-email",
+    default=None,
+    help="Caller email for Unpaywall PDF discovery on --doi (else $OPENALEX_MAILTO).",
+)
+@click.option("--collection", default=None, help="T3 collection override for the index step.")
+@click.option("--corpus", default="dt", show_default=True, help="Corpus tag for the index step.")
+@click.option("--link-semantic", "link_semantic", is_flag=True, default=False,
+              help="After indexing, create Layer B 'relates' edges (see nx dt index).")
+@click.option("--writeback", is_flag=True, default=False,
+              help="After indexing, stamp nexus identity back onto the DT record (Layer F).")
+@click.option("--highlights", "highlights", is_flag=True, default=False,
+              help="After indexing, ingest the record's highlights (Layer E).")
+@click.pass_context
+def capture_cmd(
+    ctx: click.Context,
+    url: str | None,
+    doi: str | None,
+    file_path: str | None,
+    capture_type: str,
+    contact_email: str | None,
+    collection: str | None,
+    corpus: str,
+    link_semantic: bool,
+    writeback: bool,
+    highlights: bool,
+) -> None:
+    """Capture a URL, DOI, or file into DEVONthink and index it (RDR-139 Layer G).
+
+    Provide exactly one source: a URL argument, ``--doi``, or ``--file``. The
+    captured record is then indexed (and optionally linked / written-back /
+    highlight-ingested) end to end.
+
+    This is the ONE DT-bound verb: unlike ``nx dt index`` / ``--enrich`` (which
+    degrade silently when DEVONthink is absent), ``nx dt capture`` reports
+    DT-required and exits NON-ZERO, because capture is impossible without DT.
+    """
+    if not _is_darwin():
+        raise click.ClickException("DEVONthink integration is macOS-only")
+
+    sources = [bool(url), doi is not None, file_path is not None]
+    if sum(sources) != 1:
+        raise click.UsageError(
+            "Provide exactly one capture source: a URL argument, --doi, or --file.",
+        )
+
+    from nexus.mcp_client import devonthink as _dt  # noqa: PLC0415
+
+    if not _dt.available():
+        # Gap-0 NON-OPTIONAL exception: capture cannot proceed without DT, so it
+        # fails loud (non-zero) rather than silently doing nothing.
+        raise click.ClickException(
+            "nx dt capture requires DEVONthink to be running — this verb is "
+            "DT-bound by design (unlike nx dt index, which degrades silently).",
+        )
+
+    if url:
+        uuid = _dt.dt_capture_web_page(url, capture_type=capture_type)
+        file_backed = capture_type.lower() == "pdf"
+        what = url
+    elif doi is not None:
+        import os as _os  # noqa: PLC0415
+
+        email = contact_email or _os.environ.get("OPENALEX_MAILTO", "")
+        uuid = _dt.dt_download_pdf_from_doi(doi, contact_email=email)
+        file_backed = True
+        what = f"doi:{doi}"
+    else:
+        uuid = _dt.dt_import_file(file_path or "")
+        file_backed = True
+        what = file_path or ""
+
+    if not uuid:
+        hint = (
+            " (no open-access PDF found for this DOI)" if doi is not None else ""
+        )
+        raise click.ClickException(f"capture failed for {what}{hint} — no record created.")
+
+    click.echo(f"Captured {what} -> DEVONthink record {uuid}")
+    # Reuse the full index path. Non-file-backed captures (html/webarchive/
+    # markdown) route through Layer D's --dt-content; pdf/doi/file captures are
+    # file-backed and index normally (CA6 finding).
+    ctx.invoke(
+        index_cmd,
+        uuids=(uuid,),
+        collection=collection,
+        corpus=corpus,
+        dt_content=not file_backed,
+        link_semantic=link_semantic,
+        writeback=writeback,
+        highlights=highlights,
+    )
+
+
 # ── DT-side AppleScript installer (nexus-tv5u) ────────────────────────────────
 
 

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -950,7 +950,8 @@ def highlights_cmd(tumbler_or_uuid: str) -> None:
     type=click.Choice(["html", "webarchive", "markdown", "pdf"], case_sensitive=False),
     default="webarchive",
     show_default=True,
-    help="Web-capture format (URL captures only). pdf is file-backed; the others are not.",
+    help="Web-capture format (URL captures only). pdf and markdown index from "
+         "the on-disk file DT creates; html and webarchive are non-file-backed.",
 )
 @click.option(
     "--contact-email",
@@ -965,6 +966,8 @@ def highlights_cmd(tumbler_or_uuid: str) -> None:
               help="After indexing, stamp nexus identity back onto the DT record (Layer F).")
 @click.option("--highlights", "highlights", is_flag=True, default=False,
               help="After indexing, ingest the record's highlights (Layer E).")
+@click.option("--enrich", "enrich", is_flag=True, default=False,
+              help="After indexing, run DT-CrossRef bib gap-fill over the collection (Layer C).")
 @click.pass_context
 def capture_cmd(
     ctx: click.Context,
@@ -978,6 +981,7 @@ def capture_cmd(
     link_semantic: bool,
     writeback: bool,
     highlights: bool,
+    enrich: bool,
 ) -> None:
     """Capture a URL, DOI, or file into DEVONthink and index it (RDR-139 Layer G).
 
@@ -992,7 +996,9 @@ def capture_cmd(
     if not _is_darwin():
         raise click.ClickException("DEVONthink integration is macOS-only")
 
-    sources = [bool(url), doi is not None, file_path is not None]
+    # Count by truthiness so an empty --doi "" / --file "" is "no source" with
+    # a clear message, not a confusing blank-target failure downstream.
+    sources = [bool(url), bool(doi), bool(file_path)]
     if sum(sources) != 1:
         raise click.UsageError(
             "Provide exactly one capture source: a URL argument, --doi, or --file.",
@@ -1009,13 +1015,23 @@ def capture_cmd(
         )
 
     if url:
+        # pdf AND markdown captures are stored by DT as on-disk files (.pdf /
+        # .md) — they index from the file (better fidelity than AI re-extract).
+        # html / webarchive captures are non-file-backed -> Layer D dt_content.
+        file_backed = capture_type.lower() in {"pdf", "markdown"}
         uuid = _dt.dt_capture_web_page(url, capture_type=capture_type)
-        file_backed = capture_type.lower() == "pdf"
         what = url
-    elif doi is not None:
+    elif doi:
         import os as _os  # noqa: PLC0415
 
         email = contact_email or _os.environ.get("OPENALEX_MAILTO", "")
+        if not email:
+            click.echo(
+                "Warning: no contact email (--contact-email / $OPENALEX_MAILTO); "
+                "Unpaywall open-access PDF discovery is disabled, CrossRef "
+                "metadata only.",
+                err=True,
+            )
         uuid = _dt.dt_download_pdf_from_doi(doi, contact_email=email)
         file_backed = True
         what = f"doi:{doi}"
@@ -1025,25 +1041,35 @@ def capture_cmd(
         what = file_path or ""
 
     if not uuid:
-        hint = (
-            " (no open-access PDF found for this DOI)" if doi is not None else ""
-        )
+        hint = " (no open-access PDF found for this DOI)" if doi else ""
         raise click.ClickException(f"capture failed for {what}{hint} — no record created.")
 
     click.echo(f"Captured {what} -> DEVONthink record {uuid}")
-    # Reuse the full index path. Non-file-backed captures (html/webarchive/
-    # markdown) route through Layer D's --dt-content; pdf/doi/file captures are
-    # file-backed and index normally (CA6 finding).
-    ctx.invoke(
-        index_cmd,
-        uuids=(uuid,),
-        collection=collection,
-        corpus=corpus,
-        dt_content=not file_backed,
-        link_semantic=link_semantic,
-        writeback=writeback,
-        highlights=highlights,
-    )
+    # Reuse the full index path. file_backed (pdf/markdown/doi/file) indexes
+    # from the on-disk file; non-file-backed (html/webarchive) routes through
+    # Layer D's --dt-content (CA6 finding).
+    try:
+        ctx.invoke(
+            index_cmd,
+            uuids=(uuid,),
+            collection=collection,
+            corpus=corpus,
+            dt_content=not file_backed,
+            link_semantic=link_semantic,
+            writeback=writeback,
+            highlights=highlights,
+            enrich=enrich,
+        )
+    except click.ClickException:
+        # Capture succeeded but indexing failed: the DT record exists but is
+        # un-indexed (no catalog entry, invisible to nx dt open / de-index).
+        # Surface the recovery path before propagating.
+        click.echo(
+            f"Note: DEVONthink record {uuid} was captured but indexing failed. "
+            f"Recover with: nx dt index --uuid {uuid}",
+            err=True,
+        )
+        raise
 
 
 # ── DT-side AppleScript installer (nexus-tv5u) ────────────────────────────────

--- a/src/nexus/mcp_client/devonthink.py
+++ b/src/nexus/mcp_client/devonthink.py
@@ -267,6 +267,70 @@ def dt_extract_mentions(uuid: str) -> str | None:
     return _dt_markdown_or_none(dt_call("extract_record_mentions", {"uuid": uuid}))
 
 
+def _uuid_from_capture_result(result: dict[str, Any] | None) -> str | None:
+    """Pull the new record's UUID from a capture/import/download result.
+
+    ``capture_web_page`` / ``import_file`` put ``uuid`` at the top level;
+    ``download_pdf_from_doi`` nests the imported record under ``record`` (or
+    ``imported``) and returns metadata-only (no UUID) when no PDF was found.
+    """
+    if not isinstance(result, dict):
+        return None
+    uuid = result.get("uuid")
+    if isinstance(uuid, str) and uuid:
+        return uuid
+    for key in ("record", "imported"):
+        nested = result.get(key)
+        if isinstance(nested, dict):
+            nuuid = nested.get("uuid")
+            if isinstance(nuuid, str) and nuuid:
+                return nuuid
+    return None
+
+
+def dt_capture_web_page(
+    url: str, *, capture_type: str = "webarchive", name: str | None = None,
+) -> str | None:
+    """Capture ``url`` into DEVONthink, returning the new record's UUID (Layer G).
+
+    ``capture_type`` is one of html/webarchive/markdown/pdf. ``None`` on failure
+    (fail-soft). PDF captures are file-backed; the others are not.
+    """
+    args: dict[str, Any] = {"url": url, "type": capture_type}
+    if name:
+        args["name"] = name
+    return _uuid_from_capture_result(dt_call("capture_web_page", args))
+
+
+def dt_download_pdf_from_doi(
+    doi: str, *, contact_email: str = "", name: str | None = None,
+) -> str | None:
+    """Resolve ``doi`` and download its open-access PDF into DEVONthink (Layer G).
+
+    Returns the imported record's UUID, or ``None`` when no open-access PDF was
+    found (metadata-only result) or DT is unavailable. ``contact_email`` enables
+    Unpaywall's PDF discovery (without it only CrossRef metadata is fetched).
+    """
+    if not doi:
+        return None
+    args: dict[str, Any] = {"doi": doi}
+    if contact_email:
+        args["contact_email"] = contact_email
+    if name:
+        args["name"] = name
+    return _uuid_from_capture_result(dt_call("download_pdf_from_doi", args))
+
+
+def dt_import_file(path: str, *, mode: str = "import") -> str | None:
+    """Import a loose file into DEVONthink, returning the new record's UUID (Layer G).
+
+    ``mode`` is import (copy in) or index (reference in place). ``None`` on failure.
+    """
+    if not path:
+        return None
+    return _uuid_from_capture_result(dt_call("import_file", {"path": path, "mode": mode}))
+
+
 def dt_set_tags(uuid: str, tags: list[str], *, mode: str = "add") -> bool:
     """Write tags onto a record (default additive). ``True`` on success (Layer F)."""
     if not tags:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -526,6 +526,7 @@ _MODE_LINT_EXCLUDE_FILES: frozenset[str] = frozenset({
     "test_dt_mcp_fallback.py",
     "test_document_highlights.py",
     "test_dt_highlights_layer_e.py",
+    "test_dt_capture_cmd.py",
     "test_migrations_rdr108_phase1c.py",
     "test_plan_run.py",
     "test_rdr_hook.py",  # tests/hooks/ — collection-name shape only

--- a/tests/test_dt_capture_cmd.py
+++ b/tests/test_dt_capture_cmd.py
@@ -76,7 +76,26 @@ def test_pdf_capture_is_file_backed(runner, monkeypatch) -> None:
     assert file_calls == ["PDF-UUID"]
 
 
-def test_doi_capture_downloads_pdf(runner, monkeypatch) -> None:
+def test_markdown_capture_is_file_backed(runner, monkeypatch) -> None:
+    """SIG-1: a markdown capture is stored by DT as a .md file -> index from the
+    file (file-backed), NOT the AI re-extract (dt_content) path."""
+    from nexus.cli import main
+    monkeypatch.setattr("nexus.mcp_client.devonthink.available", lambda **k: True)
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_capture_web_page",
+                        lambda url, **kw: "MD-UUID")
+    monkeypatch.setattr("nexus.commands.dt._gather_records",
+                        lambda **kw: [(kw["uuids"][0], "/captured.md")])
+    file_calls: list[str] = []
+    monkeypatch.setattr("nexus.commands.dt._index_record",
+                        lambda uuid, path, **kw: file_calls.append(uuid) or True)
+    monkeypatch.setattr("nexus.commands.dt._index_dt_content_record",
+                        lambda uuid, **kw: (_ for _ in ()).throw(AssertionError("markdown must not route to dt_content")))
+    result = runner.invoke(main, ["dt", "capture", "https://e.com", "--type", "markdown"])
+    assert result.exit_code == 0, result.output
+    assert file_calls == ["MD-UUID"]
+
+
+def test_doi_capture_downloads_pdf_and_indexes(runner, monkeypatch) -> None:
     from nexus.cli import main
     monkeypatch.setattr("nexus.mcp_client.devonthink.available", lambda **k: True)
     seen = {}
@@ -85,12 +104,52 @@ def test_doi_capture_downloads_pdf(runner, monkeypatch) -> None:
     monkeypatch.setattr("nexus.mcp_client.devonthink.dt_download_pdf_from_doi", _dl)
     monkeypatch.setattr("nexus.commands.dt._gather_records",
                         lambda **kw: [(kw["uuids"][0], "/p.pdf")])
+    indexed: list[str] = []
     monkeypatch.setattr("nexus.commands.dt._index_record",
-                        lambda uuid, path, **kw: True)
+                        lambda uuid, path, **kw: indexed.append(uuid) or True)
     result = runner.invoke(main, ["dt", "capture", "--doi", "10.1/x",
                                   "--contact-email", "me@x.co"])
     assert result.exit_code == 0, result.output
     assert seen == {"doi": "10.1/x", "email": "me@x.co"}
+    assert indexed == ["DOI-UUID"]  # the captured record was actually indexed
+
+
+def test_doi_without_email_warns(runner, monkeypatch) -> None:
+    from nexus.cli import main
+    monkeypatch.delenv("OPENALEX_MAILTO", raising=False)
+    monkeypatch.setattr("nexus.mcp_client.devonthink.available", lambda **k: True)
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_download_pdf_from_doi",
+                        lambda doi, **kw: "U")
+    monkeypatch.setattr("nexus.commands.dt._gather_records",
+                        lambda **kw: [(kw["uuids"][0], "/p.pdf")])
+    monkeypatch.setattr("nexus.commands.dt._index_record", lambda uuid, path, **kw: True)
+    result = runner.invoke(main, ["dt", "capture", "--doi", "10.1/x"])
+    assert result.exit_code == 0, result.output
+    assert "Unpaywall open-access PDF discovery is disabled" in result.output
+
+
+def test_empty_file_source_errors(runner, monkeypatch) -> None:
+    from nexus.cli import main
+    result = runner.invoke(main, ["dt", "capture", "--file", ""])
+    assert result.exit_code != 0
+    assert "exactly one capture source" in result.output
+
+
+def test_partial_failure_surfaces_recovery_hint(runner, monkeypatch) -> None:
+    """MEDIUM-4: capture succeeds but indexing fails -> recovery hint + non-zero."""
+    import click as _click
+    from nexus.cli import main
+    monkeypatch.setattr("nexus.mcp_client.devonthink.available", lambda **k: True)
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_capture_web_page",
+                        lambda url, **kw: "ORPHAN-UUID")
+
+    def _boom(**kw):
+        raise _click.ClickException("indexing blew up")
+    monkeypatch.setattr("nexus.commands.dt._gather_records", _boom)
+    result = runner.invoke(main, ["dt", "capture", "https://e.com"])
+    assert result.exit_code != 0
+    assert "ORPHAN-UUID was captured but indexing failed" in result.output
+    assert "nx dt index --uuid ORPHAN-UUID" in result.output
 
 
 def test_capture_failure_is_clean_error(runner, monkeypatch) -> None:

--- a/tests/test_dt_capture_cmd.py
+++ b/tests/test_dt_capture_cmd.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-139 Layer G — nx dt capture command.
+
+The one DT-bound verb: DT absent -> non-zero exit + DT-required message (NOT a
+silent no-op). DT present -> capture (web/doi/file) then index end to end.
+"""
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _force_darwin(monkeypatch):
+    # capture_cmd platform-gates on _is_darwin; pin True so CI (linux) exercises
+    # the real logic instead of the macOS-only early exit.
+    monkeypatch.setattr("nexus.commands.dt._is_darwin", lambda: True)
+
+
+def _patch_index(monkeypatch):
+    """Stub the index path so capture's ctx.invoke(index_cmd) runs without DT
+    selectors / real indexing. Returns (dt_content_calls, file_calls)."""
+    monkeypatch.setattr("nexus.commands.dt._gather_records",
+                        lambda **kw: [(kw["uuids"][0], "/captured.webarchive")])
+    dt_calls: list[str] = []
+    file_calls: list[str] = []
+    monkeypatch.setattr("nexus.commands.dt._index_dt_content_record",
+                        lambda uuid, **kw: dt_calls.append(uuid) or True)
+    monkeypatch.setattr("nexus.commands.dt._index_record",
+                        lambda uuid, path, **kw: file_calls.append(uuid) or True)
+    return dt_calls, file_calls
+
+
+def test_dt_absent_exits_nonzero_with_required_message(runner, monkeypatch) -> None:
+    monkeypatch.setattr("nexus.mcp_client.devonthink.available", lambda **k: False)
+    result = runner.invoke(__import__("nexus.cli", fromlist=["main"]).main,
+                           ["dt", "capture", "https://example.com"])
+    assert result.exit_code != 0
+    assert "requires DEVONthink" in result.output
+
+
+def test_webarchive_capture_routes_through_dt_content(runner, monkeypatch) -> None:
+    from nexus.cli import main
+    monkeypatch.setattr("nexus.mcp_client.devonthink.available", lambda **k: True)
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_capture_web_page",
+                        lambda url, **kw: "NEW-UUID")
+    dt_calls, file_calls = _patch_index(monkeypatch)
+    result = runner.invoke(main, ["dt", "capture", "https://example.com",
+                                  "--collection", "docs__t__voyage-context-3__v1"])
+    assert result.exit_code == 0, result.output
+    assert "Captured https://example.com -> DEVONthink record NEW-UUID" in result.output
+    assert dt_calls == ["NEW-UUID"]   # non-file-backed -> Layer D path
+    assert file_calls == []
+
+
+def test_pdf_capture_is_file_backed(runner, monkeypatch) -> None:
+    from nexus.cli import main
+    monkeypatch.setattr("nexus.mcp_client.devonthink.available", lambda **k: True)
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_capture_web_page",
+                        lambda url, **kw: "PDF-UUID")
+    # a pdf-typed capture is file-backed -> normal index path
+    monkeypatch.setattr("nexus.commands.dt._gather_records",
+                        lambda **kw: [(kw["uuids"][0], "/captured.pdf")])
+    file_calls: list[str] = []
+    monkeypatch.setattr("nexus.commands.dt._index_record",
+                        lambda uuid, path, **kw: file_calls.append(uuid) or True)
+    monkeypatch.setattr("nexus.commands.dt._index_dt_content_record",
+                        lambda uuid, **kw: (_ for _ in ()).throw(AssertionError("should not route to dt_content")))
+    result = runner.invoke(main, ["dt", "capture", "https://e.com", "--type", "pdf"])
+    assert result.exit_code == 0, result.output
+    assert file_calls == ["PDF-UUID"]
+
+
+def test_doi_capture_downloads_pdf(runner, monkeypatch) -> None:
+    from nexus.cli import main
+    monkeypatch.setattr("nexus.mcp_client.devonthink.available", lambda **k: True)
+    seen = {}
+    def _dl(doi, **kw):
+        seen["doi"] = doi; seen["email"] = kw.get("contact_email"); return "DOI-UUID"
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_download_pdf_from_doi", _dl)
+    monkeypatch.setattr("nexus.commands.dt._gather_records",
+                        lambda **kw: [(kw["uuids"][0], "/p.pdf")])
+    monkeypatch.setattr("nexus.commands.dt._index_record",
+                        lambda uuid, path, **kw: True)
+    result = runner.invoke(main, ["dt", "capture", "--doi", "10.1/x",
+                                  "--contact-email", "me@x.co"])
+    assert result.exit_code == 0, result.output
+    assert seen == {"doi": "10.1/x", "email": "me@x.co"}
+
+
+def test_capture_failure_is_clean_error(runner, monkeypatch) -> None:
+    from nexus.cli import main
+    monkeypatch.setattr("nexus.mcp_client.devonthink.available", lambda **k: True)
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_capture_web_page",
+                        lambda url, **kw: None)
+    result = runner.invoke(main, ["dt", "capture", "https://e.com"])
+    assert result.exit_code != 0
+    assert "capture failed" in result.output
+
+
+def test_doi_failure_hints_no_oa_pdf(runner, monkeypatch) -> None:
+    from nexus.cli import main
+    monkeypatch.setattr("nexus.mcp_client.devonthink.available", lambda **k: True)
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_download_pdf_from_doi",
+                        lambda doi, **kw: None)
+    result = runner.invoke(main, ["dt", "capture", "--doi", "10.1/x"])
+    assert result.exit_code != 0
+    assert "no open-access PDF" in result.output
+
+
+def test_no_source_errors(runner, monkeypatch) -> None:
+    from nexus.cli import main
+    result = runner.invoke(main, ["dt", "capture"])
+    assert result.exit_code != 0
+    assert "exactly one capture source" in result.output
+
+
+def test_two_sources_error(runner, monkeypatch) -> None:
+    from nexus.cli import main
+    result = runner.invoke(main, ["dt", "capture", "https://e.com", "--doi", "10.1/x"])
+    assert result.exit_code != 0
+    assert "exactly one capture source" in result.output

--- a/tests/test_dt_capture_helpers.py
+++ b/tests/test_dt_capture_helpers.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-139 Layer G — DT capture helpers (capture_web_page / download_pdf_from_doi
+/ import_file). Each returns the new record's UUID or None, fail-soft."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from nexus.mcp_client.devonthink import (
+    dt_capture_web_page,
+    dt_download_pdf_from_doi,
+    dt_import_file,
+)
+
+
+def test_capture_web_page_reads_top_level_uuid() -> None:
+    # CA6 live shape: a flat dict with uuid at top level.
+    with patch("nexus.mcp_client.devonthink.dt_call",
+               return_value={"uuid": "ABC-123", "type": "webarchive"}):
+        assert dt_capture_web_page("https://example.com") == "ABC-123"
+
+
+def test_capture_web_page_unavailable_is_none() -> None:
+    with patch("nexus.mcp_client.devonthink.dt_call", return_value=None):
+        assert dt_capture_web_page("https://example.com") is None
+
+
+def test_capture_web_page_no_uuid_is_none() -> None:
+    with patch("nexus.mcp_client.devonthink.dt_call", return_value={"error": "boom"}):
+        assert dt_capture_web_page("https://example.com") is None
+
+
+def test_download_pdf_reads_nested_record_uuid() -> None:
+    # download_pdf_from_doi returns "metadata and the imported record".
+    with patch("nexus.mcp_client.devonthink.dt_call",
+               return_value={"record": {"uuid": "PDF-9"}, "title": "X"}):
+        assert dt_download_pdf_from_doi("10.1/x", contact_email="a@b.co") == "PDF-9"
+
+
+def test_download_pdf_metadata_only_no_pdf_is_none() -> None:
+    # metadata-only (no open-access PDF) -> no imported record -> None
+    with patch("nexus.mcp_client.devonthink.dt_call",
+               return_value={"title": "X", "doi": "10.1/x"}):
+        assert dt_download_pdf_from_doi("10.1/x", contact_email="a@b.co") is None
+
+
+def test_import_file_reads_uuid() -> None:
+    with patch("nexus.mcp_client.devonthink.dt_call",
+               return_value={"uuid": "FILE-7"}):
+        assert dt_import_file("/tmp/x.pdf") == "FILE-7"
+
+
+def test_capture_passes_type_and_name() -> None:
+    with patch("nexus.mcp_client.devonthink.dt_call",
+               return_value={"uuid": "U"}) as m:
+        dt_capture_web_page("https://e.com", capture_type="pdf", name="My Page")
+    args = m.call_args.args
+    assert args[0] == "capture_web_page"
+    assert args[1]["url"] == "https://e.com"
+    assert args[1]["type"] == "pdf"
+    assert args[1]["name"] == "My Page"

--- a/tests/test_dt_mcp_fallback.py
+++ b/tests/test_dt_mcp_fallback.py
@@ -211,3 +211,19 @@ class TestLayerEFallback:
         from nexus.mcp_client.devonthink import dt_extract_mentions
         with patch("nexus.mcp_client.devonthink.dt_call", return_value=None):
             assert dt_extract_mentions("U") is None
+
+
+class TestLayerGException:
+    """Layer G (capture) is the DELIBERATE Gap-0 exception: unlike every other
+    layer (silent degrade, exit 0), nx dt capture fails LOUD when DT is absent
+    — non-zero exit + a DT-required message — because capture is impossible
+    without DEVONthink."""
+
+    def test_capture_exits_nonzero_when_dt_absent(self):
+        from click.testing import CliRunner
+        from nexus.cli import main
+        with patch("nexus.commands.dt._is_darwin", lambda: True), \
+             patch("nexus.mcp_client.devonthink.available", lambda **k: False):
+            result = CliRunner().invoke(main, ["dt", "capture", "https://example.com"])
+        assert result.exit_code != 0  # NOT a silent exit-0 no-op
+        assert "requires DEVONthink" in result.output


### PR DESCRIPTION
RDR-139 Phase 3, Layer G (`nexus-fdp5r`): `nx dt capture` — capture a URL, DOI, or file into DEVONthink and index it end to end, in one verb.

## What ships
- **`nx dt capture <url>`** — `capture_web_page` → DT record → index. `--type html|webarchive|markdown|pdf`.
- **`nx dt capture --doi <doi>`** — `download_pdf_from_doi` (Unpaywall open-access PDF; `--contact-email` / `$OPENALEX_MAILTO`).
- **`nx dt capture --file <path>`** — `import_file` for a loose file.
- Passthrough index opt-ins: `--link-semantic` (B), `--writeback` (F), `--highlights` (E), `--enrich` (C).
- The captured record is indexed via `ctx.invoke(index_cmd, ...)`. File-backed captures (pdf/markdown/doi/file) index from the on-disk file; html/webarchive route through Layer D `--dt-content` (CA6 finding).

## The one non-optional verb (Gap 0)
Unlike every other layer (silent degrade, exit 0), `nx dt capture` **fails loud** when DEVONthink is absent: non-zero exit + a DT-required message. Capture is impossible without DT, so it says so cleanly.

## Verification
- 92 unit tests green (capture command + helpers + dt regression + fallback + mode-lint).
- **CA6** (`nexus-e9qo0`, closed) verified live: `capture_web_page` returns a flat dict with top-level `uuid`; the captured record indexes and joins via `catalog.by_source_uri`.
- Stacked review (both reviewers): markdown routing bug (file-backed) fixed, partial-failure recovery hint added, empty-source + no-email UX fixed, `--enrich` forwarded. 0 critical.
- **Live wrapped-command MVV**: `nx dt capture https://example.com --writeback` ran capture → index → catalog join (tumbler `1.12.42`) → write-back clean end to end; artifacts cleaned up. Details in T2 `139-layer-g-review-mvv-2026-05-30`.

Part of epic `nexus-james`, Phase 3 parent `nexus-ubmed`. Remaining Phase 3: Layer A′ (`nexus-jvlcn`), then P3.5 fallback + P3.6 closeout.