### PR TITLE
feat(rdr-149): migrate T2 onto the leased registry (P2, reference)

### DIFF
--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -558,6 +558,24 @@ def t2_start_cmd(config_dir_str: str | None, db_path_str: str | None) -> None:
         sys.exit(2)
 
 
+def _discovery_record_pid(data: dict) -> int | None:
+    """Extract the owner pid from a T2 discovery record.
+
+    RDR-149 P2: a lease record carries the pid under ``endpoint``; a
+    legacy payload carries it at the top level. Read both so ``stop`` /
+    ``status`` keep working across an in-flight upgrade window.
+    """
+    pid = data.get("pid")
+    if isinstance(pid, int):
+        return pid
+    endpoint = data.get("endpoint")
+    if isinstance(endpoint, dict):
+        ep_pid = endpoint.get("pid")
+        if isinstance(ep_pid, int):
+            return ep_pid
+    return None
+
+
 @t2_group.command("stop")
 @click.option(
     "--config-dir",
@@ -593,7 +611,7 @@ def t2_stop_cmd(config_dir_str: str | None) -> None:
         )
         disc.unlink(missing_ok=True)
         return
-    pid = payload.get("pid")
+    pid = _discovery_record_pid(payload)
     if not isinstance(pid, int) or pid <= 0:
         click.echo(f"Invalid pid in discovery file: {pid!r}", err=True)
         disc.unlink(missing_ok=True)
@@ -642,7 +660,7 @@ def t2_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
     # its daemon (e.g. an interrupted graceful stop left the file while
     # the process died, or a crash). Reporting such a file as "running"
     # masks a dead daemon (nexus-n8sbw).
-    pid = data.get("pid")
+    pid = _discovery_record_pid(data)
     alive = False
     if isinstance(pid, int) and pid > 0:
         try:
@@ -947,32 +965,31 @@ def _t2_ensure_running_inner(
     enum to CLI exit codes.
     """
     import time as _time
-    from nexus.daemon.t2_daemon import t2_discovery_path
 
     config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
-    disc = t2_discovery_path(config_dir)
 
     def _running_daemon() -> tuple[int, str] | None:
         """Return (pid, daemon_version) of the live daemon, or None.
 
-        Probes the recorded PID via ``os.kill(pid, 0)``; stale discovery
-        files outlive crashed daemons, so a readable file is not proof of
-        life.
+        RDR-149 P2: liveness is now lease freshness, resolved through
+        ``find_t2_daemon`` (which TTL-checks the lease and falls back to
+        pid-liveness for a legacy payload mid-upgrade). The external
+        contract is unchanged: callers still receive ``(pid, version)`` of
+        a live daemon, with the pid (lifted from the lease endpoint) used
+        for the SIGTERM in the version-skew cycle below.
         """
-        if not disc.exists():
+        from nexus.daemon.discovery import find_t2_daemon
+
+        payload = find_t2_daemon(config_dir)
+        if payload is None:
             return None
-        try:
-            data = json.loads(disc.read_text())
-        except (OSError, json.JSONDecodeError):
-            return None
-        pid = data.get("pid")
+        pid = payload.get("pid")
         if not isinstance(pid, int):
             return None
-        try:
-            os.kill(pid, 0)
-        except (ProcessLookupError, PermissionError):
-            return None
-        return pid, str(data.get("daemon_version") or "")
+        # New lease records carry ``version``; a legacy payload carries
+        # ``daemon_version`` (upgrade-window compatibility).
+        version = payload.get("version") or payload.get("daemon_version") or ""
+        return pid, str(version)
 
     def _daemon_is_alive() -> bool:
         return _running_daemon() is not None

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -661,13 +661,13 @@ def t2_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
     # the process died, or a crash). Reporting such a file as "running"
     # masks a dead daemon (nexus-n8sbw).
     pid = _discovery_record_pid(data)
-    alive = False
-    if isinstance(pid, int) and pid > 0:
-        try:
-            os.kill(pid, 0)
-            alive = True
-        except (ProcessLookupError, PermissionError):
-            alive = False
+    # RDR-149 P2: liveness is what a CLIENT would resolve. For a lease
+    # record that is freshness (a daemon whose heartbeat loop wedged reads
+    # as down even though its pid is alive); for a legacy payload it is
+    # pid-liveness. ``find_t2_daemon`` applies the right rule per format.
+    from nexus.daemon.discovery import find_t2_daemon
+
+    alive = find_t2_daemon(config_dir) is not None
 
     # RDR-140 P4.2 (Gap 5): surface how many restarts the crash-loop guard has
     # recorded in the current window — a rising count is the crash-loop signal.

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -214,11 +214,16 @@ def _quiesce_daemon() -> None:
         from nexus.config import nexus_config_dir
         from nexus.daemon.t2_daemon import t2_discovery_path
 
+        from nexus.commands.daemon import _discovery_record_pid
+
         disc = t2_discovery_path(nexus_config_dir())
         pid: int | None = None
         if disc.exists():
             try:
-                pid = json.loads(disc.read_text()).get("pid")
+                # RDR-149 P2: the lease record carries the owner pid under
+                # ``endpoint``; the helper reads both shapes so the
+                # post-stop exit-wait below still fires.
+                pid = _discovery_record_pid(json.loads(disc.read_text()))
             except (OSError, json.JSONDecodeError):
                 pid = None
 

--- a/src/nexus/daemon/discovery.py
+++ b/src/nexus/daemon/discovery.py
@@ -163,21 +163,76 @@ def _read_payload(path: Path, *, tier: Tier) -> Optional[Any]:
         return None
 
 
-def _resolve_t2_lease(
-    raw: dict[str, Any], path: Path
+#: The leased-registry record format version this client understands
+#: (mirrors ``service_registry._FORMAT_VERSION``; kept local to avoid a
+#: lower-level module importing the substrate).
+_LEASE_FORMAT_VERSION: int = 1
+
+
+def is_lease_record(raw: Any) -> bool:
+    """True if *raw* is a RDR-149 leased-registry record (vs a legacy
+    pid-payload). A lease record carries both ``endpoint`` and
+    ``generation``; a legacy payload carries neither."""
+    return (
+        isinstance(raw, dict)
+        and isinstance(raw.get("endpoint"), dict)
+        and "generation" in raw
+    )
+
+
+def normalize_discovery_view(raw: Any) -> dict[str, Any]:
+    """Flatten a discovery record (lease OR legacy) to a uniform view with
+    top-level ``pid`` / ``uds_path`` / ``tcp_host`` / ``tcp_port`` /
+    ``daemon_version``, applying NO liveness or freshness filter.
+
+    Reap paths must inspect even a stale / unreachable predecessor's
+    record (that is precisely what they reap), so they cannot go through
+    the freshness-filtering ``find_t*_daemon``. This pure normalizer gives
+    them the legacy-shaped view they expect from either format.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    if not is_lease_record(raw):
+        return raw  # legacy payload is already top-level
+    endpoint = raw["endpoint"]
+    return {
+        "pid": endpoint.get("pid"),
+        "uds_path": endpoint.get("uds_path"),
+        "tcp_host": endpoint.get("tcp_host"),
+        "tcp_port": endpoint.get("tcp_port"),
+        "daemon_version": raw.get("version"),
+        "generation": raw.get("generation"),
+        "owner_token": raw.get("owner_token"),
+        "status": raw.get("status", "live"),
+    }
+
+
+def _resolve_lease_record(
+    raw: dict[str, Any], path: Path, *, tier: str
 ) -> Optional[dict[str, Any]]:
-    """Resolve a RDR-149 T2 lease record to a connection dict, or ``None``.
+    """Resolve a RDR-149 lease record to a connection dict, or ``None``.
 
     Liveness is lease freshness (``now - heartbeat_epoch < ttl``), not pid:
     a dead owner's lease simply ages out, giving pid-reuse immunity. A
-    stale or shutdown-marked lease is best-effort unlinked so the next
-    lookup is fast. The endpoint fields (``uds_path`` / ``tcp_host`` /
-    ``tcp_port``) are lifted to the top level so the existing client
-    contract (``discovery_resolve`` -> connect) is unchanged; the lease
-    metadata (``generation`` / ``owner_token``) rides alongside.
+    stale, shutdown-marked, or forward-incompatible lease is rejected; an
+    expired one is best-effort unlinked so the next lookup is fast. The
+    endpoint fields (``uds_path`` / ``tcp_host`` / ``tcp_port``) are lifted
+    to the top level so the existing client contract
+    (``discovery_resolve`` -> connect) is unchanged; the lease metadata
+    (``generation`` / ``owner_token`` / ``version``) rides alongside.
+
+    Tier-parameterized so the T3 migration (RDR-149 P3) reuses it verbatim.
     """
+    fmt = raw.get("format_version", _LEASE_FORMAT_VERSION)
+    if isinstance(fmt, int) and fmt > _LEASE_FORMAT_VERSION:
+        _log.warning(
+            f"{tier}_discovery_lease_format_too_new",
+            path=str(path),
+            format_version=fmt,
+        )
+        return None
     if raw.get("status", "live") != "live":
-        _log.info("t2_discovery_shutdown_marker_seen", path=str(path))
+        _log.info(f"{tier}_discovery_shutdown_marker_seen", path=str(path))
         return None
     endpoint = raw.get("endpoint")
     heartbeat_epoch = raw.get("heartbeat_epoch")
@@ -187,20 +242,23 @@ def _resolve_t2_lease(
         or not isinstance(heartbeat_epoch, (int, float))
         or not isinstance(ttl, (int, float))
     ):
-        _log.warning("t2_discovery_lease_malformed", path=str(path))
+        _log.warning(f"{tier}_discovery_lease_malformed", path=str(path))
         return None
-    if (time.time() - heartbeat_epoch) >= ttl:
-        _log.warning("t2_discovery_lease_expired", path=str(path))
+    # Guard a backward clock step (NTP correction): a suspiciously large
+    # negative age is treated as stale rather than perpetually fresh.
+    age = time.time() - heartbeat_epoch
+    if age >= ttl or age <= -ttl:
+        _log.warning(f"{tier}_discovery_lease_expired", path=str(path), age=age)
         try:
             path.unlink(missing_ok=True)
         except OSError as exc:
-            _log.warning("t2_discovery_unlink_failed", path=str(path), error=str(exc))
+            _log.warning(
+                f"{tier}_discovery_unlink_failed", path=str(path), error=str(exc)
+            )
         return None
     result = dict(endpoint)
     result["generation"] = raw.get("generation")
     result["owner_token"] = raw.get("owner_token")
-    # The daemon version rides the lease ``version`` field; surface it so
-    # the RDR-141 version-skew arm can read the running daemon's version.
     result["version"] = raw.get("version")
     return result
 
@@ -220,8 +278,8 @@ def find_t2_daemon(config_dir: Optional[Path] = None) -> Optional[dict[str, Any]
     raw = _read_payload(path, tier="t2")
     if raw is None:
         return None
-    if isinstance(raw, dict) and "endpoint" in raw and "generation" in raw:
-        return _resolve_t2_lease(raw, path)
+    if is_lease_record(raw):
+        return _resolve_lease_record(raw, path, tier="t2")
     return _validate_discovery_payload(raw, path, tier="t2")
 
 

--- a/src/nexus/daemon/discovery.py
+++ b/src/nexus/daemon/discovery.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import errno
 import json
 import os
+import time
 from pathlib import Path
 from typing import Any, Literal, Optional
 
@@ -162,16 +163,65 @@ def _read_payload(path: Path, *, tier: Tier) -> Optional[Any]:
         return None
 
 
+def _resolve_t2_lease(
+    raw: dict[str, Any], path: Path
+) -> Optional[dict[str, Any]]:
+    """Resolve a RDR-149 T2 lease record to a connection dict, or ``None``.
+
+    Liveness is lease freshness (``now - heartbeat_epoch < ttl``), not pid:
+    a dead owner's lease simply ages out, giving pid-reuse immunity. A
+    stale or shutdown-marked lease is best-effort unlinked so the next
+    lookup is fast. The endpoint fields (``uds_path`` / ``tcp_host`` /
+    ``tcp_port``) are lifted to the top level so the existing client
+    contract (``discovery_resolve`` -> connect) is unchanged; the lease
+    metadata (``generation`` / ``owner_token``) rides alongside.
+    """
+    if raw.get("status", "live") != "live":
+        _log.info("t2_discovery_shutdown_marker_seen", path=str(path))
+        return None
+    endpoint = raw.get("endpoint")
+    heartbeat_epoch = raw.get("heartbeat_epoch")
+    ttl = raw.get("ttl")
+    if (
+        not isinstance(endpoint, dict)
+        or not isinstance(heartbeat_epoch, (int, float))
+        or not isinstance(ttl, (int, float))
+    ):
+        _log.warning("t2_discovery_lease_malformed", path=str(path))
+        return None
+    if (time.time() - heartbeat_epoch) >= ttl:
+        _log.warning("t2_discovery_lease_expired", path=str(path))
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            _log.warning("t2_discovery_unlink_failed", path=str(path), error=str(exc))
+        return None
+    result = dict(endpoint)
+    result["generation"] = raw.get("generation")
+    result["owner_token"] = raw.get("owner_token")
+    # The daemon version rides the lease ``version`` field; surface it so
+    # the RDR-141 version-skew arm can read the running daemon's version.
+    result["version"] = raw.get("version")
+    return result
+
+
 def find_t2_daemon(config_dir: Optional[Path] = None) -> Optional[dict[str, Any]]:
     """Return the T2 daemon's discovery payload, or ``None`` if absent /
-    unreadable / stale. The T2 daemon ships in RDR-120 P3a; this helper
-    is in place so the T3 paths and the eventual T2 paths share a
-    validator.
+    unreadable / stale.
+
+    RDR-149 P2: the T2 record is now a leased registry record
+    (``generation`` + ``owner_token`` + ``endpoint`` + TTL-stamped
+    ``heartbeat_epoch``). A record carrying those keys is resolved by lease
+    freshness; a legacy payload (top-level pid, no ``endpoint``) falls back
+    to the shared pid-liveness validator so an in-flight upgrade window is
+    still readable.
     """
     path = discovery_path(config_dir, tier="t2")
     raw = _read_payload(path, tier="t2")
     if raw is None:
         return None
+    if isinstance(raw, dict) and "endpoint" in raw and "generation" in raw:
+        return _resolve_t2_lease(raw, path)
     return _validate_discovery_payload(raw, path, tier="t2")
 
 

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -107,6 +107,11 @@ _DISPATCH_RETRY_SLEEPS: tuple[float, ...] = (0.1, 0.25)
 from nexus.catalog.write_priority import (  # noqa: E402
     INTERACTIVE_WINDOW_S as _INTERACTIVE_WINDOW_S,
 )
+from nexus.daemon.service_registry import (  # noqa: E402
+    LeaseRecord,
+    ServiceRegistry,
+    ServiceSupervisor,
+)
 
 #: RPC op name (under the ``catalog.*`` read namespace) the background
 #: indexer polls. In-memory only (reads the deadline flag, touches no SQLite).
@@ -736,8 +741,16 @@ class T2Daemon:
         self._spawn_lock_fd: int | None = None
         self._spawn_lock_fd_path: int | None = None
         self._stop_event: asyncio.Event | None = None
+        # RDR-149 P2 (nexus-fx77g): discovery identity now rides the leased
+        # service-registry substrate. The wall-clock used for the lease
+        # heartbeat stamp is injectable (tests pin it), distinct from the
+        # monotonic fairness clock above. The supervisor owns the lease +
+        # heartbeat; the spawn-lock above still owns single-writer (RDR-128).
+        self._lease_clock: Any = time.time
+        self._registry: ServiceRegistry | None = None
+        self._supervisor: ServiceSupervisor | None = None
+        self._lease_record: LeaseRecord | None = None
         # RDR-140 P1.3: self-healing discovery re-assert (holder only).
-        self._discovery_payload: dict[str, Any] | None = None
         self._reassert_task: asyncio.Task[None] | None = None
 
     # ── public properties ───────────────────────────────────────────────
@@ -812,16 +825,31 @@ class T2Daemon:
             self._make_handler(is_uds=False), sock=tcp_sock,
         )
 
+        # RDR-149 P2: publish the discovery identity as a lease record via
+        # the shared registry. Scope key is the uid, so the record path is
+        # the same ``t2_addr.<uid>`` the legacy payload used; only the
+        # on-disk shape (lease + generation + endpoint) and the liveness
+        # mechanism (TTL freshness, not pid) change. The endpoint carries
+        # the uds/tcp connection fields clients resolve, plus the pid for
+        # the loser-poll breadcrumb and legacy-reader compatibility.
         self._discovery_path = t2_discovery_path(self._config_dir)
-        payload = _build_discovery_payload(
-            uds_path=self._uds_path,
-            tcp_host=_T2_HOST,
-            tcp_port=self._tcp_port,
-            pid=os.getpid(),
-            daemon_version=_daemon_version(),
+        scope_key = str(os.getuid())
+        endpoint = {
+            "uds_path": str(self._uds_path),
+            "tcp_host": _T2_HOST,
+            "tcp_port": self._tcp_port,
+            "pid": os.getpid(),
+        }
+        self._registry = ServiceRegistry(
+            dir=self._config_dir, tier="t2", clock=self._lease_clock
         )
-        _write_discovery_atomic(self._discovery_path, payload)
-        self._discovery_payload = payload
+        self._supervisor = ServiceSupervisor(
+            self._registry,
+            scope_key,
+            version=_daemon_version(),
+            endpoint_provider=lambda: endpoint,
+        )
+        self._lease_record = self._supervisor.publish_once()
 
         # RDR-140 P1.3: start the self-healing re-assert task now that the
         # discovery file is written. It re-creates the file if it ever goes
@@ -852,21 +880,24 @@ class T2Daemon:
         """
         while True:
             await asyncio.sleep(_REASSERT_INTERVAL)
-            path = self._discovery_path
-            payload = self._discovery_payload
-            if path is None or payload is None:
+            supervisor = self._supervisor
+            if supervisor is None:
                 continue
             try:
-                needs_write = True
-                if path.exists():
-                    try:
-                        current = json.loads(path.read_text())
-                        needs_write = current.get("pid") != payload["pid"]
-                    except (OSError, json.JSONDecodeError):
-                        needs_write = True
-                if needs_write:
-                    _write_discovery_atomic(path, payload)
-                    _log.info("t2_daemon_discovery_reasserted", pid=payload["pid"])
+                # RDR-149 P2: one supervisor tick re-stamps the lease,
+                # which self-heals a transiently lost record at the same
+                # generation (the RDR-140 re-assert) and learns if a newer
+                # owner fenced us (cannot happen while we hold the spawn
+                # lock, but the loser-quiet-exit is logged if it ever does).
+                supervisor.heartbeat_tick()
+                if supervisor.fenced:
+                    _log.warning(
+                        "t2_daemon_discovery_fenced",
+                        pid=os.getpid(),
+                        scope=str(os.getuid()),
+                    )
+                else:
+                    self._lease_record = supervisor.record
             except asyncio.CancelledError:
                 raise
             except Exception as exc:  # noqa: BLE001
@@ -929,9 +960,16 @@ class T2Daemon:
             self._tcp_server.close()
             await self._tcp_server.wait_closed()
             self._tcp_server = None
-        if self._discovery_path is not None:
-            self._discovery_path.unlink(missing_ok=True)
-            self._discovery_path = None
+        if self._registry is not None and self._lease_record is not None:
+            # RDR-149 P2: relinquish is own-record-only, so a fenced
+            # predecessor's delayed stop cannot unlink a successor's record
+            # (CA-4) — the same invariant the early-unlink ordering above
+            # protects (reassert cancelled BEFORE this).
+            self._registry.relinquish(self._lease_record)
+            self._lease_record = None
+            self._supervisor = None
+            self._registry = None
+        self._discovery_path = None
         if self._uds_path is not None and self._uds_path.exists():
             self._uds_path.unlink(missing_ok=True)
         if self._t2db is not None:
@@ -1414,21 +1452,26 @@ def _poll_for_winner(config_dir: Path, timeout: float) -> bool:
 
     RDR-140 P1.3 (nexus-h2oko): a spawn-lock loser calls this purely for
     observability before exiting 0. Returns True once the winner's t2_addr
-    file names a live pid AND its UDS is connectable; False if the timeout
-    elapses first. A discovered-but-unreachable target (set file, socket not
-    yet accepting) or a stale addr (dead pid) is NOT treated as a live
-    attach — we keep polling and report False at timeout rather than claim a
-    stale attach. Never raises.
+    lease resolves to a fresh owner AND its UDS is connectable; False if the
+    timeout elapses first. A discovered-but-unreachable target (set file,
+    socket not yet accepting) or a stale lease (aged past TTL) is NOT
+    treated as a live attach — we keep polling and report False at timeout
+    rather than claim a stale attach. Never raises.
+
+    RDR-149 P2: liveness is now lease freshness, not pid; resolution goes
+    through ``find_t2_daemon`` so the loser sees the winner exactly as a
+    real client would (the lease-aware reader handles both the new lease
+    record and a legacy payload mid-upgrade).
     """
+    from nexus.daemon.discovery import find_t2_daemon
+
     deadline = time.monotonic() + timeout
-    disc_path = t2_discovery_path(config_dir)
     while time.monotonic() < deadline:
         try:
-            if disc_path.exists():
-                payload = json.loads(disc_path.read_text())
-                pid = payload.get("pid")
+            payload = find_t2_daemon(config_dir)
+            if payload is not None:
                 uds = payload.get("uds_path")
-                if isinstance(pid, int) and _pid_is_alive(pid) and uds:
+                if uds:
                     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                     try:
                         sock.settimeout(0.5)
@@ -1438,7 +1481,7 @@ def _poll_for_winner(config_dir: Path, timeout: float) -> bool:
                         pass  # set-but-unreachable — keep polling.
                     finally:
                         sock.close()
-        except (OSError, json.JSONDecodeError):
+        except OSError:
             pass
         time.sleep(0.05)
     return False

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -840,6 +840,14 @@ class T2Daemon:
             "tcp_port": self._tcp_port,
             "pid": os.getpid(),
         }
+        # Two flocks, two concerns (do NOT conflate when migrating T3/T1):
+        # the spawn-lock acquired above is the RDR-128 single-writer
+        # guarantee and IS T2's election (exactly one daemon opens the WAL).
+        # The primitive's per-scope election flock (t2_elect.<uid>.lock,
+        # taken briefly inside publish/heartbeat) does NOT replace it; it
+        # only serializes the generation read-increment-write so the fencing
+        # token is monotonic. Both are required. For T1 (no spawn-lock,
+        # session-scoped) the primitive's flock IS the whole election.
         self._registry = ServiceRegistry(
             dir=self._config_dir, tier="t2", clock=self._lease_clock
         )
@@ -1259,8 +1267,16 @@ class T2Daemon:
         except (OSError, ValueError):
             payload = None
         if isinstance(payload, dict):
-            addr_payload = payload
-            pid = payload.get("pid")
+            # RDR-149 P2: the addr token may be a lease record (pid +
+            # connection fields under ``endpoint``, version under
+            # ``version``). Normalize to the legacy-shaped flat view WITHOUT
+            # a freshness filter (reap must inspect even a stale predecessor)
+            # so the pid-extraction, version-aware spare, and health-ping
+            # below all keep working across the upgrade window.
+            from nexus.daemon.discovery import normalize_discovery_view
+
+            addr_payload = normalize_discovery_view(payload)
+            pid = addr_payload.get("pid")
             if isinstance(pid, int):
                 addr_pid = pid
 

--- a/tests/daemon/test_discovery.py
+++ b/tests/daemon/test_discovery.py
@@ -162,3 +162,141 @@ class TestDiscoveryResolveT3:
         monkeypatch.setenv("NX_T3_ADDR", "host:not-a-port")
         with pytest.raises(ValueError):
             discovery_resolve("t3", config_dir=config_dir)
+
+
+# ---------------------------------------------------------------------------
+# RDR-149 P2: T2 lease-record resolution + reap-path normalization
+# ---------------------------------------------------------------------------
+
+
+def _t2_lease(pid: int, *, generation: int = 1, version: str = "1.2.3") -> dict:
+    """A RDR-149 T2 lease record as ServiceRegistry writes it."""
+    import time as _time
+
+    return {
+        "scope_key": str(os.getuid()),
+        "generation": generation,
+        "owner_token": "tok-xyz",
+        "heartbeat_epoch": _time.time(),
+        "ttl": 3.0,
+        "endpoint": {
+            "uds_path": "/tmp/t2.sock",
+            "tcp_host": "127.0.0.1",
+            "tcp_port": 5555,
+            "pid": pid,
+        },
+        "version": version,
+        "payload": {},
+        "status": "live",
+        "format_version": 1,
+    }
+
+
+class TestLeaseRecordResolution:
+    def test_is_lease_record_detects_both_shapes(self) -> None:
+        from nexus.daemon.discovery import is_lease_record
+
+        assert is_lease_record(_t2_lease(os.getpid())) is True
+        assert is_lease_record(_live_payload()) is False  # legacy
+        assert is_lease_record({"endpoint": {}}) is False  # no generation
+        assert is_lease_record("nope") is False
+
+    def test_find_t2_resolves_fresh_lease_with_flat_endpoint(
+        self, config_dir: Path
+    ) -> None:
+        from nexus.daemon.discovery import discovery_path, find_t2_daemon
+
+        path = discovery_path(config_dir, tier="t2")
+        path.write_text(json.dumps(_t2_lease(os.getpid())))
+        resolved = find_t2_daemon(config_dir)
+        assert resolved is not None
+        # Endpoint fields lifted to the top level (client contract).
+        assert resolved["uds_path"] == "/tmp/t2.sock"
+        assert resolved["tcp_port"] == 5555
+        assert resolved["pid"] == os.getpid()
+        assert resolved["generation"] == 1
+        assert resolved["version"] == "1.2.3"
+
+    def test_find_t2_rejects_and_unlinks_expired_lease(
+        self, config_dir: Path
+    ) -> None:
+        from nexus.daemon.discovery import discovery_path, find_t2_daemon
+
+        path = discovery_path(config_dir, tier="t2")
+        lease = _t2_lease(os.getpid())
+        lease["heartbeat_epoch"] = 0.0  # ancient -> aged past TTL
+        path.write_text(json.dumps(lease))
+        assert find_t2_daemon(config_dir) is None
+        assert path.exists() is False  # reaped
+
+    def test_find_t2_rejects_shutdown_marker(self, config_dir: Path) -> None:
+        from nexus.daemon.discovery import discovery_path, find_t2_daemon
+
+        path = discovery_path(config_dir, tier="t2")
+        lease = _t2_lease(os.getpid())
+        lease["status"] = "shutting_down"
+        path.write_text(json.dumps(lease))
+        assert find_t2_daemon(config_dir) is None
+
+    def test_find_t2_rejects_forward_incompatible_format(
+        self, config_dir: Path
+    ) -> None:
+        from nexus.daemon.discovery import discovery_path, find_t2_daemon
+
+        path = discovery_path(config_dir, tier="t2")
+        lease = _t2_lease(os.getpid())
+        lease["format_version"] = 2  # a newer client wrote this
+        path.write_text(json.dumps(lease))
+        assert find_t2_daemon(config_dir) is None
+
+    def test_find_t2_legacy_payload_still_resolves(self, config_dir: Path) -> None:
+        # Upgrade window: a still-running old daemon's legacy payload must
+        # remain readable via the pid-liveness fallback.
+        from nexus.daemon.discovery import discovery_path, find_t2_daemon
+
+        path = discovery_path(config_dir, tier="t2")
+        legacy = _live_payload()
+        legacy["uds_path"] = "/tmp/legacy.sock"
+        path.write_text(json.dumps(legacy))
+        resolved = find_t2_daemon(config_dir)
+        assert resolved is not None
+        assert resolved["pid"] == os.getpid()
+
+
+class TestNormalizeDiscoveryView:
+    """The reap path (``_reap_predecessor_daemon``) inspects even a stale /
+    unreachable predecessor, so it normalizes WITHOUT a freshness filter.
+    These guard the pid / version / socket extraction that the version-aware
+    graceful-drain + health-ping depend on (the P2 review Critical)."""
+
+    def test_lease_view_lifts_pid_version_and_socket(self) -> None:
+        from nexus.daemon.discovery import normalize_discovery_view
+
+        view = normalize_discovery_view(_t2_lease(4242, version="9.9.9"))
+        assert view["pid"] == 4242
+        assert view["daemon_version"] == "9.9.9"  # lease ``version`` -> daemon_version
+        assert view["uds_path"] == "/tmp/t2.sock"
+        assert view["tcp_host"] == "127.0.0.1"
+        assert view["tcp_port"] == 5555
+
+    def test_legacy_payload_passes_through(self) -> None:
+        from nexus.daemon.discovery import normalize_discovery_view
+
+        legacy = _live_payload()
+        assert normalize_discovery_view(legacy) == legacy
+
+    def test_non_dict_yields_empty(self) -> None:
+        from nexus.daemon.discovery import normalize_discovery_view
+
+        assert normalize_discovery_view("garbage") == {}
+
+    def test_health_ping_and_handshake_read_normalized_lease(self) -> None:
+        # The reap discrimination helpers must work off the normalized view:
+        # _peer_handshake reads daemon_version, _health_ping reads the socket
+        # fields — both absent at the top level of a raw lease record.
+        from nexus.daemon.discovery import normalize_discovery_view
+        from nexus.daemon.t2_daemon import _peer_handshake
+
+        view = normalize_discovery_view(_t2_lease(os.getpid(), version="7.0.0"))
+        version, _reachable = _peer_handshake(os.getpid(), view)
+        assert version == "7.0.0"  # would be None if it read raw lease["version"] wrongly

--- a/tests/daemon/test_rdr149_lifecycle_conformance.py
+++ b/tests/daemon/test_rdr149_lifecycle_conformance.py
@@ -1,44 +1,49 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""RDR-149 Phase 0 (bead nexus-sq50c): cross-tier lifecycle conformance suite.
+"""RDR-149: cross-tier lifecycle conformance suite.
 
 The load-bearing artifact for the whole RDR-149 arc. ONE parameterized
-property battery run against the THREE current service-lifecycle
-implementations (T1 session.py, T2 daemon, T3 daemon) exactly as they
-exist today. The red cells are the evidence-based scope of the
-migration: where a property fails for T1 or T3 but passes for T2, the
-gap is real and a migration phase will flip it green.
+lifecycle property battery run against the THREE service-lifecycle
+implementations (T1 session.py, T2 daemon, T3 daemon). Each tier's
+harness drives that tier's REAL publish / discover / reap path, so the
+battery is a living spec: as a tier migrates onto the leased registry
+(P2-P5) its harness points at the migrated path and its red cells flip
+green.
 
-Red-first contract (CA-1). The suite MUST reproduce two filed defects as
-failures against current code:
+Liveness models differ across tiers and the battery is agnostic to which
+one a tier uses:
 
-- GH #1114 (T1 lost-addr, no self-heal) -> ``test_self_heal`` xfails for T1.
-- GH #1112 (T3 stale after upgrade)     -> ``test_version_cycle`` xfails for T3.
+- T1 / T3 (un-migrated): identity + liveness are pid-based. Ungraceful
+  death = the owner pid dies; reap = the orphan sweep / discovery-time
+  pid validation removes the dead record.
+- T2 (migrated, RDR-149 P2): identity is a server-unique owner token and
+  liveness is lease freshness (TTL on a wall-clock heartbeat). Ungraceful
+  death = the owner stops heartbeating and the lease ages out.
 
-and T2 MUST pass every property T1/T3 fail. If any of those reds turned
-green against today's code, or T2 failed a discriminating property, the
-suite would be vacuous; ``test_matrix_is_not_vacuous`` guards that
-invariant directly against the expectation table.
+The harness vocabulary (``simulate_ungraceful_death`` / ``advance_to_reap``
+/ ``self_heal_tick`` / ``stale_reassert``) abstracts those models so one
+test body asserts the same property for every tier.
 
-How red-first is encoded while CI stays green: each currently-broken
-cell is marked ``xfail(strict=True)``. ``strict`` means an unexpected
-pass turns the suite RED, so the migration phase that fixes a tier is
-FORCED to delete the matching expectation entry. That is the
-red-first -> green-on-migration ratchet.
+Red-first contract (CA-1). The matrix MUST reproduce the two filed
+defects as failures against un-migrated code:
 
-Two cell kinds share the ``xfail`` mechanism but differ in intent:
+- GH #1114 (T1 lost-addr, no self-heal)  -> ``test_self_heal`` xfails for T1.
+- GH #1112 (T3 stale after upgrade)      -> ``test_version_cycle`` xfails for T3.
 
-- ``GAP``  : a tier-specific lifecycle hole with a named issue and the
-             RDR-149 phase that closes it (T1 self-heal/rekey/election,
-             T3 self-heal/version-cycle).
-- ``SPEC`` : a forward property of the not-yet-extracted leased primitive
-             (monotonic generation, fencing, pid-reuse immunity) that no
-             tier satisfies today (RF-3); un-xfailed at P1/P2.
+and T2 MUST pass every property T1/T3 fail. The non-vacuity guard
+(``TestMatrixIsNotVacuous``) enforces that directly against the
+expectation table.
 
-Flakiness control (RDR-140 convention, keeps this out of the nexus-9eaz
-flake family): the battery is in-process and record-level with injected
-liveness, a fixed clock, and shrunk interval constants; ``port=0`` and a
-single event loop for the one real-daemon self-heal proof. The
-live-process behavioral variants live under the ``integration`` marker.
+Encoding: each broken cell is ``xfail(strict=True)`` so an unexpected
+pass turns the suite RED and forces the migrating phase to delete the
+stale cell (the red-first -> green ratchet). GAP cells name an issue + the
+phase that closes them; SPEC cells are forward properties of the leased
+primitive. RDR-149 P2 flips T2's SPEC cells (generation / fencing /
+pid-reuse) to ``pass`` now that T2 rides the primitive.
+
+Flakiness control (RDR-140 convention): the unit battery is in-process,
+record-level, with injected liveness + a fixed clock; ``port=0`` and a
+single event loop for the one live-daemon self-heal proof, which is
+``integration``-marked.
 """
 from __future__ import annotations
 
@@ -46,45 +51,43 @@ import asyncio
 import json
 import os
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 import pytest
 
 from nexus.daemon import discovery as _disc
-
-# Real publish/validate entrypoints under test, per tier.
-from nexus.daemon.t2_daemon import (
-    _build_discovery_payload as _t2_build_payload,
-    _write_discovery_atomic as _t2_write_atomic,
-)
 from nexus.daemon.t3_daemon import (
     _build_payload as _t3_build_payload,
     _write_discovery_atomic as _t3_write_atomic,
+)
+from nexus.daemon.service_registry import (
+    LeaseRecord,
+    ServiceRegistry,
+    StaleOwnerError,
 )
 from nexus import session as _sess
 
 
 TIERS = ("t1", "t2", "t3")
 
-# A synthetic owner pid, never a real live process; liveness is injected.
+# Synthetic owner pids, never real live processes; liveness is injected.
 _OWNER_PID = 970001
 _SIBLING_PID = 970002
 _REUSED_PID = 970003
 
 
 # ---------------------------------------------------------------------------
-# Injected liveness + clock (no real processes, no wall-clock)
+# Injected liveness (T1/T3 pid model) + fixed clock (T2 lease model)
 # ---------------------------------------------------------------------------
 
 
 class _AliveSet:
-    """Controllable process-liveness oracle shared by every tier harness.
+    """Controllable process-liveness oracle for the pid-based tiers.
 
-    ``os.kill(pid, 0)`` (the T2/T3 validator probe) and
-    ``session._is_pid_alive`` (the T1 sweep probe) are both redirected
-    here so 'ungraceful kill' and 'pid reuse' are deterministic without
-    spawning processes. Pids not managed here delegate to the real
-    probe, so unrelated kernel calls keep working.
+    ``os.kill(pid, 0)`` (the T3 validator probe) and
+    ``session._is_pid_alive`` (the T1 sweep probe) are redirected here so
+    ungraceful death and pid reuse are deterministic without spawning
+    processes. Pids not managed here delegate to the real probe.
     """
 
     def __init__(self) -> None:
@@ -107,9 +110,6 @@ class _AliveSet:
         return _real_is_pid_alive(pid)
 
     def fake_os_kill(self, pid: int, sig: int) -> None:
-        # Only the signal-0 liveness probe is redirected; a real signal
-        # to a managed synthetic pid would otherwise hit an unrelated
-        # process, so refuse anything but the probe.
         if sig != 0:
             raise AssertionError(f"unexpected real signal {sig} to managed pid {pid}")
         if pid in self._alive:
@@ -124,7 +124,7 @@ _real_is_pid_alive = _sess._is_pid_alive
 
 
 class _FakeClock:
-    """Fixed, advanceable monotonic clock (mirrors test_rdr146_fairness)."""
+    """Fixed, advanceable wall-clock surrogate (mirrors P1 / fairness)."""
 
     def __init__(self) -> None:
         self.t = 1000.0
@@ -137,158 +137,65 @@ class _FakeClock:
 
 
 # ---------------------------------------------------------------------------
-# Tier harnesses: a uniform record-level vocabulary over each tier's REAL
-# publish / discover / reap functions. Where a tier genuinely lacks a
-# mechanism (T1/T3 self-heal, T1/T3 version-cycle, T1 election) the method
-# is a real no-op so the failing assertion is behavioral, not synthetic.
+# Tier harnesses: a uniform, liveness-model-agnostic vocabulary over each
+# tier's REAL lifecycle path. ``owner`` is an integer owner id (a pid for
+# the pid-based tiers; an owner-token seed for T2).
 # ---------------------------------------------------------------------------
 
 
 class RecordHarness:
-    """Base adapter. ``scope`` is the election scope key for the tier:
-    ``uid`` for T2/T3 (one owner per user), ``session`` for T1 (one owner
-    per session-id, today mis-keyed on claude_pid)."""
-
     tier: str
-    scope: str
-    #: Does the tier run an in-process self-heal re-assert today (RF-1)?
+    scope: str  # "uid" (one owner per user) | "session" (one per session-id)
     has_self_heal: bool
-    #: Does an upgrade-cycle entrypoint cover this tier today (RF-4)?
     has_version_cycle: bool
 
-    def __init__(self, config_dir: Path, alive: _AliveSet) -> None:
+    def __init__(self, config_dir: Path, alive: _AliveSet, clock: _FakeClock) -> None:
         self._cd = config_dir
         self._alive = alive
+        self._clock = clock
 
-    # -- publish / discover -------------------------------------------------
-    def publish(self, *, pid: int = _OWNER_PID, generation: Optional[int] = None,
-                version: str = "1.0.0") -> None:
+    def publish(self, owner: int = _OWNER_PID) -> None:
         raise NotImplementedError
 
-    def discover(self, *, pid: int = _OWNER_PID) -> Optional[dict[str, Any]]:
+    def discover(self, owner: int = _OWNER_PID) -> Optional[dict[str, Any]]:
         raise NotImplementedError
 
-    def record_generation(self, *, pid: int = _OWNER_PID) -> Optional[int]:
-        rec = self.discover(pid=pid)
+    def current_generation(self, owner: int = _OWNER_PID) -> Optional[int]:
+        rec = self.discover(owner)
         if rec is None:
             return None
         gen = rec.get("generation")
         return gen if isinstance(gen, int) else None
 
-    # -- lifecycle events ---------------------------------------------------
-    def reap(self) -> None:
-        """Run the tier's orphan-reap path (discovery-time validation or
-        the one-shot sweep)."""
+    def simulate_ungraceful_death(self, owner: int = _OWNER_PID) -> None:
+        """The owner dies with no cleanup (SIGKILL / OOM): no record removal,
+        no graceful relinquish."""
         raise NotImplementedError
 
-    def external_delete(self, *, pid: int = _OWNER_PID) -> None:
+    def advance_to_reap(self) -> None:
+        """Advance whatever the tier needs so a dead owner becomes reapable.
+        A no-op for pid tiers (death is observable immediately); a TTL
+        advance for the lease tier."""
         raise NotImplementedError
-
-    def heartbeat(self, *, pid: int = _OWNER_PID) -> None:
-        """Run ONE self-heal tick using the tier's real re-assert path.
-        A no-op for tiers that have none (T1, T3) -> behavioral red."""
-        raise NotImplementedError
-
-    def owners_in_scope(self, *, session_id: str) -> int:
-        """Count distinct live owner records that resolve within one
-        election scope. T2/T3: per-uid (always 0 or 1). T1: per
-        session-id, which today is un-keyed so siblings each get their
-        own record."""
-        raise NotImplementedError
-
-
-class _DaemonRecordHarness(RecordHarness):
-    """Shared T2/T3 record harness: uid-keyed discovery file, pid-liveness
-    validation, discovery-time reap. Subclasses supply the real
-    build-payload + write-atomic + path + finder."""
-
-    scope = "uid"
-    has_self_heal = True  # overridden per-tier below
-
-    _build_payload: Callable[..., dict[str, Any]]
-    _write_atomic: Callable[[Path, dict[str, Any]], None]
-    _finder: Callable[[Optional[Path]], Optional[dict[str, Any]]]
-
-    def _path(self) -> Path:
-        return _disc.discovery_path(self._cd, tier=self.tier)  # type: ignore[arg-type]
-
-    def publish(self, *, pid: int = _OWNER_PID, generation: Optional[int] = None,
-                version: str = "1.0.0") -> None:
-        payload = self._build_real_payload(pid=pid, version=version)
-        if generation is not None:
-            payload["generation"] = generation
-        self._alive.mark_alive(pid)
-        type(self)._write_atomic(self._path(), payload)
-
-    def _build_real_payload(self, *, pid: int, version: str) -> dict[str, Any]:
-        raise NotImplementedError
-
-    def discover(self, *, pid: int = _OWNER_PID) -> Optional[dict[str, Any]]:
-        return type(self)._finder(self._cd)
 
     def reap(self) -> None:
-        # Discovery-time validation IS the reap path for T2/T3: a stale
-        # (dead-pid) record is unlinked by the validator on read.
-        type(self)._finder(self._cd)
+        raise NotImplementedError
 
-    def external_delete(self, *, pid: int = _OWNER_PID) -> None:
-        self._path().unlink(missing_ok=True)
+    def external_delete(self, owner: int = _OWNER_PID) -> None:
+        raise NotImplementedError
 
-    def owners_in_scope(self, *, session_id: str) -> int:
-        return 1 if self.discover() is not None else 0
+    def self_heal_tick(self, owner: int = _OWNER_PID) -> None:
+        """Run ONE self-heal tick using the tier's real re-assert path; a
+        genuine no-op for tiers that have none (T1, T3)."""
+        raise NotImplementedError
 
+    def stale_reassert(self, owner: int) -> None:
+        """A stale owner attempts to re-assert its record. A fenced tier
+        rejects it; an unfenced tier lets it through (the failure mode)."""
+        raise NotImplementedError
 
-class T2RecordHarness(_DaemonRecordHarness):
-    tier = "t2"
-    has_self_heal = True
-    has_version_cycle = True
-    _write_atomic = staticmethod(_t2_write_atomic)
-    _finder = staticmethod(_disc.find_t2_daemon)
-
-    def _build_real_payload(self, *, pid: int, version: str) -> dict[str, Any]:
-        return _t2_build_payload(
-            uds_path=str(self._cd / "t2.sock"),
-            tcp_host="127.0.0.1",
-            tcp_port=0,
-            pid=pid,
-            daemon_version=version,
-        )
-
-    def heartbeat(self, *, pid: int = _OWNER_PID) -> None:
-        # T2's real self-heal re-assert rewrites the record when it is
-        # missing or names a different pid (t2_daemon._reassert_discovery_
-        # loop body). Replay that exact decision using the real payload
-        # builder + atomic writer the loop itself calls.
-        path = self._path()
-        needs_write = True
-        if path.exists():
-            try:
-                needs_write = json.loads(path.read_text()).get("pid") != pid
-            except (OSError, json.JSONDecodeError):
-                needs_write = True
-        if needs_write:
-            self.publish(pid=pid)
-
-
-class T3RecordHarness(_DaemonRecordHarness):
-    tier = "t3"
-    has_self_heal = False  # RF-4: T3 has no re-assert loop (self-heal=0)
-    has_version_cycle = False  # #1112: upgrade-cycle does not cover T3
-    _write_atomic = staticmethod(_t3_write_atomic)
-    _finder = staticmethod(_disc.find_t3_daemon)
-
-    def _build_real_payload(self, *, pid: int, version: str) -> dict[str, Any]:
-        return _t3_build_payload(
-            tcp_port=0,
-            pid=pid,
-            local_path=self._cd / "chroma",
-            daemon_version=version,
-        )
-
-    def heartbeat(self, *, pid: int = _OWNER_PID) -> None:
-        # Genuine no-op: T3 has no self-heal re-assert loop (RF-4). The
-        # externally deleted record is NOT restored -> behavioral red.
-        return
+    def owners_in_scope(self, session_id: str) -> int:
+        raise NotImplementedError
 
 
 class T1RecordHarness(RecordHarness):
@@ -297,43 +204,160 @@ class T1RecordHarness(RecordHarness):
     has_self_heal = False  # #1114: ZERO self-heal in session.py
     has_version_cycle = False
 
-    def _key(self, pid: int) -> int:
-        return pid
+    def publish(self, owner: int = _OWNER_PID) -> None:
+        self._alive.mark_alive(owner)
+        _sess.write_t1_addr(owner, "127.0.0.1", 0)
 
-    def publish(self, *, pid: int = _OWNER_PID, generation: Optional[int] = None,
-                version: str = "1.0.0") -> None:
-        # T1's record is keyed by claude_pid and carries only host:port.
-        # generation/version are unstorable -> the generation property is
-        # structurally unsatisfiable today (covered by SPEC xfail).
-        self._alive.mark_alive(pid)
-        _sess.write_t1_addr(pid, "127.0.0.1", 0)
-
-    def discover(self, *, pid: int = _OWNER_PID) -> Optional[dict[str, Any]]:
-        # T1 discovery does NOT validate owner liveness; the filename pid
-        # IS the identity. A live record resolves to host:port.
-        hp = _sess.read_t1_addr_for(pid)
+    def discover(self, owner: int = _OWNER_PID) -> Optional[dict[str, Any]]:
+        hp = _sess.read_t1_addr_for(owner)
         if hp is None:
             return None
-        return {"pid": pid, "host": hp[0], "port": hp[1]}
+        return {"pid": owner, "owner": owner, "host": hp[0], "port": hp[1]}
+
+    def simulate_ungraceful_death(self, owner: int = _OWNER_PID) -> None:
+        self._alive.mark_dead(owner)
+
+    def advance_to_reap(self) -> None:
+        return  # pid death is observable immediately
 
     def reap(self) -> None:
-        # T1's reap is the one-shot orphan sweep (filename-pid liveness).
         _sess.sweep_orphan_t1_addr_files()
 
-    def external_delete(self, *, pid: int = _OWNER_PID) -> None:
-        _sess.unlink_t1_addr(pid)
+    def external_delete(self, owner: int = _OWNER_PID) -> None:
+        _sess.unlink_t1_addr(owner)
 
-    def heartbeat(self, *, pid: int = _OWNER_PID) -> None:
-        # Genuine no-op: session.py runs NO re-assert loop (#1114). A lost
-        # addr file is never republished while the owner is alive.
-        return
+    def self_heal_tick(self, owner: int = _OWNER_PID) -> None:
+        return  # session.py runs no re-assert loop (#1114)
 
-    def owners_in_scope(self, *, session_id: str) -> int:
-        # T1 keys on claude_pid, NOT session-id, so every sibling owns its
-        # own record. There is no session linkage to collapse them, so a
-        # single logical session with two MCP siblings shows two owners.
+    def stale_reassert(self, owner: int) -> None:
+        # No fencing: the stale owner simply rewrites its own pid-keyed file.
+        _sess.write_t1_addr(owner, "127.0.0.1", 0)
+
+    def owners_in_scope(self, session_id: str) -> int:
+        # T1 keys on claude_pid, not session-id, so every sibling owns its
+        # own record; one logical session with two MCP siblings shows two.
         cfg = _sess._nexus_config_dir_at_import()
         return len(list(cfg.glob("t1_addr.*")))
+
+
+class T3RecordHarness(RecordHarness):
+    tier = "t3"
+    scope = "uid"
+    has_self_heal = False  # RF-4: T3 has no re-assert loop
+    has_version_cycle = False  # #1112: upgrade-cycle does not cover T3
+
+    def _path(self) -> Path:
+        return _disc.discovery_path(self._cd, tier="t3")
+
+    def publish(self, owner: int = _OWNER_PID) -> None:
+        self._alive.mark_alive(owner)
+        payload = _t3_build_payload(
+            tcp_port=0, pid=owner, local_path=self._cd / "chroma",
+            daemon_version="1.0.0",
+        )
+        _t3_write_atomic(self._path(), payload)
+
+    def discover(self, owner: int = _OWNER_PID) -> Optional[dict[str, Any]]:
+        rec = _disc.find_t3_daemon(self._cd)
+        if rec is None:
+            return None
+        return {"pid": rec.get("pid"), "owner": rec.get("pid"), "generation": None}
+
+    def simulate_ungraceful_death(self, owner: int = _OWNER_PID) -> None:
+        self._alive.mark_dead(owner)
+
+    def advance_to_reap(self) -> None:
+        return
+
+    def reap(self) -> None:
+        _disc.find_t3_daemon(self._cd)  # validator unlinks a dead-pid record
+
+    def external_delete(self, owner: int = _OWNER_PID) -> None:
+        self._path().unlink(missing_ok=True)
+
+    def self_heal_tick(self, owner: int = _OWNER_PID) -> None:
+        return  # T3 has no re-assert loop (RF-4)
+
+    def stale_reassert(self, owner: int) -> None:
+        self.publish(owner)  # no fencing: the stale owner rewrites the record
+
+    def owners_in_scope(self, session_id: str) -> int:
+        return 1 if self.discover() is not None else 0
+
+
+class T2RecordHarness(RecordHarness):
+    """RDR-149 P2: T2 now rides the leased registry. This harness drives the
+    SAME ``ServiceRegistry`` the migrated daemon uses, with the injected
+    clock, so the lease semantics (generation, fencing, TTL liveness,
+    pid-reuse immunity) are exercised exactly as in production."""
+
+    tier = "t2"
+    scope = "uid"
+    has_self_heal = True
+    has_version_cycle = True
+
+    def __init__(self, config_dir: Path, alive: _AliveSet, clock: _FakeClock) -> None:
+        super().__init__(config_dir, alive, clock)
+        self._registry = ServiceRegistry(
+            dir=config_dir, tier="t2", clock=clock, ttl=3.0, heartbeat_interval=1.0
+        )
+        self._scope = str(os.getuid())
+        self._records: dict[int, LeaseRecord] = {}
+
+    def publish(self, owner: int = _OWNER_PID) -> None:
+        rec = self._registry.publish(
+            self._scope,
+            endpoint={"pid": owner, "host": "127.0.0.1", "port": 0},
+            version="1.0.0",
+            owner_token=f"tok-{owner}",
+        )
+        self._records[owner] = rec
+
+    def discover(self, owner: int = _OWNER_PID) -> Optional[dict[str, Any]]:
+        rec = self._registry.discover(self._scope)
+        if rec is None:
+            return None
+        return {
+            "pid": rec.endpoint.get("pid"),
+            "owner": rec.endpoint.get("pid"),
+            "generation": rec.generation,
+            "owner_token": rec.owner_token,
+        }
+
+    def simulate_ungraceful_death(self, owner: int = _OWNER_PID) -> None:
+        # The owner stops heartbeating; nothing else changes. The lease ages
+        # out on its own (advance_to_reap). No pid is consulted.
+        self._records.pop(owner, None)
+
+    def advance_to_reap(self) -> None:
+        self._clock.advance(3.1)  # past TTL
+
+    def reap(self) -> None:
+        self._registry.discover(self._scope)  # discovery reaps an expired lease
+
+    def external_delete(self, owner: int = _OWNER_PID) -> None:
+        self._registry._record_path(self._scope).unlink(missing_ok=True)
+
+    def self_heal_tick(self, owner: int = _OWNER_PID) -> None:
+        rec = self._records.get(owner)
+        if rec is None:
+            return
+        try:
+            self._records[owner] = self._registry.heartbeat(rec)
+        except StaleOwnerError:
+            pass
+
+    def stale_reassert(self, owner: int) -> None:
+        rec = self._records.get(owner)
+        if rec is None:
+            return
+        try:
+            self._registry.heartbeat(rec)  # fenced: raises, writes nothing
+        except StaleOwnerError:
+            pass
+
+    def owners_in_scope(self, session_id: str) -> int:
+        return 1 if self.discover() is not None else 0
 
 
 _HARNESS_CLASSES: dict[str, type[RecordHarness]] = {
@@ -344,24 +368,19 @@ _HARNESS_CLASSES: dict[str, type[RecordHarness]] = {
 
 
 # ---------------------------------------------------------------------------
-# The expectation matrix: the single source of truth for CA-1. "pass" means
-# the property holds against current code; an (kind, reason) tuple means the
-# property is expected to fail today and is xfailed strict. GAP cells name
-# the issue + the RDR-149 phase that flips them; SPEC cells are forward
-# properties of the leased primitive (no tier satisfies them yet).
+# The expectation matrix: the single source of truth for CA-1.
 # ---------------------------------------------------------------------------
 
 GAP = "gap"
 SPEC = "spec"
 
-# property -> {tier -> "pass" | (kind, reason)}
 EXPECTATIONS: dict[str, dict[str, Any]] = {
     "roundtrip": {"t1": "pass", "t2": "pass", "t3": "pass"},
     "reap_ungraceful": {"t1": "pass", "t2": "pass", "t3": "pass"},
     "self_heal": {
         "t1": (GAP, "#1114: session.py has no self-heal re-assert; RDR-149 P5"),
         "t2": "pass",
-        "t3": (GAP, "RF-4: T3 daemon has no re-assert loop; RDR-149 P4"),
+        "t3": (GAP, "RF-4: T3 daemon has no re-assert loop; RDR-149 P3"),
     },
     "concurrent_one_owner": {
         "t1": (GAP, "T1 keys on claude_pid not session-id; RDR-149 P5/CA-3"),
@@ -371,30 +390,28 @@ EXPECTATIONS: dict[str, dict[str, Any]] = {
     "version_cycle": {
         "t1": (GAP, "T1 not covered by any upgrade-cycle; RDR-149 P5"),
         "t2": "pass",
-        "t3": (GAP, "#1112: upgrade-cycle does not cover T3; RDR-149 P4"),
+        "t3": (GAP, "#1112: upgrade-cycle does not cover T3; RDR-149 P3"),
     },
+    # RDR-149 P2: T2 rides the primitive now, so its lease properties pass.
     "pid_reuse_immunity": {
-        "t1": (SPEC, "lease/generation kills pid-reuse; RDR-149 P1/P2"),
-        "t2": (SPEC, "validator trusts a reused live pid; RDR-149 P1/P2"),
-        "t3": (SPEC, "validator trusts a reused live pid; RDR-149 P1/P2"),
+        "t1": (SPEC, "lease/generation kills pid-reuse; RDR-149 P5"),
+        "t2": "pass",
+        "t3": (SPEC, "validator trusts a reused live pid; RDR-149 P3"),
     },
     "restart_higher_generation": {
-        "t1": (SPEC, "RF-3: no generation primitive; RDR-149 P1"),
-        "t2": (SPEC, "RF-3: no generation primitive; RDR-149 P1"),
-        "t3": (SPEC, "RF-3: no generation primitive; RDR-149 P1"),
+        "t1": (SPEC, "RF-3: no generation primitive; RDR-149 P5"),
+        "t2": "pass",
+        "t3": (SPEC, "RF-3: no generation primitive; RDR-149 P3"),
     },
     "restart_race_fencing": {
-        "t1": (SPEC, "CA-4: no fencing token; RDR-149 P1/P2"),
-        "t2": (SPEC, "CA-4: no fencing token; RDR-149 P1/P2"),
-        "t3": (SPEC, "CA-4: no fencing token; RDR-149 P1/P2"),
+        "t1": (SPEC, "CA-4: no fencing token; RDR-149 P5"),
+        "t2": "pass",
+        "t3": (SPEC, "CA-4: no fencing token; RDR-149 P3"),
     },
 }
 
 
 def _maybe_xfail(property_name: str, tier: str) -> None:
-    """Apply strict xfail for a (property, tier) cell expected to fail
-    today. A cell that unexpectedly passes turns the suite red, forcing
-    the migration phase to delete the stale expectation."""
     cell = EXPECTATIONS[property_name][tier]
     if cell == "pass":
         return
@@ -412,9 +429,13 @@ def alive() -> _AliveSet:
     return _AliveSet()
 
 
+@pytest.fixture
+def clock() -> _FakeClock:
+    return _FakeClock()
+
+
 @pytest.fixture(autouse=True)
 def _inject_liveness(monkeypatch: pytest.MonkeyPatch, alive: _AliveSet) -> None:
-    # Redirect both tier liveness probes at the managed synthetic pids.
     monkeypatch.setattr("nexus.daemon.discovery.os.kill", alive.fake_os_kill)
     monkeypatch.setattr("nexus.session._is_pid_alive", alive.is_alive)
 
@@ -423,7 +444,6 @@ def _inject_liveness(monkeypatch: pytest.MonkeyPatch, alive: _AliveSet) -> None:
 def config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     cd = tmp_path / "cfg"
     cd.mkdir(parents=True, exist_ok=True, mode=0o700)
-    # T1 paths resolve NEXUS_CONFIG_DIR at call time (session.py contract).
     monkeypatch.setenv("NEXUS_CONFIG_DIR", str(cd))
     return cd
 
@@ -434,8 +454,10 @@ def tier(request: pytest.FixtureRequest) -> str:
 
 
 @pytest.fixture
-def harness(tier: str, config_dir: Path, alive: _AliveSet) -> RecordHarness:
-    return _HARNESS_CLASSES[tier](config_dir, alive)
+def harness(
+    tier: str, config_dir: Path, alive: _AliveSet, clock: _FakeClock
+) -> RecordHarness:
+    return _HARNESS_CLASSES[tier](config_dir, alive, clock)
 
 
 # ---------------------------------------------------------------------------
@@ -449,125 +471,109 @@ class TestLifecycleConformance:
         harness.publish()
         rec = harness.discover()
         assert rec is not None
-        assert rec["pid"] == _OWNER_PID
+        assert rec["owner"] == _OWNER_PID
 
-    def test_reap_ungraceful(
-        self, harness: RecordHarness, tier: str, alive: _AliveSet
-    ) -> None:
-        # Owner dies with no cleanup (SIGKILL): the record lingers on disk
-        # but the tier's reap path must reject/remove it so no client
-        # resolves a dead owner.
+    def test_reap_ungraceful(self, harness: RecordHarness, tier: str) -> None:
+        # Owner dies with no cleanup: the record lingers but the tier's reap
+        # path (pid validation, or lease TTL) must stop resolving a dead
+        # owner.
         _maybe_xfail("reap_ungraceful", tier)
         harness.publish()
         assert harness.discover() is not None
-        alive.mark_dead(_OWNER_PID)
+        harness.simulate_ungraceful_death()
+        harness.advance_to_reap()
         harness.reap()
         assert harness.discover() is None
 
     def test_self_heal(self, harness: RecordHarness, tier: str) -> None:
-        # The record is lost (transient fs gap / external rm) while the
-        # owner is alive. A self-healing tier re-asserts it within a tick;
-        # T1 (#1114) and T3 (RF-4) have no re-assert loop -> stays gone.
+        # The record is lost while the owner is alive. A self-healing tier
+        # re-asserts it within a tick; T1 (#1114) and T3 (RF-4) do not.
         _maybe_xfail("self_heal", tier)
         harness.publish()
         harness.external_delete()
         assert harness.discover() is None
         for _ in range(3):
-            harness.heartbeat()
+            harness.self_heal_tick()
         assert harness.discover() is not None, "owner alive but record not self-healed"
 
-    def test_concurrent_one_owner(
-        self, harness: RecordHarness, tier: str, alive: _AliveSet
-    ) -> None:
-        # Two MCP siblings of ONE logical session (same session-id) race to
-        # own the scope. T2/T3 (uid scope) converge to exactly one record;
-        # T1 keys on claude_pid so the session ends up with two owners.
+    def test_concurrent_one_owner(self, harness: RecordHarness, tier: str) -> None:
+        # Two siblings of ONE logical session race. T2/T3 (uid scope)
+        # converge to one record; T1 keys on pid so the session ends up with
+        # two owners.
         _maybe_xfail("concurrent_one_owner", tier)
-        alive.mark_alive(_OWNER_PID)
-        alive.mark_alive(_SIBLING_PID)
-        harness.publish(pid=_OWNER_PID)
-        harness.publish(pid=_SIBLING_PID)
-        assert harness.owners_in_scope(session_id="sess-A") == 1
+        harness.publish(_OWNER_PID)
+        harness.publish(_SIBLING_PID)
+        assert harness.owners_in_scope("sess-A") == 1
 
     def test_version_cycle(self, harness: RecordHarness, tier: str) -> None:
-        # An upgrade must replace the running owner with a current-version
-        # owner. Today only T2 is wired into the upgrade-cycle; T3 (#1112)
-        # and T1 are left running the stale version.
+        # An upgrade must be able to replace the running owner. Only T2 is
+        # wired into a cycle today; T3 (#1112) and T1 are not.
         _maybe_xfail("version_cycle", tier)
         assert harness.has_version_cycle, (
             "tier is not covered by any upgrade-cycle entrypoint"
         )
 
-    def test_pid_reuse_immunity(
-        self, harness: RecordHarness, tier: str, alive: _AliveSet
-    ) -> None:
+    def test_pid_reuse_immunity(self, harness: RecordHarness, tier: str) -> None:
         # Owner dies; the kernel recycles its pid to an unrelated live
-        # process. A pid-based liveness check FALSELY treats the stale
-        # record as live. A leased/generation primitive is immune.
+        # process. A pid-based liveness check FALSELY keeps the stale record;
+        # a leased primitive ages it out regardless of the pid.
         _maybe_xfail("pid_reuse_immunity", tier)
-        harness.publish(pid=_REUSED_PID)
-        assert harness.discover(pid=_REUSED_PID) is not None
-        # Owner exits, pid recycled to a different live process: still
-        # "alive" by os.kill(pid, 0), so the record survives a reap.
-        alive.mark_alive(_REUSED_PID)  # the recycled occupant is alive
+        harness.publish(_REUSED_PID)
+        assert harness.discover(_REUSED_PID) is not None
+        harness.simulate_ungraceful_death(_REUSED_PID)
+        # The recycled pid is now a live, unrelated process.
+        harness._alive.mark_alive(_REUSED_PID)
+        harness.advance_to_reap()
         harness.reap()
-        # Immunity means the now-stale record is NOT resolvable. Today it
-        # is (pid happens alive), so this fails until the lease lands.
-        assert harness.discover(pid=_REUSED_PID) is None
+        assert harness.discover(_REUSED_PID) is None
 
     def test_restart_higher_generation(
         self, harness: RecordHarness, tier: str
     ) -> None:
-        # A restarted owner must republish with a strictly higher
-        # monotonic generation so stale predecessors are fenced. No tier
-        # persists a generation today (RF-3).
+        # A restarted owner republishes with a strictly higher monotonic
+        # generation so stale predecessors are fenced. The crashed owner's
+        # record persists (TTL) until the successor publishes, so the
+        # generation is read and bumped, not reset.
         _maybe_xfail("restart_higher_generation", tier)
-        harness.publish(generation=1)
-        assert harness.record_generation() == 1
-        harness.external_delete()
-        harness.publish(generation=None)  # a naive restart with no gen bump
-        gen = harness.record_generation()
-        assert gen is not None and gen > 1, "restart did not fence with a higher generation"
+        harness.publish(_OWNER_PID)
+        gen1 = harness.current_generation()
+        assert gen1 == 1
+        # Successor restarts while the predecessor record still exists.
+        harness.publish(_SIBLING_PID)
+        gen2 = harness.current_generation(_SIBLING_PID)
+        assert gen2 is not None and gen2 > gen1, "restart did not fence with a higher generation"
 
-    def test_restart_race_fencing(
-        self, harness: RecordHarness, tier: str, alive: _AliveSet
-    ) -> None:
-        # A slow predecessor's delayed shutdown must NOT clobber a newer,
-        # higher-generation owner's record (CA-4). Without a fencing token
-        # the late write wins and strands clients on the dead owner.
+    def test_restart_race_fencing(self, harness: RecordHarness, tier: str) -> None:
+        # A slow predecessor's delayed re-assert must NOT clobber a newer,
+        # higher-generation owner's record (CA-4).
         _maybe_xfail("restart_race_fencing", tier)
-        harness.publish(pid=_OWNER_PID, generation=2)  # the new owner
-        # The old owner (generation 1) wakes late and re-writes.
-        harness.publish(pid=_SIBLING_PID, generation=1)
+        harness.publish(_OWNER_PID)  # predecessor
+        harness.publish(_SIBLING_PID)  # successor takes over (higher generation)
+        harness.stale_reassert(_OWNER_PID)  # predecessor wakes late
         rec = harness.discover()
         assert rec is not None
-        assert rec.get("generation") == 2, "stale lower-generation owner clobbered the record"
+        assert rec["owner"] == _SIBLING_PID, "stale predecessor clobbered the record"
 
 
 # ---------------------------------------------------------------------------
-# T1-only properties (CA-3): the transient-key -> session-id re-key. T1
-# today has no session-id keying at all, so the property is unsatisfiable.
+# T1-only property (CA-3): the transient-key -> session-id re-key. T1 today
+# has no session-id keying, so the property is unsatisfiable until P5.
 # ---------------------------------------------------------------------------
 
 
 class TestT1SessionRekey:
     def test_record_keyed_on_session_id_not_pid(
-        self, config_dir: Path, alive: _AliveSet
+        self, config_dir: Path, alive: _AliveSet, clock: _FakeClock
     ) -> None:
-        # CA-3: a reader resolving by session-id must find the owner. Today
-        # T1 keys solely on claude_pid, so there is no session-id-addressed
-        # record to resolve. RDR-149 P5 introduces the re-key.
         pytest.xfail("CA-3: T1 has no session-id-keyed record yet; RDR-149 P5")
-        h = T1RecordHarness(config_dir, alive)
-        h.publish(pid=_OWNER_PID)
-        # No public session-id resolver exists; assert the intended shape.
+        h = T1RecordHarness(config_dir, alive, clock)
+        h.publish(_OWNER_PID)
         sess_path = config_dir / "t1_addr.sess-A"
         assert sess_path.exists(), "no session-id-keyed T1 record"
 
 
 # ---------------------------------------------------------------------------
-# Non-vacuity guard (CA-1): the matrix MUST reproduce #1114 and #1112 as
-# reds, and T2 MUST pass every property that T1 or T3 fails as a GAP.
+# Non-vacuity guard (CA-1).
 # ---------------------------------------------------------------------------
 
 
@@ -583,10 +589,8 @@ class TestMatrixIsNotVacuous:
         assert "#1112" in cell[1]
 
     def test_t2_passes_every_gap_t1_or_t3_fails(self) -> None:
-        # The discriminating invariant: for any property where T1 or T3 has
-        # a GAP, T2 must pass it. A GAP that T2 also failed would be
-        # mis-specified (CA-1). SPEC cells (forward primitive) are exempt:
-        # no tier satisfies them yet by construction.
+        # For any property where T1 or T3 has a GAP, T2 must pass it; a GAP
+        # T2 also failed would be mis-specified (CA-1).
         for prop, cells in EXPECTATIONS.items():
             t1_gap = isinstance(cells["t1"], tuple) and cells["t1"][0] == GAP
             t3_gap = isinstance(cells["t3"], tuple) and cells["t3"][0] == GAP
@@ -596,6 +600,19 @@ class TestMatrixIsNotVacuous:
                     f"it; the property is mis-specified (CA-1)"
                 )
 
+    def test_t2_migration_flipped_its_spec_cells(self) -> None:
+        # RDR-149 P2 ratchet: once T2 rides the primitive, every lease
+        # property must pass for T2 (no remaining xfail on the reference
+        # tier). A regression that re-broke one would surface here.
+        for prop in (
+            "pid_reuse_immunity",
+            "restart_higher_generation",
+            "restart_race_fencing",
+        ):
+            assert EXPECTATIONS[prop]["t2"] == "pass", (
+                f"T2 lease property {prop!r} regressed to non-pass after P2"
+            )
+
     def test_every_cell_covers_all_tiers(self) -> None:
         for prop, cells in EXPECTATIONS.items():
             assert set(cells) == set(TIERS), f"property {prop!r} missing a tier"
@@ -603,10 +620,8 @@ class TestMatrixIsNotVacuous:
 
 # ---------------------------------------------------------------------------
 # Live-process behavioral proof (integration marker only): a REAL in-process
-# T2 daemon self-heals a deleted discovery file via its re-assert loop. This
-# is the green counterpart to the record-level T2 self_heal cell and the
-# anchor the T1/T3 migrations are measured against. port=0, shrunk interval,
-# single event loop (RDR-140 convention); mirrors test_rdr146_fairness.
+# T2 daemon self-heals a deleted discovery file via its supervisor heartbeat.
+# port=0, shrunk interval, single event loop (RDR-140 convention).
 # ---------------------------------------------------------------------------
 
 
@@ -621,31 +636,32 @@ class TestLiveT2SelfHeal:
         from nexus.daemon import t2_daemon as _t2
 
         monkeypatch.setattr(_t2, "_REASSERT_INTERVAL", 0.05)
-        # Short /tmp config dir: the deep pytest tmp_path overflows the
-        # AF_UNIX UDS path limit (mirrors test_rdr146_fairness.config_dir).
         cd = Path(tempfile.mkdtemp(prefix="nx149-", dir="/tmp"))
         daemon = _t2.T2Daemon(config_dir=cd, db_path=cd / "memory.db")
-        daemon._monotonic = _FakeClock()
 
         async def _main() -> None:
             await daemon.start()
             try:
                 disc = daemon.discovery_path
                 assert disc.exists()
+                # RDR-149 P2: the record is a lease; the owner pid lives under
+                # endpoint and the generation is present.
+                payload = json.loads(disc.read_text())
+                assert payload["endpoint"]["pid"] == os.getpid()
+                assert payload["generation"] == 1
                 disc.unlink()
                 assert not disc.exists()
-                # The re-assert loop must restore the file within a few
-                # shrunk intervals while the daemon is alive.
                 for _ in range(40):
                     await asyncio.sleep(0.05)
                     if disc.exists():
                         break
                 assert disc.exists(), "live T2 daemon failed to self-heal discovery file"
-                payload = json.loads(disc.read_text())
-                assert payload["pid"] == os.getpid()
+                healed = json.loads(disc.read_text())
+                assert healed["endpoint"]["pid"] == os.getpid()
+                # Self-heal preserves the generation (re-assert, not a restart).
+                assert healed["generation"] == 1
             finally:
                 await daemon.stop()
-            # stop() cancels re-assert BEFORE unlink, so the file stays gone.
             assert not disc.exists()
 
         loop = asyncio.new_event_loop()

--- a/tests/daemon/test_rdr149_lifecycle_conformance.py
+++ b/tests/daemon/test_rdr149_lifecycle_conformance.py
@@ -61,9 +61,8 @@ from nexus.daemon.t3_daemon import (
     _write_discovery_atomic as _t3_write_atomic,
 )
 from nexus.daemon.service_registry import (
-    LeaseRecord,
     ServiceRegistry,
-    StaleOwnerError,
+    ServiceSupervisor,
 )
 from nexus import session as _sess
 
@@ -302,16 +301,22 @@ class T2RecordHarness(RecordHarness):
             dir=config_dir, tier="t2", clock=clock, ttl=3.0, heartbeat_interval=1.0
         )
         self._scope = str(os.getuid())
-        self._records: dict[int, LeaseRecord] = {}
+        # One ServiceSupervisor per owner, exactly as the migrated daemon
+        # uses it (publish_once + heartbeat_tick) — so the unit battery
+        # exercises the real daemon dispatch path, including the fenced-flag
+        # guard, not just ServiceRegistry in isolation.
+        self._supervisors: dict[int, ServiceSupervisor] = {}
 
     def publish(self, owner: int = _OWNER_PID) -> None:
-        rec = self._registry.publish(
+        sup = ServiceSupervisor(
+            self._registry,
             self._scope,
-            endpoint={"pid": owner, "host": "127.0.0.1", "port": 0},
             version="1.0.0",
+            endpoint_provider=lambda o=owner: {"pid": o, "host": "127.0.0.1", "port": 0},
             owner_token=f"tok-{owner}",
         )
-        self._records[owner] = rec
+        sup.publish_once()
+        self._supervisors[owner] = sup
 
     def discover(self, owner: int = _OWNER_PID) -> Optional[dict[str, Any]]:
         rec = self._registry.discover(self._scope)
@@ -327,7 +332,7 @@ class T2RecordHarness(RecordHarness):
     def simulate_ungraceful_death(self, owner: int = _OWNER_PID) -> None:
         # The owner stops heartbeating; nothing else changes. The lease ages
         # out on its own (advance_to_reap). No pid is consulted.
-        self._records.pop(owner, None)
+        self._supervisors.pop(owner, None)
 
     def advance_to_reap(self) -> None:
         self._clock.advance(3.1)  # past TTL
@@ -339,22 +344,14 @@ class T2RecordHarness(RecordHarness):
         self._registry._record_path(self._scope).unlink(missing_ok=True)
 
     def self_heal_tick(self, owner: int = _OWNER_PID) -> None:
-        rec = self._records.get(owner)
-        if rec is None:
-            return
-        try:
-            self._records[owner] = self._registry.heartbeat(rec)
-        except StaleOwnerError:
-            pass
+        sup = self._supervisors.get(owner)
+        if sup is not None:
+            sup.heartbeat_tick()  # re-stamps; self-heals a lost record
 
     def stale_reassert(self, owner: int) -> None:
-        rec = self._records.get(owner)
-        if rec is None:
-            return
-        try:
-            self._registry.heartbeat(rec)  # fenced: raises, writes nothing
-        except StaleOwnerError:
-            pass
+        sup = self._supervisors.get(owner)
+        if sup is not None:
+            sup.heartbeat_tick()  # fenced: sets sup.fenced, writes nothing
 
     def owners_in_scope(self, session_id: str) -> int:
         return 1 if self.discover() is not None else 0
@@ -545,7 +542,13 @@ class TestLifecycleConformance:
 
     def test_restart_race_fencing(self, harness: RecordHarness, tier: str) -> None:
         # A slow predecessor's delayed re-assert must NOT clobber a newer,
-        # higher-generation owner's record (CA-4).
+        # higher-generation owner's record (CA-4). For the leased tier this
+        # proves the heartbeat-fencing arm: a stale owner re-stamping its
+        # lease is rejected (StaleOwnerError) and writes nothing. The
+        # complementary guarantee — that publish can only ever INCREMENT the
+        # generation, so a stale owner cannot re-publish a lower one — is a
+        # structural property proven at the file level in
+        # test_service_registry.py (P1). Together they are CA-4.
         _maybe_xfail("restart_race_fencing", tier)
         harness.publish(_OWNER_PID)  # predecessor
         harness.publish(_SIBLING_PID)  # successor takes over (higher generation)

--- a/tests/daemon/test_t2_daemon_lifecycle.py
+++ b/tests/daemon/test_t2_daemon_lifecycle.py
@@ -266,19 +266,25 @@ class TestStartStopLifecycle:
 
             disc_path = t2_discovery_path(config_dir)
             assert disc_path.exists()
+            # RDR-149 P2: the discovery file is now a lease record; the
+            # connection fields live under ``endpoint`` and liveness is the
+            # lease (generation + heartbeat TTL), not a top-level pid.
             payload = json.loads(disc_path.read_text())
-            assert payload["pid"] == os.getpid()
-            assert payload["tcp_host"] == "127.0.0.1"
-            assert isinstance(payload["tcp_port"], int) and payload["tcp_port"] > 0
-            assert payload["uds_path"].endswith("t2.sock")
             assert payload["format_version"] == 1
+            assert payload["generation"] == 1
+            assert payload["owner_token"]
+            endpoint = payload["endpoint"]
+            assert endpoint["pid"] == os.getpid()
+            assert endpoint["tcp_host"] == "127.0.0.1"
+            assert isinstance(endpoint["tcp_port"], int) and endpoint["tcp_port"] > 0
+            assert endpoint["uds_path"].endswith("t2.sock")
 
             # UDS and TCP both reachable.
             uds = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            uds.connect(payload["uds_path"])
+            uds.connect(endpoint["uds_path"])
             uds.close()
             tcp = socket.create_connection(
-                (payload["tcp_host"], payload["tcp_port"]), timeout=2.0,
+                (endpoint["tcp_host"], endpoint["tcp_port"]), timeout=2.0,
             )
             tcp.close()
         finally:

--- a/tests/daemon/test_t2_multistack_race.py
+++ b/tests/daemon/test_t2_multistack_race.py
@@ -130,23 +130,15 @@ def _count_daemon_events(config_dir: Path) -> dict[str, int]:
 
 
 def _live_daemon_count(config_dir: Path) -> int:
-    """0 or 1: whether the recorded discovery pid is a live process."""
-    from nexus.daemon.t2_daemon import t2_discovery_path
+    """0 or 1: whether the discovery lease resolves to a live owner.
 
-    disc = t2_discovery_path(config_dir)
-    if not disc.exists():
-        return 0
-    try:
-        pid = json.loads(disc.read_text()).get("pid")
-    except (OSError, json.JSONDecodeError):
-        return 0
-    if not isinstance(pid, int):
-        return 0
-    try:
-        os.kill(pid, 0)
-    except (ProcessLookupError, PermissionError):
-        return 0
-    return 1
+    RDR-149 P2: T2 liveness is now lease freshness, not pid. Resolve
+    through ``find_t2_daemon`` so this counts a live daemon exactly as a
+    real client would (lease TTL, with the legacy pid-payload fallback
+    intact for an in-flight upgrade)."""
+    from nexus.daemon.discovery import find_t2_daemon
+
+    return 1 if find_t2_daemon(config_dir) is not None else 0
 
 
 def _wait_for_convergence(config_dir: Path) -> None:


### PR DESCRIPTION
RDR-149 Phase 2 (bead nexus-fx77g): the reference migration. T2 is the most complete tier, so it migrates first and the conformance suite proves no regression.

## Production seam (what moved vs what stayed)
- **start()**: the discovery record is now a `LeaseRecord` published via `ServiceRegistry`/`ServiceSupervisor` (scope = uid, so the path is the same `t2_addr.<uid>`). Liveness is the lease TTL, not pid → pid-reuse immunity + generation fencing.
- **reassert loop**: one `supervisor.heartbeat_tick()` per interval (self-heals a lost record at the same generation; logs if ever fenced).
- **stop()**: `registry.relinquish()` (own-record-only, preserving the RDR-129 reassert-cancel-before-unlink ordering).
- **Kept in T2**: the spawn-lock single-writer (RDR-128), `_reap_predecessor`, and the `_t2_ensure_running_inner` external contract (RDR-141 seam) — only its internals now resolve liveness via the lease-aware `find_t2_daemon`.

## Discovery read path
`find_t2_daemon` resolves a lease record (TTL freshness, endpoint lifted to top level so the client contract is unchanged) and falls back to the legacy pid-payload validator for an in-flight upgrade window. The resolver is tier-parameterized (`_resolve_lease_record`) so the T3 migration (P3) reuses it. T3 paths untouched.

## Conformance suite
`T2RecordHarness` now drives the same `ServiceRegistry`/`ServiceSupervisor` the daemon uses, so T2's SPEC cells (pid-reuse, generation, fencing) flip from xfail to **pass**; a ratchet meta-test asserts they stay green. The battery is now liveness-model-agnostic so one body spans pid-based T1/T3 and lease-based T2.

## Reviews (migration boundary)
Both stacked reviewers ran. They converged on one Critical — `_reap_predecessor_daemon` read top-level `pid` (absent in a lease record), defeating the version-aware graceful-drain — fixed via a pure `normalize_discovery_view` flatten (commit 2f8e2ce8), plus a format-version guard, a lease-freshness `status`, the dual-flock doc, and a supervisor-driven harness. `/conexus:phase-review-gate rdr-149 --phase 2` **PASSED**.

## Evidence (CA-2 behaviour-preserving)
exactly-one / never-zero / loser-quiet-attach (0 spawn-lost) / reassert-before-relinquish all green; RDR-140/129/141/146/128 + upgrade-e2e suites pass (339 passed / 12 xfail). Conformance: 18 pass / 12 xfail + live self-heal proof.

Refs #1112
Refs #1114