### PR TITLE
fix(pg_provision): relocation-aware pgvector preflight (nexus-1e205)

### DIFF
--- a/src/nexus/db/pg_provision.py
+++ b/src/nexus/db/pg_provision.py
@@ -204,10 +204,53 @@ def discover_pg_binaries() -> PgBinaries:
 # ── Port helpers ───────────────────────────────────────────────────────────────
 
 
+def _pg_config_value(pg_config: Path, flag: str) -> str | None:
+    """Return a ``pg_config <flag>`` value, or None when indeterminate."""
+    try:
+        result = subprocess.run(
+            [str(pg_config), flag],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _log.warning("pgvector_preflight_indeterminate", error=str(exc), flag=flag)
+        return None
+    value = result.stdout.strip()
+    if result.returncode != 0 or not value:
+        _log.warning("pgvector_preflight_indeterminate", returncode=result.returncode, flag=flag)
+        return None
+    return value
+
+
+def _candidate_sharedirs(pg_config: Path, bin_dir: Path, sharedir: str) -> list[Path]:
+    """Sharedir locations to probe for ``extension/vector.control``.
+
+    ``pg_config`` reports the **build-time absolute** sharedir. For a relocatable
+    bundle extracted to a new prefix (RDR-157 local distribution) that path does
+    not exist on the target — so we ALSO re-anchor the sharedir on the actual
+    ``bin_dir`` using its offset from ``pg_config``'s reported ``--bindir``
+    (PostgreSQL keeps the internal tree layout stable across relocation, which is
+    how the server itself resolves paths via ``find_my_exec``). Both the reported
+    and the re-anchored paths are probed; non-relocated installs collapse to one.
+    """
+    candidates = [Path(sharedir)]
+    bindir = _pg_config_value(pg_config, "--bindir")
+    if bindir:
+        try:
+            rel = os.path.relpath(sharedir, bindir)
+            reanchored = (bin_dir / rel).resolve()
+            if reanchored not in candidates:
+                candidates.append(reanchored)
+        except ValueError:
+            pass  # e.g. different drives on Windows — skip re-anchoring
+    return candidates
+
+
 def check_pgvector_available(bins: PgBinaries) -> None:
     """Fail loud when pgvector is not installed for THIS PostgreSQL.
 
-    Checks for ``<sharedir>/extension/vector.control`` via ``pg_config``.
+    Checks for ``<sharedir>/extension/vector.control``. ``pg_config`` reports the
+    build-time sharedir, which is wrong for a relocated bundle, so we also probe
+    the binary-relative (re-anchored) sharedir — see :func:`_candidate_sharedirs`.
     Indeterminate (pg_config missing/failing) does NOT block — provisioning
     will fail loud at CREATE EXTENSION anyway; this gate exists to move the
     common failure earlier, not to add a new way to be wrong.
@@ -216,24 +259,13 @@ def check_pgvector_available(bins: PgBinaries) -> None:
     if not pg_config.is_file():
         _log.warning("pgvector_preflight_no_pg_config", bin_dir=str(bins.bin_dir))
         return
-    try:
-        result = subprocess.run(
-            [str(pg_config), "--sharedir"],
-            capture_output=True, text=True, timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        _log.warning("pgvector_preflight_indeterminate", error=str(exc))
+    sharedir = _pg_config_value(pg_config, "--sharedir")
+    if sharedir is None:
         return
-    sharedir = result.stdout.strip()
-    if result.returncode != 0 or not sharedir:
-        _log.warning(
-            "pgvector_preflight_indeterminate",
-            returncode=result.returncode,
-        )
+    candidates = _candidate_sharedirs(pg_config, bins.bin_dir, sharedir)
+    if any((c / "extension" / "vector.control").is_file() for c in candidates):
         return
-    control = Path(sharedir) / "extension" / "vector.control"
-    if control.is_file():
-        return
+    control = candidates[0] / "extension" / "vector.control"
     raise PgVectorNotInstalledError(
         f"The pgvector extension is not installed for the PostgreSQL at "
         f"{bins.bin_dir} (no {control}).\n"

--- a/tests/db/test_pg_provision_relocation.py
+++ b/tests/db/test_pg_provision_relocation.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Relocation-awareness of check_pgvector_available (RDR-157, bead nexus-1e205).
+
+`pg_config` reports build-time absolute paths. For a relocatable bundle (the
+RDR-157 local distribution) extracted to a new prefix, `pg_config --sharedir`
+returns the build prefix — which does not exist on the target. The preflight
+must instead resolve the sharedir relative to the actual binary location.
+
+These tests use a stub `pg_config` shell script (no mocking, no real PG) that
+reports a nonexistent build prefix, and place `vector.control` only at the
+re-anchored (binary-relative) location.
+"""
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from nexus.db.pg_provision import (
+    PgBinaries,
+    PgVectorNotInstalledError,
+    check_pgvector_available,
+)
+
+
+def _write_pg_config(bin_dir: Path, reported_prefix: str) -> None:
+    """Create an executable stub pg_config reporting a fixed build prefix.
+
+    --bindir -> <prefix>/bin, --sharedir -> <prefix>/share (the from-source
+    --prefix layout). The prefix is deliberately a path that does not exist on
+    disk, simulating a bundle relocated away from its build location.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    pg_config = bin_dir / "pg_config"
+    pg_config.write_text(
+        "#!/usr/bin/env bash\n"
+        "case \"$1\" in\n"
+        f"  --sharedir) echo {reported_prefix}/share ;;\n"
+        f"  --bindir)   echo {reported_prefix}/bin ;;\n"
+        "  *) echo '' ;;\n"
+        "esac\n"
+    )
+    pg_config.chmod(pg_config.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _bins(bin_dir: Path) -> PgBinaries:
+    # check_pgvector_available only touches bins.bin_dir / "pg_config".
+    return PgBinaries.from_dir(bin_dir)
+
+
+class TestRelocationAware:
+    def test_reanchored_control_passes_when_reported_prefix_is_gone(self, tmp_path):
+        """The build prefix does not exist; vector.control lives only at the
+        binary-relative sharedir. Preflight must find it via re-anchoring."""
+        bundle = tmp_path / "relocated-bundle"
+        bin_dir = bundle / "bin"
+        _write_pg_config(bin_dir, reported_prefix="/nonexistent/build/pg")
+        # Re-anchored sharedir = bin_dir/../share  ==  bundle/share
+        control = bundle / "share" / "extension" / "vector.control"
+        control.parent.mkdir(parents=True)
+        control.write_text("comment = 'vector'\ndefault_version = '0.8.2'\n")
+
+        check_pgvector_available(_bins(bin_dir))  # must NOT raise
+
+    def test_reported_sharedir_still_works_when_not_relocated(self, tmp_path):
+        """Non-relocated install: the reported sharedir exists and has the
+        control file. (Here the reported prefix IS the real bundle.)"""
+        bundle = tmp_path / "insitu"
+        bin_dir = bundle / "bin"
+        _write_pg_config(bin_dir, reported_prefix=str(bundle))
+        control = bundle / "share" / "extension" / "vector.control"
+        control.parent.mkdir(parents=True)
+        control.write_text("comment = 'vector'\n")
+
+        check_pgvector_available(_bins(bin_dir))  # must NOT raise
+
+    def test_missing_everywhere_raises(self, tmp_path):
+        """No vector.control at either the reported or re-anchored sharedir."""
+        bundle = tmp_path / "no-pgvector"
+        bin_dir = bundle / "bin"
+        _write_pg_config(bin_dir, reported_prefix="/nonexistent/build/pg")
+        # No control file created anywhere.
+        with pytest.raises(PgVectorNotInstalledError):
+            check_pgvector_available(_bins(bin_dir))
+
+    def test_no_pg_config_does_not_block(self, tmp_path):
+        """Indeterminate (pg_config absent) is a warning, not a failure."""
+        bin_dir = tmp_path / "empty" / "bin"
+        bin_dir.mkdir(parents=True)
+        check_pgvector_available(_bins(bin_dir))  # must NOT raise


### PR DESCRIPTION
## Relocation-aware pgvector preflight (`nexus-1e205`)

The principal **local-distribution first-run blocker** surfaced by the substantive-critic review of the CA-3 work (PR #1188).

`check_pgvector_available` resolved `vector.control` via `pg_config --sharedir`, which reports the **build-time absolute prefix**. For a relocatable bundle (the RDR-157 local distribution) extracted to a user-local path, that prefix doesn't exist on the target — so the preflight wrongly reports pgvector **absent** and `nx init --service` aborts at first run.

### Fix
Re-anchor the sharedir on the **actual** `bin_dir` using its offset from `pg_config`'s reported `--bindir` (PostgreSQL keeps the internal tree layout stable across relocation — the same basis the server uses via `find_my_exec`). Probe both the reported and re-anchored sharedirs; non-relocated installs collapse to one. Indeterminate `pg_config` still doesn't block.

### TDD
`tests/db/test_pg_provision_relocation.py` — a stub `pg_config` reports a nonexistent build prefix with `vector.control` only at the re-anchored location (no mocking, real I/O). Passes; missing-everywhere still raises; non-relocated still works. Full `tests/db` suite green (668 passed).

### Unblocks
`nexus-vwvv5.18` (P4 local-distro fresh-machine E2E) — depended on this.

Refs nexus-1e205