### PR TITLE
RDR-151: serialize all T2 daemon writes — root-cause fix for the write-burst CPU peg (nexus-xmohw)

### DIFF
--- a/docs/rdr/rdr-151-daemon-event-loop-selector-spin-write-contention.md
+++ b/docs/rdr/rdr-151-daemon-event-loop-selector-spin-write-contention.md
@@ -318,6 +318,26 @@ asserting no executor thread is wedged in the SQLite busy handler.
 > within ~5 s. T2-only by construction (the T3 daemon is a synchronous subprocess
 > supervisor with no asyncio loop). Tests: `tests/daemon/test_spin_guard.py`.
 
+> **ROOT-CAUSE FIX (2026-06-06, `nexus-xmohw`, GH #1137).** The spin guard is the
+> backstop; this is the cause. GH #1137 reproduced the peg under a `memory.delete`
+> write burst and identified two co-occurring mechanisms: a selector spin (guard
+> handles) and **intra-daemon WAL write contention** — un-serialised `memory.*`
+> writes plus the daemon's own 30 s reclaim loop each launched parallel
+> `to_thread` writers racing the one SQLite writer lock → `SQLITE_BUSY` → tight
+> retry → spin. 2.1a serialised only `catalog_write.*`/`taxonomy.*`; this makes the
+> daemon a genuine **single serialised writer** (RDR-129 B3 / Datasette
+> write-queue): `_WRITE_OPS` + the reclaim loop all serialise through one write
+> lock, so there is never a second intra-daemon writer → no `SQLITE_BUSY` from
+> self-contention. Reads stay concurrent (esp. `database.hello`, to avoid the
+> slow-hello → ensure-running-stale → takeover-churn cascade). Lock-hold is bounded
+> to one write attempt (backoff happens outside the lock). A coverage forcing-test
+> (`test_rdr151_xmohw_write_serialization.py::test_write_op_coverage`) fails if any
+> mutating dispatch op is left un-serialised — closing the silent-recurrence gap.
+> **Deferred (coupled, tracked):** 2.1b `BEGIN IMMEDIATE` + 2.1c fast-fail
+> `busy_timeout` for the cross-process/version-skew double-writer case — they must
+> land together (BEGIN IMMEDIATE alone, with the 30 s busy_timeout, would create a
+> long head-of-line lock-hold; 2.1c bounds it).
+
 ### Phase 3 design (2026-06-06, nexus-uzay8)
 
 Full design: T2 `nexus/rdr151-phase3-design-2026-06-06`.

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -100,7 +100,7 @@ _GRACEFUL_PEER_EXIT_WAIT: float = 3.0
 # contention, so this only fires when a window exceeds the timeout; it turns a
 # >30s contention spike into a wait rather than a dropped best-effort write.
 # Module constant so tests can shrink the sleeps.
-_DISPATCH_RETRY_SLEEPS: tuple[float, ...] = (0.1, 0.25)
+_DISPATCH_RETRY_SLEEPS: tuple[float, ...] = (0.05, 0.1, 0.2, 0.4, 0.8)
 
 # RDR-146 P2 (nexus-5p2ci.12): interactive-vs-batch catalog-write fairness.
 # An interactive-priority catalog write opens an in-memory deadline window;
@@ -667,6 +667,56 @@ _CATALOG_WRITE_PREFIX = "catalog_write."
 #: cannot silently bypass serialisation. ``str.startswith`` accepts this tuple.
 _WRITE_SERIALIZED_PREFIXES: tuple[str, ...] = (_CATALOG_WRITE_PREFIX, "taxonomy.")
 
+#: RDR-151 nexus-xmohw: every mutating dispatch op must serialise through the
+#: daemon's single write lock. The peg root cause (issue #1137) is intra-daemon
+#: WAL write contention: a burst of un-serialised ``memory.*`` writes plus the
+#: internal reclaim loop each launch parallel ``to_thread`` writers racing the
+#: one SQLite writer lock → SQLITE_BUSY → tight retry → selector spin / 100% CPU.
+#: 2.1a serialised only ``catalog_write.*`` + ``taxonomy.*``; this extends it to
+#: ALL writers so the daemon is a genuine single serialised writer (RDR-129 B3 /
+#: Datasette write-queue model): one write at a time, no intra-daemon contention,
+#: no busy-spin. READS are intentionally NOT here — WAL allows concurrent readers,
+#: and serialising reads (esp. ``database.hello``) behind writes would re-create
+#: the slow-hello → ensure-running-declares-stale → takeover-churn cascade.
+#:
+#: ``tests/daemon/test_rdr151_xmohw_write_serialization.py::test_write_op_coverage``
+#: is the forcing function: it verb-matches every dispatchable store method and
+#: fails if a mutating op is not serialised here — closing the silent-recurrence
+#: gap (a future writer added without serialisation).
+_WRITE_OPS: frozenset[str] = frozenset({
+    # memory store
+    "memory.put", "memory.delete", "memory.expire", "memory.merge_memories",
+    "memory.put_or_merge", "memory.flag_stale_memories",
+    # plan library
+    "plans.save_plan", "plans.delete_plan", "plans.set_plan_disabled",
+    "plans.set_plan_enabled", "plans.set_scope_tags",
+    "plans.increment_match_metrics", "plans.increment_run_started",
+    "plans.increment_run_outcome",
+    # chash index
+    "chash_index.upsert", "chash_index.upsert_many",
+    "chash_index.delete_collection", "chash_index.delete_stale",
+    "chash_index.rename_collection",
+    # telemetry
+    "telemetry.log_relevance", "telemetry.log_relevance_batch",
+    "telemetry.expire_relevance_log", "telemetry.log_search_batch",
+    "telemetry.trim_search_telemetry", "telemetry.rename_collection",
+    # document aspects (upsert/get are RPC-denied; these are the dispatchable writes)
+    "document_aspects.set_salient_sentences",
+    "document_aspects.set_salient_sentences_by_key",
+    "document_aspects.delete", "document_aspects.delete_orphans",
+    "document_aspects.rename_collection",
+    # aspect extraction queue
+    "aspect_queue.enqueue", "aspect_queue.claim_next", "aspect_queue.claim_batch",
+    "aspect_queue.mark_done", "aspect_queue.mark_failed", "aspect_queue.mark_retry",
+    "aspect_queue.reclaim_stale", "aspect_queue.rename_collection",
+    # T2Database top-level write methods (dispatched as ``database.*``)
+    "database.rename_collection_cascade", "database.expire",
+    "database.complete_aspect",
+    # catalog read-store commit (flushes pending writes); catalog mutations
+    # proper go through the catalog_write.* prefix.
+    "catalog.commit",
+})
+
 
 def _build_dispatch_table(t2db: Any) -> dict[str, Any]:
     """Build the ``{op: bound_callable}`` dispatch table from *t2db*.
@@ -1145,10 +1195,7 @@ class T2Daemon:
             t2db = self._t2db
             if t2db is not None:
                 try:
-                    reclaimed = await asyncio.to_thread(
-                        t2db.aspect_queue.reclaim_stale,
-                        _ASPECT_RECLAIM_STALE_TIMEOUT_S,
-                    )
+                    reclaimed = await self._reclaim_stale_once(t2db)
                     if reclaimed:
                         _log.info(
                             "t2_daemon_aspect_reclaim", reclaimed=reclaimed
@@ -1161,6 +1208,24 @@ class T2Daemon:
                         "t2_daemon_aspect_reclaim_failed", exc=str(exc)
                     )
             await asyncio.sleep(_ASPECT_RECLAIM_INTERVAL)
+
+    async def _reclaim_stale_once(self, t2db: Any) -> int:
+        """Run one aspect-queue stale-reclaim pass — RDR-151 nexus-xmohw: the
+        daemon's OWN reclaim writer serialises through the SAME write lock as
+        serve-path writes (issue #1137 mechanism 2: the 30s reclaim loop raced a
+        ``memory.delete`` burst on the WAL writer lock → SQLITE_BUSY → retry
+        spin). Under the lock there is one writer at a time, so no contention.
+        The lock is created in ``start()``; the pre-start window falls back to a
+        direct write (no other writer exists yet)."""
+        lock = self._catalog_write_lock
+        if lock is not None:
+            async with lock:
+                return await asyncio.to_thread(
+                    t2db.aspect_queue.reclaim_stale, _ASPECT_RECLAIM_STALE_TIMEOUT_S
+                )
+        return await asyncio.to_thread(
+            t2db.aspect_queue.reclaim_stale, _ASPECT_RECLAIM_STALE_TIMEOUT_S
+        )
 
     async def run_until_signal(self) -> None:
         """Block until SIGTERM/SIGINT arrives."""
@@ -1510,15 +1575,43 @@ class T2Daemon:
         # prefix is serialised (not an enumerated write-op set) so a future
         # taxonomy writer is covered by default — a missed writer is exactly the
         # silent-recurrence class this fix closes. Taxonomy reads serialising
-        # behind a write is acceptable: they are not a hot daemon read path, and
-        # P2.1b/P2.1c keep write hold-time short.
+        # behind a write is acceptable: they are not a hot daemon read path.
+        # Lock hold-time is bounded to one write attempt (backoff happens outside
+        # the lock in _invoke_serialized_with_retry).
         if (
-            op.startswith(_WRITE_SERIALIZED_PREFIXES)
+            (op in _WRITE_OPS or op.startswith(_WRITE_SERIALIZED_PREFIXES))
             and self._catalog_write_lock is not None
         ):
-            async with self._catalog_write_lock:
-                return await self._invoke_with_lock_retry(callable_, op, args, kwargs)
+            return await self._invoke_serialized_with_retry(
+                callable_, op, args, kwargs
+            )
         return await self._invoke_with_lock_retry(callable_, op, args, kwargs)
+
+    async def _invoke_serialized_with_retry(
+        self, callable_: Any, op: str, args: list[Any], kwargs: dict[str, Any],
+    ) -> Any:
+        """Serialised write path (RDR-151 nexus-xmohw): hold the daemon write
+        lock for ONE write attempt, then release it BEFORE the backoff sleep, so
+        a write waiting on a cross-process writer never blocks the daemon's other
+        writes for the whole retry budget (critic C2 head-of-line bound). Intra-
+        daemon contention is gone by construction (one writer at a time); the
+        retry only fires against an out-of-daemon writer."""
+        lock = self._catalog_write_lock
+        assert lock is not None  # caller checked
+        sleeps = _DISPATCH_RETRY_SLEEPS
+        max_attempts = len(sleeps) + 1
+        for attempt in range(1, max_attempts + 1):
+            async with lock:
+                try:
+                    return await asyncio.to_thread(callable_, *args, **kwargs)
+                except sqlite3.OperationalError as exc:
+                    if not _is_locked_error(exc) or attempt == max_attempts:
+                        raise
+                    _log.warning(
+                        "t2_daemon_dispatch_lock_retry",
+                        op=op, attempt=attempt, exc=str(exc),
+                    )
+            await asyncio.sleep(sleeps[attempt - 1])  # backoff OUTSIDE the lock
 
     async def _invoke_with_lock_retry(
         self, callable_: Any, op: str, args: list[Any], kwargs: dict[str, Any],

--- a/tests/daemon/test_rdr151_xmohw_write_serialization.py
+++ b/tests/daemon/test_rdr151_xmohw_write_serialization.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-151 nexus-xmohw (issue #1137): ALL daemon writes serialise through the
+single write lock, so the T2 daemon is a genuine single serialised writer and
+cannot self-contend into a SQLITE_BUSY retry spin / 100% CPU peg.
+
+2.1a serialised only ``catalog_write.*`` + ``taxonomy.*``. #1137 showed a
+``memory.delete`` burst plus the daemon's own 30s reclaim loop racing the WAL
+writer lock — both un-serialised. These tests assert (1) memory writes now
+serialise, (2) the reclaim writer serialises against serve-path writes, and
+(3) a coverage forcing-function so no future mutating op silently bypasses.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+import threading
+import time
+from pathlib import Path
+from tempfile import mkdtemp
+
+
+async def _max_overlap_for_op(op: str) -> int:
+    """Drive two concurrent dispatches of *op* with a slow threaded body and
+    return the max observed overlap (2 = concurrent/un-serialised, 1 = serial)."""
+    from nexus.daemon.t2_daemon import T2Daemon
+
+    cfgdir = Path(mkdtemp(prefix="xmohw-"))
+    (cfgdir / "sockets").mkdir(exist_ok=True)
+    daemon = T2Daemon(config_dir=cfgdir, db_path=cfgdir / "memory.db")
+    await daemon.start()
+
+    state = {"cur": 0, "max": 0}
+    lock = threading.Lock()
+
+    def _slow_write(*_a, **_k) -> int:
+        with lock:
+            state["cur"] += 1
+            state["max"] = max(state["max"], state["cur"])
+        time.sleep(0.15)
+        with lock:
+            state["cur"] -= 1
+        return 0
+
+    daemon._dispatch_table[op] = _slow_write  # type: ignore[index]
+    frame = {"op": op, "args": [], "kwargs": {}, "request_id": 1}
+    try:
+        await asyncio.gather(
+            daemon._dispatch(dict(frame), is_uds=True),
+            daemon._dispatch(dict(frame), is_uds=True),
+        )
+    finally:
+        try:
+            await asyncio.wait_for(daemon.stop(), timeout=10.0)
+        except Exception:  # noqa: BLE001
+            pass
+    return state["max"]
+
+
+def test_memory_delete_is_serialized() -> None:
+    """#1137 trigger: a burst of memory.delete must serialise (overlap 1)."""
+    assert asyncio.run(_max_overlap_for_op("memory.delete")) == 1
+
+
+def test_memory_put_is_serialized() -> None:
+    assert asyncio.run(_max_overlap_for_op("memory.put")) == 1
+
+
+def test_reclaim_serializes_against_serve_write() -> None:
+    """#1137 mechanism 2: the internal reclaim writer must not run concurrently
+    with a serve-path write — both hold the single write lock."""
+    from nexus.daemon.t2_daemon import T2Daemon
+
+    async def _drive() -> int:
+        cfgdir = Path(mkdtemp(prefix="xmohw-rec-"))
+        (cfgdir / "sockets").mkdir(exist_ok=True)
+        daemon = T2Daemon(config_dir=cfgdir, db_path=cfgdir / "memory.db")
+        await daemon.start()
+
+        state = {"cur": 0, "max": 0}
+        guard = threading.Lock()
+
+        def _bump_hold_drop() -> int:
+            with guard:
+                state["cur"] += 1
+                state["max"] = max(state["max"], state["cur"])
+            time.sleep(0.15)
+            with guard:
+                state["cur"] -= 1
+            return 0
+
+        # A serve-path write (serialised) ...
+        daemon._dispatch_table["memory.put"] = _bump_hold_drop  # type: ignore[index]
+        # ... and the reclaim writer pointed at the same instrumented body.
+        fake_t2 = type("T", (), {"aspect_queue": type("Q", (), {
+            "reclaim_stale": staticmethod(lambda _t: _bump_hold_drop()),
+        })()})()
+        frame = {"op": "memory.put", "args": [], "kwargs": {}, "request_id": 1}
+        try:
+            await asyncio.gather(
+                daemon._dispatch(dict(frame), is_uds=True),
+                daemon._reclaim_stale_once(fake_t2),
+            )
+        finally:
+            try:
+                await asyncio.wait_for(daemon.stop(), timeout=10.0)
+            except Exception:  # noqa: BLE001
+                pass
+        return state["max"]
+
+    assert asyncio.run(_drive()) == 1, "reclaim must not overlap a serve write"
+
+
+def test_write_op_coverage() -> None:
+    """Forcing function (silent-recurrence guard): every dispatchable mutating
+    store method MUST be serialised — present in _WRITE_OPS or matched by a
+    serialised prefix. A future writer added without serialisation fails here."""
+    from nexus.db.t2 import T2Database
+    from nexus.daemon.t2_daemon import (
+        _RPC_DENY_OPS,
+        _T2_STORE_ATTRS,
+        _WRITE_OPS,
+        _WRITE_SERIALIZED_PREFIXES,
+        _build_dispatch_table,
+    )
+
+    write_verb = re.compile(
+        r"^(put|delete|merge|update|insert|upsert|claim|complete|mark|enqueue|"
+        r"dequeue|set_|clear|prune|purge|flag|promote|reclaim|save|store|persist|"
+        r"increment|add_|expire|trim|log_|rename|rebuild|assign|commit|vacuum|"
+        r"archive|sweep|drop|apply|write|record|remove|migrate|backfill)"
+    )
+
+    cfgdir = Path(mkdtemp(prefix="xmohw-cov-"))
+    with T2Database(cfgdir / "memory.db", run_migrations=True) as db:
+        table = _build_dispatch_table(db)
+        missing: list[str] = []
+        for store_name in _T2_STORE_ATTRS:
+            store = getattr(db, store_name, None)
+            if store is None:
+                continue
+            for attr in dir(store):
+                if attr.startswith("_"):
+                    continue
+                op = f"{store_name}.{attr}"
+                if op in _RPC_DENY_OPS or op not in table:
+                    continue  # not dispatchable
+                if not callable(getattr(store, attr)):
+                    continue
+                if not write_verb.match(attr):
+                    continue  # not a mutating verb
+                serialized = (
+                    op in _WRITE_OPS or op.startswith(_WRITE_SERIALIZED_PREFIXES)
+                )
+                if not serialized:
+                    missing.append(op)
+
+    assert not missing, (
+        "mutating dispatch ops not serialised (add to _WRITE_OPS): "
+        + ", ".join(sorted(missing))
+    )
+
+
+def test_write_ops_have_no_stale_entries() -> None:
+    """Every _WRITE_OPS entry must name a real dispatchable op (no typos / drift)."""
+    from nexus.db.t2 import T2Database
+    from nexus.daemon.t2_daemon import _WRITE_OPS, _build_dispatch_table
+
+    cfgdir = Path(mkdtemp(prefix="xmohw-stale-"))
+    with T2Database(cfgdir / "memory.db", run_migrations=True) as db:
+        table = _build_dispatch_table(db)
+        # database.* methods are added under the pseudo-store; include them.
+        valid = set(table)
+        stale = [op for op in _WRITE_OPS if op not in valid]
+    assert not stale, f"_WRITE_OPS names non-dispatchable ops: {stale}"


### PR DESCRIPTION
Root-cause fix for GH #1137 (pairs with the merged spin-guard backstop #1135).

GH #1137 reproduced the ~100% CPU peg under a `memory.delete` write burst: two co-occurring mechanisms — a selector spin (the `nexus-u2vmv` guard backstops it) and **intra-daemon WAL write contention**. Un-serialised `memory.*` writes plus the daemon's own 30s reclaim loop each launched parallel `to_thread` writers racing the one SQLite writer lock → SQLITE_BUSY → tight retry → spin.

2.1a serialised only `catalog_write.*`/`taxonomy.*`. This makes the daemon a genuine **single serialised writer** (RDR-129 B3 / Datasette write-queue):
- `_WRITE_OPS` serialises every mutating dispatch op through the one write lock; reads stay concurrent (`database.hello` deliberately NOT serialised — avoids the slow-hello → ensure-running-stale → takeover-churn cascade).
- `_reclaim_stale_once`: the daemon's own reclaim writer acquires the same lock (#1137 mechanism 2).
- `_invoke_serialized_with_retry`: backoff happens **outside** the lock → lock-hold bounded to one write attempt (no head-of-line blocking).
- A coverage forcing-test fails if any mutating op is left un-serialised (silent-recurrence guard) + a no-stale-entries test guards `_WRITE_OPS` drift.

Reviewed by code-review-expert + substantive-critic; both criticals remediated (`catalog.commit` coverage gap; HOL lock-hold amplification). Coupled follow-on (BEGIN IMMEDIATE 2.1b + fast-fail busy_timeout 2.1c, for the cross-process double-writer case) filed as a separate bead — they must land together. Full unit suite green (9099 passed).

nexus-xmohw