### PR TITLE
RDR-140 P4: observability (status restart-count + crash-loop guard)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1462,6 +1462,11 @@ an `"alive": false` field) and exits 1, so a daemon that died leaving a
 stale discovery file is not reported as running. Exit code 1 also when no
 discovery file exists.
 
+The output also includes `restarts_in_window` (RDR-140 P4): the number
+of cold respawns the crash-loop guard has recorded in the current window
+(see `ensure-running` below). A rising count across successive `status`
+calls is the crash-loop signal. `0` once the daemon converges.
+
 ### nx daemon t2 ensure-running
 
 Idempotent: silent no-op if the T2 daemon is already running on the
@@ -1481,6 +1486,17 @@ the running daemon matches the installed code. This is why `nx upgrade`,
 hooks all call `ensure-running` after an install: the daemon comes up on
 the new version without a manual restart. A daemon already matching the
 installed version is left untouched.
+
+Crash-loop guard (RDR-140 P4). Each cold respawn is recorded in a
+sentinel file beside the discovery file. After `_CRASHLOOP_MAX_RESTARTS`
+(default 5) respawns within `_CRASHLOOP_WINDOW_S` (default 300s) without
+the daemon converging, `ensure-running` stops respawning, logs once at
+`error` (`t2_daemon_crash_loop_suppressed`), and exits 1, instead of an
+endless crash-loop with a traceback per attempt. The counter is cleared
+the moment a spawned daemon becomes reachable. This bounds the launchd /
+systemd `KeepAlive` respawn rate for a daemon that is failing to start
+(e.g. a corrupt DB); inspect the daemon log, then re-run `ensure-running`
+after fixing the root cause.
 
 | Flag | Description |
 |------|-------------|

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1487,16 +1487,28 @@ hooks all call `ensure-running` after an install: the daemon comes up on
 the new version without a manual restart. A daemon already matching the
 installed version is left untouched.
 
-Crash-loop guard (RDR-140 P4). Each cold respawn is recorded in a
-sentinel file beside the discovery file. After `_CRASHLOOP_MAX_RESTARTS`
-(default 5) respawns within `_CRASHLOOP_WINDOW_S` (default 300s) without
-the daemon converging, `ensure-running` stops respawning, logs once at
-`error` (`t2_daemon_crash_loop_suppressed`), and exits 1, instead of an
-endless crash-loop with a traceback per attempt. The counter is cleared
-the moment a spawned daemon becomes reachable. This bounds the launchd /
-systemd `KeepAlive` respawn rate for a daemon that is failing to start
-(e.g. a corrupt DB); inspect the daemon log, then re-run `ensure-running`
-after fixing the root cause.
+Crash-loop guard (RDR-140 P4). Each cold respawn driven by
+`ensure-running` is recorded in a sentinel file beside the discovery
+file. After `_CRASHLOOP_MAX_RESTARTS` (default 5) respawns within
+`_CRASHLOOP_WINDOW_S` (default 300s) without the daemon converging,
+`ensure-running` stops respawning, logs once at `error`
+(`t2_daemon_crash_loop_suppressed`), and exits 1, instead of an endless
+crash-loop with a traceback per attempt. The counter clears when a
+spawned daemon becomes reachable, and re-arms for a fresh window once the
+prior restarts age out.
+
+Scope: this guard bounds the `ensure-running`-driven respawn path (the
+dominant source of churn, since the plugin / `.mcpb` session-start hooks
+call `ensure-running` on every MCP-server boot). It does NOT bound the
+launchd / systemd path: `install --autostart` runs `nx daemon t2 start`
+directly, which never consults the sentinel, so a daemon failing under
+`KeepAlive` is rate-limited only by the supervisor's own throttle
+(launchd `ThrottleInterval`, systemd `RestartSec`). Known limitation: a
+daemon that becomes briefly reachable then dies repeatedly (flapping)
+resets the counter each cycle, so the guard fires only for a daemon that
+never reaches the discovery-written state within the spawn timeout.
+Inspect the daemon log, then re-run `ensure-running` after fixing the
+root cause.
 
 | Flag | Description |
 |------|-------------|

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -27,8 +27,11 @@ from pathlib import Path
 from xml.sax.saxutils import escape as _xml_escape
 
 import click
+import structlog
 
 from nexus.config import nexus_config_dir
+
+_log = structlog.get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -647,8 +650,14 @@ def t2_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
         except (ProcessLookupError, PermissionError):
             alive = False
 
+    # RDR-140 P4.2 (Gap 5): surface how many restarts the crash-loop guard has
+    # recorded in the current window — a rising count is the crash-loop signal.
+    restarts = _restart_count(config_dir, now=time.time())
+
     if as_json:
-        click.echo(_json.dumps({**data, "alive": alive}, indent=2))
+        click.echo(_json.dumps(
+            {**data, "alive": alive, "restarts_in_window": restarts}, indent=2,
+        ))
         if not alive:
             sys.exit(1)
         return
@@ -657,6 +666,7 @@ def t2_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
     click.echo("-" * 40)
     for key, value in data.items():
         click.echo(f"  {key}: {value}")
+    click.echo(f"  restarts_in_window: {restarts}")
     if not alive:
         click.echo(
             f"  status: STALE (recorded pid {pid} is not running). "
@@ -768,6 +778,85 @@ def _release_election_lock(fd: int | None) -> None:
         pass
     try:
         os.close(fd)
+    except OSError:
+        pass
+
+
+# RDR-140 P4.2 (nexus-hrrpz) Gap 5: bounded crash-loop guard. Cold respawns are
+# one-shot (``t2 start`` per ``ensure-running`` / launchd KeepAlive), so the
+# guard is a persistent counter in a sentinel file beside the discovery file:
+# restart timestamps within a rolling window. After _CRASHLOOP_MAX_RESTARTS in
+# the window, ``ensure-running`` stops respawning and logs ONCE at error
+# (instead of an endless crash-loop with a traceback per attempt). A daemon
+# that converges (becomes reachable) clears the counter. This is suppression of
+# respawn attempts, NOT a writer-lock change — RDR-128/129 single-writer is
+# untouched. Module constants so tests can shrink the window/cap.
+_CRASHLOOP_WINDOW_S: float = 300.0
+_CRASHLOOP_MAX_RESTARTS: int = 5
+
+
+def _crashloop_sentinel_path(config_dir: Path) -> Path:
+    """Sentinel file path for the crash-loop guard, a sibling of the discovery
+    file under *config_dir*."""
+    return config_dir / "t2_crashloop.json"
+
+
+def _read_crashloop(config_dir: Path) -> dict:
+    try:
+        data = json.loads(_crashloop_sentinel_path(config_dir).read_text())
+    except (OSError, json.JSONDecodeError):
+        return {"timestamps": [], "tripped_logged": False}
+    if not isinstance(data, dict):
+        return {"timestamps": [], "tripped_logged": False}
+    ts = data.get("timestamps")
+    data["timestamps"] = [t for t in ts if isinstance(t, (int, float))] if isinstance(ts, list) else []
+    data["tripped_logged"] = bool(data.get("tripped_logged"))
+    return data
+
+
+def _write_crashloop_atomic(config_dir: Path, data: dict) -> None:
+    """Atomic 0o600 write (mirrors ``_write_discovery_atomic``) so a concurrent
+    reader never sees a partial sentinel."""
+    path = _crashloop_sentinel_path(config_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    body = json.dumps(data).encode("utf-8")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, body)
+    finally:
+        os.close(fd)
+    os.replace(str(tmp), str(path))
+
+
+def _restart_count(config_dir: Path, *, now: float) -> int:
+    """Restarts recorded within the window ending at *now* (read-only)."""
+    cutoff = now - _CRASHLOOP_WINDOW_S
+    data = _read_crashloop(config_dir)
+    return sum(1 for t in data["timestamps"] if t >= cutoff)
+
+
+def _record_restart(config_dir: Path, *, now: float) -> int:
+    """Append a restart at *now*, prune entries older than the window, persist,
+    and return the in-window count."""
+    cutoff = now - _CRASHLOOP_WINDOW_S
+    data = _read_crashloop(config_dir)
+    kept = [t for t in data["timestamps"] if t >= cutoff]
+    kept.append(now)
+    data["timestamps"] = kept
+    _write_crashloop_atomic(config_dir, data)
+    return len(kept)
+
+
+def _crashloop_tripped(config_dir: Path, *, now: float) -> bool:
+    """True when the in-window restart count has reached the cap."""
+    return _restart_count(config_dir, now=now) >= _CRASHLOOP_MAX_RESTARTS
+
+
+def _reset_crashloop(config_dir: Path) -> None:
+    """Clear the guard on healthy convergence (best-effort; never raises)."""
+    try:
+        _crashloop_sentinel_path(config_dir).unlink(missing_ok=True)
     except OSError:
         pass
 
@@ -1003,6 +1092,34 @@ def t2_ensure_running_cmd(
                 return  # never trade a working daemon for none
             # predecessor fully exited; its spawn lock is released — cold spawn.
 
+        # RDR-140 P4.2 (Gap 5): crash-loop guard. If we have already respawned
+        # _CRASHLOOP_MAX_RESTARTS times within the window without converging,
+        # stop — an endless crash-loop with a traceback per attempt helps no
+        # one. Log ONCE at error (the sentinel's tripped_logged flag prevents
+        # re-logging on every suppressed call) and refuse to respawn. A healthy
+        # convergence below clears the counter.
+        _cl_now = _time.time()
+        if _crashloop_tripped(config_dir, now=_cl_now):
+            _data = _read_crashloop(config_dir)
+            if not _data.get("tripped_logged"):
+                _log.error(
+                    "t2_daemon_crash_loop_suppressed",
+                    restarts=_restart_count(config_dir, now=_cl_now),
+                    window_s=_CRASHLOOP_WINDOW_S,
+                    max_restarts=_CRASHLOOP_MAX_RESTARTS,
+                )
+                _data["tripped_logged"] = True
+                _write_crashloop_atomic(config_dir, _data)
+            click.echo(
+                f"Error: T2 daemon crash-loop suppressed "
+                f"({_CRASHLOOP_MAX_RESTARTS}+ restarts in "
+                f"{_CRASHLOOP_WINDOW_S:.0f}s); refusing to respawn. Investigate "
+                "the daemon log, then 'nx daemon t2 status'.",
+                err=True,
+            )
+            sys.exit(1)
+        _record_restart(config_dir, now=_cl_now)
+
         # Cold spawn. Use the same nx binary the operator invoked (preserves
         # PATH/virtualenv assumptions). start_new_session detaches the child
         # so this command can exit while the daemon keeps running.
@@ -1033,6 +1150,8 @@ def t2_ensure_running_cmd(
         deadline = _time.monotonic() + timeout
         while _time.monotonic() < deadline:
             if _daemon_is_alive():
+                # Healthy convergence: clear the crash-loop counter.
+                _reset_crashloop(config_dir)
                 if not quiet:
                     click.echo("T2 daemon is reachable.")
                 return

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -842,6 +842,12 @@ def _record_restart(config_dir: Path, *, now: float) -> int:
     cutoff = now - _CRASHLOOP_WINDOW_S
     data = _read_crashloop(config_dir)
     kept = [t for t in data["timestamps"] if t >= cutoff]
+    if not kept:
+        # Fresh window (all prior restarts aged out): re-arm the one-shot
+        # error log so a NEW crash loop is reported, not silently swallowed
+        # by a stale tripped_logged flag from a previous window (code-review
+        # HIGH-1).
+        data["tripped_logged"] = False
     kept.append(now)
     data["timestamps"] = kept
     _write_crashloop_atomic(config_dir, data)

--- a/tests/daemon/test_t2_daemon_observability.py
+++ b/tests/daemon/test_t2_daemon_observability.py
@@ -304,6 +304,24 @@ class TestCrashLoopGuard:
         assert dm._restart_count(tmp_path, now=now) == 0
         assert dm._crashloop_tripped(tmp_path, now=now) is False
 
+    def test_tripped_logged_rearms_after_window_expiry(self, tmp_path: Path) -> None:
+        """code-review HIGH-1: a stale ``tripped_logged`` from a previous
+        window must not silence the error log for a NEW crash loop. The first
+        restart of a fresh window (all prior entries aged out) re-arms it."""
+        from nexus.commands import daemon as dm
+
+        now = 1_000_000.0
+        for i in range(dm._CRASHLOOP_MAX_RESTARTS):
+            dm._record_restart(tmp_path, now=now + i)
+        data = dm._read_crashloop(tmp_path)
+        data["tripped_logged"] = True
+        dm._write_crashloop_atomic(tmp_path, data)
+        assert dm._read_crashloop(tmp_path)["tripped_logged"] is True
+
+        later = now + dm._CRASHLOOP_WINDOW_S + 10.0  # a full window later
+        dm._record_restart(tmp_path, now=later)
+        assert dm._read_crashloop(tmp_path)["tripped_logged"] is False
+
 
 class TestCrashLoopRespawnRefusal:
     """A tripped crash-loop guard must make ensure-running log ONCE at error
@@ -345,6 +363,43 @@ class TestCrashLoopRespawnRefusal:
         assert spawns == [], "tripped guard must NOT spawn"
         assert result.exit_code != 0
         assert len(errors) == 1, f"crash-loop must log exactly once, saw {errors}"
+
+    def test_tripped_guard_logs_once_across_invocations(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """The error log fires once, not per suppressed ensure-running call:
+        the tripped_logged sentinel flag suppresses re-logging on the second
+        invocation of an already-tripped guard."""
+        import nexus.commands.daemon as dm
+
+        now = 1_000_000.0
+        for i in range(dm._CRASHLOOP_MAX_RESTARTS):
+            dm._record_restart(tmp_path, now=now + i)
+        monkeypatch.setattr(dm.time, "time", lambda: now + dm._CRASHLOOP_MAX_RESTARTS)
+
+        spawns: list = []
+        monkeypatch.setattr(
+            dm.subprocess, "Popen",
+            lambda *a, **k: spawns.append(a) or _Unreachable(),
+        )
+        errors: list = []
+
+        class _FakeLog:
+            def error(self, event, **kw):
+                errors.append(event)
+
+            def __getattr__(self, _n):
+                return lambda *a, **k: None
+
+        monkeypatch.setattr(dm, "_log", _FakeLog(), raising=False)
+
+        for _ in range(2):
+            CliRunner().invoke(
+                main, ["daemon", "t2", "ensure-running",
+                       "--config-dir", str(tmp_path), "--timeout", "0.2"],
+            )
+        assert spawns == []
+        assert len(errors) == 1, f"must log once across invocations, saw {errors}"
 
 
 class _Unreachable:

--- a/tests/daemon/test_t2_daemon_observability.py
+++ b/tests/daemon/test_t2_daemon_observability.py
@@ -206,3 +206,149 @@ class TestStopBreadcrumbDurability:
         assert order == ["breadcrumb", "flush"], (
             f"breadcrumb must be written THEN flushed; saw {order}"
         )
+
+
+# ---------------------------------------------------------------------------
+# RDR-140 P4.1 (nexus-0gyhe): Gap 5 — status surface + crash-loop guard
+# ---------------------------------------------------------------------------
+
+
+class TestStatusSurface:
+    """`nx daemon t2 status` must explicitly surface owner pid, socket
+    liveness, daemon version, AND a restart-count-in-interval. The first three
+    already render (the discovery dict is dumped); the restart count is NEW and
+    is RED until P4.2 (nexus-hrrpz) sources it from the crash-loop guard."""
+
+    def test_status_surfaces_owner_pid_version_and_liveness(
+        self, tmp_path: Path,
+    ) -> None:
+        _write_discovery(tmp_path, os.getpid())
+        result = CliRunner().invoke(
+            main, ["daemon", "t2", "status", "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+        out = result.output
+        assert str(os.getpid()) in out          # owner pid
+        assert "5.0.2" in out                    # daemon version (token)
+        assert "running" in out.lower()          # socket/pid liveness
+
+    def test_status_surfaces_restart_count_field(self, tmp_path: Path) -> None:
+        """RED until P4.2: status reports how many restarts occurred in the
+        crash-loop window (sourced from the guard sentinel; 0 when none).
+
+        Asserts the explicit ``restarts_in_window`` label, NOT a bare
+        "restart" substring — the pytest tmp_path is derived from this test's
+        name and contains "restart", which would match the path vacuously."""
+        _write_discovery(tmp_path, os.getpid())
+        result = CliRunner().invoke(
+            main, ["daemon", "t2", "status", "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "restarts_in_window" in result.output
+
+
+class TestCrashLoopGuard:
+    """Bounded crash-loop guard (Gap 5). Seam contract pinned for P4.2
+    (nexus-hrrpz), all in ``nexus.commands.daemon``:
+
+    * constants ``_CRASHLOOP_WINDOW_S: float`` and ``_CRASHLOOP_MAX_RESTARTS: int``.
+    * ``_record_restart(config_dir, *, now) -> int`` — append a wall-clock
+      timestamp to the sentinel, prune entries older than the window, return
+      the count within the window.
+    * ``_restart_count(config_dir, *, now) -> int`` — read-only count within
+      the window (no write); used by status.
+    * ``_crashloop_tripped(config_dir, *, now) -> bool`` — count >= cap.
+    * ``_reset_crashloop(config_dir)`` — clear the sentinel (healthy converge).
+
+    The clock is injected (``now`` is a ``time.time()``-style float) so the
+    window logic is deterministic — no real wall clock, no sleeps. RED
+    (AttributeError) until P4.2 adds the seam.
+    """
+
+    def test_records_and_counts_within_window(self, tmp_path: Path) -> None:
+        from nexus.commands import daemon as dm
+
+        now = 1_000_000.0
+        assert dm._record_restart(tmp_path, now=now) == 1
+        assert dm._record_restart(tmp_path, now=now + 1) == 2
+        assert dm._record_restart(tmp_path, now=now + 2) == 3
+        assert dm._restart_count(tmp_path, now=now + 2) == 3
+
+    def test_count_excludes_entries_outside_window(self, tmp_path: Path) -> None:
+        from nexus.commands import daemon as dm
+
+        now = 1_000_000.0
+        dm._record_restart(tmp_path, now=now)
+        # A probe a full window + 1s later: the old entry has aged out.
+        later = now + dm._CRASHLOOP_WINDOW_S + 1.0
+        assert dm._restart_count(tmp_path, now=later) == 0
+
+    def test_tripped_after_cap(self, tmp_path: Path) -> None:
+        from nexus.commands import daemon as dm
+
+        now = 1_000_000.0
+        for i in range(dm._CRASHLOOP_MAX_RESTARTS):
+            dm._record_restart(tmp_path, now=now + i)
+            # Not tripped until the cap is reached.
+            expected = (i + 1) >= dm._CRASHLOOP_MAX_RESTARTS
+            assert dm._crashloop_tripped(tmp_path, now=now + i) is expected
+
+    def test_reset_clears_count(self, tmp_path: Path) -> None:
+        from nexus.commands import daemon as dm
+
+        now = 1_000_000.0
+        for i in range(dm._CRASHLOOP_MAX_RESTARTS):
+            dm._record_restart(tmp_path, now=now + i)
+        assert dm._crashloop_tripped(tmp_path, now=now) is True
+        dm._reset_crashloop(tmp_path)
+        assert dm._restart_count(tmp_path, now=now) == 0
+        assert dm._crashloop_tripped(tmp_path, now=now) is False
+
+
+class TestCrashLoopRespawnRefusal:
+    """A tripped crash-loop guard must make ensure-running log ONCE at error
+    and STOP respawning — no Nth+1 spawn, no traceback. RED until P4.2 wires
+    the guard into ``t2_ensure_running_cmd``."""
+
+    def test_tripped_guard_refuses_respawn_and_logs_once(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        import nexus.commands.daemon as dm
+
+        # Pre-trip the guard: cap restarts inside the window.
+        now = 1_000_000.0
+        for i in range(dm._CRASHLOOP_MAX_RESTARTS):
+            dm._record_restart(tmp_path, now=now + i)
+        monkeypatch.setattr(dm.time, "time", lambda: now + dm._CRASHLOOP_MAX_RESTARTS)
+
+        spawns: list = []
+        monkeypatch.setattr(
+            dm.subprocess, "Popen",
+            lambda *a, **k: spawns.append(a) or _Unreachable(),
+        )
+        errors: list = []
+
+        class _FakeLog:
+            def error(self, event, **kw):
+                errors.append(event)
+
+            def __getattr__(self, _n):
+                return lambda *a, **k: None
+
+        monkeypatch.setattr(dm, "_log", _FakeLog(), raising=False)
+
+        # No live daemon (no discovery file) -> would normally cold-spawn.
+        result = CliRunner().invoke(
+            main, ["daemon", "t2", "ensure-running",
+                   "--config-dir", str(tmp_path), "--timeout", "0.2"],
+        )
+        assert spawns == [], "tripped guard must NOT spawn"
+        assert result.exit_code != 0
+        assert len(errors) == 1, f"crash-loop must log exactly once, saw {errors}"
+
+
+class _Unreachable:
+    """A Popen stand-in that is alive but never becomes reachable."""
+
+    def poll(self):
+        return None


### PR DESCRIPTION
## RDR-140 P4 — Observability (contained)

Final phase of RDR-140 (Gap 5). Adds a status restart-count and a bounded crash-loop guard so a daemon that keeps failing to start no longer emits an endless stream of `t2_daemon_crashed` tracebacks. Contained: no change to the RDR-128/129 single-writer flock.

### Status surface (`src/nexus/commands/daemon.py`)
`nx daemon t2 status` now surfaces `restarts_in_window` (human output + `--json`) alongside the existing owner pid, socket liveness, and daemon version. A rising count across `status` calls is the crash-loop signal; `0` once the daemon converges.

### Crash-loop guard
A sentinel file (`t2_crashloop.json` beside the discovery file, atomic 0o600 writes) records cold-respawn timestamps in a rolling window. Helpers `_record_restart` / `_restart_count` / `_crashloop_tripped` / `_reset_crashloop` with an injected clock + module constants `_CRASHLOOP_WINDOW_S` (300s) / `_CRASHLOOP_MAX_RESTARTS` (5). `ensure-running` checks the guard before cold-spawning: when tripped it logs once at error (`t2_daemon_crash_loop_suppressed`, gated by a `tripped_logged` flag, re-armed on a fresh window) and exits 1 without spawning; a daemon that becomes reachable clears the counter.

**Scope (documented accurately):** the guard bounds the `ensure-running`-driven respawn path (the dominant churn, since plugin/`.mcpb` session-start hooks call `ensure-running` on every MCP-server boot). It does **not** bound the launchd/systemd `start` path (those run `nx daemon t2 start` directly); those are throttled by `ThrottleInterval` / `RestartSec`. Extending the guard to the `start` path is recorded as a follow-up (behavioral, out of contained-P4 scope).

### Tests
- `TestStatusSurface`, `TestCrashLoopGuard`, `TestCrashLoopRespawnRefusal` in `tests/daemon/test_t2_daemon_observability.py`: status fields, window/prune/trip/reset semantics, refuse-respawn, log-once within and across invocations, `tripped_logged` re-arm after window expiry.
- **Full unit suite: 8506 passed, 0 failures. Daemon-arc integration (`-m integration`): 18 passed.**

### Review
Stacked gate (code-review-expert + substantive-critic): a Critical (false launchd-coverage doc claim) and a High (`tripped_logged` cross-window leak) found and fixed. MEDIUM/LOW items and the flapping limitation recorded as documented trade-offs / follow-ups (T2 `rdr140-p4-gate`).

Beads: nexus-0gyhe, nexus-hrrpz, nexus-d8qvr, nexus-b4nq1, nexus-mxrws (P4). Epic: nexus-7nxc2 (P1–P3 already merged). This completes RDR-140's implementation; the RDR moves to close after merge.
