### PR TITLE
test(service): Testcontainers pgvector substrate (RDR-155 P1.0)

### DIFF
--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -22,11 +22,10 @@ jobs:
   java-test-and-drift-guard:
     name: Java tests + jOOQ codegen drift guard
     runs-on: ubuntu-latest
-    # Embedded Postgres (io.zonky) downloads a PG binary on first run;
-    # subsequent runs use the Maven local-repo cache.  25m is generous:
-    # the test suite itself runs in ~8s locally; the first runner run
-    # (cold Maven cache + PG binary download) takes ~3-5m.
-    timeout-minutes: 25
+    # Testcontainers pulls pgvector/pgvector:pg17 on first run (~180 MB);
+    # subsequent runs use the Docker layer cache.  30m covers a cold
+    # runner: Maven cache miss + Docker image pull + suite (~8s locally).
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -38,15 +37,6 @@ jobs:
           distribution: 'graalvm'
           # Cache Maven local repo across runs; bust when pom.xml changes.
           cache: 'maven'
-
-      - name: Cache embedded-postgres binaries
-        # io.zonky EmbeddedPostgres downloads a platform-specific PG binary
-        # (~60 MB) on first use and caches it under /tmp/embedded-pg/.
-        # Caching here avoids re-downloading it on every CI run.
-        uses: actions/cache@v4
-        with:
-          path: /tmp/embedded-pg
-          key: embedded-pg-${{ runner.os }}-${{ runner.arch }}-v1
 
       - name: Cache ChromaDB ONNX model
         # EmbedParityTest constructs OnnxEmbedder, which loads the
@@ -85,8 +75,8 @@ jobs:
       # Drift guard: regenerate jOOQ sources from the changelog and
       # fail if the committed sources in src/main/generated/jooq/ differ.
       # This catches schema changes that were not followed by a regen+commit.
-      # Mechanism: -Pcodegen runs JooqCodegenBootstrap (boots embedded PG,
-      # applies Liquibase, generates to the committed output dir), then
+      # Mechanism: -Pcodegen runs JooqCodegenBootstrap (spins up a pgvector
+      # container, applies Liquibase, generates to the committed output dir), then
       # `git diff --exit-code` fails CI on any unstaged diff.
       - name: jOOQ codegen drift guard
         working-directory: service

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -21,7 +21,7 @@
         <jackson.version>2.18.3</jackson.version>
         <junit.version>5.11.4</junit.version>
         <assertj.version>3.27.3</assertj.version>
-        <zonky.version>2.1.0</zonky.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
         <liquibase.version>4.29.2</liquibase.version>
 
         <mainClass>dev.nexus.service.Main</mainClass>
@@ -33,7 +33,7 @@
             jOOQ generated sources:
             - Default build: src/main/generated/jooq (committed to git, always available)
             - -Pcodegen: regenerates into the same directory via JooqCodegenBootstrap
-              (boots io.zonky EmbeddedPostgres, applies Liquibase, runs GenerationTool)
+              (spins up pgvector/pgvector:pg17 container, applies Liquibase, runs GenerationTool)
 
             WHY COMMITTED SOURCES (OPTION 3 RATIONALE):
             Option 1 (LiquibaseDatabase/H2): REJECTED. The changelog uses Postgres-only DDL
@@ -48,7 +48,7 @@
                  Downloading a newer version requires network access not guaranteed in all CI
                  environments. Not viable without an explicit Groovy-Java25 compatible version.
               b) exec-maven-plugin + manual javac + hardcoded classpath: REJECTED. Requires
-                 enumerating ALL transitive dependencies of io.zonky:embedded-postgres by hand.
+                 enumerating ALL transitive dependencies of the embedded-postgres library by hand.
                  This is brittle (version drift breaks the codegen classpath silently) and
                  couples the pom to the local Maven repo structure.
 
@@ -57,7 +57,7 @@
             changes are infrequent (bead-gated), and committing them provides:
               - IDE support without running codegen first
               - Fast incremental builds (no PG startup on every mvn compile)
-              - Full CI reproducibility (no external process needed for standard builds)
+              - Full CI reproducibility (only the test suite needs Docker; standard builds do not)
               - A clear "schema changed => regenerate => commit" workflow enforced by -Pcodegen
             This pattern is used by jHipster, Spring, and many production Maven projects with jOOQ.
         -->
@@ -152,18 +152,23 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Test: embedded-postgres (real PG in-process, no Docker) -->
+        <!-- Test: Testcontainers pgvector/pgvector:pg17 (replaces io.zonky embedded-postgres) -->
         <dependency>
-            <groupId>io.zonky.test</groupId>
-            <artifactId>embedded-postgres</artifactId>
-            <version>${zonky.version}</version>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- darwin-arm64v8 binary bundle -->
         <dependency>
-            <groupId>io.zonky.test.postgres</groupId>
-            <artifactId>embedded-postgres-binaries-darwin-arm64v8</artifactId>
-            <version>16.4.0</version>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -324,13 +329,13 @@
               5. Normal builds pick up the committed sources automatically
 
             Implementation: JooqCodegenBootstrap (in src/test/java) is compiled at
-            test-compile phase (picks up test scope deps: embedded-postgres, jooq-codegen,
+            test-compile phase (picks up test scope deps: testcontainers, jooq-codegen,
             jooq-meta).  exec:java runs it in process-test-classes phase using the test
             classpath, which includes the compiled bootstrap class.  The bootstrap:
-              - Boots io.zonky EmbeddedPostgres (no Docker needed)
+              - Boots a Testcontainers pgvector/pgvector:pg17 container (requires Docker)
               - Applies the Liquibase changelog via programmatic API
               - Runs org.jooq.codegen.GenerationTool (PostgresDatabase)
-              - Stops embedded PG
+              - Stops the container
 
             The output goes to src/main/generated/jooq (NOT target/) so it is committed
             and available without running -Pcodegen.
@@ -351,7 +356,7 @@
                                     <goal>java</goal>
                                 </goals>
                                 <configuration>
-                                    <!-- Use test classpath: includes embedded-postgres, jooq-codegen,
+                                    <!-- Use test classpath: includes testcontainers, jooq-codegen,
                                          jooq-meta, liquibase-core, and the compiled bootstrap class -->
                                     <classpathScope>test</classpathScope>
                                     <mainClass>dev.nexus.service.codegen.JooqCodegenBootstrap</mainClass>
@@ -359,6 +364,16 @@
                                         <argument>${jooq.generated.dir}</argument>
                                         <argument>${project.basedir}/src/main/resources</argument>
                                     </arguments>
+                                    <!-- Disable Ryuk so the background reaper thread does not
+                                         survive main() exit and trigger exec-maven-plugin's
+                                         uncaught-exception handler with InterruptedException.
+                                         The env-var form is used because exec:java inherits
+                                         the Maven JVM's system properties, but Testcontainers
+                                         reads TESTCONTAINERS_RYUK_DISABLED at class-load time
+                                         from the environment, not from System.getProperty. -->
+                                    <environmentVariables>
+                                        <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
+                                    </environmentVariables>
                                 </configuration>
                             </execution>
                         </executions>

--- a/service/src/test/java/dev/nexus/service/AspectOperatorQueryTest.java
+++ b/service/src/test/java/dev/nexus/service/AspectOperatorQueryTest.java
@@ -2,7 +2,7 @@ package dev.nexus.service;
 
 import dev.nexus.service.db.AspectRepository;
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -41,16 +41,16 @@ class AspectOperatorQueryTest {
     private static final String SVC_ROLE = "svc_op_query_test";
     private static final String SVC_PASS = "svc_op_query_test_pass";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
     AspectRepository repo;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -66,7 +66,7 @@ class AspectOperatorQueryTest {
                 "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             Liquibase liquibase = new Liquibase(
@@ -75,7 +75,7 @@ class AspectOperatorQueryTest {
             liquibase.update(new Contexts());
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             for (String table : List.of("document_aspects", "document_highlights",
@@ -100,7 +100,7 @@ class AspectOperatorQueryTest {
         }
 
         com.zaxxer.hikari.HikariConfig svcCfg = new com.zaxxer.hikari.HikariConfig();
-        svcCfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        svcCfg.setJdbcUrl(pg.getJdbcUrl());
         svcCfg.setUsername(SVC_ROLE);
         svcCfg.setPassword(SVC_PASS);
         svcCfg.setMaximumPoolSize(4);
@@ -113,7 +113,7 @@ class AspectOperatorQueryTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg != null)    pg.close();
+        if (pg != null)    pg.stop();
     }
 
     /** Seed a minimal aspect row for operator-query tests. */

--- a/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
@@ -2,7 +2,7 @@ package dev.nexus.service;
 
 import dev.nexus.service.db.AspectRepository;
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -68,16 +68,16 @@ class AspectRepositoryTest {
     private static final String SVC_ROLE = "svc_aspect_test";
     private static final String SVC_PASS = "svc_aspect_test_pass";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
     AspectRepository repo;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -93,7 +93,7 @@ class AspectRepositoryTest {
                 "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             Liquibase liquibase = new Liquibase(
@@ -102,7 +102,7 @@ class AspectRepositoryTest {
             liquibase.update(new Contexts());
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             // Grant on all 4 aspect tables
@@ -145,7 +145,7 @@ class AspectRepositoryTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg != null)    pg.close();
+        if (pg != null)    pg.stop();
     }
 
     // ── Helper ─────────────────────────────────────────────────────────────────
@@ -860,7 +860,7 @@ class AspectRepositoryTest {
 
     private com.zaxxer.hikari.HikariDataSource buildSvcDataSource() {
         var cfg = new com.zaxxer.hikari.HikariConfig();
-        cfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        cfg.setJdbcUrl(pg.getJdbcUrl());
         cfg.setUsername(SVC_ROLE);
         cfg.setPassword(SVC_PASS);
         cfg.setMaximumPoolSize(10);   // higher for concurrency test

--- a/service/src/test/java/dev/nexus/service/AuthFilterTest.java
+++ b/service/src/test/java/dev/nexus/service/AuthFilterTest.java
@@ -10,7 +10,7 @@ import dev.nexus.service.db.TokenHashing;
 import dev.nexus.service.db.TokenStore;
 import dev.nexus.service.http.AuthFilter;
 import dev.nexus.service.http.RequestContext;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * RDR-152 bead nexus-gmiaf.32.2 — AuthFilter integration tests.
  *
- * <p>Hermetic: embedded Postgres (io.zonky), port 0, no Docker. A fixed/mutable
+ * <p>Hermetic: embedded Postgres (Testcontainers pgvector), port 0, requires Docker. A fixed/mutable
  * {@link Clock} drives all expiry/TTL assertions deterministically. Two layers:
  * HTTP-level (the filter end to end against a real {@link HttpServer}) and
  * cache-level (the TTL/invalidate/expiry seam against {@link TokenCache}).
@@ -71,7 +71,7 @@ class AuthFilterTest {
     private static final String SESS_EXPIRED = "raw-session-expired";
     private static final String TOK_WILDCARD = "raw-token-bootstrap-wildcard";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     HikariDataSource ds;
     MutableClock clock;
     TokenStore store;
@@ -82,9 +82,9 @@ class AuthFilterTest {
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
         // grants-nexus-svc.xml fail-fasts if the role is absent; create it first.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN "
@@ -93,7 +93,7 @@ class AuthFilterTest {
                 + "  END IF; "
                 + "END $$");
         }
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             new Liquibase("db/changelog/db.changelog-master.xml",
@@ -101,8 +101,9 @@ class AuthFilterTest {
         }
 
         var cfg = new HikariConfig();
-        cfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
-        cfg.setUsername("postgres");
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(PgContainerHelper.USERNAME);
+        cfg.setPassword(PgContainerHelper.PASSWORD);
         cfg.setMaximumPoolSize(5);
         cfg.setAutoCommit(true);
         cfg.setConnectionInitSql("SET search_path TO nexus, t1, public");
@@ -125,7 +126,7 @@ class AuthFilterTest {
     void stopAll() {
         if (server != null) server.stop(0);
         if (ds != null) ds.close();
-        if (pg != null) { try { pg.close(); } catch (IOException ignored) { } }
+        if (pg != null) pg.stop();
     }
 
     @BeforeEach
@@ -134,7 +135,7 @@ class AuthFilterTest {
     }
 
     private void seedTokens() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertServiceToken(su, TOK_A, "tenant-a", null, null);
             insertServiceToken(su, TOK_B, "tenant-b", null, null);
@@ -278,12 +279,12 @@ class AuthFilterTest {
         var c = new TokenCache(store, clock);
         String raw = "raw-token-invalidate";
         String h = TokenHashing.sha256Hex(raw);
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             insertServiceToken(su, raw, "tenant-a", null, null);
         }
         assertThat(c.resolveTenant(h)).contains("tenant-a");  // now cached
         // Revoke in DB, then invalidate the cache entry — must be empty immediately.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.createStatement().execute(
                 "UPDATE nexus.service_tokens SET revoked_at = now() WHERE token_hash = '" + h + "'");
         }
@@ -298,11 +299,11 @@ class AuthFilterTest {
         var c = new TokenCache(store, clock, Duration.ofSeconds(30), 10_000);
         String raw = "raw-token-ttl";
         String h = TokenHashing.sha256Hex(raw);
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             insertServiceToken(su, raw, "tenant-a", null, null);
         }
         assertThat(c.resolveTenant(h)).contains("tenant-a");  // cached at T0
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.createStatement().execute(
                 "UPDATE nexus.service_tokens SET revoked_at = now() WHERE token_hash = '" + h + "'");
         }
@@ -320,7 +321,7 @@ class AuthFilterTest {
         var c = new TokenCache(store, clock, Duration.ofSeconds(300), 10_000);
         String raw = "raw-token-expiring";
         String h = TokenHashing.sha256Hex(raw);
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             insertServiceToken(su, raw, "tenant-a",
                 OffsetDateTime.ofInstant(T0.plusSeconds(100), ZoneOffset.UTC), null);
         }
@@ -355,7 +356,7 @@ class AuthFilterTest {
 
         // Idempotent: a second call does not error or duplicate.
         store.ensureBootstrapToken(raw, defaultTenant);
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT COUNT(*) AS c FROM nexus.service_tokens WHERE token_hash = '" + h + "'");
             assertThat(rs.next()).isTrue();

--- a/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
@@ -2,7 +2,7 @@ package dev.nexus.service;
 
 import dev.nexus.service.db.CatalogRepository;
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.DatabaseFactory;
@@ -51,17 +51,17 @@ class CatalogRepositoryTest {
     private static final String SVC_ROLE  = "svc_catalog_test";
     private static final String SVC_PASS  = "svc_catalog_test_pass";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
     CatalogRepository repo;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
         // Phase 1: role creation (autoCommit=true; CREATE ROLE cannot run in txn).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -78,7 +78,7 @@ class CatalogRepositoryTest {
         }
 
         // Phase 2: apply Liquibase master changelog (separate connection, committed before grants).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             var lb = new Liquibase(
                 "db/changelog/db.changelog-master.xml",
                 new ClassLoaderResourceAccessor(),
@@ -88,7 +88,7 @@ class CatalogRepositoryTest {
         }
 
         // Phase 3: grant svc role access to all catalog tables (separate connection, all Liquibase DDL visible).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             for (String tbl : new String[]{
@@ -106,7 +106,7 @@ class CatalogRepositoryTest {
 
         // HikariCP as svc role (bare JDBC URL + setUsername, NOT superuser, to enforce RLS).
         var config = new com.zaxxer.hikari.HikariConfig();
-        config.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        config.setJdbcUrl(pg.getJdbcUrl());
         config.setUsername(SVC_ROLE);
         config.setPassword(SVC_PASS);
         config.setMaximumPoolSize(4);
@@ -120,7 +120,7 @@ class CatalogRepositoryTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg != null) pg.close();
+        if (pg != null) pg.stop();
     }
 
     // ══════════════════════════════════════════════════════════════════════════

--- a/service/src/test/java/dev/nexus/service/CatalogSchemaLiquibaseTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogSchemaLiquibaseTest.java
@@ -1,6 +1,6 @@
 package dev.nexus.service;
 
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.DatabaseFactory;
@@ -23,8 +23,8 @@ class CatalogSchemaLiquibaseTest {
 
     @Test
     void catalogSchemaAppliesCleanly() throws Exception {
-        try (var pg = EmbeddedPostgres.builder().start();
-             Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (var pg = PgContainerHelper.start();
+             Connection su = pg.createConnection("")) {
 
             // The consolidated grants-nexus-svc.xml changeset (runAlways=true, nexus-net63)
             // requires nexus_svc to exist — it fails loud when the role is missing.
@@ -47,8 +47,8 @@ class CatalogSchemaLiquibaseTest {
         }
 
         // Re-open a fresh connection after changelog committed to verify schema
-        try (var pg = EmbeddedPostgres.builder().start();
-             Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (var pg = PgContainerHelper.start();
+             Connection su = pg.createConnection("")) {
 
             // Create nexus_svc for the grants changeset (runAlways=true).
             su.setAutoCommit(true);

--- a/service/src/test/java/dev/nexus/service/ChashRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/ChashRepositoryTest.java
@@ -2,7 +2,7 @@ package dev.nexus.service;
 
 import dev.nexus.service.db.ChashRepository;
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.DatabaseFactory;
@@ -50,19 +50,19 @@ class ChashRepositoryTest {
     private static final String SVC_ROLE = "svc_chash_test";
     private static final String SVC_PASS = "svc_chash_test_pass";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
     ChashRepository repo;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
         // Phase 1: create roles (separate connection, autoCommit=true).
         // CREATE ROLE cannot run inside a transaction; autoCommit=true ensures each
         // statement is committed immediately (mirrors PlanRepositoryTest bootstrap).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -80,7 +80,7 @@ class ChashRepositoryTest {
 
         // Phase 2: apply Liquibase master changelog (separate connection so Liquibase
         // commits all changesets before the svc-role grants below).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             var lb = new Liquibase(
                 "db/changelog/db.changelog-master.xml",
                 new ClassLoaderResourceAccessor(),
@@ -91,7 +91,7 @@ class ChashRepositoryTest {
 
         // Phase 3: grant svc role access to chash_index (separate connection so all
         // Liquibase DDL is already committed and visible).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             su.createStatement().execute("GRANT SELECT, INSERT, UPDATE, DELETE ON nexus.chash_index TO " + SVC_ROLE);
@@ -102,7 +102,7 @@ class ChashRepositoryTest {
         // pattern: bare JDBC URL with explicit setUsername so the pool connects as svc_chash_test,
         // NOT as the postgres superuser (which would bypass RLS via BYPASSRLS privilege).
         var config = new com.zaxxer.hikari.HikariConfig();
-        config.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        config.setJdbcUrl(pg.getJdbcUrl());
         config.setUsername(SVC_ROLE);
         config.setPassword(SVC_PASS);
         config.setMaximumPoolSize(3);
@@ -116,7 +116,7 @@ class ChashRepositoryTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg != null) pg.close();
+        if (pg != null) pg.stop();
     }
 
     // ── Test 1: upsert inserts a new row ─────────────────────────────────────

--- a/service/src/test/java/dev/nexus/service/ForeignKeyConstraintTest.java
+++ b/service/src/test/java/dev/nexus/service/ForeignKeyConstraintTest.java
@@ -1,6 +1,6 @@
 package dev.nexus.service;
 
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.DatabaseFactory;
@@ -63,15 +63,15 @@ class ForeignKeyConstraintTest {
     private static final String TUMBLER_A = "1.1";
     private static final String TUMBLER_B = "2.1";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
         // Phase 1: create roles (autoCommit=true; CREATE ROLE cannot run in txn)
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -88,7 +88,7 @@ class ForeignKeyConstraintTest {
         }
 
         // Phase 2: apply full master changelog (includes fk-001-catalog-cross-store)
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             var lb = new Liquibase(
                 "db/changelog/db.changelog-master.xml",
                 new ClassLoaderResourceAccessor(),
@@ -98,7 +98,7 @@ class ForeignKeyConstraintTest {
         }
 
         // Phase 3: grant svc role access to all relevant tables
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             for (String tbl : List.of(
@@ -126,7 +126,7 @@ class ForeignKeyConstraintTest {
 
         // HikariCP as svc role (non-superuser, subject to RLS)
         var config = new com.zaxxer.hikari.HikariConfig();
-        config.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        config.setJdbcUrl(pg.getJdbcUrl());
         config.setUsername(SVC_ROLE);
         config.setPassword(SVC_PASS);
         config.setMaximumPoolSize(4);
@@ -137,7 +137,7 @@ class ForeignKeyConstraintTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg != null)    pg.close();
+        if (pg != null)    pg.stop();
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -146,7 +146,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(1)
     void fkChangeset_appliesCleanly_allFkConstraintsPresent() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             // Verify the 4 cross-store FK constraints exist in pg_constraint.
             // topic_assignments is intentionally EXCLUDED (nexus-sa14p): its doc_id is a
             // chunk chash, not a document tumbler, so no fk_ta_catalog_doc is registered.
@@ -175,7 +175,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(2)
     void docAspectsDocId_isNullable() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT is_nullable FROM information_schema.columns " +
                 "WHERE table_schema='nexus' AND table_name='document_aspects' AND column_name='doc_id'");
@@ -186,7 +186,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(3)
     void aspectQueueDocId_isNullable() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT is_nullable FROM information_schema.columns " +
                 "WHERE table_schema='nexus' AND table_name='aspect_extraction_queue' AND column_name='doc_id'");
@@ -203,7 +203,7 @@ class ForeignKeyConstraintTest {
     void topicAssignment_chashDocId_succeeds_noCatalogFk() throws Exception {
         // nexus-sa14p: doc_id is a chunk chash, not a catalog tumbler, and there is no
         // fk_ta_catalog_doc. A chash doc_id with no matching catalog_documents row imports.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertTopic(su, TENANT_A, 100L, "test-topic", "col-a");
             String chash = "7740557a279d0481db33c93fd0342464"; // 32-hex chunk chash, not a tumbler
@@ -223,7 +223,7 @@ class ForeignKeyConstraintTest {
     void topicAssignment_topicIdFk_stillEnforced() throws Exception {
         // The topic_id -> topics(id) FK IS correct and remains enforced (only the
         // catalog doc_id FK was removed). An assignment to a non-existent topic rejects.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             Exception ex = assertThrows(PSQLException.class, () ->
                 su.createStatement().execute(
@@ -239,7 +239,7 @@ class ForeignKeyConstraintTest {
     void deleteCatalogDoc_doesNotAffectTopicAssignments() throws Exception {
         // nexus-sa14p: with no catalog FK, deleting a catalog document does NOT cascade
         // to topic_assignments (assignments are chunk-keyed and independent of the catalog).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "1.99");
             insertTopic(su, TENANT_A, 199L, "no-cascade-topic", "col-a");
@@ -268,7 +268,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(20)
     void aspect_nullDocId_isAccepted() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             // doc_id=NULL is valid for a FK — no catalog reference required
             su.createStatement().execute(
@@ -285,7 +285,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(21)
     void aspect_validDocId_succeeds() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "3.1");
             su.createStatement().execute(
@@ -302,7 +302,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(22)
     void aspect_orphanDocId_rejectsWithFKViolation() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             Exception ex = assertThrows(PSQLException.class, () ->
                 su.createStatement().execute(
@@ -316,7 +316,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(23)
     void deleteCatalogDoc_cascadesToAspects() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "3.99");
             su.createStatement().execute(
@@ -342,7 +342,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(30)
     void highlight_validDocId_succeeds() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "4.1");
             su.createStatement().execute(
@@ -359,7 +359,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(31)
     void highlight_orphanDocId_rejectsWithFKViolation() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             Exception ex = assertThrows(PSQLException.class, () ->
                 su.createStatement().execute(
@@ -373,7 +373,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(32)
     void deleteCatalogDoc_cascadesToHighlights() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "4.99");
             su.createStatement().execute(
@@ -399,7 +399,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(40)
     void queue_nullDocId_isAccepted() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "INSERT INTO nexus.aspect_extraction_queue " +
@@ -415,7 +415,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(41)
     void queue_validDocId_succeeds() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "5.1");
             su.createStatement().execute(
@@ -432,7 +432,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(42)
     void queue_orphanDocId_rejectsWithFKViolation() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             Exception ex = assertThrows(PSQLException.class, () ->
                 su.createStatement().execute(
@@ -446,7 +446,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(43)
     void deleteCatalogDoc_cascadesToQueue() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "5.99");
             su.createStatement().execute(
@@ -472,7 +472,7 @@ class ForeignKeyConstraintTest {
     void queue_nullDocId_survivesDocDeletion() throws Exception {
         // A queue item with doc_id=NULL is not bound to any catalog doc;
         // deleting catalog docs must not affect it.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "6.1");
             su.createStatement().execute(
@@ -508,7 +508,7 @@ class ForeignKeyConstraintTest {
      */
     @Test @Order(51)
     void crossTenantAspect_isRejectedByCompositeFk() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             // Tenant-A has a catalog document; Tenant-B tries to reference it
             insertCatalogDocument(su, TENANT_A, TUMBLER_A);
@@ -527,7 +527,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(52)
     void crossTenantHighlight_isRejectedByCompositeFk() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, TUMBLER_A);
 
@@ -545,7 +545,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(53)
     void crossTenantQueueItem_isRejectedByCompositeFk() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, TUMBLER_A);
 
@@ -567,7 +567,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(70)
     void chunkManifest_validDocId_succeeds() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "chunk-doc-1");
             su.createStatement().execute(
@@ -584,7 +584,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(71)
     void chunkManifest_orphanDocId_rejectsWithFKViolation() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             Exception ex = assertThrows(PSQLException.class, () ->
                 su.createStatement().execute(
@@ -600,7 +600,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(72)
     void deleteCatalogDoc_cascadesToChunkManifest() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "chunk-cascade-doc");
             su.createStatement().execute(
@@ -631,7 +631,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(73)
     void crossTenantChunkManifest_isRejectedByCompositeFk() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             // Seed catalog_documents for TENANT_A only
             insertCatalogDocument(su, TENANT_A, TUMBLER_A);
@@ -661,7 +661,7 @@ class ForeignKeyConstraintTest {
     @Test @Order(60)
     void rlsIsolation_tenantA_invisibleToTenantB() throws Exception {
         // Insert a catalog doc for TENANT_A via superuser
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "rls-check-tumbler");
         }
@@ -682,7 +682,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(61)
     void rlsIsolation_topicAssignment_tenantA_invisibleToTenantB() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "rls-ta-tumbler");
             insertTopic(su, TENANT_A, 300L, "rls-topic", "col-rls");
@@ -706,7 +706,7 @@ class ForeignKeyConstraintTest {
 
     @Test @Order(62)
     void rlsIsolation_documentAspects_tenantA_invisibleToTenantB() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "rls-asp-tumbler");
             su.createStatement().execute(

--- a/service/src/test/java/dev/nexus/service/MemoryHandlerTest.java
+++ b/service/src/test/java/dev/nexus/service/MemoryHandlerTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.nexus.service.db.MemoryRepository;
 import dev.nexus.service.db.TenantConstants;
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -58,7 +58,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   <li>Auth: 401 on missing/bad token</li>
  * </ol>
  *
- * <p>Hermetic: embedded Postgres (io.zonky), port 0, no Docker.
+ * <p>Hermetic: embedded Postgres (Testcontainers pgvector), port 0, requires Docker.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MemoryHandlerTest {
@@ -73,7 +73,7 @@ class MemoryHandlerTest {
     private static final TypeReference<Map<String, Object>> MAP_T = new TypeReference<>() {};
     private static final TypeReference<List<Map<String, Object>>> LIST_T = new TypeReference<>() {};
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     NexusService service;
     HttpClient http;
     com.zaxxer.hikari.HikariDataSource svcDs;
@@ -82,9 +82,9 @@ class MemoryHandlerTest {
     @BeforeAll
     void startAll() throws Exception {
         mapper = new ObjectMapper();
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -100,7 +100,7 @@ class MemoryHandlerTest {
                 "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             Liquibase liquibase = new Liquibase(
@@ -109,7 +109,7 @@ class MemoryHandlerTest {
             liquibase.update(new Contexts());
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             su.createStatement().execute(
@@ -135,7 +135,7 @@ class MemoryHandlerTest {
         }
 
         var cfg = new com.zaxxer.hikari.HikariConfig();
-        cfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        cfg.setJdbcUrl(pg.getJdbcUrl());
         cfg.setUsername(SVC_ROLE);
         cfg.setPassword(SVC_PASS);
         cfg.setMaximumPoolSize(5);
@@ -151,7 +151,7 @@ class MemoryHandlerTest {
     void stopAll() throws Exception {
         if (service != null) service.stop();
         if (svcDs != null)   svcDs.close();
-        if (pg != null)      pg.close();
+        if (pg != null)      pg.stop();
     }
 
     // ── Test 1: PUT ───────────────────────────────────────────────────────────

--- a/service/src/test/java/dev/nexus/service/MemoryRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/MemoryRepositoryTest.java
@@ -4,7 +4,7 @@ import dev.nexus.service.db.MemoryRepository;
 import dev.nexus.service.db.TenantConstants;
 import dev.nexus.service.db.TenantScope;
 import dev.nexus.service.jooq.nexus.tables.records.MemoryRecord;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *   <li>cross-tenant upsert: inserting with mismatched tenant_id is blocked by RLS.</li>
  * </ol>
  *
- * <p>Hermetic: embedded Postgres (io.zonky), port 0, no Docker.
+ * <p>Hermetic: embedded Postgres (Testcontainers pgvector), port 0, requires Docker.
  * Schema applied via Liquibase master changelog (same as MemorySchemaLiquibaseTest).
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -52,16 +52,16 @@ class MemoryRepositoryTest {
     private static final String TENANT_A = "tenant-a";
     private static final String TENANT_B = "tenant-b";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
     MemoryRepository repo;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             // Create the service role used by TenantScope connections.
             su.createStatement().execute(
@@ -80,7 +80,7 @@ class MemoryRepositoryTest {
         }
 
         // Apply Liquibase changelog via superuser.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             Liquibase liquibase = new Liquibase(
@@ -91,7 +91,7 @@ class MemoryRepositoryTest {
         }
 
         // Grant the service role the same privileges as nexus_svc.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             su.createStatement().execute(
@@ -103,7 +103,7 @@ class MemoryRepositoryTest {
         }
 
         var cfg = new com.zaxxer.hikari.HikariConfig();
-        cfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        cfg.setJdbcUrl(pg.getJdbcUrl());
         cfg.setUsername(SVC_ROLE);
         cfg.setPassword(SVC_PASS);
         cfg.setMaximumPoolSize(5);
@@ -117,7 +117,7 @@ class MemoryRepositoryTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg != null)    pg.close();
+        if (pg != null)    pg.stop();
     }
 
     // ── Test 1: upsert INSERT — generated id, row visible ───────────────────

--- a/service/src/test/java/dev/nexus/service/MemorySchemaLiquibaseTest.java
+++ b/service/src/test/java/dev/nexus/service/MemorySchemaLiquibaseTest.java
@@ -2,7 +2,7 @@ package dev.nexus.service;
 
 import dev.nexus.service.db.TenantConstants;
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * RDR-152 bead nexus-gmiaf.5 — Liquibase memory baseline integration test.
  *
- * <p>Hermetic: embedded Postgres (io.zonky), port 0, no Docker. Applies the
+ * <p>Hermetic: embedded Postgres (Testcontainers pgvector), port 0, requires Docker. Applies the
  * Liquibase master changelog programmatically (no Maven plugin binding yet —
  * that is bead .6) and asserts all required structural and runtime properties.
  *
@@ -61,16 +61,16 @@ class MemorySchemaLiquibaseTest {
     private static final String SVC_ROLE = "svc_memory_test";
     private static final String SVC_PASS = "svc_memory_test_pass";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
         // Bootstrap service role BEFORE Liquibase runs (so changeset 5 finds it).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -89,7 +89,7 @@ class MemorySchemaLiquibaseTest {
 
         // Apply Liquibase changelog via superuser connection (schema DDL requires superuser
         // or schema owner; service role is granted privileges after table creation).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             Liquibase liquibase = new Liquibase(
@@ -100,7 +100,7 @@ class MemorySchemaLiquibaseTest {
         }
 
         // Grant svc_memory_test the same privileges as nexus_svc (for RLS tests).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             su.createStatement().execute(
@@ -118,14 +118,14 @@ class MemorySchemaLiquibaseTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg != null)    pg.close();
+        if (pg != null)    pg.stop();
     }
 
     // ── Test 1: exact column set ─────────────────────────────────────────────
 
     @Test
     void memoryTable_hasExactColumnSet() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.getMetaData().getColumns(null, "nexus", "memory", null);
             Set<String> actual = new java.util.HashSet<>();
             while (rs.next()) {
@@ -141,7 +141,7 @@ class MemorySchemaLiquibaseTest {
 
     @Test
     void memoryTable_rlsEnabledAndForced() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             // pg_class flags
             ResultSet cls = su.createStatement().executeQuery(
                 "SELECT relrowsecurity, relforcerowsecurity " +
@@ -190,7 +190,7 @@ class MemorySchemaLiquibaseTest {
 
     @Test
     void memoryTable_ftsColumnAndIndexExist_tokenisationCorrect() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             // fts_vector column exists and is a generated stored column
             ResultSet gen = su.createStatement().executeQuery(
                 "SELECT a.attname, a.attgenerated, " +
@@ -265,7 +265,7 @@ class MemorySchemaLiquibaseTest {
         //       which does NOT match 'running' in the simple-indexed tags column.
         //       If tags were accidentally indexed under english instead of simple,
         //       'running' would be stored as 'run' and the query WOULD match.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(false);
             try (var ps = su.prepareStatement("SELECT set_config(?, ?, true)")) {
                 ps.setString(1, TenantConstants.GUC_NAME);
@@ -323,7 +323,7 @@ class MemorySchemaLiquibaseTest {
     @Test
     void tenantIsolation_and_ftsQuery_viaWithTenant() throws Exception {
         // Seed rows for two tenants via superuser (bypasses RLS for seeding).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(false);
             insertRow(su, "alpha", "alpha-proj", "Machine learning basics",
                 "neural networks deep learning", "ml,ai,research");
@@ -424,7 +424,7 @@ class MemorySchemaLiquibaseTest {
     @Test
     void rls_failClosed_noGucStamp_returnsZeroRows() throws Exception {
         // Seed at least one row as superuser so the table is non-empty.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(false);
             insertRow(su, "failclosed-tenant", "fc-proj", "Sentinel row",
                 "content for fail-closed probe", "probe");
@@ -484,7 +484,7 @@ class MemorySchemaLiquibaseTest {
     @Test
     void rls_withCheck_blocksCrossTenantTenantIdRewrite() throws Exception {
         // Seed a row for 'alpha-rw' via superuser.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(false);
             insertRow(su, "alpha-rw", "rw-proj", "Row to rewrite",
                 "content", "tag");
@@ -510,7 +510,7 @@ class MemorySchemaLiquibaseTest {
 
     private com.zaxxer.hikari.HikariDataSource buildSvcDataSource() {
         var config = new com.zaxxer.hikari.HikariConfig();
-        config.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        config.setJdbcUrl(pg.getJdbcUrl());
         config.setUsername(SVC_ROLE);
         config.setPassword(SVC_PASS);
         config.setMaximumPoolSize(5);

--- a/service/src/test/java/dev/nexus/service/PgContainerHelper.java
+++ b/service/src/test/java/dev/nexus/service/PgContainerHelper.java
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+
+/**
+ * Shared factory for per-class Testcontainers PostgreSQL containers.
+ *
+ * <p>RDR-155 P1.0 (nexus-22man): replaces io.zonky EmbeddedPostgres throughout the
+ * service test suite.  Each test class creates its own container via {@link #start()}
+ * (PER_CLASS lifecycle mirrors the previous EmbeddedPostgres.builder().start() pattern).
+ *
+ * <p>The image is {@code pgvector/pgvector:pg17} declared compatible with {@code postgres},
+ * which allows PostgreSQLContainer to perform its normal wait-strategy and connection
+ * checks.  The container runs stock PostgreSQL 17 with the pgvector extension available
+ * but not yet loaded — {@code CREATE EXTENSION vector} lands in a later bead (nexus-mf447).
+ */
+public final class PgContainerHelper {
+
+    /** Image used for all service-module test containers. */
+    public static final String IMAGE = "pgvector/pgvector:pg17";
+
+    /** Superuser database name (matches io.zonky default). */
+    public static final String DATABASE = "postgres";
+
+    /** Superuser username (matches io.zonky default). */
+    public static final String USERNAME = "postgres";
+
+    /** Superuser password. */
+    public static final String PASSWORD = "postgres";
+
+    private PgContainerHelper() {}
+
+    /**
+     * Create and start a fresh container.
+     *
+     * <p>Replaces {@code EmbeddedPostgres.builder().start()}.
+     */
+    @SuppressWarnings("resource")
+    public static PostgreSQLContainer<?> start() {
+        PostgreSQLContainer<?> c = new PostgreSQLContainer<>(
+            DockerImageName.parse(IMAGE).asCompatibleSubstituteFor("postgres"))
+            .withDatabaseName(DATABASE)
+            .withUsername(USERNAME)
+            .withPassword(PASSWORD);
+        c.start();
+        return c;
+    }
+
+    /**
+     * Return a pooled superuser DataSource.
+     *
+     * <p>Replaces {@code pg.getPostgresDatabase()} when used as a {@code DataSource} argument.
+     * Returns {@link HikariDataSource} (not the {@code DataSource} interface) so the caller
+     * MUST close it — unlike {@code EmbeddedPostgres.getPostgresDatabase()}, this pool is not
+     * owned by the container lifecycle (review nexus-22man: close it in teardown / TWR).
+     */
+    public static HikariDataSource superuserDataSource(PostgreSQLContainer<?> c) {
+        var cfg = new HikariConfig();
+        cfg.setJdbcUrl(c.getJdbcUrl());
+        cfg.setUsername(c.getUsername());
+        cfg.setPassword(c.getPassword());
+        cfg.setMaximumPoolSize(5);
+        cfg.setAutoCommit(true);
+        return new HikariDataSource(cfg);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/PlanRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/PlanRepositoryTest.java
@@ -3,7 +3,7 @@ package dev.nexus.service;
 import dev.nexus.service.db.PlanRepository;
 import dev.nexus.service.db.TenantConstants;
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -55,16 +55,16 @@ class PlanRepositoryTest {
     private static final String SVC_ROLE = "svc_plan_test";
     private static final String SVC_PASS = "svc_plan_test_pass";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
     PlanRepository repo;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -80,7 +80,7 @@ class PlanRepositoryTest {
                 "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             Liquibase liquibase = new Liquibase(
@@ -89,7 +89,7 @@ class PlanRepositoryTest {
             liquibase.update(new Contexts());
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             su.createStatement().execute(
@@ -108,7 +108,7 @@ class PlanRepositoryTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg != null)    pg.close();
+        if (pg != null)    pg.stop();
     }
 
     @Test
@@ -519,7 +519,7 @@ class PlanRepositoryTest {
 
     private com.zaxxer.hikari.HikariDataSource buildSvcDataSource() {
         var cfg = new com.zaxxer.hikari.HikariConfig();
-        cfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        cfg.setJdbcUrl(pg.getJdbcUrl());
         cfg.setUsername(SVC_ROLE);
         cfg.setPassword(SVC_PASS);
         cfg.setMaximumPoolSize(5);

--- a/service/src/test/java/dev/nexus/service/PlansSchemaLiquibaseTest.java
+++ b/service/src/test/java/dev/nexus/service/PlansSchemaLiquibaseTest.java
@@ -2,7 +2,7 @@ package dev.nexus.service;
 
 import dev.nexus.service.db.TenantConstants;
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * RDR-152 bead nexus-gmiaf.11 — Liquibase plans baseline integration test.
  *
- * <p>Hermetic: embedded Postgres (io.zonky), port 0, no Docker. Applies the
+ * <p>Hermetic: embedded Postgres (Testcontainers pgvector), port 0, requires Docker. Applies the
  * Liquibase master changelog programmatically and asserts all required structural
  * and runtime properties for the nexus.plans table (Store 2).
  *
@@ -64,16 +64,16 @@ class PlansSchemaLiquibaseTest {
     private static final String SVC_ROLE = "svc_plans_schema_test";
     private static final String SVC_PASS = "svc_plans_schema_test_pass";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
         // Bootstrap service role BEFORE Liquibase runs (so changeset grants find it).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -89,7 +89,7 @@ class PlansSchemaLiquibaseTest {
                 "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             Liquibase liquibase = new Liquibase(
@@ -100,7 +100,7 @@ class PlansSchemaLiquibaseTest {
         }
 
         // Grant svc role the same privileges as nexus_svc.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             su.createStatement().execute(
@@ -122,14 +122,14 @@ class PlansSchemaLiquibaseTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg != null)    pg.close();
+        if (pg != null)    pg.stop();
     }
 
     // ── Test 1: exact column set ─────────────────────────────────────────────
 
     @Test
     void plansTable_hasExactColumnSet() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.getMetaData().getColumns(null, "nexus", "plans", null);
             Set<String> actual = new java.util.HashSet<>();
             while (rs.next()) {
@@ -145,7 +145,7 @@ class PlansSchemaLiquibaseTest {
 
     @Test
     void plansTable_rlsEnabledAndForced() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet cls = su.createStatement().executeQuery(
                 "SELECT relrowsecurity, relforcerowsecurity " +
                 "FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid " +
@@ -188,7 +188,7 @@ class PlansSchemaLiquibaseTest {
 
     @Test
     void plansTable_ftsColumnAndIndexExist_tokenisationCorrect() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             // fts_vector column: exists and is a STORED generated tsvector
             ResultSet gen = su.createStatement().executeQuery(
                 "SELECT a.attname, a.attgenerated, " +
@@ -253,7 +253,7 @@ class PlansSchemaLiquibaseTest {
         //   plainto_tsquery('simple','plan') → literal 'plan' must NOT match 'planning'
         //   in simple-indexed tags (negative discrimination probe — proves tags use simple
         //   not english; if tags were english-indexed, 'planning'→'plan' and query would match).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(false);
             try (var ps = su.prepareStatement("SELECT set_config(?, ?, true)")) {
                 ps.setString(1, TenantConstants.GUC_NAME);
@@ -312,7 +312,7 @@ class PlansSchemaLiquibaseTest {
     @Test
     void tenantIsolation_and_ftsQuery_viaWithTenant() throws Exception {
         // Seed rows for two tenants via superuser (bypasses RLS for seeding).
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(false);
             insertPlan(su, "plan-alpha", "plan-proj", "How to search knowledge bases",
                 "knowledge,search", "How to search knowledge bases. research scope global");
@@ -407,7 +407,7 @@ class PlansSchemaLiquibaseTest {
     @Test
     void rls_failClosed_noGucStamp_returnsZeroRows() throws Exception {
         // Seed at least one plan row as superuser so table is non-empty.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(false);
             insertPlan(su, "failclosed-tenant", "fc-proj",
                 "Sentinel plan for fail-closed probe", "sentinel", "Sentinel plan");
@@ -454,7 +454,7 @@ class PlansSchemaLiquibaseTest {
 
     @Test
     void rls_withCheck_blocksCrossTenantTenantIdRewrite() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(false);
             insertPlan(su, "alpha-plans-rw", "rw-proj", "Plan to rewrite", "rw", "Plan to rewrite");
             su.commit();
@@ -477,7 +477,7 @@ class PlansSchemaLiquibaseTest {
 
     private com.zaxxer.hikari.HikariDataSource buildSvcDataSource() {
         var cfg = new com.zaxxer.hikari.HikariConfig();
-        cfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        cfg.setJdbcUrl(pg.getJdbcUrl());
         cfg.setUsername(SVC_ROLE);
         cfg.setPassword(SVC_PASS);
         cfg.setMaximumPoolSize(5);

--- a/service/src/test/java/dev/nexus/service/SchemaMigratorIntegrationTest.java
+++ b/service/src/test/java/dev/nexus/service/SchemaMigratorIntegrationTest.java
@@ -1,7 +1,7 @@
 package dev.nexus.service;
 
 import dev.nexus.service.db.SchemaMigrator;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import org.junit.jupiter.api.*;
 
 import java.sql.Connection;
@@ -72,7 +72,7 @@ class SchemaMigratorIntegrationTest {
 
     // ── Fixtures ─────────────────────────────────────────────────────────────
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
 
     /** Migration pool — uses nexus_admin_test (non-superuser owner). */
     com.zaxxer.hikari.HikariDataSource adminDs;
@@ -83,7 +83,7 @@ class SchemaMigratorIntegrationTest {
     @BeforeAll
     void bootstrap() throws Exception {
         // Start a completely schema-less embedded Postgres.
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
         // ── Phase A: provisioning (done by DBA / Phase-5 nx step, NOT by Liquibase) ──
         // Using the embedded postgres superuser to simulate the DBA bootstrap:
@@ -92,7 +92,7 @@ class SchemaMigratorIntegrationTest {
         //   3. Create the schemas and transfer ownership to nexus_admin_test.
         //      (In real provisioning: CREATE DATABASE nexus; CREATE SCHEMA nexus
         //       AUTHORIZATION nexus_admin; Liquibase then runs as nexus_admin.)
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
 
             // nexus_admin_test: NOT superuser, NOT createrole — plain schema owner.
@@ -125,7 +125,7 @@ class SchemaMigratorIntegrationTest {
 
         // Migration pool: nexus_admin_test (non-superuser owner).
         var adminCfg = new com.zaxxer.hikari.HikariConfig();
-        adminCfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        adminCfg.setJdbcUrl(pg.getJdbcUrl());
         adminCfg.setUsername(ADMIN_ROLE);
         adminCfg.setPassword(ADMIN_PASS);
         adminCfg.setMaximumPoolSize(2);
@@ -134,7 +134,7 @@ class SchemaMigratorIntegrationTest {
 
         // Service pool: nexus_svc (NOSUPERUSER NOBYPASSRLS) with search_path via initSql.
         var svcCfg = new com.zaxxer.hikari.HikariConfig();
-        svcCfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        svcCfg.setJdbcUrl(pg.getJdbcUrl());
         svcCfg.setUsername(SVC_ROLE);
         svcCfg.setPassword(SVC_PASS);
         svcCfg.setMaximumPoolSize(3);
@@ -148,7 +148,7 @@ class SchemaMigratorIntegrationTest {
         if (adminDs != null) adminDs.close();
         if (svcDs   != null) svcDs.close();
         try {
-            if (pg != null) pg.close();
+            if (pg != null) pg.stop();
         } catch (Exception ignored) { }
     }
 

--- a/service/src/test/java/dev/nexus/service/ScratchHandlerTest.java
+++ b/service/src/test/java/dev/nexus/service/ScratchHandlerTest.java
@@ -3,7 +3,7 @@ package dev.nexus.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.nexus.service.db.TenantConstants;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -49,7 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   <li>Auth: 401 on missing/bad Bearer token</li>
  * </ol>
  *
- * <p>Hermetic: embedded Postgres (io.zonky), port 0, no Docker.
+ * <p>Hermetic: embedded Postgres (Testcontainers pgvector), port 0, requires Docker.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ScratchHandlerTest {
@@ -66,7 +66,7 @@ class ScratchHandlerTest {
     private static final TypeReference<Map<String, Object>> MAP_T = new TypeReference<>() {};
     private static final TypeReference<List<Map<String, Object>>> LIST_T = new TypeReference<>() {};
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     NexusService service;
     HttpClient http;
     com.zaxxer.hikari.HikariDataSource svcDs;
@@ -75,9 +75,9 @@ class ScratchHandlerTest {
     @BeforeAll
     void startAll() throws Exception {
         mapper = new ObjectMapper();
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -93,7 +93,7 @@ class ScratchHandlerTest {
                 "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             new Liquibase("db/changelog/db.changelog-master.xml",
@@ -101,7 +101,7 @@ class ScratchHandlerTest {
                 .update(new Contexts());
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             su.createStatement().execute(
@@ -129,7 +129,7 @@ class ScratchHandlerTest {
         }
 
         var cfg = new com.zaxxer.hikari.HikariConfig();
-        cfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        cfg.setJdbcUrl(pg.getJdbcUrl());
         cfg.setUsername(SVC_ROLE);
         cfg.setPassword(SVC_PASS);
         cfg.setMaximumPoolSize(5);
@@ -145,7 +145,7 @@ class ScratchHandlerTest {
     void stopAll() throws Exception {
         if (service != null) service.stop();
         if (svcDs  != null) svcDs.close();
-        if (pg     != null) pg.close();
+        if (pg     != null) pg.stop();
     }
 
     // ── Test 1: PUT ───────────────────────────────────────────────────────────
@@ -479,7 +479,7 @@ class ScratchHandlerTest {
     }
 
     private void seedMintedSession(String rawSessionToken, String sessionId) throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             try (var ps = su.prepareStatement(
                 "INSERT INTO nexus.session_tokens (session_token_hash, tenant_id, session_id, expires_at) "

--- a/service/src/test/java/dev/nexus/service/ScratchRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/ScratchRepositoryTest.java
@@ -2,7 +2,7 @@ package dev.nexus.service;
 
 import dev.nexus.service.db.ScratchRepository;
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   <li>resolvePrefix: full UUID found by prefix</li>
  * </ol>
  *
- * <p>Hermetic: embedded Postgres (io.zonky), port 0, no Docker.
+ * <p>Hermetic: embedded Postgres (Testcontainers pgvector), port 0, requires Docker.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ScratchRepositoryTest {
@@ -56,16 +56,16 @@ class ScratchRepositoryTest {
     private static final String SESSION_A = "session-aaaa";
     private static final String SESSION_B = "session-bbbb";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
     ScratchRepository repo;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -81,7 +81,7 @@ class ScratchRepositoryTest {
                 "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             new Liquibase("db/changelog/db.changelog-master.xml",
@@ -89,7 +89,7 @@ class ScratchRepositoryTest {
                 .update(new Contexts());
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA t1 TO " + SVC_ROLE);
             su.createStatement().execute(
@@ -106,7 +106,7 @@ class ScratchRepositoryTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg    != null) pg.close();
+        if (pg    != null) pg.stop();
     }
 
     // ── Test 1: put/get round-trip ────────────────────────────────────────────
@@ -485,7 +485,7 @@ class ScratchRepositoryTest {
 
     private com.zaxxer.hikari.HikariDataSource buildSvcDs() {
         var config = new com.zaxxer.hikari.HikariConfig();
-        config.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        config.setJdbcUrl(pg.getJdbcUrl());
         config.setUsername(SVC_ROLE);
         config.setPassword(SVC_PASS);
         config.setMaximumPoolSize(5);

--- a/service/src/test/java/dev/nexus/service/ScratchSchemaLiquibaseTest.java
+++ b/service/src/test/java/dev/nexus/service/ScratchSchemaLiquibaseTest.java
@@ -2,7 +2,7 @@ package dev.nexus.service;
 
 import dev.nexus.service.db.ScratchRepository;
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * RDR-152 bead nexus-gmiaf.13 — Liquibase t1 scratch schema integration test.
  *
- * <p>Hermetic: embedded Postgres (io.zonky), port 0, no Docker. Applies the
+ * <p>Hermetic: embedded Postgres (Testcontainers pgvector), port 0, requires Docker. Applies the
  * Liquibase master changelog and asserts all structural and runtime properties
  * of the T1 scratch tier.
  *
@@ -52,15 +52,15 @@ class ScratchSchemaLiquibaseTest {
     private static final String SVC_ROLE = "svc_scratch_schema_test";
     private static final String SVC_PASS = "svc_scratch_schema_test_pass";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -76,7 +76,7 @@ class ScratchSchemaLiquibaseTest {
                 "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             new Liquibase("db/changelog/db.changelog-master.xml",
@@ -84,7 +84,7 @@ class ScratchSchemaLiquibaseTest {
                 .update(new Contexts());
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA t1 TO " + SVC_ROLE);
             su.createStatement().execute(
@@ -100,14 +100,14 @@ class ScratchSchemaLiquibaseTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg    != null) pg.close();
+        if (pg    != null) pg.stop();
     }
 
     // ── Test 1: exact column set ─────────────────────────────────────────────
 
     @Test
     void scratchTable_hasExactColumnSet() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.getMetaData().getColumns(null, "t1", "scratch", null);
             Set<String> actual = new java.util.HashSet<>();
             while (rs.next()) actual.add(rs.getString("COLUMN_NAME").toLowerCase());
@@ -121,7 +121,7 @@ class ScratchSchemaLiquibaseTest {
 
     @Test
     void scratchTable_isUnlogged() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT relpersistence FROM pg_class c " +
                 "JOIN pg_namespace n ON c.relnamespace = n.oid " +
@@ -137,7 +137,7 @@ class ScratchSchemaLiquibaseTest {
 
     @Test
     void scratchTable_rlsEnabledAndForced_usingT1TenantGuc() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet cls = su.createStatement().executeQuery(
                 "SELECT relrowsecurity, relforcerowsecurity " +
                 "FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid " +
@@ -164,7 +164,7 @@ class ScratchSchemaLiquibaseTest {
 
     @Test
     void scratchTable_ftsColumnAndIndex_tokenisationCorrect() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             // Verify STORED generated column
             ResultSet gen = su.createStatement().executeQuery(
                 "SELECT a.attgenerated, pg_catalog.format_type(a.atttypid, a.atttypmod) AS col_type " +
@@ -204,7 +204,7 @@ class ScratchSchemaLiquibaseTest {
         }
 
         // Tokenisation probe: insert via superuser, verify FTS behavior
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(false);
             try (var ps = su.prepareStatement("SELECT set_config('nexus.t1_tenant', ?, true)")) {
                 ps.setString(1, "probe-tenant-scratch");
@@ -238,7 +238,7 @@ class ScratchSchemaLiquibaseTest {
     @Test
     void rls_tenantIsolation_viaWithTenant() throws Exception {
         // Seed rows for two tenants via superuser
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(false);
             insertRow(su, "t1-alice", "session-alice", "alice-entry-1", "content for alice", "alice");
             insertRow(su, "t1-bob",   "session-bob",   "bob-entry-1",   "content for bob",   "bob");
@@ -284,7 +284,7 @@ class ScratchSchemaLiquibaseTest {
 
     @Test
     void rls_failClosed_noGucStamp_returnsZeroRows() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(false);
             insertRow(su, "fc-tenant", "fc-session", "fc-id", "fail-closed probe", "probe");
             su.commit();
@@ -325,7 +325,7 @@ class ScratchSchemaLiquibaseTest {
 
     private com.zaxxer.hikari.HikariDataSource buildSvcDs() {
         var config = new com.zaxxer.hikari.HikariConfig();
-        config.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        config.setJdbcUrl(pg.getJdbcUrl());
         config.setUsername(SVC_ROLE);
         config.setPassword(SVC_PASS);
         config.setMaximumPoolSize(5);

--- a/service/src/test/java/dev/nexus/service/ServiceIntegrationTest.java
+++ b/service/src/test/java/dev/nexus/service/ServiceIntegrationTest.java
@@ -1,7 +1,7 @@
 package dev.nexus.service;
 
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 /**
  * RDR-152 bead nexus-gmiaf.3 — skeleton integration tests.
  *
- * 5 required tests (all hermetic, port 0, embedded PG, no Docker):
+ * 5 required tests (all hermetic, port 0, embedded PG, requires Docker):
  *   1. /health returns 200 and DB is up
  *   2. auth 401 matrix (no token, bad token, good token)
  *   3. missing X-Nexus-Tenant → 400
@@ -38,7 +38,7 @@ class ServiceIntegrationTest {
 
     static final String TOKEN = "test-token-secret-0123456789abcdef";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     NexusService service;
     HttpClient http;
     TenantScope tenantScope;
@@ -47,12 +47,13 @@ class ServiceIntegrationTest {
     @BeforeAll
     void startAll() throws Exception {
         // Start embedded postgres on a free port
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
-        DataSource ds = pg.getPostgresDatabase();
-
-        // Bootstrap: create service role and RLS schema for test 4
-        bootstrapTestSchema(ds);
+        // Bootstrap: create service role and RLS schema for test 4. The superuser pool is
+        // transient (setup only); close it so it does not leak (review nexus-22man).
+        try (com.zaxxer.hikari.HikariDataSource ds = PgContainerHelper.superuserDataSource(pg)) {
+            bootstrapTestSchema(ds);
+        }
 
         // Build the DataSource for service using the svc_user role
         // (service scope, subject to RLS)
@@ -76,7 +77,7 @@ class ServiceIntegrationTest {
             svcDs.close();
         }
         if (pg != null) {
-            pg.close();
+            pg.stop();
         }
     }
 
@@ -144,7 +145,7 @@ class ServiceIntegrationTest {
         });
 
         // Seed data via superuser (bypasses RLS) — 3 rows for A, 1 for B
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(false);
             stampAndInsert(su, "tenant-A", "key-a1", "alpha one");
             stampAndInsert(su, "tenant-A", "key-a2", "alpha two");
@@ -187,7 +188,7 @@ class ServiceIntegrationTest {
 
         // Verify via SUPERUSER (bypasses RLS) — an RLS-subject connection would
         // see empty due to RLS even if the row was committed; superuser proves rollback.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             var rs = su.createStatement().executeQuery(
                 "SELECT key FROM nexus_test.rls_probe WHERE tenant_id = 'tenant-X'");
@@ -296,9 +297,9 @@ class ServiceIntegrationTest {
      * autoCommit=true matches the production pool default in Main.java;
      * TenantScope toggles to false per borrow.
      */
-    private com.zaxxer.hikari.HikariDataSource buildSvcDataSource(EmbeddedPostgres epg) {
+    private com.zaxxer.hikari.HikariDataSource buildSvcDataSource(PostgreSQLContainer<?> epg) {
         var config = new com.zaxxer.hikari.HikariConfig();
-        config.setJdbcUrl("jdbc:postgresql://localhost:" + epg.getPort() + "/postgres");
+        config.setJdbcUrl(epg.getJdbcUrl());
         config.setUsername("svc_test");
         config.setPassword("svc_test_pass");
         config.setMaximumPoolSize(5);

--- a/service/src/test/java/dev/nexus/service/ServiceTokenSchemaLiquibaseTest.java
+++ b/service/src/test/java/dev/nexus/service/ServiceTokenSchemaLiquibaseTest.java
@@ -2,7 +2,7 @@ package dev.nexus.service;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * RDR-152 bead nexus-gmiaf.32.1 — Phase A schema integration test for the
  * bridge token lifecycle credential tables.
  *
- * <p>Hermetic: embedded Postgres (io.zonky), port 0, no Docker. Applies the
+ * <p>Hermetic: embedded Postgres (Testcontainers pgvector), port 0, requires Docker. Applies the
  * Liquibase master changelog and asserts the structural and runtime properties
  * of {@code nexus.service_tokens} and {@code nexus.session_tokens}.
  *
@@ -68,18 +68,18 @@ class ServiceTokenSchemaLiquibaseTest {
     private static final String SVC_ROLE = "nexus_svc";
     private static final String SVC_PASS = "nexus_svc_pass";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
         // Create nexus_svc with the production posture: LOGIN, NOSUPERUSER,
         // NOBYPASSRLS. The grants-nexus-svc.xml changeset (runAlways, LAST) then
         // grants it DML on ALL TABLES in the nexus schema, including the two new
         // credential tables.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -90,7 +90,7 @@ class ServiceTokenSchemaLiquibaseTest {
                 "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             new Liquibase("db/changelog/db.changelog-master.xml",
@@ -104,7 +104,7 @@ class ServiceTokenSchemaLiquibaseTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg    != null) pg.close();
+        if (pg    != null) pg.stop();
     }
 
     // ── Test 1: service_tokens exact column set ──────────────────────────────
@@ -150,7 +150,7 @@ class ServiceTokenSchemaLiquibaseTest {
     @Test
     void serviceTokens_readableByServiceRole_withoutTenantGuc() throws Exception {
         // Seed two rows for two different tenants via superuser.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("TRUNCATE nexus.service_tokens");
             su.createStatement().execute(
@@ -176,7 +176,7 @@ class ServiceTokenSchemaLiquibaseTest {
 
     @Test
     void sessionTokens_readableByServiceRole_withoutTenantGuc() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("TRUNCATE nexus.session_tokens");
             su.createStatement().execute(
@@ -241,7 +241,7 @@ class ServiceTokenSchemaLiquibaseTest {
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private Set<String> columnsOf(String schema, String table) throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.getMetaData().getColumns(null, schema, table, null);
             Set<String> actual = new HashSet<>();
             while (rs.next()) actual.add(rs.getString("COLUMN_NAME").toLowerCase());
@@ -250,7 +250,7 @@ class ServiceTokenSchemaLiquibaseTest {
     }
 
     private boolean rlsEnabled(String schema, String table) throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT relrowsecurity FROM pg_class c "
                 + "JOIN pg_namespace n ON c.relnamespace = n.oid "
@@ -261,7 +261,7 @@ class ServiceTokenSchemaLiquibaseTest {
     }
 
     private Set<String> indexDefsOf(String schema, String table) throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT indexdef FROM pg_indexes "
                 + "WHERE schemaname = '" + schema + "' AND tablename = '" + table + "'");
@@ -273,7 +273,7 @@ class ServiceTokenSchemaLiquibaseTest {
 
     private HikariDataSource buildSvcDs() {
         var config = new HikariConfig();
-        config.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        config.setJdbcUrl(pg.getJdbcUrl());
         config.setUsername(SVC_ROLE);
         config.setPassword(SVC_PASS);
         config.setMaximumPoolSize(5);

--- a/service/src/test/java/dev/nexus/service/SessionTokenHandlerTest.java
+++ b/service/src/test/java/dev/nexus/service/SessionTokenHandlerTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import dev.nexus.service.db.TokenHashing;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -39,7 +39,7 @@ class SessionTokenHandlerTest {
     private static final String TENANT = "tenant-sess";
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     HikariDataSource ds;
     NexusService service;
     int port;
@@ -47,20 +47,20 @@ class SessionTokenHandlerTest {
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='nexus_svc') THEN "
                 + "CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
         }
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             new Liquibase("db/changelog/db.changelog-master.xml",
                 new ClassLoaderResourceAccessor(), db).update(new Contexts());
         }
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             try (var ps = su.prepareStatement(
                 "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label) VALUES (?, ?, 'boot') "
@@ -72,8 +72,9 @@ class SessionTokenHandlerTest {
             }
         }
         var cfg = new HikariConfig();
-        cfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
-        cfg.setUsername("postgres");
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(PgContainerHelper.USERNAME);
+        cfg.setPassword(PgContainerHelper.PASSWORD);
         cfg.setMaximumPoolSize(5);
         cfg.setAutoCommit(true);
         cfg.setConnectionInitSql("SET search_path TO nexus, t1, public");
@@ -87,7 +88,7 @@ class SessionTokenHandlerTest {
     void stopAll() throws Exception {
         if (service != null) service.stop();
         if (ds != null) ds.close();
-        if (pg != null) pg.close();
+        if (pg != null) pg.stop();
     }
 
     @Test
@@ -96,7 +97,7 @@ class SessionTokenHandlerTest {
         assertThat(r.path("session_token").asText()).isNotBlank();
         assertThat(r.get("session_id").asText()).isEqualTo("sess-store");
         String hash = TokenHashing.sha256Hex(r.get("session_token").asText());
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT tenant_id, session_id FROM nexus.session_tokens WHERE session_token_hash = '" + hash + "'");
             assertThat(rs.next()).isTrue();
@@ -125,7 +126,7 @@ class SessionTokenHandlerTest {
             .get("session_token").asText();
         assertThat(second).isNotEqualTo(first);
         // Exactly one live row for the session; the old token's hash is gone.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT COUNT(*) c FROM nexus.session_tokens WHERE tenant_id='" + TENANT
                 + "' AND session_id='sess-remint'");
@@ -156,7 +157,7 @@ class SessionTokenHandlerTest {
         assertThat(post("/v1/sessions/close", "{\"session_id\":\"sess-close\"}")
             .get("closed").asInt()).isEqualTo(0);
         // The row is gone.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT COUNT(*) c FROM nexus.session_tokens WHERE session_token_hash = '"
                 + TokenHashing.sha256Hex(token) + "'");

--- a/service/src/test/java/dev/nexus/service/TaxonomyRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/TaxonomyRepositoryTest.java
@@ -2,7 +2,7 @@ package dev.nexus.service;
 
 import dev.nexus.service.db.TaxonomyRepository;
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -63,16 +63,16 @@ class TaxonomyRepositoryTest {
     private static final String COL_A    = "knowledge__a";
     private static final String COL_B    = "knowledge__b";
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
     TaxonomyRepository repo;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -88,7 +88,7 @@ class TaxonomyRepositoryTest {
                 "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             Liquibase liquibase = new Liquibase(
@@ -97,7 +97,7 @@ class TaxonomyRepositoryTest {
             liquibase.update(new Contexts());
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             String schema = "nexus";
             for (String table : List.of("topics", "taxonomy_meta", "topic_assignments", "topic_links")) {
@@ -139,7 +139,7 @@ class TaxonomyRepositoryTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg != null)    pg.close();
+        if (pg != null)    pg.stop();
     }
 
     // ── Topics CRUD ────────────────────────────────────────────────────────────
@@ -507,7 +507,7 @@ class TaxonomyRepositoryTest {
     void rls_withCheck_rejectsWrongTenant() throws Exception {
         // Direct INSERT with tenant_id != GUC → WITH CHECK violation
         // The GUC is 'injector-tenant' but the row has tenant_id='other-tenant' → rejected
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             // Grant INSERT so the svc role can attempt the INSERT (it will be rejected by RLS)
             su.createStatement().execute(
@@ -542,7 +542,7 @@ class TaxonomyRepositoryTest {
 
         // Connect directly with svc role, no GUC stamp → RLS sees NULL tenant → 0 rows
         var rawConfig = new com.zaxxer.hikari.HikariConfig();
-        rawConfig.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        rawConfig.setJdbcUrl(pg.getJdbcUrl());
         rawConfig.setUsername(SVC_ROLE);
         rawConfig.setPassword(SVC_PASS);
         rawConfig.setMaximumPoolSize(1);
@@ -562,7 +562,7 @@ class TaxonomyRepositoryTest {
 
     private com.zaxxer.hikari.HikariDataSource buildSvcDataSource() {
         var config = new com.zaxxer.hikari.HikariConfig();
-        config.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        config.setJdbcUrl(pg.getJdbcUrl());
         config.setUsername(SVC_ROLE);
         config.setPassword(SVC_PASS);
         config.setMaximumPoolSize(5);

--- a/service/src/test/java/dev/nexus/service/TaxonomySchemaLiquibaseTest.java
+++ b/service/src/test/java/dev/nexus/service/TaxonomySchemaLiquibaseTest.java
@@ -1,6 +1,6 @@
 package dev.nexus.service;
 
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -27,9 +27,9 @@ class TaxonomySchemaLiquibaseTest {
 
     @Test
     void taxonomyChangeset_appliesAndCreatesExpectedTables() throws Exception {
-        try (EmbeddedPostgres pg = EmbeddedPostgres.builder().start()) {
+        try (PostgreSQLContainer<?> pg = PgContainerHelper.start()) {
 
-            try (Connection su = pg.getPostgresDatabase().getConnection()) {
+            try (Connection su = pg.createConnection("")) {
                 su.createStatement().execute(
                     "DO $$ BEGIN " +
                     "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
@@ -45,7 +45,7 @@ class TaxonomySchemaLiquibaseTest {
                 lb.update(new Contexts());
             }
 
-            try (Connection c = pg.getPostgresDatabase().getConnection()) {
+            try (Connection c = pg.createConnection("")) {
                 // All four tables exist in nexus schema
                 for (String table : List.of("topics", "taxonomy_meta",
                                             "topic_assignments", "topic_links")) {

--- a/service/src/test/java/dev/nexus/service/TelemetryRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/TelemetryRepositoryTest.java
@@ -3,7 +3,7 @@ package dev.nexus.service;
 import dev.nexus.service.db.TelemetryRepository;
 import dev.nexus.service.db.TenantConstants;
 import dev.nexus.service.db.TenantScope;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -61,16 +61,16 @@ class TelemetryRepositoryTest {
     private static final OffsetDateTime PAST_ODT =
         OffsetDateTime.parse("2024-01-15T10:30:00+00:00");
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
     TelemetryRepository repo;
     com.zaxxer.hikari.HikariDataSource svcDs;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -86,7 +86,7 @@ class TelemetryRepositoryTest {
                 "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             Liquibase liquibase = new Liquibase(
@@ -95,7 +95,7 @@ class TelemetryRepositoryTest {
             liquibase.update(new Contexts());
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             String schema = "nexus";
             // Grant all telemetry tables
@@ -122,7 +122,7 @@ class TelemetryRepositoryTest {
     @AfterAll
     void stopAll() throws Exception {
         if (svcDs != null) svcDs.close();
-        if (pg != null)    pg.close();
+        if (pg != null)    pg.stop();
     }
 
     // ── relevance_log ──────────────────────────────────────────────────────────
@@ -268,7 +268,7 @@ class TelemetryRepositoryTest {
             "sess-tier-fid", PAST_TS, "memory_put", "T2", "developer", "proj-a", "notes.md");
 
         // Verify via raw query
-        try (Connection conn = pg.getPostgresDatabase().getConnection()) {
+        try (Connection conn = pg.createConnection("")) {
             conn.createStatement().execute(
                 "SET nexus.tenant = '" + TENANT_A + "'");
             var rs = conn.createStatement().executeQuery(
@@ -298,7 +298,7 @@ class TelemetryRepositoryTest {
             "What is the meaning of RDR-152?", 42L, 0.95,
             3, "It is the storage migration RDR.", 0.003, 1500, PAST_TS);
 
-        try (Connection conn = pg.getPostgresDatabase().getConnection()) {
+        try (Connection conn = pg.createConnection("")) {
             conn.createStatement().execute("SET nexus.tenant = '" + TENANT_A + "'");
             var rs = conn.createStatement().executeQuery(
                 "SELECT created_at FROM nexus.nx_answer_runs WHERE question='What is the meaning of RDR-152?'");
@@ -327,7 +327,7 @@ class TelemetryRepositoryTest {
             "doc-hook-001", "code__nexus", "taxonomy_assign_batch_hook",
             "ChromaDB timeout", PAST_TS, null, false, "single");
 
-        try (Connection conn = pg.getPostgresDatabase().getConnection()) {
+        try (Connection conn = pg.createConnection("")) {
             conn.createStatement().execute("SET nexus.tenant = '" + TENANT_A + "'");
             var rs = conn.createStatement().executeQuery(
                 "SELECT occurred_at FROM nexus.hook_failures WHERE doc_id='doc-hook-001'");
@@ -395,7 +395,7 @@ class TelemetryRepositoryTest {
         repo.upsertFrecency(TENANT_A, "chunk-frec-embed",
             "2025-01-01T00:00:00Z", 30, 0.5, 1, "2025-01-01T00:00:00Z");
 
-        try (Connection conn = pg.getPostgresDatabase().getConnection()) {
+        try (Connection conn = pg.createConnection("")) {
             conn.createStatement().execute("SET nexus.tenant = '" + TENANT_A + "'");
             var rs = conn.createStatement().executeQuery(
                 "SELECT embedded_at FROM nexus.frecency WHERE chunk_id='chunk-frec-embed'");
@@ -545,7 +545,7 @@ class TelemetryRepositoryTest {
             null,   // project — must stay NULL
             null);  // target_title — must stay NULL
 
-        try (Connection conn = pg.getPostgresDatabase().getConnection()) {
+        try (Connection conn = pg.createConnection("")) {
             conn.createStatement().execute("SET nexus.tenant = '" + TENANT_A + "'");
             var rs = conn.createStatement().executeQuery(
                 "SELECT agent, project, target_title " +
@@ -587,7 +587,7 @@ class TelemetryRepositoryTest {
 
     private com.zaxxer.hikari.HikariDataSource buildSvcDataSource() {
         var config = new com.zaxxer.hikari.HikariConfig();
-        config.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        config.setJdbcUrl(pg.getJdbcUrl());
         config.setUsername(SVC_ROLE);
         config.setPassword(SVC_PASS);
         config.setMaximumPoolSize(4);

--- a/service/src/test/java/dev/nexus/service/TelemetrySchemaLiquibaseTest.java
+++ b/service/src/test/java/dev/nexus/service/TelemetrySchemaLiquibaseTest.java
@@ -1,6 +1,6 @@
 package dev.nexus.service;
 
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -57,13 +57,13 @@ class TelemetrySchemaLiquibaseTest {
         "relevance_log", "search_telemetry", "tier_writes",
         "nx_answer_runs", "hook_failures", "frecency");
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
+        pg = PgContainerHelper.start();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN " +
@@ -73,7 +73,7 @@ class TelemetrySchemaLiquibaseTest {
                 "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             Liquibase liquibase = new Liquibase(
@@ -85,7 +85,7 @@ class TelemetrySchemaLiquibaseTest {
 
     @AfterAll
     void stopAll() throws Exception {
-        if (pg != null) pg.close();
+        if (pg != null) pg.stop();
     }
 
     // ── Test 1: exact column sets ────────────────────────────────────────────
@@ -124,7 +124,7 @@ class TelemetrySchemaLiquibaseTest {
 
     @Test
     void allTelemetryTables_rlsEnabledForcedWithPolicy() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             for (String table : ALL_TEL_TABLES) {
                 ResultSet cls = su.createStatement().executeQuery(
                     "SELECT relrowsecurity, relforcerowsecurity " +
@@ -150,7 +150,7 @@ class TelemetrySchemaLiquibaseTest {
 
     @Test
     void allTelemetryTables_noTsvectorColumns() throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             for (String table : ALL_TEL_TABLES) {
                 ResultSet rs = su.createStatement().executeQuery(
                     "SELECT COUNT(*) AS cnt " +
@@ -182,7 +182,7 @@ class TelemetrySchemaLiquibaseTest {
             new String[]{ "frecency",         "last_hit_at" }
         );
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             for (var entry : tableToTsCol) {
                 String table = entry[0];
                 String tsCol  = entry[1];
@@ -217,7 +217,7 @@ class TelemetrySchemaLiquibaseTest {
             new String[]{ "hook_failures",  "idx_hook_failures_etl_dedup" }
         );
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             for (var entry : dedupIndexNames) {
                 String table     = entry[0];
                 String indexName = entry[1];
@@ -238,7 +238,7 @@ class TelemetrySchemaLiquibaseTest {
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private void assertColumns(String table, Set<String> expected) throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.getMetaData().getColumns(null, "nexus", table, null);
             Set<String> actual = new HashSet<>();
             while (rs.next()) {

--- a/service/src/test/java/dev/nexus/service/TokenAdminHandlerTest.java
+++ b/service/src/test/java/dev/nexus/service/TokenAdminHandlerTest.java
@@ -6,7 +6,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import dev.nexus.service.db.TenantConstants;
 import dev.nexus.service.db.TokenHashing;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * RDR-152 bead nexus-gmiaf.32.3 — token lifecycle admin endpoints, end-to-end through the
  * real {@link NexusService} (so the admin handler and AuthFilter share the live TokenCache).
  *
- * <p>Hermetic: embedded Postgres, port 0, no Docker. A wildcard bootstrap token authenticates
+ * <p>Hermetic: embedded Postgres, port 0, requires Docker. A wildcard bootstrap token authenticates
  * the admin calls (mirrors provisioning riding the legacy credential).
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -41,7 +41,7 @@ class TokenAdminHandlerTest {
     private static final String BOOT = "boot-admin-token";
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     HikariDataSource ds;
     NexusService service;
     int port;
@@ -49,14 +49,14 @@ class TokenAdminHandlerTest {
 
     @BeforeAll
     void startAll() throws Exception {
-        pg = EmbeddedPostgres.builder().start();
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute(
                 "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='nexus_svc') THEN "
                 + "CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
         }
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             new Liquibase("db/changelog/db.changelog-master.xml",
@@ -65,7 +65,7 @@ class TokenAdminHandlerTest {
         // Seed the persistent root token (Phase E nexus-gmiaf.32.5) used to authenticate
         // the admin calls: BOUND to the default tenant with ROOT_TOKEN_LABEL so the
         // lockout protection (revoke-refused / list-excluded) applies to it.
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             try (var ps = su.prepareStatement(
                 "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label) VALUES (?, ?, ?) "
@@ -77,8 +77,9 @@ class TokenAdminHandlerTest {
             }
         }
         var cfg = new HikariConfig();
-        cfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
-        cfg.setUsername("postgres");
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(PgContainerHelper.USERNAME);
+        cfg.setPassword(PgContainerHelper.PASSWORD);
         cfg.setMaximumPoolSize(5);
         cfg.setAutoCommit(true);
         cfg.setConnectionInitSql("SET search_path TO nexus, t1, public");
@@ -93,7 +94,7 @@ class TokenAdminHandlerTest {
     void stopAll() throws Exception {
         if (service != null) service.stop();
         if (ds != null) ds.close();
-        if (pg != null) pg.close();
+        if (pg != null) pg.stop();
     }
 
     // ── issue ────────────────────────────────────────────────────────────────
@@ -144,7 +145,7 @@ class TokenAdminHandlerTest {
         JsonNode r = postJson("/v1/service-tokens/rotate", "{\"tenant\":\"tenant-rot\",\"grace_seconds\":300}");
         assertThat(r.get("token").asText()).isNotBlank();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             // All three rows are still live (revoked_at IS NULL) during the grace window.
             assertThat(countLive("tenant-rot", su)).isEqualTo(3L);
             // The two pre-existing rows now have a future expires_at; the new one has none.
@@ -171,7 +172,7 @@ class TokenAdminHandlerTest {
         postJson("/v1/service-tokens/rotate",
             "{\"tenant\":\"" + TenantConstants.DEFAULT_TENANT + "\",\"grace_seconds\":300}");
         String bootHash = TokenHashing.sha256Hex(BOOT);
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT expires_at, revoked_at FROM nexus.service_tokens WHERE token_hash = '"
                 + bootHash + "'");
@@ -259,7 +260,7 @@ class TokenAdminHandlerTest {
     @Test
     void issue_withTtl_setsExpiry() throws Exception {
         JsonNode r = postJson("/v1/service-tokens/issue", "{\"tenant\":\"tenant-exp\",\"ttl_seconds\":3600}");
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT expires_at FROM nexus.service_tokens WHERE token_hash = '"
                 + r.get("token_hash").asText() + "'");
@@ -331,7 +332,7 @@ class TokenAdminHandlerTest {
     }
 
     private String tenantOf(String hash) throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT tenant_id FROM nexus.service_tokens WHERE token_hash = '" + hash + "'");
             assertThat(rs.next()).isTrue();

--- a/service/src/test/java/dev/nexus/service/TokenBoundaryAdversarialTest.java
+++ b/service/src/test/java/dev/nexus/service/TokenBoundaryAdversarialTest.java
@@ -12,7 +12,7 @@ import dev.nexus.service.db.TokenHashing;
 import dev.nexus.service.db.TokenStore;
 import dev.nexus.service.http.AuthFilter;
 import dev.nexus.service.http.RequestContext;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.Database;
@@ -119,7 +119,7 @@ class TokenBoundaryAdversarialTest {
 
     private static final TypeReference<Map<String, Object>> MAP_T = new TypeReference<>() {};
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     NexusService service;
     HikariDataSource svcDs;
     HttpClient http;
@@ -129,17 +129,16 @@ class TokenBoundaryAdversarialTest {
     void startAll() throws Exception {
         mapper = new ObjectMapper();
         http   = HttpClient.newHttpClient();
-        pg     = EmbeddedPostgres.builder().start();
+        pg     = PgContainerHelper.start();
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             // RLS-enforcing app role: NOSUPERUSER NOBYPASSRLS makes the tenant policy a
             // real boundary. nexus_svc is fail-fast-required by grants-nexus-svc.xml.
             su.createStatement().execute(
                 "DO $$ BEGIN "
                 + "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '" + SVC_ROLE + "') THEN "
-                + "    CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS
-                + "    ' NOSUPERUSER NOBYPASSRLS; "
+                + "    CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "' NOSUPERUSER NOBYPASSRLS; "
                 + "  END IF; "
                 + "END $$");
             su.createStatement().execute(
@@ -150,14 +149,14 @@ class TokenBoundaryAdversarialTest {
                 + "END $$");
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
             new Liquibase("db/changelog/db.changelog-master.xml",
                 new ClassLoaderResourceAccessor(), db).update(new Contexts());
         }
 
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             su.createStatement().execute("GRANT USAGE ON SCHEMA t1 TO " + SVC_ROLE);
@@ -191,7 +190,7 @@ class TokenBoundaryAdversarialTest {
         }
 
         var cfg = new HikariConfig();
-        cfg.setJdbcUrl("jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        cfg.setJdbcUrl(pg.getJdbcUrl());
         cfg.setUsername(SVC_ROLE);
         cfg.setPassword(SVC_PASS);
         cfg.setMaximumPoolSize(5);
@@ -206,7 +205,7 @@ class TokenBoundaryAdversarialTest {
     void stopAll() throws Exception {
         if (service != null) service.stop();
         if (svcDs   != null) svcDs.close();
-        if (pg      != null) pg.close();
+        if (pg      != null) pg.stop();
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -433,7 +432,7 @@ class TokenBoundaryAdversarialTest {
 
         // Revoke out-of-band, then invalidate the SAME cache the AuthFilter reads.
         String hash = TokenHashing.sha256Hex(TOK_REVOKE_ME);
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             try (var ps = su.prepareStatement(
                 "UPDATE nexus.service_tokens SET revoked_at = now() WHERE token_hash = ?")) {
@@ -508,7 +507,7 @@ class TokenBoundaryAdversarialTest {
             assertThat(h.call(tok.rawToken()).statusCode()).isEqualTo(200);
 
             // Revoke out-of-band WITHOUT invalidating the cache (e.g. a direct DB edit).
-            try (Connection su = pg.getPostgresDatabase().getConnection()) {
+            try (Connection su = pg.createConnection("")) {
                 su.setAutoCommit(true);
                 try (var ps = su.prepareStatement(
                     "UPDATE nexus.service_tokens SET revoked_at = now() WHERE token_hash = ?")) {
@@ -568,7 +567,7 @@ class TokenBoundaryAdversarialTest {
     // ── Superuser seeding + counts (bypass RLS for non-vacuous negatives) ─────
 
     private void seedMemoryRow(String tenant, String project, String title, String content) throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             try (var ps = su.prepareStatement(
                 "INSERT INTO nexus.memory (tenant_id, project, title, content, timestamp) "
@@ -583,7 +582,7 @@ class TokenBoundaryAdversarialTest {
     }
 
     private int superuserMemoryCount(String tenant, String project) throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection();
+        try (Connection su = pg.createConnection("");
              var ps = su.prepareStatement(
                  "SELECT COUNT(*) AS c FROM nexus.memory WHERE tenant_id = ? AND project = ?")) {
             ps.setString(1, tenant);
@@ -595,7 +594,7 @@ class TokenBoundaryAdversarialTest {
     }
 
     private void seedScratchRow(String id, String tenant, String session, String content) throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection()) {
+        try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             try (var ps = su.prepareStatement(
                 "INSERT INTO t1.scratch (id, tenant_id, session_id, content) VALUES (?, ?, ?, ?)")) {
@@ -609,7 +608,7 @@ class TokenBoundaryAdversarialTest {
     }
 
     private int superuserScratchCount(String tenant, String session) throws Exception {
-        try (Connection su = pg.getPostgresDatabase().getConnection();
+        try (Connection su = pg.createConnection("");
              var ps = su.prepareStatement(
                  "SELECT COUNT(*) AS c FROM t1.scratch WHERE tenant_id = ? AND session_id = ?")) {
             ps.setString(1, tenant);
@@ -696,13 +695,15 @@ class TokenBoundaryAdversarialTest {
          *  which the restricted role cannot. Mirrors production's split (auth reads via the
          *  app role; lifecycle writes via the admin/provisioning path). Shares the clock. */
         final TokenStore seedStore;
+        final com.zaxxer.hikari.HikariDataSource seedDs;
         final HttpServer server;
         final int port;
 
         ClockHarness(Clock clock) throws IOException {
             this.store     = new TokenStore(svcDs, clock);
             this.cache     = new TokenCache(store, clock);
-            this.seedStore = new TokenStore(pg.getPostgresDatabase(), clock);
+            this.seedDs    = PgContainerHelper.superuserDataSource(pg);
+            this.seedStore = new TokenStore(seedDs, clock);
             this.server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
             var ctx = server.createContext("/v1/echo", new EchoHandler());
             ctx.getFilters().add(new AuthFilter(cache, store));
@@ -719,6 +720,7 @@ class TokenBoundaryAdversarialTest {
 
         @Override public void close() {
             server.stop(0);
+            seedDs.close();  // the superuser seed pool is harness-owned (review nexus-22man)
         }
     }
 

--- a/service/src/test/java/dev/nexus/service/VectorIntegrationTest.java
+++ b/service/src/test/java/dev/nexus/service/VectorIntegrationTest.java
@@ -9,7 +9,7 @@ import dev.nexus.service.vectors.ChromaRestClient;
 import dev.nexus.service.vectors.LocalChromaServer;
 import dev.nexus.service.vectors.OnnxEmbedder;
 import dev.nexus.service.vectors.VectorRepository;
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.testcontainers.containers.PostgreSQLContainer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * <p>All tests use:
  * <ul>
- *   <li>Embedded Postgres (io.zonky:embedded-postgres)</li>
+ *   <li>Embedded Postgres (Testcontainers pgvector/pgvector:pg17)</li>
  *   <li>Local ChromaDB child process ({@code chroma run}) on a free port</li>
  *   <li>Local ONNX embedder (all-MiniLM-L6-v2 from chromadb cache)</li>
  *   <li>Port 0 for the NexusService HTTP server</li>
@@ -64,7 +64,7 @@ class VectorIntegrationTest {
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    EmbeddedPostgres pg;
+    PostgreSQLContainer<?> pg;
     LocalChromaServer localChroma;
     OnnxEmbedder      onnxEmbedder;
     VectorRepository  vectorRepo;
@@ -74,11 +74,13 @@ class VectorIntegrationTest {
     @BeforeAll
     void startAll() throws Exception {
         // Embedded Postgres — needed only for the service's DB-backed endpoints
-        pg = EmbeddedPostgres.builder().start();
-        var pgDs = pg.getPostgresDatabase();
+        pg = PgContainerHelper.start();
 
-        // Bootstrap minimal schema + tables the service expects
-        bootstrapSchema(pgDs);
+        // Bootstrap minimal schema + tables the service expects. The superuser pool is
+        // transient (setup only); close it so it does not leak (review nexus-22man).
+        try (var pgDs = PgContainerHelper.superuserDataSource(pg)) {
+            bootstrapSchema(pgDs);
+        }
 
         var svcDs = buildSvcDs(pg);
 
@@ -107,7 +109,7 @@ class VectorIntegrationTest {
         if (service     != null) service.stop();
         if (onnxEmbedder != null) onnxEmbedder.close();
         if (localChroma != null) localChroma.stop();
-        if (pg          != null) pg.close();
+        if (pg          != null) pg.stop();
     }
 
     // ── Test 1: upsert-chunks → search returns them ──────────────────────────
@@ -550,11 +552,11 @@ class VectorIntegrationTest {
         }
     }
 
-    private com.zaxxer.hikari.HikariDataSource buildSvcDs(EmbeddedPostgres pg) {
+    private com.zaxxer.hikari.HikariDataSource buildSvcDs(PostgreSQLContainer<?> pg) {
         var cfg = new com.zaxxer.hikari.HikariConfig();
-        cfg.setJdbcUrl(pg.getJdbcUrl("postgres", "postgres"));
-        cfg.setUsername("postgres");
-        cfg.setPassword("");
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(PgContainerHelper.USERNAME);
+        cfg.setPassword(PgContainerHelper.PASSWORD);
         cfg.setMaximumPoolSize(5);
         cfg.setAutoCommit(true);
         return new com.zaxxer.hikari.HikariDataSource(cfg);

--- a/service/src/test/java/dev/nexus/service/codegen/JooqCodegenBootstrap.java
+++ b/service/src/test/java/dev/nexus/service/codegen/JooqCodegenBootstrap.java
@@ -1,6 +1,6 @@
 package dev.nexus.service.codegen;
 
-import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import dev.nexus.service.PgContainerHelper;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.DatabaseFactory;
@@ -13,6 +13,7 @@ import org.jooq.meta.jaxb.Generator;
 import org.jooq.meta.jaxb.Jdbc;
 import org.jooq.meta.jaxb.SchemaMappingType;
 import org.jooq.meta.jaxb.Target;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.io.File;
 import java.sql.Connection;
@@ -20,17 +21,17 @@ import java.sql.Connection;
 /**
  * RDR-152 bead nexus-gmiaf.6 — jOOQ codegen bootstrap.
  *
- * <p>Starts an io.zonky EmbeddedPostgres instance (no Docker required), applies
- * the Liquibase changelog to create the nexus schema, then runs the jOOQ
- * GenerationTool with PostgresDatabase to generate typed classes for the nexus
- * schema into {@code target/generated-sources/jooq}.
+ * <p>Starts a pgvector/pgvector:pg17 Testcontainers container (RDR-155 P1.0,
+ * nexus-22man), applies the Liquibase changelog to create the nexus schema, then
+ * runs the jOOQ GenerationTool with PostgresDatabase to generate typed classes for
+ * the nexus schema into {@code src/main/generated/jooq}.
  *
  * <p>Invoked via the {@code -Pcodegen} Maven profile:
  * {@code mvn -Pcodegen process-test-classes} (from the service/ directory).
  * The profile uses exec-maven-plugin {@code exec:java} in the
  * {@code process-test-classes} phase with {@code classpathScope=test}, so all
- * test-scope dependencies (embedded-postgres, jooq-codegen, jooq-meta, liquibase)
- * are already on the classpath — no manual jar enumeration required.
+ * test-scope dependencies (testcontainers, postgresql, jooq-codegen, jooq-meta,
+ * liquibase) are already on the classpath — no manual jar enumeration required.
  *
  * <p>WHY NOT OPTION 1 (LiquibaseDatabase/H2): the changelog uses Postgres-only DDL
  * (TSVECTOR GENERATED ALWAYS AS STORED, ENABLE/FORCE ROW LEVEL SECURITY,
@@ -51,18 +52,19 @@ public class JooqCodegenBootstrap {
         String resourcesDir = args.length > 1 ? args[1]
             : "src/main/resources";
 
-        System.out.println("[jooq-codegen] Starting embedded Postgres...");
-        EmbeddedPostgres pg = EmbeddedPostgres.builder().start();
+        System.out.println("[jooq-codegen] Starting pgvector container...");
+        PostgreSQLContainer<?> pg = PgContainerHelper.start();
+        boolean success = false;
         try {
-            String url  = "jdbc:postgresql://localhost:" + pg.getPort() + "/postgres";
-            String user = "postgres";
-            String pass = "";
+            String url  = pg.getJdbcUrl();
+            String user = PgContainerHelper.USERNAME;
+            String pass = PgContainerHelper.PASSWORD;
 
             // Apply Liquibase changelog via superuser connection.
             // DirectoryResourceAccessor resolves paths relative to the given directory,
             // so "db/changelog/db.changelog-master.xml" resolves from src/main/resources.
             System.out.println("[jooq-codegen] Applying Liquibase changelog...");
-            try (Connection conn = pg.getPostgresDatabase().getConnection()) {
+            try (Connection conn = pg.createConnection("")) {
                 // The master changelog's runAlways grants-nexus-svc changeset
                 // (RDR-152 nexus-net63) is fail-loud: it GRANTs to nexus_svc and
                 // errors if the role is absent. Codegen only needs the schema,
@@ -114,9 +116,16 @@ public class JooqCodegenBootstrap {
 
             GenerationTool.generate(config);
             System.out.println("[jooq-codegen] Done: " + outputDir);
+            success = true;
         } finally {
-            pg.close();
-            System.out.println("[jooq-codegen] Embedded Postgres stopped");
+            System.out.println("[jooq-codegen] Stopping pgvector container...");
+            pg.stop();
+            // Force JVM exit so Testcontainers background threads (Ryuk reaper) do not
+            // keep the Maven exec:java goal alive and trigger an InterruptedException on
+            // shutdown. Exit NON-ZERO if generation threw — otherwise a codegen failure
+            // would exit 0, the build would pass, and the drift guard would pass vacuously
+            // against stale committed sources (AC-3 review, nexus-22man).
+            System.exit(success ? 0 : 1);
         }
     }
 }


### PR DESCRIPTION
RDR-155 P1.0 (nexus-22man) — the foundation bead that gates the whole RDR-155 TDD loop. Switches the Java service test module + jOOQ codegen from io.zonky EmbeddedPostgres to Testcontainers `pgvector/pgvector:pg17` (later beads add `CREATE EXTENSION vector` + chunks tables that zonky cannot host).

**Substrate-only / behavior-neutral** — no schema change; master changelog applies identically.

- `pom.xml`: testcontainers 1.21.4 replaces io.zonky; `service-ci.yml` drops the embedded-pg cache (Docker on ubuntu-latest).
- New `PgContainerHelper`; 27 test classes migrated to per-class `PostgreSQLContainer`; codegen bootstrap on the pgvector container.

## Review (code-review-expert + substantive-critic)
- **Critical fixed**: `JooqCodegenBootstrap.System.exit(0)` swallowed codegen failures → drift guard vacuous. Now `exit(success ? 0 : 1)`.
- Pool leaks fixed (HikariDataSource closed by 3 callers).
- Cleanup: dead imports, stale "io.zonky/no Docker" javadoc.
- Filed `nexus-5j7pb` (pre-existing, out of scope): two auth tests run the app layer as superuser (BYPASSRLS).

Verified: **457/0/0/0**; codegen drift guard **zero diff** on pgvector:pg17.