### PR TITLE
release: conexus 5.10.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.10.2"
+        "ref": "v5.10.3"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.10.2"
+      "version": "5.10.3"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.10.2"
+        "ref": "v5.10.3"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.10.2"
+      "version": "5.10.3"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.10.3] - 2026-06-05
+
+T2 daemon reliability fix.
+
+### Fixed
+
+- **T2 daemon no longer pegged to ~100% CPU (and T2 writes no longer fail
+  with `database is locked`) by a client `reclaim_stale` RPC flood
+  (nexus-xmohw).** Aspect-queue stale-row reclaim is daemon-owned since
+  nexus-we61e — the daemon's own loop calls it directly once per interval.
+  But version-skewed workers from before we61e (conexus <=5.10.0) still RPC
+  `aspect_queue.reclaim_stale` on every poll, and the daemon honoured each as
+  a real full-table UPDATE+commit. With several stale workers that floods the
+  SQLite write lock, pegs a core, makes the daemon slow to answer `hello()`,
+  and triggers ensure-running to spawn a replacement — a takeover churn that
+  leaves two daemons contending on `memory.db`, at which point `nx memory
+  put` fails outright. The client-facing dispatch entry for
+  `aspect_queue.reclaim_stale` is now a cheap no-op returning 0 that never
+  touches the DB; the daemon's own reclaim loop is unaffected. A one-shot
+  WARNING per daemon surfaces that stale workers are still present so an
+  operator can restart them.
+
 ## [5.10.2] - 2026-06-05
 
 T1 scratch reliability fix from the 5.10.1 shakeout.

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.10.2",
+  "version": "5.10.3",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.10.3] - 2026-06-05
+
+Plugin version aligned with conexus 5.10.3 (T2 daemon reliability fix: a
+client `reclaim_stale` RPC flood from version-skewed <=5.10.0 workers pegged
+the daemon and caused `nx memory put` to fail with `database is locked`; the
+RPC is now a daemon-owned no-op — nexus-xmohw). No plugin-side changes.
+
 ## [5.10.2] - 2026-06-05
 
 Plugin version aligned with conexus 5.10.2 (T1 scratch session-id-divergence

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.10.2",
+  "version": "5.10.3",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conexus-mcpb"
-version = "5.10.2"
+version = "5.10.3"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
@@ -10,7 +10,7 @@ dependencies = [
     # while collections are indexed at 768/1024-dim, so every T3 search hits a
     # dimension mismatch and returns zero results. The .mcpb cannot run the
     # interactive `nx init` embedder choice, so it must pin [local] explicitly.
-    "conexus[local]>=5.10.2",
+    "conexus[local]>=5.10.3",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.10.2"
+version = "5.10.3"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.10.2",
+  "version": "5.10.3",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -615,13 +615,36 @@ def _build_dispatch_table(t2db: Any) -> dict[str, Any]:
     # the client-facing entry is a cheap no-op returning 0 that never
     # touches the DB. The daemon's own loop is unaffected (it bypasses
     # this table), so legitimate reclaim still happens.
+    # The override must run AFTER the store-enumeration loop above (which
+    # registers the real bound method); the membership check is the guard
+    # for that ordering. If reclaim_stale is ever legitimately removed from
+    # the client table (e.g. added to _RPC_DENY_OPS), absence is also safe —
+    # a denied op raises unknown-op, which is likewise a cheap no-DB path, so
+    # the flood still cannot peg the daemon. The dispatch-table test asserts
+    # the entry is present and is the no-op, so a silent skip fails CI.
     if "aspect_queue.reclaim_stale" in table:
+        # warn-once-per-daemon-instance: the no-op silences the T2-write-
+        # failure symptom, so an operator would otherwise have NO signal that
+        # version-skewed workers are still present and need restarting. Emit
+        # one WARNING (visible at INFO-level production logging) the first
+        # time a stale client RPCs reclaim; stay at DEBUG thereafter so a
+        # 1800/hr-per-worker flood does not spam the log (reviewer: critic S1).
+        _warned = [False]
+
         def _reclaim_stale_rpc_noop(*_args: Any, **_kwargs: Any) -> int:
-            # DEBUG (not WARNING): a stale-worker flood would spam at higher
-            # levels. Operators chasing the cause enable debug to confirm
-            # version-skewed workers are still RPC'ing reclaim, then restart
-            # the offending nx-mcp processes.
-            _log.debug("t2_daemon_reclaim_stale_rpc_noop")
+            if not _warned[0]:
+                _warned[0] = True
+                _log.warning(
+                    "t2_daemon_reclaim_stale_rpc_ignored",
+                    hint=(
+                        "a version-skewed (<=5.10.0) nx-mcp worker is RPC'ing "
+                        "aspect_queue.reclaim_stale; reclaim is daemon-owned "
+                        "since we61e and this RPC is a no-op — restart stale "
+                        "nx-mcp processes to clear the source (nexus-xmohw)"
+                    ),
+                )
+            else:
+                _log.debug("t2_daemon_reclaim_stale_rpc_noop")
             return 0
 
         table["aspect_queue.reclaim_stale"] = _reclaim_stale_rpc_noop

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -601,6 +601,30 @@ def _build_dispatch_table(t2db: Any) -> dict[str, Any]:
         candidate = getattr(t2db, method_name, None)
         if callable(candidate):
             table[f"database.{method_name}"] = candidate
+    # nexus-xmohw: ``aspect_queue.reclaim_stale`` is daemon-owned since
+    # nexus-we61e — ``T2Daemon._reclaim_stale_loop`` calls it DIRECTLY on
+    # ``t2db`` (not through this table), exactly once per interval. No
+    # current worker RPCs it (aspect_worker.py deliberately stopped after
+    # we61e), but version-skewed workers from before we61e (<=5.10.0) still
+    # do on every poll. Honouring each as a real full-table UPDATE+commit
+    # floods the SQLite write lock and pegs the daemon at ~100% CPU, which
+    # makes it slow to answer ``hello()`` -> ensure-running declares it
+    # stale and spawns a replacement -> takeover churn -> 2+ daemons
+    # contend on memory.db -> ``nx memory put`` hard-fails with
+    # ``database is locked``. Neutralise the flood at the RPC boundary:
+    # the client-facing entry is a cheap no-op returning 0 that never
+    # touches the DB. The daemon's own loop is unaffected (it bypasses
+    # this table), so legitimate reclaim still happens.
+    if "aspect_queue.reclaim_stale" in table:
+        def _reclaim_stale_rpc_noop(*_args: Any, **_kwargs: Any) -> int:
+            # DEBUG (not WARNING): a stale-worker flood would spam at higher
+            # levels. Operators chasing the cause enable debug to confirm
+            # version-skewed workers are still RPC'ing reclaim, then restart
+            # the offending nx-mcp processes.
+            _log.debug("t2_daemon_reclaim_stale_rpc_noop")
+            return 0
+
+        table["aspect_queue.reclaim_stale"] = _reclaim_stale_rpc_noop
     return table
 
 

--- a/tests/daemon/test_t2_daemon_lifecycle.py
+++ b/tests/daemon/test_t2_daemon_lifecycle.py
@@ -224,6 +224,38 @@ class TestDispatchTable:
         for op in _RPC_DENY_OPS:
             assert op not in table, f"denied op {op!r} leaked into dispatch table"
 
+    def test_reclaim_stale_rpc_is_noop(self, db_path: Path) -> None:
+        """nexus-xmohw: ``aspect_queue.reclaim_stale`` over RPC must be a
+        cheap no-op returning 0 that NEVER touches the DB.
+
+        Reclaim is daemon-owned (nexus-we61e: ``_reclaim_stale_loop``
+        calls it directly on ``t2db``). No current worker RPCs it, but
+        version-skewed workers (<=5.10.0, pre-we61e) still do every poll.
+        Honouring each as a real full-table UPDATE+commit floods the
+        write lock and pegs the daemon at 100% CPU -> slow ``hello()`` ->
+        takeover churn -> multi-daemon -> T2 write failures (nexus-x47yx).
+        The client-facing dispatch entry must therefore bypass the DB
+        entirely.
+        """
+        from unittest.mock import MagicMock
+
+        from nexus.daemon.t2_daemon import _build_dispatch_table
+        from nexus.db.t2 import T2Database
+
+        db = T2Database(db_path)
+        try:
+            # Spy on the real reclaim_stale: the RPC entry must NOT call it.
+            real = MagicMock(return_value=99)
+            db.aspect_queue.reclaim_stale = real  # type: ignore[method-assign]
+            table = _build_dispatch_table(db)
+            rpc_entry = table["aspect_queue.reclaim_stale"]
+            result = rpc_entry(60)  # what a stale worker sends (timeout_seconds)
+        finally:
+            db.close()
+
+        assert result == 0, "RPC reclaim_stale must return 0 (daemon-owned no-op)"
+        real.assert_not_called()  # must not touch the DB / real reclaim
+
 
 # ---------------------------------------------------------------------------
 # Daemon lifecycle (real sockets, in-process)

--- a/tests/daemon/test_t2_daemon_lifecycle.py
+++ b/tests/daemon/test_t2_daemon_lifecycle.py
@@ -250,11 +250,21 @@ class TestDispatchTable:
             table = _build_dispatch_table(db)
             rpc_entry = table["aspect_queue.reclaim_stale"]
             result = rpc_entry(60)  # what a stale worker sends (timeout_seconds)
+            # The override is table-SCOPED: it must NOT mutate the store's
+            # real method, which the daemon's own _reclaim_stale_loop calls
+            # directly (t2db.aspect_queue.reclaim_stale) to do legitimate
+            # reclaim. If the override leaked onto the store, the daemon would
+            # silently stop reclaiming.
+            store_method_unchanged = db.aspect_queue.reclaim_stale is real
         finally:
             db.close()
 
         assert result == 0, "RPC reclaim_stale must return 0 (daemon-owned no-op)"
         real.assert_not_called()  # must not touch the DB / real reclaim
+        assert store_method_unchanged, (
+            "override leaked onto the store method; the daemon's own reclaim "
+            "loop would stop reclaiming"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.10.2"
+version = "5.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Patch release: T2 daemon reliability fix (nexus-xmohw). Base: main (5.10.2) + the reviewed fix.

## Fixed
A client `reclaim_stale` RPC flood from version-skewed (<=5.10.0) workers pegged the T2 daemon at ~100% CPU and caused `nx memory put` to fail with `database is locked` (via slow-hello → takeover churn → multi-daemon contention). Reclaim is daemon-owned since we61e; the client-facing RPC for `aspect_queue.reclaim_stale` is now a cheap no-op returning 0 (the daemon's own loop still reclaims). One-shot WARNING surfaces stale workers for operators.

## Review
Stacked review complete (code-review-expert APPROVED 0 Critical; substantive-critic 0 Critical, 1 Significant on observability — remediated: warn-once). T2: `gff3g`-style verdict in `xmohw-reclaim-stale-rpc-noop-review-2026-06-05`.

## Scope note
Removes the demonstrated RPC-flood cause of the T2-write-failure cascade. A separate residual lone-daemon CPU burst (startup backlog-drain + migration, can't settle while churn continues) is being observed post-deploy; not in scope here.

Refs nexus-xmohw, nexus-x47yx, nexus-we61e