### PR TITLE
docs(readme): clarify the .mcpb uv requirement (RDR-126 A1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Three surfaces share one host substrate. Pick the one that matches how you use C
 
 ### Claude Desktop chat
 
-Download `conexus.mcpb` from the [latest release](https://github.com/Hellblazer/nexus/releases/latest) and double-click. Claude Desktop registers it under Settings → Connectors. Requires [uv](https://docs.astral.sh/uv/) on the host PATH; deps resolve on first launch (~20s).
+Download `conexus.mcpb` from the [latest release](https://github.com/Hellblazer/nexus/releases/latest) and double-click. Claude Desktop registers it under Settings → Connectors. Requires [uv](https://docs.astral.sh/uv/) installed on the host (the standard installer or Homebrew puts it where Claude Desktop resolves it — no PATH setup needed); deps resolve on first launch (~20s).
 
 ### Claude Code (terminal)
 


### PR DESCRIPTION
README line 22 said *"Requires uv on the host PATH,"* which is imprecise and was the exact dead-end the original RDR-126 A1 desk analysis hit before the live spike overturned it.

**What the A1 spike verified** (T2 `nexus_rdr/126-research-A1-A2-A5`): Claude Desktop does **not** use the bare launchd/system PATH (which lacks uv). It injects a login-shell-like PATH at extension spawn (`~/.local/bin`, `/opt/homebrew/bin`, `~/.cargo/bin`) and resolves uv by **absolute path** (`Using MCP server command: /Users/.../.local/bin/uv`). So any standard uv install (astral installer or Homebrew) is found automatically — no PATH setup.

Reword to state the accurate requirement: uv must be **installed** on the host, not manually placed "on the PATH."