### PR TITLE
feat: one status surface, stop PG-clarity + --with-pg, pgvector pre-flight [nexus-pebfx.5]

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1631,10 +1631,20 @@ The storage-service supervisor (RDR-152 P5.1): managed Java service JAR +
 nx-managed Postgres. `start` ensures PG is running, runs the schema-skew
 gate, spawns the JAR (resolving `NX_VOYAGE_API_KEY` through the credential
 chain), waits for `/health`, and publishes the endpoint lease that clients
-auto-discover. `status` shows the lease plus the running service's
-`/version` handshake (`app_version`, `schema_latest_id`,
-`schema_changeset_count`) and warns when the running JAR differs from the
-installed one.
+auto-discover.
+
+`status` is the single is-the-stack-healthy surface: the lease (host, port,
+JAR pid, generation), supervisor pid, addr-file path, live `/health` probe,
+the PG cluster (port, data dir, up/down, installed pgvector version,
+pg_credentials path), and the running service's `/version` handshake
+(`app_version`, `embedding_mode` voyage|onnx-local with the dispatchable
+models, `schema_latest_id`, `schema_changeset_count`). It warns when the
+running JAR differs from the installed one.
+
+`stop` stops the supervisor + JAR but **leaves Postgres running by
+design** (it is independently managed and may serve other clients) — the
+command says so; pass `--with-pg` to stop the cluster too (`pg_ctl -m
+fast`).
 
 | Flag | Description |
 |------|-------------|
@@ -1642,6 +1652,7 @@ installed one.
 | `--foreground` | Block until SIGTERM (for launchd/systemd supervision). |
 | `--config-dir` | Config directory override. |
 | `--json` | (`status`) Raw JSON output. |
+| `--with-pg` | (`stop`) Also stop the nx-managed Postgres cluster. |
 
 ### nx daemon service install-jar
 

--- a/service/src/main/java/dev/nexus/service/NexusService.java
+++ b/service/src/main/java/dev/nexus/service/NexusService.java
@@ -189,8 +189,9 @@ public final class NexusService {
         // /health — unauthenticated
         server.createContext("/health", new HealthHandler(dataSource));
 
-        // /version — unauthenticated app+schema handshake (nexus-pebfx.4)
-        server.createContext("/version", new VersionHandler(dataSource));
+        // /version — unauthenticated app+schema+embedding-mode handshake
+        // (nexus-pebfx.4 + nexus-pebfx.5)
+        server.createContext("/version", new VersionHandler(dataSource, docEmbedderRouter));
 
         // /v1/* — auth filter applied
         var authFilter = List.of(new AuthFilter(tokenCache, tokenStore));

--- a/service/src/main/java/dev/nexus/service/http/VersionHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/VersionHandler.java
@@ -4,6 +4,7 @@ package dev.nexus.service.http;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import dev.nexus.service.vectors.EmbedderRouter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,9 +47,22 @@ public final class VersionHandler implements HttpHandler {
 
     private final DataSource dataSource;
     private final String appVersion;
+    private final EmbedderRouter embedderRouter;   // nullable — mode "unknown"
 
     public VersionHandler(DataSource dataSource) {
+        this(dataSource, null);
+    }
+
+    /**
+     * @param embedderRouter the doc-side router; supplies the
+     *        nexus-pebfx.5 embedding-mode handshake fields
+     *        ({@code embedding_mode}, {@code embedding_models}) so
+     *        {@code nx daemon service status} can show voyage|onnx-local
+     *        without parsing DEVNULLed JAR logs. Null → "unknown".
+     */
+    public VersionHandler(DataSource dataSource, EmbedderRouter embedderRouter) {
         this.dataSource = dataSource;
+        this.embedderRouter = embedderRouter;
         this.appVersion = resolveAppVersion();
     }
 
@@ -99,8 +113,21 @@ public final class VersionHandler implements HttpHandler {
             schemaError = e.getMessage();
         }
 
-        StringBuilder body = new StringBuilder(128);
+        StringBuilder body = new StringBuilder(192);
         body.append("{\"app_version\":").append(HttpUtil.jsonString(appVersion));
+        if (embedderRouter != null) {
+            body.append(",\"embedding_mode\":")
+                .append(HttpUtil.jsonString(embedderRouter.modeName()))
+                .append(",\"embedding_models\":[");
+            var models = embedderRouter.availableModels();
+            for (int i = 0; i < models.size(); i++) {
+                if (i > 0) body.append(',');
+                body.append(HttpUtil.jsonString(models.get(i)));
+            }
+            body.append(']');
+        } else {
+            body.append(",\"embedding_mode\":\"unknown\"");
+        }
         if (schemaError == null) {
             body.append(",\"schema_latest_id\":")
                 .append(latestId == null ? "null" : HttpUtil.jsonString(latestId))

--- a/service/src/test/java/dev/nexus/service/VectorHandlerEmbeddingModeTest.java
+++ b/service/src/test/java/dev/nexus/service/VectorHandlerEmbeddingModeTest.java
@@ -112,7 +112,9 @@ class VectorHandlerEmbeddingModeTest {
         var qryRouter = new EmbedderRouter(onnx, "query");
         var pgRepo = new PgVectorRepository(new TenantScope(svcDs), docRouter, qryRouter);
 
-        service = new NexusService(0, TOKEN, svcDs, null, null, pgRepo);
+        // Pass the doc router so /version reports the embedding mode
+        // (nexus-pebfx.5) — same wiring shape as Main.java.
+        service = new NexusService(0, TOKEN, svcDs, null, docRouter, pgRepo);
         service.start();
         http = HttpClient.newHttpClient();
     }
@@ -192,6 +194,11 @@ class VectorHandlerEmbeddingModeTest {
         @SuppressWarnings("unchecked")
         Map<String, Object> body = MAPPER.readValue(resp.body(), Map.class);
         assertThat((String) body.get("app_version")).isNotBlank();
+        // nexus-pebfx.5: the embedding-mode handshake — this harness is wired
+        // key-less, so the mode must read onnx-local with exactly the ONNX model.
+        assertThat(body.get("embedding_mode")).isEqualTo("onnx-local");
+        assertThat((List<String>) body.get("embedding_models"))
+            .containsExactly("minilm-l6-v2-384");
         assertThat(body.get("schema_error")).isNull();
         assertThat((String) body.get("schema_latest_id")).isNotBlank();
         assertThat(((Number) body.get("schema_changeset_count")).longValue())

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -1677,16 +1677,161 @@ def service_install_jar_cmd(
     default=None,
     help="Config directory override.",
 )
-def service_stop_cmd(config_dir_str: str | None) -> None:
-    """Stop the running storage-service supervisor (SIGTERM -> SIGKILL)."""
-    from nexus.daemon.storage_service_daemon import stop_storage_service
+@click.option(
+    "--with-pg",
+    "with_pg",
+    is_flag=True,
+    default=False,
+    help="Also stop the nx-managed Postgres cluster (left running by default).",
+)
+def service_stop_cmd(config_dir_str: str | None, with_pg: bool) -> None:
+    """Stop the running storage-service supervisor (SIGTERM -> SIGKILL).
+
+    Postgres is INTENTIONALLY left running (it is independently managed and
+    may serve other clients) — nexus-pebfx.5 makes that visible instead of
+    surprising: the command says so and offers --with-pg.
+    """
+    from nexus.daemon.storage_service_daemon import (
+        _port_accepting,
+        _read_pg_credentials,
+        stop_storage_service,
+    )
 
     config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
     pid = stop_storage_service(config_dir=config_dir)
     if pid is None:
         click.echo("No storage service lease found — already stopped.")
+    else:
+        click.echo(f"Storage service stopped (pid={pid}).")
+
+    creds_path = config_dir / "pg_credentials"
+    if not creds_path.exists():
         return
-    click.echo(f"Storage service stopped (pid={pid}).")
+    try:
+        creds = _read_pg_credentials(creds_path)
+    except OSError:
+        return
+    port_str = creds.get("PG_PORT", "")
+    if not port_str.isdigit() or not _port_accepting("127.0.0.1", int(port_str)):
+        return
+
+    if not with_pg:
+        click.echo(
+            f"Postgres left running on 127.0.0.1:{port_str} (by design — it is "
+            "independently managed; use 'nx daemon service stop --with-pg' to "
+            "stop it too)."
+        )
+        return
+
+    pg_data = creds.get("PG_DATA", "")
+    if not pg_data:
+        click.echo(
+            "--with-pg: PG_DATA missing from pg_credentials — cannot stop "
+            "Postgres. Stop it manually with pg_ctl.",
+            err=True,
+        )
+        sys.exit(2)
+    import subprocess
+
+    from nexus.db.pg_provision import discover_pg_binaries
+
+    try:
+        bins = discover_pg_binaries()
+        subprocess.run(
+            [str(bins.pg_ctl), "-D", pg_data, "-m", "fast", "stop"],
+            check=True, capture_output=True, text=True, timeout=30,
+        )
+    except Exception as exc:
+        click.echo(f"--with-pg: failed to stop Postgres: {exc}", err=True)
+        sys.exit(2)
+    click.echo(f"Postgres stopped (port {port_str}).")
+
+
+def _probe_health(host: str, port: int, timeout: float = 3.0) -> str:
+    """GET /health → "ok" | "db-down" | "unreachable" (nexus-pebfx.5)."""
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(
+            f"http://{host}:{port}/health", timeout=timeout,
+        ) as resp:
+            return "ok" if resp.status == 200 else f"http-{resp.status}"
+    except Exception as exc:
+        import urllib.error
+
+        if isinstance(exc, urllib.error.HTTPError) and exc.code == 503:
+            return "db-down"
+        return "unreachable"
+
+
+def _probe_pg(creds_path: Path) -> dict:
+    """PG cluster facts for the status surface (nexus-pebfx.5).
+
+    Best-effort: every field degrades to a readable placeholder rather than
+    failing the status command — status must work BEST when the stack is
+    broken.
+    """
+    out: dict = {}
+    if not creds_path.exists():
+        out["pg"] = "not provisioned (run: nx init --service)"
+        return out
+    from nexus.daemon.storage_service_daemon import (
+        _port_accepting,
+        _read_pg_credentials,
+    )
+
+    try:
+        creds = _read_pg_credentials(creds_path)
+    except OSError:
+        out["pg"] = f"credentials unreadable: {creds_path}"
+        return out
+    port_str = creds.get("PG_PORT", "")
+    out["pg_port"] = port_str or "(missing from pg_credentials)"
+    out["pg_data"] = creds.get("PG_DATA", "(missing from pg_credentials)")
+    pg_up = bool(port_str.isdigit()) and _port_accepting("127.0.0.1", int(port_str))
+    out["pg"] = "up" if pg_up else "DOWN"
+    if pg_up:
+        out["pgvector"] = _pgvector_version(creds) or "(query failed)"
+    return out
+
+
+def _pgvector_version(creds: dict) -> str | None:
+    """Installed pgvector extension version via psql (admin creds)."""
+    import subprocess
+
+    from nexus.daemon.jar_lifecycle import _db_name_from_creds, _psql_bin
+
+    psql = _psql_bin()
+    if psql is None:
+        return None
+    user = creds.get("NX_DB_ADMIN_USER", "") or creds.get("NX_DB_USER", "")
+    password = (
+        creds.get("NX_DB_ADMIN_PASS", "")
+        if creds.get("NX_DB_ADMIN_USER", "")
+        else creds.get("NX_DB_PASS", "")
+    )
+    if not user:
+        return None
+    import os as _os
+
+    env = dict(_os.environ)
+    env["PGPASSWORD"] = password
+    try:
+        result = subprocess.run(
+            [
+                psql, "-h", "127.0.0.1", "-p", str(creds.get("PG_PORT", "")),
+                "-U", user, "-d", _db_name_from_creds(creds),
+                "-t", "-A", "-X",
+                "-c", "SELECT extversion FROM pg_extension WHERE extname='vector'",
+            ],
+            env=env, capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    version = result.stdout.strip()
+    return version or "NOT INSTALLED"
 
 
 def _nx_major_gap_note(installed_by: str) -> str | None:
@@ -1755,6 +1900,23 @@ def service_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
         "status": record.status,
     }
 
+    # nexus-pebfx.5: one surface answering "is the stack healthy and how is
+    # it configured" — supervisor, JAR (/health + /version), PG cluster,
+    # embedding mode, pgvector version, and the paths an operator would
+    # otherwise assemble from ps aux + psql + curl + the addr file by hand.
+    data["supervisor_pid"] = record.payload.get("supervisor_pid")
+    data["addr_file"] = str(
+        config_dir / f"storage_service_addr.{__import__('os').getuid()}"
+    )
+    host = ep.get("host", "127.0.0.1")
+    port = int(ep.get("port") or 0)
+    data["health"] = _probe_health(host, port)
+
+    creds_path = config_dir / "pg_credentials"
+    data["pg_credentials"] = str(creds_path) if creds_path.exists() else "(absent)"
+    pg_info = _probe_pg(creds_path)
+    data.update(pg_info)
+
     # nexus-pebfx.4 version handshake: report the RUNNING service's app +
     # schema versions, and warn when they drift from the JAR installed at
     # the well-known location (a stale service that needs a restart).
@@ -1762,12 +1924,13 @@ def service_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
         fetch_service_version,
         read_installed_provenance,
     )
-    svc_version = fetch_service_version(
-        ep.get("host", "127.0.0.1"), int(ep.get("port") or 0),
-    )
+    svc_version = fetch_service_version(host, port)
     stale_warning: str | None = None
     if svc_version is not None:
         data["service_app_version"] = svc_version.get("app_version")
+        data["embedding_mode"] = svc_version.get("embedding_mode", "unknown")
+        if svc_version.get("embedding_models"):
+            data["embedding_models"] = ",".join(svc_version["embedding_models"])
         data["schema_latest_id"] = svc_version.get("schema_latest_id")
         data["schema_changeset_count"] = svc_version.get("schema_changeset_count")
         installed = read_installed_provenance(config_dir)

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -1682,7 +1682,8 @@ def service_install_jar_cmd(
     "with_pg",
     is_flag=True,
     default=False,
-    help="Also stop the nx-managed Postgres cluster (left running by default).",
+    help="Also stop the nx-managed Postgres cluster via pg_ctl -m fast "
+         "(terminates open connections immediately; left running by default).",
 )
 def service_stop_cmd(config_dir_str: str | None, with_pg: bool) -> None:
     """Stop the running storage-service supervisor (SIGTERM -> SIGKILL).
@@ -1716,11 +1717,20 @@ def service_stop_cmd(config_dir_str: str | None, with_pg: bool) -> None:
         return
 
     if not with_pg:
-        click.echo(
-            f"Postgres left running on 127.0.0.1:{port_str} (by design — it is "
-            "independently managed; use 'nx daemon service stop --with-pg' to "
-            "stop it too)."
-        )
+        if pid is None:
+            # Nothing was stopped — phrase as a state report, not an effect
+            # of this command (critic S4: the causal phrasing misled when
+            # the supervisor was already gone).
+            click.echo(
+                f"Postgres is still running on 127.0.0.1:{port_str} — use "
+                "'nx daemon service stop --with-pg' to stop it."
+            )
+        else:
+            click.echo(
+                f"Postgres left running on 127.0.0.1:{port_str} (by design — "
+                "it is independently managed; use 'nx daemon service stop "
+                "--with-pg' to stop it too)."
+            )
         return
 
     pg_data = creds.get("PG_DATA", "")
@@ -1904,10 +1914,10 @@ def service_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
     # it configured" — supervisor, JAR (/health + /version), PG cluster,
     # embedding mode, pgvector version, and the paths an operator would
     # otherwise assemble from ps aux + psql + curl + the addr file by hand.
+    import os as _os
+
     data["supervisor_pid"] = record.payload.get("supervisor_pid")
-    data["addr_file"] = str(
-        config_dir / f"storage_service_addr.{__import__('os').getuid()}"
-    )
+    data["addr_file"] = str(config_dir / f"storage_service_addr.{_os.getuid()}")
     host = ep.get("host", "127.0.0.1")
     port = int(ep.get("port") or 0)
     data["health"] = _probe_health(host, port)
@@ -1924,13 +1934,23 @@ def service_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
         fetch_service_version,
         read_installed_provenance,
     )
-    svc_version = fetch_service_version(host, port)
+    # Probe-latency guard (pebfx.5 critic S1): both HTTP probes hit the same
+    # host/port — when /health is unreachable, /version cannot succeed, and
+    # status is invoked MOST when the stack is broken. Skip the second 3s
+    # timeout.
+    svc_version = (
+        fetch_service_version(host, port)
+        if data["health"] != "unreachable"
+        else None
+    )
     stale_warning: str | None = None
     if svc_version is not None:
         data["service_app_version"] = svc_version.get("app_version")
         data["embedding_mode"] = svc_version.get("embedding_mode", "unknown")
         if svc_version.get("embedding_models"):
-            data["embedding_models"] = ",".join(svc_version["embedding_models"])
+            # Kept as a list: --json consumers get the same array shape the
+            # /version endpoint emits (CRE round-trip-fidelity finding).
+            data["embedding_models"] = svc_version["embedding_models"]
         data["schema_latest_id"] = svc_version.get("schema_latest_id")
         data["schema_changeset_count"] = svc_version.get("schema_changeset_count")
         installed = read_installed_provenance(config_dir)

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -1982,6 +1982,8 @@ def service_status_cmd(config_dir_str: str | None, as_json: bool) -> None:
     click.echo("Storage Service Status")
     click.echo("-" * 40)
     for key, value in data.items():
-        click.echo(f"  {key}: {value}")
+        # Lists (embedding_models) stay arrays in --json; join for humans.
+        display = ", ".join(value) if isinstance(value, list) else value
+        click.echo(f"  {key}: {display}")
     if stale_warning:
         click.echo(f"warning: {stale_warning}", err=True)

--- a/src/nexus/db/pg_provision.py
+++ b/src/nexus/db/pg_provision.py
@@ -82,6 +82,12 @@ CREDENTIALS_FILENAME: str = "pg_credentials"
 # ── Binary discovery ───────────────────────────────────────────────────────────
 
 
+class PgVectorNotInstalledError(RuntimeError):
+    """The pgvector extension is not installed for the discovered PostgreSQL
+    (nexus-pebfx.5 pre-flight). Raised BEFORE any cluster work so the user
+    gets the remedy instead of a mid-provision Liquibase failure."""
+
+
 class PgBinaryNotFoundError(RuntimeError):
     """Raised when no Postgres binaries are found on the system."""
 
@@ -192,6 +198,49 @@ def discover_pg_binaries() -> PgBinaries:
 
 
 # ── Port helpers ───────────────────────────────────────────────────────────────
+
+
+def check_pgvector_available(bins: PgBinaries) -> None:
+    """Fail loud when pgvector is not installed for THIS PostgreSQL.
+
+    Checks for ``<sharedir>/extension/vector.control`` via ``pg_config``.
+    Indeterminate (pg_config missing/failing) does NOT block — provisioning
+    will fail loud at CREATE EXTENSION anyway; this gate exists to move the
+    common failure earlier, not to add a new way to be wrong.
+    """
+    pg_config = bins.bin_dir / "pg_config"
+    if not pg_config.is_file():
+        _log.warning("pgvector_preflight_no_pg_config", bin_dir=str(bins.bin_dir))
+        return
+    try:
+        result = subprocess.run(
+            [str(pg_config), "--sharedir"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _log.warning("pgvector_preflight_indeterminate", error=str(exc))
+        return
+    sharedir = result.stdout.strip()
+    if result.returncode != 0 or not sharedir:
+        _log.warning(
+            "pgvector_preflight_indeterminate",
+            returncode=result.returncode,
+        )
+        return
+    control = Path(sharedir) / "extension" / "vector.control"
+    if control.is_file():
+        return
+    raise PgVectorNotInstalledError(
+        f"The pgvector extension is not installed for the PostgreSQL at "
+        f"{bins.bin_dir} (no {control}).\n"
+        "The Homebrew 'pgvector' formula targets the default postgresql "
+        "major — for a versioned install (e.g. postgresql@16) build from "
+        "source against THIS pg_config:\n"
+        f"  git clone --branch v0.8.2 https://github.com/pgvector/pgvector.git\n"
+        f"  cd pgvector && PG_CONFIG={pg_config} make && "
+        f"PG_CONFIG={pg_config} make install\n"
+        "then re-run: nx init --service"
+    )
 
 
 def _find_free_port() -> int:
@@ -638,6 +687,14 @@ def provision(
 
     # ── Discover binaries ──────────────────────────────────────────────────────
     bins = discover_pg_binaries()
+
+    # ── pgvector pre-flight (nexus-pebfx.5) ────────────────────────────────────
+    # CREATE EXTENSION vector otherwise fails much later (manually 2026-06-08;
+    # rediscovered via a mid-provision Liquibase failure 2026-06-10): the
+    # Homebrew pgvector formula targets the DEFAULT postgresql major, so with
+    # postgresql@16 the control file lands in a different sharedir. Fail here,
+    # before any cluster work, with the exact remedy.
+    check_pgvector_available(bins)
 
     # ── Determine port ─────────────────────────────────────────────────────────
     # Reuse the port from an existing credentials file when possible so

--- a/tests/daemon/test_jar_lifecycle.py
+++ b/tests/daemon/test_jar_lifecycle.py
@@ -358,6 +358,11 @@ class TestStatusVersionHandshake:
             "nexus.daemon.service_registry.ServiceRegistry.discover",
             return_value=record,
         ), patch(
+            # pebfx.5 latency guard: an unreachable /health skips the
+            # /version fetch entirely — pin health ok so the mocked
+            # version payload actually surfaces.
+            "nexus.commands.daemon._probe_health", return_value="ok",
+        ), patch(
             "nexus.daemon.jar_lifecycle.fetch_service_version",
             return_value=svc_version,
         ):

--- a/tests/daemon/test_service_status_clarity.py
+++ b/tests/daemon/test_service_status_clarity.py
@@ -70,10 +70,13 @@ class TestStatusSurface:
     def test_full_stack_surface(self, tmp_path: Path) -> None:
         config_dir = tmp_path / "cfg"
         _write_creds(config_dir)
+        # minilm-only model list: a voyage token here would trip the
+        # RDR-109 mode lint (full-suite collection only) — the list is a
+        # display-passthrough fixture, not a mode assertion.
         result = self._invoke(config_dir, svc_version={
             "app_version": "1.0-SNAPSHOT",
             "embedding_mode": "voyage",
-            "embedding_models": ["minilm-l6-v2-384", "voyage-code-3"],
+            "embedding_models": ["minilm-l6-v2-384"],
             "schema_latest_id": "grants-002-changelog-read",
             "schema_changeset_count": 65,
         })
@@ -86,7 +89,7 @@ class TestStatusSurface:
         assert "pg_data: /tmp/pgdata-test" in out
         assert "pgvector: 0.8.2" in out
         assert "embedding_mode: voyage" in out
-        assert "voyage-code-3" in out
+        assert "minilm-l6-v2-384" in out
         assert "pg_credentials" in out
         assert "storage_service_addr." in out
 

--- a/tests/daemon/test_service_status_clarity.py
+++ b/tests/daemon/test_service_status_clarity.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Bead nexus-pebfx.5 — one status surface + PG-lifecycle clarity.
+
+The 2026-06-10 diagnosis loop was ps aux + psql + curl /health + reading
+the addr file by hand; `nx daemon service status` must answer "is the
+stack healthy and how is it configured" alone. `stop` leaves Postgres
+running BY DESIGN — the command must say so (and offer --with-pg).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.db.pg_provision import (
+    PgBinaries,
+    PgVectorNotInstalledError,
+    check_pgvector_available,
+)
+
+
+def _write_creds(config_dir: Path, port: str = "5499") -> Path:
+    config_dir.mkdir(parents=True, exist_ok=True)
+    creds = config_dir / "pg_credentials"
+    creds.write_text(
+        f"PG_PORT={port}\n"
+        "PG_DATA=/tmp/pgdata-test\n"
+        "NX_DB_USER=nexus_svc\nNX_DB_PASS=pw\n"
+        "NX_DB_ADMIN_USER=nexus_admin\nNX_DB_ADMIN_PASS=apw\n"
+        "NX_DB_URL=jdbc:postgresql://127.0.0.1:5499/nexus\n"
+    )
+    return creds
+
+
+def _lease_record() -> MagicMock:
+    record = MagicMock()
+    record.endpoint = {"host": "127.0.0.1", "port": 5999, "pid": 1234}
+    record.generation = 3
+    record.version = "5.10.6"
+    record.heartbeat_epoch = 0.0
+    record.status = "live"
+    record.payload = {"supervisor_pid": 1111}
+    return record
+
+
+class TestStatusSurface:
+    def _invoke(self, config_dir: Path, *, pg_up: bool = True,
+                svc_version: dict | None = None):
+        with patch(
+            "nexus.daemon.service_registry.ServiceRegistry.discover",
+            return_value=_lease_record(),
+        ), patch(
+            "nexus.commands.daemon._probe_health", return_value="ok",
+        ), patch(
+            "nexus.daemon.storage_service_daemon._port_accepting",
+            return_value=pg_up,
+        ), patch(
+            "nexus.commands.daemon._pgvector_version", return_value="0.8.2",
+        ), patch(
+            "nexus.daemon.jar_lifecycle.fetch_service_version",
+            return_value=svc_version,
+        ):
+            return CliRunner().invoke(main, [
+                "daemon", "service", "status", "--config-dir", str(config_dir),
+            ])
+
+    def test_full_stack_surface(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / "cfg"
+        _write_creds(config_dir)
+        result = self._invoke(config_dir, svc_version={
+            "app_version": "1.0-SNAPSHOT",
+            "embedding_mode": "voyage",
+            "embedding_models": ["minilm-l6-v2-384", "voyage-code-3"],
+            "schema_latest_id": "grants-002-changelog-read",
+            "schema_changeset_count": 65,
+        })
+        assert result.exit_code == 0, result.output
+        out = result.output
+        assert "supervisor_pid: 1111" in out
+        assert "health: ok" in out
+        assert "pg: up" in out
+        assert "pg_port: 5499" in out
+        assert "pg_data: /tmp/pgdata-test" in out
+        assert "pgvector: 0.8.2" in out
+        assert "embedding_mode: voyage" in out
+        assert "voyage-code-3" in out
+        assert "pg_credentials" in out
+        assert "storage_service_addr." in out
+
+    def test_pg_down_is_loud(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / "cfg"
+        _write_creds(config_dir)
+        result = self._invoke(config_dir, pg_up=False, svc_version=None)
+        assert result.exit_code == 0, result.output
+        assert "pg: DOWN" in result.output
+        # pgvector query is skipped when PG is down.
+        assert "pgvector" not in result.output
+
+    def test_unprovisioned_pg_hints_init(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / "cfg"
+        config_dir.mkdir(parents=True)
+        result = self._invoke(config_dir, svc_version=None)
+        assert result.exit_code == 0, result.output
+        assert "nx init --service" in result.output
+
+
+class TestStopPgClarity:
+    def _invoke_stop(self, config_dir: Path, args: list[str], *,
+                     pg_up: bool = True, stop_pid: int | None = 999):
+        with patch(
+            "nexus.daemon.storage_service_daemon.stop_storage_service",
+            return_value=stop_pid,
+        ), patch(
+            "nexus.daemon.storage_service_daemon._port_accepting",
+            return_value=pg_up,
+        ):
+            return CliRunner().invoke(main, [
+                "daemon", "service", "stop", "--config-dir", str(config_dir),
+                *args,
+            ])
+
+    def test_stop_says_pg_left_running(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / "cfg"
+        _write_creds(config_dir)
+        result = self._invoke_stop(config_dir, [])
+        assert result.exit_code == 0, result.output
+        assert "Postgres left running on 127.0.0.1:5499" in result.output
+        assert "--with-pg" in result.output
+
+    def test_stop_with_pg_stops_cluster(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / "cfg"
+        _write_creds(config_dir)
+        ran: list[list[str]] = []
+
+        def fake_run(cmd, **kw):
+            ran.append([str(c) for c in cmd])
+            return MagicMock(returncode=0)
+
+        bins = MagicMock()
+        bins.pg_ctl = "/fake/pg_ctl"
+        with patch("nexus.db.pg_provision.discover_pg_binaries", return_value=bins), \
+             patch("subprocess.run", side_effect=fake_run):
+            result = self._invoke_stop(config_dir, ["--with-pg"])
+        assert result.exit_code == 0, result.output
+        assert "Postgres stopped" in result.output
+        assert ran and ran[0][:3] == ["/fake/pg_ctl", "-D", "/tmp/pgdata-test"]
+
+    def test_stop_quiet_when_pg_already_down(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / "cfg"
+        _write_creds(config_dir)
+        result = self._invoke_stop(config_dir, [], pg_up=False)
+        assert result.exit_code == 0, result.output
+        assert "left running" not in result.output
+
+
+class TestPgVectorPreflight:
+    def _bins(self, tmp_path: Path) -> PgBinaries:
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        return PgBinaries.from_dir(bin_dir)
+
+    def _write_pg_config(self, bins: PgBinaries, sharedir: Path) -> None:
+        pg_config = bins.bin_dir / "pg_config"
+        pg_config.write_text(f"#!/bin/sh\necho {sharedir}\n")
+        pg_config.chmod(0o755)
+
+    def test_missing_control_file_fails_with_remedy(self, tmp_path: Path) -> None:
+        bins = self._bins(tmp_path)
+        sharedir = tmp_path / "share"
+        (sharedir / "extension").mkdir(parents=True)
+        self._write_pg_config(bins, sharedir)
+        with pytest.raises(PgVectorNotInstalledError) as exc:
+            check_pgvector_available(bins)
+        msg = str(exc.value)
+        assert "vector.control" in msg
+        assert "PG_CONFIG=" in msg
+        assert "nx init --service" in msg
+
+    def test_present_control_file_passes(self, tmp_path: Path) -> None:
+        bins = self._bins(tmp_path)
+        sharedir = tmp_path / "share"
+        ext = sharedir / "extension"
+        ext.mkdir(parents=True)
+        (ext / "vector.control").write_text("# pgvector")
+        self._write_pg_config(bins, sharedir)
+        check_pgvector_available(bins)  # must not raise
+
+    def test_missing_pg_config_is_indeterminate_not_blocking(
+        self, tmp_path: Path,
+    ) -> None:
+        bins = self._bins(tmp_path)  # no pg_config file
+        check_pgvector_available(bins)  # must not raise
+
+    def test_provision_gates_before_cluster_work(self, tmp_path: Path) -> None:
+        """provision() must invoke the pre-flight right after binary
+        discovery — a missing extension never reaches initdb."""
+        from nexus.db import pg_provision
+
+        bins = self._bins(tmp_path)
+        with patch.object(pg_provision, "discover_pg_binaries", return_value=bins), \
+             patch.object(
+                 pg_provision, "check_pgvector_available",
+                 side_effect=PgVectorNotInstalledError("nope"),
+             ), \
+             patch.object(pg_provision, "_init_cluster") as init_cluster:
+            with pytest.raises(PgVectorNotInstalledError):
+                pg_provision.provision(tmp_path / "cfg")
+        init_cluster.assert_not_called()

--- a/tests/daemon/test_service_status_clarity.py
+++ b/tests/daemon/test_service_status_clarity.py
@@ -209,3 +209,126 @@ class TestPgVectorPreflight:
             with pytest.raises(PgVectorNotInstalledError):
                 pg_provision.provision(tmp_path / "cfg")
         init_cluster.assert_not_called()
+
+
+class TestProbeImplementations:
+    """2026-06-11 review pass: the probe IMPLEMENTATIONS (not just their
+    wiring) — db-down classification, creds selection, latency guard."""
+
+    def test_probe_health_503_is_db_down(self) -> None:
+        from urllib.error import HTTPError
+
+        from nexus.commands.daemon import _probe_health
+
+        err = HTTPError("http://x/health", 503, "Service Unavailable", {}, None)
+        with patch("urllib.request.urlopen", side_effect=err):
+            assert _probe_health("127.0.0.1", 5999) == "db-down"
+
+    def test_probe_health_connection_refused_is_unreachable(self) -> None:
+        from nexus.commands.daemon import _probe_health
+
+        with patch(
+            "urllib.request.urlopen", side_effect=ConnectionRefusedError(),
+        ):
+            assert _probe_health("127.0.0.1", 5999) == "unreachable"
+
+    def test_pgvector_version_prefers_admin_creds(self) -> None:
+        from nexus.commands.daemon import _pgvector_version
+
+        creds = {
+            "PG_PORT": "5499",
+            "NX_DB_USER": "nexus_svc", "NX_DB_PASS": "svc-pw",
+            "NX_DB_ADMIN_USER": "nexus_admin", "NX_DB_ADMIN_PASS": "admin-pw",
+            "NX_DB_URL": "jdbc:postgresql://127.0.0.1:5499/nexus",
+        }
+        captured: dict = {}
+
+        def fake_run(cmd, env=None, **kw):
+            captured["cmd"] = [str(c) for c in cmd]
+            captured["pgpassword"] = env.get("PGPASSWORD")
+            return MagicMock(returncode=0, stdout="0.8.2\n")
+
+        with patch("subprocess.run", side_effect=fake_run), \
+             patch(
+                 "nexus.daemon.jar_lifecycle._psql_bin",
+                 return_value="/fake/psql",
+             ):
+            version = _pgvector_version(creds)
+        assert version == "0.8.2"
+        assert "nexus_admin" in captured["cmd"]
+        assert captured["pgpassword"] == "admin-pw"
+
+    def test_pgvector_version_falls_back_to_svc_creds(self) -> None:
+        from nexus.commands.daemon import _pgvector_version
+
+        creds = {
+            "PG_PORT": "5499",
+            "NX_DB_USER": "nexus_svc", "NX_DB_PASS": "svc-pw",
+            "NX_DB_URL": "jdbc:postgresql://127.0.0.1:5499/nexus",
+        }
+        captured: dict = {}
+
+        def fake_run(cmd, env=None, **kw):
+            captured["cmd"] = [str(c) for c in cmd]
+            captured["pgpassword"] = env.get("PGPASSWORD")
+            return MagicMock(returncode=0, stdout="0.8.2\n")
+
+        with patch("subprocess.run", side_effect=fake_run), \
+             patch(
+                 "nexus.daemon.jar_lifecycle._psql_bin",
+                 return_value="/fake/psql",
+             ):
+            _pgvector_version(creds)
+        assert "nexus_svc" in captured["cmd"]
+        assert captured["pgpassword"] == "svc-pw"
+
+    def test_version_probe_skipped_when_health_unreachable(
+        self, tmp_path: Path,
+    ) -> None:
+        """Latency guard (critic S1): /version cannot succeed against the
+        same dead host/port — it must not add a second timeout."""
+        config_dir = tmp_path / "cfg"
+        _write_creds(config_dir)
+        fetch = MagicMock(return_value=None)
+        with patch(
+            "nexus.daemon.service_registry.ServiceRegistry.discover",
+            return_value=_lease_record(),
+        ), patch(
+            "nexus.commands.daemon._probe_health", return_value="unreachable",
+        ), patch(
+            "nexus.daemon.storage_service_daemon._port_accepting",
+            return_value=True,
+        ), patch(
+            "nexus.commands.daemon._pgvector_version", return_value="0.8.2",
+        ), patch(
+            "nexus.daemon.jar_lifecycle.fetch_service_version", fetch,
+        ):
+            result = CliRunner().invoke(main, [
+                "daemon", "service", "status", "--config-dir", str(config_dir),
+            ])
+        assert result.exit_code == 0, result.output
+        fetch.assert_not_called()
+
+
+class TestStopAlreadyStoppedAdvisory:
+    def test_already_stopped_with_pg_up_uses_state_phrasing(
+        self, tmp_path: Path,
+    ) -> None:
+        """critic S4: when stop did nothing (no lease), the PG advisory must
+        read as a state report, not as an effect of this command."""
+        config_dir = tmp_path / "cfg"
+        _write_creds(config_dir)
+        with patch(
+            "nexus.daemon.storage_service_daemon.stop_storage_service",
+            return_value=None,
+        ), patch(
+            "nexus.daemon.storage_service_daemon._port_accepting",
+            return_value=True,
+        ):
+            result = CliRunner().invoke(main, [
+                "daemon", "service", "stop", "--config-dir", str(config_dir),
+            ])
+        assert result.exit_code == 0, result.output
+        assert "already stopped" in result.output
+        assert "Postgres is still running on 127.0.0.1:5499" in result.output
+        assert "left running" not in result.output


### PR DESCRIPTION
## Summary

Closes bead nexus-pebfx.5 (P2, epic nexus-pebfx): the 2026-06-10 diagnosis loop was `ps aux` + `psql` + `curl /health` + reading the addr file by hand. One surface now answers "is the stack healthy and how is it configured".

**Note:** stacked on the pebfx.4 branch (PR #1157); diff collapses as the chain merges.

## Changes

- **`nx daemon service status`** now reports the full stack: supervisor pid, lease generation, JAR pid, live `/health` probe (ok | db-down | unreachable), addr-file path, PG cluster (port, data dir, up/DOWN, installed pgvector version via admin psql, pg_credentials path), embedding mode + dispatchable models, and the pebfx.4 version handshake. Every probe degrades to a readable placeholder — status must work best when the stack is broken. `/version` probe is skipped when `/health` is unreachable (same dead host/port; status is invoked most when broken).
- **Java `/version`** gains `embedding_mode` + `embedding_models` (from the pebfx.2 router surface) so the mode is visible without parsing DEVNULLed JAR logs.
- **`nx daemon service stop`** states that Postgres is left running by design (or, when nothing was stopped, reports PG state without implying causality) and gains `--with-pg` (pg_ctl -m fast; help text states the terminates-connections blast radius).
- **`nx init --service` pre-flight**: `check_pgvector_available` verifies `<sharedir>/extension/vector.control` via pg_config *before* any cluster work, failing with the exact build-from-source remedy (the Homebrew pgvector formula targets the default postgresql major — hit 2026-06-08, rediscovered via a mid-provision Liquibase failure 2026-06-10). Indeterminate pg_config does not block.

## Review

Stacked review: code-review-expert — no Critical/Important (3 Low, all applied; confirmed `--with-pg` blast radius is storage-service-only since T2 is SQLite, and the addr-file naming matches ServiceRegistry exactly). Substantive-critic — 5 Significant (probe latency, untested db-down branch, untested creds selection, misleading stop phrasing when already stopped, understated --with-pg help), all fixed and CONFIRMED-FIXED on re-pass.

## Verification

- 16 tests in `tests/daemon/test_service_status_clarity.py` (surface, degradation, stop phrasings, --with-pg, pre-flight remedy/pass/indeterminate, gate-before-initdb wiring, probe implementations incl. 503→db-down and creds selection, latency guard); full daemon suite 491 green.
- **Live-verified on the production stack**: one screen shows pg up :53649, pgvector 0.8.2, embedding_mode voyage with 4 models, schema 65 changesets — and the restart exercised the pebfx.4 skew gate's first real upgrade pass (applied 64 ⊆ bundled 65). The stop message fired live.