### PR TITLE
RDR-140 P1+P2: stop the noise + single-flight election

### DIFF
--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -684,6 +684,72 @@ _T2_CYCLE_DB_PROBE_TIMEOUT_MS: int = 30000
 # shrink it.
 _T2_CYCLE_EXIT_TIMEOUT: float = 10.0
 
+# RDR-140 P2.2 (nexus-fkhe2): how long ``ensure-running`` blocks on the
+# single-flight election lock before giving up and proceeding to spawn anyway.
+# The election lock makes only one of K racing stacks cold-spawn; on timeout we
+# degrade to the pre-P2 behaviour (the daemon's own spawn lock is still the hard
+# backstop, so a redundant spawn merely quiet-attaches — never a deadlock).
+# Module constant so tests can shrink it.
+_T2_ELECTION_WAIT_TIMEOUT: float = 15.0
+
+
+def _election_lock_path_for_db(db_path: Path) -> Path:
+    """Election-coordination lock path for *db_path*.
+
+    RDR-140 P2.2: a sibling of the data file (``<db>.election_lock``) so stacks
+    started from different ``config_dir``s against the same data file contend
+    on one election. DISTINCT from the daemon's lifetime spawn lock
+    (``<db>.spawn_lock`` / ``t2_spawn.lock``): if ``ensure-running`` held the
+    daemon's own spawn lock, the spawned ``t2 start`` child would hit EAGAIN on
+    its ``_acquire_spawn_lock`` and exit, leaving zero daemons.
+    """
+    return db_path.parent / f"{db_path.name}.election_lock"
+
+
+def _acquire_election_lock(db_path: Path, timeout: float) -> int | None:
+    """Blocking-with-timeout ``LOCK_EX`` on the election lock. Returns the held
+    fd, or ``None`` if the timeout elapsed (caller proceeds unguarded).
+
+    Blocking (not ``LOCK_NB``-fail-fast) so waiters queue then re-discover; the
+    daemon's ``_acquire_spawn_lock`` uses ``LOCK_NB`` and must not, hence the
+    distinct lock file. Auto-releases on holder death (the OS drops the fd's
+    lock), so a holder that crashes mid-spawn never deadlocks the waiters.
+    """
+    import errno
+    import fcntl
+
+    path = _election_lock_path_for_db(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT, 0o600)
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd
+        except OSError as exc:
+            if exc.errno not in (errno.EAGAIN, errno.EACCES):
+                os.close(fd)
+                raise
+            if time.monotonic() >= deadline:
+                os.close(fd)
+                return None
+            time.sleep(0.05)
+
+
+def _release_election_lock(fd: int | None) -> None:
+    if fd is None:
+        return
+    import fcntl
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError:
+        pass
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
 
 def _predecessor_alive(pid: int) -> bool:
     """True iff *pid* is alive AND still looks like a t2 daemon.
@@ -818,125 +884,158 @@ def t2_ensure_running_cmd(
         except PackageNotFoundError:
             return ""
 
+    # Fast pre-discovery (lock-free common case): a live matching-version
+    # daemon means we are done without ever touching the election lock —
+    # bounded boot latency is paid only on the actual spawn path.
     running = _running_daemon()
     if running is not None:
-        running_pid, running_ver = running
+        _running_pid, running_ver = running
         installed = _installed_version()
-        # A live daemon whose version matches the installed tool (or whose
-        # installed version can't be determined) is left alone (idempotent).
         if not installed or running_ver == installed:
             if not quiet:
                 click.echo("T2 daemon already running.")
             return
-        # Version skew: the daemon froze its code at start and predates the
-        # last upgrade (nexus-5ldk1). "Ensure running" means ensure a
-        # CURRENT daemon; gracefully cycle the stale one and respawn below.
-        # SIGTERM lets the daemon drain in-flight RPC (stop() awaits
-        # wait_closed) and remove its discovery file before we respawn.
-        #
-        # RDR-128 P0b (RF-4): but do NOT SIGTERM a healthy (if stale) daemon
-        # while memory.db's WAL writer lock is held — the respawn's startup
-        # migration would race the holder (typically `nx index repo`) and
-        # could crash-loop, and because ensure-running is one-shot we'd be
-        # left with NO daemon. Probe the lock with a bounded timeout; on
-        # timeout, ABORT the cycle: leave the stale-but-working daemon up and
-        # defer to the next ensure-running. Never hang; never trade a working
-        # daemon for none.
-        db_path = config_dir / "memory.db"
-        if not _t2_db_write_lock_acquirable(
-            db_path, timeout_ms=_T2_CYCLE_DB_PROBE_TIMEOUT_MS
-        ):
-            click.echo(
-                f"T2 daemon v{running_ver} stale but memory.db write lock "
-                f"held; cycle deferred (will retry on next ensure-running).",
-                err=True,
-            )
-            return  # leave the stale daemon up — best-effort, retried later
-        if not quiet:
-            click.echo(
-                f"T2 daemon is stale (running {running_ver}, installed "
-                f"{installed}); cycling to current."
-            )
-        try:
-            os.kill(running_pid, signal.SIGTERM)
-        except (ProcessLookupError, PermissionError):
-            pass
-        # RDR-129 A2 (nexus-kwqhd): poll the predecessor's PID liveness, NOT
-        # the discovery file. stop() now holds the spawn lock until the
-        # process exits (defer-release-to-exit) while unlinking the discovery
-        # file early; a discovery-file poll would see "gone" while the pid is
-        # still alive and holding the lock, so the cold spawn below would hit
-        # EAGAIN on the spawn lock and leave ZERO daemons. Wait for the pid to
-        # actually exit (lock dropped by the OS); if it outlives the window,
-        # abort and keep the stale-but-working daemon (RF-4: never trade a
-        # working daemon for none).
-        cycle_deadline = _time.monotonic() + _T2_CYCLE_EXIT_TIMEOUT
-        while _time.monotonic() < cycle_deadline:
-            if not _predecessor_alive(running_pid):
-                break
-            _time.sleep(0.1)
-        else:
-            click.echo(
-                f"T2 daemon v{running_ver} (pid {running_pid}) did not exit "
-                f"within {_T2_CYCLE_EXIT_TIMEOUT}s of SIGTERM; cycle aborted, "
-                "leaving it up (will retry on next ensure-running).",
-                err=True,
-            )
-            return  # never trade a working daemon for none
-        # predecessor fully exited; its spawn lock is released — cold spawn.
 
-    # Cold spawn. Use the same nx binary the operator invoked (preserves
-    # PATH/virtualenv assumptions). start_new_session detaches the child
-    # so this command can exit while the daemon keeps running.
-    nx_bin = _resolve_nx_bin()
-    argv = [*nx_bin, "daemon", "t2", "start"]
-    if config_dir_str is not None:
-        argv.extend(["--config-dir", config_dir_str])
-    if not quiet:
-        click.echo(f"Spawning T2 daemon: {' '.join(argv)}")
-    proc = subprocess.Popen(
-        argv,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        stdin=subprocess.DEVNULL,
-        start_new_session=True,
-    )
-
-    # nexus-u3mfr: migration-aware wait. A cold-start daemon runs its
-    # one-time startup migration (multi-second, holds the write lock)
-    # BEFORE it binds and writes the discovery file, so reachability
-    # legitimately lags the spawn by several seconds. The fix is two-fold:
-    # the default budget is generous enough to cover the migration
-    # (--timeout default raised to 15s), AND we distinguish "still alive,
-    # migrating" from "the process died" — if the spawned child exits
-    # without becoming reachable we fail fast with its exit code rather
-    # than waiting out the whole budget on a corpse. The warning therefore
-    # only fires on a genuinely slow/stuck migration, not a healthy boot.
-    deadline = _time.monotonic() + timeout
-    while _time.monotonic() < deadline:
-        if _daemon_is_alive():
+    # RDR-140 P2.2 (nexus-fkhe2): single-flight election around the
+    # discover→spawn decision. K racing stacks block on this lock; only the
+    # holder cold-spawns. We RE-DISCOVER after acquiring it so a stack that
+    # finished spawning while we waited is attached, not duplicated. The lock
+    # is anchored on the data file and is DISTINCT from the daemon's lifetime
+    # spawn lock; fcntl auto-releases it on the holder's death, so a holder
+    # that dies mid-spawn never deadlocks the waiters (they win the lock,
+    # re-discover no daemon, and exactly one spawns).
+    db_path = config_dir / "memory.db"
+    election_fd = _acquire_election_lock(db_path, _T2_ELECTION_WAIT_TIMEOUT)
+    if election_fd is None and not quiet:
+        click.echo(
+            "T2 election-lock wait timed out; proceeding to spawn unguarded "
+            "(the daemon spawn lock remains the backstop).",
+            err=True,
+        )
+    try:
+        # Re-discover under the lock — the winner may have come up already.
+        running = _running_daemon()
+        if running is not None:
+            running_pid, running_ver = running
+            installed = _installed_version()
+            # A live daemon whose version matches the installed tool (or whose
+            # installed version can't be determined) is left alone (idempotent).
+            if not installed or running_ver == installed:
+                if not quiet:
+                    click.echo("T2 daemon already running.")
+                return
+            # Version skew: the daemon froze its code at start and predates the
+            # last upgrade (nexus-5ldk1). "Ensure running" means ensure a
+            # CURRENT daemon; gracefully cycle the stale one and respawn below.
+            # SIGTERM lets the daemon drain in-flight RPC (stop() awaits
+            # wait_closed) and remove its discovery file before we respawn.
+            #
+            # RDR-128 P0b (RF-4): but do NOT SIGTERM a healthy (if stale)
+            # daemon while memory.db's WAL writer lock is held — the respawn's
+            # startup migration would race the holder (typically `nx index
+            # repo`) and could crash-loop, and because ensure-running is
+            # one-shot we'd be left with NO daemon. Probe the lock with a
+            # bounded timeout; on timeout, ABORT the cycle: leave the
+            # stale-but-working daemon up and defer to the next ensure-running.
+            # Never hang; never trade a working daemon for none.
+            if not _t2_db_write_lock_acquirable(
+                db_path, timeout_ms=_T2_CYCLE_DB_PROBE_TIMEOUT_MS
+            ):
+                click.echo(
+                    f"T2 daemon v{running_ver} stale but memory.db write lock "
+                    f"held; cycle deferred (will retry on next ensure-running).",
+                    err=True,
+                )
+                return  # leave the stale daemon up — best-effort, retried later
             if not quiet:
-                click.echo("T2 daemon is reachable.")
-            return
-        if proc.poll() is not None:
-            click.echo(
-                f"Error: T2 daemon process exited (code {proc.returncode}) "
-                "before becoming reachable. Check ~/Library/Logs/nexus-t2.err "
-                "(macOS) or `journalctl --user -u nexus-t2.service` (Linux) "
-                "for the failure.",
-                err=True,
-            )
-            sys.exit(1)
-        _time.sleep(0.1)
+                click.echo(
+                    f"T2 daemon is stale (running {running_ver}, installed "
+                    f"{installed}); cycling to current."
+                )
+            try:
+                os.kill(running_pid, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError):
+                pass
+            # RDR-129 A2 (nexus-kwqhd): poll the predecessor's PID liveness,
+            # NOT the discovery file. stop() now holds the spawn lock until the
+            # process exits (defer-release-to-exit) while unlinking the
+            # discovery file early; a discovery-file poll would see "gone"
+            # while the pid is still alive and holding the lock, so the cold
+            # spawn below would hit EAGAIN on the spawn lock and leave ZERO
+            # daemons. Wait for the pid to actually exit (lock dropped by the
+            # OS); if it outlives the window, abort and keep the
+            # stale-but-working daemon (RF-4: never trade a working daemon for
+            # none).
+            cycle_deadline = _time.monotonic() + _T2_CYCLE_EXIT_TIMEOUT
+            while _time.monotonic() < cycle_deadline:
+                if not _predecessor_alive(running_pid):
+                    break
+                _time.sleep(0.1)
+            else:
+                click.echo(
+                    f"T2 daemon v{running_ver} (pid {running_pid}) did not "
+                    f"exit within {_T2_CYCLE_EXIT_TIMEOUT}s of SIGTERM; cycle "
+                    "aborted, leaving it up (will retry on next "
+                    "ensure-running).",
+                    err=True,
+                )
+                return  # never trade a working daemon for none
+            # predecessor fully exited; its spawn lock is released — cold spawn.
 
-    click.echo(
-        f"Warning: T2 daemon did not become reachable within {timeout}s "
-        "(process still alive — likely a slow or stalled startup "
-        "migration). Check ~/Library/Logs/nexus-t2.err (macOS) or "
-        "`journalctl --user -u nexus-t2.service` (Linux) for the failure.",
-        err=True,
-    )
-    sys.exit(1)
+        # Cold spawn. Use the same nx binary the operator invoked (preserves
+        # PATH/virtualenv assumptions). start_new_session detaches the child
+        # so this command can exit while the daemon keeps running.
+        nx_bin = _resolve_nx_bin()
+        argv = [*nx_bin, "daemon", "t2", "start"]
+        if config_dir_str is not None:
+            argv.extend(["--config-dir", config_dir_str])
+        if not quiet:
+            click.echo(f"Spawning T2 daemon: {' '.join(argv)}")
+        proc = subprocess.Popen(
+            argv,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+        # nexus-u3mfr: migration-aware wait. A cold-start daemon runs its
+        # one-time startup migration (multi-second, holds the write lock)
+        # BEFORE it binds and writes the discovery file, so reachability
+        # legitimately lags the spawn by several seconds. The fix is two-fold:
+        # the default budget is generous enough to cover the migration
+        # (--timeout default raised to 15s), AND we distinguish "still alive,
+        # migrating" from "the process died" — if the spawned child exits
+        # without becoming reachable we fail fast with its exit code rather
+        # than waiting out the whole budget on a corpse. The warning therefore
+        # only fires on a genuinely slow/stuck migration, not a healthy boot.
+        deadline = _time.monotonic() + timeout
+        while _time.monotonic() < deadline:
+            if _daemon_is_alive():
+                if not quiet:
+                    click.echo("T2 daemon is reachable.")
+                return
+            if proc.poll() is not None:
+                click.echo(
+                    f"Error: T2 daemon process exited (code {proc.returncode}) "
+                    "before becoming reachable. Check "
+                    "~/Library/Logs/nexus-t2.err (macOS) or `journalctl "
+                    "--user -u nexus-t2.service` (Linux) for the failure.",
+                    err=True,
+                )
+                sys.exit(1)
+            _time.sleep(0.1)
+
+        click.echo(
+            f"Warning: T2 daemon did not become reachable within {timeout}s "
+            "(process still alive — likely a slow or stalled startup "
+            "migration). Check ~/Library/Logs/nexus-t2.err (macOS) or "
+            "`journalctl --user -u nexus-t2.service` (Linux) for the failure.",
+            err=True,
+        )
+        sys.exit(1)
+    finally:
+        _release_election_lock(election_fd)
 
 
 @t2_group.command("install")

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -684,13 +684,34 @@ _T2_CYCLE_DB_PROBE_TIMEOUT_MS: int = 30000
 # shrink it.
 _T2_CYCLE_EXIT_TIMEOUT: float = 10.0
 
-# RDR-140 P2.2 (nexus-fkhe2): how long ``ensure-running`` blocks on the
-# single-flight election lock before giving up and proceeding to spawn anyway.
-# The election lock makes only one of K racing stacks cold-spawn; on timeout we
-# degrade to the pre-P2 behaviour (the daemon's own spawn lock is still the hard
-# backstop, so a redundant spawn merely quiet-attaches — never a deadlock).
-# Module constant so tests can shrink it.
-_T2_ELECTION_WAIT_TIMEOUT: float = 15.0
+# RDR-140 P2.2 (nexus-fkhe2): safety margin added on top of the holder's
+# worst-case hold time to derive how long a waiter blocks on the single-flight
+# election lock. The wait is computed DYNAMICALLY (see
+# ``_election_wait_for``) rather than fixed: the holder keeps the lock across
+# its whole discover→spawn→reachability path, whose worst case is
+# ``_T2_CYCLE_DB_PROBE_TIMEOUT_MS/1000`` (stale-version write-lock probe) +
+# ``_T2_CYCLE_EXIT_TIMEOUT`` (predecessor exit poll) + ``timeout`` (reachability
+# poll). A fixed wait shorter than that hold reproduces the pre-P2 thundering
+# herd on timeout (code-review H-1 / critic S-1): every waiter times out at
+# once, re-discovers the stale/absent daemon unguarded, and all cold-spawn.
+# Deriving the wait from the same budgets guarantees a waiter never gives up
+# before the holder releases, on any ``--timeout``. Releasing the lock earlier
+# (before the reachability poll) is NOT an option: a waiter acquiring it during
+# the winner's migration window would re-discover no live daemon and spawn too,
+# defeating single-flight. Margin is a module constant so tests can shrink it.
+_T2_ELECTION_WAIT_MARGIN: float = 5.0
+
+
+def _election_wait_for(timeout: float) -> float:
+    """Waiter election-lock budget: must exceed the holder's worst-case hold so
+    waiters block until the winner is reachable, then attach rather than
+    redundantly spawn (RDR-140 P2.2)."""
+    return (
+        _T2_CYCLE_DB_PROBE_TIMEOUT_MS / 1000.0
+        + _T2_CYCLE_EXIT_TIMEOUT
+        + timeout
+        + _T2_ELECTION_WAIT_MARGIN
+    )
 
 
 def _election_lock_path_for_db(db_path: Path) -> Path:
@@ -905,7 +926,7 @@ def t2_ensure_running_cmd(
     # that dies mid-spawn never deadlocks the waiters (they win the lock,
     # re-discover no daemon, and exactly one spawns).
     db_path = config_dir / "memory.db"
-    election_fd = _acquire_election_lock(db_path, _T2_ELECTION_WAIT_TIMEOUT)
+    election_fd = _acquire_election_lock(db_path, _election_wait_for(timeout))
     if election_fd is None and not quiet:
         click.echo(
             "T2 election-lock wait timed out; proceeding to spawn unguarded "

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -529,8 +529,14 @@ def t2_start_cmd(config_dir_str: str | None, db_path_str: str | None) -> None:
     systemd via ``nx daemon t2 install --autostart`` for production
     use; the foreground requirement is what the supervisor watches.
 
-    Refuses to start if another T2 daemon already holds the spawn
-    lock on the same config_dir (raises T2DaemonError fail-loud).
+    If another T2 daemon already holds the spawn lock (a live winner
+    already owns the data file), this process quiet-attaches instead of
+    crashing (RDR-140 P1.3): ``run_t2_daemon`` logs ``t2_daemon_spawn_lost``
+    at info and returns, so the command exits 0 with no traceback. The
+    launchd/systemd template treats a zero exit as "do not restart"
+    (see the install command), so a loser does not trigger a respawn loop.
+    A genuine lifecycle error (bind failed, etc.) still raises
+    ``T2DaemonError`` and exits 2.
     """
     from nexus.commands._helpers import default_db_path
     from nexus.daemon.t2_daemon import T2DaemonError, run_t2_daemon

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -84,6 +84,18 @@ _PREDECESSOR_REAP_TIMEOUT: float = 5.0
 # Module constant so tests can shrink the sleeps.
 _DISPATCH_RETRY_SLEEPS: tuple[float, ...] = (0.1, 0.25)
 
+# RDR-140 P1.3 (nexus-h2oko): self-healing discovery re-assert + loser poll.
+# The spawn-lock HOLDER re-asserts its own t2_addr discovery file every
+# ``_REASSERT_INTERVAL`` so a transient gap (a stale/lost addr file while the
+# daemon is alive) self-heals instead of stranding clients. A spawn-lock LOSER
+# polls for the winner's discovery file/socket for up to ``_LOSER_POLL_TIMEOUT``
+# before quiet-exiting 0. Invariant: ``_LOSER_POLL_TIMEOUT`` >=
+# ``_REASSERT_INTERVAL`` + worst-case write latency, so a loser polling for the
+# winner's file never times out inside a window where the holder is mid-
+# re-assert. Module-level so tests can shrink them.
+_REASSERT_INTERVAL: float = 1.0
+_LOSER_POLL_TIMEOUT: float = 3.0
+
 
 def _is_locked_error(exc: BaseException) -> bool:
     """True when *exc* is transient WAL writer-lock contention
@@ -287,6 +299,17 @@ class ProtocolError(Exception):
 class T2DaemonError(RuntimeError):
     """Raised on daemon lifecycle errors (bind failed, address in use,
     discovery write failed, etc.)."""
+
+
+class T2SpawnLockLost(T2DaemonError):
+    """RDR-140 P1.3 (nexus-h2oko): the spawn lock is already held by a live
+    winner, so this process must quiet-attach and exit 0 — NOT crash.
+
+    Subclasses :class:`T2DaemonError` so existing callers that catch the base
+    (and assert ``"spawn lock"`` in the message) keep working; ``run_t2_daemon``
+    catches this subtype first to short-circuit the crash path. A1-verified:
+    raised from ``_acquire_spawn_lock`` (start():645) strictly BEFORE any
+    ``T2Database`` construction (:658), so a loser never opens the DB."""
 
 
 # ---------------------------------------------------------------------------
@@ -612,6 +635,9 @@ class T2Daemon:
         self._spawn_lock_fd: int | None = None
         self._spawn_lock_fd_path: int | None = None
         self._stop_event: asyncio.Event | None = None
+        # RDR-140 P1.3: self-healing discovery re-assert (holder only).
+        self._discovery_payload: dict[str, Any] | None = None
+        self._reassert_task: asyncio.Task[None] | None = None
 
     # ── public properties ───────────────────────────────────────────────
 
@@ -677,6 +703,14 @@ class T2Daemon:
             daemon_version=_daemon_version(),
         )
         _write_discovery_atomic(self._discovery_path, payload)
+        self._discovery_payload = payload
+
+        # RDR-140 P1.3: start the self-healing re-assert task now that the
+        # discovery file is written. It re-creates the file if it ever goes
+        # missing while we (the spawn-lock holder) are alive. stop() cancels
+        # it BEFORE unlinking the discovery file so it cannot resurrect a
+        # mid-shutdown daemon's addr (RDR-129 early-unlink ordering).
+        self._reassert_task = asyncio.create_task(self._reassert_discovery_loop())
 
         self._stop_event = asyncio.Event()
         _log.info(
@@ -686,6 +720,40 @@ class T2Daemon:
             tcp_port=self._tcp_port,
             db_path=str(self._db_path),
         )
+
+    async def _reassert_discovery_loop(self) -> None:
+        """Periodically re-assert our own discovery file (holder self-heal).
+
+        RDR-140 P1.3 (nexus-h2oko): a transient loss of the t2_addr file while
+        the daemon is alive otherwise strands clients (the race-harness saw all
+        racers crash in the discovery-gap case). Every ``_REASSERT_INTERVAL``
+        we re-write the file iff it is missing or no longer names our pid;
+        when it is intact this is a cheap stat + read with no write. Cancelled
+        at the START of :meth:`stop` so it can never resurrect a file the
+        shutdown unlink just removed.
+        """
+        while True:
+            await asyncio.sleep(_REASSERT_INTERVAL)
+            path = self._discovery_path
+            payload = self._discovery_payload
+            if path is None or payload is None:
+                continue
+            try:
+                needs_write = True
+                if path.exists():
+                    try:
+                        current = json.loads(path.read_text())
+                        needs_write = current.get("pid") != payload["pid"]
+                    except (OSError, json.JSONDecodeError):
+                        needs_write = True
+                if needs_write:
+                    _write_discovery_atomic(path, payload)
+                    _log.info("t2_daemon_discovery_reasserted", pid=payload["pid"])
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                # Self-heal is best-effort; never let it crash the daemon.
+                _log.warning("t2_daemon_discovery_reassert_failed", exc=str(exc))
 
     async def run_until_signal(self) -> None:
         """Block until SIGTERM/SIGINT arrives."""
@@ -723,6 +791,18 @@ class T2Daemon:
         never spawns into the lock-still-held window. ``_release_spawn_lock``
         remains callable for explicit teardown (tests simulate process exit).
         """
+        # RDR-140 P1.3 (nexus-h2oko): cancel the self-healing re-assert task
+        # FIRST — before the discovery-file unlink below — so it can never
+        # re-create the addr file for a daemon that is shutting down (the
+        # resurrection race against RDR-129 early-unlink-on-stop ordering).
+        if self._reassert_task is not None:
+            self._reassert_task.cancel()
+            try:
+                await self._reassert_task
+            except BaseException:  # noqa: BLE001
+                pass
+            self._reassert_task = None
+
         if self._uds_server is not None:
             self._uds_server.close()
             await self._uds_server.wait_closed()
@@ -1031,7 +1111,7 @@ class T2Daemon:
         except OSError as exc:
             os.close(fd)
             if exc.errno in (errno.EAGAIN, errno.EACCES):
-                raise T2DaemonError(
+                raise T2SpawnLockLost(
                     f"another T2 daemon already holds the spawn lock at "
                     f"{lock_path}; refusing to start a second instance"
                 ) from exc
@@ -1056,7 +1136,7 @@ class T2Daemon:
                 pass
             self._spawn_lock_fd = None
             if exc.errno in (errno.EAGAIN, errno.EACCES):
-                raise T2DaemonError(
+                raise T2SpawnLockLost(
                     f"another T2 daemon already holds the db_path spawn "
                     f"lock at {path_lock}; refusing to start a second "
                     f"instance against the same data file"
@@ -1085,6 +1165,41 @@ class T2Daemon:
 # ---------------------------------------------------------------------------
 # Sync entrypoint for the CLI verb
 # ---------------------------------------------------------------------------
+
+
+def _poll_for_winner(config_dir: Path, timeout: float) -> bool:
+    """Poll for the spawn-lock winner's discovery file + reachable socket.
+
+    RDR-140 P1.3 (nexus-h2oko): a spawn-lock loser calls this purely for
+    observability before exiting 0. Returns True once the winner's t2_addr
+    file names a live pid AND its UDS is connectable; False if the timeout
+    elapses first. A discovered-but-unreachable target (set file, socket not
+    yet accepting) or a stale addr (dead pid) is NOT treated as a live
+    attach — we keep polling and report False at timeout rather than claim a
+    stale attach. Never raises.
+    """
+    deadline = time.monotonic() + timeout
+    disc_path = t2_discovery_path(config_dir)
+    while time.monotonic() < deadline:
+        try:
+            if disc_path.exists():
+                payload = json.loads(disc_path.read_text())
+                pid = payload.get("pid")
+                uds = payload.get("uds_path")
+                if isinstance(pid, int) and _pid_is_alive(pid) and uds:
+                    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    try:
+                        sock.settimeout(0.5)
+                        sock.connect(str(uds))
+                        return True
+                    except OSError:
+                        pass  # set-but-unreachable — keep polling.
+                    finally:
+                        sock.close()
+        except (OSError, json.JSONDecodeError):
+            pass
+        time.sleep(0.05)
+    return False
 
 
 def run_t2_daemon(
@@ -1126,6 +1241,17 @@ def run_t2_daemon(
 
     try:
         asyncio.run(_main())
+    except T2SpawnLockLost:
+        # RDR-140 P1.3 (nexus-h2oko): losing the spawn lock is a benign
+        # quiet-attach, NOT a crash. A live winner already owns the data
+        # file; poll briefly for its discovery file/socket (best-effort
+        # observability — a discovered-but-unreachable or stale addr just
+        # keeps polling until the timeout), then exit 0 with an info-level
+        # breadcrumb and no traceback. A1-verified: T2Database was never
+        # constructed, so there is nothing to tear down.
+        attached = _poll_for_winner(config_dir, _LOSER_POLL_TIMEOUT)
+        _log.info("t2_daemon_spawn_lost", attached=attached)
+        return
     except Exception:
         # Last-resort: an exception escaping the loop (e.g. start()
         # raising before the handler is installed) must hit the log

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -166,6 +166,47 @@ def _apply_pending_with_lock_retry(
             )
             time.sleep(sleep_seconds)
 
+
+def _cold_start_is_current_and_wal(path: Path) -> bool:
+    """Return True iff *path* is already at ``current_version`` AND already in
+    WAL journal mode, using only lock-free reads (RDR-140 P1.2 Gap 4, A3).
+
+    Both probes succeed under a held EXCLUSIVE writer lock, so this never
+    contends with a concurrent writer. Any read error, a missing/``0.0.0``
+    version row, a non-WAL journal, or a ``"0.0.0"`` current version (the
+    importlib fallback) returns False so the caller takes the full
+    flock+migration path — a genuine pending migration must always run.
+    """
+    try:
+        from importlib.metadata import version as _pkg_version
+
+        try:
+            current_version = _pkg_version("conexus")
+        except Exception:  # noqa: BLE001
+            return False
+        if current_version == "0.0.0":
+            return False
+
+        conn = sqlite3.connect(str(path))
+        try:
+            try:
+                row = conn.execute(
+                    "SELECT value FROM _nexus_version WHERE key='cli_version'"
+                ).fetchone()
+            except sqlite3.OperationalError:
+                return False  # _nexus_version absent — uninitialised DB.
+            if not row or row[0] != current_version:
+                return False
+            mode = conn.execute("PRAGMA journal_mode").fetchone()
+            if not mode or str(mode[0]).lower() != "wal":
+                return False
+            return True
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return False
+
+
 # Re-export surface for backward compatibility. Resolution happens
 # lazily through the module-level ``__getattr__`` below; the eager
 # imports were pulling sklearn/scipy/numpy through CatalogTaxonomy on
@@ -463,6 +504,25 @@ class T2Database:
         with _upgrade_lock:
             if path_key in _upgrade_done:
                 return
+
+        # RDR-140 P1.2 (nexus-2p52a) Gap 4: cold-start (cross-process) fast
+        # path. When a fresh process meets a DB that is already at
+        # current_version AND already in WAL, the existing flock-wait +
+        # connection-open + no-op apply_pending below is pure overhead that
+        # still takes SQLite's writer lock (PRAGMA journal_mode=WAL is a write
+        # when the file is not WAL, and bootstrap_version writes the version
+        # table). A3 (T2 rdr/140-research-A3, verified) proved both probes are
+        # lock-free: SELECT value FROM _nexus_version (mirrors
+        # ``stored_schema_version``) and PRAGMA journal_mode read succeed even
+        # under a held EXCLUSIVE writer lock. Short-circuit ONLY when BOTH
+        # conditions hold; anything else (missing/0.0.0 row, non-WAL journal,
+        # or any read error) falls through to the unchanged flock+migration
+        # path so a genuine pending migration always runs (no silent fallback
+        # for correctness, mem:feedback_no_silent_fallbacks_for_correctness).
+        if _cold_start_is_current_and_wal(path):
+            with _upgrade_lock:
+                _upgrade_done.add(path_key)
+            return
 
         # RDR-128 P2: acquire the cross-process migration flock BEFORE the
         # in-process ``_upgrade_lock`` so the lock order matches ``nx upgrade``

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -177,6 +177,17 @@ def _cold_start_is_current_and_wal(path: Path) -> bool:
     importlib fallback) returns False so the caller takes the full
     flock+migration path — a genuine pending migration must always run.
     """
+    # A non-existent path is a fresh DB: there is nothing to fast-path, and we
+    # must NOT create the file here (this probe is read-only by contract — a
+    # plain ``sqlite3.connect`` would materialise a 0-byte DB). Fall through to
+    # the full bootstrap, which creates and migrates it. We use a plain
+    # read-write connection rather than ``mode=ro`` because read-only mode
+    # cannot create the ``-shm`` file a WAL DB needs when no other connection
+    # is open (the exact cold-start steady state we optimise), which would
+    # defeat the fast path. Reads on a plain connection are lock-free (A3),
+    # mirroring ``stored_schema_version``.
+    if not path.exists():
+        return False
     try:
         from importlib.metadata import version as _pkg_version
 
@@ -187,7 +198,7 @@ def _cold_start_is_current_and_wal(path: Path) -> bool:
         if current_version == "0.0.0":
             return False
 
-        conn = sqlite3.connect(str(path))
+        conn = sqlite3.connect(str(path), check_same_thread=False)
         try:
             try:
                 row = conn.execute(
@@ -521,6 +532,11 @@ class T2Database:
         # for correctness, mem:feedback_no_silent_fallbacks_for_correctness).
         if _cold_start_is_current_and_wal(path):
             with _upgrade_lock:
+                # Double-check (mirrors the full-migration path below): another
+                # thread may have finished a migration for this path while we
+                # ran the lock-free probe.
+                if path_key in _upgrade_done:
+                    return
                 _upgrade_done.add(path_key)
             return
 

--- a/tests/daemon/test_t2_daemon_lifecycle.py
+++ b/tests/daemon/test_t2_daemon_lifecycle.py
@@ -344,12 +344,23 @@ class TestSpawnLockLoserQuietAttach:
     def test_loser_quiet_attaches_without_constructing_t2db(
         self, config_dir: Path, db_path: Path, tmp_path: Path, monkeypatch,
     ) -> None:
+        import logging
         from unittest.mock import MagicMock
+
+        import structlog
 
         import nexus.db.t2 as t2_module
         import nexus.logging_setup as logging_setup
         from nexus.daemon.t2_daemon import T2Daemon, run_t2_daemon
         from structlog.testing import capture_logs
+
+        # conftest pins structlog to WARNING by default, which would filter the
+        # info-level spawn_lost event before capture_logs sees it. Lower to INFO
+        # for this test; the autouse _restore_structlog_after_test fixture
+        # restores the prior config afterwards.
+        structlog.configure(
+            wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        )
 
         # Hold the spawn lock with a real first daemon.
         first = T2Daemon(config_dir=config_dir, db_path=db_path)

--- a/tests/daemon/test_t2_daemon_lifecycle.py
+++ b/tests/daemon/test_t2_daemon_lifecycle.py
@@ -403,10 +403,55 @@ class TestSpawnLockLoserQuietAttach:
             crashed = [e for e in logs if e.get("event") == "t2_daemon_crashed"]
             assert len(spawn_lost) == 1
             assert spawn_lost[0].get("log_level") == "info"
+            # The winner is alive and its UDS is accepting, so the loser's
+            # poll must report a live attach (not a vacuous timeout).
+            assert spawn_lost[0].get("attached") is True
             assert len(crashed) == 0
         finally:
             stop.set()
             thread.join(timeout=10.0)
+
+    def test_reassert_task_cancelled_before_discovery_unlink(
+        self, config_dir: Path, db_path: Path,
+    ) -> None:
+        """RDR-129 ordering: stop() must cancel the self-healing re-assert task
+        BEFORE unlinking the discovery file, else the task could resurrect a
+        mid-shutdown daemon's addr. Pin the order by recording the relative
+        sequence of Task.cancel and Path.unlink.
+        """
+        from nexus.daemon.t2_daemon import T2Daemon, t2_discovery_path
+
+        events: list[str] = []
+
+        async def _main() -> None:
+            daemon = T2Daemon(config_dir=config_dir, db_path=db_path)
+            await daemon.start()
+            assert daemon._reassert_task is not None
+
+            real_cancel = daemon._reassert_task.cancel
+            disc_path = t2_discovery_path(config_dir)
+            orig_unlink = Path.unlink
+
+            def spy_cancel(*a, **k):
+                events.append("cancel")
+                return real_cancel(*a, **k)
+
+            def spy_unlink(self_path, *a, **k):
+                if self_path == disc_path:
+                    events.append("unlink")
+                return orig_unlink(self_path, *a, **k)
+
+            daemon._reassert_task.cancel = spy_cancel  # type: ignore[method-assign]
+            import unittest.mock as _mock
+
+            with _mock.patch.object(Path, "unlink", spy_unlink):
+                await daemon.stop()
+
+        asyncio.run(_main())
+
+        assert "cancel" in events, "re-assert task was never cancelled"
+        assert "unlink" in events, "discovery file was never unlinked"
+        assert events.index("cancel") < events.index("unlink")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/daemon/test_t2_daemon_lifecycle.py
+++ b/tests/daemon/test_t2_daemon_lifecycle.py
@@ -320,6 +320,85 @@ class TestStartStopLifecycle:
 
 
 # ---------------------------------------------------------------------------
+# RDR-140 P1.1 (nexus-266iu): spawn-lock loser quiet-attach
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnLockLoserQuietAttach:
+    """A second daemon that loses the spawn lock must quiet-attach, not crash.
+
+    Intended behaviour (implemented in P1.3 / nexus-h2oko), pinned RED here:
+
+    - The losing process NEVER constructs ``T2Database`` (spy call count == 0;
+      A1-verified that the spawn lock at start() is strictly before the
+      T2Database open).
+    - ``run_t2_daemon`` returns cleanly (exit code 0 — no exception escapes).
+    - It logs ``t2_daemon_spawn_lost`` at info exactly once, and does NOT log
+      ``t2_daemon_crashed`` (no traceback).
+
+    Against current code this FAILS: the spawn-loss raises T2DaemonError which
+    lands in ``run_t2_daemon``'s ``except Exception: _log.exception(
+    "t2_daemon_crashed"); raise`` — a crash with traceback and non-zero exit.
+    """
+
+    def test_loser_quiet_attaches_without_constructing_t2db(
+        self, config_dir: Path, db_path: Path, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        import nexus.db.t2 as t2_module
+        import nexus.logging_setup as logging_setup
+        from nexus.daemon.t2_daemon import T2Daemon, run_t2_daemon
+        from structlog.testing import capture_logs
+
+        # Hold the spawn lock with a real first daemon.
+        first = T2Daemon(config_dir=config_dir, db_path=db_path)
+        ready = threading.Event()
+        stop = threading.Event()
+        thread = threading.Thread(
+            target=_run_daemon_in_thread, args=(first, ready, stop),
+        )
+        thread.start()
+        try:
+            assert ready.wait(timeout=10.0)
+
+            # Spy on T2Database construction. The first daemon already opened
+            # its DB before this patch, so any call now can only come from the
+            # losing second daemon.
+            t2db_spy = MagicMock(name="T2Database")
+            monkeypatch.setattr(t2_module, "T2Database", t2db_spy)
+            # Keep capture_logs' structlog config in place: run_t2_daemon's
+            # configure_logging would otherwise reconfigure structlog away.
+            monkeypatch.setattr(logging_setup, "configure_logging", lambda *a, **k: None)
+
+            raised: Exception | None = None
+            with capture_logs() as logs:
+                try:
+                    result = run_t2_daemon(
+                        config_dir=config_dir, db_path=tmp_path / "second.db",
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    raised = exc
+                    result = None
+
+            # Clean quiet-attach: no exception escaped, returned None (exit 0).
+            assert raised is None
+            assert result is None
+
+            # The loser never constructed T2Database.
+            assert t2db_spy.call_count == 0
+
+            spawn_lost = [e for e in logs if e.get("event") == "t2_daemon_spawn_lost"]
+            crashed = [e for e in logs if e.get("event") == "t2_daemon_crashed"]
+            assert len(spawn_lost) == 1
+            assert spawn_lost[0].get("log_level") == "info"
+            assert len(crashed) == 0
+        finally:
+            stop.set()
+            thread.join(timeout=10.0)
+
+
+# ---------------------------------------------------------------------------
 # Module exposes the expected public surface
 # ---------------------------------------------------------------------------
 

--- a/tests/daemon/test_t2_ensure_running.py
+++ b/tests/daemon/test_t2_ensure_running.py
@@ -662,3 +662,106 @@ class TestCycleInterlock:
         assert state["terminated"] is True, "free lock should allow the cycle"
         assert len(spawned) == 1
         assert "cycling to current" in result.output.lower()
+
+
+class TestEnsureRunningElectionLock:
+    """RDR-140 P2.2 (nexus-fkhe2): single-flight election-lock helpers and the
+    on-timeout graceful-degradation path."""
+
+    def test_acquire_election_lock_times_out_when_held(self, tmp_path) -> None:
+        import fcntl
+
+        from nexus.commands.daemon import (
+            _acquire_election_lock,
+            _election_lock_path_for_db,
+        )
+
+        db = tmp_path / "memory.db"
+        lock_path = _election_lock_path_for_db(db)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        holder = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+        fcntl.flock(holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            # A second exclusive lock on the held file must not be granted; the
+            # bounded wait returns None rather than blocking forever.
+            assert _acquire_election_lock(db, 0.2) is None
+        finally:
+            fcntl.flock(holder, fcntl.LOCK_UN)
+            os.close(holder)
+
+    def test_acquire_release_roundtrip_and_reacquire(self, tmp_path) -> None:
+        from nexus.commands.daemon import (
+            _acquire_election_lock,
+            _release_election_lock,
+        )
+
+        db = tmp_path / "memory.db"
+        fd = _acquire_election_lock(db, 1.0)
+        assert isinstance(fd, int)
+        _release_election_lock(fd)
+        # Re-acquirable once released.
+        fd2 = _acquire_election_lock(db, 1.0)
+        assert isinstance(fd2, int)
+        _release_election_lock(fd2)
+        # Releasing None is a no-op (does not raise).
+        _release_election_lock(None)
+
+    def test_election_wait_covers_worst_case_hold(self) -> None:
+        from nexus.commands.daemon import (
+            _T2_CYCLE_DB_PROBE_TIMEOUT_MS,
+            _T2_CYCLE_EXIT_TIMEOUT,
+            _election_wait_for,
+        )
+
+        # The waiter budget must exceed the holder's worst-case hold (stale
+        # write-lock probe + predecessor-exit poll + reachability poll), or the
+        # herd reappears on timeout.
+        timeout = 15.0
+        hold = _T2_CYCLE_DB_PROBE_TIMEOUT_MS / 1000.0 + _T2_CYCLE_EXIT_TIMEOUT + timeout
+        assert _election_wait_for(timeout) > hold
+
+    def test_election_timeout_proceeds_to_spawn_unguarded(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """When the election lock is held by another stack and the wait
+        elapses, ensure-running degrades to an unguarded spawn (the daemon
+        spawn lock remains the backstop) and warns — never deadlocks."""
+        import fcntl
+
+        from nexus.commands import daemon as daemon_mod
+
+        # No discovery file pre-seeded => no live daemon to attach to.
+        db = tmp_path / "memory.db"
+        lock_path = daemon_mod._election_lock_path_for_db(db)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        holder = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+        fcntl.flock(holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        # Shrink the election wait so the timeout path fires fast.
+        monkeypatch.setattr(daemon_mod, "_election_wait_for", lambda _t: 0.2)
+
+        spawn_calls: list[list[str]] = []
+
+        class _FakePopen:
+            def __init__(self, argv, **_kw):  # noqa: ANN001
+                spawn_calls.append(argv)
+
+            def poll(self):
+                return None  # alive/migrating; mocked daemon never reachable
+
+        monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+        try:
+            result = CliRunner().invoke(
+                main,
+                ["daemon", "t2", "ensure-running",
+                 "--config-dir", str(tmp_path), "--timeout", "0.2"],
+            )
+        finally:
+            fcntl.flock(holder, fcntl.LOCK_UN)
+            os.close(holder)
+
+        # Proceeded unguarded (one spawn), did not deadlock, warned.
+        assert len(spawn_calls) == 1
+        assert result.exit_code == 1  # mocked daemon never becomes reachable
+        err = result.stderr_bytes.decode() if result.stderr_bytes else ""
+        assert "election-lock wait timed out" in (result.output + err)

--- a/tests/daemon/test_t2_multistack_race.py
+++ b/tests/daemon/test_t2_multistack_race.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-140 P2.1 (nexus-remh4): multi-stack race harness — the P2/P3 GATE artifact.
+
+Spawns K real, concurrent ``nx daemon t2 ensure-running`` processes against ONE
+``memory.db`` (isolated via ``NEXUS_CONFIG_DIR``) and asserts the convergence
+invariant. Real subprocesses, not mocks: the load-bearing race is the OS-level
+``fcntl`` spawn-lock contention between independently-started ``t2 start``
+children, which only a real process race exercises.
+
+Why this is a gate, not just a test
+-----------------------------------
+Before RDR-140, a K-way race converged to one daemon but via crash+reap churn —
+the A4 research signature was ``started=1 / crashed=9 / stop_requested=1`` for a
+single converged daemon: eight siblings crash-looped and were reaped before the
+survivor stuck. P1 (loser quiet-attach) removes the crashes. P2 (Gap 3
+single-flight election) removes the *redundant spawns* themselves so only one
+stack ever runs ``t2 start``.
+
+Two invariants, split by which phase delivers them:
+
+* ``test_kway_race_converges_without_crash_or_reap`` — GREEN as of P1. Exactly
+  one ``t2_daemon_started``, zero ``t2_daemon_crashed``, zero healthy-peer
+  reaps, every racer exits 0, exactly one live daemon at the end. This is the
+  regression guard P2 and P3 must keep green.
+* ``test_kway_race_is_single_flight`` — RED until P2.2 (nexus-fkhe2). Asserts
+  zero redundant spawns (``t2_daemon_spawn_lost`` count == 0): with a real
+  election lock, only the winner spawns ``t2 start`` at all. ``xfail(strict)``
+  so it fails loudly — telling us to drop the marker — once P2.2 lands.
+
+Race outcomes are stochastic; a single green pass proves nothing. Both tests
+loop over ``_ITERATIONS`` fresh cold-start config_dirs and assert on every run.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+# K racers per iteration; _ITERATIONS independent cold-start races. Both are
+# deliberately modest — every iteration spawns K+1 real processes, so the wall
+# cost is K*_ITERATIONS daemon spawns. Enough to surface a stochastic race
+# without making the suite slow.
+_K = 5
+_ITERATIONS = 5
+
+# Bounded waits — the harness must never hang, even when the invariant is
+# violated; it fails with a diagnostic instead of timing out the suite.
+_ENSURE_TIMEOUT = 60.0
+_CONVERGE_TIMEOUT = 30.0
+
+
+def _child_env(config_dir: Path) -> dict[str, str]:
+    """Env for a racer subprocess: isolate to *config_dir* and force the inner
+    ``t2 start`` spawn to use this interpreter's in-tree source.
+
+    ``ensure-running`` resolves the daemon binary via ``shutil.which("nx")``,
+    which would pick up the installed (possibly stale) shim. Stripping every
+    PATH entry that contains an ``nx`` executable makes ``_resolve_nx_bin``
+    fall back to ``[sys.executable, "-m", "nexus.cli"]`` — the editable src the
+    test itself runs — so the race exercises the code under development.
+    """
+    env = os.environ.copy()
+    env["NEXUS_CONFIG_DIR"] = str(config_dir)
+    kept = [
+        p for p in env.get("PATH", "").split(os.pathsep)
+        if p and not (Path(p) / "nx").exists()
+    ]
+    env["PATH"] = os.pathsep.join(kept)
+    return env
+
+
+def _spawn_k_ensure_running(config_dir: Path, k: int) -> list[int]:
+    """Launch *k* concurrent ``ensure-running`` racers; return their exit codes.
+
+    All k are started before any is awaited so they genuinely contend.
+    """
+    env = _child_env(config_dir)
+    argv = [
+        sys.executable, "-m", "nexus.cli", "daemon", "t2", "ensure-running",
+        "--config-dir", str(config_dir), "--quiet",
+    ]
+    procs = [
+        subprocess.Popen(
+            argv, env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        for _ in range(k)
+    ]
+    codes: list[int] = []
+    for p in procs:
+        try:
+            _out, err = p.communicate(timeout=_ENSURE_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            _out, err = p.communicate()
+            raise AssertionError(
+                f"ensure-running racer hung > {_ENSURE_TIMEOUT}s; stderr={err!r}"
+            )
+        codes.append(p.returncode)
+    return codes
+
+
+def _count_daemon_events(config_dir: Path) -> dict[str, int]:
+    """Count structlog event occurrences in the daemon's rotating log file.
+
+    The file formatter renders ``<asctime> <name> <level> <event> k=v ...`` via
+    KeyValueRenderer, so the event name appears as a whitespace-delimited token.
+    We count lines containing each event token.
+    """
+    log_path = config_dir / "logs" / "t2_daemon.log"
+    counts = {
+        "t2_daemon_started": 0,
+        "t2_daemon_crashed": 0,
+        "t2_daemon_spawn_lost": 0,
+        "t2_predecessor_reaped": 0,
+        "t2_predecessor_sigkilled": 0,
+    }
+    if not log_path.exists():
+        return counts
+    for line in log_path.read_text(errors="replace").splitlines():
+        for event in counts:
+            if event in line:
+                counts[event] += 1
+    return counts
+
+
+def _live_daemon_count(config_dir: Path) -> int:
+    """0 or 1: whether the recorded discovery pid is a live process."""
+    from nexus.daemon.t2_daemon import t2_discovery_path
+
+    disc = t2_discovery_path(config_dir)
+    if not disc.exists():
+        return 0
+    try:
+        pid = json.loads(disc.read_text()).get("pid")
+    except (OSError, json.JSONDecodeError):
+        return 0
+    if not isinstance(pid, int):
+        return 0
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, PermissionError):
+        return 0
+    return 1
+
+
+def _wait_for_convergence(config_dir: Path) -> None:
+    """Bounded wait until exactly one live daemon is reachable."""
+    deadline = time.monotonic() + _CONVERGE_TIMEOUT
+    while time.monotonic() < deadline:
+        if _live_daemon_count(config_dir) == 1:
+            return
+        time.sleep(0.1)
+    raise AssertionError(
+        f"no single live daemon within {_CONVERGE_TIMEOUT}s "
+        f"(events={_count_daemon_events(config_dir)})"
+    )
+
+
+def _fresh_config_dir() -> Path:
+    # Short /tmp path: macOS caps AF_UNIX socket paths at 104 chars.
+    return Path(tempfile.mkdtemp(prefix="nxt2race-", dir="/tmp"))
+
+
+def _teardown(config_dir: Path) -> None:
+    from tests._daemon_leak_guard import reap_tmp_daemons
+
+    try:
+        reap_tmp_daemons(config_dir, tiers=("t2",))
+    except BaseException:  # noqa: BLE001 — teardown guard must never raise
+        pass
+    shutil.rmtree(config_dir, ignore_errors=True)
+
+
+class TestMultiStackRace:
+    def test_kway_race_converges_without_crash_or_reap(self) -> None:
+        """GREEN as of P1: K racers converge to exactly one daemon with no
+        crash and no healthy-peer reap, on every cold-start iteration."""
+        for i in range(_ITERATIONS):
+            cd = _fresh_config_dir()
+            try:
+                codes = _spawn_k_ensure_running(cd, _K)
+                _wait_for_convergence(cd)
+                events = _count_daemon_events(cd)
+
+                assert codes == [0] * _K, (
+                    f"iter {i}: ensure-running exit codes {codes} != all-0"
+                )
+                assert events["t2_daemon_started"] == 1, (
+                    f"iter {i}: started={events['t2_daemon_started']} != 1"
+                )
+                assert events["t2_daemon_crashed"] == 0, (
+                    f"iter {i}: crashed={events['t2_daemon_crashed']} != 0"
+                )
+                assert events["t2_predecessor_reaped"] == 0, (
+                    f"iter {i}: healthy-peer reaped="
+                    f"{events['t2_predecessor_reaped']} != 0"
+                )
+                assert events["t2_predecessor_sigkilled"] == 0, (
+                    f"iter {i}: healthy-peer sigkilled="
+                    f"{events['t2_predecessor_sigkilled']} != 0"
+                )
+                assert _live_daemon_count(cd) == 1, (
+                    f"iter {i}: live daemon count != 1"
+                )
+            finally:
+                _teardown(cd)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="RED until P2.2 (nexus-fkhe2): a single-flight election lock "
+        "means only the winner spawns t2 start, so zero siblings reach the "
+        "spawn lock and quiet-attach. Pre-P2 the thundering herd produces "
+        "1..K-1 redundant spawns (t2_daemon_spawn_lost > 0).",
+    )
+    def test_kway_race_is_single_flight(self) -> None:
+        """RED until P2.2: zero redundant spawns across all iterations.
+
+        The convergence guard above tolerates redundant spawns that quiet-
+        attach; this one demands the election lock eliminate them. Summed over
+        iterations so a single race that happens to serialise can't mask the
+        herd.
+        """
+        total_spawn_lost = 0
+        for _i in range(_ITERATIONS):
+            cd = _fresh_config_dir()
+            try:
+                _spawn_k_ensure_running(cd, _K)
+                _wait_for_convergence(cd)
+                total_spawn_lost += _count_daemon_events(cd)["t2_daemon_spawn_lost"]
+            finally:
+                _teardown(cd)
+        assert total_spawn_lost == 0

--- a/tests/daemon/test_t2_multistack_race.py
+++ b/tests/daemon/test_t2_multistack_race.py
@@ -276,12 +276,19 @@ class TestMultiStackRace:
         mask a herd regression.
         """
         total_spawn_lost = 0
-        for _i in range(_ITERATIONS):
+        for i in range(_ITERATIONS):
             cd = _fresh_config_dir()
             try:
                 _spawn_k_ensure_running(cd, _K)
                 _wait_for_convergence(cd)
-                total_spawn_lost += _count_daemon_events(cd)["t2_daemon_spawn_lost"]
+                events = _count_daemon_events(cd)
+                # Exactly one stack spawned (guards the silent-winner-death
+                # regression where a second waiter wins and starts a second
+                # daemon while spawn_lost stays 0).
+                assert events["t2_daemon_started"] == 1, (
+                    f"iter {i}: started={events['t2_daemon_started']} != 1"
+                )
+                total_spawn_lost += events["t2_daemon_spawn_lost"]
             finally:
                 _teardown(cd)
         assert total_spawn_lost == 0

--- a/tests/daemon/test_t2_multistack_race.py
+++ b/tests/daemon/test_t2_multistack_race.py
@@ -41,8 +41,6 @@ import tempfile
 import time
 from pathlib import Path
 
-import pytest
-
 # K racers per iteration; _ITERATIONS independent cold-start races. Both are
 # deliberately modest — every iteration spawns K+1 real processes, so the wall
 # cost is K*_ITERATIONS daemon spawns. Enough to surface a stochastic race
@@ -265,20 +263,17 @@ class TestMultiStackRace:
         finally:
             _teardown(cd)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="RED until P2.2 (nexus-fkhe2): a single-flight election lock "
-        "means only the winner spawns t2 start, so zero siblings reach the "
-        "spawn lock and quiet-attach. Pre-P2 the thundering herd produces "
-        "1..K-1 redundant spawns (t2_daemon_spawn_lost > 0).",
-    )
     def test_kway_race_is_single_flight(self) -> None:
-        """RED until P2.2: zero redundant spawns across all iterations.
+        """GREEN as of P2.2 (nexus-fkhe2): zero redundant spawns across all
+        iterations.
 
         The convergence guard above tolerates redundant spawns that quiet-
-        attach; this one demands the election lock eliminate them. Summed over
-        iterations so a single race that happens to serialise can't mask the
-        herd.
+        attach; this one demands the single-flight election lock eliminate them
+        — only the election holder cold-spawns ``t2 start``, waiters block then
+        re-discover the live winner and attach without spawning, so no sibling
+        ever reaches the daemon spawn lock (``t2_daemon_spawn_lost`` == 0).
+        Summed over iterations so a single race that happens to serialise can't
+        mask a herd regression.
         """
         total_spawn_lost = 0
         for _i in range(_ITERATIONS):

--- a/tests/daemon/test_t2_multistack_race.py
+++ b/tests/daemon/test_t2_multistack_race.py
@@ -213,6 +213,58 @@ class TestMultiStackRace:
             finally:
                 _teardown(cd)
 
+    def test_holder_dies_mid_spawn_waiters_recover(self) -> None:
+        """A daemon that dies after acquiring the spawn lock but before binding
+        must not wedge the system: a subsequent K-way ensure-running race
+        recovers to exactly one live daemon, no crash, no deadlock.
+
+        Pre-P2 the contended lock is the fcntl spawn lock (the OS releases it on
+        the holder's death); P2's election lock generalises the same recovery
+        contract. Drivable and GREEN now — a regression guard either way. We
+        widen the kill window using the cold-start migration delay: a fresh DB
+        forces a multi-second migration while the spawn lock is held and before
+        discovery is written.
+        """
+        from nexus.daemon.t2_daemon import _SPAWN_LOCK_FILE, t2_discovery_path
+
+        cd = _fresh_config_dir()
+        try:
+            env = _child_env(cd)
+            start_argv = [
+                sys.executable, "-m", "nexus.cli", "daemon", "t2", "start",
+                "--config-dir", str(cd),
+            ]
+            holder = subprocess.Popen(
+                start_argv, env=env,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            # Wait until it has taken the spawn lock but not yet written
+            # discovery (mid-spawn), bounded; then kill it there.
+            lock_file = cd / _SPAWN_LOCK_FILE
+            disc = t2_discovery_path(cd)
+            deadline = time.monotonic() + _CONVERGE_TIMEOUT
+            while time.monotonic() < deadline:
+                if lock_file.exists() and not disc.exists():
+                    break
+                if holder.poll() is not None:
+                    break
+                time.sleep(0.02)
+            holder.kill()
+            holder.communicate(timeout=_ENSURE_TIMEOUT)
+
+            # Waiters recover: a fresh K-way race brings up exactly one daemon.
+            codes = _spawn_k_ensure_running(cd, _K)
+            _wait_for_convergence(cd)
+            events = _count_daemon_events(cd)
+
+            assert codes == [0] * _K, f"recovery racer exit codes {codes} != all-0"
+            assert events["t2_daemon_crashed"] == 0, (
+                f"crashed={events['t2_daemon_crashed']} != 0 after holder death"
+            )
+            assert _live_daemon_count(cd) == 1, "no single live daemon after recovery"
+        finally:
+            _teardown(cd)
+
     @pytest.mark.xfail(
         strict=True,
         reason="RED until P2.2 (nexus-fkhe2): a single-flight election lock "

--- a/tests/db/test_migration_fast_path.py
+++ b/tests/db/test_migration_fast_path.py
@@ -148,6 +148,18 @@ class TestMigrationFastPath:
         assert installed_sentinels["flock"] == 0
         assert installed_sentinels["apply"] == 0
 
+    def test_nonexistent_db_returns_false_without_creating_file(
+        self, tmp_path: Path,
+    ) -> None:
+        """The probe is read-only by contract: on a non-existent path it must
+        return False AND not materialise a 0-byte DB file (a plain
+        ``sqlite3.connect`` would)."""
+        from nexus.db.t2 import _cold_start_is_current_and_wal
+
+        db = tmp_path / "never.db"
+        assert _cold_start_is_current_and_wal(db) is False
+        assert not db.exists()
+
     def test_stale_stored_version_still_runs_full_migration_path(
         self, tmp_path: Path, installed_sentinels: dict,
     ) -> None:

--- a/tests/db/test_migration_fast_path.py
+++ b/tests/db/test_migration_fast_path.py
@@ -160,6 +160,35 @@ class TestMigrationFastPath:
         assert _cold_start_is_current_and_wal(db) is False
         assert not db.exists()
 
+    def test_existing_db_without_version_table_returns_false(
+        self, tmp_path: Path,
+    ) -> None:
+        """An existing file with no ``_nexus_version`` table (skeleton DB /
+        bootstrap-in-progress) must fall through, not fast-path."""
+        from nexus.db.t2 import _cold_start_is_current_and_wal
+
+        db = tmp_path / "skeleton.db"
+        conn = sqlite3.connect(str(db))  # materialise an empty, schema-less DB
+        conn.close()
+        assert db.exists()
+        assert _cold_start_is_current_and_wal(db) is False
+
+    def test_zero_zero_zero_current_version_returns_false(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """A ``0.0.0`` current version (broken/editable install) must never
+        match a real stored version — the probe returns False so the full
+        path runs."""
+        from nexus.db.t2 import _cold_start_is_current_and_wal
+
+        db = tmp_path / "memory.db"
+        _make_migrated_wal_db(db)
+        assert _stored_version(db) == _current_version()
+        assert _journal_mode(db) == "wal"
+
+        monkeypatch.setattr("importlib.metadata.version", lambda _name: "0.0.0")
+        assert _cold_start_is_current_and_wal(db) is False
+
     def test_stale_stored_version_still_runs_full_migration_path(
         self, tmp_path: Path, installed_sentinels: dict,
     ) -> None:

--- a/tests/db/test_migration_fast_path.py
+++ b/tests/db/test_migration_fast_path.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-140 P1.1 (nexus-266iu) — TDD: migration current_version fast-path.
+
+Pins the intended cold-start fast path for ``T2Database.bootstrap_schema``:
+when the on-disk DB is already at ``current_version`` AND already in WAL
+journal mode, a cold start (fresh process: ``_upgrade_done`` empty) must
+short-circuit BEFORE acquiring the cross-process migration flock or running
+``_apply_pending_with_lock_retry`` — i.e. it takes NO writer lock. A genuine
+pending migration (stale stored version, or non-WAL journal) must STILL run
+the full flock + apply path so the fast path never swallows a real upgrade.
+
+These tests are written to FAIL against current code (which always enters the
+flock + writer-locking apply path on a cold start). P1.2 (nexus-2p52a)
+implements the lock-free pre-check that turns them green. Do NOT change
+production code in this bead.
+
+A3 (verified): the pre-check must use the lock-free reads ``SELECT value FROM
+_nexus_version WHERE key='cli_version'`` + ``PRAGMA journal_mode`` (read),
+mirroring ``T2Database.stored_schema_version`` — NOT ``bootstrap_version``,
+which is a writer.
+"""
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+
+import pytest
+
+
+def _current_version() -> str:
+    return _pkg_version("conexus")
+
+
+def _stored_version(db_path: Path) -> str:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT value FROM _nexus_version WHERE key='cli_version'"
+        ).fetchone()
+        return row[0] if row else "0.0.0"
+    finally:
+        conn.close()
+
+
+def _journal_mode(db_path: Path) -> str:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute("PRAGMA journal_mode").fetchone()[0].lower()
+    finally:
+        conn.close()
+
+
+def _stamp_version(db_path: Path, value: str) -> None:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO _nexus_version (key, value) "
+            "VALUES ('cli_version', ?)",
+            (value,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _make_migrated_wal_db(db_path: Path) -> None:
+    """Build a realistic 'already fully migrated, WAL-on' DB.
+
+    A bare tmp-path bootstrap leaves the stored version at ``0.0.0`` because
+    two RDR-108 PK migrations defer when no catalog exists, so the run never
+    stamps ``current_version``. We run the real bootstrap (genuine schema +
+    WAL) and then stamp the version row to ``current_version`` to represent
+    the steady-state, fully-migrated DB a cold start would actually meet in
+    production.
+    """
+    from nexus.db.t2 import T2Database
+
+    T2Database.bootstrap_schema(db_path)
+    _stamp_version(db_path, _current_version())
+
+
+def _clear_upgrade_done() -> None:
+    """Simulate a cold start in a fresh process: the in-process
+    ``_upgrade_done`` memo is empty, so only the on-disk state can
+    short-circuit the migration."""
+    from nexus.db.migrations import _upgrade_done
+
+    _upgrade_done.clear()
+
+
+@pytest.fixture
+def installed_sentinels(monkeypatch):
+    """Wrap ``t2_migration_flock`` and ``_apply_pending_with_lock_retry`` with
+    call counters that still delegate to the real implementations.
+
+    ``t2_migration_flock`` entry count and ``_apply_pending_with_lock_retry``
+    call count are both proxies for "took the writer-locking migration path".
+    On the fast path both must be 0; on a real pending migration both must
+    be exactly 1.
+    """
+    import nexus.db.migrations as migrations
+    import nexus.db.t2 as t2
+
+    counts = {"flock": 0, "apply": 0}
+
+    real_flock = migrations.t2_migration_flock
+    real_apply = t2._apply_pending_with_lock_retry
+
+    @contextmanager
+    def counting_flock(parent):
+        counts["flock"] += 1
+        with real_flock(parent):
+            yield
+
+    def counting_apply(conn, current_version):
+        counts["apply"] += 1
+        return real_apply(conn, current_version)
+
+    monkeypatch.setattr(migrations, "t2_migration_flock", counting_flock)
+    monkeypatch.setattr(t2, "_apply_pending_with_lock_retry", counting_apply)
+    return counts
+
+
+class TestMigrationFastPath:
+    def test_already_migrated_wal_db_takes_no_writer_lock_on_cold_start(
+        self, tmp_path: Path, installed_sentinels: dict,
+    ) -> None:
+        from nexus.db.t2 import T2Database
+
+        db = tmp_path / "memory.db"
+
+        # Steady state: schema built, version at current, journal in WAL.
+        _make_migrated_wal_db(db)
+        assert _stored_version(db) == _current_version()
+        assert _journal_mode(db) == "wal"
+
+        # Reset to simulate a brand-new process: nothing memoised in-process,
+        # but the on-disk DB is already fully migrated and in WAL.
+        _clear_upgrade_done()
+        installed_sentinels["flock"] = 0
+        installed_sentinels["apply"] = 0
+
+        # Second cold start MUST short-circuit before any writer-locking work.
+        T2Database.bootstrap_schema(db)
+
+        assert installed_sentinels["flock"] == 0
+        assert installed_sentinels["apply"] == 0
+
+    def test_stale_stored_version_still_runs_full_migration_path(
+        self, tmp_path: Path, installed_sentinels: dict,
+    ) -> None:
+        from nexus.db.t2 import T2Database
+
+        db = tmp_path / "memory.db"
+        _make_migrated_wal_db(db)
+
+        # Force a genuine pending migration by rewinding the stored version.
+        _stamp_version(db, "0.0.0")
+        assert _stored_version(db) == "0.0.0"
+
+        _clear_upgrade_done()
+        installed_sentinels["flock"] = 0
+        installed_sentinels["apply"] = 0
+
+        T2Database.bootstrap_schema(db)
+
+        # Full writer-locking migration path taken exactly once.
+        assert installed_sentinels["flock"] == 1
+        assert installed_sentinels["apply"] == 1
+
+    def test_non_wal_journal_still_runs_full_migration_path(
+        self, tmp_path: Path, installed_sentinels: dict,
+    ) -> None:
+        from nexus.db.t2 import T2Database
+
+        db = tmp_path / "memory.db"
+        _make_migrated_wal_db(db)
+
+        # Knock the journal out of WAL: the fast path must NOT short-circuit
+        # because re-enabling WAL is itself a writer operation that has to run.
+        conn = sqlite3.connect(str(db))
+        try:
+            conn.execute("PRAGMA journal_mode=DELETE")
+        finally:
+            conn.close()
+        assert _journal_mode(db) == "delete"
+
+        _clear_upgrade_done()
+        installed_sentinels["flock"] = 0
+        installed_sentinels["apply"] = 0
+
+        T2Database.bootstrap_schema(db)
+
+        assert installed_sentinels["flock"] == 1
+        assert installed_sentinels["apply"] == 1
+        assert _journal_mode(db) == "wal"


### PR DESCRIPTION
## RDR-140 P1 + P2 — Stop the noise + Single-flight election

First two (contained) phases of RDR-140 (T2 Daemon Supervisor & Ownership Model). Removes the spawn-race crash tracebacks and the SQLite-lock thrash, and serialises the discover→spawn decision so K racing stacks converge to exactly one daemon. **No ownership-invariant change** — `_reap_predecessor_daemon` is untouched (that's the gated P3). The RDR-128/129 single-writer flock backstop is not weakened.

### P1 — Stop the noise (Gap 1 + Gap 4)
- **Migration cold-start fast-path** (`db/t2/__init__.py`): when the DB is already at `current_version` and in WAL, `bootstrap_schema` short-circuits before the migration flock / writer lock via A3-verified lock-free reads. Genuine pending migrations (stale version, non-WAL, missing row) still take the full path.
- **Loser quiet-attach** (`daemon/t2_daemon.py`): spawn-lock loss raises typed `T2SpawnLockLost`; `run_t2_daemon` catches it, polls for the winner, logs `t2_daemon_spawn_lost`@info, exits 0 — never constructs `T2Database` (A1), no traceback. Holder self-heals its discovery file via a re-assert task cancelled before the RDR-129 early-unlink.

### P2 — Single-flight election (Gap 3)
- **Election coordination lock** (`commands/daemon.py`): `t2_ensure_running_cmd` wraps discover→spawn in a blocking-with-timeout `fcntl` lock anchored on the data file (`<db>.election_lock`, distinct from the daemon's spawn lock). After acquiring it, re-discovers — a winner that came up while waiting is attached, not duplicated; only the holder cold-spawns. Common case (daemon already up) stays lock-free. The waiter budget is derived dynamically from the worst-case hold so it never times out into a thundering herd. Auto-releases on holder death → no deadlock.

### Tests
- New deterministic **multi-stack race harness** (`tests/daemon/test_t2_multistack_race.py`) — the P2/P3 gate artifact. Real K-way subprocess races over repeated cold-start iterations: converges to exactly 1 daemon, 0 crashed, 0 healthy-peer reaps, single-flight (0 redundant spawns), and recovers from holder-dies-mid-spawn.
- Migration fast-path coverage, loser quiet-attach + cancel-before-unlink ordering, election-lock helper unit tests + on-timeout degradation.
- **Full unit suite: 8481 passed, 0 failures.** `-m integration` deferred to RDR close (excluded from develop CI; P1/P2 touch no embedding/retrieval/cloud paths).

### Review
Both phases passed the stacked gate (code-review-expert + substantive-critic) with all Critical/High findings remediated, plus per-phase test-validation and a §scope cross-walk (no silent scope reduction).

Beads: nexus-266iu, nexus-2p52a, nexus-h2oko, nexus-jtdsm, nexus-ktsjv, nexus-m63u0 (P1); nexus-remh4, nexus-fkhe2, nexus-8nx8g, nexus-7wql2, nexus-9uri3 (P2). Tracking: nexus-13bcq (#1041). Epic: nexus-7nxc2.

Remaining in RDR-140: P3 (ownership-aware reaping, invariant-touching/gated) and P4 (observability), both unblocked by this PR.
