### PR TITLE
feat(upgrade): refresh all repos' git hooks + fix RDR-108 orphan error message

### DIFF
--- a/src/nexus/commands/hooks.py
+++ b/src/nexus/commands/hooks.py
@@ -238,6 +238,117 @@ def hooks_update(path: Path) -> None:
     click.echo("Done. New stanza in effect from the next commit.")
 
 
+def _refresh_managed_hooks(hooks_dir: Path) -> list[tuple[str, str]]:
+    """Refresh every nexus-managed hook in *hooks_dir* to the current stanza.
+
+    Only rewrites hooks that already carry the sentinel block; never touches
+    unmanaged or absent hook files. Returns a list of ``(hook_name, action)``
+    where action is ``refreshed:<install-action>`` | ``unmanaged`` |
+    ``not installed``.
+    """
+    results: list[tuple[str, str]] = []
+    for name in _HOOK_NAMES:
+        hook_file = hooks_dir / name
+        if not hook_file.exists():
+            results.append((name, "not installed"))
+            continue
+        if SENTINEL_BEGIN not in hook_file.read_text():
+            results.append((name, "unmanaged"))
+            continue
+        _uninstall_hook(hooks_dir, name)
+        action = _install_hook(hooks_dir, name)
+        results.append((name, f"refreshed:{action}"))
+    return results
+
+
+def _iter_managed_repo_roots() -> list[Path]:
+    """Return existing registered repo working trees (catalog ∪ registry).
+
+    Reuses ``list_repos_dual`` — the same canonical enumeration ``nx doctor``
+    uses for its git-hook drift check — so every repo the doctor reports drift
+    for is reachable here. Resilient: returns ``[]`` when the catalog is
+    uninitialised or unreadable rather than raising, because the caller
+    (``nx upgrade``) treats hook refresh as best-effort.
+    """
+    try:
+        from nexus.catalog.catalog import Catalog  # noqa: PLC0415
+        from nexus.config import catalog_path, nexus_config_dir  # noqa: PLC0415
+        from nexus.repos import list_repos_dual  # noqa: PLC0415
+
+        cat_dir = catalog_path()
+        if not (cat_dir / ".catalog.db").exists():
+            return []
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+        registry_path = nexus_config_dir() / "repos.json"
+        repo_strs = list_repos_dual(cat=cat, registry_path=registry_path)
+    except Exception:  # noqa: BLE001 — best-effort enumeration
+        return []
+
+    seen: set[Path] = set()
+    repos: list[Path] = []
+    for repo_str in repo_strs:
+        repo = Path(repo_str)
+        if repo in seen or not repo.is_dir():
+            continue
+        seen.add(repo)
+        repos.append(repo)
+    return repos
+
+
+def refresh_all_managed_hooks(*, echo: bool = False) -> dict[str, int]:
+    """Refresh nexus-managed git hooks across every catalog-registered repo.
+
+    Best-effort: a repo that can't be resolved (non-git, hooks dir not
+    writable, etc.) is counted under ``errors`` and skipped — one bad repo
+    never aborts the sweep. Returns a summary dict with ``repos``,
+    ``refreshed``, and ``errors`` counts.
+    """
+    summary = {"repos": 0, "refreshed": 0, "errors": 0}
+    for repo in _iter_managed_repo_roots():
+        try:
+            hooks_dir = _effective_hooks_dir(repo)
+            if hooks_dir.exists() and not _is_writable(hooks_dir):
+                summary["errors"] += 1
+                if echo:
+                    click.echo(f"  ! {repo}  (hooks dir not writable; skipped)")
+                continue
+            results = _refresh_managed_hooks(hooks_dir)
+        except click.ClickException as exc:
+            summary["errors"] += 1
+            if echo:
+                click.echo(f"  ! {repo}  ({exc.format_message()})")
+            continue
+
+        refreshed = [n for n, a in results if a.startswith("refreshed")]
+        if refreshed:
+            summary["repos"] += 1
+            summary["refreshed"] += len(refreshed)
+            if echo:
+                click.echo(f"  ✓ {repo}  ({len(refreshed)} hook(s) refreshed)")
+    return summary
+
+
+@hooks.command("update-all")
+def hooks_update_all() -> None:
+    """Refresh nexus-managed git hooks across ALL catalog-registered repos.
+
+    Sweeps every ``repo`` owner in the catalog and refreshes any hook that
+    already carries the nexus stanza, so a single command brings every repo
+    to the current stanza after a conexus upgrade. Unmanaged and uninstalled
+    hooks are left untouched. This is also run automatically by ``nx upgrade``.
+    """
+    click.echo("Refreshing nexus hooks across all registered repos…")
+    summary = refresh_all_managed_hooks(echo=True)
+    if summary["repos"] == 0 and summary["errors"] == 0:
+        click.echo("No nexus-managed hooks found in any registered repo.")
+        return
+    click.echo(
+        f"Done. {summary['refreshed']} hook(s) refreshed across "
+        f"{summary['repos']} repo(s)"
+        + (f"; {summary['errors']} repo(s) skipped." if summary["errors"] else ".")
+    )
+
+
 @hooks.command("status")
 @click.argument("path", type=click.Path(file_okay=False, path_type=Path), default=".")
 def hooks_status(path: Path) -> None:

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -343,8 +343,40 @@ def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool =
         if not auto_mode:
             _migrate_repos_json_to_catalog(dry_run=dry_run)
 
+        # Refresh nexus-managed git hooks across every registered repo so a
+        # stanza change (e.g. a new pgrep guard) lands everywhere in one
+        # upgrade instead of a per-repo `nx hooks update`. Best-effort,
+        # non-auto, non-dry-run; only touches already-managed hooks.
+        if not auto_mode and not dry_run:
+            _refresh_all_git_hooks()
+
     finally:
         conn.close()
+
+
+def _refresh_all_git_hooks() -> None:
+    """Refresh nexus-managed git hooks across all registered repos.
+
+    Best-effort: never raises — a hook-refresh failure must not fail the
+    upgrade. Silent when no managed hooks exist anywhere.
+    """
+    try:
+        from nexus.commands.hooks import refresh_all_managed_hooks
+
+        summary = refresh_all_managed_hooks(echo=False)
+        if summary["refreshed"]:
+            click.echo(
+                f"\nRefreshed {summary['refreshed']} git hook(s) across "
+                f"{summary['repos']} repo(s)"
+                + (
+                    f"; {summary['errors']} repo(s) skipped "
+                    "(see `nx hooks update-all`)."
+                    if summary["errors"]
+                    else "."
+                )
+            )
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("upgrade_git_hook_refresh_failed", error=str(exc))
 
 
 def _migrate_repos_json_to_catalog(*, dry_run: bool) -> None:

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -1442,7 +1442,7 @@ def _check_high_volume_orphans(conn: sqlite3.Connection, *, table: str) -> None:
     var (default ``_HIGH_VOLUME_ORPHAN_THRESHOLD`` = 10) on every call so
     operators can lower it for small installs without rebuilding.
 
-    SIG-4: The error message includes a ``nx catalog mark-superseded`` command
+    SIG-4: The error message includes a ``nx catalog rename-collection`` command
     template per orphan collection so operators have an actionable next step.
     """
     import os as _os
@@ -1468,15 +1468,25 @@ def _check_high_volume_orphans(conn: sqlite3.Connection, *, table: str) -> None:
 
     detail = "; ".join(f"{coll} ({n} rows)" for coll, n in rows)
     remediation_lines = "\n".join(
-        f"  nx catalog mark-superseded {coll} <new-collection-name>"
+        f"  nx catalog rename-collection {coll} <new-collection-name> --yes"
         for coll, _ in rows
     )
     raise MigrationError(
         f"RDR-108 Phase 1c: {table} has high-volume unmapped orphan collection(s): "
         f"{detail}.\n"
-        f"For each listed collection, register its superseded_by mapping:\n"
+        f"\n"
+        f"These are derived aspect rows (RDR-089) whose source documents are no "
+        f"longer in the catalog. You have two options:\n"
+        f"\n"
+        f"1. If the collection was RENAMED, point it at its successor so the rows "
+        f"re-map instead of dropping (sets collections.superseded_by):\n"
         f"{remediation_lines}\n"
-        f"Then re-run the migration."
+        f"   Then re-run `nx upgrade`.\n"
+        f"\n"
+        f"2. If the collection is STALE, let the migration drop the orphans "
+        f"(aspects are regenerable via `nx enrich aspects <collection>`). Raise "
+        f"the gate threshold for this run:\n"
+        f"   NEXUS_MIGRATION_HIGH_VOLUME_THRESHOLD=100000 nx upgrade"
     )
 
 

--- a/tests/test_git_hooks.py
+++ b/tests/test_git_hooks.py
@@ -4,6 +4,7 @@ import stat
 from pathlib import Path
 from unittest.mock import patch
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -295,6 +296,115 @@ class TestUpdate:
         assert "pgrep -f" in new_content
         # Single sentinel block
         assert new_content.count(SENTINEL_BEGIN) == 1
+
+
+class TestUpdateAll:
+    """``nx hooks update-all`` (and the ``nx upgrade`` hook) refreshes every
+    nexus-managed hook across all registered repos in one sweep."""
+
+    def _legacy_stanza_file(self, hook_file: Path) -> None:
+        hook_file.write_text(
+            f"#!/bin/sh\n{SENTINEL_BEGIN}\n"
+            'nx index repo "$(git rev-parse --show-toplevel)" --on-locked=skip \\\n'
+            '  >> "$HOME/.config/nexus/index.log" 2>&1 &\n'
+            f"disown\n{SENTINEL_END}\n"
+        )
+
+    def _make_repo(self, tmp_path: Path, name: str) -> Path:
+        repo = tmp_path / name
+        (repo / ".git" / "hooks").mkdir(parents=True)
+        return repo
+
+    def test_refreshes_all_managed_repos(self, runner, tmp_path, monkeypatch):
+        from nexus.cli import main
+
+        repo_a = self._make_repo(tmp_path, "repo_a")
+        repo_b = self._make_repo(tmp_path, "repo_b")
+        for repo in (repo_a, repo_b):
+            self._legacy_stanza_file(repo / ".git" / "hooks" / "post-commit")
+
+        monkeypatch.setattr(
+            "nexus.commands.hooks._iter_managed_repo_roots",
+            lambda: [repo_a, repo_b],
+        )
+        monkeypatch.setattr(
+            "nexus.commands.hooks._effective_hooks_dir",
+            lambda repo: repo / ".git" / "hooks",
+        )
+
+        result = runner.invoke(main, ["hooks", "update-all"])
+        assert result.exit_code == 0, result.output
+        for repo in (repo_a, repo_b):
+            content = (repo / ".git" / "hooks" / "post-commit").read_text()
+            assert "pgrep -f" in content
+            assert content.count(SENTINEL_BEGIN) == 1
+        assert "2 repo(s)" in result.output
+
+    def test_skips_unmanaged_and_absent(self, runner, tmp_path, monkeypatch):
+        from nexus.cli import main
+
+        managed = self._make_repo(tmp_path, "managed")
+        unmanaged = self._make_repo(tmp_path, "unmanaged")
+        self._legacy_stanza_file(managed / ".git" / "hooks" / "post-commit")
+        (unmanaged / ".git" / "hooks" / "post-commit").write_text(
+            "#!/bin/sh\necho hi\n"
+        )
+
+        monkeypatch.setattr(
+            "nexus.commands.hooks._iter_managed_repo_roots",
+            lambda: [managed, unmanaged],
+        )
+        monkeypatch.setattr(
+            "nexus.commands.hooks._effective_hooks_dir",
+            lambda repo: repo / ".git" / "hooks",
+        )
+
+        result = runner.invoke(main, ["hooks", "update-all"])
+        assert result.exit_code == 0, result.output
+        # Unmanaged file untouched.
+        assert (
+            unmanaged / ".git" / "hooks" / "post-commit"
+        ).read_text() == "#!/bin/sh\necho hi\n"
+        assert "1 repo(s)" in result.output
+
+    def test_one_bad_repo_does_not_abort_sweep(self, runner, tmp_path, monkeypatch):
+        from nexus.cli import main
+
+        good = self._make_repo(tmp_path, "good")
+        bad = tmp_path / "bad"  # no .git → effective_hooks_dir raises
+        bad.mkdir()
+        self._legacy_stanza_file(good / ".git" / "hooks" / "post-commit")
+
+        def _hooks_dir(repo: Path):
+            if repo == bad:
+                raise click.ClickException("not a git repo")
+            return repo / ".git" / "hooks"
+
+        monkeypatch.setattr(
+            "nexus.commands.hooks._iter_managed_repo_roots",
+            lambda: [bad, good],
+        )
+        monkeypatch.setattr(
+            "nexus.commands.hooks._effective_hooks_dir", _hooks_dir
+        )
+
+        result = runner.invoke(main, ["hooks", "update-all"])
+        assert result.exit_code == 0, result.output
+        # Good repo still refreshed despite bad repo earlier in the list.
+        assert "pgrep -f" in (
+            good / ".git" / "hooks" / "post-commit"
+        ).read_text()
+        assert "1 repo(s) skipped" in result.output
+
+    def test_no_managed_hooks_anywhere(self, runner, monkeypatch):
+        from nexus.cli import main
+
+        monkeypatch.setattr(
+            "nexus.commands.hooks._iter_managed_repo_roots", lambda: []
+        )
+        result = runner.invoke(main, ["hooks", "update-all"])
+        assert result.exit_code == 0, result.output
+        assert "No nexus-managed hooks" in result.output
 
 
 # ── doctor stanza-drift check ──────────────────────────────────────────────────

--- a/tests/test_rdr108_phase1_remediation.py
+++ b/tests/test_rdr108_phase1_remediation.py
@@ -456,7 +456,7 @@ class TestAutoBootstrapCreatedAtEmpty:
 
 class TestSIG4ActionableErrorMessage:
     """SIG-4: _check_high_volume_orphans must include the
-    `nx catalog mark-superseded <legacy> <new>` template in the error message."""
+    `nx catalog rename-collection <legacy> <new>` template in the error message."""
 
     def _make_aspects_db_with_orphans(
         self, tmp_path: Path, collection: str, count: int
@@ -482,9 +482,9 @@ class TestSIG4ActionableErrorMessage:
         conn.commit()
         return conn
 
-    def test_error_message_contains_mark_superseded_template(self, tmp_path):
+    def test_error_message_contains_rename_collection_template(self, tmp_path):
         """MigrationError raised by _check_high_volume_orphans must include
-        the `nx catalog mark-superseded` command template."""
+        the `nx catalog rename-collection` command template."""
         from nexus.db.migrations import _check_high_volume_orphans, MigrationError
 
         orphan_collection = "code__legacy_orphan"
@@ -494,8 +494,8 @@ class TestSIG4ActionableErrorMessage:
             _check_high_volume_orphans(conn, table="document_aspects")
 
         msg = str(exc_info.value)
-        assert "nx catalog mark-superseded" in msg, (
-            f"Error message must include 'nx catalog mark-superseded' template, got: {msg!r}"
+        assert "nx catalog rename-collection" in msg, (
+            f"Error message must include 'nx catalog rename-collection' template, got: {msg!r}"
         )
         assert orphan_collection in msg, (
             f"Error message must name the orphan collection {orphan_collection!r}, got: {msg!r}"
@@ -526,7 +526,7 @@ class TestSIG4ActionableErrorMessage:
         msg = str(exc_info.value)
         assert "code__alpha" in msg
         assert "code__beta" in msg
-        assert "nx catalog mark-superseded" in msg
+        assert "nx catalog rename-collection" in msg
 
 
 # ── OBS-1: migration telemetry ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two operator-facing fixes surfaced during a field `nx upgrade`.

### 1. `nx upgrade` refreshes git hooks across all repos
Previously a stanza change (e.g. the pgrep guard) required a per-repo `nx hooks update`, which is painful with many repos. Now:
- `nx upgrade` refreshes the nexus-managed hook stanza across **every registered repo** in one sweep, using `list_repos_dual` (catalog ∪ registry) — the same enumeration `nx doctor` uses for its hook-drift check, so anything the doctor reports is reachable.
- New `nx hooks update-all` exposes the same sweep directly.
- Best-effort and safe: only touches already-managed hooks; one unresolvable repo (non-git, unwritable hooks dir) is counted as skipped and never aborts the sweep; a refresh failure never fails the upgrade; runs only in non-auto, non-dry-run.

### 2. Fix misleading RDR-108 Phase 1c orphan error
The high-volume-orphan `MigrationError` told operators to run `nx catalog mark-superseded`, **which does not exist**. It now names the real `nx catalog rename-collection <coll> <new> --yes` path and documents the `NEXUS_MIGRATION_HIGH_VOLUME_THRESHOLD=...` drop-and-regenerate alternative (aspects are regenerable via `nx enrich aspects`).

## Tests
- 4 new cases in `tests/test_git_hooks.py` (multi-repo refresh, skip unmanaged, bad-repo resilience, empty case).
- `test_git_hooks.py` 29 pass, `test_migrations_rdr108_phase1c.py` 33 pass, `test_upgrade_cmd.py` 11 pass.

## Closes
Closes nexus-utglm