### PR TITLE
fix(beads): repair corrupt push-state.json merge-conflict markers

### DIFF
--- a/.beads/push-state.json
+++ b/.beads/push-state.json
@@ -1,15 +1,4 @@
 {
-  "last_push": "2026-05-21T19:57:30Z",
-  "last_commit": "j4chvnj6l13nn30vubcqtpl13o4qel9b"
-=======
-  "last_push": "2026-05-21T19:52:42Z",
-  "last_commit": "7ufh3t618408d66qvf28k1loc695kgt1"
-=======
-  "last_push": "2026-05-21T20:09:59Z",
-  "last_commit": "ik4ttf1g42j2c2gq4q78oqeipk01th5g"
-=======
-}
-=======
   "last_push": "2026-05-21T20:09:59Z",
   "last_commit": "ik4ttf1g42j2c2gq4q78oqeipk01th5g"
 }


### PR DESCRIPTION
## What

`.beads/push-state.json` was committed with a botched merge resolution: bare `=======` separators (no `<<<<<<<` / `>>>>>>>` markers) concatenating four conflicting entries, leaving the file as **invalid JSON**. Any reader of the bd dolt push-state reconciliation would fail to parse it.

## Fix

Collapse to the most-recent entry by `last_push` timestamp (`2026-05-21T20:09:59Z`, commit `ik4ttf1g...`) — which was also the winning side of the botched resolution (it appears as the resolved tail). Validated as well-formed JSON.

Found incidentally while triaging beads state. No code impact.