### PR TITLE
fix(t1): restore T1 scratch when session-id diverges from MCP lease key (nexus-gff3g) [P0]

### DIFF
--- a/src/nexus/commands/scratch.py
+++ b/src/nexus/commands/scratch.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import click
 
-from nexus.db.t1 import T1Database
+from nexus.db.t1 import T1Database, T1ServerNotFoundError
 
 
 def _t1() -> T1Database:
@@ -14,8 +14,23 @@ def _t1() -> T1Database:
     leased T1 record, falling back to a local EphemeralClient under
     ``NX_T1_ISOLATED=1`` or raising ``T1ServerNotFoundError`` if no live
     lease is found.
+
+    On that raise, surface a clean actionable message via
+    ``click.ClickException`` (exit 1, no traceback) instead of letting the
+    exception propagate as an unhandled stack dump (nexus-gff3g): a CLI user
+    whose session-id diverges from the MCP's lease key got a wall of traceback
+    where a one-line hint belongs.
     """
-    return T1Database()
+    try:
+        return T1Database()
+    except T1ServerNotFoundError as exc:
+        raise click.ClickException(
+            f"{exc}\n\n"
+            "Quick fix: prefix the command with NX_T1_ISOLATED=1 for an "
+            "in-process ephemeral scratch (not shared with the MCP server), or "
+            "reconnect the conexus MCP/extension so a session-id lease is "
+            "published for this session."
+        ) from exc
 
 
 @click.group()

--- a/src/nexus/daemon/t1_lease.py
+++ b/src/nexus/daemon/t1_lease.py
@@ -156,10 +156,20 @@ class T1LeasePublisher:
             "session_id": session_id,
             "server_pid": self._server_pid,
         }
-        # The claude_pid window-target is only meaningful while transient
-        # (no session-id resolves yet); once session-keyed, readers resolve
-        # by session-id and the hint is dead weight.
-        if session_id is None and self._claude_pid is not None:
+        # Stamp the owner's immediate Claude ancestor pid into EVERY record,
+        # transient and session-keyed alike (nexus-gff3g). A sibling shell whose
+        # resolved session-id diverges from the owner's lease key cannot find the
+        # lease by session-id, and the claude-ancestor-pid fallback is its only
+        # path to its own T1. Divergence is the common case, not an edge case:
+        # the MCP keys on NX_SESSION_ID while the SessionStart hook writes
+        # current_session, and the two Claude-provided ids differ on resume,
+        # with multiple concurrent frontends, and under version skew. The prior
+        # behavior dropped the hint the instant a session-id resolved, so a warm
+        # publish (NX_SESSION_ID set at MCP startup, the common config) never
+        # recorded it and silently killed the fallback. Readers only ever use
+        # claude_pid as a fallback AFTER the session-id path misses, so carrying
+        # it on session-keyed records is free.
+        if self._claude_pid is not None:
             payload["claude_pid"] = self._claude_pid
         return payload
 
@@ -345,8 +355,17 @@ def discover_t1_transient_for_claude(
             record = LeaseRecord.from_json(path.read_text(encoding="utf-8"))
         except (OSError, ValueError, KeyError):
             continue
-        if record.payload.get("session_id") is not None:
-            continue  # session-keyed: resolved via discover_t1_lease, not here
+        # nexus-gff3g: match transient AND session-keyed leases by claude_pid.
+        # By the time control reaches here the session-id path
+        # (discover_t1_lease) has already missed. A session-keyed lease whose
+        # owner shares this sibling's immediate Claude ancestor pid is still the
+        # sibling's own T1 — even though the owner's session-id label diverges
+        # from what this process resolves (NX_SESSION_ID given to the MCP vs
+        # current_session written by the SessionStart hook). The match stays
+        # ancestor-pid-targeted (a different session has a different immediate
+        # Claude ancestor) and TTL-bounded (only fresh leases), so there is no
+        # cross-session mis-bind. The prior `session_id is not None: continue`
+        # skip made this fallback inert for every warm/re-keyed lease.
         if record.payload.get("claude_pid") != claude_pid:
             continue
         if not record.is_fresh(now):

--- a/src/nexus/daemon/t1_lease.py
+++ b/src/nexus/daemon/t1_lease.py
@@ -33,7 +33,7 @@ of the T1 migration, tracked as CA-3):
    resolvable session-id, so it matches the owner's transient record by the
    owner's immediate Claude ancestor pid (stamped in the payload, resolved
    identically on both sides via RF-6) -- session-targeted and TTL-bounded,
-   so no cross-session mis-bind (:func:`discover_t1_transient_for_claude`,
+   so no cross-session mis-bind (:func:`discover_t1_by_claude_ancestor`,
    nexus-0x16i). No record is ever keyed ``"unknown"``.
 
 Session-scoped N-per-user semantics are preserved: the session-id IS the
@@ -320,29 +320,44 @@ def discover_t1_lease(
     return host, int(port)
 
 
-def discover_t1_transient_for_claude(
+def discover_t1_by_claude_ancestor(
     claude_pid: int,
     *,
     config_dir: Path,
     clock: Clock = time.time,
 ) -> Optional[tuple[str, int]]:
-    """Cold-start transient-window fallback for a bare Bash sibling (nexus-0x16i).
+    """Discover a live T1 endpoint by the sibling's immediate Claude ancestor pid.
 
-    During the sliver before the SessionStart hook writes ``current_session``,
-    a sibling resolves no session-id, so :func:`discover_t1_lease` cannot find
-    the owner. The owner's TRANSIENT record (still server_pid-keyed, no
-    session-id) carries the owner's immediate Claude ancestor pid in its
-    payload; both sides compute that pid identically (RF-6). This matches the
-    fresh transient lease whose ``payload.claude_pid`` equals the sibling's own
-    ``claude_pid`` and returns its endpoint.
+    The fallback that fires when the session-id lookup
+    (:func:`discover_t1_lease`) misses. It is LOAD-BEARING, not a narrow edge
+    case: it covers two situations that both leave a Bash sibling unable to
+    find its own T1 by session-id.
 
-    Session-targeted (a concurrent cold-starting session has a different
-    immediate Claude ancestor, so its transient lease never matches) and
-    TTL-bounded (only fresh leases are considered), so there is no
-    cross-session mis-bind. Returns ``None`` if no matching fresh transient
-    lease exists; the caller then fails loud (Path D). Once the owner re-keys
-    to the session-id the transient record is gone and this returns ``None`` —
-    by then the session-id path resolves.
+    * **Cold start** (nexus-0x16i): before the SessionStart hook writes
+      ``current_session`` the sibling resolves no session-id at all, so the
+      owner's still-transient (server_pid-keyed) lease is unfindable by
+      session-id.
+    * **Session-id divergence** (nexus-gff3g — the COMMON production case): the
+      owner's MCP keyed its lease on its ``NX_SESSION_ID`` while the sibling
+      resolves ``current_session`` (written by the SessionStart hook), and the
+      two Claude-provided ids differ (resume, multiple concurrent frontends,
+      version skew). ``discover_t1_lease`` then returns ``None`` for the
+      sibling's id even though the owner's *session-keyed* lease is live.
+
+    In both cases the owner's lease carries the owner's immediate Claude
+    ancestor pid in its payload, and the sibling computes the same pid
+    identically (RF-6). This matches the fresh (``status == "live"``, within
+    TTL) lease — transient OR session-keyed — whose ``payload.claude_pid``
+    equals ``claude_pid`` and returns its endpoint.
+
+    Safety: ancestor-pid-targeted (a different session descends from a
+    different immediate Claude process, so its lease never matches) and
+    TTL-bounded (only fresh leases), so there is no cross-session mis-bind.
+    When more than one fresh lease shares the pid (a brief re-key overlap, or
+    one Claude process owning multiple MCP servers), the record with the
+    newest ``heartbeat_epoch`` wins, so the choice is deterministic rather than
+    dependent on ``glob`` ordering. Returns ``None`` if nothing matches; the
+    caller then fails loud (Path D).
     """
     if claude_pid <= 0:
         return None
@@ -350,22 +365,18 @@ def discover_t1_transient_for_claude(
     if not cfg.exists():
         return None
     now = clock()
+    best: Optional[tuple[float, str, int]] = None
     for path in cfg.glob("t1_addr.*"):
         try:
             record = LeaseRecord.from_json(path.read_text(encoding="utf-8"))
         except (OSError, ValueError, KeyError):
             continue
-        # nexus-gff3g: match transient AND session-keyed leases by claude_pid.
-        # By the time control reaches here the session-id path
-        # (discover_t1_lease) has already missed. A session-keyed lease whose
-        # owner shares this sibling's immediate Claude ancestor pid is still the
-        # sibling's own T1 — even though the owner's session-id label diverges
-        # from what this process resolves (NX_SESSION_ID given to the MCP vs
-        # current_session written by the SessionStart hook). The match stays
-        # ancestor-pid-targeted (a different session has a different immediate
-        # Claude ancestor) and TTL-bounded (only fresh leases), so there is no
-        # cross-session mis-bind. The prior `session_id is not None: continue`
-        # skip made this fallback inert for every warm/re-keyed lease.
+        # Match transient AND session-keyed leases (nexus-gff3g): control only
+        # reaches here after the session-id path missed, and a lease whose
+        # owner shares this sibling's immediate Claude ancestor is the
+        # sibling's own T1 regardless of how its session-id is labeled. The
+        # prior ``session_id is not None: continue`` skip made this inert for
+        # every warm/re-keyed lease.
         if record.payload.get("claude_pid") != claude_pid:
             continue
         if not record.is_fresh(now):
@@ -374,5 +385,9 @@ def discover_t1_transient_for_claude(
         port = record.endpoint.get("port")
         if not isinstance(host, str) or not isinstance(port, (int, float)):
             continue
-        return host, int(port)
-    return None
+        # Deterministic tie-break: newest heartbeat wins (M1/O1).
+        if best is None or record.heartbeat_epoch > best[0]:
+            best = (record.heartbeat_epoch, host, int(port))
+    if best is None:
+        return None
+    return best[1], best[2]

--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -198,7 +198,7 @@ class T1Database:
             ``current_session`` (and with no ``NX_SESSION_ID`` in env), a
             bare Bash sibling resolves no session-id and falls back to
             matching the owner's transient lease by its own immediate Claude
-            ancestor pid (``discover_t1_transient_for_claude``, nexus-0x16i);
+            ancestor pid (``discover_t1_by_claude_ancestor``, nexus-0x16i);
             a sibling of a different session does not match and fails loud
             (Path D). MCP-dispatched subprocesses are unaffected (Path A).
         Path D (failure)
@@ -241,17 +241,20 @@ class T1Database:
                 self._session_id = self._resolve_session_id(session_id)
                 return
 
-        # Cold-start transient-window fallback (nexus-0x16i): before the
-        # SessionStart hook writes current_session, a bare Bash sibling
-        # resolves no session-id. Target the owner's transient lease by the
-        # sibling's own immediate Claude ancestor pid (RF-6: both sides
-        # resolve it identically). Session-targeted + TTL-bounded, so no
-        # cross-session mis-bind; once the owner re-keys to the session-id
-        # this returns None and the session-id path above takes over.
-        from nexus.daemon.t1_lease import discover_t1_transient_for_claude
+        # Ancestor-pid fallback when the session-id path missed. Two cases
+        # (nexus-0x16i cold start AND nexus-gff3g session-id divergence): the
+        # sibling may resolve no session-id (before SessionStart writes
+        # current_session) OR a session-id that simply has no live lease
+        # (because the owner's MCP keyed on a divergent NX_SESSION_ID). Either
+        # way, target the owner's own lease — transient or session-keyed — by
+        # the sibling's immediate Claude ancestor pid (RF-6: both sides resolve
+        # it identically). Ancestor-pid-targeted + TTL-bounded, so no
+        # cross-session mis-bind. ``resolved_session`` being non-empty does NOT
+        # mean this path is unreachable: a non-empty-but-unleased id falls here.
+        from nexus.daemon.t1_lease import discover_t1_by_claude_ancestor
         from nexus.session import find_immediate_claude_pid
 
-        addr = discover_t1_transient_for_claude(
+        addr = discover_t1_by_claude_ancestor(
             find_immediate_claude_pid(), config_dir=config_dir
         )
         if addr is not None:

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -77,7 +77,12 @@ def session_start(claude_session_id: str | None = None) -> str:
     if not inherited:
         write_claude_session_id(session_id)
 
-    return f"Nexus ready. T1 scratch initialized (session: {session_id})."
+    # nexus-gff3g: do NOT claim "T1 scratch initialized" here. This hook only
+    # records the session-id; T1 chroma is owned by the MCP server's FastMCP
+    # lifespan (RDR-105 P4), which may key its lease on a DIFFERENT session-id
+    # (its NX_SESSION_ID) than the one written above. Claiming initialization
+    # masked exactly that divergence during the 5.10.x T1-scratch failure.
+    return f"Nexus ready (session: {session_id})."
 
 
 # -- SessionEnd ---------------------------------------------------------------

--- a/tests/daemon/test_t1_lease.py
+++ b/tests/daemon/test_t1_lease.py
@@ -28,7 +28,7 @@ from nexus.daemon.service_registry import ServiceRegistry, mint_owner_token
 from nexus.daemon.t1_lease import (
     T1LeasePublisher,
     discover_t1_lease,
-    discover_t1_transient_for_claude,
+    discover_t1_by_claude_ancestor,
 )
 
 _SERVER_PID = 4242
@@ -361,7 +361,7 @@ class TestTransientClaudeFallback:
         _publisher(
             reg, session_resolver=lambda: None, claude_pid=self._CLAUDE_PID
         ).publish()
-        addr = discover_t1_transient_for_claude(
+        addr = discover_t1_by_claude_ancestor(
             self._CLAUDE_PID, config_dir=config_dir, clock=clock
         )
         assert addr == (_HOST, _PORT)
@@ -376,7 +376,7 @@ class TestTransientClaudeFallback:
             reg, session_resolver=lambda: None, claude_pid=self._CLAUDE_PID
         ).publish()
         assert (
-            discover_t1_transient_for_claude(
+            discover_t1_by_claude_ancestor(
                 9999, config_dir=config_dir, clock=clock
             )
             is None
@@ -397,7 +397,7 @@ class TestTransientClaudeFallback:
         _publisher(
             reg, session_resolver=lambda: "sess-A", claude_pid=self._CLAUDE_PID
         ).publish()
-        assert discover_t1_transient_for_claude(
+        assert discover_t1_by_claude_ancestor(
             self._CLAUDE_PID, config_dir=config_dir, clock=clock
         ) == (_HOST, _PORT)
 
@@ -412,11 +412,34 @@ class TestTransientClaudeFallback:
             reg, session_resolver=lambda: "sess-A", claude_pid=self._CLAUDE_PID
         ).publish()
         assert (
-            discover_t1_transient_for_claude(
+            discover_t1_by_claude_ancestor(
                 self._CLAUDE_PID + 1, config_dir=config_dir, clock=clock
             )
             is None
         )
+
+    def test_tie_break_prefers_newest_heartbeat(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # nexus-gff3g M1/O1: when >1 fresh lease shares the claude_pid (a brief
+        # re-key overlap, or one Claude process owning multiple MCP servers),
+        # the newest heartbeat wins deterministically rather than glob order.
+        reg = _registry(config_dir, clock)
+        T1LeasePublisher(
+            registry=reg, server_pid=_SERVER_PID, host="127.0.0.1", port=11111,
+            version="1.0.0", session_resolver=lambda: "sess-old",
+            claude_pid=self._CLAUDE_PID,
+        ).publish()
+        clock.advance(0.5)  # newer heartbeat, still inside the 3.0s TTL
+        T1LeasePublisher(
+            registry=reg, server_pid=_SIBLING_SERVER_PID, host="127.0.0.1",
+            port=22222, version="1.0.0", session_resolver=lambda: "sess-new",
+            claude_pid=self._CLAUDE_PID,
+        ).publish()
+        # Both leases are fresh and share the pid; the newest-heartbeat one wins.
+        assert discover_t1_by_claude_ancestor(
+            self._CLAUDE_PID, config_dir=config_dir, clock=clock
+        ) == ("127.0.0.1", 22222)
 
     def test_no_match_for_expired_transient_lease(
         self, config_dir: Path, clock: _FakeClock
@@ -427,7 +450,7 @@ class TestTransientClaudeFallback:
         ).publish()
         clock.advance(3.1)  # past TTL
         assert (
-            discover_t1_transient_for_claude(
+            discover_t1_by_claude_ancestor(
                 self._CLAUDE_PID, config_dir=config_dir, clock=clock
             )
             is None

--- a/tests/daemon/test_t1_lease.py
+++ b/tests/daemon/test_t1_lease.py
@@ -382,18 +382,38 @@ class TestTransientClaudeFallback:
             is None
         )
 
-    def test_no_match_for_session_keyed_lease(
+    def test_matches_session_keyed_lease_by_claude_pid(
         self, config_dir: Path, clock: _FakeClock
     ) -> None:
-        # Once re-keyed to a session-id the record is no longer transient;
-        # the fallback ignores it (the session-id path handles it).
+        # nexus-gff3g: a session-keyed lease whose owner shares this sibling's
+        # immediate Claude ancestor pid IS the sibling's own T1 and must match.
+        # The fallback only fires after the session-id path (discover_t1_lease)
+        # has already missed, which happens whenever the owner's session-id
+        # label diverges from what the sibling resolves (NX_SESSION_ID given to
+        # the MCP vs current_session written by the SessionStart hook). The old
+        # `session_id is not None: continue` skip made this fallback inert for
+        # every warm/re-keyed lease, the 5.10.x T1-scratch hard-fail.
+        reg = _registry(config_dir, clock)
+        _publisher(
+            reg, session_resolver=lambda: "sess-A", claude_pid=self._CLAUDE_PID
+        ).publish()
+        assert discover_t1_transient_for_claude(
+            self._CLAUDE_PID, config_dir=config_dir, clock=clock
+        ) == (_HOST, _PORT)
+
+    def test_no_match_for_session_keyed_lease_with_different_claude_pid(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        # Extending the fallback to session-keyed leases preserves the
+        # no-cross-session-mis-bind property: a different immediate Claude
+        # ancestor pid must NOT match, even for a session-keyed lease.
         reg = _registry(config_dir, clock)
         _publisher(
             reg, session_resolver=lambda: "sess-A", claude_pid=self._CLAUDE_PID
         ).publish()
         assert (
             discover_t1_transient_for_claude(
-                self._CLAUDE_PID, config_dir=config_dir, clock=clock
+                self._CLAUDE_PID + 1, config_dir=config_dir, clock=clock
             )
             is None
         )
@@ -413,10 +433,13 @@ class TestTransientClaudeFallback:
             is None
         )
 
-    def test_rekey_drops_claude_pid_hint(
+    def test_rekey_retains_claude_pid_hint(
         self, config_dir: Path, clock: _FakeClock
     ) -> None:
-        # After re-key the session record carries no claude_pid (dead weight).
+        # nexus-gff3g: after re-key the session record RETAINS claude_pid so a
+        # sibling whose session-id diverges from the owner's can still reach its
+        # own T1 via the claude-ancestor-pid fallback. Dropping it (the prior
+        # behavior) silently killed that fallback for every re-keyed lease.
         reg = _registry(config_dir, clock)
         sid: dict[str, str | None] = {"v": None}
         pub = _publisher(
@@ -426,4 +449,5 @@ class TestTransientClaudeFallback:
         sid["v"] = "sess-A"
         pub.tick()  # re-keys to sess-A
         rec = reg.discover("sess-A")
-        assert rec is not None and "claude_pid" not in rec.payload
+        assert rec is not None
+        assert rec.payload.get("claude_pid") == self._CLAUDE_PID

--- a/tests/test_scratch_cmd.py
+++ b/tests/test_scratch_cmd.py
@@ -163,3 +163,29 @@ def test_scratch_delete_not_found(runner: CliRunner, fake_home: Path) -> None:
 
 
 
+
+
+# ── friendly error when T1 is unresolvable (nexus-gff3g) ─────────────────────
+
+def test_scratch_list_friendly_error_when_t1_unresolvable(
+    runner: CliRunner,
+) -> None:
+    """nx scratch must print a clean hint, not a raw traceback, when the
+    session-id diverges from the MCP's lease key and no T1 lease resolves.
+
+    Pre-fix the T1ServerNotFoundError propagated unhandled and click dumped
+    the full Python stack; the user got a wall of traceback where a one-line
+    fix belongs.
+    """
+    from nexus.db.t1 import T1ServerNotFoundError
+
+    with patch(
+        "nexus.commands.scratch.T1Database",
+        side_effect=T1ServerNotFoundError("T1 not configured for this process."),
+    ):
+        result = runner.invoke(main, ["scratch", "list"])
+
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output
+    assert "NX_T1_ISOLATED=1" in result.output
+    assert "T1 not configured" in result.output

--- a/tests/test_t1_discovery.py
+++ b/tests/test_t1_discovery.py
@@ -53,8 +53,10 @@ def _publish_t1_session_lease(
     config_dir, session_id, host, port, *, server_pid=4242, claude_pid=None
 ):
     """RDR-149 P4 test helper: publish a T1 lease. With ``session_id`` it is
-    session-keyed; with ``session_id=None`` it is a transient record (and
-    ``claude_pid`` is stamped into its payload for the cold-start fallback)."""
+    session-keyed; with ``session_id=None`` it is a transient record.
+    ``claude_pid`` is stamped into the payload of EITHER kind (nexus-gff3g) for
+    the ancestor-pid fallback, which serves both the cold-start window and the
+    common session-id-divergence case (NX_SESSION_ID != current_session)."""
     from nexus.daemon.service_registry import ServiceRegistry
     from nexus.daemon.t1_lease import T1LeasePublisher
 

--- a/tests/test_t1_discovery.py
+++ b/tests/test_t1_discovery.py
@@ -322,6 +322,99 @@ class TestT1ColdStartTransientWindow:
             T1Database()
         fake_chromadb.HttpClient.assert_not_called()
 
+    # ── nexus-gff3g: session-id divergence (NX_SESSION_ID != current_session)
+    # The owner's MCP keys its lease on its own resolved session-id (warm
+    # publish), but a sibling shell resolves a DIFFERENT session-id, so the
+    # session-id lease path misses. The claude-ancestor-pid fallback MUST still
+    # find the owner's own T1 — which requires (a) the warm/session-keyed lease
+    # to RETAIN claude_pid in its payload and (b) the fallback to consider
+    # session-keyed leases, not just transient ones.
+
+    def test_warm_session_keyed_lease_retains_claude_pid(self, tmp_path):
+        """A session-keyed (warm) publish must keep claude_pid in the payload.
+
+        Pre-fix, ``_payload`` dropped claude_pid whenever a session-id
+        resolved, so every MCP launched with NX_SESSION_ID set published a
+        lease with no claude_pid hint — killing the cold-start fallback in
+        the common configuration (nexus-gff3g).
+        """
+        pub = _publish_t1_session_lease(
+            tmp_path, "owner-sess", "127.0.0.1", 9999,
+            server_pid=70707, claude_pid=8080,
+        )
+        assert pub.record.payload.get("session_id") == "owner-sess"
+        assert pub.record.payload.get("claude_pid") == 8080
+
+    def test_sibling_connects_to_session_keyed_lease_when_session_diverges(
+        self, tmp_path, monkeypatch
+    ):
+        """Divergent session-id + matching Claude ancestor pid -> connect.
+
+        The owner published a SESSION-KEYED lease under ``owner-sess`` stamped
+        with claude_pid 8080. The sibling resolves a DIFFERENT session-id
+        (``divergent-sess`` via NX_SESSION_ID), so ``discover_t1_lease`` misses;
+        it must fall back to the owner's own lease by the shared immediate
+        Claude ancestor pid. This is the exact 5.10.x production failure.
+        """
+        from unittest.mock import MagicMock
+
+        fake_chromadb = MagicMock()
+        fake_chromadb.HttpClient.return_value = MagicMock()
+        monkeypatch.setitem(sys.modules, "chromadb", fake_chromadb)
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        for var in ("NX_T1_HOST", "NX_T1_PORT", "NX_T1_ISOLATED",
+                    "NEXUS_SKIP_T1"):
+            monkeypatch.delenv(var, raising=False)
+        # Sibling resolves a session-id that does NOT match the lease key.
+        monkeypatch.setenv("NX_SESSION_ID", "divergent-sess")
+
+        _publish_t1_session_lease(
+            tmp_path, "owner-sess", "127.0.0.1", 9999,
+            server_pid=70707, claude_pid=8080,
+        )
+        monkeypatch.setattr(
+            "nexus.session.find_immediate_claude_pid", lambda start_pid=None: 8080
+        )
+
+        from nexus.db.t1 import T1Database
+        T1Database()
+        fake_chromadb.HttpClient.assert_called_once_with(host="127.0.0.1", port=9999)
+
+    def test_session_keyed_fallback_preserves_no_mis_bind(
+        self, tmp_path, monkeypatch
+    ):
+        """Extending the fallback to session-keyed leases must NOT mis-bind.
+
+        A sibling whose Claude ancestor pid (9090) differs from the lease's
+        (8080) must still fail loud even with a divergent session-id — the
+        ancestor-pid targeting that prevents cross-session mis-bind for
+        transient leases must hold for session-keyed leases too.
+        """
+        from unittest.mock import MagicMock
+
+        fake_chromadb = MagicMock()
+        monkeypatch.setitem(sys.modules, "chromadb", fake_chromadb)
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        for var in ("NX_T1_HOST", "NX_T1_PORT", "NX_T1_ISOLATED",
+                    "NEXUS_SKIP_T1"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("NX_SESSION_ID", "divergent-sess")
+
+        _publish_t1_session_lease(
+            tmp_path, "owner-sess", "127.0.0.1", 9999,
+            server_pid=70707, claude_pid=8080,
+        )
+        monkeypatch.setattr(
+            "nexus.session.find_immediate_claude_pid", lambda start_pid=None: 9090
+        )
+
+        from nexus.db.t1 import T1Database, T1ServerNotFoundError
+        with pytest.raises(T1ServerNotFoundError):
+            T1Database()
+        fake_chromadb.HttpClient.assert_not_called()
+
     def test_unresolvable_claude_pid_falls_through_to_raise(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Emergency P0 — T1 scratch hard-fail on 5.10.x

`nx scratch` (CLI, raw traceback) and the MCP scratch tool both raised `T1ServerNotFoundError` whenever a shell sibling's resolved session-id diverged from the MCP server's T1 lease key. The MCP keys its lease on `NX_SESSION_ID`; the SessionStart hook writes `current_session`; the two Claude-provided ids diverge on **resume**, with **multiple concurrent frontends** (Code CLI + Desktop `.mcpb`), and under **version skew**. `discover_t1_lease` then finds no lease for the shell's id, and the claude-ancestor-pid fallback couldn't save it due to two coupled bugs:

1. `T1LeasePublisher._payload` recorded `claude_pid` **only while transient**. A warm publish (`NX_SESSION_ID` set at MCP startup — the common config) keyed straight on the session and dropped the hint.
2. The fallback skipped session-keyed leases entirely.

## Fix
- Stamp `claude_pid` into **every** lease record (transient + session-keyed).
- Let the ancestor-pid fallback match session-keyed leases too. Renamed `discover_t1_transient_for_claude` → **`discover_t1_by_claude_ancestor`** with an honest docstring (it's load-bearing, not a cold-start edge case).
- Deterministic newest-`heartbeat_epoch` tie-break when >1 fresh lease shares a `claude_pid`.
- CLI: clean `click.ClickException` + workaround hint instead of an unhandled traceback.
- SessionStart hook no longer claims "T1 scratch initialized" (it only records the session-id; the MCP lifespan owns T1).

**No-cross-session-mis-bind preserved**: ancestor-pid-targeted + TTL-bounded + `status==live`. Regression test included.

## Not in scope (deferred, P2/RDR)
The underlying `NX_SESSION_ID` vs `current_session` divergence (session-scoped attribution). The pid fallback makes T1 *functional*; reconciliation is a follow-up.

## Review
Stacked review complete — code-review-expert (APPROVED, 0 Critical) + substantive-critic (0 Critical, 2 Significant both naming/docs, all remediated in 226456ee). Verdicts in T2 `gff3g-p0-patch-review-2026-06-05`.

## Tests
Red-first. 1188 green across the touched surface; 88 green on t1_lease + t1_discovery + scratch_cmd. New: warm-publish retains claude_pid; sibling connects to session-keyed lease on divergence; no-mis-bind on different pid; deterministic tie-break; CLI friendly-catch.

Refs nexus-gff3g, nexus-4fw0z