### PR TITLE
RDR-155 Phase 3: native hybrid search on pgvector + hybrid-parity seam (green on live engine)

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -159,6 +159,16 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Test: SQLite FTS5 — the legacy FTS5 engine itself (unicode61 tokenizer), the
+             text leg of the RDR-155 Phase 3 hybrid-parity comparand. The Python T2 path
+             uses the same SQLite FTS5 C library; xerial bundles it. -->
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.47.1.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/service/src/main/java/dev/nexus/service/NexusService.java
+++ b/service/src/main/java/dev/nexus/service/NexusService.java
@@ -27,6 +27,7 @@ import dev.nexus.service.http.TokenAdminHandler;
 import dev.nexus.service.http.VectorHandler;
 import dev.nexus.service.http.WhoamiHandler;
 import dev.nexus.service.vectors.EmbedderRouter;
+import dev.nexus.service.vectors.PgVectorRepository;
 import dev.nexus.service.vectors.VectorRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,6 +112,26 @@ public final class NexusService {
     public NexusService(int port, String token, DataSource dataSource,
                         VectorRepository vectorRepository,
                         EmbedderRouter docEmbedderRouter) throws IOException {
+        this(port, token, dataSource, vectorRepository, docEmbedderRouter, null);
+    }
+
+    /**
+     * Full constructor with the pgvector repository for {@code /v1/vectors/hybrid-search}
+     * (RDR-155 P3.2, bead nexus-eap5l).
+     *
+     * @param port              listen port; 0 for OS-assigned ephemeral (use in tests)
+     * @param token             expected bearer token
+     * @param dataSource        pooled connection source
+     * @param vectorRepository  optional Chroma VectorRepository (may be null)
+     * @param docEmbedderRouter optional EmbedderRouter for {@code /v1/vectors/embed} (may be null)
+     * @param pgVectorRepository optional PgVectorRepository for {@code /v1/vectors/hybrid-search}
+     *                           (may be null; production serving wiring is the Phase 4a cutover —
+     *                           until then the validation harness wires it explicitly)
+     */
+    public NexusService(int port, String token, DataSource dataSource,
+                        VectorRepository vectorRepository,
+                        EmbedderRouter docEmbedderRouter,
+                        PgVectorRepository pgVectorRepository) throws IOException {
         this.tenantScope = new TenantScope(dataSource);
 
         // Token lifecycle (RDR-152 bead nexus-gmiaf.32.2): resolve bearer→tenant
@@ -190,14 +211,16 @@ public final class NexusService {
         var sessionsCtx = server.createContext("/v1/sessions", new SessionTokenHandler(tokenStore));
         sessionsCtx.getFilters().addAll(authFilter);
 
-        // /v1/vectors/* — vector (Chroma) endpoints (bead nexus-gmiaf.20)
+        // /v1/vectors/* — vector endpoints (bead nexus-gmiaf.20; hybrid: RDR-155 P3.2)
         // Registered when a VectorRepository is provided OR an EmbedderRouter alone is provided
-        // (parity-gate mode: NX_CHROMA_MODE=none + NX_VOYAGE_API_KEY — only /embed is active).
-        if (vectorRepository != null || docEmbedderRouter != null) {
+        // (parity-gate mode: NX_CHROMA_MODE=none + NX_VOYAGE_API_KEY — only /embed is active)
+        // OR a PgVectorRepository is provided (hybrid-search validation seam).
+        if (vectorRepository != null || docEmbedderRouter != null || pgVectorRepository != null) {
             var vectorCtx = server.createContext("/v1/vectors",
-                    new VectorHandler(vectorRepository, docEmbedderRouter));
+                    new VectorHandler(vectorRepository, docEmbedderRouter, pgVectorRepository));
             vectorCtx.getFilters().addAll(authFilter);
-            log.info("event=vector_endpoints_registered has_storage={}", vectorRepository != null);
+            log.info("event=vector_endpoints_registered has_storage={} has_pgvector={}",
+                    vectorRepository != null, pgVectorRepository != null);
         }
 
         server.setExecutor(Executors.newVirtualThreadPerTaskExecutor());

--- a/service/src/main/java/dev/nexus/service/http/VectorHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/VectorHandler.java
@@ -12,6 +12,7 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import dev.nexus.service.vectors.ChromaQuotaValidator;
 import dev.nexus.service.vectors.EmbedderRouter;
+import dev.nexus.service.vectors.PgVectorRepository;
 import dev.nexus.service.vectors.VectorRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +33,7 @@ import java.util.Map;
  *   POST /v1/vectors/upsert-chunks   server-side embed + quota + Chroma write
  *   POST /v1/vectors/search          embed query server-side + Chroma query (multi-collection)
  *   POST /v1/vectors/query           alias for search (mirrors MCP query tool)
+ *   POST /v1/vectors/hybrid-search   pgvector hybrid fusion (tsvector+pg_trgm gate, vector rank) — RDR-155 P3
  *   POST /v1/vectors/store-put       single-chunk put (MCP store_put path)
  *   POST /v1/vectors/get              get chunks by metadata where-filter (incremental-sync staleness check)
  *   POST /v1/vectors/store-get       fetch chunks by IDs (MCP store_get/store_get_many)
@@ -59,21 +61,37 @@ public final class VectorHandler implements HttpHandler {
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
-    private final VectorRepository repo;
-    private final EmbedderRouter   embedderRouter;
+    private final VectorRepository    repo;
+    private final EmbedderRouter      embedderRouter;
+    private final PgVectorRepository  pgRepo;
+
+    /**
+     * Full constructor (RDR-155 P3.2, bead nexus-eap5l).
+     *
+     * @param repo           Chroma vector repository for storage ops (may be null)
+     * @param embedderRouter collection-aware embedder router for /embed (may be null)
+     * @param pgRepo         pgvector repository for /hybrid-search (may be null until the
+     *                       Phase 4a serving cutover wires it in production; the conexus
+     *                       xr7.8.9 validation harness wires it explicitly)
+     */
+    public VectorHandler(VectorRepository repo, EmbedderRouter embedderRouter,
+                         PgVectorRepository pgRepo) {
+        this.repo           = repo;
+        this.embedderRouter = embedderRouter;
+        this.pgRepo         = pgRepo;
+    }
 
     /**
      * @param repo          vector repository for storage ops
      * @param embedderRouter collection-aware embedder router (for /embed endpoint)
      */
     public VectorHandler(VectorRepository repo, EmbedderRouter embedderRouter) {
-        this.repo          = repo;
-        this.embedderRouter = embedderRouter;
+        this(repo, embedderRouter, null);
     }
 
     /** Backwards-compatible constructor for tests without an embedder router. */
     public VectorHandler(VectorRepository repo) {
-        this(repo, null);
+        this(repo, null, null);
     }
 
     @Override
@@ -92,6 +110,7 @@ public final class VectorHandler implements HttpHandler {
                 case "/upsert-chunks" -> handleUpsertChunks(exchange, method);
                 case "/search"        -> handleSearch(exchange, method);
                 case "/query"         -> handleSearch(exchange, method);   // alias
+                case "/hybrid-search" -> handleHybridSearch(exchange, method);  // RDR-155 P3
                 case "/store-put"     -> handleStorePut(exchange, method);
                 case "/get"           -> handleGet(exchange, method);
                 case "/store-get"     -> handleStoreGet(exchange, method);
@@ -182,6 +201,44 @@ public final class VectorHandler implements HttpHandler {
         Map<String, Object> where     = optMap(body, "where");
 
         var results = repo.search(queryText, collections, nResults, where);
+        HttpUtil.send(ex, 200, json(results));
+    }
+
+    /**
+     * POST /v1/vectors/hybrid-search — RDR-155 Phase 3 (bead nexus-eap5l).
+     *
+     * <p>The pgvector hybrid fusion query (tsvector + pg_trgm text gate, vector rank)
+     * through the EXISTING /v1/vectors surface — the validation seam the conexus
+     * xr7.8.9 go-live gate drives. Request body matches /search:
+     * {@code {"query": "...", "collections": [...], "n_results": 10, "where": {...}}}.
+     *
+     * <p>Tenant: SERVER-RESOLVED from the authenticated bearer
+     * ({@link RequestContext#tenant()}) — RLS is the tenant boundary on the pgvector
+     * path, unlike the Chroma routes where collection names encode scope.
+     *
+     * <p>503 when no {@link PgVectorRepository} is wired (same pattern as /embed):
+     * production wiring is the Phase 4a serving cutover; until then the harness wires
+     * it explicitly.
+     */
+    private void handleHybridSearch(HttpExchange ex, String method) throws IOException {
+        requireMethod(ex, method, "POST");
+        if (pgRepo == null) {
+            HttpUtil.send(ex, 503, json(Map.of(
+                    "error", "hybrid-search endpoint not configured (no pgvector repository)")));
+            return;
+        }
+        String tenant = RequestContext.tenant();
+        if (tenant == null || tenant.isBlank()) {
+            HttpUtil.send(ex, 401, json(Map.of("error", "no resolved tenant for request")));
+            return;
+        }
+        Map<String, Object> body = readBody(ex);
+        String queryText          = requireString(body, "query");
+        List<String> collections  = requireStringList(body, "collections");
+        int nResults              = optInt(body, "n_results", 10);
+        Map<String, Object> where = optMap(body, "where");
+
+        var results = pgRepo.hybridSearch(tenant, queryText, collections, nResults, where);
         HttpUtil.send(ex, 200, json(results));
     }
 

--- a/service/src/main/java/dev/nexus/service/http/VectorHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/VectorHandler.java
@@ -227,6 +227,11 @@ public final class VectorHandler implements HttpHandler {
                     "error", "hybrid-search endpoint not configured (no pgvector repository)")));
             return;
         }
+        // Defense-in-depth, deliberately redundant: AuthFilter rejects unauthenticated
+        // requests before this handler runs, and TenantScope.withTenant fails loud on a
+        // blank tenant. This guard exists because the pgvector path's tenant boundary is
+        // RLS (unlike the Chroma routes, where collection names encode scope) - if this
+        // handler is ever instantiated without the filter, it must refuse, not widen.
         String tenant = RequestContext.tenant();
         if (tenant == null || tenant.isBlank()) {
             HttpUtil.send(ex, 401, json(Map.of("error", "no resolved tenant for request")));

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -351,6 +351,56 @@ public final class PgVectorRepository {
     }
 
     /**
+     * RDR-155 Phase 3 - hybrid search: text signals ({@code tsvector} FTS + {@code pg_trgm}
+     * trigram similarity) gate the candidate set, vector cosine distance ranks it, fused in
+     * ONE query against the dispatched {@code chunks_<dim>} table. Replaces the engine's
+     * legacy FTS5 + Chroma two-path fusion.
+     *
+     * <p><strong>P3.1 skeleton (bead nexus-sbvg0): NOT IMPLEMENTED.</strong> Throws
+     * {@link UnsupportedOperationException} so the locked contract suite
+     * ({@code PgVectorHybridSearchContractTest}) compiles and runs RED; bead nexus-eap5l
+     * (P3.2) implements against that suite without changing it.
+     *
+     * <p>Contract pinned by the P3.1 suite (RDR-155 §Query path Hybrid search; aligned with
+     * the conexus xr7.8.7 fused reference that the xr7.8.9 go-live gate drives):
+     * <ul>
+     *   <li><strong>Text gate.</strong> A returned row must match at least one text signal:
+     *       {@code chunk_tsv @@ plainto_tsquery('english', queryText)} OR trigram similarity
+     *       between {@code queryText} and {@code chunk_text} above the implementation's
+     *       threshold. A row with NO text signal never appears, however close its vector -
+     *       semantic-only retrieval stays on {@link #search}. Zero text candidates returns
+     *       an empty list (no silent vector fallback).
+     *   <li><strong>Vector rank.</strong> Candidates are ordered by cosine distance
+     *       ({@code embedding <=> query}) ascending, {@code chash} ascending on ties - the
+     *       same ordering contract as {@link #search}.
+     *   <li><strong>Trigram rescue.</strong> The {@code pg_trgm} leg exists for queries the
+     *       english stemmer mishandles (typos, identifiers): a query that matches no FTS
+     *       lexeme still returns rows whose text is trigram-similar.
+     *   <li><strong>Same envelope as {@link #search}.</strong> Tenant RLS scope, per-dim
+     *       dispatch with mixed-dim fail-loud, {@code collection IN (...)} multi-collection
+     *       union, metadata {@code where} equality predicates ANDed with the text gate,
+     *       {@code nResults} cap, flat row shape ({@code id}, {@code content},
+     *       {@code distance}, {@code collection}, metadata flattened in).
+     * </ul>
+     *
+     * @param tenant          tenant principal for RLS scoping
+     * @param queryText       search query - used for BOTH the text gate and the
+     *                        server-side query embedding
+     * @param collectionNames collection names to search (filtered union, single query)
+     * @param nResults        maximum rows returned
+     * @param where           optional metadata equality predicates (ANDed); null/empty = none
+     * @return text-gated rows sorted by cosine distance ascending; same flat row shape
+     *         as {@link #search}
+     */
+    public List<Map<String, Object>> hybridSearch(String tenant, String queryText,
+                                                  List<String> collectionNames,
+                                                  int nResults,
+                                                  Map<String, Object> where) {
+        throw new UnsupportedOperationException(
+            "hybridSearch is implemented by RDR-155 P3.2 (bead nexus-eap5l)");
+    }
+
+    /**
      * Fetch specific chunk IDs from a collection.
      *
      * @return Chroma-style envelope {@code {ids: List<String>, documents: List<String>,

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -356,10 +356,9 @@ public final class PgVectorRepository {
      * ONE query against the dispatched {@code chunks_<dim>} table. Replaces the engine's
      * legacy FTS5 + Chroma two-path fusion.
      *
-     * <p><strong>P3.1 skeleton (bead nexus-sbvg0): NOT IMPLEMENTED.</strong> Throws
-     * {@link UnsupportedOperationException} so the locked contract suite
-     * ({@code PgVectorHybridSearchContractTest}) compiles and runs RED; bead nexus-eap5l
-     * (P3.2) implements against that suite without changing it.
+     * <p>Implemented by P3.2 (bead nexus-eap5l) against the locked P3.1 contract suite
+     * ({@code PgVectorHybridSearchContractTest} + {@code HybridParityIntegrationTest},
+     * bead nexus-sbvg0).
      *
      * <p>Contract pinned by the P3.1 suite (RDR-155 §Query path Hybrid search; aligned with
      * the conexus xr7.8.7 fused reference that the xr7.8.9 go-live gate drives):
@@ -388,15 +387,17 @@ public final class PgVectorRepository {
      *       filtered-recall risk the setting exists for (RDR-155 research resolution; the
      *       fixture-scale suite cannot detect its absence, the conexus xr7.8.9
      *       production-scale recall gate can).
-     *   <li><strong>Trigram gate calibration anchor (P3.2).</strong> The contract fixture
+     *   <li><strong>Trigram gate calibration anchor.</strong> The contract fixture
      *       pins the gate's discriminating range, not an exact threshold: the typo probe's
      *       candidate rows sit at word-similarity ≈ 0.9 (and plain trigram similarity
      *       ≈ 0.5 against these short fixture texts) and MUST pass; the no-signal rows sit
-     *       at ≈ 0.1 and MUST NOT. Any gate inside that window satisfies the suite - e.g.
-     *       {@code word_similarity(queryText, chunk_text) >= 0.6} (pg_trgm's default
-     *       {@code <%} threshold) or {@code similarity >= 0.3}. P3.2 records the final
-     *       operator + threshold choice; P3.G cross-checks it against the conexus xr7.8.9
-     *       production-scale calibration.
+     *       at ≈ 0.1 and MUST NOT. <strong>P3.2 decision (recorded):</strong>
+     *       {@code queryText <% chunk_text} (word_similarity) with
+     *       {@code SET LOCAL pg_trgm.word_similarity_threshold = 0.6} - the operator form
+     *       is gin_trgm_ops-indexable (vectors-002) where the function-call form is not;
+     *       word_similarity (vs plain similarity) does not dilute with chunk length; the
+     *       per-transaction pin removes cluster-config dependence. P3.G cross-checks this
+     *       against the conexus xr7.8.9 production-scale calibration.
      * </ul>
      *
      * @param tenant          tenant principal for RLS scoping
@@ -412,8 +413,82 @@ public final class PgVectorRepository {
                                                   List<String> collectionNames,
                                                   int nResults,
                                                   Map<String, Object> where) {
-        throw new UnsupportedOperationException(
-            "hybridSearch is implemented by RDR-155 P3.2 (bead nexus-eap5l)");
+        if (collectionNames == null || collectionNames.isEmpty()) {
+            return List.of();
+        }
+        int dim = dimForCollection(collectionNames.get(0));
+        for (String col : collectionNames) {
+            int colDim = dimForCollection(col);
+            if (colDim != dim) {
+                throw new IllegalArgumentException(
+                    "mixed dimensions in one hybrid-search call: '" + collectionNames.get(0)
+                    + "' is " + dim + "-dim but '" + col + "' is " + colDim
+                    + "-dim - one query vector cannot serve both spaces");
+            }
+        }
+
+        float[] queryVec = (queryRouter != null)
+                ? queryRouter.embedOneForCollection(collectionNames.get(0), queryText)
+                : queryEmbedder.embedOne(queryText);
+        if (queryVec.length != dim) {
+            throw new IllegalArgumentException(
+                "query embedder produced a " + queryVec.length
+                + "-dim vector but the collections dispatch to chunks_" + dim);
+        }
+
+        // Text gate: FTS lexeme match OR word-trigram similarity. The <% operator form
+        // (word_similarity(query, chunk_text) >= pg_trgm.word_similarity_threshold) is
+        // chosen over the explicit function call because only the operator family is
+        // supported by the gin_trgm_ops index (vectors-002); the threshold GUC is pinned
+        // per-transaction below so the gate never depends on cluster config.
+        // word_similarity (not plain similarity): plain similarity dilutes with
+        // chunk_text length and would silently kill the trgm leg on production-size
+        // chunks; word_similarity matches the query against the best continuous extent.
+        StringBuilder sql = new StringBuilder()
+            .append("SELECT chash, chunk_text, collection, metadata::text AS metadata_json,")
+            .append(" (embedding <=> ?::vector) AS distance")
+            .append(" FROM ").append(chunksTable(dim))
+            .append(" WHERE collection IN (").append(placeholders(collectionNames.size())).append(")")
+            .append(" AND (chunk_tsv @@ plainto_tsquery('english', ?) OR ? <% chunk_text)");
+        List<Object> binds = new ArrayList<>();
+        binds.add(vectorLiteral(queryVec));
+        binds.addAll(collectionNames);
+        binds.add(queryText);
+        binds.add(queryText);
+        if (where != null) {
+            for (Map.Entry<String, Object> e : where.entrySet()) {
+                sql.append(" AND metadata->>? = ?");
+                binds.add(e.getKey());
+                binds.add(String.valueOf(e.getValue()));
+            }
+        }
+        sql.append(" ORDER BY distance ASC, chash ASC LIMIT ?");
+        binds.add(nResults);
+
+        Result<Record> result = tenantScope.withTenant(tenant, ctx -> {
+            // Filtered-ANN recall: the text gate + RLS + where predicates narrow the
+            // candidate set even harder than plain search - keep HNSW scanning past
+            // ef_search (contract requirement; SET LOCAL is txn-scoped, pool-safe).
+            ctx.execute("SET LOCAL hnsw.iterative_scan = 'relaxed_order'");
+            // Trigram gate calibration (contract anchor): word_similarity >= 0.6,
+            // pg_trgm's default - typo-probe candidates sit at ~0.9 and pass, no-signal
+            // rows at ~0.1 do not. Pinned per-transaction so the gate is independent of
+            // cluster-level GUC configuration.
+            ctx.execute("SET LOCAL pg_trgm.word_similarity_threshold = 0.6");
+            return ctx.fetch(sql.toString(), binds.toArray());
+        });
+
+        List<Map<String, Object>> rows = new ArrayList<>(result.size());
+        for (Record rec : result) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("id",         rec.get("chash", String.class));
+            row.put("content",    rec.get("chunk_text", String.class));
+            row.put("distance",   rec.get("distance", Double.class));
+            row.put("collection", rec.get("collection", String.class));
+            row.putAll(fromJson(rec.get("metadata_json", String.class)));
+            rows.add(row);
+        }
+        return rows;
     }
 
     /**

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -400,14 +400,26 @@ public final class PgVectorRepository {
      *       against the conexus xr7.8.9 production-scale calibration.
      * </ul>
      *
+     * <p><strong>Seam B coverage note (P3.2):</strong> all current suites construct this
+     * repository through the plain-Embedder constructor ({@code queryRouter} null); the
+     * {@link EmbedderRouter#embedOneForCollection} branch of the hybrid query embed is
+     * exercised by the P3.E harness (nexus-h3ked) which wires the production router
+     * constructor - recorded there, not a silent gap.
+     *
+     * <p>No upper bound is applied to {@code nResults} by design: the result-size caps
+     * the Chroma path enforces are Chroma-imposed quotas (RDR-155 §Retire - they fall
+     * away with pgvector). Non-positive values fail loud.
+     *
      * @param tenant          tenant principal for RLS scoping
      * @param queryText       search query - used for BOTH the text gate and the
      *                        server-side query embedding
      * @param collectionNames collection names to search (filtered union, single query)
-     * @param nResults        maximum rows returned
+     * @param nResults        maximum rows returned; must be >= 1
      * @param where           optional metadata equality predicates (ANDed); null/empty = none
      * @return text-gated rows sorted by cosine distance ascending; same flat row shape
      *         as {@link #search}
+     * @throws IllegalArgumentException if {@code nResults < 1} (a non-positive LIMIT would
+     *                                  silently unbound the query: LIMIT -1 means no limit)
      */
     public List<Map<String, Object>> hybridSearch(String tenant, String queryText,
                                                   List<String> collectionNames,
@@ -415,6 +427,11 @@ public final class PgVectorRepository {
                                                   Map<String, Object> where) {
         if (collectionNames == null || collectionNames.isEmpty()) {
             return List.of();
+        }
+        if (nResults < 1) {
+            // LIMIT -1 is "no limit" in Postgres - a non-positive value would silently
+            // unbound the query instead of capping it.
+            throw new IllegalArgumentException("nResults must be >= 1, got " + nResults);
         }
         int dim = dimForCollection(collectionNames.get(0));
         for (String col : collectionNames) {

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -381,6 +381,22 @@ public final class PgVectorRepository {
      *       union, metadata {@code where} equality predicates ANDed with the text gate,
      *       {@code nResults} cap, flat row shape ({@code id}, {@code content},
      *       {@code distance}, {@code collection}, metadata flattened in).
+     *   <li><strong>Filtered-ANN session setting.</strong> The implementation MUST run
+     *       {@code SET LOCAL hnsw.iterative_scan = 'relaxed_order'} before the query,
+     *       exactly like {@link #search} - the text gate + RLS + {@code where} predicates
+     *       narrow the candidate set even harder than plain search, which is precisely the
+     *       filtered-recall risk the setting exists for (RDR-155 research resolution; the
+     *       fixture-scale suite cannot detect its absence, the conexus xr7.8.9
+     *       production-scale recall gate can).
+     *   <li><strong>Trigram gate calibration anchor (P3.2).</strong> The contract fixture
+     *       pins the gate's discriminating range, not an exact threshold: the typo probe's
+     *       candidate rows sit at word-similarity ≈ 0.9 (and plain trigram similarity
+     *       ≈ 0.5 against these short fixture texts) and MUST pass; the no-signal rows sit
+     *       at ≈ 0.1 and MUST NOT. Any gate inside that window satisfies the suite - e.g.
+     *       {@code word_similarity(queryText, chunk_text) >= 0.6} (pg_trgm's default
+     *       {@code <%} threshold) or {@code similarity >= 0.3}. P3.2 records the final
+     *       operator + threshold choice; P3.G cross-checks it against the conexus xr7.8.9
+     *       production-scale calibration.
      * </ul>
      *
      * @param tenant          tenant principal for RLS scoping

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -55,6 +55,9 @@
     <!-- Store 10: pgvector chunks tables + manifest collection column (bead nexus-mf447) -->
     <include file="db/changelog/vectors-001-baseline.xml"/>
 
+    <!-- Store 10b: trigram GIN indexes for the hybrid pg_trgm gate (bead nexus-eap5l) -->
+    <include file="db/changelog/vectors-002-trgm-index.xml"/>
+
     <!--
         Consolidated nexus_svc DML grants (bead nexus-net63) — runAlways="true".
         Must be LAST so all schema objects exist before grants are issued.

--- a/service/src/main/resources/db/changelog/vectors-002-trgm-index.xml
+++ b/service/src/main/resources/db/changelog/vectors-002-trgm-index.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    RDR-155 bead nexus-eap5l (P3.2) — trigram GIN indexes for the hybrid-search
+    pg_trgm gate leg.
+
+    The hybrid query gates candidates with
+        chunk_tsv @@ plainto_tsquery('english', q)  OR  q <% chunk_text
+    The <% (word_similarity) operator family is index-supported by gin_trgm_ops;
+    without this index the trgm leg sequential-scans chunk_text on every hybrid
+    query (invisible at fixture scale, a latency problem at production scale —
+    flagged by the P3.1 substantive-critic review, recorded on nexus-eap5l).
+    Postgres combines this index with the existing chunk_tsv GIN via BitmapOr,
+    keeping the OR-gate a single indexed query.
+
+    Per-dim DDL stays byte-identical modulo dim (locked RDR-155 invariant):
+    any changeset touching one chunks_<dim> table touches all three.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="vectors-002-1" author="nexus-eap5l">
+        <comment>Trigram GIN index on chunks_384.chunk_text for the hybrid pg_trgm gate</comment>
+        <sql>
+CREATE INDEX idx_chunks_384_trgm
+    ON nexus.chunks_384
+    USING GIN (chunk_text gin_trgm_ops);
+        </sql>
+        <rollback>DROP INDEX IF EXISTS nexus.idx_chunks_384_trgm</rollback>
+    </changeSet>
+
+    <changeSet id="vectors-002-2" author="nexus-eap5l">
+        <comment>Trigram GIN index on chunks_768.chunk_text for the hybrid pg_trgm gate</comment>
+        <sql>
+CREATE INDEX idx_chunks_768_trgm
+    ON nexus.chunks_768
+    USING GIN (chunk_text gin_trgm_ops);
+        </sql>
+        <rollback>DROP INDEX IF EXISTS nexus.idx_chunks_768_trgm</rollback>
+    </changeSet>
+
+    <changeSet id="vectors-002-3" author="nexus-eap5l">
+        <comment>Trigram GIN index on chunks_1024.chunk_text for the hybrid pg_trgm gate</comment>
+        <sql>
+CREATE INDEX idx_chunks_1024_trgm
+    ON nexus.chunks_1024
+    USING GIN (chunk_text gin_trgm_ops);
+        </sql>
+        <rollback>DROP INDEX IF EXISTS nexus.idx_chunks_1024_trgm</rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/main/resources/db/changelog/vectors-002-trgm-index.xml
+++ b/service/src/main/resources/db/changelog/vectors-002-trgm-index.xml
@@ -14,6 +14,14 @@
 
     Per-dim DDL stays byte-identical modulo dim (locked RDR-155 invariant):
     any changeset touching one chunks_<dim> table touches all three.
+
+    BUILD-WINDOW DECISION (P3.2 review): plain CREATE INDEX, not CONCURRENTLY,
+    deliberately. In every real deployment path this changeset runs BEFORE the
+    Phase 5 migration ETL populates the chunks tables — the GIN build happens on
+    EMPTY tables, so the ShareLock window is milliseconds and CONCURRENTLY's
+    no-transaction requirement (runInTransaction="false", non-rollbackable
+    partial states) buys nothing. If a future re-index on POPULATED tables is
+    ever needed, do it as a manual CREATE INDEX CONCURRENTLY outside Liquibase.
 -->
 <databaseChangeLog
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"

--- a/service/src/test/java/dev/nexus/service/DualRunHarnessIntegrationTest.java
+++ b/service/src/test/java/dev/nexus/service/DualRunHarnessIntegrationTest.java
@@ -76,10 +76,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       so the english-stemmer FTS candidate set equals plain word containment), and
  *       FTS-matching queries return non-empty results. The cross-engine FTS5
  *       comparand at fixture scale is {@code HybridParityIntegrationTest} (P3.1).
- *   <li><strong>Non-waivable p95 latency bound.</strong> p95 of the engine hybrid
- *       HTTP path over the query set must clear {@code nx.dualrun.p95.ms}. The
- *       assertion always runs — there is no skip flag; production tightens the bound,
- *       nothing can waive it.
+ *   <li><strong>p95 latency bound, always measured.</strong> p95 of the engine hybrid
+ *       HTTP path over the query set must clear {@code nx.dualrun.p95.ms}. No
+ *       dedicated skip flag exists — the assertion always runs and the latency is
+ *       always measured — but the bound itself is caller-parameterized (conexus owns
+ *       the production number; an absurd bound is the caller's responsibility, the
+ *       harness cannot police it).
  * </ul>
  *
  * <p><strong>Parameterization (conexus xr7.8.9 drives these):</strong>
@@ -88,13 +90,19 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   -Dnx.dualrun.queries=20         number of probe queries
  *   -Dnx.dualrun.k=10               top-k depth for recall
  *   -Dnx.dualrun.recall.min=1.0     minimum aggregate recall fraction
+ *   -Dnx.dualrun.recall.query.min=0.5  per-query overlap floor (fraction of k)
  *   -Dnx.dualrun.p95.ms=250         p95 bound for the hybrid HTTP path, milliseconds
  * </pre>
  *
  * <p>Fixture-load: the Chroma leg loads THROUGH the service
  * ({@code /v1/vectors/upsert-chunks}); the pgvector leg loads via the repository —
  * a pgvector HTTP write surface does not exist until the Phase 4a serving cutover,
- * and creating one here would be exactly the premature surface P4a gates.
+ * and creating one here would be exactly the premature surface P4a gates. The same
+ * boundary applies on the READ side: {@code /v1/vectors/search} routes to Chroma and
+ * no pgvector plain-ANN HTTP endpoint exists yet, so the recall test queries the
+ * pgvector leg via {@link PgVectorRepository#search} directly; only hybrid
+ * ({@code /v1/vectors/hybrid-search}) has an HTTP surface pre-P4a and it is driven
+ * through HTTP everywhere in this class.
  *
  * <p>Requires (same as {@code VectorIntegrationTest}): {@code chroma} CLI on PATH,
  * ONNX MiniLM files in the chromadb cache. Run via
@@ -118,6 +126,8 @@ class DualRunHarnessIntegrationTest {
     private static final int    K           = Integer.getInteger("nx.dualrun.k", 10);
     private static final double RECALL_MIN  =
         Double.parseDouble(System.getProperty("nx.dualrun.recall.min", "1.0"));
+    private static final double RECALL_QUERY_MIN =
+        Double.parseDouble(System.getProperty("nx.dualrun.recall.query.min", "0.5"));
     private static final long   P95_BOUND_MS =
         Long.getLong("nx.dualrun.p95.ms", 250L);
 
@@ -171,9 +181,16 @@ class DualRunHarnessIntegrationTest {
         try (Connection su = pg.createConnection("")) {
             Database db = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(su));
-            new Liquibase("db/changelog/db.changelog-master.xml",
-                          new ClassLoaderResourceAccessor(), db)
-                .update(new Contexts());
+            try (Liquibase liquibase = new Liquibase(
+                    "db/changelog/db.changelog-master.xml",
+                    new ClassLoaderResourceAccessor(), db)) {
+                liquibase.update(new Contexts());
+            }
+        }
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "ALTER ROLE nexus_svc SET search_path TO nexus, public");
         }
         try (Connection su = pg.createConnection("");
              var ps = su.prepareStatement(
@@ -324,6 +341,10 @@ class DualRunHarnessIntegrationTest {
 
     @Test
     void guard_corpusLoadedIdentically_bothStores() throws Exception {
+        assertThat(QUERY_COUNT)
+            .as("nx.dualrun.queries must be >= 1 — zero queries makes every dual-run "
+                + "test vacuous and the p95 index math degenerate")
+            .isGreaterThanOrEqualTo(1);
         assertThat(pgRepo.count(TENANT, PG_COL))
             .as("pgvector leg holds the full corpus").isEqualTo(CORPUS_SIZE);
         assertThat(chromaRepo.count(CHROMA_COL))
@@ -334,6 +355,30 @@ class DualRunHarnessIntegrationTest {
                 .as("every probe query must have at least one text candidate "
                     + "(query construction guarantees it)")
                 .isNotEmpty();
+        }
+    }
+
+    @Test
+    void guard_trgmIndexesExist_notJustMigrationOrder() throws Exception {
+        // Recorded bead obligation (nexus-h3ked): verify the trgm GIN indexes exist
+        // rather than trusting Liquibase migration order. Without them hybridSearch
+        // still returns CORRECT results via sequential scan — every other test here
+        // stays green while the production latency property silently evaporates.
+        try (Connection su = pg.createConnection("")) {
+            for (int dim : new int[] {384, 768, 1024}) {
+                try (var ps = su.prepareStatement(
+                         "SELECT 1 FROM pg_indexes WHERE schemaname = 'nexus'"
+                         + " AND indexname = ?")) {
+                    ps.setString(1, "idx_chunks_" + dim + "_trgm");
+                    try (var rs = ps.executeQuery()) {
+                        assertThat(rs.next())
+                            .as("trgm GIN index idx_chunks_%d_trgm must exist "
+                                + "(vectors-002) — its absence is invisible to the "
+                                + "correctness tests", dim)
+                            .isTrue();
+                    }
+                }
+            }
         }
     }
 
@@ -360,6 +405,14 @@ class DualRunHarnessIntegrationTest {
 
             Set<String> inter = new LinkedHashSet<>(pgTop);
             inter.retainAll(chromaTop);
+            // Per-query floor: an aggregate-only bound lets one catastrophically
+            // broken query hide inside an otherwise-high average once production
+            // bounds drop recall.min below 1.0. Floor default 0.5 of k; conexus
+            // coordinates the production floor with its aggregate bound.
+            assertThat(inter.size())
+                .as("per-query recall floor for '%s': overlap %d/%d must be >= "
+                    + "ceil(k * %s)", q, inter.size(), K, RECALL_QUERY_MIN)
+                .isGreaterThanOrEqualTo((int) Math.ceil(K * RECALL_QUERY_MIN));
             totalOverlap  += inter.size();
             totalPossible += K;
             perQuery.add(q + "=" + inter.size() + "/" + K);
@@ -421,6 +474,11 @@ class DualRunHarnessIntegrationTest {
 
             String[] terms = q.split(" ");
             for (String id : hybridIds) {
+                assertThat(corpus)
+                    .as("hybrid row '%s' for query '%s' was never inserted by this "
+                        + "harness — an unknown ID means a cross-tenant leak or a "
+                        + "stale store, not a text-gate question", id, q)
+                    .containsKey(id);
                 Set<String> words = Set.of(corpus.get(id).split(" "));
                 boolean anyTerm = false;
                 for (String t : terms) {
@@ -468,7 +526,8 @@ class DualRunHarnessIntegrationTest {
         assertThat(p95)
             .as("p95 of the engine hybrid HTTP path over %d samples must be <= %dms "
                 + "(engine-side default; conexus xr7.8.9 sets the production bound via "
-                + "-Dnx.dualrun.p95.ms). This assertion has no skip flag.",
+                + "-Dnx.dualrun.p95.ms). No dedicated skip flag exists — the bound is "
+                + "caller-parameterized, the measurement is not.",
                 sorted.size(), P95_BOUND_MS)
             .isLessThanOrEqualTo(P95_BOUND_MS);
     }

--- a/service/src/test/java/dev/nexus/service/DualRunHarnessIntegrationTest.java
+++ b/service/src/test/java/dev/nexus/service/DualRunHarnessIntegrationTest.java
@@ -1,0 +1,475 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.nexus.service.db.TenantScope;
+import dev.nexus.service.db.TokenHashing;
+import dev.nexus.service.vectors.ChromaRestClient;
+import dev.nexus.service.vectors.EmbedderRouter;
+import dev.nexus.service.vectors.LocalChromaServer;
+import dev.nexus.service.vectors.OnnxEmbedder;
+import dev.nexus.service.vectors.PgVectorRepository;
+import dev.nexus.service.vectors.VectorRepository;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RDR-155 P3.E (bead nexus-h3ked): engine-side DUAL-RUN harness — the test-invocable
+ * validation seam for the conexus xr7.8.9 go-live gates.
+ *
+ * <p><strong>Scope boundary (recorded on the bead):</strong> this harness is
+ * corpus-agnostic and its bounds are engine-side DEFAULTS. The production-scale
+ * filtered-recall and hybrid-parity GO-LIVE GATES are owned by conexus (xr7.8.9):
+ * conexus supplies the production corpus and the go/no-go numeric bounds via the
+ * system properties below; this class supplies the seam and the harness mechanics.
+ * Generalizes the conexus slice spike ({@code conexus/spikes/pgvector-recall/})
+ * THROUGH the service.
+ *
+ * <p><strong>What it proves</strong>:
+ * <ul>
+ *   <li><strong>Verbatim-identical vectors, Seam B wiring.</strong> ONE
+ *       {@link OnnxEmbedder} behind production-shaped {@link EmbedderRouter}s
+ *       (document + query) feeds BOTH stores: the Chroma {@link VectorRepository}
+ *       (router constructor) and the {@link PgVectorRepository} (router constructor —
+ *       this closes the P3.2 review deferral: the {@code embedOneForCollection}
+ *       hybrid-query branch is exercised here).
+ *   <li><strong>Exact-count recall.</strong> Per query, the pgvector top-k ID set vs
+ *       the Chroma baseline top-k ID set; per-query overlap counted exactly and the
+ *       aggregate recall fraction asserted against {@code nx.dualrun.recall.min}
+ *       (default 1.0 — identical vectors, cosine both sides, fixture-default scale
+ *       where HNSW is effectively exact).
+ *   <li><strong>HTTP seam fidelity.</strong> {@code POST /v1/vectors/hybrid-search}
+ *       returns exactly what {@link PgVectorRepository#hybridSearch} returns — the
+ *       service path (auth, server-resolved tenant, RLS) adds and loses nothing.
+ *   <li><strong>Hybrid-parity hook.</strong> Every hybrid result is inside the
+ *       exactly-computable text-candidate oracle (the corpus uses exact word forms,
+ *       so the english-stemmer FTS candidate set equals plain word containment), and
+ *       FTS-matching queries return non-empty results. The cross-engine FTS5
+ *       comparand at fixture scale is {@code HybridParityIntegrationTest} (P3.1).
+ *   <li><strong>Non-waivable p95 latency bound.</strong> p95 of the engine hybrid
+ *       HTTP path over the query set must clear {@code nx.dualrun.p95.ms}. The
+ *       assertion always runs — there is no skip flag; production tightens the bound,
+ *       nothing can waive it.
+ * </ul>
+ *
+ * <p><strong>Parameterization (conexus xr7.8.9 drives these):</strong>
+ * <pre>
+ *   -Dnx.dualrun.corpus.size=200    documents generated (deterministic, seeded)
+ *   -Dnx.dualrun.queries=20         number of probe queries
+ *   -Dnx.dualrun.k=10               top-k depth for recall
+ *   -Dnx.dualrun.recall.min=1.0     minimum aggregate recall fraction
+ *   -Dnx.dualrun.p95.ms=250         p95 bound for the hybrid HTTP path, milliseconds
+ * </pre>
+ *
+ * <p>Fixture-load: the Chroma leg loads THROUGH the service
+ * ({@code /v1/vectors/upsert-chunks}); the pgvector leg loads via the repository —
+ * a pgvector HTTP write surface does not exist until the Phase 4a serving cutover,
+ * and creating one here would be exactly the premature surface P4a gates.
+ *
+ * <p>Requires (same as {@code VectorIntegrationTest}): {@code chroma} CLI on PATH,
+ * ONNX MiniLM files in the chromadb cache. Run via
+ * {@code mvn test -Dtest=DualRunHarnessIntegrationTest -Dtest.excluded.groups="" -Dgroups=integration}.
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DualRunHarnessIntegrationTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String TOKEN  = "dualrun-harness-token-0123456789abcdef";
+    private static final String TENANT = "dualrun-tenant";
+
+    private static final String PG_COL     = "knowledge__dualrun__minilm-l6-v2-384__v1";
+    private static final String CHROMA_COL = "knowledge__dualrun__all-minilm-l6-v2__v1";
+
+    // Engine-side defaults; conexus xr7.8.9 overrides via -D system properties.
+    private static final int    CORPUS_SIZE = Integer.getInteger("nx.dualrun.corpus.size", 200);
+    private static final int    QUERY_COUNT = Integer.getInteger("nx.dualrun.queries", 20);
+    private static final int    K           = Integer.getInteger("nx.dualrun.k", 10);
+    private static final double RECALL_MIN  =
+        Double.parseDouble(System.getProperty("nx.dualrun.recall.min", "1.0"));
+    private static final long   P95_BOUND_MS =
+        Long.getLong("nx.dualrun.p95.ms", 250L);
+
+    /**
+     * Word bank for deterministic corpus generation. All entries are single english
+     * words with DISTINCT stems and exact-form usage (no morphological variants), so
+     * the english-stemmer FTS candidate set for any two-word query equals plain word
+     * containment — an exactly-computable oracle without a second FTS engine.
+     */
+    private static final List<String> WORD_BANK = List.of(
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+        "india", "juliet", "kilo", "lima", "mike", "november", "oscar", "papa",
+        "quebec", "romeo", "sierra", "tango", "uniform", "victor", "whiskey",
+        "yankee", "zulu", "cobalt", "quartz", "falcon", "harbor", "lantern",
+        "marble", "nickel", "orchid", "pylon", "quiver", "raven", "saddle",
+        "timber", "vortex", "willow");
+
+    PostgreSQLContainer<?> pg;
+    HikariDataSource       svcDs;
+    TenantScope            tenantScope;
+    OnnxEmbedder           onnx;
+    EmbedderRouter         docRouter;
+    EmbedderRouter         queryRouter;
+    PgVectorRepository     pgRepo;
+    LocalChromaServer      localChroma;
+    Path                   chromaData;
+    VectorRepository       chromaRepo;
+    NexusService           service;
+    HttpClient             http;
+
+    /** Generated corpus: id → text (insertion-ordered, deterministic). */
+    final Map<String, String> corpus = new LinkedHashMap<>();
+    /** Probe queries (two exact corpus words each, deterministic). */
+    final List<String> queries = new ArrayList<>();
+
+    @BeforeAll
+    void startAll() throws Exception {
+        generateCorpusAndQueries();
+
+        // --- pgvector substrate.
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
+                "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            Database db = DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(su));
+            new Liquibase("db/changelog/db.changelog-master.xml",
+                          new ClassLoaderResourceAccessor(), db)
+                .update(new Contexts());
+        }
+        try (Connection su = pg.createConnection("");
+             var ps = su.prepareStatement(
+                 "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label)"
+                 + " VALUES (?, ?, ?) ON CONFLICT (token_hash) DO NOTHING")) {
+            su.setAutoCommit(true);
+            ps.setString(1, TokenHashing.sha256Hex(TOKEN));
+            ps.setString(2, TENANT);
+            ps.setString(3, "dualrun-harness");
+            ps.executeUpdate();
+        }
+        var cfg = new HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername("nexus_svc");
+        cfg.setPassword("nexus_svc_pass");
+        cfg.setMaximumPoolSize(5);
+        cfg.setAutoCommit(true);
+        svcDs = new HikariDataSource(cfg);
+        tenantScope = new TenantScope(svcDs);
+
+        // --- ONE embedder, production-shaped routers, BOTH repos on the router
+        //     constructor (Seam B). Local-mode router: everything routes to ONNX.
+        onnx        = new OnnxEmbedder();
+        docRouter   = new EmbedderRouter(onnx, "document");
+        queryRouter = new EmbedderRouter(onnx, "query");
+        pgRepo      = new PgVectorRepository(tenantScope, docRouter, queryRouter);
+
+        String chromaBinary = LocalChromaServer.findChromaBinary();
+        chromaData = Files.createTempDirectory("dualrun-chroma-");
+        int chromaPort = LocalChromaServer.findFreePort();
+        localChroma = new LocalChromaServer(chromaBinary, chromaData.toString(), chromaPort);
+        localChroma.start();
+        chromaRepo = new VectorRepository(docRouter, queryRouter,
+                                          ChromaRestClient.local("127.0.0.1", chromaPort));
+
+        service = new NexusService(0, TOKEN, svcDs, chromaRepo, docRouter, pgRepo);
+        service.start();
+        http = HttpClient.newHttpClient();
+
+        // --- Fixture-load. Chroma THROUGH the service; pgvector via the repository
+        //     (no pgvector HTTP write surface until Phase 4a — deliberate).
+        List<String> ids   = new ArrayList<>(corpus.keySet());
+        List<String> texts = new ArrayList<>(corpus.values());
+        int batch = 100;   // under the Chroma MAX_RECORDS_PER_WRITE=300 quota
+        for (int i = 0; i < ids.size(); i += batch) {
+            int end = Math.min(i + batch, ids.size());
+            List<Map<String, Object>> metas = new ArrayList<>();
+            for (int j = i; j < end; j++) metas.add(Map.of());
+            var resp = post("/v1/vectors/upsert-chunks", Map.of(
+                "collection", CHROMA_COL,
+                "ids",        ids.subList(i, end),
+                "documents",  texts.subList(i, end),
+                "metadatas",  metas));
+            assertThat(resp.statusCode())
+                .as("chroma fixture-load batch %d..%d through the service", i, end)
+                .isEqualTo(200);
+            pgRepo.upsertChunks(TENANT, PG_COL,
+                ids.subList(i, end), texts.subList(i, end), metas);
+        }
+    }
+
+    @AfterAll
+    void stopAll() throws Exception {
+        if (service     != null) service.stop();
+        if (localChroma != null) localChroma.stop();
+        if (chromaData  != null) {
+            try (var walk = Files.walk(chromaData)) {
+                walk.sorted(java.util.Comparator.reverseOrder())
+                    .forEach(p -> p.toFile().delete());
+            }
+        }
+        if (onnx        != null) onnx.close();
+        if (svcDs       != null) svcDs.close();
+        if (pg          != null) pg.stop();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Deterministic corpus + queries
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Seeded generation: each document is 8-12 distinct bank words plus a unique
+     * discriminator token; each query is the first two words of a distinct document
+     * (guaranteeing at least one FTS match per query). Seed fixed — the corpus is
+     * identical on every run at the same {@code corpus.size}.
+     */
+    private void generateCorpusAndQueries() {
+        Random rnd = new Random(20260609L);
+        for (int d = 0; d < CORPUS_SIZE; d++) {
+            int len = 8 + rnd.nextInt(5);
+            Set<String> words = new LinkedHashSet<>();
+            while (words.size() < len) {
+                words.add(WORD_BANK.get(rnd.nextInt(WORD_BANK.size())));
+            }
+            String id = String.format("dr-%05d", d);
+            corpus.put(id, String.join(" ", words) + " doc" + d);
+        }
+        List<String> docTexts = new ArrayList<>(corpus.values());
+        for (int q = 0; q < QUERY_COUNT; q++) {
+            String[] w = docTexts.get((q * 7) % docTexts.size()).split(" ");
+            queries.add(w[0] + " " + w[1]);
+        }
+    }
+
+    /** Exact text-candidate oracle: corpus IDs whose text contains EVERY query word. */
+    private Set<String> textCandidates(String query) {
+        String[] terms = query.split(" ");
+        Set<String> out = new LinkedHashSet<>();
+        for (var e : corpus.entrySet()) {
+            Set<String> words = Set.of(e.getValue().split(" "));
+            boolean all = true;
+            for (String t : terms) {
+                if (!words.contains(t)) { all = false; break; }
+            }
+            if (all) out.add(e.getKey());
+        }
+        return out;
+    }
+
+    // ---------------------------------------------------------------------------
+    // HTTP helpers
+    // ---------------------------------------------------------------------------
+
+    private HttpResponse<String> post(String path, Object body) throws Exception {
+        var req = HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + service.getPort() + path))
+            .header("Authorization", "Bearer " + TOKEN)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)))
+            .build();
+        return http.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> postRows(String path, Object body) throws Exception {
+        var resp = post(path, body);
+        assertThat(resp.statusCode()).as("%s must return 200", path).isEqualTo(200);
+        return MAPPER.readValue(resp.body(), List.class);
+    }
+
+    private static List<String> ids(List<Map<String, Object>> rows) {
+        return rows.stream().map(r -> (String) r.get("id")).toList();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Guards
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void guard_corpusLoadedIdentically_bothStores() throws Exception {
+        assertThat(pgRepo.count(TENANT, PG_COL))
+            .as("pgvector leg holds the full corpus").isEqualTo(CORPUS_SIZE);
+        assertThat(chromaRepo.count(CHROMA_COL))
+            .as("chroma leg holds the full corpus").isEqualTo(CORPUS_SIZE);
+        assertThat(queries).hasSize(QUERY_COUNT);
+        for (String q : queries) {
+            assertThat(textCandidates(q))
+                .as("every probe query must have at least one text candidate "
+                    + "(query construction guarantees it)")
+                .isNotEmpty();
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Dual-run: exact-count recall (pgvector vs Chroma baseline)
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void dualRun_exactCountRecall_pgVsChromaBaseline() throws Exception {
+        int totalOverlap = 0;
+        int totalPossible = 0;
+        List<String> perQuery = new ArrayList<>();
+
+        for (String q : queries) {
+            List<Map<String, Object>> chromaRows = postRows("/v1/vectors/search",
+                Map.of("query", q, "collections", List.of(CHROMA_COL), "n_results", K));
+            List<Map<String, Object>> pgRows =
+                pgRepo.search(TENANT, q, List.of(PG_COL), K, null);
+
+            Set<String> chromaTop = new LinkedHashSet<>(ids(chromaRows));
+            Set<String> pgTop     = new LinkedHashSet<>(ids(pgRows));
+            assertThat(chromaTop).as("chroma baseline returns k rows for '%s'", q).hasSize(K);
+            assertThat(pgTop).as("pgvector returns k rows for '%s'", q).hasSize(K);
+
+            Set<String> inter = new LinkedHashSet<>(pgTop);
+            inter.retainAll(chromaTop);
+            totalOverlap  += inter.size();
+            totalPossible += K;
+            perQuery.add(q + "=" + inter.size() + "/" + K);
+        }
+
+        double recall = (double) totalOverlap / totalPossible;
+        assertThat(recall)
+            .as("aggregate exact-count recall (pgvector top-%d vs Chroma baseline) over "
+                + "%d queries must be >= %s. Per-query: %s",
+                K, queries.size(), RECALL_MIN, perQuery)
+            .isGreaterThanOrEqualTo(RECALL_MIN);
+    }
+
+    // ---------------------------------------------------------------------------
+    // HTTP seam fidelity: /hybrid-search == repository hybridSearch
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void hybridHttp_matchesRepositoryHybrid_exactly() throws Exception {
+        for (String q : queries) {
+            List<String> httpIds = ids(postRows("/v1/vectors/hybrid-search",
+                Map.of("query", q, "collections", List.of(PG_COL), "n_results", K)));
+            List<String> repoIds = ids(
+                pgRepo.hybridSearch(TENANT, q, List.of(PG_COL), K, null));
+
+            assertThat(httpIds)
+                .as("the HTTP seam must return exactly the repository's fused list for "
+                    + "'%s' — the service path (auth, tenant resolution, RLS) adds and "
+                    + "loses nothing", q)
+                .containsExactlyElementsOf(repoIds);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Hybrid-parity hook: results inside the exact text-candidate oracle
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void hybridHttp_resultsInsideTextSignalOracle() throws Exception {
+        // Two-level oracle. (1) SOUNDNESS: every hybrid row must share at least one
+        // exact query word — a row with ZERO query words has no plausible text signal
+        // (word_similarity of a two-word query cannot reach the 0.6 gate against a text
+        // containing neither word) and would mean the text gate leaked vector-only
+        // rows. NOTE: exact both-word containment is deliberately NOT required — the
+        // trgm leg legitimately admits near-miss rows that contain one query word plus
+        // a trigram-similar neighbour (observed at this corpus scale: word_similarity
+        // crosses 0.6 with one exact word + partial overlap on the other).
+        // (2) COMPLETENESS: every exact both-word candidate must rank if room remains
+        // (the fused list is only allowed to omit an exact candidate when k is full).
+        for (String q : queries) {
+            Set<String> exact = textCandidates(q);
+            List<String> hybridIds = ids(postRows("/v1/vectors/hybrid-search",
+                Map.of("query", q, "collections", List.of(PG_COL), "n_results", K)));
+
+            assertThat(hybridIds)
+                .as("hybrid results for '%s' must be non-empty (the query is built from "
+                    + "a document's own words)", q)
+                .isNotEmpty();
+
+            String[] terms = q.split(" ");
+            for (String id : hybridIds) {
+                Set<String> words = Set.of(corpus.get(id).split(" "));
+                boolean anyTerm = false;
+                for (String t : terms) {
+                    if (words.contains(t)) { anyTerm = true; break; }
+                }
+                assertThat(anyTerm)
+                    .as("hybrid row %s for query '%s' contains NO query word — the "
+                        + "text gate leaked a vector-only row", id, q)
+                    .isTrue();
+            }
+
+            if (hybridIds.size() < K) {
+                assertThat(hybridIds)
+                    .as("the fused list for '%s' has room (%d < k=%d) — every exact "
+                        + "both-word candidate must be present", q, hybridIds.size(), K)
+                    .containsAll(exact);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Non-waivable p95 latency bound on the engine hybrid HTTP path
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void hybridHttp_p95LatencyBound_nonWaivable() throws Exception {
+        // Warm-up pass (JIT, pool, embedder) — excluded from measurement.
+        for (String q : queries) {
+            postRows("/v1/vectors/hybrid-search",
+                Map.of("query", q, "collections", List.of(PG_COL), "n_results", K));
+        }
+
+        List<Long> samplesMs = new ArrayList<>();
+        for (int round = 0; round < 3; round++) {
+            for (String q : queries) {
+                long t0 = System.nanoTime();
+                postRows("/v1/vectors/hybrid-search",
+                    Map.of("query", q, "collections", List.of(PG_COL), "n_results", K));
+                samplesMs.add((System.nanoTime() - t0) / 1_000_000L);
+            }
+        }
+        List<Long> sorted = samplesMs.stream().sorted().toList();
+        long p95 = sorted.get((int) Math.ceil(sorted.size() * 0.95) - 1);
+
+        assertThat(p95)
+            .as("p95 of the engine hybrid HTTP path over %d samples must be <= %dms "
+                + "(engine-side default; conexus xr7.8.9 sets the production bound via "
+                + "-Dnx.dualrun.p95.ms). This assertion has no skip flag.",
+                sorted.size(), P95_BOUND_MS)
+            .isLessThanOrEqualTo(P95_BOUND_MS);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/HybridParityIntegrationTest.java
+++ b/service/src/test/java/dev/nexus/service/HybridParityIntegrationTest.java
@@ -157,6 +157,7 @@ class HybridParityIntegrationTest {
     PgVectorRepository     pgRepo;
     LocalChromaServer      localChroma;
     VectorRepository       chromaRepo;
+    Path                   chromaData;
     Connection             sqlite;   // in-memory FTS5 lives and dies with this connection
 
     @BeforeAll
@@ -208,7 +209,7 @@ class HybridParityIntegrationTest {
 
         // --- Legacy vector leg: live local Chroma (cosine space via ChromaRestClient).
         String chromaBinary = LocalChromaServer.findChromaBinary();
-        Path chromaData = Files.createTempDirectory("hybrid-parity-chroma-");
+        chromaData = Files.createTempDirectory("hybrid-parity-chroma-");
         int chromaPort = LocalChromaServer.findFreePort();
         localChroma = new LocalChromaServer(chromaBinary, chromaData.toString(), chromaPort);
         localChroma.start();
@@ -242,6 +243,12 @@ class HybridParityIntegrationTest {
     void stopAll() throws Exception {
         if (sqlite      != null) sqlite.close();
         if (localChroma != null) localChroma.stop();
+        if (chromaData  != null) {
+            try (var walk = Files.walk(chromaData)) {
+                walk.sorted(java.util.Comparator.reverseOrder())
+                    .forEach(p -> p.toFile().delete());
+            }
+        }
         if (onnx        != null) onnx.close();
         if (svcDs       != null) svcDs.close();
         if (pg          != null) pg.stop();
@@ -333,24 +340,32 @@ class HybridParityIntegrationTest {
         // If a future corpus edit creates a near-tie between candidate rows, ordered
         // parity assertions would become float-noise-flaky. Catch it here by name
         // (conexus xr7.8.7 min-gap guard, runtime form — embeddings are real, not
-        // hand-authored).
+        // hand-authored). Both legs are checked: pgvector ranks in float8, Chroma in
+        // float32 — a near-tie in EITHER domain breaks ordered parity.
         for (var probe : List.of(Map.entry(QA, QA_LEGACY_CANDIDATES),
                                  Map.entry(QB, QB_ENGINE_CANDIDATES))) {
-            List<Map<String, Object>> rows =
+            List<Map<String, Object>> pgRows =
                 pgRepo.search(TENANT, probe.getKey(), List.of(PG_COL), CORPUS.size(), null);
-            List<Double> candidateDists = rows.stream()
-                .filter(r -> probe.getValue().contains((String) r.get("id")))
-                .map(r -> ((Number) r.get("distance")).doubleValue())
-                .toList();
-            assertThat(candidateDists)
-                .as("all candidates of %s must rank", probe.getKey())
-                .hasSize(probe.getValue().size());
-            for (int i = 1; i < candidateDists.size(); i++) {
-                assertThat(candidateDists.get(i) - candidateDists.get(i - 1))
-                    .as("consecutive candidate distances for query '%s' must be separated "
-                        + "by > 1e-4 — a near-tie makes ordered parity flaky; reword the "
-                        + "fixture text", probe.getKey())
-                    .isGreaterThan(1e-4);
+            List<Map<String, Object>> chromaRows =
+                chromaRepo.search(probe.getKey(), List.of(CHROMA_COL), CORPUS.size(), null);
+            for (var leg : List.of(Map.entry("pgvector", pgRows),
+                                   Map.entry("chroma", chromaRows))) {
+                List<Double> candidateDists = leg.getValue().stream()
+                    .filter(r -> probe.getValue().contains((String) r.get("id")))
+                    .map(r -> ((Number) r.get("distance")).doubleValue())
+                    .toList();
+                assertThat(candidateDists)
+                    .as("all candidates of '%s' must rank on the %s leg",
+                        probe.getKey(), leg.getKey())
+                    .hasSize(probe.getValue().size());
+                for (int i = 1; i < candidateDists.size(); i++) {
+                    assertThat(candidateDists.get(i) - candidateDists.get(i - 1))
+                        .as("consecutive candidate distances for query '%s' on the %s leg "
+                            + "must be separated by > 1e-4 — a near-tie makes ordered "
+                            + "parity flaky; reword the fixture text",
+                            probe.getKey(), leg.getKey())
+                        .isGreaterThan(1e-4);
+                }
             }
         }
     }
@@ -438,9 +453,14 @@ class HybridParityIntegrationTest {
 
         assertThat(overlapA).as("aligned-query overlap is exactly 1.0").isEqualTo(1.0);
         assertThat(overlapB).as("stemmer-delta overlap is exactly 1/3").isEqualTo(1.0 / 3.0);
-        assertThat((overlapA + overlapB) / 2.0)
-            .as("fixture-scale aggregate overlap (exact: 2/3) must clear the seam "
-                + "threshold %s", PARITY_OVERLAP_THRESHOLD)
+        double aggregate = (overlapA + overlapB) / 2.0;
+        assertThat(aggregate)
+            .as("fixture-scale aggregate overlap is EXACTLY 2/3 — an inequality here "
+                + "would mask partial divergence (exact-assertion rule)")
+            .isEqualTo(2.0 / 3.0);
+        assertThat(aggregate)
+            .as("the exact aggregate clears the named seam threshold %s",
+                PARITY_OVERLAP_THRESHOLD)
             .isGreaterThanOrEqualTo(PARITY_OVERLAP_THRESHOLD);
     }
 }

--- a/service/src/test/java/dev/nexus/service/HybridParityIntegrationTest.java
+++ b/service/src/test/java/dev/nexus/service/HybridParityIntegrationTest.java
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.nexus.service.db.TenantScope;
+import dev.nexus.service.vectors.ChromaRestClient;
+import dev.nexus.service.vectors.LocalChromaServer;
+import dev.nexus.service.vectors.OnnxEmbedder;
+import dev.nexus.service.vectors.PgVectorRepository;
+import dev.nexus.service.vectors.VectorRepository;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RDR-155 P3.1 (bead nexus-sbvg0): hybrid-parity seam — engine pgvector hybrid vs the
+ * legacy FTS5 + Chroma two-path fusion, fixture scale.
+ *
+ * <p><strong>TDD-RED:</strong> the parity tests call
+ * {@link PgVectorRepository#hybridSearch} and fail with
+ * {@link UnsupportedOperationException} until bead nexus-eap5l (P3.2) implements it.
+ * The fixture guards (corpus seeding, legacy-leg candidate sets, tie margins) are
+ * green now — they verify the COMPARAND is correctly constructed before the engine
+ * side exists, exactly like the conexus xr7.8.7 fixture guards.
+ *
+ * <p><strong>The comparand is the real legacy engines, not a reimplementation:</strong>
+ * <ul>
+ *   <li><strong>Vector leg</strong> — the still-runnable Chroma {@link VectorRepository}
+ *       against a live local Chroma server (cosine space), embedding server-side with
+ *       the SAME {@link OnnxEmbedder} instance as the pgvector leg, so both stores hold
+ *       verbatim-identical vectors (OnnxEmbedder is bit-exactly deterministic; see
+ *       {@code VectorIntegrationTest}). Phase 4a may not retire this path before the
+ *       P3.G gate runs this suite green (plan invariant 3).
+ *   <li><strong>FTS leg</strong> — SQLite FTS5 with the DEFAULT unicode61 tokenizer via
+ *       sqlite-jdbc: the same SQLite FTS5 C library the Python T2 path uses
+ *       ({@code migrations.py} passes no {@code tokenize=} option, so unicode61 is the
+ *       live legacy config).
+ *   <li><strong>Legacy fusion</strong> — FTS5-candidate set ranked by Chroma cosine
+ *       distance: the gate-then-rank isomorphism of the engine's hybrid, so the measured
+ *       delta is exactly the engine delta (english-stemmer tsvector + pg_trgm + pgvector
+ *       vs unicode61 FTS5 + Chroma).
+ * </ul>
+ *
+ * <p><strong>Expected-delta classes pinned exactly</strong> (RDR-155 locked anchor,
+ * {@code 152-FTS-tokenizer-DECISION} Option B):
+ * <ul>
+ *   <li>Aligned query (exact word forms both sides): candidate sets identical, vectors
+ *       identical, cosine both sides — ordered top-k EQUAL (overlap 1.0).
+ *   <li>Stemmer-divergent query: english matches morphological variants unicode61 cannot;
+ *       the legacy candidate set is a strict subset. Overlap drops to an exactly
+ *       derivable value — asserted as {@code ==}, not {@code >=} noise.
+ *   <li>Typo query: pg_trgm rescues, FTS5 is typo-blind — a capability delta (legacy
+ *       empty, engine non-empty), excluded from the overlap aggregate.
+ * </ul>
+ *
+ * <p>The aggregate overlap threshold here is the fixture-scale seam assertion this bead
+ * owns. The production-scale go/no-go bounds and corpus are conexus-owned (xr7.8.9);
+ * the engine-side dual-run harness through the /v1/vectors HTTP seam is P3.E
+ * (nexus-h3ked). Do not encode production bounds here.
+ *
+ * <p>Requires (same as {@code VectorIntegrationTest}): {@code chroma} CLI on PATH (or
+ * NX_CHROMA_BINARY), ONNX MiniLM model files in the chromadb cache. Run via
+ * {@code mvn test -Dgroups=integration}.
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HybridParityIntegrationTest {
+
+    private static final String SVC_ROLE = "svc_parity_test";
+    private static final String SVC_PASS = "svc_parity_test_pass";
+    private static final String TENANT   = "parity-tenant";
+
+    /** pgvector leg: dispatches to chunks_384 (OnnxEmbedder MiniLM is 384-dim). */
+    private static final String PG_COL     = "knowledge__parity__minilm-l6-v2-384__v1";
+    /** Chroma leg: separate store, four-segment name, cosine space. */
+    private static final String CHROMA_COL = "knowledge__parity__all-minilm-l6-v2__v1";
+
+    private static final int K = 5;
+
+    /**
+     * Fixture-scale aggregate overlap threshold (mean Jaccard over the comparable
+     * queries QA + QB). Exact per-query values are asserted separately; this constant
+     * is the bead's named "overlap >= threshold" seam assertion. Production-scale
+     * thresholds are conexus xr7.8.9's to set, not this suite's.
+     */
+    private static final double PARITY_OVERLAP_THRESHOLD = 0.5;
+
+    // ---------------------------------------------------------------------------
+    // Corpus — hand-authored so tokenizer behaviour is exactly analyzable.
+    // Vocabulary domains are disjoint: the postgres-transaction rows (QA), the
+    // indexing rows (QB), and fillers share no stem-colliding words.
+    // ---------------------------------------------------------------------------
+
+    private static final Map<String, String> CORPUS = new LinkedHashMap<>();
+    static {
+        // QA domain — exact word forms 'postgres' + 'transaction' (no variants anywhere
+        // else in the corpus): english and unicode61 derive the SAME candidate set.
+        CORPUS.put("par-t1", "postgres transaction semantics with mvcc");
+        CORPUS.put("par-t2", "a postgres transaction can roll back");
+        CORPUS.put("par-t3", "postgres transaction isolation levels explained");
+        // QB domain — morphological variants: 'indexing strategies' / 'index strategy' /
+        // 'indexed strategies'. The english stemmer maps all three to 'index' &
+        // 'strategi'; unicode61 FTS5 matches only the exact tokens.
+        CORPUS.put("par-u1", "indexing strategies for large corpora");
+        CORPUS.put("par-u2", "an index strategy for btree lookups");
+        CORPUS.put("par-u3", "indexed strategies guide for analytics");
+        // Fillers — distinct vocabulary, never text-match any probe query.
+        CORPUS.put("par-f1", "chroma etl pipeline with rollback flag");
+        CORPUS.put("par-f2", "tokenizer divergence between engines");
+        CORPUS.put("par-f3", "hybrid retrieval fusion ranking");
+        CORPUS.put("par-f4", "cosine similarity in embedding spaces");
+    }
+
+    /** QA — aligned: both tokenizers match exactly {t1, t2, t3}. */
+    private static final String QA = "postgres transaction";
+    private static final Set<String> QA_LEGACY_CANDIDATES = Set.of("par-t1", "par-t2", "par-t3");
+
+    /** QB — stemmer-divergent: english matches {u1, u2, u3}, unicode61 only {u1}. */
+    private static final String QB = "indexing strategies";
+    private static final Set<String> QB_LEGACY_CANDIDATES = Set.of("par-u1");
+    private static final Set<String> QB_ENGINE_CANDIDATES = Set.of("par-u1", "par-u2", "par-u3");
+
+    /** QC — typo ('transacton'): no FTS lexeme either side; only pg_trgm can rescue. */
+    private static final String QC = "transacton isolation";
+
+    PostgreSQLContainer<?> pg;
+    HikariDataSource       svcDs;
+    TenantScope            tenantScope;
+    OnnxEmbedder           onnx;
+    PgVectorRepository     pgRepo;
+    LocalChromaServer      localChroma;
+    VectorRepository       chromaRepo;
+    Connection             sqlite;   // in-memory FTS5 lives and dies with this connection
+
+    @BeforeAll
+    void startAll() throws Exception {
+        // --- pgvector substrate (same steps as PgVectorRepositoryContractTest).
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '" + SVC_ROLE + "') THEN " +
+                "    CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
+                "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            Database db = DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(su));
+            new Liquibase("db/changelog/db.changelog-master.xml",
+                          new ClassLoaderResourceAccessor(), db)
+                .update(new Contexts());
+        }
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus.chunks_384 TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+        }
+        var cfg = new HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(5);
+        cfg.setAutoCommit(true);
+        svcDs = new HikariDataSource(cfg);
+        tenantScope = new TenantScope(svcDs);
+
+        // --- ONE embedder instance for both legs: verbatim-identical vectors.
+        onnx   = new OnnxEmbedder();
+        pgRepo = new PgVectorRepository(tenantScope, onnx, onnx);
+
+        // --- Legacy vector leg: live local Chroma (cosine space via ChromaRestClient).
+        String chromaBinary = LocalChromaServer.findChromaBinary();
+        Path chromaData = Files.createTempDirectory("hybrid-parity-chroma-");
+        int chromaPort = LocalChromaServer.findFreePort();
+        localChroma = new LocalChromaServer(chromaBinary, chromaData.toString(), chromaPort);
+        localChroma.start();
+        chromaRepo = new VectorRepository(onnx, onnx, ChromaRestClient.local("127.0.0.1", chromaPort));
+
+        // --- Legacy FTS leg: SQLite FTS5, DEFAULT unicode61 tokenizer (the live T2
+        //     config — migrations.py passes no tokenize= option).
+        sqlite = DriverManager.getConnection("jdbc:sqlite::memory:");
+        sqlite.createStatement().execute(
+            "CREATE VIRTUAL TABLE chunks_fts USING fts5(id UNINDEXED, body)");
+
+        // --- Seed the identical corpus into all three stores.
+        List<String> ids  = new ArrayList<>(CORPUS.keySet());
+        List<String> docs = new ArrayList<>(CORPUS.values());
+        List<Map<String, Object>> metas = new ArrayList<>();
+        for (int i = 0; i < ids.size(); i++) metas.add(Map.of());
+
+        pgRepo.upsertChunks(TENANT, PG_COL, ids, docs, metas);
+        chromaRepo.upsertChunks(CHROMA_COL, ids, docs, metas);
+        try (PreparedStatement ps = sqlite.prepareStatement(
+                "INSERT INTO chunks_fts (id, body) VALUES (?, ?)")) {
+            for (int i = 0; i < ids.size(); i++) {
+                ps.setString(1, ids.get(i));
+                ps.setString(2, docs.get(i));
+                ps.executeUpdate();
+            }
+        }
+    }
+
+    @AfterAll
+    void stopAll() throws Exception {
+        if (sqlite      != null) sqlite.close();
+        if (localChroma != null) localChroma.stop();
+        if (onnx        != null) onnx.close();
+        if (svcDs       != null) svcDs.close();
+        if (pg          != null) pg.stop();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Legacy two-path fusion (the comparand)
+    // ---------------------------------------------------------------------------
+
+    /** FTS5 candidate IDs for a query (unicode61, implicit AND — plainto_tsquery's analog). */
+    private Set<String> fts5Candidates(String query) throws SQLException {
+        Set<String> out = new LinkedHashSet<>();
+        try (PreparedStatement ps = sqlite.prepareStatement(
+                "SELECT id FROM chunks_fts WHERE chunks_fts MATCH ?")) {
+            ps.setString(1, query);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) out.add(rs.getString(1));
+            }
+        }
+        return out;
+    }
+
+    /** Chroma vector ranking over the whole collection (cosine distance ascending). */
+    private List<String> chromaVectorRanking(String query) {
+        List<Map<String, Object>> rows =
+            chromaRepo.search(query, List.of(CHROMA_COL), CORPUS.size(), null);
+        return rows.stream().map(r -> (String) r.get("id")).toList();
+    }
+
+    /** Legacy fused top-k: FTS5 candidates ranked by Chroma cosine distance. */
+    private List<String> legacyFusedTopK(String query, int k) throws SQLException {
+        Set<String> fts = fts5Candidates(query);
+        return chromaVectorRanking(query).stream()
+                .filter(fts::contains)
+                .limit(k)
+                .toList();
+    }
+
+    /** Engine hybrid top-k IDs (RED until P3.2 implements hybridSearch). */
+    private List<String> engineHybridTopK(String query, int k) {
+        return pgRepo.hybridSearch(TENANT, query, List.of(PG_COL), k, null).stream()
+                .map(r -> (String) r.get("id"))
+                .toList();
+    }
+
+    private static double jaccard(Set<String> a, Set<String> b) {
+        if (a.isEmpty() && b.isEmpty()) return 1.0;
+        Set<String> inter = new LinkedHashSet<>(a);
+        inter.retainAll(b);
+        Set<String> union = new LinkedHashSet<>(a);
+        union.addAll(b);
+        return (double) inter.size() / union.size();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Fixture guards (GREEN before P3.2 — they verify the comparand, not the engine)
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void guard_corpusSeededIdentically_allThreeStores() throws Exception {
+        assertThat(pgRepo.count(TENANT, PG_COL))
+            .as("pgvector leg holds the full corpus").isEqualTo(CORPUS.size());
+        assertThat(chromaVectorRanking(QA))
+            .as("chroma leg ranks the full corpus").hasSize(CORPUS.size());
+        try (ResultSet rs = sqlite.createStatement()
+                .executeQuery("SELECT count(*) FROM chunks_fts")) {
+            rs.next();
+            assertThat(rs.getInt(1)).as("FTS5 leg holds the full corpus")
+                .isEqualTo(CORPUS.size());
+        }
+    }
+
+    @Test
+    void guard_legacyFts5CandidateSets_exact() throws Exception {
+        assertThat(fts5Candidates(QA))
+            .as("aligned query: unicode61 matches exactly the three exact-word-form rows")
+            .containsExactlyInAnyOrderElementsOf(QA_LEGACY_CANDIDATES);
+        assertThat(fts5Candidates(QB))
+            .as("stemmer-divergent query: unicode61 (no stemming) matches ONLY the row "
+                + "with the exact tokens 'indexing' AND 'strategies'")
+            .containsExactlyInAnyOrderElementsOf(QB_LEGACY_CANDIDATES);
+        assertThat(fts5Candidates(QC))
+            .as("typo query: FTS5 is typo-blind — the legacy text leg has NO candidates")
+            .isEmpty();
+    }
+
+    @Test
+    void guard_candidateVectorMargins_noNearTies() {
+        // If a future corpus edit creates a near-tie between candidate rows, ordered
+        // parity assertions would become float-noise-flaky. Catch it here by name
+        // (conexus xr7.8.7 min-gap guard, runtime form — embeddings are real, not
+        // hand-authored).
+        for (var probe : List.of(Map.entry(QA, QA_LEGACY_CANDIDATES),
+                                 Map.entry(QB, QB_ENGINE_CANDIDATES))) {
+            List<Map<String, Object>> rows =
+                pgRepo.search(TENANT, probe.getKey(), List.of(PG_COL), CORPUS.size(), null);
+            List<Double> candidateDists = rows.stream()
+                .filter(r -> probe.getValue().contains((String) r.get("id")))
+                .map(r -> ((Number) r.get("distance")).doubleValue())
+                .toList();
+            assertThat(candidateDists)
+                .as("all candidates of %s must rank", probe.getKey())
+                .hasSize(probe.getValue().size());
+            for (int i = 1; i < candidateDists.size(); i++) {
+                assertThat(candidateDists.get(i) - candidateDists.get(i - 1))
+                    .as("consecutive candidate distances for query '%s' must be separated "
+                        + "by > 1e-4 — a near-tie makes ordered parity flaky; reword the "
+                        + "fixture text", probe.getKey())
+                    .isGreaterThan(1e-4);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Parity seam (RED until P3.2)
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void parity_alignedQuery_orderedTopKEqual() throws Exception {
+        // Identical candidate sets (guard above), identical vectors (one embedder),
+        // cosine both sides: the ordered lists must be EQUAL, not merely overlapping.
+        List<String> legacy = legacyFusedTopK(QA, K);
+        List<String> engine = engineHybridTopK(QA, K);
+
+        assertThat(legacy)
+            .as("non-vacuity: the legacy fused list is non-empty")
+            .isNotEmpty();
+        assertThat(engine)
+            .as("aligned query: engine hybrid ordering must EQUAL the legacy fused "
+                + "ordering — any divergence here is engine error, not tokenizer delta")
+            .containsExactlyElementsOf(legacy);
+    }
+
+    @Test
+    void parity_stemmerDivergentQuery_exactExpectedDelta() throws Exception {
+        // The locked anchor (152-FTS-tokenizer-DECISION Option B): english-stemmer vs
+        // unicode61 divergence is the EXPECTED delta. On this fixture it is exactly
+        // derivable: legacy candidates {u1}, engine candidates {u1, u2, u3}.
+        List<String> legacy = legacyFusedTopK(QB, K);
+        List<String> engine = engineHybridTopK(QB, K);
+
+        assertThat(legacy)
+            .as("legacy fused list is exactly the single exact-token row")
+            .containsExactly("par-u1");
+        assertThat(Set.copyOf(engine))
+            .as("engine candidate set is exactly the three stemmed-variant rows")
+            .isEqualTo(QB_ENGINE_CANDIDATES);
+        assertThat(jaccard(Set.copyOf(legacy), Set.copyOf(engine)))
+            .as("the stemmer delta on this fixture is EXACTLY 1/3 — not an inequality")
+            .isEqualTo(1.0 / 3.0);
+    }
+
+    @Test
+    void parity_legacyCandidates_subsetOfEngineCandidates() throws Exception {
+        // Stemming and trigram similarity only WIDEN the text gate. Any legacy hit the
+        // engine misses is an engine regression, never an expected delta.
+        for (String query : List.of(QA, QB)) {
+            Set<String> legacy = Set.copyOf(legacyFusedTopK(query, K));
+            Set<String> engine = Set.copyOf(engineHybridTopK(query, K));
+            assertThat(engine)
+                .as("every legacy candidate for '%s' must appear in the engine results",
+                    query)
+                .containsAll(legacy);
+        }
+    }
+
+    @Test
+    void parity_typoQuery_trgmCapabilityDelta() throws Exception {
+        // pg_trgm is a capability the legacy path never had: FTS5 is typo-blind
+        // (guard asserts legacy candidates empty), the engine must still reach the
+        // row containing both corrected words. Excluded from the overlap aggregate.
+        assertThat(legacyFusedTopK(QC, K))
+            .as("legacy two-path fusion returns nothing for a typo query")
+            .isEmpty();
+
+        List<String> engine = engineHybridTopK(QC, K);
+        assertThat(engine)
+            .as("engine trgm leg rescues the typo query")
+            .isNotEmpty()
+            .as("the row containing both corrected words ('transaction isolation') has "
+                + "the highest text similarity under any sane gate and must be present")
+            .contains("par-t3");
+    }
+
+    @Test
+    void parity_overlapAggregate_meetsThreshold() throws Exception {
+        // The bead's named seam assertion: mean Jaccard overlap across the comparable
+        // queries >= PARITY_OVERLAP_THRESHOLD. Non-vacuous: per-query values are
+        // exactly pinned above (QA == 1.0, QB == 1/3), both sides non-empty.
+        double overlapA = jaccard(Set.copyOf(legacyFusedTopK(QA, K)),
+                                  Set.copyOf(engineHybridTopK(QA, K)));
+        double overlapB = jaccard(Set.copyOf(legacyFusedTopK(QB, K)),
+                                  Set.copyOf(engineHybridTopK(QB, K)));
+
+        assertThat(overlapA).as("aligned-query overlap is exactly 1.0").isEqualTo(1.0);
+        assertThat(overlapB).as("stemmer-delta overlap is exactly 1/3").isEqualTo(1.0 / 3.0);
+        assertThat((overlapA + overlapB) / 2.0)
+            .as("fixture-scale aggregate overlap (exact: 2/3) must clear the seam "
+                + "threshold %s", PARITY_OVERLAP_THRESHOLD)
+            .isGreaterThanOrEqualTo(PARITY_OVERLAP_THRESHOLD);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/PgVectorHybridSearchContractTest.java
+++ b/service/src/test/java/dev/nexus/service/PgVectorHybridSearchContractTest.java
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
 package dev.nexus.service;
 
 import com.zaxxer.hikari.HikariConfig;
@@ -450,10 +452,14 @@ class PgVectorHybridSearchContractTest {
     }
 
     @Test
-    void hybridSearch_emptyCollections_returnsEmpty() {
+    void hybridSearch_emptyCollectionsList_returnsEmpty() {
         assertThat(repo1024.hybridSearch(TENANT_A, Q, List.of(), 10, null))
             .as("no collections to search returns empty, same as search()")
             .isEmpty();
+    }
+
+    @Test
+    void hybridSearch_nullCollections_returnsEmpty() {
         assertThat(repo1024.hybridSearch(TENANT_A, Q, null, 10, null))
             .as("null collections returns empty, same as search()")
             .isEmpty();

--- a/service/src/test/java/dev/nexus/service/PgVectorHybridSearchContractTest.java
+++ b/service/src/test/java/dev/nexus/service/PgVectorHybridSearchContractTest.java
@@ -1,0 +1,461 @@
+package dev.nexus.service;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.nexus.service.db.TenantScope;
+import dev.nexus.service.vectors.PgVectorRepository;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * RDR-155 P3.1 (bead nexus-sbvg0): hybrid tsvector + pg_trgm + vector fusion contract suite.
+ *
+ * <p><strong>TDD-RED: every test in this class fails with
+ * {@link UnsupportedOperationException} until bead nexus-eap5l (P3.2) implements
+ * {@link PgVectorRepository#hybridSearch}.</strong> The method ships as a signature-only
+ * skeleton in this bead; P3.2 fills the body and makes this suite green WITHOUT changing
+ * it (the suite is the locked contract — exact orderings, exact exclusions).
+ *
+ * <p>Fusion contract pinned here (RDR-155 §Query path Hybrid search; bead nexus-sbvg0):
+ * <ul>
+ *   <li><strong>Text gate, vector rank.</strong> The candidate set is rows matching at
+ *       least one text signal — {@code chunk_tsv @@ plainto_tsquery('english', q)} OR
+ *       trigram similarity — and candidates are ranked by vector cosine distance ascending.
+ *       This is the same fused-reference shape the conexus xr7.8.7 parity harness validated
+ *       and the xr7.8.9 go-live gate drives against this engine's seam.
+ *   <li><strong>No silent vector fallback.</strong> A query with zero text candidates
+ *       returns empty — a vector-close row with no text signal NEVER appears. Semantic-only
+ *       retrieval remains {@link PgVectorRepository#search}'s job.
+ *   <li><strong>Trigram rescue.</strong> A typo query that matches no FTS lexeme still
+ *       returns the trigram-similar rows ({@code pg_trgm} leg is real, not decorative).
+ *   <li><strong>Same envelope as search().</strong> RLS tenant scope, per-dim dispatch with
+ *       fail-loud on mixed dims / unknown model segments, multi-collection filtered union,
+ *       metadata where-predicates ANDed with the text gate, nResults cap, flat row shape.
+ * </ul>
+ *
+ * <p>Non-vacuity (conexus xr7.8.7 pattern): the fixture is designed so FTS-candidate
+ * chash ordering != fused ordering != vector-only ordering. Tests assert all three
+ * differ, proving both signals are load-bearing.
+ *
+ * <p>Embedding is the deterministic {@link PgVectorRepositoryContractTest.FakeEmbedder}
+ * (unit vectors with exact pairwise cosine distances). Hermetic: Testcontainers
+ * pgvector/pgvector:pg17, PER_CLASS lifecycle, fixture seeded once via the GREEN P2
+ * upsert path.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PgVectorHybridSearchContractTest {
+
+    // Plain-LOGIN service role: NOSUPERUSER, NOT table owner, NO BYPASSRLS.
+    private static final String SVC_ROLE = "svc_hybrid_test";
+    private static final String SVC_PASS = "svc_hybrid_test_pass";
+
+    private static final String TENANT_A = "tenant-a";
+    private static final String TENANT_B = "tenant-b";
+
+    private static final String COL_HY   = "knowledge__hybrid__voyage-context-3__v1";
+    private static final String COL_MA   = "knowledge__hyba__voyage-context-3__v1";
+    private static final String COL_MB   = "code__hybb__voyage-code-3__v1";
+    private static final String COL_WH   = "docs__hybridwhere__bge-base-en-v15-768__v1";
+    private static final String COL_384H = "knowledge__hybrid384__minilm-l6-v2-384__v1";
+    private static final String COL_MINI = "knowledge__alpha__minilm-l6-v2-384__v1";
+    private static final String COL_UNKNOWN = "code__alpha__mystery-model-9000__v1";
+
+    /**
+     * The fused-ranking probe query. Embeds to (1, 0); every COL_HY text registers a
+     * vector whose first two components make its cosine distance to this query exact.
+     */
+    private static final String Q = "tenant isolation policy";
+
+    /**
+     * Trigram-rescue probe: single-character typo ("isolaton") of a phrase present
+     * verbatim in the FTS-matching fixture rows. {@code plainto_tsquery('english',
+     * 'tenant isolaton policy')} produces the lexeme 'isolaton' which appears NOWHERE,
+     * so the FTS leg matches nothing — only the pg_trgm leg can return candidates
+     * (word similarity vs the matching rows is ≈0.9, far above any sane gate; vs the
+     * non-matching rows ≈0.1, far below).
+     */
+    private static final String Q_TYPO = "tenant isolaton policy";
+
+    /** No text signal anywhere in the fixture: no FTS lexeme, no trigram similarity. */
+    private static final String Q_JUNK = "zzqq xkcd glorp";
+
+    // COL_HY fixture — (chash, text, unit vector, cosine distance to Q):
+    //   hyb-c1  FTS match   (1.0,  0.0)        dist 0.0   (nearest)
+    //   hyb-c2  FTS match   (0.6,  0.8)        dist 0.4   (third)
+    //   hyb-c3  FTS match   (0.8,  0.6)        dist 0.2   (second)
+    //   hyb-c4  NO signal   (0.995, 0.0998749) dist 0.005 (vector-close, text-unrelated)
+    //   hyb-c5  NO signal   (0.0,  1.0)        dist 1.0   (excluded both ways)
+    //   hyb-c6  FTS match   (-1.0, 0.0)        dist 2.0   (furthest candidate)
+    //
+    // Fused expected: [c1, c3, c2, c6] — differs from candidate-chash order [c1, c2, c3, c6]
+    // (vector signal real) and from vector-only top-4 [c1, c4, c3, c2] (text gate real).
+    // Minimum gap between consecutive candidate distances is 0.2 — far above float noise.
+    private static final String T_C1 = "the tenant isolation policy guards every row";
+    private static final String T_C2 = "tenant isolation policy enforcement in postgres";
+    private static final String T_C3 = "a tenant isolation policy for vector chunks";
+    private static final String T_C4 = "quantum entanglement spectroscopy experiment";
+    private static final String T_C5 = "unrelated cooking recipe for pasta carbonara";
+    private static final String T_C6 = "the tenant isolation policy appendix";
+
+    private static final List<String> FUSED_EXPECTED = List.of("hyb-c1", "hyb-c3", "hyb-c2", "hyb-c6");
+
+    PostgreSQLContainer<?> pg;
+    TenantScope tenantScope;
+    HikariDataSource svcDs;
+
+    PgVectorRepositoryContractTest.FakeEmbedder embedder1024;
+    PgVectorRepositoryContractTest.FakeEmbedder embedder768;
+    PgVectorRepositoryContractTest.FakeEmbedder embedder384;
+
+    PgVectorRepository repo1024;
+    PgVectorRepository repo768;
+    PgVectorRepository repo384;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+
+        // --- Step 1: roles before Liquibase (changeset DO-blocks need them).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '" + SVC_ROLE + "') THEN " +
+                "    CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
+                "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+        }
+
+        // --- Step 2: full master changelog (chunks tables + pgvector + pg_trgm).
+        try (Connection su = pg.createConnection("")) {
+            Database db = DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(su));
+            new Liquibase("db/changelog/db.changelog-master.xml",
+                          new ClassLoaderResourceAccessor(), db)
+                .update(new Contexts());
+        }
+
+        // --- Step 3: grants for the svc role.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            for (int dim : new int[] {384, 768, 1024}) {
+                su.createStatement().execute(
+                    "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus.chunks_" + dim + " TO " + SVC_ROLE);
+            }
+            su.createStatement().execute(
+                "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+        }
+
+        // --- Step 4: svc pool + repositories.
+        var cfg = new HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(5);
+        cfg.setAutoCommit(true);
+        svcDs = new HikariDataSource(cfg);
+        tenantScope = new TenantScope(svcDs);
+
+        embedder1024 = new PgVectorRepositoryContractTest.FakeEmbedder(1024);
+        embedder768  = new PgVectorRepositoryContractTest.FakeEmbedder(768);
+        embedder384  = new PgVectorRepositoryContractTest.FakeEmbedder(384);
+        repo1024 = new PgVectorRepository(tenantScope, embedder1024, embedder1024);
+        repo768  = new PgVectorRepository(tenantScope, embedder768,  embedder768);
+        repo384  = new PgVectorRepository(tenantScope, embedder384,  embedder384);
+
+        seedFixtures();
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (svcDs != null) svcDs.close();
+        if (pg    != null) pg.stop();
+    }
+
+    /** Seed every collection once via the GREEN P2 upsert path; tests are read-only. */
+    private void seedFixtures() {
+        // Queries embed to (1, 0). Q_TYPO and Q_JUNK fall through to FakeEmbedder's
+        // default (1, 0) — registered explicitly anyway for readability.
+        embedder1024.register(Q,      1.0f, 0.0f);
+        embedder1024.register(Q_TYPO, 1.0f, 0.0f);
+        embedder1024.register(Q_JUNK, 1.0f, 0.0f);
+
+        embedder1024.register(T_C1,  1.0f, 0.0f);
+        embedder1024.register(T_C2,  0.6f, 0.8f);
+        embedder1024.register(T_C3,  0.8f, 0.6f);
+        embedder1024.register(T_C4,  0.995f, 0.0998749f);
+        embedder1024.register(T_C5,  0.0f, 1.0f);
+        embedder1024.register(T_C6, -1.0f, 0.0f);
+        repo1024.upsertChunks(TENANT_A, COL_HY,
+            List.of("hyb-c1", "hyb-c2", "hyb-c3", "hyb-c4", "hyb-c5", "hyb-c6"),
+            List.of(T_C1, T_C2, T_C3, T_C4, T_C5, T_C6),
+            List.of(Map.of("kind", "hy"), Map.of("kind", "hy"), Map.of("kind", "hy"),
+                    Map.of("kind", "hy"), Map.of("kind", "hy"), Map.of("kind", "hy")));
+
+        // Multi-collection union fixture: two 1024 collections, distances interleave.
+        embedder1024.register("tenant isolation policy alpha document", 1.0f, 0.0f);
+        embedder1024.register("tenant isolation policy beta document",  0.8f, 0.6f);
+        embedder1024.register("tenant isolation policy gamma document", 0.6f, 0.8f);
+        repo1024.upsertChunks(TENANT_A, COL_MA,
+            List.of("ma-c1", "ma-c2"),
+            List.of("tenant isolation policy alpha document",
+                    "tenant isolation policy gamma document"),
+            List.of(Map.of(), Map.of()));
+        repo1024.upsertChunks(TENANT_A, COL_MB,
+            List.of("mb-c1"),
+            List.of("tenant isolation policy beta document"),
+            List.of(Map.of()));
+
+        // where-filter fixture on the 768 table.
+        embedder768.register(Q, 1.0f, 0.0f);
+        embedder768.register("tenant isolation policy for java services",   1.0f, 0.0f);
+        embedder768.register("tenant isolation policy for python services", 0.6f, 0.8f);
+        repo768.upsertChunks(TENANT_A, COL_WH,
+            List.of("wh-c1", "wh-c2"),
+            List.of("tenant isolation policy for java services",
+                    "tenant isolation policy for python services"),
+            List.of(Map.of("lang", "java"), Map.of("lang", "py")));
+
+        // 384 dispatch fixture (per-dim DDL is byte-identical; the hybrid query must
+        // behave identically on every chunks_<dim> table).
+        embedder384.register(Q, 1.0f, 0.0f);
+        embedder384.register("tenant isolation policy small model",   1.0f, 0.0f);
+        embedder384.register("tenant isolation policy variant",       0.8f, 0.6f);
+        embedder384.register("cooking carbonara again",               0.995f, 0.0998749f);
+        repo384.upsertChunks(TENANT_A, COL_384H,
+            List.of("m384-c1", "m384-c2", "m384-c3"),
+            List.of("tenant isolation policy small model",
+                    "tenant isolation policy variant",
+                    "cooking carbonara again"),
+            List.of(Map.of(), Map.of(), Map.of()));
+    }
+
+    private static List<String> ids(List<Map<String, Object>> rows) {
+        return rows.stream().map(r -> (String) r.get("id")).toList();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Contract 1: fused ordering — text gate, then vector rank (exact)
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void hybridSearch_fusedOrdering_textGateThenVectorRank() {
+        List<Map<String, Object>> rows =
+            repo1024.hybridSearch(TENANT_A, Q, List.of(COL_HY), 10, null);
+
+        assertThat(ids(rows))
+            .as("fused = FTS candidates {c1,c2,c3,c6} ranked by cosine distance "
+                + "(0.0, 0.2, 0.4, 2.0) — exact ordering, exact membership")
+            .containsExactlyElementsOf(FUSED_EXPECTED);
+    }
+
+    @Test
+    void hybridSearch_excludesVectorCloseRowWithNoTextSignal() {
+        // Differentiation proof: plain vector search DOES surface hyb-c4 (distance
+        // 0.005, second-nearest) — the GREEN P2 path establishes the row is there
+        // and vector-reachable. Hybrid must exclude it: no text signal, no row.
+        List<Map<String, Object>> vectorOnly =
+            repo1024.search(TENANT_A, Q, List.of(COL_HY), 10, null);
+        assertThat(ids(vectorOnly))
+            .as("precondition: vector-only search surfaces the text-unrelated row")
+            .contains("hyb-c4");
+
+        List<Map<String, Object>> fused =
+            repo1024.hybridSearch(TENANT_A, Q, List.of(COL_HY), 10, null);
+        assertThat(ids(fused))
+            .as("a vector-close row with no text signal must NEVER appear in hybrid results")
+            .doesNotContain("hyb-c4", "hyb-c5");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Contract 2: non-vacuity — both signals are load-bearing (conexus xr7.8.7 pattern)
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void hybridSearch_orderingDiffersFromChashOrder_vectorSignalReal() {
+        List<Map<String, Object>> rows =
+            repo1024.hybridSearch(TENANT_A, Q, List.of(COL_HY), 10, null);
+
+        List<String> fusedOrder = ids(rows);
+        List<String> chashOrder = fusedOrder.stream().sorted().toList();
+
+        assertThat(fusedOrder)
+            .as("fused ordering must differ from candidate chash ordering — otherwise the "
+                + "vector signal has no effect and the fusion assertion is vacuous")
+            .isNotEqualTo(chashOrder);
+    }
+
+    @Test
+    void hybridSearch_vectorOnlyOrderingDiffers_textGateReal() {
+        List<Map<String, Object>> vectorOnly =
+            repo1024.search(TENANT_A, Q, List.of(COL_HY), 4, null);
+        List<Map<String, Object>> fused =
+            repo1024.hybridSearch(TENANT_A, Q, List.of(COL_HY), 4, null);
+
+        assertThat(ids(fused))
+            .as("vector-only top-4 [c1,c4,c3,c2] must differ from fused top-4 "
+                + "[c1,c3,c2,c6] — otherwise the text gate has no effect")
+            .isNotEqualTo(ids(vectorOnly));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Contract 3: pg_trgm leg — typo queries still reach trigram-similar rows
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void hybridSearch_trgmRescue_typoQueryReturnsCandidates() {
+        // 'isolaton' matches no FTS lexeme anywhere — only pg_trgm can gate these
+        // rows in. Same candidates, same vector ranking as the clean query.
+        List<Map<String, Object>> rows =
+            repo1024.hybridSearch(TENANT_A, Q_TYPO, List.of(COL_HY), 10, null);
+
+        assertThat(ids(rows))
+            .as("typo query must trigram-rescue the candidate rows (FTS leg matches "
+                + "nothing); ranking stays vector-distance ascending")
+            .containsExactlyElementsOf(FUSED_EXPECTED);
+    }
+
+    @Test
+    void hybridSearch_noTextSignal_returnsEmpty_noVectorFallback() {
+        List<Map<String, Object>> rows =
+            repo1024.hybridSearch(TENANT_A, Q_JUNK, List.of(COL_HY), 10, null);
+
+        assertThat(rows)
+            .as("zero text candidates returns empty — hybrid must NOT silently fall "
+                + "back to vector-only (that is search()'s job)")
+            .isEmpty();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Contract 4: search() envelope carried over
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void hybridSearch_multiCollection_singleRankedUnion() {
+        List<Map<String, Object>> rows =
+            repo1024.hybridSearch(TENANT_A, Q, List.of(COL_MA, COL_MB), 10, null);
+
+        assertThat(ids(rows))
+            .as("multi-collection hybrid is ONE ranked list interleaved by distance "
+                + "(ma-c1 0.0, mb-c1 0.2, ma-c2 0.4), not per-collection blocks")
+            .containsExactly("ma-c1", "mb-c1", "ma-c2");
+    }
+
+    @Test
+    void hybridSearch_whereFilter_composesWithTextGate() {
+        List<Map<String, Object>> rows =
+            repo768.hybridSearch(TENANT_A, Q, List.of(COL_WH), 10, Map.of("lang", "py"));
+
+        assertThat(ids(rows))
+            .as("metadata where-predicate ANDs with the text gate: wh-c1 matches the "
+                + "text gate but not lang=py and must be filtered out")
+            .containsExactly("wh-c2");
+    }
+
+    @Test
+    void hybridSearch_respectsNResultsLimit() {
+        List<Map<String, Object>> rows =
+            repo1024.hybridSearch(TENANT_A, Q, List.of(COL_HY), 2, null);
+
+        assertThat(ids(rows))
+            .as("nResults truncates the ranked fused list — top-2 exactly")
+            .containsExactly("hyb-c1", "hyb-c3");
+    }
+
+    @Test
+    void hybridSearch_tenantIsolated_otherTenantGetsNothing() {
+        List<Map<String, Object>> rows =
+            repo1024.hybridSearch(TENANT_B, Q, List.of(COL_HY), 10, null);
+
+        assertThat(rows)
+            .as("RLS must scope the hybrid query exactly like search(): another tenant "
+                + "sees 0 of tenant-a's rows")
+            .isEmpty();
+    }
+
+    @Test
+    void hybridSearch_worksOnChunks384() {
+        List<Map<String, Object>> rows =
+            repo384.hybridSearch(TENANT_A, Q, List.of(COL_384H), 10, null);
+
+        assertThat(ids(rows))
+            .as("hybrid dispatches per-dim exactly like search(): same gate + rank "
+                + "behaviour on chunks_384, text-unrelated row excluded")
+            .containsExactly("m384-c1", "m384-c2");
+    }
+
+    @Test
+    void hybridSearch_rowShape_matchesSearchContract() {
+        List<Map<String, Object>> rows =
+            repo1024.hybridSearch(TENANT_A, Q, List.of(COL_HY), 1, null);
+
+        assertThat(rows).hasSize(1);
+        Map<String, Object> top = rows.get(0);
+        assertThat(top.get("id")).isEqualTo("hyb-c1");
+        assertThat(top.get("content")).isEqualTo(T_C1);
+        assertThat(top.get("collection")).isEqualTo(COL_HY);
+        assertThat(((Number) top.get("distance")).doubleValue())
+            .as("hyb-c1 embeds to the query vector — cosine distance exactly 0")
+            .isCloseTo(0.0, within(1e-6));
+        assertThat(top.get("kind"))
+            .as("metadata keys flatten into the row, same as search()")
+            .isEqualTo("hy");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Contract 5: dispatch failure modes (same as search())
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void hybridSearch_mixedDimensions_failLoud() {
+        assertThatThrownBy(() ->
+                repo1024.hybridSearch(TENANT_A, Q, List.of(COL_HY, COL_MINI), 10, null))
+            .as("a 1024-dim and a 384-dim collection cannot share one query vector — "
+                + "fail loud, exactly like search()")
+            .isInstanceOf(IllegalArgumentException.class)
+            .isNotInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void hybridSearch_unknownModelSegment_failsLoud() {
+        assertThatThrownBy(() ->
+                repo1024.hybridSearch(TENANT_A, Q, List.of(COL_UNKNOWN), 10, null))
+            .as("unknown embedding-model segment must fail loud — never a fallback dim")
+            .isInstanceOf(IllegalArgumentException.class)
+            .isNotInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void hybridSearch_emptyCollections_returnsEmpty() {
+        assertThat(repo1024.hybridSearch(TENANT_A, Q, List.of(), 10, null))
+            .as("no collections to search returns empty, same as search()")
+            .isEmpty();
+        assertThat(repo1024.hybridSearch(TENANT_A, Q, null, 10, null))
+            .as("null collections returns empty, same as search()")
+            .isEmpty();
+    }
+}

--- a/service/src/test/java/dev/nexus/service/VectorHybridHttpTest.java
+++ b/service/src/test/java/dev/nexus/service/VectorHybridHttpTest.java
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.nexus.service.db.TenantScope;
+import dev.nexus.service.db.TokenHashing;
+import dev.nexus.service.vectors.ChromaRestClient;
+import dev.nexus.service.vectors.PgVectorRepository;
+import dev.nexus.service.vectors.VectorRepository;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RDR-155 P3.2 (bead nexus-eap5l): {@code POST /v1/vectors/hybrid-search} HTTP seam.
+ *
+ * <p>This is the wiring test for the validation seam the conexus xr7.8.9 go-live gate
+ * drives: the pgvector hybrid fusion exposed through the EXISTING /v1/vectors surface
+ * (no new public surface). The fusion semantics themselves are locked by the P3.1
+ * suites ({@code PgVectorHybridSearchContractTest}, {@code HybridParityIntegrationTest});
+ * this class pins only the HTTP envelope:
+ * <ul>
+ *   <li>Route exists, request body matches /search, response is the flat row list.
+ *   <li>Tenant is SERVER-RESOLVED from the bearer token (RLS boundary) — a token bound
+ *       to another tenant sees zero rows, and no client-supplied header can widen it.
+ *   <li>503 when no PgVectorRepository is wired (the /embed absent-backend pattern);
+ *       Chroma routes are untouched either way (Phase 4a owns the serving cutover).
+ *   <li>400 on a malformed body (missing query).
+ * </ul>
+ *
+ * <p>Hermetic: Testcontainers pgvector/pgvector:pg17, full master changelog, port 0,
+ * nexus_svc pool, FakeEmbedder vectors.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class VectorHybridHttpTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String TOKEN_A = "hybrid-http-token-a-0123456789abcdef";
+    private static final String TOKEN_B = "hybrid-http-token-b-0123456789abcdef";
+    private static final String TENANT_A = "hyb-http-tenant-a";
+    private static final String TENANT_B = "hyb-http-tenant-b";
+
+    private static final String COL = "knowledge__httph__voyage-context-3__v1";
+    private static final String Q   = "tenant isolation policy";
+
+    PostgreSQLContainer<?> pg;
+    HikariDataSource svcDs;
+    TenantScope tenantScope;
+    PgVectorRepository pgRepo;
+    NexusService service;        // hybrid-wired
+    NexusService serviceNoPg;    // Chroma-only — /hybrid-search must 503
+    HttpClient http;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+
+        // nexus_svc role before Liquibase (grants changeset is fail-loud without it).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
+                "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            Database db = DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(su));
+            new Liquibase("db/changelog/db.changelog-master.xml",
+                          new ClassLoaderResourceAccessor(), db)
+                .update(new Contexts());
+        }
+        // Bind one token per tenant (server-side tenant resolution under test).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            for (var bound : List.of(Map.entry(TOKEN_A, TENANT_A),
+                                     Map.entry(TOKEN_B, TENANT_B))) {
+                su.createStatement().execute(
+                    "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label) VALUES ('"
+                    + TokenHashing.sha256Hex(bound.getKey()) + "', '" + bound.getValue()
+                    + "', 'hybrid-http-test') ON CONFLICT (token_hash) DO NOTHING");
+            }
+        }
+
+        var cfg = new HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername("nexus_svc");
+        cfg.setPassword("nexus_svc_pass");
+        cfg.setMaximumPoolSize(5);
+        cfg.setAutoCommit(true);
+        svcDs = new HikariDataSource(cfg);
+        tenantScope = new TenantScope(svcDs);
+
+        var embedder = new PgVectorRepositoryContractTest.FakeEmbedder(1024);
+        embedder.register(Q, 1.0f, 0.0f);
+        embedder.register("the tenant isolation policy guards every row", 1.0f, 0.0f);
+        embedder.register("tenant isolation policy enforcement in postgres", 0.8f, 0.6f);
+        embedder.register("quantum entanglement spectroscopy experiment", 0.995f, 0.0998749f);
+        pgRepo = new PgVectorRepository(tenantScope, embedder, embedder);
+        pgRepo.upsertChunks(TENANT_A, COL,
+            List.of("hh-c1", "hh-c2", "hh-c3"),
+            List.of("the tenant isolation policy guards every row",
+                    "tenant isolation policy enforcement in postgres",
+                    "quantum entanglement spectroscopy experiment"),
+            List.of(Map.of("kind", "hh"), Map.of("kind", "hh"), Map.of("kind", "hh")));
+
+        service = new NexusService(0, TOKEN_A, svcDs, null, null, pgRepo);
+        service.start();
+
+        // Chroma-only service: VectorRepository wired (client config only — the 503
+        // path never touches Chroma), no PgVectorRepository.
+        serviceNoPg = new NexusService(0, TOKEN_A, svcDs,
+            new VectorRepository(embedder, embedder, ChromaRestClient.local("127.0.0.1", 1)),
+            null);
+        serviceNoPg.start();
+
+        http = HttpClient.newHttpClient();
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (service     != null) service.stop();
+        if (serviceNoPg != null) serviceNoPg.stop();
+        if (svcDs       != null) svcDs.close();
+        if (pg          != null) pg.stop();
+    }
+
+    private HttpResponse<String> post(NexusService svc, String token, Object body)
+            throws Exception {
+        var req = HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + svc.getPort() + "/v1/vectors/hybrid-search"))
+            .header("Authorization", "Bearer " + token)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)))
+            .build();
+        return http.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    void hybridSearch_overHttp_returnsFusedRows() throws Exception {
+        var resp = post(service, TOKEN_A,
+            Map.of("query", Q, "collections", List.of(COL), "n_results", 10));
+
+        assertThat(resp.statusCode()).as("hybrid-search 200").isEqualTo(200);
+        List<Map<String, Object>> rows = MAPPER.readValue(resp.body(), List.class);
+        assertThat(rows.stream().map(r -> r.get("id")).toList())
+            .as("text-gated rows ranked by distance; the no-text-signal row hh-c3 "
+                + "(vector-closer than hh-c2) is excluded")
+            .containsExactly("hh-c1", "hh-c2");
+        assertThat(rows.get(0).get("kind"))
+            .as("metadata flattens into HTTP rows exactly like /search")
+            .isEqualTo("hh");
+    }
+
+    @Test
+    void hybridSearch_tenantResolvedServerSide_fromBearer() throws Exception {
+        // TOKEN_B is bound to TENANT_B, which owns no rows: the same request body
+        // must return zero rows. RLS + server-resolved tenant is the boundary; there
+        // is no client-supplied field that can widen it.
+        var resp = post(service, TOKEN_B,
+            Map.of("query", Q, "collections", List.of(COL), "n_results", 10));
+
+        assertThat(resp.statusCode()).isEqualTo(200);
+        List<?> rows = MAPPER.readValue(resp.body(), List.class);
+        assertThat(rows)
+            .as("a bearer bound to another tenant sees exactly 0 rows")
+            .isEmpty();
+    }
+
+    @Test
+    void hybridSearch_withoutPgRepo_returns503() throws Exception {
+        var resp = post(serviceNoPg, TOKEN_A,
+            Map.of("query", Q, "collections", List.of(COL), "n_results", 10));
+
+        assertThat(resp.statusCode())
+            .as("Chroma-only service: hybrid-search is explicitly not configured (the "
+                + "/embed absent-backend pattern), never a silent Chroma fallback")
+            .isEqualTo(503);
+        assertThat(resp.body()).contains("not configured");
+    }
+
+    @Test
+    void hybridSearch_missingQuery_returns400() throws Exception {
+        var resp = post(service, TOKEN_A,
+            Map.of("collections", List.of(COL), "n_results", 10));
+
+        assertThat(resp.statusCode()).as("missing 'query' is a client error").isEqualTo(400);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/VectorHybridHttpTest.java
+++ b/service/src/test/java/dev/nexus/service/VectorHybridHttpTest.java
@@ -95,14 +95,17 @@ class VectorHybridHttpTest {
                 .update(new Contexts());
         }
         // Bind one token per tenant (server-side tenant resolution under test).
-        try (Connection su = pg.createConnection("")) {
+        try (Connection su = pg.createConnection("");
+             var ps = su.prepareStatement(
+                 "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label)"
+                 + " VALUES (?, ?, ?) ON CONFLICT (token_hash) DO NOTHING")) {
             su.setAutoCommit(true);
             for (var bound : List.of(Map.entry(TOKEN_A, TENANT_A),
                                      Map.entry(TOKEN_B, TENANT_B))) {
-                su.createStatement().execute(
-                    "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label) VALUES ('"
-                    + TokenHashing.sha256Hex(bound.getKey()) + "', '" + bound.getValue()
-                    + "', 'hybrid-http-test') ON CONFLICT (token_hash) DO NOTHING");
+                ps.setString(1, TokenHashing.sha256Hex(bound.getKey()));
+                ps.setString(2, bound.getValue());
+                ps.setString(3, "hybrid-http-test");
+                ps.executeUpdate();
             }
         }
 


### PR DESCRIPTION
## Summary

RDR-155 Phase 3 complete — the engine's hybrid search moves from the FTS5+Chroma two-path fusion to a single pgvector query, with the hybrid-parity seam GREEN against the real legacy engines and the xr7.8.9 validation harness in place. Phase gate P3.G PASSED (cross-walk 5/5, full clean suite 531/531, stacked dual reviews 0 Critical, test-validator PASS). This gate authorizes Phase 4a (Chroma serving retire).

## Commits (TDD pairs + harness, each dual-reviewed with delta confirmation)

- `72f52a7a` **P3.1** (nexus-sbvg0): PgVectorHybridSearchContractTest (16 tests, hermetic) + HybridParityIntegrationTest (8 tests, integration) + UOE skeleton — verified RED (15/15 then 16/16 after review split; no vacuous passes).
- `797015b2` P3.1 review fixes (temp-dir cleanup, exact 2/3 aggregate, two-sided tie guard, trgm calibration anchor, iterative_scan contract bullet).
- `aeb1d5e6` **P3.2** (nexus-eap5l): `PgVectorRepository.hybridSearch` — one SQL statement: `WHERE collection IN (...) AND (chunk_tsv @@ plainto_tsquery('english', ?) OR ? <% chunk_text) ORDER BY embedding <=> ?, chash` with SET LOCAL `hnsw.iterative_scan='relaxed_order'` + `pg_trgm.word_similarity_threshold=0.6`; vectors-002 trgm GIN changeset (all three per-dim tables); `POST /v1/vectors/hybrid-search` on the existing surface with server-resolved tenant (RLS boundary); VectorHybridHttpTest (4 tests). Both P3.1 suites RED→GREEN **unmodified**.
- `5a2dfe52` P3.2 review fixes (nResults < 1 fail-loud + no-upper-cap-by-design doc, CONCURRENTLY decision doc, Seam B deferral recorded, parameterized test INSERT).
- `4c6be055` **P3.E** (nexus-h3ked): DualRunHarnessIntegrationTest (6 tests) — the corpus-agnostic dual-run seam conexus xr7.8.9 drives (`-Dnx.dualrun.*`): exact-count recall pgvector vs Chroma baseline (1.0 at fixture scale), HTTP==repo hybrid fidelity, text-signal oracle, trgm-index existence guard, p95 bound; Seam B EmbedderRouter wiring exercised for hybrid.
- `d720c694` P3.E review fixes (trgm pg_indexes guard, per-query recall floor, NPE→assertion, Liquibase close, search_path).

## Parity headline

Engine pgvector hybrid vs the REAL legacy engines (live local Chroma + SQLite FTS5 unicode61, one OnnxEmbedder both legs): aligned query ordered-EQUAL (overlap 1.0); stemmer-divergent query Jaccard exactly 1/3 (the locked english-vs-unicode61 expected-delta class); typo query = trgm capability delta (legacy returns nothing); aggregate exactly 2/3.

## Verification

- Full clean default suite: **531/531** (0F/0E/0S, surefire XML aggregate post-`mvn clean`).
- Integration: HybridParityIntegrationTest 8/8, DualRunHarnessIntegrationTest 6/6.
- Gate record: T2 `nexus_rdr/155-P3-gate-result`. Beads closed: nexus-sbvg0, nexus-eap5l, nexus-h3ked, nexus-thp60.