### PR TITLE
docs(rdr-139): document the DEVONthink integration surface (release prep)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,10 +67,10 @@ CLI (cli.py)            MCP Server (mcp_server.py)
     └── Storage tiers (RDR-120 substrate split, daemon-mediated)
           T1: ChromaDB HTTP server (session scratch, shared across agent processes)
           T2: SQLite + FTS5 daemon ── nx daemon t2 start
-                Eight domain stores behind T2Database / T2Client
+                Nine domain stores behind T2Database / T2Client
                 Transport: UDS (UID-gated) + 127.0.0.1 loopback TCP
                 memory · plans · chash_index · taxonomy · telemetry ·
-                document_aspects · aspect_queue · catalog
+                document_aspects · aspect_queue · document_highlights · catalog
           T3: ChromaDB daemon ── nx daemon t3 start  (local mode only)
               OR ChromaDB Cloud + Voyage AI (cloud, higher quality;
                                               daemon does not apply)
@@ -359,7 +359,7 @@ The partial-commit failure mode (a batch hook commits an early sub-step then rai
 
 ## T2 Domain Stores
 
-`src/nexus/db/t2/` is a Python package split into seven domain-specific
+`src/nexus/db/t2/` is a Python package split into eight domain-specific
 stores. Each store owns its own tables in a shared SQLite file and runs
 against its own `sqlite3.Connection` in WAL mode. Reads in one domain
 are never blocked by writes in another (the Phase 1 global Python
@@ -380,10 +380,11 @@ wait rather than a dropped write.
 | Chash index       | `ChashIndex`              | `db.chash_index`       | Global chash → (collection, doc_id) lookup; populated via dual-write at every T3 upsert site (RDR-086 Phase 1) |
 | Document aspects  | `DocumentAspects`         | `db.document_aspects`  | Per-document structured aspects (problem, method, datasets, baselines, results, extras) keyed by `(collection, source_path)`; populated by the async aspect-extraction worker (RDR-089 P1.1) |
 | Aspect queue      | `AspectExtractionQueue`   | `db.aspect_queue`      | Durable WAL buffer feeding the aspect-extraction worker; FIFO `claim_next` with cross-process compare-and-swap atomicity; `reclaim_stale` recovers rows from crashed workers (RDR-089 follow-up) |
+| Document highlights | `DocumentHighlights`    | `db.document_highlights` | Per-document DEVONthink highlight / mention markdown notes, keyed by catalog tumbler (`doc_id`); populated by `nx dt index --highlights` (RDR-139 Layer E). Deliberately separate from `document_aspects`: free-text highlights must not contend with the aspect worker's whole-row overwrite or its confidence gate |
 
-`T2Database` is a composing facade: it constructs the seven stores in
+`T2Database` is a composing facade: it constructs the eight stores in
 order (memory → plans → taxonomy → telemetry → chash_index →
-document_aspects → aspect_queue), re-exposes the memory-domain public
+document_aspects → aspect_queue → document_highlights), re-exposes the memory-domain public
 methods as thin delegates for backward compatibility, and runs
 cross-domain operations like `expire()` over all of them. The
 chash_index, taxonomy, document_aspects, and aspect_queue domains are
@@ -531,7 +532,7 @@ See `src/nexus/db/t2/__init__.py` for the facade source and
 | **Taxonomy** | `db/t2/catalog_taxonomy.py`, `commands/taxonomy_cmd.py`, `taxonomy.py` (shim) | HDBSCAN topic discovery from T3 embeddings (RDR-070). T2 tables: `topics`, `topic_assignments`, `taxonomy_meta`, `topic_links`. ChromaDB `taxonomy__centroids` (cosine/HNSW) for centroid ANN. `discover_for_collection()` is the shared entry point for CLI and `nx index repo`. `taxonomy_assign_hook` in `mcp_infra.py` fires on every `store_put` for incremental assignment. `taxonomy.py` is a backward-compatibility shim that forwards old call sites to `db.taxonomy` |
 | **Hooks** | `commands/hooks.py`, `commands/hook.py` | `hooks.py`: Git hook install/uninstall/status, sentinel-bounded stanza management. `hook.py`: Claude Code SessionStart/SessionEnd lifecycle runners |
 | **Verification** | `config.py` (verification section), `conexus/hooks/scripts/stop_verification_hook.sh`, `conexus/hooks/scripts/pre_close_verification_hook.sh`, `conexus/hooks/scripts/read_verification_config.py` | Opt-in mechanical enforcement: Stop hook (session-end checks), PreToolUse hook (bd-close gate), standalone config reader. See [Verification config](configuration.md#verification) |
-| **MCP Servers** | `mcp/core.py`, `mcp/catalog.py`, `mcp_infra.py`, `mcp_server.py` (shim) | Dual-server FastMCP architecture (RDR-062). `nexus` core server (26 tools: storage, retrieval, operators, orchestration) + `nexus-catalog` (10 tools: catalog and link graph). Short-name convention: catalog tools drop the redundant `catalog_` prefix since the server namespace already provides context. Six destructive / maintenance operations are intentionally kept CLI-only. Backward-compat shim at `mcp_server.py` re-exports every function. `query()` has catalog-aware routing (author, content_type, subtree, follow_links, depth); singletons and test injection live in `mcp_infra.py`. **For the full tool catalog see [MCP Servers](mcp-servers.md).** |
+| **MCP Servers** | `mcp/core.py`, `mcp/catalog.py`, `mcp/devonthink.py`, `mcp_infra.py`, `mcp_server.py` (shim) | Multi-server FastMCP architecture (RDR-062, RDR-139). `nexus` core server (26 tools: storage, retrieval, operators, orchestration) + `nexus-catalog` (10 tools: catalog and link graph) + `devonthink` (RDR-139 Layer A': the `nx-mcp-devonthink` agent-surface server, ~17 curated DEVONthink tools + the `dt_incorporate` composite). The devonthink server **always spawns** and gates internally on `available()`: DT present → the curated surface; DT absent → only a `devonthink_status` stub (zero DT tools, no spawn error). Declared `alwaysLoad:false` in `conexus/.mcp.json` as a tool-search startup optimization, not the optionality mechanism. Tools surface as `mcp__plugin_conexus_devonthink__*`. Short-name convention: catalog tools drop the redundant `catalog_` prefix since the server namespace already provides context. Six destructive / maintenance operations are intentionally kept CLI-only. Backward-compat shim at `mcp_server.py` re-exports every function. `query()` has catalog-aware routing (author, content_type, subtree, follow_links, depth); singletons and test injection live in `mcp_infra.py`. **For the full tool catalog see [MCP Servers](mcp-servers.md).** |
 | **Enrichment** | `bib_enricher.py`, `aspect_extractor.py`, `aspect_worker.py`, `commands/enrich.py` | Two enrichment surfaces. (1) Bibliographic via Semantic Scholar (`bib_enricher.py` lookup + `nx enrich bib` CLI). (2) Structured aspects via Claude CLI (`aspect_extractor.py` synchronous extractor + `aspect_worker.py` async-queue daemon worker registered as the document-grain post-store hook + `nx enrich aspects` CLI). Aspect extraction is `knowledge__*` only in Phase 1 (RDR-089); the worker drains `aspect_extraction_queue` and writes to `document_aspects` |
 | **Health** | `health.py`, `logging_setup.py` | `health.py`: health check data model and runner used by `nx doctor` and `nx console`. `logging_setup.py`: structured logging configuration for CLI, console, MCP, and hook entry points (stderr + rotating file handler) |
 | **Support** | `config.py`, `registry.py`, `corpus.py`, `session.py`, `hooks.py`, `ttl.py`, `formatters.py`, `types.py`, `errors.py`, `retry.py`, `commands/_helpers.py`, `commands/_provision.py` | Configuration, naming, formatting, session lifecycle, transient-error retry. `_helpers.py`: shared CLI helpers (e.g. `default_db_path()`). `_provision.py`: ChromaDB Cloud database provisioning (tenant resolution, database creation) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -213,6 +213,20 @@ nx dt index --selection --dry-run
 | `--collection <name>` | T3 collection override. Wins over the extension-based default (e.g. `--collection knowledge__delos`) |
 | `--corpus <name>` | Corpus name used to derive the default collection (default: `dt`). PDFs route to `knowledge__<corpus>-papers` (paper-shaped, aspect-eligible); markdown notes route to `docs__<corpus>` |
 | `--dry-run` | Print records that would be indexed; make no T3 writes |
+| `--extractor [auto\|docling\|mineru]` | PDF extraction backend for file-backed records (default `auto`). `mineru` is formula-aware but can OOM-fail on formula-dense pages; the recovery is `--extractor docling` (formula-stripped, always completes) |
+| `--link-semantic` | After a record indexes, create `relates` edges to its DT similarity + explicit-link neighbours already indexed in nexus (RDR-139 Layer B). DT unavailable → zero edges. Opt-in |
+| `--writeback` | After a record indexes, stamp the nexus identity back onto the DT record (RDR-139 Layer F): `nx-indexed` / `nx-tumbler:<t>` tags + a tumbler backlink annotation. nexus-owned namespace only; never edits user content. Opt-in |
+| `--enrich` | After indexing, run a DT-CrossRef bibliographic gap-fill over each touched collection (RDR-139 Layer C): the `auto` primary backend, then DT's CrossRef resolver fills only still-empty `bib_*` fields (lowest precedence, never overwrites S2/OpenAlex). Opt-in |
+| `--dt-content` | Index non-file-backed records (web archives, bookmarks, formatted notes) from DT's AI-extracted text instead of skipping them (RDR-139 Layer D). Every such chunk is stamped `extraction_source=dt_content`; file-backed records still index from their file. DT unavailable → records skipped as before. Opt-in |
+| `--highlights` | After a record indexes, ingest its DT highlights + mentions as a markdown note attached to the record's tumbler in the `document_highlights` T2 table (RDR-139 Layer E). Read back with `nx dt highlights`. Opt-in |
+
+**RDR-139 layered ingest.** The opt-in flags above compose: a single
+`nx dt index --selection --link-semantic --writeback --enrich --highlights`
+indexes the selection, links it into the graph, gap-fills bibliographic
+metadata, stamps the nexus identity back onto each DT record, and ingests its
+highlights. Each flag degrades cleanly when DEVONthink is absent (zero edges /
+no write-back / primary-backend-only enrich / no highlight ingest); the index
+itself always succeeds. See [`docs/rdr/rdr-139-devonthink-mcp-semantic-linking-sync.md`](rdr/rdr-139-devonthink-mcp-semantic-linking-sync.md).
 
 **Default routing by extension** (nexus-cvaw): `nx dt index --uuid X` without `--collection` picks the home based on file type. PDFs land in `knowledge__<corpus>-papers` so `nx enrich aspects` can extract structured fields via `scholarly-paper-v1`. Markdown notes land in `docs__<corpus>` (no aspect extraction; `docs__` is reserved for non-paper prose per nexus-z70w). Pre-nexus-cvaw both extensions defaulted to `docs__default`, which stranded paper PDFs.
 
@@ -229,6 +243,58 @@ Exit codes:
 - `0`: indexed (or dry-ran) successfully, including the no-records case.
 - `1`: DT not running, malformed selectors, or non-darwin platform.
 - `2`: Click usage error (missing or mutually-exclusive flags).
+
+### nx dt capture
+
+Capture a URL, DOI, or file into DEVONthink and index it end to end, in one
+verb (RDR-139 Layer G). Provide exactly one source: a URL argument, `--doi`,
+or `--file`. The captured record is then indexed (and optionally linked,
+written-back, highlight-ingested, enriched).
+
+This is the one DT-bound verb: unlike `nx dt index` (which degrades silently
+when DEVONthink is absent), `nx dt capture` reports DT-required and exits
+non-zero, because capture is impossible without DEVONthink.
+
+```bash
+# Capture a web page (default: web archive) and index it.
+nx dt capture https://example.com/article
+
+# Capture as a PDF and run the full incorporation chain.
+nx dt capture https://example.com/paper --type pdf --link-semantic --writeback
+
+# Download a DOI's open-access PDF (Unpaywall) and index it.
+nx dt capture --doi 10.1038/nature12373 --contact-email you@example.com
+
+# Import a loose file from disk.
+nx dt capture --file ~/Downloads/notes.pdf
+```
+
+| Flag | Description |
+| --- | --- |
+| `<URL>` | Capture a web page via `capture_web_page` |
+| `--doi <doi>` | Capture by DOI: download the open-access PDF (Unpaywall) |
+| `--file <path>` | Import a loose file from this POSIX path |
+| `--type [html\|webarchive\|markdown\|pdf]` | Web-capture format (default `webarchive`). `pdf` and `markdown` index from the on-disk file DT creates; `html` and `webarchive` are non-file-backed |
+| `--contact-email <addr>` | Caller email for Unpaywall PDF discovery on `--doi` (else `$OPENALEX_MAILTO`) |
+| `--collection` / `--corpus` | Index-step collection / corpus (as `nx dt index`) |
+| `--link-semantic` / `--writeback` / `--highlights` / `--enrich` / `--extractor` | Forwarded to the index step |
+
+Exit codes:
+
+- `0`: captured and indexed (or the index step surfaced a per-record failure with exit 0).
+- non-zero: DEVONthink not running (DT-required), no capture source / more than one, or capture produced no record.
+
+### nx dt highlights
+
+Show the DEVONthink highlights + mentions ingested for a record (RDR-139
+Layer E). Accepts a tumbler or a DT UUID. This is a pure T2 read of the
+`document_highlights` table populated by `nx dt index --highlights`;
+DEVONthink need not be running.
+
+```bash
+nx dt highlights 1.14.4
+nx dt highlights 886082AB-87B6-4AE6-AAF6-2E80891014B6
+```
 
 ### nx dt open
 

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -4,14 +4,15 @@ Nexus ships two MCP servers, bundled in the Claude Code plugin and the Claude De
 
 For **when to use which retrieval interface**, see [Querying Guide](querying-guide.md). For conceptual background, see [Document Catalog](catalog.md) and [Storage Tiers](storage-tiers.md).
 
-## The two servers
+## The three servers
 
 | Server | Entry point | Tools | Purpose |
 |---|---|---|---|
 | `nexus` | `nx-mcp` | 26 | Storage tiers, retrieval, operators, orchestration |
 | `nexus-catalog` | `nx-mcp-catalog` | 10 | Document catalog, link graph, tumbler resolution |
+| `devonthink` | `nx-mcp-devonthink` | ~17 (DT present) / 1 (DT absent) | DEVONthink agent surface: AI/content/bib/capture tools + the `dt_incorporate` composite (RDR-139 Layer A') |
 
-Both register automatically when you install the plugin (`/plugin install conexus@nexus-plugins`) or the `.mcpb` extension. No separate install.
+The `nexus` and `nexus-catalog` servers register automatically when you install the plugin (`/plugin install conexus@nexus-plugins`) or the `.mcpb` extension. No separate install.
 
 **Substrate dependency**: since conexus 4.34.0 (RDR-120), storage tools route through the T2 daemon (and the T3 daemon in local mode). The Claude Code plugin's SessionStart hook auto-spawns `nx daemon t2 ensure-running`; for a daemon that survives reboots independent of Claude Code, run `nx daemon t2 install --autostart` once. See [Container Integration](container-integration.md) for the multi-process / multi-host model.
 
@@ -100,6 +101,36 @@ Full tool names follow `mcp__plugin_conexus_nexus-catalog__<tool>`. No redundant
 | `link_query` | Query the full link table including orphans (admin / audit view) |
 | `resolve` | Resolve a file path, title, or tumbler to a catalog entry |
 | `stats` | Summary stats — total entries, link counts by type, orphan counts |
+
+## `devonthink` — DEVONthink agent surface (RDR-139 Layer A')
+
+Full tool names follow `mcp__plugin_conexus_devonthink__<tool>`. This server is
+the agent-facing face of the DEVONthink integration: a nexus-owned MCP server
+that proxies a curated slice of DEVONthink's built-in MCP plus nexus composites.
+
+It **always spawns** and gates internally on `available()`. When DEVONthink is
+reachable it advertises the curated surface below; when DEVONthink is absent it
+advertises only `devonthink_status` (zero DT tools), still exits 0, and never
+errors a DT-less consumer. The `conexus/.mcp.json` entry carries
+`alwaysLoad:false` purely as a tool-search startup optimization — the internal
+gate is the optionality mechanism, not the `.mcp.json` flag.
+
+The agent's DEVONthink entry point is a record UUID obtained from a **nexus**
+search (DT's own selectors stay on the `nx dt` CLI, out of scope here), after
+which it uses these tools and the `dt_incorporate` composite.
+
+| Tool | Purpose |
+|---|---|
+| `devonthink_status` | Whether DT is reachable + open-database count (the always-present stub) |
+| `find_similar_records` | DT AI "See Also" neighbours of a record |
+| `classify_record` | DT AI suggested groups for a record |
+| `extract_record_content` | AI-optimised text of a record |
+| `extract_record_highlights` / `extract_record_mentions` | Markdown summary of a record's highlights / mentions |
+| `get_record_text` / `get_record_annotation` | A record's body / annotation note |
+| `get_record_links` / `get_databases` | A record's item links / the open databases |
+| `resolve_doi_metadata` / `search_crossref` / `resolve_google_books_metadata` | Bibliographic resolution (CrossRef / Google Books) |
+| `capture_web_page` / `download_pdf_from_doi` / `import_file` | Capture a URL / DOI PDF / loose file into DT |
+| `dt_incorporate` | Composite: for an already-indexed record, create DT-derived `relates` edges (Layer B) and stamp the nexus identity back onto the DT record (Layer F), in one agent call |
 
 ## CLI-only operations
 


### PR DESCRIPTION
Closes the doc drift before the conexus 5.5.0 release — RDR-139 shipped a large surface with no user-facing docs.

- **cli-reference**: new `nx dt capture` (Layer G) and `nx dt highlights` (Layer E) sections; `nx dt index` flag table extended with `--extractor`/`--link-semantic`/`--writeback`/`--enrich`/`--dt-content`/`--highlights` + a layered-ingest note.
- **architecture**: `document_highlights` documented as the eighth eager T2 store (stores table + facade construction order + the diagram); `nx-mcp-devonthink` added to the MCP Servers row.
- **mcp-servers**: 'three servers' table + a full `devonthink` server section (gate semantics, curated tool list, `dt_incorporate` composite).

Lands on develop before the release branch is cut.