### PR TITLE
feat(service): production native-image build — Linux CI gate + full-stack bring-up

### DIFF
--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -81,4 +81,60 @@ jobs:
       # protection; renaming would strand required checks.
       - name: Run Java test suite
         working-directory: service
-        run: mvn -q test
+        run: ./mvnw -q test
+
+  native-image-build-and-smoke:
+    name: Native image build + smoke (nexus-lp2qo)
+    runs-on: ubuntu-latest
+    # Native-image build (~2-3m analysis + image) + jOOQ codegen testcontainer
+    # + pgvector pull + native smoke. 40m covers a cold runner.
+    timeout-minutes: 40
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up GraalVM 25.0.3
+        uses: graalvm/setup-graalvm@v1
+        with:
+          # >= 25.0.2 REQUIRED: the bundled jOOQ 3.20.0 / liquibase reachability
+          # metadata use GraalVM's unified reachability-metadata SCHEMA, which
+          # 25.0.1 rejects ("installation does not provide reachability-metadata
+          # schema"). Pinned for native-build determinism (nexus-lp2qo).
+          java-version: '25.0.3'
+          distribution: 'graalvm'
+          cache: 'maven'
+
+      - name: Cache ChromaDB ONNX model
+        # The service initializes the ONNX embedder at startup (NX_EMBED_MODE=onnx),
+        # loading all-MiniLM-L6-v2 from ~/.cache/chroma — the native smoke needs it.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/chroma
+          key: chromadb-onnx-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            chromadb-onnx-${{ runner.os }}-
+
+      - name: Prime ONNX model on cache miss
+        run: |
+          MODEL_DIR="$HOME/.cache/chroma/onnx_models/all-MiniLM-L6-v2"
+          if [ ! -f "$MODEL_DIR/onnx/model.onnx" ]; then
+            mkdir -p "$MODEL_DIR"
+            curl -fsSL https://chroma-onnx-models.s3.amazonaws.com/all-MiniLM-L6-v2/onnx.tar.gz \
+              -o /tmp/onnx.tar.gz
+            tar -xzf /tmp/onnx.tar.gz -C "$MODEL_DIR"
+            test -f "$MODEL_DIR/onnx/model.onnx" || { echo "model.onnx missing after extract"; exit 1; }
+          fi
+
+      - name: Build native image
+        working-directory: service
+        # -Pnative runs jOOQ codegen (testcontainers pgvector) then native-image.
+        # The committed traced reachability-metadata.json + community metadata repo
+        # supply the reflection/resource set. This is the authoritative LINUX gate
+        # for the native path (the spike verified macOS/arm64; this proves amd64).
+        run: ./mvnw -q -Pnative -DskipTests package
+
+      - name: Native smoke test
+        working-directory: service
+        # Boots the native binary against a throwaway pgvector and asserts
+        # liquibase migration + jOOQ INSERT/SELECT/FTS all return 200.
+        run: ./native-smoke.sh

--- a/service/.mvn/wrapper/maven-wrapper.properties
+++ b/service/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,73 @@
+# nexus-service
+
+Postgres-backed T2/T3 storage service for nexus (RDR-152). Java 25, jOOQ, Liquibase,
+HikariCP, local ONNX embedding (onnxruntime + DJL HuggingFace tokenizers).
+
+## Build
+
+```bash
+./mvnw test                       # JVM unit suite (needs Docker for testcontainers)
+./mvnw -DskipTests package        # fat jar -> target/nexus-service-*.jar
+./mvnw -DskipTests package -Pnative   # GraalVM native binary -> target/nexus-service
+```
+
+Every build runs jOOQ codegen against a throwaway `pgvector/pgvector:pg17`
+testcontainer, so **Docker must be running**.
+
+## Native image (`-Pnative`)
+
+Produces a self-contained binary — no JVM needed at runtime. Opt-in; the default
+build and the jlink image are unaffected.
+
+### Prerequisites
+
+- **GraalVM ≥ 25.0.3** (Oracle GraalVM, `distribution: graalvm`). 25.0.1 is rejected:
+  the bundled jOOQ/liquibase reachability metadata use the unified
+  `reachability-metadata` schema only newer 25.x understands. Point both
+  `JAVA_HOME` and `GRAALVM_HOME` at it (the plugin detects via `GRAALVM_HOME`).
+- **Docker** — for the codegen testcontainer.
+- **A C toolchain for native-image:**
+  - **Linux:** `gcc`, `glibc-devel`, `zlib-devel` (the Oracle `native-image` container has them).
+  - **macOS:** Xcode Command Line Tools (`xcode-select --install`).
+  - **Windows:** **MSVC Build Tools** (Visual Studio "Desktop development with C++"
+    workload). Run the build from a *Developer Command Prompt for VS* (or any shell
+    where `cl.exe` is on `PATH`).
+
+### native-image does NOT cross-compile
+
+The binary targets the **build host's OS + arch**. To get a Windows `.exe`, build on
+Windows; for a macOS binary, build on a Mac; for Linux, build on Linux (or in the
+Oracle GraalVM container). There is no Docker cross-build to a Windows/macOS target —
+Docker only helps for Linux, and Windows containers need a Windows host.
+
+### Per-platform embedding libs (automatic)
+
+onnxruntime and DJL tokenizers ship a native lib per `<os-arch>` inside their jars.
+The build embeds **only the host platform's** libs (not all ~120MB of them), selected
+by the `native-libs-{mac,windows,linux-aarch64}` profiles in `pom.xml` (Maven `<os>`
+activation; linux-x64 is the default). So you just run `./mvnw -Pnative package` on
+each machine and it bundles the right `.so`/`.dylib`/`.dll`.
+
+Supported build hosts: linux-x64, linux-aarch64, osx-aarch64, win-x64. (Intel macOS
+is not supported — DJL 0.30.0 ships no `osx-x86_64` tokenizers lib.)
+
+### Smoke test
+
+```bash
+./native-smoke.sh        # boots the native binary on a throwaway pgvector,
+                         # asserts migration + jOOQ INSERT/SELECT/FTS = 200
+```
+
+### Runtime env
+
+`NX_DB_URL` `NX_DB_USER` `NX_DB_PASS` (Postgres), `NX_SERVICE_PORT`,
+`NX_SERVICE_TOKEN`, `NX_EMBED_MODE=onnx`. See `Main.java` for the full set.
+
+### CI
+
+`.github/workflows/service-ci.yml` builds and smoke-tests the native image on
+Linux amd64 every time `service/**` changes — the authoritative gate. The
+`native-build-tools` reachability metadata plus the committed
+`META-INF/native-image/traced/reachability-metadata.json` (captured by the
+native-image tracing agent via `trace-native.sh`) supply the reflection/resource
+config; re-capture with `trace-native.sh` if reflection-using deps change.

--- a/service/linux-native-verify.sh
+++ b/service/linux-native-verify.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# nexus-lp2qo: genuine Linux/arm64 verification of the native-image path, run on
+# the macOS host via Docker Desktop (linux/arm64). Builds the native image inside
+# the Oracle GraalVM 25.0.3 container using the Maven wrapper (./mvnw -Pnative),
+# then boots the resulting Linux binary against a sibling pgvector and asserts the
+# jOOQ + liquibase runtime path. Proves the committed metadata is Linux-correct
+# (the spike verified macOS/arm64; CI proves amd64; this bridges to Linux now).
+set -uo pipefail
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+IMG=container-registry.oracle.com/graalvm/native-image:25
+NET=lp2qo-net
+PG=lp2qo-lin-pg
+BUILDER=lp2qo-lin-build
+
+cleanup() {
+  docker rm -f "$PG" "$BUILDER" >/dev/null 2>&1 || true
+  docker network rm "$NET" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+cleanup
+
+docker network create "$NET" >/dev/null
+docker run -d --name "$PG" --network "$NET" \
+  -e POSTGRES_DB=nexus -e POSTGRES_USER=nexus -e POSTGRES_PASSWORD=nexus \
+  pgvector/pgvector:pg17 >/dev/null
+echo "waiting for pg..."
+until docker exec "$PG" pg_isready -U nexus >/dev/null 2>&1; do sleep 1; done
+sleep 2; echo "pg ready"
+
+# Build + smoke inside the linux/arm64 GraalVM container. Docker socket + host
+# override let the testcontainers jOOQ codegen reach the host daemon; the smoke
+# pgvector is reached by container name on $NET. ONNX model mounted from host cache.
+docker run --rm --name "$BUILDER" --platform linux/arm64 --network "$NET" \
+  -v "$REPO:$REPO" -w "$REPO/service" \
+  -v "$HOME/.m2:/root/.m2" \
+  -v "$HOME/.cache/chroma:/root/.cache/chroma" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal \
+  -e DOCKER_HOST=unix:///var/run/docker.sock \
+  --add-host=host.docker.internal:host-gateway \
+  --entrypoint bash "$IMG" -c '
+    set -e
+    echo "=== container: $(native-image --version | head -1) ==="
+    echo "=== Linux native build via wrapper ==="
+    ./mvnw -q -Pnative -DskipTests package
+    echo "=== boot linux native binary + smoke ==="
+    export NX_DB_URL="jdbc:postgresql://'"$PG"':5432/nexus" NX_DB_USER=nexus NX_DB_PASS=nexus
+    export NX_SERVICE_PORT=8080 NX_SERVICE_TOKEN=lintoken NX_EMBED_MODE=onnx
+    ./target/nexus-service > /tmp/lin-svc.log 2>&1 &
+    PID=$!
+    UP=0
+    for i in $(seq 1 60); do
+      kill -0 $PID 2>/dev/null || { echo "SVC EXITED"; tail -30 /tmp/lin-svc.log; break; }
+      curl -fsS http://localhost:8080/health >/dev/null 2>&1 && { UP=1; break; }
+      sleep 1
+    done
+    [ "$UP" = 1 ] || { echo "LINUX SMOKE FAIL: not healthy"; tail -30 /tmp/lin-svc.log; exit 1; }
+    echo -n "version : "; curl -s -H "Authorization: Bearer lintoken" http://localhost:8080/version; echo
+    echo -n "put     : "; curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer lintoken" -H "Content-Type: application/json" -X POST -d "{\"project\":\"lin\",\"title\":\"a\",\"content\":\"linux native\",\"tags\":\"t\",\"ttl\":30}" http://localhost:8080/v1/memory/put; echo
+    echo -n "get     : "; curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer lintoken" "http://localhost:8080/v1/memory/get?project=lin&title=a"; echo
+    echo -n "search  : "; curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer lintoken" -H "Content-Type: application/json" -X POST -d "{\"query\":\"linux\",\"project\":\"lin\"}" http://localhost:8080/v1/memory/search; echo
+    grep -iE "MissingReflection|NoClassDefFound|UnsatisfiedLink|NullPointer" /tmp/lin-svc.log && { echo "LINUX RUNTIME ERROR"; exit 1; } || true
+    kill $PID 2>/dev/null || true
+    echo "LINUX NATIVE OK"
+  '

--- a/service/mvnw
+++ b/service/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/service/mvnw.cmd
+++ b/service/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/service/native-smoke.sh
+++ b/service/native-smoke.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# nexus-lp2qo: native-image smoke test. Boots the native binary against a
+# pgvector Postgres and asserts the full runtime path works: liquibase migration
+# applies, and jOOQ INSERT / SELECT / Postgres-FTS-search all return 200 with
+# real rows. Exits non-zero on any failure — used as the CI native gate and for
+# local verification.
+#
+# Env (optional):
+#   NX_DB_URL / NX_DB_USER / NX_DB_PASS  — point at an existing Postgres.
+#       When unset, a throwaway pgvector/pgvector:pg17 container is started.
+#   BIN  — path to the native binary (default: target/nexus-service)
+set -uo pipefail
+cd "$(dirname "$0")"
+BIN="${BIN:-target/nexus-service}"
+[ -x "$BIN" ] || { echo "FAIL: native binary not found/executable at $BIN"; exit 2; }
+
+OWN_PG=0
+if [ -z "${NX_DB_URL:-}" ]; then
+  OWN_PG=1
+  PGPORT=$(python3 -c "import socket;s=socket.socket();s.bind(('',0));print(s.getsockname()[1]);s.close()")
+  docker rm -f lp2qo-smoke-pg >/dev/null 2>&1 || true
+  docker run -d --name lp2qo-smoke-pg -e POSTGRES_DB=nexus -e POSTGRES_USER=nexus \
+    -e POSTGRES_PASSWORD=nexus -p ${PGPORT}:5432 pgvector/pgvector:pg17 >/dev/null
+  until docker exec lp2qo-smoke-pg pg_isready -U nexus >/dev/null 2>&1; do sleep 1; done
+  sleep 2
+  export NX_DB_URL="jdbc:postgresql://localhost:${PGPORT}/nexus"
+  export NX_DB_USER=nexus NX_DB_PASS=nexus
+fi
+
+SVCPORT=$(python3 -c "import socket;s=socket.socket();s.bind(('',0));print(s.getsockname()[1]);s.close()")
+export NX_SERVICE_PORT=$SVCPORT NX_SERVICE_TOKEN=smoketoken NX_EMBED_MODE=onnx
+
+cleanup() {
+  [ -n "${SVCPID:-}" ] && kill "$SVCPID" 2>/dev/null
+  [ "$OWN_PG" = "1" ] && docker rm -f lp2qo-smoke-pg >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+"$BIN" > /tmp/native-smoke-svc.log 2>&1 &
+SVCPID=$!
+U="http://localhost:${SVCPORT}"
+
+UP=0
+for i in $(seq 1 60); do
+  kill -0 $SVCPID 2>/dev/null || { echo "FAIL: service exited during startup"; tail -40 /tmp/native-smoke-svc.log; exit 1; }
+  curl -fsS "$U/health" >/dev/null 2>&1 && { UP=1; break; }
+  sleep 1
+done
+[ "$UP" = "1" ] || { echo "FAIL: service never became healthy"; tail -40 /tmp/native-smoke-svc.log; exit 1; }
+
+# Migration must have applied (changeset_count > 0).
+VER=$(curl -fsS -H "Authorization: Bearer smoketoken" "$U/version")
+echo "version: $VER"
+echo "$VER" | grep -qE '"schema_changeset_count":[1-9]' || { echo "FAIL: migration did not apply"; tail -40 /tmp/native-smoke-svc.log; exit 1; }
+
+fail=0
+assert() { # name expected_code curl-args...
+  local name="$1" exp="$2"; shift 2
+  local code; code=$(curl -s -o /tmp/ns.out -w "%{http_code}" "$@")
+  if [ "$code" = "$exp" ]; then echo "  ok   $name -> $code"; else echo "  FAIL $name -> $code (want $exp): $(head -c160 /tmp/ns.out)"; fail=1; fi
+}
+A=(-H "Authorization: Bearer smoketoken"); J=(-H "Content-Type: application/json")
+echo "jOOQ runtime path:"
+assert "memory/put (INSERT)"   200 "${A[@]}" "${J[@]}" -X POST -d '{"project":"smoke","title":"a","content":"native ok","tags":"t","ttl":30}' "$U/v1/memory/put"
+assert "memory/get (SELECT)"   200 "${A[@]}" "$U/v1/memory/get?project=smoke&title=a"
+assert "memory/search (FTS)"   200 "${A[@]}" "${J[@]}" -X POST -d '{"query":"native","project":"smoke"}' "$U/v1/memory/search"
+assert "memory/list"           200 "${A[@]}" "$U/v1/memory/list?project=smoke"
+assert "plans/search"          200 "${A[@]}" "${J[@]}" -X POST -d '{"query":"q","project":"smoke"}' "$U/v1/plans/search"
+assert "taxonomy/topics"       200 "${A[@]}" "$U/v1/taxonomy/topics?collection=knowledge__x"
+assert "chash/distinct"        200 "${A[@]}" "$U/v1/chash/distinct_collections"
+
+if grep -qiE "MissingReflection|NoClassDefFound|UnsatisfiedLink|NullPointerException" /tmp/native-smoke-svc.log; then
+  echo "FAIL: native runtime error in service log:"; grep -iE "MissingReflection|NoClassDefFound|UnsatisfiedLink|NullPointerException" /tmp/native-smoke-svc.log | head; fail=1
+fi
+
+if [ "$fail" = "0" ]; then echo "NATIVE SMOKE PASS"; exit 0; else echo "NATIVE SMOKE FAIL"; exit 1; fi

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -55,6 +55,14 @@
         <onnxruntime.version>1.20.0</onnxruntime.version>
         <djl.tokenizers.version>0.30.0</djl.tokenizers.version>
 
+        <!-- Per-platform native-lib dirs for the -Pnative image (nexus-lp2qo).
+             Default = linux amd64 (CI + the deployment target); the native-libs-*
+             OS profiles below override these on macOS / Windows / linux-aarch64
+             build hosts so each binary embeds only its own platform's embedding
+             libs. onnxruntime vs djl use different <os-arch> naming, hence two. -->
+        <onnx.native.dir>linux-x64</onnx.native.dir>
+        <djl.native.dir>linux-x86_64</djl.native.dir>
+
         <!-- Surefire tag exclusion: skip @Tag("integration") by default -->
         <!-- Override with: mvn test -Dtest.excluded.groups="" -Dgroups=integration -->
         <test.excluded.groups>integration</test.excluded.groups>
@@ -403,6 +411,36 @@
     </build>
 
     <profiles>
+        <!-- Per-platform embedding-native-lib selection (nexus-lp2qo). These
+             auto-activate by build-host OS/arch (Maven built-in <os> activation,
+             no plugin needed) and override the linux-x64 defaults so -Pnative
+             embeds only the host's onnx/djl libs. Build a Windows .exe on Windows,
+             a Mac binary on a Mac — native-image does not cross-compile. -->
+        <profile>
+            <id>native-libs-mac</id>
+            <activation><os><family>mac</family></os></activation>
+            <properties>
+                <onnx.native.dir>osx-aarch64</onnx.native.dir>
+                <djl.native.dir>osx-aarch64</djl.native.dir>
+            </properties>
+        </profile>
+        <profile>
+            <id>native-libs-windows</id>
+            <activation><os><family>windows</family></os></activation>
+            <properties>
+                <onnx.native.dir>win-x64</onnx.native.dir>
+                <djl.native.dir>win-x86_64</djl.native.dir>
+            </properties>
+        </profile>
+        <profile>
+            <id>native-libs-linux-aarch64</id>
+            <activation><os><name>linux</name><arch>aarch64</arch></os></activation>
+            <properties>
+                <onnx.native.dir>linux-aarch64</onnx.native.dir>
+                <djl.native.dir>linux-aarch64</djl.native.dir>
+            </properties>
+        </profile>
+
         <!-- -Pnative: opt-in native-image build (S0.4 C2 — CI must add Linux job) -->
         <profile>
             <id>native</id>
@@ -451,6 +489,17 @@
                                              runtime-reflection the community metadata lacked). Both also
                                              ride the jar classpath, but list them explicitly for clarity. -->
                                         <buildArg>-H:ConfigurationFileDirectories=src/main/resources/META-INF/native-image,src/main/resources/META-INF/native-image/traced</buildArg>
+                                        <!-- Per-platform embedding native libs (nexus-lp2qo). onnxruntime
+                                             and djl-tokenizers bundle a .so/.dylib/.dll per <os-arch> in the
+                                             jar; native-image only embeds resources it is told to. Rather
+                                             than bundle ALL platforms into every binary (~120MB of foreign
+                                             libs), the ${onnx.native.dir} / ${djl.native.dir} properties are
+                                             set per build host by the native-libs-* OS profiles below, so the
+                                             binary carries ONLY its own platform's libs. ExcludeResources
+                                             drops the macOS .dSYM debug-symbol dirs. -->
+                                        <buildArg>-H:IncludeResources=ai/onnxruntime/native/${onnx.native.dir}/.*</buildArg>
+                                        <buildArg>-H:IncludeResources=native/lib/${djl.native.dir}/.*</buildArg>
+                                        <buildArg>-H:ExcludeResources=.*\.dSYM/.*</buildArg>
                                         <!-- Portability: compatibility march for CI/prod (not native) -->
                                         <buildArg>-march=compatibility</buildArg>
                                     </buildArgs>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -22,7 +22,7 @@
         <junit.version>5.11.4</junit.version>
         <assertj.version>3.27.3</assertj.version>
         <testcontainers.version>1.21.4</testcontainers.version>
-        <liquibase.version>4.29.2</liquibase.version>
+        <liquibase.version>4.29.0</liquibase.version>
 
         <mainClass>dev.nexus.service.Main</mainClass>
 
@@ -111,6 +111,18 @@
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
             <version>${liquibase.version}</version>
+        </dependency>
+        <!-- nexus-lp2qo spike: picocli is an OPTIONAL dep of liquibase-core (CLI only).
+             The native-image community metadata registers liquibase's commandline
+             classes for reflection; without picocli on the classpath
+             LiquibaseCommandLine fails to link ("Type not found during analysis").
+             The service uses liquibase via the Java API (SchemaMigrator), not the
+             CLI, but the metadata forces the class reachable — supply picocli so it
+             resolves. Harmless on the jlink/JVM path. -->
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>4.7.7</version>
         </dependency>
 
         <!-- Seam B: local ONNX embedding (onnxruntime-java + DJL HF tokenizer) -->
@@ -399,7 +411,7 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
-                        <version>0.10.4</version>
+                        <version>1.1.2</version>
                         <extensions>true</extensions>
                         <executions>
                             <execution>
@@ -423,35 +435,32 @@
                                         <!-- Logback/SLF4J: initialize at build time -->
                                         <buildArg>--initialize-at-build-time=org.slf4j,ch.qos.logback</buildArg>
                                         <!-- jOOQ 3.20.11 + GraalVM 25 native-image initialization.
-                                             nexus-gmiaf.9 resolution: community metadata 3.18.2
-                                             typeReachable guards for SQLDataType cause DefaultDataType
-                                             to be partially analyzed at build time. Even with the
-                                             org.jooq runtime-init flag, the TYPES_BY_NAME array is
-                                             null when SQLDataType static-init runs at runtime (NPE).
-                                             Fix: exclude org.jooq from community metadata entirely;
-                                             rely on our hand-crafted reflect-config.json instead. -->
-                                        <buildArg>--initialize-at-run-time=org.jooq</buildArg>
-                                        <!-- Reachability config from traced metadata -->
-                                        <buildArg>-H:ConfigurationFileDirectories=src/main/resources/META-INF/native-image</buildArg>
+                                             nexus-lp2qo spike (2026-06-12): community metadata now
+                                             ships a jOOQ 3.20.0 entry (tested 3.20.0-3.21.5, covers
+                                             3.20.11) via native-build-tools 1.1.2 — the proper
+                                             reachability set for the 3.20.x line. We now CONSUME it
+                                             (un-excluded below) instead of the prior workaround
+                                             (exclude 3.18.2 metadata + a run-time-init flag for
+                                             org.jooq, nexus-gmiaf.9), whose typeReachable guards partially
+                                             analyzed DefaultDataType at build time and left
+                                             TYPES_BY_NAME null at runtime (NPE). -->
+                                        <!-- Hand-crafted reflect/resource config (app classes, logback,
+                                             postgres/hikari, liquibase changelog + XSD resources) AND the
+                                             agent-traced reachability-metadata.json (nexus-lp2qo: captured
+                                             from a live migrate+jOOQ-CRUD+embed run; supplies the liquibase
+                                             runtime-reflection the community metadata lacked). Both also
+                                             ride the jar classpath, but list them explicitly for clarity. -->
+                                        <buildArg>-H:ConfigurationFileDirectories=src/main/resources/META-INF/native-image,src/main/resources/META-INF/native-image/traced</buildArg>
                                         <!-- Portability: compatibility march for CI/prod (not native) -->
                                         <buildArg>-march=compatibility</buildArg>
-                                        <!-- Diagnostics during bring-up -->
-                                        <buildArg>--emit=build-report</buildArg>
-                                        <buildArg>--enable-monitoring</buildArg>
                                     </buildArgs>
                                     <metadataRepository>
                                         <enabled>true</enabled>
-                                        <!-- Exclude jOOQ community metadata: 3.18.2 typeReachable
-                                             guards for SQLDataType cause DefaultDataType TYPES_BY_NAME
-                                             (ConcurrentHashMap) to be null at runtime init (NPE in
-                                             ConcurrentHashMap.putVal). nexus-gmiaf.9 C3 fix. -->
-                                        <dependencies>
-                                            <dependency>
-                                                <groupId>org.jooq</groupId>
-                                                <artifactId>jooq</artifactId>
-                                                <excluded>true</excluded>
-                                            </dependency>
-                                        </dependencies>
+                                        <!-- nexus-lp2qo spike: jOOQ metadata NO LONGER excluded.
+                                             native-build-tools 1.1.2 bundles org.jooq/jooq/3.20.0
+                                             (reachability-metadata.json, tested 3.20.0-3.21.5) which
+                                             is the correct set for our 3.20.11 and supersedes the
+                                             3.18.2 entry that forced the gmiaf.9 exclusion. -->
                                     </metadataRepository>
                                 </configuration>
                             </execution>
@@ -464,7 +473,7 @@
                 <dependency>
                     <groupId>org.graalvm.buildtools</groupId>
                     <artifactId>graalvm-reachability-metadata</artifactId>
-                    <version>0.10.4</version>
+                    <version>1.1.2</version>
                     <classifier>repository</classifier>
                     <type>zip</type>
                     <scope>provided</scope>

--- a/service/src/main/resources/META-INF/native-image/resource-config.json
+++ b/service/src/main/resources/META-INF/native-image/resource-config.json
@@ -7,8 +7,6 @@
       {"pattern": "liquibase.build.properties"},
       {"pattern": "liquibase/.*\\.xml"},
       {"pattern": "liquibase/servicelocator/.*"},
-      {"pattern": "ai/onnxruntime/native/linux-.*"},
-      {"pattern": "native/lib/linux-x86_64/.*"},
       {"pattern": "native/lib/tokenizers.properties"}
     ]
   },

--- a/service/src/main/resources/META-INF/native-image/resource-config.json
+++ b/service/src/main/resources/META-INF/native-image/resource-config.json
@@ -1,7 +1,15 @@
 {
   "resources": {
     "includes": [
-      {"pattern": "\\Qlogback.xml\\E"}
+      {"pattern": "\\Qlogback.xml\\E"},
+      {"pattern": "db/changelog/.*\\.xml"},
+      {"pattern": "www.liquibase.org/xml/ns/dbchangelog/.*\\.xsd"},
+      {"pattern": "liquibase.build.properties"},
+      {"pattern": "liquibase/.*\\.xml"},
+      {"pattern": "liquibase/servicelocator/.*"},
+      {"pattern": "ai/onnxruntime/native/linux-.*"},
+      {"pattern": "native/lib/linux-x86_64/.*"},
+      {"pattern": "native/lib/tokenizers.properties"}
     ]
   },
   "bundles": []

--- a/service/src/main/resources/META-INF/native-image/traced/reachability-metadata.json
+++ b/service/src/main/resources/META-INF/native-image/traced/reachability-metadata.json
@@ -1,0 +1,3596 @@
+{
+  "reflection": [
+    {
+      "type": "ch.qos.logback.classic.encoder.PatternLayoutEncoder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.classic.joran.SerializedModelConfigurator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.classic.spi.LogbackServiceProvider"
+    },
+    {
+      "type": "ch.qos.logback.classic.util.DefaultJoranConfigurator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.core.ConsoleAppender",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.core.OutputStreamAppender",
+      "methods": [
+        {
+          "name": "setEncoder",
+          "parameterTypes": [
+            "ch.qos.logback.core.encoder.Encoder"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.core.encoder.Encoder"
+    },
+    {
+      "type": "ch.qos.logback.core.encoder.LayoutWrappingEncoder",
+      "methods": [
+        {
+          "name": "setParent",
+          "parameterTypes": [
+            "ch.qos.logback.core.spi.ContextAware"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.core.pattern.PatternLayoutEncoderBase",
+      "methods": [
+        {
+          "name": "setPattern",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.core.spi.ContextAware"
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.deser.BeanDeserializerModifier[]"
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.deser.KeyDeserializers[]"
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.deser.ValueInstantiators[]"
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.ser.BeanSerializerModifier[]"
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA224",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.jna.Callback",
+      "jniAccessible": true
+    },
+    {
+      "type": "com.sun.jna.CallbackProxy"
+    },
+    {
+      "type": "com.sun.jna.CallbackReference",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getCallback",
+          "parameterTypes": [
+            "java.lang.Class",
+            "com.sun.jna.Pointer",
+            "boolean"
+          ]
+        },
+        {
+          "name": "getFunctionPointer",
+          "parameterTypes": [
+            "com.sun.jna.Callback",
+            "boolean"
+          ]
+        },
+        {
+          "name": "getNativeString",
+          "parameterTypes": [
+            "java.lang.Object",
+            "boolean"
+          ]
+        },
+        {
+          "name": "initializeThread",
+          "parameterTypes": [
+            "com.sun.jna.Callback",
+            "com.sun.jna.CallbackReference$AttachOptions"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.sun.jna.CallbackReference$AttachOptions",
+      "jniAccessible": true
+    },
+    {
+      "type": "com.sun.jna.FromNativeConverter",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "nativeType",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.jna.IntegerType",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "value"
+        }
+      ]
+    },
+    {
+      "type": "com.sun.jna.JNIEnv",
+      "jniAccessible": true
+    },
+    {
+      "type": "com.sun.jna.Native",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "dispose",
+          "parameterTypes": []
+        },
+        {
+          "name": "fromNative",
+          "parameterTypes": [
+            "com.sun.jna.FromNativeConverter",
+            "java.lang.Object",
+            "java.lang.reflect.Method"
+          ]
+        },
+        {
+          "name": "fromNative",
+          "parameterTypes": [
+            "java.lang.Class",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "fromNative",
+          "parameterTypes": [
+            "java.lang.reflect.Method",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "nativeType",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "toNative",
+          "parameterTypes": [
+            "com.sun.jna.ToNativeConverter",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.sun.jna.Native$ffi_callback",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "invoke",
+          "parameterTypes": [
+            "long",
+            "long",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.sun.jna.NativeMapped",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "toNative",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.jna.Pointer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "peer"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.sun.jna.PointerType",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "pointer"
+        }
+      ]
+    },
+    {
+      "type": "com.sun.jna.Structure",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "memory"
+        },
+        {
+          "name": "typeInfo"
+        }
+      ],
+      "methods": [
+        {
+          "name": "autoRead",
+          "parameterTypes": []
+        },
+        {
+          "name": "autoWrite",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTypeInfo",
+          "parameterTypes": []
+        },
+        {
+          "name": "newInstance",
+          "parameterTypes": [
+            "java.lang.Class",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.sun.jna.Structure$ByValue",
+      "jniAccessible": true
+    },
+    {
+      "type": "com.sun.jna.Structure$FFIType$FFITypes",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "ffi_type_double"
+        },
+        {
+          "name": "ffi_type_float"
+        },
+        {
+          "name": "ffi_type_longdouble"
+        },
+        {
+          "name": "ffi_type_pointer"
+        },
+        {
+          "name": "ffi_type_sint16"
+        },
+        {
+          "name": "ffi_type_sint32"
+        },
+        {
+          "name": "ffi_type_sint64"
+        },
+        {
+          "name": "ffi_type_sint8"
+        },
+        {
+          "name": "ffi_type_uint16"
+        },
+        {
+          "name": "ffi_type_uint32"
+        },
+        {
+          "name": "ffi_type_uint64"
+        },
+        {
+          "name": "ffi_type_uint8"
+        },
+        {
+          "name": "ffi_type_void"
+        }
+      ]
+    },
+    {
+      "type": "com.sun.jna.WString",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.sun.org.apache.xerces.internal.impl.dv.xs.ExtendedSchemaDVFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.org.apache.xerces.internal.impl.dv.xs.SchemaDVFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.zaxxer.hikari.HikariConfig",
+      "fields": [
+        {
+          "name": "catalog"
+        },
+        {
+          "name": "connectionInitSql"
+        },
+        {
+          "name": "connectionTestQuery"
+        },
+        {
+          "name": "connectionTimeout"
+        },
+        {
+          "name": "credentials"
+        },
+        {
+          "name": "dataSource"
+        },
+        {
+          "name": "dataSourceClassName"
+        },
+        {
+          "name": "dataSourceJndiName"
+        },
+        {
+          "name": "dataSourceProperties"
+        },
+        {
+          "name": "driverClassName"
+        },
+        {
+          "name": "exceptionOverride"
+        },
+        {
+          "name": "exceptionOverrideClassName"
+        },
+        {
+          "name": "healthCheckProperties"
+        },
+        {
+          "name": "healthCheckRegistry"
+        },
+        {
+          "name": "idleTimeout"
+        },
+        {
+          "name": "initializationFailTimeout"
+        },
+        {
+          "name": "isAllowPoolSuspension"
+        },
+        {
+          "name": "isAutoCommit"
+        },
+        {
+          "name": "isIsolateInternalQueries"
+        },
+        {
+          "name": "isReadOnly"
+        },
+        {
+          "name": "isRegisterMbeans"
+        },
+        {
+          "name": "jdbcUrl"
+        },
+        {
+          "name": "keepaliveTime"
+        },
+        {
+          "name": "leakDetectionThreshold"
+        },
+        {
+          "name": "maxLifetime"
+        },
+        {
+          "name": "maxPoolSize"
+        },
+        {
+          "name": "metricRegistry"
+        },
+        {
+          "name": "metricsTrackerFactory"
+        },
+        {
+          "name": "minIdle"
+        },
+        {
+          "name": "poolName"
+        },
+        {
+          "name": "scheduledExecutor"
+        },
+        {
+          "name": "schema"
+        },
+        {
+          "name": "sealed"
+        },
+        {
+          "name": "threadFactory"
+        },
+        {
+          "name": "transactionIsolationName"
+        },
+        {
+          "name": "unitTest"
+        },
+        {
+          "name": "validationTimeout"
+        }
+      ]
+    },
+    {
+      "type": "com.zaxxer.hikari.pool.PoolBase"
+    },
+    {
+      "type": "com.zaxxer.hikari.pool.PoolEntry"
+    },
+    {
+      "type": "com.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry[]"
+    },
+    {
+      "type": "dev.nexus.service.jooq.nexus.tables.records.MemoryRecord",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "dev.nexus.service.jooq.nexus.tables.records.PlansRecord"
+    },
+    {
+      "type": "java.beans.PropertyVetoException"
+    },
+    {
+      "type": "java.io.Serializable"
+    },
+    {
+      "type": "java.lang.Boolean",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "getBoolean",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Boolean[]"
+    },
+    {
+      "type": "java.lang.Byte",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Byte[]"
+    },
+    {
+      "type": "java.lang.Character",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "char"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Class",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getComponentType",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Double",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "double"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Double[]"
+    },
+    {
+      "type": "java.lang.Float",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "float"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Float[]"
+    },
+    {
+      "type": "java.lang.Integer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Integer[]"
+    },
+    {
+      "type": "java.lang.Iterable"
+    },
+    {
+      "type": "java.lang.Long",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Long[]"
+    },
+    {
+      "type": "java.lang.Object",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "toString",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.ObjectBeanInfo"
+    },
+    {
+      "type": "java.lang.ObjectCustomizer"
+    },
+    {
+      "type": "java.lang.Object[]"
+    },
+    {
+      "type": "java.lang.SecurityManager",
+      "methods": [
+        {
+          "name": "checkPermission",
+          "parameterTypes": [
+            "java.security.Permission"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Short",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "short"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Short[]"
+    },
+    {
+      "type": "java.lang.String",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte[]"
+          ]
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte[]",
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "getBytes",
+          "parameterTypes": []
+        },
+        {
+          "name": "getBytes",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "toCharArray",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.String[]"
+    },
+    {
+      "type": "java.lang.System",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getProperty",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "getSecurityManager",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "isVirtual",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Throwable",
+      "methods": [
+        {
+          "name": "addSuppressed",
+          "parameterTypes": [
+            "java.lang.Throwable"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.UnsatisfiedLinkError",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Void",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        }
+      ]
+    },
+    {
+      "type": "java.lang.reflect.Method",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getParameterTypes",
+          "parameterTypes": []
+        },
+        {
+          "name": "getReturnType",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.math.BigDecimal[]"
+    },
+    {
+      "type": "java.math.BigInteger[]"
+    },
+    {
+      "type": "java.nio.Buffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "position",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.nio.ByteBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.nio.CharBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.nio.DoubleBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.nio.FloatBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.nio.IntBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.nio.LongBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.nio.ShortBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.security.AccessController",
+      "methods": [
+        {
+          "name": "doPrivileged",
+          "parameterTypes": [
+            "java.security.PrivilegedExceptionAction"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.sql.Date[]"
+    },
+    {
+      "type": "java.sql.SQLException"
+    },
+    {
+      "type": "java.sql.Statement[]"
+    },
+    {
+      "type": "java.sql.Time[]"
+    },
+    {
+      "type": "java.sql.Timestamp[]"
+    },
+    {
+      "type": "java.time.Instant[]"
+    },
+    {
+      "type": "java.time.LocalDateTime[]"
+    },
+    {
+      "type": "java.time.LocalDate[]"
+    },
+    {
+      "type": "java.time.LocalTime[]"
+    },
+    {
+      "type": "java.time.OffsetDateTime[]"
+    },
+    {
+      "type": "java.time.OffsetTime[]"
+    },
+    {
+      "type": "java.time.Year[]"
+    },
+    {
+      "type": "java.util.AbstractCollection"
+    },
+    {
+      "type": "java.util.AbstractMap"
+    },
+    {
+      "type": "java.util.Collection"
+    },
+    {
+      "type": "java.util.ImmutableCollections$AbstractImmutableCollection"
+    },
+    {
+      "type": "java.util.ImmutableCollections$AbstractImmutableList"
+    },
+    {
+      "type": "java.util.ImmutableCollections$AbstractImmutableMap"
+    },
+    {
+      "type": "java.util.ImmutableCollections$ListN"
+    },
+    {
+      "type": "java.util.ImmutableCollections$Map1"
+    },
+    {
+      "type": "java.util.List"
+    },
+    {
+      "type": "java.util.Map"
+    },
+    {
+      "type": "java.util.RandomAccess"
+    },
+    {
+      "type": "java.util.UUID[]"
+    },
+    {
+      "type": "liquibase.AbstractExtensibleObject"
+    },
+    {
+      "type": "liquibase.AbstractExtensibleObjectBeanInfo"
+    },
+    {
+      "type": "liquibase.AbstractExtensibleObjectCustomizer"
+    },
+    {
+      "type": "liquibase.ExtensibleObject"
+    },
+    {
+      "type": "liquibase.GlobalConfiguration"
+    },
+    {
+      "type": "liquibase.change.AbstractChange"
+    },
+    {
+      "type": "liquibase.change.AbstractChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.AbstractChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.AbstractSQLChange",
+      "methods": [
+        {
+          "name": "setSplitStatements",
+          "parameterTypes": [
+            "java.lang.Boolean"
+          ]
+        },
+        {
+          "name": "setSql",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "setStripComments",
+          "parameterTypes": [
+            "java.lang.Boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.AbstractSQLChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.AbstractSQLChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.AbstractTableChange"
+    },
+    {
+      "type": "liquibase.change.AbstractTableChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.AbstractTableChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.Change"
+    },
+    {
+      "type": "liquibase.change.ChangeFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.ChangeWithColumns"
+    },
+    {
+      "type": "liquibase.change.DbmsTargetedChange"
+    },
+    {
+      "type": "liquibase.change.ReplaceIfExists"
+    },
+    {
+      "type": "liquibase.change.core.AbstractModifyDataChange"
+    },
+    {
+      "type": "liquibase.change.core.AbstractModifyDataChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.AbstractModifyDataChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.AddAutoIncrementChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.AddAutoIncrementChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.AddAutoIncrementChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.AddColumnChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.AddColumnChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.AddColumnChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.AddDefaultValueChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.AddDefaultValueChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.AddDefaultValueChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.AddForeignKeyConstraintChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.AddForeignKeyConstraintChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.AddForeignKeyConstraintChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.AddLookupTableChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.AddLookupTableChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.AddLookupTableChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.AddNotNullConstraintChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.AddNotNullConstraintChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.AddNotNullConstraintChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.AddPrimaryKeyChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.AddPrimaryKeyChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.AddPrimaryKeyChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.AddUniqueConstraintChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.AddUniqueConstraintChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.AddUniqueConstraintChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.AlterSequenceChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.AlterSequenceChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.AlterSequenceChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.CreateIndexChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.CreateIndexChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.CreateIndexChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.CreateProcedureChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.CreateProcedureChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.CreateProcedureChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.CreateSequenceChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.CreateSequenceChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.CreateSequenceChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.CreateTableChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.CreateTableChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.CreateTableChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.CreateViewChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.CreateViewChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.CreateViewChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DeleteDataChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DeleteDataChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DeleteDataChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DropAllForeignKeyConstraintsChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DropAllForeignKeyConstraintsChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DropAllForeignKeyConstraintsChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DropColumnChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DropColumnChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DropColumnChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DropDefaultValueChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DropDefaultValueChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DropDefaultValueChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DropForeignKeyConstraintChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DropForeignKeyConstraintChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DropForeignKeyConstraintChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DropIndexChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DropIndexChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DropIndexChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DropNotNullConstraintChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DropNotNullConstraintChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DropNotNullConstraintChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DropPrimaryKeyChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DropPrimaryKeyChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DropPrimaryKeyChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DropProcedureChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DropProcedureChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DropProcedureChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DropSequenceChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DropSequenceChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DropSequenceChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DropTableChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DropTableChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DropTableChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DropUniqueConstraintChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DropUniqueConstraintChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DropUniqueConstraintChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.DropViewChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.DropViewChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.DropViewChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.EmptyChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.EmptyChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.EmptyChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.ExecuteShellCommandChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.ExecuteShellCommandChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.ExecuteShellCommandChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.InsertDataChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.InsertDataChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.InsertDataChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.LoadDataChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.LoadDataChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.LoadDataChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.LoadUpdateDataChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.LoadUpdateDataChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.LoadUpdateDataChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.MergeColumnChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.MergeColumnChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.MergeColumnChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.ModifyDataTypeChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.ModifyDataTypeChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.ModifyDataTypeChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.OutputChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.OutputChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.OutputChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.RawSQLChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.RawSQLChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.RawSQLChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.RenameColumnChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.RenameColumnChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.RenameColumnChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.RenameSequenceChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.RenameSequenceChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.RenameSequenceChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.RenameTableChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.RenameTableChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.RenameTableChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.RenameViewChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.RenameViewChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.RenameViewChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.SQLFileChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.SQLFileChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.SQLFileChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.SetColumnRemarksChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.SetColumnRemarksChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.SetColumnRemarksChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.SetTableRemarksChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.SetTableRemarksChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.SetTableRemarksChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.StopChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.StopChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.StopChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.TagDatabaseChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.TagDatabaseChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.TagDatabaseChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.core.UpdateDataChange",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.core.UpdateDataChangeBeanInfo"
+    },
+    {
+      "type": "liquibase.change.core.UpdateDataChangeCustomizer"
+    },
+    {
+      "type": "liquibase.change.custom.CustomChangeWrapper",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.change.custom.CustomChangeWrapperBeanInfo"
+    },
+    {
+      "type": "liquibase.change.custom.CustomChangeWrapperCustomizer"
+    },
+    {
+      "type": "liquibase.changelog.ChangeLogHistoryServiceFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.changelog.FastCheckService",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.changelog.MockChangeLogHistoryService"
+    },
+    {
+      "type": "liquibase.changelog.StandardChangeLogHistoryService",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.changelog.visitor.StandardValidatingVisitorGenerator"
+    },
+    {
+      "type": "liquibase.changelog.visitor.ValidatingVisitorGeneratorFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.changeset.StandardChangeSetService"
+    },
+    {
+      "type": "liquibase.command.CommandFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.command.core.CalculateChecksumCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.ChangelogSyncCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.ChangelogSyncSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.ChangelogSyncToTagCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.ChangelogSyncToTagSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.ClearChecksumsCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.DbDocCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.DiffChangelogCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.DiffCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.DropAllCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.ExecuteSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.FutureRollbackCountSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.FutureRollbackFromTagSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.FutureRollbackSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.GenerateChangelogCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.HistoryCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.InternalSnapshotCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.ListLocksCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.MarkNextChangesetRanCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.MarkNextChangesetRanSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.ReleaseLocksCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.RollbackCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.RollbackCountCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.RollbackCountSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.RollbackSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.RollbackToDateCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.RollbackToDateSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.SnapshotCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.SnapshotReferenceCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.StartH2CommandStep"
+    },
+    {
+      "type": "liquibase.command.core.StatusCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.StopH2CommandStep"
+    },
+    {
+      "type": "liquibase.command.core.TagCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.TagExistsCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.UnexpectedChangesetsCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.UpdateCommandStep",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.command.core.UpdateCountCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.UpdateCountSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.UpdateSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.UpdateTestingRollbackCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.UpdateToTagCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.UpdateToTagSqlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.ValidateCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.helpers.ChangeExecListenerCommandStep",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.command.core.helpers.DatabaseChangelogCommandStep",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.command.core.helpers.DbUrlConnectionCommandStep",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.command.core.helpers.DiffOutputControlCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.helpers.LockServiceCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.helpers.OutputWriterCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.helpers.PreCompareCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.helpers.ReferenceDatabaseOutputWriterCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.helpers.ReferenceDbUrlConnectionCommandStep"
+    },
+    {
+      "type": "liquibase.command.core.helpers.ShowSummaryArgument",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.configuration.ConfiguredValueModifierFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.configuration.LiquibaseConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.configuration.core.DeprecatedConfigurationValueProvider"
+    },
+    {
+      "type": "liquibase.configuration.core.EnvironmentValueProvider"
+    },
+    {
+      "type": "liquibase.configuration.core.ScopeValueProvider"
+    },
+    {
+      "type": "liquibase.configuration.core.SystemPropertyValueProvider"
+    },
+    {
+      "type": "liquibase.database.LiquibaseTableNamesFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.database.StandardLiquibaseTableNames"
+    },
+    {
+      "type": "liquibase.database.core.CockroachDatabase"
+    },
+    {
+      "type": "liquibase.database.core.DB2Database"
+    },
+    {
+      "type": "liquibase.database.core.Db2zDatabase"
+    },
+    {
+      "type": "liquibase.database.core.DerbyDatabase"
+    },
+    {
+      "type": "liquibase.database.core.EnterpriseDBDatabase"
+    },
+    {
+      "type": "liquibase.database.core.FirebirdDatabase"
+    },
+    {
+      "type": "liquibase.database.core.H2Database"
+    },
+    {
+      "type": "liquibase.database.core.HsqlDatabase"
+    },
+    {
+      "type": "liquibase.database.core.InformixDatabase"
+    },
+    {
+      "type": "liquibase.database.core.Ingres9Database"
+    },
+    {
+      "type": "liquibase.database.core.MSSQLDatabase"
+    },
+    {
+      "type": "liquibase.database.core.MariaDBDatabase"
+    },
+    {
+      "type": "liquibase.database.core.MockDatabase"
+    },
+    {
+      "type": "liquibase.database.core.MySQLDatabase"
+    },
+    {
+      "type": "liquibase.database.core.OracleDatabase"
+    },
+    {
+      "type": "liquibase.database.core.PostgresDatabase",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.database.core.SQLiteDatabase"
+    },
+    {
+      "type": "liquibase.database.core.SnowflakeDatabase"
+    },
+    {
+      "type": "liquibase.database.core.SybaseASADatabase"
+    },
+    {
+      "type": "liquibase.database.core.SybaseDatabase"
+    },
+    {
+      "type": "liquibase.database.core.UnsupportedDatabase"
+    },
+    {
+      "type": "liquibase.database.jvm.JdbcConnectionPatterns"
+    },
+    {
+      "type": "liquibase.datatype.core.BigIntType"
+    },
+    {
+      "type": "liquibase.datatype.core.BinaryTypeSnowflake",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.datatype.core.BlobType",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.datatype.core.BooleanType",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.datatype.core.CharType"
+    },
+    {
+      "type": "liquibase.datatype.core.ClobType",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.datatype.core.ClobTypeSnowflake",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.datatype.core.CurrencyType"
+    },
+    {
+      "type": "liquibase.datatype.core.DatabaseFunctionType"
+    },
+    {
+      "type": "liquibase.datatype.core.DateTimeType",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.datatype.core.DateType"
+    },
+    {
+      "type": "liquibase.datatype.core.DecimalType"
+    },
+    {
+      "type": "liquibase.datatype.core.DoubleDataTypeSnowflake",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.datatype.core.DoubleType",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.datatype.core.FloatType"
+    },
+    {
+      "type": "liquibase.datatype.core.IntType",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.datatype.core.MediumIntType"
+    },
+    {
+      "type": "liquibase.datatype.core.NCharType"
+    },
+    {
+      "type": "liquibase.datatype.core.NVarcharType"
+    },
+    {
+      "type": "liquibase.datatype.core.NumberType"
+    },
+    {
+      "type": "liquibase.datatype.core.SmallIntType"
+    },
+    {
+      "type": "liquibase.datatype.core.TextDataTypeSnowflake",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.datatype.core.TimeType"
+    },
+    {
+      "type": "liquibase.datatype.core.TimestampNTZTypeSnowflake",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.datatype.core.TimestampType"
+    },
+    {
+      "type": "liquibase.datatype.core.TinyIntType"
+    },
+    {
+      "type": "liquibase.datatype.core.UUIDType"
+    },
+    {
+      "type": "liquibase.datatype.core.UnknownType"
+    },
+    {
+      "type": "liquibase.datatype.core.VarcharType",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.datatype.core.XMLType"
+    },
+    {
+      "type": "liquibase.executor.ExecutorService",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.executor.jvm.JdbcExecutor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.executor.jvm.SnowflakeJdbcExecutor"
+    },
+    {
+      "type": "liquibase.integration.commandline.LiquibaseCommandLineConfiguration"
+    },
+    {
+      "type": "liquibase.lockservice.LockServiceImpl"
+    },
+    {
+      "type": "liquibase.lockservice.MockLockService"
+    },
+    {
+      "type": "liquibase.lockservice.OfflineLockService"
+    },
+    {
+      "type": "liquibase.lockservice.StandardLockService",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.logging.core.BufferedLogService"
+    },
+    {
+      "type": "liquibase.logging.core.CompositeLogService"
+    },
+    {
+      "type": "liquibase.logging.core.DefaultLoggerConfiguration"
+    },
+    {
+      "type": "liquibase.logging.core.JavaLogService"
+    },
+    {
+      "type": "liquibase.logging.core.LogServiceFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.logging.mdc.MdcManagerFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.logging.mdc.NoOpMdcManager"
+    },
+    {
+      "type": "liquibase.parser.ChangeLogParserConfiguration"
+    },
+    {
+      "type": "liquibase.parser.SqlParserFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.parser.core.formattedsql.FormattedSqlChangeLogParser"
+    },
+    {
+      "type": "liquibase.parser.core.json.JsonChangeLogParser"
+    },
+    {
+      "type": "liquibase.parser.core.sql.SqlChangeLogParser"
+    },
+    {
+      "type": "liquibase.parser.core.xml.XMLChangeLogSAXParser"
+    },
+    {
+      "type": "liquibase.parser.core.yaml.YamlChangeLogParser"
+    },
+    {
+      "type": "liquibase.plugin.AbstractPlugin"
+    },
+    {
+      "type": "liquibase.plugin.AbstractPluginBeanInfo"
+    },
+    {
+      "type": "liquibase.plugin.AbstractPluginCustomizer"
+    },
+    {
+      "type": "liquibase.plugin.Plugin"
+    },
+    {
+      "type": "liquibase.precondition.CustomPreconditionWrapper"
+    },
+    {
+      "type": "liquibase.precondition.core.AndPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.ChangeLogPropertyDefinedPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.ChangeSetExecutedPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.ColumnExistsPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.DBMSPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.ForeignKeyExistsPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.IndexExistsPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.NotPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.ObjectQuotingStrategyPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.OrPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.PreconditionContainer"
+    },
+    {
+      "type": "liquibase.precondition.core.PrimaryKeyExistsPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.RowCountPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.RunningAsPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.SequenceExistsPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.SqlPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.TableExistsPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.TableIsEmptyPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.UniqueConstraintExistsPrecondition"
+    },
+    {
+      "type": "liquibase.precondition.core.ViewExistsPrecondition"
+    },
+    {
+      "type": "liquibase.report.ShowSummaryGeneratorFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.report.StandardShowSummaryGenerator"
+    },
+    {
+      "type": "liquibase.serializer.LiquibaseSerializable"
+    },
+    {
+      "type": "liquibase.servicelocator.StandardServiceLocator"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.CatalogSnapshotGenerator"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.ColumnSnapshotGenerator"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.ColumnSnapshotGeneratorH2"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.ColumnSnapshotGeneratorInformix"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.ColumnSnapshotGeneratorOracle"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.DataSnapshotGenerator"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.ForeignKeySnapshotGenerator"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.IndexSnapshotGenerator"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.PrimaryKeySnapshotGenerator"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.SchemaSnapshotGenerator"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.SchemaSnapshotGeneratorSnowflake"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.SequenceSnapshotGenerator"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.SequenceSnapshotGeneratorSnowflake"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.TableSnapshotGenerator"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.UniqueConstraintSnapshotGenerator"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.UniqueConstraintSnapshotGeneratorSnowflake"
+    },
+    {
+      "type": "liquibase.snapshot.jvm.ViewSnapshotGenerator"
+    },
+    {
+      "type": "liquibase.sql.SqlConfiguration"
+    },
+    {
+      "type": "liquibase.sql.visitor.AppendSqlVisitor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.sql.visitor.PrependSqlVisitor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.sql.visitor.RegExpReplaceSqlVisitor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.sql.visitor.ReplaceSqlVisitor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddAutoIncrementGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddAutoIncrementGeneratorDB2"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddAutoIncrementGeneratorHsqlH2"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddAutoIncrementGeneratorInformix"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddAutoIncrementGeneratorMySQL"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddAutoIncrementGeneratorSQLite"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddColumnGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddColumnGeneratorDefaultClauseBeforeNotNull"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddColumnGeneratorSQLite"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddDefaultValueGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddDefaultValueGeneratorDerby"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddDefaultValueGeneratorInformix"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddDefaultValueGeneratorMSSQL"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddDefaultValueGeneratorMySQL"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddDefaultValueGeneratorOracle"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddDefaultValueGeneratorPostgres"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddDefaultValueGeneratorSQLite"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddDefaultValueGeneratorSybase"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddDefaultValueGeneratorSybaseASA"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddForeignKeyConstraintGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddPrimaryKeyGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddPrimaryKeyGeneratorInformix"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddUniqueConstraintGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddUniqueConstraintGeneratorInformix"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AddUniqueConstraintGeneratorTDS"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.AlterSequenceGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.BatchDmlExecutablePreparedStatementGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.ClearDatabaseChangeLogTableGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CommentGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CopyRowsGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateDatabaseChangeLogLockTableGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateDatabaseChangeLogTableGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateDatabaseChangeLogTableGeneratorSybase"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateIndexGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateIndexGeneratorFirebird"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateIndexGeneratorPostgres"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateProcedureGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateSequenceGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateSequenceGeneratorSnowflake"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateTableGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateTableGeneratorInformix"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateViewGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.CreateViewGeneratorInformix"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DeleteGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DropColumnGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DropDefaultValueGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DropDefaultValueGeneratorSnowflake"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DropForeignKeyConstraintGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DropIndexGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DropPrimaryKeyGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DropProcedureGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DropProcedureGeneratorSnowflake"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DropSequenceGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DropTableGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DropUniqueConstraintGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.DropViewGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetNextChangeSetSequenceValueGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetViewDefinitionGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetViewDefinitionGeneratorDB2"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetViewDefinitionGeneratorDerby"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetViewDefinitionGeneratorFirebird"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetViewDefinitionGeneratorHsql"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetViewDefinitionGeneratorInformix"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetViewDefinitionGeneratorMSSQL"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetViewDefinitionGeneratorOracle"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetViewDefinitionGeneratorPostgres"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetViewDefinitionGeneratorSnowflake"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetViewDefinitionGeneratorSybase"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.GetViewDefinitionGeneratorSybaseASA"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InitializeDatabaseChangeLogLockTableGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertDataChangeGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertOrUpdateGeneratorDB2"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertOrUpdateGeneratorH2"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertOrUpdateGeneratorHsql"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertOrUpdateGeneratorInformix"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertOrUpdateGeneratorMSSQL"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertOrUpdateGeneratorMySQL"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertOrUpdateGeneratorOracle"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertOrUpdateGeneratorPostgres"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertOrUpdateGeneratorSQLite"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertOrUpdateGeneratorSnowflake"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertOrUpdateGeneratorSybaseASA"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.InsertSetGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.LockDatabaseChangeLogGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.MarkChangeSetRanGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.ModifyDataTypeGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.RawParameterizedSqlGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.RawSqlGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.ReindexGeneratorSQLite"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.RemoveChangeSetRanStatusGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.RenameColumnGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.RenameSequenceGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.RenameTableGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.RenameTableGeneratorSnowflake"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.RenameViewGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.RenameViewGeneratorSnowflake"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.ReorganizeTableGeneratorDB2"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.RuntimeGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.SelectFromDatabaseChangeLogGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.SelectFromDatabaseChangeLogLockGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.SetColumnRemarksGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.SetColumnRemarksGeneratorSnowflake"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.SetNullableGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.SetTableRemarksGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.SetTableRemarksGeneratorSnowflake"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.SetViewRemarksGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.StoredProcedureGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.TableIsEmptyGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.TableRowCountGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.TagDatabaseGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.UnlockDatabaseChangeLogGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.UpdateChangeSetChecksumGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.UpdateDataChangeGenerator"
+    },
+    {
+      "type": "liquibase.sqlgenerator.core.UpdateGenerator"
+    },
+    {
+      "type": "liquibase.util.StandardSqlParser"
+    },
+    {
+      "type": "org.jooq.Decfloat[]"
+    },
+    {
+      "type": "org.jooq.Geography[]"
+    },
+    {
+      "type": "org.jooq.Geometry[]"
+    },
+    {
+      "type": "org.jooq.JSONB[]"
+    },
+    {
+      "type": "org.jooq.JSON[]"
+    },
+    {
+      "type": "org.jooq.Record[]"
+    },
+    {
+      "type": "org.jooq.Result[]"
+    },
+    {
+      "type": "org.jooq.RowId[]"
+    },
+    {
+      "type": "org.jooq.XML[]"
+    },
+    {
+      "type": "org.jooq.impl.SQLDataType"
+    },
+    {
+      "type": "org.jooq.impl.SQLDataTypes$ClickHouseDataType"
+    },
+    {
+      "type": "org.jooq.impl.SQLDataTypes$DuckDBDataType"
+    },
+    {
+      "type": "org.jooq.impl.SQLDataTypes$TrinoDataType"
+    },
+    {
+      "type": "org.jooq.types.DayToSecond[]"
+    },
+    {
+      "type": "org.jooq.types.UByte[]"
+    },
+    {
+      "type": "org.jooq.types.UInteger[]"
+    },
+    {
+      "type": "org.jooq.types.ULong[]"
+    },
+    {
+      "type": "org.jooq.types.UShort[]"
+    },
+    {
+      "type": "org.jooq.types.YearToMonth[]"
+    },
+    {
+      "type": "org.jooq.types.YearToSecond[]"
+    },
+    {
+      "type": "org.jooq.util.cubrid.CUBRIDDataType"
+    },
+    {
+      "type": "org.jooq.util.derby.DerbyDataType"
+    },
+    {
+      "type": "org.jooq.util.firebird.FirebirdDataType"
+    },
+    {
+      "type": "org.jooq.util.h2.H2DataType"
+    },
+    {
+      "type": "org.jooq.util.hsqldb.HSQLDBDataType"
+    },
+    {
+      "type": "org.jooq.util.ignite.IgniteDataType"
+    },
+    {
+      "type": "org.jooq.util.mariadb.MariaDBDataType"
+    },
+    {
+      "type": "org.jooq.util.mysql.MySQLDataType"
+    },
+    {
+      "type": "org.jooq.util.postgres.PostgresDataType"
+    },
+    {
+      "type": "org.jooq.util.sqlite.SQLiteDataType"
+    },
+    {
+      "type": "org.jooq.util.yugabytedb.YugabyteDBDataType"
+    },
+    {
+      "type": "org.postgresql.Driver"
+    },
+    {
+      "type": "org.postgresql.core.QueryExecutorCloseAction"
+    },
+    {
+      "type": "org.postgresql.jdbc.PgStatement"
+    },
+    {
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "type": "sun.security.provider.MD5",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "sun.security.provider.SHA2$SHA224",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "sun.text.resources.FormatData"
+    },
+    {
+      "type": "sun.text.resources.FormatData_en"
+    },
+    {
+      "type": "sun.text.resources.FormatData_en_US"
+    },
+    {
+      "type": "sun.text.resources.JavaTimeSupplementary"
+    },
+    {
+      "type": "sun.text.resources.cldr.FormatData"
+    },
+    {
+      "type": "sun.text.resources.cldr.FormatData_en"
+    },
+    {
+      "type": "sun.text.resources.cldr.FormatData_en_US"
+    },
+    {
+      "type": "sun.util.resources.cldr.CalendarData"
+    },
+    {
+      "type": "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "type": "sun.util.resources.cldr.TimeZoneNames_en"
+    },
+    {
+      "type": "sun.util.resources.cldr.TimeZoneNames_en_US"
+    },
+    {
+      "type": {
+        "proxy": [
+          "java.sql.Connection"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/maven/dev.nexus/nexus-service/pom.properties"
+    },
+    {
+      "glob": "META-INF/services/ch.qos.logback.classic.spi.Configurator"
+    },
+    {
+      "glob": "META-INF/services/com.sun.net.httpserver.spi.HttpServerProvider"
+    },
+    {
+      "glob": "META-INF/services/java.net.spi.InetAddressResolverProvider"
+    },
+    {
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "glob": "META-INF/services/java.nio.channels.spi.SelectorProvider"
+    },
+    {
+      "glob": "META-INF/services/java.sql.Driver"
+    },
+    {
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "glob": "META-INF/services/javax.xml.parsers.SAXParserFactory"
+    },
+    {
+      "glob": "META-INF/services/liquibase.change.Change"
+    },
+    {
+      "glob": "META-INF/services/liquibase.changelog.ChangeLogHistoryService"
+    },
+    {
+      "glob": "META-INF/services/liquibase.changelog.visitor.ValidatingVisitorGenerator"
+    },
+    {
+      "glob": "META-INF/services/liquibase.changeset.ChangeSetService"
+    },
+    {
+      "glob": "META-INF/services/liquibase.command.CommandStep"
+    },
+    {
+      "glob": "META-INF/services/liquibase.configuration.AutoloadedConfigurations"
+    },
+    {
+      "glob": "META-INF/services/liquibase.configuration.ConfigurationValueProvider"
+    },
+    {
+      "glob": "META-INF/services/liquibase.configuration.ConfiguredValueModifier"
+    },
+    {
+      "glob": "META-INF/services/liquibase.database.Database"
+    },
+    {
+      "glob": "META-INF/services/liquibase.database.LiquibaseTableNames"
+    },
+    {
+      "glob": "META-INF/services/liquibase.database.jvm.ConnectionPatterns"
+    },
+    {
+      "glob": "META-INF/services/liquibase.datatype.LiquibaseDataType"
+    },
+    {
+      "glob": "META-INF/services/liquibase.executor.Executor"
+    },
+    {
+      "glob": "META-INF/services/liquibase.lockservice.LockService"
+    },
+    {
+      "glob": "META-INF/services/liquibase.logging.LogService"
+    },
+    {
+      "glob": "META-INF/services/liquibase.logging.mdc.MdcManager"
+    },
+    {
+      "glob": "META-INF/services/liquibase.parser.ChangeLogParser"
+    },
+    {
+      "glob": "META-INF/services/liquibase.parser.LiquibaseSqlParser"
+    },
+    {
+      "glob": "META-INF/services/liquibase.precondition.Precondition"
+    },
+    {
+      "glob": "META-INF/services/liquibase.report.ShowSummaryGenerator"
+    },
+    {
+      "glob": "META-INF/services/liquibase.servicelocator.ServiceLocator"
+    },
+    {
+      "glob": "META-INF/services/liquibase.snapshot.SnapshotGenerator"
+    },
+    {
+      "glob": "META-INF/services/liquibase.sqlgenerator.SqlGenerator"
+    },
+    {
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "glob": "ai/onnxruntime/native/osx-aarch64/libonnxruntime.dylib"
+    },
+    {
+      "glob": "ai/onnxruntime/native/osx-aarch64/libonnxruntime4j_jni.dylib"
+    },
+    {
+      "glob": "ai/onnxruntime/native/osx-aarch64/libonnxruntime_providers_shared.dylib"
+    },
+    {
+      "glob": "com/sun/jna/darwin-aarch64/libjnidispatch.jnilib"
+    },
+    {
+      "glob": "darwin-aarch64/libcudart.dylib"
+    },
+    {
+      "glob": "darwin/libcudart.dylib"
+    },
+    {
+      "glob": "db/changelog/aspects-001-baseline.xml"
+    },
+    {
+      "glob": "db/changelog/catalog-001-baseline.xml"
+    },
+    {
+      "glob": "db/changelog/catalog-002-hygiene.xml"
+    },
+    {
+      "glob": "db/changelog/catalog-003-soft-delete.xml"
+    },
+    {
+      "glob": "db/changelog/catalog-004-manifest-functions.xml"
+    },
+    {
+      "glob": "db/changelog/catalog-005-collection-vector-stats.xml"
+    },
+    {
+      "glob": "db/changelog/chash-001-baseline.xml"
+    },
+    {
+      "glob": "db/changelog/db.changelog-master.xml"
+    },
+    {
+      "glob": "db/changelog/fk-001-catalog-cross-store.xml"
+    },
+    {
+      "glob": "db/changelog/fk-002-collection-registry.xml"
+    },
+    {
+      "glob": "db/changelog/grants-nexus-svc.xml"
+    },
+    {
+      "glob": "db/changelog/memory-001-baseline.xml"
+    },
+    {
+      "glob": "db/changelog/plans-001-baseline.xml"
+    },
+    {
+      "glob": "db/changelog/role-001-nexus-svc.xml"
+    },
+    {
+      "glob": "db/changelog/service-tokens-001-baseline.xml"
+    },
+    {
+      "glob": "db/changelog/t1-001-baseline.xml"
+    },
+    {
+      "glob": "db/changelog/taxonomy-001-baseline.xml"
+    },
+    {
+      "glob": "db/changelog/taxonomy-002-centroids.xml"
+    },
+    {
+      "glob": "db/changelog/telemetry-001-baseline.xml"
+    },
+    {
+      "glob": "db/changelog/vectors-001-baseline.xml"
+    },
+    {
+      "glob": "db/changelog/vectors-002-trgm-index.xml"
+    },
+    {
+      "glob": "jooq-settings.xml"
+    },
+    {
+      "glob": "libcudart.dylib"
+    },
+    {
+      "glob": "liquibase.build.properties"
+    },
+    {
+      "glob": "liquibase/i18n/liquibase-core.properties"
+    },
+    {
+      "glob": "liquibase/i18n/liquibase-core_en.properties"
+    },
+    {
+      "glob": "liquibase/i18n/liquibase-core_en_US.properties"
+    },
+    {
+      "glob": "logback-test.scmo"
+    },
+    {
+      "glob": "logback-test.xml"
+    },
+    {
+      "glob": "logback.scmo"
+    },
+    {
+      "glob": "logback.xml"
+    },
+    {
+      "glob": "native/lib/tokenizers.properties"
+    },
+    {
+      "glob": "org/postgresql/driverconfig.properties"
+    },
+    {
+      "glob": "org/postgresql/translation/messages.properties"
+    },
+    {
+      "glob": "org/postgresql/translation/messages_en.properties"
+    },
+    {
+      "glob": "org/postgresql/translation/messages_en_US.properties"
+    },
+    {
+      "glob": "tokenizers-engine.properties"
+    },
+    {
+      "glob": "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd"
+    },
+    {
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/nfc.nrm"
+    },
+    {
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/nfkc.nrm"
+    },
+    {
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "module": "java.xml",
+      "glob": "com/sun/org/apache/xerces/internal/impl/xpath/regex/message.properties"
+    },
+    {
+      "module": "java.xml",
+      "glob": "com/sun/org/apache/xerces/internal/impl/xpath/regex/message_en.properties"
+    },
+    {
+      "module": "java.xml",
+      "glob": "com/sun/org/apache/xerces/internal/impl/xpath/regex/message_en_US.properties"
+    },
+    {
+      "bundle": "com.sun.org.apache.xerces.internal.impl.xpath.regex.message"
+    },
+    {
+      "bundle": "liquibase/i18n/liquibase-core"
+    },
+    {
+      "bundle": "org.postgresql.translation.messages"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/service/trace-native.sh
+++ b/service/trace-native.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# nexus-lp2qo spike: native-image tracing-agent run. Boots the shaded fat jar on
+# GraalVM 25.0.3 under native-image-agent, drives a broad workload across every
+# T2/T1 repo (migration + jOOQ CRUD + reads) plus embed init, then SIGTERMs so the
+# agent flushes traced metadata into META-INF/native-image/traced/.
+set -u
+cd "$(dirname "$0")"
+JH="$HOME/.sdkman/candidates/java/25.0.3-graal"
+JAR=target/nexus-service-1.0-SNAPSHOT.jar
+TRACE_DIR=src/main/resources/META-INF/native-image/traced
+mkdir -p "$TRACE_DIR"
+
+PGPORT=$(python3 -c "import socket;s=socket.socket();s.bind(('',0));print(s.getsockname()[1]);s.close()")
+SVCPORT=$(python3 -c "import socket;s=socket.socket();s.bind(('',0));print(s.getsockname()[1]);s.close()")
+echo "PGPORT=$PGPORT SVCPORT=$SVCPORT TRACE_DIR=$TRACE_DIR"
+docker rm -f lp2qo-pg >/dev/null 2>&1 || true
+docker run -d --name lp2qo-pg -e POSTGRES_DB=nexus -e POSTGRES_USER=nexus -e POSTGRES_PASSWORD=nexus -p ${PGPORT}:5432 pgvector/pgvector:pg17 >/dev/null
+until docker exec lp2qo-pg pg_isready -U nexus >/dev/null 2>&1; do sleep 1; done; sleep 2; echo "PG ready"
+
+export NX_DB_URL="jdbc:postgresql://localhost:${PGPORT}/nexus"
+export NX_DB_USER=nexus NX_DB_PASS=nexus
+export NX_SERVICE_PORT=$SVCPORT NX_SERVICE_TOKEN=spiketoken NX_EMBED_MODE=onnx
+
+"$JH/bin/java" \
+  -agentlib:native-image-agent=config-merge-dir="$TRACE_DIR",experimental-class-define-support \
+  --enable-preview --enable-native-access=ALL-UNNAMED \
+  -jar "$JAR" > /tmp/lp2qo-trace-svc.log 2>&1 &
+SVCPID=$!
+echo "svc pid $SVCPID (agent tracing)"
+
+UP=0
+for i in $(seq 1 90); do
+  if ! kill -0 $SVCPID 2>/dev/null; then echo "SERVICE EXITED EARLY at ${i}s"; tail -30 /tmp/lp2qo-trace-svc.log; break; fi
+  if curl -fsS "http://localhost:${SVCPORT}/health" >/dev/null 2>&1; then echo "HEALTH OK after ${i}s"; UP=1; break; fi
+  sleep 1
+done
+
+if [ "$UP" = "1" ]; then
+  B=(-s -o /dev/null -w "%{http_code} ")
+  AUTH=(-H "Authorization: Bearer spiketoken")
+  J=(-H "Content-Type: application/json")
+  U="http://localhost:${SVCPORT}"
+  echo "--- driving workload ---"
+  echo -n "health/version: "; curl "${B[@]}" "$U/health"; curl "${B[@]}" "${AUTH[@]}" "$U/version"; echo
+  echo -n "memory: "
+  curl "${B[@]}" "${AUTH[@]}" "${J[@]}" -X POST -d '{"project":"spike","title":"t1","content":"native jooq","tags":"a,b","ttl":30}' "$U/v1/memory/put"
+  curl "${B[@]}" "${AUTH[@]}" "${J[@]}" -X POST -d '{"project":"spike","title":"t2","content":"second","tags":"c","ttl":30}' "$U/v1/memory/put"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/memory/get?project=spike&title=t1"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/memory/search?query=native&project=spike"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/memory/list?project=spike"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/memory/all?project=spike"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/memory/projects"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/memory/search_by_tag?tag=a&project=spike"
+  curl "${B[@]}" "${AUTH[@]}" "${J[@]}" -X POST -d '{"keepId":1,"deleteIds":[],"mergedContent":"m"}' "$U/v1/memory/merge"
+  curl "${B[@]}" "${AUTH[@]}" -X DELETE "$U/v1/memory/delete?project=spike&title=t2"; echo
+  echo -n "scratch(t1): "
+  curl "${B[@]}" "${AUTH[@]}" "${J[@]}" -X POST -d '{"content":"scratch entry","tags":"x"}' "$U/v1/t1/put"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/t1/list"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/t1/search?query=scratch"; echo
+  echo -n "plans: "
+  curl "${B[@]}" "${AUTH[@]}" "${J[@]}" -X POST -d '{"query":"q","planJson":"{}","project":"spike","outcome":"success","tags":"t"}' "$U/v1/plans/save"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/plans/list?project=spike"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/plans/list_active?project=spike"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/plans/search?query=q&project=spike"; echo
+  echo -n "taxonomy: "
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/taxonomy/topics?collection=knowledge__x"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/taxonomy/top_topics?collection=knowledge__x"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/taxonomy/projection_counts?collection=knowledge__x"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/taxonomy/hubs?collection=knowledge__x"; echo
+  echo -n "aspects: "
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/aspects/list_by_collection?collection=knowledge__x"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/aspects/get_by_doc_id?doc_id=d1&collection=knowledge__x"; echo
+  echo -n "chash: "
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/chash/distinct_collections"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/chash/is_empty?collection=knowledge__x"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/chash/count_for_collection?collection=knowledge__x"
+  curl "${B[@]}" "${AUTH[@]}" "$U/v1/chash/lookup?collection=knowledge__x&chash=abc"; echo
+  echo "--- workload done ---"
+else
+  echo "SERVICE NEVER CAME UP — agent config may be incomplete"
+fi
+
+echo "--- SIGTERM for agent flush ---"
+kill -TERM $SVCPID 2>/dev/null
+for i in $(seq 1 20); do kill -0 $SVCPID 2>/dev/null || { echo "exited after ${i}s"; break; }; sleep 1; done
+kill -9 $SVCPID 2>/dev/null || true
+docker rm -f lp2qo-pg >/dev/null 2>&1 || true
+echo "=== traced config files ==="
+ls -la "$TRACE_DIR" 2>/dev/null
+echo "DONE"


### PR DESCRIPTION
Makes GraalVM native-image a viable, CI-gated artifact for `nexus-service`. Closes the parked **nexus-lp2qo** jOOQ blocker and carries the whole service — liquibase migration, jOOQ DSL, HTTP, ONNX embedding — to a working native binary on macOS/arm64 and Linux. **Opt-in (`-Pnative`); the default build and jlink path are untouched, so this is safe to merge.**

## What it does
- **jOOQ blocker resolved** — native-build-tools 1.1.2 (jOOQ 3.20.0 metadata covers 3.20.11), jOOQ un-excluded, runtime-init workaround removed. Requires GraalVM ≥ 25.0.2 (unified reachability-metadata schema).
- **Full-stack bring-up** — agent-traced `reachability-metadata.json` supplies liquibase runtime reflection; picocli (CLI link); liquibase 4.29.0 (metadata-covered); changelog/XSD resources; platform native libs for ONNX (`linux-.*`) + DJL tokenizers (`linux-x86_64`).
- **CI gate** — new `service-ci.yml` job builds the native image on Linux amd64 (GraalVM 25.0.3) and runs `native-smoke.sh` (migration + jOOQ INSERT/SELECT/Postgres-FTS = 200). Both jobs now use the **Maven wrapper**.

## Verification
- macOS native build + smoke green (90 changesets + jOOQ + ONNX embed)
- Java JVM suite green (liquibase 4.29.0 + picocli don't regress)
- Linux/arm64 build confirmed migration + jOOQ + ONNX resource-load; **this CI run is the amd64 confirmation of the embedding stack**

## Notes
- The Linux/arm64 local run caught two platform native-lib gaps the macOS trace alone would have shipped broken (ONNX `.so`, DJL tokenizer lib) — both fixed.
- Native stays opt-in; the native-vs-jlink default-shipping decision is tracked separately (nexus-lqb9j) and is release-boundary-gated by nexus-luxe6.

Refs nexus-ykrhb, nexus-lp2qo, nexus-r8f1h, nexus-k1x4r