### PR TITLE
ci(rdr-157): CA-3 on linux-arm64 + mac-arm64 — closes nexus-xqk5r + nexus-0ixqc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,11 +117,20 @@ jobs:
     # pre-authorized Strategy B as the CA-3-failure fallback. See RF-157-9 /
     # T2 nexus_rdr/157-CA3-FINDING-zonky-reduced-insufficient.
     #
-    # linux-amd64 only for release N; linux-aarch64 (nexus-xqk5r) and mac-arm64
-    # (nexus-0ixqc) live runs are deferred to P3 with named beads.
-    name: CA-3 live (PG from source + pgvector, linux-amd64)
-    runs-on: ubuntu-latest
+    # Both linux targets run live (nexus-xqk5r closed aarch64). mac-arm64
+    # (nexus-0ixqc) is still deferred — it needs a darwin test variant
+    # (vector.dylib / dyld / otool minos floor, not GLIBC).
+    name: CA-3 live (PG from source + pgvector, ${{ matrix.target.arch }})
+    runs-on: ${{ matrix.target.runner }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          # arch values are the check-context suffixes; keep stable (branch
+          # protection requires "...(linux-amd64)" and "...(linux-arm64)").
+          - { arch: linux-amd64, runner: ubuntu-latest,    image: "quay.io/pypa/manylinux_2_28_x86_64" }
+          - { arch: linux-arm64, runner: ubuntu-24.04-arm, image: "quay.io/pypa/manylinux_2_28_aarch64" }
     env:
       # Pinned for determinism. pgvector >= 0.8 is the RDR-155 iterative_scan floor
       # (a pgvector version, not a PG major). nexus is aligned on PG17 to match the
@@ -129,14 +138,13 @@ jobs:
       PG_VERSION: "17.5"
       PGVECTOR_VERSION: "v0.8.2"
       # manylinux_2_28 == glibc 2.28 (AlmaLinux 8 baseline: RHEL8 / Debian 10 /
-      # Ubuntu 18.10+). Building the tree + vector.so here pins their glibc floor
-      # to a broadly compatible baseline instead of the runner's glibc (~2.39), so
-      # the binaries dlopen-load on older distros. We deliberately do NOT use
-      # manylinux2014 (glibc 2.17 / CentOS 7): CentOS 7 is EOL and its in-container
-      # yum mirrors are dead. glibc 2.28 is a defensible 2026 floor and the image
-      # ships a working gcc/make. Must match GLIBC_FLOOR in
-      # tests/db/test_pg_provision_ca3_bundle.py.
-      MANYLINUX_IMAGE: "quay.io/pypa/manylinux_2_28_x86_64"
+      # Ubuntu 18.10+), per-arch image from the matrix. Building the tree +
+      # vector.so here pins their glibc floor to a broadly compatible baseline
+      # instead of the runner's glibc (~2.39), so the binaries dlopen-load on older
+      # distros. We deliberately do NOT use manylinux2014 (glibc 2.17 / CentOS 7):
+      # CentOS 7 is EOL and its in-container yum mirrors are dead. glibc 2.28 is a
+      # defensible 2026 floor. GLIBC_FLOOR=(2,28) in the test holds for both arches.
+      MANYLINUX_IMAGE: ${{ matrix.target.image }}
 
     steps:
       - uses: actions/checkout@v4
@@ -150,9 +158,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ runner.temp }}/setup-uv-cache
-          key: uv-${{ runner.os }}-3.12-${{ hashFiles('uv.lock') }}
+          key: uv-${{ runner.os }}-${{ matrix.target.arch }}-3.12-${{ hashFiles('uv.lock') }}
           restore-keys: |
-            uv-${{ runner.os }}-3.12-
+            uv-${{ runner.os }}-${{ matrix.target.arch }}-3.12-
 
       - name: Install project + dev deps
         run: uv sync --group dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,25 +230,74 @@ jobs:
           # integration-marked CA-3 module is collected.
           uv run pytest tests/db/test_pg_provision_ca3_bundle.py \
             -o addopts="" -m integration -q -rs --junit-xml=ca3.xml
-          uv run python - <<'PY'
-          import xml.etree.ElementTree as ET
-          root = ET.parse("ca3.xml").getroot()
-          skipped = passed = 0
-          core_ok = False
-          for c in root.iter("testcase"):
-              is_skip = c.find("skipped") is not None
-              is_fail = c.find("failure") is not None or c.find("error") is not None
-              if is_skip:
-                  skipped += 1
-              elif not is_fail:
-                  passed += 1
-              # endswith, not ==: future pytest may qualify @name with the class.
-              if c.get("name", "").endswith("test_create_extension_vector_loads") and not is_skip and not is_fail:
-                  core_ok = True
-          assert skipped == 0, f"{skipped} CA-3 test(s) skipped — bundle not materialized; gate is vacuous"
-          assert core_ok, (
-              "core CREATE EXTENSION vector test did not pass — assemble path unproven "
-              "(or the testcase @name no longer ends with 'test_create_extension_vector_loads')"
-          )
-          print(f"CA-3 PASS: {passed} passed, 0 skipped, pgvector load + glibc floor verified")
-          PY
+          # Non-vacuity gate: platform-conditional tests (GLIBC on mac / minos on
+          # linux) skip legitimately; only a bundle-absence skip is a vacuous gate.
+          uv run python scripts/assert_ca3_ran.py ca3.xml
+
+  ca3-pgvector-bundle-macos:
+    # RDR-157 CA-3 for mac-arm64 (bead nexus-0ixqc). Same assemble gate as the
+    # linux job, but macOS has no manylinux container: build PG + pgvector
+    # NATIVELY on a macos-14 (arm64) runner. pgvector produces vector.dylib; the
+    # loader is dyld, so the floor is the Mach-O LC_BUILD_VERSION minos
+    # (MACOSX_DEPLOYMENT_TARGET), not GLIBC — asserted by TestMacosFloor.
+    name: CA-3 live (PG from source + pgvector, mac-arm64)
+    runs-on: macos-14
+    timeout-minutes: 30
+    env:
+      PG_VERSION: "17.5"
+      PGVECTOR_VERSION: "v0.8.2"
+      # The dyld analog of the glibc floor: build back-deployable to macOS 13
+      # (Ventura). Must match MACOS_MIN_FLOOR in the test.
+      MACOSX_DEPLOYMENT_TARGET: "13.0"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: false
+
+      - name: Install project + dev deps
+        run: uv sync --group dev
+
+      - name: Build complete PG + pgvector from source (native, deployment-target 13.0)
+        run: |
+          set -euo pipefail
+          # PG's build needs a newer flex/bison than macOS ships; Xcode CLT
+          # provides clang/make. curl/perl/otool are present on the runner.
+          brew install -q flex bison >/dev/null
+          export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$PATH"
+          bundle="$GITHUB_WORKSPACE/bundle"
+          mkdir -p "$bundle"
+          cd "$RUNNER_TEMP"
+          curl -fsSL "https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.bz2" -o pg.tar.bz2
+          tar -xjf pg.tar.bz2
+          cd "postgresql-${PG_VERSION}"
+          # Same lean flags as the linux gate (safe for nexus's loopback PG).
+          ./configure --prefix="${bundle}" \
+            --without-icu --without-zlib --without-readline --without-openssl >/dev/null
+          make -s -j"$(sysctl -n hw.ncpu)" >/dev/null
+          make -s install >/dev/null
+          cd "$RUNNER_TEMP"
+          git clone --depth 1 --branch "${PGVECTOR_VERSION}" https://github.com/pgvector/pgvector.git
+          cd pgvector
+          make -s PG_CONFIG="${bundle}/bin/pg_config"
+          make -s PG_CONFIG="${bundle}/bin/pg_config" install
+          # Sanity: complete tool set + injected dylib + control.
+          for b in initdb pg_ctl postgres psql createdb pg_config; do
+            test -x "$bundle/bin/$b" || { echo "missing $bundle/bin/$b"; exit 1; }
+          done
+          pkglib="$("$bundle/bin/pg_config" --pkglibdir)"
+          sharedir="$("$bundle/bin/pg_config" --sharedir)"
+          test -f "$pkglib/vector.dylib" || { ls -la "$pkglib"; exit 1; }
+          test -f "$sharedir/extension/vector.control" || { ls -la "$sharedir/extension"; exit 1; }
+          echo "NEXUS_CA3_BUNDLE=$bundle" >> "$GITHUB_ENV"
+          echo "Built: $("$bundle/bin/initdb" --version); vector.dylib at $pkglib"
+
+      - name: Run CA-3 live test (asserts it actually ran, not skipped)
+        run: |
+          set -euo pipefail
+          uv run pytest tests/db/test_pg_provision_ca3_bundle.py \
+            -o addopts="" -m integration -q -rs --junit-xml=ca3.xml
+          uv run python scripts/assert_ca3_ran.py ca3.xml

--- a/scripts/assert_ca3_ran.py
+++ b/scripts/assert_ca3_ran.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Assert a CA-3 run actually exercised the bundle (not vacuously all-skipped).
+
+Used by the ci.yml CA-3 jobs (linux matrix + macOS). Platform-conditional tests
+are LEGITIMATELY skipped — the GLIBC-floor tests skip on macOS, the macOS-floor
+tests skip on linux — so a blanket ``skipped == 0`` is wrong. Only a skip caused
+by the BUNDLE being absent makes the gate vacuous; that is what we guard against.
+Also require the load-bearing ``CREATE EXTENSION vector`` test to have passed.
+
+Usage: ``python scripts/assert_ca3_ran.py <junit.xml>``
+"""
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+
+# Substring of the bundle-absence skip reason (pytestmark skipif in
+# tests/db/test_pg_provision_ca3_bundle.py). A skip carrying this message means
+# NEXUS_CA3_BUNDLE was not materialized — the gate would prove nothing.
+_BUNDLE_ABSENT_MARKER = "no CA-3 bundle"
+_CORE_TEST = "test_create_extension_vector_loads"
+
+
+def main(junit_path: str) -> None:
+    root = ET.parse(junit_path).getroot()
+    bundle_skips = passed = 0
+    core_ok = False
+    for case in root.iter("testcase"):
+        skipped = case.find("skipped")
+        failed = case.find("failure") is not None or case.find("error") is not None
+        if skipped is not None:
+            if _BUNDLE_ABSENT_MARKER in (skipped.get("message") or ""):
+                bundle_skips += 1
+        elif not failed:
+            passed += 1
+        # endswith, not ==: future pytest may class-qualify the @name.
+        if case.get("name", "").endswith(_CORE_TEST) and skipped is None and not failed:
+            core_ok = True
+
+    assert bundle_skips == 0, (
+        f"{bundle_skips} CA-3 test(s) skipped for bundle-absence — gate is vacuous "
+        "(NEXUS_CA3_BUNDLE not materialized)"
+    )
+    assert core_ok, (
+        "core CREATE EXTENSION vector test did not pass — assemble path unproven "
+        f"(no passing testcase ending in '{_CORE_TEST}')"
+    )
+    print(f"CA-3 PASS: {passed} passed, 0 bundle-skips, pgvector load + floor verified")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: python scripts/assert_ca3_ran.py <junit.xml>", file=sys.stderr)
+        raise SystemExit(2)
+    main(sys.argv[1])

--- a/tests/db/test_pg_provision_ca3_bundle.py
+++ b/tests/db/test_pg_provision_ca3_bundle.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -81,6 +82,15 @@ from nexus.db.pg_provision import (
 # manylinux_2_28 baseline (glibc 2.28) on both. mac-arm64 needs a darwin variant
 # (dyld/otool minos, not GLIBC) — nexus-0ixqc.
 GLIBC_FLOOR: tuple[int, int] = (2, 28)
+
+# Per-OS shared-object name + floor mechanism. On macOS pgvector builds
+# ``vector.dylib`` and the loader is ``dyld`` (no GLIBC); the analog of the
+# glibc floor is the Mach-O ``LC_BUILD_VERSION`` minos — the binary won't load
+# on a macOS older than its deployment target. The macOS CI job pins
+# MACOSX_DEPLOYMENT_TARGET to this value (nexus-0ixqc).
+_IS_DARWIN = sys.platform == "darwin"
+_VECTOR_LIB = "vector.dylib" if _IS_DARWIN else "vector.so"
+MACOS_MIN_FLOOR: tuple[int, int] = (13, 0)  # macOS 13 Ventura — a defensible 2026 floor
 
 
 # ── Bundle discovery / skip gate ───────────────────────────────────────────────
@@ -161,6 +171,23 @@ def _max_glibc_requirement(so_path: Path) -> tuple[int, int]:
     return max(versions) if versions else (0, 0)
 
 
+def _macos_minos(macho_path: Path) -> tuple[int, int]:
+    """macOS deployment-target (LC_BUILD_VERSION minos) of a Mach-O object.
+
+    Parses ``otool -l`` for the ``minos X.Y`` line. Returns (0, 0) when no
+    LC_BUILD_VERSION/LC_VERSION_MIN load command is present.
+    """
+    out = subprocess.run(
+        ["otool", "-l", str(macho_path)],
+        capture_output=True, text=True, check=True,
+    )
+    versions: list[tuple[int, int]] = []
+    for m in re.finditer(r"minos (\d+)\.(\d+)", out.stdout):
+        versions.append((int(m.group(1)), int(m.group(2))))
+    # The binary's effective floor is the HIGHEST minos across its load commands.
+    return max(versions) if versions else (0, 0)
+
+
 # ── Fixtures ───────────────────────────────────────────────────────────────────
 
 @pytest.fixture(scope="module")
@@ -234,8 +261,8 @@ class TestPgvectorInjected:
 
     def test_shared_object_present(self, bins):
         pkglibdir = Path(_pg_config(bins, "--pkglibdir"))
-        assert (pkglibdir / "vector.so").is_file(), (
-            f"vector.so not injected into {pkglibdir}"
+        assert (pkglibdir / _VECTOR_LIB).is_file(), (
+            f"{_VECTOR_LIB} not injected into {pkglibdir}"
         )
 
     def test_preflight_passes(self, bins):
@@ -246,8 +273,9 @@ class TestPgvectorInjected:
             pytest.fail(f"preflight wrongly reported pgvector missing: {exc}")
 
 
-# ── Test 3: glibc floor pinned (RF-157-9 regression guard) ──────────────────────
+# ── Test 3: glibc floor pinned (RF-157-9 regression guard; linux only) ──────────
 
+@pytest.mark.skipif(_IS_DARWIN, reason="GLIBC floor is linux-only; macOS uses TestMacosFloor")
 class TestGlibcFloor:
     def test_vector_so_within_pinned_floor(self, bins):
         """vector.so must not require a glibc newer than the pinned per-target
@@ -292,6 +320,44 @@ class TestGlibcFloor:
             f"postgres binary requires GLIBC_{required[0]}.{required[1]} > "
             f"pinned floor GLIBC_{GLIBC_FLOOR[0]}.{GLIBC_FLOOR[1]} — the build "
             "baseline drifted above the documented target (RF-157-9)"
+        )
+
+
+# ── Test 3 (macOS): deployment-target floor pinned (dyld analog of the glibc floor) ─
+
+@pytest.mark.skipif(not _IS_DARWIN, reason="macOS minos floor; linux uses TestGlibcFloor")
+class TestMacosFloor:
+    def test_vector_dylib_within_minos_floor(self, bins):
+        """vector.dylib must not require a macOS newer than the pinned deployment
+        target. A build that silently raises minos (e.g. forgetting
+        MACOSX_DEPLOYMENT_TARGET, so it targets the runner's OS) fails HERE, not
+        at a user's dyld load on an older macOS."""
+        pkglibdir = Path(_pg_config(bins, "--pkglibdir"))
+        minos = _macos_minos(pkglibdir / _VECTOR_LIB)
+        assert minos > (0, 0), (
+            f"no LC_BUILD_VERSION minos in {pkglibdir / _VECTOR_LIB} — otool found "
+            "no deployment target; the floor check would be vacuous"
+        )
+        assert minos <= MACOS_MIN_FLOOR, (
+            f"vector.dylib requires macOS {minos[0]}.{minos[1]} > pinned floor "
+            f"{MACOS_MIN_FLOOR[0]}.{MACOS_MIN_FLOOR[1]}; set "
+            f"MACOSX_DEPLOYMENT_TARGET={MACOS_MIN_FLOOR[0]}.{MACOS_MIN_FLOOR[1]} "
+            "when building (nexus-0ixqc)"
+        )
+
+    def test_postgres_binary_within_minos_floor(self, bins):
+        """The server binary's own deployment-target floor must also hold — the
+        effective install floor is max(postgres, vector.dylib)."""
+        postgres = bins.bin_dir / "postgres"
+        minos = _macos_minos(postgres)
+        assert minos > (0, 0), (
+            f"no LC_BUILD_VERSION minos in {postgres} — otool found no deployment "
+            "target; the floor check would be vacuous"
+        )
+        assert minos <= MACOS_MIN_FLOOR, (
+            f"postgres binary requires macOS {minos[0]}.{minos[1]} > pinned floor "
+            f"{MACOS_MIN_FLOOR[0]}.{MACOS_MIN_FLOOR[1]} — the build's "
+            "MACOSX_DEPLOYMENT_TARGET drifted above the documented target (nexus-0ixqc)"
         )
 
 

--- a/tests/db/test_pg_provision_ca3_bundle.py
+++ b/tests/db/test_pg_provision_ca3_bundle.py
@@ -76,9 +76,10 @@ from nexus.db.pg_provision import (
 # manylinux_2_28 == glibc 2.28 (AlmaLinux 8 baseline: RHEL8 / Debian 10 /
 # Ubuntu 18.10+). The CI job builds vector.so in that image precisely so this
 # floor holds. (manylinux2014 / glibc 2.17 was rejected: CentOS 7 is EOL with
-# dead in-container repos.) linux-aarch64's live run is deferred to the P2/P3
-# build matrix (needs an arm64 runner); its floor is the same
-# manylinux_2_28_aarch64 baseline (glibc 2.28), exercised live when that job lands.
+# dead in-container repos.) Both linux targets run this module live in CI
+# (linux-amd64 + linux-arm64, via the ci.yml matrix); the floor is the same
+# manylinux_2_28 baseline (glibc 2.28) on both. mac-arm64 needs a darwin variant
+# (dyld/otool minos, not GLIBC) — nexus-0ixqc.
 GLIBC_FLOOR: tuple[int, int] = (2, 28)
 
 


### PR DESCRIPTION
## Complete CA-3 platform coverage (`nexus-xqk5r` + `nexus-0ixqc`)

Extends the CA-3 assemble gate from amd64-only to **all three release-N targets**.

| target | runner | build | floor mechanism |
|---|---|---|---|
| linux-amd64 | `ubuntu-latest` | manylinux_2_28_x86_64 container | GLIBC ≤ 2.28 (`objdump`) |
| linux-arm64 | `ubuntu-24.04-arm` | manylinux_2_28_aarch64 container | GLIBC ≤ 2.28 (`objdump`) |
| mac-arm64 | `macos-14` | **native** (no container) | macOS minos ≤ 13.0 (`otool` LC_BUILD_VERSION) |

### Platform-aware test
- `_VECTOR_LIB` (`.so`/`.dylib`); `TestGlibcFloor` skips on darwin; new **`TestMacosFloor`** asserts the dylib + postgres deployment-target (`minos`) ≤ `MACOS_MIN_FLOOR=(13,0)` — the dyld analog of the glibc floor (macOS has no GLIBC).
- macOS job pins `MACOSX_DEPLOYMENT_TARGET=13.0` (back-deployable to Ventura).

### Gate script (`scripts/assert_ca3_ran.py`)
Replaces the inline junit parse. Platform-conditional skips (GLIBC on mac / minos on linux) are **legitimate**, so it flags only **bundle-absence** skips as vacuous and requires the core `CREATE EXTENSION vector` test to pass. *(Required: `TestMacosFloor` skips on linux, so the old `skipped == 0` check would have broken the linux matrix.)* Unit-sanity-checked both directions.

### Branch protection
Context names stable: `...(linux-amd64)` preserved; add `...(linux-arm64)` and `...(mac-arm64)` to develop's required checks once first green.

Closes nexus-xqk5r nexus-0ixqc