### PR TITLE
fix(rdr-157): P3.2 stacked-review findings (nexus-vwvv5.14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,16 @@ jobs:
           # -C parent + basename preserves the relative bin/ lib/ share/ layout
           # that relocation depends on.
           tar -cJf "$txz" -C "$(dirname "$bundle")" "$(basename "$bundle")"
+          # CA-2 ship-alongside regression tripwire (nexus-vwvv5.11): the verdict
+          # rests on a small bundle (~5.74 MB compressed). A configure-flag change
+          # or new contrib module that doubled it would invalidate the rationale
+          # silently. Ceiling is generous head-room, not a tight bound.
+          sz=$(wc -c < "$txz")
+          echo "bundle .txz size: $sz bytes"
+          if [ "$sz" -gt $((10 * 1024 * 1024)) ]; then
+            echo "::error::nexus-pg bundle .txz is $sz bytes (> 10 MiB) — CA-2 ship-alongside size assumption breached"
+            exit 1
+          fi
           reloc="$RUNNER_TEMP/relocated"
           mkdir -p "$reloc"
           tar -xJf "$txz" -C "$reloc"
@@ -378,6 +388,15 @@ jobs:
           bundle="$GITHUB_WORKSPACE/bundle"
           txz="$RUNNER_TEMP/nexus-pg-mac-arm64.txz"
           tar -cJf "$txz" -C "$(dirname "$bundle")" "$(basename "$bundle")"
+          # CA-2 ship-alongside regression tripwire (nexus-vwvv5.11): see the
+          # linux job for rationale. Generous 10 MiB ceiling over the ~5.74 MB
+          # current bundle.
+          sz=$(wc -c < "$txz")
+          echo "bundle .txz size: $sz bytes"
+          if [ "$sz" -gt $((10 * 1024 * 1024)) ]; then
+            echo "::error::nexus-pg bundle .txz is $sz bytes (> 10 MiB) — CA-2 ship-alongside size assumption breached"
+            exit 1
+          fi
           reloc="$RUNNER_TEMP/relocated"
           mkdir -p "$reloc"
           tar -xJf "$txz" -C "$reloc"

--- a/src/nexus/db/pg_provision.py
+++ b/src/nexus/db/pg_provision.py
@@ -117,6 +117,19 @@ class PgBinaries:
             p.is_file() for p in [self.initdb, self.pg_ctl, self.psql, self.createdb]
         )
 
+    def missing_names(self) -> list[str]:
+        """Names of the required binaries that are not present on disk."""
+        return [
+            name
+            for name, p in (
+                ("initdb", self.initdb),
+                ("pg_ctl", self.pg_ctl),
+                ("psql", self.psql),
+                ("createdb", self.createdb),
+            )
+            if not p.is_file()
+        ]
+
 
 def _install_hint() -> str:
     """Return a platform-appropriate install hint."""
@@ -195,6 +208,16 @@ def discover_pg_binaries() -> PgBinaries:
         if bins.all_present():
             _log.debug("pg_binaries_from_bundle", bin_dir=str(bundle_bin))
             return bins
+        # The bundle cache directory exists with a valid completion marker but
+        # its binaries are gone (manually deleted / partial corruption). Falling
+        # through to host PG silently would pick the WRONG PostgreSQL on a
+        # local-distribution machine and fail late at CREATE EXTENSION vector.
+        # Warn loud about why the bundle was not used (no silent downgrade).
+        _log.warning(
+            "pg_bundle_incomplete_cache",
+            bin_dir=str(bundle_bin),
+            missing=bins.missing_names(),
+        )
 
     # 2. Fixed candidate directories.
     for d in _CANDIDATE_DIRS:
@@ -281,10 +304,13 @@ def check_pgvector_available(bins: PgBinaries) -> None:
     candidates = _candidate_sharedirs(pg_config, bins.bin_dir, sharedir)
     if any((c / "extension" / "vector.control").is_file() for c in candidates):
         return
-    control = candidates[0] / "extension" / "vector.control"
+    # Report EVERY probed location, not just candidates[0] — for a relocated
+    # bundle candidates[0] is pg_config's build-time absolute sharedir, a path
+    # that does not exist on the target machine and so misleads the user.
+    probed = ", ".join(str(c / "extension" / "vector.control") for c in candidates)
     raise PgVectorNotInstalledError(
         f"The pgvector extension is not installed for the PostgreSQL at "
-        f"{bins.bin_dir} (no {control}).\n"
+        f"{bins.bin_dir} (no vector.control under any of: {probed}).\n"
         "The Homebrew 'pgvector' formula targets the default postgresql "
         "major — for a versioned install (e.g. postgresql@17) build from "
         "source against THIS pg_config:\n"

--- a/tests/db/test_pg_provision_ca3_bundle.py
+++ b/tests/db/test_pg_provision_ca3_bundle.py
@@ -265,6 +265,19 @@ class TestPgvectorInjected:
             f"{_VECTOR_LIB} not injected into {pkglibdir}"
         )
 
+    def test_pg_trgm_present(self, bins):
+        """pg_trgm (contrib, required by the RDR-155 schema) must be in the
+        bundle the CA-3 gate validates — not only in the relocation smoke. The
+        build (build_pg_bundle.sh) installs it; a regression dropping it would
+        otherwise pass this canonical gate green. Mirrors
+        test_pg_bundle_relocation.py::test_pg_trgm_present_under_root."""
+        sharedir = Path(_pg_config(bins, "--sharedir"))
+        control = sharedir / "extension" / "pg_trgm.control"
+        assert control.is_file(), (
+            f"pg_trgm.control not present at {control} — contrib extension "
+            "missing from the bundle (RDR-155 schema requires it)"
+        )
+
     def test_preflight_passes(self, bins):
         """check_pgvector_available must NOT raise once the control file is in place."""
         try:

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -676,6 +676,48 @@ def test_provision_step_aborts_loud_on_broken_bundle(tmp_path, monkeypatch) -> N
     assert called["provision"] is False
 
 
+def test_provision_step_idempotent_on_rerun(tmp_path, monkeypatch, make_pg_bundle_txz) -> None:
+    """Composed re-run idempotency (RDR-157 §Approach P3 charge #1): running
+    _provision_postgres_step twice extracts the ship-alongside bundle EXACTLY
+    once (marker honored) and provisions each time, reporting already-provisioned
+    on the rerun. The components are individually idempotent; this locks the
+    composition (NEXUS_PG_BIN set on the first call must not force a re-extract)."""
+    from types import SimpleNamespace
+
+    import nexus.commands.init as init_mod
+    from nexus.db import pg_bundle
+
+    monkeypatch.delenv("NEXUS_PG_BIN", raising=False)
+    archive = make_pg_bundle_txz(tmp_path, "nexus-pg-rerun.txz")
+    monkeypatch.setenv(pg_bundle.BUNDLE_ENV, str(archive))
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    monkeypatch.setattr(init_mod._config, "nexus_config_dir", lambda: config_dir)
+
+    extractions = {"n": 0}
+    real_extract = pg_bundle.extract_bundle
+
+    def _counting_extract(*a, **k):
+        extractions["n"] += 1
+        return real_extract(*a, **k)
+
+    monkeypatch.setattr(pg_bundle, "extract_bundle", _counting_extract)
+
+    provisions = {"n": 0}
+
+    def _fake_provision(_cfg):
+        provisions["n"] += 1
+        return SimpleNamespace(already_provisioned=True, port=15432)
+
+    monkeypatch.setattr("nexus.db.pg_provision.provision", _fake_provision)
+
+    init_mod._provision_postgres_step()
+    init_mod._provision_postgres_step()
+
+    assert extractions["n"] == 1, "bundle re-extracted on rerun (marker not honored)"
+    assert provisions["n"] == 2, "provision must run on each invocation"
+
+
 class TestServiceLocalEmbedder:
     """RDR-160 P3.1/P3.2: a local --service install locks bge-768 and fetches
     the STANDARD ONNX the Java service reads. minilm-384 is non-operative here."""


### PR DESCRIPTION
## What

Resolves the RDR-157 P3.2 stacked-review findings (bead nexus-vwvv5.14). The
review of the P3 local-distribution PG bundle change set (diff ff3aeba9~1..8ecbc49f)
returned **0 Critical / 0 High**. code-review-expert approved; substantive-critic
verdict `partial` with 3 Significant. This PR closes all 3 Significant + 2 Medium.

### substantive-critic Significant
- **S1** — assert `pg_trgm.control` in the canonical CA-3 gate (`test_pg_provision_ca3_bundle.py::TestPgvectorInjected`), mirroring the relocation smoke. A build regression dropping the RDR-155-required contrib extension would otherwise pass CA-3 green.
- **S2** — composed re-run idempotency test for `_provision_postgres_step` (spec §Approach P3 charge #1): two invocations extract the bundle exactly once (marker honored), provision runs each time.
- **S3** — CA-2 ship-alongside size regression tripwire in CI (10 MiB ceiling over the ~5.74 MB current bundle), both linux and mac-arm64 packaging steps.

### code-review-expert Medium
- **M1** — `check_pgvector_available` reports every probed sharedir candidate, not `candidates[0]` (pg_config build-time absolute path, nonexistent on a relocated bundle).
- **M2** — warn `pg_bundle_incomplete_cache` when the bundle cache dir has a valid marker but the binaries are gone, instead of silently downgrading to host PG. Adds `PgBinaries.missing_names()`.

## Test
Affected unit tests: 70 passed, 1 integration skip. New `test_provision_step_idempotent_on_rerun` and `test_pg_trgm_present` (integration-gated) added. CI YAML validated.

Topology invariant confirmed clean by the critic (no local-Java→remote-PG, no client-side remote-pgvector check).

Review record: T2 `nexus/vwvv5.14-p3-bundle-stacked-review-2026-06-16`.
