### PR TITLE
docs: RDR-106 superseded by RDR-156

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -128,7 +128,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-103](rdr-103-catalog-collection-name-authority.md) | Catalog as Collection-Name Authority | Architecture | Closed | 2026-05-03 |
 | [RDR-104](rdr-104-incremental-catalog-projection-rebuild.md) | Incremental Catalog Projection Rebuild | Architecture | Closed | 2026-05-05 |
 | [RDR-105](rdr-105-t1-chroma-architecture-env-passdown.md) | T1 Chroma Architecture: Eliminate On-Disk Session Records via Env-Var Passdown | Architecture | Closed | 2026-05-07 |
-| [RDR-106](rdr-106-soft-delete-tombstone-column.md) | Soft-Delete via Tombstone Columns on Catalog Projection | Architecture | Draft | 2026-05-08 |
+| [RDR-106](rdr-106-soft-delete-tombstone-column.md) | Soft-Delete via Tombstone Columns on Catalog Projection | Architecture | Superseded by RDR-156 | 2026-05-08 |
 | [RDR-107](rdr-107-t3-chunk-soft-delete.md) | T3 Chunk Soft-Delete via Tombstone Metadata | Architecture | Superseded by RDR-108 | 2026-05-08 |
 | [RDR-108](rdr-108-graph-identity-normalization.md) | Graph Identity Normalization: Catalog Holds the Tree, T3 is a Content-Addressed Blob Store | Architecture | Closed 2026-05-20 | 2026-05-08 |
 | [RDR-109](rdr-109-honest-naming-and-cross-encoder-salience.md) | Honest Local-Mode Naming and Cross-Encoder Salience: Two Naming/Scoring Designs Touching the Same Test-Suite Mode-Default Surface | Architecture | Closed 2026-05-20 | 2026-05-10 |

--- a/docs/rdr/rdr-106-soft-delete-tombstone-column.md
+++ b/docs/rdr/rdr-106-soft-delete-tombstone-column.md
@@ -2,7 +2,8 @@
 title: "Soft-Delete via Tombstone Columns on Catalog Projection"
 id: RDR-106
 type: Architecture
-status: draft
+status: superseded
+superseded-by: RDR-156
 priority: high
 author: Hal Hildebrand
 reviewed-by: self


### PR DESCRIPTION
Flips RDR-106 frontmatter to `status: superseded` + `superseded-by: RDR-156` and updates the README index row (style matches the RDR-107 supersession row).

Disposition per RDR-156 acceptance: the catalog-projection tombstone scope is absorbed into RDR-156 P1; the SQLite-era backup/undelete mechanism remains shipped history; the event-sourced projector-verb scope died with events.jsonl in RDR-152 (RDR-156 Decision 6 scope boundary). File retained per the never-delete-RDRs rule.

Bead: nexus-70r3c.21 (standalone admin task under epic nexus-70r3c).