### PR TITLE
ci(rdr-157): remediate P2 stacked-review findings (nexus-vwvv5.7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,9 @@ jobs:
               # A dep bump can change test collection / the Python env the CA-3
               # tests depend on without touching any path above; gate on the
               # lockfile + manifest so such a change re-runs the gate instead of
-              # passing vacuously green (substantive-critic S1).
+              # passing vacuously green (substantive-critic S1). Deliberate cost:
+              # every dep-bump PR now pays the ~10min PG-from-source build x3 arches
+              # — accepted as the price of a non-vacuous gate (substantive-critic O-A).
               - 'uv.lock'
               - 'pyproject.toml'
 
@@ -320,7 +322,9 @@ jobs:
               # A dep bump can change test collection / the Python env the CA-3
               # tests depend on without touching any path above; gate on the
               # lockfile + manifest so such a change re-runs the gate instead of
-              # passing vacuously green (substantive-critic S1).
+              # passing vacuously green (substantive-critic S1). Deliberate cost:
+              # every dep-bump PR now pays the ~10min PG-from-source build x3 arches
+              # — accepted as the price of a non-vacuous gate (substantive-critic O-A).
               - 'uv.lock'
               - 'pyproject.toml'
 
@@ -410,6 +414,12 @@ jobs:
     # NOT a required check — a normal job whose expensive steps are path-gated, so
     # unrelated PRs see a fast no-op. (A required job MUST always run; this one is
     # advisory, so gating the whole job's work via step `if:` is fine.)
+    #
+    # ADVISORY, NOT BLOCKING (substantive-critic S2, nexus-a5rj8): because it is not
+    # a required check, a RED result here does not block merge — it converts "zero
+    # build visibility on PRs" into "visible but ignorable". Promoting it to a
+    # required check (paying ~40min native build on every service/** PR) is an open
+    # decision tracked in nexus-a5rj8.
     name: engine-service native build (PR trip-wire)
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,9 @@ jobs:
     # pre-authorized Strategy B as the CA-3-failure fallback. See RF-157-9 /
     # T2 nexus_rdr/157-CA3-FINDING-zonky-reduced-insufficient.
     #
-    # Both linux targets run live (nexus-xqk5r closed aarch64). mac-arm64
-    # (nexus-0ixqc) is still deferred — it needs a darwin test variant
-    # (vector.dylib / dyld / otool minos floor, not GLIBC).
+    # Both linux targets run live (nexus-xqk5r closed aarch64). mac-arm64 runs
+    # live in the separate ca3-pgvector-bundle-macos job below (nexus-0ixqc) — it
+    # needs a darwin variant (vector.dylib / dyld / otool minos floor, not GLIBC).
     name: CA-3 live (PG from source + pgvector, ${{ matrix.target.arch }})
     runs-on: ${{ matrix.target.runner }}
     timeout-minutes: 30
@@ -153,7 +153,12 @@ jobs:
       # required status check always reports), but the build/test/smoke steps run
       # only when the assemble surface changed — avoiding a ~10min PG build on
       # every unrelated PR. nexus-vwvv5.6 follow-up.
-      - uses: dorny/paths-filter@v3
+      # SHA-pinned (not @v3): this filter's `ca3` output gates whether EVERY
+      # build/test step in a REQUIRED check runs. A floating tag that was
+      # compromised to always emit ca3='false' would skip the PG build + tests
+      # while the job still reports green — the exact vacuous gate the
+      # always-run-job pattern exists to prevent. de90cc6 == v3.0.2.
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
         id: changes
         with:
           filters: |
@@ -164,6 +169,12 @@ jobs:
               - 'scripts/liquibase_bundle_smoke.sh'
               - '.github/workflows/ci.yml'
               - 'service/src/main/resources/db/changelog/**'
+              # A dep bump can change test collection / the Python env the CA-3
+              # tests depend on without touching any path above; gate on the
+              # lockfile + manifest so such a change re-runs the gate instead of
+              # passing vacuously green (substantive-critic S1).
+              - 'uv.lock'
+              - 'pyproject.toml'
 
       - uses: astral-sh/setup-uv@v5
         if: steps.changes.outputs.ca3 == 'true'
@@ -290,7 +301,12 @@ jobs:
       # Path-gate the expensive native PG build (same rationale as the linux CA-3
       # job): the job always runs so the required check reports, but the build/test
       # run only when the assemble surface changed.
-      - uses: dorny/paths-filter@v3
+      # SHA-pinned (not @v3): this filter's `ca3` output gates whether EVERY
+      # build/test step in a REQUIRED check runs. A floating tag that was
+      # compromised to always emit ca3='false' would skip the PG build + tests
+      # while the job still reports green — the exact vacuous gate the
+      # always-run-job pattern exists to prevent. de90cc6 == v3.0.2.
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
         id: changes
         with:
           filters: |
@@ -301,12 +317,29 @@ jobs:
               - 'scripts/liquibase_bundle_smoke.sh'
               - '.github/workflows/ci.yml'
               - 'service/src/main/resources/db/changelog/**'
+              # A dep bump can change test collection / the Python env the CA-3
+              # tests depend on without touching any path above; gate on the
+              # lockfile + manifest so such a change re-runs the gate instead of
+              # passing vacuously green (substantive-critic S1).
+              - 'uv.lock'
+              - 'pyproject.toml'
 
       - uses: astral-sh/setup-uv@v5
         if: steps.changes.outputs.ca3 == 'true'
         with:
           python-version: "3.12"
           enable-cache: false
+
+      - name: Cache uv wheel cache
+        # Mirror the linux CA-3 jobs so a gated mac run reuses wheels instead of
+        # re-downloading from scratch (code-review L1).
+        if: steps.changes.outputs.ca3 == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/setup-uv-cache
+          key: uv-${{ runner.os }}-mac-arm64-3.12-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-mac-arm64-3.12-
 
       - name: Install project + dev deps
         if: steps.changes.outputs.ca3 == 'true'
@@ -320,6 +353,14 @@ jobs:
           # provides clang/make. curl/perl/otool are present on the runner.
           brew install -q flex bison >/dev/null
           export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$PATH"
+          # Make the deployment-target floor EXPLICIT in the compiler flags rather
+          # than relying on apple-clang implicitly honouring MACOSX_DEPLOYMENT_TARGET.
+          # pgvector's Makefile invokes the compiler directly; if a future pgvector
+          # restructures its Makefile and drops the env, the dylib could build with a
+          # higher minos. TestMacosFloor (otool minos <= 13.0) is the backstop, but
+          # passing -mmacosx-version-min through CFLAGS removes the implicit dependency
+          # (code-review M2).
+          export CFLAGS="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}${CFLAGS:+ ${CFLAGS}}"
           bundle="$GITHUB_WORKSPACE/bundle"
           mkdir -p "$bundle"
           cd "$RUNNER_TEMP"
@@ -356,3 +397,51 @@ jobs:
           uv run pytest tests/db/test_pg_provision_ca3_bundle.py \
             -o addopts="" -m integration -q -rs --junit-xml=ca3.xml
           uv run python scripts/assert_ca3_ran.py ca3.xml
+
+  engine-service-build:
+    # S2 (substantive-critic): engine-service-release.yml runs ONLY on
+    # workflow_dispatch + engine-service-v* tags, so PR CI never compiles the
+    # service. A jOOQ-apply, Liquibase, or GraalVM-reachability regression in
+    # service/** can merge to develop unseen until a human cuts a release tag.
+    # This is a PR trip-wire: on service/** changes, regenerate jOOQ sources
+    # (testcontainers codegen, Docker) and run the SAME native build the release
+    # does (-Pnative -Pprebuilt-jooq -DskipTests), minus smoke + publish.
+    #
+    # NOT a required check — a normal job whose expensive steps are path-gated, so
+    # unrelated PRs see a fast no-op. (A required job MUST always run; this one is
+    # advisory, so gating the whole job's work via step `if:` is fine.)
+    name: engine-service native build (PR trip-wire)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+        id: changes
+        with:
+          filters: |
+            svc:
+              - 'service/**'
+              - '.github/workflows/ci.yml'
+
+      - name: Set up GraalVM 25.0.3
+        if: steps.changes.outputs.svc == 'true'
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f  # v1
+        with:
+          java-version: '25.0.3'
+          distribution: 'graalvm'
+          cache: 'maven'
+
+      - name: Generate jOOQ sources (testcontainers codegen, Docker)
+        if: steps.changes.outputs.svc == 'true'
+        working-directory: service
+        run: ./mvnw -q generate-sources
+
+      - name: Build native image (-Pnative -Pprebuilt-jooq, no smoke/publish)
+        if: steps.changes.outputs.svc == 'true'
+        working-directory: service
+        # The same build the release performs, minus smoke + publish — catches
+        # jOOQ-apply and GraalVM-reachability regressions on the PR instead of at
+        # tag-cut. Do NOT `clean`: generate-sources just populated
+        # target/generated-sources/jooq, and -Pprebuilt-jooq compiles it in place.
+        run: ./mvnw -q -Pnative -Pprebuilt-jooq -DskipTests package

--- a/.github/workflows/engine-service-release.yml
+++ b/.github/workflows/engine-service-release.yml
@@ -29,6 +29,8 @@ name: Engine Service Native Release
 # mac-arm64 is build+publish but UNSMOKED: native-smoke.sh needs Docker (throwaway
 # pgvector) which GH macOS lacks, so its runtime correctness rests on the
 # mac-arm64 CA-3 gate + the lp2qo native-serving spike, not a per-build smoke.
+# That coverage gap (no per-build macOS service-binary smoke) is tracked in
+# nexus-4xf5m (substantive-critic O-B).
 # conexus pins/pulls the linux-amd64 asset; local-distro users grab their arch.
 
 on:
@@ -204,6 +206,14 @@ jobs:
         # only at image-build time. Assert it here too: linux max-required GLIBC
         # must be <= the conexus runtime base (debian:trixie-slim = 2.41). For mac,
         # report the Mach-O minos (informational; no Docker smoke covers it).
+        #
+        # CROSS-REPO COUPLING (substantive-critic M1): the 2.41 ceiling is the glibc
+        # of conexus's runtime base, whose canonical definition lives in the conexus
+        # repo (deploy/engine/build-image.sh / its FROM image), NOT here. If conexus
+        # changes its runtime base distro/version, UPDATE this ceiling in lockstep —
+        # nothing in nexus/ will alert you otherwise. Keep this the looser (>=) of
+        # the two bases if they ever diverge so the assertion never blocks a release
+        # that the consumer would actually accept.
         run: |
           set -euo pipefail
           asset="dist/$ASSET"
@@ -213,15 +223,26 @@ jobs:
               maxglibc=$(objdump -T "$asset" 2>/dev/null \
                 | grep -oE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' \
                 | sed 's/GLIBC_//' | sort -V | tail -1)
-              echo "max required GLIBC: ${maxglibc:-none}"
-              ceiling="2.41"  # conexus runtime base (debian:trixie-slim)
-              if [ -n "$maxglibc" ] && [ "$(printf '%s\n%s\n' "$maxglibc" "$ceiling" | sort -V | tail -1)" != "$ceiling" ]; then
-                echo "FAIL: binary requires GLIBC $maxglibc > consumer base $ceiling" >&2
-                exit 1
+              if [ -z "$maxglibc" ]; then
+                # No GLIBC tokens: a statically-linked binary (no floor to enforce).
+                # GraalVM on linux currently emits DYNAMIC binaries, so flag this as
+                # a surprising build change rather than silently passing (code-review L1).
+                echo "NOTE: no GLIBC symbol references in $asset — statically linked? (no floor to assert)"
+              else
+                echo "max required GLIBC: $maxglibc"
+                ceiling="2.41"  # conexus runtime base (debian:trixie-slim) — see header note
+                if [ "$(printf '%s\n%s\n' "$maxglibc" "$ceiling" | sort -V | tail -1)" != "$ceiling" ]; then
+                  echo "FAIL: binary requires GLIBC $maxglibc > consumer base $ceiling" >&2
+                  exit 1
+                fi
               fi
               ;;
             mac-*)
               otool -l "$asset" | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print "Mach-O "$0; f=0}' || true
+              ;;
+            *)
+              echo "FAIL: unhandled arch '${{ matrix.target.arch }}' — no ABI floor check defined" >&2
+              exit 1
               ;;
           esac
 

--- a/.github/workflows/engine-service-release.yml
+++ b/.github/workflows/engine-service-release.yml
@@ -22,11 +22,14 @@ name: Engine Service Native Release
 #                         linux-amd64 native binary + its sha256 (what conexus
 #                         pins and pulls).
 #
-# Per-platform matrix (nexus-vwvv5.6): linux-amd64 + linux-arm64 native binaries
-# on their own runners (native-image does not cross-compile). mac-arm64 is
-# deferred (nexus-f6j31) — GH macOS runners lack Docker for the -Pnative jOOQ
-# codegen. conexus pins/pulls the linux-amd64 asset; local-distro users grab
-# their arch.
+# Per-platform matrix (nexus-vwvv5.6): linux-amd64 + linux-arm64 + mac-arm64
+# native binaries on their own runners (native-image does not cross-compile).
+# The jOOQ decouple (nexus-f6j31) pre-generates sources on a Docker-capable linux
+# runner and passes them as an artifact, so mac-arm64 can BUILD without Docker.
+# mac-arm64 is build+publish but UNSMOKED: native-smoke.sh needs Docker (throwaway
+# pgvector) which GH macOS lacks, so its runtime correctness rests on the
+# mac-arm64 CA-3 gate + the lp2qo native-serving spike, not a per-build smoke.
+# conexus pins/pulls the linux-amd64 asset; local-distro users grab their arch.
 
 on:
   workflow_dispatch:
@@ -85,9 +88,9 @@ jobs:
         target:
           - { arch: linux-amd64, runner: ubuntu-latest,    smoke: true }
           - { arch: linux-arm64, runner: ubuntu-24.04-arm, smoke: true }
-          # mac-arm64: build-only. native-smoke.sh needs Docker (throwaway
-          # pgvector) which GH macOS lacks; macOS runtime correctness is covered
-          # by the mac-arm64 CA-3 gate + the lp2qo native-serving spike.
+          # mac-arm64: build + publish, but UNSMOKED. native-smoke.sh needs Docker
+          # (throwaway pgvector) which GH macOS lacks; macOS runtime correctness is
+          # covered by the mac-arm64 CA-3 gate + the lp2qo native-serving spike.
           - { arch: mac-arm64,   runner: macos-14,          smoke: false }
     env:
       ASSET: nexus-service-${{ matrix.target.arch }}
@@ -193,6 +196,35 @@ jobs:
           ls -la dist
           file "dist/$ASSET" || true
 
+      - name: Assert binary ABI floor (code-review M1)
+        # The release native image is built on ubuntu-latest (~glibc 2.39) — a
+        # HIGHER floor than the CA-3 bundle gate (manylinux 2.28). Enforcement was
+        # previously deferred entirely to conexus deploy/engine/build-image.sh, so a
+        # runner bump that pushed the floor ABOVE the consumer base would surface
+        # only at image-build time. Assert it here too: linux max-required GLIBC
+        # must be <= the conexus runtime base (debian:trixie-slim = 2.41). For mac,
+        # report the Mach-O minos (informational; no Docker smoke covers it).
+        run: |
+          set -euo pipefail
+          asset="dist/$ASSET"
+          case "${{ matrix.target.arch }}" in
+            linux-*)
+              # Max GLIBC_x.y.z token referenced by the binary's dynamic symbols.
+              maxglibc=$(objdump -T "$asset" 2>/dev/null \
+                | grep -oE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' \
+                | sed 's/GLIBC_//' | sort -V | tail -1)
+              echo "max required GLIBC: ${maxglibc:-none}"
+              ceiling="2.41"  # conexus runtime base (debian:trixie-slim)
+              if [ -n "$maxglibc" ] && [ "$(printf '%s\n%s\n' "$maxglibc" "$ceiling" | sort -V | tail -1)" != "$ceiling" ]; then
+                echo "FAIL: binary requires GLIBC $maxglibc > consumer base $ceiling" >&2
+                exit 1
+              fi
+              ;;
+            mac-*)
+              otool -l "$asset" | awk '/LC_BUILD_VERSION/{f=1} f&&/minos/{print "Mach-O "$0; f=0}' || true
+              ;;
+          esac
+
       - name: Upload Actions artifact (always — dev smoke / non-tag path)
         uses: actions/upload-artifact@v4
         with:
@@ -214,8 +246,13 @@ jobs:
             "run with no embedded PG, pointed at a managed Postgres via NX_DB_URL" \
             "(skips pg_provision). Consumed by conexus deploy/engine (build the" \
             "runtime image FROM the linux-amd64 binary). Per-platform assets +" \
-            "sha256 attached: nexus-service-linux-amd64, nexus-service-linux-arm64." \
-            "(mac-arm64 deferred — nexus-f6j31.)" \
+            "sha256 attached: nexus-service-linux-amd64, nexus-service-linux-arm64," \
+            "nexus-service-mac-arm64." \
+            "" \
+            "NOTE: the mac-arm64 binary is UNSMOKED (GH macOS runners have no Docker" \
+            "for native-smoke.sh). Its runtime correctness rests on the mac-arm64" \
+            "CA-3 gate + the lp2qo native-serving spike, not a per-build smoke —" \
+            "treat it as experimental. The linux binaries ARE smoke-tested." \
             "" \
             "glibc floor: linux binaries built on ubuntu-latest (~2.39). The runtime" \
             "base must have glibc >= that (conexus uses debian:trixie-slim = 2.41);" \
@@ -228,8 +265,19 @@ jobs:
             "" \
             "Provenance: sha256 only for now; cosign/Sigstore signing tracked for N+1." \
             > notes.md
-          # Matrix-safe: create the release once (whichever arch job wins; the
-          # losers' create fails 'already exists' -> ignored), then each job
-          # uploads its OWN arch assets (--clobber for re-runs).
-          gh release create "$tag" --title "nexus-service (native) ${tag}" --notes-file notes.md 2>/dev/null || true
+          # Matrix-safe: create the release once (whichever arch job wins), then
+          # each job uploads its OWN arch assets (--clobber for re-runs). Use
+          # view-then-create rather than `create ... 2>/dev/null || true`: the old
+          # idiom swallowed auth/network/rate-limit failures identically to the
+          # expected 'already exists', then fell through to `upload` which failed
+          # with a confusing 'release not found' (code-review H1).
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            # Tolerate ONLY the matrix race (another arch job created it between the
+            # view and this create); surface auth/network/anything else.
+            if ! gh release create "$tag" --title "nexus-service (native) ${tag}" \
+                   --notes-file notes.md 2>create_err.txt; then
+              grep -qi "already exists" create_err.txt \
+                || { echo "release create failed:" >&2; cat create_err.txt >&2; exit 1; }
+            fi
+          fi
           gh release upload "$tag" --clobber "dist/$ASSET" "dist/$ASSET.sha256"

--- a/scripts/assert_ca3_ran.py
+++ b/scripts/assert_ca3_ran.py
@@ -11,6 +11,7 @@ Usage: ``python scripts/assert_ca3_ran.py <junit.xml>``
 """
 from __future__ import annotations
 
+import os
 import sys
 import xml.etree.ElementTree as ET
 
@@ -22,6 +23,15 @@ _CORE_TEST = "test_create_extension_vector_loads"
 
 
 def main(junit_path: str) -> None:
+    # A missing JUnit file means pytest crashed before writing it (import error,
+    # fixture failure, OOM) — fail with the real cause, not a bare
+    # FileNotFoundError that points at the wrong place (code-review M3).
+    if not os.path.exists(junit_path):
+        raise SystemExit(
+            f"CA-3 JUnit output not found at '{junit_path}' — pytest likely crashed "
+            "before writing it (import error / fixture failure / OOM). Check the "
+            "'Run CA-3 live test' step log above."
+        )
     root = ET.parse(junit_path).getroot()
     bundle_skips = passed = 0
     core_ok = False

--- a/scripts/liquibase_bundle_smoke.sh
+++ b/scripts/liquibase_bundle_smoke.sh
@@ -21,12 +21,20 @@ export NEXUS_PG_BIN="$bundle/bin"
 cfg="$(mktemp -d)"
 export NEXUS_CONFIG_DIR="$cfg"
 
-cleanup() { "$bundle/bin/pg_ctl" -D "$cfg/postgres" -m immediate stop >/dev/null 2>&1 || true; }
+cleanup() {
+  # Logged so a CI reader can tell "provision failed, PG never started, no-op
+  # stop" apart from "PG started, teardown" (code-review L2).
+  echo "==> cleanup: pg_ctl stop (immediate)" >&2
+  "$bundle/bin/pg_ctl" -D "$cfg/postgres" -m immediate stop >/dev/null 2>&1 || true
+}
 trap cleanup EXIT
 
 echo "==> provisioning bundle cluster (nexus_admin + nexus_svc + nexus DB)"
 uv run python -c "from nexus.db.pg_provision import provision; provision()"
 
+# Dot-source the generated credentials. Safe because pg_provision emits
+# alphanumeric-only passwords (no shell metacharacters); if that generation ever
+# changes to include $, ", `, etc., this source would misparse (code-review L3).
 # shellcheck disable=SC1091
 set -a; . "$cfg/pg_credentials"; set +a
 echo "==> provisioned: port=${PG_PORT} admin=${NX_DB_ADMIN_USER}"
@@ -54,4 +62,15 @@ applied=$(PGPASSWORD="${NX_DB_ADMIN_PASS}" "$bundle/bin/psql" \
 echo "==> databasechangelog rows: ${applied}"
 [ "${applied:-0}" -gt 0 ] || { echo "FAIL: no changesets recorded"; exit 1; }
 
-echo "LIQUIBASE-AGAINST-BUNDLE SMOKE PASS (${applied} changesets on the lean bundle)"
+# Row count proves the migration RAN and was recorded, not that the extension
+# LAYER is intact: a `CREATE EXTENSION IF NOT EXISTS pg_trgm` changeset records a
+# row even when the contrib extension is absent and the statement no-ops. That is
+# exactly the gap that hid the pg_trgm miss (nexus-ywts8). Assert both required
+# extensions are actually installed (substantive-critic O3).
+exts=$(PGPASSWORD="${NX_DB_ADMIN_PASS}" "$bundle/bin/psql" \
+  -h 127.0.0.1 -p "${PG_PORT}" -U "${NX_DB_ADMIN_USER}" -d nexus -tAc \
+  "SELECT count(*) FROM pg_extension WHERE extname IN ('vector','pg_trgm')")
+echo "==> required extensions present (vector, pg_trgm): ${exts}/2"
+[ "${exts:-0}" -eq 2 ] || { echo "FAIL: expected vector + pg_trgm installed, found ${exts}"; exit 1; }
+
+echo "LIQUIBASE-AGAINST-BUNDLE SMOKE PASS (${applied} changesets, vector+pg_trgm verified)"

--- a/scripts/liquibase_bundle_smoke.sh
+++ b/scripts/liquibase_bundle_smoke.sh
@@ -67,10 +67,18 @@ echo "==> databasechangelog rows: ${applied}"
 # row even when the contrib extension is absent and the statement no-ops. That is
 # exactly the gap that hid the pg_trgm miss (nexus-ywts8). Assert both required
 # extensions are actually installed (substantive-critic O3).
+#
+# vector + pg_trgm are the ONLY extensions in the changelog today. If a future
+# changeset adds a third (uuid-ossp, pg_stat_statements, ...), add it to the list
+# below — the expected count is derived from the list, so the assertion stays in
+# sync and won't silently undercount a missing new extension (substantive-critic O-C).
+required_exts="vector pg_trgm"
+expected=$(printf '%s\n' $required_exts | wc -l | tr -d ' ')
+in_list=$(printf "'%s'," $required_exts | sed 's/,$//')
 exts=$(PGPASSWORD="${NX_DB_ADMIN_PASS}" "$bundle/bin/psql" \
   -h 127.0.0.1 -p "${PG_PORT}" -U "${NX_DB_ADMIN_USER}" -d nexus -tAc \
-  "SELECT count(*) FROM pg_extension WHERE extname IN ('vector','pg_trgm')")
-echo "==> required extensions present (vector, pg_trgm): ${exts}/2"
-[ "${exts:-0}" -eq 2 ] || { echo "FAIL: expected vector + pg_trgm installed, found ${exts}"; exit 1; }
+  "SELECT count(*) FROM pg_extension WHERE extname IN (${in_list})")
+echo "==> required extensions present (${required_exts}): ${exts}/${expected}"
+[ "${exts:-0}" -eq "$expected" ] || { echo "FAIL: expected ${required_exts} installed, found ${exts}"; exit 1; }
 
 echo "LIQUIBASE-AGAINST-BUNDLE SMOKE PASS (${applied} changesets, vector+pg_trgm verified)"

--- a/tests/db/test_pg_provision_ca3_bundle.py
+++ b/tests/db/test_pg_provision_ca3_bundle.py
@@ -228,7 +228,7 @@ def provisioned(bins: PgBinaries, tmp_path_factory):
 
 # ── Test 1: the bundle ships a complete PG17 with consistent paths ──────────────
 
-class TestCompletePg16Bundle:
+class TestCompletePg17Bundle:
     def test_binaries_discovered_via_env_seam(self, bins):
         assert bins.all_present(), "bundle missing one of initdb/pg_ctl/psql/createdb"
 


### PR DESCRIPTION
## Remediation of the RDR-157 P2 stacked review (bead nexus-vwvv5.7)

The stacked review (code-review-expert + substantive-critic) of the merged P2 native-image build matrix found **0 Critical**, 3 High, 2 Significant, 3 Important, 3 minor. This PR remediates **all** of them.

### Gate integrity (the vacuous-green class)
- **H3** — SHA-pin `dorny/paths-filter` (`@v3` → `@de90cc6` v3.0.2) in both CA-3 jobs. That filter's `ca3` output gates whether a **required** check actually builds/tests; a floating tag that emitted `ca3='false'` would pass green without running anything — the exact failure the always-run-job pattern exists to prevent. Matches the repo's existing graalvm SHA-pin rationale.
- **S1** — add `uv.lock` + `pyproject.toml` to the CA-3 path filter. A dep bump can break test collection without touching any gated path; it now re-runs the gate instead of passing vacuously.

### engine-service release workflow
- **H1** — replace `gh release create … 2>/dev/null || true` with view-then-create that tolerates **only** the matrix create race (`already exists`) and surfaces auth/network/rate-limit failures, instead of falling through to a confusing `release not found` on upload.
- **H2** — mac-arm64 is build+publish now (post-`nexus-f6j31` jOOQ decouple), not deferred. Stale comment + release notes fixed; mac binary listed as attached but explicitly **UNSMOKED/experimental**.
- **M1** — add a binary ABI-floor assertion in the publish path: linux max-required GLIBC must be `<=` the conexus runtime base (2.41); mac reports Mach-O minos. Enforcement was previously deferred entirely to the conexus consumer.

### CA-3 surface
- **S2** — new `engine-service-build` PR trip-wire job (path-gated to `service/**`). `engine-service-release.yml` runs only on tag/dispatch, so PR CI never compiled the service; this regenerates jOOQ + runs the native build on service changes, catching jOOQ-apply and GraalVM-reachability regressions on the PR instead of at tag-cut.
- **M2** — pass `-mmacosx-version-min` via `CFLAGS` in the mac CA-3 build rather than relying on apple-clang implicitly honouring `MACOSX_DEPLOYMENT_TARGET`.
- **M3** — `assert_ca3_ran.py` fails with a clear "pytest crashed before writing it" message when the JUnit file is missing.
- **O3** — liquibase smoke now asserts `vector` + `pg_trgm` are actually installed (`pg_extension`), not just that changelog rows landed — the exact gap that hid the pg_trgm miss (`nexus-ywts8`).
- **O6** — rename test class `TestCompletePg16Bundle` → `TestCompletePg17Bundle`; fix stale mac-deferred CA-3 comment.
- **L1/L2/L3** — uv wheel cache on the mac CA-3 job; log the liquibase cleanup trap; document the pg_credentials alphanumeric-password assumption.

### Self-verifying
This PR touches `ci.yml`, so the CA-3 path filter matches → the PG-from-source builds run fully here (confirming the SHA-pin + the new `uv.lock`/`pyproject.toml` filter entries), and the `service/**`+`ci.yml` filter triggers the new `engine-service-build` trip-wire (confirming it works).

Refs nexus-vwvv5.7, nexus-d16cp
