### PR TITLE
fix(deps): exclude PyAV to resolve the av/opencv libavdevice dylib conflict (nexus-usppl)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,3 +186,19 @@ dev = [
     "syrupy>=4.0",
     "twine>=6.2.0",
 ]
+
+[tool.uv]
+# nexus-usppl: exclude PyAV. It is pulled transitively by MinerU's VLM backend
+# (mineru -> qwen-vl-utils -> av), which nexus never uses — nexus drives MinerU's
+# PIPELINE backend (`mineru.cli.common.do_parse`) and Docling, neither of which
+# imports `av`. PyAV vendors ffmpeg 62.x dylibs (libavdevice.62) that collide
+# with opencv's bundled ffmpeg 61.x dylibs (libavdevice.61) inside a single
+# process, producing the macOS objc "Class AVFFrameReceiver implemented in both
+# ... may cause spurious casting failures and mysterious crashes" warning that
+# destabilises the PDF extraction stack. Verified safe: `import mineru`,
+# `mineru.cli.common`, `qwen_vl_utils`, `docling`, and `cv2` all import cleanly
+# with `av` absent (qwen-vl-utils imports av lazily on its unused video path).
+# The never-true marker drops `av` from resolution on every platform.
+override-dependencies = [
+    "av; sys_platform == 'never'",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,9 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[manifest]
+overrides = [{ name = "av", marker = "sys_platform == 'never'" }]
+
 [[package]]
 name = "accelerate"
 version = "1.13.0"
@@ -214,16 +217,6 @@ name = "av"
 version = "17.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/eb/abca886df3a091bc406feb5ff71b4c4f426beaae6b71b9697264ce8c7211/av-17.0.0.tar.gz", hash = "sha256:c53685df73775a8763c375c7b2d62a6cb149d992a26a4b098204da42ade8c3df", size = 4410769, upload-time = "2026-03-14T14:38:45.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/fb/55e3b5b5d1fc61466292f26fbcbabafa2642f378dc48875f8f554591e1a4/av-17.0.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ed4013fac77c309a4a68141dcf6148f1821bb1073a36d4289379762a6372f711", size = 23238424, upload-time = "2026-03-14T14:38:05.856Z" },
-    { url = "https://files.pythonhosted.org/packages/52/03/9ace1acc08bc9ae38c14bf3a4b1360e995e4d999d1d33c2cbd7c9e77582a/av-17.0.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:e44b6c83e9f3be9f79ee87d0b77a27cea9a9cd67bd630362c86b7e56a748dfbb", size = 18709043, upload-time = "2026-03-14T14:38:08.288Z" },
-    { url = "https://files.pythonhosted.org/packages/00/c0/637721f3cd5bb8bd16105a1a08efd781fc12f449931bdb3a4d0cfd63fa55/av-17.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b440da6ac47da0629d509316f24bcd858f33158dbdd0f1b7293d71e99beb26de", size = 34018780, upload-time = "2026-03-14T14:38:10.45Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/59/d19bc3257dd985d55337d7f0414c019414b97e16cd3690ebf9941a847543/av-17.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1060cba85f97f4a337311169d92c0b5e143452cfa5ca0e65fa499d7955e8592e", size = 36358757, upload-time = "2026-03-14T14:38:13.092Z" },
-    { url = "https://files.pythonhosted.org/packages/52/6c/a1f4f2677bae6f2ade7a8a18e90ebdcf70690c9b1c4e40e118aa30fa313f/av-17.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:deda202e6021cfc7ba3e816897760ec5431309d59a4da1f75df3c0e9413d71e7", size = 35195281, upload-time = "2026-03-14T14:38:15.789Z" },
-    { url = "https://files.pythonhosted.org/packages/90/ea/52b0fc6f69432c7bf3f5fbe6f707113650aa40a1a05b9096ffc2bba4f77d/av-17.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ffaf266a1a9c2148072de0a4b5ae98061465178d2cfaa69ee089761149342974", size = 37444817, upload-time = "2026-03-14T14:38:18.563Z" },
-    { url = "https://files.pythonhosted.org/packages/34/ad/d2172966282cb8f146c13b6be7416efefde74186460c5e1708ddfc13dba6/av-17.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:45a35a40b2875bf2f98de7c952d74d960f92f319734e6d28e03b4c62a49e6f49", size = 28888553, upload-time = "2026-03-14T14:38:21.223Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/bb/c5a4c4172c514d631fb506e6366b503576b8c7f29809cf42aca73e28ff01/av-17.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:3d32e9b5c5bbcb872a0b6917b352a1db8a42142237826c9b49a36d5dbd9e9c26", size = 21916910, upload-time = "2026-03-14T14:38:23.706Z" },
-]
 
 [[package]]
 name = "banks"
@@ -3585,7 +3578,7 @@ name = "qwen-vl-utils"
 version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "av" },
+    { name = "av", marker = "sys_platform == 'never'" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "requests" },


### PR DESCRIPTION
Resolves `nexus-usppl` — surfaced during the RDR-139 demo: a `Class AVFFrameReceiver is implemented in both … may cause spurious casting failures and mysterious crashes` objc warning from two copies of ffmpeg's `libavdevice` loading into one process during PDF extraction.

## Root cause
`av` (PyAV) vendors **ffmpeg 62.x** (`libavdevice.62.1.100`); `opencv` vendors **ffmpeg 61.x** (`libavdevice.61.3.100`). Both load together during extraction (MinerU + Docling both pull opencv; MinerU's VLM utils pull av), and the macOS objc runtime warns about the duplicate AVFoundation classes.

Key finding: **`opencv-python` vs `opencv-python-headless` is irrelevant** — both ship the *identical* `libavdevice.61.3.100.dylib` (same sha256). The duplicate is the **av 62.x** side.

## Fix: drop `av`
`av` reaches the tree only via MinerU's **VLM backend** (`mineru → qwen-vl-utils → av`), which nexus never uses — nexus drives MinerU's **pipeline** backend (`mineru.cli.common.do_parse`) and Docling. Excluding `av` removes the 62.x libavdevice, leaving opencv's 61.x as the sole copy → no duplicate → warning gone.

Implemented as a uv override (`av; sys_platform == 'never'`).

## Verified safe
- `import mineru`, `mineru.cli.common`, `qwen_vl_utils`, `docling`, `cv2` all import cleanly with `av` absent (qwen-vl-utils imports av lazily on its unused video path).
- A real MinerU **pipeline** extraction succeeds with av gone: page 1 → 9412 chars, **no objc warning**.
- `import cv2` + an op runs clean (warning eliminated).
- 279 pdf/extractor tests green.

Trade-off: MinerU's VLM backend is disabled (nexus doesn't use it). If a future feature needs PyAV, it can be re-added with the ffmpeg collision addressed separately.

Closes `nexus-usppl`.