### PR TITLE
refactor(rdr-149): delete dead T1 addr-file lifecycle code (P5)

### DIFF
--- a/conexus/hooks/scripts/routing/phase_review_close_requires_gate.py
+++ b/conexus/hooks/scripts/routing/phase_review_close_requires_gate.py
@@ -13,8 +13,9 @@ Sentinel path: ``${TMPDIR:-/tmp}/nx-phase-gate-sentinel/<claude_pid>-<rdr-id>-<p
 
 Three checks (all must hold for ``allow``):
   (a) sentinel file exists
-  (b) sentinel mtime is newer than the session-start time (ctime of
-      ``~/.config/nexus/t1_addr.<claude_pid>``)
+  (b) sentinel mtime is newer than the session-start time (mtime of
+      ``~/.config/nexus/current_session``; RDR-149 P4 retired the
+      ``t1_addr.<claude_pid>`` anchor)
   (c) sentinel content reports ``outcome: PASSED``
 
 Escape token ``# routing-allow: <reason>=8 chars>`` allows the close to
@@ -90,16 +91,25 @@ def _claude_pid() -> int:
 
 
 def _session_start_time(claude_pid: int) -> float | None:
-    """Return ctime of the t1_addr.<pid> file, or None if unavailable."""
+    """Return the session-start anchor time, or None if unavailable.
+
+    RDR-149 P4 retired the ``t1_addr.<claude_pid>`` addr file (T1 now keys
+    its leased registry record on the session-id, not the claude_pid), so
+    this anchors on the ``current_session`` pointer instead: the
+    SessionStart hook (re)writes it once per session, so its mtime is the
+    session-start proxy. A sentinel older than this is a stale carry-over
+    from a previous session. ``claude_pid`` is accepted for caller
+    signature stability but no longer selects the file.
+    """
     base = os.environ.get("NEXUS_CONFIG_DIR")
     if base:
-        addr = pathlib.Path(base) / f"t1_addr.{claude_pid}"
+        marker = pathlib.Path(base) / "current_session"
     else:
-        addr = pathlib.Path.home() / ".config" / "nexus" / f"t1_addr.{claude_pid}"
-    if not addr.exists():
+        marker = pathlib.Path.home() / ".config" / "nexus" / "current_session"
+    if not marker.exists():
         return None
     try:
-        return addr.stat().st_ctime
+        return marker.stat().st_mtime
     except OSError:
         return None
 

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -1206,11 +1206,10 @@ def _run_check_mineru() -> None:
     "check_t1",
     is_flag=True,
     default=False,
-    help="Diagnose T1 addr-file presence + reachability. Detects "
-         "the 'no t1_addr.<claude_pid> when Claude Code is parent' "
-         "case and the exec -a / wrapper-rename residual. RDR-105 "
-         "P5 / nexus-ssdg. Exits 1 when Claude is in the chain "
-         "but the addr file is missing or unreachable.",
+    help="Diagnose T1 session-id lease presence + reachability "
+         "(RDR-149 P4). Resolves the active session-id and probes its "
+         "lease at ~/.config/nexus/t1_addr.<session_id>. Exits 1 when a "
+         "session-id resolves but the lease is missing or unreachable.",
 )
 @click.option(
     "--days",

--- a/src/nexus/console/watchers.py
+++ b/src/nexus/console/watchers.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import socket
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, AsyncIterator, Callable
@@ -110,43 +111,41 @@ def _tcp_probe(host: str, port: int, timeout: float = 0.5) -> bool:
 
 
 def scan_sessions_sync(config_dir: Path) -> list[SessionInfo]:
-    """Scan ``t1_addr.<claude_pid>`` files and probe each for liveness.
+    """Scan ``t1_addr.<session_id>`` lease records and probe each for liveness.
 
-    Post-RDR-105 P4 the address surface is one flat file per live
-    Claude Code session. Each file contains ``host:port\\n``; the
-    file's stem suffix encodes the owning Claude's PID (used as the
-    session identifier here for human-readable display).
+    RDR-149 P4: T1 publishes a leased registry record per live session
+    (``~/.config/nexus/t1_addr.<session_id>``, re-keyed from a transient
+    ``server_pid`` key at cold start). Liveness is lease freshness (TTL),
+    not pid; the endpoint is additionally TCP-probed. ``session_id`` is the
+    lease scope key; ``pid`` carries the chroma ``server_pid`` for display.
     """
     if not config_dir.exists():
         return []
 
+    from nexus.daemon.service_registry import LeaseRecord
+
+    now = time.time()
     results: list[SessionInfo] = []
     for path in config_dir.glob("t1_addr.*"):
         try:
-            text = path.read_text().strip()
-        except OSError:
-            continue
-        if ":" not in text:
-            continue
-        host, _, port_str = text.partition(":")
-        try:
-            port = int(port_str)
-        except ValueError:
-            continue
-        try:
-            claude_pid = int(path.suffix.lstrip("."))
-        except ValueError:
+            record = LeaseRecord.from_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, KeyError):
+            continue  # not a lease record (malformed / legacy / partial write)
+        host = record.endpoint.get("host")
+        port = record.endpoint.get("port")
+        if not isinstance(host, str) or not isinstance(port, int):
             continue
 
-        pid_alive = _is_pid_alive(claude_pid) if claude_pid else False
-        tcp_ok = _tcp_probe(host, port) if pid_alive else False
+        fresh = record.is_fresh(now)
+        tcp_ok = _tcp_probe(host, port) if fresh else False
+        server_pid = record.endpoint.get("server_pid")
 
         results.append(SessionInfo(
-            session_id=str(claude_pid),
+            session_id=record.scope_key,
             host=host,
             port=port,
-            pid=claude_pid,
-            pid_alive=pid_alive,
+            pid=server_pid if isinstance(server_pid, int) else 0,
+            pid_alive=fresh,
             tcp_reachable=tcp_ok,
             created_at="",
         ))

--- a/src/nexus/console/watchers.py
+++ b/src/nexus/console/watchers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import socket
 import time
 from dataclasses import dataclass
@@ -90,14 +89,6 @@ class SessionInfo:
     pid_alive: bool
     tcp_reachable: bool
     created_at: str
-
-
-def _is_pid_alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-        return True
-    except OSError:
-        return False
 
 
 def _tcp_probe(host: str, port: int, timeout: float = 0.5) -> bool:

--- a/src/nexus/daemon/t3_daemon.py
+++ b/src/nexus/daemon/t3_daemon.py
@@ -14,11 +14,12 @@ The chroma subprocess is spawned with ``start_new_session=True`` so a
 SIGTERM at shutdown reaches the whole process group — chroma's
 multiprocessing workers and resource_tracker child included.
 
-T1/T3 non-collision invariant: T1 uses ephemeral tempdirs +
-``t1_addr.<claude_pid>``; T3 uses ``nexus.config._default_local_path()``
-+ ``t3_addr.<uid>``. Both pick free ports via the OS allocator. Distinct
-addr-file naming and distinct chroma --path roots mean two coexisting
-chroma subprocesses on the same host do not collide.
+T1/T3 non-collision invariant: T1 uses ephemeral tempdirs + a leased
+registry record at ``t1_addr.<session_id>`` (RDR-149 P4); T3 uses
+``nexus.config._default_local_path()`` + ``t3_addr.<uid>``. Both pick free
+ports via the OS allocator. Distinct addr-file naming and distinct chroma
+--path roots mean two coexisting chroma subprocesses on the same host do
+not collide.
 """
 from __future__ import annotations
 

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -755,18 +755,18 @@ def _check_index_log() -> list[HealthResult]:
 
 
 def _check_orphan_t1() -> list[HealthResult]:
-    """Report on T1 address files left by previous Claude Code sessions.
+    """Report on T1 lease records on disk (RDR-149 P4 leased registry).
 
-    RDR-105 P4 replaced the per-session JSON record files with a
-    single-writer ``~/.config/nexus/t1_addr.<claude_pid>`` flat file
-    per live Claude. An orphan here is an addr file whose
-    ``<claude_pid>`` is no longer a running process (typically left
-    behind when Claude Code exits ungracefully so the lifespan
-    finally never ran). The MCP startup sweep
-    (``sweep_orphan_t1_addr_files``) reaps them automatically; this
-    check just surfaces what is currently on disk.
+    T1 publishes a leased registry record at
+    ``~/.config/nexus/t1_addr.<session_id>`` (re-keyed from a transient
+    ``server_pid`` key at cold start). Liveness is lease freshness (TTL),
+    not pid: a dead owner's lease ages out on its own, so there is no
+    bespoke orphan sweep (RDR-149 P5 removed it). This check surfaces any
+    stale (expired) lease record still on disk; such records are inert
+    (readers reap them on discovery), so removal is cosmetic.
     """
     from nexus.config import nexus_config_dir
+    from nexus.daemon.service_registry import LeaseRecord
 
     config_dir = nexus_config_dir()
     if not config_dir.exists():
@@ -777,37 +777,37 @@ def _check_orphan_t1() -> list[HealthResult]:
         return [HealthResult(label="T1 sessions", ok=True, detail="no live T1 sessions")]
 
     now = time.time()
-    orphans: list[str] = []
-    live_descriptors: list[str] = []
+    fresh: list[str] = []
+    stale: list[str] = []
     for path in addr_files:
-        suffix = path.suffix.lstrip(".")
         try:
-            claude_pid = int(suffix)
-        except ValueError:
-            _log.debug("orphan_t1_addr_unparseable_suffix", path=str(path), suffix=suffix)
+            record = LeaseRecord.from_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, KeyError):
+            _log.debug("t1_lease_unparseable", path=str(path))
             continue
-        age_s = max(0, int(now - path.stat().st_mtime))
-        age_str = f"{age_s // 60}m" if age_s < 3600 else f"{age_s // 3600}h"
-        try:
-            os.kill(claude_pid, 0)
-            live_descriptors.append(f"{path.name} (claude_pid {claude_pid} alive, age {age_str})")
-        except OSError:
-            orphans.append(path.name)
+        if record.is_fresh(now):
+            age_s = max(0, int(now - record.heartbeat_epoch))
+            fresh.append(f"{path.name} (fresh, last heartbeat {age_s}s ago)")
+        else:
+            stale.append(path.name)
 
-    if orphans:
+    if stale:
         return [HealthResult(
             label="T1 sessions",
             ok=False,
-            detail=f"{len(orphans)} orphan addr file(s) (claude_pid dead): {', '.join(orphans)}",
+            detail=f"{len(stale)} stale T1 lease(s) (expired past TTL): {', '.join(stale)}",
             fix_suggestions=[
-                "Remove stale files: rm ~/.config/nexus/t1_addr.*",
-                "Or run nx doctor (the next MCP startup sweeps these automatically).",
+                "Stale leases are inert (readers reap on discovery); removal is cosmetic.",
+                "Remove them anyway: rm ~/.config/nexus/t1_addr.*",
             ],
         )]
 
+    if not fresh:
+        return [HealthResult(label="T1 sessions", ok=True, detail="no live T1 sessions")]
+
     return [HealthResult(
         label="T1 sessions", ok=True,
-        detail=f"{len(addr_files)} addr file(s), all owning Claudes alive: {', '.join(live_descriptors)}",
+        detail=f"{len(fresh)} live T1 lease(s): {', '.join(fresh)}",
     )]
 
 

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -779,11 +779,17 @@ def _check_orphan_t1() -> list[HealthResult]:
     now = time.time()
     fresh: list[str] = []
     stale: list[str] = []
+    legacy: list[str] = []
     for path in addr_files:
         try:
             record = LeaseRecord.from_json(path.read_text(encoding="utf-8"))
         except (OSError, ValueError, KeyError):
+            # Not a lease record: a pre-P4 ``host:port`` addr file left on
+            # disk by an older version (RDR-149 P4 changed the format). Inert
+            # -- nothing reads it -- but surfaced so it is not silently
+            # invisible after a "no bespoke copies" audit.
             _log.debug("t1_lease_unparseable", path=str(path))
+            legacy.append(path.name)
             continue
         if record.is_fresh(now):
             age_s = max(0, int(now - record.heartbeat_epoch))
@@ -802,13 +808,20 @@ def _check_orphan_t1() -> list[HealthResult]:
             ],
         )]
 
+    if legacy and not fresh:
+        return [HealthResult(
+            label="T1 sessions", ok=True,
+            detail=f"no live T1 sessions ({len(legacy)} inert pre-P4 addr file(s) on disk)",
+            fix_suggestions=["Remove inert legacy files: rm ~/.config/nexus/t1_addr.*"],
+        )]
+
     if not fresh:
         return [HealthResult(label="T1 sessions", ok=True, detail="no live T1 sessions")]
 
-    return [HealthResult(
-        label="T1 sessions", ok=True,
-        detail=f"{len(fresh)} live T1 lease(s): {', '.join(fresh)}",
-    )]
+    detail = f"{len(fresh)} live T1 lease(s): {', '.join(fresh)}"
+    if legacy:
+        detail += f" (+{len(legacy)} inert pre-P4 addr file(s))"
+    return [HealthResult(label="T1 sessions", ok=True, detail=detail)]
 
 
 def _check_orphan_checkpoints() -> list[HealthResult]:

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -96,11 +96,12 @@ def session_end_flush() -> str:
     Known race window
         On stdio transport the SessionEnd hook fires when stdin EOFs,
         which is the same event that drives the MCP server's lifespan
-        ``async finally`` to unlink ``~/.config/nexus/t1_addr.<pid>``
-        and stop chroma. The launcher daemonizes ``session_end_flush``
+        ``async finally`` to relinquish its T1 lease record
+        (``~/.config/nexus/t1_addr.<session_id>``) and stop chroma
+        (RDR-149 P4). The launcher daemonizes ``session_end_flush``
         in a grandchild, but if the lifespan finally wins the race the
-        grandchild's ``T1Database()`` walks the PPID chain, finds no
-        addr file, and raises ``T1ServerNotFoundError``. The
+        grandchild's ``T1Database()`` resolves the session-id, finds no
+        live lease, and raises ``T1ServerNotFoundError``. The
         ``except`` below catches the raise and logs
         ``session_end_flush_t1_unavailable``; flagged entries are then
         silently dropped. Best-effort flush is the documented contract;

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -54,10 +54,10 @@ _install_default_hooks(_hooks)
 #       owns chroma. Yield without spawning.
 #   Branch 2 (isolation): NX_T1_ISOLATED=1 (or its deprecated
 #       NEXUS_SKIP_T1=1 alias). Stateless one-shot. Yield without spawning.
-#   Branch 3 (top-level / owned): spawn chroma, write
-#       ~/.config/nexus/t1_addr.<claude_pid>, populate
-#       _t1_state.T1_ADDR, yield, then unlink + stop chroma + rmtree
-#       tmpdir + reset _t1_state.T1_ADDR on cleanup.
+#   Branch 3 (top-level / owned): spawn chroma, publish a leased
+#       registry record (~/.config/nexus/t1_addr.<session_id>, RDR-149
+#       P4), populate _t1_state.T1_ADDR, yield, then relinquish the lease
+#       + stop chroma + rmtree tmpdir + reset _t1_state.T1_ADDR on cleanup.
 #
 # Cleanup is idempotent across three sites: the lifespan async finally
 # (HTTP/SSE clean exit + clean stdin EOF on stdio), _sigterm_handler

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -200,30 +200,26 @@ async def _t1_chroma_lifespan(_app: Any):
     from nexus.session import (
         start_t1_server,
         sweep_orphan_resource_trackers,
-        sweep_orphan_t1_addr_files,
         sweep_orphan_t1_chromadbs,
         sweep_orphan_tmpdirs,
     )
 
-    # Best-effort orphan cleanup before we spawn. Three surfaces:
-    # (a) addr files from sessions that exited ungracefully (SIGKILL),
-    # (b) tmpdirs from chromas reaped before their cleanup completed,
-    # (c) multiprocessing resource_tracker processes re-parented to
-    #     init (PPID=1) holding POSIX named semaphores. (c) is
+    # Best-effort orphan cleanup before we spawn. Two surfaces:
+    # (a) tmpdirs from chromas reaped before their cleanup completed,
+    # (b) multiprocessing resource_tracker processes re-parented to
+    #     init (PPID=1) holding POSIX named semaphores. (b) is
     #     critical because the namespace is bounded
     #     (kern.posix.sem.max=10000 on macOS); chronic accumulation
     #     produces Errno 28 system-wide. Bead nexus-9h1s; live
     #     shakeout 2026-05-08 cleared 3,314 trackers / 8,359
-    #     semaphores. (a) and (b) are bounded; failures are logged
-    #     at debug and never block startup. The sweep functions log
-    #     per-file outcomes themselves; this outer guard catches
-    #     unexpected sweep-level failures.
+    #     semaphores. (a) is bounded; failures are logged at debug and
+    #     never block startup. The sweep functions log per-file
+    #     outcomes themselves; this outer guard catches unexpected
+    #     sweep-level failures. RDR-149 P5: the bespoke T1 addr-file
+    #     orphan sweep is gone -- the leased registry ages stale lease
+    #     records out via their TTL, no pid-keyed sweep needed.
     import structlog
     _sweep_log = structlog.get_logger(__name__)
-    try:
-        sweep_orphan_t1_addr_files()
-    except Exception as exc:
-        _sweep_log.debug("sweep_orphan_t1_addr_files_failed", error=str(exc))
     try:
         sweep_orphan_tmpdirs()
     except Exception as exc:

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -626,8 +626,9 @@ def start_t1_server() -> tuple[str, int, int, str]:
             # process; cleanup is the SessionEnd hook's job. Ungraceful
             # exits (Claude Code SIGKILL/OOM) leak the server until the
             # next top-level MCP startup, which runs
-            # ``sweep_orphan_t1_addr_files`` + ``sweep_orphan_tmpdirs``
-            # to reap any leftovers.
+            # ``sweep_orphan_t1_chromadbs`` + ``sweep_orphan_tmpdirs``
+            # to reap any leftovers (RDR-149 P5: the bespoke addr-file
+            # sweep is gone; the leased registry self-expires via TTL).
             return _T1_SERVER_HOST, port, proc.pid, tmpdir
         except OSError:
             time.sleep(0.2)  # intentional: server not yet listening, retry loop
@@ -736,23 +737,20 @@ def _command_name_of(pid: int) -> str:
 def find_immediate_claude_pid(start_pid: int | None = None) -> int:
     """Return the FIRST ``claude*`` ancestor walking up from *start_pid*.
 
-    RDR-105 RF-6 (CRITICAL): topmost-walk silently breaks owned-mode
-    isolation. An owned ``claude -p`` subprocess MCP's process tree
-    contains two ``claude*`` ancestors (the immediate parent
-    ``claude -p`` and the user's top-level Claude). Topmost-walk
-    returns the user's Claude → the owned MCP would (a) write its
-    addr file at the parent's claude_pid, clobbering the parent's
-    file, and (b) read its own discovery from the parent's file,
-    silently sharing instead of isolating.
+    RDR-105 RF-6: returns the immediate (not topmost) ``claude*``
+    ancestor so nested owned ``claude -p`` subprocesses resolve their own
+    immediate Claude rather than the user's top-level one.
 
-    Returning the FIRST match keys the addr file at the immediate
-    Claude ancestor, sealing the owned subprocess from the parent.
-    Verified across all four nesting cases per RF-6.
+    RDR-149 P4 retired the T1 addr-file publish/discovery that originally
+    motivated this (T1 now keys its leased registry record on the
+    session-id, not the claude_pid). This function is retained for its
+    remaining non-T1 consumer, ``nexus.phase_review_sentinel``, which keys
+    its phase-gate sentinel files by the immediate Claude pid.
 
     Falls back to the immediate PPID when no ``claude*`` ancestor is
-    found (matches the no-claude-in-chain semantics of the legacy
-    function so consumers behave identically in that case). Returns
-    0 only when the PPID chain cannot be walked at all.
+    found (matches the no-claude-in-chain semantics so consumers behave
+    identically in that case). Returns 0 only when the PPID chain cannot
+    be walked at all.
     """
     pid = start_pid if start_pid is not None else os.getpid()
     seen: set[int] = set()
@@ -793,128 +791,6 @@ def _t1_isolated_env() -> bool:
             message="NEXUS_SKIP_T1 is deprecated; use NX_T1_ISOLATED=1 instead. Will be removed in 5.0.",
         )
     return isolated or legacy
-
-
-def t1_addr_path(claude_pid: int) -> Path:
-    """Return the path to the address file for *claude_pid*.
-
-    Resolved against ``NEXUS_CONFIG_DIR`` at call time so tests that
-    set the env var see the redirect without monkeypatching module
-    constants. Default location: ``~/.config/nexus/t1_addr.<pid>``.
-    """
-    return _nexus_config_dir_at_import() / f"t1_addr.{claude_pid}"
-
-
-def write_t1_addr(claude_pid: int, host: str, port: int) -> Path:
-    """Atomically write the address file for *claude_pid*.
-
-    Single-writer contract: only the top-level (or owned subprocess)
-    MCP at lifespan start writes this file. The atomic rename keeps a
-    concurrent reader either on the prior contents or the new
-    contents, never torn.
-    """
-    target = t1_addr_path(claude_pid)
-    target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    tmp = target.with_suffix(target.suffix + f".{os.getpid()}.tmp")
-    fd = os.open(str(tmp), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
-    try:
-        try:
-            os.write(fd, f"{host}:{port}\n".encode())
-        finally:
-            os.close(fd)
-        tmp.replace(target)
-    except BaseException:
-        # Disk-full / permissions / interrupt: don't leave the tmp
-        # file behind for the next sweep to clean up.
-        try:
-            tmp.unlink()
-        except FileNotFoundError:
-            pass
-        raise
-    return target
-
-
-def read_t1_addr_for(claude_pid: int) -> tuple[str, int] | None:
-    """Read the addr file for *claude_pid*. Returns ``(host, port)`` or None.
-
-    None on missing file, malformed contents, or unreadable file;
-    callers fail loud at the next layer (``T1Database`` constructor's
-    raise) rather than constructing an EphemeralClient.
-    """
-    path = t1_addr_path(claude_pid)
-    try:
-        text = path.read_text().strip()
-    except OSError:
-        return None  # intentional: missing/unreadable, callers handle
-    if ":" not in text:
-        return None
-    host, _, port_str = text.partition(":")
-    try:
-        return host, int(port_str)
-    except ValueError:
-        return None
-
-
-def unlink_t1_addr(claude_pid: int) -> None:
-    """Best-effort delete of the addr file. No-op if already gone."""
-    path = t1_addr_path(claude_pid)
-    try:
-        path.unlink()
-    except FileNotFoundError:
-        return  # intentional: idempotent
-    except OSError as exc:
-        _log.debug("t1_addr_unlink_failed", path=str(path), error=str(exc))
-
-
-def sweep_orphan_t1_addr_files() -> int:
-    """Reap ``t1_addr.<claude_pid>`` files whose ``<claude_pid>`` is dead.
-
-    Best-effort orphan cleanup runs at top-level MCP startup. A
-    Claude Code session that exits ungracefully (SIGKILL, OOM, hard
-    crash) leaves its addr file behind; the lifespan finally never
-    runs. The next MCP boot's sweep reaps any stale files so a
-    sibling subprocess does not connect to a dead chroma.
-
-    Returns the count of files reaped. Failures are logged but
-    never propagate; this is not load-bearing.
-
-    PID reuse: if a live unrelated process happens to have the same
-    PID as the dead Claude (PIDs wrap on Linux), the sweep skips the
-    file (false-negative). Worst outcome: the file lingers until the
-    next sweep, at which point either the PID is still reused (still
-    skipped, still no harm) or it has exited (now reaped). No
-    incorrect destructive action is possible. A ``comm`` cross-check
-    would close the false-negative but adds two subprocess calls per
-    file with portability concerns; not justified for a best-effort
-    path.
-    """
-    config_dir = _nexus_config_dir_at_import()
-    if not config_dir.exists():
-        return 0
-    reaped = 0
-    for path in config_dir.glob("t1_addr.*"):
-        suffix = path.suffix.lstrip(".")
-        try:
-            claude_pid = int(suffix)
-        except ValueError:
-            continue
-        if claude_pid > 0 and _is_pid_alive(claude_pid):
-            continue
-        try:
-            path.unlink()
-            reaped += 1
-            _log.info("sweep_reaped_orphan_t1_addr", path=str(path), pid=claude_pid)
-        except FileNotFoundError:
-            continue
-        except OSError as exc:
-            _log.debug("sweep_t1_addr_unlink_failed", path=str(path), error=str(exc))
-    return reaped
-
-
-
-
-
-
 
 
 # ── Private helpers ───────────────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -261,7 +261,7 @@ def _isolate_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     ``read_claude_session_id`` resolves to via ``NEXUS_CONFIG_DIR``.
 
     The directory itself is *not* pre-created — write helpers
-    (``write_claude_session_id``, ``write_t1_addr``, etc.) all do
+    (``write_claude_session_id``, the T1 lease registry, etc.) all do
     ``parents=True, exist_ok=True`` themselves, and tests that
     explicitly call ``mkdir(parents=True)`` without ``exist_ok``
     on the same path would otherwise hit ``FileExistsError``.

--- a/tests/test_health_panel.py
+++ b/tests/test_health_panel.py
@@ -44,23 +44,42 @@ def test_scan_sessions_no_dir():
     assert results == []
 
 
+def _write_t1_lease(config_dir: Path, session_id: str, host: str, port: int,
+                    *, heartbeat_epoch: float, ttl: float = 30.0,
+                    server_pid: int = 4242) -> None:
+    """Write a RDR-149 T1 lease record at ``t1_addr.<session_id>``."""
+    from nexus.daemon.service_registry import LeaseRecord
+
+    record = LeaseRecord(
+        scope_key=session_id,
+        generation=1,
+        owner_token="tok",
+        heartbeat_epoch=heartbeat_epoch,
+        ttl=ttl,
+        endpoint={"host": host, "port": port, "server_pid": server_pid},
+        version="1.0.0",
+        payload={"session_id": session_id, "server_pid": server_pid},
+    )
+    (config_dir / f"t1_addr.{session_id}").write_text(record.to_json())
+
+
 def test_scan_sessions_live_session(tmp_path):
-    """Addr file keyed by our own PID, should be detected as alive."""
-    import os
-    own_pid = os.getpid()
-    (tmp_path / f"t1_addr.{own_pid}").write_text("127.0.0.1:0\n")
+    """A fresh lease (recent heartbeat) is detected as alive (RDR-149 P4)."""
+    import time
+    _write_t1_lease(tmp_path, "sess-A", "127.0.0.1", 0, heartbeat_epoch=time.time())
     results = scan_sessions_sync(tmp_path)
     assert len(results) == 1
-    assert results[0].session_id == str(own_pid)
+    assert results[0].session_id == "sess-A"
     assert results[0].pid_alive is True
 
 
 def test_scan_sessions_dead_pid(tmp_path):
-    """Addr file keyed by a dead PID."""
-    import subprocess
-    proc = subprocess.Popen(["true"])
-    proc.wait()
-    (tmp_path / f"t1_addr.{proc.pid}").write_text("127.0.0.1:12345\n")
+    """An expired lease (heartbeat older than TTL) is not alive (RDR-149 P4)."""
+    import time
+    _write_t1_lease(
+        tmp_path, "sess-stale", "127.0.0.1", 12345,
+        heartbeat_epoch=time.time() - 1000.0, ttl=30.0,
+    )
     results = scan_sessions_sync(tmp_path)
     assert len(results) == 1
     assert results[0].pid_alive is False

--- a/tests/test_routing_phase_review_close.py
+++ b/tests/test_routing_phase_review_close.py
@@ -106,9 +106,14 @@ def _decision(proc: subprocess.CompletedProcess) -> dict:
 
 
 def _make_session_addr(config_dir: pathlib.Path, claude_pid: int) -> pathlib.Path:
-    """Create a t1_addr file representing a live Claude session."""
-    p = config_dir / f"t1_addr.{claude_pid}"
-    p.write_text(f"127.0.0.1:8000\n{claude_pid}")
+    """Create the ``current_session`` pointer representing a live session.
+
+    RDR-149 P4: the session-start anchor moved from ``t1_addr.<pid>`` to the
+    ``current_session`` pointer (the gate hook reads its mtime). ``claude_pid``
+    is written as the session-id content for determinism.
+    """
+    p = config_dir / "current_session"
+    p.write_text(str(claude_pid))
     return p
 
 
@@ -332,13 +337,13 @@ def test_sentinel_stale_denies(tmp_env):
         title="RDR-112 Phase 1 review gate",
     )
     addr = _make_session_addr(tmp_env["config_dir"], pid)
-    # Force session ctime to NOW; sentinel mtime in the past.
-    addr_ctime = addr.stat().st_ctime
+    # Session anchor is the current_session mtime (now); sentinel in the past.
+    addr_mtime = addr.stat().st_mtime
     _make_sentinel(
         tmp_env["sentinel_dir"],
         claude_pid=pid, rdr_id="112", phase="1",
         outcome="PASSED",
-        mtime=addr_ctime - 3600,  # one hour before session start
+        mtime=addr_mtime - 3600,  # one hour before session start
     )
     proc = _run_hook(
         {"tool_name": "Bash", "tool_input": {"command": "bd close nexus-abc"}},

--- a/tests/test_t1_discovery.py
+++ b/tests/test_t1_discovery.py
@@ -1,21 +1,21 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""RDR-105 hybrid T1 discovery tests.
+"""RDR-105 hybrid T1 discovery tests (RDR-149 P4 lease model).
 
-The single hybrid-discovery code path (RDR-105 P4) is the only T1
-resolution surface. Verifies:
+The single hybrid-discovery code path is the only T1 resolution surface.
+Verifies:
 
 * ``find_immediate_claude_pid`` returns the FIRST ``claude*`` ancestor
-  walking up, NOT the topmost (RF-6, the load-bearing fix that prevents
-  owned-mode isolation breakage).
-* Address-file primitives (``write_t1_addr`` / ``read_t1_addr_for`` /
-  ``unlink_t1_addr``) round-trip atomically.
-* ``T1Database.__init__`` flag-gated paths: env (Path A), addr file
-  (Path B), legacy fall-through.
-* MCP lifespan augmentation publishes the addr file + populates
-  ``_t1_state.T1_ADDR`` when flag-on; cleanup unlinks + resets.
+  walking up, NOT the topmost (RF-6). Retained for its non-T1 consumer
+  (``phase_review_sentinel``); RDR-149 P4 moved T1 off pid keying.
+* ``T1Database.__init__`` flag-gated paths: env (Path A), session-id
+  lease (Path B), isolation (Path C), fail-loud (Path D).
+* MCP lifespan Branch 3 publishes a leased registry record + populates
+  ``_t1_state.T1_ADDR``; cleanup relinquishes + resets.
+* The cold-start transient-window behavior (CA-3): owner + env-inheritors
+  covered; a bare Bash sibling fails loud and retries.
 * Dispatcher env builder honours ``share_t1`` + flag.
-* End-to-end: subprocess sibling discovers a live chroma via the addr
-  file (Path B) and via env (Path A).
+* End-to-end: subprocess sibling discovers a live chroma via the
+  session-id lease (Path B) and via env (Path A).
 """
 from __future__ import annotations
 
@@ -164,176 +164,6 @@ class TestFindImmediateClaudePid:
              patch("nexus.session._command_name_of",
                    side_effect=lambda pid: comm_map.get(pid, "")):
             assert find_immediate_claude_pid(start_pid=500) == 600
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Address-file primitives
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-class TestT1AddrFile:
-    """Single-writer ``~/.config/nexus/t1_addr.<claude_pid>``.
-
-    File contents: ``host:port\\n``. Atomic write via temp-then-replace.
-    """
-
-    def test_t1_addr_path_under_nexus_config(self, tmp_path, monkeypatch):
-        from nexus.session import t1_addr_path
-
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-        path = t1_addr_path(12345)
-        assert path.name == "t1_addr.12345"
-        assert path.parent == tmp_path
-
-    def test_write_read_roundtrip(self, tmp_path, monkeypatch):
-        from nexus.session import read_t1_addr_for, write_t1_addr
-
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-        write_t1_addr(12345, "127.0.0.1", 54321)
-        assert read_t1_addr_for(12345) == ("127.0.0.1", 54321)
-
-    def test_read_missing_returns_none(self, tmp_path, monkeypatch):
-        from nexus.session import read_t1_addr_for
-
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-        assert read_t1_addr_for(99999) is None
-
-    def test_unlink_idempotent(self, tmp_path, monkeypatch):
-        from nexus.session import read_t1_addr_for, unlink_t1_addr, write_t1_addr
-
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-        write_t1_addr(54321, "127.0.0.1", 11111)
-        unlink_t1_addr(54321)
-        assert read_t1_addr_for(54321) is None
-        # Second unlink: no-op (file already gone), no exception.
-        unlink_t1_addr(54321)
-        assert read_t1_addr_for(54321) is None
-
-    def test_atomic_write_replaces_existing(self, tmp_path, monkeypatch):
-        from nexus.session import read_t1_addr_for, write_t1_addr
-
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-        write_t1_addr(7, "127.0.0.1", 1000)
-        write_t1_addr(7, "127.0.0.1", 2000)
-        assert read_t1_addr_for(7) == ("127.0.0.1", 2000)
-
-    def test_read_corrupt_file_returns_none(self, tmp_path, monkeypatch):
-        from nexus.session import read_t1_addr_for, t1_addr_path
-
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-        path = t1_addr_path(13)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("garbage no colon\n")
-        assert read_t1_addr_for(13) is None
-
-    def test_addr_file_permissions(self, tmp_path, monkeypatch):
-        """Per the rest of the module, dir is 0o700 and file is 0o600."""
-        from nexus.session import t1_addr_path, write_t1_addr
-
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-        write_t1_addr(11, "127.0.0.1", 22)
-        path = t1_addr_path(11)
-        assert path.exists()
-        # Permissions check (best-effort: the platform may strip group/other bits).
-        mode = path.stat().st_mode & 0o777
-        assert mode & 0o077 == 0, f"world/group readable: {oct(mode)}"
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Periodic orphan reaper (sweep_orphan_t1_addr_files)
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-class TestSweepOrphanT1AddrFiles:
-    """RDR-105 P4 (nexus-sp84): top-level MCP startup runs this sweep
-    to reap addr files left by sessions that exited ungracefully.
-    Best-effort cleanup; not load-bearing.
-    """
-
-    def test_reaps_dead_pid(self, tmp_path, monkeypatch):
-        import subprocess as _sub
-
-        from nexus.session import (
-            sweep_orphan_t1_addr_files,
-            t1_addr_path,
-            write_t1_addr,
-        )
-
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-
-        proc = _sub.Popen(["true"])
-        proc.wait()
-        write_t1_addr(proc.pid, "127.0.0.1", 1234)
-        assert t1_addr_path(proc.pid).exists()
-
-        reaped = sweep_orphan_t1_addr_files()
-        assert reaped == 1
-        assert not t1_addr_path(proc.pid).exists()
-
-    def test_keeps_live_pid(self, tmp_path, monkeypatch):
-        import os as _os
-
-        from nexus.session import (
-            sweep_orphan_t1_addr_files,
-            t1_addr_path,
-            write_t1_addr,
-        )
-
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-
-        own_pid = _os.getpid()
-        write_t1_addr(own_pid, "127.0.0.1", 9999)
-
-        reaped = sweep_orphan_t1_addr_files()
-        assert reaped == 0
-        assert t1_addr_path(own_pid).exists()
-
-    def test_skips_malformed_suffix(self, tmp_path, monkeypatch):
-        from nexus.session import sweep_orphan_t1_addr_files
-
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-        # Files whose suffix is not an integer must be skipped (not
-        # reaped, not crashed). Belt-and-braces against an operator
-        # leaving stray ``t1_addr.something-weird`` lying around.
-        weird = tmp_path / "t1_addr.not-a-number"
-        tmp_path.mkdir(parents=True, exist_ok=True)
-        weird.write_text("127.0.0.1:5555\n")
-
-        reaped = sweep_orphan_t1_addr_files()
-        assert reaped == 0
-        assert weird.exists()
-
-    def test_no_op_when_config_dir_missing(self, tmp_path, monkeypatch):
-        from nexus.session import sweep_orphan_t1_addr_files
-
-        # Point NEXUS_CONFIG_DIR at a path that does not exist; sweep
-        # must return 0 cleanly.
-        missing = tmp_path / "does-not-exist"
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(missing))
-        assert sweep_orphan_t1_addr_files() == 0
-
-    def test_mixed_dead_and_live(self, tmp_path, monkeypatch):
-        import os as _os
-        import subprocess as _sub
-
-        from nexus.session import (
-            sweep_orphan_t1_addr_files,
-            t1_addr_path,
-            write_t1_addr,
-        )
-
-        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
-
-        own_pid = _os.getpid()
-        proc = _sub.Popen(["true"])
-        proc.wait()
-        write_t1_addr(own_pid, "127.0.0.1", 1)
-        write_t1_addr(proc.pid, "127.0.0.1", 2)
-
-        reaped = sweep_orphan_t1_addr_files()
-        assert reaped == 1
-        assert t1_addr_path(own_pid).exists()
-        assert not t1_addr_path(proc.pid).exists()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1134,24 +964,21 @@ class TestLifespanNewDiscoveryGenerator:
         monkeypatch.setenv("NX_T1_HOST", "127.0.0.1")
         monkeypatch.setenv("NX_T1_PORT", "5555")
 
-        called = {"start": 0, "write": 0}
+        called = {"start": 0}
 
         def fake_start():
             called["start"] += 1
             return ("127.0.0.1", 1, 1, "/tmp/x")
 
-        def fake_write(*args, **kwargs):
-            called["write"] += 1
-
-        with patch("nexus.session.start_t1_server", side_effect=fake_start), \
-             patch("nexus.session.write_t1_addr", side_effect=fake_write):
+        with patch("nexus.session.start_t1_server", side_effect=fake_start):
             async def _run():
                 async with mcp_core._t1_chroma_lifespan(None):
                     pass
             asyncio.run(_run())
 
+        # No spawn means no lease publish (the publisher is only built in
+        # Branch 3, after start_t1_server).
         assert called["start"] == 0
-        assert called["write"] == 0
 
     def test_branch2_isolated_does_not_spawn(self, monkeypatch):
         """``NX_T1_ISOLATED=1`` -> no spawn, no file."""
@@ -1163,19 +990,16 @@ class TestLifespanNewDiscoveryGenerator:
         monkeypatch.delenv("NX_T1_PORT", raising=False)
         monkeypatch.setenv("NX_T1_ISOLATED", "1")
 
-        called = {"start": 0, "write": 0}
+        called = {"start": 0}
 
         with patch("nexus.session.start_t1_server",
-                   side_effect=lambda: called.update(start=called["start"] + 1) or ("h", 1, 1, "/t")), \
-             patch("nexus.session.write_t1_addr",
-                   side_effect=lambda *a, **k: called.update(write=called["write"] + 1)):
+                   side_effect=lambda: called.update(start=called["start"] + 1) or ("h", 1, 1, "/t")):
             async def _run():
                 async with mcp_core._t1_chroma_lifespan(None):
                     pass
             asyncio.run(_run())
 
         assert called["start"] == 0
-        assert called["write"] == 0
 
     def test_branch3_top_level_spawns_and_publishes(self, tmp_path, monkeypatch):
         """RDR-149 P4: no env, no isolation, no resolvable session -> spawn
@@ -1440,10 +1264,10 @@ class TestLifespanNewDiscoveryGenerator:
         try:
             with patch("nexus.session.start_t1_server",
                        return_value=("127.0.0.1", 22222, 22222, str(tmp_path / "owned_chroma_tmpdir"))), \
-                 patch("nexus.session.stop_t1_server", side_effect=lambda _p: None), \
-                 patch("nexus.session.sweep_orphan_t1_addr_files", return_value=0):
-                # Patch the orphan-reaper sweep off so it does not reap the
-                # sibling's transient lease (server_pid=100 is not a live pid).
+                 patch("nexus.session.stop_t1_server", side_effect=lambda _p: None):
+                # RDR-149 P5: the bespoke addr-file orphan sweep is gone, so
+                # nothing reaps the sibling's transient lease on entry; lease
+                # liveness is TTL freshness via the registry.
                 async def _run():
                     async with mcp_core._t1_chroma_lifespan(None):
                         # Owned MCP keyed on its OWN server_pid.


### PR DESCRIPTION
RDR-149 P5 (bead nexus-79519, Approach item 6, epic nexus-idxg4). With all three tiers on the leased ServiceRegistry primitive (P2/P3/P4), the bespoke T1 pid-keyed addr-file machinery is dead. This phase deletes it and proves zero copies remain.

## Deleted
- `session.py`: `write_t1_addr`, `read_t1_addr_for`, `unlink_t1_addr`, `t1_addr_path`, `sweep_orphan_t1_addr_files` (the per-tier orphan sweep) + their legacy unit tests.
- `mcp/core.py`: the addr-file orphan sweep from the lifespan entry (the leased registry self-expires stale records via TTL; the chroma tmpdir / resource-tracker / chromadb sweeps stay).

`find_immediate_claude_pid` / `_ppid_of` / `_command_name_of` are **kept** — they have a live non-T1 consumer (the phase-review sentinel scheme keys files by the immediate Claude pid). The RDR §Validation target is "no `find_immediate_claude_pid` **publish path**", which P4 already removed.

## Retooled (surfaces that read the old host:port addr files)
These would otherwise silently return empty/garbage for JSON lease records:
- `console/watchers.py` `scan_sessions_sync` → parses `LeaseRecord`, keys on session-id, liveness = lease freshness (feeds the console health panel).
- `health.py` `_check_orphan_t1` → reports fresh vs TTL-expired leases, and surfaces inert pre-P4 legacy files rather than a silent "no live sessions".
- `doctor.py --check-t1` help + `t3_daemon`/`session`/`hooks` docstrings.

## Reviews
Both stacked reviewers ran on `a4607cf5`; remediation in `f0506907`:
- **substantive-critic CRITICAL** (code-reviewer missed it): the inverse-grep had skipped the `conexus/hooks/` tree. The phase-review-close gate hook's `_session_start_time` anchored sentinel-staleness on `t1_addr.<claude_pid>` — never written post-P4 — so the fail-closed "sentinel must postdate session start" check silently no-opped. Fixed by anchoring on the `current_session` pointer mtime + updating the masking test to exercise the real path. Critic re-verified: **CRITICAL closed**.
- Also removed now-dead `watchers._is_pid_alive`, fixed a stale `hooks.py` race-window comment, and surfaced legacy files in health.

Declined the critic's one-time legacy-reap suggestion: the RDR P5 mandate is "no per-tier orphan sweep"; legacy files are inert and now surfaced in health.

## Validation
Inverse-grep audit genuinely at zero across `src/` + `tests/` + `conexus/`: no `write/read/unlink/sweep` copy, no `t1_addr.<claude_pid>` publish/read path, no per-tier election outside the primitive. Net -247 lines. Phase-review-gate P5 PASSED. Full unit suite: 9026 passed, 1 xfailed, 0 failed.

This is the last migration phase; P6 (nexus-s2vlu) adds the standing process gate.

Refs nexus-79519