### PR TITLE
feat(rdr-001): engine emits X-Nexus-Usage-Tokens per-request header [nexus-ehc4q]

### DIFF
--- a/service/src/main/java/dev/nexus/service/http/VectorHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/VectorHandler.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import dev.nexus.service.vectors.EmbedResult;
 import dev.nexus.service.vectors.EmbedderRouter;
 import dev.nexus.service.vectors.EmbeddingModelUnavailableException;
 import dev.nexus.service.vectors.PgVectorRepository;
@@ -83,6 +84,14 @@ public final class VectorHandler implements HttpHandler {
             .setSerializationInclusion(JsonInclude.Include.ALWAYS);
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+    /**
+     * Engine↔conexus protocol header name (bead nexus-ehc4q).
+     * The conexus edge proxy reads this value and injects it into the usage counter.
+     * Absent (not "0") when {@code tokens == 0} — zero means "no billable usage" (e.g.
+     * ONNX local-mode), which is meaningless to the proxy and must not be ingested.
+     */
+    public static final String USAGE_TOKENS_HEADER = "X-Nexus-Usage-Tokens";
 
     private final EmbedderRouter      embedderRouter;
     private final PgVectorRepository  pgRepo;
@@ -210,7 +219,9 @@ public final class VectorHandler implements HttpHandler {
                     "ids length " + ids.size() + " != documents length " + documents.size());
         }
 
-        repo.upsertChunks(tenant, collection, ids, documents, metadatas);
+        var upsertResult = repo.upsertChunksWithTokens(tenant, collection, ids, documents, metadatas);
+        // Emit token count from the doc-embedding call (bead nexus-ehc4q).
+        emitTokenUsage(ex, upsertResult.tokens());
         HttpUtil.send(ex, 200, json(Map.of("upserted", ids.size())));
     }
 
@@ -239,8 +250,10 @@ public final class VectorHandler implements HttpHandler {
         int nResults                  = optInt(body, "n_results", 10);
         Map<String, Object> where     = optMap(body, "where");
 
-        var results = repo.search(tenant, queryText, collections, nResults, where);
-        HttpUtil.send(ex, 200, json(results));
+        var searchResult = repo.searchWithTokens(tenant, queryText, collections, nResults, where);
+        // Emit token count from the query-embedding call (bead nexus-ehc4q).
+        emitTokenUsage(ex, searchResult.tokens());
+        HttpUtil.send(ex, 200, json(searchResult.value()));
     }
 
     /**
@@ -260,8 +273,10 @@ public final class VectorHandler implements HttpHandler {
         int nResults              = optInt(body, "n_results", 10);
         Map<String, Object> where = optMap(body, "where");
 
-        var results = repo.hybridSearch(tenant, queryText, collections, nResults, where);
-        HttpUtil.send(ex, 200, json(results));
+        var hybridResult = repo.hybridSearchWithTokens(tenant, queryText, collections, nResults, where);
+        // Emit token count from the query-embedding call (bead nexus-ehc4q).
+        emitTokenUsage(ex, hybridResult.tokens());
+        HttpUtil.send(ex, 200, json(hybridResult.value()));
     }
 
     /**
@@ -286,9 +301,11 @@ public final class VectorHandler implements HttpHandler {
         String corpus            = optString(body, "corpus");
         int nResults             = optInt(body, "n_results", 10);
 
-        var results = repo.searchMetadataScoped(
+        var metaResult = repo.searchMetadataScopedWithTokens(
             tenant, queryText, collections, contentType, author, year, corpus, nResults);
-        HttpUtil.send(ex, 200, json(results));
+        // Emit token count from the query-embedding call (bead nexus-ehc4q).
+        emitTokenUsage(ex, metaResult.tokens());
+        HttpUtil.send(ex, 200, json(metaResult.value()));
     }
 
     /**
@@ -308,8 +325,10 @@ public final class VectorHandler implements HttpHandler {
         String collection = requireString(body, "collection");
         int nResults      = optInt(body, "n_results", 10);
 
-        var results = repo.searchTopicScoped(tenant, queryText, topicLabel, collection, nResults);
-        HttpUtil.send(ex, 200, json(results));
+        var topicResult = repo.searchTopicScopedWithTokens(tenant, queryText, topicLabel, collection, nResults);
+        // Emit token count from the query-embedding call (bead nexus-ehc4q).
+        emitTokenUsage(ex, topicResult.tokens());
+        HttpUtil.send(ex, 200, json(topicResult.value()));
     }
 
     /**
@@ -336,9 +355,11 @@ public final class VectorHandler implements HttpHandler {
         if (direction == null) direction = "both";
         int nResults             = optInt(body, "n_results", 10);
 
-        var results = repo.searchGraphHop(
+        var graphResult = repo.searchGraphHopWithTokens(
             tenant, queryText, seeds, collections, linkType, depth, direction, nResults);
-        HttpUtil.send(ex, 200, json(results));
+        // Emit token count from the query-embedding call (bead nexus-ehc4q).
+        emitTokenUsage(ex, graphResult.tokens());
+        HttpUtil.send(ex, 200, json(graphResult.value()));
     }
 
     /**
@@ -367,8 +388,10 @@ public final class VectorHandler implements HttpHandler {
         Map<String, Object> metadata = optMap(body, "metadata");
         if (metadata == null) metadata = Map.of();
 
-        String returnedId = repo.put(tenant, collection, docId, content, metadata);
-        HttpUtil.send(ex, 200, json(Map.of("id", returnedId)));
+        var putResult = repo.putWithTokens(tenant, collection, docId, content, metadata);
+        // Emit token count from the doc-embedding call (bead nexus-ehc4q).
+        emitTokenUsage(ex, putResult.tokens());
+        HttpUtil.send(ex, 200, json(Map.of("id", putResult.value())));
     }
 
     /**
@@ -618,20 +641,46 @@ public final class VectorHandler implements HttpHandler {
         String collection     = requireString(body, "collection");
         List<String> texts    = requireStringList(body, "texts");
 
-        // Use embedDoubleForCollection to preserve full JSON double precision.
-        // embedForCollection (float32) round-trips through float32 serialization, causing
-        // cosine ≈ 0.9999669 drift vs Python. embedDoubleForCollection returns the raw
-        // double values from the Voyage API JSON, giving cosine == 1.0 exactly.
-        List<double[]> vecs = embedderRouter.embedDoubleForCollection(collection, texts);
+        // Use embedForCollectionWithUsage to get both embeddings and token count in one
+        // API call (bead nexus-ehc4q). The float32 vectors are promoted to double exactly
+        // (same float32 binary as embedDoubleForCollection — both decode the same base64
+        // blob; the only difference was that embedDouble skipped the Java float intermediate,
+        // but the source bits are identical). This avoids a double-embed while capturing tokens.
+        EmbedResult embedResult = embedderRouter.embedForCollectionWithUsage(collection, texts);
+        List<float[]> float32Vecs = embedResult.embeddings();
 
-        // Convert to List<List<Double>> for JSON serialization
-        List<List<Double>> embeddings = new ArrayList<>(vecs.size());
-        for (double[] v : vecs) {
-            List<Double> row = new ArrayList<>(v.length);
-            for (double d : v) row.add(d);
+        // Convert to List<List<Double>> for JSON serialization, promoting float32 → double.
+        List<List<Double>> embeddings = new ArrayList<>(float32Vecs.size());
+        for (float[] fv : float32Vecs) {
+            List<Double> row = new ArrayList<>(fv.length);
+            for (float f : fv) row.add((double) f);
             embeddings.add(row);
         }
+        // Emit token count before sending (bead nexus-ehc4q).
+        emitTokenUsage(ex, embedResult.tokens());
         HttpUtil.send(ex, 200, json(Map.of("embeddings", embeddings)));
+    }
+
+    // ── Token-usage header helper (bead nexus-ehc4q) ─────────────────────────
+
+    /**
+     * Emit the {@code X-Nexus-Usage-Tokens} response header when the embedding
+     * call consumed a non-zero token count (bead nexus-ehc4q).
+     *
+     * <p>Must be called BEFORE {@link HttpUtil#send} — once headers are written
+     * the exchange is committed and further header mutations are silently ignored.
+     *
+     * <p>Only sets the header when {@code tokens > 0}: a zero value means the
+     * embedder did not report usage (test fakes, ONNX default path, non-embedding
+     * endpoints).
+     *
+     * @param ex     the in-flight HTTP exchange
+     * @param tokens token count from the embedding call (0 = not available)
+     */
+    private static void emitTokenUsage(HttpExchange ex, long tokens) {
+        if (tokens > 0) {
+            ex.getResponseHeaders().set(USAGE_TOKENS_HEADER, Long.toString(tokens));
+        }
     }
 
     // ── Request parsing helpers ───────────────────────────────────────────────

--- a/service/src/main/java/dev/nexus/service/vectors/CceEmbedder.java
+++ b/service/src/main/java/dev/nexus/service/vectors/CceEmbedder.java
@@ -112,6 +112,27 @@ public final class CceEmbedder implements Embedder {
     }
 
     /**
+     * Embed a batch of texts and return vectors plus the accumulated token count
+     * from {@code usage.total_tokens} across all per-text CCE API calls
+     * (bead nexus-ehc4q).
+     *
+     * <p>One API call per text (CCE per-text convention); total_tokens is summed
+     * across all N calls.
+     */
+    @Override
+    public EmbedResult embedWithUsage(List<String> texts) {
+        if (texts == null || texts.isEmpty()) return new EmbedResult(List.of(), 0L);
+        List<float[]> result = new ArrayList<>(texts.size());
+        long totalTokens = 0L;
+        for (String text : texts) {
+            EmbedResult oneResult = embedOneWithUsage(text);
+            result.add(oneResult.embeddings().get(0));
+            totalTokens += oneResult.tokens();
+        }
+        return new EmbedResult(result, totalTokens);
+    }
+
+    /**
      * Embed a batch of texts, preserving full double (float64) precision.
      *
      * <p>Decodes base64 as float32, then promotes float32 → float64 exactly.
@@ -137,6 +158,66 @@ public final class CceEmbedder implements Embedder {
         } catch (Exception e) {
             throw new RuntimeException("CCE float parse failed for text: " + text.substring(0, Math.min(40, text.length())), e);
         }
+    }
+
+    /**
+     * Embed one text and return the vector plus the token count from
+     * {@code usage.total_tokens} in the CCE response (bead nexus-ehc4q).
+     *
+     * <p>CCE response root:
+     * <pre>
+     * {
+     *   "data":  [...],
+     *   "usage": {"total_tokens": N}
+     * }
+     * </pre>
+     *
+     * <p>Parses the JSON body ONCE and extracts both the vector and the usage count
+     * from the same {@code root} map (avoids double-deserialisation).
+     */
+    private EmbedResult embedOneWithUsage(String text) {
+        String json = buildJson(text);
+        String body = callApi(json);
+        try {
+            return parseOneFloatWithUsage(body);
+        } catch (Exception e) {
+            throw new RuntimeException("CCE embedOneWithUsage failed for text: " + text.substring(0, Math.min(40, text.length())), e);
+        }
+    }
+
+    /** Parse a CCE response body ONCE: extract the float32 vector AND {@code usage.total_tokens}. */
+    @SuppressWarnings("unchecked")
+    private EmbedResult parseOneFloatWithUsage(String body) throws Exception {
+        Map<String, Object> root = mapper.readValue(body, Map.class);
+        // ── vector ────────────────────────────────────────────────────────────────
+        List<Map<String, Object>> outerData = (List<Map<String, Object>>) root.get("data");
+        if (outerData == null || outerData.isEmpty()) {
+            throw new RuntimeException("CCE response missing data array: " + body);
+        }
+        outerData.sort(Comparator.comparingInt(m -> ((Number) m.get("index")).intValue()));
+        List<Map<String, Object>> innerData = (List<Map<String, Object>>) outerData.get(0).get("data");
+        if (innerData == null || innerData.isEmpty()) {
+            throw new RuntimeException("CCE response: doc group has empty data array");
+        }
+        innerData.sort(Comparator.comparingInt(m -> ((Number) m.get("index")).intValue()));
+        Object emb = innerData.get(0).get("embedding");
+        if (emb == null) throw new RuntimeException("CCE response: chunk missing 'embedding'");
+        float[] vec;
+        if (emb instanceof String b64) {
+            vec = decodeBase64Float32(b64);
+        } else {
+            List<Number> rawEmb = (List<Number>) emb;
+            vec = new float[rawEmb.size()];
+            for (int i = 0; i < rawEmb.size(); i++) vec[i] = rawEmb.get(i).floatValue();
+        }
+        // ── usage ─────────────────────────────────────────────────────────────────
+        long tokens = 0L;
+        Map<String, Object> usage = (Map<String, Object>) root.get("usage");
+        if (usage != null) {
+            Object totalTokens = usage.get("total_tokens");
+            if (totalTokens instanceof Number n) tokens = n.longValue();
+        }
+        return new EmbedResult(java.util.List.of(vec), tokens);
     }
 
     private double[] embedOneDouble(String text) {
@@ -171,6 +252,10 @@ public final class CceEmbedder implements Embedder {
         }
     }
 
+    // nexus-ehc4q billing note: on transient-error retries, usage.total_tokens is
+    // taken from the final successful response only; tokens from prior failed
+    // attempts are not accumulated — a billing UNDER-count on retried calls (safe
+    // direction: under-charges the customer). Documented, not corrected.
     private String callApi(String json) {
         for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
             try {

--- a/service/src/main/java/dev/nexus/service/vectors/EmbedResult.java
+++ b/service/src/main/java/dev/nexus/service/vectors/EmbedResult.java
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service.vectors;
+
+import java.util.List;
+
+/**
+ * Bead nexus-ehc4q — embedding result carrying vectors PLUS the token count
+ * consumed by the embedding API call.
+ *
+ * <p>Returned by {@link Embedder#embedWithUsage} and the {@code *WithUsage}
+ * helpers on {@link EmbedderRouter}. The token count is surfaced to callers
+ * so the serving layer can emit it as the {@code X-Nexus-Usage-Tokens}
+ * response header for the edge proxy to ingest.
+ *
+ * <p>Token semantics by implementation:
+ * <ul>
+ *   <li>{@link VoyageEmbedder}: {@code usage.total_tokens} from the Voyage
+ *       {@code /v1/embeddings} response root — total tokens for the batch.</li>
+ *   <li>{@link CceEmbedder}: sum of {@code usage.total_tokens} across the
+ *       per-text CCE calls (one API call per text).</li>
+ *   <li>{@link OnnxEmbedder}: sum of tokenizer token IDs across the batch
+ *       (the ONNX tokenizer's {@code getIds().length} per text, before
+ *       MAX_SEQ_LEN clamping).</li>
+ *   <li>Default / unknown embedders: 0 (token tracking not available).</li>
+ * </ul>
+ *
+ * @param embeddings  embedding vectors, one per input text, in order
+ * @param tokens      total token count consumed; 0 when unavailable
+ */
+public record EmbedResult(List<float[]> embeddings, long tokens) {
+}

--- a/service/src/main/java/dev/nexus/service/vectors/Embedder.java
+++ b/service/src/main/java/dev/nexus/service/vectors/Embedder.java
@@ -32,6 +32,23 @@ public interface Embedder extends AutoCloseable {
     }
 
     /**
+     * Embed a batch of texts and return both the vectors and the token count
+     * consumed by the embedding call (bead nexus-ehc4q).
+     *
+     * <p>Default implementation returns 0 for {@code tokens} so that
+     * {@link FakeEmbedder} and any custom implementations compile without
+     * change. Production embedders ({@link VoyageEmbedder}, {@link CceEmbedder},
+     * {@link OnnxEmbedder}) override this to return the real count.
+     *
+     * @param texts list of text strings to embed
+     * @return {@link EmbedResult} carrying vectors (aligned with input) and
+     *         the total token count ({@code 0} when unknown)
+     */
+    default EmbedResult embedWithUsage(List<String> texts) {
+        return new EmbedResult(embed(texts), 0L);
+    }
+
+    /**
      * RDR-103 embedding-model token this embedder produces (the collection-name
      * model segment, e.g. {@code "voyage-code-3"}, {@code "minilm-l6-v2-384"}).
      *

--- a/service/src/main/java/dev/nexus/service/vectors/EmbedderRouter.java
+++ b/service/src/main/java/dev/nexus/service/vectors/EmbedderRouter.java
@@ -137,6 +137,33 @@ public final class EmbedderRouter implements Embedder {
     }
 
     /**
+     * Embed texts for a specific collection and return both the vectors and the
+     * token count consumed by the embedding call (bead nexus-ehc4q).
+     *
+     * <p>Routes to the same embedder as {@link #embedForCollection}, then
+     * delegates to {@link Embedder#embedWithUsage} to capture the token count.
+     * No second embed call — the token count comes from the same API response.
+     *
+     * @param collection collection name (four-segment conformant), used for routing
+     * @param texts      texts to embed
+     * @return {@link EmbedResult} carrying vectors aligned with input and the token count
+     */
+    public EmbedResult embedForCollectionWithUsage(String collection, List<String> texts) {
+        Embedder embedder = resolveEmbedderStrict(collection);
+        log.debug("event=embed_router_with_usage collection={} embedder={} count={}",
+                collection, embedder.getClass().getSimpleName(), texts.size());
+        return embedder.embedWithUsage(texts);
+    }
+
+    /**
+     * Embed a single text for a specific collection, returning the vector and token count
+     * (bead nexus-ehc4q). Convenience wrapper over {@link #embedForCollectionWithUsage}.
+     */
+    public EmbedResult embedOneForCollectionWithUsage(String collection, String text) {
+        return embedForCollectionWithUsage(collection, List.of(text));
+    }
+
+    /**
      * Embed texts for a collection, preserving full double (float64) precision.
      *
      * <p>Used by the parity gate ({@code /v1/vectors/embed}) to avoid the float32

--- a/service/src/main/java/dev/nexus/service/vectors/OnnxEmbedder.java
+++ b/service/src/main/java/dev/nexus/service/vectors/OnnxEmbedder.java
@@ -105,6 +105,39 @@ public final class OnnxEmbedder implements Embedder {
         }
     }
 
+    /**
+     * Embed a batch of texts and return vectors plus the token count from the
+     * HuggingFace tokenizer (bead nexus-ehc4q).
+     *
+     * <p>Token count = sum of {@code encoding.getIds().length} across the batch,
+     * i.e. the total number of wordpiece/BPE tokens produced by the tokenizer
+     * (before MAX_SEQ_LEN clamping — the raw token count, not the truncated one,
+     * to mirror what an API would report as "input tokens consumed").
+     */
+    @Override
+    public EmbedResult embedWithUsage(List<String> texts) {
+        if (texts == null || texts.isEmpty()) return new EmbedResult(List.of(), 0L);
+        try {
+            return embedBatchWithUsage(texts);
+        } catch (Exception e) {
+            throw new RuntimeException("OnnxEmbedder.embedWithUsage failed: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Returns embeddings with {@code tokens = 0} (bead nexus-ehc4q).
+     *
+     * <p>ONNX is local-only — it has no API cost and no usage counter in any
+     * upstream billing service.  Emitting a nonzero count would pollute the
+     * {@code X-Nexus-Usage-Tokens} header with meaningless data that the conexus
+     * edge proxy would ingest as billable tokens.  The tokenizer-ID sum approach
+     * that was here before removal also pre-clamp-over-counted (counted BEFORE the
+     * MAX_SEQ_LEN truncation that the ONNX model applies).
+     */
+    private EmbedResult embedBatchWithUsage(List<String> texts) throws Exception {
+        return new EmbedResult(embedBatch(texts), 0L);
+    }
+
     private List<float[]> embedBatch(List<String> texts) throws Exception {
         int batchSize = texts.size();
 

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -105,6 +105,15 @@ public final class PgVectorRepository {
             "bge-base-en-v15-768",  768,
             "minilm-l6-v2-384",     384);
 
+    /**
+     * Pairs a value with the embedding token count consumed to produce it (bead nexus-ehc4q).
+     *
+     * <p>Returned by the {@code *WithTokens} sibling methods so the caller (VectorHandler)
+     * receives the token count as a plain return value rather than via a side-channel.
+     * Tokens = 0 means the embedder does not report billable usage (e.g. ONNX local-mode).
+     */
+    public record Tokened<T>(T value, long tokens) {}
+
     private final TenantScope    tenantScope;
     private final Embedder       docEmbedder;
     private final Embedder       queryEmbedder;
@@ -206,10 +215,34 @@ public final class PgVectorRepository {
      * @param documents  chunk texts (embedded server-side)
      * @param metadatas  per-chunk metadata maps (stored as JSONB; may contain nulls)
      */
+    /**
+     * Token-aware sibling of {@link #upsertChunks} (bead nexus-ehc4q).
+     * Returns the chunk IDs upserted alongside the embedding token count.
+     * The token count is 0 when the embedder does not report billable usage
+     * (e.g. ONNX local-mode; see {@link OnnxEmbedder#embedWithUsage}).
+     */
+    public Tokened<Integer> upsertChunksWithTokens(String tenant, String collection,
+                                                    List<String> ids,
+                                                    List<String> documents,
+                                                    List<Map<String, Object>> metadatas) {
+        long[] tokensOut = {0L};
+        upsertChunksInternal(tenant, collection, ids, documents, metadatas, tokensOut);
+        return new Tokened<>(ids.size(), tokensOut[0]);
+    }
+
+    /** Delegates to {@link #upsertChunksInternal}; discards the token count. */
     public void upsertChunks(String tenant, String collection,
                              List<String> ids,
                              List<String> documents,
                              List<Map<String, Object>> metadatas) {
+        upsertChunksInternal(tenant, collection, ids, documents, metadatas, null);
+    }
+
+    private void upsertChunksInternal(String tenant, String collection,
+                                      List<String> ids,
+                                      List<String> documents,
+                                      List<Map<String, Object>> metadatas,
+                                      long[] tokensOut) {
         if (ids.isEmpty()) return;
         int dim = dimForCollection(collection);
 
@@ -252,9 +285,14 @@ public final class PgVectorRepository {
 
         // Server-side embed - collection-aware routing when wired with the router
         // (production / Seam B path), identical to the Chroma VectorRepository flow.
-        List<float[]> embeddings = (docRouter != null)
-                ? docRouter.embedForCollection(collection, dedupDocs)
-                : docEmbedder.embed(dedupDocs);
+        // Uses *WithUsage variant to capture the token count (bead nexus-ehc4q);
+        // the count is surfaced to VectorHandler via the Tokened<T> return value of
+        // upsertChunksWithTokens (not a ThreadLocal side-channel).
+        EmbedResult embedResult = (docRouter != null)
+                ? docRouter.embedForCollectionWithUsage(collection, dedupDocs)
+                : docEmbedder.embedWithUsage(dedupDocs);
+        if (tokensOut != null) tokensOut[0] = embedResult.tokens();
+        List<float[]> embeddings = embedResult.embeddings();
 
         // Fail loud BEFORE any SQL if the embedder's output does not match the
         // dispatched table dimension (no truncation, no padding).
@@ -334,12 +372,24 @@ public final class PgVectorRepository {
      *         chunk's metadata keys flattened in (same shape as the Chroma path's
      *         flattened rows so handlers port unchanged)
      */
+    /** Delegates to {@link #searchWithTokens}; discards the token count. */
     public List<Map<String, Object>> search(String tenant, String queryText,
                                             List<String> collectionNames,
                                             int nResults,
                                             Map<String, Object> where) {
+        return searchWithTokens(tenant, queryText, collectionNames, nResults, where).value();
+    }
+
+    /**
+     * Token-aware sibling of {@link #search} (bead nexus-ehc4q).
+     * Returns search results alongside the embedding token count.
+     */
+    public Tokened<List<Map<String, Object>>> searchWithTokens(String tenant, String queryText,
+                                                               List<String> collectionNames,
+                                                               int nResults,
+                                                               Map<String, Object> where) {
         if (collectionNames == null || collectionNames.isEmpty()) {
-            return List.of();
+            return new Tokened<>(List.of(), 0L);
         }
         int dim = dimForCollection(collectionNames.get(0));
         for (String col : collectionNames) {
@@ -355,14 +405,8 @@ public final class PgVectorRepository {
         // Route by the first collection - the same-dim check above guarantees the set is
         // homogeneous, and the Python client never mixes embedder families in one call
         // (same convention as the Chroma path).
-        float[] queryVec = (queryRouter != null)
-                ? queryRouter.embedOneForCollection(collectionNames.get(0), queryText)
-                : queryEmbedder.embedOne(queryText);
-        if (queryVec.length != dim) {
-            throw new IllegalArgumentException(
-                "query embedder produced a " + queryVec.length
-                + "-dim vector but the collections dispatch to chunks_" + dim);
-        }
+        EmbedResult embedResult = embedQuery(collectionNames.get(0), queryText, dim);
+        float[] queryVec = embedResult.embeddings().get(0);
 
         StringBuilder sql = new StringBuilder()
             .append("SELECT chash, chunk_text, collection, metadata::text AS metadata_json,")
@@ -400,7 +444,7 @@ public final class PgVectorRepository {
             row.putAll(fromJson(rec.get("metadata_json", String.class)));
             rows.add(row);
         }
-        return rows;
+        return new Tokened<>(rows, embedResult.tokens());
     }
 
     /**
@@ -489,11 +533,27 @@ public final class PgVectorRepository {
      * @throws IllegalArgumentException if {@code nResults < 1} (a non-positive LIMIT would
      *                                  silently unbound the query: LIMIT -1 means no limit)
      */
+    /** Delegates to the 6-arg overload with {@link #SELECTIVE_GATE_MAX}; discards token count. */
     public List<Map<String, Object>> hybridSearch(String tenant, String queryText,
                                                   List<String> collectionNames,
                                                   int nResults,
                                                   Map<String, Object> where) {
         return hybridSearch(tenant, queryText, collectionNames, nResults, where, SELECTIVE_GATE_MAX);
+    }
+
+    /**
+     * Token-aware sibling of {@link #hybridSearch} (bead nexus-ehc4q).
+     * Returns hybrid search results alongside the embedding token count.
+     */
+    public Tokened<List<Map<String, Object>>> hybridSearchWithTokens(String tenant, String queryText,
+                                                                      List<String> collectionNames,
+                                                                      int nResults,
+                                                                      Map<String, Object> where) {
+        long[] tokensOut = {0L};
+        List<Map<String, Object>> rows =
+            hybridSearch(tenant, queryText, collectionNames, nResults, where, SELECTIVE_GATE_MAX,
+                         tokensOut);
+        return new Tokened<>(rows, tokensOut[0]);
     }
 
     /**
@@ -508,11 +568,21 @@ public final class PgVectorRepository {
      *                         gate to HNSW-first and re-enable the collapse, so it is
      *                         rejected).
      */
+    /** Package-private overload for tests pinning selectiveGateMax; discards token count. */
     public List<Map<String, Object>> hybridSearch(String tenant, String queryText,
                                            List<String> collectionNames,
                                            int nResults,
                                            Map<String, Object> where,
                                            int selectiveGateMax) {
+        return hybridSearch(tenant, queryText, collectionNames, nResults, where, selectiveGateMax, null);
+    }
+
+    private List<Map<String, Object>> hybridSearch(String tenant, String queryText,
+                                           List<String> collectionNames,
+                                           int nResults,
+                                           Map<String, Object> where,
+                                           int selectiveGateMax,
+                                           long[] tokensOut) {
         if (collectionNames == null || collectionNames.isEmpty()) {
             return List.of();
         }
@@ -543,14 +613,9 @@ public final class PgVectorRepository {
             }
         }
 
-        float[] queryVec = (queryRouter != null)
-                ? queryRouter.embedOneForCollection(collectionNames.get(0), queryText)
-                : queryEmbedder.embedOne(queryText);
-        if (queryVec.length != dim) {
-            throw new IllegalArgumentException(
-                "query embedder produced a " + queryVec.length
-                + "-dim vector but the collections dispatch to chunks_" + dim);
-        }
+        EmbedResult hybridEmbed = embedQuery(collectionNames.get(0), queryText, dim);
+        if (tokensOut != null) tokensOut[0] = hybridEmbed.tokens();
+        float[] queryVec = hybridEmbed.embeddings().get(0);
 
         // Text gate fragment, shared by the COUNT probe and the ranked query. FTS lexeme
         // match OR word-trigram similarity: the <% operator form (word_similarity >=
@@ -772,9 +837,21 @@ public final class PgVectorRepository {
      */
     public String put(String tenant, String collection, String docId,
                       String content, Map<String, Object> metadata) {
-        upsertChunks(tenant, collection, List.of(docId), List.of(content),
-                     List.of(metadata != null ? metadata : Map.of()));
+        putWithTokens(tenant, collection, docId, content, metadata);
         return docId;
+    }
+
+    /**
+     * Token-aware sibling of {@link #put} (bead nexus-ehc4q).
+     * Delegates to {@link #upsertChunksWithTokens}; the token count is the
+     * embedding cost for the single chunk.
+     */
+    public Tokened<String> putWithTokens(String tenant, String collection, String docId,
+                                          String content, Map<String, Object> metadata) {
+        Tokened<Integer> result = upsertChunksWithTokens(
+            tenant, collection, List.of(docId), List.of(content),
+            List.of(metadata != null ? metadata : Map.of()));
+        return new Tokened<>(docId, result.tokens());
     }
 
     /**
@@ -881,17 +958,29 @@ public final class PgVectorRepository {
      * @param year        catalog year filter; null = no filter
      * @param corpus      catalog corpus filter; null = no filter
      */
+    /** Delegates to {@link #searchMetadataScopedWithTokens}; discards the token count. */
     public List<Map<String, Object>> searchMetadataScoped(
             String tenant, String queryText, List<String> collectionNames,
             String contentType, String author, Integer year, String corpus, int nResults) {
+        return searchMetadataScopedWithTokens(
+            tenant, queryText, collectionNames, contentType, author, year, corpus, nResults).value();
+    }
+
+    /**
+     * Token-aware sibling of {@link #searchMetadataScoped} (bead nexus-ehc4q).
+     */
+    public Tokened<List<Map<String, Object>>> searchMetadataScopedWithTokens(
+            String tenant, String queryText, List<String> collectionNames,
+            String contentType, String author, Integer year, String corpus, int nResults) {
         if (collectionNames == null || collectionNames.isEmpty()) {
-            return List.of();
+            return new Tokened<>(List.of(), 0L);
         }
         if (nResults < 1) {
             throw new IllegalArgumentException("nResults must be >= 1, got " + nResults);
         }
         int dim = requireHomogeneousDim(collectionNames);
-        float[] queryVec = embedQuery(collectionNames.get(0), queryText, dim);
+        EmbedResult embed = embedQuery(collectionNames.get(0), queryText, dim);
+        float[] queryVec = embed.embeddings().get(0);
 
         String sql = "SELECT id, content, collection, distance"
                    + " FROM nexus.search_metadata_scoped_" + dim
@@ -906,7 +995,7 @@ public final class PgVectorRepository {
         binds.add(corpus);
         binds.add(nResults);
 
-        return runCombinedQuery(tenant, sql, binds);
+        return new Tokened<>(runCombinedQuery(tenant, sql, binds), embed.tokens());
     }
 
     /**
@@ -919,16 +1008,26 @@ public final class PgVectorRepository {
      * matching {@link #search}). Same query-vector-as-argument + iterative_scan discipline
      * as {@link #searchMetadataScoped}.
      */
+    /** Delegates to {@link #searchTopicScopedWithTokens}; discards the token count. */
     public List<Map<String, Object>> searchTopicScoped(
             String tenant, String queryText, String topicLabel, String collection, int nResults) {
+        return searchTopicScopedWithTokens(tenant, queryText, topicLabel, collection, nResults).value();
+    }
+
+    /**
+     * Token-aware sibling of {@link #searchTopicScoped} (bead nexus-ehc4q).
+     */
+    public Tokened<List<Map<String, Object>>> searchTopicScopedWithTokens(
+            String tenant, String queryText, String topicLabel, String collection, int nResults) {
         if (collection == null || collection.isBlank()) {
-            return List.of();
+            return new Tokened<>(List.of(), 0L);
         }
         if (nResults < 1) {
             throw new IllegalArgumentException("nResults must be >= 1, got " + nResults);
         }
         int dim = dimForCollection(collection);
-        float[] queryVec = embedQuery(collection, queryText, dim);
+        EmbedResult embed = embedQuery(collection, queryText, dim);
+        float[] queryVec = embed.embeddings().get(0);
 
         String sql = "SELECT id, content, collection, distance"
                    + " FROM nexus.search_topic_scoped_" + dim
@@ -939,7 +1038,7 @@ public final class PgVectorRepository {
         binds.add(collection);
         binds.add(nResults);
 
-        return runCombinedQuery(tenant, sql, binds);
+        return new Tokened<>(runCombinedQuery(tenant, sql, binds), embed.tokens());
     }
 
     /**
@@ -967,12 +1066,23 @@ public final class PgVectorRepository {
      * @param depth     BFS depth (clamped to [1,3])
      * @param direction "out" | "in" | "both"
      */
+    /** Delegates to {@link #searchGraphHopWithTokens}; discards the token count. */
     public List<Map<String, Object>> searchGraphHop(
+            String tenant, String queryText, List<String> seeds, List<String> collectionNames,
+            String linkType, int depth, String direction, int nResults) {
+        return searchGraphHopWithTokens(
+            tenant, queryText, seeds, collectionNames, linkType, depth, direction, nResults).value();
+    }
+
+    /**
+     * Token-aware sibling of {@link #searchGraphHop} (bead nexus-ehc4q).
+     */
+    public Tokened<List<Map<String, Object>>> searchGraphHopWithTokens(
             String tenant, String queryText, List<String> seeds, List<String> collectionNames,
             String linkType, int depth, String direction, int nResults) {
         if (seeds == null || seeds.isEmpty()
                 || collectionNames == null || collectionNames.isEmpty()) {
-            return List.of();
+            return new Tokened<>(List.of(), 0L);
         }
         if (nResults < 1) {
             throw new IllegalArgumentException("nResults must be >= 1, got " + nResults);
@@ -984,7 +1094,8 @@ public final class PgVectorRepository {
         }
         int clampedDepth = Math.min(Math.max(depth, 1), 3);  // mirror graphBFS bound
         int dim = requireHomogeneousDim(collectionNames);
-        float[] queryVec = embedQuery(collectionNames.get(0), queryText, dim);
+        EmbedResult embed = embedQuery(collectionNames.get(0), queryText, dim);
+        float[] queryVec = embed.embeddings().get(0);
 
         String sql = "SELECT id, content, collection, distance, chash"
                    + " FROM nexus.search_graph_hop_" + dim
@@ -1000,7 +1111,7 @@ public final class PgVectorRepository {
         binds.add(dir);
         binds.add(nResults);
 
-        return runCombinedQueryWithChash(tenant, sql, binds);
+        return new Tokened<>(runCombinedQueryWithChash(tenant, sql, binds), embed.tokens());
     }
 
     /**
@@ -1021,17 +1132,22 @@ public final class PgVectorRepository {
         return dim;
     }
 
-    /** Embed the query server-side, routing by collection; fail loud on dim mismatch. */
-    private float[] embedQuery(String collection, String queryText, int dim) {
-        float[] queryVec = (queryRouter != null)
-                ? queryRouter.embedOneForCollection(collection, queryText)
-                : queryEmbedder.embedOne(queryText);
+    /**
+     * Embed the query server-side, routing by collection; fail loud on dim mismatch.
+     * Returns the embedding result including the token count so callers can propagate
+     * it as a return value (bead nexus-ehc4q — no ThreadLocal side-channel).
+     */
+    private EmbedResult embedQuery(String collection, String queryText, int dim) {
+        EmbedResult result = (queryRouter != null)
+                ? queryRouter.embedOneForCollectionWithUsage(collection, queryText)
+                : queryEmbedder.embedWithUsage(List.of(queryText));
+        float[] queryVec = result.embeddings().get(0);
         if (queryVec.length != dim) {
             throw new IllegalArgumentException(
                 "query embedder produced a " + queryVec.length
                 + "-dim vector but the collection dispatches to chunks_" + dim);
         }
-        return queryVec;
+        return result;
     }
 
     /**

--- a/service/src/main/java/dev/nexus/service/vectors/VoyageEmbedder.java
+++ b/service/src/main/java/dev/nexus/service/vectors/VoyageEmbedder.java
@@ -98,6 +98,24 @@ public final class VoyageEmbedder implements Embedder {
     }
 
     /**
+     * Embed a batch of texts and return vectors plus the token count from
+     * {@code usage.total_tokens} in the Voyage response (bead nexus-ehc4q).
+     *
+     * <p>Reuses the same {@link #callApi} / parse path; no second HTTP call.
+     */
+    @Override
+    public EmbedResult embedWithUsage(List<String> texts) {
+        if (texts == null || texts.isEmpty()) return new EmbedResult(List.of(), 0L);
+        String json = buildJson(texts);
+        String responseBody = callApi(json);
+        try {
+            return parseResponseWithUsage(responseBody);
+        } catch (Exception e) {
+            throw new RuntimeException("Voyage embedWithUsage parse failed", e);
+        }
+    }
+
+    /**
      * Embed texts preserving full double (float64) precision for the parity gate.
      *
      * <p>The Python SDK uses base64 encoding and decodes as float32 binary.  This method
@@ -136,6 +154,10 @@ public final class VoyageEmbedder implements Embedder {
         }
     }
 
+    // nexus-ehc4q billing note: on transient-error retries, usage.total_tokens is
+    // taken from the final successful response only; tokens from prior failed
+    // attempts are not accumulated — a billing UNDER-count on retried calls (safe
+    // direction: under-charges the customer). Documented, not corrected.
     private String callApi(String json) {
         for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
             try {
@@ -190,6 +212,41 @@ public final class VoyageEmbedder implements Embedder {
         }
         data.sort(Comparator.comparingInt(m -> ((Number) m.get("index")).intValue()));
         return data;
+    }
+
+    /**
+     * Parse the Voyage response returning both the float32 vectors and the token count
+     * from {@code usage.total_tokens} (bead nexus-ehc4q).
+     *
+     * <p>The Voyage {@code /v1/embeddings} response root structure:
+     * <pre>
+     * {
+     *   "data":  [...],
+     *   "usage": {"total_tokens": N}
+     * }
+     * </pre>
+     */
+    @SuppressWarnings("unchecked")
+    private EmbedResult parseResponseWithUsage(String body) throws Exception {
+        Map<String, Object> root = mapper.readValue(body, Map.class);
+        List<Map<String, Object>> data = (List<Map<String, Object>>) root.get("data");
+        if (data == null || data.isEmpty()) {
+            throw new RuntimeException("Voyage AI returned empty data array: " + body);
+        }
+        data.sort(Comparator.comparingInt(m -> ((Number) m.get("index")).intValue()));
+
+        List<float[]> result = new ArrayList<>(data.size());
+        for (Map<String, Object> item : data) {
+            result.add(decodeBase64Float32(getEmbeddingField(item, body)));
+        }
+
+        long tokens = 0L;
+        Map<String, Object> usage = (Map<String, Object>) root.get("usage");
+        if (usage != null) {
+            Object totalTokens = usage.get("total_tokens");
+            if (totalTokens instanceof Number n) tokens = n.longValue();
+        }
+        return new EmbedResult(result, tokens);
     }
 
     /**

--- a/service/src/test/java/dev/nexus/service/VectorHandlerTokenUsageTest.java
+++ b/service/src/test/java/dev/nexus/service/VectorHandlerTokenUsageTest.java
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.nexus.service.db.TenantScope;
+import dev.nexus.service.db.TokenHashing;
+import dev.nexus.service.http.VectorHandler;
+import dev.nexus.service.vectors.EmbedResult;
+import dev.nexus.service.vectors.Embedder;
+import dev.nexus.service.vectors.PgVectorRepository;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Bead nexus-ehc4q — HTTP-boundary contract for {@code X-Nexus-Usage-Tokens} header.
+ *
+ * <p>Pins the following invariants:
+ * <ol>
+ *   <li>An embedding endpoint (e.g. {@code /v1/vectors/search}) sets
+ *       {@code X-Nexus-Usage-Tokens: 73} when the stub embedder reports 73 tokens.</li>
+ *   <li>A non-embedding endpoint ({@code /v1/vectors/store-list}) NEVER sets the header
+ *       — it does not embed and must not emit a stale value.</li>
+ *   <li>When the embedder returns {@code tokens=0} (no usage data), the header is ABSENT
+ *       (a zero is not emitted — it is meaningless to the edge proxy).</li>
+ * </ol>
+ *
+ * <p>Wiring: {@link TokenReportingEmbedder} overrides
+ * {@link Embedder#embedWithUsage} to return the configured token count.
+ * The rest of the setup mirrors {@link VectorHybridHttpTest}: Testcontainers
+ * pgvector, Liquibase schema, port 0, PER_CLASS.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class VectorHandlerTokenUsageTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String TOKEN  = "tok-usage-test-0123456789abcdef0000";
+    private static final String TENANT = "tok-usage-tenant";
+
+    /** Collection with ONNX (minilm) model — no voyage credentials needed. */
+    private static final String COL = "knowledge__usage__minilm-l6-v2-384__v1";
+
+    PostgreSQLContainer<?> pg;
+    HikariDataSource svcDs;
+    NexusService service;
+    HttpClient http;
+
+    /** Fixed token count the stub embedder reports — chosen to be distinctive. */
+    static final long STUB_TOKENS = 73L;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+
+        // nexus_svc role (grants changeset is fail-loud without it).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
+                "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            Database db = DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(su));
+            new Liquibase("db/changelog/db.changelog-master.xml",
+                          new ClassLoaderResourceAccessor(), db)
+                .update(new Contexts());
+        }
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "ALTER ROLE nexus_svc SET search_path TO nexus, public");
+        }
+        // Register the service token used throughout this suite.
+        try (Connection su = pg.createConnection("");
+             var ps = su.prepareStatement(
+                 "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label)"
+                 + " VALUES (?, ?, ?) ON CONFLICT (token_hash) DO NOTHING")) {
+            su.setAutoCommit(true);
+            ps.setString(1, TokenHashing.sha256Hex(TOKEN));
+            ps.setString(2, TENANT);
+            ps.setString(3, "token-usage-test");
+            ps.executeUpdate();
+        }
+
+        var cfg = new HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername("nexus_svc");
+        cfg.setPassword("nexus_svc_pass");
+        cfg.setMaximumPoolSize(5);
+        cfg.setAutoCommit(true);
+        svcDs = new HikariDataSource(cfg);
+
+        // Stub embedder that returns STUB_TOKENS from embedWithUsage.
+        // 384-dim to match the minilm collection; also registered as the query embedder.
+        var embedder = new TokenReportingEmbedder(384, STUB_TOKENS);
+        embedder.register("hello world");
+
+        var pgRepo = new PgVectorRepository(new TenantScope(svcDs), embedder, embedder);
+
+        // Seed one chunk so /search returns a non-empty result (header is set regardless
+        // of result count, but seeding gives a deterministic happy-path).
+        pgRepo.upsertChunks(TENANT, COL,
+            List.of("tokc1000000000000000000000000000"),
+            List.of("hello world"),
+            List.of(Map.of()));
+
+        service = new NexusService(0, TOKEN, svcDs, null, pgRepo);
+        service.start();
+        http = HttpClient.newHttpClient();
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (service != null) service.stop();
+        if (svcDs   != null) svcDs.close();
+        if (pg      != null) pg.stop();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private HttpResponse<String> post(String path, Object body) throws Exception {
+        var req = HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + service.getPort() + path))
+            .header("Authorization", "Bearer " + TOKEN)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)))
+            .build();
+        return http.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        var req = HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + service.getPort() + path))
+            .header("Authorization", "Bearer " + TOKEN)
+            .GET()
+            .build();
+        return http.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    /**
+     * (a) Header present and correct on an embedding endpoint.
+     * (e) Header NAME matches {@link VectorHandler#USAGE_TOKENS_HEADER}.
+     *
+     * <p>/search embeds the query; the stub reports STUB_TOKENS = 73.
+     * Pins: header name is the constant, value is a decimal integer string = "73".
+     */
+    @Test
+    void search_emitsTokenUsageHeader_whenEmbedderReportsTokens() throws Exception {
+        var resp = post("/v1/vectors/search", Map.of(
+            "query",       "hello world",
+            "collections", List.of(COL),
+            "n_results",   5));
+
+        assertThat(resp.statusCode())
+            .as("search should return 200 (got: %s)", resp.body())
+            .isEqualTo(200);
+
+        // (e) header name matches the constant — a typo in the constant would fail here
+        assertThat(resp.headers().firstValue(VectorHandler.USAGE_TOKENS_HEADER))
+            .as("header name must match VectorHandler.USAGE_TOKENS_HEADER = '%s'",
+                VectorHandler.USAGE_TOKENS_HEADER)
+            .isPresent();
+
+        // value is a decimal integer string (not "73.0", not "73tokens", not blank)
+        String headerValue = resp.headers().firstValue(VectorHandler.USAGE_TOKENS_HEADER).get();
+        assertThat(headerValue)
+            .as("header value must be a decimal integer string")
+            .matches("\\d+");
+        assertThat(Long.parseLong(headerValue))
+            .as("header value must equal the stub token count")
+            .isEqualTo(STUB_TOKENS);
+    }
+
+    /**
+     * (b) Header ABSENT on a non-embedding endpoint.
+     *
+     * <p>/store-list does NOT call embedQuery — there is no embedding path to set
+     * a token count. The non-embedding handler structurally never calls emitTokenUsage.
+     * With return-value threading there is no ThreadLocal side-channel to stale-read.
+     */
+    @Test
+    void storeList_doesNotEmitTokenUsageHeader() throws Exception {
+        var resp = post("/v1/vectors/store-list", Map.of(
+            "collection", COL,
+            "limit",      5,
+            "offset",     0));
+
+        assertThat(resp.statusCode())
+            .as("store-list should return 200 (got: %s)", resp.body())
+            .isEqualTo(200);
+        assertThat(resp.headers().firstValue(VectorHandler.USAGE_TOKENS_HEADER))
+            .as("non-embedding endpoint must NEVER emit %s", VectorHandler.USAGE_TOKENS_HEADER)
+            .isEmpty();
+    }
+
+    /**
+     * (c) Header ABSENT when the embedder reports 0 tokens.
+     *
+     * <p>Covers the ONNX local-mode case: ONNX embedders return {@code tokens=0}
+     * because they have no API cost. Emitting "X-Nexus-Usage-Tokens: 0" is meaningless
+     * and must be suppressed (the proxy treats absent == no billing event to record).
+     */
+    @Test
+    void search_withZeroTokens_headerIsAbsent() throws Exception {
+        // Wire a fresh service with a zero-token embedder (models ONNX local-mode behaviour).
+        var zeroEmbedder = new TokenReportingEmbedder(384, 0L);
+        zeroEmbedder.register("hello world");
+        var zeroRepo = new PgVectorRepository(new TenantScope(svcDs), zeroEmbedder, zeroEmbedder);
+        zeroRepo.upsertChunks(TENANT, COL,
+            List.of("tokz1000000000000000000000000000"),
+            List.of("hello world"),
+            List.of(Map.of()));
+
+        NexusService zeroService = new NexusService(0, TOKEN, svcDs, null, zeroRepo);
+        zeroService.start();
+        try {
+            var req = HttpRequest.newBuilder()
+                .uri(URI.create("http://127.0.0.1:" + zeroService.getPort() + "/v1/vectors/search"))
+                .header("Authorization", "Bearer " + TOKEN)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(Map.of(
+                    "query",       "hello world",
+                    "collections", List.of(COL),
+                    "n_results",   1))))
+                .build();
+            var resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+
+            assertThat(resp.statusCode()).isEqualTo(200);
+            assertThat(resp.headers().firstValue(VectorHandler.USAGE_TOKENS_HEADER))
+                .as("zero-token embedder (ONNX local-mode): header must be absent, not '0'")
+                .isEmpty();
+        } finally {
+            zeroService.stop();
+        }
+    }
+
+    /**
+     * (d) Header ABSENT on error response.
+     *
+     * <p>A /store-list request missing 'collection' triggers IllegalArgumentException
+     * → 400. The error path never reaches the embedding call so no token count is
+     * available to emit.
+     */
+    @Test
+    void errorResponse_doesNotEmitTokenUsageHeader() throws Exception {
+        // Missing 'collection' triggers IllegalArgumentException → 400.
+        var resp = post("/v1/vectors/store-list", Map.of(
+            "limit",  5,
+            "offset", 0));
+        assertThat(resp.headers().firstValue(VectorHandler.USAGE_TOKENS_HEADER))
+            .as("error response must not carry %s", VectorHandler.USAGE_TOKENS_HEADER)
+            .isEmpty();
+    }
+
+    // ── Stub embedder ─────────────────────────────────────────────────────────
+
+    /**
+     * Deterministic embedder that returns a configurable token count from
+     * {@link #embedWithUsage}, enabling unit-level assertion of the header value
+     * without Voyage API credentials.
+     *
+     * <p>Produces fixed unit vectors (identical to {@link PgVectorRepositoryContractTest.FakeEmbedder}
+     * for known texts, 1-hot for unknown). The model token is {@code "minilm-l6-v2-384"}
+     * so it routes to the {@code chunks_384} table without Voyage credentials.
+     */
+    static final class TokenReportingEmbedder implements Embedder {
+
+        private final int dim;
+        private final long tokenCount;
+        private final Map<String, float[]> registered = new HashMap<>();
+
+        TokenReportingEmbedder(int dim, long tokenCount) {
+            this.dim        = dim;
+            this.tokenCount = tokenCount;
+        }
+
+        void register(String text) {
+            float[] v = new float[dim];
+            v[0] = 1.0f;  // unit vector along first axis
+            registered.put(text, v);
+        }
+
+        @Override
+        public String modelToken() {
+            // minilm-l6-v2-384: dispatches to chunks_384; no Voyage credentials needed.
+            return "minilm-l6-v2-384";
+        }
+
+        @Override
+        public List<float[]> embed(List<String> texts) {
+            List<float[]> out = new ArrayList<>(texts.size());
+            for (String t : texts) {
+                float[] v = registered.getOrDefault(t, defaultVec());
+                out.add(java.util.Arrays.copyOf(v, v.length));
+            }
+            return out;
+        }
+
+        /**
+         * Returns the configured {@link #tokenCount} so the handler can emit
+         * {@code X-Nexus-Usage-Tokens}.
+         */
+        @Override
+        public EmbedResult embedWithUsage(List<String> texts) {
+            return new EmbedResult(embed(texts), tokenCount);
+        }
+
+        private float[] defaultVec() {
+            float[] v = new float[dim];
+            v[0] = 1.0f;
+            return v;
+        }
+    }
+}


### PR DESCRIPTION
## What

Closes the per-tenant token-metering gap for conexus RDR-001 (`nexus-ehc4q`, mirrors `conexus-xr7.6.3`). The conexus control-plane already built+tested the consumer-side ingestion (`MeteringService.recordTokenUsage` → `usage_counter.tokens`) but had **nothing to ingest** — the engine emitted no per-request token usage. This adds the engine emitter.

## How

The engine sets an HTTP response header `X-Nexus-Usage-Tokens: <int>` carrying the embedding token count for each request that embeds. The conexus edge proxy (separate bead, conexus-xr7.6.3) reads it, calls `recordTokenUsage`, and strips it from the client relay.

- **Token source**: `EmbedResult(embeddings, tokens)`; `Embedder.embedWithUsage` (default 0). VoyageEmbedder captures `usage.total_tokens` (batch); CceEmbedder accumulates across per-text calls; OnnxEmbedder returns **0** (local, no paid API — emitting a count would pollute the billing header).
- **Threading**: the count flows through **explicit return values** — `PgVectorRepository.Tokened<T>` record + `*WithTokens` sibling methods for the 5 search paths + upsert + put. Existing public methods delegate and discard the count (zero caller churn). No ThreadLocal side-channel.
- **Emission**: `VectorHandler.USAGE_TOKENS_HEADER` constant; set (tokens>0 only) before `HttpUtil.send` in the embedding endpoints; non-embedding + error paths never set it.

## Tests

`VectorHandlerTokenUsageTest` (4): header present + correct (decimal-int, via the constant), absent on non-embedding endpoint, absent on zero tokens, absent on error. 60 service unit tests green; `VectorIntegrationTest` `/embed` cosine-1.0 parity gate green (float32→double precision unchanged).

## Review

Stacked review (code-review-expert + substantive-critic), 2 rounds. Round 1: the critic flagged the initial `ThreadLocal` token side-channel as **wrong architecture for billing-critical data** (2 Critical) — replaced with return-value threading; ONNX-local set to 0 billing tokens; header contract pinned to a constant + format test; `put()` coverage verified. Round 2 verdict: **justified, 0 Critical / 0 Significant**. Known caveat documented (not corrected): on transient-error retries, `usage.total_tokens` reflects the final response only — a billing under-count in the safe (customer-favorable) direction.

## Scope

Engine-side only. The conexus `EdgeProxyHandler` ingest + header-strip is **conexus-xr7.6.3** (full design recorded on the `nexus-ehc4q` bead for handoff). End-to-end verification is owned there.