### PR TITLE
feat(rdr-001): reframe managed-endpoint failures with a remedy at first /v1 use (nexus-kf679)

### DIFF
--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -208,6 +208,26 @@ def _request(
         return _request_once(method, path, tenant=tenant, timeout=timeout, body=body)
 
 
+def _managed_remedy() -> str | None:
+    """Remedy text when the client is pointed at an EXPLICIT managed endpoint.
+
+    RDR-001 (nexus-kf679): a misconfigured managed-cloud endpoint otherwise fails
+    at the first /v1 call with a bare connection error / HTTP 401 and no guidance.
+    When ``NX_SERVICE_URL`` is explicitly set we reframe that failure with an
+    actionable remedy. Returns ``None`` for the local/lease topology
+    (``NX_SERVICE_URL`` unset) so a local user's transient errors are NEVER
+    reframed as a managed-service problem — and their error type/flow is unchanged.
+    """
+    base = os.environ.get("NX_SERVICE_URL", "").strip()
+    if not base:
+        return None
+    return (
+        f"the managed nexus service at {base} could not be reached/authenticated "
+        "— check NX_SERVICE_URL is reachable and NX_SERVICE_TOKEN is valid "
+        "(verify with `nx service probe` or `nx doctor`)."
+    )
+
+
 def _post(path: str, body: dict, *, tenant: str = "default", timeout: int = 120) -> Any:
     """POST JSON to the service endpoint, return parsed response body.
 
@@ -229,9 +249,19 @@ def _post(path: str, body: dict, *, tenant: str = "default", timeout: int = 120)
             err = json.loads(body_bytes)
         except Exception:
             err = {"error": body_bytes.decode(errors="replace")}
-        raise VectorServiceError(
-            f"POST {path} → HTTP {e.code}: {err.get('error', err)}", code=e.code
-        ) from e
+        msg = f"POST {path} → HTTP {e.code}: {err.get('error', err)}"
+        remedy = _managed_remedy() if e.code in (401, 403) else None
+        if remedy:
+            msg += f"\n{remedy}"
+        raise VectorServiceError(msg, code=e.code) from e
+    except (urllib.error.URLError, ConnectionError, TimeoutError) as e:
+        # Connection-level failure (bad/unreachable endpoint). Reframe with a
+        # remedy ONLY for an explicit managed endpoint; local/lease users keep
+        # the original error and flow unchanged.
+        remedy = _managed_remedy()
+        if remedy is None:
+            raise
+        raise VectorServiceError(f"POST {path} failed: {e}\n{remedy}") from e
 
 
 def _get(path: str, *, tenant: str = "default") -> Any:
@@ -246,9 +276,16 @@ def _get(path: str, *, tenant: str = "default") -> Any:
             err = json.loads(body_bytes)
         except Exception:
             err = {"error": body_bytes.decode(errors="replace")}
-        raise VectorServiceError(
-            f"GET {path} → HTTP {e.code}: {err.get('error', err)}", code=e.code
-        ) from e
+        msg = f"GET {path} → HTTP {e.code}: {err.get('error', err)}"
+        remedy = _managed_remedy() if e.code in (401, 403) else None
+        if remedy:
+            msg += f"\n{remedy}"
+        raise VectorServiceError(msg, code=e.code) from e
+    except (urllib.error.URLError, ConnectionError, TimeoutError) as e:
+        remedy = _managed_remedy()
+        if remedy is None:
+            raise
+        raise VectorServiceError(f"GET {path} failed: {e}\n{remedy}") from e
 
 
 class VectorServiceError(RuntimeError):

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -197,6 +197,9 @@ def _request(
     # participate in retry classification. RuntimeError from an unresolvable
     # endpoint propagates untouched — fail-loud must never become a retry.
     except (urllib.error.URLError, ConnectionRefusedError, ConnectionResetError) as exc:
+        # TimeoutError is intentionally NOT in this retry classifier (it is not an
+        # auto-restart signature); it propagates straight to the _get/_post handler,
+        # which reframes it for managed endpoints (nexus-kf679).
         if not _is_retryable_endpoint_error(exc):
             raise
         _log.info(
@@ -217,6 +220,17 @@ def _managed_remedy() -> str | None:
     actionable remedy. Returns ``None`` for the local/lease topology
     (``NX_SERVICE_URL`` unset) so a local user's transient errors are NEVER
     reframed as a managed-service problem — and their error type/flow is unchanged.
+
+    Note: a managed-cloud user with ``NX_SERVICE_URL`` UNSET is not a silent dead
+    zone — there is no local supervisor lease to discover, so
+    :func:`_resolve_endpoint` fails loud first ("export NX_SERVICE_URL / TOKEN")
+    before any request reaches here. This reframing covers the set-but-wrong case.
+
+    Exception-type note: for an explicit managed endpoint, connection-level errors
+    (URLError/ConnectionError/TimeoutError) are surfaced by :func:`_get`/:func:`_post`
+    as :class:`VectorServiceError` (``code=None``) rather than the raw urllib/OSError
+    — callers that classify transient failures by raw type should catch
+    ``VectorServiceError`` for the managed path. Local callers are unaffected.
     """
     base = os.environ.get("NX_SERVICE_URL", "").strip()
     if not base:

--- a/tests/db/test_http_vector_client.py
+++ b/tests/db/test_http_vector_client.py
@@ -982,12 +982,39 @@ class TestManagedFailureReframe:
         assert "api.conexus-nexus.com" in str(exc.value)
         assert "nx service probe" in str(exc.value)
 
-    def test_connection_error_local_unchanged(self, monkeypatch):
-        # NX_SERVICE_URL unset → local/lease topology → original error propagates
-        # unchanged (NOT reframed as a managed VectorServiceError).
-        import urllib.error
+    def test_post_403_managed_appends_remedy(self, monkeypatch):
+        import nexus.db.http_vector_client as hv
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com")
+        monkeypatch.setattr(hv, "_request", lambda *a, **k: (_ for _ in ()).throw(self._http_error(403)))
+        with pytest.raises(VectorServiceError) as exc:
+            hv._post("/v1/vectors/search", {})
+        assert exc.value.code == 403
+        assert "NX_SERVICE_TOKEN" in str(exc.value)
+
+    def test_post_401_local_no_remedy(self, monkeypatch):
+        # NX_SERVICE_URL unset: 401 still raises VectorServiceError(code=401) but
+        # WITHOUT a managed remedy (a local user isn't told to check a managed URL).
         import nexus.db.http_vector_client as hv
         monkeypatch.delenv("NX_SERVICE_URL", raising=False)
-        monkeypatch.setattr(hv, "_request", lambda *a, **k: (_ for _ in ()).throw(urllib.error.URLError("refused")))
-        with pytest.raises(urllib.error.URLError):
+        monkeypatch.setattr(hv, "_request", lambda *a, **k: (_ for _ in ()).throw(self._http_error(401)))
+        with pytest.raises(VectorServiceError) as exc:
+            hv._post("/v1/vectors/search", {})
+        assert exc.value.code == 401
+        assert "NX_SERVICE_TOKEN" not in str(exc.value)
+
+    @pytest.mark.parametrize("err", ["urlerror", "connection", "timeout"])
+    def test_connection_error_local_unchanged(self, monkeypatch, err):
+        # NX_SERVICE_URL unset → local/lease topology → original error propagates
+        # unchanged (NOT reframed as a managed VectorServiceError), for every
+        # connection-level family the managed path would otherwise wrap.
+        import urllib.error
+        import nexus.db.http_vector_client as hv
+        exc_obj = {
+            "urlerror": urllib.error.URLError("refused"),
+            "connection": ConnectionError("refused"),
+            "timeout": TimeoutError("timed out"),
+        }[err]
+        monkeypatch.delenv("NX_SERVICE_URL", raising=False)
+        monkeypatch.setattr(hv, "_request", lambda *a, **k: (_ for _ in ()).throw(exc_obj))
+        with pytest.raises(type(exc_obj)):
             hv._get("/v1/vectors/collections")

--- a/tests/db/test_http_vector_client.py
+++ b/tests/db/test_http_vector_client.py
@@ -936,3 +936,58 @@ class TestServiceModeDefault:
 
         monkeypatch.setenv("NX_STORAGE_BACKEND_VECTORS", "chroma")
         assert is_vector_service_mode() is False
+
+
+# ── RDR-001 nexus-kf679: managed-endpoint failure reframing ───────────────────
+
+
+class TestManagedFailureReframe:
+    """First-use failures against an EXPLICIT managed endpoint (NX_SERVICE_URL set)
+    are reframed with an actionable remedy; the local/lease topology is unchanged."""
+
+    def _http_error(self, code: int, body: bytes = b'{"error":"x"}'):
+        import io
+        import urllib.error
+        return urllib.error.HTTPError(
+            url="http://svc/v1/x", code=code, msg="err", hdrs={},
+            fp=io.BytesIO(body),
+        )
+
+    def test_post_401_managed_appends_remedy(self, monkeypatch):
+        import nexus.db.http_vector_client as hv
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com")
+        monkeypatch.setattr(hv, "_request", lambda *a, **k: (_ for _ in ()).throw(self._http_error(401)))
+        with pytest.raises(VectorServiceError) as exc:
+            hv._post("/v1/vectors/search", {})
+        assert exc.value.code == 401
+        assert "NX_SERVICE_TOKEN" in str(exc.value)
+        assert "api.conexus-nexus.com" in str(exc.value)
+
+    def test_post_500_managed_no_remedy(self, monkeypatch):
+        import nexus.db.http_vector_client as hv
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com")
+        monkeypatch.setattr(hv, "_request", lambda *a, **k: (_ for _ in ()).throw(self._http_error(500)))
+        with pytest.raises(VectorServiceError) as exc:
+            hv._post("/v1/vectors/search", {})
+        assert exc.value.code == 500
+        assert "NX_SERVICE_TOKEN" not in str(exc.value)  # remedy only for auth failures
+
+    def test_get_connection_error_managed_reframed(self, monkeypatch):
+        import urllib.error
+        import nexus.db.http_vector_client as hv
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com")
+        monkeypatch.setattr(hv, "_request", lambda *a, **k: (_ for _ in ()).throw(urllib.error.URLError("refused")))
+        with pytest.raises(VectorServiceError) as exc:
+            hv._get("/v1/vectors/collections")
+        assert "api.conexus-nexus.com" in str(exc.value)
+        assert "nx service probe" in str(exc.value)
+
+    def test_connection_error_local_unchanged(self, monkeypatch):
+        # NX_SERVICE_URL unset → local/lease topology → original error propagates
+        # unchanged (NOT reframed as a managed VectorServiceError).
+        import urllib.error
+        import nexus.db.http_vector_client as hv
+        monkeypatch.delenv("NX_SERVICE_URL", raising=False)
+        monkeypatch.setattr(hv, "_request", lambda *a, **k: (_ for _ in ()).throw(urllib.error.URLError("refused")))
+        with pytest.raises(urllib.error.URLError):
+            hv._get("/v1/vectors/collections")


### PR DESCRIPTION
RDR-001 follow-up `nexus-kf679` (split from o6fch). A misconfigured managed-cloud endpoint previously failed at the first /v1 call with a bare connection error or HTTP 401 and no guidance. The T3 HTTP layer now reframes those failures with an actionable remedy.

## Approach: catch-and-enrich (chosen over a proactive probe)
No extra round-trip on the happy path, no change to endpoint RESOLUTION (resolution tests untouched), activates only on a real failure. A proactive /version probe in `_resolve_endpoint` was rejected — that function's contract is to resolve, not verify, and a probe there would break resolution tests + add latency.

## What's here (`_get`/`_post`)
- HTTP **401/403** → append the remedy to `VectorServiceError`; other HTTP codes unchanged.
- Connection-level errors (`URLError`/`ConnectionError`/`TimeoutError`) → reframed as `VectorServiceError` with the remedy **only when `NX_SERVICE_URL` is explicitly set** (managed topology); for the local/lease topology the original error type and flow are **unchanged**.

## Gating safety
`_managed_remedy()` returns `None` when `NX_SERVICE_URL` is unset, so a local user is never told to check a managed endpoint. A managed user with `NX_SERVICE_URL` unset is not a dead zone — `_resolve_endpoint` already fails loud requiring it.

## Review & tests
Stacked (code-review-expert + substantive-critic): 0 critical. Documented the gating/exception-type semantics (S1/S2), commented the TimeoutError retry exclusion (M1), and added tests for 403-managed, 401-local-no-remedy, and local-unchanged across all three connection-error families (S3/L1/M2). 8 reframe tests + 91 client/discovery/migrate tests green.

The doctor check (#1206) + `nx service probe` remain the proactive surfaces; this is the reactive fail-loud-with-remedy at actual first use.

Closes nexus-kf679.
