### PR TITLE
ci(rdr-157): Liquibase-against-bundle smoke (nexus-ywts8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,15 @@ jobs:
           # linux) skip legitimately; only a bundle-absence skip is a vacuous gate.
           uv run python scripts/assert_ca3_ran.py ca3.xml
 
+      - name: Liquibase-against-bundle smoke (nexus-ywts8, linux-amd64 only)
+        # Applies the service's full SQL changelog to the lean bundle PG, proving
+        # the ICU-less / --no-locale build handles the real schema. linux-only:
+        # uses `docker --network host` to reach the provisioned PG. One arch is
+        # enough — the schema is arch-independent; this validates the lean
+        # configure flags, not the platform.
+        if: matrix.target.arch == 'linux-amd64'
+        run: bash scripts/liquibase_bundle_smoke.sh
+
   ca3-pgvector-bundle-macos:
     # RDR-157 CA-3 for mac-arm64 (bead nexus-0ixqc). Same assemble gate as the
     # linux job, but macOS has no manylinux container: build PG + pgvector

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,10 @@ jobs:
                 --without-icu --without-zlib --without-readline --without-openssl >/dev/null
               make -s -j"$(nproc)" >/dev/null
               make -s install >/dev/null
+              # Contrib extensions the schema needs (pg_trgm, RDR-155). Core
+              # `make install` does NOT build contrib — the bundle would be
+              # missing pg_trgm and the full migration would fail.
+              make -s -C contrib/pg_trgm install >/dev/null
               # pgvector against the freshly-built pg_config (same major + glibc).
               cd /tmp
               git clone --depth 1 --branch "${PGVECTOR_VERSION}" https://github.com/pgvector/pgvector.git
@@ -288,6 +292,8 @@ jobs:
             --without-icu --without-zlib --without-readline --without-openssl >/dev/null
           make -s -j"$(sysctl -n hw.ncpu)" >/dev/null
           make -s install >/dev/null
+          # Contrib extensions the schema needs (pg_trgm, RDR-155).
+          make -s -C contrib/pg_trgm install >/dev/null
           cd "$RUNNER_TEMP"
           git clone --depth 1 --branch "${PGVECTOR_VERSION}" https://github.com/pgvector/pgvector.git
           cd pgvector

--- a/scripts/liquibase_bundle_smoke.sh
+++ b/scripts/liquibase_bundle_smoke.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# nexus-ywts8: apply the service's FULL Liquibase changelog against the
+# from-source CA-3 bundle PG, confirming the lean (ICU-less, --no-locale,
+# no-zlib/readline/openssl) bundle handles the real schema — the
+# "complete local-distro proof" the CA-3 gate alone does not give.
+#
+# The changelogs are pure SQL (no Java <customChange>), so the liquibase CLI
+# applies them faithfully — no need to build the JVM service. We reuse
+# pg_provision so the real nexus_admin / nexus_svc roles + nexus DB exist before
+# the migration; role-001's `IF NOT EXISTS` then no-ops, mirroring the production
+# "DBA pre-creates the role, the changelog is self-contained" path.
+#
+# linux-only: uses `docker --network host` to let the liquibase container reach
+# the provisioned PG on 127.0.0.1. Requires NEXUS_CA3_BUNDLE (the built bundle),
+# docker, and a uv-installed nexus.
+set -euo pipefail
+
+LIQUIBASE_IMAGE="${LIQUIBASE_IMAGE:-liquibase/liquibase:4.31}"
+bundle="${NEXUS_CA3_BUNDLE:?NEXUS_CA3_BUNDLE must point at the built PG+pgvector bundle}"
+export NEXUS_PG_BIN="$bundle/bin"
+cfg="$(mktemp -d)"
+export NEXUS_CONFIG_DIR="$cfg"
+
+cleanup() { "$bundle/bin/pg_ctl" -D "$cfg/postgres" -m immediate stop >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "==> provisioning bundle cluster (nexus_admin + nexus_svc + nexus DB)"
+uv run python -c "from nexus.db.pg_provision import provision; provision()"
+
+# shellcheck disable=SC1091
+set -a; . "$cfg/pg_credentials"; set +a
+echo "==> provisioned: port=${PG_PORT} admin=${NX_DB_ADMIN_USER}"
+
+changelog_dir="$PWD/service/src/main/resources/db/changelog"
+test -f "$changelog_dir/db.changelog-master.xml" \
+  || { echo "FAIL: master changelog not found at $changelog_dir"; exit 1; }
+
+echo "==> applying master changelog via liquibase CLI ($LIQUIBASE_IMAGE)"
+docker run --rm --network host -v "$changelog_dir:/cl:ro" "$LIQUIBASE_IMAGE" \
+  --searchPath=/cl \
+  --changeLogFile=db.changelog-master.xml \
+  --url="jdbc:postgresql://127.0.0.1:${PG_PORT}/nexus" \
+  --username="${NX_DB_ADMIN_USER}" \
+  --password="${NX_DB_ADMIN_PASS}" \
+  update
+
+# Confirm a representative set of objects actually landed (non-vacuous).
+applied=$(PGPASSWORD="${NX_DB_ADMIN_PASS}" "$bundle/bin/psql" \
+  -h 127.0.0.1 -p "${PG_PORT}" -U "${NX_DB_ADMIN_USER}" -d nexus -tAc \
+  "SELECT count(*) FROM databasechangelog")
+echo "==> databasechangelog rows: ${applied}"
+[ "${applied:-0}" -gt 0 ] || { echo "FAIL: no changesets recorded"; exit 1; }
+
+echo "LIQUIBASE-AGAINST-BUNDLE SMOKE PASS (${applied} changesets on the lean bundle)"

--- a/scripts/liquibase_bundle_smoke.sh
+++ b/scripts/liquibase_bundle_smoke.sh
@@ -31,14 +31,17 @@ uv run python -c "from nexus.db.pg_provision import provision; provision()"
 set -a; . "$cfg/pg_credentials"; set +a
 echo "==> provisioned: port=${PG_PORT} admin=${NX_DB_ADMIN_USER}"
 
-changelog_dir="$PWD/service/src/main/resources/db/changelog"
-test -f "$changelog_dir/db.changelog-master.xml" \
-  || { echo "FAIL: master changelog not found at $changelog_dir"; exit 1; }
+# Mount the resources ROOT (not just db/changelog), because the master
+# changelog's <include file="db/changelog/...">s are relative to the classpath
+# root. searchPath=/cl + changeLogFile=db/changelog/db.changelog-master.xml.
+resources_dir="$PWD/service/src/main/resources"
+test -f "$resources_dir/db/changelog/db.changelog-master.xml" \
+  || { echo "FAIL: master changelog not found under $resources_dir"; exit 1; }
 
 echo "==> applying master changelog via liquibase CLI ($LIQUIBASE_IMAGE)"
-docker run --rm --network host -v "$changelog_dir:/cl:ro" "$LIQUIBASE_IMAGE" \
+docker run --rm --network host -v "$resources_dir:/cl:ro" "$LIQUIBASE_IMAGE" \
   --searchPath=/cl \
-  --changeLogFile=db.changelog-master.xml \
+  --changeLogFile=db/changelog/db.changelog-master.xml \
   --url="jdbc:postgresql://127.0.0.1:${PG_PORT}/nexus" \
   --username="${NX_DB_ADMIN_USER}" \
   --password="${NX_DB_ADMIN_PASS}" \


### PR DESCRIPTION
## Liquibase-against-bundle smoke (`nexus-ywts8`)

Proves the **lean from-source bundle PG** (`--without-icu --without-zlib --without-readline --without-openssl`, `initdb --no-locale`) applies the service's **real** Liquibase schema — the local-distro completeness check the CA-3 gate alone doesn't give (it only does `CREATE EXTENSION vector`).

### Decision: liquibase CLI (not boot-the-service)
Investigated the changelog: it's **pure SQL** (107 `<sql>` changesets, **no Java `<customChange>`**), so the **liquibase CLI applies it faithfully** without building the JVM service. `role-001` uses `IF NOT EXISTS`, so reusing `pg_provision` (which pre-creates `nexus_admin`/`nexus_svc`) makes it a no-op — exactly the production "DBA pre-creates the role, the changelog is self-contained" path.

### What it does (`scripts/liquibase_bundle_smoke.sh`)
`provision()` the bundle cluster → `liquibase/liquibase:4.31` (`docker --network host`) applies `db.changelog-master.xml` as `nexus_admin` → assert `databasechangelog` rows landed.

Wired as a **linux-amd64-only** step in the CA-3 job (reuses the bundle already built there; macOS runner has no docker/host-networking, and the schema is arch-independent so one arch suffices).

Closes nexus-ywts8