### PR TITLE
feat(daemon): interactive-vs-batch catalog-write fairness (RDR-146 P2)

### DIFF
--- a/src/nexus/catalog/factory.py
+++ b/src/nexus/catalog/factory.py
@@ -140,11 +140,23 @@ class CatalogWriter:
     :func:`make_catalog_reader` instance.
     """
 
-    def __init__(self, *, config_dir: Optional[Path] = None) -> None:
+    def __init__(
+        self,
+        *,
+        config_dir: Optional[Path] = None,
+        priority: Optional[str] = None,
+    ) -> None:
         self._config_dir = config_dir
         self._client: Any = None
         self._direct: Optional[Catalog] = None
         self._routed = False
+        # RDR-146 P2 (nexus-5p2ci.12): resolve once at construction (a writer
+        # is long-lived; one resolve per batch). Interactive writers tag every
+        # routed write so the daemon opens its fairness window; batch writers
+        # send no priority field (daemon defaults batch). Resolution honours
+        # NX_WRITE_PRIORITY, then the explicit ``priority`` arg, then isatty.
+        from nexus.catalog.write_priority import resolve_write_priority
+        self._priority = resolve_write_priority(priority)
         self._connect()
 
     def _connect(self) -> None:
@@ -184,6 +196,28 @@ class CatalogWriter:
         """True when writes route through the daemon; False on direct fallback."""
         return self._routed
 
+    @property
+    def priority(self) -> str:
+        """Resolved write priority (``"interactive"`` | ``"batch"``)."""
+        return self._priority
+
+    def is_interactive_write_pending(self) -> bool:
+        """RDR-146 P2: True when the daemon reports an interactive catalog
+        write window is open, so a background (batch) producer should yield.
+
+        Routed through the same daemon connection as this writer's writes.
+        Returns False on the direct fallback (no daemon => no cross-process
+        catalog-write contention to mediate; the per-repo advisory lock
+        handles two same-repo indexers) and on any probe transport error
+        (fail-open: never block a write on a probe failure)."""
+        if self._client is None:
+            return False
+        try:
+            return bool(self._client.catalog.is_interactive_write_pending())
+        except Exception:  # noqa: BLE001 — probe must never break a write
+            _log.debug("catalog_interactive_probe_failed", exc_info=True)
+            return False
+
     def __getattr__(self, name: str) -> Any:
         # __getattr__ only fires for names not found normally, so the
         # instance attributes set in __init__ are never shadowed.
@@ -194,7 +228,15 @@ class CatalogWriter:
                 f"For reads use make_catalog_reader()."
             )
         if self._client is not None:
-            return getattr(self._client.catalog_write, name)
+            inner = getattr(self._client.catalog_write, name)
+            if self._priority == "interactive":
+                # Tag every routed write so the daemon opens / refreshes its
+                # fairness window. Batch stays untagged (byte-identical wire).
+                def _routed(*args: Any, **kwargs: Any) -> Any:
+                    return inner(*args, _priority="interactive", **kwargs)
+
+                return _routed
+            return inner
         return getattr(self._direct, name)
 
     def close(self) -> None:
@@ -215,6 +257,14 @@ class CatalogWriter:
         self.close()
 
 
-def make_catalog_writer(*, config_dir: Optional[Path] = None) -> CatalogWriter:
-    """Return a write-only catalog proxy (daemon-routed or direct fallback)."""
-    return CatalogWriter(config_dir=config_dir)
+def make_catalog_writer(
+    *, config_dir: Optional[Path] = None, priority: Optional[str] = None,
+) -> CatalogWriter:
+    """Return a write-only catalog proxy (daemon-routed or direct fallback).
+
+    *priority* (RDR-146 P2) sets the interactive-vs-batch fairness intent:
+    ``"interactive"`` tags writes so the daemon prioritises them over a
+    background batch indexer; ``"batch"`` is the yielding background default.
+    ``None`` resolves via ``NX_WRITE_PRIORITY`` env then ``isatty()``.
+    """
+    return CatalogWriter(config_dir=config_dir, priority=priority)

--- a/src/nexus/catalog/store_hook.py
+++ b/src/nexus/catalog/store_hook.py
@@ -71,7 +71,11 @@ def catalog_store_hook(
             "SELECT tumbler_prefix FROM owners WHERE name = 'knowledge' "
             "AND owner_type = 'curator'"
         ).fetchone()
-        writer = make_catalog_writer()
+        # RDR-146 P2 (nexus-5p2ci.12): store_put / memory promote are
+        # user-initiated and latency-sensitive. The MCP server is non-tty, so
+        # the isatty() fallback would misclassify these as batch; tag
+        # interactive so they take fairness priority over a background index.
+        writer = make_catalog_writer(priority="interactive")
         if rows:
             from nexus.catalog.tumbler import Tumbler
             owner = Tumbler.parse(rows[0])

--- a/src/nexus/catalog/write_priority.py
+++ b/src/nexus/catalog/write_priority.py
@@ -95,4 +95,8 @@ def await_fair_window(
         if not probe():
             return "proceed"
         sleep_fn(delay)
+    # Final probe after the last sleep: the window may have cleared during it,
+    # in which case proceed rather than defer a write for no live reason.
+    if not probe():
+        return "proceed"
     return "skip" if on_locked == "skip" else "proceed"

--- a/src/nexus/catalog/write_priority.py
+++ b/src/nexus/catalog/write_priority.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Interactive-vs-batch fairness primitives for catalog writes (RDR-146 P2).
+
+The daemon is the single ``.catalog.db`` writer (RDR-146 Phase 1). Phase 2
+closes the residual scheduling unfairness: a foreground ``nx dt index``
+catalog write must not wait behind a sustained background ``nx index repo``
+write burst (GH #1046, inverted).
+
+The chosen lever is producer back-pressure, NOT a daemon priority queue
+(see the PC-2 design spike): an interactive write tags its RPC frame
+``priority="interactive"``, which opens a short in-memory deadline window
+on the daemon; the background indexer polls that window before each
+catalog write and yields. This module holds the two pure, side-effect-free
+pieces of that mechanism so they are unit-testable with fixed clocks:
+
+- :func:`resolve_write_priority` — how a call site decides its priority.
+- :func:`await_fair_window` — the bounded escalating-backoff yield loop the
+  background indexer runs (mirrors the RDR-129 B2 dispatch-retry shape:
+  finite attempts, escalating sleeps, defined terminal).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Callable
+
+#: Daemon-side interactive window (seconds). After an interactive catalog
+#: write, the probe reports "pending" for this long, refreshed per write so
+#: a multi-op interactive burst (``nx dt index`` does register -> link ->
+#: aspects as several ops) keeps the window open across the whole burst.
+INTERACTIVE_WINDOW_S: float = 2.0
+
+#: Bounded escalating yield budget for the background indexer (~1.75s worst
+#: case). Finite by construction so the batch is never permanently starved.
+INDEXER_YIELD_SLEEPS: tuple[float, ...] = (0.25, 0.5, 1.0)
+
+#: Explicit override env var. Lets a hook force ``batch`` and a script force
+#: ``interactive`` regardless of tty detection.
+WRITE_PRIORITY_ENV: str = "NX_WRITE_PRIORITY"
+
+_VALID_PRIORITIES: frozenset[str] = frozenset({"interactive", "batch"})
+
+
+def resolve_write_priority(explicit: str | None = None) -> str:
+    """Resolve the write priority for a catalog-write call site.
+
+    Resolution order (cheapest, most explicit first):
+
+    1. ``NX_WRITE_PRIORITY`` env override (``interactive`` | ``batch``).
+    2. The *explicit* per-command intent argument, when a command threads
+       one (``nx dt index`` / ``capture`` pass ``"interactive"``).
+    3. ``sys.stdout.isatty()`` fallback, matching the existing convention:
+       a tty is interactive, non-tty (the hook-spawned ``nx index repo``)
+       is batch.
+
+    Always returns one of ``"interactive"`` / ``"batch"``.
+    """
+    env = os.environ.get(WRITE_PRIORITY_ENV, "").strip().lower()
+    if env in _VALID_PRIORITIES:
+        return env
+    if explicit in _VALID_PRIORITIES:
+        return explicit  # type: ignore[return-value]
+    try:
+        return "interactive" if sys.stdout.isatty() else "batch"
+    except (AttributeError, ValueError):
+        # Detached / closed stdout: default to the safe non-disruptive batch.
+        return "batch"
+
+
+def await_fair_window(
+    probe: Callable[[], bool],
+    on_locked: str,
+    *,
+    sleeps: tuple[float, ...] = INDEXER_YIELD_SLEEPS,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> str:
+    """Bounded yield loop a background (batch) producer runs before a write.
+
+    Polls *probe* (the daemon's ``is_interactive_write_pending`` flag);
+    while an interactive write is pending, backs off over the escalating
+    *sleeps* budget. Returns:
+
+    - ``"proceed"`` as soon as no interactive write is pending (the common
+      case returns immediately with zero sleeps), OR after the bounded
+      budget is exhausted with ``on_locked == "wait"`` (never permanently
+      starve the batch: the RDR-129 "never trade a working state for none"
+      discipline).
+    - ``"skip"`` when the budget is exhausted and ``on_locked == "skip"``
+      (defer this write to the next idempotent index pass).
+
+    *sleep_fn* is injectable so tests drive the loop with a fake clock.
+    """
+    for delay in sleeps:
+        if not probe():
+            return "proceed"
+        sleep_fn(delay)
+    return "skip" if on_locked == "skip" else "proceed"

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -155,7 +155,10 @@ def _stamp_dt_uri_on_entry(file_path: Path, uuid: str) -> bool:
         return False
 
     reader = make_catalog_reader()
-    writer = make_catalog_writer()
+    # RDR-146 P2 (nexus-5p2ci.12): foreground, user-initiated dt write —
+    # the latency-sensitive op #1046 showed starved by background indexing.
+    # Tag interactive so the daemon prioritises it over a batch index burst.
+    writer = make_catalog_writer(priority="interactive")
     try:
         # Globally find the entry by file_path — no owner constraint
         # because we don't know it from here. ``documents`` is keyed
@@ -221,7 +224,8 @@ def _link_semantic_record(uuid: str) -> bool:
     if not Catalog.is_initialized(cat_path):
         return False
     reader = make_catalog_reader()
-    writer = make_catalog_writer()
+    # RDR-146 P2: foreground dt write — interactive priority (see above).
+    writer = make_catalog_writer(priority="interactive")
     try:
         entry = reader.by_source_uri(dt_uri)
         if entry is None:

--- a/src/nexus/daemon/t2_client.py
+++ b/src/nexus/daemon/t2_client.py
@@ -366,12 +366,22 @@ class T2Client:
             )
         self._handshake_done = True
 
-    def call(self, op: str, *args: Any, **kwargs: Any) -> Any:
+    def call(
+        self, op: str, *args: Any, _priority: str | None = None, **kwargs: Any
+    ) -> Any:
         """Invoke *op* with positional + keyword args; return the
         decoded result. Raises ``T2ClientError`` on daemon-side
         failure, ``T2DaemonNotReachableError`` on transport failure,
         ``T2SchemaVersionMismatchError`` if the lazy handshake detects
         a client/daemon schema-version skew on first connect.
+
+        *_priority* (RDR-146 P2) is a keyword-only out-of-band frame field
+        (``"interactive"`` | ``"batch"``), NOT an op argument: when set it is
+        added to the frame as ``priority`` so the daemon's catalog-write
+        fairness window keys off it. ``None`` omits the field entirely
+        (the daemon defaults absent -> batch), keeping batch frames byte-
+        identical to the pre-P2 wire shape. The leading underscore keeps it
+        from colliding with an op's ``**fields`` / ``**meta`` keyword args.
         """
         with self._lock:
             sock = self._ensure_sock()
@@ -403,6 +413,8 @@ class T2Client:
                 "kwargs": dict(kwargs),
                 "request_id": request_id,
             }
+            if _priority is not None:
+                frame["priority"] = _priority
             try:
                 _send_frame_sync(sock, frame)
                 response = _recv_frame_sync(sock)
@@ -500,10 +512,11 @@ class _CatalogWriterProxy:
             )
         client = self._client
 
-        def _call(*args: Any, **kwargs: Any) -> Any:
+        def _call(*args: Any, _priority: str | None = None, **kwargs: Any) -> Any:
             enc_args, enc_kwargs = encode_tumbler_args(args, kwargs)
             result = client.call(
-                f"{CATALOG_WRITE_PREFIX}{method_name}", *enc_args, **enc_kwargs
+                f"{CATALOG_WRITE_PREFIX}{method_name}", *enc_args,
+                _priority=_priority, **enc_kwargs,
             )
             return decode_return(method_name, result)
 

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -99,6 +99,19 @@ _GRACEFUL_PEER_EXIT_WAIT: float = 3.0
 # Module constant so tests can shrink the sleeps.
 _DISPATCH_RETRY_SLEEPS: tuple[float, ...] = (0.1, 0.25)
 
+# RDR-146 P2 (nexus-5p2ci.12): interactive-vs-batch catalog-write fairness.
+# An interactive-priority catalog write opens an in-memory deadline window;
+# ``catalog.is_interactive_write_pending`` reports True until it lapses so a
+# background batch indexer can yield. Imported from the catalog layer (the
+# single source of truth shared with the producer-side yield loop).
+from nexus.catalog.write_priority import (  # noqa: E402
+    INTERACTIVE_WINDOW_S as _INTERACTIVE_WINDOW_S,
+)
+
+#: RPC op name (under the ``catalog.*`` read namespace) the background
+#: indexer polls. In-memory only (reads the deadline flag, touches no SQLite).
+_INTERACTIVE_PROBE_OP = "catalog.is_interactive_write_pending"
+
 # RDR-140 P1.3 (nexus-h2oko): self-healing discovery re-assert + loser poll.
 # The spawn-lock HOLDER re-asserts its own t2_addr discovery file every
 # ``_REASSERT_INTERVAL`` so a transient gap (a stale/lost addr file while the
@@ -707,6 +720,13 @@ class T2Daemon:
         # and the directory flock does not serialise sibling threads).
         self._catalog: Any = None
         self._catalog_write_lock: asyncio.Lock | None = None
+        # RDR-146 P2 (nexus-5p2ci.12): interactive-vs-batch fairness. An
+        # interactive-priority catalog write sets this deadline; the probe op
+        # reports pending until ``self._monotonic()`` passes it. In-memory
+        # only. ``_monotonic`` is injectable so fairness tests use a fixed
+        # clock (project rule: deterministic, fixed clocks).
+        self._interactive_write_deadline: float = 0.0
+        self._monotonic: Any = time.monotonic
         self._dispatch_table: dict[str, Any] = {}
         self._uds_server: asyncio.AbstractServer | None = None
         self._tcp_server: asyncio.AbstractServer | None = None
@@ -775,6 +795,12 @@ class T2Daemon:
         self._catalog = self._build_hosted_catalog()
         from nexus.daemon.catalog_write_shim import build_catalog_write_dispatch
         self._dispatch_table.update(build_catalog_write_dispatch(self._catalog))
+        # RDR-146 P2 (nexus-5p2ci.12): the interactive-pending probe. A real
+        # daemon method (no SQLite touch) registered under the catalog.* read
+        # namespace so the background indexer reaches it via the read proxy.
+        # The low-level CatalogStore has no method of this name, so there is
+        # no collision with the auto-enumerated catalog.* reads.
+        self._dispatch_table[_INTERACTIVE_PROBE_OP] = self._is_interactive_write_pending
 
         uds_sock = self._bind_uds()
         tcp_sock = self._bind_tcp()
@@ -1069,6 +1095,17 @@ class T2Daemon:
         if not isinstance(args, list) or not isinstance(kwargs, dict):
             raise ProtocolError("frame 'args' must be list, 'kwargs' must be dict")
         callable_ = self._dispatch_table[op]
+        # RDR-146 P2 (nexus-5p2ci.12): interactive-vs-batch fairness. An
+        # interactive-priority catalog WRITE opens (or refreshes) the in-memory
+        # deadline window BEFORE the op runs, so a background batch indexer
+        # polling ``catalog.is_interactive_write_pending`` yields for the whole
+        # interactive burst. Reads/probe and batch writes never touch it; an
+        # absent ``priority`` field defaults to batch (back-compat).
+        if (
+            frame.get("priority", "batch") == "interactive"
+            and op.startswith(_CATALOG_WRITE_PREFIX)
+        ):
+            self._interactive_write_deadline = self._monotonic() + _INTERACTIVE_WINDOW_S
         # RDR-146 P1 (nexus-5p2ci.20): catalog writes are serialised. The
         # hosted rich Catalog performs multi-step JSONL+SQLite mutations
         # that are not atomic across the dispatch thread pool (the
@@ -1110,6 +1147,13 @@ class T2Daemon:
                     op=op, attempt=attempt, exc=str(exc),
                 )
                 await asyncio.sleep(sleeps[attempt - 1])
+
+    def _is_interactive_write_pending(self) -> bool:
+        """RDR-146 P2 probe: True while an interactive catalog write window is
+        open. In-memory read of the deadline flag; touches no SQLite. Reached
+        over RPC as ``catalog.is_interactive_write_pending`` by the background
+        indexer's yield loop."""
+        return self._monotonic() < self._interactive_write_deadline
 
     @staticmethod
     def _send_error(

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -663,6 +663,7 @@ def _catalog_hook(
     repo_hash: str,
     head_hash: str,
     indexed_files: list[tuple[Path, str, str]],
+    on_locked: str = "wait",
 ) -> dict[Path, str]:
     """Register/update indexed files in catalog. Silently skipped if catalog absent.
 
@@ -672,7 +673,20 @@ def _catalog_hook(
     before per-file indexing runs (RDR-101 Phase 3 PR δ Stage B). The
     return type is additive — existing test call sites that ignore the
     return value continue to work unchanged.
+
+    RDR-146 P2 (nexus-5p2ci.12): this is the background batch producer that
+    GH #1046 showed starving a foreground ``nx dt index``. The writer is
+    constructed with the resolved write priority (the hook-spawned indexer
+    is non-tty -> batch); a batch writer polls the daemon's interactive
+    window before each file's catalog write and yields. ``on_locked``
+    retargets (PC-5 collapse) from the per-repo advisory file lock to the
+    catalog-contention signal: ``"skip"`` defers the remaining catalog
+    writes to the next idempotent index pass once the bounded yield budget
+    is exhausted; ``"wait"`` proceeds after the budget (never permanently
+    starve the batch). The per-repo advisory lock keeps its orthogonal job
+    (two ``nx index repo`` on the same repo) up in ``index_repository``.
     """
+    from nexus.catalog.write_priority import await_fair_window
     file_to_doc_id: dict[Path, str] = {}
     reader = None
     writer = None
@@ -692,8 +706,12 @@ def _catalog_hook(
             make_catalog_writer,
         )
         reader = make_catalog_reader()
+        # RDR-146 P2: resolve priority (non-tty hook spawn -> batch). Only a
+        # batch writer yields to interactive writes; an interactive/foreground
+        # ``nx index repo`` is itself latency-sensitive and does not throttle.
         writer = make_catalog_writer()
         cat = reader
+        _batch_producer = writer.priority == "batch"
 
         # ``_catalog_hook`` accepts an explicit ``repo_hash`` (and
         # ``repo_name``) so callers and tests can override the
@@ -735,7 +753,26 @@ def _catalog_hook(
         # for every subsequent file in this run. Found via Hal's
         # ghost-chunk class on 2026-05-02.
         skipped_files: list[tuple[Path, str]] = []
+        fairness_yielded = 0  # RDR-146 P2: files deferred to the next pass.
         for abs_path, content_type, collection_name in indexed_files:
+            # RDR-146 P2 (nexus-5p2ci.12): yield to a pending interactive
+            # catalog write so a foreground ``nx dt index`` is not starved by
+            # this background burst. Only batch producers yield; the probe is
+            # an in-memory daemon read (cheap) and returns False with no
+            # daemon. ``skip`` terminal defers the rest of the batch to the
+            # next idempotent pass (break, not abort: already-registered files
+            # and housekeeping below still run on the full indexed set).
+            if _batch_producer:
+                if await_fair_window(
+                    writer.is_interactive_write_pending, on_locked,
+                ) == "skip":
+                    fairness_yielded = len(indexed_files) - len(new_tumblers) - len(skipped_files)
+                    _log.info(
+                        "catalog_write_yielded_skipped",
+                        repo=repo_name, deferred=fairness_yielded,
+                        reason="interactive_write_pending",
+                    )
+                    break
             try:
                 rel_path = str(abs_path.relative_to(repo))
             except ValueError:
@@ -1051,7 +1088,7 @@ def index_repository(
             _run_index_frecency_only(repo, registry)
             stats: dict[str, int] = {}
         else:
-            stats = _run_index(repo, registry, chunk_lines=chunk_lines, force=force, force_stale=force_stale, on_start=on_start, on_file=on_file, on_phase=on_phase, on_stage_timers=on_stage_timers, hooks=hooks)
+            stats = _run_index(repo, registry, chunk_lines=chunk_lines, force=force, force_stale=force_stale, on_locked=on_locked, on_start=on_start, on_file=on_file, on_phase=on_phase, on_stage_timers=on_stage_timers, hooks=hooks)
             _set_owner_head_hash(repo, _current_head(repo))
         return stats
     finally:
@@ -2003,6 +2040,7 @@ def _run_index(
     *,
     force: bool = False,
     force_stale: bool = False,
+    on_locked: str = "wait",
     on_start: Callable[[int], None] | None = None,
     on_file: Callable[[Path, int, float], None] | None = None,
     on_phase: Callable[[str], None] | None = None,
@@ -2401,6 +2439,7 @@ def _run_index(
         repo_hash=_repo_hash,
         head_hash=_current_head(repo),
         indexed_files=indexed_for_catalog,
+        on_locked=on_locked,
     )
     if on_phase is not None:
         on_phase(

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -766,7 +766,13 @@ def _catalog_hook(
                 if await_fair_window(
                     writer.is_interactive_write_pending, on_locked,
                 ) == "skip":
-                    fairness_yielded = len(indexed_files) - len(new_tumblers) - len(skipped_files)
+                    # Deferred = total minus successes (new + updated, tracked
+                    # in file_to_doc_id) minus per-file failures. ``new_tumblers``
+                    # counts new-only, so an updated-then-deferred batch would
+                    # overcount; ``file_to_doc_id`` is the right success set.
+                    fairness_yielded = (
+                        len(indexed_files) - len(file_to_doc_id) - len(skipped_files)
+                    )
                     _log.info(
                         "catalog_write_yielded_skipped",
                         repo=repo_name, deferred=fairness_yielded,

--- a/src/nexus/mcp/devonthink.py
+++ b/src/nexus/mcp/devonthink.py
@@ -94,7 +94,10 @@ def _incorporate_sync(uuid: str) -> dict[str, Any]:
         tumbler = entry.tumbler
         # RDR-146 P1.2: generate_dt_links reads via the reader, writes
         # (link_if_absent) via the write-only daemon proxy.
-        writer = make_catalog_writer()
+        # RDR-146 P2 (nexus-5p2ci.12): foreground, user-initiated dt
+        # incorporate — interactive priority so the daemon prioritises it
+        # over a background ``nx index repo`` burst (the #1046 starvation).
+        writer = make_catalog_writer(priority="interactive")
         links = generate_dt_links(cat, tumbler, uuid, writer=writer)
         writeback = writeback_record(uuid, str(tumbler))
         return {"tumbler": str(tumbler), "links": links, "writeback": writeback}

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -500,9 +500,16 @@ def get_catalog_writer():
     Routes the whitelisted write ops through the T2 daemon (the single
     .catalog.db writer) when reachable, else a direct in-process Catalog.
     Always returns a CatalogWriter; callers ``.close()`` it when done.
+
+    RDR-146 P2 (nexus-5p2ci.12): MCP tool invocations are user-initiated and
+    latency-sensitive (``store_put`` / ``memory promote`` register through
+    ``catalog/store_hook.py``). The MCP server process is non-tty, so the
+    ``isatty()`` fallback would misclassify these as batch and make them yield
+    to (or be deferred behind) a background index burst. Tag interactive so
+    they take fairness priority, same as the foreground ``nx dt`` writes.
     """
     from nexus.catalog.factory import make_catalog_writer
-    return make_catalog_writer()
+    return make_catalog_writer(priority="interactive")
 
 
 def require_catalog():

--- a/tests/daemon/test_rdr146_fairness.py
+++ b/tests/daemon/test_rdr146_fairness.py
@@ -1,0 +1,457 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-146 Phase 2 / bead nexus-5p2ci.12: interactive-vs-batch fairness.
+
+The single daemon already serialises catalog writes (Phase 1); Phase 2
+ensures a foreground interactive catalog write is not starved by a
+sustained background batch write burst (GH #1046 inverted). The mechanism
+is producer back-pressure: an interactive RPC frame carries
+``priority="interactive"`` which opens an in-memory deadline window on the
+daemon; the background indexer polls ``catalog.is_interactive_write_pending``
+and yields. No daemon priority queue is introduced.
+
+Layers:
+1. Pure units (no daemon): ``resolve_write_priority`` + ``await_fair_window``.
+2. Daemon window semantics with an injected monotonic clock.
+3. End-to-end over real sockets: priority frame opens the window; probe op
+   is reachable; a batch frame (and a no-priority frame) never opens it.
+"""
+from __future__ import annotations
+
+import asyncio
+import shutil
+import tempfile
+import threading
+import types
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog.write_priority import (
+    INDEXER_YIELD_SLEEPS,
+    INTERACTIVE_WINDOW_S,
+    WRITE_PRIORITY_ENV,
+    await_fair_window,
+    resolve_write_priority,
+)
+
+
+@pytest.fixture
+def config_dir():
+    cd = Path(tempfile.mkdtemp(prefix="nxfair-", dir="/tmp"))
+    yield cd
+    shutil.rmtree(cd, ignore_errors=True)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "memory.db"
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — pure units
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWritePriority:
+    def test_env_override_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(WRITE_PRIORITY_ENV, "batch")
+        # Explicit interactive + a tty must both lose to the env override.
+        monkeypatch.setattr("sys.stdout", types.SimpleNamespace(isatty=lambda: True))
+        assert resolve_write_priority("interactive") == "batch"
+
+    def test_env_interactive_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(WRITE_PRIORITY_ENV, "interactive")
+        monkeypatch.setattr("sys.stdout", types.SimpleNamespace(isatty=lambda: False))
+        assert resolve_write_priority(None) == "interactive"
+
+    def test_explicit_used_when_no_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(WRITE_PRIORITY_ENV, raising=False)
+        monkeypatch.setattr("sys.stdout", types.SimpleNamespace(isatty=lambda: False))
+        assert resolve_write_priority("interactive") == "interactive"
+
+    def test_isatty_fallback_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(WRITE_PRIORITY_ENV, raising=False)
+        monkeypatch.setattr("sys.stdout", types.SimpleNamespace(isatty=lambda: True))
+        assert resolve_write_priority(None) == "interactive"
+
+    def test_isatty_fallback_non_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(WRITE_PRIORITY_ENV, raising=False)
+        monkeypatch.setattr("sys.stdout", types.SimpleNamespace(isatty=lambda: False))
+        assert resolve_write_priority(None) == "batch"
+
+    def test_invalid_env_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(WRITE_PRIORITY_ENV, "garbage")
+        monkeypatch.setattr("sys.stdout", types.SimpleNamespace(isatty=lambda: False))
+        assert resolve_write_priority("interactive") == "interactive"
+
+
+class TestAwaitFairWindow:
+    def test_proceeds_immediately_when_not_pending(self) -> None:
+        slept: list[float] = []
+        result = await_fair_window(
+            lambda: False, "skip", sleep_fn=slept.append
+        )
+        assert result == "proceed"
+        assert slept == []  # never sleeps in the common case
+
+    def test_skip_terminal_when_always_pending(self) -> None:
+        slept: list[float] = []
+        result = await_fair_window(
+            lambda: True, "skip", sleep_fn=slept.append
+        )
+        assert result == "skip"
+        # Full bounded budget consumed, in escalating order.
+        assert slept == list(INDEXER_YIELD_SLEEPS)
+
+    def test_wait_terminal_proceeds_after_budget(self) -> None:
+        slept: list[float] = []
+        result = await_fair_window(
+            lambda: True, "wait", sleep_fn=slept.append
+        )
+        assert result == "proceed"
+        assert slept == list(INDEXER_YIELD_SLEEPS)
+
+    def test_proceeds_when_window_clears_midloop(self) -> None:
+        # Pending for the first two probes, then clears.
+        calls = {"n": 0}
+
+        def probe() -> bool:
+            calls["n"] += 1
+            return calls["n"] <= 2
+
+        slept: list[float] = []
+        result = await_fair_window(probe, "skip", sleep_fn=slept.append)
+        assert result == "proceed"
+        # Two sleeps consumed before the window cleared on the third probe.
+        assert slept == list(INDEXER_YIELD_SLEEPS[:2])
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — daemon window semantics with an injected monotonic clock
+# ---------------------------------------------------------------------------
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+class TestDaemonWindow:
+    """Drive start -> dispatch -> probe -> stop inside ONE event loop. The
+    daemon binds its reassert task to the loop running ``start()``, so the
+    whole scenario must live in a single ``_run`` coroutine."""
+
+    @staticmethod
+    def _drive(config_dir: Path, db_path: Path, scenario):
+        from nexus.daemon.t2_daemon import T2Daemon
+
+        daemon = T2Daemon(config_dir=config_dir, db_path=db_path)
+        clock = _FakeClock()
+        daemon._monotonic = clock
+
+        async def _main():
+            await daemon.start()
+            try:
+                await scenario(daemon, clock)
+            finally:
+                await daemon.stop()
+
+        _run(_main())
+
+    @staticmethod
+    def _owner_frame(repo_hash: str, priority: str | None = None) -> dict:
+        frame = {
+            "op": "catalog_write.register_owner",
+            "args": ["acme", "project"],
+            "kwargs": {"repo_hash": repo_hash, "repo_root": "/tmp/acme"},
+        }
+        if priority is not None:
+            frame["priority"] = priority
+        return frame
+
+    def test_interactive_write_opens_window(self, config_dir, db_path) -> None:
+        async def scenario(daemon, clock):
+            assert daemon._is_interactive_write_pending() is False
+            await daemon._dispatch(self._owner_frame("h1", "interactive"), is_uds=True)
+            # Pending immediately and right up to (but not past) the window.
+            assert daemon._is_interactive_write_pending() is True
+            clock.advance(INTERACTIVE_WINDOW_S - 0.01)
+            assert daemon._is_interactive_write_pending() is True
+            clock.advance(0.02)
+            assert daemon._is_interactive_write_pending() is False
+
+        self._drive(config_dir, db_path, scenario)
+
+    def test_batch_write_does_not_open_window(self, config_dir, db_path) -> None:
+        async def scenario(daemon, clock):
+            await daemon._dispatch(self._owner_frame("h2", "batch"), is_uds=True)
+            assert daemon._is_interactive_write_pending() is False
+
+        self._drive(config_dir, db_path, scenario)
+
+    def test_no_priority_field_is_batch(self, config_dir, db_path) -> None:
+        async def scenario(daemon, clock):
+            await daemon._dispatch(self._owner_frame("h3"), is_uds=True)
+            assert daemon._is_interactive_write_pending() is False
+
+        self._drive(config_dir, db_path, scenario)
+
+    def test_burst_refreshes_deadline(self, config_dir, db_path) -> None:
+        async def scenario(daemon, clock):
+            await daemon._dispatch(self._owner_frame("b1", "interactive"), is_uds=True)
+            clock.advance(INTERACTIVE_WINDOW_S - 0.1)
+            assert daemon._is_interactive_write_pending() is True
+            # A second interactive write refreshes the deadline.
+            await daemon._dispatch(self._owner_frame("b2", "interactive"), is_uds=True)
+            clock.advance(INTERACTIVE_WINDOW_S - 0.1)
+            # Still pending: total elapsed > one window, but the refresh held it.
+            assert daemon._is_interactive_write_pending() is True
+            clock.advance(0.2)
+            assert daemon._is_interactive_write_pending() is False
+
+        self._drive(config_dir, db_path, scenario)
+
+    def test_probe_op_registered_in_dispatch_table(self, config_dir, db_path) -> None:
+        async def scenario(daemon, clock):
+            assert "catalog.is_interactive_write_pending" in daemon._dispatch_table
+
+        self._drive(config_dir, db_path, scenario)
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — end-to-end over real sockets
+# ---------------------------------------------------------------------------
+
+
+def _run_daemon_in_thread(daemon, ready: threading.Event, stop_evt: threading.Event):
+    async def _main() -> None:
+        await daemon.start()
+        ready.set()
+        while not stop_evt.is_set():
+            await asyncio.sleep(0.05)
+        await daemon.stop()
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_main())
+    finally:
+        loop.close()
+
+
+class TestEndToEndFairness:
+    def test_priority_frame_opens_window_probe_reads_it(
+        self, config_dir, db_path
+    ) -> None:
+        from nexus.daemon.t2_client import make_t2_client
+        from nexus.daemon.t2_daemon import T2Daemon
+
+        daemon = T2Daemon(config_dir=config_dir, db_path=db_path)
+        ready, stop_evt = threading.Event(), threading.Event()
+        th = threading.Thread(
+            target=_run_daemon_in_thread,
+            args=(daemon, ready, stop_evt), daemon=True,
+        )
+        th.start()
+        assert ready.wait(timeout=10), "daemon did not start"
+        try:
+            client = make_t2_client(config_dir=config_dir)
+            # Probe is reachable through the read proxy and starts False.
+            assert client.catalog.is_interactive_write_pending() is False
+
+            # An interactive-priority write opens the window.
+            client.catalog_write.register_owner(
+                "acme", "project", repo_hash="h1", repo_root="/tmp/acme",
+                _priority="interactive",
+            )
+            assert client.catalog.is_interactive_write_pending() is True
+            client.close()
+        finally:
+            stop_evt.set()
+            th.join(timeout=10)
+
+    def test_batch_frame_does_not_open_window(self, config_dir, db_path) -> None:
+        from nexus.daemon.t2_client import make_t2_client
+        from nexus.daemon.t2_daemon import T2Daemon
+
+        daemon = T2Daemon(config_dir=config_dir, db_path=db_path)
+        ready, stop_evt = threading.Event(), threading.Event()
+        th = threading.Thread(
+            target=_run_daemon_in_thread,
+            args=(daemon, ready, stop_evt), daemon=True,
+        )
+        th.start()
+        assert ready.wait(timeout=10), "daemon did not start"
+        try:
+            client = make_t2_client(config_dir=config_dir)
+            # Default (no _priority) write is batch and must not open the window.
+            client.catalog_write.register_owner(
+                "acme", "project", repo_hash="h2", repo_root="/tmp/acme2",
+            )
+            assert client.catalog.is_interactive_write_pending() is False
+            client.close()
+        finally:
+            stop_evt.set()
+            th.join(timeout=10)
+
+
+class TestIndexerYieldIntegration:
+    """The background ``_catalog_hook`` is the batch producer. Stub the yield
+    decision so the break-vs-proceed control flow is deterministic and fast
+    (no real sleeps); the bounded-loop timing itself is covered by
+    ``TestAwaitFairWindow``."""
+
+    @pytest.fixture(autouse=True)
+    def _git_identity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.invalid")
+        monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
+
+    def _catalog(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from nexus.catalog.catalog import Catalog
+
+        catalog_dir = tmp_path / "catalog"
+        cat = Catalog.init(catalog_dir)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+        return cat
+
+    def test_skip_terminal_defers_registration(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        from nexus import indexer
+
+        cat = self._catalog(tmp_path, monkeypatch)
+        # Force the yield loop to a skip terminal (window stuck open).
+        monkeypatch.setattr(
+            "nexus.catalog.write_priority.await_fair_window",
+            lambda *a, **k: "skip",
+        )
+        src = tmp_path / "src" / "main.py"
+        src.parent.mkdir(parents=True)
+        src.write_text("print('hello')")
+
+        result = indexer._catalog_hook(
+            repo=tmp_path, repo_name="nexus", repo_hash="571b8edd",
+            head_hash="abc", indexed_files=[(src, "code", "code__nexus")],
+            on_locked="skip",
+        )
+        # Deferred: nothing registered this pass, empty doc-id map returned.
+        assert result == {}
+        owner = cat.owner_for_repo("571b8edd")
+        assert cat.by_file_path(owner, "src/main.py") is None
+
+    def test_proceed_terminal_registers(self, tmp_path, monkeypatch) -> None:
+        from nexus import indexer
+
+        cat = self._catalog(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            "nexus.catalog.write_priority.await_fair_window",
+            lambda *a, **k: "proceed",
+        )
+        src = tmp_path / "src" / "main.py"
+        src.parent.mkdir(parents=True)
+        src.write_text("print('hello')")
+
+        result = indexer._catalog_hook(
+            repo=tmp_path, repo_name="nexus", repo_hash="571b8edd",
+            head_hash="abc", indexed_files=[(src, "code", "code__nexus")],
+            on_locked="skip",
+        )
+        assert src in result
+        owner = cat.owner_for_repo("571b8edd")
+        assert cat.by_file_path(owner, "src/main.py") is not None
+
+    def test_skip_then_reconciles_next_pass(self, tmp_path, monkeypatch) -> None:
+        """Idempotent reconciliation: a skipped file registers on the next
+        pass once the window has cleared (proceed)."""
+        from nexus import indexer
+
+        cat = self._catalog(tmp_path, monkeypatch)
+        src = tmp_path / "src" / "main.py"
+        src.parent.mkdir(parents=True)
+        src.write_text("print('hello')")
+
+        monkeypatch.setattr(
+            "nexus.catalog.write_priority.await_fair_window",
+            lambda *a, **k: "skip",
+        )
+        indexer._catalog_hook(
+            repo=tmp_path, repo_name="nexus", repo_hash="571b8edd",
+            head_hash="abc", indexed_files=[(src, "code", "code__nexus")],
+            on_locked="skip",
+        )
+        owner = cat.owner_for_repo("571b8edd")
+        assert cat.by_file_path(owner, "src/main.py") is None
+
+        # Next pass, window clear -> proceed -> registered.
+        monkeypatch.setattr(
+            "nexus.catalog.write_priority.await_fair_window",
+            lambda *a, **k: "proceed",
+        )
+        indexer._catalog_hook(
+            repo=tmp_path, repo_name="nexus", repo_hash="571b8edd",
+            head_hash="abc", indexed_files=[(src, "code", "code__nexus")],
+            on_locked="skip",
+        )
+        assert cat.by_file_path(owner, "src/main.py") is not None
+
+
+class TestCatalogWriterPriority:
+    def test_writer_injects_interactive_priority(
+        self, config_dir, db_path
+    ) -> None:
+        """A CatalogWriter(priority="interactive") opens the window; a batch
+        writer does not. Exercised through the real factory + daemon."""
+        from nexus.daemon.t2_client import make_t2_client
+        from nexus.daemon.t2_daemon import T2Daemon
+
+        daemon = T2Daemon(config_dir=config_dir, db_path=db_path)
+        ready, stop_evt = threading.Event(), threading.Event()
+        th = threading.Thread(
+            target=_run_daemon_in_thread,
+            args=(daemon, ready, stop_evt), daemon=True,
+        )
+        th.start()
+        assert ready.wait(timeout=10), "daemon did not start"
+        try:
+            from nexus.catalog.factory import make_catalog_writer
+
+            probe_client = make_t2_client(config_dir=config_dir)
+
+            batch_writer = make_catalog_writer(
+                config_dir=config_dir, priority="batch",
+            )
+            assert batch_writer.routed is True
+            batch_writer.register_owner(
+                "acme", "project", repo_hash="hb", repo_root="/tmp/ab",
+            )
+            assert probe_client.catalog.is_interactive_write_pending() is False
+            assert batch_writer.is_interactive_write_pending() is False
+            batch_writer.close()
+
+            inter_writer = make_catalog_writer(
+                config_dir=config_dir, priority="interactive",
+            )
+            inter_writer.register_owner(
+                "acme2", "project", repo_hash="hi", repo_root="/tmp/ai",
+            )
+            assert probe_client.catalog.is_interactive_write_pending() is True
+            inter_writer.close()
+            probe_client.close()
+        finally:
+            stop_evt.set()
+            th.join(timeout=10)

--- a/tests/daemon/test_rdr146_fairness.py
+++ b/tests/daemon/test_rdr146_fairness.py
@@ -119,6 +119,33 @@ class TestAwaitFairWindow:
         assert result == "proceed"
         assert slept == list(INDEXER_YIELD_SLEEPS)
 
+    def test_proceeds_when_window_clears_during_final_sleep(self) -> None:
+        # Pending through all in-loop probes, then clears on the post-loop
+        # final probe (exercises the after-budget "proceed" arm, GAP-1).
+        calls = {"n": 0}
+
+        def probe() -> bool:
+            calls["n"] += 1
+            return calls["n"] <= len(INDEXER_YIELD_SLEEPS)
+
+        slept: list[float] = []
+        result = await_fair_window(probe, "skip", sleep_fn=slept.append)
+        assert result == "proceed"
+        assert slept == list(INDEXER_YIELD_SLEEPS)
+        assert calls["n"] == len(INDEXER_YIELD_SLEEPS) + 1  # final probe ran
+
+    def test_detached_stdout_defaults_batch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # isatty() raising (detached / closed stdout) falls to safe batch.
+        monkeypatch.delenv(WRITE_PRIORITY_ENV, raising=False)
+
+        def _boom() -> bool:
+            raise ValueError("I/O operation on closed file")
+
+        monkeypatch.setattr("sys.stdout", types.SimpleNamespace(isatty=_boom))
+        assert resolve_write_priority(None) == "batch"
+
     def test_proceeds_when_window_clears_midloop(self) -> None:
         # Pending for the first two probes, then clears.
         calls = {"n": 0}
@@ -231,6 +258,23 @@ class TestDaemonWindow:
 
         self._drive(config_dir, db_path, scenario)
 
+    def test_no_central_op_queue_invariant(self, config_dir, db_path) -> None:
+        """Design gate scenario #6: fairness is producer-side back-pressure,
+        NOT a daemon priority queue. The dispatch path stays unchanged in
+        structure — write serialisation is still the asyncio.Lock from
+        Phase 1, and no asyncio.Queue is introduced anywhere on the daemon."""
+        import asyncio as _asyncio
+
+        async def scenario(daemon, clock):
+            assert isinstance(daemon._catalog_write_lock, _asyncio.Lock)
+            queues = [
+                name for name, val in vars(daemon).items()
+                if isinstance(val, _asyncio.Queue)
+            ]
+            assert queues == [], f"unexpected op queue(s): {queues}"
+
+        self._drive(config_dir, db_path, scenario)
+
 
 # ---------------------------------------------------------------------------
 # Layer 3 — end-to-end over real sockets
@@ -307,6 +351,166 @@ class TestEndToEndFairness:
             stop_evt.set()
             th.join(timeout=10)
 
+    def test_interactive_not_starved_by_batch_storm(
+        self, config_dir, db_path
+    ) -> None:
+        """Design gate scenario #1 (the #1046 repro INVERTED): a background
+        thread issues a sustained storm of ``priority="batch"`` catalog writes
+        through the daemon; one ``priority="interactive"`` write issued
+        concurrently must complete in a bounded time, NOT block for the storm's
+        duration.
+
+        Scope: the storm is a single synchronous client (sequential RPCs), so
+        what this proves is that the daemon dispatch path stays FIFO-fair and
+        does not deadlock or serialise the interactive write behind the storm's
+        whole lifetime — the dangerous regression classes. The producer-side
+        yield CHAIN (indexer sees the window and defers) is proven directly by
+        ``test_real_indexer_yields_to_open_window`` below; together they cover
+        the full no-starvation claim.
+
+        Wall-clock (not fixed-clock) because the claim is about completion
+        latency under real concurrent dispatch; the 5s bound is generous."""
+        import time
+
+        from nexus.daemon.t2_client import make_t2_client
+        from nexus.daemon.t2_daemon import T2Daemon
+
+        daemon = T2Daemon(config_dir=config_dir, db_path=db_path)
+        ready, stop_evt = threading.Event(), threading.Event()
+        th = threading.Thread(
+            target=_run_daemon_in_thread,
+            args=(daemon, ready, stop_evt), daemon=True,
+        )
+        th.start()
+        assert ready.wait(timeout=10), "daemon did not start"
+
+        storm_stop = threading.Event()
+        storm_started = threading.Event()
+        storm_count = {"n": 0}
+
+        def _storm() -> None:
+            bc = make_t2_client(config_dir=config_dir)
+            try:
+                i = 0
+                while not storm_stop.is_set():
+                    bc.catalog_write.register_owner(
+                        f"batch{i}", "project",
+                        repo_hash=f"sh{i}", repo_root=f"/tmp/s{i}",
+                    )
+                    storm_count["n"] += 1
+                    storm_started.set()
+                    i += 1
+            finally:
+                bc.close()
+
+        storm_th = threading.Thread(target=_storm, daemon=True)
+        storm_th.start()
+        try:
+            assert storm_started.wait(timeout=10), "batch storm did not start"
+            client = make_t2_client(config_dir=config_dir)
+            t0 = time.monotonic()
+            owner = client.catalog_write.register_owner(
+                "foreground", "project",
+                repo_hash="fg", repo_root="/tmp/fg",
+                _priority="interactive",
+            )
+            elapsed = time.monotonic() - t0
+            from nexus.catalog.tumbler import Tumbler
+            assert isinstance(owner, Tumbler)
+            # Bounded completion: the interactive write is not held for the
+            # storm's lifetime. The asyncio dispatch lock is FIFO-fair, so this
+            # completes within a small multiple of one op's latency. 5s is a
+            # generous ceiling that still catches a hang / full-storm serialise.
+            assert elapsed < 5.0, f"interactive write starved: {elapsed:.2f}s"
+            # The storm kept running throughout (it was a real sustained load).
+            assert storm_count["n"] >= 1
+            client.close()
+        finally:
+            storm_stop.set()
+            storm_th.join(timeout=10)
+            stop_evt.set()
+            th.join(timeout=10)
+
+
+class TestRealChainIntegration:
+    """Proves the full producer-yield chain WITHOUT stubbing: a real daemon
+    with an open interactive window + the real ``_catalog_hook`` batch
+    producer routing through it -> the indexer probes, sees the window, and
+    defers (skip). This is the end-to-end causal proof that the isolated unit
+    tests only cover by composition (substantive-critic coverage note)."""
+
+    @pytest.fixture(autouse=True)
+    def _git_identity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.invalid")
+        monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
+
+    def test_real_indexer_yields_to_open_window(
+        self, config_dir, tmp_path, monkeypatch
+    ) -> None:
+        from nexus import indexer
+        from nexus.catalog.catalog import Catalog
+        from nexus.daemon.t2_client import make_t2_client
+        from nexus.daemon.t2_daemon import T2Daemon
+
+        # Point the config + catalog at the SHORT /tmp config_dir (the deep
+        # pytest tmp path overflows the AF_UNIX UDS limit). Overriding
+        # NEXUS_CONFIG_DIR here means the default-config make_catalog_writer()
+        # inside _catalog_hook resolves to THIS daemon. Keep the window open
+        # well past the ~1.75s indexer yield budget so the skip is
+        # deterministic (no wall-clock race).
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
+        cat_path = config_dir / "catalog"
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(cat_path))
+        monkeypatch.setattr(
+            "nexus.daemon.t2_daemon._INTERACTIVE_WINDOW_S", 30.0,
+        )
+        Catalog.init(cat_path)
+
+        daemon = T2Daemon(config_dir=config_dir, db_path=config_dir / "memory.db")
+        ready, stop_evt = threading.Event(), threading.Event()
+        th = threading.Thread(
+            target=_run_daemon_in_thread,
+            args=(daemon, ready, stop_evt), daemon=True,
+        )
+        th.start()
+        assert ready.wait(timeout=10), "daemon did not start"
+        try:
+            # Open the interactive window through the real daemon.
+            client = make_t2_client(config_dir=config_dir)
+            client.catalog_write.register_owner(
+                "fg", "curator", repo_hash="fgh", repo_root="/tmp/fg",
+                _priority="interactive",
+            )
+            assert client.catalog.is_interactive_write_pending() is True
+            client.close()
+
+            # The real batch producer routes through the same daemon, probes
+            # the open window, yields the bounded budget, then skips.
+            src = tmp_path / "src" / "main.py"
+            src.parent.mkdir(parents=True)
+            src.write_text("print('hello')")
+            result = indexer._catalog_hook(
+                repo=tmp_path, repo_name="nexus", repo_hash="571b8edd",
+                head_hash="abc",
+                indexed_files=[(src, "code", "code__nexus")],
+                on_locked="skip",
+            )
+            # Deferred: the file was not registered this pass.
+            assert result == {}
+            reader = Catalog(cat_path, cat_path / ".catalog.db", read_only=True)
+            try:
+                owner = reader.owner_for_repo("571b8edd")
+                # Owner creation is not gated (it precedes the per-file loop),
+                # but the document write was deferred by the open window.
+                assert owner is None or reader.by_file_path(owner, "src/main.py") is None
+            finally:
+                reader._db.close()
+        finally:
+            stop_evt.set()
+            th.join(timeout=10)
+
 
 class TestIndexerYieldIntegration:
     """The background ``_catalog_hook`` is the batch producer. Stub the yield
@@ -374,6 +578,49 @@ class TestIndexerYieldIntegration:
         assert src in result
         owner = cat.owner_for_repo("571b8edd")
         assert cat.by_file_path(owner, "src/main.py") is not None
+
+    def test_interactive_producer_never_yields(self, tmp_path, monkeypatch) -> None:
+        """GAP-4: an interactive ``nx index repo`` (NX_WRITE_PRIORITY=interactive)
+        is itself latency-sensitive and must NOT run the yield gate. Force the
+        yield decision to raise; if the gate were invoked the hook would error
+        and register nothing. The file registering proves the gate is bypassed."""
+        from nexus import indexer
+
+        cat = self._catalog(tmp_path, monkeypatch)
+        monkeypatch.setenv("NX_WRITE_PRIORITY", "interactive")
+
+        def _boom(*a, **k):
+            raise AssertionError("yield gate must not run for an interactive producer")
+
+        monkeypatch.setattr(
+            "nexus.catalog.write_priority.await_fair_window", _boom,
+        )
+        src = tmp_path / "src" / "main.py"
+        src.parent.mkdir(parents=True)
+        src.write_text("print('hello')")
+
+        result = indexer._catalog_hook(
+            repo=tmp_path, repo_name="nexus", repo_hash="571b8edd",
+            head_hash="abc", indexed_files=[(src, "code", "code__nexus")],
+            on_locked="skip",
+        )
+        assert src in result
+        owner = cat.owner_for_repo("571b8edd")
+        assert cat.by_file_path(owner, "src/main.py") is not None
+
+    def test_direct_fallback_probe_is_false(self, tmp_path, monkeypatch) -> None:
+        """GAP-3: with no daemon, CatalogWriter falls back to a direct in-process
+        Catalog (routed=False) and the probe returns False unconditionally, so a
+        batch producer never yields when there is no cross-process contention."""
+        self._catalog(tmp_path, monkeypatch)
+        from nexus.catalog.factory import make_catalog_writer
+
+        writer = make_catalog_writer(priority="batch")
+        try:
+            assert writer.routed is False
+            assert writer.is_interactive_write_pending() is False
+        finally:
+            writer.close()
 
     def test_skip_then_reconciles_next_pass(self, tmp_path, monkeypatch) -> None:
         """Idempotent reconciliation: a skipped file registers on the next


### PR DESCRIPTION
## What

RDR-146 Phase 2 (bead `nexus-5p2ci.12`): close the residual #1046 starvation. With Phase 1 routing all catalog writes through the single T2 daemon, a foreground interactive catalog write (e.g. `nx dt index`) can still wait behind a sustained background `nx index repo` write burst. This adds **producer back-pressure** (NOT a daemon priority queue, per the locked PC-2 design).

§Approach items 3 (interactive-vs-batch fairness) and 4 (`--on-locked=skip` retarget), collapsed into one mechanism per PC-5.

## Mechanism

- **Priority bit on the write RPC.** `T2Client.call(_priority=...)` adds an out-of-band `frame["priority"]`; absent defaults to `batch` (byte-identical pre-P2 wire).
- **Daemon interactive window.** An interactive `catalog_write.*` op opens an in-memory deadline window (`INTERACTIVE_WINDOW_S=2.0`, refreshed per write to cover a burst). New read-only probe op `catalog.is_interactive_write_pending` reads the flag only (no SQLite). Clock injectable for fixed-clock tests.
- **Producer yield loop.** `catalog/write_priority.py`: `resolve_write_priority` (`NX_WRITE_PRIORITY` > explicit > `isatty`) + `await_fair_window` (bounded escalating sleeps `0.25/0.5/1.0`, terminal `skip`|`proceed`, mirrors the RDR-129 B2 dispatch-retry shape).
- **Indexer gate.** `_catalog_hook` (the batch producer) probes before each file's catalog write and yields; `skip` defers the rest to the next idempotent pass, `wait` proceeds after the budget (never permanently starves the batch). `on_locked` is threaded `index_repository → _run_index → _catalog_hook` and retargets from the per-repo advisory lock to the writer-availability probe. The advisory lock keeps its orthogonal two-same-repo job.
- **Foreground tagging.** `nx dt index/capture/incorporate` and MCP-driven `store_put` / `memory promote` (non-tty, so the `isatty` fallback would misclassify them as batch) tag `interactive`.

## Tests

`tests/daemon/test_rdr146_fairness.py` (28). All six design gate scenarios + a real-chain integration test (real daemon + real `_catalog_hook` + open window → indexer probes, yields, skips, no stubs). Fixed clocks on deterministic layers; two wall-clock tests (batch storm + real chain) with robust bounds.

Full unit suite green: 8947 passed, 109 skipped, 0 failed.

## Review

Stacked review run at the phase boundary:
- **code-review-expert**: APPROVED (1 Medium counter bug fixed).
- **substantive-critic**: PARTIAL → justified (2 Criticals — missing batch-storm + no-queue gate tests — and 1 Significant `mcp_infra` misclassification all remediated; coverage observation closed with the real-chain integration test).
- **test-validator**: PASS (4 LOW defensive-branch gaps closed).
- **phase-review-gate** (items 3+4): both traceable to `nexus-5p2ci.12`, no silent scope reduction.

Refs #1046