### PR TITLE
fix: implement get_embeddings via service endpoint — contradiction/clustering restored in service mode [nexus-pebfx.7]

### DIFF
--- a/service/src/main/java/dev/nexus/service/http/VectorHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/VectorHandler.java
@@ -113,6 +113,7 @@ public final class VectorHandler implements HttpHandler {
                 case "/store-put"     -> handleStorePut(exchange, method);
                 case "/get"           -> handleGet(exchange, method);
                 case "/store-get"     -> handleStoreGet(exchange, method);
+                case "/get-embeddings" -> handleGetEmbeddings(exchange, method);
                 case "/store-list"    -> handleStoreList(exchange, method);
                 case "/store-delete"  -> handleStoreDelete(exchange, method);
                 case "/update-metadata" -> handleUpdateMetadata(exchange, method);
@@ -354,6 +355,26 @@ public final class VectorHandler implements HttpHandler {
         var result = (ids == null)
                 ? repo.getWhere(tenant, collection, null, limit, offset)
                 : repo.get(tenant, collection, ids, limit, offset);
+        HttpUtil.send(ex, 200, json(result));
+    }
+
+    /**
+     * POST /v1/vectors/get-embeddings (bead nexus-pebfx.7)
+     *
+     * <p>Request: {"collection": "...", "ids": ["...", ...]}
+     * <p>Response 200: {"ids":[...], "embeddings":[[...], ...]} in request
+     * order; missing ids omitted (Chroma parity — the Python caller detects
+     * the count mismatch).
+     */
+    private void handleGetEmbeddings(HttpExchange ex, String method) throws IOException {
+        requireMethod(ex, method, "POST");
+        var repo   = requirePgRepo(ex);
+        var tenant = requireTenant(ex);
+        Map<String, Object> body = readBody(ex);
+        String collection = requireString(body, "collection");
+        List<String> ids  = optStringList(body, "ids");
+        var result = repo.getEmbeddings(tenant, collection,
+                                        ids == null ? List.of() : ids);
         HttpUtil.send(ex, 200, json(result));
     }
 

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -623,6 +623,14 @@ public final class PgVectorRepository {
 
     /** Parse a pgvector text literal {@code "[0.1,0.2,...]"} into floats. */
     private static List<Float> parseVectorLiteral(String literal) {
+        if (literal == null || literal.length() < 2) {
+            // Schema says NOT NULL; a null/short literal means a malformed
+            // row. Return an empty row — the Python caller's ndarray
+            // construction rejects the ragged shape and fails the
+            // collection's fetch (degrade, never misattribute).
+            log.warn("event=embedding_literal_malformed literal={}", literal);
+            return List.of();
+        }
         String body = literal.substring(1, literal.length() - 1);
         if (body.isBlank()) {
             return List.of();

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -574,6 +574,68 @@ public final class PgVectorRepository {
     }
 
     /**
+     * Stored embeddings for {@code ids} (bead nexus-pebfx.7).
+     *
+     * <p>The Python search engine fetches result vectors post-search for the
+     * contradiction check and Ward-clustering grouping
+     * ({@code search_engine._fetch_embeddings_for_results}); without this the
+     * client raised {@code NotImplementedError} and both features silently
+     * degraded on every service-mode search.
+     *
+     * @return envelope {@code {ids: List<String>, embeddings: List<List<Float>>}}
+     *         in REQUEST order; ids not present (or invisible under RLS) are
+     *         OMITTED — Chroma {@code get(include=["embeddings"])} parity; the
+     *         Python caller treats {@code N < len(ids)} as a per-collection
+     *         fetch failure.
+     */
+    public Map<String, Object> getEmbeddings(String tenant, String collection,
+                                             List<String> ids) {
+        int dim = dimForCollection(collection);
+        if (ids == null || ids.isEmpty()) {
+            return Map.of("ids", List.of(), "embeddings", List.of());
+        }
+        List<Object> binds = new ArrayList<>();
+        binds.add(collection);
+        binds.addAll(ids);
+        Result<Record> result = tenantScope.withTenant(tenant, ctx ->
+            ctx.fetch("SELECT chash, embedding::text AS embedding_text FROM "
+                      + chunksTable(dim)
+                      + " WHERE collection = ? AND chash IN ("
+                      + placeholders(ids.size()) + ")",
+                      binds.toArray()));
+
+        Map<String, List<Float>> byChash = new HashMap<>();
+        for (Record rec : result) {
+            byChash.put(rec.get("chash", String.class),
+                        parseVectorLiteral(rec.get("embedding_text", String.class)));
+        }
+        List<String> outIds = new ArrayList<>();
+        List<List<Float>> outEmbeddings = new ArrayList<>();
+        for (String id : ids) {
+            List<Float> vec = byChash.get(id);
+            if (vec != null) {
+                outIds.add(id);
+                outEmbeddings.add(vec);
+            }
+        }
+        return Map.of("ids", outIds, "embeddings", outEmbeddings);
+    }
+
+    /** Parse a pgvector text literal {@code "[0.1,0.2,...]"} into floats. */
+    private static List<Float> parseVectorLiteral(String literal) {
+        String body = literal.substring(1, literal.length() - 1);
+        if (body.isBlank()) {
+            return List.of();
+        }
+        String[] parts = body.split(",");
+        List<Float> out = new ArrayList<>(parts.length);
+        for (String part : parts) {
+            out.add(Float.parseFloat(part.trim()));
+        }
+        return out;
+    }
+
+    /**
      * Single-chunk put (MCP {@code store_put} path) — embed + upsert one chunk.
      *
      * <p>RDR-155 P4a.2 (bead nexus-1k8s1): mirrors the Chroma

--- a/service/src/test/java/dev/nexus/service/VectorHandlerEmbeddingModeTest.java
+++ b/service/src/test/java/dev/nexus/service/VectorHandlerEmbeddingModeTest.java
@@ -199,6 +199,36 @@ class VectorHandlerEmbeddingModeTest {
     }
 
     @Test
+    void getEmbeddings_returnsStoredVectors_inRequestOrder() throws Exception {
+        // nexus-pebfx.7: the search engine fetches result vectors post-search
+        // (contradiction check + Ward clustering); the endpoint returns stored
+        // pgvector rows, request order, missing ids omitted (Chroma parity).
+        var up = post("/v1/vectors/upsert-chunks", Map.of(
+            "collection", "knowledge__pebfx7__minilm-l6-v2-384__v1",
+            "ids",        List.of("emb-b", "emb-a"),
+            "documents",  List.of("second text", "first text"),
+            "metadatas",  List.of(Map.of(), Map.of())));
+        assertThat(up.statusCode()).isEqualTo(200);
+
+        var resp = post("/v1/vectors/get-embeddings", Map.of(
+            "collection", "knowledge__pebfx7__minilm-l6-v2-384__v1",
+            "ids",        List.of("emb-a", "emb-b", "emb-missing")));
+        assertThat(resp.statusCode()).isEqualTo(200);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = MAPPER.readValue(resp.body(), Map.class);
+        @SuppressWarnings("unchecked")
+        List<String> ids = (List<String>) body.get("ids");
+        @SuppressWarnings("unchecked")
+        List<List<Number>> embeddings = (List<List<Number>>) body.get("embeddings");
+        assertThat(ids).containsExactly("emb-a", "emb-b");   // request order, missing omitted
+        assertThat(embeddings).hasSize(2);
+        assertThat(embeddings.get(0)).hasSize(384);
+        assertThat(embeddings.get(1)).hasSize(384);
+        // The two texts differ, so the stored vectors must differ.
+        assertThat(embeddings.get(0)).isNotEqualTo(embeddings.get(1));
+    }
+
+    @Test
     void minilmCollectionInOnnxMode_stillServes200() throws Exception {
         var resp = post("/v1/vectors/upsert-chunks", Map.of(
             "collection", "knowledge__pebfx2__minilm-l6-v2-384__v1",

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -679,6 +679,24 @@ class HttpVectorClient:
         """
         return _ServiceCollectionStub(name=name, tenant=self._tenant)
 
+    def get_embeddings(self, collection: str, ids: list[str]):
+        """Fetch stored embeddings for *ids* via the service (nexus-pebfx.7).
+
+        Mirrors ``T3Database.get_embeddings``: returns an ``(N, D)`` float32
+        ndarray with rows in request order; ids the service does not find
+        are DROPPED (``N < len(ids)``), which the search-engine caller
+        already treats as a per-collection shape-mismatch failure —
+        identical to the Chroma path's semantics.
+        """
+        import numpy as np
+
+        result = _post(
+            "/v1/vectors/get-embeddings",
+            {"collection": collection, "ids": ids},
+            tenant=self._tenant,
+        )
+        return np.array(result.get("embeddings", []), dtype=np.float32)
+
     # ── Stubs for T3Database surface not used by Seam B ─────────────────────
 
     def delete_collection(self, name: str) -> None:
@@ -686,9 +704,6 @@ class HttpVectorClient:
 
     def delete_by_source(self, collection: str, source_path: str) -> int:
         raise NotImplementedError("delete_by_source not implemented in HttpVectorClient")
-
-    def get_embeddings(self, collection: str, ids: list[str]):  # type: ignore[return]
-        raise NotImplementedError("get_embeddings not implemented in HttpVectorClient")
 
     # ── Utility ──────────────────────────────────────────────────────────────
 

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -764,9 +764,19 @@ class T3Database:
     def get_embeddings(self, collection_name: str, ids: list[str]) -> "np.ndarray":
         """Fetch embeddings for specific document IDs.
 
-        Returns an ``(N, D)`` float32 ndarray, one row per ID (in order).
-        Used by the clustering pipeline to avoid including embeddings in
-        every search response.
+        Returns an ``(N, D)`` float32 ndarray with rows in REQUEST order;
+        ids the store does not have are dropped (``N < len(ids)`` is the
+        caller's per-collection failure signal). Used by the clustering +
+        contradiction pipeline to avoid including embeddings in every
+        search response.
+
+        nexus-pebfx.7 critic finding: Chroma's ``col.get(ids=...)`` returns
+        rows in its INTERNAL insertion order (``ORDER BY embeddings_t.id``),
+        not request order — the previous positional ``np.array(...)`` could
+        misattribute embeddings to the wrong results whenever insertion
+        order differed from request order (false contradiction flags, wrong
+        cluster geometry). Reorder explicitly, exactly like the service
+        path's ``PgVectorRepository.getEmbeddings``.
         """
         import numpy as np
 
@@ -774,7 +784,10 @@ class T3Database:
             self._client_for(collection_name).get_collection, collection_name,
         )
         result = _chroma_with_retry(col.get, ids=ids, include=["embeddings"])
-        return np.array(result["embeddings"], dtype=np.float32)
+        by_id = dict(zip(result["ids"], result["embeddings"]))
+        return np.array(
+            [by_id[i] for i in ids if i in by_id], dtype=np.float32,
+        )
 
     # ── Write ─────────────────────────────────────────────────────────────────
 

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -760,9 +760,26 @@ def _fetch_embeddings_for_results(
     if emb_dim is None:
         return None, failed_indices
 
+    # nexus-pebfx.7 live-verify catch: cross-corpus results can mix embedding
+    # dims (e.g. 1024-dim voyage collections + a 384-dim minilm collection).
+    # One matrix can only hold one dim — and cross-dim cosine/Euclidean is
+    # meaningless anyway — so collections whose dim differs from the first
+    # successful fetch are marked failed (their results lose the
+    # contradiction/clustering features, same semantics as a fetch failure).
+    # Latent before this bead: the fetch always failed in service mode, so
+    # the mixed-dim assembly was unreachable.
     embeddings = np.zeros((len(results), emb_dim), dtype=np.float32)
     for col, col_emb in col_fetched.items():
         indices = col_groups[col]
+        if col_emb.shape[1] != emb_dim:
+            _log.warning(
+                "embedding_dim_mismatch_across_collections",
+                collection=col,
+                dim=col_emb.shape[1],
+                matrix_dim=emb_dim,
+            )
+            failed_indices.update(indices)
+            continue
         for local_idx, global_idx in enumerate(indices):
             embeddings[global_idx] = col_emb[local_idx]
 

--- a/tests/db/test_http_vector_client.py
+++ b/tests/db/test_http_vector_client.py
@@ -465,10 +465,8 @@ class TestNotImplementedMethods:
         with pytest.raises(NotImplementedError):
             client.delete_by_source("col", "/path/to/file.py")
 
-    def test_get_embeddings_raises(self):
-        client = HttpVectorClient()
-        with pytest.raises(NotImplementedError):
-            client.get_embeddings("col", ["id1"])
+    # get_embeddings was here until nexus-pebfx.7 implemented it via
+    # /v1/vectors/get-embeddings — see TestGetEmbeddings.
 
 
 # ── get_t3() routing (integration with mcp_infra) ────────────────────────────
@@ -676,3 +674,52 @@ class TestTaxonomyServiceModeGuard:
             "_fetch_or_embed must return None in service mode — "
             "HttpVectorClient has no ._client, so the Chroma fetch path must be skipped."
         )
+
+
+class TestGetEmbeddings:
+    """nexus-pebfx.7: get_embeddings via /v1/vectors/get-embeddings — the
+    search engine's contradiction-check + Ward-clustering features silently
+    degraded on EVERY service-mode search while this raised
+    NotImplementedError."""
+
+    def test_posts_to_get_embeddings_endpoint(self, monkeypatch):
+        client = HttpVectorClient()
+        calls = []
+
+        def fake_post(path, body, *, tenant="default", timeout=120):
+            calls.append((path, body))
+            return {"ids": ["a", "b"], "embeddings": [[0.1, 0.2], [0.3, 0.4]]}
+
+        monkeypatch.setattr("nexus.db.http_vector_client._post", fake_post)
+        result = client.get_embeddings("knowledge__x__minilm-l6-v2-384__v1", ["a", "b"])
+        path, body = calls[0]
+        assert path == "/v1/vectors/get-embeddings"
+        assert body == {
+            "collection": "knowledge__x__minilm-l6-v2-384__v1",
+            "ids": ["a", "b"],
+        }
+        import numpy as np
+
+        assert result.dtype == np.float32
+        assert result.shape == (2, 2)
+        assert result[1][1] == np.float32(0.4)
+
+    def test_missing_ids_dropped_chroma_parity(self, monkeypatch):
+        # The service omits ids it cannot find; N < len(ids) is the caller's
+        # shape-mismatch signal — same semantics as the Chroma path.
+        client = HttpVectorClient()
+        monkeypatch.setattr(
+            "nexus.db.http_vector_client._post",
+            _make_mock_post({"ids": ["a"], "embeddings": [[0.1, 0.2]]}),
+        )
+        result = client.get_embeddings("col", ["a", "missing"])
+        assert result.shape == (1, 2)
+
+    def test_empty_result_shape(self, monkeypatch):
+        client = HttpVectorClient()
+        monkeypatch.setattr(
+            "nexus.db.http_vector_client._post",
+            _make_mock_post({"ids": [], "embeddings": []}),
+        )
+        result = client.get_embeddings("col", ["x"])
+        assert result.shape[0] == 0

--- a/tests/db/test_http_vector_client.py
+++ b/tests/db/test_http_vector_client.py
@@ -723,3 +723,84 @@ class TestGetEmbeddings:
         )
         result = client.get_embeddings("col", ["x"])
         assert result.shape[0] == 0
+
+
+class TestEmbeddingFetchServiceModeRegression:
+    """nexus-pebfx.7 critic: lock the NAMED symptom — a service-mode search's
+    embedding fetch must NOT emit embedding_fetch_failed (it did, once per
+    collection per search, while get_embeddings raised NotImplementedError)."""
+
+    @staticmethod
+    def _results(col: str, n: int):
+        from nexus.types import SearchResult
+
+        return [
+            SearchResult(
+                id=f"{col}-{i}", content=f"text {i}", distance=0.1,
+                collection=col, metadata={},
+            )
+            for i in range(n)
+        ]
+
+    def test_fetch_succeeds_without_embedding_fetch_failed(self, monkeypatch):
+        from structlog.testing import capture_logs
+
+        from nexus.search_engine import _fetch_embeddings_for_results
+
+        client = HttpVectorClient()
+        monkeypatch.setattr(
+            "nexus.db.http_vector_client._post",
+            _make_mock_post({
+                "ids": ["colA-0", "colA-1"],
+                "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+            }),
+        )
+        results = self._results("colA", 2)
+        with capture_logs() as logs:
+            embeddings, failed = _fetch_embeddings_for_results(results, client)
+        assert not any(e["event"] == "embedding_fetch_failed" for e in logs)
+        assert failed == set()
+        assert embeddings.shape == (2, 2)
+
+    def test_shape_mismatch_marks_collection_failed(self, monkeypatch):
+        # Service omits a missing id -> N < len(ids) -> the collection's
+        # indices land in failed_indices (never positional misattribution).
+        from nexus.search_engine import _fetch_embeddings_for_results
+
+        client = HttpVectorClient()
+        monkeypatch.setattr(
+            "nexus.db.http_vector_client._post",
+            _make_mock_post({"ids": ["colA-0"], "embeddings": [[0.1, 0.2]]}),
+        )
+        results = self._results("colA", 2)
+        _, failed = _fetch_embeddings_for_results(results, client)
+        assert failed == {0, 1}
+
+    def test_mixed_dim_collections_fail_minority_not_crash(self, monkeypatch):
+        """Live-verify catch (2026-06-11): a 384-dim collection in the same
+        result set as 1024-dim collections crashed the whole search with a
+        broadcast ValueError once the fetch started succeeding. The
+        odd-dim collection must be marked failed instead."""
+        from nexus.search_engine import _fetch_embeddings_for_results
+        from nexus.types import SearchResult
+
+        client = HttpVectorClient()
+        payloads = {
+            "colBig": {"ids": ["colBig-0"], "embeddings": [[0.1] * 1024]},
+            "colSmall": {"ids": ["colSmall-0"], "embeddings": [[0.2] * 384]},
+        }
+
+        def fake_post(path, body, *, tenant="default", timeout=120):
+            return payloads[body["collection"]]
+
+        monkeypatch.setattr("nexus.db.http_vector_client._post", fake_post)
+        results = [
+            SearchResult(id="colBig-0", content="t", distance=0.1,
+                         collection="colBig", metadata={}),
+            SearchResult(id="colSmall-0", content="t", distance=0.1,
+                         collection="colSmall", metadata={}),
+        ]
+        embeddings, failed = _fetch_embeddings_for_results(results, client)
+        assert embeddings is not None
+        assert embeddings.shape == (2, 1024)
+        assert failed == {1}

--- a/tests/test_t3_gc.py
+++ b/tests/test_t3_gc.py
@@ -555,3 +555,49 @@ def test_gc_no_yes_flag_reports_only(t3_db, catalog, tmp_path, runner):
         events = [e for e in EventLog(catalog._dir).replay()
                   if e.type == TYPE_CHUNK_ORPHANED]
         assert events == []
+
+
+class TestGetEmbeddingsRequestOrder:
+    """nexus-pebfx.7 critic: Chroma's col.get(ids=...) returns rows in
+    INTERNAL insertion order, not request order — positional consumption
+    misattributed embeddings whenever the orders differed (false
+    contradiction flags, wrong cluster geometry). T3Database.get_embeddings
+    must reorder to request order, exactly like the service path."""
+
+    def test_rows_follow_request_order_not_insertion_order(self):
+        import chromadb
+        import numpy as np
+        from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+        from nexus.db.t3 import T3Database
+
+        client = chromadb.EphemeralClient()
+        t3 = T3Database(_client=client, _ef_override=DefaultEmbeddingFunction())
+        col = t3.get_or_create_collection("knowledge__ordertest", strict=False)
+        # Insert in REVERSE alphabetical order so insertion order != request
+        # order for the ["id-a", "id-b"] request below.
+        col.add(
+            ids=["id-b", "id-a"],
+            documents=["text for b", "text for a"],
+            metadatas=[{"k": "b"}, {"k": "a"}],
+        )
+        direct = col.get(ids=["id-a", "id-b"], include=["embeddings"])
+        by_id = dict(zip(direct["ids"], direct["embeddings"]))
+
+        result = t3.get_embeddings("knowledge__ordertest", ["id-a", "id-b"])
+        assert result.shape[0] == 2
+        assert np.allclose(result[0], np.array(by_id["id-a"], dtype=np.float32))
+        assert np.allclose(result[1], np.array(by_id["id-b"], dtype=np.float32))
+
+    def test_missing_ids_dropped(self):
+        import chromadb
+        from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+        from nexus.db.t3 import T3Database
+
+        client = chromadb.EphemeralClient()
+        t3 = T3Database(_client=client, _ef_override=DefaultEmbeddingFunction())
+        col = t3.get_or_create_collection("knowledge__ordertest2", strict=False)
+        col.add(ids=["only"], documents=["text"], metadatas=[{"k": "v"}])
+        result = t3.get_embeddings("knowledge__ordertest2", ["only", "absent"])
+        assert result.shape[0] == 1


### PR DESCRIPTION
## Summary

Closes bead nexus-pebfx.7 (P2, epic nexus-pebfx): `HttpVectorClient.get_embeddings` raised `NotImplementedError`, so `search_engine._fetch_embeddings_for_results` degraded on **every** service-mode search with one `embedding_fetch_failed` warning per collection.

**Note:** stacked on the pebfx.4 branch (PR #1157, itself stacked on #1156); diff collapses to the two pebfx.7 commits as those merge.

## Audit (bead-mandated, performed first)

Single call site. The fetched embeddings feed exactly two features: **contradiction detection** (RDR-057, default-on) and **Ward-clustering result grouping** (fallback when topic coverage ≤50%) — *not* the Voyage reranker the bead hypothesized. Option (b) obviation is RDR-156 P4 territory (unlanded), so option (a) ships.

## Changes

- **Java**: `PgVectorRepository.getEmbeddings` — one SELECT of stored `embedding::text` rows from the dispatched `chunks_<dim>` table; `POST /v1/vectors/get-embeddings`; envelope `{ids, embeddings}` in request order with missing ids omitted (Chroma parity). Null/short vector literal hardening.
- **Python**: `HttpVectorClient.get_embeddings` returns the `(N, D)` float32 contract; `N < len(ids)` stays the caller's per-collection failure signal.
- **Bonus fix (critic finding, pre-existing LOCAL-mode bug)**: `T3Database.get_embeddings` consumed Chroma rows positionally, but Chroma returns them in internal insertion order — embeddings could be misattributed to wrong results (false contradiction flags, wrong cluster geometry). Now reorders by id like the service path.
- **Bonus fix (live-verify catch)**: with the fetch now succeeding, mixed-dim result sets (1024 voyage + 384 minilm) crashed the whole search on the single `(N, emb_dim)` matrix — latent while the fetch always failed. Odd-dim collections now fail cleanly with `embedding_dim_mismatch_across_collections`.

## Review

Stacked review: code-review-expert approved (caller alignment — the top suspect — verified safe: the shape check gates before row assignment); substantive-critic 2 Significant, both fixed and CONFIRMED-FIXED on re-pass, including independent confirmation of the audit.

## Verification

- 8 new tests: client contract (3), symptom lock via structlog capture (no `embedding_fetch_failed` on success; shape-mismatch → failed indices), mixed-dim isolation, Chroma request-order regression against a real EphemeralClient (2), HTTP round-trip upserting real ONNX chunks.
- 160 tests green across affected modules.
- **Live-verified on the production pgvector stack with the rebuilt JAR**: default search returns relevant results with zero `embedding_fetch_failed` and no traceback — the live run is also what caught the mixed-dim crash.