### PR TITLE
feat(rdr-157): P4.1 nx init --service collapse + native-binary launch (nexus-vwvv5.17)

### DIFF
--- a/src/nexus/commands/init.py
+++ b/src/nexus/commands/init.py
@@ -337,6 +337,40 @@ def _provision_service_embedder_step(embedder: str | None) -> None:
         raise click.ClickException(str(exc)) from exc
 
 
+def _start_service_step() -> None:
+    """Start the local storage service and confirm it is serving (status green).
+
+    RDR-157 P4.1: the final step of the ``nx init --service`` one-command
+    collapse. ``start_storage_service`` is idempotent — it short-circuits on a
+    live lease, ensures Postgres is up, waits for ``/health`` 200, and only then
+    publishes the discovery lease — so re-running ``nx init --service`` is safe.
+    Any failure surfaces as an actionable error with a remedy, never a traceback.
+    """
+    from nexus.daemon.storage_service_daemon import (
+        StorageServiceStartError,
+        start_storage_service,
+    )
+
+    click.echo("\nStarting the storage service …")
+    try:
+        endpoint = start_storage_service()
+    except StorageServiceStartError as exc:
+        # StorageServiceStartError messages already carry a remedy (build/install
+        # the artifact, re-run init, etc.); relay verbatim, fail fatal.
+        click.echo(f"\nStorage service failed to start: {exc}", err=True)
+        raise SystemExit(1)
+    except Exception as exc:  # noqa: BLE001 — user-facing, must stay actionable
+        _log.error("service_start_failed", error=str(exc))
+        click.echo(f"\nStorage service failed to start: {exc}", err=True)
+        raise SystemExit(1)
+
+    click.echo(
+        f"  Service running on {endpoint.get('host')}:{endpoint.get('port')} "
+        f"(pid {endpoint.get('pid')}, generation {endpoint.get('generation')})."
+    )
+    click.echo("  nx init --service complete — the service backend is serving.")
+
+
 # ── P5 (A) Postgres provisioning ──────────────────────────────────────────────
 
 
@@ -476,9 +510,14 @@ def init_cmd(embedder: str | None, assume_yes: bool, provision_service: bool) ->
             return
         # Local service backend (RDR-160): the Java service embeds every
         # collection with bge-768. Lock the embedder + provision the standard
-        # ONNX it reads, then return — the interactive local-embedder prompt
-        # below is for the non-service Python (fastembed) path only.
+        # ONNX it reads.
         _provision_service_embedder_step(embedder)
+        # RDR-157 P4.1: collapse fresh-install -> serving. Start the service and
+        # confirm status green before returning, so one command leaves the user
+        # with a running backend (idempotent; safe to re-run). The interactive
+        # local-embedder prompt below is for the non-service Python (fastembed)
+        # path only.
+        _start_service_step()
         return
 
     # Import-site call so tests can patch ``nexus.config.is_local_mode``

--- a/src/nexus/daemon/jar_lifecycle.py
+++ b/src/nexus/daemon/jar_lifecycle.py
@@ -38,6 +38,7 @@ _log = structlog.get_logger(__name__)
 
 __all__ = [
     "well_known_jar_path",
+    "well_known_binary_path",
     "sidecar_path",
     "extract_jar_provenance",
     "install_jar",
@@ -49,6 +50,7 @@ __all__ = [
 
 _WELL_KNOWN_SUBDIR = "service"
 _WELL_KNOWN_JAR_NAME = "nexus-service.jar"
+_WELL_KNOWN_BINARY_NAME = "nexus-service"
 _SIDECAR_NAME = "nexus-service.jar.meta.json"
 
 # Liquibase changeSet identity is (id, author); attribute order in the XML is
@@ -70,6 +72,16 @@ _CHANGELOG_MEMBER_RE = re.compile(r"^db/changelog/[^/]+\.xml$")
 def well_known_jar_path(config_dir: Path) -> Path:
     """``<config_dir>/service/nexus-service.jar`` — the installed-user JAR home."""
     return config_dir / _WELL_KNOWN_SUBDIR / _WELL_KNOWN_JAR_NAME
+
+
+def well_known_binary_path(config_dir: Path) -> Path:
+    """``<config_dir>/service/nexus-service`` — the installed-user NATIVE binary.
+
+    RDR-157 ships per-OS/arch native-image binaries (no JVM). When one is
+    positioned here (by the distribution launcher / ``nx init --service``), the
+    storage-service supervisor execs it directly instead of ``java -jar``.
+    """
+    return config_dir / _WELL_KNOWN_SUBDIR / _WELL_KNOWN_BINARY_NAME
 
 
 def sidecar_path(config_dir: Path) -> Path:

--- a/src/nexus/daemon/storage_service_daemon.py
+++ b/src/nexus/daemon/storage_service_daemon.py
@@ -214,11 +214,15 @@ def _find_service_binary(config_dir: Path) -> Path | None:
        named a binary that does not exist made a mistake worth surfacing.
     2. The well-known installed location ``<config_dir>/service/nexus-service``.
     """
+    # NOTE (RDR-157 P4.2, bead nexus-vwvv5.18): positioning the binary at the
+    # well-known path / setting NEXUS_SERVICE_BIN is the distribution launcher's
+    # job, delivered by the fresh-machine E2E. P4.1 only makes the supervisor
+    # ABLE to launch a binary that is already present.
     env_override = os.environ.get("NEXUS_SERVICE_BIN", "").strip()
     if env_override:
         p = Path(env_override)
         if p.is_file():
-            return p
+            return _require_executable(p, "NEXUS_SERVICE_BIN")
         raise StorageServiceStartError(
             f"NEXUS_SERVICE_BIN is set to {env_override!r} but the file does not "
             "exist. Point it at a built native nexus-service binary, or unset it "
@@ -228,8 +232,21 @@ def _find_service_binary(config_dir: Path) -> Path | None:
     from nexus.daemon.jar_lifecycle import well_known_binary_path
     well_known = well_known_binary_path(config_dir)
     if well_known.is_file():
-        return well_known
+        return _require_executable(well_known, "nexus-service")
     return None
+
+
+def _require_executable(p: Path, label: str) -> Path:
+    """Return *p* if it carries the execute bit; fail loud with a chmod remedy.
+
+    A present-but-non-executable binary would otherwise surface as a bare
+    ``PermissionError`` from ``subprocess.Popen`` — an errno, not a remedy.
+    """
+    if not os.access(p, os.X_OK):
+        raise StorageServiceStartError(
+            f"{label} at {p} is not executable. Make it runnable: chmod +x {p}"
+        )
+    return p
 
 
 # ── Port helpers ───────────────────────────────────────────────────────────────
@@ -346,6 +363,11 @@ class StorageServiceSupervisor:
         self._config_dir = config_dir
         self._jar_path = jar_path
         self._binary_path = binary_path
+        # RDR-157: the launch artifact kind drives log naming + crash-triage
+        # event fields so a native-only operator never sees "jar" labels for a
+        # process that is not a JAR.
+        self._launch_mode = "native" if binary_path is not None else "jar"
+        self._svc_log_name = f"storage_service_{self._launch_mode}"
         self._pg_port = pg_port
         self._service_port = service_port
         self._creds = creds
@@ -459,20 +481,20 @@ class StorageServiceSupervisor:
         if self._binary_path is not None:
             argv = [str(self._binary_path)]
             artifact = str(self._binary_path)
-            launch_mode = "native"
         else:
             assert self._jar_path is not None  # guaranteed by __init__
             argv = [self._find_java(), "-jar", str(self._jar_path)]
             artifact = str(self._jar_path)
-            launch_mode = "jar"
         # nexus-ovbr7: the jar's logback config is console-only, so DEVNULL
         # here discarded every Java log line AND the JVM-level output logback
         # can't capture (OOM banners, hs_err preambles). Route both streams
         # to one file so interleaved output keeps its order; O_APPEND means a
         # respawn never truncates the previous process's final (crash) output.
+        # Log stem follows the launch mode so a native host writes
+        # storage_service_native.log, a JAR host storage_service_jar.log.
         from nexus.logging_setup import open_child_log_or_devnull
 
-        svc_log = open_child_log_or_devnull("storage_service_jar", self._config_dir)
+        svc_log = open_child_log_or_devnull(self._svc_log_name, self._config_dir)
         try:
             proc = subprocess.Popen(
                 argv,
@@ -490,7 +512,7 @@ class StorageServiceSupervisor:
             "storage_service_spawned",
             pid=proc.pid,
             port=port,
-            launch_mode=launch_mode,
+            launch_mode=self._launch_mode,
             artifact=artifact,
             service_log=getattr(svc_log, "name", "DEVNULL"),
         )
@@ -859,15 +881,18 @@ class StorageServiceSupervisor:
             return False, False
         if (rc := self._proc.poll()) is not None:
             # nexus-ovbr7: the returncode is the single cheapest diagnostic a
-            # dead jar leaves behind (137=SIGKILL/oom, 143=SIGTERM, 1=java
-            # error) — record it, plus where the jar's own output went.
+            # dead service process leaves behind (137=SIGKILL/oom, 143=SIGTERM,
+            # 1=error) — record it, plus where the process's own output went.
+            # launch_mode distinguishes a native-binary exit from a JAR exit so
+            # triage is not misdirected on native-only hosts.
             _log.warning(
                 "storage_service_jar_exit_detected",
                 pid=self._proc.pid,
                 returncode=rc,
-                jar_log=str(self._config_dir / "logs" / "storage_service_jar.log"),
+                launch_mode=self._launch_mode,
+                service_log=str(self._config_dir / "logs" / f"{self._svc_log_name}.log"),
             )
-            return False, False  # jar exited; signal the run loop to respawn
+            return False, False  # process exited; signal the run loop to respawn
 
         jar_alive = _pid_is_alive(self._proc.pid)
         service_ok = self._service_healthy()
@@ -1139,7 +1164,8 @@ def _supervise_until_stopped(
                 # the loop) — do not call sup.stop() mid-loop.
                 _log.warning(
                     "storage_service_jar_and_pg_died",
-                    msg="jar and PG both down; restarting PG before jar respawn",
+                    launch_mode=sup._launch_mode,
+                    msg="service process and PG both down; restarting PG before respawn",
                 )
                 try:
                     sup._ensure_pg_running()
@@ -1152,7 +1178,11 @@ def _supervise_until_stopped(
                     )
                     exit_code = 4
                     break
-            _log.warning("storage_service_jar_exited", msg="jar child gone; attempting restart")
+            _log.warning(
+                "storage_service_jar_exited",
+                launch_mode=sup._launch_mode,
+                msg="service child gone; attempting restart",
+            )
             try:
                 sup._respawn()
                 _log.info("storage_service_restarted_successfully")

--- a/src/nexus/daemon/storage_service_daemon.py
+++ b/src/nexus/daemon/storage_service_daemon.py
@@ -201,6 +201,37 @@ def _find_service_jar() -> Path:
     )
 
 
+def _find_service_binary(config_dir: Path) -> Path | None:
+    """Locate the nexus-service NATIVE binary, or None when none is installed.
+
+    RDR-157 ships per-OS/arch native-image binaries (no JVM). When one is
+    present the supervisor execs it directly; absence is NOT an error here —
+    the caller falls back to the ``java -jar`` path.
+
+    Search order:
+    1. ``NEXUS_SERVICE_BIN`` env override. Set-but-missing FAILS LOUD (mirrors
+       ``_find_service_jar``'s ``NEXUS_SERVICE_JAR`` contract) — an operator who
+       named a binary that does not exist made a mistake worth surfacing.
+    2. The well-known installed location ``<config_dir>/service/nexus-service``.
+    """
+    env_override = os.environ.get("NEXUS_SERVICE_BIN", "").strip()
+    if env_override:
+        p = Path(env_override)
+        if p.is_file():
+            return p
+        raise StorageServiceStartError(
+            f"NEXUS_SERVICE_BIN is set to {env_override!r} but the file does not "
+            "exist. Point it at a built native nexus-service binary, or unset it "
+            "to use the JAR."
+        )
+
+    from nexus.daemon.jar_lifecycle import well_known_binary_path
+    well_known = well_known_binary_path(config_dir)
+    if well_known.is_file():
+        return well_known
+    return None
+
+
 # ── Port helpers ───────────────────────────────────────────────────────────────
 
 
@@ -296,15 +327,25 @@ class StorageServiceSupervisor:
         self,
         *,
         config_dir: Path,
-        jar_path: Path,
+        jar_path: Path | None = None,
         pg_port: int,
         service_port: int,
         creds: dict[str, str],
+        binary_path: Path | None = None,
         lease_clock: Callable[[], float] = time.time,
         supervised: bool = False,
     ) -> None:
+        # Exactly one launch artifact must be resolvable: a native binary
+        # (RDR-157, preferred) or a JAR (dev / JVM fallback). The native binary
+        # wins when both are present.
+        if binary_path is None and jar_path is None:
+            raise StorageServiceStartError(
+                "StorageServiceSupervisor needs a native binary or a JAR to launch; "
+                "neither was provided."
+            )
         self._config_dir = config_dir
         self._jar_path = jar_path
+        self._binary_path = binary_path
         self._pg_port = pg_port
         self._service_port = service_port
         self._creds = creds
@@ -369,7 +410,13 @@ class StorageServiceSupervisor:
     # -- Internal helpers ---------------------------------------------------
 
     def _spawn_service(self) -> tuple[subprocess.Popen[bytes], int]:
-        """Spawn the Java JAR with env vars, returning (proc, port)."""
+        """Spawn the service process with env vars, returning (proc, port).
+
+        Prefers the RDR-157 native binary (``self._binary_path``); falls back to
+        ``java -jar`` when only a JAR is available. Configuration reaches the
+        service ENTIRELY via the environment below, so the two launch modes are
+        argv-only variants of each other.
+        """
         port = _allocate_free_port()
         env = dict(os.environ)
         # Credentials from pg_credentials
@@ -408,34 +455,44 @@ class StorageServiceSupervisor:
                     hint="set VOYAGE_API_KEY or `nx config set voyage_api_key <key>`",
                 )
 
-        java_bin = self._find_java()
+        # Native binary (RDR-157) wins over the JAR when both are present.
+        if self._binary_path is not None:
+            argv = [str(self._binary_path)]
+            artifact = str(self._binary_path)
+            launch_mode = "native"
+        else:
+            assert self._jar_path is not None  # guaranteed by __init__
+            argv = [self._find_java(), "-jar", str(self._jar_path)]
+            artifact = str(self._jar_path)
+            launch_mode = "jar"
         # nexus-ovbr7: the jar's logback config is console-only, so DEVNULL
         # here discarded every Java log line AND the JVM-level output logback
         # can't capture (OOM banners, hs_err preambles). Route both streams
         # to one file so interleaved output keeps its order; O_APPEND means a
-        # respawn never truncates the previous jar's final (crash) output.
+        # respawn never truncates the previous process's final (crash) output.
         from nexus.logging_setup import open_child_log_or_devnull
 
-        jar_log = open_child_log_or_devnull("storage_service_jar", self._config_dir)
+        svc_log = open_child_log_or_devnull("storage_service_jar", self._config_dir)
         try:
             proc = subprocess.Popen(
-                [java_bin, "-jar", str(self._jar_path)],
+                argv,
                 env=env,
-                stdout=jar_log,
-                stderr=jar_log,
+                stdout=svc_log,
+                stderr=svc_log,
                 start_new_session=True,
             )
         finally:
             # The child holds its own duplicated fd; the parent's handle is
             # no longer needed (and must not leak across respawns).
-            if not isinstance(jar_log, int):
-                jar_log.close()
+            if not isinstance(svc_log, int):
+                svc_log.close()
         _log.info(
             "storage_service_spawned",
             pid=proc.pid,
             port=port,
-            jar=str(self._jar_path),
-            jar_log=getattr(jar_log, "name", "DEVNULL"),
+            launch_mode=launch_mode,
+            artifact=artifact,
+            service_log=getattr(svc_log, "name", "DEVNULL"),
         )
         return proc, port
 
@@ -689,8 +746,17 @@ class StorageServiceSupervisor:
         # Liquibase silently ignores applied changesets it does not know, so an
         # old JAR would boot cleanly and fail undiagnosably at runtime. Gate
         # AFTER PG is up (it reads databasechangelog) and BEFORE the spawn.
-        from nexus.daemon.jar_lifecycle import check_schema_skew
-        check_schema_skew(self._jar_path, self._creds)
+        # JAR-only: check_schema_skew introspects the JAR's bundled changelog,
+        # which a native binary (RDR-157) cannot expose. A native binary ships
+        # its changelog baked at build time alongside the schema, so the
+        # old-artifact-vs-new-schema risk this guards against is a dev-JAR
+        # concern; skip it for native launches rather than fail.
+        if self._binary_path is None:
+            from nexus.daemon.jar_lifecycle import check_schema_skew
+            assert self._jar_path is not None  # guaranteed by __init__
+            check_schema_skew(self._jar_path, self._creds)
+        else:
+            _log.info("schema_skew_check_skipped", reason="native-binary")
 
         # Step 2: spawn the Java JAR.
         proc, port = self._spawn_service()
@@ -927,9 +993,12 @@ def start_storage_service(
         )
     pg_port = int(pg_port_str)
 
-    if jar_path is None:
+    # RDR-157: prefer a native binary; only require a JAR when none is present.
+    # An explicit jar_path argument (tests / operator override) still wins.
+    binary_path = None if jar_path is not None else _find_service_binary(config_dir)
+    if binary_path is None and jar_path is None:
         jar_path = _find_service_jar()
-    elif not jar_path.is_file():
+    elif jar_path is not None and not jar_path.is_file():
         raise StorageServiceStartError(
             f"nexus-service JAR not found at {jar_path}. "
             "Build it first: cd service && mvn package -DskipTests -q"
@@ -938,6 +1007,7 @@ def start_storage_service(
     sup = StorageServiceSupervisor(
         config_dir=config_dir,
         jar_path=jar_path,
+        binary_path=binary_path,
         pg_port=pg_port,
         service_port=0,  # allocated inside start()
         creds=creds,
@@ -1003,13 +1073,16 @@ def run_storage_supervisor(
         )
     pg_port = int(pg_port_str)
 
-    if jar_path is None:
+    # RDR-157: prefer a native binary; require a JAR only when none is present.
+    binary_path = None if jar_path is not None else _find_service_binary(config_dir)
+    if binary_path is None and jar_path is None:
         jar_path = _find_service_jar()
 
     _log.info(
         "storage_service_supervisor_started",
         pid=os.getpid(),
-        jar_path=str(jar_path),
+        launch_mode="native" if binary_path is not None else "jar",
+        artifact=str(binary_path if binary_path is not None else jar_path),
         pg_port=pg_port,
         config_dir=str(config_dir),
     )
@@ -1017,6 +1090,7 @@ def run_storage_supervisor(
     sup = StorageServiceSupervisor(
         config_dir=config_dir,
         jar_path=jar_path,
+        binary_path=binary_path,
         pg_port=pg_port,
         service_port=0,
         creds=creds,

--- a/tests/daemon/test_rdr157_native_launch.py
+++ b/tests/daemon/test_rdr157_native_launch.py
@@ -70,6 +70,17 @@ def test_find_binary_absent_returns_none(tmp_path, monkeypatch):
     assert _find_service_binary(tmp_path / "cfg") is None
 
 
+def test_find_binary_not_executable_fails_loud(tmp_path, monkeypatch):
+    # Present but non-executable -> a chmod remedy, not a bare PermissionError
+    # later from Popen.
+    binary = tmp_path / "nexus-service"
+    binary.write_text("not executable")
+    binary.chmod(0o644)
+    monkeypatch.setenv("NEXUS_SERVICE_BIN", str(binary))
+    with pytest.raises(StorageServiceStartError, match="not executable"):
+        _find_service_binary(tmp_path / "cfg")
+
+
 # ── supervisor construction guard ───────────────────────────────────────────
 
 

--- a/tests/daemon/test_rdr157_native_launch.py
+++ b/tests/daemon/test_rdr157_native_launch.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-157 P4.1 (bead nexus-vwvv5.17): native-image binary launch.
+
+The storage-service supervisor must exec the RDR-157 native binary when one is
+present, falling back to ``java -jar`` only when it is not. Config reaches the
+service entirely via the environment, so the two launch modes differ only in
+argv. These unit tests pin: binary discovery (env override + well-known +
+absent), the argv branch in ``_spawn_service``, the JAR-only schema-skew gate,
+and ``start_storage_service`` preferring the binary.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nexus.daemon.jar_lifecycle import well_known_binary_path
+from nexus.daemon.storage_service_daemon import (
+    StorageServiceStartError,
+    StorageServiceSupervisor,
+    _find_service_binary,
+)
+
+_CREDS = {
+    "NX_DB_URL": "jdbc:postgresql://127.0.0.1:15432/nexus",
+    "NX_DB_USER": "svc",
+    "NX_DB_PASS": "pass",
+    "NX_DB_ADMIN_URL": "jdbc:postgresql://127.0.0.1:15432/nexus",
+    "NX_DB_ADMIN_USER": "admin",
+    "NX_DB_ADMIN_PASS": "adminpass",
+    "PG_PORT": "15432",
+    "NX_SERVICE_TOKEN": "root-token-from-creds-deadbeef",
+}
+
+
+def _make_native_binary(d: Path) -> Path:
+    p = d / "nexus-service"
+    p.write_text("#!/bin/sh\nexit 0\n")
+    p.chmod(0o755)
+    return p
+
+
+# ── _find_service_binary ───────────────────────────────────────────────────
+
+
+def test_find_binary_env_override_present(tmp_path, monkeypatch):
+    binary = _make_native_binary(tmp_path)
+    monkeypatch.setenv("NEXUS_SERVICE_BIN", str(binary))
+    assert _find_service_binary(tmp_path / "cfg") == binary
+
+
+def test_find_binary_env_override_missing_fails_loud(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEXUS_SERVICE_BIN", str(tmp_path / "nope"))
+    with pytest.raises(StorageServiceStartError, match="NEXUS_SERVICE_BIN"):
+        _find_service_binary(tmp_path / "cfg")
+
+
+def test_find_binary_well_known(tmp_path, monkeypatch):
+    monkeypatch.delenv("NEXUS_SERVICE_BIN", raising=False)
+    config_dir = tmp_path / "cfg"
+    well_known = well_known_binary_path(config_dir)
+    well_known.parent.mkdir(parents=True)
+    _make_native_binary(well_known.parent).rename(well_known)
+    assert _find_service_binary(config_dir) == well_known
+
+
+def test_find_binary_absent_returns_none(tmp_path, monkeypatch):
+    monkeypatch.delenv("NEXUS_SERVICE_BIN", raising=False)
+    assert _find_service_binary(tmp_path / "cfg") is None
+
+
+# ── supervisor construction guard ───────────────────────────────────────────
+
+
+def test_supervisor_requires_an_artifact(tmp_path):
+    with pytest.raises(StorageServiceStartError, match="native binary or a JAR"):
+        StorageServiceSupervisor(
+            config_dir=tmp_path,
+            pg_port=15432,
+            service_port=0,
+            creds=_CREDS,
+        )
+
+
+# ── _spawn_service argv branch ───────────────────────────────────────────────
+
+
+def _spawn_and_capture_argv(sup) -> list[str]:
+    fake_proc = MagicMock()
+    fake_proc.pid = 4242
+    with patch(
+        "nexus.daemon.storage_service_daemon._allocate_free_port", return_value=18091
+    ), patch(
+        "nexus.logging_setup.open_child_log_or_devnull", return_value=MagicMock()
+    ), patch(
+        "nexus.daemon.storage_service_daemon.subprocess.Popen", return_value=fake_proc
+    ) as popen:
+        proc, port = sup._spawn_service()
+    assert proc is fake_proc
+    assert port == 18091
+    return popen.call_args.args[0]
+
+
+def test_spawn_native_uses_binary_argv(tmp_path):
+    binary = _make_native_binary(tmp_path)
+    sup = StorageServiceSupervisor(
+        config_dir=tmp_path,
+        binary_path=binary,
+        pg_port=15432,
+        service_port=0,
+        creds=_CREDS,
+    )
+    argv = _spawn_and_capture_argv(sup)
+    assert argv == [str(binary)], "native launch must exec the binary directly"
+
+
+def test_spawn_jar_uses_java_argv(tmp_path):
+    jar = tmp_path / "nexus-service.jar"
+    jar.write_text("fake jar")
+    sup = StorageServiceSupervisor(
+        config_dir=tmp_path,
+        jar_path=jar,
+        pg_port=15432,
+        service_port=0,
+        creds=_CREDS,
+    )
+    with patch.object(sup, "_find_java", return_value="/usr/bin/java"):
+        argv = _spawn_and_capture_argv(sup)
+    assert argv == ["/usr/bin/java", "-jar", str(jar)]
+
+
+# ── schema-skew gate is JAR-only ─────────────────────────────────────────────
+
+
+def _drive_start_locked(sup):
+    """Run _start_locked with PG/spawn/health/publish stubbed so only the
+    schema-skew decision is exercised."""
+    fake_proc = MagicMock()
+    fake_proc.pid = 4242
+    with patch(
+        "nexus.daemon.storage_service_daemon.ServiceRegistry"
+    ) as Reg, patch.object(
+        sup, "_ensure_pg_running"
+    ), patch.object(
+        sup, "_spawn_service", return_value=(fake_proc, 18092)
+    ), patch.object(
+        sup, "_wait_for_service_ready"
+    ), patch.object(
+        sup, "_publish"
+    ), patch(
+        "nexus.daemon.jar_lifecycle.check_schema_skew"
+    ) as skew:
+        Reg.return_value.discover.return_value = None
+        # _publish sets up the supervisor record the payload reads; stubbing it
+        # leaves _supervisor None, so short-circuit the payload assembly by
+        # making _publish populate a minimal record.
+        sup._supervisor = MagicMock()
+        sup._supervisor.record.generation = 1
+        sup._start_locked()
+    return skew
+
+
+def test_schema_skew_checked_for_jar(tmp_path):
+    jar = tmp_path / "nexus-service.jar"
+    jar.write_text("fake jar")
+    sup = StorageServiceSupervisor(
+        config_dir=tmp_path, jar_path=jar, pg_port=15432, service_port=0, creds=_CREDS
+    )
+    skew = _drive_start_locked(sup)
+    skew.assert_called_once()
+
+
+def test_schema_skew_skipped_for_native(tmp_path):
+    binary = _make_native_binary(tmp_path)
+    sup = StorageServiceSupervisor(
+        config_dir=tmp_path,
+        binary_path=binary,
+        pg_port=15432,
+        service_port=0,
+        creds=_CREDS,
+    )
+    skew = _drive_start_locked(sup)
+    skew.assert_not_called()
+
+
+# ── start_storage_service prefers the binary ─────────────────────────────────
+
+
+def test_start_storage_service_prefers_binary(tmp_path, monkeypatch):
+    from nexus.daemon import storage_service_daemon as mod
+
+    binary = _make_native_binary(tmp_path)
+    monkeypatch.setattr(mod, "_load_credentials", lambda cfg: _CREDS)
+    monkeypatch.setattr(mod, "_find_service_binary", lambda cfg: binary)
+
+    def _no_jar():
+        raise AssertionError("_find_service_jar must not be called when a binary exists")
+
+    monkeypatch.setattr(mod, "_find_service_jar", _no_jar)
+    captured = {}
+
+    class _SpySup:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+        def start(self):
+            return {"host": "127.0.0.1", "port": 18093, "pid": 1, "generation": 1}
+
+    monkeypatch.setattr(mod, "StorageServiceSupervisor", _SpySup)
+    mod.start_storage_service(config_dir=tmp_path)
+    assert captured["binary_path"] == binary
+    assert captured["jar_path"] is None

--- a/tests/daemon/test_storage_service_daemon.py
+++ b/tests/daemon/test_storage_service_daemon.py
@@ -1265,6 +1265,7 @@ class _ScriptedSupervisor:
         self._stop = stop_requested
         self._ensure_pg_raises = ensure_pg_raises
         self._respawn_raises = respawn_raises
+        self._launch_mode = "jar"  # mirrors the real supervisor's attribute
         self.calls: list[str] = []
 
     def start(self) -> None:

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -726,6 +726,10 @@ class TestServiceLocalEmbedder:
         # No real Postgres, local mode, and a recording stub for the bge fetch.
         monkeypatch.setattr("nexus.commands.init._provision_postgres_step", lambda: None)
         monkeypatch.setattr("nexus.config.is_local_mode", lambda: True)
+        # RDR-157 P4.1: init --service now also starts the service. Stub it here
+        # so the embedder-focused tests stay hermetic (start coverage is in
+        # TestServiceStartStep below).
+        monkeypatch.setattr("nexus.commands.init._start_service_step", lambda: None)
         calls: list[str] = []
         monkeypatch.setattr(
             "nexus.db.service_bge_model.fetch_service_bge_onnx",
@@ -772,3 +776,64 @@ class TestServiceLocalEmbedder:
         result = CliRunner().invoke(init_cmd, ["--service"])
         assert result.exit_code != 0  # fail-loud + fatal
         assert "will not boot" in result.output
+
+
+class TestServiceStartStep:
+    """RDR-157 P4.1 (nexus-vwvv5.17): nx init --service collapses through to a
+    started, status-green service. _start_service_step calls the idempotent
+    start_storage_service and fails loud (never a traceback) on any error."""
+
+    def test_start_step_reports_running_endpoint(self, monkeypatch) -> None:
+        import nexus.commands.init as init_mod
+
+        monkeypatch.setattr(
+            "nexus.daemon.storage_service_daemon.start_storage_service",
+            lambda: {"host": "127.0.0.1", "port": 18099, "pid": 4242, "generation": 3},
+        )
+        runner_out: list[str] = []
+        monkeypatch.setattr(init_mod.click, "echo", lambda *a, **k: runner_out.append(a[0] if a else ""))
+
+        init_mod._start_service_step()
+
+        joined = "\n".join(runner_out)
+        assert "127.0.0.1:18099" in joined
+        assert "serving" in joined.lower()
+
+    def test_start_step_fails_loud_on_start_error(self, monkeypatch) -> None:
+        import nexus.commands.init as init_mod
+        from nexus.daemon.storage_service_daemon import StorageServiceStartError
+
+        def _boom():
+            raise StorageServiceStartError(
+                "No nexus-service JAR found. Install one: nx daemon service install-jar <path>"
+            )
+
+        monkeypatch.setattr(
+            "nexus.daemon.storage_service_daemon.start_storage_service", _boom
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            init_mod._start_service_step()
+        assert exc.value.code == 1
+
+    def test_init_service_local_wires_start_after_embedder(
+        self, cfg_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The collapse order is provision -> embedder -> start, and start runs."""
+        order: list[str] = []
+        monkeypatch.setattr(
+            "nexus.commands.init._provision_postgres_step",
+            lambda: order.append("pg"),
+        )
+        monkeypatch.setattr("nexus.config.is_local_mode", lambda: True)
+        monkeypatch.setattr(
+            "nexus.db.service_bge_model.fetch_service_bge_onnx",
+            lambda **kw: (order.append("embed"), Path("/fake/onnx"))[1],
+        )
+        monkeypatch.setattr(
+            "nexus.commands.init._start_service_step",
+            lambda: order.append("start"),
+        )
+        result = CliRunner().invoke(init_cmd, ["--service"])
+        assert result.exit_code == 0, result.output
+        assert order == ["pg", "embed", "start"]

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -529,6 +529,9 @@ class TestServiceProvisioningFlag:
             lambda: called.append("called"),
         )
         monkeypatch.setattr("nexus.config.is_local_mode", lambda: False)
+        # Defensive: cloud mode returns before the start step, but stub it so a
+        # future local-mode flip can't reach the real service starter.
+        monkeypatch.setattr("nexus.commands.init._start_service_step", lambda: None)
 
         result = CliRunner().invoke(init_cmd, ["--service"])
 
@@ -559,6 +562,7 @@ class TestServiceProvisioningFlag:
         """When ``NX_STORAGE_BACKEND=service`` is set, provisioning auto-triggers."""
         monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
         monkeypatch.setattr("nexus.config.is_local_mode", lambda: False)
+        monkeypatch.setattr("nexus.commands.init._start_service_step", lambda: None)
         called: list[str] = []
         monkeypatch.setattr(
             "nexus.commands.init._provision_postgres_step",
@@ -835,5 +839,28 @@ class TestServiceStartStep:
             lambda: order.append("start"),
         )
         result = CliRunner().invoke(init_cmd, ["--service"])
+        assert result.exit_code == 0, result.output
+        assert order == ["pg", "embed", "start"]
+
+    def test_auto_service_local_wires_start(
+        self, cfg_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """NX_STORAGE_BACKEND=service auto-trigger in LOCAL mode runs the full
+        collapse (pg -> embed -> start), not just provisioning. This is the
+        re-run path an operator hits after a first `nx init --service`."""
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
+        monkeypatch.setattr("nexus.config.is_local_mode", lambda: True)
+        order: list[str] = []
+        monkeypatch.setattr(
+            "nexus.commands.init._provision_postgres_step", lambda: order.append("pg")
+        )
+        monkeypatch.setattr(
+            "nexus.db.service_bge_model.fetch_service_bge_onnx",
+            lambda **kw: (order.append("embed"), Path("/fake/onnx"))[1],
+        )
+        monkeypatch.setattr(
+            "nexus.commands.init._start_service_step", lambda: order.append("start")
+        )
+        result = CliRunner().invoke(init_cmd, [])
         assert result.exit_code == 0, result.output
         assert order == ["pg", "embed", "start"]


### PR DESCRIPTION
## What

RDR-157 **P4.1** (bead nexus-vwvv5.17): collapse fresh-install → serving into a single `nx init --service`, and teach the storage-service supervisor to launch the RDR-157 **native-image binary** (no JVM), falling back to `java -jar` for dev.

### Part A — native-binary launch
- `_find_service_binary(config_dir)`: `NEXUS_SERVICE_BIN` override (set-but-missing / non-executable both fail loud with a remedy) → well-known `<config_dir>/service/nexus-service` → None.
- `StorageServiceSupervisor` takes `binary_path` (jar_path now optional; both-None guard). `_spawn_service` execs the binary directly when present, else `java -jar`. Config is env-only, so the modes are argv-only variants.
- Schema-skew gate is JAR-only (it introspects the JAR's Liquibase changelog, which a native binary cannot expose); skipped + logged for native.
- `start_storage_service` / `run_storage_supervisor` resolve the binary first; require a JAR only when none is present — native-only machines serve.
- Observability: `launch_mode` threaded through spawn + crash events; native host writes `storage_service_native.log`.

### Part B — one-command collapse
- `_start_service_step()` calls the idempotent `start_storage_service` (live-lease short-circuit, ensures PG, waits `/health` 200, publishes lease) and reports the running endpoint; any failure is fail-loud with a remedy, never a traceback. Wired into the **LOCAL**-mode `--service` branch after the bge-768 embedder step (cloud mode has no local service per the corrected topology).

## Scope boundary
Positioning the binary at the well-known path / setting `NEXUS_SERVICE_BIN` is the distribution launcher's job — explicitly deferred to **P4.2** (nexus-vwvv5.18) and cross-referenced in code. P4.1 makes the supervisor *able* to launch a present binary.

## Review
Stacked review (code-review-expert + substantive-critic): 0 Critical / 0 High. 2 Significant + 2 Medium + observations all fixed in the second commit (native-aware observability, exec-bit fail-loud, `_auto_service`+LOCAL collapse test, defensive stubs, P4.2 cross-ref). Review record: T2 `nexus/vwvv5.17-p4.1-review-2026-06-16`. Design: T2 `nexus_rdr/157-P4.1-design-native-launch-and-init-collapse-2026-06-16`.

## Test
188 passed, 1 xfailed across init + daemon + observability + jar_lifecycle + rdr149 conformance suites.
