### PR TITLE
fix(daemon): daemon-owned aspect reclaim + spawn-loss retry (nexus-we61e, nexus-64w50)

### DIFF
--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -139,14 +139,10 @@ class AspectExtractionWorker:
 
     Constructor injection: caller may pass ``poll_interval`` and
     ``stale_timeout`` for tests; defaults are tuned for production.
-    """
 
-    # Reclaim runs every N polls rather than every poll: at the
-    # default poll_interval=2s and reclaim_every=15, stale-row
-    # reclamation fires every ~30s. Suppresses the O(N) UPDATE
-    # storm a large stuck queue would otherwise see, while still
-    # recovering crashed-worker rows within one reclaim cycle.
-    _RECLAIM_EVERY_N_POLLS = 15
+    Stale-row reclamation is owned by the T2 daemon, not this worker
+    (nexus-we61e) — see ``_run_loop``.
+    """
 
     # Batch-extraction threshold (RDR-089 Phase D). When the queue
     # has at least this many pending rows, drain them in a single
@@ -168,7 +164,6 @@ class AspectExtractionWorker:
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
         self._lock = threading.Lock()
-        self._poll_count = 0
 
     def start(self) -> None:
         """Spawn the daemon thread. Idempotent — calling twice does
@@ -241,17 +236,23 @@ class AspectExtractionWorker:
         """Drain loop. Runs until ``_stop_event`` is set.
 
         Each iteration:
-          1. Reclaim stale ``in_progress`` rows (every
-             ``_RECLAIM_EVERY_N_POLLS`` iterations — frequency guard
-             on the O(N) UPDATE for large stuck queues).
-          2. Claim a batch of up to ``batch_size`` pending rows.
-          3. If empty: sleep ``poll_interval``.
-          4. If batch_size >= 2: invoke extract_aspects_batch (one
+          1. Claim a batch of up to ``batch_size`` pending rows.
+          2. If empty: sleep ``poll_interval``.
+          3. If batch_size >= 2: invoke extract_aspects_batch (one
              Claude call extracts all rows). RDR-089 Phase D path —
              cost-amortises across rows.
-          5. If batch_size == 1: invoke single-paper extract_aspects
+          4. If batch_size == 1: invoke single-paper extract_aspects
              (existing path). Small-queue case where batch overhead
              is not worth it.
+
+        Stale-row reclamation is NOT done here (nexus-we61e). It is a
+        GLOBAL janitor op, but this worker runs inside every nx-mcp
+        process, so N workers each RPC'd a redundant ``reclaim_stale``
+        UPDATE into the single T2 daemon — N-fold WAL contention that
+        pegged a core on ``database is locked`` after a restart with a
+        stale-row backlog. Reclaim now runs exactly once, on the
+        daemon's own periodic loop (``T2Daemon._reclaim_stale_loop``),
+        which is singular by construction.
 
         All exceptions inside the loop are caught and recorded; the
         worker thread itself never dies from a row's failure.
@@ -259,16 +260,9 @@ class AspectExtractionWorker:
         from nexus.db.t2.aspect_extraction_queue import QueueRow
         from nexus.mcp_infra import t2_index_write
         while not self._stop_event.is_set():
-            # Increment unconditionally so a sustained T2 unavailability
-            # does not pin _poll_count at a multiple of
-            # _RECLAIM_EVERY_N_POLLS and amplify the reclaim UPDATE
-            # against an already-stressed database.
-            self._poll_count += 1
-            do_reclaim = self._poll_count % self._RECLAIM_EVERY_N_POLLS == 0
             try:
-                # RDR-128 P3 (nexus-sbxbe.3): route the hot poll block
-                # (reclaim + claim, every ~poll_interval seconds) through
-                # the T2 daemon so this worker — which runs inside every
+                # RDR-128 P3 (nexus-sbxbe.3): route the claim through the
+                # T2 daemon so this worker — which runs inside every
                 # nx-mcp process — stops opening memory.db directly and
                 # contending on its single WAL writer lock. This is the
                 # every-2s contention behind the recurring
@@ -279,11 +273,13 @@ class AspectExtractionWorker:
                 # `complete_aspect` method (AspectRecord travels as an
                 # asdict() field dict). The worker no longer opens
                 # memory.db on ANY path.
+                #
+                # nexus-we61e: ``reclaim_stale`` is deliberately NOT
+                # called here. It is a global janitor op and running it
+                # from every per-process worker meant N redundant reclaim
+                # UPDATEs RPC'd into the one daemon. The daemon now owns
+                # reclaim on its own periodic loop.
                 def _poll(t2):
-                    if do_reclaim:
-                        t2.aspect_queue.reclaim_stale(
-                            timeout_seconds=self._stale_timeout_seconds,
-                        )
                     return t2.aspect_queue.claim_batch(self._batch_size)
 
                 rows = t2_index_write(_poll)

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -127,7 +127,40 @@ _INTERACTIVE_PROBE_OP = "catalog.is_interactive_write_pending"
 # winner's file never times out inside a window where the holder is mid-
 # re-assert. Module-level so tests can shrink them.
 _REASSERT_INTERVAL: float = 1.0
+
+# nexus-we61e: cadence + staleness window for the daemon-owned aspect-queue
+# reclaim loop. The interval preserves the worker's prior ~30s effective
+# cadence (poll_interval=2s × _RECLAIM_EVERY_N_POLLS=15); the staleness
+# window matches the worker's old ``stale_timeout_seconds`` default so a
+# crashed worker's claimed row is recovered on the same timescale as before.
+_ASPECT_RECLAIM_INTERVAL: float = 30.0
+_ASPECT_RECLAIM_STALE_TIMEOUT_S: int = 60
 _LOSER_POLL_TIMEOUT: float = 3.0
+
+# nexus-64w50: a spawn-lock loser that polls and finds NO reachable winner
+# (``attached=False``) may have collided with an incumbent that is mid-exit
+# inside the RDR-129 defer-release-to-exit drain window: the incumbent
+# early-unlinks its discovery file but holds the spawn lock until the
+# process actually exits. A one-shot loser that quit here left ZERO daemons
+# (the incumbent finishes exiting; nothing replaced it — the live-2026-06-05
+# orphan). So on ``attached=False`` we retry the spawn a bounded number of
+# times; once the incumbent's process exits the OS frees the lock and our
+# retry wins it. Single-writer is preserved because ``_acquire_spawn_lock``
+# is non-blocking (LOCK_NB): a retry can only win when the lock is genuinely
+# free, and otherwise loses again and is counted toward the bound. The
+# window (≈ MAX × (poll + backoff) ≈ 6 × (3 + 2) = 30 s) covers the
+# incumbent's normal drain: the only HARD-bounded leg is the DB close
+# (_DB_CLOSE_TIMEOUT 10 s, enforced via asyncio.wait_for in stop()); socket
+# teardown (server.close + wait_closed) is best-effort and not wrapped in a
+# timeout, so a connection draining a long in-flight RPC at SIGTERM can push
+# the real drain past 10 s. 30 s leaves margin for that in practice; it is
+# NOT a correctness bound (if every retry is exhausted the loser exits 0 and
+# launchd / ensure-running re-spawns). An ``attached=True`` poll exits
+# immediately — a real serving winner is never disturbed, and the in-process
+# retry is invisible to the ensure-running crash-loop guard (which counts
+# cold spawns, not these LOCK_NB losses).
+_SPAWN_LOST_RETRY_MAX: int = 6
+_SPAWN_LOST_RETRY_BACKOFF: float = 2.0
 
 
 def _is_locked_error(exc: BaseException) -> bool:
@@ -752,6 +785,13 @@ class T2Daemon:
         self._lease_record: LeaseRecord | None = None
         # RDR-140 P1.3: self-healing discovery re-assert (holder only).
         self._reassert_task: asyncio.Task[None] | None = None
+        # nexus-we61e: the daemon owns aspect-queue stale-row reclamation.
+        # Reclaim was previously run from every per-process aspect worker,
+        # so N workers RPC'd N redundant reclaim UPDATEs into this one
+        # daemon — the WAL contention that pegged a core on `database is
+        # locked` after a restart with a stale-row backlog. Running it on
+        # the daemon's own loop makes it singular by construction.
+        self._reclaim_task: asyncio.Task[None] | None = None
 
     # ── public properties ───────────────────────────────────────────────
 
@@ -866,6 +906,9 @@ class T2Daemon:
         # mid-shutdown daemon's addr (RDR-129 early-unlink ordering).
         self._reassert_task = asyncio.create_task(self._reassert_discovery_loop())
 
+        # nexus-we61e: the daemon owns aspect-queue stale-row reclaim.
+        self._reclaim_task = asyncio.create_task(self._reclaim_stale_loop())
+
         self._stop_event = asyncio.Event()
         _log.info(
             "t2_daemon_started",
@@ -911,6 +954,45 @@ class T2Daemon:
             except Exception as exc:  # noqa: BLE001
                 # Self-heal is best-effort; never let it crash the daemon.
                 _log.warning("t2_daemon_discovery_reassert_failed", exc=str(exc))
+
+    async def _reclaim_stale_loop(self) -> None:
+        """Periodically reclaim stale ``in_progress`` aspect-queue rows.
+
+        nexus-we61e: this is the SOLE caller of ``reclaim_stale`` in
+        production. It previously ran inside every per-process aspect
+        worker's poll loop; with N nx-mcp processes that meant N
+        redundant reclaim UPDATEs RPC'd into this one daemon, the
+        WAL-lock contention that pegged a core after a restart with a
+        stale-row backlog. The daemon is singular by construction
+        (spawn lock + lease), so running reclaim here runs it exactly
+        once per interval regardless of how many workers are polling.
+
+        Calls ``reclaim_stale`` directly on the hosted T2Database — no
+        RPC, no cross-process contention; it serialises only against the
+        daemon's own dispatch writes through the store's internal lock.
+        Best-effort: a transient ``database is locked`` (already retried
+        with backoff inside ``reclaim_stale``) is logged and the loop
+        continues. Cancelled in :meth:`stop`.
+        """
+        while True:
+            await asyncio.sleep(_ASPECT_RECLAIM_INTERVAL)
+            t2db = self._t2db
+            if t2db is None:
+                continue
+            try:
+                reclaimed = await asyncio.to_thread(
+                    t2db.aspect_queue.reclaim_stale,
+                    _ASPECT_RECLAIM_STALE_TIMEOUT_S,
+                )
+                if reclaimed:
+                    _log.info(
+                        "t2_daemon_aspect_reclaim", reclaimed=reclaimed
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                # Best-effort janitor; never let it crash the daemon.
+                _log.warning("t2_daemon_aspect_reclaim_failed", exc=str(exc))
 
     async def run_until_signal(self) -> None:
         """Block until SIGTERM/SIGINT arrives."""
@@ -959,6 +1041,18 @@ class T2Daemon:
             except BaseException:  # noqa: BLE001
                 pass
             self._reassert_task = None
+
+        # nexus-we61e: stop the daemon-owned reclaim loop. Order is not
+        # load-bearing (it touches only the aspect queue, not discovery),
+        # but cancel before the T2Database close below so an in-flight
+        # reclaim cannot race the handle teardown.
+        if self._reclaim_task is not None:
+            self._reclaim_task.cancel()
+            try:
+                await self._reclaim_task
+            except BaseException:  # noqa: BLE001
+                pass
+            self._reclaim_task = None
 
         if self._uds_server is not None:
             self._uds_server.close()
@@ -1540,22 +1634,42 @@ def run_t2_daemon(
         finally:
             await daemon.stop()
 
-    try:
-        asyncio.run(_main())
-    except T2SpawnLockLost:
-        # RDR-140 P1.3 (nexus-h2oko): losing the spawn lock is a benign
-        # quiet-attach, NOT a crash. A live winner already owns the data
-        # file; poll briefly for its discovery file/socket (best-effort
-        # observability — a discovered-but-unreachable or stale addr just
-        # keeps polling until the timeout), then exit 0 with an info-level
-        # breadcrumb and no traceback. A1-verified: T2Database was never
-        # constructed, so there is nothing to tear down.
-        attached = _poll_for_winner(config_dir, _LOSER_POLL_TIMEOUT)
-        _log.info("t2_daemon_spawn_lost", attached=attached)
-        return
-    except Exception:
-        # Last-resort: an exception escaping the loop (e.g. start()
-        # raising before the handler is installed) must hit the log
-        # file, not a DEVNULL'd stderr.
-        _log.exception("t2_daemon_crashed")
-        raise
+    for attempt in range(1, _SPAWN_LOST_RETRY_MAX + 1):
+        try:
+            asyncio.run(_main())
+            return
+        except T2SpawnLockLost:
+            # RDR-140 P1.3 (nexus-h2oko): losing the spawn lock is a benign
+            # quiet-attach, NOT a crash. A live winner already owns the data
+            # file; poll briefly for its discovery file/socket (best-effort
+            # observability — a discovered-but-unreachable or stale addr just
+            # keeps polling until the timeout). A1-verified: T2Database was
+            # never constructed, so there is nothing to tear down.
+            attached = _poll_for_winner(config_dir, _LOSER_POLL_TIMEOUT)
+            if attached:
+                # A real winner is serving — never disturb it. Exit 0.
+                _log.info("t2_daemon_spawn_lost", attached=True)
+                return
+            # nexus-64w50: no reachable winner. The incumbent is likely
+            # mid-exit in the defer-release-to-exit drain window (lock still
+            # held, discovery file already unlinked). Retry so the freed
+            # lock is re-acquired by us, rather than quit and leave zero
+            # daemons. _acquire_spawn_lock is LOCK_NB, so a retry that still
+            # collides simply loses again and counts toward the bound.
+            if attempt < _SPAWN_LOST_RETRY_MAX:
+                _log.info(
+                    "t2_daemon_spawn_lost_retry",
+                    attempt=attempt,
+                    max_attempts=_SPAWN_LOST_RETRY_MAX,
+                )
+                time.sleep(_SPAWN_LOST_RETRY_BACKOFF)
+                continue
+            # Exhausted the bound without acquiring or finding a winner.
+            _log.info("t2_daemon_spawn_lost", attached=False)
+            return
+        except Exception:
+            # Last-resort: an exception escaping the loop (e.g. start()
+            # raising before the handler is installed) must hit the log
+            # file, not a DEVNULL'd stderr.
+            _log.exception("t2_daemon_crashed")
+            raise

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -149,13 +149,13 @@ _LOSER_POLL_TIMEOUT: float = 3.0
 # is non-blocking (LOCK_NB): a retry can only win when the lock is genuinely
 # free, and otherwise loses again and is counted toward the bound. The
 # window (≈ MAX × (poll + backoff) ≈ 6 × (3 + 2) = 30 s) covers the
-# incumbent's normal drain: the only HARD-bounded leg is the DB close
-# (_DB_CLOSE_TIMEOUT 10 s, enforced via asyncio.wait_for in stop()); socket
-# teardown (server.close + wait_closed) is best-effort and not wrapped in a
-# timeout, so a connection draining a long in-flight RPC at SIGTERM can push
-# the real drain past 10 s. 30 s leaves margin for that in practice; it is
-# NOT a correctness bound (if every retry is exhausted the loser exits 0 and
-# launchd / ensure-running re-spawns). An ``attached=True`` poll exits
+# incumbent's worst-case drain. The two principal legs are HARD-bounded in
+# stop(): socket teardown (_GRACEFUL_STOP_TIMEOUT 5 s, nexus-saigj) + DB
+# close (_DB_CLOSE_TIMEOUT 10 s) ≈ 15 s, leaving comfortable margin. (The
+# catalog handle close is a plain conn.close() with no WAL checkpoint —
+# negligible, not separately timeout-wrapped.) Even if a
+# retry budget is exhausted it is not a correctness failure: the loser exits
+# 0 and launchd / ensure-running re-spawns. An ``attached=True`` poll exits
 # immediately — a real serving winner is never disturbed, and the in-process
 # retry is invisible to the ensure-running crash-loop guard (which counts
 # cold spawns, not these LOCK_NB losses).
@@ -973,26 +973,42 @@ class T2Daemon:
         Best-effort: a transient ``database is locked`` (already retried
         with backoff inside ``reclaim_stale``) is logged and the loop
         continues. Cancelled in :meth:`stop`.
+
+        nexus-nhqll: reclaim runs FIRST, then sleeps — so a freshly
+        (re)started daemon clears any stale-row backlog left by a prior
+        worker death at once, rather than waiting a full interval. This
+        is the recovery path for the post-restart backlog case.
+
+        Residual gap (accepted): while a daemon is crash-loop-suppressed,
+        workers still run and claim/complete rows via the direct-write
+        fallback, so a worker crash there can strand an ``in_progress``
+        row with no reclaimer (reclaim is daemon-only). We do NOT add a
+        worker-side reclaim for it: that would reintroduce the N-fold WAL
+        contention RDR-128 was filed to close, to cover a transient
+        degraded state the crash-loop guard or an operator resolves — and
+        the moment any daemon comes back up, this loop's reclaim-first
+        entry clears the backlog immediately.
         """
         while True:
-            await asyncio.sleep(_ASPECT_RECLAIM_INTERVAL)
             t2db = self._t2db
-            if t2db is None:
-                continue
-            try:
-                reclaimed = await asyncio.to_thread(
-                    t2db.aspect_queue.reclaim_stale,
-                    _ASPECT_RECLAIM_STALE_TIMEOUT_S,
-                )
-                if reclaimed:
-                    _log.info(
-                        "t2_daemon_aspect_reclaim", reclaimed=reclaimed
+            if t2db is not None:
+                try:
+                    reclaimed = await asyncio.to_thread(
+                        t2db.aspect_queue.reclaim_stale,
+                        _ASPECT_RECLAIM_STALE_TIMEOUT_S,
                     )
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:  # noqa: BLE001
-                # Best-effort janitor; never let it crash the daemon.
-                _log.warning("t2_daemon_aspect_reclaim_failed", exc=str(exc))
+                    if reclaimed:
+                        _log.info(
+                            "t2_daemon_aspect_reclaim", reclaimed=reclaimed
+                        )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:  # noqa: BLE001
+                    # Best-effort janitor; never let it crash the daemon.
+                    _log.warning(
+                        "t2_daemon_aspect_reclaim_failed", exc=str(exc)
+                    )
+            await asyncio.sleep(_ASPECT_RECLAIM_INTERVAL)
 
     async def run_until_signal(self) -> None:
         """Block until SIGTERM/SIGINT arrives."""
@@ -1054,14 +1070,32 @@ class T2Daemon:
                 pass
             self._reclaim_task = None
 
-        if self._uds_server is not None:
-            self._uds_server.close()
-            await self._uds_server.wait_closed()
-            self._uds_server = None
-        if self._tcp_server is not None:
-            self._tcp_server.close()
-            await self._tcp_server.wait_closed()
-            self._tcp_server = None
+        # nexus-saigj: bound socket teardown. ``wait_closed()`` blocks until
+        # every open connection drains; a connection holding a long in-flight
+        # RPC at SIGTERM could otherwise extend the drain (and thus the
+        # spawn-lock hold) without limit. Cap each with _GRACEFUL_STOP_TIMEOUT
+        # (the same defense-in-depth pattern as the _DB_CLOSE_TIMEOUT'd close
+        # below); on timeout the server is already closed to new connections,
+        # so we log and proceed — the OS reaps the rest at process exit.
+        for name, server in (
+            ("uds", self._uds_server),
+            ("tcp", self._tcp_server),
+        ):
+            if server is None:
+                continue
+            server.close()
+            try:
+                await asyncio.wait_for(
+                    server.wait_closed(), timeout=_GRACEFUL_STOP_TIMEOUT
+                )
+            except TimeoutError:
+                _log.warning(
+                    "t2_daemon_socket_close_timeout",
+                    server=name,
+                    timeout_s=_GRACEFUL_STOP_TIMEOUT,
+                )
+        self._uds_server = None
+        self._tcp_server = None
         if self._registry is not None and self._lease_record is not None:
             # RDR-149 P2: relinquish is own-record-only, so a fenced
             # predecessor's delayed stop cannot unlink a successor's record

--- a/tests/daemon/test_nexus_64w50_we61e_daemon_reclaim_takeover.py
+++ b/tests/daemon/test_nexus_64w50_we61e_daemon_reclaim_takeover.py
@@ -91,6 +91,36 @@ def test_daemon_reclaim_loop_calls_reclaim_stale(
     assert reclaim.call_args[0][0] == t2_daemon._ASPECT_RECLAIM_STALE_TIMEOUT_S
 
 
+def test_daemon_reclaim_runs_before_first_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """nexus-nhqll: reclaim fires immediately on loop entry, BEFORE the
+    first interval sleep, so a freshly (re)started daemon clears a
+    stale-row backlog at once rather than waiting a full interval."""
+    # A long interval: a sleep-first loop would NOT have reclaimed yet
+    # within the short drive window below; a reclaim-first loop will have.
+    monkeypatch.setattr(t2_daemon, "_ASPECT_RECLAIM_INTERVAL", 999.0)
+
+    reclaim = MagicMock(name="reclaim_stale", return_value=5)
+    daemon = T2Daemon(config_dir=None, db_path=None)  # type: ignore[arg-type]
+    daemon._t2db = SimpleNamespace(
+        aspect_queue=SimpleNamespace(reclaim_stale=reclaim)
+    )
+
+    async def _drive() -> None:
+        task = asyncio.create_task(daemon._reclaim_stale_loop())
+        await asyncio.sleep(0.05)  # << one interval if it slept first
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_drive())
+
+    assert reclaim.call_count == 1  # reclaimed once on entry, then long sleep
+
+
 def test_daemon_reclaim_loop_survives_reclaim_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -115,6 +145,53 @@ def test_daemon_reclaim_loop_survives_reclaim_error(
     # Must not raise out of the loop.
     asyncio.run(_drive())
     assert reclaim.call_count >= 1
+
+
+# ── nexus-saigj: stop() socket teardown is timeout-bounded ────────────────────
+
+
+def test_stop_bounds_hung_socket_wait_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connection whose ``wait_closed()`` never returns must not wedge
+    ``stop()`` open: it is capped at _GRACEFUL_STOP_TIMEOUT and proceeds."""
+    monkeypatch.setattr(t2_daemon, "_GRACEFUL_STOP_TIMEOUT", 0.05)
+
+    closed: set[str] = set()
+
+    class _HungServer:
+        def __init__(self, name: str) -> None:
+            self._name = name
+
+        def close(self) -> None:
+            closed.add(self._name)
+
+        async def wait_closed(self) -> None:
+            await asyncio.Event().wait()  # never set → blocks forever
+
+    daemon = T2Daemon(config_dir=None, db_path=None)  # type: ignore[arg-type]
+    # Both legs hung: a bug that bounded only one would leave the other
+    # to trip the outer guard or drop a timeout log.
+    daemon._uds_server = _HungServer("uds")  # type: ignore[assignment]
+    daemon._tcp_server = _HungServer("tcp")  # type: ignore[assignment]
+
+    async def _drive() -> None:
+        # Bound the whole stop() generously; the internal cap should fire
+        # well before this, so a regression (unbounded wait) trips it.
+        await asyncio.wait_for(daemon.stop(), timeout=5.0)
+
+    with capture_logs() as logs:
+        asyncio.run(_drive())
+
+    assert closed == {"uds", "tcp"}
+    timeouts = sorted(
+        e.get("server")
+        for e in logs
+        if e.get("event") == "t2_daemon_socket_close_timeout"
+    )
+    assert timeouts == ["tcp", "uds"]
+    assert daemon._uds_server is None
+    assert daemon._tcp_server is None
 
 
 # ── nexus-64w50: spawn-loser retries instead of orphaning the service ─────────

--- a/tests/daemon/test_nexus_64w50_we61e_daemon_reclaim_takeover.py
+++ b/tests/daemon/test_nexus_64w50_we61e_daemon_reclaim_takeover.py
@@ -1,0 +1,220 @@
+"""Regression tests for two coupled daemon bugs (2026-06-05, conexus 5.10.0).
+
+nexus-we61e — ``reclaim_stale`` is a GLOBAL janitor op but used to run inside
+every per-process aspect worker's poll loop, so N nx-mcp processes RPC'd N
+redundant reclaim UPDATEs into the one T2 daemon — the WAL-lock contention
+that pegged a core on ``database is locked`` after a restart. Reclaim now runs
+once, on the daemon's own periodic loop.
+
+nexus-64w50 — a spawn-lock loser that polled and found no reachable winner
+(``attached=False``) used to quit, which left ZERO daemons when the incumbent
+was mid-exit in the RDR-129 defer-release-to-exit drain window (lock still
+held, discovery file already unlinked). ``run_t2_daemon`` now retries the
+spawn so the freed lock is re-acquired rather than orphaning the service.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import structlog
+from structlog.testing import capture_logs
+
+import nexus.daemon.t2_daemon as t2_daemon
+from nexus.daemon.t2_daemon import T2Daemon, T2SpawnLockLost, run_t2_daemon
+
+
+# ── nexus-we61e: worker no longer reclaims; daemon owns reclaim ───────────────
+
+
+def test_worker_poll_does_not_reclaim_stale(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The per-process aspect worker's poll claims rows but never calls
+    ``reclaim_stale`` — that op is the daemon's responsibility now."""
+    from nexus.aspect_worker import AspectExtractionWorker
+
+    reclaim = MagicMock(name="reclaim_stale")
+
+    worker = AspectExtractionWorker(poll_interval=0.0)
+
+    def _claim_batch(_n):  # noqa: ANN001
+        # Stop the loop after exactly one claim so the test is bounded.
+        worker._stop_event.set()
+        return []
+
+    fake_t2 = SimpleNamespace(
+        aspect_queue=SimpleNamespace(
+            reclaim_stale=reclaim, claim_batch=_claim_batch,
+        )
+    )
+
+    import nexus.mcp_infra as infra
+
+    monkeypatch.setattr(infra, "t2_index_write", lambda fn: fn(fake_t2))
+
+    worker._run_loop()
+
+    reclaim.assert_not_called()
+
+
+def test_daemon_reclaim_loop_calls_reclaim_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The daemon's periodic loop is the sole caller of ``reclaim_stale``,
+    invoked with the stale-row timeout window."""
+    monkeypatch.setattr(t2_daemon, "_ASPECT_RECLAIM_INTERVAL", 0.0)
+
+    reclaim = MagicMock(name="reclaim_stale", return_value=3)
+    daemon = T2Daemon(config_dir=None, db_path=None)  # type: ignore[arg-type]
+    daemon._t2db = SimpleNamespace(
+        aspect_queue=SimpleNamespace(reclaim_stale=reclaim)
+    )
+
+    async def _drive() -> None:
+        task = asyncio.create_task(daemon._reclaim_stale_loop())
+        # Let the zero-interval loop tick a few times, then cancel.
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_drive())
+
+    assert reclaim.call_count >= 1
+    # Called positionally with the stale-row timeout window.
+    assert reclaim.call_args[0][0] == t2_daemon._ASPECT_RECLAIM_STALE_TIMEOUT_S
+
+
+def test_daemon_reclaim_loop_survives_reclaim_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reclaim failure is logged best-effort and never crashes the loop."""
+    monkeypatch.setattr(t2_daemon, "_ASPECT_RECLAIM_INTERVAL", 0.0)
+
+    reclaim = MagicMock(side_effect=RuntimeError("locked"))
+    daemon = T2Daemon(config_dir=None, db_path=None)  # type: ignore[arg-type]
+    daemon._t2db = SimpleNamespace(
+        aspect_queue=SimpleNamespace(reclaim_stale=reclaim)
+    )
+
+    async def _drive() -> None:
+        task = asyncio.create_task(daemon._reclaim_stale_loop())
+        await asyncio.sleep(0.02)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # Must not raise out of the loop.
+    asyncio.run(_drive())
+    assert reclaim.call_count >= 1
+
+
+# ── nexus-64w50: spawn-loser retries instead of orphaning the service ─────────
+
+
+@pytest.fixture
+def _info_logs(monkeypatch: pytest.MonkeyPatch):
+    """Capture structlog at INFO and stub the side-effecting seams of
+    ``run_t2_daemon`` (logging config + sleep), yielding the captured list."""
+    import nexus.logging_setup as logging_setup
+
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+    )
+    monkeypatch.setattr(logging_setup, "configure_logging", lambda *a, **k: None)
+    monkeypatch.setattr(t2_daemon, "_SPAWN_LOST_RETRY_BACKOFF", 0.0)
+    monkeypatch.setattr(time, "sleep", lambda _s: None)
+
+
+def _stub_asyncio_run(monkeypatch: pytest.MonkeyPatch, outcomes: list):
+    """Replace ``asyncio.run`` with a scripted sequence. Each outcome is
+    either an exception instance (raised) or a sentinel for clean return.
+    The passed coroutine is closed to avoid 'never awaited' warnings."""
+    calls: list[int] = []
+
+    def _fake_run(coro):  # noqa: ANN001
+        coro.close()
+        idx = len(calls)
+        calls.append(1)
+        outcome = outcomes[idx]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(asyncio, "run", _fake_run)
+    return calls
+
+
+def test_spawn_loss_retries_then_acquires(
+    monkeypatch: pytest.MonkeyPatch, _info_logs,
+) -> None:
+    """No reachable winner + lock collisions that clear → the loser retries
+    and eventually wins the freed lock (clean daemon run), never orphaning."""
+    monkeypatch.setattr(t2_daemon, "_poll_for_winner", lambda *a, **k: False)
+    calls = _stub_asyncio_run(
+        monkeypatch,
+        [T2SpawnLockLost("held"), T2SpawnLockLost("held"), None],
+    )
+
+    with capture_logs() as logs:
+        result = run_t2_daemon(config_dir=None, db_path=None)  # type: ignore[arg-type]
+
+    assert result is None
+    assert len(calls) == 3  # two losses, then the winning run
+    retries = [e for e in logs if e.get("event") == "t2_daemon_spawn_lost_retry"]
+    assert len(retries) == 2
+    # Won the lock on attempt 3 → no terminal spawn_lost, no crash.
+    assert not [e for e in logs if e.get("event") == "t2_daemon_spawn_lost"]
+    assert not [e for e in logs if e.get("event") == "t2_daemon_crashed"]
+
+
+def test_spawn_loss_exhausts_retries_without_crash(
+    monkeypatch: pytest.MonkeyPatch, _info_logs,
+) -> None:
+    """Persistent collision + no winner → bounded retries, then a clean
+    terminal ``spawn_lost`` (attached=False). Never an unbounded spin or a
+    crash."""
+    monkeypatch.setattr(t2_daemon, "_poll_for_winner", lambda *a, **k: False)
+    calls = _stub_asyncio_run(
+        monkeypatch,
+        [T2SpawnLockLost("held")] * t2_daemon._SPAWN_LOST_RETRY_MAX,
+    )
+
+    with capture_logs() as logs:
+        result = run_t2_daemon(config_dir=None, db_path=None)  # type: ignore[arg-type]
+
+    assert result is None
+    assert len(calls) == t2_daemon._SPAWN_LOST_RETRY_MAX
+    retries = [e for e in logs if e.get("event") == "t2_daemon_spawn_lost_retry"]
+    assert len(retries) == t2_daemon._SPAWN_LOST_RETRY_MAX - 1
+    terminal = [e for e in logs if e.get("event") == "t2_daemon_spawn_lost"]
+    assert len(terminal) == 1
+    assert terminal[0].get("attached") is False
+    assert not [e for e in logs if e.get("event") == "t2_daemon_crashed"]
+
+
+def test_spawn_loss_to_live_winner_does_not_retry(
+    monkeypatch: pytest.MonkeyPatch, _info_logs,
+) -> None:
+    """A reachable serving winner (attached=True) is never disturbed: the
+    loser exits immediately on the first loss, no retries."""
+    monkeypatch.setattr(t2_daemon, "_poll_for_winner", lambda *a, **k: True)
+    calls = _stub_asyncio_run(monkeypatch, [T2SpawnLockLost("held")])
+
+    with capture_logs() as logs:
+        result = run_t2_daemon(config_dir=None, db_path=None)  # type: ignore[arg-type]
+
+    assert result is None
+    assert len(calls) == 1
+    assert not [e for e in logs if e.get("event") == "t2_daemon_spawn_lost_retry"]
+    terminal = [e for e in logs if e.get("event") == "t2_daemon_spawn_lost"]
+    assert len(terminal) == 1
+    assert terminal[0].get("attached") is True


### PR DESCRIPTION
Four T2-daemon bugs from the 2026-06-05 conexus 5.10.0 shakeout. Direct fixes (no RDR) for a patch release.

## nexus-we61e — reclaim_stale pegs a core after restart
`aspect_queue.reclaim_stale` is a global janitor op but ran inside every per-process `AspectExtractionWorker` poll loop → with N nx-mcp processes (each routing through the single daemon per nexus-zir76), N redundant reclaim `UPDATE`s hammered the one daemon's WAL writer lock (163/200 recent log lines were `database is locked`, 71/200 were reclaim). **Fix:** move reclaim to a daemon-owned periodic task (`_reclaim_stale_loop`), singular by construction; workers only `claim_batch`.

## nexus-64w50 — lease takeover leaves zero daemons
Root cause is the RDR-129 *defer-release-to-exit* drain-window race (confirmed in the live log: `stop_requested` → `spawn_lost attached=False`, no `version_cycle`), **not** the bead's "slow hello()" hypothesis. Incumbent gets SIGTERM → early-unlinks discovery file but holds the spawn lock until exit; a replacement spawn during the drain loses the lock, finds no winner, and quits → zero daemons. **Fix:** `run_t2_daemon` retries the spawn (bounded, max 6, 2s backoff) on `attached=False`. Single-writer preserved: `_acquire_spawn_lock` is `LOCK_NB`, so a retry wins only when the lock is genuinely free.

## nexus-saigj — stop() socket teardown unbounded
`stop()` awaited `wait_closed()` with no timeout; a connection draining a long in-flight RPC at SIGTERM could extend the spawn-lock hold without bound. **Fix:** wrap both `_uds`/`_tcp` `wait_closed()` in `asyncio.wait_for(_GRACEFUL_STOP_TIMEOUT)`, log + proceed on timeout. Makes the 64w50 retry-window budget a real bound.

## nexus-nhqll — stale rows not reclaimed promptly after restart
The reclaim loop slept before its first reclaim, so a restarted daemon waited a full interval before clearing a backlog. **Fix:** reclaim-first-then-sleep — any daemon (re)start clears the backlog immediately. The inherent residual (no daemon ever starts) is documented and deliberately not patched with a worker-side reclaim (would reintroduce RDR-128 multi-writer contention).

## Tests
`tests/daemon/test_nexus_64w50_we61e_daemon_reclaim_takeover.py` (8 tests): worker-doesn't-reclaim, daemon-loop-reclaims-with-correct-timeout, reclaim-before-first-sleep, loop-survives-error, stop-bounds-hung-socket (both legs), retry-then-acquires, retry-exhausts-without-crash, live-winner-not-disturbed. Full daemon + aspect suites green (381 passed).

## Review
Stacked review clean on both commits: code-review-expert APPROVED (0 Critical/Important); substantive-critic 0 Critical / 0 Significant (all prior findings addressed). Lifecycle gate green — changes orthogonal to the lease/liveness primitive.

## Closes
Closes nexus-we61e
Closes nexus-64w50
Closes nexus-saigj
Closes nexus-nhqll