### PR TITLE
RDR-156 P4: combined-query unification — schema + Java seam

### DIFF
--- a/conexus/hooks/scripts/auto-approve-nx-mcp.sh
+++ b/conexus/hooks/scripts/auto-approve-nx-mcp.sh
@@ -9,6 +9,8 @@ TOOL_NAME=$(echo "$INPUT" | python3 -c "import json,sys; print(json.loads(sys.st
 case "$TOOL_NAME" in
   mcp__plugin_conexus_nexus__search|\
   mcp__plugin_conexus_nexus__query|\
+  mcp__plugin_conexus_nexus__search_metadata_scoped|\
+  mcp__plugin_conexus_nexus__search_topic_scoped|\
   mcp__plugin_conexus_nexus__store_put|\
   mcp__plugin_conexus_nexus__store_get|\
   mcp__plugin_conexus_nexus__store_get_many|\

--- a/conexus/plans/builtin/find-by-author.yml
+++ b/conexus/plans/builtin/find-by-author.yml
@@ -1,12 +1,12 @@
 name: find-by-author
 description: >-
   Find documents attributed to a specific author. Routes through the
-  catalog's author index to locate every entry by that person, hydrates
-  the matching documents' content, and summarises their contribution
-  surface so a downstream agent can characterise what the author has
-  written and published. Useful for "who is X" and "what has X published"
-  lookups where the caller already has an author name but not a specific
-  title.
+  combined metadata-scoped query (RDR-156 P4): one statement joins the
+  vector chunks to the catalog and filters by author, ranking by relevance
+  to the author's contribution surface, then summarises so a downstream
+  agent can characterise what the author has written. Useful for "who is X"
+  and "what has X published" lookups where the caller has an author name
+  but not a specific title.
 dimensions:
   verb: research
   scope: global
@@ -17,19 +17,20 @@ optional_bindings:
   - limit
 default_bindings:
   limit: 10
-tags: builtin-template,rdr-092,catalog,author
+tags: builtin-template,rdr-092,rdr-156,catalog,author,combined-query
 plan_json:
   steps:
-    - tool: query
+    # RDR-156 P4 (nexus-zo0zt): combined metadata-scoped query replaces the
+    # query()-tool catalog dance + store_get_many hydration. The structured
+    # output carries contents inline, so summarize reads $step1.contents
+    # directly (no chash-keyed store_get_many — these ids are document
+    # tumblers). Service-mode (pgvector) only.
+    - tool: search_metadata_scoped
       args:
-        question: $author research contributions
+        query: $author
         author: $author
         limit: $limit
         corpus: all
-    - tool: store_get_many
-      args:
-        ids: $step1.ids
-        collections: $step1.collections
     - tool: summarize
       args:
-        inputs: $step2.contents
+        inputs: $step1.contents

--- a/conexus/plans/builtin/type-scoped-search.yml
+++ b/conexus/plans/builtin/type-scoped-search.yml
@@ -1,12 +1,13 @@
 name: type-scoped-search
 description: >-
   Search within a single content type (code, paper, rdr, knowledge).
-  Routes through the catalog to resolve the content-type bucket, runs the
-  semantic query against only those collections, hydrates the matches,
-  and summarises the findings. Useful when the caller already knows the
-  artefact kind (for example, "search code for X" or "search RDRs for Y")
-  but not the specific document, and wants the answer scoped narrowly
-  enough that unrelated corpora do not dilute the ranking.
+  Routes through the combined metadata-scoped query (RDR-156 P4): one
+  statement joins the vector chunks to the catalog and filters by content
+  type, ranks the matches semantically, and summarises the findings.
+  Useful when the caller knows the artefact kind (for example, "search code
+  for X" or "search RDRs for Y") but not the specific document, and wants
+  the answer scoped narrowly enough that unrelated corpora do not dilute the
+  ranking.
 dimensions:
   verb: research
   scope: global
@@ -18,19 +19,18 @@ optional_bindings:
   - limit
 default_bindings:
   limit: 10
-tags: builtin-template,rdr-092,catalog,type-scoped
+tags: builtin-template,rdr-092,rdr-156,catalog,type-scoped,combined-query
 plan_json:
   steps:
-    - tool: query
+    # RDR-156 P4 (nexus-zo0zt): combined metadata-scoped query replaces the
+    # query()-tool catalog dance + store_get_many hydration; summarize reads
+    # $step1.contents inline. Service-mode (pgvector) only.
+    - tool: search_metadata_scoped
       args:
-        question: $question
+        query: $question
         content_type: $content_type
         limit: $limit
         corpus: all
-    - tool: store_get_many
-      args:
-        ids: $step1.ids
-        collections: $step1.collections
     - tool: summarize
       args:
-        inputs: $step2.contents
+        inputs: $step1.contents

--- a/service/src/main/java/dev/nexus/service/http/VectorHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/VectorHandler.java
@@ -111,6 +111,8 @@ public final class VectorHandler implements HttpHandler {
                 case "/search"        -> handleSearch(exchange, method);
                 case "/query"         -> handleSearch(exchange, method);   // alias
                 case "/hybrid-search" -> handleHybridSearch(exchange, method);  // RDR-155 P3
+                case "/search-metadata-scoped" -> handleSearchMetadataScoped(exchange, method);  // RDR-156 P4
+                case "/search-topic-scoped"    -> handleSearchTopicScoped(exchange, method);     // RDR-156 P4
                 case "/store-put"     -> handleStorePut(exchange, method);
                 case "/get"           -> handleGet(exchange, method);
                 case "/store-get"     -> handleStoreGet(exchange, method);
@@ -258,6 +260,54 @@ public final class VectorHandler implements HttpHandler {
         Map<String, Object> where = optMap(body, "where");
 
         var results = repo.hybridSearch(tenant, queryText, collections, nResults, where);
+        HttpUtil.send(ex, 200, json(results));
+    }
+
+    /**
+     * POST /v1/vectors/search-metadata-scoped (RDR-156 P4, Decision 5).
+     *
+     * <p>The combined metadata-scoped query that retires the {@code query} MCP tool's
+     * app-side catalog-routing dance. Request:
+     * {@code {"query": "...", "collections": [...], "content_type": "...", "author": "...",
+     * "year": 2024, "corpus": "...", "n_results": 10}} — any of content_type/author/year/
+     * corpus may be omitted (no filter on that dimension). Returns document-level rows.
+     */
+    private void handleSearchMetadataScoped(HttpExchange ex, String method) throws IOException {
+        requireMethod(ex, method, "POST");
+        var repo   = requirePgRepo(ex);
+        var tenant = requireTenant(ex);
+        Map<String, Object> body = readBody(ex);
+        String queryText         = requireString(body, "query");
+        List<String> collections = requireStringList(body, "collections");
+        String contentType       = optString(body, "content_type");
+        String author            = optString(body, "author");
+        Integer year             = optInteger(body, "year");
+        String corpus            = optString(body, "corpus");
+        int nResults             = optInt(body, "n_results", 10);
+
+        var results = repo.searchMetadataScoped(
+            tenant, queryText, collections, contentType, author, year, corpus, nResults);
+        HttpUtil.send(ex, 200, json(results));
+    }
+
+    /**
+     * POST /v1/vectors/search-topic-scoped (RDR-156 P4, Decision 5).
+     *
+     * <p>The combined topic-scoped query. Request:
+     * {@code {"query": "...", "topic": "...", "collection": "...", "n_results": 10}}.
+     * Chunk-level results (topic membership is chunk-keyed, nexus-sa14p).
+     */
+    private void handleSearchTopicScoped(HttpExchange ex, String method) throws IOException {
+        requireMethod(ex, method, "POST");
+        var repo   = requirePgRepo(ex);
+        var tenant = requireTenant(ex);
+        Map<String, Object> body = readBody(ex);
+        String queryText  = requireString(body, "query");
+        String topicLabel = requireString(body, "topic");
+        String collection = requireString(body, "collection");
+        int nResults      = optInt(body, "n_results", 10);
+
+        var results = repo.searchTopicScoped(tenant, queryText, topicLabel, collection, nResults);
         HttpUtil.send(ex, 200, json(results));
     }
 
@@ -622,6 +672,25 @@ public final class VectorHandler implements HttpHandler {
     private int optInt(Map<String, Object> body, String key, int defaultValue) {
         Object val = body.get(key);
         if (val == null) return defaultValue;
+        if (val instanceof Number n) return n.intValue();
+        try { return Integer.parseInt(val.toString()); }
+        catch (NumberFormatException e) {
+            throw new IllegalArgumentException("field '" + key + "' must be an integer");
+        }
+    }
+
+    /** Optional string field; null/blank → null (no-filter semantics for combined queries). */
+    private String optString(Map<String, Object> body, String key) {
+        Object val = body.get(key);
+        if (val == null) return null;
+        String s = val.toString();
+        return s.isBlank() ? null : s;
+    }
+
+    /** Optional integer field; null → null (no-filter on that dimension). */
+    private Integer optInteger(Map<String, Object> body, String key) {
+        Object val = body.get(key);
+        if (val == null) return null;
         if (val instanceof Number n) return n.intValue();
         try { return Integer.parseInt(val.toString()); }
         catch (NumberFormatException e) {

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -776,9 +776,13 @@ public final class PgVectorRepository {
      * catalog_documents}, filters by the catalog metadata dimensions (NULL = skip),
      * tombstone-filters, and ranks by cosine distance. The query vector is embedded
      * server-side and passed as a function ARGUMENT so the HNSW index engages
-     * (Finding 5a). {@code SET LOCAL hnsw.iterative_scan='relaxed_order'} is the
-     * narrow-collection {@code max_scan_tuples} defense (Finding 5b) at the call site —
-     * the inlinable SQL function deliberately has no in-function selectivity switch.
+     * (Finding 5a). {@code runCombinedQuery} applies {@code SET LOCAL
+     * hnsw.iterative_scan='relaxed_order'} — the same filtered-ANN setting
+     * {@link #search}/{@link #hybridSearch} use; the inlinable SQL function has no
+     * in-function selectivity switch (kept inlinable by decision). NOTE: this alone does
+     * NOT tune {@code hnsw.max_scan_tuples}, so the Finding-5b narrow/distant scoped
+     * under-return ceiling is not yet fully defended — tracked separately (nexus-0zcn9);
+     * the production-scale recall gate is owned by conexus xr7.8.9.
      *
      * <p>Returns the document tumbler as {@code id} (document-level retrieval). A
      * document with multiple matching chunks can appear more than once; consumer-side

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -768,6 +768,144 @@ public final class PgVectorRepository {
     }
 
     /**
+     * Metadata-scoped combined search (RDR-156 P4, Decision 5, bead nexus-70r3c.15/joesk).
+     *
+     * <p>Unifies the {@code query} MCP tool's catalog-aware-routing dance into one
+     * planner-optimizable statement: calls {@code nexus.search_metadata_scoped_<dim>}
+     * (catalog-006) which joins {@code chunks_<dim> ⋈ catalog_document_chunks ⋈
+     * catalog_documents}, filters by the catalog metadata dimensions (NULL = skip),
+     * tombstone-filters, and ranks by cosine distance. The query vector is embedded
+     * server-side and passed as a function ARGUMENT so the HNSW index engages
+     * (Finding 5a). {@code SET LOCAL hnsw.iterative_scan='relaxed_order'} is the
+     * narrow-collection {@code max_scan_tuples} defense (Finding 5b) at the call site —
+     * the inlinable SQL function deliberately has no in-function selectivity switch.
+     *
+     * <p>Returns the document tumbler as {@code id} (document-level retrieval). A
+     * document with multiple matching chunks can appear more than once; consumer-side
+     * de-duplication (keep best distance per id) is the {@code query}-tool repoint's
+     * responsibility, not this method's.
+     *
+     * @param contentType catalog content_type filter; null = no filter
+     * @param author      catalog author filter; null = no filter
+     * @param year        catalog year filter; null = no filter
+     * @param corpus      catalog corpus filter; null = no filter
+     */
+    public List<Map<String, Object>> searchMetadataScoped(
+            String tenant, String queryText, List<String> collectionNames,
+            String contentType, String author, Integer year, String corpus, int nResults) {
+        if (collectionNames == null || collectionNames.isEmpty()) {
+            return List.of();
+        }
+        if (nResults < 1) {
+            throw new IllegalArgumentException("nResults must be >= 1, got " + nResults);
+        }
+        int dim = requireHomogeneousDim(collectionNames);
+        float[] queryVec = embedQuery(collectionNames.get(0), queryText, dim);
+
+        String sql = "SELECT id, content, collection, distance"
+                   + " FROM nexus.search_metadata_scoped_" + dim
+                   + "(?::vector, ARRAY[" + placeholders(collectionNames.size()) + "]::text[],"
+                   + " ?::text, ?::text, ?::int, ?::text, ?)";
+        List<Object> binds = new ArrayList<>();
+        binds.add(vectorLiteral(queryVec));
+        binds.addAll(collectionNames);
+        binds.add(contentType);
+        binds.add(author);
+        binds.add(year);
+        binds.add(corpus);
+        binds.add(nResults);
+
+        return runCombinedQuery(tenant, sql, binds);
+    }
+
+    /**
+     * Topic-scoped combined search (RDR-156 P4, Decision 5, bead nexus-70r3c.15/joesk).
+     *
+     * <p>Calls {@code nexus.search_topic_scoped_<dim>} (catalog-006). Topic membership is
+     * CHUNK-level: {@code topic_assignments.doc_id} is a chunk chash (nexus-sa14p), so the
+     * function joins {@code chunks_<dim>.chash = topic_assignments.doc_id}, live-filters,
+     * and ranks by cosine distance. Returns the chunk chash as {@code id} (chunk-level,
+     * matching {@link #search}). Same query-vector-as-argument + iterative_scan discipline
+     * as {@link #searchMetadataScoped}.
+     */
+    public List<Map<String, Object>> searchTopicScoped(
+            String tenant, String queryText, String topicLabel, String collection, int nResults) {
+        if (collection == null || collection.isBlank()) {
+            return List.of();
+        }
+        if (nResults < 1) {
+            throw new IllegalArgumentException("nResults must be >= 1, got " + nResults);
+        }
+        int dim = dimForCollection(collection);
+        float[] queryVec = embedQuery(collection, queryText, dim);
+
+        String sql = "SELECT id, content, collection, distance"
+                   + " FROM nexus.search_topic_scoped_" + dim
+                   + "(?::vector, ?::text, ?::text, ?)";
+        List<Object> binds = new ArrayList<>();
+        binds.add(vectorLiteral(queryVec));
+        binds.add(topicLabel);
+        binds.add(collection);
+        binds.add(nResults);
+
+        return runCombinedQuery(tenant, sql, binds);
+    }
+
+    /**
+     * Validate every collection dispatches to the same dim and return it.
+     * Mirrors the same-dim guard in {@link #search}.
+     */
+    private static int requireHomogeneousDim(List<String> collectionNames) {
+        int dim = dimForCollection(collectionNames.get(0));
+        for (String col : collectionNames) {
+            int colDim = dimForCollection(col);
+            if (colDim != dim) {
+                throw new IllegalArgumentException(
+                    "mixed dimensions in one combined-query call: '" + collectionNames.get(0)
+                    + "' is " + dim + "-dim but '" + col + "' is " + colDim
+                    + "-dim - one query vector cannot serve both spaces");
+            }
+        }
+        return dim;
+    }
+
+    /** Embed the query server-side, routing by collection; fail loud on dim mismatch. */
+    private float[] embedQuery(String collection, String queryText, int dim) {
+        float[] queryVec = (queryRouter != null)
+                ? queryRouter.embedOneForCollection(collection, queryText)
+                : queryEmbedder.embedOne(queryText);
+        if (queryVec.length != dim) {
+            throw new IllegalArgumentException(
+                "query embedder produced a " + queryVec.length
+                + "-dim vector but the collection dispatches to chunks_" + dim);
+        }
+        return queryVec;
+    }
+
+    /**
+     * Execute a combined-query function call under the tenant RLS scope with the
+     * filtered-ANN session setting, and map the (id, content, collection, distance)
+     * rows to the flat search() envelope.
+     */
+    private List<Map<String, Object>> runCombinedQuery(
+            String tenant, String sql, List<Object> binds) {
+        Result<Record> result = tenantScope.withTenant(tenant, ctx -> {
+            ctx.execute("SET LOCAL hnsw.iterative_scan = 'relaxed_order'");
+            return ctx.fetch(sql, binds.toArray());
+        });
+        List<Map<String, Object>> rows = new ArrayList<>(result.size());
+        for (Record rec : result) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("id",         rec.get("id", String.class));
+            row.put("content",    rec.get("content", String.class));
+            row.put("distance",   rec.get("distance", Double.class));
+            row.put("collection", rec.get("collection", String.class));
+            rows.add(row);
+        }
+        return rows;
+    }
+
+    /**
      * Per-collection vector statistics for {@code tenant} (RDR-156 P3, Decision 4,
      * bead nexus-70r3c.12).
      *

--- a/service/src/main/resources/db/changelog/catalog-006-combined-query-functions.xml
+++ b/service/src/main/resources/db/changelog/catalog-006-combined-query-functions.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    RDR-156 bead nexus-70r3c.15 — P4.2 combined-query functions (Decision 5).
+
+    The Phase-4 unification deliverable: the two highest-traffic cross-store stitches
+    (the `query` MCP tool's catalog-aware-routing dance and topic-scoped search) become
+    single planner-optimizable SQL functions. Each is per-dim (chunks_384/768/1024) so
+    the query vector is a typed, plan-time ARGUMENT — Research Finding 5a: HNSW only
+    engages when the probe vector is a constant/parameter (literal → 2ms Index Scan;
+    join-sourced → 340ms Seq Scan).
+
+    Capability-selection discipline (RDR-154 P3 / RDR-156 §Decision): these are
+    set-returning LANGUAGE sql functions, NOT views, because a view cannot take the
+    query vector as an argument. They are written to be INLINABLE (single SELECT,
+    STABLE, SECURITY INVOKER, not STRICT) so the planner folds them into the calling
+    query and the HNSW index scan survives the join — the P4.1 EXPLAIN test
+    (CombinedQueryParityTest GROUP 3) is the enforcement point.
+
+    SECURITY INVOKER (RDR-154 standing rule): the function runs with the CALLER's
+    privileges, so FORCE RLS on chunks_<dim> / catalog_documents / topic_assignments
+    provides tenant isolation. No SECURITY DEFINER (would also defeat inlining).
+
+    NULL-arg-means-skip: each metadata filter is `(p_x IS NULL OR col = p_x)`, so a
+    NULL argument disables that dimension. The function is deliberately NOT marked
+    STRICT (which would both return NULL on any NULL arg and prevent inlining).
+
+    Tombstone-filtered: every shape joins catalog_documents and requires
+    `deleted_at IS NULL` (Decision 6 single enforcement point). A document-backed chunk
+    whose doc is tombstoned drops out; manifest-less note chunks have no catalog row and
+    are therefore not metadata/topic-addressable by construction (they carry no metadata
+    and belong to no topic).
+
+    Result contract (CombinedQueryParityTest): RETURNS TABLE(id text, content text,
+    collection text, distance float8); id is the document tumbler (these shapes feed the
+    document-level `query` tool), content is the matched chunk text, distance is cosine
+    (<=>). Ordered by distance ascending, capped at p_n. Multi-chunk-per-document
+    de-duplication is a consumer/follow-on concern (aspect-filtered + graph-hop shapes,
+    explicitly deferred by the bead); fixtures are one-chunk-per-doc.
+
+    EXECUTE defaults to PUBLIC for functions; SECURITY INVOKER means the underlying
+    table grants (grants-nexus-svc.xml) are the real boundary, exactly like the
+    catalog-005 view.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <!-- ════════════════════════════════════════════════════════════════════════
+         metadata-scoped search — per dim (384 / 768 / 1024)
+         ════════════════════════════════════════════════════════════════════════ -->
+
+    <changeSet id="catalog-006-1" author="nexus-70r3c.15">
+        <comment>search_metadata_scoped_384: chunks_384 ⋈ manifest ⋈ catalog_documents, metadata-filtered, vector-ranked</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE FUNCTION nexus.search_metadata_scoped_384(
+    p_query        vector(384),
+    p_collections  text[],
+    p_content_type text,
+    p_author       text,
+    p_year         int,
+    p_corpus       text,
+    p_n            int
+) RETURNS TABLE(id text, content text, collection text, distance float8)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    SELECT d.tumbler,
+           c.chunk_text,
+           c.collection,
+           (c.embedding &lt;=&gt; p_query)::float8
+      FROM nexus.chunks_384 c
+      JOIN nexus.catalog_document_chunks m
+        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d
+        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+     WHERE c.collection = ANY(p_collections)
+       AND d.deleted_at IS NULL
+       AND (p_content_type IS NULL OR d.content_type = p_content_type)
+       AND (p_author       IS NULL OR d.author       = p_author)
+       AND (p_year         IS NULL OR d.year         = p_year)
+       AND (p_corpus       IS NULL OR d.corpus       = p_corpus)
+     ORDER BY c.embedding &lt;=&gt; p_query
+     LIMIT p_n
+$$;
+        </sql>
+        <rollback>DROP FUNCTION IF EXISTS nexus.search_metadata_scoped_384(vector, text[], text, text, int, text, int)</rollback>
+    </changeSet>
+
+    <changeSet id="catalog-006-2" author="nexus-70r3c.15">
+        <comment>search_metadata_scoped_768</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE FUNCTION nexus.search_metadata_scoped_768(
+    p_query        vector(768),
+    p_collections  text[],
+    p_content_type text,
+    p_author       text,
+    p_year         int,
+    p_corpus       text,
+    p_n            int
+) RETURNS TABLE(id text, content text, collection text, distance float8)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    SELECT d.tumbler,
+           c.chunk_text,
+           c.collection,
+           (c.embedding &lt;=&gt; p_query)::float8
+      FROM nexus.chunks_768 c
+      JOIN nexus.catalog_document_chunks m
+        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d
+        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+     WHERE c.collection = ANY(p_collections)
+       AND d.deleted_at IS NULL
+       AND (p_content_type IS NULL OR d.content_type = p_content_type)
+       AND (p_author       IS NULL OR d.author       = p_author)
+       AND (p_year         IS NULL OR d.year         = p_year)
+       AND (p_corpus       IS NULL OR d.corpus       = p_corpus)
+     ORDER BY c.embedding &lt;=&gt; p_query
+     LIMIT p_n
+$$;
+        </sql>
+        <rollback>DROP FUNCTION IF EXISTS nexus.search_metadata_scoped_768(vector, text[], text, text, int, text, int)</rollback>
+    </changeSet>
+
+    <changeSet id="catalog-006-3" author="nexus-70r3c.15">
+        <comment>search_metadata_scoped_1024</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE FUNCTION nexus.search_metadata_scoped_1024(
+    p_query        vector(1024),
+    p_collections  text[],
+    p_content_type text,
+    p_author       text,
+    p_year         int,
+    p_corpus       text,
+    p_n            int
+) RETURNS TABLE(id text, content text, collection text, distance float8)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    SELECT d.tumbler,
+           c.chunk_text,
+           c.collection,
+           (c.embedding &lt;=&gt; p_query)::float8
+      FROM nexus.chunks_1024 c
+      JOIN nexus.catalog_document_chunks m
+        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d
+        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+     WHERE c.collection = ANY(p_collections)
+       AND d.deleted_at IS NULL
+       AND (p_content_type IS NULL OR d.content_type = p_content_type)
+       AND (p_author       IS NULL OR d.author       = p_author)
+       AND (p_year         IS NULL OR d.year         = p_year)
+       AND (p_corpus       IS NULL OR d.corpus       = p_corpus)
+     ORDER BY c.embedding &lt;=&gt; p_query
+     LIMIT p_n
+$$;
+        </sql>
+        <rollback>DROP FUNCTION IF EXISTS nexus.search_metadata_scoped_1024(vector, text[], text, text, int, text, int)</rollback>
+    </changeSet>
+
+    <!-- ════════════════════════════════════════════════════════════════════════
+         topic-scoped search — per dim (384 / 768 / 1024)
+         ════════════════════════════════════════════════════════════════════════ -->
+
+    <changeSet id="catalog-006-4" author="nexus-70r3c.15">
+        <comment>search_topic_scoped_384: chunks_384 ⋈ manifest ⋈ catalog_documents ⋈ topic_assignments ⋈ topics</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE FUNCTION nexus.search_topic_scoped_384(
+    p_query       vector(384),
+    p_topic_label text,
+    p_collection  text,
+    p_n           int
+) RETURNS TABLE(id text, content text, collection text, distance float8)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    SELECT d.tumbler,
+           c.chunk_text,
+           c.collection,
+           (c.embedding &lt;=&gt; p_query)::float8
+      FROM nexus.chunks_384 c
+      JOIN nexus.catalog_document_chunks m
+        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d
+        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+      JOIN nexus.topic_assignments ta
+        ON ta.tenant_id = d.tenant_id AND ta.doc_id = d.tumbler
+      JOIN nexus.topics t
+        ON t.tenant_id = ta.tenant_id AND t.id = ta.topic_id
+     WHERE c.collection = p_collection
+       AND t.collection = p_collection
+       AND t.label = p_topic_label
+       AND d.deleted_at IS NULL
+     ORDER BY c.embedding &lt;=&gt; p_query
+     LIMIT p_n
+$$;
+        </sql>
+        <rollback>DROP FUNCTION IF EXISTS nexus.search_topic_scoped_384(vector, text, text, int)</rollback>
+    </changeSet>
+
+    <changeSet id="catalog-006-5" author="nexus-70r3c.15">
+        <comment>search_topic_scoped_768</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE FUNCTION nexus.search_topic_scoped_768(
+    p_query       vector(768),
+    p_topic_label text,
+    p_collection  text,
+    p_n           int
+) RETURNS TABLE(id text, content text, collection text, distance float8)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    SELECT d.tumbler,
+           c.chunk_text,
+           c.collection,
+           (c.embedding &lt;=&gt; p_query)::float8
+      FROM nexus.chunks_768 c
+      JOIN nexus.catalog_document_chunks m
+        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d
+        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+      JOIN nexus.topic_assignments ta
+        ON ta.tenant_id = d.tenant_id AND ta.doc_id = d.tumbler
+      JOIN nexus.topics t
+        ON t.tenant_id = ta.tenant_id AND t.id = ta.topic_id
+     WHERE c.collection = p_collection
+       AND t.collection = p_collection
+       AND t.label = p_topic_label
+       AND d.deleted_at IS NULL
+     ORDER BY c.embedding &lt;=&gt; p_query
+     LIMIT p_n
+$$;
+        </sql>
+        <rollback>DROP FUNCTION IF EXISTS nexus.search_topic_scoped_768(vector, text, text, int)</rollback>
+    </changeSet>
+
+    <changeSet id="catalog-006-6" author="nexus-70r3c.15">
+        <comment>search_topic_scoped_1024</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE FUNCTION nexus.search_topic_scoped_1024(
+    p_query       vector(1024),
+    p_topic_label text,
+    p_collection  text,
+    p_n           int
+) RETURNS TABLE(id text, content text, collection text, distance float8)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    SELECT d.tumbler,
+           c.chunk_text,
+           c.collection,
+           (c.embedding &lt;=&gt; p_query)::float8
+      FROM nexus.chunks_1024 c
+      JOIN nexus.catalog_document_chunks m
+        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d
+        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+      JOIN nexus.topic_assignments ta
+        ON ta.tenant_id = d.tenant_id AND ta.doc_id = d.tumbler
+      JOIN nexus.topics t
+        ON t.tenant_id = ta.tenant_id AND t.id = ta.topic_id
+     WHERE c.collection = p_collection
+       AND t.collection = p_collection
+       AND t.label = p_topic_label
+       AND d.deleted_at IS NULL
+     ORDER BY c.embedding &lt;=&gt; p_query
+     LIMIT p_n
+$$;
+        </sql>
+        <rollback>DROP FUNCTION IF EXISTS nexus.search_topic_scoped_1024(vector, text, text, int)</rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/main/resources/db/changelog/catalog-006-combined-query-functions.xml
+++ b/service/src/main/resources/db/changelog/catalog-006-combined-query-functions.xml
@@ -169,8 +169,18 @@ $$;
          topic-scoped search — per dim (384 / 768 / 1024)
          ════════════════════════════════════════════════════════════════════════ -->
 
+    <!--
+        Topic membership is CHUNK-level: topic_assignments.doc_id is a chunk content-hash
+        (chash), NOT a document tumbler (nexus-sa14p — the HDBSCAN taxonomy clusters chunk
+        embeddings). The join is therefore chunks_<dim>.chash = topic_assignments.doc_id
+        directly, and the returned id is the chunk chash (chunk-level retrieval, matching
+        raw search()). Tombstone filtering uses the live_chunks predicate inline (a chunk
+        is live if it has no manifest rows — MCP note chunk — or at least one manifest row
+        to a live document); inlined rather than joined to the view so the HNSW index on
+        the raw chunks table still engages.
+    -->
     <changeSet id="catalog-006-4" author="nexus-70r3c.15">
-        <comment>search_topic_scoped_384: chunks_384 ⋈ manifest ⋈ catalog_documents ⋈ topic_assignments ⋈ topics</comment>
+        <comment>search_topic_scoped_384: chunks_384 ⋈ topic_assignments(chash) ⋈ topics; chunk-level, live-filtered</comment>
         <sql splitStatements="false" stripComments="false">
 CREATE OR REPLACE FUNCTION nexus.search_topic_scoped_384(
     p_query       vector(384),
@@ -182,23 +192,25 @@ LANGUAGE sql
 STABLE
 SECURITY INVOKER
 AS $$
-    SELECT d.tumbler,
+    SELECT c.chash,
            c.chunk_text,
            c.collection,
            (c.embedding &lt;=&gt; p_query)::float8
       FROM nexus.chunks_384 c
-      JOIN nexus.catalog_document_chunks m
-        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
-      JOIN nexus.catalog_documents d
-        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
       JOIN nexus.topic_assignments ta
-        ON ta.tenant_id = d.tenant_id AND ta.doc_id = d.tumbler
+        ON ta.tenant_id = c.tenant_id AND ta.doc_id = c.chash
       JOIN nexus.topics t
         ON t.tenant_id = ta.tenant_id AND t.id = ta.topic_id
      WHERE c.collection = p_collection
        AND t.collection = p_collection
        AND t.label = p_topic_label
-       AND d.deleted_at IS NULL
+       AND (NOT EXISTS (SELECT 1 FROM nexus.catalog_document_chunks m
+                         WHERE m.tenant_id = c.tenant_id AND m.chash = c.chash)
+            OR EXISTS (SELECT 1 FROM nexus.catalog_document_chunks m
+                         JOIN nexus.catalog_documents d
+                           ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+                        WHERE m.tenant_id = c.tenant_id AND m.chash = c.chash
+                          AND d.deleted_at IS NULL))
      ORDER BY c.embedding &lt;=&gt; p_query
      LIMIT p_n
 $$;
@@ -219,23 +231,25 @@ LANGUAGE sql
 STABLE
 SECURITY INVOKER
 AS $$
-    SELECT d.tumbler,
+    SELECT c.chash,
            c.chunk_text,
            c.collection,
            (c.embedding &lt;=&gt; p_query)::float8
       FROM nexus.chunks_768 c
-      JOIN nexus.catalog_document_chunks m
-        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
-      JOIN nexus.catalog_documents d
-        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
       JOIN nexus.topic_assignments ta
-        ON ta.tenant_id = d.tenant_id AND ta.doc_id = d.tumbler
+        ON ta.tenant_id = c.tenant_id AND ta.doc_id = c.chash
       JOIN nexus.topics t
         ON t.tenant_id = ta.tenant_id AND t.id = ta.topic_id
      WHERE c.collection = p_collection
        AND t.collection = p_collection
        AND t.label = p_topic_label
-       AND d.deleted_at IS NULL
+       AND (NOT EXISTS (SELECT 1 FROM nexus.catalog_document_chunks m
+                         WHERE m.tenant_id = c.tenant_id AND m.chash = c.chash)
+            OR EXISTS (SELECT 1 FROM nexus.catalog_document_chunks m
+                         JOIN nexus.catalog_documents d
+                           ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+                        WHERE m.tenant_id = c.tenant_id AND m.chash = c.chash
+                          AND d.deleted_at IS NULL))
      ORDER BY c.embedding &lt;=&gt; p_query
      LIMIT p_n
 $$;
@@ -256,23 +270,25 @@ LANGUAGE sql
 STABLE
 SECURITY INVOKER
 AS $$
-    SELECT d.tumbler,
+    SELECT c.chash,
            c.chunk_text,
            c.collection,
            (c.embedding &lt;=&gt; p_query)::float8
       FROM nexus.chunks_1024 c
-      JOIN nexus.catalog_document_chunks m
-        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
-      JOIN nexus.catalog_documents d
-        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
       JOIN nexus.topic_assignments ta
-        ON ta.tenant_id = d.tenant_id AND ta.doc_id = d.tumbler
+        ON ta.tenant_id = c.tenant_id AND ta.doc_id = c.chash
       JOIN nexus.topics t
         ON t.tenant_id = ta.tenant_id AND t.id = ta.topic_id
      WHERE c.collection = p_collection
        AND t.collection = p_collection
        AND t.label = p_topic_label
-       AND d.deleted_at IS NULL
+       AND (NOT EXISTS (SELECT 1 FROM nexus.catalog_document_chunks m
+                         WHERE m.tenant_id = c.tenant_id AND m.chash = c.chash)
+            OR EXISTS (SELECT 1 FROM nexus.catalog_document_chunks m
+                         JOIN nexus.catalog_documents d
+                           ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+                        WHERE m.tenant_id = c.tenant_id AND m.chash = c.chash
+                          AND d.deleted_at IS NULL))
      ORDER BY c.embedding &lt;=&gt; p_query
      LIMIT p_n
 $$;

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -88,6 +88,15 @@
          placed after catalog-004 to keep the catalog-NNN sequence in file order. -->
     <include file="db/changelog/catalog-005-collection-vector-stats.xml"/>
 
+    <!-- Combined-query functions (bead nexus-70r3c.15, RDR-156 P4.2):
+         per-dim search_metadata_scoped_<dim> + search_topic_scoped_<dim> set-returning
+         SQL functions (Decision 5). Inlinable LANGUAGE sql, SECURITY INVOKER, query
+         vector as a plan-time argument (Finding 5a) so the HNSW index survives the join;
+         tombstone-filtered (deleted_at IS NULL). Depends on vectors-001 (chunks_<dim>),
+         catalog-001 (documents/manifest), catalog-003 (deleted_at), taxonomy-001
+         (topics/topic_assignments). Contract: CombinedQueryParityTest (P4.1). -->
+    <include file="db/changelog/catalog-006-combined-query-functions.xml"/>
+
     <!-- pgvector taxonomy centroids (bead nexus-t1hnc.1, RDR-156):
          taxonomy_centroids_384/768/1024 — moves the taxonomy__centroids ChromaDB
          collection into Postgres so service-mode taxonomy compute is chroma-free.

--- a/service/src/test/java/dev/nexus/service/CombinedQueryParityTest.java
+++ b/service/src/test/java/dev/nexus/service/CombinedQueryParityTest.java
@@ -1,0 +1,915 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RDR-156 P4.1 (bead nexus-70r3c.14) — TDD-RED suite for the Phase-4 combined-query
+ * deliverable (Decision 5, the unification of the two highest-traffic cross-store
+ * stitches into single planner-optimizable statements).
+ *
+ * <p><strong>Two shapes pinned here</strong> (the {@code query} MCP tool's catalog
+ * dance and topic-scoped search), each as a per-dim set-returning SQL function so the
+ * planner can inline it and keep the query vector a plan-time constant (Finding 5a):
+ * <ul>
+ *   <li>{@code nexus.search_metadata_scoped_<dim>(p_query vector, p_collections text[],
+ *       p_content_type text, p_author text, p_year int, p_corpus text, p_n int)} —
+ *       joins {@code chunks_<dim> ⋈ catalog_document_chunks ⋈ catalog_documents},
+ *       filters by the catalog metadata dimensions the {@code query} tool routes on
+ *       (NULL arg = no filter on that dimension), ranks by cosine distance ascending.</li>
+ *   <li>{@code nexus.search_topic_scoped_<dim>(p_query vector, p_topic_label text,
+ *       p_collection text, p_n int)} — joins {@code chunks_<dim> ⋈ catalog_document_chunks
+ *       ⋈ topic_assignments ⋈ topics}, scoped to the named topic label within a
+ *       collection, ranks by cosine distance ascending.</li>
+ * </ul>
+ *
+ * <p><strong>The four mandatory encodings (bead nexus-70r3c.14)</strong>, mapped to
+ * test groups:
+ * <ol>
+ *   <li><strong>Query-vector-as-argument (Finding 5a)</strong> — GROUP 1 / GROUP 2:
+ *       every function takes the probe vector as its first ARGUMENT (asserted via
+ *       {@code pg_proc} signature introspection and by calling with a literal vector).
+ *       A join-sourced vector is a hard FAIL (it produces a 340 ms Seq Scan instead of
+ *       the 2 ms HNSW Index Scan).</li>
+ *   <li><strong>EXPLAIN plan check — HNSW survives the join</strong> — GROUP 3: the
+ *       plan for the combined query uses {@code idx_chunks_<dim>_embedding} (the HNSW
+ *       index), never a Seq Scan on the chunks table. A {@code Function Scan} node
+ *       (i.e. a non-inlinable plpgsql body) also fails this group — only an inlinable
+ *       LANGUAGE sql function exposes the underlying index scan to EXPLAIN.</li>
+ *   <li><strong>Narrow-collection exact-recall {@code == N}</strong> — GROUP 4: a
+ *       narrow collection (size &lt; {@code hnsw.ef_search}) with a semantically distant
+ *       query vector, asserted with an EXACT count ({@code == N}, never
+ *       {@code >= threshold}). At container scale this is the correctness pin (exact
+ *       recall, no silent under-return); the production-scale {@code max_scan_tuples}
+ *       ceiling reproduction stays conexus xr7.8.9 / the integration DualRunHarness,
+ *       same scope split as RDR-155 P3.E.</li>
+ *   <li><strong>Parity vs the stitched path</strong> — GROUP 5: each combined query
+ *       returns IDENTICAL results to the app-side stitch it retires (catalog filter →
+ *       per-collection vector search → re-rank), computed here as an in-test SQL oracle.</li>
+ * </ol>
+ *
+ * <p><strong>Non-vacuity</strong> (conexus xr7.8.7 / hybrid-test pattern): the topic
+ * fixture places a vector-CLOSER row under a DIFFERENT topic so a non-filtering
+ * implementation cannot pass GROUP 2; the metadata fixture's filtered orderings differ
+ * from the unfiltered ordering so a no-op filter cannot pass GROUP 1; tombstone tests
+ * (GROUP 6) assert BOTH directions; RLS tests (GROUP 7) assert a superuser CONTROL
+ * proving foreign rows exist underneath.
+ *
+ * <p><strong>Expected RED before catalog-006 lands</strong>: every functional group
+ * errors with "function ... does not exist" until bead nexus-70r3c.15 (P4.2) adds the
+ * per-dim functions. CONTROL paths (raw fixture inserts, raw vector order-by oracle)
+ * are GREEN always.
+ *
+ * <p>Mirrors conventions from CollectionVectorStatsTest / PgVectorHybridSearchContractTest:
+ * PgContainerHelper, Liquibase master, PER_CLASS, {@link Order}, superuser fixtures,
+ * svc-role + GUC for RLS, 32-char chashes, registered collections (fk-002), exact
+ * assertions ({@code containsExactly} / {@code isEqualTo}, never inequalities), and the
+ * 2-D unit-vector trick (only the first two components are non-zero, so cosine distance
+ * to the query {@code (1,0)} is fully determined and exact).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CombinedQueryParityTest {
+
+    // ── Tenant IDs ────────────────────────────────────────────────────────────
+    private static final String TENANT_A = "cqp-tenant-a";
+    private static final String TENANT_B = "cqp-tenant-b";
+
+    // ── Svc role (NOSUPERUSER, NOBYPASSRLS — subject to FORCE RLS) ───────────
+    private static final String SVC_ROLE = "svc_cqp_test";
+    private static final String SVC_PASS = "svc_cqp_test_pass";
+
+    // ── Combined-query function names (catalog-006 must create these) ─────────
+    private static final String FN_META_1024  = "nexus.search_metadata_scoped_1024";
+    private static final String FN_META_384   = "nexus.search_metadata_scoped_384";
+    private static final String FN_TOPIC_1024 = "nexus.search_topic_scoped_1024";
+    private static final String FN_TOPIC_384  = "nexus.search_topic_scoped_384";
+
+    // ── Collections (conformant <type>__<owner>__<model>__<version>) ─────────
+    private static final String COLL_M     = "knowledge__cqp-meta__voyage-context-3__v1";       // 1024
+    private static final String COLL_T     = "knowledge__cqp-topic__voyage-context-3__v1";      // 1024
+    private static final String COLL_NARROW= "knowledge__cqp-narrow__voyage-context-3__v1";     // 1024
+    private static final String COLL_M_384 = "knowledge__cqp-meta384__minilm-l6-v2-384__v1";    // 384
+    private static final String COLL_T_384 = "knowledge__cqp-topic384__minilm-l6-v2-384__v1";   // 384
+    private static final String COLL_B     = "knowledge__cqp-b__voyage-context-3__v1";          // 1024, tenant B
+
+    // ── Topic labels ─────────────────────────────────────────────────────────
+    private static final String TOPIC_VEC   = "Vector Search";
+    private static final String TOPIC_OTHER = "Cooking";
+
+    PostgreSQLContainer<?> pg;
+    com.zaxxer.hikari.HikariDataSource svcDs;
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // LIFECYCLE
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+
+        // Phase 1: roles (CREATE ROLE cannot run inside a transaction).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
+                "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '" + SVC_ROLE + "') THEN " +
+                "    CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+        }
+
+        // Phase 2: full master changelog.
+        try (Connection su = pg.createConnection("")) {
+            var lb = new Liquibase(
+                "db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(
+                    new JdbcConnection(su)));
+            lb.update(new Contexts());
+        }
+
+        // Phase 3: grants for the svc role (RLS group reads through it).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            for (String tbl : List.of(
+                    "catalog_collections", "catalog_documents", "catalog_document_chunks",
+                    "topics", "topic_assignments",
+                    "chunks_384", "chunks_768", "chunks_1024")) {
+                su.createStatement().execute(
+                    "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus." + tbl + " TO " + SVC_ROLE);
+            }
+            su.createStatement().execute("GRANT USAGE ON ALL SEQUENCES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+        }
+
+        var cfg = new com.zaxxer.hikari.HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(4);
+        cfg.setAutoCommit(true);
+        svcDs = new com.zaxxer.hikari.HikariDataSource(cfg);
+
+        seedFixtures();
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (svcDs != null) svcDs.close();
+        if (pg != null)    pg.stop();
+    }
+
+    /**
+     * Seed all fixtures once via superuser (bypasses FORCE RLS). Distances are exact:
+     * each chunk's embedding is a 2-D unit direction (x,y) padded to {@code dim}; cosine
+     * distance to the probe vector {@code (1,0)} is {@code 1 - x} for a unit (x,y).
+     *
+     * <p>Metadata fixture COLL_M — one chunk per doc, doc carries the metadata:
+     * <pre>
+     *   doc  content_type author year corpus   dir       dist  query=(1,0)
+     *   m1   paper        alice  2024 research (1.0,0.0)  0.0
+     *   m2   paper        bob    2023 research (0.8,0.6)  0.2
+     *   m3   code         alice  2024 research (0.6,0.8)  0.4   (excluded by type=paper)
+     *   m4   paper        alice  2022 archive  (0.0,1.0)  1.0
+     *   m5   paper        carol  2024 research (-1.0,0.0) 2.0
+     * </pre>
+     * type=paper                 → [m1,m2,m4,m5]   (m3 dropped)
+     * type=paper AND author=alice→ [m1,m4]
+     * author=alice (type NULL)   → [m1,m3,m4]      (ordering differs from type=paper → filter is real)
+     * year=2024                  → [m1,m3,m5]
+     *
+     * <p>Topic fixture COLL_T — TOPIC_VEC has {t1,t2}; t3 is vector-CLOSER but under
+     * TOPIC_OTHER, so a non-filtering impl would wrongly surface it:
+     * <pre>
+     *   doc  topic       dir       dist
+     *   t1   Vector...   (1.0,0.0) 0.0
+     *   t2   Vector...   (0.6,0.8) 0.4
+     *   t3   Cooking     (0.8,0.6) 0.2   (closer than t2, MUST be excluded)
+     * </pre>
+     * topic=Vector Search → [t1,t2]   (t3 excluded despite dist 0.2 &lt; 0.4 → topic gate real)
+     *
+     * <p>Narrow fixture COLL_NARROW — 3 chunks, query vector semantically distant
+     * (orthogonal-ish); exact-recall must return all 3 (==N), no silent under-return.
+     */
+    private void seedFixtures() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+
+            // ----- metadata fixture (1024) -----
+            insertCollection(su, TENANT_A, COLL_M);
+            seedMetaDoc(su, 1024, COLL_M, "m1", "paper", "alice", 2024, "research", 1.0, 0.0);
+            seedMetaDoc(su, 1024, COLL_M, "m2", "paper", "bob",   2023, "research", 0.8, 0.6);
+            seedMetaDoc(su, 1024, COLL_M, "m3", "code",  "alice", 2024, "research", 0.6, 0.8);
+            seedMetaDoc(su, 1024, COLL_M, "m4", "paper", "alice", 2022, "archive",  0.0, 1.0);
+            seedMetaDoc(su, 1024, COLL_M, "m5", "paper", "carol", 2024, "research", -1.0, 0.0);
+
+            // ----- metadata fixture (384) for per-dim dispatch -----
+            insertCollection(su, TENANT_A, COLL_M_384);
+            seedMetaDoc(su, 384, COLL_M_384, "m384a", "paper", "alice", 2024, "research", 1.0, 0.0);
+            seedMetaDoc(su, 384, COLL_M_384, "m384b", "code",  "alice", 2024, "research", 0.8, 0.6);
+
+            // ----- topic fixture (1024) -----
+            insertCollection(su, TENANT_A, COLL_T);
+            long topicVec   = insertTopic(su, TENANT_A, TOPIC_VEC,   COLL_T);
+            long topicOther = insertTopic(su, TENANT_A, TOPIC_OTHER, COLL_T);
+            seedTopicDoc(su, 1024, COLL_T, "t1", topicVec,   1.0, 0.0);
+            seedTopicDoc(su, 1024, COLL_T, "t2", topicVec,   0.6, 0.8);
+            seedTopicDoc(su, 1024, COLL_T, "t3", topicOther, 0.8, 0.6);
+
+            // ----- topic fixture (384) for per-dim dispatch -----
+            insertCollection(su, TENANT_A, COLL_T_384);
+            long topicVec384 = insertTopic(su, TENANT_A, TOPIC_VEC, COLL_T_384);
+            seedTopicDoc(su, 384, COLL_T_384, "t384a", topicVec384, 1.0, 0.0);
+
+            // ----- narrow fixture (1024): 3 docs, distant query -----
+            insertCollection(su, TENANT_A, COLL_NARROW);
+            seedMetaDoc(su, 1024, COLL_NARROW, "n1", "paper", "ned", 2024, "research", 0.0, 1.0);
+            seedMetaDoc(su, 1024, COLL_NARROW, "n2", "paper", "ned", 2024, "research", -0.2, 0.9797959);
+            seedMetaDoc(su, 1024, COLL_NARROW, "n3", "paper", "ned", 2024, "research", 0.2, 0.9797959);
+
+            // ----- tenant-B fixture (1024) for RLS group -----
+            insertCollection(su, TENANT_B, COLL_B);
+            long topicVecB = insertTopic(su, TENANT_B, TOPIC_VEC, COLL_B);
+            seedMetaDoc(su, 1024, COLL_B, "b1", "paper", "zed", 2024, "research", 1.0, 0.0);
+            seedTopicDoc(su, 1024, COLL_B, "b2", topicVecB, 1.0, 0.0);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 1 — metadata-scoped: query-vector-as-argument + exact filtered ranking
+    //
+    // EXPECTED RED: nexus.search_metadata_scoped_1024 absent until catalog-006.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(10)
+    void metadata_queryVectorIsFirstArgument_signaturePinned() throws Exception {
+        // The probe vector MUST be a function ARGUMENT (Finding 5a). Introspect the
+        // declared signature: first arg is a `vector`, and the seven-arg shape is the
+        // pinned contract catalog-006 must honor.
+        try (Connection su = pg.createConnection("")) {
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT pg_catalog.pg_get_function_arguments(p.oid) AS args " +
+                "  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace " +
+                " WHERE n.nspname = 'nexus' AND p.proname = 'search_metadata_scoped_1024'");
+            assertThat(rs.next())
+                .as("nexus.search_metadata_scoped_1024 must exist (catalog-006)").isTrue();
+            String args = rs.getString("args");
+            assertThat(args)
+                .as("query vector must be the FIRST argument, typed `vector` — never "
+                    + "join-sourced (Finding 5a: a join-sourced vector forces a 340ms "
+                    + "Seq Scan instead of the 2ms HNSW Index Scan)")
+                .startsWith("p_query vector");
+            assertThat(args)
+                .as("metadata-scoped signature pins the catalog dimensions the query "
+                    + "tool routes on: collections[], content_type, author, year, corpus, n")
+                .contains("p_collections text[]")
+                .contains("p_content_type text")
+                .contains("p_author text")
+                .contains("p_year integer")
+                .contains("p_corpus text")
+                .contains("p_n integer");
+        }
+    }
+
+    @Test @Order(11)
+    void metadata_contentTypeFilter_exactRankedByDistance() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callMeta(su, 1024, COLL_M, "paper", null, null, null, 10))
+                .as("content_type=paper → {m1,m2,m4,m5} ranked by cosine distance "
+                    + "(0.0,0.2,1.0,2.0); m3 (code) excluded")
+                .containsExactly("m1", "m2", "m4", "m5");
+        }
+    }
+
+    @Test @Order(12)
+    void metadata_typeAndAuthor_compose_exact() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callMeta(su, 1024, COLL_M, "paper", "alice", null, null, 10))
+                .as("type=paper AND author=alice → {m1,m4} ranked by distance (0.0,1.0)")
+                .containsExactly("m1", "m4");
+        }
+    }
+
+    @Test @Order(13)
+    void metadata_authorOnly_orderingDiffersFromTypeFilter_filterIsReal() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            List<String> authorOnly = callMeta(su, 1024, COLL_M, null, "alice", null, null, 10);
+            assertThat(authorOnly)
+                .as("author=alice (type NULL=no filter) → {m1,m3,m4} by distance "
+                    + "(0.0,0.4,1.0) — includes m3 (code), excluded under type=paper")
+                .containsExactly("m1", "m3", "m4");
+            assertThat(authorOnly)
+                .as("author-only ordering must DIFFER from the type=paper ordering — "
+                    + "otherwise a NULL arg is not actually skipping the filter (vacuous)")
+                .isNotEqualTo(callMeta(su, 1024, COLL_M, "paper", null, null, null, 10));
+        }
+    }
+
+    @Test @Order(14)
+    void metadata_yearFilter_exact() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callMeta(su, 1024, COLL_M, null, null, 2024, null, 10))
+                .as("year=2024 → {m1,m3,m5} by distance (0.0,0.4,2.0)")
+                .containsExactly("m1", "m3", "m5");
+        }
+    }
+
+    @Test @Order(15)
+    void metadata_nResultsLimit_truncatesRankedList() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callMeta(su, 1024, COLL_M, "paper", null, null, null, 2))
+                .as("n=2 truncates the ranked list to the two nearest papers [m1,m2]")
+                .containsExactly("m1", "m2");
+        }
+    }
+
+    @Test @Order(16)
+    void metadata_noFilters_allChunksRanked() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callMeta(su, 1024, COLL_M, null, null, null, null, 10))
+                .as("all NULL filters → every chunk in COLL_M ranked by distance "
+                    + "[m1,m2,m3,m4,m5] (0.0,0.2,0.4,1.0,2.0)")
+                .containsExactly("m1", "m2", "m3", "m4", "m5");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 2 — topic-scoped: query-vector-as-argument + topic gate is load-bearing
+    //
+    // EXPECTED RED: nexus.search_topic_scoped_1024 absent until catalog-006.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(20)
+    void topic_queryVectorIsFirstArgument_signaturePinned() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT pg_catalog.pg_get_function_arguments(p.oid) AS args " +
+                "  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace " +
+                " WHERE n.nspname = 'nexus' AND p.proname = 'search_topic_scoped_1024'");
+            assertThat(rs.next())
+                .as("nexus.search_topic_scoped_1024 must exist (catalog-006)").isTrue();
+            String args = rs.getString("args");
+            assertThat(args)
+                .as("topic-scoped query vector must be the FIRST argument, typed `vector`")
+                .startsWith("p_query vector");
+            assertThat(args)
+                .as("topic-scoped signature: topic_label, collection, n")
+                .contains("p_topic_label text")
+                .contains("p_collection text")
+                .contains("p_n integer");
+        }
+    }
+
+    @Test @Order(21)
+    void topic_scopedToLabel_excludesVectorCloserOtherTopic() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callTopic(su, 1024, COLL_T, TOPIC_VEC, 10))
+                .as("topic='Vector Search' → {t1,t2} by distance (0.0,0.4). t3 is "
+                    + "vector-CLOSER (0.2) but under topic 'Cooking' — its exclusion "
+                    + "proves the topic gate is load-bearing, not a vector passthrough")
+                .containsExactly("t1", "t2");
+        }
+    }
+
+    @Test @Order(22)
+    void topic_otherLabel_returnsOnlyItsMembers() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callTopic(su, 1024, COLL_T, TOPIC_OTHER, 10))
+                .as("topic='Cooking' → {t3} only")
+                .containsExactly("t3");
+        }
+    }
+
+    @Test @Order(23)
+    void topic_unknownLabel_returnsEmpty() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callTopic(su, 1024, COLL_T, "No Such Topic", 10))
+                .as("an unknown topic label returns empty, never a silent vector fallback")
+                .isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 3 — EXPLAIN: the HNSW index scan survives the join (Finding 5a/5b)
+    //
+    // EXPECTED RED: function absent until catalog-006.
+    //
+    // enable_seqscan=off forces the planner to reach for the index; with a literal
+    // vector argument the HNSW index idx_chunks_1024_embedding IS usable for the
+    // ORDER BY embedding <=> p_query. The assertion proves:
+    //   (a) the function is INLINABLE (a plpgsql body shows "Function Scan" and no
+    //       inner index node → fails — only LANGUAGE sql exposes the index scan);
+    //   (b) the vector is a plan-time constant (a join-sourced vector cannot use the
+    //       index at all → Seq Scan → fails);
+    //   (c) the metadata join does not force a Seq Scan on the chunks table.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(30)
+    void explain_metadataScoped_usesHnswIndex_notSeqScan() throws Exception {
+        String plan = explainMetaPlan(1024, COLL_M, "paper");
+        assertThat(plan)
+            .as("combined metadata query must use the HNSW index "
+                + "idx_chunks_1024_embedding for the ANN ordering — the vector is a "
+                + "plan-time argument and the function inlines. Plan was:%n%s", plan)
+            .contains("idx_chunks_1024_embedding");
+        assertThat(plan)
+            .as("the metadata join must NOT defeat the index into a Seq Scan on "
+                + "chunks_1024 (a filter that defeats the index is a regression, not a "
+                + "simplification — Decision 5). Plan was:%n%s", plan)
+            .doesNotContain("Seq Scan on chunks_1024");
+        assertThat(plan)
+            .as("a Function Scan node means the function is not inlinable (plpgsql) — "
+                + "EXPLAIN cannot then see the index scan; catalog-006 must use an "
+                + "inlinable LANGUAGE sql function. Plan was:%n%s", plan)
+            .doesNotContain("Function Scan");
+    }
+
+    @Test @Order(31)
+    void explain_topicScoped_usesHnswIndex_notSeqScan() throws Exception {
+        String plan = explainTopicPlan(1024, COLL_T, TOPIC_VEC);
+        assertThat(plan)
+            .as("topic-scoped query must keep the HNSW index scan through the "
+                + "topic_assignments join. Plan was:%n%s", plan)
+            .contains("idx_chunks_1024_embedding");
+        assertThat(plan)
+            .as("topic join must not force a Seq Scan on chunks_1024. Plan was:%n%s", plan)
+            .doesNotContain("Seq Scan on chunks_1024");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 4 — narrow-collection EXACT-recall == N (Finding 5b, MANDATORY)
+    //
+    // EXPECTED RED: function absent until catalog-006.
+    //
+    // COLL_NARROW has exactly 3 chunks; the query vector (1,0) is semantically distant
+    // from all three (they cluster near (0,1)). The combined query must return ALL 3
+    // (== N exact, never a >= threshold). At container scale this is the correctness
+    // pin; the production max_scan_tuples ceiling reproduction is conexus xr7.8.9.
+    // A naive HNSW path that under-returns (the "2 of LIMIT 10" failure) cannot pass.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(40)
+    void narrowCollection_exactRecall_returnsAllN() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            // CONTROL: the collection holds exactly 3 chunks.
+            assertThat(rawChunkCount(su, 1024, TENANT_A, COLL_NARROW))
+                .as("CONTROL: COLL_NARROW must hold exactly 3 chunks").isEqualTo(3);
+
+            List<String> got = callMeta(su, 1024, COLL_NARROW, null, null, null, null, 10);
+            assertThat(got)
+                .as("narrow collection (size 3 < ef_search), distant query vector: the "
+                    + "combined query must return EXACTLY 3 rows (== N) — a silent "
+                    + "under-return at the scan ceiling is the precise Finding-5b hazard")
+                .hasSize(3)
+                .containsExactlyInAnyOrder("n1", "n2", "n3");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 5 — parity vs the stitched path the combined query retires
+    //
+    // EXPECTED RED: function absent until catalog-006.
+    //
+    // The stitched path = (1) catalog filter to candidate doc tumblers, (2) map to
+    // their chashes via the manifest, (3) vector-rank those chashes. Computed here as
+    // a single SQL oracle (catalog filter + raw ORDER BY embedding <=> q over the
+    // candidate chashes). The combined query must equal it EXACTLY, ordering included.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(50)
+    void parity_metadataScoped_equalsStitchedOracle() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            List<String> stitched = stitchedMetaOracle(su, 1024, COLL_M, "paper", "alice");
+            // CONTROL: the oracle itself is non-empty and discriminating.
+            assertThat(stitched)
+                .as("CONTROL: stitched oracle for type=paper,author=alice is [m1,m4]")
+                .containsExactly("m1", "m4");
+            assertThat(callMeta(su, 1024, COLL_M, "paper", "alice", null, null, 10))
+                .as("combined metadata query must return EXACTLY the stitched path's "
+                    + "result (the app-side catalog-dance it retires), ordering included")
+                .containsExactlyElementsOf(stitched);
+        }
+    }
+
+    @Test @Order(51)
+    void parity_topicScoped_equalsStitchedOracle() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            List<String> stitched = stitchedTopicOracle(su, 1024, COLL_T, TOPIC_VEC);
+            assertThat(stitched)
+                .as("CONTROL: stitched topic oracle for 'Vector Search' is [t1,t2]")
+                .containsExactly("t1", "t2");
+            assertThat(callTopic(su, 1024, COLL_T, TOPIC_VEC, 10))
+                .as("combined topic query must return EXACTLY the stitched path's result")
+                .containsExactlyElementsOf(stitched);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 6 — tombstone filtering, both directions (non-vacuous)
+    //
+    // EXPECTED RED: function absent until catalog-006.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(60)
+    void metadata_tombstone_dropsAndReturns() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            // Direction 1: m2 present.
+            assertThat(callMeta(su, 1024, COLL_M, "paper", "bob", null, null, 10))
+                .as("baseline: type=paper,author=bob → [m2]").containsExactly("m2");
+
+            // Direction 2: tombstone m2's doc → excluded.
+            setDeleted(su, TENANT_A, "m2", true);
+            assertThat(callMeta(su, 1024, COLL_M, "paper", "bob", null, null, 10))
+                .as("tombstoned doc m2 must drop out of combined results").isEmpty();
+
+            // Direction 3: restore → returns.
+            setDeleted(su, TENANT_A, "m2", false);
+            assertThat(callMeta(su, 1024, COLL_M, "paper", "bob", null, null, 10))
+                .as("restored doc m2 must return").containsExactly("m2");
+        }
+    }
+
+    @Test @Order(61)
+    void topic_tombstone_dropsAndReturns() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            assertThat(callTopic(su, 1024, COLL_T, TOPIC_VEC, 10))
+                .as("baseline topic 'Vector Search' → [t1,t2]").containsExactly("t1", "t2");
+
+            setDeleted(su, TENANT_A, "t2", true);
+            assertThat(callTopic(su, 1024, COLL_T, TOPIC_VEC, 10))
+                .as("tombstoned doc t2 must drop from topic-scoped results")
+                .containsExactly("t1");
+
+            setDeleted(su, TENANT_A, "t2", false);
+            assertThat(callTopic(su, 1024, COLL_T, TOPIC_VEC, 10))
+                .as("restored doc t2 must return").containsExactly("t1", "t2");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 7 — RLS isolation: the functions are SECURITY INVOKER (caller RLS)
+    //
+    // EXPECTED RED: function absent until catalog-006.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(70)
+    void rls_metadataScoped_tenantSeesOnlyOwnRows() throws Exception {
+        // CONTROL: superuser (BYPASSRLS) sees tenant-B's row through the function —
+        // proves foreign rows exist underneath, so the svc assertions are non-vacuous.
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callMeta(su, 1024, COLL_B, "paper", null, null, null, 10))
+                .as("CONTROL: superuser sees tenant-B row b1 (foreign rows exist)")
+                .containsExactly("b1");
+        }
+        // svc + GUC=A: cannot see tenant-B's collection at all.
+        try (Connection svc = svcDs.getConnection()) {
+            svc.createStatement().execute(
+                "SELECT set_config('nexus.tenant', '" + TENANT_A + "', false)");
+            assertThat(callMeta(svc, 1024, COLL_B, "paper", null, null, null, 10))
+                .as("svc GUC=A must see ZERO tenant-B rows (function is SECURITY "
+                    + "INVOKER — caller RLS on chunks_1024/catalog applies)").isEmpty();
+            assertThat(callMeta(svc, 1024, COLL_M, "paper", null, null, null, 10))
+                .as("svc GUC=A must still see its OWN tenant-A papers")
+                .containsExactly("m1", "m2", "m4", "m5");
+        }
+        // svc + no GUC: nothing.
+        try (Connection svc = svcDs.getConnection()) {
+            svc.createStatement().execute("RESET nexus.tenant");
+            assertThat(callMeta(svc, 1024, COLL_M, "paper", null, null, null, 10))
+                .as("svc with no nexus.tenant GUC sees nothing (RLS matches NULL)")
+                .isEmpty();
+        }
+    }
+
+    @Test @Order(71)
+    void rls_topicScoped_tenantSeesOnlyOwnRows() throws Exception {
+        try (Connection svc = svcDs.getConnection()) {
+            svc.createStatement().execute(
+                "SELECT set_config('nexus.tenant', '" + TENANT_A + "', false)");
+            assertThat(callTopic(svc, 1024, COLL_B, TOPIC_VEC, 10))
+                .as("svc GUC=A must see ZERO tenant-B topic rows").isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 8 — per-dim dispatch (the functions exist and behave on chunks_384)
+    //
+    // EXPECTED RED: 384 functions absent until catalog-006.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(80)
+    void perDim_metadataScoped_384_behavesIdentically() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callMeta(su, 384, COLL_M_384, "paper", null, null, null, 10))
+                .as("search_metadata_scoped_384 must exist and behave identically — "
+                    + "only m384a is type=paper")
+                .containsExactly("m384a");
+        }
+    }
+
+    @Test @Order(81)
+    void perDim_topicScoped_384_behavesIdentically() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callTopic(su, 384, COLL_T_384, TOPIC_VEC, 10))
+                .as("search_topic_scoped_384 must exist and behave identically")
+                .containsExactly("t384a");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // CALL HELPERS (combined-query functions)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /** Invoke search_metadata_scoped_&lt;dim&gt;; returns ids in returned order. */
+    private List<String> callMeta(Connection conn, int dim, String collection,
+                                  String contentType, String author, Integer year,
+                                  String corpus, int n) throws Exception {
+        String sql =
+            "SELECT id FROM nexus.search_metadata_scoped_" + dim + "(" +
+            queryVecLiteral(dim) + ", " +
+            "ARRAY['" + collection + "']::text[], " +
+            sqlText(contentType) + ", " +
+            sqlText(author) + ", " +
+            (year == null ? "NULL::int" : year.toString()) + ", " +
+            sqlText(corpus) + ", " +
+            n + ")";
+        return runIds(conn, sql);
+    }
+
+    /** Invoke search_topic_scoped_&lt;dim&gt;; returns ids in returned order. */
+    private List<String> callTopic(Connection conn, int dim, String collection,
+                                   String topicLabel, int n) throws Exception {
+        String sql =
+            "SELECT id FROM nexus.search_topic_scoped_" + dim + "(" +
+            queryVecLiteral(dim) + ", " +
+            sqlText(topicLabel) + ", " +
+            sqlText(collection) + ", " +
+            n + ")";
+        return runIds(conn, sql);
+    }
+
+    /** EXPLAIN (no ANALYZE) the metadata function with seqscan disabled. */
+    private String explainMetaPlan(int dim, String collection, String contentType)
+            throws Exception {
+        String inner =
+            "SELECT id FROM nexus.search_metadata_scoped_" + dim + "(" +
+            queryVecLiteral(dim) + ", ARRAY['" + collection + "']::text[], " +
+            sqlText(contentType) + ", NULL, NULL::int, NULL, 10)";
+        return explain(inner);
+    }
+
+    /** EXPLAIN (no ANALYZE) the topic function with seqscan disabled. */
+    private String explainTopicPlan(int dim, String collection, String topicLabel)
+            throws Exception {
+        String inner =
+            "SELECT id FROM nexus.search_topic_scoped_" + dim + "(" +
+            queryVecLiteral(dim) + ", " + sqlText(topicLabel) + ", " +
+            sqlText(collection) + ", 10)";
+        return explain(inner);
+    }
+
+    private String explain(String inner) throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            // Force the planner to reach for the index; at fixture scale a tiny table
+            // would otherwise seq-scan regardless of how the function is written.
+            su.createStatement().execute("SET enable_seqscan = off");
+            ResultSet rs = su.createStatement().executeQuery("EXPLAIN " + inner);
+            StringBuilder sb = new StringBuilder();
+            while (rs.next()) sb.append(rs.getString(1)).append('\n');
+            return sb.toString();
+        }
+    }
+
+    private static List<String> runIds(Connection conn, String sql) throws Exception {
+        List<String> out = new ArrayList<>();
+        ResultSet rs = conn.createStatement().executeQuery(sql);
+        while (rs.next()) out.add(rs.getString(1));
+        return out;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // STITCHED-PATH ORACLES (the app-side dance the combined query retires)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Stitched metadata path: catalog filter → candidate chashes → vector rank.
+     * One SQL statement, but structured as the explicit join the Python query tool
+     * performs across stores today. Tombstone-filtered (deleted_at IS NULL).
+     */
+    private List<String> stitchedMetaOracle(Connection conn, int dim, String collection,
+                                            String contentType, String author)
+            throws Exception {
+        String sql =
+            "SELECT d.tumbler AS id " +
+            "  FROM nexus.catalog_documents d " +
+            "  JOIN nexus.catalog_document_chunks m " +
+            "    ON m.tenant_id = d.tenant_id AND m.doc_id = d.tumbler " +
+            "  JOIN nexus.chunks_" + dim + " c " +
+            "    ON c.tenant_id = m.tenant_id AND c.collection = m.collection " +
+            "   AND c.chash = m.chash " +
+            " WHERE m.collection = '" + collection + "' " +
+            "   AND d.deleted_at IS NULL " +
+            (contentType == null ? "" : "   AND d.content_type = " + sqlText(contentType) + " ") +
+            (author == null ? "" : "   AND d.author = " + sqlText(author) + " ") +
+            " ORDER BY c.embedding <=> " + queryVecLiteral(dim) + " ASC";
+        return runIds(conn, sql);
+    }
+
+    /** Stitched topic path: topics ⋈ topic_assignments ⋈ manifest ⋈ chunks, vector rank. */
+    private List<String> stitchedTopicOracle(Connection conn, int dim, String collection,
+                                             String topicLabel) throws Exception {
+        String sql =
+            "SELECT d.tumbler AS id " +
+            "  FROM nexus.topics t " +
+            "  JOIN nexus.topic_assignments ta " +
+            "    ON ta.tenant_id = t.tenant_id AND ta.topic_id = t.id " +
+            "  JOIN nexus.catalog_documents d " +
+            "    ON d.tenant_id = ta.tenant_id AND d.tumbler = ta.doc_id " +
+            "  JOIN nexus.catalog_document_chunks m " +
+            "    ON m.tenant_id = d.tenant_id AND m.doc_id = d.tumbler " +
+            "  JOIN nexus.chunks_" + dim + " c " +
+            "    ON c.tenant_id = m.tenant_id AND c.collection = m.collection " +
+            "   AND c.chash = m.chash " +
+            " WHERE t.label = " + sqlText(topicLabel) + " " +
+            "   AND t.collection = '" + collection + "' " +
+            "   AND d.deleted_at IS NULL " +
+            " ORDER BY c.embedding <=> " + queryVecLiteral(dim) + " ASC";
+        return runIds(conn, sql);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // FIXTURE HELPERS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Seed a metadata doc: catalog_documents row (with metadata) + manifest row + one
+     * chunk whose embedding is the 2-D unit direction (x,y). doc tumbler == chunk id
+     * (== the value the functions return).
+     */
+    private void seedMetaDoc(Connection su, int dim, String collection, String tumbler,
+                             String contentType, String author, int year, String corpus,
+                             double x, double y) throws Exception {
+        String tenant = tenantFor(collection);
+        String chash = validChash(tumbler);
+        insertCatalogDocumentFull(su, tenant, tumbler, collection, contentType, author,
+                                  year, corpus);
+        insertManifestRow(su, tenant, tumbler, 0, chash, collection);
+        insertChunk(su, dim, tenant, collection, chash, tumbler, x, y);
+    }
+
+    /**
+     * Seed a topic doc: catalog_documents row + topic_assignments row + manifest +
+     * chunk. Minimal metadata (the topic path filters on topic membership, not fields).
+     */
+    private void seedTopicDoc(Connection su, int dim, String collection, String tumbler,
+                              long topicId, double x, double y) throws Exception {
+        String chash = validChash(tumbler);
+        String tenant = tenantFor(collection);
+        insertCatalogDocumentFull(su, tenant, tumbler, collection,
+                                  "paper", "topicauthor", 2024, "research");
+        insertTopicAssignment(su, tenant, tumbler, topicId, collection);
+        insertManifestRow(su, tenant, tumbler, 0, chash, collection);
+        insertChunk(su, dim, tenant, collection, chash, tumbler, x, y);
+    }
+
+    /** COLL_B belongs to tenant B; everything else to tenant A. */
+    private static String tenantFor(String collection) {
+        return COLL_B.equals(collection) ? TENANT_B : TENANT_A;
+    }
+
+    private static void insertCollection(Connection su, String tenantId, String name)
+            throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" +
+            tenantId + "', '" + name + "') ON CONFLICT (tenant_id, name) DO NOTHING");
+    }
+
+    private static void insertCatalogDocumentFull(Connection su, String tenantId, String tumbler,
+                                                  String collection, String contentType,
+                                                  String author, int year, String corpus)
+            throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_documents " +
+            "  (tenant_id, tumbler, title, author, year, content_type, corpus, physical_collection) " +
+            "VALUES ('" + tenantId + "', '" + tumbler + "', 'Doc " + tumbler + "', " +
+            sqlText(author) + ", " + year + ", " + sqlText(contentType) + ", " +
+            sqlText(corpus) + ", '" + collection + "') " +
+            "ON CONFLICT (tenant_id, tumbler) DO NOTHING");
+    }
+
+    private static void insertManifestRow(Connection su, String tenantId, String docId,
+                                          int position, String chash, String collection)
+            throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_document_chunks " +
+            "  (tenant_id, doc_id, position, chash, collection) " +
+            "VALUES ('" + tenantId + "', '" + docId + "', " + position + ", '" + chash + "', '" +
+            collection + "') ON CONFLICT (tenant_id, doc_id, position) DO NOTHING");
+    }
+
+    /** Insert a topic; returns its generated id. */
+    private static long insertTopic(Connection su, String tenantId, String label,
+                                    String collection) throws Exception {
+        ResultSet rs = su.createStatement().executeQuery(
+            "INSERT INTO nexus.topics (tenant_id, label, collection, created_at) " +
+            "VALUES ('" + tenantId + "', " + sqlText(label) + ", '" + collection + "', " +
+            "'2026-01-01T00:00:00+00'::timestamptz) RETURNING id");
+        rs.next();
+        return rs.getLong(1);
+    }
+
+    private static void insertTopicAssignment(Connection su, String tenantId, String docId,
+                                              long topicId, String collection) throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.topic_assignments " +
+            "  (tenant_id, doc_id, topic_id, source_collection, assigned_at) " +
+            "VALUES ('" + tenantId + "', '" + docId + "', " + topicId + ", '" + collection + "', " +
+            "'2026-01-01T00:00:00+00'::timestamptz) " +
+            "ON CONFLICT (tenant_id, doc_id, topic_id) DO NOTHING");
+    }
+
+    /** Insert a chunks_&lt;dim&gt; row with a 2-D unit direction embedding. */
+    private static void insertChunk(Connection su, int dim, String tenantId, String collection,
+                                    String chash, String chunkText, double x, double y)
+            throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.chunks_" + dim +
+            " (tenant_id, collection, chash, chunk_text, embedding) VALUES ('" +
+            tenantId + "', '" + collection + "', '" + chash + "', '" +
+            chunkText.replace("'", "''") + "', " + vec2(dim, x, y) + "::vector) " +
+            "ON CONFLICT (tenant_id, collection, chash) DO NOTHING");
+    }
+
+    private static void setDeleted(Connection su, String tenantId, String tumbler, boolean deleted)
+            throws Exception {
+        su.createStatement().execute(
+            "UPDATE nexus.catalog_documents SET deleted_at = " +
+            (deleted ? "now()" : "NULL") +
+            " WHERE tenant_id = '" + tenantId + "' AND tumbler = '" + tumbler + "'");
+    }
+
+    private static long rawChunkCount(Connection conn, int dim, String tenantId,
+                                      String collection) throws Exception {
+        ResultSet rs = conn.createStatement().executeQuery(
+            "SELECT count(*) FROM nexus.chunks_" + dim +
+            " WHERE tenant_id = '" + tenantId + "' AND collection = '" + collection + "'");
+        rs.next();
+        return rs.getLong(1);
+    }
+
+    // ── value helpers ────────────────────────────────────────────────────────
+
+    /** The probe query vector literal: 2-D direction (1,0) padded to dim, ::vector. */
+    private static String queryVecLiteral(int dim) {
+        return vec2(dim, 1.0, 0.0) + "::vector";
+    }
+
+    /** A length-{@code dim} pgvector literal with first two components (x,y), rest 0. */
+    private static String vec2(int dim, double x, double y) {
+        StringBuilder sb = new StringBuilder("'[");
+        sb.append(fmt(x)).append(',').append(fmt(y));
+        for (int i = 2; i < dim; i++) sb.append(",0");
+        return sb.append("]'").toString();
+    }
+
+    private static String fmt(double v) {
+        if (v == Math.rint(v)) return Integer.toString((int) v);
+        return Double.toString(v);
+    }
+
+    /** SQL string literal or NULL token for a nullable text value. */
+    private static String sqlText(String v) {
+        return v == null ? "NULL" : "'" + v.replace("'", "''") + "'";
+    }
+
+    /** Length-32 chash deterministically derived from seed (catalog-002 CHECK). */
+    private static String validChash(String seed) {
+        return (seed.replaceAll("[^0-9a-f]", "a") + "0".repeat(32)).substring(0, 32);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/CombinedQueryParityTest.java
+++ b/service/src/test/java/dev/nexus/service/CombinedQueryParityTest.java
@@ -106,6 +106,12 @@ class CombinedQueryParityTest {
     private static final String COLL_M_384 = "knowledge__cqp-meta384__minilm-l6-v2-384__v1";    // 384
     private static final String COLL_T_384 = "knowledge__cqp-topic384__minilm-l6-v2-384__v1";   // 384
     private static final String COLL_B     = "knowledge__cqp-b__voyage-context-3__v1";          // 1024, tenant B
+    // Large (non-selective) fixture: lets the planner pick the HNSW index over a
+    // filter-first sort, so the EXPLAIN encoding (GROUP 3) is meaningful. At the tiny
+    // GROUP-1 scale a selective filter correctly wins (the selectivity switch) and HNSW
+    // is rightly NOT chosen — that is not what GROUP 3 is asserting.
+    private static final String COLL_EXPLAIN = "knowledge__cqp-explain__voyage-context-3__v1";  // 1024
+    private static final int    EXPLAIN_ROWS = 500;
 
     // ── Topic labels ─────────────────────────────────────────────────────────
     private static final String TOPIC_VEC   = "Vector Search";
@@ -255,7 +261,49 @@ class CombinedQueryParityTest {
             long topicVecB = insertTopic(su, TENANT_B, TOPIC_VEC, COLL_B);
             seedMetaDoc(su, 1024, COLL_B, "b1", "paper", "zed", 2024, "research", 1.0, 0.0);
             seedTopicDoc(su, 1024, COLL_B, "b2", topicVecB, 1.0, 0.0);
+
+            // ----- large fixture for the EXPLAIN group (GROUP 3) -----
+            seedExplainFixture(su);
+
+            // Real row-count statistics so the planner does not under-estimate the
+            // bulk-loaded tables to rows=1 and wrongly prefer a filter-first sort over
+            // the HNSW index in GROUP 3.
+            for (String tbl : List.of("chunks_1024", "catalog_documents",
+                    "catalog_document_chunks", "topic_assignments", "topics")) {
+                su.createStatement().execute("ANALYZE nexus." + tbl);
+            }
         }
+    }
+
+    /**
+     * Bulk-seed {@link #EXPLAIN_ROWS} paper documents in COLL_EXPLAIN, all assigned to
+     * TOPIC_VEC, server-side (one statement per table, no JDBC round-trip per row). The
+     * volume + non-selective predicate is what makes the planner choose the HNSW index
+     * over a filter-first sort, so GROUP 3 asserts a real "HNSW survives the join" plan.
+     */
+    private void seedExplainFixture(Connection su) throws Exception {
+        insertCollection(su, TENANT_A, COLL_EXPLAIN);
+        long topicId = insertTopic(su, TENANT_A, TOPIC_VEC, COLL_EXPLAIN);
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_documents " +
+            "  (tenant_id, tumbler, title, author, year, content_type, corpus, physical_collection) " +
+            "SELECT '" + TENANT_A + "', 'ex'||g, 'Doc '||g, 'exauthor', 2024, 'paper', 'research', '" +
+            COLL_EXPLAIN + "' FROM generate_series(1, " + EXPLAIN_ROWS + ") g");
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash, collection) " +
+            "SELECT '" + TENANT_A + "', 'ex'||g, 0, lpad(g::text, 32, '0'), '" + COLL_EXPLAIN + "' " +
+            "FROM generate_series(1, " + EXPLAIN_ROWS + ") g");
+        // Embedding: 2-D direction (g%100/100, 1) padded to 1024 — varied enough that
+        // HNSW is exercised, dense in the (x,1) plane.
+        su.createStatement().execute(
+            "INSERT INTO nexus.chunks_1024 (tenant_id, collection, chash, chunk_text, embedding) " +
+            "SELECT '" + TENANT_A + "', '" + COLL_EXPLAIN + "', lpad(g::text, 32, '0'), 'ex'||g, " +
+            "('[' || ((g % 100)::float8 / 100.0) || ',1' || repeat(',0', 1022) || ']')::vector " +
+            "FROM generate_series(1, " + EXPLAIN_ROWS + ") g");
+        su.createStatement().execute(
+            "INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, source_collection, assigned_at) " +
+            "SELECT '" + TENANT_A + "', 'ex'||g, " + topicId + ", '" + COLL_EXPLAIN + "', " +
+            "'2026-01-01T00:00:00+00'::timestamptz FROM generate_series(1, " + EXPLAIN_ROWS + ") g");
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -429,7 +477,11 @@ class CombinedQueryParityTest {
 
     @Test @Order(30)
     void explain_metadataScoped_usesHnswIndex_notSeqScan() throws Exception {
-        String plan = explainMetaPlan(1024, COLL_M, "paper");
+        // Large, NON-selectively-filtered fixture: the vector ANN is the driving access
+        // path, so a correct impl uses the HNSW index. (A selective filter at small
+        // scale rightly wins with a filter-first sort — that is GROUP 1's regime, not
+        // this one.)
+        String plan = explainMetaPlan(1024, COLL_EXPLAIN, null);
         assertThat(plan)
             .as("combined metadata query must use the HNSW index "
                 + "idx_chunks_1024_embedding for the ANN ordering — the vector is a "
@@ -449,7 +501,7 @@ class CombinedQueryParityTest {
 
     @Test @Order(31)
     void explain_topicScoped_usesHnswIndex_notSeqScan() throws Exception {
-        String plan = explainTopicPlan(1024, COLL_T, TOPIC_VEC);
+        String plan = explainTopicPlan(1024, COLL_EXPLAIN, TOPIC_VEC);
         assertThat(plan)
             .as("topic-scoped query must keep the HNSW index scan through the "
                 + "topic_assignments join. Plan was:%n%s", plan)
@@ -583,8 +635,9 @@ class CombinedQueryParityTest {
         // proves foreign rows exist underneath, so the svc assertions are non-vacuous.
         try (Connection su = pg.createConnection("")) {
             assertThat(callMeta(su, 1024, COLL_B, "paper", null, null, null, 10))
-                .as("CONTROL: superuser sees tenant-B row b1 (foreign rows exist)")
-                .containsExactly("b1");
+                .as("CONTROL: superuser sees tenant-B papers b1,b2 (foreign rows exist, "
+                    + "so the svc-role assertions below are non-vacuous)")
+                .containsExactlyInAnyOrder("b1", "b2");
         }
         // svc + GUC=A: cannot see tenant-B's collection at all.
         try (Connection svc = svcDs.getConnection()) {
@@ -696,9 +749,17 @@ class CombinedQueryParityTest {
     private String explain(String inner) throws Exception {
         try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
-            // Force the planner to reach for the index; at fixture scale a tiny table
-            // would otherwise seq-scan regardless of how the function is written.
-            su.createStatement().execute("SET enable_seqscan = off");
+            // Penalize every NON-index way to satisfy ORDER BY embedding <=> <const>
+            // LIMIT. At unit scale the cost crossover that makes HNSW the *natural*
+            // plan (Finding 5: ~2ms vs 340ms at 98k rows) is not reproducible, so we
+            // assert REACHABILITY: with sort/seq/bitmap/hash penalized, the cheapest
+            // remaining plan is the HNSW Index Scan through the join — and a join-sourced
+            // vector (the Finding-5a regression) could NOT use the index even then, so
+            // the assertion still distinguishes a correct impl from the regression.
+            for (String guc : List.of("enable_seqscan", "enable_bitmapscan",
+                    "enable_sort", "enable_hashjoin")) {
+                su.createStatement().execute("SET " + guc + " = off");
+            }
             ResultSet rs = su.createStatement().executeQuery("EXPLAIN " + inner);
             StringBuilder sb = new StringBuilder();
             while (rs.next()) sb.append(rs.getString(1)).append('\n');

--- a/service/src/test/java/dev/nexus/service/CombinedQueryParityTest.java
+++ b/service/src/test/java/dev/nexus/service/CombinedQueryParityTest.java
@@ -32,9 +32,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       filters by the catalog metadata dimensions the {@code query} tool routes on
  *       (NULL arg = no filter on that dimension), ranks by cosine distance ascending.</li>
  *   <li>{@code nexus.search_topic_scoped_<dim>(p_query vector, p_topic_label text,
- *       p_collection text, p_n int)} — joins {@code chunks_<dim> ⋈ catalog_document_chunks
- *       ⋈ topic_assignments ⋈ topics}, scoped to the named topic label within a
- *       collection, ranks by cosine distance ascending.</li>
+ *       p_collection text, p_n int)} — chunk-level: joins {@code chunks_<dim> ⋈
+ *       topic_assignments} on {@code chash = topic_assignments.doc_id} (topic membership
+ *       is chunk-keyed, nexus-sa14p) {@code ⋈ topics}, scoped to the named topic label
+ *       within a collection, live-filtered (live_chunks predicate), ranks by cosine
+ *       distance ascending, returns the chunk chash as id.</li>
  * </ul>
  *
  * <p><strong>The four mandatory encodings (bead nexus-70r3c.14)</strong>, mapped to
@@ -302,7 +304,7 @@ class CombinedQueryParityTest {
             "FROM generate_series(1, " + EXPLAIN_ROWS + ") g");
         su.createStatement().execute(
             "INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, source_collection, assigned_at) " +
-            "SELECT '" + TENANT_A + "', 'ex'||g, " + topicId + ", '" + COLL_EXPLAIN + "', " +
+            "SELECT '" + TENANT_A + "', lpad(g::text, 32, '0'), " + topicId + ", '" + COLL_EXPLAIN + "', " +
             "'2026-01-01T00:00:00+00'::timestamptz FROM generate_series(1, " + EXPLAIN_ROWS + ") g");
     }
 
@@ -435,10 +437,10 @@ class CombinedQueryParityTest {
     void topic_scopedToLabel_excludesVectorCloserOtherTopic() throws Exception {
         try (Connection su = pg.createConnection("")) {
             assertThat(callTopic(su, 1024, COLL_T, TOPIC_VEC, 10))
-                .as("topic='Vector Search' → {t1,t2} by distance (0.0,0.4). t3 is "
+                .as("topic='Vector Search' → chunks {t1,t2} by distance (0.0,0.4). t3 is "
                     + "vector-CLOSER (0.2) but under topic 'Cooking' — its exclusion "
                     + "proves the topic gate is load-bearing, not a vector passthrough")
-                .containsExactly("t1", "t2");
+                .containsExactly(chashOf("t1"), chashOf("t2"));
         }
     }
 
@@ -446,8 +448,8 @@ class CombinedQueryParityTest {
     void topic_otherLabel_returnsOnlyItsMembers() throws Exception {
         try (Connection su = pg.createConnection("")) {
             assertThat(callTopic(su, 1024, COLL_T, TOPIC_OTHER, 10))
-                .as("topic='Cooking' → {t3} only")
-                .containsExactly("t3");
+                .as("topic='Cooking' → chunk {t3} only")
+                .containsExactly(chashOf("t3"));
         }
     }
 
@@ -519,8 +521,11 @@ class CombinedQueryParityTest {
     // COLL_NARROW has exactly 3 chunks; the query vector (1,0) is semantically distant
     // from all three (they cluster near (0,1)). The combined query must return ALL 3
     // (== N exact, never a >= threshold). At container scale this is the correctness
-    // pin; the production max_scan_tuples ceiling reproduction is conexus xr7.8.9.
-    // A naive HNSW path that under-returns (the "2 of LIMIT 10" failure) cannot pass.
+    // pin; the production max_scan_tuples ceiling reproduction is conexus xr7.8.9. This
+    // does NOT prove a selectivity-strategy switch fires — the inlinable SQL functions
+    // have no switch; the planner picks filter-first vs HNSW by cost. The production
+    // max_scan_tuples defense (tuned hnsw.iterative_scan at the repoint) is tracked
+    // separately. This test pins exact-recall correctness only.
     // ══════════════════════════════════════════════════════════════════════════
 
     @Test @Order(40)
@@ -571,8 +576,8 @@ class CombinedQueryParityTest {
         try (Connection su = pg.createConnection("")) {
             List<String> stitched = stitchedTopicOracle(su, 1024, COLL_T, TOPIC_VEC);
             assertThat(stitched)
-                .as("CONTROL: stitched topic oracle for 'Vector Search' is [t1,t2]")
-                .containsExactly("t1", "t2");
+                .as("CONTROL: stitched topic oracle for 'Vector Search' is chunks [t1,t2]")
+                .containsExactly(chashOf("t1"), chashOf("t2"));
             assertThat(callTopic(su, 1024, COLL_T, TOPIC_VEC, 10))
                 .as("combined topic query must return EXACTLY the stitched path's result")
                 .containsExactlyElementsOf(stitched);
@@ -610,16 +615,19 @@ class CombinedQueryParityTest {
         try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             assertThat(callTopic(su, 1024, COLL_T, TOPIC_VEC, 10))
-                .as("baseline topic 'Vector Search' → [t1,t2]").containsExactly("t1", "t2");
+                .as("baseline topic 'Vector Search' → chunks [t1,t2]")
+                .containsExactly(chashOf("t1"), chashOf("t2"));
 
             setDeleted(su, TENANT_A, "t2", true);
             assertThat(callTopic(su, 1024, COLL_T, TOPIC_VEC, 10))
-                .as("tombstoned doc t2 must drop from topic-scoped results")
-                .containsExactly("t1");
+                .as("tombstoned doc t2 must drop from topic-scoped results "
+                    + "(its chunk's only manifest row points to a tombstoned doc)")
+                .containsExactly(chashOf("t1"));
 
             setDeleted(su, TENANT_A, "t2", false);
             assertThat(callTopic(su, 1024, COLL_T, TOPIC_VEC, 10))
-                .as("restored doc t2 must return").containsExactly("t1", "t2");
+                .as("restored doc t2 must return")
+                .containsExactly(chashOf("t1"), chashOf("t2"));
         }
     }
 
@@ -661,11 +669,19 @@ class CombinedQueryParityTest {
 
     @Test @Order(71)
     void rls_topicScoped_tenantSeesOnlyOwnRows() throws Exception {
+        // CONTROL: superuser (BYPASSRLS) sees tenant-B's topic chunk — proves the
+        // foreign row exists, so the svc assertion below is non-vacuous.
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callTopic(su, 1024, COLL_B, TOPIC_VEC, 10))
+                .as("CONTROL: superuser sees tenant-B topic chunk b2 (foreign rows exist)")
+                .containsExactly(chashOf("b2"));
+        }
         try (Connection svc = svcDs.getConnection()) {
             svc.createStatement().execute(
                 "SELECT set_config('nexus.tenant', '" + TENANT_A + "', false)");
             assertThat(callTopic(svc, 1024, COLL_B, TOPIC_VEC, 10))
-                .as("svc GUC=A must see ZERO tenant-B topic rows").isEmpty();
+                .as("svc GUC=A must see ZERO tenant-B topic rows (SECURITY INVOKER — "
+                    + "caller RLS on chunks_1024 applies)").isEmpty();
         }
     }
 
@@ -689,8 +705,8 @@ class CombinedQueryParityTest {
     void perDim_topicScoped_384_behavesIdentically() throws Exception {
         try (Connection su = pg.createConnection("")) {
             assertThat(callTopic(su, 384, COLL_T_384, TOPIC_VEC, 10))
-                .as("search_topic_scoped_384 must exist and behave identically")
-                .containsExactly("t384a");
+                .as("search_topic_scoped_384 must exist and behave identically (chunk-level)")
+                .containsExactly(chashOf("t384a"));
         }
     }
 
@@ -756,6 +772,9 @@ class CombinedQueryParityTest {
             // remaining plan is the HNSW Index Scan through the join — and a join-sourced
             // vector (the Finding-5a regression) could NOT use the index even then, so
             // the assertion still distinguishes a correct impl from the regression.
+            // NOTE: enable_nestloop stays ON — the HNSW-ordered chunk scan joins to the
+            // catalog/topic tables via nested loop; disabling it would defeat the very
+            // plan this test asserts.
             for (String guc : List.of("enable_seqscan", "enable_bitmapscan",
                     "enable_sort", "enable_hashjoin")) {
                 su.createStatement().execute("SET " + guc + " = off");
@@ -769,8 +788,9 @@ class CombinedQueryParityTest {
 
     private static List<String> runIds(Connection conn, String sql) throws Exception {
         List<String> out = new ArrayList<>();
-        ResultSet rs = conn.createStatement().executeQuery(sql);
-        while (rs.next()) out.add(rs.getString(1));
+        try (var st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) out.add(rs.getString(1));
+        }
         return out;
     }
 
@@ -806,20 +826,22 @@ class CombinedQueryParityTest {
     private List<String> stitchedTopicOracle(Connection conn, int dim, String collection,
                                              String topicLabel) throws Exception {
         String sql =
-            "SELECT d.tumbler AS id " +
-            "  FROM nexus.topics t " +
+            "SELECT c.chash AS id " +
+            "  FROM nexus.chunks_" + dim + " c " +
             "  JOIN nexus.topic_assignments ta " +
-            "    ON ta.tenant_id = t.tenant_id AND ta.topic_id = t.id " +
-            "  JOIN nexus.catalog_documents d " +
-            "    ON d.tenant_id = ta.tenant_id AND d.tumbler = ta.doc_id " +
-            "  JOIN nexus.catalog_document_chunks m " +
-            "    ON m.tenant_id = d.tenant_id AND m.doc_id = d.tumbler " +
-            "  JOIN nexus.chunks_" + dim + " c " +
-            "    ON c.tenant_id = m.tenant_id AND c.collection = m.collection " +
-            "   AND c.chash = m.chash " +
-            " WHERE t.label = " + sqlText(topicLabel) + " " +
+            "    ON ta.tenant_id = c.tenant_id AND ta.doc_id = c.chash " +
+            "  JOIN nexus.topics t " +
+            "    ON t.tenant_id = ta.tenant_id AND t.id = ta.topic_id " +
+            " WHERE c.collection = '" + collection + "' " +
             "   AND t.collection = '" + collection + "' " +
-            "   AND d.deleted_at IS NULL " +
+            "   AND t.label = " + sqlText(topicLabel) + " " +
+            "   AND (NOT EXISTS (SELECT 1 FROM nexus.catalog_document_chunks m " +
+            "                     WHERE m.tenant_id = c.tenant_id AND m.chash = c.chash) " +
+            "        OR EXISTS (SELECT 1 FROM nexus.catalog_document_chunks m " +
+            "                     JOIN nexus.catalog_documents d " +
+            "                       ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id " +
+            "                    WHERE m.tenant_id = c.tenant_id AND m.chash = c.chash " +
+            "                      AND d.deleted_at IS NULL)) " +
             " ORDER BY c.embedding <=> " + queryVecLiteral(dim) + " ASC";
         return runIds(conn, sql);
     }
@@ -854,9 +876,11 @@ class CombinedQueryParityTest {
         String tenant = tenantFor(collection);
         insertCatalogDocumentFull(su, tenant, tumbler, collection,
                                   "paper", "topicauthor", 2024, "research");
-        insertTopicAssignment(su, tenant, tumbler, topicId, collection);
         insertManifestRow(su, tenant, tumbler, 0, chash, collection);
         insertChunk(su, dim, tenant, collection, chash, tumbler, x, y);
+        // Topic membership is CHUNK-level: topic_assignments.doc_id is the chunk chash
+        // (nexus-sa14p), NOT the document tumbler.
+        insertTopicAssignment(su, tenant, chash, topicId, collection);
     }
 
     /** COLL_B belongs to tenant B; everything else to tenant A. */
@@ -897,12 +921,14 @@ class CombinedQueryParityTest {
     /** Insert a topic; returns its generated id. */
     private static long insertTopic(Connection su, String tenantId, String label,
                                     String collection) throws Exception {
-        ResultSet rs = su.createStatement().executeQuery(
-            "INSERT INTO nexus.topics (tenant_id, label, collection, created_at) " +
-            "VALUES ('" + tenantId + "', " + sqlText(label) + ", '" + collection + "', " +
-            "'2026-01-01T00:00:00+00'::timestamptz) RETURNING id");
-        rs.next();
-        return rs.getLong(1);
+        try (var st = su.createStatement();
+             ResultSet rs = st.executeQuery(
+                "INSERT INTO nexus.topics (tenant_id, label, collection, created_at) " +
+                "VALUES ('" + tenantId + "', " + sqlText(label) + ", '" + collection + "', " +
+                "'2026-01-01T00:00:00+00'::timestamptz) RETURNING id")) {
+            rs.next();
+            return rs.getLong(1);
+        }
     }
 
     private static void insertTopicAssignment(Connection su, String tenantId, String docId,
@@ -937,11 +963,13 @@ class CombinedQueryParityTest {
 
     private static long rawChunkCount(Connection conn, int dim, String tenantId,
                                       String collection) throws Exception {
-        ResultSet rs = conn.createStatement().executeQuery(
-            "SELECT count(*) FROM nexus.chunks_" + dim +
-            " WHERE tenant_id = '" + tenantId + "' AND collection = '" + collection + "'");
-        rs.next();
-        return rs.getLong(1);
+        try (var st = conn.createStatement();
+             ResultSet rs = st.executeQuery(
+                "SELECT count(*) FROM nexus.chunks_" + dim +
+                " WHERE tenant_id = '" + tenantId + "' AND collection = '" + collection + "'")) {
+            rs.next();
+            return rs.getLong(1);
+        }
     }
 
     // ── value helpers ────────────────────────────────────────────────────────
@@ -969,8 +997,32 @@ class CombinedQueryParityTest {
         return v == null ? "NULL" : "'" + v.replace("'", "''") + "'";
     }
 
-    /** Length-32 chash deterministically derived from seed (catalog-002 CHECK). */
+    /**
+     * Length-32 lowercase-hex chash deterministically derived from seed (catalog-002
+     * CHECK). SHA-256-based so distinct tumblers get distinct chashes — a naive
+     * char-substitution derivation collapses e.g. "m2" and "t2" to the same value, and
+     * because chunks are content-addressed (the live-chunk predicate is chash-scoped,
+     * NOT collection-scoped), a collision lets a live doc in one collection keep a
+     * tombstoned doc's shared chash alive in another.
+     */
     private static String validChash(String seed) {
-        return (seed.replaceAll("[^0-9a-f]", "a") + "0".repeat(32)).substring(0, 32);
+        try {
+            byte[] h = java.security.MessageDigest.getInstance("SHA-256")
+                .digest(seed.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(64);
+            for (byte b : h) sb.append(String.format("%02x", b));
+            return sb.substring(0, 32);
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    /**
+     * The chunk chash for a fixture tumbler — same derivation seedMetaDoc/seedTopicDoc
+     * use. Topic-scoped search is chunk-level (topic_assignments.doc_id is a chash,
+     * nexus-sa14p), so topic assertions match on chash, not tumbler.
+     */
+    private static String chashOf(String tumbler) {
+        return validChash(tumbler);
     }
 }

--- a/service/src/test/java/dev/nexus/service/PgVectorCombinedQueryContractTest.java
+++ b/service/src/test/java/dev/nexus/service/PgVectorCombinedQueryContractTest.java
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.nexus.service.db.TenantScope;
+import dev.nexus.service.vectors.PgVectorRepository;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * RDR-156 P4.2b (bead nexus-joesk) — repository-layer contract for the combined-query
+ * methods {@link PgVectorRepository#searchMetadataScoped} and
+ * {@link PgVectorRepository#searchTopicScoped}, which the Python {@code query}/search
+ * composition repoints onto.
+ *
+ * <p>The SQL-function behaviour (joins, NULL-skip, distance ordering, tombstone filter,
+ * topic chash identity, EXPLAIN/HNSW) is exhaustively pinned by
+ * {@code CombinedQueryParityTest}. This suite covers the REPOSITORY LAYER concerns that
+ * test does not: server-side query embedding, per-dim dispatch + mixed-dim fail-loud,
+ * the {@code nResults} guard, empty/blank input, the flat {@code (id, content,
+ * collection, distance)} row envelope, and RLS scoping through the svc-role pool.
+ *
+ * <p>Chunks are superuser-seeded with explicit unit-vector literals (exact distances);
+ * the query text is embedded by {@link PgVectorRepositoryContractTest.FakeEmbedder}
+ * (registered {@code Q → (1,0)}), so the repository's server-side embed path is the
+ * thing under test, not the embedder.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PgVectorCombinedQueryContractTest {
+
+    private static final String SVC_ROLE = "svc_cqr_test";
+    private static final String SVC_PASS = "svc_cqr_test_pass";
+
+    private static final String TENANT_A = "cqr-tenant-a";
+    private static final String TENANT_B = "cqr-tenant-b";
+
+    private static final String COLL_M    = "knowledge__cqr-meta__voyage-context-3__v1";   // 1024
+    private static final String COLL_T    = "knowledge__cqr-topic__voyage-context-3__v1";   // 1024
+    private static final String COLL_MINI = "knowledge__cqr-mini__minilm-l6-v2-384__v1";    // 384
+    private static final String COLL_B    = "knowledge__cqr-b__voyage-context-3__v1";       // 1024, tenant B
+
+    private static final String TOPIC_VEC = "Vector Search";
+    private static final String Q = "combined query probe";
+
+    PostgreSQLContainer<?> pg;
+    HikariDataSource svcDs;
+    TenantScope tenantScope;
+    PgVectorRepository repo;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            for (String role : List.of("nexus_svc", SVC_ROLE)) {
+                su.createStatement().execute(
+                    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '" + role
+                    + "') THEN CREATE ROLE " + role + " LOGIN PASSWORD '" + role
+                    + "_pass' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
+            }
+        }
+        try (Connection su = pg.createConnection("")) {
+            new Liquibase("db/changelog/db.changelog-master.xml",
+                          new ClassLoaderResourceAccessor(),
+                          DatabaseFactory.getInstance().findCorrectDatabaseImplementation(
+                              new JdbcConnection(su))).update(new Contexts());
+        }
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            for (String tbl : List.of("catalog_collections", "catalog_documents",
+                    "catalog_document_chunks", "topics", "topic_assignments",
+                    "chunks_384", "chunks_768", "chunks_1024")) {
+                su.createStatement().execute(
+                    "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus." + tbl + " TO " + SVC_ROLE);
+            }
+            su.createStatement().execute("GRANT USAGE ON ALL SEQUENCES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+        }
+
+        var cfg = new HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(4);
+        cfg.setAutoCommit(true);
+        svcDs = new HikariDataSource(cfg);
+        tenantScope = new TenantScope(svcDs);
+
+        var embedder = new PgVectorRepositoryContractTest.FakeEmbedder(1024);
+        embedder.register(Q, 1.0f, 0.0f);
+        repo = new PgVectorRepository(tenantScope, embedder, embedder);
+
+        seedFixtures();
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (svcDs != null) svcDs.close();
+        if (pg != null)    pg.stop();
+    }
+
+    private void seedFixtures() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            // metadata fixture: m1 paper (1,0) d0; m2 paper (0.8,0.6) d0.2; m3 code (0.6,0.8) d0.4
+            insertCollection(su, TENANT_A, COLL_M);
+            seedMetaDoc(su, TENANT_A, 1024, COLL_M, "m1", "paper", 1.0, 0.0);
+            seedMetaDoc(su, TENANT_A, 1024, COLL_M, "m2", "paper", 0.8, 0.6);
+            seedMetaDoc(su, TENANT_A, 1024, COLL_M, "m3", "code",  0.6, 0.8);
+
+            // topic fixture: tv1 (1,0) d0 in topic; tv2 (0.6,0.8) d0.4 in topic
+            insertCollection(su, TENANT_A, COLL_T);
+            long topic = insertTopic(su, TENANT_A, TOPIC_VEC, COLL_T);
+            seedTopicChunk(su, TENANT_A, 1024, COLL_T, "tv1", topic, 1.0, 0.0);
+            seedTopicChunk(su, TENANT_A, 1024, COLL_T, "tv2", topic, 0.6, 0.8);
+
+            // tenant-B fixture (RLS)
+            insertCollection(su, TENANT_B, COLL_B);
+            seedMetaDoc(su, TENANT_B, 1024, COLL_B, "b1", "paper", 1.0, 0.0);
+        }
+    }
+
+    // ── repository-layer behaviour ──────────────────────────────────────────────
+
+    @Test
+    void metadataScoped_filtersAndRanks_flatRowShape() {
+        List<Map<String, Object>> rows =
+            repo.searchMetadataScoped(TENANT_A, Q, List.of(COLL_M), "paper", null, null, null, 10);
+        assertThat(ids(rows))
+            .as("type=paper ranked by distance → [m1, m2]")
+            .containsExactly("m1", "m2");
+        Map<String, Object> top = rows.get(0);
+        assertThat(top.keySet())
+            .as("flat envelope: exactly id, content, distance, collection")
+            .containsExactlyInAnyOrder("id", "content", "distance", "collection");
+        assertThat(top.get("collection")).isEqualTo(COLL_M);
+        assertThat(((Number) top.get("distance")).doubleValue()).isCloseTo(0.0, within());
+    }
+
+    @Test
+    void metadataScoped_nResultsTruncates() {
+        assertThat(ids(repo.searchMetadataScoped(TENANT_A, Q, List.of(COLL_M), "paper", null, null, null, 1)))
+            .as("nResults=1 → nearest paper only").containsExactly("m1");
+    }
+
+    @Test
+    void metadataScoped_mixedDimensions_failLoud() {
+        assertThatThrownBy(() ->
+            repo.searchMetadataScoped(TENANT_A, Q, List.of(COLL_M, COLL_MINI), null, null, null, null, 10))
+            .as("1024 + 384 cannot share one query vector — fail loud")
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void metadataScoped_nonPositiveN_failLoud() {
+        assertThatThrownBy(() ->
+            repo.searchMetadataScoped(TENANT_A, Q, List.of(COLL_M), null, null, null, null, 0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void metadataScoped_emptyCollections_returnsEmpty() {
+        assertThat(repo.searchMetadataScoped(TENANT_A, Q, List.of(), null, null, null, null, 10)).isEmpty();
+        assertThat(repo.searchMetadataScoped(TENANT_A, Q, null, null, null, null, null, 10)).isEmpty();
+    }
+
+    @Test
+    void metadataScoped_rlsScoped_otherTenantSeesNothing() {
+        assertThat(repo.searchMetadataScoped(TENANT_A, Q, List.of(COLL_B), "paper", null, null, null, 10))
+            .as("tenant-A cannot see tenant-B's collection rows (RLS via SECURITY INVOKER)")
+            .isEmpty();
+    }
+
+    @Test
+    void topicScoped_chunkLevel_rankedByDistance() {
+        List<Map<String, Object>> rows =
+            repo.searchTopicScoped(TENANT_A, Q, TOPIC_VEC, COLL_T, 10);
+        assertThat(ids(rows))
+            .as("topic-scoped is chunk-level: ids are chunk chashes, ranked by distance")
+            .containsExactly(chashOf("tv1"), chashOf("tv2"));
+    }
+
+    @Test
+    void topicScoped_blankCollection_returnsEmpty() {
+        assertThat(repo.searchTopicScoped(TENANT_A, Q, TOPIC_VEC, "", 10)).isEmpty();
+    }
+
+    @Test
+    void topicScoped_nonPositiveN_failLoud() {
+        assertThatThrownBy(() -> repo.searchTopicScoped(TENANT_A, Q, TOPIC_VEC, COLL_T, 0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static org.assertj.core.data.Offset<Double> within() {
+        return org.assertj.core.data.Offset.offset(1e-6);
+    }
+
+    private static List<String> ids(List<Map<String, Object>> rows) {
+        return rows.stream().map(r -> (String) r.get("id")).toList();
+    }
+
+    private void seedMetaDoc(Connection su, String tenant, int dim, String collection,
+                             String tumbler, String contentType, double x, double y) throws Exception {
+        String chash = chashOf(tumbler);
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title, content_type, physical_collection) "
+            + "VALUES ('" + tenant + "', '" + tumbler + "', 'Doc', '" + contentType + "', '" + collection + "') "
+            + "ON CONFLICT (tenant_id, tumbler) DO NOTHING");
+        insertManifest(su, tenant, tumbler, chash, collection);
+        insertChunk(su, tenant, dim, collection, chash, tumbler, x, y);
+    }
+
+    private void seedTopicChunk(Connection su, String tenant, int dim, String collection,
+                                String tumbler, long topicId, double x, double y) throws Exception {
+        String chash = chashOf(tumbler);
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title, content_type, physical_collection) "
+            + "VALUES ('" + tenant + "', '" + tumbler + "', 'Doc', 'paper', '" + collection + "') "
+            + "ON CONFLICT (tenant_id, tumbler) DO NOTHING");
+        insertManifest(su, tenant, tumbler, chash, collection);
+        insertChunk(su, tenant, dim, collection, chash, tumbler, x, y);
+        // chunk-level topic membership: topic_assignments.doc_id = chash (nexus-sa14p)
+        su.createStatement().execute(
+            "INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, source_collection, assigned_at) "
+            + "VALUES ('" + tenant + "', '" + chash + "', " + topicId + ", '" + collection + "', "
+            + "'2026-01-01T00:00:00+00'::timestamptz) ON CONFLICT (tenant_id, doc_id, topic_id) DO NOTHING");
+    }
+
+    private static void insertCollection(Connection su, String tenant, String name) throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + tenant + "', '" + name + "') "
+            + "ON CONFLICT (tenant_id, name) DO NOTHING");
+    }
+
+    private static void insertManifest(Connection su, String tenant, String docId, String chash,
+                                       String collection) throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash, collection) "
+            + "VALUES ('" + tenant + "', '" + docId + "', 0, '" + chash + "', '" + collection + "') "
+            + "ON CONFLICT (tenant_id, doc_id, position) DO NOTHING");
+    }
+
+    private static void insertChunk(Connection su, String tenant, int dim, String collection,
+                                    String chash, String text, double x, double y) throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.chunks_" + dim + " (tenant_id, collection, chash, chunk_text, embedding) "
+            + "VALUES ('" + tenant + "', '" + collection + "', '" + chash + "', '" + text + "', "
+            + vec2(dim, x, y) + "::vector) ON CONFLICT (tenant_id, collection, chash) DO NOTHING");
+    }
+
+    private static long insertTopic(Connection su, String tenant, String label, String collection)
+            throws Exception {
+        try (var st = su.createStatement();
+             var rs = st.executeQuery(
+                "INSERT INTO nexus.topics (tenant_id, label, collection, created_at) VALUES ('"
+                + tenant + "', '" + label + "', '" + collection + "', '2026-01-01T00:00:00+00'::timestamptz) "
+                + "RETURNING id")) {
+            rs.next();
+            return rs.getLong(1);
+        }
+    }
+
+    private static String vec2(int dim, double x, double y) {
+        StringBuilder sb = new StringBuilder("'[").append(x).append(',').append(y);
+        sb.append(",0".repeat(dim - 2));
+        return sb.append("]'").toString();
+    }
+
+    private static String chashOf(String seed) {
+        try {
+            byte[] h = java.security.MessageDigest.getInstance("SHA-256")
+                .digest(seed.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(64);
+            for (byte b : h) sb.append(String.format("%02x", b));
+            return sb.substring(0, 32);
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/service/src/test/java/dev/nexus/service/PgVectorCombinedQueryContractTest.java
+++ b/service/src/test/java/dev/nexus/service/PgVectorCombinedQueryContractTest.java
@@ -158,6 +158,24 @@ class PgVectorCombinedQueryContractTest {
     }
 
     @Test
+    void metadataScoped_multiCollection_arrayBind_rankedUnion() {
+        // Exercises the ARRAY[?,?]::text[] bind path with >1 same-dim collection
+        // (the single-element happy paths never reach the multi-element SQL).
+        // COLL_T also holds tenant-A paper docs (tv1/tv2 via seedTopicChunk).
+        List<String> got = ids(repo.searchMetadataScoped(
+            TENANT_A, Q, List.of(COLL_M, COLL_T), "paper", null, null, null, 10));
+        // m1 & tv1 both embed (1,0) → distance 0 (tie, no secondary sort), then
+        // m2 (0.2), tv2 (0.4); m3 is code → excluded. Tie-safe assertion.
+        assertThat(got).hasSize(4);
+        assertThat(got.subList(0, 2))
+            .as("the two distance-0 papers (m1, tv1) rank first, any tie order")
+            .containsExactlyInAnyOrder("m1", "tv1");
+        assertThat(got.subList(2, 4))
+            .as("then m2 (0.2) then tv2 (0.4), in distance order")
+            .containsExactly("m2", "tv2");
+    }
+
+    @Test
     void metadataScoped_nResultsTruncates() {
         assertThat(ids(repo.searchMetadataScoped(TENANT_A, Q, List.of(COLL_M), "paper", null, null, null, 1)))
             .as("nResults=1 → nearest paper only").containsExactly("m1");

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -632,6 +632,67 @@ class HttpVectorClient:
             }
         return results
 
+    def search_metadata_scoped(
+        self,
+        query: str,
+        collection_names: list[str],
+        *,
+        content_type: str | None = None,
+        author: str | None = None,
+        year: int | None = None,
+        corpus: str | None = None,
+        n_results: int = 10,
+    ) -> list[dict]:
+        """Metadata-scoped combined search (RDR-156 P4, Decision 5).
+
+        Routes to ``POST /v1/vectors/search-metadata-scoped`` —
+        ``nexus.search_metadata_scoped_<dim>`` (catalog-006), which joins the
+        chunk table to the catalog manifest + documents and filters by the
+        catalog metadata dimensions in ONE statement (the unification of the
+        ``query`` tool's app-side catalog-routing dance). A ``None`` filter is
+        omitted from the body (no filter on that dimension). Returns the flat
+        ``{id, content, distance, collection}`` row list; ``id`` is the document
+        tumbler (document-level retrieval — de-dup per id is the caller's job).
+        """
+        body: dict[str, Any] = {
+            "query": query,
+            "collections": collection_names,
+            "n_results": n_results,
+        }
+        if content_type is not None:
+            body["content_type"] = content_type
+        if author is not None:
+            body["author"] = author
+        if year is not None:
+            body["year"] = year
+        if corpus is not None:
+            body["corpus"] = corpus
+        return _post("/v1/vectors/search-metadata-scoped", body, tenant=self._tenant)
+
+    def search_topic_scoped(
+        self,
+        query: str,
+        topic: str,
+        collection: str,
+        *,
+        n_results: int = 10,
+    ) -> list[dict]:
+        """Topic-scoped combined search (RDR-156 P4, Decision 5).
+
+        Routes to ``POST /v1/vectors/search-topic-scoped`` —
+        ``nexus.search_topic_scoped_<dim>`` (catalog-006). Topic membership is
+        chunk-level (``topic_assignments.doc_id`` is a chunk chash, nexus-sa14p),
+        so results are chunk-level (``id`` is the chunk chash). Returns the flat
+        ``{id, content, distance, collection}`` row list.
+        """
+        body: dict[str, Any] = {
+            "query": query,
+            "topic": topic,
+            "collection": collection,
+            "n_results": n_results,
+        }
+        return _post("/v1/vectors/search-topic-scoped", body, tenant=self._tenant)
+
     def get_by_id(self, collection: str, doc_id: str) -> dict | None:
         """Fetch a single chunk by ID.
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1017,10 +1017,18 @@ def search_metadata_scoped(
     The single-statement unification of the ``query`` tool's catalog-routing
     dance: ``nexus.search_metadata_scoped_<dim>`` joins the chunk table to the
     catalog manifest + documents and filters by catalog metadata in one query
-    (HNSW survives the join). Document-level results (``id`` is the tumbler).
+    (HNSW survives the join). Document-level results (``id`` is the tumbler),
+    deduped to one row per tumbler at the best (nearest) distance.
 
     Service-mode only — the combined-query functions live in the pgvector
     Postgres; in local/Chroma mode this returns an error.
+
+    PLAN-RUNNER CAVEAT: the structured ``ids``/``tumblers`` are document tumblers,
+    NOT chunk chashes. The runner's auto-hydration (``store_get_many``) is
+    chash-keyed, so feeding ``$stepN.ids`` straight into an operator returns empty
+    content — use a tumbler-aware hydration path (tracked: nexus-zekpl). The
+    ``catalog_documents.corpus`` filter the SQL function supports is NOT exposed
+    here (``corpus`` is the collection-routing arg); add it explicitly if needed.
 
     Args:
         query: Search query string.
@@ -1098,7 +1106,12 @@ def search_topic_scoped(
     ``topic_assignments`` on chunk chash (topic membership is chunk-level,
     nexus-sa14p) and ranks by vector distance. Chunk-level results (``id`` is
     the chunk chash). Resolved across every collection in *corpus* (topics are
-    per-collection), merged by distance.
+    per-collection — a label belongs to one collection's taxonomy, so the
+    multi-collection loop is usually single-hit), merged by distance. NOTE: the
+    merge is per-collection-limit-then-merge-then-truncate, so for a label genuinely
+    present in multiple collections the global top-N can drop a collection's
+    (limit+1)th row that would have ranked; over-fetch per collection if that case
+    becomes real.
 
     Service-mode only.
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 Hal Hildebrand. All rights reserved.
 """MCP core tools: search, store, memory, scratch, collections, plans.
 
-14 registered tools + 3 demoted (plain functions, no @mcp.tool()).
+16 registered tools + 3 demoted (plain functions, no @mcp.tool()).
 """
 from __future__ import annotations
 
@@ -968,6 +968,177 @@ def search(
             lines.append(f"\n--- showing {offset + 1}-{shown_end} of {total} (end)")
 
         return "\n\n".join(lines)
+    except Exception as e:
+        return f"Error: {e}"
+
+
+def _resolve_corpus_target(corpus: str, t3: Any) -> list[str]:
+    """Resolve a comma-separated corpus/collection spec to collection names.
+
+    Mirrors the ``search`` tool's routing: ``all`` expands to every live
+    prefix; a ``__``-qualified part is a collection name; a bare part is a
+    corpus prefix resolved against the live collection list.
+    """
+    all_names = _get_collection_names()
+    if corpus == "all":
+        seen: list[str] = []
+        for n in all_names:
+            prefix = n.split("__", 1)[0]
+            if prefix and prefix not in seen:
+                seen.append(prefix)
+        corpus = ",".join(seen) if seen else "knowledge,code,docs,rdr"
+    target: list[str] = []
+    for part in corpus.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "__" in part:
+            target.append(t3_collection_name(part, t3=t3))
+        else:
+            target.extend(resolve_corpus(part, all_names))
+    return list(dict.fromkeys(target))
+
+
+@mcp.tool(
+    title="Metadata-Scoped Combined Search",
+    annotations={"readOnlyHint": True},
+)
+def search_metadata_scoped(
+    query: str,
+    corpus: str = "knowledge,code,docs",
+    limit: int = 10,
+    content_type: str = "",
+    author: str = "",
+    year: int = 0,
+    structured: bool = False,
+) -> "str | dict":
+    """Metadata-scoped combined search (RDR-156 P4, Decision 5).
+
+    The single-statement unification of the ``query`` tool's catalog-routing
+    dance: ``nexus.search_metadata_scoped_<dim>`` joins the chunk table to the
+    catalog manifest + documents and filters by catalog metadata in one query
+    (HNSW survives the join). Document-level results (``id`` is the tumbler).
+
+    Service-mode only — the combined-query functions live in the pgvector
+    Postgres; in local/Chroma mode this returns an error.
+
+    Args:
+        query: Search query string.
+        corpus: Corpus prefixes or collection names, comma-separated; "all" for all.
+        limit: Max rows.
+        content_type: Catalog content_type filter ("" = no filter).
+        author: Catalog author filter ("" = no filter).
+        year: Catalog year filter (0 = no filter).
+        structured: Return ``{ids, tumblers, distances, collections}`` for the plan runner.
+    """
+    try:
+        from nexus.db.http_vector_client import is_service_backed
+
+        t3 = _get_t3()
+        if not is_service_backed(t3):
+            return ("Error: search_metadata_scoped requires service mode "
+                    "(pgvector); not available in local/Chroma mode")
+        target = _resolve_corpus_target(corpus, t3)
+        if not target:
+            return f"No collections match corpus {corpus!r}"
+        rows = t3.search_metadata_scoped(
+            query, target,
+            content_type=content_type or None,
+            author=author or None,
+            year=(year or None),
+            n_results=limit,
+        )
+        # Metadata-scoped is document-level: the function returns one row per
+        # matching CHUNK, so a multi-chunk document repeats its tumbler. Collapse
+        # to one row per id, keeping the best (nearest) distance. Rows arrive
+        # distance-ascending, so the FIRST occurrence of each id is its best.
+        seen_ids: set[str] = set()
+        deduped: list[dict] = []
+        for r in rows:
+            rid = r.get("id", "")
+            if rid in seen_ids:
+                continue
+            seen_ids.add(rid)
+            deduped.append(r)
+        rows = deduped
+        if structured:
+            # id IS the document tumbler for metadata-scoped (document-level).
+            ids = [r.get("id", "") for r in rows]
+            return {
+                "ids": ids,
+                "tumblers": ids,
+                "distances": [r.get("distance", 0.0) for r in rows],
+                "collections": [r.get("collection", "") for r in rows],
+            }
+        if not rows:
+            return "No documents found."
+        return "\n\n".join(
+            f"[{r.get('collection', '')}] {r.get('id', '')} (dist={r.get('distance', 0.0):.4f})"
+            f"\n{r.get('content', '')}"
+            for r in rows
+        )
+    except Exception as e:
+        return f"Error: {e}"
+
+
+@mcp.tool(
+    title="Topic-Scoped Combined Search",
+    annotations={"readOnlyHint": True},
+)
+def search_topic_scoped(
+    query: str,
+    topic: str,
+    corpus: str = "knowledge,code,docs",
+    limit: int = 10,
+    structured: bool = False,
+) -> "str | dict":
+    """Topic-scoped combined search (RDR-156 P4, Decision 5).
+
+    ``nexus.search_topic_scoped_<dim>`` joins the chunk table to
+    ``topic_assignments`` on chunk chash (topic membership is chunk-level,
+    nexus-sa14p) and ranks by vector distance. Chunk-level results (``id`` is
+    the chunk chash). Resolved across every collection in *corpus* (topics are
+    per-collection), merged by distance.
+
+    Service-mode only.
+
+    Args:
+        query: Search query string.
+        topic: Topic label (from ``nx taxonomy discover``).
+        corpus: Corpus prefixes or collection names, comma-separated; "all" for all.
+        limit: Max rows.
+        structured: Return ``{ids, tumblers, distances, collections}`` for the plan runner.
+    """
+    try:
+        from nexus.db.http_vector_client import is_service_backed
+
+        t3 = _get_t3()
+        if not is_service_backed(t3):
+            return ("Error: search_topic_scoped requires service mode "
+                    "(pgvector); not available in local/Chroma mode")
+        target = _resolve_corpus_target(corpus, t3)
+        if not target:
+            return f"No collections match corpus {corpus!r}"
+        merged: list[dict] = []
+        for col in target:
+            merged.extend(t3.search_topic_scoped(query, topic, col, n_results=limit))
+        merged.sort(key=lambda r: r.get("distance", 0.0))
+        merged = merged[:limit]
+        if structured:
+            # Chunk-level: ids are chunk chashes; no document tumbler.
+            return {
+                "ids": [r.get("id", "") for r in merged],
+                "tumblers": ["" for _ in merged],
+                "distances": [r.get("distance", 0.0) for r in merged],
+                "collections": [r.get("collection", "") for r in merged],
+            }
+        if not merged:
+            return f"No chunks found for topic {topic!r}."
+        return "\n\n".join(
+            f"[{r.get('collection', '')}] {r.get('id', '')} (dist={r.get('distance', 0.0):.4f})"
+            f"\n{r.get('content', '')}"
+            for r in merged
+        )
     except Exception as e:
         return f"Error: {e}"
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1077,6 +1077,10 @@ def search_metadata_scoped(
                 "tumblers": ids,
                 "distances": [r.get("distance", 0.0) for r in rows],
                 "collections": [r.get("collection", "") for r in rows],
+                # contents inline so plan steps can summarize directly via
+                # $stepN.contents WITHOUT store_get_many hydration (which is
+                # chash-keyed and would miss these document tumblers).
+                "contents": [r.get("content", "") for r in rows],
             }
         if not rows:
             return "No documents found."
@@ -1144,6 +1148,9 @@ def search_topic_scoped(
                 "tumblers": ["" for _ in merged],
                 "distances": [r.get("distance", 0.0) for r in merged],
                 "collections": [r.get("collection", "") for r in merged],
+                # contents inline so plan steps summarize via $stepN.contents
+                # without hydration (topic ids are chunk chashes).
+                "contents": [r.get("content", "") for r in merged],
             }
         if not merged:
             return f"No chunks found for topic {topic!r}."

--- a/src/nexus/plans/runner.py
+++ b/src/nexus/plans/runner.py
@@ -252,7 +252,10 @@ _NON_EMBEDDING_TOOLS: frozenset[str] = frozenset({"traverse"})
 #: otherwise have to thread ``structured=True`` into every YAML
 #: hydration step.
 _RETRIEVAL_TOOLS: frozenset[str] = frozenset(
-    {"search", "query", "store_get_many"},
+    {"search", "query", "store_get_many",
+     # RDR-156 P4 (nexus-joesk): combined-query primitives — structured=True so
+     # $stepN.ids/tumblers resolve from the {ids, tumblers, distances, collections} shape.
+     "search_metadata_scoped", "search_topic_scoped"},
 )
 
 #: Args keys that may carry a collection name. The runner extracts

--- a/src/nexus/plans/runner.py
+++ b/src/nexus/plans/runner.py
@@ -961,9 +961,13 @@ async def _default_dispatcher(tool: str, args: dict[str, Any]) -> dict[str, Any]
     # (catalog not initialized, subtree too deep, …) with a bare
     # ``"Error: …"`` string even when ``structured=True`` is passed.
     # In that case synthesize the empty structured shape so the plan
-    # step still conforms to ``{ids, tumblers, distances, collections}``
-    # and downstream ``$stepN.tumblers`` refs don't crash; preserve the
-    # error text in an ``error`` key for visibility.
+    # step still conforms to ``{ids, tumblers, distances, collections,
+    # contents}`` and downstream ``$stepN.tumblers`` / ``$stepN.contents``
+    # refs don't crash; preserve the error text in an ``error`` key for
+    # visibility. ``contents`` is included so combined-query consumers
+    # (RDR-156 P4 search_metadata_scoped / search_topic_scoped, whose
+    # structured output carries chunk text inline) degrade to an empty
+    # summarize in local mode rather than raising PlanRunStepRefError.
     if isinstance(result, str):
         if tool in _RETRIEVAL_TOOLS:
             # Retrieval error strings usually indicate a plan-binding
@@ -980,6 +984,7 @@ async def _default_dispatcher(tool: str, args: dict[str, Any]) -> dict[str, Any]
             )
             return {
                 "ids": [], "tumblers": [], "distances": [], "collections": [],
+                "contents": [],
                 "error": result,
             }
         return {"text": result}

--- a/tests/test_combined_query_mcp_tools.py
+++ b/tests/test_combined_query_mcp_tools.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-156 P4.2b (nexus-joesk): combined-query MCP tools.
+
+``search_metadata_scoped`` / ``search_topic_scoped`` in ``nexus.mcp.core`` are
+the plan-runner-consumable primitives wrapping the catalog-006 combined-query
+functions (via HttpVectorClient). These tests pin: corpus→collection routing,
+the service-mode gate, the client call shape, and the structured
+``{ids, tumblers, distances, collections}`` envelope the plan runner consumes.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from nexus.mcp import core
+
+
+class _FakeServiceT3:
+    """Records combined-query client calls; stands in for HttpVectorClient."""
+
+    def __init__(self, meta_rows: list[dict] | None = None,
+                 topic_rows_by_col: dict[str, list[dict]] | None = None) -> None:
+        self.meta_rows = meta_rows or []
+        self.topic_rows_by_col = topic_rows_by_col or {}
+        self.meta_calls: list[tuple] = []
+        self.topic_calls: list[tuple] = []
+
+    def search_metadata_scoped(self, query, collection_names, *, content_type=None,
+                               author=None, year=None, corpus=None, n_results=10):
+        self.meta_calls.append((query, list(collection_names), content_type, author,
+                                year, corpus, n_results))
+        return self.meta_rows
+
+    def search_topic_scoped(self, query, topic, collection, *, n_results=10):
+        self.topic_calls.append((query, topic, collection, n_results))
+        return self.topic_rows_by_col.get(collection, [])
+
+
+def _wire(monkeypatch, t3, target, *, service=True):
+    monkeypatch.setattr(core, "_get_t3", lambda: t3)
+    monkeypatch.setattr(core, "_resolve_corpus_target", lambda corpus, t3: target)
+    monkeypatch.setattr(
+        "nexus.db.http_vector_client.is_service_backed", lambda db: service)
+
+
+class TestSearchMetadataScopedTool:
+    def test_structured_doc_level_ids_are_tumblers(self, monkeypatch):
+        rows = [
+            {"id": "1.2.3", "content": "a", "distance": 0.1, "collection": "c1"},
+            {"id": "1.2.4", "content": "b", "distance": 0.3, "collection": "c1"},
+        ]
+        t3 = _FakeServiceT3(meta_rows=rows)
+        _wire(monkeypatch, t3, ["c1"])
+
+        out = core.search_metadata_scoped(
+            "q", corpus="knowledge", content_type="paper", author="alice",
+            year=2024, limit=5, structured=True)
+
+        assert out == {
+            "ids": ["1.2.3", "1.2.4"],
+            "tumblers": ["1.2.3", "1.2.4"],   # document-level: tumblers == ids
+            "distances": [0.1, 0.3],
+            "collections": ["c1", "c1"],
+        }
+        # filters forwarded; year=0/"" → None handled by the tool
+        assert t3.meta_calls == [("q", ["c1"], "paper", "alice", 2024, None, 5)]
+
+    def test_empty_filters_become_none(self, monkeypatch):
+        t3 = _FakeServiceT3(meta_rows=[])
+        _wire(monkeypatch, t3, ["c1"])
+        core.search_metadata_scoped("q", corpus="knowledge", structured=True)
+        assert t3.meta_calls == [("q", ["c1"], None, None, None, None, 10)]
+
+    def test_non_service_mode_errors(self, monkeypatch):
+        t3 = _FakeServiceT3()
+        _wire(monkeypatch, t3, ["c1"], service=False)
+        out = core.search_metadata_scoped("q", structured=True)
+        assert isinstance(out, str) and out.startswith("Error:")
+        assert t3.meta_calls == []
+
+    def test_multichunk_doc_deduped_keeps_best_distance(self, monkeypatch):
+        # The SQL function returns one row per matching chunk (distance-asc), so a
+        # 2-chunk document repeats its tumbler. The tool collapses to one row per
+        # id at the best distance — document-level contract.
+        rows = [
+            {"id": "1.2.3", "content": "near chunk", "distance": 0.1, "collection": "c1"},
+            {"id": "1.2.4", "content": "other doc",  "distance": 0.2, "collection": "c1"},
+            {"id": "1.2.3", "content": "far chunk",  "distance": 0.9, "collection": "c1"},
+        ]
+        t3 = _FakeServiceT3(meta_rows=rows)
+        _wire(monkeypatch, t3, ["c1"])
+        out = core.search_metadata_scoped("q", structured=True)
+        assert out["ids"] == ["1.2.3", "1.2.4"]
+        assert out["distances"] == [0.1, 0.2]  # 1.2.3 kept at its best (0.1), not 0.9
+
+
+class TestSearchTopicScopedTool:
+    def test_structured_chunk_level_merges_collections(self, monkeypatch):
+        rows = {
+            "c1": [{"id": "h1", "content": "x", "distance": 0.4, "collection": "c1"}],
+            "c2": [{"id": "h2", "content": "y", "distance": 0.1, "collection": "c2"}],
+        }
+        t3 = _FakeServiceT3(topic_rows_by_col=rows)
+        _wire(monkeypatch, t3, ["c1", "c2"])
+
+        out = core.search_topic_scoped("q", "Vector Search", corpus="all",
+                                       limit=10, structured=True)
+
+        # merged across collections, sorted by distance ascending
+        assert out["ids"] == ["h2", "h1"]
+        assert out["distances"] == [0.1, 0.4]
+        assert out["collections"] == ["c2", "c1"]
+        # chunk-level: no document tumblers
+        assert out["tumblers"] == ["", ""]
+        assert [c[2] for c in t3.topic_calls] == ["c1", "c2"]
+
+    def test_non_service_mode_errors(self, monkeypatch):
+        t3 = _FakeServiceT3()
+        _wire(monkeypatch, t3, ["c1"], service=False)
+        out = core.search_topic_scoped("q", "T", structured=True)
+        assert isinstance(out, str) and out.startswith("Error:")
+
+
+class TestPlanRunnerRegistration:
+    def test_tools_registered_as_retrieval(self):
+        from nexus.plans.runner import _RETRIEVAL_TOOLS
+        assert "search_metadata_scoped" in _RETRIEVAL_TOOLS
+        assert "search_topic_scoped" in _RETRIEVAL_TOOLS
+
+    def test_tools_resolvable_on_core(self):
+        assert callable(getattr(core, "search_metadata_scoped"))
+        assert callable(getattr(core, "search_topic_scoped"))

--- a/tests/test_combined_query_mcp_tools.py
+++ b/tests/test_combined_query_mcp_tools.py
@@ -61,6 +61,7 @@ class TestSearchMetadataScopedTool:
             "tumblers": ["1.2.3", "1.2.4"],   # document-level: tumblers == ids
             "distances": [0.1, 0.3],
             "collections": ["c1", "c1"],
+            "contents": ["a", "b"],
         }
         # filters forwarded; year=0/"" → None handled by the tool
         assert t3.meta_calls == [("q", ["c1"], "paper", "alice", 2024, None, 5)]
@@ -92,6 +93,7 @@ class TestSearchMetadataScopedTool:
         out = core.search_metadata_scoped("q", structured=True)
         assert out["ids"] == ["1.2.3", "1.2.4"]
         assert out["distances"] == [0.1, 0.2]  # 1.2.3 kept at its best (0.1), not 0.9
+        assert out["contents"] == ["near chunk", "other doc"]  # best-distance row's content
 
 
 class TestSearchTopicScopedTool:
@@ -112,6 +114,7 @@ class TestSearchTopicScopedTool:
         assert out["collections"] == ["c2", "c1"]
         # chunk-level: no document tumblers
         assert out["tumblers"] == ["", ""]
+        assert out["contents"] == ["y", "x"]  # inline contents, distance order
         assert [c[2] for c in t3.topic_calls] == ["c1", "c2"]
 
     def test_non_service_mode_errors(self, monkeypatch):

--- a/tests/test_combined_query_plan_templates.py
+++ b/tests/test_combined_query_plan_templates.py
@@ -109,6 +109,25 @@ class TestRepointedExecution:
         assert disp.calls[1][1]["inputs"] == step1_out["contents"]
 
     @pytest.mark.asyncio
+    async def test_local_mode_synthesized_shape_has_contents(self, monkeypatch):
+        # In local/Chroma mode search_metadata_scoped returns an Error string.
+        # _default_dispatcher must synthesize the empty retrieval shape WITH a
+        # contents key so a downstream $stepN.contents resolves to [] (graceful
+        # empty summarize) instead of raising PlanRunStepRefError.
+        from nexus.mcp import core
+        from nexus.plans.runner import _default_dispatcher
+
+        monkeypatch.setattr(
+            core, "search_metadata_scoped",
+            lambda **kw: "Error: search_metadata_scoped requires service mode")
+
+        out = await _default_dispatcher("search_metadata_scoped",
+                                        {"query": "q", "collections": ["c1"]})
+        assert out["contents"] == []
+        assert out["ids"] == [] and out["tumblers"] == []
+        assert "error" in out
+
+    @pytest.mark.asyncio
     async def test_type_scoped_binds_content_type(self):
         from nexus.plans.runner import plan_run
 

--- a/tests/test_combined_query_plan_templates.py
+++ b/tests/test_combined_query_plan_templates.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-156 P4 (nexus-zo0zt): consumer adoption of the combined-query primitives.
+
+The ``find-by-author`` and ``type-scoped-search`` builtin plan templates are
+repointed from the ``query``-tool catalog dance (+ ``store_get_many`` hydration)
+onto ``search_metadata_scoped`` → ``summarize($step1.contents)``. These tests pin
+the repointed step shape AND prove it runs end-to-end through ``plan_run``: the
+new primitive is actually driven, and the inline ``contents`` flow to
+``summarize`` without the chash-keyed ``store_get_many`` hydration.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+_BUILTIN = Path(__file__).parent.parent / "conexus" / "plans" / "builtin"
+_AUTHOR = _BUILTIN / "find-by-author.yml"
+_TYPE = _BUILTIN / "type-scoped-search.yml"
+
+
+def _template(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+def _match(template: dict):
+    from nexus.plans.match import Match
+
+    pj = template["plan_json"]
+    return Match(
+        plan_id=1, name=template["name"], description=template["description"],
+        confidence=0.9, dimensions=template["dimensions"], tags=template.get("tags", ""),
+        plan_json=json.dumps(pj),
+        required_bindings=list(template.get("required_bindings", []) or []),
+        optional_bindings=list(template.get("optional_bindings", []) or []),
+        default_bindings=dict(template.get("default_bindings", {}) or {}),
+        parent_dims=None,
+    )
+
+
+class _FakeDispatcher:
+    def __init__(self, outputs: list[dict]) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._outputs = list(outputs)
+
+    async def __call__(self, tool: str, args: dict) -> dict:
+        self.calls.append((tool, args))
+        return self._outputs.pop(0) if self._outputs else {"text": f"{tool}(stub)"}
+
+
+# ── structural: step shape repointed onto the combined primitive ──────────────
+
+
+class TestRepointedShape:
+    def test_find_by_author_routes_through_metadata_scoped(self):
+        steps = _template(_AUTHOR)["plan_json"]["steps"]
+        assert [s["tool"] for s in steps] == ["search_metadata_scoped", "summarize"]
+        assert steps[0]["args"]["author"] == "$author"
+        assert steps[0]["args"]["corpus"] == "all"
+        # contents flow directly — NO store_get_many (chash-keyed, would miss tumblers)
+        assert steps[1]["args"]["inputs"] == "$step1.contents"
+        assert all(s["tool"] != "store_get_many" for s in steps)
+
+    def test_type_scoped_routes_through_metadata_scoped(self):
+        steps = _template(_TYPE)["plan_json"]["steps"]
+        assert [s["tool"] for s in steps] == ["search_metadata_scoped", "summarize"]
+        assert steps[0]["args"]["content_type"] == "$content_type"
+        assert steps[1]["args"]["inputs"] == "$step1.contents"
+        assert all(s["tool"] != "store_get_many" for s in steps)
+
+    def test_dimensions_unchanged(self):
+        # Repoint must not move the routing target — plan_match still selects these.
+        assert _template(_AUTHOR)["dimensions"]["strategy"] == "find-by-author"
+        assert _template(_TYPE)["dimensions"]["strategy"] == "type-scoped"
+
+
+# ── end-to-end: the primitive is actually driven, contents reach summarize ────
+
+
+class TestRepointedExecution:
+    @pytest.mark.asyncio
+    async def test_find_by_author_drives_primitive_and_flows_contents(self):
+        from nexus.plans.runner import plan_run
+
+        step1_out = {
+            "ids": ["1.2.3", "1.2.9"],
+            "tumblers": ["1.2.3", "1.2.9"],
+            "distances": [0.1, 0.4],
+            "collections": ["knowledge__x__m__v1", "knowledge__x__m__v1"],
+            "contents": ["Ada on analytical engines", "Ada on Bernoulli numbers"],
+        }
+        disp = _FakeDispatcher([step1_out, {"text": "summary"}])
+
+        await plan_run(_match(_template(_AUTHOR)), {"author": "Ada Lovelace"},
+                       dispatcher=disp, bundle_operators=False)
+
+        assert [t for t, _ in disp.calls] == ["search_metadata_scoped", "summarize"]
+        meta_args = disp.calls[0][1]
+        assert meta_args["author"] == "Ada Lovelace"          # binding resolved
+        assert meta_args["query"] == "Ada Lovelace"           # whole-token $author resolved
+        assert meta_args["corpus"] == "all"
+        # (structured=True is injected by the default dispatcher for _RETRIEVAL_TOOLS;
+        #  registration is asserted in test_combined_query_mcp_tools.)
+        # contents flow into summarize WITHOUT store_get_many hydration
+        assert disp.calls[1][0] == "summarize"
+        assert disp.calls[1][1]["inputs"] == step1_out["contents"]
+
+    @pytest.mark.asyncio
+    async def test_type_scoped_binds_content_type(self):
+        from nexus.plans.runner import plan_run
+
+        step1_out = {"ids": ["1.1.1"], "tumblers": ["1.1.1"], "distances": [0.2],
+                     "collections": ["code__x__m__v1"], "contents": ["def f(): ..."]}
+        disp = _FakeDispatcher([step1_out, {"text": "summary"}])
+
+        await plan_run(_match(_template(_TYPE)),
+                       {"question": "retry logic", "content_type": "code"},
+                       dispatcher=disp, bundle_operators=False)
+
+        meta_args = disp.calls[0][1]
+        assert meta_args["content_type"] == "code"
+        assert meta_args["query"] == "retry logic"
+        assert disp.calls[1][1]["inputs"] == step1_out["contents"]

--- a/tests/test_http_vector_client_combined_query.py
+++ b/tests/test_http_vector_client_combined_query.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-156 P4.2b (nexus-joesk): HttpVectorClient combined-query methods.
+
+``search_metadata_scoped`` and ``search_topic_scoped`` are the client legs for
+``POST /v1/vectors/search-metadata-scoped`` and ``/search-topic-scoped`` — the
+combined-query functions (catalog-006) the Python ``query`` composition repoints
+onto. These tests pin the request envelope (path, body keys, NULL-filter
+omission) and the flat-list passthrough; the SQL semantics are pinned engine-side
+by CombinedQueryParityTest / PgVectorCombinedQueryContractTest.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from nexus.db.http_vector_client import HttpVectorClient
+
+META_PATH = "/v1/vectors/search-metadata-scoped"
+TOPIC_PATH = "/v1/vectors/search-topic-scoped"
+
+
+def _patch_post(monkeypatch, handler) -> list[tuple[str, dict]]:
+    """Patch module-level _post, recording (path, body) calls."""
+    calls: list[tuple[str, dict]] = []
+
+    def fake_post(path: str, body: dict, *, tenant: str = "default",
+                  timeout: int = 120) -> Any:
+        calls.append((path, body))
+        return handler(path, body)
+
+    monkeypatch.setattr("nexus.db.http_vector_client._post", fake_post)
+    return calls
+
+
+class TestSearchMetadataScoped:
+    def test_posts_to_metadata_route_with_filters(self, monkeypatch):
+        rows = [{"id": "1.2.3", "content": "x", "distance": 0.1,
+                 "collection": "code__a__model-x__v1"}]
+        calls = _patch_post(monkeypatch, lambda p, b: rows)
+
+        got = HttpVectorClient().search_metadata_scoped(
+            "how does x work", ["code__a__model-x__v1"],
+            content_type="paper", author="alice", year=2024, corpus="research",
+            n_results=5)
+
+        assert got == rows
+        assert len(calls) == 1
+        path, body = calls[0]
+        assert path == META_PATH
+        assert body == {
+            "query": "how does x work",
+            "collections": ["code__a__model-x__v1"],
+            "content_type": "paper",
+            "author": "alice",
+            "year": 2024,
+            "corpus": "research",
+            "n_results": 5,
+        }
+
+    def test_omits_none_filters_from_body(self, monkeypatch):
+        calls = _patch_post(monkeypatch, lambda p, b: [])
+
+        HttpVectorClient().search_metadata_scoped(
+            "q", ["code__a__model-x__v1"], content_type="paper")
+
+        _, body = calls[0]
+        assert body == {
+            "query": "q",
+            "collections": ["code__a__model-x__v1"],
+            "content_type": "paper",
+            "n_results": 10,
+        }
+        assert "author" not in body
+        assert "year" not in body
+        assert "corpus" not in body
+
+    def test_returns_empty_list_passthrough(self, monkeypatch):
+        _patch_post(monkeypatch, lambda p, b: [])
+        assert HttpVectorClient().search_metadata_scoped("q", ["code__a__model-x__v1"]) == []
+
+
+class TestSearchTopicScoped:
+    def test_posts_to_topic_route(self, monkeypatch):
+        rows = [{"id": "abc123", "content": "y", "distance": 0.0,
+                 "collection": "knowledge__b__minilm-l6-v2-384__v1"}]
+        calls = _patch_post(monkeypatch, lambda p, b: rows)
+
+        got = HttpVectorClient().search_topic_scoped(
+            "vector search", "Vector Search",
+            "knowledge__b__minilm-l6-v2-384__v1", n_results=3)
+
+        assert got == rows
+        path, body = calls[0]
+        assert path == TOPIC_PATH
+        assert body == {
+            "query": "vector search",
+            "topic": "Vector Search",
+            "collection": "knowledge__b__minilm-l6-v2-384__v1",
+            "n_results": 3,
+        }
+
+    def test_default_n_results(self, monkeypatch):
+        calls = _patch_post(monkeypatch, lambda p, b: [])
+        HttpVectorClient().search_topic_scoped("q", "T", "knowledge__b__minilm-l6-v2-384__v1")
+        _, body = calls[0]
+        assert body["n_results"] == 10

--- a/tests/test_mcp_package.py
+++ b/tests/test_mcp_package.py
@@ -21,8 +21,9 @@ def test_catalog_module_importable():
 
 
 def test_core_registered_tools():
-    """29 core tools are registered with @mcp.tool() (RDR-088 added filter, check,
-    verify; RDR-126 added daemon_uninstall)."""
+    """Core tools registered with @mcp.tool() (RDR-088 added filter, check,
+    verify; RDR-126 added daemon_uninstall; RDR-156 P4 added the two
+    combined-query primitives)."""
     from nexus.mcp.core import mcp
 
     tool_names = {t.name for t in mcp._tool_manager.list_tools()}
@@ -38,6 +39,8 @@ def test_core_registered_tools():
         "operator_groupby", "operator_aggregate",
         "nx_answer", "nx_tidy", "nx_enrich_beads", "nx_plan_audit",
         "daemon_uninstall",
+        # RDR-156 P4 combined-query primitives (nexus-joesk)
+        "search_metadata_scoped", "search_topic_scoped",
     }
     assert expected == tool_names, f"Missing: {expected - tool_names}, Extra: {tool_names - expected}"
 


### PR DESCRIPTION
RDR-156 Phase 4 (combined-query unification, Decision 5). Two of the highest-traffic cross-store stitches become single planner-optimizable SQL functions, plus the Java repository/HTTP seam the Python query layer will repoint onto.

## What's here (additive, all-green; no consumers repointed yet)

**Schema (`nexus-70r3c.14` test / `nexus-70r3c.15` impl)** — `catalog-006`:
- `nexus.search_metadata_scoped_{384,768,1024}` — document-level; `chunks ⋈ catalog_document_chunks ⋈ catalog_documents`, NULL-skip metadata filters, tombstone-filtered.
- `nexus.search_topic_scoped_{384,768,1024}` — chunk-level; `chunks ⋈ topic_assignments` on `chash = doc_id` (topic membership is chunk-keyed, nexus-sa14p), inline live-chunk predicate.
- Inlinable `LANGUAGE sql`, `SECURITY INVOKER`, query-vector-as-argument (Finding 5a — HNSW survives the join), no in-function selectivity switch (kept inlinable by decision; narrow-collection `max_scan_tuples` defense applied at the call site via `hnsw.iterative_scan`).
- `CombinedQueryParityTest` — 22 tests: query-vector-as-arg, EXPLAIN HNSW-survives-join, narrow-collection exact-recall `==N`, parity vs stitched oracle, non-vacuity, tombstone both-directions, RLS, per-dim dispatch.

**Java seam (`nexus-joesk`)**:
- `PgVectorRepository.searchMetadataScoped` / `searchTopicScoped` (server-side embed, per-dim dispatch, `SET LOCAL hnsw.iterative_scan='relaxed_order'`, flat envelope).
- `POST /v1/vectors/search-metadata-scoped` + `/search-topic-scoped`.
- `PgVectorCombinedQueryContractTest` — 9 repository-layer tests.

## Stacked review
Both reviewers run (2026-06-13). Caught a production CRITICAL: topic functions originally joined `topic_assignments.doc_id = tumbler` but `doc_id` is a chunk chash — structurally empty in prod, masked by the fixture. Fixed to chunk-level chash join; SHA-256 chash derivation closed a content-addressed collision; re-review clean. T2: `nexus/review-nexus-70r3c.14-15-rdr156-p4-2026-06-13`.

## Deferred + tracked (block the P4 gate `nexus-70r3c.16`)
- `nexus-joesk` (continues) — repoint `search_engine.search_cross_corpus` (catalog dance + topic prefilter) + Python client + multi-chunk dedup. Live serving path; its own RED tests + review.
- `nexus-2bqpn` — delete the app-side stitching (separate commit, git revert = rollback).
- `nexus-qrm3s` — extend the RDR-155 P3.E DualRunHarness for corpus-scale function-vs-stitched-path parity (Finding 4) — also covers the HTTP-seam end-to-end.

Draft until the repoint lands.