### PR TITLE
docs(proposals): preserve Beyond-Similarity-Search + Open-Ontologies proposals

### DIFF
--- a/docs/proposals/beyond-similarity-search-application.md
+++ b/docs/proposals/beyond-similarity-search-application.md
@@ -1,0 +1,104 @@
+# Proposal: Applying "Beyond Similarity Search" to Nexus
+
+**Status:** draft — proposal only, no code or doc changes yet
+**Author:** synthesis of /nx:research run 2026-05-17
+**Source paper:** Budigi & Sirigiri, *Beyond Similarity Search: A Unified Data Layer for Production RAG Systems*, arXiv:2605.03275 (2026)
+**Indexed at:** `knowledge__dt-papers__voyage-context-3__v1`, tumbler `1.12.1`
+**Research finding:** T3 doc `24c5da9677eb700f93ecb2772d2f76b9` (`knowledge__knowledge__voyage-context-3__v1`)
+**Related bead:** nexus-1714 (P0 doctor check)
+**Related fix:** PR #835 / nexus-m8a7 (manifest-chash reader)
+
+This document is a **proposal**, not an in-place edit of `docs/architecture.md` or any existing RDR. If the proposal is accepted, the inline edits and any new RDR are tracked as separate work.
+
+---
+
+## 1. What the paper claims
+
+The paper's thesis: split-tier RAG architectures (specialised vector store + relational metadata store + cache) suffer three structural failure modes:
+
+1. **Data staleness** — inconsistency window between the vector store and the metadata store. Paper measures 3.54 ms mean window on a simulated split stack.
+2. **Tenant data leakage** — application-layer filtering bugs leak rows across tenants (0.2 % leakage rate on their bench).
+3. **Query composition explosion** — multi-constraint queries (similarity + columnar filter + ACL) require multiple round-trips and ~1 800 lines of synchronisation glue.
+
+Proposed remedy: a unified PostgreSQL layer with pgvector + HNSW + row-level security, where similarity, filter, and access control execute in one SQL statement and one transaction. Fallback for extreme scale: a hot (PG+pgvector) / warm (specialised vector DB) / cold (object store) three-tier hybrid.
+
+Reported results (synthetic 50 k-doc, 128-dim, 20-tenant corpus): 92 % latency reduction on date-filtered queries, 74 % on tenant-scoped queries, 0 ms inconsistency window, 0 % leakage, ~93 % less glue code.
+
+## 2. Where it applies to nexus
+
+### 2.1 Split-tier inconsistency — APPLIES
+
+Nexus is a split-tier RAG stack. T2 SQLite (catalog + manifests + aspects) and T3 ChromaDB (chunks) are not in one transaction. The post-store hook fires after T3 returns, leaving T2 as the lagging side for one request.
+
+**The nexus-m8a7 bug (PR #835) is the canonical instance of the paper's diagnosis.** RDR-108 Phase 3 retired `doc_id` from T3 chunk metadata, making the T2 manifest authoritative. The aspect reader had not been updated and queried `where={doc_id: ...}` on T3, returning zero rows even though the manifest knew the exact chashes. Two systems' identity models drifted. The fix was to make the reader respect the manifest as the source of truth.
+
+This is exactly the failure class the paper diagnoses, with one twist: nexus already has the **structural** fix (manifest-first contract, RDR-108). What it lacks is universal enforcement.
+
+### 2.2 Residual exposure — tolerance branches
+
+Code that still reads identity fields from T3 chunk metadata as fallback:
+
+| Location | Field | Purpose |
+|---|---|---|
+| `src/nexus/mcp/core.py:740` | `source_path` | display label fallback |
+| `src/nexus/mcp/core.py:1004,1008,1038,1040` | `doc_id`, `source_path` | tolerance read with explanatory comment |
+| `src/nexus/indexer_utils.py:275,369–372` | `source_path` | `StalenessCache.by_source_path` secondary index, explicit pre-Phase-3 path |
+| `src/nexus/search_engine.py:189–207` | `doc_id` | metadata-first, catalog-fallback ordering |
+
+These are deliberate, documented tolerance paths for chunks predating Phase 3. They are not bugs. But they are **live split-identity dependencies with no expiry condition**: until operators can prove the legacy corpus is fully pruned, the branches stay forever, and the failure class nexus-m8a7 surfaced remains reachable for any future contributor who adds a similar read.
+
+The P0 recommendation (§4) is to gate removal of those branches on an operator-visible doctor check.
+
+### 2.3 GC freshness gap
+
+`src/nexus/indexer.py:1778–1782` documents an explicit split: the user-facing `nx t3 gc` CLI verb uses the legacy `meta.doc_id`-keyed path and "reports zero candidates for post-Phase-3 chunks." The manifest-keyed `_gc_orphan_chunks()` is the authoritative post-Phase-3 path but isn't wired to the CLI (bead nexus-e5aw, already filed).
+
+Until that's reconciled, T3 orphans from re-indexing accumulate invisibly to operators — the paper's "stale data" failure mode at the GC layer.
+
+### 2.4 Catalog-aware pre-filtering — APPLIES (already done)
+
+`src/nexus/search_engine.py:267–308` (`_build_doc_id_prefilter`) queries T2 SQLite for matching doc_ids and injects them as a ChromaDB `where {"doc_id": {"$in": [...]}}` filter. This is the "filter before similarity" pattern the paper advocates as the unified-architecture's win. Nexus already does it.
+
+The remaining gap: the join key inside T3 is still `doc_id` chunk metadata, not manifest-derived chash ids. Closing that gap is one of the residual-exposure items in §2.2.
+
+## 3. Where it does NOT apply to nexus
+
+| Paper claim | Why inapplicable |
+|---|---|
+| Multi-tenancy + RLS | Nexus is single-user. No tenant boundaries to leak across. |
+| Query composition explosion | ChromaDB quota caps `where` predicates at 8 (`chroma_quotas.py:MAX_WHERE_PREDICATES`). High-cardinality filter explosion isn't a workload nexus faces. |
+| ~1 800 LOC of glue | Paper measures multi-service synchronisation cost (Pinecone + Postgres + Redis + custom sync code). Nexus's post-store hook is in-process and small. |
+| 50 k-doc "enterprise scale" | Nexus has ~290 k chunks (per T2 memory `project_t3_metadata_audit_2026_05_08`), larger in absolute terms but with no concurrent tenant pressure or per-read RLS. Access pattern differs. |
+
+## 4. Recommendations
+
+| Priority | Recommendation | Confidence | Bead / Next step |
+|---|---|---|---|
+| **P0** | `nx doctor` check: per-collection count of chunks carrying `doc_id` or `source_path` in T3 metadata. Non-zero warns; gate removal of §2.2 tolerance branches on the check reporting 0 across all collections. | HIGH | **nexus-1714** (filed) |
+| P1 | Wire `nx t3 gc` CLI to the manifest-keyed GC path. Operators are currently blind to post-Phase-3 orphans. | MEDIUM | **nexus-e5aw** (filed; unblock) |
+| P2 | Add `docs/architecture.md` section: "Cross-tier write ordering and recovery." Document the actual inconsistency window (post-store hook, same-process, sub-millisecond), the recovery path (re-index), and the manifest-first invariant. Cite paper §5.3 as external validation. | MEDIUM | doc-only |
+| P3 | Name the hot / warm / cold framing in `docs/architecture.md` and `CLAUDE.md`. Cite RDR-105 (T1 contract) and paper §7.2. External validation at zero cost. | LOW | doc-only |
+
+The P0 + P1 pair has a natural sequence: P0 surfaces the data, P1 closes the GC loop, and only then do the §2.2 tolerance branches become removable.
+
+## 5. Skepticism about the paper
+
+The structural arguments in the paper are sound engineering reasoning. **The numbers are not portable.** Calibrate any quotation from §6 / §7 with these caveats:
+
+- **Synthetic corpus.** 50 k documents, 128-dim embeddings, 20 tenants, 5 categories. Voyage embeddings in nexus are 1 024-dim. HNSW recall, index build time, and query latency all scale differently in higher dimensions; the 92 % and 74 % latency-reduction figures do not transfer to nexus's embedding space.
+- **No ablations.** `ablations_present: false` per the extracted aspect record (tumbler 1.12.1). The 92 % reduction is a single-condition comparison.
+- **Simulated vector DB.** The "specialised vector store" baseline is simulated as a separate ChromaDB HTTP service, not a real Pinecone / Qdrant / Weaviate deployment. Proprietary HNSW optimisations in production vector DBs are not characterised.
+- **No code released, zero external citations.** OpenAlex `W7160446511` reports `cited_by_count: 0` and an empty `referenced_works` list as of 2026-05-17. Fresh arXiv preprint, not peer-reviewed.
+- **Future-dated.** Publication year 2026; nexus indexed it within days of upload. Treat conclusions as directional, not validated.
+
+Use the paper for **architectural framing** (split-tier failure modes are real; manifest-as-source-of-truth is correct; hot/warm/cold is a sensible tiering pattern). Do not cite it for **quantitative claims** about latency or consistency without your own benchmark.
+
+## 6. Decision asked
+
+Three decisions, separable:
+
+1. **Accept P0 (nexus-1714) as the next concrete action?** — yes / no / modify.
+2. **Promote this proposal to an RDR?** The §2 findings touch RDR-108 enforcement and RDR-101 reranking and could warrant a dedicated RDR if the §4 P2/P3 doc edits land. — yes / no / defer.
+3. **Persist the research finding (already in T3 doc `24c5da9677eb700f93ecb2772d2f76b9`) as a permanent reference, or let it age out?** — keep / age-out.
+
+No code changes from this document. The accepted recommendations become beads; bead work happens on its own branches.

--- a/docs/proposals/open-ontologies-application.md
+++ b/docs/proposals/open-ontologies-application.md
@@ -1,0 +1,115 @@
+# Proposal: Applying "Open Ontologies" Findings to Nexus
+
+**Status:** draft — proposal only, no code or doc changes yet
+**Author:** synthesis of /nx:research run 2026-05-17
+**Source paper:** Fabio Rovai, *Open Ontologies: Tool-Augmented Ontology Engineering with Stable Matching Alignment*, arXiv:2512.05594 (2026)
+**Indexed at:** `knowledge__dt-papers__voyage-context-3__v1`, tumbler `1.12.2`
+**Source repo:** https://github.com/fabio-rovai/open-ontologies (Rust, ~17.4 k LOC, MIT)
+**Research finding:** T3 doc `743c3e484617712304878893ca3fcc9c` (`knowledge__knowledge__voyage-context-3__v1`)
+**Sibling proposal:** `docs/proposals/beyond-similarity-search-application.md`
+
+This document is a **proposal**, not an in-place edit of `docs/architecture.md`, RDR-088, RDR-101, or any other existing artifact. Accepted recommendations become beads; bead work happens on its own branches.
+
+---
+
+## 1. What the paper claims
+
+The paper presents Open Ontologies, a Rust + MCP system exposing 43 narrowly-typed tools (`onto_validate`, `onto_align`, `onto_diff`, `onto_search`, `onto_similarity`, …) across 14 functional categories. Core ideas:
+
+1. **Tool decomposition over raw context.** Compared to passing OWL files into an LLM, exposing typed tools that the LLM composes step-by-step dramatically improves task accuracy.
+2. **Stable 1-to-1 matching with a label penalty.** Alignment is a weighted six-signal similarity score followed by Gale-Shapley stable matching that downweights structurally unsupported matches.
+3. **Quantitative results** (OAEI Anatomy F1 0.182 → 0.832; OntoAxiom F1 conditions):
+   - A: unaided LLM = **0.431**
+   - B: LLM + typed MCP tools = **0.717** (+66 % vs A)
+   - C: LLM + structured summary in prompt = 0.430 (no benefit vs A)
+   - D: LLM + raw OWL file in context = **0.323** (*worse* than unaided)
+4. **Weight irrelevance.** Five signal-weight configurations under stable matching produce F1 0.830–0.834 (<0.004 spread). The matching constraint dominates over weight tuning.
+
+LLM used: Claude Opus 4 (`claude-opus-4-20250514`) — same model family nexus runs against, so portability of LLM-side findings is higher than usual.
+
+## 2. What's portable to nexus
+
+### 2.1 Operator decomposition is the right pattern — independent validation
+
+Condition D below is the headline. **Raw OWL in context (F1 0.323) is worse than no file at all (F1 0.431).** Typed MCP tools (F1 0.717) recover and exceed the unaided baseline. The mechanism is decomposition: the LLM is forced into typed, verifiable steps instead of free-running over a large structured blob.
+
+Nexus arrived at the same conclusion from the AgenticScholar paper (RDR-088). The operator suite at `src/nexus/mcp/core.py:2206–2832` (`operator_extract`, `operator_rank`, `operator_compare`, `operator_summarize`, `operator_generate`, `operator_filter`, `operator_check`, `operator_verify`, `operator_groupby`, `operator_aggregate`) is the nexus equivalent of the Open Ontologies tool suite, plus a composition layer (`nx_answer` at `core.py:3479`) that the paper's system does not have. Convergent design from two independent domains.
+
+The conclusion is: **the pattern is right; the divergence to watch is structural drift.** Specifically, there is no convention preventing a nexus caller from passing a raw T3 dump to `operator_generate` and recreating Condition D inside nexus. `chroma_quotas.py:MAX_DOCUMENT_BYTES = 16384` is a quota cap, not a usage convention.
+
+### 2.2 Stable matching has exactly one credible nexus application
+
+The paper's stable-matching algorithm applies to any "pick a deterministic 1-to-1 assignment between two fuzzy-matched sets" problem. In nexus that means: where do we currently have a many-to-many or silent-failure matching problem that should be 1-to-1?
+
+**Candidate: `src/nexus/catalog/link_generator.py:61–66` — fuzzy bib-ID bridge.** Today the citation auto-linker matches references by exact string within a single ID space (S2 paperIds or OpenAlex W-IDs). The code comment is explicit:
+
+> cross-backend references (a paper enriched by OpenAlex referencing one enriched only by S2) won't match — that's the correct conservative behavior, since the two ID spaces are distinct and we don't have a DOI bridge yet.
+
+A small 3-signal similarity (title Jaro-Winkler + year delta + DOI suffix) followed by Gale-Shapley would build that DOI bridge cleanly. Each reference maps to at most one catalog entry. 1-to-1 cardinality is exactly the constraint Gale-Shapley enforces.
+
+Other candidates fail the 1-to-1 test: plan→bead matching is asymmetric; chash dedupe is already exact; `relates` links are intentionally many-to-many.
+
+### 2.3 Multi-signal similarity is already covered
+
+The paper's six signals are: label similarity (Jaro-Winkler + token Jaccard), property overlap, parent overlap, instance overlap, semantic embedding, structural embedding. Signals 2–4 are ontology-specific.
+
+Nexus's reranker (`src/nexus/search_engine.py`) uses: vector distance, catalog prefilter (`:303`), topic boost (`:628`), salience boost (`:646`). Different signal classes for a different domain, but the same multi-signal pattern.
+
+The **operational lesson from the paper's weight-irrelevance result** is: don't spend engineering effort on reranker weight tuning. Spend it on signal diversity. The sibling Beyond Similarity Search finding agrees on this point from a different angle.
+
+## 3. What to reject
+
+| Idea | Why reject |
+|---|---|
+| OWL / triple store / SHACL / OWL-RL reasoner | Catalog link types are a closed enum of seven types (`docs/catalog-link-types.md`). Consistency checks are two-line SQL against T2. Graph is O(thousands of edges), not millions. Raw-SQL invariant per `CLAUDE.md` excludes ORMs and rules out a new storage engine here. |
+| Adopting Open Ontologies as a dependency | Rust binary, ontology-specific. Nexus's domain is knowledge retrieval, not ontology engineering. Zero callers. |
+| Passing raw catalog or T3 dump as single LLM context | Condition D from the paper: actively worse than unaided. The right move is decomposition via operators, which nexus already has. |
+| Reranker weight-tuning sprints | Paper's weight irrelevance + Beyond Similarity Search's portability skepticism both argue this is low-leverage. |
+
+## 4. Recommendations
+
+| Priority | Recommendation | Confidence | Next step |
+|---|---|---|---|
+| **P0** | One-paragraph note in `docs/architecture.md` recording Open Ontologies' Condition A/B/D result as external validation of operator decomposition over raw-dump. Cite arXiv:2512.05594. | HIGH | doc-only, file bead |
+| **P1** | Spike Gale-Shapley fuzzy stable matching in `generate_citation_links()` for cross-backend bib-ID bridging. 3 signals (title Jaro-Winkler + year delta + DOI suffix). Behind a feature flag; measure false-positive rate against a held-out set of known same-paper-different-backend pairs. | MEDIUM | file bead, target `link_generator.py` |
+| **P2** | Add a note in RDR-101 § Further Work: reranker weight tuning is low-leverage per Open Ontologies + Beyond Similarity Search converging evidence. Future work should add signals, not retune weights. | MEDIUM | doc-only |
+| **P3** | Doc convention in `docs/mcp-servers.md` or `CLAUDE.md`: do not invoke MCP operators with raw T3 / catalog dumps that bypass decomposition. Cite paper Condition D. | LOW | doc-only |
+| (reject) | No OWL / triple store / SHACL adoption. | HIGH | nothing |
+
+P0 and P3 are doc-only and small. P1 is the only real engineering candidate from this paper; it is **investigate, not adopt** — start with a measurement spike before any production change. P2 is one paragraph.
+
+## 5. Cross-link with the sibling proposal
+
+The Beyond Similarity Search proposal (`docs/proposals/beyond-similarity-search-application.md`) addressed the **retrieval layer**: T2/T3 split consistency, manifest-first contract, hot/warm/cold framing. This Open Ontologies proposal addresses the **interaction layer**: how LLMs use nexus's tool surface, and how the catalog graph is constructed.
+
+Where the two interact:
+
+- **Multi-signal ranking.** Both papers converge: signal diversity matters, weight tuning does not. RDR-101 § Further Work should record this as joint evidence.
+- **Tool surface discipline.** Beyond Similarity Search argues for cross-tier consistency; Open Ontologies argues for cross-tool discipline. Both point at the same broader principle: typed contracts beat shape-free dumps.
+
+## 6. Evidence quality
+
+This paper has a **stronger** evidence base than the Beyond Similarity Search sibling:
+
+- Code released and substantive (~17.4 k LOC Rust, 43 tools, real Tauri studio, clinical Arrow/Parquet support — verified from the GitHub repo as primary source, not inferred from paper alone).
+- Ablations present (`ablations_present: true` per the extracted aspect record).
+- Real OAEI benchmarks with published baselines (LogMap F1=0.67, BERTMap F1=0.71) — not a wholly synthetic corpus.
+- Same LLM family (Claude Opus 4) as nexus, improving result portability for the tool-design claims.
+
+Remaining cautions:
+
+- LLM A/B/C/D conditions were single-run; the +66 % F1 claim has no variance bound.
+- Condition D simulated "raw file in prompt" via tool injection. The paper acknowledges this may slightly inflate the degradation.
+- The domain (OWL alignment) is distant from nexus (knowledge retrieval). Generic tool-design lessons transfer; specific benchmarks do not.
+- arXiv preprint, no peer review, zero external citations (DOI `10.48550/arXiv.2512.05594`, fresh as of 2026-05-17).
+
+Net: structurally portable conclusions are stronger than the sibling paper. Quantitative claims should still be treated as directional.
+
+## 7. Decisions asked
+
+1. **Accept P0** (architecture.md paragraph on operator decomposition validation)? — yes / no / modify.
+2. **Accept P1** (Gale-Shapley bib-ID bridge spike) as a bead? — yes / no / defer.
+3. **Accept P2 / P3** (RDR-101 + mcp-servers.md doc notes)? — yes / no / batch with P0.
+4. **Promote to RDR?** — only if any of P0–P3 trigger non-trivial code changes. P1 alone might warrant one if its scope expands. — yes / no / defer.
+
+No code changes from this document.


### PR DESCRIPTION
Docs-only. Rescues two research proposal docs that lived **only** on stale branches rooted in the scrapped RDR-110–119 chain, so those heavy branches can be deleted without losing the ideas. Neither doc was on develop.

- `docs/proposals/beyond-similarity-search-application.md` — synthesis of *Beyond Similarity Search* (Budigi & Sirigiri, arXiv:2605.03275). Backs the open P1 bead **`nexus-1714`** (an `nx doctor` check that flags T3 chunks still carrying legacy `doc_id`/`source_path` metadata, so the RDR-108 legacy-tolerance code branches can finally be removed).
- `docs/proposals/open-ontologies-application.md` — exploratory "Open Ontologies" application.

After this lands I'll delete `feature/nexus-1714-doctor-legacy-metadata-proposal` and `feature/open-ontologies-proposal` (their only develop-absent content is preserved here). `feature/nexus-lbie5-mcpb-spike` stays (RDR-126 is an active draft).