### PR TITLE
release: conexus 5.10.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.10.3"
+        "ref": "v5.10.5"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.10.3"
+      "version": "5.10.5"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.10.3"
+        "ref": "v5.10.5"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.10.3"
+      "version": "5.10.5"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.10.5] - 2026-06-06
+
+RDR-151 daemon CPU-peg hardening: a cause-agnostic spin backstop plus the
+write-contention root-cause fix.
+
+### Fixed
+
+- **T2 daemon can no longer spin at ~100% CPU (RDR-151, nexus-u2vmv) — backstop.**
+  A cause-agnostic event-loop spin guard (`spin_guard.py`): a `SpinGuardSelector`
+  counts immediate ready-returns by wall-time and a `SpinWatchdog` daemon thread,
+  on a sustained spin, auto-captures the selector map + `loop._ready` + thread
+  stacks and self-heals (SIGTERM → graceful stop; `os._exit` fallback → clean
+  respawn), bounded so a persistent trigger disarms to pegged-but-serving (never
+  worse than baseline). Validated against the live postmortem signature.
+- **T2 daemon write-burst CPU peg root-caused (RDR-151, nexus-xmohw, GH #1137).**
+  The daemon is now a single serialised writer: every mutating dispatch op AND the
+  internal aspect-reclaim loop serialise through one write lock, so a `memory.*`
+  write burst plus the reclaim loop can no longer race the SQLite writer lock into
+  a `SQLITE_BUSY` retry spin. Reads stay concurrent (`database.hello` is never
+  serialised — avoids the slow-hello → ensure-running-stale → takeover cascade);
+  lock-hold is bounded to one write attempt (backoff happens outside the lock). A
+  coverage forcing-test fails CI if any mutating op is left un-serialised.
+- **Stop hook no longer files P1 bug beads for transient API failures (#1136).**
+
+## [5.10.4] - 2026-06-06
+
+RDR-151 root-cause fix for the recurring T2 daemon 100% CPU peg, plus a T1 scratch
+recovery fix.
+
+### Fixed
+
+- **T2 daemon CPU peg root-caused and fixed (RDR-151, nexus-uzay8 / nexus-xmohw).**
+  The peg was contention-driven write starvation: `taxonomy.*` write RPCs bypassed
+  the daemon's `_catalog_write_lock`, and `nx index` opened its own direct T2 write
+  connection, so multiple writers raced the single SQLite WAL writer lock while the
+  daemon's executor thread wedged on it. Two fixes: (1) `taxonomy.*` writes now
+  serialize through the daemon's catalog write lock; (2) every direct T2 taxonomy
+  write on the `nx index` path and the `nx taxonomy` CLI now routes through the
+  daemon (compute client-side where ChromaDB is needed, persist daemon-routed),
+  leaving only read-only direct connections (WAL readers don't take the writer
+  lock). A `storage_boundary_lint` enforce-flip fails CI on any taxonomy write
+  method called on a directly-constructed handle outside `db/`+`daemon/`.
+- **T1 scratch restored when the session id diverges from the MCP lease key
+  (nexus-gff3g).** T1 working memory is now matched by Claude-ancestor pid with a
+  deterministic tie-break, so sibling agents recover the correct scratch when the
+  session id and lease key differ.
+- Daemon lifecycle/teardown hardening: idle read deadline on accepted connections,
+  `mark_shutting_down()` first in `stop()` (T2 + T3), `to_thread(heartbeat_tick)`
+  so the flock never blocks the event loop, and reaper `endpoint.pid` fallback.
+
+### Changed
+
+- RDR-147 (multi-hop entity-resolution retrieval) accepted.
+
 ## [5.10.3] - 2026-06-05
 
 T2 daemon reliability fix.

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.10.3",
+  "version": "5.10.5",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.10.5] - 2026-06-06
+
+Plugin version aligned with conexus 5.10.5 (RDR-151 daemon CPU-peg hardening:
+cause-agnostic spin backstop + write-serialization root-cause fix).
+
 ### Changed
 
 - **StopFailure hook no longer files issues for transient API failures.** The
@@ -14,6 +19,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   work (32 such beads had accumulated). Rate limits, server errors, and auth
   failures are infra events, not bugs. The hook now records the crash via
   `bd remember` only (unchanged observability log); it never files an issue.
+
+## [5.10.4] - 2026-06-06
+
+Plugin version aligned with conexus 5.10.4. No plugin-side changes; the release
+is the RDR-151 root-cause fix for the T2 daemon CPU peg (taxonomy writes now route
+through the daemon) plus a T1 scratch recovery fix (nexus-gff3g).
 
 ## [5.10.3] - 2026-06-05
 

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **StopFailure hook no longer files issues for transient API failures.** The
+  hook previously ran `bd create --type=bug --priority=1` on every `rate_limit`
+  stop, dropping P1 bugs into the `bd ready` queue as if they were actionable
+  work (32 such beads had accumulated). Rate limits, server errors, and auth
+  failures are infra events, not bugs. The hook now records the crash via
+  `bd remember` only (unchanged observability log); it never files an issue.
+
 ## [5.10.3] - 2026-06-05
 
 Plugin version aligned with conexus 5.10.3 (T2 daemon reliability fix: a

--- a/conexus/hooks/scripts/stop_failure_hook.py
+++ b/conexus/hooks/scripts/stop_failure_hook.py
@@ -2,7 +2,9 @@
 """StopFailure hook — log API failure context to beads memory for observability.
 
 Output and exit codes are ignored by Claude Code. This script exists purely
-for side effects: bd remember (all failures) and bd create (rate_limit only).
+for one side effect: bd remember (all failures), a crash/abnormal-termination
+log for observability. It does NOT file issues — transient API failures are
+infra events, not actionable bugs, and filing them pollutes the ready queue.
 """
 from __future__ import annotations
 
@@ -84,21 +86,15 @@ def main() -> None:
         _debug("bd not on PATH, skipping")
         return
 
-    # Log failure to beads memory
+    # Log failure to beads memory for observability. This is the only side
+    # effect: a crash/abnormal-termination record. We intentionally do NOT
+    # create an issue (`bd create`) here — transient API failures (rate limit,
+    # server error, auth) are infra events, not actionable bugs, and filing
+    # them as P1 issues pollutes `bd ready` with non-work that masquerades as
+    # the next thing to do. The remember-log is sufficient for tracking.
     summary = f"stop-failure-{error_type}: {error_details[:200]} at {timestamp}"
     _run(["bd", "remember", summary])
     _debug(f"logged: {summary}")
-
-    # Rate limit: create a blocker bead so next session sees it
-    if error_type == "rate_limit":
-        _run([
-            "bd", "create",
-            f"--title=Rate limit hit at {timestamp}",
-            "--type=bug",
-            "--priority=1",
-            f"--description=API rate limit triggered. Details: {error_details[:200]}",
-        ])
-        _debug("created rate-limit blocker bead")
 
 
 if __name__ == "__main__":

--- a/docs/postmortem/2026-06-06-daemon-5104-idle-peg-sample.txt
+++ b/docs/postmortem/2026-06-06-daemon-5104-idle-peg-sample.txt
@@ -1,0 +1,1782 @@
+Analysis of sampling python3 (pid 62704) every 1 millisecond
+Process:         python3.12 [62704]
+Path:            /Users/USER/*/python3.12
+Load Address:    0x104168000
+Identifier:      python3.12
+Version:         ???
+Code Type:       ARM64
+Platform:        macOS
+Parent Process:  launchd [1]
+Target Type:     live task
+
+Date/Time:       2026-06-06 09:31:10.444 -0700
+Launch Time:     2026-06-06 09:28:05.170 -0700
+OS Version:      macOS 26.4.1 (25E253)
+Report Version:  7
+Analysis Tool:   /usr/bin/sample
+
+Physical footprint:         164.0M
+Physical footprint (peak):  164.0M
+Idle exit:                  untracked
+----
+
+Call graph:
+    3839 Thread_79463477   DispatchQueue_1: com.apple.main-thread  (serial)
+    + 3839 start  (in dyld) + 6992  [0x189ea7da4]
+    +   3839 Py_BytesMain  (in libpython3.12.dylib) + 36  [0x105a46318]
+    +     3839 pymain_main  (in libpython3.12.dylib) + 456  [0x105a464ec]
+    +       3839 Py_RunMain  (in libpython3.12.dylib) + 716  [0x105a7636c]
+    +         3839 pymain_run_file  (in libpython3.12.dylib) + 72  [0x105ad1b90]
+    +           3839 pymain_run_file_obj  (in libpython3.12.dylib) + 164  [0x105ad1cd4]
+    +             3839 _PyRun_AnyFileObject  (in libpython3.12.dylib) + 80  [0x105ad1efc]
+    +               3839 _PyRun_SimpleFileObject  (in libpython3.12.dylib) + 268  [0x105ad2124]
+    +                 3839 pyrun_file  (in libpython3.12.dylib) + 156  [0x105ad24fc]
+    +                   3839 run_mod.llvm.1901145599790430720  (in libpython3.12.dylib) + 284  [0x1059d1bec]
+    +                     3839 PyEval_EvalCode  (in libpython3.12.dylib) + 220  [0x1059d1d98]
+    +                       3839 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 177896  [0x105932b80]
+    +                         3839 slot_tp_call  (in libpython3.12.dylib) + 116  [0x105944768]
+    +                           3839 _PyObject_Call_Prepend  (in libpython3.12.dylib) + 152  [0x105944cc0]
+    +                             3839 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 192132  [0x10593631c]
+    +                               3839 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+    +                                 3839 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 194176  [0x105936b18]
+    +                                   3839 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 292  [0x105b21c6c]
+    +                                     3822 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +                                     ! 3822 select_kqueue_control_impl  (in libpython3.12.dylib) + 456  [0x10626d610]
+    +                                     !   3822 kevent  (in libsystem_kernel.dylib) + 8  [0x18a225fc4]
+    +                                     8 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 192132  [0x10593631c]
+    +                                     ! 8 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+    +                                     !   8 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+    +                                     !     7 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+    +                                     !     : 5 cfunction_vectorcall_O.llvm.5662885461150521209  (in libpython3.12.dylib) + 108  [0x105a39c40]
+    +                                     !     : | 5 task_wakeup  (in libpython3.12.dylib) + 236  [0x106209af4]
+    +                                     !     : |   5 task_step  (in libpython3.12.dylib) + 60  [0x1062087e4]
+    +                                     !     : |     5 task_step_impl  (in libpython3.12.dylib) + 444  [0x106208a18]
+    +                                     !     : |       5 gen_send_ex2  (in libpython3.12.dylib) + 188  [0x1059b5d70]
+    +                                     !     : |         3 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 5320,65492,...  [0x105908960,0x10591746c,...]
+    +                                     !     : |         1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 3820  [0x105908384]
+    +                                     !     : |         + 1 gc_collect_main.llvm.3171393176106260942  (in libpython3.12.dylib) + 300  [0x1058f87b4]
+    +                                     !     : |         +   1 deduce_unreachable  (in libpython3.12.dylib) + 352  [0x1058f9a38]
+    +                                     !     : |         +     1 gc_traverse  (in libpython3.12.dylib) + 0  [0x1061df688]
+    +                                     !     : |         1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 192132  [0x10593631c]
+    +                                     !     : |           1 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 172  [0x105b21bf4]
+    +                                     !     : |             1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 65504  [0x105917478]
+    +                                     !     : 1 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 172  [0x105b21bf4]
+    +                                     !     : | 1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 192132  [0x10593631c]
+    +                                     !     : |   1 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 172  [0x105b21bf4]
+    +                                     !     : |     1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +                                     !     : |       1 select_kqueue_control_impl  (in libpython3.12.dylib) + 456  [0x10626d610]
+    +                                     !     : |         1 kevent  (in libsystem_kernel.dylib) + 8  [0x18a225fc4]
+    +                                     !     : 1 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+    +                                     !     :   1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 177044  [0x10593282c]
+    +                                     !     :     1 method_vectorcall_VARARGS.llvm.3960725272945190732  (in libpython3.12.dylib) + 376  [0x105b25370]
+    +                                     !     :       1 sock_recv  (in libpython3.12.dylib) + 108  [0x106238338]
+    +                                     !     :         1 sock_recv_guts  (in libpython3.12.dylib) + 56  [0x10623a118]
+    +                                     !     :           1 sock_call_ex  (in libpython3.12.dylib) + 192  [0x1062396bc]
+    +                                     !     :             1 sock_recv_impl  (in libpython3.12.dylib) + 36  [0x10623a160]
+    +                                     !     :               1 __recvfrom  (in libsystem_kernel.dylib) + 8  [0x18a2243bc]
+    +                                     !     1 _PyObject_MakeTpCall  (in libpython3.12.dylib) + 364  [0x1058953c4]
+    +                                     !       1 task_step  (in libpython3.12.dylib) + 60  [0x1062087e4]
+    +                                     !         1 task_step_impl  (in libpython3.12.dylib) + 444  [0x106208a18]
+    +                                     !           1 gen_send_ex2  (in libpython3.12.dylib) + 188  [0x1059b5d70]
+    +                                     !             1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 177896  [0x105932b80]
+    +                                     !               1 type_call  (in libpython3.12.dylib) + 148  [0x105b3fc2c]
+    +                                     !                 1 slot_tp_init  (in libpython3.12.dylib) + 276  [0x105b41e08]
+    +                                     !                   1 _PyFunction_Vectorcall  (in libpython3.12.dylib) + 192  [0x105b21244]
+    +                                     2 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 5888  [0x105908b98]
+    +                                     ! 2 subtype_dealloc  (in libpython3.12.dylib) + 624  [0x105ae93c8]
+    +                                     !   2 func_dealloc  (in libpython3.12.dylib) + 136  [0x1058cf648]
+    +                                     !     2 func_clear  (in libpython3.12.dylib) + 492  [0x1058cf960]
+    +                                     !       2 tupledealloc  (in libpython3.12.dylib) + 516  [0x1061d1528]
+    +                                     !         2 cell_dealloc  (in libpython3.12.dylib) + 92  [0x1061b93b8]
+    +                                     !           1 subtype_dealloc  (in libpython3.12.dylib) + 708  [0x105ae941c]
+    +                                     !           : 1 subtype_dealloc  (in libpython3.12.dylib) + 820  [0x105ae948c]
+    +                                     !           :   1 deque_dealloc  (in libpython3.12.dylib) + 172  [0x105a2eaf0]
+    +                                     !           :     1 _PyObject_Free  (in libpython3.12.dylib) + 204  [0x1061cde28]
+    +                                     !           :       1 DYLD-STUB$$free  (in libpython3.12.dylib) + 0  [0x10628f3b4]
+    +                                     !           1 subtype_dealloc  (in libpython3.12.dylib) + 820  [0x105ae948c]
+    +                                     !             1 list_dealloc  (in libpython3.12.dylib) + 252  [0x1061c70a0]
+    +                                     2 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 182676  [0x105933e2c]
+    +                                     ! 2 _platform_memset  (in libsystem_platform.dylib) + 188,208  [0x18a26d1ac,0x18a26d1c0]
+    +                                     1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 158824  [0x10592e100]
+    +                                     ! 1 range_iter  (in libpython3.12.dylib) + 176  [0x105b39e00]
+    +                                     !   1 _PyObject_Malloc  (in libpython3.12.dylib) + 348  [0x105afad60]
+    +                                     1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 177044  [0x10593282c]
+    +                                     ! 1 cfunction_vectorcall_NOARGS.llvm.5662885461150521209  (in libpython3.12.dylib) + 0  [0x105b382e0]
+    +                                     1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 187620  [0x10593517c]
+    +                                     ! 1 heappop_internal  (in libpython3.12.dylib) + 124  [0x1059d26c0]
+    +                                     !   1 siftup  (in libpython3.12.dylib) + 152  [0x105968808]
+    +                                     !     1 PyObject_RichCompareBool  (in libpython3.12.dylib) + 148  [0x105897a88]
+    +                                     !       1 slot_tp_richcompare  (in libpython3.12.dylib) + 228  [0x105b41228]
+    +                                     !         1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 220908  [0x10593d384]
+    +                                     1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 188872  [0x105935660]
+    +                                     ! 1 deque_len  (in libpython3.12.dylib) + 0  [0x106280a20]
+    +                                     1 list_extend.llvm.10255276370259422413  (in libpython3.12.dylib) + 432  [0x105897ef8]
+    3839 Thread_79463657
+    + 3839 thread_start  (in libsystem_pthread.dylib) + 8  [0x18a25ec1c]
+    +   3839 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x18a263c58]
+    +     3839 pythread_wrapper.llvm.14749647604360532379  (in libpython3.12.dylib) + 48  [0x106201ff0]
+    +       3839 thread_run  (in libpython3.12.dylib) + 188  [0x105a6283c]
+    +         3839 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+    +           2208 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 177044  [0x10593282c]
+    +           ! 2208 method_vectorcall_FASTCALL_KEYWORDS_METHOD.llvm.3960725272945190732  (in libpython3.12.dylib) + 136  [0x1058a8714]
+    +           !   2208 _queue_SimpleQueue_get  (in libpython3.12.dylib) + 220  [0x106233a44]
+    +           !     2208 _queue_SimpleQueue_get_impl  (in libpython3.12.dylib) + 232  [0x106233d88]
+    +           !       2208 PyThread_acquire_lock_timed  (in libpython3.12.dylib) + 440  [0x1059443c4]
+    +           !         2208 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x18a264128]
+    +           !           2208 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x18a22350c]
+    +           1631 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 192132  [0x10593631c]
+    +             1628 partial_vectorcall  (in libpython3.12.dylib) + 556  [0x105a11468]
+    +             : 1628 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+    +             :   1628 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+    +             :     1628 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+    +             :       1627 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 172  [0x105b21bf4]
+    +             :       | 1627 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +             :       |   1627 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+    +             :       |     1627 _pysqlite_query_execute  (in libpython3.12.dylib) + 860  [0x10623fb34]
+    +             :       |       1627 stmt_step  (in libpython3.12.dylib) + 32  [0x10624042c]
+    +             :       |         1627 sqlite3_step  (in libpython3.12.dylib) + 104  [0x105dfa17c]
+    +             :       |           1627 sqlite3Step  (in libpython3.12.dylib) + 484  [0x105dff520]
+    +             :       |             836 sqlite3VdbeExec  (in libpython3.12.dylib) + 352,392,...  [0x105e37410,0x105e37438,...]
+    +             :       |             239 sqlite3VdbeExec  (in libpython3.12.dylib) + 27220  [0x105e3dd04]
+    +             :       |             + 197 sqlite3BtreeNext  (in libpython3.12.dylib) + 192  [0x105e44fc8]
+    +             :       |             + ! 196 moveToLeftmost  (in libpython3.12.dylib) + 196  [0x105e4f244]
+    +             :       |             + ! : 195 moveToChild  (in libpython3.12.dylib) + 200  [0x105e4c6a4]
+    +             :       |             + ! : | 181 getAndInitPage  (in libpython3.12.dylib) + 112  [0x105e4c7d8]
+    +             :       |             + ! : | + 181 sqlite3PagerGet  (in libpython3.12.dylib) + 56  [0x105dfa87c]
+    +             :       |             + ! : | +   160 getPageNormal  (in libpython3.12.dylib) + 592  [0x105e233a0]
+    +             :       |             + ! : | +   ! 151 readDbPage  (in libpython3.12.dylib) + 232  [0x105e23ad4]
+    +             :       |             + ! : | +   ! : 151 sqlite3OsRead  (in libpython3.12.dylib) + 60  [0x105e21f5c]
+    +             :       |             + ! : | +   ! :   151 unixRead  (in libpython3.12.dylib) + 260  [0x105e112a8]
+    +             :       |             + ! : | +   ! :     149 seekAndRead  (in libpython3.12.dylib) + 72  [0x105e13214]
+    +             :       |             + ! : | +   ! :     | 149 pread  (in libsystem_kernel.dylib) + 8,4  [0x18a221650,0x18a22164c]
+    +             :       |             + ! : | +   ! :     2 seekAndRead  (in libpython3.12.dylib) + 304  [0x105e132fc]
+    +             :       |             + ! : | +   ! 6 readDbPage  (in libpython3.12.dylib) + 76  [0x105e23a38]
+    +             :       |             + ! : | +   ! : 6 sqlite3WalFindFrame  (in libpython3.12.dylib) + 40  [0x105e23430]
+    +             :       |             + ! : | +   ! :   3 walFindFrame  (in libpython3.12.dylib) + 168  [0x105e1fbc0]
+    +             :       |             + ! : | +   ! :   | 3 walHashGet  (in libpython3.12.dylib) + 68,196,...  [0x105e2224c,0x105e222cc,...]
+    +             :       |             + ! : | +   ! :   3 walFindFrame  (in libpython3.12.dylib) + 220,252,...  [0x105e1fbf4,0x105e1fc14,...]
+    +             :       |             + ! : | +   ! 2 readDbPage  (in libpython3.12.dylib) + 108,236  [0x105e23a58,0x105e23ad8]
+    +             :       |             + ! : | +   ! 1 readDbPage  (in libpython3.12.dylib) + 156  [0x105e23a88]
+    +             :       |             + ! : | +   !   1 sqlite3WalReadFrame  (in libpython3.12.dylib) + 192  [0x105e23cf0]
+    +             :       |             + ! : | +   !     1 sqlite3OsRead  (in libpython3.12.dylib) + 60  [0x105e21f5c]
+    +             :       |             + ! : | +   !       1 unixRead  (in libpython3.12.dylib) + 260  [0x105e112a8]
+    +             :       |             + ! : | +   !         1 seekAndRead  (in libpython3.12.dylib) + 72  [0x105e13214]
+    +             :       |             + ! : | +   !           1 pread  (in libsystem_kernel.dylib) + 8  [0x18a221650]
+    +             :       |             + ! : | +   15 getPageNormal  (in libpython3.12.dylib) + 80  [0x105e231a0]
+    +             :       |             + ! : | +   ! 15 sqlite3PcacheFetch  (in libpython3.12.dylib) + 76  [0x105e23690]
+    +             :       |             + ! : | +   !   15 pcache1Fetch  (in libpython3.12.dylib) + 40  [0x105ee8594]
+    +             :       |             + ! : | +   !     11 pcache1FetchNoMutex  (in libpython3.12.dylib) + 240  [0x105ee8df8]
+    +             :       |             + ! : | +   !     : 11 pcache1FetchStage2  (in libpython3.12.dylib) + 324  [0x105ee8f5c]
+    +             :       |             + ! : | +   !     :   11 pcache1RemoveFromHash  (in libpython3.12.dylib) + 108,136,...  [0x105ee8c28,0x105ee8c44,...]
+    +             :       |             + ! : | +   !     4 pcache1FetchNoMutex  (in libpython3.12.dylib) + 96,100,...  [0x105ee8d68,0x105ee8d6c,...]
+    +             :       |             + ! : | +   6 getPageNormal  (in libpython3.12.dylib) + 188  [0x105e2320c]
+    +             :       |             + ! : | +     5 sqlite3PcacheFetchFinish  (in libpython3.12.dylib) + 68  [0x105e236e8]
+    +             :       |             + ! : | +     : 4 pcacheFetchFinishWithInit  (in libpython3.12.dylib) + 188  [0x105e237e8]
+    +             :       |             + ! : | +     : | 4 sqlite3PcacheFetchFinish  (in libpython3.12.dylib) + 40,120  [0x105e236cc,0x105e2371c]
+    +             :       |             + ! : | +     : 1 pcacheFetchFinishWithInit  (in libpython3.12.dylib) + 68  [0x105e23770]
+    +             :       |             + ! : | +     :   1 DYLD-STUB$$mkostemps  (in libsystem_c.dylib) + 12  [0x18a16bad4]
+    +             :       |             + ! : | +     1 sqlite3PcacheFetchFinish  (in libpython3.12.dylib) + 124  [0x105e23720]
+    +             :       |             + ! : | 12 getAndInitPage  (in libpython3.12.dylib) + 200  [0x105e4c830]
+    +             :       |             + ! : | + 9 btreeInitPage  (in libpython3.12.dylib) + 140,20,...  [0x105e2717c,0x105e27104,...]
+    +             :       |             + ! : | + 3 btreeInitPage  (in libpython3.12.dylib) + 68  [0x105e27134]
+    +             :       |             + ! : | +   3 decodeFlags  (in libpython3.12.dylib) + 676,48  [0x105e27530,0x105e272bc]
+    +             :       |             + ! : | 1 getAndInitPage  (in libpython3.12.dylib) + 192  [0x105e4c828]
+    +             :       |             + ! : | + 1 btreePageFromDbPage  (in libpython3.12.dylib) + 68  [0x105e2be1c]
+    +             :       |             + ! : | +   1 sqlite3PagerGetData  (in libpython3.12.dylib) + 0  [0x105dfa888]
+    +             :       |             + ! : | 1 getAndInitPage  (in libpython3.12.dylib) + 272  [0x105e4c878]
+    +             :       |             + ! : 1 moveToChild  (in libpython3.12.dylib) + 224  [0x105e4c6bc]
+    +             :       |             + ! 1 moveToLeftmost  (in libpython3.12.dylib) + 32  [0x105e4f1a0]
+    +             :       |             + 34 sqlite3BtreeNext  (in libpython3.12.dylib) + 48,164,...  [0x105e44f38,0x105e44fac,...]
+    +             :       |             + 8 sqlite3BtreeNext  (in libpython3.12.dylib) + 152  [0x105e44fa0]
+    +             :       |             +   7 btreeNext  (in libpython3.12.dylib) + 496  [0x105e4f0f0]
+    +             :       |             +   : 7 moveToParent  (in libpython3.12.dylib) + 144  [0x105e4c5d0]
+    +             :       |             +   :   7 releasePageNotNull  (in libpython3.12.dylib) + 28  [0x105e2f04c]
+    +             :       |             +   :     7 sqlite3PagerUnrefNotNull  (in libpython3.12.dylib) + 52  [0x105e19f48]
+    +             :       |             +   :       4 sqlite3PcacheRelease  (in libpython3.12.dylib) + 108,36,...  [0x105e1a048,0x105e1a000,...]
+    +             :       |             +   :       3 sqlite3PcacheRelease  (in libpython3.12.dylib) + 84  [0x105e1a030]
+    +             :       |             +   :         3 pcacheUnpin  (in libpython3.12.dylib) + 80  [0x105e1a0e4]
+    +             :       |             +   1 btreeNext  (in libpython3.12.dylib) + 400  [0x105e4f090]
+    +             :       |             +     1 moveToChild  (in libpython3.12.dylib) + 200  [0x105e4c6a4]
+    +             :       |             +       1 getAndInitPage  (in libpython3.12.dylib) + 112  [0x105e4c7d8]
+    +             :       |             +         1 sqlite3PagerGet  (in libpython3.12.dylib) + 56  [0x105dfa87c]
+    +             :       |             +           1 getPageNormal  (in libpython3.12.dylib) + 80  [0x105e231a0]
+    +             :       |             +             1 sqlite3PcacheFetch  (in libpython3.12.dylib) + 76  [0x105e23690]
+    +             :       |             +               1 pcache1Fetch  (in libpython3.12.dylib) + 40  [0x105ee8594]
+    +             :       |             +                 1 pcache1FetchNoMutex  (in libpython3.12.dylib) + 240  [0x105ee8df8]
+    +             :       |             +                   1 pcache1FetchStage2  (in libpython3.12.dylib) + 52  [0x105ee8e4c]
+    +             :       |             207 sqlite3VdbeExec  (in libpython3.12.dylib) + 10428  [0x105e39b6c]
+    +             :       |             + 171 sqlite3BtreePayloadSize  (in libpython3.12.dylib) + 24  [0x105e2e3b8]
+    +             :       |             + ! 135 getCellInfo  (in libpython3.12.dylib) + 76  [0x105e2e458]
+    +             :       |             + ! : 76 btreeParseCell  (in libpython3.12.dylib) + 120  [0x105e2e4e4]
+    +             :       |             + ! : | 76 btreeParseCellPtrIndex  (in libpython3.12.dylib) + 304,56,...  [0x105e27fbc,0x105e27ec4,...]
+    +             :       |             + ! : 59 btreeParseCell  (in libpython3.12.dylib) + 108,36,...  [0x105e2e4d8,0x105e2e490,...]
+    +             :       |             + ! 33 getCellInfo  (in libpython3.12.dylib) + 20,12,...  [0x105e2e420,0x105e2e418,...]
+    +             :       |             + ! 3 btreeParseCell  (in libpython3.12.dylib) + 128,124  [0x105e2e4ec,0x105e2e4e8]
+    +             :       |             + 36 sqlite3BtreePayloadSize  (in libpython3.12.dylib) + 28,32,...  [0x105e2e3bc,0x105e2e3c0,...]
+    +             :       |             118 sqlite3VdbeExec  (in libpython3.12.dylib) + 11776  [0x105e3a0b0]
+    +             :       |             + 118 sqlite3VdbeSerialGet  (in libpython3.12.dylib) + 740,28,...  [0x105e42ec4,0x105e42bfc,...]
+    +             :       |             117 sqlite3VdbeExec  (in libpython3.12.dylib) + 10452  [0x105e39b84]
+    +             :       |             + 89 sqlite3BtreePayloadFetch  (in libpython3.12.dylib) + 32  [0x105e429c8]
+    +             :       |             + ! 89 fetchPayload  (in libpython3.12.dylib) + 44,16,...  [0x105e4bcf4,0x105e4bcd8,...]
+    +             :       |             + 28 sqlite3BtreePayloadFetch  (in libpython3.12.dylib) + 32,20,...  [0x105e429c8,0x105e429bc,...]
+    +             :       |             66 sqlite3VdbeExec  (in libpython3.12.dylib) + 21676  [0x105e3c75c]
+    +             :       |             + 45 sqlite3BtreeIndexMoveto  (in libpython3.12.dylib) + 616  [0x105e44a50]
+    +             :       |             + ! 33 vdbeRecordCompareString  (in libpython3.12.dylib) + 372,352,...  [0x105e4ee14,0x105e4ee00,...]
+    +             :       |             + ! 10 vdbeRecordCompareString  (in libpython3.12.dylib) + 336  [0x105e4edf0]
+    +             :       |             + ! : 8 _platform_memcmp  (in libsystem_platform.dylib) + 56,128,...  [0x18a26af68,0x18a26afb0,...]
+    +             :       |             + ! : 2 DYLD-STUB$$memcmp  (in libpython3.12.dylib) + 4  [0x10628f5ec]
+    +             :       |             + ! 2 vdbeRecordCompareString  (in libpython3.12.dylib) + 472  [0x105e4ee78]
+    +             :       |             + !   2 sqlite3VdbeRecordCompareWithSkip  (in libpython3.12.dylib) + 52,1948  [0x105e47600,0x105e47d68]
+    +             :       |             + 15 sqlite3BtreeIndexMoveto  (in libpython3.12.dylib) + 1200,576,...  [0x105e44c98,0x105e44a28,...]
+    +             :       |             + 4 sqlite3BtreeIndexMoveto  (in libpython3.12.dylib) + 1612  [0x105e44e34]
+    +             :       |             + ! 2 getAndInitPage  (in libpython3.12.dylib) + 112  [0x105e4c7d8]
+    +             :       |             + ! : 2 sqlite3PagerGet  (in libpython3.12.dylib) + 56  [0x105dfa87c]
+    +             :       |             + ! :   1 getPageNormal  (in libpython3.12.dylib) + 80  [0x105e231a0]
+    +             :       |             + ! :   | 1 sqlite3PcacheFetch  (in libpython3.12.dylib) + 76  [0x105e23690]
+    +             :       |             + ! :   |   1 pcache1Fetch  (in libpython3.12.dylib) + 40  [0x105ee8594]
+    +             :       |             + ! :   |     1 pcache1FetchNoMutex  (in libpython3.12.dylib) + 80  [0x105ee8d58]
+    +             :       |             + ! :   1 getPageNormal  (in libpython3.12.dylib) + 592  [0x105e233a0]
+    +             :       |             + ! :     1 readDbPage  (in libpython3.12.dylib) + 232  [0x105e23ad4]
+    +             :       |             + ! :       1 sqlite3OsRead  (in libpython3.12.dylib) + 60  [0x105e21f5c]
+    +             :       |             + ! :         1 unixRead  (in libpython3.12.dylib) + 260  [0x105e112a8]
+    +             :       |             + ! :           1 seekAndRead  (in libpython3.12.dylib) + 72  [0x105e13214]
+    +             :       |             + ! :             1 pread  (in libsystem_kernel.dylib) + 8  [0x18a221650]
+    +             :       |             + ! 1 getAndInitPage  (in libpython3.12.dylib) + 44  [0x105e4c794]
+    +             :       |             + ! : 1 btreePagecount  (in libpython3.12.dylib) + 12  [0x105e2c750]
+    +             :       |             + ! 1 getAndInitPage  (in libpython3.12.dylib) + 168  [0x105e4c810]
+    +             :       |             + 2 sqlite3BtreeIndexMoveto  (in libpython3.12.dylib) + 356  [0x105e4494c]
+    +             :       |             +   1 moveToRoot  (in libpython3.12.dylib) + 64  [0x105e4c2c4]
+    +             :       |             +   : 1 releasePageNotNull  (in libpython3.12.dylib) + 28  [0x105e2f04c]
+    +             :       |             +   :   1 sqlite3PagerUnrefNotNull  (in libpython3.12.dylib) + 52  [0x105e19f48]
+    +             :       |             +   :     1 sqlite3PcacheRelease  (in libpython3.12.dylib) + 56  [0x105e1a014]
+    +             :       |             +   1 moveToRoot  (in libpython3.12.dylib) + 124  [0x105e4c300]
+    +             :       |             +     1 releasePageNotNull  (in libpython3.12.dylib) + 28  [0x105e2f04c]
+    +             :       |             +       1 sqlite3PagerUnrefNotNull  (in libpython3.12.dylib) + 56  [0x105e19f4c]
+    +             :       |             26 sqlite3VdbeExec  (in libpython3.12.dylib) + 11048  [0x105e39dd8]
+    +             :       |             + 26 sqlite3VdbeOneByteSerialTypeLen  (in libpython3.12.dylib) + 24,8,...  [0x105e42b7c,0x105e42b6c,...]
+    +             :       |             8 sqlite3VdbeExec  (in libpython3.12.dylib) + 10376  [0x105e39b38]
+    +             :       |             + 8 sqlite3BtreeCursorHasMoved  (in libpython3.12.dylib) + 12,4,...  [0x105e42938,0x105e42930,...]
+    +             :       |             8 sqlite3VdbeExec  (in libpython3.12.dylib) + 10704  [0x105e39c80]
+    +             :       |             + 8 sqlite3BtreeCursorHasMoved  (in libpython3.12.dylib) + 12  [0x105e42938]
+    +             :       |             1 sqlite3BtreeNext  (in libpython3.12.dylib) + 212  [0x105e44fdc]
+    +             :       |             1 sqlite3VdbeSerialGet  (in libpython3.12.dylib) + 744  [0x105e42ec8]
+    +             :       1 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+    +             :         1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +             :           1 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+    +             :             1 _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+    +             :               1 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+    +             :                 1 bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+    +             :                   1 PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+    +             :                     1 pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+    +             :                       1 pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+    +             :                         1 sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+    +             :                           1 sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+    +             :                             1 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +             :                               1 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +             :                                 1 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +             :                                   1 yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+    +             :                                     1 sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+    +             :                                       1 sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+    +             :                                         1 sqlite3InitOne  (in libpython3.12.dylib) + 1164  [0x105e486b8]
+    +             :                                           1 sqlite3_exec  (in libpython3.12.dylib) + 740  [0x105dfa680]
+    +             :                                             1 sqlite3InitCallback  (in libpython3.12.dylib) + 516  [0x105e48a58]
+    +             :                                               1 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +             :                                                 1 sqlite3RunParser  (in libpython3.12.dylib) + 796  [0x105e07914]
+    +             :                                                   1 sqlite3ParserFinalize  (in libpython3.12.dylib) + 68  [0x105e627b0]
+    +             3 _PyObject_MakeTpCall  (in libpython3.12.dylib) + 364  [0x1058953c4]
+    +               3 partial_call  (in libpython3.12.dylib) + 92  [0x105a08af8]
+    +                 3 _PyVectorcall_Call.llvm.7333159498766099632  (in libpython3.12.dylib) + 152  [0x1058eb34c]
+    +                   3 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+    +                     3 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+    +                       3 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+    +                         3 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 172  [0x105b21bf4]
+    +                           2 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +                           | 2 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+    +                           |   2 _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+    +                           |     2 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+    +                           |       2 bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+    +                           |         2 PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+    +                           |           2 pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+    +                           |             2 pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+    +                           |               2 sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+    +                           |                 2 sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+    +                           |                   2 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +                           |                     2 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +                           |                       2 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +                           |                         2 yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+    +                           |                           2 sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+    +                           |                             2 sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+    +                           |                               2 sqlite3InitOne  (in libpython3.12.dylib) + 1164  [0x105e486b8]
+    +                           |                                 1 sqlite3_exec  (in libpython3.12.dylib) + 608  [0x105dfa5fc]
+    +                           |                                 + 1 sqlite3_column_text  (in libpython3.12.dylib) + 36  [0x105e0018c]
+    +                           |                                 +   1 sqlite3_value_text  (in libpython3.12.dylib) + 28  [0x105dfd7d0]
+    +                           |                                 +     1 sqlite3ValueText  (in libpython3.12.dylib) + 156  [0x105dfdc80]
+    +                           |                                 1 sqlite3_exec  (in libpython3.12.dylib) + 740  [0x105dfa680]
+    +                           |                                   1 sqlite3InitCallback  (in libpython3.12.dylib) + 516  [0x105e48a58]
+    +                           |                                     1 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +                           |                                       1 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +                           |                                         1 sqlite3Parser  (in libpython3.12.dylib) + 404  [0x105e62760]
+    +                           1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191256  [0x105935fb0]
+    +                             1 pysqlite_connection_commit_impl  (in libpython3.12.dylib) + 112  [0x10623cf88]
+    +                               1 connection_exec_stmt  (in libpython3.12.dylib) + 124  [0x10623b444]
+    +                                 1 sqlite3_step  (in libpython3.12.dylib) + 104  [0x105dfa17c]
+    +                                   1 sqlite3Step  (in libpython3.12.dylib) + 484  [0x105dff520]
+    +                                     1 sqlite3VdbeExec  (in libpython3.12.dylib) + 17708  [0x105e3b7dc]
+    +                                       1 sqlite3VdbeHalt  (in libpython3.12.dylib) + 736  [0x105e319f8]
+    +                                         1 vdbeCommit  (in libpython3.12.dylib) + 588  [0x105e325b8]
+    +                                           1 sqlite3BtreeCommitPhaseOne  (in libpython3.12.dylib) + 188  [0x105dfca2c]
+    +                                             1 sqlite3PagerCommitPhaseOne  (in libpython3.12.dylib) + 280  [0x105dfc580]
+    +                                               1 pagerWalFrames  (in libpython3.12.dylib) + 268  [0x105e1d15c]
+    +                                                 1 sqlite3WalFrames  (in libpython3.12.dylib) + 64  [0x105e1ec2c]
+    +                                                   1 walFrames  (in libpython3.12.dylib) + 1080  [0x105e1f0bc]
+    +                                                     1 walWriteOneFrame  (in libpython3.12.dylib) + 112  [0x105e1fd78]
+    +                                                       1 walWriteToLog  (in libpython3.12.dylib) + 296  [0x105e22550]
+    +                                                         1 sqlite3OsWrite  (in libpython3.12.dylib) + 60  [0x105dfc764]
+    +                                                           1 unixWrite  (in libpython3.12.dylib) + 64  [0x105e113c0]
+    +                                                             1 seekAndWrite  (in libpython3.12.dylib) + 60  [0x105e13364]
+    +                                                               1 seekAndWriteFd  (in libpython3.12.dylib) + 84  [0x105e133c4]
+    +                                                                 1 pwrite  (in libsystem_kernel.dylib) + 8  [0x18a223430]
+    3839 Thread_79463734
+    + 3839 thread_start  (in libsystem_pthread.dylib) + 8  [0x18a25ec1c]
+    +   3839 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x18a263c58]
+    +     3839 pythread_wrapper.llvm.14749647604360532379  (in libpython3.12.dylib) + 48  [0x106201ff0]
+    +       3839 thread_run  (in libpython3.12.dylib) + 188  [0x105a6283c]
+    +         3839 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+    +           3833 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 177044  [0x10593282c]
+    +           ! 3833 method_vectorcall_FASTCALL_KEYWORDS_METHOD.llvm.3960725272945190732  (in libpython3.12.dylib) + 136  [0x1058a8714]
+    +           !   3832 _queue_SimpleQueue_get  (in libpython3.12.dylib) + 220  [0x106233a44]
+    +           !   : 3832 _queue_SimpleQueue_get_impl  (in libpython3.12.dylib) + 232  [0x106233d88]
+    +           !   :   3832 PyThread_acquire_lock_timed  (in libpython3.12.dylib) + 440  [0x1059443c4]
+    +           !   :     3832 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x18a264128]
+    +           !   :       3832 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x18a22350c]
+    +           !   1 _queue_SimpleQueue_get_impl  (in libpython3.12.dylib) + 456  [0x106233e68]
+    +           !     1 _PyErr_SetObject  (in libpython3.12.dylib) + 364  [0x105894cc8]
+    +           !       1 _tlv_get_addr  (in libdyld.dylib) + 0  [0x189e70388]
+    +           6 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 192132  [0x10593631c]
+    +             5 partial_vectorcall  (in libpython3.12.dylib) + 556  [0x105a11468]
+    +             : 5 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+    +             :   5 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+    +             :     5 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+    +             :       5 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+    +             :         4 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +             :         | 4 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+    +             :         |   4 _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+    +             :         |     4 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+    +             :         |       4 bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+    +             :         |         4 PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+    +             :         |           4 pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+    +             :         |             4 pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+    +             :         |               4 sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+    +             :         |                 4 sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+    +             :         |                   4 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +             :         |                     4 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +             :         |                       4 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +             :         |                         4 yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+    +             :         |                           4 sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+    +             :         |                             4 sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+    +             :         |                               4 sqlite3InitOne  (in libpython3.12.dylib) + 1164  [0x105e486b8]
+    +             :         |                                 4 sqlite3_exec  (in libpython3.12.dylib) + 740  [0x105dfa680]
+    +             :         |                                   3 sqlite3InitCallback  (in libpython3.12.dylib) + 516  [0x105e48a58]
+    +             :         |                                   + 3 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +             :         |                                   +   3 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +             :         |                                   +     2 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +             :         |                                   +     ! 1 yy_reduce  (in libpython3.12.dylib) + 1204  [0x105e63100]
+    +             :         |                                   +     ! : 1 sqlite3AddDefaultValue  (in libpython3.12.dylib) + 368  [0x105e68d54]
+    +             :         |                                   +     ! :   1 sqlite3ColumnSetExpr  (in libpython3.12.dylib) + 168  [0x105e8c0e0]
+    +             :         |                                   +     ! :     1 sqlite3ExprListAppend  (in libpython3.12.dylib) + 112  [0x105e6f204]
+    +             :         |                                   +     ! :       1 sqlite3ExprListAppendGrow  (in libpython3.12.dylib) + 76  [0x105ec12e4]
+    +             :         |                                   +     ! :         1 sqlite3DbRealloc  (in libpython3.12.dylib) + 224  [0x105e10988]
+    +             :         |                                   +     ! :           1 dbReallocFinish  (in libpython3.12.dylib) + 180  [0x105e10c28]
+    +             :         |                                   +     ! :             1 sqlite3Realloc  (in libpython3.12.dylib) + 460  [0x105df3f58]
+    +             :         |                                   +     ! :               1 sqlite3StatusUp  (in libpython3.12.dylib) + 104  [0x105e10690]
+    +             :         |                                   +     ! 1 yy_reduce  (in libpython3.12.dylib) + 11968  [0x105e65b0c]
+    +             :         |                                   +     !   1 sqlite3CreateIndex  (in libpython3.12.dylib) + 3468  [0x105e6a288]
+    +             :         |                                   +     !     1 sqlite3DefaultRowEst  (in libpython3.12.dylib) + 0  [0x105e5b110]
+    +             :         |                                   +     1 sqlite3Parser  (in libpython3.12.dylib) + 404  [0x105e62760]
+    +             :         |                                   1 sqlite3InitCallback  (in libpython3.12.dylib) + 864  [0x105e48bb4]
+    +             :         |                                     1 sqlite3FindIndex  (in libpython3.12.dylib) + 192  [0x105e5a9f8]
+    +             :         |                                       1 sqlite3HashFind  (in libpython3.12.dylib) + 36  [0x105e59aa4]
+    +             :         |                                         1 findElementWithHash  (in libpython3.12.dylib) + 212  [0x105e59d58]
+    +             :         |                                           1 sqlite3StrICmp  (in libpython3.12.dylib) + 84  [0x105df8600]
+    +             :         1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 188440  [0x1059354b0]
+    +             :           1 os_open  (in libpython3.12.dylib) + 408  [0x105aa9f18]
+    +             :             1 open  (in libsystem_kernel.dylib) + 64  [0x18a22b8f0]
+    +             :               1 __open  (in libsystem_kernel.dylib) + 8  [0x18a220694]
+    +             1 _PyObject_MakeTpCall  (in libpython3.12.dylib) + 364  [0x1058953c4]
+    +               1 partial_call  (in libpython3.12.dylib) + 92  [0x105a08af8]
+    +                 1 _PyVectorcall_Call.llvm.7333159498766099632  (in libpython3.12.dylib) + 152  [0x1058eb34c]
+    +                   1 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+    +                     1 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+    +                       1 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+    +                         1 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 172  [0x105b21bf4]
+    +                           1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +                             1 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+    +                               1 _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+    +                                 1 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+    +                                   1 bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+    +                                     1 PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+    +                                       1 pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+    +                                         1 pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+    +                                           1 sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+    +                                             1 sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+    +                                               1 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +                                                 1 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +                                                   1 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +                                                     1 yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+    +                                                       1 sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+    +                                                         1 sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+    +                                                           1 sqlite3InitOne  (in libpython3.12.dylib) + 396  [0x105e483b8]
+    +                                                             1 sqlite3BtreeBeginTrans  (in libpython3.12.dylib) + 104  [0x105dfbc1c]
+    +                                                               1 btreeBeginTrans  (in libpython3.12.dylib) + 552  [0x105e2a4e0]
+    +                                                                 1 lockBtree  (in libpython3.12.dylib) + 32  [0x105e2a9e4]
+    +                                                                   1 sqlite3PagerSharedLock  (in libpython3.12.dylib) + 796  [0x105e2b534]
+    +                                                                     1 pagerOpenWalIfPresent  (in libpython3.12.dylib) + 188  [0x105e2baf8]
+    +                                                                       1 sqlite3PagerOpenWal  (in libpython3.12.dylib) + 104  [0x105e2b6f4]
+    +                                                                         1 pagerOpenWal  (in libpython3.12.dylib) + 116  [0x105e2bf90]
+    +                                                                           1 sqlite3WalOpen  (in libpython3.12.dylib) + 252  [0x105e2c104]
+    +                                                                             1 sqlite3OsOpen  (in libpython3.12.dylib) + 76  [0x105e1c860]
+    +                                                                               1 unixOpen  (in libpython3.12.dylib) + 780  [0x105df8b48]
+    +                                                                                 1 robust_open  (in libpython3.12.dylib) + 104  [0x105e15bd8]
+    +                                                                                   1 posixOpen  (in libpython3.12.dylib) + 48  [0x105e18588]
+    +                                                                                     1 open  (in libsystem_kernel.dylib) + 64  [0x18a22b8f0]
+    +                                                                                       1 __open  (in libsystem_kernel.dylib) + 8  [0x18a220694]
+    3839 Thread_79463781
+    + 3839 thread_start  (in libsystem_pthread.dylib) + 8  [0x18a25ec1c]
+    +   3839 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x18a263c58]
+    +     3839 pythread_wrapper.llvm.14749647604360532379  (in libpython3.12.dylib) + 48  [0x106201ff0]
+    +       3839 thread_run  (in libpython3.12.dylib) + 188  [0x105a6283c]
+    +         3839 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+    +           3832 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 177044  [0x10593282c]
+    +           ! 3832 method_vectorcall_FASTCALL_KEYWORDS_METHOD.llvm.3960725272945190732  (in libpython3.12.dylib) + 136  [0x1058a8714]
+    +           !   3832 _queue_SimpleQueue_get  (in libpython3.12.dylib) + 220  [0x106233a44]
+    +           !     3832 _queue_SimpleQueue_get_impl  (in libpython3.12.dylib) + 232  [0x106233d88]
+    +           !       3832 PyThread_acquire_lock_timed  (in libpython3.12.dylib) + 440  [0x1059443c4]
+    +           !         3832 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x18a264128]
+    +           !           3832 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x18a22350c]
+    +           7 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 192132  [0x10593631c]
+    +             6 _PyObject_MakeTpCall  (in libpython3.12.dylib) + 364  [0x1058953c4]
+    +             : 6 partial_call  (in libpython3.12.dylib) + 92  [0x105a08af8]
+    +             :   6 _PyVectorcall_Call.llvm.7333159498766099632  (in libpython3.12.dylib) + 152  [0x1058eb34c]
+    +             :     6 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+    +             :       6 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+    +             :         6 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+    +             :           6 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 172  [0x105b21bf4]
+    +             :             6 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +             :               6 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+    +             :                 6 _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+    +             :                   6 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+    +             :                     6 bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+    +             :                       6 PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+    +             :                         6 pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+    +             :                           6 pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+    +             :                             6 sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+    +             :                               6 sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+    +             :                                 6 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +             :                                   6 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +             :                                     6 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +             :                                       6 yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+    +             :                                         6 sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+    +             :                                           6 sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+    +             :                                             5 sqlite3InitOne  (in libpython3.12.dylib) + 1164  [0x105e486b8]
+    +             :                                             | 3 sqlite3_exec  (in libpython3.12.dylib) + 740  [0x105dfa680]
+    +             :                                             | + 3 sqlite3InitCallback  (in libpython3.12.dylib) + 516  [0x105e48a58]
+    +             :                                             | +   3 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +             :                                             | +     3 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +             :                                             | +       3 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +             :                                             | +         1 yy_reduce  (in libpython3.12.dylib) + 944  [0x105e62ffc]
+    +             :                                             | +         ! 1 sqlite3AddColumn  (in libpython3.12.dylib) + 1128  [0x105e68a7c]
+    +             :                                             | +         !   1 sqlite3DbRealloc  (in libpython3.12.dylib) + 224  [0x105e10988]
+    +             :                                             | +         !     1 dbReallocFinish  (in libpython3.12.dylib) + 180  [0x105e10c28]
+    +             :                                             | +         !       1 sqlite3Realloc  (in libpython3.12.dylib) + 476  [0x105df3f68]
+    +             :                                             | +         !         1 sqlite3_mutex_leave  (in libpython3.12.dylib) + 48  [0x105df26a4]
+    +             :                                             | +         !           1 pthreadMutexLeave  (in libpython3.12.dylib) + 24  [0x105e10374]
+    +             :                                             | +         !             1 _pthread_mutex_firstfit_unlock_slow  (in libsystem_pthread.dylib) + 220  [0x18a25eb94]
+    +             :                                             | +         !               1 _pthread_mutex_firstfit_wake  (in libsystem_pthread.dylib) + 28  [0x18a260f0c]
+    +             :                                             | +         !                 1 __psynch_mutexdrop  (in libsystem_kernel.dylib) + 8  [0x18a222ba8]
+    +             :                                             | +         1 yy_reduce  (in libpython3.12.dylib) + 2136  [0x105e634a4]
+    +             :                                             | +         ! 1 sqlite3AddPrimaryKey  (in libpython3.12.dylib) + 800  [0x105e694d0]
+    +             :                                             | +         !   1 sqlite3CreateIndex  (in libpython3.12.dylib) + 1924  [0x105e69c80]
+    +             :                                             | +         !     1 sqlite3AllocateIndexObject  (in libpython3.12.dylib) + 148  [0x105e98358]
+    +             :                                             | +         !       1 sqlite3DbMallocZero  (in libpython3.12.dylib) + 32  [0x105dffe54]
+    +             :                                             | +         !         1 sqlite3DbMallocRaw  (in libpython3.12.dylib) + 44  [0x105e048a0]
+    +             :                                             | +         !           1 sqlite3DbMallocRawNN  (in libpython3.12.dylib) + 120  [0x105e10a18]
+    +             :                                             | +         !             1 dbMallocRawFinish  (in libpython3.12.dylib) + 28  [0x105e10c78]
+    +             :                                             | +         !               1 sqlite3Malloc  (in libpython3.12.dylib) + 116  [0x105df3ba8]
+    +             :                                             | +         !                 1 sqlite3_mutex_leave  (in libpython3.12.dylib) + 48  [0x105df26a4]
+    +             :                                             | +         !                   1 pthreadMutexLeave  (in libpython3.12.dylib) + 24  [0x105e10374]
+    +             :                                             | +         !                     1 _pthread_mutex_firstfit_unlock_slow  (in libsystem_pthread.dylib) + 220  [0x18a25eb94]
+    +             :                                             | +         !                       1 _pthread_mutex_firstfit_wake  (in libsystem_pthread.dylib) + 28  [0x18a260f0c]
+    +             :                                             | +         !                         1 __psynch_mutexdrop  (in libsystem_kernel.dylib) + 8  [0x18a222ba8]
+    +             :                                             | +         1 yy_reduce  (in libpython3.12.dylib) + 15456  [0x105e668ac]
+    +             :                                             | +           1 yy_find_reduce_action  (in libpython3.12.dylib) + 0  [0x105e7e8c4]
+    +             :                                             | 1 sqlite3_exec  (in libpython3.12.dylib) + 288  [0x105dfa4bc]
+    +             :                                             | + 1 sqlite3_step  (in libpython3.12.dylib) + 104  [0x105dfa17c]
+    +             :                                             | +   1 sqlite3Step  (in libpython3.12.dylib) + 484  [0x105dff520]
+    +             :                                             | +     1 sqlite3VdbeExec  (in libpython3.12.dylib) + 11968  [0x105e3a170]
+    +             :                                             | +       1 _platform_memmove  (in libsystem_platform.dylib) + 436  [0x18a26d574]
+    +             :                                             | 1 sqlite3_exec  (in libpython3.12.dylib) + 576  [0x105dfa5dc]
+    +             :                                             1 sqlite3InitOne  (in libpython3.12.dylib) + 396  [0x105e483b8]
+    +             :                                               1 sqlite3BtreeBeginTrans  (in libpython3.12.dylib) + 104  [0x105dfbc1c]
+    +             :                                                 1 btreeBeginTrans  (in libpython3.12.dylib) + 552  [0x105e2a4e0]
+    +             :                                                   1 lockBtree  (in libpython3.12.dylib) + 32  [0x105e2a9e4]
+    +             :                                                     1 sqlite3PagerSharedLock  (in libpython3.12.dylib) + 796  [0x105e2b534]
+    +             :                                                       1 pagerOpenWalIfPresent  (in libpython3.12.dylib) + 188  [0x105e2baf8]
+    +             :                                                         1 sqlite3PagerOpenWal  (in libpython3.12.dylib) + 104  [0x105e2b6f4]
+    +             :                                                           1 pagerOpenWal  (in libpython3.12.dylib) + 116  [0x105e2bf90]
+    +             :                                                             1 sqlite3WalOpen  (in libpython3.12.dylib) + 252  [0x105e2c104]
+    +             :                                                               1 sqlite3OsOpen  (in libpython3.12.dylib) + 76  [0x105e1c860]
+    +             :                                                                 1 unixOpen  (in libpython3.12.dylib) + 780  [0x105df8b48]
+    +             :                                                                   1 robust_open  (in libpython3.12.dylib) + 104  [0x105e15bd8]
+    +             :                                                                     1 posixOpen  (in libpython3.12.dylib) + 48  [0x105e18588]
+    +             :                                                                       1 open  (in libsystem_kernel.dylib) + 64  [0x18a22b8f0]
+    +             :                                                                         1 __open  (in libsystem_kernel.dylib) + 8  [0x18a220694]
+    +             1 partial_vectorcall  (in libpython3.12.dylib) + 556  [0x105a11468]
+    +               1 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+    +                 1 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+    +                   1 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+    +                     1 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+    +                       1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +                         1 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+    +                           1 _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+    +                             1 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+    +                               1 bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+    +                                 1 PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+    +                                   1 pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+    +                                     1 pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+    +                                       1 sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+    +                                         1 sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+    +                                           1 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +                                             1 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +                                               1 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +                                                 1 yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+    +                                                   1 sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+    +                                                     1 sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+    +                                                       1 sqlite3InitOne  (in libpython3.12.dylib) + 1164  [0x105e486b8]
+    +                                                         1 sqlite3_exec  (in libpython3.12.dylib) + 740  [0x105dfa680]
+    +                                                           1 sqlite3InitCallback  (in libpython3.12.dylib) + 516  [0x105e48a58]
+    +                                                             1 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +                                                               1 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +                                                                 1 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +                                                                   1 yy_reduce  (in libpython3.12.dylib) + 11968  [0x105e65b0c]
+    +                                                                     1 sqlite3CreateIndex  (in libpython3.12.dylib) + 452  [0x105e696c0]
+    +                                                                       1 sqlite3LocateTableItem  (in libpython3.12.dylib) + 136  [0x105e94330]
+    +                                                                         1 sqlite3LocateTable  (in libpython3.12.dylib) + 96  [0x105e02744]
+    +                                                                           1 sqlite3FindTable  (in libpython3.12.dylib) + 232  [0x105e0d614]
+    +                                                                             1 sqlite3HashFind  (in libpython3.12.dylib) + 36  [0x105e59aa4]
+    +                                                                               1 findElementWithHash  (in libpython3.12.dylib) + 48  [0x105e59cb4]
+    +                                                                                 1 strHash  (in libpython3.12.dylib) + 32  [0x105e59dc8]
+    3839 Thread_79470859
+    + 3839 thread_start  (in libsystem_pthread.dylib) + 8  [0x18a25ec1c]
+    +   3839 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x18a263c58]
+    +     3839 pythread_wrapper.llvm.14749647604360532379  (in libpython3.12.dylib) + 48  [0x106201ff0]
+    +       3839 thread_run  (in libpython3.12.dylib) + 188  [0x105a6283c]
+    +         3839 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+    +           3835 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 177044  [0x10593282c]
+    +           ! 3835 method_vectorcall_FASTCALL_KEYWORDS_METHOD.llvm.3960725272945190732  (in libpython3.12.dylib) + 136  [0x1058a8714]
+    +           !   3835 _queue_SimpleQueue_get  (in libpython3.12.dylib) + 220  [0x106233a44]
+    +           !     3835 _queue_SimpleQueue_get_impl  (in libpython3.12.dylib) + 232  [0x106233d88]
+    +           !       3835 PyThread_acquire_lock_timed  (in libpython3.12.dylib) + 440  [0x1059443c4]
+    +           !         3835 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x18a264128]
+    +           !           3835 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x18a22350c]
+    +           4 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 192132  [0x10593631c]
+    +             3 partial_vectorcall  (in libpython3.12.dylib) + 556  [0x105a11468]
+    +             : 3 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+    +             :   3 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+    +             :     3 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+    +             :       3 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+    +             :         2 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +             :         | 2 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+    +             :         |   2 _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+    +             :         |     2 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+    +             :         |       2 bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+    +             :         |         2 PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+    +             :         |           2 pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+    +             :         |             2 pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+    +             :         |               2 sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+    +             :         |                 2 sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+    +             :         |                   2 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +             :         |                     2 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +             :         |                       2 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +             :         |                         2 yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+    +             :         |                           2 sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+    +             :         |                             2 sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+    +             :         |                               1 sqlite3InitOne  (in libpython3.12.dylib) + 396  [0x105e483b8]
+    +             :         |                               + 1 sqlite3BtreeBeginTrans  (in libpython3.12.dylib) + 104  [0x105dfbc1c]
+    +             :         |                               +   1 btreeBeginTrans  (in libpython3.12.dylib) + 552  [0x105e2a4e0]
+    +             :         |                               +     1 lockBtree  (in libpython3.12.dylib) + 32  [0x105e2a9e4]
+    +             :         |                               +       1 sqlite3PagerSharedLock  (in libpython3.12.dylib) + 896  [0x105e2b598]
+    +             :         |                               +         1 pagerPagecount  (in libpython3.12.dylib) + 156  [0x105e2bc80]
+    +             :         |                               1 sqlite3InitOne  (in libpython3.12.dylib) + 1164  [0x105e486b8]
+    +             :         |                                 1 sqlite3_exec  (in libpython3.12.dylib) + 740  [0x105dfa680]
+    +             :         |                                   1 sqlite3InitCallback  (in libpython3.12.dylib) + 516  [0x105e48a58]
+    +             :         |                                     1 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +             :         |                                       1 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +             :         |                                         1 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +             :         |                                           1 yy_reduce  (in libpython3.12.dylib) + 944  [0x105e62ffc]
+    +             :         |                                             1 sqlite3AddColumn  (in libpython3.12.dylib) + 808  [0x105e6893c]
+    +             :         |                                               1 sqlite3DbMallocRaw  (in libpython3.12.dylib) + 44  [0x105e048a0]
+    +             :         |                                                 1 sqlite3DbMallocRawNN  (in libpython3.12.dylib) + 28  [0x105e109bc]
+    +             :         1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191256  [0x105935fb0]
+    +             :           1 pysqlite_connection_close_impl  (in libpython3.12.dylib) + 84  [0x10623ced0]
+    +             :             1 connection_close  (in libpython3.12.dylib) + 64  [0x10623b37c]
+    +             :               1 sqlite3_close_v2  (in libpython3.12.dylib) + 28  [0x105e0a368]
+    +             :                 1 sqlite3Close  (in libpython3.12.dylib) + 352  [0x105e0a334]
+    +             :                   1 sqlite3LeaveMutexAndCloseZombie  (in libpython3.12.dylib) + 168  [0x105dfce8c]
+    +             :                     1 sqlite3BtreeClose  (in libpython3.12.dylib) + 164  [0x105e339c0]
+    +             :                       1 sqlite3SchemaClear  (in libpython3.12.dylib) + 244  [0x105e481b4]
+    +             :                         1 sqlite3DeleteTable  (in libpython3.12.dylib) + 96  [0x105df30e8]
+    +             :                           1 deleteTable  (in libpython3.12.dylib) + 268  [0x105e6052c]
+    +             :                             1 sqlite3DeleteColumnNames  (in libpython3.12.dylib) + 168  [0x105e60824]
+    +             :                               1 sqlite3ExprListDelete  (in libpython3.12.dylib) + 48  [0x105e07b00]
+    +             1 _PyObject_MakeTpCall  (in libpython3.12.dylib) + 364  [0x1058953c4]
+    +               1 partial_call  (in libpython3.12.dylib) + 92  [0x105a08af8]
+    +                 1 _PyVectorcall_Call.llvm.7333159498766099632  (in libpython3.12.dylib) + 152  [0x1058eb34c]
+    +                   1 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+    +                     1 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+    +                       1 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+    +                         1 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 172  [0x105b21bf4]
+    +                           1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +                             1 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+    +                               1 _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+    +                                 1 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+    +                                   1 bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+    +                                     1 PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+    +                                       1 pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+    +                                         1 pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+    +                                           1 sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+    +                                             1 sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+    +                                               1 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +                                                 1 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +                                                   1 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +                                                     1 yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+    +                                                       1 sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+    +                                                         1 sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+    +                                                           1 sqlite3InitOne  (in libpython3.12.dylib) + 1164  [0x105e486b8]
+    +                                                             1 sqlite3_exec  (in libpython3.12.dylib) + 740  [0x105dfa680]
+    +                                                               1 sqlite3InitCallback  (in libpython3.12.dylib) + 516  [0x105e48a58]
+    +                                                                 1 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +                                                                   1 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +                                                                     1 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +                                                                       1 yy_reduce  (in libpython3.12.dylib) + 11968  [0x105e65b0c]
+    +                                                                         1 sqlite3CreateIndex  (in libpython3.12.dylib) + 2392  [0x105e69e54]
+    +                                                                           1 sqlite3ResolveSelfReference  (in libpython3.12.dylib) + 232  [0x105e8bfdc]
+    +                                                                             1 sqlite3ResolveExprNames  (in libpython3.12.dylib) + 228  [0x105e8d0d8]
+    +                                                                               1 sqlite3WalkExprNN  (in libpython3.12.dylib) + 44  [0x105e85280]
+    +                                                                                 1 resolveExprStep  (in libpython3.12.dylib) + 1296  [0x105e8d898]
+    +                                                                                   1 lookupName  (in libpython3.12.dylib) + 1932  [0x105e8f738]
+    3839 Thread_79470861
+    + 3839 thread_start  (in libsystem_pthread.dylib) + 8  [0x18a25ec1c]
+    +   3839 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x18a263c58]
+    +     3839 pythread_wrapper.llvm.14749647604360532379  (in libpython3.12.dylib) + 48  [0x106201ff0]
+    +       3839 thread_run  (in libpython3.12.dylib) + 188  [0x105a6283c]
+    +         3839 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+    +           3827 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 177044  [0x10593282c]
+    +           ! 3827 method_vectorcall_FASTCALL_KEYWORDS_METHOD.llvm.3960725272945190732  (in libpython3.12.dylib) + 136  [0x1058a8714]
+    +           !   3827 _queue_SimpleQueue_get  (in libpython3.12.dylib) + 220  [0x106233a44]
+    +           !     3827 _queue_SimpleQueue_get_impl  (in libpython3.12.dylib) + 232  [0x106233d88]
+    +           !       3827 PyThread_acquire_lock_timed  (in libpython3.12.dylib) + 440  [0x1059443c4]
+    +           !         3827 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x18a264128]
+    +           !           3827 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x18a22350c]
+    +           12 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 192132  [0x10593631c]
+    +             6 _PyObject_MakeTpCall  (in libpython3.12.dylib) + 364  [0x1058953c4]
+    +             : 6 partial_call  (in libpython3.12.dylib) + 92  [0x105a08af8]
+    +             :   6 _PyVectorcall_Call.llvm.7333159498766099632  (in libpython3.12.dylib) + 152  [0x1058eb34c]
+    +             :     6 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+    +             :       6 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+    +             :         6 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+    +             :           6 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 172  [0x105b21bf4]
+    +             :             4 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +             :             | 4 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+    +             :             |   4 _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+    +             :             |     4 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+    +             :             |       4 bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+    +             :             |         4 PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+    +             :             |           4 pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+    +             :             |             4 pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+    +             :             |               4 sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+    +             :             |                 4 sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+    +             :             |                   4 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +             :             |                     4 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +             :             |                       4 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +             :             |                         4 yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+    +             :             |                           4 sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+    +             :             |                             4 sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+    +             :             |                               4 sqlite3InitOne  (in libpython3.12.dylib) + 1164  [0x105e486b8]
+    +             :             |                                 4 sqlite3_exec  (in libpython3.12.dylib) + 740  [0x105dfa680]
+    +             :             |                                   4 sqlite3InitCallback  (in libpython3.12.dylib) + 516  [0x105e48a58]
+    +             :             |                                     4 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +             :             |                                       4 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +             :             |                                         4 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +             :             |                                           1 yy_reduce  (in libpython3.12.dylib) + 400  [0x105e62ddc]
+    +             :             |                                           + 1 sqlite3StartTable  (in libpython3.12.dylib) + 300  [0x105e67510]
+    +             :             |                                           +   1 sqlite3NameFromToken  (in libpython3.12.dylib) + 60  [0x105e6f9f4]
+    +             :             |                                           +     1 sqlite3DbStrNDup  (in libpython3.12.dylib) + 52  [0x105e5aba4]
+    +             :             |                                           +       1 sqlite3DbMallocRawNN  (in libpython3.12.dylib) + 120  [0x105e10a18]
+    +             :             |                                           +         1 dbMallocRawFinish  (in libpython3.12.dylib) + 28  [0x105e10c78]
+    +             :             |                                           +           1 sqlite3Malloc  (in libpython3.12.dylib) + 88  [0x105df3b8c]
+    +             :             |                                           +             1 sqlite3_mutex_enter  (in libpython3.12.dylib) + 48  [0x105df2664]
+    +             :             |                                           +               1 pthreadMutexEnter  (in libpython3.12.dylib) + 24  [0x105e1030c]
+    +             :             |                                           +                 1 _pthread_mutex_firstfit_lock_slow  (in libsystem_pthread.dylib) + 216  [0x18a25e8e0]
+    +             :             |                                           +                   1 _pthread_mutex_firstfit_lock_wait  (in libsystem_pthread.dylib) + 84  [0x18a260e9c]
+    +             :             |                                           +                     1 __psynch_mutexwait  (in libsystem_kernel.dylib) + 8  [0x18a2229dc]
+    +             :             |                                           1 yy_reduce  (in libpython3.12.dylib) + 2204  [0x105e634e8]
+    +             :             |                                           + 1 sqlite3CreateIndex  (in libpython3.12.dylib) + 1924  [0x105e69c80]
+    +             :             |                                           +   1 sqlite3AllocateIndexObject  (in libpython3.12.dylib) + 148  [0x105e98358]
+    +             :             |                                           +     1 sqlite3DbMallocZero  (in libpython3.12.dylib) + 32  [0x105dffe54]
+    +             :             |                                           +       1 sqlite3DbMallocRaw  (in libpython3.12.dylib) + 20  [0x105e04888]
+    +             :             |                                           1 yy_reduce  (in libpython3.12.dylib) + 11968  [0x105e65b0c]
+    +             :             |                                           + 1 sqlite3CreateIndex  (in libpython3.12.dylib) + 452  [0x105e696c0]
+    +             :             |                                           +   1 sqlite3LocateTableItem  (in libpython3.12.dylib) + 136  [0x105e94330]
+    +             :             |                                           +     1 sqlite3LocateTable  (in libpython3.12.dylib) + 96  [0x105e02744]
+    +             :             |                                           +       1 sqlite3FindTable  (in libpython3.12.dylib) + 232  [0x105e0d614]
+    +             :             |                                           +         1 sqlite3HashFind  (in libpython3.12.dylib) + 36  [0x105e59aa4]
+    +             :             |                                           +           1 findElementWithHash  (in libpython3.12.dylib) + 212  [0x105e59d58]
+    +             :             |                                           +             1 sqlite3StrICmp  (in libpython3.12.dylib) + 72  [0x105df85f4]
+    +             :             |                                           1 yy_reduce  (in libpython3.12.dylib) + 12512  [0x105e65d2c]
+    +             :             |                                             1 sqlite3FinishTrigger  (in libpython3.12.dylib) + 816  [0x105e7b2a4]
+    +             :             |                                               1 sqlite3HashInsert  (in libpython3.12.dylib) + 172  [0x105e59b60]
+    +             :             |                                                 1 sqlite3Malloc  (in libpython3.12.dylib) + 88  [0x105df3b8c]
+    +             :             |                                                   1 sqlite3_mutex_enter  (in libpython3.12.dylib) + 48  [0x105df2664]
+    +             :             |                                                     1 pthreadMutexEnter  (in libpython3.12.dylib) + 24  [0x105e1030c]
+    +             :             |                                                       1 _pthread_mutex_firstfit_lock_slow  (in libsystem_pthread.dylib) + 216  [0x18a25e8e0]
+    +             :             |                                                         1 _pthread_mutex_firstfit_lock_wait  (in libsystem_pthread.dylib) + 84  [0x18a260e9c]
+    +             :             |                                                           1 __psynch_mutexwait  (in libsystem_kernel.dylib) + 8  [0x18a2229dc]
+    +             :             1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 188440  [0x1059354b0]
+    +             :             | 1 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+    +             :             |   1 type_call  (in libpython3.12.dylib) + 148  [0x105b3fc2c]
+    +             :             |     1 pysqlite_connection_init  (in libpython3.12.dylib) + 320  [0x10623ae88]
+    +             :             |       1 pysqlite_connection_init_impl  (in libpython3.12.dylib) + 200  [0x10623f44c]
+    +             :             |         1 sqlite3_open_v2  (in libpython3.12.dylib) + 48  [0x105e0c6e0]
+    +             :             |           1 openDatabase  (in libpython3.12.dylib) + 680  [0x105e0c244]
+    +             :             |             1 createCollation  (in libpython3.12.dylib) + 488  [0x105e0cadc]
+    +             :             |               1 sqlite3FindCollSeq  (in libpython3.12.dylib) + 56  [0x105e598f0]
+    +             :             |                 1 findCollSeqEntry  (in libpython3.12.dylib) + 100  [0x105e599a4]
+    +             :             |                   1 sqlite3DbMallocZero  (in libpython3.12.dylib) + 32  [0x105dffe54]
+    +             :             |                     1 sqlite3DbMallocRaw  (in libpython3.12.dylib) + 44  [0x105e048a0]
+    +             :             |                       1 sqlite3DbMallocRawNN  (in libpython3.12.dylib) + 120  [0x105e10a18]
+    +             :             |                         1 dbMallocRawFinish  (in libpython3.12.dylib) + 28  [0x105e10c78]
+    +             :             |                           1 sqlite3Malloc  (in libpython3.12.dylib) + 88  [0x105df3b8c]
+    +             :             |                             1 sqlite3_mutex_enter  (in libpython3.12.dylib) + 48  [0x105df2664]
+    +             :             |                               1 pthreadMutexEnter  (in libpython3.12.dylib) + 24  [0x105e1030c]
+    +             :             |                                 1 _pthread_mutex_firstfit_lock_slow  (in libsystem_pthread.dylib) + 216  [0x18a25e8e0]
+    +             :             |                                   1 _pthread_mutex_firstfit_lock_wait  (in libsystem_pthread.dylib) + 84  [0x18a260e9c]
+    +             :             |                                     1 __psynch_mutexwait  (in libsystem_kernel.dylib) + 8  [0x18a2229dc]
+    +             :             1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191256  [0x105935fb0]
+    +             :               1 pysqlite_connection_close_impl  (in libpython3.12.dylib) + 84  [0x10623ced0]
+    +             :                 1 connection_close  (in libpython3.12.dylib) + 72  [0x10623b384]
+    +             :                   1 PyEval_RestoreThread  (in libpython3.12.dylib) + 24  [0x105960544]
+    +             :                     1 take_gil.llvm.5578766886800543231  (in libpython3.12.dylib) + 20  [0x1059605c0]
+    +             6 partial_vectorcall  (in libpython3.12.dylib) + 556  [0x105a11468]
+    +               6 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+    +                 6 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+    +                   6 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+    +                     6 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+    +                       5 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+    +                       | 5 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+    +                       |   5 _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+    +                       |     5 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+    +                       |       5 bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+    +                       |         5 PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+    +                       |           5 pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+    +                       |             5 pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+    +                       |               5 sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+    +                       |                 5 sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+    +                       |                   5 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +                       |                     5 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +                       |                       5 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +                       |                         5 yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+    +                       |                           5 sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+    +                       |                             5 sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+    +                       |                               5 sqlite3InitOne  (in libpython3.12.dylib) + 1164  [0x105e486b8]
+    +                       |                                 4 sqlite3_exec  (in libpython3.12.dylib) + 740  [0x105dfa680]
+    +                       |                                 + 4 sqlite3InitCallback  (in libpython3.12.dylib) + 516  [0x105e48a58]
+    +                       |                                 +   4 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+    +                       |                                 +     4 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+    +                       |                                 +       1 sqlite3Parser  (in libpython3.12.dylib) + 84  [0x105e62620]
+    +                       |                                 +       ! 1 yy_find_shift_action  (in libpython3.12.dylib) + 12  [0x105e62928]
+    +                       |                                 +       1 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+    +                       |                                 +       ! 1 yy_reduce  (in libpython3.12.dylib) + 11968  [0x105e65b0c]
+    +                       |                                 +       !   1 sqlite3CreateIndex  (in libpython3.12.dylib) + 4408  [0x105e6a634]
+    +                       |                                 +       !     1 sqlite3HashInsert  (in libpython3.12.dylib) + 40  [0x105e59adc]
+    +                       |                                 +       !       1 findElementWithHash  (in libpython3.12.dylib) + 48  [0x105e59cb4]
+    +                       |                                 +       !         1 strHash  (in libpython3.12.dylib) + 28  [0x105e59dc4]
+    +                       |                                 +       1 sqlite3Parser  (in libpython3.12.dylib) + 288  [0x105e626ec]
+    +                       |                                 +       ! 1 yy_shift  (in libpython3.12.dylib) + 156  [0x105e6699c]
+    +                       |                                 +       1 yy_reduce  (in libpython3.12.dylib) + 15532  [0x105e668f8]
+    +                       |                                 1 sqlite3_exec  (in libpython3.12.dylib) + 288  [0x105dfa4bc]
+    +                       |                                   1 sqlite3_step  (in libpython3.12.dylib) + 104  [0x105dfa17c]
+    +                       |                                     1 sqlite3Step  (in libpython3.12.dylib) + 484  [0x105dff520]
+    +                       |                                       1 sqlite3VdbeExec  (in libpython3.12.dylib) + 11252  [0x105e39ea4]
+    +                       1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191256  [0x105935fb0]
+    +                         1 pysqlite_connection_close_impl  (in libpython3.12.dylib) + 84  [0x10623ced0]
+    +                           1 connection_close  (in libpython3.12.dylib) + 64  [0x10623b37c]
+    +                             1 sqlite3_close_v2  (in libpython3.12.dylib) + 28  [0x105e0a368]
+    +                               1 sqlite3Close  (in libpython3.12.dylib) + 352  [0x105e0a334]
+    +                                 1 sqlite3LeaveMutexAndCloseZombie  (in libpython3.12.dylib) + 168  [0x105dfce8c]
+    +                                   1 sqlite3BtreeClose  (in libpython3.12.dylib) + 164  [0x105e339c0]
+    +                                     1 sqlite3SchemaClear  (in libpython3.12.dylib) + 156  [0x105e4815c]
+    +                                       1 sqlite3DeleteTrigger  (in libpython3.12.dylib) + 100  [0x105df304c]
+    +                                         1 sqlite3DbFree  (in libpython3.12.dylib) + 44  [0x105df73f0]
+    +                                           1 sqlite3DbFreeNN  (in libpython3.12.dylib) + 232  [0x105e10858]
+    +                                             1 sqlite3_free  (in libpython3.12.dylib) + 16  [0x105df3c34]
+    3839 Thread_79471040
+      3839 thread_start  (in libsystem_pthread.dylib) + 8  [0x18a25ec1c]
+        3839 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x18a263c58]
+          3839 pythread_wrapper.llvm.14749647604360532379  (in libpython3.12.dylib) + 48  [0x106201ff0]
+            3839 thread_run  (in libpython3.12.dylib) + 188  [0x105a6283c]
+              3839 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+                3832 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 177044  [0x10593282c]
+                ! 3832 method_vectorcall_FASTCALL_KEYWORDS_METHOD.llvm.3960725272945190732  (in libpython3.12.dylib) + 136  [0x1058a8714]
+                !   3832 _queue_SimpleQueue_get  (in libpython3.12.dylib) + 220  [0x106233a44]
+                !     3831 _queue_SimpleQueue_get_impl  (in libpython3.12.dylib) + 232  [0x106233d88]
+                !     : 3831 PyThread_acquire_lock_timed  (in libpython3.12.dylib) + 440  [0x1059443c4]
+                !     :   3831 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x18a264128]
+                !     :     3831 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x18a22350c]
+                !     1 _queue_SimpleQueue_get_impl  (in libpython3.12.dylib) + 244  [0x106233d94]
+                !       1 PyEval_RestoreThread  (in libpython3.12.dylib) + 24  [0x105960544]
+                !         1 take_gil.llvm.5578766886800543231  (in libpython3.12.dylib) + 496  [0x10596079c]
+                !           1 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x18a264128]
+                !             1 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x18a22350c]
+                7 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 192132  [0x10593631c]
+                  5 _PyObject_MakeTpCall  (in libpython3.12.dylib) + 364  [0x1058953c4]
+                  : 5 partial_call  (in libpython3.12.dylib) + 92  [0x105a08af8]
+                  :   5 _PyVectorcall_Call.llvm.7333159498766099632  (in libpython3.12.dylib) + 152  [0x1058eb34c]
+                  :     5 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+                  :       5 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+                  :         5 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+                  :           5 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 172  [0x105b21bf4]
+                  :             4 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+                  :             | 4 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+                  :             |   4 _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+                  :             |     4 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+                  :             |       4 bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+                  :             |         4 PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+                  :             |           4 pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+                  :             |             4 pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+                  :             |               4 sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+                  :             |                 4 sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+                  :             |                   4 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+                  :             |                     4 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+                  :             |                       4 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+                  :             |                         4 yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+                  :             |                           4 sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+                  :             |                             4 sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+                  :             |                               3 sqlite3InitOne  (in libpython3.12.dylib) + 1164  [0x105e486b8]
+                  :             |                               + 2 sqlite3_exec  (in libpython3.12.dylib) + 740  [0x105dfa680]
+                  :             |                               + ! 2 sqlite3InitCallback  (in libpython3.12.dylib) + 516  [0x105e48a58]
+                  :             |                               + !   2 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+                  :             |                               + !     2 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+                  :             |                               + !       2 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+                  :             |                               + !         1 yy_reduce  (in libpython3.12.dylib) + 2136  [0x105e634a4]
+                  :             |                               + !         : 1 sqlite3AddPrimaryKey  (in libpython3.12.dylib) + 800  [0x105e694d0]
+                  :             |                               + !         :   1 sqlite3CreateIndex  (in libpython3.12.dylib) + 1248  [0x105e699dc]
+                  :             |                               + !         :     1 sqlite3MPrintf  (in libpython3.12.dylib) + 48  [0x105e02ac8]
+                  :             |                               + !         :       1 sqlite3VMPrintf  (in libpython3.12.dylib) + 104  [0x105e1a4d4]
+                  :             |                               + !         :         1 sqlite3StrAccumFinish  (in libpython3.12.dylib) + 100  [0x105df7548]
+                  :             |                               + !         :           1 strAccumFinishRealloc  (in libpython3.12.dylib) + 48  [0x105e10d78]
+                  :             |                               + !         :             1 sqlite3DbMallocRaw  (in libpython3.12.dylib) + 44  [0x105e048a0]
+                  :             |                               + !         :               1 sqlite3DbMallocRawNN  (in libpython3.12.dylib) + 120  [0x105e10a18]
+                  :             |                               + !         :                 1 dbMallocRawFinish  (in libpython3.12.dylib) + 28  [0x105e10c78]
+                  :             |                               + !         :                   1 sqlite3Malloc  (in libpython3.12.dylib) + 104  [0x105df3b9c]
+                  :             |                               + !         :                     1 mallocWithAlarm  (in libpython3.12.dylib) + 304  [0x105e10518]
+                  :             |                               + !         :                       1 sqlite3MemMalloc  (in libpython3.12.dylib) + 32  [0x105ee7e80]
+                  :             |                               + !         :                         1 _xzm_xzone_malloc_tiny  (in libsystem_malloc.dylib) + 40  [0x18a085efc]
+                  :             |                               + !         1 yy_reduce  (in libpython3.12.dylib) + 15456  [0x105e668ac]
+                  :             |                               + !           1 yy_find_reduce_action  (in libpython3.12.dylib) + 12  [0x105e7e8d0]
+                  :             |                               + 1 sqlite3_exec  (in libpython3.12.dylib) + 288  [0x105dfa4bc]
+                  :             |                               +   1 sqlite3_step  (in libpython3.12.dylib) + 104  [0x105dfa17c]
+                  :             |                               +     1 sqlite3Step  (in libpython3.12.dylib) + 484  [0x105dff520]
+                  :             |                               +       1 sqlite3VdbeExec  (in libpython3.12.dylib) + 27220  [0x105e3dd04]
+                  :             |                               +         1 sqlite3BtreeNext  (in libpython3.12.dylib) + 152  [0x105e44fa0]
+                  :             |                               +           1 btreeNext  (in libpython3.12.dylib) + 568  [0x105e4f138]
+                  :             |                               +             1 sqlite3BtreeNext  (in libpython3.12.dylib) + 152  [0x105e44fa0]
+                  :             |                               +               1 btreeNext  (in libpython3.12.dylib) + 400  [0x105e4f090]
+                  :             |                               +                 1 moveToChild  (in libpython3.12.dylib) + 200  [0x105e4c6a4]
+                  :             |                               +                   1 getAndInitPage  (in libpython3.12.dylib) + 112  [0x105e4c7d8]
+                  :             |                               +                     1 sqlite3PagerGet  (in libpython3.12.dylib) + 56  [0x105dfa87c]
+                  :             |                               +                       1 getPageNormal  (in libpython3.12.dylib) + 592  [0x105e233a0]
+                  :             |                               +                         1 readDbPage  (in libpython3.12.dylib) + 232  [0x105e23ad4]
+                  :             |                               +                           1 sqlite3OsRead  (in libpython3.12.dylib) + 60  [0x105e21f5c]
+                  :             |                               +                             1 unixRead  (in libpython3.12.dylib) + 260  [0x105e112a8]
+                  :             |                               +                               1 seekAndRead  (in libpython3.12.dylib) + 72  [0x105e13214]
+                  :             |                               +                                 1 pread  (in libsystem_kernel.dylib) + 8  [0x18a221650]
+                  :             |                               1 sqlite3InitOne  (in libpython3.12.dylib) + 396  [0x105e483b8]
+                  :             |                                 1 sqlite3BtreeBeginTrans  (in libpython3.12.dylib) + 104  [0x105dfbc1c]
+                  :             |                                   1 btreeBeginTrans  (in libpython3.12.dylib) + 552  [0x105e2a4e0]
+                  :             |                                     1 lockBtree  (in libpython3.12.dylib) + 32  [0x105e2a9e4]
+                  :             |                                       1 sqlite3PagerSharedLock  (in libpython3.12.dylib) + 796  [0x105e2b534]
+                  :             |                                         1 pagerOpenWalIfPresent  (in libpython3.12.dylib) + 188  [0x105e2baf8]
+                  :             |                                           1 sqlite3PagerOpenWal  (in libpython3.12.dylib) + 104  [0x105e2b6f4]
+                  :             |                                             1 pagerOpenWal  (in libpython3.12.dylib) + 116  [0x105e2bf90]
+                  :             |                                               1 sqlite3WalOpen  (in libpython3.12.dylib) + 252  [0x105e2c104]
+                  :             |                                                 1 sqlite3OsOpen  (in libpython3.12.dylib) + 76  [0x105e1c860]
+                  :             |                                                   1 unixOpen  (in libpython3.12.dylib) + 780  [0x105df8b48]
+                  :             |                                                     1 robust_open  (in libpython3.12.dylib) + 104  [0x105e15bd8]
+                  :             |                                                       1 posixOpen  (in libpython3.12.dylib) + 48  [0x105e18588]
+                  :             |                                                         1 open  (in libsystem_kernel.dylib) + 64  [0x18a22b8f0]
+                  :             |                                                           1 __open  (in libsystem_kernel.dylib) + 8  [0x18a220694]
+                  :             1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191256  [0x105935fb0]
+                  :               1 pysqlite_connection_close_impl  (in libpython3.12.dylib) + 84  [0x10623ced0]
+                  :                 1 connection_close  (in libpython3.12.dylib) + 64  [0x10623b37c]
+                  :                   1 sqlite3_close_v2  (in libpython3.12.dylib) + 28  [0x105e0a368]
+                  :                     1 sqlite3Close  (in libpython3.12.dylib) + 352  [0x105e0a334]
+                  :                       1 sqlite3LeaveMutexAndCloseZombie  (in libpython3.12.dylib) + 168  [0x105dfce8c]
+                  :                         1 sqlite3BtreeClose  (in libpython3.12.dylib) + 112  [0x105e3398c]
+                  :                           1 sqlite3PagerClose  (in libpython3.12.dylib) + 168  [0x105e1bfd4]
+                  :                             1 pager_reset  (in libpython3.12.dylib) + 56  [0x105e26d60]
+                  :                               1 sqlite3PcacheClear  (in libpython3.12.dylib) + 28  [0x105e270a8]
+                  :                                 1 sqlite3PcacheTruncate  (in libpython3.12.dylib) + 280  [0x105e266d4]
+                  :                                   1 pcache1Truncate  (in libpython3.12.dylib) + 64  [0x105ee87c8]
+                  :                                     1 pcache1TruncateUnsafe  (in libpython3.12.dylib) + 200  [0x105ee952c]
+                  2 partial_vectorcall  (in libpython3.12.dylib) + 556  [0x105a11468]
+                    2 cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+                      2 context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+                        2 _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+                          2 method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+                            1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 188440  [0x1059354b0]
+                            | 1 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+                            |   1 type_call  (in libpython3.12.dylib) + 148  [0x105b3fc2c]
+                            |     1 pysqlite_connection_init  (in libpython3.12.dylib) + 320  [0x10623ae88]
+                            |       1 pysqlite_connection_init_impl  (in libpython3.12.dylib) + 396  [0x10623f510]
+                            |         1 new_statement_cache  (in libpython3.12.dylib) + 144  [0x10623f6f8]
+                            |           1 PyObject_Vectorcall  (in libpython3.12.dylib) + 84  [0x1058fa954]
+                            |             1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 161580  [0x10592ebc4]
+                            1 _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+                              1 pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+                                1 _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+                                  1 PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+                                    1 bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+                                      1 PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+                                        1 pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+                                          1 pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+                                            1 sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+                                              1 sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+                                                1 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+                                                  1 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+                                                    1 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+                                                      1 yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+                                                        1 sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+                                                          1 sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+                                                            1 sqlite3InitOne  (in libpython3.12.dylib) + 1164  [0x105e486b8]
+                                                              1 sqlite3_exec  (in libpython3.12.dylib) + 740  [0x105dfa680]
+                                                                1 sqlite3InitCallback  (in libpython3.12.dylib) + 516  [0x105e48a58]
+                                                                  1 sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+                                                                    1 sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+                                                                      1 sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+                                                                        1 yy_reduce  (in libpython3.12.dylib) + 948  [0x105e63000]
+
+Total number in stack (recursive counted multiple, when >=5):
+        23       sqlite3Prepare  (in libpython3.12.dylib) + 748  [0x105e5a79c]
+        22       sqlite3RunParser  (in libpython3.12.dylib) + 740  [0x105e078dc]
+        21       sqlite3Parser  (in libpython3.12.dylib) + 236  [0x105e626b8]
+        15       _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191600  [0x105936108]
+        14       PyObject_Vectorcall  (in libpython3.12.dylib) + 424  [0x1058faaa8]
+        14       method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 356  [0x105b21cac]
+        13       _PyObject_VectorcallTstate  (in libpython3.12.dylib) + 68  [0x1061f05f8]
+        13       cfunction_vectorcall_FASTCALL_KEYWORDS.llvm.5662885461150521209  (in libpython3.12.dylib) + 92  [0x105b3828c]
+        13       context_run  (in libpython3.12.dylib) + 156  [0x1061f04d8]
+        13       pysqlite_connection_execute_impl  (in libpython3.12.dylib) + 60  [0x10623df20]
+        12       PyObject_Call  (in libpython3.12.dylib) + 140  [0x1058eb1d8]
+        12       _pysqlite_query_execute  (in libpython3.12.dylib) + 220  [0x10623f8b4]
+        12       bounded_lru_cache_wrapper  (in libpython3.12.dylib) + 284  [0x105a15988]
+        12       pysqlite_connection_call  (in libpython3.12.dylib) + 116  [0x10623b0a0]
+        12       pysqlite_statement_create  (in libpython3.12.dylib) + 184  [0x106242b64]
+        12       sqlite3Init  (in libpython3.12.dylib) + 116  [0x105e0d448]
+        12       sqlite3LockAndPrepare  (in libpython3.12.dylib) + 156  [0x105e05528]
+        12       sqlite3ReadSchema  (in libpython3.12.dylib) + 64  [0x105e5f160]
+        12       sqlite3_prepare_v2  (in libpython3.12.dylib) + 64  [0x105dfa100]
+        12       yy_reduce  (in libpython3.12.dylib) + 2556  [0x105e63648]
+        11       sqlite3InitCallback  (in libpython3.12.dylib) + 516  [0x105e48a58]
+        11       sqlite3InitOne  (in libpython3.12.dylib) + 1164  [0x105e486b8]
+        11       sqlite3_exec  (in libpython3.12.dylib) + 740  [0x105dfa680]
+        10       _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 192132  [0x10593631c]
+        10       method_vectorcall.llvm.11532218367111411510  (in libpython3.12.dylib) + 172  [0x105b21bf4]
+        8       _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 177044  [0x10593282c]
+        7       _PyObject_MakeTpCall  (in libpython3.12.dylib) + 364  [0x1058953c4]
+        7       __psynch_cvwait  (in libsystem_kernel.dylib) + 0  [0x18a223504]
+        7       _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x18a264128]
+        6       PyThread_acquire_lock_timed  (in libpython3.12.dylib) + 440  [0x1059443c4]
+        6       _PyVectorcall_Call.llvm.7333159498766099632  (in libpython3.12.dylib) + 152  [0x1058eb34c]
+        6       _pthread_start  (in libsystem_pthread.dylib) + 136  [0x18a263c58]
+        6       _queue_SimpleQueue_get  (in libpython3.12.dylib) + 220  [0x106233a44]
+        6       _queue_SimpleQueue_get_impl  (in libpython3.12.dylib) + 232  [0x106233d88]
+        6       method_vectorcall_FASTCALL_KEYWORDS_METHOD.llvm.3960725272945190732  (in libpython3.12.dylib) + 136  [0x1058a8714]
+        6       partial_call  (in libpython3.12.dylib) + 92  [0x105a08af8]
+        6       partial_vectorcall  (in libpython3.12.dylib) + 556  [0x105a11468]
+        6       pythread_wrapper.llvm.14749647604360532379  (in libpython3.12.dylib) + 48  [0x106201ff0]
+        6       thread_run  (in libpython3.12.dylib) + 188  [0x105a6283c]
+        6       thread_start  (in libsystem_pthread.dylib) + 8  [0x18a25ec1c]
+        5       _PyEval_EvalFrameDefault  (in libpython3.12.dylib) + 191256  [0x105935fb0]
+        5       sqlite3Step  (in libpython3.12.dylib) + 484  [0x105dff520]
+        5       sqlite3_step  (in libpython3.12.dylib) + 104  [0x105dfa17c]
+        5       yy_reduce  (in libpython3.12.dylib) + 11968  [0x105e65b0c]
+
+Sort by top of stack, same collapsed (when >= 5):
+        __psynch_cvwait  (in libsystem_kernel.dylib)        21366
+        kevent  (in libsystem_kernel.dylib)        3823
+        sqlite3VdbeExec  (in libpython3.12.dylib)        837
+        pread  (in libsystem_kernel.dylib)        152
+        sqlite3VdbeSerialGet  (in libpython3.12.dylib)        119
+        fetchPayload  (in libpython3.12.dylib)        89
+        btreeParseCellPtrIndex  (in libpython3.12.dylib)        76
+        btreeParseCell  (in libpython3.12.dylib)        62
+        sqlite3BtreePayloadSize  (in libpython3.12.dylib)        36
+        sqlite3BtreeNext  (in libpython3.12.dylib)        35
+        getCellInfo  (in libpython3.12.dylib)        33
+        vdbeRecordCompareString  (in libpython3.12.dylib)        33
+        sqlite3BtreePayloadFetch  (in libpython3.12.dylib)        28
+        sqlite3VdbeOneByteSerialTypeLen  (in libpython3.12.dylib)        26
+        sqlite3BtreeCursorHasMoved  (in libpython3.12.dylib)        16
+        sqlite3BtreeIndexMoveto  (in libpython3.12.dylib)        15
+        pcache1RemoveFromHash  (in libpython3.12.dylib)        11
+        btreeInitPage  (in libpython3.12.dylib)        9
+        _platform_memcmp  (in libsystem_platform.dylib)        8
+        _PyEval_EvalFrameDefault  (in libpython3.12.dylib)        6
+        pcache1FetchNoMutex  (in libpython3.12.dylib)        5
+        sqlite3PcacheFetchFinish  (in libpython3.12.dylib)        5
+        sqlite3PcacheRelease  (in libpython3.12.dylib)        5
+
+Binary Images:
+       0x104168000 -        0x10416965f +python3.12 (???) <4C4C44CD-5555-3144-A15B-808AB780177D> /Users/*/python3.12
+       0x10459c000 -        0x10459ffff +cd.cpython-312-darwin.so (0) <F58B75CC-61E0-37AD-9E9F-BE9DDF2CC747> /Users/*/cd.cpython-312-darwin.so
+       0x1049cc000 -        0x1049d99b7 +_greenlet.cpython-312-darwin.so (0) <A800E6DB-0A4D-3E0C-94FB-6A66633BFC17> /Users/*/_greenlet.cpython-312-darwin.so
+       0x1057a0000 -        0x1057a7ffb +_pybase64.cpython-312-darwin.so (0) <5D763726-2440-3B69-AB18-EDAFED487584> /Users/*/_pybase64.cpython-312-darwin.so
+       0x1057b4000 -        0x1057bbfff +_check_build.cpython-312-darwin.so (0) <254E052E-E2CB-3911-A75B-012F02CA14B6> /Users/*/_check_build.cpython-312-darwin.so
+       0x1057c8000 -        0x1057dfff3 +_umath_linalg.cpython-312-darwin.so (0) <F38844C2-35CB-3BAF-BC47-142D6F717A99> /Users/*/_umath_linalg.cpython-312-darwin.so
+       0x105800000 -        0x10583d303 +_yaml.cpython-312-darwin.so (0) <0E39AAA2-304D-366C-A868-6484D55AEDA5> /Users/*/_yaml.cpython-312-darwin.so
+       0x105860000 -        0x105863fff +_zeros.cpython-312-darwin.so (0) <951DBD39-CD91-3EBF-B1C3-7EFB77BB839B> /Users/*/_zeros.cpython-312-darwin.so
+       0x105878000 -        0x105883ffb +_sfc64.cpython-312-darwin.so (0) <4C391512-EB09-387A-9A56-27ED9411CF5E> /Users/*/_sfc64.cpython-312-darwin.so
+       0x105890000 -        0x10662a9cf +libpython3.12.dylib (3.12) <4C4C443C-5555-3144-A10C-9E4A95FAA910> /Users/*/libpython3.12.dylib
+       0x10b020000 -        0x10b028d93 +_psutil_osx.abi3.so (0) <9F38D1A0-1AF2-3062-9683-0E0D0AF4A252> /Users/*/_psutil_osx.abi3.so
+       0x10b03c000 -        0x10b04bffb +_ccallback_c.cpython-312-darwin.so (0) <72F6E3DE-B829-3031-A8C4-D60749993E3D> /Users/*/_ccallback_c.cpython-312-darwin.so
+       0x10b060000 -        0x10b09093f +orjson.cpython-312-darwin.so (0) <709CD51C-F84A-3530-9D14-621076E6F81F> /Users/*/orjson.cpython-312-darwin.so
+       0x10b0a4000 -        0x10b38ffff +_multiarray_umath.cpython-312-darwin.so (0) <74854C40-4756-36AF-95AE-5A447F08178B> /Users/*/_multiarray_umath.cpython-312-darwin.so
+       0x10b77c000 -        0x10b797ffb +_cyutility.cpython-312-darwin.so (0) <8E4A78FD-968F-3283-A12B-6CEA013DB18B> /Users/*/_cyutility.cpython-312-darwin.so
+       0x10b7a8000 -        0x10b7c7ff3 +bit_generator.cpython-312-darwin.so (0) <AFACEE4E-FF25-3AE4-B453-51F74B287296> /Users/*/bit_generator.cpython-312-darwin.so
+       0x10b7d8000 -        0x10b7dfffb +_comb.cpython-312-darwin.so (0) <6141F4F5-AD3C-3170-A679-698C331D564A> /Users/*/_comb.cpython-312-darwin.so
+       0x10b7f0000 -        0x10b827fff +_bounded_integers.cpython-312-darwin.so (0) <0BE4393F-A567-3574-86BE-4E7AACDA15C6> /Users/*/_bounded_integers.cpython-312-darwin.so
+       0x10b83c000 -        0x10bbec947 +_pydantic_core.cpython-312-darwin.so (0) <96E03A30-CCC5-3D72-AEDC-95D70BCE0CF8> /Users/*/_pydantic_core.cpython-312-darwin.so
+       0x10bd38000 -        0x10bdd3f77 +rpds.cpython-312-darwin.so (0) <AA48033F-39C8-3423-9C27-C62B5CFD7AE8> /Users/*/rpds.cpython-312-darwin.so
+       0x10c018000 -        0x10c0afff7 +backend_c.cpython-312-darwin.so (0) <03EB4A23-6419-392C-B931-04296BA20077> /Users/*/backend_c.cpython-312-darwin.so
+       0x10e8a4000 -        0x10e8dbff3 +_message.abi3.so (0) <8710AF96-7C77-3EB6-B196-0BB7C1B96F7D> /Users/*/_message.abi3.so
+       0x10e9f8000 -        0x10ea0bfff +_pcg64.cpython-312-darwin.so (0) <3B3A0800-2E70-35A4-BE36-F8754032DD9A> /Users/*/_pcg64.cpython-312-darwin.so
+       0x10ea1c000 -        0x10ea23ff7 +_matfuncs_schur_sqrtm.cpython-312-darwin.so (0) <BAEA7ABB-BB07-3382-B718-CD949992EFA1> /Users/*/_matfuncs_schur_sqrtm.cpython-312-darwin.so
+       0x10ea34000 -        0x10ea5ffff +_common.cpython-312-darwin.so (0) <8FB1C53B-0BF9-3D3B-9E2D-84CE8B3D2F00> /Users/*/_common.cpython-312-darwin.so
+       0x10ea70000 -        0x10ea83fff +_mt19937.cpython-312-darwin.so (0) <33CB37A1-6141-3D43-B8BE-DAADE1CFD201> /Users/*/_mt19937.cpython-312-darwin.so
+       0x10ea94000 -        0x10eaa3ffb +_philox.cpython-312-darwin.so (0) <75205A2A-0BBD-3D7E-A1E4-10B1A2C0A79B> /Users/*/_philox.cpython-312-darwin.so
+       0x10eab8000 -        0x10f4237d7 +cygrpc.cpython-312-darwin.so (0) <10B17AE6-2006-338D-9FCB-A2AAB7AC2EE5> /Users/*/cygrpc.cpython-312-darwin.so
+       0x1100cc000 -        0x110107ff7 +81d243bd2c585b0f4821__mypyc.cpython-312-darwin.so (0) <2B27BB3A-6C61-3DE1-B7BA-9DA79CDA70B1> /Users/*/81d243bd2c585b0f4821__mypyc.cpython-312-darwin.so
+       0x110128000 -        0x110133fff +messagestream.cpython-312-darwin.so (0) <0150F4CF-0A6E-34A2-B202-B8774DB0908E> /Users/*/messagestream.cpython-312-darwin.so
+       0x110144000 -        0x110153ffb +_ellip_harm_2.cpython-312-darwin.so (0) <F3C5AF6F-3D4A-3366-9595-BB5271E76FEC> /Users/*/_ellip_harm_2.cpython-312-darwin.so
+       0x11016c000 -        0x1101f7ff7 +_generator.cpython-312-darwin.so (0) <E6FFD0AC-0598-3D5B-A23D-D22E66F8916E> /Users/*/_generator.cpython-312-darwin.so
+       0x110210000 -        0x11027ffff +mtrand.cpython-312-darwin.so (0) <93E4E74B-AE8D-3EFB-A198-310571032F00> /Users/*/mtrand.cpython-312-darwin.so
+       0x110394000 -        0x1103d3fff +_pocketfft_umath.cpython-312-darwin.so (0) <8B8DD0F1-38D5-306D-864A-7883048AEB08> /Users/*/_pocketfft_umath.cpython-312-darwin.so
+       0x1107e8000 -        0x1107f7ff3 +_decomp_lu_cython.cpython-312-darwin.so (0) <352447E0-0CAC-3D66-B3A4-B9D69D1A2EBB> /Users/*/_decomp_lu_cython.cpython-312-darwin.so
+       0x110804000 -        0x11080bfff +_lbfgsb.cpython-312-darwin.so (0) <784AF47C-4767-3BC1-8766-A46DC4CBDF3B> /Users/*/_lbfgsb.cpython-312-darwin.so
+       0x110818000 -        0x110837fff +_specfun.cpython-312-darwin.so (0) <B08C3F84-254F-36E8-967C-09FF3BFD7EAE> /Users/*/_specfun.cpython-312-darwin.so
+       0x11084c000 -        0x11089fff3 +_csparsetools.cpython-312-darwin.so (0) <23BF1040-5516-3D24-BFB5-78E34CC0F2B2> /Users/*/_csparsetools.cpython-312-darwin.so
+       0x110ab0000 -        0x110abfff3 +_solve_toeplitz.cpython-312-darwin.so (0) <C8F9C9DF-D423-379A-8347-A0F2BFFD2714> /Users/*/_solve_toeplitz.cpython-312-darwin.so
+       0x110ad0000 -        0x110ae3fff +_batched_linalg.cpython-312-darwin.so (0) <ACC675FD-B88B-3ADB-8F63-7EAFBA92B886> /Users/*/_batched_linalg.cpython-312-darwin.so
+       0x110af4000 -        0x110b27fff +_cythonized_array_utils.cpython-312-darwin.so (0) <5572E46D-90E8-3B12-B8B9-6E7F1C814900> /Users/*/_cythonized_array_utils.cpython-312-darwin.so
+       0x110b38000 -        0x110b47fff +_matfuncs_expm.cpython-312-darwin.so (0) <59683E16-6389-3AB8-9A1E-713D86DA50A3> /Users/*/_matfuncs_expm.cpython-312-darwin.so
+       0x110b5c000 -        0x110e5bff7 +_sparsetools.cpython-312-darwin.so (0) <94B11BE2-81BA-3D2E-94EC-43984831CC29> /Users/*/_sparsetools.cpython-312-darwin.so
+       0x1110d0000 -        0x111167fff +_ufuncs.cpython-312-darwin.so (0) <E81339C1-8810-328C-8DCB-670B8184FBE2> /Users/*/_ufuncs.cpython-312-darwin.so
+       0x111180000 -        0x1111dbff3 +_gufuncs.cpython-312-darwin.so (0) <0C747137-1DB7-3849-B296-B87527B18F0F> /Users/*/_gufuncs.cpython-312-darwin.so
+       0x11121c000 -        0x11126bffa +_fblas.cpython-312-darwin.so (0) <AE7B2A98-EC77-3E2D-B8A1-E6987053EE28> /Users/*/_fblas.cpython-312-darwin.so
+       0x1112a4000 -        0x1112afff7 +_voronoi.cpython-312-darwin.so (0) <D550D3FE-44CE-3119-ACC2-6EF0448AAE7A> /Users/*/_voronoi.cpython-312-darwin.so
+       0x1112bc000 -        0x1112bfff3 +_rank_filter_1d.cpython-312-darwin.so (0) <9D02C5F8-BFAF-3DEA-972A-2B249B0E9DB4> /Users/*/_rank_filter_1d.cpython-312-darwin.so
+       0x1112cc000 -        0x1113bbfff +_ufuncs_cxx.cpython-312-darwin.so (0) <14C91942-4F0F-3683-B96C-3DFEABB07C70> /Users/*/_ufuncs_cxx.cpython-312-darwin.so
+       0x111418000 -        0x1114ffffb +_special_ufuncs.cpython-312-darwin.so (0) <E84F0F8D-C21C-386D-AE67-16D18B6D8693> /Users/*/_special_ufuncs.cpython-312-darwin.so
+       0x111730000 -        0x111747fff +_linalg_pythran.cpython-312-darwin.so (0) <806EF9B9-A55F-34FF-BEEC-A2A49005E34F> /Users/*/_linalg_pythran.cpython-312-darwin.so
+       0x111754000 -        0x111763ffb +cython_blas.cpython-312-darwin.so (0) <10ABC5A4-FA07-35EB-854F-57731C8176D7> /Users/*/cython_blas.cpython-312-darwin.so
+       0x111778000 -        0x11177ffff +_slsqplib.cpython-312-darwin.so (0) <E2B218D9-73CD-3A6C-B3AD-D5E7DDFC4B09> /Users/*/_slsqplib.cpython-312-darwin.so
+       0x11178c000 -        0x1117abffb +cython_lapack.cpython-312-darwin.so (0) <BCB19869-C58E-32A3-A792-3D16C291F3A8> /Users/*/cython_lapack.cpython-312-darwin.so
+       0x1117e8000 -        0x1117fffff +_propack.cpython-312-darwin.so (0) <78CB23F3-CB7D-32F0-867E-22CADFB7DA2A> /Users/*/_propack.cpython-312-darwin.so
+       0x11180c000 -        0x111817fff +_hausdorff.cpython-312-darwin.so (0) <BFF5AB09-6BB7-393F-B382-7F9BE37DB636> /Users/*/_hausdorff.cpython-312-darwin.so
+       0x111824000 -        0x11184ffff +_decomp_update.cpython-312-darwin.so (0) <6665B969-2A14-36D6-ACDB-A37C1A738BE3> /Users/*/_decomp_update.cpython-312-darwin.so
+       0x111860000 -        0x11187fffb +_arpacklib.cpython-312-darwin.so (0) <45039B6B-E67C-3FCD-BBA0-87136AFE0CF9> /Users/*/_arpacklib.cpython-312-darwin.so
+       0x11188c000 -        0x111897fff +_group_columns.cpython-312-darwin.so (0) <77302A56-BFDF-3E2F-9732-0D4164938C1C> /Users/*/_group_columns.cpython-312-darwin.so
+       0x1118a8000 -        0x1118dfff7 +_superlu.cpython-312-darwin.so (0) <ABFB1D9F-2F00-3410-8535-5157C1E89032> /Users/*/_superlu.cpython-312-darwin.so
+       0x1118fc000 -        0x111a0bfff +_flapack.cpython-312-darwin.so (0) <0863D4FC-1117-321E-AD34-7D3A8527CDC9> /Users/*/_flapack.cpython-312-darwin.so
+       0x111bc8000 -        0x111bd7ff7 +_distance_wrap.cpython-312-darwin.so (0) <36C855A6-078D-3D81-9D0E-31EE4FDFD4FC> /Users/*/_distance_wrap.cpython-312-darwin.so
+       0x111be4000 -        0x111bebffb +givens_elimination.cpython-312-darwin.so (0) <01D5E6FF-3E9D-3F14-A827-C6A36723AC22> /Users/*/givens_elimination.cpython-312-darwin.so
+       0x111bf8000 -        0x111bfbfff +_heap.cpython-312-darwin.so (0) <7AF964CF-B8FC-3EE0-97FB-534A7D4282F7> /Users/*/_heap.cpython-312-darwin.so
+       0x111c14000 -        0x111c33ffb +_trlib.cpython-312-darwin.so (0) <4A7C8698-CDA4-3591-9173-30530A523614> /Users/*/_trlib.cpython-312-darwin.so
+       0x111c48000 -        0x111cafffb +_ckdtree.cpython-312-darwin.so (0) <95A61D62-3E59-3135-A764-CE9541954CCF> /Users/*/_ckdtree.cpython-312-darwin.so
+       0x111cc8000 -        0x111cefff7 +_rigid_transform_cy.cpython-312-darwin.so (0) <FFBFA347-CF35-39C4-85AB-0C83C3213ADD> /Users/*/_rigid_transform_cy.cpython-312-darwin.so
+       0x111d28000 -        0x111d3fff7 +_moduleTNC.cpython-312-darwin.so (0) <9AEA891C-5D8A-3B23-8509-6159AAD3EBB4> /Users/*/_moduleTNC.cpython-312-darwin.so
+       0x111d4c000 -        0x111d5bff7 +_minpack.cpython-312-darwin.so (0) <9EA9BA0E-5B98-3179-A3A4-BC56C317E713> /Users/*/_minpack.cpython-312-darwin.so
+       0x111d68000 -        0x111d6bfff +_partition_nodes.cpython-312-darwin.so (0) <D804646B-4B7B-36F8-B90B-209C563A0D12> /Users/*/_partition_nodes.cpython-312-darwin.so
+       0x111d78000 -        0x111e13ff7 +_qhull.cpython-312-darwin.so (0) <39821C33-7785-3BDF-97EC-19C2B39FAAC8> /Users/*/_qhull.cpython-312-darwin.so
+       0x111e28000 -        0x111e7bffb +_rotation_cy.cpython-312-darwin.so (0) <C16AD39E-CF78-3407-A950-C076E9E011F1> /Users/*/_rotation_cy.cpython-312-darwin.so
+       0x111e8c000 -        0x111e93ff3 +_lsap.cpython-312-darwin.so (0) <27D4DB6C-2B0A-3584-B329-7B8E754BC6C9> /Users/*/_lsap.cpython-312-darwin.so
+       0x111ea0000 -        0x111ea7ff7 +_direct.cpython-312-darwin.so (0) <D22217F8-CF56-3A24-A1E9-61C95CC673CC> /Users/*/_direct.cpython-312-darwin.so
+       0x111eb4000 -        0x111f17ff7 +_distance_pybind.cpython-312-darwin.so (0) <401F6E27-3DD2-3FE4-A075-B810DC7E3BEC> /Users/*/_distance_pybind.cpython-312-darwin.so
+       0x112140000 -        0x11214fff3 +_uarray.cpython-312-darwin.so (0) <FBD84C31-09E1-35D6-8141-D8A384F1385B> /Users/*/_uarray.cpython-312-darwin.so
+       0x112160000 -        0x11216bff7 +_odepack.cpython-312-darwin.so (0) <BCC2A49C-1795-3C97-9E90-A28168E5175F> /Users/*/_odepack.cpython-312-darwin.so
+       0x112178000 -        0x112187fff +_quadpack.cpython-312-darwin.so (0) <2A17F19E-79CE-3D97-AC4C-188B7EB5FF46> /Users/*/_quadpack.cpython-312-darwin.so
+       0x1121a4000 -        0x1121e7ff3 +_highs_options.cpython-312-darwin.so (0) <211721F4-45EE-3A75-8B5A-DB23E3EF3EC1> /Users/*/_highs_options.cpython-312-darwin.so
+       0x112208000 -        0x112223ffb +_bglu_dense.cpython-312-darwin.so (0) <D3163FD7-6F79-3113-BD33-211123FFF8BF> /Users/*/_bglu_dense.cpython-312-darwin.so
+       0x112234000 -        0x112253ffb +_pava_pybind.cpython-312-darwin.so (0) <04DB73C5-8A6A-397B-88EB-4AAB95242887> /Users/*/_pava_pybind.cpython-312-darwin.so
+       0x11226c000 -        0x112277fff +_dop.cpython-312-darwin.so (0) <63E0CC3F-AAE0-3D35-AEB6-1E1BBF6EC745> /Users/*/_dop.cpython-312-darwin.so
+       0x112290000 -        0x112307ffb +_decomp_interpolative.cpython-312-darwin.so (0) <9BBF0C51-623C-347B-9721-1B163FA09210> /Users/*/_decomp_interpolative.cpython-312-darwin.so
+       0x112418000 -        0x11242bfff +_vode.cpython-312-darwin.so (0) <A3A98F4F-8184-390B-AE72-B92E0842BF7C> /Users/*/_vode.cpython-312-darwin.so
+       0x112438000 -        0x112447ff7 +_dierckx.cpython-312-darwin.so (0) <CCA67C78-748E-3099-8850-9ACF3D88A409> /Users/*/_dierckx.cpython-312-darwin.so
+       0x112458000 -        0x112467fff +_fitpack.cpython-312-darwin.so (0) <0931C750-7DE1-37DD-8479-8EA1415D91D6> /Users/*/_fitpack.cpython-312-darwin.so
+       0x112478000 -        0x11247fffb +levyst.cpython-312-darwin.so (0) <0F13B82F-6770-39E6-9499-C6540A90B9BE> /Users/*/levyst.cpython-312-darwin.so
+       0x11248c000 -        0x11249bfff +_ansari_swilk_statistics.cpython-312-darwin.so (0) <0F22A72C-4DBF-3AEB-85BA-54E0174E6BD9> /Users/*/_ansari_swilk_statistics.cpython-312-darwin.so
+       0x1124a8000 -        0x1124b7fff +libgcc_s.1.1.dylib (0) <CC460BEA-9872-3F83-8668-C69259E63B43> /Users/*/libgcc_s.1.1.dylib
+       0x1124d4000 -        0x1124e3ffb +_rgi_cython.cpython-312-darwin.so (0) <D4A7278B-C792-32CA-A2F2-871BB11ECB37> /Users/*/_rgi_cython.cpython-312-darwin.so
+       0x112500000 -        0x1125a7ff7 +pypocketfft.cpython-312-darwin.so (0) <8F290DDF-D92F-3500-9B27-66EAB959BADA> /Users/*/pypocketfft.cpython-312-darwin.so
+       0x1125e8000 -        0x112627fff +libquadmath.0.dylib (0) <13842585-89B5-3A2B-9482-99F7B4DDE5BD> /Users/*/libquadmath.0.dylib
+       0x112650000 -        0x112a27ff7 +_core.cpython-312-darwin.so (0) <098893F3-3471-3910-BE14-FCAC0D161813> /Users/*/_core.cpython-312-darwin.so
+       0x112d78000 -        0x112d8fffb +_biasedurn.cpython-312-darwin.so (0) <09932CEA-5E2C-3263-8F01-AD354634B757> /Users/*/_biasedurn.cpython-312-darwin.so
+       0x112da4000 -        0x112db3ffb +_min_spanning_tree.cpython-312-darwin.so (0) <9F3BA21F-164E-30B4-B6C5-B15A70AAC20D> /Users/*/_min_spanning_tree.cpython-312-darwin.so
+       0x112dc8000 -        0x112dfffff +_dfitpack.cpython-312-darwin.so (0) <21DACAAB-EBDE-3824-9A04-8C6B3155A46E> /Users/*/_dfitpack.cpython-312-darwin.so
+       0x112e18000 -        0x112e3bff7 +_ppoly.cpython-312-darwin.so (0) <9E2AC5F2-62EA-33B0-80EB-7F9F50150C39> /Users/*/_ppoly.cpython-312-darwin.so
+       0x112e4c000 -        0x112e6ffff +_interpnd.cpython-312-darwin.so (0) <9685B395-B8FA-3D68-A223-34BB8F9C60C8> /Users/*/_interpnd.cpython-312-darwin.so
+       0x112e80000 -        0x112ebbff7 +_rbfinterp_pythran.cpython-312-darwin.so (0) <08187CE6-D5E9-3A33-80DA-524158BE770D> /Users/*/_rbfinterp_pythran.cpython-312-darwin.so
+       0x112ecc000 -        0x112eebfff +_stats_pythran.cpython-312-darwin.so (0) <BCCAEC45-1A21-312F-9FF3-D1CF308A7870> /Users/*/_stats_pythran.cpython-312-darwin.so
+       0x112efc000 -        0x112f07fff +rcont.cpython-312-darwin.so (0) <B2077C3B-0C59-31F1-8558-C781FB81C681> /Users/*/rcont.cpython-312-darwin.so
+       0x112f24000 -        0x112f3bffb +_reordering.cpython-312-darwin.so (0) <8B89EFCE-4A79-33DF-9EDD-3CF580729A72> /Users/*/_reordering.cpython-312-darwin.so
+       0x112f4c000 -        0x11309ffff +libgfortran.5.dylib (0) <18BCCF8F-B816-387F-BAAB-97018C5046CB> /Users/*/libgfortran.5.dylib
+       0x113120000 -        0x11316fffb +_stats.cpython-312-darwin.so (0) <8C65DF61-E78A-3AA8-83F4-5F4D638F8AD6> /Users/*/_stats.cpython-312-darwin.so
+       0x113280000 -        0x11329bff3 +_tools.cpython-312-darwin.so (0) <64882C40-CC32-3E2B-BEF9-130D97D38407> /Users/*/_tools.cpython-312-darwin.so
+       0x1132ac000 -        0x1132e3ffb +_traversal.cpython-312-darwin.so (0) <8348B84C-41F8-3BE1-9F82-6AC7DA2B235C> /Users/*/_traversal.cpython-312-darwin.so
+       0x1132f4000 -        0x11330ffff +_flow.cpython-312-darwin.so (0) <DCC60CCE-EAB6-3EF9-83EC-543ED5659245> /Users/*/_flow.cpython-312-darwin.so
+       0x113320000 -        0x11348bff7 +cython_special.cpython-312-darwin.so (0) <B6CFE2B9-B3E2-3032-B331-0DD1CD788C05> /Users/*/cython_special.cpython-312-darwin.so
+       0x1136c0000 -        0x113703ff7 +_shortest_path.cpython-312-darwin.so (0) <1AE7E33D-818F-3E62-814D-6131B859EDAE> /Users/*/_shortest_path.cpython-312-darwin.so
+       0x113718000 -        0x113733fff +_matching.cpython-312-darwin.so (0) <A1436FB6-96AB-3BEA-9DD4-D4A252866F58> /Users/*/_matching.cpython-312-darwin.so
+       0x113744000 -        0x113753ffb +_qmc_cy.cpython-312-darwin.so (0) <CE31458F-27AF-3878-9FA2-5966A4CB6D92> /Users/*/_qmc_cy.cpython-312-darwin.so
+       0x113770000 -        0x11378bfff +_sobol.cpython-312-darwin.so (0) <60979E2C-6459-3833-98F9-8743410070B9> /Users/*/_sobol.cpython-312-darwin.so
+       0x11389c000 -        0x1138a144f +pandas_parser.cpython-312-darwin.so (0) <E6F1F773-1C6A-35AF-B801-9ED4B07FFE2D> /Users/*/pandas_parser.cpython-312-darwin.so
+       0x1138c0000 -        0x1138d3fff +_qmvnt_cy.cpython-312-darwin.so (0) <39A3AD3D-3A2E-3F6F-A7FD-C1ADE06988AF> /Users/*/_qmvnt_cy.cpython-312-darwin.so
+       0x1139e4000 -        0x1139ea957 +pandas_datetime.cpython-312-darwin.so (0) <F5FD0573-3583-3CC0-B02F-F112084DFFC5> /Users/*/pandas_datetime.cpython-312-darwin.so
+       0x1139f8000 -        0x1139ff7b7 +ops_dispatch.cpython-312-darwin.so (0) <388B46C3-3754-32EE-8920-FDA608CECDD4> /Users/*/ops_dispatch.cpython-312-darwin.so
+       0x113a0c000 -        0x113a27ffb +_nd_image.cpython-312-darwin.so (0) <81B68E63-0AC4-342B-90E6-3420F135F094> /Users/*/_nd_image.cpython-312-darwin.so
+       0x113a34000 -        0x113a3fec3 +ccalendar.cpython-312-darwin.so (0) <76A3A68E-8357-312A-AF82-6A0844FDDCFB> /Users/*/ccalendar.cpython-312-darwin.so
+       0x113a84000 -        0x113aa3ff7 +_ni_label.cpython-312-darwin.so (0) <ED8C49A1-D56C-3EED-BE2B-DDE8A8B21C3E> /Users/*/_ni_label.cpython-312-darwin.so
+       0x113ab4000 -        0x113ad1aff +missing.cpython-312-darwin.so (0) <2A3E3ECD-6ABD-3B32-BA6C-8A147057A627> /Users/*/missing.cpython-312-darwin.so
+       0x113ae4000 -        0x113afc27f +dtypes.cpython-312-darwin.so (0) <2939BC83-A774-3FEC-A8FF-B8E3800E165E> /Users/*/dtypes.cpython-312-darwin.so
+       0x113b10000 -        0x113b17f1f +base.cpython-312-darwin.so (0) <2C4667D0-9C33-30F4-BDF2-9BCB79235A59> /Users/*/base.cpython-312-darwin.so
+       0x113b28000 -        0x113b2fffb +_dbscan_inner.cpython-312-darwin.so (0) <6685E498-D4F5-3071-AFAC-6F77AB903CC9> /Users/*/_dbscan_inner.cpython-312-darwin.so
+       0x113b3c000 -        0x113b56dc7 +_cyutility.cpython-312-darwin.so (0) <16F9743C-D0EB-3DEA-B8A8-8CC90F5CE37A> /Users/*/_cyutility.cpython-312-darwin.so
+       0x113b68000 -        0x113b7cde3 +np_datetime.cpython-312-darwin.so (0) <A872DBA7-6483-3270-9A9C-C7472C462BCE> /Users/*/np_datetime.cpython-312-darwin.so
+       0x113b90000 -        0x113b9ae37 +properties.cpython-312-darwin.so (0) <85517317-2A4A-313D-8D52-B13D8EB8E01B> /Users/*/properties.cpython-312-darwin.so
+       0x113bac000 -        0x113c624b7 +interval.cpython-312-darwin.so (0) <943E1E9A-7E76-35B5-939C-B038E7D6D608> /Users/*/interval.cpython-312-darwin.so
+       0x113da4000 -        0x113dbddff +conversion.cpython-312-darwin.so (0) <A4811ADB-BD25-391F-8DBC-8A0D707B3F4D> /Users/*/conversion.cpython-312-darwin.so
+       0x113dd0000 -        0x113ddaaf3 +hashing.cpython-312-darwin.so (0) <F4BB6B51-98AE-3F6B-8EF1-0CB92B9C22C7> /Users/*/hashing.cpython-312-darwin.so
+       0x113dec000 -        0x113df5a27 +json.cpython-312-darwin.so (0) <4973B619-2D64-3C00-8BFA-1DE79D37E9A7> /Users/*/json.cpython-312-darwin.so
+       0x113e04000 -        0x113e25e97 +nattype.cpython-312-darwin.so (0) <6F602DDB-BA86-37C8-859E-203CAE22D171> /Users/*/nattype.cpython-312-darwin.so
+       0x113e38000 -        0x113e52877 +timezones.cpython-312-darwin.so (0) <612D8C5C-518E-3DF9-A248-0CFCC2DFB81B> /Users/*/timezones.cpython-312-darwin.so
+       0x113e68000 -        0x113fd3707 +hashtable.cpython-312-darwin.so (0) <FF5D9E8E-0987-3C36-A644-CD2366D3AFC9> /Users/*/hashtable.cpython-312-darwin.so
+       0x114034000 -        0x11408dd67 +timestamps.cpython-312-darwin.so (0) <ABEB129C-4689-3782-91FE-88660C77482A> /Users/*/timestamps.cpython-312-darwin.so
+       0x1140a8000 -        0x1140c25ef +tzconversion.cpython-312-darwin.so (0) <B6FE0F13-8FDA-3950-ABEA-2237E17A6E78> /Users/*/tzconversion.cpython-312-darwin.so
+       0x1140e0000 -        0x1141006af +fields.cpython-312-darwin.so (0) <5DD5F080-9145-39C0-A10A-7C01C286D08C> /Users/*/fields.cpython-312-darwin.so
+       0x114124000 -        0x1141e14d7 +offsets.cpython-312-darwin.so (0) <3C4B60F8-748C-3A74-AA0F-00354FF55955> /Users/*/offsets.cpython-312-darwin.so
+       0x114218000 -        0x11426a487 +timedeltas.cpython-312-darwin.so (0) <6754411F-1DA9-345E-960A-DF37808B2651> /Users/*/timedeltas.cpython-312-darwin.so
+       0x114288000 -        0x114297b8f +vectorized.cpython-312-darwin.so (0) <223E96D3-C328-3533-A901-B4AD44D57129> /Users/*/vectorized.cpython-312-darwin.so
+       0x1142a8000 -        0x1142b0843 +indexing.cpython-312-darwin.so (0) <5312392F-FBB6-3D0E-9ED1-7B37369C2490> /Users/*/indexing.cpython-312-darwin.so
+       0x1142c8000 -        0x1142f14ff +parsing.cpython-312-darwin.so (0) <5233F2B9-88D4-36CC-A41F-DB8A8C3FCFB8> /Users/*/parsing.cpython-312-darwin.so
+       0x114408000 -        0x114429d63 +strptime.cpython-312-darwin.so (0) <515BA5B5-0AED-33C9-99C1-F2B4D0499E1B> /Users/*/strptime.cpython-312-darwin.so
+       0x114440000 -        0x114452d1f +ops.cpython-312-darwin.so (0) <A0FC3661-AB8B-30FB-BC4C-1BBE02A1AED6> /Users/*/ops.cpython-312-darwin.so
+       0x114464000 -        0x11446fffb +_isfinite.cpython-312-darwin.so (0) <B80C5A5F-757D-3EA2-B4E2-4EFD3C7A115E> /Users/*/_isfinite.cpython-312-darwin.so
+       0x11447c000 -        0x114487ffb +_openmp_helpers.cpython-312-darwin.so (0) <C9FB4942-C1D5-30FE-A152-5A719E9C8BB7> /Users/*/_openmp_helpers.cpython-312-darwin.so
+       0x11449c000 -        0x1144dd4bf +period.cpython-312-darwin.so (0) <1CCEBAEB-FCF2-3FA1-B82C-F9E8E7411729> /Users/*/period.cpython-312-darwin.so
+       0x1144f8000 -        0x11450939b +arrays.cpython-312-darwin.so (0) <3DAFBE9E-5541-3836-8CC0-E8755CBB1498> /Users/*/arrays.cpython-312-darwin.so
+       0x11451c000 -        0x114532acf +tslib.cpython-312-darwin.so (0) <FE7885D0-F6C8-3CF4-8C23-2B2653832777> /Users/*/tslib.cpython-312-darwin.so
+       0x114544000 -        0x114552fff +writers.cpython-312-darwin.so (0) <C85FB1AB-597B-3E86-B27A-7DA7371B81E5> /Users/*/writers.cpython-312-darwin.so
+       0x114564000 -        0x11456ffff +_expected_mutual_info_fast.cpython-312-darwin.so (0) <462B033D-A8AD-3A02-8579-3A82A0552FAC> /Users/*/_expected_mutual_info_fast.cpython-312-darwin.so
+       0x114580000 -        0x1145ebfe7 +lib.cpython-312-darwin.so (0) <52A92FD8-5A48-3F88-B94C-AA0593F4DC7F> /Users/*/lib.cpython-312-darwin.so
+       0x11460c000 -        0x114629113 +indexers.cpython-312-darwin.so (0) <2400B9FF-2DAE-3579-9F73-AE0E6B8CFB67> /Users/*/indexers.cpython-312-darwin.so
+       0x114640000 -        0x114659b7b +reshape.cpython-312-darwin.so (0) <6F7B0B88-DF9A-3761-B0EB-43C8363C65F9> /Users/*/reshape.cpython-312-darwin.so
+       0x114688000 -        0x1147dc097 +algos.cpython-312-darwin.so (0) <F55D63C7-D328-3DEC-9ED5-47D2C8AC2E51> /Users/*/algos.cpython-312-darwin.so
+       0x114b1c000 -        0x114b4870f +internals.cpython-312-darwin.so (0) <C5658EDB-A6E2-358D-9AF3-C2E18F100175> /Users/*/internals.cpython-312-darwin.so
+       0x114b64000 -        0x114ba64af +aggregations.cpython-312-darwin.so (0) <4986DE60-FCCC-3392-A3CE-CD643C5D6C77> /Users/*/aggregations.cpython-312-darwin.so
+       0x114bcc000 -        0x114c57c67 +sparse.cpython-312-darwin.so (0) <67BEFA1F-C53A-3FBC-8204-842EC501C517> /Users/*/sparse.cpython-312-darwin.so
+       0x114d7c000 -        0x114d8b06f +testing.cpython-312-darwin.so (0) <FD3A7FFC-A6F6-3A46-B3CA-367F57C68777> /Users/*/testing.cpython-312-darwin.so
+       0x114d9c000 -        0x114dabffb +murmurhash.cpython-312-darwin.so (0) <664532F7-E1C8-3AC1-BC38-0E2E9C6FD1ED> /Users/*/murmurhash.cpython-312-darwin.so
+       0x114dc8000 -        0x114de3ff3 +_cyutility.cpython-312-darwin.so (0) <BDAD4F31-ADC9-380A-BD75-6B3BF9279F55> /Users/*/_cyutility.cpython-312-darwin.so
+       0x114df4000 -        0x114dfffff +_sorting.cpython-312-darwin.so (0) <8DD3731A-5378-383F-A3E8-E9933B677CB4> /Users/*/_sorting.cpython-312-darwin.so
+       0x114e0c000 -        0x114e17ff7 +_weight_vector.cpython-312-darwin.so (0) <924DB29F-2B4A-326F-AA6A-CEDE7EE9986D> /Users/*/_weight_vector.cpython-312-darwin.so
+       0x114e28000 -        0x114ea4e57 +index.cpython-312-darwin.so (0) <95540B3F-1A5F-3B92-B460-3E282784147A> /Users/*/index.cpython-312-darwin.so
+       0x114ed4000 -        0x114f19c67 +parsers.cpython-312-darwin.so (0) <F652DFAB-E321-3665-B8B2-F48794F4A1E6> /Users/*/parsers.cpython-312-darwin.so
+       0x114f34000 -        0x114f4fffb +_base.cpython-312-darwin.so (0) <5DAFA6AF-82FC-37A1-A897-F872F8BE99CE> /Users/*/_base.cpython-312-darwin.so
+       0x114f6c000 -        0x114f8bfff +_argkmin.cpython-312-darwin.so (0) <76AD00E9-C985-3BF2-8962-988FA4199B34> /Users/*/_argkmin.cpython-312-darwin.so
+       0x114fa4000 -        0x114fafffb +_cdnmf_fast.cpython-312-darwin.so (0) <E1189686-6AB6-339F-9EE2-A2F07D45CF0C> /Users/*/_cdnmf_fast.cpython-312-darwin.so
+       0x114fc0000 -        0x11508151f +join.cpython-312-darwin.so (0) <466DFF18-137A-38AA-9FDB-FAA422918AD7> /Users/*/join.cpython-312-darwin.so
+       0x1154ac000 -        0x115523fff +sparsefuncs_fast.cpython-312-darwin.so (0) <E3703768-5084-3A41-8F79-DCE7E0B0952E> /Users/*/sparsefuncs_fast.cpython-312-darwin.so
+       0x115534000 -        0x115557fff +_cython_blas.cpython-312-darwin.so (0) <7D52D0F2-B86B-3DC4-8782-20C4629468EC> /Users/*/_cython_blas.cpython-312-darwin.so
+       0x115568000 -        0x115573ffb +_utils.cpython-312-darwin.so (0) <D5BFA6B8-3DD4-3E98-AE1E-44F632D52D15> /Users/*/_utils.cpython-312-darwin.so
+       0x115580000 -        0x11558bffb +_hashing_fast.cpython-312-darwin.so (0) <B9255EF6-1361-3228-B94A-4621F601CD65> /Users/*/_hashing_fast.cpython-312-darwin.so
+       0x11559c000 -        0x115746ab7 +groupby.cpython-312-darwin.so (0) <9B6CE975-7D7B-3985-862E-1431F64C929C> /Users/*/groupby.cpython-312-darwin.so
+       0x115990000 -        0x1159e7fff +_dist_metrics.cpython-312-darwin.so (0) <8F0145DD-E038-313C-AB4E-AD29C8D4B99A> /Users/*/_dist_metrics.cpython-312-darwin.so
+       0x115a04000 -        0x115a17fff +_argkmin_classmode.cpython-312-darwin.so (0) <2A43FABF-3A12-3EE1-83F4-0FAD6DDB84E0> /Users/*/_argkmin_classmode.cpython-312-darwin.so
+       0x115a38000 -        0x115aabff7 +libomp.dylib (0) <E3A31AB3-3AE5-3371-87D0-7FD870A41A0D> /Users/*/libomp.dylib
+       0x115ae4000 -        0x115b13ffb +_datasets_pair.cpython-312-darwin.so (0) <8910467C-02B4-30BD-BF84-319EC4B32280> /Users/*/_datasets_pair.cpython-312-darwin.so
+       0x115b28000 -        0x115b3bfff +_vector_sentinel.cpython-312-darwin.so (0) <CCE28D7D-6639-32DE-A324-48BE19D7A23C> /Users/*/_vector_sentinel.cpython-312-darwin.so
+       0x115c70000 -        0x115c83ffb +_fast_dict.cpython-312-darwin.so (0) <CCBB3D2E-8EA5-3556-85AE-1E614B559AAA> /Users/*/_fast_dict.cpython-312-darwin.so
+       0x115cb4000 -        0x115ccbffb +_radius_neighbors_classmode.cpython-312-darwin.so (0) <96789C63-2DA6-3D83-9CBA-ADA5DE67AF08> /Users/*/_radius_neighbors_classmode.cpython-312-darwin.so
+       0x115cf0000 -        0x115d13ffb +_radius_neighbors.cpython-312-darwin.so (0) <17AB6BF9-6224-3E08-A35B-DF85CD8E3568> /Users/*/_radius_neighbors.cpython-312-darwin.so
+       0x115d60000 -        0x115d93fff +_middle_term_computer.cpython-312-darwin.so (0) <4E426043-4B32-37F8-B737-688D3CA17AD4> /Users/*/_middle_term_computer.cpython-312-darwin.so
+       0x115dac000 -        0x115dbfffb +_sag_fast.cpython-312-darwin.so (0) <A409DA7F-4DEA-3F84-8035-0CCAC4C3683D> /Users/*/_sag_fast.cpython-312-darwin.so
+       0x115dec000 -        0x115dfffff +arrayfuncs.cpython-312-darwin.so (0) <4AF70594-52F3-3094-8886-74F473A4F544> /Users/*/arrayfuncs.cpython-312-darwin.so
+       0x115e30000 -        0x115e43ffb +_pairwise_fast.cpython-312-darwin.so (0) <D259822C-A12C-36ED-BF33-F021A11AD71C> /Users/*/_pairwise_fast.cpython-312-darwin.so
+       0x115e58000 -        0x115e67ff7 +_linkage.cpython-312-darwin.so (0) <D8668F4F-619B-33B9-B292-6F1101A99E12> /Users/*/_linkage.cpython-312-darwin.so
+       0x115e98000 -        0x115eb3fff +_hierarchical_fast.cpython-312-darwin.so (0) <2C20C925-768D-3307-8ABC-5BCECFA08496> /Users/*/_hierarchical_fast.cpython-312-darwin.so
+       0x115f00000 -        0x115f2bfff +_csr_polynomial_expansion.cpython-312-darwin.so (0) <57010065-D3E2-3F19-A2E7-F0ACC70849EB> /Users/*/_csr_polynomial_expansion.cpython-312-darwin.so
+       0x115f88000 -        0x115f9bffb +_online_lda_fast.cpython-312-darwin.so (0) <1A3DFEA0-CC26-3441-A85E-6F28DDA10920> /Users/*/_online_lda_fast.cpython-312-darwin.so
+       0x115fcc000 -        0x115fdfffb +_isotonic.cpython-312-darwin.so (0) <9FE5525B-447A-3645-9D0E-0D4E207D4CE0> /Users/*/_isotonic.cpython-312-darwin.so
+       0x116010000 -        0x11602fffb +_k_means_lloyd.cpython-312-darwin.so (0) <D938460C-8892-3691-919E-80ADFC005D80> /Users/*/_k_means_lloyd.cpython-312-darwin.so
+       0x116044000 -        0x116057ffb +_k_means_minibatch.cpython-312-darwin.so (0) <C6071A84-A392-350D-8E40-767BD0A0745B> /Users/*/_k_means_minibatch.cpython-312-darwin.so
+       0x11609c000 -        0x1160abffb +_barnes_hut_tsne.cpython-312-darwin.so (0) <26A584DE-BE38-349B-B7DF-17EA8DDF31C1> /Users/*/_barnes_hut_tsne.cpython-312-darwin.so
+       0x1160e0000 -        0x11610ffff +_k_means_common.cpython-312-darwin.so (0) <37532837-A99B-3B1C-813D-6475DDF9C217> /Users/*/_k_means_common.cpython-312-darwin.so
+       0x116148000 -        0x11615bff7 +_splitter.cpython-312-darwin.so (0) <70D24DDB-F845-3955-90A9-77B1A2889820> /Users/*/_splitter.cpython-312-darwin.so
+       0x11618c000 -        0x11619bffb +_utils.cpython-312-darwin.so (0) <F41C453B-0996-3D78-99C2-5D084B1C2321> /Users/*/_utils.cpython-312-darwin.so
+       0x1162d0000 -        0x11630bfff +_target_encoder_fast.cpython-312-darwin.so (0) <B6AB31BC-9E67-3E43-82A2-016532EE1808> /Users/*/_target_encoder_fast.cpython-312-darwin.so
+       0x116360000 -        0x116393ffb +_k_means_elkan.cpython-312-darwin.so (0) <786418FF-4C7F-3B01-A128-739820840D95> /Users/*/_k_means_elkan.cpython-312-darwin.so
+       0x11640c000 -        0x116427fff +_seq_dataset.cpython-312-darwin.so (0) <64054E96-9201-3DD4-A78C-D4D93442C6B0> /Users/*/_seq_dataset.cpython-312-darwin.so
+       0x116474000 -        0x11648fff3 +_random.cpython-312-darwin.so (0) <E593335A-5968-3DA7-A757-9E184C65CFD2> /Users/*/_random.cpython-312-darwin.so
+       0x1164dc000 -        0x1164f3ff7 +_liblinear.cpython-312-darwin.so (0) <0227DC71-599F-3570-B4B9-1F9AEBAB634D> /Users/*/_liblinear.cpython-312-darwin.so
+       0x116618000 -        0x116673fff +_ball_tree.cpython-312-darwin.so (0) <633B8BBE-49C3-36FD-8D65-A33D0CEB58CD> /Users/*/_ball_tree.cpython-312-darwin.so
+       0x1166cc000 -        0x1166ebfff +_sgd_fast.cpython-312-darwin.so (0) <D6CD8446-2D8E-3963-AD40-997D9FD0FD92> /Users/*/_sgd_fast.cpython-312-darwin.so
+       0x116700000 -        0x116763fff +_kd_tree.cpython-312-darwin.so (0) <20E49D4E-5F99-3747-82C9-C909C716BF2E> /Users/*/_kd_tree.cpython-312-darwin.so
+       0x1168bc000 -        0x1168dbffb +_reachability.cpython-312-darwin.so (0) <CB855F86-3B3E-3F6B-9693-DF058297E1A0> /Users/*/_reachability.cpython-312-darwin.so
+       0x11697c000 -        0x1169c3fff +_cd_fast.cpython-312-darwin.so (0) <7886482D-7A7C-38A0-9179-A31205820675> /Users/*/_cd_fast.cpython-312-darwin.so
+       0x116ad4000 -        0x116afbff3 +_tree.cpython-312-darwin.so (0) <5CE45C83-D4ED-37B0-B1C2-C833DA573262> /Users/*/_tree.cpython-312-darwin.so
+       0x116b48000 -        0x116c97ff3 +_loss.cpython-312-darwin.so (0) <4E5A934C-4463-3CFA-8077-AF8619B56ECF> /Users/*/_loss.cpython-312-darwin.so
+       0x116d54000 -        0x116d93fff +_libsvm.cpython-312-darwin.so (0) <4144F449-0BA4-3860-AA5F-7D92445471F3> /Users/*/_libsvm.cpython-312-darwin.so
+       0x116df4000 -        0x116e2bff3 +_libsvm_sparse.cpython-312-darwin.so (0) <9472ABAC-050F-3896-A347-B9FC71AC63AE> /Users/*/_libsvm_sparse.cpython-312-darwin.so
+       0x11702c000 -        0x117043ff7 +_quad_tree.cpython-312-darwin.so (0) <569CD5C7-1EE2-3534-B210-C82D67B6A59E> /Users/*/_quad_tree.cpython-312-darwin.so
+       0x117054000 -        0x117073ffb +_criterion.cpython-312-darwin.so (0) <4E9A3085-3B8F-3FAA-BE0C-7D3B4877A0AB> /Users/*/_criterion.cpython-312-darwin.so
+       0x117084000 -        0x11709bfff +_partitioner.cpython-312-darwin.so (0) <DD293FBE-F578-3F0B-BF36-2CCFFFB23935> /Users/*/_partitioner.cpython-312-darwin.so
+       0x117310000 -        0x117353ff7 +_tree.cpython-312-darwin.so (0) <BBD90FB2-F93E-3D24-ACF6-3F0A3DF81BDC> /Users/*/_tree.cpython-312-darwin.so
+       0x189e00000 -        0x189e52b4b  libobjc.A.dylib (951.7) <2E858E25-1FF6-3DA6-84F6-911630620512> /usr/lib/libobjc.A.dylib
+       0x189e53000 -        0x189e87b34  libdyld.dylib (1376.6) <2C3C5F75-3686-39A1-9202-BD4D2133379D> /usr/lib/system/libdyld.dylib
+       0x189e88000 -        0x189f2dec7  dyld (1.0.0 - 1376.6) <9F682DCF-340C-3BFA-BCDD-DD702F30313E> /usr/lib/dyld
+       0x189f2e000 -        0x189f31228  libsystem_blocks.dylib (96) <2EA73169-CF76-3DD1-9869-F23C8B338022> /usr/lib/system/libsystem_blocks.dylib
+       0x189f32000 -        0x189f8651f  libxpc.dylib (3102.100.102) <618039C8-9965-3782-A7D2-90FD4C3DD66F> /usr/lib/system/libxpc.dylib
+       0x189f87000 -        0x189fa79bf  libsystem_trace.dylib (1861.100.19) <08629650-54FC-3AA6-910E-EACA563804D0> /usr/lib/system/libsystem_trace.dylib
+       0x189fa8000 -        0x18a055daf  libcorecrypto.dylib (1922.101.2) <D1EC203E-9B2E-391B-8DE3-7C58F0589437> /usr/lib/system/libcorecrypto.dylib
+       0x18a056000 -        0x18a0a61d7  libsystem_malloc.dylib (812.100.31) <2AD21BE3-FFDB-31D5-A3D7-2F7F672D6E92> /usr/lib/system/libsystem_malloc.dylib
+       0x18a0a7000 -        0x18a0ee23f  libdispatch.dylib (1542.100.32) <E17AA23F-DB2A-3302-B14C-F6B08C540FCF> /usr/lib/system/libdispatch.dylib
+       0x18a0ef000 -        0x18a0f1ffb  libsystem_featureflags.dylib (103) <0DE01F76-4B36-35A2-98F9-43DD147EDD95> /usr/lib/system/libsystem_featureflags.dylib
+       0x18a0f2000 -        0x18a172ef7  libsystem_c.dylib (1752.100.10) <66EBD321-6899-3863-BA24-5CFC3076A0CB> /usr/lib/system/libsystem_c.dylib
+       0x18a173000 -        0x18a203ae7  libc++.1.dylib (2100.43) <1E9541EC-C564-38CB-BED6-46F708E8D863> /usr/lib/libc++.1.dylib
+       0x18a204000 -        0x18a21e75f  libc++abi.dylib (2100.43) <E8D325ED-3B97-325E-B494-B1B0FF93D133> /usr/lib/libc++abi.dylib
+       0x18a21f000 -        0x18a25c28f  libsystem_kernel.dylib (12377.101.15) <51565B39-F595-3E96-A217-FEF29815057A> /usr/lib/system/libsystem_kernel.dylib
+       0x18a25d000 -        0x18a269b3b  libsystem_pthread.dylib (539.100.4) <E7A73008-0C09-31E3-9DD9-0C61652F0E85> /usr/lib/system/libsystem_pthread.dylib
+       0x18a26a000 -        0x18a2728f3  libsystem_platform.dylib (375.100.10) <D93EC420-F465-3A3A-916D-A04AF9B023EB> /usr/lib/system/libsystem_platform.dylib
+       0x18a273000 -        0x18a2a26eb  libsystem_info.dylib (600) <201FD67C-3DF6-3788-B132-A69CAA2AA3D7> /usr/lib/system/libsystem_info.dylib
+       0x18a2a3000 -        0x18a800c5f  com.apple.CoreFoundation (6.9 - 4424.1.402) <04941709-2330-3BF8-9213-6D33964DB448> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
+       0x18a801000 -        0x18ab1bbdf  com.apple.LaunchServices (1141.1 - 1141.1) <7E01ED2D-7B3A-34D5-87F0-AA2785A5605F> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
+       0x18ab1c000 -        0x18ad049bf  com.apple.gpusw.MetalTools (1.0 - 1) <287AFB31-4869-3E39-BBD1-3BB410FEA798> /System/Library/PrivateFrameworks/MetalTools.framework/Versions/A/MetalTools
+       0x18ad05000 -        0x18b4ff4bf  libBLAS.dylib (1551.100.26) <4FC8C9A8-58C3-35DD-A4D8-F02D57F085ED> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
+       0x18b500000 -        0x18b60f35f  com.apple.Lexicon-framework (1.0 - 195.12) <AE8E0828-1A0B-373D-8A02-1531D08590D7> /System/Library/PrivateFrameworks/Lexicon.framework/Versions/A/Lexicon
+       0x18b610000 -        0x18b77d417  libSparse.dylib (184.80.2) <C7D1864B-A800-3452-B01F-CDBBC9EB70CD> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparse.dylib
+       0x18b77e000 -        0x18b8111df  com.apple.SystemConfiguration (1.21 - 1.21) <E192312E-A963-3625-9E4E-5BAE21807384> /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
+       0x18b812000 -        0x18b84657b  libCRFSuite.dylib (55) <33BBBA2B-3BC6-31BB-81A5-03565AF927B3> /usr/lib/libCRFSuite.dylib
+       0x18bb0f000 -        0x18caf11df  com.apple.Foundation (6.9 - 4424.1.402) <8E9A5C62-7E95-3047-81E7-735AE1AEE5F8> /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
+       0x18caf2000 -        0x18cca0edf  com.apple.LanguageModeling (1.0 - 433.5) <D10E108F-C0FB-3790-A1A8-BCFCC93E6899> /System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
+       0x18cca1000 -        0x18cdc1cbf  com.apple.CoreDisplay (291.3 - 291.3) <193E4CF1-2F3E-3023-BC85-B995752B5290> /System/Library/Frameworks/CoreDisplay.framework/Versions/A/CoreDisplay
+       0x18cdc2000 -        0x18d18473f  com.apple.audio.AudioToolboxCore (1.0 - 1556.528) <E04892F4-3ED8-3993-8683-B8D7A40C3A2D> /System/Library/PrivateFrameworks/AudioToolboxCore.framework/Versions/A/AudioToolboxCore
+       0x18d185000 -        0x18d3adf1f  com.apple.CoreText (877.4.0.7 - 877.4.0.7) <A372F0BF-AC92-39F6-A41C-580158486082> /System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
+       0x18d3ae000 -        0x18db43e9f  com.apple.audio.CoreAudio (5.0 - 5.0) <72080A9B-8C5B-3E6D-8DE7-0F86C3E698EC> /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
+       0x18db44000 -        0x18df61d1f  com.apple.security (7.0 - 61901.101.4) <4CBBF5DD-B67C-3BE4-9B97-5F113FD01950> /System/Library/Frameworks/Security.framework/Versions/A/Security
+       0x18df62000 -        0x18e237d33  libicucore.A.dylib (76142.4.7) <BD826EC4-73D6-3F95-ABED-001F02B4A429> /usr/lib/libicucore.A.dylib
+       0x18e238000 -        0x18e241e5f  libsystem_darwin.dylib (1752.100.10) <D5BA0CAB-F283-3620-AAA9-1EEB718E1BA8> /usr/lib/system/libsystem_darwin.dylib
+       0x18e242000 -        0x18e539cbf  com.apple.CoreServices.CarbonCore (1333 - 1333) <9BDEEDD0-75AB-38E6-B9D8-E639A234893A> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
+       0x18e53a000 -        0x18e579a5b  com.apple.CoreServicesInternal (505 - 505) <A460D760-9940-3977-A0D7-900705491053> /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
+       0x18e57a000 -        0x18e5b91bf  com.apple.CSStore (1141.1 - 1141.1) <D703C5EE-2AC4-3EB8-9258-08501E1BD733> /System/Library/PrivateFrameworks/CoreServicesStore.framework/Versions/A/CoreServicesStore
+       0x18e5ba000 -        0x18e6a223f  com.apple.framework.IOKit (2.0.2 - 100231.100.18.0.1) <E4D05845-A890-377F-BB68-5972BF638119> /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
+       0x18e6a3000 -        0x18e6b4f5b  libsystem_notify.dylib (348.100.7) <9F46F30B-B7C0-3DD7-AC38-57B78C7971FF> /usr/lib/system/libsystem_notify.dylib
+       0x18e6b5000 -        0x18e71168f  libsandbox.1.dylib (2680.100.174) <371D12AD-6696-38A6-8BD0-AEC5F095D65F> /usr/lib/libsandbox.1.dylib
+       0x18e712000 -        0x18fe34abf  com.apple.AppKit (6.9 - 2685.50.120) <59E23BD5-D01E-305A-B96F-A5790356049A> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
+       0x18fe35000 -        0x18ffed7df  com.apple.UIFoundation (1.0 - 1018.1) <D75D6411-8FC8-321A-9CAD-DF4C5D811D84> /System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
+       0x18ffee000 -        0x1900043ff  com.apple.UniformTypeIdentifiers (709 - 709) <31BBE997-B323-3535-9ADB-FD7EF7382BAC> /System/Library/Frameworks/UniformTypeIdentifiers.framework/Versions/A/UniformTypeIdentifiers
+       0x1904df000 -        0x1905b729f  libboringssl.dylib (532.101.3) <042D12D8-A8A0-3F41-ABA8-4F0C1BC7B777> /usr/lib/libboringssl.dylib
+       0x1905b8000 -        0x19096cf1f  com.apple.CFNetwork (1.0 - 3860.500.112) <3D8050B5-4263-3729-AD04-DF521A24CAC9> /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
+       0x19096d000 -        0x190987f5b  libsystem_networkextension.dylib (2226.101.1) <85169C7B-48DD-3542-AD38-F1B88EA2A95A> /usr/lib/system/libsystem_networkextension.dylib
+       0x190988000 -        0x190989067  libenergytrace.dylib (23) <62B33A35-EA5F-3FCA-9FD4-79C4DFB82FC9> /usr/lib/libenergytrace.dylib
+       0x19098a000 -        0x190a09c7f  libMobileGestalt.dylib (1484.100.29.0.1) <018D1CC6-9A6F-309C-92CF-A30594FB12A7> /usr/lib/libMobileGestalt.dylib
+       0x190a0a000 -        0x190a21fdf  libsystem_asl.dylib (406) <6427D987-7938-3278-8C14-10FB9C06BBD5> /usr/lib/system/libsystem_asl.dylib
+       0x190a22000 -        0x190a45827  com.apple.TCC (1.0 - 1) <BC682334-20A5-3374-9FC6-627EA7921E04> /System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
+       0x190a46000 -        0x190ffab5f  com.apple.SkyLight (1.600.0 - 921.13.1) <EF82BE18-450B-33FE-9C68-A2C88144F367> /System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight
+       0x190ffb000 -        0x19174ffff  com.apple.CoreGraphics (2.0 - 1965.4.5) <B00B63EB-CE38-3544-9C9E-D5309957CE58> /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
+       0x191750000 -        0x1918f7b8b  com.apple.ColorSync (4.13.0 - 3813.3.3) <5467E64B-022C-3ABE-9D08-A7A433F9FC07> /System/Library/Frameworks/ColorSync.framework/Versions/A/ColorSync
+       0x1918f8000 -        0x19196335f  com.apple.HIServices (1.22 - 817) <3AA36B9F-7D37-35FF-8034-A16DABFE5981> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
+       0x191a61000 -        0x191c5545f  com.apple.Montreal (1.0 - 178) <C091E6B6-4D00-3B6F-8AFB-03CAE8AEB715> /System/Library/PrivateFrameworks/Montreal.framework/Versions/A/Montreal
+       0x191d4c000 -        0x192139f5f  com.apple.CoreData (120 - 1526) <FC7B6078-A83A-39E4-B4CD-46E46FC71151> /System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
+       0x19213a000 -        0x192155d5f  com.apple.ProtocolBuffer (1 - 310.24.7.28.9) <66E64E0E-00B6-38DA-8A84-A90DA509B284> /System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
+       0x192156000 -        0x19233e9ff  libsqlite3.dylib (381) <53ABC511-4939-38EE-9170-BE252A25B254> /usr/lib/libsqlite3.dylib
+       0x19233f000 -        0x1923c925f  com.apple.Accounts (113 - 113) <6EE0898E-75B7-3B03-B339-0593C023AA2F> /System/Library/Frameworks/Accounts.framework/Versions/A/Accounts
+       0x1923e1000 -        0x1924d249f  com.apple.BaseBoard (732.1.1 - 732.1.1) <F3D9ECDD-A111-3EFA-913E-7E15E7BB5318> /System/Library/PrivateFrameworks/BaseBoard.framework/Versions/A/BaseBoard
+       0x1924d3000 -        0x19253e93f  com.apple.RunningBoardServices (1.0 - 1015.100.16) <4937DF6A-027A-3661-A7CC-CCE0F1674A40> /System/Library/PrivateFrameworks/RunningBoardServices.framework/Versions/A/RunningBoardServices
+       0x19253f000 -        0x1925b2c37  com.apple.AE (944 - 944) <5376E565-7730-3F73-B948-B9D10D08A772> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
+       0x1925b3000 -        0x1925c4d87  libdns_services.dylib (2881.100.56.0.1) <8169DB95-C8DE-322C-99BF-D592F610013E> /usr/lib/libdns_services.dylib
+       0x1925c5000 -        0x1925cd387  libsystem_symptoms.dylib (2169.100.30) <28B6E34E-9C7D-3437-A3F1-A3C979DE579A> /usr/lib/system/libsystem_symptoms.dylib
+       0x1925ce000 -        0x193de6cff  com.apple.Network (1.0 - 5812.101.2) <66B895AF-CEE8-378F-ABD8-D4F9738476CA> /System/Library/Frameworks/Network.framework/Versions/A/Network
+       0x193de7000 -        0x193e16ddf  com.apple.analyticsd (1.0 - 1) <ED4098AC-ECE3-3A22-92F1-A2292DFC13F2> /System/Library/PrivateFrameworks/CoreAnalytics.framework/Versions/A/CoreAnalytics
+       0x193e17000 -        0x193e188bb  libDiagnosticMessagesClient.dylib (113) <D5EBC67A-F9F1-3105-A4D0-F1AE518EA2A6> /usr/lib/libDiagnosticMessagesClient.dylib
+       0x193e19000 -        0x193e8501f  com.apple.spotlight.metadata.utilities (1.0 - 2418.4.13.404) <0DFEA3CB-1A37-390A-956D-D956B8688AC6> /System/Library/PrivateFrameworks/MetadataUtilities.framework/Versions/A/MetadataUtilities
+       0x193e86000 -        0x193f11b5f  com.apple.Metadata (26.4 - 2418.4.13.404) <9A860898-453E-36F4-9830-6D754A8C7CDC> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
+       0x193f12000 -        0x193f1b1eb  com.apple.DiskArbitration (2.7 - 2.7) <CB2C8249-4DCA-34C5-97C0-368485718E68> /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
+       0x193f1c000 -        0x194340023  com.apple.vImage (8.1 - 632.100.6) <E718351A-2443-3919-8135-67ADB9312327> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
+       0x194341000 -        0x19475659f  com.apple.QuartzCore (1195.9 - 1195.9) <B1C40645-C68A-3850-BBC4-29F74E486DF9> /System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
+       0x194757000 -        0x1947a84ff  libFontRegistry.dylib (408.4.0.1) <16C4640D-B9D6-35E1-9813-DD8480382152> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
+       0x1947a9000 -        0x19492f7bf  com.apple.coreui (2.1 - 974.1) <1B12A15C-6172-3FB5-AA64-B5C3F2473F6B> /System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
+       0x194a65000 -        0x194a6ee7f  com.apple.PerformanceAnalysis (1.427 - 427) <ECB271C4-DEED-3295-8200-451EE1509B28> /System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
+       0x194a6f000 -        0x194a7caff  com.apple.OpenDirectory (26.4 - 666.100.1) <C0B8EA4A-22A3-3801-A66E-C42358AC0468> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
+       0x194a7d000 -        0x194aa627f  com.apple.CFOpenDirectory (26.4 - 666.100.1) <3C2B9FAA-A99C-34B6-AA54-601FF113111D> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
+       0x194aa7000 -        0x194ab391b  com.apple.CoreServices.FSEvents (1413.100.6 - 1413.100.6) <EB26C31A-4C42-31CD-B48B-9BFCCFAA7A4B> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
+       0x194ab4000 -        0x194add0df  com.apple.coreservices.SharedFileList (225 - 225) <5BCA48BA-0BDB-355B-9F0A-75E649EC3359> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SharedFileList.framework/Versions/A/SharedFileList
+       0x194ade000 -        0x194ae108f  libapp_launch_measurement.dylib (17) <DBB6338E-E92E-364B-8714-9578C3E53B7E> /usr/lib/libapp_launch_measurement.dylib
+       0x194ae2000 -        0x194b2a9bf  com.apple.CoreAutoLayout (1.0 - 34) <EF256F92-D3A3-3C65-97B9-DBAED3A57A8D> /System/Library/PrivateFrameworks/CoreAutoLayout.framework/Versions/A/CoreAutoLayout
+       0x194b2b000 -        0x194c1113b  libxml2.2.dylib (39.10) <B627FBCA-2F68-3C56-B092-73F62A6FCC92> /usr/lib/libxml2.2.dylib
+       0x194c12000 -        0x194c9285f  com.apple.CoreVideo (1.8 - 734.4) <27CE0BA7-202B-34AC-BA6C-56891CCEC5F1> /System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
+       0x194c93000 -        0x194c95f5f  com.apple.loginsupport (3.0 - 264.4.1) <D27E83AC-E64D-3180-ACB3-9FDAC47541DD> /System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
+       0x194cd4000 -        0x194d0065f  com.apple.UserManagement (1.0 - 1) <0C8B7C6C-CCCD-3EAF-B5E5-D4B6F776123A> /System/Library/PrivateFrameworks/UserManagement.framework/Versions/A/UserManagement
+       0x1951fc000 -        0x195a3579f  com.apple.CoreML (1.0 - 3520.5.1) <1B0B67DA-8096-3CDD-969F-B38DF46FACC8> /System/Library/Frameworks/CoreML.framework/Versions/A/CoreML
+       0x196860000 -        0x19689825f  libsystem_containermanager.dylib (725.100.37) <14750F95-BB3A-3654-8610-A05A454643A8> /usr/lib/system/libsystem_containermanager.dylib
+       0x196899000 -        0x1968b525f  com.apple.IOSurface (393.5.7 - 393.5.7) <6A59B8B3-E55E-315B-87BF-260C95008770> /System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
+       0x1968b6000 -        0x1968c005f  com.apple.IOAccelerator (487.4.3 - 487.4.3) <D7DC2BD8-513C-3354-ACC0-C3140D9A0A86> /System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
+       0x1968c1000 -        0x196b9acdf  com.apple.Metal (372.16 - 372.16) <4E1D8F53-729B-3232-A184-2E9CD18AAD43> /System/Library/Frameworks/Metal.framework/Versions/A/Metal
+       0x196b9b000 -        0x196bc403f  com.apple.audio.caulk (1.0 - 214.501) <2BDD6811-CE34-3098-9833-10D9F74B7FFC> /System/Library/PrivateFrameworks/caulk.framework/Versions/A/caulk
+       0x196bc5000 -        0x196d6601f  com.apple.CoreMedia (1.0 - 3305.24.5.2) <09574F0D-9398-3C09-9DE8-F3834E693B68> /System/Library/Frameworks/CoreMedia.framework/Versions/A/CoreMedia
+       0x196d67000 -        0x19703625f  libFontParser.dylib (435.4.0.2) <8B98C347-62C7-38F2-92C8-244B6DFD3639> /System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib
+       0x197037000 -        0x19733205f  com.apple.HIToolbox (2.1.1 - 1249.3) <BCB81496-C81F-3D3E-A617-CCCA047989E0> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
+       0x197333000 -        0x1973475ff  com.apple.framework.DFRFoundation (1.0 - 293.1.1) <550E7FEC-455D-35A4-A4BD-EC452B2DA3FC> /System/Library/PrivateFrameworks/DFRFoundation.framework/Versions/A/DFRFoundation
+       0x197348000 -        0x19734d35f  com.apple.dt.XCTTargetBootstrap (26.4 - 24823) <416B231E-8505-3F79-A2C4-E53A03BFCD6C> /System/Library/PrivateFrameworks/XCTTargetBootstrap.framework/Versions/A/XCTTargetBootstrap
+       0x19734e000 -        0x19738b19f  com.apple.CoreSVG (1.0 - 341) <30BC4F58-5464-3ABE-ADFB-03A980C6DFE1> /System/Library/PrivateFrameworks/CoreSVG.framework/Versions/A/CoreSVG
+       0x19738c000 -        0x1976cacff  com.apple.ImageIO (3.3.0 - 2784.4.14) <7FA508AE-1EC7-36B6-AE29-EDD453A34CAD> /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
+       0x1976cb000 -        0x197bb5eff  com.apple.CoreImage (19.0.0 - 1592.80.2) <8ED0F6C5-AFF1-3217-B13C-DC2FB7090F2D> /System/Library/Frameworks/CoreImage.framework/Versions/A/CoreImage
+       0x197bb6000 -        0x197c6fddf  com.apple.MetalPerformanceShaders.MPSCore (1.0 - 1) <8E8DEA53-FF92-3DA6-A47E-BA27226D8029> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSCore.framework/Versions/A/MPSCore
+       0x197c70000 -        0x197c745d7  libsystem_configuration.dylib (1405.100.8) <634F597D-F8BD-3C00-B967-86047FC15D14> /usr/lib/system/libsystem_configuration.dylib
+       0x197c75000 -        0x197c7b8cf  libsystem_sandbox.dylib (2680.100.174) <AF76231D-EADC-3399-9414-6AD90FB4EA89> /usr/lib/system/libsystem_sandbox.dylib
+       0x197c7c000 -        0x197c7d17f  com.apple.AggregateDictionary (1.0 - 1) <1178C8EA-95DB-3BBA-A00F-E6D3A647940E> /System/Library/PrivateFrameworks/AggregateDictionary.framework/Versions/A/AggregateDictionary
+       0x197c7e000 -        0x197c824d3  com.apple.AppleSystemInfo (3.1.5 - 3.1.5) <450E68B1-E42E-3448-8003-6E070946E9E7> /System/Library/PrivateFrameworks/AppleSystemInfo.framework/Versions/A/AppleSystemInfo
+       0x197c83000 -        0x197c8446b  liblangid.dylib (140) <A5624740-6148-34D2-B600-FB6FD4FB8451> /usr/lib/liblangid.dylib
+       0x197c85000 -        0x197da445f  com.apple.CoreNLP (1.0 - 313) <1B118152-B1A9-315A-8B44-BDAC6FB589B5> /System/Library/PrivateFrameworks/CoreNLP.framework/Versions/A/CoreNLP
+       0x197da5000 -        0x197dab91f  com.apple.LinguisticData (1.0 - 483.10) <3273A361-CE08-3AED-91E9-55AB460015F3> /System/Library/PrivateFrameworks/LinguisticData.framework/Versions/A/LinguisticData
+       0x197dac000 -        0x198e207ef  libBNNS.dylib (1961.100.57) <BEA265F4-3EBD-39BD-89B3-39F251359D46> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBNNS.dylib
+       0x198e21000 -        0x198f5e46f  libvDSP.dylib (1126.100.7) <7F1C88BC-7C8D-3D5C-B38C-43082CD9C468> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
+       0x198f5f000 -        0x198f9263f  com.apple.CoreEmoji (1.0 - 261.4.6) <65E5FCDB-BD0C-3023-8B50-75CDC213937D> /System/Library/PrivateFrameworks/CoreEmoji.framework/Versions/A/CoreEmoji
+       0x198f93000 -        0x198fcc267  com.apple.IOMobileFramebuffer (343.0.0 - 343.0.0) <4E324CA4-23BF-3216-8749-717D5AD761B3> /System/Library/PrivateFrameworks/IOMobileFramebuffer.framework/Versions/A/IOMobileFramebuffer
+       0x199050000 -        0x1991c3e1f  com.apple.CoreUtils (8.2 - 820.46) <B6ECB9CF-DC74-3D6E-AD7D-0441729179E9> /System/Library/PrivateFrameworks/CoreUtils.framework/Versions/A/CoreUtils
+       0x1991c4000 -        0x1991db6df  com.apple.MobileKeyBag (2.0 - 1.0) <F8D5F6A0-E9FC-3CD4-ABDB-C1AE9347AB2B> /System/Library/PrivateFrameworks/MobileKeyBag.framework/Versions/A/MobileKeyBag
+       0x1991dc000 -        0x1991ea0ff  com.apple.AssertionServices (1.0 - 1015.100.16) <8BDF4215-2AE2-38A1-92D9-8D503B064790> /System/Library/PrivateFrameworks/AssertionServices.framework/Versions/A/AssertionServices
+       0x1991eb000 -        0x19927da9f  com.apple.securityfoundation (6.0 - 55293) <46DCD2FA-35AA-3CE1-AF5A-CB7D207E4B95> /System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
+       0x19927e000 -        0x1992af2ff  com.apple.coreservices.BackgroundTaskManagement (1.0 - 104) <92EFE219-3F5F-31DE-BF8F-A48374CC3A11> /System/Library/PrivateFrameworks/BackgroundTaskManagement.framework/Versions/A/BackgroundTaskManagement
+       0x1992bb000 -        0x1992be1fb  libquarantine.dylib (196.100.8) <268FEB6E-A237-3050-BFFF-AE3A66B7EAD4> /usr/lib/system/libquarantine.dylib
+       0x1992bf000 -        0x1992ca2bf  libCheckFix.dylib (33) <01812E54-6AFA-31D0-9ED8-9780885AA285> /usr/lib/libCheckFix.dylib
+       0x1992cb000 -        0x1992e27ab  libcoretls.dylib (187.100.3) <2CB72424-441F-392D-8F30-40B6DEE19795> /usr/lib/libcoretls.dylib
+       0x1992e3000 -        0x1992f4273  libbsm.0.dylib (90) <B2A2B623-537B-3853-A317-53DC4943A4D8> /usr/lib/libbsm.0.dylib
+       0x1992f5000 -        0x199353c6b  libmecab.dylib (1121.4.4) <AFC99DD8-D62A-3790-B5AA-537CAF849CDA> /usr/lib/libmecab.dylib
+       0x199354000 -        0x19935641b  libgermantok.dylib (31) <F04FD03E-0352-3625-8E4C-BA96210FD966> /usr/lib/libgermantok.dylib
+       0x199357000 -        0x19936ae3f  libLinearAlgebra.dylib (1551.100.26) <CD0AE837-ED86-307A-BAB6-69E9B55E809F> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
+       0x19936b000 -        0x1995c117f  com.apple.MetalPerformanceShaders.MPSNeuralNetwork (1.0 - 1) <891172A3-75F1-325A-A3A9-7CF2E3F31D79> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSNeuralNetwork.framework/Versions/A/MPSNeuralNetwork
+       0x1995c2000 -        0x19961619f  com.apple.MetalPerformanceShaders.MPSRayIntersector (1.0 - 1) <F10D9EF3-65A3-3DA6-8336-465E4A4C5076> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSRayIntersector.framework/Versions/A/MPSRayIntersector
+       0x199617000 -        0x1997a9edf  com.apple.MLCompute (1.0 - 1) <5189B965-70C0-3362-96D8-AD587217F5ED> /System/Library/Frameworks/MLCompute.framework/Versions/A/MLCompute
+       0x1997aa000 -        0x1997db57f  com.apple.MetalPerformanceShaders.MPSMatrix (1.0 - 1) <3CAC578C-742A-360E-B6FE-703AB65552A3> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSMatrix.framework/Versions/A/MPSMatrix
+       0x1997dc000 -        0x1999abe7f  com.apple.MetalPerformanceShaders.MPSNDArray (1.0 - 1) <93BA8B8F-DD36-370F-B6FF-F47614F314A7> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSNDArray.framework/Versions/A/MPSNDArray
+       0x1999ac000 -        0x199a401df  com.apple.MetalPerformanceShaders.MPSImage (1.0 - 1) <CB3CEFB0-2E32-3E00-A252-81B8CE6E3DFE> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSImage.framework/Versions/A/MPSImage
+       0x199a41000 -        0x199a4c4b3  com.apple.AppleFSCompression (174.100.2 - 1.0) <5E4BD0FD-F038-33D2-AF7E-5DEC574FF457> /System/Library/PrivateFrameworks/AppleFSCompression.framework/Versions/A/AppleFSCompression
+       0x199a4d000 -        0x199a590a3  libbz2.1.0.dylib (47) <95721BB3-328F-34A5-9567-4BB14DD45268> /usr/lib/libbz2.1.0.dylib
+       0x199a5a000 -        0x199a60d03  libsystem_coreservices.dylib (191.4.5) <7129349D-04F9-3C3C-BF37-3082C1468654> /usr/lib/system/libsystem_coreservices.dylib
+       0x199a61000 -        0x199a92adf  com.apple.CoreServices.OSServices (1141.1 - 1141.1) <AE3050F3-46C3-3A20-B1F2-DF7F9400A9F0> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
+       0x199e14000 -        0x199e646ff  com.apple.UserNotifications (1.0 - 640.4.40) <32687746-BA09-3EB4-A67C-E7CDBDD97EB8> /System/Library/Frameworks/UserNotifications.framework/Versions/A/UserNotifications
+       0x199fd0000 -        0x199fded87  libz.1.dylib (100) <25DC8186-B2D8-3839-9F10-D89BC289ECFF> /usr/lib/libz.1.dylib
+       0x199fdf000 -        0x19a01ca77  libsystem_m.dylib (3312.100.1) <83B173CD-7F32-3901-8E67-C0B2676BE015> /usr/lib/system/libsystem_m.dylib
+       0x19a01d000 -        0x19a01dc9b  libcharset.1.dylib (115.100.1) <994633BA-AA7A-31BF-94C5-E31A08CA6243> /usr/lib/libcharset.1.dylib
+       0x19a01e000 -        0x19a021527  libmacho.dylib (1376.6) <9729ECEA-0A08-32E3-8BDB-B42FC15FF258> /usr/lib/system/libmacho.dylib
+       0x19a022000 -        0x19a03adc3  libkxld.dylib (12377.101.15) <6808ADDF-053F-3215-916D-A375A3531661> /usr/lib/system/libkxld.dylib
+       0x19a03b000 -        0x19a0483a7  libcommonCrypto.dylib (600035) <710EC5FA-F77C-3646-A9E3-C037C42E1539> /usr/lib/system/libcommonCrypto.dylib
+       0x19a049000 -        0x19a052ca3  libunwind.dylib (2100.2) <FB0518B9-DF0F-3A03-A74B-AF1B21C26F8B> /usr/lib/system/libunwind.dylib
+       0x19a053000 -        0x19a05a349  liboah.dylib (367.5) <2FC1EF06-04C4-35FC-8DC3-BEA1E9FBD63F> /usr/lib/liboah.dylib
+       0x19a05b000 -        0x19a0657ff  libcopyfile.dylib (240) <0B7FF027-5579-3CBF-A12B-68A4FD36641C> /usr/lib/system/libcopyfile.dylib
+       0x19a066000 -        0x19a069987  libcompiler_rt.dylib (103.3) <65E29E6E-7042-3F73-A1D2-F2C4EBCD7524> /usr/lib/system/libcompiler_rt.dylib
+       0x19a06a000 -        0x19a06e78b  libsystem_collections.dylib (1752.100.10) <B81193DE-3BEC-3340-86D0-DB7F3683D135> /usr/lib/system/libsystem_collections.dylib
+       0x19a06f000 -        0x19a0724cf  libsystem_secinit.dylib (168.100.7) <A6B77B36-195D-33F8-8058-FE0B5BFA9D37> /usr/lib/system/libsystem_secinit.dylib
+       0x19a073000 -        0x19a075bf7  libremovefile.dylib (85.100.6) <BD89B1A3-0D06-3881-B5E1-EFC6CFBDFCC1> /usr/lib/system/libremovefile.dylib
+       0x19a076000 -        0x19a076f27  libkeymgr.dylib (31) <DE8F8219-0072-35C2-8932-C065491ED15D> /usr/lib/system/libkeymgr.dylib
+       0x19a077000 -        0x19a07fe3f  libsystem_dnssd.dylib (2881.100.56.0.1) <DEC8BDD2-366C-3BF9-A123-35744DB06354> /usr/lib/system/libsystem_dnssd.dylib
+       0x19a080000 -        0x19a08509b  libcache.dylib (95) <4D6833A3-C910-3A76-AA8A-303F698B36BF> /usr/lib/system/libcache.dylib
+       0x19a086000 -        0x19a087ce3  libSystem.B.dylib (1356) <E05F5341-06B7-365E-8014-E9CD64C352FE> /usr/lib/libSystem.B.dylib
+       0x19a088000 -        0x19a089fcf  libfakelink.dylib (5) <0DECB33A-FC26-3C73-8762-E9C8F15343AD> /usr/lib/libfakelink.dylib
+       0x19a08a000 -        0x19a08aa33  com.apple.SoftLinking (1.0 - 71) <FACACD62-537D-3FF8-B1D4-B1685938C303> /System/Library/PrivateFrameworks/SoftLinking.framework/Versions/A/SoftLinking
+       0x19a0c0000 -        0x19a0c71cb  libiconv.2.dylib (115.100.1) <E384E5FE-DFF5-36ED-88C8-0EEF2FBF89CE> /usr/lib/libiconv.2.dylib
+       0x19a0c8000 -        0x19a0da457  libcmph.dylib (9) <269122C5-B3B8-3881-8C9B-6BFF0812B183> /usr/lib/libcmph.dylib
+       0x19a0db000 -        0x19a1d2aaf  libarchive.2.dylib (167) <9F7CC46A-CC71-3EF8-BFE9-ABE40819EA73> /usr/lib/libarchive.2.dylib
+       0x19a1d3000 -        0x19a23885b  com.apple.SearchKit (1.4.2 - 1.4.2) <3E8F0ABC-A863-3A3E-8B0C-D01A44A98468> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
+       0x19a239000 -        0x19a24118f  libThaiTokenizer.dylib (28) <C2DE957F-29A8-324D-AB0F-1EADC7BB4E89> /usr/lib/libThaiTokenizer.dylib
+       0x19a242000 -        0x19a265f37  com.apple.applesauce (1.0 - 17.7) <8468AF10-88F2-3DD8-9DD4-0BBFCA10B055> /System/Library/PrivateFrameworks/AppleSauce.framework/Versions/A/AppleSauce
+       0x19a266000 -        0x19a27e23b  libapple_nghttp2.dylib (37) <33B20CAF-51C2-32E9-B20B-7F3B137BFFB9> /usr/lib/libapple_nghttp2.dylib
+       0x19a27f000 -        0x19a2a5ac3  libSparseBLAS.dylib (1551.100.26) <1BC4EAAD-4363-31DF-8C91-022B24AD87CD> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparseBLAS.dylib
+       0x19a2a6000 -        0x19a2a763f  com.apple.MetalPerformanceShaders.MetalPerformanceShaders (1.0 - 1) <59D13EAF-0DF5-3A93-9E12-7A1D22B52520> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/MetalPerformanceShaders
+       0x19a2a8000 -        0x19a2adff7  libpam.2.dylib (35) <CF7680E1-7AB2-39A5-B30C-E3AB30A5B0BB> /usr/lib/libpam.2.dylib
+       0x19a2ae000 -        0x19a37d417  libcompression.dylib (193.100.5) <0C99FEA2-9041-3226-9995-046879C3B9B1> /usr/lib/libcompression.dylib
+       0x19a37e000 -        0x19a382267  libQuadrature.dylib (8) <B6674817-731D-3178-A928-7963E5EED61C> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libQuadrature.dylib
+       0x19a383000 -        0x19b55394f  libLAPACK.dylib (1551.100.26) <9170F5E5-6D1E-3667-BDCF-E74CC880EB06> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
+       0x19b554000 -        0x19b5aa41f  com.apple.DictionaryServices (1.2 - 373) <EFE68757-B99A-3768-8494-2E54E23C2172> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
+       0x19b5ab000 -        0x19b5c94f7  liblzma.5.dylib (21) <7BC382B4-38A9-3054-8D3F-ED10CFBFF192> /usr/lib/liblzma.5.dylib
+       0x19b5ca000 -        0x19b5cb85f  libcoretls_cfhelpers.dylib (187.100.3) <67086CB0-340C-3DFD-B1E0-2B4C7C77026A> /usr/lib/libcoretls_cfhelpers.dylib
+       0x19b5cc000 -        0x19b63f6cb  com.apple.APFS (2811.101.1 - 2811.101.1) <86DD0616-A944-3596-8742-36F86E537A74> /System/Library/PrivateFrameworks/APFS.framework/Versions/A/APFS
+       0x19b640000 -        0x19b64e693  libxar.1.dylib (503) <A3F96FD4-FBE8-3867-93EE-7FF4F9B3E867> /usr/lib/libxar.1.dylib
+       0x19b64f000 -        0x19b65279b  libutil.dylib (73) <4FE4BA84-8B65-343C-9A7C-A174849301F1> /usr/lib/libutil.dylib
+       0x19b653000 -        0x19b67dcdf  libxslt.1.dylib (21.13) <D88D4FE7-8B33-3553-9CC8-8C5888B8BAA9> /usr/lib/libxslt.1.dylib
+       0x19b686000 -        0x19b6ff587  libvMisc.dylib (1126.100.7) <4E031DEB-7FC6-343A-8CCA-61617B5C6DF1> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
+       0x19b700000 -        0x19b78f45f  libate.dylib (3.0.9) <18973DAC-3297-3904-B329-A46242C87ABA> /usr/lib/libate.dylib
+       0x19b790000 -        0x19b798923  libIOReport.dylib (107) <78134EA0-367B-3D1D-94A2-75BDB03E5C7E> /usr/lib/libIOReport.dylib
+       0x19b799000 -        0x19b7ac1bf  com.apple.CrashReporterSupport (10.13 - 15140) <1238D09C-0D64-377F-913D-2DD04FEE8AF2> /System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
+       0x19b7ce000 -        0x19b8cb83f  com.apple.CVNLP (1.0 - 119) <CD3D3C09-E9C8-3AF6-B2A0-A61DA0886AA1> /System/Library/PrivateFrameworks/CVNLP.framework/Versions/A/CVNLP
+       0x19b8f0000 -        0x19b930f9f  com.apple.pluginkit.framework (1.0 - 1) <FB09CB89-BB7F-3085-B035-2D99017521B0> /System/Library/PrivateFrameworks/PlugInKit.framework/Versions/A/PlugInKit
+       0x19b931000 -        0x19b938403  libMatch.1.dylib (49) <9C90F41C-F7B9-356C-A2E6-61A6362F7943> /usr/lib/libMatch.1.dylib
+       0x19b9a7000 -        0x19b9ef9ff  com.apple.AppleVAFramework (6.2.10 - 6.2.10) <860D72AD-8149-3F4E-ACF4-EAED5CB1A85E> /System/Library/PrivateFrameworks/AppleVA.framework/Versions/A/AppleVA
+       0x19b9f0000 -        0x19ba0acbf  libexpat.1.dylib (45) <703912FD-D1AE-310C-BC05-7388D6CED6F5> /usr/lib/libexpat.1.dylib
+       0x19ba0b000 -        0x19ba14bd3  libheimdal-asn1.dylib (710.100.4) <9DA69DFC-DDCE-3986-8997-B944EE0A9965> /usr/lib/libheimdal-asn1.dylib
+       0x19ba15000 -        0x19ba7561f  com.apple.IconFoundation (494 - 494) <B3CD5CD7-92FB-3CBC-98CA-133548B63270> /System/Library/PrivateFrameworks/IconFoundation.framework/Versions/A/IconFoundation
+       0x19ba76000 -        0x19bb342ff  com.apple.IconServices (494 - 494) <B44E2BF9-0F0F-3CE1-8102-862AC2FC3215> /System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
+       0x19bb35000 -        0x19bbf667f  com.apple.MediaExperience (1.0 - 1) <A9DA4BC3-09C2-3E8B-8345-5A53F0D33056> /System/Library/PrivateFrameworks/MediaExperience.framework/Versions/A/MediaExperience
+       0x19bc24000 -        0x19bc337ff  com.apple.GraphVisualizer (1.0 - 307) <967136C2-27D1-363D-BB62-7029C00A0FA2> /System/Library/PrivateFrameworks/GraphVisualizer.framework/Versions/A/GraphVisualizer
+       0x19bc34000 -        0x19bc7351f  com.apple.OTSVG (1.0 - 877.4.0.7) <F032D306-361F-36D7-AB5C-10B81D4326E4> /System/Library/PrivateFrameworks/OTSVG.framework/Versions/A/OTSVG
+       0x19bc74000 -        0x19bc80c7f  com.apple.xpc.AppServerSupport (1.0 - 3102.100.102) <A88EE161-4724-302C-A026-D1B87AD54106> /System/Library/PrivateFrameworks/AppServerSupport.framework/Versions/A/AppServerSupport
+       0x19bc81000 -        0x19bc87abf  libspindump.dylib (419.2.4) <7FD26E92-31BB-390A-A80B-29D8AAE9FAD8> /usr/lib/libspindump.dylib
+       0x19bc88000 -        0x19bd48dff  com.apple.Heimdal (4.0 - 2.0) <26F4315D-6DD3-34D6-B479-B1032834C093> /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
+       0x19bd6d000 -        0x19beedb5f  com.apple.corebrightness (1.0 - 1) <C2271915-D67F-3895-A911-58EF8907C63D> /System/Library/PrivateFrameworks/CoreBrightness.framework/Versions/A/CoreBrightness
+       0x19c017000 -        0x19c05b6ef  com.apple.AppleJPEG (1.0 - 1) <A67D4167-3070-3F74-AAA3-D026E9B24C20> /System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
+       0x19c05c000 -        0x19c21c92f  libJP2.dylib (2784.4.14) <04679436-B3A9-3394-ACB5-74AE06684A27> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
+       0x19c21d000 -        0x19c21ee1f  com.apple.WatchdogClient.framework (1.0 - 333) <62C8465E-0729-3B6F-A298-6BB40D0BD3ED> /System/Library/PrivateFrameworks/WatchdogClient.framework/Versions/A/WatchdogClient
+       0x19c21f000 -        0x19c264c1f  com.apple.MultitouchSupport.framework (9440.9 - 9440.9) <DBBEDD3D-E0C4-3520-9548-5DD8A346A941> /System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
+       0x19c265000 -        0x19c7bb29f  com.apple.VideoToolbox (1.0 - 3305.24.5.2) <C266DA23-A7F3-3D85-81F6-8A9DCD783FD9> /System/Library/Frameworks/VideoToolbox.framework/Versions/A/VideoToolbox
+       0x19c7bc000 -        0x19c7e120f  libAudioToolboxUtility.dylib (1556.528) <C2B4CF76-E4A5-32C0-A5F3-8127BDCA92EB> /usr/lib/libAudioToolboxUtility.dylib
+       0x19c7e2000 -        0x19c80c01f  libPng.dylib (2784.4.14) <77ADBD9D-5B48-3588-AB0F-721187BED8EC> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
+       0x19c80d000 -        0x19c86da77  libTIFF.dylib (2784.4.14) <88FF9BDE-4C76-3616-A764-9E8C89F7237B> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
+       0x19c86e000 -        0x19c88d257  com.apple.IOPresentment (67 - 67) <964E964E-0852-3F03-8B48-331B3102CFE9> /System/Library/PrivateFrameworks/IOPresentment.framework/Versions/A/IOPresentment
+       0x19c88e000 -        0x19c8927d3  com.apple.GPUWrangler (8.1.12 - 8.1.12) <87A30363-DC91-34AA-9E7F-34CE76339267> /System/Library/PrivateFrameworks/GPUWrangler.framework/Versions/A/GPUWrangler
+       0x19c893000 -        0x19c895913  libRadiance.dylib (2784.4.14) <9A06F7A0-3845-30D5-95F6-FD16510B8BA9> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
+       0x19c896000 -        0x19c89b2f3  com.apple.DSExternalDisplay (3.1 - 380) <B9FC4FDF-0C94-3E77-AE41-B204D287F253> /System/Library/PrivateFrameworks/DSExternalDisplay.framework/Versions/A/DSExternalDisplay
+       0x19c89c000 -        0x19c8c6baf  libJPEG.dylib (2784.4.14) <77A9D581-5B49-3D6D-AF13-3CF5F6B3301E> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
+       0x19c8c7000 -        0x19c8f457f  com.apple.ATSUI (1.0 - 1) <A415A327-EBE6-34A5-AED1-713B89F40A23> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATSUI.framework/Versions/A/ATSUI
+       0x19c8f5000 -        0x19c8fa9fb  libGIF.dylib (2784.4.14) <2C78C162-3F2C-3159-84F4-8E3AE1DDB990> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
+       0x19c8fb000 -        0x19c90b19f  com.apple.CMCaptureCore (1.0 - 665.101.3) <2DE5381F-785A-3983-BBC7-0753BB151F14> /System/Library/PrivateFrameworks/CMCaptureCore.framework/Versions/A/CMCaptureCore
+       0x19c90c000 -        0x19c97e71f  com.apple.print.framework.PrintCore (19 - 601.2) <A3EBBAA4-FD6A-3841-B784-0242A5B581E6> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
+       0x19c97f000 -        0x19ca1591f  com.apple.TextureIO (3.10.12 - 3.10.12) <B81B7342-77B2-3DFE-ADE1-C52E21AB7386> /System/Library/PrivateFrameworks/TextureIO.framework/Versions/A/TextureIO
+       0x19ca16000 -        0x19cd1ff9f  com.apple.InternationalSupport (1.0 - 74) <526A16B3-FD9E-3265-8437-D98395B61A62> /System/Library/PrivateFrameworks/InternationalSupport.framework/Versions/A/InternationalSupport
+       0x19cd20000 -        0x19cd71cff  com.apple.datadetectorscore (8.0 - 821.6) <C3EB8FCD-83FD-33EF-8E47-205D49127063> /System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
+       0x19cd72000 -        0x19cde28df  com.apple.UserActivity (551 - 551) <558FF577-66FB-356C-983E-FBA1B713F80F> /System/Library/PrivateFrameworks/UserActivity.framework/Versions/A/UserActivity
+       0x19cde3000 -        0x19d87f35f  com.apple.MediaToolbox (1.0 - 3305.24.5.2) <1EE9EC7B-F475-3D3A-AF35-3B3970A85E56> /System/Library/Frameworks/MediaToolbox.framework/Versions/A/MediaToolbox
+       0x19d880000 -        0x19d8ee86f  libusrtcp.dylib (5812.101.2) <923F2A55-C3F5-3D6A-A5FE-F508E9A61204> /usr/lib/libusrtcp.dylib
+       0x19d8ef000 -        0x19de9093f  libswiftCore.dylib (6.3.0 - 6.3.0.123.11) <FB6AD37D-0F92-3774-AB61-0323DB22C111> /usr/lib/swift/libswiftCore.dylib
+       0x19df0a000 -        0x19df4303f  com.apple.locationsupport (3072.0.46.3.1 - 3072.0.46.3.1) <4E28B985-0375-341D-AB18-532DF320FFA9> /System/Library/PrivateFrameworks/LocationSupport.framework/Versions/A/LocationSupport
+       0x19df44000 -        0x19df9917f  libSessionUtility.dylib (398.516) <5904C1CD-1487-3433-93DE-92DCCAA7CB84> /System/Library/PrivateFrameworks/AudioSession.framework/libSessionUtility.dylib
+       0x19df9a000 -        0x19e16eb9f  com.apple.audio.toolbox.AudioToolbox (1.14 - 1.14) <0D8B0DA8-C582-3CCA-B648-5EE242E876D8> /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
+       0x19e16f000 -        0x19e1ef7df  com.apple.audio.AudioSession (1.0 - 398.516) <2EB71B02-7180-3007-B6A9-BF5DD3A4F79D> /System/Library/PrivateFrameworks/AudioSession.framework/Versions/A/AudioSession
+       0x19e1f0000 -        0x19e20939f  libAudioStatistics.dylib (262.514) <F2A3C791-1F5B-35C2-972B-69785C913B0C> /usr/lib/libAudioStatistics.dylib
+       0x19e20a000 -        0x19e23793f  com.apple.speech.synthesis.framework (9.2.22 - 9.2.22) <D9A460A9-2C2A-3223-A26C-4CD12220E1FC> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
+       0x19e238000 -        0x19e27f39f  com.apple.ApplicationServices.ATS (377 - 587) <B84BE70C-27E0-3910-9A9B-D5BA710E2A47> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
+       0x19e280000 -        0x19e29c19b  libresolv.9.dylib (96) <1F96EC72-E8BA-32DD-84AA-13C44654C1FA> /usr/lib/libresolv.9.dylib
+       0x19e29d000 -        0x19e2af7e7  libsasl2.2.dylib (215) <A12DC471-B201-359D-9F0D-C8F48BDF5870> /usr/lib/libsasl2.2.dylib
+       0x19e395000 -        0x19e49787f  com.apple.CoreMediaIO (1000.0 - 5617.100.5) <347D8925-13E9-3553-8CDC-57BDF91DB9A2> /System/Library/Frameworks/CoreMediaIO.framework/Versions/A/CoreMediaIO
+       0x19e498000 -        0x19e578337  libSMC.dylib (38) <22C15CB5-9AD6-3866-837A-8CBE8AF5BFC4> /usr/lib/libSMC.dylib
+       0x19e579000 -        0x19e5d7b9f  libcups.2.dylib (522.3) <7AF22069-C3A2-3263-81D6-2BE4DB4FECCA> /usr/lib/libcups.2.dylib
+       0x19e5d8000 -        0x19e5e4747  com.apple.NetAuth (6.2 - 6.2) <C9B294F3-C37B-3729-9493-10DCBE2362A6> /System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
+       0x19e5e5000 -        0x19e5e9dcb  com.apple.ColorSyncLegacy (4.13.0 - 1) <333CBEEF-B92E-3132-8C87-C4F758D44C82> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSyncLegacy.framework/Versions/A/ColorSyncLegacy
+       0x19e5ea000 -        0x19e5f2def  com.apple.QD (4.0 - 451) <4C584383-7D25-3207-BCAA-EDA21353B728> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
+       0x19e5f3000 -        0x19e600b1f  com.apple.perfdata (1.0 - 130) <AED99EAC-C348-3326-98F1-97D0AE3CEBAD> /System/Library/PrivateFrameworks/perfdata.framework/Versions/A/perfdata
+       0x19e601000 -        0x19e60ec9f  libperfcheck.dylib (46) <90EEF798-81FA-38B6-99AF-117D4AB01DE6> /usr/lib/libperfcheck.dylib
+       0x19e60f000 -        0x19e620187  com.apple.Kerberos (3.0 - 1) <E44B7A34-FE5B-3390-AC49-00907B159390> /System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
+       0x19e621000 -        0x19e672aaf  com.apple.GSS (4.0 - 2.0) <6DD8C0F7-306B-3FCF-AE30-A174E455F142> /System/Library/Frameworks/GSS.framework/Versions/A/GSS
+       0x19e673000 -        0x19e683d6f  com.apple.CommonAuth (4.0 - 2.0) <A5F22FD9-D680-3B7C-B7F9-8BE2C58F7DFF> /System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
+       0x19e684000 -        0x19e767c7f  com.apple.MobileAssets (1.0 - 1837.101.1) <BDDD31D4-3841-302F-A4B8-697F85E50F8F> /System/Library/PrivateFrameworks/MobileAsset.framework/Versions/A/MobileAsset
+       0x19e7fa000 -        0x19e809160  com.apple.CorePhoneNumbers (1.0 - 1) <8E1BEC85-B822-3578-A145-720317FA3F1F> /System/Library/PrivateFrameworks/CorePhoneNumbers.framework/Versions/A/CorePhoneNumbers
+       0x19e80a000 -        0x19e89345f  libTelephonyUtilDynamic.dylib (6392) <5ABD80F2-0F5C-36B3-B759-32DC018F1809> /usr/lib/libTelephonyUtilDynamic.dylib
+       0x1a0121000 -        0x1a01d8fff  com.apple.Bluetooth (1.0 - 1) <59C9AA53-58A9-3FC2-BFEA-9A7D16BAA9E0> /System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
+       0x1a03d3000 -        0x1a04c6a36  com.apple.combine (1.0 - 3023) <04059A33-C97D-3F63-A2C4-E56496D251DD> /System/Library/Frameworks/Combine.framework/Versions/A/Combine
+       0x1a04c7000 -        0x1a22e0d7f  com.apple.GeoServices (1.0 - 2031.24.7.17.31) <941EEC3D-2826-3394-A064-9A417CD19D1A> /System/Library/PrivateFrameworks/GeoServices.framework/Versions/A/GeoServices
+       0x1a2309000 -        0x1a230c967  com.apple.speech.recognition.framework (6.0.5 - 6.0.5) <B7465A14-09B0-338E-A327-28FE7E77F7BC> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
+       0x1a2698000 -        0x1a26bab9f  com.apple.Accessibility (1.0 - 1) <44FEE1CE-C2A4-3A7B-9180-6908428417CD> /System/Library/Frameworks/Accessibility.framework/Versions/A/Accessibility
+       0x1a26bb000 -        0x1a26bc89f  libpanel.5.4.dylib (79) <613B06CC-8188-3447-B6C0-E712464C136E> /usr/lib/libpanel.5.4.dylib
+       0x1a26f5000 -        0x1a26f586f  com.apple.Accelerate.vecLib (3.11 - vecLib 3.11) <273012BA-11EF-3A4E-A050-A3A488943FA3> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
+       0x1a271a000 -        0x1a271a98f  com.apple.CoreServices (1226 - 1226) <95340769-0B35-37EA-9EAF-9A7E1D530910> /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
+       0x1a2999000 -        0x1a2999417  com.apple.Accelerate (1.11 - Accelerate 1.11) <0A9F7A80-1DC3-369D-AE67-2D21EE9D7C50> /System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
+       0x1a29e8000 -        0x1a29fa53f  com.apple.MediaAccessibility (1.0 - 153) <A2FBFD9E-30EC-3617-9D3A-05A8625ED12C> /System/Library/Frameworks/MediaAccessibility.framework/Versions/A/MediaAccessibility
+       0x1a2a41000 -        0x1a30daebf  com.apple.VN (9.5.4 - 9.5.4) <F5F8E563-83DF-34D4-A50D-6B19D70EFF35> /System/Library/Frameworks/Vision.framework/Versions/A/Vision
+       0x1a30db000 -        0x1a30db3ef  libswiftFoundation.dylib (2000) <927F1F52-43AA-3D11-995E-AC21E4294038> /usr/lib/swift/libswiftFoundation.dylib
+       0x1a3783000 -        0x1a388d09f  com.apple.CoreBluetooth (194.26.1.0.1) <B3EE681B-1684-3117-93EF-EE56600BA17A> /System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
+       0x1a388e000 -        0x1a389d53f  com.apple.SymptomDiagnosticReporter (1.0 - 411.100.14) <A1B05E3E-3DF9-33B6-BDB3-E4644931BB69> /System/Library/PrivateFrameworks/SymptomDiagnosticReporter.framework/Versions/A/SymptomDiagnosticReporter
+       0x1a389e000 -        0x1a38cc2ff  com.apple.PowerLog (1.0 - 1) <36E48134-17FF-3841-B765-79589A4CFCBA> /System/Library/PrivateFrameworks/PowerLog.framework/Versions/A/PowerLog
+       0x1a38da000 -        0x1a398b6df  com.apple.DiscRecording (9.0.3 - 9030.4.5) <79D5F6E9-7FA2-336E-9793-225B4A412D1C> /System/Library/Frameworks/DiscRecording.framework/Versions/A/DiscRecording
+       0x1a398c000 -        0x1a39bd137  com.apple.MediaKit (16 - 938) <784D6F29-2E0E-3AB2-8E3E-83009F82812F> /System/Library/PrivateFrameworks/MediaKit.framework/Versions/A/MediaKit
+       0x1a3aa1000 -        0x1a3aad23f  com.apple.CoreAUC (616.1 - 616.1) <A77A7D29-C5D1-31FB-B078-7D43E7CC28EF> /System/Library/PrivateFrameworks/CoreAUC.framework/Versions/A/CoreAUC
+       0x1a3aae000 -        0x1a3ab177b  com.apple.Mangrove (1.0 - 25) <0A77F849-B195-3432-B2BF-B0C902AD0408> /System/Library/PrivateFrameworks/Mangrove.framework/Versions/A/Mangrove
+       0x1a3ab2000 -        0x1a3adff87  com.apple.CoreAVCHD (6.0.0 - 6244.1) <C9F9BF8E-73E0-3FC6-9442-12A031AE3514> /System/Library/PrivateFrameworks/CoreAVCHD.framework/Versions/A/CoreAVCHD
+       0x1a4276000 -        0x1a445da3f  com.apple.CoreTelephony (113 - 13173) <69DAAAC7-AEA3-3BD0-9BC0-34ABF9CD259A> /System/Library/Frameworks/CoreTelephony.framework/Versions/A/CoreTelephony
+       0x1a447a000 -        0x1a4490950  libswiftDispatch.dylib (1542.100.32) <CFCF86C6-4B2C-3D79-A3B2-93B725BCEF2C> /usr/lib/swift/libswiftDispatch.dylib
+       0x1a4491000 -        0x1a470011f  com.apple.AVFCore (1.0 - 2410.24.5.1) <37D9A2FB-87BB-356F-B543-4E00C1844176> /System/Library/PrivateFrameworks/AVFCore.framework/Versions/A/AVFCore
+       0x1a4701000 -        0x1a47da3bf  com.apple.FrontBoardServices (1000.4.11 - 1000.4.11) <E3110730-AF5C-37E8-ACA3-B74D7A7BDA4F> /System/Library/PrivateFrameworks/FrontBoardServices.framework/Versions/A/FrontBoardServices
+       0x1a47db000 -        0x1a4867c3f  com.apple.BoardServices (1.0 - 732.1.1) <00CE20DD-828E-3ECD-92A3-FF88B0DA61CE> /System/Library/PrivateFrameworks/BoardServices.framework/Versions/A/BoardServices
+       0x1a48a8000 -        0x1a48b553f  com.apple.GraphicsServices (1.0 - 1.0) <C1833E07-4E3E-3604-9C04-CEF7FA7B55D9> /System/Library/PrivateFrameworks/GraphicsServices.framework/Versions/A/GraphicsServices
+       0x1a48ba000 -        0x1a493badf  com.apple.CryptoTokenKit (1.0 - 1) <F83B4058-AFFB-39D0-82D3-A2AA8D1D3243> /System/Library/Frameworks/CryptoTokenKit.framework/Versions/A/CryptoTokenKit
+       0x1a4bd1000 -        0x1a4bf2e9f  com.apple.DebugSymbols (216 - 217) <28F7AD5A-D1F0-36D5-9658-BDE3910BEA55> /System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
+       0x1a4bf3000 -        0x1a4d4e5ff  com.apple.CoreSymbolication (16.0 - 64575.51.1) <FDAEC762-CC55-34D9-9951-85382E50F9F5> /System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
+       0x1a4d4f000 -        0x1a4d5909f  com.apple.CoreTime (334.0.16.3 - 334.0.16.3) <6B69F2AE-681C-34FE-AF72-5932E6396B76> /System/Library/PrivateFrameworks/CoreTime.framework/Versions/A/CoreTime
+       0x1a4d5a000 -        0x1a4e4d4bf  com.apple.Rapport (7.1 - 715.2) <F135A4EF-AD5C-33AF-898C-327F9A9AD6DE> /System/Library/PrivateFrameworks/Rapport.framework/Versions/A/Rapport
+       0x1a61e5000 -        0x1a66a687f  com.apple.CoreWiFi (1.0 - 1000.18) <54180EFA-D1A0-3ECE-8975-0290F0C2B234> /System/Library/PrivateFrameworks/CoreWiFi.framework/Versions/A/CoreWiFi
+       0x1a66a7000 -        0x1a671959f  com.apple.BackBoardServices (1.0 - 1.0) <1BFBA7A9-B789-3FCB-9C5D-987DE4D1DEE8> /System/Library/PrivateFrameworks/BackBoardServices.framework/Versions/A/BackBoardServices
+       0x1a671a000 -        0x1a67554ef  com.apple.LDAPFramework (2.4.28 - 194.5) <2FEFD34B-DFD5-36E0-9CEE-7EFE6FDA7FD9> /System/Library/Frameworks/LDAP.framework/Versions/A/LDAP
+       0x1a6756000 -        0x1a67577b7  com.apple.TrustEvaluationAgent (2.0 - 38) <16ED4F40-C1B7-3F95-8FDD-CDE8DD7FA1A7> /System/Library/PrivateFrameworks/TrustEvaluationAgent.framework/Versions/A/TrustEvaluationAgent
+       0x1a6885000 -        0x1a693e57f  com.apple.DiskImagesFramework (683.100.3 - 683.100.3) <B870832E-8BB7-3E88-9B9D-A25AEB6FD2B0> /System/Library/PrivateFrameworks/DiskImages.framework/Versions/A/DiskImages
+       0x1a697f000 -        0x1a69955bf  com.apple.RemoteServiceDiscovery (1.0 - 219.100.6) <F4BB09A4-E464-35B8-968E-8936A4298C48> /System/Library/PrivateFrameworks/RemoteServiceDiscovery.framework/Versions/A/RemoteServiceDiscovery
+       0x1a6996000 -        0x1a69abc3f  com.apple.xpc.RemoteXPC (1.0 - 3102.100.102) <ED290C70-5627-3D78-98CF-FDDCC7E6176B> /System/Library/PrivateFrameworks/RemoteXPC.framework/Versions/A/RemoteXPC
+       0x1a6a2b000 -        0x1a6a2e653  com.apple.help (1.3.8 - 81) <B06CE5C5-37B6-3926-ABBC-89369CC18DAD> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
+       0x1a6a40000 -        0x1a6ac0f43  libcurl.4.dylib (164) <E0A4E7B3-7592-39E5-B8B9-D1DB72C95041> /usr/lib/libcurl.4.dylib
+       0x1a6ac7000 -        0x1a6b0a25f  com.apple.AppSupport (1.0.0 - 29) <3DE9E998-0707-3635-B57B-1954D8712DFB> /System/Library/PrivateFrameworks/AppSupport.framework/Versions/A/AppSupport
+       0x1a6dda000 -        0x1a6dda927  com.apple.ApplicationServices (48 - 66) <542873FE-897D-3929-A243-4FF3B6468C82> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
+       0x1a6ddb000 -        0x1a6dddf3f  com.apple.InternationalTextSearch (1.0 - 1) <33E50974-2591-31C3-9853-2096E37742F3> /System/Library/PrivateFrameworks/InternationalTextSearch.framework/Versions/A/InternationalTextSearch
+       0x1a73a6000 -        0x1a73a9d3f  com.apple.security.CryptoKit-C-Bridging (1.0 - 1) <D0F2916D-4EEA-3A82-82A7-D2704D32E7A5> /System/Library/PrivateFrameworks/CryptoKitCBridging.framework/Versions/A/CryptoKitCBridging
+       0x1a73aa000 -        0x1a73aa3f7  libHeimdalProxy.dylib (88) <4E34BA0D-4F2D-3A97-8A03-0F961CF5A58A> /System/Library/Frameworks/Kerberos.framework/Versions/A/Libraries/libHeimdalProxy.dylib
+       0x1a73ab000 -        0x1a73ab512  com.apple.audio.units.AudioUnit (1.14 - 1.14) <85863348-479E-3696-A780-FC739E0B979A> /System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
+       0x1a73d5000 -        0x1a73f3b9f  com.apple.StreamingZip (1.0 - 1) <4D3F2AFC-034D-30C7-88D1-B7B2DC521310> /System/Library/PrivateFrameworks/StreamingZip.framework/Versions/A/StreamingZip
+       0x1a744d000 -        0x1a74506bf  libswiftObjectiveC.dylib (951.7) <1BF42593-32DC-301E-B8EC-BFDA5DE18F37> /usr/lib/swift/libswiftObjectiveC.dylib
+       0x1a7451000 -        0x1a746e6ff  libswiftos.dylib (1082) <B8E3586E-8FD3-37F9-A004-C0E369A4F650> /usr/lib/swift/libswiftos.dylib
+       0x1a7535000 -        0x1a838675f  com.apple.vision.EspressoFramework (1.0 - 3520.15.1.14.2) <FBFB25C9-2D45-3A79-8178-9A29D8B51D13> /System/Library/PrivateFrameworks/Espresso.framework/Versions/A/Espresso
+       0x1a8387000 -        0x1a83b799f  com.apple.ANEServices (9.511 - 9.511) <76555323-AE24-3804-8064-60846E7511C4> /System/Library/PrivateFrameworks/ANEServices.framework/Versions/A/ANEServices
+       0x1a83b8000 -        0x1a844685f  com.apple.proactive.support.ProactiveSupport (1.0 - 418.1) <F035491A-8388-3A51-B36A-C3B20C8A0FE8> /System/Library/PrivateFrameworks/ProactiveSupport.framework/Versions/A/ProactiveSupport
+       0x1a8543000 -        0x1a856729f  com.apple.ASEProcessing (1.55.0 - 1.55.0) <830CFC7B-FEDE-3187-A209-B49966597433> /System/Library/PrivateFrameworks/ASEProcessing.framework/Versions/A/ASEProcessing
+       0x1a9603000 -        0x1a967087f  com.apple.CoreML.AppleNeuralEngine (1.0 - 1) <342FCCB6-AE2A-3DBA-91A1-44B2D3E5A82D> /System/Library/PrivateFrameworks/AppleNeuralEngine.framework/Versions/A/AppleNeuralEngine
+       0x1a97be000 -        0x1a988cc1f  com.apple.audio.midi.CoreMIDI (2.0 - 88) <03707B1E-A19F-32D7-98A9-E3A7248B1209> /System/Library/Frameworks/CoreMIDI.framework/Versions/A/CoreMIDI
+       0x1a99b1000 -        0x1a99b1467  com.apple.Cocoa (6.11 - 24) <AC139373-5D57-327A-943E-DD7A3ABB2C6F> /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
+       0x1aa4c6000 -        0x1aa4ca75f  com.apple.IOSurfaceAccelerator (1.0.0 - 1.0.0) <ED79EC5A-409D-39A9-9521-3043C39FE108> /System/Library/PrivateFrameworks/IOSurfaceAccelerator.framework/Versions/A/IOSurfaceAccelerator
+       0x1ac079000 -        0x1ac095b1f  com.apple.openscripting (1.7 - 199) <DBAC1721-88C8-3691-BFEC-0A6DD1E04406> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
+       0x1ac096000 -        0x1ac098d27  com.apple.securityhi (9.0 - 55010) <99BE2B0B-F5DA-3212-B1DF-3C63F7E14E16> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
+       0x1ac099000 -        0x1ac099863  com.apple.ink.framework (10.15 - 227) <8A2A01EC-03ED-32DB-8C43-0BEDE0AABEA8> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
+       0x1ac09a000 -        0x1ac09dba7  com.apple.CommonPanels (1.2.6 - 106.1) <A6BFBD00-8EDF-3C33-ADDB-84E7544F2067> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
+       0x1ac09e000 -        0x1ac0a01fb  com.apple.ImageCapture (2020.2.2 - 2020.2.2) <C6290EDB-1C43-30C1-AD28-5B9E4F96EE02> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
+       0x1adc42000 -        0x1ade8313f  com.apple.AVFCapture (1.0 - 665.101.3) <384B6DB9-A738-3199-8298-49A3B970AD5D> /System/Library/PrivateFrameworks/AVFCapture.framework/Versions/A/AVFCapture
+       0x1ade84000 -        0x1adfb4d1f  com.apple.Quagga (186 - 186) <A39F98F2-3E99-3150-96EF-0C62B827909D> /System/Library/PrivateFrameworks/Quagga.framework/Versions/A/Quagga
+       0x1adfb5000 -        0x1ae5efb1f  com.apple.CMCapture (1.0 - 665.101.3) <51D4272C-4794-3536-9D9E-86D9B53BBD08> /System/Library/PrivateFrameworks/CMCapture.framework/Versions/A/CMCapture
+       0x1ae5f0000 -        0x1ae77391f  com.apple.RenderBox (7.4.25 - 7.4.25) <392735CB-8F39-390C-A7DE-6DF080C008EB> /System/Library/PrivateFrameworks/RenderBox.framework/Versions/A/RenderBox
+       0x1af322000 -        0x1af3359ff  com.apple.HID (1.0 - 1) <F7402197-24C0-392F-9137-8681EF9C6670> /System/Library/PrivateFrameworks/HID.framework/Versions/A/HID
+       0x1af643000 -        0x1af68b08b  com.apple.private.yara (1.0 - 1) <773122F6-E6D1-360B-9B90-47B559A29580> /System/Library/PrivateFrameworks/yara.framework/Versions/A/yara
+       0x1b0221000 -        0x1b022217f  com.apple.PhoneNumbers (1.0 - 1) <EA60A0F6-0C9C-3FA4-BD81-AE210925F4E5> /System/Library/PrivateFrameworks/PhoneNumbers.framework/Versions/A/PhoneNumbers
+       0x1b022d000 -        0x1b0338bbf  com.apple.accessibility.AXCoreUtilities (1.0 - 1) <820A456D-11CD-320F-BB0C-25B9E5F69472> /System/Library/PrivateFrameworks/AXCoreUtilities.framework/Versions/A/AXCoreUtilities
+       0x1b0339000 -        0x1b036f75f  libAccessibility.dylib (3191.25.1) <09AA52ED-5DA3-382A-B25E-D7859E2DC832> /usr/lib/libAccessibility.dylib
+       0x1b3dc8000 -        0x1b3dd71ff  com.apple.NetFS (6.0 - 4.0) <96DF6DA3-4780-3138-8318-2D9292EA4775> /System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
+       0x1b4321000 -        0x1b4321357  libswiftCoreGraphics.dylib (17) <B50E0A57-5B80-3B7C-A5FB-C1032C27D887> /usr/lib/swift/libswiftCoreGraphics.dylib
+       0x1b4322000 -        0x1b4324707  libswiftDarwin.dylib (377.100.15) <319E1D29-E697-3ABC-BE2D-B897CD71F3F2> /usr/lib/swift/libswiftDarwin.dylib
+       0x1b5e3e000 -        0x1b5e3e817  com.apple.Carbon (160 - 170) <E30FAC97-B793-3704-9A30-23C4531CCE7C> /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
+       0x1b5e3f000 -        0x1b61d929f  com.apple.coremotion (3072.0.46.3.1 - 3072.0.46.3.1) <9B758E78-0B5C-341E-838E-36FEF5DB83FC> /System/Library/Frameworks/CoreMotion.framework/Versions/A/CoreMotion
+       0x1b6241000 -        0x1b62415a7  com.apple.avfoundation (2.0 - 2410.24.5.1) <A91FBD2D-DE97-341C-8E45-058E8B968DFE> /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
+       0x1b6375000 -        0x1b645e4bf  libquic.dylib (5812.101.2) <4D5CD3CB-3FDD-38B3-BB26-EBB2582A5AA1> /usr/lib/libquic.dylib
+       0x1b646a000 -        0x1b6492eff  com.apple.private.SystemPolicy (1.0 - 1) <8618CC84-FA89-362C-AD11-E70A0B62EFF8> /System/Library/PrivateFrameworks/SystemPolicy.framework/Versions/A/SystemPolicy
+       0x1b6ffe000 -        0x1b70765ff  com.apple.NaturalLanguage (1.0 - 114) <768F35AE-2817-3116-AFFB-9A0721FAA2C4> /System/Library/Frameworks/NaturalLanguage.framework/Versions/A/NaturalLanguage
+       0x1b733a000 -        0x1b73c8bff  com.apple.LoggingSupport (1.0 - 1861.100.19) <F1F1C407-6F51-3081-B00F-EA13A5B3DED8> /System/Library/PrivateFrameworks/LoggingSupport.framework/Versions/A/LoggingSupport
+       0x1b73c9000 -        0x1b73d5acb  com.apple.MallocStackLogging (1.0 - 65000) <0A1A0710-C15E-3C5D-A67A-B582F40B23F4> /System/Library/PrivateFrameworks/MallocStackLogging.framework/Versions/A/MallocStackLogging
+       0x1b73fb000 -        0x1b7453aff  libmis.dylib (463.100.17) <6709C629-CDF4-3590-94C3-720428D172F5> /usr/lib/libmis.dylib
+       0x1b7454000 -        0x1b7457c5f  com.apple.gpusw.GPURawCounter (34 - 34) <5EB9C19F-7B49-31FC-A0F4-F8DDBD5B2859> /System/Library/PrivateFrameworks/GPURawCounter.framework/Versions/A/GPURawCounter
+       0x1b7458000 -        0x1b747787f  libswiftCoreAudio.dylib (411.520) <E048689E-9E66-3941-AA17-48B0A441ED26> /usr/lib/swift/libswiftCoreAudio.dylib
+       0x1b7478000 -        0x1b747e327  libswiftCoreFoundation.dylib (2411) <8160F4BC-FCFC-3847-8912-7D784E814692> /usr/lib/swift/libswiftCoreFoundation.dylib
+       0x1b748b000 -        0x1b74d76d3  libswiftXPC.dylib (128.100.15) <60C33839-9A05-3397-A1FB-CC203B10AB2D> /usr/lib/swift/libswiftXPC.dylib
+       0x1b74d8000 -        0x1b74d87ff  libswiftCoreImage.dylib (2.2) <40B43AC1-C3F9-320C-A4E3-622BF2EE9EF6> /usr/lib/swift/libswiftCoreImage.dylib
+       0x1b74d9000 -        0x1b74d98a3  libswiftIOKit.dylib (1) <3609AE97-C1C9-3D5C-995D-1351BE19C532> /usr/lib/swift/libswiftIOKit.dylib
+       0x1b7e48000 -        0x1b7ec69df  com.apple.TrialProto (1.0 - 474.2.18) <D42C380B-5169-3720-914F-C99F27CB45B7> /System/Library/PrivateFrameworks/TrialProto.framework/Versions/A/TrialProto
+       0x1b7ec7000 -        0x1b7f706ff  com.apple.trial (1.0 - 474.2.18) <5CA59866-367F-30D5-B0AA-7EE72B82B80C> /System/Library/PrivateFrameworks/Trial.framework/Versions/A/Trial
+       0x1b9505000 -        0x1b953e2c7  libbootpolicy.dylib (289.100.5) <906CDC5E-FCE3-3DB4-AC97-46C9373D6C26> /usr/lib/libbootpolicy.dylib
+       0x1ba5ea000 -        0x1ba618a1f  com.apple.skp.FeedbackLogger (1.0 - 1) <270485CB-B53E-3B3E-AD0A-26EF7615320B> /System/Library/PrivateFrameworks/FeedbackLogger.framework/Versions/A/FeedbackLogger
+       0x1bafb3000 -        0x1bafca88b  libswiftsimd.dylib (23) <BF085F71-EE8E-3791-B258-816A98B1E84B> /usr/lib/swift/libswiftsimd.dylib
+       0x1bb236000 -        0x1bb40d07f  com.apple.TextInput (1.0 - 1.0) <35AA800B-620D-30C5-AC16-AFCC51D29EB7> /System/Library/PrivateFrameworks/TextInput.framework/Versions/A/TextInput
+       0x1bc68c000 -        0x1bc6c82af  libncurses.5.4.dylib (79) <071B3987-EFA6-3936-B470-B7ECDCD000FB> /usr/lib/libncurses.5.4.dylib
+       0x1bc6c9000 -        0x1bc6d237f  com.apple.IOAccelMemoryInfo (1.0 - 1) <AEE0B693-229A-32BD-8CF6-B534B4FB73E1> /System/Library/PrivateFrameworks/IOAccelMemoryInfo.framework/Versions/A/IOAccelMemoryInfo
+       0x1bce56000 -        0x1bdd46adf  com.apple.siri.SiriInstrumentation (1.0 - 1) <B95E0E6A-6B00-340E-B95D-1BAA1208775C> /System/Library/PrivateFrameworks/SiriInstrumentation.framework/Versions/A/SiriInstrumentation
+       0x1bdd84000 -        0x1bdd8d0be  libswiftCoreMIDI.dylib (6) <5E94EF55-3133-3ABB-9C73-E75138953F3D> /usr/lib/swift/libswiftCoreMIDI.dylib
+       0x1be560000 -        0x1be566bbf  com.apple.MSUDataAccessor (1.0 - 1) <CBF1231F-9088-3855-83B8-9B5196641BBC> /System/Library/PrivateFrameworks/MSUDataAccessor.framework/Versions/A/MSUDataAccessor
+       0x1be98a000 -        0x1be9eca3f  com.apple.SoftwareUpdateCoreSupport (1.0 - 1) <820532AC-6CC2-352E-95F0-CD31377DA3B4> /System/Library/PrivateFrameworks/SoftwareUpdateCoreSupport.framework/Versions/A/SoftwareUpdateCoreSupport
+       0x1c0596000 -        0x1c05db0ff  com.apple.AttributeGraph (7.0.80 - 7.0.80) <C9289991-F749-3DF3-AEFA-788884864080> /System/Library/PrivateFrameworks/AttributeGraph.framework/Versions/A/AttributeGraph
+       0x1c074b000 -        0x1c0ff169f  libfaceCore.dylib (9.5.4) <6038AE24-75A6-311E-AC3F-854034BDED2E> /System/Library/Frameworks/Vision.framework/libfaceCore.dylib
+       0x1c0ff2000 -        0x1c126459f  com.apple.TextRecognition (1.0 - 157) <F235AA1F-A750-33A7-8697-5A9C1074D9CD> /System/Library/PrivateFrameworks/TextRecognition.framework/Versions/A/TextRecognition
+       0x1c1265000 -        0x1c127c25f  com.apple.Futhark (1.0 - 1) <9F8F0EED-5668-3C7F-AC08-AA4C1B14572D> /System/Library/PrivateFrameworks/Futhark.framework/Versions/A/Futhark
+       0x1c17bc000 -        0x1c17f5ba7  com.apple.MobileBluetooth (1.0 - 1.0) <AC6F8C2C-8C3E-3EB7-B64C-62696ADB2BED> /System/Library/PrivateFrameworks/MobileBluetooth.framework/Versions/A/MobileBluetooth
+       0x1c24a5000 -        0x1c24fc39f  com.apple.biome.BiomeFoundation (1.0 - 209.15.0.2) <87FC78C7-6A65-3209-9537-DEE615D84725> /System/Library/PrivateFrameworks/BiomeFoundation.framework/Versions/A/BiomeFoundation
+       0x1c518c000 -        0x1c52033df  com.apple.acg.InertiaCam (1.0 - 1) <61D434C4-AE11-3800-8510-C03EABC6836C> /System/Library/PrivateFrameworks/InertiaCam.framework/Versions/A/InertiaCam
+       0x1c53c5000 -        0x1c53d2a1f  libswiftMetal.dylib (372.16) <D96EF332-F72B-3B75-82E3-5FBDD6882BC4> /usr/lib/swift/libswiftMetal.dylib
+       0x1c53d3000 -        0x1c53d9e05  libswiftCompression.dylib (11) <E0C174A8-CE74-3FF0-81C3-E71693751F76> /usr/lib/swift/libswiftCompression.dylib
+       0x1c62f7000 -        0x1c63a1d5f  libFDR.dylib (1499.100.48) <142B6C05-3B93-3A74-89BB-FC0719EDAFD0> /usr/lib/libFDR.dylib
+       0x1c63a2000 -        0x1c64228ff  com.apple.TimeSync (1.0 - 1440.24) <FE022DCF-5424-3ADA-8E7B-D3AD1A50B2CD> /System/Library/PrivateFrameworks/TimeSync.framework/Versions/A/TimeSync
+       0x1c6423000 -        0x1c69edf5f  com.apple.biome.BiomeStreams (1.0 - 209.15.0.2) <89BE0C47-C549-3DB1-AEEE-8A5DEBEE4688> /System/Library/PrivateFrameworks/BiomeStreams.framework/Versions/A/BiomeStreams
+       0x1c6ec1000 -        0x1c6ed58ff  com.apple.SoftwareUpdateCoreConnect (1.0 - 1) <1C3E0445-FC4C-3BA1-A555-7CBB653840F2> /System/Library/PrivateFrameworks/SoftwareUpdateCoreConnect.framework/Versions/A/SoftwareUpdateCoreConnect
+       0x1c805e000 -        0x1c8067b5f  com.apple.audio.IOKitten (300.1 - 300.1) <0686A098-1D27-377C-962F-7961E9FD1B36> /System/Library/PrivateFrameworks/IOKitten.framework/Versions/A/IOKitten
+       0x1c9310000 -        0x1c937ac1f  com.apple.osanalytics.OSAnalytics (1.0 - 1) <69F29612-5092-3F2F-BA61-5510D4857FA2> /System/Library/PrivateFrameworks/OSAnalytics.framework/Versions/A/OSAnalytics
+       0x1ca7a6000 -        0x1ca7a7f9f  libswiftQuartzCore.dylib (5) <CCB3028F-09BA-3887-947D-6F8FD47E2B09> /usr/lib/swift/libswiftQuartzCore.dylib
+       0x1cab99000 -        0x1cab9e8e7  com.apple.kperf (1.0 - 1) <56910FEC-A3D1-3DF4-9CD3-31C65D4B7B88> /System/Library/PrivateFrameworks/kperf.framework/Versions/A/kperf
+       0x1cacb0000 -        0x1cacb563f  com.apple.MobileSystemServices (1.0 - 1) <61161103-8CB4-34CC-8AD6-43F587D2D25B> /System/Library/PrivateFrameworks/MobileSystemServices.framework/Versions/A/MobileSystemServices
+       0x1cc29a000 -        0x1cc2bc29f  libamsupport.dylib (434.100.4) <0D37C527-DC1F-363A-B4D8-A0E95104DA36> /usr/lib/libamsupport.dylib
+       0x1cc698000 -        0x1cc6f80bf  com.apple.biome.BiomePubSub (1.0 - 209.15.0.2) <1056981B-EFD4-37A2-8CA3-2691A18A34EF> /System/Library/PrivateFrameworks/BiomePubSub.framework/Versions/A/BiomePubSub
+       0x1cc6f9000 -        0x1cc73c01f  com.apple.biome.BiomeStorage (1.0 - 209.15.0.2) <31E41201-08D1-338B-BDED-CC6A677D7487> /System/Library/PrivateFrameworks/BiomeStorage.framework/Versions/A/BiomeStorage
+       0x1cca26000 -        0x1cca391ff  com.apple.private.XprotectFrameWork.XprotectFramework (1.0 - 1) <4EA5944E-33C5-372F-9C0C-FE20BD7126A5> /System/Library/PrivateFrameworks/XprotectFramework.framework/Versions/A/XprotectFramework
+       0x1cf22e000 -        0x1cf23d13f  libswiftUniformTypeIdentifiers.dylib (877.4.9.400) <B08C16EF-8677-3331-B9A6-16294A1A6AA0> /usr/lib/swift/libswiftUniformTypeIdentifiers.dylib
+       0x1cf23e000 -        0x1cf303a9b  libswiftAccelerate.dylib (77.100.2) <ADC97387-1D6A-3155-B732-3F5066BD6360> /usr/lib/swift/libswiftAccelerate.dylib
+       0x1cf456000 -        0x1cf46711f  libpartition2_dynamic.dylib (3476.100.145) <21D8FFBE-3A8A-3D01-B608-085D50238EE5> /usr/lib/libpartition2_dynamic.dylib
+       0x1cf9c3000 -        0x1cf9cdfdf  com.apple.AFKUser (1.0 - 1) <C25CEB23-5EF8-3E11-A260-EDA76C3A7105> /System/Library/PrivateFrameworks/AFKUser.framework/Versions/A/AFKUser
+       0x1d1e62000 -        0x1d1e6cb3f  com.apple.CPMS (1.0 - 1) <1F55B0F5-DC93-3C50-B544-1A509820746D> /System/Library/PrivateFrameworks/CPMS.framework/Versions/A/CPMS
+       0x1d33a7000 -        0x1d340875f  libswiftCoreMedia.dylib (3305.24.5.2) <450AA35C-B2E6-3327-827B-ACEB171F87D4> /usr/lib/swift/libswiftCoreMedia.dylib
+       0x1d4b55000 -        0x1d4b56bbf  libswiftOSLog.dylib (10) <2B310D36-BAAA-346C-860E-2B9FA9EBFE2F> /usr/lib/swift/libswiftOSLog.dylib
+       0x1d4ded000 -        0x1d4e355df  libswiftAVFoundation.dylib (2410.24.5.1) <CF222BF4-8FEE-30B8-90D9-52E2BE74466A> /usr/lib/swift/libswiftAVFoundation.dylib
+       0x1d8c1b000 -        0x1d8d27aff  com.apple.Symbolication (16.0 - 64575.69.1) <D18DE969-073E-38CF-BA4F-466045A5818D> /System/Library/PrivateFrameworks/Symbolication.framework/Versions/A/Symbolication
+       0x1d93f3000 -        0x1d93fc4d3  com.apple.framework.netrb (1.0 - 1) <C618A482-D842-3096-B090-AFD53AC31AA2> /System/Library/PrivateFrameworks/Netrb.framework/Versions/A/Netrb
+       0x1d9431000 -        0x1d9455c1f  com.apple.CoreMaterial (1.0 - 1) <D2A2A7C2-02D9-3586-AD56-B08F345483E5> /System/Library/PrivateFrameworks/CoreMaterial.framework/Versions/A/CoreMaterial
+       0x1dd222000 -        0x1dd2323df  com.apple.OSLog (1.0 - 1861.100.19) <D1D8B4E1-367E-3ED0-AD02-37D720B6F1E7> /System/Library/Frameworks/OSLog.framework/Versions/A/OSLog
+       0x1dd530000 -        0x1dd64175f  com.apple.InternalSwiftProtobuf (1.0 - 1.26.0) <A510588F-6A70-3706-8E8F-AD186EE908A9> /System/Library/PrivateFrameworks/InternalSwiftProtobuf.framework/Versions/A/InternalSwiftProtobuf
+       0x1dd707000 -        0x1dd7120bf  com.apple.HIDDisplay (1.0 - 1) <B2053120-9D29-3678-8566-7388E0B5DC33> /System/Library/PrivateFrameworks/HIDDisplay.framework/Versions/A/HIDDisplay
+       0x1e0289000 -        0x1e032e35f  com.apple.security.CryptoKit (1.0 - 1) <D7C5C0C1-0448-347B-8295-48E58DA1E588> /System/Library/Frameworks/CryptoKit.framework/Versions/A/CryptoKit
+       0x1e3532000 -        0x1e354fd9f  libedit.3.dylib (65) <B52B7A66-3106-3250-829C-A68EC8D0925B> /usr/lib/libedit.3.dylib
+       0x1e5666000 -        0x1e5666af3  com.apple.FeatureFlags (1.0 - 103) <320F2910-E9AD-3A26-A9E5-80709DE442C6> /System/Library/PrivateFrameworks/FeatureFlags.framework/Versions/A/FeatureFlags
+       0x1e5672000 -        0x1e5679cbf  libswiftNaturalLanguage.dylib (4.3) <7F45AD44-826C-35FB-B6C4-C1670389699E> /usr/lib/swift/libswiftNaturalLanguage.dylib
+       0x1e56ea000 -        0x1e573b7bf  com.apple.WiFiPeerToPeer (845.22.0 - 845.22) <57421E22-C817-3A6F-AE74-96942B45E286> /System/Library/PrivateFrameworks/WiFiPeerToPeer.framework/Versions/A/WiFiPeerToPeer
+       0x1ee632000 -        0x1ee65424f  libswiftSwiftOnoneSupport.dylib (6.3.0 - 6.3.0.123.11) <E229DEDA-78FE-3E96-AD2F-53CF7DD8082C> /usr/lib/swift/libswiftSwiftOnoneSupport.dylib
+       0x1eec8e000 -        0x1eec905bf  com.apple.ConfigProfileHelper (18.0 - 1800) <CC0C5D1A-B8D4-31A2-89E1-0EFAC52DCB20> /System/Library/PrivateFrameworks/ConfigProfileHelper.framework/Versions/A/ConfigProfileHelper
+       0x22c650000 -        0x22dcc9067  com.apple.ANECompiler (9.509.0 - 9.509.0) <27B2AFC5-42C2-35A0-8DC0-2B06592B4F15> /System/Library/PrivateFrameworks/ANECompiler.framework/Versions/A/ANECompiler
+       0x22f2c6000 -        0x22f2cd2a3  libCoreFSCache.dylib (352) <4AC2B004-453D-3053-8CE3-DB02BF78634B> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreFSCache.dylib
+       0x22f2ce000 -        0x22f2d3947  libCoreVMClient.dylib (352) <F3F2109F-8C42-3EF3-8E23-69CE9D6D21AC> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
+       0x22f2d4000 -        0x22f2e42b7  com.apple.opengl (23.1.1 - 23.1.1) <46037BEA-D5A5-3E3F-BB30-1CAC01B5068F> /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
+       0x22f2e5000 -        0x22f2e77bf  libCVMSPluginSupport.dylib (23.1.1) <484EB0B7-ED7C-312E-B3A6-B64CC93FAA93> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
+       0x22f2e8000 -        0x22f2f04ff  libGFXShared.dylib (23.1.1) <7288278F-C62B-38D0-A3B9-5745AA80CE86> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
+       0x22f2f1000 -        0x22f32454b  libGLImage.dylib (23.1.1) <D1122A05-2EBB-3AD2-8892-C24FF521D310> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
+       0x22f325000 -        0x22f35e5bf  libGLU.dylib (23.1.1) <535E6602-2A32-3E9B-9556-AD1D11D2C842> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
+       0x22f4b5000 -        0x22f4bebc7  libGL.dylib (23.1.1) <C7B73037-CD52-3D9D-A485-91245CEFAD48> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
+       0x22f841000 -        0x22f9839ff  com.apple.audio.AVFAudio (1.0 - 743.508) <8E4D44EE-1B59-3DC5-BAC8-FD96078883D4> /System/Library/Frameworks/AVFAudio.framework/Versions/A/AVFAudio
+       0x22f985000 -        0x22f9ffebf  com.apple.AVRouting (1.0 - 1) <2DE37858-E589-37D2-BC44-DB6C706E2106> /System/Library/Frameworks/AVRouting.framework/Versions/A/AVRouting
+       0x230cce000 -        0x230d16fdf  com.apple.CoreTransferable (1.0.1 - 1) <40E313C1-EA8E-3768-9692-D4AD6AD87166> /System/Library/Frameworks/CoreTransferable.framework/Versions/A/CoreTransferable
+       0x2311e9000 -        0x2311f6bff  com.apple.DataDetection (8.0 - 821.6) <68878A04-565C-3EB1-95D6-1BAA74EF98BF> /System/Library/Frameworks/DataDetection.framework/Versions/A/DataDetection
+       0x231200000 -        0x23121775f  com.apple.dt.DeveloperToolsSupport (23.40.26 - 23.40.26) <9DE70721-8E63-36A6-A8D1-7457EFDC4505> /System/Library/Frameworks/DeveloperToolsSupport.framework/Versions/A/DeveloperToolsSupport
+       0x23134a000 -        0x2314bc81f  com.apple.ExtensionFoundation (97 - 97) <8414CA2A-21EF-3B0B-A60B-789666C62990> /System/Library/Frameworks/ExtensionFoundation.framework/Versions/A/ExtensionFoundation
+       0x232735000 -        0x232777a1f  com.apple.LightweightCodeRequirements (1.0 - 1) <BC31094B-0028-31CE-A0A4-AAAD41DD9AA3> /System/Library/Frameworks/LightweightCodeRequirements.framework/Versions/A/LightweightCodeRequirements
+       0x233597000 -        0x2335b51ff  com.apple.MPSBenchmarkLoop (1.0 - 1) <FE426DDE-CE08-3740-8439-2EF901E3576F> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSBenchmarkLoop.framework/Versions/A/MPSBenchmarkLoop
+       0x2335b6000 -        0x2335c9e7f  com.apple.MPSFunctions (1.0 - 1) <E72A458C-E7CA-3070-983D-DCF1A13856FB> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSFunctions.framework/Versions/A/MPSFunctions
+       0x2335ca000 -        0x2335cf53f  com.apple.MPSHost (1.0 - 1) <EB2488F5-7C40-3E41-AF79-232149835176> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/Frameworks/MPSHost.framework/Versions/A/MPSHost
+       0x2335d0000 -        0x23490767f  com.apple.MetalPerformanceShadersGraph (6.4.2 - 6.4.2) <7A190F03-A6E4-316C-B574-DD383E59751C> /System/Library/Frameworks/MetalPerformanceShadersGraph.framework/Versions/A/MetalPerformanceShadersGraph
+       0x236877000 -        0x2369e34bf  com.apple.SwiftData (1.0 - 135) <35B80273-CE4A-3CF8-BD6C-7DC17BA20BFB> /System/Library/Frameworks/SwiftData.framework/Versions/A/SwiftData
+       0x2369e4000 -        0x23794091f  com.apple.SwiftUICore (7.4.27 - 7.4.27) <85689117-3964-395E-8D53-9526FBC52CF2> /System/Library/Frameworks/SwiftUICore.framework/Versions/A/SwiftUICore
+       0x237941000 -        0x237954e3f  com.apple.Symbols (1.0 - 190.4.0.1) <954D7B6D-E615-3F79-9FF6-D8FD105B5954> /System/Library/Frameworks/Symbols.framework/Versions/A/Symbols
+       0x23795b000 -        0x237a99b5f  com.apple.DataFrame (1.0 - 52) <BFF6B68B-3B93-3BDE-9C96-3859450D9166> /System/Library/Frameworks/TabularData.framework/Versions/A/TabularData
+       0x2388c2000 -        0x2388ecb5f  com.apple.CoreLocation.LocationEssentials (1.0 - 1) <84A21444-813B-3886-AEA4-C345149F4CD9> /System/Library/Frameworks/_LocationEssentials.framework/Versions/A/_LocationEssentials
+       0x23d427000 -        0x23d43babf  com.apple.AppleDeviceQuerySupport (1.0 - 408.100.18) <280507E6-93B0-3DEE-842C-42912C1A394B> /System/Library/PrivateFrameworks/AppleDeviceQuerySupport.framework/Versions/A/AppleDeviceQuerySupport
+       0x23d48e000 -        0x23d4a909f  com.apple.siri.flatbuffer.AppleFlatBuffers (1) <A676BCC9-5301-330A-ACF2-E5A82B9CC3B9> /System/Library/PrivateFrameworks/AppleFlatBuffers.framework/Versions/A/AppleFlatBuffers
+       0x23d861000 -        0x23d8efa5f  com.apple.proactive.AppleIntelligenceReporting (1.0 - 1) <E8DFD4BF-09F5-3E26-9CBB-85A3CCCD53D0> /System/Library/PrivateFrameworks/AppleIntelligenceReporting.framework/Versions/A/AppleIntelligenceReporting
+       0x23d9e3000 -        0x23dbb1ae7  com.apple.cmphoto.AppleJPEGXL (1.0 - 1) <0EB5DD9C-5074-32F0-98A8-9969C14481E7> /System/Library/PrivateFrameworks/AppleJPEGXL.framework/Versions/A/AppleJPEGXL
+       0x23dbb2000 -        0x23dc2ccc6  com.apple.AppleKeyStore (1.0 - 1.0) <67B6D752-B0D2-34AC-9F6B-4368F0CCF674> /System/Library/PrivateFrameworks/AppleKeyStore.framework/Versions/A/AppleKeyStore
+       0x23e555000 -        0x23e56d9df  com.apple.private.AppleMobileFileIntegrity-fmk (1.0 - 1) <8EB88354-07F6-3225-A92E-F7CE8595573B> /System/Library/PrivateFrameworks/AppleMobileFileIntegrity.framework/Versions/A/AppleMobileFileIntegrity
+       0x23e704000 -        0x23e77fea7  com.apple.ArgumentParserInternal (1.0 - 1.20.2) <45F74F2A-9F13-3C0F-B930-24D348C92B93> /System/Library/PrivateFrameworks/ArgumentParserInternal.framework/Versions/A/ArgumentParserInternal
+       0x23ea66000 -        0x23ea78799  com.apple.AtomicsInternal (1.1.0 - 154) <407FE060-8C88-3194-A21B-8688FD8EC4E5> /System/Library/PrivateFrameworks/AtomicsInternal.framework/Versions/A/AtomicsInternal
+       0x23eb35000 -        0x23eb57dff  com.apple.imgaudio.AudioAnalytics (1.0 - 1) <836137A2-2EFE-35FF-B641-6042C5D72771> /System/Library/PrivateFrameworks/AudioAnalytics.framework/Versions/A/AudioAnalytics
+       0x23f127000 -        0x23f16f7df  com.apple.BackBoardHIDEventFoundation (1.0 - 1) <BDDBB7D2-5979-3E4D-A110-D6484BE6B63D> /System/Library/PrivateFrameworks/BackBoardHIDEventFoundation.framework/Versions/A/BackBoardHIDEventFoundation
+       0x23f208000 -        0x23f2218df  com.apple.biome.BiomeDSL (1.0 - 209.15.0.2) <B81F347F-E6B4-3E12-84CA-F9B1B70FF675> /System/Library/PrivateFrameworks/BiomeDSL.framework/Versions/A/BiomeDSL
+       0x23f222000 -        0x23facf15f  com.apple.BiomeLibrary (274.52) <E7A86C30-C81B-3E2E-8C9D-AB0301998890> /System/Library/PrivateFrameworks/BiomeLibrary.framework/Versions/A/BiomeLibrary
+       0x23fad0000 -        0x23fad5b5f  com.apple.biome.BiomeSync (1.0 - 209.15.0.2) <102054CD-90EC-3295-9F9B-F98336CD69B3> /System/Library/PrivateFrameworks/BiomeSync.framework/Versions/A/BiomeSync
+       0x240522000 -        0x24052412f  com.apple.CMCaptureDevice (665.101.3) <C69E6385-2B54-340C-9F83-42015FF456EF> /System/Library/PrivateFrameworks/CMCaptureDevice.framework/Versions/A/CMCaptureDevice
+       0x2405e7000 -        0x2407ef49f  com.apple.CMImaging (1.0 - 665.101.3) <862E849D-75A7-30F0-9EB4-F0B41676338B> /System/Library/PrivateFrameworks/CMImaging.framework/Versions/A/CMImaging
+       0x2407f0000 -        0x2409ba63f  com.apple.CMPhoto (1.0 - 1) <BEA93ABC-917B-34D3-89EF-67DF320E73ED> /System/Library/PrivateFrameworks/CMPhoto.framework/Versions/A/CMPhoto
+       0x2410fe000 -        0x241196dbf  com.apple.biome.CascadeSets (1.0 - 209.15.0.2) <6CED7B79-85C6-3ABA-A1D4-691B2031239D> /System/Library/PrivateFrameworks/CascadeSets.framework/Versions/A/CascadeSets
+       0x2411b2000 -        0x2411b7cff  com.apple.Centauri (1.0 - 1) <6CB1EB51-4330-3BEC-8720-73E9395DCCB8> /System/Library/PrivateFrameworks/Centauri.framework/Versions/A/Centauri
+       0x2416a8000 -        0x2416e059f  com.apple.CinematicFraming (1.0 - 665.101.3) <7F3F6586-D7B0-37EF-A91A-38ED74633322> /System/Library/PrivateFrameworks/CinematicFraming.framework/Versions/A/CinematicFraming
+       0x242526000 -        0x24254a8ff  com.apple.CollectionViewCore (1.0 - 1) <E1B9C804-83D6-3C89-9D67-CE505D60ACE2> /System/Library/PrivateFrameworks/CollectionViewCore.framework/Versions/A/CollectionViewCore
+       0x24254b000 -        0x24268a2ae  com.apple.CollectionsInternal (1.2.0 - 154) <1A480C96-2A0B-3BDC-BE26-7779B2F282DB> /System/Library/PrivateFrameworks/CollectionsInternal.framework/Versions/A/CollectionsInternal
+       0x244944000 -        0x2449e1fff  com.apple.audio.coreaudio.Stravinsky (1.0 - 1) <B6F95607-CE64-317E-B4CE-3DB1D29DE089> /System/Library/PrivateFrameworks/CoreAudioOrchestration.framework/Versions/A/CoreAudioOrchestration
+       0x2487e7000 -        0x2488ecfbf  com.apple.CoreSceneUnderstanding (1.74.0 - 1.74.0) <EEA014DF-1461-3445-9B98-02406D693C69> /System/Library/PrivateFrameworks/CoreSceneUnderstanding.framework/Versions/A/CoreSceneUnderstanding
+       0x248aee000 -        0x248b1464f  com.apple.CoreUtilsExtras (1.0 - 1) <C87E479E-42B5-3236-B16D-1A740034CABE> /System/Library/PrivateFrameworks/CoreUtilsExtras.framework/Versions/A/CoreUtilsExtras
+       0x2492c9000 -        0x249338e7f  com.apple.aiml.dendrite.Dendrite (1.0 - 1) <84E14030-811C-32CA-9F3C-F59C0C7257F5> /System/Library/PrivateFrameworks/Dendrite.framework/Versions/A/Dendrite
+       0x249339000 -        0x2494b6b1f  com.apple.DesignLibrary (7.4.27 - 7.4.27) <A922812C-DD55-3989-8607-AE52925610E4> /System/Library/PrivateFrameworks/DesignLibrary.framework/Versions/A/DesignLibrary
+       0x249847000 -        0x24985a49f  com.apple.DeviceRecovery (1.0 - 1) <4B0612CE-7637-3581-B9A1-7EBC923047FC> /System/Library/PrivateFrameworks/DeviceRecovery.framework/Versions/A/DeviceRecovery
+       0x249c7a000 -        0x249c9067f  com.apple.DistributedSensing (1.0 - 1) <2CAB6666-310E-35C3-AC04-DC6145EBE3E7> /System/Library/PrivateFrameworks/DistributedSensing.framework/Versions/A/DistributedSensing
+       0x24b917000 -        0x24b96a53f  com.apple.UIKit.FocusEngine (9126.4.27.1.402) <75AB8D8B-DEFD-3F47-A5A0-5584F8B15C47> /System/Library/PrivateFrameworks/FocusEngine.framework/Versions/A/FocusEngine
+       0x24bae0000 -        0x24bae32ff  com.apple.FontServices (1.0 - 1) <2D16E478-3384-3947-8A97-472C8265DEA3> /System/Library/PrivateFrameworks/FontServices.framework/Versions/A/FontServices
+       0x24bae4000 -        0x24bbd3e2f  libXTFontStaticRegistryData.dylib (335.4.0.6) <D3CA2DB8-9982-3978-BABC-92B5D3E4528C> /System/Library/PrivateFrameworks/FontServices.framework/libXTFontStaticRegistryData.dylib
+       0x24bbd5000 -        0x24bbe1c9f  com.apple.FramePacing (1.0 - 1) <94C088E1-45CE-32F2-94E2-D92BE086B6F4> /System/Library/PrivateFrameworks/FramePacing.framework/Versions/A/FramePacing
+       0x24bbe2000 -        0x24bca337f  com.apple.FrontBoard (1000.4.11 - 1000.4.11) <7D654726-E1A4-3061-A7A3-8CF5FC24C4CB> /System/Library/PrivateFrameworks/FrontBoard.framework/Versions/A/FrontBoard
+       0x24cd02000 -        0x24cd07f07  libGPUCompilerUtils.dylib (32023.883.1) <CB93CEE8-91B3-31B0-9EF4-9A2261EE0DC1> /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/32023/Libraries/libGPUCompilerUtils.dylib
+       0x251175000 -        0x2511b4797  libllvm-flatbuffers.dylib (32023.883.1) <5C724D09-588C-3E79-8D58-209B6147A7AD> /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/32023/Libraries/libllvm-flatbuffers.dylib
+       0x2547dc000 -        0x2548297a6  com.apple.GenerativeFunctions.GenerativeFunctions (1.0 - 222.35.5) <E149A9D6-6411-3725-AC29-39B7C07398AC> /System/Library/PrivateFrameworks/GenerativeFunctions.framework/Versions/A/GenerativeFunctions
+       0x25482a000 -        0x2548bf47f  com.apple.GenerativeFunctions.GenerativeFunctionsFoundation (1.0 - 222.35.5) <6A703D76-0BA5-3548-9354-CC1C34BE061D> /System/Library/PrivateFrameworks/GenerativeFunctionsFoundation.framework/Versions/A/GenerativeFunctionsFoundation
+       0x2548c0000 -        0x25492597f  com.apple.GenerativeFunctions.GenerativeFunctionsInstrumentation (1.0 - 222.35.5) <B6E3AA95-1B4D-34B3-A1B1-844EAA18C8F0> /System/Library/PrivateFrameworks/GenerativeFunctionsInstrumentation.framework/Versions/A/GenerativeFunctionsInstrumentation
+       0x254926000 -        0x254a081df  com.apple.GenerativeFunctions.GenerativeModels (1.0 - 222.35.5) <D49B3220-0E00-3AD9-A4B0-498B09263B40> /System/Library/PrivateFrameworks/GenerativeModels.framework/Versions/A/GenerativeModels
+       0x254a09000 -        0x254a7eb9f  com.apple.GenerativeFunctions.GenerativeModelsFoundation (1.0 - 222.35.5) <528AB060-F0CB-31AC-B7FA-8D2CF1959F74> /System/Library/PrivateFrameworks/GenerativeModelsFoundation.framework/Versions/A/GenerativeModelsFoundation
+       0x254c1a000 -        0x254c1f27f  com.apple.GeoServices (1.0 - 2031.24.7.17.31) <335F3229-8668-38CE-AC37-2AC6EC15EA11> /System/Library/PrivateFrameworks/GeoServicesCore.framework/Versions/A/GeoServicesCore
+       0x254dc8000 -        0x254e8be9f  com.apple.Gestures (9126.1.5 - 9126.1.5) <EBD4A257-1460-3CFB-91FF-61EBA39B1AC3> /System/Library/PrivateFrameworks/Gestures.framework/Versions/A/Gestures
+       0x257eef000 -        0x257f5035f  com.apple.IO80211 (1.0 - 1) <81F5021D-001D-3504-91C4-92AC993A4F47> /System/Library/PrivateFrameworks/IO80211.framework/Versions/A/IO80211
+       0x257f5a000 -        0x257f6483f  com.apple.IPConfiguration (1.21 - 1.21) <D7883181-7B54-352E-B4C2-197C89BAFF20> /System/Library/PrivateFrameworks/IPConfiguration.framework/Versions/A/IPConfiguration
+       0x257f9a000 -        0x25800b07f  com.apple.cocoa.IconRendering (1.0 - 92.2) <51CD9ACA-CC48-3F76-9BDE-83BD926DBD88> /System/Library/PrivateFrameworks/IconRendering.framework/Versions/A/IconRendering
+       0x2589ef000 -        0x258af829f  com.apple.InstalledContentLibrary (1.0 - 1.0) <B509C80B-393D-34B8-969F-F6C7F3332041> /System/Library/PrivateFrameworks/InstalledContentLibrary.framework/Versions/A/InstalledContentLibrary
+       0x25b42c000 -        0x25bbfa35f  com.apple.IntelligencePlatformLibrary (274.52) <FB23F4B0-47DB-3BB7-86EB-6B155DA406CF> /System/Library/PrivateFrameworks/IntelligencePlatformLibrary.framework/Versions/A/IntelligencePlatformLibrary
+       0x25bda8000 -        0x25bddfb5f  com.apple.audio.CoreAudio.IsolatedCoreAudioClient (1.0 - 1) <179E9B66-26D4-35A0-822B-56904562A165> /System/Library/PrivateFrameworks/IsolatedCoreAudioClient.framework/Versions/A/IsolatedCoreAudioClient
+       0x25d3b7000 -        0x25d3bb5df  com.apple.CoreLocation.LocationLogEncryption (3072.0.46.3.1) <60014D5C-63B9-31EF-897B-9E1C4B7B0280> /System/Library/PrivateFrameworks/LocationLogEncryption.framework/Versions/A/LocationLogEncryption
+       0x25d4d5000 -        0x25db6b923  com.apple.MIL (3520.4 - 3520.4.1) <AE9BCA7C-3F03-3EEE-9687-F02E8CD6110C> /System/Library/PrivateFrameworks/MIL.framework/Versions/A/MIL
+       0x25db6c000 -        0x25dbe903f  com.apple.CoreML.MLAssetIO (1.0 - 3520.5.1) <7B4EFA32-1233-34AA-B422-D17B89A504F3> /System/Library/PrivateFrameworks/MLAssetIO.framework/Versions/A/MLAssetIO
+       0x25dbea000 -        0x25dc43b0f  com.apple.mlcompiler.runtime (3404.3.1 - 3404.3.1) <EB556DF4-F092-3B64-A383-7114408B15F6> /System/Library/PrivateFrameworks/MLCompilerRuntime.framework/Versions/A/MLCompilerRuntime
+       0x25dc44000 -        0x25dc5d827  com.apple.mlcompiler.services (3404.3.1 - 3404.3.1) <B1680062-A436-3598-B9B8-0A28EA6DDDA1> /System/Library/PrivateFrameworks/MLCompilerServices.framework/Versions/A/MLCompilerServices
+       0x2608d1000 -        0x2608e831f  com.apple.ggml.ModelAsset (1.0 - 1) <B532BC19-9B2F-3F0B-9945-E9A7014757A3> /System/Library/PrivateFrameworks/MLModelAsset.framework/Versions/A/MLModelAsset
+       0x2626db000 -        0x26273ca5f  com.apple.MessageSecurity (1.0 - 195.100.77) <A209D53C-DAD5-3A1F-A8C2-14B0C20A547A> /System/Library/PrivateFrameworks/MessageSecurity.framework/Versions/A/MessageSecurity
+       0x263669000 -        0x2639070bf  com.apple.ModelCatalog.ModelCatalog (1.0 - 233.34.4) <941B7C09-EE1C-3449-B0A9-9D65DDC0F689> /System/Library/PrivateFrameworks/ModelCatalog.framework/Versions/A/ModelCatalog
+       0x2639a4000 -        0x263b3c3ff  com.apple.ModelManagerServices (1.0 - 1) <52F929FB-9403-3F7E-8693-5CB50BC8FEC7> /System/Library/PrivateFrameworks/ModelManagerServices.framework/Versions/A/ModelManagerServices
+       0x267357000 -        0x2675cf3df  com.apple.mlpt.ODIE (1.0 - 1) <815E9513-4279-3E15-820A-ACB6134C60EB> /System/Library/PrivateFrameworks/ODIE.framework/Versions/A/ODIE
+       0x2675d5000 -        0x2675feb1f  com.apple.OSEligibility (319.101.1) <9D45879B-E72F-3EC2-B8BA-F17AF6993AB1> /System/Library/PrivateFrameworks/OSEligibility.framework/Versions/A/OSEligibility
+       0x268255000 -        0x26836d85f  com.apple.ParsingInternal (0.0.1 - 154) <AA740584-BC9B-3F37-9A1A-EF0414380CE6> /System/Library/PrivateFrameworks/ParsingInternal.framework/Versions/A/ParsingInternal
+       0x26b700000 -        0x26b721e1f  com.apple.accessibility.PhotosensitivityProcessing (1.0 - 1) <3931DECB-C3BB-39E7-BCBF-54CCE20032C7> /System/Library/PrivateFrameworks/PhotosensitivityProcessing.framework/Versions/A/PhotosensitivityProcessing
+       0x26bb14000 -        0x26bb50a3c  com.apple.PoirotSQLite (1.0 - 1) <B3D3E21E-698D-3C9E-B4DF-7DB6B7A31822> /System/Library/PrivateFrameworks/PoirotSQLite.framework/Versions/A/PoirotSQLite
+       0x26bb51000 -        0x26bbbe25f  com.apple.PoirotSchematizer (1.0 - 1) <4992FDC0-2A39-37DD-926E-0E9F9CC9B381> /System/Library/PrivateFrameworks/PoirotSchematizer.framework/Versions/A/PoirotSchematizer
+       0x26bbbf000 -        0x26bbf4bff  com.apple.PoirotUDFs (1.0 - 1) <A70FE2AE-430C-30E5-B105-B3DCC294DF37> /System/Library/PrivateFrameworks/PoirotUDFs.framework/Versions/A/PoirotUDFs
+       0x26cd89000 -        0x26cec511f  com.apple.ProDisplayLibrary (10.4.28 - 10.4.28) <085F6583-4A26-3006-8C7A-853A09AD40E0> /System/Library/PrivateFrameworks/ProDisplayLibrary.framework/Versions/A/ProDisplayLibrary
+       0x26cf28000 -        0x26cf5557f  com.apple.intelligenceflow.ProactiveDaemonSupport (1.0 - 3520.68.1) <86A8ECBF-55A5-3334-A2ED-FECA2B42CD00> /System/Library/PrivateFrameworks/ProactiveDaemonSupport.framework/Versions/A/ProactiveDaemonSupport
+       0x26d4ef000 -        0x26d69efdf  com.apple.GenerativeFunctions.PromptKit (1.0 - 222.35.5) <26BE1B9A-1C68-3EB1-B920-95448FB2A97A> /System/Library/PrivateFrameworks/PromptKit.framework/Versions/A/PromptKit
+       0x26de5d000 -        0x26de654cf  com.apple.ReflectionInternal (1.0.0 - 154) <FBAA34DB-DCB6-36C6-94C7-DFB542C0A55B> /System/Library/PrivateFrameworks/ReflectionInternal.framework/Versions/A/ReflectionInternal
+       0x26eda5000 -        0x26edb89c7  com.apple.RuntimeInternal (1.0.0 - 154) <0A0F41D4-3475-30F6-8682-3227EC3FE8A8> /System/Library/PrivateFrameworks/RuntimeInternal.framework/Versions/A/RuntimeInternal
+       0x26ef71000 -        0x26eff6a3f  com.apple.SFSymbolsFramework (1 - 190.4.0.1) <009CB06E-6F11-3411-98C4-18700A3F9371> /System/Library/PrivateFrameworks/SFSymbols.framework/Versions/A/SFSymbols
+       0x26eff7000 -        0x26f064abf  com.apple.SILManager (53.19 - 53.19) <A1A3D3E5-BB48-318C-A1A2-949DAE63B749> /System/Library/PrivateFrameworks/SILManager.framework/Versions/A/SILManager
+       0x27064c000 -        0x2707390bf  com.apple.SensitiveContentAnalysisML (1) <61D5764F-2201-3003-869E-4F4F4F4EF11C> /System/Library/PrivateFrameworks/SensitiveContentAnalysisML.framework/Versions/A/SensitiveContentAnalysisML
+       0x27091c000 -        0x2709ae8ff  com.apple.SentencePieceInternal (57.3) <1BE59A5F-4EC7-3077-BE96-E04E2D3EB910> /System/Library/PrivateFrameworks/SentencePieceInternal.framework/Versions/A/SentencePieceInternal
+       0x27142e000 -        0x27154b13f  com.apple.siri.SiriAnalytics (1.0 - 1) <4F77344D-2D2E-3747-B198-8046E6AA04FF> /System/Library/PrivateFrameworks/SiriAnalytics.framework/Versions/A/SiriAnalytics
+       0x27a4b8000 -        0x27a4e44a1  com.apple.security.SwiftASN1Internal (1.0 - 1) <EDAC3CA1-D139-3B18-941A-86FC1B7E2143> /System/Library/PrivateFrameworks/SwiftASN1Internal.framework/Versions/A/SwiftASN1Internal
+       0x27b305000 -        0x27b3606df  com.apple.SystemStatus (1.0 - 1) <5B741C0F-12D3-3234-8EDE-400725731F58> /System/Library/PrivateFrameworks/SystemStatus.framework/Versions/A/SystemStatus
+       0x27dbcb000 -        0x27dc071df  com.apple.tightbeam (1.0 - 483.100.88) <AFDCDFFD-BD5E-3527-B924-8860400C0AD3> /System/Library/PrivateFrameworks/Tightbeam.framework/Versions/A/Tightbeam
+       0x27e0ce000 -        0x27e30517f  com.apple.TokenGeneration (1.0 - 1) <D1BEE003-62F2-347A-9A6A-4DA190F8C7C9> /System/Library/PrivateFrameworks/TokenGeneration.framework/Versions/A/TokenGeneration
+       0x27e306000 -        0x27e4d3f3f  com.apple.TokenGenerationCore (1.0 - 1) <CE47732C-F9F3-3DB2-894A-E82A155C2434> /System/Library/PrivateFrameworks/TokenGenerationCore.framework/Versions/A/TokenGenerationCore
+       0x27fd14000 -        0x27fe4a51f  com.apple.UIIntelligenceSupport (1.0 - 1) <9C9DBF7E-9CCC-3939-B102-FED4D9CBD61B> /System/Library/PrivateFrameworks/UIIntelligenceSupport.framework/Versions/A/UIIntelligenceSupport
+       0x2803ef000 -        0x2804b43ff  com.apple.UnifiedAssetFramework (1.0 - 1) <C089150D-8EEA-309B-8A92-34522FBB3848> /System/Library/PrivateFrameworks/UnifiedAssetFramework.framework/Versions/A/UnifiedAssetFramework
+       0x280c08000 -        0x280c0a1ff  com.apple.UpdateCycle (1 - 1) <F6455B3C-A322-366F-B294-B2F883D8ADBF> /System/Library/PrivateFrameworks/UpdateCycle.framework/Versions/A/UpdateCycle
+       0x2822d4000 -        0x2822d52cf  com.apple.VideoToolboxParavirtualizationSupport (64.4.7 - 64.4.7) <C020E1A9-FA32-3DDE-A814-761CC904519C> /System/Library/PrivateFrameworks/VideoToolboxParavirtualizationSupport.framework/Versions/A/VideoToolboxParavirtualizationSupport
+       0x282ed8000 -        0x282f2409f  com.apple.VisionCore (9.5.4 - 9.5.4) <0F37FF69-F191-3018-A42D-FE24D59B7E57> /System/Library/PrivateFrameworks/VisionCore.framework/Versions/A/VisionCore
+       0x285636000 -        0x2856561bf  com.apple.WindowManagement (1.0 - 341.4.4) <5D5B7E51-5830-373E-9DFC-A54809AC758C> /System/Library/PrivateFrameworks/WindowManagement.framework/Versions/A/WindowManagement
+       0x28682d000 -        0x2868319ff  com.apple.WritingTools (1.0 - 1) <3AF4E157-9258-34CE-9A93-C8FF2571F436> /System/Library/PrivateFrameworks/WritingTools.framework/Versions/A/WritingTools
+       0x28c3f6000 -        0x28c3f989f  com.apple.UIUtilities (9126.4.27.1.402) <5271A254-6593-360E-9B2D-0DE34A8A9174> /System/Library/SubFrameworks/UIUtilities.framework/Versions/A/UIUtilities
+       0x28c4d9000 -        0x28c4dbd5f  libAXSafeCategoryBundle.dylib (3191.25.1) <3998A41F-D32A-3E02-B658-76FCCB87FCFD> /usr/lib/libAXSafeCategoryBundle.dylib
+       0x28c516000 -        0x28c5b035f  libAppleArchive.dylib (450.100.4) <F7C3CEC7-1F55-3617-B917-F221A2BCE7B6> /usr/lib/libAppleArchive.dylib
+       0x28c66b000 -        0x28c67545f  libCoreEntitlements.dylib (80.100.6) <40E810FC-0D99-3C00-92D7-F0C66D6152FB> /usr/lib/libCoreEntitlements.dylib
+       0x28c7c6000 -        0x28c7d05c3  libEndpointSecuritySystem.dylib (589.100.29) <71B56740-4EAF-3DFF-BDAF-5364CA3369E4> /usr/lib/libEndpointSecuritySystem.dylib
+       0x28c849000 -        0x28c84ad1f  libInterpreterSecurity.dylib (726.100.65) <8ED791A2-D02A-3A0D-ABF9-B7134EFBE85A> /usr/lib/libInterpreterSecurity.dylib
+       0x28c961000 -        0x28c96887f  libReverseProxyDevice.dylib (104.40.3) <1EE2E566-2280-3B41-B13B-BF71517DC956> /usr/lib/libReverseProxyDevice.dylib
+       0x28c969000 -        0x28c970349  libRosetta.dylib (367.5) <2FC1EF06-04C4-35FC-8DC3-BEA1E9FBD63F> /usr/lib/libRosetta.dylib
+       0x28c9d5000 -        0x28c9d535f  libSpatial.dylib (108) <7C1FBA2B-DAAD-3E29-86A9-83EA70699458> /usr/lib/libSpatial.dylib
+       0x28c9d8000 -        0x28c9e13ff  libTLE.dylib (80.100.6) <876EA47E-51E0-39FB-9D49-E6654AD58464> /usr/lib/libTLE.dylib
+       0x28d2a5000 -        0x28d3b6b17  libcrypto.46.dylib (109.100.2) <DAA12A78-F0F0-30B8-92F4-C9257843E858> /usr/lib/libcrypto.46.dylib
+       0x28d4f1000 -        0x28d50d762  libhvf.dylib (11) <FA8F5DCD-0A2B-30A9-8BD5-065DF59ED592> /usr/lib/libhvf.dylib
+       0x28d941000 -        0x28d94928a  libmrc.dylib (2881.100.56.0.1) <CC546CAC-2404-3061-A71A-DA8D16F9BEAC> /usr/lib/libmrc.dylib
+       0x28de3e000 -        0x28de76527  libssl.48.dylib (109.100.2) <7BD6E551-5BBF-3AEB-B1A7-BD698770A40E> /usr/lib/libssl.48.dylib
+       0x28deb1000 -        0x28dedee37  libswiftPrespecialized.dylib (0) <A7F970BC-D107-3D9B-A49E-ACA772E588E6> /usr/lib/libswiftPrespecialized.dylib
+       0x28e17a000 -        0x28e18c043  libswiftDistributed.dylib (6.3.0 - 6.3.0.123.11) <B39D029A-D50B-3A5F-8ED3-CDB591E7D429> /usr/lib/swift/libswiftDistributed.dylib
+       0x28e194000 -        0x28e19b31f  libswiftMLCompute.dylib (84) <F385924A-1D49-3B87-8783-DC2C9E667D00> /usr/lib/swift/libswiftMLCompute.dylib
+       0x28e1a3000 -        0x28e1b2ebc  libswiftObservation.dylib (6.3.0 - 6.3.0.123.11) <8A5C9C34-6237-3DAF-B402-7CCBDA47E028> /usr/lib/swift/libswiftObservation.dylib
+       0x28e1c2000 -        0x28e1ce817  libswiftRegexBuilder.dylib (6.3 - 6.3.0.123.11) <F73B9447-AD5E-39BD-8925-1C97EB0A2476> /usr/lib/swift/libswiftRegexBuilder.dylib
+       0x28e265000 -        0x28e2db72f  libswiftSpatial.dylib (108) <70821B44-314F-3799-A2D3-2E9A77A4EEBD> /usr/lib/swift/libswiftSpatial.dylib
+       0x28e2df000 -        0x28e2f28ef  libswiftSynchronization.dylib (6.3.0 - 6.3.0.123.11) <8D3DB366-76F8-3D99-8CC3-326AA513F7B4> /usr/lib/swift/libswiftSynchronization.dylib
+       0x28e2f3000 -        0x28e30be60  libswiftSystem.dylib (75) <9808DC7D-BE41-300B-A7E2-BA827446EE0A> /usr/lib/swift/libswiftSystem.dylib
+       0x28e30d000 -        0x28e32379f  libswiftVideoToolbox.dylib (3305.24.5.2) <3E76FAE6-CDCE-31A2-BC50-3907797972CF> /usr/lib/swift/libswiftVideoToolbox.dylib
+       0x28e325000 -        0x28e325669  libswift_Builtin_float.dylib (6.3.0.123.11) <86B92BEF-06E8-3E10-A155-E1AB40B3F854> /usr/lib/swift/libswift_Builtin_float.dylib
+       0x28e326000 -        0x28e3b1095  libswift_Concurrency.dylib (6.3.0 - 6.3.0.123.11) <02634765-CB69-3C2B-9CCE-10103CBEA22A> /usr/lib/swift/libswift_Concurrency.dylib
+       0x28e3b2000 -        0x28e3b4f83  libswift_DarwinFoundation1.dylib (377.100.15) <251F0C0D-17E0-37BB-A903-BB04A6C99999> /usr/lib/swift/libswift_DarwinFoundation1.dylib
+       0x28e3b5000 -        0x28e3b5eeb  libswift_DarwinFoundation2.dylib (377.100.15) <D22D6BC3-62DD-314C-8A8E-56CD69ABAB3C> /usr/lib/swift/libswift_DarwinFoundation2.dylib
+       0x28e3b6000 -        0x28e3b67a7  libswift_DarwinFoundation3.dylib (377.100.15) <02812A8B-CF65-3C0F-A795-C4A03E71D00E> /usr/lib/swift/libswift_DarwinFoundation3.dylib
+       0x28e3b7000 -        0x28e45549f  libswift_RegexParser.dylib (6.3 - 6.3.0.123.11) <4AFB7E54-4E3C-351E-A353-9B1C99CBDA36> /usr/lib/swift/libswift_RegexParser.dylib
+       0x28e456000 -        0x28e4e20bd  libswift_StringProcessing.dylib (6.3 - 6.3.0.123.11) <DC0CDBD3-5AAF-3A71-880F-8E40074817E4> /usr/lib/swift/libswift_StringProcessing.dylib
+       0x28e4eb000 -        0x28e4eb3d3  libswiftsys_time.dylib (377.100.15) <C828D472-DADC-3008-8171-7FAD56785384> /usr/lib/swift/libswiftsys_time.dylib
+       0x28e646000 -        0x28e649a4b  libsystem_darwindirectory.dylib (122) <CCAA2170-32DD-34BD-A927-32DF30893969> /usr/lib/system/libsystem_darwindirectory.dylib
+       0x28e64a000 -        0x28e6535a7  libsystem_eligibility.dylib (319.101.1) <2D19994A-87BB-34B8-A343-CB8DD47FF110> /usr/lib/system/libsystem_eligibility.dylib
+       0x28e654000 -        0x28e65b8db  libsystem_sanitizers.dylib (26) <FCB93D2F-4437-3089-A43F-A19BC23DD65B> /usr/lib/system/libsystem_sanitizers.dylib
+       0x28e65c000 -        0x28e65cbb7  libsystem_trial.dylib (474.2.18) <5BB81430-4E33-3160-94D2-1FFB2B614DB2> /usr/lib/system/libsystem_trial.dylib

--- a/docs/rdr/rdr-151-daemon-event-loop-selector-spin-write-contention.md
+++ b/docs/rdr/rdr-151-daemon-event-loop-selector-spin-write-contention.md
@@ -318,6 +318,26 @@ asserting no executor thread is wedged in the SQLite busy handler.
 > within ~5 s. T2-only by construction (the T3 daemon is a synchronous subprocess
 > supervisor with no asyncio loop). Tests: `tests/daemon/test_spin_guard.py`.
 
+> **ROOT-CAUSE FIX (2026-06-06, `nexus-xmohw`, GH #1137).** The spin guard is the
+> backstop; this is the cause. GH #1137 reproduced the peg under a `memory.delete`
+> write burst and identified two co-occurring mechanisms: a selector spin (guard
+> handles) and **intra-daemon WAL write contention** — un-serialised `memory.*`
+> writes plus the daemon's own 30 s reclaim loop each launched parallel
+> `to_thread` writers racing the one SQLite writer lock → `SQLITE_BUSY` → tight
+> retry → spin. 2.1a serialised only `catalog_write.*`/`taxonomy.*`; this makes the
+> daemon a genuine **single serialised writer** (RDR-129 B3 / Datasette
+> write-queue): `_WRITE_OPS` + the reclaim loop all serialise through one write
+> lock, so there is never a second intra-daemon writer → no `SQLITE_BUSY` from
+> self-contention. Reads stay concurrent (esp. `database.hello`, to avoid the
+> slow-hello → ensure-running-stale → takeover-churn cascade). Lock-hold is bounded
+> to one write attempt (backoff happens outside the lock). A coverage forcing-test
+> (`test_rdr151_xmohw_write_serialization.py::test_write_op_coverage`) fails if any
+> mutating dispatch op is left un-serialised — closing the silent-recurrence gap.
+> **Deferred (coupled, tracked):** 2.1b `BEGIN IMMEDIATE` + 2.1c fast-fail
+> `busy_timeout` for the cross-process/version-skew double-writer case — they must
+> land together (BEGIN IMMEDIATE alone, with the 30 s busy_timeout, would create a
+> long head-of-line lock-hold; 2.1c bounds it).
+
 ### Phase 3 design (2026-06-06, nexus-uzay8)
 
 Full design: T2 `nexus/rdr151-phase3-design-2026-06-06`.

--- a/docs/rdr/rdr-151-daemon-event-loop-selector-spin-write-contention.md
+++ b/docs/rdr/rdr-151-daemon-event-loop-selector-spin-write-contention.md
@@ -285,6 +285,39 @@ Aggregate `select/s` is throughput-polluted and must NOT be the oracle. Use
 returns to single-digit `select/s` within ~10 s. Plus a `sample`-based soak
 asserting no executor thread is wedged in the SQLite busy handler.
 
+> **LIVE ORACLE RESULT (2026-06-06): FAILED.** Phase 3 shipped in conexus 5.10.4
+> (PR #1134, tag `v5.10.4`). On deploy, a *fresh* 5.10.4 daemon pegs ~97–100% CPU
+> at **idle** — no clients, no contenders — within ~60 s. `sample` shows the main
+> asyncio thread spinning in the `_PyEval` event loop (pure Python eval, not blocked
+> in `kevent`) with an occasional `context_run → pysqlite execute` callback: a
+> selector busy-spin. This is the **RF-1-shaped idle/teardown spin**, *distinct* from
+> the write-contention peg Phase 3 fixed. RF-1 was refuted only as the cause of the
+> *contention* peg; the idle spin is real and unaddressed. Tracked as **`nexus-u2vmv`**
+> (P1); evidence `docs/postmortem/2026-06-06-daemon-5104-idle-peg-sample.txt`.
+> Pre-existing (5.10.3 and earlier pegged too) — 5.10.4 is an incomplete fix, not a
+> regression. RDR-151 is **not closeable**; `nexus-uzay8` must not be closed as
+> peg-fixed.
+
+> **SPIN-GUARD RESOLUTION (2026-06-06, `nexus-u2vmv`).** The specific trigger
+> could not be reproduced synthetically (the current daemon is robust to idle,
+> abrupt-RST, connect storms, and 16 concurrent real clients; the peg needs an
+> actual old-version client / takeover race, and the version-skew client zoo was
+> the live driver). Rather than chase one path, the loop is made
+> **constitutionally spin-proof**: `src/nexus/daemon/spin_guard.py` adds a
+> `SpinGuardSelector` (counts immediate ready-returns by *wall-time* — catches
+> both `select(0)` polls and a blocking `select(None)` that returns instantly on
+> a perpetually-ready fd) and a `SpinWatchdog` daemon thread that, on a sustained
+> over-threshold rate, (1) **auto-captures** the selector map + `loop._ready` +
+> thread stacks (the ground-truth the manual capture kept missing — the next
+> wild peg self-documents) and (2) **self-heals** (SIGTERM → graceful stop;
+> `os._exit` daemon-timer fallback → supervisor respawns a clean daemon), bounded
+> so a persistent trigger disarms self-heal and the daemon stays up
+> pegged-but-serving (never worse than the pre-guard baseline). Validated against
+> the postmortem sample: 3822/3847 frames in `kevent` = exactly the immediate
+> ready-return shape the guard measures, so it would have fired on the 5.10.4 peg
+> within ~5 s. T2-only by construction (the T3 daemon is a synchronous subprocess
+> supervisor with no asyncio loop). Tests: `tests/daemon/test_spin_guard.py`.
+
 ### Phase 3 design (2026-06-06, nexus-uzay8)
 
 Full design: T2 `nexus/rdr151-phase3-design-2026-06-06`.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.10.3",
+  "version": "5.10.5",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conexus-mcpb"
-version = "5.10.3"
+version = "5.10.5"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
@@ -10,7 +10,7 @@ dependencies = [
     # while collections are indexed at 768/1024-dim, so every T3 search hits a
     # dimension mismatch and returns zero results. The .mcpb cannot run the
     # interactive `nx init` embedder choice, so it must pin [local] explicitly.
-    "conexus[local]>=5.10.3",
+    "conexus[local]>=5.10.5",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.10.3"
+version = "5.10.5"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.10.3",
+  "version": "5.10.5",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/daemon/spin_guard.py
+++ b/src/nexus/daemon/spin_guard.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Cause-agnostic event-loop spin guard (RDR-151, nexus-u2vmv).
+
+The T2 daemon must be constitutionally unable to peg at ~100% CPU regardless of
+client version mix or takeover races. The peg's signature is an asyncio event
+loop whose ``selector.select()`` keeps returning a perpetually-ready fd on a
+zero timeout — ``_run_once`` spins without ever blocking. We can't always
+reproduce the specific trigger (it requires an old-version client), so instead
+of chasing one path we make the loop spin-*proof*:
+
+* :class:`SpinGuardSelector` counts zero-timeout ready-returns per fd — the
+  precise spin signature (a healthy idle loop blocks in ``select``; a healthy
+  busy loop is bounded by real work; only a spin polls ready thousands of
+  times per second).
+* :class:`SpinWatchdog` runs on a background thread (which still gets scheduled
+  under a spinning loop — CPython releases the GIL on the switch interval) and,
+  on a sustained over-threshold rate, invokes ``on_spin`` with a capture
+  payload. The daemon wires ``on_spin`` to log the selector map + thread stacks
+  (the ground-truth capture that has been missing) and then self-heal (SIGTERM →
+  graceful stop → ``os._exit`` fallback), so a pegged daemon recovers instead of
+  burning a core forever.
+"""
+from __future__ import annotations
+
+import selectors
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+#: A ``select`` call that returns ready in under this many seconds is an
+#: *immediate ready-return*. This is the spin shape and it is measured by
+#: wall-time, NOT by the requested timeout: a perpetually-ready fd makes asyncio's
+#: blocking ``select(timeout=None)`` return instantly (it never actually blocks),
+#: which a timeout-based check would miss. A healthy idle loop blocks for real
+#: (long duration); a healthy busy loop has a bounded immediate-return rate; only
+#: a spin produces thousands of immediate ready-returns per second.
+_IMMEDIATE_EPS: float = 0.0005
+
+
+class SpinGuardSelector(selectors.DefaultSelector):  # type: ignore[misc]
+    """``DefaultSelector`` that counts zero-timeout ready-returns per fd.
+
+    Cheap: a couple of integer bumps per ``select`` call. The counters are read
+    by :class:`SpinWatchdog` from another thread; plain int/dict reads and
+    writes are atomic enough under the GIL for a rate estimate.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.zero_to_ready: int = 0
+        self.ready_fd_hits: dict[int, int] = {}
+
+    def select(self, timeout: float | None = None) -> list[Any]:  # type: ignore[override]
+        t0 = time.monotonic()
+        res = super().select(timeout)
+        # Immediate ready-return (by wall-time) is the spin signature — see
+        # _IMMEDIATE_EPS. Catches both select(0) polls and a blocking
+        # select(None) that returns instantly on a perpetually-ready fd.
+        if res and (time.monotonic() - t0) <= _IMMEDIATE_EPS:
+            self.zero_to_ready += 1
+            for key, _events in res:
+                fd = key.fd
+                self.ready_fd_hits[fd] = self.ready_fd_hits.get(fd, 0) + 1
+        return res
+
+
+class SpinWatchdog:
+    """Detect a sustained event-loop spin and invoke ``on_spin``.
+
+    Decision logic (:meth:`poll`) is separated from the threading (:meth:`start`)
+    so it is deterministically testable with an injected clock. A spin is
+    declared after ``consecutive`` polling windows whose zero-timeout
+    ready-return *rate* meets or exceeds ``threshold_per_s``.
+    """
+
+    def __init__(
+        self,
+        counter: Any,
+        *,
+        threshold_per_s: float,
+        window_s: float,
+        consecutive: int,
+        on_spin: Callable[[dict[str, Any]], None],
+    ) -> None:
+        self._counter = counter
+        self._threshold = threshold_per_s
+        self._window = window_s
+        self._consecutive = consecutive
+        self._on_spin = on_spin
+        # Baseline at construction so the first poll() yields a real delta
+        # (the deterministic tests rely on this); start() re-baselines to the
+        # current monotonic clock for the live thread path.
+        self._last_count: int = int(getattr(counter, "zero_to_ready", 0))
+        self._last_time: float = 0.0
+        self._streak: int = 0
+        self._fired: bool = False
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    def poll(self, now: float) -> bool:
+        """Sample the counter at wall-clock *now*. Returns True iff a spin was
+        declared this call (``on_spin`` already invoked)."""
+        count = int(getattr(self._counter, "zero_to_ready", 0))
+        dt = now - self._last_time
+        delta = count - self._last_count
+        self._last_count = count
+        self._last_time = now
+        if dt <= 0:
+            return False
+        rate = delta / dt
+        if rate >= self._threshold:
+            self._streak += 1
+        else:
+            self._streak = 0
+        if self._streak >= self._consecutive and not self._fired:
+            self._fired = True
+            self._streak = 0
+            self._on_spin(self._capture(rate))
+            return True
+        return False
+
+    def _capture(self, rate: float) -> dict[str, Any]:
+        hits: dict[int, int] = dict(getattr(self._counter, "ready_fd_hits", {}))
+        hot_fd = max(hits, key=hits.get) if hits else None  # type: ignore[arg-type]
+        return {
+            "rate_per_s": rate,
+            "hot_fd": hot_fd,
+            "ready_fd_hits": hits,
+            "threshold_per_s": self._threshold,
+        }
+
+    # ── live thread path ────────────────────────────────────────────────────
+
+    def start(self, loop: Any = None) -> None:
+        """Launch the watchdog on a daemon thread. ``loop`` is accepted for
+        symmetry/future use; detection reads the selector counters directly."""
+        import time
+
+        self._last_time = time.monotonic()
+        self._last_count = int(getattr(self._counter, "zero_to_ready", 0))
+
+        def _run() -> None:
+            while not self._stop.wait(self._window):
+                try:
+                    if self.poll(time.monotonic()):
+                        return  # spun + handled; stop watching
+                except Exception as exc:  # noqa: BLE001 — never crash the daemon
+                    # But never die SILENTLY either: a silently-dead watchdog
+                    # disarms the guard and the peg goes undetected. Log loud.
+                    _log.warning("spin_watchdog_poll_error", error=repr(exc))
+
+        self._thread = threading.Thread(
+            target=_run, name="t2-spin-watchdog", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        t = self._thread
+        if t is not None and t.is_alive() and t is not threading.current_thread():
+            t.join(timeout=2.0)

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -62,7 +62,9 @@ import sqlite3
 import struct
 import subprocess
 import sys
+import threading
 import time
+import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -363,6 +365,34 @@ _DB_CLOSE_TIMEOUT: float = 10.0
 #: RPC client connects, calls, and closes promptly); finite so a dead-but-not-
 #: RST peer cannot pin the connection forever.
 _IDLE_READ_TIMEOUT: float = 300.0
+
+#: RDR-151 nexus-u2vmv: cause-agnostic event-loop spin guard. If the loop polls
+#: the selector for an immediate ready-return at a sustained rate above the
+#: threshold, the daemon is spinning (~100% CPU) — capture and self-heal rather
+#: than peg a core forever. Threshold default 10000/s with headroom above the
+#: *measured* peaks of legitimate churn (~5110/s graceful memory.put, ~6872/s
+#: abrupt-RST churn per the RDR-151 P2.1 synthesis — those are throughput, not a
+#: peg); the historical peg sustained far higher. Env-tunable.
+#:
+#: NOTE: this guard is T2-specific by construction — it instruments the T2
+#: daemon's asyncio SelectorEventLoop. The T3 daemon (run_t3_supervisor) is a
+#: SYNCHRONOUS subprocess supervisor with no asyncio loop/selector, so the
+#: shared-primitive lifecycle rule's selector-spin concern does not apply there
+#: (verified 2026-06-06: t3_daemon.py has no asyncio.run / event loop).
+_SPIN_THRESHOLD_PER_S: float = float(os.environ.get("NX_T2_SPIN_THRESHOLD", "10000"))
+_SPIN_WINDOW_S: float = 1.0
+_SPIN_CONSECUTIVE: int = 5  # ~5s sustained before declaring a spin
+_SPIN_HARD_EXIT_TIMEOUT: float = 10.0  # graceful SIGTERM grace before os._exit
+_SPIN_EXIT_CODE: int = 99
+#: Bound self-heal restarts so a PERSISTENT trigger (e.g. a skewed client that
+#: re-induces the spin on every fresh daemon) can never drive the supervisor's
+#: crash-loop guard to permanent suppression (a suppressed daemon serves
+#: nothing — strictly worse than a pegged-but-serving one). After this many
+#: spin-heals within the window, the daemon DISARMS self-heal and stays up
+#: pegged-but-serving (== the pre-guard baseline; never worse) while logging a
+#: loud, actionable ERROR. nexus-u2vmv critic C2.
+_SPIN_HEAL_MAX: int = 2
+_SPIN_HEAL_WINDOW_S: float = 600.0
 
 
 # ---------------------------------------------------------------------------
@@ -1828,6 +1858,157 @@ def _poll_for_winner(config_dir: Path, timeout: float) -> bool:
     return False
 
 
+def _spin_heal_count_in_window(config_dir: Path, now: float) -> int:
+    """Append *now* to the persistent spin-heal log and return the number of
+    heals within ``_SPIN_HEAL_WINDOW_S`` (including this one). Best-effort: on
+    any IO error returns 1 (treat as first heal — self-heal allowed)."""
+    path = config_dir / ".t2_spin_heals"
+    cutoff = now - _SPIN_HEAL_WINDOW_S
+    stamps: list[float] = []
+    try:
+        if path.exists():
+            for line in path.read_text().splitlines():
+                try:
+                    ts = float(line.strip())
+                except ValueError:
+                    continue
+                if ts >= cutoff:
+                    stamps.append(ts)
+        stamps.append(now)
+        path.write_text("\n".join(f"{ts:.3f}" for ts in stamps) + "\n")
+    except Exception:  # noqa: BLE001
+        return 1
+    return len(stamps)
+
+
+def _t2_spin_capture_and_heal(
+    config_dir: Path, loop: Any, info: dict[str, Any]
+) -> None:
+    """RDR-151 nexus-u2vmv: on a detected event-loop spin, capture ground-truth
+    diagnostics (the missing-until-now selector + stack + loop._ready dump) and
+    self-heal — UNLESS self-heal has fired too often, in which case stay up
+    pegged-but-serving (never worse than the pre-guard baseline; critic C2).
+
+    Runs on the watchdog thread (scheduled even under a spinning loop — CPython
+    releases the GIL on the switch interval). Self-heal is SIGTERM → graceful
+    stop (the spinning loop still iterates, so the signal self-pipe callback
+    fires promptly); a hard ``os._exit`` DAEMON timer guarantees the process
+    dies even if graceful stop wedges, so the supervisor respawns a clean
+    daemon (a fresh daemon does not spin)."""
+    pid = os.getpid()
+    frames = [
+        f"--- thread {tid} ---\n" + "".join(traceback.format_stack(fr))
+        for tid, fr in sys._current_frames().items()
+    ]
+    # loop._ready distinguishes a perpetually-ready-fd spin (empty ready queue)
+    # from a self-rescheduling call_soon spin (ready queue full) — the diagnostic
+    # dimension sys._current_frames() alone cannot show (critic C4).
+    ready = getattr(loop, "_ready", None)
+    ready_len = len(ready) if ready is not None else None
+    ready_sample = [repr(h) for h in list(ready or [])[:20]]
+
+    heals = _spin_heal_count_in_window(config_dir, time.time())
+    disarm = heals > _SPIN_HEAL_MAX
+
+    _log.error(
+        "t2_daemon_spin_detected",
+        pid=pid,
+        hot_fd=info.get("hot_fd"),
+        rate_per_s=info.get("rate_per_s"),
+        ready_fd_hits=info.get("ready_fd_hits"),
+        threshold_per_s=info.get("threshold_per_s"),
+        loop_ready_len=ready_len,
+        heals_in_window=heals,
+        action="serve_degraded" if disarm else "self_heal",
+        hint=(
+            "event loop spinning ~100% CPU; "
+            + (
+                "self-heal disarmed (persistent trigger — a stale/skewed client "
+                "is likely present); staying up pegged-but-serving. Restart "
+                "stale nx-mcp/desktop clients."
+                if disarm
+                else "capturing + self-healing (RDR-151 u2vmv)"
+            )
+        ),
+    )
+    try:
+        logs = config_dir / "logs"
+        logs.mkdir(parents=True, exist_ok=True)
+        path = logs / f"t2_spin_{pid}_{int(time.time())}.txt"
+        path.write_text(
+            f"hot_fd={info.get('hot_fd')} rate_per_s={info.get('rate_per_s')} "
+            f"threshold_per_s={info.get('threshold_per_s')} "
+            f"loop_ready_len={ready_len} heals_in_window={heals} disarm={disarm}\n"
+            f"ready_fd_hits={info.get('ready_fd_hits')}\n"
+            f"loop._ready sample:\n  " + "\n  ".join(ready_sample) + "\n\n"
+            + "\n".join(frames)
+        )
+        _log.error("t2_daemon_spin_capture_written", path=str(path))
+    except Exception:  # noqa: BLE001 — capture is best-effort; heal regardless
+        pass
+
+    if disarm:
+        # Never make it worse than baseline: a persistent trigger would otherwise
+        # drive 5 spin-restarts into the supervisor crash-loop guard and leave
+        # the daemon permanently suppressed (serving nothing). Stay up.
+        return
+
+    # Hard-exit fallback first, so a wedged graceful stop cannot leave the daemon
+    # pegged. DAEMON thread so a normal (sub-timeout) graceful stop exits cleanly
+    # with code 0 and the timer is reaped silently — without daemon=True the
+    # interpreter would join it and force exit 99 on every fire (critic CRITICAL).
+    timer = threading.Timer(_SPIN_HARD_EXIT_TIMEOUT, lambda: os._exit(_SPIN_EXIT_CODE))
+    timer.daemon = True
+    timer.start()
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except Exception:  # noqa: BLE001
+        os._exit(_SPIN_EXIT_CODE)
+
+
+def _run_main_spin_guarded(
+    main_factory: "Callable[[], Any]", config_dir: Path
+) -> None:
+    """Run *main_factory()* on a loop whose selector is spin-instrumented, with a
+    watchdog that captures + self-heals on a sustained spin (RDR-151 u2vmv).
+    Mirrors ``asyncio.run`` (set loop, run, cancel pending, shutdown asyncgens,
+    close)."""
+    from nexus.daemon.spin_guard import SpinGuardSelector, SpinWatchdog
+
+    sel = SpinGuardSelector()
+    loop = asyncio.SelectorEventLoop(sel)
+    watchdog = SpinWatchdog(
+        sel,
+        threshold_per_s=_SPIN_THRESHOLD_PER_S,
+        window_s=_SPIN_WINDOW_S,
+        consecutive=_SPIN_CONSECUTIVE,
+        on_spin=lambda spin_info: _t2_spin_capture_and_heal(
+            config_dir, loop, spin_info
+        ),
+    )
+    try:
+        asyncio.set_event_loop(loop)
+        watchdog.start(loop)
+        loop.run_until_complete(main_factory())
+    finally:
+        watchdog.stop()
+        try:
+            # Safety net matching asyncio.run: cancel any task _main did not
+            # await, then drain, so nothing leaks / warns.
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+            loop.run_until_complete(loop.shutdown_asyncgens())
+        except Exception:  # noqa: BLE001
+            pass
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
 def run_t2_daemon(
     *,
     config_dir: Path,
@@ -1867,7 +2048,7 @@ def run_t2_daemon(
 
     for attempt in range(1, _SPAWN_LOST_RETRY_MAX + 1):
         try:
-            asyncio.run(_main())
+            _run_main_spin_guarded(_main, config_dir)
             return
         except T2SpawnLockLost:
             # RDR-140 P1.3 (nexus-h2oko): losing the spawn lock is a benign

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -100,7 +100,7 @@ _GRACEFUL_PEER_EXIT_WAIT: float = 3.0
 # contention, so this only fires when a window exceeds the timeout; it turns a
 # >30s contention spike into a wait rather than a dropped best-effort write.
 # Module constant so tests can shrink the sleeps.
-_DISPATCH_RETRY_SLEEPS: tuple[float, ...] = (0.1, 0.25)
+_DISPATCH_RETRY_SLEEPS: tuple[float, ...] = (0.05, 0.1, 0.2, 0.4, 0.8)
 
 # RDR-146 P2 (nexus-5p2ci.12): interactive-vs-batch catalog-write fairness.
 # An interactive-priority catalog write opens an in-memory deadline window;
@@ -667,6 +667,56 @@ _CATALOG_WRITE_PREFIX = "catalog_write."
 #: cannot silently bypass serialisation. ``str.startswith`` accepts this tuple.
 _WRITE_SERIALIZED_PREFIXES: tuple[str, ...] = (_CATALOG_WRITE_PREFIX, "taxonomy.")
 
+#: RDR-151 nexus-xmohw: every mutating dispatch op must serialise through the
+#: daemon's single write lock. The peg root cause (issue #1137) is intra-daemon
+#: WAL write contention: a burst of un-serialised ``memory.*`` writes plus the
+#: internal reclaim loop each launch parallel ``to_thread`` writers racing the
+#: one SQLite writer lock → SQLITE_BUSY → tight retry → selector spin / 100% CPU.
+#: 2.1a serialised only ``catalog_write.*`` + ``taxonomy.*``; this extends it to
+#: ALL writers so the daemon is a genuine single serialised writer (RDR-129 B3 /
+#: Datasette write-queue model): one write at a time, no intra-daemon contention,
+#: no busy-spin. READS are intentionally NOT here — WAL allows concurrent readers,
+#: and serialising reads (esp. ``database.hello``) behind writes would re-create
+#: the slow-hello → ensure-running-declares-stale → takeover-churn cascade.
+#:
+#: ``tests/daemon/test_rdr151_xmohw_write_serialization.py::test_write_op_coverage``
+#: is the forcing function: it verb-matches every dispatchable store method and
+#: fails if a mutating op is not serialised here — closing the silent-recurrence
+#: gap (a future writer added without serialisation).
+_WRITE_OPS: frozenset[str] = frozenset({
+    # memory store
+    "memory.put", "memory.delete", "memory.expire", "memory.merge_memories",
+    "memory.put_or_merge", "memory.flag_stale_memories",
+    # plan library
+    "plans.save_plan", "plans.delete_plan", "plans.set_plan_disabled",
+    "plans.set_plan_enabled", "plans.set_scope_tags",
+    "plans.increment_match_metrics", "plans.increment_run_started",
+    "plans.increment_run_outcome",
+    # chash index
+    "chash_index.upsert", "chash_index.upsert_many",
+    "chash_index.delete_collection", "chash_index.delete_stale",
+    "chash_index.rename_collection",
+    # telemetry
+    "telemetry.log_relevance", "telemetry.log_relevance_batch",
+    "telemetry.expire_relevance_log", "telemetry.log_search_batch",
+    "telemetry.trim_search_telemetry", "telemetry.rename_collection",
+    # document aspects (upsert/get are RPC-denied; these are the dispatchable writes)
+    "document_aspects.set_salient_sentences",
+    "document_aspects.set_salient_sentences_by_key",
+    "document_aspects.delete", "document_aspects.delete_orphans",
+    "document_aspects.rename_collection",
+    # aspect extraction queue
+    "aspect_queue.enqueue", "aspect_queue.claim_next", "aspect_queue.claim_batch",
+    "aspect_queue.mark_done", "aspect_queue.mark_failed", "aspect_queue.mark_retry",
+    "aspect_queue.reclaim_stale", "aspect_queue.rename_collection",
+    # T2Database top-level write methods (dispatched as ``database.*``)
+    "database.rename_collection_cascade", "database.expire",
+    "database.complete_aspect",
+    # catalog read-store commit (flushes pending writes); catalog mutations
+    # proper go through the catalog_write.* prefix.
+    "catalog.commit",
+})
+
 
 def _build_dispatch_table(t2db: Any) -> dict[str, Any]:
     """Build the ``{op: bound_callable}`` dispatch table from *t2db*.
@@ -1145,10 +1195,7 @@ class T2Daemon:
             t2db = self._t2db
             if t2db is not None:
                 try:
-                    reclaimed = await asyncio.to_thread(
-                        t2db.aspect_queue.reclaim_stale,
-                        _ASPECT_RECLAIM_STALE_TIMEOUT_S,
-                    )
+                    reclaimed = await self._reclaim_stale_once(t2db)
                     if reclaimed:
                         _log.info(
                             "t2_daemon_aspect_reclaim", reclaimed=reclaimed
@@ -1161,6 +1208,24 @@ class T2Daemon:
                         "t2_daemon_aspect_reclaim_failed", exc=str(exc)
                     )
             await asyncio.sleep(_ASPECT_RECLAIM_INTERVAL)
+
+    async def _reclaim_stale_once(self, t2db: Any) -> int:
+        """Run one aspect-queue stale-reclaim pass — RDR-151 nexus-xmohw: the
+        daemon's OWN reclaim writer serialises through the SAME write lock as
+        serve-path writes (issue #1137 mechanism 2: the 30s reclaim loop raced a
+        ``memory.delete`` burst on the WAL writer lock → SQLITE_BUSY → retry
+        spin). Under the lock there is one writer at a time, so no contention.
+        The lock is created in ``start()``; the pre-start window falls back to a
+        direct write (no other writer exists yet)."""
+        lock = self._catalog_write_lock
+        if lock is not None:
+            async with lock:
+                return await asyncio.to_thread(
+                    t2db.aspect_queue.reclaim_stale, _ASPECT_RECLAIM_STALE_TIMEOUT_S
+                )
+        return await asyncio.to_thread(
+            t2db.aspect_queue.reclaim_stale, _ASPECT_RECLAIM_STALE_TIMEOUT_S
+        )
 
     async def run_until_signal(self) -> None:
         """Block until SIGTERM/SIGINT arrives."""
@@ -1510,15 +1575,43 @@ class T2Daemon:
         # prefix is serialised (not an enumerated write-op set) so a future
         # taxonomy writer is covered by default — a missed writer is exactly the
         # silent-recurrence class this fix closes. Taxonomy reads serialising
-        # behind a write is acceptable: they are not a hot daemon read path, and
-        # P2.1b/P2.1c keep write hold-time short.
+        # behind a write is acceptable: they are not a hot daemon read path.
+        # Lock hold-time is bounded to one write attempt (backoff happens outside
+        # the lock in _invoke_serialized_with_retry).
         if (
-            op.startswith(_WRITE_SERIALIZED_PREFIXES)
+            (op in _WRITE_OPS or op.startswith(_WRITE_SERIALIZED_PREFIXES))
             and self._catalog_write_lock is not None
         ):
-            async with self._catalog_write_lock:
-                return await self._invoke_with_lock_retry(callable_, op, args, kwargs)
+            return await self._invoke_serialized_with_retry(
+                callable_, op, args, kwargs
+            )
         return await self._invoke_with_lock_retry(callable_, op, args, kwargs)
+
+    async def _invoke_serialized_with_retry(
+        self, callable_: Any, op: str, args: list[Any], kwargs: dict[str, Any],
+    ) -> Any:
+        """Serialised write path (RDR-151 nexus-xmohw): hold the daemon write
+        lock for ONE write attempt, then release it BEFORE the backoff sleep, so
+        a write waiting on a cross-process writer never blocks the daemon's other
+        writes for the whole retry budget (critic C2 head-of-line bound). Intra-
+        daemon contention is gone by construction (one writer at a time); the
+        retry only fires against an out-of-daemon writer."""
+        lock = self._catalog_write_lock
+        assert lock is not None  # caller checked
+        sleeps = _DISPATCH_RETRY_SLEEPS
+        max_attempts = len(sleeps) + 1
+        for attempt in range(1, max_attempts + 1):
+            async with lock:
+                try:
+                    return await asyncio.to_thread(callable_, *args, **kwargs)
+                except sqlite3.OperationalError as exc:
+                    if not _is_locked_error(exc) or attempt == max_attempts:
+                        raise
+                    _log.warning(
+                        "t2_daemon_dispatch_lock_retry",
+                        op=op, attempt=attempt, exc=str(exc),
+                    )
+            await asyncio.sleep(sleeps[attempt - 1])  # backoff OUTSIDE the lock
 
     async def _invoke_with_lock_retry(
         self, callable_: Any, op: str, args: list[Any], kwargs: dict[str, Any],

--- a/tests/daemon/test_nexus_64w50_we61e_daemon_reclaim_takeover.py
+++ b/tests/daemon/test_nexus_64w50_we61e_daemon_reclaim_takeover.py
@@ -212,13 +212,13 @@ def _info_logs(monkeypatch: pytest.MonkeyPatch):
 
 
 def _stub_asyncio_run(monkeypatch: pytest.MonkeyPatch, outcomes: list):
-    """Replace ``asyncio.run`` with a scripted sequence. Each outcome is
-    either an exception instance (raised) or a sentinel for clean return.
-    The passed coroutine is closed to avoid 'never awaited' warnings."""
+    """Replace the daemon's spin-guarded runner with a scripted sequence
+    (RDR-151 u2vmv: run_t2_daemon now calls ``_run_main_spin_guarded`` instead
+    of ``asyncio.run`` directly). Each outcome is either an exception instance
+    (raised) or a sentinel for clean return; the _main factory is not invoked."""
     calls: list[int] = []
 
-    def _fake_run(coro):  # noqa: ANN001
-        coro.close()
+    def _fake_run(main_factory, config_dir):  # noqa: ANN001
         idx = len(calls)
         calls.append(1)
         outcome = outcomes[idx]
@@ -226,7 +226,7 @@ def _stub_asyncio_run(monkeypatch: pytest.MonkeyPatch, outcomes: list):
             raise outcome
         return outcome
 
-    monkeypatch.setattr(asyncio, "run", _fake_run)
+    monkeypatch.setattr(t2_daemon, "_run_main_spin_guarded", _fake_run)
     return calls
 
 

--- a/tests/daemon/test_rdr151_xmohw_write_serialization.py
+++ b/tests/daemon/test_rdr151_xmohw_write_serialization.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-151 nexus-xmohw (issue #1137): ALL daemon writes serialise through the
+single write lock, so the T2 daemon is a genuine single serialised writer and
+cannot self-contend into a SQLITE_BUSY retry spin / 100% CPU peg.
+
+2.1a serialised only ``catalog_write.*`` + ``taxonomy.*``. #1137 showed a
+``memory.delete`` burst plus the daemon's own 30s reclaim loop racing the WAL
+writer lock — both un-serialised. These tests assert (1) memory writes now
+serialise, (2) the reclaim writer serialises against serve-path writes, and
+(3) a coverage forcing-function so no future mutating op silently bypasses.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+import threading
+import time
+from pathlib import Path
+from tempfile import mkdtemp
+
+
+async def _max_overlap_for_op(op: str) -> int:
+    """Drive two concurrent dispatches of *op* with a slow threaded body and
+    return the max observed overlap (2 = concurrent/un-serialised, 1 = serial)."""
+    from nexus.daemon.t2_daemon import T2Daemon
+
+    cfgdir = Path(mkdtemp(prefix="xmohw-"))
+    (cfgdir / "sockets").mkdir(exist_ok=True)
+    daemon = T2Daemon(config_dir=cfgdir, db_path=cfgdir / "memory.db")
+    await daemon.start()
+
+    state = {"cur": 0, "max": 0}
+    lock = threading.Lock()
+
+    def _slow_write(*_a, **_k) -> int:
+        with lock:
+            state["cur"] += 1
+            state["max"] = max(state["max"], state["cur"])
+        time.sleep(0.15)
+        with lock:
+            state["cur"] -= 1
+        return 0
+
+    daemon._dispatch_table[op] = _slow_write  # type: ignore[index]
+    frame = {"op": op, "args": [], "kwargs": {}, "request_id": 1}
+    try:
+        await asyncio.gather(
+            daemon._dispatch(dict(frame), is_uds=True),
+            daemon._dispatch(dict(frame), is_uds=True),
+        )
+    finally:
+        try:
+            await asyncio.wait_for(daemon.stop(), timeout=10.0)
+        except Exception:  # noqa: BLE001
+            pass
+    return state["max"]
+
+
+def test_memory_delete_is_serialized() -> None:
+    """#1137 trigger: a burst of memory.delete must serialise (overlap 1)."""
+    assert asyncio.run(_max_overlap_for_op("memory.delete")) == 1
+
+
+def test_memory_put_is_serialized() -> None:
+    assert asyncio.run(_max_overlap_for_op("memory.put")) == 1
+
+
+def test_reclaim_serializes_against_serve_write() -> None:
+    """#1137 mechanism 2: the internal reclaim writer must not run concurrently
+    with a serve-path write — both hold the single write lock."""
+    from nexus.daemon.t2_daemon import T2Daemon
+
+    async def _drive() -> int:
+        cfgdir = Path(mkdtemp(prefix="xmohw-rec-"))
+        (cfgdir / "sockets").mkdir(exist_ok=True)
+        daemon = T2Daemon(config_dir=cfgdir, db_path=cfgdir / "memory.db")
+        await daemon.start()
+
+        state = {"cur": 0, "max": 0}
+        guard = threading.Lock()
+
+        def _bump_hold_drop() -> int:
+            with guard:
+                state["cur"] += 1
+                state["max"] = max(state["max"], state["cur"])
+            time.sleep(0.15)
+            with guard:
+                state["cur"] -= 1
+            return 0
+
+        # A serve-path write (serialised) ...
+        daemon._dispatch_table["memory.put"] = _bump_hold_drop  # type: ignore[index]
+        # ... and the reclaim writer pointed at the same instrumented body.
+        fake_t2 = type("T", (), {"aspect_queue": type("Q", (), {
+            "reclaim_stale": staticmethod(lambda _t: _bump_hold_drop()),
+        })()})()
+        frame = {"op": "memory.put", "args": [], "kwargs": {}, "request_id": 1}
+        try:
+            await asyncio.gather(
+                daemon._dispatch(dict(frame), is_uds=True),
+                daemon._reclaim_stale_once(fake_t2),
+            )
+        finally:
+            try:
+                await asyncio.wait_for(daemon.stop(), timeout=10.0)
+            except Exception:  # noqa: BLE001
+                pass
+        return state["max"]
+
+    assert asyncio.run(_drive()) == 1, "reclaim must not overlap a serve write"
+
+
+def test_write_op_coverage() -> None:
+    """Forcing function (silent-recurrence guard): every dispatchable mutating
+    store method MUST be serialised — present in _WRITE_OPS or matched by a
+    serialised prefix. A future writer added without serialisation fails here."""
+    from nexus.db.t2 import T2Database
+    from nexus.daemon.t2_daemon import (
+        _RPC_DENY_OPS,
+        _T2_STORE_ATTRS,
+        _WRITE_OPS,
+        _WRITE_SERIALIZED_PREFIXES,
+        _build_dispatch_table,
+    )
+
+    write_verb = re.compile(
+        r"^(put|delete|merge|update|insert|upsert|claim|complete|mark|enqueue|"
+        r"dequeue|set_|clear|prune|purge|flag|promote|reclaim|save|store|persist|"
+        r"increment|add_|expire|trim|log_|rename|rebuild|assign|commit|vacuum|"
+        r"archive|sweep|drop|apply|write|record|remove|migrate|backfill)"
+    )
+
+    cfgdir = Path(mkdtemp(prefix="xmohw-cov-"))
+    with T2Database(cfgdir / "memory.db", run_migrations=True) as db:
+        table = _build_dispatch_table(db)
+        missing: list[str] = []
+        for store_name in _T2_STORE_ATTRS:
+            store = getattr(db, store_name, None)
+            if store is None:
+                continue
+            for attr in dir(store):
+                if attr.startswith("_"):
+                    continue
+                op = f"{store_name}.{attr}"
+                if op in _RPC_DENY_OPS or op not in table:
+                    continue  # not dispatchable
+                if not callable(getattr(store, attr)):
+                    continue
+                if not write_verb.match(attr):
+                    continue  # not a mutating verb
+                serialized = (
+                    op in _WRITE_OPS or op.startswith(_WRITE_SERIALIZED_PREFIXES)
+                )
+                if not serialized:
+                    missing.append(op)
+
+    assert not missing, (
+        "mutating dispatch ops not serialised (add to _WRITE_OPS): "
+        + ", ".join(sorted(missing))
+    )
+
+
+def test_write_ops_have_no_stale_entries() -> None:
+    """Every _WRITE_OPS entry must name a real dispatchable op (no typos / drift)."""
+    from nexus.db.t2 import T2Database
+    from nexus.daemon.t2_daemon import _WRITE_OPS, _build_dispatch_table
+
+    cfgdir = Path(mkdtemp(prefix="xmohw-stale-"))
+    with T2Database(cfgdir / "memory.db", run_migrations=True) as db:
+        table = _build_dispatch_table(db)
+        # database.* methods are added under the pseudo-store; include them.
+        valid = set(table)
+        stale = [op for op in _WRITE_OPS if op not in valid]
+    assert not stale, f"_WRITE_OPS names non-dispatchable ops: {stale}"

--- a/tests/daemon/test_spin_guard.py
+++ b/tests/daemon/test_spin_guard.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-151 nexus-u2vmv: cause-agnostic event-loop spin guard.
+
+The T2 daemon must be constitutionally unable to peg at ~100% CPU regardless of
+client version mix or takeover races. These tests cover the detector
+(`SpinGuardSelector` counts zero-timeout ready-returns), the watchdog decision
+logic (fires after K consecutive over-threshold windows, never on bounded load),
+and a REAL selector spin (a no-op reader on a perpetually-ready pipe) to prove
+the guard detects and breaks an actual 100% spin.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import selectors
+import threading
+
+import pytest
+
+from nexus.daemon.spin_guard import SpinGuardSelector, SpinWatchdog
+
+
+# ── detector ──────────────────────────────────────────────────────────────
+
+
+def test_spinguard_selector_counts_zero_timeout_ready_returns() -> None:
+    """A select(timeout≈0) that returns a ready fd is the spin signature and
+    must be counted per-fd; a blocking/empty select must not."""
+    sel = SpinGuardSelector()
+    r, w = os.pipe()
+    try:
+        sel.register(r, selectors.EVENT_READ)
+        os.write(w, b"x")  # read end now perpetually ready
+        before = sel.zero_to_ready
+        for _ in range(5):
+            sel.select(0)  # zero-timeout poll, fd ready each time => spin shape
+        assert sel.zero_to_ready == before + 5
+        assert sel.ready_fd_hits.get(r, 0) >= 5
+    finally:
+        sel.unregister(r)
+        os.close(r)
+        os.close(w)
+        sel.close()
+
+
+def test_spinguard_selector_blocking_select_not_counted() -> None:
+    """A select with a real timeout that returns nothing is healthy, not a spin."""
+    sel = SpinGuardSelector()
+    try:
+        before = sel.zero_to_ready
+        sel.select(0.001)  # nothing registered → returns empty
+        assert sel.zero_to_ready == before
+    finally:
+        sel.close()
+
+
+# ── watchdog decision logic (deterministic, injected clock + counter) ───────
+
+
+class _FakeCounter:
+    def __init__(self) -> None:
+        self.zero_to_ready = 0
+        self.ready_fd_hits: dict[int, int] = {}
+
+
+def test_watchdog_fires_after_consecutive_over_threshold_windows() -> None:
+    fired: list[dict] = []
+    ctr = _FakeCounter()
+    wd = SpinWatchdog(
+        ctr,
+        threshold_per_s=1000,
+        window_s=1.0,
+        consecutive=3,
+        on_spin=lambda info: fired.append(info),
+    )
+    t = 0.0
+    # 3 windows each adding 5000 zero_to_ready over 1s => 5000/s >> 1000/s
+    for _ in range(3):
+        ctr.zero_to_ready += 5000
+        t += 1.0
+        wd.poll(now=t)
+    assert len(fired) == 1, "must fire once after 3 consecutive hot windows"
+    assert fired[0]["rate_per_s"] >= 1000
+
+
+def test_watchdog_does_not_fire_on_bounded_load() -> None:
+    """Healthy high-but-bounded throughput must not trip the guard."""
+    fired: list[dict] = []
+    ctr = _FakeCounter()
+    wd = SpinWatchdog(
+        ctr, threshold_per_s=5000, window_s=1.0, consecutive=3,
+        on_spin=lambda info: fired.append(info),
+    )
+    t = 0.0
+    for _ in range(10):
+        ctr.zero_to_ready += 800  # 800/s, well under threshold
+        t += 1.0
+        wd.poll(now=t)
+    assert fired == []
+
+
+def test_watchdog_resets_on_dip_below_threshold() -> None:
+    """A transient burst (not sustained) must not fire — consecutive resets."""
+    fired: list[dict] = []
+    ctr = _FakeCounter()
+    wd = SpinWatchdog(
+        ctr, threshold_per_s=1000, window_s=1.0, consecutive=3,
+        on_spin=lambda info: fired.append(info),
+    )
+    t = 0.0
+    pattern = [5000, 5000, 0, 5000, 5000]  # never 3 in a row
+    for d in pattern:
+        ctr.zero_to_ready += d
+        t += 1.0
+        wd.poll(now=t)
+    assert fired == []
+
+
+# ── real spin: prove the guard catches an actual 100% selector spin ─────────
+
+
+def test_real_selector_spin_is_detected_and_broken() -> None:
+    """Register a no-op reader on a perpetually-ready pipe — asyncio will call
+    _run_once at ~100% CPU forever. The watchdog must detect it and invoke
+    on_spin, which stops the loop (the spin-breaker). A fallback timer stops the
+    loop after 15s so a regression FAILS the assertion instead of hanging CI."""
+    sel = SpinGuardSelector()
+    loop = asyncio.SelectorEventLoop(sel)
+    r, w = os.pipe()
+    os.write(w, b"spin")  # read end perpetually ready; the reader never drains it
+    fired: list[dict] = []
+
+    def _on_spin(info: dict) -> None:
+        fired.append(info)
+        loop.call_soon_threadsafe(loop.stop)
+
+    # Regression fallback: if the guard never fires, don't hang — stop the loop.
+    guard_timer = threading.Timer(
+        15.0, lambda: loop.call_soon_threadsafe(loop.stop)
+    )
+    guard_timer.start()
+
+    def _noop_reader() -> None:
+        # Deliberately does NOT read r — fd stays ready => busy spin.
+        pass
+
+    try:
+        loop.add_reader(r, _noop_reader)
+        wd = SpinWatchdog(
+            sel, threshold_per_s=2000, window_s=0.5, consecutive=2,
+            on_spin=_on_spin,
+        )
+        wd.start(loop)  # background thread
+        loop.run_forever()
+    finally:
+        guard_timer.cancel()
+        wd.stop()
+        loop.remove_reader(r)
+        loop.close()
+        os.close(r)
+        os.close(w)
+
+    assert fired, "watchdog must detect and break a real selector spin"
+    assert fired[0].get("hot_fd") == r, "capture must name the perpetually-ready fd"
+
+
+# ── self-heal bounding: never worse than a pegged-but-serving daemon ─────────
+
+
+class _FakeLoop:
+    def __init__(self) -> None:
+        self._ready: list = []
+
+
+def test_spin_heal_count_window_prunes_old(tmp_path) -> None:
+    from nexus.daemon import t2_daemon as td
+
+    now = 1_000_000.0
+    # Two stamps inside the window, one far outside.
+    old = now - td._SPIN_HEAL_WINDOW_S - 100
+    (tmp_path / ".t2_spin_heals").write_text(f"{old}\n{now - 10}\n")
+    count = td._spin_heal_count_in_window(tmp_path, now)
+    assert count == 2, "old stamp pruned; recent + current counted"
+
+
+def test_spin_heal_disarms_after_max_never_suppresses(tmp_path, monkeypatch) -> None:
+    """Critic C2: a persistent trigger must NOT drive repeated os._exit (which
+    the supervisor crash-loop guard would turn into permanent suppression). After
+    _SPIN_HEAL_MAX heals the daemon disarms self-heal and stays up (no SIGTERM,
+    no exit timer) — pegged-but-serving == the pre-guard baseline, never worse."""
+    from nexus.daemon import t2_daemon as td
+
+    kills: list = []
+    timers: list = []
+    monkeypatch.setattr(td.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+
+    class _FakeTimer:
+        def __init__(self, *a, **k) -> None:
+            self.daemon = False
+
+        def start(self) -> None:
+            timers.append(1)
+
+    monkeypatch.setattr(td.threading, "Timer", _FakeTimer)
+
+    loop = _FakeLoop()
+    info = {
+        "hot_fd": 7, "rate_per_s": 99999.0,
+        "ready_fd_hits": {7: 99999}, "threshold_per_s": td._SPIN_THRESHOLD_PER_S,
+    }
+    # First _SPIN_HEAL_MAX calls self-heal (SIGTERM + exit timer armed).
+    for _ in range(td._SPIN_HEAL_MAX):
+        td._t2_spin_capture_and_heal(tmp_path, loop, info)
+    assert len(kills) == td._SPIN_HEAL_MAX
+    assert len(timers) == td._SPIN_HEAL_MAX
+
+    # The next spin EXCEEDS the bound → disarm: no further kill, no exit timer.
+    td._t2_spin_capture_and_heal(tmp_path, loop, info)
+    assert len(kills) == td._SPIN_HEAL_MAX, "must NOT self-heal past the bound"
+    assert len(timers) == td._SPIN_HEAL_MAX, "must NOT arm os._exit past the bound"
+
+
+def test_spin_capture_records_loop_ready_len(tmp_path, monkeypatch) -> None:
+    """Critic C4: the capture must record loop._ready length (distinguishes a
+    perpetually-ready-fd spin from a self-rescheduling call_soon spin)."""
+    from nexus.daemon import t2_daemon as td
+
+    monkeypatch.setattr(td.os, "kill", lambda *a: None)
+    monkeypatch.setattr(td.threading, "Timer", lambda *a, **k: type(
+        "T", (), {"daemon": False, "start": lambda self: None}
+    )())
+
+    loop = _FakeLoop()
+    loop._ready = ["cb1", "cb2", "cb3"]
+    td._t2_spin_capture_and_heal(
+        tmp_path, loop,
+        {"hot_fd": 9, "rate_per_s": 5e4, "ready_fd_hits": {9: 1}, "threshold_per_s": 1e4},
+    )
+    caps = list((tmp_path / "logs").glob("t2_spin_*.txt"))
+    assert caps, "a capture file must be written"
+    text = caps[0].read_text()
+    assert "loop_ready_len=3" in text

--- a/tests/hooks/test_stop_failure_hook.py
+++ b/tests/hooks/test_stop_failure_hook.py
@@ -126,3 +126,33 @@ class TestStopFailureHook:
         )
         assert result.returncode == 0
         assert "skipping side effects" in result.stderr.lower()
+
+    def test_rate_limit_remembers_but_never_creates_bead(self, tmp_path: Path) -> None:
+        """Side-effect contract: log via `bd remember`, but never `bd create`.
+
+        Transient API failures are infra events, not actionable bugs. Filing
+        them as P1 issues pollutes `bd ready`. This pins that we record the
+        crash (remember) without ever filing an issue (create).
+        """
+        # Fake `bd` on PATH that appends its subcommand to a log file.
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        log = tmp_path / "bd_calls.log"
+        bd = fake_bin / "bd"
+        bd.write_text(
+            "#!/bin/sh\n"
+            f'echo "$1" >> "{log}"\n'
+            "exit 0\n"
+        )
+        bd.chmod(0o755)
+        result = _run_hook(
+            _make_payload("rate_limit"),
+            env_overrides={
+                "CLAUDECODE": "1",
+                "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
+            },
+        )
+        assert result.returncode == 0
+        calls = log.read_text().split() if log.exists() else []
+        assert "remember" in calls, f"expected a bd remember call, got {calls}"
+        assert "create" not in calls, f"hook must not file issues, got {calls}"

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.10.3"
+version = "5.10.5"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## conexus 5.10.5

Promotes `develop` to `main`. RDR-151 daemon CPU-peg hardening — the daemon now both **can't spin** (backstop) and **won't self-contend** (root cause).

### Fixed
- **Spin backstop (RDR-151, nexus-u2vmv).** Cause-agnostic event-loop spin guard: `SpinGuardSelector` (immediate-ready-return by wall-time) + `SpinWatchdog` that auto-captures (selector map + `loop._ready` + stacks) and self-heals (bounded; disarms to pegged-but-serving so it's never worse than baseline). Validated against the live postmortem signature (would have fired on the 5.10.4 peg in ~5s).
- **Write-contention root cause (RDR-151, nexus-xmohw, GH #1137).** The daemon is now a single serialised writer: every mutating dispatch op + the internal reclaim loop serialise through one write lock, so a `memory.*` write burst + reclaim can't race the SQLite writer into a `SQLITE_BUSY` retry spin. Reads stay concurrent (`database.hello` never serialised); lock-hold bounded to one attempt (backoff outside the lock). Coverage forcing-test guards against un-serialised writers.
- **Stop hook no longer files P1 bug beads for transient API failures (#1136).**

### Coupled follow-on (tracked, not in this release)
`BEGIN IMMEDIATE` (2.1b) + fast-fail `busy_timeout` (2.1c) for the cross-process/version-skew double-writer case — they must land together.

### Validation
Unit 9099 · integration 80 (0 failures) · sandbox smoke `[done]` · upgrade-shakeout 12/12 (5.10.4→5.10.5). All 7 version targets + both `source.ref` bumped; `uv.lock` refreshed; both changelogs updated (incl. 5.10.4 catch-up for the develop/main changelog drift).
