### PR TITLE
feat(rdr-149): leased/fenced/atomic service-registry primitive (P1)

### DIFF
--- a/src/nexus/daemon/service_registry.py
+++ b/src/nexus/daemon/service_registry.py
@@ -1,0 +1,451 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-149: the leased / fenced / atomic service-registry substrate.
+
+ONE pure, deterministic, tier-agnostic primitive for ephemeral local
+service lifecycle. T1, T2 and T3 each migrate onto it (RDR-149 P2-P5),
+parameterized only by a scope key (uid for T2/T3, session-id for T1) and
+a tier file prefix. No tier-specific code lives here.
+
+The primitive replaces three divergent bespoke implementations (pid
+sweeps, PPID walks, per-tier election) with one mechanism whose parts
+subsume the per-tier features that drifted apart:
+
+- **Lease, not PID.** Identity is a server-unique ``owner_token``
+  (uuid4 per owner instance); liveness is TTL freshness on a wall-clock
+  heartbeat stamp. A dead owner's lease simply ages out past ``ttl`` no
+  matter what the kernel does with its pid -> pid-reuse immunity for
+  free, and "process alive" is no longer conflated with "endpoint live".
+- **Heartbeat == self-heal == reap.** The owner re-stamps the lease every
+  ``heartbeat_interval``; that same re-stamp re-creates a transiently
+  lost record (RF-1, the RDR-140 re-assert), and a reader treats an
+  expired lease as absent and unlinks it (orphan reap).
+- **Monotonic generation fencing.** Each publish bumps a per-scope
+  ``generation`` counter under the election flock (read-increment-write,
+  RF-3). A stale lower-generation owner can neither overwrite nor unlink
+  a newer higher-generation owner's record (CA-4). The counter lives
+  inside the record, so it survives restarts with no clock dependency.
+- **Atomic publish.** Every write is temp-file + ``os.replace`` so a
+  concurrent reader sees either the old or the new record, never a torn
+  one.
+- **Scope-keyed election.** A per-scope ``fcntl.flock`` serializes the
+  generation read-increment-write, so concurrent siblings converge to
+  exactly one owner per scope with strictly increasing generations.
+
+The TTL/heartbeat defaults reuse the RDR-140 T2 constants
+(``heartbeat_interval`` = ``_REASSERT_INTERVAL`` = 1.0,
+``ttl`` = ``_LOSER_POLL_TIMEOUT`` = 3.0); the constructor enforces the
+RF-1 invariant ``ttl >= heartbeat_interval`` so a discoverer's poll
+window can never straddle a mid-heartbeat gap.
+
+Determinism: the wall-clock used for the lease stamp is injectable
+(``clock``), mirroring ``T2Daemon._monotonic``; the supervisor exposes a
+synchronous ``heartbeat_tick`` so tests drive cadence with a fixed clock
+and never sleep.
+"""
+from __future__ import annotations
+
+import contextlib
+import errno
+import fcntl
+import json
+import os
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterator, Optional
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+# RF-1: substrate defaults reuse the RDR-140 T2 lifecycle constants.
+DEFAULT_HEARTBEAT_INTERVAL: float = 1.0
+DEFAULT_TTL: float = 3.0
+
+_FORMAT_VERSION: int = 1
+
+Clock = Callable[[], float]
+
+
+class ServiceRegistryError(RuntimeError):
+    """Base error for the service-registry substrate."""
+
+
+class StaleOwnerError(ServiceRegistryError):
+    """Raised when an owner tries to heartbeat a lease that a newer
+    (higher-generation) or different owner now holds. The caller has been
+    fenced and must stop; it must not re-create or overwrite the record.
+    """
+
+
+def mint_owner_token() -> str:
+    """A server-unique owner identity. Never a pid (pid-reuse immunity)."""
+    return uuid.uuid4().hex
+
+
+@dataclass(frozen=True)
+class LeaseRecord:
+    """One owner's lease over a scope. Serialized to the discovery file.
+
+    ``generation`` is the fencing token; ``owner_token`` is the identity;
+    ``heartbeat_epoch`` is the wall-clock liveness stamp checked against
+    ``ttl``. ``endpoint`` / ``version`` / ``payload`` carry the
+    tier-specific connection details (the registry never interprets
+    them).
+    """
+
+    scope_key: str
+    generation: int
+    owner_token: str
+    heartbeat_epoch: float
+    ttl: float
+    endpoint: dict[str, Any]
+    version: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    status: str = "live"
+    format_version: int = _FORMAT_VERSION
+
+    def is_fresh(self, now: float) -> bool:
+        """Live iff status is ``live`` and the lease has not aged past TTL."""
+        if self.status != "live":
+            return False
+        return (now - self.heartbeat_epoch) < self.ttl
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, text: str) -> "LeaseRecord":
+        data = json.loads(text)
+        return cls(
+            scope_key=data["scope_key"],
+            generation=int(data["generation"]),
+            owner_token=data["owner_token"],
+            heartbeat_epoch=float(data["heartbeat_epoch"]),
+            ttl=float(data["ttl"]),
+            endpoint=dict(data["endpoint"]),
+            version=str(data["version"]),
+            payload=dict(data.get("payload", {})),
+            status=str(data.get("status", "live")),
+            format_version=int(data.get("format_version", _FORMAT_VERSION)),
+        )
+
+
+class ServiceRegistry:
+    """File-backed leased registry, parameterized by tier prefix + scope.
+
+    One instance serves any number of scopes within a tier; per-call
+    ``scope_key`` selects the record + election lock. All mutating
+    operations take the per-scope flock for the duration of their
+    read-modify-write so generation bumps are serialized across
+    processes.
+    """
+
+    def __init__(
+        self,
+        *,
+        dir: Path,
+        tier: str,
+        clock: Clock = time.time,
+        ttl: float = DEFAULT_TTL,
+        heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
+    ) -> None:
+        if ttl < heartbeat_interval:
+            raise ValueError(
+                f"ttl ({ttl}) must be >= heartbeat_interval "
+                f"({heartbeat_interval}) (RF-1: a discoverer's poll window "
+                f"must not straddle a mid-heartbeat gap)"
+            )
+        self._dir = dir
+        self._tier = tier
+        self._clock = clock
+        self._ttl = ttl
+        self._heartbeat_interval = heartbeat_interval
+
+    # -- paths --------------------------------------------------------------
+
+    @property
+    def clock(self) -> Clock:
+        return self._clock
+
+    @property
+    def heartbeat_interval(self) -> float:
+        return self._heartbeat_interval
+
+    def _record_path(self, scope_key: str) -> Path:
+        return self._dir / f"{self._tier}_addr.{scope_key}"
+
+    def _election_path(self, scope_key: str) -> Path:
+        return self._dir / f"{self._tier}_elect.{scope_key}.lock"
+
+    def _ensure_dir(self) -> None:
+        self._dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    # -- election -----------------------------------------------------------
+
+    @contextlib.contextmanager
+    def _elect(self, scope_key: str) -> Iterator[None]:
+        """Hold the per-scope election flock for a read-modify-write.
+
+        Blocking ``LOCK_EX``: the critical section (read current record,
+        increment generation, atomic write) is short, and a publisher
+        must wait its turn rather than fail, so concurrent siblings
+        serialize into strictly increasing generations.
+        """
+        self._ensure_dir()
+        path = self._election_path(scope_key)
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+
+    # -- atomic IO ----------------------------------------------------------
+
+    def _read_record(self, scope_key: str) -> Optional[LeaseRecord]:
+        path = self._record_path(scope_key)
+        try:
+            text = path.read_text()
+        except OSError:
+            return None
+        try:
+            return LeaseRecord.from_json(text)
+        except (json.JSONDecodeError, KeyError, ValueError) as exc:
+            _log.warning(
+                "service_registry_corrupt_record", path=str(path), error=str(exc)
+            )
+            return None
+
+    def _write_record_atomic(self, record: LeaseRecord) -> None:
+        self._ensure_dir()
+        path = self._record_path(record.scope_key)
+        tmp = path.with_suffix(path.suffix + f".{os.getpid()}.{uuid.uuid4().hex}.tmp")
+        fd = os.open(str(tmp), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+        try:
+            try:
+                os.write(fd, record.to_json().encode("utf-8"))
+            finally:
+                os.close(fd)
+            os.replace(str(tmp), str(path))
+        except BaseException:
+            with contextlib.suppress(OSError):
+                tmp.unlink()
+            raise
+
+    # -- publish / heartbeat / discover / relinquish ------------------------
+
+    def publish(
+        self,
+        scope_key: str,
+        *,
+        endpoint: dict[str, Any],
+        version: str,
+        owner_token: str,
+        payload: Optional[dict[str, Any]] = None,
+    ) -> LeaseRecord:
+        """Claim (or re-claim) ``scope_key``, bumping the generation.
+
+        Under the election flock: read the current record, set the new
+        generation to ``current.generation + 1`` (or 1 if none), and
+        atomically write the new lease stamped at the current clock. The
+        winner of a concurrent race is the last to enter the critical
+        section and therefore carries the highest generation.
+        """
+        with self._elect(scope_key):
+            current = self._read_record(scope_key)
+            generation = (current.generation + 1) if current is not None else 1
+            record = LeaseRecord(
+                scope_key=scope_key,
+                generation=generation,
+                owner_token=owner_token,
+                heartbeat_epoch=self._clock(),
+                ttl=self._ttl,
+                endpoint=dict(endpoint),
+                version=version,
+                payload=dict(payload or {}),
+            )
+            self._write_record_atomic(record)
+            return record
+
+    def heartbeat(self, record: LeaseRecord) -> LeaseRecord:
+        """Re-stamp ``record``'s lease, preserving generation + identity.
+
+        Self-heal (RF-1): if the record was transiently lost, re-create
+        it at the SAME generation. Fencing (CA-4): if a newer owner has
+        taken the scope (higher generation, or the same generation under
+        a different ``owner_token``), raise ``StaleOwnerError`` and write
+        nothing.
+        """
+        with self._elect(record.scope_key):
+            current = self._read_record(record.scope_key)
+            if current is not None:
+                if current.generation > record.generation:
+                    raise StaleOwnerError(
+                        f"scope {record.scope_key!r} fenced: a generation "
+                        f"{current.generation} owner superseded generation "
+                        f"{record.generation}"
+                    )
+                if current.owner_token != record.owner_token:
+                    raise StaleOwnerError(
+                        f"scope {record.scope_key!r} owned by a different "
+                        f"token at generation {current.generation}"
+                    )
+            refreshed = LeaseRecord(
+                scope_key=record.scope_key,
+                generation=record.generation,
+                owner_token=record.owner_token,
+                heartbeat_epoch=self._clock(),
+                ttl=self._ttl,
+                endpoint=dict(record.endpoint),
+                version=record.version,
+                payload=dict(record.payload),
+            )
+            self._write_record_atomic(refreshed)
+            return refreshed
+
+    def discover(self, scope_key: str) -> Optional[LeaseRecord]:
+        """Resolve the live owner of ``scope_key``, or ``None``.
+
+        Returns ``None`` for a missing, expired (TTL), or shutdown-marked
+        record. An expired record is best-effort reaped so the next
+        lookup is fast. No pid is consulted: liveness is purely lease
+        freshness.
+        """
+        record = self._read_record(scope_key)
+        if record is None:
+            return None
+        if not record.is_fresh(self._clock()):
+            with contextlib.suppress(OSError):
+                self._record_path(scope_key).unlink()
+            return None
+        return record
+
+    def mark_shutting_down(self, record: LeaseRecord) -> None:
+        """Publish a shutdown marker so discoverers stop resolving us
+        immediately, before the record is unlinked."""
+        with self._elect(record.scope_key):
+            current = self._read_record(record.scope_key)
+            if current is None or current.owner_token != record.owner_token:
+                return
+            marker = LeaseRecord(
+                scope_key=current.scope_key,
+                generation=current.generation,
+                owner_token=current.owner_token,
+                heartbeat_epoch=current.heartbeat_epoch,
+                ttl=current.ttl,
+                endpoint=dict(current.endpoint),
+                version=current.version,
+                payload=dict(current.payload),
+                status="shutting_down",
+            )
+            self._write_record_atomic(marker)
+
+    def relinquish(self, record: LeaseRecord) -> None:
+        """Release ``scope_key`` on graceful shutdown, but only if we still
+        own it. A delayed shutdown from a fenced predecessor must not
+        unlink a successor's record (CA-4)."""
+        with self._elect(record.scope_key):
+            current = self._read_record(record.scope_key)
+            if current is None:
+                return
+            if current.owner_token != record.owner_token:
+                return  # a successor owns it now; leave it alone
+            with contextlib.suppress(OSError):
+                self._record_path(record.scope_key).unlink()
+
+
+class ServiceSupervisor:
+    """Owns one scope's heartbeat cadence and version-cycle.
+
+    Generic over tier: the supervisor mints the owner token, publishes
+    the lease, re-stamps it each tick (stopping itself when fenced), and
+    orchestrates a version-skew cycle via tier-supplied ``stop_owner`` /
+    ``start_owner`` hooks. The version-cycle is what #1112 lacked for T3;
+    here it is uniform across tiers, driven by version-skew on the lease.
+    """
+
+    def __init__(
+        self,
+        registry: ServiceRegistry,
+        scope_key: str,
+        *,
+        version: str,
+        endpoint_provider: Callable[[], dict[str, Any]],
+        payload: Optional[dict[str, Any]] = None,
+        owner_token: Optional[str] = None,
+    ) -> None:
+        self._registry = registry
+        self._scope_key = scope_key
+        self._version = version
+        self._endpoint_provider = endpoint_provider
+        self._payload = dict(payload or {})
+        self._owner_token = owner_token or mint_owner_token()
+        self._record: Optional[LeaseRecord] = None
+        self.fenced: bool = False
+
+    @property
+    def owner_token(self) -> str:
+        return self._owner_token
+
+    @property
+    def record(self) -> Optional[LeaseRecord]:
+        return self._record
+
+    def publish_once(self) -> LeaseRecord:
+        """Claim the scope and remember our lease."""
+        self._record = self._registry.publish(
+            self._scope_key,
+            endpoint=self._endpoint_provider(),
+            version=self._version,
+            owner_token=self._owner_token,
+            payload=self._payload,
+        )
+        return self._record
+
+    def heartbeat_tick(self) -> None:
+        """Re-stamp the lease once. If we have been fenced by a newer
+        owner, set ``fenced`` and stop trying (the loser-quiet-exit)."""
+        if self._record is None or self.fenced:
+            return
+        try:
+            self._record = self._registry.heartbeat(self._record)
+        except StaleOwnerError:
+            self.fenced = True
+            _log.info(
+                "service_supervisor_fenced",
+                scope=self._scope_key,
+                owner_token=self._owner_token,
+            )
+
+    def cycle_to_current(
+        self,
+        current_version: str,
+        *,
+        stop_owner: Callable[[], None],
+        start_owner: Callable[[], None],
+    ) -> bool:
+        """Replace a running owner whose version differs from
+        ``current_version``. Returns True if a cycle was performed.
+
+        The running owner's version is read from the live lease; on skew,
+        ``stop_owner`` tears the old process down and ``start_owner``
+        spawns the new-version owner (which re-publishes with the next
+        generation). On a version match this is a no-op.
+        """
+        running = self._registry.discover(self._scope_key)
+        if running is None or running.version == current_version:
+            return False
+        _log.info(
+            "service_supervisor_version_cycle",
+            scope=self._scope_key,
+            running_version=running.version,
+            current_version=current_version,
+        )
+        stop_owner()
+        start_owner()
+        return True

--- a/tests/daemon/test_service_registry.py
+++ b/tests/daemon/test_service_registry.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-149 Phase 1 (bead nexus-qf0lk): the leased service-registry primitive.
+
+Unit suite for ``nexus.daemon.service_registry`` — the single pure,
+deterministic, fixed-clock-testable substrate that T1/T2/T3 migrate onto
+(P2-P5). No tier-specific code is exercised here; the registry is
+parameterized only by a scope key + a tier file prefix.
+
+Core semantics under test (RDR-149 Decision):
+- Lease, not PID: liveness is TTL freshness on a wall-clock heartbeat
+  stamp; identity is a server-unique ``owner_token`` (uuid4), never a pid.
+- Fencing token: a per-scope monotonic ``generation`` bumped under the
+  election flock at publish (read-increment-write, RF-3).
+- Atomic publish: write-temp + os.replace, always.
+- Scope-keyed election: a per-scope flock serializes the generation RMW.
+- CA-4: a stale lower-generation owner can never clobber a newer
+  higher-generation owner's record (the restart-race harness).
+- pid-reuse immunity: no pid in the identity or liveness path.
+"""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from nexus.daemon.service_registry import (
+    LeaseRecord,
+    ServiceRegistry,
+    ServiceSupervisor,
+    StaleOwnerError,
+)
+
+
+class _FakeClock:
+    """Fixed, advanceable wall-clock surrogate (mirrors P0 / fairness)."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+@pytest.fixture
+def clock() -> _FakeClock:
+    return _FakeClock()
+
+
+@pytest.fixture
+def registry(tmp_path: Path, clock: _FakeClock) -> ServiceRegistry:
+    return ServiceRegistry(
+        dir=tmp_path, tier="t2", clock=clock, ttl=3.0, heartbeat_interval=1.0
+    )
+
+
+def _endpoint(port: int = 5000) -> dict:
+    return {"host": "127.0.0.1", "port": port}
+
+
+# ---------------------------------------------------------------------------
+# LeaseRecord
+# ---------------------------------------------------------------------------
+
+
+class TestLeaseRecord:
+    def test_json_roundtrip(self) -> None:
+        rec = LeaseRecord(
+            scope_key="42",
+            generation=7,
+            owner_token="tok-abc",
+            heartbeat_epoch=1234.5,
+            ttl=3.0,
+            endpoint=_endpoint(),
+            version="1.2.3",
+            payload={"k": "v"},
+        )
+        back = LeaseRecord.from_json(rec.to_json())
+        assert back == rec
+
+    def test_is_fresh_within_ttl(self) -> None:
+        rec = LeaseRecord(
+            scope_key="42", generation=1, owner_token="t", heartbeat_epoch=1000.0,
+            ttl=3.0, endpoint=_endpoint(), version="1",
+        )
+        assert rec.is_fresh(1002.99) is True
+        assert rec.is_fresh(1003.01) is False
+
+    def test_shutdown_marker_is_never_fresh(self) -> None:
+        rec = LeaseRecord(
+            scope_key="42", generation=1, owner_token="t", heartbeat_epoch=1000.0,
+            ttl=3.0, endpoint=_endpoint(), version="1", status="shutting_down",
+        )
+        assert rec.is_fresh(1000.0) is False
+
+
+# ---------------------------------------------------------------------------
+# publish: election + generation fencing
+# ---------------------------------------------------------------------------
+
+
+class TestPublish:
+    def test_first_publish_is_generation_one(self, registry: ServiceRegistry) -> None:
+        rec = registry.publish(
+            "42", endpoint=_endpoint(), version="1", owner_token="A"
+        )
+        assert rec.generation == 1
+        assert rec.owner_token == "A"
+
+    def test_republish_increments_generation(self, registry: ServiceRegistry) -> None:
+        registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        rec2 = registry.publish("42", endpoint=_endpoint(), version="2", owner_token="B")
+        assert rec2.generation == 2
+
+    def test_publish_stamps_current_clock(
+        self, registry: ServiceRegistry, clock: _FakeClock
+    ) -> None:
+        clock.advance(50.0)
+        rec = registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        assert rec.heartbeat_epoch == 1050.0
+
+    def test_publish_is_atomic_no_tmp_left(
+        self, registry: ServiceRegistry, tmp_path: Path
+    ) -> None:
+        registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_distinct_scopes_are_independent(self, registry: ServiceRegistry) -> None:
+        a = registry.publish("uidA", endpoint=_endpoint(), version="1", owner_token="A")
+        b = registry.publish("uidB", endpoint=_endpoint(), version="1", owner_token="B")
+        assert a.generation == 1 and b.generation == 1
+        assert registry.discover("uidA").owner_token == "A"
+        assert registry.discover("uidB").owner_token == "B"
+
+
+# ---------------------------------------------------------------------------
+# heartbeat: refresh, self-heal, fencing
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeat:
+    def test_heartbeat_refreshes_epoch_same_generation(
+        self, registry: ServiceRegistry, clock: _FakeClock
+    ) -> None:
+        rec = registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        clock.advance(1.0)
+        refreshed = registry.heartbeat(rec)
+        assert refreshed.generation == 1
+        assert refreshed.owner_token == "A"
+        assert refreshed.heartbeat_epoch == 1001.0
+
+    def test_heartbeat_self_heals_lost_record(
+        self, registry: ServiceRegistry
+    ) -> None:
+        # RF-1: the record is externally deleted while the owner is alive;
+        # the next heartbeat re-publishes it at the SAME generation.
+        rec = registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        registry._record_path("42").unlink()
+        assert registry.discover("42") is None
+        healed = registry.heartbeat(rec)
+        assert healed.generation == 1
+        assert registry.discover("42") is not None
+
+    def test_heartbeat_fenced_by_newer_generation_raises(
+        self, registry: ServiceRegistry
+    ) -> None:
+        # CA-4: a newer owner (gen 2) exists; the old owner's heartbeat must
+        # NOT clobber it and must learn it has been fenced.
+        old = registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        registry.publish("42", endpoint=_endpoint(), version="2", owner_token="B")
+        with pytest.raises(StaleOwnerError):
+            registry.heartbeat(old)
+        # B's record is untouched.
+        cur = registry.discover("42")
+        assert cur.generation == 2 and cur.owner_token == "B"
+
+    def test_heartbeat_foreign_same_generation_raises(
+        self, registry: ServiceRegistry, tmp_path: Path
+    ) -> None:
+        # A different owner_token at the same generation means our identity
+        # was displaced; refuse to overwrite.
+        rec = registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        # Forge a same-generation record owned by someone else.
+        foreign = LeaseRecord(
+            scope_key="42", generation=1, owner_token="X",
+            heartbeat_epoch=rec.heartbeat_epoch, ttl=3.0, endpoint=_endpoint(),
+            version="1",
+        )
+        registry._record_path("42").write_text(foreign.to_json())
+        with pytest.raises(StaleOwnerError):
+            registry.heartbeat(rec)
+
+
+# ---------------------------------------------------------------------------
+# discover + reap (TTL liveness, pid-free)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscover:
+    def test_discover_returns_fresh_owner(self, registry: ServiceRegistry) -> None:
+        registry.publish("42", endpoint=_endpoint(7), version="1", owner_token="A")
+        rec = registry.discover("42")
+        assert rec is not None and rec.endpoint["port"] == 7
+
+    def test_discover_none_when_missing(self, registry: ServiceRegistry) -> None:
+        assert registry.discover("nope") is None
+
+    def test_discover_none_and_reaps_when_stale(
+        self, registry: ServiceRegistry, clock: _FakeClock
+    ) -> None:
+        registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        clock.advance(3.1)  # past TTL
+        assert registry.discover("42") is None
+        # Stale record was reaped.
+        assert registry._record_path("42").exists() is False
+
+    def test_discover_none_on_shutdown_marker(
+        self, registry: ServiceRegistry
+    ) -> None:
+        rec = registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        registry.mark_shutting_down(rec)
+        assert registry.discover("42") is None
+
+    def test_pid_reuse_immunity_dead_lease_ages_out(
+        self, registry: ServiceRegistry, clock: _FakeClock
+    ) -> None:
+        # No pid is consulted anywhere; a dead owner's lease simply ages
+        # past TTL and is gone, regardless of any pid recycling.
+        registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        clock.advance(10.0)
+        assert registry.discover("42") is None
+
+
+# ---------------------------------------------------------------------------
+# relinquish: own-record-only deletion (CA-4 shutdown ordering)
+# ---------------------------------------------------------------------------
+
+
+class TestRelinquish:
+    def test_relinquish_deletes_own_record(self, registry: ServiceRegistry) -> None:
+        rec = registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        registry.relinquish(rec)
+        assert registry.discover("42") is None
+
+    def test_relinquish_does_not_delete_successor_record(
+        self, registry: ServiceRegistry
+    ) -> None:
+        # CA-4: an old owner's delayed shutdown must not unlink the newer
+        # owner's record.
+        old = registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        registry.publish("42", endpoint=_endpoint(), version="2", owner_token="B")
+        registry.relinquish(old)  # A shutting down late
+        cur = registry.discover("42")
+        assert cur is not None and cur.owner_token == "B"
+
+
+# ---------------------------------------------------------------------------
+# Election: concurrent publish serializes to distinct generations
+# ---------------------------------------------------------------------------
+
+
+class TestElection:
+    def test_concurrent_publish_distinct_generations_one_survivor(
+        self, registry: ServiceRegistry
+    ) -> None:
+        # The per-scope flock serializes the read-increment-write so two
+        # racing publishers get distinct generations and exactly one final
+        # record survives (last writer), never a torn or duplicated record.
+        results: list[LeaseRecord] = []
+        barrier = threading.Barrier(2)
+
+        def _pub(tok: str) -> None:
+            barrier.wait()
+            results.append(
+                registry.publish("42", endpoint=_endpoint(), version="1", owner_token=tok)
+            )
+
+        ths = [threading.Thread(target=_pub, args=(t,)) for t in ("A", "B")]
+        for t in ths:
+            t.start()
+        for t in ths:
+            t.join(timeout=10)
+
+        gens = sorted(r.generation for r in results)
+        assert gens == [1, 2], f"election did not serialize generations: {gens}"
+        assert registry.discover("42") is not None
+
+
+# ---------------------------------------------------------------------------
+# CA-4 restart-race harness (the load-bearing fencing proof)
+# ---------------------------------------------------------------------------
+
+
+class TestRestartRaceFencing:
+    def test_delayed_old_owner_cannot_clobber_newer(
+        self, registry: ServiceRegistry
+    ) -> None:
+        # A: gen 1. Restart elects B: gen 2. A's shutdown + heartbeat arrive
+        # LATE. Neither may touch B's record.
+        a = registry.publish("42", endpoint=_endpoint(1), version="1", owner_token="A")
+        b = registry.publish("42", endpoint=_endpoint(2), version="2", owner_token="B")
+        assert b.generation == 2
+
+        # Late heartbeat from A: fenced.
+        with pytest.raises(StaleOwnerError):
+            registry.heartbeat(a)
+        # Late relinquish from A: no-op on B's record.
+        registry.relinquish(a)
+
+        cur = registry.discover("42")
+        assert cur is not None
+        assert cur.generation == 2
+        assert cur.owner_token == "B"
+        assert cur.endpoint["port"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Supervisor: heartbeat cadence + version-cycle (covers all tiers)
+# ---------------------------------------------------------------------------
+
+
+class TestSupervisor:
+    def test_publish_once_then_tick_refreshes(
+        self, registry: ServiceRegistry, clock: _FakeClock
+    ) -> None:
+        sup = ServiceSupervisor(
+            registry, "42", version="1", endpoint_provider=lambda: _endpoint()
+        )
+        rec = sup.publish_once()
+        assert rec.generation == 1
+        clock.advance(1.0)
+        sup.heartbeat_tick()
+        assert registry.discover("42").heartbeat_epoch == 1001.0
+
+    def test_tick_after_fence_marks_supervisor_fenced(
+        self, registry: ServiceRegistry
+    ) -> None:
+        sup = ServiceSupervisor(
+            registry, "42", version="1", endpoint_provider=lambda: _endpoint()
+        )
+        sup.publish_once()
+        # A newer owner takes over.
+        registry.publish("42", endpoint=_endpoint(), version="2", owner_token="newer")
+        sup.heartbeat_tick()
+        assert sup.fenced is True
+
+    def test_cycle_to_current_no_op_when_versions_match(
+        self, registry: ServiceRegistry
+    ) -> None:
+        sup = ServiceSupervisor(
+            registry, "42", version="1", endpoint_provider=lambda: _endpoint()
+        )
+        sup.publish_once()
+        calls: list[str] = []
+        sup.cycle_to_current(
+            "1", stop_owner=lambda: calls.append("stop"),
+            start_owner=lambda: calls.append("start"),
+        )
+        assert calls == []
+
+    def test_cycle_to_current_stops_and_starts_on_skew(
+        self, registry: ServiceRegistry
+    ) -> None:
+        # #1112 root cause is T3 having no cycle; the primitive supplies a
+        # generic one driven by version-skew on the lease.
+        sup = ServiceSupervisor(
+            registry, "42", version="0.9", endpoint_provider=lambda: _endpoint()
+        )
+        sup.publish_once()
+        calls: list[str] = []
+        sup.cycle_to_current(
+            "1.0", stop_owner=lambda: calls.append("stop"),
+            start_owner=lambda: calls.append("start"),
+        )
+        assert calls == ["stop", "start"]


### PR DESCRIPTION
RDR-149 Phase 1 (bead nexus-qf0lk): the pure, tier-agnostic service-lifecycle substrate that T1/T2/T3 migrate onto in P2-P5.

> Stacked on #1116 (P0). Base will retarget to `develop` once P0 lands. The diff here is the two new files only.

## What
`src/nexus/daemon/service_registry.py` — one mechanism replacing three divergent bespoke implementations (pid sweeps, PPID walks, per-tier election), parameterized only by a scope key (uid for T2/T3, session-id for T1) and a tier file prefix. No tier-specific code.

## Semantics (RDR-149 Decision)
- **Lease not PID** — identity is a server-unique `owner_token` (uuid4); liveness is TTL freshness on a wall-clock heartbeat stamp. pid-reuse immunity falls out for free.
- **Heartbeat == self-heal == reap** — one re-stamp re-creates a transiently lost record (RF-1); an expired lease is treated as absent and unlinked.
- **Monotonic generation fencing** — each publish bumps a per-scope counter under the election flock (read-increment-write, RF-3); the counter lives in the record, surviving restarts with no clock dependency.
- **Atomic publish** — temp-file + `os.replace`, always.
- **Scope-keyed election** — a per-scope `flock` serializes the generation RMW, so concurrent siblings converge to one owner with strictly increasing generations.

## CA-4 discharged
A stale lower-generation owner can neither overwrite (`heartbeat` raises `StaleOwnerError`) nor unlink (`relinquish` is own-record-only) a newer owner's record. Proven directly by `TestRestartRaceFencing`.

## Supervisor
Owns the heartbeat cadence (synchronous `heartbeat_tick` for fixed-clock tests; sets `fenced` on `StaleOwnerError` = the loser-quiet-exit) and a generic version-cycle (the mechanism #1112 lacked for T3), driven by version-skew on the lease via tier-supplied stop/start hooks.

## Determinism
TTL/heartbeat defaults reuse the RDR-140 T2 constants (1.0 / 3.0); the constructor enforces the RF-1 invariant `ttl >= heartbeat_interval`. Clock injectable, no wall-clock sleeps. **25 unit tests pass.**

No tier wiring yet (P2 migrates T2 as the reference).

Refs #1112
Refs #1114