### PR TITLE
fix(operators): agent-replacement MCP tools work without subprocess MCP approval (nexus-mawqw)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -448,6 +448,119 @@ def _clamp_subagent_timeout(requested: float, tool_name: str) -> float:
     return requested
 
 
+def _subprocess_tool_grant() -> tuple[dict[str, Any], list[str]]:
+    """Build the (mcp_servers, allowed_tools) grant for tool-needing
+    operator subprocesses. nexus-mawqw / Fix B.
+
+    The agent-replacement tools (``nx_enrich_beads``, ``nx_plan_audit``)
+    do open-ended codebase exploration that cannot be pre-fetched, so
+    their ``claude -p`` child must be able to call nx MCP read tools plus
+    the built-in file tools. We pass the conexus MCP servers *inline* via
+    ``--mcp-config`` (claude_dispatch's ``mcp_servers``) so they clear the
+    post-CC-2.1.162 pending-approval gate, and allowlist them by server
+    key plus the read-only built-ins.
+
+    Server keys here become the child's tool-name prefix
+    (``mcp__nexus__search`` etc.), independent of the parent plugin's
+    ``mcp__plugin_conexus_nexus__*`` naming — the child gets its own
+    fresh, explicitly-trusted server registration.
+
+    ``CLAUDE_PLUGIN_ROOT`` is threaded through from the current env so
+    the spawned ``nx-mcp`` resolves the same plugin root as the parent;
+    omitted when unset (CLI / non-plugin contexts) so we never inject a
+    literal ``${...}`` placeholder.
+    """
+    env: dict[str, str] = {}
+    plugin_root = _os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        env["CLAUDE_PLUGIN_ROOT"] = plugin_root
+
+    server_env = {"env": env} if env else {}
+    mcp_servers: dict[str, Any] = {
+        "nexus": {"command": "nx-mcp", "args": [], **server_env},
+        "nexus_catalog": {"command": "nx-mcp-catalog", "args": [], **server_env},
+    }
+    allowed_tools = [
+        "Read", "Grep", "Glob",
+        "mcp__nexus", "mcp__nexus_catalog",
+    ]
+    return mcp_servers, allowed_tools
+
+
+# nexus-mawqw / Fix A: cap how much we pre-fetch + inline into the tidy
+# prompt. 30 entries at 2 KB each keeps the prompt well under any context
+# pressure while covering the realistic consolidation working set.
+_TIDY_MAX_ENTRIES = 30
+_TIDY_MAX_CHARS_PER_ENTRY = 2000
+
+
+def _tidy_prefetch(topic: str, collection: str) -> tuple[str, int]:
+    """Retrieve + hydrate the entries to consolidate, server-side.
+
+    nexus-mawqw / Fix A. The MCP server holds direct T3 access, so the
+    ``tidy`` retrieval runs in-process here and the hydrated entries are
+    inlined into the prompt. The ``claude -p`` child then does LLM-only
+    dedup/summarise with NO tools, making ``nx_tidy`` immune to the
+    post-CC-2.1.162 MCP-server-approval gate that broke the old
+    subprocess-calls-MCP-tools design.
+
+    Returns ``(entries_block, n_entries)``. Degrades to ``("", 0)`` on any
+    retrieval failure or empty result so the caller still dispatches a
+    well-formed (entry-free) prompt rather than raising.
+    """
+    try:
+        hits = search(
+            query=topic,
+            corpus=collection,
+            limit=_TIDY_MAX_ENTRIES,
+            structured=True,
+        )
+    except Exception:
+        import structlog
+        structlog.get_logger().debug("tidy_prefetch_search_failed", exc_info=True)
+        return "", 0
+    if not isinstance(hits, dict):
+        # search() returns a human-readable string on no-match / error.
+        return "", 0
+    ids = hits.get("ids") or []
+    if not ids:
+        return "", 0
+    cols = hits.get("chunk_collections") or hits.get("collections") or [collection]
+
+    try:
+        hydrated = store_get_many(
+            ids,
+            cols,
+            max_chars_per_doc=_TIDY_MAX_CHARS_PER_ENTRY,
+            structured=True,
+        )
+    except Exception:
+        import structlog
+        structlog.get_logger().debug("tidy_prefetch_hydrate_failed", exc_info=True)
+        return "", 0
+    if isinstance(hydrated, dict) and hydrated.get("error"):
+        # store_get_many caught an internal error and returned it as a
+        # structured field rather than raising. Surface it at DEBUG so a
+        # T3 outage during tidy is diagnosable instead of vanishing.
+        import structlog
+        structlog.get_logger().debug(
+            "tidy_prefetch_hydrate_error", error=hydrated["error"],
+        )
+    contents = hydrated.get("contents") if isinstance(hydrated, dict) else None
+    if not contents:
+        return "", 0
+
+    blocks: list[str] = []
+    for i, (doc_id, body) in enumerate(zip(ids, contents), start=1):
+        body = (body or "").strip()
+        if not body:
+            continue
+        blocks.append(f"--- Entry {i} (id={doc_id}) ---\n{body}")
+    if not blocks:
+        return "", 0
+    return "\n\n".join(blocks), len(blocks)
+
+
 # ── Tier-discipline telemetry (Phase 1A nexus-kren) ─────────────────────────
 
 
@@ -4154,7 +4267,7 @@ async def nx_answer(
 
 @mcp.tool(
     title="Consolidate Knowledge Topic",
-    annotations={"readOnlyHint": False, "destructiveHint": True},
+    annotations={"readOnlyHint": True},
 )
 async def nx_tidy(
     topic: str,
@@ -4163,17 +4276,28 @@ async def nx_tidy(
 ) -> str:
     """Consolidate knowledge entries on *topic* via claude -p. RDR-080 P3.
 
-    Replaces the ``knowledge-tidier`` agent. Spawns a ``claude -p``
-    subprocess that searches T3 for entries matching *topic*, identifies
-    duplicates and contradictions, and returns a consolidated summary.
+    Replaces the ``knowledge-tidier`` agent. nexus-mawqw / Fix A:
+    retrieves and hydrates matching entries **server-side** (in-process,
+    a single semantic ``search`` pass), inlines them into the prompt, then
+    dispatches a **tool-free** ``claude -p`` to identify duplicates,
+    contradictions, and outdated entries. Read-only: it reports a
+    consolidated summary plus suggested actions but performs no writes
+    (the old prompt claimed ``store_put`` access the child never had).
+
+    Retrieval scope is one semantic-search pass capped at
+    ``_TIDY_MAX_ENTRIES`` chunks; it does not expand the query, chase
+    related terms, or deduplicate chunks to documents. Best suited to
+    note-shaped collections (≈one chunk per entry). When the cap is hit
+    the returned summary says so explicitly (no silent truncation).
 
     Args:
         topic: The knowledge topic to consolidate (e.g. "chromadb quotas").
         collection: T3 collection to search (default: knowledge).
         timeout: Subprocess timeout in seconds. Default 600s (10 min) —
-            consolidation on a large corpus does multi-step search +
-            cross-reference; 120s was hitting the timeout routinely on
-            real workloads. Caller can override lower for small topics.
+            consolidation on a large corpus does heavy LLM-only reasoning
+            over the inlined entries; 120s was hitting the timeout
+            routinely on real workloads. Caller can override lower for
+            small topics.
 
     Returns:
         Consolidated summary as a human-readable string.
@@ -4188,15 +4312,37 @@ async def nx_tidy(
             "actions": {"type": "array", "items": {"type": "object"}},
         },
     }
+    # nexus-mawqw / Fix A: pre-fetch the entries server-side and inline
+    # them. The child claude -p then consolidates LLM-only with NO tools,
+    # so it can never trip the post-CC-2.1.162 MCP-server-approval gate.
+    entries_block, n_entries = _tidy_prefetch(topic, collection)
+    capped = n_entries >= _TIDY_MAX_ENTRIES
+    if capped:
+        import structlog
+        structlog.get_logger().info(
+            "tidy_prefetch_capped",
+            topic=topic, collection=collection, cap=_TIDY_MAX_ENTRIES,
+        )
+    if n_entries:
+        entries_section = (
+            f"\n\nHere are the {n_entries} retrieved entries to consolidate. "
+            "Work ONLY from these entries; do NOT call any tools:\n\n"
+            f"{entries_block}"
+        )
+    else:
+        entries_section = (
+            "\n\nNo matching entries were retrieved from the collection. "
+            "Report that there is nothing to consolidate. Do NOT call any tools."
+        )
     prompt = (
-        "You are the `tidy` knowledge consolidation operator. You have "
-        "access to nx MCP tools (search, query, store_put, store_get). "
-        "Search the specified collection for entries matching the topic, "
-        "identify duplicates, contradictions, and outdated entries, then "
-        "produce a consolidated summary.\n\n"
+        "You are the `tidy` knowledge consolidation operator. You have NO "
+        "tools available — all input is provided inline below. Identify "
+        "duplicates, contradictions, and outdated entries among the provided "
+        "entries, then produce a consolidated summary plus a list of "
+        "suggested actions.\n\n"
         f"Consolidate knowledge entries about '{topic}' in collection "
-        f"'{collection}'. Search for all related entries, identify duplicates "
-        "or contradictions, and produce a consolidated summary."
+        f"'{collection}'."
+        f"{entries_section}"
     )
     payload = await claude_dispatch(prompt, schema, timeout=timeout)
 
@@ -4205,6 +4351,12 @@ async def nx_tidy(
     lines = [summary]
     if actions:
         lines.append(f"\n{len(actions)} action(s) suggested.")
+    if capped:
+        lines.append(
+            f"\nNote: retrieval was capped at {_TIDY_MAX_ENTRIES} entries; "
+            "the collection may contain additional matching content not seen "
+            "by this consolidation pass."
+        )
     return "\n".join(lines)
 
 
@@ -4241,6 +4393,7 @@ async def nx_enrich_beads(
     from nexus.operators.dispatch import claude_dispatch
 
     timeout = _clamp_subagent_timeout(timeout, "nx_enrich_beads")
+    mcp_servers, allowed_tools = _subprocess_tool_grant()
 
     schema = {
         "type": "object",
@@ -4263,7 +4416,10 @@ async def nx_enrich_beads(
     if context:
         prompt += f"\n\nAdditional context:\n{context}"
 
-    payload = await claude_dispatch(prompt, schema, timeout=timeout)
+    payload = await claude_dispatch(
+        prompt, schema, timeout=timeout,
+        mcp_servers=mcp_servers, allowed_tools=allowed_tools,
+    )
     return (
         payload.get("enriched_description", "")
         if isinstance(payload, dict) else str(payload)
@@ -4304,6 +4460,7 @@ async def nx_plan_audit(
     from nexus.operators.dispatch import claude_dispatch
 
     timeout = _clamp_subagent_timeout(timeout, "nx_plan_audit")
+    mcp_servers, allowed_tools = _subprocess_tool_grant()
 
     schema = {
         "type": "object",
@@ -4324,7 +4481,10 @@ async def nx_plan_audit(
     if context:
         prompt += f"\n\nContext:\n{context}"
 
-    payload = await claude_dispatch(prompt, schema, timeout=timeout)
+    payload = await claude_dispatch(
+        prompt, schema, timeout=timeout,
+        mcp_servers=mcp_servers, allowed_tools=allowed_tools,
+    )
     if isinstance(payload, dict):
         verdict = payload.get("verdict", "unknown")
         summary = payload.get("summary", "")

--- a/src/nexus/operators/dispatch.py
+++ b/src/nexus/operators/dispatch.py
@@ -173,6 +173,9 @@ async def claude_dispatch(
     prompt: str,
     json_schema: dict[str, Any],
     timeout: float = 300.0,
+    *,
+    allowed_tools: list[str] | None = None,
+    mcp_servers: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Dispatch a single operator call to claude -p, fully async.
 
@@ -188,6 +191,23 @@ async def claude_dispatch(
             override up (``nx_plan_audit`` / ``nx_tidy`` use 600s).
             The prior 60s default produced a lot of false timeouts
             on real workloads.
+        allowed_tools: Opt-in tool allowlist (nexus-mawqw). When set,
+            ``--allowedTools <comma-joined>`` is passed so the child
+            ``claude -p`` may call those tools (built-ins like ``Read`` /
+            ``Grep`` / ``Glob`` and/or MCP tools like ``mcp__nexus``).
+            ``None`` (default) keeps the stateless-operator contract:
+            no tool access. DO NOT pass this for stateless operators
+            (extract/filter/rank/etc.) — they take all input from the
+            prompt and must stay tool-free.
+        mcp_servers: Opt-in MCP server map (nexus-mawqw), shape
+            ``{server_key: {"command": ..., "args": [...], ...}}``. When
+            set, ``--mcp-config '{"mcpServers": {...}}'`` is passed inline.
+            Servers provided via the flag are *explicitly* supplied, so
+            they clear the post-CC-2.1.162 pending-approval gate that
+            denies tool calls to unapproved ``.mcp.json`` servers. Pair
+            with ``allowed_tools`` containing ``mcp__<server_key>`` (or a
+            specific ``mcp__<server_key>__<tool>``) to actually permit the
+            calls. ``None`` (default) injects no MCP servers.
 
     Returns:
         Parsed JSON dict from stdout.
@@ -235,11 +255,22 @@ async def claude_dispatch(
         ephemeral=True,
         parent_session_id=parent_session_id,
     )
-    proc = await asyncio.create_subprocess_exec(
+    # Base argv is the stateless, tool-free default. Opt-in tool access
+    # (nexus-mawqw) appends --mcp-config / --allowedTools only when the
+    # caller explicitly requests it, preserving the stateless-operator
+    # contract for extract/filter/rank/etc.
+    argv: list[str] = [
         "claude", "-p",
         "--output-format", "json",
         "--json-schema", schema_json,
         "--no-session-persistence",
+    ]
+    if mcp_servers:
+        argv += ["--mcp-config", json.dumps({"mcpServers": mcp_servers})]
+    if allowed_tools:
+        argv += ["--allowedTools", ",".join(allowed_tools)]
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,

--- a/tests/test_nx_answer.py
+++ b/tests/test_nx_answer.py
@@ -1074,6 +1074,105 @@ class TestNxTidy:
             f"nx_tidy default timeout must be 600s; got {captured['timeout']}"
         )
 
+    @pytest.mark.asyncio
+    async def test_prefetches_entries_and_stays_tool_free(self, monkeypatch):
+        """nexus-mawqw / Fix A: nx_tidy retrieves entries server-side
+        (the MCP server holds direct T3 access), inlines them into the
+        prompt, and dispatches a TOOL-FREE claude -p. This makes nx_tidy
+        immune to CC permission posture forever — the child never calls a
+        tool, so the post-2.1.162 server-approval gate can't break it."""
+        import nexus.operators.dispatch as _mod
+        import nexus.mcp.core as _core
+        from nexus.mcp.core import nx_tidy
+
+        # Pre-fetch surface: search returns structured ids, store_get_many
+        # hydrates the bodies. Both run in-process on the server side.
+        monkeypatch.setattr(_core, "search", lambda **kw: {
+            "ids": ["id1", "id2"],
+            "chunk_collections": ["knowledge__x", "knowledge__x"],
+            "collections": ["knowledge__x"],
+        })
+        monkeypatch.setattr(_core, "store_get_many", lambda *a, **kw: {
+            "contents": [
+                "ENTRY-BODY-SENTINEL-ONE about chromadb quotas",
+                "ENTRY-BODY-SENTINEL-TWO duplicate of one",
+            ],
+            "missing": [],
+        })
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
+            captured["prompt"] = prompt
+            captured["kwargs"] = kwargs
+            return {"summary": "ok", "actions": []}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await nx_tidy(topic="chromadb quotas", collection="knowledge__x")
+
+        # Hydrated bodies inlined into the prompt.
+        assert "ENTRY-BODY-SENTINEL-ONE" in captured["prompt"]
+        assert "ENTRY-BODY-SENTINEL-TWO" in captured["prompt"]
+        # Tool-free: no MCP/tool grant passed to dispatch.
+        assert not captured["kwargs"].get("mcp_servers"), (
+            "nx_tidy must stay tool-free (Fix A pre-fetches in-process)"
+        )
+        assert not captured["kwargs"].get("allowed_tools")
+
+    @pytest.mark.asyncio
+    async def test_cap_saturation_is_surfaced_not_silent(self, monkeypatch):
+        """nexus-mawqw / no-silent-caps: when retrieval saturates the
+        _TIDY_MAX_ENTRIES cap, the returned summary must say so. A silent
+        cap would let a tidy 'consolidate' a 200-entry collection from 30
+        chunks and suggest deletions for entries it never saw."""
+        import nexus.operators.dispatch as _mod
+        import nexus.mcp.core as _core
+        from nexus.mcp.core import nx_tidy, _TIDY_MAX_ENTRIES
+
+        n = _TIDY_MAX_ENTRIES
+        monkeypatch.setattr(_core, "search", lambda **kw: {
+            "ids": [f"id{i}" for i in range(n)],
+            "chunk_collections": ["knowledge__x"] * n,
+            "collections": ["knowledge__x"],
+        })
+        monkeypatch.setattr(_core, "store_get_many", lambda *a, **kw: {
+            "contents": [f"body {i}" for i in range(n)],
+            "missing": [],
+        })
+
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
+            return {"summary": "done", "actions": []}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        result = await nx_tidy(topic="t", collection="knowledge__x")
+        assert str(_TIDY_MAX_ENTRIES) in result
+        assert "capped" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_prefetch_failure_degrades_gracefully(self, monkeypatch):
+        """If server-side retrieval errors, nx_tidy still dispatches
+        (with no inlined entries) rather than raising — a tidy on a
+        missing collection should report 'nothing found', not crash."""
+        import nexus.operators.dispatch as _mod
+        import nexus.mcp.core as _core
+        from nexus.mcp.core import nx_tidy
+
+        def boom(**kw):
+            raise RuntimeError("t3 down")
+
+        monkeypatch.setattr(_core, "search", boom)
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
+            captured["prompt"] = prompt
+            return {"summary": "nothing to consolidate", "actions": []}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        result = await nx_tidy(topic="ghost topic")
+        assert "ghost topic" in captured["prompt"]
+        assert isinstance(result, str)
+
 
 # ── nx_enrich_beads ───────────────────────────────────────────────────────────
 
@@ -1085,7 +1184,7 @@ class TestNxEnrichBeads:
         import nexus.operators.dispatch as _mod
         from nexus.mcp.core import nx_enrich_beads
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             return {"enriched_description": "## Enriched\n\nDetails here."}
 
         monkeypatch.setattr(_mod, "claude_dispatch", fake)
@@ -1099,7 +1198,7 @@ class TestNxEnrichBeads:
 
         captured = []
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             captured.append(prompt)
             return {"enriched_description": "ok"}
 
@@ -1114,7 +1213,7 @@ class TestNxEnrichBeads:
 
         captured = []
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             captured.append(prompt)
             return {"enriched_description": "ok"}
 
@@ -1134,7 +1233,7 @@ class TestNxEnrichBeads:
 
         captured = {}
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             captured["timeout"] = timeout
             return {"enriched_description": "ok"}
 
@@ -1144,6 +1243,31 @@ class TestNxEnrichBeads:
             f"nx_enrich_beads default timeout must be 300s; "
             f"got {captured['timeout']}"
         )
+
+    @pytest.mark.asyncio
+    async def test_grants_mcp_and_tool_access(self, monkeypatch):
+        """nexus-mawqw / Fix B: enrich does open-ended codebase
+        exploration, so its claude -p child must be granted MCP + file
+        tools. Without the grant the child sees the conexus server as
+        unapproved (post-CC-2.1.162) and every tool call is denied."""
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import nx_enrich_beads
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
+            captured.update(kwargs)
+            return {"enriched_description": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await nx_enrich_beads(bead_description="task")
+        assert "nexus" in (captured.get("mcp_servers") or {}), (
+            "enrich must inject the conexus MCP server inline"
+        )
+        assert "nexus_catalog" in (captured.get("mcp_servers") or {})
+        allowed = captured.get("allowed_tools") or []
+        assert "mcp__nexus" in allowed
+        assert "Read" in allowed and "Grep" in allowed
 
 
 # ── nx_plan_audit ─────────────────────────────────────────────────────────────
@@ -1156,7 +1280,7 @@ class TestNxPlanAudit:
         import nexus.operators.dispatch as _mod
         from nexus.mcp.core import nx_plan_audit
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             return {"verdict": "pass", "findings": [], "summary": "All good."}
 
         monkeypatch.setattr(_mod, "claude_dispatch", fake)
@@ -1169,7 +1293,7 @@ class TestNxPlanAudit:
         import nexus.operators.dispatch as _mod
         from nexus.mcp.core import nx_plan_audit
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             return {
                 "verdict": "warn",
                 "findings": [{"severity": "important", "title": "Missing file"}],
@@ -1188,7 +1312,7 @@ class TestNxPlanAudit:
 
         captured = []
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             captured.append(prompt)
             return {"verdict": "pass", "findings": [], "summary": "ok"}
 
@@ -1211,7 +1335,7 @@ class TestNxPlanAudit:
 
         captured = {}
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             captured["timeout"] = timeout
             return {"verdict": "pass", "findings": [], "summary": "ok"}
 
@@ -1221,6 +1345,28 @@ class TestNxPlanAudit:
             f"nx_plan_audit default timeout must be 600s; "
             f"got {captured['timeout']}"
         )
+
+    @pytest.mark.asyncio
+    async def test_grants_mcp_and_tool_access(self, monkeypatch):
+        """nexus-mawqw / Fix B: plan audit verifies file:line pointers
+        across the codebase, so its claude -p child must be granted MCP +
+        file tools."""
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import nx_plan_audit
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
+            captured.update(kwargs)
+            return {"verdict": "pass", "findings": [], "summary": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await nx_plan_audit(plan_json='{"steps": []}')
+        assert "nexus" in (captured.get("mcp_servers") or {})
+        assert "nexus_catalog" in (captured.get("mcp_servers") or {})
+        allowed = captured.get("allowed_tools") or []
+        assert "mcp__nexus" in allowed
+        assert "Read" in allowed
 
 
 # ── Operator timeout defaults (all raised to 300s 2026-04-17) ────────────────
@@ -1771,7 +1917,7 @@ class TestSubagentTimeoutFloor:
 
         captured = {}
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             captured["timeout"] = timeout
             return {"verdict": "pass", "findings": [], "summary": "ok"}
 
@@ -1789,7 +1935,7 @@ class TestSubagentTimeoutFloor:
 
         captured = {}
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             captured["timeout"] = timeout
             return {"verdict": "pass", "findings": [], "summary": "ok"}
 
@@ -1806,7 +1952,7 @@ class TestSubagentTimeoutFloor:
 
         captured = {}
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             captured["timeout"] = timeout
             return {"enriched_description": "ok"}
 
@@ -1824,7 +1970,7 @@ class TestSubagentTimeoutFloor:
 
         captured = {}
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             captured["timeout"] = timeout
             return {"enriched_description": "ok"}
 
@@ -1837,7 +1983,7 @@ class TestSubagentTimeoutFloor:
         import nexus.operators.dispatch as _mod
         from nexus.mcp.core import nx_plan_audit
 
-        async def fake(prompt, schema, timeout=60.0):
+        async def fake(prompt, schema, timeout=60.0, **kwargs):
             return {"verdict": "pass", "findings": [], "summary": "ok"}
 
         monkeypatch.setattr(_mod, "claude_dispatch", fake)

--- a/tests/test_operator_dispatch.py
+++ b/tests/test_operator_dispatch.py
@@ -161,6 +161,140 @@ class TestNoAuthCheck:
         assert not spawned, f"subprocess.run called on import: {spawned}"
 
 
+# ── Opt-in tool access (Fix B, nexus-mawqw) ────────────────────────────────
+
+class TestOptInToolAccess:
+    """Stateless operators stay tool-free by default. Agent-replacement
+    tools (nx_enrich_beads, nx_plan_audit) opt in to MCP + built-in tools
+    by passing ``allowed_tools`` and ``mcp_servers``. Without this, the
+    child claude -p sees the conexus MCP server as unapproved (post-CC
+    2.1.162) and every tool call is denied.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_dispatch_passes_no_tool_flags(self) -> None:
+        """The stateless default must NOT pass --allowedTools or
+        --mcp-config. Adding blanket tool access to every operator would
+        regress the stateless-tool-free invariant."""
+        from nexus.operators.dispatch import claude_dispatch
+
+        proc = _make_proc()
+        captured: list = []
+
+        async def intercept(*args, **kwargs):
+            captured.append(args)
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=intercept):
+            await claude_dispatch("prompt", _SIMPLE_SCHEMA)
+
+        argv = captured[0]
+        assert "--allowedTools" not in argv, "default dispatch must be tool-free"
+        assert "--mcp-config" not in argv, "default dispatch must not inject MCP servers"
+
+    @pytest.mark.asyncio
+    async def test_allowed_tools_emits_flag(self) -> None:
+        """Passing allowed_tools must emit --allowedTools with the
+        comma-joined tool names."""
+        from nexus.operators.dispatch import claude_dispatch
+
+        proc = _make_proc()
+        captured: list = []
+
+        async def intercept(*args, **kwargs):
+            captured.append(args)
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=intercept):
+            await claude_dispatch(
+                "prompt", _SIMPLE_SCHEMA,
+                allowed_tools=["Read", "Grep", "mcp__nexus"],
+            )
+
+        argv = list(captured[0])
+        assert "--allowedTools" in argv
+        val = argv[argv.index("--allowedTools") + 1]
+        assert val == "Read,Grep,mcp__nexus"
+
+    @pytest.mark.asyncio
+    async def test_mcp_servers_emits_inline_config(self) -> None:
+        """Passing mcp_servers must emit --mcp-config with an inline
+        {"mcpServers": {...}} JSON payload. Servers passed via the flag
+        are explicitly provided, so they clear the post-2.1.162
+        pending-approval gate that blocks .mcp.json servers."""
+        from nexus.operators.dispatch import claude_dispatch
+
+        proc = _make_proc()
+        captured: list = []
+
+        async def intercept(*args, **kwargs):
+            captured.append(args)
+            return proc
+
+        servers = {"nexus": {"command": "nx-mcp", "args": []}}
+        with patch("asyncio.create_subprocess_exec", side_effect=intercept):
+            await claude_dispatch(
+                "prompt", _SIMPLE_SCHEMA, mcp_servers=servers,
+            )
+
+        argv = list(captured[0])
+        assert "--mcp-config" in argv
+        cfg = json.loads(argv[argv.index("--mcp-config") + 1])
+        assert cfg == {"mcpServers": {"nexus": {"command": "nx-mcp", "args": []}}}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("call_operator", [
+        lambda: __import__("nexus.mcp.core", fromlist=["operator_extract"]).operator_extract(inputs="x", fields="y"),
+        lambda: __import__("nexus.mcp.core", fromlist=["operator_rank"]).operator_rank(items='["a","b"]', criterion="rel"),
+        lambda: __import__("nexus.mcp.core", fromlist=["operator_filter"]).operator_filter(items='[{"id":"a"}]', criterion="rel", source="llm"),
+    ])
+    async def test_stateless_operators_pass_no_tool_flags(self, call_operator) -> None:
+        """Load-bearing invariant guard at the CONCRETE-operator layer
+        (substantive-critic, nexus-mawqw). The dispatch-layer default test
+        alone wouldn't catch an operator that accidentally started passing
+        a tool grant. Drive the real operator through create_subprocess_exec
+        and assert the argv carries no --allowedTools / --mcp-config."""
+        proc = _make_proc(
+            stdout=b'{"extractions": [], "ranked": [], "items": [], "rationale": []}'
+        )
+        captured: list = []
+
+        async def intercept(*args, **kwargs):
+            captured.append(args)
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=intercept):
+            await call_operator()
+
+        assert captured, "operator never reached create_subprocess_exec"
+        argv = captured[0]
+        assert "--allowedTools" not in argv, (
+            "stateless operator leaked tool access — the tool-free invariant "
+            "is broken"
+        )
+        assert "--mcp-config" not in argv, (
+            "stateless operator injected an MCP server — must stay tool-free"
+        )
+
+    @pytest.mark.asyncio
+    async def test_tool_enabled_dispatch_still_parses_json(self) -> None:
+        """Opt-in tool flags must not change the output contract — the
+        return value is still the parsed JSON dict."""
+        from nexus.operators.dispatch import claude_dispatch
+
+        payload = {"result": "ok"}
+        proc = _make_proc(stdout=json.dumps(payload).encode())
+
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
+            result = await claude_dispatch(
+                "prompt", _SIMPLE_SCHEMA,
+                allowed_tools=["Read"],
+                mcp_servers={"nexus": {"command": "nx-mcp", "args": []}},
+            )
+
+        assert result == payload
+
+
 # ── Subprocess invocation contract ────────────────────────────────────────
 
 class TestSubprocessContract:


### PR DESCRIPTION
## Problem

`nx_tidy`, `nx_enrich_beads`, and `nx_plan_audit` (the RDR-080 agent-replacement MCP tools) reuse the **stateless** `claude_dispatch`, but their prompts instruct the child `claude -p` to call nx MCP tools. Claude Code tightened MCP-server auto-approval (~2.1.162): the child now sees the conexus MCP server as **unapproved**, so every tool call is denied and the tool aborts mid-operation. The stateless dispatch passes no `--allowedTools` and no `--mcp-config` — it was designed for operators that take all input from the prompt and call zero tools.

## Fix

**Fix A — `nx_tidy` pre-fetch (durable).** The MCP process already holds direct T3 access, so retrieval runs in-process (`_tidy_prefetch` → `search` structured + `store_get_many`), the hydrated entries are inlined into the prompt, and the child `claude -p` consolidates **LLM-only with no tools**. Immune to CC permission posture forever. Now read-only (`destructiveHint` dropped — the old prompt claimed `store_put` access the child never actually had). Retrieval is one semantic-search pass capped at 30 chunks; the cap is **surfaced in the summary** (no silent truncation) and logged.

**Fix B — opt-in tool access for enrich/audit.** These do open-ended codebase exploration that can't be pre-fetched. `claude_dispatch` gains keyword-only `allowed_tools` + `mcp_servers` (both default `None` = unchanged stateless tool-free behavior). The two tools pass an inline `--mcp-config` for the conexus servers (explicitly-supplied servers clear the post-2.1.162 pending-approval gate) plus `--allowedTools`. The stateless-operator-stays-tool-free invariant is preserved and now guarded by a concrete-operator argv-inspection test.

**Fix C — dropped.** The original mitigation (preflight auto-allowlisting nexus read tools in user `settings.json`) is subsumed by Fix B: the enrich/audit children now bring their own explicitly-trusted MCP server, so none of the three tools depend on the user's allowlist anymore.

## Review

Stacked review run (code-review-expert + substantive-critic). Folded in: concrete-operator tool-free test (critic's Critical), silent-cap surfacing, `destructiveHint=False` + docstring correction, `nexus_catalog` grant assertions, discarded-`error`-key logging.

## Tests

195 affected tests green (`test_operator_dispatch`, `test_nx_answer`, `test_operator_pipelines_dispatch`, `test_nx_preflight_hook`, `test_mcp_package`).

Closes #nexus-mawqw
