### PR TITLE
fix: per-collection error isolation in cross-corpus search [nexus-pebfx.8]

### DIFF
--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -19,6 +19,7 @@ from nexus.formatters import (
     format_vimgrep,
 )
 from nexus.scoring import RG_FLOOR_SCORE, apply_hybrid_scoring, rerank_results, round_robin_interleave
+from nexus.db.http_vector_client import VectorServiceError
 from nexus.search_engine import SearchDiagnostics, search_cross_corpus
 from nexus.types import SearchResult
 
@@ -326,7 +327,12 @@ def search_cmd(
                 raw.extend(_rg_hit_to_result(h) for h in rg_hits)
         return raw
 
-    results = _retrieve(query)
+    try:
+        results = _retrieve(query)
+    except VectorServiceError as exc:
+        # nexus-pebfx.8: every targeted collection was unservable — show the
+        # service's error body cleanly instead of a raw traceback.
+        raise click.ClickException(str(exc)) from exc
 
     if not results:
         _maybe_emit_silent_zero_note(

--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -67,6 +67,15 @@ def _maybe_emit_silent_zero_note(
     if not diagnostics_out:
         return
     diag = diagnostics_out[0]
+    if diag.failed_collections:
+        # nexus-pebfx.8: skipped-by-service-error collections were never
+        # searched — a zero-hit must say so or it reads as a genuine miss.
+        click.echo(
+            f"note: {len(diag.failed_collections)} collection(s) excluded by "
+            "service errors and NOT searched: "
+            + ", ".join(diag.failed_collections),
+            err=True,
+        )
     if diag.total_dropped < 1:
         return
     worst = diag.worst_offender()

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -740,15 +740,26 @@ def _no_results_message(diagnostics: list, *, base: str = "No results.") -> str:
     """
     if not diagnostics:
         return base
+    # nexus-pebfx.8: collections the backend refused to serve were skipped,
+    # not searched — a zero-hit must say so or it reads as a genuine miss.
+    failed = diagnostics[0].failed_collections
+    suffix = ""
+    if failed:
+        suffix = (
+            f" Note: {len(failed)} collection(s) were excluded by service "
+            "errors and NOT searched: "
+            + "; ".join(f"{c}: {e}" for c, e in failed.items())
+        )
     worst = diagnostics[0].worst_offender()
     if worst is None:
-        return base
+        return base + suffix
     name, threshold, top_distance = worst
     thr = f"{threshold:.4f}" if threshold is not None else "the per-corpus default"
     return (
         f"{base} Closest candidate was dropped at distance {top_distance:.4f} "
         f"(threshold {thr}, collection {name}). Re-run with "
         f"threshold={top_distance + 0.05:.2f} (or higher) to include it."
+        + suffix
     )
 
 

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -466,6 +466,11 @@ def search_cross_corpus(
     else:
         effective_where = where
 
+    # nexus-pebfx.8: dedupe — failed_collections is keyed by name, so a
+    # duplicated input name would break the all-failed equality check below
+    # (and duplicate searches buy nothing).
+    collections = list(dict.fromkeys(collections))
+
     all_results: list[SearchResult] = []
     diag_per_collection: dict[str, tuple[int, int, float | None, float | None]] = {}
     failed_collections: dict[str, str] = {}
@@ -543,7 +548,7 @@ def search_cross_corpus(
         # Nothing was servable — surface the failure instead of silently
         # returning zero results (a misconfigured service must fail loud).
         raise VectorServiceError(
-            f"all {len(collections)} collections failed: "
+            f"all {len(failed_collections)} collections failed: "
             + "; ".join(f"{c}: {e}" for c, e in failed_collections.items()),
         )
 

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -11,6 +11,7 @@ from typing import Any
 import structlog
 
 from nexus.config import get_telemetry_config, load_config
+from nexus.db.http_vector_client import VectorServiceError
 from nexus.types import SearchResult
 
 _log = structlog.get_logger(__name__)
@@ -43,6 +44,10 @@ class SearchDiagnostics:
     )
     total_dropped: int = 0
     total_raw: int = 0
+    # nexus-pebfx.8: collections the backend refused to serve (e.g. service-mode
+    # HTTP 400 on an embedding-space mismatch), name → error text. These are
+    # excluded from ``per_collection`` so threshold telemetry stays clean.
+    failed_collections: dict[str, str] = field(default_factory=dict)
 
     def collections_with_drops(self) -> int:
         return sum(
@@ -463,6 +468,7 @@ def search_cross_corpus(
 
     all_results: list[SearchResult] = []
     diag_per_collection: dict[str, tuple[int, int, float | None, float | None]] = {}
+    failed_collections: dict[str, str] = {}
     total_dropped = 0
     total_raw = 0
     # Per-collection raw min-distance accumulator for search_telemetry rows.
@@ -482,7 +488,19 @@ def search_cross_corpus(
             threshold = threshold_override
         else:
             threshold = _threshold_for_collection(col, cfg)
-        raw = t3.search(query, [col], n_results=per_k, where=effective_where)
+        try:
+            raw = t3.search(query, [col], n_results=per_k, where=effective_where)
+        except VectorServiceError as exc:
+            # nexus-pebfx.8: one unservable collection (embedding-space
+            # mismatch → service-side HTTP 400) must not sink the whole
+            # cross-corpus search. Skip it, keep the rest.
+            failed_collections[col] = str(exc)
+            _log.warning(
+                "collection_search_failed",
+                collection=col,
+                error=str(exc),
+            )
+            continue
         dropped = 0
         # Minimum distance among dropped items — best-of-dropped, used by
         # SearchDiagnostics.worst_offender() for the "threshold bump" hint.
@@ -521,11 +539,20 @@ def search_cross_corpus(
                 threshold=threshold,
             )
 
+    if failed_collections and len(failed_collections) == len(collections):
+        # Nothing was servable — surface the failure instead of silently
+        # returning zero results (a misconfigured service must fail loud).
+        raise VectorServiceError(
+            f"all {len(collections)} collections failed: "
+            + "; ".join(f"{c}: {e}" for c, e in failed_collections.items()),
+        )
+
     if diagnostics_out is not None:
         diagnostics_out.append(SearchDiagnostics(
             per_collection=diag_per_collection,
             total_dropped=total_dropped,
             total_raw=total_raw,
+            failed_collections=failed_collections,
         ))
 
     # RDR-087 Phase 2.2: persist per-call threshold-filter telemetry.

--- a/tests/test_distance_thresholds.py
+++ b/tests/test_distance_thresholds.py
@@ -170,3 +170,45 @@ class TestNoResultsMessage:
             per_collection={"code__x": (0, 0, 0.45, None)},
         )
         assert _no_results_message([diag]) == "No results."
+
+
+class TestNoResultsMessageFailedCollections:
+    """nexus-pebfx.8: a zero-hit where collections were excluded by service
+    errors must say so — otherwise a partial outage reads as a genuine miss."""
+
+    def test_failed_collections_noted_when_nothing_dropped(self) -> None:
+        from nexus.mcp.core import _no_results_message
+        from nexus.search_engine import SearchDiagnostics
+
+        diag = SearchDiagnostics(
+            per_collection={"code__x": (0, 0, 0.45, None)},
+            failed_collections={
+                "knowledge__seam": "POST /v1/vectors/search → HTTP 400: dim mismatch",
+            },
+        )
+        msg = _no_results_message([diag])
+        assert msg.startswith("No results.")
+        assert "1 collection(s) were excluded" in msg
+        assert "knowledge__seam" in msg
+        assert "HTTP 400" in msg
+
+    def test_failed_collections_appended_to_threshold_note(self) -> None:
+        from nexus.mcp.core import _no_results_message
+        from nexus.search_engine import SearchDiagnostics
+
+        diag = SearchDiagnostics(
+            per_collection={"knowledge__papers": (3, 3, 0.65, 0.5515)},
+            total_dropped=3,
+            total_raw=3,
+            failed_collections={"knowledge__seam": "HTTP 400: dim mismatch"},
+        )
+        msg = _no_results_message([diag])
+        assert "0.5515" in msg
+        assert "knowledge__seam" in msg
+
+    def test_no_suffix_without_failures(self) -> None:
+        from nexus.mcp.core import _no_results_message
+        from nexus.search_engine import SearchDiagnostics
+
+        diag = SearchDiagnostics(per_collection={"code__x": (0, 0, 0.45, None)})
+        assert _no_results_message([diag]) == "No results."

--- a/tests/test_search_cmd.py
+++ b/tests/test_search_cmd.py
@@ -892,3 +892,27 @@ def test_silent_zero_picks_worst_offender_across_collections(
     # Must NOT report the other collection's threshold as if it were worst.
     assert "code__a" not in result.output.split("knowledge__b")[0] or \
         "top_distance 0.82" in result.output
+
+
+# ── Service-error surface (nexus-pebfx.8) ───────────────────────────────────
+
+
+def test_vector_service_error_renders_clean_message(runner: CliRunner, cloud_env) -> None:
+    """An all-collections-failed VectorServiceError surfaces as a clean
+    click error, not a raw traceback (nexus-pebfx.8 secondary issue)."""
+    from nexus.db.http_vector_client import VectorServiceError
+
+    mock_t3 = _mock_t3()
+    err = VectorServiceError(
+        "all 1 collections failed: knowledge__test: POST /v1/vectors/search "
+        "→ HTTP 400: query embedder produced a 1024-dim vector but the "
+        "collections dispatch to chunks_384",
+    )
+    with patch("nexus.commands.search_cmd._t3", return_value=mock_t3), \
+         patch("nexus.commands.search_cmd.search_cross_corpus", side_effect=err), \
+         patch("nexus.commands.search_cmd.load_config", return_value=_LOAD_CFG):
+        res = runner.invoke(main, ["search", "query", "--corpus", "knowledge"])
+    assert res.exit_code == 1
+    assert "HTTP 400" in res.output
+    assert "Traceback" not in res.output
+    assert not isinstance(res.exception, VectorServiceError)

--- a/tests/test_search_cmd.py
+++ b/tests/test_search_cmd.py
@@ -916,3 +916,35 @@ def test_vector_service_error_renders_clean_message(runner: CliRunner, cloud_env
     assert "HTTP 400" in res.output
     assert "Traceback" not in res.output
     assert not isinstance(res.exception, VectorServiceError)
+
+
+def test_silent_zero_notes_failed_collections(
+    runner: CliRunner, cloud_env,
+) -> None:
+    """nexus-pebfx.8: zero results with service-error-excluded collections
+    must emit a stderr note naming them — a partial outage must not read
+    as a genuine miss."""
+    from nexus.search_engine import SearchDiagnostics
+
+    mock_t3 = _mock_t3(["knowledge__art"])
+
+    def fake(query, cols, n_results, t3, where=None, **kwargs):
+        diag_out = kwargs.get("diagnostics_out")
+        if diag_out is not None:
+            diag_out.append(SearchDiagnostics(
+                per_collection={"knowledge__art": (0, 0, 0.65, None)},
+                total_dropped=0,
+                total_raw=0,
+                failed_collections={
+                    "knowledge__seam": "HTTP 400: dim mismatch",
+                },
+            ))
+        return []
+
+    with patch("nexus.commands.search_cmd._t3", return_value=mock_t3), \
+         patch("nexus.commands.search_cmd.search_cross_corpus", side_effect=fake), \
+         patch("nexus.commands.search_cmd.load_config", return_value=_LOAD_CFG):
+        result = runner.invoke(main, ["search", "query", "--corpus", "knowledge"])
+    assert result.exit_code == 0, result.output
+    assert "excluded by service errors" in result.output
+    assert "knowledge__seam" in result.output

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -790,3 +790,95 @@ class TestAttachDocIdsFromCatalog:
             "Phase-3 chunk did NOT receive link boost. The attach helper "
             "did not inject doc_id, OR apply_link_boost regressed."
         )
+
+
+# ── Per-collection error isolation (nexus-pebfx.8) ──────────────────────────
+
+
+class _FailingT3:
+    """T3 stand-in where selected collections raise VectorServiceError.
+
+    Models the service-mode failure where a collection's embedding space
+    doesn't match the query embedding (HTTP 400 from /v1/vectors/search).
+    """
+
+    def __init__(
+        self,
+        results_by_col: dict[str, list[dict]],
+        failing: set[str],
+        voyage: bool = True,
+    ):
+        self._results = results_by_col
+        self._failing = set(failing)
+        self._voyage_client = "fake-voyage" if voyage else None
+
+    def search(self, query, collection_names, n_results=10, where=None):
+        from nexus.db.http_vector_client import VectorServiceError
+
+        col = collection_names[0]
+        if col in self._failing:
+            raise VectorServiceError(
+                "POST /v1/vectors/search → HTTP 400: query embedder produced "
+                "a 1024-dim vector but the collections dispatch to chunks_384",
+            )
+        return self._results.get(col, [])
+
+
+class TestPerCollectionErrorIsolation:
+    """One unservable collection must not sink the whole cross-corpus search.
+
+    nexus-pebfx.8: the default knowledge,code,docs search died with HTTP 400
+    because the 384-dim seam-b-test collection was in the prefix expansion
+    alongside 1024-dim collections — the loop re-raised on the first
+    unservable collection and the user got zero results plus a traceback.
+    """
+
+    def test_one_failing_collection_does_not_sink_the_search(self):
+        t3 = _FailingT3(
+            {"code__nexus": [{"id": "a", "content": "hit", "distance": 0.30}]},
+            failing={"knowledge__seam-b-test__minilm-l6-v2-384__v1"},
+        )
+        results = search_cross_corpus(
+            "q",
+            ["code__nexus", "knowledge__seam-b-test__minilm-l6-v2-384__v1"],
+            10,
+            t3,
+        )
+        assert {r.id for r in results} == {"a"}
+
+    def test_failure_recorded_in_diagnostics(self):
+        from nexus.search_engine import SearchDiagnostics
+
+        t3 = _FailingT3(
+            {"code__nexus": [{"id": "a", "content": "hit", "distance": 0.30}]},
+            failing={"knowledge__seam"},
+        )
+        diags: list[SearchDiagnostics] = []
+        search_cross_corpus(
+            "q", ["code__nexus", "knowledge__seam"], 10, t3,
+            diagnostics_out=diags,
+        )
+        assert list(diags[0].failed_collections) == ["knowledge__seam"]
+        assert "HTTP 400" in diags[0].failed_collections["knowledge__seam"]
+
+    def test_failed_collection_absent_from_per_collection_diag(self):
+        from nexus.search_engine import SearchDiagnostics
+
+        t3 = _FailingT3(
+            {"code__nexus": [{"id": "a", "content": "hit", "distance": 0.30}]},
+            failing={"knowledge__seam"},
+        )
+        diags: list[SearchDiagnostics] = []
+        search_cross_corpus(
+            "q", ["code__nexus", "knowledge__seam"], 10, t3,
+            diagnostics_out=diags,
+        )
+        assert "knowledge__seam" not in diags[0].per_collection
+        assert list(diags[0].per_collection) == ["code__nexus"]
+
+    def test_all_collections_failing_reraises(self):
+        from nexus.db.http_vector_client import VectorServiceError
+
+        t3 = _FailingT3({}, failing={"code__a", "knowledge__b"})
+        with pytest.raises(VectorServiceError, match="all 2 collections failed"):
+            search_cross_corpus("q", ["code__a", "knowledge__b"], 10, t3)

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -882,3 +882,29 @@ class TestPerCollectionErrorIsolation:
         t3 = _FailingT3({}, failing={"code__a", "knowledge__b"})
         with pytest.raises(VectorServiceError, match="all 2 collections failed"):
             search_cross_corpus("q", ["code__a", "knowledge__b"], 10, t3)
+
+    def test_duplicate_collections_all_failing_still_reraises(self):
+        """The all-fail guard must not be defeated by a duplicated input
+        name (failed_collections is keyed by name; pre-dedup the input)."""
+        from nexus.db.http_vector_client import VectorServiceError
+
+        t3 = _FailingT3({}, failing={"code__a"})
+        with pytest.raises(VectorServiceError, match="all 1 collections failed"):
+            search_cross_corpus("q", ["code__a", "code__a"], 10, t3)
+
+    def test_failure_log_event_name_locked(self):
+        """Lock the ``collection_search_failed`` structlog event name —
+        downstream log consumers grep for it."""
+        from structlog.testing import capture_logs
+
+        t3 = _FailingT3(
+            {"code__nexus": [{"id": "a", "content": "hit", "distance": 0.30}]},
+            failing={"knowledge__seam"},
+        )
+        with capture_logs() as logs:
+            search_cross_corpus("q", ["code__nexus", "knowledge__seam"], 10, t3)
+        assert any(
+            entry["event"] == "collection_search_failed"
+            and entry["collection"] == "knowledge__seam"
+            for entry in logs
+        )


### PR DESCRIPTION
## Summary

Fixes nexus-pebfx.8 (P1, epic nexus-pebfx): in service mode, the default `knowledge,code,docs` search died with HTTP 400 and a raw traceback because one unservable collection sank the whole cross-corpus loop.

**Root cause (refined from the bead's hypothesis):** `search_cross_corpus` already issues one service call per collection — there is no mixed-dim union call. The 384-dim `knowledge__seam-b-test` collection is unservable by the Voyage-mode service (query embedded at 1024 dims → HTTP 400 per the locked P2.1 contract), and that per-collection `VectorServiceError` propagated through the loop. The bead's proposed dim-grouping fix is moot; error isolation is the correct fix.

## Changes

- `search_cross_corpus` catches `VectorServiceError` per collection: logs `collection_search_failed` with the 400 body, records it in the new `SearchDiagnostics.failed_collections` field, and continues. Failed collections are excluded from `per_collection` so threshold telemetry stays clean.
- When **all** collections fail, an aggregated `VectorServiceError` re-raises — a misconfigured service fails loud, never silently returns zero results.
- CLI converts the all-fail re-raise into a clean `ClickException` (no more raw traceback).
- Collections are deduped at engine entry: duplicate names defeated the all-fail equality guard (the MCP `search` tool did not dedupe its target list).
- Zero-hit results now surface excluded collections in both the MCP `_no_results_message` and the CLI silent-zero stderr note — a partial outage must not read as a genuine miss.

## Review

Stacked review per discipline: code-review-expert + substantive-critic on 475c91b6; all findings (HIGH duplicate-guard, MEDIUM zero-hit surface ×2, LOW event-name lock) fixed in 67b873d6 and CONFIRMED-FIXED by critic re-pass. Review records in T2.

## Verification

- 9 new tests (engine isolation/diagnostics/re-raise/dedup/event-name, MCP message suffix, CLI note + ClickException surface); 273 tests green across affected modules.
- Live verified against the production pgvector service: default search returns relevant hits with exactly one `collection_search_failed` warning for the 384-dim collection; previously it returned nothing with a traceback.