### PR TITLE
feat(rdr-160): nx doctor warns when the service bge-768 model is missing (nexus-gzqvg)

### DIFF
--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -382,10 +382,17 @@ def _check_service_bge_model() -> list[HealthResult]:
     return [HealthResult(
         label="Service embedder (bge-768)",
         ok=False,
-        fatal=True,
+        # SOFT warn, not fatal: this is the "surface it earlier" advisory. The
+        # HARD gate is the Bge768Embedder boot preflight. A fatal here would
+        # (a) red-X doctor for a mid-setup user who has pg_credentials but has
+        # not provisioned/started the service yet, and (b) stack a third fatal
+        # on top of _check_vector_service / _check_storage_service_health when the
+        # service is simply down — noise, not signal.
+        warn=True,
         detail=(
             f"the local Java service embeds with bge-768 but its ONNX is missing "
-            f"or incomplete at {model_dir} — the service will fail to boot"
+            f"or incomplete at {model_dir} — the service will not boot until it is "
+            f"provisioned"
         ),
         fix_suggestions=[
             "Provision it: nx init --service",

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -343,6 +343,58 @@ def _check_t3_local() -> list[HealthResult]:
     return results
 
 
+def _check_service_bge_model() -> list[HealthResult]:
+    """RDR-160 (nexus-gzqvg): surface a missing/incomplete bge-768 service model.
+
+    In local mode the Java service embeds every collection with bge-768 and reads
+    the STANDARD fp32 ONNX from a fixed path; without it the service fail-loud-
+    crashes at boot (the {@code Bge768Embedder} preflight), which is opaque if you
+    have not seen it before. ``nx doctor`` surfaces the gap earlier.
+
+    Gated on SERVICE mode (``pg_credentials`` present) because only the Java
+    service reads this file: a pure-Python local install uses the fastembed cache,
+    and cloud mode embeds server-side via Voyage. Called from the local-mode
+    branch of :func:`run_health_checks`, so cloud mode never reaches it. Returns
+    ``[]`` (no output) when this is not a service install.
+
+    ``service_bge_model_present()`` applies the same size floors as provisioning,
+    so a truncated download or a quantized/fused substitute reads as "incomplete"
+    and is flagged, not silently accepted.
+    """
+    from nexus.config import nexus_config_dir
+    from nexus.db.pg_provision import CREDENTIALS_FILENAME
+
+    if not (nexus_config_dir() / CREDENTIALS_FILENAME).exists():
+        return []  # not a service install — the Java service is what reads this model
+
+    from nexus.db.service_bge_model import (
+        service_bge_model_dir,
+        service_bge_model_present,
+    )
+
+    model_dir = service_bge_model_dir()
+    if service_bge_model_present():
+        return [HealthResult(
+            label="Service embedder (bge-768)",
+            ok=True,
+            detail=f"standard ONNX present at {model_dir}",
+        )]
+    return [HealthResult(
+        label="Service embedder (bge-768)",
+        ok=False,
+        fatal=True,
+        detail=(
+            f"the local Java service embeds with bge-768 but its ONNX is missing "
+            f"or incomplete at {model_dir} — the service will fail to boot"
+        ),
+        fix_suggestions=[
+            "Provision it: nx init --service",
+            "Or stage the STANDARD fp32 export (Xenova/bge-base-en-v1.5 model.onnx "
+            "+ tokenizer.json — NOT fastembed's model_optimized.onnx) at that path.",
+        ],
+    )]
+
+
 def _check_vector_service() -> HealthResult:
     """Reachability probe for the pgvector-backed vector serving surface.
 
@@ -2038,6 +2090,7 @@ def run_health_checks() -> tuple[list[HealthResult], bool]:
     _local = is_local_mode()
     if _local:
         results.extend(_check_t3_local())
+        results.extend(_check_service_bge_model())
         results.extend(_check_t3_daemon_version())
     else:
         results.extend(_check_t3_cloud())

--- a/tests/test_health_service_checks.py
+++ b/tests/test_health_service_checks.py
@@ -742,3 +742,57 @@ class TestRlsTableCompleteness:
         assert "nexus.memory" in missing, (
             "Expected cross-walk to detect nexus.memory as missing from impl"
         )
+
+
+# ── RDR-160 nexus-gzqvg: service bge-768 model doctor check ────────────────────
+
+
+class TestServiceBgeModelCheck:
+    """`_check_service_bge_model` — fires ONLY for a local service install."""
+
+    def _setup(self, tmp_path, monkeypatch, *, creds: bool, model: bool, truncated: bool = False):
+        from nexus.db import service_bge_model as sbm
+
+        cfg = tmp_path / "cfg"
+        cfg.mkdir()
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(cfg))
+        if creds:
+            (cfg / "pg_credentials").write_text("PG_PORT=15432\n")
+
+        bge = tmp_path / "bge"
+        monkeypatch.setenv("NX_SERVICE_BGE_DIR", str(bge))
+        monkeypatch.setattr(sbm, "_MIN_MODEL_BYTES", 4)
+        monkeypatch.setattr(sbm, "_MIN_TOKENIZER_BYTES", 1)
+        if model:
+            bge.mkdir(parents=True)
+            (bge / "model.onnx").write_bytes(b"x" if truncated else b"MODEL")
+            (bge / "tokenizer.json").write_bytes(b"T")
+
+    def test_not_service_install_returns_nothing(self, tmp_path, monkeypatch):
+        from nexus.health import _check_service_bge_model
+        self._setup(tmp_path, monkeypatch, creds=False, model=False)
+        assert _check_service_bge_model() == []
+
+    def test_service_with_model_present_ok(self, tmp_path, monkeypatch):
+        from nexus.health import _check_service_bge_model
+        self._setup(tmp_path, monkeypatch, creds=True, model=True)
+        res = _check_service_bge_model()
+        assert len(res) == 1
+        assert res[0].ok is True
+        assert "present" in res[0].detail
+
+    def test_service_with_model_missing_is_fatal_with_remedy(self, tmp_path, monkeypatch):
+        from nexus.health import _check_service_bge_model
+        self._setup(tmp_path, monkeypatch, creds=True, model=False)
+        res = _check_service_bge_model()
+        assert len(res) == 1
+        assert res[0].ok is False and res[0].fatal is True
+        assert "will fail to boot" in res[0].detail
+        assert any("nx init --service" in s for s in res[0].fix_suggestions)
+
+    def test_service_with_truncated_model_is_flagged(self, tmp_path, monkeypatch):
+        # below the size floor → "incomplete", treated as not-present
+        from nexus.health import _check_service_bge_model
+        self._setup(tmp_path, monkeypatch, creds=True, model=True, truncated=True)
+        res = _check_service_bge_model()
+        assert len(res) == 1 and res[0].ok is False and res[0].fatal is True

--- a/tests/test_health_service_checks.py
+++ b/tests/test_health_service_checks.py
@@ -781,13 +781,15 @@ class TestServiceBgeModelCheck:
         assert res[0].ok is True
         assert "present" in res[0].detail
 
-    def test_service_with_model_missing_is_fatal_with_remedy(self, tmp_path, monkeypatch):
+    def test_service_with_model_missing_is_soft_warn_with_remedy(self, tmp_path, monkeypatch):
+        # SOFT warn (not fatal): surfaces the gap without red-X-ing doctor for a
+        # mid-setup user; the Bge768Embedder boot preflight is the hard gate.
         from nexus.health import _check_service_bge_model
         self._setup(tmp_path, monkeypatch, creds=True, model=False)
         res = _check_service_bge_model()
         assert len(res) == 1
-        assert res[0].ok is False and res[0].fatal is True
-        assert "will fail to boot" in res[0].detail
+        assert res[0].ok is False and res[0].warn is True and res[0].fatal is False
+        assert "will not boot" in res[0].detail
         assert any("nx init --service" in s for s in res[0].fix_suggestions)
 
     def test_service_with_truncated_model_is_flagged(self, tmp_path, monkeypatch):
@@ -795,4 +797,10 @@ class TestServiceBgeModelCheck:
         from nexus.health import _check_service_bge_model
         self._setup(tmp_path, monkeypatch, creds=True, model=True, truncated=True)
         res = _check_service_bge_model()
-        assert len(res) == 1 and res[0].ok is False and res[0].fatal is True
+        assert len(res) == 1 and res[0].ok is False and res[0].warn is True
+
+    def test_present_model_is_not_fatal_or_warn(self, tmp_path, monkeypatch):
+        from nexus.health import _check_service_bge_model
+        self._setup(tmp_path, monkeypatch, creds=True, model=True)
+        res = _check_service_bge_model()
+        assert res[0].ok is True and res[0].fatal is False and res[0].warn is False


### PR DESCRIPTION
Follow-up from RDR-160 P3 review (nexus-gzqvg). A local `--service` install whose bge-768 ONNX is missing or incomplete previously only surfaced the problem when the Java service fail-loud-crashed at boot. `nx doctor` now flags it earlier.

## What's here
`_check_service_bge_model` in `nexus/health.py`:
- Gated on **service mode** (`pg_credentials` present) and runs only in the local-mode branch of `run_health_checks`, so it never fires for a pure-Python local install (which uses the fastembed cache, not the Java-read path) or for cloud mode (server-side Voyage).
- Reuses `service_bge_model_present()`, so a truncated download or a quantized/fused substitute reads as "incomplete" and is flagged (size-floor proxy; the Java boot preflight remains the hard gate).
- **Soft warn** (`ok=False, warn=True`), not fatal: it surfaces the gap without red-X-ing doctor for a mid-setup user, and avoids stacking a third fatal on top of `_check_vector_service` / `_check_storage_service_health` when the service is simply down. OK when the standard ONNX is present.

## Review
Stacked (code-review-expert + substantive-critic): 0 critical. The critic's severity-calibration finding (fatal overstated) is applied here (fatal → soft warn). Adjacent `local_embedder_advisory`-vs-service-mode confusion filed as `nexus-ybw87`.

## Tests
5 new in `TestServiceBgeModelCheck` (not-service / present / missing-soft-warn / truncated / present-not-fatal-not-warn); 57 doctor_cmd tests green.

Closes nexus-gzqvg.
