### PR TITLE
feat(rdr-157): P3.4 local-distribution first-run PG bundle extraction

### DIFF
--- a/src/nexus/commands/init.py
+++ b/src/nexus/commands/init.py
@@ -285,6 +285,32 @@ def _warmup_bge() -> None:
 # ── P5 (A) Postgres provisioning ──────────────────────────────────────────────
 
 
+def _select_bundled_pg(
+    config_dir: Path, *, search_dirs: list[Path] | None = None
+) -> Path | None:
+    """First-run: extract the ship-alongside PG bundle and select it for provisioning.
+
+    RDR-157 P3.4 (bead nexus-vwvv5.13). When a ``nexus-pg-<platform>.txz`` is
+    locatable (``NEXUS_PG_BUNDLE`` or next to the binary), extract it once under the
+    config dir and point ``NEXUS_PG_BIN`` at it so ``provision`` discovers the
+    bundle's PostgreSQL ahead of any host install. Returns the selected ``bin/`` dir,
+    or ``None`` when no bundle is present (dev / host-PG mode) — in which case
+    discovery proceeds unchanged.
+
+    An explicit pre-existing ``NEXUS_PG_BIN`` wins (operator override / tests): the
+    bundle is not consulted, so a deliberately pointed PG is never overridden.
+    """
+    if os.environ.get("NEXUS_PG_BIN", "").strip():
+        return None
+    from nexus.db.pg_bundle import ensure_pg_bundle
+
+    bin_dir = ensure_pg_bundle(config_dir, search_dirs=search_dirs)
+    if bin_dir is not None:
+        os.environ["NEXUS_PG_BIN"] = str(bin_dir)
+        _log.info("pg_bundle_selected", bin_dir=str(bin_dir))
+    return bin_dir
+
+
 def _provision_postgres_step() -> None:
     """Provision (or verify) the nx-managed local Postgres cluster.
 
@@ -299,6 +325,16 @@ def _provision_postgres_step() -> None:
 
     config_dir = _config.nexus_config_dir()
     click.echo("\nProvisioning local Postgres cluster for the service backend …")
+
+    # First-run local distribution: extract + select the ship-alongside PG bundle
+    # (no-op when none is shipped — host PG is then discovered as before).
+    try:
+        if _select_bundled_pg(config_dir) is not None:
+            click.echo("  Using bundled PostgreSQL (extracted on first run).")
+    except Exception as exc:  # noqa: BLE001 — user-facing, must stay actionable
+        _log.error("pg_bundle_extract_failed", error=str(exc))
+        click.echo(f"\nBundled PostgreSQL extraction failed: {exc}", err=True)
+        raise SystemExit(1)
 
     try:
         result = provision(config_dir)

--- a/src/nexus/db/pg_bundle.py
+++ b/src/nexus/db/pg_bundle.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""First-run extraction of the ship-alongside PostgreSQL bundle (RDR-157 P3.4).
+
+The local distribution ships a ``nexus-pg-<platform>.txz`` next to the native
+binary (CA-2 verdict, bead nexus-vwvv5.11: ship-alongside, not embed). On first
+run nexus locates that archive, extracts it once to a stable cache dir under the
+config directory, and returns the bundle's ``bin/`` directory. The caller exports
+that as ``NEXUS_PG_BIN`` so the existing
+:func:`nexus.db.pg_provision.discover_pg_binaries` /
+:func:`~nexus.db.pg_provision.provision` flow runs unchanged — the bundle is just
+another binary location, selected ahead of host-PG discovery.
+
+Relocation is safe: PostgreSQL resolves ``share``/``lib`` relative to the
+executable via ``find_my_exec``, so the extracted tree works at any prefix (proven
+end to end by ``tests/db/test_pg_bundle_relocation.py``). This module owns only the
+LOCATE + idempotent EXTRACT + SELECT orchestration.
+
+Artifact contract (RDR-157 P3.1, bead nexus-vwvv5.10): the ``.txz`` extracts to a
+``bundle/`` tree containing ``bin/ include/ lib/ share/``; the CI artifact is named
+``nexus-pg-<target>`` for targets ``mac-arm64`` / ``linux-amd64`` / ``linux-arm64``.
+"""
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import sys
+import tarfile
+from pathlib import Path
+
+import structlog
+
+from nexus.db.pg_provision import PgBinaries
+
+_log = structlog.get_logger(__name__)
+
+#: Env override pointing at an explicit ``.txz`` (set by the distribution launcher
+#: or by tests). Highest priority in :func:`locate_bundle_archive`.
+BUNDLE_ENV = "NEXUS_PG_BUNDLE"
+
+#: Marker dropped at the extract root once a complete bundle is materialised, so a
+#: re-run is a cheap no-op rather than a re-extract.
+_EXTRACT_MARKER = ".nx_bundle_extracted"
+
+#: Relocation provenance marker the build (``scripts/build_pg_bundle.sh``) places
+#: at ``bundle/.build_prefix``. Its presence proves the archive is a genuine
+#: relocatable nexus PG bundle rather than an arbitrary tarball.
+_BUILD_PREFIX_MARKER = ".build_prefix"
+
+#: Sub-directory of the config dir the bundle is extracted into.
+_CACHE_SUBDIR = "pg-bundle"
+
+
+def current_platform_tag() -> str:
+    """Return the artifact platform tag for this host (matches ``nexus-pg-<tag>``).
+
+    Release N targets: ``mac-arm64`` (darwin; mac-x64 is out of scope, owner call),
+    ``linux-amd64`` (x86_64), ``linux-arm64`` (aarch64). Windows is release N+1.
+    """
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "darwin":
+        # mac-x64 is out of scope for the bundle (owner call); return its true tag
+        # anyway so locate simply finds no artifact and falls back to host PG,
+        # rather than mislabelling an Intel Mac as mac-arm64.
+        return "mac-arm64" if machine in {"arm64", "aarch64"} else "mac-x64"
+    if system == "linux":
+        return "linux-arm64" if machine in {"aarch64", "arm64"} else "linux-amd64"
+    raise RuntimeError(
+        f"No PostgreSQL bundle target for platform {system!r}/{machine!r} "
+        "(Windows is a release N+1 follow-on)."
+    )
+
+
+def bundle_bin_dir(extract_root: Path) -> Path:
+    """The ``bin/`` directory inside an extracted bundle tree."""
+    return extract_root / "bundle" / "bin"
+
+
+def _build_prefix_marker(extract_root: Path) -> Path:
+    """The ``bundle/.build_prefix`` relocation-provenance marker."""
+    return extract_root / "bundle" / _BUILD_PREFIX_MARKER
+
+
+def is_bundle_extracted(extract_root: Path) -> bool:
+    """True when *extract_root* holds a COMPLETE, marked bundle.
+
+    Requires both the extraction marker AND all four required binaries, so a
+    half-written tree (interrupted extract) is treated as not-extracted and is
+    re-extracted rather than silently used.
+    """
+    marker = extract_root / _EXTRACT_MARKER
+    return marker.is_file() and PgBinaries.from_dir(bundle_bin_dir(extract_root)).all_present()
+
+
+def _default_search_dirs() -> list[Path]:
+    """Conventional locations for the ship-alongside ``.txz`` (best-effort).
+
+    The distribution launcher should set ``NEXUS_PG_BUNDLE`` explicitly; this is
+    the fallback for an archive sitting next to the running executable.
+    """
+    return [Path(sys.executable).resolve().parent]
+
+
+def locate_bundle_archive(*, search_dirs: list[Path] | None = None) -> Path | None:
+    """Find the PG bundle ``.txz`` for this platform.
+
+    Resolution order:
+
+    1. ``NEXUS_PG_BUNDLE`` — an explicit archive path. Set-but-missing is a loud
+       error (a misconfigured override must never silently fall through to a
+       different bundle or to host PG).
+    2. ``nexus-pg-<platform-tag>.txz`` in *search_dirs* (default: the directory of
+       the running executable).
+
+    Returns ``None`` when no bundle is found — the caller then falls back to host
+    PostgreSQL discovery (dev boxes, host-installed PG).
+    """
+    env = os.environ.get(BUNDLE_ENV, "").strip()
+    if env:
+        archive = Path(env)
+        if not archive.is_file():
+            raise FileNotFoundError(
+                f"{BUNDLE_ENV} is set to '{env}' but no such file exists. "
+                f"Fix or unset {BUNDLE_ENV}."
+            )
+        return archive
+
+    name = f"nexus-pg-{current_platform_tag()}.txz"
+    for d in (search_dirs if search_dirs is not None else _default_search_dirs()):
+        candidate = Path(d) / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def extract_bundle(archive: Path, extract_root: Path) -> Path:
+    """Idempotently extract *archive* to *extract_root*; return the ``bin/`` dir.
+
+    A complete prior extraction (marker + all binaries) is a no-op — the existing
+    tree is preserved, so a user-modified or already-provisioned bundle is never
+    clobbered on re-run. A bad archive (incomplete tree) raises ``RuntimeError``
+    and leaves no marker.
+    """
+    bin_dir = bundle_bin_dir(extract_root)
+    if is_bundle_extracted(extract_root):
+        _log.debug("pg_bundle_already_extracted", extract_root=str(extract_root))
+        return bin_dir
+
+    extract_root.mkdir(parents=True, exist_ok=True)
+    _log.info("pg_bundle_extracting", archive=str(archive), extract_root=str(extract_root))
+    try:
+        with tarfile.open(archive, "r:xz") as tf:
+            # filter="data" (3.12+) blocks path traversal / unsafe members.
+            tf.extractall(extract_root, filter="data")
+    except Exception:
+        # Corrupt archive / disk-full / permission error mid-extract leaves a
+        # partial tree. Remove it so a retry starts clean and a half-written tree
+        # is never mistaken for a usable bundle (no marker is written).
+        shutil.rmtree(extract_root, ignore_errors=True)
+        raise
+
+    if not PgBinaries.from_dir(bin_dir).all_present():
+        present = [p.name for p in bin_dir.glob("*")] if bin_dir.is_dir() else []
+        shutil.rmtree(extract_root, ignore_errors=True)
+        raise RuntimeError(
+            f"PG bundle '{archive}' extracted an incomplete tree: "
+            f"missing one or more of initdb/pg_ctl/psql/createdb under "
+            f"{bin_dir} (found: {present or 'none'})."
+        )
+    if not _build_prefix_marker(extract_root).is_file():
+        shutil.rmtree(extract_root, ignore_errors=True)
+        raise RuntimeError(
+            f"PG bundle '{archive}' is missing its '{_BUILD_PREFIX_MARKER}' "
+            "relocation marker — not a genuine nexus PG bundle "
+            "(scripts/build_pg_bundle.sh stamps it at bundle/.build_prefix)."
+        )
+
+    # Atomic marker: write to a temp file then rename, so a kill mid-write never
+    # leaves a truncated marker that a re-run would trust.
+    marker = extract_root / _EXTRACT_MARKER
+    tmp = extract_root / (_EXTRACT_MARKER + ".tmp")
+    tmp.write_text(f"source={archive}\n")
+    tmp.replace(marker)
+    _log.info("pg_bundle_extracted", bin_dir=str(bin_dir))
+    return bin_dir
+
+
+def extracted_bin_dir(config_dir: Path) -> Path | None:
+    """Return the bundle ``bin/`` dir if a COMPLETE bundle is already extracted.
+
+    Cheap, archive-free check of the stable cache location
+    (``<config_dir>/pg-bundle``). Used by
+    :func:`nexus.db.pg_provision.discover_pg_binaries` so EVERY consumer of PG
+    binaries (init, the storage-service daemon's PG-restart path, ``_psql_bin``)
+    finds the bundle on a local-distribution machine — not only the one-shot
+    ``nx init`` process that performed the extraction. Returns ``None`` when no
+    extracted bundle is present (host-PG / dev mode).
+    """
+    extract_root = config_dir / _CACHE_SUBDIR
+    return bundle_bin_dir(extract_root) if is_bundle_extracted(extract_root) else None
+
+
+def ensure_pg_bundle(
+    config_dir: Path, *, search_dirs: list[Path] | None = None
+) -> Path | None:
+    """Locate + extract the ship-alongside PG bundle for first-run provisioning.
+
+    Returns the extracted ``bin/`` directory (to be exported as ``NEXUS_PG_BIN``),
+    or ``None`` when no bundle is present — in which case the caller proceeds with
+    host PostgreSQL discovery (dev / host-installed PG). Idempotent: a second call
+    after a successful extract is a cheap no-op.
+    """
+    archive = locate_bundle_archive(search_dirs=search_dirs)
+    if archive is None:
+        return None
+    return extract_bundle(archive, config_dir / _CACHE_SUBDIR)

--- a/src/nexus/db/pg_provision.py
+++ b/src/nexus/db/pg_provision.py
@@ -180,6 +180,22 @@ def discover_pg_binaries() -> PgBinaries:
             + _install_hint()
         )
 
+    # 1.5. Already-extracted ship-alongside PG bundle under the config dir
+    #      (RDR-157 P3.4, bead nexus-vwvv5.13). This makes EVERY caller —
+    #      not just the one-shot `nx init` process that extracted it — discover
+    #      the bundle on a local-distribution machine, in particular the
+    #      storage-service daemon's PG-restart path (`_ensure_pg_running`).
+    #      Lazy import avoids a pg_bundle <-> pg_provision import cycle.
+    from nexus.config import nexus_config_dir  # local import to avoid circular
+    from nexus.db.pg_bundle import extracted_bin_dir
+
+    bundle_bin = extracted_bin_dir(nexus_config_dir())
+    if bundle_bin is not None:
+        bins = PgBinaries.from_dir(bundle_bin)
+        if bins.all_present():
+            _log.debug("pg_binaries_from_bundle", bin_dir=str(bundle_bin))
+            return bins
+
     # 2. Fixed candidate directories.
     for d in _CANDIDATE_DIRS:
         bins = PgBinaries.from_dir(d)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -791,3 +791,39 @@ def multipage_pdf(pdf_fixtures_dir: Path) -> Path:
 @pytest.fixture(scope="session")
 def type3_pdf(pdf_fixtures_dir: Path) -> Path:
     return pdf_fixtures_dir / "type3_font.pdf"
+
+
+# ── RDR-157 P3.4: synthetic PG bundle factory (bead nexus-vwvv5.13) ─────────────
+
+
+@pytest.fixture
+def make_pg_bundle_txz():
+    """Factory building a synthetic ``nexus-pg-*.txz`` for bundle-extract tests.
+
+    Mirrors the real P3.1 artifact shape: a ``bundle/`` root containing
+    ``bin/{initdb,pg_ctl,psql,createdb}`` (stub executables), ``include/``,
+    ``lib/``, ``share/``, and the ``.build_prefix`` relocation marker that
+    ``scripts/build_pg_bundle.sh`` stamps. Single source of truth so a layout
+    change (e.g. a new required binary) is a one-site edit.
+    """
+    import tarfile
+
+    def _factory(tmp: Path, name: str = "nexus-pg-test.txz", *, with_build_prefix: bool = True) -> Path:
+        staging = tmp / f"_stage_{name}"
+        bundle = staging / "bundle"
+        bin_dir = bundle / "bin"
+        bin_dir.mkdir(parents=True)
+        for b in ("initdb", "pg_ctl", "psql", "createdb"):
+            f = bin_dir / b
+            f.write_text("#!/bin/sh\nexit 0\n")
+            f.chmod(0o755)
+        for sub in ("include", "lib", "share"):
+            (bundle / sub).mkdir()
+        if with_build_prefix:
+            (bundle / ".build_prefix").write_text("/build/prefix/nexus-pg\n")
+        archive = tmp / name
+        with tarfile.open(archive, "w:xz") as tf:
+            tf.add(bundle, arcname="bundle")
+        return archive
+
+    return _factory

--- a/tests/db/test_pg_bundle_extract.py
+++ b/tests/db/test_pg_bundle_extract.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""P3.4 local-distribution first-run bundle extraction (RDR-157, bead nexus-vwvv5.13).
+
+The local distribution ships, ship-alongside (CA-2 verdict, bead nexus-vwvv5.11),
+a ``nexus-pg-<platform>.txz`` next to the native binary. On first run nexus must:
+
+  1. LOCATE that archive (explicit ``NEXUS_PG_BUNDLE`` override, else a
+     conventional ``nexus-pg-<tag>.txz`` in known search dirs),
+  2. EXTRACT it to a stable cache dir under the config dir (idempotently — a
+     re-run must NOT re-extract), and
+  3. SELECT it for provisioning by handing back the bundle's ``bin/`` dir, which
+     the caller exports as ``NEXUS_PG_BIN`` so the existing
+     :func:`nexus.db.pg_provision.discover_pg_binaries` /
+     :func:`~nexus.db.pg_provision.provision` flow runs unchanged.
+
+These are pure filesystem-orchestration tests over a SYNTHETIC bundle (four stub
+binaries under ``bundle/bin`` + the ``.build_prefix`` marker, built by the
+``make_pg_bundle_txz`` fixture in ``tests/conftest.py``); they do not run
+PostgreSQL. The real extract→initdb→provision→``CREATE EXTENSION vector``
+round-trip is proven against a genuine artifact by
+``tests/db/test_pg_bundle_relocation.py``.
+"""
+from __future__ import annotations
+
+import os
+import platform
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from nexus.db import pg_bundle
+from nexus.db.pg_provision import PgBinaries
+
+
+# ── platform tag ────────────────────────────────────────────────────────────────
+
+
+def test_current_platform_tag_matches_ci_artifact_naming() -> None:
+    """The tag must match the CI artifact names (nexus-pg-<tag>.txz)."""
+    tag = pg_bundle.current_platform_tag()
+    sys_name = platform.system().lower()
+    machine = platform.machine().lower()
+    if sys_name == "darwin":
+        assert tag == ("mac-arm64" if machine in {"arm64", "aarch64"} else "mac-x64")
+    elif sys_name == "linux":
+        assert tag == ("linux-arm64" if machine in {"aarch64", "arm64"} else "linux-amd64")
+    # Release-N shipped targets (the only ones with a real artifact).
+    assert tag in {"mac-arm64", "mac-x64", "linux-amd64", "linux-arm64"}
+
+
+# ── locate_bundle_archive ───────────────────────────────────────────────────────
+
+
+def test_locate_via_explicit_env_override(tmp_path, monkeypatch, make_pg_bundle_txz) -> None:
+    archive = make_pg_bundle_txz(tmp_path, "nexus-pg-mac-arm64.txz")
+    monkeypatch.setenv(pg_bundle.BUNDLE_ENV, str(archive))
+    assert pg_bundle.locate_bundle_archive() == archive
+
+
+def test_locate_env_override_missing_fails_loud(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv(pg_bundle.BUNDLE_ENV, str(tmp_path / "nope.txz"))
+    with pytest.raises(FileNotFoundError, match=pg_bundle.BUNDLE_ENV):
+        pg_bundle.locate_bundle_archive()
+
+
+def test_locate_via_conventional_name_in_search_dir(tmp_path, monkeypatch, make_pg_bundle_txz) -> None:
+    monkeypatch.delenv(pg_bundle.BUNDLE_ENV, raising=False)
+    tag = pg_bundle.current_platform_tag()
+    archive = make_pg_bundle_txz(tmp_path, f"nexus-pg-{tag}.txz")
+    assert pg_bundle.locate_bundle_archive(search_dirs=[tmp_path]) == archive
+
+
+def test_locate_returns_none_when_absent(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv(pg_bundle.BUNDLE_ENV, raising=False)
+    assert pg_bundle.locate_bundle_archive(search_dirs=[tmp_path]) is None
+
+
+def test_locate_ignores_wrong_platform_archive(tmp_path, monkeypatch, make_pg_bundle_txz) -> None:
+    """A bundle for a different platform must not be picked up by convention."""
+    monkeypatch.delenv(pg_bundle.BUNDLE_ENV, raising=False)
+    tag = pg_bundle.current_platform_tag()
+    other = "linux-amd64" if tag != "linux-amd64" else "mac-arm64"
+    make_pg_bundle_txz(tmp_path, f"nexus-pg-{other}.txz")
+    assert pg_bundle.locate_bundle_archive(search_dirs=[tmp_path]) is None
+
+
+# ── extract_bundle ──────────────────────────────────────────────────────────────
+
+
+def test_extract_bundle_returns_bin_dir_with_all_binaries(tmp_path, make_pg_bundle_txz) -> None:
+    archive = make_pg_bundle_txz(tmp_path)
+    extract_root = tmp_path / "cache"
+    bin_dir = pg_bundle.extract_bundle(archive, extract_root)
+    assert bin_dir == pg_bundle.bundle_bin_dir(extract_root)
+    assert PgBinaries.from_dir(bin_dir).all_present()
+    assert (extract_root / "bundle" / ".build_prefix").is_file()
+
+
+def test_extract_bundle_is_idempotent_no_reextract(tmp_path, make_pg_bundle_txz) -> None:
+    archive = make_pg_bundle_txz(tmp_path)
+    extract_root = tmp_path / "cache"
+    bin_dir = pg_bundle.extract_bundle(archive, extract_root)
+    # Stamp a sentinel inside the extracted tree; a re-extract would wipe it.
+    sentinel = bin_dir / "initdb"
+    sentinel.write_text("MUTATED-BY-TEST\n")
+    again = pg_bundle.extract_bundle(archive, extract_root)
+    assert again == bin_dir
+    assert sentinel.read_text() == "MUTATED-BY-TEST\n", "re-extract clobbered an existing tree"
+
+
+def test_extract_bundle_incomplete_tree_fails_loud(tmp_path) -> None:
+    """A .txz missing required binaries must raise, not return a broken bin dir."""
+    staging = tmp_path / "_bad"
+    (staging / "bundle" / "bin").mkdir(parents=True)
+    (staging / "bundle" / "bin" / "initdb").write_text("only one\n")  # missing 3
+    (staging / "bundle" / ".build_prefix").write_text("/x\n")
+    archive = tmp_path / "nexus-pg-bad.txz"
+    with tarfile.open(archive, "w:xz") as tf:
+        tf.add(staging / "bundle", arcname="bundle")
+    extract_root = tmp_path / "cache"
+    with pytest.raises(RuntimeError, match="incomplete|missing"):
+        pg_bundle.extract_bundle(archive, extract_root)
+    # Partial tree removed so a retry starts clean.
+    assert not extract_root.exists()
+
+
+def test_extract_bundle_missing_build_prefix_fails_loud(tmp_path, make_pg_bundle_txz) -> None:
+    """A tarball without the .build_prefix relocation marker is rejected."""
+    archive = make_pg_bundle_txz(tmp_path, "nexus-pg-noprefix.txz", with_build_prefix=False)
+    with pytest.raises(RuntimeError, match="build_prefix|relocation"):
+        pg_bundle.extract_bundle(archive, tmp_path / "cache")
+
+
+def test_is_bundle_extracted_reflects_state(tmp_path, make_pg_bundle_txz) -> None:
+    archive = make_pg_bundle_txz(tmp_path)
+    extract_root = tmp_path / "cache"
+    assert pg_bundle.is_bundle_extracted(extract_root) is False
+    pg_bundle.extract_bundle(archive, extract_root)
+    assert pg_bundle.is_bundle_extracted(extract_root) is True
+
+
+# ── ensure_pg_bundle orchestration ──────────────────────────────────────────────
+
+
+def test_ensure_returns_none_without_bundle(tmp_path, monkeypatch) -> None:
+    """No bundle locatable → None (host-PG / dev mode, provision discovers normally)."""
+    monkeypatch.delenv(pg_bundle.BUNDLE_ENV, raising=False)
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    assert pg_bundle.ensure_pg_bundle(config_dir, search_dirs=[tmp_path / "empty"]) is None
+
+
+def test_ensure_extracts_under_config_dir_and_returns_bin(tmp_path, monkeypatch, make_pg_bundle_txz) -> None:
+    archive = make_pg_bundle_txz(tmp_path, "nexus-pg-mac-arm64.txz")
+    monkeypatch.setenv(pg_bundle.BUNDLE_ENV, str(archive))
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    bin_dir = pg_bundle.ensure_pg_bundle(config_dir)
+    assert bin_dir is not None
+    # Extracted under the config dir, not next to the archive.
+    assert str(bin_dir).startswith(str(config_dir))
+    assert PgBinaries.from_dir(bin_dir).all_present()
+
+
+def test_ensure_is_idempotent(tmp_path, monkeypatch, make_pg_bundle_txz) -> None:
+    archive = make_pg_bundle_txz(tmp_path, "nexus-pg-mac-arm64.txz")
+    monkeypatch.setenv(pg_bundle.BUNDLE_ENV, str(archive))
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    first = pg_bundle.ensure_pg_bundle(config_dir)
+    assert first is not None
+    sentinel = first / "psql"
+    sentinel.write_text("KEEP\n")
+    second = pg_bundle.ensure_pg_bundle(config_dir)
+    assert second == first
+    assert sentinel.read_text() == "KEEP\n"
+
+
+def test_extracted_bin_dir_finds_already_extracted(tmp_path, monkeypatch, make_pg_bundle_txz) -> None:
+    """The archive-free discovery helper used by discover_pg_binaries."""
+    archive = make_pg_bundle_txz(tmp_path, "nexus-pg-mac-arm64.txz")
+    monkeypatch.setenv(pg_bundle.BUNDLE_ENV, str(archive))
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    assert pg_bundle.extracted_bin_dir(config_dir) is None  # not yet extracted
+    bin_dir = pg_bundle.ensure_pg_bundle(config_dir)
+    assert pg_bundle.extracted_bin_dir(config_dir) == bin_dir  # found, no archive needed
+
+
+def test_discover_pg_binaries_finds_bundle_without_env(tmp_path, monkeypatch, make_pg_bundle_txz) -> None:
+    """Critical (substantive-critic, P3.4): the daemon's PG-restart path calls
+    discover_pg_binaries() in a SEPARATE process from `nx init`, so it cannot rely
+    on the transient NEXUS_PG_BIN set during extraction. discover_pg_binaries must
+    find the already-extracted bundle via the config dir with NO env set.
+    """
+    import nexus.db.pg_provision as pgp
+
+    archive = make_pg_bundle_txz(tmp_path, "nexus-pg-mac-arm64.txz")
+    monkeypatch.setenv(pg_bundle.BUNDLE_ENV, str(archive))
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    bin_dir = pg_bundle.ensure_pg_bundle(config_dir)
+    assert bin_dir is not None
+
+    # Simulate the daemon process: no NEXUS_PG_BIN, config dir points at the
+    # extracted bundle, and NO host PG on the candidate dirs/PATH would match
+    # these stub binaries anyway.
+    monkeypatch.delenv("NEXUS_PG_BIN", raising=False)
+    monkeypatch.delenv(pg_bundle.BUNDLE_ENV, raising=False)
+    # discover_pg_binaries does a local `from nexus.config import nexus_config_dir`,
+    # so patch it at the source module.
+    monkeypatch.setattr("nexus.config.nexus_config_dir", lambda: config_dir)
+
+    bins = pgp.discover_pg_binaries()
+    assert bins.bin_dir == bin_dir
+
+
+# ── Integration: real artifact (gated on NEXUS_PG_BUNDLE pointing at a .txz) ─────
+
+
+@pytest.mark.integration
+def test_ensure_real_bundle_discovers_and_has_pgvector(tmp_path, monkeypatch) -> None:
+    """First-run orchestration end to end on a GENUINE artifact.
+
+    Gated on ``NEXUS_PG_BUNDLE`` pointing at a real ``nexus-pg-<plat>.txz`` (the
+    P3.1 CI artifact). Proves the NEW locate→extract→select path: the extracted
+    bundle's binaries are discoverable via ``NEXUS_PG_BIN`` and pgvector's
+    ``vector.control`` resolves (re-anchored on the relocated bin dir). The full
+    extract→initdb→provision→``CREATE EXTENSION`` round-trip is covered by
+    ``test_pg_bundle_relocation.py``.
+    """
+    from nexus.db.pg_provision import (
+        check_pgvector_available,
+        discover_pg_binaries,
+    )
+
+    archive = os.environ.get("NEXUS_PG_BUNDLE", "").strip()
+    if not archive or not Path(archive).is_file():
+        pytest.skip("no NEXUS_PG_BUNDLE .txz artifact (provided by the CA-3 bundle job)")
+
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    monkeypatch.delenv("NEXUS_PG_BIN", raising=False)
+
+    bin_dir = pg_bundle.ensure_pg_bundle(config_dir)
+    assert bin_dir is not None
+    assert PgBinaries.from_dir(bin_dir).all_present()
+    assert (bin_dir.parent / ".build_prefix").is_file()
+
+    monkeypatch.setenv("NEXUS_PG_BIN", str(bin_dir))
+    bins = discover_pg_binaries()
+    assert bins.bin_dir == bin_dir
+    check_pgvector_available(bins)  # raises if pgvector is not loadable from the bundle

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -12,6 +12,8 @@ cloud credentials and ``is_local_mode()`` defaults to True there
 """
 from __future__ import annotations
 
+import os
+
 from pathlib import Path
 
 import pytest
@@ -598,3 +600,77 @@ def _wrap(fn):
         fn()
 
     return _cmd
+
+
+# ── RDR-157 P3.4: first-run bundled-PG selection (bead nexus-vwvv5.13) ──────────
+
+
+def test_select_bundled_pg_sets_env_from_bundle(tmp_path, monkeypatch, make_pg_bundle_txz) -> None:
+    from nexus.commands.init import _select_bundled_pg
+    from nexus.db import pg_bundle
+
+    monkeypatch.delenv("NEXUS_PG_BIN", raising=False)
+    archive = make_pg_bundle_txz(tmp_path, "nexus-pg-x.txz")
+    monkeypatch.setenv(pg_bundle.BUNDLE_ENV, str(archive))
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+
+    bin_dir = _select_bundled_pg(config_dir)
+
+    assert bin_dir is not None
+    assert os.environ["NEXUS_PG_BIN"] == str(bin_dir)
+    assert str(bin_dir).startswith(str(config_dir))
+
+
+def test_select_bundled_pg_none_without_bundle(tmp_path, monkeypatch) -> None:
+    from nexus.commands.init import _select_bundled_pg
+    from nexus.db import pg_bundle
+
+    monkeypatch.delenv("NEXUS_PG_BIN", raising=False)
+    monkeypatch.delenv(pg_bundle.BUNDLE_ENV, raising=False)
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+
+    # Deterministic: explicit empty search dir (no reliance on what sits next to
+    # the test interpreter).
+    result = _select_bundled_pg(config_dir, search_dirs=[tmp_path / "empty"])
+    assert result is None
+    assert not os.environ.get("NEXUS_PG_BIN")
+
+
+def test_select_bundled_pg_respects_existing_env_override(tmp_path, monkeypatch, make_pg_bundle_txz) -> None:
+    from nexus.commands.init import _select_bundled_pg
+    from nexus.db import pg_bundle
+
+    # Operator already pointed NEXUS_PG_BIN somewhere -> bundle not consulted.
+    monkeypatch.setenv("NEXUS_PG_BIN", "/opt/my/pg/bin")
+    archive = make_pg_bundle_txz(tmp_path, "nexus-pg-y.txz")
+    monkeypatch.setenv(pg_bundle.BUNDLE_ENV, str(archive))
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+
+    assert _select_bundled_pg(config_dir) is None
+    assert os.environ["NEXUS_PG_BIN"] == "/opt/my/pg/bin"
+
+
+def test_provision_step_aborts_loud_on_broken_bundle(tmp_path, monkeypatch) -> None:
+    """M2: a set-but-missing NEXUS_PG_BUNDLE must SystemExit(1), never reach provision."""
+    import nexus.commands.init as init_mod
+    from nexus.db import pg_bundle
+
+    monkeypatch.delenv("NEXUS_PG_BIN", raising=False)
+    monkeypatch.setenv(pg_bundle.BUNDLE_ENV, str(tmp_path / "does-not-exist.txz"))
+    monkeypatch.setattr(init_mod._config, "nexus_config_dir", lambda: tmp_path / "cfg")
+
+    called = {"provision": False}
+
+    def _fail_if_called(*a, **k):  # provision must NOT run when the bundle is broken
+        called["provision"] = True
+        raise AssertionError("provision() must not be reached on a broken bundle")
+
+    monkeypatch.setattr("nexus.db.pg_provision.provision", _fail_if_called)
+
+    with pytest.raises(SystemExit) as exc:
+        init_mod._provision_postgres_step()
+    assert exc.value.code == 1
+    assert called["provision"] is False


### PR DESCRIPTION
## What

RDR-157 P3.4 (bead `nexus-vwvv5.13`): the **local distribution** first-run path. The PG bundle ships ship-alongside (CA-2 verdict, `nexus-vwvv5.11`) as `nexus-pg-<platform>.txz`. On first run nexus **locates → extracts (once, idempotently) → selects** it for provisioning, then the existing `provision()` flow runs unchanged.

## New module `src/nexus/db/pg_bundle.py`

- `current_platform_tag()` — `mac-arm64` / `mac-x64` / `linux-amd64` / `linux-arm64`.
- `locate_bundle_archive()` — `NEXUS_PG_BUNDLE` override (set-but-missing **fails loud**), else conventional `nexus-pg-<tag>.txz` in search dirs.
- `extract_bundle()` — path-traversal-safe (`filter="data"`), validates all four binaries **and** the `.build_prefix` relocation marker, cleans the partial tree on any failure, writes its completion marker **atomically**.
- `ensure_pg_bundle()` / `extracted_bin_dir()` — orchestration + archive-free discovery.

## Wiring

- `init.py` `_provision_postgres_step` extracts+selects the bundle before `provision()` (no-op when none shipped → host PG as before); an explicit `NEXUS_PG_BIN` always wins.
- `discover_pg_binaries()` now consults the extracted bundle under the config dir (after `NEXUS_PG_BIN`, before fixed candidates). **Shared-primitive fix:** every caller — init, the daemon's `_ensure_pg_running` PG-restart path, `_psql_bin` — finds the bundle on a bundle-only machine, not just the one-shot `nx init` process.

## Scope boundary

The full `extract → initdb → provision → CREATE EXTENSION` round-trip is proven against a genuine artifact by `tests/db/test_pg_bundle_relocation.py` (P3.1). This change owns the **locate/extract/select orchestration**; an integration test (gated on `NEXUS_PG_BUNDLE`) exercises it against a real artifact, validated locally on mac-arm64.

## Review

Stacked review (code-review-expert + substantive-critic) run to **round-2 clean**. Round-1 surfaced a Critical — the daemon PG-restart path runs in a separate process and could not see the transient `NEXUS_PG_BIN` — now closed by the `discover_pg_binaries()` shared-primitive fix and verified by a targeted test (`test_discover_pg_binaries_finds_bundle_without_env`). Round-1 Highs (extractall cleanup, non-deterministic test), Mediums (atomic marker, abort-path test, helper dedup), and the mac-x64 tag / `.build_prefix` validation all remediated.

Bead: `nexus-vwvv5.13`. Feeds the P3 stacked review (`nexus-vwvv5.14`).
