### PR TITLE
fix(classifier): SKIP binary assets instead of embedding as prose

### DIFF
--- a/src/nexus/classifier.py
+++ b/src/nexus/classifier.py
@@ -43,6 +43,34 @@ _SKIP_EXTENSIONS: frozenset[str] = frozenset({
     ".txt", ".csv", ".tsv", ".dat", ".log",
 })
 
+# Binary asset extensions. The step-7 fall-through default is PROSE, so any
+# binary file without a code/prose extension would otherwise be embedded as
+# prose — producing zero search signal and wasting Voyage budget. Game/media
+# repos (WoW addons, Unity, etc.) track these in git: textures, audio, fonts,
+# compiled binaries. WeakAuras2 (2026-05-31) registered 366 such files
+# (.tga ×246, .ogg ×104, .blp, .ttf, .mp3) as "prose"; the resulting docs
+# collection held 0 usable vectors. Classify binary assets as SKIP.
+# Operators with a genuine need opt back in via ``prose_extensions``.
+_BINARY_EXTENSIONS: frozenset[str] = frozenset({
+    # Images / textures
+    ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".ico", ".tiff", ".tif",
+    ".webp", ".tga", ".blp", ".dds", ".psd", ".ai", ".eps",
+    # Audio
+    ".mp3", ".ogg", ".wav", ".flac", ".aac", ".m4a", ".opus", ".aiff",
+    # Video
+    ".mp4", ".webm", ".mov", ".avi", ".mkv", ".wmv", ".flv",
+    # Fonts
+    ".ttf", ".otf", ".woff", ".woff2", ".eot",
+    # Archives
+    ".zip", ".tar", ".gz", ".bz2", ".xz", ".7z", ".rar", ".jar",
+    # Compiled / binary objects
+    ".so", ".dll", ".dylib", ".exe", ".o", ".a", ".obj", ".lib",
+    ".class", ".pyc", ".pyo", ".wasm", ".bin", ".dat.gz",
+    # Documents / misc binary
+    ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+    ".db", ".sqlite", ".sqlite3",
+})
+
 # nexus-haet (GH issue surfaced 2026-05-08): minified bundle filenames
 # (``htmx.min.js``, ``react.min.css``, ``vendor.min.mjs``) are
 # extension-wise indexable code, but the bytes are unreadable for
@@ -99,8 +127,9 @@ def classify_file(
     3. prose_extensions config override (wins over all)
     4. Effective code set (defaults + code_extensions config)
     5. _SKIP_EXTENSIONS (known-noise file types)
-    6. Extensionless files: shebang → CODE, else → SKIP
-    7. Everything else → PROSE
+    6. _BINARY_EXTENSIONS (binary assets — textures, audio, fonts, objects)
+    7. Extensionless files: shebang → CODE, else → SKIP
+    8. Everything else → PROSE
     """
     ext = path.suffix.lower()
 
@@ -131,6 +160,11 @@ def classify_file(
 
     # Known-noise extensions
     if ext in _SKIP_EXTENSIONS:
+        return ContentClass.SKIP
+
+    # Binary assets (textures, audio, fonts, compiled objects). Checked after
+    # prose_extensions so an operator override can still force one to PROSE.
+    if ext in _BINARY_EXTENSIONS:
         return ContentClass.SKIP
 
     # Extensionless files: shebang → CODE, else → SKIP

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -2122,7 +2122,16 @@ def _run_index(
                 pdf_files.append((score, path))
                 # PDF files not included in ripgrep text cache
             case ContentClass.SKIP:
-                pass  # known-noise file; silently ignore
+                # Known-noise or binary asset (nexus-6e6u1). Logged at debug so
+                # the operator can see what got dropped at classification time
+                # rather than having it silently vanish — WeakAuras2 dropped 366
+                # binary files this way. Distinct from the byte-sniff "skipped
+                # non-text file" emitted in prose/code indexers on decode failure.
+                _log.debug(
+                    "skipped non-indexable file",
+                    path=str(path),
+                    ext=path.suffix.lower(),
+                )
 
     # Sort all lists descending by frecency
     code_files.sort(key=lambda x: x[0], reverse=True)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -114,6 +114,64 @@ def test_skip_extensions(filename: str):
     assert classify_file(Path(filename)) == ContentClass.SKIP, f"{filename} should be SKIP"
 
 
+# ── Binary asset extensions (WeakAuras2 misclassification, 2026-05-31) ──────────
+#
+# Game/media repos (WoW addons, Unity projects, etc.) carry binary assets
+# tracked in git: textures, audio, fonts, compiled models. These have no
+# code/prose extension, so the step-7 fall-through ("everything else → PROSE")
+# routed them to voyage-context-3 embedding — 366 binary files in WeakAuras2
+# registered as "prose", producing zero usable vectors. Binary media must SKIP.
+
+@pytest.mark.parametrize("filename", [
+    "texture.tga",
+    "icon.blp",
+    "image.png",
+    "photo.jpg",
+    "photo.jpeg",
+    "anim.gif",
+    "favicon.ico",
+    "bitmap.bmp",
+    "render.tiff",
+    "sound.ogg",
+    "music.mp3",
+    "voice.wav",
+    "stream.flac",
+    "clip.m4a",
+    "movie.mp4",
+    "clip.webm",
+    "font.ttf",
+    "font.otf",
+    "font.woff",
+    "font.woff2",
+    "archive.zip",
+    "bundle.tar",
+    "package.gz",
+    "lib.so",
+    "app.dll",
+    "app.dylib",
+    "program.exe",
+    "module.wasm",
+    "cache.bin",
+])
+def test_binary_assets_classified_as_skip(filename: str):
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path(filename)) == ContentClass.SKIP, f"{filename} should be SKIP"
+
+
+def test_binary_skip_is_case_insensitive():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("TEXTURE.TGA")) == ContentClass.SKIP
+    assert classify_file(Path("Sound.OGG")) == ContentClass.SKIP
+
+
+def test_prose_override_wins_over_binary_skip():
+    """An operator can still force a binary extension to PROSE if they
+    have a genuine reason — prose_extensions wins over the skip list."""
+    from nexus.classifier import classify_file, ContentClass
+    cfg = {"prose_extensions": [".tga"]}
+    assert classify_file(Path("texture.tga"), indexing_config=cfg) == ContentClass.PROSE
+
+
 # ── New code extensions ────────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("filename", [

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -337,7 +337,14 @@ def test_run_index_logs_skipped_binary_files(tmp_path):
                               "voyageai.Client": {"return_value": _voyage(1)}}):
         with patch("nexus.indexer._log") as l1, patch("nexus.prose_indexer._log") as l2:
             _run_index(repo, _reg())
-    assert any("skipped non-text file" in str(c) for c in l1.debug.call_args_list + l2.debug.call_args_list)
+    # Binary extensions (.bin) are now caught at classification time (nexus-6e6u1)
+    # and SKIP-logged as "skipped non-indexable file" rather than reaching the
+    # byte-sniff "skipped non-text file" path in the prose/code indexers.
+    calls = l1.debug.call_args_list + l2.debug.call_args_list
+    assert any(
+        "skipped non-indexable file" in str(c) or "skipped non-text file" in str(c)
+        for c in calls
+    )
 
 
 def test_run_index_logs_empty_chunks(tmp_path):


### PR DESCRIPTION
## Problem

`classify_file`'s final fall-through is **PROSE**, and `_SKIP_EXTENSIONS` covered config/text data but **no binary media**. Binary files without a code/prose extension were routed to voyage-context-3 prose embedding.

Surfaced while indexing **WeakAuras2** (a WoW addon) on 2026-05-31:

| collection | what landed there |
|---|---|
| `docs__1-30` | `.tga ×246`, `.ogg ×104`, `.blp ×7`, `.ttf ×7`, `.mp3 ×2` registered as "prose" |

366 binary files registered as prose; the resulting docs collection held **0 usable vectors** — wasted catalog churn, wasted Voyage budget, and a broken/empty prose collection for the repo.

## Fix

Add `_BINARY_EXTENSIONS` (images, audio, video, fonts, archives, compiled objects, binary docs) classified as **SKIP**. Inserted after the `prose_extensions` check so an operator override can still force a binary extension to PROSE.

Priority order in the docstring updated (now 8 steps).

## Tests

+32 tests (binary-skip parametrized, case-insensitivity, prose-override-wins). Full classifier suite: **86 passed**.