### PR TITLE
chore: merge main into develop (5.9.3 reconcile)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.9.2"
+        "ref": "v5.9.3"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.9.2"
+      "version": "5.9.3"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.9.2"
+        "ref": "v5.9.3"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.9.2"
+      "version": "5.9.3"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.9.3] - 2026-06-04
+
+Catalog moved behind the T2 daemon (RDR-146), closing the GH #1046 starvation.
+
+### Fixed
+
+- **Interactive `nx dt index` no longer starved by background indexing
+  (#1046).** `.catalog.db` was the last shared-state store still on the
+  direct-`sqlite3` model, so a foreground catalog write could wait ~30 min
+  behind a hook-spawned `nx index repo` contending on the one SQLite writer
+  lock. The T2 daemon now hosts the single rich `Catalog` (sole `.catalog.db`
+  writer) behind a write-only op whitelist; every consumer write routes
+  through it via typed `make_catalog_reader` / `make_catalog_writer` factories
+  (reads stay local), enforced by the storage-boundary lint.
+
+### Changed
+
+- **Interactive-vs-batch catalog-write fairness (RDR-146).** Inside the single
+  daemon, an interactive write (foreground `nx dt index` / `capture` /
+  `incorporate`, MCP `store_put`) opens a short priority window; the background
+  indexer polls it and yields over a bounded budget so interactive writes are
+  never starved. `nx index --on-locked=skip` now also defers a yielded catalog
+  write to the next idempotent pass; the per-repo advisory lock keeps its
+  separate two-same-repo job. New `NX_WRITE_PRIORITY=interactive|batch`
+  overrides the tty-based default.
+- **Bounded catalog graph traversal.** `_LinkOps.graph()` BFS replaced with a
+  single `WITH RECURSIVE` SQL query (depth cap, cycle detection).
+
 ## [5.9.2] - 2026-06-03
 
 Bug-fix batch from a GitHub-issue triage sweep.

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.9.2",
+  "version": "5.9.3",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.9.3] - 2026-06-04
+
+Plugin version aligned with conexus 5.9.3. No plugin-side changes; the release
+is the RDR-146 catalog-behind-daemon work (#1046 starvation fix) on the nexus
+package side.
+
 ## [5.9.2] - 2026-06-03
 
 Plugin version aligned with conexus 5.9.2. The bug-fix batch (#1068 mcpb local

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -501,6 +501,23 @@ is locked` daemon incidents):
   surfaces a `restarts_in_window` count in `nx daemon t2 status`. The
   non-daemon direct-writer fallbacks (the `t2_index_write`
   schema-mismatch arm) remain the RDR-128 A1 boundary, unchanged.
+- **Catalog behind the daemon (RDR-146).** `.catalog.db` (the 8th T2
+  domain store, on its own file) was the last shared-state store still on
+  the direct-`sqlite3` model; GH #1046 was its starvation symptom (an
+  interactive `nx dt index` starved ~30 min by a hook-spawned `nx index
+  repo` on the shared catalog writer). The T2 daemon now hosts the one rich
+  `Catalog` (sole `.catalog.db` writer + JSONL append path) behind a
+  write-only op whitelist; consumers reach it through typed
+  `make_catalog_reader` (read-only, local) / `make_catalog_writer`
+  (daemon-routed, direct fallback when no daemon) factories, enforced by
+  the same boundary lint (`CATALOG_CONSTRUCTION_BASELINE = 0`). Within the
+  single daemon, fairness is producer back-pressure: an interactive write
+  tags its RPC frame (`NX_WRITE_PRIORITY` / `isatty` / per-command intent),
+  opening a short in-memory window the background indexer polls
+  (`catalog.is_interactive_write_pending`) and yields to over a bounded
+  budget. `nx index --on-locked=skip` defers a yielded catalog write to the
+  next idempotent pass; the per-repo advisory lock keeps its orthogonal
+  two-same-repo job.
 
 **Migration Registry** (RDR-076): All T2 schema migrations are centralised in
 `src/nexus/db/migrations.py`. The `MIGRATIONS` list contains version-tagged

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,7 +81,7 @@ nx index repo ./my-project
 |------|-------------|
 | `--frecency-only` | Update frecency scores only; skip re-embedding (faster, for re-ranking refresh). Mutually exclusive with `--force` |
 | `--force-stale` | Re-index only if collection pipeline version is outdated (smart force — skips current collections) |
-| `--on-locked {skip,wait}` | Behavior when another process holds the repo lock: `skip` exits immediately, `wait` blocks (default: `wait`) |
+| `--on-locked {skip,wait}` | Behavior under contention (default: `wait`). Per-repo advisory lock (two `nx index repo` on the same repo): `skip` exits immediately, `wait` blocks. Catalog-write fairness (RDR-146): when a foreground interactive catalog write is pending, `skip` defers this run's catalog writes to the next idempotent pass, `wait` proceeds after a bounded yield. `NX_WRITE_PRIORITY=interactive|batch` overrides the tty-based priority of a run's catalog writes. |
 | `--no-taxonomy` | Skip automatic topic discovery after indexing |
 | `--debug-timing` | Emit an end-of-run per-stage breakdown to stderr (chunking / embed / upload / retry seconds per file, aggregated with percentages). Instruments code, prose, and PDF per-file paths — silent without the flag. Use when investigating "why did indexing take N minutes?" (introduced 4.9.0, nexus-7niu) |
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.9.2",
+  "version": "5.9.3",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conexus-mcpb"
-version = "5.9.2"
+version = "5.9.3"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
@@ -10,7 +10,7 @@ dependencies = [
     # while collections are indexed at 768/1024-dim, so every T3 search hits a
     # dimension mismatch and returns zero results. The .mcpb cannot run the
     # interactive `nx init` embedder choice, so it must pin [local] explicitly.
-    "conexus[local]>=5.9.2",
+    "conexus[local]>=5.9.3",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.9.2"
+version = "5.9.3"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.9.2",
+  "version": "5.9.3",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.9.2"
+version = "5.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Reconcile the develop/main divergence after the 5.9.3 release. Carries the `chore(release): conexus 5.9.3` version bump (all 7 manifests + source.ref) and the #1109 merge commit back onto develop so the two branches converge. No new code; release-mechanics only.