### PR TITLE
feat(pg): align nexus on PostgreSQL 17 (match deployed conexus)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
 
   ca3-pgvector-bundle:
     # RDR-157 P1 CA-3 gate (bead nexus-vwvv5.2): prove the assemble path — a
-    # COMPLETE PG16 tree + pgvector — can be driven by nx's own provisioner to a
+    # COMPLETE PG tree + pgvector — can be driven by nx's own provisioner to a
     # cluster that LOADS pgvector, with the binary's glibc floor pinned. This is
     # the go/no-go before the P2/P3 build-out.
     #
@@ -119,12 +119,14 @@ jobs:
     #
     # linux-amd64 only for release N; linux-aarch64 (nexus-xqk5r) and mac-arm64
     # (nexus-0ixqc) live runs are deferred to P3 with named beads.
-    name: CA-3 live (PG16 from source + pgvector, linux-amd64)
+    name: CA-3 live (PG from source + pgvector, linux-amd64)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      # Pinned for determinism. pgvector >= 0.8 is the RDR-155 iterative_scan floor.
-      PG_VERSION: "16.4"
+      # Pinned for determinism. pgvector >= 0.8 is the RDR-155 iterative_scan floor
+      # (a pgvector version, not a PG major). nexus is aligned on PG17 to match the
+      # deployed conexus stack (nexus-41bso); PG16 was incidental.
+      PG_VERSION: "17.5"
       PGVECTOR_VERSION: "v0.8.2"
       # manylinux_2_28 == glibc 2.28 (AlmaLinux 8 baseline: RHEL8 / Debian 10 /
       # Ubuntu 18.10+). Building the tree + vector.so here pins their glibc floor
@@ -155,7 +157,7 @@ jobs:
       - name: Install project + dev deps
         run: uv sync --group dev
 
-      - name: Build complete PG16 + pgvector from source (Strategy B, glibc 2.28)
+      - name: Build complete PG + pgvector from source (Strategy B, glibc 2.28)
         run: |
           set -euo pipefail
           # The bundle is installed at its build prefix and mounted at the SAME

--- a/docs/rdr/rdr-157-end-user-distribution-and-installation.md
+++ b/docs/rdr/rdr-157-end-user-distribution-and-installation.md
@@ -204,7 +204,7 @@ is release N+1.
    sha256 manifest for release N; evaluate Sigstore/cosign signing for N+1 (the binary
    runs with DB credentials and is opaque to static inspection — see Open Q4).
 4. **P3 — embedded-PG bundle + the two distributions.**
-   - **Bundle build (per OS/arch):** **Strategy B — build PostgreSQL 16 from source**
+   - **Bundle build (per OS/arch):** **Strategy B — build PostgreSQL 17 from source**
      (locked by CA-3 / RF-157-9: Strategy A's zonky reduced bundle is incomplete —
      no pg_config/psql/createdb/headers). Build pgvector against the from-source
      `pg_config`. Smoke: `initdb` → `CREATE EXTENSION vector` in CI (proven for
@@ -447,9 +447,15 @@ two-distribution architecture; it only decides single-file-vs-archive packaging.
 ### RF-157-9 (CA-3, P1 gate, VERIFIED 2026-06-15): Strategy A falsified → Strategy B proven
 
 **Verdict: Strategy A (zonky reduced bundle + inject pgvector) FAILED on completeness;
-Strategy B (build PG16 from source) VERIFIED green in CI. Bead `nexus-vwvv5.2`.**
+Strategy B (build PG from source) VERIFIED green in CI. Bead `nexus-vwvv5.2`.**
 
-CA-3 is the go/no-go before the P2/P3 build-out: can a complete PG16 tree + pgvector be
+> **PG major (nexus-41bso):** nexus is aligned on **PG17** to match the deployed conexus
+> stack. The PG major is **not load-bearing** — the only hard constraint is pgvector
+> ≥ 0.8 (iterative_scan, RDR-155), available on both 16 and 17. CA-3 was first proven
+> green on PG16.4 (the mechanism is major-agnostic) and the gate now builds **PG17.5**;
+> the "16" references in this section are the original run.
+
+CA-3 is the go/no-go before the P2/P3 build-out: can a complete PG tree + pgvector be
 driven by nx's own provisioner to a cluster that loads pgvector, with the glibc floor
 pinned?
 
@@ -473,10 +479,10 @@ PG16 from source. Two artifacts:
   loudly (named CI job) when no bundle.
 - **`.github/workflows/ci.yml` job `ca3-pgvector-bundle`** (linux-amd64) — inside a
   **manylinux_2_28 (glibc 2.28)** container: `./configure --prefix=<bundle> && make &&
-  make install` PostgreSQL **16.4** from source (a complete tree), build pgvector
-  `v0.8.2` against that pg_config, then run the test with a junit parse asserting
-  **0 skipped + `CREATE EXTENSION` passed** (no silent all-skip). **Green 2026-06-15:
-  11 passed, 0 skipped, glibc floor verified.**
+  make install` PostgreSQL **17.5** from source (a complete tree; first proven green on
+  16.4), build pgvector `v0.8.2` against that pg_config, then run the test with a junit
+  parse asserting **0 skipped + `CREATE EXTENSION` passed** (no silent all-skip). Green
+  on 16.4 2026-06-15 (11 passed, 0 skipped); re-verified on 17.5 under nexus-41bso.
 
 **Glibc floor.** `check_pgvector_available` only stats `vector.control`; it never
 `dlopen`s. The ABI/glibc failure surfaces at extension LOAD, not preflight — so the tree

--- a/src/nexus/db/pg_provision.py
+++ b/src/nexus/db/pg_provision.py
@@ -30,13 +30,13 @@ IDEMPOTENCY:
       service's env configuration.
 
 BINARY DISCOVERY:
-  The provisioner requires system-installed PostgreSQL 16 (or 15) binaries.
+  The provisioner requires system-installed PostgreSQL 17 (or 16/15) binaries.
   Search order:
     1. ``NEXUS_PG_BIN`` env var override (tests + custom installs).
-    2. ``/opt/homebrew/opt/postgresql@16/bin`` (macOS Homebrew PG 16).
+    2. ``/opt/homebrew/opt/postgresql@17/bin`` (macOS Homebrew PG 17).
     3. ``/opt/homebrew/opt/postgresql@15/bin`` (macOS Homebrew PG 15).
     4. ``initdb`` on PATH (Linux; ``shutil.which`` → parent directory).
-    5. ``/usr/lib/postgresql/16/bin`` (Debian/Ubuntu system install).
+    5. ``/usr/lib/postgresql/17/bin`` (Debian/Ubuntu system install).
     6. ``/usr/lib/postgresql/15/bin`` (Debian/Ubuntu PG 15 fallback).
 
   Fails loudly with a platform-appropriate install hint when no binaries
@@ -122,24 +122,28 @@ def _install_hint() -> str:
     """Return a platform-appropriate install hint."""
     if sys.platform == "darwin":
         return (
-            "Install PostgreSQL 16 with Homebrew:\n"
-            "  brew install postgresql@16\n"
-            "  brew services start postgresql@16\n"
+            "Install PostgreSQL 17 with Homebrew:\n"
+            "  brew install postgresql@17\n"
+            "  brew services start postgresql@17\n"
             "Then re-run `nx init --service`."
         )
     return (
-        "Install PostgreSQL 16:\n"
+        "Install PostgreSQL 17:\n"
         "  # Debian/Ubuntu:\n"
-        "  sudo apt-get install postgresql-16\n"
+        "  sudo apt-get install postgresql-17\n"
         "  # RHEL/Fedora:\n"
         "  sudo dnf install postgresql-server\n"
         "Then re-run `nx init --service`."
     )
 
 
+# nexus is aligned on PG17 (matches the deployed conexus stack; nexus-41bso).
+# 16/15 remain as fallbacks so an existing host install still works.
 _CANDIDATE_DIRS: list[Path] = [
+    Path("/opt/homebrew/opt/postgresql@17/bin"),
     Path("/opt/homebrew/opt/postgresql@16/bin"),
     Path("/opt/homebrew/opt/postgresql@15/bin"),
+    Path("/usr/lib/postgresql/17/bin"),
     Path("/usr/lib/postgresql/16/bin"),
     Path("/usr/lib/postgresql/15/bin"),
 ]
@@ -234,7 +238,7 @@ def check_pgvector_available(bins: PgBinaries) -> None:
         f"The pgvector extension is not installed for the PostgreSQL at "
         f"{bins.bin_dir} (no {control}).\n"
         "The Homebrew 'pgvector' formula targets the default postgresql "
-        "major — for a versioned install (e.g. postgresql@16) build from "
+        "major — for a versioned install (e.g. postgresql@17) build from "
         "source against THIS pg_config:\n"
         f"  git clone --branch v0.8.2 https://github.com/pgvector/pgvector.git\n"
         f"  cd pgvector && PG_CONFIG={pg_config} make && "

--- a/tests/db/test_pg_provision_ca3_bundle.py
+++ b/tests/db/test_pg_provision_ca3_bundle.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""CA-3 live test: complete PG16 tree + pgvector (RDR-157 P1, bead nexus-vwvv5.2).
+"""CA-3 live test: complete PG17 tree + pgvector (RDR-157 P1, bead nexus-vwvv5.2).
 
 RDR-157 Critical Assumption 3 (CA-3): the *assemble* strategy works end to end —
-a complete PG16 binary tree, with a CI-built ``vector.so`` in its
+a complete PG17 binary tree, with a CI-built ``vector.so`` in its
 ``pkglibdir``/``sharedir``, can be driven by ``nx``'s own provisioner to a
 running cluster that loads pgvector, with the binaries' glibc floor pinned.
 
@@ -23,7 +23,7 @@ a pre-materialized bundle so they stay deterministic and hermetic. The CI job
 ``ca3-pgvector-bundle`` (``.github/workflows/ci.yml``) performs the
 side-effecting work inside a **manylinux_2_28 (glibc 2.28)** container:
 
-  1. ``./configure --prefix=<bundle> && make && make install`` PostgreSQL 16
+  1. ``./configure --prefix=<bundle> && make && make install`` PostgreSQL 17
      from source — a complete tree (initdb, pg_ctl, postgres, psql, createdb,
      pg_config, headers, pgxs),
   2. build ``pgvector`` against that ``pg_config`` and ``make install`` it,
@@ -85,7 +85,7 @@ GLIBC_FLOOR: tuple[int, int] = (2, 28)
 # ── Bundle discovery / skip gate ───────────────────────────────────────────────
 
 def _bundle_root() -> Path | None:
-    """The PG16 bundle root, or None when not materialized.
+    """The PG17 bundle root, or None when not materialized.
 
     Set by the CI ``ca3-pgvector-bundle`` job. Absent locally → tests skip.
     """
@@ -106,7 +106,7 @@ pytestmark = [
     pytest.mark.skipif(
         _BUNDLE is None,
         reason=(
-            "skipped: no CA-3 bundle — set NEXUS_CA3_BUNDLE to a complete PG16 "
+            "skipped: no CA-3 bundle — set NEXUS_CA3_BUNDLE to a complete PG17 "
             "tree with pgvector (provided by the ci.yml "
             "'ca3-pgvector-bundle' job)"
         ),
@@ -198,18 +198,18 @@ def provisioned(bins: PgBinaries, tmp_path_factory):
         pass
 
 
-# ── Test 1: the bundle ships a complete PG16 with consistent paths ──────────────
+# ── Test 1: the bundle ships a complete PG17 with consistent paths ──────────────
 
 class TestCompletePg16Bundle:
     def test_binaries_discovered_via_env_seam(self, bins):
         assert bins.all_present(), "bundle missing one of initdb/pg_ctl/psql/createdb"
 
-    def test_reports_postgres_16(self, bins):
+    def test_reports_postgres_17(self, bins):
         out = subprocess.run(
             [str(bins.bin_dir / "initdb"), "--version"],
             capture_output=True, text=True, check=True,
         ).stdout
-        assert "16." in out, f"expected PostgreSQL 16.x, got: {out.strip()!r}"
+        assert "17." in out, f"expected PostgreSQL 17.x, got: {out.strip()!r}"
 
     def test_sharedir_resolves_inside_bundle(self, bins):
         """pg_config --sharedir resolves UNDER the bundle root (the bundle is


### PR DESCRIPTION
## Align nexus on PostgreSQL 17 (`nexus-41bso`)

Resolves the pg16/pg17 conflict surfaced while wiring `nexus-6o0bc` (the conexus consumer flip): conexus's deployed stack (Crunchy Bridge + all `deploy/` tooling) is **pg17**, while nexus carried an incidental **pg16**. Moving nexus to pg17 aligns local + cloud on one major and avoids any live managed-DB downgrade.

### Why nothing blocked it
- The only hard constraint is **pgvector ≥ 0.8** (`iterative_scan`, RDR-155) — a pgvector version, available on both 16 and 17.
- The engine is **already pg17-validated**: jOOQ codegen, `native-smoke.sh`, service-ci testcontainers, and the service test suite all use `pgvector/pgvector:pg17`.
- pg16 survived only incidentally in `pg_provision` discovery dirs/hints and the CA-3 from-source build version.

### Changes
- **`pg_provision.py`** — discovery dirs + install hints prefer `postgresql@17` / `postgresql-17`; **16/15 kept as fallbacks** (existing host installs still work).
- **`ci.yml` CA-3** — `PG_VERSION` `16.4` → `17.5`; **job name made version-agnostic** (`CA-3 live (PG from source + pgvector, linux-amd64)`) so future PG bumps never churn branch protection. The required-status-check context was updated to the new name.
- **CA-3 test** — `initdb --version` assertion `16.` → `17.`; PG16 prose → PG17.
- **RDR-157** RF-157-9 + P3 → PG17, with an alignment note (major not load-bearing; first proven green on 16.4, re-verified on 17.5).

### Verification
- `pg_provision` discovery unit tests pass locally.
- The **CA-3 gate re-runs on PG17.5** in this PR (the required check) — that's the live re-verification.

RDR-155/156 don't pin the major (only pgvector ≥ 0.8), so no change there.

Refs nexus-41bso