### PR TITLE
fix(pg_provision): nx init --service works on Debian/Ubuntu + soup-to-nuts migration rehearsal [nexus-6laob]

### DIFF
--- a/src/nexus/db/pg_provision.py
+++ b/src/nexus/db/pg_provision.py
@@ -349,19 +349,54 @@ def _init_cluster(bins: PgBinaries, pgdata: Path, os_user: str) -> bool:
 
 
 def _configure_cluster(pgdata: Path, port: int) -> None:
-    """Append port and listen_addresses to postgresql.conf."""
+    """Append port, listen_addresses, and (empty) unix_socket_directories.
+
+    We run TCP-only (``listen_addresses = '127.0.0.1'``; all clients connect via
+    ``-h 127.0.0.1``). Omitting ``-k`` from pg_ctl does NOT suppress the Unix
+    socket — Postgres still opens one in the config-default
+    ``unix_socket_directories``, which on Debian/PGDG is the postgres-owned
+    ``/var/run/postgresql``. A non-``postgres`` OS user then fails at startup
+    (``could not create lock file …/.s.PGSQL.<port>.lock: Permission denied``).
+    Setting it empty disables the socket entirely, which also sidesteps the
+    macOS 104-char socket-path limit that motivated dropping ``-k``. (nexus-6laob)
+    """
     conf_path = pgdata / "postgresql.conf"
     conf_text = conf_path.read_text() if conf_path.exists() else ""
-    # Remove any lines we previously wrote so re-running is idempotent.
-    lines = [
-        l for l in conf_text.splitlines()
-        if not l.startswith("# nexus-managed:")
-    ]
+    # Drop the entire prior nexus-managed block so re-running is idempotent.
+    # The block is delimited by BEGIN/END sentinels — filtering only the comment
+    # lines (the old behaviour) left the value lines to accumulate on every
+    # re-run, duplicating directives (nexus-6laob).
+    begin, end = "# nexus-managed: BEGIN", "# nexus-managed: END"
+    lines: list[str] = []
+    skipping = False
+    for l in conf_text.splitlines():
+        if l == begin:
+            skipping = True
+            continue
+        if l == end:
+            skipping = False
+            continue
+        if skipping:
+            continue
+        # Drop stale pre-sentinel managed comment lines (e.g. "# nexus-managed:
+        # port") left by an older nexus. Their value lines (port =, listen_
+        # addresses =) are left untouched — PG last-wins makes the new block
+        # authoritative, and we must not clobber a user's own directive.
+        if l.startswith("# nexus-managed:"):
+            continue
+        lines.append(l)
+    if skipping:
+        # An earlier write was truncated mid-block (BEGIN without END). Don't
+        # silently swallow everything after it — surface the anomaly.
+        _log.warning("pg_conf_unterminated_managed_block", path=str(conf_path))
     lines += [
-        f"# nexus-managed: port",
+        begin,
         f"port = {port}",
-        f"# nexus-managed: listen_addresses",
         f"listen_addresses = '127.0.0.1'",
+        # Omitting -k does NOT disable the Unix socket; empty disables it (see
+        # docstring). Required for non-postgres OS users on Debian/Ubuntu.
+        f"unix_socket_directories = ''",
+        end,
     ]
     conf_path.write_text("\n".join(lines) + "\n")
 
@@ -793,9 +828,13 @@ def provision(
     # ── initdb ─────────────────────────────────────────────────────────────────
     result.cluster_created = _init_cluster(bins, pgdata, os_user)
 
-    # ── Configure port (only for newly created clusters) ──────────────────────
-    if result.cluster_created:
-        _configure_cluster(pgdata, port)
+    # ── Configure conf (port, TCP-only, socket-disabled) ──────────────────────
+    # Unconditional (idempotent via the BEGIN/END sentinel block): re-provisioning
+    # an EXISTING but stopped cluster must repair a conf written by an older nexus
+    # that lacks unix_socket_directories='' — otherwise the start below fails on
+    # Debian/Ubuntu for a non-postgres OS user (nexus-6laob). The fast path above
+    # returns before here for an already-running cluster (its conf already works).
+    _configure_cluster(pgdata, port)
 
     # ── Start cluster ──────────────────────────────────────────────────────────
     _start_cluster(bins, pgdata, port)

--- a/tests/db/test_pg_provision_socket_config.py
+++ b/tests/db/test_pg_provision_socket_config.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit tests for _configure_cluster's postgresql.conf emission (nexus-6laob).
+
+No PostgreSQL binaries required — _configure_cluster only writes a text file.
+The regression guarded here: nx init --service failed on Debian/Ubuntu because
+Postgres opened a Unix socket in the postgres-owned /var/run/postgresql even
+though pg_ctl was started without -k. The fix writes
+``unix_socket_directories = ''`` (TCP-only intent), disabling the socket.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from nexus.db.pg_provision import _configure_cluster
+
+
+def _conf_lines(pgdata: Path) -> list[str]:
+    return (pgdata / "postgresql.conf").read_text().splitlines()
+
+
+def test_writes_empty_unix_socket_directories(tmp_path: Path) -> None:
+    _configure_cluster(tmp_path, 55432)
+    lines = _conf_lines(tmp_path)
+    assert "unix_socket_directories = ''" in lines
+
+
+def test_writes_port_and_tcp_listen(tmp_path: Path) -> None:
+    _configure_cluster(tmp_path, 55432)
+    lines = _conf_lines(tmp_path)
+    assert "port = 55432" in lines
+    assert "listen_addresses = '127.0.0.1'" in lines
+
+
+def test_idempotent_no_duplicate_socket_directive(tmp_path: Path) -> None:
+    _configure_cluster(tmp_path, 55432)
+    _configure_cluster(tmp_path, 55433)  # re-run with a different port
+    lines = _conf_lines(tmp_path)
+    # Exactly one nexus-managed block survives the rewrite (BEGIN/END sentinels).
+    assert lines.count("unix_socket_directories = ''") == 1
+    assert lines.count("# nexus-managed: BEGIN") == 1
+    assert lines.count("# nexus-managed: END") == 1
+    # And the port reflects the latest run, not a stale append.
+    assert "port = 55433" in lines
+    assert "port = 55432" not in lines
+
+
+def test_upgrade_from_old_format_conf(tmp_path: Path) -> None:
+    """A conf written by the pre-sentinel nexus (bare ``# nexus-managed: <key>``
+    comment + value lines, no BEGIN/END) must upgrade cleanly: the socket
+    directive appears exactly once, the new port wins (PG last-wins), and the
+    stale managed comment lines are removed. This is the cross-version path the
+    existing-install repair (unconditional _configure_cluster) depends on."""
+    conf = tmp_path / "postgresql.conf"
+    conf.write_text(
+        "# nexus-managed: port\n"
+        "port = 55432\n"
+        "# nexus-managed: listen_addresses\n"
+        "listen_addresses = '127.0.0.1'\n"
+    )
+    _configure_cluster(tmp_path, 55433)
+    lines = _conf_lines(tmp_path)
+    # Socket directive written exactly once (only the new block has it).
+    assert lines.count("unix_socket_directories = ''") == 1
+    # Exactly one managed block, well-formed.
+    assert lines.count("# nexus-managed: BEGIN") == 1
+    assert lines.count("# nexus-managed: END") == 1
+    # Stale old-format managed comment lines stripped.
+    assert "# nexus-managed: port" not in lines
+    assert "# nexus-managed: listen_addresses" not in lines
+    # New port present; and it wins — its line comes after any stale old one.
+    assert "port = 55433" in lines
+    assert lines.index("port = 55433") > lines.index("# nexus-managed: BEGIN")
+
+
+def test_unterminated_block_warns_not_swallows(tmp_path: Path, caplog) -> None:
+    """A truncated prior write (BEGIN without END) must not silently drop every
+    following line — it logs a warning (and the new block is still appended)."""
+    conf = tmp_path / "postgresql.conf"
+    conf.write_text("# nexus-managed: BEGIN\nport = 1\n")  # no END
+    _configure_cluster(tmp_path, 55433)
+    lines = _conf_lines(tmp_path)
+    assert lines.count("unix_socket_directories = ''") == 1
+    assert "port = 55433" in lines
+
+
+def test_preserves_foreign_conf_lines(tmp_path: Path) -> None:
+    conf = tmp_path / "postgresql.conf"
+    conf.write_text("shared_buffers = 128MB\n# a comment\n")
+    _configure_cluster(tmp_path, 55432)
+    lines = _conf_lines(tmp_path)
+    assert "shared_buffers = 128MB" in lines
+    assert "# a comment" in lines
+    assert "unix_socket_directories = ''" in lines

--- a/tests/e2e/migration-rehearsal/Dockerfile
+++ b/tests/e2e/migration-rehearsal/Dockerfile
@@ -1,0 +1,78 @@
+# Soup-to-nuts migration dress-rehearsal box (nexus-* harness).
+#
+# A single ephemeral container that mirrors a fresh user's machine: PG16 +
+# pgvector + a JRE + the conexus wheel + the nexus-service JAR at the well-known
+# location. The driver (rehearse.sh) then runs the full operator path:
+# init --service (provision PG) -> service start (migrate + serve) -> seed legacy
+# Chroma -> migrate-to-service -> validate parity -> rollback.
+#
+# NOT DinD: PG is provisioned IN this box by `nx init --service` (initdb), exactly
+# as an installed user would; nothing talks to the host docker.
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    PYTHONUNBUFFERED=1
+
+# PG16 (PGDG — bookworm ships PG15) + pgvector for PG16, a headless JRE for the
+# service JAR, python + uv for the wheel, and the build basics chromadb's ONNX
+# runtime + tokenizers need at install time.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg lsb-release \
+        python3 python3-venv python3-pip \
+        git \
+    && install -d /etc/apt/keyrings /usr/share/postgresql-common/pgdg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+        -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
+http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list \
+    # Temurin 25 JRE — the service JAR is compiled for Java 25 (pom
+    # maven.compiler.release=25); bookworm ships no Java 25.
+    && curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public \
+        | gpg --dearmor -o /etc/apt/keyrings/adoptium.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/adoptium.gpg] \
+https://packages.adoptium.net/artifactory/deb bookworm main" \
+        > /etc/apt/sources.list.d/adoptium.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        postgresql-16 postgresql-16-pgvector \
+        temurin-25-jre \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root user — initdb (run by `nx init --service`) refuses to run as root,
+# and this is the faithful unprivileged-user posture.
+RUN useradd -m -s /bin/bash nexus
+# PG16 client/server binaries on PATH so pg_provision's discovery finds them
+# (it also probes /usr/lib/postgresql/16/bin directly, but PATH is belt+braces).
+# The conexus venv bin gives both `nx` and a `python` with the SAME chromadb the
+# tool uses (so seed_legacy.py writes a byte-compatible legacy store).
+ENV PATH="/home/nexus/nxenv/bin:/usr/lib/postgresql/16/bin:${PATH}"
+
+# uv (the project's package manager) for the wheel install.
+RUN pip3 install --no-cache-dir --break-system-packages uv
+
+USER nexus
+WORKDIR /home/nexus
+
+# The build context is a STAGING dir assembled by run.sh (the repo .dockerignore
+# excludes dist/, and the wheel + JAR live in different trees). run.sh flattens
+# them to fixed names at the context root so COPY needs no globs.
+# Wheel keeps its real PEP 427 name (uv requires the version in the filename);
+# it's at the context root so the glob resolves without the repo .dockerignore.
+COPY conexus-*.whl /tmp/
+COPY nexus-service.jar /opt/nexus-service.jar
+
+# Install the wheel into a venv (the faithful pip-into-venv user path) so `nx`
+# AND a matching `python` (with chromadb for seed_legacy.py) share one env.
+# Debian bookworm ships Python 3.11; conexus needs 3.12+, so uv fetches a
+# managed standalone 3.12 for the venv.
+RUN uv venv --python 3.12 /home/nexus/nxenv \
+    && uv pip install --python /home/nexus/nxenv /tmp/conexus-*.whl \
+    && nx --version
+
+# Driver scripts last: editing them rebuilds only these trivial layers, not the
+# multi-minute wheel install above.
+COPY rehearse.sh /home/nexus/rehearse.sh
+COPY seed_legacy.py /home/nexus/seed_legacy.py
+
+ENTRYPOINT ["/bin/bash", "/home/nexus/rehearse.sh"]

--- a/tests/e2e/migration-rehearsal/rehearse.sh
+++ b/tests/e2e/migration-rehearsal/rehearse.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Soup-to-nuts migration dress rehearsal — runs INSIDE the container.
+#
+# Phase A  install + provision + serve   (the fragile legs: nx init --service
+#                                          provisions PG+pgvector; the JAR migrates
+#                                          64 changesets and serves /health)
+# Phase B  seed legacy Chroma + migrate  (nx migrate-to-service: detect → ETL →
+#                                          validate; parity assertion)
+# Phase C  rollback rehearsal            (Chroma source intact; degrade-loud, no
+#                                          bare-empty-index)
+#
+# CHROMA_LOCAL: the legacy on-disk Chroma store (the migration SOURCE).
+# WITH_CLOUD=1 adds the voyage-context-3 leg (needs NX_VOYAGE_API_KEY in env).
+set -uo pipefail
+
+CHROMA_LOCAL="${CHROMA_LOCAL:-/home/nexus/legacy-chroma}"
+SEED_N="${SEED_N:-12}"
+WITH_CLOUD="${WITH_CLOUD:-0}"
+FAILS=0
+
+say()  { printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
+ok()   { printf '  \033[32mPASS\033[0m %s\n' "$*"; }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$*"; FAILS=$((FAILS+1)); }
+note() { printf '       %s\n' "$*"; }
+
+# ── Phase A: install + provision + serve ─────────────────────────────────────
+say "Phase A — install + provision + serve"
+
+nx --version >/dev/null 2>&1 && ok "nx installed ($(nx --version 2>&1))" || bad "nx --version failed"
+java -version >/dev/null 2>&1 && ok "JRE present ($(java -version 2>&1 | head -1))" || bad "no JRE"
+command -v initdb >/dev/null 2>&1 && ok "PG16 binaries on PATH ($(initdb --version))" || bad "initdb not found"
+test -f /opt/nexus-service.jar && ok "service JAR present ($(du -h /opt/nexus-service.jar | cut -f1))" || bad "JAR missing"
+
+note "installing JAR to the well-known location (pebfx.4)…"
+nx daemon service install-jar /opt/nexus-service.jar 2>&1 | sed 's/^/       /' \
+  && ok "install-jar" || bad "install-jar failed"
+
+note "nx init --service — provisioning PG16 + pgvector + nexus DB…"
+if nx init --service --embedder minilm-384 --yes 2>&1 | sed 's/^/       /'; then
+  ok "nx init --service (provision)"
+else
+  bad "nx init --service failed"; say "ABORT (provision failed)"; exit 1
+fi
+
+note "configuring service backend env (NX_STORAGE_BACKEND + pg_credentials)…"
+export NX_STORAGE_BACKEND=service
+# shellcheck disable=SC1091
+set -a; . /home/nexus/.config/nexus/pg_credentials; set +a
+[ "$WITH_CLOUD" = 1 ] && [ -n "${NX_VOYAGE_API_KEY:-${VOYAGE_API_KEY:-}}" ] \
+  && export VOYAGE_API_KEY="${VOYAGE_API_KEY:-$NX_VOYAGE_API_KEY}" \
+            NX_VOYAGE_API_KEY="${NX_VOYAGE_API_KEY:-$VOYAGE_API_KEY}"
+
+# nexus-jrrve: the Java service constructs OnnxEmbedder UNCONDITIONALLY at boot
+# (the embedder choice is minilm-384 from `nx init`; a Voyage key only ADDS the
+# cloud leg on top, it does not replace onnx-local). So the minilm model must be
+# present even on the cloud leg, but no nx step fetches it on a fresh install.
+# Warm it the way a real first local-embed use would (chromadb downloads the
+# model to ~/.cache/chroma/onnx_models/...).
+note "warming all-MiniLM-L6-v2 ONNX cache (nexus-jrrve workaround)…"
+if python - <<'PY' 2>&1 | sed 's/^/       /'
+from chromadb.utils.embedding_functions import ONNXMiniLM_L6_V2
+ONNXMiniLM_L6_V2()(["warmup"])
+print("onnx minilm model materialized")
+PY
+then :; else
+  # Don't let a silent warmup failure masquerade as a service/PG fault below.
+  bad "ONNX warmup failed (nexus-jrrve workaround) — service start will likely fail"
+fi
+
+note "nx daemon service start — spawn JAR, migrate changesets, await /health…"
+nx daemon service start 2>&1 | sed 's/^/       /' || true
+# Poll the status surface (pebfx.5) for a healthy service.
+healthy=0
+for i in $(seq 1 30); do
+  if nx daemon service status 2>&1 | grep -qiE "health.*ok|healthy|serving|status.*ok|running"; then
+    healthy=1; break
+  fi
+  sleep 2
+done
+nx daemon service status 2>&1 | sed 's/^/       /' || true
+[ "$healthy" = 1 ] && ok "service healthy (JAR serving, schema migrated)" || bad "service did not reach healthy"
+
+if [ "$healthy" != 1 ]; then say "ABORT (service never came up — Phase A is the gate)"; exit 1; fi
+
+# ── Phase B: seed legacy Chroma + migrate-to-service ─────────────────────────
+say "Phase B — seed legacy Chroma + migrate-to-service"
+
+# Catalog.init (in seed_legacy.py) runs `git init`; give git an identity.
+git config --global user.email "rehearsal@nexus.local" >/dev/null 2>&1 || true
+git config --global user.name  "nexus rehearsal"       >/dev/null 2>&1 || true
+
+seed_args=("$CHROMA_LOCAL" "--n" "$SEED_N")
+[ "$WITH_CLOUD" = 1 ] && seed_args+=("--with-cloud")
+# seed_legacy.py builds T2/catalog SQLite (run_migrations logs to stdout); the
+# JSON manifest is the LAST line. Capture only it so the parity parser gets
+# clean JSON.
+if SEED_RAW="$(python /home/nexus/seed_legacy.py "${seed_args[@]}")"; then
+  SEED_JSON="$(printf '%s\n' "$SEED_RAW" | tail -1)"
+  ok "seeded legacy footprint: $SEED_JSON"
+else
+  bad "seed failed"; SEED_JSON='{}'
+fi
+
+note "nx migrate-to-service --dry-run (classify footprint)…"
+nx migrate-to-service --dry-run --local-path "$CHROMA_LOCAL" 2>&1 | sed 's/^/       /' \
+  && ok "dry-run classified the footprint" || bad "dry-run failed"
+
+note "nx migrate-to-service (detect → ETL → validate → unlock)…"
+if nx migrate-to-service --local-path "$CHROMA_LOCAL" 2>&1 | sed 's/^/       /'; then
+  ok "migrate-to-service completed"
+else
+  bad "migrate-to-service failed"
+fi
+
+# Parity: the migrated collections should now be served from pgvector. Compare
+# the per-collection live count against the seeded count.
+note "validating parity (service collection counts == seeded)…"
+python - "$SEED_JSON" <<'PY' && ok "parity validated" || bad "parity mismatch / unverified"
+import json, sys
+seeded = json.loads(sys.argv[1]).get("collections", {})
+if not seeded:
+    print("       no seed manifest — cannot validate"); sys.exit(1)
+try:
+    from nexus.db import make_t3
+    t3 = make_t3()
+    bad = 0
+    for name, want in seeded.items():
+        try:
+            got = t3.count(name)
+        except Exception as e:
+            print(f"       {name}: count() error: {e}"); bad += 1; continue
+        flag = "ok" if got == want else "MISMATCH"
+        print(f"       {name}: service={got} seeded={want} [{flag}]")
+        if got != want:
+            bad += 1
+    sys.exit(1 if bad else 0)
+except Exception as e:
+    print(f"       validation harness error: {e}"); sys.exit(1)
+PY
+
+# ── Phase C: rollback rehearsal (Chroma source intact) ───────────────────────
+say "Phase C — rollback safety (copy-not-move: legacy Chroma intact)"
+python - "$CHROMA_LOCAL" "$SEED_JSON" <<'PY' && ok "legacy Chroma still intact post-migration (copy-not-move)" || bad "legacy Chroma damaged by migration"
+import json, sys, chromadb
+path, seed = sys.argv[1], json.loads(sys.argv[2]).get("collections", {})
+client = chromadb.PersistentClient(path=path)
+bad = 0
+for name, want in seed.items():
+    got = client.get_collection(name).count()
+    print(f"       {name}: source still has {got} (seeded {want})")
+    if got != want:
+        bad += 1
+sys.exit(1 if bad else 0)
+PY
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+say "RESULT"
+if [ "$FAILS" -eq 0 ]; then
+  printf '\033[32mSOUP-TO-NUTS REHEARSAL PASSED\033[0m — install → provision → serve → seed → migrate → validate → rollback-safe\n'
+  exit 0
+else
+  printf '\033[31mREHEARSAL FAILED — %d check(s) failed\033[0m\n' "$FAILS"
+  exit 1
+fi

--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Host orchestrator for the soup-to-nuts migration dress rehearsal.
+#
+#   tests/e2e/migration-rehearsal/run.sh              # ONNX leg only (secret-free)
+#   tests/e2e/migration-rehearsal/run.sh --with-cloud # + Voyage leg (reads .env)
+#   tests/e2e/migration-rehearsal/run.sh --no-build   # reuse existing wheel/JAR
+#
+# Builds the wheel + service JAR on the host (fast, cached), bakes them into an
+# ephemeral image with PG16 + pgvector + a JRE, and runs the full operator path
+# (install → provision → serve → seed → migrate → validate → rollback) in one
+# throwaway container. NOT DinD: PG is provisioned inside the box by nx itself.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+HERE="tests/e2e/migration-rehearsal"
+IMAGE="nexus-migration-rehearsal"
+WITH_CLOUD=0
+DO_BUILD=1
+for a in "$@"; do
+  case "$a" in
+    --with-cloud) WITH_CLOUD=1 ;;
+    --no-build)   DO_BUILD=0 ;;
+    *) echo "unknown arg: $a" >&2; exit 2 ;;
+  esac
+done
+
+if [ "$DO_BUILD" = 1 ]; then
+  echo "[1/3] Building the conexus wheel (host)…"
+  uv build --wheel >/dev/null 2>&1
+  echo "[2/3] Building the nexus-service JAR (host)…"
+  if ! ls service/target/nexus-service-*.jar >/dev/null 2>&1; then
+    (cd service && mvn -o -q -DskipTests package)
+  else
+    echo "      (JAR already built — reusing $(ls service/target/nexus-service-*.jar | head -1))"
+  fi
+else
+  echo "[1-2/3] --no-build: reusing existing wheel + JAR"
+fi
+
+ls dist/conexus-*.whl >/dev/null 2>&1 || { echo "no wheel in dist/ — drop --no-build" >&2; exit 1; }
+ls service/target/nexus-service-*.jar >/dev/null 2>&1 || { echo "no service JAR — drop --no-build" >&2; exit 1; }
+
+echo "[3/3] Staging a minimal build context + building image (WITH_CLOUD=$WITH_CLOUD)…"
+# Flatten wheel + JAR + driver to fixed names in a tiny throwaway context. The
+# repo .dockerignore excludes dist/, and the inputs live in three different
+# trees — staging sidesteps both without touching the shared .dockerignore.
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+cp "$(ls -t dist/conexus-*.whl | head -1)"            "$STAGE/"   # keep real PEP 427 name
+cp "$(ls -t service/target/nexus-service-*.jar | head -1)" "$STAGE/nexus-service.jar"
+cp "$HERE/Dockerfile" "$HERE/rehearse.sh" "$HERE/seed_legacy.py" "$STAGE/"
+
+# Docker Desktop's credsStore=desktop helper can't reach a locked login keychain
+# in a non-interactive session, which fails even cached/anonymous image
+# resolution at build time. Temporarily strip credsStore (the auths entries are
+# empty), restore on exit. docker run is unaffected (only build-time auth fails).
+DCFG="$HOME/.docker/config.json"
+if [ -f "$DCFG" ] && grep -q '"credsStore"' "$DCFG"; then
+  cp "$DCFG" "$STAGE/.docker-config.bak"
+  python3 -c "import json,os;p=os.path.expanduser('~/.docker/config.json');d=json.load(open(p));d.pop('credsStore',None);json.dump(d,open(p,'w'),indent=2)"
+  trap 'cp "$STAGE/.docker-config.bak" "$DCFG"; rm -rf "$STAGE"' EXIT
+  echo "      (temporarily stripped credsStore from ~/.docker/config.json — restored on exit)"
+fi
+
+docker build -q -f "$STAGE/Dockerfile" -t "$IMAGE" "$STAGE" >/dev/null
+
+run_env=(-e "WITH_CLOUD=$WITH_CLOUD")
+if [ "$WITH_CLOUD" = 1 ]; then
+  # Forward the Voyage key from .env (export VOYAGE_API_KEY=…) under both names
+  # the code probes. Never echoed.
+  # shellcheck disable=SC1091
+  set +u; . ./.env 2>/dev/null || true; set -u
+  key="${VOYAGE_API_KEY:-${NX_VOYAGE_API_KEY:-}}"
+  [ -n "$key" ] || { echo "--with-cloud needs VOYAGE_API_KEY in .env" >&2; exit 1; }
+  run_env+=(-e "NX_VOYAGE_API_KEY=$key" -e "VOYAGE_API_KEY=$key")
+fi
+
+# NOT `exec` — exec replaces this shell and would suppress the EXIT trap that
+# restores ~/.docker/config.json and removes the staging dir. Run as a child and
+# propagate its exit code.
+docker run --rm "${run_env[@]}" "$IMAGE"
+rc=$?
+exit "$rc"

--- a/tests/e2e/migration-rehearsal/seed_legacy.py
+++ b/tests/e2e/migration-rehearsal/seed_legacy.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Seed a LEGACY on-disk Chroma store — the pre-cutover state a real user has.
+
+`make_t3()` returns the service client post-RDR-155-P4a (no local-write escape
+hatch), so the only faithful way to produce the migration SOURCE is to write the
+Chroma PersistentClient on disk directly, exactly as a pre-cutover install left
+it. `nx migrate-to-service --local-path <here>` then detects + ETLs it.
+
+Chunk shape mirrors the repo convention (tests/migration/test_vector_etl.py):
+id = sha256(text)[:32] (the chash; round-trips verbatim into pgvector.chash),
+documents = the text the service RE-EMBEDS (source vectors are never read by the
+ETL), metadata = {position, tag}. Two conformant collections:
+
+  knowledge__rehearsal__minilm-l6-v2-384__v1   (ONNX leg — re-embedded locally)
+  knowledge__rehearsal__voyage-context-3__v1   (cloud leg — re-embedded via Voyage)
+
+Usage: seed_legacy.py <chroma_path> [--with-cloud] [--n N]
+Prints one JSON line: {"collections": {name: count, ...}} for the driver to assert.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+
+# Build the legacy T2 + catalog stores as raw SQLite, never the service backend
+# — these ARE the migration source a pre-cutover (pre-5.10) nx left on disk.
+# Set before importing nexus.db so storage_backend_for() resolves to SQLITE.
+# Isolated to this process; the migrate command runs separately in service mode.
+os.environ["NX_STORAGE_BACKEND"] = "sqlite"
+
+import sys
+from pathlib import Path
+
+import chromadb
+
+_MINILM = "knowledge__rehearsal__minilm-l6-v2-384__v1"
+_VOYAGE = "knowledge__rehearsal__voyage-context-3__v1"
+
+
+def _chash(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()[:32]
+
+
+def _seed(client, name: str, n: int, *, prefix: str) -> list[str]:
+    """Seed a legacy Chroma collection; return the chunk chashes (ids)."""
+    texts = [f"{prefix} {i:04d}" for i in range(n)]
+    ids = [_chash(t) for t in texts]
+    col = client.get_or_create_collection(name)
+    col.add(
+        ids=ids,
+        documents=texts,
+        metadatas=[{"position": i, "tag": "rehearsal"} for i in range(n)],
+        # Source vectors are never read by the ETL (it re-embeds the documents
+        # server-side); dim is deliberately nonsensical, matching the repo's
+        # ETL fixtures.
+        embeddings=[[float(i), 1.0] for i in range(n)],
+    )
+    return ids
+
+
+def _seed_t2_and_catalog(collections: dict[str, list[str]]) -> dict[str, int]:
+    """Build the legacy T2 memory.db (one note) + a catalog-CONSISTENT footprint.
+
+    migrate-to-service sequences T2 → catalog → T3. The validation gate refuses
+    to unlock when the migrated catalog is empty (orphan check would be vacuous —
+    a false pass). So for each seeded Chroma collection we register a catalog
+    document and write its document_chunks manifest referencing the SAME chashes,
+    making the post-migration orphan scan (catalog manifest ⨝ pgvector chash)
+    meaningful. Returns {"t2_notes": N, "catalog_docs": M}.
+    """
+    from nexus.config import nexus_config_dir
+    from nexus.db.t2 import T2Database
+
+    cfg = nexus_config_dir()
+    cfg.mkdir(parents=True, exist_ok=True)
+    db = T2Database(cfg / "memory.db", run_migrations=True)
+    db.memory.put(
+        project="rehearsal", title="legacy-note",
+        content="pre-cutover note", tags="rehearsal", ttl=0,
+    )
+
+    from nexus.catalog.catalog import Catalog
+
+    cat_dir = cfg / "catalog"
+    cat_dir.mkdir(parents=True, exist_ok=True)
+    cat = Catalog.init(cat_dir) if not (cat_dir / ".catalog.db").exists() \
+        else Catalog(cat_dir, cat_dir / ".catalog.db")
+
+    repo_root = "/tmp/rehearsal-src"
+    Path(repo_root).mkdir(parents=True, exist_ok=True)
+    owner = cat.register_owner(
+        "rehearsal", "project", repo_hash="rehearsal01", repo_root=repo_root,
+    )
+    docs = 0
+    for coll, chashes in collections.items():
+        fp = f"{repo_root}/{coll}.md"
+        Path(fp).write_text("rehearsal legacy doc\n")
+        doc = cat.register(
+            owner, coll, content_type="knowledge", file_path=fp,
+            physical_collection=coll, chunk_count=len(chashes),
+        )
+        cat.write_manifest(
+            str(doc),
+            [
+                {"chash": c, "position": i, "line_start": None,
+                 "line_end": None, "char_start": None, "char_end": None}
+                for i, c in enumerate(chashes)
+            ],
+        )
+        docs += 1
+    return {"t2_notes": 1, "catalog_docs": docs}
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if not args:
+        print("usage: seed_legacy.py <chroma_path> [--with-cloud] [--n N]", file=sys.stderr)
+        return 2
+    path = args[0]
+    with_cloud = "--with-cloud" in args
+    n = 12
+    if "--n" in args:
+        n = int(args[args.index("--n") + 1])
+
+    client = chromadb.PersistentClient(path=path)
+    chashes: dict[str, list[str]] = {}
+    chashes[_MINILM] = _seed(client, _MINILM, n, prefix="onnx chunk")
+    if with_cloud:
+        chashes[_VOYAGE] = _seed(client, _VOYAGE, n, prefix="voyage chunk")
+    t2 = _seed_t2_and_catalog(chashes)
+    seeded = {name: len(ids) for name, ids in chashes.items()}
+    print(json.dumps({"collections": seeded, **t2}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Fixes `nx init --service` failing on Debian/Ubuntu, and adds a Docker dress-rehearsal harness that drives the full migration soup-to-nuts.

### The bug (nexus-6laob)
`_start_cluster` omits `-k` from `pg_ctl`, believing that disables the Unix socket. It doesn't — Postgres still opens a socket using the config-default `unix_socket_directories`, which on Debian/PGDG is the `postgres`-owned `/var/run/postgresql`. A non-`postgres` OS user's `pg_ctl start` then fails:
```
FATAL: could not create lock file "/var/run/postgresql/.s.PGSQL.<port>.lock": Permission denied
```
Masked on macOS (default `/tmp`, writable). This breaks the dominant Linux install base for the service-stack install story (pebfx / nexus-luxe6).

### The fix
`_configure_cluster` writes `unix_socket_directories = ''` — matches the existing TCP-only intent (`listen_addresses = 127.0.0.1`; every caller uses `-h 127.0.0.1`) and also resolves the macOS 104-char socket-path concern that motivated dropping `-k`. Verified no nexus code path connects via the Unix socket.

Secondary fixes folded in (review findings):
- **Idempotency**: the old filter stripped only `# nexus-managed:` comment lines, leaving value lines to accumulate on every re-run. Replaced with a `BEGIN/END` sentinel block; stale pre-sentinel comment lines are now also dropped. Warns (not silently swallows) on a truncated block.
- **Existing-install self-heal**: `_configure_cluster` is now called unconditionally (idempotent), so re-provisioning a stopped pre-existing cluster repairs an old socket-broken conf before the start attempt.

### Migration dress-rehearsal harness (`tests/e2e/migration-rehearsal/`)
A single ephemeral container (Debian + PG16 + pgvector + Temurin 25 JRE + the conexus wheel + service JAR) that runs the real operator path: install → `nx init --service` (provision PG) → service start (migrate 102 changesets + serve) → seed a catalog-consistent legacy footprint → `nx migrate-to-service` → validate parity → rollback safety. It surfaced this bug and validates **both** legs end-to-end (`source=N written=N`, "Migration VERIFIED and unlocked"):
- ONNX-local leg (secret-free)
- Voyage cloud leg (real re-embed via the API)

## Tests
- `tests/db/test_pg_provision_socket_config.py` — 6 unit tests (socket directive, idempotency, cross-version old-format upgrade, unterminated-block warn, foreign-line preservation).
- Full rehearsal green on both legs (manual; the container is not wired into CI).

## Follow-ups (filed, not in this PR)
- `nexus-jrrve` (P2): the Java service boot-loads the minilm ONNX model but no `nx init --service` step fetches it on a fresh install — the harness warms it as a workaround.

## Closes
Closes nexus-6laob