### PR TITLE
feat(rdr-139): thread --extractor through nx dt index/capture (nexus-pxxyn)

### DIFF
--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -73,6 +73,7 @@ def _index_record(
     collection: str | None,
     corpus: str,
     dry_run: bool,
+    extractor: str = "auto",
 ) -> bool:
     """Dispatch a single supported ``(uuid, path)`` to the right indexer.
 
@@ -109,7 +110,10 @@ def _index_record(
     file_path = Path(path)
     ext = file_path.suffix.lower()
     if ext == ".pdf":
-        index_pdf(file_path, corpus=corpus, collection_name=collection)
+        # nexus-pxxyn: thread the operator's --extractor choice through so the
+        # documented MinerU-failure recovery ("rerun with --extractor docling")
+        # is actionable on the DT path. Markdown has no extractor backend.
+        index_pdf(file_path, corpus=corpus, collection_name=collection, extractor=extractor)
     else:  # .md — extension filtering happens in index_cmd
         index_markdown(file_path, corpus=corpus, collection_name=collection)
 
@@ -558,6 +562,18 @@ def dt() -> None:
         "ingested. Opt-in, default off."
     ),
 )
+@click.option(
+    "--extractor",
+    type=click.Choice(["auto", "docling", "mineru"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help=(
+        "PDF extraction backend for file-backed records. ``mineru`` is "
+        "formula-aware but OOM-fails on some formula-dense pages; the recovery "
+        "is ``--extractor docling`` (formula-stripped, but always completes). "
+        "``auto`` picks mineru when formulas are detected, else docling."
+    ),
+)
 def index_cmd(
     use_selection: bool,
     tag: str | None,
@@ -573,6 +589,7 @@ def index_cmd(
     enrich: bool,
     dt_content: bool,
     highlights: bool,
+    extractor: str,
 ) -> None:
     """Index DEVONthink records into Nexus.
 
@@ -677,6 +694,7 @@ def index_cmd(
                 collection=resolved_collection,
                 corpus=corpus,
                 dry_run=False,
+                extractor=extractor,
             )
         except (RuntimeError, ImportError) as exc:
             # nexus-2fyb code-review R4-I2: a single indexing failure must
@@ -968,6 +986,11 @@ def highlights_cmd(tumbler_or_uuid: str) -> None:
               help="After indexing, ingest the record's highlights (Layer E).")
 @click.option("--enrich", "enrich", is_flag=True, default=False,
               help="After indexing, run DT-CrossRef bib gap-fill over the collection (Layer C).")
+@click.option("--extractor",
+              type=click.Choice(["auto", "docling", "mineru"], case_sensitive=False),
+              default="auto", show_default=True,
+              help="PDF extraction backend for the index step (docling = formula-stripped "
+                   "recovery when mineru OOM-fails on formula-dense PDFs).")
 @click.pass_context
 def capture_cmd(
     ctx: click.Context,
@@ -982,6 +1005,7 @@ def capture_cmd(
     writeback: bool,
     highlights: bool,
     enrich: bool,
+    extractor: str,
 ) -> None:
     """Capture a URL, DOI, or file into DEVONthink and index it (RDR-139 Layer G).
 
@@ -1059,6 +1083,7 @@ def capture_cmd(
             writeback=writeback,
             highlights=highlights,
             enrich=enrich,
+            extractor=extractor,
         )
     except click.ClickException:
         # Capture succeeded but indexing failed: the DT record exists but is

--- a/tests/test_commands_dt.py
+++ b/tests/test_commands_dt.py
@@ -83,6 +83,7 @@ def fake_dispatcher(monkeypatch) -> list[dict]:
         collection: str | None,
         corpus: str,
         dry_run: bool,
+        extractor: str = "auto",
     ) -> bool:
         calls.append({
             "uuid": uuid,
@@ -90,6 +91,7 @@ def fake_dispatcher(monkeypatch) -> list[dict]:
             "collection": collection,
             "corpus": corpus,
             "dry_run": dry_run,
+            "extractor": extractor,
         })
         # Default success — tests that want to exercise the
         # stamp-failed summary path replace the dispatcher with
@@ -377,6 +379,30 @@ class TestPassthroughFlags:
         assert result.exit_code == 0, result.output
         assert fake_dispatcher[0]["corpus"] == "knowledge"
 
+    def test_extractor_passthrough(
+        self, runner, fake_selectors, fake_dispatcher,
+    ):
+        # nexus-pxxyn: --extractor reaches the PDF indexer so the MinerU-failure
+        # recovery (--extractor docling) is actionable on the DT path.
+        from nexus.cli import main
+
+        fake_selectors["selection"].return_value = [("U", "/a.pdf")]
+        result = runner.invoke(main, [
+            "dt", "index", "--selection", "--extractor", "docling",
+        ])
+        assert result.exit_code == 0, result.output
+        assert fake_dispatcher[0]["extractor"] == "docling"
+
+    def test_extractor_defaults_to_auto(
+        self, runner, fake_selectors, fake_dispatcher,
+    ):
+        from nexus.cli import main
+
+        fake_selectors["selection"].return_value = [("U", "/a.pdf")]
+        result = runner.invoke(main, ["dt", "index", "--selection"])
+        assert result.exit_code == 0, result.output
+        assert fake_dispatcher[0]["extractor"] == "auto"
+
 
 # ── nexus-cvaw: paper PDFs route to knowledge__ by default ──────────────────
 
@@ -529,7 +555,7 @@ class TestStampFailedSummary:
         ]
 
         # Dispatcher returns False for the two that should fail to stamp.
-        def maybe_fail(uuid, path, *, collection, corpus, dry_run):
+        def maybe_fail(uuid, path, *, collection, corpus, dry_run, extractor="auto"):
             return uuid == "U-OK"
 
         monkeypatch.setattr("nexus.commands.dt._index_record", maybe_fail)
@@ -1137,7 +1163,7 @@ class TestLinkSemantic:
         wb_calls: list[str] = []
         monkeypatch.setattr(
             "nexus.commands.dt._index_record",
-            lambda uuid, path, *, collection, corpus, dry_run: uuid == "U-OK",
+            lambda uuid, path, *, collection, corpus, dry_run, extractor="auto": uuid == "U-OK",
         )
         monkeypatch.setattr(
             "nexus.commands.dt._link_semantic_record",

--- a/tests/test_dt_capture_cmd.py
+++ b/tests/test_dt_capture_cmd.py
@@ -114,6 +114,24 @@ def test_doi_capture_downloads_pdf_and_indexes(runner, monkeypatch) -> None:
     assert indexed == ["DOI-UUID"]  # the captured record was actually indexed
 
 
+def test_capture_forwards_extractor_to_index(runner, monkeypatch) -> None:
+    """nexus-pxxyn: nx dt capture --extractor docling reaches the PDF indexer
+    (so a formula-heavy captured PDF can use the docling recovery)."""
+    from nexus.cli import main
+    monkeypatch.setattr("nexus.mcp_client.devonthink.available", lambda **k: True)
+    monkeypatch.setattr("nexus.mcp_client.devonthink.dt_capture_web_page",
+                        lambda url, **kw: "PDF-UUID")
+    monkeypatch.setattr("nexus.commands.dt._gather_records",
+                        lambda **kw: [(kw["uuids"][0], "/captured.pdf")])
+    seen = {}
+    monkeypatch.setattr("nexus.commands.dt._index_record",
+                        lambda uuid, path, **kw: seen.update(kw) or True)
+    result = runner.invoke(main, ["dt", "capture", "https://e.com",
+                                  "--type", "pdf", "--extractor", "docling"])
+    assert result.exit_code == 0, result.output
+    assert seen.get("extractor") == "docling"
+
+
 def test_doi_without_email_warns(runner, monkeypatch) -> None:
     from nexus.cli import main
     monkeypatch.delenv("OPENALEX_MAILTO", raising=False)


### PR DESCRIPTION
Resolves `nexus-pxxyn` — surfaced during the RDR-139 demo: when MinerU OOM-fails on a formula-dense PDF, the loud error says "rerun with `--extractor docling`", but `nx dt index`/`nx dt capture` didn't expose `--extractor`, so the recovery was only reachable by dropping to `nx index pdf <path-inside-DT-package>`.

## Change
- `nx dt index` and `nx dt capture` now take `--extractor [auto|docling|mineru]` (default `auto`).
- Threaded through `_index_record → index_pdf(extractor=…)` (markdown has no extractor backend; the param is PDF-only). `nx dt capture` forwards it to the index step via `ctx.invoke`.

## Validated end-to-end (live)
Re-indexed the demo's `arXiv:2605.13379` — the 42-page, formula-heavy PDF that reproducibly OOM-killed MinerU on page 31 — via the new recovery:
```
nx dt index --uuid 4ABDC8BB… --extractor docling --link-semantic --writeback --highlights
→ Indexed 1 record(s) (… 1 written back to DT)
→ catalog tumbler 1.12.43, 291 chunks (document_chunks manifest), formula-stripped
```
The paper MinerU couldn't extract is now in nexus semantic search. The recovery hint is finally actionable on the DT path.

Tests: `--extractor docling`/`auto` passthrough asserted for both `nx dt index` and `nx dt capture`; 82 dt tests green.

Closes `nexus-pxxyn`. (Sibling demo follow-ons: `nexus-usppl` av/opencv conflict — PR #1032; `nexus-m26oq` per-page MFR-OOM graceful degradation — still open.)