### PR TITLE
fix(tests): repair develop red — extractor kwarg in dt-highlights stubs

### DIFF
--- a/tests/test_dt_highlights_layer_e.py
+++ b/tests/test_dt_highlights_layer_e.py
@@ -131,7 +131,7 @@ def test_index_highlights_flag_routes_and_summarizes(runner, fake_gather, monkey
 
     fake_gather.append(("U1", "/a.pdf"))
     monkeypatch.setattr("nexus.commands.dt._index_record",
-                        lambda uuid, path, *, collection, corpus, dry_run: True)
+                        lambda uuid, path, *, collection, corpus, dry_run, extractor="auto": True)
     calls: list[str] = []
     monkeypatch.setattr("nexus.commands.dt._ingest_highlights_record",
                         lambda uuid: calls.append(uuid) or True)
@@ -146,7 +146,7 @@ def test_no_highlights_flag_skips_ingest(runner, fake_gather, monkeypatch) -> No
 
     fake_gather.append(("U1", "/a.pdf"))
     monkeypatch.setattr("nexus.commands.dt._index_record",
-                        lambda uuid, path, *, collection, corpus, dry_run: True)
+                        lambda uuid, path, *, collection, corpus, dry_run, extractor="auto": True)
     calls: list[str] = []
     monkeypatch.setattr("nexus.commands.dt._ingest_highlights_record",
                         lambda uuid: calls.append(uuid) or True)


### PR DESCRIPTION
**develop is currently red.** #1033 (`--extractor` passthrough) added the `extractor` kwarg to `_index_record` and updated the stubs in `test_commands_dt.py` + `test_dt_capture_cmd.py`, but missed two `_index_record` stubs in `test_dt_highlights_layer_e.py`:
- `test_index_highlights_flag_routes_and_summarizes`
- `test_no_highlights_flag_skips_ingest`

Their lambdas raised `TypeError: unexpected keyword argument 'extractor'` → 2 failing tests on develop. #1033's PR CI did not surface it (a stale-merge CI artifact — the merge result wasn't re-run against the final base); the pre-5.5.0 **release prep** caught it, which is exactly what that gate is for.

Fix: add `extractor="auto"` to both stubs. No production code change. Swept the suite — these were the only two remaining broken stubs. 101 dt tests green locally.

This unblocks the stuck doc PRs (#1034, #1035 inherited the red base) and the 5.5.0 release.