### PR TITLE
fix(rdr-152): HTTP stores recover stale service port via lease re-resolve [nexus-om64x]

### DIFF
--- a/src/nexus/db/http_scratch_store.py
+++ b/src/nexus/db/http_scratch_store.py
@@ -136,11 +136,7 @@ class HttpScratchStore:
             _HEADER_T1_SESSION: self._session_token,
             "Content-Type": "application/json",
         }
-        self._client = httpx.Client(
-            base_url=self._base_url,
-            headers=self._headers,
-            timeout=30.0,
-        )
+        self._client = self._build_client()
         _log.info(
             "http_scratch_store.init",
             base_url=self._base_url,
@@ -159,6 +155,31 @@ class HttpScratchStore:
         """Close the keep-alive connection pool (idempotent)."""
         self._client.close()
         _log.debug("http_scratch_store.closed")
+
+    def _rebind_from_lease(self) -> bool:
+        """nexus-om64x: on connection-refused (supervisor restarted on a new
+        port; our env port is stale), re-resolve the endpoint from the
+        ServiceRegistry lease and rebuild the client. Returns True if rebound to
+        a NEW endpoint, False otherwise (genuine outage — let the error stand)."""
+        from nexus.db.service_endpoint import recover_endpoint_from_lease
+
+        recovered = recover_endpoint_from_lease(self._base_url)
+        if recovered is None:
+            return False
+        new_url, new_token = recovered
+        _log.warning("http_scratch_store.rebind", old=self._base_url, new=new_url)
+        self._base_url = new_url
+        if new_token:
+            self._headers["Authorization"] = f"Bearer {new_token}"
+        try:
+            self._client.close()
+        except Exception:
+            pass
+        self._client = self._build_client()
+        return True
+
+    def _build_client(self) -> httpx.Client:
+        return httpx.Client(base_url=self._base_url, headers=self._headers, timeout=30.0)
 
     def close_session(self) -> int:
         """Delete all scratch entries for this session. Returns count deleted.
@@ -405,6 +426,16 @@ class HttpScratchStore:
         """
         try:
             resp = self._client.post(path, json=payload)
+        except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.ReadError):
+            # nexus-om64x: stale endpoint after a supervisor restart (connect-refused
+            # OR TCP RST on a pooled in-flight connection) — re-resolve from the lease
+            # and retry ONCE before failing.
+            if not self._rebind_from_lease():
+                raise RuntimeError(f"HttpScratchStore: connect failed on {path}")
+            try:
+                resp = self._client.post(path, json=payload)
+            except httpx.HTTPError as exc:
+                raise RuntimeError(f"HttpScratchStore: connect failed on retry {path}: {exc}") from exc
         except httpx.HTTPError as exc:
             raise RuntimeError(f"HttpScratchStore: network error on {path}: {exc}") from exc
         if not resp.is_success:
@@ -417,6 +448,15 @@ class HttpScratchStore:
         """POST *payload* to *path* and return parsed JSON without raising on 404-class."""
         try:
             resp = self._client.post(path, json=payload)
+        except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.ReadError):
+            # nexus-om64x: stale endpoint after a supervisor restart (connect-refused
+            # OR TCP RST on a pooled in-flight connection) — re-resolve + retry once.
+            if not self._rebind_from_lease():
+                raise RuntimeError(f"HttpScratchStore: connect failed on {path}")
+            try:
+                resp = self._client.post(path, json=payload)
+            except httpx.HTTPError as exc:
+                raise RuntimeError(f"HttpScratchStore: connect failed on retry {path}: {exc}") from exc
         except httpx.HTTPError as exc:
             raise RuntimeError(f"HttpScratchStore: network error on {path}: {exc}") from exc
         if resp.status_code == 404:

--- a/src/nexus/db/service_endpoint.py
+++ b/src/nexus/db/service_endpoint.py
@@ -57,6 +57,43 @@ def discover_lease() -> tuple[str | None, str | None]:
     return None, None
 
 
+def recover_endpoint_from_lease(current_base_url: str) -> tuple[str, str | None] | None:
+    """Connection-refused recovery (nexus-om64x).
+
+    After a supervisor ``_respawn`` allocates a NEW port, a long-lived MCP
+    process still carries the OLD ``NX_SERVICE_PORT`` in its environment — so
+    env-first :func:`resolve_service_config` keeps handing back the dead port and
+    a store that resolved ONCE at construction is stuck (session mint + T1
+    scratch hit connection-refused until the MCP restarts).
+
+    This consults the :class:`ServiceRegistry` lease DIRECTLY (the supervisor's
+    source of truth, republished on every restart — it deliberately bypasses the
+    stale env). Returns ``(new_base_url, token)`` when the lease points somewhere
+    DIFFERENT from *current_base_url* (the store should rebind + retry), or
+    ``None`` when there is no lease or it matches the current endpoint (a genuine
+    outage — let the original connection error propagate).
+
+    SCOPE / known residuals (nexus-om64x, P2 targeting the FATAL paths):
+
+    * **Phase-1 restart window**: the old lease is NOT relinquished on SIGTERM; it
+      lingers until its heartbeat TTL (~3s) expires, and the NEW lease only
+      publishes after the replacement JVM is ready. So a request that fails DURING
+      that window sees either the old (==current) lease or no lease → this returns
+      ``None`` and the error propagates. A request that arrives once the restart
+      has SETTLED (the common case) sees the new lease and recovers via the
+      caller's single retry. Closing the in-window case would need a relinquish on
+      stop or a backoff loop — out of scope for this P2.
+    * **Coverage**: only ``http_token_store`` + ``http_scratch_store`` (the
+      session-mint + T1-scratch FATAL paths) wire this recovery today. The other
+      long-lived service-backed stores (memory/taxonomy/plan/aspect/chash/…) share
+      the resolve-once pattern and remain unguarded — tracked for a sweep follow-on.
+    """
+    lease_url, lease_token = discover_lease()
+    if lease_url is not None and lease_url.rstrip("/") != (current_base_url or "").rstrip("/"):
+        return lease_url.rstrip("/"), lease_token
+    return None
+
+
 def resolve_service_config() -> tuple[str, int, str]:
     """``(host, port, token)`` — env halves, then the lease, then fail loud.
 

--- a/src/nexus/db/t2/http_token_store.py
+++ b/src/nexus/db/t2/http_token_store.py
@@ -64,16 +64,42 @@ class HttpTokenStore:
             host, port, token = _resolve_config()
             self._base_url = f"http://{host}:{port}"
             _token = token
-        self._client = httpx.Client(
+        self._tenant = tenant
+        self._auth_token = _token or ""
+        self._client = self._build_client()
+        _log.info("http_token_store.init", base_url=self._base_url)
+
+    def _build_client(self) -> httpx.Client:
+        return httpx.Client(
             base_url=self._base_url,
             headers={
-                "Authorization": f"Bearer {_token}",
-                "X-Nexus-Tenant": tenant,
+                "Authorization": f"Bearer {self._auth_token}",
+                "X-Nexus-Tenant": self._tenant,
                 "Content-Type": "application/json",
             },
             timeout=30.0,
         )
-        _log.info("http_token_store.init", base_url=self._base_url)
+
+    def _rebind_from_lease(self) -> bool:
+        """nexus-om64x: on connection-refused, re-resolve the endpoint from the
+        ServiceRegistry lease (bypassing the stale env port) and rebuild the
+        client. Returns True if rebound to a NEW endpoint, False otherwise."""
+        from nexus.db.service_endpoint import recover_endpoint_from_lease
+
+        recovered = recover_endpoint_from_lease(self._base_url)
+        if recovered is None:
+            return False
+        new_url, new_token = recovered
+        _log.warning("http_token_store.rebind", old=self._base_url, new=new_url)
+        self._base_url = new_url
+        if new_token:
+            self._auth_token = new_token
+        try:
+            self._client.close()
+        except Exception:
+            pass
+        self._client = self._build_client()
+        return True
 
     def close(self) -> None:
         """Close the connection pool (idempotent)."""
@@ -86,7 +112,18 @@ class HttpTokenStore:
         self.close()
 
     def _post(self, path: str, body: dict[str, Any]) -> dict[str, Any]:
-        resp = self._client.post(path, json=body)
+        try:
+            resp = self._client.post(path, json=body)
+        except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.ReadError):
+            # nexus-om64x: stale endpoint (supervisor restarted on a new port; our
+            # env port is dead). ConnectError = connect-refused (store reconnects
+            # post-restart); RemoteProtocolError/ReadError = TCP RST on a pooled
+            # keep-alive connection that was in flight when the JVM was SIGTERM'd
+            # (mirrors http_vector_client's reset handling). Re-resolve from the
+            # lease and retry ONCE.
+            if not self._rebind_from_lease():
+                raise
+            resp = self._client.post(path, json=body)
         resp.raise_for_status()
         return resp.json()
 

--- a/tests/db/test_om64x_stale_port_recovery.py
+++ b/tests/db/test_om64x_stale_port_recovery.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-om64x: HTTP stores recover from a stale NX_SERVICE_PORT after a
+supervisor restart by re-resolving from the ServiceRegistry lease.
+
+After ``_respawn`` allocates a new port and republishes the lease, a long-lived
+MCP process still carries the OLD ``NX_SERVICE_PORT`` in its env — so env-first
+``resolve_service_config`` keeps handing back the dead port. A store that
+resolved ONCE at construction is stuck on connection-refused until the MCP
+restarts (session mint + T1 scratch hard-fail). The fix: on ``httpx.ConnectError``
+the store consults the lease DIRECTLY (bypassing the stale env), rebinds, and
+retries once.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from nexus.daemon.service_registry import ServiceRegistry
+from nexus.db import service_endpoint
+from nexus.db.service_endpoint import recover_endpoint_from_lease
+
+
+# ── recover_endpoint_from_lease (the shared primitive) ───────────────────────
+
+
+class TestRecoverEndpointFromLease:
+    def test_returns_new_endpoint_when_lease_differs(self, monkeypatch):
+        monkeypatch.setattr(
+            service_endpoint, "discover_lease",
+            lambda: ("http://127.0.0.1:9999", "fresh-token"),
+        )
+        # current points at the stale (dead) port
+        got = recover_endpoint_from_lease("http://127.0.0.1:8080")
+        assert got == ("http://127.0.0.1:9999", "fresh-token")
+
+    def test_none_when_lease_matches_current(self, monkeypatch):
+        # lease == current → genuine outage, not a stale port; let it propagate
+        monkeypatch.setattr(
+            service_endpoint, "discover_lease",
+            lambda: ("http://127.0.0.1:8080", "t"),
+        )
+        assert recover_endpoint_from_lease("http://127.0.0.1:8080") is None
+
+    def test_none_when_no_lease(self, monkeypatch):
+        monkeypatch.setattr(service_endpoint, "discover_lease", lambda: (None, None))
+        assert recover_endpoint_from_lease("http://127.0.0.1:8080") is None
+
+    def test_trailing_slash_insensitive(self, monkeypatch):
+        monkeypatch.setattr(
+            service_endpoint, "discover_lease",
+            lambda: ("http://127.0.0.1:8080/", "t"),
+        )
+        # same endpoint modulo trailing slash → no spurious rebind
+        assert recover_endpoint_from_lease("http://127.0.0.1:8080") is None
+
+
+# ── store recovery: ConnectError → rebind → retry once ───────────────────────
+
+
+class _StubResp:
+    def __init__(self, body: dict, status: int = 200) -> None:
+        self._body = body
+        self.status_code = status
+        self.is_success = 200 <= status < 300
+        self.text = str(body)
+
+    def raise_for_status(self) -> None:
+        if not self.is_success:  # pragma: no cover
+            req = httpx.Request("POST", "http://x")
+            raise httpx.HTTPStatusError(
+                "err", request=req, response=httpx.Response(self.status_code, request=req))
+
+    def json(self) -> dict:
+        return self._body
+
+
+class _FlakyClient:
+    """Raises *exc* on the first post, then succeeds (the rebound client).
+
+    *exc* lets us exercise both connect-refused (ConnectError) and the TCP-RST
+    in-flight class (RemoteProtocolError / ReadError) — nexus-om64x must recover
+    from all three (the supervisor SIGTERMs the JVM mid-flight)."""
+
+    def __init__(self, *, raise_first: bool,
+                 exc: Exception | None = None) -> None:
+        self.raise_first = raise_first
+        self.exc = exc or httpx.ConnectError("connection refused")
+        self.posts = 0
+
+    def post(self, path, json=None):  # noqa: A002
+        self.posts += 1
+        if self.raise_first and self.posts == 1:
+            raise self.exc
+        return _StubResp({"ok": True, "deleted": 0})
+
+    def close(self) -> None:
+        pass
+
+
+class TestTokenStoreRecovery:
+    def _store(self, monkeypatch):
+        from nexus.db.t2.http_token_store import HttpTokenStore
+
+        s = HttpTokenStore(base_url="http://127.0.0.1:8080", _token="tok")
+        # first client raises ConnectError; rebind installs a working stub
+        s._client = _FlakyClient(raise_first=True)
+        monkeypatch.setattr(
+            service_endpoint, "discover_lease",
+            lambda: ("http://127.0.0.1:9999", "fresh"),
+        )
+        monkeypatch.setattr(s, "_build_client", lambda: _FlakyClient(raise_first=False))
+        return s
+
+    def test_post_rebinds_and_retries_on_connect_error(self, monkeypatch):
+        s = self._store(monkeypatch)
+        out = s._post("/v1/tenants/create", {"name": "t"})
+        assert out == {"ok": True, "deleted": 0}
+        assert s._base_url == "http://127.0.0.1:9999"   # rebound to the lease
+        assert s._auth_token == "fresh"                 # token refreshed from lease
+
+    def test_post_propagates_when_no_lease(self, monkeypatch):
+        from nexus.db.t2.http_token_store import HttpTokenStore
+
+        s = HttpTokenStore(base_url="http://127.0.0.1:8080", _token="tok")
+        s._client = _FlakyClient(raise_first=True)
+        monkeypatch.setattr(service_endpoint, "discover_lease", lambda: (None, None))
+        with pytest.raises(httpx.ConnectError):
+            s._post("/v1/tenants/create", {"name": "t"})
+
+    @pytest.mark.parametrize("exc", [
+        httpx.RemoteProtocolError("server disconnected"),  # TCP RST, in-flight
+        httpx.ReadError("socket closed mid-read"),
+    ])
+    def test_post_recovers_from_tcp_reset_classes(self, monkeypatch, exc):
+        from nexus.db.t2.http_token_store import HttpTokenStore
+
+        s = HttpTokenStore(base_url="http://127.0.0.1:8080", _token="tok")
+        s._client = _FlakyClient(raise_first=True, exc=exc)
+        monkeypatch.setattr(
+            service_endpoint, "discover_lease",
+            lambda: ("http://127.0.0.1:9999", "fresh"),
+        )
+        monkeypatch.setattr(s, "_build_client", lambda: _FlakyClient(raise_first=False))
+        out = s._post("/v1/tenants/create", {"name": "t"})
+        assert out == {"ok": True, "deleted": 0}
+        assert s._base_url == "http://127.0.0.1:9999"
+
+
+class TestScratchStoreRecovery:
+    def _store(self, monkeypatch):
+        from nexus.db.http_scratch_store import HttpScratchStore
+
+        s = HttpScratchStore(base_url="http://127.0.0.1:8080", _token="tok",
+                             session_id="sess-1")
+        s._client = _FlakyClient(raise_first=True)
+        monkeypatch.setattr(
+            service_endpoint, "discover_lease",
+            lambda: ("http://127.0.0.1:9999", "fresh"),
+        )
+        monkeypatch.setattr(s, "_build_client", lambda: _FlakyClient(raise_first=False))
+        return s
+
+    def test_post_rebinds_and_retries(self, monkeypatch):
+        s = self._store(monkeypatch)
+        out = s._post("/v1/t1/list", {"session_id": "sess-1"})
+        assert out == {"ok": True, "deleted": 0}
+        assert s._base_url == "http://127.0.0.1:9999"
+        assert s._headers["Authorization"] == "Bearer fresh"
+
+    def test_post_raw_rebinds_and_retries(self, monkeypatch):
+        s = self._store(monkeypatch)
+        out = s._post_raw("/v1/t1/get", {"id": "x", "session_id": "sess-1"})
+        assert out == {"ok": True, "deleted": 0}
+        assert s._base_url == "http://127.0.0.1:9999"
+
+    def test_post_propagates_when_no_lease(self, monkeypatch):
+        from nexus.db.http_scratch_store import HttpScratchStore
+
+        s = HttpScratchStore(base_url="http://127.0.0.1:8080", _token="tok",
+                             session_id="sess-1")
+        s._client = _FlakyClient(raise_first=True)
+        monkeypatch.setattr(service_endpoint, "discover_lease", lambda: (None, None))
+        with pytest.raises(RuntimeError):
+            s._post("/v1/t1/list", {"session_id": "sess-1"})
+
+    def test_post_raw_propagates_when_no_lease(self, monkeypatch):
+        from nexus.db.http_scratch_store import HttpScratchStore
+
+        s = HttpScratchStore(base_url="http://127.0.0.1:8080", _token="tok",
+                             session_id="sess-1")
+        s._client = _FlakyClient(raise_first=True)
+        monkeypatch.setattr(service_endpoint, "discover_lease", lambda: (None, None))
+        with pytest.raises(RuntimeError):
+            s._post_raw("/v1/t1/get", {"id": "x", "session_id": "sess-1"})
+
+    @pytest.mark.parametrize("exc", [
+        httpx.RemoteProtocolError("server disconnected"),
+        httpx.ReadError("socket closed mid-read"),
+    ])
+    def test_post_recovers_from_tcp_reset(self, monkeypatch, exc):
+        from nexus.db.http_scratch_store import HttpScratchStore
+
+        s = HttpScratchStore(base_url="http://127.0.0.1:8080", _token="tok",
+                             session_id="sess-1")
+        s._client = _FlakyClient(raise_first=True, exc=exc)
+        monkeypatch.setattr(
+            service_endpoint, "discover_lease",
+            lambda: ("http://127.0.0.1:9999", "fresh"),
+        )
+        monkeypatch.setattr(s, "_build_client", lambda: _FlakyClient(raise_first=False))
+        out = s._post("/v1/t1/list", {"session_id": "sess-1"})
+        assert out == {"ok": True, "deleted": 0}
+        assert s._base_url == "http://127.0.0.1:9999"


### PR DESCRIPTION
## What

Fixes `nexus-om64x` (RDR-152 P5-gate review MEDIUM): after a supervisor `_respawn` allocates a new port + republishes the ServiceRegistry lease, a long-lived MCP process still carries the OLD `NX_SERVICE_PORT` in its env. Env-first `resolve_service_config` keeps handing back the dead port, and `http_token_store` / `http_scratch_store` resolved **once** at construction → **session mint (Phase-E FATAL) + T1 scratch hard-fail** on connection errors until the MCP restarts. (`http_vector_client` already self-heals; these two didn't.)

## Fix

- Shared `service_endpoint.recover_endpoint_from_lease(current)` — consults the ServiceRegistry lease **directly** (bypassing the stale env; the registry is the supervisor's source of truth, republished every restart) and returns a new endpoint only when it **differs** from current.
- Both stores catch `(httpx.ConnectError, httpx.RemoteProtocolError, httpx.ReadError)` in their POST paths — connect-refused **and** the TCP-RST class for a pooled in-flight connection hit by the SIGTERM'd JVM (mirrors the vector client) — rebind (rebuild client + refresh token from the lease) and **retry once**; a missing/matching lease propagates the original error. No retry loop.

## Tests

`tests/db/test_om64x_stale_port_recovery.py` (14): the recover helper (differs/matches/absent/trailing-slash), and both stores' ConnectError + RST-class → rebind → retry-once, plus propagate-when-no-lease (`_post` and `_post_raw`). db/token/scratch sweep: 718 green.

## Scope (P2 → the FATAL paths)

Documented residuals in the helper docstring + a follow-on sweep bead filed: the **Phase-1 restart window** (old lease lingers ~TTL on SIGTERM, new lease publishes after JVM-ready — a request *during* that window still propagates; a request after the restart settles recovers), and the **9 sibling resolve-once stores** (memory/taxonomy/plan/aspect/chash/…) that share the pattern but aren't FATAL — to be wired via a shared rebind/retry wrapper in the sweep.

## Review

Stacked review (code-review-expert + substantive-critic), 2 rounds. Round 1: critic **Critical** (ConnectError-only missed TCP RST for in-flight requests) → catch widened + RST tests; code-review M1/M2/L1/L2 → fixed. Round 2: **justified, 0 Critical / 0 Significant**.

Clears `nexus-gmiaf.24`'s last non-boundary dependency (`.24` itself stays gated on the release/migration boundary).