### PR TITLE
feat(rdr-001): nx doctor probes a managed endpoint for version compat (nexus-o6fch)

### DIFF
--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -484,7 +484,7 @@ def _check_managed_service_probe() -> list[HealthResult]:
         caps = probe_managed_service(base_url=base)
     except ManagedServiceIncompatible as exc:
         return [HealthResult(
-            label="Managed service (version)",
+            label="Managed/remote service (version)",
             ok=False,
             warn=True,
             detail=str(exc),
@@ -497,14 +497,14 @@ def _check_managed_service_probe() -> list[HealthResult]:
         # Unreachable — _check_vector_service owns the fatal reachability signal;
         # stay soft here to avoid a double-report on a down endpoint.
         return [HealthResult(
-            label="Managed service (version)",
+            label="Managed/remote service (version)",
             ok=False,
             warn=True,
             detail=str(exc),
             fix_suggestions=["Confirm NX_SERVICE_URL is reachable (see the vector-service check)."],
         )]
     return [HealthResult(
-        label="Managed service (version)",
+        label="Managed/remote service (version)",
         ok=True,
         detail=f"{caps.base_url} — app_version {caps.app_version} (mode {caps.embedding_mode})",
     )]

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -452,12 +452,71 @@ def _check_vector_service() -> HealthResult:
         )
 
 
+def _check_managed_service_probe() -> list[HealthResult]:
+    """RDR-001 (nexus-o6fch): version-compatibility probe of a MANAGED endpoint.
+
+    Runs ONLY when ``NX_SERVICE_URL`` is explicitly set — the unambiguous "I have
+    pointed the client at a specific managed endpoint" signal. It deliberately
+    NEVER defaults to ``https://api.conexus-nexus.com``: a local-service-in-cloud-
+    mode user (``NX_SERVICE_URL`` unset, endpoint lease-discovered on localhost)
+    must not be probed against the public managed endpoint.
+
+    Complements :func:`_check_vector_service` (which probes
+    ``/v1/vectors/collections`` for reachability + auth): this adds the
+    unauthenticated ``/version`` handshake → app_version COMPATIBILITY, which
+    reachability alone misses (a reachable-but-incompatible managed service). SOFT
+    warn only — reachability fatals are ``_check_vector_service``'s domain, so this
+    surfaces the version/remedy signal without a duplicate fatal on a down service.
+    """
+    import os
+
+    base = os.environ.get("NX_SERVICE_URL", "").strip()
+    if not base:
+        return []  # no explicit managed endpoint — never default-probe the public one
+
+    from nexus.db.managed_endpoint import (
+        ManagedServiceError,
+        ManagedServiceIncompatible,
+        probe_managed_service,
+    )
+
+    try:
+        caps = probe_managed_service(base_url=base)
+    except ManagedServiceIncompatible as exc:
+        return [HealthResult(
+            label="Managed service (version)",
+            ok=False,
+            warn=True,
+            detail=str(exc),
+            fix_suggestions=[
+                "Align the managed-service and nx-client versions, or correct "
+                "NX_SERVICE_URL.",
+            ],
+        )]
+    except ManagedServiceError as exc:
+        # Unreachable — _check_vector_service owns the fatal reachability signal;
+        # stay soft here to avoid a double-report on a down endpoint.
+        return [HealthResult(
+            label="Managed service (version)",
+            ok=False,
+            warn=True,
+            detail=str(exc),
+            fix_suggestions=["Confirm NX_SERVICE_URL is reachable (see the vector-service check)."],
+        )]
+    return [HealthResult(
+        label="Managed service (version)",
+        ok=True,
+        detail=f"{caps.base_url} — app_version {caps.app_version} (mode {caps.embedding_mode})",
+    )]
+
+
 def _check_t3_cloud() -> list[HealthResult]:
     from nexus.config import get_credential
 
     results: list[HealthResult] = []
     results.append(HealthResult(label="T3 mode", ok=True, detail="cloud"))
     results.append(_check_vector_service())
+    results.extend(_check_managed_service_probe())
 
     # CHROMA_API_KEY
     chroma_key = get_credential("chroma_api_key")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -350,6 +350,32 @@ class TestManagedServiceProbeCheck:
         from nexus.health import _check_managed_service_probe
         assert _check_managed_service_probe() == []
 
+    def test_whitespace_service_url_does_not_probe(self, monkeypatch):
+        monkeypatch.setenv("NX_SERVICE_URL", "   ")
+        from nexus.health import _check_managed_service_probe
+        assert _check_managed_service_probe() == []
+
+    def test_probes_explicit_url_never_the_public_default(self, monkeypatch):
+        # SAFETY INVARIANT: the probe receives the EXPLICIT NX_SERVICE_URL, never
+        # base_url=None (which would default to https://api.conexus-nexus.com).
+        monkeypatch.setenv("NX_SERVICE_URL", "https://staging.example.com")
+        from nexus.db import managed_endpoint as me
+
+        seen = {}
+        caps = me.ManagedCapabilities(
+            base_url="https://staging.example.com", app_version="1.0",
+            embedding_mode="voyage", embedding_models=[],
+            schema_latest_id=None, schema_changeset_count=None,
+        )
+
+        def _capture(**kw):
+            seen.update(kw)
+            return caps
+        monkeypatch.setattr(me, "probe_managed_service", _capture)
+        from nexus.health import _check_managed_service_probe
+        _check_managed_service_probe()
+        assert seen.get("base_url") == "https://staging.example.com"
+
     def test_compatible_is_ok(self, monkeypatch):
         monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com")
         from nexus.db import managed_endpoint as me

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -336,3 +336,56 @@ def test_check_t3_daemon_version_mismatch_warns(monkeypatch) -> None:
     assert r.ok is False and r.warn is True and r.fatal is False
     assert "0.0.1-stale" in r.detail
     assert any("daemon t3" in s for s in r.fix_suggestions)
+
+
+# ── _check_managed_service_probe (RDR-001 nexus-o6fch) ───────────────────────
+
+
+class TestManagedServiceProbeCheck:
+    """Doctor cloud-branch probe of a MANAGED endpoint — only when NX_SERVICE_URL
+    is explicitly set (never default-probes the public api.conexus-nexus.com)."""
+
+    def test_no_service_url_does_not_probe(self, monkeypatch):
+        monkeypatch.delenv("NX_SERVICE_URL", raising=False)
+        from nexus.health import _check_managed_service_probe
+        assert _check_managed_service_probe() == []
+
+    def test_compatible_is_ok(self, monkeypatch):
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com")
+        from nexus.db import managed_endpoint as me
+
+        caps = me.ManagedCapabilities(
+            base_url="https://api.conexus-nexus.com", app_version="1.0-SNAPSHOT",
+            embedding_mode="voyage", embedding_models=[],
+            schema_latest_id="vectors-002", schema_changeset_count=64,
+        )
+        monkeypatch.setattr(me, "probe_managed_service", lambda **kw: caps)
+        from nexus.health import _check_managed_service_probe
+        res = _check_managed_service_probe()
+        assert len(res) == 1 and res[0].ok is True
+        assert "1.0-SNAPSHOT" in res[0].detail
+
+    def test_incompatible_is_soft_warn(self, monkeypatch):
+        monkeypatch.setenv("NX_SERVICE_URL", "https://x")
+        from nexus.db import managed_endpoint as me
+
+        def _boom(**kw):
+            raise me.ManagedServiceIncompatible("app_version 0.9.0 below minimum 1.0.0")
+        monkeypatch.setattr(me, "probe_managed_service", _boom)
+        from nexus.health import _check_managed_service_probe
+        res = _check_managed_service_probe()
+        assert len(res) == 1
+        assert res[0].ok is False and res[0].warn is True and res[0].fatal is False
+        assert "0.9.0" in res[0].detail
+
+    def test_unreachable_is_soft_warn_not_double_fatal(self, monkeypatch):
+        # reachability fatal is _check_vector_service's domain — stay soft here
+        monkeypatch.setenv("NX_SERVICE_URL", "https://x")
+        from nexus.db import managed_endpoint as me
+
+        def _boom(**kw):
+            raise me.ManagedServiceUnreachable("unreachable")
+        monkeypatch.setattr(me, "probe_managed_service", _boom)
+        from nexus.health import _check_managed_service_probe
+        res = _check_managed_service_probe()
+        assert len(res) == 1 and res[0].ok is False and res[0].warn is True and res[0].fatal is False


### PR DESCRIPTION
RDR-001 follow-up `nexus-o6fch`. `probe_managed_service()` existed but nothing called it automatically, so a misconfigured managed endpoint only failed opaquely at the first /v1 call. `nx doctor`'s cloud branch now runs it.

## What's here
`_check_managed_service_probe` (wired into `_check_t3_cloud`):
- Gated on **`NX_SERVICE_URL` explicitly set** — the unambiguous "I pointed the client at a managed endpoint" signal. It **never** defaults to `https://api.conexus-nexus.com`, so a local-service-in-cloud-mode user (NX_SERVICE_URL unset, endpoint lease-discovered on localhost) is never probed against the public endpoint (the exact worry that deferred this from vwvv5.12 S1).
- Complements `_check_vector_service` (reachability + auth on `/v1/vectors/collections`) by adding the unauthenticated `/version` handshake → **app_version compatibility**, which reachability alone misses.
- **Soft warn** only — reachability fatals are `_check_vector_service`'s domain; this surfaces the version/remedy signal without a duplicate fatal on a down endpoint.

## Scope split
The bead also asked for a fail-loud probe **at first cloud-mode use** (hot path). That is split to **`nexus-kf679`**: a `/version` probe in `http_vector_client._resolve_endpoint` (per-op) would fire for the 11 `NX_SERVICE_URL`-setting test files (several do real T3 ops) and break stub-backed ones, plus add per-process latency — it needs its own one-time-gated design. The doctor check here + `nx service probe` cover proactive verification meanwhile.

## Review & tests
Stacked (code-review-expert + substantive-critic): 0 critical. Applied S2 (relabel "Managed" → "Managed/remote" for explicit local URLs), M1 (test the base_url-passthrough safety invariant — never `base_url=None`), L1 (whitespace url gates out); O1 already handled by split except-blocks. 6 `TestManagedServiceProbeCheck` tests + doctor_cmd green.

Closes nexus-o6fch (doctor wiring); startup-probe tracked as nexus-kf679.
