### PR TITLE
feat(rdr-157): keyless cosign signing of engine-service release assets (nexus-1odsm)

### DIFF
--- a/.github/workflows/engine-service-release.yml
+++ b/.github/workflows/engine-service-release.yml
@@ -251,10 +251,12 @@ jobs:
 
       - name: Install cosign (release tag only)
         # nexus-1odsm: keyless Sigstore signing. Only needed on the publish path.
-        # sigstore-official installer; version-tag pinned like the actions/* above
-        # (dorny/paths-filter is the one SHA-pinned third-party action).
+        # SHA-pinned (not @v3.7.0): this is the tool that installs the release
+        # signing primitive, so a floating tag is the supply-chain hole this whole
+        # bead exists to close — same reasoning as the SHA-pinned graalvm action
+        # above. SHA backs v3.7.0.
         if: startsWith(github.ref, 'refs/tags/engine-service-v')
-        uses: sigstore/cosign-installer@v3.7.0
+        uses: sigstore/cosign-installer@1aa8e0f2454b781fbf0fbf306a4c9533a0c57409  # v3.7.0
 
       - name: Sign release asset (cosign keyless, release tag only)
         # nexus-1odsm: the native binary runs with DB credentials in the conexus
@@ -318,12 +320,11 @@ jobs:
             "  curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/tokenizer.json -o \$MODEL_DIR/tokenizer.json" \
             "" \
             "Provenance: each asset carries a sha256 AND a keyless cosign/Sigstore" \
-            "signature bundle (<asset>.cosign.bundle). Verify before use with" \
-            "'cosign verify-blob <asset> --bundle <asset>.cosign.bundle', passing" \
-            "--certificate-oidc-issuer https://token.actions.githubusercontent.com and" \
-            "--certificate-identity-regexp matching this workflow at an" \
-            "engine-service-v* tag ref. conexus deploy verifies this bundle before" \
-            "docker run (see ECR_PUSH.md)." \
+            "signature bundle (<asset>.cosign.bundle). Verify before use:" \
+            "  cosign verify-blob <asset> --bundle <asset>.cosign.bundle \\" \
+            "    --certificate-oidc-issuer https://token.actions.githubusercontent.com \\" \
+            "    --certificate-identity-regexp 'https://github.com/${GITHUB_REPOSITORY}/.github/workflows/engine-service-release.yml@refs/tags/engine-service-v.*'" \
+            "conexus deploy verifies this bundle before docker run (see ECR_PUSH.md)." \
             > notes.md
           # Matrix-safe: create the release once (whichever arch job wins), then
           # each job uploads its OWN arch assets (--clobber for re-runs). Use

--- a/.github/workflows/engine-service-release.yml
+++ b/.github/workflows/engine-service-release.yml
@@ -41,6 +41,7 @@ on:
 
 permissions:
   contents: write  # create the GitHub Release + upload assets on tag push
+  id-token: write  # nexus-1odsm: keyless cosign signing of release assets (OIDC)
 
 concurrency:
   group: engine-service-release-${{ github.ref }}
@@ -248,6 +249,34 @@ jobs:
               ;;
           esac
 
+      - name: Install cosign (release tag only)
+        # nexus-1odsm: keyless Sigstore signing. Only needed on the publish path.
+        # sigstore-official installer; version-tag pinned like the actions/* above
+        # (dorny/paths-filter is the one SHA-pinned third-party action).
+        if: startsWith(github.ref, 'refs/tags/engine-service-v')
+        uses: sigstore/cosign-installer@v3.7.0
+
+      - name: Sign release asset (cosign keyless, release tag only)
+        # nexus-1odsm: the native binary runs with DB credentials in the conexus
+        # cloud and is opaque to static inspection, so a detached Sigstore
+        # signature matters more than for a JAR. Keyless: the GitHub Actions OIDC
+        # identity is bound into the Fulcio cert; the Rekor transparency log entry
+        # is embedded in the bundle. Verify with the identity + issuer below
+        # (see the release notes / conexus deploy ECR_PUSH.md).
+        if: startsWith(github.ref, 'refs/tags/engine-service-v')
+        env:
+          COSIGN_YES: "true"
+        run: |
+          set -euo pipefail
+          cosign sign-blob "dist/$ASSET" --bundle "dist/$ASSET.cosign.bundle"
+          # Self-verify before publishing so a malformed bundle fails the build,
+          # not the consumer. Identity = this workflow at this tag ref.
+          cosign verify-blob "dist/$ASSET" \
+            --bundle "dist/$ASSET.cosign.bundle" \
+            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/engine-service-release.yml@${GITHUB_REF}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+          echo "cosign signature verified for $ASSET"
+
       - name: Upload Actions artifact (always — dev smoke / non-tag path)
         uses: actions/upload-artifact@v4
         with:
@@ -288,7 +317,13 @@ jobs:
             "  curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/onnx/model.onnx -o \$MODEL_DIR/model.onnx" \
             "  curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/tokenizer.json -o \$MODEL_DIR/tokenizer.json" \
             "" \
-            "Provenance: sha256 only for now; cosign/Sigstore signing tracked for N+1." \
+            "Provenance: each asset carries a sha256 AND a keyless cosign/Sigstore" \
+            "signature bundle (<asset>.cosign.bundle). Verify before use with" \
+            "'cosign verify-blob <asset> --bundle <asset>.cosign.bundle', passing" \
+            "--certificate-oidc-issuer https://token.actions.githubusercontent.com and" \
+            "--certificate-identity-regexp matching this workflow at an" \
+            "engine-service-v* tag ref. conexus deploy verifies this bundle before" \
+            "docker run (see ECR_PUSH.md)." \
             > notes.md
           # Matrix-safe: create the release once (whichever arch job wins), then
           # each job uploads its OWN arch assets (--clobber for re-runs). Use
@@ -305,4 +340,5 @@ jobs:
                 || { echo "release create failed:" >&2; cat create_err.txt >&2; exit 1; }
             fi
           fi
-          gh release upload "$tag" --clobber "dist/$ASSET" "dist/$ASSET.sha256"
+          gh release upload "$tag" --clobber \
+            "dist/$ASSET" "dist/$ASSET.sha256" "dist/$ASSET.cosign.bundle"

--- a/docs/rdr/rdr-157-handoff-to-conexus-rdr-001.md
+++ b/docs/rdr/rdr-157-handoff-to-conexus-rdr-001.md
@@ -31,7 +31,7 @@ the consumer.**
   cosign verify-blob <asset> --bundle <asset>.cosign.bundle \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
     --certificate-identity-regexp \
-      'https://github.com/<owner>/nexus/.github/workflows/engine-service-release.yml@refs/tags/engine-service-v.*'
+      'https://github.com/Hellblazer/nexus/.github/workflows/engine-service-release.yml@refs/tags/engine-service-v.*'
   ```
   conexus deploy/engine must run this check before `docker run` (track in
   conexus `ECR_PUSH.md`, which already verifies the pushed image's signature).
@@ -151,4 +151,8 @@ engine-side blocker and hands the install/upgrade primitives above to RDR-001.
 - Native-binary live E2E through the Python init path (the native spawn is
   unit-covered with a mocked `Popen`; the Java `/health` is covered by the
   engine-service-release CI smoke).
-- `cosign`/Sigstore signing of the published binary (bead `nexus-1odsm`, N+1).
+- `cosign`/Sigstore signing of the published binary: the **publisher half**
+  (sign + self-verify + publish the bundle) is delivered (`nexus-1odsm`,
+  primitive 1 above). The **consumer half** (conexus deploy verifies the bundle
+  before `docker run`, documented in conexus `ECR_PUSH.md`) is the remaining
+  RDR-001 consumer task, tracked by a child bead under `nexus-w5v8j`.

--- a/docs/rdr/rdr-157-handoff-to-conexus-rdr-001.md
+++ b/docs/rdr/rdr-157-handoff-to-conexus-rdr-001.md
@@ -23,8 +23,21 @@ the consumer.**
 - **Contract:** download the target's binary, verify against the sha256 manifest,
   mark executable. The binary is self-contained (no JVM/JRE). Windows is a
   separate release-N+1 follow-on; `mac-x64` is out of scope (owner call).
+- **Provenance (cosign/Sigstore, `nexus-1odsm`):** each asset additionally
+  carries a keyless cosign signature bundle `<asset>.cosign.bundle`. The
+  publisher (`engine-service-release.yml`) signs and self-verifies before
+  upload. **Consumers MUST verify before use:**
+  ```
+  cosign verify-blob <asset> --bundle <asset>.cosign.bundle \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate-identity-regexp \
+      'https://github.com/<owner>/nexus/.github/workflows/engine-service-release.yml@refs/tags/engine-service-v.*'
+  ```
+  conexus deploy/engine must run this check before `docker run` (track in
+  conexus `ECR_PUSH.md`, which already verifies the pushed image's signature).
 - **Consumer use:** upgrade-orchestration fetches the binary for the host
-  platform during an install/upgrade and positions it (see primitive 4).
+  platform during an install/upgrade, verifies the cosign bundle + sha256, and
+  positions it (see primitive 4).
 
 ### 2. Relocatable PG17 + pgvector bundle (P3.1, ship-alongside)
 


### PR DESCRIPTION
## What

RDR-157 **nexus-1odsm** (publisher half): keyless cosign/Sigstore signing of the native `engine-service` release assets in `.github/workflows/engine-service-release.yml`, plus the consumer verification contract in the handoff doc.

- `id-token: write`; install cosign (SHA-pinned `1aa8e0f`, v3.7.0); `cosign sign-blob --bundle` each release asset (GitHub OIDC → Fulcio cert, Rekor entry embedded); **self-verify before upload** so a malformed bundle fails the build; upload `<asset>.cosign.bundle` alongside the binary + sha256. Signing is gated on the `engine-service-v*` tag (dev/dispatch path unaffected).
- Release notes carry a copy-pasteable `cosign verify-blob` command (identity-regexp pinning this repo + workflow + tag-ref pattern).

## Stacked review (both reviewers) — all findings fixed
- **Critical (critic):** consumer-side verification was unimplemented and the first commit falsely claimed it was "tracked under nexus-w5v8j." → Split into a real bead **nexus-1jt17** (consumer half: conexus deploy `cosign verify-blob` before `docker run` + ECR_PUSH.md), narrowed nexus-1odsm to the publisher half. A published-but-unchecked signature protects nothing until the consumer half lands.
- **Significant:** SHA-pin the installer (the tool installing the signing primitive must not float — matches the graalvm SHA-pin on this path); release notes made copy-pasteable.
- Handoff-doc stale "deferred" line + owner placeholder fixed.

Review record: T2 `nexus_rdr/1odsm-cosign-critique-2026-06-16`.

## Scope
Publisher half only. Consumer-side verification is conexus-repo work tracked by **nexus-1jt17** under the RDR-001 consumer epic.
