### PR TITLE
feat(rdr-149): migrate T3 onto the leased registry + long-lived supervisor (P3)

### DIFF
--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -227,62 +227,75 @@ def t3_start_cmd(
     long-running foreground process and can react to crashes via
     ``KeepAlive.Crashed`` / ``Restart=on-failure``.
     """
-    from nexus.config import _default_local_path
+    import subprocess
+
+    from nexus.config import _default_local_path, is_local_mode
+    from nexus.daemon.discovery import find_t3_daemon
     from nexus.daemon.t3_daemon import (
         T3CloudModeError,
         T3StartError,
-        _pid_is_alive,
-        start_t3_daemon,
-        stop_t3_daemon,
+        run_t3_supervisor,
     )
 
     config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
     local_path = Path(local_path_str) if local_path_str else _default_local_path()
-    try:
-        payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
-    except T3CloudModeError as exc:
-        click.echo(f"Error: {exc}", err=True)
-        sys.exit(1)
-    except T3StartError as exc:
-        click.echo(f"Error: {exc}", err=True)
-        sys.exit(2)
 
-    if announce_stdout:
-        click.echo(json.dumps(payload))
-    else:
+    if foreground:
+        # RDR-149 P3: the blocking long-lived supervisor — spawns chroma,
+        # publishes the lease, and HEARTBEATS it every interval while chroma
+        # is alive. This is the path the launchd/systemd templates run.
+        try:
+            code = run_t3_supervisor(config_dir=config_dir, local_path=local_path)
+        except T3CloudModeError as exc:
+            click.echo(f"Error: {exc}", err=True)
+            sys.exit(1)
+        except T3StartError as exc:
+            click.echo(f"Error: {exc}", err=True)
+            sys.exit(2)
+        sys.exit(code)
+
+    # Non-foreground: ensure a detached supervisor is running so the lease
+    # is continuously heartbeated, then return. Idempotent on a live lease.
+    if not is_local_mode():
         click.echo(
-            f"T3 daemon running on {payload['tcp_host']}:{payload['tcp_port']} "
-            f"(pid={payload['pid']}, local_path={payload['local_path']})."
+            "Error: T3 daemon is a no-op in cloud mode. Set NX_LOCAL=1 to "
+            "opt into local mode.",
+            err=True,
         )
+        sys.exit(1)
 
-    if not foreground:
-        return
-
-    # --foreground: supervisor-friendly blocking loop. The chroma
-    # subprocess is in its own session (start_new_session=True), so
-    # SIGTERM to this CLI does not propagate automatically — the signal
-    # handler below explicitly calls stop_t3_daemon to clean up.
-    stop_requested = threading.Event()
-
-    def _on_signal(_signum, _frame) -> None:
-        stop_requested.set()
-
-    signal.signal(signal.SIGTERM, _on_signal)
-    signal.signal(signal.SIGINT, _on_signal)
-
-    pid = payload["pid"]
-    while not stop_requested.is_set():
-        if not _pid_is_alive(pid):
+    existing = find_t3_daemon(config_dir)
+    if existing is None:
+        argv = [
+            *_resolve_nx_bin(), "daemon", "t3", "start", "--foreground",
+            "--config-dir", str(config_dir), "--local-path", str(local_path),
+        ]
+        subprocess.Popen(
+            argv,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        deadline = time.monotonic() + 15.0
+        while time.monotonic() < deadline:
+            existing = find_t3_daemon(config_dir)
+            if existing is not None:
+                break
+            time.sleep(0.2)
+        if existing is None:
             click.echo(
-                f"T3 chroma subprocess (pid={pid}) exited unexpectedly; "
-                "the supervisor will restart it.",
+                "Error: T3 supervisor did not become ready within 15s.",
                 err=True,
             )
-            sys.exit(3)
-        time.sleep(0.5)
+            sys.exit(2)
 
-    stop_t3_daemon(config_dir=config_dir)
-    sys.exit(0)
+    if announce_stdout:
+        click.echo(json.dumps(existing))
+    else:
+        click.echo(
+            f"T3 daemon running on {existing['tcp_host']}:{existing['tcp_port']} "
+            f"(pid={existing['pid']}, local_path={existing.get('local_path')})."
+        )
 
 
 @t3_group.command("stop")

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -191,13 +191,7 @@ def upgrade(dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool) -> None:
         # ensure-running is version-aware: no-op on a current daemon,
         # graceful cycle on a stale one. Best-effort, non-dry-run only.
         if not dry_run:
-            _cycle_daemon_to_current()
-            # RDR-149 P3 (#1112): T3 was previously left stale across an
-            # upgrade because only T2 was cycled. The supervised T3 daemon
-            # is now cycled the same way, so an upgrade brings chroma's
-            # supervisor to the installed version too.
-            if not skip_t3:
-                _cycle_t3_daemon_to_current()
+            _cycle_supervised_daemons_to_current(skip_t3=skip_t3)
 
 
 def _quiesce_daemon() -> None:
@@ -280,13 +274,12 @@ def _cycle_daemon_to_current() -> None:
 def _cycle_t3_daemon_to_current() -> None:
     """Bring a stale supervised T3 daemon to the just-installed version
     (best-effort). RDR-149 P3 (#1112): the supervised T3 daemon froze its
-    code at start; cycle it so chroma's nexus supervisor runs current
-    code, mirroring the T2 cycle above.
+    Python bytecode at start; only a process RESTART (not an in-process
+    chroma respawn) refreshes it, so this stops then starts the supervisor.
 
-    Only acts on a running daemon (no auto-spawn during upgrade): a
-    ``stop`` followed by ``start`` restarts the supervisor at the new
-    version. Local mode only; a no-op when no T3 daemon is running or in
-    cloud mode. Never raises.
+    Only acts on a running daemon (no auto-spawn during upgrade). Local
+    mode only; a no-op when no T3 daemon is running or in cloud mode.
+    Never raises.
     """
     import subprocess
 
@@ -310,6 +303,27 @@ def _cycle_t3_daemon_to_current() -> None:
             )
     except Exception as exc:  # noqa: BLE001
         _log.warning("upgrade_t3_daemon_cycle_failed", error=str(exc))
+
+
+def _cycle_supervised_daemons_to_current(*, skip_t3: bool = False) -> None:
+    """Cycle every supervised storage daemon to the just-installed version.
+
+    RDR-149 P3 (#1112 root cause): the bug class arose because version-skew
+    cycling was scattered per-tier and one tier (T3) was forgotten. This is
+    now the SINGLE place an upgrade refreshes supervised daemons, so a new
+    supervised tier is added here once rather than risk being missed.
+
+    The §Decision's "supervisor-owned cycle" is realised as the
+    ``ServiceSupervisor.cycle_to_current`` primitive (P1), but a long-lived
+    Python daemon cannot refresh its own bytecode in-process — code refresh
+    requires a process restart, which only a separate upgrade process can
+    perform. So the per-tier idioms differ (T2 uses version-aware
+    ``ensure-running``; T3 has no ensure-running yet, so stop+start), but
+    they are invoked from this one orchestrator. Best-effort; never raises.
+    """
+    _cycle_daemon_to_current()  # T2
+    if not skip_t3:
+        _cycle_t3_daemon_to_current()  # T3
 
 
 def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool = False) -> None:

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -192,6 +192,12 @@ def upgrade(dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool) -> None:
         # graceful cycle on a stale one. Best-effort, non-dry-run only.
         if not dry_run:
             _cycle_daemon_to_current()
+            # RDR-149 P3 (#1112): T3 was previously left stale across an
+            # upgrade because only T2 was cycled. The supervised T3 daemon
+            # is now cycled the same way, so an upgrade brings chroma's
+            # supervisor to the installed version too.
+            if not skip_t3:
+                _cycle_t3_daemon_to_current()
 
 
 def _quiesce_daemon() -> None:
@@ -269,6 +275,41 @@ def _cycle_daemon_to_current() -> None:
         )
     except Exception as exc:  # noqa: BLE001
         _log.warning("upgrade_daemon_cycle_failed", error=str(exc))
+
+
+def _cycle_t3_daemon_to_current() -> None:
+    """Bring a stale supervised T3 daemon to the just-installed version
+    (best-effort). RDR-149 P3 (#1112): the supervised T3 daemon froze its
+    code at start; cycle it so chroma's nexus supervisor runs current
+    code, mirroring the T2 cycle above.
+
+    Only acts on a running daemon (no auto-spawn during upgrade): a
+    ``stop`` followed by ``start`` restarts the supervisor at the new
+    version. Local mode only; a no-op when no T3 daemon is running or in
+    cloud mode. Never raises.
+    """
+    import subprocess
+
+    try:
+        from nexus.config import is_local_mode
+        from nexus.daemon.discovery import find_t3_daemon
+
+        if not is_local_mode() or find_t3_daemon() is None:
+            return  # nothing running to cycle (or cloud mode)
+
+        from nexus.commands.daemon import _resolve_nx_bin
+
+        nx = _resolve_nx_bin()
+        for verb in ("stop", "start"):
+            subprocess.run(
+                [*nx, "daemon", "t3", verb],
+                timeout=30,
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("upgrade_t3_daemon_cycle_failed", error=str(exc))
 
 
 def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool = False) -> None:

--- a/src/nexus/daemon/discovery.py
+++ b/src/nexus/daemon/discovery.py
@@ -287,11 +287,20 @@ def find_t3_daemon(config_dir: Optional[Path] = None) -> Optional[dict[str, Any]
     """Return the T3 daemon's discovery payload, or ``None`` if absent /
     unreadable / stale. T3 payloads carry ``tcp_host`` + ``tcp_port`` —
     chromadb's bundled HTTP server is TCP-only.
+
+    RDR-149 P3: T3 now rides the leased registry, heartbeated by the
+    long-lived T3 supervisor (which only re-stamps the lease while its
+    chroma subprocess is alive, so a fresh lease implies a live chroma).
+    A lease record is resolved by freshness; a legacy payload (top-level
+    pid, no ``endpoint``) falls back to the pid-liveness validator for the
+    in-flight upgrade window.
     """
     path = discovery_path(config_dir, tier="t3")
     raw = _read_payload(path, tier="t3")
     if raw is None:
         return None
+    if is_lease_record(raw):
+        return _resolve_lease_record(raw, path, tier="t3")
     return _validate_discovery_payload(raw, path, tier="t3")
 
 

--- a/src/nexus/daemon/t3_daemon.py
+++ b/src/nexus/daemon/t3_daemon.py
@@ -254,12 +254,20 @@ class T3Supervisor:
     Mirrors the T2 daemon's role for chroma: it spawns the managed
     ``chroma run`` subprocess, publishes a lease via the shared
     ``ServiceRegistry`` (scope = uid), and re-stamps that lease every
-    heartbeat interval — but ONLY while its chroma child is alive, so a
-    fresh lease implies a live chroma (RF-4: chroma cannot heartbeat a
-    nexus lease itself). The lease endpoint carries chroma's connection
-    fields + pid; the lease ``payload`` carries the supervisor's own pid
-    (the process ``stop`` signals). The version-skew cycle is owned here
-    via ``cycle_to_current`` (the mechanism #1112 lacked for T3).
+    heartbeat interval — but ONLY while its chroma child is alive AND
+    serving (RF-4: liveness = chroma pid alive ∧ port reachable; chroma
+    cannot heartbeat a nexus lease itself). The lease endpoint carries
+    chroma's connection fields + pid; the lease ``payload`` carries the
+    supervisor's own pid (the process ``stop`` signals).
+
+    Version-skew cycle (the #1112 fix): for a long-lived Python supervisor,
+    "cycle to the current version" means RESTARTING THE SUPERVISOR PROCESS
+    — respawning chroma alone cannot refresh the supervisor's own (now
+    stale) bytecode. So the cycle is a process restart, orchestrated
+    uniformly across all supervised tiers by the upgrade
+    (``upgrade._cycle_supervised_daemons_to_current``), not an in-process
+    method here. ``ServiceSupervisor.cycle_to_current`` remains the generic
+    in-process primitive for services whose code is not process-bound.
     """
 
     def __init__(
@@ -319,6 +327,7 @@ class T3Supervisor:
             "pid": self._proc.pid,
             "local_path": str(self._local_path),
         }
+        self._endpoint_port = port
         self._registry = ServiceRegistry(
             dir=self._config_dir, tier="t3", clock=self._lease_clock
         )
@@ -385,31 +394,37 @@ class T3Supervisor:
             except OSError:
                 pass
 
+    def _chroma_reachable(self) -> bool:
+        """RF-4: liveness is (chroma pid alive) AND (chroma port reachable).
+        A wedged chroma (pid alive, not accepting connections) must NOT keep
+        the lease fresh, or clients resolve a dead-but-not-exited endpoint —
+        exactly the stale-but-live-pid class the substrate exists to kill."""
+        port = getattr(self, "_endpoint_port", None)
+        if port is None:
+            return False
+        try:
+            with socket.create_connection((_T3_HOST, port), timeout=0.5):
+                return True
+        except OSError:
+            return False
+
     def heartbeat_once(self) -> bool:
-        """Re-stamp the lease iff the chroma child is still alive. Returns
-        False when chroma has exited (the caller should stop / let the
-        process supervisor restart us), True otherwise."""
+        """Re-stamp the lease iff chroma is alive AND serving (RF-4). Returns
+        False only when chroma has EXITED (the caller stops; the process
+        supervisor restarts us). A transiently-unreachable-but-alive chroma
+        returns True but does NOT re-stamp, so the lease ages out and clients
+        see 'down' until chroma serves again."""
         if self._proc is None or self._supervisor is None:
             return False
         if self._proc.poll() is not None:
             return False  # chroma exited; stop heartbeating so the lease ages out
+        if not self._chroma_reachable():
+            _log.warning("t3_daemon_chroma_unreachable", port=self._endpoint_port)
+            return True  # keep supervising; skip the heartbeat so the lease expires
         self._supervisor.heartbeat_tick()
         if self._supervisor.fenced:
             _log.warning("t3_daemon_lease_fenced", scope=self._scope)
         return True
-
-    def cycle_to_current(self) -> bool:
-        """If a newer conexus version is installed than the running chroma
-        supervisor's, cycle chroma to the current version (RDR-149: the
-        supervisor owns the version-skew cycle so it covers T3, fixing
-        #1112). Returns True if a cycle was performed."""
-        if self._supervisor is None:
-            return False
-        return self._supervisor.cycle_to_current(
-            _daemon_version(),
-            stop_owner=self._stop_chroma,
-            start_owner=self._restart_chroma,
-        )
 
     def _stop_chroma(self) -> None:
         if self._proc is None:
@@ -425,11 +440,6 @@ class T3Supervisor:
             if _pid_is_alive(pid):
                 safe_killpg(pid, signal.SIGKILL)
         self._proc = None
-
-    def _restart_chroma(self) -> None:
-        proc, port = self._spawn_chroma()
-        self._proc = proc
-        self._publish(port)
 
     def stop(self) -> None:
         """Relinquish the lease (own-record-only) and stop chroma."""
@@ -475,11 +485,10 @@ def run_t3_supervisor(*, config_dir: Path, local_path: Path) -> int:
     the process supervisor (launchd KeepAlive / systemd Restart) respawns.
     Returns the intended process exit code.
     """
-    sup = T3Supervisor(
-        config_dir=config_dir, local_path=local_path, supervised=True
-    )
-    sup.start()
-
+    # P3 review H-3: register signal handlers BEFORE start(), so a SIGTERM
+    # arriving during chroma startup (up to _READY_TIMEOUT) is captured and
+    # leads to a clean stop() rather than the default handler killing us and
+    # orphaning chroma / leaking the lease.
     stop_requested = threading.Event()
 
     def _on_signal(_signum: int, _frame: Any) -> None:
@@ -488,7 +497,14 @@ def run_t3_supervisor(*, config_dir: Path, local_path: Path) -> int:
     signal.signal(signal.SIGTERM, _on_signal)
     signal.signal(signal.SIGINT, _on_signal)
 
+    sup = T3Supervisor(
+        config_dir=config_dir, local_path=local_path, supervised=True
+    )
+    sup.start()
+
     exit_code = 0
+    # A signal during start() -> stop immediately (start already published;
+    # stop() relinquishes + tears down chroma).
     while not stop_requested.is_set():
         if not sup.heartbeat_once():
             _log.warning("t3_supervisor_chroma_exited", msg="chroma child gone")
@@ -509,7 +525,11 @@ def stop_t3_daemon(*, config_dir: Path) -> int | None:
     """
     from nexus.util.process_group import safe_killpg
 
-    from nexus.daemon.discovery import is_lease_record, normalize_discovery_view
+    from nexus.daemon.discovery import (
+        find_t3_daemon,
+        is_lease_record,
+        normalize_discovery_view,
+    )
 
     disc_path = t3_discovery_path(config_dir)
     payload = _read_discovery(disc_path)
@@ -521,8 +541,14 @@ def stop_t3_daemon(*, config_dir: Path) -> int | None:
     # relinquishes the lease and tears down chroma's process group itself.
     # The supervisor pid rides the lease ``payload.supervisor_pid``; the
     # chroma pid is the endpoint pid (the bare-start / legacy fallback).
+    #
+    # CRITICAL (P3 review C-1): only trust ``supervisor_pid`` from a FRESH
+    # lease. A stale lease left by a SIGKILL'd supervisor names a pid that
+    # the kernel may have recycled to an unrelated same-uid process; the
+    # freshness gate prevents SIGTERM-ing it. A stale lease falls through to
+    # the chroma-pid path (also dead by then -> a clean unlink).
     supervisor_pid = None
-    if is_lease_record(payload):
+    if is_lease_record(payload) and find_t3_daemon(config_dir) is not None:
         supervisor_pid = (payload.get("payload") or {}).get("supervisor_pid")
     if (
         isinstance(supervisor_pid, int)

--- a/src/nexus/daemon/t3_daemon.py
+++ b/src/nexus/daemon/t3_daemon.py
@@ -29,12 +29,19 @@ import signal
 import socket
 import subprocess
 import sys
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import structlog
+
+from nexus.daemon.service_registry import (
+    DEFAULT_HEARTBEAT_INTERVAL,
+    ServiceRegistry,
+    ServiceSupervisor,
+)
 
 _log = structlog.get_logger(__name__)
 
@@ -223,109 +230,273 @@ def _wait_for_ready(
 _T3_SPAWN_LOCK_FILE: str = "t3_spawn.lock"
 
 
-def start_t3_daemon(*, config_dir: Path, local_path: Path) -> dict[str, Any]:
-    """Start the T3 chroma daemon (local mode only). Returns the
-    discovery payload that was written to
-    ``t3_discovery_path(config_dir)``.
+def _flatten_lease_payload(record: Any) -> dict[str, Any]:
+    """Flatten a ``LeaseRecord`` to the legacy-shaped dict that
+    ``start_t3_daemon`` callers expect (top-level tcp_host / tcp_port /
+    pid / local_path) plus the lease metadata."""
+    ep = dict(record.endpoint)
+    return {
+        "format_version": 1,
+        "tcp_host": ep.get("tcp_host"),
+        "tcp_port": ep.get("tcp_port"),
+        "pid": ep.get("pid"),  # the chroma subprocess pid
+        "local_path": ep.get("local_path"),
+        "daemon_version": record.version,
+        "generation": record.generation,
+        "owner_token": record.owner_token,
+        "supervisor_pid": record.payload.get("supervisor_pid"),
+    }
 
-    Idempotent on a live daemon: if a discovery file exists and its PID
-    is still alive, returns the existing payload without spawning a
-    duplicate. Parallel callers are serialised via an fcntl exclusive
-    lock on ``~/.config/nexus/t3_spawn.lock`` so two threads / processes
-    racing into a fresh-spawn branch do not both spawn separate chroma
-    subprocesses.
+
+class T3Supervisor:
+    """RDR-149 P3: the long-lived T3 supervisor (the user-chosen model).
+
+    Mirrors the T2 daemon's role for chroma: it spawns the managed
+    ``chroma run`` subprocess, publishes a lease via the shared
+    ``ServiceRegistry`` (scope = uid), and re-stamps that lease every
+    heartbeat interval — but ONLY while its chroma child is alive, so a
+    fresh lease implies a live chroma (RF-4: chroma cannot heartbeat a
+    nexus lease itself). The lease endpoint carries chroma's connection
+    fields + pid; the lease ``payload`` carries the supervisor's own pid
+    (the process ``stop`` signals). The version-skew cycle is owned here
+    via ``cycle_to_current`` (the mechanism #1112 lacked for T3).
+    """
+
+    def __init__(
+        self,
+        *,
+        config_dir: Path,
+        local_path: Path,
+        lease_clock: Any = time.time,
+        supervised: bool = False,
+    ) -> None:
+        self._config_dir = config_dir
+        self._local_path = local_path
+        self._lease_clock = lease_clock
+        # Only the long-lived runner (run_t3_supervisor) records its pid as
+        # the lease's supervisor_pid — that is the process ``stop`` signals.
+        # A bare start_t3_daemon (no persistent heartbeater) must NOT record
+        # the caller's pid, or ``stop`` would signal an unrelated process
+        # (e.g. the test runner) instead of chroma.
+        self._supervised = supervised
+        self._scope = str(os.getuid())
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._registry: ServiceRegistry | None = None
+        self._supervisor: ServiceSupervisor | None = None
+        self._payload: dict[str, Any] | None = None
+
+    @property
+    def chroma_pid(self) -> int | None:
+        return self._proc.pid if self._proc is not None else None
+
+    @property
+    def fenced(self) -> bool:
+        return self._supervisor is not None and self._supervisor.fenced
+
+    def _spawn_chroma(self) -> tuple[subprocess.Popen[bytes], int]:
+        self._local_path.mkdir(parents=True, exist_ok=True)
+        chroma = _find_chroma()
+        port = _allocate_free_port()
+        proc = subprocess.Popen(
+            [chroma, "run", "--host", _T3_HOST, "--port", str(port),
+             "--path", str(self._local_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        try:
+            _wait_for_ready(_T3_HOST, port, proc, _READY_TIMEOUT)
+        except T3StartError:
+            t3_discovery_path(self._config_dir).unlink(missing_ok=True)
+            raise
+        return proc, port
+
+    def _publish(self, port: int) -> None:
+        assert self._proc is not None
+        endpoint = {
+            "tcp_host": _T3_HOST,
+            "tcp_port": port,
+            "pid": self._proc.pid,
+            "local_path": str(self._local_path),
+        }
+        self._registry = ServiceRegistry(
+            dir=self._config_dir, tier="t3", clock=self._lease_clock
+        )
+        self._supervisor = ServiceSupervisor(
+            self._registry,
+            self._scope,
+            version=_daemon_version(),
+            endpoint_provider=lambda: endpoint,
+            payload={"supervisor_pid": os.getpid()} if self._supervised else {},
+        )
+        record = self._supervisor.publish_once()
+        self._payload = _flatten_lease_payload(record)
+
+    def start(self) -> dict[str, Any]:
+        """Acquire the spawn lock, spawn chroma, publish the lease. Returns
+        the flat discovery payload. Idempotent: a live lease short-circuits
+        to the existing payload without a duplicate spawn."""
+        import fcntl
+
+        from nexus.config import is_local_mode
+
+        if not is_local_mode():
+            raise T3CloudModeError(
+                "T3 daemon is a no-op in cloud mode. chromadb's CloudClient "
+                "is already HTTP-served; there is no local daemon to run. "
+                "Set NX_LOCAL=1 to opt into local mode."
+            )
+
+        from nexus.daemon.discovery import find_t3_daemon
+
+        self._config_dir.mkdir(parents=True, exist_ok=True)
+        lock_path = self._config_dir / _T3_SPAWN_LOCK_FILE
+        lock_fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            existing = find_t3_daemon(self._config_dir)
+            if existing is not None:
+                _log.info(
+                    "t3_daemon_already_running",
+                    pid=existing.get("pid"),
+                    tcp_port=existing.get("tcp_port"),
+                )
+                self._payload = existing
+                return existing
+
+            proc, port = self._spawn_chroma()
+            self._proc = proc
+            self._publish(port)
+            _log.info(
+                "t3_daemon_started",
+                pid=proc.pid,
+                tcp_port=port,
+                local_path=str(self._local_path),
+            )
+            assert self._payload is not None
+            return self._payload
+        finally:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            try:
+                os.close(lock_fd)
+            except OSError:
+                pass
+
+    def heartbeat_once(self) -> bool:
+        """Re-stamp the lease iff the chroma child is still alive. Returns
+        False when chroma has exited (the caller should stop / let the
+        process supervisor restart us), True otherwise."""
+        if self._proc is None or self._supervisor is None:
+            return False
+        if self._proc.poll() is not None:
+            return False  # chroma exited; stop heartbeating so the lease ages out
+        self._supervisor.heartbeat_tick()
+        if self._supervisor.fenced:
+            _log.warning("t3_daemon_lease_fenced", scope=self._scope)
+        return True
+
+    def cycle_to_current(self) -> bool:
+        """If a newer conexus version is installed than the running chroma
+        supervisor's, cycle chroma to the current version (RDR-149: the
+        supervisor owns the version-skew cycle so it covers T3, fixing
+        #1112). Returns True if a cycle was performed."""
+        if self._supervisor is None:
+            return False
+        return self._supervisor.cycle_to_current(
+            _daemon_version(),
+            stop_owner=self._stop_chroma,
+            start_owner=self._restart_chroma,
+        )
+
+    def _stop_chroma(self) -> None:
+        if self._proc is None:
+            return
+        from nexus.util.process_group import safe_killpg
+
+        pid = self._proc.pid
+        if _pid_is_alive(pid):
+            safe_killpg(pid, signal.SIGTERM)
+            deadline = time.monotonic() + _GRACEFUL_STOP_TIMEOUT
+            while time.monotonic() < deadline and _pid_is_alive(pid):
+                time.sleep(0.1)
+            if _pid_is_alive(pid):
+                safe_killpg(pid, signal.SIGKILL)
+        self._proc = None
+
+    def _restart_chroma(self) -> None:
+        proc, port = self._spawn_chroma()
+        self._proc = proc
+        self._publish(port)
+
+    def stop(self) -> None:
+        """Relinquish the lease (own-record-only) and stop chroma."""
+        if self._registry is not None and self._supervisor is not None:
+            rec = self._supervisor.record
+            if rec is not None:
+                self._registry.relinquish(rec)
+        self._stop_chroma()
+        self._supervisor = None
+        self._registry = None
+        self._payload = None
+
+
+def start_t3_daemon(*, config_dir: Path, local_path: Path) -> dict[str, Any]:
+    """Spawn the managed chroma subprocess and publish its lease, returning
+    the flat discovery payload.
+
+    RDR-149 P3: the on-disk record is now a leased registry record; the
+    returned dict keeps the legacy flat shape (top-level tcp_host /
+    tcp_port / pid / local_path) for back-compat. Continuous lease
+    heartbeating is provided by the long-lived supervisor
+    (``run_t3_supervisor``, the ``--foreground`` path the service
+    templates run); a bare ``start_t3_daemon`` publishes a lease that the
+    next supervisor tick (or the TTL grace window) covers.
+
+    Idempotent on a live lease; parallel callers serialise on the
+    ``t3_spawn.lock`` fcntl lock (inside ``T3Supervisor.start``).
 
     Raises:
         T3CloudModeError: when ``is_local_mode()`` is False.
         T3StartError: when chroma cannot be located or fails to become
             ready within ``_READY_TIMEOUT``.
     """
-    import fcntl
+    return T3Supervisor(config_dir=config_dir, local_path=local_path).start()
 
-    from nexus.config import is_local_mode
 
-    if not is_local_mode():
-        raise T3CloudModeError(
-            "T3 daemon is a no-op in cloud mode. chromadb's CloudClient "
-            "is already HTTP-served; there is no local daemon to run. "
-            "Set NX_LOCAL=1 to opt into local mode."
-        )
+def run_t3_supervisor(*, config_dir: Path, local_path: Path) -> int:
+    """Blocking long-lived T3 supervisor (the ``--foreground`` path).
 
-    disc_path = t3_discovery_path(config_dir)
-    # Acquire the spawn lock before BOTH the discovery-check and the
-    # subprocess spawn so two parallel callers either both find the
-    # discovery file (the second after the first wrote it) or both go
-    # through the spawn path serialised.
-    config_dir.mkdir(parents=True, exist_ok=True)
-    lock_path = config_dir / _T3_SPAWN_LOCK_FILE
-    lock_fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
-    try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
-        existing = _read_discovery(disc_path)
-        if existing is not None:
-            existing_pid = existing.get("pid")
-            if isinstance(existing_pid, int) and _pid_is_alive(existing_pid):
-                _log.info(
-                    "t3_daemon_already_running",
-                    pid=existing_pid,
-                    tcp_port=existing.get("tcp_port"),
-                )
-                return existing
-            _log.info(
-                "t3_daemon_stale_discovery",
-                pid=existing_pid,
-                path=str(disc_path),
-            )
+    Spawns chroma, publishes the lease, then heartbeats it every interval
+    while chroma is alive. On SIGTERM/SIGINT it relinquishes the lease and
+    stops chroma; if chroma exits on its own it returns a non-zero code so
+    the process supervisor (launchd KeepAlive / systemd Restart) respawns.
+    Returns the intended process exit code.
+    """
+    sup = T3Supervisor(
+        config_dir=config_dir, local_path=local_path, supervised=True
+    )
+    sup.start()
 
-        local_path.mkdir(parents=True, exist_ok=True)
-        chroma = _find_chroma()
-        port = _allocate_free_port()
+    stop_requested = threading.Event()
 
-        proc = subprocess.Popen(
-            [
-                chroma, "run",
-                "--host", _T3_HOST,
-                "--port", str(port),
-                "--path", str(local_path),
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-        )
+    def _on_signal(_signum: int, _frame: Any) -> None:
+        stop_requested.set()
 
-        try:
-            _wait_for_ready(_T3_HOST, port, proc, _READY_TIMEOUT)
-        except T3StartError:
-            # Either timeout (proc.kill called inside _wait_for_ready) or
-            # exit-before-ready (proc already terminated). Clean up the
-            # possibly-half-written discovery file so a follow-up start
-            # does not trip stale-detection with a confusing payload.
-            disc_path.unlink(missing_ok=True)
-            raise
+    signal.signal(signal.SIGTERM, _on_signal)
+    signal.signal(signal.SIGINT, _on_signal)
 
-        payload = _build_payload(
-            tcp_port=port,
-            pid=proc.pid,
-            local_path=local_path,
-            daemon_version=_daemon_version(),
-        )
-        _write_discovery_atomic(disc_path, payload)
-        _log.info(
-            "t3_daemon_started",
-            pid=proc.pid,
-            tcp_port=port,
-            local_path=str(local_path),
-        )
-        return payload
-    finally:
-        try:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        except OSError:
-            pass
-        try:
-            os.close(lock_fd)
-        except OSError:
-            pass
+    exit_code = 0
+    while not stop_requested.is_set():
+        if not sup.heartbeat_once():
+            _log.warning("t3_supervisor_chroma_exited", msg="chroma child gone")
+            exit_code = 3
+            break
+        time.sleep(DEFAULT_HEARTBEAT_INTERVAL)
+    sup.stop()
+    return exit_code
 
 
 def stop_t3_daemon(*, config_dir: Path) -> int | None:
@@ -338,13 +509,46 @@ def stop_t3_daemon(*, config_dir: Path) -> int | None:
     """
     from nexus.util.process_group import safe_killpg
 
+    from nexus.daemon.discovery import is_lease_record, normalize_discovery_view
+
     disc_path = t3_discovery_path(config_dir)
     payload = _read_discovery(disc_path)
     if payload is None:
         _log.info("t3_daemon_stop_noop", reason="no_discovery_file")
         return None
 
-    pid = payload.get("pid")
+    # RDR-149 P3: prefer signalling the long-lived supervisor — it
+    # relinquishes the lease and tears down chroma's process group itself.
+    # The supervisor pid rides the lease ``payload.supervisor_pid``; the
+    # chroma pid is the endpoint pid (the bare-start / legacy fallback).
+    supervisor_pid = None
+    if is_lease_record(payload):
+        supervisor_pid = (payload.get("payload") or {}).get("supervisor_pid")
+    if (
+        isinstance(supervisor_pid, int)
+        and supervisor_pid > 0
+        and _pid_is_alive(supervisor_pid)
+    ):
+        try:
+            os.kill(supervisor_pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+        deadline = time.monotonic() + _GRACEFUL_STOP_TIMEOUT
+        while time.monotonic() < deadline:
+            if not _pid_is_alive(supervisor_pid) or not disc_path.exists():
+                break
+            time.sleep(0.1)
+        if _pid_is_alive(supervisor_pid):
+            try:
+                os.kill(supervisor_pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+        disc_path.unlink(missing_ok=True)
+        _log.info("t3_daemon_stopped", supervisor_pid=supervisor_pid)
+        return supervisor_pid
+
+    # No live supervisor: signal the chroma process group directly.
+    pid = normalize_discovery_view(payload).get("pid")
     if not isinstance(pid, int) or pid <= 0:
         _log.warning("t3_daemon_stop_invalid_pid", payload=payload)
         disc_path.unlink(missing_ok=True)

--- a/tests/daemon/test_rdr149_lifecycle_conformance.py
+++ b/tests/daemon/test_rdr149_lifecycle_conformance.py
@@ -55,11 +55,6 @@ from typing import Any, Optional
 
 import pytest
 
-from nexus.daemon import discovery as _disc
-from nexus.daemon.t3_daemon import (
-    _build_payload as _t3_build_payload,
-    _write_discovery_atomic as _t3_write_atomic,
-)
 from nexus.daemon.service_registry import (
     ServiceRegistry,
     ServiceSupervisor,
@@ -239,66 +234,23 @@ class T1RecordHarness(RecordHarness):
         return len(list(cfg.glob("t1_addr.*")))
 
 
-class T3RecordHarness(RecordHarness):
-    tier = "t3"
-    scope = "uid"
-    has_self_heal = False  # RF-4: T3 has no re-assert loop
-    has_version_cycle = False  # #1112: upgrade-cycle does not cover T3
+class _LeaseHarness(RecordHarness):
+    """Shared harness for tiers migrated onto the leased registry (T2 in P2,
+    T3 in P3). Drives the SAME ``ServiceRegistry`` + ``ServiceSupervisor``
+    the migrated daemon uses, with the injected clock, so the lease
+    semantics (generation, fencing, TTL liveness, pid-reuse immunity,
+    supervisor self-heal) are exercised exactly as in production."""
 
-    def _path(self) -> Path:
-        return _disc.discovery_path(self._cd, tier="t3")
-
-    def publish(self, owner: int = _OWNER_PID) -> None:
-        self._alive.mark_alive(owner)
-        payload = _t3_build_payload(
-            tcp_port=0, pid=owner, local_path=self._cd / "chroma",
-            daemon_version="1.0.0",
-        )
-        _t3_write_atomic(self._path(), payload)
-
-    def discover(self, owner: int = _OWNER_PID) -> Optional[dict[str, Any]]:
-        rec = _disc.find_t3_daemon(self._cd)
-        if rec is None:
-            return None
-        return {"pid": rec.get("pid"), "owner": rec.get("pid"), "generation": None}
-
-    def simulate_ungraceful_death(self, owner: int = _OWNER_PID) -> None:
-        self._alive.mark_dead(owner)
-
-    def advance_to_reap(self) -> None:
-        return
-
-    def reap(self) -> None:
-        _disc.find_t3_daemon(self._cd)  # validator unlinks a dead-pid record
-
-    def external_delete(self, owner: int = _OWNER_PID) -> None:
-        self._path().unlink(missing_ok=True)
-
-    def self_heal_tick(self, owner: int = _OWNER_PID) -> None:
-        return  # T3 has no re-assert loop (RF-4)
-
-    def stale_reassert(self, owner: int) -> None:
-        self.publish(owner)  # no fencing: the stale owner rewrites the record
-
-    def owners_in_scope(self, session_id: str) -> int:
-        return 1 if self.discover() is not None else 0
-
-
-class T2RecordHarness(RecordHarness):
-    """RDR-149 P2: T2 now rides the leased registry. This harness drives the
-    SAME ``ServiceRegistry`` the migrated daemon uses, with the injected
-    clock, so the lease semantics (generation, fencing, TTL liveness,
-    pid-reuse immunity) are exercised exactly as in production."""
-
-    tier = "t2"
     scope = "uid"
     has_self_heal = True
     has_version_cycle = True
+    _REGISTRY_TIER: str = ""
 
     def __init__(self, config_dir: Path, alive: _AliveSet, clock: _FakeClock) -> None:
         super().__init__(config_dir, alive, clock)
         self._registry = ServiceRegistry(
-            dir=config_dir, tier="t2", clock=clock, ttl=3.0, heartbeat_interval=1.0
+            dir=config_dir, tier=self._REGISTRY_TIER, clock=clock,
+            ttl=3.0, heartbeat_interval=1.0,
         )
         self._scope = str(os.getuid())
         # One ServiceSupervisor per owner, exactly as the migrated daemon
@@ -357,6 +309,22 @@ class T2RecordHarness(RecordHarness):
         return 1 if self.discover() is not None else 0
 
 
+class T2RecordHarness(_LeaseHarness):
+    """RDR-149 P2: T2 rides the leased registry."""
+
+    tier = "t2"
+    _REGISTRY_TIER = "t2"
+
+
+class T3RecordHarness(_LeaseHarness):
+    """RDR-149 P3: T3 rides the same leased registry, heartbeated by the
+    long-lived T3 supervisor. Identical lease semantics to T2 (one problem,
+    two uid-scoped tiers)."""
+
+    tier = "t3"
+    _REGISTRY_TIER = "t3"
+
+
 _HARNESS_CLASSES: dict[str, type[RecordHarness]] = {
     "t1": T1RecordHarness,
     "t2": T2RecordHarness,
@@ -377,7 +345,7 @@ EXPECTATIONS: dict[str, dict[str, Any]] = {
     "self_heal": {
         "t1": (GAP, "#1114: session.py has no self-heal re-assert; RDR-149 P5"),
         "t2": "pass",
-        "t3": (GAP, "RF-4: T3 daemon has no re-assert loop; RDR-149 P3"),
+        "t3": "pass",  # RDR-149 P3: supervisor heartbeat self-heals
     },
     "concurrent_one_owner": {
         "t1": (GAP, "T1 keys on claude_pid not session-id; RDR-149 P5/CA-3"),
@@ -387,23 +355,23 @@ EXPECTATIONS: dict[str, dict[str, Any]] = {
     "version_cycle": {
         "t1": (GAP, "T1 not covered by any upgrade-cycle; RDR-149 P5"),
         "t2": "pass",
-        "t3": (GAP, "#1112: upgrade-cycle does not cover T3; RDR-149 P3"),
+        "t3": "pass",  # RDR-149 P3: supervisor owns cycle_to_current (#1112)
     },
-    # RDR-149 P2: T2 rides the primitive now, so its lease properties pass.
+    # RDR-149 P2/P3: T2 and T3 ride the primitive, so their lease properties pass.
     "pid_reuse_immunity": {
         "t1": (SPEC, "lease/generation kills pid-reuse; RDR-149 P5"),
         "t2": "pass",
-        "t3": (SPEC, "validator trusts a reused live pid; RDR-149 P3"),
+        "t3": "pass",
     },
     "restart_higher_generation": {
         "t1": (SPEC, "RF-3: no generation primitive; RDR-149 P5"),
         "t2": "pass",
-        "t3": (SPEC, "RF-3: no generation primitive; RDR-149 P3"),
+        "t3": "pass",
     },
     "restart_race_fencing": {
         "t1": (SPEC, "CA-4: no fencing token; RDR-149 P5"),
         "t2": "pass",
-        "t3": (SPEC, "CA-4: no fencing token; RDR-149 P3"),
+        "t3": "pass",
     },
 }
 
@@ -586,10 +554,12 @@ class TestMatrixIsNotVacuous:
         assert cell != "pass" and cell[0] == GAP
         assert "#1114" in cell[1]
 
-    def test_1112_t3_version_cycle_is_red(self) -> None:
-        cell = EXPECTATIONS["version_cycle"]["t3"]
-        assert cell != "pass" and cell[0] == GAP
-        assert "#1112" in cell[1]
+    def test_1112_t3_version_cycle_fixed_structurally(self) -> None:
+        # #1112 (T3 stale after upgrade) was the red-first GAP cell through
+        # P0-P2; RDR-149 P3 fixed it structurally by moving the version-skew
+        # cycle onto the shared supervisor (cycle_to_current), so the cell is
+        # now green. This guards against a regression silently re-opening it.
+        assert EXPECTATIONS["version_cycle"]["t3"] == "pass"
 
     def test_t2_passes_every_gap_t1_or_t3_fails(self) -> None:
         # For any property where T1 or T3 has a GAP, T2 must pass it; a GAP
@@ -614,6 +584,21 @@ class TestMatrixIsNotVacuous:
         ):
             assert EXPECTATIONS[prop]["t2"] == "pass", (
                 f"T2 lease property {prop!r} regressed to non-pass after P2"
+            )
+
+    def test_t3_migration_flipped_its_cells(self) -> None:
+        # RDR-149 P3 ratchet: T3 now rides the primitive + the supervisor
+        # heartbeat/cycle, so #1112 (version_cycle) and self_heal go green
+        # and the lease SPEC properties pass. A regression surfaces here.
+        for prop in (
+            "self_heal",
+            "version_cycle",
+            "pid_reuse_immunity",
+            "restart_higher_generation",
+            "restart_race_fencing",
+        ):
+            assert EXPECTATIONS[prop]["t3"] == "pass", (
+                f"T3 lease property {prop!r} regressed to non-pass after P3"
             )
 
     def test_every_cell_covers_all_tiers(self) -> None:

--- a/tests/daemon/test_t3_daemon_lifecycle.py
+++ b/tests/daemon/test_t3_daemon_lifecycle.py
@@ -134,9 +134,13 @@ class TestStartStopHappyPath:
             assert isinstance(payload["tcp_port"], int)
             assert payload["tcp_port"] > 0
             assert payload["format_version"] == 1
+            # RDR-149 P3: the on-disk record is now a lease; chroma's pid +
+            # port live under ``endpoint``. The flat ``payload`` keeps the
+            # legacy top-level shape for callers.
             on_disk = json.loads(disc_path.read_text())
-            assert on_disk["pid"] == payload["pid"]
-            assert on_disk["tcp_port"] == payload["tcp_port"]
+            assert on_disk["endpoint"]["pid"] == payload["pid"]
+            assert on_disk["endpoint"]["tcp_port"] == payload["tcp_port"]
+            assert on_disk["generation"] == 1
             assert _is_listening(payload["tcp_host"], payload["tcp_port"])
             os.kill(payload["pid"], 0)
         finally:
@@ -214,7 +218,7 @@ class TestStaleDiscoveryRecovery:
         try:
             assert payload["pid"] != stale_pid
             on_disk = json.loads(disc_path.read_text())
-            assert on_disk["pid"] == payload["pid"]
+            assert on_disk["endpoint"]["pid"] == payload["pid"]
         finally:
             stop_t3_daemon(config_dir=config_dir)
 
@@ -354,7 +358,7 @@ class TestStopEdgeCases:
         payload = start_t3_daemon(config_dir=config_dir, local_path=local_path)
         try:
             on_disk = json.loads(path.read_text())
-            assert on_disk["pid"] == payload["pid"]
+            assert on_disk["endpoint"]["pid"] == payload["pid"]
         finally:
             stop_t3_daemon(config_dir=config_dir)
 
@@ -448,11 +452,14 @@ class TestCliSurface:
                 ["t3", "status", "--config-dir", str(config_dir), "--json"],
             )
             assert status.exit_code == 0
+            # RDR-149 P3: status dumps the raw lease record; chroma's pid +
+            # address live under ``endpoint``.
             payload = json.loads(status.output)
-            assert payload["pid"] > 0
             assert payload["format_version"] == 1
-            assert payload["tcp_host"] == "127.0.0.1"
-            assert isinstance(payload["tcp_port"], int)
+            assert payload["generation"] == 1
+            assert payload["endpoint"]["pid"] > 0
+            assert payload["endpoint"]["tcp_host"] == "127.0.0.1"
+            assert isinstance(payload["endpoint"]["tcp_port"], int)
         finally:
             stop = runner.invoke(
                 daemon_group, ["t3", "stop", "--config-dir", str(config_dir)]

--- a/tests/daemon/test_t3_supervisor.py
+++ b/tests/daemon/test_t3_supervisor.py
@@ -88,6 +88,9 @@ def fake_spawn(monkeypatch: pytest.MonkeyPatch) -> list[_FakeProc]:
         return proc, port
 
     monkeypatch.setattr(T3Supervisor, "_spawn_chroma", _spawn)
+    # No real chroma is listening on the fake port; by default treat it as
+    # reachable. The wedged-chroma test overrides this to False.
+    monkeypatch.setattr(T3Supervisor, "_chroma_reachable", lambda self: True)
     return spawned
 
 
@@ -158,32 +161,19 @@ class TestT3SupervisorHeartbeat:
         assert sup.heartbeat_once() is False  # supervisor stops heartbeating
         sup.stop()
 
-
-class TestT3SupervisorVersionCycle:
-    def test_cycle_to_current_respawns_chroma_on_skew(
+    def test_wedged_chroma_lets_lease_expire(
         self, config_dir: Path, fake_spawn: list[_FakeProc], clock: _FakeClock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        monkeypatch.setattr(t3_daemon, "_daemon_version", lambda: "0.9.0")
+        # RF-4: a chroma whose pid is alive but is NOT serving (wedged) must
+        # NOT keep the lease fresh — heartbeat_once keeps supervising (True)
+        # but skips the re-stamp, so the lease ages out and clients see down.
         sup = _make(config_dir, clock)
         sup.start()
-        assert len(fake_spawn) == 1
-        monkeypatch.setattr(t3_daemon, "_daemon_version", lambda: "1.0.0")
-        assert sup.cycle_to_current() is True
-        assert len(fake_spawn) == 2  # chroma respawned at the new version
-        resolved = find_t3_daemon(config_dir)
-        assert resolved is not None and resolved["version"] == "1.0.0"
-        sup.stop()
-
-    def test_cycle_to_current_noop_when_version_matches(
-        self, config_dir: Path, fake_spawn: list[_FakeProc], clock: _FakeClock,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setattr(t3_daemon, "_daemon_version", lambda: "1.0.0")
-        sup = _make(config_dir, clock)
-        sup.start()
-        assert sup.cycle_to_current() is False
-        assert len(fake_spawn) == 1  # no respawn
+        monkeypatch.setattr(T3Supervisor, "_chroma_reachable", lambda self: False)
+        assert sup.heartbeat_once() is True  # still supervising
+        clock.advance(3.1)  # past TTL with no re-stamp
+        assert find_t3_daemon(config_dir) is None  # lease expired
         sup.stop()
 
 

--- a/tests/daemon/test_t3_supervisor.py
+++ b/tests/daemon/test_t3_supervisor.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-149 P3 (bead nexus-wab47): the long-lived T3 supervisor.
+
+Unit coverage for ``T3Supervisor`` with the chroma subprocess spawn
+injected, so the lease publish / heartbeat / version-cycle / stop wiring
+is exercised deterministically without a real ``chroma run`` (the live
+chroma path is an integration concern). Proves the supervisor delegates
+to the shared ``ServiceRegistry`` / ``ServiceSupervisor`` exactly as the
+conformance suite's T3 cells assume.
+
+The injected ``clock`` fixture patches BOTH the supervisor's lease stamp
+and the discovery reader's clock, so ``find_t3_daemon`` (the real read
+path, which uses wall-clock TTL) agrees with the supervisor's
+fixed-clock stamps.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.daemon import t3_daemon
+from nexus.daemon.discovery import find_t3_daemon
+from nexus.daemon.t3_daemon import T3Supervisor
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+class _FakeProc:
+    """Stand-in for a chroma ``subprocess.Popen``: a controllable pid +
+    poll() (None = running, int = exited)."""
+
+    _next_pid = 880001
+
+    def __init__(self) -> None:
+        self.pid = _FakeProc._next_pid
+        _FakeProc._next_pid += 1
+        self._exited = False
+
+    def poll(self) -> int | None:
+        return 0 if self._exited else None
+
+    def die(self) -> None:
+        self._exited = True
+
+
+@pytest.fixture(autouse=True)
+def _local_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: True)
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    cd = tmp_path / "cfg"
+    cd.mkdir(parents=True, exist_ok=True, mode=0o700)
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(cd))
+    return cd
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> _FakeClock:
+    c = _FakeClock()
+    # The discovery reader checks lease freshness against wall-clock; pin
+    # it to the same fixed clock the supervisor stamps with.
+    monkeypatch.setattr("nexus.daemon.discovery.time.time", c)
+    return c
+
+
+@pytest.fixture
+def fake_spawn(monkeypatch: pytest.MonkeyPatch) -> list[_FakeProc]:
+    """Replace chroma spawn with a fake proc + a fixed port. Returns the
+    list of spawned procs so a test can kill one to simulate chroma death."""
+    spawned: list[_FakeProc] = []
+    port = 54321
+
+    def _spawn(self: T3Supervisor) -> tuple[_FakeProc, int]:
+        proc = _FakeProc()
+        spawned.append(proc)
+        return proc, port
+
+    monkeypatch.setattr(T3Supervisor, "_spawn_chroma", _spawn)
+    return spawned
+
+
+def _make(config_dir: Path, clock: _FakeClock) -> T3Supervisor:
+    # supervised=True mirrors the real long-lived runner (run_t3_supervisor),
+    # which records its pid as the lease supervisor_pid.
+    return T3Supervisor(
+        config_dir=config_dir, local_path=config_dir / "chroma",
+        lease_clock=clock, supervised=True,
+    )
+
+
+class TestT3SupervisorPublish:
+    def test_start_publishes_resolvable_lease(
+        self, config_dir: Path, fake_spawn: list[_FakeProc], clock: _FakeClock
+    ) -> None:
+        sup = _make(config_dir, clock)
+        payload = sup.start()
+        assert payload["pid"] == fake_spawn[0].pid  # chroma pid
+        assert payload["tcp_port"] == 54321
+        assert payload["generation"] == 1
+        assert payload["supervisor_pid"] is not None
+        resolved = find_t3_daemon(config_dir)
+        assert resolved is not None
+        assert resolved["pid"] == fake_spawn[0].pid
+        sup.stop()
+
+    def test_idempotent_second_start_returns_existing(
+        self, config_dir: Path, fake_spawn: list[_FakeProc], clock: _FakeClock
+    ) -> None:
+        sup = _make(config_dir, clock)
+        sup.start()
+        sup2 = _make(config_dir, clock)
+        sup2.start()  # live lease present -> no second spawn
+        assert len(fake_spawn) == 1
+        sup.stop()
+
+
+class TestT3SupervisorHeartbeat:
+    def test_heartbeat_keeps_lease_fresh_past_ttl(
+        self, config_dir: Path, fake_spawn: list[_FakeProc], clock: _FakeClock
+    ) -> None:
+        sup = _make(config_dir, clock)
+        sup.start()
+        clock.advance(2.0)
+        assert sup.heartbeat_once() is True
+        clock.advance(2.0)
+        assert find_t3_daemon(config_dir) is not None  # heartbeat held it fresh
+        sup.stop()
+
+    def test_heartbeat_self_heals_deleted_record(
+        self, config_dir: Path, fake_spawn: list[_FakeProc], clock: _FakeClock
+    ) -> None:
+        sup = _make(config_dir, clock)
+        sup.start()
+        t3_daemon.t3_discovery_path(config_dir).unlink()
+        assert find_t3_daemon(config_dir) is None
+        assert sup.heartbeat_once() is True
+        assert find_t3_daemon(config_dir) is not None  # re-asserted
+        sup.stop()
+
+    def test_heartbeat_stops_when_chroma_dies(
+        self, config_dir: Path, fake_spawn: list[_FakeProc], clock: _FakeClock
+    ) -> None:
+        sup = _make(config_dir, clock)
+        sup.start()
+        fake_spawn[0].die()  # chroma exits
+        assert sup.heartbeat_once() is False  # supervisor stops heartbeating
+        sup.stop()
+
+
+class TestT3SupervisorVersionCycle:
+    def test_cycle_to_current_respawns_chroma_on_skew(
+        self, config_dir: Path, fake_spawn: list[_FakeProc], clock: _FakeClock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(t3_daemon, "_daemon_version", lambda: "0.9.0")
+        sup = _make(config_dir, clock)
+        sup.start()
+        assert len(fake_spawn) == 1
+        monkeypatch.setattr(t3_daemon, "_daemon_version", lambda: "1.0.0")
+        assert sup.cycle_to_current() is True
+        assert len(fake_spawn) == 2  # chroma respawned at the new version
+        resolved = find_t3_daemon(config_dir)
+        assert resolved is not None and resolved["version"] == "1.0.0"
+        sup.stop()
+
+    def test_cycle_to_current_noop_when_version_matches(
+        self, config_dir: Path, fake_spawn: list[_FakeProc], clock: _FakeClock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(t3_daemon, "_daemon_version", lambda: "1.0.0")
+        sup = _make(config_dir, clock)
+        sup.start()
+        assert sup.cycle_to_current() is False
+        assert len(fake_spawn) == 1  # no respawn
+        sup.stop()
+
+
+class TestT3SupervisorStop:
+    def test_stop_relinquishes_lease(
+        self, config_dir: Path, fake_spawn: list[_FakeProc], clock: _FakeClock
+    ) -> None:
+        sup = _make(config_dir, clock)
+        sup.start()
+        assert find_t3_daemon(config_dir) is not None
+        sup.stop()
+        assert find_t3_daemon(config_dir) is None  # record removed


### PR DESCRIPTION
RDR-149 Phase 3 (bead nexus-wab47): migrate T3 + move the version-skew cycle ownership. **Closes the #1112 class structurally.**

## The problem (RF-4)
T3 is a managed `chroma run` subprocess. Previously `start_t3_daemon` spawned chroma **detached** and the nexus process exited, so nothing heartbeated a lease and the upgrade-cycle covered only T2 (#1112). Per your decision, T3 now gets a **long-lived supervisor** mirroring T2.

## What
- **T3Supervisor**: spawns the managed chroma subprocess, publishes a lease via the shared `ServiceRegistry` (scope=uid), and re-stamps it every interval **only while chroma is alive AND serving** (RF-4: a loopback port probe, not just pid-liveness, so a wedged chroma lets the lease expire instead of stranding clients).
- **run_t3_supervisor**: the blocking `--foreground` path (service templates). Default `nx daemon t3 start` now spawns it detached so the lease is always heartbeated. Signal handlers registered before startup (clean stop on a SIGTERM during boot).
- **find_t3_daemon**: lease-aware via the tier-parameterized `_resolve_lease_record` (extracted in P2), legacy fallback for the upgrade window.
- **stop_t3_daemon**: signals the supervisor (relinquishes lease + tears down chroma's group), falling back to the chroma pid; the `supervisor_pid` is trusted only from a **fresh** lease (no SIGTERM-ing a recycled pid).
- **#1112 fix**: `_cycle_supervised_daemons_to_current` — one orchestrator cycling every supervised daemon on upgrade (T2 + T3), so a new tier is added once rather than risk being missed. Supervised-daemon version-cycle is a process restart (a long-lived Python supervisor can't refresh its own bytecode in-process); `ServiceSupervisor.cycle_to_current` remains the generic primitive.

## Conformance
T3's cells (self_heal, version_cycle, pid_reuse, generation, fencing) flip **xfail → pass**; the #1112 guard now asserts the structural fix landed; a T3 ratchet meta-test locks it. T2/T3 share a `_LeaseHarness` (one problem, two uid-scoped tiers). New `test_t3_supervisor.py` proves the real supervisor wiring (publish/heartbeat/self-heal/wedged-chroma/stop) with the chroma spawn injected.

## Reviews (migration boundary)
Both stacked reviewers ran. Convergent fixes (commit 38c58902): freshness-gated `stop` (C-1), removed dead `cycle_to_current` + unified the upgrade orchestrator (the per-tier-pattern finding), signal-before-start (H-3), RF-4 port-reachability probe. `/conexus:phase-review-gate rdr-149 --phase 3` **PASSED**. Deferred (tracked beads): live T3 integration test; nx doctor CLI-vs-T3 version flag.

## Green
Conformance 24 pass / 7 xfail (all T1) + live self-heal; full `tests/daemon/` 315 passed; upgrade-e2e + rdr128 + upgrade_cmd 59 passed.

Refs #1112