### PR TITLE
chore: reconcile develop with main after v5.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.5.1"
+        "ref": "v5.6.0"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.5.1"
+      "version": "5.6.0"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.5.1"
+        "ref": "v5.6.0"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.5.1"
+      "version": "5.6.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.6.0] - 2026-05-31
+
+### Added
+
+- **T2 daemon supervisor & ownership model (RDR-140).** Ends the spawn-race /
+  SQLite-lock thrash that produced hundreds of `t2_daemon_crashed` events per day
+  when many stacks (CLI sessions, MCP servers, Desktop) started concurrently.
+  Four contained/gated phases:
+  - **Single-flight election.** `nx daemon t2 ensure-running` now takes a
+    blocking coordination lock around the discover→spawn decision and
+    re-discovers after acquiring it, so K racing stacks converge to exactly one
+    cold spawn with the rest attaching — no thundering herd.
+  - **Loser quiet-attach.** A process that loses the spawn lock attaches and
+    exits 0 (never opening a second writer) instead of crashing with a
+    traceback.
+  - **Ownership-aware reaping.** The startup reap spares a healthy,
+    current-version peer (wait-then-force: let a mid-shutdown peer drain, force
+    only if it overstays — never coexist) while still reaping stale-version and
+    orphaned writers. The RDR-128/129 single-writer backstop is preserved.
+  - **Crash-loop guard + status.** `nx daemon t2 status` surfaces a
+    `restarts_in_window` count; a bounded guard stops `ensure-running` respawns
+    after repeated failures in a window and logs once, instead of an endless
+    crash-loop. (Scope: the `ensure-running` path; launchd/systemd autostart is
+    bounded by the supervisor's own throttle.)
+  - **Migration cold-start fast-path.** When the DB is already at the current
+    schema version and in WAL, cold start skips the migration writer-lock via
+    lock-free reads.
+
+### Changed
+
+- **Binary assets are classified as SKIP, not embedded as prose.** Textures,
+  audio, fonts, and 3D-object files are now skipped at classification time (with
+  a `skipped non-indexable file` log) instead of being embedded as garbage text.
+
 ## [5.5.1] - 2026-05-31
 
 ### Fixed

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.6.0] - 2026-05-31
+
+Plugin version aligned with conexus 5.6.0. No plugin-side changes; the release
+ships the RDR-140 T2 daemon supervisor & ownership model (single-flight
+election, loser quiet-attach, ownership-aware reaping, crash-loop guard +
+`restarts_in_window` status) and the binary-asset SKIP classifier in the
+`nx` core.
+
 ## [5.5.1] - 2026-05-31
 
 ### Fixed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -484,6 +484,23 @@ is locked` daemon incidents):
   and surfaces a dropped-best-effort-write meter as a soft warning (B4);
   the drop log path is `~/.config/nexus/dropped_writes.jsonl`
   (`NX_DROPPED_WRITES_LOG_PATH` override).
+- **Supervisor & ownership model (RDR-140).** Where RDR-129 made the
+  reap unconditional, RDR-140 makes the *election* single-flight and the
+  *reap* ownership-aware, ending the spawn-race / lock-thrash churn under
+  many concurrent stacks. `ensure-running` takes a blocking
+  coordination flock around the discover→spawn decision and re-discovers
+  after acquiring it, so K racing stacks converge to exactly one cold
+  spawn with the rest attaching (no thundering herd). A spawn-lock loser
+  quiet-attaches (exit 0, never opens `T2Database`) instead of crashing.
+  The startup reap spares a healthy, current-version peer named in the
+  addr token (wait-then-force: let a mid-shutdown peer drain, force only
+  if it overstays — never coexist) while still reaping stale-version and
+  unreachable/orphaned writers, so the single-writer backstop is
+  preserved. A bounded crash-loop guard (sentinel `t2_crashloop.json`)
+  stops `ensure-running` respawns after N failures in a window and
+  surfaces a `restarts_in_window` count in `nx daemon t2 status`. The
+  non-daemon direct-writer fallbacks (the `t2_index_write`
+  schema-mismatch arm) remain the RDR-128 A1 boundary, unchanged.
 
 **Migration Registry** (RDR-076): All T2 schema migrations are centralised in
 `src/nexus/db/migrations.py`. The `MIGRATIONS` list contains version-tagged

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "conexus-mcpb"
-version = "5.5.1"
+version = "5.6.0"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
-    "conexus>=5.5.1",
+    "conexus>=5.6.0",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.5.1"
+version = "5.6.0"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.5.1"
+version = "5.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Post-release reconciliation: merges the v5.6.0 release bump commit from main back into develop so develop carries version 5.6.0 (manifests + uv.lock + CHANGELOGs + architecture.md). Without this the next release branch would start from 5.5.1. Standard release-promote-then-reconcile flow (mem: develop is the integration branch).