### PR TITLE
feat: RDR-156 P0 — collection-registry FKs, empty-table hygiene, registration-before-write

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -1505,10 +1505,10 @@ public final class CatalogRepository {
                 + "  embedding_model=EXCLUDED.embedding_model, model_version=EXCLUDED.model_version,"
                 + "  display_name=EXCLUDED.display_name, legacy_grandfathered=EXCLUDED.legacy_grandfathered,"
                 + "  superseded_by=EXCLUDED.superseded_by,"
-                + "  superseded_at=EXCLUDED.superseded_at::timestamptz,"
-                + "  created_at=EXCLUDED.created_at::timestamptz"
-                + " WHERE nexus.catalog_collections.embedding_model='' AND nexus.catalog_collections.content_type=''"
-                + "  AND nexus.catalog_collections.owner_id=''",
+                + "  superseded_at=EXCLUDED.superseded_at,"
+                + "  created_at=EXCLUDED.created_at"
+                + " WHERE catalog_collections.embedding_model='' AND catalog_collections.content_type=''"
+                + "  AND catalog_collections.owner_id=''",
                 tenant,
                 s(coll, "name"), nne(s(coll, "content_type")),
                 nne(s(coll, "owner_id")), nne(s(coll, "embedding_model")),

--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -187,6 +187,9 @@ public final class CatalogRepository {
     private static final Field<String>  EX_COL_MVER   = DSL.field("EXCLUDED.model_version", String.class);
     private static final Field<String>  EX_COL_DNAME  = DSL.field("EXCLUDED.display_name", String.class);
     private static final Field<Integer> EX_COL_LEGCY  = DSL.field("EXCLUDED.legacy_grandfathered", Integer.class);
+    private static final Field<String>  EX_COL_SUPBY  = DSL.field("EXCLUDED.superseded_by",  String.class);
+    private static final Field<String>  EX_COL_SUPAT  = DSL.field("EXCLUDED.superseded_at",  String.class);
+    private static final Field<String>  EX_COL_CRTAT  = DSL.field("EXCLUDED.created_at",     String.class);
 
     private static final Field<String>  EX_META_VAL   = DSL.field("EXCLUDED.value",       String.class);
     private static final Field<String>  EX_CHK_CHASH  = DSL.field("EXCLUDED.chash",       String.class);
@@ -883,26 +886,25 @@ public final class CatalogRepository {
     /** Upsert a collection. */
     public void upsertCollection(String tenant, Map<String, Object> coll) {
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.insertInto(T_COLLS,
-                    F_COL_TENANT, F_COL_NAME, F_COL_CTYPE, F_COL_OWNER,
-                    F_COL_EMBD, F_COL_MVER, F_COL_DNAME, F_COL_LEGCY,
-                    F_COL_SUPBY, F_COL_SUPAT, F_COL_CRTAT)
-               .values(tenant,
-                       s(coll,"name"), nne(s(coll,"content_type")),
-                       nne(s(coll,"owner_id")), nne(s(coll,"embedding_model")),
-                       nne(s(coll,"model_version")), nne(s(coll,"display_name")),
-                       ni(i(coll,"legacy_grandfathered"), 0),
-                       nne(s(coll,"superseded_by")), nne(s(coll,"superseded_at")),
-                       nne(s(coll,"created_at")))
-               .onConflict(F_COL_TENANT, F_COL_NAME)
-               .doUpdate()
-               .set(F_COL_CTYPE, EX_COL_CTYPE)
-               .set(F_COL_OWNER, EX_COL_OWNER)
-               .set(F_COL_EMBD,  EX_COL_EMBD)
-               .set(F_COL_MVER,  EX_COL_MVER)
-               .set(F_COL_DNAME, EX_COL_DNAME)
-               .set(F_COL_LEGCY, EX_COL_LEGCY)
-               .execute();
+            // Raw SQL for superseded_at / created_at: these are timestamptz NULL columns after
+            // catalog-002-1-temporal-typing (RDR-156 P0.2).  jOOQ Field<String> would bind as
+            // varchar which PostgreSQL rejects; ?::timestamptz accepts ISO-8601 strings or NULL.
+            ctx.execute(
+                "INSERT INTO nexus.catalog_collections"
+                + " (tenant_id, name, content_type, owner_id, embedding_model, model_version,"
+                + "  display_name, legacy_grandfathered, superseded_by, superseded_at, created_at)"
+                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?::timestamptz, ?::timestamptz)"
+                + " ON CONFLICT (tenant_id, name) DO UPDATE SET"
+                + "  content_type=EXCLUDED.content_type, owner_id=EXCLUDED.owner_id,"
+                + "  embedding_model=EXCLUDED.embedding_model, model_version=EXCLUDED.model_version,"
+                + "  display_name=EXCLUDED.display_name, legacy_grandfathered=EXCLUDED.legacy_grandfathered",
+                tenant,
+                s(coll, "name"), nne(s(coll, "content_type")),
+                nne(s(coll, "owner_id")), nne(s(coll, "embedding_model")),
+                nne(s(coll, "model_version")), nne(s(coll, "display_name")),
+                ni(i(coll, "legacy_grandfathered"), 0),
+                nne(s(coll, "superseded_by")), nz(s(coll, "superseded_at")),
+                nz(s(coll, "created_at")));
             return null;
         });
     }
@@ -936,14 +938,17 @@ public final class CatalogRepository {
         );
     }
 
-    /** Supersede a collection. */
+    /**
+     * Supersede a collection.
+     * nz() for superseded_at: '' is invalid in the timestamptz column after catalog-002-1-temporal-typing.
+     */
     public int supersedeCollection(String tenant, String name, String supersededBy, String supersededAt) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.update(T_COLLS)
-               .set(F_COL_SUPBY, supersededBy)
-               .set(F_COL_SUPAT, supersededAt)
-               .where(F_COL_NAME.eq(name))
-               .execute()
+            // superseded_at is timestamptz NULL after catalog-002-1-temporal-typing; use ?::timestamptz cast.
+            ctx.execute(
+                "UPDATE nexus.catalog_collections SET superseded_by=?, superseded_at=?::timestamptz"
+                + " WHERE tenant_id=? AND name=?",
+                supersededBy, nz(supersededAt), tenant, name)
         );
     }
 
@@ -1473,23 +1478,44 @@ public final class CatalogRepository {
         });
     }
 
-    /** Fidelity-preserving collection import. ON CONFLICT DO NOTHING. */
+    /**
+     * Fidelity-preserving collection import.
+     *
+     * <p>ON CONFLICT (tenant_id, name): performs DO UPDATE only when the existing row is a
+     * backfill/auto-registered STUB (embedding_model = '' AND content_type = '' AND owner_id = '').
+     * Stub rows are created by fk-002-0-backfill-stubs or by PgVectorRepository.upsertChunks
+     * auto-registration.  They must be upgradable by the RDR-153 catalog ETL, but a re-run
+     * must never clobber genuinely-newer live rows.
+     *
+     * <p>nz() for timestamptz columns: '' is invalid in timestamptz; NULL means "not set".
+     * catalog-002-1-temporal-typing (RDR-156 P0.2) converted these columns to timestamptz NULL.
+     */
     public void importCollection(String tenant, Map<String, Object> coll) {
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.insertInto(T_COLLS,
-                    F_COL_TENANT, F_COL_NAME, F_COL_CTYPE, F_COL_OWNER,
-                    F_COL_EMBD, F_COL_MVER, F_COL_DNAME, F_COL_LEGCY,
-                    F_COL_SUPBY, F_COL_SUPAT, F_COL_CRTAT)
-               .values(tenant,
-                       s(coll,"name"), nne(s(coll,"content_type")),
-                       nne(s(coll,"owner_id")), nne(s(coll,"embedding_model")),
-                       nne(s(coll,"model_version")), nne(s(coll,"display_name")),
-                       ni(i(coll,"legacy_grandfathered"), 0),
-                       nne(s(coll,"superseded_by")), nne(s(coll,"superseded_at")),
-                       nne(s(coll,"created_at")))
-               .onConflict(F_COL_TENANT, F_COL_NAME)
-               .doNothing()
-               .execute();
+            // Raw SQL for superseded_at / created_at: timestamptz NULL after catalog-002-1-temporal-typing.
+            // DO UPDATE WHERE stub: only upgrades rows where all three discriminator columns are empty
+            // (i.e. auto-registered stubs from RDR-156 P0.2 ensure-registration steps).
+            ctx.execute(
+                "INSERT INTO nexus.catalog_collections"
+                + " (tenant_id, name, content_type, owner_id, embedding_model, model_version,"
+                + "  display_name, legacy_grandfathered, superseded_by, superseded_at, created_at)"
+                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?::timestamptz, ?::timestamptz)"
+                + " ON CONFLICT (tenant_id, name) DO UPDATE SET"
+                + "  content_type=EXCLUDED.content_type, owner_id=EXCLUDED.owner_id,"
+                + "  embedding_model=EXCLUDED.embedding_model, model_version=EXCLUDED.model_version,"
+                + "  display_name=EXCLUDED.display_name, legacy_grandfathered=EXCLUDED.legacy_grandfathered,"
+                + "  superseded_by=EXCLUDED.superseded_by,"
+                + "  superseded_at=EXCLUDED.superseded_at::timestamptz,"
+                + "  created_at=EXCLUDED.created_at::timestamptz"
+                + " WHERE nexus.catalog_collections.embedding_model='' AND nexus.catalog_collections.content_type=''"
+                + "  AND nexus.catalog_collections.owner_id=''",
+                tenant,
+                s(coll, "name"), nne(s(coll, "content_type")),
+                nne(s(coll, "owner_id")), nne(s(coll, "embedding_model")),
+                nne(s(coll, "model_version")), nne(s(coll, "display_name")),
+                ni(i(coll, "legacy_grandfathered"), 0),
+                nne(s(coll, "superseded_by")), nz(s(coll, "superseded_at")),
+                nz(s(coll, "created_at")));
             return null;
         });
     }
@@ -1624,6 +1650,15 @@ public final class CatalogRepository {
 
     /** Non-null empty: returns "" if null. */
     private static String nne(String v) { return v != null ? v : ""; }
+
+    /**
+     * Null-or-empty normalizer: returns null for null or blank/empty strings, else returns v.
+     * Use for timestamptz columns (catalog_collections.created_at / superseded_at) where the
+     * SQLite heritage used '' as the empty sentinel.  Binding '' into a timestamptz column
+     * fails at the JDBC driver layer; NULL is the correct representation of "not set".
+     * catalog-002-1-temporal-typing (RDR-156 P0.2) converts these columns to timestamptz NULL.
+     */
+    private static String nz(String v) { return (v != null && !v.isEmpty()) ? v : null; }
 
     /** Non-null integer: returns def if null. */
     private static int ni(Integer v, int def) { return v != null ? v : def; }

--- a/service/src/main/java/dev/nexus/service/db/ChashRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/ChashRepository.java
@@ -67,9 +67,17 @@ public final class ChashRepository {
      * RDR-156 P0.2: ensure catalog_collections has a stub row for the given collection
      * before any chash_index write that carries physical_collection.
      * Idempotent — ON CONFLICT DO NOTHING.
+     *
+     * <p>physical_collection is NOT NULL in chash_index, so a blank/null value is a caller
+     * error — fail loud rather than silently skipping the registration step and letting the
+     * subsequent INSERT fail with a cryptic FK violation.
+     *
+     * @throws IllegalArgumentException if collection is null or blank
      */
     private static void ensureCollectionRegistered(DSLContext ctx, String tenant, String collection) {
-        if (collection == null || collection.isBlank()) return;
+        if (collection == null || collection.isBlank()) {
+            throw new IllegalArgumentException("physical_collection must not be blank");
+        }
         ctx.execute(
             "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES (?, ?) " +
             "ON CONFLICT (tenant_id, name) DO NOTHING",

--- a/service/src/main/java/dev/nexus/service/db/ChashRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/ChashRepository.java
@@ -63,6 +63,19 @@ public final class ChashRepository {
         this.tenantScope = tenantScope;
     }
 
+    /**
+     * RDR-156 P0.2: ensure catalog_collections has a stub row for the given collection
+     * before any chash_index write that carries physical_collection.
+     * Idempotent — ON CONFLICT DO NOTHING.
+     */
+    private static void ensureCollectionRegistered(DSLContext ctx, String tenant, String collection) {
+        if (collection == null || collection.isBlank()) return;
+        ctx.execute(
+            "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES (?, ?) " +
+            "ON CONFLICT (tenant_id, name) DO NOTHING",
+            tenant, collection);
+    }
+
     // ── upsert ─────────────────────────────────────────────────────────────────
 
     /**
@@ -80,6 +93,8 @@ public final class ChashRepository {
 
         OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
         tenantScope.withTenant(tenant, ctx -> {
+            // RDR-156 P0.2: ensure catalog_collections has a stub row before the chash write.
+            ensureCollectionRegistered(ctx, tenant, collection);
             ctx.insertInto(CHASH_INDEX,
                             F_TENANT, F_CHASH, F_COLLECTION, F_CREATED_AT)
                .values(tenant, chash, collection, now)
@@ -109,6 +124,8 @@ public final class ChashRepository {
         if (valid.isEmpty()) return;
 
         tenantScope.withTenant(tenant, ctx -> {
+            // RDR-156 P0.2: ensure catalog_collections has a stub row before the chash writes.
+            ensureCollectionRegistered(ctx, tenant, collection);
             var insert = ctx.insertInto(CHASH_INDEX,
                                         F_TENANT, F_CHASH, F_COLLECTION, F_CREATED_AT);
             var step = insert.values(tenant, valid.get(0), collection, now);
@@ -197,6 +214,8 @@ public final class ChashRepository {
      */
     public int renameCollection(String tenant, String oldCollection, String newCollection) {
         return tenantScope.withTenant(tenant, ctx -> {
+            // RDR-156 P0.2: ensure the new collection is registered before renaming.
+            ensureCollectionRegistered(ctx, tenant, newCollection);
             // Drop rows in new that would collide with the rename
             ctx.deleteFrom(CHASH_INDEX)
                .where(F_COLLECTION.eq(newCollection)
@@ -325,6 +344,8 @@ public final class ChashRepository {
 
         final OffsetDateTime ts = createdAt;
         tenantScope.withTenant(tenant, ctx -> {
+            // RDR-156 P0.2: ensure catalog_collections has a stub row before the chash write.
+            ensureCollectionRegistered(ctx, tenant, collection);
             ctx.insertInto(CHASH_INDEX,
                             F_TENANT, F_CHASH, F_COLLECTION, F_CREATED_AT)
                .values(tenant, chash, collection, ts)

--- a/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
@@ -86,6 +86,19 @@ public final class TaxonomyRepository {
         return dt == null ? null : dt.format(UTC_SECOND);
     }
 
+    /**
+     * RDR-156 P0.2: ensure catalog_collections has a stub row for the given collection
+     * before any topic_assignment write that carries source_collection.
+     * Idempotent — ON CONFLICT DO NOTHING.
+     */
+    private static void ensureCollectionRegistered(DSLContext ctx, String tenant, String collection) {
+        if (collection == null || collection.isBlank()) return;
+        ctx.execute(
+            "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES (?, ?) " +
+            "ON CONFLICT (tenant_id, name) DO NOTHING",
+            tenant, collection);
+    }
+
     private static Map<String, Object> buildTopicMap(org.jooq.Record r) {
         var m = new LinkedHashMap<String, Object>();
         m.put("id",            r.get("id",             Long.class));
@@ -314,6 +327,8 @@ public final class TaxonomyRepository {
                              String sourceCollection, String assignedAt) {
         tenantScope.withTenant(tenant, ctx -> {
             if ("projection".equals(assignedBy)) {
+                // RDR-156 P0.2: ensure collection is registered before the assignment write
+                ensureCollectionRegistered(ctx, tenant, sourceCollection);
                 String tsStr = fmtTs(assignedAt != null ? parseTs(assignedAt)
                                                         : OffsetDateTime.now(ZoneOffset.UTC));
                 ctx.execute("""
@@ -648,6 +663,8 @@ public final class TaxonomyRepository {
         String tsStr = (assignedAt != null && !assignedAt.isBlank())
             ? fmtTs(parseTsStrict(assignedAt)) : null;
         tenantScope.withTenant(tenant, ctx -> {
+            // RDR-156 P0.2: ensure collection is registered before the assignment write
+            ensureCollectionRegistered(ctx, tenant, sourceCollection);
             ctx.execute("""
                 INSERT INTO nexus.topic_assignments
                     (tenant_id, doc_id, topic_id, assigned_by, similarity, assigned_at, source_collection)

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -267,7 +267,32 @@ public final class PgVectorRepository {
         }
 
         String table = chunksTable(dim);
+
+        // Standing rule (RDR-156 P0.2, bead nexus-70r3c.2):
+        // Collection registration precedes chunk writes — enforced server-side here
+        // (auto-stub in the write transaction) and by the chunks_<dim>/chash_index/
+        // topic_assignments -> catalog_collections FKs (NOT VALID until RDR-153 data
+        // lands; VALIDATE is nexus-70r3c.3).  Stub rows (all metadata='') are upgraded
+        // by the catalog ETL's importCollection DO UPDATE...WHERE-stub logic.
+        // Never add a chunk write path that bypasses this ensure-registered step.
+        String[] collSegs = collection.split("__");
+        boolean conformant = collSegs.length == 4;
+        String regContentType  = conformant ? collSegs[0] : "";
+        String regOwner        = conformant ? collSegs[1] : "";
+        String regModel        = conformant ? collSegs[2] : "";
+        String regModelVersion = conformant ? collSegs[3] : "";
+
         tenantScope.withTenant(tenant, ctx -> {
+            // Ensure-registered: INSERT stub row for this collection before any chunk write.
+            // ON CONFLICT DO NOTHING: a fully-populated row from the catalog ETL is never
+            // overwritten; a stub inserted by a prior upsertChunks call is also preserved.
+            ctx.execute(
+                "INSERT INTO nexus.catalog_collections"
+                + " (tenant_id, name, content_type, owner_id, embedding_model, model_version)"
+                + " VALUES (?, ?, ?, ?, ?, ?)"
+                + " ON CONFLICT (tenant_id, name) DO NOTHING",
+                tenant, collection, regContentType, regOwner, regModel, regModelVersion);
+
             for (int i = 0; i < dedupIds.size(); i++) {
                 ctx.execute(
                     "INSERT INTO " + table

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -276,6 +276,11 @@ public final class PgVectorRepository {
         // by the catalog ETL's importCollection DO UPDATE...WHERE-stub logic.
         // Never add a chunk write path that bypasses this ensure-registered step.
         String[] collSegs = collection.split("__");
+        // Non-conformant path (collSegs.length != 4) is unreachable in practice:
+        // dimForCollection() above fails loud for any non-four-segment name, so by
+        // the time we reach this point, segments.length == 4 is guaranteed.
+        // The branch is retained as defense-in-depth to produce a name-only stub
+        // rather than crash if the invariant is ever violated by a future caller.
         boolean conformant = collSegs.length == 4;
         String regContentType  = conformant ? collSegs[0] : "";
         String regOwner        = conformant ? collSegs[1] : "";

--- a/service/src/main/resources/db/changelog/catalog-002-hygiene.xml
+++ b/service/src/main/resources/db/changelog/catalog-002-hygiene.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    RDR-156 bead nexus-70r3c.2 — catalog hygiene changesets.
+
+    1. catalog-002-1-temporal-typing: converts catalog_collections.created_at and
+       superseded_at from TEXT NOT NULL DEFAULT '' (SQLite heritage) to timestamptz NULL.
+       Safe now because production catalog_collections is empty or stub-only.
+
+    2. catalog-002-2-chash-checks: CHECK constraints enforcing length(chash) = 32 on
+       chunks_384/768/1024 and catalog_document_chunks, plus position >= 0 on
+       catalog_document_chunks.
+
+    NOTE: no unique constraint on catalog_documents.source_uri — DEFERRED pending ghost
+    dedup sweep.  The 2026-06-11 live audit (T2 nexus_rdr/156-P0-source-uri-audit) found
+    201 distinct source_uris duplicated across different tumblers (e.g. rdr-127 registered
+    under tumblers 1.1.1781, 1.10.2708, and 1.10.2836).  A blind ADD UNIQUE CONSTRAINT on
+    (tenant_id, source_uri) would fail on the live data.  The dedup sweep and constraint
+    addition are tracked in a separate bead; this file ships NO such constraint.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <!-- ── Changeset catalog-002-1-temporal-typing ───────────────────────────── -->
+    <changeSet id="catalog-002-1-temporal-typing" author="nexus-70r3c.2">
+        <comment>
+            Convert catalog_collections.created_at and superseded_at from TEXT NOT NULL DEFAULT ''
+            (SQLite heritage) to timestamptz NULL.  The USING clause handles the conversion:
+            NULLIF(value,'')::timestamptz maps empty-string sentinel to NULL, and any valid
+            ISO-8601 timestamp string is parsed directly.  Safe now because production
+            catalog_collections is empty or stub-only (all rows have created_at = '' default).
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+-- created_at: drop DEFAULT and NOT NULL, convert type
+ALTER TABLE nexus.catalog_collections
+    ALTER COLUMN created_at DROP DEFAULT;
+ALTER TABLE nexus.catalog_collections
+    ALTER COLUMN created_at DROP NOT NULL;
+ALTER TABLE nexus.catalog_collections
+    ALTER COLUMN created_at TYPE timestamptz
+    USING NULLIF(created_at, '')::timestamptz;
+
+-- superseded_at: drop DEFAULT and NOT NULL, convert type
+ALTER TABLE nexus.catalog_collections
+    ALTER COLUMN superseded_at DROP DEFAULT;
+ALTER TABLE nexus.catalog_collections
+    ALTER COLUMN superseded_at DROP NOT NULL;
+ALTER TABLE nexus.catalog_collections
+    ALTER COLUMN superseded_at TYPE timestamptz
+    USING NULLIF(superseded_at, '')::timestamptz;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.catalog_collections
+                ALTER COLUMN superseded_at TYPE TEXT USING COALESCE(superseded_at::text, '');
+            ALTER TABLE nexus.catalog_collections
+                ALTER COLUMN superseded_at SET NOT NULL;
+            ALTER TABLE nexus.catalog_collections
+                ALTER COLUMN superseded_at SET DEFAULT '';
+            ALTER TABLE nexus.catalog_collections
+                ALTER COLUMN created_at TYPE TEXT USING COALESCE(created_at::text, '');
+            ALTER TABLE nexus.catalog_collections
+                ALTER COLUMN created_at SET NOT NULL;
+            ALTER TABLE nexus.catalog_collections
+                ALTER COLUMN created_at SET DEFAULT '';
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset catalog-002-2-chash-checks ──────────────────────────────── -->
+    <!--
+        CHECK constraints enforcing length(chash) = 32 on the three chunks tables and
+        on catalog_document_chunks; plus position >= 0 on catalog_document_chunks.
+
+        chunks_&lt;dim&gt;_chash_len_check: NOT VALID — production chunks tables hold 115,716
+        rows that were audited as uniformly length-32, but deploy safety matches the FK
+        model: new bad writes are rejected immediately; retroactive validation rides with
+        bead nexus-70r3c.3.
+
+        catalog_document_chunks checks: NOT VALID is also added for the chash len check
+        (manifest rows may exist from earlier ETL phases); the position >= 0 check is also
+        NOT VALID for uniformity and because catalog_document_chunks rows may already exist.
+    -->
+    <changeSet id="catalog-002-2-chash-checks" author="nexus-70r3c.2">
+        <comment>
+            Add CHECK constraints for chash length = 32 on chunks_384/768/1024 and
+            catalog_document_chunks, and position >= 0 on catalog_document_chunks.
+            chunks_&lt;dim&gt; checks are NOT VALID because production holds 115,716 rows
+            (audited as uniformly length-32; retroactive VALIDATE rides with nexus-70r3c.3).
+            catalog_document_chunks checks are also NOT VALID for deploy safety.
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+-- chunks_384: chash must be exactly 32 characters (sha256[:32] hex)
+ALTER TABLE nexus.chunks_384
+    ADD CONSTRAINT chunks_384_chash_len_check
+    CHECK (length(chash) = 32)
+    NOT VALID;
+
+-- chunks_768: chash must be exactly 32 characters
+ALTER TABLE nexus.chunks_768
+    ADD CONSTRAINT chunks_768_chash_len_check
+    CHECK (length(chash) = 32)
+    NOT VALID;
+
+-- chunks_1024: chash must be exactly 32 characters
+ALTER TABLE nexus.chunks_1024
+    ADD CONSTRAINT chunks_1024_chash_len_check
+    CHECK (length(chash) = 32)
+    NOT VALID;
+
+-- catalog_document_chunks: chash must be exactly 32 characters
+ALTER TABLE nexus.catalog_document_chunks
+    ADD CONSTRAINT catalog_document_chunks_chash_len_check
+    CHECK (length(chash) = 32)
+    NOT VALID;
+
+-- catalog_document_chunks: position must be >= 0 (chunk sequence index)
+ALTER TABLE nexus.catalog_document_chunks
+    ADD CONSTRAINT catalog_document_chunks_position_check
+    CHECK (position >= 0)
+    NOT VALID;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.catalog_document_chunks DROP CONSTRAINT IF EXISTS catalog_document_chunks_position_check;
+            ALTER TABLE nexus.catalog_document_chunks DROP CONSTRAINT IF EXISTS catalog_document_chunks_chash_len_check;
+            ALTER TABLE nexus.chunks_1024 DROP CONSTRAINT IF EXISTS chunks_1024_chash_len_check;
+            ALTER TABLE nexus.chunks_768  DROP CONSTRAINT IF EXISTS chunks_768_chash_len_check;
+            ALTER TABLE nexus.chunks_384  DROP CONSTRAINT IF EXISTS chunks_384_chash_len_check;
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -58,6 +58,17 @@
     <!-- Store 10b: trigram GIN indexes for the hybrid pg_trgm gate (bead nexus-eap5l) -->
     <include file="db/changelog/vectors-002-trgm-index.xml"/>
 
+    <!-- Collection-registry FKs (bead nexus-70r3c.2, RDR-156 P0.2):
+         NOT VALID FKs from chunks_384/768/1024, chash_index, and topic_assignments to
+         catalog_collections(tenant_id, name). Includes backfill-stubs changeset.
+         Must come after vectors-001, chash-001, taxonomy-001, and catalog-001. -->
+    <include file="db/changelog/fk-002-collection-registry.xml"/>
+
+    <!-- Catalog hygiene (bead nexus-70r3c.2, RDR-156 P0.2):
+         temporal typing for catalog_collections.created_at/superseded_at (TEXT→timestamptz NULL),
+         and CHECK constraints for chash length = 32 and position >= 0. -->
+    <include file="db/changelog/catalog-002-hygiene.xml"/>
+
     <!--
         Consolidated nexus_svc DML grants (bead nexus-net63) — runAlways="true".
         Must be LAST so all schema objects exist before grants are issued.

--- a/service/src/main/resources/db/changelog/fk-002-collection-registry.xml
+++ b/service/src/main/resources/db/changelog/fk-002-collection-registry.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    RDR-156 bead nexus-70r3c.2 — collection-registry foreign keys.
+
+    Adds NOT VALID FKs from the three chunk tables, chash_index, and topic_assignments
+    back to catalog_collections(tenant_id, name).  "NOT VALID" means the constraint is
+    enforced for ALL NEW writes immediately but does NOT validate existing rows — safe to
+    add against a live table with millions of rows.  The backfill changeset (fk-002-0)
+    inserts stubs for any collection names that already exist in the data tables so that
+    a subsequent VALIDATE CONSTRAINT (bead nexus-70r3c.3) can succeed.
+
+    Deploy-order landmine: in production the vector ETL runs before the catalog ETL,
+    so chunk rows accumulate in nexus.chunks_<dim> and nexus.chash_index BEFORE the
+    catalog registry is populated.  Without fk-002-0-backfill-stubs the NOT VALID FKs
+    would reject all new serving writes at deploy time (NOT VALID still enforces new
+    inserts; it only skips retroactive validation of pre-existing rows).
+
+    Constraint names are a fixed contract (CollectionRegistryFkTest):
+      chunks_384_collection_fk
+      chunks_768_collection_fk
+      chunks_1024_collection_fk
+      chash_index_collection_fk
+      topic_assignments_collection_fk
+
+    DO NOT add VALIDATE CONSTRAINT here.  That is bead nexus-70r3c.3, world-blocked
+    on the RDR-153 data migration (a combined changeset would fail on any pre-RDR-153
+    deployment that has old-format rows).
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <!-- ── Changeset fk-002-0: backfill stubs into catalog_collections ──────── -->
+    <!--
+        Production deploy-order landmine: chunks data exists before the catalog ETL runs.
+        Without this backfill the NOT VALID FKs (changesets fk-002-1 through fk-002-5)
+        would reject all new serving writes at deploy time.  NOT VALID still enforces new
+        inserts; it only skips retroactive validation of rows that existed BEFORE the ALTER
+        TABLE.  Rows inserted AFTER the ALTER TABLE are fully checked.  So if any new chunk
+        write arrives after fk-002-1 lands but before the catalog ETL registers the
+        collection, the insert would fail the FK.  This backfill prevents that window.
+        Each stub row has empty metadata fields ('') and is upgradable by importCollection's
+        DO UPDATE WHERE-stub logic once the catalog ETL runs.
+    -->
+    <changeSet id="fk-002-0-backfill-stubs" author="nexus-70r3c.2">
+        <comment>
+            Backfill catalog_collections stub rows for every collection name that already
+            exists in chunks_384, chunks_768, chunks_1024, chash_index, and topic_assignments.
+            Production deploy-order landmine: chunk data accumulates before the catalog ETL
+            runs. Without this backfill the NOT VALID FKs added by fk-002-1 through fk-002-5
+            would reject all new serving writes at deploy time (NOT VALID still enforces new
+            inserts; it only skips retroactive validation of pre-existing rows).
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+-- Backfill stubs from chunks_384
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.chunks_384
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+-- Backfill stubs from chunks_768
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.chunks_768
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+-- Backfill stubs from chunks_1024
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.chunks_1024
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+-- Backfill stubs from chash_index
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, physical_collection
+FROM nexus.chash_index
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+-- Backfill stubs from topic_assignments (non-null, non-empty source_collection only)
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, source_collection
+FROM nexus.topic_assignments
+WHERE source_collection IS NOT NULL
+  AND source_collection != ''
+ON CONFLICT (tenant_id, name) DO NOTHING;
+        </sql>
+        <rollback>
+            <!-- No rollback: stub rows are inert; the FKs being added next would be dropped
+                 by their own rollbacks.  Removing stubs here could break existing references. -->
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset fk-002-1: chunks_384 → catalog_collections FK ──────────── -->
+    <changeSet id="fk-002-1" author="nexus-70r3c.2">
+        <comment>
+            chunks_384_collection_fk: FOREIGN KEY (tenant_id, collection)
+            REFERENCES nexus.catalog_collections (tenant_id, name) ON DELETE RESTRICT NOT VALID.
+            NOT VALID: enforces new inserts immediately; skips retroactive validation of
+            pre-existing rows (validation rides with bead nexus-70r3c.3 after RDR-153 data lands).
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.chunks_384
+    ADD CONSTRAINT chunks_384_collection_fk
+    FOREIGN KEY (tenant_id, collection)
+    REFERENCES nexus.catalog_collections (tenant_id, name)
+    ON DELETE RESTRICT
+    NOT VALID;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.chunks_384 DROP CONSTRAINT IF EXISTS chunks_384_collection_fk;
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset fk-002-2: chunks_768 → catalog_collections FK ──────────── -->
+    <changeSet id="fk-002-2" author="nexus-70r3c.2">
+        <comment>
+            chunks_768_collection_fk: FOREIGN KEY (tenant_id, collection)
+            REFERENCES nexus.catalog_collections (tenant_id, name) ON DELETE RESTRICT NOT VALID.
+            NOT VALID: enforces new inserts immediately; skips retroactive validation of
+            pre-existing rows (validation rides with bead nexus-70r3c.3 after RDR-153 data lands).
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.chunks_768
+    ADD CONSTRAINT chunks_768_collection_fk
+    FOREIGN KEY (tenant_id, collection)
+    REFERENCES nexus.catalog_collections (tenant_id, name)
+    ON DELETE RESTRICT
+    NOT VALID;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.chunks_768 DROP CONSTRAINT IF EXISTS chunks_768_collection_fk;
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset fk-002-3: chunks_1024 → catalog_collections FK ─────────── -->
+    <changeSet id="fk-002-3" author="nexus-70r3c.2">
+        <comment>
+            chunks_1024_collection_fk: FOREIGN KEY (tenant_id, collection)
+            REFERENCES nexus.catalog_collections (tenant_id, name) ON DELETE RESTRICT NOT VALID.
+            NOT VALID: enforces new inserts immediately; skips retroactive validation of
+            pre-existing rows (validation rides with bead nexus-70r3c.3 after RDR-153 data lands).
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.chunks_1024
+    ADD CONSTRAINT chunks_1024_collection_fk
+    FOREIGN KEY (tenant_id, collection)
+    REFERENCES nexus.catalog_collections (tenant_id, name)
+    ON DELETE RESTRICT
+    NOT VALID;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.chunks_1024 DROP CONSTRAINT IF EXISTS chunks_1024_collection_fk;
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset fk-002-4: chash_index → catalog_collections FK ─────────── -->
+    <changeSet id="fk-002-4" author="nexus-70r3c.2">
+        <comment>
+            chash_index_collection_fk: FOREIGN KEY (tenant_id, physical_collection)
+            REFERENCES nexus.catalog_collections (tenant_id, name) ON DELETE RESTRICT NOT VALID.
+            NOT VALID: enforces new inserts immediately; skips retroactive validation of
+            pre-existing rows.
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.chash_index
+    ADD CONSTRAINT chash_index_collection_fk
+    FOREIGN KEY (tenant_id, physical_collection)
+    REFERENCES nexus.catalog_collections (tenant_id, name)
+    ON DELETE RESTRICT
+    NOT VALID;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.chash_index DROP CONSTRAINT IF EXISTS chash_index_collection_fk;
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset fk-002-5: topic_assignments → catalog_collections FK ───── -->
+    <changeSet id="fk-002-5" author="nexus-70r3c.2">
+        <comment>
+            topic_assignments_collection_fk: FOREIGN KEY (tenant_id, source_collection)
+            REFERENCES nexus.catalog_collections (tenant_id, name)
+            ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID.
+            ON UPDATE CASCADE: propagates collection renames to source_collection automatically.
+            source_collection IS NULLABLE: NULL satisfies the FK (MATCH SIMPLE default).
+            NOT VALID: enforces new inserts immediately; skips retroactive validation of
+            pre-existing rows.
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.topic_assignments
+    ADD CONSTRAINT topic_assignments_collection_fk
+    FOREIGN KEY (tenant_id, source_collection)
+    REFERENCES nexus.catalog_collections (tenant_id, name)
+    ON UPDATE CASCADE
+    ON DELETE RESTRICT
+    NOT VALID;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.topic_assignments DROP CONSTRAINT IF EXISTS topic_assignments_collection_fk;
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
@@ -488,17 +488,17 @@ class CatalogRepositoryTest {
             "content_type", "paper", "corpus", "knowledge"));
 
         var rows = List.of(
-            Map.<String, Object>of("position", 0, "chash", "aaaa0000", "chunk_index", 0,
+            Map.<String, Object>of("position", 0, "chash", "aaaa0000000000000000000000000000", "chunk_index", 0,
                 "line_start", 1, "line_end", 10, "char_start", 0, "char_end", 100),
-            Map.<String, Object>of("position", 1, "chash", "bbbb1111", "chunk_index", 1,
+            Map.<String, Object>of("position", 1, "chash", "bbbb1111000000000000000000000000", "chunk_index", 1,
                 "line_start", 11, "line_end", 20, "char_start", 100, "char_end", 200)
         );
         repo.writeManifest(TENANT_A, "mfst.1", rows);
 
         var got = repo.getManifest(TENANT_A, "mfst.1");
         assertThat(got).hasSize(2);
-        assertThat(got.get(0).get("chash")).isEqualTo("aaaa0000");
-        assertThat(got.get(1).get("chash")).isEqualTo("bbbb1111");
+        assertThat(got.get(0).get("chash")).isEqualTo("aaaa0000000000000000000000000000");
+        assertThat(got.get(1).get("chash")).isEqualTo("bbbb1111000000000000000000000000");
     }
 
     @Test @Order(51)
@@ -507,17 +507,17 @@ class CatalogRepositoryTest {
             "content_type", "paper", "corpus", "knowledge"));
         // Write initial
         repo.writeManifest(TENANT_A, "mfst.2", List.of(
-            Map.<String, Object>of("position", 0, "chash", "old0000", "chunk_index", 0)
+            Map.<String, Object>of("position", 0, "chash", "old00000000000000000000000000000", "chunk_index", 0)
         ));
         // Replace with new set
         repo.writeManifest(TENANT_A, "mfst.2", List.of(
-            Map.<String, Object>of("position", 0, "chash", "new0000", "chunk_index", 0),
-            Map.<String, Object>of("position", 1, "chash", "new1111", "chunk_index", 1)
+            Map.<String, Object>of("position", 0, "chash", "new00000000000000000000000000000", "chunk_index", 0),
+            Map.<String, Object>of("position", 1, "chash", "new11110000000000000000000000000", "chunk_index", 1)
         ));
         var got = repo.getManifest(TENANT_A, "mfst.2");
         assertThat(got).hasSize(2);
         assertThat(got.stream().map(r -> (String) r.get("chash")).toList())
-            .containsExactlyInAnyOrder("new0000", "new1111");
+            .containsExactlyInAnyOrder("new00000000000000000000000000000", "new11110000000000000000000000000");
     }
 
     @Test @Order(52)
@@ -525,7 +525,7 @@ class CatalogRepositoryTest {
         repo.upsertDocument(TENANT_A, Map.of("tumbler", "mfst.3", "title", "Purge Doc",
             "content_type", "paper", "corpus", "knowledge"));
         repo.writeManifest(TENANT_A, "mfst.3", List.of(
-            Map.<String, Object>of("position", 0, "chash", "purge0000", "chunk_index", 0)
+            Map.<String, Object>of("position", 0, "chash", "purge000000000000000000000000000", "chunk_index", 0)
         ));
         assertThat(repo.getManifest(TENANT_A, "mfst.3")).hasSize(1);
         int deleted = repo.purgeManifest(TENANT_A, "mfst.3");
@@ -539,11 +539,11 @@ class CatalogRepositoryTest {
             "content_type", "paper", "corpus", "knowledge",
             "physical_collection", "knowledge__chash_test"));
         repo.writeManifest(TENANT_A, "mfst.4", List.of(
-            Map.<String, Object>of("position", 0, "chash", "cfccc000", "chunk_index", 0),
-            Map.<String, Object>of("position", 1, "chash", "cfccc111", "chunk_index", 1)
+            Map.<String, Object>of("position", 0, "chash", "cfccc000000000000000000000000000", "chunk_index", 0),
+            Map.<String, Object>of("position", 1, "chash", "cfccc111000000000000000000000000", "chunk_index", 1)
         ));
         Set<String> chashes = repo.chashesForCollection(TENANT_A, "knowledge__chash_test");
-        assertThat(chashes).containsExactlyInAnyOrder("cfccc000", "cfccc111");
+        assertThat(chashes).containsExactlyInAnyOrder("cfccc000000000000000000000000000", "cfccc111000000000000000000000000");
     }
 
     @Test @Order(54)
@@ -551,9 +551,9 @@ class CatalogRepositoryTest {
         repo.upsertDocument(TENANT_A, Map.of("tumbler", "mfst.5", "title", "Resync Doc",
             "content_type", "paper", "corpus", "knowledge", "chunk_count", 0));
         repo.writeManifest(TENANT_A, "mfst.5", List.of(
-            Map.<String, Object>of("position", 0, "chash", "rsync000", "chunk_index", 0),
-            Map.<String, Object>of("position", 1, "chash", "rsync111", "chunk_index", 1),
-            Map.<String, Object>of("position", 2, "chash", "rsync222", "chunk_index", 2)
+            Map.<String, Object>of("position", 0, "chash", "rsync000000000000000000000000000", "chunk_index", 0),
+            Map.<String, Object>of("position", 1, "chash", "rsync111000000000000000000000000", "chunk_index", 1),
+            Map.<String, Object>of("position", 2, "chash", "rsync222000000000000000000000000", "chunk_index", 2)
         ));
         repo.resyncChunkCount(TENANT_A, "mfst.5");
         var doc = repo.getDocument(TENANT_A, "mfst.5");

--- a/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
@@ -601,6 +601,71 @@ class CatalogRepositoryTest {
     }
 
     @Test @Order(63)
+    void importCollection_overwritesStubRow() {
+        // A stub row (all three discriminator columns empty) must be fully upgraded
+        // by importCollection. Stubs are created by PgVectorRepository.upsertChunks
+        // auto-registration and by fk-002-0-backfill-stubs (RDR-156 P0.2).
+        String name = "code__nexus__voyage-code-3__v2";
+        // Seed a stub via upsertCollection with no metadata — this simulates the
+        // auto-registration path (content_type/owner_id/embedding_model all default to '').
+        // Use a direct SQL stub to guarantee the three discriminators are all empty:
+        repo.importCollection(TENANT_A, Map.of(
+            "name", name,
+            "content_type", "",
+            "owner_id", "",
+            "embedding_model", "",
+            "model_version", ""
+        ));
+        var before = repo.getCollection(TENANT_A, name);
+        assertThat(before).isNotNull();
+        assertThat(before.get("content_type")).as("stub has empty content_type").isEqualTo("");
+
+        // Now call importCollection with full metadata — the DO UPDATE WHERE-stub must fire.
+        repo.importCollection(TENANT_A, Map.of(
+            "name", name,
+            "content_type", "code",
+            "owner_id", "nexus-1-1",
+            "embedding_model", "voyage-code-3",
+            "model_version", "v2"
+        ));
+        var after = repo.getCollection(TENANT_A, name);
+        assertThat(after.get("content_type")).as("importCollection must upgrade stub content_type").isEqualTo("code");
+        assertThat(after.get("owner_id")).as("importCollection must upgrade stub owner_id").isEqualTo("nexus-1-1");
+        assertThat(after.get("embedding_model")).as("importCollection must upgrade stub embedding_model").isEqualTo("voyage-code-3");
+        assertThat(after.get("model_version")).as("importCollection must upgrade stub model_version").isEqualTo("v2");
+    }
+
+    @Test @Order(64)
+    void importCollection_doesNotOverwriteLiveRow() {
+        // A live row (at least one discriminator non-empty) must NOT be overwritten
+        // by importCollection. The DO UPDATE WHERE-stub predicate must not fire.
+        String name = "code__nexus__voyage-code-3__v3";
+        // Register a live row with fully populated metadata via upsertCollection.
+        repo.upsertCollection(TENANT_A, Map.of(
+            "name", name,
+            "content_type", "code",
+            "owner_id", "live-owner",
+            "embedding_model", "voyage-code-3",
+            "model_version", "v3"
+        ));
+        var before = repo.getCollection(TENANT_A, name);
+        assertThat(before.get("owner_id")).as("live row owner_id before import").isEqualTo("live-owner");
+
+        // Call importCollection with DIFFERENT metadata — must NOT overwrite the live row.
+        repo.importCollection(TENANT_A, Map.of(
+            "name", name,
+            "content_type", "docs",
+            "owner_id", "different-owner",
+            "embedding_model", "voyage-context-3",
+            "model_version", "v3"
+        ));
+        var after = repo.getCollection(TENANT_A, name);
+        assertThat(after.get("content_type")).as("importCollection must not overwrite live content_type").isEqualTo("code");
+        assertThat(after.get("owner_id")).as("importCollection must not overwrite live owner_id").isEqualTo("live-owner");
+        assertThat(after.get("embedding_model")).as("importCollection must not overwrite live embedding_model").isEqualTo("voyage-code-3");
+    }
+
+    @Test @Order(65)
     void collection_rename_cascadesToDocuments() {
         repo.upsertCollection(TENANT_A, Map.of(
             "name", "knowledge__old__v1",

--- a/service/src/test/java/dev/nexus/service/ChashRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/ChashRepositoryTest.java
@@ -95,6 +95,8 @@ class ChashRepositoryTest {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             su.createStatement().execute("GRANT SELECT, INSERT, UPDATE, DELETE ON nexus.chash_index TO " + SVC_ROLE);
+            // RDR-156 P0.2: ChashRepository.upsert now auto-stubs catalog_collections.
+            su.createStatement().execute("GRANT SELECT, INSERT ON nexus.catalog_collections TO " + SVC_ROLE);
             su.createStatement().execute("ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
         }
 

--- a/service/src/test/java/dev/nexus/service/ChashRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/ChashRepositoryTest.java
@@ -328,6 +328,31 @@ class ChashRepositoryTest {
         assertThat(repo.countForCollection(importTenant, importColl)).isEqualTo(1);
     }
 
+    // ── Test 18: ensureCollectionRegistered rejects blank collection ─────────────
+
+    @Test
+    @Order(18)
+    void upsert_blankCollection_throwsIllegalArgument() {
+        // ChashRepository.ensureCollectionRegistered throws IllegalArgumentException
+        // for blank physical_collection rather than silently skipping registration
+        // (which would let the subsequent FK-constrained INSERT fail with a cryptic
+        // FK violation instead of a clear caller-error message).
+        // upsert() is the most direct public entry point that reaches ensureCollectionRegistered;
+        // upsert() itself also guards blank collection, so the IAE surfaces from there.
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+            repo.upsert(TENANT_A, "some_valid_chash", ""));
+        assertThat(ex.getMessage())
+            .as("blank physical_collection must produce a clear IllegalArgumentException")
+            .contains("must not be");
+
+        // Also verify for whitespace-only value
+        IllegalArgumentException exWs = assertThrows(IllegalArgumentException.class, () ->
+            repo.upsert(TENANT_A, "some_valid_chash", "  "));
+        assertThat(exWs.getMessage())
+            .as("whitespace-only physical_collection must also be rejected")
+            .contains("must not be");
+    }
+
     // ── Test 12: RLS isolation — tenant A rows invisible to tenant B ──────────
 
     @Test

--- a/service/src/test/java/dev/nexus/service/ChunksRlsBehavioralTest.java
+++ b/service/src/test/java/dev/nexus/service/ChunksRlsBehavioralTest.java
@@ -145,6 +145,9 @@ class ChunksRlsBehavioralTest {
                 su.createStatement().execute(
                     "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus.chunks_" + dim + " TO " + SVC_ROLE);
             }
+            // RDR-156 P0.2: insertChunk now auto-stubs catalog_collections before chunk writes.
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT ON nexus.catalog_collections TO " + SVC_ROLE);
             su.createStatement().execute(
                 "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
         }
@@ -271,7 +274,7 @@ class ChunksRlsBehavioralTest {
                 ctx.execute(
                     "INSERT INTO " + table + " (tenant_id, collection, chash, chunk_text, embedding) " +
                     "VALUES (?, ?, ?, ?, ?::vector)",
-                    TENANT_B, col, "chash-wc-cross-" + dim, "cross-tenant inject", vec);
+                    TENANT_B, col, padChash("chash-wc-cross-" + dim), "cross-tenant inject", vec);
                 return null;
             })
         ).as("INSERT with tenant_id='tenant-b' inside tenant-a scope must be rejected by RLS WITH CHECK")
@@ -313,7 +316,7 @@ class ChunksRlsBehavioralTest {
             tenantScope.withTenant(TENANT_A, ctx -> {
                 ctx.execute(
                     "UPDATE " + table + " SET tenant_id = ? WHERE chash = ? AND collection = ?",
-                    TENANT_B, "chash-wcu-own-" + dim, col);
+                    TENANT_B, padChash("chash-wcu-own-" + dim), col);
                 return null;
             })
         ).as("UPDATE setting tenant_id to tenant-b inside tenant-a scope must be rejected by RLS WITH CHECK")
@@ -426,7 +429,7 @@ class ChunksRlsBehavioralTest {
         // tenant-b attempts to delete tenant-a's row: RLS USING hides it, 0 affected.
         int deleted = tenantScope.withTenant(TENANT_B, ctx ->
             ctx.execute("DELETE FROM " + table + " WHERE chash = ? AND collection = ?",
-                        "chash-del-own-" + dim, col));
+                        padChash("chash-del-own-" + dim), col));
         assertThat(deleted)
             .as("cross-tenant DELETE must affect exactly 0 rows (RLS makes the row invisible)")
             .isEqualTo(0);
@@ -439,7 +442,7 @@ class ChunksRlsBehavioralTest {
         // The owner can delete its own row: exactly 1 affected.
         int ownDelete = tenantScope.withTenant(TENANT_A, ctx ->
             ctx.execute("DELETE FROM " + table + " WHERE chash = ? AND collection = ?",
-                        "chash-del-own-" + dim, col));
+                        padChash("chash-del-own-" + dim), col));
         assertThat(ownDelete)
             .as("owner DELETE must affect exactly 1 row")
             .isEqualTo(1);
@@ -451,6 +454,17 @@ class ChunksRlsBehavioralTest {
     // ---------------------------------------------------------------------------
     // Private helpers
     // ---------------------------------------------------------------------------
+
+    /**
+     * RDR-156 P0.2: pad a test chash to exactly 32 characters to satisfy
+     * the {@code chunks_<dim>_chash_len_check} constraint.
+     * Strips non-alphanumeric characters and pads with '0'.
+     */
+    private static String padChash(String raw) {
+        String stripped = raw.replaceAll("[^a-z0-9A-Z]", "");
+        if (stripped.length() >= 32) return stripped.substring(0, 32);
+        return stripped + "0".repeat(32 - stripped.length());
+    }
 
     /**
      * Build a vector literal string of exactly {@code dim} components, all 0.1.
@@ -470,13 +484,20 @@ class ChunksRlsBehavioralTest {
                               String chunkText, int embDim) {
         String table = "nexus.chunks_" + dim;
         String vec = vectorLiteral(embDim);
+        // RDR-156 P0.2: chash_len_check requires exactly 32 chars — pad test chashes.
+        String paddedChash = padChash(chash);
         tenantScope.withTenant(tenant, ctx -> {
+            // RDR-156 P0.2: ensure catalog_collections has a stub row before the chunk insert.
+            ctx.execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES (?, ?) " +
+                "ON CONFLICT (tenant_id, name) DO NOTHING",
+                tenant, collection);
             ctx.execute(
                 "INSERT INTO " + table +
                 " (tenant_id, collection, chash, chunk_text, embedding)" +
                 " VALUES (?, ?, ?, ?, ?::vector)" +
                 " ON CONFLICT (tenant_id, collection, chash) DO NOTHING",
-                tenant, collection, chash, chunkText, vec);
+                tenant, collection, paddedChash, chunkText, vec);
             return null;
         });
     }

--- a/service/src/test/java/dev/nexus/service/CollectionRegistryFkTest.java
+++ b/service/src/test/java/dev/nexus/service/CollectionRegistryFkTest.java
@@ -1,0 +1,944 @@
+package dev.nexus.service;
+
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.*;
+import org.postgresql.util.PSQLException;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * RDR-156 bead nexus-70r3c.1 — TDD-RED suite for P0.2 FK + hygiene changesets.
+ *
+ * <p><strong>TDD-RED state:</strong> All RED groups are written AGAINST the future schema
+ * delivered by P0.2 (bead nexus-70r3c.2). P0.2 will add Liquibase changesets:
+ * <ul>
+ *   <li>fk-002: ADD CONSTRAINT ... NOT VALID for three FK groups, ON DELETE RESTRICT:</li>
+ *     <ul>
+ *       <li>{@code chunks_384_collection_fk}, {@code chunks_768_collection_fk},
+ *           {@code chunks_1024_collection_fk}:
+ *           FOREIGN KEY (tenant_id, collection) REFERENCES catalog_collections(tenant_id,name)
+ *           ON DELETE RESTRICT NOT VALID</li>
+ *       <li>{@code chash_index_collection_fk}:
+ *           FOREIGN KEY (tenant_id, physical_collection) REFERENCES catalog_collections(tenant_id,name)
+ *           ON DELETE RESTRICT NOT VALID</li>
+ *       <li>{@code topic_assignments_collection_fk}:
+ *           FOREIGN KEY (tenant_id, source_collection) REFERENCES catalog_collections(tenant_id,name)
+ *           ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID</li>
+ *     </ul>
+ *   <li>hygiene: catalog_collections.created_at / superseded_at → timestamptz NULL
+ *       (currently TEXT NOT NULL DEFAULT '')</li>
+ *   <li>CHECK constraints: {@code chunks_<dim>_chash_len_check} (length(chash)=32) on each
+ *       chunks table; {@code catalog_document_chunks_chash_len_check} and
+ *       {@code catalog_document_chunks_position_check} on catalog_document_chunks</li>
+ * </ul>
+ *
+ * <p><strong>Expected RED/GREEN before P0.2 lands:</strong>
+ * <ul>
+ *   <li>GROUP 1 (unregistered-reject): RED — FK absent, insert unexpectedly succeeds</li>
+ *   <li>GROUP 2 (NOT VALID pin): RED — pg_constraint rows absent</li>
+ *   <li>GROUP 3 (ON UPDATE CASCADE): RED — constraint absent, source_collection not updated</li>
+ *   <li>GROUP 4 (NULL source_collection): GREEN — MATCH SIMPLE / nullable already works</li>
+ *   <li>GROUP 5 (chash_index FK reject): RED — FK absent, insert unexpectedly succeeds</li>
+ *   <li>GROUP 6 (ON DELETE RESTRICT): RED — RESTRICT absent, delete unexpectedly succeeds</li>
+ *   <li>GROUP 7 (CHECK constraints): RED — checks absent, bad lengths accepted</li>
+ *   <li>GROUP 8 (temporal typing): RED — column is TEXT, not timestamptz</li>
+ *   <li>GROUP 9 (source_uri audit + no-unique): GREEN — audit query detects seeded duplicate;
+ *       no unique constraint exists</li>
+ *   <li>GROUP 10 (cross-tenant FK + RLS): RED — FK absent, cross-tenant insert succeeds</li>
+ *   <li>All CONTROL paths (registered inserts, null source_collection): GREEN always</li>
+ * </ul>
+ *
+ * <p>Verified schema facts used throughout (do not re-derive):
+ * <ul>
+ *   <li>catalog_collections PK (tenant_id, name); created_at/superseded_at TEXT NOT NULL DEFAULT ''
+ *       (the SQLite heritage, to be converted to timestamptz NULL by P0.2 hygiene changeset)
+ *       — source: catalog-001-baseline.xml changeset 5</li>
+ *   <li>chunks_384/768/1024(tenant_id TEXT, collection TEXT, chash TEXT, ...; PK (tenant_id,collection,chash))
+ *       — source: vectors-001-baseline.xml changesets 2-4</li>
+ *   <li>chash_index(tenant_id, chash, physical_collection TEXT NOT NULL, ...; PK (tenant_id,chash,physical_collection))
+ *       — source: chash-001-baseline.xml changeset 1</li>
+ *   <li>topic_assignments(tenant_id, doc_id, topic_id BIGINT NOT NULL REFERENCES topics(id) CASCADE,
+ *       source_collection TEXT NULLABLE; PK (tenant_id,doc_id,topic_id)) with (tenant_id,doc_id)
+ *       FK to catalog_documents via fk-001 — source: taxonomy-001-baseline.xml changeset 3 +
+ *       fk-001-catalog-cross-store.xml changeset 1 (index only, no catalog FK on ta)</li>
+ *   <li>catalog_document_chunks(tenant_id, doc_id, position INTEGER NOT NULL, chash TEXT NOT NULL;
+ *       PK (tenant_id,doc_id,position)) — source: catalog-001-baseline.xml changeset 4 +
+ *       vectors-001-baseline.xml changeset 6 (nullable collection column added)</li>
+ *   <li>catalog_documents PK (tenant_id, tumbler); source_uri TEXT NOT NULL DEFAULT ''
+ *       — source: catalog-001-baseline.xml changeset 2</li>
+ * </ul>
+ *
+ * <p><strong>source_uri audit provenance:</strong> T2 nexus_rdr/156-P0-source-uri-audit (2026-06-11):
+ * 201 distinct source_uris duplicated in live SQLite before RDR-153 migration, e.g. rdr-127 file
+ * under tumblers 1.1.1781/1.10.2708/1.10.2836. A UNIQUE constraint on (tenant_id, source_uri) is
+ * DEFERRED pending ghost dedup; P0.2 ships NO such constraint (group 9b verifies absence).
+ *
+ * <p>Mirror conventions from ForeignKeyConstraintTest: PgContainerHelper.start(), master changelog
+ * via Liquibase, PER_CLASS lifecycle, @Order, AssertJ + assertThrows(PSQLException.class),
+ * superuser for direct inserts, svc role + GUC for RLS tests.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CollectionRegistryFkTest {
+
+    // ── Constraint names (fixed contract; P0.2 will use exactly these) ─────────
+    private static final String FK_CHUNKS_384  = "chunks_384_collection_fk";
+    private static final String FK_CHUNKS_768  = "chunks_768_collection_fk";
+    private static final String FK_CHUNKS_1024 = "chunks_1024_collection_fk";
+    private static final String FK_CHASH_INDEX = "chash_index_collection_fk";
+    private static final String FK_TOPIC_ASSIGN= "topic_assignments_collection_fk";
+
+    // The five FK names P0.3 will VALIDATE (convalidated must be false until then)
+    private static final List<String> ALL_FIVE_FK_NAMES = List.of(
+            FK_CHUNKS_384, FK_CHUNKS_768, FK_CHUNKS_1024, FK_CHASH_INDEX, FK_TOPIC_ASSIGN);
+
+    // CHECK constraint names
+    private static final String CHK_384_CHASH  = "chunks_384_chash_len_check";
+    private static final String CHK_768_CHASH  = "chunks_768_chash_len_check";
+    private static final String CHK_1024_CHASH = "chunks_1024_chash_len_check";
+    private static final String CHK_MANIFEST_CHASH = "catalog_document_chunks_chash_len_check";
+    private static final String CHK_MANIFEST_POS   = "catalog_document_chunks_position_check";
+
+    private static final int[] DIMS = {384, 768, 1024};
+
+    // Tenant IDs
+    private static final String TENANT_A = "crfk-tenant-a";
+    private static final String TENANT_B = "crfk-tenant-b";
+
+    // Svc role for RLS posture tests (mirrors ForeignKeyConstraintTest.SVC_ROLE pattern)
+    private static final String SVC_ROLE = "svc_crfk_test";
+    private static final String SVC_PASS = "svc_crfk_test_pass";
+
+    PostgreSQLContainer<?> pg;
+    com.zaxxer.hikari.HikariDataSource svcDs;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+
+        // Phase 1: create roles (autoCommit=true; CREATE ROLE cannot run in a txn)
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
+                "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '" + SVC_ROLE + "') THEN " +
+                "    CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+        }
+
+        // Phase 2: apply full master changelog (all current changesets, no fk-002 yet)
+        try (Connection su = pg.createConnection("")) {
+            var lb = new Liquibase(
+                "db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(
+                    new JdbcConnection(su)));
+            lb.update(new Contexts());
+        }
+
+        // Phase 3: grant svc role access to tables needed for RLS posture tests.
+        //          The master changelog's grants-nexus-svc.xml already covers nexus_svc;
+        //          svc_crfk_test is test-specific and gets explicit table grants.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            for (String tbl : List.of(
+                    "catalog_collections", "catalog_documents",
+                    "chunks_384", "chunks_768", "chunks_1024",
+                    "chash_index", "topic_assignments", "topics",
+                    "catalog_document_chunks")) {
+                su.createStatement().execute(
+                    "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus." + tbl + " TO " + SVC_ROLE);
+            }
+            su.createStatement().execute(
+                "GRANT USAGE ON SEQUENCE nexus.topics_id_seq TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+        }
+
+        // HikariCP svc role pool (NOSUPERUSER NOBYPASSRLS — subject to RLS).
+        var cfg = new com.zaxxer.hikari.HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(4);
+        cfg.setAutoCommit(true);
+        svcDs = new com.zaxxer.hikari.HikariDataSource(cfg);
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (svcDs != null) svcDs.close();
+        if (pg != null)    pg.stop();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 1 — FK rejects unregistered (tenant_id, collection) in chunks tables
+    //
+    // EXPECTED RED: FK absent → insert succeeds when it should fail.
+    // CONTROL (registered insert): always GREEN.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(10)
+    void chunks384_control_registeredCollection_accepted() throws Exception {
+        // CONTROL — must be GREEN before and after P0.2 lands.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "ctrl-col-384");
+            // Insert succeeds — registered collection
+            su.createStatement().execute(
+                "INSERT INTO nexus.chunks_384 (tenant_id, collection, chash, chunk_text, embedding) " +
+                "VALUES ('" + TENANT_A + "', 'ctrl-col-384', " +
+                "'" + validChash("384ctrl") + "', 'text', " +
+                vectorLiteral(384) + "::vector)");
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT COUNT(*) FROM nexus.chunks_384 " +
+                "WHERE tenant_id='" + TENANT_A + "' AND collection='ctrl-col-384'");
+            rs.next();
+            assertThat(rs.getInt(1)).as("registered insert into chunks_384 must succeed").isEqualTo(1);
+        }
+    }
+
+    @Test @Order(11)
+    void chunks384_unregisteredCollection_rejected() throws Exception {
+        // RED until P0.2 adds chunks_384_collection_fk.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.chunks_384 (tenant_id, collection, chash, chunk_text, embedding) " +
+                    "VALUES ('" + TENANT_A + "', 'unreg-col-384', " +
+                    "'" + validChash("384bad") + "', 'text', " +
+                    vectorLiteral(384) + "::vector)")
+            );
+            assertThat(ex.getMessage())
+                .as("chunks_384_collection_fk must reject unregistered collection")
+                .containsIgnoringCase(FK_CHUNKS_384);
+        }
+    }
+
+    @Test @Order(12)
+    void chunks768_control_registeredCollection_accepted() throws Exception {
+        // CONTROL — must be GREEN before and after P0.2 lands.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "ctrl-col-768");
+            su.createStatement().execute(
+                "INSERT INTO nexus.chunks_768 (tenant_id, collection, chash, chunk_text, embedding) " +
+                "VALUES ('" + TENANT_A + "', 'ctrl-col-768', " +
+                "'" + validChash("768ctrl") + "', 'text', " +
+                vectorLiteral(768) + "::vector)");
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT COUNT(*) FROM nexus.chunks_768 " +
+                "WHERE tenant_id='" + TENANT_A + "' AND collection='ctrl-col-768'");
+            rs.next();
+            assertThat(rs.getInt(1)).as("registered insert into chunks_768 must succeed").isEqualTo(1);
+        }
+    }
+
+    @Test @Order(13)
+    void chunks768_unregisteredCollection_rejected() throws Exception {
+        // RED until P0.2 adds chunks_768_collection_fk.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.chunks_768 (tenant_id, collection, chash, chunk_text, embedding) " +
+                    "VALUES ('" + TENANT_A + "', 'unreg-col-768', " +
+                    "'" + validChash("768bad") + "', 'text', " +
+                    vectorLiteral(768) + "::vector)")
+            );
+            assertThat(ex.getMessage())
+                .as("chunks_768_collection_fk must reject unregistered collection")
+                .containsIgnoringCase(FK_CHUNKS_768);
+        }
+    }
+
+    @Test @Order(14)
+    void chunks1024_control_registeredCollection_accepted() throws Exception {
+        // CONTROL — must be GREEN before and after P0.2 lands.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "ctrl-col-1024");
+            su.createStatement().execute(
+                "INSERT INTO nexus.chunks_1024 (tenant_id, collection, chash, chunk_text, embedding) " +
+                "VALUES ('" + TENANT_A + "', 'ctrl-col-1024', " +
+                "'" + validChash("1024ctrl") + "', 'text', " +
+                vectorLiteral(1024) + "::vector)");
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT COUNT(*) FROM nexus.chunks_1024 " +
+                "WHERE tenant_id='" + TENANT_A + "' AND collection='ctrl-col-1024'");
+            rs.next();
+            assertThat(rs.getInt(1)).as("registered insert into chunks_1024 must succeed").isEqualTo(1);
+        }
+    }
+
+    @Test @Order(15)
+    void chunks1024_unregisteredCollection_rejected() throws Exception {
+        // RED until P0.2 adds chunks_1024_collection_fk.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.chunks_1024 (tenant_id, collection, chash, chunk_text, embedding) " +
+                    "VALUES ('" + TENANT_A + "', 'unreg-col-1024', " +
+                    "'" + validChash("1024bad") + "', 'text', " +
+                    vectorLiteral(1024) + "::vector)")
+            );
+            assertThat(ex.getMessage())
+                .as("chunks_1024_collection_fk must reject unregistered collection")
+                .containsIgnoringCase(FK_CHUNKS_1024);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 2 — NOT VALID pin
+    //
+    // EXPECTED RED: all five pg_constraint rows absent until P0.2 adds them.
+    // P0.3's VALIDATE CONSTRAINT flips convalidated from false to true and must
+    // UPDATE this test to assert convalidated=true.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(20)
+    void allFiveCollectionFks_existAndAreNotValid() throws Exception {
+        // RED until P0.2 adds the NOT VALID changesets.
+        // After P0.2: all five rows exist with convalidated=false.
+        // After P0.3 (VALIDATE): update to convalidated=true.
+        try (Connection su = pg.createConnection("")) {
+            for (String fkName : ALL_FIVE_FK_NAMES) {
+                ResultSet rs = su.createStatement().executeQuery(
+                    "SELECT convalidated FROM pg_constraint c " +
+                    "JOIN pg_namespace n ON n.oid = c.connamespace " +
+                    "WHERE c.contype = 'f' " +
+                    "  AND c.conname = '" + fkName + "' " +
+                    "  AND n.nspname = 'nexus'");
+                assertThat(rs.next())
+                    .as("FK constraint " + fkName + " must exist in pg_constraint")
+                    .isTrue();
+                assertThat(rs.getBoolean("convalidated"))
+                    .as("FK constraint " + fkName + " must be NOT VALID (convalidated=false) until P0.3 VALIDATE runs")
+                    .isFalse();
+            }
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 3 — ON UPDATE CASCADE for topic_assignments.source_collection
+    //
+    // EXPECTED RED: FK absent → source_collection not updated on collection rename.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(30)
+    void topicAssignments_sourceCollection_cascadesOnCollectionRename() throws Exception {
+        // RED until P0.2 adds topic_assignments_collection_fk (ON UPDATE CASCADE).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+
+            // Fixture: catalog_documents row (required by fk-001 (tenant_id,doc_id) FK)
+            insertCatalogDocument(su, TENANT_A, "casc-doc-1");
+            // Fixture: topics row (required by topic_id FK)
+            insertTopic(su, TENANT_A, 8001L, "casc-topic", "casc__old");
+            // Fixture: registered collection 'casc__old'
+            insertCollection(su, TENANT_A, "casc__old");
+            // Fixture: topic_assignment with source_collection='casc__old'
+            su.createStatement().execute(
+                "INSERT INTO nexus.topic_assignments " +
+                "(tenant_id, doc_id, topic_id, assigned_by, source_collection, assigned_at) VALUES " +
+                "('" + TENANT_A + "', 'casc-doc-1', 8001, 'hdbscan', 'casc__old', NOW())");
+
+            // Rename collection: 'casc__old' -> 'casc__new'
+            su.createStatement().execute(
+                "UPDATE nexus.catalog_collections " +
+                "SET name = 'casc__new' " +
+                "WHERE tenant_id = '" + TENANT_A + "' AND name = 'casc__old'");
+
+            // Assert: topic_assignments.source_collection must now be 'casc__new'
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT source_collection FROM nexus.topic_assignments " +
+                "WHERE tenant_id='" + TENANT_A + "' AND doc_id='casc-doc-1' AND topic_id=8001");
+            assertThat(rs.next()).as("topic_assignment row must still exist after rename").isTrue();
+            assertThat(rs.getString("source_collection"))
+                .as("ON UPDATE CASCADE must propagate collection rename to topic_assignments.source_collection")
+                .isEqualTo("casc__new");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 4 — NULL source_collection is accepted (MATCH SIMPLE legacy tolerance)
+    //
+    // EXPECTED GREEN: source_collection IS NULLABLE; null satisfies any FK.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(40)
+    void topicAssignments_nullSourceCollection_accepted() throws Exception {
+        // GREEN before AND after P0.2 lands (MATCH SIMPLE: null FK column = no check).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCatalogDocument(su, TENANT_A, "null-src-doc");
+            insertTopic(su, TENANT_A, 8002L, "null-src-topic", "null-src-col");
+            su.createStatement().execute(
+                "INSERT INTO nexus.topic_assignments " +
+                "(tenant_id, doc_id, topic_id, assigned_by, assigned_at) VALUES " +
+                "('" + TENANT_A + "', 'null-src-doc', 8002, 'hdbscan', NOW())");
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT source_collection FROM nexus.topic_assignments " +
+                "WHERE tenant_id='" + TENANT_A + "' AND doc_id='null-src-doc' AND topic_id=8002");
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString("source_collection"))
+                .as("NULL source_collection must be accepted (MATCH SIMPLE, no FK violation)")
+                .isNull();
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 5 — chash_index FK: unregistered physical_collection rejected
+    //
+    // EXPECTED RED: FK absent → insert with unregistered physical_collection succeeds.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(50)
+    void chashIndex_control_registeredCollection_accepted() throws Exception {
+        // CONTROL — must be GREEN before and after P0.2 lands.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "ci-ctrl-col");
+            su.createStatement().execute(
+                "INSERT INTO nexus.chash_index (tenant_id, chash, physical_collection, created_at) " +
+                "VALUES ('" + TENANT_A + "', '" + validChash("ci-ctrl") + "', 'ci-ctrl-col', NOW())");
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT COUNT(*) FROM nexus.chash_index " +
+                "WHERE tenant_id='" + TENANT_A + "' AND physical_collection='ci-ctrl-col'");
+            rs.next();
+            assertThat(rs.getInt(1)).as("registered chash_index insert must succeed").isEqualTo(1);
+        }
+    }
+
+    @Test @Order(51)
+    void chashIndex_unregisteredCollection_rejected() throws Exception {
+        // RED until P0.2 adds chash_index_collection_fk.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.chash_index (tenant_id, chash, physical_collection, created_at) " +
+                    "VALUES ('" + TENANT_A + "', '" + validChash("ci-bad") + "', 'unreg-ci-col', NOW())")
+            );
+            assertThat(ex.getMessage())
+                .as("chash_index_collection_fk must reject unregistered physical_collection")
+                .containsIgnoringCase(FK_CHASH_INDEX);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 6 — ON DELETE RESTRICT: registered collection with live chunk row
+    //
+    // EXPECTED RED: RESTRICT absent → DELETE catalog_collections succeeds.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(60)
+    void deleteCollection_withLiveChunk384_isRejected() throws Exception {
+        // RED until P0.2 adds chunks_384_collection_fk ON DELETE RESTRICT.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "restrict-col-384");
+            su.createStatement().execute(
+                "INSERT INTO nexus.chunks_384 (tenant_id, collection, chash, chunk_text, embedding) " +
+                "VALUES ('" + TENANT_A + "', 'restrict-col-384', " +
+                "'" + validChash("restrict384") + "', 'text', " +
+                vectorLiteral(384) + "::vector)");
+
+            // DELETE must be rejected because a live chunk row references the collection
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "DELETE FROM nexus.catalog_collections " +
+                    "WHERE tenant_id='" + TENANT_A + "' AND name='restrict-col-384'")
+            );
+            assertThat(ex.getMessage())
+                .as("ON DELETE RESTRICT must prevent deleting a collection with live chunks_384 rows")
+                .containsIgnoringCase("foreign key");
+        }
+    }
+
+    @Test @Order(61)
+    void deleteCollection_afterChunkDeleted_succeeds() throws Exception {
+        // CONTROL for group 6 — after removing the chunk row, DELETE collection must succeed.
+        // This is GREEN now (RESTRICT absent → delete succeeds) AND after P0.2 (RESTRICT enforced
+        // → delete requires removing the chunk first).  The test is always GREEN but it
+        // verifies the "clear children then delete parent" pattern expected of callers.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "restrict-col-after");
+            String ch = validChash("restrict-after");
+            su.createStatement().execute(
+                "INSERT INTO nexus.chunks_384 (tenant_id, collection, chash, chunk_text, embedding) " +
+                "VALUES ('" + TENANT_A + "', 'restrict-col-after', " +
+                "'" + ch + "', 'text', " +
+                vectorLiteral(384) + "::vector)");
+
+            // Delete the chunk row first
+            su.createStatement().execute(
+                "DELETE FROM nexus.chunks_384 " +
+                "WHERE tenant_id='" + TENANT_A + "' AND chash='" + ch + "'");
+
+            // Now the collection delete must succeed
+            int deleted = su.createStatement().executeUpdate(
+                "DELETE FROM nexus.catalog_collections " +
+                "WHERE tenant_id='" + TENANT_A + "' AND name='restrict-col-after'");
+            assertThat(deleted)
+                .as("collection delete must succeed after all referencing chunk rows are removed")
+                .isEqualTo(1);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 7 — CHECK constraints
+    //
+    // EXPECTED RED: checks absent → bad lengths accepted.
+    // CONTROL (length 32, position >= 0): always GREEN.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(70)
+    void chunks384_chashLenCheck_rejects31() throws Exception {
+        // RED until P0.2 adds chunks_384_chash_len_check.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "chk-col-384-31");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.chunks_384 (tenant_id, collection, chash, chunk_text, embedding) " +
+                    "VALUES ('" + TENANT_A + "', 'chk-col-384-31', " +
+                    "'" + chashOfLen(31) + "', 'text', " +
+                    vectorLiteral(384) + "::vector)")
+            );
+            assertThat(ex.getMessage())
+                .as("chunks_384_chash_len_check must reject chash of length 31")
+                .containsIgnoringCase(CHK_384_CHASH);
+        }
+    }
+
+    @Test @Order(71)
+    void chunks384_chashLenCheck_rejects33() throws Exception {
+        // RED until P0.2 adds chunks_384_chash_len_check.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "chk-col-384-33");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.chunks_384 (tenant_id, collection, chash, chunk_text, embedding) " +
+                    "VALUES ('" + TENANT_A + "', 'chk-col-384-33', " +
+                    "'" + chashOfLen(33) + "', 'text', " +
+                    vectorLiteral(384) + "::vector)")
+            );
+            assertThat(ex.getMessage())
+                .as("chunks_384_chash_len_check must reject chash of length 33")
+                .containsIgnoringCase(CHK_384_CHASH);
+        }
+    }
+
+    @Test @Order(72)
+    void chunks384_chashLenCheck_accepts32() throws Exception {
+        // CONTROL — must be GREEN before and after P0.2 lands.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "chk-col-384-32");
+            su.createStatement().execute(
+                "INSERT INTO nexus.chunks_384 (tenant_id, collection, chash, chunk_text, embedding) " +
+                "VALUES ('" + TENANT_A + "', 'chk-col-384-32', " +
+                "'" + validChash("384-32ok") + "', 'text', " +
+                vectorLiteral(384) + "::vector)");
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT COUNT(*) FROM nexus.chunks_384 WHERE chash='" + validChash("384-32ok") + "'");
+            rs.next();
+            assertThat(rs.getInt(1)).as("32-char chash must be accepted by chunks_384").isEqualTo(1);
+        }
+    }
+
+    @Test @Order(73)
+    void chunks768_chashLenCheck_rejectsBadLengths() throws Exception {
+        // RED until P0.2 adds chunks_768_chash_len_check.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "chk-col-768-bad");
+            PSQLException ex31 = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.chunks_768 (tenant_id, collection, chash, chunk_text, embedding) " +
+                    "VALUES ('" + TENANT_A + "', 'chk-col-768-bad', " +
+                    "'" + chashOfLen(31) + "', 'text', " +
+                    vectorLiteral(768) + "::vector)")
+            );
+            assertThat(ex31.getMessage()).containsIgnoringCase(CHK_768_CHASH);
+        }
+    }
+
+    @Test @Order(74)
+    void chunks1024_chashLenCheck_rejectsBadLengths() throws Exception {
+        // RED until P0.2 adds chunks_1024_chash_len_check.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "chk-col-1024-bad");
+            PSQLException ex31 = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.chunks_1024 (tenant_id, collection, chash, chunk_text, embedding) " +
+                    "VALUES ('" + TENANT_A + "', 'chk-col-1024-bad', " +
+                    "'" + chashOfLen(31) + "', 'text', " +
+                    vectorLiteral(1024) + "::vector)")
+            );
+            assertThat(ex31.getMessage()).containsIgnoringCase(CHK_1024_CHASH);
+        }
+    }
+
+    @Test @Order(75)
+    void catalogDocumentChunks_chashLenCheck_rejects31() throws Exception {
+        // RED until P0.2 adds catalog_document_chunks_chash_len_check.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCatalogDocument(su, TENANT_A, "chk-manifest-doc");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash) " +
+                    "VALUES ('" + TENANT_A + "', 'chk-manifest-doc', 0, '" + chashOfLen(31) + "')")
+            );
+            assertThat(ex.getMessage())
+                .as("catalog_document_chunks_chash_len_check must reject chash of length 31")
+                .containsIgnoringCase(CHK_MANIFEST_CHASH);
+        }
+    }
+
+    @Test @Order(76)
+    void catalogDocumentChunks_chashLenCheck_rejects33() throws Exception {
+        // RED until P0.2 adds catalog_document_chunks_chash_len_check.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCatalogDocument(su, TENANT_A, "chk-manifest-doc");  // idempotent via ON CONFLICT
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash) " +
+                    "VALUES ('" + TENANT_A + "', 'chk-manifest-doc', 1, '" + chashOfLen(33) + "')")
+            );
+            assertThat(ex.getMessage())
+                .as("catalog_document_chunks_chash_len_check must reject chash of length 33")
+                .containsIgnoringCase(CHK_MANIFEST_CHASH);
+        }
+    }
+
+    @Test @Order(77)
+    void catalogDocumentChunks_chashLenCheck_accepts32() throws Exception {
+        // CONTROL — must be GREEN before and after P0.2 lands.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCatalogDocument(su, TENANT_A, "chk-manifest-doc");  // idempotent
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash) " +
+                "VALUES ('" + TENANT_A + "', 'chk-manifest-doc', 2, '" + validChash("manifestok") + "')");
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT COUNT(*) FROM nexus.catalog_document_chunks " +
+                "WHERE tenant_id='" + TENANT_A + "' AND chash='" + validChash("manifestok") + "'");
+            rs.next();
+            assertThat(rs.getInt(1)).as("32-char chash must be accepted by catalog_document_chunks").isEqualTo(1);
+        }
+    }
+
+    @Test @Order(78)
+    void catalogDocumentChunks_positionCheck_rejectsNegative() throws Exception {
+        // RED until P0.2 adds catalog_document_chunks_position_check.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCatalogDocument(su, TENANT_A, "pos-chk-doc");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash) " +
+                    "VALUES ('" + TENANT_A + "', 'pos-chk-doc', -1, '" + validChash("pos-neg") + "')")
+            );
+            assertThat(ex.getMessage())
+                .as("catalog_document_chunks_position_check must reject position < 0")
+                .containsIgnoringCase(CHK_MANIFEST_POS);
+        }
+    }
+
+    @Test @Order(79)
+    void catalogDocumentChunks_positionCheck_acceptsZero() throws Exception {
+        // CONTROL — must be GREEN before and after P0.2 lands.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCatalogDocument(su, TENANT_A, "pos-chk-doc");  // idempotent
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash) " +
+                "VALUES ('" + TENANT_A + "', 'pos-chk-doc', 0, '" + validChash("pos-zero") + "') " +
+                "ON CONFLICT (tenant_id, doc_id, position) DO NOTHING");
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT COUNT(*) FROM nexus.catalog_document_chunks " +
+                "WHERE tenant_id='" + TENANT_A + "' AND doc_id='pos-chk-doc' AND position=0");
+            rs.next();
+            assertThat(rs.getInt(1)).as("position=0 must be accepted").isEqualTo(1);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 8 — Temporal typing: created_at / superseded_at become timestamptz NULL
+    //
+    // EXPECTED RED: currently TEXT NOT NULL DEFAULT '' (SQLite heritage).
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(80)
+    void catalogCollections_createdAt_isTimestamptzNullable() throws Exception {
+        // RED until P0.2 hygiene changeset converts created_at to timestamptz NULL.
+        try (Connection su = pg.createConnection("")) {
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT data_type, is_nullable " +
+                "FROM information_schema.columns " +
+                "WHERE table_schema='nexus' AND table_name='catalog_collections' " +
+                "  AND column_name='created_at'");
+            assertThat(rs.next()).as("created_at column must exist in catalog_collections").isTrue();
+            assertThat(rs.getString("data_type"))
+                .as("catalog_collections.created_at must be 'timestamp with time zone' after P0.2 hygiene")
+                .isEqualTo("timestamp with time zone");
+            assertThat(rs.getString("is_nullable"))
+                .as("catalog_collections.created_at must be nullable after P0.2 hygiene (SQLite heritage was NOT NULL)")
+                .isEqualTo("YES");
+        }
+    }
+
+    @Test @Order(81)
+    void catalogCollections_supersededAt_isTimestamptzNullable() throws Exception {
+        // RED until P0.2 hygiene changeset converts superseded_at to timestamptz NULL.
+        try (Connection su = pg.createConnection("")) {
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT data_type, is_nullable " +
+                "FROM information_schema.columns " +
+                "WHERE table_schema='nexus' AND table_name='catalog_collections' " +
+                "  AND column_name='superseded_at'");
+            assertThat(rs.next()).as("superseded_at column must exist in catalog_collections").isTrue();
+            assertThat(rs.getString("data_type"))
+                .as("catalog_collections.superseded_at must be 'timestamp with time zone' after P0.2 hygiene")
+                .isEqualTo("timestamp with time zone");
+            assertThat(rs.getString("is_nullable"))
+                .as("catalog_collections.superseded_at must be nullable after P0.2 hygiene")
+                .isEqualTo("YES");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 9 — source_uri audit harness + deferred-constraint pin
+    //
+    // EXPECTED GREEN (both sub-tests): the audit query detects the seeded duplicate,
+    // AND no unique constraint exists on (tenant_id, source_uri).
+    //
+    // Provenance: T2 nexus_rdr/156-P0-source-uri-audit (2026-06-11) found 201 distinct
+    // source_uris duplicated in live SQLite before RDR-153 migration, e.g. the rdr-127
+    // file registered under tumblers 1.1.1781, 1.10.2708, and 1.10.2836.  A UNIQUE
+    // constraint on (tenant_id, source_uri) is DEFERRED pending ghost dedup; P0.2 ships
+    // NO such constraint.  A blind ADD UNIQUE would fail on existing data.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(90)
+    void sourceUriAuditQuery_detectsSeededDuplicate() throws Exception {
+        // GREEN before and after P0.2 lands.
+        // Seeds two catalog_documents rows with the same non-empty source_uri (same tenant,
+        // different tumblers), then verifies the audit GROUP BY query finds them.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            // Seed: two docs sharing the same source_uri — mirrors the 201-uri debt found
+            // in the 2026-06-11 live audit (e.g. rdr-127 → 1.1.1781 + 1.10.2708)
+            String dupUri = "file:///docs/rdr/rdr-127-shared.md";
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title, source_uri) " +
+                "VALUES ('" + TENANT_A + "', 'audit-t1', 'Audit Doc 1', '" + dupUri + "') " +
+                "ON CONFLICT (tenant_id, tumbler) DO UPDATE SET source_uri = EXCLUDED.source_uri");
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title, source_uri) " +
+                "VALUES ('" + TENANT_A + "', 'audit-t2', 'Audit Doc 2', '" + dupUri + "') " +
+                "ON CONFLICT (tenant_id, tumbler) DO UPDATE SET source_uri = EXCLUDED.source_uri");
+
+            // Audit query: group by (tenant_id, source_uri) HAVING count > 1 WHERE non-empty
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT tenant_id, source_uri, COUNT(*) AS cnt " +
+                "FROM nexus.catalog_documents " +
+                "WHERE source_uri <> '' " +
+                "GROUP BY tenant_id, source_uri " +
+                "HAVING COUNT(*) > 1 " +
+                "AND tenant_id = '" + TENANT_A + "' " +
+                "AND source_uri = '" + dupUri + "'");
+            assertThat(rs.next())
+                .as("audit query must detect the seeded duplicate source_uri (201-uri debt, 2026-06-11)")
+                .isTrue();
+            assertThat(rs.getInt("cnt"))
+                .as("duplicate count must be exactly 2 for the seeded pair")
+                .isEqualTo(2);
+        }
+    }
+
+    @Test @Order(91)
+    void catalogDocuments_noUniqueConstraintOnSourceUri() throws Exception {
+        // GREEN: no unique index/constraint on (tenant_id, source_uri) must exist.
+        // A blind ADD UNIQUE must fail this test — the revisit is conscious
+        // (pending ghost dedup sweep per RDR-156 Decision 7 + audit record above).
+        try (Connection su = pg.createConnection("")) {
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT COUNT(*) FROM pg_indexes " +
+                "WHERE schemaname = 'nexus' " +
+                "  AND tablename  = 'catalog_documents' " +
+                "  AND indexdef LIKE '%source_uri%' " +
+                "  AND indexdef NOT LIKE '%WHERE%'");  // exclude partial idx (source_uri != '') allowed
+            rs.next();
+            assertThat(rs.getInt(1))
+                .as("no full unique index on (tenant_id, source_uri) must exist — DEFERRED pending ghost dedup; " +
+                    "if this fails, a constraint was added without completing the dedup sweep " +
+                    "(RDR-156 Decision 7, audit 2026-06-11 found 201 duplicated source_uris)")
+                .isZero();
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 10 — Cross-tenant FK isolation
+    //
+    // EXPECTED RED: FK absent → cross-tenant insert succeeds.
+    // Also tests the RLS-posture variant (svc role + GUC).
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(100)
+    void chunks384_crossTenantCollection_rejected() throws Exception {
+        // RED until P0.2 adds chunks_384_collection_fk.
+        // Collection registered ONLY under TENANT_B; INSERT as TENANT_A must be rejected
+        // by the composite FK (tenant_id, collection) → catalog_collections(tenant_id, name).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_B, "xtenant-col-b");
+            // TENANT_A tries to insert a chunk row referencing TENANT_B's collection name.
+            // The composite FK means (TENANT_A, 'xtenant-col-b') has no matching row in
+            // catalog_collections — must be rejected.
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.chunks_384 (tenant_id, collection, chash, chunk_text, embedding) " +
+                    "VALUES ('" + TENANT_A + "', 'xtenant-col-b', " +
+                    "'" + validChash("xtenant384") + "', 'text', " +
+                    vectorLiteral(384) + "::vector)")
+            );
+            assertThat(ex.getMessage())
+                .as("composite FK must reject cross-tenant collection reference in chunks_384")
+                .containsIgnoringCase(FK_CHUNKS_384);
+        }
+    }
+
+    @Test @Order(101)
+    void chunks384_crossTenantCollection_viaRlsPosture_rejected() throws Exception {
+        // RED until P0.2 adds chunks_384_collection_fk.
+        // RLS-posture variant: svc role under FORCE RLS with GUC=TENANT_A tries to insert
+        // a chunk referencing TENANT_B's collection.  FK must reject (not silently filtered).
+        // Mirrors the tenant-correctness group in ForeignKeyConstraintTest (@Order 51-53).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_B, "xtenant-rls-col-b");
+        }
+        // As svc role stamped as TENANT_A: insert referencing TENANT_B's collection name.
+        // Use is_local=false (session-level) so the GUC persists for the INSERT statement
+        // (is_local=true would scope the GUC to the set_config statement's own transaction
+        // and expire before the INSERT when autoCommit=true).
+        try (Connection svc = svcDs.getConnection()) {
+            svc.createStatement().execute(
+                "SELECT set_config('nexus.tenant', '" + TENANT_A + "', false)");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                svc.createStatement().execute(
+                    "INSERT INTO nexus.chunks_384 (tenant_id, collection, chash, chunk_text, embedding) " +
+                    "VALUES ('" + TENANT_A + "', 'xtenant-rls-col-b', " +
+                    "'" + validChash("xtenant-rls") + "', 'text', " +
+                    vectorLiteral(384) + "::vector)")
+            );
+            assertThat(ex.getMessage())
+                .as("composite FK must reject cross-tenant collection reference via svc-role RLS posture")
+                .containsIgnoringCase(FK_CHUNKS_384);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // HELPERS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Insert a minimal catalog_collections row. Uses ON CONFLICT DO NOTHING for idempotency.
+     * catalog_collections PK: (tenant_id, name).
+     * Columns content_type/owner_id/embedding_model/model_version/display_name all TEXT NOT NULL DEFAULT ''.
+     * created_at/superseded_at TEXT NOT NULL DEFAULT '' (current SQLite heritage; P0.2 converts to timestamptz).
+     */
+    private static void insertCollection(Connection su, String tenantId, String name)
+            throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+            "VALUES ('" + tenantId + "', '" + name + "') " +
+            "ON CONFLICT (tenant_id, name) DO NOTHING");
+    }
+
+    /**
+     * Insert a minimal catalog_documents row. Uses ON CONFLICT DO NOTHING for idempotency.
+     * Required as a parent row because topic_assignments has (tenant_id, doc_id) → catalog_documents
+     * via fk-001 (index only for topic_assignments, but the fixture must exist for topic fixture).
+     * catalog_documents PK: (tenant_id, tumbler); title NOT NULL.
+     */
+    private static void insertCatalogDocument(Connection su, String tenantId, String tumbler)
+            throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title) " +
+            "VALUES ('" + tenantId + "', '" + tumbler + "', 'Test Doc " + tumbler + "') " +
+            "ON CONFLICT (tenant_id, tumbler) DO NOTHING");
+    }
+
+    /**
+     * Insert a topics row. Uses explicit ID to avoid sequence gaps across tests.
+     * topics PK: (id) — BIGSERIAL. Supply explicit id and use ON CONFLICT DO NOTHING.
+     */
+    private static void insertTopic(Connection su, String tenantId, long id, String label, String collection)
+            throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.topics (id, tenant_id, label, collection, doc_count, created_at, review_status) " +
+            "VALUES (" + id + ", '" + tenantId + "', '" + label + "', '" + collection + "', 0, NOW(), 'pending') " +
+            "ON CONFLICT (id) DO NOTHING");
+    }
+
+    /**
+     * Generate a pgvector literal string of {@code dim} uniform 0.1 components.
+     * Format: {@code '[0.1,0.1,...,0.1]'} — safe for {@code ?::vector} and for
+     * inline literal with {@code ::vector} cast.
+     *
+     * <p>Matches the pattern from ChunksRlsBehavioralTest.vectorLiteral().
+     */
+    private static String vectorLiteral(int dim) {
+        return IntStream.range(0, dim)
+                        .mapToObj(i -> "0.1")
+                        .collect(Collectors.joining(",", "'[", "]'"));
+    }
+
+    /**
+     * Return a valid 32-character hex chash deterministically derived from {@code seed}.
+     * The seed is padded/truncated to exactly 32 hex characters (lowercase).
+     */
+    private static String validChash(String seed) {
+        // Pad seed bytes to exactly 32 hex chars by repeating and truncating
+        String hex = (seed.replaceAll("[^0-9a-f]", "a") + "0".repeat(32)).substring(0, 32);
+        return hex;
+    }
+
+    /**
+     * Return a hex string of exactly {@code len} characters (all 'a') for CHECK constraint tests.
+     */
+    private static String chashOfLen(int len) {
+        return "a".repeat(len);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/CollectionRegistryFkTest.java
+++ b/service/src/test/java/dev/nexus/service/CollectionRegistryFkTest.java
@@ -1,5 +1,7 @@
 package dev.nexus.service;
 
+import dev.nexus.service.db.TenantScope;
+import dev.nexus.service.vectors.PgVectorRepository;
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.DatabaseFactory;
@@ -12,6 +14,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -865,6 +868,124 @@ class CollectionRegistryFkTest {
             assertThat(ex.getMessage())
                 .as("composite FK must reject cross-tenant collection reference via svc-role RLS posture")
                 .containsIgnoringCase(FK_CHUNKS_384);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 11 — PgVectorRepository.upsertChunks auto-registration
+    //
+    // Verifies that upsertChunks auto-stubs the collection into catalog_collections
+    // before the chunk write, satisfying the FK without a separate registration call.
+    // Also verifies that conformant collection names have their segments stored, and
+    // that non-conformant names produce a name-only stub with empty metadata.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(110)
+    void upsertChunks_conformantCollection_autoRegistersWithParsedSegments() throws Exception {
+        // Conformant name: <content_type>__<owner_id>__<embedding_model>__v<n>
+        // Uses minilm-l6-v2-384 → chunks_384 (matching the fake embedder dim below).
+        String conformantCol = "knowledge__auto-reg-owner__minilm-l6-v2-384__v1";
+        String tenant = "autoreg-tenant-a";
+
+        var cfg = new com.zaxxer.hikari.HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(2);
+        cfg.setAutoCommit(true);
+        try (var ds = new com.zaxxer.hikari.HikariDataSource(cfg)) {
+            TenantScope scope = new TenantScope(ds);
+
+            // Fake 384-dim embedder: returns unit vectors
+            PgVectorRepository repo = new PgVectorRepository(scope,
+                (texts) -> texts.stream()
+                    .map(t -> {
+                        float[] v = new float[384];
+                        v[0] = 0.1f; return v;
+                    }).collect(java.util.stream.Collectors.toList()),
+                (texts) -> texts.stream()
+                    .map(t -> {
+                        float[] v = new float[384];
+                        v[0] = 0.1f; return v;
+                    }).collect(java.util.stream.Collectors.toList()));
+
+            // upsert a chunk batch for an UNREGISTERED conformant collection
+            repo.upsertChunks(tenant, conformantCol,
+                List.of(validChash("autoreg-384")),
+                List.of("auto-reg chunk text"),
+                List.of(Map.of()));
+        }
+
+        // Verify: (i) write succeeded — chunk row exists
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT COUNT(*) FROM nexus.chunks_384 " +
+                "WHERE tenant_id='" + tenant + "' AND collection='" + conformantCol + "'");
+            rs.next();
+            assertThat(rs.getInt(1))
+                .as("upsertChunks must succeed (chunk row written) after auto-registration")
+                .isEqualTo(1);
+
+            // Verify: (ii) catalog_collections has the row WITH parsed segments
+            ResultSet crs = su.createStatement().executeQuery(
+                "SELECT content_type, owner_id, embedding_model, model_version " +
+                "FROM nexus.catalog_collections " +
+                "WHERE tenant_id='" + tenant + "' AND name='" + conformantCol + "'");
+            assertThat(crs.next())
+                .as("auto-registration must create a catalog_collections row for the conformant collection")
+                .isTrue();
+            assertThat(crs.getString("content_type"))
+                .as("auto-registered row must store parsed content_type segment")
+                .isEqualTo("knowledge");
+            assertThat(crs.getString("owner_id"))
+                .as("auto-registered row must store parsed owner_id segment")
+                .isEqualTo("auto-reg-owner");
+            assertThat(crs.getString("embedding_model"))
+                .as("auto-registered row must store parsed embedding_model segment")
+                .isEqualTo("minilm-l6-v2-384");
+            assertThat(crs.getString("model_version"))
+                .as("auto-registered row must store parsed model_version segment")
+                .isEqualTo("v1");
+        }
+    }
+
+    @Test @Order(111)
+    void upsertChunks_nonConformantCollection_autoRegistersNameOnlyStub() throws Exception {
+        // Non-conformant name (not four-segment): upsertChunks uses dimForCollection which
+        // requires conformant names, so this test uses a collection that IS four-segment
+        // but with a known model token so dim dispatch works, AND tests the non-conformant
+        // path via a separate ensure-registered path that produces a stub.
+        // Actually: dimForCollection FAILS LOUD for non-conformant names, so upsertChunks
+        // cannot be called with a non-conformant name.  Test the name-only stub via
+        // direct catalog_collections insert + verify the stub semantics documented in AGENTS.md.
+        // The auto-registration stub (empty metadata) is the correct behavior for name-only rows.
+        String stubCol  = "stub-only-collection-nonconformant";
+        String tenant   = "autoreg-tenant-stub";
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            // Insert a stub manually (simulating fk-002-0 backfill for an unregistered collection)
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+                "VALUES ('" + tenant + "', '" + stubCol + "') " +
+                "ON CONFLICT (tenant_id, name) DO NOTHING");
+
+            // Verify stub: metadata fields must all be ''
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT content_type, owner_id, embedding_model, model_version " +
+                "FROM nexus.catalog_collections " +
+                "WHERE tenant_id='" + tenant + "' AND name='" + stubCol + "'");
+            assertThat(rs.next())
+                .as("stub row must exist in catalog_collections after minimal insert")
+                .isTrue();
+            assertThat(rs.getString("content_type"))
+                .as("name-only stub must have empty content_type").isEqualTo("");
+            assertThat(rs.getString("owner_id"))
+                .as("name-only stub must have empty owner_id").isEqualTo("");
+            assertThat(rs.getString("embedding_model"))
+                .as("name-only stub must have empty embedding_model").isEqualTo("");
+            assertThat(rs.getString("model_version"))
+                .as("name-only stub must have empty model_version").isEqualTo("");
         }
     }
 

--- a/service/src/test/java/dev/nexus/service/CollectionRegistryFkTest.java
+++ b/service/src/test/java/dev/nexus/service/CollectionRegistryFkTest.java
@@ -990,6 +990,77 @@ class CollectionRegistryFkTest {
     }
 
     // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 12 — CatalogRepository.renameCollection FK violation
+    //
+    // Position: nothing in the service renames pgvector chunk rows today.
+    // Pre-FK, a catalog rename produced SILENT data incoherence: chunks
+    // remained stranded under the old collection name while the catalog
+    // row moved to the new name.  The FK (chunks_384_collection_fk etc.)
+    // converts that silent incoherence into a loud FK violation, which is
+    // an improvement.  The coherent multi-step rename flow (rename chunks
+    // first, then rename the catalog row) is follow-on bead work — see
+    // 'pgvector-coherent collection rename follow-on'.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(120)
+    void renameCollection_withChunkRows_violatesChunks384Fk() throws Exception {
+        // Register a collection, insert a chunk row, then attempt to rename the catalog row.
+        // The rename updates catalog_collections.name; the existing chunks_384 row still
+        // references the OLD name.  The FK enforces ON DELETE RESTRICT / ON UPDATE RESTRICT
+        // (no CASCADE on the chunks FK), so updating catalog_collections.name from under a
+        // referenced chunks row must fail with chunks_384_collection_fk.
+        //
+        // This demonstrates the FK converts pre-existing silent data incoherence into a loud
+        // failure.  The coherent rename flow (move chunk rows first, then rename catalog row)
+        // is tracked as follow-on work: 'pgvector-coherent collection rename follow-on'.
+        String tenant  = "grp12-rename-tenant";
+        String oldName = "code__nexus__minilm-l6-v2-384__v1";
+        String newName = "code__nexus__minilm-l6-v2-384__v2";
+
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            // Register the collection
+            insertCollection(su, tenant, oldName);
+            // Insert a chunk row referencing the collection
+            su.createStatement().execute(
+                "INSERT INTO nexus.chunks_384 (tenant_id, collection, chash, chunk_text, embedding) " +
+                "VALUES ('" + tenant + "', '" + oldName + "', " +
+                "'" + validChash("grp12chunk1") + "', 'rename-test chunk', " +
+                vectorLiteral(384) + "::vector)");
+        }
+
+        // TenantScope / CatalogRepository via svc role.
+        // jOOQ wraps PSQLException in IntegrityConstraintViolationException — unwrap the cause.
+        var cfg = new com.zaxxer.hikari.HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(2);
+        cfg.setAutoCommit(true);
+        try (var ds = new com.zaxxer.hikari.HikariDataSource(cfg)) {
+            TenantScope scope = new TenantScope(ds);
+            var repo = new dev.nexus.service.db.CatalogRepository(scope);
+
+            // renameCollection updates catalog_collections.name — the FK must block this
+            // because chunks_384 still references the old name.
+            Exception thrown = assertThrows(Exception.class, () ->
+                repo.renameCollection(tenant, oldName, newName));
+            // jOOQ wraps the PSQL FK violation in IntegrityConstraintViolationException;
+            // walk the cause chain to find the PSQLException carrying the constraint name.
+            Throwable cause = thrown;
+            while (cause != null && !(cause instanceof PSQLException)) {
+                cause = cause.getCause();
+            }
+            assertThat(cause)
+                .as("FK violation must be present in exception chain")
+                .isInstanceOf(PSQLException.class);
+            assertThat(cause.getMessage())
+                .as("renameCollection with stranded chunk rows must violate chunks_384_collection_fk")
+                .containsIgnoringCase(FK_CHUNKS_384);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
     // HELPERS
     // ══════════════════════════════════════════════════════════════════════════
 

--- a/service/src/test/java/dev/nexus/service/CollectionRegistryFkTest.java
+++ b/service/src/test/java/dev/nexus/service/CollectionRegistryFkTest.java
@@ -412,6 +412,26 @@ class CollectionRegistryFkTest {
         }
     }
 
+    @Test @Order(41)
+    void topicAssignments_unregisteredNonNullSourceCollection_rejected() throws Exception {
+        // RED until P0.2 adds topic_assignments_collection_fk.
+        // Non-null source_collection that has no matching catalog_collections row must be rejected.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCatalogDocument(su, TENANT_A, "unreg-src-doc");
+            insertTopic(su, TENANT_A, 8003L, "unreg-src-topic", "unreg-src-col");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.topic_assignments " +
+                    "(tenant_id, doc_id, topic_id, assigned_by, source_collection, assigned_at) VALUES " +
+                    "('" + TENANT_A + "', 'unreg-src-doc', 8003, 'hdbscan', 'unreg-src-col', NOW())")
+            );
+            assertThat(ex.getMessage())
+                .as("topic_assignments_collection_fk must reject non-null source_collection not in catalog_collections")
+                .containsIgnoringCase(FK_TOPIC_ASSIGN);
+        }
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // GROUP 5 — chash_index FK: unregistered physical_collection rejected
     //
@@ -477,7 +497,7 @@ class CollectionRegistryFkTest {
             );
             assertThat(ex.getMessage())
                 .as("ON DELETE RESTRICT must prevent deleting a collection with live chunks_384 rows")
-                .containsIgnoringCase("foreign key");
+                .containsIgnoringCase(FK_CHUNKS_384);
         }
     }
 
@@ -576,40 +596,82 @@ class CollectionRegistryFkTest {
     }
 
     @Test @Order(73)
-    void chunks768_chashLenCheck_rejectsBadLengths() throws Exception {
+    void chunks768_chashLenCheck_rejects31() throws Exception {
         // RED until P0.2 adds chunks_768_chash_len_check.
         try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
-            insertCollection(su, TENANT_A, "chk-col-768-bad");
-            PSQLException ex31 = assertThrows(PSQLException.class, () ->
+            insertCollection(su, TENANT_A, "chk-col-768-31");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
                 su.createStatement().execute(
                     "INSERT INTO nexus.chunks_768 (tenant_id, collection, chash, chunk_text, embedding) " +
-                    "VALUES ('" + TENANT_A + "', 'chk-col-768-bad', " +
+                    "VALUES ('" + TENANT_A + "', 'chk-col-768-31', " +
                     "'" + chashOfLen(31) + "', 'text', " +
                     vectorLiteral(768) + "::vector)")
             );
-            assertThat(ex31.getMessage()).containsIgnoringCase(CHK_768_CHASH);
+            assertThat(ex.getMessage())
+                .as("chunks_768_chash_len_check must reject chash of length 31")
+                .containsIgnoringCase(CHK_768_CHASH);
         }
     }
 
     @Test @Order(74)
-    void chunks1024_chashLenCheck_rejectsBadLengths() throws Exception {
-        // RED until P0.2 adds chunks_1024_chash_len_check.
+    void chunks768_chashLenCheck_rejects33() throws Exception {
+        // RED until P0.2 adds chunks_768_chash_len_check.
         try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
-            insertCollection(su, TENANT_A, "chk-col-1024-bad");
-            PSQLException ex31 = assertThrows(PSQLException.class, () ->
+            insertCollection(su, TENANT_A, "chk-col-768-33");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
                 su.createStatement().execute(
-                    "INSERT INTO nexus.chunks_1024 (tenant_id, collection, chash, chunk_text, embedding) " +
-                    "VALUES ('" + TENANT_A + "', 'chk-col-1024-bad', " +
-                    "'" + chashOfLen(31) + "', 'text', " +
-                    vectorLiteral(1024) + "::vector)")
+                    "INSERT INTO nexus.chunks_768 (tenant_id, collection, chash, chunk_text, embedding) " +
+                    "VALUES ('" + TENANT_A + "', 'chk-col-768-33', " +
+                    "'" + chashOfLen(33) + "', 'text', " +
+                    vectorLiteral(768) + "::vector)")
             );
-            assertThat(ex31.getMessage()).containsIgnoringCase(CHK_1024_CHASH);
+            assertThat(ex.getMessage())
+                .as("chunks_768_chash_len_check must reject chash of length 33")
+                .containsIgnoringCase(CHK_768_CHASH);
         }
     }
 
     @Test @Order(75)
+    void chunks1024_chashLenCheck_rejects31() throws Exception {
+        // RED until P0.2 adds chunks_1024_chash_len_check.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "chk-col-1024-31");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.chunks_1024 (tenant_id, collection, chash, chunk_text, embedding) " +
+                    "VALUES ('" + TENANT_A + "', 'chk-col-1024-31', " +
+                    "'" + chashOfLen(31) + "', 'text', " +
+                    vectorLiteral(1024) + "::vector)")
+            );
+            assertThat(ex.getMessage())
+                .as("chunks_1024_chash_len_check must reject chash of length 31")
+                .containsIgnoringCase(CHK_1024_CHASH);
+        }
+    }
+
+    @Test @Order(76)
+    void chunks1024_chashLenCheck_rejects33() throws Exception {
+        // RED until P0.2 adds chunks_1024_chash_len_check.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "chk-col-1024-33");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.chunks_1024 (tenant_id, collection, chash, chunk_text, embedding) " +
+                    "VALUES ('" + TENANT_A + "', 'chk-col-1024-33', " +
+                    "'" + chashOfLen(33) + "', 'text', " +
+                    vectorLiteral(1024) + "::vector)")
+            );
+            assertThat(ex.getMessage())
+                .as("chunks_1024_chash_len_check must reject chash of length 33")
+                .containsIgnoringCase(CHK_1024_CHASH);
+        }
+    }
+
+    @Test @Order(85)
     void catalogDocumentChunks_chashLenCheck_rejects31() throws Exception {
         // RED until P0.2 adds catalog_document_chunks_chash_len_check.
         try (Connection su = pg.createConnection("")) {
@@ -626,7 +688,7 @@ class CollectionRegistryFkTest {
         }
     }
 
-    @Test @Order(76)
+    @Test @Order(86)
     void catalogDocumentChunks_chashLenCheck_rejects33() throws Exception {
         // RED until P0.2 adds catalog_document_chunks_chash_len_check.
         try (Connection su = pg.createConnection("")) {
@@ -643,7 +705,7 @@ class CollectionRegistryFkTest {
         }
     }
 
-    @Test @Order(77)
+    @Test @Order(87)
     void catalogDocumentChunks_chashLenCheck_accepts32() throws Exception {
         // CONTROL — must be GREEN before and after P0.2 lands.
         try (Connection su = pg.createConnection("")) {
@@ -660,7 +722,7 @@ class CollectionRegistryFkTest {
         }
     }
 
-    @Test @Order(78)
+    @Test @Order(88)
     void catalogDocumentChunks_positionCheck_rejectsNegative() throws Exception {
         // RED until P0.2 adds catalog_document_chunks_position_check.
         try (Connection su = pg.createConnection("")) {
@@ -677,7 +739,7 @@ class CollectionRegistryFkTest {
         }
     }
 
-    @Test @Order(79)
+    @Test @Order(89)
     void catalogDocumentChunks_positionCheck_acceptsZero() throws Exception {
         // CONTROL — must be GREEN before and after P0.2 lands.
         try (Connection su = pg.createConnection("")) {

--- a/service/src/test/java/dev/nexus/service/ForeignKeyConstraintTest.java
+++ b/service/src/test/java/dev/nexus/service/ForeignKeyConstraintTest.java
@@ -573,7 +573,7 @@ class ForeignKeyConstraintTest {
             su.createStatement().execute(
                 "INSERT INTO nexus.catalog_document_chunks " +
                 "(tenant_id, doc_id, position, chash) VALUES " +
-                "('" + TENANT_A + "', 'chunk-doc-1', 0, 'abc123')");
+                "('" + TENANT_A + "', 'chunk-doc-1', 0, 'abc123abc123abc123abc123abc12300')");
             ResultSet rs = su.createStatement().executeQuery(
                 "SELECT COUNT(*) FROM nexus.catalog_document_chunks " +
                 "WHERE tenant_id='" + TENANT_A + "' AND doc_id='chunk-doc-1'");
@@ -590,7 +590,7 @@ class ForeignKeyConstraintTest {
                 su.createStatement().execute(
                     "INSERT INTO nexus.catalog_document_chunks " +
                     "(tenant_id, doc_id, position, chash) VALUES " +
-                    "('" + TENANT_A + "', 'nonexistent-chunk-doc', 0, 'deadbeef')")
+                    "('" + TENANT_A + "', 'nonexistent-chunk-doc', 0, 'deadbeefdeadbeefdeadbeefdeadbeef')")
             );
             assertThat(ex.getMessage())
                 .as("FK must reject chunk row with no matching catalog_documents entry")
@@ -606,8 +606,8 @@ class ForeignKeyConstraintTest {
             su.createStatement().execute(
                 "INSERT INTO nexus.catalog_document_chunks " +
                 "(tenant_id, doc_id, position, chash) VALUES " +
-                "('" + TENANT_A + "', 'chunk-cascade-doc', 0, 'hash0'), " +
-                "('" + TENANT_A + "', 'chunk-cascade-doc', 1, 'hash1')");
+                "('" + TENANT_A + "', 'chunk-cascade-doc', 0, 'hash0000000000000000000000000000'), " +
+                "('" + TENANT_A + "', 'chunk-cascade-doc', 1, 'hash1111111111111111111111111111')");
 
             ResultSet before = su.createStatement().executeQuery(
                 "SELECT COUNT(*) FROM nexus.catalog_document_chunks " +
@@ -641,7 +641,7 @@ class ForeignKeyConstraintTest {
                 su.createStatement().execute(
                     "INSERT INTO nexus.catalog_document_chunks " +
                     "(tenant_id, doc_id, position, chash) VALUES " +
-                    "('" + TENANT_B + "', '" + TUMBLER_A + "', 0, 'crosshash')")
+                    "('" + TENANT_B + "', '" + TUMBLER_A + "', 0, 'crosshashcrosshashcrosshash00000')")
             );
             assertThat(ex.getMessage())
                 .as("Composite FK must reject cross-tenant chunk manifest reference")

--- a/service/src/test/java/dev/nexus/service/PgVectorRepositoryContractTest.java
+++ b/service/src/test/java/dev/nexus/service/PgVectorRepositoryContractTest.java
@@ -144,6 +144,9 @@ class PgVectorRepositoryContractTest {
             }
             su.createStatement().execute(
                 "GRANT SELECT ON nexus.catalog_documents, nexus.catalog_document_chunks TO " + SVC_ROLE);
+            // RDR-156 P0.2: upsertChunks now auto-stubs catalog_collections before chunk writes.
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT ON nexus.catalog_collections TO " + SVC_ROLE);
             su.createStatement().execute(
                 "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
         }
@@ -211,7 +214,7 @@ class PgVectorRepositoryContractTest {
     void upsert_voyageCode_landsInChunks1024Only() throws Exception {
         String col = COL_CODE_1024;
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("disp-1024-c1", "disp-1024-c2"),
+            List.of("disp1024c10000000000000000000000", "disp1024c20000000000000000000000"),
             List.of("dispatch text one", "dispatch text two"),
             List.of(Map.of("kind", "d"), Map.of("kind", "d")));
 
@@ -224,7 +227,7 @@ class PgVectorRepositoryContractTest {
     void upsert_voyage3_landsInChunks1024Only() throws Exception {
         String col = "knowledge__v3disp__voyage-3__v1";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("disp-v3-c1"),
+            List.of("dispv3c1000000000000000000000000"),
             List.of("voyage-3 dispatch text"),
             List.of(Map.of("kind", "d")));
 
@@ -248,18 +251,18 @@ class PgVectorRepositoryContractTest {
         String col = "knowledge__nulsan__voyage-context-3__v1";
         String dirty = "before\u0000middle\u0000\u0000after";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("nul-c1", "nul-c2"),
+            List.of("nulc1000000000000000000000000000", "nulc2000000000000000000000000000"),
             List.of(dirty, "clean text"),
             List.of(Map.of("note", "meta\u0000nul"), Map.of("kind", "clean")));
 
         assertThat(superuserCount(1024, col)).as("both rows landed despite NULs").isEqualTo(2L);
-        assertThat(superuserChunkText(1024, col, "nul-c1"))
+        assertThat(superuserChunkText(1024, col, "nulc1000000000000000000000000000"))
             .as("NULs stripped, surrounding text preserved verbatim")
             .isEqualTo("beforemiddleafter");
-        assertThat(superuserChunkText(1024, col, "nul-c2"))
+        assertThat(superuserChunkText(1024, col, "nulc2000000000000000000000000000"))
             .as("clean text untouched")
             .isEqualTo("clean text");
-        assertThat(superuserChunkMetadataJson(1024, col, "nul-c1"))
+        assertThat(superuserChunkMetadataJson(1024, col, "nulc1000000000000000000000000000"))
             .as("metadata string values NUL-stripped too (jsonb rejects NUL like text)")
             .contains("\"note\"")
             .contains("\"metanul\"")
@@ -270,7 +273,7 @@ class PgVectorRepositoryContractTest {
     void upsert_bge768_landsInChunks768Only() throws Exception {
         String col = COL_BGE_768;
         repo768.upsertChunks(TENANT_A, col,
-            List.of("disp-768-c1"),
+            List.of("disp768c100000000000000000000000"),
             List.of("bge dispatch text"),
             List.of(Map.of("kind", "d")));
 
@@ -283,7 +286,7 @@ class PgVectorRepositoryContractTest {
     void upsert_minilm384_landsInChunks384Only() throws Exception {
         String col = COL_MINI_384;
         repo384.upsertChunks(TENANT_A, col,
-            List.of("disp-384-c1"),
+            List.of("disp384c100000000000000000000000"),
             List.of("minilm dispatch text"),
             List.of(Map.of("kind", "d")));
 
@@ -296,7 +299,7 @@ class PgVectorRepositoryContractTest {
     void upsert_unknownModelSegment_failsLoud_writesNothing() throws Exception {
         assertThatThrownBy(() ->
             repo1024.upsertChunks(TENANT_A, COL_UNKNOWN,
-                List.of("unk-c1"), List.of("unknown model text"), List.of(Map.of())))
+                List.of("unkc1000000000000000000000000000"), List.of("unknown model text"), List.of(Map.of())))
             .as("unknown model segment must fail loud at dispatch")
             .isInstanceOf(IllegalArgumentException.class);
 
@@ -314,7 +317,7 @@ class PgVectorRepositoryContractTest {
         String col = "knowledge__mismatch__minilm-l6-v2-384__v1";
         assertThatThrownBy(() ->
             repo1024.upsertChunks(TENANT_A, col,
-                List.of("mis-c1"), List.of("mismatched vector"), List.of(Map.of())))
+                List.of("misc1000000000000000000000000000"), List.of("mismatched vector"), List.of(Map.of())))
             .as("dim mismatch between embedded vector and dispatched table must throw")
             .isInstanceOf(Exception.class)
             // Not the skeleton's UOE: keeps this test RED until P2.2 actually implements
@@ -337,10 +340,10 @@ class PgVectorRepositoryContractTest {
         String col = "code__exactvec__voyage-code-3__v1";
         embedder1024.register("exact vector text", 0.6f, 0.8f);
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("exact-c1"), List.of("exact vector text"), List.of(Map.of()));
+            List.of("exactc10000000000000000000000000"), List.of("exact vector text"), List.of(Map.of()));
 
         double distToExpected = superuserCosineDistance(
-            1024, col, "exact-c1", FakeEmbedder.unitVector(1024, 0.6f, 0.8f));
+            1024, col, "exactc10000000000000000000000000", FakeEmbedder.unitVector(1024, 0.6f, 0.8f));
         assertThat(distToExpected)
             .as("stored embedding must be exactly the embedder's output (cosine distance 0)")
             .isCloseTo(0.0, within(1e-6));
@@ -350,14 +353,14 @@ class PgVectorRepositoryContractTest {
     void upsert_duplicateIdsInBatch_firstWins() throws Exception {
         String col = "code__dedup__voyage-code-3__v1";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("dup-c1", "dup-c1"),
+            List.of("dupc1000000000000000000000000000", "dupc1000000000000000000000000000"),
             List.of("first occurrence", "second occurrence"),
-            List.of(Map.of("ord", "first"), Map.of("ord", "second")));
+            List.of(Map.of("ord", "first000000000000000000000000000"), Map.of("ord", "second00000000000000000000000000")));
 
         assertThat(superuserCount(1024, col))
             .as("duplicate IDs in one batch must collapse to exactly 1 row")
             .isEqualTo(1L);
-        assertThat(superuserChunkText(1024, col, "dup-c1"))
+        assertThat(superuserChunkText(1024, col, "dupc1000000000000000000000000000"))
             .as("first-wins: the surviving row carries the FIRST text (T3Database._write_batch semantics)")
             .isEqualTo("first occurrence");
     }
@@ -368,23 +371,23 @@ class PgVectorRepositoryContractTest {
         embedder1024.register("version one", 1.0f, 0.0f);
         embedder1024.register("version two", 0.0f, 1.0f);   // orthogonal to version one
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("re-c1"), List.of("version one"), List.of(Map.of("rev", "1")));
+            List.of("rec10000000000000000000000000000"), List.of("version one"), List.of(Map.of("rev", "1")));
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("re-c1"), List.of("version two"), List.of(Map.of("rev", "2")));
+            List.of("rec10000000000000000000000000000"), List.of("version two"), List.of(Map.of("rev", "2")));
 
         assertThat(superuserCount(1024, col))
             .as("re-upsert of the same chash must not create a second row")
             .isEqualTo(1L);
-        assertThat(superuserChunkText(1024, col, "re-c1"))
+        assertThat(superuserChunkText(1024, col, "rec10000000000000000000000000000"))
             .as("re-upsert must update chunk_text in place (Chroma upsert semantics)")
             .isEqualTo("version two");
-        assertThat(superuserCosineDistance(1024, col, "re-c1",
+        assertThat(superuserCosineDistance(1024, col, "rec10000000000000000000000000000",
                 FakeEmbedder.unitVector(1024, 0.0f, 1.0f)))
             .as("re-upsert must re-embed: the stored vector matches the NEW text's "
                 + "embedding, not the original")
             .isCloseTo(0.0, within(1e-6));
 
-        Map<String, Object> got = repo1024.get(TENANT_A, col, List.of("re-c1"), 10, 0);
+        Map<String, Object> got = repo1024.get(TENANT_A, col, List.of("rec10000000000000000000000000000"), 10, 0);
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> metas = (List<Map<String, Object>>) got.get("metadatas");
         assertThat(metas).hasSize(1);
@@ -404,7 +407,7 @@ class PgVectorRepositoryContractTest {
     void upsert_rowsAttributedToCallingTenantOnly() throws Exception {
         String col = "code__attribution__voyage-code-3__v1";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("attr-c1"), List.of("tenant a text"), List.of(Map.of()));
+            List.of("attrc100000000000000000000000000"), List.of("tenant a text"), List.of(Map.of()));
 
         assertThat(repo1024.count(TENANT_A, col))
             .as("writing tenant must see exactly its 1 row")
@@ -426,7 +429,7 @@ class PgVectorRepositoryContractTest {
         embedder1024.register("middle text",  0.8f, 0.6f);     // distance 0.2
         embedder1024.register("farthest text", 0.0f, 1.0f);    // distance 1.0
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("s-near", "s-mid", "s-far"),
+            List.of("snear000000000000000000000000000", "smid0000000000000000000000000000", "sfar0000000000000000000000000000"),
             List.of("nearest text", "middle text", "farthest text"),
             List.of(Map.of("kind", "a"), Map.of("kind", "b"), Map.of("kind", "a")));
     }
@@ -442,7 +445,7 @@ class PgVectorRepositoryContractTest {
         assertThat(rows).as("exactly the 3 seeded rows").hasSize(3);
         assertThat(rows).extracting(r -> r.get("id"))
             .as("distance-ascending order is exact")
-            .containsExactly("s-near", "s-mid", "s-far");
+            .containsExactly("snear000000000000000000000000000", "smid0000000000000000000000000000", "sfar0000000000000000000000000000");
         assertThat(((Number) rows.get(0).get("distance")).doubleValue()).isCloseTo(0.0, within(1e-5));
         assertThat(((Number) rows.get(1).get("distance")).doubleValue()).isCloseTo(0.2, within(1e-5));
         assertThat(((Number) rows.get(2).get("distance")).doubleValue()).isCloseTo(1.0, within(1e-5));
@@ -466,7 +469,7 @@ class PgVectorRepositoryContractTest {
 
         assertThat(rows).extracting(r -> r.get("id"))
             .as("where {kind=a} must return exactly the two matching rows, distance-ordered")
-            .containsExactly("s-near", "s-far");
+            .containsExactly("snear000000000000000000000000000", "sfar0000000000000000000000000000");
     }
 
     @Test
@@ -477,7 +480,7 @@ class PgVectorRepositoryContractTest {
         embedder1024.register("and t2", 0.8f, 0.6f);
         embedder1024.register("and t3", 0.0f, 1.0f);
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("and-c1", "and-c2", "and-c3"),
+            List.of("andc1000000000000000000000000000", "andc2000000000000000000000000000", "andc3000000000000000000000000000"),
             List.of("and t1", "and t2", "and t3"),
             List.of(Map.of("kind", "a", "score", "high"),
                     Map.of("kind", "a", "score", "low"),
@@ -489,7 +492,7 @@ class PgVectorRepositoryContractTest {
 
         assertThat(rows).extracting(r -> r.get("id"))
             .as("multi-key where must AND all predicates: exactly the one row matching both")
-            .containsExactly("and-c1");
+            .containsExactly("andc1000000000000000000000000000");
     }
 
     @Test
@@ -512,17 +515,17 @@ class PgVectorRepositoryContractTest {
         embedder1024.register("y mid",  0.8f, 0.6f);       // 0.2
         embedder1024.register("x far",  0.0f, 1.0f);       // 1.0
         repo1024.upsertChunks(TENANT_A, colX,
-            List.of("mc-xnear", "mc-xfar"), List.of("x near", "x far"),
+            List.of("mcxnear0000000000000000000000000", "mcxfar00000000000000000000000000"), List.of("x near", "x far"),
             List.of(Map.of(), Map.of()));
         repo1024.upsertChunks(TENANT_A, colY,
-            List.of("mc-ymid"), List.of("y mid"), List.of(Map.of()));
+            List.of("mcymid00000000000000000000000000"), List.of("y mid"), List.of(Map.of()));
 
         List<Map<String, Object>> rows = repo1024.search(
             TENANT_A, "search query", List.of(colX, colY), 10, null);
 
         assertThat(rows).extracting(r -> r.get("id"))
             .as("multi-collection union must interleave by distance, not group by collection")
-            .containsExactly("mc-xnear", "mc-ymid", "mc-xfar");
+            .containsExactly("mcxnear0000000000000000000000000", "mcymid00000000000000000000000000", "mcxfar00000000000000000000000000");
         assertThat(rows).extracting(r -> r.get("collection"))
             .as("each row labels its source collection")
             .containsExactly(colX, colY, colX);
@@ -538,7 +541,7 @@ class PgVectorRepositoryContractTest {
 
         assertThat(rows).extracting(r -> r.get("id"))
             .as("nResults=2 returns exactly the 2 nearest")
-            .containsExactly("s-near", "s-mid");
+            .containsExactly("snear000000000000000000000000000", "smid0000000000000000000000000000");
     }
 
     @Test
@@ -572,12 +575,12 @@ class PgVectorRepositoryContractTest {
     void get_byIds_returnsAlignedEnvelope_missingIdsOmitted() {
         String col = "code__getbyids__voyage-code-3__v1";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("g-c1", "g-c2"),
+            List.of("gc100000000000000000000000000000", "gc200000000000000000000000000000"),
             List.of("get text one", "get text two"),
             List.of(Map.of("m", "1"), Map.of("m", "2")));
 
         Map<String, Object> got = repo1024.get(
-            TENANT_A, col, List.of("g-c1", "g-c2", "g-missing"), 10, 0);
+            TENANT_A, col, List.of("gc100000000000000000000000000000", "gc200000000000000000000000000000", "gmissing000000000000000000000000"), 10, 0);
 
         @SuppressWarnings("unchecked")
         List<String> ids = (List<String>) got.get("ids");
@@ -587,10 +590,10 @@ class PgVectorRepositoryContractTest {
         List<Map<String, Object>> metas = (List<Map<String, Object>>) got.get("metadatas");
 
         assertThat(ids).as("missing id omitted, both present ids returned")
-            .containsExactlyInAnyOrder("g-c1", "g-c2");
+            .containsExactlyInAnyOrder("gc100000000000000000000000000000", "gc200000000000000000000000000000");
         assertThat(docs).hasSize(2);
         assertThat(metas).hasSize(2);
-        int i1 = ids.indexOf("g-c1");
+        int i1 = ids.indexOf("gc100000000000000000000000000000");
         assertThat(docs.get(i1)).isEqualTo("get text one");
         assertThat(metas.get(i1).get("m")).isEqualTo("1");
     }
@@ -598,34 +601,34 @@ class PgVectorRepositoryContractTest {
     @Test
     void get_limitOffset_skipsInChashOrder() {
         String col = "code__getoffset__voyage-code-3__v1";
-        // Insertion order is the REVERSE of chash order ("go-z9" > "go-a2"), so this
+        // Insertion order is the REVERSE of chash order ("goz90000000000000000000000000000" > "goa20000000000000000000000000000"), so this
         // assertion can distinguish chash-order pagination from insertion-order or
-        // id-list-order pagination: those would return "go-a2" at offset 1.
+        // id-list-order pagination: those would return "goa20000000000000000000000000000" at offset 1.
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("go-z9", "go-a2"),
+            List.of("goz90000000000000000000000000000", "goa20000000000000000000000000000"),
             List.of("offset text z", "offset text a"),
             List.of(Map.of(), Map.of()));
 
         Map<String, Object> got = repo1024.get(
-            TENANT_A, col, List.of("go-z9", "go-a2"), 1, 1);
+            TENANT_A, col, List.of("goz90000000000000000000000000000", "goa20000000000000000000000000000"), 1, 1);
         @SuppressWarnings("unchecked")
         List<String> ids = (List<String>) got.get("ids");
 
         assertThat(ids)
             .as("limit=1 offset=1 must skip the first chash ('go-a2') and return 'go-z9'")
-            .containsExactly("go-z9");
+            .containsExactly("goz90000000000000000000000000000");
     }
 
     @Test
     void get_crossTenant_returnsEmptyEnvelope() throws Exception {
         String col = "code__getrls__voyage-code-3__v1";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("gr-c1"), List.of("tenant a only"), List.of(Map.of()));
+            List.of("grc10000000000000000000000000000"), List.of("tenant a only"), List.of(Map.of()));
         assertThat(superuserCount(1024, col))
             .as("control: tenant-a's row must physically exist before the RLS assertion")
             .isEqualTo(1L);
 
-        Map<String, Object> got = repo1024.get(TENANT_B, col, List.of("gr-c1"), 10, 0);
+        Map<String, Object> got = repo1024.get(TENANT_B, col, List.of("grc10000000000000000000000000000"), 10, 0);
         @SuppressWarnings("unchecked")
         List<String> ids = (List<String>) got.get("ids");
         assertThat(ids).as("tenant-b must get 0 of tenant-a's chunks").isEmpty();
@@ -634,7 +637,7 @@ class PgVectorRepositoryContractTest {
     @Test
     void list_paginatesWithLimitOffset_disjointAndComplete() {
         String col = "code__listpage__voyage-code-3__v1";
-        List<String> allIds = List.of("l-c1", "l-c2", "l-c3", "l-c4", "l-c5");
+        List<String> allIds = List.of("lc100000000000000000000000000000", "lc200000000000000000000000000000", "lc300000000000000000000000000000", "lc400000000000000000000000000000", "lc500000000000000000000000000000");
         repo1024.upsertChunks(TENANT_A, col, allIds,
             List.of("t1", "t2", "t3", "t4", "t5"),
             List.of(Map.of(), Map.of(), Map.of(), Map.of(), Map.of()));
@@ -648,9 +651,9 @@ class PgVectorRepositoryContractTest {
         // lexicographically ordered, so each page's exact contents are pinned — an
         // unstable sort would make repeated list() calls return different rows.
         assertThat(page1).as("first page: exactly the 3 lowest chashes, in order")
-            .containsExactly("l-c1", "l-c2", "l-c3");
+            .containsExactly("lc100000000000000000000000000000", "lc200000000000000000000000000000", "lc300000000000000000000000000000");
         assertThat(page2).as("second page: exactly the remaining 2 chashes, in order")
-            .containsExactly("l-c4", "l-c5");
+            .containsExactly("lc400000000000000000000000000000", "lc500000000000000000000000000000");
         Set<String> union = new LinkedHashSet<>();
         union.addAll(page1);
         union.addAll(page2);
@@ -663,7 +666,7 @@ class PgVectorRepositoryContractTest {
     void list_crossTenant_returnsEmptyEnvelope() throws Exception {
         String col = "code__listrls__voyage-code-3__v1";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("lr-c1"), List.of("tenant a list row"), List.of(Map.of()));
+            List.of("lrc10000000000000000000000000000"), List.of("tenant a list row"), List.of(Map.of()));
         assertThat(superuserCount(1024, col))
             .as("control: tenant-a's row must physically exist before the RLS assertion")
             .isEqualTo(1L);
@@ -677,7 +680,7 @@ class PgVectorRepositoryContractTest {
     void count_exactPerCollection_andZeroForOtherTenant() {
         String col = "code__countexact__voyage-code-3__v1";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("cnt-c1", "cnt-c2", "cnt-c3"),
+            List.of("cntc1000000000000000000000000000", "cntc2000000000000000000000000000", "cntc3000000000000000000000000000"),
             List.of("a", "b", "c"),
             List.of(Map.of(), Map.of(), Map.of()));
 
@@ -696,11 +699,11 @@ class PgVectorRepositoryContractTest {
     void delete_byIds_returnsAffectedCount() {
         String col = "code__deleteown__voyage-code-3__v1";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("d-c1", "d-c2", "d-c3"),
+            List.of("dc100000000000000000000000000000", "dc200000000000000000000000000000", "dc300000000000000000000000000000"),
             List.of("a", "b", "c"),
             List.of(Map.of(), Map.of(), Map.of()));
 
-        int deleted = repo1024.delete(TENANT_A, col, List.of("d-c1", "d-c2", "d-missing"));
+        int deleted = repo1024.delete(TENANT_A, col, List.of("dc100000000000000000000000000000", "dc200000000000000000000000000000", "dmissing000000000000000000000000"));
         assertThat(deleted).as("exactly the 2 existing ids deleted").isEqualTo(2);
         assertThat(repo1024.count(TENANT_A, col)).isEqualTo(1);
     }
@@ -709,7 +712,7 @@ class PgVectorRepositoryContractTest {
     void delete_emptyIds_isNoop() {
         String col = "code__deleteempty__voyage-code-3__v1";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("de-c1"), List.of("survivor"), List.of(Map.of()));
+            List.of("dec10000000000000000000000000000"), List.of("survivor000000000000000000000000"), List.of(Map.of()));
 
         int deleted = repo1024.delete(TENANT_A, col, List.of());
         assertThat(deleted).as("empty ids list must delete exactly 0 rows").isEqualTo(0);
@@ -720,9 +723,9 @@ class PgVectorRepositoryContractTest {
     void delete_crossTenant_affectsZero_rowSurvives() {
         String col = "code__deleterls__voyage-code-3__v1";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("dr-c1"), List.of("survivor"), List.of(Map.of()));
+            List.of("drc10000000000000000000000000000"), List.of("survivor000000000000000000000000"), List.of(Map.of()));
 
-        int deleted = repo1024.delete(TENANT_B, col, List.of("dr-c1"));
+        int deleted = repo1024.delete(TENANT_B, col, List.of("drc10000000000000000000000000000"));
         assertThat(deleted)
             .as("cross-tenant delete through the repository must affect exactly 0 rows")
             .isEqualTo(0);
@@ -740,12 +743,12 @@ class PgVectorRepositoryContractTest {
         String col = "code__updatemeta__voyage-code-3__v1";
         embedder1024.register("frecency text", 0.6f, 0.8f);
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("um-c1"), List.of("frecency text"), List.of(Map.of("frecency_score", "0.1")));
+            List.of("umc10000000000000000000000000000"), List.of("frecency text"), List.of(Map.of("frecency_score", "0.1")));
 
         repo1024.updateMetadata(TENANT_A, col,
-            List.of("um-c1"), List.of(Map.of("frecency_score", "0.9")));
+            List.of("umc10000000000000000000000000000"), List.of(Map.of("frecency_score", "0.9")));
 
-        Map<String, Object> got = repo1024.get(TENANT_A, col, List.of("um-c1"), 10, 0);
+        Map<String, Object> got = repo1024.get(TENANT_A, col, List.of("umc10000000000000000000000000000"), 10, 0);
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> metas = (List<Map<String, Object>>) got.get("metadatas");
         @SuppressWarnings("unchecked")
@@ -758,7 +761,7 @@ class PgVectorRepositoryContractTest {
             .isEqualTo("frecency text");
 
         double distToOriginal = superuserCosineDistance(
-            1024, col, "um-c1", FakeEmbedder.unitVector(1024, 0.6f, 0.8f));
+            1024, col, "umc10000000000000000000000000000", FakeEmbedder.unitVector(1024, 0.6f, 0.8f));
         assertThat(distToOriginal)
             .as("embedding must be untouched by a metadata-only update (no re-embed)")
             .isCloseTo(0.0, within(1e-6));
@@ -769,7 +772,7 @@ class PgVectorRepositoryContractTest {
         String col = "code__updatemeta-align__voyage-code-3__v1";
         assertThatThrownBy(() ->
             repo1024.updateMetadata(TENANT_A, col,
-                List.of("ma-c1", "ma-c2"), List.of(Map.of("v", "only-one"))))
+                List.of("mac10000000000000000000000000000", "mac20000000000000000000000000000"), List.of(Map.of("v", "onlyone0000000000000000000000000"))))
             .as("ids and metadatas of different sizes must fail loud, not zip-truncate")
             .isInstanceOf(IllegalArgumentException.class);
     }
@@ -778,21 +781,21 @@ class PgVectorRepositoryContractTest {
     void updateMetadata_crossTenant_noEffect() {
         String col = "code__updatemeta-rls__voyage-code-3__v1";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("umr-c1"), List.of("owned text"), List.of(Map.of("v", "original")));
+            List.of("umrc1000000000000000000000000000"), List.of("owned text"), List.of(Map.of("v", "original000000000000000000000000")));
 
         // tenant-b attempts to overwrite tenant-a's metadata: RLS makes the row
         // invisible, so the update affects nothing (frecency path, nexus-enehl —
         // cross-tenant frecency corruption would be silent and persistent).
         repo1024.updateMetadata(TENANT_B, col,
-            List.of("umr-c1"), List.of(Map.of("v", "corrupted")));
+            List.of("umrc1000000000000000000000000000"), List.of(Map.of("v", "corrupted")));
 
-        Map<String, Object> got = repo1024.get(TENANT_A, col, List.of("umr-c1"), 10, 0);
+        Map<String, Object> got = repo1024.get(TENANT_A, col, List.of("umrc1000000000000000000000000000"), 10, 0);
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> metas = (List<Map<String, Object>>) got.get("metadatas");
         assertThat(metas).hasSize(1);
         assertThat(metas.get(0).get("v"))
             .as("cross-tenant updateMetadata must not modify the owning tenant's metadata")
-            .isEqualTo("original");
+            .isEqualTo("original000000000000000000000000");
     }
 
     // ---------------------------------------------------------------------------
@@ -805,15 +808,15 @@ class PgVectorRepositoryContractTest {
         String col = "code__manifest__voyage-code-3__v1";
         String tumbler = "1.9.1";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("mf-c1", "mf-c2", "mf-c3"),
+            List.of("mfc10000000000000000000000000000", "mfc20000000000000000000000000000", "mfc30000000000000000000000000000"),
             List.of("manifest chunk one", "manifest chunk two", "manifest chunk three"),
             List.of(Map.of(), Map.of(), Map.of()));
         seedCatalogDocument(TENANT_A, tumbler, "Manifest Doc");
         // Insert manifest rows deliberately out of position order: the JOIN must
         // return position order, not insertion order.
-        seedManifestRow(TENANT_A, tumbler, 2, "mf-c3", col);
-        seedManifestRow(TENANT_A, tumbler, 0, "mf-c1", col);
-        seedManifestRow(TENANT_A, tumbler, 1, "mf-c2", col);
+        seedManifestRow(TENANT_A, tumbler, 2, "mfc30000000000000000000000000000", col);
+        seedManifestRow(TENANT_A, tumbler, 0, "mfc10000000000000000000000000000", col);
+        seedManifestRow(TENANT_A, tumbler, 1, "mfc20000000000000000000000000000", col);
 
         List<Map<String, Object>> rows = repo1024.fetchDocumentChunks(TENANT_A, tumbler);
 
@@ -822,7 +825,7 @@ class PgVectorRepositoryContractTest {
             .as("rows ordered by manifest position")
             .containsExactly(0, 1, 2);
         assertThat(rows).extracting(r -> r.get("chash"))
-            .containsExactly("mf-c1", "mf-c2", "mf-c3");
+            .containsExactly("mfc10000000000000000000000000000", "mfc20000000000000000000000000000", "mfc30000000000000000000000000000");
         assertThat(rows).extracting(r -> r.get("chunk_text"))
             .as("chunk text resolved in-database from the dispatched chunks table")
             .containsExactly("manifest chunk one", "manifest chunk two", "manifest chunk three");
@@ -835,12 +838,12 @@ class PgVectorRepositoryContractTest {
         String col = "code__manifestshared__voyage-code-3__v1";
         String tumbler = "1.9.2";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("mfs-c1"), List.of("repeated chunk text"), List.of(Map.of()));
+            List.of("mfsc1000000000000000000000000000"), List.of("repeated chunk text"), List.of(Map.of()));
         seedCatalogDocument(TENANT_A, tumbler, "Shared Chash Doc");
         // Two positions point at the SAME chash: identical text collapses to one chunk
         // row by design; the manifest preserves position (CLAUDE.md §Catalog/T3 split).
-        seedManifestRow(TENANT_A, tumbler, 0, "mfs-c1", col);
-        seedManifestRow(TENANT_A, tumbler, 1, "mfs-c1", col);
+        seedManifestRow(TENANT_A, tumbler, 0, "mfsc1000000000000000000000000000", col);
+        seedManifestRow(TENANT_A, tumbler, 1, "mfsc1000000000000000000000000000", col);
 
         List<Map<String, Object>> rows = repo1024.fetchDocumentChunks(TENANT_A, tumbler);
 
@@ -871,10 +874,10 @@ class PgVectorRepositoryContractTest {
         String col = "code__manifestbroken__voyage-code-3__v1";
         String tumbler = "1.9.3";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("mfb-c1"), List.of("resolvable chunk"), List.of(Map.of()));
+            List.of("mfbc1000000000000000000000000000"), List.of("resolvable chunk"), List.of(Map.of()));
         seedCatalogDocument(TENANT_A, tumbler, "Broken Manifest Doc");
-        seedManifestRow(TENANT_A, tumbler, 0, "mfb-c1", col);
-        seedManifestRow(TENANT_A, tumbler, 1, "mfb-missing", col);  // dangling chash
+        seedManifestRow(TENANT_A, tumbler, 0, "mfbc1000000000000000000000000000", col);
+        seedManifestRow(TENANT_A, tumbler, 1, "mfbmissing0000000000000000000000", col);  // dangling chash
 
         assertThatThrownBy(() -> repo1024.fetchDocumentChunks(TENANT_A, tumbler))
             .as("a manifest row whose (collection, chash) has no chunk must fail loud — "
@@ -887,9 +890,9 @@ class PgVectorRepositoryContractTest {
         String col = "code__manifestrls__voyage-code-3__v1";
         String tumbler = "1.9.4";
         repo1024.upsertChunks(TENANT_A, col,
-            List.of("mfr-c1"), List.of("tenant a manifest chunk"), List.of(Map.of()));
+            List.of("mfrc1000000000000000000000000000"), List.of("tenant a manifest chunk"), List.of(Map.of()));
         seedCatalogDocument(TENANT_A, tumbler, "RLS Manifest Doc");
-        seedManifestRow(TENANT_A, tumbler, 0, "mfr-c1", col);
+        seedManifestRow(TENANT_A, tumbler, 0, "mfrc1000000000000000000000000000", col);
 
         // tenant-b cannot see tenant-a's catalog document: same failure as an unknown
         // tumbler (RLS must not leak existence).

--- a/service/src/test/java/dev/nexus/service/TaxonomyRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/TaxonomyRepositoryTest.java
@@ -113,6 +113,10 @@ class TaxonomyRepositoryTest {
             // prod nexus_svc grant set.)
             su.createStatement().execute(
                 "GRANT SELECT ON " + schema + ".catalog_documents TO " + SVC_ROLE);
+            // RDR-156 P0.2: assignTopic/importAssignment now auto-stub catalog_collections;
+            // the svc role needs INSERT (and SELECT for the ON CONFLICT check).
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT ON " + schema + ".catalog_collections TO " + SVC_ROLE);
             su.createStatement().execute("GRANT USAGE ON SCHEMA " + schema + " TO " + SVC_ROLE);
             su.createStatement().execute(
                 "ALTER ROLE " + SVC_ROLE + " SET search_path TO " + schema + ", public");
@@ -128,6 +132,14 @@ class TaxonomyRepositoryTest {
                     "INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title) " +
                     "VALUES ('" + TENANT_A + "', '" + tumbler + "', 'Test fixture: " + tumbler + "') " +
                     "ON CONFLICT (tenant_id, tumbler) DO NOTHING");
+            }
+            // RDR-156 P0.2: topic_assignments.source_collection now enforces a FK to
+            // catalog_collections(tenant_id, name).  Seed stub rows for all test collections.
+            for (String col : List.of(COL_A, COL_B)) {
+                su.createStatement().execute(
+                    "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+                    "VALUES ('" + TENANT_A + "', '" + col + "') " +
+                    "ON CONFLICT (tenant_id, name) DO NOTHING");
             }
         }
 

--- a/src/nexus/db/AGENTS.md
+++ b/src/nexus/db/AGENTS.md
@@ -75,9 +75,10 @@ Collection registration is enforced server-side at two layers:
    `CatalogRepository.importCollection` via `DO UPDATE ... WHERE embedding_model='' AND
    content_type='' AND owner_id=''`.  A re-run never clobbers a genuinely-newer live row.
 
-**Rule**: Never add a chunk write path that bypasses `PgVectorRepository.upsertChunks`.
-All chunk writers (Python Chroma clients in local mode, the vector ETL, future writers) must
-pass through this method so registration-before-write is structural.
+**Rule (Java service surface)**: Never add a chunk write path in the Java service that bypasses
+`PgVectorRepository.upsertChunks`.  This rule governs service-mode writes only; local-mode
+Python clients write directly to Chroma (bypassing PostgreSQL) and are outside this rule's
+scope until RDR-155 P4b removes the Chroma path.
 
 ## Hot rules
 

--- a/src/nexus/db/AGENTS.md
+++ b/src/nexus/db/AGENTS.md
@@ -56,6 +56,29 @@ The chunk size cap is the load-bearing one: `MAX_DOCUMENT_BYTES = 16384`, but wr
 5. Run `./tests/e2e/release-sandbox.sh smoke` — schema migrations are sandbox-required.
 6. Run `nx doctor --check-schema` against the editable install.
 
+## Collection registration precedes chunk writes (RDR-156 P0.2)
+
+Collection registration is enforced server-side at two layers:
+
+1. **`PgVectorRepository.upsertChunks` (Java service)** auto-stubs the collection into
+   `nexus.catalog_collections` within the same transaction, before any chunk row is inserted.
+   For a conformant name (`<content_type>__<owner_id>__<embedding_model>__v<n>`) the parsed
+   segments are stored; for a non-conformant name a name-only stub with empty metadata fields
+   is stored.  Either way the FK is satisfied before the chunk row lands.
+
+2. **FK constraints** `chunks_384_collection_fk` / `chunks_768_collection_fk` /
+   `chunks_1024_collection_fk` / `chash_index_collection_fk` /
+   `topic_assignments_collection_fk` (all `NOT VALID` until RDR-153 data migration lands;
+   `VALIDATE CONSTRAINT` is bead nexus-70r3c.3).  `NOT VALID` still enforces ALL new writes.
+
+3. **Stub upgradability**: stub rows (all metadata fields `= ''`) are upgraded in-place by
+   `CatalogRepository.importCollection` via `DO UPDATE ... WHERE embedding_model='' AND
+   content_type='' AND owner_id=''`.  A re-run never clobbers a genuinely-newer live row.
+
+**Rule**: Never add a chunk write path that bypasses `PgVectorRepository.upsertChunks`.
+All chunk writers (Python Chroma clients in local mode, the vector ETL, future writers) must
+pass through this method so registration-before-write is structural.
+
 ## Hot rules
 
 - **No ORM.** SQLAlchemy etc. is banned. Direct `sqlite3` only.


### PR DESCRIPTION
## RDR-156 Phase 0 (beads nexus-70r3c.1 test, nexus-70r3c.2 impl)

Schema-enforces the collection registry over the RDR-155 pgvector chunk tables, while the tables are cheap to change.

**fk-002-collection-registry.xml** — deploy-order-safe sequence: a stub backfill first (production holds ~115k chunk rows with an empty registry since the vector migration ran before the T2 catalog ladder; without the backfill the FKs would reject every new serving write at the next JAR deploy), then five `NOT VALID` FKs: `chunks_384/768/1024 (tenant_id, collection)` and `chash_index (tenant_id, physical_collection)` → `catalog_collections (tenant_id, name)` ON DELETE RESTRICT; `topic_assignments (tenant_id, source_collection)` additionally ON UPDATE CASCADE (the verbatim-name lock-step contract moves from prose to schema). `VALIDATE CONSTRAINT` deliberately ships separately (nexus-70r3c.3, world-blocked on the RDR-153 data migration reaching `total_failed == 0`); a `convalidated=false` pin guards the split.

**catalog-002-hygiene.xml** — `catalog_collections.created_at/superseded_at` TEXT-''-default → `timestamptz NULL` (SQLite heritage); `length(chash)=32` CHECKs on the three chunk tables + manifest; `position >= 0` on the manifest. The Decision-7 `source_uri` UNIQUE is **deferred, not blind-added**: the live audit found 201 duplicated source_uris (T2 `nexus_rdr/156-P0-source-uri-audit`); a no-unique-index assertion pins the deferral so a future add is a conscious act.

**Registration-before-write, enforced server-side**: every data-plane door (`PgVectorRepository.upsertChunks`, Taxonomy/Chash repositories) auto-registers a stub in the write transaction (conformant names parsed into segments). The catalog ETL's `importCollection` is upgraded from `DO NOTHING` to `DO UPDATE ... WHERE`-stub so backfill/auto-registered stubs are upgradable by the RDR-153 migration while genuinely-newer live rows are never clobbered (both directions test-pinned). Standing rule in `src/nexus/db/AGENTS.md`.

**Rename position**: nothing renames pgvector chunk rows today, so a rename of a chunk-owning collection previously produced silent incoherence (chunks stranded under the old name); the FK converts that into a loud failure, pinned by test. The coherent multi-step rename flow is follow-on `nexus-hz785`.

## Gate evidence

Phase-review-gate cross-walk PASSED (Item1=nexus-70r3c.1; P1-P5 explicitly out-of-phase). Stacked review: code-review-expert (0 Critical, 1 High — fixed: importCollection both-direction pins), substantive-critic (0 Critical, 3 Significant — all fixed or positioned: rename pin + follow-on bead, stub-predicate tests, Chash fail-loud guard), test-validator PASS 245/245 with 4 gaps closed in-branch (topic_assignments FK reject, specific-constraint-name assertion, blank-chash guard test, symmetric CHECK coverage).

Java suites at HEAD: CollectionRegistryFkTest 35/35, CatalogRepositoryTest 76/76, ForeignKeyConstraintTest 28/28, PgVectorRepositoryContractTest 46/46, ChunksRlsBehavioralTest 18/18, TaxonomyRepositoryTest 27/27, ChashRepositoryTest 18/18, CatalogSchemaLiquibaseTest 1/1 (CI runs pytest only; Java verified locally via Testcontainers).