### PR TITLE
feat(rdr-156): P4 graph-hop combined-query function [nexus-houg9]

### DIFF
--- a/conexus/hooks/scripts/auto-approve-nx-mcp.sh
+++ b/conexus/hooks/scripts/auto-approve-nx-mcp.sh
@@ -11,6 +11,7 @@ case "$TOOL_NAME" in
   mcp__plugin_conexus_nexus__query|\
   mcp__plugin_conexus_nexus__search_metadata_scoped|\
   mcp__plugin_conexus_nexus__search_topic_scoped|\
+  mcp__plugin_conexus_nexus__search_graph_hop|\
   mcp__plugin_conexus_nexus__store_put|\
   mcp__plugin_conexus_nexus__store_get|\
   mcp__plugin_conexus_nexus__store_get_many|\

--- a/service/src/main/java/dev/nexus/service/http/VectorHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/VectorHandler.java
@@ -113,6 +113,7 @@ public final class VectorHandler implements HttpHandler {
                 case "/hybrid-search" -> handleHybridSearch(exchange, method);  // RDR-155 P3
                 case "/search-metadata-scoped" -> handleSearchMetadataScoped(exchange, method);  // RDR-156 P4
                 case "/search-topic-scoped"    -> handleSearchTopicScoped(exchange, method);     // RDR-156 P4
+                case "/search-graph-hop"       -> handleSearchGraphHop(exchange, method);        // RDR-156 P4 (houg9)
                 case "/store-put"     -> handleStorePut(exchange, method);
                 case "/get"           -> handleGet(exchange, method);
                 case "/store-get"     -> handleStoreGet(exchange, method);
@@ -308,6 +309,35 @@ public final class VectorHandler implements HttpHandler {
         int nResults      = optInt(body, "n_results", 10);
 
         var results = repo.searchTopicScoped(tenant, queryText, topicLabel, collection, nResults);
+        HttpUtil.send(ex, 200, json(results));
+    }
+
+    /**
+     * POST /v1/vectors/search-graph-hop (RDR-156 P4 follow-on, Decision 5, bead nexus-houg9).
+     *
+     * <p>The combined graph-hop query that retires the {@code query} tool's
+     * {@code follow_links} app-side BFS dance. Request:
+     * {@code {"query": "...", "seeds": [...], "collections": [...], "link_type": "cites",
+     * "depth": 1, "direction": "both", "n_results": 10}} — link_type may be omitted
+     * (follow all edge types); direction defaults to "both"; depth defaults to 1.
+     * Document-level rows, each carrying the matched chunk's {@code chash}.
+     */
+    private void handleSearchGraphHop(HttpExchange ex, String method) throws IOException {
+        requireMethod(ex, method, "POST");
+        var repo   = requirePgRepo(ex);
+        var tenant = requireTenant(ex);
+        Map<String, Object> body = readBody(ex);
+        String queryText         = requireString(body, "query");
+        List<String> seeds       = requireStringList(body, "seeds");
+        List<String> collections = requireStringList(body, "collections");
+        String linkType          = optString(body, "link_type");
+        int depth                = optInt(body, "depth", 1);
+        String direction         = optString(body, "direction");
+        if (direction == null) direction = "both";
+        int nResults             = optInt(body, "n_results", 10);
+
+        var results = repo.searchGraphHop(
+            tenant, queryText, seeds, collections, linkType, depth, direction, nResults);
         HttpUtil.send(ex, 200, json(results));
     }
 

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -856,6 +856,67 @@ public final class PgVectorRepository {
     }
 
     /**
+     * Graph-hop combined search (RDR-156 P4 follow-on, Decision 5, bead nexus-houg9).
+     *
+     * <p>Calls {@code nexus.search_graph_hop_<dim>} (catalog-007): a {@code WITH
+     * RECURSIVE} BFS over {@code nexus.catalog_links} from {@code seeds} to {@code depth}
+     * hops collects the reachable document set, which is joined to {@code chunks_<dim>}
+     * and vector-ranked. This retires the {@code query} tool's app-side {@code follow_links}
+     * dance ({@link dev.nexus.service.db.CatalogRepository#graphBFS} + per-collection
+     * search + re-join). Traversal semantics mirror {@code graphBFS} exactly: seeds are
+     * at depth 0 and included; {@code direction} is {@code "out"}/{@code "in"}/{@code "both"}
+     * (default {@code "both"}, matching {@code Catalog.graph}); a {@code null} link type
+     * follows all edge types. {@code depth} is clamped to [1,3] — the same bound graphBFS
+     * applies.
+     *
+     * <p>Returns the document tumbler as {@code id} (document-level, like
+     * {@link #searchMetadataScoped}) AND the matched chunk's {@code chash} (audit HIGH:
+     * the {@code query}-repoint populates the RDR-086 {@code chunk_text_hash} from this
+     * matched-chunk chash, never a per-doc manifest guess). A document with multiple
+     * matching chunks can appear more than once; consumer-side de-dup is the repoint's job.
+     *
+     * @param seeds     seed document tumblers to traverse from
+     * @param linkType  catalog link_type filter; null = follow all types
+     * @param depth     BFS depth (clamped to [1,3])
+     * @param direction "out" | "in" | "both"
+     */
+    public List<Map<String, Object>> searchGraphHop(
+            String tenant, String queryText, List<String> seeds, List<String> collectionNames,
+            String linkType, int depth, String direction, int nResults) {
+        if (seeds == null || seeds.isEmpty()
+                || collectionNames == null || collectionNames.isEmpty()) {
+            return List.of();
+        }
+        if (nResults < 1) {
+            throw new IllegalArgumentException("nResults must be >= 1, got " + nResults);
+        }
+        String dir = (direction == null || direction.isBlank()) ? "both" : direction;
+        if (!dir.equals("out") && !dir.equals("in") && !dir.equals("both")) {
+            throw new IllegalArgumentException(
+                "direction must be 'out', 'in', or 'both', got '" + direction + "'");
+        }
+        int clampedDepth = Math.min(Math.max(depth, 1), 3);  // mirror graphBFS bound
+        int dim = requireHomogeneousDim(collectionNames);
+        float[] queryVec = embedQuery(collectionNames.get(0), queryText, dim);
+
+        String sql = "SELECT id, content, collection, distance, chash"
+                   + " FROM nexus.search_graph_hop_" + dim
+                   + "(?::vector, ARRAY[" + placeholders(seeds.size()) + "]::text[],"
+                   + " ARRAY[" + placeholders(collectionNames.size()) + "]::text[],"
+                   + " ?::text, ?::int, ?::text, ?)";
+        List<Object> binds = new ArrayList<>();
+        binds.add(vectorLiteral(queryVec));
+        binds.addAll(seeds);
+        binds.addAll(collectionNames);
+        binds.add(linkType);
+        binds.add(clampedDepth);
+        binds.add(dir);
+        binds.add(nResults);
+
+        return runCombinedQueryWithChash(tenant, sql, binds);
+    }
+
+    /**
      * Validate every collection dispatches to the same dim and return it.
      * Mirrors the same-dim guard in {@link #search}.
      */
@@ -904,6 +965,30 @@ public final class PgVectorRepository {
             row.put("content",    rec.get("content", String.class));
             row.put("distance",   rec.get("distance", Double.class));
             row.put("collection", rec.get("collection", String.class));
+            rows.add(row);
+        }
+        return rows;
+    }
+
+    /**
+     * Like {@link #runCombinedQuery} but also maps the matched chunk's {@code chash}
+     * column (graph-hop, bead nexus-houg9). Kept separate because the metadata/topic
+     * functions do not expose chash — {@code rec.get("chash", ...)} would throw there.
+     */
+    private List<Map<String, Object>> runCombinedQueryWithChash(
+            String tenant, String sql, List<Object> binds) {
+        Result<Record> result = tenantScope.withTenant(tenant, ctx -> {
+            ctx.execute("SET LOCAL hnsw.iterative_scan = 'relaxed_order'");
+            return ctx.fetch(sql, binds.toArray());
+        });
+        List<Map<String, Object>> rows = new ArrayList<>(result.size());
+        for (Record rec : result) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("id",         rec.get("id", String.class));
+            row.put("content",    rec.get("content", String.class));
+            row.put("distance",   rec.get("distance", Double.class));
+            row.put("collection", rec.get("collection", String.class));
+            row.put("chash",      rec.get("chash", String.class));
             rows.add(row);
         }
         return rows;

--- a/service/src/main/resources/db/changelog/catalog-007-graph-hop-functions.xml
+++ b/service/src/main/resources/db/changelog/catalog-007-graph-hop-functions.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    RDR-156 P4 follow-on, bead nexus-houg9 — Decision 5 "graph-hop + rank" shape.
+
+    The third combined-query shape: the `query` MCP tool's `follow_links` graph dance
+    becomes a single SQL function. Today CatalogRepository.graphBFS walks
+    nexus.catalog_links app-side (breadth-first to depth N from seed tumblers), then the
+    caller searches each reachable document's collection and re-joins. Now that the
+    typed edge table (catalog_links) is co-resident with the vectors (chunks_<dim>) in
+    one Postgres (RDR-152/155), the whole traversal is SQL-expressible: a WITH RECURSIVE
+    BFS collects the reachable doc set, which is joined to chunks_<dim> and vector-ranked.
+
+    Structure (houg9 audit LOW): the reachable doc set is materialized FIRST (the
+    `reached` CTE), and the vector rank happens in the OUTER select — NOT inside the
+    recursive CTE. Ranking inside the recursion would defeat the HNSW index. A recursive
+    CTE makes the LANGUAGE sql function non-inlinable, so the planner shows a Function
+    Scan at the call site (accepted/expected per the audit); within the function the
+    outer rank still engages HNSW because the probe vector is a plan-time argument.
+
+    Traversal semantics mirror graphBFS exactly:
+      * seeds are at depth 0 and ARE included in the reachable set (graphBFS seeds the
+        visited set with the seeds, and returns them as nodes).
+      * direction 'out' follows from_tumbler→, 'in' follows →to_tumbler, 'both' either.
+        Default 'both' matches Catalog.graph's default (what query()'s follow_links uses).
+      * p_link_type NULL follows ALL edge types; a set value follows only that type.
+      * depth bound: a node reachable within p_depth hops is included; p_depth+1 is not.
+        UNION (not UNION ALL) + the `r.d < p_depth` guard makes the recursion cycle-safe
+        and terminating regardless of cycles in the graph.
+
+    Result contract (GraphHopParityTest): RETURNS TABLE(id text, content text, collection
+    text, distance float8, chash text). id is the document tumbler (document-level, like
+    search_metadata_scoped); content is the matched chunk text; distance is cosine (<=>);
+    chash is the MATCHED chunk's content hash — audit HIGH: the query()-repoint (rzqto)
+    populates the RDR-086 chunk_text_hash from this matched-chunk chash, never a per-doc
+    manifest guess. chunks_<dim>.chash is the caller-provided id, never recomputed.
+
+    LANGUAGE sql, STABLE, SECURITY INVOKER, NOT STRICT — same discipline as catalog-006.
+    SECURITY INVOKER means FORCE RLS on catalog_links / catalog_documents / chunks_<dim>
+    scopes the traversal AND the rank to the caller's tenant. NOT STRICT so a NULL
+    p_link_type (follow-all) does not null the whole result.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="catalog-007-1" author="nexus-houg9">
+        <comment>search_graph_hop_384: WITH RECURSIVE BFS over catalog_links → reached docs → chunks_384 vector rank</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE FUNCTION nexus.search_graph_hop_384(
+    p_query       vector(384),
+    p_seeds       text[],
+    p_collections text[],
+    p_link_type   text,
+    p_depth       int,
+    p_direction   text,
+    p_n           int
+) RETURNS TABLE(id text, content text, collection text, distance float8, chash text)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    WITH RECURSIVE reach(tumbler, d) AS (
+            SELECT s, 0 FROM unnest(p_seeds) AS s
+        UNION
+            SELECT CASE WHEN l.from_tumbler = r.tumbler THEN l.to_tumbler ELSE l.from_tumbler END,
+                   r.d + 1
+              FROM reach r
+              JOIN nexus.catalog_links l
+                ON ((p_direction = 'out'  AND l.from_tumbler = r.tumbler)
+                 OR (p_direction = 'in'   AND l.to_tumbler   = r.tumbler)
+                 OR (p_direction = 'both' AND (l.from_tumbler = r.tumbler OR l.to_tumbler = r.tumbler)))
+             WHERE r.d &lt; p_depth
+               AND (p_link_type IS NULL OR l.link_type = p_link_type)
+    ),
+    reached AS (SELECT DISTINCT tumbler FROM reach)
+    SELECT d.tumbler,
+           c.chunk_text,
+           c.collection,
+           (c.embedding &lt;=&gt; p_query)::float8,
+           c.chash
+      FROM nexus.chunks_384 c
+      JOIN nexus.catalog_document_chunks m
+        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d
+        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+      JOIN reached rd
+        ON rd.tumbler = d.tumbler
+     WHERE c.collection = ANY(p_collections)
+       AND d.deleted_at IS NULL
+     ORDER BY c.embedding &lt;=&gt; p_query
+     LIMIT p_n
+$$;
+        </sql>
+        <rollback>DROP FUNCTION IF EXISTS nexus.search_graph_hop_384(vector, text[], text[], text, int, text, int)</rollback>
+    </changeSet>
+
+    <changeSet id="catalog-007-2" author="nexus-houg9">
+        <comment>search_graph_hop_768</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE FUNCTION nexus.search_graph_hop_768(
+    p_query       vector(768),
+    p_seeds       text[],
+    p_collections text[],
+    p_link_type   text,
+    p_depth       int,
+    p_direction   text,
+    p_n           int
+) RETURNS TABLE(id text, content text, collection text, distance float8, chash text)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    WITH RECURSIVE reach(tumbler, d) AS (
+            SELECT s, 0 FROM unnest(p_seeds) AS s
+        UNION
+            SELECT CASE WHEN l.from_tumbler = r.tumbler THEN l.to_tumbler ELSE l.from_tumbler END,
+                   r.d + 1
+              FROM reach r
+              JOIN nexus.catalog_links l
+                ON ((p_direction = 'out'  AND l.from_tumbler = r.tumbler)
+                 OR (p_direction = 'in'   AND l.to_tumbler   = r.tumbler)
+                 OR (p_direction = 'both' AND (l.from_tumbler = r.tumbler OR l.to_tumbler = r.tumbler)))
+             WHERE r.d &lt; p_depth
+               AND (p_link_type IS NULL OR l.link_type = p_link_type)
+    ),
+    reached AS (SELECT DISTINCT tumbler FROM reach)
+    SELECT d.tumbler,
+           c.chunk_text,
+           c.collection,
+           (c.embedding &lt;=&gt; p_query)::float8,
+           c.chash
+      FROM nexus.chunks_768 c
+      JOIN nexus.catalog_document_chunks m
+        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d
+        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+      JOIN reached rd
+        ON rd.tumbler = d.tumbler
+     WHERE c.collection = ANY(p_collections)
+       AND d.deleted_at IS NULL
+     ORDER BY c.embedding &lt;=&gt; p_query
+     LIMIT p_n
+$$;
+        </sql>
+        <rollback>DROP FUNCTION IF EXISTS nexus.search_graph_hop_768(vector, text[], text[], text, int, text, int)</rollback>
+    </changeSet>
+
+    <changeSet id="catalog-007-3" author="nexus-houg9">
+        <comment>search_graph_hop_1024</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE FUNCTION nexus.search_graph_hop_1024(
+    p_query       vector(1024),
+    p_seeds       text[],
+    p_collections text[],
+    p_link_type   text,
+    p_depth       int,
+    p_direction   text,
+    p_n           int
+) RETURNS TABLE(id text, content text, collection text, distance float8, chash text)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    WITH RECURSIVE reach(tumbler, d) AS (
+            SELECT s, 0 FROM unnest(p_seeds) AS s
+        UNION
+            SELECT CASE WHEN l.from_tumbler = r.tumbler THEN l.to_tumbler ELSE l.from_tumbler END,
+                   r.d + 1
+              FROM reach r
+              JOIN nexus.catalog_links l
+                ON ((p_direction = 'out'  AND l.from_tumbler = r.tumbler)
+                 OR (p_direction = 'in'   AND l.to_tumbler   = r.tumbler)
+                 OR (p_direction = 'both' AND (l.from_tumbler = r.tumbler OR l.to_tumbler = r.tumbler)))
+             WHERE r.d &lt; p_depth
+               AND (p_link_type IS NULL OR l.link_type = p_link_type)
+    ),
+    reached AS (SELECT DISTINCT tumbler FROM reach)
+    SELECT d.tumbler,
+           c.chunk_text,
+           c.collection,
+           (c.embedding &lt;=&gt; p_query)::float8,
+           c.chash
+      FROM nexus.chunks_1024 c
+      JOIN nexus.catalog_document_chunks m
+        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d
+        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+      JOIN reached rd
+        ON rd.tumbler = d.tumbler
+     WHERE c.collection = ANY(p_collections)
+       AND d.deleted_at IS NULL
+     ORDER BY c.embedding &lt;=&gt; p_query
+     LIMIT p_n
+$$;
+        </sql>
+        <rollback>DROP FUNCTION IF EXISTS nexus.search_graph_hop_1024(vector, text[], text[], text, int, text, int)</rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -97,6 +97,17 @@
          (topics/topic_assignments). Contract: CombinedQueryParityTest (P4.1). -->
     <include file="db/changelog/catalog-006-combined-query-functions.xml"/>
 
+    <!-- Graph-hop combined-query function (bead nexus-houg9, RDR-156 P4 follow-on):
+         per-dim search_graph_hop_<dim> — a WITH RECURSIVE BFS over catalog_links collects
+         the reachable doc set, then joins chunks_<dim> and vector-ranks (Decision 5
+         "graph-hop + rank"). Retires the query() follow_links app-side graphBFS dance.
+         Recursive CTE is non-inlinable (Function Scan accepted); the reachable set is
+         materialized before the rank so HNSW survives the outer join. Returns the matched
+         chunk's chash (audit HIGH: rzqto populates RDR-086 chunk_text_hash from it).
+         Depends on catalog-001 (links/documents/manifest), catalog-003 (deleted_at),
+         vectors-001 (chunks_<dim>). Contract: GraphHopParityTest. -->
+    <include file="db/changelog/catalog-007-graph-hop-functions.xml"/>
+
     <!-- pgvector taxonomy centroids (bead nexus-t1hnc.1, RDR-156):
          taxonomy_centroids_384/768/1024 — moves the taxonomy__centroids ChromaDB
          collection into Postgres so service-mode taxonomy compute is chroma-free.

--- a/service/src/test/java/dev/nexus/service/GraphHopParityIntegrationTest.java
+++ b/service/src/test/java/dev/nexus/service/GraphHopParityIntegrationTest.java
@@ -74,6 +74,15 @@ class GraphHopParityIntegrationTest {
     private static final String LINK   = "cites";
     private static final int DEPTH     = 2;
 
+    // Branching fixture (collection COLL2) for the reachable-set equivalence sweep: a
+    // diamond + inbound + cross-type + cycle topology that DISCRIMINATES a wrong
+    // direction/CASE impl. Every doc shares a probe word so vector search returns the
+    // whole set and the GRAPH gate is the sole discriminator (K large → no truncation,
+    // so the assertion is reachable-set equality, not vector-order).
+    private static final String COLL2  = "knowledge__ghparity2__minilm-l6-v2-384__v1";
+    private static final String B_SEED = "b-a";
+    private static final String B_PROBE = "alpha bravo";   // present in every COLL2 doc
+
     private static final int GH_SIZE = Integer.getInteger("nx.ghparity.size", 60);
     private static final int K        = Integer.getInteger("nx.ghparity.k", 10);
     private static final String TOMB_TUMBLER = "gh-doc-tombstoned";
@@ -96,6 +105,7 @@ class GraphHopParityIntegrationTest {
 
     final List<GhDoc> docs = new ArrayList<>();
     final List<String> queries = new ArrayList<>();
+    final List<String> branchTumblers = new ArrayList<>();   // COLL2 doc tumblers
 
     @BeforeAll
     void startAll() throws Exception {
@@ -208,6 +218,62 @@ class GraphHopParityIntegrationTest {
                 + "', 'test') ON CONFLICT DO NOTHING");
             // UNREACH_TUMBLER intentionally has NO edges.
         }
+
+        seedBranchingFixture();
+    }
+
+    /**
+     * Diamond + inbound + cross-type + cycle topology in COLL2, every doc sharing
+     * B_PROBE so the vector leg returns all of them and the GRAPH is the discriminator:
+     * <pre>
+     *   b-x --cites--> b-a            (inbound to the seed)
+     *   b-a --cites--> b-b, b-c       (fan-out)
+     *   b-b --cites--> b-d            (diamond left)
+     *   b-c --cites--> b-d            (diamond merge — reached via two paths)
+     *   b-d --cites--> b-e            (depth chain)
+     *   b-b --relates-> b-c           (cross edge, DIFFERENT type)
+     *   b-e --cites--> b-b            (cycle b-b→b-d→b-e→b-b)
+     *   b-z                           (isolated — unreachable)
+     * </pre>
+     */
+    private void seedBranchingFixture() throws Exception {
+        String[] names = {"b-x", "b-a", "b-b", "b-c", "b-d", "b-e", "b-z"};
+        List<String> chashes = new ArrayList<>();
+        List<String> texts = new ArrayList<>();
+        for (String n : names) {
+            branchTumblers.add(n);
+            chashes.add(sha256Hex32("bchash-" + n));
+            texts.add(B_PROBE + " " + n.replace("-", ""));
+        }
+        pgRepo.upsertChunks(TENANT, COLL2, chashes, texts,
+            texts.stream().map(t -> Map.<String, Object>of()).toList());
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            for (int i = 0; i < names.length; i++) {
+                su.createStatement().execute(
+                    "INSERT INTO nexus.catalog_documents "
+                    + "(tenant_id, tumbler, title, author, content_type, physical_collection) "
+                    + "VALUES ('" + TENANT + "', '" + names[i] + "', 'Doc', 'ada', 'paper', '"
+                    + COLL2 + "') ON CONFLICT (tenant_id, tumbler) DO NOTHING");
+                su.createStatement().execute(
+                    "INSERT INTO nexus.catalog_document_chunks "
+                    + "(tenant_id, doc_id, position, chash, collection) "
+                    + "VALUES ('" + TENANT + "', '" + names[i] + "', 0, '" + chashes.get(i)
+                    + "', '" + COLL2 + "') ON CONFLICT (tenant_id, doc_id, position) DO NOTHING");
+            }
+            String[][] edges = {
+                {"b-x", "b-a", "cites"}, {"b-a", "b-b", "cites"}, {"b-a", "b-c", "cites"},
+                {"b-b", "b-d", "cites"}, {"b-c", "b-d", "cites"}, {"b-d", "b-e", "cites"},
+                {"b-b", "b-c", "relates"}, {"b-e", "b-b", "cites"},
+            };
+            for (String[] e : edges) {
+                su.createStatement().execute(
+                    "INSERT INTO nexus.catalog_links "
+                    + "(tenant_id, from_tumbler, to_tumbler, link_type, created_by) "
+                    + "VALUES ('" + TENANT + "', '" + e[0] + "', '" + e[1] + "', '" + e[2]
+                    + "', 'test') ON CONFLICT DO NOTHING");
+            }
+        }
     }
 
     @Test
@@ -304,6 +370,78 @@ class GraphHopParityIntegrationTest {
             assertThat((String) r.get("chash"))
                 .as("row %s chash must be its matched chunk's chash", r.get("id"))
                 .isEqualTo(tumblerToChash.get((String) r.get("id")));
+        }
+    }
+
+    @Test
+    void graphHop_reachableSetEqualsGraphBFS_acrossDirectionsAndTopology() {
+        // The genuine cross-impl equivalence proof the unit GROUP-9 in-SQL oracle can't
+        // give: the function's reachable set MUST equal the real Java graphBFS's visited
+        // set across directions ('out'/'in'/'both'), depths (1..3) over a diamond + cycle
+        // + cross-type topology, and link-type filtering (null = all types). K is large
+        // so there is no top-K truncation — the assertion is reachable-set equality, not
+        // vector ordering. This is where a wrong direction CASE / over- or under-reach
+        // would surface (it does not for cites/out/linear-chain alone).
+        int bigK = branchTumblers.size() + 5;
+        String[] directions = {"out", "in", "both"};
+        // null linkType = follow all edge types (graphBFS: empty linkTypes list).
+        String[] linkTypes = {"cites", null};
+        Map<String, String> tumblerToChash = docs2Chashes();
+
+        for (String linkType : linkTypes) {
+            List<String> bfsTypes = linkType == null ? List.of() : List.of(linkType);
+            for (String dir : directions) {
+                for (int depth = 1; depth <= 3; depth++) {
+                    // Oracle: production graphBFS reachable tumblers (all live here).
+                    @SuppressWarnings("unchecked")
+                    List<Map<String, Object>> nodes = (List<Map<String, Object>>) catRepo
+                        .graphBFS(TENANT, List.of(B_SEED), bfsTypes, dir, depth).get("nodes");
+                    Set<String> bfsReachable = nodes.stream()
+                        .map(n -> (String) n.get("tumbler"))
+                        .filter(tumblerToChash::containsKey)   // COLL2 docs only
+                        .collect(Collectors.toSet());
+
+                    // Function: returned tumblers (deduped — single-chunk fixture).
+                    Set<String> fnReachable = new java.util.HashSet<>(ids(pgRepo.searchGraphHop(
+                        TENANT, B_PROBE, List.of(B_SEED), List.of(COLL2),
+                        linkType, depth, dir, bigK)));
+
+                    assertThat(fnReachable)
+                        .as("reachable set divergence: linkType=%s dir=%s depth=%d — "
+                            + "search_graph_hop must equal graphBFS. fn=%s bfs=%s",
+                            linkType, dir, depth, fnReachable, bfsReachable)
+                        .isEqualTo(bfsReachable);
+                }
+            }
+        }
+        // Non-vacuity: the topology genuinely varies with direction/depth (otherwise the
+        // sweep above could pass trivially on a constant set).
+        Set<String> out1 = new java.util.HashSet<>(ids(pgRepo.searchGraphHop(
+            TENANT, B_PROBE, List.of(B_SEED), List.of(COLL2), "cites", 1, "out", bigK)));
+        Set<String> out3 = new java.util.HashSet<>(ids(pgRepo.searchGraphHop(
+            TENANT, B_PROBE, List.of(B_SEED), List.of(COLL2), "cites", 3, "out", bigK)));
+        assertThat(out3).as("depth 3 must reach strictly more than depth 1 (diamond+chain)")
+            .containsAll(out1).hasSizeGreaterThan(out1.size());
+        Set<String> in1 = new java.util.HashSet<>(ids(pgRepo.searchGraphHop(
+            TENANT, B_PROBE, List.of(B_SEED), List.of(COLL2), "cites", 1, "in", bigK)));
+        assertThat(in1).as("direction 'in' from b-a reaches the inbound b-x")
+            .contains("b-x").doesNotContain("b-b");
+        assertThat(out1).as("direction 'out' from b-a reaches b-b, not the inbound b-x")
+            .contains("b-b").doesNotContain("b-x");
+    }
+
+    /** Tumbler→chash map for the COLL2 branching docs. */
+    private Map<String, String> docs2Chashes() {
+        Map<String, String> m = new java.util.HashMap<>();
+        for (String t : branchTumblers) m.put(t, sha256HexUnchecked("bchash-" + t));
+        return m;
+    }
+
+    private static String sha256HexUnchecked(String seed) {
+        try {
+            return sha256Hex32(seed);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
         }
     }
 

--- a/service/src/test/java/dev/nexus/service/GraphHopParityIntegrationTest.java
+++ b/service/src/test/java/dev/nexus/service/GraphHopParityIntegrationTest.java
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.nexus.service.db.CatalogRepository;
+import dev.nexus.service.db.TenantScope;
+import dev.nexus.service.vectors.EmbedderRouter;
+import dev.nexus.service.vectors.OnnxEmbedder;
+import dev.nexus.service.vectors.PgVectorRepository;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RDR-156 P4 follow-on (bead nexus-houg9): corpus-scale function-vs-app-stitch parity for
+ * the graph-hop combined query {@code nexus.search_graph_hop_<dim>} (catalog-007).
+ *
+ * <p>The graph-hop function collapses the {@code query} tool's {@code follow_links} dance
+ * into one statement. This suite proves it returns the SAME top-k documents as the
+ * multi-step app stitch it retires, where the stitch uses the PRODUCTION
+ * {@link CatalogRepository#graphBFS} (the very app-side BFS the function replaces) for the
+ * reachable-set leg, then the production {@link PgVectorRepository#search} for the vector
+ * leg, then an app-side filter+rerank. So the comparison is genuinely function-vs-stitch,
+ * NOT function-vs-itself (the gap a same-engine SQL oracle leaves open — the unit
+ * {@link GraphHopParityTest} parity group uses an in-SQL oracle; this closes it against
+ * the real Java graphBFS).
+ *
+ * <p>Built as a focused sibling (not a DualRunHarness extension) for the same reason as
+ * {@link CombinedQueryParityIntegrationTest}: the harness's Chroma baseline leg is
+ * unrelated to combined-query parity and can't embed the minilm token in a minilm-only
+ * router (nexus-i055u). Graph-hop parity is pgvector-only: function vs app-stitch on the
+ * same store.
+ *
+ * <p><strong>Non-vacuity:</strong> the fixture plants a vector-CLOSEST but graph-UNREACHABLE
+ * doc and a tombstoned reachable doc whose text matches a probe; both the stitch and the
+ * function must exclude them. A function that ignored the graph (ranked the whole
+ * collection) or dropped {@code deleted_at IS NULL} would diverge.
+ *
+ * <p><strong>Scale boundary:</strong> validates correctness at fixture scale (default 60
+ * docs); the HNSW recall property (Finding 5b) is conexus xr7.8.9, not here.
+ *
+ * <p>Real ONNX MiniLM embeddings, deterministic seed. Requires Docker + ONNX MiniLM cache.
+ * Run: {@code mvn test -Dtest=GraphHopParityIntegrationTest -Dtest.excluded.groups="" -Dgroups=integration}.
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GraphHopParityIntegrationTest {
+
+    private static final String TENANT = "ghparity-tenant";
+    private static final String COLL   = "knowledge__ghparity__minilm-l6-v2-384__v1";
+    private static final String SEED   = "gh-doc-0";
+    private static final String LINK   = "cites";
+    private static final int DEPTH     = 2;
+
+    private static final int GH_SIZE = Integer.getInteger("nx.ghparity.size", 60);
+    private static final int K        = Integer.getInteger("nx.ghparity.k", 10);
+    private static final String TOMB_TUMBLER = "gh-doc-tombstoned";
+    private static final String UNREACH_TUMBLER = "gh-doc-unreachable";
+
+    private static final List<String> WORD_BANK = List.of(
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+        "india", "juliet", "kilo", "lima", "mike", "november", "oscar", "papa",
+        "quebec", "romeo", "sierra", "tango", "uniform", "victor", "whiskey",
+        "yankee", "zulu", "cobalt", "quartz", "falcon", "harbor", "lantern");
+
+    record GhDoc(String tumbler, String chash, String text, boolean tombstoned) {}
+
+    PostgreSQLContainer<?> pg;
+    HikariDataSource svcDs;
+    TenantScope tenantScope;
+    OnnxEmbedder onnx;
+    PgVectorRepository pgRepo;
+    CatalogRepository catRepo;
+
+    final List<GhDoc> docs = new ArrayList<>();
+    final List<String> queries = new ArrayList<>();
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') "
+                + "THEN CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; "
+                + "END IF; END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            Database db = DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(su));
+            try (Liquibase lb = new Liquibase("db/changelog/db.changelog-master.xml",
+                    new ClassLoaderResourceAccessor(), db)) {
+                lb.update(new Contexts());
+            }
+        }
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("ALTER ROLE nexus_svc SET search_path TO nexus, public");
+        }
+        var cfg = new HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername("nexus_svc");
+        cfg.setPassword("nexus_svc_pass");
+        cfg.setMaximumPoolSize(5);
+        cfg.setAutoCommit(true);
+        svcDs = new HikariDataSource(cfg);
+        tenantScope = new TenantScope(svcDs);
+
+        onnx = new OnnxEmbedder();
+        EmbedderRouter docRouter = new EmbedderRouter(onnx, "document");
+        EmbedderRouter queryRouter = new EmbedderRouter(onnx, "query");
+        pgRepo = new PgVectorRepository(tenantScope, docRouter, queryRouter);
+        catRepo = new CatalogRepository(tenantScope);
+
+        seedFixtures();
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (onnx  != null) onnx.close();
+        if (svcDs != null) svcDs.close();
+        if (pg    != null) pg.stop();
+    }
+
+    /**
+     * Linear cites chain gh-doc-0 → gh-doc-1 → … (each cites the next), so depth-2 BFS
+     * from the seed reaches docs 0,1,2. Plus an UNREACHABLE doc (no edges) whose text ==
+     * a probe (vector-closest, graph-excluded) and a TOMBSTONED reachable doc.
+     */
+    private void seedFixtures() throws Exception {
+        Random rnd = new Random(20260614L);
+        for (int d = 0; d < GH_SIZE; d++) {
+            int len = 8 + rnd.nextInt(5);
+            Set<String> words = new LinkedHashSet<>();
+            while (words.size() < len) words.add(WORD_BANK.get(rnd.nextInt(WORD_BANK.size())));
+            docs.add(new GhDoc("gh-doc-" + d, sha256Hex32("gh-chash-" + d),
+                String.join(" ", words) + " ghdoc" + d, false));
+        }
+        // Probes drawn from the FIRST THREE docs' words (the depth-2 reachable set), so
+        // the stitch surfaces reachable docs and parity is meaningful.
+        for (int q = 0; q < 3; q++) {
+            String[] w = docs.get(q).text().split(" ");
+            queries.add(w[0] + " " + w[1]);
+        }
+        // Unreachable doc: text == queries.get(0) → vector top match, but NO edges, so
+        // graphBFS never reaches it. Both stitch and function must exclude it.
+        docs.add(new GhDoc(UNREACH_TUMBLER, sha256Hex32("gh-unreach"), queries.get(0), false));
+        // Tombstoned reachable doc: linked into the chain (so graph-reachable) but
+        // deleted_at set; text == queries.get(0) so it would top-rank if the guard missed.
+        docs.add(new GhDoc(TOMB_TUMBLER, sha256Hex32("gh-tomb"), queries.get(0), true));
+
+        pgRepo.upsertChunks(TENANT, COLL,
+            docs.stream().map(GhDoc::chash).toList(),
+            docs.stream().map(GhDoc::text).toList(),
+            docs.stream().map(c -> Map.<String, Object>of()).toList());
+
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            for (GhDoc c : docs) {
+                su.createStatement().execute(
+                    "INSERT INTO nexus.catalog_documents "
+                    + "(tenant_id, tumbler, title, author, content_type, physical_collection, deleted_at) "
+                    + "VALUES ('" + TENANT + "', '" + c.tumbler() + "', 'Doc', 'ada', 'paper', '"
+                    + COLL + "', " + (c.tombstoned() ? "now()" : "NULL") + ") "
+                    + "ON CONFLICT (tenant_id, tumbler) DO NOTHING");
+                su.createStatement().execute(
+                    "INSERT INTO nexus.catalog_document_chunks "
+                    + "(tenant_id, doc_id, position, chash, collection) "
+                    + "VALUES ('" + TENANT + "', '" + c.tumbler() + "', 0, '" + c.chash()
+                    + "', '" + COLL + "') ON CONFLICT (tenant_id, doc_id, position) DO NOTHING");
+            }
+            // cites chain gh-doc-0 → 1 → 2 → 3 … across the whole numbered range.
+            for (int d = 0; d < GH_SIZE - 1; d++) {
+                su.createStatement().execute(
+                    "INSERT INTO nexus.catalog_links "
+                    + "(tenant_id, from_tumbler, to_tumbler, link_type, created_by) "
+                    + "VALUES ('" + TENANT + "', 'gh-doc-" + d + "', 'gh-doc-" + (d + 1)
+                    + "', '" + LINK + "', 'test') ON CONFLICT DO NOTHING");
+            }
+            // Tombstoned doc is reachable: link gh-doc-1 → tombstoned (1 hop from a
+            // depth-1 node → within depth 2).
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_links "
+                + "(tenant_id, from_tumbler, to_tumbler, link_type, created_by) "
+                + "VALUES ('" + TENANT + "', 'gh-doc-1', '" + TOMB_TUMBLER + "', '" + LINK
+                + "', 'test') ON CONFLICT DO NOTHING");
+            // UNREACH_TUMBLER intentionally has NO edges.
+        }
+    }
+
+    @Test
+    void graphHop_parityWithAppStitch() {
+        Map<String, String> chashToTumbler = docs.stream()
+            .collect(Collectors.toMap(GhDoc::chash, GhDoc::tumbler));
+        Map<String, String> tumblerToChash = docs.stream()
+            .collect(Collectors.toMap(GhDoc::tumbler, GhDoc::chash));
+
+        for (String q : queries) {
+            // ── App stitch leg 1: production graphBFS for the reachable doc set. ──
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> nodes = (List<Map<String, Object>>) catRepo
+                .graphBFS(TENANT, List.of(SEED), List.of(LINK), "out", DEPTH).get("nodes");
+            // Reachable, LIVE tumblers (graphBFS returns docRows incl. tombstoned; the
+            // function tombstone-filters, so the oracle must too).
+            Set<String> reachableLiveChashes = nodes.stream()
+                .map(n -> (String) n.get("tumbler"))
+                .filter(t -> tumblerToChash.containsKey(t))
+                .filter(t -> docs.stream().noneMatch(d -> d.tumbler().equals(t) && d.tombstoned()))
+                .map(tumblerToChash::get)
+                .collect(Collectors.toSet());
+
+            // ── App stitch leg 2: production vector search → keep reachable → top-K. ──
+            List<String> stitched = new ArrayList<>();
+            for (Map<String, Object> r : pgRepo.search(TENANT, q, List.of(COLL), GH_SIZE, null)) {
+                if (reachableLiveChashes.contains((String) r.get("id"))) {
+                    stitched.add(chashToTumbler.get((String) r.get("id")));
+                    if (stitched.size() == K) break;
+                }
+            }
+
+            // ── Combined: one function call, document-level tumblers, top-K. ──
+            List<String> combined = ids(pgRepo.searchGraphHop(
+                TENANT, q, List.of(SEED), List.of(COLL), LINK, DEPTH, "out", K));
+
+            assertThat(stitched)
+                .as("non-vacuity: the app stitch must surface reachable docs for '%s'", q)
+                .isNotEmpty();
+            assertThat(combined)
+                .as("graph-hop for '%s' must equal the app-stitch (graphBFS + search) "
+                    + "top-%d docs. combined=%s stitched=%s", q, K, combined, stitched)
+                .containsExactlyInAnyOrderElementsOf(stitched);
+            // The graph-excluded vector-closest doc must appear in NEITHER.
+            assertThat(combined).as("unreachable doc must be excluded for '%s'", q)
+                .doesNotContain(UNREACH_TUMBLER);
+        }
+    }
+
+    @Test
+    void graphHop_excludesUnreachableTopRankedDoc() {
+        // UNREACH_TUMBLER's text == queries.get(0) → it is a top vector match, yet it has
+        // no edges so graphBFS never reaches it. A function that ranked the whole
+        // collection (ignoring the graph) would surface it → divergence.
+        String q = queries.get(0);
+        String unreachChash = docs.stream().filter(d -> d.tumbler().equals(UNREACH_TUMBLER))
+            .findFirst().orElseThrow().chash();
+        List<String> rawIds = ids(pgRepo.search(TENANT, q, List.of(COLL), GH_SIZE, null));
+        assertThat(rawIds)
+            .as("precondition: the unreachable doc IS a top vector match for its own text")
+            .contains(unreachChash);
+
+        List<String> combined = ids(pgRepo.searchGraphHop(
+            TENANT, q, List.of(SEED), List.of(COLL), LINK, DEPTH, "out", K));
+        assertThat(combined)
+            .as("graph-hop must EXCLUDE the vector-closest but graph-UNREACHABLE doc — "
+                + "proves the traversal gate is load-bearing, not a vector passthrough")
+            .doesNotContain(UNREACH_TUMBLER);
+    }
+
+    @Test
+    void graphHop_excludesTombstonedReachableDoc() {
+        // TOMB_TUMBLER is graph-reachable (gh-doc-1 → it) AND a top vector match for
+        // queries.get(0), but tombstoned — the deleted_at IS NULL guard must drop it.
+        String q = queries.get(0);
+        List<String> combined = ids(pgRepo.searchGraphHop(
+            TENANT, q, List.of(SEED), List.of(COLL), LINK, DEPTH, "out", K));
+        assertThat(combined)
+            .as("graph-hop must EXCLUDE the reachable-but-tombstoned doc despite a top "
+                + "vector match — proves deleted_at IS NULL fires on the graph path too")
+            .doesNotContain(TOMB_TUMBLER);
+    }
+
+    @Test
+    void graphHop_chashIsMatchedChunkChash() {
+        // Audit HIGH: every returned row's chash is the matched chunk's chash (the value
+        // rzqto wires into chunk_text_hash), i.e. the chash we seeded for that tumbler.
+        Map<String, String> tumblerToChash = docs.stream()
+            .collect(Collectors.toMap(GhDoc::tumbler, GhDoc::chash));
+        List<Map<String, Object>> rows = pgRepo.searchGraphHop(
+            TENANT, queries.get(0), List.of(SEED), List.of(COLL), LINK, DEPTH, "out", K);
+        assertThat(rows).isNotEmpty();
+        for (Map<String, Object> r : rows) {
+            assertThat((String) r.get("chash"))
+                .as("row %s chash must be its matched chunk's chash", r.get("id"))
+                .isEqualTo(tumblerToChash.get((String) r.get("id")));
+        }
+    }
+
+    private static List<String> ids(List<Map<String, Object>> rows) {
+        return rows.stream().map(r -> (String) r.get("id")).toList();
+    }
+
+    private static String sha256Hex32(String seed) throws Exception {
+        byte[] h = java.security.MessageDigest.getInstance("SHA-256")
+            .digest(seed.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        StringBuilder sb = new StringBuilder(64);
+        for (byte b : h) sb.append(String.format("%02x", b));
+        return sb.substring(0, 32);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/GraphHopParityTest.java
+++ b/service/src/test/java/dev/nexus/service/GraphHopParityTest.java
@@ -479,9 +479,16 @@ class GraphHopParityTest {
 
     @Test @Order(100)
     void explain_reachedThenRank_usesHnswIndex_notSeqScan() throws Exception {
-        // The outer shape the function uses once `reached` is materialized: rank the
-        // chunks of the reached doc set. Modelled here with the reached set sourced from
-        // the (non-recursive) star edges, so the probe vector stays a plan-time literal.
+        // SCOPE: this EXPLAINs the OUTER materialize-then-rank shape in isolation (the
+        // reached set sourced from a non-recursive subquery), NOT a call to
+        // nexus.search_graph_hop_1024 — that call is an opaque Function Scan (the
+        // recursive CTE is non-inlinable), so EXPLAIN of the call site reveals nothing
+        // about the inner rank. What this proves: ranking the reached set OUTSIDE the
+        // recursion keeps the probe vector a plan-time literal so HNSW is reachable (the
+        // audit's structural decision). It does NOT prove the planner picks HNSW for the
+        // real function call at corpus scale — that recall/latency gate is conexus
+        // xr7.8.9 / nexus-0zcn9, deferred per the houg9 audit. The disabled GUCs force
+        // reachability, not representativeness.
         String inner =
             "SELECT d.tumbler " +
             "  FROM nexus.chunks_1024 c " +
@@ -556,8 +563,13 @@ class GraphHopParityTest {
      * Reachable-set-then-rank oracle: a recursive BFS over catalog_links (the explicit
      * traversal {@link dev.nexus.service.db.CatalogRepository#graphBFS} does app-side),
      * then a raw vector rank over the reachable docs' chunks. Tombstone-filtered.
-     * Written as the literal SQL the app-stitch is equivalent to, so parity is a real
-     * cross-check, not a copy of the function body.
+     * NOTE: this oracle is an algorithmic ALIAS of the function body (same recursive
+     * CTE shape), so it pins the materialize-then-rank contract but is NOT an independent
+     * traversal check — a shared error in the direction CASE would pass here. The
+     * INDEPENDENT cross-impl oracle is {@code GraphHopParityIntegrationTest}, which
+     * compares the function against the real Java {@code CatalogRepository.graphBFS}
+     * across directions/topologies. Keep both: this for fast in-memory SQL contract,
+     * that for genuine function-vs-app-stitch equivalence.
      */
     private List<String> stitchedGraphOracle(Connection conn, int dim, String collection,
                                              String seed, String linkType, int depth,
@@ -572,7 +584,8 @@ class GraphHopParityTest {
             "  UNION " +
             "    SELECT CASE WHEN l.from_tumbler = r.tumbler THEN l.to_tumbler ELSE l.from_tumbler END, r.d + 1 " +
             "    FROM reach r JOIN nexus.catalog_links l ON " + dirPred + " " +
-            "    WHERE r.d < " + depth + " AND l.link_type = " + sqlText(linkType) +
+            "    WHERE r.d < " + depth +
+            "      AND (" + sqlText(linkType) + " IS NULL OR l.link_type = " + sqlText(linkType) + ") " +
             "), reached AS (SELECT DISTINCT tumbler FROM reach) " +
             "SELECT d.tumbler AS id " +
             "  FROM nexus.chunks_" + dim + " c " +

--- a/service/src/test/java/dev/nexus/service/GraphHopParityTest.java
+++ b/service/src/test/java/dev/nexus/service/GraphHopParityTest.java
@@ -1,0 +1,675 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package dev.nexus.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * RDR-156 P4 follow-on, bead nexus-houg9 — contract suite for the graph-hop combined
+ * query function {@code nexus.search_graph_hop_<dim>} (catalog-007, Decision 5
+ * "graph-hop + rank").
+ *
+ * <p>The graph-hop shape retires the {@code query} MCP tool's app-side
+ * {@code follow_links} dance: today {@link dev.nexus.service.db.CatalogRepository#graphBFS}
+ * does breadth-first traversal app-side, then the caller searches each reachable
+ * document's collection and re-joins. catalog-007 folds the whole thing into ONE
+ * planner-optimizable SQL function: a {@code WITH RECURSIVE} BFS over
+ * {@code nexus.catalog_links} (the typed edge table) collects the reachable doc set,
+ * which is then joined to {@code chunks_<dim>} and vector-ranked.
+ *
+ * <p>Contract pins (RED until catalog-007 + the PgVectorRepository method land):
+ * <ul>
+ *   <li><strong>Signature</strong> — GROUP 1: query vector is the FIRST argument,
+ *       typed {@code vector} (Finding 5a), and the result table carries the matched
+ *       chunk's {@code chash} as an output column (audit HIGH: rzqto populates the
+ *       RDR-086 {@code chunk_text_hash} from the MATCHED chunk, never a per-doc guess).</li>
+ *   <li><strong>Depth-bound BFS</strong> — GROUP 2: depth=1 returns seeds + 1-hop only
+ *       (no N+1 leak); depth=2 adds the 2-hop layer. Mirrors graphBFS's
+ *       {@code maxDepth} contract.</li>
+ *   <li><strong>link_type / direction filters</strong> — GROUP 3: a NULL link_type
+ *       follows all edges; a set link_type follows only those; direction in/out/both
+ *       matches {@code Catalog.graph}'s default ("both") and graphBFS's dirCond.</li>
+ *   <li><strong>Cycle safety</strong> — GROUP 4: a cyclic edge set terminates and the
+ *       reachable set is the BFS-visited set (each node once).</li>
+ *   <li><strong>Vector rank + tombstone + RLS + per-dim</strong> — GROUPs 5-8, mirroring
+ *       {@link CombinedQueryParityTest}.</li>
+ *   <li><strong>Parity vs the app-stitch</strong> — GROUP 9: the function equals the
+ *       reachable-set-then-rank oracle EXACTLY, ordering included, with a non-vacuity
+ *       guard (a wrong impl that ignores the graph would surface the unreachable
+ *       vector-closer doc g4).</li>
+ *   <li><strong>EXPLAIN</strong> — GROUP 10: the materialize-reached-then-rank shape
+ *       engages the HNSW index (the recursive-CTE function itself is non-inlinable —
+ *       Function Scan at the call site is ACCEPTED per the audit; what must hold is
+ *       that ranking the reached set OUTSIDE the recursive CTE keeps HNSW usable).</li>
+ * </ul>
+ *
+ * <p>Graph fixture (COLL_G, 1024-dim), query probe (1,0), cosine distance = 1 - x:
+ * <pre>
+ *   doc   embedding   dist   edges
+ *   g0    (1.0,0.0)   0.0    --cites-->g1, --relates-->g3   (seed)
+ *   g1    (0.8,0.6)   0.2    --cites-->g2
+ *   g2    (0.6,0.8)   0.4    --cites-->g1   (cycle g1<->g2)
+ *   g3    (0.0,1.0)   1.0
+ *   g4    (-1.0,0.0)  2.0    (UNREACHABLE — non-vacuity guard: closest after g0? no, farthest;
+ *                             gin is the discriminator instead)
+ *   gin   (0.96,0.28) ~0.04  --cites-->g0   (INBOUND to g0)
+ * </pre>
+ * cites/out/depth1 from g0 → {g0,g1}; depth2 → {g0,g1,g2}; all-types/out/depth1 →
+ * {g0,g1,g3}; cites/in/depth1 → {g0,gin}; cites/both/depth1 → {g0,g1,gin}.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class GraphHopParityTest {
+
+    // ── Tenant IDs ────────────────────────────────────────────────────────────
+    private static final String TENANT_A = "ghp-tenant-a";
+    private static final String TENANT_B = "ghp-tenant-b";
+
+    // ── Svc role (NOSUPERUSER, NOBYPASSRLS — subject to FORCE RLS) ───────────
+    private static final String SVC_ROLE = "svc_ghp_test";
+    private static final String SVC_PASS = "svc_ghp_test_pass";
+
+    // ── Collections (conformant <type>__<owner>__<model>__<version>) ─────────
+    private static final String COLL_G     = "knowledge__ghp-graph__voyage-context-3__v1";   // 1024
+    private static final String COLL_G_384 = "knowledge__ghp-graph384__minilm-l6-v2-384__v1"; // 384
+    private static final String COLL_B     = "knowledge__ghp-b__voyage-context-3__v1";        // 1024, tenant B
+    private static final String COLL_EXPLAIN = "knowledge__ghp-explain__voyage-context-3__v1"; // 1024
+    private static final int    EXPLAIN_ROWS = 500;
+
+    PostgreSQLContainer<?> pg;
+    com.zaxxer.hikari.HikariDataSource svcDs;
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // LIFECYCLE
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
+                "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '" + SVC_ROLE + "') THEN " +
+                "    CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+        }
+
+        try (Connection su = pg.createConnection("")) {
+            var lb = new Liquibase(
+                "db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(
+                    new JdbcConnection(su)));
+            lb.update(new Contexts());
+        }
+
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            for (String tbl : List.of(
+                    "catalog_collections", "catalog_documents", "catalog_document_chunks",
+                    "catalog_links", "chunks_384", "chunks_768", "chunks_1024")) {
+                su.createStatement().execute(
+                    "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus." + tbl + " TO " + SVC_ROLE);
+            }
+            su.createStatement().execute("GRANT USAGE ON ALL SEQUENCES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+        }
+
+        var cfg = new com.zaxxer.hikari.HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(4);
+        cfg.setAutoCommit(true);
+        svcDs = new com.zaxxer.hikari.HikariDataSource(cfg);
+
+        seedFixtures();
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (svcDs != null) svcDs.close();
+        if (pg != null)    pg.stop();
+    }
+
+    private void seedFixtures() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+
+            // ----- graph fixture (1024) -----
+            insertCollection(su, TENANT_A, COLL_G);
+            seedDoc(su, 1024, COLL_G, "g0",  1.0,  0.0);
+            seedDoc(su, 1024, COLL_G, "g1",  0.8,  0.6);
+            seedDoc(su, 1024, COLL_G, "g2",  0.6,  0.8);
+            seedDoc(su, 1024, COLL_G, "g3",  0.0,  1.0);
+            seedDoc(su, 1024, COLL_G, "g4", -1.0,  0.0);
+            seedDoc(su, 1024, COLL_G, "gin", 0.96, 0.28);
+            link(su, TENANT_A, "g0", "g1", "cites");
+            link(su, TENANT_A, "g1", "g2", "cites");
+            link(su, TENANT_A, "g2", "g1", "cites");   // cycle g1<->g2
+            link(su, TENANT_A, "g0", "g3", "relates");
+            link(su, TENANT_A, "gin", "g0", "cites");  // inbound to g0
+            // g4 has NO edges — unreachable from g0 by any path.
+
+            // ----- graph fixture (384) for per-dim dispatch -----
+            insertCollection(su, TENANT_A, COLL_G_384);
+            seedDoc(su, 384, COLL_G_384, "h0", 1.0, 0.0);
+            seedDoc(su, 384, COLL_G_384, "h1", 0.8, 0.6);
+            link(su, TENANT_A, "h0", "h1", "cites");
+
+            // ----- tenant-B fixture (1024) for RLS group -----
+            insertCollection(su, TENANT_B, COLL_B);
+            seedDoc(su, 1024, COLL_B, "b0", 1.0, 0.0);
+            seedDoc(su, 1024, COLL_B, "b1", 0.8, 0.6);
+            link(su, TENANT_B, "b0", "b1", "cites");
+
+            // ----- large star fixture for the EXPLAIN group (GROUP 10) -----
+            seedExplainFixture(su);
+
+            for (String tbl : List.of("chunks_1024", "catalog_documents",
+                    "catalog_document_chunks", "catalog_links")) {
+                su.createStatement().execute("ANALYZE nexus." + tbl);
+            }
+        }
+    }
+
+    /**
+     * Star graph: seed exseed --cites--> ex1..exN, so cites/out/depth1 reaches all N
+     * docs. The volume + the materialize-then-rank shape is what lets the planner pick
+     * the HNSW index for the outer vector rank (GROUP 10).
+     */
+    private void seedExplainFixture(Connection su) throws Exception {
+        insertCollection(su, TENANT_A, COLL_EXPLAIN);
+        // seed doc
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_documents " +
+            "  (tenant_id, tumbler, title, author, year, content_type, corpus, physical_collection) " +
+            "VALUES ('" + TENANT_A + "', 'exseed', 'Seed', 'exauthor', 2024, 'paper', 'research', '" +
+            COLL_EXPLAIN + "')");
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_documents " +
+            "  (tenant_id, tumbler, title, author, year, content_type, corpus, physical_collection) " +
+            "SELECT '" + TENANT_A + "', 'ex'||g, 'Doc '||g, 'exauthor', 2024, 'paper', 'research', '" +
+            COLL_EXPLAIN + "' FROM generate_series(1, " + EXPLAIN_ROWS + ") g");
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash, collection) " +
+            "SELECT '" + TENANT_A + "', 'ex'||g, 0, lpad(g::text, 32, '0'), '" + COLL_EXPLAIN + "' " +
+            "FROM generate_series(1, " + EXPLAIN_ROWS + ") g");
+        su.createStatement().execute(
+            "INSERT INTO nexus.chunks_1024 (tenant_id, collection, chash, chunk_text, embedding) " +
+            "SELECT '" + TENANT_A + "', '" + COLL_EXPLAIN + "', lpad(g::text, 32, '0'), 'ex'||g, " +
+            "('[' || ((g % 100)::float8 / 100.0) || ',1' || repeat(',0', 1022) || ']')::vector " +
+            "FROM generate_series(1, " + EXPLAIN_ROWS + ") g");
+        // edges exseed --cites--> ex1..exN
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_links (tenant_id, from_tumbler, to_tumbler, link_type, created_by) " +
+            "SELECT '" + TENANT_A + "', 'exseed', 'ex'||g, 'cites', 'test' " +
+            "FROM generate_series(1, " + EXPLAIN_ROWS + ") g");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 1 — signature: query vector first; chash is an output column (audit HIGH)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(10)
+    void signature_queryVectorFirst_chashInResult() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT pg_catalog.pg_get_function_arguments(p.oid) AS args, " +
+                "       pg_catalog.pg_get_function_result(p.oid)    AS result " +
+                "  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace " +
+                " WHERE n.nspname = 'nexus' AND p.proname = 'search_graph_hop_1024'");
+            assertThat(rs.next())
+                .as("nexus.search_graph_hop_1024 must exist (catalog-007)").isTrue();
+            String args = rs.getString("args");
+            assertThat(args)
+                .as("query vector must be the FIRST argument, typed `vector` (Finding 5a)")
+                .startsWith("p_query vector");
+            assertThat(args)
+                .as("graph-hop signature pins seeds[], collections[], link_type, depth, direction, n")
+                .contains("p_seeds text[]")
+                .contains("p_collections text[]")
+                .contains("p_link_type text")
+                .contains("p_depth integer")
+                .contains("p_direction text")
+                .contains("p_n integer");
+            assertThat(rs.getString("result"))
+                .as("audit HIGH: result table MUST carry the matched chunk's chash so the "
+                    + "query() repoint (rzqto) populates RDR-086 chunk_text_hash from the "
+                    + "MATCHED chunk, not a per-doc manifest guess")
+                .contains("chash text");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 2 — depth-bound BFS (exactly N, no N+1 leak)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(20)
+    void depth1_cites_out_seedsPlusOneHopOnly() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callGraph(su, 1024, COLL_G, "g0", "cites", 1, "out", 10))
+                .as("cites/out/depth1 from g0 → seeds + 1-hop = {g0,g1}, ranked by distance "
+                    + "(0.0, 0.2). g2 (2-hop) must NOT leak; g3 (relates) excluded")
+                .containsExactly("g0", "g1");
+        }
+    }
+
+    @Test @Order(21)
+    void depth2_cites_out_addsTwoHopLayer() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callGraph(su, 1024, COLL_G, "g0", "cites", 2, "out", 10))
+                .as("cites/out/depth2 from g0 → {g0,g1,g2} ranked (0.0,0.2,0.4)")
+                .containsExactly("g0", "g1", "g2");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 3 — link_type / direction filters
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(30)
+    void linkTypeNull_followsAllEdges() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callGraph(su, 1024, COLL_G, "g0", null, 1, "out", 10))
+                .as("link_type NULL/out/depth1 from g0 → all 1-hop = {g0,g1,g3} "
+                    + "ranked (0.0,0.2,1.0); the relates edge to g3 is followed too")
+                .containsExactly("g0", "g1", "g3");
+        }
+    }
+
+    @Test @Order(31)
+    void linkTypeFilter_followsOnlyThatType() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callGraph(su, 1024, COLL_G, "g0", "relates", 2, "out", 10))
+                .as("relates/out/depth2 from g0 → {g0,g3} only (g3 has no further relates "
+                    + "edges; the cites chain to g1/g2 is NOT followed)")
+                .containsExactly("g0", "g3");
+        }
+    }
+
+    @Test @Order(32)
+    void directionIn_followsInboundEdges() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callGraph(su, 1024, COLL_G, "g0", "cites", 1, "in", 10))
+                .as("cites/in/depth1 from g0 → {g0,gin} (gin --cites--> g0 is inbound); "
+                    + "g1 (outbound) excluded. Ranked (0.0, ~0.04)")
+                .containsExactly("g0", "gin");
+        }
+    }
+
+    @Test @Order(33)
+    void directionBoth_followsEitherEnd() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callGraph(su, 1024, COLL_G, "g0", "cites", 1, "both", 10))
+                .as("cites/both/depth1 from g0 → {g0,gin,g1} ranked (0.0, ~0.04, 0.2)")
+                .containsExactly("g0", "gin", "g1");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 4 — cycle safety
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(40)
+    void cycle_terminatesAndVisitsEachOnce() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            // g1<->g2 is a cycle; depth3 must terminate and the reachable set is the
+            // BFS-visited set {g0,g1,g2} — never an infinite loop or duplicate rows.
+            assertThat(callGraph(su, 1024, COLL_G, "g0", "cites", 3, "out", 10))
+                .as("cites/out/depth3 from g0 across the g1<->g2 cycle → {g0,g1,g2}, "
+                    + "terminating, one row per doc")
+                .containsExactly("g0", "g1", "g2");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 5 — chash output column correctness
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(50)
+    void chashColumn_matchesSeededChunkChash() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT id, chash FROM nexus.search_graph_hop_1024(" +
+                queryVecLiteral(1024) + ", ARRAY['g0']::text[], " +
+                "ARRAY['" + COLL_G + "']::text[], 'cites', 1, 'out', 10) ORDER BY distance");
+            int seen = 0;
+            while (rs.next()) {
+                String id = rs.getString("id");
+                String chash = rs.getString("chash");
+                assertThat(chash)
+                    .as("the chash column must be the MATCHED chunk's chash for doc " + id)
+                    .isEqualTo(validChash(id));
+                seen++;
+            }
+            assertThat(seen).as("expected g0,g1 rows").isEqualTo(2);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 6 — tombstone filtering (both directions, non-vacuous)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(60)
+    void tombstone_dropsAndReturns() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            assertThat(callGraph(su, 1024, COLL_G, "g0", "cites", 1, "out", 10))
+                .as("baseline → {g0,g1}").containsExactly("g0", "g1");
+
+            setDeleted(su, TENANT_A, "g1", true);
+            assertThat(callGraph(su, 1024, COLL_G, "g0", "cites", 1, "out", 10))
+                .as("tombstoned g1 drops out of graph-hop results (still graph-reachable, "
+                    + "but deleted_at IS NULL filters it)")
+                .containsExactly("g0");
+
+            setDeleted(su, TENANT_A, "g1", false);
+            assertThat(callGraph(su, 1024, COLL_G, "g0", "cites", 1, "out", 10))
+                .as("restored g1 returns").containsExactly("g0", "g1");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 7 — RLS isolation (SECURITY INVOKER, caller RLS)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(70)
+    void rls_tenantSeesOnlyOwnRows() throws Exception {
+        // CONTROL: superuser (BYPASSRLS) sees tenant-B's reachable docs.
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callGraph(su, 1024, COLL_B, "b0", "cites", 1, "out", 10))
+                .as("CONTROL: superuser sees tenant-B {b0,b1} (foreign rows exist → svc "
+                    + "assertions below are non-vacuous)")
+                .containsExactly("b0", "b1");
+        }
+        // svc + GUC=A: cannot traverse into tenant-B at all (catalog_links RLS).
+        try (Connection svc = svcDs.getConnection()) {
+            svc.createStatement().execute(
+                "SELECT set_config('nexus.tenant', '" + TENANT_A + "', false)");
+            assertThat(callGraph(svc, 1024, COLL_B, "b0", "cites", 1, "out", 10))
+                .as("svc GUC=A sees ZERO tenant-B rows — the recursive CTE over "
+                    + "catalog_links is also RLS-scoped (SECURITY INVOKER)").isEmpty();
+            assertThat(callGraph(svc, 1024, COLL_G, "g0", "cites", 1, "out", 10))
+                .as("svc GUC=A still sees its OWN tenant-A graph")
+                .containsExactly("g0", "g1");
+        }
+        // svc + no GUC: nothing.
+        try (Connection svc = svcDs.getConnection()) {
+            svc.createStatement().execute("RESET nexus.tenant");
+            assertThat(callGraph(svc, 1024, COLL_G, "g0", "cites", 1, "out", 10))
+                .as("svc with no nexus.tenant GUC sees nothing (RLS matches NULL)")
+                .isEmpty();
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 8 — per-dim dispatch (384)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(80)
+    void perDim_384_behavesIdentically() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callGraph(su, 384, COLL_G_384, "h0", "cites", 1, "out", 10))
+                .as("search_graph_hop_384 must exist and behave identically → {h0,h1}")
+                .containsExactly("h0", "h1");
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 9 — parity vs the reachable-set-then-rank oracle (non-vacuous)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(90)
+    void parity_equalsReachableThenRankOracle() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            List<String> oracle = stitchedGraphOracle(su, 1024, COLL_G, "g0", "cites", 2, "out");
+            assertThat(oracle)
+                .as("CONTROL: reachable-then-rank oracle for cites/out/depth2 = [g0,g1,g2]")
+                .containsExactly("g0", "g1", "g2");
+            // Non-vacuity: g4 is vector-present but graph-UNREACHABLE; a broken impl that
+            // ignored the graph and ranked the whole collection would surface g4 (and g3,
+            // gin). The oracle and the function must BOTH exclude them.
+            assertThat(oracle).as("oracle must exclude unreachable g4/g3/gin")
+                .doesNotContain("g4", "g3", "gin");
+            assertThat(callGraph(su, 1024, COLL_G, "g0", "cites", 2, "out", 10))
+                .as("graph-hop function must equal the reachable-then-rank oracle EXACTLY, "
+                    + "ordering included")
+                .containsExactlyElementsOf(oracle);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 10 — EXPLAIN: ranking the reached set OUTSIDE the recursive CTE keeps HNSW
+    //
+    // The recursive-CTE function is non-inlinable (Function Scan at the call site is
+    // ACCEPTED per the houg9 audit). What MUST hold is the audit's structural decision:
+    // materialize the reachable doc set first, then vector-rank with an HNSW-engaging
+    // join — NOT rank inside the recursive CTE. This EXPLAINs that outer shape over a
+    // large star graph (reached set = all EXPLAIN_ROWS docs).
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(100)
+    void explain_reachedThenRank_usesHnswIndex_notSeqScan() throws Exception {
+        // The outer shape the function uses once `reached` is materialized: rank the
+        // chunks of the reached doc set. Modelled here with the reached set sourced from
+        // the (non-recursive) star edges, so the probe vector stays a plan-time literal.
+        String inner =
+            "SELECT d.tumbler " +
+            "  FROM nexus.chunks_1024 c " +
+            "  JOIN nexus.catalog_document_chunks m " +
+            "    ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash " +
+            "  JOIN nexus.catalog_documents d " +
+            "    ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id " +
+            "  JOIN (SELECT DISTINCT to_tumbler AS tumbler FROM nexus.catalog_links " +
+            "         WHERE from_tumbler = 'exseed' AND link_type = 'cites') rd " +
+            "    ON rd.tumbler = d.tumbler " +
+            " WHERE c.collection = '" + COLL_EXPLAIN + "' AND d.deleted_at IS NULL " +
+            " ORDER BY c.embedding <=> " + queryVecLiteral(1024) + " LIMIT 10";
+        String plan = explain(inner);
+        assertThat(plan)
+            .as("materialize-reached-then-rank must use the HNSW index "
+                + "idx_chunks_1024_embedding (rank OUTSIDE the recursive CTE keeps the "
+                + "probe vector a plan-time literal). Plan was:%n%s", plan)
+            .contains("idx_chunks_1024_embedding");
+        assertThat(plan)
+            .as("the reached-set join must NOT defeat the index into a Seq Scan on "
+                + "chunks_1024. Plan was:%n%s", plan)
+            .doesNotContain("Seq Scan on chunks_1024");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // CALL HELPERS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /** Invoke search_graph_hop_&lt;dim&gt;; returns ids (tumblers) in returned order. */
+    private List<String> callGraph(Connection conn, int dim, String collection, String seed,
+                                   String linkType, int depth, String direction, int n)
+            throws Exception {
+        String sql =
+            "SELECT id FROM nexus.search_graph_hop_" + dim + "(" +
+            queryVecLiteral(dim) + ", " +
+            "ARRAY['" + seed + "']::text[], " +
+            "ARRAY['" + collection + "']::text[], " +
+            sqlText(linkType) + ", " +
+            depth + ", " +
+            sqlText(direction) + ", " +
+            n + ")";
+        return runIds(conn, sql);
+    }
+
+    private String explain(String inner) throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            for (String guc : List.of("enable_seqscan", "enable_bitmapscan",
+                    "enable_sort", "enable_hashjoin")) {
+                su.createStatement().execute("SET " + guc + " = off");
+            }
+            ResultSet rs = su.createStatement().executeQuery("EXPLAIN " + inner);
+            StringBuilder sb = new StringBuilder();
+            while (rs.next()) sb.append(rs.getString(1)).append('\n');
+            return sb.toString();
+        }
+    }
+
+    private static List<String> runIds(Connection conn, String sql) throws Exception {
+        List<String> out = new ArrayList<>();
+        try (var st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) out.add(rs.getString(1));
+        }
+        return out;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // STITCHED-PATH ORACLE (the app-side follow_links dance the function retires)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Reachable-set-then-rank oracle: a recursive BFS over catalog_links (the explicit
+     * traversal {@link dev.nexus.service.db.CatalogRepository#graphBFS} does app-side),
+     * then a raw vector rank over the reachable docs' chunks. Tombstone-filtered.
+     * Written as the literal SQL the app-stitch is equivalent to, so parity is a real
+     * cross-check, not a copy of the function body.
+     */
+    private List<String> stitchedGraphOracle(Connection conn, int dim, String collection,
+                                             String seed, String linkType, int depth,
+                                             String direction) throws Exception {
+        String dirPred =
+            "out".equals(direction)  ? "l.from_tumbler = r.tumbler"
+          : "in".equals(direction)   ? "l.to_tumbler = r.tumbler"
+          : "(l.from_tumbler = r.tumbler OR l.to_tumbler = r.tumbler)";
+        String sql =
+            "WITH RECURSIVE reach(tumbler, d) AS (" +
+            "    SELECT '" + seed + "', 0 " +
+            "  UNION " +
+            "    SELECT CASE WHEN l.from_tumbler = r.tumbler THEN l.to_tumbler ELSE l.from_tumbler END, r.d + 1 " +
+            "    FROM reach r JOIN nexus.catalog_links l ON " + dirPred + " " +
+            "    WHERE r.d < " + depth + " AND l.link_type = " + sqlText(linkType) +
+            "), reached AS (SELECT DISTINCT tumbler FROM reach) " +
+            "SELECT d.tumbler AS id " +
+            "  FROM nexus.chunks_" + dim + " c " +
+            "  JOIN nexus.catalog_document_chunks m " +
+            "    ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash " +
+            "  JOIN nexus.catalog_documents d " +
+            "    ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id " +
+            "  JOIN reached rd ON rd.tumbler = d.tumbler " +
+            " WHERE c.collection = '" + collection + "' AND d.deleted_at IS NULL " +
+            " ORDER BY c.embedding <=> " + queryVecLiteral(dim) + " ASC";
+        return runIds(conn, sql);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // FIXTURE HELPERS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /** Seed a doc: catalog_documents + manifest + one chunk (2-D unit dir embedding). */
+    private void seedDoc(Connection su, int dim, String collection, String tumbler,
+                         double x, double y) throws Exception {
+        String tenant = tenantFor(collection);
+        String chash = validChash(tumbler);
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_documents " +
+            "  (tenant_id, tumbler, title, author, year, content_type, corpus, physical_collection) " +
+            "VALUES ('" + tenant + "', '" + tumbler + "', 'Doc " + tumbler + "', 'a', 2024, " +
+            "'paper', 'research', '" + collection + "') ON CONFLICT (tenant_id, tumbler) DO NOTHING");
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash, collection) " +
+            "VALUES ('" + tenant + "', '" + tumbler + "', 0, '" + chash + "', '" + collection + "') " +
+            "ON CONFLICT (tenant_id, doc_id, position) DO NOTHING");
+        su.createStatement().execute(
+            "INSERT INTO nexus.chunks_" + dim +
+            " (tenant_id, collection, chash, chunk_text, embedding) VALUES ('" +
+            tenant + "', '" + collection + "', '" + chash + "', '" + tumbler + "', " +
+            vec2(dim, x, y) + "::vector) ON CONFLICT (tenant_id, collection, chash) DO NOTHING");
+    }
+
+    private static void link(Connection su, String tenant, String from, String to, String type)
+            throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_links (tenant_id, from_tumbler, to_tumbler, link_type, created_by) " +
+            "VALUES ('" + tenant + "', '" + from + "', '" + to + "', '" + type + "', 'test') " +
+            "ON CONFLICT (tenant_id, from_tumbler, to_tumbler, link_type) DO NOTHING");
+    }
+
+    private static String tenantFor(String collection) {
+        return COLL_B.equals(collection) ? TENANT_B : TENANT_A;
+    }
+
+    private static void insertCollection(Connection su, String tenantId, String name)
+            throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" +
+            tenantId + "', '" + name + "') ON CONFLICT (tenant_id, name) DO NOTHING");
+    }
+
+    private static void setDeleted(Connection su, String tenantId, String tumbler, boolean deleted)
+            throws Exception {
+        su.createStatement().execute(
+            "UPDATE nexus.catalog_documents SET deleted_at = " +
+            (deleted ? "now()" : "NULL") +
+            " WHERE tenant_id = '" + tenantId + "' AND tumbler = '" + tumbler + "'");
+    }
+
+    // ── value helpers ────────────────────────────────────────────────────────
+
+    private static String queryVecLiteral(int dim) {
+        return vec2(dim, 1.0, 0.0) + "::vector";
+    }
+
+    private static String vec2(int dim, double x, double y) {
+        StringBuilder sb = new StringBuilder("'[");
+        sb.append(fmt(x)).append(',').append(fmt(y));
+        for (int i = 2; i < dim; i++) sb.append(",0");
+        return sb.append("]'").toString();
+    }
+
+    private static String fmt(double v) {
+        if (v == Math.rint(v)) return Integer.toString((int) v);
+        return Double.toString(v);
+    }
+
+    private static String sqlText(String v) {
+        return v == null ? "NULL" : "'" + v.replace("'", "''") + "'";
+    }
+
+    /** Length-32 lowercase-hex chash deterministically derived from seed (catalog-002 CHECK). */
+    private static String validChash(String seed) {
+        try {
+            byte[] h = java.security.MessageDigest.getInstance("SHA-256")
+                .digest(seed.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(64);
+            for (byte b : h) sb.append(String.format("%02x", b));
+            return sb.substring(0, 32);
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -693,6 +693,42 @@ class HttpVectorClient:
         }
         return _post("/v1/vectors/search-topic-scoped", body, tenant=self._tenant)
 
+    def search_graph_hop(
+        self,
+        query: str,
+        seeds: list[str],
+        collection_names: list[str],
+        *,
+        link_type: str | None = None,
+        depth: int = 1,
+        direction: str = "both",
+        n_results: int = 10,
+    ) -> list[dict]:
+        """Graph-hop combined search (RDR-156 P4 follow-on, Decision 5, bead nexus-houg9).
+
+        Routes to ``POST /v1/vectors/search-graph-hop`` —
+        ``nexus.search_graph_hop_<dim>`` (catalog-007): a ``WITH RECURSIVE`` BFS over
+        ``catalog_links`` from ``seeds`` to ``depth`` hops collects the reachable
+        document set, joins ``chunks_<dim>``, and vector-ranks. The single-statement
+        unification of the ``query`` tool's ``follow_links`` app-side graphBFS dance.
+        ``link_type=None`` follows all edge types; ``direction`` is ``"out"``/``"in"``/
+        ``"both"`` (default ``"both"``, matching ``Catalog.graph``); ``depth`` is clamped
+        to [1,3] service-side. Returns the flat ``{id, content, distance, collection,
+        chash}`` row list; ``id`` is the document tumbler, ``chash`` the MATCHED chunk's
+        content hash (the repoint populates the RDR-086 ``chunk_text_hash`` from it).
+        """
+        body: dict[str, Any] = {
+            "query": query,
+            "seeds": seeds,
+            "collections": collection_names,
+            "depth": depth,
+            "direction": direction,
+            "n_results": n_results,
+        }
+        if link_type is not None:
+            body["link_type"] = link_type
+        return _post("/v1/vectors/search-graph-hop", body, tenant=self._tenant)
+
     def get_by_id(self, collection: str, doc_id: str) -> dict | None:
         """Fetch a single chunk by ID.
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1164,6 +1164,105 @@ def search_topic_scoped(
 
 
 @mcp.tool(
+    title="Graph-Hop Combined Search",
+    annotations={"readOnlyHint": True},
+)
+def search_graph_hop(
+    query: str,
+    seeds: list[str] | str,
+    corpus: str = "knowledge,code,docs",
+    limit: int = 10,
+    link_type: str = "",
+    depth: int = 1,
+    direction: str = "both",
+    structured: bool = False,
+) -> "str | dict":
+    """Graph-hop combined search (RDR-156 P4 follow-on, Decision 5, bead nexus-houg9).
+
+    The single-statement unification of the ``query`` tool's ``follow_links`` dance:
+    ``nexus.search_graph_hop_<dim>`` runs a ``WITH RECURSIVE`` BFS over
+    ``catalog_links`` from *seeds* to *depth* hops, collects the reachable document
+    set, joins ``chunks_<dim>`` and vector-ranks — replacing the app-side graphBFS +
+    per-collection search + re-join. Document-level results (``id`` is the tumbler),
+    deduped to one row per tumbler at the best (nearest) distance. Each row also carries
+    the MATCHED chunk's ``chash`` (so the query() repoint populates the RDR-086
+    ``chunk_text_hash`` from it, never a per-doc manifest guess).
+
+    Seeds are document tumblers; ``depth`` is clamped to [1,3] service-side; an empty
+    ``link_type`` follows all edge types; ``direction`` is ``"out"``/``"in"``/``"both"``
+    (default ``"both"``, matching ``Catalog.graph`` / the ``query`` tool's follow_links).
+
+    Service-mode only — the combined-query functions live in the pgvector Postgres; in
+    local/Chroma mode this returns an error.
+
+    Args:
+        query: Search query string.
+        seeds: Seed document tumbler(s) to traverse from (list, or a single string).
+        corpus: Corpus prefixes or collection names, comma-separated; "all" for all.
+        limit: Max rows.
+        link_type: Catalog link_type filter ("" = follow all edge types).
+        depth: BFS depth (clamped to [1,3]).
+        direction: "out" | "in" | "both".
+        structured: Return ``{ids, tumblers, distances, collections, contents, chashes}``.
+    """
+    try:
+        from nexus.db.http_vector_client import is_service_backed
+
+        t3 = _get_t3()
+        if not is_service_backed(t3):
+            return ("Error: search_graph_hop requires service mode "
+                    "(pgvector); not available in local/Chroma mode")
+        seed_list = [seeds] if isinstance(seeds, str) else list(seeds)
+        seed_list = [s for s in seed_list if s]
+        if not seed_list:
+            return "No seeds provided."
+        target = _resolve_corpus_target(corpus, t3)
+        if not target:
+            return f"No collections match corpus {corpus!r}"
+        rows = t3.search_graph_hop(
+            query, seed_list, target,
+            link_type=(link_type or None),
+            depth=depth,
+            direction=direction,
+            n_results=limit,
+        )
+        # Document-level: collapse to one row per tumbler, keeping the best (nearest)
+        # distance. Rows arrive distance-ascending, so the FIRST occurrence is best.
+        seen_ids: set[str] = set()
+        deduped: list[dict] = []
+        for r in rows:
+            rid = r.get("id", "")
+            if rid in seen_ids:
+                continue
+            seen_ids.add(rid)
+            deduped.append(r)
+        rows = deduped
+        if structured:
+            ids = [r.get("id", "") for r in rows]
+            return {
+                "ids": ids,
+                "tumblers": ids,
+                "distances": [r.get("distance", 0.0) for r in rows],
+                "collections": [r.get("collection", "") for r in rows],
+                # contents inline so plan steps summarize via $stepN.contents WITHOUT
+                # store_get_many hydration (which is chash-keyed and would miss tumblers).
+                "contents": [r.get("content", "") for r in rows],
+                # the matched chunk's chash per row — rzqto wires this into the
+                # structured chunk_text_hash (RDR-086 chash-citations).
+                "chashes": [r.get("chash", "") for r in rows],
+            }
+        if not rows:
+            return "No documents found."
+        return "\n\n".join(
+            f"[{r.get('collection', '')}] {r.get('id', '')} (dist={r.get('distance', 0.0):.4f})"
+            f"\n{r.get('content', '')}"
+            for r in rows
+        )
+    except Exception as e:
+        return f"Error: {e}"
+
+
+@mcp.tool(
     title="Catalog-Aware Document Query",
     annotations={"readOnlyHint": True},
 )

--- a/src/nexus/plans/runner.py
+++ b/src/nexus/plans/runner.py
@@ -255,7 +255,7 @@ _RETRIEVAL_TOOLS: frozenset[str] = frozenset(
     {"search", "query", "store_get_many",
      # RDR-156 P4 (nexus-joesk): combined-query primitives — structured=True so
      # $stepN.ids/tumblers resolve from the {ids, tumblers, distances, collections} shape.
-     "search_metadata_scoped", "search_topic_scoped"},
+     "search_metadata_scoped", "search_topic_scoped", "search_graph_hop"},
 )
 
 #: Args keys that may carry a collection name. The runner extracts

--- a/tests/test_combined_query_mcp_tools.py
+++ b/tests/test_combined_query_mcp_tools.py
@@ -19,11 +19,14 @@ class _FakeServiceT3:
     """Records combined-query client calls; stands in for HttpVectorClient."""
 
     def __init__(self, meta_rows: list[dict] | None = None,
-                 topic_rows_by_col: dict[str, list[dict]] | None = None) -> None:
+                 topic_rows_by_col: dict[str, list[dict]] | None = None,
+                 graph_rows: list[dict] | None = None) -> None:
         self.meta_rows = meta_rows or []
         self.topic_rows_by_col = topic_rows_by_col or {}
+        self.graph_rows = graph_rows or []
         self.meta_calls: list[tuple] = []
         self.topic_calls: list[tuple] = []
+        self.graph_calls: list[tuple] = []
 
     def search_metadata_scoped(self, query, collection_names, *, content_type=None,
                                author=None, year=None, corpus=None, n_results=10):
@@ -34,6 +37,12 @@ class _FakeServiceT3:
     def search_topic_scoped(self, query, topic, collection, *, n_results=10):
         self.topic_calls.append((query, topic, collection, n_results))
         return self.topic_rows_by_col.get(collection, [])
+
+    def search_graph_hop(self, query, seeds, collection_names, *, link_type=None,
+                         depth=1, direction="both", n_results=10):
+        self.graph_calls.append((query, list(seeds), list(collection_names),
+                                 link_type, depth, direction, n_results))
+        return self.graph_rows
 
 
 def _wire(monkeypatch, t3, target, *, service=True):
@@ -124,12 +133,78 @@ class TestSearchTopicScopedTool:
         assert isinstance(out, str) and out.startswith("Error:")
 
 
+class TestSearchGraphHopTool:
+    """nexus-houg9: graph-hop tool — doc-level dedup + chash in the structured shape."""
+
+    def test_structured_doc_level_with_chashes(self, monkeypatch):
+        rows = [
+            {"id": "1.2.3", "content": "a", "distance": 0.1, "collection": "c1",
+             "chash": "a" * 32},
+            {"id": "1.2.4", "content": "b", "distance": 0.3, "collection": "c1",
+             "chash": "b" * 32},
+        ]
+        t3 = _FakeServiceT3(graph_rows=rows)
+        _wire(monkeypatch, t3, ["c1"])
+
+        out = core.search_graph_hop(
+            "q", ["1.2.0"], corpus="rdr", link_type="cites", depth=2,
+            direction="out", limit=5, structured=True)
+
+        assert out == {
+            "ids": ["1.2.3", "1.2.4"],
+            "tumblers": ["1.2.3", "1.2.4"],
+            "distances": [0.1, 0.3],
+            "collections": ["c1", "c1"],
+            "contents": ["a", "b"],
+            "chashes": ["a" * 32, "b" * 32],
+        }
+        assert t3.graph_calls == [("q", ["1.2.0"], ["c1"], "cites", 2, "out", 5)]
+
+    def test_single_string_seed_accepted(self, monkeypatch):
+        t3 = _FakeServiceT3(graph_rows=[])
+        _wire(monkeypatch, t3, ["c1"])
+        core.search_graph_hop("q", "1.2.0", corpus="rdr", structured=True)
+        assert t3.graph_calls == [("q", ["1.2.0"], ["c1"], None, 1, "both", 10)]
+
+    def test_empty_seeds_short_circuit(self, monkeypatch):
+        t3 = _FakeServiceT3(graph_rows=[])
+        _wire(monkeypatch, t3, ["c1"])
+        out = core.search_graph_hop("q", [], corpus="rdr")
+        assert isinstance(out, str) and "No seeds" in out
+        assert t3.graph_calls == []
+
+    def test_multichunk_doc_deduped_keeps_best_distance(self, monkeypatch):
+        rows = [
+            {"id": "1.2.3", "content": "near", "distance": 0.1, "collection": "c1",
+             "chash": "a" * 32},
+            {"id": "1.2.4", "content": "other", "distance": 0.2, "collection": "c1",
+             "chash": "c" * 32},
+            {"id": "1.2.3", "content": "far", "distance": 0.9, "collection": "c1",
+             "chash": "d" * 32},
+        ]
+        t3 = _FakeServiceT3(graph_rows=rows)
+        _wire(monkeypatch, t3, ["c1"])
+        out = core.search_graph_hop("q", ["1.2.0"], structured=True)
+        assert out["ids"] == ["1.2.3", "1.2.4"]
+        assert out["distances"] == [0.1, 0.2]
+        assert out["chashes"] == ["a" * 32, "c" * 32]  # best-distance row's chash
+
+    def test_non_service_mode_errors(self, monkeypatch):
+        t3 = _FakeServiceT3()
+        _wire(monkeypatch, t3, ["c1"], service=False)
+        out = core.search_graph_hop("q", ["1.2.0"], structured=True)
+        assert isinstance(out, str) and out.startswith("Error:")
+        assert t3.graph_calls == []
+
+
 class TestPlanRunnerRegistration:
     def test_tools_registered_as_retrieval(self):
         from nexus.plans.runner import _RETRIEVAL_TOOLS
         assert "search_metadata_scoped" in _RETRIEVAL_TOOLS
         assert "search_topic_scoped" in _RETRIEVAL_TOOLS
+        assert "search_graph_hop" in _RETRIEVAL_TOOLS
 
     def test_tools_resolvable_on_core(self):
         assert callable(getattr(core, "search_metadata_scoped"))
         assert callable(getattr(core, "search_topic_scoped"))
+        assert callable(getattr(core, "search_graph_hop"))

--- a/tests/test_http_vector_client_combined_query.py
+++ b/tests/test_http_vector_client_combined_query.py
@@ -17,6 +17,7 @@ from nexus.db.http_vector_client import HttpVectorClient
 
 META_PATH = "/v1/vectors/search-metadata-scoped"
 TOPIC_PATH = "/v1/vectors/search-topic-scoped"
+GRAPH_PATH = "/v1/vectors/search-graph-hop"
 
 
 def _patch_post(monkeypatch, handler) -> list[tuple[str, dict]]:
@@ -104,3 +105,52 @@ class TestSearchTopicScoped:
         HttpVectorClient().search_topic_scoped("q", "T", "knowledge__b__minilm-l6-v2-384__v1")
         _, body = calls[0]
         assert body["n_results"] == 10
+
+
+class TestSearchGraphHop:
+    """nexus-houg9: graph-hop client leg for POST /v1/vectors/search-graph-hop."""
+
+    def test_posts_to_graph_route_with_link_type(self, monkeypatch):
+        rows = [{"id": "1.2.3", "content": "z", "distance": 0.1,
+                 "collection": "rdr__a__voyage-context-3__v1",
+                 "chash": "0" * 32}]
+        calls = _patch_post(monkeypatch, lambda p, b: rows)
+
+        got = HttpVectorClient().search_graph_hop(
+            "how does x work", ["1.2.3"], ["rdr__a__voyage-context-3__v1"],
+            link_type="cites", depth=2, direction="out", n_results=5)
+
+        assert got == rows
+        assert len(calls) == 1
+        path, body = calls[0]
+        assert path == GRAPH_PATH
+        assert body == {
+            "query": "how does x work",
+            "seeds": ["1.2.3"],
+            "collections": ["rdr__a__voyage-context-3__v1"],
+            "link_type": "cites",
+            "depth": 2,
+            "direction": "out",
+            "n_results": 5,
+        }
+
+    def test_omits_none_link_type_and_defaults(self, monkeypatch):
+        calls = _patch_post(monkeypatch, lambda p, b: [])
+
+        HttpVectorClient().search_graph_hop("q", ["1.1"], ["rdr__a__voyage-context-3__v1"])
+
+        _, body = calls[0]
+        assert body == {
+            "query": "q",
+            "seeds": ["1.1"],
+            "collections": ["rdr__a__voyage-context-3__v1"],
+            "depth": 1,
+            "direction": "both",
+            "n_results": 10,
+        }
+        assert "link_type" not in body
+
+    def test_returns_empty_list_passthrough(self, monkeypatch):
+        _patch_post(monkeypatch, lambda p, b: [])
+        assert HttpVectorClient().search_graph_hop(
+            "q", ["1.1"], ["rdr__a__voyage-context-3__v1"]) == []

--- a/tests/test_http_vector_client_combined_query.py
+++ b/tests/test_http_vector_client_combined_query.py
@@ -112,12 +112,12 @@ class TestSearchGraphHop:
 
     def test_posts_to_graph_route_with_link_type(self, monkeypatch):
         rows = [{"id": "1.2.3", "content": "z", "distance": 0.1,
-                 "collection": "rdr__a__voyage-context-3__v1",
+                 "collection": "rdr__a__model-x__v1",
                  "chash": "0" * 32}]
         calls = _patch_post(monkeypatch, lambda p, b: rows)
 
         got = HttpVectorClient().search_graph_hop(
-            "how does x work", ["1.2.3"], ["rdr__a__voyage-context-3__v1"],
+            "how does x work", ["1.2.3"], ["rdr__a__model-x__v1"],
             link_type="cites", depth=2, direction="out", n_results=5)
 
         assert got == rows
@@ -127,7 +127,7 @@ class TestSearchGraphHop:
         assert body == {
             "query": "how does x work",
             "seeds": ["1.2.3"],
-            "collections": ["rdr__a__voyage-context-3__v1"],
+            "collections": ["rdr__a__model-x__v1"],
             "link_type": "cites",
             "depth": 2,
             "direction": "out",
@@ -137,13 +137,13 @@ class TestSearchGraphHop:
     def test_omits_none_link_type_and_defaults(self, monkeypatch):
         calls = _patch_post(monkeypatch, lambda p, b: [])
 
-        HttpVectorClient().search_graph_hop("q", ["1.1"], ["rdr__a__voyage-context-3__v1"])
+        HttpVectorClient().search_graph_hop("q", ["1.1"], ["rdr__a__model-x__v1"])
 
         _, body = calls[0]
         assert body == {
             "query": "q",
             "seeds": ["1.1"],
-            "collections": ["rdr__a__voyage-context-3__v1"],
+            "collections": ["rdr__a__model-x__v1"],
             "depth": 1,
             "direction": "both",
             "n_results": 10,
@@ -153,4 +153,4 @@ class TestSearchGraphHop:
     def test_returns_empty_list_passthrough(self, monkeypatch):
         _patch_post(monkeypatch, lambda p, b: [])
         assert HttpVectorClient().search_graph_hop(
-            "q", ["1.1"], ["rdr__a__voyage-context-3__v1"]) == []
+            "q", ["1.1"], ["rdr__a__model-x__v1"]) == []

--- a/tests/test_mcp_package.py
+++ b/tests/test_mcp_package.py
@@ -39,8 +39,8 @@ def test_core_registered_tools():
         "operator_groupby", "operator_aggregate",
         "nx_answer", "nx_tidy", "nx_enrich_beads", "nx_plan_audit",
         "daemon_uninstall",
-        # RDR-156 P4 combined-query primitives (nexus-joesk)
-        "search_metadata_scoped", "search_topic_scoped",
+        # RDR-156 P4 combined-query primitives (nexus-joesk, nexus-houg9)
+        "search_metadata_scoped", "search_topic_scoped", "search_graph_hop",
     }
     assert expected == tool_names, f"Missing: {expected - tool_names}, Extra: {tool_names - expected}"
 


### PR DESCRIPTION
## What

RDR-156 Phase 4 follow-on (bead `nexus-houg9`): the Decision-5 **"graph-hop + rank"** combined-query shape — the keystone of the query()-collapse arc. A `WITH RECURSIVE` BFS over `catalog_links` collects the reachable document set, which is joined to `chunks_<dim>` and vector-ranked, all in one SQL function. This retires the `query` tool's `follow_links` app-side dance (`CatalogRepository.graphBFS` + per-collection search + app re-join), now that the typed edge table and the vectors are co-resident in one Postgres (RDR-152/155).

## Surfaces

- **catalog-007** migration: `nexus.search_graph_hop_<dim>` (384/768/1024), `LANGUAGE sql STABLE SECURITY INVOKER NOT STRICT`. Reachable set materialized **first**; vector rank in the outer `SELECT` (not inside the recursion) so HNSW survives. Recursive-CTE non-inlinability (Function Scan at the call site) is accepted per the audit.
- Returns the **matched chunk's `chash`** as an output column (audit HIGH: the downstream repoint `nexus-rzqto` populates RDR-086 `chunk_text_hash` from it, never a per-doc manifest guess).
- Traversal mirrors `graphBFS` exactly: seeds at depth 0 included, direction `out`/`in`/`both` (default `both`), `NULL` link_type follows all edge types, depth clamped `[1,3]`, `UNION` (cycle-safe). Tombstone-filtered (`deleted_at IS NULL`), RLS-scoped.
- `PgVectorRepository.searchGraphHop` + chash-aware mapper; `/v1/vectors/search-graph-hop` route; `http_vector_client.search_graph_hop`; `core.py` `search_graph_hop` MCP tool (structured shape carries `chashes`); registered in `_RETRIEVAL_TOOLS` and the two MCP completeness gates.

## Tests

- `GraphHopParityTest` — 14 unit (depth-bound/no-N+1, link_type, direction, cycle-safety, chash-column, tombstone, RLS, per-dim, in-SQL-oracle parity, EXPLAIN materialize-then-rank engages HNSW).
- `GraphHopParityIntegrationTest` — 5 `@integration` (corpus-scale parity vs the real `graphBFS` app-stitch, a reachable-set **equivalence sweep** across directions × depths × link-type over a diamond+cycle+inbound topology, unreachable-top-ranked exclusion, tombstoned-reachable exclusion, chash identity).

Full service suite green (714/714); pytest gates green. `@integration` verified locally (excluded from CI).

## Review

Stacked review complete (code-review-expert + substantive-critic) — no Critical. Findings addressed: integration equivalence sweep added (closes the "only cites/out/linear-chain proven" + tautological-unit-oracle gaps), dormant test-oracle `link_type = NULL` bug fixed, EXPLAIN-scope wording clarified.
