### PR TITLE
release: conexus 5.10.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v5.10.5"
+        "ref": "v5.10.6"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "5.10.5"
+      "version": "5.10.6"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v5.10.5"
+        "ref": "v5.10.6"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "5.10.5"
+      "version": "5.10.6"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.10.6] - 2026-06-07
+
+Hotfix: the RDR-080 agent-replacement MCP tools regressed when Claude Code
+tightened MCP-server auto-approval.
+
+### Fixed
+
+- **Agent-replacement MCP tools no longer fail when the `claude -p`
+  subprocess lacks MCP approval (nexus-mawqw).** `nx_tidy`,
+  `nx_enrich_beads`, and `nx_plan_audit` reused the stateless operator
+  dispatch but their prompts instructed the child `claude -p` to call nx
+  MCP tools. Claude Code tightened MCP-server auto-approval (~2.1.162), so
+  the child saw the conexus server as unapproved and every tool call was
+  denied mid-operation. Two-part fix: (1) `nx_tidy` now pre-fetches the
+  entries to consolidate **server-side** (the MCP process holds direct T3
+  access), inlines them into the prompt, and dispatches a **tool-free**
+  `claude -p` — immune to CC permission posture, and now read-only with a
+  surfaced retrieval cap (no silent truncation); (2) `nx_enrich_beads` and
+  `nx_plan_audit`, which do open-ended codebase exploration that cannot be
+  pre-fetched, get an opt-in inline `--mcp-config` (explicitly-supplied
+  servers clear the pending-approval gate) plus `--allowedTools`. Stateless
+  operators (extract/filter/rank/etc.) stay tool-free, now guarded by a
+  concrete-operator argv-inspection test.
+
 ## [5.10.5] - 2026-06-06
 
 RDR-151 daemon CPU-peg hardening: a cause-agnostic spin backstop plus the

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "5.10.5",
+  "version": "5.10.6",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.10.6] - 2026-06-07
+
+Plugin version aligned with conexus 5.10.6 (hotfix: RDR-080
+agent-replacement MCP tools work again under Claude Code's tightened
+MCP-server approval). No plugin-side changes.
+
 ## [5.10.5] - 2026-06-06
 
 Plugin version aligned with conexus 5.10.5 (RDR-151 daemon CPU-peg hardening:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "5.10.5",
+  "version": "5.10.6",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conexus-mcpb"
-version = "5.10.5"
+version = "5.10.6"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
@@ -10,7 +10,7 @@ dependencies = [
     # while collections are indexed at 768/1024-dim, so every T3 search hits a
     # dimension mismatch and returns zero results. The .mcpb cannot run the
     # interactive `nx init` embedder choice, so it must pin [local] explicitly.
-    "conexus[local]>=5.10.5",
+    "conexus[local]>=5.10.6",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "5.10.5"
+version = "5.10.6"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "5.10.5",
+  "version": "5.10.6",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "5.10.5"
+version = "5.10.6"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Hotfix release: the RDR-080 agent-replacement MCP tools (`nx_tidy`, `nx_enrich_beads`, `nx_plan_audit`) regressed under Claude Code's tightened MCP-server auto-approval (~2.1.162). Fixed in #1140 (nexus-mawqw).

Cut from **main** (not a develop promotion) — develop's in-flight RDR-152 catalog→Postgres migration is intentionally not included.

### Bumped
All 7 parity targets + both changelogs + uv.lock to 5.10.6. Sandbox smoke passed (`[done]`, schema confirmed at v5.10.6).

See CHANGELOG.md for the full entry.