### PR TITLE
ci(rdr-160): prime + cache bge-768 ONNX for the native smoke

### DIFF
--- a/.github/workflows/engine-service-release.yml
+++ b/.github/workflows/engine-service-release.yml
@@ -111,28 +111,30 @@ jobs:
           distribution: 'graalvm'
           cache: 'maven'
 
-      - name: Cache ChromaDB ONNX model
-        # The service constructs the ONNX embedder at startup (NX_EMBED_MODE=onnx),
-        # loading all-MiniLM-L6-v2 from ~/.cache/chroma — the native smoke needs it.
+      - name: Cache bge-768 ONNX model
+        # RDR-160: in local mode the native binary constructs Bge768Embedder,
+        # which loads the STANDARD fp32 bge-base-en-v1.5 ONNX from ~/.cache/nexus
+        # (NOT MiniLM, NOT fastembed's fused optimized export) — the native smoke
+        # needs it. STABLE key (immutable upstream export): one cold download per
+        # arch, restored thereafter; bump -v only if the model source changes.
         uses: actions/cache@v4
         with:
-          path: ~/.cache/chroma
-          key: chromadb-onnx-${{ runner.os }}-${{ matrix.target.arch }}-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            chromadb-onnx-${{ runner.os }}-${{ matrix.target.arch }}-
+          path: ~/.cache/nexus/onnx_models/bge-base-en-v1.5
+          key: bge-onnx-standard-${{ runner.os }}-${{ matrix.target.arch }}-v1
 
-      - name: Prime ONNX model on cache miss
+      - name: Prime bge-768 ONNX on cache miss
         run: |
-          MODEL_DIR="$HOME/.cache/chroma/onnx_models/all-MiniLM-L6-v2"
-          if [ ! -f "$MODEL_DIR/onnx/model.onnx" ]; then
-            echo "ONNX model not in cache; downloading."
+          MODEL_DIR="$HOME/.cache/nexus/onnx_models/bge-base-en-v1.5/onnx"
+          if [ ! -f "$MODEL_DIR/model.onnx" ]; then
+            echo "bge ONNX not in cache; downloading the standard fp32 export (~416MB)."
             mkdir -p "$MODEL_DIR"
-            curl -fsSL https://chroma-onnx-models.s3.amazonaws.com/all-MiniLM-L6-v2/onnx.tar.gz \
-              -o /tmp/onnx.tar.gz
-            tar -xzf /tmp/onnx.tar.gz -C "$MODEL_DIR"
-            test -f "$MODEL_DIR/onnx/model.onnx" || { echo "model.onnx missing after extract"; exit 1; }
+            curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/onnx/model.onnx \
+              -o "$MODEL_DIR/model.onnx"
+            curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/tokenizer.json \
+              -o "$MODEL_DIR/tokenizer.json"
+            test -f "$MODEL_DIR/model.onnx" || { echo "bge model.onnx missing after download"; exit 1; }
           else
-            echo "ONNX model restored from cache."
+            echo "bge ONNX restored from cache."
           fi
 
       - name: Resolve engine-service version
@@ -279,10 +281,12 @@ jobs:
             "base must have glibc >= that (conexus uses debian:trixie-slim = 2.41);" \
             "deploy/engine/build-image.sh enforces this via objdump." \
             "" \
-            "ONNX model NOT bundled — the binary loads all-MiniLM-L6-v2 from the" \
-            "filesystem at runtime. Before building the runtime image, stage it:" \
-            "  mkdir -p ~/.cache/chroma/onnx_models/all-MiniLM-L6-v2/onnx" \
-            "  curl -fsSL https://chroma-onnx-models.s3.amazonaws.com/all-MiniLM-L6-v2/onnx.tar.gz | tar -xz -C ~/.cache/chroma/onnx_models/all-MiniLM-L6-v2" \
+            "ONNX model NOT bundled (RDR-160) — in local mode the binary loads the" \
+            "STANDARD fp32 bge-base-en-v1.5 ONNX from the filesystem at runtime." \
+            "Before building the runtime image, stage it (or run nx init --service):" \
+            "  MODEL_DIR=~/.cache/nexus/onnx_models/bge-base-en-v1.5/onnx; mkdir -p \$MODEL_DIR" \
+            "  curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/onnx/model.onnx -o \$MODEL_DIR/model.onnx" \
+            "  curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/tokenizer.json -o \$MODEL_DIR/tokenizer.json" \
             "" \
             "Provenance: sha256 only for now; cosign/Sigstore signing tracked for N+1." \
             > notes.md

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -68,6 +68,31 @@ jobs:
             echo "ONNX model restored from cache."
           fi
 
+      - name: Cache bge-768 ONNX model
+        # RDR-160: Bge768ParityTest (the parity go/no-go gate) loads the STANDARD
+        # fp32 bge ONNX; priming it here makes the gate RUN on CI instead of
+        # skipping. STABLE key (immutable upstream export) — one cold download,
+        # restored thereafter, shared with the native-smoke job.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/nexus/onnx_models/bge-base-en-v1.5
+          key: bge-onnx-standard-${{ runner.os }}-v1
+
+      - name: Prime bge-768 ONNX on cache miss
+        run: |
+          MODEL_DIR="$HOME/.cache/nexus/onnx_models/bge-base-en-v1.5/onnx"
+          if [ ! -f "$MODEL_DIR/model.onnx" ]; then
+            echo "bge ONNX not in cache; downloading the standard fp32 export (~416MB)."
+            mkdir -p "$MODEL_DIR"
+            curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/onnx/model.onnx \
+              -o "$MODEL_DIR/model.onnx"
+            curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/tokenizer.json \
+              -o "$MODEL_DIR/tokenizer.json"
+            test -f "$MODEL_DIR/model.onnx" || { echo "bge model.onnx missing after download"; exit 1; }
+          else
+            echo "bge ONNX restored from cache."
+          fi
+
       # jOOQ codegen now runs INSIDE the build (bead nexus-9qvam): the
       # testcontainers-jooq-codegen-maven-plugin generates into
       # target/generated-sources/jooq at the generate-sources phase from the
@@ -104,25 +129,31 @@ jobs:
           distribution: 'graalvm'
           cache: 'maven'
 
-      - name: Cache ChromaDB ONNX model
-        # The service initializes the ONNX embedder at startup (NX_EMBED_MODE=onnx),
-        # loading all-MiniLM-L6-v2 from ~/.cache/chroma — the native smoke needs it.
+      - name: Cache bge-768 ONNX model
+        # RDR-160: in local mode the native binary constructs Bge768Embedder,
+        # which loads the STANDARD fp32 bge-base-en-v1.5 ONNX from
+        # ~/.cache/nexus (NOT MiniLM, NOT fastembed's fused optimized export).
+        # STABLE key — the model is an immutable upstream export, so it
+        # downloads ONCE on a cold cache and restores on every later run; bump
+        # the -v suffix only if the model SOURCE changes.
         uses: actions/cache@v4
         with:
-          path: ~/.cache/chroma
-          key: chromadb-onnx-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            chromadb-onnx-${{ runner.os }}-
+          path: ~/.cache/nexus/onnx_models/bge-base-en-v1.5
+          key: bge-onnx-standard-${{ runner.os }}-v1
 
-      - name: Prime ONNX model on cache miss
+      - name: Prime bge-768 ONNX on cache miss
         run: |
-          MODEL_DIR="$HOME/.cache/chroma/onnx_models/all-MiniLM-L6-v2"
-          if [ ! -f "$MODEL_DIR/onnx/model.onnx" ]; then
+          MODEL_DIR="$HOME/.cache/nexus/onnx_models/bge-base-en-v1.5/onnx"
+          if [ ! -f "$MODEL_DIR/model.onnx" ]; then
+            echo "bge ONNX not in cache; downloading the standard fp32 export (~416MB)."
             mkdir -p "$MODEL_DIR"
-            curl -fsSL https://chroma-onnx-models.s3.amazonaws.com/all-MiniLM-L6-v2/onnx.tar.gz \
-              -o /tmp/onnx.tar.gz
-            tar -xzf /tmp/onnx.tar.gz -C "$MODEL_DIR"
-            test -f "$MODEL_DIR/onnx/model.onnx" || { echo "model.onnx missing after extract"; exit 1; }
+            curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/onnx/model.onnx \
+              -o "$MODEL_DIR/model.onnx"
+            curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/tokenizer.json \
+              -o "$MODEL_DIR/tokenizer.json"
+            test -f "$MODEL_DIR/model.onnx" || { echo "bge model.onnx missing after download"; exit 1; }
+          else
+            echo "bge ONNX restored from cache."
           fi
 
       - name: Build native image


### PR DESCRIPTION
Follow-up to RDR-160 (PR #1202, merged). The native-image smoke check is not a required check, so #1202 auto-merged on the required checks (pytest/Java/CA-3) passing before this CI fix landed — leaving develop's native smoke red.

After RDR-160 the native binary embeds local collections with bge-768 (Bge768Embedder), not MiniLM, so the native-smoke job's eager local-mode boot fail-loud-crashes when only MiniLM is primed (model not found at the bge path). This primes + caches the STANDARD fp32 bge ONNX at ~/.cache/nexus/... (the Java DEFAULT_MODEL_PATH).

Caching: STABLE key (`bge-onnx-standard-<os>[-<arch>]-v1`), independent of uv.lock — the model is an immutable upstream export, so it downloads ONCE on a cold cache and restores on every later run.

- service-ci.yml: native-smoke job MiniLM→bge; also prime bge in the Java-test job so Bge768ParityTest (the parity go/no-go gate) RUNS on CI instead of skipping (MiniLM prime kept for the OnnxEmbedder tests).
- engine-service-release.yml: matrixed native-smoke prime → bge; release-notes staging hint updated to the bge CDN URLs.
