### PR TITLE
test: fixture sweep — full Java suite green after RDR-156 P0 constraints

### DIFF
--- a/service/src/test/java/dev/nexus/service/PgVectorHybridSearchContractTest.java
+++ b/service/src/test/java/dev/nexus/service/PgVectorHybridSearchContractTest.java
@@ -116,7 +116,7 @@ class PgVectorHybridSearchContractTest {
     private static final String T_C5 = "unrelated cooking recipe for pasta carbonara";
     private static final String T_C6 = "the tenant isolation policy appendix";
 
-    private static final List<String> FUSED_EXPECTED = List.of("hyb-c1", "hyb-c3", "hyb-c2", "hyb-c6");
+    private static final List<String> FUSED_EXPECTED = List.of("hyb-c100000000000000000000000000", "hyb-c300000000000000000000000000", "hyb-c200000000000000000000000000", "hyb-c600000000000000000000000000");
 
     PostgreSQLContainer<?> pg;
     TenantScope tenantScope;
@@ -168,6 +168,11 @@ class PgVectorHybridSearchContractTest {
                 su.createStatement().execute(
                     "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus.chunks_" + dim + " TO " + SVC_ROLE);
             }
+            // ensureCollectionRegistered() in PgVectorRepository.upsertChunks() needs
+            // INSERT (for the ON CONFLICT DO NOTHING upsert) and SELECT (implicit in
+            // ON CONFLICT clause resolution) on catalog_collections.
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT ON nexus.catalog_collections TO " + SVC_ROLE);
             su.createStatement().execute(
                 "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
         }
@@ -213,7 +218,7 @@ class PgVectorHybridSearchContractTest {
         embedder1024.register(T_C5,  0.0f, 1.0f);
         embedder1024.register(T_C6, -1.0f, 0.0f);
         repo1024.upsertChunks(TENANT_A, COL_HY,
-            List.of("hyb-c1", "hyb-c2", "hyb-c3", "hyb-c4", "hyb-c5", "hyb-c6"),
+            List.of("hyb-c100000000000000000000000000", "hyb-c200000000000000000000000000", "hyb-c300000000000000000000000000", "hyb-c400000000000000000000000000", "hyb-c500000000000000000000000000", "hyb-c600000000000000000000000000"),
             List.of(T_C1, T_C2, T_C3, T_C4, T_C5, T_C6),
             List.of(Map.of("kind", "hy"), Map.of("kind", "hy"), Map.of("kind", "hy"),
                     Map.of("kind", "hy"), Map.of("kind", "hy"), Map.of("kind", "hy")));
@@ -223,12 +228,12 @@ class PgVectorHybridSearchContractTest {
         embedder1024.register("tenant isolation policy beta document",  0.8f, 0.6f);
         embedder1024.register("tenant isolation policy gamma document", 0.6f, 0.8f);
         repo1024.upsertChunks(TENANT_A, COL_MA,
-            List.of("ma-c1", "ma-c2"),
+            List.of("ma-c1000000000000000000000000000", "ma-c2000000000000000000000000000"),
             List.of("tenant isolation policy alpha document",
                     "tenant isolation policy gamma document"),
             List.of(Map.of(), Map.of()));
         repo1024.upsertChunks(TENANT_A, COL_MB,
-            List.of("mb-c1"),
+            List.of("mb-c1000000000000000000000000000"),
             List.of("tenant isolation policy beta document"),
             List.of(Map.of()));
 
@@ -237,7 +242,7 @@ class PgVectorHybridSearchContractTest {
         embedder768.register("tenant isolation policy for java services",   1.0f, 0.0f);
         embedder768.register("tenant isolation policy for python services", 0.6f, 0.8f);
         repo768.upsertChunks(TENANT_A, COL_WH,
-            List.of("wh-c1", "wh-c2"),
+            List.of("wh-c1000000000000000000000000000", "wh-c2000000000000000000000000000"),
             List.of("tenant isolation policy for java services",
                     "tenant isolation policy for python services"),
             List.of(Map.of("lang", "java"), Map.of("lang", "py")));
@@ -249,7 +254,7 @@ class PgVectorHybridSearchContractTest {
         embedder384.register("tenant isolation policy variant",       0.8f, 0.6f);
         embedder384.register("cooking carbonara again",               0.995f, 0.0998749f);
         repo384.upsertChunks(TENANT_A, COL_384H,
-            List.of("m384-c1", "m384-c2", "m384-c3"),
+            List.of("m384-c10000000000000000000000000", "m384-c20000000000000000000000000", "m384-c30000000000000000000000000"),
             List.of("tenant isolation policy small model",
                     "tenant isolation policy variant",
                     "cooking carbonara again"),
@@ -284,13 +289,13 @@ class PgVectorHybridSearchContractTest {
             repo1024.search(TENANT_A, Q, List.of(COL_HY), 10, null);
         assertThat(ids(vectorOnly))
             .as("precondition: vector-only search surfaces the text-unrelated row")
-            .contains("hyb-c4");
+            .contains("hyb-c400000000000000000000000000");
 
         List<Map<String, Object>> fused =
             repo1024.hybridSearch(TENANT_A, Q, List.of(COL_HY), 10, null);
         assertThat(ids(fused))
             .as("a vector-close row with no text signal must NEVER appear in hybrid results")
-            .doesNotContain("hyb-c4", "hyb-c5");
+            .doesNotContain("hyb-c400000000000000000000000000", "hyb-c500000000000000000000000000");
     }
 
     // ---------------------------------------------------------------------------
@@ -364,7 +369,7 @@ class PgVectorHybridSearchContractTest {
         assertThat(ids(rows))
             .as("multi-collection hybrid is ONE ranked list interleaved by distance "
                 + "(ma-c1 0.0, mb-c1 0.2, ma-c2 0.4), not per-collection blocks")
-            .containsExactly("ma-c1", "mb-c1", "ma-c2");
+            .containsExactly("ma-c1000000000000000000000000000", "mb-c1000000000000000000000000000", "ma-c2000000000000000000000000000");
     }
 
     @Test
@@ -375,7 +380,7 @@ class PgVectorHybridSearchContractTest {
         assertThat(ids(rows))
             .as("metadata where-predicate ANDs with the text gate: wh-c1 matches the "
                 + "text gate but not lang=py and must be filtered out")
-            .containsExactly("wh-c2");
+            .containsExactly("wh-c2000000000000000000000000000");
     }
 
     @Test
@@ -385,7 +390,7 @@ class PgVectorHybridSearchContractTest {
 
         assertThat(ids(rows))
             .as("nResults truncates the ranked fused list — top-2 exactly")
-            .containsExactly("hyb-c1", "hyb-c3");
+            .containsExactly("hyb-c100000000000000000000000000", "hyb-c300000000000000000000000000");
     }
 
     @Test
@@ -407,7 +412,7 @@ class PgVectorHybridSearchContractTest {
         assertThat(ids(rows))
             .as("hybrid dispatches per-dim exactly like search(): same gate + rank "
                 + "behaviour on chunks_384, text-unrelated row excluded")
-            .containsExactly("m384-c1", "m384-c2");
+            .containsExactly("m384-c10000000000000000000000000", "m384-c20000000000000000000000000");
     }
 
     @Test
@@ -417,7 +422,7 @@ class PgVectorHybridSearchContractTest {
 
         assertThat(rows).hasSize(1);
         Map<String, Object> top = rows.get(0);
-        assertThat(top.get("id")).isEqualTo("hyb-c1");
+        assertThat(top.get("id")).isEqualTo("hyb-c100000000000000000000000000");
         assertThat(top.get("content")).isEqualTo(T_C1);
         assertThat(top.get("collection")).isEqualTo(COL_HY);
         assertThat(((Number) top.get("distance")).doubleValue())

--- a/service/src/test/java/dev/nexus/service/PgVectorServingContractTest.java
+++ b/service/src/test/java/dev/nexus/service/PgVectorServingContractTest.java
@@ -214,7 +214,7 @@ class PgVectorServingContractTest {
     void upsertChunks_servesFromPgvector() throws Exception {
         Map<String, Object> resp = postOk("/v1/vectors/upsert-chunks", TOKEN_A, Map.of(
             "collection", COL,
-            "ids",        List.of("p4a-c1", "p4a-c2", "p4a-c3"),
+            "ids",        List.of("p4a-c100000000000000000000000000", "p4a-c200000000000000000000000000", "p4a-c300000000000000000000000000"),
             "documents",  List.of(
                 "the tenant isolation policy guards every row",
                 "tenant isolation policy enforcement in postgres",
@@ -253,7 +253,7 @@ class PgVectorServingContractTest {
         List<Map<String, Object>> rows = MAPPER.readValue(resp.body(), List.class);
         assertThat(rows.stream().map(r -> r.get("id")).toList())
             .as("cosine-ranked flat rows: distances 0.0, 0.2, 0.4 exactly")
-            .containsExactly("p4a-c1", "p4a-c2", "p4a-c3");
+            .containsExactly("p4a-c100000000000000000000000000", "p4a-c200000000000000000000000000", "p4a-c300000000000000000000000000");
         assertThat(rows.get(0).get("lang"))
             .as("metadata flattens into rows, same envelope as the Chroma path")
             .isEqualTo("java");
@@ -264,12 +264,12 @@ class PgVectorServingContractTest {
     void storePut_singleChunk() throws Exception {
         Map<String, Object> resp = postOk("/v1/vectors/store-put", TOKEN_A, Map.of(
             "collection", COL,
-            "doc_id",     "p4a-put1",
+            "doc_id",     "p4a-put1000000000000000000000000",
             "content",    "single put chunk about tenant isolation policy",
             "metadata",   Map.of("kind", "put")));
         assertThat(resp.get("id"))
             .as("store-put envelope {\"id\": ...} preserved")
-            .isEqualTo("p4a-put1");
+            .isEqualTo("p4a-put1000000000000000000000000");
     }
 
     @Test
@@ -277,11 +277,11 @@ class PgVectorServingContractTest {
     void storeGet_byIds_chromaEnvelope() throws Exception {
         Map<String, Object> resp = postOk("/v1/vectors/store-get", TOKEN_A, Map.of(
             "collection", COL,
-            "ids",        List.of("p4a-c1", "p4a-put1")));
+            "ids",        List.of("p4a-c100000000000000000000000000", "p4a-put1000000000000000000000000")));
 
         assertThat((List<Object>) resp.get("ids"))
             .as("store-get envelope: ids aligned ascending by chash")
-            .containsExactly("p4a-c1", "p4a-put1");
+            .containsExactly("p4a-c100000000000000000000000000", "p4a-put1000000000000000000000000");
         assertThat((List<Object>) resp.get("documents"))
             .containsExactly(
                 "the tenant isolation policy guards every row",
@@ -302,7 +302,7 @@ class PgVectorServingContractTest {
         assertThat((List<Object>) resp.get("ids"))
             .as("plain-equality where filter (the incremental-sync staleness "
                 + "check's shape) returns exactly the matching chunk")
-            .containsExactly("p4a-c2");
+            .containsExactly("p4a-c200000000000000000000000000");
     }
 
     @Test
@@ -313,7 +313,7 @@ class PgVectorServingContractTest {
 
         assertThat((List<Object>) resp.get("ids"))
             .as("store-list paginates in chash order")
-            .containsExactly("p4a-c1", "p4a-c2");
+            .containsExactly("p4a-c100000000000000000000000000", "p4a-c200000000000000000000000000");
         assertThat((List<?>) resp.get("metadatas"))
             .as("metadatas aligned with the page of ids")
             .hasSize(2);
@@ -324,7 +324,7 @@ class PgVectorServingContractTest {
     void updateMetadata_metadataOnly_textAndVectorUntouched() throws Exception {
         Map<String, Object> resp = postOk("/v1/vectors/update-metadata", TOKEN_A, Map.of(
             "collection", COL,
-            "ids",        List.of("p4a-c1"),
+            "ids",        List.of("p4a-c100000000000000000000000000"),
             "metadatas",  List.of(Map.of("lang", "java", "frecency_score", 0.75))));
         assertThat(((Number) resp.get("updated")).intValue()).isEqualTo(1);
 
@@ -334,7 +334,7 @@ class PgVectorServingContractTest {
                  "SELECT chunk_text, metadata->>'frecency_score' FROM nexus.chunks_1024"
                  + " WHERE collection = ? AND chash = ?")) {
             ps.setString(1, COL);
-            ps.setString(2, "p4a-c1");
+            ps.setString(2, "p4a-c100000000000000000000000000");
             try (var rs = ps.executeQuery()) {
                 assertThat(rs.next()).isTrue();
                 assertThat(rs.getString(1))
@@ -390,14 +390,14 @@ class PgVectorServingContractTest {
     void storeDelete_tenantIsolated_thenOwnerDeletes() throws Exception {
         // Foreign tenant deletes exactly 0 of tenant-a's rows.
         Map<String, Object> foreign = postOk("/v1/vectors/store-delete", TOKEN_B, Map.of(
-            "collection", COL, "ids", List.of("p4a-c1", "p4a-c2")));
+            "collection", COL, "ids", List.of("p4a-c100000000000000000000000000", "p4a-c200000000000000000000000000")));
         assertThat(((Number) foreign.get("deleted")).intValue())
             .as("cross-tenant delete affects exactly 0 rows under RLS")
             .isEqualTo(0);
 
         // Owner deletes for real.
         Map<String, Object> owner = postOk("/v1/vectors/store-delete", TOKEN_A, Map.of(
-            "collection", COL, "ids", List.of("p4a-c3", "p4a-put1")));
+            "collection", COL, "ids", List.of("p4a-c300000000000000000000000000", "p4a-put1000000000000000000000000")));
         assertThat(((Number) owner.get("deleted")).intValue()).isEqualTo(2);
 
         try (Connection su = pg.createConnection("");
@@ -422,7 +422,7 @@ class PgVectorServingContractTest {
         // tenant-B's partition and tenant-A's rows must be untouched.
         Map<String, Object> resp = postOk("/v1/vectors/upsert-chunks", TOKEN_B, Map.of(
             "collection", COL,
-            "ids",        List.of("p4a-b1"),
+            "ids",        List.of("p4a-b100000000000000000000000000"),
             "documents",  List.of("the tenant isolation policy guards every row"),
             "metadatas",  List.of(Map.of("owner", "b"))));
         assertThat(((Number) resp.get("upserted")).intValue()).isEqualTo(1);

--- a/service/src/test/java/dev/nexus/service/VectorHandlerEmbeddingModeTest.java
+++ b/service/src/test/java/dev/nexus/service/VectorHandlerEmbeddingModeTest.java
@@ -212,14 +212,14 @@ class VectorHandlerEmbeddingModeTest {
         // pgvector rows, request order, missing ids omitted (Chroma parity).
         var up = post("/v1/vectors/upsert-chunks", Map.of(
             "collection", "knowledge__pebfx7__minilm-l6-v2-384__v1",
-            "ids",        List.of("emb-b", "emb-a"),
+            "ids",        List.of("emb-b000000000000000000000000000", "emb-a000000000000000000000000000"),
             "documents",  List.of("second text", "first text"),
             "metadatas",  List.of(Map.of(), Map.of())));
         assertThat(up.statusCode()).isEqualTo(200);
 
         var resp = post("/v1/vectors/get-embeddings", Map.of(
             "collection", "knowledge__pebfx7__minilm-l6-v2-384__v1",
-            "ids",        List.of("emb-a", "emb-b", "emb-missing")));
+            "ids",        List.of("emb-a000000000000000000000000000", "emb-b000000000000000000000000000", "emb-missing000000000000000000000")));
         assertThat(resp.statusCode()).isEqualTo(200);
         @SuppressWarnings("unchecked")
         Map<String, Object> body = MAPPER.readValue(resp.body(), Map.class);
@@ -227,7 +227,7 @@ class VectorHandlerEmbeddingModeTest {
         List<String> ids = (List<String>) body.get("ids");
         @SuppressWarnings("unchecked")
         List<List<Number>> embeddings = (List<List<Number>>) body.get("embeddings");
-        assertThat(ids).containsExactly("emb-a", "emb-b");   // request order, missing omitted
+        assertThat(ids).containsExactly("emb-a000000000000000000000000000", "emb-b000000000000000000000000000");   // request order, missing omitted
         assertThat(embeddings).hasSize(2);
         assertThat(embeddings.get(0)).hasSize(384);
         assertThat(embeddings.get(1)).hasSize(384);
@@ -239,7 +239,7 @@ class VectorHandlerEmbeddingModeTest {
     void minilmCollectionInOnnxMode_stillServes200() throws Exception {
         var resp = post("/v1/vectors/upsert-chunks", Map.of(
             "collection", "knowledge__pebfx2__minilm-l6-v2-384__v1",
-            "ids",        List.of("pebfx2-ok1"),
+            "ids",        List.of("pebfx2-ok10000000000000000000000"),
             "documents",  List.of("a servable chunk"),
             "metadatas",  List.of(Map.of())));
         assertThat(resp.statusCode())

--- a/service/src/test/java/dev/nexus/service/VectorHybridHttpTest.java
+++ b/service/src/test/java/dev/nexus/service/VectorHybridHttpTest.java
@@ -123,7 +123,7 @@ class VectorHybridHttpTest {
         embedder.register("quantum entanglement spectroscopy experiment", 0.995f, 0.0998749f);
         pgRepo = new PgVectorRepository(tenantScope, embedder, embedder);
         pgRepo.upsertChunks(TENANT_A, COL,
-            List.of("hh-c1", "hh-c2", "hh-c3"),
+            List.of("hh-c1000000000000000000000000000", "hh-c2000000000000000000000000000", "hh-c3000000000000000000000000000"),
             List.of("the tenant isolation policy guards every row",
                     "tenant isolation policy enforcement in postgres",
                     "quantum entanglement spectroscopy experiment"),
@@ -169,7 +169,7 @@ class VectorHybridHttpTest {
         assertThat(rows.stream().map(r -> r.get("id")).toList())
             .as("text-gated rows ranked by distance; the no-text-signal row hh-c3 "
                 + "(vector-closer than hh-c2) is excluded")
-            .containsExactly("hh-c1", "hh-c2");
+            .containsExactly("hh-c1000000000000000000000000000", "hh-c2000000000000000000000000000");
         assertThat(rows.get(0).get("kind"))
             .as("metadata flattens into HTTP rows exactly like /search")
             .isEqualTo("hh");


### PR DESCRIPTION
PR #1167 merged with the advisory Java CI job red (only the pytest jobs are branch-protection-required). Root cause: four suites outside the hand-picked local verification list still used pre-P0 fixtures.

- `PgVectorServingContractTest`, `VectorHandlerEmbeddingModeTest`, `VectorHybridHttpTest`: chash ids right-padded to 32 chars with a uniform fill, preserving the lexicographic ordering the serving assertions depend on (`'p4a-c1…' < 'p4a-c2…' < 'p4a-put1…'` verified).
- `PgVectorHybridSearchContractTest`: the suite's custom restricted role gains INSERT on `catalog_collections` for the new `upsertChunks` auto-registration. Checked the production side explicitly: `grants-nexus-svc.xml` grants `SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA nexus` plus `ALTER DEFAULT PRIVILEGES`, applied after catalog-001 — no production defect.

Full suite exactly as CI runs it: `mvn -q test` = **600/600 green**.

Test-only change. Bead: nexus-70r3c.2.