### PR TITLE
feat(index): add --collection flag to nx index md (GH #981)

### DIFF
--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -1111,7 +1111,11 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
         "T3 collection name. Bare names (e.g. 'mynotes') are auto-normalized "
         "to knowledge__<name>; qualified names (e.g. knowledge__mydocs) pass through. "
         "Overrides --corpus when set. Use to route Markdown into a knowledge__ "
-        "collection so 'nx enrich aspects' can process it (GH #981)."
+        "collection so 'nx enrich aspects' can process it (GH #981). "
+        "NOTE: the aspect extractor for knowledge__ targets the scholarly-paper schema; "
+        "it works well for paper-shaped content but will fabricate fields on general "
+        "prose / design notes. A prose extractor is tracked as a follow-on (fix #2 "
+        "from GH #981)."
     ),
 )
 @click.option(
@@ -1135,6 +1139,20 @@ def index_md_cmd(path: Path, corpus: str, collection: str | None, force: bool, m
     # collection_name=None so index_markdown derives docs__<corpus> as before.
     if collection is not None:
         collection = t3_collection_name(collection)
+        # Warn when routing into knowledge__*: the registered aspect extractor
+        # uses the scholarly-paper-v1 schema (title, abstract, methods, venue).
+        # For paper-shaped Markdown this is correct. For general prose / design
+        # notes it will hallucinate paper fields. A general-prose extractor is
+        # tracked as GH #981 fix #2 (deferred). Reverted attempt: nexus-z70w / #377.
+        if collection.startswith("knowledge__"):
+            click.echo(
+                "Note: 'nx enrich aspects' on knowledge__ collections applies the "
+                "scholarly-paper extractor (title, abstract, methods, venue). "
+                "This is appropriate for paper-shaped content; it will hallucinate "
+                "structure on general prose or design notes. "
+                "A prose extractor is tracked as a follow-on (GH #981 fix #2).",
+                err=True,
+            )
 
     path = path.resolve()
     label = "Force re-indexing" if force else "Indexing"

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -1105,6 +1105,16 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
 @click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option("--corpus", default="default", show_default=True, help="Corpus name for docs__ collection.")
 @click.option(
+    "--collection",
+    default=None,
+    help=(
+        "T3 collection name. Bare names (e.g. 'mynotes') are auto-normalized "
+        "to knowledge__<name>; qualified names (e.g. knowledge__mydocs) pass through. "
+        "Overrides --corpus when set. Use to route Markdown into a knowledge__ "
+        "collection so 'nx enrich aspects' can process it (GH #981)."
+    ),
+)
+@click.option(
     "--force",
     is_flag=True,
     default=False,
@@ -1112,10 +1122,19 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
 )
 @click.option("--monitor", is_flag=True, default=False,
               help="Print chunking metadata after indexing. Auto-enabled when stdout is not a TTY.")
-def index_md_cmd(path: Path, corpus: str, force: bool, monitor: bool) -> None:
-    """Extract and index a Markdown file into T3 docs__CORPUS."""
+def index_md_cmd(path: Path, corpus: str, collection: str | None, force: bool, monitor: bool) -> None:
+    """Extract and index a Markdown file into T3 docs__CORPUS (or --collection)."""
+    from nexus.corpus import t3_collection_name
     from nexus.doc_indexer import index_markdown
     from nexus.errors import CredentialsMissingError
+
+    # Normalize --collection through t3_collection_name() so bare names like
+    # "mynotes" become "knowledge__mynotes__voyage-context-3__v1", matching
+    # the behavior of nx index pdf --collection. Without this, chunks end up
+    # in unsearchable bare collections. When --collection is absent, pass
+    # collection_name=None so index_markdown derives docs__<corpus> as before.
+    if collection is not None:
+        collection = t3_collection_name(collection)
 
     path = path.resolve()
     label = "Force re-indexing" if force else "Indexing"
@@ -1129,14 +1148,14 @@ def index_md_cmd(path: Path, corpus: str, force: bool, monitor: bool) -> None:
                 chunk_bar.n = current
                 chunk_bar.refresh()
 
-            meta = index_markdown(path, corpus=corpus, force=force, return_metadata=True,
-                                  on_progress=on_chunk_progress)
+            meta = index_markdown(path, corpus=corpus, collection_name=collection, force=force,
+                                  return_metadata=True, on_progress=on_chunk_progress)
             chunk_bar.close()
             n = meta["chunks"]  # type: ignore[index]
             sections = meta.get("sections", 0)  # type: ignore[union-attr]
             click.echo(f"\n  Chunks: {n}  Sections: {sections}")
         else:
-            n = index_markdown(path, corpus=corpus, force=force)
+            n = index_markdown(path, corpus=corpus, collection_name=collection, force=force)
     except CredentialsMissingError as exc:
         # GH #336: surface the silent failure visibly. Click maps
         # ClickException to stderr + non-zero exit.

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -425,6 +425,25 @@ def test_md_collection_flag_produces_knowledge_prefix(runner, fake_md):
     assert kw["collection_name"].startswith("knowledge__")
 
 
+def test_md_collection_knowledge_target_emits_prose_extractor_warning(runner, fake_md):
+    """--collection with knowledge__ target emits the scholarly-paper warning (GH #981)."""
+    # CliRunner (Click 8.x) mixes stdout+stderr into result.output by default.
+    with patch("nexus.doc_indexer.index_markdown", return_value=MD_RESULT):
+        result = runner.invoke(main, ["index", "md", str(fake_md), "--collection", "mynotes"])
+    assert result.exit_code == 0, result.output
+    assert "scholarly-paper extractor" in result.output
+    assert "hallucinate" in result.output
+    assert "GH #981 fix #2" in result.output
+
+
+def test_md_collection_no_warning_when_corpus_default(runner, fake_md):
+    """No prose-extractor warning when --collection is absent (docs__ path)."""
+    with patch("nexus.doc_indexer.index_markdown", return_value=MD_RESULT):
+        result = runner.invoke(main, ["index", "md", str(fake_md)])
+    assert result.exit_code == 0, result.output
+    assert "scholarly-paper extractor" not in result.output
+
+
 # ── --extractor flag ─────────────────────────────────────────────────────────
 
 _PDF_STUB = {"chunks": 1, "pages": [], "title": "", "author": ""}

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -386,6 +386,45 @@ def test_pdf_collection_flag_normalization(runner, fake_pdf, flag_val, expected)
     assert kw["collection_name"] == expected
 
 
+# ── nx index md --collection flag (GH #981) ──────────────────────────────────
+
+@pytest.mark.parametrize("flag_val,expected", [
+    # Bare name: auto-normalized to knowledge__<name>__voyage-context-3__v1
+    ("x", "knowledge__x__voyage-context-3__v1"),
+    # 2-segment legacy: auto-promoted to conformant 4-segment
+    ("knowledge__mydocs", "knowledge__mydocs__voyage-context-3__v1"),
+    # Already-conformant 4-segment: passed through unchanged
+    ("knowledge__mydocs__voyage-context-3__v1", "knowledge__mydocs__voyage-context-3__v1"),
+])
+def test_md_collection_flag_normalization(runner, fake_md, flag_val, expected):
+    """--collection on nx index md routes to knowledge__ (GH #981, fix #1)."""
+    with patch("nexus.doc_indexer.index_markdown", return_value=MD_RESULT) as m:
+        result = runner.invoke(main, ["index", "md", str(fake_md), "--collection", flag_val])
+    assert result.exit_code == 0, result.output
+    _, kw = m.call_args
+    assert kw["collection_name"] == expected
+
+
+def test_md_collection_flag_absent_uses_corpus_default(runner, fake_md):
+    """Without --collection, docs__<corpus> default is preserved (no regression)."""
+    with patch("nexus.doc_indexer.index_markdown", return_value=MD_RESULT) as m:
+        result = runner.invoke(main, ["index", "md", str(fake_md), "--corpus", "myproject"])
+    assert result.exit_code == 0, result.output
+    _, kw = m.call_args
+    # collection_name must be None so index_markdown derives docs__myproject itself
+    assert kw.get("collection_name") is None
+    assert kw.get("corpus") == "myproject"
+
+
+def test_md_collection_flag_produces_knowledge_prefix(runner, fake_md):
+    """Collection produced by --collection starts with knowledge__ (aspect-eligible)."""
+    with patch("nexus.doc_indexer.index_markdown", return_value=MD_RESULT) as m:
+        result = runner.invoke(main, ["index", "md", str(fake_md), "--collection", "mynotes"])
+    assert result.exit_code == 0, result.output
+    _, kw = m.call_args
+    assert kw["collection_name"].startswith("knowledge__")
+
+
 # ── --extractor flag ─────────────────────────────────────────────────────────
 
 _PDF_STUB = {"chunks": 1, "pages": [], "title": "", "author": ""}


### PR DESCRIPTION
## Summary

- Adds \`--collection\` flag to \`nx index md\`, mirroring the existing \`nx index pdf --collection\` behavior
- Bare names (e.g. \`mynotes\`) auto-normalize to \`knowledge__<name>__voyage-context-3__v1\`; qualified/conformant names pass through unchanged
- Absent \`--collection\`, the existing \`--corpus\` -> \`docs__<corpus>\` default is fully preserved (no regression)
- Enables Markdown files to land in \`knowledge__*\` collections, closing the **routing gap** (GH #981 fix #1)
- Emits a stderr note when routing into \`knowledge__*\`: the registered extractor uses the scholarly-paper-v1 schema (title, abstract, methods, venue), which is correct for paper-shaped content but will hallucinate fields on general prose / design notes. The general-prose extractor (GH #981 fix #2) is deferred; the reverted attempt is documented as nexus-z70w / #377.

## Test plan

- [x] `test_md_collection_flag_normalization` — three parametrized cases: bare name, 2-segment, conformant 4-segment
- [x] `test_md_collection_flag_absent_uses_corpus_default` — no regression: absent `--collection`, `collection_name=None` and `corpus` pass through
- [x] `test_md_collection_flag_produces_knowledge_prefix` — result starts with `knowledge__`
- [x] `test_md_collection_knowledge_target_emits_prose_extractor_warning` — warning appears in output for knowledge__ target
- [x] `test_md_collection_no_warning_when_corpus_default` — no warning on docs__ default path
- [x] All 54 tests in `test_index_cmd.py` pass

## Closes

Closes #981