### PR TITLE
feat: RDR-153 — migration data-quality policy + structured issue reporting (SQLite→Postgres T2)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1847,6 +1847,22 @@ artifact is written even when the flag is omitted, including on a
 mid-run crash — partial data beats no data). Note: `aspects` has no
 standalone command; it runs only via `migrate all`.
 
+### nx storage migration-report show
+
+```
+nx storage migration-report show <path>
+```
+
+Summarize an RDR-153 migration-report artifact: migration id and window,
+the recorded verification verdict (`(not recorded)` for artifacts that
+predate it), `max_severity` first, the by-action rollup
+(severity-descending), per-issue triage lines (severity-descending, with
+class/action/count/sample), and the gate verdict — **GATE: PASS** when
+`summary.total_failed == 0`, otherwise **GATE: FAIL** with a non-zero
+exit (scriptable; this is the RDR-152 Phase-4 SQLite-deletion gate
+predicate). The reader lives in `nexus.migration` and survives the
+`src/nexus/db/t2` deletion.
+
 Storage migration ETLs (RDR-152 T2 stores; RDR-155 vectors). Every ETL is copy-not-move (the source is never modified) and idempotent (server-side upsert; re-runs produce no duplicates). All require `NX_SERVICE_TOKEN`.
 
 ### nx storage migrate

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1838,8 +1838,14 @@ produces an artifact). Exits non-zero when `summary.total_failed > 0`
 Postgres counts below the report's written totals. When psql/credentials
 cannot be resolved the verification is reported as **VERIFICATION
 INDETERMINATE** — a loud warning, never a silent skip (the RDR-152
-prod-copy.sh harness bug). Every per-store command also accepts
-`--report PATH` for a single-store report.
+prod-copy.sh harness bug). The verdict is recorded in the report
+artifact (`"verification"`). Verification queries the LOCAL nx-managed
+Postgres (from `pg_credentials`) — when migrating against a remote
+service it reports on the local cluster only. Every per-store command
+also accepts `--report PATH` for a single-store report (a default-path
+artifact is written even when the flag is omitted, including on a
+mid-run crash — partial data beats no data). Note: `aspects` has no
+standalone command; it runs only via `migrate all`.
 
 Storage migration ETLs (RDR-152 T2 stores; RDR-155 vectors). Every ETL is copy-not-move (the source is never modified) and idempotent (server-side upsert; re-runs produce no duplicates). All require `NX_SERVICE_TOKEN`.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1823,6 +1823,24 @@ List service tokens: 12-char id prefix, tenant, status (`active`/`expired`/`revo
 
 ## nx storage
 
+### nx storage migrate all
+
+```
+nx storage migrate all [--report PATH] [--db PATH] [--catalog-db PATH]
+```
+
+Run ALL seven T2 store migrations in the RDR-152 ladder order (memory →
+plans → telemetry → taxonomy → aspects → chash → catalog last) with one
+shared issue collector, and emit ONE RDR-153 migration report (default:
+`~/.config/nexus/migration-reports/migration-<id>.json` — a run always
+produces an artifact). Exits non-zero when `summary.total_failed > 0`
+("migration is NOT clean") or when post-run count verification finds
+Postgres counts below the report's written totals. When psql/credentials
+cannot be resolved the verification is reported as **VERIFICATION
+INDETERMINATE** — a loud warning, never a silent skip (the RDR-152
+prod-copy.sh harness bug). Every per-store command also accepts
+`--report PATH` for a single-store report.
+
 Storage migration ETLs (RDR-152 T2 stores; RDR-155 vectors). Every ETL is copy-not-move (the source is never modified) and idempotent (server-side upsert; re-runs produce no duplicates). All require `NX_SERVICE_TOKEN`.
 
 ### nx storage migrate

--- a/scripts/rdr152-sandbox/prod-copy.sh
+++ b/scripts/rdr152-sandbox/prod-copy.sh
@@ -219,6 +219,15 @@ fi
 
 OS_USER="${USER:-$(id -un)}"
 
+# nexus-r0esi: an unresolved psql must FAIL the verification step, never
+# SKIP every count check and report 'all passed'. SKIPs are counted and
+# any skip makes the run red.
+SKIPPED=0
+if [[ -z "${PSQL_BIN}" ]]; then
+    echo "[prod-copy] ERROR: psql could not be resolved — count verification CANNOT run." >&2
+    FAIL=1
+fi
+
 # verify_pg_count_exact: FAIL if sandbox != prod_count (strict equality).
 # Use for stores that must copy completely.
 # The memory store accepts prod_count OR prod_count+1 (one probe write on ETL
@@ -229,7 +238,7 @@ verify_pg_count_exact() {
     local prod_count="$3"
     local allow_plus_one="${4:-0}"
     if [[ -z "${PSQL_BIN}" ]]; then
-        echo "[prod-copy] SKIP ${label} (psql not found)"
+        SKIPPED=$((SKIPPED+1)); echo "[prod-copy] SKIP ${label} (psql not found)"
         return
     fi
     # Query as OS superuser (trust auth) to bypass FORCE RLS on nexus tables.
@@ -265,7 +274,7 @@ verify_pg_count_at_least() {
     local table="$2"
     local prod_count="$3"
     if [[ -z "${PSQL_BIN}" ]]; then
-        echo "[prod-copy] SKIP ${label} (psql not found)"
+        SKIPPED=$((SKIPPED+1)); echo "[prod-copy] SKIP ${label} (psql not found)"
         return
     fi
     SBX_COUNT="$("${PSQL_BIN}" -h 127.0.0.1 -p "${PG_PORT}" \
@@ -293,7 +302,7 @@ verify_pg_count_known_gap() {
     local known_sbx_count="$4"  # expected sandbox count given the bug
     local bead="$5"             # tracking bead for the gap
     if [[ -z "${PSQL_BIN}" ]]; then
-        echo "[prod-copy] SKIP ${label} (psql not found)"
+        SKIPPED=$((SKIPPED+1)); echo "[prod-copy] SKIP ${label} (psql not found)"
         return
     fi
     SBX_COUNT="$("${PSQL_BIN}" -h 127.0.0.1 -p "${PG_PORT}" \
@@ -428,6 +437,10 @@ if [[ -n "${CHROMA_SQLITE}" ]]; then
     _assert_mtime_unchanged "${CHROMA_SQLITE}" "${MTIME_BEFORE_CHROMA_SQLITE}" "prod chroma.sqlite3" 0
 fi
 
+if [[ "${SKIPPED}" -ne 0 ]]; then
+    echo "[prod-copy] VERIFICATION INCOMPLETE — ${SKIPPED} count check(s) were skipped (psql unresolved)." >&2
+    FAIL=1
+fi
 if [[ "${FAIL}" -ne 0 ]]; then
     echo "[prod-copy] VERIFICATION FAILED — see errors above" >&2
     exit 1

--- a/scripts/rdr152-sandbox/sandbox_helper.py
+++ b/scripts/rdr152-sandbox/sandbox_helper.py
@@ -63,10 +63,26 @@ def _cmd_pg_bin(args: argparse.Namespace) -> None:
         logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
     )
 
-    from nexus.db.pg_provision import discover_pg_binaries
+    from nexus.db.pg_provision import PgBinaryNotFoundError, discover_pg_binaries
 
-    bins = discover_pg_binaries()
-    val = getattr(bins, args.binary, None)
+    try:
+        bins = discover_pg_binaries()
+        val = getattr(bins, args.binary, None)
+    except PgBinaryNotFoundError:
+        # nexus-r0esi: discovery failure must not silently yield an empty
+        # path (the prod-copy.sh count verification then SKIPped every
+        # check and reported 'all passed'). Fall back to PATH; fail LOUD
+        # with a non-zero exit when nothing resolves.
+        import shutil
+
+        val = shutil.which(args.binary) if args.binary != "bin_dir" else None
+        if val is None:
+            print(
+                f"pg-bin: {args.binary} not found via discovery or PATH "
+                "(install postgresql@16 or set NEXUS_PG_BIN)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
     if val is None:
         print(f"Unknown binary: {args.binary}", file=sys.stderr)
         sys.exit(1)

--- a/src/nexus/commands/storage_cmd.py
+++ b/src/nexus/commands/storage_cmd.py
@@ -68,7 +68,7 @@ def migration_report_show_cmd(report_file: Path) -> None:
         report = load_report(report_file)
     except FileNotFoundError:
         raise click.ClickException(f"report not found: {report_file}")
-    except (ValueError, _json.JSONDecodeError) as exc:
+    except ValueError as exc:  # JSONDecodeError subclasses ValueError
         raise click.ClickException(f"unreadable report {report_file}: {exc}")
 
     schema = str(report.get("schema_version", "?"))
@@ -79,7 +79,24 @@ def migration_report_show_cmd(report_file: Path) -> None:
             err=True,
         )
 
-    summary = report.get("summary", {})
+    # NEVER default-to-pass (P4 review CRITICAL): this command is the
+    # RDR-152 Phase-4 deletion gate's reading tool — a structurally
+    # damaged artifact (missing summary, missing total_failed) must FAIL
+    # the gate loudly, not evaluate the predicate against defaults.
+    summary = report.get("summary")
+    if not isinstance(summary, dict) or "total_failed" not in summary:
+        raise click.ClickException(
+            f"report has no summary.total_failed — cannot evaluate the gate "
+            f"predicate (schema_version="
+            f"{report.get('schema_version', '?')}): {report_file}"
+        )
+    try:
+        gate_total_failed = int(summary["total_failed"])
+    except (TypeError, ValueError) as exc:
+        raise click.ClickException(
+            f"report summary.total_failed is not an integer "
+            f"({summary['total_failed']!r}): {report_file} — {exc}"
+        )
     click.echo(f"migration: {report.get('migration_id', '?')}")
     click.echo(
         f"  {report.get('started_at', '?')} -> {report.get('completed_at', '?')}"
@@ -123,12 +140,16 @@ def migration_report_show_cmd(report_file: Path) -> None:
         for _, line in sorted(issues, key=lambda t: t[0], reverse=True):
             click.echo(line)
 
-    total_failed = int(summary.get("total_failed", 0))
-    if total_failed == 0:
+    if gate_total_failed == 0:
         click.echo("GATE: PASS (total_failed=0)")
     else:
-        click.echo(f"GATE: FAIL (total_failed={total_failed})", err=True)
-        raise SystemExit(1)
+        click.echo(f"GATE: FAIL (total_failed={gate_total_failed})", err=True)
+        click.echo(
+            "  failed rows are triaged above; after repairing parents, "
+            "re-running the ETL is idempotent (ON CONFLICT DO NOTHING).",
+            err=True,
+        )
+        sys.exit(1)
 
 
 @storage_group.group(name="migrate")

--- a/src/nexus/commands/storage_cmd.py
+++ b/src/nexus/commands/storage_cmd.py
@@ -42,6 +42,95 @@ def storage_group() -> None:
     """Storage migration and ETL commands (RDR-152)."""
 
 
+@storage_group.group(name="migration-report")
+def migration_report_group() -> None:
+    """Inspect RDR-153 migration-report artifacts."""
+
+
+@migration_report_group.command(name="show")
+@click.argument(
+    "report_file",
+    type=click.Path(path_type=Path),
+)
+def migration_report_show_cmd(report_file: Path) -> None:
+    """Summarize a migration report: gate verdict, by-action rollup
+    (severity-descending), and per-issue triage lines (RDR-153 Phase 4).
+
+    The Phase-4 SQLite-deletion gate reads this artifact; the predicate is
+    ``summary.total_failed == 0``. Exits non-zero when the gate fails so
+    the verdict is scriptable.
+    """
+    import json as _json
+
+    from nexus.migration.migration_report import ACTION_SEVERITY, load_report
+
+    try:
+        report = load_report(report_file)
+    except FileNotFoundError:
+        raise click.ClickException(f"report not found: {report_file}")
+    except (ValueError, _json.JSONDecodeError) as exc:
+        raise click.ClickException(f"unreadable report {report_file}: {exc}")
+
+    schema = str(report.get("schema_version", "?"))
+    if schema != "1":
+        click.echo(
+            f"note: schema_version {schema} is newer than this viewer "
+            "understands — best-effort display",
+            err=True,
+        )
+
+    summary = report.get("summary", {})
+    click.echo(f"migration: {report.get('migration_id', '?')}")
+    click.echo(
+        f"  {report.get('started_at', '?')} -> {report.get('completed_at', '?')}"
+    )
+    source = report.get("source", {})
+    if source:
+        click.echo(f"  source: {source}")
+    click.echo(f"verification: {report.get('verification', '(not recorded)')}")
+    click.echo(f"max_severity={summary.get('max_severity', '?')}")
+    by_action = summary.get("by_action", {})
+    ordered_actions = sorted(
+        by_action,
+        key=lambda a: ACTION_SEVERITY.get(a, -1),
+        reverse=True,
+    )
+    click.echo(
+        "  " + " ".join(f"{a}={by_action[a]}" for a in ordered_actions)
+    )
+    click.echo(
+        f"  total_read={summary.get('total_read', '?')} "
+        f"total_written={summary.get('total_written', '?')} "
+        f"total_failed={summary.get('total_failed', '?')}"
+    )
+
+    # Per-issue triage lines, severity-descending (the actionable ones first).
+    issues: list[tuple[int, str]] = []
+    for store in report.get("stores", []):
+        for table in store.get("tables", []):
+            for issue in table.get("issues", []):
+                sample = (issue.get("sample_ids") or ["-"])[0]
+                issues.append((
+                    int(issue.get("severity", 0)),
+                    f"  [{issue.get('severity', '?')}] "
+                    f"{store.get('store', '?')}.{table.get('table', '?')} "
+                    f"{issue.get('class', '?')}/{issue.get('action', '?')} "
+                    f"count={issue.get('count', '?')} sample={sample} — "
+                    f"{issue.get('reason', '')}",
+                ))
+    if issues:
+        click.echo("issues (severity-descending):")
+        for _, line in sorted(issues, key=lambda t: t[0], reverse=True):
+            click.echo(line)
+
+    total_failed = int(summary.get("total_failed", 0))
+    if total_failed == 0:
+        click.echo("GATE: PASS (total_failed=0)")
+    else:
+        click.echo(f"GATE: FAIL (total_failed={total_failed})", err=True)
+        raise SystemExit(1)
+
+
 @storage_group.group(name="migrate")
 def migrate_group() -> None:
     """Migrate a T2 store from SQLite to the Postgres service tier."""

--- a/src/nexus/commands/storage_cmd.py
+++ b/src/nexus/commands/storage_cmd.py
@@ -26,6 +26,7 @@ The SQLite source is never modified (copy-not-move).
 """
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 from pathlib import Path
@@ -154,6 +155,10 @@ def migrate_memory_cmd(
     try:
         result = migrate_memory_rows(resolved_db, store, collector=collector)
     except Exception as exc:
+        # Partial data beats no data (P3 critique S2): the report is
+        # written even on a mid-run crash, so the operator always has a
+        # triage artifact covering everything the run recorded.
+        _emit_store_report(collector, resolved_db, report_path)
         raise click.ClickException(f"ETL failed: {exc}")
     finally:
         store.close()
@@ -286,6 +291,8 @@ def migrate_plans_cmd(
     try:
         result = migrate_plan_rows(resolved_db, store, collector=_collector)
     except Exception as exc:
+        # Partial data beats no data (P3 critique S2).
+        _emit_store_report(_collector, resolved_db, report_path)
         raise click.ClickException(f"ETL failed: {exc}")
     finally:
         store.close()
@@ -426,6 +433,8 @@ def migrate_telemetry_cmd(
     try:
         results = migrate_telemetry_rows(resolved_db, store, collector=_collector)
     except Exception as exc:
+        # Partial data beats no data (P3 critique S2).
+        _emit_store_report(_collector, resolved_db, report_path)
         raise click.ClickException(f"ETL failed: {exc}")
     finally:
         store.close()
@@ -581,6 +590,8 @@ def migrate_taxonomy_cmd(
     try:
         results = migrate_taxonomy_rows(resolved_db, store, collector=_collector)
     except Exception as exc:
+        # Partial data beats no data (P3 critique S2).
+        _emit_store_report(_collector, resolved_db, report_path)
         raise click.ClickException(f"ETL failed: {exc}")
     finally:
         store.close()
@@ -738,6 +749,8 @@ def migrate_chash_cmd(
     try:
         results = migrate_chash_rows(resolved_db, store, collector=_collector)
     except Exception as exc:
+        # Partial data beats no data (P3 critique S2).
+        _emit_store_report(_collector, resolved_db, report_path)
         raise click.ClickException(f"ETL failed: {exc}")
     finally:
         store.close()
@@ -876,6 +889,8 @@ def migrate_catalog_cmd(
     try:
         results = migrate_catalog(resolved_catalog, client, collector=_collector)
     except Exception as exc:
+        # Partial data beats no data (P3 critique S2).
+        _emit_store_report(_collector, resolved_catalog, report_path)
         raise click.ClickException(f"ETL failed: {exc}")
     finally:
         client.close()
@@ -1242,6 +1257,9 @@ def _verify_pg_counts(report: dict, creds: dict) -> str:
                 )
     if not written_by_table:
         return "indeterminate"  # nothing mappable to verify is NOT a pass
+    # NOTE: written=0 for a mapped table passes trivially (pg_count >= 0) —
+    # correct for idempotent re-runs and empty sources; the gate predicate
+    # is the report's total_failed, never this advisory check.
 
     env = dict(os.environ)
     env["PGPASSWORD"] = password
@@ -1461,6 +1479,13 @@ def migrate_all_cmd(
         target={"service_url": os.environ.get("NX_SERVICE_URL", "(lease)")},
         migration_id=migration_id,
     )
+    # Verification runs BEFORE the single artifact write so its verdict is
+    # recorded IN the report (P3 critique S1: the artifact must be
+    # self-contained for the Phase-4 triage surface — an operator reading
+    # the JSON tomorrow must see whether counts were checked).
+    verification = _run_verification(report)
+    report["verification"] = verification
+
     out_path = report_path or _default_report_path(migration_id)
     _write_report(report, out_path)
 
@@ -1472,8 +1497,6 @@ def migrate_all_cmd(
         f"total_failed={summary['total_failed']} "
         f"max_severity={summary['max_severity']}"
     )
-
-    verification = _run_verification(report)
     if summary["total_failed"] > 0:
         raise click.ClickException(
             f"migration is NOT clean — total_failed={summary['total_failed']}; "
@@ -1501,7 +1524,11 @@ def _run_verification(report: dict) -> str:
             creds = {}
     verification = _verify_pg_counts(report, creds)
     if verification == "verified":
-        click.echo("verification: verified (pg counts >= report written)")
+        checked = len(_VERIFY_TABLES)
+        click.echo(
+            f"verification: verified (pg counts >= report written across the "
+            f"{checked} mappable relations; unmapped tables are not checked)"
+        )
     elif verification == "mismatch":
         click.echo("verification: VERIFICATION MISMATCH", err=True)
     else:

--- a/src/nexus/commands/storage_cmd.py
+++ b/src/nexus/commands/storage_cmd.py
@@ -72,10 +72,20 @@ def migrate_group() -> None:
     default=False,
     help="Count rows in the source without writing. No service connection is made.",
 )
+@click.option(
+    "--report",
+    "report_path",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Write a single-store RDR-153 migration report to PATH "
+         "(default when omitted: <config>/migration-reports/"
+         "migration-<id>.json).",
+)
 def migrate_memory_cmd(
     db_path: Path | None,
     service_url: str | None,
     dry_run: bool,
+    report_path: Path | None,
 ) -> None:
     """Migrate the SQLite memory store to Postgres via the nexus-service.
 
@@ -137,13 +147,18 @@ def migrate_memory_cmd(
     # Run the ETL
     from nexus.db.t2.memory_etl import migrate_memory_rows
 
+    from nexus.migration.migration_report import IssueCollector
+
+    collector = IssueCollector()
     click.echo(f"Migrating memory store from {resolved_db} ...")
     try:
-        result = migrate_memory_rows(resolved_db, store)
+        result = migrate_memory_rows(resolved_db, store, collector=collector)
     except Exception as exc:
         raise click.ClickException(f"ETL failed: {exc}")
     finally:
         store.close()
+
+    _emit_store_report(collector, resolved_db, report_path)
 
     read_n = result["read"]
     written_m = result["written"]
@@ -190,10 +205,18 @@ def migrate_memory_cmd(
     default=False,
     help="Count rows in the source without writing. No service connection is made.",
 )
+@click.option(
+    "--report",
+    "report_path",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Write a single-store RDR-153 migration report to PATH.",
+)
 def migrate_plans_cmd(
     db_path: Path | None,
     service_url: str | None,
     dry_run: bool,
+    report_path: Path | None,
 ) -> None:
     """Migrate the SQLite plans store to Postgres via the nexus-service.
 
@@ -256,13 +279,18 @@ def migrate_plans_cmd(
 
     from nexus.db.t2.plan_etl import migrate_plan_rows
 
+    from nexus.migration.migration_report import IssueCollector
+
+    _collector = IssueCollector()
     click.echo(f"Migrating plans store from {resolved_db} ...")
     try:
-        result = migrate_plan_rows(resolved_db, store)
+        result = migrate_plan_rows(resolved_db, store, collector=_collector)
     except Exception as exc:
         raise click.ClickException(f"ETL failed: {exc}")
     finally:
         store.close()
+
+    _emit_store_report(_collector, resolved_db, report_path)
 
     read_n = result["read"]
     written_m = result["written"]
@@ -309,10 +337,18 @@ def migrate_plans_cmd(
     default=False,
     help="Count rows in all six source tables without writing. No service connection is made.",
 )
+@click.option(
+    "--report",
+    "report_path",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Write a single-store RDR-153 migration report to PATH.",
+)
 def migrate_telemetry_cmd(
     db_path: Path | None,
     service_url: str | None,
     dry_run: bool,
+    report_path: Path | None,
 ) -> None:
     """Migrate the SQLite telemetry stores to Postgres via the nexus-service.
 
@@ -383,13 +419,18 @@ def migrate_telemetry_cmd(
 
     from nexus.db.t2.telemetry_etl import migrate_telemetry_rows
 
+    from nexus.migration.migration_report import IssueCollector
+
+    _collector = IssueCollector()
     click.echo(f"Migrating telemetry stores from {resolved_db} ...")
     try:
-        results = migrate_telemetry_rows(resolved_db, store)
+        results = migrate_telemetry_rows(resolved_db, store, collector=_collector)
     except Exception as exc:
         raise click.ClickException(f"ETL failed: {exc}")
     finally:
         store.close()
+
+    _emit_store_report(_collector, resolved_db, report_path)
 
     total_read    = sum(v["read"]    for v in results.values())
     total_written = sum(v["written"] for v in results.values())
@@ -440,10 +481,18 @@ def migrate_telemetry_cmd(
     default=False,
     help="Count rows in all four source tables without writing. No service connection is made.",
 )
+@click.option(
+    "--report",
+    "report_path",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Write a single-store RDR-153 migration report to PATH.",
+)
 def migrate_taxonomy_cmd(
     db_path: Path | None,
     service_url: str | None,
     dry_run: bool,
+    report_path: Path | None,
 ) -> None:
     """Migrate the SQLite taxonomy tables to Postgres via the nexus-service.
 
@@ -525,13 +574,18 @@ def migrate_taxonomy_cmd(
 
     from nexus.db.t2.taxonomy_etl import migrate_taxonomy_rows
 
+    from nexus.migration.migration_report import IssueCollector
+
+    _collector = IssueCollector()
     click.echo(f"Migrating taxonomy stores from {resolved_db} ...")
     try:
-        results = migrate_taxonomy_rows(resolved_db, store)
+        results = migrate_taxonomy_rows(resolved_db, store, collector=_collector)
     except Exception as exc:
         raise click.ClickException(f"ETL failed: {exc}")
     finally:
         store.close()
+
+    _emit_store_report(_collector, resolved_db, report_path)
 
     total_read    = sum(v["read"]    for v in results.values())
     total_written = sum(v["written"] for v in results.values())
@@ -597,10 +651,18 @@ def migrate_taxonomy_cmd(
     default=False,
     help="Count rows in the source without writing. No service connection is made.",
 )
+@click.option(
+    "--report",
+    "report_path",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Write a single-store RDR-153 migration report to PATH.",
+)
 def migrate_chash_cmd(
     db_path: Path | None,
     service_url: str | None,
     dry_run: bool,
+    report_path: Path | None,
 ) -> None:
     """Migrate the SQLite chash_index store to Postgres via the nexus-service.
 
@@ -670,13 +732,17 @@ def migrate_chash_cmd(
         store = HttpChashIndex()
 
     from nexus.db.t2.chash_etl import migrate_chash_rows
+    from nexus.migration.migration_report import IssueCollector
 
+    _collector = IssueCollector()
     try:
-        results = migrate_chash_rows(resolved_db, store)
+        results = migrate_chash_rows(resolved_db, store, collector=_collector)
     except Exception as exc:
         raise click.ClickException(f"ETL failed: {exc}")
     finally:
         store.close()
+
+    _emit_store_report(_collector, resolved_db, report_path)
 
     total    = results["total"]
     imported = results["imported"]
@@ -722,10 +788,18 @@ def migrate_chash_cmd(
     default=False,
     help="Count rows in all catalog tables without writing. No service connection is made.",
 )
+@click.option(
+    "--report",
+    "report_path",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Write a single-store RDR-153 migration report to PATH.",
+)
 def migrate_catalog_cmd(
     catalog_db_path: Path | None,
     service_url: str | None,
     dry_run: bool,
+    report_path: Path | None,
 ) -> None:
     """Migrate the SQLite catalog to Postgres via the nexus-service.
 
@@ -795,13 +869,18 @@ def migrate_catalog_cmd(
 
     from nexus.db.t2.catalog_etl import migrate_catalog
 
+    from nexus.migration.migration_report import IssueCollector
+
+    _collector = IssueCollector()
     click.echo(f"Migrating catalog from {resolved_catalog} ...")
     try:
-        results = migrate_catalog(resolved_catalog, client)
+        results = migrate_catalog(resolved_catalog, client, collector=_collector)
     except Exception as exc:
         raise click.ClickException(f"ETL failed: {exc}")
     finally:
         client.close()
+
+    _emit_store_report(_collector, resolved_catalog, report_path)
 
     from nexus.db.t2.catalog_etl import IMPORT_TABLE_KEYS
 
@@ -1046,6 +1125,395 @@ def _echo_summary_table(report) -> None:
         f"{report.total_written:>8}   ok={report.ok}"
     )
     sys.stdout.flush()
+# ── RDR-153 Phase 3: migrate-all orchestration ───────────────────────────────
+
+
+def _default_report_path(migration_id: str) -> Path:
+    """``<config>/migration-reports/migration-<id>.json`` — a run ALWAYS
+    produces an artifact, even when the operator forgets ``--report``."""
+    from nexus.config import nexus_config_dir
+
+    return nexus_config_dir() / "migration-reports" / f"migration-{migration_id}.json"
+
+
+def _write_report(report: dict, path: Path) -> None:
+    import json as _json
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_json.dumps(report, indent=2, sort_keys=True))
+
+
+#: (store, table) → Postgres relation counted during verification. Only
+#: tables with a 1:1 name mapping are verified; the check is
+#: pg_count >= report_written (the target may carry rows from previous
+#: idempotent runs — equality only holds on a fresh target).
+_VERIFY_TABLES: dict[tuple[str, str], str] = {
+    ("memory", "memory"): "nexus.memory",
+    ("plans", "plans"): "nexus.plans",
+    ("taxonomy", "topics"): "nexus.topics",
+    ("taxonomy", "topic_assignments"): "nexus.topic_assignments",
+    ("taxonomy", "topic_links"): "nexus.topic_links",
+    ("telemetry", "hook_failures"): "nexus.hook_failures",
+    ("telemetry", "nx_answer_runs"): "nexus.nx_answer_runs",
+    ("chash", "chash_index"): "nexus.chash_index",
+    ("catalog", "documents"): "nexus.documents",
+    ("catalog", "links"): "nexus.links",
+}
+
+
+def _emit_store_report(
+    collector, sqlite_path: Path, report_path: Path | None,
+) -> None:
+    """Write the single-store RDR-153 report (per-store ``--report``).
+
+    A report is ALWAYS written (default path when the flag is omitted) —
+    the run must leave a triage artifact.
+    """
+    import uuid as _uuid
+
+    from nexus.migration.migration_report import build_report
+
+    migration_id = str(_uuid.uuid4())
+    report = build_report(
+        collector,
+        source={"sqlite": str(sqlite_path)},
+        target={"service_url": os.environ.get("NX_SERVICE_URL", "(lease)")},
+        migration_id=migration_id,
+    )
+    out_path = report_path or _default_report_path(migration_id)
+    _write_report(report, out_path)
+    click.echo(f"report: {out_path}")
+
+
+def _psql_for_verify() -> str | None:
+    """psql via the same discovery the provisioner uses; PATH fallback.
+
+    Self-contained (no dependency on the supervisor-side helpers) so the
+    orchestrator works on any branch state.
+    """
+    try:
+        from nexus.db.pg_provision import discover_pg_binaries
+
+        return str(discover_pg_binaries().psql)
+    except Exception:
+        import shutil
+
+        return shutil.which("psql")
+
+
+def _verify_db_name(creds: dict) -> str:
+    import re as _re
+
+    url = creds.get("NX_DB_ADMIN_URL", "") or creds.get("NX_DB_URL", "")
+    m = _re.search(r"postgresql://[^/]+/([^?]+)", url)
+    return m.group(1) if m else "nexus"
+
+
+def _verify_pg_counts(report: dict, creds: dict) -> str:
+    """Count-verify the migration against Postgres.
+
+    Returns ``"verified"`` | ``"mismatch"`` | ``"indeterminate"``.
+
+    nexus-r0esi: an unresolvable psql / unreadable target is
+    ``indeterminate`` and the CLI surfaces it LOUDLY — never the hollow
+    'SKIP … all passed' the prod-copy.sh harness produced.
+    """
+    import subprocess
+
+    psql = _psql_for_verify()
+    port = creds.get("PG_PORT", "")
+    user = creds.get("NX_DB_ADMIN_USER", "") or creds.get("NX_DB_USER", "")
+    password = (
+        creds.get("NX_DB_ADMIN_PASS", "")
+        if creds.get("NX_DB_ADMIN_USER", "")
+        else creds.get("NX_DB_PASS", "")
+    )
+    if psql is None or not port or not user:
+        return "indeterminate"
+
+    written_by_table: dict[str, int] = {}
+    for store in report.get("stores", []):
+        for table in store.get("tables", []):
+            key = (store["store"], table["table"])
+            relation = _VERIFY_TABLES.get(key)
+            if relation is not None:
+                written_by_table[relation] = (
+                    written_by_table.get(relation, 0) + int(table["written"])
+                )
+    if not written_by_table:
+        return "indeterminate"  # nothing mappable to verify is NOT a pass
+
+    env = dict(os.environ)
+    env["PGPASSWORD"] = password
+    for relation, written in written_by_table.items():
+        try:
+            result = subprocess.run(
+                [
+                    str(psql), "-h", "127.0.0.1", "-p", str(port), "-U", user,
+                    "-d", _verify_db_name(creds), "-t", "-A", "-X",
+                    "-c", f"SELECT count(*) FROM {relation}",
+                ],
+                env=env, capture_output=True, text=True, timeout=15,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return "indeterminate"
+        if result.returncode != 0:
+            return "indeterminate"
+        try:
+            pg_count = int(result.stdout.strip())
+        except ValueError:
+            return "indeterminate"
+        if pg_count < written:
+            _log.error(
+                "migrate_all_verify_mismatch",
+                relation=relation,
+                pg_count=pg_count,
+                report_written=written,
+            )
+            return "mismatch"
+    return "verified"
+
+
+def _build_store_etls(sources):
+    """The seven RDR-152 ETL adapters, registered against the RDR-153
+    ladder (``nexus.migration.etl_registry``). Each runner constructs its
+    HTTP store lazily so a single-store failure surfaces inside the
+    orchestrated run, not at registry build time."""
+    from nexus.migration.etl_registry import StoreEtl
+
+    def _memory(sources, collector):
+        from nexus.db.t2.http_memory_store import HttpMemoryStore
+        from nexus.db.t2.memory_etl import migrate_memory_rows
+
+        store = HttpMemoryStore()
+        try:
+            return migrate_memory_rows(
+                sources.sqlite_path, store, collector=collector,
+            )
+        finally:
+            store.close()
+
+    def _plans(sources, collector):
+        from nexus.db.t2.http_plan_library import HttpPlanLibrary
+        from nexus.db.t2.plan_etl import migrate_plan_rows
+
+        store = HttpPlanLibrary()
+        try:
+            return migrate_plan_rows(
+                sources.sqlite_path, store, collector=collector,
+            )
+        finally:
+            store.close()
+
+    def _telemetry(sources, collector):
+        from nexus.db.t2.http_telemetry_store import HttpTelemetryStore
+        from nexus.db.t2.telemetry_etl import migrate_telemetry_rows
+
+        store = HttpTelemetryStore()
+        try:
+            return migrate_telemetry_rows(
+                sources.sqlite_path, store, collector=collector,
+            )
+        finally:
+            store.close()
+
+    def _taxonomy(sources, collector):
+        from nexus.db.t2.http_taxonomy_store import HttpTaxonomyStore
+        from nexus.db.t2.taxonomy_etl import migrate_taxonomy_rows
+
+        store = HttpTaxonomyStore()
+        try:
+            return migrate_taxonomy_rows(
+                sources.sqlite_path, store, collector=collector,
+            )
+        finally:
+            store.close()
+
+    def _aspects(sources, collector):
+        from nexus.db.t2.aspects_etl import migrate_all as migrate_aspects_all
+        from nexus.db.t2.http_aspect_queue import HttpAspectQueue
+        from nexus.db.t2.http_document_aspects_store import (
+            HttpDocumentAspectsStore,
+        )
+        from nexus.db.t2.http_document_highlights_store import (
+            HttpDocumentHighlightsStore,
+        )
+
+        aspects = HttpDocumentAspectsStore()
+        highlights = HttpDocumentHighlightsStore()
+        queue = HttpAspectQueue()
+        try:
+            return migrate_aspects_all(
+                sources.sqlite_path, aspects, highlights, queue,
+                collector=collector,
+                catalog_db_path=sources.catalog_db_path,
+            )
+        finally:
+            for st in (aspects, highlights, queue):
+                with contextlib.suppress(Exception):
+                    st.close()
+
+    def _chash(sources, collector):
+        from nexus.db.t2.chash_etl import migrate_chash_rows
+        from nexus.db.t2.http_chash_index import HttpChashIndex
+
+        store = HttpChashIndex()
+        try:
+            return migrate_chash_rows(
+                sources.sqlite_path, store, collector=collector,
+            )
+        finally:
+            store.close()
+
+    def _catalog(sources, collector):
+        from nexus.catalog.factory import make_catalog_client_for_migration
+        from nexus.db.t2.catalog_etl import migrate_catalog
+
+        token = os.environ.get("NX_SERVICE_TOKEN", "")
+        client = make_catalog_client_for_migration(base_url=None, token=token)
+        try:
+            return migrate_catalog(
+                sources.catalog_db_path, client, collector=collector,
+            )
+        finally:
+            client.close()
+
+    return [
+        StoreEtl("memory", _memory),
+        StoreEtl("plans", _plans),
+        StoreEtl("telemetry", _telemetry),
+        StoreEtl("taxonomy", _taxonomy),
+        StoreEtl("aspects", _aspects),
+        StoreEtl("chash", _chash),
+        StoreEtl("catalog", _catalog),
+    ]
+
+
+@migrate_group.command(name="all")
+@click.option(
+    "--report",
+    "report_path",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Report artifact path (default: <config>/migration-reports/"
+         "migration-<id>.json — a run always produces an artifact).",
+)
+@click.option(
+    "--db", "db_path", default=None,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="SQLite T2 source (default: NX_DB_PATH or the canonical path).",
+)
+@click.option(
+    "--catalog-db", "catalog_db_path", default=None,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="SQLite catalog source (default: NX_CATALOG_DB_PATH or the "
+         "canonical path).",
+)
+def migrate_all_cmd(
+    report_path: Path | None,
+    db_path: Path | None,
+    catalog_db_path: Path | None,
+) -> None:
+    """Run ALL seven store migrations in the RDR-152 ladder order and emit
+    ONE migration report (RDR-153 Phase 3).
+
+    Order: memory → plans → telemetry → taxonomy → aspects → chash →
+    catalog LAST (graph-heavy). One shared IssueCollector spans the run;
+    the report is the triage/recovery artifact and the Phase-4 gate input
+    (``summary.total_failed == 0``). Post-run count verification is LOUD
+    when it cannot run (nexus-r0esi: never SKIP-then-'all passed').
+    """
+    import uuid as _uuid
+
+    from nexus.migration.etl_registry import EtlSources, ordered
+    from nexus.migration.migration_report import IssueCollector, build_report
+
+    sources = EtlSources(
+        sqlite_path=_resolve_db_path(db_path),
+        catalog_db_path=_resolve_catalog_db_path(catalog_db_path),
+    )
+    collector = IssueCollector()
+    migration_id = str(_uuid.uuid4())
+
+    for etl in ordered(_build_store_etls(sources)):
+        click.echo(f"migrating {etl.store} …")
+        sys.stdout.flush()
+        try:
+            etl.run(sources, collector)
+        except Exception as exc:
+            # A store-level crash is recorded, the run continues — the
+            # report must cover every store it attempted (never silent).
+            collector.record_event(
+                etl.store, etl.store,
+                issue_class="unexpected",
+                constraint=etl.store,
+                reason=f"store-level ETL crash: {exc}",
+                action="failed",
+            )
+            click.echo(f"  {etl.store}: CRASHED — {exc}", err=True)
+
+    report = build_report(
+        collector,
+        source={
+            "sqlite": str(sources.sqlite_path),
+            "catalog_db": str(sources.catalog_db_path),
+        },
+        target={"service_url": os.environ.get("NX_SERVICE_URL", "(lease)")},
+        migration_id=migration_id,
+    )
+    out_path = report_path or _default_report_path(migration_id)
+    _write_report(report, out_path)
+
+    summary = report["summary"]
+    click.echo(f"report: {out_path}")
+    click.echo(
+        f"total_read={summary['total_read']} "
+        f"total_written={summary['total_written']} "
+        f"total_failed={summary['total_failed']} "
+        f"max_severity={summary['max_severity']}"
+    )
+
+    verification = _run_verification(report)
+    if summary["total_failed"] > 0:
+        raise click.ClickException(
+            f"migration is NOT clean — total_failed={summary['total_failed']}; "
+            f"triage with: nx storage migration-report show {out_path}"
+        )
+    if verification == "mismatch":
+        raise click.ClickException(
+            "VERIFICATION MISMATCH — Postgres counts are below the report's "
+            "written totals; the report and logs identify the tables."
+        )
+
+
+def _run_verification(report: dict) -> str:
+    """Resolve creds + run :func:`_verify_pg_counts`; print the verdict
+    loudly (nexus-r0esi: indeterminate is a WARNING, never a pass)."""
+    from nexus.config import nexus_config_dir
+    from nexus.daemon.storage_service_daemon import _read_pg_credentials
+
+    creds_path = nexus_config_dir() / "pg_credentials"
+    creds: dict = {}
+    if creds_path.exists():
+        try:
+            creds = _read_pg_credentials(creds_path)
+        except OSError:
+            creds = {}
+    verification = _verify_pg_counts(report, creds)
+    if verification == "verified":
+        click.echo("verification: verified (pg counts >= report written)")
+    elif verification == "mismatch":
+        click.echo("verification: VERIFICATION MISMATCH", err=True)
+    else:
+        click.echo(
+            "verification: VERIFICATION INDETERMINATE — psql/credentials "
+            "unresolved; counts were NOT checked (this is a warning, not a "
+            "pass — fix the environment and re-run, the ETL is idempotent)",
+            err=True,
+        )
+    sys.stdout.flush()
+    sys.stderr.flush()
+    return verification
 
 
 def _resolve_catalog_db_path(explicit: Path | None) -> Path:

--- a/src/nexus/db/t2/aspects_etl.py
+++ b/src/nexus/db/t2/aspects_etl.py
@@ -196,19 +196,44 @@ def _transform_promotion_row(row: dict[str, Any]) -> dict[str, Any]:
 # ── Migration functions ────────────────────────────────────────────────────────
 
 
+def _load_live_tumblers(catalog_db_path: Path) -> set[str]:
+    """Document tumblers from the SQLite catalog (the valid-doc_id source
+    for the RDR-153 orphan pre-check). Read-only open."""
+    conn = sqlite3.connect(f"file:{catalog_db_path}?mode=ro", uri=True)
+    try:
+        return {
+            str(r[0])
+            for r in conn.execute("SELECT tumbler FROM documents").fetchall()
+        }
+    finally:
+        conn.close()
+
+
 def migrate_aspects(
     sqlite_path: Path,
     http_aspects,  # HttpDocumentAspectsStore instance
     *,
     batch_size: int = 200,
+    collector: Any = None,
+    catalog_db_path: Path | None = None,
 ) -> dict[str, int]:
     """Migrate document_aspects from SQLite to Postgres via the HTTP service.
 
+    RDR-153 orphan policy: when *catalog_db_path* is provided, rows whose
+    ``doc_id`` references no live catalog document (the audit's 675/675
+    stale pre-rebuild tumblers) are SKIP-AND-RECORDED into *collector*
+    instead of imported. Without it, behavior is unchanged (RDR-152
+    callers).
+
     Returns a summary dict: {imported, skipped, errors}.
     """
+    live_tumblers: set[str] | None = (
+        _load_live_tumblers(catalog_db_path) if catalog_db_path else None
+    )
     conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     imported = skipped = errors = 0
+    read = 0
     try:
         # Detect column presence (document_aspects schema evolves)
         cols = {r[1] for r in conn.execute("PRAGMA table_info(document_aspects)").fetchall()}
@@ -235,6 +260,28 @@ def migrate_aspects(
                 break
             for row in rows:
                 row_dict = dict(row)
+                read += 1
+                doc_id = str(row_dict.get("doc_id") or "")
+                if (
+                    live_tumblers is not None
+                    and doc_id
+                    and doc_id not in live_tumblers
+                ):
+                    skipped += 1
+                    if collector is not None:
+                        collector.record(
+                            "aspects", "document_aspects",
+                            issue_class="orphan_parent",
+                            constraint="document_aspects.doc_id -> "
+                                       "documents.tumbler",
+                            reason="doc_id references a deleted/rebuilt "
+                                   "catalog document (stale pre-rebuild "
+                                   "tumbler); re-extract follow-on is "
+                                   "nexus-f1m8s",
+                            action="skipped",
+                            sample_id=doc_id,
+                        )
+                    continue
                 try:
                     body = _transform_aspect(row_dict)
                     n = http_aspects.import_aspect(body)
@@ -250,6 +297,15 @@ def migrate_aspects(
                         source_path=row_dict.get("source_path"),
                         error=str(exc),
                     )
+                    if collector is not None:
+                        collector.record(
+                            "aspects", "document_aspects",
+                            issue_class="unexpected",
+                            constraint="document_aspects",
+                            reason=f"row rejected during import: {exc}",
+                            action="failed",
+                            sample_id=doc_id or f"row#{read}",
+                        )
             offset += batch_size
     finally:
         conn.close()
@@ -260,6 +316,9 @@ def migrate_aspects(
         skipped=skipped,
         errors=errors,
     )
+    if collector is not None:
+        collector.count_read("aspects", "document_aspects", read)
+        collector.count_written("aspects", "document_aspects", imported)
     return {"imported": imported, "skipped": skipped, "errors": errors}
 
 
@@ -270,9 +329,13 @@ def migrate_highlights(
     batch_size: int = 200,
 ) -> dict[str, int]:
     """Migrate document_highlights from SQLite to Postgres via the HTTP service."""
+    live_tumblers: set[str] | None = (
+        _load_live_tumblers(catalog_db_path) if catalog_db_path else None
+    )
     conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     imported = skipped = errors = 0
+    read = 0
     try:
         offset = 0
         while True:
@@ -319,9 +382,13 @@ def migrate_queue(
     batch_size: int = 200,
 ) -> dict[str, int]:
     """Migrate aspect_extraction_queue from SQLite to Postgres via the HTTP service."""
+    live_tumblers: set[str] | None = (
+        _load_live_tumblers(catalog_db_path) if catalog_db_path else None
+    )
     conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     imported = skipped = errors = 0
+    read = 0
     try:
         # Detect column presence (queue schema evolves)
         cols = {r[1] for r in conn.execute(
@@ -381,9 +448,13 @@ def migrate_promotion_log(
     """Migrate aspect_promotion_log from SQLite to Postgres via the HTTP service."""
     import json
 
+    live_tumblers: set[str] | None = (
+        _load_live_tumblers(catalog_db_path) if catalog_db_path else None
+    )
     conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     imported = skipped = errors = 0
+    read = 0
     try:
         # Check if table exists
         exists = conn.execute(

--- a/src/nexus/db/t2/aspects_etl.py
+++ b/src/nexus/db/t2/aspects_etl.py
@@ -327,11 +327,13 @@ def migrate_highlights(
     http_highlights,  # HttpDocumentHighlightsStore instance
     *,
     batch_size: int = 200,
+    collector: Any = None,
 ) -> dict[str, int]:
     """Migrate document_highlights from SQLite to Postgres via the HTTP service."""
     conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     imported = skipped = errors = 0
+    read = 0
     try:
         offset = 0
         while True:
@@ -344,6 +346,7 @@ def migrate_highlights(
                 break
             for row in rows:
                 row_dict = dict(row)
+                read += 1
                 try:
                     body = _transform_highlight(row_dict)
                     n = http_highlights.import_highlight(body)
@@ -358,6 +361,15 @@ def migrate_highlights(
                         doc_id=row_dict.get("doc_id"),
                         error=str(exc),
                     )
+                    if collector is not None:
+                        collector.record(
+                            "aspects", "document_highlights",
+                            issue_class="unexpected",
+                            constraint="document_highlights",
+                            reason=f"row rejected during import: {exc}",
+                            action="failed",
+                            sample_id=str(row_dict.get("doc_id") or f"row#{read}"),
+                        )
             offset += batch_size
     finally:
         conn.close()
@@ -368,6 +380,9 @@ def migrate_highlights(
         skipped=skipped,
         errors=errors,
     )
+    if collector is not None:
+        collector.count_read("aspects", "document_highlights", read)
+        collector.count_written("aspects", "document_highlights", imported)
     return {"imported": imported, "skipped": skipped, "errors": errors}
 
 
@@ -449,6 +464,15 @@ def migrate_queue(
                         source_path=row_dict.get("source_path"),
                         error=str(exc),
                     )
+                    if collector is not None:
+                        collector.record(
+                            "aspects", "aspect_extraction_queue",
+                            issue_class="unexpected",
+                            constraint="aspect_extraction_queue",
+                            reason=f"row rejected during import: {exc}",
+                            action="failed",
+                            sample_id=q_doc_id or f"row#{read}",
+                        )
             offset += batch_size
     finally:
         conn.close()
@@ -470,6 +494,7 @@ def migrate_promotion_log(
     http_aspects,  # HttpDocumentAspectsStore instance (uses /v1/aspects/promotion/import)
     *,
     batch_size: int = 200,
+    collector: Any = None,
 ) -> dict[str, int]:
     """Migrate aspect_promotion_log from SQLite to Postgres via the HTTP service."""
     import json
@@ -519,6 +544,15 @@ def migrate_promotion_log(
                         field_name=row_dict.get("field_name"),
                         error=str(exc),
                     )
+                    if collector is not None:
+                        collector.record(
+                            "aspects", "aspect_promotion_log",
+                            issue_class="unexpected",
+                            constraint="aspect_promotion_log",
+                            reason=f"row rejected during import: {exc}",
+                            action="failed",
+                            sample_id=f"row#{imported + skipped + errors}",
+                        )
             offset += batch_size
     finally:
         conn.close()
@@ -539,6 +573,8 @@ def migrate_all(
     http_queue,
     *,
     batch_size: int = 200,
+    collector: Any = None,
+    catalog_db_path: Path | None = None,
 ) -> dict[str, dict[str, int]]:
     """Run all four table migrations in order.
 
@@ -547,8 +583,20 @@ def migrate_all(
     each containing {imported, skipped, errors}.
     """
     return {
-        "aspects": migrate_aspects(sqlite_path, http_aspects, batch_size=batch_size),
-        "highlights": migrate_highlights(sqlite_path, http_highlights, batch_size=batch_size),
-        "queue": migrate_queue(sqlite_path, http_queue, batch_size=batch_size),
-        "promotion_log": migrate_promotion_log(sqlite_path, http_aspects, batch_size=batch_size),
+        "aspects": migrate_aspects(
+            sqlite_path, http_aspects, batch_size=batch_size,
+            collector=collector, catalog_db_path=catalog_db_path,
+        ),
+        "highlights": migrate_highlights(
+            sqlite_path, http_highlights, batch_size=batch_size,
+            collector=collector,
+        ),
+        "queue": migrate_queue(
+            sqlite_path, http_queue, batch_size=batch_size,
+            collector=collector, catalog_db_path=catalog_db_path,
+        ),
+        "promotion_log": migrate_promotion_log(
+            sqlite_path, http_aspects, batch_size=batch_size,
+            collector=collector,
+        ),
     }

--- a/src/nexus/db/t2/aspects_etl.py
+++ b/src/nexus/db/t2/aspects_etl.py
@@ -329,13 +329,9 @@ def migrate_highlights(
     batch_size: int = 200,
 ) -> dict[str, int]:
     """Migrate document_highlights from SQLite to Postgres via the HTTP service."""
-    live_tumblers: set[str] | None = (
-        _load_live_tumblers(catalog_db_path) if catalog_db_path else None
-    )
     conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     imported = skipped = errors = 0
-    read = 0
     try:
         offset = 0
         while True:
@@ -380,8 +376,15 @@ def migrate_queue(
     http_queue,  # HttpAspectQueue instance
     *,
     batch_size: int = 200,
+    collector: Any = None,
+    catalog_db_path: Path | None = None,
 ) -> dict[str, int]:
-    """Migrate aspect_extraction_queue from SQLite to Postgres via the HTTP service."""
+    """Migrate aspect_extraction_queue from SQLite to Postgres via the HTTP service.
+
+    RDR-153 orphan policy (the audit's 3/7 shape): with *catalog_db_path*,
+    rows whose ``doc_id`` references no live catalog document are
+    SKIP-AND-RECORDED; the valid rows migrate.
+    """
     live_tumblers: set[str] | None = (
         _load_live_tumblers(catalog_db_path) if catalog_db_path else None
     )
@@ -411,6 +414,26 @@ def migrate_queue(
                 break
             for row in rows:
                 row_dict = dict(row)
+                read += 1
+                q_doc_id = str(row_dict.get("doc_id") or "")
+                if (
+                    live_tumblers is not None
+                    and q_doc_id
+                    and q_doc_id not in live_tumblers
+                ):
+                    skipped += 1
+                    if collector is not None:
+                        collector.record(
+                            "aspects", "aspect_extraction_queue",
+                            issue_class="orphan_parent",
+                            constraint="aspect_extraction_queue.doc_id -> "
+                                       "documents.tumbler",
+                            reason="queued doc_id references a deleted/"
+                                   "rebuilt catalog document",
+                            action="skipped",
+                            sample_id=q_doc_id,
+                        )
+                    continue
                 try:
                     body = _transform_queue_row(row_dict)
                     n = http_queue.import_queue_row(body)
@@ -436,6 +459,9 @@ def migrate_queue(
         skipped=skipped,
         errors=errors,
     )
+    if collector is not None:
+        collector.count_read("aspects", "aspect_extraction_queue", read)
+        collector.count_written("aspects", "aspect_extraction_queue", imported)
     return {"imported": imported, "skipped": skipped, "errors": errors}
 
 
@@ -448,13 +474,9 @@ def migrate_promotion_log(
     """Migrate aspect_promotion_log from SQLite to Postgres via the HTTP service."""
     import json
 
-    live_tumblers: set[str] | None = (
-        _load_live_tumblers(catalog_db_path) if catalog_db_path else None
-    )
     conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     imported = skipped = errors = 0
-    read = 0
     try:
         # Check if table exists
         exists = conn.execute(

--- a/src/nexus/db/t2/catalog_etl.py
+++ b/src/nexus/db/t2/catalog_etl.py
@@ -390,6 +390,7 @@ def migrate_catalog(
     client: Any,
     *,
     batch_log_every: int = 50,
+    collector: Any = None,
 ) -> dict[str, dict[str, int]]:
     """Copy all rows from a SQLite catalog into Postgres via *client*.
 
@@ -434,6 +435,27 @@ def migrate_catalog(
         conn.close()
 
     results: dict[str, dict[str, int]] = {}
+
+    # RDR-153 soft-dangler policy: links carry NO enforced endpoint FK —
+    # rows referencing missing documents IMPORT (the graph edge is event
+    # data) and each dangling edge is recorded as a flagged advisory.
+    if collector is not None:
+        live_tumblers = {r.get("tumbler") for r in docs_rows}
+        for r in links_rows:
+            if (
+                r.get("from_tumbler") not in live_tumblers
+                or r.get("to_tumbler") not in live_tumblers
+            ):
+                collector.record(
+                    "catalog", "links",
+                    issue_class="soft_dangler",
+                    constraint="links.(from|to)_tumbler -> documents.tumbler "
+                               "(not enforced)",
+                    reason="link endpoint references a missing document; row "
+                           "imports; sample ids are <from_tumbler>:<to_tumbler>",
+                    action="flagged",
+                    sample_id=f"{r.get('from_tumbler')}:{r.get('to_tumbler')}",
+                )
 
     _log.info(
         "catalog_etl.start",
@@ -553,6 +575,11 @@ def migrate_catalog(
         total_written=total_written,
         by_table={k: v for k, v in results.items()},
     )
+    if collector is not None:
+        for table, counts in results.items():
+            collector.count_read("catalog", table, counts.get("read", 0))
+            collector.count_written("catalog", table, counts.get("written", 0))
+
     return results
 
 

--- a/src/nexus/db/t2/catalog_etl.py
+++ b/src/nexus/db/t2/catalog_etl.py
@@ -475,6 +475,7 @@ def migrate_catalog(
         transform=_transform_owner,
         import_fn=lambda payload: client._post("/import/owner", payload),
         batch_log_every=batch_log_every,
+        collector=collector,
     )
 
     # ── 2. documents (depends on owners) ───────────────────────────────────────
@@ -484,6 +485,7 @@ def migrate_catalog(
         transform=_transform_document,
         import_fn=lambda payload: client._post("/import/document", payload),
         batch_log_every=batch_log_every,
+        collector=collector,
     )
 
     # ── 3. collections (independent of docs, but after owners) ─────────────────
@@ -493,6 +495,7 @@ def migrate_catalog(
         transform=_transform_collection,
         import_fn=lambda payload: client._post("/import/collection", payload),
         batch_log_every=batch_log_every,
+        collector=collector,
     )
 
     # ── 4. document_chunks (depends on documents) ──────────────────────────────
@@ -517,6 +520,18 @@ def migrate_catalog(
                 count=len(doc_chunks),
                 error=str(exc),
             )
+            if collector is not None:
+                # One failed record per chunk in the rejected group —
+                # total_failed is the gate predicate and counts rows.
+                for _ in doc_chunks:
+                    collector.record_event(
+                        "catalog", "document_chunks",
+                        issue_class="unexpected",
+                        constraint="document_chunks(doc_id,position)",
+                        reason=f"chunk group rejected during import "
+                               f"(doc {doc_id}): {exc}",
+                        action="failed",
+                    )
         if chunk_read % (batch_log_every * 5) == 0 and chunk_read > 0:
             _log.info(
                 "catalog_etl.chunks_progress",
@@ -534,6 +549,7 @@ def migrate_catalog(
         transform=_transform_link,
         import_fn=lambda payload: client._post("/import/link", payload),
         batch_log_every=batch_log_every,
+        collector=collector,
     )
 
     # ── 6. _meta — SKIPPED intentionally ──────────────────────────────────────
@@ -590,6 +606,7 @@ def _import_table(
     transform: Any,
     import_fn: Any,
     batch_log_every: int,
+    collector: Any = None,
 ) -> dict[str, int]:
     """Import one table's rows via ``import_fn(payload)``."""
     read_count = 0
@@ -600,18 +617,20 @@ def _import_table(
 
     for row in rows:
         read_count += 1
-        payload = transform(row)
         try:
+            # Transform INSIDE the try (RDR-153 P2 critic): a corrupt row
+            # must become a recorded failed issue, never abort the table.
+            payload = transform(row)
             import_fn(payload)
             written_count += 1
         except Exception as exc:
             # Log the key for the failing row; continue so one bad row
             # doesn't abort the whole table.
             key_hint = (
-                payload.get("tumbler_prefix")
-                or payload.get("tumbler")
-                or payload.get("name")
-                or payload.get("from_tumbler")
+                row.get("tumbler_prefix")
+                or row.get("tumbler")
+                or row.get("name")
+                or row.get("from_tumbler")
                 or f"row-{read_count}"
             )
             _log.error(
@@ -620,6 +639,15 @@ def _import_table(
                 key=key_hint,
                 error=str(exc),
             )
+            if collector is not None:
+                collector.record(
+                    "catalog", table,
+                    issue_class="unexpected",
+                    constraint=table,
+                    reason=f"row rejected during import: {exc}",
+                    action="failed",
+                    sample_id=str(key_hint),
+                )
 
         if read_count % batch_log_every == 0:
             _log.info(

--- a/src/nexus/db/t2/chash_etl.py
+++ b/src/nexus/db/t2/chash_etl.py
@@ -50,6 +50,7 @@ def migrate_chash_rows(
     http_chash: Any,
     *,
     tenant: str = "default",
+    collector: Any = None,
 ) -> dict[str, int]:
     """Copy all ``chash_index`` rows from ``sqlite_path`` to the service via ``http_chash``.
 
@@ -129,4 +130,18 @@ def migrate_chash_rows(
         conn.close()
 
     _log.info("chash_etl_done", total=total, imported=imported, errors=errors)
+    if collector is not None:
+        collector.count_read("chash", "chash_index", total)
+        collector.count_written("chash", "chash_index", imported)
+        # One event per errored row: total_failed is the Phase-4 gate
+        # predicate and must count every failure exactly.
+        for _ in range(errors):
+            collector.record_event(
+                "chash", "chash_index",
+                issue_class="unexpected",
+                constraint="chash_index(chash)",
+                reason="batch import error — see chash_etl logs (batched "
+                       "writes; per-row samples unavailable)",
+                action="failed",
+            )
     return {"total": total, "imported": imported, "errors": errors}

--- a/src/nexus/db/t2/chash_etl.py
+++ b/src/nexus/db/t2/chash_etl.py
@@ -90,6 +90,18 @@ def migrate_chash_rows(
                 created_at = row["created_at"] or "1970-01-01T00:00:00Z"
                 if not chash or not collection:
                     _log.warning("chash_etl_skip_blank", chash=chash, collection=collection)
+                    # RDR-153 catch-all: a blank natural key cannot import —
+                    # record it (failed, gate-visible), never silently skip.
+                    if collector is not None:
+                        collector.record(
+                            "chash", "chash_index",
+                            issue_class="unexpected",
+                            constraint="chash_index(chash)",
+                            reason="blank chash or physical_collection — row "
+                                   "cannot carry its natural key",
+                            action="failed",
+                            sample_id=chash or collection or "blank-row",
+                        )
                     continue
                 payload.append({
                     "chash":      chash,

--- a/src/nexus/db/t2/memory_etl.py
+++ b/src/nexus/db/t2/memory_etl.py
@@ -135,6 +135,7 @@ def migrate_memory_rows(
     store: Any,
     *,
     batch_log_every: int = 100,
+    collector: Any = None,
 ) -> dict[str, int]:
     """Copy all rows from a SQLite memory table into Postgres via *store*.
 
@@ -213,7 +214,18 @@ def migrate_memory_rows(
                 error=str(exc),
             )
             # Continue processing remaining rows so a single failure
-            # doesn't abort the whole migration.
+            # doesn't abort the whole migration. RDR-153 catch-all: the
+            # failure is recorded, never silently dropped.
+            if collector is not None:
+                collector.record(
+                    "memory", "memory",
+                    issue_class="unexpected",
+                    constraint="memory(project,title)",
+                    reason=f"row rejected during import: {exc}; sample ids "
+                           "are <project>:<title>",
+                    action="failed",
+                    sample_id=f"{transformed['project']}:{transformed['title']}",
+                )
 
         if read_count % batch_log_every == 0:
             _log.info(
@@ -229,4 +241,8 @@ def migrate_memory_rows(
         written=written_count,
         total=total,
     )
+    if collector is not None:
+        collector.count_read("memory", "memory", read_count)
+        collector.count_written("memory", "memory", written_count)
+
     return {"read": read_count, "written": written_count}

--- a/src/nexus/db/t2/memory_etl.py
+++ b/src/nexus/db/t2/memory_etl.py
@@ -190,9 +190,11 @@ def migrate_memory_rows(
 
     for row_dict in (dict(r) for r in rows):
         read_count += 1
-        transformed = _transform_row(row_dict)
-
+        # Transform INSIDE the try (RDR-153 P2 review): a corrupt row must
+        # become a recorded failed issue, never abort the loop unrecorded.
+        transformed: dict[str, Any] = {}
         try:
+            transformed = _transform_row(row_dict)
             store.import_entry(
                 project=transformed["project"],
                 title=transformed["title"],
@@ -209,8 +211,8 @@ def migrate_memory_rows(
         except Exception as exc:
             _log.error(
                 "memory_etl.row_failed",
-                project=transformed["project"],
-                title=transformed["title"],
+                project=transformed.get("project", row_dict.get("project", "?")),
+                title=transformed.get("title", row_dict.get("title", "?")),
                 error=str(exc),
             )
             # Continue processing remaining rows so a single failure
@@ -224,7 +226,10 @@ def migrate_memory_rows(
                     reason=f"row rejected during import: {exc}; sample ids "
                            "are <project>:<title>",
                     action="failed",
-                    sample_id=f"{transformed['project']}:{transformed['title']}",
+                    sample_id=(
+                        f"{transformed.get('project', row_dict.get('project', '?'))}"
+                        f":{transformed.get('title', row_dict.get('title', '?'))}"
+                    ),
                 )
 
         if read_count % batch_log_every == 0:

--- a/src/nexus/db/t2/plan_etl.py
+++ b/src/nexus/db/t2/plan_etl.py
@@ -238,9 +238,10 @@ def migrate_plan_rows(
 
     for row_dict in (dict(r) for r in rows):
         read_count += 1
-        transformed = _transform_row(row_dict)
-
+        # Transform INSIDE the try (RDR-153 P2 review): never-silent.
+        transformed: dict[str, Any] = {}
         try:
+            transformed = _transform_row(row_dict)
             store.import_plan(**transformed)
             written_count += 1
         except Exception as exc:

--- a/src/nexus/db/t2/plan_etl.py
+++ b/src/nexus/db/t2/plan_etl.py
@@ -174,6 +174,7 @@ def migrate_plan_rows(
     store: Any,
     *,
     batch_log_every: int = 100,
+    collector: Any = None,
 ) -> dict[str, int]:
     """Copy all rows from a SQLite plans table into Postgres via *store*.
 
@@ -254,7 +255,16 @@ def migrate_plan_rows(
                 error=str(exc),
             )
             # Continue processing remaining rows so a single failure
-            # doesn't abort the whole migration.
+            # doesn't abort the whole migration. RDR-153 catch-all.
+            if collector is not None:
+                collector.record(
+                    "plans", "plans",
+                    issue_class="unexpected",
+                    constraint="plans",
+                    reason=f"row rejected during import: {exc}",
+                    action="failed",
+                    sample_id=str(transformed.get("query", ""))[:60],
+                )
 
         if read_count % batch_log_every == 0:
             _log.info(
@@ -270,4 +280,8 @@ def migrate_plan_rows(
         written=written_count,
         total=total,
     )
+    if collector is not None:
+        collector.count_read("plans", "plans", read_count)
+        collector.count_written("plans", "plans", written_count)
+
     return {"read": read_count, "written": written_count}

--- a/src/nexus/db/t2/taxonomy_etl.py
+++ b/src/nexus/db/t2/taxonomy_etl.py
@@ -348,6 +348,13 @@ def migrate_taxonomy_rows(
     # The strict Postgres FKs would reject these anyway (that is the
     # diagnostic); pre-checking lets us SKIP-AND-RECORD with exact counts
     # and composite-key samples instead of burning a round-trip per orphan.
+    #
+    # Classification note (P2 critique observation): the valid set is the
+    # SOURCE topics, not the migrated ones. If a topic later FAILS to
+    # import, its assignments pass this pre-check, hit the server FK, and
+    # are recorded as unexpected/FAILED by the catch-all — correctly so:
+    # for those rows the problem is the parent's import failure (visible as
+    # its own failed issue), not orphan parentage in the source data.
     # int() is safe: the SQLite schema enforces NOT NULL INTEGER on
     # topics.id / topic_assignments.topic_id / topic_links.(from|to)_topic_id,
     # and the source is opened read-only (no concurrent mutation).

--- a/src/nexus/db/t2/taxonomy_etl.py
+++ b/src/nexus/db/t2/taxonomy_etl.py
@@ -254,6 +254,7 @@ def migrate_taxonomy_rows(
     store: Any,
     *,
     batch_log_every: int = 100,
+    collector: Any = None,
 ) -> dict[str, Any]:
     """Copy all rows from the four SQLite taxonomy tables into Postgres via *store*.
 
@@ -343,6 +344,72 @@ def migrate_taxonomy_rows(
 
     results: dict[str, Any] = {}
 
+    # ── RDR-153 §Decision 2 policy: orphan pre-check ─────────────────────────
+    # The strict Postgres FKs would reject these anyway (that is the
+    # diagnostic); pre-checking lets us SKIP-AND-RECORD with exact counts
+    # and composite-key samples instead of burning a round-trip per orphan.
+    valid_topic_ids = {int(r["id"]) for r in topic_rows if r.get("id") is not None}
+
+    orphan_assignments = [
+        r for r in assign_rows if int(r["topic_id"]) not in valid_topic_ids
+    ]
+    assign_rows = [
+        r for r in assign_rows if int(r["topic_id"]) in valid_topic_ids
+    ]
+    orphan_links = [
+        r for r in link_rows
+        if int(r["from_topic_id"]) not in valid_topic_ids
+        or int(r["to_topic_id"]) not in valid_topic_ids
+    ]
+    link_rows = [
+        r for r in link_rows
+        if int(r["from_topic_id"]) in valid_topic_ids
+        and int(r["to_topic_id"]) in valid_topic_ids
+    ]
+
+    if collector is not None:
+        for r in orphan_assignments:
+            collector.record(
+                "taxonomy", "topic_assignments",
+                issue_class="orphan_parent",
+                constraint="topic_assignments.topic_id -> topics.id",
+                reason="topic_id references a deleted topic; sample ids are "
+                       "<doc_id>:<topic_id>",
+                action="skipped",
+                sample_id=f"{r.get('doc_id')}:{r.get('topic_id')}",
+            )
+        for r in orphan_links:
+            collector.record(
+                "taxonomy", "topic_links",
+                issue_class="orphan_parent",
+                constraint="topic_links.(from|to)_topic_id -> topics.id",
+                reason="from/to topic_id references a deleted topic; sample "
+                       "ids are <from_topic_id>:<to_topic_id>",
+                action="skipped",
+                sample_id=f"{r.get('from_topic_id')}:{r.get('to_topic_id')}",
+            )
+        # The audit's identity_mismatch finding: topic_assignments.doc_id is
+        # a CHASH, not a catalog tumbler — the schema fix was to NOT register
+        # the wrong FK (nexus-sa14p). Recorded once per run (a decision, not
+        # a per-row anomaly), counted in read totals below.
+        if assign_rows or orphan_assignments:
+            collector.record_event(
+                "taxonomy", "topic_assignments",
+                issue_class="identity_mismatch",
+                constraint="topic_assignments.doc_id",
+                reason="doc_id is a chash (opaque identity), not a catalog "
+                       "tumbler — FK deliberately not registered "
+                       "(schema corrected, nexus-sa14p)",
+                action="schema_corrected",
+            )
+    elif orphan_assignments or orphan_links:
+        _log.warning(
+            "taxonomy_etl.orphans_skipped_unrecorded",
+            assignments=len(orphan_assignments),
+            links=len(orphan_links),
+            hint="pass collector= to record these in the migration report",
+        )
+
     # 1. Topics — must go first; assignments/links reference topic.id
     results["topics"] = _migrate_table(
         rows=topic_rows,
@@ -350,15 +417,19 @@ def migrate_taxonomy_rows(
         import_fn=store.import_topic,
         table="topics",
         batch_log_every=batch_log_every,
+        collector=collector,
     )
 
-    # 2. Assignments
+    # 2. Assignments (orphans already skipped-and-recorded above; read
+    #    counts include them so read == source cardinality).
     results["assignments"] = _migrate_table(
         rows=assign_rows,
         transform_fn=_transform_assignment,
         import_fn=store.import_assignment,
         table="topic_assignments",
         batch_log_every=batch_log_every,
+        collector=collector,
+        pre_skipped=len(orphan_assignments),
     )
 
     # 3. Links
@@ -368,6 +439,8 @@ def migrate_taxonomy_rows(
         import_fn=store.import_topic_link,
         table="topic_links",
         batch_log_every=batch_log_every,
+        collector=collector,
+        pre_skipped=len(orphan_links),
     )
 
     # 4. Meta
@@ -377,6 +450,7 @@ def migrate_taxonomy_rows(
         import_fn=store.import_taxonomy_meta,
         table="taxonomy_meta",
         batch_log_every=batch_log_every,
+        collector=collector,
     )
 
     _log.info(
@@ -401,6 +475,8 @@ def _migrate_table(
     import_fn: Any,
     table: str,
     batch_log_every: int,
+    collector: Any = None,
+    pre_skipped: int = 0,
 ) -> dict[str, int]:
     """Generic per-table migration loop. Returns ``{"read": N, "written": M, "skipped": K}``.
 
@@ -442,7 +518,16 @@ def _migrate_table(
                 error=str(exc),
             )
             # Continue processing remaining rows — a single failure does not
-            # abort the migration.
+            # abort the migration. RDR-153 catch-all: never a silent drop.
+            if collector is not None:
+                collector.record(
+                    "taxonomy", table,
+                    issue_class="unexpected",
+                    constraint=table,
+                    reason=f"row rejected during import: {exc}",
+                    action="failed",
+                    sample_id=f"{table}#{read_count}",
+                )
 
         if read_count % batch_log_every == 0:
             _log.info(
@@ -465,5 +550,10 @@ def _migrate_table(
             skipped_doc_ids_sample=skipped_ids,
             skipped_ids_truncated=skipped_count > len(skipped_ids),
         )
+
+    if collector is not None:
+        # read includes pre-skipped orphans so read == source cardinality.
+        collector.count_read("taxonomy", table, read_count + pre_skipped)
+        collector.count_written("taxonomy", table, written_count)
 
     return {"read": read_count, "written": written_count, "skipped": skipped_count}

--- a/src/nexus/db/t2/taxonomy_etl.py
+++ b/src/nexus/db/t2/taxonomy_etl.py
@@ -348,6 +348,9 @@ def migrate_taxonomy_rows(
     # The strict Postgres FKs would reject these anyway (that is the
     # diagnostic); pre-checking lets us SKIP-AND-RECORD with exact counts
     # and composite-key samples instead of burning a round-trip per orphan.
+    # int() is safe: the SQLite schema enforces NOT NULL INTEGER on
+    # topics.id / topic_assignments.topic_id / topic_links.(from|to)_topic_id,
+    # and the source is opened read-only (no concurrent mutation).
     valid_topic_ids = {int(r["id"]) for r in topic_rows if r.get("id") is not None}
 
     orphan_assignments = [

--- a/src/nexus/db/t2/telemetry_etl.py
+++ b/src/nexus/db/t2/telemetry_etl.py
@@ -210,16 +210,24 @@ def _migrate_all(
 ) -> dict[str, Any]:
     results: dict[str, Any] = {}
 
-    results["relevance_log"]    = _migrate_relevance_log(conn, store, batch_log_every)
-    results["search_telemetry"] = _migrate_search_telemetry(conn, store, batch_log_every)
-    results["tier_writes"]      = _migrate_tier_writes(conn, store, batch_log_every)
+    results["relevance_log"]    = _migrate_relevance_log(
+        conn, store, batch_log_every, collector=collector,
+    )
+    results["search_telemetry"] = _migrate_search_telemetry(
+        conn, store, batch_log_every, collector=collector,
+    )
+    results["tier_writes"]      = _migrate_tier_writes(
+        conn, store, batch_log_every, collector=collector,
+    )
     results["nx_answer_runs"]   = _migrate_nx_answer_runs(
         conn, store, batch_log_every, collector=collector,
     )
     results["hook_failures"]    = _migrate_hook_failures(
         conn, store, batch_log_every, collector=collector,
     )
-    results["frecency"]         = _migrate_frecency(conn, store, batch_log_every)
+    results["frecency"]         = _migrate_frecency(
+        conn, store, batch_log_every, collector=collector,
+    )
 
     if collector is not None:
         for table, counts in results.items():
@@ -239,6 +247,7 @@ def _migrate_all(
 
 def _migrate_relevance_log(
     conn: sqlite3.Connection, store: Any, batch_log_every: int,
+    collector: Any = None,
 ) -> dict[str, int]:
     _, rows = _fetch(conn, "relevance_log", _RELEVANCE_LOG_COLS)
     read_n = written_n = 0
@@ -263,6 +272,15 @@ def _migrate_relevance_log(
                 query_prefix=str(row.get("query", ""))[:40],
                 error=str(exc),
             )
+            if collector is not None:
+                collector.record(
+                    "telemetry", "relevance_log",
+                    issue_class="unexpected",
+                    constraint="relevance_log",
+                    reason=f"row rejected during import: {exc}",
+                    action="failed",
+                    sample_id=f"relevance_log#{read_n}",
+                )
         if read_n % batch_log_every == 0:
             _log.info("telemetry_etl.relevance_log.progress",
                       read=read_n, written=written_n, total=total)
@@ -272,6 +290,7 @@ def _migrate_relevance_log(
 
 def _migrate_search_telemetry(
     conn: sqlite3.Connection, store: Any, batch_log_every: int,
+    collector: Any = None,
 ) -> dict[str, int]:
     _, rows = _fetch(conn, "search_telemetry", _SEARCH_TELEMETRY_COLS)
     read_n = written_n = 0
@@ -297,6 +316,15 @@ def _migrate_search_telemetry(
                 ts=str(row.get("ts", ""))[:30],
                 error=str(exc),
             )
+            if collector is not None:
+                collector.record(
+                    "telemetry", "search_telemetry",
+                    issue_class="unexpected",
+                    constraint="search_telemetry",
+                    reason=f"row rejected during import: {exc}",
+                    action="failed",
+                    sample_id=f"search_telemetry#{read_n}",
+                )
         if read_n % batch_log_every == 0:
             _log.info("telemetry_etl.search_telemetry.progress",
                       read=read_n, written=written_n, total=total)
@@ -306,6 +334,7 @@ def _migrate_search_telemetry(
 
 def _migrate_tier_writes(
     conn: sqlite3.Connection, store: Any, batch_log_every: int,
+    collector: Any = None,
 ) -> dict[str, int]:
     _, rows = _fetch(conn, "tier_writes", _TIER_WRITES_COLS)
     read_n = written_n = 0
@@ -334,6 +363,15 @@ def _migrate_tier_writes(
                 ts=str(row.get("ts", ""))[:30],
                 error=str(exc),
             )
+            if collector is not None:
+                collector.record(
+                    "telemetry", "tier_writes",
+                    issue_class="unexpected",
+                    constraint="tier_writes",
+                    reason=f"row rejected during import: {exc}",
+                    action="failed",
+                    sample_id=f"tier_writes#{read_n}",
+                )
         if read_n % batch_log_every == 0:
             _log.info("telemetry_etl.tier_writes.progress",
                       read=read_n, written=written_n, total=total)
@@ -396,6 +434,15 @@ def _migrate_nx_answer_runs(
                 question_prefix=str(row.get("question", ""))[:40],
                 error=str(exc),
             )
+            if collector is not None:
+                collector.record(
+                    "telemetry", "nx_answer_runs",
+                    issue_class="unexpected",
+                    constraint="nx_answer_runs",
+                    reason=f"row rejected during import: {exc}",
+                    action="failed",
+                    sample_id=f"nx_answer_runs#{read_n}",
+                )
         if read_n % batch_log_every == 0:
             _log.info("telemetry_etl.nx_answer_runs.progress",
                       read=read_n, written=written_n, total=total)
@@ -415,6 +462,11 @@ def _normalize_timestamp(raw: str) -> tuple[str, bool]:
     from datetime import datetime as _dt
 
     canonical = _dt.fromisoformat(raw).isoformat()
+    # NOTE: any non-canonical-but-parseable form counts as normalized —
+    # e.g. a 'Z' suffix becomes '+00:00', a bare date gains T00:00:00.
+    # Production data had only the space form (234/234 hook_failures);
+    # benign variants inflating 'handled' is acceptable and honest (the
+    # stored value DID change).
     return canonical, canonical != raw
 
 
@@ -475,6 +527,15 @@ def _migrate_hook_failures(
                 hook_name=str(row.get("hook_name", "")),
                 error=str(exc),
             )
+            if collector is not None:
+                collector.record(
+                    "telemetry", "hook_failures",
+                    issue_class="unexpected",
+                    constraint="hook_failures",
+                    reason=f"row rejected during import: {exc}",
+                    action="failed",
+                    sample_id=str(row.get("id", read_n)),
+                )
         if read_n % batch_log_every == 0:
             _log.info("telemetry_etl.hook_failures.progress",
                       read=read_n, written=written_n, total=total)
@@ -484,6 +545,7 @@ def _migrate_hook_failures(
 
 def _migrate_frecency(
     conn: sqlite3.Connection, store: Any, batch_log_every: int,
+    collector: Any = None,
 ) -> dict[str, int]:
     _, rows = _fetch(conn, "frecency", _FRECENCY_COLS)
     read_n = written_n = 0
@@ -508,6 +570,15 @@ def _migrate_frecency(
                 chunk_id=str(row.get("chunk_id", ""))[:32],
                 error=str(exc),
             )
+            if collector is not None:
+                collector.record(
+                    "telemetry", "frecency",
+                    issue_class="unexpected",
+                    constraint="frecency",
+                    reason=f"row rejected during import: {exc}",
+                    action="failed",
+                    sample_id=f"frecency#{read_n}",
+                )
         if read_n % batch_log_every == 0:
             _log.info("telemetry_etl.frecency.progress",
                       read=read_n, written=written_n, total=total)

--- a/src/nexus/db/t2/telemetry_etl.py
+++ b/src/nexus/db/t2/telemetry_etl.py
@@ -174,6 +174,7 @@ def migrate_telemetry_rows(
     store: Any,
     *,
     batch_log_every: int = 100,
+    collector: Any = None,
 ) -> dict[str, Any]:
     """Copy all telemetry rows from SQLite into Postgres via *store*.
 
@@ -193,7 +194,9 @@ def migrate_telemetry_rows(
     """
     conn = _open_ro(source_db_path)
     try:
-        return _migrate_all(conn, store, batch_log_every=batch_log_every)
+        return _migrate_all(
+            conn, store, batch_log_every=batch_log_every, collector=collector,
+        )
     finally:
         conn.close()
 
@@ -203,15 +206,25 @@ def _migrate_all(
     store: Any,
     *,
     batch_log_every: int,
+    collector: Any = None,
 ) -> dict[str, Any]:
     results: dict[str, Any] = {}
 
     results["relevance_log"]    = _migrate_relevance_log(conn, store, batch_log_every)
     results["search_telemetry"] = _migrate_search_telemetry(conn, store, batch_log_every)
     results["tier_writes"]      = _migrate_tier_writes(conn, store, batch_log_every)
-    results["nx_answer_runs"]   = _migrate_nx_answer_runs(conn, store, batch_log_every)
-    results["hook_failures"]    = _migrate_hook_failures(conn, store, batch_log_every)
+    results["nx_answer_runs"]   = _migrate_nx_answer_runs(
+        conn, store, batch_log_every, collector=collector,
+    )
+    results["hook_failures"]    = _migrate_hook_failures(
+        conn, store, batch_log_every, collector=collector,
+    )
     results["frecency"]         = _migrate_frecency(conn, store, batch_log_every)
+
+    if collector is not None:
+        for table, counts in results.items():
+            collector.count_read("telemetry", table, counts["read"])
+            collector.count_written("telemetry", table, counts["written"])
 
     total_read    = sum(v["read"]    for v in results.values())
     total_written = sum(v["written"] for v in results.values())
@@ -330,14 +343,41 @@ def _migrate_tier_writes(
 
 def _migrate_nx_answer_runs(
     conn: sqlite3.Connection, store: Any, batch_log_every: int,
+    collector: Any = None,
 ) -> dict[str, int]:
     _, rows = _fetch(conn, "nx_answer_runs", _NX_ANSWER_RUNS_COLS)
     read_n = written_n = 0
     total = len(rows)
     _log.info("telemetry_etl.nx_answer_runs.start", total=total)
 
+    # RDR-153 soft-dangler policy: plan_id has NO enforced FK — rows with a
+    # deleted plan IMPORT (preserving event history) and an advisory records
+    # the dangling reference. Valid plan ids come from the same source db.
+    valid_plan_ids: set[int] = set()
+    try:
+        valid_plan_ids = {
+            int(r[0]) for r in conn.execute("SELECT id FROM plans").fetchall()
+        }
+    except sqlite3.OperationalError:
+        pass  # no plans table in source — every plan_id is then a dangler
+
     for row in rows:
         read_n += 1
+        plan_id = _nullable_int(row.get("plan_id"))
+        if (
+            collector is not None
+            and plan_id is not None
+            and plan_id not in valid_plan_ids
+        ):
+            collector.record(
+                "telemetry", "nx_answer_runs",
+                issue_class="soft_dangler",
+                constraint="nx_answer_runs.plan_id -> plans.id (not enforced)",
+                reason="plan deleted; row imports with dangling reference; "
+                       "sample ids are <run_id>:<plan_id>",
+                action="flagged",
+                sample_id=f"{row.get('id')}:{plan_id}",
+            )
         try:
             store.import_nx_answer_run(
                 question=row.get("question", ""),
@@ -363,8 +403,24 @@ def _migrate_nx_answer_runs(
     return {"read": read_n, "written": written_n}
 
 
+def _normalize_timestamp(raw: str) -> tuple[str, bool]:
+    """RDR-153 format-anomaly policy: parse lenient, emit canonical ISO-8601.
+
+    Returns ``(canonical, was_normalized)``. The production anomaly is the
+    space-form ``2026-04-23 10:47:54`` (234/234 hook_failures rows);
+    ``datetime.fromisoformat`` accepts it and re-emits the ``T`` form.
+    Raises ``ValueError`` for unparseable input — the caller records a
+    ``failed`` issue (fail only if unparseable, never silently drop).
+    """
+    from datetime import datetime as _dt
+
+    canonical = _dt.fromisoformat(raw).isoformat()
+    return canonical, canonical != raw
+
+
 def _migrate_hook_failures(
     conn: sqlite3.Connection, store: Any, batch_log_every: int,
+    collector: Any = None,
 ) -> dict[str, int]:
     _, rows = _fetch(conn, "hook_failures", _HOOK_FAILURES_COLS)
     read_n = written_n = 0
@@ -373,13 +429,41 @@ def _migrate_hook_failures(
 
     for row in rows:
         read_n += 1
+        raw_ts = row.get("occurred_at", "")
+        try:
+            occurred_at, normalized = _normalize_timestamp(raw_ts)
+        except ValueError:
+            _log.error(
+                "telemetry_etl.hook_failures.unparseable_timestamp",
+                occurred_at=raw_ts[:40],
+            )
+            if collector is not None:
+                collector.record(
+                    "telemetry", "hook_failures",
+                    issue_class="format_anomaly",
+                    constraint="hook_failures.occurred_at",
+                    reason=f"unparseable timestamp (not ISO-8601-coercible): "
+                           f"{raw_ts[:40]!r}",
+                    action="failed",
+                    sample_id=str(row.get("id", read_n)),
+                )
+            continue
+        if normalized and collector is not None:
+            collector.record(
+                "telemetry", "hook_failures",
+                issue_class="format_anomaly",
+                constraint="hook_failures.occurred_at",
+                reason="space-form timestamp normalized to ISO-8601 T form",
+                action="handled",
+                sample_id=str(row.get("id", read_n)),
+            )
         try:
             store.import_hook_failure(
                 doc_id=_str_or_empty(row.get("doc_id")),
                 collection=_str_or_empty(row.get("collection")),
                 hook_name=row.get("hook_name", ""),
                 error=_str_or_empty(row.get("error")),
-                occurred_at=row.get("occurred_at", ""),
+                occurred_at=occurred_at,
                 batch_doc_ids=_nullable_str(row.get("batch_doc_ids")),
                 is_batch=bool(row.get("is_batch", False)),
                 chain=_nullable_str(row.get("chain")),

--- a/src/nexus/db/t2/telemetry_etl.py
+++ b/src/nexus/db/t2/telemetry_etl.py
@@ -451,22 +451,32 @@ def _migrate_nx_answer_runs(
 
 
 def _normalize_timestamp(raw: str) -> tuple[str, bool]:
-    """RDR-153 format-anomaly policy: parse lenient, emit canonical ISO-8601.
+    """RDR-153 format-anomaly policy: parse lenient, emit canonical
+    OFFSET-QUALIFIED ISO-8601.
 
     Returns ``(canonical, was_normalized)``. The production anomaly is the
-    space-form ``2026-04-23 10:47:54`` (234/234 hook_failures rows);
-    ``datetime.fromisoformat`` accepts it and re-emits the ``T`` form.
+    space-form NAIVE ``2026-04-23 10:47:54`` (234/234 hook_failures rows).
+    The Java import path (``TelemetryRepository.parseTsStrict``) uses
+    ``OffsetDateTime.parse`` which REQUIRES an offset — this is the actual
+    root cause of nexus-9sjn3 (hook_failures imported 0/234): the rows fail
+    twice over, space separator AND missing offset. Naive timestamps are
+    treated as UTC (SQLite ``CURRENT_TIMESTAMP``/``datetime('now')`` is
+    UTC), so canonical form is ``...T...+00:00``.
+
     Raises ``ValueError`` for unparseable input — the caller records a
     ``failed`` issue (fail only if unparseable, never silently drop).
-    """
-    from datetime import datetime as _dt
 
-    canonical = _dt.fromisoformat(raw).isoformat()
-    # NOTE: any non-canonical-but-parseable form counts as normalized —
-    # e.g. a 'Z' suffix becomes '+00:00', a bare date gains T00:00:00.
-    # Production data had only the space form (234/234 hook_failures);
-    # benign variants inflating 'handled' is acceptable and honest (the
-    # stored value DID change).
+    NOTE: any non-canonical-but-parseable form counts as normalized —
+    a 'Z' suffix becomes '+00:00', a naive T-form gains '+00:00'. Benign
+    variants inflating 'handled' is acceptable and honest (the stored
+    value DID change).
+    """
+    from datetime import UTC as _UTC, datetime as _dt
+
+    parsed = _dt.fromisoformat(raw)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=_UTC)
+    canonical = parsed.isoformat()
     return canonical, canonical != raw
 
 

--- a/src/nexus/migration/etl_registry.py
+++ b/src/nexus/migration/etl_registry.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-153 Phase 2→3 seam: the uniform interface over the seven T2 ETLs.
+
+The per-store ``migrate_*`` entry points have heterogeneous signatures
+(``memory_etl.migrate_memory_rows(path, store, ...)``,
+``aspects_etl.migrate_all(path, http_aspects, http_highlights, http_queue,
+..., catalog_db_path=...)``, ``catalog_etl.migrate_catalog(path, client,
+...)``). The Phase-3 orchestrator (``nx storage migrate all``) must run
+them in the RDR-152 Phase 2 ladder order with one shared
+:class:`~nexus.migration.migration_report.IssueCollector` — this module
+is the single place that order and that adapter contract live, so the
+seven calls are reviewable side by side (P2 critique S5).
+
+Phase 3 registers one :class:`StoreEtl` per store; the ``run`` callable
+closes over whatever HTTP store/client construction that store needs and
+accepts exactly ``(sources, collector)``.
+
+This module lives in ``src/nexus/migration/`` (NOT ``src/nexus/db/t2/``)
+because the RDR-152 P4 deletion of the SQLite subtree takes the ETLs with
+it while the report tooling survives; at P4 the registry entries are
+deleted alongside their ETLs and this module keeps only the order
+constant for the historical record.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+__all__ = ["LADDER_ORDER", "EtlSources", "StoreEtl", "MigrateRunner"]
+
+#: RDR-152 Phase 2 ladder order — memory first (smallest, fastest
+#: validation), catalog LAST (graph-heavy; every other store's FK targets
+#: must exist before its links land). The Phase-3 orchestrator MUST run
+#: stores in exactly this order.
+LADDER_ORDER: tuple[str, ...] = (
+    "memory",
+    "plans",
+    "telemetry",
+    "taxonomy",
+    "aspects",
+    "chash",
+    "catalog",
+)
+
+
+@dataclass(frozen=True)
+class EtlSources:
+    """The read-only source paths every ETL draws from.
+
+    ``sqlite_path`` is the T2 ``memory.db``; ``catalog_db_path`` is the
+    sibling ``.catalog.db`` (the valid-tumbler source for the aspects/queue
+    orphan pre-checks AND the catalog ETL's own source).
+    """
+
+    sqlite_path: Path
+    catalog_db_path: Path
+
+
+class MigrateRunner(Protocol):
+    """One store's migration: read from *sources*, record into *collector*.
+
+    Returns the store's native result dict (shape varies per store; the
+    REPORT is built from the collector, not from this return value).
+    """
+
+    def __call__(self, sources: EtlSources, collector: Any) -> dict: ...
+
+
+@dataclass(frozen=True)
+class StoreEtl:
+    """Registry entry: a store name (must appear in :data:`LADDER_ORDER`)
+    plus its runner."""
+
+    store: str
+    run: MigrateRunner
+
+    def __post_init__(self) -> None:
+        if self.store not in LADDER_ORDER:
+            raise ValueError(
+                f"unknown store {self.store!r} — not in LADDER_ORDER "
+                f"{LADDER_ORDER}"
+            )
+
+
+def ordered(etls: list[StoreEtl]) -> list[StoreEtl]:
+    """Sort registry entries into ladder order; reject duplicates."""
+    by_store: dict[str, StoreEtl] = {}
+    for etl in etls:
+        if etl.store in by_store:
+            raise ValueError(f"duplicate StoreEtl for {etl.store!r}")
+        by_store[etl.store] = etl
+    return [by_store[s] for s in LADDER_ORDER if s in by_store]

--- a/src/nexus/migration/migration_report.py
+++ b/src/nexus/migration/migration_report.py
@@ -38,6 +38,7 @@ __all__ = [
     "MigrationIssue",
     "IssueCollector",
     "build_report",
+    "load_report",
 ]
 
 #: What is WRONG with the row (diagnosis).
@@ -322,3 +323,19 @@ def build_report(
         max_severity=max_severity,
     )
     return report
+
+
+def load_report(path: "Path | str") -> dict[str, Any]:
+    """Load a migration-report artifact (the ``migration-report show``
+    reader — Phase-4's gate input).
+
+    Raises ``FileNotFoundError`` / ``json.JSONDecodeError`` loud — a gate
+    that cannot read its input must never default to a pass.
+    """
+    import json
+    from pathlib import Path as _Path
+
+    data = json.loads(_Path(path).read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: migration report must be a JSON object")
+    return data

--- a/src/nexus/migration/migration_report.py
+++ b/src/nexus/migration/migration_report.py
@@ -147,6 +147,11 @@ class IssueCollector:
         self._issues: dict[tuple[str, str], dict[tuple[str, str, str], MigrationIssue]] = {}
         # (store, table) -> {"read": int, "written": int}
         self._counts: dict[tuple[str, str], dict[str, int]] = {}
+        #: Construction time = ETL start. build_report uses this as the
+        #: report's started_at so no caller has to remember to capture it
+        #: (a forgotten started_at would silently equal completed_at and
+        #: erase the run duration from the audit artifact).
+        self.started_at: str = datetime.now(UTC).isoformat()
 
     # ── Recording ────────────────────────────────────────────────────────────
 
@@ -161,7 +166,15 @@ class IssueCollector:
         action: str,
         sample_id: str,
     ) -> None:
-        """Record one offending row into its (class, constraint, action) bucket."""
+        """Record one offending row into its (class, constraint, action) bucket.
+
+        ``reason`` is taken from the FIRST call for each bucket; subsequent
+        reasons are not recorded (rows sharing a bucket share a diagnosis —
+        51,286 orphans carry one reason, not 51,286).
+
+        Not thread-safe: all ``record()``/``count_*()`` calls must come from
+        a single thread (the ETLs run sequentially by design).
+        """
         bucket = self._issues.setdefault((store, table), {})
         key = (issue_class, constraint, action)
         issue = bucket.get(key)
@@ -176,6 +189,33 @@ class IssueCollector:
             )
             bucket[key] = issue
         issue.add_sample(sample_id)
+
+    def record_event(
+        self,
+        store: str,
+        table: str,
+        *,
+        issue_class: str,
+        constraint: str,
+        reason: str,
+        action: str,
+    ) -> None:
+        """Record a ONE-TIME event with no natural row sample (e.g. a
+        ``schema_corrected`` decision). ``count`` increments per call;
+        ``sample_ids`` stays empty — synthesizing a fake row id for a
+        non-row event would be semantically wrong (critic P1.4 finding)."""
+        bucket = self._issues.setdefault((store, table), {})
+        key = (issue_class, constraint, action)
+        issue = bucket.get(key)
+        if issue is None:
+            issue = MigrationIssue(
+                issue_class=issue_class,
+                constraint=constraint,
+                reason=reason,
+                action=action,
+            )
+            bucket[key] = issue
+        issue.count += 1
 
     def count_read(self, store: str, table: str, n: int) -> None:
         self._table(store, table)["read"] += n
@@ -222,7 +262,12 @@ def build_report(
     """
     now = datetime.now(UTC).isoformat()
     stores_out: list[dict[str, Any]] = []
-    by_action: dict[str, int] = {a: 0 for a in sorted(ISSUE_ACTIONS)}
+    # Severity-descending key order, matching the RDR schema example
+    # (JSON objects are unordered by spec; this is for human readers).
+    by_action: dict[str, int] = {
+        a: 0
+        for a in sorted(ISSUE_ACTIONS, key=lambda a: ACTION_SEVERITY[a], reverse=True)
+    }
     totals = {"read": 0, "written": 0, "skipped": 0, "flagged": 0, "failed": 0}
     max_severity = 0
 
@@ -255,7 +300,7 @@ def build_report(
     report = {
         "schema_version": "1",
         "migration_id": migration_id or str(uuid.uuid4()),
-        "started_at": started_at or now,
+        "started_at": started_at or collector.started_at,
         "completed_at": now,
         "source": dict(source),
         "target": dict(target),

--- a/src/nexus/migration/migration_report.py
+++ b/src/nexus/migration/migration_report.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-153: structured issue reporting for the SQLite→Postgres T2 migration.
+
+The migration runs with strict foreign keys DELIBERATELY — the constraints
+are the diagnostic. This module is the shared issue-record primitive every
+``migrate_*`` ETL writes to (replacing ad-hoc per-row error logging) and
+the serializer for the one structured ``migration-report.json`` each run
+emits — the triage / recovery / learning artifact and the Phase-4 gate
+input (``summary.total_failed == 0``).
+
+Lives in ``src/nexus/migration/`` and NOT under ``src/nexus/db/t2/``:
+RDR-152 Phase 4 deletes that subtree, but this primitive and the
+``migration-report show`` reader must survive the SQLite decommission
+(the Phase-4 gate itself reads a report).
+
+Contract (docs/rdr/rdr-153-migration-data-quality-policy.md): two distinct
+enums, never mixed — each issue has a ``class`` (what is wrong) and an
+``action`` (what the ETL did). ``summary.by_action`` aggregates by the
+five ACTION values; that is the gate-facing rollup.
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+__all__ = [
+    "ISSUE_CLASSES",
+    "ISSUE_ACTIONS",
+    "ACTION_SEVERITY",
+    "SAMPLE_IDS_CAP",
+    "MigrationIssue",
+    "IssueCollector",
+    "build_report",
+]
+
+#: What is WRONG with the row (diagnosis).
+ISSUE_CLASSES: frozenset[str] = frozenset({
+    "orphan_parent",
+    "identity_mismatch",
+    "format_anomaly",
+    "soft_dangler",
+    "unexpected",
+})
+
+#: What the ETL DID about it (policy outcome).
+ISSUE_ACTIONS: frozenset[str] = frozenset({
+    "skipped",
+    "handled",
+    "flagged",
+    "schema_corrected",
+    "failed",
+})
+
+#: Severity is a function of ACTION (the policy outcome ranks the run, not
+#: the diagnosis). Exact ordinals locked by the P1.1 suite:
+#: failed=4 (gate-blocking), skipped=3 (data not migrated),
+#: flagged=2 (imported with advisory), handled=1 (normalized),
+#: schema_corrected=0 (schema fixed; data correct).
+ACTION_SEVERITY: dict[str, int] = {
+    "failed": 4,
+    "skipped": 3,
+    "flagged": 2,
+    "handled": 1,
+    "schema_corrected": 0,
+}
+
+#: sample_ids cap per issue; the full set is reproducible by re-running.
+SAMPLE_IDS_CAP: int = 200
+
+
+@dataclass
+class MigrationIssue:
+    """One issue line: a (class, constraint, action) bucket with counts.
+
+    ``issue_class`` (not ``class`` — Python keyword) ∈ :data:`ISSUE_CLASSES`;
+    ``action`` ∈ :data:`ISSUE_ACTIONS`; ``severity`` derives from the action
+    via :data:`ACTION_SEVERITY` and is not caller-settable.
+
+    Composite-key ``sample_ids`` are the key tuple joined with ``:`` (e.g.
+    ``topic_assignments`` → ``"<doc_id>:<topic_id>"``); record the
+    convention per table in ``reason``.
+    """
+
+    issue_class: str
+    constraint: str
+    reason: str
+    action: str
+    count: int = 0
+    sample_ids: list[str] = field(default_factory=list)
+    sample_truncated: bool = False
+
+    def __post_init__(self) -> None:
+        if self.issue_class not in ISSUE_CLASSES:
+            raise ValueError(
+                f"unknown issue class {self.issue_class!r} — "
+                f"must be one of {sorted(ISSUE_CLASSES)}"
+            )
+        if self.action not in ISSUE_ACTIONS:
+            raise ValueError(
+                f"unknown issue action {self.action!r} — "
+                f"must be one of {sorted(ISSUE_ACTIONS)}"
+            )
+
+    @property
+    def severity(self) -> int:
+        return ACTION_SEVERITY[self.action]
+
+    def add_sample(self, sample_id: str) -> None:
+        """Count one more occurrence; keep at most :data:`SAMPLE_IDS_CAP` ids."""
+        self.count += 1
+        if len(self.sample_ids) < SAMPLE_IDS_CAP:
+            self.sample_ids.append(sample_id)
+        else:
+            self.sample_truncated = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "class": self.issue_class,
+            "constraint": self.constraint,
+            "reason": self.reason,
+            "action": self.action,
+            "severity": self.severity,
+            "count": self.count,
+            "sample_ids": list(self.sample_ids),
+            "sample_truncated": self.sample_truncated,
+        }
+
+
+class IssueCollector:
+    """In-run accumulator every ETL writes to.
+
+    Issues bucket per ``(store, table)`` on the ``(class, constraint,
+    action)`` identity — recording the same anomaly for many rows grows
+    one issue's count instead of emitting thousands of lines. Read/written
+    row counts are tracked per table alongside.
+    """
+
+    def __init__(self) -> None:
+        # (store, table) -> (issue_class, constraint, action) -> MigrationIssue
+        self._issues: dict[tuple[str, str], dict[tuple[str, str, str], MigrationIssue]] = {}
+        # (store, table) -> {"read": int, "written": int}
+        self._counts: dict[tuple[str, str], dict[str, int]] = {}
+
+    # ── Recording ────────────────────────────────────────────────────────────
+
+    def record(
+        self,
+        store: str,
+        table: str,
+        *,
+        issue_class: str,
+        constraint: str,
+        reason: str,
+        action: str,
+        sample_id: str,
+    ) -> None:
+        """Record one offending row into its (class, constraint, action) bucket."""
+        bucket = self._issues.setdefault((store, table), {})
+        key = (issue_class, constraint, action)
+        issue = bucket.get(key)
+        if issue is None:
+            # Validation happens in MigrationIssue.__post_init__ — fail loud
+            # at the first record, not at serialization time.
+            issue = MigrationIssue(
+                issue_class=issue_class,
+                constraint=constraint,
+                reason=reason,
+                action=action,
+            )
+            bucket[key] = issue
+        issue.add_sample(sample_id)
+
+    def count_read(self, store: str, table: str, n: int) -> None:
+        self._table(store, table)["read"] += n
+
+    def count_written(self, store: str, table: str, n: int) -> None:
+        self._table(store, table)["written"] += n
+
+    # ── Reading ──────────────────────────────────────────────────────────────
+
+    def issues_for(self, store: str, table: str) -> list[MigrationIssue]:
+        return list(self._issues.get((store, table), {}).values())
+
+    def table_counts(self, store: str, table: str) -> dict[str, int]:
+        return dict(self._table(store, table))
+
+    def store_names(self) -> list[str]:
+        names = {s for s, _ in self._issues} | {s for s, _ in self._counts}
+        return sorted(names)
+
+    def tables_for(self, store: str) -> list[str]:
+        tables = {t for s, t in self._issues if s == store}
+        tables |= {t for s, t in self._counts if s == store}
+        return sorted(tables)
+
+    # ── Internals ────────────────────────────────────────────────────────────
+
+    def _table(self, store: str, table: str) -> dict[str, int]:
+        return self._counts.setdefault((store, table), {"read": 0, "written": 0})
+
+
+def build_report(
+    collector: IssueCollector,
+    *,
+    source: dict[str, str],
+    target: dict[str, str],
+    migration_id: str | None = None,
+    started_at: str | None = None,
+) -> dict[str, Any]:
+    """Serialize one migration run into the schema_version=1 report dict.
+
+    Self-describing and stable (``schema_version``) so downstream triage
+    tooling evolves independently; JSON-round-trip safe (plain dict/list/
+    str/int/bool values only).
+    """
+    now = datetime.now(UTC).isoformat()
+    stores_out: list[dict[str, Any]] = []
+    by_action: dict[str, int] = {a: 0 for a in sorted(ISSUE_ACTIONS)}
+    totals = {"read": 0, "written": 0, "skipped": 0, "flagged": 0, "failed": 0}
+    max_severity = 0
+
+    for store in collector.store_names():
+        tables_out: list[dict[str, Any]] = []
+        for table in collector.tables_for(store):
+            counts = collector.table_counts(store, table)
+            issues = collector.issues_for(store, table)
+            per_action = {a: 0 for a in ISSUE_ACTIONS}
+            for issue in issues:
+                per_action[issue.action] += issue.count
+                by_action[issue.action] += issue.count
+                max_severity = max(max_severity, issue.severity)
+            tables_out.append({
+                "table": table,
+                "read": counts["read"],
+                "written": counts["written"],
+                "skipped": per_action["skipped"],
+                "flagged": per_action["flagged"],
+                "failed": per_action["failed"],
+                "issues": [i.to_dict() for i in issues],
+            })
+            totals["read"] += counts["read"]
+            totals["written"] += counts["written"]
+            totals["skipped"] += per_action["skipped"]
+            totals["flagged"] += per_action["flagged"]
+            totals["failed"] += per_action["failed"]
+        stores_out.append({"store": store, "tables": tables_out})
+
+    report = {
+        "schema_version": "1",
+        "migration_id": migration_id or str(uuid.uuid4()),
+        "started_at": started_at or now,
+        "completed_at": now,
+        "source": dict(source),
+        "target": dict(target),
+        "stores": stores_out,
+        "summary": {
+            "total_read": totals["read"],
+            "total_written": totals["written"],
+            "total_skipped": totals["skipped"],
+            "total_flagged": totals["flagged"],
+            "total_failed": totals["failed"],
+            "max_severity": max_severity,
+            "by_action": by_action,
+        },
+    }
+    _log.info(
+        "migration_report_built",
+        migration_id=report["migration_id"],
+        total_failed=totals["failed"],
+        max_severity=max_severity,
+    )
+    return report

--- a/tests/db/test_etl_policy_integration.py
+++ b/tests/db/test_etl_policy_integration.py
@@ -381,3 +381,220 @@ class TestEndToEndReport:
         assert summary["by_action"]["schema_corrected"] == 1
         assert summary["total_failed"] == 1              # the unparseable ts
         assert summary["max_severity"] == 4
+
+
+# ── Catalog policy (P2.3) ────────────────────────────────────────────────────
+
+_CATALOG_SCHEMA = """
+CREATE TABLE owners (
+    tumbler_prefix TEXT PRIMARY KEY,
+    name           TEXT NOT NULL,
+    owner_type     TEXT NOT NULL,
+    repo_hash      TEXT,
+    description    TEXT,
+    repo_root      TEXT DEFAULT '',
+    head_hash      TEXT
+);
+CREATE TABLE documents (
+    tumbler              TEXT PRIMARY KEY,
+    title                TEXT NOT NULL,
+    author               TEXT,
+    year                 INTEGER,
+    content_type         TEXT,
+    file_path            TEXT,
+    corpus               TEXT,
+    physical_collection  TEXT,
+    chunk_count          INTEGER,
+    head_hash            TEXT,
+    indexed_at           TEXT,
+    metadata             TEXT,
+    source_mtime         REAL DEFAULT 0.0,
+    alias_of             TEXT DEFAULT '',
+    source_uri           TEXT DEFAULT ''
+);
+CREATE TABLE links (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_tumbler TEXT NOT NULL,
+    to_tumbler   TEXT NOT NULL,
+    link_type    TEXT NOT NULL,
+    from_span    TEXT DEFAULT '',
+    to_span      TEXT DEFAULT '',
+    created_by   TEXT DEFAULT 'user',
+    created_at   TEXT DEFAULT '',
+    metadata     TEXT
+);
+CREATE TABLE collections (
+    name         TEXT PRIMARY KEY,
+    content_type TEXT DEFAULT ''
+);
+CREATE TABLE document_chunks (
+    doc_id   TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    chash    TEXT NOT NULL
+);
+CREATE TABLE _meta (key TEXT PRIMARY KEY, value TEXT);
+"""
+
+
+class _CaptureCatalogClient:
+    """Duck-typed HttpCatalogClient: records _post calls per path."""
+
+    def __init__(self) -> None:
+        self.posts: dict[str, list[dict]] = {}
+
+    def _post(self, path: str, payload: dict) -> dict:
+        self.posts.setdefault(path, []).append(payload)
+        return {"imported": 1}
+
+
+class TestCatalogPolicy:
+    def _seeded_db(self, tmp_path: Path) -> Path:
+        db = _make_db(tmp_path, _CATALOG_SCHEMA, name="catalog.db")
+        _insert(db, "INSERT INTO owners (tumbler_prefix, name, owner_type) VALUES (?,?,?)", [
+            ("1.1", "nexus", "repo"),
+        ])
+        _insert(db, "INSERT INTO documents (tumbler, title) VALUES (?,?)", [
+            ("1.1.1", "doc-a"),
+            ("1.1.2", "doc-b"),
+        ])
+        _insert(db, "INSERT INTO links (from_tumbler, to_tumbler, link_type) VALUES (?,?,?)", [
+            ("1.1.1", "1.1.2", "cites"),     # valid
+            ("1.1.1", "9.9.9", "cites"),     # dangling endpoint (deleted doc)
+            ("9.9.8", "1.1.2", "relates"),   # dangling from-side
+        ])
+        return db
+
+    def test_dangling_links_imported_and_flagged(self, tmp_path: Path) -> None:
+        """Soft-dangler policy: catalog links have no enforced endpoint FK —
+        they IMPORT (273/1,719 in the audit) and the advisory records each."""
+        from nexus.db.t2.catalog_etl import migrate_catalog
+
+        db = self._seeded_db(tmp_path)
+        client = _CaptureCatalogClient()
+        collector = IssueCollector()
+
+        migrate_catalog(db, client, collector=collector)
+
+        # ALL three links imported — flag, never drop.
+        assert len(client.posts["/import/link"]) == 3
+        (issue,) = [
+            i for i in collector.issues_for("catalog", "links")
+            if i.action == "flagged"
+        ]
+        assert issue.issue_class == "soft_dangler"
+        assert issue.count == 2
+        assert set(issue.sample_ids) == {"1.1.1:9.9.9", "9.9.8:1.1.2"}
+        assert collector.table_counts("catalog", "links") == {
+            "read": 3, "written": 3,
+        }
+
+    def test_collector_optional_back_compat(self, tmp_path: Path) -> None:
+        from nexus.db.t2.catalog_etl import migrate_catalog
+
+        db = self._seeded_db(tmp_path)
+        result = migrate_catalog(db, _CaptureCatalogClient())
+        assert result["links"]["written"] == 3
+
+
+# ── Aspects policy (P2.3) ────────────────────────────────────────────────────
+
+_ASPECTS_SCHEMA = """
+CREATE TABLE document_aspects (
+    collection            TEXT,
+    source_path           TEXT,
+    doc_id                TEXT,
+    problem_formulation   TEXT,
+    proposed_method       TEXT,
+    experimental_datasets TEXT,
+    experimental_baselines TEXT,
+    experimental_results  TEXT,
+    extras                TEXT,
+    confidence            REAL,
+    extracted_at          TEXT,
+    model_version         TEXT,
+    extractor_name        TEXT
+);
+CREATE TABLE aspect_extraction_queue (
+    id          INTEGER PRIMARY KEY,
+    doc_id      TEXT,
+    collection  TEXT,
+    source_path TEXT,
+    status      TEXT,
+    enqueued_at TEXT
+);
+"""
+
+
+class _CaptureAspectsStore:
+    def __init__(self) -> None:
+        self.imported: list[dict] = []
+        self.queued: list[dict] = []
+
+    def import_aspect(self, body: dict) -> int:
+        self.imported.append(body)
+        return 1
+
+    def import_queue_row(self, body: dict) -> int:
+        self.queued.append(body)
+        return 1
+
+
+class TestAspectsPolicy:
+    def _seeded(self, tmp_path: Path) -> tuple[Path, Path]:
+        aspects_db = _make_db(tmp_path, _ASPECTS_SCHEMA, name="memory.db")
+        catalog_db = _make_db(tmp_path, _CATALOG_SCHEMA, name="catalog.db")
+        _insert(catalog_db, "INSERT INTO documents (tumbler, title) VALUES (?,?)", [
+            ("1.1.1", "live-doc"),
+        ])
+        _insert(
+            aspects_db,
+            "INSERT INTO document_aspects "
+            "(collection, source_path, doc_id, extracted_at, model_version, extractor_name) "
+            "VALUES (?,?,?,?,?,?)",
+            [
+                ("knowledge__x", "/a", "1.1.1", "2026-01-01", "v2", "claude"),  # valid doc
+                ("knowledge__x", "/b", "9.9.9", "2026-01-01", "v2", "claude"),  # stale doc_id
+            ],
+        )
+        _insert(
+            aspects_db,
+            "INSERT INTO aspect_extraction_queue (doc_id, collection, status) VALUES (?,?,?)",
+            [
+                ("1.1.1", "knowledge__x", "pending"),  # valid
+                ("9.9.9", "knowledge__x", "pending"),  # orphan
+            ],
+        )
+        return aspects_db, catalog_db
+
+    def test_orphan_doc_id_skipped_and_recorded(self, tmp_path: Path) -> None:
+        from nexus.db.t2.aspects_etl import migrate_aspects
+
+        aspects_db, catalog_db = self._seeded(tmp_path)
+        store = _CaptureAspectsStore()
+        collector = IssueCollector()
+
+        migrate_aspects(
+            aspects_db, store, collector=collector, catalog_db_path=catalog_db,
+        )
+
+        assert len(store.imported) == 1                  # only the live doc
+        assert store.imported[0]["doc_id"] == "1.1.1"
+        (issue,) = [
+            i for i in collector.issues_for("aspects", "document_aspects")
+            if i.action == "skipped"
+        ]
+        assert issue.issue_class == "orphan_parent"
+        assert issue.count == 1
+        assert collector.table_counts("aspects", "document_aspects") == {
+            "read": 2, "written": 1,
+        }
+
+    def test_without_catalog_db_no_orphan_check_back_compat(
+        self, tmp_path: Path,
+    ) -> None:
+        from nexus.db.t2.aspects_etl import migrate_aspects
+
+        aspects_db, _ = self._seeded(tmp_path)
+        store = _CaptureAspectsStore()
+        result = migrate_aspects(aspects_db, store)
+        assert result["imported"] == 2  # current behavior preserved

--- a/tests/db/test_etl_policy_integration.py
+++ b/tests/db/test_etl_policy_integration.py
@@ -515,12 +515,16 @@ CREATE TABLE document_aspects (
     extractor_name        TEXT
 );
 CREATE TABLE aspect_extraction_queue (
-    id          INTEGER PRIMARY KEY,
-    doc_id      TEXT,
-    collection  TEXT,
-    source_path TEXT,
-    status      TEXT,
-    enqueued_at TEXT
+    id              INTEGER PRIMARY KEY,
+    doc_id          TEXT,
+    collection      TEXT,
+    source_path     TEXT,
+    content_hash    TEXT,
+    status          TEXT,
+    retry_count     INTEGER DEFAULT 0,
+    enqueued_at     TEXT,
+    last_attempt_at TEXT,
+    last_error      TEXT
 );
 """
 
@@ -558,10 +562,11 @@ class TestAspectsPolicy:
         )
         _insert(
             aspects_db,
-            "INSERT INTO aspect_extraction_queue (doc_id, collection, status) VALUES (?,?,?)",
+            "INSERT INTO aspect_extraction_queue "
+            "(doc_id, collection, source_path, status, enqueued_at) VALUES (?,?,?,?,?)",
             [
-                ("1.1.1", "knowledge__x", "pending"),  # valid
-                ("9.9.9", "knowledge__x", "pending"),  # orphan
+                ("1.1.1", "knowledge__x", "/a", "pending", "2026-01-01"),  # valid
+                ("9.9.9", "knowledge__x", "/b", "pending", "2026-01-01"),  # orphan
             ],
         )
         return aspects_db, catalog_db
@@ -598,3 +603,138 @@ class TestAspectsPolicy:
         store = _CaptureAspectsStore()
         result = migrate_aspects(aspects_db, store)
         assert result["imported"] == 2  # current behavior preserved
+
+    def test_queue_orphans_skipped_valid_migrate(self, tmp_path: Path) -> None:
+        """The audit's 3/7 queue-orphan shape: orphans skip-and-record, the
+        valid rows migrate."""
+        from nexus.db.t2.aspects_etl import migrate_queue
+
+        aspects_db, catalog_db = self._seeded(tmp_path)
+        store = _CaptureAspectsStore()
+        collector = IssueCollector()
+
+        migrate_queue(
+            aspects_db, store, collector=collector, catalog_db_path=catalog_db,
+        )
+
+        assert len(store.queued) == 1
+        assert store.queued[0]["doc_id"] == "1.1.1"
+        (issue,) = [
+            i for i in collector.issues_for("aspects", "aspect_extraction_queue")
+            if i.action == "skipped"
+        ]
+        assert issue.issue_class == "orphan_parent"
+        assert issue.count == 1
+        assert collector.table_counts("aspects", "aspect_extraction_queue") == {
+            "read": 2, "written": 1,
+        }
+
+
+# ── Clean stores: counts + catch-all only (P2.3) ─────────────────────────────
+
+_MEMORY_SCHEMA = """
+CREATE TABLE memory (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    project       TEXT NOT NULL,
+    title         TEXT NOT NULL,
+    content       TEXT NOT NULL,
+    tags          TEXT,
+    timestamp     TEXT,
+    ttl_days      INTEGER DEFAULT 0,
+    access_count  INTEGER DEFAULT 0,
+    last_accessed TEXT,
+    session_id    TEXT,
+    source_agent  TEXT,
+    UNIQUE (project, title)
+);
+"""
+
+
+class TestCleanStoreCountsAndCatchAll:
+    def test_memory_counts_and_failed_catch_all(self, tmp_path: Path) -> None:
+        from nexus.db.t2.memory_etl import migrate_memory_rows
+
+        db = _make_db(tmp_path, _MEMORY_SCHEMA)
+        _insert(
+            db,
+            "INSERT INTO memory (project, title, content) VALUES (?,?,?)",
+            [("p", "t1", "c1"), ("p", "t2", "c2"), ("p", "t3", "c3")],
+        )
+        store = _CaptureStore()
+        store.fail_on["import_entry"] = 2
+        collector = IssueCollector()
+
+        migrate_memory_rows(db, store, collector=collector)
+
+        assert collector.table_counts("memory", "memory") == {
+            "read": 3, "written": 2,
+        }
+        (issue,) = [
+            i for i in collector.issues_for("memory", "memory")
+            if i.action == "failed"
+        ]
+        assert issue.issue_class == "unexpected"
+        assert issue.count == 1
+
+    def test_plans_counts_and_failed_catch_all(self, tmp_path: Path) -> None:
+        from nexus.db.t2.plan_etl import migrate_plan_rows
+
+        db = tmp_path / "plans.db"
+        conn = sqlite3.connect(db)
+        conn.executescript(
+            "CREATE TABLE plans (id INTEGER PRIMARY KEY, project TEXT, "
+            "query TEXT NOT NULL, plan_json TEXT NOT NULL DEFAULT '{}', "
+            "outcome TEXT DEFAULT 'success', tags TEXT DEFAULT '', "
+            "created_at TEXT DEFAULT '');"
+        )
+        conn.executemany(
+            "INSERT INTO plans (project, query) VALUES (?,?)",
+            [("p", "q1"), ("p", "q2")],
+        )
+        conn.commit()
+        conn.close()
+        store = _CaptureStore()
+        store.fail_on["import_plan"] = 1
+        collector = IssueCollector()
+
+        migrate_plan_rows(db, store, collector=collector)
+
+        assert collector.table_counts("plans", "plans") == {
+            "read": 2, "written": 1,
+        }
+        (issue,) = [
+            i for i in collector.issues_for("plans", "plans")
+            if i.action == "failed"
+        ]
+        assert issue.count == 1
+
+    def test_chash_counts_and_batch_error_exact(self, tmp_path: Path) -> None:
+        from nexus.db.t2.chash_etl import migrate_chash_rows
+
+        db = tmp_path / "chash.db"
+        conn = sqlite3.connect(db)
+        conn.executescript(
+            "CREATE TABLE chash_index (chash TEXT PRIMARY KEY, "
+            "physical_collection TEXT, created_at TEXT);"
+        )
+        conn.executemany(
+            "INSERT INTO chash_index VALUES (?,?,?)",
+            [("c1", "k", ""), ("c2", "k", "")],
+        )
+        conn.commit()
+        conn.close()
+
+        class _OkChash:
+            def import_batch(self, *a, **k):
+                return len(a[0]) if a else 0
+
+            def __getattr__(self, name):
+                def _f(*a, **k):
+                    payload = a[0] if a else k.get("rows", [])
+                    return {"imported": len(payload)} if isinstance(payload, list) else 1
+                return _f
+
+        collector = IssueCollector()
+        migrate_chash_rows(db, _OkChash(), collector=collector)
+        counts = collector.table_counts("chash", "chash_index")
+        assert counts["read"] == 2

--- a/tests/db/test_etl_policy_integration.py
+++ b/tests/db/test_etl_policy_integration.py
@@ -299,15 +299,18 @@ class TestTelemetryPolicy:
         migrate_telemetry_rows(db, store, collector=collector)
 
         by_ts = {c["occurred_at"] for c in store.calls["import_hook_failure"]}
-        assert "2026-04-23T10:47:54" in by_ts     # normalized
-        assert "2026-04-24T09:00:00" in by_ts     # untouched
+        # Canonical form is OFFSET-QUALIFIED: the Java strict import
+        # parser (OffsetDateTime.parse) rejects naive timestamps — the
+        # actual nexus-9sjn3 root cause (0/234 imported). Naive == UTC.
+        assert "2026-04-23T10:47:54+00:00" in by_ts   # space form normalized
+        assert "2026-04-24T09:00:00+00:00" in by_ts  # naive T form gains offset
         assert "2026-04-23 10:47:54" not in by_ts # space form never written
         (issue,) = [
             i for i in collector.issues_for("telemetry", "hook_failures")
             if i.action == "handled"
         ]
         assert issue.issue_class == "format_anomaly"
-        assert issue.count == 1   # only the space-form row was normalized
+        assert issue.count == 2   # both naive rows were normalized
 
     def test_unparseable_timestamp_failed_never_silent(
         self, tmp_path: Path,
@@ -376,7 +379,7 @@ class TestEndToEndReport:
         report = build_report(collector, source={"sqlite": str(tax_db)}, target={})
         summary = report["summary"]
         assert summary["by_action"]["skipped"] == 4      # 2 assignments + 2 links
-        assert summary["by_action"]["handled"] == 1
+        assert summary["by_action"]["handled"] == 2  # both naive ts rows
         assert summary["by_action"]["flagged"] == 1
         assert summary["by_action"]["schema_corrected"] == 1
         assert summary["total_failed"] == 1              # the unparseable ts

--- a/tests/db/test_etl_policy_integration.py
+++ b/tests/db/test_etl_policy_integration.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-153 Phase 2 (bead nexus-cr3oo, TDD-red): per-store ETL policy
+integration — the data-quality policy table applied inside the RDR-152
+T2 ETLs, recording into the Phase-1 ``IssueCollector``.
+
+Policy (RDR §Decision 2): orphan_parent → skip-and-record (skipped);
+identity_mismatch → schema_corrected; format_anomaly parseable →
+normalize (handled), unparseable → failed; soft_dangler →
+import-but-flag (flagged); unexpected → fail-and-record (failed, NEVER
+a silent drop).
+
+Real tmp SQLite sources (integration over mocks — the source side is the
+thing under test); the Postgres side is a duck-typed capture store, as
+in the existing per-ETL suites (the service's INSERT…ON CONFLICT
+idempotency is its own locked contract there).
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.db.t2.taxonomy_etl import migrate_taxonomy_rows
+from nexus.db.t2.telemetry_etl import migrate_telemetry_rows
+from nexus.migration.migration_report import IssueCollector, build_report
+
+# ── Source fixtures ──────────────────────────────────────────────────────────
+
+_TAXONOMY_SCHEMA = """
+CREATE TABLE topics (
+    id            INTEGER PRIMARY KEY,
+    label         TEXT NOT NULL,
+    parent_id     INTEGER,
+    collection    TEXT NOT NULL,
+    centroid_hash TEXT,
+    doc_count     INTEGER NOT NULL DEFAULT 0,
+    created_at    TEXT NOT NULL,
+    review_status TEXT NOT NULL DEFAULT 'pending',
+    terms         TEXT
+);
+CREATE TABLE topic_assignments (
+    doc_id            TEXT NOT NULL,
+    topic_id          INTEGER NOT NULL,
+    assigned_by       TEXT NOT NULL DEFAULT 'hdbscan',
+    similarity        REAL,
+    assigned_at       TEXT,
+    source_collection TEXT,
+    PRIMARY KEY (doc_id, topic_id)
+);
+CREATE TABLE topic_links (
+    from_topic_id INTEGER NOT NULL,
+    to_topic_id   INTEGER NOT NULL,
+    link_type     TEXT NOT NULL DEFAULT 'related',
+    weight        REAL,
+    created_at    TEXT
+);
+CREATE TABLE taxonomy_meta (
+    collection              TEXT PRIMARY KEY,
+    last_discover_doc_count INTEGER NOT NULL DEFAULT 0,
+    last_discover_at        TEXT
+);
+"""
+
+_TELEMETRY_SCHEMA = """
+CREATE TABLE hook_failures (
+    id            INTEGER PRIMARY KEY,
+    doc_id        TEXT,
+    collection    TEXT,
+    hook_name     TEXT NOT NULL,
+    error         TEXT,
+    occurred_at   TEXT NOT NULL,
+    batch_doc_ids TEXT,
+    is_batch      INTEGER DEFAULT 0,
+    chain         TEXT
+);
+CREATE TABLE nx_answer_runs (
+    id                 INTEGER PRIMARY KEY,
+    question           TEXT NOT NULL,
+    plan_id            INTEGER,
+    matched_confidence REAL,
+    step_count         INTEGER DEFAULT 0,
+    final_text         TEXT,
+    cost_usd           REAL,
+    duration_ms        INTEGER DEFAULT 0,
+    created_at         TEXT NOT NULL
+);
+CREATE TABLE plans (
+    id         INTEGER PRIMARY KEY,
+    query      TEXT,
+    created_at TEXT
+);
+"""
+
+
+def _make_db(tmp_path: Path, schema: str, name: str = "src.db") -> Path:
+    db = tmp_path / name
+    conn = sqlite3.connect(db)
+    conn.executescript(schema)
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _insert(db: Path, sql: str, rows: list[tuple]) -> None:
+    conn = sqlite3.connect(db)
+    conn.executemany(sql, rows)
+    conn.commit()
+    conn.close()
+
+
+class _CaptureStore:
+    """Duck-typed Postgres store: records every import call; raises for
+    keys registered via ``fail_on`` (models a service-side rejection)."""
+
+    def __init__(self) -> None:
+        self.calls: dict[str, list[dict]] = {}
+        self.fail_on: dict[str, int] = {}  # method -> 1-based call index
+
+    def __getattr__(self, name: str):
+        if not name.startswith("import_"):
+            raise AttributeError(name)
+
+        def _record(*args, **kwargs):
+            seq = self.calls.setdefault(name, [])
+            seq.append(kwargs or (args[0] if args else {}))
+            if self.fail_on.get(name) == len(seq):
+                raise RuntimeError(f"injected failure on {name} #{len(seq)}")
+
+        return _record
+
+
+# ── Taxonomy policy ──────────────────────────────────────────────────────────
+
+
+class TestTaxonomyPolicy:
+    def _seeded_db(self, tmp_path: Path) -> Path:
+        db = _make_db(tmp_path, _TAXONOMY_SCHEMA)
+        _insert(db, "INSERT INTO topics (id, label, collection, created_at) VALUES (?,?,?,?)", [
+            (1, "alpha", "knowledge__x", "2026-01-01T00:00:00"),
+            (2, "beta", "knowledge__x", "2026-01-01T00:00:00"),
+        ])
+        _insert(db, "INSERT INTO topic_assignments (doc_id, topic_id) VALUES (?,?)", [
+            ("chash-a", 1),        # valid
+            ("chash-b", 2),        # valid
+            ("chash-c", 99),       # orphan: topic 99 deleted
+            ("chash-d", 99),       # orphan
+        ])
+        _insert(db, "INSERT INTO topic_links (from_topic_id, to_topic_id) VALUES (?,?)", [
+            (1, 2),                # valid
+            (1, 99),               # orphan to-side
+            (99, 2),               # orphan from-side
+        ])
+        return db
+
+    def test_orphan_assignments_skipped_and_recorded(self, tmp_path: Path) -> None:
+        db = self._seeded_db(tmp_path)
+        store = _CaptureStore()
+        collector = IssueCollector()
+
+        migrate_taxonomy_rows(db, store, collector=collector)
+
+        # Valid rows imported; orphans NEVER reach the store.
+        imported = {c["doc_id"] for c in store.calls["import_assignment"]}
+        assert imported == {"chash-a", "chash-b"}
+        (issue,) = [
+            i for i in collector.issues_for("taxonomy", "topic_assignments")
+            if i.issue_class == "orphan_parent"
+        ]
+        assert issue.action == "skipped"
+        assert issue.count == 2
+        # Composite-key sample convention: <doc_id>:<topic_id>.
+        assert set(issue.sample_ids) == {"chash-c:99", "chash-d:99"}
+
+    def test_orphan_links_skipped_both_sides(self, tmp_path: Path) -> None:
+        db = self._seeded_db(tmp_path)
+        store = _CaptureStore()
+        collector = IssueCollector()
+
+        migrate_taxonomy_rows(db, store, collector=collector)
+
+        links = store.calls["import_topic_link"]
+        assert len(links) == 1
+        assert (links[0]["from_topic_id"], links[0]["to_topic_id"]) == (1, 2)
+        (issue,) = [
+            i for i in collector.issues_for("taxonomy", "topic_links")
+            if i.issue_class == "orphan_parent"
+        ]
+        assert issue.action == "skipped"
+        assert issue.count == 2
+        assert set(issue.sample_ids) == {"1:99", "99:2"}
+
+    def test_doc_id_is_chash_schema_correction_recorded_once(
+        self, tmp_path: Path,
+    ) -> None:
+        db = self._seeded_db(tmp_path)
+        collector = IssueCollector()
+        migrate_taxonomy_rows(db, _CaptureStore(), collector=collector)
+        issues = [
+            i for i in collector.issues_for("taxonomy", "topic_assignments")
+            if i.issue_class == "identity_mismatch"
+        ]
+        assert len(issues) == 1
+        assert issues[0].action == "schema_corrected"
+        assert issues[0].count == 1          # ONCE per run, not per row
+        assert issues[0].sample_ids == []    # one-time event, no row sample
+
+    def test_counts_recorded_per_table(self, tmp_path: Path) -> None:
+        db = self._seeded_db(tmp_path)
+        collector = IssueCollector()
+        migrate_taxonomy_rows(db, _CaptureStore(), collector=collector)
+        assert collector.table_counts("taxonomy", "topic_assignments") == {
+            "read": 4, "written": 2,
+        }
+        assert collector.table_counts("taxonomy", "topic_links") == {
+            "read": 3, "written": 1,
+        }
+        assert collector.table_counts("taxonomy", "topics") == {
+            "read": 2, "written": 2,
+        }
+
+    def test_store_rejection_is_failed_issue_never_silent(
+        self, tmp_path: Path,
+    ) -> None:
+        """Catch-all: a service-side rejection on one row records a failed
+        issue and the run continues (no abort, no silent drop)."""
+        db = self._seeded_db(tmp_path)
+        store = _CaptureStore()
+        store.fail_on["import_topic"] = 2   # second topic write blows up
+        collector = IssueCollector()
+
+        migrate_taxonomy_rows(db, store, collector=collector)
+
+        (issue,) = [
+            i for i in collector.issues_for("taxonomy", "topics")
+            if i.action == "failed"
+        ]
+        assert issue.issue_class == "unexpected"
+        assert issue.count == 1
+        assert collector.table_counts("taxonomy", "topics")["written"] == 1
+        # The run continued: assignments still migrated.
+        assert len(store.calls["import_assignment"]) == 2
+
+    def test_rerun_is_idempotent_at_etl_level(self, tmp_path: Path) -> None:
+        """Re-run after parent repair must not raise (server-side
+        INSERT…ON CONFLICT DO NOTHING absorbs already-migrated rows; the
+        ETL must not fail on identical inputs either)."""
+        db = self._seeded_db(tmp_path)
+        store = _CaptureStore()
+        migrate_taxonomy_rows(db, store, collector=IssueCollector())
+        collector2 = IssueCollector()
+        migrate_taxonomy_rows(db, store, collector=collector2)
+        # Second run reads identically; orphans recorded identically.
+        assert collector2.table_counts("taxonomy", "topic_assignments") == {
+            "read": 4, "written": 2,
+        }
+
+    def test_collector_optional_back_compat(self, tmp_path: Path) -> None:
+        # The RDR-152 callers pass no collector; the ETL must work unchanged.
+        db = self._seeded_db(tmp_path)
+        result = migrate_taxonomy_rows(db, _CaptureStore())
+        assert result["topics"]["written"] == 2
+
+
+# ── Telemetry policy ─────────────────────────────────────────────────────────
+
+
+class TestTelemetryPolicy:
+    def _seeded_db(self, tmp_path: Path) -> Path:
+        db = _make_db(tmp_path, _TELEMETRY_SCHEMA)
+        _insert(db, "INSERT INTO plans (id, query) VALUES (?,?)", [(7, "q")])
+        _insert(
+            db,
+            "INSERT INTO hook_failures (hook_name, error, occurred_at) VALUES (?,?,?)",
+            [
+                ("auto_link", "boom", "2026-04-23 10:47:54"),   # space form
+                ("auto_link", "boom", "2026-04-24T09:00:00"),   # already ISO
+                ("auto_link", "boom", "not-a-timestamp"),       # unparseable
+            ],
+        )
+        _insert(
+            db,
+            "INSERT INTO nx_answer_runs (question, plan_id, created_at) VALUES (?,?,?)",
+            [
+                ("q-ok", 7, "2026-05-01T00:00:00"),     # plan exists
+                ("q-dangler", 99, "2026-05-01T00:00:00"),  # plan deleted
+                ("q-none", None, "2026-05-01T00:00:00"),   # NULL is fine
+            ],
+        )
+        return db
+
+    def test_space_form_timestamp_normalized_and_handled(
+        self, tmp_path: Path,
+    ) -> None:
+        db = self._seeded_db(tmp_path)
+        store = _CaptureStore()
+        collector = IssueCollector()
+
+        migrate_telemetry_rows(db, store, collector=collector)
+
+        by_ts = {c["occurred_at"] for c in store.calls["import_hook_failure"]}
+        assert "2026-04-23T10:47:54" in by_ts     # normalized
+        assert "2026-04-24T09:00:00" in by_ts     # untouched
+        assert "2026-04-23 10:47:54" not in by_ts # space form never written
+        (issue,) = [
+            i for i in collector.issues_for("telemetry", "hook_failures")
+            if i.action == "handled"
+        ]
+        assert issue.issue_class == "format_anomaly"
+        assert issue.count == 1   # only the space-form row was normalized
+
+    def test_unparseable_timestamp_failed_never_silent(
+        self, tmp_path: Path,
+    ) -> None:
+        db = self._seeded_db(tmp_path)
+        store = _CaptureStore()
+        collector = IssueCollector()
+
+        migrate_telemetry_rows(db, store, collector=collector)
+
+        (issue,) = [
+            i for i in collector.issues_for("telemetry", "hook_failures")
+            if i.action == "failed"
+        ]
+        assert issue.issue_class == "format_anomaly"
+        assert issue.count == 1
+        # The unparseable row was NOT written.
+        assert len(store.calls["import_hook_failure"]) == 2
+        assert collector.table_counts("telemetry", "hook_failures") == {
+            "read": 3, "written": 2,
+        }
+
+    def test_plan_danglers_imported_and_flagged(self, tmp_path: Path) -> None:
+        """Soft dangler policy: the row IMPORTS (no FK enforced) and an
+        advisory records the dangling reference."""
+        db = self._seeded_db(tmp_path)
+        store = _CaptureStore()
+        collector = IssueCollector()
+
+        migrate_telemetry_rows(db, store, collector=collector)
+
+        # All three runs imported — danglers are not dropped.
+        assert len(store.calls["import_nx_answer_run"]) == 3
+        (issue,) = [
+            i for i in collector.issues_for("telemetry", "nx_answer_runs")
+            if i.action == "flagged"
+        ]
+        assert issue.issue_class == "soft_dangler"
+        assert issue.count == 1               # only plan_id=99; NULL is not a dangler
+        assert collector.table_counts("telemetry", "nx_answer_runs") == {
+            "read": 3, "written": 3,
+        }
+
+    def test_collector_optional_back_compat(self, tmp_path: Path) -> None:
+        db = self._seeded_db(tmp_path)
+        result = migrate_telemetry_rows(db, _CaptureStore())
+        assert result["nx_answer_runs"]["written"] == 3
+
+
+# ── Report round-trip over a real two-store run ──────────────────────────────
+
+
+class TestEndToEndReport:
+    def test_gate_predicate_over_real_etl_run(self, tmp_path: Path) -> None:
+        """The production-shaped pass: orphans skipped, timestamps handled,
+        danglers flagged, one unparseable row failed — the report reflects
+        every action and total_failed counts exactly the failed rows."""
+        tax_db = TestTaxonomyPolicy()._seeded_db(tmp_path)
+        tel_db = TestTelemetryPolicy()._seeded_db(
+            (tmp_path / "tel").resolve() if (tmp_path / "tel").mkdir() is None else tmp_path / "tel",
+        )
+        collector = IssueCollector()
+        migrate_taxonomy_rows(tax_db, _CaptureStore(), collector=collector)
+        migrate_telemetry_rows(tel_db, _CaptureStore(), collector=collector)
+
+        report = build_report(collector, source={"sqlite": str(tax_db)}, target={})
+        summary = report["summary"]
+        assert summary["by_action"]["skipped"] == 4      # 2 assignments + 2 links
+        assert summary["by_action"]["handled"] == 1
+        assert summary["by_action"]["flagged"] == 1
+        assert summary["by_action"]["schema_corrected"] == 1
+        assert summary["total_failed"] == 1              # the unparseable ts
+        assert summary["max_severity"] == 4

--- a/tests/db/test_etl_policy_integration.py
+++ b/tests/db/test_etl_policy_integration.py
@@ -708,7 +708,7 @@ class TestCleanStoreCountsAndCatchAll:
         ]
         assert issue.count == 1
 
-    def test_chash_counts_and_batch_error_exact(self, tmp_path: Path) -> None:
+    def test_chash_batch_error_records_failed_per_row(self, tmp_path: Path) -> None:
         from nexus.db.t2.chash_etl import migrate_chash_rows
 
         db = tmp_path / "chash.db"
@@ -738,3 +738,124 @@ class TestCleanStoreCountsAndCatchAll:
         migrate_chash_rows(db, _OkChash(), collector=collector)
         counts = collector.table_counts("chash", "chash_index")
         assert counts["read"] == 2
+        # _OkChash's __getattr__ returns a bare function for ._client, so
+        # the batch post raises — this test OWNS the error path (CRE P2
+        # finding): nothing written, and total_failed counts BOTH rows.
+        assert counts["written"] == 0
+        (issue,) = [
+            i for i in collector.issues_for("chash", "chash_index")
+            if i.action == "failed"
+        ]
+        assert issue.count == 2
+
+
+class TestNeverSilentSweep:
+    """RDR-153 P2 critic Criticals: EVERY ETL surface records import
+    rejections — a silent path lets the Phase-4 gate pass falsely."""
+
+    def test_telemetry_relevance_log_failure_recorded(self, tmp_path: Path) -> None:
+        from nexus.db.t2.telemetry_etl import migrate_telemetry_rows
+
+        db = _make_db(tmp_path, _TELEMETRY_SCHEMA + """
+CREATE TABLE relevance_log (
+    id INTEGER PRIMARY KEY, query TEXT, doc_id TEXT, rank INTEGER,
+    clicked INTEGER DEFAULT 0, timestamp TEXT
+);""")
+        _insert(db, "INSERT INTO relevance_log (query, doc_id, rank) VALUES (?,?,?)", [
+            ("q", "d1", 1), ("q", "d2", 2),
+        ])
+        store = _CaptureStore()
+        store.fail_on["import_relevance_row"] = 1
+        collector = IssueCollector()
+
+        migrate_telemetry_rows(db, store, collector=collector)
+
+        failed = [
+            i for i in collector.issues_for("telemetry", "relevance_log")
+            if i.action == "failed"
+        ]
+        assert len(failed) == 1
+        assert failed[0].count == 1
+
+    def test_catalog_import_failure_recorded(self, tmp_path: Path) -> None:
+        from nexus.db.t2.catalog_etl import migrate_catalog
+
+        db = TestCatalogPolicy()._seeded_db(tmp_path)
+
+        class _FailingSecondDoc(_CaptureCatalogClient):
+            def _post(self, path, payload):
+                super()._post(path, payload)
+                if path == "/import/document" and len(self.posts[path]) == 2:
+                    raise RuntimeError("injected")
+                return {"imported": 1}
+
+        collector = IssueCollector()
+        migrate_catalog(db, _FailingSecondDoc(), collector=collector)
+
+        (issue,) = [
+            i for i in collector.issues_for("catalog", "documents")
+            if i.action == "failed"
+        ]
+        assert issue.count == 1
+        assert collector.table_counts("catalog", "documents")["written"] == 1
+
+    def test_queue_import_rejection_recorded(self, tmp_path: Path) -> None:
+        from nexus.db.t2.aspects_etl import migrate_queue
+
+        aspects_db, catalog_db = TestAspectsPolicy()._seeded(tmp_path)
+
+        class _RejectingQueue(_CaptureAspectsStore):
+            def import_queue_row(self, body):
+                raise RuntimeError("rejected")
+
+        collector = IssueCollector()
+        migrate_queue(
+            aspects_db, _RejectingQueue(), collector=collector,
+            catalog_db_path=catalog_db,
+        )
+        failed = [
+            i for i in collector.issues_for("aspects", "aspect_extraction_queue")
+            if i.action == "failed"
+        ]
+        assert len(failed) == 1
+        assert failed[0].count == 1  # the valid row; the orphan was skipped
+
+    def test_memory_transform_failure_recorded_not_aborting(
+        self, tmp_path: Path,
+    ) -> None:
+        """CRE Low-2: a corrupt row whose TRANSFORM raises must record a
+        failed issue and the loop must continue (never-silent, no abort)."""
+        from nexus.db.t2.memory_etl import migrate_memory_rows
+
+        db = _make_db(tmp_path, _MEMORY_SCHEMA)
+        conn = sqlite3.connect(db)
+        # NULL content slips past SQLite (no NOT NULL via executescript path?
+        # enforce corruption explicitly: drop NOT NULL by inserting via a
+        # direct pragma-free path is impossible — instead simulate transform
+        # failure with a row whose content is NULL through a relaxed table).
+        conn.executescript(
+            "CREATE TABLE m2 AS SELECT * FROM memory; DROP TABLE memory;"
+            "CREATE TABLE memory (id INTEGER PRIMARY KEY, project TEXT, "
+            "title TEXT, content TEXT, tags TEXT, timestamp TEXT, "
+            "ttl_days INTEGER, access_count INTEGER, last_accessed TEXT, "
+            "session_id TEXT, source_agent TEXT);"
+        )
+        conn.executemany(
+            "INSERT INTO memory (project, title, content) VALUES (?,?,?)",
+            [("p", "good", "c"), (None, None, None), ("p", "good2", "c")],
+        )
+        conn.commit()
+        conn.close()
+        store = _CaptureStore()
+        collector = IssueCollector()
+
+        migrate_memory_rows(db, store, collector=collector)
+
+        counts = collector.table_counts("memory", "memory")
+        assert counts["read"] == 3
+        # The corrupt row either transforms-and-imports or records failed —
+        # never silently vanishes:
+        assert counts["written"] + sum(
+            i.count for i in collector.issues_for("memory", "memory")
+            if i.action == "failed"
+        ) == 3

--- a/tests/migration/test_migration_report.py
+++ b/tests/migration/test_migration_report.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-153 Phase 1 (bead nexus-ouuwb, TDD-red): MigrationIssue +
+IssueCollector + JSON report serialization.
+
+The report is the triage / recovery / learning artifact for the
+SQLite→Postgres T2 migration and a Phase-4 gate input
+(``summary.total_failed == 0``). Contract source:
+docs/rdr/rdr-153-migration-data-quality-policy.md § JSON report schema.
+
+Two distinct enums, never mixed: ``class`` (what is wrong) vs ``action``
+(what the ETL did). ``summary.by_action`` aggregates by the five ACTION
+values — the gate-facing rollup.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime
+
+import pytest
+
+from nexus.migration.migration_report import (
+    ACTION_SEVERITY,
+    IssueCollector,
+    MigrationIssue,
+    build_report,
+)
+
+# ── MigrationIssue ───────────────────────────────────────────────────────────
+
+
+class TestMigrationIssue:
+    def test_carries_full_contract(self) -> None:
+        issue = MigrationIssue(
+            issue_class="orphan_parent",
+            constraint="topic_assignments.topic_id -> topics.id",
+            reason="topic_id references a deleted topic",
+            action="skipped",
+            count=51286,
+            sample_ids=["d1:t9", "d2:t9"],
+            sample_truncated=True,
+        )
+        assert issue.issue_class == "orphan_parent"
+        assert issue.action == "skipped"
+        assert issue.severity == 3  # derived from action, see ordinals below
+        assert issue.constraint.endswith("topics.id")
+        assert issue.count == 51286
+        assert issue.sample_ids == ["d1:t9", "d2:t9"]
+        assert issue.sample_truncated is True
+
+    @pytest.mark.parametrize("bad_class", ["orphan", "", "ORPHAN_PARENT"])
+    def test_unknown_class_rejected(self, bad_class: str) -> None:
+        with pytest.raises(ValueError, match="class"):
+            MigrationIssue(
+                issue_class=bad_class, constraint="", reason="r",
+                action="skipped", count=1,
+            )
+
+    @pytest.mark.parametrize("bad_action", ["dropped", "", "SKIPPED"])
+    def test_unknown_action_rejected(self, bad_action: str) -> None:
+        with pytest.raises(ValueError, match="action"):
+            MigrationIssue(
+                issue_class="unexpected", constraint="", reason="r",
+                action=bad_action, count=1,
+            )
+
+    def test_severity_ordinals_exact(self) -> None:
+        """Severity is a function of ACTION, locked to exact ordinals (the
+        bead mandates ==N, never >=): failed=4, skipped=3, flagged=2,
+        handled=1, schema_corrected=0."""
+        assert ACTION_SEVERITY == {
+            "failed": 4,
+            "skipped": 3,
+            "flagged": 2,
+            "handled": 1,
+            "schema_corrected": 0,
+        }
+        for action, expected in ACTION_SEVERITY.items():
+            issue = MigrationIssue(
+                issue_class="unexpected", constraint="", reason="r",
+                action=action, count=1,
+            )
+            assert issue.severity == expected
+
+
+# ── IssueCollector ───────────────────────────────────────────────────────────
+
+
+class TestIssueCollector:
+    def test_accumulates_per_store_table(self) -> None:
+        c = IssueCollector()
+        c.record(
+            "taxonomy", "topic_assignments",
+            issue_class="orphan_parent",
+            constraint="topic_assignments.topic_id -> topics.id",
+            reason="deleted topic",
+            action="skipped",
+            sample_id="d1:t9",
+        )
+        c.record(
+            "taxonomy", "topic_assignments",
+            issue_class="orphan_parent",
+            constraint="topic_assignments.topic_id -> topics.id",
+            reason="deleted topic",
+            action="skipped",
+            sample_id="d2:t9",
+        )
+        c.record(
+            "telemetry", "hook_failures",
+            issue_class="format_anomaly",
+            constraint="hook_failures.occurred_at",
+            reason="space-form timestamp normalized to ISO-8601",
+            action="handled",
+            sample_id="hf-1",
+        )
+        tax = c.issues_for("taxonomy", "topic_assignments")
+        assert len(tax) == 1  # same (class, constraint, action) → one issue
+        assert tax[0].count == 2
+        assert tax[0].sample_ids == ["d1:t9", "d2:t9"]
+        tel = c.issues_for("telemetry", "hook_failures")
+        assert len(tel) == 1
+        assert tel[0].action == "handled"
+        assert c.issues_for("telemetry", "nx_answer_runs") == []
+
+    def test_sample_ids_capped_at_200(self) -> None:
+        c = IssueCollector()
+        for i in range(250):
+            c.record(
+                "taxonomy", "topic_links",
+                issue_class="orphan_parent",
+                constraint="topic_links.topic_id -> topics.id",
+                reason="deleted topic",
+                action="skipped",
+                sample_id=f"row-{i}",
+            )
+        (issue,) = c.issues_for("taxonomy", "topic_links")
+        assert issue.count == 250            # full count, exact
+        assert len(issue.sample_ids) == 200  # capped
+        assert issue.sample_truncated is True
+        assert issue.sample_ids[0] == "row-0"
+
+    def test_under_cap_not_truncated(self) -> None:
+        c = IssueCollector()
+        c.record(
+            "catalog", "links",
+            issue_class="soft_dangler",
+            constraint="links.from_tumbler -> documents.tumbler",
+            reason="endpoint missing",
+            action="flagged",
+            sample_id="L1",
+        )
+        (issue,) = c.issues_for("catalog", "links")
+        assert issue.sample_truncated is False
+
+    def test_table_counts_tracked(self) -> None:
+        c = IssueCollector()
+        c.count_read("memory", "memory", 2621)
+        c.count_written("memory", "memory", 2621)
+        counts = c.table_counts("memory", "memory")
+        assert counts == {"read": 2621, "written": 2621}
+
+
+# ── Report serialization ─────────────────────────────────────────────────────
+
+
+def _populated_collector() -> IssueCollector:
+    c = IssueCollector()
+    c.count_read("taxonomy", "topic_assignments", 180806)
+    c.count_written("taxonomy", "topic_assignments", 129520)
+    for i in range(3):
+        c.record(
+            "taxonomy", "topic_assignments",
+            issue_class="orphan_parent",
+            constraint="topic_assignments.topic_id -> topics.id",
+            reason="topic_id references a deleted topic",
+            action="skipped",
+            sample_id=f"d{i}:t9",
+        )
+    c.count_read("telemetry", "hook_failures", 234)
+    c.count_written("telemetry", "hook_failures", 234)
+    c.record(
+        "telemetry", "hook_failures",
+        issue_class="format_anomaly",
+        constraint="hook_failures.occurred_at",
+        reason="space-form timestamp normalized to ISO-8601",
+        action="handled",
+        sample_id="hf-1",
+    )
+    c.record(
+        "telemetry", "nx_answer_runs",
+        issue_class="soft_dangler",
+        constraint="nx_answer_runs.plan_id -> plans.id",
+        reason="plan deleted; row imports with dangling reference",
+        action="flagged",
+        sample_id="run-7",
+    )
+    c.record(
+        "taxonomy", "document_aspects",
+        issue_class="unexpected",
+        constraint="document_aspects",
+        reason="unparseable row",
+        action="failed",
+        sample_id="da-3",
+    )
+    c.record(
+        "taxonomy", "topics",
+        issue_class="identity_mismatch",
+        constraint="topics.doc_id",
+        reason="doc_id is a chash, not a tumbler — schema corrected once",
+        action="schema_corrected",
+        sample_id="topics",
+    )
+    return c
+
+
+class TestBuildReport:
+    def _report(self) -> dict:
+        return build_report(
+            _populated_collector(),
+            source={"sqlite": "/cfg/memory.db", "catalog_db": "/cfg/catalog.db"},
+            target={"service_url": "http://127.0.0.1:5999",
+                    "db_schema_version": "grants-002-changelog-read"},
+        )
+
+    def test_envelope_contract(self) -> None:
+        report = self._report()
+        assert report["schema_version"] == "1"
+        uuid.UUID(report["migration_id"])  # parseable uuid
+        datetime.fromisoformat(report["started_at"])
+        datetime.fromisoformat(report["completed_at"])
+        assert report["source"]["sqlite"] == "/cfg/memory.db"
+        assert report["target"]["db_schema_version"] == "grants-002-changelog-read"
+
+    def test_stores_and_tables_shape(self) -> None:
+        report = self._report()
+        stores = {s["store"]: s for s in report["stores"]}
+        assert set(stores) == {"taxonomy", "telemetry"}
+        tables = {t["table"]: t for t in stores["taxonomy"]["tables"]}
+        ta = tables["topic_assignments"]
+        assert ta["read"] == 180806
+        assert ta["written"] == 129520
+        assert ta["skipped"] == 3
+        assert ta["flagged"] == 0
+        assert ta["failed"] == 0
+        (issue,) = ta["issues"]
+        assert issue["class"] == "orphan_parent"
+        assert issue["action"] == "skipped"
+        assert issue["severity"] == 3
+        assert issue["count"] == 3
+        assert issue["sample_truncated"] is False
+
+    def test_summary_by_action_keyed_on_actions(self) -> None:
+        """CRITICAL contract: by_action keys are the 5 ACTION values, not
+        classes — this is the gate-facing rollup."""
+        report = self._report()
+        summary = report["summary"]
+        assert set(summary["by_action"]) == {
+            "skipped", "handled", "flagged", "schema_corrected", "failed",
+        }
+        assert summary["by_action"]["skipped"] == 3
+        assert summary["by_action"]["handled"] == 1
+        assert summary["by_action"]["flagged"] == 1
+        assert summary["by_action"]["failed"] == 1
+        assert summary["by_action"]["schema_corrected"] == 1
+        assert summary["total_read"] == 180806 + 234
+        assert summary["total_written"] == 129520 + 234
+        assert summary["total_skipped"] == 3
+        assert summary["total_flagged"] == 1
+        assert summary["total_failed"] == 1
+        assert summary["max_severity"] == 4  # the failed issue
+
+    def test_phase4_gate_predicate(self) -> None:
+        # The Phase-4 gate predicate is summary.total_failed == 0.
+        clean = IssueCollector()
+        clean.count_read("memory", "memory", 10)
+        clean.count_written("memory", "memory", 10)
+        report = build_report(clean, source={}, target={})
+        assert report["summary"]["total_failed"] == 0
+        assert report["summary"]["max_severity"] == 0
+
+    def test_round_trip_stable(self) -> None:
+        report = self._report()
+        encoded = json.dumps(report, sort_keys=True)
+        decoded = json.loads(encoded)
+        assert decoded == report
+        assert json.dumps(decoded, sort_keys=True) == encoded

--- a/tests/migration/test_migration_report.py
+++ b/tests/migration/test_migration_report.py
@@ -425,3 +425,35 @@ class TestReviewPassRegressions:
         assert issue.count == 1
         assert issue.sample_ids == []
         assert issue.sample_truncated is False
+
+
+class TestEtlRegistry:
+    """RDR-153 P2 critique S5: the Phase-3 seam — ladder order + the
+    uniform runner contract live in ONE reviewable place."""
+
+    def test_ladder_order_exact(self) -> None:
+        from nexus.migration.etl_registry import LADDER_ORDER
+
+        assert LADDER_ORDER == (
+            "memory", "plans", "telemetry", "taxonomy",
+            "aspects", "chash", "catalog",
+        )
+
+    def test_unknown_store_rejected(self) -> None:
+        from nexus.migration.etl_registry import StoreEtl
+
+        with pytest.raises(ValueError, match="unknown store"):
+            StoreEtl(store="vectors", run=lambda sources, collector: {})
+
+    def test_ordered_sorts_and_rejects_duplicates(self) -> None:
+        from nexus.migration.etl_registry import StoreEtl, ordered
+
+        runner = lambda sources, collector: {}  # noqa: E731
+        etls = [
+            StoreEtl("catalog", runner),
+            StoreEtl("memory", runner),
+            StoreEtl("taxonomy", runner),
+        ]
+        assert [e.store for e in ordered(etls)] == ["memory", "taxonomy", "catalog"]
+        with pytest.raises(ValueError, match="duplicate"):
+            ordered([StoreEtl("memory", runner), StoreEtl("memory", runner)])

--- a/tests/migration/test_migration_report.py
+++ b/tests/migration/test_migration_report.py
@@ -284,3 +284,144 @@ class TestBuildReport:
         decoded = json.loads(encoded)
         assert decoded == report
         assert json.dumps(decoded, sort_keys=True) == encoded
+
+
+class TestReviewPassRegressions:
+    """P1.3/P1.4 review findings (2026-06-11)."""
+
+    def test_phase4_gate_clears_with_nonzero_skipped_and_handled(self) -> None:
+        """Critic S1: the REAL passing-gate shape — the production audit
+        expects ~51k skipped + 273 flagged + 234 handled + 1 schema
+        correction and ZERO failed. The gate must clear on exactly that."""
+        c = IssueCollector()
+        c.count_read("taxonomy", "topic_assignments", 180806)
+        c.count_written("taxonomy", "topic_assignments", 129520)
+        for i in range(3):
+            c.record(
+                "taxonomy", "topic_assignments",
+                issue_class="orphan_parent",
+                constraint="topic_assignments.topic_id -> topics.id",
+                reason="deleted topic",
+                action="skipped",
+                sample_id=f"d{i}:t9",
+            )
+        c.record(
+            "catalog", "links",
+            issue_class="soft_dangler",
+            constraint="links.from_tumbler -> documents.tumbler",
+            reason="endpoint missing",
+            action="flagged",
+            sample_id="L1",
+        )
+        c.record(
+            "telemetry", "hook_failures",
+            issue_class="format_anomaly",
+            constraint="hook_failures.occurred_at",
+            reason="space-form timestamp normalized",
+            action="handled",
+            sample_id="hf-1",
+        )
+        c.record_event(
+            "taxonomy", "topics",
+            issue_class="identity_mismatch",
+            constraint="topics.doc_id",
+            reason="doc_id is a chash — schema corrected",
+            action="schema_corrected",
+        )
+        report = build_report(c, source={}, target={})
+        summary = report["summary"]
+        assert summary["total_failed"] == 0      # the gate clears
+        assert summary["total_skipped"] == 3
+        assert summary["total_flagged"] == 1
+        assert summary["by_action"]["handled"] == 1
+        assert summary["by_action"]["schema_corrected"] == 1
+        assert summary["max_severity"] == 3      # skipped, nothing failed
+
+    def test_started_at_defaults_to_collector_construction(self) -> None:
+        """Critic S2: a forgotten started_at must not silently equal
+        completed_at — the collector captures it at construction (= ETL
+        start), so the audit artifact keeps the run duration."""
+        c = IssueCollector()
+        c.count_read("memory", "memory", 1)
+        report = build_report(c, source={}, target={})
+        assert report["started_at"] == c.started_at
+        assert report["completed_at"] >= report["started_at"]
+        # Explicit override still wins.
+        explicit = build_report(
+            c, source={}, target={}, started_at="2026-06-10T00:00:00+00:00",
+        )
+        assert explicit["started_at"] == "2026-06-10T00:00:00+00:00"
+
+    def test_multiple_issues_same_table(self) -> None:
+        """CRE M2: two distinct (class, constraint, action) buckets in ONE
+        (store, table) — the most likely production shape."""
+        c = IssueCollector()
+        c.count_read("taxonomy", "topic_links", 17638)
+        c.count_written("taxonomy", "topic_links", 6535)
+        c.record(
+            "taxonomy", "topic_links",
+            issue_class="orphan_parent",
+            constraint="topic_links.topic_id -> topics.id",
+            reason="deleted from-topic",
+            action="skipped",
+            sample_id="tl-1",
+        )
+        c.record(
+            "taxonomy", "topic_links",
+            issue_class="orphan_parent",
+            constraint="topic_links.to_topic_id -> topics.id",
+            reason="deleted to-topic",
+            action="skipped",
+            sample_id="tl-2",
+        )
+        c.record(
+            "taxonomy", "topic_links",
+            issue_class="unexpected",
+            constraint="topic_links",
+            reason="unparseable row",
+            action="failed",
+            sample_id="tl-3",
+        )
+        report = build_report(c, source={}, target={})
+        (store,) = report["stores"]
+        (table,) = store["tables"]
+        assert len(table["issues"]) == 3
+        assert table["skipped"] == 2   # summed across the two skip buckets
+        assert table["failed"] == 1
+        assert report["summary"]["by_action"]["skipped"] == 2
+        assert report["summary"]["total_failed"] == 1
+
+    def test_table_key_set_locked(self) -> None:
+        """CRE L2: the table dict carries EXACTLY the RDR schema columns —
+        handled/schema_corrected are by_action-only by design."""
+        c = IssueCollector()
+        c.count_read("memory", "memory", 1)
+        report = build_report(c, source={}, target={})
+        (table,) = report["stores"][0]["tables"]
+        assert set(table.keys()) == {
+            "table", "read", "written", "skipped", "flagged", "failed", "issues",
+        }
+
+    def test_by_action_severity_descending_order(self) -> None:
+        """CRE L1: key order matches the RDR example (human readability;
+        JSON object order is non-semantic)."""
+        c = IssueCollector()
+        c.count_read("memory", "memory", 1)
+        report = build_report(c, source={}, target={})
+        assert list(report["summary"]["by_action"]) == [
+            "failed", "skipped", "flagged", "handled", "schema_corrected",
+        ]
+
+    def test_record_event_has_no_samples(self) -> None:
+        c = IssueCollector()
+        c.record_event(
+            "taxonomy", "topics",
+            issue_class="identity_mismatch",
+            constraint="topics.doc_id",
+            reason="schema corrected once",
+            action="schema_corrected",
+        )
+        (issue,) = c.issues_for("taxonomy", "topics")
+        assert issue.count == 1
+        assert issue.sample_ids == []
+        assert issue.sample_truncated is False

--- a/tests/test_migration_report_show.py
+++ b/tests/test_migration_report_show.py
@@ -146,15 +146,54 @@ class TestShowSummary:
         result = runner.invoke(main, [
             "storage", "migration-report", "show", str(tmp_path / "absent.json"),
         ])
-        assert result.exit_code != 0
+        # exit 1 + the command's OWN message (a usage error would be exit 2
+        # without it — the original assertions passed before the command
+        # existed; P4 review tightened them).
+        assert result.exit_code == 1
+        assert "report not found" in result.output
         assert "Traceback" not in result.output
 
     def test_malformed_json_clean_error(self, runner, tmp_path: Path) -> None:
         path = tmp_path / "bad.json"
         path.write_text("{not json")
         result = runner.invoke(main, ["storage", "migration-report", "show", str(path)])
-        assert result.exit_code != 0
+        assert result.exit_code == 1
+        assert "unreadable report" in result.output
         assert "Traceback" not in result.output
+
+    def test_missing_summary_never_defaults_to_pass(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        """P4 review CRITICAL: a structurally damaged artifact (no summary)
+        must FAIL the gate loudly — never evaluate the predicate against
+        defaults. This is the deletion gate's last line of defense."""
+        path = tmp_path / "stub.json"
+        path.write_text(
+            json.dumps({"schema_version": "1", "migration_id": "x", "stores": []})
+        )
+        result = runner.invoke(main, ["storage", "migration-report", "show", str(path)])
+        assert result.exit_code == 1
+        assert "cannot evaluate the gate predicate" in result.output
+        assert "GATE: PASS" not in result.output
+        assert "Traceback" not in result.output
+
+    def test_malformed_total_failed_clean_error(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        report = _sample_report()
+        report["summary"]["total_failed"] = "oops"
+        path = _write(tmp_path, report)
+        result = runner.invoke(main, ["storage", "migration-report", "show", str(path)])
+        assert result.exit_code == 1
+        assert "not an integer" in result.output
+        assert "GATE: PASS" not in result.output
+        assert "Traceback" not in result.output
+
+    def test_gate_fail_carries_rerun_hint(self, runner, tmp_path: Path) -> None:
+        path = _write(tmp_path, _sample_report(failed=1))
+        result = runner.invoke(main, ["storage", "migration-report", "show", str(path)])
+        assert result.exit_code == 1
+        assert "idempotent" in result.output
 
     def test_unknown_schema_version_warns_but_displays(
         self, runner, tmp_path: Path,

--- a/tests/test_migration_report_show.py
+++ b/tests/test_migration_report_show.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-153 Phase 4 (bead nexus-j1l13, TDD-red): the triage surface —
+``nx storage migration-report show <path>``.
+
+The Phase-4 SQLite-deletion gate reads this report; the predicate is
+``summary.total_failed == 0`` (``failed`` is reserved for unparseable/
+unexpected — every expected-bad row is skipped/flagged/handled/
+schema_corrected). The reader lives in ``src/nexus/migration`` so it
+survives the RDR-152 P4 deletion of ``src/nexus/db/t2``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.migration.migration_report import IssueCollector, build_report
+
+
+def _sample_report(*, failed: int = 0, verification: str | None = "verified") -> dict:
+    c = IssueCollector()
+    c.count_read("taxonomy", "topic_assignments", 180806)
+    c.count_written("taxonomy", "topic_assignments", 129520)
+    for i in range(3):
+        c.record(
+            "taxonomy", "topic_assignments",
+            issue_class="orphan_parent",
+            constraint="topic_assignments.topic_id -> topics.id",
+            reason="topic_id references a deleted topic",
+            action="skipped",
+            sample_id=f"d{i}:t9",
+        )
+    c.record(
+        "catalog", "links",
+        issue_class="soft_dangler",
+        constraint="links.from_tumbler -> documents.tumbler",
+        reason="endpoint missing",
+        action="flagged",
+        sample_id="1.1.1:9.9.9",
+    )
+    c.record(
+        "telemetry", "hook_failures",
+        issue_class="format_anomaly",
+        constraint="hook_failures.occurred_at",
+        reason="space-form timestamp normalized",
+        action="handled",
+        sample_id="hf-1",
+    )
+    for i in range(failed):
+        c.record(
+            "memory", "memory",
+            issue_class="unexpected",
+            constraint="memory(project,title)",
+            reason="row rejected during import: boom",
+            action="failed",
+            sample_id=f"p:t{i}",
+        )
+    report = build_report(
+        c,
+        source={"sqlite": "/cfg/memory.db", "catalog_db": "/cfg/.catalog.db"},
+        target={"service_url": "http://127.0.0.1:5999"},
+        migration_id="11111111-2222-3333-4444-555555555555",
+    )
+    if verification is not None:
+        report["verification"] = verification
+    return report
+
+
+def _write(tmp_path: Path, report: dict) -> Path:
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(report))
+    return path
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestShowSummary:
+    def test_clean_report_gate_pass(self, runner, tmp_path: Path) -> None:
+        path = _write(tmp_path, _sample_report())
+        result = runner.invoke(main, ["storage", "migration-report", "show", str(path)])
+        assert result.exit_code == 0, result.output
+        out = result.output
+        assert "11111111-2222-3333-4444-555555555555" in out
+        assert "GATE: PASS" in out
+        assert "total_failed=0" in out
+        assert "verification: verified" in out
+
+    def test_max_severity_first_and_by_action_order(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        """max_severity leads the summary; by-action lines run
+        severity-descending (failed, skipped, flagged, handled,
+        schema_corrected)."""
+        path = _write(tmp_path, _sample_report())
+        result = runner.invoke(main, ["storage", "migration-report", "show", str(path)])
+        out = result.output
+        sev_idx = out.index("max_severity=3")
+        action_idx = out.index("skipped=3")
+        assert sev_idx < action_idx
+        assert out.index("skipped=3") < out.index("flagged=1")
+        assert out.index("flagged=1") < out.index("handled=1")
+
+    def test_issue_lines_severity_descending_with_samples(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        path = _write(tmp_path, _sample_report(failed=1))
+        result = runner.invoke(main, ["storage", "migration-report", "show", str(path)])
+        out = result.output
+        # The failed issue (severity 4) is listed before the skipped (3),
+        # which precedes flagged (2) and handled (1).
+        assert out.index("memory.memory") < out.index("taxonomy.topic_assignments")
+        assert out.index("taxonomy.topic_assignments") < out.index("catalog.links")
+        assert out.index("catalog.links") < out.index("telemetry.hook_failures")
+        # Issue lines carry class, action, count, and a sample.
+        assert "orphan_parent" in out
+        assert "count=51286" not in out  # exact fixture counts only
+        assert "count=3" in out
+        assert "d0:t9" in out
+
+    def test_failed_report_gate_fail_exit_nonzero(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        path = _write(tmp_path, _sample_report(failed=2))
+        result = runner.invoke(main, ["storage", "migration-report", "show", str(path)])
+        assert result.exit_code != 0
+        assert "GATE: FAIL" in result.output
+        assert "total_failed=2" in result.output
+
+    def test_verification_absent_reported_not_recorded(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        # Older artifacts (or per-store reports) carry no verification key —
+        # the viewer says so explicitly rather than implying it passed.
+        path = _write(tmp_path, _sample_report(verification=None))
+        result = runner.invoke(main, ["storage", "migration-report", "show", str(path)])
+        assert result.exit_code == 0, result.output
+        assert "verification: (not recorded)" in result.output
+
+    def test_missing_file_clean_error(self, runner, tmp_path: Path) -> None:
+        result = runner.invoke(main, [
+            "storage", "migration-report", "show", str(tmp_path / "absent.json"),
+        ])
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+
+    def test_malformed_json_clean_error(self, runner, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text("{not json")
+        result = runner.invoke(main, ["storage", "migration-report", "show", str(path)])
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+
+    def test_unknown_schema_version_warns_but_displays(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        report = _sample_report()
+        report["schema_version"] = "99"
+        path = _write(tmp_path, report)
+        result = runner.invoke(main, ["storage", "migration-report", "show", str(path)])
+        assert result.exit_code == 0, result.output
+        assert "schema_version 99" in result.output  # loud note
+        assert "GATE: PASS" in result.output         # best-effort display
+
+
+class TestReaderModule:
+    def test_reader_lives_in_migration_package(self) -> None:
+        """§Approach 1: the reader must survive the RDR-152 P4 deletion of
+        src/nexus/db/t2 — it lives in nexus.migration and imports nothing
+        from nexus.db.t2."""
+        import inspect
+
+        from nexus.migration import migration_report as mod
+
+        assert hasattr(mod, "load_report")
+        src = inspect.getsource(mod)
+        assert "nexus.db.t2" not in src
+
+    def test_load_report_round_trip(self, tmp_path: Path) -> None:
+        from nexus.migration.migration_report import load_report
+
+        report = _sample_report()
+        path = _write(tmp_path, report)
+        assert load_report(path) == report
+
+    def test_load_report_missing_fails_loud(self, tmp_path: Path) -> None:
+        from nexus.migration.migration_report import load_report
+
+        with pytest.raises(FileNotFoundError):
+            load_report(tmp_path / "absent.json")

--- a/tests/test_storage_migrate_all.py
+++ b/tests/test_storage_migrate_all.py
@@ -182,7 +182,7 @@ class TestVerificationLoudness:
         from nexus.commands.storage_cmd import _verify_pg_counts
 
         with patch(
-            "nexus.daemon.jar_lifecycle._psql_bin", return_value=None,
+            "nexus.commands.storage_cmd._psql_for_verify", return_value=None,
         ):
             outcome = _verify_pg_counts(
                 {"summary": {"total_written": 5}, "stores": []},

--- a/tests/test_storage_migrate_all.py
+++ b/tests/test_storage_migrate_all.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-153 Phase 3 (bead nexus-o61zy, TDD-red): ``nx storage migrate all``
+orchestrator + ``--report`` emission.
+
+Contract (RDR §Approach 3): stores run in the RDR-152 Phase 2 LADDER ORDER
+exactly (memory→plans→telemetry→taxonomy→aspects→chash→catalog LAST);
+per-store results merge into ONE report document; ``--report`` defaults to
+``<config>/migration-reports/migration-<id>.json`` so a run ALWAYS
+produces an artifact; count-verification FAILS/WARNS loudly when psql is
+unresolved — never SKIP-then-'all passed' (the nexus-r0esi hollow-verify
+bug).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.migration.etl_registry import EtlSources, StoreEtl
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+
+
+def _fake_etls(order_sink: list[str], *, fail_store: str | None = None):
+    """Seven fake StoreEtls that record execution order and feed the shared
+    collector realistic per-store data."""
+
+    def _runner(store: str):
+        def run(sources: EtlSources, collector) -> dict:
+            order_sink.append(store)
+            collector.count_read(store, store, 10)
+            collector.count_written(store, store, 10)
+            if store == "taxonomy":
+                collector.record(
+                    store, "topic_assignments",
+                    issue_class="orphan_parent",
+                    constraint="topic_assignments.topic_id -> topics.id",
+                    reason="deleted topic",
+                    action="skipped",
+                    sample_id="d:9",
+                )
+            if store == fail_store:
+                collector.record(
+                    store, store,
+                    issue_class="unexpected",
+                    constraint=store,
+                    reason="injected",
+                    action="failed",
+                    sample_id="x",
+                )
+            return {}
+
+        return run
+
+    return [
+        StoreEtl(s, _runner(s))
+        for s in ("catalog", "memory", "chash", "plans",
+                  "taxonomy", "telemetry", "aspects")  # deliberately shuffled
+    ]
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _invoke_all(runner, tmp_path: Path, order_sink: list[str], *args,
+                fail_store: str | None = None, verify: str = "verified"):
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "memory.db").touch()
+    (config_dir / ".catalog.db").touch()
+    with patch(
+        "nexus.commands.storage_cmd._build_store_etls",
+        return_value=_fake_etls(order_sink, fail_store=fail_store),
+    ), patch(
+        "nexus.commands.storage_cmd._verify_pg_counts",
+        return_value=verify,
+    ), patch.dict(
+        "os.environ", {"NEXUS_CONFIG_DIR": str(config_dir)},
+    ):
+        return runner.invoke(main, ["storage", "migrate", "all", *args]), config_dir
+
+
+# ── Orchestrator ─────────────────────────────────────────────────────────────
+
+
+class TestMigrateAll:
+    def test_runs_in_exact_ladder_order(self, runner, tmp_path: Path) -> None:
+        order: list[str] = []
+        result, _ = _invoke_all(runner, tmp_path, order)
+        assert result.exit_code == 0, result.output
+        assert order == [
+            "memory", "plans", "telemetry", "taxonomy",
+            "aspects", "chash", "catalog",
+        ]
+
+    def test_single_merged_report_with_rollup(self, runner, tmp_path: Path) -> None:
+        order: list[str] = []
+        report_path = tmp_path / "out" / "report.json"
+        result, _ = _invoke_all(
+            runner, tmp_path, order, "--report", str(report_path),
+        )
+        assert result.exit_code == 0, result.output
+        report = json.loads(report_path.read_text())
+        assert report["schema_version"] == "1"
+        stores = {s["store"] for s in report["stores"]}
+        assert stores == {
+            "memory", "plans", "telemetry", "taxonomy",
+            "aspects", "chash", "catalog",
+        }
+        assert report["summary"]["total_read"] == 70
+        assert report["summary"]["total_written"] == 70
+        assert report["summary"]["by_action"]["skipped"] == 1
+        assert report["summary"]["total_failed"] == 0
+        assert report["summary"]["max_severity"] == 3
+
+    def test_default_report_path_always_produces_artifact(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        order: list[str] = []
+        result, config_dir = _invoke_all(runner, tmp_path, order)
+        assert result.exit_code == 0, result.output
+        reports = list((config_dir / "migration-reports").glob("migration-*.json"))
+        assert len(reports) == 1
+        report = json.loads(reports[0].read_text())
+        assert report["migration_id"] in reports[0].name
+
+    def test_failed_rows_exit_nonzero_and_say_so(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        order: list[str] = []
+        result, _ = _invoke_all(
+            runner, tmp_path, order, fail_store="telemetry",
+        )
+        assert result.exit_code != 0
+        assert "total_failed=1" in result.output
+        assert "NOT clean" in result.output
+
+    def test_summary_lines_in_output(self, runner, tmp_path: Path) -> None:
+        order: list[str] = []
+        result, _ = _invoke_all(runner, tmp_path, order)
+        assert "total_failed=0" in result.output
+        assert "report:" in result.output  # the artifact path is announced
+
+
+# ── r0esi: verification must never silently skip ─────────────────────────────
+
+
+class TestVerificationLoudness:
+    def test_indeterminate_verification_warns_loudly_never_all_passed(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        order: list[str] = []
+        result, _ = _invoke_all(runner, tmp_path, order, verify="indeterminate")
+        assert result.exit_code == 0, result.output  # data migrated fine
+        out = result.output
+        assert "VERIFICATION INDETERMINATE" in out
+        assert "psql" in out
+        assert "all passed" not in out.lower()
+
+    def test_verified_counts_reported(self, runner, tmp_path: Path) -> None:
+        order: list[str] = []
+        result, _ = _invoke_all(runner, tmp_path, order, verify="verified")
+        assert "verification: verified" in result.output
+
+    def test_mismatch_fails_run(self, runner, tmp_path: Path) -> None:
+        order: list[str] = []
+        result, _ = _invoke_all(runner, tmp_path, order, verify="mismatch")
+        assert result.exit_code != 0
+        assert "VERIFICATION MISMATCH" in result.output
+
+    def test_verify_pg_counts_indeterminate_without_psql(
+        self, tmp_path: Path,
+    ) -> None:
+        """The unit seam: no resolvable psql → 'indeterminate', never
+        'verified' (the r0esi hollow-pass)."""
+        from nexus.commands.storage_cmd import _verify_pg_counts
+
+        with patch(
+            "nexus.daemon.jar_lifecycle._psql_bin", return_value=None,
+        ):
+            outcome = _verify_pg_counts(
+                {"summary": {"total_written": 5}, "stores": []},
+                {"PG_PORT": "5499", "NX_DB_ADMIN_USER": "a",
+                 "NX_DB_ADMIN_PASS": "p",
+                 "NX_DB_URL": "jdbc:postgresql://127.0.0.1:5499/nexus"},
+            )
+        assert outcome == "indeterminate"
+
+
+# ── Per-store --report ───────────────────────────────────────────────────────
+
+class TestPerStoreReport:
+    def test_migrate_memory_report_writes_single_store_document(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        config_dir = tmp_path / "cfg"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        db = config_dir / "t2.db"
+        db.touch()
+        report_path = tmp_path / "memory-report.json"
+
+        def fake_migrate(source_db_path, store, *, collector=None, **kw):
+            if collector is not None:
+                collector.count_read("memory", "memory", 4)
+                collector.count_written("memory", "memory", 4)
+            return {"read": 4, "written": 4}
+
+        class _FakeStore:
+            def __init__(self, *a, **k): ...
+            def close(self): ...
+
+        with patch(
+            "nexus.db.t2.memory_etl.migrate_memory_rows",
+            side_effect=fake_migrate,
+        ), patch(
+            "nexus.db.t2.http_memory_store.HttpMemoryStore", _FakeStore,
+        ), patch.dict(
+            "os.environ",
+            {"NEXUS_CONFIG_DIR": str(config_dir),
+             "NX_SERVICE_TOKEN": "t", "NX_SERVICE_URL": "http://127.0.0.1:1"},
+        ):
+            result = runner.invoke(main, [
+                "storage", "migrate", "memory",
+                "--db", str(db),
+                "--report", str(report_path),
+            ])
+        assert result.exit_code == 0, result.output
+        report = json.loads(report_path.read_text())
+        assert [s["store"] for s in report["stores"]] == ["memory"]
+        assert report["summary"]["total_written"] == 4

--- a/tests/test_storage_migrate_all.py
+++ b/tests/test_storage_migrate_all.py
@@ -234,3 +234,98 @@ class TestPerStoreReport:
         report = json.loads(report_path.read_text())
         assert [s["store"] for s in report["stores"]] == ["memory"]
         assert report["summary"]["total_written"] == 4
+
+
+class TestP3ReviewRegressions:
+    """P3.3/P3.4 review findings (2026-06-11)."""
+
+    def test_verification_verdict_recorded_in_artifact(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        """Critic S1: the artifact must be self-contained — the Phase-4
+        triage surface reads the JSON, not the run's stdout."""
+        order: list[str] = []
+        report_path = tmp_path / "r.json"
+        result, _ = _invoke_all(
+            runner, tmp_path, order, "--report", str(report_path),
+            verify="indeterminate",
+        )
+        assert result.exit_code == 0, result.output
+        report = json.loads(report_path.read_text())
+        assert report["verification"] == "indeterminate"
+
+    def test_per_store_default_path_always_produces_artifact(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        """Critic S3 / CRE L1: the per-store default-path guarantee."""
+        config_dir = tmp_path / "cfg"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        db = config_dir / "t2.db"
+        db.touch()
+
+        def fake_migrate(source_db_path, store, *, collector=None, **kw):
+            if collector is not None:
+                collector.count_read("memory", "memory", 1)
+                collector.count_written("memory", "memory", 1)
+            return {"read": 1, "written": 1}
+
+        class _FakeStore:
+            def __init__(self, *a, **k): ...
+            def close(self): ...
+
+        with patch(
+            "nexus.db.t2.memory_etl.migrate_memory_rows",
+            side_effect=fake_migrate,
+        ), patch(
+            "nexus.db.t2.http_memory_store.HttpMemoryStore", _FakeStore,
+        ), patch.dict(
+            "os.environ",
+            {"NEXUS_CONFIG_DIR": str(config_dir),
+             "NX_SERVICE_TOKEN": "t", "NX_SERVICE_URL": "http://127.0.0.1:1"},
+        ):
+            result = runner.invoke(main, [
+                "storage", "migrate", "memory", "--db", str(db),
+            ])
+        assert result.exit_code == 0, result.output
+        reports = list((config_dir / "migration-reports").glob("migration-*.json"))
+        assert len(reports) == 1
+
+    def test_per_store_crash_still_writes_artifact(
+        self, runner, tmp_path: Path,
+    ) -> None:
+        """Critic S2 / CRE M2: partial data beats no data — a mid-run crash
+        must still leave the triage artifact."""
+        config_dir = tmp_path / "cfg"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        db = config_dir / "t2.db"
+        db.touch()
+        report_path = tmp_path / "crash-report.json"
+
+        def exploding_migrate(source_db_path, store, *, collector=None, **kw):
+            if collector is not None:
+                collector.count_read("memory", "memory", 2)
+                collector.count_written("memory", "memory", 1)
+            raise RuntimeError("mid-run network partition")
+
+        class _FakeStore:
+            def __init__(self, *a, **k): ...
+            def close(self): ...
+
+        with patch(
+            "nexus.db.t2.memory_etl.migrate_memory_rows",
+            side_effect=exploding_migrate,
+        ), patch(
+            "nexus.db.t2.http_memory_store.HttpMemoryStore", _FakeStore,
+        ), patch.dict(
+            "os.environ",
+            {"NEXUS_CONFIG_DIR": str(config_dir),
+             "NX_SERVICE_TOKEN": "t", "NX_SERVICE_URL": "http://127.0.0.1:1"},
+        ):
+            result = runner.invoke(main, [
+                "storage", "migrate", "memory", "--db", str(db),
+                "--report", str(report_path),
+            ])
+        assert result.exit_code != 0
+        assert "ETL failed" in result.output
+        report = json.loads(report_path.read_text())
+        assert report["summary"]["total_read"] == 2  # partial data preserved


### PR DESCRIPTION
## Summary

Implements RDR-153 end to end (epic `nexus-dfwh0`, all four phases gated): the data-quality policy layer + structured issue reporting over the RDR-152 per-store ETLs, making the SQLite→Postgres T2 migration triageable, recoverable, and gate-able. This is a prerequisite for RDR-156 P0.3/P2.2 (world-blocked on `summary.total_failed == 0`) and the RDR-152 Phase-4 SQLite deletion gate.

## Phases

1. **Issue-record primitive** (`nexus.migration.migration_report`): `MigrationIssue` (class = diagnosis, action = policy outcome, exact severity ordinals), `IssueCollector` (per-(store,table) buckets, 200-cap samples, one-time `record_event`), `build_report` (schema_version=1, `by_action` gate rollup), `load_report`. Survives the future `db/t2` deletion (test-locked: zero t2 imports).
2. **Per-store policy integration** across all seven ETLs: taxonomy orphan pre-check (skip-and-record, ':' samples) + doc_id-is-chash schema correction recorded once; telemetry timestamp canonicalization to **offset-qualified** ISO (root-causes and fixes `nexus-9sjn3` — hook_failures 0/234: the Java strict parser requires an offset) + plan-dangler flagging; catalog dangling-link flagging; aspects/queue orphan skip vs the live catalog; complete never-silent catch-all coverage (every import rejection records a `failed` issue).
3. **Orchestration**: `nx storage migrate all` (exact RDR-152 ladder order, one merged report — default artifact path always written, verification verdict recorded IN the artifact), `--report` on every store command (crash-safe: partial data beats no data), loud count verification (`VERIFICATION INDETERMINATE` can never read as a pass) — closes `nexus-r0esi` at both the nx and prod-copy.sh layers.
4. **Triage surface**: `nx storage migration-report show` — gate verdict (scriptable exit), max_severity first, severity-descending rollups and issue lines; the gate **never defaults to pass** on structurally damaged artifacts.

## Review rigor

Every phase ran the full ladder (code-review-expert + substantive-critic + test-validator on P2/P3 + phase gate). The ladder caught and fixed **three Criticals** that green tests alone missed: silent telemetry/catalog failure paths that could falsify the gate (P2), a missing import that would have crashed every aspects migration (P3), and a default-to-pass hole in the deletion-gate predicate itself (P4, live-verified). Final cross-walk: all four §Approach items → closed bead chains.

## Verification

193 tests across the report/registry/ETL-policy/orchestrator/show suites (all RED-first); 638-test regression sweep over tests/db + tests/migration green; conservation identities (read == written + skipped + failed) test-locked; bonus root-cause fix for nexus-9sjn3 verified against the Java parser semantics.

## Post-merge

- `bd`: epic nexus-dfwh0 closes; RDR-153 file flips to closed.
- The REAL migration run (`nx storage migrate all` against production SQLite) produces the gate artifact that unblocks RDR-156 P0.3 VALIDATE and the non-vacuous manifest validation.