### PR TITLE
test(rdr-157): CA-3 live gate — zonky PG16 + injected pgvector (P1.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,9 @@ jobs:
             -w /pgvector \
             -v "$PWD/bundle:/bundle" -v "$PWD/pgvector:/pgvector" \
             "$MANYLINUX_IMAGE" /bin/bash -c '
-              set -euxo pipefail
+              # NB: no pipefail — `cmd | head` makes head close the pipe early,
+              # the producer takes SIGPIPE, and pipefail+-e would abort (141).
+              set -eux
               echo "=== ENTER container ==="
               head -2 /etc/os-release
               command -v gcc make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,8 @@ jobs:
           docker run --rm \
             -v "$PWD/bundle:/bundle" -v "$PWD/pgvector:/pgvector" \
             "$MANYLINUX_IMAGE" bash -euo pipefail -c '
-              source /opt/rh/devtoolset-10/enable 2>/dev/null || true
+              source /opt/rh/devtoolset-10/enable 2>/dev/null \
+                || echo "WARNING: devtoolset-10 absent; using default gcc: $(gcc --version | head -1)"
               cd /pgvector
               make CC=gcc PG_CONFIG=/bundle/bin/pg_config
               make CC=gcc PG_CONFIG=/bundle/bin/pg_config install
@@ -199,9 +200,13 @@ jobs:
                   skipped += 1
               elif not is_fail:
                   passed += 1
-              if c.get("name") == "test_create_extension_vector_loads" and not is_skip and not is_fail:
+              # endswith, not ==: future pytest may qualify @name with the class.
+              if c.get("name", "").endswith("test_create_extension_vector_loads") and not is_skip and not is_fail:
                   core_ok = True
           assert skipped == 0, f"{skipped} CA-3 test(s) skipped — bundle not materialized; gate is vacuous"
-          assert core_ok, "core CREATE EXTENSION vector test did not pass — Strategy A unproven"
+          assert core_ok, (
+              "core CREATE EXTENSION vector test did not pass — Strategy A unproven "
+              "(or the testcase @name no longer ends with 'test_create_extension_vector_loads')"
+          )
           print(f"CA-3 PASS: {passed} passed, 0 skipped, pgvector load + glibc floor verified")
           PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,15 @@ jobs:
       # PG16 binaries; pgvector >= 0.8 is the RDR-155 iterative_scan floor.
       ZONKY_PG_VERSION: "16.4.0"
       PGVECTOR_VERSION: "v0.8.2"
-      # manylinux2014 == glibc 2.17 (CentOS 7). Building vector.so here pins its
-      # glibc floor to zonky's broad-compat baseline instead of the runner's glibc
-      # (~2.39), so the binary dlopen-loads on old distros. Must match GLIBC_FLOOR
+      # manylinux_2_28 == glibc 2.28 (AlmaLinux 8 baseline: RHEL8 / Debian 10 /
+      # Ubuntu 18.10+). Building vector.so here pins its glibc floor to a broadly
+      # compatible baseline instead of the runner's glibc (~2.39), so the binary
+      # dlopen-loads on older distros. We deliberately do NOT use manylinux2014
+      # (glibc 2.17 / CentOS 7): CentOS 7 is EOL and its in-container yum mirrors
+      # are dead, so a toolchain top-up is impossible. glibc 2.28 is a defensible
+      # 2026 floor and the image ships a working gcc/make. Must match GLIBC_FLOOR
       # in tests/db/test_pg_provision_ca3_bundle.py.
-      MANYLINUX_IMAGE: "quay.io/pypa/manylinux2014_x86_64"
+      MANYLINUX_IMAGE: "quay.io/pypa/manylinux_2_28_x86_64"
 
     steps:
       - uses: actions/checkout@v4
@@ -164,25 +168,22 @@ jobs:
             https://github.com/pgvector/pgvector.git pgvector
           # Build against the EXTRACTED tree's pg_config so make install lands
           # vector.so in the bundle's pkglibdir and vector.control in its sharedir.
-          # manylinux2014 (CentOS 7, glibc 2.17) ships gcc via a toolset whose
-          # enable-script path drifts across image revisions; rather than guess,
-          # install the base toolchain explicitly (yum) and fail loud if the
-          # compiler still isn't resolvable. pgvector is plain C — CentOS 7's
-          # gcc is sufficient and keeps the glibc 2.17 floor.
+          # manylinux_2_28 ships a working gcc/make toolchain on PATH (gcc-toolset);
+          # no package top-up needed. set -x traces every command so a build break
+          # is diagnosable from the log rather than a bare exit code. pgvector is
+          # plain C and PGXS picks the compiler from pg_config's Makefile.global.
           docker run --rm \
+            -w /pgvector \
             -v "$PWD/bundle:/bundle" -v "$PWD/pgvector:/pgvector" \
-            "$MANYLINUX_IMAGE" bash -euo pipefail -c '
-              yum -y -q install make gcc >/dev/null 2>&1 || true
-              # Prefer a devtoolset/gcc-toolset gcc if one is enabled; otherwise
-              # the yum-installed system gcc. Glob the enable script so we are not
-              # pinned to a single toolset version.
-              for f in /opt/rh/*/enable; do source "$f" 2>/dev/null || true; done
-              command -v make >/dev/null || { echo "FATAL: make not found in container"; exit 127; }
-              command -v gcc  >/dev/null || { echo "FATAL: gcc not found in container";  exit 127; }
-              echo "toolchain: $(gcc --version | head -1); $(make --version | head -1); glibc $(ldd --version | head -1)"
-              cd /pgvector
-              make CC=gcc PG_CONFIG=/bundle/bin/pg_config
-              make CC=gcc PG_CONFIG=/bundle/bin/pg_config install
+            "$MANYLINUX_IMAGE" /bin/bash -c '
+              set -euxo pipefail
+              echo "=== ENTER container ==="
+              head -2 /etc/os-release
+              command -v gcc make
+              gcc --version | head -1
+              ldd --version | head -1
+              make PG_CONFIG=/bundle/bin/pg_config
+              make PG_CONFIG=/bundle/bin/pg_config install
             '
           # pg_config on the host reports the relocated (host) pkglibdir; docker
           # mounted that same dir, so make install wrote vector.so straight into it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,13 +164,22 @@ jobs:
             https://github.com/pgvector/pgvector.git pgvector
           # Build against the EXTRACTED tree's pg_config so make install lands
           # vector.so in the bundle's pkglibdir and vector.control in its sharedir.
-          # CC=gcc: zonky's Makefile.global may name a compiler absent in the
-          # container; the devtoolset gcc is the portable choice.
+          # manylinux2014 (CentOS 7, glibc 2.17) ships gcc via a toolset whose
+          # enable-script path drifts across image revisions; rather than guess,
+          # install the base toolchain explicitly (yum) and fail loud if the
+          # compiler still isn't resolvable. pgvector is plain C — CentOS 7's
+          # gcc is sufficient and keeps the glibc 2.17 floor.
           docker run --rm \
             -v "$PWD/bundle:/bundle" -v "$PWD/pgvector:/pgvector" \
             "$MANYLINUX_IMAGE" bash -euo pipefail -c '
-              source /opt/rh/devtoolset-10/enable 2>/dev/null \
-                || echo "WARNING: devtoolset-10 absent; using default gcc: $(gcc --version | head -1)"
+              yum -y -q install make gcc >/dev/null 2>&1 || true
+              # Prefer a devtoolset/gcc-toolset gcc if one is enabled; otherwise
+              # the yum-installed system gcc. Glob the enable script so we are not
+              # pinned to a single toolset version.
+              for f in /opt/rh/*/enable; do source "$f" 2>/dev/null || true; done
+              command -v make >/dev/null || { echo "FATAL: make not found in container"; exit 127; }
+              command -v gcc  >/dev/null || { echo "FATAL: gcc not found in container";  exit 127; }
+              echo "toolchain: $(gcc --version | head -1); $(make --version | head -1); glibc $(ldd --version | head -1)"
               cd /pgvector
               make CC=gcc PG_CONFIG=/bundle/bin/pg_config
               make CC=gcc PG_CONFIG=/bundle/bin/pg_config install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,106 @@ jobs:
 
       - name: Run tests
         run: uv run pytest tests/ -q --durations=25
+
+  ca3-pgvector-bundle:
+    # RDR-157 P1 CA-3 gate (bead nexus-vwvv5.2): prove Strategy A — a relocatable
+    # zonky PG16 binary bundle + a CI-built pgvector .so injected into it — can be
+    # driven by nx's own provisioner to a cluster that LOADS pgvector. This is the
+    # go/no-go before the P2/P3 build-out; FAILURE means falling back to Strategy B
+    # (build PostgreSQL from source). linux-amd64 only for release N; linux-aarch64
+    # live-run is deferred to the P2/P3 build matrix (needs an arm64 runner).
+    name: CA-3 live (zonky PG16 + pgvector, linux-amd64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      # Pinned for determinism. zonky ships relocatable, broad-compat linux-amd64
+      # PG16 binaries; pgvector >= 0.8 is the RDR-155 iterative_scan floor.
+      ZONKY_PG_VERSION: "16.4.0"
+      PGVECTOR_VERSION: "v0.8.2"
+      # manylinux2014 == glibc 2.17 (CentOS 7). Building vector.so here pins its
+      # glibc floor to zonky's broad-compat baseline instead of the runner's glibc
+      # (~2.39), so the binary dlopen-loads on old distros. Must match GLIBC_FLOOR
+      # in tests/db/test_pg_provision_ca3_bundle.py.
+      MANYLINUX_IMAGE: "quay.io/pypa/manylinux2014_x86_64"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: false
+
+      - name: Cache uv wheel cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/setup-uv-cache
+          key: uv-${{ runner.os }}-3.12-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-3.12-
+
+      - name: Install project + dev deps
+        run: uv sync --group dev
+
+      - name: Fetch + extract relocatable zonky PG16 bundle
+        run: |
+          set -euo pipefail
+          jar="embedded-postgres-binaries-linux-amd64-${ZONKY_PG_VERSION}.jar"
+          url="https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-linux-amd64/${ZONKY_PG_VERSION}/${jar}"
+          curl -fsSL -o pg.jar "$url"
+          mkdir -p jarx bundle
+          (cd jarx && unzip -q ../pg.jar)
+          # The jar wraps a single postgres-linux-x86_64.txz of the PG tree.
+          tar -xJf jarx/postgres-linux-x86_64.txz -C bundle
+          test -x bundle/bin/initdb
+          echo "NEXUS_CA3_BUNDLE=$PWD/bundle" >> "$GITHUB_ENV"
+          echo "Extracted: $(bundle/bin/initdb --version)"
+
+      - name: Build + inject pgvector (manylinux2014, glibc 2.17)
+        run: |
+          set -euo pipefail
+          git clone --depth 1 --branch "${PGVECTOR_VERSION}" \
+            https://github.com/pgvector/pgvector.git pgvector
+          # Build against the EXTRACTED tree's pg_config so make install lands
+          # vector.so in the bundle's pkglibdir and vector.control in its sharedir.
+          # CC=gcc: zonky's Makefile.global may name a compiler absent in the
+          # container; the devtoolset gcc is the portable choice.
+          docker run --rm \
+            -v "$PWD/bundle:/bundle" -v "$PWD/pgvector:/pgvector" \
+            "$MANYLINUX_IMAGE" bash -euo pipefail -c '
+              source /opt/rh/devtoolset-10/enable 2>/dev/null || true
+              cd /pgvector
+              make CC=gcc PG_CONFIG=/bundle/bin/pg_config
+              make CC=gcc PG_CONFIG=/bundle/bin/pg_config install
+            '
+          # pg_config on the host reports the relocated (host) pkglibdir; docker
+          # mounted that same dir, so make install wrote vector.so straight into it.
+          pkglib="$(bundle/bin/pg_config --pkglibdir)"
+          test -f "$pkglib/vector.so" || { ls -la "$pkglib"; exit 1; }
+          echo "Injected: $pkglib/vector.so"
+
+      - name: Run CA-3 live test (asserts it actually ran, not skipped)
+        run: |
+          set -euo pipefail
+          # -o addopts="" clears the repo default `-m 'not integration'` so the
+          # integration-marked CA-3 module is collected.
+          uv run pytest tests/db/test_pg_provision_ca3_bundle.py \
+            -o addopts="" -m integration -q -rs --junit-xml=ca3.xml
+          uv run python - <<'PY'
+          import xml.etree.ElementTree as ET
+          root = ET.parse("ca3.xml").getroot()
+          skipped = passed = 0
+          core_ok = False
+          for c in root.iter("testcase"):
+              is_skip = c.find("skipped") is not None
+              is_fail = c.find("failure") is not None or c.find("error") is not None
+              if is_skip:
+                  skipped += 1
+              elif not is_fail:
+                  passed += 1
+              if c.get("name") == "test_create_extension_vector_loads" and not is_skip and not is_fail:
+                  core_ok = True
+          assert skipped == 0, f"{skipped} CA-3 test(s) skipped — bundle not materialized; gate is vacuous"
+          assert core_ok, "core CREATE EXTENSION vector test did not pass — Strategy A unproven"
+          print(f"CA-3 PASS: {passed} passed, 0 skipped, pgvector load + glibc floor verified")
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
               tar -xjf pg.tar.bz2
               cd "postgresql-${PG_VERSION}"
               # Minimal deps: a functional server + client + headers + pgxs.
-              # The dropped options are safe for nx's embedded, loopback-only PG
+              # The dropped options are safe for the nexus embedded, loopback-only PG
               # and these same flags carry forward to the P3 bundle build:
               #   --without-icu      : provision runs `initdb --no-locale` (C
               #                        collation), so ICU is unused; keeps the
@@ -189,7 +189,7 @@ jobs:
               #   --without-readline : psql is driven headlessly (subprocess).
               #   --without-zlib     : no wire compression / pg_dump -Fc needed.
               #   --without-openssl  : loopback-only; EXPLICIT so an image that
-              #                        later ships openssl-devel can't silently
+              #                        later ships openssl-devel cannot silently
               #                        link libssl and break startup on the runner.
               ./configure --prefix="${bundle}" \
                 --without-icu --without-zlib --without-readline --without-openssl >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,28 +104,36 @@ jobs:
         run: uv run pytest tests/ -q --durations=25
 
   ca3-pgvector-bundle:
-    # RDR-157 P1 CA-3 gate (bead nexus-vwvv5.2): prove Strategy A — a relocatable
-    # zonky PG16 binary bundle + a CI-built pgvector .so injected into it — can be
-    # driven by nx's own provisioner to a cluster that LOADS pgvector. This is the
-    # go/no-go before the P2/P3 build-out; FAILURE means falling back to Strategy B
-    # (build PostgreSQL from source). linux-amd64 only for release N; linux-aarch64
-    # live-run is deferred to the P2/P3 build matrix (needs an arm64 runner).
-    name: CA-3 live (zonky PG16 + pgvector, linux-amd64)
+    # RDR-157 P1 CA-3 gate (bead nexus-vwvv5.2): prove the assemble path — a
+    # COMPLETE PG16 tree + pgvector — can be driven by nx's own provisioner to a
+    # cluster that LOADS pgvector, with the binary's glibc floor pinned. This is
+    # the go/no-go before the P2/P3 build-out.
+    #
+    # Strategy B (build from source), NOT zonky. CA-3 empirically falsified the
+    # original "zonky reduced bundle + inject pgvector" plan: zonky's
+    # embedded-postgres-binaries reduced bundle ships ONLY initdb/pg_ctl/postgres
+    # — no pg_config/psql/createdb/headers — so pgvector cannot be built against
+    # it AND nx's provisioner (which needs psql+createdb) cannot use it. The RDR
+    # pre-authorized Strategy B as the CA-3-failure fallback. See RF-157-9 /
+    # T2 nexus_rdr/157-CA3-FINDING-zonky-reduced-insufficient.
+    #
+    # linux-amd64 only for release N; linux-aarch64 (nexus-xqk5r) and mac-arm64
+    # (nexus-0ixqc) live runs are deferred to P3 with named beads.
+    name: CA-3 live (PG16 from source + pgvector, linux-amd64)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
-      # Pinned for determinism. zonky ships relocatable, broad-compat linux-amd64
-      # PG16 binaries; pgvector >= 0.8 is the RDR-155 iterative_scan floor.
-      ZONKY_PG_VERSION: "16.4.0"
+      # Pinned for determinism. pgvector >= 0.8 is the RDR-155 iterative_scan floor.
+      PG_VERSION: "16.4"
       PGVECTOR_VERSION: "v0.8.2"
       # manylinux_2_28 == glibc 2.28 (AlmaLinux 8 baseline: RHEL8 / Debian 10 /
-      # Ubuntu 18.10+). Building vector.so here pins its glibc floor to a broadly
-      # compatible baseline instead of the runner's glibc (~2.39), so the binary
-      # dlopen-loads on older distros. We deliberately do NOT use manylinux2014
-      # (glibc 2.17 / CentOS 7): CentOS 7 is EOL and its in-container yum mirrors
-      # are dead, so a toolchain top-up is impossible. glibc 2.28 is a defensible
-      # 2026 floor and the image ships a working gcc/make. Must match GLIBC_FLOOR
-      # in tests/db/test_pg_provision_ca3_bundle.py.
+      # Ubuntu 18.10+). Building the tree + vector.so here pins their glibc floor
+      # to a broadly compatible baseline instead of the runner's glibc (~2.39), so
+      # the binaries dlopen-load on older distros. We deliberately do NOT use
+      # manylinux2014 (glibc 2.17 / CentOS 7): CentOS 7 is EOL and its in-container
+      # yum mirrors are dead. glibc 2.28 is a defensible 2026 floor and the image
+      # ships a working gcc/make. Must match GLIBC_FLOOR in
+      # tests/db/test_pg_provision_ca3_bundle.py.
       MANYLINUX_IMAGE: "quay.io/pypa/manylinux_2_28_x86_64"
 
     steps:
@@ -147,51 +155,53 @@ jobs:
       - name: Install project + dev deps
         run: uv sync --group dev
 
-      - name: Fetch + extract relocatable zonky PG16 bundle
+      - name: Build complete PG16 + pgvector from source (Strategy B, glibc 2.28)
         run: |
           set -euo pipefail
-          jar="embedded-postgres-binaries-linux-amd64-${ZONKY_PG_VERSION}.jar"
-          url="https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-linux-amd64/${ZONKY_PG_VERSION}/${jar}"
-          curl -fsSL -o pg.jar "$url"
-          mkdir -p jarx bundle
-          (cd jarx && unzip -q ../pg.jar)
-          # The jar wraps a single postgres-linux-x86_64.txz of the PG tree.
-          tar -xJf jarx/postgres-linux-x86_64.txz -C bundle
-          test -x bundle/bin/initdb
-          echo "NEXUS_CA3_BUNDLE=$PWD/bundle" >> "$GITHUB_ENV"
-          echo "Extracted: $(bundle/bin/initdb --version)"
-
-      - name: Build + inject pgvector (manylinux2014, glibc 2.17)
-        run: |
-          set -euo pipefail
-          git clone --depth 1 --branch "${PGVECTOR_VERSION}" \
-            https://github.com/pgvector/pgvector.git pgvector
-          # Build against the EXTRACTED tree's pg_config so make install lands
-          # vector.so in the bundle's pkglibdir and vector.control in its sharedir.
-          # manylinux_2_28 ships a working gcc/make toolchain on PATH (gcc-toolset);
-          # no package top-up needed. set -x traces every command so a build break
-          # is diagnosable from the log rather than a bare exit code. pgvector is
-          # plain C and PGXS picks the compiler from pg_config's Makefile.global.
+          # The bundle is installed at its build prefix and mounted at the SAME
+          # path inside the container, so pg_config's compiled-in paths agree with
+          # the host (no relocation mismatch for the gate). True extract-to-
+          # arbitrary-dir relocation — where pg_config's build-prefix-boundness
+          # makes path resolution a real concern — is a P3 bundle-build problem
+          # (nexus-vwvv5.9), not this gate.
+          bundle="$GITHUB_WORKSPACE/bundle"
+          mkdir -p "$bundle"
+          # set -x traces every command; no pipefail (cmd|head SIGPIPEs -> 141).
           docker run --rm \
-            -w /pgvector \
-            -v "$PWD/bundle:/bundle" -v "$PWD/pgvector:/pgvector" \
+            -e PG_VERSION -e PGVECTOR_VERSION -e bundle="$bundle" \
+            -v "$bundle:$bundle" \
             "$MANYLINUX_IMAGE" /bin/bash -c '
-              # NB: no pipefail — `cmd | head` makes head close the pipe early,
-              # the producer takes SIGPIPE, and pipefail+-e would abort (141).
               set -eux
               echo "=== ENTER container ==="
-              head -2 /etc/os-release
-              command -v gcc make
-              gcc --version | head -1
-              ldd --version | head -1
-              make PG_CONFIG=/bundle/bin/pg_config
-              make PG_CONFIG=/bundle/bin/pg_config install
+              head -2 /etc/os-release; ldd --version | head -1
+              # PostgreSQL build prereqs not in the base toolchain image.
+              dnf -y -q install flex bison perl >/dev/null
+              cd /tmp
+              curl -fsSL "https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.bz2" -o pg.tar.bz2
+              tar -xjf pg.tar.bz2
+              cd "postgresql-${PG_VERSION}"
+              # Minimal deps: a functional server + client + headers + pgxs. No
+              # icu/zlib/readline/openssl keeps the build fast and the .so deps lean.
+              ./configure --prefix="${bundle}" --without-icu --without-zlib --without-readline >/dev/null
+              make -s -j"$(nproc)" >/dev/null
+              make -s install >/dev/null
+              # pgvector against the freshly-built pg_config (same major + glibc).
+              cd /tmp
+              git clone --depth 1 --branch "${PGVECTOR_VERSION}" https://github.com/pgvector/pgvector.git
+              cd pgvector
+              make -s PG_CONFIG="${bundle}/bin/pg_config"
+              make -s PG_CONFIG="${bundle}/bin/pg_config" install
             '
-          # pg_config on the host reports the relocated (host) pkglibdir; docker
-          # mounted that same dir, so make install wrote vector.so straight into it.
-          pkglib="$(bundle/bin/pg_config --pkglibdir)"
+          # Sanity on the host: complete tool set + injected extension present.
+          for b in initdb pg_ctl postgres psql createdb pg_config; do
+            test -x "$bundle/bin/$b" || { echo "missing $bundle/bin/$b"; exit 1; }
+          done
+          pkglib="$("$bundle/bin/pg_config" --pkglibdir)"
+          sharedir="$("$bundle/bin/pg_config" --sharedir)"
           test -f "$pkglib/vector.so" || { ls -la "$pkglib"; exit 1; }
-          echo "Injected: $pkglib/vector.so"
+          test -f "$sharedir/extension/vector.control" || { ls -la "$sharedir/extension"; exit 1; }
+          echo "NEXUS_CA3_BUNDLE=$bundle" >> "$GITHUB_ENV"
+          echo "Built: $("$bundle/bin/initdb" --version); vector.so at $pkglib"
 
       - name: Run CA-3 live test (asserts it actually ran, not skipped)
         run: |
@@ -217,7 +227,7 @@ jobs:
                   core_ok = True
           assert skipped == 0, f"{skipped} CA-3 test(s) skipped — bundle not materialized; gate is vacuous"
           assert core_ok, (
-              "core CREATE EXTENSION vector test did not pass — Strategy A unproven "
+              "core CREATE EXTENSION vector test did not pass — assemble path unproven "
               "(or the testcase @name no longer ends with 'test_create_extension_vector_loads')"
           )
           print(f"CA-3 PASS: {passed} passed, 0 skipped, pgvector load + glibc floor verified")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,19 @@ jobs:
               curl -fsSL "https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.bz2" -o pg.tar.bz2
               tar -xjf pg.tar.bz2
               cd "postgresql-${PG_VERSION}"
-              # Minimal deps: a functional server + client + headers + pgxs. No
-              # icu/zlib/readline/openssl keeps the build fast and the .so deps lean.
-              ./configure --prefix="${bundle}" --without-icu --without-zlib --without-readline >/dev/null
+              # Minimal deps: a functional server + client + headers + pgxs.
+              # The dropped options are safe for nx's embedded, loopback-only PG
+              # and these same flags carry forward to the P3 bundle build:
+              #   --without-icu      : provision runs `initdb --no-locale` (C
+              #                        collation), so ICU is unused; keeps the
+              #                        binary off an ICU .so absent on old distros.
+              #   --without-readline : psql is driven headlessly (subprocess).
+              #   --without-zlib     : no wire compression / pg_dump -Fc needed.
+              #   --without-openssl  : loopback-only; EXPLICIT so an image that
+              #                        later ships openssl-devel can't silently
+              #                        link libssl and break startup on the runner.
+              ./configure --prefix="${bundle}" \
+                --without-icu --without-zlib --without-readline --without-openssl >/dev/null
               make -s -j"$(nproc)" >/dev/null
               make -s install >/dev/null
               # pgvector against the freshly-built pg_config (same major + glibc).

--- a/docs/rdr/rdr-157-end-user-distribution-and-installation.md
+++ b/docs/rdr/rdr-157-end-user-distribution-and-installation.md
@@ -435,46 +435,63 @@ bloat is unacceptable, fall back to ship-alongside** — the per-OS/arch archive
 zero native-image involvement, guaranteed to work. Either way CA-2 does not gate the
 two-distribution architecture; it only decides single-file-vs-archive packaging.
 
-### RF-157-9 (CA-3, P1 gate, test + CI authored 2026-06-14): Strategy A assemble path — live verification
+### RF-157-9 (CA-3, P1 gate, VERIFIED 2026-06-15): Strategy A falsified → Strategy B proven
 
-**Verdict: pending the first green CI run (the test and the `ca3-pgvector-bundle` job
-that drives it are implemented; the VERIFIED/FAILED stamp lands when it runs on the PR).
-Bead `nexus-vwvv5.2`.**
+**Verdict: Strategy A (zonky reduced bundle + inject pgvector) FAILED on completeness;
+Strategy B (build PG16 from source) VERIFIED green in CI. Bead `nexus-vwvv5.2`.**
 
-CA-3 is the go/no-go before the P2/P3 build-out: does Strategy A (assemble — zonky PG16
-bundle + CI-built pgvector injected) actually work end to end under nx's own
-provisioner? The verification is two artifacts:
+CA-3 is the go/no-go before the P2/P3 build-out: can a complete PG16 tree + pgvector be
+driven by nx's own provisioner to a cluster that loads pgvector, with the glibc floor
+pinned?
 
+**Strategy A empirically falsified.** The original plan was "zonky
+`embedded-postgres-binaries-linux-amd64` + CI-built pgvector injected." Extracting that
+bundle (16.4.0) shows it ships **only** `initdb`, `pg_ctl`, `postgres` — no `pg_config`,
+`psql`, `createdb`, headers, or pgxs (zonky's reduced bundle is by design for embedded
+test servers). Two independent blockers: (1) pgvector cannot be built against it (no
+pg_config/headers/pgxs); (2) nx's own `discover_pg_binaries` requires `psql`+`createdb`,
+so the provisioner can't even use it. This is the CA-1 "reduced bundle completeness"
+risk, confirmed fatal. There is no "full" zonky artifact.
+
+**Strategy B verified.** The CA-3 gate was pivoted (owner-approved) to build a complete
+PG16 from source. Two artifacts:
 - **`tests/db/test_pg_provision_ca3_bundle.py`** — pure verification over a
-  pre-materialized bundle (so it stays hermetic): discovers the bundle via the
-  production `NEXUS_PG_BIN` seam, asserts the binaries are PG16 and **relocatable**
-  (`pg_config --sharedir` resolves *inside* the extracted tree), that pgvector is
-  injected and passes `check_pgvector_available`, and — the load-bearing assertion —
-  provisions a hermetic cluster from the bundle and runs `CREATE EXTENSION vector`,
-  which forces `dlopen(vector.so)`. Locally (no bundle) every test skips with a reason
-  naming the CI job.
-- **`.github/workflows/ci.yml` job `ca3-pgvector-bundle`** (linux-amd64) — fetches
-  `embedded-postgres-binaries-linux-amd64:16.4.0` from Maven Central, extracts the inner
-  `.txz`, builds pgvector `v0.8.2` against the extracted `pg_config` **inside
-  manylinux2014 (glibc 2.17)**, `make install`s it into the bundle, then runs the test
-  with a junit parse that asserts **0 skipped + the `CREATE EXTENSION` case passed** —
-  so a silent all-skip cannot masquerade as a green gate.
+  pre-materialized bundle via the production `NEXUS_PG_BIN` seam: PG16 binaries present
+  and complete (`all_present` incl. psql+createdb), `pg_config --sharedir` resolves inside
+  the bundle, pgvector present + `check_pgvector_available` passes, the pinned glibc
+  floor holds, and — the load-bearing assertion — provisions a hermetic cluster and runs
+  `CREATE EXTENSION vector` (forces `dlopen(vector.so)`) + a vector distance op. Skips
+  loudly (named CI job) when no bundle.
+- **`.github/workflows/ci.yml` job `ca3-pgvector-bundle`** (linux-amd64) — inside a
+  **manylinux_2_28 (glibc 2.28)** container: `./configure --prefix=<bundle> && make &&
+  make install` PostgreSQL **16.4** from source (a complete tree), build pgvector
+  `v0.8.2` against that pg_config, then run the test with a junit parse asserting
+  **0 skipped + `CREATE EXTENSION` passed** (no silent all-skip). **Green 2026-06-15:
+  11 passed, 0 skipped, glibc floor verified.**
 
-**Glibc floor (the actionable finding).** `check_pgvector_available` only stats
-`vector.control`; it never `dlopen`s. The ABI/glibc failure surfaces at extension LOAD,
-not preflight — so pgvector must be built on the **oldest reasonable glibc baseline**,
-not the CI runner's (ubuntu-latest ≈ glibc 2.39, which would `dlopen`-fail on
-RHEL7/CentOS7/old-Debian). Decision: build in **manylinux2014 (glibc 2.17)** to match
-zonky's broad-compat baseline; the test pins `GLIBC_FLOOR=(2,17)` and `objdump -T`
-asserts **both** `vector.so` and the zonky `postgres` binary require ≤ `GLIBC_2.17`. A
-builder drift that raises the floor fails the test, not the user.
+**Glibc floor.** `check_pgvector_available` only stats `vector.control`; it never
+`dlopen`s. The ABI/glibc failure surfaces at extension LOAD, not preflight — so the tree
++ pgvector must be built on the **oldest reasonable glibc baseline**, not the CI runner's
+(ubuntu-latest ≈ glibc 2.39, which would `dlopen`-fail on older distros). Decision: build
+in **manylinux_2_28 (glibc 2.28** = RHEL8 / Debian 10 / Ubuntu 18.10+, a defensible 2026
+floor; manylinux2014 / glibc 2.17 was rejected — CentOS 7 is EOL with dead in-container
+repos). The test pins `GLIBC_FLOOR=(2,28)` and `objdump -T` asserts **both** `vector.so`
+and the `postgres` binary require ≤ `GLIBC_2.28`. A builder drift that raises the floor
+fails the test, not the user.
+
+**Relocation caveat (P3).** The gate builds the bundle at, and consumes it from, the same
+prefix, so `pg_config`'s compiled-in paths agree with the runtime location. True
+extract-to-arbitrary-dir relocation is **not** proven here: `pg_config` reports build-time
+absolute paths, so any nx path resolution via `pg_config` (e.g. `check_pgvector_available`'s
+sharedir lookup) is not relocation-safe. The local-distribution bundle build must either
+install at a fixed runtime prefix or resolve paths relative to the binary (PostgreSQL's
+`find_my_exec`). Tracked as P3 work (`nexus-vwvv5.9`).
 
 **Per-target coverage (release N = linux-amd64 + linux-aarch64 + mac-arm64 per CA-1).**
 The P1 gate covers **linux-amd64** live. The other two release-N targets are deferred to
 P3 with **named beads** so the deferral is traceable, not silent:
-- **linux-aarch64** (`nexus-xqk5r`): same `manylinux2014_aarch64` baseline (glibc 2.17,
-  `GLIBC_FLOOR` already applies); runs the existing test against the zonky
-  `linux-arm64v8` bundle on an arm64 runner.
+- **linux-aarch64** (`nexus-xqk5r`): same `manylinux_2_28_aarch64` baseline (glibc 2.28,
+  `GLIBC_FLOOR` applies); runs the same from-source build on an arm64 runner.
 - **mac-arm64** (`nexus-0ixqc`): darwin-specific unknowns the linux gate does NOT
   exercise — pgvector produces a `.dylib` (not `.so`), the loader is `dyld` (no glibc
   floor; pin the macOS deployment-target/`minos` via `otool`/`vtool` instead), and
@@ -482,12 +499,9 @@ P3 with **named beads** so the deferral is traceable, not silent:
   variant on a `macos-14` runner. P3 must not start the mac-arm64 bundle build assuming
   the linux result transfers.
 
-**FAILED path → Strategy B trigger.** If the live job fails (zonky's reduced bundle is
-incomplete, ABI mismatch on the same PG16 minor, pgvector won't build against the
-extracted tree, or `dlopen` fails despite the manylinux build), RDR-157 falls back to
-**Strategy B**: build PostgreSQL 16 from source in the existing native-image CI matrix
-and build pgvector against that (ABI-safe, costlier; Windows MSVC PG-from-source is the
-long pole — release N+1 regardless). CA-1 (RF-157-7) already names B as the fallback.
+**Consequence for P3.** The embedded-PG bundle is built from PostgreSQL source per
+OS/arch (not repackaged from zonky). Windows MSVC PG-from-source remains the long pole
+(release N+1).
 
 ### Implications for the draft Decisions — SUPERSEDED by the 2026-06-14 lock
 

--- a/docs/rdr/rdr-157-end-user-distribution-and-installation.md
+++ b/docs/rdr/rdr-157-end-user-distribution-and-installation.md
@@ -204,9 +204,18 @@ is release N+1.
    sha256 manifest for release N; evaluate Sigstore/cosign signing for N+1 (the binary
    runs with DB credentials and is opaque to static inspection — see Open Q4).
 4. **P3 — embedded-PG bundle + the two distributions.**
-   - **Bundle build (per OS/arch):** Strategy A (zonky PG16 + CI-built pgvector injected
-     into the bundle `pkglibdir`/`sharedir`), or Strategy B if CA-3 forced it. Smoke:
-     extract → `initdb` → `CREATE EXTENSION vector` in CI.
+   - **Bundle build (per OS/arch):** **Strategy B — build PostgreSQL 16 from source**
+     (locked by CA-3 / RF-157-9: Strategy A's zonky reduced bundle is incomplete —
+     no pg_config/psql/createdb/headers). Build pgvector against the from-source
+     `pg_config`. Smoke: `initdb` → `CREATE EXTENSION vector` in CI (proven for
+     linux-amd64 by the P1 gate). **Two carry-forwards from the gate:** (a) the
+     `--without-icu/zlib/readline/openssl` configure flags (safe for nx's loopback,
+     `--no-locale` PG — rationale in the CI job); (b) **relocation: `pg_config`
+     reports build-time absolute paths, so `pg_provision` must be made
+     relocation-aware (resolve sharedir/pkglibdir relative to the binary, not via
+     `pg_config`) BEFORE the bundle is extracted to a user-local path** — tracked as
+     a code bead (`nexus-1e205`), distinct from this packaging step. A
+     Liquibase-against-bundle-PG smoke completes the local-distro proof.
    - **Embed vs ship-alongside (CA-2):** spike `-H:IncludeResources` of the bundle +
      first-run self-extract; measure build cost + binary bloat + extract latency. Fall
      back to ship-alongside (`{binary, pg-<plat>.txz}` archive) if unacceptable.

--- a/docs/rdr/rdr-157-end-user-distribution-and-installation.md
+++ b/docs/rdr/rdr-157-end-user-distribution-and-installation.md
@@ -435,6 +435,50 @@ bloat is unacceptable, fall back to ship-alongside** — the per-OS/arch archive
 zero native-image involvement, guaranteed to work. Either way CA-2 does not gate the
 two-distribution architecture; it only decides single-file-vs-archive packaging.
 
+### RF-157-9 (CA-3, P1 gate, test + CI authored 2026-06-14): Strategy A assemble path — live verification
+
+**Verdict: pending the first green CI run (the test and the `ca3-pgvector-bundle` job
+that drives it are implemented; the VERIFIED/FAILED stamp lands when it runs on the PR).
+Bead `nexus-vwvv5.2`.**
+
+CA-3 is the go/no-go before the P2/P3 build-out: does Strategy A (assemble — zonky PG16
+bundle + CI-built pgvector injected) actually work end to end under nx's own
+provisioner? The verification is two artifacts:
+
+- **`tests/db/test_pg_provision_ca3_bundle.py`** — pure verification over a
+  pre-materialized bundle (so it stays hermetic): discovers the bundle via the
+  production `NEXUS_PG_BIN` seam, asserts the binaries are PG16 and **relocatable**
+  (`pg_config --sharedir` resolves *inside* the extracted tree), that pgvector is
+  injected and passes `check_pgvector_available`, and — the load-bearing assertion —
+  provisions a hermetic cluster from the bundle and runs `CREATE EXTENSION vector`,
+  which forces `dlopen(vector.so)`. Locally (no bundle) every test skips with a reason
+  naming the CI job.
+- **`.github/workflows/ci.yml` job `ca3-pgvector-bundle`** (linux-amd64) — fetches
+  `embedded-postgres-binaries-linux-amd64:16.4.0` from Maven Central, extracts the inner
+  `.txz`, builds pgvector `v0.8.2` against the extracted `pg_config` **inside
+  manylinux2014 (glibc 2.17)**, `make install`s it into the bundle, then runs the test
+  with a junit parse that asserts **0 skipped + the `CREATE EXTENSION` case passed** —
+  so a silent all-skip cannot masquerade as a green gate.
+
+**Glibc floor (the actionable finding).** `check_pgvector_available` only stats
+`vector.control`; it never `dlopen`s. The ABI/glibc failure surfaces at extension LOAD,
+not preflight — so pgvector must be built on the **oldest reasonable glibc baseline**,
+not the CI runner's (ubuntu-latest ≈ glibc 2.39, which would `dlopen`-fail on
+RHEL7/CentOS7/old-Debian). Decision: build in **manylinux2014 (glibc 2.17)** to match
+zonky's broad-compat baseline; the test pins `GLIBC_FLOOR=(2,17)` and `objdump -T`
+asserts **both** `vector.so` and the zonky `postgres` binary require ≤ `GLIBC_2.17`. A
+builder drift that raises the floor fails the test, not the user. **linux-aarch64**
+floor is the same `manylinux2014_aarch64` baseline (glibc 2.17), documented here; its
+**live** run is deferred to the P2/P3 build matrix (needs an arm64 runner) — flagged,
+not silently dropped.
+
+**FAILED path → Strategy B trigger.** If the live job fails (zonky's reduced bundle is
+incomplete, ABI mismatch on the same PG16 minor, pgvector won't build against the
+extracted tree, or `dlopen` fails despite the manylinux build), RDR-157 falls back to
+**Strategy B**: build PostgreSQL 16 from source in the existing native-image CI matrix
+and build pgvector against that (ABI-safe, costlier; Windows MSVC PG-from-source is the
+long pole — release N+1 regardless). CA-1 (RF-157-7) already names B as the fallback.
+
 ### Implications for the draft Decisions — SUPERSEDED by the 2026-06-14 lock
 
 > **Historical research trail. Superseded by `## Decision — UPDATED 2026-06-14` and the

--- a/docs/rdr/rdr-157-end-user-distribution-and-installation.md
+++ b/docs/rdr/rdr-157-end-user-distribution-and-installation.md
@@ -467,10 +467,20 @@ not the CI runner's (ubuntu-latest ≈ glibc 2.39, which would `dlopen`-fail on
 RHEL7/CentOS7/old-Debian). Decision: build in **manylinux2014 (glibc 2.17)** to match
 zonky's broad-compat baseline; the test pins `GLIBC_FLOOR=(2,17)` and `objdump -T`
 asserts **both** `vector.so` and the zonky `postgres` binary require ≤ `GLIBC_2.17`. A
-builder drift that raises the floor fails the test, not the user. **linux-aarch64**
-floor is the same `manylinux2014_aarch64` baseline (glibc 2.17), documented here; its
-**live** run is deferred to the P2/P3 build matrix (needs an arm64 runner) — flagged,
-not silently dropped.
+builder drift that raises the floor fails the test, not the user.
+
+**Per-target coverage (release N = linux-amd64 + linux-aarch64 + mac-arm64 per CA-1).**
+The P1 gate covers **linux-amd64** live. The other two release-N targets are deferred to
+P3 with **named beads** so the deferral is traceable, not silent:
+- **linux-aarch64** (`nexus-xqk5r`): same `manylinux2014_aarch64` baseline (glibc 2.17,
+  `GLIBC_FLOOR` already applies); runs the existing test against the zonky
+  `linux-arm64v8` bundle on an arm64 runner.
+- **mac-arm64** (`nexus-0ixqc`): darwin-specific unknowns the linux gate does NOT
+  exercise — pgvector produces a `.dylib` (not `.so`), the loader is `dyld` (no glibc
+  floor; pin the macOS deployment-target/`minos` via `otool`/`vtool` instead), and
+  code-signing/SIP can reject an unsigned `.dylib` at load. Needs its own darwin test
+  variant on a `macos-14` runner. P3 must not start the mac-arm64 bundle build assuming
+  the linux result transfers.
 
 **FAILED path → Strategy B trigger.** If the live job fails (zonky's reduced bundle is
 incomplete, ABI mismatch on the same PG16 minor, pgvector won't build against the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ markers = [
     "integration: end-to-end tests requiring real services (deselect with '-m not integration')",
     "slow: expensive benchmarks (deselect with '-m not slow')",
     "stress: RDR-120 stress harness scenarios (run with 'pytest -m stress')",
+    "no_service_jar: integration test that drives PostgreSQL directly and is exempt from the service-jar freshness gate",
 ]
 
 [dependency-groups]

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -38,9 +38,14 @@ def _service_jar_freshness(
 
     Only acts on tests carrying the ``integration`` marker — unit tests in
     tests/db neither build nor launch the jar and must not be gated on it.
+    Tests that opt out with ``@pytest.mark.no_service_jar`` are also exempt:
+    some integration suites (e.g. the RDR-157 CA-3 pgvector gate) drive
+    PostgreSQL directly via psql and never touch the JVM service.
     SKIP locally, FAIL in CI (a missing/stale jar in CI is a build defect).
     """
     if request.node.get_closest_marker("integration") is None:
+        return
+    if request.node.get_closest_marker("no_service_jar") is not None:
         return
     if _jar_freshness_reason is not None:
         if _IN_CI:

--- a/tests/db/test_pg_provision_ca3_bundle.py
+++ b/tests/db/test_pg_provision_ca3_bundle.py
@@ -270,10 +270,23 @@ class TestGlibcFloor:
         )
 
     def test_postgres_binary_within_pinned_floor(self, bins):
-        """The server binary's own glibc floor must also hold — the
-        effective install floor is max(postgres, vector.so)."""
+        """The server binary's own *direct* glibc floor must also hold — the
+        effective install floor is max(postgres, vector.so).
+
+        Note: ``objdump -T`` reports only the symbols the ELF references
+        directly, not those reached transitively through shared libraries it
+        links. The from-source build deliberately drops icu/zlib/readline/ssl
+        (see the CI configure flags), so postgres' transitive surface is
+        essentially libc, making the direct check representative here."""
         postgres = bins.bin_dir / "postgres"
         required = _max_glibc_requirement(postgres)
+        # Same non-vacuity guard as vector.so: a dynamically-linked postgres
+        # always references versioned glibc symbols; (0, 0) means objdump saw
+        # none (wrong path / static build) and the floor check would be vacuous.
+        assert required > (0, 0), (
+            f"no GLIBC_x.y symbols found in {postgres} — objdump produced no "
+            "versioned references; the floor check would be vacuous"
+        )
         assert required <= GLIBC_FLOOR, (
             f"postgres binary requires GLIBC_{required[0]}.{required[1]} > "
             f"pinned floor GLIBC_{GLIBC_FLOOR[0]}.{GLIBC_FLOOR[1]} — the build "

--- a/tests/db/test_pg_provision_ca3_bundle.py
+++ b/tests/db/test_pg_provision_ca3_bundle.py
@@ -101,11 +101,24 @@ pytestmark = [
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
-def _bundle_bins() -> PgBinaries:
-    """Resolve the bundle's binaries via the production NEXUS_PG_BIN seam."""
+@pytest.fixture(scope="module")
+def bundle_bin_env():
+    """Point NEXUS_PG_BIN at the bundle for the module, restore on teardown.
+
+    The restore matters: without it the bundle path leaks into the process
+    environment and a later pg_provision test in the same pytest invocation
+    would resolve the bundle binaries instead of the system PostgreSQL.
+    """
     assert _BUNDLE is not None  # guarded by pytestmark
+    old = os.environ.get("NEXUS_PG_BIN")
     os.environ["NEXUS_PG_BIN"] = str(_BUNDLE / "bin")
-    return discover_pg_binaries()
+    try:
+        yield
+    finally:
+        if old is None:
+            os.environ.pop("NEXUS_PG_BIN", None)
+        else:
+            os.environ["NEXUS_PG_BIN"] = old
 
 
 def _pg_config(bins: PgBinaries, flag: str) -> str:
@@ -135,8 +148,9 @@ def _max_glibc_requirement(so_path: Path) -> tuple[int, int]:
 # ── Fixtures ───────────────────────────────────────────────────────────────────
 
 @pytest.fixture(scope="module")
-def bins() -> PgBinaries:
-    return _bundle_bins()
+def bins(bundle_bin_env) -> PgBinaries:
+    """Resolve the bundle's binaries via the production NEXUS_PG_BIN seam."""
+    return discover_pg_binaries()
 
 
 @pytest.fixture(scope="module")
@@ -226,6 +240,14 @@ class TestGlibcFloor:
         dlopen on an older distro."""
         pkglibdir = Path(_pg_config(bins, "--pkglibdir"))
         required = _max_glibc_requirement(pkglibdir / "vector.so")
+        # Non-vacuity guard: a real pgvector .so always references versioned
+        # glibc symbols. (0, 0) means objdump found none — wrong file, empty
+        # output, or static-libc linkage — which would let the floor check
+        # pass without proving anything.
+        assert required > (0, 0), (
+            f"no GLIBC_x.y symbols found in {pkglibdir / 'vector.so'} — objdump "
+            "produced no versioned references; the floor check would be vacuous"
+        )
         assert required <= GLIBC_FLOOR, (
             f"vector.so requires GLIBC_{required[0]}.{required[1]} > pinned floor "
             f"GLIBC_{GLIBC_FLOOR[0]}.{GLIBC_FLOOR[1]}; build pgvector on "
@@ -256,7 +278,7 @@ class TestCreateExtensionLive:
         return subprocess.run(
             [str(bins.bin_dir / "psql"), "-h", "127.0.0.1", "-p", str(port),
              "-U", os_user, "-d", NEXUS_DB_NAME, "-t", "-A", "-c", sql],
-            capture_output=True, text=True,
+            capture_output=True, text=True, timeout=30,
         )
 
     def test_cluster_accepts_connections(self, provisioned):

--- a/tests/db/test_pg_provision_ca3_bundle.py
+++ b/tests/db/test_pg_provision_ca3_bundle.py
@@ -19,7 +19,7 @@ performs the side-effecting work:
   1. fetch ``io.zonky.test.postgres:embedded-postgres-binaries-linux-amd64:16.x``
      from Maven Central and extract its inner ``postgres-linux-x86_64.txz``,
   2. build ``pgvector`` against the extracted tree's ``pg_config`` inside a
-     **manylinux2014 (glibc 2.17)** container so the ``.so``'s glibc floor
+     **manylinux_2_28 (glibc 2.28)** container so the ``.so``'s glibc floor
      matches zonky's broad-compat baseline rather than the runner's glibc,
   3. ``make install`` the extension into the extracted tree,
   4. export ``NEXUS_CA3_BUNDLE=<extracted-root>`` and run this module with
@@ -62,12 +62,13 @@ from nexus.db.pg_provision import (
 
 # ── Pinned glibc floor per linux target (RF-157-9) ─────────────────────────────
 #
-# manylinux2014 == glibc 2.17 (CentOS 7 baseline). The CI job builds vector.so
-# in that image precisely so this floor holds. linux-aarch64's live run is
-# deferred to the P2/P3 build matrix (needs an arm64 runner); its floor is the
-# same manylinux2014_aarch64 baseline (glibc 2.17) and is asserted here as the
-# documented target value, exercised live when the aarch64 bundle job lands.
-GLIBC_FLOOR: tuple[int, int] = (2, 17)
+# manylinux_2_28 == glibc 2.28 (AlmaLinux 8 baseline: RHEL8 / Debian 10 /
+# Ubuntu 18.10+). The CI job builds vector.so in that image precisely so this
+# floor holds. (manylinux2014 / glibc 2.17 was rejected: CentOS 7 is EOL with
+# dead in-container repos.) linux-aarch64's live run is deferred to the P2/P3
+# build matrix (needs an arm64 runner); its floor is the same
+# manylinux_2_28_aarch64 baseline (glibc 2.28), exercised live when that job lands.
+GLIBC_FLOOR: tuple[int, int] = (2, 28)
 
 
 # ── Bundle discovery / skip gate ───────────────────────────────────────────────
@@ -236,7 +237,7 @@ class TestGlibcFloor:
     def test_vector_so_within_pinned_floor(self, bins):
         """vector.so must not require a glibc newer than the pinned per-target
         floor. A builder that silently raises the requirement (e.g. building on
-        ubuntu-latest instead of manylinux2014) fails HERE, not at a user's
+        ubuntu-latest instead of manylinux_2_28) fails HERE, not at a user's
         dlopen on an older distro."""
         pkglibdir = Path(_pg_config(bins, "--pkglibdir"))
         required = _max_glibc_requirement(pkglibdir / "vector.so")
@@ -251,7 +252,7 @@ class TestGlibcFloor:
         assert required <= GLIBC_FLOOR, (
             f"vector.so requires GLIBC_{required[0]}.{required[1]} > pinned floor "
             f"GLIBC_{GLIBC_FLOOR[0]}.{GLIBC_FLOOR[1]}; build pgvector on "
-            "manylinux2014 (glibc 2.17) to match zonky's baseline (RF-157-9)"
+            "manylinux_2_28 (glibc 2.28) to match a broad-compat baseline (RF-157-9)"
         )
 
     def test_postgres_binary_within_pinned_floor(self, bins):

--- a/tests/db/test_pg_provision_ca3_bundle.py
+++ b/tests/db/test_pg_provision_ca3_bundle.py
@@ -1,29 +1,40 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""CA-3 live test: relocatable zonky PG16 + injected pgvector (RDR-157 P1, bead nexus-vwvv5.2).
+"""CA-3 live test: complete PG16 tree + pgvector (RDR-157 P1, bead nexus-vwvv5.2).
 
-RDR-157 Critical Assumption 3 (CA-3): the *assemble* strategy (Strategy A,
-RF-157-7) works end to end — a relocatable zonky PG16 binary bundle, with a
-CI-built ``vector.so`` injected into its ``pkglibdir``/``sharedir``, can be
-driven by ``nx``'s own provisioner to a running cluster that loads pgvector.
+RDR-157 Critical Assumption 3 (CA-3): the *assemble* strategy works end to end —
+a complete PG16 binary tree, with a CI-built ``vector.so`` in its
+``pkglibdir``/``sharedir``, can be driven by ``nx``'s own provisioner to a
+running cluster that loads pgvector, with the binaries' glibc floor pinned.
 
-This is the gate before the P2/P3 build-out. If it FAILS, RDR-157 falls back to
-Strategy B (build PostgreSQL from source in the native-image CI matrix).
+This is the gate before the P2/P3 build-out.
+
+Strategy B, not zonky. CA-3 empirically falsified the original "zonky reduced
+bundle + inject pgvector" plan (RF-157-7): zonky's
+``embedded-postgres-binaries`` reduced bundle ships ONLY initdb/pg_ctl/postgres
+— no ``pg_config``/``psql``/``createdb``/headers — so pgvector cannot be built
+against it AND ``discover_pg_binaries`` (which requires psql+createdb) cannot
+use it. The RDR pre-authorized **Strategy B** (build PostgreSQL from source) as
+the CA-3-failure fallback; this gate proves that path.
 
 How the bundle is materialized
 ------------------------------
-These tests do not download or build anything themselves — they are pure
-*verification* over a pre-materialized bundle so they stay deterministic and
-hermetic. The CI job ``ca3-pgvector-bundle`` (``.github/workflows/ci.yml``)
-performs the side-effecting work:
+These tests do not build anything themselves — they are pure *verification* over
+a pre-materialized bundle so they stay deterministic and hermetic. The CI job
+``ca3-pgvector-bundle`` (``.github/workflows/ci.yml``) performs the
+side-effecting work inside a **manylinux_2_28 (glibc 2.28)** container:
 
-  1. fetch ``io.zonky.test.postgres:embedded-postgres-binaries-linux-amd64:16.x``
-     from Maven Central and extract its inner ``postgres-linux-x86_64.txz``,
-  2. build ``pgvector`` against the extracted tree's ``pg_config`` inside a
-     **manylinux_2_28 (glibc 2.28)** container so the ``.so``'s glibc floor
-     matches zonky's broad-compat baseline rather than the runner's glibc,
-  3. ``make install`` the extension into the extracted tree,
-  4. export ``NEXUS_CA3_BUNDLE=<extracted-root>`` and run this module with
+  1. ``./configure --prefix=<bundle> && make && make install`` PostgreSQL 16
+     from source — a complete tree (initdb, pg_ctl, postgres, psql, createdb,
+     pg_config, headers, pgxs),
+  2. build ``pgvector`` against that ``pg_config`` and ``make install`` it,
+  3. export ``NEXUS_CA3_BUNDLE=<bundle>`` and run this module with
      ``-m integration``.
+
+The bundle is built at, and mounted at, the same path it is consumed from, so
+``pg_config``'s compiled-in paths agree with the runtime location. True
+extract-to-arbitrary-dir relocation (where ``pg_config``'s build-prefix-boundness
+becomes a real concern) is a P3 bundle-build problem (``nexus-vwvv5.9``), not
+this gate.
 
 Locally (e.g. on a darwin dev box) the bundle is absent, so every test skips
 with a reason that names the providing CI job. The CI job additionally asserts
@@ -74,7 +85,7 @@ GLIBC_FLOOR: tuple[int, int] = (2, 28)
 # ── Bundle discovery / skip gate ───────────────────────────────────────────────
 
 def _bundle_root() -> Path | None:
-    """The extracted zonky bundle root, or None when not materialized.
+    """The PG16 bundle root, or None when not materialized.
 
     Set by the CI ``ca3-pgvector-bundle`` job. Absent locally → tests skip.
     """
@@ -92,8 +103,8 @@ pytestmark = [
     pytest.mark.skipif(
         _BUNDLE is None,
         reason=(
-            "skipped: no CA-3 zonky bundle — set NEXUS_CA3_BUNDLE to an extracted "
-            "PG16 tree with pgvector injected (provided by the ci.yml "
+            "skipped: no CA-3 bundle — set NEXUS_CA3_BUNDLE to a complete PG16 "
+            "tree with pgvector (provided by the ci.yml "
             "'ca3-pgvector-bundle' job)"
         ),
     ),
@@ -159,7 +170,7 @@ def provisioned(bins: PgBinaries, tmp_path_factory):
     """Provision a hermetic cluster *from the bundle* (NEXUS_PG_BIN points at it).
 
     Mirrors the production path: discover_pg_binaries honours NEXUS_PG_BIN, so
-    provision() builds the cluster with the relocatable bundle binaries.
+    provision() builds the cluster with the bundle binaries.
     """
     config_dir = tmp_path_factory.mktemp("nexus_ca3_bundle")
     old_cfg = os.environ.get("NEXUS_CONFIG_DIR")
@@ -184,11 +195,11 @@ def provisioned(bins: PgBinaries, tmp_path_factory):
         pass
 
 
-# ── Test 1: zonky bundle ships a complete, relocatable PG16 ─────────────────────
+# ── Test 1: the bundle ships a complete PG16 with consistent paths ──────────────
 
-class TestZonkyBundle:
+class TestCompletePg16Bundle:
     def test_binaries_discovered_via_env_seam(self, bins):
-        assert bins.all_present(), "zonky bundle missing one of initdb/pg_ctl/psql/createdb"
+        assert bins.all_present(), "bundle missing one of initdb/pg_ctl/psql/createdb"
 
     def test_reports_postgres_16(self, bins):
         out = subprocess.run(
@@ -198,14 +209,14 @@ class TestZonkyBundle:
         assert "16." in out, f"expected PostgreSQL 16.x, got: {out.strip()!r}"
 
     def test_sharedir_resolves_inside_bundle(self, bins):
-        """Relocatable proof: pg_config --sharedir is UNDER the extracted root,
-        not a hard-coded system path baked at zonky's build time."""
+        """pg_config --sharedir resolves UNDER the bundle root (the bundle is
+        built at, and consumed from, the same prefix)."""
         sharedir = Path(_pg_config(bins, "--sharedir")).resolve()
         assert _BUNDLE is not None
         root = _BUNDLE.resolve()
         assert root in sharedir.parents or sharedir == root, (
-            f"sharedir {sharedir} is not inside the relocated bundle {root} — "
-            "binaries are not relocatable"
+            f"sharedir {sharedir} is not inside the bundle {root} — "
+            "pg_config paths disagree with the bundle location"
         )
 
 
@@ -256,14 +267,14 @@ class TestGlibcFloor:
         )
 
     def test_postgres_binary_within_pinned_floor(self, bins):
-        """The zonky server binary's own glibc floor must also hold — the
+        """The server binary's own glibc floor must also hold — the
         effective install floor is max(postgres, vector.so)."""
         postgres = bins.bin_dir / "postgres"
         required = _max_glibc_requirement(postgres)
         assert required <= GLIBC_FLOOR, (
-            f"zonky postgres binary requires GLIBC_{required[0]}.{required[1]} > "
-            f"pinned floor GLIBC_{GLIBC_FLOOR[0]}.{GLIBC_FLOOR[1]} — zonky's "
-            "linux-amd64 baseline drifted above the documented target (RF-157-9)"
+            f"postgres binary requires GLIBC_{required[0]}.{required[1]} > "
+            f"pinned floor GLIBC_{GLIBC_FLOOR[0]}.{GLIBC_FLOOR[1]} — the build "
+            "baseline drifted above the documented target (RF-157-9)"
         )
 
 

--- a/tests/db/test_pg_provision_ca3_bundle.py
+++ b/tests/db/test_pg_provision_ca3_bundle.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""CA-3 live test: relocatable zonky PG16 + injected pgvector (RDR-157 P1, bead nexus-vwvv5.2).
+
+RDR-157 Critical Assumption 3 (CA-3): the *assemble* strategy (Strategy A,
+RF-157-7) works end to end — a relocatable zonky PG16 binary bundle, with a
+CI-built ``vector.so`` injected into its ``pkglibdir``/``sharedir``, can be
+driven by ``nx``'s own provisioner to a running cluster that loads pgvector.
+
+This is the gate before the P2/P3 build-out. If it FAILS, RDR-157 falls back to
+Strategy B (build PostgreSQL from source in the native-image CI matrix).
+
+How the bundle is materialized
+------------------------------
+These tests do not download or build anything themselves — they are pure
+*verification* over a pre-materialized bundle so they stay deterministic and
+hermetic. The CI job ``ca3-pgvector-bundle`` (``.github/workflows/ci.yml``)
+performs the side-effecting work:
+
+  1. fetch ``io.zonky.test.postgres:embedded-postgres-binaries-linux-amd64:16.x``
+     from Maven Central and extract its inner ``postgres-linux-x86_64.txz``,
+  2. build ``pgvector`` against the extracted tree's ``pg_config`` inside a
+     **manylinux2014 (glibc 2.17)** container so the ``.so``'s glibc floor
+     matches zonky's broad-compat baseline rather than the runner's glibc,
+  3. ``make install`` the extension into the extracted tree,
+  4. export ``NEXUS_CA3_BUNDLE=<extracted-root>`` and run this module with
+     ``-m integration``.
+
+Locally (e.g. on a darwin dev box) the bundle is absent, so every test skips
+with a reason that names the providing CI job. The CI job additionally asserts
+the core test actually *ran* (see the workflow), so a silent all-skip can never
+masquerade as a pass.
+
+Glibc floor (RF-157-9)
+----------------------
+``check_pgvector_available`` only stats ``vector.control`` — it never dlopens
+``vector.so``. The real ABI/glibc failure surfaces at ``CREATE EXTENSION
+vector`` (extension LOAD time), which is why :class:`TestCreateExtensionLive`
+is the load-bearing assertion. :class:`TestGlibcFloor` pins the maximum
+``GLIBC_x.y`` symbol version the ``.so`` may require, so a future builder
+upgrade that silently raises the floor fails the test instead of shipping a
+binary that ``dlopen``-fails on older distros.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from nexus.db.pg_provision import (
+    NEXUS_DB_NAME,
+    PgBinaries,
+    PgVectorNotInstalledError,
+    ProvisionResult,
+    _port_accepting,
+    check_pgvector_available,
+    discover_pg_binaries,
+    provision,
+)
+
+# ── Pinned glibc floor per linux target (RF-157-9) ─────────────────────────────
+#
+# manylinux2014 == glibc 2.17 (CentOS 7 baseline). The CI job builds vector.so
+# in that image precisely so this floor holds. linux-aarch64's live run is
+# deferred to the P2/P3 build matrix (needs an arm64 runner); its floor is the
+# same manylinux2014_aarch64 baseline (glibc 2.17) and is asserted here as the
+# documented target value, exercised live when the aarch64 bundle job lands.
+GLIBC_FLOOR: tuple[int, int] = (2, 17)
+
+
+# ── Bundle discovery / skip gate ───────────────────────────────────────────────
+
+def _bundle_root() -> Path | None:
+    """The extracted zonky bundle root, or None when not materialized.
+
+    Set by the CI ``ca3-pgvector-bundle`` job. Absent locally → tests skip.
+    """
+    raw = os.environ.get("NEXUS_CA3_BUNDLE", "").strip()
+    if not raw:
+        return None
+    root = Path(raw)
+    return root if (root / "bin" / "initdb").is_file() else None
+
+
+_BUNDLE = _bundle_root()
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        _BUNDLE is None,
+        reason=(
+            "skipped: no CA-3 zonky bundle — set NEXUS_CA3_BUNDLE to an extracted "
+            "PG16 tree with pgvector injected (provided by the ci.yml "
+            "'ca3-pgvector-bundle' job)"
+        ),
+    ),
+]
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _bundle_bins() -> PgBinaries:
+    """Resolve the bundle's binaries via the production NEXUS_PG_BIN seam."""
+    assert _BUNDLE is not None  # guarded by pytestmark
+    os.environ["NEXUS_PG_BIN"] = str(_BUNDLE / "bin")
+    return discover_pg_binaries()
+
+
+def _pg_config(bins: PgBinaries, flag: str) -> str:
+    out = subprocess.run(
+        [str(bins.bin_dir / "pg_config"), flag],
+        capture_output=True, text=True, check=True, timeout=10,
+    )
+    return out.stdout.strip()
+
+
+def _max_glibc_requirement(so_path: Path) -> tuple[int, int]:
+    """Highest GLIBC_x.y symbol version *required* by an ELF shared object.
+
+    Parses ``objdump -T`` version-reference records. Returns (0, 0) when the
+    object references no versioned glibc symbols.
+    """
+    out = subprocess.run(
+        ["objdump", "-T", str(so_path)],
+        capture_output=True, text=True, check=True,
+    )
+    versions: list[tuple[int, int]] = []
+    for m in re.finditer(r"GLIBC_(\d+)\.(\d+)", out.stdout):
+        versions.append((int(m.group(1)), int(m.group(2))))
+    return max(versions) if versions else (0, 0)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def bins() -> PgBinaries:
+    return _bundle_bins()
+
+
+@pytest.fixture(scope="module")
+def provisioned(bins: PgBinaries, tmp_path_factory):
+    """Provision a hermetic cluster *from the bundle* (NEXUS_PG_BIN points at it).
+
+    Mirrors the production path: discover_pg_binaries honours NEXUS_PG_BIN, so
+    provision() builds the cluster with the relocatable bundle binaries.
+    """
+    config_dir = tmp_path_factory.mktemp("nexus_ca3_bundle")
+    old_cfg = os.environ.get("NEXUS_CONFIG_DIR")
+    os.environ["NEXUS_CONFIG_DIR"] = str(config_dir)
+    try:
+        result: ProvisionResult = provision(config_dir, force_new_port=True)
+    finally:
+        if old_cfg is None:
+            os.environ.pop("NEXUS_CONFIG_DIR", None)
+        else:
+            os.environ["NEXUS_CONFIG_DIR"] = old_cfg
+
+    yield result, config_dir
+
+    pgdata = config_dir / "postgres"
+    try:
+        subprocess.run(
+            [str(bins.bin_dir / "pg_ctl"), "-D", str(pgdata), "-m", "immediate", "stop"],
+            capture_output=True, check=False, timeout=10,
+        )
+    except Exception:  # noqa: BLE001 — teardown must not reraise
+        pass
+
+
+# ── Test 1: zonky bundle ships a complete, relocatable PG16 ─────────────────────
+
+class TestZonkyBundle:
+    def test_binaries_discovered_via_env_seam(self, bins):
+        assert bins.all_present(), "zonky bundle missing one of initdb/pg_ctl/psql/createdb"
+
+    def test_reports_postgres_16(self, bins):
+        out = subprocess.run(
+            [str(bins.bin_dir / "initdb"), "--version"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        assert "16." in out, f"expected PostgreSQL 16.x, got: {out.strip()!r}"
+
+    def test_sharedir_resolves_inside_bundle(self, bins):
+        """Relocatable proof: pg_config --sharedir is UNDER the extracted root,
+        not a hard-coded system path baked at zonky's build time."""
+        sharedir = Path(_pg_config(bins, "--sharedir")).resolve()
+        assert _BUNDLE is not None
+        root = _BUNDLE.resolve()
+        assert root in sharedir.parents or sharedir == root, (
+            f"sharedir {sharedir} is not inside the relocated bundle {root} — "
+            "binaries are not relocatable"
+        )
+
+
+# ── Test 2: pgvector injected and visible to the preflight ──────────────────────
+
+class TestPgvectorInjected:
+    def test_control_file_present(self, bins):
+        sharedir = Path(_pg_config(bins, "--sharedir"))
+        control = sharedir / "extension" / "vector.control"
+        assert control.is_file(), f"vector.control not injected at {control}"
+
+    def test_shared_object_present(self, bins):
+        pkglibdir = Path(_pg_config(bins, "--pkglibdir"))
+        assert (pkglibdir / "vector.so").is_file(), (
+            f"vector.so not injected into {pkglibdir}"
+        )
+
+    def test_preflight_passes(self, bins):
+        """check_pgvector_available must NOT raise once the control file is in place."""
+        try:
+            check_pgvector_available(bins)
+        except PgVectorNotInstalledError as exc:  # pragma: no cover - failure path
+            pytest.fail(f"preflight wrongly reported pgvector missing: {exc}")
+
+
+# ── Test 3: glibc floor pinned (RF-157-9 regression guard) ──────────────────────
+
+class TestGlibcFloor:
+    def test_vector_so_within_pinned_floor(self, bins):
+        """vector.so must not require a glibc newer than the pinned per-target
+        floor. A builder that silently raises the requirement (e.g. building on
+        ubuntu-latest instead of manylinux2014) fails HERE, not at a user's
+        dlopen on an older distro."""
+        pkglibdir = Path(_pg_config(bins, "--pkglibdir"))
+        required = _max_glibc_requirement(pkglibdir / "vector.so")
+        assert required <= GLIBC_FLOOR, (
+            f"vector.so requires GLIBC_{required[0]}.{required[1]} > pinned floor "
+            f"GLIBC_{GLIBC_FLOOR[0]}.{GLIBC_FLOOR[1]}; build pgvector on "
+            "manylinux2014 (glibc 2.17) to match zonky's baseline (RF-157-9)"
+        )
+
+    def test_postgres_binary_within_pinned_floor(self, bins):
+        """The zonky server binary's own glibc floor must also hold — the
+        effective install floor is max(postgres, vector.so)."""
+        postgres = bins.bin_dir / "postgres"
+        required = _max_glibc_requirement(postgres)
+        assert required <= GLIBC_FLOOR, (
+            f"zonky postgres binary requires GLIBC_{required[0]}.{required[1]} > "
+            f"pinned floor GLIBC_{GLIBC_FLOOR[0]}.{GLIBC_FLOOR[1]} — zonky's "
+            "linux-amd64 baseline drifted above the documented target (RF-157-9)"
+        )
+
+
+# ── Test 4: CREATE EXTENSION vector live (the CA-3 go/no-go) ─────────────────────
+
+class TestCreateExtensionLive:
+    """The load-bearing assertion: provision a cluster from the bundle and
+    actually LOAD pgvector. This forces dlopen(vector.so) — the failure mode the
+    glibc floor and Strategy A exist to defend against."""
+
+    def _query(self, bins, port, sql) -> subprocess.CompletedProcess:
+        os_user = os.environ.get("USER") or os.environ.get("LOGNAME") or "postgres"
+        return subprocess.run(
+            [str(bins.bin_dir / "psql"), "-h", "127.0.0.1", "-p", str(port),
+             "-U", os_user, "-d", NEXUS_DB_NAME, "-t", "-A", "-c", sql],
+            capture_output=True, text=True,
+        )
+
+    def test_cluster_accepts_connections(self, provisioned):
+        result, _ = provisioned
+        assert _port_accepting("127.0.0.1", result.port), (
+            f"bundle cluster not accepting connections on {result.port}"
+        )
+
+    def test_create_extension_vector_loads(self, provisioned, bins):
+        result, _ = provisioned
+        proc = self._query(bins, result.port, "CREATE EXTENSION IF NOT EXISTS vector")
+        assert proc.returncode == 0, (
+            "CREATE EXTENSION vector failed — pgvector did not load from the "
+            f"bundle (dlopen/ABI failure):\n{proc.stderr}"
+        )
+
+    def test_vector_type_usable(self, provisioned, bins):
+        result, _ = provisioned
+        self._query(bins, result.port, "CREATE EXTENSION IF NOT EXISTS vector")
+        proc = self._query(
+            bins, result.port,
+            "SELECT '[1,2,3]'::vector <-> '[3,2,1]'::vector",
+        )
+        assert proc.returncode == 0 and proc.stdout.strip(), (
+            f"vector distance op failed after load:\n{proc.stderr}"
+        )

--- a/tests/db/test_pg_provision_ca3_bundle.py
+++ b/tests/db/test_pg_provision_ca3_bundle.py
@@ -100,6 +100,9 @@ _BUNDLE = _bundle_root()
 
 pytestmark = [
     pytest.mark.integration,
+    # CA-3 drives PostgreSQL directly via psql; it never launches the JVM
+    # service jar, so exempt it from tests/db/conftest.py's jar-freshness gate.
+    pytest.mark.no_service_jar,
     pytest.mark.skipif(
         _BUNDLE is None,
         reason=(


### PR DESCRIPTION
## RDR-157 P1.1 — CA-3 live gate (`nexus-vwvv5.2`)

Strategy A go/no-go: prove a relocatable **zonky PG16** binary bundle + a **CI-built pgvector** `.so` injected into it can be driven by nx's own provisioner (`pg_provision`) to a cluster that **loads** pgvector.

### What's here
- **`tests/db/test_pg_provision_ca3_bundle.py`** — verification over a pre-materialized bundle via the production `NEXUS_PG_BIN` seam: relocatable PG16 (`pg_config --sharedir` inside the extracted tree), pgvector injected + `check_pgvector_available`, **glibc floor pinned** (`GLIBC_FLOOR=(2,17)`, `objdump -T` on both `vector.so` and the zonky `postgres` binary), and the load-bearing **`CREATE EXTENSION vector`** (forces `dlopen`). Skips loudly when no bundle (local dev).
- **`.github/workflows/ci.yml` job `ca3-pgvector-bundle`** (linux-amd64) — fetch zonky `16.4.0`, extract, build pgvector `v0.8.2` in **manylinux2014 (glibc 2.17)** against the extracted `pg_config`, inject, run the test, **junit-assert 0 skipped + core test passed** (non-vacuous gate).
- **RF-157-9** recorded in the RDR Research Findings + T2.

### Key finding (glibc floor)
`check_pgvector_available` only stats `vector.control`; the ABI/glibc failure surfaces at extension **LOAD**, not preflight. So pgvector is built on glibc 2.17 (manylinux2014) to match zonky's broad-compat baseline rather than the runner's glibc (~2.39) which would `dlopen`-fail on old distros. linux-aarch64 live run deferred to the P2/P3 build matrix (arm64 runner); floor documented.

### FAILED path
Documents the **Strategy B** trigger (build PG16 from source) per CA-1/RF-157-7.

### Scope / not in this PR
Stacked review is `nexus-vwvv5.3`; do **not** merge until it passes. `develop` remains unreleasable (RDR-155 P4a).

Refs nexus-vwvv5.2