### PR TITLE
feat(rdr-156): repoint query() onto combined-query functions in service mode [nexus-rzqto]

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -440,6 +440,14 @@ class CatalogEntry:
     # URIs (chroma://, https://, etc.) are stored verbatim. ''
     # only on legacy entries that predate P2.1's column migration.
     source_uri: str = ""
+    # nexus-rzqto: bibliographic enrichment surfaced from catalog_documents
+    # (RDR-101 columns) so the document-level query() text form can render
+    # bib metadata in service mode without reading chunk metadata. Defaults
+    # keep every existing CatalogEntry construction site compiling.
+    bib_year: int = 0
+    bib_authors: str = ""
+    bib_venue: str = ""
+    bib_citation_count: int = 0
 
     def to_dict(self) -> dict:
         return {
@@ -458,6 +466,10 @@ class CatalogEntry:
             "source_mtime": self.source_mtime,
             "alias_of": self.alias_of,
             "source_uri": self.source_uri,
+            "bib_year": self.bib_year,
+            "bib_authors": self.bib_authors,
+            "bib_venue": self.bib_venue,
+            "bib_citation_count": self.bib_citation_count,
         }
 
 

--- a/src/nexus/catalog/catalog_docs.py
+++ b/src/nexus/catalog/catalog_docs.py
@@ -135,7 +135,8 @@ class _DocumentOps:
         row = cat._db.execute(
             "SELECT tumbler, title, author, year, content_type, file_path, "
             "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
-            "metadata, source_mtime, alias_of, source_uri "
+            "metadata, source_mtime, alias_of, source_uri, "
+            "bib_year, bib_authors, bib_venue, bib_citation_count "
             "FROM documents WHERE tumbler = ?",
             (str(target),),
         ).fetchone()
@@ -157,6 +158,11 @@ class _DocumentOps:
             source_mtime=row[12] or 0.0,
             alias_of=row[13] or "",
             source_uri=row[14] or "",
+            # nexus-rzqto: bib_* surfaced for the service-mode query() text form.
+            bib_year=row[15] or 0,
+            bib_authors=row[16] or "",
+            bib_venue=row[17] or "",
+            bib_citation_count=row[18] or 0,
         )
 
     def list_by_collection(

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -78,7 +78,8 @@ def _to_entry(d: dict) -> CatalogEntry:
 
     All CatalogEntry fields are non-optional; coerce None / missing values
     to the same empty-string / 0 / {} defaults the SQLite Catalog uses.
-    CatalogEntry has no bib fields — those live only in T3 metadata.
+    The Java catalog document payload (CatalogRepository.docRowFromRecord)
+    carries the RDR-101 bib_* columns; surface them on the entry (nexus-rzqto).
     """
     return CatalogEntry(
         tumbler=Tumbler.parse(d["tumbler"]),
@@ -96,6 +97,10 @@ def _to_entry(d: dict) -> CatalogEntry:
         source_mtime=d.get("source_mtime") or 0.0,
         alias_of=d.get("alias_of") or "",
         source_uri=d.get("source_uri") or "",
+        bib_year=d.get("bib_year") or 0,
+        bib_authors=d.get("bib_authors") or "",
+        bib_venue=d.get("bib_venue") or "",
+        bib_citation_count=d.get("bib_citation_count") or 0,
     )
 
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1366,13 +1366,208 @@ def query(
             if cat is None:
                 return "Error: catalog not initialized — catalog params (author, content_type, follow_links, subtree) require 'nx catalog setup'"
 
-            # Resolve seed entries for catalog routing
-            seed_entries: list = []
+            # Guard: document-level subtree address (3+ segments) cannot have descendants
             if subtree:
-                # Depth check: document-level (3+ segments) has no descendants in the catalog
                 subtree_depth = len(subtree.split("."))
                 if subtree_depth >= 3:
                     return f"Error: subtree '{subtree}' is a document-level address — use an owner prefix (e.g., '{'.'.join(subtree.split('.')[:2])}') to search a subtree"
+
+            # ── SERVICE-MODE BRANCH (nexus-rzqto) ────────────────────────────
+            # When the T3 backend is the pgvector service, route through the
+            # combined-query SQL functions (search_metadata_scoped /
+            # search_graph_hop) instead of the app-side catalog dance +
+            # search_cross_corpus.  The SQL functions perform the catalog-
+            # metadata join server-side and return document-level rows
+            # (id=tumbler, content, distance, collection, chash).
+            #
+            # bib richness (nexus-rzqto): the combined functions return only
+            # (id=tumbler, content, distance, collection, chash), so the text
+            # form re-hydrates title/author/year AND bib_year/bib_authors/
+            # bib_venue/bib_citation_count per tumbler from CatalogEntry — the
+            # Java catalog already serializes the bib_* columns
+            # (CatalogRepository.docRowFromRecord), surfaced onto CatalogEntry.
+            from nexus.db.http_vector_client import is_service_backed
+            _where_dict = _parse_where_str(where)
+            # H2: follow_links + where — search_graph_hop has no `where` param.
+            # Fall back to the dance path so the caller's where filter is
+            # honored instead of being silently dropped.
+            _skip_service = follow_links and bool(_where_dict)
+            if is_service_backed(t3) and not _skip_service:
+                # Broad corpus target: the SQL functions filter by catalog
+                # metadata internally, so pass the full corpus set.
+                target = _resolve_corpus_target(corpus, t3)
+                if not target:
+                    return f"No collections match corpus {corpus!r}"
+
+                where_dict = _where_dict
+                fetch_n = limit * 10
+
+                _no_docs_msg = (
+                    f"No documents found matching catalog filters "
+                    f"(author={author!r}, content_type={content_type!r}, "
+                    f"subtree={subtree!r}, follow_links={follow_links!r})"
+                )
+
+                if follow_links:
+                    # Graph-hop path: seeds resolved app-side, BFS in SQL.
+                    seed_tumblers: list[str] = []
+                    if subtree:
+                        desc = cat.descendants(subtree)
+                        seed_tumblers = [d["tumbler"] for d in desc if d.get("tumbler")]
+                    elif author or content_type:
+                        if content_type and not author:
+                            seed_entries_svc = cat.by_content_type(content_type)
+                        else:
+                            seed_entries_svc = cat.find(author, content_type=content_type or None)
+                            seed_entries_svc = [
+                                r for r in seed_entries_svc
+                                if author.lower() in (r.author or "").lower()
+                            ]
+                        seed_tumblers = [str(r.tumbler) for r in seed_entries_svc if r.tumbler]
+                    else:
+                        # follow_links only: use question as catalog seed
+                        seed_results_svc = cat.find(question)
+                        seed_tumblers = [str(r.tumbler) for r in seed_results_svc[:5] if r.tumbler]
+
+                    if not seed_tumblers:
+                        # No graph seeds resolved — fall through to
+                        # search_metadata_scoped over the broad target
+                        # (mirrors the dance path's fallback to broad search
+                        # when catalog_collections stays None).
+                        rows = t3.search_metadata_scoped(
+                            question, target,
+                            content_type=content_type or None,
+                            author=author or None,
+                            subtree=(subtree or None),
+                            where=(where_dict or None),
+                            n_results=fetch_n,
+                        )
+                    else:
+                        rows = t3.search_graph_hop(
+                            question, seed_tumblers, target,
+                            link_type=(follow_links or None),
+                            depth=depth,
+                            n_results=fetch_n,
+                        )
+                else:
+                    # Metadata-scoped path: catalog filters pushed into SQL.
+                    rows = t3.search_metadata_scoped(
+                        question, target,
+                        content_type=content_type or None,
+                        author=author or None,
+                        subtree=(subtree or None),
+                        where=(where_dict or None),
+                        n_results=fetch_n,
+                    )
+
+                # Dedup: one row per tumbler, keeping best (lowest) distance.
+                # Rows arrive distance-ascending so first occurrence is best.
+                seen_svc: set[str] = set()
+                deduped_svc: list[dict] = []
+                for r in rows:
+                    rid = r.get("id", "")
+                    if rid in seen_svc:
+                        continue
+                    seen_svc.add(rid)
+                    deduped_svc.append(r)
+                rows = deduped_svc[:limit]
+
+                if not rows:
+                    if structured:
+                        return {
+                            "ids": [], "tumblers": [], "distances": [],
+                            "collections": [], "chunk_collections": [],
+                            "chunk_text_hash": [],
+                        }
+                    return _no_docs_msg
+
+                if structured:
+                    tumblers_svc = [r.get("id", "") for r in rows]
+                    return {
+                        "ids": tumblers_svc,
+                        "tumblers": tumblers_svc,
+                        "distances": [float(r.get("distance", 0.0)) for r in rows],
+                        # sorted distinct across rows (mirrors existing dance path)
+                        "collections": sorted({r.get("collection", "") for r in rows}),
+                        # per-row aligned (RDR-086 / review #7)
+                        "chunk_collections": [r.get("collection", "") for r in rows],
+                        # HIGH-1: chash per matched chunk row, not a manifest guess
+                        "chunk_text_hash": [r.get("chash", "") for r in rows],
+                    }
+
+                # Text form: re-hydrate per tumbler from the catalog to build
+                # the same format as the existing dance path.
+                parts_note = []
+                if author:
+                    parts_note.append(f"author={author!r}")
+                if content_type:
+                    parts_note.append(f"content_type={content_type!r}")
+                if subtree:
+                    parts_note.append(f"subtree={subtree!r}")
+                if follow_links:
+                    parts_note.append(f"follow_links={follow_links!r}")
+                routing_note_svc = (
+                    f"[Catalog routing: {', '.join(parts_note)} -> {len(target)} collections]"
+                )
+                header_svc = (
+                    f"Found {len(rows)} documents "
+                    f"(from {len(deduped_svc)} across {len(target)} collections)"
+                )
+                lines_svc: list[str] = [f"{routing_note_svc}\n{header_svc}"]
+                lines_svc.append("")
+                for i, row in enumerate(rows, 1):
+                    tumbler_str = row.get("id", "")
+                    dist = f"{row.get('distance', 0.0):.4f}"
+                    # Re-hydrate from catalog
+                    try:
+                        entry_svc = cat.resolve(Tumbler.parse(tumbler_str)) if tumbler_str else None
+                    except Exception:
+                        entry_svc = None
+                    title_svc = (entry_svc.title if entry_svc else tumbler_str or "")[:70]
+                    # Mirror the dance path's bib richness: prefer bib_* (RDR-101
+                    # enrichment), fall back to the plain author/year fields.
+                    bib_year_svc = (entry_svc.bib_year or entry_svc.year) if entry_svc else 0
+                    bib_authors_svc = (entry_svc.bib_authors or entry_svc.author) if entry_svc else ""
+                    bib_venue_svc = entry_svc.bib_venue if entry_svc else ""
+                    bib_citation_count_svc = entry_svc.bib_citation_count if entry_svc else 0
+                    try:
+                        chunk_count_svc = len(cat.get_manifest(tumbler_str)) if tumbler_str else 0
+                    except Exception:
+                        chunk_count_svc = 0
+                    snippet_svc = row.get("content", "")[:300].replace("\n", " ")
+                    collection_svc = row.get("collection", "")
+
+                    lines_svc.append(f"{i}. [{dist}] {title_svc}")
+                    bib_svc: list[str] = []
+                    if bib_year_svc:
+                        bib_svc.append(str(bib_year_svc))
+                    if bib_authors_svc:
+                        bib_svc.append(bib_authors_svc[:60])
+                    if bib_venue_svc:
+                        bib_svc.append(bib_venue_svc[:30])
+                    if bib_citation_count_svc:
+                        bib_svc.append(f"{bib_citation_count_svc} citations")
+                    if bib_svc:
+                        lines_svc.append(f"   {' · '.join(bib_svc)}")
+                    if chunk_count_svc:
+                        lines_svc.append(f"   [{chunk_count_svc} chunks]")
+                    lines_svc.append(f"   {collection_svc}")
+                    lines_svc.append(f"   {snippet_svc}")
+                    lines_svc.append("")
+
+                if len(deduped_svc) > limit:
+                    lines_svc.append(
+                        f"\n--- showing 1-{len(rows)} of {len(deduped_svc)} documents. "
+                        f"Results are capped at limit={limit}."
+                    )
+                return "\n".join(lines_svc)
+            # ── END SERVICE-MODE BRANCH ───────────────────────────────────────
+
+            # FALLBACK: local/Chroma mode — existing app-side catalog dance below.
+
+            # Resolve seed entries for catalog routing
+            seed_entries: list = []
+            if subtree:
                 # Use descendants() directly — NOT catalog_search(owner=) which has depth-equality bug
                 desc = cat.descendants(subtree)
                 catalog_collections = {d["physical_collection"] for d in desc if d.get("physical_collection")}
@@ -1483,7 +1678,9 @@ def query(
                 "ids": [r.id for r in page],
                 "tumblers": [r.metadata.get("tumbler", "") for r in page],
                 "distances": [float(r.distance) for r in page],
-                "collections": list({r.collection for r in page}),
+                # H1 (nexus-rzqto): sorted for deterministic ordering across
+                # local and service modes.
+                "collections": sorted({r.collection for r in page}),
                 # Review #7: per-result aligned list for consumers
                 # that need per-chunk origin (e.g. nx_answer envelope).
                 "chunk_collections": [r.collection for r in page],

--- a/tests/test_query_repoint.py
+++ b/tests/test_query_repoint.py
@@ -1,0 +1,671 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-156 P4 follow-on (nexus-rzqto): query() service-mode repoint tests.
+
+Pins: service-mode catalog-param paths route through search_metadata_scoped /
+search_graph_hop; fallback to search_cross_corpus in local mode or no catalog
+params; exact structured key-set parity {ids, tumblers, distances, collections,
+chunk_collections, chunk_text_hash}; guards (subtree depth>=3, catalog-not-init,
+empty-filters) preserved.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from nexus.mcp import core
+
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+
+class _FakeServiceT3:
+    """Stands in for HttpVectorClient; records combined-query calls."""
+
+    def __init__(
+        self,
+        meta_rows: list[dict] | None = None,
+        graph_rows: list[dict] | None = None,
+    ) -> None:
+        self.meta_rows = meta_rows or []
+        self.graph_rows = graph_rows or []
+        self.meta_calls: list[tuple] = []
+        self.graph_calls: list[tuple] = []
+        self.cross_calls: list[tuple] = []  # not used on service T3
+
+    def search_metadata_scoped(
+        self, query, collection_names, *, content_type=None, author=None,
+        year=None, corpus=None, subtree=None, where=None, n_results=10,
+    ):
+        self.meta_calls.append(
+            (query, list(collection_names), content_type, author,
+             year, corpus, subtree, where, n_results)
+        )
+        return self.meta_rows
+
+    def search_graph_hop(
+        self, query, seeds, collection_names, *, link_type=None,
+        depth=1, direction="both", n_results=10,
+    ):
+        self.graph_calls.append(
+            (query, list(seeds), list(collection_names), link_type, depth, direction, n_results)
+        )
+        return self.graph_rows
+
+
+class _FakeLocalT3:
+    """Non-service T3; search_cross_corpus is called via search_engine module."""
+    pass
+
+
+class _FakeCatalogEntry:
+    """Minimal CatalogEntry stand-in."""
+
+    def __init__(
+        self, tumbler_str: str, title: str, author: str = "",
+        year: int = 0, physical_collection: str = "", chunk_count: int = 3,
+        bib_year: int = 0, bib_authors: str = "", bib_venue: str = "",
+        bib_citation_count: int = 0,
+    ) -> None:
+        from nexus.catalog.tumbler import Tumbler
+        self.tumbler = Tumbler.parse(tumbler_str)
+        self.title = title
+        self.author = author
+        self.year = year
+        self.physical_collection = physical_collection
+        self.chunk_count = chunk_count
+        self.bib_year = bib_year
+        self.bib_authors = bib_authors
+        self.bib_venue = bib_venue
+        self.bib_citation_count = bib_citation_count
+
+
+class _FakeCatalog:
+    """Fake Catalog; supports the subset of methods query() calls."""
+
+    def __init__(
+        self,
+        entries: list[_FakeCatalogEntry] | None = None,
+        descendants_out: list[dict] | None = None,
+        graph_out: dict | None = None,
+        manifest_len: int = 3,
+    ) -> None:
+        self._entries = entries or []
+        self._descendants = descendants_out or []
+        self._graph_out = graph_out or {"nodes": [], "edges": []}
+        self._manifest_len = manifest_len
+        self.find_calls: list = []
+        self.descendants_calls: list = []
+        self.by_content_type_calls: list = []
+        self.graph_calls: list = []
+        self.resolve_calls: list = []
+
+    def find(self, query: str, *, content_type: str | None = None) -> list:
+        self.find_calls.append((query, content_type))
+        return list(self._entries)
+
+    def descendants(self, prefix: str) -> list[dict]:
+        self.descendants_calls.append(prefix)
+        return list(self._descendants)
+
+    def by_content_type(self, content_type: str) -> list:
+        self.by_content_type_calls.append(content_type)
+        return list(self._entries)
+
+    def graph(self, tumbler, depth=1, direction="both", link_type="", **kw) -> dict:
+        self.graph_calls.append((tumbler, depth, direction, link_type))
+        return self._graph_out
+
+    def resolve(self, tumbler) -> _FakeCatalogEntry | None:
+        self.resolve_calls.append(tumbler)
+        tumbler_str = str(tumbler)
+        for e in self._entries:
+            if str(e.tumbler) == tumbler_str:
+                return e
+        return None
+
+    def get_manifest(self, doc_id: str) -> list:
+        return [object()] * self._manifest_len  # list of length manifest_len
+
+    def docs_for_chashes(self, chashes: list[str]) -> dict[str, list[str]]:
+        return {}
+
+
+# ── Wiring helpers ────────────────────────────────────────────────────────────
+
+def _wire(
+    monkeypatch,
+    t3,
+    broad_target: list[str],
+    cat: _FakeCatalog | None,
+    *,
+    service: bool = True,
+    cross_corpus_result=None,
+):
+    """Patch all the seams query() calls into."""
+    monkeypatch.setattr(core, "_get_t3", lambda: t3)
+    monkeypatch.setattr(core, "_resolve_corpus_target", lambda corpus, _t3: broad_target)
+    monkeypatch.setattr(
+        "nexus.db.http_vector_client.is_service_backed", lambda db: service,
+    )
+    monkeypatch.setattr(core, "_get_catalog", lambda: cat)
+    # Patch _get_collection_names (needed by the old path when catalog_collections is None)
+    monkeypatch.setattr(core, "_get_collection_names", lambda: broad_target)
+
+    # Stub _t2_ctx as a context manager returning a fake T2 db
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_t2_ctx():
+        fake_t2 = MagicMock()
+        fake_t2.taxonomy = None
+        fake_t2.telemetry = None
+        yield fake_t2
+
+    monkeypatch.setattr(core, "_t2_ctx", _fake_t2_ctx)
+
+    # Stub search_cross_corpus — old dance path
+    if cross_corpus_result is None:
+        cross_corpus_result = []
+
+    import nexus.search_engine as se
+    monkeypatch.setattr(se, "search_cross_corpus", lambda *a, **kw: cross_corpus_result)
+
+
+# ── Rows helpers ──────────────────────────────────────────────────────────────
+
+def _make_meta_rows(*items):
+    """Build list of rows as returned by search_metadata_scoped."""
+    rows = []
+    for i, (tumbler, chash) in enumerate(items):
+        rows.append({
+            "id": tumbler,
+            "content": f"snippet for {tumbler}",
+            "distance": 0.1 * (i + 1),
+            "collection": "knowledge__owner__v1",
+            "chash": chash,
+        })
+    return rows
+
+
+def _make_graph_rows(*items):
+    """Build list of rows as returned by search_graph_hop."""
+    rows = []
+    for i, (tumbler, chash) in enumerate(items):
+        rows.append({
+            "id": tumbler,
+            "content": f"snippet for {tumbler}",
+            "distance": 0.1 * (i + 1),
+            "collection": "knowledge__owner__v1",
+            "chash": chash,
+        })
+    return rows
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# SERVICE MODE: metadata-scoped path (author / content_type / subtree)
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestQueryRepointMetadataScoped:
+    """Service mode + catalog params → search_metadata_scoped is called."""
+
+    def test_author_routes_to_search_metadata_scoped(self, monkeypatch):
+        """Author filter in service mode calls search_metadata_scoped with broad target."""
+        rows = _make_meta_rows(("1.2.3", "a" * 32), ("1.2.4", "b" * 32))
+        t3 = _FakeServiceT3(meta_rows=rows)
+        entry = _FakeCatalogEntry("1.2.3", "Paper A", author="Alice", year=2023,
+                                  physical_collection="knowledge__owner__v1")
+        cat = _FakeCatalog(entries=[entry])
+        _wire(monkeypatch, t3, ["knowledge__owner__v1"], cat, service=True)
+
+        result = core.query("test question", author="Alice", structured=True)
+
+        assert isinstance(result, dict)
+        assert t3.meta_calls, "search_metadata_scoped must be called in service mode"
+        call = t3.meta_calls[0]
+        assert call[0] == "test question"
+        assert "knowledge__owner__v1" in call[1]  # broad target passed
+        assert call[3] == "Alice"  # author param forwarded
+
+    def test_structured_chunk_text_hash_from_row_chash(self, monkeypatch):
+        """HIGH-1: chunk_text_hash must come from row['chash'], not manifest guess."""
+        chash_a = "a" * 32
+        chash_b = "b" * 32
+        rows = _make_meta_rows(("1.2.3", chash_a), ("1.2.4", chash_b))
+        t3 = _FakeServiceT3(meta_rows=rows)
+        entry = _FakeCatalogEntry("1.2.3", "Paper A", physical_collection="knowledge__owner__v1")
+        cat = _FakeCatalog(entries=[entry])
+        _wire(monkeypatch, t3, ["knowledge__owner__v1"], cat, service=True)
+
+        result = core.query("test", author="Alice", structured=True)
+
+        assert result["chunk_text_hash"] == [chash_a, chash_b]
+
+    def test_structured_exact_key_set(self, monkeypatch):
+        """Structured output must have EXACTLY: ids, tumblers, distances, collections,
+        chunk_collections, chunk_text_hash — matching the existing dance path."""
+        rows = _make_meta_rows(("1.2.3", "a" * 32))
+        t3 = _FakeServiceT3(meta_rows=rows)
+        cat = _FakeCatalog(entries=[_FakeCatalogEntry("1.2.3", "T",
+                                                      physical_collection="c1")])
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", author="X", structured=True)
+
+        assert set(result.keys()) == {
+            "ids", "tumblers", "distances", "collections",
+            "chunk_collections", "chunk_text_hash",
+        }
+
+    def test_structured_ids_are_tumblers(self, monkeypatch):
+        rows = _make_meta_rows(("1.2.3", "a" * 32), ("1.2.4", "b" * 32))
+        t3 = _FakeServiceT3(meta_rows=rows)
+        cat = _FakeCatalog()
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", content_type="paper", structured=True)
+
+        assert result["ids"] == ["1.2.3", "1.2.4"]
+        assert result["tumblers"] == ["1.2.3", "1.2.4"]
+
+    def test_dedup_rows_keeps_best_distance(self, monkeypatch):
+        """Multi-chunk doc: dedup to one per tumbler at best (lowest) distance."""
+        rows = [
+            {"id": "1.2.3", "content": "near", "distance": 0.1, "collection": "c1", "chash": "a" * 32},
+            {"id": "1.2.4", "content": "other", "distance": 0.2, "collection": "c1", "chash": "b" * 32},
+            {"id": "1.2.3", "content": "far", "distance": 0.9, "collection": "c1", "chash": "c" * 32},
+        ]
+        t3 = _FakeServiceT3(meta_rows=rows)
+        cat = _FakeCatalog()
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", author="X", structured=True)
+
+        assert result["ids"] == ["1.2.3", "1.2.4"]
+        assert result["distances"] == [0.1, 0.2]
+        assert result["chunk_text_hash"] == ["a" * 32, "b" * 32]  # best-distance chash
+
+    def test_collections_sorted_distinct(self, monkeypatch):
+        """structured['collections'] is sorted distinct across result rows."""
+        rows = [
+            {"id": "1.2.3", "content": "x", "distance": 0.1, "collection": "z_col", "chash": "a" * 32},
+            {"id": "1.2.4", "content": "y", "distance": 0.2, "collection": "a_col", "chash": "b" * 32},
+        ]
+        t3 = _FakeServiceT3(meta_rows=rows)
+        cat = _FakeCatalog()
+        _wire(monkeypatch, t3, ["a_col", "z_col"], cat, service=True)
+
+        result = core.query("q", author="X", structured=True)
+
+        assert result["collections"] == sorted({"z_col", "a_col"})
+
+    def test_chunk_collections_per_row_aligned(self, monkeypatch):
+        """chunk_collections is per-row aligned (like the existing dance path)."""
+        rows = [
+            {"id": "1.2.3", "content": "x", "distance": 0.1, "collection": "c1", "chash": "a" * 32},
+            {"id": "1.2.4", "content": "y", "distance": 0.2, "collection": "c2", "chash": "b" * 32},
+        ]
+        t3 = _FakeServiceT3(meta_rows=rows)
+        cat = _FakeCatalog()
+        _wire(monkeypatch, t3, ["c1", "c2"], cat, service=True)
+
+        result = core.query("q", content_type="paper", structured=True)
+
+        assert result["chunk_collections"] == ["c1", "c2"]
+
+    def test_text_form_includes_rehydrated_title(self, monkeypatch):
+        """Text form: title comes from catalog.resolve(tumbler).title."""
+        rows = _make_meta_rows(("1.2.3", "a" * 32))
+        t3 = _FakeServiceT3(meta_rows=rows)
+        entry = _FakeCatalogEntry("1.2.3", "The Real Title", author="Bob",
+                                  year=2022, physical_collection="c1", chunk_count=5)
+        cat = _FakeCatalog(entries=[entry])
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", author="Bob", structured=False)
+
+        assert isinstance(result, str)
+        assert "The Real Title" in result
+
+    def test_text_form_includes_chunk_count_from_manifest(self, monkeypatch):
+        """Text form: chunk_count comes from len(cat.get_manifest(tumbler))."""
+        rows = _make_meta_rows(("1.2.3", "a" * 32))
+        t3 = _FakeServiceT3(meta_rows=rows)
+        entry = _FakeCatalogEntry("1.2.3", "Doc", physical_collection="c1", chunk_count=99)
+        cat = _FakeCatalog(entries=[entry], manifest_len=7)
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", author="X", structured=False)
+
+        assert "7 chunks" in result
+
+    def test_empty_result_returns_no_documents_message(self, monkeypatch):
+        """MEDIUM-3: empty result under catalog filters → 'No documents found matching catalog filters'."""
+        t3 = _FakeServiceT3(meta_rows=[])
+        cat = _FakeCatalog()
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", author="Nobody", structured=False)
+
+        assert "No documents found matching catalog filters" in result
+        assert "author=" in result
+
+    def test_empty_result_structured_returns_empty_dict(self, monkeypatch):
+        """Empty result in structured mode returns the 6-key empty dict."""
+        t3 = _FakeServiceT3(meta_rows=[])
+        cat = _FakeCatalog()
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", author="Nobody", structured=True)
+
+        assert result == {
+            "ids": [], "tumblers": [], "distances": [],
+            "collections": [], "chunk_collections": [],
+            "chunk_text_hash": [],
+        }
+
+    def test_where_forwarded_to_search_metadata_scoped(self, monkeypatch):
+        """L2: where=KEY=VALUE is parsed and forwarded to search_metadata_scoped."""
+        rows = _make_meta_rows(("1.2.3", "a" * 32))
+        t3 = _FakeServiceT3(meta_rows=rows)
+        cat = _FakeCatalog()
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        core.query("q", content_type="paper", where="lang=python", structured=True)
+
+        assert t3.meta_calls
+        where_arg = t3.meta_calls[0][7]  # where is the 8th positional arg
+        assert where_arg == {"lang": "python"}
+
+    def test_text_form_includes_bib_authors_venue_citation_count(self, monkeypatch):
+        """nexus-rzqto bead requirement: the service text form preserves the full bib
+        richness (bib_authors/bib_venue/bib_citation_count), re-hydrated from CatalogEntry
+        (the Java catalog already serializes these columns via docRowFromRecord; they are
+        now surfaced onto CatalogEntry). Mirrors the dance path's bib line."""
+        rows = _make_meta_rows(("1.2.3", "a" * 32))
+        t3 = _FakeServiceT3(meta_rows=rows)
+        entry = _FakeCatalogEntry("1.2.3", "Rich Paper", physical_collection="c1",
+                                  bib_year=2023, bib_authors="Smith, Jones",
+                                  bib_venue="NeurIPS", bib_citation_count=42)
+        cat = _FakeCatalog(entries=[entry])
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", author="Smith", structured=False)
+
+        assert "2023" in result
+        assert "Smith, Jones" in result      # bib_authors
+        assert "NeurIPS" in result           # bib_venue
+        assert "42 citations" in result      # bib_citation_count
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# SERVICE MODE: graph-hop path (follow_links)
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestQueryRepointGraphHop:
+    """Service mode + follow_links → seeds resolved app-side, then search_graph_hop."""
+
+    def test_follow_links_calls_search_graph_hop(self, monkeypatch):
+        """follow_links in service mode resolves seeds then calls t3.search_graph_hop."""
+        rows = _make_graph_rows(("1.2.3", "a" * 32))
+        t3 = _FakeServiceT3(graph_rows=rows)
+        seed_entry = _FakeCatalogEntry("1.1.1", "Seed Doc", physical_collection="c1")
+        cat = _FakeCatalog(entries=[seed_entry])
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", follow_links="cites", structured=True)
+
+        assert t3.graph_calls, "search_graph_hop must be called"
+        call = t3.graph_calls[0]
+        assert call[0] == "q"
+        assert "c1" in call[2]  # broad target
+        assert call[3] == "cites"  # link_type
+
+    def test_follow_links_with_author_resolves_author_seeds(self, monkeypatch):
+        """follow_links + author: seeds come from cat.find(author, ...) filtered by author."""
+        rows = _make_graph_rows(("1.2.3", "a" * 32))
+        t3 = _FakeServiceT3(graph_rows=rows)
+        entry = _FakeCatalogEntry("1.1.1", "Seed", author="Carol",
+                                  physical_collection="c1")
+        cat = _FakeCatalog(entries=[entry])
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", author="carol", follow_links="cites", structured=True)
+
+        assert t3.graph_calls
+        seeds_arg = t3.graph_calls[0][1]
+        assert "1.1.1" in seeds_arg
+
+    def test_follow_links_structured_chunk_text_hash_from_chash(self, monkeypatch):
+        """HIGH-1: follow_links structured path also uses row['chash'] for chunk_text_hash."""
+        chash = "f" * 32
+        rows = _make_graph_rows(("1.2.3", chash))
+        t3 = _FakeServiceT3(graph_rows=rows)
+        entry = _FakeCatalogEntry("1.1.1", "Seed", author="X", physical_collection="c1")
+        cat = _FakeCatalog(entries=[entry])
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", follow_links="cites", structured=True)
+
+        assert result["chunk_text_hash"] == [chash]
+
+    def test_follow_links_no_seeds_falls_through_to_metadata_scoped(self, monkeypatch):
+        """SIGNIFICANT: follow_links-only with no seeds → broad search via search_metadata_scoped.
+
+        The dance path falls through to broad corpus search when no seeds resolve
+        (catalog_collections stays None). The service branch must mirror this:
+        call search_metadata_scoped over the broad target instead of returning an
+        error (the previous behaviour).
+        """
+        rows = _make_meta_rows(("1.2.3", "a" * 32))
+        t3 = _FakeServiceT3(graph_rows=[], meta_rows=rows)
+        cat = _FakeCatalog(entries=[])  # find() returns nothing → no seeds
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", follow_links="cites", structured=True)
+
+        assert t3.graph_calls == [], "graph-hop must NOT be called with empty seeds"
+        assert t3.meta_calls, "search_metadata_scoped must be called as fallback"
+        assert isinstance(result, dict)
+        assert result["ids"] == ["1.2.3"]
+
+    def test_follow_links_no_seeds_empty_fallback_returns_no_docs_message(self, monkeypatch):
+        """When no seeds AND metadata_scoped fallback also returns empty → no-docs message."""
+        t3 = _FakeServiceT3(graph_rows=[], meta_rows=[])
+        cat = _FakeCatalog(entries=[])
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", follow_links="cites", structured=False)
+
+        assert "No documents found matching catalog filters" in result
+        assert t3.graph_calls == []
+        assert t3.meta_calls  # metadata_scoped still called
+
+    def test_follow_links_where_falls_back_to_dance(self, monkeypatch):
+        """HIGH: follow_links + where → service branch skipped; dance (search_cross_corpus) called.
+
+        search_graph_hop has no `where` param. When both are set, we fall back to the
+        dance path so the caller's where filter is honored, not silently dropped.
+        """
+        import nexus.search_engine as se
+
+        cross_called = []
+
+        def _fake_cross(*a, **kw):
+            cross_called.append(True)
+            return []
+
+        t3 = _FakeServiceT3()
+        # Empty catalog entries: cat.find(question) returns [] so catalog_collections
+        # stays None in the dance path, which falls through to broad search
+        # (resolve_corpus("c1", ["c1"]) exact-matches → search_cross_corpus).
+        cat = _FakeCatalog(entries=[])
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+        # Override after _wire so it isn't overridden
+        monkeypatch.setattr(se, "search_cross_corpus", _fake_cross)
+
+        # corpus="c1" so resolve_corpus exact-matches the broad_target ["c1"]
+        core.query("q", follow_links="cites", where="lang=python", corpus="c1")
+
+        assert cross_called, "dance must be used when follow_links AND where both set"
+        assert not t3.graph_calls, "search_graph_hop must NOT be called"
+        assert not t3.meta_calls, "search_metadata_scoped must NOT be called"
+
+    def test_follow_links_subtree_service_mode(self, monkeypatch):
+        """L1: follow_links + subtree in service mode: seeds come from cat.descendants()."""
+        rows = _make_graph_rows(("1.2.3", "a" * 32))
+        t3 = _FakeServiceT3(graph_rows=rows)
+        cat = _FakeCatalog(
+            descendants_out=[{"tumbler": "1.2.3", "physical_collection": "c1"}],
+        )
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", follow_links="cites", subtree="1.2", structured=True)
+
+        assert t3.graph_calls, "search_graph_hop must be called"
+        seeds_arg = t3.graph_calls[0][1]
+        assert "1.2.3" in seeds_arg
+        assert result["ids"] == ["1.2.3"]
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# GUARD PRESERVATION (MEDIUM-3)
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestQueryGuards:
+    """Guards from the existing dance path must be preserved in the service-mode branch."""
+
+    def test_subtree_depth_3_returns_existing_error(self, monkeypatch):
+        """MEDIUM-3: subtree with 3+ segments → existing error string."""
+        t3 = _FakeServiceT3()
+        entry = _FakeCatalogEntry("1.1.1", "S", physical_collection="c1")
+        cat = _FakeCatalog(entries=[entry])
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", subtree="1.2.3")  # 3 segments → doc-level
+
+        assert isinstance(result, str)
+        assert "document-level address" in result
+        assert "1.2.3" in result
+
+    def test_catalog_not_initialized_returns_error(self, monkeypatch):
+        """MEDIUM-3: catalog params without catalog → existing error message."""
+        t3 = _FakeServiceT3()
+        _wire(monkeypatch, t3, ["c1"], None, service=True)  # cat=None
+
+        result = core.query("q", author="X")
+
+        assert "catalog not initialized" in result
+
+    def test_catalog_filters_match_nothing_returns_no_docs_message(self, monkeypatch):
+        """MEDIUM-3: filters resolve to empty set → 'No documents found matching catalog filters'."""
+        t3 = _FakeServiceT3()
+        cat = _FakeCatalog(entries=[])  # find returns nothing
+        _wire(monkeypatch, t3, ["c1"], cat, service=True)
+
+        result = core.query("q", author="Ghost")
+
+        assert "No documents found matching catalog filters" in result
+        assert "author=" in result
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# FALLBACK: LOCAL MODE (non-service) must NOT call combined-query functions
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestQueryDancePathCollectionsSorted:
+    """H1: dance path `collections` must also be sorted for cross-mode parity."""
+
+    def test_dance_path_collections_sorted(self, monkeypatch):
+        """H1: dance path structured['collections'] is sorted (not arbitrary set order)."""
+        import nexus.search_engine as se
+
+        class _FakeResult:
+            def __init__(self, coll, dist):
+                self.id = "chunk1"
+                self.collection = coll
+                self.distance = dist
+                self.metadata = {}
+                self.content = "text"
+
+        results = [
+            _FakeResult("z_col", 0.1),
+            _FakeResult("a_col", 0.2),
+        ]
+
+        _wire(monkeypatch, object(), ["z_col", "a_col"], None, service=False)
+        monkeypatch.setattr(se, "search_cross_corpus",
+                            lambda *a, **kw: results)
+
+        # corpus="all" causes the dance to build target from all_names=["z_col","a_col"]
+        # via the "all" expansion path (resolve_corpus exact-matches each prefix).
+        result = core.query("q", structured=True, corpus="all")
+
+        # H1: must be sorted, not arbitrary iteration order
+        assert result["collections"] == sorted({"z_col", "a_col"})
+
+
+class TestQueryFallbackLocalMode:
+    """LOCAL MODE: is_service_backed=False → existing dance + search_cross_corpus runs."""
+
+    def test_local_mode_with_catalog_params_uses_cross_corpus(self, monkeypatch):
+        """Non-service mode + catalog params: search_cross_corpus is called, not combined funcs."""
+        import nexus.search_engine as se
+
+        t3 = _FakeLocalT3()
+        # Add combined-query methods to detect wrong calls
+        t3.meta_calls = []
+        t3.graph_calls = []
+
+        def _bad_meta(*a, **kw):
+            t3.meta_calls.append(True)
+            return []
+
+        def _bad_graph(*a, **kw):
+            t3.graph_calls.append(True)
+            return []
+
+        t3.search_metadata_scoped = _bad_meta
+        t3.search_graph_hop = _bad_graph
+
+        cross_called = []
+
+        def _fake_cross(question, target, *, n_results, t3, where, catalog, link_boost, taxonomy, telemetry, diagnostics_out=None, **kw):
+            cross_called.append(True)
+            return []
+
+        entry = _FakeCatalogEntry("1.1.1", "Doc", author="Alice",
+                                  physical_collection="c1")
+        cat = _FakeCatalog(entries=[entry])
+
+        _wire(monkeypatch, t3, ["c1"], cat, service=False)
+        # Override search_cross_corpus with spy AFTER _wire (so it isn't overridden)
+        monkeypatch.setattr(se, "search_cross_corpus", _fake_cross)
+
+        result = core.query("q", author="Alice")
+
+        assert cross_called, "search_cross_corpus must be called in local mode"
+        assert not t3.meta_calls, "search_metadata_scoped must NOT be called in local mode"
+        assert not t3.graph_calls, "search_graph_hop must NOT be called in local mode"
+
+    def test_no_catalog_params_uses_cross_corpus_regardless_of_service_mode(self, monkeypatch):
+        """No catalog params → old dance regardless of service mode."""
+        import nexus.search_engine as se
+
+        t3 = _FakeServiceT3()
+        cross_called = []
+
+        # Wire first, then override search_cross_corpus with spy AFTER
+        # (order matters: _wire's cross_corpus_result would override otherwise)
+        _wire(monkeypatch, t3, ["knowledge__v1"], None, service=True)
+
+        def _fake_cross(*a, **kw):
+            cross_called.append(True)
+            return []
+
+        monkeypatch.setattr(se, "search_cross_corpus", _fake_cross)
+
+        core.query("q")  # no author/content_type/follow_links/subtree
+
+        assert cross_called, "No catalog params → search_cross_corpus path"
+        assert not t3.meta_calls
+        assert not t3.graph_calls


### PR DESCRIPTION
## What

RDR-156 P4 (`nexus-rzqto`): the keystone repoint. In **service mode** with catalog params, the `query()` MCP tool now routes through the combined-query SQL functions (`search_metadata_scoped` + `search_graph_hop`, built by houg9/889ff) instead of the app-side catalog dance + `search_cross_corpus`. The dance is **kept as a fallback** (local/Chroma mode, catalog-absent, non-catalog-param, and the `follow_links`+`where` combo).

## How

- Service-mode branch: broad target from `corpus` (the SQL functions filter by catalog metadata server-side); `follow_links` resolves seed tumblers app-side → `search_graph_hop`; otherwise `search_metadata_scoped` (subtree/where/author/content_type). Dedup per tumbler at best distance.
- **structured** `chunk_text_hash` comes from the function's per-row `chash` (HIGH-1), not a per-doc manifest guess.
- **Rich text form preserved** (bead must-fix): `bib_year/bib_authors/bib_venue/bib_citation_count` are surfaced onto `CatalogEntry` (the Java catalog already serializes them via `docRowFromRecord`; added to the dataclass + `http_catalog_client` + SQLite `catalog_docs.resolve()`) and rendered per tumbler, mirroring the dance's bib line. Plus title/author/year/chunk_count (manifest).
- Guards preserved (MEDIUM-3): subtree depth≥3 error, catalog-not-initialized error, empty-catalog-filters message.
- `follow_links` no-seeds → broad fallback (matches the dance, not an error); `follow_links`+`where` → dance fallback so `where` is honored; `collections` sorted-distinct in both paths.

## Scope decisions (recorded on the bead)

- **HIGH-2**: a local/Chroma path still exists pre-migration, so the dance stays as the service-mode fallback. `2bqpn` (next) deletes only the service-mode stitch — a self-contained `if is_service_backed(...)` block with a clean deletion boundary.
- content_type precision intentionally moves collection-granular → doc-granular (bead-accepted).

## Tests

`tests/test_query_repoint.py` (26): service routing (author/follow_links/subtree), bib richness, where-forwarding, `follow_links`+`where` dance fallback, no-seeds broad fallback, guards, and the local-mode fallback (asserts `search_cross_corpus` runs, not the combined functions). Catalog/query/http_catalog/combined-query sweep: 1557 passed, 0 failures.

## Review

Stacked review (code-review-expert + substantive-critic), 2 rounds. Round 1: critic **Critical** (bib richness dropped) + code-review **High** (`where` silently dropped on `follow_links`) + parity gaps — all fixed. Round 2 verdict: **justified, 0 Critical / 0 Significant**.

Unblocks `nexus-2bqpn` (delete the service-mode stitch) → P4.G gate.