### PR TITLE
fix: restart PG before jar respawn on simultaneous JAR+PG death

### DIFF
--- a/src/nexus/daemon/storage_service_daemon.py
+++ b/src/nexus/daemon/storage_service_daemon.py
@@ -723,6 +723,14 @@ class StorageServiceSupervisor:
         Reuses ``pg_provision._start_cluster`` so PG lifecycle logic stays
         in the provisioner, not here. Raises ``StorageServiceStartError``
         if PG cannot be started.
+
+        Known limitation (nexus-14k0m critic): "accepting" means TCP
+        accept, not query readiness. A PG in crash recovery (WAL replay)
+        accepts connections while rejecting queries, so a success here
+        does not guarantee the jar's subsequent /health ready-wait (60s)
+        will pass — a long replay can still burn one respawn attempt. A
+        ``pg_isready``-grade probe is the follow-on if that residual is
+        ever observed in practice.
         """
         if _port_accepting(_SERVICE_HOST, self._pg_port):
             _log.debug("storage_service_pg_already_running", port=self._pg_port)
@@ -1047,6 +1055,13 @@ def _supervise_until_stopped(
                 # burned down with zero pg_ctl attempts. Restart PG FIRST;
                 # if PG is unrecoverable, respawning the jar is futile —
                 # exit 4 (the PG-unrecoverable contract) with budget intact.
+                # Covers BOTH routes into jar_running=False (process exit
+                # hardcodes pg_ok=False; stuck-JVM carries a live probe) —
+                # _ensure_pg_running() re-probes, so a hardcoded False with
+                # PG actually up is a cheap no-op, never a false exit 4.
+                # Loop invariant: heartbeat_once() returned (False, False)
+                # with _proc/_supervisor still set (stop() only runs after
+                # the loop) — do not call sup.stop() mid-loop.
                 _log.warning(
                     "storage_service_jar_and_pg_died",
                     msg="jar and PG both down; restarting PG before jar respawn",
@@ -1056,7 +1071,7 @@ def _supervise_until_stopped(
                     _log.info("storage_service_pg_restarted_before_respawn")
                 except StorageServiceStartError as exc:
                     _log.error(
-                        "storage_service_pg_restart_failed",
+                        "storage_service_jar_and_pg_restart_failed",
                         error=str(exc),
                         msg="Could not restart PG; supervisor exiting",
                     )

--- a/src/nexus/daemon/storage_service_daemon.py
+++ b/src/nexus/daemon/storage_service_daemon.py
@@ -950,6 +950,11 @@ def run_storage_supervisor(
     PG-only failure: when heartbeat_once() returns (True, False), the run loop
     calls _ensure_pg_running() directly — a PG restart without a jar respawn.
 
+    Simultaneous JAR+PG death (False, False): PG is restarted FIRST, then the
+    jar respawns (nexus-14k0m) — a respawn against a dead PG can never pass
+    /health and would burn the restart budget with no PG attempt. If PG is
+    unrecoverable the supervisor exits 4 without consuming respawn budget.
+
     Jar failure or stuck JVM: when heartbeat_once() returns (False, _),
     auto-restart up to _MAX_RESTART_ATTEMPTS times in the current window.
     The (False, _) signal is raised both when the jar process exits AND when
@@ -1034,10 +1039,29 @@ def _supervise_until_stopped(
 
         if not jar_running:
             # Jar exited (or stuck-JVM threshold hit) — attempt auto-restart.
-            # NOTE: _respawn() does NOT call _ensure_pg_running(); if PG is also
-            # down the new jar's /health will keep failing until PG is restarted
-            # (next loop's `elif not pg_ok` branch) or the restart budget is
-            # exhausted and the supervisor exits.
+            if not pg_ok:
+                # nexus-14k0m: simultaneous JAR+PG death. _respawn() never
+                # starts PG, and the `elif not pg_ok` branch below only fires
+                # while the jar is ALIVE — so without this, the respawned
+                # jar's /health could never pass and the restart budget
+                # burned down with zero pg_ctl attempts. Restart PG FIRST;
+                # if PG is unrecoverable, respawning the jar is futile —
+                # exit 4 (the PG-unrecoverable contract) with budget intact.
+                _log.warning(
+                    "storage_service_jar_and_pg_died",
+                    msg="jar and PG both down; restarting PG before jar respawn",
+                )
+                try:
+                    sup._ensure_pg_running()
+                    _log.info("storage_service_pg_restarted_before_respawn")
+                except StorageServiceStartError as exc:
+                    _log.error(
+                        "storage_service_pg_restart_failed",
+                        error=str(exc),
+                        msg="Could not restart PG; supervisor exiting",
+                    )
+                    exit_code = 4
+                    break
             _log.warning("storage_service_jar_exited", msg="jar child gone; attempting restart")
             try:
                 sup._respawn()

--- a/tests/daemon/test_storage_service_daemon.py
+++ b/tests/daemon/test_storage_service_daemon.py
@@ -1298,7 +1298,12 @@ class TestSimultaneousJarPgDeath:
     """nexus-14k0m (P5 gate code-review HIGH): heartbeat (False, False)
     previously hit only the ``not jar_running`` branch, whose _respawn()
     never restarts PG — the new jar's /health can never pass, the restart
-    budget burns down, and the supervisor exits without ONE pg_ctl attempt."""
+    budget burns down, and the supervisor exits without ONE pg_ctl attempt.
+
+    The (False, False) beat models BOTH real routes into jar_running=False
+    (process exit, which hardcodes pg_ok=False; stuck-JVM threshold, which
+    carries a live PG probe) — at the run-loop seam they are
+    indistinguishable, so one scripted beat covers both (CRE M2)."""
 
     def _run(self, sup_factory):
         import threading
@@ -1331,6 +1336,7 @@ class TestSimultaneousJarPgDeath:
             )
         )
         assert code == 4, "PG-unrecoverable is the exit-4 contract"
+        assert "ensure_pg" in sup.calls, "exit 4 must come FROM the PG attempt"
         assert "respawn" not in sup.calls, (
             "respawning the jar with PG down is futile budget burn"
         )

--- a/tests/daemon/test_storage_service_daemon.py
+++ b/tests/daemon/test_storage_service_daemon.py
@@ -1241,3 +1241,114 @@ class TestSchemaSkewGateWiring:
             payload = sup.start()
         gate.assert_called_once()
         assert payload["port"] == 19500
+
+
+# ---------------------------------------------------------------------------
+# nexus-14k0m: simultaneous JAR+PG death must attempt PG recovery
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedSupervisor:
+    """run-loop double for ``_supervise_until_stopped``: heartbeat_once pops
+    scripted (jar_running, pg_ok) tuples; every lifecycle call is recorded in
+    ``calls`` so ordering assertions are exact."""
+
+    def __init__(
+        self,
+        beats: list[tuple[bool, bool]],
+        stop_requested,
+        *,
+        ensure_pg_raises: Exception | None = None,
+        respawn_raises: Exception | None = None,
+    ) -> None:
+        self._beats = list(beats)
+        self._stop = stop_requested
+        self._ensure_pg_raises = ensure_pg_raises
+        self._respawn_raises = respawn_raises
+        self.calls: list[str] = []
+
+    def start(self) -> None:
+        self.calls.append("start")
+
+    def heartbeat_once(self) -> tuple[bool, bool]:
+        if not self._beats:
+            # Script exhausted: end the loop instead of inventing beats.
+            self._stop.set()
+            return True, True
+        beat = self._beats.pop(0)
+        if not self._beats:
+            self._stop.set()  # last scripted beat — loop exits after handling
+        return beat
+
+    def _ensure_pg_running(self) -> None:
+        self.calls.append("ensure_pg")
+        if self._ensure_pg_raises is not None:
+            raise self._ensure_pg_raises
+
+    def _respawn(self) -> None:
+        self.calls.append("respawn")
+        if self._respawn_raises is not None:
+            raise self._respawn_raises
+
+    def stop(self) -> None:
+        self.calls.append("stop")
+
+
+class TestSimultaneousJarPgDeath:
+    """nexus-14k0m (P5 gate code-review HIGH): heartbeat (False, False)
+    previously hit only the ``not jar_running`` branch, whose _respawn()
+    never restarts PG — the new jar's /health can never pass, the restart
+    budget burns down, and the supervisor exits without ONE pg_ctl attempt."""
+
+    def _run(self, sup_factory):
+        import threading
+
+        from nexus.daemon import storage_service_daemon as ssd
+
+        stop = threading.Event()
+        sup = sup_factory(stop)
+        with patch.object(ssd, "DEFAULT_HEARTBEAT_INTERVAL", 0.0):
+            code = ssd._supervise_until_stopped(sup, stop, lambda: None)
+        return sup, code
+
+    def test_pg_restarted_before_jar_respawn(self) -> None:
+        sup, code = self._run(
+            lambda stop: _ScriptedSupervisor([(False, False)], stop)
+        )
+        assert code == 0
+        assert "ensure_pg" in sup.calls, (
+            "simultaneous death must attempt PG recovery, not only respawn"
+        )
+        assert sup.calls.index("ensure_pg") < sup.calls.index("respawn"), (
+            "PG must be up BEFORE the jar respawn or /health can never pass"
+        )
+
+    def test_pg_restart_failure_exits_4_without_burning_respawn(self) -> None:
+        sup, code = self._run(
+            lambda stop: _ScriptedSupervisor(
+                [(False, False)], stop,
+                ensure_pg_raises=StorageServiceStartError("pg_ctl failed"),
+            )
+        )
+        assert code == 4, "PG-unrecoverable is the exit-4 contract"
+        assert "respawn" not in sup.calls, (
+            "respawning the jar with PG down is futile budget burn"
+        )
+
+    def test_jar_only_death_does_not_touch_pg(self) -> None:
+        sup, code = self._run(
+            lambda stop: _ScriptedSupervisor([(False, True)], stop)
+        )
+        assert code == 0
+        assert "respawn" in sup.calls
+        assert "ensure_pg" not in sup.calls, (
+            "jar-only death keeps the existing no-PG-churn behaviour"
+        )
+
+    def test_pg_only_death_unchanged(self) -> None:
+        sup, code = self._run(
+            lambda stop: _ScriptedSupervisor([(True, False)], stop)
+        )
+        assert code == 0
+        assert sup.calls.count("ensure_pg") == 1
+        assert "respawn" not in sup.calls


### PR DESCRIPTION
## Problem (nexus-14k0m, P5-gate code-review HIGH)

When the JVM and Postgres die together, `heartbeat_once()` returns `(jar_running=False, pg_ok=False)` and the run loop hits only the `not jar_running` branch. `_respawn()` never starts PG, and the `elif not pg_ok` PG-recovery branch only fires while the jar is *alive* — so the respawned jar's `/health` could never pass, the restart budget burned down, and the supervisor exited code 3 with **zero** `pg_ctl` attempts. Only an external process supervisor could recover the node.

## Fix

On a `(False, False)` heartbeat the loop restarts PG **first**, then respawns the jar. If PG is unrecoverable, the supervisor exits 4 (the existing PG-unrecoverable contract) without consuming respawn budget — respawning a jar against a dead PG is futile. Both routes into `jar_running=False` are covered (process exit hardcodes `pg_ok=False`; stuck-JVM carries a live probe); `_ensure_pg_running()` re-probes, so a hardcoded `False` with PG actually up is a cheap no-op, never a false exit 4.

## Review ladder

code-review-expert: APPROVED, 0 Critical/High; polish applied (distinct `storage_service_jar_and_pg_restart_failed` event so alerting can separate the two exit-4 sources; exit-4 provenance assertion; loop-invariant and both-routes comments). substantive-critic: justified, 0 Critical; two pre-existing residuals documented rather than coded per no-preventive-scope: (1) `_ensure_pg_running` confirms TCP accept, not query readiness — a long WAL replay can still burn one respawn attempt (now in the docstring; `pg_isready`-grade probe is the follow-on if observed); (2) a narrow TOCTOU where PG dies between a `(False, True)` beat and the respawn's ready-wait — same class, one-cycle-deep, recovered on the next beat.

## Testing

New `TestSimultaneousJarPgDeath` (4 tests, scripted-supervisor double against `_supervise_until_stopped`): PG-before-respawn order pin, exit-4-without-budget-burn with provenance, jar-only and PG-only regression guards. TDD red confirmed pre-fix. Daemon suite green (506 passed).

Bead: nexus-14k0m (blocks nexus-gmiaf.24, the RDR-152 P4 lifecycle-class deletion).