### PR TITLE
feat(rdr-149): finish deferred follow-ons — T1 cold-start fallback + nx doctor T3 version (nexus-0x16i, nexus-ymn76)

### DIFF
--- a/docs/rdr/rdr-149-unified-service-registry-substrate.md
+++ b/docs/rdr/rdr-149-unified-service-registry-substrate.md
@@ -373,7 +373,16 @@ method and the Approach item that discharges it.
 - Post-migration, an inverse-grep audit shows **zero** surviving bespoke copies:
   no `find_immediate_claude_pid` publish path, no per-tier orphan sweep, no
   per-tier election outside the primitive (Approach item 6), mirroring the
-  RDR-146 boundary-lint-to-0 discipline.
+  RDR-146 boundary-lint-to-0 discipline. "No `find_immediate_claude_pid`
+  publish path" means specifically: it is never a T1 scope **key** (no
+  `t1_addr.<claude_pid>` record, no claude-pid-keyed discovery). The
+  nexus-0x16i cold-start fallback (`discover_t1_transient_for_claude`)
+  reintroduces `find_immediate_claude_pid` as a *transient-record payload
+  hint* — a read-path window-target dropped on re-key, never a scope key — and
+  is a permitted, tracked exception. The mechanical gate
+  (`tests/daemon/test_lifecycle_gate.py`) enforces the scope-key invariant
+  (`LeaseRecord` + the election flock live only in the primitive); it does not
+  ban the payload-hint use.
 - A live multi-session shakeout: in a real session, a sibling shell `nx scratch
   list` succeeds whenever the MCP T1 server is up (the #1114 reproducer), and a
   `nx upgrade` cycles T3 as well as T2 (the #1112 reproducer).

--- a/src/nexus/daemon/t1_lease.py
+++ b/src/nexus/daemon/t1_lease.py
@@ -25,17 +25,16 @@ of the T1 migration, tracked as CA-3):
    relinquishes the transient record (which only ever unlinks the
    publisher's own ``server_pid`` key).
 3. Readers resolve by session-id (:func:`discover_t1_lease`). The transient
-   window covers the two reader classes RF-2's mechanism names: the owning
-   MCP process (via the in-process ``_t1_state`` pointer) and an
-   MCP-dispatched ``claude -p`` subprocess (via the inherited
-   ``NX_T1_HOST``/``NX_T1_PORT`` env, RDR-105 Path A). It does NOT cover a
-   Claude-Code-spawned Bash sibling that has neither the env nor a resolvable
-   session-id yet (the cold-start sliver before the SessionStart hook writes
-   ``current_session``): such a sibling gets a loud, retryable
-   ``T1ServerNotFoundError`` and succeeds once the session-id resolves. That
-   sliver is the accepted tradeoff of keying on session-id instead of the
-   unreliable ``find_immediate_claude_pid`` PPID-walk (RDR §Gap 2); it is
-   tracked, not a silent failure. No record is ever keyed ``"unknown"``.
+   window covers all three reader classes: the owning MCP process (via the
+   in-process ``_t1_state`` pointer), an MCP-dispatched ``claude -p``
+   subprocess (via the inherited ``NX_T1_HOST``/``NX_T1_PORT`` env, RDR-105
+   Path A), and a Claude-Code-spawned Bash sibling in the cold-start sliver
+   before ``current_session`` is written. The sibling has no env and no
+   resolvable session-id, so it matches the owner's transient record by the
+   owner's immediate Claude ancestor pid (stamped in the payload, resolved
+   identically on both sides via RF-6) -- session-targeted and TTL-bounded,
+   so no cross-session mis-bind (:func:`discover_t1_transient_for_claude`,
+   nexus-0x16i). No record is ever keyed ``"unknown"``.
 
 Session-scoped N-per-user semantics are preserved: the session-id IS the
 scope key (intentionally N owners per uid, one T1 server per session), so
@@ -100,6 +99,7 @@ class T1LeasePublisher:
         version: Optional[str] = None,
         session_resolver: SessionResolver,
         owner_token: Optional[str] = None,
+        claude_pid: Optional[int] = None,
     ) -> None:
         self._registry = registry
         self._server_pid = server_pid
@@ -111,6 +111,13 @@ class T1LeasePublisher:
         }
         self._version = version or _t1_version()
         self._resolver = session_resolver
+        # The owner's immediate Claude ancestor pid (RF-6). Carried in the
+        # transient record's payload ONLY so a bare Bash sibling in the
+        # cold-start window can target this owner's transient lease by the
+        # same pid it resolves for itself (nexus-0x16i). Never a scope KEY
+        # (keys stay server_pid/session-id); never a liveness probe (liveness
+        # is lease freshness). Dropped once the lease re-keys to the session.
+        self._claude_pid = claude_pid
         self._owner_token = owner_token or mint_owner_token()
         self._record: Optional[LeaseRecord] = None
         self._session_key: Optional[str] = None
@@ -145,7 +152,16 @@ class T1LeasePublisher:
         return self._fenced
 
     def _payload(self, session_id: Optional[str]) -> dict[str, Any]:
-        return {"session_id": session_id, "server_pid": self._server_pid}
+        payload: dict[str, Any] = {
+            "session_id": session_id,
+            "server_pid": self._server_pid,
+        }
+        # The claude_pid window-target is only meaningful while transient
+        # (no session-id resolves yet); once session-keyed, readers resolve
+        # by session-id and the hint is dead weight.
+        if session_id is None and self._claude_pid is not None:
+            payload["claude_pid"] = self._claude_pid
+        return payload
 
     def publish(self) -> LeaseRecord:
         """Claim the scope, keying on the session-id if it already resolves,
@@ -292,3 +308,52 @@ def discover_t1_lease(
     if not isinstance(host, str) or not isinstance(port, (int, float)):
         return None
     return host, int(port)
+
+
+def discover_t1_transient_for_claude(
+    claude_pid: int,
+    *,
+    config_dir: Path,
+    clock: Clock = time.time,
+) -> Optional[tuple[str, int]]:
+    """Cold-start transient-window fallback for a bare Bash sibling (nexus-0x16i).
+
+    During the sliver before the SessionStart hook writes ``current_session``,
+    a sibling resolves no session-id, so :func:`discover_t1_lease` cannot find
+    the owner. The owner's TRANSIENT record (still server_pid-keyed, no
+    session-id) carries the owner's immediate Claude ancestor pid in its
+    payload; both sides compute that pid identically (RF-6). This matches the
+    fresh transient lease whose ``payload.claude_pid`` equals the sibling's own
+    ``claude_pid`` and returns its endpoint.
+
+    Session-targeted (a concurrent cold-starting session has a different
+    immediate Claude ancestor, so its transient lease never matches) and
+    TTL-bounded (only fresh leases are considered), so there is no
+    cross-session mis-bind. Returns ``None`` if no matching fresh transient
+    lease exists; the caller then fails loud (Path D). Once the owner re-keys
+    to the session-id the transient record is gone and this returns ``None`` —
+    by then the session-id path resolves.
+    """
+    if claude_pid <= 0:
+        return None
+    cfg = Path(config_dir)
+    if not cfg.exists():
+        return None
+    now = clock()
+    for path in cfg.glob("t1_addr.*"):
+        try:
+            record = LeaseRecord.from_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, KeyError):
+            continue
+        if record.payload.get("session_id") is not None:
+            continue  # session-keyed: resolved via discover_t1_lease, not here
+        if record.payload.get("claude_pid") != claude_pid:
+            continue
+        if not record.is_fresh(now):
+            continue
+        host = record.endpoint.get("host")
+        port = record.endpoint.get("port")
+        if not isinstance(host, str) or not isinstance(port, (int, float)):
+            continue
+        return host, int(port)
+    return None

--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -196,10 +196,11 @@ class T1Database:
             siblings (Bash tool, hooks) once a session-id resolves. In the
             cold-start sliver before the SessionStart hook writes
             ``current_session`` (and with no ``NX_SESSION_ID`` in env), a
-            bare Bash sibling resolves no session-id and falls through to
-            Path D (a loud, retryable ``T1ServerNotFoundError``); it
-            succeeds on retry once the session-id resolves. MCP-dispatched
-            subprocesses are unaffected (Path A env breadcrumb).
+            bare Bash sibling resolves no session-id and falls back to
+            matching the owner's transient lease by its own immediate Claude
+            ancestor pid (``discover_t1_transient_for_claude``, nexus-0x16i);
+            a sibling of a different session does not match and fails loud
+            (Path D). MCP-dispatched subprocesses are unaffected (Path A).
         Path D (failure)
             None of the above -> raise :class:`T1ServerNotFoundError`.
 
@@ -226,19 +227,38 @@ class T1Database:
             self._session_id = self._resolve_session_id(session_id)
             return
 
+        from nexus.session import _nexus_config_dir_at_import
+
+        config_dir = _nexus_config_dir_at_import()
         resolved_session = resolve_active_session_id(session_id)
         if resolved_session:
             from nexus.daemon.t1_lease import discover_t1_lease
-            from nexus.session import _nexus_config_dir_at_import
 
-            addr = discover_t1_lease(
-                resolved_session, config_dir=_nexus_config_dir_at_import()
-            )
+            addr = discover_t1_lease(resolved_session, config_dir=config_dir)
             if addr is not None:
                 host, port = addr
                 self._client = chromadb.HttpClient(host=host, port=port)
                 self._session_id = self._resolve_session_id(session_id)
                 return
+
+        # Cold-start transient-window fallback (nexus-0x16i): before the
+        # SessionStart hook writes current_session, a bare Bash sibling
+        # resolves no session-id. Target the owner's transient lease by the
+        # sibling's own immediate Claude ancestor pid (RF-6: both sides
+        # resolve it identically). Session-targeted + TTL-bounded, so no
+        # cross-session mis-bind; once the owner re-keys to the session-id
+        # this returns None and the session-id path above takes over.
+        from nexus.daemon.t1_lease import discover_t1_transient_for_claude
+        from nexus.session import find_immediate_claude_pid
+
+        addr = discover_t1_transient_for_claude(
+            find_immediate_claude_pid(), config_dir=config_dir
+        )
+        if addr is not None:
+            host, port = addr
+            self._client = chromadb.HttpClient(host=host, port=port)
+            self._session_id = self._resolve_session_id(session_id)
+            return
 
         raise T1ServerNotFoundError(
             "T1 not configured for this process. Either inherit "

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -824,6 +824,56 @@ def _check_orphan_t1() -> list[HealthResult]:
     return [HealthResult(label="T1 sessions", ok=True, detail=detail)]
 
 
+def _check_t3_daemon_version() -> list[HealthResult]:
+    """Flag a CLI-vs-T3-daemon version mismatch (RDR-149, nexus-ymn76).
+
+    The supervised T3 daemon stamps its conexus version in its lease record
+    (RDR-149 P3). After a CLI upgrade the version-skew cycle restarts it (the
+    #1112 fix), but until that fires — or if it failed — the daemon keeps
+    serving the old binary. This is the operator-visible counterpart to that
+    structural fix: it surfaces the mismatch as a soft warning (the daemon
+    still works, it is merely stale). Local mode only; cloud T3 has no daemon.
+    """
+    from importlib.metadata import version as _pkg_version
+
+    from nexus.daemon.discovery import find_t3_daemon
+
+    try:
+        cli_version = _pkg_version("conexus")
+    except Exception:
+        return []  # installed version unknown — nothing to compare against
+
+    daemon = find_t3_daemon()
+    if daemon is None:
+        return [HealthResult(
+            label="T3 daemon version", ok=True, detail="no T3 daemon running"
+        )]
+    daemon_version = daemon.get("version")
+    if not daemon_version:
+        return [HealthResult(
+            label="T3 daemon version", ok=True,
+            detail="T3 daemon lease carries no version (pre-RDR-149 daemon?)",
+        )]
+    if daemon_version == cli_version:
+        return [HealthResult(
+            label="T3 daemon version", ok=True,
+            detail=f"{daemon_version} (matches CLI)",
+        )]
+    return [HealthResult(
+        label="T3 daemon version", ok=False, warn=True,
+        detail=(
+            f"T3 daemon is running {daemon_version} but the CLI is "
+            f"{cli_version} (stale daemon — serving the old binary)"
+        ),
+        fix_suggestions=[
+            "Restart the T3 daemon to pick up the new version: "
+            "nx daemon t3 stop && nx daemon t3 start",
+            "nx upgrade cycles supervised daemons automatically; a mismatch "
+            "here means the version-skew cycle has not run yet or failed.",
+        ],
+    )]
+
+
 def _check_orphan_checkpoints() -> list[HealthResult]:
     from nexus.checkpoint import CHECKPOINT_DIR, scan_orphaned_checkpoints
 
@@ -1325,6 +1375,7 @@ def run_health_checks() -> tuple[list[HealthResult], bool]:
     _local = is_local_mode()
     if _local:
         results.extend(_check_t3_local())
+        results.extend(_check_t3_daemon_version())
     else:
         results.extend(_check_t3_cloud())
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -273,6 +273,7 @@ async def _t1_chroma_lifespan(_app: Any):
         from nexus.daemon.t1_lease import T1LeasePublisher
         from nexus.session import (
             _nexus_config_dir_at_import,
+            find_immediate_claude_pid,
             resolve_active_session_id,
         )
 
@@ -289,12 +290,17 @@ async def _t1_chroma_lifespan(_app: Any):
         registry = ServiceRegistry(
             dir=_nexus_config_dir_at_import(), tier="t1"
         )
+        # nexus-0x16i: stamp the owner's immediate Claude ancestor pid into
+        # the transient record's payload so a bare Bash sibling in the
+        # cold-start window can target this owner by the same pid it resolves
+        # for itself (RF-6). Read-path window hint only; not a scope key.
         publisher = T1LeasePublisher(
             registry=registry,
             server_pid=server_pid,
             host=host,
             port=port,
             session_resolver=resolve_active_session_id,
+            claude_pid=find_immediate_claude_pid(),
         )
         # Invariant: ``_t1_state.T1_ADDR`` (in-process readers) and
         # ``_OWNED_CHROMA["t1_lease_publisher"]`` (the shutdown relinquish

--- a/tests/daemon/test_rdr149_lifecycle_conformance.py
+++ b/tests/daemon/test_rdr149_lifecycle_conformance.py
@@ -600,12 +600,12 @@ def _t1_publisher(
 class TestT1SessionRekey:
     """CA-3: the transient-key -> session-id re-key has no ``"unknown"``
     collapse and no window where the OWNER or an env-inheriting subprocess
-    is stranded. NOTE: the transient lease is registry-discoverable under
-    the ``server_pid`` key (proving the re-key carry-forward and the owner's
-    ``_t1_state`` breadcrumb), but a bare Claude-Code Bash sibling does NOT
-    read that key in production -- the cold-start Bash-sibling sliver is a
-    documented, tracked limitation (see ``test_t1_discovery`` for the honest
-    production-path behavior), not a discoverability guarantee."""
+    is stranded. This asserts the registry-layer invariant: the transient
+    lease is discoverable under the ``server_pid`` key (the re-key
+    carry-forward + owner ``_t1_state`` breadcrumb). The bare Bash sibling's
+    production read path (matching the transient lease by claude_pid,
+    nexus-0x16i) is covered in ``test_t1_discovery`` /
+    ``test_t1_lease.TestTransientClaudeFallback``."""
 
     def _registry(self, config_dir: Path, clock: _FakeClock) -> ServiceRegistry:
         return ServiceRegistry(

--- a/tests/daemon/test_t1_lease.py
+++ b/tests/daemon/test_t1_lease.py
@@ -25,7 +25,11 @@ from pathlib import Path
 import pytest
 
 from nexus.daemon.service_registry import ServiceRegistry, mint_owner_token
-from nexus.daemon.t1_lease import T1LeasePublisher, discover_t1_lease
+from nexus.daemon.t1_lease import (
+    T1LeasePublisher,
+    discover_t1_lease,
+    discover_t1_transient_for_claude,
+)
 
 _SERVER_PID = 4242
 _SIBLING_SERVER_PID = 4343
@@ -56,6 +60,7 @@ def _publisher(
     server_pid: int = _SERVER_PID,
     session_resolver=lambda: None,
     owner_token: str | None = None,
+    claude_pid: int | None = None,
 ) -> T1LeasePublisher:
     return T1LeasePublisher(
         registry=registry,
@@ -65,6 +70,7 @@ def _publisher(
         version="1.0.0",
         session_resolver=session_resolver,
         owner_token=owner_token or mint_owner_token(),
+        claude_pid=claude_pid,
     )
 
 
@@ -339,3 +345,85 @@ class TestDiscoverReader:
     ) -> None:
         assert discover_t1_lease(None, config_dir=config_dir, clock=clock) is None
         assert discover_t1_lease("", config_dir=config_dir, clock=clock) is None
+
+
+class TestTransientClaudeFallback:
+    """nexus-0x16i: the cold-start transient-window fallback. A bare Bash
+    sibling with no resolvable session-id finds the owner's transient lease
+    by matching its own immediate Claude ancestor pid (RF-6)."""
+
+    _CLAUDE_PID = 5150
+
+    def test_matches_fresh_transient_lease_by_claude_pid(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        reg = _registry(config_dir, clock)
+        _publisher(
+            reg, session_resolver=lambda: None, claude_pid=self._CLAUDE_PID
+        ).publish()
+        addr = discover_t1_transient_for_claude(
+            self._CLAUDE_PID, config_dir=config_dir, clock=clock
+        )
+        assert addr == (_HOST, _PORT)
+
+    def test_no_match_for_different_claude_pid(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # A concurrent cold-starting session has a different immediate Claude
+        # ancestor; its transient lease must NOT be grabbed (no mis-bind).
+        reg = _registry(config_dir, clock)
+        _publisher(
+            reg, session_resolver=lambda: None, claude_pid=self._CLAUDE_PID
+        ).publish()
+        assert (
+            discover_t1_transient_for_claude(
+                9999, config_dir=config_dir, clock=clock
+            )
+            is None
+        )
+
+    def test_no_match_for_session_keyed_lease(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # Once re-keyed to a session-id the record is no longer transient;
+        # the fallback ignores it (the session-id path handles it).
+        reg = _registry(config_dir, clock)
+        _publisher(
+            reg, session_resolver=lambda: "sess-A", claude_pid=self._CLAUDE_PID
+        ).publish()
+        assert (
+            discover_t1_transient_for_claude(
+                self._CLAUDE_PID, config_dir=config_dir, clock=clock
+            )
+            is None
+        )
+
+    def test_no_match_for_expired_transient_lease(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        reg = _registry(config_dir, clock)
+        _publisher(
+            reg, session_resolver=lambda: None, claude_pid=self._CLAUDE_PID
+        ).publish()
+        clock.advance(3.1)  # past TTL
+        assert (
+            discover_t1_transient_for_claude(
+                self._CLAUDE_PID, config_dir=config_dir, clock=clock
+            )
+            is None
+        )
+
+    def test_rekey_drops_claude_pid_hint(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # After re-key the session record carries no claude_pid (dead weight).
+        reg = _registry(config_dir, clock)
+        sid: dict[str, str | None] = {"v": None}
+        pub = _publisher(
+            reg, session_resolver=lambda: sid["v"], claude_pid=self._CLAUDE_PID
+        )
+        pub.publish()
+        sid["v"] = "sess-A"
+        pub.tick()  # re-keys to sess-A
+        rec = reg.discover("sess-A")
+        assert rec is not None and "claude_pid" not in rec.payload

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -222,7 +222,6 @@ def test_check_t3_local_surfaces_state2_degraded_bge(tmp_path, monkeypatch) -> N
 def test_check_t3_daemon_version_no_daemon(monkeypatch) -> None:
     from nexus import health
 
-    monkeypatch.setattr(health, "find_t3_daemon", lambda: None, raising=False)
     monkeypatch.setattr(
         "nexus.daemon.discovery.find_t3_daemon", lambda config_dir=None: None
     )
@@ -230,6 +229,20 @@ def test_check_t3_daemon_version_no_daemon(monkeypatch) -> None:
     assert len(results) == 1
     assert results[0].ok is True
     assert "no t3 daemon" in results[0].detail.lower()
+
+
+def test_check_t3_daemon_version_lease_without_version(monkeypatch) -> None:
+    # A pre-RDR-149 daemon lease carries no version field — informational, ok.
+    from nexus import health
+
+    monkeypatch.setattr(
+        "nexus.daemon.discovery.find_t3_daemon",
+        lambda config_dir=None: {"tcp_host": "127.0.0.1", "tcp_port": 1},
+    )
+    results = health._check_t3_daemon_version()
+    assert len(results) == 1
+    assert results[0].ok is True
+    assert "no version" in results[0].detail.lower()
 
 
 def test_check_t3_daemon_version_match(monkeypatch) -> None:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -214,3 +214,50 @@ def test_check_t3_local_surfaces_state2_degraded_bge(tmp_path, monkeypatch) -> N
     assert advisory.warn is True and advisory.fatal is False
     joined = advisory.detail + " " + " ".join(advisory.fix_suggestions)
     assert "bge-768" in joined and "384" in joined
+
+
+# ── _check_t3_daemon_version (RDR-149 nexus-ymn76) ───────────────────────────
+
+
+def test_check_t3_daemon_version_no_daemon(monkeypatch) -> None:
+    from nexus import health
+
+    monkeypatch.setattr(health, "find_t3_daemon", lambda: None, raising=False)
+    monkeypatch.setattr(
+        "nexus.daemon.discovery.find_t3_daemon", lambda config_dir=None: None
+    )
+    results = health._check_t3_daemon_version()
+    assert len(results) == 1
+    assert results[0].ok is True
+    assert "no t3 daemon" in results[0].detail.lower()
+
+
+def test_check_t3_daemon_version_match(monkeypatch) -> None:
+    from importlib.metadata import version as _pkg_version
+
+    from nexus import health
+
+    cli = _pkg_version("conexus")
+    monkeypatch.setattr(
+        "nexus.daemon.discovery.find_t3_daemon",
+        lambda config_dir=None: {"version": cli, "tcp_host": "127.0.0.1", "tcp_port": 1},
+    )
+    results = health._check_t3_daemon_version()
+    assert len(results) == 1
+    assert results[0].ok is True
+    assert cli in results[0].detail
+
+
+def test_check_t3_daemon_version_mismatch_warns(monkeypatch) -> None:
+    from nexus import health
+
+    monkeypatch.setattr(
+        "nexus.daemon.discovery.find_t3_daemon",
+        lambda config_dir=None: {"version": "0.0.1-stale", "tcp_host": "127.0.0.1", "tcp_port": 1},
+    )
+    results = health._check_t3_daemon_version()
+    assert len(results) == 1
+    r = results[0]
+    assert r.ok is False and r.warn is True and r.fatal is False
+    assert "0.0.1-stale" in r.detail
+    assert any("daemon t3" in s for s in r.fix_suggestions)

--- a/tests/test_t1_discovery.py
+++ b/tests/test_t1_discovery.py
@@ -49,9 +49,12 @@ def _discover_t1_endpoint(config_dir, scope_key) -> tuple[str, int] | None:
     return host, port
 
 
-def _publish_t1_session_lease(config_dir, session_id, host, port, *, server_pid=4242):
-    """RDR-149 P4 test helper: publish a session-id-keyed T1 lease so a
-    discovery path that resolves ``session_id`` finds ``(host, port)``."""
+def _publish_t1_session_lease(
+    config_dir, session_id, host, port, *, server_pid=4242, claude_pid=None
+):
+    """RDR-149 P4 test helper: publish a T1 lease. With ``session_id`` it is
+    session-keyed; with ``session_id=None`` it is a transient record (and
+    ``claude_pid`` is stamped into its payload for the cold-start fallback)."""
     from nexus.daemon.service_registry import ServiceRegistry
     from nexus.daemon.t1_lease import T1LeasePublisher
 
@@ -63,6 +66,7 @@ def _publish_t1_session_lease(config_dir, session_id, host, port, *, server_pid=
         port=port,
         version="1.0.0",
         session_resolver=lambda: session_id,
+        claude_pid=claude_pid,
     )
     publisher.publish()
     return publisher
@@ -250,20 +254,47 @@ class TestT1DatabaseFlagOnFilePath:
 
 
 class TestT1ColdStartTransientWindow:
-    """RDR-149 P4 / CA-3: the honest production read-path behavior during the
+    """RDR-149 nexus-0x16i: the production read-path behavior during the
     cold-start transient window (the writer published a transient
     ``server_pid`` lease but no session-id resolves yet).
 
-    The owner (via ``_t1_state``) and MCP-dispatched subprocesses (via the
-    ``NX_T1_HOST``/``NX_T1_PORT`` env breadcrumb, Path A) are covered. A bare
-    Claude-Code Bash sibling -- no env, no resolvable session-id -- is NOT:
-    it gets a loud, retryable ``T1ServerNotFoundError`` (Path D), succeeding
-    once the session-id resolves. This is the accepted tradeoff of keying on
-    session-id rather than the unreliable PPID-walk (RDR §Gap 2), tracked as
-    a known limitation, and is the property the conformance suite's
-    registry-layer ``TestT1SessionRekey`` does NOT by itself assert."""
+    The owner (via ``_t1_state``), MCP-dispatched subprocesses (via the
+    ``NX_T1_HOST``/``NX_T1_PORT`` env breadcrumb, Path A), AND a bare
+    Claude-Code Bash sibling are all covered: the sibling matches the owner's
+    transient lease by its own immediate Claude ancestor pid (RF-6), which is
+    stamped in the transient record's payload. A sibling of a DIFFERENT
+    session (different immediate Claude pid) does not match and fails loud --
+    no cross-session mis-bind."""
 
-    def test_bare_sibling_in_transient_window_raises_not_found(
+    def test_bare_sibling_connects_via_matching_claude_pid(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import MagicMock
+
+        fake_chromadb = MagicMock()
+        fake_chromadb.HttpClient.return_value = MagicMock()
+        monkeypatch.setitem(sys.modules, "chromadb", fake_chromadb)
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        for var in ("NX_T1_HOST", "NX_T1_PORT", "NX_T1_ISOLATED",
+                    "NEXUS_SKIP_T1", "NX_SESSION_ID"):
+            monkeypatch.delenv(var, raising=False)
+
+        # The writer published a TRANSIENT lease stamped with its immediate
+        # Claude pid (8080). No current_session, no NX_SESSION_ID.
+        _publish_t1_session_lease(
+            tmp_path, None, "127.0.0.1", 9999, server_pid=70707, claude_pid=8080
+        )
+        # The sibling resolves the SAME immediate Claude ancestor (RF-6).
+        monkeypatch.setattr(
+            "nexus.session.find_immediate_claude_pid", lambda start_pid=None: 8080
+        )
+
+        from nexus.db.t1 import T1Database
+        T1Database()
+        fake_chromadb.HttpClient.assert_called_once_with(host="127.0.0.1", port=9999)
+
+    def test_sibling_of_different_session_does_not_mis_bind(
         self, tmp_path, monkeypatch
     ):
         from unittest.mock import MagicMock
@@ -276,14 +307,17 @@ class TestT1ColdStartTransientWindow:
                     "NEXUS_SKIP_T1", "NX_SESSION_ID"):
             monkeypatch.delenv(var, raising=False)
 
-        # The writer published a TRANSIENT server_pid lease (session-id
-        # unresolved). No current_session file, no NX_SESSION_ID.
-        _publish_t1_session_lease(tmp_path, None, "127.0.0.1", 9999, server_pid=70707)
+        # A different session's transient lease (its Claude pid is 8080).
+        _publish_t1_session_lease(
+            tmp_path, None, "127.0.0.1", 9999, server_pid=70707, claude_pid=8080
+        )
+        # This sibling belongs to a different session (Claude pid 9090); it
+        # must NOT grab the other session's transient lease.
+        monkeypatch.setattr(
+            "nexus.session.find_immediate_claude_pid", lambda start_pid=None: 9090
+        )
 
         from nexus.db.t1 import T1Database, T1ServerNotFoundError
-        # The bare sibling cannot resolve a session-id, so Path B is skipped
-        # and it fails loud -- it does NOT silently bind to the transient
-        # server_pid lease (no cross-session mis-binding hazard).
         with pytest.raises(T1ServerNotFoundError):
             T1Database()
         fake_chromadb.HttpClient.assert_not_called()

--- a/tests/test_t1_discovery.py
+++ b/tests/test_t1_discovery.py
@@ -322,6 +322,33 @@ class TestT1ColdStartTransientWindow:
             T1Database()
         fake_chromadb.HttpClient.assert_not_called()
 
+    def test_unresolvable_claude_pid_falls_through_to_raise(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import MagicMock
+
+        fake_chromadb = MagicMock()
+        monkeypatch.setitem(sys.modules, "chromadb", fake_chromadb)
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        for var in ("NX_T1_HOST", "NX_T1_PORT", "NX_T1_ISOLATED",
+                    "NEXUS_SKIP_T1", "NX_SESSION_ID"):
+            monkeypatch.delenv(var, raising=False)
+
+        _publish_t1_session_lease(
+            tmp_path, None, "127.0.0.1", 9999, server_pid=70707, claude_pid=8080
+        )
+        # No claude ancestor resolvable (PPID chain yields 0): the fallback
+        # cannot target anything and the constructor fails loud.
+        monkeypatch.setattr(
+            "nexus.session.find_immediate_claude_pid", lambda start_pid=None: 0
+        )
+
+        from nexus.db.t1 import T1Database, T1ServerNotFoundError
+        with pytest.raises(T1ServerNotFoundError):
+            T1Database()
+        fake_chromadb.HttpClient.assert_not_called()
+
     def test_mcp_dispatched_subprocess_in_transient_window_uses_env(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
The two deferred RDR-149 follow-ons, now finished (not deferred), closing out the arc's open follow-on beads.

## nexus-0x16i — close the T1 cold-start Bash-sibling sliver
P4 left a documented limitation: a bare Claude-Code Bash sibling in the cold-start window (before the SessionStart hook writes `current_session`, no `NX_SESSION_ID` in env) resolved no session-id and got a loud `T1ServerNotFoundError`. During P4 review, closing it via a *blind* transient-lease scan was rejected as a cross-session mis-binding hazard. This closes it **safely** with a session-targeted variant:
- The owner stamps its immediate Claude ancestor pid (`find_immediate_claude_pid`, RF-6) into the **transient record's payload** — a read-path window hint only, never a scope key, dropped on re-key to the session-id.
- A sibling in the window falls back to `discover_t1_transient_for_claude`: it matches the fresh transient lease whose `payload.claude_pid` equals the sibling's own immediate Claude ancestor. Both sides resolve the same pid because `nx-mcp` and Bash-tool processes are both direct children of the `claude` binary (verified by the critic). Session-targeted + TTL-bounded ⇒ no cross-session mis-bind — strictly safer than the old pre-P4 PPID-walk.

None of the RDR-149 wins are undermined: liveness stays lease-freshness (TTL), the substrate stays single, no `"unknown"`-keyed records, and the **publish path stays session-id/server_pid-keyed**. The RDR §Validation clause is amended to scope "no `find_immediate_claude_pid` publish path" to the scope-key ban and record the payload-hint as a permitted, gate-consistent exception.

## nexus-ymn76 — nx doctor flags CLI-vs-T3-daemon version mismatch
The operator-visible counterpart to the #1112 structural fix. `health._check_t3_daemon_version` compares the running T3 daemon's lease version against the installed CLI version and soft-warns (the daemon still works, it is merely stale) with a restart fix-suggestion. Local-mode only; registered in `run_health_checks`.

## Reviews
Both stacked reviewers ran on `f9b94887` + `702de913`: code-reviewer approved (3 medium test-hygiene items fixed); substantive-critic flagged one RDR-doc-consistency gap (amended) and **independently verified the cold-start fallback's cross-session safety against the real process-tree topology**. Re-verified: **justified** (0 critical, 0 significant). Full unit suite: 9041 passed, 1 xfailed, 0 failed.

Closes the last two RDR-149 follow-on beads; after merge the epic (nexus-idxg4) and RDR close.

Refs nexus-0x16i, nexus-ymn76