### PR TITLE
chore: reconcile main into develop (5.5.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.5.0"
+        "ref": "v5.5.1"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.5.0"
+      "version": "5.5.1"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.5.0"
+        "ref": "v5.5.1"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.5.0"
+      "version": "5.5.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.5.1] - 2026-05-31
+
+### Fixed
+
+- **Routing hooks now deliver their deny reason to the model.** The PreToolUse
+  routing hooks (grep→Serena redirect, `git add` wildcard guard,
+  phase-review-close gate) emitted only the legacy `reason` field, which current
+  Claude Code does not read on a deny — so a blocked command arrived as a bare
+  "denied" with no cause or remediation. They now emit `permissionDecisionReason`
+  (the full remediation text, model-facing) plus a short top-level
+  `systemMessage` that renders as a terse one-line transcript banner instead of
+  the full remediation essay. `deny(reason, summary=...)` decouples the two
+  audiences. [nexus-rpvqu]
+
+### Changed
+
+- Tightened the grep→Serena redirect message (~38% smaller): the directive plus
+  the exact Serena tool calls, with the human-doc justification prose removed.
+
+### Internal
+
+- Substantial cc-validation harness overhaul (test infrastructure; not
+  user-facing): keychain-based credential provisioning, deterministic
+  `--mcp-config` launch with trust pre-seed, deferred-MCP-tool warmup, a
+  scenario-isolation fix, and elimination of vacuous-pass / model-output-fragile
+  assertions across the routing/MCP/permission scenarios.
+
 ## [5.5.0] - 2026-05-31
 
 ### Added

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.5.1] - 2026-05-31
+
+### Fixed
+
+- **Routing hooks now deliver their deny reason to the model.** The conexus
+  routing hooks (`git add` wildcard guard, phase-review-close gate) emitted only
+  the legacy `reason` field, which current Claude Code does not read on a deny.
+  They now emit `permissionDecisionReason` (full remediation, model-facing) plus
+  a short top-level `systemMessage` transcript banner. Plugin version aligned
+  with conexus 5.5.1. [nexus-rpvqu]
+
 ## [5.5.0] - 2026-05-31
 
 ### Added

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.5.0"
+version = "5.5.1"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.5.0",
+    "conexus>=5.5.1",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.5.0"
+version = "5.5.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.5.0"
+version = "5.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
Brings the 5.5.1 release commits from main back into develop. develop was a strict ancestor of main (no divergence) — this is the standard post-release reconciliation merge so develop carries the version bump and release artifacts.

## Contents
- `chore(release): conexus 5.5.1` (#1039) — version bump across all manifests + uv.lock.

No code changes beyond the release bump; develop now reads version 5.5.1.