### PR TITLE
feat(rdr-157): P3.1 relocatable PG17+pgvector bundle build (Strategy B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,9 @@ jobs:
             ca3:
               - 'src/nexus/db/pg_provision.py'
               - 'tests/db/test_pg_provision_ca3_bundle.py'
+              - 'tests/db/test_pg_bundle_relocation.py'
               - 'scripts/assert_ca3_ran.py'
+              - 'scripts/build_pg_bundle.sh'
               - 'scripts/liquibase_bundle_smoke.sh'
               - '.github/workflows/ci.yml'
               - 'service/src/main/resources/db/changelog/**'
@@ -201,64 +203,24 @@ jobs:
         if: steps.changes.outputs.ca3 == 'true'
         run: |
           set -euo pipefail
-          # The bundle is installed at its build prefix and mounted at the SAME
-          # path inside the container, so pg_config's compiled-in paths agree with
-          # the host (no relocation mismatch for the gate). True extract-to-
-          # arbitrary-dir relocation — where pg_config's build-prefix-boundness
-          # makes path resolution a real concern — is a P3 bundle-build problem
-          # (nexus-vwvv5.9), not this gate.
+          # Single source of truth for the build is scripts/build_pg_bundle.sh
+          # (RDR-157 P3.1, bead nexus-vwvv5.10) — the CA-3 gate and the P3 bundle
+          # artifact build the SAME tree. The bundle is installed at its build
+          # prefix and mounted at the SAME path inside the container, so
+          # pg_config's compiled-in paths agree with the host for the CA-3 gate.
+          # The relocation step below additionally proves an extract to a
+          # DIFFERENT dir works (the P3 shippable-bundle contract).
           bundle="$GITHUB_WORKSPACE/bundle"
           mkdir -p "$bundle"
-          # set -x traces every command; no pipefail (cmd|head SIGPIPEs -> 141).
           docker run --rm \
-            -e PG_VERSION -e PGVECTOR_VERSION -e bundle="$bundle" \
-            -v "$bundle:$bundle" \
+            -e PG_VERSION -e PGVECTOR_VERSION -e BUNDLE_PREFIX="$bundle" \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
             "$MANYLINUX_IMAGE" /bin/bash -c '
               set -eux
-              echo "=== ENTER container ==="
-              head -2 /etc/os-release; ldd --version | head -1
-              # PostgreSQL build prereqs not in the base toolchain image.
-              dnf -y -q install flex bison perl >/dev/null
-              cd /tmp
-              curl -fsSL "https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.bz2" -o pg.tar.bz2
-              tar -xjf pg.tar.bz2
-              cd "postgresql-${PG_VERSION}"
-              # Minimal deps: a functional server + client + headers + pgxs.
-              # The dropped options are safe for the nexus embedded, loopback-only PG
-              # and these same flags carry forward to the P3 bundle build:
-              #   --without-icu      : provision runs `initdb --no-locale` (C
-              #                        collation), so ICU is unused; keeps the
-              #                        binary off an ICU .so absent on old distros.
-              #   --without-readline : psql is driven headlessly (subprocess).
-              #   --without-zlib     : no wire compression / pg_dump -Fc needed.
-              #   --without-openssl  : loopback-only; EXPLICIT so an image that
-              #                        later ships openssl-devel cannot silently
-              #                        link libssl and break startup on the runner.
-              ./configure --prefix="${bundle}" \
-                --without-icu --without-zlib --without-readline --without-openssl >/dev/null
-              make -s -j"$(nproc)" >/dev/null
-              make -s install >/dev/null
-              # Contrib extensions the schema needs (pg_trgm, RDR-155). Core
-              # `make install` does NOT build contrib — the bundle would be
-              # missing pg_trgm and the full migration would fail.
-              make -s -C contrib/pg_trgm install >/dev/null
-              # pgvector against the freshly-built pg_config (same major + glibc).
-              cd /tmp
-              git clone --depth 1 --branch "${PGVECTOR_VERSION}" https://github.com/pgvector/pgvector.git
-              cd pgvector
-              make -s PG_CONFIG="${bundle}/bin/pg_config"
-              make -s PG_CONFIG="${bundle}/bin/pg_config" install
+              echo "=== ENTER container ==="; head -2 /etc/os-release; ldd --version | head -1
+              bash "'"$GITHUB_WORKSPACE"'/scripts/build_pg_bundle.sh"
             '
-          # Sanity on the host: complete tool set + injected extension present.
-          for b in initdb pg_ctl postgres psql createdb pg_config; do
-            test -x "$bundle/bin/$b" || { echo "missing $bundle/bin/$b"; exit 1; }
-          done
-          pkglib="$("$bundle/bin/pg_config" --pkglibdir)"
-          sharedir="$("$bundle/bin/pg_config" --sharedir)"
-          test -f "$pkglib/vector.so" || { ls -la "$pkglib"; exit 1; }
-          test -f "$sharedir/extension/vector.control" || { ls -la "$sharedir/extension"; exit 1; }
           echo "NEXUS_CA3_BUNDLE=$bundle" >> "$GITHUB_ENV"
-          echo "Built: $("$bundle/bin/initdb" --version); vector.so at $pkglib"
 
       - name: Run CA-3 live test (asserts it actually ran, not skipped)
         if: steps.changes.outputs.ca3 == 'true'
@@ -271,6 +233,40 @@ jobs:
           # Non-vacuity gate: platform-conditional tests (GLIBC on mac / minos on
           # linux) skip legitimately; only a bundle-absence skip is a vacuous gate.
           uv run python scripts/assert_ca3_ran.py ca3.xml
+
+      - name: Package bundle + relocation smoke (P3.1, nexus-vwvv5.10)
+        # Tar the built tree to a shippable .txz, then EXTRACT it to a dir other
+        # than the build prefix and prove the relocated tree still provisions +
+        # loads pgvector (closes the relocation concern CA-3 deferred). The
+        # glibc-2.28-built binaries run on the ubuntu-latest host (glibc ~2.39,
+        # forward-compatible) — that the relocated tree runs OUTSIDE its build
+        # container is itself part of the portability proof.
+        if: steps.changes.outputs.ca3 == 'true'
+        run: |
+          set -euo pipefail
+          bundle="$GITHUB_WORKSPACE/bundle"
+          txz="$RUNNER_TEMP/nexus-pg-${{ matrix.target.arch }}.txz"
+          # -C parent + basename preserves the relative bin/ lib/ share/ layout
+          # that relocation depends on.
+          tar -cJf "$txz" -C "$(dirname "$bundle")" "$(basename "$bundle")"
+          reloc="$RUNNER_TEMP/relocated"
+          mkdir -p "$reloc"
+          tar -xJf "$txz" -C "$reloc"
+          export NEXUS_PG_BUNDLE_ROOT="$reloc/$(basename "$bundle")"
+          uv run pytest tests/db/test_pg_bundle_relocation.py \
+            -o addopts="" -m integration -q -rs --junit-xml=reloc.xml
+          # Reuse the CA-3 non-vacuity asserter (keys on the shared
+          # "no CA-3 bundle" skip phrase + the CREATE EXTENSION core test).
+          uv run python scripts/assert_ca3_ran.py reloc.xml
+
+      - name: Upload bundle artifact (P3.1, consumed by P3.2/P3.4)
+        if: steps.changes.outputs.ca3 == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: nexus-pg-${{ matrix.target.arch }}
+          path: ${{ runner.temp }}/nexus-pg-${{ matrix.target.arch }}.txz
+          retention-days: 7
+          if-no-files-found: error
 
       - name: Liquibase-against-bundle smoke (nexus-ywts8, linux-amd64 only)
         # Applies the service's full SQL changelog to the lean bundle PG, proving
@@ -315,7 +311,9 @@ jobs:
             ca3:
               - 'src/nexus/db/pg_provision.py'
               - 'tests/db/test_pg_provision_ca3_bundle.py'
+              - 'tests/db/test_pg_bundle_relocation.py'
               - 'scripts/assert_ca3_ran.py'
+              - 'scripts/build_pg_bundle.sh'
               - 'scripts/liquibase_bundle_smoke.sh'
               - '.github/workflows/ci.yml'
               - 'service/src/main/resources/db/changelog/**'
@@ -351,48 +349,16 @@ jobs:
 
       - name: Build complete PG + pgvector from source (native, deployment-target 13.0)
         if: steps.changes.outputs.ca3 == 'true'
+        env:
+          BUNDLE_PREFIX: ${{ github.workspace }}/bundle
         run: |
           set -euo pipefail
-          # PG's build needs a newer flex/bison than macOS ships; Xcode CLT
-          # provides clang/make. curl/perl/otool are present on the runner.
-          brew install -q flex bison >/dev/null
-          export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$PATH"
-          # Make the deployment-target floor EXPLICIT in the compiler flags rather
-          # than relying on apple-clang implicitly honouring MACOSX_DEPLOYMENT_TARGET.
-          # pgvector's Makefile invokes the compiler directly; if a future pgvector
-          # restructures its Makefile and drops the env, the dylib could build with a
-          # higher minos. TestMacosFloor (otool minos <= 13.0) is the backstop, but
-          # passing -mmacosx-version-min through CFLAGS removes the implicit dependency
-          # (code-review M2).
-          export CFLAGS="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}${CFLAGS:+ ${CFLAGS}}"
-          bundle="$GITHUB_WORKSPACE/bundle"
-          mkdir -p "$bundle"
-          cd "$RUNNER_TEMP"
-          curl -fsSL "https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.bz2" -o pg.tar.bz2
-          tar -xjf pg.tar.bz2
-          cd "postgresql-${PG_VERSION}"
-          # Same lean flags as the linux gate (safe for nexus's loopback PG).
-          ./configure --prefix="${bundle}" \
-            --without-icu --without-zlib --without-readline --without-openssl >/dev/null
-          make -s -j"$(sysctl -n hw.ncpu)" >/dev/null
-          make -s install >/dev/null
-          # Contrib extensions the schema needs (pg_trgm, RDR-155).
-          make -s -C contrib/pg_trgm install >/dev/null
-          cd "$RUNNER_TEMP"
-          git clone --depth 1 --branch "${PGVECTOR_VERSION}" https://github.com/pgvector/pgvector.git
-          cd pgvector
-          make -s PG_CONFIG="${bundle}/bin/pg_config"
-          make -s PG_CONFIG="${bundle}/bin/pg_config" install
-          # Sanity: complete tool set + injected dylib + control.
-          for b in initdb pg_ctl postgres psql createdb pg_config; do
-            test -x "$bundle/bin/$b" || { echo "missing $bundle/bin/$b"; exit 1; }
-          done
-          pkglib="$("$bundle/bin/pg_config" --pkglibdir)"
-          sharedir="$("$bundle/bin/pg_config" --sharedir)"
-          test -f "$pkglib/vector.dylib" || { ls -la "$pkglib"; exit 1; }
-          test -f "$sharedir/extension/vector.control" || { ls -la "$sharedir/extension"; exit 1; }
-          echo "NEXUS_CA3_BUNDLE=$bundle" >> "$GITHUB_ENV"
-          echo "Built: $("$bundle/bin/initdb" --version); vector.dylib at $pkglib"
+          # Single source of truth: scripts/build_pg_bundle.sh (same script the
+          # linux CA-3 job runs inside its container). It installs flex/bison via
+          # brew, applies MACOSX_DEPLOYMENT_TARGET / -mmacosx-version-min, builds
+          # PG + pg_trgm + pgvector, and records the build prefix marker.
+          bash scripts/build_pg_bundle.sh
+          echo "NEXUS_CA3_BUNDLE=$BUNDLE_PREFIX" >> "$GITHUB_ENV"
 
       - name: Run CA-3 live test (asserts it actually ran, not skipped)
         if: steps.changes.outputs.ca3 == 'true'
@@ -401,6 +367,33 @@ jobs:
           uv run pytest tests/db/test_pg_provision_ca3_bundle.py \
             -o addopts="" -m integration -q -rs --junit-xml=ca3.xml
           uv run python scripts/assert_ca3_ran.py ca3.xml
+
+      - name: Package bundle + relocation smoke (P3.1, nexus-vwvv5.10)
+        # Same relocation proof as the linux job: tar the tree, extract to a dir
+        # other than the build prefix, prove the relocated tree provisions +
+        # loads pgvector (vector.dylib via dyld) from the new location.
+        if: steps.changes.outputs.ca3 == 'true'
+        run: |
+          set -euo pipefail
+          bundle="$GITHUB_WORKSPACE/bundle"
+          txz="$RUNNER_TEMP/nexus-pg-mac-arm64.txz"
+          tar -cJf "$txz" -C "$(dirname "$bundle")" "$(basename "$bundle")"
+          reloc="$RUNNER_TEMP/relocated"
+          mkdir -p "$reloc"
+          tar -xJf "$txz" -C "$reloc"
+          export NEXUS_PG_BUNDLE_ROOT="$reloc/$(basename "$bundle")"
+          uv run pytest tests/db/test_pg_bundle_relocation.py \
+            -o addopts="" -m integration -q -rs --junit-xml=reloc.xml
+          uv run python scripts/assert_ca3_ran.py reloc.xml
+
+      - name: Upload bundle artifact (P3.1, consumed by P3.2/P3.4)
+        if: steps.changes.outputs.ca3 == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: nexus-pg-mac-arm64
+          path: ${{ runner.temp }}/nexus-pg-mac-arm64.txz
+          retention-days: 7
+          if-no-files-found: error
 
   engine-service-build:
     # S2 (substantive-critic): engine-service-release.yml runs ONLY on

--- a/scripts/build_pg_bundle.sh
+++ b/scripts/build_pg_bundle.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Build a COMPLETE, RELOCATABLE PostgreSQL + pgvector + pg_trgm bundle from
+# source (RDR-157 P3.1, bead nexus-vwvv5.10 — Strategy B).
+#
+# Single source of truth for the bundle build, extracted from the proven CA-3
+# CI jobs (.github/workflows/ci.yml). CA-3 falsified Strategy A (zonky reduced
+# bundle): zonky ships only initdb/pg_ctl/postgres — no pg_config/psql/createdb/
+# headers/pgxs — so pgvector cannot be built against it and nx's provisioner
+# cannot discover it (RF-157-9). This builds a complete tree instead.
+#
+# Lean configure flags (safe for nexus's loopback-only, --no-locale PG):
+#   --without-icu      provision runs `initdb --no-locale` (C collation).
+#   --without-readline psql is driven headlessly (subprocess).
+#   --without-zlib     no wire compression / pg_dump -Fc needed.
+#   --without-openssl  loopback-only; EXPLICIT so an image that later ships
+#                      openssl-devel cannot silently link libssl.
+#
+# Produces a tree whose internal layout (bin/ lib/ share/) is relocation-stable:
+# PostgreSQL is relocatable by design — its programs (including pg_config)
+# resolve share/lib relative to the executable's own location via find_my_exec,
+# so after extraction to a new prefix pg_config reports the NEW paths, not this
+# build prefix. nexus additionally re-anchors the sharedir on bin_dir
+# (pg_provision._candidate_sharedirs) as belt-and-suspenders. The tree therefore
+# works after extraction to any directory (proven by
+# tests/db/test_pg_bundle_relocation.py).
+#
+# Required env:
+#   BUNDLE_PREFIX   absolute install prefix (configure --prefix); also the tree root.
+# Optional env:
+#   PG_VERSION              default 17.5   (PG major aligned on 17; nexus-41bso)
+#   PGVECTOR_VERSION        default v0.8.2 (>=0.8 is the RDR-155 iterative_scan floor)
+#   WORK_DIR                scratch dir for sources; default `mktemp -d`
+#   MACOSX_DEPLOYMENT_TARGET (darwin only) default 13.0 — Mach-O minos floor
+#   SKIP_PREREQS            when "1", do not attempt to install flex/bison/perl
+#
+# Usage:
+#   BUNDLE_PREFIX=/opt/nexus-pg scripts/build_pg_bundle.sh
+set -euo pipefail
+
+: "${BUNDLE_PREFIX:?BUNDLE_PREFIX (absolute install prefix) is required}"
+PG_VERSION="${PG_VERSION:-17.5}"
+PGVECTOR_VERSION="${PGVECTOR_VERSION:-v0.8.2}"
+# Default to a private scratch dir we own (and clean up). If the caller supplies
+# WORK_DIR we leave it untouched on exit — it's theirs.
+if [ -z "${WORK_DIR:-}" ]; then
+    WORK_DIR="$(mktemp -d)"
+    trap 'rm -rf "$WORK_DIR"' EXIT
+fi
+SKIP_PREREQS="${SKIP_PREREQS:-0}"
+
+uname_s="$(uname -s)"
+
+log() { echo "=== $* ==="; }
+
+install_prereqs() {
+    if [ "$SKIP_PREREQS" = "1" ]; then
+        log "SKIP_PREREQS=1 — assuming flex/bison/perl present"
+        return
+    fi
+    case "$uname_s" in
+        Linux)
+            # manylinux_2_28 base toolchain lacks these.
+            if command -v dnf >/dev/null 2>&1; then
+                dnf -y -q install flex bison perl >/dev/null
+            elif command -v apt-get >/dev/null 2>&1; then
+                apt-get -y -q install flex bison perl >/dev/null
+            else
+                echo "WARN: no dnf/apt-get found — assuming flex/bison/perl present" >&2
+            fi
+            ;;
+        Darwin)
+            # PG's build needs a newer flex/bison than macOS ships; Xcode CLT
+            # provides clang/make. curl/perl/otool are present on the runner.
+            brew install -q flex bison >/dev/null
+            export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$PATH"
+            ;;
+    esac
+}
+
+configure_flags=( "--prefix=${BUNDLE_PREFIX}"
+                  --without-icu --without-zlib --without-readline --without-openssl )
+
+build_pg() {
+    local njobs target
+    log "build PostgreSQL ${PG_VERSION} -> ${BUNDLE_PREFIX} (${uname_s})"
+    cd "$WORK_DIR"
+    curl -fsSL "https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.bz2" -o pg.tar.bz2
+    tar -xjf pg.tar.bz2
+    cd "postgresql-${PG_VERSION}"
+
+    if [ "$uname_s" = "Darwin" ]; then
+        # Make the deployment-target floor explicit in CFLAGS rather than relying
+        # on apple-clang implicitly honouring MACOSX_DEPLOYMENT_TARGET — pgvector's
+        # Makefile invokes the compiler directly (code-review M2, carried from CA-3).
+        target="${MACOSX_DEPLOYMENT_TARGET:-13.0}"
+        export MACOSX_DEPLOYMENT_TARGET="$target"
+        export CFLAGS="-mmacosx-version-min=${target}${CFLAGS:+ ${CFLAGS}}"
+        njobs="$(sysctl -n hw.ncpu)"
+    else
+        njobs="$(nproc)"
+    fi
+
+    ./configure "${configure_flags[@]}" >/dev/null
+    make -s -j"${njobs}" >/dev/null
+    make -s install >/dev/null
+    # Contrib extensions the schema needs (pg_trgm, RDR-155). Core `make install`
+    # does NOT build contrib — the bundle would be missing pg_trgm and the full
+    # migration would fail.
+    make -s -C contrib/pg_trgm install >/dev/null
+}
+
+build_pgvector() {
+    log "build pgvector ${PGVECTOR_VERSION} against ${BUNDLE_PREFIX}/bin/pg_config"
+    cd "$WORK_DIR"
+    git clone --depth 1 --branch "${PGVECTOR_VERSION}" https://github.com/pgvector/pgvector.git
+    cd pgvector
+    make -s PG_CONFIG="${BUNDLE_PREFIX}/bin/pg_config"
+    make -s PG_CONFIG="${BUNDLE_PREFIX}/bin/pg_config" install
+}
+
+verify_and_mark() {
+    log "verify complete tool set + injected extension"
+    local b vector_lib pkglib sharedir
+    for b in initdb pg_ctl postgres psql createdb pg_config; do
+        test -x "${BUNDLE_PREFIX}/bin/${b}" || { echo "missing ${BUNDLE_PREFIX}/bin/${b}"; exit 1; }
+    done
+    if [ "$uname_s" = "Darwin" ]; then vector_lib="vector.dylib"; else vector_lib="vector.so"; fi
+    pkglib="$("${BUNDLE_PREFIX}/bin/pg_config" --pkglibdir)"
+    sharedir="$("${BUNDLE_PREFIX}/bin/pg_config" --sharedir)"
+    test -f "${pkglib}/${vector_lib}" || { ls -la "${pkglib}"; exit 1; }
+    test -f "${sharedir}/extension/vector.control" || { ls -la "${sharedir}/extension"; exit 1; }
+    test -f "${sharedir}/extension/pg_trgm.control" || { ls -la "${sharedir}/extension"; exit 1; }
+
+    # Record the configure --prefix so the relocation smoke can prove that an
+    # extracted root differs from where the tree was built
+    # (tests/db/test_pg_bundle_relocation.py::TestActuallyRelocated).
+    python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "${BUNDLE_PREFIX}" \
+        > "${BUNDLE_PREFIX}/.build_prefix"
+
+    echo "Built: $("${BUNDLE_PREFIX}/bin/initdb" --version)"
+    echo "  ${vector_lib} at ${pkglib}"
+    echo "  build prefix recorded at ${BUNDLE_PREFIX}/.build_prefix"
+}
+
+mkdir -p "$BUNDLE_PREFIX"
+install_prereqs
+build_pg
+build_pgvector
+verify_and_mark
+log "bundle complete: ${BUNDLE_PREFIX}"

--- a/tests/db/test_pg_bundle_relocation.py
+++ b/tests/db/test_pg_bundle_relocation.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""P3.1 relocation smoke: a packaged PG17+pgvector bundle, EXTRACTED to an
+arbitrary directory distinct from its build ``--prefix``, still provisions and
+loads pgvector (RDR-157 P3.1, bead nexus-vwvv5.10).
+
+Why this is distinct from the CA-3 gate
+---------------------------------------
+``tests/db/test_pg_provision_ca3_bundle.py`` proves the *assemble* path with the
+bundle consumed AT its build prefix (prefix == mount path), so ``pg_config``'s
+compiled-in paths happen to agree with the runtime location. CA-3 explicitly
+**deferred true relocation** — extract-to-arbitrary-dir, where ``pg_config``'s
+build-prefix-boundness becomes a real concern — to P3.
+
+A shippable local-distribution bundle is extracted to a user directory (e.g.
+``~/.config/nexus/pg-bundle``) that is NOT the build ``--prefix``. PostgreSQL is
+relocatable by design: its programs (including ``pg_config``) resolve
+``share``/``lib`` relative to the executable's own location via
+``find_my_exec`` — so after extraction ``pg_config --sharedir`` reports the NEW
+location, not the build prefix. nexus's :func:`check_pgvector_available`
+additionally re-anchors the sharedir on ``bin_dir``
+(:func:`nexus.db.pg_provision._candidate_sharedirs`) as belt-and-suspenders.
+This module proves the FUNCTIONAL outcome end to end against a genuinely
+relocated tree:
+
+  1. the extracted root is NOT the build ``--prefix`` (we really did relocate —
+     non-vacuity), ``pg_config`` resolves its paths back inside that new root,
+     and
+  2. ``discover_pg_binaries`` + ``provision`` + ``CREATE EXTENSION vector`` all
+     succeed from the new location.
+
+How the relocated tree is materialized
+--------------------------------------
+The CI job builds the bundle from source at one prefix, packages it to a
+``.txz``, then EXTRACTS that tarball to ``$RUNNER_TEMP/relocated`` and exports
+``NEXUS_PG_BUNDLE_ROOT`` at the extracted root. ``scripts/build_pg_bundle.sh``
+drops a ``.build_prefix`` marker recording the original configure ``--prefix``
+so this module can assert root != build-prefix without guessing.
+
+Locally (e.g. a darwin dev box) the bundle is absent, so every test skips with a
+reason naming the providing job. The CI job additionally asserts the core
+``CREATE EXTENSION`` test actually ran (``scripts/assert_ca3_ran.py``), so a
+silent all-skip can never masquerade as a pass.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from nexus.db.pg_provision import (
+    NEXUS_DB_NAME,
+    PgBinaries,
+    PgVectorNotInstalledError,
+    ProvisionResult,
+    _port_accepting,
+    check_pgvector_available,
+    discover_pg_binaries,
+    provision,
+)
+
+_IS_DARWIN = sys.platform == "darwin"
+_VECTOR_LIB = "vector.dylib" if _IS_DARWIN else "vector.so"
+
+# Pinned floors for the PACKAGED artifact (must match the CA-3 gate's floors in
+# tests/db/test_pg_provision_ca3_bundle.py). The relocation smoke re-checks them
+# on the extracted libs because the .txz this step uploads is what P3.2/P3.4
+# consume — a floor regression must fail at artifact time, not only at assemble
+# time. The floor is a static property of the shared object (objdump/otool), so
+# it holds even though the linux smoke runs on the host's newer glibc.
+GLIBC_FLOOR: tuple[int, int] = (2, 28)        # manylinux_2_28 baseline (RF-157-9)
+MACOS_MIN_FLOOR: tuple[int, int] = (13, 0)    # macOS 13 Ventura (nexus-0ixqc)
+
+# Pinned PG version (the CI env sets PG_VERSION=17.5). Exact, not a "17." prefix
+# (project rule: exact assertions in regression tests).
+PG_VERSION_PIN = "17.5"
+
+# Substring of the bundle-absence skip reason. assert_ca3_ran.py keys on
+# "no CA-3 bundle"; keep this phrase aligned with that marker so the same
+# non-vacuity asserter guards this relocation smoke too.
+_SKIP_REASON = (
+    "skipped: no CA-3 bundle (relocated) — set NEXUS_PG_BUNDLE_ROOT to a "
+    "PG17+pgvector tree EXTRACTED from its .txz to a dir other than its build "
+    "prefix (provided by the ci.yml 'ca3-pgvector-bundle' relocation step)"
+)
+
+
+def _relocated_root() -> Path | None:
+    """The relocated (extracted) bundle root, or None when not materialized."""
+    raw = os.environ.get("NEXUS_PG_BUNDLE_ROOT", "").strip()
+    if not raw:
+        return None
+    root = Path(raw)
+    return root if (root / "bin" / "initdb").is_file() else None
+
+
+_ROOT = _relocated_root()
+
+pytestmark = [
+    pytest.mark.integration,
+    # Drives PostgreSQL directly via psql; never launches the JVM service jar.
+    pytest.mark.no_service_jar,
+    pytest.mark.skipif(_ROOT is None, reason=_SKIP_REASON),
+]
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def bundle_bin_env():
+    """Point NEXUS_PG_BIN at the relocated bin/, restore on teardown.
+
+    The restore matters: a leaked NEXUS_PG_BIN would make a later pg_provision
+    test in the same invocation resolve the relocated bundle instead of the
+    system PostgreSQL.
+    """
+    assert _ROOT is not None  # guarded by pytestmark
+    old = os.environ.get("NEXUS_PG_BIN")
+    os.environ["NEXUS_PG_BIN"] = str(_ROOT / "bin")
+    try:
+        yield
+    finally:
+        if old is None:
+            os.environ.pop("NEXUS_PG_BIN", None)
+        else:
+            os.environ["NEXUS_PG_BIN"] = old
+
+
+@pytest.fixture(scope="module")
+def bins(bundle_bin_env) -> PgBinaries:
+    """Resolve the relocated binaries via the production NEXUS_PG_BIN seam."""
+    return discover_pg_binaries()
+
+
+@pytest.fixture(scope="module")
+def provisioned(bins: PgBinaries, tmp_path_factory):
+    """Provision a hermetic cluster from the RELOCATED tree."""
+    config_dir = tmp_path_factory.mktemp("nexus_reloc_bundle")
+    old_cfg = os.environ.get("NEXUS_CONFIG_DIR")
+    os.environ["NEXUS_CONFIG_DIR"] = str(config_dir)
+    try:
+        result: ProvisionResult = provision(config_dir, force_new_port=True)
+    finally:
+        if old_cfg is None:
+            os.environ.pop("NEXUS_CONFIG_DIR", None)
+        else:
+            os.environ["NEXUS_CONFIG_DIR"] = old_cfg
+
+    yield result, config_dir
+
+    pgdata = config_dir / "postgres"
+    try:
+        subprocess.run(
+            [str(bins.bin_dir / "pg_ctl"), "-D", str(pgdata), "-m", "immediate", "stop"],
+            capture_output=True, check=False, timeout=10,
+        )
+    except Exception:  # noqa: BLE001 — teardown must not reraise
+        pass
+
+
+def _pg_config(bins: PgBinaries, flag: str) -> str:
+    out = subprocess.run(
+        [str(bins.bin_dir / "pg_config"), flag],
+        capture_output=True, text=True, check=True, timeout=10,
+    )
+    return out.stdout.strip()
+
+
+def _reanchored(bins: PgBinaries, flag: str) -> Path:
+    """A pg_config path re-anchored on the actual ``bin_dir``.
+
+    Mirrors production :func:`nexus.db.pg_provision._candidate_sharedirs`: take
+    the path's offset from ``pg_config --bindir`` and re-apply it to the resolved
+    ``bin_dir``. Robust whether or not pg_config itself relocated.
+    """
+    reported = _pg_config(bins, flag)
+    bindir = _pg_config(bins, "--bindir")
+    rel = os.path.relpath(reported, bindir)
+    return (bins.bin_dir / rel).resolve()
+
+
+def _max_glibc_requirement(so_path: Path) -> tuple[int, int]:
+    """Highest GLIBC_x.y symbol version *required* by an ELF shared object.
+
+    Parses ``objdump -T`` version-reference records. Returns (0, 0) when the
+    object references no versioned glibc symbols (the non-vacuity sentinel).
+    """
+    import re
+    out = subprocess.run(
+        ["objdump", "-T", str(so_path)], capture_output=True, text=True, check=True,
+    )
+    versions = [(int(a), int(b)) for a, b in re.findall(r"GLIBC_(\d+)\.(\d+)", out.stdout)]
+    return max(versions) if versions else (0, 0)
+
+
+def _macos_minos(macho_path: Path) -> tuple[int, int]:
+    """macOS deployment-target (LC_BUILD_VERSION minos) of a Mach-O object.
+
+    Returns (0, 0) when no minos load command is present (non-vacuity sentinel).
+    """
+    import re
+    out = subprocess.run(
+        ["otool", "-l", str(macho_path)], capture_output=True, text=True, check=True,
+    )
+    versions = [(int(a), int(b)) for a, b in re.findall(r"minos (\d+)\.(\d+)", out.stdout)]
+    return max(versions) if versions else (0, 0)
+
+
+# ── Test 1: we genuinely relocated (non-vacuity guard) ──────────────────────────
+
+class TestActuallyRelocated:
+    """Without these, a smoke that accidentally ran at the build prefix would
+    pass without proving relocation — the same vacuity trap CA-3 guards against."""
+
+    def test_root_differs_from_build_prefix(self):
+        """The extracted root must NOT be the original configure --prefix.
+
+        ``scripts/build_pg_bundle.sh`` records the build prefix in a
+        ``.build_prefix`` marker at the bundle root; relocation extracted the
+        tree somewhere else.
+        """
+        assert _ROOT is not None
+        marker = _ROOT / ".build_prefix"
+        assert marker.is_file(), (
+            f"no .build_prefix marker at {marker} — build script must record the "
+            "configure --prefix so relocation is provable"
+        )
+        build_prefix = Path(marker.read_text().strip()).resolve()
+        assert _ROOT.resolve() != build_prefix, (
+            f"relocated root {_ROOT.resolve()} equals the build prefix "
+            f"{build_prefix} — the bundle was NOT relocated, smoke is vacuous"
+        )
+
+    def test_pg_config_resolves_inside_relocated_root(self, bins):
+        """pg_config's reported sharedir must resolve back INSIDE the relocated
+        root. PostgreSQL's relocatable-install support computes support-file
+        paths relative to the executable (find_my_exec), so a tree extracted to
+        a new prefix reports the new location, not the build prefix. This is the
+        positive proof that the bundle's path resolution survived relocation."""
+        assert _ROOT is not None
+        sharedir = Path(_pg_config(bins, "--sharedir")).resolve()
+        root = _ROOT.resolve()
+        assert root == sharedir or root in sharedir.parents, (
+            f"pg_config --sharedir {sharedir} resolved OUTSIDE the relocated root "
+            f"{root} — PostgreSQL did not relocate its support-file paths; the "
+            "tree layout was not preserved by the tarball"
+        )
+
+
+# ── Test 2: complete relocated tree + pgvector present ──────────────────────────
+
+class TestRelocatedBundleComplete:
+    def test_all_binaries_present(self, bins):
+        assert bins.all_present(), (
+            "relocated bundle missing one of initdb/pg_ctl/psql/createdb"
+        )
+
+    def test_reports_exact_pinned_postgres_version(self, bins):
+        out = subprocess.run(
+            [str(bins.bin_dir / "initdb"), "--version"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        assert f"(PostgreSQL) {PG_VERSION_PIN}" in out, (
+            f"expected PostgreSQL {PG_VERSION_PIN}, got: {out.strip()!r}"
+        )
+
+    def test_vector_lib_present_under_root(self, bins):
+        """vector.so/.dylib must live UNDER the relocated root — the relative
+        tree layout (bin/ lib/ share/) survived the tarball round-trip. Uses the
+        bin-relative re-anchoring so it holds regardless of how pg_config reports
+        pkglibdir."""
+        pkglibdir = _reanchored(bins, "--pkglibdir")
+        assert (pkglibdir / _VECTOR_LIB).is_file(), (
+            f"{_VECTOR_LIB} not found under relocated root at {pkglibdir}"
+        )
+
+    def test_pg_trgm_present_under_root(self, bins):
+        """pg_trgm (contrib, required by the RDR-155 schema) must also survive
+        packaging + extraction — not just pgvector. The build verifies it
+        pre-package; this re-verifies the extracted artifact."""
+        sharedir = _reanchored(bins, "--sharedir")
+        control = sharedir / "extension" / "pg_trgm.control"
+        assert control.is_file(), (
+            f"pg_trgm.control not found under relocated root at {control} — "
+            "contrib extension lost in packaging/extraction"
+        )
+
+    def test_preflight_passes_after_relocation(self, bins):
+        """check_pgvector_available must re-anchor and find vector.control under
+        the relocated root despite pg_config's stale sharedir."""
+        try:
+            check_pgvector_available(bins)
+        except PgVectorNotInstalledError as exc:  # pragma: no cover - failure path
+            pytest.fail(
+                f"preflight wrongly reported pgvector missing after relocation: {exc}"
+            )
+
+
+# ── Test 3: the PACKAGED artifact's compat floor is preserved ───────────────────
+
+@pytest.mark.skipif(_IS_DARWIN, reason="GLIBC floor is linux-only; macOS uses TestPackagedMacosFloor")
+class TestPackagedGlibcFloor:
+    """The .txz uploaded by this step is what P3.2/P3.4 consume; re-assert the
+    glibc floor on the EXTRACTED libs so an artifact-boundary regression fails
+    here, not at a downstream user's dlopen on an older distro."""
+
+    def test_vector_so_within_floor(self, bins):
+        so = _reanchored(bins, "--pkglibdir") / "vector.so"
+        required = _max_glibc_requirement(so)
+        assert required > (0, 0), (
+            f"no GLIBC_x.y symbols in {so} — objdump vacuous (wrong file/static link)"
+        )
+        assert required <= GLIBC_FLOOR, (
+            f"vector.so requires GLIBC_{required[0]}.{required[1]} > floor "
+            f"GLIBC_{GLIBC_FLOOR[0]}.{GLIBC_FLOOR[1]} (RF-157-9)"
+        )
+
+    def test_postgres_binary_within_floor(self, bins):
+        required = _max_glibc_requirement(bins.bin_dir / "postgres")
+        assert required > (0, 0), (
+            f"no GLIBC_x.y symbols in {bins.bin_dir / 'postgres'} — objdump vacuous"
+        )
+        assert required <= GLIBC_FLOOR, (
+            f"postgres requires GLIBC_{required[0]}.{required[1]} > floor "
+            f"GLIBC_{GLIBC_FLOOR[0]}.{GLIBC_FLOOR[1]} (RF-157-9)"
+        )
+
+
+@pytest.mark.skipif(not _IS_DARWIN, reason="minos floor is macOS-only; linux uses TestPackagedGlibcFloor")
+class TestPackagedMacosFloor:
+    """Mach-O minos floor on the extracted dylib + server binary — the dyld
+    analog of the glibc floor, re-asserted at artifact time."""
+
+    def test_vector_dylib_within_floor(self, bins):
+        dylib = _reanchored(bins, "--pkglibdir") / "vector.dylib"
+        minos = _macos_minos(dylib)
+        assert minos > (0, 0), (
+            f"no LC_BUILD_VERSION minos in {dylib} — otool vacuous"
+        )
+        assert minos <= MACOS_MIN_FLOOR, (
+            f"vector.dylib requires macOS {minos[0]}.{minos[1]} > floor "
+            f"{MACOS_MIN_FLOOR[0]}.{MACOS_MIN_FLOOR[1]} (nexus-0ixqc)"
+        )
+
+    def test_postgres_binary_within_floor(self, bins):
+        minos = _macos_minos(bins.bin_dir / "postgres")
+        assert minos > (0, 0), (
+            f"no LC_BUILD_VERSION minos in {bins.bin_dir / 'postgres'} — otool vacuous"
+        )
+        assert minos <= MACOS_MIN_FLOOR, (
+            f"postgres requires macOS {minos[0]}.{minos[1]} > floor "
+            f"{MACOS_MIN_FLOOR[0]}.{MACOS_MIN_FLOOR[1]} (nexus-0ixqc)"
+        )
+
+
+# ── Test 4: CREATE EXTENSION vector live from the relocated tree (go/no-go) ─────
+
+class TestCreateExtensionFromRelocated:
+    """The load-bearing assertion: provision a cluster from the RELOCATED bundle
+    and actually LOAD pgvector. Forces dlopen of the shared object from the new
+    location — the failure mode relocation could introduce."""
+
+    def _query(self, bins, port, sql) -> subprocess.CompletedProcess:
+        os_user = os.environ.get("USER") or os.environ.get("LOGNAME") or "postgres"
+        return subprocess.run(
+            [str(bins.bin_dir / "psql"), "-h", "127.0.0.1", "-p", str(port),
+             "-U", os_user, "-d", NEXUS_DB_NAME, "-t", "-A", "-c", sql],
+            capture_output=True, text=True, timeout=30,
+        )
+
+    def test_cluster_accepts_connections(self, provisioned):
+        result, _ = provisioned
+        assert _port_accepting("127.0.0.1", result.port), (
+            f"relocated cluster not accepting connections on {result.port}"
+        )
+
+    def test_create_extension_vector_loads(self, provisioned, bins):
+        result, _ = provisioned
+        proc = self._query(bins, result.port, "CREATE EXTENSION IF NOT EXISTS vector")
+        assert proc.returncode == 0, (
+            "CREATE EXTENSION vector failed — pgvector did not load from the "
+            f"RELOCATED bundle (dlopen/relocation failure):\n{proc.stderr}"
+        )
+
+    def test_vector_type_usable(self, provisioned, bins):
+        result, _ = provisioned
+        self._query(bins, result.port, "CREATE EXTENSION IF NOT EXISTS vector")
+        proc = self._query(
+            bins, result.port,
+            "SELECT '[1,2,3]'::vector <-> '[3,2,1]'::vector",
+        )
+        assert proc.returncode == 0 and proc.stdout.strip(), (
+            f"vector distance op failed after load from relocated tree:\n{proc.stderr}"
+        )


### PR DESCRIPTION
## What

RDR-157 P3.1 (bead nexus-vwvv5.10): generalize the proven CA-3 PostgreSQL-from-source build into a shippable, **relocatable** PG 17.5 + pgvector v0.8.2 + contrib pg_trgm bundle artifact for all three targets `{linux-amd64, linux-arm64, mac-arm64}`, with a CI smoke that extracts the packaged `.txz` to an arbitrary directory and proves it still provisions and loads pgvector.

Re-scoped to **Strategy B** (build complete PG from source) first. Strategy A (zonky reduced bundle + inject pgvector) was empirically falsified by CA-3 / RF-157-9: zonky's `embedded-postgres-binaries` ships only `initdb`/`pg_ctl`/`postgres` — no `pg_config`/`psql`/`createdb`/headers/pgxs — so pgvector cannot be built against it and `pg_provision.PgBinaries.all_present()` cannot discover it.

## Changes

- **`scripts/build_pg_bundle.sh`** (new) — single source of truth for the build. Both CA-3 jobs now call it (no behavior drift). Lean configure flags (`--without-icu/zlib/readline/openssl`), glibc 2.28 (manylinux_2_28) / minos 13.0 (macOS) floors, drops a `.build_prefix` marker for relocation non-vacuity.
- **`tests/db/test_pg_bundle_relocation.py`** (new) — integration-gated (env `NEXUS_PG_BUNDLE_ROOT`). Proves an extracted-elsewhere bundle provisions + `CREATE EXTENSION vector` loads. Asserts the extracted root ≠ build prefix, `pg_config` relocates (via PostgreSQL `find_my_exec`) inside the new root, vector **and** pg_trgm survive the tar round-trip, the packaged artifact's glibc/minos floors hold, and the vector op works live.
- **`.github/workflows/ci.yml`** — both CA-3 jobs package the bundle to `.txz`, extract-relocate, run the relocation smoke, and upload a `nexus-pg-<target>.txz` artifact (consumed by P3.2/P3.4). CA-3 required job contexts **unchanged** (branch protection safe). paths-filter extended with the two new files.

## Validation

- Built PG 17.5 from source locally on macOS, packaged, extracted to a different dir, ran the relocation suite: **12 passed, 2 legitimate platform skips**.
- `scripts/assert_ca3_ran.py` verified to **pass live** (0 bundle-skips) and **fail vacuous** (all-skip → assertion error).
- Stacked review run (code-review-expert + substantive-critic); all Critical/Significant/Medium findings remediated.

## Notes

- `develop` remains unreleasable (RDR-155 P4a); this ships no release.
- Empirical finding: PostgreSQL's `pg_config` **is** relocation-aware (`find_my_exec`); the original "stale path" assumption was falsified and the test asserts the positive (relocated) behavior.

Bead: nexus-vwvv5.10
