### PR TITLE
feat(rdr-156): metadata-scoped subtree + where + author-ILIKE + chash [nexus-889ff]

### DIFF
--- a/service/src/main/java/dev/nexus/service/http/VectorHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/VectorHandler.java
@@ -284,10 +284,13 @@ public final class VectorHandler implements HttpHandler {
         String author            = optString(body, "author");
         Integer year             = optInteger(body, "year");
         String corpus            = optString(body, "corpus");
+        String subtree           = optString(body, "subtree");
+        Map<String, Object> where = optMap(body, "where");
         int nResults             = optInt(body, "n_results", 10);
 
         var results = repo.searchMetadataScoped(
-            tenant, queryText, collections, contentType, author, year, corpus, nResults);
+            tenant, queryText, collections, contentType, author, year, corpus,
+            subtree, where, nResults);
         HttpUtil.send(ex, 200, json(results));
     }
 

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -876,14 +876,35 @@ public final class PgVectorRepository {
      * de-duplication (keep best distance per id) is the {@code query}-tool repoint's
      * responsibility, not this method's.
      *
+     * <p>nexus-889ff extends the catalog dance coverage so the {@code query}-tool repoint
+     * can fully collapse: {@code subtree} is a tumbler-prefix scope; {@code where} is a
+     * chunk-metadata equality map (JSONB containment); {@code author} is matched
+     * case-insensitively as a SUBSTRING (ILIKE) — mirroring {@code query()}'s
+     * {@code author.lower() IN} semantics, not exact equality. Each returned row also
+     * carries the MATCHED chunk's {@code chash} (audit HIGH: the repoint populates the
+     * RDR-086 {@code chunk_text_hash} from it).
+     *
      * @param contentType catalog content_type filter; null = no filter
-     * @param author      catalog author filter; null = no filter
+     * @param author      catalog author SUBSTRING filter (ILIKE); null = no filter
      * @param year        catalog year filter; null = no filter
      * @param corpus      catalog corpus filter; null = no filter
+     * @param subtree     tumbler-prefix scope — DESCENDANTS only (root-exclusive, matching
+     *                    {@code cat.descendants()}); also filters alias rows; null = no filter
+     * @param where       chunk-metadata equality predicates (JSONB containment); null/empty
+     *                    = no filter
      */
     public List<Map<String, Object>> searchMetadataScoped(
             String tenant, String queryText, List<String> collectionNames,
             String contentType, String author, Integer year, String corpus, int nResults) {
+        return searchMetadataScoped(tenant, queryText, collectionNames, contentType, author,
+                                    year, corpus, null, null, nResults);
+    }
+
+    /** Full metadata-scoped search with subtree + where + ILIKE author + chash (nexus-889ff). */
+    public List<Map<String, Object>> searchMetadataScoped(
+            String tenant, String queryText, List<String> collectionNames,
+            String contentType, String author, Integer year, String corpus,
+            String subtree, Map<String, Object> where, int nResults) {
         if (collectionNames == null || collectionNames.isEmpty()) {
             return List.of();
         }
@@ -892,11 +913,12 @@ public final class PgVectorRepository {
         }
         int dim = requireHomogeneousDim(collectionNames);
         float[] queryVec = embedQuery(collectionNames.get(0), queryText, dim);
+        String whereJson = (where == null || where.isEmpty()) ? null : toJson(where);
 
-        String sql = "SELECT id, content, collection, distance"
+        String sql = "SELECT id, content, collection, distance, chash"
                    + " FROM nexus.search_metadata_scoped_" + dim
                    + "(?::vector, ARRAY[" + placeholders(collectionNames.size()) + "]::text[],"
-                   + " ?::text, ?::text, ?::int, ?::text, ?)";
+                   + " ?::text, ?::text, ?::int, ?::text, ?::text, ?::jsonb, ?)";
         List<Object> binds = new ArrayList<>();
         binds.add(vectorLiteral(queryVec));
         binds.addAll(collectionNames);
@@ -904,9 +926,11 @@ public final class PgVectorRepository {
         binds.add(author);
         binds.add(year);
         binds.add(corpus);
+        binds.add(subtree);
+        binds.add(whereJson);
         binds.add(nResults);
 
-        return runCombinedQuery(tenant, sql, binds);
+        return runCombinedQueryWithChash(tenant, sql, binds);
     }
 
     /**

--- a/service/src/main/resources/db/changelog/catalog-008-combined-query-extensions.xml
+++ b/service/src/main/resources/db/changelog/catalog-008-combined-query-extensions.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    RDR-156 P4 follow-on, bead nexus-889ff — extend search_metadata_scoped_<dim> so the
+    `query` tool's catalog dance can FULLY collapse onto the combined function (the
+    remaining cases beyond catalog-006's content_type/author/year/corpus).
+
+    Three additions + the shared audit-HIGH chash output:
+
+      * subtree (p_subtree): tumbler-prefix scope. Matches query()'s cat.descendants(),
+        which is ROOT-EXCLUSIVE (LIKE 'prefix.%' / startswith(prefix + '.') in both the
+        SQLite and HTTP catalog impls) — so the predicate is d.tumbler LIKE p_subtree||'.%'
+        WITHOUT a self-equality arm. Including the root would diverge from query() and the
+        repoint (rzqto) would silently change results. Also filters alias_of = '' so the
+        function never returns alias tumblers (query() dereferences via resolve(follow_alias);
+        a doc-level address is the canonical tumbler). query()'s subtree-depth>=3 guard stays
+        app-side in the repoint.
+
+      * where (p_where jsonb): chunk-metadata equality via JSONB containment
+        (c.metadata @> p_where). Mirrors the existing service `where` semantics
+        (hybridSearch's metadata equality) — equality only, which is all the service
+        ever supported; comparison ops (bib_year>=) were never service-side and map to
+        the typed catalog params (p_year) instead.
+
+      * author match-mode: catalog-006 did exact d.author = p_author, but query() uses
+        author.lower() IN (r.author or '').lower() — a case-insensitive SUBSTRING match.
+        Exact would silently regress "Hildebrand" vs "Hal Hildebrand". Switched to
+        d.author ILIKE '%' || p_author || '%'.
+
+      * chash output column (audit HIGH, shared with nexus-houg9): the function now
+        returns the MATCHED chunk's chash so the repoint (rzqto) populates the RDR-086
+        chunk_text_hash from the matched chunk, never a per-doc manifest guess.
+        chunks_<dim>.chash is the caller-provided id, never recomputed.
+
+    The 9-arg function REPLACES the catalog-006 7-arg version (dropped here so there is one
+    canonical signature; rollback recreates the 7-arg). Same discipline as catalog-006:
+    LANGUAGE sql STABLE SECURITY INVOKER NOT STRICT, query-vector-as-argument, inline
+    tombstone filter (deleted_at IS NULL), not joined to a view (keeps HNSW usable).
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="catalog-008-1" author="nexus-889ff">
+        <comment>search_metadata_scoped_384: add subtree + where(jsonb) + author ILIKE + chash output; replaces the 7-arg catalog-006 version</comment>
+        <sql splitStatements="false" stripComments="false">
+DROP FUNCTION IF EXISTS nexus.search_metadata_scoped_384(vector, text[], text, text, int, text, int);
+CREATE OR REPLACE FUNCTION nexus.search_metadata_scoped_384(
+    p_query        vector(384),
+    p_collections  text[],
+    p_content_type text,
+    p_author       text,
+    p_year         int,
+    p_corpus       text,
+    p_subtree      text,
+    p_where        jsonb,
+    p_n            int
+) RETURNS TABLE(id text, content text, collection text, distance float8, chash text)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    SELECT d.tumbler,
+           c.chunk_text,
+           c.collection,
+           (c.embedding &lt;=&gt; p_query)::float8,
+           c.chash
+      FROM nexus.chunks_384 c
+      JOIN nexus.catalog_document_chunks m
+        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d
+        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+     WHERE c.collection = ANY(p_collections)
+       AND d.deleted_at IS NULL
+       AND (p_content_type IS NULL OR d.content_type = p_content_type)
+       AND (p_author       IS NULL OR d.author ILIKE '%' || p_author || '%')
+       AND (p_year         IS NULL OR d.year         = p_year)
+       AND (p_corpus       IS NULL OR d.corpus       = p_corpus)
+       AND d.alias_of = ''
+       AND (p_subtree      IS NULL OR d.tumbler LIKE p_subtree || '.%')
+       AND (p_where        IS NULL OR c.metadata @&gt; p_where)
+     ORDER BY c.embedding &lt;=&gt; p_query
+     LIMIT p_n
+$$;
+        </sql>
+        <rollback>
+DROP FUNCTION IF EXISTS nexus.search_metadata_scoped_384(vector, text[], text, text, int, text, text, jsonb, int);
+CREATE OR REPLACE FUNCTION nexus.search_metadata_scoped_384(
+    p_query vector(384), p_collections text[], p_content_type text, p_author text,
+    p_year int, p_corpus text, p_n int
+) RETURNS TABLE(id text, content text, collection text, distance float8)
+LANGUAGE sql STABLE SECURITY INVOKER AS $$
+    SELECT d.tumbler, c.chunk_text, c.collection, (c.embedding &lt;=&gt; p_query)::float8
+      FROM nexus.chunks_384 c
+      JOIN nexus.catalog_document_chunks m ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+     WHERE c.collection = ANY(p_collections) AND d.deleted_at IS NULL
+       AND (p_content_type IS NULL OR d.content_type = p_content_type)
+       AND (p_author IS NULL OR d.author = p_author)
+       AND (p_year IS NULL OR d.year = p_year)
+       AND (p_corpus IS NULL OR d.corpus = p_corpus)
+     ORDER BY c.embedding &lt;=&gt; p_query LIMIT p_n
+$$;
+        </rollback>
+    </changeSet>
+
+    <changeSet id="catalog-008-2" author="nexus-889ff">
+        <comment>search_metadata_scoped_768: subtree + where + author ILIKE + chash</comment>
+        <sql splitStatements="false" stripComments="false">
+DROP FUNCTION IF EXISTS nexus.search_metadata_scoped_768(vector, text[], text, text, int, text, int);
+CREATE OR REPLACE FUNCTION nexus.search_metadata_scoped_768(
+    p_query        vector(768),
+    p_collections  text[],
+    p_content_type text,
+    p_author       text,
+    p_year         int,
+    p_corpus       text,
+    p_subtree      text,
+    p_where        jsonb,
+    p_n            int
+) RETURNS TABLE(id text, content text, collection text, distance float8, chash text)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    SELECT d.tumbler,
+           c.chunk_text,
+           c.collection,
+           (c.embedding &lt;=&gt; p_query)::float8,
+           c.chash
+      FROM nexus.chunks_768 c
+      JOIN nexus.catalog_document_chunks m
+        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d
+        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+     WHERE c.collection = ANY(p_collections)
+       AND d.deleted_at IS NULL
+       AND (p_content_type IS NULL OR d.content_type = p_content_type)
+       AND (p_author       IS NULL OR d.author ILIKE '%' || p_author || '%')
+       AND (p_year         IS NULL OR d.year         = p_year)
+       AND (p_corpus       IS NULL OR d.corpus       = p_corpus)
+       AND d.alias_of = ''
+       AND (p_subtree      IS NULL OR d.tumbler LIKE p_subtree || '.%')
+       AND (p_where        IS NULL OR c.metadata @&gt; p_where)
+     ORDER BY c.embedding &lt;=&gt; p_query
+     LIMIT p_n
+$$;
+        </sql>
+        <rollback>
+DROP FUNCTION IF EXISTS nexus.search_metadata_scoped_768(vector, text[], text, text, int, text, text, jsonb, int);
+CREATE OR REPLACE FUNCTION nexus.search_metadata_scoped_768(
+    p_query vector(768), p_collections text[], p_content_type text, p_author text,
+    p_year int, p_corpus text, p_n int
+) RETURNS TABLE(id text, content text, collection text, distance float8)
+LANGUAGE sql STABLE SECURITY INVOKER AS $$
+    SELECT d.tumbler, c.chunk_text, c.collection, (c.embedding &lt;=&gt; p_query)::float8
+      FROM nexus.chunks_768 c
+      JOIN nexus.catalog_document_chunks m ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+     WHERE c.collection = ANY(p_collections) AND d.deleted_at IS NULL
+       AND (p_content_type IS NULL OR d.content_type = p_content_type)
+       AND (p_author IS NULL OR d.author = p_author)
+       AND (p_year IS NULL OR d.year = p_year)
+       AND (p_corpus IS NULL OR d.corpus = p_corpus)
+     ORDER BY c.embedding &lt;=&gt; p_query LIMIT p_n
+$$;
+        </rollback>
+    </changeSet>
+
+    <changeSet id="catalog-008-3" author="nexus-889ff">
+        <comment>search_metadata_scoped_1024: subtree + where + author ILIKE + chash</comment>
+        <sql splitStatements="false" stripComments="false">
+DROP FUNCTION IF EXISTS nexus.search_metadata_scoped_1024(vector, text[], text, text, int, text, int);
+CREATE OR REPLACE FUNCTION nexus.search_metadata_scoped_1024(
+    p_query        vector(1024),
+    p_collections  text[],
+    p_content_type text,
+    p_author       text,
+    p_year         int,
+    p_corpus       text,
+    p_subtree      text,
+    p_where        jsonb,
+    p_n            int
+) RETURNS TABLE(id text, content text, collection text, distance float8, chash text)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    SELECT d.tumbler,
+           c.chunk_text,
+           c.collection,
+           (c.embedding &lt;=&gt; p_query)::float8,
+           c.chash
+      FROM nexus.chunks_1024 c
+      JOIN nexus.catalog_document_chunks m
+        ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d
+        ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+     WHERE c.collection = ANY(p_collections)
+       AND d.deleted_at IS NULL
+       AND (p_content_type IS NULL OR d.content_type = p_content_type)
+       AND (p_author       IS NULL OR d.author ILIKE '%' || p_author || '%')
+       AND (p_year         IS NULL OR d.year         = p_year)
+       AND (p_corpus       IS NULL OR d.corpus       = p_corpus)
+       AND d.alias_of = ''
+       AND (p_subtree      IS NULL OR d.tumbler LIKE p_subtree || '.%')
+       AND (p_where        IS NULL OR c.metadata @&gt; p_where)
+     ORDER BY c.embedding &lt;=&gt; p_query
+     LIMIT p_n
+$$;
+        </sql>
+        <rollback>
+DROP FUNCTION IF EXISTS nexus.search_metadata_scoped_1024(vector, text[], text, text, int, text, text, jsonb, int);
+CREATE OR REPLACE FUNCTION nexus.search_metadata_scoped_1024(
+    p_query vector(1024), p_collections text[], p_content_type text, p_author text,
+    p_year int, p_corpus text, p_n int
+) RETURNS TABLE(id text, content text, collection text, distance float8)
+LANGUAGE sql STABLE SECURITY INVOKER AS $$
+    SELECT d.tumbler, c.chunk_text, c.collection, (c.embedding &lt;=&gt; p_query)::float8
+      FROM nexus.chunks_1024 c
+      JOIN nexus.catalog_document_chunks m ON m.tenant_id = c.tenant_id AND m.collection = c.collection AND m.chash = c.chash
+      JOIN nexus.catalog_documents d ON d.tenant_id = m.tenant_id AND d.tumbler = m.doc_id
+     WHERE c.collection = ANY(p_collections) AND d.deleted_at IS NULL
+       AND (p_content_type IS NULL OR d.content_type = p_content_type)
+       AND (p_author IS NULL OR d.author = p_author)
+       AND (p_year IS NULL OR d.year = p_year)
+       AND (p_corpus IS NULL OR d.corpus = p_corpus)
+     ORDER BY c.embedding &lt;=&gt; p_query LIMIT p_n
+$$;
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -108,6 +108,14 @@
          vectors-001 (chunks_<dim>). Contract: GraphHopParityTest. -->
     <include file="db/changelog/catalog-007-graph-hop-functions.xml"/>
 
+    <!-- Combined-query metadata-scoped extensions (bead nexus-889ff, RDR-156 P4 follow-on):
+         extends search_metadata_scoped_<dim> with subtree (tumbler prefix), where (jsonb
+         chunk-metadata containment), author ILIKE substring, and the matched-chunk chash
+         output column — the remaining query()-dance cases so the repoint (rzqto) can fully
+         collapse. Replaces the catalog-006 7-arg version with a 9-arg signature. Depends on
+         catalog-006. -->
+    <include file="db/changelog/catalog-008-combined-query-extensions.xml"/>
+
     <!-- pgvector taxonomy centroids (bead nexus-t1hnc.1, RDR-156):
          taxonomy_centroids_384/768/1024 — moves the taxonomy__centroids ChromaDB
          collection into Postgres so service-mode taxonomy compute is chroma-free.

--- a/service/src/test/java/dev/nexus/service/CombinedQueryParityTest.java
+++ b/service/src/test/java/dev/nexus/service/CombinedQueryParityTest.java
@@ -114,6 +114,9 @@ class CombinedQueryParityTest {
     // is rightly NOT chosen — that is not what GROUP 3 is asserting.
     private static final String COLL_EXPLAIN = "knowledge__cqp-explain__voyage-context-3__v1";  // 1024
     private static final int    EXPLAIN_ROWS = 500;
+    // catalog-008 (nexus-889ff): subtree (dotted tumblers) + where (chunk metadata) fixtures.
+    private static final String COLL_SUB   = "knowledge__cqp-sub__voyage-context-3__v1";       // 1024
+    private static final String COLL_WHERE = "knowledge__cqp-where__voyage-context-3__v1";     // 1024
 
     // ── Topic labels ─────────────────────────────────────────────────────────
     private static final String TOPIC_VEC   = "Vector Search";
@@ -264,6 +267,22 @@ class CombinedQueryParityTest {
             seedMetaDoc(su, 1024, COLL_B, "b1", "paper", "zed", 2024, "research", 1.0, 0.0);
             seedTopicDoc(su, 1024, COLL_B, "b2", topicVecB, 1.0, 0.0);
 
+            // ----- subtree fixture (1024): dotted tumblers for the prefix predicate -----
+            // subtree="1.2" must match {1.2, 1.2.3, 1.2.4} (self + descendants) but NOT
+            // 1.3.1 (sibling subtree) and NOT 1.20 (prefix-string-but-not-tumbler-child).
+            insertCollection(su, TENANT_A, COLL_SUB);
+            seedMetaDoc(su, 1024, COLL_SUB, "1.2",   "paper", "sa", 2024, "research", 1.0, 0.0);  // 0.0
+            seedMetaDoc(su, 1024, COLL_SUB, "1.2.3", "paper", "sa", 2024, "research", 0.8, 0.6);  // 0.2
+            seedMetaDoc(su, 1024, COLL_SUB, "1.2.4", "paper", "sa", 2024, "research", 0.6, 0.8);  // 0.4
+            seedMetaDoc(su, 1024, COLL_SUB, "1.3.1", "paper", "sa", 2024, "research", 0.0, 1.0);  // 1.0 (sibling)
+            seedMetaDoc(su, 1024, COLL_SUB, "1.20",  "paper", "sa", 2024, "research", -1.0, 0.0); // 2.0 (string-prefix trap)
+
+            // ----- where fixture (1024): chunks carry metadata for the @> containment gate -----
+            insertCollection(su, TENANT_A, COLL_WHERE);
+            seedMetaDocMeta(su, COLL_WHERE, "w1", 1.0, 0.0, "{\"lang\": \"java\"}");   // 0.0
+            seedMetaDocMeta(su, COLL_WHERE, "w2", 0.8, 0.6, "{\"lang\": \"py\"}");     // 0.2
+            seedMetaDocMeta(su, COLL_WHERE, "w3", 0.6, 0.8, "{\"lang\": \"java\"}");   // 0.4
+
             // ----- large fixture for the EXPLAIN group (GROUP 3) -----
             seedExplainFixture(su);
 
@@ -334,12 +353,15 @@ class CombinedQueryParityTest {
                 .startsWith("p_query vector");
             assertThat(args)
                 .as("metadata-scoped signature pins the catalog dimensions the query "
-                    + "tool routes on: collections[], content_type, author, year, corpus, n")
+                    + "tool routes on: collections[], content_type, author, year, corpus, "
+                    + "subtree, where, n (catalog-008 added subtree + where(jsonb))")
                 .contains("p_collections text[]")
                 .contains("p_content_type text")
                 .contains("p_author text")
                 .contains("p_year integer")
                 .contains("p_corpus text")
+                .contains("p_subtree text")
+                .contains("p_where jsonb")
                 .contains("p_n integer");
         }
     }
@@ -711,6 +733,71 @@ class CombinedQueryParityTest {
     }
 
     // ══════════════════════════════════════════════════════════════════════════
+    // GROUP 9 — catalog-008 (nexus-889ff): subtree + where + author ILIKE + chash
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(90)
+    void author_ilikeSubstring_caseInsensitive() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            // query() uses author.lower() IN (substring) — NOT exact. A substring of the
+            // author and a different case must still match.
+            assertThat(callMeta(su, 1024, COLL_M, null, "lic", null, null, 10))
+                .as("author='lic' (substring of 'alice') → {m1,m3,m4} by distance — ILIKE "
+                    + "substring, not exact equality (exact would return nothing)")
+                .containsExactly("m1", "m3", "m4");
+            assertThat(callMeta(su, 1024, COLL_M, null, "ALICE", null, null, 10))
+                .as("author='ALICE' (wrong case) → same {m1,m3,m4} — ILIKE is case-insensitive")
+                .containsExactly("m1", "m3", "m4");
+        }
+    }
+
+    @Test @Order(91)
+    void subtree_matchesDescendants_notRootSiblingsOrStringPrefix() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            // ROOT-EXCLUSIVE, matching query()'s cat.descendants() (LIKE 'prefix.%'): the
+            // subtree root 1.2 itself is NOT returned — only descendants. Including the root
+            // would diverge from query() and silently change the repoint's results.
+            assertThat(callMetaFull(su, 1024, COLL_SUB, null, null, null, null, "1.2", null, 10))
+                .as("subtree='1.2' → descendants {1.2.3,1.2.4} ranked by distance; root 1.2 "
+                    + "EXCLUDED (matches cat.descendants), sibling 1.3.1 and string-prefix-trap "
+                    + "1.20 EXCLUDED")
+                .containsExactly("1.2.3", "1.2.4");
+        }
+    }
+
+    @Test @Order(92)
+    void where_jsonbContainment_filtersChunkMetadata() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(callMetaFull(su, 1024, COLL_WHERE, null, null, null, null, null,
+                                    "{\"lang\": \"java\"}", 10))
+                .as("where={lang:java} → {w1,w3} by distance (0.0,0.4); w2 (py) excluded")
+                .containsExactly("w1", "w3");
+            assertThat(callMetaFull(su, 1024, COLL_WHERE, null, null, null, null, null,
+                                    "{\"lang\": \"py\"}", 10))
+                .as("where={lang:py} → {w2} only")
+                .containsExactly("w2");
+        }
+    }
+
+    @Test @Order(93)
+    void chashColumn_isMatchedChunkChash() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT id, chash FROM nexus.search_metadata_scoped_1024(" +
+                queryVecLiteral(1024) + ", ARRAY['" + COLL_M + "']::text[], 'paper', " +
+                "NULL, NULL::int, NULL, NULL::text, NULL::jsonb, 10) ORDER BY distance");
+            int seen = 0;
+            while (rs.next()) {
+                assertThat(rs.getString("chash"))
+                    .as("chash column must be the matched chunk's chash for doc " + rs.getString("id"))
+                    .isEqualTo(validChash(rs.getString("id")));
+                seen++;
+            }
+            assertThat(seen).as("type=paper → m1,m2,m4,m5").isEqualTo(4);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
     // CALL HELPERS (combined-query functions)
     // ══════════════════════════════════════════════════════════════════════════
 
@@ -718,6 +805,16 @@ class CombinedQueryParityTest {
     private List<String> callMeta(Connection conn, int dim, String collection,
                                   String contentType, String author, Integer year,
                                   String corpus, int n) throws Exception {
+        return callMetaFull(conn, dim, collection, contentType, author, year, corpus,
+                            null, null, n);
+    }
+
+    /** Full metadata-scoped call with subtree + where (catalog-008). whereJson is a raw
+     *  JSON object literal (e.g. {@code "{\"tags\":\"arch\"}"}) or null. */
+    private List<String> callMetaFull(Connection conn, int dim, String collection,
+                                      String contentType, String author, Integer year,
+                                      String corpus, String subtree, String whereJson,
+                                      int n) throws Exception {
         String sql =
             "SELECT id FROM nexus.search_metadata_scoped_" + dim + "(" +
             queryVecLiteral(dim) + ", " +
@@ -726,6 +823,8 @@ class CombinedQueryParityTest {
             sqlText(author) + ", " +
             (year == null ? "NULL::int" : year.toString()) + ", " +
             sqlText(corpus) + ", " +
+            sqlText(subtree) + ", " +
+            (whereJson == null ? "NULL::jsonb" : "'" + whereJson.replace("'", "''") + "'::jsonb") + ", " +
             n + ")";
         return runIds(conn, sql);
     }
@@ -748,7 +847,7 @@ class CombinedQueryParityTest {
         String inner =
             "SELECT id FROM nexus.search_metadata_scoped_" + dim + "(" +
             queryVecLiteral(dim) + ", ARRAY['" + collection + "']::text[], " +
-            sqlText(contentType) + ", NULL, NULL::int, NULL, 10)";
+            sqlText(contentType) + ", NULL, NULL::int, NULL, NULL::text, NULL::jsonb, 10)";
         return explain(inner);
     }
 
@@ -817,7 +916,7 @@ class CombinedQueryParityTest {
             " WHERE m.collection = '" + collection + "' " +
             "   AND d.deleted_at IS NULL " +
             (contentType == null ? "" : "   AND d.content_type = " + sqlText(contentType) + " ") +
-            (author == null ? "" : "   AND d.author = " + sqlText(author) + " ") +
+            (author == null ? "" : "   AND d.author ILIKE '%' || " + sqlText(author) + " || '%' ") +
             " ORDER BY c.embedding <=> " + queryVecLiteral(dim) + " ASC";
         return runIds(conn, sql);
     }
@@ -864,6 +963,23 @@ class CombinedQueryParityTest {
                                   year, corpus);
         insertManifestRow(su, tenant, tumbler, 0, chash, collection);
         insertChunk(su, dim, tenant, collection, chash, tumbler, x, y);
+    }
+
+    /**
+     * Seed a 1024-dim doc whose CHUNK carries {@code metaJson} JSONB metadata — for the
+     * catalog-008 {@code where} containment gate (c.metadata @&gt; p_where).
+     */
+    private void seedMetaDocMeta(Connection su, String collection, String tumbler,
+                                 double x, double y, String metaJson) throws Exception {
+        String tenant = tenantFor(collection);
+        String chash = validChash(tumbler);
+        insertCatalogDocumentFull(su, tenant, tumbler, collection, "paper", "wa", 2024, "research");
+        insertManifestRow(su, tenant, tumbler, 0, chash, collection);
+        su.createStatement().execute(
+            "INSERT INTO nexus.chunks_1024 (tenant_id, collection, chash, chunk_text, embedding, metadata)"
+            + " VALUES ('" + tenant + "', '" + collection + "', '" + chash + "', '" + tumbler + "', "
+            + vec2(1024, x, y) + "::vector, '" + metaJson.replace("'", "''") + "'::jsonb)"
+            + " ON CONFLICT (tenant_id, collection, chash) DO NOTHING");
     }
 
     /**

--- a/service/src/test/java/dev/nexus/service/PgVectorCombinedQueryContractTest.java
+++ b/service/src/test/java/dev/nexus/service/PgVectorCombinedQueryContractTest.java
@@ -151,9 +151,11 @@ class PgVectorCombinedQueryContractTest {
             .containsExactly("m1", "m2");
         Map<String, Object> top = rows.get(0);
         assertThat(top.keySet())
-            .as("flat envelope: exactly id, content, distance, collection")
-            .containsExactlyInAnyOrder("id", "content", "distance", "collection");
+            .as("flat envelope: id, content, distance, collection, chash (catalog-008 "
+                + "added the matched-chunk chash for the query() repoint / RDR-086)")
+            .containsExactlyInAnyOrder("id", "content", "distance", "collection", "chash");
         assertThat(top.get("collection")).isEqualTo(COLL_M);
+        assertThat((String) top.get("chash")).as("chash is the matched chunk's hash").isNotBlank();
         assertThat(((Number) top.get("distance")).doubleValue()).isCloseTo(0.0, within());
     }
 

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -641,18 +641,23 @@ class HttpVectorClient:
         author: str | None = None,
         year: int | None = None,
         corpus: str | None = None,
+        subtree: str | None = None,
+        where: dict | None = None,
         n_results: int = 10,
     ) -> list[dict]:
-        """Metadata-scoped combined search (RDR-156 P4, Decision 5).
+        """Metadata-scoped combined search (RDR-156 P4, Decision 5; catalog-008).
 
         Routes to ``POST /v1/vectors/search-metadata-scoped`` —
-        ``nexus.search_metadata_scoped_<dim>`` (catalog-006), which joins the
-        chunk table to the catalog manifest + documents and filters by the
-        catalog metadata dimensions in ONE statement (the unification of the
-        ``query`` tool's app-side catalog-routing dance). A ``None`` filter is
-        omitted from the body (no filter on that dimension). Returns the flat
-        ``{id, content, distance, collection}`` row list; ``id`` is the document
-        tumbler (document-level retrieval — de-dup per id is the caller's job).
+        ``nexus.search_metadata_scoped_<dim>``, which joins the chunk table to
+        the catalog manifest + documents and filters by the catalog dimensions
+        in ONE statement (the unification of the ``query`` tool's app-side
+        catalog-routing dance). A ``None``/empty filter is omitted (no filter on
+        that dimension). ``author`` is matched case-insensitively as a SUBSTRING
+        (ILIKE), ``subtree`` is a tumbler-prefix scope, ``where`` is a
+        chunk-metadata equality map (JSONB containment). Returns the flat
+        ``{id, content, distance, collection, chash}`` row list; ``id`` is the
+        document tumbler (de-dup per id is the caller's job); ``chash`` is the
+        matched chunk's hash (RDR-086 ``chunk_text_hash`` source).
         """
         body: dict[str, Any] = {
             "query": query,
@@ -667,6 +672,10 @@ class HttpVectorClient:
             body["year"] = year
         if corpus is not None:
             body["corpus"] = corpus
+        if subtree is not None:
+            body["subtree"] = subtree
+        if where:
+            body["where"] = where
         return _post("/v1/vectors/search-metadata-scoped", body, tenant=self._tenant)
 
     def search_topic_scoped(

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1010,15 +1010,18 @@ def search_metadata_scoped(
     content_type: str = "",
     author: str = "",
     year: int = 0,
+    subtree: str = "",
+    where: str = "",
     structured: bool = False,
 ) -> "str | dict":
-    """Metadata-scoped combined search (RDR-156 P4, Decision 5).
+    """Metadata-scoped combined search (RDR-156 P4, Decision 5; catalog-008).
 
     The single-statement unification of the ``query`` tool's catalog-routing
     dance: ``nexus.search_metadata_scoped_<dim>`` joins the chunk table to the
     catalog manifest + documents and filters by catalog metadata in one query
     (HNSW survives the join). Document-level results (``id`` is the tumbler),
-    deduped to one row per tumbler at the best (nearest) distance.
+    deduped to one row per tumbler at the best (nearest) distance. Each row also
+    carries the matched chunk's ``chash`` (RDR-086 ``chunk_text_hash`` source).
 
     Service-mode only — the combined-query functions live in the pgvector
     Postgres; in local/Chroma mode this returns an error.
@@ -1035,9 +1038,14 @@ def search_metadata_scoped(
         corpus: Corpus prefixes or collection names, comma-separated; "all" for all.
         limit: Max rows.
         content_type: Catalog content_type filter ("" = no filter).
-        author: Catalog author filter ("" = no filter).
+        author: Catalog author SUBSTRING filter, case-insensitive (ILIKE; "" = no filter).
         year: Catalog year filter (0 = no filter).
-        structured: Return ``{ids, tumblers, distances, collections}`` for the plan runner.
+        subtree: Tumbler-prefix scope, e.g. "1.2" → the DESCENDANTS of 1.2 (root-exclusive,
+            matching the catalog's descendants()); alias rows excluded ("" = no filter).
+        where: Chunk-metadata equality filter, ``KEY=VALUE`` comma-separated, e.g.
+            "lang=java,kind=fn" ("" = no filter). Equality only (matches the service
+            ``where`` semantics); applied as JSONB containment on chunk metadata.
+        structured: Return ``{ids, tumblers, distances, collections, contents, chashes}``.
     """
     try:
         from nexus.db.http_vector_client import is_service_backed
@@ -1049,11 +1057,31 @@ def search_metadata_scoped(
         target = _resolve_corpus_target(corpus, t3)
         if not target:
             return f"No collections match corpus {corpus!r}"
+        # Parse the KEY=VALUE,... where string into a typed equality dict (applied as
+        # JSONB containment on chunk metadata). search_metadata_scoped is EQUALITY-ONLY
+        # (matches the service `where` semantics); reject comparison operators LOUDLY
+        # rather than silently mis-parsing them (a raw split would turn "bib_year>=2020"
+        # into the bogus key "bib_year>" and drop the filter — nexus-889ff review).
+        where_map: dict | None = None
+        if where.strip():
+            from nexus.filters import parse_where_str
+
+            parsed = parse_where_str(where)
+            if parsed and (
+                "$and" in parsed or "$or" in parsed
+                or any(isinstance(v, dict) for v in parsed.values())
+            ):
+                return ("Error: search_metadata_scoped `where` is equality-only "
+                        "(KEY=VALUE, comma-separated); comparison operators "
+                        "(>=, <=, >, <, !=) are not supported in service mode")
+            where_map = parsed or None
         rows = t3.search_metadata_scoped(
             query, target,
             content_type=content_type or None,
             author=author or None,
             year=(year or None),
+            subtree=(subtree or None),
+            where=(where_map or None),
             n_results=limit,
         )
         # Metadata-scoped is document-level: the function returns one row per
@@ -1081,6 +1109,9 @@ def search_metadata_scoped(
                 # $stepN.contents WITHOUT store_get_many hydration (which is
                 # chash-keyed and would miss these document tumblers).
                 "contents": [r.get("content", "") for r in rows],
+                # matched-chunk chash per row — the repoint wires this into the
+                # structured chunk_text_hash (RDR-086 chash-citations).
+                "chashes": [r.get("chash", "") for r in rows],
             }
         if not rows:
             return "No documents found."

--- a/tests/test_combined_query_mcp_tools.py
+++ b/tests/test_combined_query_mcp_tools.py
@@ -29,9 +29,10 @@ class _FakeServiceT3:
         self.graph_calls: list[tuple] = []
 
     def search_metadata_scoped(self, query, collection_names, *, content_type=None,
-                               author=None, year=None, corpus=None, n_results=10):
+                               author=None, year=None, corpus=None, subtree=None,
+                               where=None, n_results=10):
         self.meta_calls.append((query, list(collection_names), content_type, author,
-                                year, corpus, n_results))
+                                year, corpus, subtree, where, n_results))
         return self.meta_rows
 
     def search_topic_scoped(self, query, topic, collection, *, n_results=10):
@@ -61,9 +62,11 @@ class TestSearchMetadataScopedTool:
         t3 = _FakeServiceT3(meta_rows=rows)
         _wire(monkeypatch, t3, ["c1"])
 
+        rows[0]["chash"] = "a" * 32
+        rows[1]["chash"] = "b" * 32
         out = core.search_metadata_scoped(
             "q", corpus="knowledge", content_type="paper", author="alice",
-            year=2024, limit=5, structured=True)
+            year=2024, subtree="1.2", where="lang=java", limit=5, structured=True)
 
         assert out == {
             "ids": ["1.2.3", "1.2.4"],
@@ -71,15 +74,40 @@ class TestSearchMetadataScopedTool:
             "distances": [0.1, 0.3],
             "collections": ["c1", "c1"],
             "contents": ["a", "b"],
+            "chashes": ["a" * 32, "b" * 32],
         }
-        # filters forwarded; year=0/"" → None handled by the tool
-        assert t3.meta_calls == [("q", ["c1"], "paper", "alice", 2024, None, 5)]
+        # filters forwarded; year=0/"" → None; where string parsed to a dict
+        assert t3.meta_calls == [
+            ("q", ["c1"], "paper", "alice", 2024, None, "1.2", {"lang": "java"}, 5)]
 
     def test_empty_filters_become_none(self, monkeypatch):
         t3 = _FakeServiceT3(meta_rows=[])
         _wire(monkeypatch, t3, ["c1"])
         core.search_metadata_scoped("q", corpus="knowledge", structured=True)
-        assert t3.meta_calls == [("q", ["c1"], None, None, None, None, 10)]
+        assert t3.meta_calls == [
+            ("q", ["c1"], None, None, None, None, None, None, 10)]
+
+    def test_where_multi_pair_parsed(self, monkeypatch):
+        t3 = _FakeServiceT3(meta_rows=[])
+        _wire(monkeypatch, t3, ["c1"])
+        core.search_metadata_scoped("q", where="lang=java, kind=fn", structured=True)
+        assert t3.meta_calls[0][7] == {"lang": "java", "kind": "fn"}
+
+    def test_where_range_operator_rejected_loudly(self, monkeypatch):
+        # Equality-only: a comparison op must error, NOT silently parse to a bogus key
+        # ("bib_year>") that matches nothing and drops the filter (nexus-889ff review C2).
+        t3 = _FakeServiceT3(meta_rows=[])
+        _wire(monkeypatch, t3, ["c1"])
+        out = core.search_metadata_scoped("q", where="bib_year>=2020", structured=True)
+        assert isinstance(out, str) and out.startswith("Error:") and "equality-only" in out
+        assert t3.meta_calls == []  # rejected before dispatch
+
+    def test_where_numeric_equality_typed(self, monkeypatch):
+        # parse_where_str coerces known numeric fields → JSONB number, not string.
+        t3 = _FakeServiceT3(meta_rows=[])
+        _wire(monkeypatch, t3, ["c1"])
+        core.search_metadata_scoped("q", where="page_count=3", structured=True)
+        assert t3.meta_calls[0][7] == {"page_count": 3}
 
     def test_non_service_mode_errors(self, monkeypatch):
         t3 = _FakeServiceT3()

--- a/tests/test_http_vector_client_combined_query.py
+++ b/tests/test_http_vector_client_combined_query.py
@@ -79,6 +79,23 @@ class TestSearchMetadataScoped:
         _patch_post(monkeypatch, lambda p, b: [])
         assert HttpVectorClient().search_metadata_scoped("q", ["code__a__model-x__v1"]) == []
 
+    def test_subtree_and_where_forwarded(self, monkeypatch):
+        # catalog-008 (nexus-889ff): subtree + where(dict) reach the body; empty where omitted.
+        calls = _patch_post(monkeypatch, lambda p, b: [])
+        HttpVectorClient().search_metadata_scoped(
+            "q", ["code__a__model-x__v1"], subtree="1.2", where={"lang": "java"})
+        _, body = calls[0]
+        assert body["subtree"] == "1.2"
+        assert body["where"] == {"lang": "java"}
+
+    def test_empty_where_omitted(self, monkeypatch):
+        calls = _patch_post(monkeypatch, lambda p, b: [])
+        HttpVectorClient().search_metadata_scoped(
+            "q", ["code__a__model-x__v1"], where={})
+        _, body = calls[0]
+        assert "where" not in body
+        assert "subtree" not in body
+
 
 class TestSearchTopicScoped:
     def test_posts_to_topic_route(self, monkeypatch):


### PR DESCRIPTION
## What

RDR-156 P4 follow-on (`nexus-889ff`): extends the shipped `search_metadata_scoped_<dim>` combined-query function so the `query` MCP tool's catalog-routing dance can **fully collapse** onto it (the next bead, `nexus-rzqto`, does the actual repoint). Adds the remaining query() filters beyond content_type/author/year/corpus, plus the shared audit-HIGH chash output.

## Changes (catalog-008, replacing the catalog-006 7-arg version)

- **subtree** (`p_subtree`): tumbler-prefix scope, **root-exclusive** — `d.tumbler LIKE p_subtree||'.%'`, matching `cat.descendants()`. Also filters `d.alias_of = ''` so alias tumblers never surface.
- **where** (`p_where jsonb`): chunk-metadata equality via JSONB containment (`c.metadata @> p_where`). The MCP tool parses via `parse_where_str` and **rejects comparison operators** (`>=`,`<=`,`>`,`<`,`!=`) with a loud error — equality-only, matching service `where` semantics.
- **author**: exact `=` → `ILIKE '%'||p_author||'%'` (query() uses case-insensitive substring; exact would regress "Hildebrand" vs "Hal Hildebrand").
- **chash** output column (audit HIGH, shared with `nexus-houg9`): returns the matched chunk's chash so the repoint populates the RDR-086 `chunk_text_hash` from it.

Full stack: `PgVectorRepository.searchMetadataScoped` (5-arg backward-compat overload delegating to the 10-arg; reuses `runCombinedQueryWithChash`); `VectorHandler`; `http_vector_client`; `core.py` MCP tool (typed KEY=VALUE parse + chashes).

## Tests

`CombinedQueryParityTest` GROUP-9 (author ILIKE substring+case, subtree descendants-only excluding root/siblings/string-prefix-trap, where JSONB containment, chash column); signature → 9-arg; parity oracle → ILIKE. `PgVectorCombinedQueryContractTest` flat-shape → +chash. Python client + MCP tool tests (subtree/where/chashes, range-op rejection, numeric typing). Full service suite 730 green; `@integration` combined-query parity 3 green; Python 26 green.

## Review

Stacked review (code-review-expert + substantive-critic), 2 rounds. Round 1: code-review-expert APPROVED; substantive-critic found 2 Critical (subtree root-inclusion divergence from `cat.descendants()`; `where` range silent-corruption via raw `split("=")`) + 1 Significant (alias rows). **All fixed**; round 2 substantive-critic verdict: **justified, 0 Critical / 0 Significant**. S2 (subtree+author additivity) / M1 (author ILIKE wildcards) / corpus-routing documented as rzqto-facing notes on the bead (intentional capability differences, not regressions).

Unblocks `nexus-rzqto` (the query() repoint).