### PR TITLE
fix(rdr-156): selectivity-aware text-first plan for hybridSearch selective-gate collapse [nexus-lcogi]

### DIFF
--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -404,6 +404,15 @@ public final class PgVectorRepository {
     }
 
     /**
+     * Gate-selectivity cutoff for {@link #hybridSearch} plan dispatch (nexus-lcogi). At or
+     * below this many text-gate matches the gate is materialized first and ranked by exact
+     * distance (bounds materialization at ~{@code SELECTIVE_GATE_MAX × 4 KB} of embeddings);
+     * above it, the HNSW-first plan is kept (a dense gate is found within the scan budget).
+     * Heuristic — superseded by the RDR-156 P5.2 unified selectivity-aware RRF plan.
+     */
+    static final int SELECTIVE_GATE_MAX = 5000;
+
+    /**
      * RDR-155 Phase 3 - hybrid search: text signals ({@code tsvector} FTS + {@code pg_trgm}
      * trigram similarity) gate the candidate set, vector cosine distance ranks it, fused in
      * ONE query against the dispatched {@code chunks_<dim>} table. Replaces the engine's
@@ -433,13 +442,19 @@ public final class PgVectorRepository {
      *       union, metadata {@code where} equality predicates ANDed with the text gate,
      *       {@code nResults} cap, flat row shape ({@code id}, {@code content},
      *       {@code distance}, {@code collection}, metadata flattened in).
-     *   <li><strong>Filtered-ANN session setting.</strong> The implementation MUST run
-     *       {@code SET LOCAL hnsw.iterative_scan = 'relaxed_order'} before the query,
-     *       exactly like {@link #search} - the text gate + RLS + {@code where} predicates
-     *       narrow the candidate set even harder than plain search, which is precisely the
-     *       filtered-recall risk the setting exists for (RDR-155 research resolution; the
-     *       fixture-scale suite cannot detect its absence, the conexus xr7.8.9
-     *       production-scale recall gate can).
+     *   <li><strong>Selectivity-aware dispatch (nexus-lcogi).</strong> A cheap COUNT over
+     *       the text gate picks the plan. For a SELECTIVE gate ({@code count <=}
+     *       {@link #SELECTIVE_GATE_MAX}) the gate is materialized FIRST via a
+     *       {@code MATERIALIZED} CTE (GIN bitmap on {@code chunk_tsv} + {@code gin_trgm_ops})
+     *       and the small gated set is ranked by EXACT cosine distance — the lcogi fix:
+     *       the prior HNSW-first plan ({@code ORDER BY embedding}, gate as scan filter)
+     *       collapsed here because a few matches in a large corpus rank past
+     *       {@code hnsw.max_scan_tuples} (lcogi: 6/116k → 0). For a NON-SELECTIVE gate the
+     *       HNSW-first plan is kept (a dense gate is found within the scan budget, and
+     *       materializing a huge gated set would spill {@code work_mem} and risk the same
+     *       timeout). Superseded by RDR-156 P5.2 server-side RRF fusion (unified
+     *       selectivity-aware); its P5.G gate verifies the selective case at production
+     *       scale rather than re-fixing it.
      *   <li><strong>Trigram gate calibration anchor.</strong> The contract fixture
      *       pins the gate's discriminating range, not an exact threshold: the typo probe's
      *       candidate rows sit at word-similarity ≈ 0.9 (and plain trigram similarity
@@ -478,6 +493,26 @@ public final class PgVectorRepository {
                                                   List<String> collectionNames,
                                                   int nResults,
                                                   Map<String, Object> where) {
+        return hybridSearch(tenant, queryText, collectionNames, nResults, where, SELECTIVE_GATE_MAX);
+    }
+
+    /**
+     * Overload exposing the gate-selectivity threshold (nexus-lcogi). The 5-arg method
+     * delegates here with {@link #SELECTIVE_GATE_MAX}; a caller (or test) that knows its
+     * gate's selectivity can pin the dispatch — passing a small value forces the
+     * non-selective (HNSW-first) branch on a fixture-scale corpus without seeding
+     * {@code > SELECTIVE_GATE_MAX} matching rows.
+     *
+     * @param selectiveGateMax gate-match cutoff for the text-first vs HNSW-first dispatch;
+     *                         must be {@code >= 1} (a non-positive value would route every
+     *                         gate to HNSW-first and re-enable the collapse, so it is
+     *                         rejected).
+     */
+    public List<Map<String, Object>> hybridSearch(String tenant, String queryText,
+                                           List<String> collectionNames,
+                                           int nResults,
+                                           Map<String, Object> where,
+                                           int selectiveGateMax) {
         if (collectionNames == null || collectionNames.isEmpty()) {
             return List.of();
         }
@@ -489,6 +524,13 @@ public final class PgVectorRepository {
             // LIMIT -1 is "no limit" in Postgres - a non-positive value would silently
             // unbound the query instead of capping it.
             throw new IllegalArgumentException("nResults must be >= 1, got " + nResults);
+        }
+        if (selectiveGateMax < 1) {
+            // A non-positive threshold routes EVERY gate to the HNSW-first branch
+            // (matchCount >= 0 is always > a non-positive cutoff), silently re-enabling
+            // the lcogi selective-gate collapse. Reject rather than mis-dispatch.
+            throw new IllegalArgumentException(
+                "selectiveGateMax must be >= 1, got " + selectiveGateMax);
         }
         int dim = dimForCollection(collectionNames.get(0));
         for (String col : collectionNames) {
@@ -510,46 +552,91 @@ public final class PgVectorRepository {
                 + "-dim vector but the collections dispatch to chunks_" + dim);
         }
 
-        // Text gate: FTS lexeme match OR word-trigram similarity. The <% operator form
-        // (word_similarity(query, chunk_text) >= pg_trgm.word_similarity_threshold) is
-        // chosen over the explicit function call because only the operator family is
-        // supported by the gin_trgm_ops index (vectors-002); the threshold GUC is pinned
-        // per-transaction below so the gate never depends on cluster config.
-        // word_similarity (not plain similarity): plain similarity dilutes with
-        // chunk_text length and would silently kill the trgm leg on production-size
-        // chunks; word_similarity matches the query against the best continuous extent.
-        StringBuilder sql = new StringBuilder()
-            .append("SELECT chash, chunk_text, collection, metadata::text AS metadata_json,")
-            .append(" (embedding <=> ?::vector) AS distance")
-            .append(" FROM ").append(chunksTable(dim))
+        // Text gate fragment, shared by the COUNT probe and the ranked query. FTS lexeme
+        // match OR word-trigram similarity: the <% operator form (word_similarity >=
+        // pg_trgm.word_similarity_threshold) is gin_trgm_ops-indexable (vectors-002) where
+        // the function-call form is not; word_similarity (vs plain similarity) does not
+        // dilute with chunk_text length. The threshold GUC is pinned per-transaction below.
+        StringBuilder gate = new StringBuilder()
             .append(" WHERE collection IN (").append(placeholders(collectionNames.size())).append(")")
             .append(" AND (chunk_tsv @@ plainto_tsquery('english', ?) OR ? <% chunk_text)");
-        List<Object> binds = new ArrayList<>();
-        binds.add(vectorLiteral(queryVec));
-        binds.addAll(collectionNames);
-        binds.add(queryText);
-        binds.add(queryText);
+        List<Object> gateBinds = new ArrayList<>();
+        gateBinds.addAll(collectionNames);
+        gateBinds.add(queryText);
+        gateBinds.add(queryText);
         if (where != null) {
             for (Map.Entry<String, Object> e : where.entrySet()) {
-                sql.append(" AND metadata->>? = ?");
-                binds.add(e.getKey());
-                binds.add(String.valueOf(e.getValue()));
+                gate.append(" AND metadata->>? = ?");
+                gateBinds.add(e.getKey());
+                gateBinds.add(String.valueOf(e.getValue()));
             }
         }
-        sql.append(" ORDER BY distance ASC, chash ASC LIMIT ?");
-        binds.add(nResults);
+        final String table = chunksTable(dim);
+        final String gateSql = gate.toString();
+        final String vecLit = vectorLiteral(queryVec);
 
+        // SELECTIVITY-AWARE DISPATCH (nexus-lcogi). A cheap COUNT over the text gate (GIN
+        // bitmap, no embedding fetch) picks the plan that serves the gate's match count:
+        //
+        //   * SELECTIVE gate (count <= SELECTIVE_GATE_MAX): a MATERIALIZED CTE evaluates the
+        //     gate FIRST via the GIN indexes (optimization fence), then ranks the small
+        //     gated set by EXACT cosine distance. This is the lcogi fix — the prior
+        //     single-query HNSW-first plan (ORDER BY embedding, gate as scan filter)
+        //     collapsed here: a handful of matches in a large corpus rank past
+        //     hnsw.max_scan_tuples from the query vector, so the scan stops before reaching
+        //     them and the endpoint returns 0 rows (6 / 116k -> 0; full recall ~95s past
+        //     every HTTP timeout). Materializing the gate first is instant and exact, with
+        //     NO dependence on hnsw.max_scan_tuples / iterative_scan.
+        //
+        //   * NON-SELECTIVE gate (count > SELECTIVE_GATE_MAX): keep the HNSW-first plan
+        //     (gate as filter, iterative_scan). A dense gate is USUALLY found within the
+        //     scan budget at corpus-average embedding distributions, so it does not
+        //     collapse — and materializing a huge gated set (embeddings are ~4 KB/row: 80k
+        //     matches ≈ 320 MB) would spill work_mem and risk the very timeout lcogi is
+        //     about. NOTE this is a heuristic, not a guarantee: a SEMI-selective gate
+        //     (count in (SELECTIVE_GATE_MAX, hnsw.max_scan_tuples] whose matches all cluster
+        //     FAR from the query vector) can still under-return on this branch — the same
+        //     geometry as the original bug, in a narrower window. P5.2's RRF fusion closes
+        //     that window; the conexus xr7.8.9 gate should verify the non-selective path too
+        //     (latency + recall), not only the 6/116k selective case.
+        //
+        // COST: the non-selective path evaluates the gate TWICE (the COUNT probe + the scan
+        // filter), an accepted overhead of the targeted dispatch that P5.2 eliminates.
+        //
+        // count == 0 falls into the selective branch and returns an empty gated set — no
+        // special case.
         Result<Record> result = tenantScope.withTenant(tenant, ctx -> {
-            // Filtered-ANN recall: the text gate + RLS + where predicates narrow the
-            // candidate set even harder than plain search - keep HNSW scanning past
-            // ef_search (contract requirement; SET LOCAL is txn-scoped, pool-safe).
-            ctx.execute("SET LOCAL hnsw.iterative_scan = 'relaxed_order'");
-            // Trigram gate calibration (contract anchor): word_similarity >= 0.6,
-            // pg_trgm's default - typo-probe candidates sit at ~0.9 and pass, no-signal
-            // rows at ~0.1 do not. Pinned per-transaction so the gate is independent of
-            // cluster-level GUC configuration.
+            // Trigram gate calibration (contract anchor): word_similarity >= 0.6, pg_trgm's
+            // default - typo-probe candidates sit at ~0.9 and pass, no-signal rows at ~0.1
+            // do not. Pinned per-transaction so the gate is independent of cluster config.
             ctx.execute("SET LOCAL pg_trgm.word_similarity_threshold = 0.6");
-            return ctx.fetch(sql.toString(), binds.toArray());
+
+            long matchCount = ctx.fetchOne(
+                "SELECT count(*) FROM " + table + gateSql, gateBinds.toArray())
+                .get(0, Long.class);
+
+            if (matchCount <= selectiveGateMax) {
+                // Text-first: gate materialized via GIN, ranked by exact distance.
+                String sql = "WITH gated AS MATERIALIZED ("
+                    + "SELECT chash, chunk_text, collection, metadata, embedding FROM " + table + gateSql + ")"
+                    + " SELECT chash, chunk_text, collection, metadata::text AS metadata_json,"
+                    + " (embedding <=> ?::vector) AS distance"
+                    + " FROM gated ORDER BY distance ASC, chash ASC LIMIT ?";
+                List<Object> b = new ArrayList<>(gateBinds);
+                b.add(vecLit);
+                b.add(nResults);
+                return ctx.fetch(sql, b.toArray());
+            }
+            // HNSW-first for a dense gate: keep HNSW scanning past ef_search.
+            ctx.execute("SET LOCAL hnsw.iterative_scan = 'relaxed_order'");
+            String sql = "SELECT chash, chunk_text, collection, metadata::text AS metadata_json,"
+                + " (embedding <=> ?::vector) AS distance FROM " + table + gateSql
+                + " ORDER BY distance ASC, chash ASC LIMIT ?";
+            List<Object> b = new ArrayList<>();
+            b.add(vecLit);
+            b.addAll(gateBinds);
+            b.add(nResults);
+            return ctx.fetch(sql, b.toArray());
         });
 
         List<Map<String, Object>> rows = new ArrayList<>(result.size());

--- a/service/src/test/java/dev/nexus/service/HybridSelectiveGateTest.java
+++ b/service/src/test/java/dev/nexus/service/HybridSelectiveGateTest.java
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.nexus.service.db.TenantScope;
+import dev.nexus.service.vectors.PgVectorRepository;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RDR-156 P4 follow-on, bead nexus-lcogi — regression suite for the selective-text-gate
+ * collapse in {@link PgVectorRepository#hybridSearch}.
+ *
+ * <p>The bug (found by the conexus xr7.8.9 production gate, cloud 116k chunks): the prior
+ * single-query plan ran {@code ORDER BY embedding <=> q} on the HNSW index with the text
+ * gate as a SCAN FILTER. For a SELECTIVE gate (a few matches in a large corpus), the
+ * matches rank deeper than {@code hnsw.max_scan_tuples} from the query vector, so the HNSW
+ * scan terminates before reaching them and the endpoint returns 0 rows (full recall costs
+ * ~95s, past every HTTP timeout). The fix is a TEXT-FIRST plan: a {@code MATERIALIZED} CTE
+ * gates via the GIN indexes first, then ranks the (small) gated set by exact distance —
+ * no dependence on {@code hnsw.max_scan_tuples}.
+ *
+ * <p><strong>What this suite can and cannot prove.</strong> The runtime collapse is a
+ * production-scale (&gt;20k-row) phenomenon: at container scale Postgres cheaply uses the
+ * collection index + sort (or seqscans) and never picks the HNSW-first plan, so the
+ * collapse cannot be reproduced faithfully here — that production-scale recall
+ * verification is owned by the conexus xr7.8.9 gate (per the bead). What IS deterministic
+ * at fixture scale:
+ * <ul>
+ *   <li>{@link #explain_textFirstPlan_gatesViaGin_neverRanksViaHnsw} — the SELECTIVE-gate
+ *       plan shape: gate via the GIN indexes, rank as a Sort over the materialized set,
+ *       the HNSW index ({@code idx_chunks_1024_embedding}) never touched. This is the
+ *       scale-independent structural core of the fix (it is a transcription of the
+ *       text-first SQL the dispatch builds for a selective gate — the behavioral tests
+ *       below anchor that the production method actually produces these results).</li>
+ *   <li>{@link #hybridSearch_textFirst_returnsAllSelectiveMatches} /
+ *       {@link #hybridSearch_textFirst_excludesNonGatedFiller} — behavioral: the production
+ *       {@code hybridSearch} returns the COMPLETE selective gate even when the matches are
+ *       the FARTHEST vectors, and excludes vector-closest non-gated filler. (These pass on
+ *       the pre-fix impl too at fixture scale — they are correctness/regression anchors,
+ *       not the discriminating proof; that is the conexus gate's.)</li>
+ * </ul>
+ * No real embeddings: a {@code FakeEmbedder} pins both the stored and query vectors so the
+ * geometry is exact.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HybridSelectiveGateTest {
+
+    private static final String TENANT = "selgate-tenant";
+    private static final String SVC_ROLE = "svc_selgate_test";
+    private static final String SVC_PASS = "svc_selgate_pass";
+    private static final String COLL = "knowledge__selgate__voyage-context-3__v1";   // 1024
+
+    // Rare token present ONLY in the target rows — a selective gate.
+    private static final String TOKEN = "ztokenxyz";
+    private static final String QUERY = TOKEN;
+    private static final int FILLER = 250;   // near the query vector, NO token
+    private static final int TARGETS = 5;    // farthest from the query, carry the token
+
+    PostgreSQLContainer<?> pg;
+    HikariDataSource svcDs;
+    TenantScope tenantScope;
+    PgVectorRepository repo;
+    PgVectorRepositoryContractTest.FakeEmbedder embedder;
+    final List<String> targetChashes = new ArrayList<>();
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '" + SVC_ROLE
+                + "') THEN CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS
+                + "' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') "
+                + "THEN CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; "
+                + "END IF; END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            Database db = DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(su));
+            new Liquibase("db/changelog/db.changelog-master.xml",
+                          new ClassLoaderResourceAccessor(), db).update(new Contexts());
+        }
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus.chunks_1024 TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT ON nexus.catalog_collections TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+        }
+        var cfg = new HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(4);
+        cfg.setAutoCommit(true);
+        svcDs = new HikariDataSource(cfg);
+        tenantScope = new TenantScope(svcDs);
+        embedder = new PgVectorRepositoryContractTest.FakeEmbedder(1024);
+        repo = new PgVectorRepository(tenantScope, embedder, embedder);
+
+        seedFixtures();
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (svcDs != null) svcDs.close();
+        if (pg != null) pg.stop();
+    }
+
+    private void seedFixtures() throws Exception {
+        embedder.register(QUERY, 1.0f, 0.0f);   // query vector points at the filler cluster
+
+        List<String> ids = new ArrayList<>();
+        List<String> texts = new ArrayList<>();
+        List<Map<String, Object>> metas = new ArrayList<>();
+
+        // Filler: near the query vector (distance 0), NO token → not in the gate.
+        for (int i = 0; i < FILLER; i++) {
+            String text = "common filler document number " + i + " alpha bravo charlie";
+            embedder.register(text, 1.0f, 0.0f);
+            ids.add(chash("selfill", i));
+            texts.add(text);
+            metas.add(Map.of());
+        }
+        // Targets: FARTHEST from the query (distance 2.0), carry the rare token → the
+        // entire selective gate. A vector-biased plan reaches them last (or never).
+        for (int i = 0; i < TARGETS; i++) {
+            String text = TOKEN + " selective gate target row " + i;
+            embedder.register(text, -1.0f, 0.0f);
+            String c = chash("seltarget", i);
+            targetChashes.add(c);
+            ids.add(c);
+            texts.add(text);
+            metas.add(Map.of());
+        }
+
+        repo.upsertChunks(TENANT, COLL, ids, texts, metas);
+
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("ANALYZE nexus.chunks_1024");
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Structural proof: the rank no longer routes through the HNSW index, so the
+    // hnsw.max_scan_tuples budget cannot starve a selective gate.
+    //
+    // The runtime collapse itself is a production-scale (>20k-row) phenomenon — at
+    // container scale Postgres cheaply seqscans, so the bad plan cannot be forced
+    // faithfully; the production-scale recall verification is owned by the conexus
+    // xr7.8.9 gate (per the bead). What IS deterministic here is the PLAN SHAPE: the
+    // retired plan ranks via the HNSW index (idx_chunks_1024_embedding) with the gate as
+    // a filter (→ starvable); the text-first plan gates via the GIN indexes and sorts the
+    // materialized set, never touching the HNSW index (→ unstarvable).
+    // ════════════════════════════════════════════════════════════════════════
+
+    @Test
+    void explain_textFirstPlan_gatesViaGin_neverRanksViaHnsw() throws Exception {
+        // The exact shape PgVectorRepository.hybridSearch now builds.
+        String textFirst =
+            "WITH gated AS MATERIALIZED (" +
+            "  SELECT chash, chunk_text, collection, metadata, embedding FROM nexus.chunks_1024" +
+            "   WHERE collection = '" + COLL + "'" +
+            "     AND (chunk_tsv @@ plainto_tsquery('english', '" + TOKEN + "') OR '" + TOKEN + "' <% chunk_text))" +
+            " SELECT chash, (embedding <=> '" + vec(1.0, 0.0) + "'::vector) AS distance" +
+            " FROM gated ORDER BY distance ASC, chash ASC LIMIT 50";
+        String plan = explain(textFirst);
+        // The MATERIALIZED fence guarantees this REGARDLESS of scale or planner cost: the
+        // gate is its own CTE-scan node and the rank is a Sort over its output — the
+        // ORDER BY embedding can never be pushed into an HNSW index scan (which is what
+        // hnsw.max_scan_tuples starves). This is the scale-independent structural core of
+        // the fix; the production-scale recall collapse itself only manifests at >20k rows
+        // (the conexus xr7.8.9 gate owns that verification, per the bead).
+        assertThat(plan)
+            .as("text-first plan MUST NOT rank via the HNSW index — that is what made the "
+                + "retired plan starvable by hnsw.max_scan_tuples. Plan was:%n%s", plan)
+            .doesNotContain("idx_chunks_1024_embedding");
+        assertThat(plan)
+            .as("the gate MUST be evaluated via the GIN text indexes (tsv/trgm) first. "
+                + "Plan was:%n%s", plan)
+            .containsAnyOf("idx_chunks_1024_tsv", "idx_chunks_1024_trgm", "Bitmap Index Scan");
+        assertThat(plan)
+            .as("the rank MUST be a Sort over the materialized gated set (exact distance), "
+                + "not an index-ordered scan. Plan was:%n%s", plan)
+            .contains("Sort");
+    }
+
+    /** EXPLAIN with seqscan disabled so index access paths are chosen at fixture scale. */
+    private String explain(String inner) throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(false);
+            su.createStatement().execute("SET LOCAL enable_seqscan = off");
+            StringBuilder sb = new StringBuilder();
+            try (ResultSet rs = su.createStatement().executeQuery("EXPLAIN " + inner)) {
+                while (rs.next()) sb.append(rs.getString(1)).append('\n');
+            }
+            su.rollback();
+            return sb.toString();
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // The fix: text-first hybridSearch returns the COMPLETE selective gate.
+    // ════════════════════════════════════════════════════════════════════════
+
+    @Test
+    void hybridSearch_textFirst_returnsAllSelectiveMatches() {
+        List<Map<String, Object>> rows = repo.hybridSearch(TENANT, QUERY, List.of(COLL), 50, null);
+        List<String> ids = rows.stream().map(r -> (String) r.get("id")).toList();
+        assertThat(ids)
+            .as("text-first hybridSearch must return ALL %d selective-gate matches even "
+                + "though they are the FARTHEST vectors from the query — the gate is "
+                + "applied via the GIN bitmap first, then ranked by exact distance, with "
+                + "no hnsw.max_scan_tuples dependence", TARGETS)
+            .containsExactlyInAnyOrderElementsOf(targetChashes);
+    }
+
+    @Test
+    void hybridSearch_nonSelectiveBranch_returnsSameGateSet() {
+        // Force the NON-selective (HNSW-first) dispatch branch via the package-private
+        // threshold overload (count of 5 matches > threshold 3). The fixture is the same;
+        // the branch differs. Both branches are semantically equivalent — the dispatch is
+        // a performance choice — so the HNSW-first branch must return the identical gate
+        // set. (At fixture scale max_scan_tuples=20k scans all rows, so it does not
+        // collapse; this covers the branch the 16 selective contract tests never exercise.)
+        List<Map<String, Object>> rows =
+            repo.hybridSearch(TENANT, QUERY, List.of(COLL), 50, null, 3);
+        List<String> ids = rows.stream().map(r -> (String) r.get("id")).toList();
+        assertThat(ids)
+            .as("non-selective HNSW-first branch must return the same complete gate set as "
+                + "the text-first branch — dispatch is performance, not semantics")
+            .containsExactlyInAnyOrderElementsOf(targetChashes);
+    }
+
+    @Test
+    void hybridSearch_nonPositiveThreshold_rejected() {
+        // A non-positive selectiveGateMax would route every gate to HNSW-first and
+        // silently re-enable the collapse — it must fail loud, not mis-dispatch.
+        org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+                repo.hybridSearch(TENANT, QUERY, List.of(COLL), 50, null, 0))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("selectiveGateMax");
+    }
+
+    @Test
+    void hybridSearch_textFirst_excludesNonGatedFiller() {
+        // Non-vacuity for the gate: the 250 filler rows are vector-CLOSEST (distance 0)
+        // but carry no token, so a working text gate excludes every one of them.
+        List<Map<String, Object>> rows = repo.hybridSearch(TENANT, QUERY, List.of(COLL), 50, null);
+        assertThat(rows)
+            .as("filler rows (vector-closest, no token) must never appear — the text gate "
+                + "is load-bearing, not a vector passthrough")
+            .allSatisfy(r -> assertThat(targetChashes).contains((String) r.get("id")));
+        assertThat(rows).as("exactly the gate set, nothing else").hasSize(TARGETS);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /** 32-char chunk id: prefix + zero-padded index (chunks_<dim>.chash is 32 chars). */
+    private static String chash(String prefix, int i) {
+        String body = prefix + i;
+        if (body.length() > 32) throw new IllegalStateException("prefix too long");
+        return body + "0".repeat(32 - body.length());
+    }
+
+    /** 1024-dim pgvector literal with first two components (x, y), rest 0. */
+    private static String vec(double x, double y) {
+        StringBuilder sb = new StringBuilder("[").append(fmt(x)).append(',').append(fmt(y));
+        for (int i = 2; i < 1024; i++) sb.append(",0");
+        return sb.append("]").toString();
+    }
+
+    private static String fmt(double v) {
+        return v == Math.rint(v) ? Integer.toString((int) v) : Double.toString(v);
+    }
+}


### PR DESCRIPTION
## What

Fixes **nexus-lcogi** (P1, mirrored from conexus-1az; found by the conexus xr7.8.9 production gate on a 116k-chunk cloud corpus). `PgVectorRepository.hybridSearch` ran ONE query — HNSW `ORDER BY embedding` with the text gate as a scan filter. For a **selective** gate, the few matches rank past `hnsw.max_scan_tuples` (20k default) from the query vector, so the HNSW scan terminates before reaching them and the endpoint returns **0 rows** (6 matches / 116k → 0; full recall ~95s, past every HTTP timeout).

## Fix — selectivity-aware dispatch

A cheap `COUNT` over the text gate (GIN bitmap, no embedding fetch) picks the plan:

- **Selective** (`count <= SELECTIVE_GATE_MAX = 5000`): a `WITH gated AS MATERIALIZED (...)` CTE gates via the GIN indexes (`chunk_tsv` + `gin_trgm_ops`) **first**, then ranks the small gated set by **exact** cosine distance — no HNSW, no `max_scan_tuples` dependence, complete recall.
- **Non-selective** (`count > 5000`): keep the original HNSW-first plan. A dense gate is found within the scan budget so it doesn't collapse, and materializing a huge gated set (~4 KB/row → 320 MB at 80k matches) would spill `work_mem` and risk the same timeout.

So each input class stays on the plan that serves it — the fix adds no new pathological case. This is the "planner-aware dispatch on gate selectivity" the bead triage named. It's a **targeted fix**; RDR-156 P5.2 server-side RRF fusion supersedes it with a unified selectivity-aware plan, and its P5.G gate verifies the selective case at production scale.

## Scope / honesty

The >20k-row runtime collapse is not reproducible at container scale (the planner correctly avoids HNSW-first on small fixtures), so production-scale recall + latency verification is owned by the conexus xr7.8.9 gate (per the bead). Two residuals flagged for that gate, recorded on the bead: the non-selective path now pays a 2× GIN eval (COUNT + filter), and a semi-selective far-clustered window `(5000, max_scan_tuples]` can still under-return until P5.2.

## Tests

- 16 `PgVectorHybridSearchContractTest` pass — behavior preserved (text gate, exact rank, tombstone, RLS, multi-collection, where-filter, per-dim).
- New `HybridSelectiveGateTest` (5): EXPLAIN proves the selective plan ranks via a Sort over the GIN-gated set and never touches `idx_chunks_1024_embedding` (scale-independent structural core); returns all selective matches as the farthest vectors; excludes vector-closest non-gated filler; forced non-selective branch returns the identical gate set; non-positive threshold rejected.

Full service unit suite green.

## Review

Stacked review complete (code-review-expert + substantive-critic, 2 rounds). Round 1 found a Critical (the first cut regressed non-selective gates) → fixed via the dispatch. Round 2: both Criticals resolved; the three Significant findings (threshold guard, heuristic-not-guarantee comment, COUNT cost) all addressed in this commit.

## Closes
Mirrors conexus-1az (which stays as the conexus-side validation anchor).