### PR TITLE
RDR-140 P3: ownership-aware reaping (invariant-touching, gated)

### DIFF
--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -1196,8 +1196,26 @@ class T2Daemon:
         try:
             os.kill(pid, signal.SIGKILL)
             _log.warning("t2_predecessor_sigkilled", pid=pid)
+        except ProcessLookupError:
+            return  # already gone
         except OSError:
-            pass
+            return
+
+        # RDR-140 P3 (nexus-dzf1q re-review): SIGKILL delivery is asynchronous —
+        # os.kill returning does NOT mean the kernel has finished reaping the
+        # process and released its db fds. start() opens T2Database the instant
+        # _reap_predecessor_daemon returns, so we MUST confirm the pid is gone
+        # before returning, or two writers could briefly overlap. SIGKILL is
+        # unblockable, so this poll terminates quickly in practice; if it
+        # overstays (zombie / kernel stall) we log and return — the pid is
+        # doomed and its writer is effectively dead.
+        deadline = time.monotonic() + _PREDECESSOR_REAP_TIMEOUT
+        while time.monotonic() < deadline:
+            if not _pid_is_alive(pid):
+                _log.info("t2_predecessor_reaped", pid=pid, via="SIGKILL")
+                return
+            time.sleep(0.1)
+        _log.warning("t2_predecessor_still_alive_after_sigkill", pid=pid)
 
     def _acquire_spawn_lock(self) -> None:
         """Acquire exclusive fcntl locks on both the config_dir-scoped

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -74,6 +74,12 @@ _log = structlog.get_logger(__name__)
 # lingering predecessor daemon on takeover (RDR-128 single-writer backstop).
 _PREDECESSOR_REAP_TIMEOUT: float = 5.0
 
+# RDR-140 P3.2 (nexus-7ffls): per-connection timeout for the reap-discrimination
+# health-ping. A peer that does not accept a connection within this budget is
+# treated as unreachable (a wedged/orphaned writer) and reaped. Module constant
+# so tests can shrink it.
+_HEALTH_PING_TIMEOUT: float = 1.0
+
 # RDR-129 B2 (nexus-qi1zb): bounded lock-retry for the serving dispatch.
 # Mirrors the bootstrap-migration retry
 # (``nexus.db.t2._apply_pending_with_lock_retry``): three attempts with two
@@ -584,6 +590,50 @@ def _daemon_version() -> str:
         return "0.0.0"
 
 
+def _health_ping(payload: dict[str, Any]) -> bool:
+    """Best-effort liveness probe: can we open a connection to the peer named in
+    its discovery *payload*? Tries the UDS path first, then TCP. Never raises.
+
+    RDR-140 P3.2: a peer that accepts a connection is serving (healthy); one
+    that refuses/times out is a wedged or orphaned writer and must be reaped.
+    """
+    uds = payload.get("uds_path")
+    if isinstance(uds, str) and uds:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.settimeout(_HEALTH_PING_TIMEOUT)
+            sock.connect(uds)
+            return True
+        except OSError:
+            pass
+        finally:
+            sock.close()
+    host, port = payload.get("tcp_host"), payload.get("tcp_port")
+    if isinstance(host, str) and host and isinstance(port, int) and port > 0:
+        try:
+            with socket.create_connection((host, port), timeout=_HEALTH_PING_TIMEOUT):
+                return True
+        except OSError:
+            pass
+    return False
+
+
+def _peer_handshake(pid: int, payload: dict[str, Any] | None) -> tuple[str | None, bool]:
+    """Reap-discrimination probe for *pid*: return ``(daemon_version, reachable)``.
+
+    RDR-140 P3.2 (nexus-7ffls). ``daemon_version`` is read from the discovery
+    *payload* (the ``t2_addr`` token carries it — A2; no new persisted state).
+    ``reachable`` is a best-effort health-ping to the token's socket. A peer with
+    no token (``payload is None`` — an open-fd-only side-orphan) returns
+    ``(None, False)``: it has no socket we can reach and no version we can trust,
+    so the caller cannot spare it (single-writer backstop).
+    """
+    if not isinstance(payload, dict):
+        return (None, False)
+    version = payload.get("daemon_version")
+    return (version if isinstance(version, str) else None, _health_ping(payload))
+
+
 def _allocate_free_port() -> int:
     """Bind a free loopback port, then close it. No SO_REUSEADDR (see T3 daemon)."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -1031,9 +1081,11 @@ class T2Daemon:
         signal a pid leaves startup to proceed (the flock already guarantees
         we are the sole new writer).
         """
-        targets: list[int] = []
-
-        # 1. addr-file pid.
+        # 1. addr-file pid + its discovery token. The token is the ONLY input
+        #    that lets us spare a healthy current-version peer (RDR-140 P3:
+        #    it carries daemon_version + the socket to health-ping).
+        addr_pid: int | None = None
+        addr_payload: dict[str, Any] | None = None
         disc_path = t2_discovery_path(self._config_dir)
         try:
             raw = disc_path.read_text()
@@ -1041,32 +1093,58 @@ class T2Daemon:
         except (OSError, ValueError):
             payload = None
         if isinstance(payload, dict):
+            addr_payload = payload
             pid = payload.get("pid")
             if isinstance(pid, int):
-                targets.append(pid)
+                addr_pid = pid
 
         # 2. same-db open-fd sweep (catches side-orphans absent from the addr
-        #    file).
-        targets.extend(_enumerate_t2_daemon_pids_for_db(self._db_path))
-
-        # Reap each distinct non-self target once.
+        #    file). These have NO token, so they pass payload=None and can
+        #    never be spared — they escaped the db spawn lock we hold and are
+        #    exactly the orphan case this sweep exists to reap.
         seen: set[int] = set()
-        for pid in targets:
-            if pid <= 0 or pid == os.getpid() or pid in seen:
-                continue
-            seen.add(pid)
-            self._reap_one_daemon(pid)
 
-    def _reap_one_daemon(self, pid: int) -> None:
+        def _reap(pid: int, tok: dict[str, Any] | None) -> None:
+            if pid <= 0 or pid == os.getpid() or pid in seen:
+                return
+            seen.add(pid)
+            self._reap_one_daemon(pid, tok)
+
+        if addr_pid is not None:
+            _reap(addr_pid, addr_payload)
+        for pid in _enumerate_t2_daemon_pids_for_db(self._db_path):
+            _reap(pid, None)
+
+    def _reap_one_daemon(
+        self, pid: int, payload: dict[str, Any] | None = None,
+    ) -> None:
         """SIGTERM (escalating to SIGKILL after ``_PREDECESSOR_REAP_TIMEOUT``)
         a single live t2-daemon *pid*. Guarded by a liveness check and a
         cmdline check (PID-reuse guard: refuse to kill a recycled pid whose
-        command line is not a t2 daemon). Best-effort; never raises."""
+        command line is not a t2 daemon). Best-effort; never raises.
+
+        RDR-140 P3.2 (nexus-7ffls): ownership/version-aware discrimination.
+        When *payload* is the peer's ``t2_addr`` token, SPARE it (attach instead
+        of kill) iff it health-pings AND its ``daemon_version`` equals ours — a
+        healthy current-version peer is the legitimate single writer and must
+        not be reaped. A stale-version or unreachable addr peer, and every
+        open-fd-only peer (``payload is None``), falls through to the reap: the
+        RDR-128/129 single-writer backstop is preserved, never weakened.
+        """
         if not _pid_is_alive(pid):
             return
         if not _is_t2_daemon_process(pid):
             _log.warning("t2_predecessor_pid_not_daemon_skip_reap", pid=pid)
             return
+
+        if payload is not None:
+            version, reachable = _peer_handshake(pid, payload)
+            if reachable and version == _daemon_version():
+                _log.info(
+                    "t2_predecessor_spared_healthy_current",
+                    pid=pid, daemon_version=version,
+                )
+                return
 
         _log.warning("t2_reaping_predecessor_daemon", pid=pid)
         try:

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -80,6 +80,15 @@ _PREDECESSOR_REAP_TIMEOUT: float = 5.0
 # so tests can shrink it.
 _HEALTH_PING_TIMEOUT: float = 1.0
 
+# RDR-140 P3.2 option B (nexus-7ffls): a reachable, current-version peer found
+# during the startup reap is a same-version daemon mid-shutdown — it released
+# the spawn lock at the start of exit (we now hold it) but has not fully gone.
+# Single-writer forbids opening the DB while it lives, but it is draining its
+# own writes, so we give it this bounded window to exit on its own before
+# forcing a reap. We NEVER coexist: it either exits here or we kill it. Module
+# constant so tests can shrink it.
+_GRACEFUL_PEER_EXIT_WAIT: float = 3.0
+
 # RDR-129 B2 (nexus-qi1zb): bounded lock-retry for the serving dispatch.
 # Mirrors the bootstrap-migration retry
 # (``nexus.db.t2._apply_pending_with_lock_retry``): three attempts with two
@@ -599,15 +608,19 @@ def _health_ping(payload: dict[str, Any]) -> bool:
     """
     uds = payload.get("uds_path")
     if isinstance(uds, str) and uds:
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock = None
         try:
+            # socket() itself can raise (EMFILE) — create inside the try so the
+            # "never raises" contract holds even under fd exhaustion.
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             sock.settimeout(_HEALTH_PING_TIMEOUT)
             sock.connect(uds)
             return True
         except OSError:
             pass
         finally:
-            sock.close()
+            if sock is not None:
+                sock.close()
     host, port = payload.get("tcp_host"), payload.get("tcp_port")
     if isinstance(host, str) and host and isinstance(port, int) and port > 0:
         try:
@@ -1123,13 +1136,21 @@ class T2Daemon:
         cmdline check (PID-reuse guard: refuse to kill a recycled pid whose
         command line is not a t2 daemon). Best-effort; never raises.
 
-        RDR-140 P3.2 (nexus-7ffls): ownership/version-aware discrimination.
-        When *payload* is the peer's ``t2_addr`` token, SPARE it (attach instead
-        of kill) iff it health-pings AND its ``daemon_version`` equals ours — a
-        healthy current-version peer is the legitimate single writer and must
-        not be reaped. A stale-version or unreachable addr peer, and every
-        open-fd-only peer (``payload is None``), falls through to the reap: the
-        RDR-128/129 single-writer backstop is preserved, never weakened.
+        RDR-140 P3.2 option B (nexus-7ffls): ownership/version-aware
+        discrimination — WAIT, never coexist. When *payload* is the peer's
+        ``t2_addr`` token and it health-pings AND its ``daemon_version`` equals
+        ours, the peer is a same-version daemon mid-shutdown (it could not still
+        hold the db spawn lock we just acquired, so it has released it at the
+        start of its own exit). We do NOT SIGTERM it immediately — it is
+        draining its own writes — but we also NEVER open the DB alongside it:
+        we wait up to ``_GRACEFUL_PEER_EXIT_WAIT`` for it to exit on its own,
+        and only if it overstays do we force the reap. Either way this method
+        does not return until the peer is gone, so ``start()`` (which opens
+        ``T2Database`` right after the sweep) is guaranteed single-writer.
+
+        A stale-version or unreachable addr peer, and every open-fd-only peer
+        (``payload is None``), is reaped immediately: the RDR-128/129
+        single-writer backstop is preserved, never weakened.
         """
         if not _pid_is_alive(pid):
             return
@@ -1140,11 +1161,21 @@ class T2Daemon:
         if payload is not None:
             version, reachable = _peer_handshake(pid, payload)
             if reachable and version == _daemon_version():
-                _log.info(
-                    "t2_predecessor_spared_healthy_current",
+                # Same-version peer mid-shutdown: let it drain and exit, but
+                # never coexist — force the reap if it overstays the window.
+                deadline = time.monotonic() + _GRACEFUL_PEER_EXIT_WAIT
+                while time.monotonic() < deadline:
+                    if not _pid_is_alive(pid):
+                        _log.info(
+                            "t2_predecessor_exited_gracefully",
+                            pid=pid, daemon_version=version,
+                        )
+                        return
+                    time.sleep(0.1)
+                _log.warning(
+                    "t2_predecessor_overstayed_graceful_wait_forcing_reap",
                     pid=pid, daemon_version=version,
                 )
-                return
 
         _log.warning("t2_reaping_predecessor_daemon", pid=pid)
         try:

--- a/tests/daemon/test_t2_daemon_startup_invariant.py
+++ b/tests/daemon/test_t2_daemon_startup_invariant.py
@@ -454,30 +454,40 @@ class TestDaemonSweepsSideOrphans:
 class TestDaemonReapDiscrimination:
     """RDR-140 P3.1 (nexus-r9hq0): ownership/version-aware reap discrimination.
 
-    THE invariant the P3 gate (nexus-x2k4b) checks: ``_reap_predecessor_daemon``
-    must reap a peer ONLY IF (pid dead) OR (daemon_version != current) OR
-    (health-ping fails) — and must NEVER SIGTERM a healthy current-version peer
-    (attach instead). The RDR-128/129 single-writer flock backstop is NOT
-    weakened: orphaned writers (dead PID or unreachable health-ping) STILL get
+    THE invariant the P3 gate (nexus-x2k4b) checks: a healthy, current-version
+    peer named in OUR addr-file token must be attached, NEVER SIGTERM'd. The
+    RDR-128/129 single-writer flock backstop is NOT weakened: a stale-version or
+    unreachable addr-file peer, AND every open-fd-only side-orphan, STILL get
     reaped.
+
+    Discrimination scope (P3 design decision, 2026-05-31 — A2-faithful, single-
+    writer-safe; see the rdr140 P3 gate notes): the spare/attach path applies
+    ONLY to the addr-file pid, whose ``t2_addr`` token carries the
+    ``daemon_version`` + socket needed to handshake it. Open-fd-only peers
+    surfaced by the RDR-129 sweep have no token and no socket we can reach; they
+    are, by construction, writers that ESCAPED the db-scoped spawn lock we now
+    hold, so sparing one would re-admit a second writer. Therefore open-fd-only
+    peers are ALWAYS reaped — they are exactly the orphan case the sweep exists
+    to kill. (The literal "spare open-fd healthy peers too" reading was rejected:
+    the db-scoped spawn lock already prevents two healthy current daemons
+    coexisting, so a sparable open-fd peer cannot legitimately arise.)
 
     Seam contract these tests pin for the P3.2 implementation (nexus-7ffls):
 
     * A module-level ``_peer_handshake(pid, payload) -> (version, reachable)``
       yields the peer's reported daemon version and whether a health-ping
       reached it. The real impl reads ``daemon_version`` from the discovery
-      payload for the addr-file pid, and live-handshakes open-fd-only peers;
-      these tests stub it per-pid for determinism.
-    * ``_reap_predecessor_daemon`` passes each target's discovery payload
-      (the addr-file token; ``None`` for open-fd-only peers) to
-      ``_reap_one_daemon(pid, payload)``.
-    * Discrimination in the reap path: after the existing liveness + cmdline
-      guards, SPARE (no kill, attach) iff ``reachable and version ==
-      _daemon_version()``; otherwise reap.
+      payload and pings the token's socket; these tests stub it per-pid.
+    * ``_reap_predecessor_daemon`` passes the addr-file token to
+      ``_reap_one_daemon(pid, payload)`` for the addr pid, and ``payload=None``
+      for open-fd-only pids.
+    * Discrimination in the reap path: SPARE (no kill, attach) iff a token is
+      present AND ``reachable and version == _daemon_version()``; otherwise
+      reap (covers stale/unreachable addr peers and all open-fd-only peers).
 
-    Tests (1) healthy-current-spared and the side-orphan variant are RED
-    against current code, which reaps every live t2-daemon pid unconditionally.
-    The reap-the-orphan tests are GREEN now and MUST STAY green (the backstop).
+    The healthy-current addr-peer-spared tests are RED against current code,
+    which reaps every live t2-daemon pid unconditionally. The reap-the-orphan
+    tests are GREEN now and MUST STAY green (the backstop).
     """
 
     _CUR = "9.9.9-current"
@@ -569,14 +579,20 @@ class TestDaemonReapDiscrimination:
         td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
         assert (700003, signal.SIGTERM) in kills
 
-    def test_healthy_current_side_orphan_via_sweep_is_spared(
+    def test_side_orphan_via_sweep_is_always_reaped(
         self, config_dir: Path, db_path: Path, monkeypatch,
     ) -> None:
-        """RED: a healthy current-version peer found via the open-fd SWEEP
-        (not the addr file) must also be spared, not just the addr-file one."""
+        """Single-writer backstop: an open-fd-only peer (surfaced by the sweep,
+        absent from the addr file) is ALWAYS reaped — even if it would handshake
+        as healthy + current. It escaped the db-scoped spawn lock we hold, so it
+        cannot be a legitimately sparable peer; the spare path is addr-file-only.
+        """
+        import signal
+
         from nexus.daemon import t2_daemon as td
 
-        # No addr file; the peer surfaces only through the open-fd probe.
+        # No addr file; the peer surfaces only through the open-fd probe. Its
+        # handshake says healthy+current, but with no token it must still die.
         monkeypatch.setattr(
             td, "_enumerate_t2_daemon_pids_for_db", lambda p: [700004],
         )
@@ -584,7 +600,7 @@ class TestDaemonReapDiscrimination:
         self._install_common(monkeypatch, td, {700004: (self._CUR, True)}, kills)
 
         td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
-        assert kills == []
+        assert (700004, signal.SIGTERM) in kills
 
     def test_unreachable_side_orphan_via_sweep_is_reaped(
         self, config_dir: Path, db_path: Path, monkeypatch,

--- a/tests/daemon/test_t2_daemon_startup_invariant.py
+++ b/tests/daemon/test_t2_daemon_startup_invariant.py
@@ -511,6 +511,7 @@ class TestDaemonReapDiscrimination:
     def _install_common(
         monkeypatch, td, handshakes: dict, kills: list,
         graceful_exit: frozenset = frozenset(),
+        sigterm_ignored: frozenset = frozenset(),
     ) -> None:
         """Pin current version, cmdline, liveness; stub the per-pid handshake
         and capture kills. ``handshakes`` maps pid -> (version, reachable).
@@ -542,7 +543,9 @@ class TestDaemonReapDiscrimination:
 
         def fake_kill(pid, sig):  # noqa: ANN001
             kills.append((pid, sig))
-            if sig == signal.SIGTERM:
+            if sig == signal.SIGKILL:
+                alive[pid] = False  # SIGKILL is unblockable
+            elif sig == signal.SIGTERM and pid not in sigterm_ignored:
                 alive[pid] = False
 
         monkeypatch.setattr(td.os, "kill", fake_kill)
@@ -582,6 +585,30 @@ class TestDaemonReapDiscrimination:
 
         td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
         assert (700001, signal.SIGTERM) in kills
+
+    def test_overstay_peer_ignoring_sigterm_is_sigkilled_and_confirmed_dead(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        """Terminal escalation: a current-version peer that overstays the
+        graceful wait AND ignores SIGTERM is SIGKILL'd, and the reap confirms
+        it is dead before returning — start() must never open the DB while it
+        lives (single-writer)."""
+        import signal
+
+        from nexus.daemon import t2_daemon as td
+
+        self._write_discovery(config_dir, 700008, self._CUR)
+        kills: list = []
+        self._install_common(
+            monkeypatch, td, {700008: (self._CUR, True)}, kills,
+            sigterm_ignored=frozenset({700008}),
+        )
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert (700008, signal.SIGTERM) in kills
+        assert (700008, signal.SIGKILL) in kills
+        # The reap's post-SIGKILL poll observed it dead (SIGKILL flips alive).
+        assert td._pid_is_alive(700008) is False
 
     def test_stale_version_addr_peer_is_reaped(
         self, config_dir: Path, db_path: Path, monkeypatch,

--- a/tests/daemon/test_t2_daemon_startup_invariant.py
+++ b/tests/daemon/test_t2_daemon_startup_invariant.py
@@ -451,6 +451,187 @@ class TestDaemonSweepsSideOrphans:
         assert kills.count((333333, signal.SIGTERM)) == 1
 
 
+class TestDaemonReapDiscrimination:
+    """RDR-140 P3.1 (nexus-r9hq0): ownership/version-aware reap discrimination.
+
+    THE invariant the P3 gate (nexus-x2k4b) checks: ``_reap_predecessor_daemon``
+    must reap a peer ONLY IF (pid dead) OR (daemon_version != current) OR
+    (health-ping fails) — and must NEVER SIGTERM a healthy current-version peer
+    (attach instead). The RDR-128/129 single-writer flock backstop is NOT
+    weakened: orphaned writers (dead PID or unreachable health-ping) STILL get
+    reaped.
+
+    Seam contract these tests pin for the P3.2 implementation (nexus-7ffls):
+
+    * A module-level ``_peer_handshake(pid, payload) -> (version, reachable)``
+      yields the peer's reported daemon version and whether a health-ping
+      reached it. The real impl reads ``daemon_version`` from the discovery
+      payload for the addr-file pid, and live-handshakes open-fd-only peers;
+      these tests stub it per-pid for determinism.
+    * ``_reap_predecessor_daemon`` passes each target's discovery payload
+      (the addr-file token; ``None`` for open-fd-only peers) to
+      ``_reap_one_daemon(pid, payload)``.
+    * Discrimination in the reap path: after the existing liveness + cmdline
+      guards, SPARE (no kill, attach) iff ``reachable and version ==
+      _daemon_version()``; otherwise reap.
+
+    Tests (1) healthy-current-spared and the side-orphan variant are RED
+    against current code, which reaps every live t2-daemon pid unconditionally.
+    The reap-the-orphan tests are GREEN now and MUST STAY green (the backstop).
+    """
+
+    _CUR = "9.9.9-current"
+    _OLD = "1.0.0-stale"
+
+    @staticmethod
+    def _write_discovery(config_dir: Path, pid: int, daemon_version: str) -> Path:
+        import json
+
+        from nexus.daemon.t2_daemon import t2_discovery_path
+
+        p = t2_discovery_path(config_dir)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        # A2: the token already carries pid + daemon_version; no NEW persisted
+        # state is introduced by P3.
+        p.write_text(json.dumps(
+            {"pid": pid, "tcp_port": 1234, "daemon_version": daemon_version},
+        ))
+        return p
+
+    @staticmethod
+    def _install_common(monkeypatch, td, handshakes: dict, kills: list) -> None:
+        """Pin current version, liveness, cmdline; stub the per-pid handshake
+        and capture kills. ``handshakes`` maps pid -> (version, reachable)."""
+        import signal
+
+        monkeypatch.setattr(td, "_daemon_version",
+                            lambda: TestDaemonReapDiscrimination._CUR)
+        monkeypatch.setattr(td, "_is_t2_daemon_process", lambda pid: True)
+        state = {pid: True for pid in handshakes}
+        monkeypatch.setattr(td, "_pid_is_alive", lambda pid: state.get(pid, False))
+
+        def _handshake(pid, payload=None):  # noqa: ANN001
+            return handshakes.get(pid, (None, False))
+
+        monkeypatch.setattr(td, "_peer_handshake", _handshake, raising=False)
+
+        def fake_kill(pid, sig):  # noqa: ANN001
+            kills.append((pid, sig))
+            if sig == signal.SIGTERM:
+                state[pid] = False
+
+        monkeypatch.setattr(td, "_PREDECESSOR_REAP_TIMEOUT", 0.2)
+        monkeypatch.setattr(td.os, "kill", fake_kill)
+
+    def test_healthy_current_addr_peer_is_spared(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        """RED against current code: a healthy, current-version predecessor
+        named in the addr file must be attached, NEVER reaped."""
+        from nexus.daemon import t2_daemon as td
+
+        self._write_discovery(config_dir, 700001, self._CUR)
+        kills: list = []
+        self._install_common(monkeypatch, td, {700001: (self._CUR, True)}, kills)
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert kills == []
+
+    def test_stale_version_addr_peer_is_reaped(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        """A reachable but stale-version peer IS reaped (ensure-a-current
+        daemon); guard stays green through P3.2."""
+        import signal
+
+        from nexus.daemon import t2_daemon as td
+
+        self._write_discovery(config_dir, 700002, self._OLD)
+        kills: list = []
+        self._install_common(monkeypatch, td, {700002: (self._OLD, True)}, kills)
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert (700002, signal.SIGTERM) in kills
+
+    def test_unreachable_current_peer_is_reaped(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        """Orphan backstop (RDR-128): a live current-version pid whose
+        health-ping FAILS is a wedged/orphaned writer and MUST be reaped."""
+        import signal
+
+        from nexus.daemon import t2_daemon as td
+
+        self._write_discovery(config_dir, 700003, self._CUR)
+        kills: list = []
+        self._install_common(monkeypatch, td, {700003: (self._CUR, False)}, kills)
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert (700003, signal.SIGTERM) in kills
+
+    def test_healthy_current_side_orphan_via_sweep_is_spared(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        """RED: a healthy current-version peer found via the open-fd SWEEP
+        (not the addr file) must also be spared, not just the addr-file one."""
+        from nexus.daemon import t2_daemon as td
+
+        # No addr file; the peer surfaces only through the open-fd probe.
+        monkeypatch.setattr(
+            td, "_enumerate_t2_daemon_pids_for_db", lambda p: [700004],
+        )
+        kills: list = []
+        self._install_common(monkeypatch, td, {700004: (self._CUR, True)}, kills)
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert kills == []
+
+    def test_unreachable_side_orphan_via_sweep_is_reaped(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        """Orphan backstop on the sweep path: an unreachable open-fd holder is
+        reaped (single-writer preserved)."""
+        import signal
+
+        from nexus.daemon import t2_daemon as td
+
+        monkeypatch.setattr(
+            td, "_enumerate_t2_daemon_pids_for_db", lambda p: [700005],
+        )
+        kills: list = []
+        self._install_common(monkeypatch, td, {700005: (self._CUR, False)}, kills)
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert (700005, signal.SIGTERM) in kills
+
+    def test_mixed_targets_reap_only_the_stale_one(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        """Convergence (case c, deterministic): among multiple live peers, only
+        the stale-version one is reaped; the healthy current-version peer is
+        spared. Exactly one reap, the rest attach."""
+        import signal
+
+        from nexus.daemon import t2_daemon as td
+
+        # addr-file peer is healthy+current (spare); a side-orphan is stale (reap).
+        self._write_discovery(config_dir, 700006, self._CUR)
+        monkeypatch.setattr(
+            td, "_enumerate_t2_daemon_pids_for_db", lambda p: [700007],
+        )
+        kills: list = []
+        self._install_common(
+            monkeypatch, td,
+            {700006: (self._CUR, True), 700007: (self._OLD, True)},
+            kills,
+        )
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert (700007, signal.SIGTERM) in kills
+        assert not any(pid == 700006 for pid, _sig in kills)
+        assert {pid for pid, _sig in kills} == {700007}
+
+
 class TestEnumerateT2DaemonPids:
     """RDR-129 A1 (nexus-exa2p): the open-fd enumeration helper used by both
     the startup sweep and the doctor multiplicity check."""

--- a/tests/daemon/test_t2_daemon_startup_invariant.py
+++ b/tests/daemon/test_t2_daemon_startup_invariant.py
@@ -512,6 +512,7 @@ class TestDaemonReapDiscrimination:
         monkeypatch, td, handshakes: dict, kills: list,
         graceful_exit: frozenset = frozenset(),
         sigterm_ignored: frozenset = frozenset(),
+        sigkill_ignored: frozenset = frozenset(),
     ) -> None:
         """Pin current version, cmdline, liveness; stub the per-pid handshake
         and capture kills. ``handshakes`` maps pid -> (version, reachable).
@@ -543,7 +544,7 @@ class TestDaemonReapDiscrimination:
 
         def fake_kill(pid, sig):  # noqa: ANN001
             kills.append((pid, sig))
-            if sig == signal.SIGKILL:
+            if sig == signal.SIGKILL and pid not in sigkill_ignored:
                 alive[pid] = False  # SIGKILL is unblockable
             elif sig == signal.SIGTERM and pid not in sigterm_ignored:
                 alive[pid] = False
@@ -609,6 +610,31 @@ class TestDaemonReapDiscrimination:
         assert (700008, signal.SIGKILL) in kills
         # The reap's post-SIGKILL poll observed it dead (SIGKILL flips alive).
         assert td._pid_is_alive(700008) is False
+
+    def test_reap_is_bounded_when_peer_survives_even_sigkill(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        """The post-SIGKILL confirmation poll must be BOUNDED — a peer that
+        somehow survives SIGTERM and SIGKILL (zombie / kernel stall) must not
+        hang startup. This pins the poll as load-bearing: it loops until
+        _PREDECESSOR_REAP_TIMEOUT then returns (logging the overstay), rather
+        than returning instantly or looping forever."""
+        import signal
+
+        from nexus.daemon import t2_daemon as td
+
+        self._write_discovery(config_dir, 700009, self._CUR)
+        kills: list = []
+        self._install_common(
+            monkeypatch, td, {700009: (self._CUR, True)}, kills,
+            sigterm_ignored=frozenset({700009}),
+            sigkill_ignored=frozenset({700009}),  # never dies
+        )
+
+        # Returns (does not hang) despite the peer never dying.
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert (700009, signal.SIGTERM) in kills
+        assert (700009, signal.SIGKILL) in kills
 
     def test_stale_version_addr_peer_is_reaped(
         self, config_dir: Path, db_path: Path, monkeypatch,

--- a/tests/daemon/test_t2_daemon_startup_invariant.py
+++ b/tests/daemon/test_t2_daemon_startup_invariant.py
@@ -455,39 +455,38 @@ class TestDaemonReapDiscrimination:
     """RDR-140 P3.1 (nexus-r9hq0): ownership/version-aware reap discrimination.
 
     THE invariant the P3 gate (nexus-x2k4b) checks: a healthy, current-version
-    peer named in OUR addr-file token must be attached, NEVER SIGTERM'd. The
-    RDR-128/129 single-writer flock backstop is NOT weakened: a stale-version or
-    unreachable addr-file peer, AND every open-fd-only side-orphan, STILL get
-    reaped.
+    peer named in OUR addr-file token is a same-version daemon mid-shutdown
+    (it released the db spawn lock we now hold). It is WAITED OUT, never
+    coexisted with: the reap gives it a bounded window to exit on its own and
+    forces the kill only if it overstays — and NEVER returns to ``start()``
+    while it is still alive, so the DB is never opened by two writers. The
+    RDR-128/129 single-writer flock backstop is NOT weakened: a stale-version
+    or unreachable addr-file peer, AND every open-fd-only side-orphan, are
+    reaped immediately.
 
-    Discrimination scope (P3 design decision, 2026-05-31 — A2-faithful, single-
-    writer-safe; see the rdr140 P3 gate notes): the spare/attach path applies
-    ONLY to the addr-file pid, whose ``t2_addr`` token carries the
+    Design (P3 option B, 2026-05-31, user-confirmed): the wait-then-force path
+    applies ONLY to the addr-file pid, whose ``t2_addr`` token carries the
     ``daemon_version`` + socket needed to handshake it. Open-fd-only peers
-    surfaced by the RDR-129 sweep have no token and no socket we can reach; they
-    are, by construction, writers that ESCAPED the db-scoped spawn lock we now
-    hold, so sparing one would re-admit a second writer. Therefore open-fd-only
-    peers are ALWAYS reaped — they are exactly the orphan case the sweep exists
-    to kill. (The literal "spare open-fd healthy peers too" reading was rejected:
-    the db-scoped spawn lock already prevents two healthy current daemons
-    coexisting, so a sparable open-fd peer cannot legitimately arise.)
+    surfaced by the RDR-129 sweep have no token/socket and ESCAPED the db spawn
+    lock; they are ALWAYS reaped immediately (the orphan case the sweep exists
+    to kill). The earlier "spare and coexist" reading was rejected: ``start()``
+    opens ``T2Database`` right after the sweep, so sparing-without-exit would
+    admit a second writer; waiting-then-forcing keeps single-writer.
 
-    Seam contract these tests pin for the P3.2 implementation (nexus-7ffls):
+    Seam contract pinned for the P3.2 implementation (nexus-7ffls):
 
-    * A module-level ``_peer_handshake(pid, payload) -> (version, reachable)``
-      yields the peer's reported daemon version and whether a health-ping
-      reached it. The real impl reads ``daemon_version`` from the discovery
-      payload and pings the token's socket; these tests stub it per-pid.
+    * ``_peer_handshake(pid, payload) -> (version, reachable)`` — version from
+      the discovery payload, reachable from a health-ping; stubbed per-pid here.
     * ``_reap_predecessor_daemon`` passes the addr-file token to
-      ``_reap_one_daemon(pid, payload)`` for the addr pid, and ``payload=None``
-      for open-fd-only pids.
-    * Discrimination in the reap path: SPARE (no kill, attach) iff a token is
-      present AND ``reachable and version == _daemon_version()``; otherwise
-      reap (covers stale/unreachable addr peers and all open-fd-only peers).
+      ``_reap_one_daemon(pid, payload)`` for the addr pid, ``None`` otherwise.
+    * Reap path: for a token peer that is ``reachable and version ==
+      _daemon_version()``, poll its liveness up to ``_GRACEFUL_PEER_EXIT_WAIT``;
+      return without a kill iff it exits in that window, else force-reap.
+      Everything else (stale/unreachable addr peer, open-fd peer) reaps now.
 
-    The healthy-current addr-peer-spared tests are RED against current code,
-    which reaps every live t2-daemon pid unconditionally. The reap-the-orphan
-    tests are GREEN now and MUST STAY green (the backstop).
+    ``test_healthy_current_addr_peer_waited_out_then_exits`` and the mixed-
+    target test are RED against current code (which reaps unconditionally). The
+    reap-the-orphan tests are GREEN now and MUST STAY green.
     """
 
     _CUR = "9.9.9-current"
@@ -509,16 +508,32 @@ class TestDaemonReapDiscrimination:
         return p
 
     @staticmethod
-    def _install_common(monkeypatch, td, handshakes: dict, kills: list) -> None:
-        """Pin current version, liveness, cmdline; stub the per-pid handshake
-        and capture kills. ``handshakes`` maps pid -> (version, reachable)."""
+    def _install_common(
+        monkeypatch, td, handshakes: dict, kills: list,
+        graceful_exit: frozenset = frozenset(),
+    ) -> None:
+        """Pin current version, cmdline, liveness; stub the per-pid handshake
+        and capture kills. ``handshakes`` maps pid -> (version, reachable).
+        ``graceful_exit`` pids report alive on the initial guard then dead on
+        the next poll, simulating a mid-shutdown peer that exits during the
+        wait window (no SIGTERM needed)."""
         import signal
 
         monkeypatch.setattr(td, "_daemon_version",
                             lambda: TestDaemonReapDiscrimination._CUR)
         monkeypatch.setattr(td, "_is_t2_daemon_process", lambda pid: True)
-        state = {pid: True for pid in handshakes}
-        monkeypatch.setattr(td, "_pid_is_alive", lambda pid: state.get(pid, False))
+        monkeypatch.setattr(td, "_GRACEFUL_PEER_EXIT_WAIT", 0.5)
+        monkeypatch.setattr(td, "_PREDECESSOR_REAP_TIMEOUT", 0.2)
+        alive = {pid: True for pid in handshakes}
+        calls: dict = {}
+
+        def _is_alive(pid):  # noqa: ANN001
+            calls[pid] = calls.get(pid, 0) + 1
+            if pid in graceful_exit and calls[pid] >= 2:
+                return False  # exits on its own during the wait loop
+            return alive.get(pid, False)
+
+        monkeypatch.setattr(td, "_pid_is_alive", _is_alive)
 
         def _handshake(pid, payload=None):  # noqa: ANN001
             return handshakes.get(pid, (None, False))
@@ -528,24 +543,45 @@ class TestDaemonReapDiscrimination:
         def fake_kill(pid, sig):  # noqa: ANN001
             kills.append((pid, sig))
             if sig == signal.SIGTERM:
-                state[pid] = False
+                alive[pid] = False
 
-        monkeypatch.setattr(td, "_PREDECESSOR_REAP_TIMEOUT", 0.2)
         monkeypatch.setattr(td.os, "kill", fake_kill)
 
-    def test_healthy_current_addr_peer_is_spared(
+    def test_healthy_current_addr_peer_waited_out_then_exits(
         self, config_dir: Path, db_path: Path, monkeypatch,
     ) -> None:
         """RED against current code: a healthy, current-version predecessor
-        named in the addr file must be attached, NEVER reaped."""
+        (mid-shutdown) that exits within the graceful window is WAITED OUT,
+        never SIGTERM'd."""
         from nexus.daemon import t2_daemon as td
 
         self._write_discovery(config_dir, 700001, self._CUR)
         kills: list = []
-        self._install_common(monkeypatch, td, {700001: (self._CUR, True)}, kills)
+        self._install_common(
+            monkeypatch, td, {700001: (self._CUR, True)}, kills,
+            graceful_exit=frozenset({700001}),
+        )
 
         td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
         assert kills == []
+
+    def test_healthy_current_addr_peer_overstays_is_force_reaped(
+        self, config_dir: Path, db_path: Path, monkeypatch,
+    ) -> None:
+        """Never coexist: a current-version peer that does NOT exit within the
+        graceful window is force-reaped — start() must not open the DB while it
+        lives."""
+        import signal
+
+        from nexus.daemon import t2_daemon as td
+
+        self._write_discovery(config_dir, 700001, self._CUR)
+        kills: list = []
+        # Not in graceful_exit -> stays alive through the wait -> forced.
+        self._install_common(monkeypatch, td, {700001: (self._CUR, True)}, kills)
+
+        td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
+        assert (700001, signal.SIGTERM) in kills
 
     def test_stale_version_addr_peer_is_reaped(
         self, config_dir: Path, db_path: Path, monkeypatch,
@@ -623,14 +659,15 @@ class TestDaemonReapDiscrimination:
     def test_mixed_targets_reap_only_the_stale_one(
         self, config_dir: Path, db_path: Path, monkeypatch,
     ) -> None:
-        """Convergence (case c, deterministic): among multiple live peers, only
-        the stale-version one is reaped; the healthy current-version peer is
-        spared. Exactly one reap, the rest attach."""
+        """Convergence (case c, deterministic): among multiple live peers, the
+        healthy current-version addr peer is waited out (exits on its own, no
+        kill) while the open-fd side-orphan is reaped. Exactly one reap."""
         import signal
 
         from nexus.daemon import t2_daemon as td
 
-        # addr-file peer is healthy+current (spare); a side-orphan is stale (reap).
+        # addr peer healthy+current and exits during the wait; a side-orphan
+        # (open-fd, payload=None) is always reaped immediately.
         self._write_discovery(config_dir, 700006, self._CUR)
         monkeypatch.setattr(
             td, "_enumerate_t2_daemon_pids_for_db", lambda p: [700007],
@@ -638,14 +675,82 @@ class TestDaemonReapDiscrimination:
         kills: list = []
         self._install_common(
             monkeypatch, td,
-            {700006: (self._CUR, True), 700007: (self._OLD, True)},
+            {700006: (self._CUR, True), 700007: (self._CUR, True)},
             kills,
+            graceful_exit=frozenset({700006}),
         )
 
         td.T2Daemon(config_dir=config_dir, db_path=db_path)._reap_predecessor_daemon()
         assert (700007, signal.SIGTERM) in kills
         assert not any(pid == 700006 for pid, _sig in kills)
         assert {pid for pid, _sig in kills} == {700007}
+
+
+class TestHealthPingAndHandshake:
+    """RDR-140 P3.2 (nexus-7ffls): the reap-discrimination probes themselves
+    (the reap-path tests stub ``_peer_handshake``, so exercise the real ones
+    here)."""
+
+    def test_peer_handshake_none_payload_is_none_unreachable(self) -> None:
+        from nexus.daemon import t2_daemon as td
+
+        assert td._peer_handshake(123, None) == (None, False)
+
+    def test_peer_handshake_reads_version_pings_socket(self, monkeypatch) -> None:
+        from nexus.daemon import t2_daemon as td
+
+        monkeypatch.setattr(td, "_health_ping", lambda payload: True)
+        assert td._peer_handshake(
+            123, {"daemon_version": "1.2.3", "uds_path": "/x"},
+        ) == ("1.2.3", True)
+
+    def test_peer_handshake_missing_version_is_none(self, monkeypatch) -> None:
+        from nexus.daemon import t2_daemon as td
+
+        monkeypatch.setattr(td, "_health_ping", lambda payload: False)
+        assert td._peer_handshake(123, {"uds_path": "/x"}) == (None, False)
+
+    def test_health_ping_no_socket_fields_is_false(self) -> None:
+        from nexus.daemon import t2_daemon as td
+
+        assert td._health_ping({}) is False
+
+    def test_health_ping_unreachable_uds_is_false(self, tmp_path) -> None:
+        from nexus.daemon import t2_daemon as td
+
+        # A path with no listener: connect refuses -> False, never raises.
+        assert td._health_ping({"uds_path": "/tmp/nxt2-nonexistent.sock"}) is False
+
+    def test_health_ping_reachable_uds_is_true(self) -> None:
+        import socket
+        import tempfile
+
+        from nexus.daemon import t2_daemon as td
+
+        # Short /tmp path: AF_UNIX caps at 104 chars.
+        with tempfile.TemporaryDirectory(prefix="nxt2hp-", dir="/tmp") as d:
+            sock_path = str(Path(d) / "t2.sock")
+            srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                srv.bind(sock_path)
+                srv.listen(1)
+                assert td._health_ping({"uds_path": sock_path}) is True
+            finally:
+                srv.close()
+
+    def test_health_ping_never_raises_under_socket_failure(self, monkeypatch) -> None:
+        """M1: socket() raising (e.g. EMFILE) must not break the 'never raises'
+        contract — the probe returns False."""
+        import socket as _socket
+
+        from nexus.daemon import t2_daemon as td
+
+        def _boom(*_a, **_k):
+            raise OSError(24, "Too many open files")
+
+        monkeypatch.setattr(td.socket, "socket", _boom)
+        # UDS path present so the socket() call is attempted; TCP absent.
+        assert td._health_ping({"uds_path": "/tmp/whatever.sock"}) is False
 
 
 class TestEnumerateT2DaemonPids:


### PR DESCRIPTION
## RDR-140 P3 — Ownership-aware reaping (invariant-touching, gated)

The single invariant-touching phase of RDR-140. The daemon startup reap (`_reap_predecessor_daemon`, run after `_acquire_spawn_lock`) becomes ownership/version-aware: it no longer blindly SIGTERMs a same-version predecessor and re-spawns it (the version-transition churn class). The RDR-128/129 single-writer flock backstop is **not weakened** — every escapee/orphan is still reaped.

### What changed (`src/nexus/daemon/t2_daemon.py`)
- `_peer_handshake(pid, payload) -> (daemon_version, reachable)` — version from the `t2_addr` token (A2: no new persisted state), reachability via `_health_ping` (UDS then TCP, bounded by `_HEALTH_PING_TIMEOUT`, never raises even under EMFILE).
- `_reap_one_daemon(pid, payload)` discrimination, **wait-then-force, never coexist**: a reachable current-version addr-file peer is a same-version daemon mid-shutdown (it released the db spawn lock we now hold). It is polled up to `_GRACEFUL_PEER_EXIT_WAIT` to exit on its own; if it overstays it is force-reaped (SIGTERM → SIGKILL), and **the method never returns while the peer is alive** — so `start()`'s immediate `T2Database` open is guaranteed single-writer. The SIGKILL escalation now confirms death (bounded post-kill poll) before returning.
- Stale-version / unreachable addr peers, and **all** open-fd-only side-orphans (no token, escaped the db spawn lock), reap immediately.

### Design note (gate-recorded)
The literal "spare a healthy current peer" reading from the RDR was found, in stacked review, to leave a single-writer hole (sparing without aborting `start()` → two writers). Analysis showed a healthy-current peer encountered post-spawn-lock is necessarily mid-shutdown; the healthy-current *attach* protection already lives in P2's ensure-running pre-discovery + the spawn lock. Resolved to **wait-then-force, never coexist**. Full rationale in T2 `rdr140-p3-spare-vs-startlock-critical` / `rdr140-p3-gate`.

### Tests
- `TestDaemonReapDiscrimination` — waited-out-exit (no kill), overstay→SIGTERM, SIGTERM-ignored→SIGKILL→death-confirmed, survives-even-SIGKILL→bounded-return, stale reaped, unreachable reaped, open-fd-only always reaped, mixed-target convergence.
- `TestHealthPingAndHandshake` — reachable/unreachable/no-socket/EMFILE; handshake none/version/missing.
- Multi-stack race harness (P2/P3 gate artifact) stays green.
- **Full unit suite: 8497 passed, 0 failures.**

### Review
Stacked gate (code-review-expert + substantive-critic) on the invariant: found a Critical (spare-without-abort) + a residual (SIGKILL-no-confirm), both fixed; critic re-review confirmed closed. Test-validate PARTIAL→gaps closed. §Approach Gap 2 cross-walk complete; deferrals (real-process version-skew harness; `t2_index_write` fallback = RDR-128 scope) explicitly recorded, not silently dropped.

Beads: nexus-r9hq0, nexus-7ffls, nexus-4n1mw, nexus-dzf1q, nexus-zblru, nexus-x2k4b (P3). Epic: nexus-7nxc2. Remaining in RDR-140: P4 (observability), then RDR close.
