### PR TITLE
fix(rdr-160): suppress Python local-embedder surface in nx doctor service mode (nexus-ybw87)

### DIFF
--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -282,23 +282,42 @@ def _check_t3_local() -> list[HealthResult]:
             detail=f"{local_path} (will be created on first index)",
         ))
 
+    # Service mode (pg_credentials present) reshapes the Python local-embedder
+    # surface below (nexus-ybw87): a --service install embeds T3 server-side in
+    # the Java service (bge-768, reported authoritatively by
+    # _check_service_bge_model). The Python LocalEmbeddingFunction here only
+    # serves T1/local-Python paths, NOT T3 — so we qualify its label and suppress
+    # the T3-framed upgrade advisory, which would otherwise contradict the
+    # service-embedder result on the very next line.
+    from nexus.config import local_embed_model_choice, nexus_config_dir
+    from nexus.db.pg_provision import CREDENTIALS_FILENAME
+
+    _service_mode = (nexus_config_dir() / CREDENTIALS_FILENAME).exists()
+
     # Embedding model
     from nexus.db.local_ef import LocalEmbeddingFunction
     ef = LocalEmbeddingFunction()
-    results.append(
-        HealthResult(
-            label="Embedding model", ok=True, detail=f"{ef.model_name} ({ef.dimensions}d)"
-        )
-    )
+    if _service_mode:
+        results.append(HealthResult(
+            label="Embedding model (local Python / T1)", ok=True,
+            detail=f"{ef.model_name} ({ef.dimensions}d) — T3 embeds server-side "
+                   f"via the bge-768 service",
+        ))
+    else:
+        results.append(HealthResult(
+            label="Embedding model", ok=True,
+            detail=f"{ef.model_name} ({ef.dimensions}d)",
+        ))
 
     # RDR-144 P5a: config-aware upgrade / degradation advisory. Replaces the
     # old unconditional minilm nudge (which pestered users who explicitly
     # chose 384 and never caught the chose-bge-but-extra-missing degrade).
-    from nexus.config import local_embed_model_choice
-
-    advisory = local_embedder_advisory(local_embed_model_choice(), ef.model_name)
-    if advisory is not None:
-        results.append(advisory)
+    # Suppressed in service mode (see above): the advisory is about the Python
+    # local embedder, which does not serve a service user's T3.
+    if not _service_mode:
+        advisory = local_embedder_advisory(local_embed_model_choice(), ef.model_name)
+        if advisory is not None:
+            results.append(advisory)
 
     # Collection count + legacy-store disk usage.
     #

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -238,6 +238,46 @@ def test_check_t3_local_surfaces_state2_degraded_bge(tmp_path, monkeypatch) -> N
     assert "bge-768" in joined and "384" in joined
 
 
+def test_check_t3_local_suppresses_advisory_in_service_mode(tmp_path, monkeypatch) -> None:
+    """nexus-ybw87: a --service install (pg_credentials present) embeds T3
+    server-side in the Java service, so the PYTHON local-embedder advisory is
+    suppressed even when it would otherwise fire (State-2 degraded-bge here) —
+    it reflects fastembed, which does not serve a service user's T3.
+    """
+    from nexus.db.local_ef import _TIER0_MODEL, _TIER1_MODEL
+    from nexus.health import _check_t3_local
+
+    cfg = tmp_path / "cfg"
+    cfg.mkdir()
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(cfg))
+    (cfg / "pg_credentials").write_text("PG_PORT=15432\n")  # service mode configured
+
+    monkeypatch.setattr(
+        "nexus.config._default_local_path", lambda: tmp_path / "does_not_exist"
+    )
+    # Would normally trigger the State-2 degraded-bge advisory:
+    monkeypatch.setattr("nexus.config.local_embed_model_choice", lambda: _TIER1_MODEL)
+
+    class _FakeEF:
+        model_name = _TIER0_MODEL
+        dimensions = 384
+
+    monkeypatch.setattr(
+        "nexus.db.local_ef.LocalEmbeddingFunction", lambda *a, **k: _FakeEF()
+    )
+
+    results = _check_t3_local()
+    assert not any(r.label == "Local embedder" for r in results), (
+        "Python local-embedder advisory must be suppressed for a service install"
+    )
+    # The Python EF line is relabeled so it does not read as the T3 embedder
+    # (which is the bge-768 service, reported by _check_service_bge_model).
+    assert not any(r.label == "Embedding model" for r in results)
+    ef_line = next((r for r in results if r.label.startswith("Embedding model")), None)
+    assert ef_line is not None and "T1" in ef_line.label
+    assert "server-side" in ef_line.detail
+
+
 # ── _check_t3_daemon_version (RDR-149 nexus-ymn76) ───────────────────────────
 
 


### PR DESCRIPTION
Follow-up from the RDR-160 gzqvg review (a substantive-critic Observation). For a local `--service` install, T3 embedding is server-side in the Java service (bge-768, reported authoritatively by `_check_service_bge_model`). The Python `LocalEmbeddingFunction` that `nx doctor` surfaces serves only T1/local-Python paths, not T3 — so its output contradicted the service-embedder result.

## What's here (`_check_t3_local`, service-mode gated on `pg_credentials`)
- **Advisory suppressed in service mode:** `local_embedder_advisory`'s "upgrade to bge-768" / "you fell back to 384" nudges are irrelevant when the service embeds T3 server-side, and directly contradicted the bge-768 service line.
- **Info line relabeled:** "Embedding model" → "Embedding model (local Python / T1)" with a "T3 embeds server-side via the bge-768 service" note, so it no longer reads as the active T3 embedder (addresses the review's M1).

Both use the same `pg_credentials` service-mode sentinel as `_check_service_bge_model` (computed once). Non-service behavior is unchanged.

## Review & tests
code-review-expert: approved, 0 critical (M1 — the info-line relabel — folded in here rather than deferred). The design is the substantive-critic's own prior recommendation. New `test_check_t3_local_suppresses_advisory_in_service_mode` (advisory absent + relabel) + the existing non-service State-2 advisory test still green. 116 health/advisory/doctor tests pass.

Closes nexus-ybw87.
