### PR TITLE
fix(hooks): StopFailure hook stops filing P1 bugs for transient API failures

### DIFF
--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **StopFailure hook no longer files issues for transient API failures.** The
+  hook previously ran `bd create --type=bug --priority=1` on every `rate_limit`
+  stop, dropping P1 bugs into the `bd ready` queue as if they were actionable
+  work (32 such beads had accumulated). Rate limits, server errors, and auth
+  failures are infra events, not bugs. The hook now records the crash via
+  `bd remember` only (unchanged observability log); it never files an issue.
+
 ## [5.10.3] - 2026-06-05
 
 Plugin version aligned with conexus 5.10.3 (T2 daemon reliability fix: a

--- a/conexus/hooks/scripts/stop_failure_hook.py
+++ b/conexus/hooks/scripts/stop_failure_hook.py
@@ -2,7 +2,9 @@
 """StopFailure hook — log API failure context to beads memory for observability.
 
 Output and exit codes are ignored by Claude Code. This script exists purely
-for side effects: bd remember (all failures) and bd create (rate_limit only).
+for one side effect: bd remember (all failures), a crash/abnormal-termination
+log for observability. It does NOT file issues — transient API failures are
+infra events, not actionable bugs, and filing them pollutes the ready queue.
 """
 from __future__ import annotations
 
@@ -84,21 +86,15 @@ def main() -> None:
         _debug("bd not on PATH, skipping")
         return
 
-    # Log failure to beads memory
+    # Log failure to beads memory for observability. This is the only side
+    # effect: a crash/abnormal-termination record. We intentionally do NOT
+    # create an issue (`bd create`) here — transient API failures (rate limit,
+    # server error, auth) are infra events, not actionable bugs, and filing
+    # them as P1 issues pollutes `bd ready` with non-work that masquerades as
+    # the next thing to do. The remember-log is sufficient for tracking.
     summary = f"stop-failure-{error_type}: {error_details[:200]} at {timestamp}"
     _run(["bd", "remember", summary])
     _debug(f"logged: {summary}")
-
-    # Rate limit: create a blocker bead so next session sees it
-    if error_type == "rate_limit":
-        _run([
-            "bd", "create",
-            f"--title=Rate limit hit at {timestamp}",
-            "--type=bug",
-            "--priority=1",
-            f"--description=API rate limit triggered. Details: {error_details[:200]}",
-        ])
-        _debug("created rate-limit blocker bead")
 
 
 if __name__ == "__main__":

--- a/tests/hooks/test_stop_failure_hook.py
+++ b/tests/hooks/test_stop_failure_hook.py
@@ -126,3 +126,33 @@ class TestStopFailureHook:
         )
         assert result.returncode == 0
         assert "skipping side effects" in result.stderr.lower()
+
+    def test_rate_limit_remembers_but_never_creates_bead(self, tmp_path: Path) -> None:
+        """Side-effect contract: log via `bd remember`, but never `bd create`.
+
+        Transient API failures are infra events, not actionable bugs. Filing
+        them as P1 issues pollutes `bd ready`. This pins that we record the
+        crash (remember) without ever filing an issue (create).
+        """
+        # Fake `bd` on PATH that appends its subcommand to a log file.
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        log = tmp_path / "bd_calls.log"
+        bd = fake_bin / "bd"
+        bd.write_text(
+            "#!/bin/sh\n"
+            f'echo "$1" >> "{log}"\n'
+            "exit 0\n"
+        )
+        bd.chmod(0o755)
+        result = _run_hook(
+            _make_payload("rate_limit"),
+            env_overrides={
+                "CLAUDECODE": "1",
+                "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
+            },
+        )
+        assert result.returncode == 0
+        calls = log.read_text().split() if log.exists() else []
+        assert "remember" in calls, f"expected a bd remember call, got {calls}"
+        assert "create" not in calls, f"hook must not file issues, got {calls}"


### PR DESCRIPTION
## Problem
The StopFailure hook ran `bd create --type=bug --priority=1` on every `rate_limit` stop, dropping P1 bugs into `bd ready` as if they were actionable work. 32 such beads had accumulated and were GC'd 2026-06-06. Rate limits, server errors, and auth failures are transient infra events, not bugs.

## Fix
Hook now records the crash via `bd remember` only (unchanged observability log); it never files an issue. Module docstring + CHANGELOG updated.

## Test
New regression test `test_rate_limit_remembers_but_never_creates_bead` stubs `bd` on PATH and asserts `remember` fires while `create` never does. Full hook suite green (17 passed).

Closes #nexus-0kwkq