### PR TITLE
feat: ServiceRegistry-lease endpoint discovery for vector + catalog clients

### DIFF
--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -77,6 +77,14 @@ def _resolve_config() -> tuple[str, int, str]:
     ServiceRegistry lease the supervisor publishes (the port churns on
     every restart, so env-only resolution broke after any auto-restart).
     Unresolvable fails loud.
+
+    RESTART-SAFETY CONTRACT (dual-review H2): unlike the vector client,
+    ``HttpCatalogClient`` resolves ONCE at construction and holds a
+    long-lived ``httpx.Client`` — there is no per-request re-resolve.
+    Restart ride-through therefore rests on callers constructing a fresh
+    client per operation (the ``get_catalog()`` MCP pattern: "no
+    process-level caching"). Do NOT cache an ``HttpCatalogClient``
+    instance across operations that may span a supervisor restart.
     """
     env_host = os.environ.get("NX_SERVICE_HOST", "").strip()
     port_str = os.environ.get("NX_SERVICE_PORT", "").strip()
@@ -97,10 +105,11 @@ def _resolve_config() -> tuple[str, int, str]:
 
         lease_url, lease_token = _discover_lease()
         if lease_url is not None:
-            # lease_url is "http://<host>:<port>" by construction.
-            lease_host, _, lease_port = lease_url.removeprefix("http://").rpartition(":")
-            host = host or lease_host
-            port = port if port is not None else int(lease_port)
+            from urllib.parse import urlsplit
+
+            parsed = urlsplit(lease_url)
+            host = host or parsed.hostname
+            port = port if port is not None else parsed.port
         token = token or lease_token
     host = host or "127.0.0.1"
 
@@ -166,8 +175,12 @@ class HttpCatalogClient:
                 _token = os.environ.get("NX_SERVICE_TOKEN", "")
                 if not _token:
                     raise RuntimeError(
-                        "NX_SERVICE_TOKEN is required when "
-                        "NX_STORAGE_BACKEND_CATALOG=service."
+                        "NX_SERVICE_TOKEN is required when an explicit "
+                        "base_url is passed (NX_STORAGE_BACKEND_CATALOG="
+                        "service): with a caller-chosen URL the supervisor "
+                        "lease token may not match — export the token, or "
+                        "omit base_url to auto-discover both halves from "
+                        "the lease ('nx daemon service start')."
                     )
             self._base_url = base_url.rstrip("/")
         else:

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -69,24 +69,48 @@ DEFAULT_TENANT: str = "default"
 
 
 def _resolve_config() -> tuple[str, int, str]:
-    """Return (host, port, token) from environment."""
-    host = os.environ.get("NX_SERVICE_HOST", "127.0.0.1")
-    port_str = os.environ.get("NX_SERVICE_PORT", "")
-    token = os.environ.get("NX_SERVICE_TOKEN", "")
-    if not port_str:
+    """Return (host, port, token): env first, then the supervisor's lease.
+
+    nexus-pebfx.1: same resolution discipline as the vector client —
+    ``NX_SERVICE_HOST`` / ``NX_SERVICE_PORT`` / ``NX_SERVICE_TOKEN`` env
+    halves override individually; missing halves come from the
+    ServiceRegistry lease the supervisor publishes (the port churns on
+    every restart, so env-only resolution broke after any auto-restart).
+    Unresolvable fails loud.
+    """
+    env_host = os.environ.get("NX_SERVICE_HOST", "").strip()
+    port_str = os.environ.get("NX_SERVICE_PORT", "").strip()
+    env_token = os.environ.get("NX_SERVICE_TOKEN", "").strip()
+
+    port: int | None = None
+    if port_str:
+        try:
+            port = int(port_str)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"NX_SERVICE_PORT must be an integer, got: {port_str!r}"
+            ) from exc
+
+    host, token = env_host or None, env_token or None
+    if port is None or token is None or host is None:
+        from nexus.db.http_vector_client import _discover_lease
+
+        lease_url, lease_token = _discover_lease()
+        if lease_url is not None:
+            # lease_url is "http://<host>:<port>" by construction.
+            lease_host, _, lease_port = lease_url.removeprefix("http://").rpartition(":")
+            host = host or lease_host
+            port = port if port is not None else int(lease_port)
+        token = token or lease_token
+    host = host or "127.0.0.1"
+
+    if port is None or not token:
         raise RuntimeError(
-            "NX_SERVICE_PORT is required when NX_STORAGE_BACKEND_CATALOG=service. "
-            "Set it to the port where the nexus-service is listening."
-        )
-    try:
-        port = int(port_str)
-    except ValueError as exc:
-        raise RuntimeError(
-            f"NX_SERVICE_PORT must be an integer, got: {port_str!r}"
-        ) from exc
-    if not token:
-        raise RuntimeError(
-            "NX_SERVICE_TOKEN is required when NX_STORAGE_BACKEND_CATALOG=service."
+            "nexus-service endpoint is not resolvable for the catalog client "
+            "(NX_STORAGE_BACKEND_CATALOG=service): start the supervisor with "
+            "'nx daemon service start' (publishes the endpoint lease), or set "
+            "NX_SERVICE_PORT / NX_SERVICE_TOKEN (and optionally "
+            "NX_SERVICE_HOST) explicitly."
         )
     return host, port, token
 

--- a/src/nexus/commands/storage_cmd.py
+++ b/src/nexus/commands/storage_cmd.py
@@ -926,14 +926,21 @@ def migrate_vectors_cmd(
     if dry_run and rollback:
         raise click.ClickException("--dry-run and --rollback are mutually exclusive.")
 
-    token = os.environ.get("NX_SERVICE_TOKEN", "")
-    if not token:
-        raise click.ClickException(
-            "NX_SERVICE_TOKEN is required for storage migrate vectors.\n"
-            "Set it to the bearer token configured in the nexus-service."
-        )
+    # No explicit NX_SERVICE_TOKEN gate (nexus-pebfx.1): the client resolves
+    # {url, token} from the supervisor's ServiceRegistry lease, with env as
+    # the override. Pre-flight the resolution here so an unresolvable
+    # endpoint is a clean early error BEFORE the (potentially long) source
+    # read — except for --dry-run, which only counts source chunks and
+    # never touches the service at all.
     if service_url:
         os.environ["NX_SERVICE_URL"] = service_url
+    if not dry_run:
+        from nexus.db.http_vector_client import _resolve_endpoint
+
+        try:
+            _resolve_endpoint()
+        except RuntimeError as exc:
+            raise click.ClickException(str(exc))
 
     from nexus.db.http_vector_client import HttpVectorClient
 

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -15,6 +15,13 @@ pgvector and embeds server-side. ``NX_STORAGE_BACKEND_VECTORS=service``
 survives only as the indexer-side opt-in that skips Python-side
 embedding (see :func:`is_vector_service_mode`).
 
+Endpoint discovery (nexus-pebfx.1): ``{url, token}`` resolve from the
+supervisor's ServiceRegistry lease (``storage_service_addr.<uid>``) by
+default, with ``NX_SERVICE_URL`` / ``NX_SERVICE_TOKEN`` env as per-half
+overrides and a single re-resolve retry on 401/connection-refused so
+clients ride through supervisor auto-restarts (the port churns on every
+restart). No hardcoded fallback URL — unresolvable fails loud.
+
 Chunking stays in Python; embed+write live in the JVM (Seam B contract —
 CHUNKING STAYS PYTHON per the bead relay).
 """
@@ -32,30 +39,149 @@ _log = structlog.get_logger(__name__)
 
 # ── Configuration ────────────────────────────────────────────────────────────
 
-#: Default service URL. Override via NX_SERVICE_URL env var.
-_DEFAULT_SERVICE_URL = "http://127.0.0.1:8080"
-
 #: Env var for the vector backend flag.
 _VECTORS_BACKEND_ENV = "NX_STORAGE_BACKEND_VECTORS"
 
 
-def _service_url() -> str:
-    return os.environ.get("NX_SERVICE_URL", _DEFAULT_SERVICE_URL).rstrip("/")
+# ── Endpoint resolution (nexus-pebfx.1) ──────────────────────────────────────
+#
+# The supervisor (``nx daemon service start``) publishes ``{host, port,
+# token}`` to the ServiceRegistry lease (``storage_service_addr.<uid>``)
+# after a healthy ``/health`` — and allocates a NEW free port on every
+# (re)start. Resolution order:
+#
+#   1. ``NX_SERVICE_URL`` / ``NX_SERVICE_TOKEN`` env — each half overrides
+#      independently (operator/test override; read fresh on every call).
+#   2. The ServiceRegistry lease (cached; invalidated on 401 / connection
+#      refused so clients ride through supervisor auto-restarts).
+#   3. FAIL LOUD. The legacy hardcoded localhost default is retired — a
+#      silent wrong-port fallback is a correctness hazard.
+
+_endpoint_lock = threading.Lock()
+#: Cached (base_url, token) from the LEASE only — env halves are read fresh.
+_lease_cache: tuple[str | None, str | None] | None = None
 
 
-def _service_token() -> str:
-    tok = os.environ.get("NX_SERVICE_TOKEN", "")
-    if not tok:
+def _discover_lease() -> tuple[str | None, str | None]:
+    """(url, token) from the supervisor's lease, or (None, None)."""
+    try:
+        from nexus.config import nexus_config_dir
+        from nexus.daemon.service_registry import ServiceRegistry
+
+        registry = ServiceRegistry(dir=nexus_config_dir(), tier="storage_service")
+        lease = registry.discover(str(os.getuid()))
+        if lease is not None:
+            ep = lease.endpoint
+            host = str(ep.get("host", "127.0.0.1"))
+            port = int(ep.get("port", 0))
+            token = str(ep.get("token", "")) or None
+            if port > 0:
+                return f"http://{host}:{port}", token
+    except Exception as exc:  # discovery is best-effort; absence fails loud below
+        _log.debug("vector_endpoint_lease_discover_failed", error=str(exc))
+    return None, None
+
+
+def _resolve_endpoint() -> tuple[str, str]:
+    """Return ``(base_url, token)`` per the resolution order above."""
+    global _lease_cache
+    env_url = os.environ.get("NX_SERVICE_URL", "").strip().rstrip("/") or None
+    env_token = os.environ.get("NX_SERVICE_TOKEN", "").strip() or None
+    url, token = env_url, env_token
+    if url is None or token is None:
+        with _endpoint_lock:
+            if _lease_cache is None:
+                _lease_cache = _discover_lease()
+            lease_url, lease_token = _lease_cache
+        url = url or lease_url
+        token = token or lease_token
+    if url is None or token is None:
         raise RuntimeError(
-            "NX_SERVICE_TOKEN must be set: T3 vector serving routes through "
-            "the nexus-service HTTP API (RDR-155 Phase 4a — the direct Chroma "
-            "serving paths are retired). Start the service and export "
-            "NX_SERVICE_URL / NX_SERVICE_TOKEN."
+            "nexus-service endpoint is not resolvable: T3 vector serving "
+            "routes through the nexus-service HTTP API (RDR-155 Phase 4a — "
+            "the direct Chroma serving paths are retired). Either start the "
+            "supervisor with 'nx daemon service start' (publishes the "
+            "endpoint lease this client auto-discovers), or export "
+            "NX_SERVICE_URL / NX_SERVICE_TOKEN explicitly."
         )
-    return tok
+    return url, token
+
+
+def _invalidate_endpoint() -> None:
+    """Drop the cached lease so the next call re-discovers (port churn)."""
+    global _lease_cache
+    with _endpoint_lock:
+        _lease_cache = None
+
+
+def _is_retryable_endpoint_error(exc: Exception) -> bool:
+    """401 (token rotated + republished) or connection-refused (supervisor
+    restarted on a new port) — the two auto-restart signatures."""
+    import urllib.error
+
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code == 401
+    if isinstance(exc, urllib.error.URLError):
+        reason = getattr(exc, "reason", None)
+        return isinstance(reason, ConnectionRefusedError)
+    return isinstance(exc, ConnectionRefusedError)
 
 
 # ── HTTP transport ────────────────────────────────────────────────────────────
+
+
+def _request_once(
+    method: str, path: str, *, tenant: str, timeout: int, body: dict | None
+) -> Any:
+    """One HTTP round-trip against the currently-resolved endpoint.
+
+    Raises the raw ``urllib.error`` exceptions — the retry wrapper below
+    classifies them; the public ``_post``/``_get`` wrap HTTP errors into
+    :class:`VectorServiceError`.
+    """
+    import urllib.request
+
+    base_url, token = _resolve_endpoint()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Nexus-Tenant": tenant,
+    }
+    data = None
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        base_url + path, data=data, headers=headers, method=method
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def _request(
+    method: str, path: str, *, tenant: str, timeout: int, body: dict | None
+) -> Any:
+    """Round-trip with ONE re-resolve retry on the auto-restart signatures.
+
+    The supervisor allocates a new port (and republishes the lease, token
+    included) on every restart; a 401 or connection-refused against the
+    cached endpoint therefore means "re-read the lease and try once more"
+    (nexus-pebfx.1), not "give up". A second failure surfaces normally —
+    no retry loops.
+    """
+    import urllib.error
+
+    try:
+        return _request_once(method, path, tenant=tenant, timeout=timeout, body=body)
+    except Exception as exc:
+        if not _is_retryable_endpoint_error(exc):
+            raise
+        _log.info(
+            "vector_endpoint_reresolve",
+            path=path,
+            reason=type(exc).__name__,
+        )
+        _invalidate_endpoint()
+        return _request_once(method, path, tenant=tenant, timeout=timeout, body=body)
 
 
 def _post(path: str, body: dict, *, tenant: str = "default", timeout: int = 120) -> Any:
@@ -70,23 +196,9 @@ def _post(path: str, body: dict, *, tenant: str = "default", timeout: int = 120)
     should still fail fast.
     """
     import urllib.error
-    import urllib.request
 
-    url = _service_url() + path
-    data = json.dumps(body).encode()
-    req = urllib.request.Request(
-        url,
-        data=data,
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {_service_token()}",
-            "X-Nexus-Tenant": tenant,
-        },
-        method="POST",
-    )
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read())
+        return _request("POST", path, tenant=tenant, timeout=timeout, body=body)
     except urllib.error.HTTPError as e:
         body_bytes = e.read()
         try:
@@ -101,20 +213,9 @@ def _post(path: str, body: dict, *, tenant: str = "default", timeout: int = 120)
 def _get(path: str, *, tenant: str = "default") -> Any:
     """GET from the service endpoint, return parsed response body."""
     import urllib.error
-    import urllib.request
 
-    url = _service_url() + path
-    req = urllib.request.Request(
-        url,
-        headers={
-            "Authorization": f"Bearer {_service_token()}",
-            "X-Nexus-Tenant": tenant,
-        },
-        method="GET",
-    )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            return json.loads(resp.read())
+        return _request("GET", path, tenant=tenant, timeout=30, body=None)
     except urllib.error.HTTPError as e:
         body_bytes = e.read()
         try:

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -59,7 +59,11 @@ _VECTORS_BACKEND_ENV = "NX_STORAGE_BACKEND_VECTORS"
 
 _endpoint_lock = threading.Lock()
 #: Cached (base_url, token) from the LEASE only — env halves are read fresh.
-_lease_cache: tuple[str | None, str | None] | None = None
+#: Module-global: shared by every HttpVectorClient instance and thread in the
+#: process (the client itself is a process-wide singleton). Populated only on
+#: a SUCCESSFUL discovery — a missing lease is never cached, so a client
+#: started before the supervisor picks the lease up as soon as it appears.
+_lease_cache: tuple[str, str | None] | None = None
 
 
 def _discover_lease() -> tuple[str | None, str | None]:
@@ -91,10 +95,23 @@ def _resolve_endpoint() -> tuple[str, str]:
     if url is None or token is None:
         with _endpoint_lock:
             if _lease_cache is None:
-                _lease_cache = _discover_lease()
-            lease_url, lease_token = _lease_cache
+                discovered = _discover_lease()
+                if discovered[0] is not None:
+                    # Cache ONLY on success: a (None, None) miss must not
+                    # stick, or a client started before the supervisor would
+                    # never discover it (dual-review S1).
+                    _lease_cache = discovered  # type: ignore[assignment]
+            lease_url, lease_token = _lease_cache or (None, None)
         url = url or lease_url
         token = token or lease_token
+        if env_url is not None and token is lease_token and token is not None:
+            _log.debug(
+                "vector_endpoint_mixed_source", url_source="env", token_source="lease"
+            )
+        elif env_token is not None and url is lease_url and url is not None:
+            _log.debug(
+                "vector_endpoint_mixed_source", url_source="lease", token_source="env"
+            )
     if url is None or token is None:
         raise RuntimeError(
             "nexus-service endpoint is not resolvable: T3 vector serving "
@@ -115,16 +132,25 @@ def _invalidate_endpoint() -> None:
 
 
 def _is_retryable_endpoint_error(exc: Exception) -> bool:
-    """401 (token rotated + republished) or connection-refused (supervisor
-    restarted on a new port) — the two auto-restart signatures."""
+    """The three auto-restart signatures (dual-review S2 added RST):
+
+    - 401: token rotated + republished with the lease.
+    - connection refused: supervisor restarted; old port is dead.
+    - connection reset (incl. ``http.client.RemoteDisconnected``): the
+      supervisor SIGTERMs the JVM process group on restart, so a request
+      IN FLIGHT at restart time gets a TCP RST, not a refusal. Every
+      operation this client issues is idempotent (upsert on
+      (tenant, collection, chash) ON CONFLICT; deletes; reads), so a
+      single retry after a mid-flight reset is safe.
+    """
     import urllib.error
 
     if isinstance(exc, urllib.error.HTTPError):
         return exc.code == 401
     if isinstance(exc, urllib.error.URLError):
         reason = getattr(exc, "reason", None)
-        return isinstance(reason, ConnectionRefusedError)
-    return isinstance(exc, ConnectionRefusedError)
+        return isinstance(reason, (ConnectionRefusedError, ConnectionResetError))
+    return isinstance(exc, (ConnectionRefusedError, ConnectionResetError))
 
 
 # ── HTTP transport ────────────────────────────────────────────────────────────
@@ -172,7 +198,10 @@ def _request(
 
     try:
         return _request_once(method, path, tenant=tenant, timeout=timeout, body=body)
-    except Exception as exc:
+    # Narrow catch (dual-review H1): only the transport/auth error families
+    # participate in retry classification. RuntimeError from an unresolvable
+    # endpoint propagates untouched — fail-loud must never become a retry.
+    except (urllib.error.URLError, ConnectionRefusedError, ConnectionResetError) as exc:
         if not _is_retryable_endpoint_error(exc):
             raise
         _log.info(

--- a/tests/db/test_service_endpoint_discovery.py
+++ b/tests/db/test_service_endpoint_discovery.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-pebfx.1 — ServiceRegistry-lease endpoint discovery for HttpVectorClient.
+
+The supervisor (``storage_service_daemon``) publishes ``{host, port, token}``
+to the ServiceRegistry lease (``storage_service_addr.<uid>``) after a healthy
+``/health``; before this bead the client ignored it and hard-required
+``NX_SERVICE_URL`` + ``NX_SERVICE_TOKEN`` env, with a silent hardcoded
+``:8080`` fallback. Since the supervisor allocates a NEW free port on every
+(re)start, every env-plumbed client broke silently after any auto-restart
+(observed live during the 2026-06-10 RDR-155 production migration:
+53748 → 54239 → 56915 in one afternoon).
+
+Resolution order pinned here (bead design, RDR-156-adjacent fail-loud
+discipline):
+
+1. ``NX_SERVICE_URL`` / ``NX_SERVICE_TOKEN`` env — each INDEPENDENTLY
+   overrides its half (operator/test override).
+2. ServiceRegistry lease — tier="storage_service", scope=str(os.getuid()),
+   exactly what the supervisor publishes.
+3. FAIL LOUD. The hardcoded ``http://127.0.0.1:8080`` default is retired —
+   a silent wrong-port fallback is a correctness hazard, not a convenience.
+
+Re-resolution: on HTTP 401 or a connection-refused class error, the cached
+endpoint is invalidated, the lease re-read, and the request retried ONCE —
+this is how clients ride through supervisor auto-restarts (new port, same
+persisted token, republished lease).
+
+The conftest autouse ``_isolate_config_dir`` fixture redirects
+``NEXUS_CONFIG_DIR`` to tmp_path, so no test here can see a real lease.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from nexus.daemon.service_registry import ServiceRegistry
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _config_dir() -> Path:
+    # The autouse _isolate_config_dir fixture sets NEXUS_CONFIG_DIR per test.
+    d = Path(os.environ["NEXUS_CONFIG_DIR"])
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _publish_lease(*, host: str = "127.0.0.1", port: int, token: str) -> None:
+    reg = ServiceRegistry(dir=_config_dir(), tier="storage_service")
+    reg.publish(
+        str(os.getuid()),
+        endpoint={"host": host, "port": port, "token": token},
+        version="test",
+        owner_token="pebfx1-test-owner",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_endpoint_state(monkeypatch):
+    """Each test starts with no env override and a cold resolver cache."""
+    monkeypatch.delenv("NX_SERVICE_URL", raising=False)
+    monkeypatch.delenv("NX_SERVICE_TOKEN", raising=False)
+    from nexus.db import http_vector_client as hvc
+
+    hvc._invalidate_endpoint()
+    yield
+    hvc._invalidate_endpoint()
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    """Tiny service stub: 200 {"ok": true} when the bearer token matches
+    ``server.expected_token``, else 401. Counts requests."""
+
+    def do_POST(self):  # noqa: N802 (http.server API)
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        expected = getattr(self.server, "expected_token", None)
+        got = self.headers.get("Authorization", "")
+        self.server.request_auths.append(got)  # type: ignore[attr-defined]
+        if expected is not None and got != f"Bearer {expected}":
+            self.send_response(401)
+            body = b'{"error": "bad token"}'
+        else:
+            self.send_response(200)
+            body = b'{"ok": true, "results": [], "upserted": 0}'
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):  # silence
+        pass
+
+
+@pytest.fixture()
+def stub_server():
+    srv = HTTPServer(("127.0.0.1", 0), _StubHandler)
+    srv.expected_token = None  # type: ignore[attr-defined]
+    srv.request_auths = []  # type: ignore[attr-defined]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    yield srv
+    srv.shutdown()
+
+
+# ── resolution order ─────────────────────────────────────────────────────────
+
+
+class TestResolutionOrder:
+    def test_env_overrides_win_without_lease(self, monkeypatch):
+        monkeypatch.setenv("NX_SERVICE_URL", "http://127.0.0.1:7777")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "env-token")
+        from nexus.db.http_vector_client import _resolve_endpoint
+
+        url, token = _resolve_endpoint()
+        assert url == "http://127.0.0.1:7777"
+        assert token == "env-token"
+
+    def test_lease_resolves_when_env_absent(self):
+        _publish_lease(port=4242, token="lease-token")
+        from nexus.db.http_vector_client import _resolve_endpoint
+
+        url, token = _resolve_endpoint()
+        assert url == "http://127.0.0.1:4242"
+        assert token == "lease-token"
+
+    def test_env_url_with_lease_token(self, monkeypatch):
+        """Each half overrides independently: URL from env, token from lease."""
+        monkeypatch.setenv("NX_SERVICE_URL", "http://127.0.0.1:7777")
+        _publish_lease(port=4242, token="lease-token")
+        from nexus.db.http_vector_client import _resolve_endpoint
+
+        url, token = _resolve_endpoint()
+        assert url == "http://127.0.0.1:7777"
+        assert token == "lease-token"
+
+    def test_env_token_with_lease_url(self, monkeypatch):
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "env-token")
+        _publish_lease(port=4242, token="lease-token")
+        from nexus.db.http_vector_client import _resolve_endpoint
+
+        url, token = _resolve_endpoint()
+        assert url == "http://127.0.0.1:4242"
+        assert token == "env-token"
+
+    def test_fail_loud_when_neither_no_8080_fallback(self):
+        """No env + no lease = RuntimeError. The legacy silent
+        ``http://127.0.0.1:8080`` default must be gone — and the message
+        must self-explain every recovery knob (GUI-spawn discipline,
+        tests/test_credential_persistence_gui_spawn.py)."""
+        from nexus.db.http_vector_client import _resolve_endpoint
+
+        with pytest.raises(RuntimeError) as exc_info:
+            _resolve_endpoint()
+        msg = str(exc_info.value)
+        assert "NX_SERVICE_TOKEN" in msg
+        assert "NX_SERVICE_URL" in msg
+        assert "nx daemon service start" in msg
+        assert "RDR-155" in msg
+        assert "8080" not in msg
+
+    def test_expired_lease_is_absent(self):
+        """A TTL-expired lease is the same as no lease: fail loud."""
+        reg = ServiceRegistry(
+            dir=_config_dir(), tier="storage_service",
+            ttl=10.0, clock=lambda: 100.0,  # published "in the past"
+        )
+        reg.publish(
+            str(os.getuid()),
+            endpoint={"host": "127.0.0.1", "port": 4242, "token": "stale"},
+            version="test",
+            owner_token="pebfx1-test-owner",
+        )
+        from nexus.db.http_vector_client import _resolve_endpoint
+
+        with pytest.raises(RuntimeError):
+            _resolve_endpoint()
+
+
+# ── live re-resolution (the port-churn / restart ride-through) ───────────────
+
+
+class TestReResolution:
+    def test_connection_refused_rereads_lease_and_retries(self, stub_server):
+        """Lease initially points at a dead port; after the cache primes,
+        the supervisor 'restarts' (lease republished at the live port).
+        The next request must ride through: refused → invalidate →
+        re-resolve → retry → 200."""
+        from nexus.db import http_vector_client as hvc
+
+        live_port = stub_server.server_address[1]
+        dead_port = _find_dead_port()
+        _publish_lease(port=dead_port, token="tok-1")
+        url, _ = hvc._resolve_endpoint()
+        assert str(dead_port) in url  # cache primed on the dead endpoint
+
+        _publish_lease(port=live_port, token="tok-1")  # "restart"
+        result = hvc._post("/v1/vectors/search", {"q": "x"})
+        assert result["ok"] is True
+
+    def test_401_rereads_lease_token_and_retries(self, stub_server):
+        """Token rotated + republished (HIGH-3: clients re-read it from the
+        lease after restart): a 401 with the cached token must trigger one
+        re-resolve + retry with the fresh token."""
+        from nexus.db import http_vector_client as hvc
+
+        live_port = stub_server.server_address[1]
+        stub_server.expected_token = "tok-new"
+        _publish_lease(port=live_port, token="tok-old")
+        hvc._resolve_endpoint()  # cache primed with tok-old
+
+        _publish_lease(port=live_port, token="tok-new")  # rotation
+        result = hvc._post("/v1/vectors/search", {"q": "x"})
+        assert result["ok"] is True
+        assert stub_server.request_auths == ["Bearer tok-old", "Bearer tok-new"]
+
+    def test_retry_is_single_shot(self):
+        """Two dead endpoints in a row = error surfaces after exactly one
+        re-resolve; no infinite retry loop."""
+        from nexus.db import http_vector_client as hvc
+
+        _publish_lease(port=_find_dead_port(), token="tok")
+        with pytest.raises(Exception):
+            hvc._post("/v1/vectors/search", {"q": "x"})
+
+
+def _find_dead_port() -> int:
+    import socket
+
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ── catalog client shares the same resolution discipline ─────────────────────
+
+
+class TestCatalogClientResolution:
+    def test_catalog_resolve_config_falls_back_to_lease(self):
+        _publish_lease(port=4243, token="lease-token")
+        from nexus.catalog.http_catalog_client import _resolve_config
+
+        host, port, token = _resolve_config()
+        assert (host, port, token) == ("127.0.0.1", 4243, "lease-token")
+
+    def test_catalog_env_halves_override_individually(self, monkeypatch):
+        monkeypatch.setenv("NX_SERVICE_PORT", "9999")
+        _publish_lease(port=4243, token="lease-token")
+        from nexus.catalog.http_catalog_client import _resolve_config
+
+        host, port, token = _resolve_config()
+        assert port == 9999          # env wins
+        assert token == "lease-token"  # lease fills the missing half
+
+    def test_catalog_fail_loud_when_neither(self):
+        from nexus.catalog.http_catalog_client import _resolve_config
+
+        with pytest.raises(RuntimeError) as exc_info:
+            _resolve_config()
+        msg = str(exc_info.value)
+        assert "nx daemon service start" in msg
+        assert "NX_SERVICE_PORT" in msg

--- a/tests/db/test_service_endpoint_discovery.py
+++ b/tests/db/test_service_endpoint_discovery.py
@@ -265,3 +265,68 @@ class TestCatalogClientResolution:
         msg = str(exc_info.value)
         assert "nx daemon service start" in msg
         assert "NX_SERVICE_PORT" in msg
+
+
+# ── dual-review fixes (S1, S2) + AUDIT closure (make_t3 serving path) ────────
+
+
+class _OneShotResetHandler(_StubHandler):
+    """First request: abrupt close (TCP RST / RemoteDisconnected — the
+    mid-flight supervisor-SIGTERM signature). Subsequent requests: normal."""
+
+    def do_POST(self):  # noqa: N802
+        if not getattr(self.server, "reset_done", False):
+            self.server.reset_done = True  # type: ignore[attr-defined]
+            self.connection.close()
+            return
+        super().do_POST()
+
+
+class TestDualReviewFixes:
+    def test_lease_miss_is_not_cached_supervisor_starts_later(self):
+        """S1: a client that resolves BEFORE the supervisor publishes its
+        lease must pick the lease up on a later call without a process
+        restart — a (None, None) miss must never stick."""
+        from nexus.db import http_vector_client as hvc
+
+        with pytest.raises(RuntimeError):
+            hvc._resolve_endpoint()  # supervisor not up yet
+
+        _publish_lease(port=4242, token="late-token")  # supervisor arrives
+        url, token = hvc._resolve_endpoint()
+        assert url == "http://127.0.0.1:4242"
+        assert token == "late-token"
+
+    def test_midflight_reset_retries(self):
+        """S2: an in-flight request at supervisor-restart time gets a TCP
+        RST (RemoteDisconnected), not a refusal — it must re-resolve and
+        retry once, same as refused."""
+        from nexus.db import http_vector_client as hvc
+
+        srv = HTTPServer(("127.0.0.1", 0), _OneShotResetHandler)
+        srv.expected_token = None  # type: ignore[attr-defined]
+        srv.request_auths = []  # type: ignore[attr-defined]
+        t = threading.Thread(target=srv.serve_forever, daemon=True)
+        t.start()
+        try:
+            _publish_lease(port=srv.server_address[1], token="tok")
+            result = hvc._post("/v1/vectors/search", {"q": "x"})
+            assert result["ok"] is True
+        finally:
+            srv.shutdown()
+
+
+class TestServingPathAuditClosure:
+    def test_make_t3_serves_via_lease_with_no_env(self, stub_server):
+        """The bead's AUDIT clause: the post-P4a serving path must work
+        out-of-box with NO env set when the supervisor lease exists —
+        ``make_t3()`` → ``HttpVectorClient`` → request resolves via the
+        lease (this was exactly the broken-for-installed-users scenario)."""
+        from nexus.db import make_t3
+
+        _publish_lease(port=stub_server.server_address[1], token="lease-tok")
+        t3 = make_t3()
+        t3.search("anything", ["knowledge__x__minilm-l6-v2-384__v1"])
+        # The proof: the request reached the stub authenticated with the
+        # LEASE token, with zero env plumbing.
+        assert stub_server.request_auths == ["Bearer lease-tok"]

--- a/tests/test_storage_migrate_vectors_cmd.py
+++ b/tests/test_storage_migrate_vectors_cmd.py
@@ -26,6 +26,10 @@ def _report(leg: str, *results: CollectionResult) -> MigrationReport:
 @pytest.fixture()
 def runner(monkeypatch) -> CliRunner:
     monkeypatch.setenv("NX_SERVICE_TOKEN", "cli-test-token")
+    # nexus-pebfx.1: the hardcoded :8080 default URL is retired (resolution is
+    # env > ServiceRegistry lease > fail loud), so tests must pin BOTH halves.
+    # The engine functions are monkeypatched below; no HTTP ever happens.
+    monkeypatch.setenv("NX_SERVICE_URL", "http://127.0.0.1:1")
     return CliRunner()
 
 


### PR DESCRIPTION
## Summary

nexus-pebfx.1 — one of the three legs of release-blocker nexus-luxe6. The supervisor publishes {host, port, token} to the storage_service lease and allocates a NEW port on every (re)start; clients hard-required NX_SERVICE_URL/NX_SERVICE_TOKEN env with a silent hardcoded :8080 fallback, so every env-plumbed client broke after any auto-restart (observed three times during the 2026-06-10 production migration).

- Resolution order: env halves override individually (read fresh) → ServiceRegistry lease (success-only cache) → FAIL LOUD with recovery knobs. The :8080 silent fallback is retired.
- Single retry on the three auto-restart signatures: 401 (token rotated + republished), connection-refused (between requests), connection-reset incl. RemoteDisconnected (mid-flight SIGTERM — all client ops are idempotent). RuntimeError fail-loud can never enter the retry path (narrowed catch).
- Catalog client `_resolve_config` gains the same lease fallback (urlsplit parse); its restart-safety contract (per-call instantiation) is now documented.
- `nx storage migrate vectors`: explicit token gate replaced by a resolution pre-flight; `--dry-run` needs no service at all.
- Bead AUDIT clause closed with a test: `make_t3()` → `search` resolves via the lease with ZERO env against a live stub — the exact broken-for-installed-users scenario.

15-test discovery suite (resolution order, expired lease, port-churn ride-through, 401 rotation, mid-flight RST, single-shot retry bound, catalog parity, factory-path audit closure). Dual review (code-review-expert + substantive-critic) + delta re-reviews: all CONFIRMED-FIXED, 0 residual, APPROVED FOR MERGE.

Practical effect: restarted Claude/nx instances converge onto the pgvector serving path with zero env ceremony — the instance-convergence enabler.

## Closes
References bead nexus-pebfx.1 (beads tracker).