### PR TITLE
feat(rdr-149): migrate T1 onto the leased registry, re-keyed on session-id (P4)

### DIFF
--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -1589,7 +1589,7 @@ def _run_check_resources() -> None:
 
 
 def _run_check_t1() -> None:
-    """Diagnostic: T1 addr-file presence + reachability.
+    """Diagnostic: T1 session-id lease presence + reachability (RDR-149 P4).
 
     .. note::
        Imports ``_tcp_probe_alive`` lazily from ``nexus.mcp.core`` to
@@ -1598,98 +1598,77 @@ def _run_check_t1() -> None:
 
     Three outcomes:
 
-    * **Healthy.** A live ``claude*`` ancestor is reachable via the
-      PPID walk and ``~/.config/nexus/t1_addr.<claude_pid>`` exists
-      AND its host:port responds to a TCP probe.
-    * **Missing addr file under live Claude.** A ``claude*`` ancestor
-      is reachable but the addr file is absent. Two common causes:
-      (a) the MCP server crashed before the lifespan wrote the file,
-      (b) the operator launched Claude Code via ``exec -a`` or a
-      custom wrapper whose process name does not start with
-      ``claude``, defeating the PPID walk's match.
-    * **No Claude in chain.** The current process has no ``claude*``
-      ancestor; ``nx scratch`` from this shell will fail-loud unless
-      the operator opts in via ``NX_T1_ISOLATED=1``.
+    * **Healthy.** A session-id resolves and its live lease at
+      ``~/.config/nexus/t1_addr.<session_id>`` yields a host:port that
+      responds to a TCP probe.
+    * **Missing lease under a resolved session.** A session-id resolves
+      but no live lease is discoverable. Common causes: (a) the MCP
+      server crashed before the lifespan published the lease, (b) the
+      lease aged out (the MCP server died ungracefully and its heartbeat
+      stopped), (c) the MCP server is still booting.
+    * **No session-id resolves.** Neither ``NX_SESSION_ID`` nor
+      ``~/.config/nexus/current_session`` is set; ``nx scratch`` from
+      this shell will fail-loud unless the operator opts in via
+      ``NX_T1_ISOLATED=1``.
 
     Exit code:
-      * 0: healthy or "no Claude in chain" (informational).
-      * 1: Claude in chain but addr file absent or unreachable.
+      * 0: healthy or "no session-id resolves" (informational).
+      * 1: session-id resolves but the lease is absent or unreachable.
     """
-    import os as _os
-
+    from nexus.daemon.t1_lease import discover_t1_lease
     from nexus.mcp.core import _tcp_probe_alive
     from nexus.session import (
-        _command_name_of,
-        find_immediate_claude_pid,
-        read_t1_addr_for,
-        t1_addr_path,
+        _nexus_config_dir_at_import,
+        resolve_active_session_id,
     )
 
-    own_pid = _os.getpid()
-    claude_pid = find_immediate_claude_pid(start_pid=own_pid)
+    session_id = resolve_active_session_id()
 
-    if claude_pid <= 0:
-        click.echo("[ ] T1: no claude ancestor in PPID chain")
+    if not session_id:
+        click.echo("[ ] T1: no session-id resolves for this process")
         click.echo(
             "    This is informational. ``nx scratch`` from this shell "
             "will fail-loud unless you opt into per-process ephemeral "
-            "T1 via ``NX_T1_ISOLATED=1``."
+            "T1 via ``NX_T1_ISOLATED=1``, or the SessionStart hook has "
+            "written ~/.config/nexus/current_session."
         )
         return
 
-    comm = _command_name_of(claude_pid)
-    is_claude = comm.lower().startswith("claude")
-    if not is_claude:
-        # find_immediate_claude_pid returned the immediate-PPID
-        # fallback because no ancestor's comm starts with "claude".
-        # Likely an exec -a / wrapper rename.
-        click.echo(
-            f"[!] T1: ancestor PID {claude_pid} (comm={comm!r}) is not "
-            "named 'claude*'; likely launched via exec -a or a "
-            "wrapper. Falling back to the immediate-PPID."
-        )
-        click.echo(
-            "    If you launched Claude Code via ``exec -a`` or a "
-            "custom wrapper, ensure the process name starts with "
-            "``claude`` so the PPID walk can find it."
-        )
-        raise click.exceptions.Exit(1)
-
-    addr_path = t1_addr_path(claude_pid)
-    addr = read_t1_addr_for(claude_pid)
+    config_dir = _nexus_config_dir_at_import()
+    addr = discover_t1_lease(session_id, config_dir=config_dir)
+    record_name = f"t1_addr.{session_id}"
     if addr is None:
         click.echo(
-            f"[✗] T1: claude ancestor PID {claude_pid} ({comm!r}) "
-            f"is alive but {addr_path} is missing or unreadable."
+            f"[✗] T1: session {session_id!r} resolves but no live lease "
+            f"at {config_dir / record_name}."
         )
         click.echo(
-            "    The MCP server's lifespan should have written this "
-            "file at session start. Causes:\n"
+            "    The MCP server's lifespan publishes this lease at "
+            "session start and heartbeats it. Causes:\n"
             "      - The MCP server crashed before the lifespan "
-            "completed (check ~/.config/nexus/logs/mcp.log).\n"
-            "      - The MCP server is still booting; retry shortly.\n"
-            "      - The Claude Code binary was launched via "
-            "``exec -a`` with a different process name (the PPID walk "
-            "found the right PID but the comm-prefix check missed)."
+            "published it (check ~/.config/nexus/logs/mcp.log).\n"
+            "      - The MCP server died ungracefully and its lease "
+            "aged out (TTL).\n"
+            "      - The MCP server is still booting; retry shortly."
         )
         raise click.exceptions.Exit(1)
 
     host, port = addr
     if _tcp_probe_alive(host, port, timeout=1.0):
         click.echo(
-            f"[✓] T1: addr file {addr_path.name} -> "
+            f"[✓] T1: lease {record_name} -> "
             f"{host}:{port} (chroma reachable)"
         )
         return
 
     click.echo(
-        f"[✗] T1: addr file {addr_path.name} -> {host}:{port} "
+        f"[✗] T1: lease {record_name} -> {host}:{port} "
         "but TCP probe failed."
     )
     click.echo(
-        "    The addr file points at a chroma that is not listening. "
+        "    The lease points at a chroma that is not listening. "
         "The MCP server may have died ungracefully. Restart Claude "
-        "Code; the next MCP startup will sweep this stale addr file "
+        "Code; the next MCP startup will publish a fresh lease "
         "and spawn a fresh chroma."
     )
     raise click.exceptions.Exit(1)

--- a/src/nexus/daemon/t1_lease.py
+++ b/src/nexus/daemon/t1_lease.py
@@ -24,10 +24,18 @@ of the T1 migration, tracked as CA-3):
    serializes the generation bump against any concurrent sibling), then
    relinquishes the transient record (which only ever unlinks the
    publisher's own ``server_pid`` key).
-3. Readers resolve by session-id (:func:`discover_t1_lease`); during the
-   transient window a sibling that needs T1 falls back to the env-passdown
-   path (RDR-105 Path A), so there is no undiscoverable window and no
-   ``"unknown"`` collapse.
+3. Readers resolve by session-id (:func:`discover_t1_lease`). The transient
+   window covers the two reader classes RF-2's mechanism names: the owning
+   MCP process (via the in-process ``_t1_state`` pointer) and an
+   MCP-dispatched ``claude -p`` subprocess (via the inherited
+   ``NX_T1_HOST``/``NX_T1_PORT`` env, RDR-105 Path A). It does NOT cover a
+   Claude-Code-spawned Bash sibling that has neither the env nor a resolvable
+   session-id yet (the cold-start sliver before the SessionStart hook writes
+   ``current_session``): such a sibling gets a loud, retryable
+   ``T1ServerNotFoundError`` and succeeds once the session-id resolves. That
+   sliver is the accepted tradeoff of keying on session-id instead of the
+   unreliable ``find_immediate_claude_pid`` PPID-walk (RDR §Gap 2); it is
+   tracked, not a silent failure. No record is ever keyed ``"unknown"``.
 
 Session-scoped N-per-user semantics are preserved: the session-id IS the
 scope key (intentionally N owners per uid, one T1 server per session), so
@@ -206,10 +214,22 @@ class T1LeasePublisher:
             owner_token=self._owner_token,
             payload=self._payload(session_id),
         )
-        if transient_record is not None:
-            self._registry.relinquish(transient_record)
+        # Commit the in-process pointer to the session record BEFORE
+        # relinquishing the transient one: if the relinquish raises, the next
+        # tick must heartbeat the session record (not re-enter _rekey and
+        # inflate the generation / re-publish). The transient record then ages
+        # out via TTL. A relinquish failure is best-effort; never re-key-loop.
         self._record = new_record
         self._session_key = session_id
+        if transient_record is not None:
+            try:
+                self._registry.relinquish(transient_record)
+            except Exception as exc:
+                _log.debug(
+                    "t1_lease_transient_relinquish_failed",
+                    scope=self._transient_key,
+                    error=str(exc),
+                )
         _log.info(
             "t1_lease_rekeyed",
             from_scope=self._transient_key,

--- a/src/nexus/daemon/t1_lease.py
+++ b/src/nexus/daemon/t1_lease.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-149 P4 (bead nexus-8znyd): T1 rides the leased service registry.
+
+T1 is the per-MCP-process working-memory tier. Unlike T2/T3 it is **not**
+a supervised daemon: it is owned by the MCP server's chroma lifespan
+(``nexus.mcp.core._t1_chroma_lifespan`` Branch 3) and consumes the shared
+``ServiceRegistry`` primitive directly. This module is that consumer.
+
+The locked RF-2 re-key protocol (the one load-bearing correctness subtlety
+of the T1 migration, tracked as CA-3):
+
+1. At lifespan publish the owner does not yet know the Claude session-id on
+   a cold top-level session: the SessionStart hook writes
+   ``~/.config/nexus/current_session`` independently of the MCP lifespan
+   (RDR-105 P4), so ``resolve_active_session_id()`` may still be ``None``.
+   The publisher therefore claims a **transient** scope key = the chroma
+   ``server_pid``: unique among live owners, never ``"unknown"``, never
+   colliding across sessions. The resolved-or-None session-id rides as a
+   payload field.
+2. The heartbeat loop calls the injected ``session_resolver`` each tick.
+   The instant it resolves non-None while the record is still
+   transient-keyed, the publisher **atomically re-keys**: it publishes the
+   session-id-keyed record (the primitive's per-scope election flock
+   serializes the generation bump against any concurrent sibling), then
+   relinquishes the transient record (which only ever unlinks the
+   publisher's own ``server_pid`` key).
+3. Readers resolve by session-id (:func:`discover_t1_lease`); during the
+   transient window a sibling that needs T1 falls back to the env-passdown
+   path (RDR-105 Path A), so there is no undiscoverable window and no
+   ``"unknown"`` collapse.
+
+Session-scoped N-per-user semantics are preserved: the session-id IS the
+scope key (intentionally N owners per uid, one T1 server per session), so
+unlike the uid-scoped T2/T3 tiers there is no one-owner-per-user election.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import structlog
+
+from nexus.daemon.service_registry import (
+    Clock,
+    LeaseRecord,
+    ServiceRegistry,
+    StaleOwnerError,
+    mint_owner_token,
+)
+
+_log = structlog.get_logger(__name__)
+
+SessionResolver = Callable[[], Optional[str]]
+
+
+def _t1_version() -> str:
+    """The running package version, stamped on the lease for observability.
+
+    T1 is not version-cycled (it is MCP-lifespan-owned; an upgrade cycles it
+    by restarting the MCP server), but the lease ``version`` field is
+    required by the primitive, so we stamp the real version for parity with
+    T2/T3 discovery payloads.
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("conexus")
+    except Exception:
+        return "0.0.0"
+
+
+class T1LeasePublisher:
+    """Owns one T1 chroma's lease, re-keyed transient ``server_pid`` ->
+    ``session_id`` per the locked RF-2 protocol.
+
+    Constructor-injected (no singletons): the MCP lifespan builds the
+    ``ServiceRegistry`` and a ``session_resolver`` and hands them in; the
+    conformance harness and unit tests inject a ``_FakeClock``-backed
+    registry and a controllable resolver so the re-key window is exercised
+    deterministically.
+    """
+
+    def __init__(
+        self,
+        *,
+        registry: ServiceRegistry,
+        server_pid: int,
+        host: str,
+        port: int,
+        version: Optional[str] = None,
+        session_resolver: SessionResolver,
+        owner_token: Optional[str] = None,
+    ) -> None:
+        self._registry = registry
+        self._server_pid = server_pid
+        self._transient_key = str(server_pid)
+        self._endpoint: dict[str, Any] = {
+            "host": host,
+            "port": port,
+            "server_pid": server_pid,
+        }
+        self._version = version or _t1_version()
+        self._resolver = session_resolver
+        self._owner_token = owner_token or mint_owner_token()
+        self._record: Optional[LeaseRecord] = None
+        self._session_key: Optional[str] = None
+        self._fenced: bool = False
+
+    @property
+    def owner_token(self) -> str:
+        return self._owner_token
+
+    @property
+    def record(self) -> Optional[LeaseRecord]:
+        return self._record
+
+    @property
+    def session_keyed(self) -> bool:
+        """True once the lease is keyed on the session-id (re-key done)."""
+        return self._session_key is not None
+
+    @property
+    def active_scope_key(self) -> str:
+        """The scope key the live record is currently published under."""
+        return self._session_key or self._transient_key
+
+    @property
+    def fenced(self) -> bool:
+        """True if a heartbeat found a newer owner had taken the scope.
+
+        For the transient ``server_pid`` key this cannot happen (the key is
+        unique to this owner); for the session key it can if a sibling of the
+        same session published a higher generation after our last publish.
+        """
+        return self._fenced
+
+    def _payload(self, session_id: Optional[str]) -> dict[str, Any]:
+        return {"session_id": session_id, "server_pid": self._server_pid}
+
+    def publish(self) -> LeaseRecord:
+        """Claim the scope, keying on the session-id if it already resolves,
+        else on the transient ``server_pid``.
+
+        Returns the published lease. On a warm session (the resolver returns
+        non-None immediately, e.g. a ``claude -p`` subprocess that inherited
+        ``NX_SESSION_ID``) there is no transient window and no later re-key.
+        """
+        session_id = self._resolve()
+        scope_key = session_id or self._transient_key
+        self._record = self._registry.publish(
+            scope_key,
+            endpoint=self._endpoint,
+            version=self._version,
+            owner_token=self._owner_token,
+            payload=self._payload(session_id),
+        )
+        self._session_key = session_id or None
+        _log.info(
+            "t1_lease_published",
+            scope_key=scope_key,
+            session_keyed=self.session_keyed,
+            server_pid=self._server_pid,
+            generation=self._record.generation,
+        )
+        return self._record
+
+    def tick(self) -> None:
+        """One heartbeat step: re-stamp the lease, then re-key if the
+        session-id has resolved while we are still transient-keyed.
+
+        Idempotent and exception-safe. A heartbeat fenced by a newer owner
+        sets :attr:`fenced` and writes nothing (CA-4). Called by the
+        lifespan's async heartbeat loop and, in tests, directly.
+        """
+        if self._record is None or self._fenced:
+            return
+        try:
+            self._record = self._registry.heartbeat(self._record)
+        except StaleOwnerError:
+            self._fenced = True
+            _log.info(
+                "t1_lease_fenced",
+                scope_key=self.active_scope_key,
+                owner_token=self._owner_token,
+            )
+            return
+        if self._session_key is None:
+            session_id = self._resolve()
+            if session_id:
+                self._rekey(session_id)
+
+    def _rekey(self, session_id: str) -> None:
+        """Atomically move the lease from the transient key to the session
+        key. Write the session record first (under its own election flock,
+        so a concurrent sibling's generation bump serializes), then relinquish
+        the transient record (which only unlinks our own ``server_pid`` key).
+        Ordering guarantees there is never a window with no record.
+        """
+        transient_record = self._record
+        new_record = self._registry.publish(
+            session_id,
+            endpoint=self._endpoint,
+            version=self._version,
+            owner_token=self._owner_token,
+            payload=self._payload(session_id),
+        )
+        if transient_record is not None:
+            self._registry.relinquish(transient_record)
+        self._record = new_record
+        self._session_key = session_id
+        _log.info(
+            "t1_lease_rekeyed",
+            from_scope=self._transient_key,
+            to_scope=session_id,
+            server_pid=self._server_pid,
+            generation=new_record.generation,
+        )
+
+    def relinquish(self) -> None:
+        """Release the lease on shutdown, marking it shutting-down first so
+        discoverers stop resolving us immediately. Only unlinks the record if
+        we still own it (a fenced predecessor must not clobber a successor).
+        Idempotent.
+        """
+        if self._record is None:
+            return
+        record = self._record
+        try:
+            self._registry.mark_shutting_down(record)
+            self._registry.relinquish(record)
+        finally:
+            self._record = None
+
+    def _resolve(self) -> Optional[str]:
+        try:
+            sid = self._resolver()
+        except Exception as exc:  # resolver is best-effort; never crash a tick
+            _log.debug("t1_lease_session_resolve_failed", error=str(exc))
+            return None
+        if sid is None:
+            return None
+        sid = sid.strip()
+        return sid or None
+
+
+def discover_t1_lease(
+    session_id: Optional[str],
+    *,
+    config_dir: Path,
+    clock: Clock = time.time,
+) -> Optional[tuple[str, int]]:
+    """Resolve the live T1 endpoint for ``session_id``, or ``None``.
+
+    The session-id-keyed read path that replaces the legacy
+    ``find_immediate_claude_pid`` PPID-walk + ``read_t1_addr_for`` (RDR-149
+    P4). Liveness is lease freshness (TTL), not pid: a dead owner's lease
+    ages out, giving pid-reuse immunity. Returns ``None`` for an empty
+    session-id, a missing/expired/shutdown lease, or a malformed endpoint;
+    callers fall back to the env-passdown path (RDR-105 Path A) or fail loud
+    at the next layer.
+    """
+    if not session_id or not session_id.strip():
+        return None
+    registry = ServiceRegistry(dir=config_dir, tier="t1", clock=clock)
+    record = registry.discover(session_id.strip())
+    if record is None:
+        return None
+    host = record.endpoint.get("host")
+    port = record.endpoint.get("port")
+    if not isinstance(host, str) or not isinstance(port, (int, float)):
+        return None
+    return host, int(port)

--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -193,9 +193,13 @@ class T1Database:
             session-id identically from ``current_session``; liveness is
             lease freshness (TTL), not pid, so a dead owner's lease ages
             out (pid-reuse immunity). Used by Claude-Code-spawned
-            siblings (Bash tool, hooks). During the cold-start transient
-            window before the SessionStart hook writes ``current_session``,
-            a sibling falls back to Path A's env-passdown breadcrumb.
+            siblings (Bash tool, hooks) once a session-id resolves. In the
+            cold-start sliver before the SessionStart hook writes
+            ``current_session`` (and with no ``NX_SESSION_ID`` in env), a
+            bare Bash sibling resolves no session-id and falls through to
+            Path D (a loud, retryable ``T1ServerNotFoundError``); it
+            succeeds on retry once the session-id resolves. MCP-dispatched
+            subprocesses are unaffected (Path A env breadcrumb).
         Path D (failure)
             None of the above -> raise :class:`T1ServerNotFoundError`.
 

--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -23,8 +23,6 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 from nexus.session import (
     _t1_isolated_env,
-    find_immediate_claude_pid,
-    read_t1_addr_for,
     resolve_active_session_id,
 )
 
@@ -187,10 +185,17 @@ class T1Database:
         Path A (env-pair discovery)
             ``NX_T1_HOST`` + ``NX_T1_PORT`` in env -> ``HttpClient``.
             Used by MCP-dispatched subprocesses (``claude -p`` shared).
-        Path B (addr-file discovery)
-            ``find_immediate_claude_pid`` resolves to a live addr file
-            at ``~/.config/nexus/t1_addr.<pid>`` -> ``HttpClient``.
-            Used by Claude-Code-spawned siblings (Bash tool, hooks).
+        Path B (session-id lease discovery)
+            ``resolve_active_session_id`` resolves a session-id whose
+            live lease at ``~/.config/nexus/t1_addr.<session_id>``
+            yields ``(host, port)`` -> ``HttpClient`` (RDR-149 P4).
+            Both the writer (MCP lifespan) and the reader compute the
+            session-id identically from ``current_session``; liveness is
+            lease freshness (TTL), not pid, so a dead owner's lease ages
+            out (pid-reuse immunity). Used by Claude-Code-spawned
+            siblings (Bash tool, hooks). During the cold-start transient
+            window before the SessionStart hook writes ``current_session``,
+            a sibling falls back to Path A's env-passdown breadcrumb.
         Path D (failure)
             None of the above -> raise :class:`T1ServerNotFoundError`.
 
@@ -217,9 +222,14 @@ class T1Database:
             self._session_id = self._resolve_session_id(session_id)
             return
 
-        claude_pid = find_immediate_claude_pid()
-        if claude_pid > 0:
-            addr = read_t1_addr_for(claude_pid)
+        resolved_session = resolve_active_session_id(session_id)
+        if resolved_session:
+            from nexus.daemon.t1_lease import discover_t1_lease
+            from nexus.session import _nexus_config_dir_at_import
+
+            addr = discover_t1_lease(
+                resolved_session, config_dir=_nexus_config_dir_at_import()
+            )
             if addr is not None:
                 host, port = addr
                 self._client = chromadb.HttpClient(host=host, port=port)
@@ -230,13 +240,14 @@ class T1Database:
             "T1 not configured for this process. Either inherit "
             "NX_T1_HOST and NX_T1_PORT from a parent MCP server "
             "(MCP-dispatched subprocess), run as a sibling of a "
-            "top-level MCP server so the address file is "
-            "discoverable via the PPID walk to the immediate "
-            "claude ancestor, or set NX_T1_ISOLATED=1 to opt in "
-            "to an in-process ephemeral T1.\n"
+            "top-level MCP server so a live session-id lease "
+            "(~/.config/nexus/t1_addr.<session_id>) is discoverable, "
+            "or set NX_T1_ISOLATED=1 to opt in to an in-process "
+            "ephemeral T1.\n"
             "\n"
-            "If you launched Claude Code via 'exec -a' or a custom "
-            "wrapper, ensure the process name starts with 'claude'."
+            "If no session-id resolves, ensure the SessionStart hook "
+            "has written ~/.config/nexus/current_session, or pass "
+            "NX_SESSION_ID explicitly."
         )
 
     def __init__(self, session_id: str | None = None, client=None) -> None:

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -103,7 +103,7 @@ async def _t1_heartbeat_loop(publisher: Any, interval: float) -> None:
     import asyncio
 
     import structlog
-    _hb_log = structlog.get_logger()
+    _hb_log = structlog.get_logger("nexus.mcp.core")
     while True:
         await asyncio.sleep(interval)
         try:

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -85,6 +85,47 @@ _OWNED_CHROMA: dict[str, Any] = {}
 #: one-shot per process.
 _SHUTDOWN_IN_FLIGHT: bool = False
 
+#: RDR-149 P4: the running T1 heartbeat + lazy re-key task, created in the
+#: lifespan Branch 3 after the lease is published and cancelled on cleanup
+#: BEFORE the lease is relinquished (RDR-129 early-stop ordering, mirroring
+#: the T2 ``_reassert_task`` discipline). ``None`` when no owned T1 is live.
+_T1_HEARTBEAT_TASK: Any = None
+
+
+async def _t1_heartbeat_loop(publisher: Any, interval: float) -> None:
+    """Re-stamp the T1 lease every ``interval`` seconds and lazily re-key the
+    transient ``server_pid`` record to the session-id once it resolves.
+
+    RDR-149 P4: this is T1's self-heal re-assert (the #1114 fix) and its
+    RF-2/CA-3 re-key driver. A tick that raises is logged at debug and the
+    loop continues; only cancellation (clean shutdown) stops it.
+    """
+    import asyncio
+
+    import structlog
+    _hb_log = structlog.get_logger()
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            publisher.tick()
+        except Exception as exc:  # never let a transient tick failure kill the loop
+            _hb_log.debug("t1_heartbeat_tick_failed", error=str(exc))
+
+
+async def _cancel_t1_heartbeat_task() -> None:
+    """Cancel and await the T1 heartbeat task if one is running. Idempotent."""
+    import asyncio
+    import contextlib
+
+    global _T1_HEARTBEAT_TASK
+    task = _T1_HEARTBEAT_TASK
+    _T1_HEARTBEAT_TASK = None
+    if task is None:
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
+
 
 def _tcp_probe_alive(host: str, port: int, timeout: float = 0.5) -> bool:
     """Return True if a TCP connection to ``(host, port)`` succeeds.
@@ -122,12 +163,14 @@ async def _t1_chroma_lifespan(_app: Any):
         spawning.
 
     Branch 3 (top-level / owned)
-        Spawn a fresh chroma; write
-        ``~/.config/nexus/t1_addr.<claude_pid>`` keyed by
-        :func:`find_immediate_claude_pid` (the FIRST claude ancestor
-        per RF-6, NOT the topmost); populate ``_t1_state.T1_ADDR``;
-        yield. Cleanup unlinks the file, stops chroma, rmtrees the
-        chroma tmpdir, and resets ``_t1_state.T1_ADDR``.
+        Spawn a fresh chroma; publish a leased registry record via
+        :class:`nexus.daemon.t1_lease.T1LeasePublisher` (RDR-149 P4) —
+        keyed transiently on the chroma ``server_pid`` and re-keyed to
+        the session-id once it resolves (RF-2/CA-3); populate
+        ``_t1_state.T1_ADDR``; start the heartbeat + re-key loop; yield.
+        Cleanup cancels the heartbeat task, relinquishes the lease,
+        stops chroma, rmtrees the chroma tmpdir, and resets
+        ``_t1_state.T1_ADDR``.
 
     Also runs a best-effort orphan-reaper sweep on entry to clean
     up any addr files left by a prior session that exited without
@@ -227,46 +270,67 @@ async def _t1_chroma_lifespan(_app: Any):
         "tmpdir": str(tmpdir),
     })
     try:
+        import asyncio
+
         from nexus.mcp import _t1_state
-        from nexus.session import find_immediate_claude_pid, write_t1_addr
+        from nexus.daemon.service_registry import ServiceRegistry
+        from nexus.daemon.t1_lease import T1LeasePublisher
+        from nexus.session import (
+            _nexus_config_dir_at_import,
+            resolve_active_session_id,
+        )
 
         import structlog
         _spawn_log = structlog.get_logger()
 
-        claude_pid = find_immediate_claude_pid()
-        if claude_pid > 0:
-            # Invariant: ``_t1_state.T1_ADDR`` and
-            # ``_OWNED_CHROMA["t1_addr_claude_pid"]`` are written
-            # together. The shutdown impl gates on the dict key so
-            # ``T1_ADDR`` cannot leak past a clean shutdown.
-            write_t1_addr(claude_pid, host, port)
-            _t1_state.T1_ADDR = (host, port)
-            _OWNED_CHROMA["t1_addr_claude_pid"] = claude_pid
-            # nexus-7m8i: happy-path observability. Pre-RDR-105 the
-            # equivalent code emitted only on the exception branches
-            # (minted, reconciled), leaving operators unable to
-            # distinguish "MCP started cleanly" from "MCP never reached
-            # the spawn step" by reading the log alone. One ``info``
-            # per owner spawn closes the gap.
-            _spawn_log.info(
-                "t1_chroma_init_owned",
-                host=host,
-                port=port,
-                server_pid=server_pid,
-                claude_pid=claude_pid,
-                tmpdir=str(tmpdir),
-            )
-        else:
-            _spawn_log.warning(
-                "t1_addr_publish_skipped_no_claude_pid",
-                host=host,
-                port=port,
-            )
+        # RDR-149 P4: T1 rides the leased registry. Publish under a transient
+        # ``server_pid`` key (never ``unknown``) carrying the resolved-or-None
+        # session-id; the heartbeat loop re-keys to the session-id the instant
+        # it resolves (RF-2/CA-3) and self-heals a lost record (#1114). T1 is
+        # session-scoped (N owners per uid, one T1 server per session), so the
+        # primitive's per-scope election flock IS the whole election (no
+        # spawn-lock daemon, unlike T2/T3).
+        registry = ServiceRegistry(
+            dir=_nexus_config_dir_at_import(), tier="t1"
+        )
+        publisher = T1LeasePublisher(
+            registry=registry,
+            server_pid=server_pid,
+            host=host,
+            port=port,
+            session_resolver=resolve_active_session_id,
+        )
+        # Invariant: ``_t1_state.T1_ADDR`` (in-process readers) and
+        # ``_OWNED_CHROMA["t1_lease_publisher"]`` (the shutdown relinquish
+        # gate) are written together. The shutdown impl gates on the dict key
+        # so ``T1_ADDR`` cannot leak past a clean shutdown.
+        publisher.publish()
+        _t1_state.T1_ADDR = (host, port)
+        _OWNED_CHROMA["t1_lease_publisher"] = publisher
+        # nexus-7m8i: happy-path observability. One ``info`` per owner spawn
+        # so operators can distinguish "MCP started cleanly" from "MCP never
+        # reached the spawn step" by reading the log alone.
+        _spawn_log.info(
+            "t1_chroma_init_owned",
+            host=host,
+            port=port,
+            server_pid=server_pid,
+            scope_key=publisher.active_scope_key,
+            session_keyed=publisher.session_keyed,
+            tmpdir=str(tmpdir),
+        )
+        global _T1_HEARTBEAT_TASK
+        _T1_HEARTBEAT_TASK = asyncio.create_task(
+            _t1_heartbeat_loop(publisher, registry.heartbeat_interval)
+        )
         yield
     finally:
-        # Idempotent. If the SIGTERM / atexit path already ran via
-        # ``_t1_chroma_shutdown``, ``_OWNED_CHROMA`` is empty and
-        # the cleanup short-circuits.
+        # Cancel the heartbeat task BEFORE relinquishing the lease so it
+        # cannot re-stamp or re-key a record we are tearing down (RDR-129
+        # early-stop ordering). Idempotent: if the SIGTERM / atexit path
+        # already ran via ``_t1_chroma_shutdown``, ``_OWNED_CHROMA`` is empty
+        # and the cleanup short-circuits.
+        await _cancel_t1_heartbeat_task()
         _t1_chroma_shutdown()
 
 
@@ -293,12 +357,22 @@ def _t1_chroma_shutdown() -> None:
     import shutil
 
     from nexus.mcp import _t1_state
-    from nexus.session import stop_t1_server, unlink_t1_addr
+    from nexus.session import stop_t1_server
 
     server_pid = _OWNED_CHROMA.get("server_pid")
     tmpdir = _OWNED_CHROMA.get("tmpdir")
-    claude_pid = _OWNED_CHROMA.get("t1_addr_claude_pid")
+    publisher = _OWNED_CHROMA.get("t1_lease_publisher")
 
+    # RDR-149 P4: relinquish the lease (mark shutting-down, then unlink only
+    # if we still own it) BEFORE stopping chroma so discoverers stop resolving
+    # us immediately. ``relinquish`` is sync file I/O, safe from the SIGTERM /
+    # atexit path where no event loop is available to await the heartbeat
+    # task's cancellation.
+    if publisher is not None:
+        try:
+            publisher.relinquish()
+        except Exception:
+            pass
     if server_pid:
         try:
             stop_t1_server(int(server_pid))
@@ -309,8 +383,6 @@ def _t1_chroma_shutdown() -> None:
             shutil.rmtree(tmpdir, ignore_errors=True)
         except OSError:
             pass
-    if claude_pid:
-        unlink_t1_addr(int(claude_pid))
 
     _t1_state.T1_ADDR = None
     _OWNED_CHROMA.clear()

--- a/tests/daemon/test_rdr149_lifecycle_conformance.py
+++ b/tests/daemon/test_rdr149_lifecycle_conformance.py
@@ -597,8 +597,14 @@ def _t1_publisher(
 
 
 class TestT1SessionRekey:
-    """CA-3: the transient-key -> session-id re-key has no undiscoverable
-    window and no ``"unknown"`` collapse."""
+    """CA-3: the transient-key -> session-id re-key has no ``"unknown"``
+    collapse and no window where the OWNER or an env-inheriting subprocess
+    is stranded. NOTE: the transient lease is registry-discoverable under
+    the ``server_pid`` key (proving the re-key carry-forward and the owner's
+    ``_t1_state`` breadcrumb), but a bare Claude-Code Bash sibling does NOT
+    read that key in production -- the cold-start Bash-sibling sliver is a
+    documented, tracked limitation (see ``test_t1_discovery`` for the honest
+    production-path behavior), not a discoverability guarantee."""
 
     def _registry(self, config_dir: Path, clock: _FakeClock) -> ServiceRegistry:
         return ServiceRegistry(
@@ -617,13 +623,16 @@ class TestT1SessionRekey:
             f"t1_addr.{_SERVER_PID}"
         ]
 
-    def test_sibling_discovers_via_server_pid_during_transient_window(
+    def test_transient_lease_is_registry_discoverable_under_server_pid(
         self, config_dir: Path, clock: _FakeClock
     ) -> None:
-        # CA-3 (ii): during the transient window (session-id not yet
-        # resolvable), the record is discoverable under the server_pid key
-        # (the env-passdown Path A breadcrumb), so there is no undiscoverable
-        # window. A sibling resolving by session-id finds nothing yet.
+        # CA-3 carry-forward: during the transient window the record exists
+        # under the server_pid key (so the re-key can read-and-carry its
+        # generation, and the owner's _t1_state breadcrumb is backed by a
+        # real record) while NOT yet discoverable under the session-id. This
+        # asserts the registry-layer invariant only; it is NOT a claim that a
+        # bare Bash sibling reads the server_pid key (it does not -- see
+        # tests/test_t1_discovery.py for the honest production read path).
         reg = self._registry(config_dir, clock)
         pub = _t1_publisher(reg, server_pid=_SERVER_PID, session_resolver=lambda: None)
         pub.publish()

--- a/tests/daemon/test_rdr149_lifecycle_conformance.py
+++ b/tests/daemon/test_rdr149_lifecycle_conformance.py
@@ -59,6 +59,7 @@ from nexus.daemon.service_registry import (
     ServiceRegistry,
     ServiceSupervisor,
 )
+from nexus.daemon.t1_lease import T1LeasePublisher
 from nexus import session as _sess
 
 
@@ -193,45 +194,79 @@ class RecordHarness:
 
 
 class T1RecordHarness(RecordHarness):
+    """RDR-149 P4: T1 rides the leased registry, MCP-lifespan-owned and
+    scoped on the **session-id** (intentionally N owners per uid, one T1
+    server per session). Each sibling drives a real ``T1LeasePublisher``
+    keyed on one shared session-id, so the unit battery exercises the
+    production publish / heartbeat-self-heal / re-key / fence path, not a
+    bespoke copy. The transient ``server_pid`` -> session-id re-key (CA-3)
+    is covered separately by ``TestT1SessionRekey``; here the publishers
+    resolve the session-id at publish time so they key on it directly."""
+
     tier = "t1"
     scope = "session"
-    has_self_heal = False  # #1114: ZERO self-heal in session.py
-    has_version_cycle = False
+    has_self_heal = True  # RDR-149 P4: publisher heartbeat self-heals (#1114)
+    has_version_cycle = False  # T1 is MCP-lifespan-owned, not upgrade-cycled
+    _SESSION = "sess-A"
+
+    def __init__(self, config_dir: Path, alive: _AliveSet, clock: _FakeClock) -> None:
+        super().__init__(config_dir, alive, clock)
+        self._registry = ServiceRegistry(
+            dir=config_dir, tier="t1", clock=clock, ttl=3.0, heartbeat_interval=1.0
+        )
+        self._pubs: dict[int, T1LeasePublisher] = {}
 
     def publish(self, owner: int = _OWNER_PID) -> None:
-        self._alive.mark_alive(owner)
-        _sess.write_t1_addr(owner, "127.0.0.1", 0)
+        pub = T1LeasePublisher(
+            registry=self._registry,
+            server_pid=owner,
+            host="127.0.0.1",
+            port=0,
+            version="1.0.0",
+            session_resolver=lambda: self._SESSION,
+            owner_token=f"tok-{owner}",
+        )
+        pub.publish()
+        self._pubs[owner] = pub
 
     def discover(self, owner: int = _OWNER_PID) -> Optional[dict[str, Any]]:
-        hp = _sess.read_t1_addr_for(owner)
-        if hp is None:
+        rec = self._registry.discover(self._SESSION)
+        if rec is None:
             return None
-        return {"pid": owner, "owner": owner, "host": hp[0], "port": hp[1]}
+        return {
+            "pid": rec.endpoint.get("server_pid"),
+            "owner": rec.endpoint.get("server_pid"),
+            "generation": rec.generation,
+            "owner_token": rec.owner_token,
+        }
 
     def simulate_ungraceful_death(self, owner: int = _OWNER_PID) -> None:
-        self._alive.mark_dead(owner)
+        # The owner stops heartbeating; the lease ages out on its own. No pid
+        # is consulted (lease freshness is the liveness primitive).
+        self._pubs.pop(owner, None)
 
     def advance_to_reap(self) -> None:
-        return  # pid death is observable immediately
+        self._clock.advance(3.1)  # past TTL
 
     def reap(self) -> None:
-        _sess.sweep_orphan_t1_addr_files()
+        self._registry.discover(self._SESSION)  # discovery reaps an expired lease
 
     def external_delete(self, owner: int = _OWNER_PID) -> None:
-        _sess.unlink_t1_addr(owner)
+        self._registry._record_path(self._SESSION).unlink(missing_ok=True)
 
     def self_heal_tick(self, owner: int = _OWNER_PID) -> None:
-        return  # session.py runs no re-assert loop (#1114)
+        pub = self._pubs.get(owner)
+        if pub is not None:
+            pub.tick()  # re-stamps; self-heals a lost record
 
     def stale_reassert(self, owner: int) -> None:
-        # No fencing: the stale owner simply rewrites its own pid-keyed file.
-        _sess.write_t1_addr(owner, "127.0.0.1", 0)
+        pub = self._pubs.get(owner)
+        if pub is not None:
+            pub.tick()  # fenced: sets pub.fenced, writes nothing
 
     def owners_in_scope(self, session_id: str) -> int:
-        # T1 keys on claude_pid, not session-id, so every sibling owns its
-        # own record; one logical session with two MCP siblings shows two.
-        cfg = _sess._nexus_config_dir_at_import()
-        return len(list(cfg.glob("t1_addr.*")))
+        # Session-scoped: two siblings of ONE session converge to one record.
+        return 1 if self.discover() is not None else 0
 
 
 class _LeaseHarness(RecordHarness):
@@ -343,33 +378,38 @@ EXPECTATIONS: dict[str, dict[str, Any]] = {
     "roundtrip": {"t1": "pass", "t2": "pass", "t3": "pass"},
     "reap_ungraceful": {"t1": "pass", "t2": "pass", "t3": "pass"},
     "self_heal": {
-        "t1": (GAP, "#1114: session.py has no self-heal re-assert; RDR-149 P5"),
+        "t1": "pass",  # RDR-149 P4: publisher heartbeat self-heals (#1114)
         "t2": "pass",
         "t3": "pass",  # RDR-149 P3: supervisor heartbeat self-heals
     },
     "concurrent_one_owner": {
-        "t1": (GAP, "T1 keys on claude_pid not session-id; RDR-149 P5/CA-3"),
+        "t1": "pass",  # RDR-149 P4: session-id scope converges to one owner
         "t2": "pass",
         "t3": "pass",
     },
     "version_cycle": {
-        "t1": (GAP, "T1 not covered by any upgrade-cycle; RDR-149 P5"),
+        # T1 is MCP-lifespan-owned, not covered by any upgrade-cycle: an
+        # upgrade republishes by restarting the MCP server, not by an
+        # in-process cycle. This is a documented N/A, not a #1114 blocker
+        # (RDR-149 P4, CA / Approach item 5).
+        "t1": (GAP, "T1 is MCP-lifespan-owned, not upgrade-cycled; RDR-149 P4 N/A"),
         "t2": "pass",
         "t3": "pass",  # RDR-149 P3: supervisor owns cycle_to_current (#1112)
     },
-    # RDR-149 P2/P3: T2 and T3 ride the primitive, so their lease properties pass.
+    # RDR-149 P2/P3/P4: all three tiers ride the primitive, so their lease
+    # properties pass.
     "pid_reuse_immunity": {
-        "t1": (SPEC, "lease/generation kills pid-reuse; RDR-149 P5"),
+        "t1": "pass",  # RDR-149 P4: lease/generation kills pid-reuse
         "t2": "pass",
         "t3": "pass",
     },
     "restart_higher_generation": {
-        "t1": (SPEC, "RF-3: no generation primitive; RDR-149 P5"),
+        "t1": "pass",  # RDR-149 P4: generation fencing token
         "t2": "pass",
         "t3": "pass",
     },
     "restart_race_fencing": {
-        "t1": (SPEC, "CA-4: no fencing token; RDR-149 P5"),
+        "t1": "pass",  # RDR-149 P4: CA-4 heartbeat-fencing arm
         "t2": "pass",
         "t3": "pass",
     },
@@ -527,20 +567,110 @@ class TestLifecycleConformance:
 
 
 # ---------------------------------------------------------------------------
-# T1-only property (CA-3): the transient-key -> session-id re-key. T1 today
-# has no session-id keying, so the property is unsatisfiable until P5.
+# T1-only property (CA-3): the locked RF-2 transient-key -> session-id re-key.
+# The cold-start lifespan race: the SessionStart hook writes current_session
+# independently of the MCP lifespan, so session-id may be None at publish. The
+# publisher keys transiently on the chroma server_pid and re-keys the instant
+# the session-id resolves. RDR-149 P4 makes this real (was xfail through P3).
 # ---------------------------------------------------------------------------
 
 
+_SERVER_PID = 90001
+_SIBLING_SERVER_PID = 90002
+
+
+def _t1_publisher(
+    registry: ServiceRegistry,
+    *,
+    server_pid: int,
+    session_resolver,
+) -> T1LeasePublisher:
+    return T1LeasePublisher(
+        registry=registry,
+        server_pid=server_pid,
+        host="127.0.0.1",
+        port=0,
+        version="1.0.0",
+        session_resolver=session_resolver,
+        owner_token=f"tok-{server_pid}",
+    )
+
+
 class TestT1SessionRekey:
-    def test_record_keyed_on_session_id_not_pid(
-        self, config_dir: Path, alive: _AliveSet, clock: _FakeClock
+    """CA-3: the transient-key -> session-id re-key has no undiscoverable
+    window and no ``"unknown"`` collapse."""
+
+    def _registry(self, config_dir: Path, clock: _FakeClock) -> ServiceRegistry:
+        return ServiceRegistry(
+            dir=config_dir, tier="t1", clock=clock, ttl=3.0, heartbeat_interval=1.0
+        )
+
+    def test_no_record_is_ever_keyed_unknown(
+        self, config_dir: Path, clock: _FakeClock
     ) -> None:
-        pytest.xfail("CA-3: T1 has no session-id-keyed record yet; RDR-149 P5")
-        h = T1RecordHarness(config_dir, alive, clock)
-        h.publish(_OWNER_PID)
-        sess_path = config_dir / "t1_addr.sess-A"
-        assert sess_path.exists(), "no session-id-keyed T1 record"
+        # CA-3 (i): a cold publish with an unresolved session-id keys on the
+        # server_pid, never the legacy "unknown" string.
+        reg = self._registry(config_dir, clock)
+        _t1_publisher(reg, server_pid=_SERVER_PID, session_resolver=lambda: None).publish()
+        assert not (config_dir / "t1_addr.unknown").exists()
+        assert [p.name for p in config_dir.glob("t1_addr.*")] == [
+            f"t1_addr.{_SERVER_PID}"
+        ]
+
+    def test_sibling_discovers_via_server_pid_during_transient_window(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # CA-3 (ii): during the transient window (session-id not yet
+        # resolvable), the record is discoverable under the server_pid key
+        # (the env-passdown Path A breadcrumb), so there is no undiscoverable
+        # window. A sibling resolving by session-id finds nothing yet.
+        reg = self._registry(config_dir, clock)
+        pub = _t1_publisher(reg, server_pid=_SERVER_PID, session_resolver=lambda: None)
+        pub.publish()
+        assert reg.discover(str(_SERVER_PID)) is not None
+        assert reg.discover("sess-A") is None
+
+    def test_rekey_moves_record_to_session_id_atomically(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # The core re-key: transient server_pid record -> session-id record,
+        # transient unlinked, exactly one record at every observable step.
+        reg = self._registry(config_dir, clock)
+        sid: dict[str, str | None] = {"v": None}
+        pub = _t1_publisher(reg, server_pid=_SERVER_PID, session_resolver=lambda: sid["v"])
+        pub.publish()
+        assert (config_dir / f"t1_addr.{_SERVER_PID}").exists()
+
+        sid["v"] = "sess-A"
+        pub.tick()
+
+        assert (config_dir / "t1_addr.sess-A").exists(), "no session-id-keyed record"
+        assert not (config_dir / f"t1_addr.{_SERVER_PID}").exists(), "transient leaked"
+        assert pub.session_keyed
+
+    def test_rekey_atomic_under_concurrent_sibling_flock(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # CA-3 (iii): two siblings of one session re-key concurrently. The
+        # session-key publish is flock-serialized (monotonic generation) and
+        # each unlinks only its own server_pid record. End state: exactly one
+        # session record at generation 2, both transient records gone.
+        reg = self._registry(config_dir, clock)
+        sid: dict[str, str | None] = {"v": None}
+        a = _t1_publisher(reg, server_pid=_SERVER_PID, session_resolver=lambda: sid["v"])
+        b = _t1_publisher(
+            reg, server_pid=_SIBLING_SERVER_PID, session_resolver=lambda: sid["v"]
+        )
+        a.publish()
+        b.publish()
+
+        sid["v"] = "sess-A"
+        a.tick()
+        b.tick()
+
+        assert [p.name for p in config_dir.glob("t1_addr.*")] == ["t1_addr.sess-A"]
+        rec = reg.discover("sess-A")
+        assert rec is not None and rec.generation == 2
 
 
 # ---------------------------------------------------------------------------
@@ -549,10 +679,13 @@ class TestT1SessionRekey:
 
 
 class TestMatrixIsNotVacuous:
-    def test_1114_t1_self_heal_is_red(self) -> None:
-        cell = EXPECTATIONS["self_heal"]["t1"]
-        assert cell != "pass" and cell[0] == GAP
-        assert "#1114" in cell[1]
+    def test_1114_t1_self_heal_fixed_structurally(self) -> None:
+        # #1114 (T1 chroma runs with a lost addr file, no self-heal) was the
+        # red-first GAP cell through P0-P3; RDR-149 P4 fixed it structurally
+        # by migrating T1 onto the leased registry so its publisher heartbeat
+        # self-heals a lost record, exactly as T2/T3 do. This guards against a
+        # regression silently re-opening it.
+        assert EXPECTATIONS["self_heal"]["t1"] == "pass"
 
     def test_1112_t3_version_cycle_fixed_structurally(self) -> None:
         # #1112 (T3 stale after upgrade) was the red-first GAP cell through
@@ -600,6 +733,26 @@ class TestMatrixIsNotVacuous:
             assert EXPECTATIONS[prop]["t3"] == "pass", (
                 f"T3 lease property {prop!r} regressed to non-pass after P3"
             )
+
+    def test_t1_migration_flipped_its_cells(self) -> None:
+        # RDR-149 P4 ratchet: T1 now rides the primitive, so self_heal goes
+        # green (#1114), session-scope converges to one owner, and the lease
+        # SPEC properties pass. version_cycle stays a documented N/A (T1 is
+        # MCP-lifespan-owned, not upgrade-cycled). A regression surfaces here.
+        for prop in (
+            "self_heal",
+            "concurrent_one_owner",
+            "pid_reuse_immunity",
+            "restart_higher_generation",
+            "restart_race_fencing",
+        ):
+            assert EXPECTATIONS[prop]["t1"] == "pass", (
+                f"T1 lease property {prop!r} regressed to non-pass after P4"
+            )
+        cell = EXPECTATIONS["version_cycle"]["t1"]
+        assert isinstance(cell, tuple) and cell[0] == GAP, (
+            "version_cycle[t1] must stay a documented N/A (MCP-lifespan-owned)"
+        )
 
     def test_every_cell_covers_all_tiers(self) -> None:
         for prop, cells in EXPECTATIONS.items():

--- a/tests/daemon/test_t1_lease.py
+++ b/tests/daemon/test_t1_lease.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-149 P4 (bead nexus-8znyd): T1 consumes the leased registry.
+
+Unit coverage for ``T1LeasePublisher`` and ``discover_t1_lease`` with an
+injected clock and an injected ``session_resolver``, so the locked RF-2
+transient-key -> session-id re-key protocol is exercised deterministically
+without a real chroma server or a real SessionStart hook.
+
+T1 stays MCP-lifespan-owned (NOT a supervised daemon, per the RDR
+Decision); it CONSUMES the ``ServiceRegistry`` primitive. The publisher:
+
+* publishes under a TRANSIENT key (the chroma ``server_pid``, unique among
+  live owners, never ``"unknown"``) carrying the resolved-or-None
+  session-id as a payload field;
+* re-keys atomically to the session-id scope the instant
+  ``session_resolver()`` first resolves non-None (CA-3);
+* heartbeats its own lease each tick (self-heal, #1114);
+* relinquishes only its own record on shutdown (CA-4 fencing safety).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.daemon.service_registry import ServiceRegistry, mint_owner_token
+from nexus.daemon.t1_lease import T1LeasePublisher, discover_t1_lease
+
+_SERVER_PID = 4242
+_SIBLING_SERVER_PID = 4343
+_HOST = "127.0.0.1"
+_PORT = 54847
+
+
+class _FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self._t = start
+
+    def __call__(self) -> float:
+        return self._t
+
+    def advance(self, dt: float) -> None:
+        self._t += dt
+
+
+def _registry(config_dir: Path, clock: _FakeClock) -> ServiceRegistry:
+    return ServiceRegistry(
+        dir=config_dir, tier="t1", clock=clock, ttl=3.0, heartbeat_interval=1.0
+    )
+
+
+def _publisher(
+    registry: ServiceRegistry,
+    *,
+    server_pid: int = _SERVER_PID,
+    session_resolver=lambda: None,
+    owner_token: str | None = None,
+) -> T1LeasePublisher:
+    return T1LeasePublisher(
+        registry=registry,
+        server_pid=server_pid,
+        host=_HOST,
+        port=_PORT,
+        version="1.0.0",
+        session_resolver=session_resolver,
+        owner_token=owner_token or mint_owner_token(),
+    )
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    cd = tmp_path / "cfg"
+    cd.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return cd
+
+
+@pytest.fixture
+def clock() -> _FakeClock:
+    return _FakeClock()
+
+
+class TestTransientPublish:
+    def test_publish_keys_on_server_pid_when_session_unresolved(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        reg = _registry(config_dir, clock)
+        pub = _publisher(reg, session_resolver=lambda: None)
+        pub.publish()
+        transient = config_dir / f"t1_addr.{_SERVER_PID}"
+        assert transient.exists(), "no transient server_pid-keyed record"
+        assert not pub.session_keyed
+        assert pub.active_scope_key == str(_SERVER_PID)
+
+    def test_no_record_is_ever_keyed_unknown(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # CA-3 (i): the transient key is the server_pid, never the string
+        # "unknown" that the legacy session-id fallback would have produced.
+        reg = _registry(config_dir, clock)
+        _publisher(reg, session_resolver=lambda: None).publish()
+        assert not (config_dir / "t1_addr.unknown").exists()
+        assert list(config_dir.glob("t1_addr.*")) == [
+            config_dir / f"t1_addr.{_SERVER_PID}"
+        ]
+
+    def test_publish_keys_on_session_directly_when_already_resolved(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # Warm session (claude -p subprocess inherits NX_SESSION_ID): the
+        # session-id resolves at publish time, so there is no transient
+        # window and no re-key needed.
+        reg = _registry(config_dir, clock)
+        pub = _publisher(reg, session_resolver=lambda: "sess-A")
+        pub.publish()
+        assert (config_dir / "t1_addr.sess-A").exists()
+        assert not (config_dir / f"t1_addr.{_SERVER_PID}").exists()
+        assert pub.session_keyed
+        assert pub.active_scope_key == "sess-A"
+
+
+class TestRekey:
+    def test_tick_rekeys_transient_to_session_on_resolution(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # CA-3: the instant session_resolver resolves non-None while still
+        # transient-keyed, the next tick atomically re-keys.
+        reg = _registry(config_dir, clock)
+        sid: dict[str, str | None] = {"v": None}
+        pub = _publisher(reg, session_resolver=lambda: sid["v"])
+        pub.publish()
+        transient = config_dir / f"t1_addr.{_SERVER_PID}"
+        session = config_dir / "t1_addr.sess-A"
+        assert transient.exists() and not session.exists()
+
+        sid["v"] = "sess-A"
+        pub.tick()
+
+        assert session.exists(), "re-key did not write the session-id record"
+        assert not transient.exists(), "re-key did not unlink the transient record"
+        assert pub.session_keyed
+        assert pub.active_scope_key == "sess-A"
+
+    def test_rekey_is_idempotent_after_first_resolution(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        reg = _registry(config_dir, clock)
+        pub = _publisher(reg, session_resolver=lambda: "sess-A")
+        pub.publish()  # keyed on session directly
+        gen_before = pub.record.generation
+        clock.advance(1.0)
+        pub.tick()  # heartbeat only, no re-key
+        assert pub.record.generation == gen_before
+        assert list(config_dir.glob("t1_addr.*")) == [config_dir / "t1_addr.sess-A"]
+
+    def test_rekey_atomic_under_concurrent_sibling(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # CA-3 (iii): two siblings of ONE session each publish transiently,
+        # then both re-key to "sess-A". The session-key publish is flock-
+        # serialized (monotonic generation), and each sibling unlinks only
+        # its own server_pid transient record. End state: exactly one
+        # session record, both transient records gone.
+        reg = _registry(config_dir, clock)
+        sid: dict[str, str | None] = {"v": None}
+        a = _publisher(reg, server_pid=_SERVER_PID, session_resolver=lambda: sid["v"])
+        b = _publisher(
+            reg, server_pid=_SIBLING_SERVER_PID, session_resolver=lambda: sid["v"]
+        )
+        a.publish()
+        b.publish()
+        assert (config_dir / f"t1_addr.{_SERVER_PID}").exists()
+        assert (config_dir / f"t1_addr.{_SIBLING_SERVER_PID}").exists()
+
+        sid["v"] = "sess-A"
+        a.tick()
+        b.tick()
+
+        records = sorted(p.name for p in config_dir.glob("t1_addr.*"))
+        assert records == ["t1_addr.sess-A"], records
+        # The session record carries a monotonic generation > 1 (b's publish
+        # read a's session record and incremented).
+        rec = reg.discover("sess-A")
+        assert rec is not None and rec.generation == 2
+
+
+class TestSelfHeal:
+    def test_tick_self_heals_externally_deleted_record(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # #1114: a transient loss of the record while the owner is alive is
+        # repaired by the next heartbeat tick (re-stamp at the same
+        # generation), unlike legacy session.py which had no re-assert.
+        reg = _registry(config_dir, clock)
+        pub = _publisher(reg, session_resolver=lambda: "sess-A")
+        pub.publish()
+        gen = pub.record.generation
+        (config_dir / "t1_addr.sess-A").unlink()
+        assert reg.discover("sess-A") is None
+
+        pub.tick()
+
+        healed = reg.discover("sess-A")
+        assert healed is not None, "owner alive but record not self-healed"
+        assert healed.generation == gen, "self-heal must preserve the generation"
+
+
+class TestFencing:
+    def test_stale_publisher_tick_is_fenced_not_clobbering(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # CA-4: a slow predecessor's delayed tick must not clobber a newer,
+        # higher-generation owner. tick() swallows StaleOwnerError.
+        reg = _registry(config_dir, clock)
+        pred = _publisher(reg, server_pid=_SERVER_PID, session_resolver=lambda: "sess-A")
+        succ = _publisher(
+            reg, server_pid=_SIBLING_SERVER_PID, session_resolver=lambda: "sess-A"
+        )
+        pred.publish()
+        succ.publish()  # generation 2 takes over
+
+        pred.tick()  # stale: fenced, writes nothing, does not raise
+
+        rec = reg.discover("sess-A")
+        assert rec is not None and rec.generation == 2
+        assert pred.fenced
+
+    def test_relinquish_only_unlinks_own_record(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        reg = _registry(config_dir, clock)
+        pred = _publisher(reg, server_pid=_SERVER_PID, session_resolver=lambda: "sess-A")
+        succ = _publisher(
+            reg, server_pid=_SIBLING_SERVER_PID, session_resolver=lambda: "sess-A"
+        )
+        pred.publish()
+        succ.publish()  # successor now owns sess-A
+
+        pred.relinquish()  # predecessor shuts down late
+
+        rec = reg.discover("sess-A")
+        assert rec is not None, "predecessor relinquish clobbered successor record"
+        assert rec.owner_token == succ.record.owner_token
+
+    def test_relinquish_marks_shutdown_then_unlinks(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        reg = _registry(config_dir, clock)
+        pub = _publisher(reg, session_resolver=lambda: "sess-A")
+        pub.publish()
+        assert (config_dir / "t1_addr.sess-A").exists()
+
+        pub.relinquish()
+
+        assert not (config_dir / "t1_addr.sess-A").exists()
+        assert pub.record is None
+
+
+class TestDiscoverReader:
+    def test_discover_resolves_session_keyed_endpoint(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        reg = _registry(config_dir, clock)
+        pub = _publisher(reg, session_resolver=lambda: "sess-A")
+        pub.publish()
+
+        addr = discover_t1_lease("sess-A", config_dir=config_dir, clock=clock)
+        assert addr == (_HOST, _PORT)
+
+    def test_discover_none_when_no_session_record(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        reg = _registry(config_dir, clock)
+        _publisher(reg, session_resolver=lambda: None).publish()  # transient only
+        # A sibling resolving by session-id finds nothing during the
+        # transient window (it falls back to env Path A in production).
+        assert discover_t1_lease("sess-A", config_dir=config_dir, clock=clock) is None
+
+    def test_discover_none_when_lease_expired(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        reg = _registry(config_dir, clock)
+        _publisher(reg, session_resolver=lambda: "sess-A").publish()
+        clock.advance(3.1)  # past TTL
+        assert discover_t1_lease("sess-A", config_dir=config_dir, clock=clock) is None
+
+    def test_discover_none_for_empty_session_id(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        assert discover_t1_lease(None, config_dir=config_dir, clock=clock) is None
+        assert discover_t1_lease("", config_dir=config_dir, clock=clock) is None

--- a/tests/daemon/test_t1_lease.py
+++ b/tests/daemon/test_t1_lease.py
@@ -255,6 +255,56 @@ class TestFencing:
         assert not (config_dir / "t1_addr.sess-A").exists()
         assert pub.record is None
 
+    def test_tick_is_noop_after_relinquish(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # The SIGTERM-path guard: relinquish() sets _record None; a heartbeat
+        # tick that interleaves (loop already past the cancel point) must not
+        # re-create the record via the self-heal path.
+        reg = _registry(config_dir, clock)
+        pub = _publisher(reg, session_resolver=lambda: "sess-A")
+        pub.publish()
+        pub.relinquish()
+
+        pub.tick()  # must not raise, must not write
+
+        assert reg.discover("sess-A") is None
+        assert not (config_dir / "t1_addr.sess-A").exists()
+
+    def test_rekey_state_advances_even_if_transient_relinquish_fails(
+        self, config_dir: Path, clock: _FakeClock, monkeypatch
+    ) -> None:
+        # IMPORTANT-1: if relinquishing the transient record raises after the
+        # session record is published, the publisher must still commit to the
+        # session key (no re-key loop, no generation inflation). The transient
+        # record then ages out via TTL.
+        reg = _registry(config_dir, clock)
+        sid: dict[str, str | None] = {"v": None}
+        pub = _publisher(reg, session_resolver=lambda: sid["v"])
+        pub.publish()
+
+        real_relinquish = reg.relinquish
+
+        def boom(record):
+            raise OSError("simulated unlink failure")
+
+        sid["v"] = "sess-A"
+        monkeypatch.setattr(reg, "relinquish", boom)
+        pub.tick()  # re-key; transient relinquish raises but is swallowed
+
+        assert pub.session_keyed
+        assert pub.active_scope_key == "sess-A"
+        session_rec = reg.discover("sess-A")
+        assert session_rec is not None and session_rec.generation == 1
+
+        # A subsequent tick heartbeats the SESSION record (no re-key loop):
+        # the generation does not inflate.
+        monkeypatch.setattr(reg, "relinquish", real_relinquish)
+        clock.advance(1.0)
+        pub.tick()
+        again = reg.discover("sess-A")
+        assert again is not None and again.generation == 1
+
 
 class TestDiscoverReader:
     def test_discover_resolves_session_keyed_endpoint(

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -896,58 +896,50 @@ class TestCheckTmpdirs:
 
 
 class TestCheckT1:
-    """Diagnostic: T1 addr-file presence + reachability."""
+    """Diagnostic: T1 session-id lease presence + reachability (RDR-149 P4)."""
 
-    def test_no_claude_ancestor_is_informational(
-        self, runner: CliRunner, tmp_path: Path,
+    @staticmethod
+    def _publish_lease(config_dir, session_id, host, port):
+        from nexus.daemon.service_registry import ServiceRegistry
+        from nexus.daemon.t1_lease import T1LeasePublisher
+
+        registry = ServiceRegistry(dir=Path(config_dir), tier="t1")
+        T1LeasePublisher(
+            registry=registry,
+            server_pid=4242,
+            host=host,
+            port=port,
+            version="1.0.0",
+            session_resolver=lambda: session_id,
+        ).publish()
+
+    def test_no_session_id_is_informational(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
     ) -> None:
-        from unittest.mock import patch
-        with patch("nexus.session.find_immediate_claude_pid", return_value=0):
-            result = runner.invoke(main, ["doctor", "--check-t1"])
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+        result = runner.invoke(main, ["doctor", "--check-t1"])
         assert result.exit_code == 0, result.output
-        assert "no claude ancestor" in result.output.lower()
+        assert "no session-id resolves" in result.output.lower()
 
-    def test_exec_a_wrapper_rename_warns(
-        self, runner: CliRunner, tmp_path: Path,
-    ) -> None:
-        """find_immediate_claude_pid returns the immediate-PPID
-        fallback when no ancestor's comm starts with 'claude'."""
-        from unittest.mock import patch
-        with (
-            patch("nexus.session.find_immediate_claude_pid", return_value=4242),
-            patch("nexus.session._command_name_of", return_value="bash"),
-        ):
-            result = runner.invoke(main, ["doctor", "--check-t1"])
-        assert result.exit_code == 1, result.output
-        assert "exec -a" in result.output
-
-    def test_addr_file_missing_under_live_claude(
+    def test_lease_missing_under_resolved_session(
         self, runner: CliRunner, tmp_path: Path, monkeypatch,
     ) -> None:
-        from unittest.mock import patch
         monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-        with (
-            patch("nexus.session.find_immediate_claude_pid", return_value=4242),
-            patch("nexus.session._command_name_of", return_value="claude"),
-        ):
-            result = runner.invoke(main, ["doctor", "--check-t1"])
+        monkeypatch.setenv("NX_SESSION_ID", "sess-A")
+        result = runner.invoke(main, ["doctor", "--check-t1"])
         assert result.exit_code == 1, result.output
-        assert "missing or unreadable" in result.output
+        assert "no live lease" in result.output
 
-    def test_addr_file_present_but_unreachable(
+    def test_lease_present_but_unreachable(
         self, runner: CliRunner, tmp_path: Path, monkeypatch,
     ) -> None:
         from unittest.mock import patch
 
-        from nexus.session import write_t1_addr
-
         monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-        write_t1_addr(4242, "127.0.0.1", 1)
-        with (
-            patch("nexus.session.find_immediate_claude_pid", return_value=4242),
-            patch("nexus.session._command_name_of", return_value="claude"),
-            patch("nexus.mcp.core._tcp_probe_alive", return_value=False),
-        ):
+        monkeypatch.setenv("NX_SESSION_ID", "sess-A")
+        self._publish_lease(tmp_path, "sess-A", "127.0.0.1", 1)
+        with patch("nexus.mcp.core._tcp_probe_alive", return_value=False):
             result = runner.invoke(main, ["doctor", "--check-t1"])
         assert result.exit_code == 1, result.output
         assert "TCP probe failed" in result.output
@@ -957,15 +949,10 @@ class TestCheckT1:
     ) -> None:
         from unittest.mock import patch
 
-        from nexus.session import write_t1_addr
-
         monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-        write_t1_addr(4242, "127.0.0.1", 12345)
-        with (
-            patch("nexus.session.find_immediate_claude_pid", return_value=4242),
-            patch("nexus.session._command_name_of", return_value="claude"),
-            patch("nexus.mcp.core._tcp_probe_alive", return_value=True),
-        ):
+        monkeypatch.setenv("NX_SESSION_ID", "sess-A")
+        self._publish_lease(tmp_path, "sess-A", "127.0.0.1", 12345)
+        with patch("nexus.mcp.core._tcp_probe_alive", return_value=True):
             result = runner.invoke(main, ["doctor", "--check-t1"])
         assert result.exit_code == 0, result.output
         assert "chroma reachable" in result.output

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -76,52 +76,52 @@ def isolated_home(tmp_path, monkeypatch):
 
 @pytest.fixture
 def scratch_session(isolated_home, monkeypatch):
-    """Boot a real chroma + write the addr file so CLI invocations
-    share state (RDR-105 P4: the legacy session-record discovery is
-    gone; CLI scratch commands resolve via Path B addr file).
+    """Boot a real chroma + publish a session-id lease so CLI invocations
+    share state (RDR-149 P4: T1 rides the leased registry, keyed on the
+    session-id; CLI scratch commands resolve the lease via Path B).
     """
-    import os as _os
     import shutil as _shutil
+    from pathlib import Path as _Path
 
+    from nexus.daemon.service_registry import ServiceRegistry
+    from nexus.daemon.t1_lease import T1LeasePublisher
     from nexus.session import (
-        find_immediate_claude_pid,
         start_t1_server,
         stop_t1_server,
-        unlink_t1_addr,
         write_claude_session_id,
-        write_t1_addr,
     )
 
+    config_dir = isolated_home / ".config" / "nexus"
     # ``HOME`` is already isolated by ``isolated_home``;
-    # ``NEXUS_CONFIG_DIR`` makes that explicit for the addr file path.
-    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(isolated_home / ".config" / "nexus"))
+    # ``NEXUS_CONFIG_DIR`` makes that explicit for the lease path.
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
     monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
     monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
     # Pin the session_id across CLI invocations so all writes/reads
-    # see the same metadata filter scope. Each ``runner.invoke``
-    # constructs a fresh ``T1Database``; without a stable session_id
-    # the T1 metadata filter excludes prior-invocation writes.
-    monkeypatch.setenv("NX_SESSION_ID", "integration-test-session")
+    # see the same metadata filter scope AND resolve the same lease.
+    # Each ``runner.invoke`` constructs a fresh ``T1Database``; without a
+    # stable session_id the T1 metadata filter excludes prior writes.
+    session_id = "integration-test-session"
+    monkeypatch.setenv("NX_SESSION_ID", session_id)
 
-    write_claude_session_id("integration-test-session")
+    write_claude_session_id(session_id)
     host, port, server_pid, tmpdir = start_t1_server()
 
-    # Pin the addr file at THIS test's PID so CLI invocations
-    # (whose PPID walk lands on this pytest process) discover it.
-    own_pid = _os.getpid()
-    monkeypatch.setattr(
-        "nexus.session.find_immediate_claude_pid",
-        lambda start_pid=None: own_pid,
+    # Publish the session-id-keyed lease the CLI invocations will resolve.
+    registry = ServiceRegistry(dir=_Path(config_dir), tier="t1")
+    publisher = T1LeasePublisher(
+        registry=registry,
+        server_pid=server_pid,
+        host=host,
+        port=port,
+        version="1.0.0",
+        session_resolver=lambda: session_id,
     )
-    monkeypatch.setattr(
-        "nexus.db.t1.find_immediate_claude_pid",
-        lambda start_pid=None: own_pid,
-    )
-    write_t1_addr(own_pid, host, port)
+    publisher.publish()
 
     yield
 
-    unlink_t1_addr(own_pid)
+    publisher.relinquish()
     stop_t1_server(server_pid)
     _shutil.rmtree(tmpdir, ignore_errors=True)
 

--- a/tests/test_t1_discovery.py
+++ b/tests/test_t1_discovery.py
@@ -23,9 +23,49 @@ import json
 import os
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
+
+def _discover_t1_endpoint(config_dir, scope_key) -> tuple[str, int] | None:
+    """RDR-149 P4 test helper: read the live T1 lease for ``scope_key``
+    (a session-id or a transient server_pid) and return ``(host, port)``.
+
+    Replaces the legacy ``read_t1_addr_for(claude_pid)`` probe now that T1
+    rides the leased registry instead of the ``host:port`` addr file.
+    """
+    from nexus.daemon.service_registry import ServiceRegistry
+
+    registry = ServiceRegistry(dir=Path(config_dir), tier="t1")
+    record = registry.discover(str(scope_key))
+    if record is None:
+        return None
+    host = record.endpoint.get("host")
+    port = record.endpoint.get("port")
+    if host is None or port is None:
+        return None
+    return host, port
+
+
+def _publish_t1_session_lease(config_dir, session_id, host, port, *, server_pid=4242):
+    """RDR-149 P4 test helper: publish a session-id-keyed T1 lease so a
+    discovery path that resolves ``session_id`` finds ``(host, port)``."""
+    from nexus.daemon.service_registry import ServiceRegistry
+    from nexus.daemon.t1_lease import T1LeasePublisher
+
+    registry = ServiceRegistry(dir=Path(config_dir), tier="t1")
+    publisher = T1LeasePublisher(
+        registry=registry,
+        server_pid=server_pid,
+        host=host,
+        port=port,
+        version="1.0.0",
+        session_resolver=lambda: session_id,
+    )
+    publisher.publish()
+    return publisher
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -353,7 +393,8 @@ class TestT1DatabaseFlagOnEnvPath:
 
 
 class TestT1DatabaseFlagOnFilePath:
-    """Path B: subprocess sibling reads addr file via PPID walk."""
+    """Path B (RDR-149 P4): sibling resolves a session-id and reads the
+    live session-id-keyed lease."""
 
     def test_file_path_uses_http_client(self, tmp_path, monkeypatch):
         from unittest.mock import MagicMock
@@ -367,13 +408,14 @@ class TestT1DatabaseFlagOnFilePath:
         monkeypatch.delenv("NX_T1_HOST", raising=False)
         monkeypatch.delenv("NX_T1_PORT", raising=False)
         monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+        monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
+        # The writer (MCP lifespan) published a session-id lease; the reader
+        # resolves the same session-id from NX_SESSION_ID.
+        _publish_t1_session_lease(tmp_path, "sess-A", "127.0.0.1", 9999)
+        monkeypatch.setenv("NX_SESSION_ID", "sess-A")
 
-        from nexus.session import write_t1_addr
-        write_t1_addr(11111, "127.0.0.1", 9999)
-
-        with patch("nexus.db.t1.find_immediate_claude_pid", return_value=11111):
-            from nexus.db.t1 import T1Database
-            T1Database()
+        from nexus.db.t1 import T1Database
+        T1Database()
         fake_chromadb.HttpClient.assert_called_once_with(host="127.0.0.1", port=9999)
 
 
@@ -414,9 +456,8 @@ class TestT1DatabaseFlagOnIsolationPath:
         monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
         monkeypatch.setenv("NX_T1_ISOLATED", "1")
 
-        with patch("nexus.db.t1.find_immediate_claude_pid", return_value=99999):
-            from nexus.db.t1 import T1Database
-            db = T1Database()
+        from nexus.db.t1 import T1Database
+        db = T1Database()
 
         fake_chromadb.HttpClient.assert_not_called()
         fake_chromadb.EphemeralClient.assert_called_once()
@@ -439,9 +480,8 @@ class TestT1DatabaseFlagOnIsolationPath:
         monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
         monkeypatch.setenv("NEXUS_SKIP_T1", "1")
 
-        with patch("nexus.db.t1.find_immediate_claude_pid", return_value=99999):
-            from nexus.db.t1 import T1Database
-            T1Database()
+        from nexus.db.t1 import T1Database
+        T1Database()
 
         fake_chromadb.EphemeralClient.assert_called_once()
 
@@ -463,11 +503,13 @@ class TestT1DatabaseFlagOnRaisesOnMisconfiguration:
         monkeypatch.delenv("NX_T1_PORT", raising=False)
         monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
         monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+        # No session-id resolves, so the session-id lease path (Path B) is
+        # skipped and the constructor fails loud (RDR-149 P4).
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
 
-        with patch("nexus.db.t1.find_immediate_claude_pid", return_value=99999):
-            from nexus.db.t1 import T1Database, T1ServerNotFoundError
-            with pytest.raises(T1ServerNotFoundError, match="NX_T1"):
-                T1Database()
+        from nexus.db.t1 import T1Database, T1ServerNotFoundError
+        with pytest.raises(T1ServerNotFoundError, match="NX_T1"):
+            T1Database()
 
         fake_chromadb.HttpClient.assert_not_called()
         fake_chromadb.EphemeralClient.assert_not_called()
@@ -534,13 +576,14 @@ class TestT1DatabaseFlagOnPrecedence:
         monkeypatch.setenv("NX_T1_PORT", "1111")
         monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
 
-        from nexus.session import write_t1_addr
-        write_t1_addr(22222, "10.0.0.2", 2222)
+        # A session-id lease also exists, but env (Path A) outranks the
+        # session-id lease path (Path B) (RF-5 precedence).
+        _publish_t1_session_lease(tmp_path, "sess-A", "10.0.0.2", 2222)
+        monkeypatch.setenv("NX_SESSION_ID", "sess-A")
 
-        with patch("nexus.db.t1.find_immediate_claude_pid", return_value=22222):
-            from nexus.db.t1 import T1Database
-            T1Database()
-        # Should have used env-supplied 10.0.0.1:1111, not file-supplied 10.0.0.2:2222.
+        from nexus.db.t1 import T1Database
+        T1Database()
+        # Should have used env-supplied 10.0.0.1:1111, not lease-supplied 10.0.0.2:2222.
         fake_chromadb.HttpClient.assert_called_once_with(host="10.0.0.1", port=1111)
 
 
@@ -586,12 +629,12 @@ class TestT1DatabaseIsolatedOverridesDiscovery:
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setenv("NX_T1_ISOLATED", "1")
 
-        from nexus.session import write_t1_addr
-        write_t1_addr(44444, "10.0.0.2", 2222)
+        # A session-id lease exists, but isolation (Path C) outranks it.
+        _publish_t1_session_lease(tmp_path, "sess-A", "10.0.0.2", 2222)
+        monkeypatch.setenv("NX_SESSION_ID", "sess-A")
 
-        with patch("nexus.db.t1.find_immediate_claude_pid", return_value=44444):
-            from nexus.db.t1 import T1Database
-            T1Database()
+        from nexus.db.t1 import T1Database
+        T1Database()
 
         fake_chromadb.EphemeralClient.assert_called_once()
         fake_chromadb.HttpClient.assert_not_called()
@@ -610,12 +653,12 @@ class TestT1DatabaseIsolatedOverridesDiscovery:
         monkeypatch.setenv("NX_T1_ISOLATED", "1")
         monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
 
-        from nexus.session import write_t1_addr
-        write_t1_addr(55555, "10.0.0.3", 3333)
+        # Both an env pair and a session-id lease exist; isolation outranks both.
+        _publish_t1_session_lease(tmp_path, "sess-A", "10.0.0.3", 3333)
+        monkeypatch.setenv("NX_SESSION_ID", "sess-A")
 
-        with patch("nexus.db.t1.find_immediate_claude_pid", return_value=55555):
-            from nexus.db.t1 import T1Database
-            T1Database()
+        from nexus.db.t1 import T1Database
+        T1Database()
 
         fake_chromadb.EphemeralClient.assert_called_once()
         fake_chromadb.HttpClient.assert_not_called()
@@ -691,19 +734,18 @@ def _setup_path(path_id: str, tmp_path, monkeypatch, fake_chromadb):
         monkeypatch.setenv("NX_T1_PORT", "5555")
         return {}, "HttpClient"
     if path_id == "addr_file":
-        from nexus.session import write_t1_addr
-        write_t1_addr(33333, "127.0.0.1", 6666)
+        # RDR-149 P4: Path B resolves a session-id, then reads the live
+        # session-id-keyed lease. The session-id is whatever the test's
+        # resolution chain produces; the lease reader is stubbed to return a
+        # live endpoint so this path exercises session_id resolution without
+        # coupling to a specific session string.
         monkeypatch.setattr(
-            "nexus.db.t1.find_immediate_claude_pid",
-            lambda start_pid=None: 33333,
+            "nexus.daemon.t1_lease.discover_t1_lease",
+            lambda session_id, **kw: ("127.0.0.1", 6666),
         )
         return {}, "HttpClient"
     if path_id == "isolation":
         monkeypatch.setenv("NX_T1_ISOLATED", "1")
-        monkeypatch.setattr(
-            "nexus.db.t1.find_immediate_claude_pid",
-            lambda start_pid=None: 0,
-        )
         return {}, "EphemeralClient"
     if path_id == "client_injection":
         return {"client": fake_chromadb.EphemeralClient.return_value}, None
@@ -781,7 +823,11 @@ class TestT1DatabaseSessionIdResolution:
         db = T1Database(**kwargs)
         assert db.session_id == "canonical-claude-uuid"
 
-    @pytest.mark.parametrize("path_id", _PATH_IDS)
+    # RDR-149 P4: the ``addr_file`` (session-id lease) path is excluded here.
+    # With no session-id resolving, Path B cannot discover a lease, so only
+    # the env / isolation / client-injection paths can reach the session_id
+    # assignment under test.
+    @pytest.mark.parametrize("path_id", ["env", "isolation", "client_injection"])
     def test_unknown_fallback_when_nothing_set(
         self, path_id, tmp_path, monkeypatch, fake_chromadb
     ):
@@ -833,13 +879,10 @@ class TestE2ESessionIdSharedAcrossProcesses:
 
         from nexus.session import (
             stop_t1_server,
-            unlink_t1_addr,
             write_claude_session_id,
-            write_t1_addr,
         )
 
         host, port, server_pid, chroma_tmpdir = _start_real_chroma()
-        own_pid = os.getpid()
         canonical = "11111111-2222-3333-4444-555555555555"
         try:
             # Populate NEXUS_CONFIG_DIR with: current_session pointer +
@@ -865,18 +908,19 @@ class TestE2ESessionIdSharedAcrossProcesses:
                     lambda: tmp_path
                 )
                 write_claude_session_id(canonical)
-                write_t1_addr(own_pid, host, port)
             finally:
                 _sess._nexus_config_dir_at_import = real_dir_at_import
+
+            # RDR-149 P4: publish the session-id-keyed lease the children
+            # resolve from the current_session pointer.
+            publisher = _publish_t1_session_lease(
+                tmp_path, canonical, host, port, server_pid=server_pid
+            )
 
             try:
                 child_code = (
                     "import os, sys, json\n"
                     "from nexus.db.t1 import T1Database\n"
-                    "import nexus.session as _sess\n"
-                    "import nexus.db.t1 as _t1\n"
-                    f"_sess.find_immediate_claude_pid = lambda start_pid=None: {own_pid}\n"
-                    f"_t1.find_immediate_claude_pid = lambda start_pid=None: {own_pid}\n"
                     "action = sys.argv[1]\n"
                     "db = T1Database()\n"
                     "if action == 'put':\n"
@@ -913,7 +957,7 @@ class TestE2ESessionIdSharedAcrossProcesses:
                 # (b) put-from-A is visible from list-in-B.
                 assert "hello-from-A" in b_result["items"], b_result
             finally:
-                unlink_t1_addr(own_pid)
+                publisher.relinquish()
         finally:
             stop_t1_server(server_pid)
             shutil.rmtree(chroma_tmpdir, ignore_errors=True)
@@ -1072,19 +1116,20 @@ class TestLifespanNewDiscoveryGenerator:
         assert called["write"] == 0
 
     def test_branch3_top_level_spawns_and_publishes(self, tmp_path, monkeypatch):
-        """No env, no isolation -> spawn chroma + write addr file +
-        populate ``_t1_state.T1_ADDR``. Cleanup unlinks file + resets
-        the variable."""
+        """RDR-149 P4: no env, no isolation, no resolvable session -> spawn
+        chroma + publish a transient ``server_pid``-keyed lease + populate
+        ``_t1_state.T1_ADDR``. Cleanup relinquishes the lease + resets the
+        variable."""
         import asyncio
 
         from nexus.mcp import _t1_state, core as mcp_core
-        from nexus.session import read_t1_addr_for
 
         monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
         monkeypatch.delenv("NX_T1_HOST", raising=False)
         monkeypatch.delenv("NX_T1_PORT", raising=False)
         monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
         monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
 
         prev_addr = _t1_state.T1_ADDR
         _t1_state.T1_ADDR = None
@@ -1096,27 +1141,28 @@ class TestLifespanNewDiscoveryGenerator:
 
             with patch("nexus.session.start_t1_server",
                        return_value=("127.0.0.1", 33333, 99999, str(tmp_path / "chroma_tmpdir"))), \
-                 patch("nexus.session.stop_t1_server", side_effect=fake_stop), \
-                 patch("nexus.session.find_immediate_claude_pid", return_value=44444):
+                 patch("nexus.session.stop_t1_server", side_effect=fake_stop):
                 async def _run():
                     async with mcp_core._t1_chroma_lifespan(None):
-                        # During the body: addr file present + state set
-                        assert read_t1_addr_for(44444) == ("127.0.0.1", 33333)
+                        # During the body: transient server_pid lease present
+                        # (session-id unresolved) + state set.
+                        assert _discover_t1_endpoint(tmp_path, 99999) == ("127.0.0.1", 33333)
                         assert _t1_state.T1_ADDR == ("127.0.0.1", 33333)
                 asyncio.run(_run())
 
-            # After body: cleanup.
-            assert read_t1_addr_for(44444) is None
+            # After body: cleanup relinquished the lease.
+            assert _discover_t1_endpoint(tmp_path, 99999) is None
             assert _t1_state.T1_ADDR is None
             assert calls["stop"] == 1
         finally:
             _t1_state.T1_ADDR = prev_addr
 
     def test_branch3_emits_t1_chroma_init_owned_log(self, tmp_path, monkeypatch):
-        """nexus-7m8i: happy-path spawn emits exactly one
+        """nexus-7m8i / RDR-149 P4: happy-path spawn emits exactly one
         ``t1_chroma_init_owned`` info log with host/port/server_pid/
-        claude_pid/tmpdir. The no-claude-pid path emits the warning
-        instead (covered indirectly by the absence of the info)."""
+        scope_key/session_keyed/tmpdir. With no resolvable session-id the
+        lease is keyed transiently on the server_pid (``session_keyed``
+        False)."""
         import asyncio
         import logging
 
@@ -1130,6 +1176,7 @@ class TestLifespanNewDiscoveryGenerator:
         monkeypatch.delenv("NX_T1_PORT", raising=False)
         monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
         monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
 
         # The default structlog wrapper filters at WARNING in test
         # context; lower to INFO so capture_logs sees the happy-path
@@ -1144,9 +1191,7 @@ class TestLifespanNewDiscoveryGenerator:
             with patch("nexus.session.start_t1_server",
                        return_value=("127.0.0.1", 51515, 88888,
                                      str(tmp_path / "chroma_tmpdir"))), \
-                 patch("nexus.session.stop_t1_server"), \
-                 patch("nexus.session.find_immediate_claude_pid",
-                       return_value=12321):
+                 patch("nexus.session.stop_t1_server"):
                 with capture_logs() as cap:
                     async def _run():
                         async with mcp_core._t1_chroma_lifespan(None):
@@ -1165,27 +1210,19 @@ class TestLifespanNewDiscoveryGenerator:
             assert ev["host"] == "127.0.0.1"
             assert ev["port"] == 51515
             assert ev["server_pid"] == 88888
-            assert ev["claude_pid"] == 12321
+            assert ev["scope_key"] == "88888"  # transient server_pid key
+            assert ev["session_keyed"] is False
             assert ev["tmpdir"] == str(tmp_path / "chroma_tmpdir")
-
-            # The warning path must NOT fire on the happy branch.
-            warnings = [
-                e for e in cap
-                if e.get("event") == "t1_addr_publish_skipped_no_claude_pid"
-            ]
-            assert warnings == []
         finally:
             _t1_state.T1_ADDR = prev_addr
             if prev_wrapper is not None:
                 structlog.configure(wrapper_class=prev_wrapper)
 
-    def test_branch3_no_claude_pid_emits_warning_not_info(
-        self, tmp_path, monkeypatch,
-    ):
-        """When ``find_immediate_claude_pid`` returns 0, the warning
-        fires and the happy-path info does NOT (nexus-7m8i symmetry)."""
+    def test_branch3_warm_session_keys_on_session_id(self, tmp_path, monkeypatch):
+        """RDR-149 P4: when the session-id resolves at publish time (warm
+        session / inherited ``NX_SESSION_ID``), the lease is keyed on the
+        session-id directly with no transient window."""
         import asyncio
-        from structlog.testing import capture_logs
 
         from nexus.mcp import _t1_state, core as mcp_core
 
@@ -1194,82 +1231,31 @@ class TestLifespanNewDiscoveryGenerator:
         monkeypatch.delenv("NX_T1_PORT", raising=False)
         monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
         monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+        monkeypatch.setenv("NX_SESSION_ID", "sess-warm")
 
         prev_addr = _t1_state.T1_ADDR
         _t1_state.T1_ADDR = None
         try:
             with patch("nexus.session.start_t1_server",
-                       return_value=("127.0.0.1", 51515, 88888,
-                                     str(tmp_path / "chroma_tmpdir"))), \
-                 patch("nexus.session.stop_t1_server"), \
-                 patch("nexus.session.find_immediate_claude_pid",
-                       return_value=0):
-                with capture_logs() as cap:
-                    async def _run():
-                        async with mcp_core._t1_chroma_lifespan(None):
-                            pass
-                    asyncio.run(_run())
-
-            owned = [e for e in cap if e.get("event") == "t1_chroma_init_owned"]
-            warned = [
-                e for e in cap
-                if e.get("event") == "t1_addr_publish_skipped_no_claude_pid"
-            ]
-            assert owned == []
-            assert len(warned) == 1
-            assert warned[0]["log_level"] == "warning"
-        finally:
-            _t1_state.T1_ADDR = prev_addr
-
-    def test_branch3_no_claude_pid_skips_publish_but_keeps_chroma(
-        self, tmp_path, monkeypatch
-    ):
-        """When ``find_immediate_claude_pid`` returns 0, the lifespan
-        emits a warning, skips the addr-file write, leaves
-        ``_t1_state.T1_ADDR`` unset, and still tears chroma down on
-        exit. Documents the unusual-process-parentage edge."""
-        import asyncio
-
-        from nexus.mcp import _t1_state, core as mcp_core
-        from nexus.session import read_t1_addr_for
-
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-        monkeypatch.delenv("NX_T1_HOST", raising=False)
-        monkeypatch.delenv("NX_T1_PORT", raising=False)
-        monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
-        monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
-
-        prev_addr = _t1_state.T1_ADDR
-        _t1_state.T1_ADDR = None
-        calls = {"stop": 0}
-        try:
-            with patch("nexus.session.start_t1_server",
-                       return_value=("127.0.0.1", 33333, 99999, str(tmp_path / "chroma_tmpdir"))), \
-                 patch("nexus.session.stop_t1_server",
-                       side_effect=lambda _p: calls.update(stop=calls["stop"] + 1)), \
-                 patch("nexus.session.find_immediate_claude_pid", return_value=0):
+                       return_value=("127.0.0.1", 41414, 77777, str(tmp_path / "chroma_tmpdir"))), \
+                 patch("nexus.session.stop_t1_server"):
                 async def _run():
                     async with mcp_core._t1_chroma_lifespan(None):
-                        # No addr file, no T1_ADDR, but chroma is running.
-                        assert _t1_state.T1_ADDR is None
-                        # No file at any pid (we mocked walker to 0).
-                        for pid in (0, 1, 100, 99999):
-                            assert read_t1_addr_for(pid) is None
+                        # Keyed on the session-id, not the server_pid.
+                        assert _discover_t1_endpoint(tmp_path, "sess-warm") == ("127.0.0.1", 41414)
+                        assert _discover_t1_endpoint(tmp_path, 77777) is None
                 asyncio.run(_run())
 
-            assert calls["stop"] == 1
-            assert _t1_state.T1_ADDR is None
+            assert _discover_t1_endpoint(tmp_path, "sess-warm") is None  # relinquished
         finally:
             _t1_state.T1_ADDR = prev_addr
 
     def test_sigterm_path_cleans_up_via_owned_chroma(self, tmp_path, monkeypatch):
         """Stdio SIGTERM scenario: lifespan body has populated
-        ``_OWNED_CHROMA``; ``_t1_chroma_shutdown`` runs (signal
-        handler / atexit) and dispatches to the new-discovery impl
-        instead of the legacy one. Idempotent with the lifespan's
-        own finally."""
+        ``_OWNED_CHROMA`` with the lease publisher; ``_t1_chroma_shutdown``
+        runs (signal handler / atexit), relinquishes the lease, and stops
+        chroma. Idempotent with the lifespan's own finally (RDR-149 P4)."""
         from nexus.mcp import _t1_state, core as mcp_core
-        from nexus.session import read_t1_addr_for, write_t1_addr
 
         monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
 
@@ -1277,14 +1263,17 @@ class TestLifespanNewDiscoveryGenerator:
         prev_addr = _t1_state.T1_ADDR
         prev_inflight = mcp_core._SHUTDOWN_IN_FLIGHT
         try:
-            # Simulate a populated lifespan-body state.
-            write_t1_addr(88888, "127.0.0.1", 7777)
+            # Simulate a populated lifespan-body state: a published lease.
+            publisher = _publish_t1_session_lease(
+                tmp_path, "sess-A", "127.0.0.1", 7777, server_pid=12345
+            )
+            assert _discover_t1_endpoint(tmp_path, "sess-A") == ("127.0.0.1", 7777)
             _t1_state.T1_ADDR = ("127.0.0.1", 7777)
             mcp_core._OWNED_CHROMA.clear()
             mcp_core._OWNED_CHROMA.update({
                 "server_pid": 12345,
                 "tmpdir": str(tmp_path / "chroma_tmpdir"),
-                "t1_addr_claude_pid": 88888,
+                "t1_lease_publisher": publisher,
             })
             mcp_core._SHUTDOWN_IN_FLIGHT = False
 
@@ -1294,8 +1283,8 @@ class TestLifespanNewDiscoveryGenerator:
                 # SIGTERM-equivalent: atexit / signal handler entry.
                 mcp_core._t1_chroma_shutdown()
 
-            # Cleanup ran: addr file gone, state reset, chroma stopped.
-            assert read_t1_addr_for(88888) is None
+            # Cleanup ran: lease relinquished, state reset, chroma stopped.
+            assert _discover_t1_endpoint(tmp_path, "sess-A") is None
             assert _t1_state.T1_ADDR is None
             assert calls["stop"] == 1
             assert not mcp_core._OWNED_CHROMA
@@ -1314,9 +1303,9 @@ class TestLifespanNewDiscoveryGenerator:
             mcp_core._SHUTDOWN_IN_FLIGHT = prev_inflight
 
     def test_branch3_chroma_reaped_when_publish_raises(self, tmp_path, monkeypatch):
-        """If ``write_t1_addr`` raises, the lifespan's finally still
+        """If the lease ``publish`` raises, the lifespan's finally still
         reaps chroma (no orphan process). Validates the spawn-then-
-        try/finally layout."""
+        try/finally layout (RDR-149 P4)."""
         import asyncio
 
         from nexus.mcp import _t1_state, core as mcp_core
@@ -1332,15 +1321,14 @@ class TestLifespanNewDiscoveryGenerator:
         try:
             calls = {"stop": 0}
 
-            def boom(*args, **kwargs):
-                raise OSError("simulated disk-full at addr-file write")
+            def boom(self):
+                raise OSError("simulated disk-full at lease publish")
 
             with patch("nexus.session.start_t1_server",
                        return_value=("127.0.0.1", 4242, 1234, str(tmp_path / "chroma_tmpdir"))), \
                  patch("nexus.session.stop_t1_server",
                        side_effect=lambda _p: calls.update(stop=calls["stop"] + 1)), \
-                 patch("nexus.session.find_immediate_claude_pid", return_value=11), \
-                 patch("nexus.session.write_t1_addr", side_effect=boom):
+                 patch("nexus.daemon.t1_lease.T1LeasePublisher.publish", side_effect=boom, autospec=True):
                 async def _run():
                     async with mcp_core._t1_chroma_lifespan(None):
                         pass
@@ -1358,62 +1346,53 @@ class TestLifespanNewDiscoveryGenerator:
             mcp_core._OWNED_CHROMA.update(prev_owned)
             _t1_state.T1_ADDR = prev_addr
 
-    def test_owned_respawn_does_not_clobber_parent_file(self, tmp_path, monkeypatch):
-        """RDR-105 RF-6 owned-mode invariant at the lifespan layer.
+    def test_owned_respawn_keys_on_own_server_pid_not_a_sibling(self, tmp_path, monkeypatch):
+        """RDR-149 P4: the owned-mode isolation invariant under the lease
+        model. An owned MCP's lifespan keys its lease on ITS OWN chroma
+        ``server_pid`` (unique per process), so it can never clobber a
+        sibling/parent's record. This supersedes the RDR-105 RF-6
+        claude_pid PPID-walk clobber concern, which P4 eliminates by
+        dropping claude_pid keying entirely.
 
-        Scenario: a top-level Claude (claude_pid=100) is running; its
-        MCP wrote ``t1_addr.100``. An owned ``claude -p`` subprocess
-        starts (its own claude_pid=200). The owned MCP's lifespan
-        spawns its own chroma and writes ``t1_addr.200``.
-
-        Invariant: the owned MCP MUST NOT touch ``t1_addr.100``. If
-        ``find_immediate_claude_pid`` accidentally returned 100 (the
-        topmost-walk bug RF-6 closes), the owned MCP would clobber
-        the parent's file with its own chroma's address.
-
-        This test simulates the scenario and locks the contract at the
-        lifespan layer; companion to the unit test on
-        ``find_immediate_claude_pid`` itself.
+        Scenario: a sibling's transient lease at ``t1_addr.<100>`` already
+        exists; the owned MCP spawns its own chroma (server_pid=22222) and
+        publishes ``t1_addr.<22222>`` without touching the sibling's record.
         """
         import asyncio
 
         from nexus.mcp import _t1_state, core as mcp_core
-        from nexus.session import read_t1_addr_for, write_t1_addr
 
         monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
         monkeypatch.delenv("NX_T1_HOST", raising=False)
         monkeypatch.delenv("NX_T1_PORT", raising=False)
         monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
         monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
 
-        # Pre-existing parent's addr file.
-        write_t1_addr(100, "127.0.0.1", 11111)
-        parent_before = read_t1_addr_for(100)
-        assert parent_before == ("127.0.0.1", 11111)
+        # A sibling's transient lease (keyed on its own server_pid=100).
+        _publish_t1_session_lease(tmp_path, None, "127.0.0.1", 11111, server_pid=100)
+        assert _discover_t1_endpoint(tmp_path, 100) == ("127.0.0.1", 11111)
 
         prev_addr = _t1_state.T1_ADDR
         _t1_state.T1_ADDR = None
         try:
             with patch("nexus.session.start_t1_server",
-                       return_value=("127.0.0.1", 22222, 99999, str(tmp_path / "owned_chroma_tmpdir"))), \
+                       return_value=("127.0.0.1", 22222, 22222, str(tmp_path / "owned_chroma_tmpdir"))), \
                  patch("nexus.session.stop_t1_server", side_effect=lambda _p: None), \
-                 patch("nexus.session.find_immediate_claude_pid", return_value=200), \
                  patch("nexus.session.sweep_orphan_t1_addr_files", return_value=0):
-                # The orphan-reaper sweep on lifespan entry would
-                # reap the test's fake parent file (pid 100 is not
-                # a live process). Patch it off so the RF-6
-                # invariant under test is exercised cleanly.
+                # Patch the orphan-reaper sweep off so it does not reap the
+                # sibling's transient lease (server_pid=100 is not a live pid).
                 async def _run():
                     async with mcp_core._t1_chroma_lifespan(None):
-                        # Owned MCP wrote its OWN file at claude_pid=200.
-                        assert read_t1_addr_for(200) == ("127.0.0.1", 22222)
-                        # Parent's file at claude_pid=100 is UNCHANGED.
-                        assert read_t1_addr_for(100) == ("127.0.0.1", 11111)
+                        # Owned MCP keyed on its OWN server_pid.
+                        assert _discover_t1_endpoint(tmp_path, 22222) == ("127.0.0.1", 22222)
+                        # The sibling's record is UNTOUCHED.
+                        assert _discover_t1_endpoint(tmp_path, 100) == ("127.0.0.1", 11111)
                 asyncio.run(_run())
 
-            # After cleanup: owned's file unlinked, parent's still intact.
-            assert read_t1_addr_for(200) is None
-            assert read_t1_addr_for(100) == ("127.0.0.1", 11111)
+            # After cleanup: owned's lease relinquished, sibling's intact.
+            assert _discover_t1_endpoint(tmp_path, 22222) is None
+            assert _discover_t1_endpoint(tmp_path, 100) == ("127.0.0.1", 11111)
         finally:
             _t1_state.T1_ADDR = prev_addr
 
@@ -1423,21 +1402,20 @@ class TestLifespanNewDiscoveryGenerator:
         import asyncio
 
         from nexus.mcp import _t1_state, core as mcp_core
-        from nexus.session import read_t1_addr_for
 
         monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
         monkeypatch.delenv("NX_T1_HOST", raising=False)
         monkeypatch.delenv("NX_T1_PORT", raising=False)
         monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
         monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
 
         prev_addr = _t1_state.T1_ADDR
         _t1_state.T1_ADDR = None
         try:
             with patch("nexus.session.start_t1_server",
-                       return_value=("127.0.0.1", 33333, 99999, str(tmp_path / "chroma_tmpdir"))), \
-                 patch("nexus.session.stop_t1_server", side_effect=lambda _p: None), \
-                 patch("nexus.session.find_immediate_claude_pid", return_value=55555):
+                       return_value=("127.0.0.1", 33333, 55555, str(tmp_path / "chroma_tmpdir"))), \
+                 patch("nexus.session.stop_t1_server", side_effect=lambda _p: None):
                 async def _run():
                     async with mcp_core._t1_chroma_lifespan(None):
                         raise RuntimeError("body error")
@@ -1445,7 +1423,7 @@ class TestLifespanNewDiscoveryGenerator:
                 with pytest.raises(RuntimeError, match="body error"):
                     asyncio.run(_run())
 
-            assert read_t1_addr_for(55555) is None
+            assert _discover_t1_endpoint(tmp_path, 55555) is None
             assert _t1_state.T1_ADDR is None
         finally:
             _t1_state.T1_ADDR = prev_addr
@@ -1486,38 +1464,33 @@ class TestE2EFileDiscovery:
     default unit suite. Run via ``uv run pytest -m integration``.
     """
 
-    def test_sibling_subprocess_connects_via_addr_file(
+    def test_sibling_subprocess_connects_via_session_lease(
         self, tmp_path, monkeypatch
     ):
         import shutil
 
-        from nexus.session import (
-            stop_t1_server,
-            unlink_t1_addr,
-            write_t1_addr,
-        )
+        from nexus.session import stop_t1_server
 
         monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
 
         host, port, server_pid, chroma_tmpdir = _start_real_chroma()
-        own_pid = os.getpid()
+        session_id = "spike-session"
         try:
-            write_t1_addr(own_pid, host, port)
+            # The writer (MCP lifespan) published a session-id-keyed lease.
+            publisher = _publish_t1_session_lease(
+                tmp_path, session_id, host, port, server_pid=server_pid
+            )
             try:
-                # Spawn a "sibling" subprocess that simulates a Bash-tool
-                # invocation. find_immediate_claude_pid is monkey-pinned to
-                # our PID so the test's own process plays the role of the
-                # subprocess's owning Claude ancestor.
+                # A "sibling" subprocess (Bash-tool invocation) resolves the
+                # same session-id from NX_SESSION_ID and reads the lease.
                 code = (
                     "import os\n"
                     f"os.environ['NEXUS_CONFIG_DIR'] = {str(tmp_path)!r}\n"
+                    f"os.environ['NX_SESSION_ID'] = {session_id!r}\n"
                     "os.environ.pop('NX_T1_HOST', None)\n"
                     "os.environ.pop('NX_T1_PORT', None)\n"
                     "os.environ.pop('NEXUS_SKIP_T1', None)\n"
-                    "import nexus.session as session\n"
-                    f"session.find_immediate_claude_pid = lambda start_pid=None: {own_pid}\n"
-                    "import nexus.db.t1 as t1\n"
-                    f"t1.find_immediate_claude_pid = lambda start_pid=None: {own_pid}\n"
+                    "os.environ.pop('NX_T1_ISOLATED', None)\n"
                     "from nexus.db.t1 import T1Database\n"
                     "db = T1Database()\n"
                     "doc_id = db.put('hello from sibling', tags='spike')\n"
@@ -1535,7 +1508,7 @@ class TestE2EFileDiscovery:
                 )
                 assert proc.stdout.startswith("OK"), proc.stdout
             finally:
-                unlink_t1_addr(own_pid)
+                publisher.relinquish()
         finally:
             stop_t1_server(server_pid)
             shutil.rmtree(chroma_tmpdir, ignore_errors=True)

--- a/tests/test_t1_discovery.py
+++ b/tests/test_t1_discovery.py
@@ -419,6 +419,68 @@ class TestT1DatabaseFlagOnFilePath:
         fake_chromadb.HttpClient.assert_called_once_with(host="127.0.0.1", port=9999)
 
 
+class TestT1ColdStartTransientWindow:
+    """RDR-149 P4 / CA-3: the honest production read-path behavior during the
+    cold-start transient window (the writer published a transient
+    ``server_pid`` lease but no session-id resolves yet).
+
+    The owner (via ``_t1_state``) and MCP-dispatched subprocesses (via the
+    ``NX_T1_HOST``/``NX_T1_PORT`` env breadcrumb, Path A) are covered. A bare
+    Claude-Code Bash sibling -- no env, no resolvable session-id -- is NOT:
+    it gets a loud, retryable ``T1ServerNotFoundError`` (Path D), succeeding
+    once the session-id resolves. This is the accepted tradeoff of keying on
+    session-id rather than the unreliable PPID-walk (RDR §Gap 2), tracked as
+    a known limitation, and is the property the conformance suite's
+    registry-layer ``TestT1SessionRekey`` does NOT by itself assert."""
+
+    def test_bare_sibling_in_transient_window_raises_not_found(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import MagicMock
+
+        fake_chromadb = MagicMock()
+        monkeypatch.setitem(sys.modules, "chromadb", fake_chromadb)
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        for var in ("NX_T1_HOST", "NX_T1_PORT", "NX_T1_ISOLATED",
+                    "NEXUS_SKIP_T1", "NX_SESSION_ID"):
+            monkeypatch.delenv(var, raising=False)
+
+        # The writer published a TRANSIENT server_pid lease (session-id
+        # unresolved). No current_session file, no NX_SESSION_ID.
+        _publish_t1_session_lease(tmp_path, None, "127.0.0.1", 9999, server_pid=70707)
+
+        from nexus.db.t1 import T1Database, T1ServerNotFoundError
+        # The bare sibling cannot resolve a session-id, so Path B is skipped
+        # and it fails loud -- it does NOT silently bind to the transient
+        # server_pid lease (no cross-session mis-binding hazard).
+        with pytest.raises(T1ServerNotFoundError):
+            T1Database()
+        fake_chromadb.HttpClient.assert_not_called()
+
+    def test_mcp_dispatched_subprocess_in_transient_window_uses_env(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import MagicMock
+
+        fake_chromadb = MagicMock()
+        fake_chromadb.HttpClient.return_value = MagicMock()
+        monkeypatch.setitem(sys.modules, "chromadb", fake_chromadb)
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
+        monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+        # MCP-dispatched subprocess: it inherited the env breadcrumb (Path A),
+        # so it connects even though no session-id resolves yet.
+        monkeypatch.setenv("NX_T1_HOST", "127.0.0.1")
+        monkeypatch.setenv("NX_T1_PORT", "9999")
+
+        from nexus.db.t1 import T1Database
+        T1Database()
+        fake_chromadb.HttpClient.assert_called_once_with(host="127.0.0.1", port=9999)
+
+
 class TestT1DatabaseFlagOffPreservesLegacyBehaviour:
     """Flag-off: legacy resolver chain runs unchanged."""
 


### PR DESCRIPTION
RDR-149 P4 (bead nexus-8znyd, epic nexus-idxg4). T1 was the last tier on a bespoke daemon lifecycle (session.py: claude_pid addr files + find_immediate_claude_pid PPID-walk, no self-heal). It now rides the shared `ServiceRegistry` primitive like T2 (P2) and T3 (P3), MCP-lifespan-owned (not a supervised daemon, per the RDR Decision).

## What changed
- **New `nexus.daemon.t1_lease.T1LeasePublisher`** implements the locked RF-2 re-key protocol: publish under a transient `server_pid` key (unique, never `"unknown"`) carrying the resolved-or-None session-id as a payload field; an async heartbeat loop re-stamps the lease (self-heal = the **#1114** fix) and, the instant `resolve_active_session_id()` first resolves while still transient-keyed, atomically re-keys to the session-id scope (flock-serialized generation bump, then relinquish the transient record).
- **`mcp/core.py`** Branch 3 publishes via the publisher + runs the heartbeat/re-key task; cleanup cancels the task before relinquishing (RDR-129 early-stop ordering).
- **`db/t1.py`** Path B resolves by session-id via `discover_t1_lease`; **`nx doctor --check-t1`** rewritten for the lease model.
- Liveness is lease freshness (TTL), not pid (pid-reuse immunity). Session-scoped N-per-user semantics preserved.

## Conformance
T1 cells (`self_heal`, `concurrent_one_owner`, `pid_reuse_immunity`, `restart_higher_generation`, `restart_race_fencing`) flip xfail→pass; the #1114 non-vacuity meta-test now asserts the structural fix landed; `TestT1SessionRekey` un-xfailed into a real CA-3 spike harness. `version_cycle[t1]` stays a documented N/A (T1 is MCP-lifespan-owned, cycled by an MCP restart).

## Reviews
Both stacked reviewers ran on `dbaa8974`; remediation in `456a52c3`:
- code-review IMPORTANT-1: `_rekey` commits the session pointer before relinquishing the transient (no re-key loop on relinquish failure).
- substantive-critic CRITICAL: the "no undiscoverable window" claim held only for the owner + MCP-dispatched subprocesses (the two mechanisms RF-2 cites). A bare Claude-Code Bash sibling in the cold-start sliver (no env, no resolvable session-id) gets a **loud, retryable `T1ServerNotFoundError`** — not silent corruption. Closing the gap via a transient-lease scan was rejected (cross-session mis-binding hazard; the RDR chose session-id over the unreliable PPID-walk precisely to avoid pid ambiguity). Accepted, documented, honestly tested, and tracked as **nexus-0x16i**.

Phase-review-gate P4 PASSED. Full unit suite: 9038 passed, 1 xfailed, 0 failed.

P5 (nexus-79519) deletes the now-dead session.py primitives + proves zero copies via inverse-grep.

Refs #1114