### PR TITLE
feat(rdr-139): Layer A' — nx-mcp-devonthink agent-surface MCP server (P3.4)

### DIFF
--- a/conexus/.mcp.json
+++ b/conexus/.mcp.json
@@ -19,5 +19,13 @@
       "CLAUDE_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}"
     },
     "alwaysLoad": true
+  },
+  "devonthink": {
+    "command": "nx-mcp-devonthink",
+    "args": [],
+    "env": {
+      "CLAUDE_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}"
+    },
+    "alwaysLoad": false
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ Documentation = "https://github.com/Hellblazer/nexus/tree/main/docs"
 nx = "nexus.cli:main"
 nx-mcp = "nexus.mcp.core:main"
 nx-mcp-catalog = "nexus.mcp.catalog:main"
+nx-mcp-devonthink = "nexus.mcp.devonthink:main"
 nx-session-end-launcher = "nexus._session_end_launcher:main"
 
 [tool.hatch.build.targets.wheel]

--- a/src/nexus/mcp/devonthink.py
+++ b/src/nexus/mcp/devonthink.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""``nx-mcp-devonthink`` — agent-surface MCP server for DEVONthink (RDR-139 Layer A').
+
+A nexus-owned MCP *server* (third sibling to ``nx-mcp`` / ``nx-mcp-catalog``)
+that is simultaneously an MCP *client* to DEVONthink's built-in server via the
+Layer A core. It is the answer to "how does a Claude Code agent reach DT" that
+declaring DT's own binary cannot give: because this wrapper is nexus code that
+ships with the package, it **always spawns successfully** on every consumer
+(DT present or not) and gates internally.
+
+**Optionality is the internal gate, not ``.mcp.json``.** On startup
+:func:`main` probes :func:`nexus.mcp_client.devonthink.available`; the curated
+DT toolset is registered only when DT is reachable. DT absent → only the
+always-present ``devonthink_status`` stub is advertised, the process still
+exits 0, and no spawn error reaches a DT-less consumer. The ``.mcp.json``
+``alwaysLoad: false`` is purely a tool-search startup-cost optimisation; the
+wrapper is equally optionality-correct with ``alwaysLoad: true`` (asserted by
+``test_layer_a_prime_wrapper``).
+
+**Async bridging.** MCP tool handlers run inside the server's event loop, so
+they must NOT call the Layer A sync helpers (``dt_call`` → ``asyncio.run``,
+which raises inside a running loop — the very hazard Layer A's running-loop
+guard defends). Pure proxies therefore call DT through the async core
+(:func:`_dt_proxy`); the ``dt_incorporate`` composite runs the sync Layer B/F
+functions via :func:`asyncio.to_thread` (a worker thread has no running loop,
+so their internal ``asyncio.run`` is safe).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from nexus.mcp_client.core import MCPEndpoint, call_tool, open_session
+from nexus.mcp_client.devonthink import dt_mcp_url
+
+
+async def _dt_proxy(tool: str, args: dict[str, Any]) -> str:
+    """Forward one call to DEVONthink's built-in MCP server, async-native.
+
+    Returns the result as a JSON string, or a structured error string when DT
+    is unreachable / the call fails. Never raises (fail-soft, like Layer A).
+    """
+    endpoint = MCPEndpoint(url=dt_mcp_url())
+    try:
+        async with open_session(endpoint) as session:
+            result = await call_tool(session, tool, args)
+    except Exception as exc:  # transport / connect failure
+        return json.dumps({"error": f"DEVONthink call failed: {type(exc).__name__}: {exc}", "tool": tool})
+    if result is None:
+        return json.dumps({"error": "DEVONthink returned no result (unavailable or excluded)", "tool": tool})
+    return json.dumps(result)
+
+
+def _incorporate_sync(uuid: str) -> dict[str, Any]:
+    """Layer B + F composite for one already-indexed record (sync; runs off-loop).
+
+    Resolves the record's tumbler (it must already be indexed in nexus), then
+    generates DT-derived ``relates`` edges (Layer B) and stamps the nexus
+    identity back onto the DT record (Layer F). Returns a structured summary.
+    """
+    from nexus.catalog.catalog import Catalog  # noqa: PLC0415
+    from nexus.catalog.dt_link_generator import generate_dt_links  # noqa: PLC0415
+    from nexus.config import catalog_path  # noqa: PLC0415
+    from nexus.dt_writeback import writeback_record  # noqa: PLC0415
+
+    cp = catalog_path()
+    if not Catalog.is_initialized(cp):
+        return {"error": "nexus catalog is not initialized"}
+    cat = Catalog(cp, cp / ".catalog.db")
+    try:
+        entry = cat.by_source_uri(f"x-devonthink-item://{uuid}")
+        if entry is None:
+            return {
+                "error": "record is not indexed in nexus; run "
+                "`nx dt index --uuid <uuid>` (or capture) first",
+                "uuid": uuid,
+            }
+        tumbler = entry.tumbler
+        links = generate_dt_links(cat, tumbler, uuid)
+        writeback = writeback_record(uuid, str(tumbler))
+        return {"tumbler": str(tumbler), "links": links, "writeback": writeback}
+    finally:
+        cat._db.close()
+
+
+# ── Tool handlers (registered conditionally by build_server) ─────────────────
+
+async def devonthink_status() -> str:
+    """Report whether DEVONthink is reachable and which databases are open.
+
+    The one always-advertised tool: present even when DT is absent so a DT-less
+    agent gets a clean status answer instead of a missing server.
+    """
+    endpoint = MCPEndpoint(url=dt_mcp_url())
+    try:
+        async with open_session(endpoint) as session:
+            running = await call_tool(session, "is_running", {})
+            dbs = await call_tool(session, "get_databases", {})
+    except Exception as exc:
+        return json.dumps({"available": False, "reason": f"{type(exc).__name__}: {exc}"})
+    available = bool(running) and bool(running.get("running"))
+    n_dbs = len(dbs.get("result", dbs)) if isinstance(dbs, dict) else 0
+    return json.dumps({"available": available, "databases": n_dbs})
+
+
+async def search_records(query: str, limit: int = 20, kind: str = "") -> str:
+    """Search DEVONthink with its query syntax (kind:, tags:, name:, etc.). Returns brief hits."""
+    args: dict[str, Any] = {"query": query, "limit": limit}
+    if kind:
+        args["query"] = f"{query} kind:{kind}"
+    return await _dt_proxy("search_records", args)
+
+
+async def lookup_records(name: str = "", url: str = "", path: str = "", comment: str = "") -> str:
+    """Look up records by exact name / URL / path / comment (dedupe before capture)."""
+    args = {k: v for k, v in {"name": name, "url": url, "path": path, "comment": comment}.items() if v}
+    return await _dt_proxy("lookup_records", args)
+
+
+async def get_record_text(uuid: str) -> str:
+    """Get a record's plain-text body."""
+    return await _dt_proxy("get_record_text", {"uuid": uuid})
+
+
+async def get_record_properties(uuid: str) -> str:
+    """Get a record's metadata, dates, and metrics."""
+    return await _dt_proxy("get_record_properties", {"uuid": uuid})
+
+
+async def get_record_children(uuid: str) -> str:
+    """List the children of a group / smart group record."""
+    return await _dt_proxy("get_record_children", {"uuid": uuid})
+
+
+async def find_similar_records(uuid: str, limit: int = 25) -> str:
+    """Find records DEVONthink's AI considers similar to this one ('See Also')."""
+    return await _dt_proxy("find_similar_records", {"mode": "record", "uuid": uuid, "limit": limit})
+
+
+async def classify_record(uuid: str) -> str:
+    """Get DEVONthink AI's suggested groups for a record (organizational hint)."""
+    return await _dt_proxy("classify_record", {"uuid": uuid})
+
+
+async def extract_record_content(uuid: str) -> str:
+    """Get a record's AI-optimised text content (for non-file-backed records)."""
+    return await _dt_proxy("extract_record_content", {"uuid": uuid})
+
+
+async def extract_record_highlights(uuid: str) -> str:
+    """Get a markdown summary of a record's highlights / annotations."""
+    return await _dt_proxy("extract_record_highlights", {"uuid": uuid})
+
+
+async def extract_record_mentions(uuid: str) -> str:
+    """Get a markdown summary of a record's mentions."""
+    return await _dt_proxy("extract_record_mentions", {"uuid": uuid})
+
+
+async def resolve_doi_metadata(doi: str) -> str:
+    """Resolve a DOI to CrossRef bibliographic metadata."""
+    return await _dt_proxy("resolve_doi_metadata", {"doi": doi})
+
+
+async def search_crossref(query: str, limit: int = 20) -> str:
+    """Search CrossRef for scholarly works by free-text query (discovery only)."""
+    return await _dt_proxy("search_crossref", {"query": query, "limit": limit})
+
+
+async def resolve_google_books_metadata(isbn: str = "", query: str = "") -> str:
+    """Resolve an ISBN (or title query) to Google Books bibliographic metadata."""
+    args = {k: v for k, v in {"isbn": isbn, "query": query}.items() if v}
+    return await _dt_proxy("resolve_google_books_metadata", args)
+
+
+async def capture_web_page(url: str, type: str = "webarchive") -> str:
+    """Capture a URL into DEVONthink (html/webarchive/markdown/pdf). Returns the new record."""
+    return await _dt_proxy("capture_web_page", {"url": url, "type": type})
+
+
+async def download_pdf_from_doi(doi: str, contact_email: str = "") -> str:
+    """Resolve a DOI and download its open-access PDF into DEVONthink (Unpaywall)."""
+    args: dict[str, Any] = {"doi": doi}
+    if contact_email:
+        args["contact_email"] = contact_email
+    return await _dt_proxy("download_pdf_from_doi", args)
+
+
+async def import_file(path: str, mode: str = "import") -> str:
+    """Import (copy in) or index (reference in place) a loose file into DEVONthink."""
+    return await _dt_proxy("import_file", {"path": path, "mode": mode})
+
+
+async def get_databases() -> str:
+    """List the open DEVONthink databases."""
+    return await _dt_proxy("get_databases", {})
+
+
+async def get_record_links(uuid: str) -> str:
+    """Get a record's deliberate item links (both directions)."""
+    return await _dt_proxy("get_record_links", {"uuid": uuid, "direction": "both", "kind": "item"})
+
+
+async def dt_incorporate(uuid: str) -> str:
+    """Incorporate an already-indexed DT record into the nexus graph (Layer B + F).
+
+    Composite: resolves the record's tumbler, creates 'relates' edges to its
+    DEVONthink similarity + explicit-link neighbours that are also indexed in
+    nexus (Layer B), and stamps the nexus identity back onto the DT record
+    (Layer F: nx-indexed / nx-tumbler tags + tumbler backlink annotation). The
+    record must already be indexed (run ``nx dt index`` / capture first).
+    """
+    result = await asyncio.to_thread(_incorporate_sync, uuid)
+    return json.dumps(result)
+
+
+#: The curated DT toolset advertised only when DEVONthink is reachable.
+#: ``devonthink_status`` is excluded here — it is registered unconditionally.
+_DT_TOOLS = (
+    search_records, lookup_records, get_record_text, get_record_properties,
+    get_record_children, find_similar_records, classify_record,
+    extract_record_content, extract_record_highlights, extract_record_mentions,
+    resolve_doi_metadata, search_crossref, resolve_google_books_metadata,
+    capture_web_page, download_pdf_from_doi, import_file, get_databases,
+    get_record_links, dt_incorporate,
+)
+
+
+def build_server(*, available: bool) -> FastMCP:
+    """Construct the FastMCP server, registering tools per the DT-availability gate.
+
+    ``available=False`` -> only ``devonthink_status`` (the harmless always-present
+    stub). ``available=True`` -> ``devonthink_status`` + the full curated surface
+    (:data:`_DT_TOOLS`). This factory is the load-bearing optionality mechanism;
+    the registered tool count is asserted by the Phase-3 alwaysLoad-independence
+    test, independent of any ``.mcp.json`` value.
+    """
+    mcp = FastMCP("nexus-devonthink")
+    mcp.add_tool(devonthink_status)
+    if available:
+        for fn in _DT_TOOLS:
+            mcp.add_tool(fn)
+    return mcp
+
+
+def main() -> None:
+    """Run the DEVONthink agent-surface MCP server on stdio (RDR-139 Layer A')."""
+    import os  # noqa: PLC0415
+
+    import structlog  # noqa: PLC0415
+
+    from nexus.logging_setup import configure_logging  # noqa: PLC0415
+    from nexus.mcp._first_run import ensure_installed_and_running  # noqa: PLC0415
+    from nexus.mcp_client.devonthink import available  # noqa: PLC0415
+
+    configure_logging("mcp")
+    log = structlog.get_logger("nexus.mcp.devonthink")
+    # Probe the gate in main() — no running loop here, so the sync available()
+    # (asyncio.run-backed) is safe; the result decides the advertised surface.
+    dt_available = available()
+    log.info(
+        "mcp_server_starting",
+        server="nx-mcp-devonthink",
+        transport="stdio",
+        devonthink_available=dt_available,
+        pid=os.getpid(),
+        ppid=os.getppid(),
+    )
+    ensure_installed_and_running()
+    mcp = build_server(available=dt_available)
+    try:
+        mcp.run(transport="stdio")
+    except (KeyboardInterrupt, SystemExit):
+        log.info("mcp_server_stopping", server="nx-mcp-devonthink", reason="signal")
+        raise
+    except BaseException as exc:
+        log.exception(
+            "mcp_server_crashed",
+            server="nx-mcp-devonthink",
+            error=f"{type(exc).__name__}: {exc}",
+        )
+        raise
+    else:
+        log.info("mcp_server_stopping", server="nx-mcp-devonthink", reason="exit")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nexus/mcp/devonthink.py
+++ b/src/nexus/mcp/devonthink.py
@@ -37,6 +37,12 @@ from mcp.server.fastmcp import FastMCP
 from nexus.mcp_client.core import MCPEndpoint, call_tool, open_session
 from nexus.mcp_client.devonthink import dt_mcp_url
 
+#: Whether the curated DT surface was registered at startup. Set by
+#: :func:`build_server`. The availability gate is probed ONCE at startup, so a
+#: server that started before DEVONthink launched advertises only the stub for
+#: its lifetime; ``devonthink_status`` surfaces a restart hint in that case.
+_STARTED_WITH_DT: bool = False
+
 
 async def _dt_proxy(tool: str, args: dict[str, Any]) -> str:
     """Forward one call to DEVONthink's built-in MCP server, async-native.
@@ -70,8 +76,9 @@ def _incorporate_sync(uuid: str) -> dict[str, Any]:
     cp = catalog_path()
     if not Catalog.is_initialized(cp):
         return {"error": "nexus catalog is not initialized"}
-    cat = Catalog(cp, cp / ".catalog.db")
+    cat = None
     try:
+        cat = Catalog(cp, cp / ".catalog.db")
         entry = cat.by_source_uri(f"x-devonthink-item://{uuid}")
         if entry is None:
             return {
@@ -84,7 +91,8 @@ def _incorporate_sync(uuid: str) -> dict[str, Any]:
         writeback = writeback_record(uuid, str(tumbler))
         return {"tumbler": str(tumbler), "links": links, "writeback": writeback}
     finally:
-        cat._db.close()
+        if cat is not None:
+            cat._db.close()
 
 
 # ── Tool handlers (registered conditionally by build_server) ─────────────────
@@ -103,37 +111,30 @@ async def devonthink_status() -> str:
     except Exception as exc:
         return json.dumps({"available": False, "reason": f"{type(exc).__name__}: {exc}"})
     available = bool(running) and bool(running.get("running"))
-    n_dbs = len(dbs.get("result", dbs)) if isinstance(dbs, dict) else 0
-    return json.dumps({"available": available, "databases": n_dbs})
-
-
-async def search_records(query: str, limit: int = 20, kind: str = "") -> str:
-    """Search DEVONthink with its query syntax (kind:, tags:, name:, etc.). Returns brief hits."""
-    args: dict[str, Any] = {"query": query, "limit": limit}
-    if kind:
-        args["query"] = f"{query} kind:{kind}"
-    return await _dt_proxy("search_records", args)
-
-
-async def lookup_records(name: str = "", url: str = "", path: str = "", comment: str = "") -> str:
-    """Look up records by exact name / URL / path / comment (dedupe before capture)."""
-    args = {k: v for k, v in {"name": name, "url": url, "path": path, "comment": comment}.items() if v}
-    return await _dt_proxy("lookup_records", args)
+    dbs_payload = dbs.get("result", dbs) if isinstance(dbs, dict) else dbs
+    n_dbs = len(dbs_payload) if isinstance(dbs_payload, list) else 0
+    status: dict[str, Any] = {"available": available, "databases": n_dbs}
+    # Startup-only gate: if DT is reachable NOW but the curated surface was not
+    # registered at startup (server started before DT launched), the DT tools
+    # are absent until restart. Surface that so the agent isn't confused.
+    if available and not _STARTED_WITH_DT:
+        status["restart_required"] = True
+        status["note"] = (
+            "DEVONthink is reachable but this server started before it was "
+            "available, so the DT tools are not registered. Restart "
+            "nx-mcp-devonthink to advertise the full surface."
+        )
+    return json.dumps(status)
 
 
 async def get_record_text(uuid: str) -> str:
-    """Get a record's plain-text body."""
+    """Get a record's plain-text body (content read; UUID comes from a nexus search)."""
     return await _dt_proxy("get_record_text", {"uuid": uuid})
 
 
-async def get_record_properties(uuid: str) -> str:
-    """Get a record's metadata, dates, and metrics."""
-    return await _dt_proxy("get_record_properties", {"uuid": uuid})
-
-
-async def get_record_children(uuid: str) -> str:
-    """List the children of a group / smart group record."""
-    return await _dt_proxy("get_record_children", {"uuid": uuid})
+async def get_record_annotation(uuid: str) -> str:
+    """Get the UUID of a record's annotation note (read with get_record_text)."""
+    return await _dt_proxy("get_record_annotation", {"uuid": uuid})
 
 
 async def find_similar_records(uuid: str, limit: int = 25) -> str:
@@ -177,9 +178,9 @@ async def resolve_google_books_metadata(isbn: str = "", query: str = "") -> str:
     return await _dt_proxy("resolve_google_books_metadata", args)
 
 
-async def capture_web_page(url: str, type: str = "webarchive") -> str:
+async def capture_web_page(url: str, capture_type: str = "webarchive") -> str:
     """Capture a URL into DEVONthink (html/webarchive/markdown/pdf). Returns the new record."""
-    return await _dt_proxy("capture_web_page", {"url": url, "type": type})
+    return await _dt_proxy("capture_web_page", {"url": url, "type": capture_type})
 
 
 async def download_pdf_from_doi(doi: str, contact_email: str = "") -> str:
@@ -220,9 +221,18 @@ async def dt_incorporate(uuid: str) -> str:
 
 #: The curated DT toolset advertised only when DEVONthink is reachable.
 #: ``devonthink_status`` is excluded here — it is registered unconditionally.
+#:
+#: Curation respects the RDR's "Explicitly out of scope" boundary: DT's own
+#: SELECTORS / CRUD (search_records, lookup_records, get_record_properties,
+#: get_selected_records, get_current_record, open_record, group/parent walks,
+#: versions) and file-management verbs (move/trash/duplicate/merge/convert/
+#: export) stay on osascript and are NOT exposed here. The agent's DT entry
+#: point is a record UUID obtained from a NEXUS search (the indexed corpus),
+#: after which it uses these AI / content / bib / capture / link tools and the
+#: dt_incorporate composite. (Code review found the selectors had slipped in;
+#: removed.)
 _DT_TOOLS = (
-    search_records, lookup_records, get_record_text, get_record_properties,
-    get_record_children, find_similar_records, classify_record,
+    get_record_text, get_record_annotation, find_similar_records, classify_record,
     extract_record_content, extract_record_highlights, extract_record_mentions,
     resolve_doi_metadata, search_crossref, resolve_google_books_metadata,
     capture_web_page, download_pdf_from_doi, import_file, get_databases,
@@ -239,6 +249,8 @@ def build_server(*, available: bool) -> FastMCP:
     the registered tool count is asserted by the Phase-3 alwaysLoad-independence
     test, independent of any ``.mcp.json`` value.
     """
+    global _STARTED_WITH_DT
+    _STARTED_WITH_DT = available
     mcp = FastMCP("nexus-devonthink")
     mcp.add_tool(devonthink_status)
     if available:

--- a/src/nexus/mcp_client/core.py
+++ b/src/nexus/mcp_client/core.py
@@ -145,11 +145,16 @@ async def open_session(endpoint: MCPEndpoint) -> AsyncIterator[Any]:
         headers=dict(endpoint.headers) or None,
         timeout=httpx.Timeout(endpoint.timeout_s),
     )
-    async with streamable_http_client(endpoint.url, http_client=http_client) as (
-        read_stream,
-        write_stream,
-        _get_session_id,
-    ):
-        async with ClientSession(read_stream, write_stream) as session:
-            await session.initialize()
-            yield session
+    # ``streamable_http_client`` does NOT own a caller-provided client's
+    # lifecycle (it skips its own ``aclose`` when ``http_client`` is passed in).
+    # Close it ourselves so the long-running Layer A' server does not leak one
+    # AsyncClient + connection pool per call (RDR-139 Layer A' code review).
+    async with http_client:
+        async with streamable_http_client(endpoint.url, http_client=http_client) as (
+            read_stream,
+            write_stream,
+            _get_session_id,
+        ):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                yield session

--- a/tests/test_mcp_devonthink_server.py
+++ b/tests/test_mcp_devonthink_server.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-139 Layer A' — nx-mcp-devonthink agent-surface MCP server.
+
+The optionality is the internal available() gate, not .mcp.json: with DT absent
+the server still builds and advertises only the devonthink_status stub (zero DT
+tools); with DT present it advertises the full curated surface. This is the
+alwaysLoad-independence contract the RDR mandates a test for.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+from nexus.mcp import devonthink as srv
+
+
+def _tool_names(mcp) -> set[str]:
+    return {t.name for t in mcp._tool_manager.list_tools()}
+
+
+# ── The gate: zero DT tools when DT absent, full surface when present ────────
+
+def test_zero_dt_tools_when_unavailable() -> None:
+    mcp = srv.build_server(available=False)
+    names = _tool_names(mcp)
+    assert names == {"devonthink_status"}  # the stub only, no spawn error
+
+
+def test_full_curated_surface_when_available() -> None:
+    mcp = srv.build_server(available=True)
+    names = _tool_names(mcp)
+    # ~20 curated tools: status + the 19 DT tools/composites.
+    assert len(names) == 20
+    assert "devonthink_status" in names
+    # spot-check the curated set across categories
+    for expected in (
+        "search_records", "get_record_text", "find_similar_records",
+        "extract_record_content", "resolve_doi_metadata", "capture_web_page",
+        "download_pdf_from_doi", "import_file", "get_databases", "dt_incorporate",
+    ):
+        assert expected in names, f"missing curated tool {expected}"
+    # out-of-scope file-management verbs are NOT exposed
+    for banned in ("move_record", "trash_record", "merge_records", "duplicate_record"):
+        assert banned not in names
+
+
+def test_status_always_present_independent_of_gate() -> None:
+    assert "devonthink_status" in _tool_names(srv.build_server(available=False))
+    assert "devonthink_status" in _tool_names(srv.build_server(available=True))
+
+
+# ── Proxies forward to DT via the async core ────────────────────────────────
+
+def test_search_records_proxies() -> None:
+    with patch.object(srv, "_dt_proxy", new=AsyncMock(return_value="{}")) as m:
+        asyncio.run(srv.search_records("memory systems", limit=5))
+    m.assert_awaited_once_with("search_records", {"query": "memory systems", "limit": 5})
+
+
+def test_search_records_kind_filter_merges_into_query() -> None:
+    with patch.object(srv, "_dt_proxy", new=AsyncMock(return_value="{}")) as m:
+        asyncio.run(srv.search_records("x", kind="pdf"))
+    assert m.await_args.args[1]["query"] == "x kind:pdf"
+
+
+def test_get_record_text_proxies() -> None:
+    with patch.object(srv, "_dt_proxy", new=AsyncMock(return_value="{}")) as m:
+        asyncio.run(srv.get_record_text("U1"))
+    m.assert_awaited_once_with("get_record_text", {"uuid": "U1"})
+
+
+def test_find_similar_proxies_record_mode() -> None:
+    with patch.object(srv, "_dt_proxy", new=AsyncMock(return_value="{}")) as m:
+        asyncio.run(srv.find_similar_records("U1", limit=10))
+    m.assert_awaited_once_with(
+        "find_similar_records", {"mode": "record", "uuid": "U1", "limit": 10})
+
+
+# ── _dt_proxy fail-soft ─────────────────────────────────────────────────────
+
+def test_dt_proxy_returns_error_json_on_transport_failure() -> None:
+    def _boom(_endpoint):
+        raise ConnectionError("refused")
+    with patch.object(srv, "open_session", _boom):
+        out = asyncio.run(srv._dt_proxy("search_records", {"query": "x"}))
+    payload = json.loads(out)
+    assert "error" in payload and payload["tool"] == "search_records"
+
+
+# ── dt_incorporate composite ────────────────────────────────────────────────
+
+def test_incorporate_runs_layer_b_and_f() -> None:
+    fake = {"tumbler": "1.2.3", "links": {"similar": 1, "link": 0},
+            "writeback": {"tags": True, "annotation": True, "metadata": False, "skipped": False}}
+    with patch.object(srv, "_incorporate_sync", return_value=fake):
+        out = asyncio.run(srv.dt_incorporate("U1"))
+    assert json.loads(out) == fake
+
+
+def test_incorporate_unindexed_record_returns_error() -> None:
+    fake = {"error": "record is not indexed in nexus; run "
+            "`nx dt index --uuid <uuid>` (or capture) first", "uuid": "U1"}
+    with patch.object(srv, "_incorporate_sync", return_value=fake):
+        out = asyncio.run(srv.dt_incorporate("U1"))
+    assert "not indexed" in json.loads(out)["error"]
+
+
+# ── main() probes the gate and builds accordingly ───────────────────────────
+
+def test_main_builds_with_zero_tools_when_dt_absent() -> None:
+    built = {}
+
+    def _capture(*, available):
+        built["available"] = available
+        mcp = srv.FastMCP("probe")
+        mcp.add_tool(srv.devonthink_status)
+        mcp.run = lambda **kw: None  # don't actually serve
+        return mcp
+
+    with patch("nexus.mcp_client.devonthink.available", return_value=False), \
+         patch("nexus.mcp._first_run.ensure_installed_and_running", lambda: None), \
+         patch.object(srv, "build_server", _capture):
+        srv.main()
+    assert built["available"] is False

--- a/tests/test_mcp_devonthink_server.py
+++ b/tests/test_mcp_devonthink_server.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from nexus.mcp import devonthink as srv
 
@@ -30,19 +30,26 @@ def test_zero_dt_tools_when_unavailable() -> None:
 def test_full_curated_surface_when_available() -> None:
     mcp = srv.build_server(available=True)
     names = _tool_names(mcp)
-    # ~20 curated tools: status + the 19 DT tools/composites.
-    assert len(names) == 20
+    # Curated surface = status + 16 in-scope DT tools/composites.
+    assert len(names) == 17
     assert "devonthink_status" in names
-    # spot-check the curated set across categories
+    # spot-check the in-scope set across categories
     for expected in (
-        "search_records", "get_record_text", "find_similar_records",
-        "extract_record_content", "resolve_doi_metadata", "capture_web_page",
-        "download_pdf_from_doi", "import_file", "get_databases", "dt_incorporate",
+        "get_record_text", "find_similar_records", "classify_record",
+        "extract_record_content", "extract_record_highlights",
+        "resolve_doi_metadata", "search_crossref", "capture_web_page",
+        "download_pdf_from_doi", "import_file", "get_databases",
+        "get_record_links", "dt_incorporate",
     ):
         assert expected in names, f"missing curated tool {expected}"
-    # out-of-scope file-management verbs are NOT exposed
-    for banned in ("move_record", "trash_record", "merge_records", "duplicate_record"):
-        assert banned not in names
+    # RDR "Explicitly out of scope": DT selectors/CRUD stay on osascript and are
+    # NOT exposed on the agent surface.
+    for banned in (
+        "search_records", "lookup_records", "get_record_properties",
+        "get_record_children", "get_selected_records", "open_record",
+        "move_record", "trash_record", "merge_records", "duplicate_record",
+    ):
+        assert banned not in names, f"out-of-scope tool {banned} must not be exposed"
 
 
 def test_status_always_present_independent_of_gate() -> None:
@@ -52,22 +59,17 @@ def test_status_always_present_independent_of_gate() -> None:
 
 # ── Proxies forward to DT via the async core ────────────────────────────────
 
-def test_search_records_proxies() -> None:
-    with patch.object(srv, "_dt_proxy", new=AsyncMock(return_value="{}")) as m:
-        asyncio.run(srv.search_records("memory systems", limit=5))
-    m.assert_awaited_once_with("search_records", {"query": "memory systems", "limit": 5})
-
-
-def test_search_records_kind_filter_merges_into_query() -> None:
-    with patch.object(srv, "_dt_proxy", new=AsyncMock(return_value="{}")) as m:
-        asyncio.run(srv.search_records("x", kind="pdf"))
-    assert m.await_args.args[1]["query"] == "x kind:pdf"
-
-
 def test_get_record_text_proxies() -> None:
-    with patch.object(srv, "_dt_proxy", new=AsyncMock(return_value="{}")) as m:
-        asyncio.run(srv.get_record_text("U1"))
+    with patch.object(srv, "_dt_proxy", new=AsyncMock(return_value='{"text":"x"}')) as m:
+        out = asyncio.run(srv.get_record_text("U1"))
     m.assert_awaited_once_with("get_record_text", {"uuid": "U1"})
+    assert out == '{"text":"x"}'  # the proxy's return flows back to the caller
+
+
+def test_resolve_doi_proxies() -> None:
+    with patch.object(srv, "_dt_proxy", new=AsyncMock(return_value="{}")) as m:
+        asyncio.run(srv.resolve_doi_metadata("10.1/x"))
+    m.assert_awaited_once_with("resolve_doi_metadata", {"doi": "10.1/x"})
 
 
 def test_find_similar_proxies_record_mode() -> None:
@@ -104,6 +106,60 @@ def test_incorporate_unindexed_record_returns_error() -> None:
     with patch.object(srv, "_incorporate_sync", return_value=fake):
         out = asyncio.run(srv.dt_incorporate("U1"))
     assert "not indexed" in json.loads(out)["error"]
+
+
+def test_incorporate_sync_unindexed_returns_error(tmp_path, monkeypatch) -> None:
+    """SIG-3: exercise _incorporate_sync's real body (catalog routing), not a
+    mock of the whole function. An unindexed UUID -> structured error, no
+    Layer B/F calls, and the catalog connection is closed."""
+    cat = MagicMock()
+    cat.by_source_uri.return_value = None
+    cat._db = MagicMock()
+    CatalogMock = MagicMock(return_value=cat)
+    CatalogMock.is_initialized = staticmethod(lambda p: True)
+    monkeypatch.setattr("nexus.catalog.catalog.Catalog", CatalogMock)
+    monkeypatch.setattr("nexus.config.catalog_path", lambda: tmp_path)
+    called = {"links": False, "wb": False}
+    monkeypatch.setattr("nexus.catalog.dt_link_generator.generate_dt_links",
+                        lambda *a, **k: called.__setitem__("links", True))
+    monkeypatch.setattr("nexus.dt_writeback.writeback_record",
+                        lambda *a, **k: called.__setitem__("wb", True))
+    out = srv._incorporate_sync("NO-SUCH-UUID")
+    assert "not indexed" in out["error"]
+    assert called == {"links": False, "wb": False}  # never reached Layer B/F
+    cat._db.close.assert_called_once()  # connection released even on the error path
+
+
+def test_incorporate_sync_uninitialized_catalog(tmp_path, monkeypatch) -> None:
+    CatalogMock = MagicMock()
+    CatalogMock.is_initialized = staticmethod(lambda p: False)
+    monkeypatch.setattr("nexus.catalog.catalog.Catalog", CatalogMock)
+    monkeypatch.setattr("nexus.config.catalog_path", lambda: tmp_path)
+    out = srv._incorporate_sync("U1")
+    assert "not initialized" in out["error"]
+
+
+def test_status_restart_hint_when_started_without_dt(monkeypatch) -> None:
+    """SIG-2: a server started before DT launched advertises only the stub;
+    devonthink_status surfaces a restart hint once DT becomes reachable."""
+    srv.build_server(available=False)  # sets _STARTED_WITH_DT = False
+
+    async def _fake_call(session, tool, args):
+        return {"running": True} if tool == "is_running" else {"result": [1, 2]}
+
+    class _FakeSession:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+
+    import contextlib
+    @contextlib.asynccontextmanager
+    async def _fake_open(endpoint):
+        yield object()
+    monkeypatch.setattr(srv, "open_session", _fake_open)
+    monkeypatch.setattr(srv, "call_tool", _fake_call)
+    out = json.loads(asyncio.run(srv.devonthink_status()))
+    assert out["available"] is True
+    assert out.get("restart_required") is True
 
 
 # ── main() probes the gate and builds accordingly ───────────────────────────

--- a/tests/test_mcp_package.py
+++ b/tests/test_mcp_package.py
@@ -113,6 +113,36 @@ def test_catalog_has_main():
     assert callable(main)
 
 
+def test_devonthink_module_importable():
+    """devonthink.py (RDR-139 Layer A') imports cleanly with no DT dependency."""
+    from nexus.mcp.devonthink import build_server
+    assert build_server(available=False).name == "nexus-devonthink"
+
+
+def test_devonthink_has_main():
+    """devonthink.py exposes a main() entry point (console-script target)."""
+    from nexus.mcp.devonthink import main
+    assert callable(main)
+
+
+def test_devonthink_registered_tools():
+    """The gate decides the surface: stub-only when DT absent, full curated
+    surface when present. Pins the count so a _DT_TOOLS edit can't drift
+    silently (mirrors the sibling-register guard for core/catalog)."""
+    from nexus.mcp.devonthink import build_server
+
+    absent = {t.name for t in build_server(available=False)._tool_manager.list_tools()}
+    assert absent == {"devonthink_status"}
+
+    present = {t.name for t in build_server(available=True)._tool_manager.list_tools()}
+    assert len(present) == 17
+    # out-of-scope DT selectors/CRUD must never appear (RDR out-of-scope)
+    assert present.isdisjoint({
+        "search_records", "lookup_records", "get_record_properties",
+        "move_record", "trash_record",
+    })
+
+
 def test_helper_moved_with_store_list():
     """_store_list_docs helper is co-located with store_list in core.py."""
     from nexus.mcp.core import _store_list_docs


### PR DESCRIPTION
RDR-139 Phase 3, Layer A' (`nexus-jvlcn`, CRITICAL-1 resolution): a nexus-owned MCP server that exposes DEVONthink to Claude Code / subagents — the agent-surface gap that declaring DT's own binary cannot fill (it would error for DT-less consumers).

## What ships
- **`nx-mcp-devonthink`** console-script (third sibling to `nx-mcp` / `nx-mcp-catalog`), declared in `conexus/.mcp.json` (`alwaysLoad:false`). Tools surface as `mcp__plugin_conexus_devonthink__*`.
- **Optionality is the internal gate, not `.mcp.json`**: `build_server(available)` registers only the `devonthink_status` stub when DT is absent (zero DT tools, no spawn error) and the full curated surface when present. The `alwaysLoad:false` is a tool-search startup optimization, asserted independent of it.
- **Curated surface** (16 in-scope DT tools + `devonthink_status`): AI (`find_similar_records`, `classify_record`, `extract_record_content`, `extract_record_highlights`/`mentions`), content reads (`get_record_text`, `get_record_annotation`), bib (`resolve_doi_metadata`, `search_crossref`, `resolve_google_books_metadata`), capture (`capture_web_page`, `download_pdf_from_doi`, `import_file`), links (`get_record_links`, `get_databases`), and the **`dt_incorporate(uuid)` composite** = Layer B+F server-side (find similar → tumblers → `relates` links → write-back) in one agent call.
- **Async bridging**: pure proxies call DT via the async core (`_dt_proxy`); `dt_incorporate` runs the sync Layer B/F functions via `asyncio.to_thread` — respecting Layer A's CLI-path-only contract.

## Scope note (reconciled with the RDR during review)
The substantive-critic caught that DT's own **selectors/CRUD** (`search_records`, `lookup_records`, `get_record_properties`, group/parent walks) are in the RDR's "Explicitly out of scope" list (they stay on osascript, gjz52). They had slipped into the surface and were removed. The agent's DT entry point is a record UUID from a **nexus** search, then these AI/content tools. So the curated surface is **17** (not 20-with-selectors) — the faithful in-scope reading.

## Verification
- 27 unit tests (gate counts, proxy forwarding, `_incorporate_sync` routing, restart-hint, sibling-register guard); plugin-structure + mode-lint + storage-boundary green.
- Stacked review (both reviewers): scope fix (above), a real `httpx.AsyncClient` leak in `open_session` (`core.py`) the long-running server is the first to hit (fixed), a `NameError`-masking guard in `_incorporate_sync`, and a startup-only-probe restart hint in `devonthink_status`. 0 critical.

## Deferred to P3.6 (tracked)
The **live agent-surface MVV** (server spawned by a real MCP client, tools callable end-to-end, `mcp__plugin_conexus_devonthink__` prefix resolves) runs at the Phase 3 closeout (`nexus-z7s5r`), which already owns the two-sided + alwaysLoad-independence live MVV. This PR ships on unit tests; the server has not yet been spawned by an MCP client.

Part of epic `nexus-james`, Phase 3 parent `nexus-ubmed`. Remaining: P3.5 fallback (`nexus-akjvc`) + P3.6 closeout (`nexus-z7s5r`).