### PR TITLE
feat(rdr-154): P0 — topics.doc_count trigger as sole writer (nexus-i7ivk)

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
@@ -243,13 +243,10 @@ public final class TaxonomyRepository {
         });
     }
 
-    /** Update doc_count for a topic (denormalized cache resync). */
-    public void updateDocCount(String tenant, long topicId, int docCount) {
-        tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute("UPDATE nexus.topics SET doc_count = ? WHERE id = ?", docCount, topicId);
-            return null;
-        });
-    }
+    // RDR-154 P0 (nexus-i7ivk): updateDocCount() removed. doc_count is now
+    // maintained solely by the trg_topic_assignments_doc_count_{ins,del}
+    // statement-level triggers; an app-side resync would re-introduce the
+    // split-maintenance drift the trigger exists to eliminate.
 
     /** Count assignments for a topic (used for doc_count resync). */
     public int countAssignments(String tenant, long topicId) {
@@ -308,10 +305,10 @@ public final class TaxonomyRepository {
 
             ctx.execute("DELETE FROM nexus.topic_assignments WHERE topic_id = ?", sourceId);
 
-            int newCount = ctx.fetchOne(
-                "SELECT COUNT(*) AS c FROM nexus.topic_assignments WHERE topic_id = ?", targetId)
-               .get("c", Integer.class);
-            ctx.execute("UPDATE nexus.topics SET doc_count = ? WHERE id = ?", newCount, targetId);
+            // RDR-154 P0 (nexus-i7ivk): no manual doc_count resync. The assignment
+            // move (INSERT) and source purge (DELETE) above each fire the
+            // statement-level triggers, which recompute target.doc_count from the
+            // live assignment rows; the trigger is the sole writer.
             ctx.execute("DELETE FROM nexus.topics WHERE id = ?", sourceId);
 
             return Optional.of(collection);
@@ -362,11 +359,11 @@ public final class TaxonomyRepository {
                     ON CONFLICT (tenant_id, doc_id, topic_id) DO NOTHING
                     """, tenant, docId, topicId, assignedBy);
             }
-            // Resync doc_count (mirrors nexus-n41p)
-            int cnt = ctx.fetchOne(
-                "SELECT COUNT(*) AS c FROM nexus.topic_assignments WHERE topic_id = ?", topicId)
-               .get("c", Integer.class);
-            ctx.execute("UPDATE nexus.topics SET doc_count = ? WHERE id = ?", cnt, topicId);
+            // RDR-154 P0 (nexus-i7ivk): no manual doc_count resync. A fresh
+            // assignment INSERT fires the AFTER INSERT statement-level trigger,
+            // which recomputes topics.doc_count from the live rows. (An ON CONFLICT
+            // DO NOTHING / DO UPDATE that changes no assignment count leaves
+            // doc_count correctly unchanged.) The trigger is the sole writer.
             return null;
         });
     }
@@ -650,7 +647,10 @@ public final class TaxonomyRepository {
                      doc_count, created_at, review_status, terms)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?::timestamptz, ?, ?)
                 ON CONFLICT (id) DO UPDATE SET
-                    doc_count     = GREATEST(nexus.topics.doc_count, EXCLUDED.doc_count),
+                    -- RDR-154 P0 (nexus-i7ivk): doc_count is trigger-maintained and
+                    -- is NOT an ETL merge participant. The INSERT branch seeds it for
+                    -- a brand-new topic; on conflict the live (trigger-computed) value
+                    -- is left untouched so a lossy snapshot can never clobber it.
                     review_status = EXCLUDED.review_status,
                     centroid_hash = EXCLUDED.centroid_hash,
                     terms         = EXCLUDED.terms
@@ -1037,9 +1037,10 @@ public final class TaxonomyRepository {
                 }
             }
 
-            // Zero out parent doc_count
-            ctx.execute("UPDATE nexus.topics SET doc_count = 0 WHERE tenant_id = ? AND id = ?",
-                        tenant, topicId);
+            // RDR-154 P0 (nexus-i7ivk): no manual parent zero-out. The parent's
+            // assignments were DELETEd above, firing the AFTER DELETE trigger which
+            // recomputes the parent's doc_count to its live value (0). The trigger
+            // is the sole writer.
 
             log.info("persist_split topic_id={} children={}", topicId, childIds.size());
             return childIds;

--- a/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
@@ -248,7 +248,11 @@ public final class TaxonomyRepository {
     // statement-level triggers; an app-side resync would re-introduce the
     // split-maintenance drift the trigger exists to eliminate.
 
-    /** Count assignments for a topic (used for doc_count resync). */
+    /**
+     * Pure read: count assignments for a topic. RDR-154 P0 (nexus-i7ivk):
+     * doc_count is now trigger-maintained — do NOT feed this value into any
+     * topics.doc_count write; the topic_assignments triggers are the sole writer.
+     */
     public int countAssignments(String tenant, long topicId) {
         return tenantScope.withTenant(tenant, ctx ->
             ctx.fetchOne("SELECT COUNT(*) AS c FROM nexus.topic_assignments WHERE topic_id = ?", topicId)

--- a/service/src/main/java/dev/nexus/service/http/TaxonomyHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/TaxonomyHandler.java
@@ -40,7 +40,6 @@ import java.util.Optional;
  *   POST  /v1/taxonomy/topics/update_label update label
  *   POST  /v1/taxonomy/topics/rename       rename + mark accepted
  *   POST  /v1/taxonomy/topics/mark_reviewed update review_status
- *   POST  /v1/taxonomy/topics/update_doc_count update doc_count
  *   GET   /v1/taxonomy/topics/count_assignments count assignments for topic_id=
  *   POST  /v1/taxonomy/topics/delete       delete topic (returns collection)
  *   POST  /v1/taxonomy/topics/merge        merge source→target
@@ -127,7 +126,6 @@ public final class TaxonomyHandler implements HttpHandler {
                 case "/topics/update_label"       -> handleUpdateLabel(exchange, tenant, method);
                 case "/topics/rename"             -> handleRenameTopic(exchange, tenant, method);
                 case "/topics/mark_reviewed"      -> handleMarkReviewed(exchange, tenant, method);
-                case "/topics/update_doc_count"   -> handleUpdateDocCount(exchange, tenant, method);
                 case "/topics/count_assignments"  -> handleCountAssignments(exchange, tenant, method);
                 case "/topics/delete"             -> handleDeleteTopic(exchange, tenant, method);
                 case "/topics/merge"              -> handleMergeTopics(exchange, tenant, method);
@@ -283,14 +281,9 @@ public final class TaxonomyHandler implements HttpHandler {
         HttpUtil.send(ex, 200, "{\"ok\":true}");
     }
 
-    private void handleUpdateDocCount(HttpExchange ex, String tenant, String method) throws IOException {
-        requireMethod(ex, method, "POST");
-        Map<String, Object> body = readBody(ex);
-        long topicId  = requireLong(body, "topic_id");
-        int  docCount = requireInt(body, "doc_count");
-        repo.updateDocCount(tenant, topicId, docCount);
-        HttpUtil.send(ex, 200, "{\"ok\":true}");
-    }
+    // RDR-154 P0 (nexus-i7ivk): handleUpdateDocCount / POST /topics/update_doc_count
+    // removed. topics.doc_count is maintained solely by the statement-level
+    // topic_assignments triggers; there is no app-side write path to expose.
 
     private void handleCountAssignments(HttpExchange ex, String tenant, String method) throws IOException {
         requireMethod(ex, method, "GET");

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -123,6 +123,12 @@
          before grants-nexus-svc (schema-wide DML grants provision the new tables). -->
     <include file="db/changelog/taxonomy-002-centroids.xml"/>
 
+    <!-- RDR-154 P0 (bead nexus-i7ivk): topics.doc_count statement-level
+         recompute triggers as the SOLE writer (SECURITY INVOKER). Must come
+         after taxonomy-001 (creates topics / topic_assignments) and before
+         grants-nexus-svc. -->
+    <include file="db/changelog/taxonomy-003-doc-count-trigger.xml"/>
+
     <!--
         Consolidated nexus_svc DML grants (bead nexus-net63) — runAlways="true".
         Must be LAST so all schema objects exist before grants are issued.

--- a/service/src/main/resources/db/changelog/taxonomy-003-doc-count-trigger.xml
+++ b/service/src/main/resources/db/changelog/taxonomy-003-doc-count-trigger.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    RDR-154 P0 bead nexus-i7ivk — topics.doc_count trigger as SOLE writer.
+
+    Replaces the scattered in-app doc_count recomputes (TaxonomyRepository
+    updateDocCount / assignTopic resync / mergeTopics resync / persistSplit
+    zero-out) with two statement-level triggers on nexus.topic_assignments
+    that recompute doc_count for the affected topics. This closes the
+    cascade/purge-delete hole that application code structurally cannot see:
+    deleting assignments (purge_assignments_for_doc) leaves the surviving
+    topics row, whose doc_count would otherwise strand stale-high.
+
+    Trigger functions are SECURITY INVOKER (never DEFINER). A DEFINER function
+    would run as its owner — not NOBYPASSRLS — and its UPDATE nexus.topics
+    would bypass FORCE ROW LEVEL SECURITY, allowing a cross-tenant write when
+    an assignment in tenant A references a topic owned by tenant B (the FK
+    check bypasses RLS, so such a row can exist). As INVOKER the recompute
+    inherits the session's nexus.tenant GUC and the FORCE-RLS policy scopes
+    the UPDATE to the session tenant's rows only.
+
+    Statement-level (not per-row) bounds the cost on the bulk-ETL assignment
+    path; affected topics are derived from the NEW/OLD transition tables.
+
+    doc_count is hereby a trigger-maintained column and MUST NOT participate
+    in any ETL ON CONFLICT DO UPDATE merge (RDR-154 Decision 1). The live
+    taxonomy-001-baseline.xml comment instructing GREATEST(EXCLUDED.doc_count,
+    topics.doc_count) is SUPERSEDED; a Liquibase changeset cannot edit a prior
+    one, so this changeset records the supersession via COMMENT ON COLUMN and
+    the taxonomy ETL upsert drops the column from its merge.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <!-- ── Changeset 1: recompute functions (SECURITY INVOKER) ───────────────── -->
+    <changeSet id="taxonomy-003-1" author="nexus-i7ivk">
+        <comment>doc_count statement-level recompute functions (SECURITY INVOKER)</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE FUNCTION nexus.topics_doc_count_recount_ins()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    SECURITY INVOKER
+AS $fn$
+BEGIN
+    UPDATE nexus.topics t
+       SET doc_count = (
+           SELECT COUNT(*)
+             FROM nexus.topic_assignments ta
+            WHERE ta.topic_id = t.id
+              AND ta.tenant_id = t.tenant_id
+       )
+      FROM (SELECT DISTINCT tenant_id, topic_id FROM new_rows) a
+     WHERE t.id = a.topic_id
+       AND t.tenant_id = a.tenant_id;
+    RETURN NULL;
+END;
+$fn$;
+        </sql>
+        <rollback>DROP FUNCTION IF EXISTS nexus.topics_doc_count_recount_ins()</rollback>
+    </changeSet>
+
+    <changeSet id="taxonomy-003-2" author="nexus-i7ivk">
+        <comment>doc_count DELETE-path recompute function (SECURITY INVOKER)</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE FUNCTION nexus.topics_doc_count_recount_del()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    SECURITY INVOKER
+AS $fn$
+BEGIN
+    UPDATE nexus.topics t
+       SET doc_count = (
+           SELECT COUNT(*)
+             FROM nexus.topic_assignments ta
+            WHERE ta.topic_id = t.id
+              AND ta.tenant_id = t.tenant_id
+       )
+      FROM (SELECT DISTINCT tenant_id, topic_id FROM old_rows) a
+     WHERE t.id = a.topic_id
+       AND t.tenant_id = a.tenant_id;
+    RETURN NULL;
+END;
+$fn$;
+        </sql>
+        <rollback>DROP FUNCTION IF EXISTS nexus.topics_doc_count_recount_del()</rollback>
+    </changeSet>
+
+    <!-- ── Changeset 2: statement-level triggers w/ transition tables ────────── -->
+    <changeSet id="taxonomy-003-3" author="nexus-i7ivk">
+        <comment>Statement-level AFTER INSERT / AFTER DELETE triggers on topic_assignments</comment>
+        <sql splitStatements="true" stripComments="false">
+CREATE TRIGGER trg_topic_assignments_doc_count_ins
+    AFTER INSERT ON nexus.topic_assignments
+    REFERENCING NEW TABLE AS new_rows
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION nexus.topics_doc_count_recount_ins();
+
+CREATE TRIGGER trg_topic_assignments_doc_count_del
+    AFTER DELETE ON nexus.topic_assignments
+    REFERENCING OLD TABLE AS old_rows
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION nexus.topics_doc_count_recount_del();
+        </sql>
+        <rollback>
+            DROP TRIGGER IF EXISTS trg_topic_assignments_doc_count_del ON nexus.topic_assignments;
+            DROP TRIGGER IF EXISTS trg_topic_assignments_doc_count_ins ON nexus.topic_assignments;
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset 3: supersede the ETL GREATEST instruction (RDR-154) ─────── -->
+    <changeSet id="taxonomy-003-4" author="nexus-i7ivk">
+        <comment>Mark doc_count trigger-maintained: do-not-ETL-write (supersedes taxonomy-001 GREATEST)</comment>
+        <sql splitStatements="false" stripComments="false">
+COMMENT ON COLUMN nexus.topics.doc_count IS
+    'Trigger-maintained (RDR-154 P0, bead nexus-i7ivk): sole writers are '
+    'trg_topic_assignments_doc_count_ins / _del. Do NOT hand-resync or '
+    'ETL-write this column; it is NOT an ON CONFLICT DO UPDATE merge '
+    'participant. Supersedes the taxonomy-001-baseline GREATEST instruction.';
+        </sql>
+        <rollback/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/test/java/dev/nexus/service/TaxonomyRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/TaxonomyRepositoryTest.java
@@ -744,9 +744,17 @@ class TaxonomyRepositoryTest {
 
     @Test @Order(42)
     void docCountTrigger_crossTenantIsolation() {
-        // SECURITY INVOKER + FORCE RLS: an assignment INSERT in tenant A that
-        // references a topic OWNED BY tenant B (the FK check bypasses RLS, so the
-        // row can be inserted) MUST NOT mutate tenant B's topics.doc_count.
+        // An assignment INSERT in tenant A that references a topic OWNED BY
+        // tenant B (the FK check bypasses RLS, so the row can be inserted) MUST
+        // NOT mutate tenant B's topics.doc_count.
+        //
+        // NOTE on what this proves: topics PK is `id` alone (globally unique), so
+        // a same-id topic cannot exist under two tenants — meaning INVOKER vs
+        // DEFINER is NOT behaviorally distinguishable here. The isolation this
+        // test exercises is the trigger's explicit `t.tenant_id = a.tenant_id`
+        // predicate (defense-in-depth), not RLS. The enforceable guard for the
+        // SECURITY INVOKER property itself is the prosecdef=false assertion in
+        // TaxonomySchemaLiquibaseTest.docCountTrigger_functionsTriggersAndComment.
         final long bTopicId = 9900500L;
         final String col = "knowledge__dctrg_xtenant";
         repo.importTopic(TENANT_B, bTopicId, "b-topic", null, col,
@@ -762,6 +770,24 @@ class TaxonomyRepositoryTest {
             .isEqualTo(7);
         // And tenant A owns no such topic id.
         assertThat(repo.getTopicById(TENANT_A, bTopicId)).isEmpty();
+    }
+
+    @Test @Order(43)
+    void docCountTrigger_discoveryAssignmentInsertOverridesSeed() {
+        // persistDiscoveredTopics seeds a per-spec doc_count then inserts the
+        // assignments. The AFTER INSERT trigger must recompute doc_count from the
+        // actual doc_ids, overriding any (here deliberately wrong) seed.
+        final String col = "knowledge__dctrg_disc";
+        var specs = List.of(
+            m("label", "disc-recount", "doc_count", 999, "terms", "[\"p\"]",
+              "assigned_by", "hdbscan",
+              "doc_ids", List.of("dr-doc-1", "dr-doc-2", "dr-doc-3")));
+        List<Long> ids = repo.persistDiscoveredTopics(TENANT_A, col, specs);
+        assertThat(ids).hasSize(1);
+
+        // Trigger recomputed the live count (3), not the bogus 999 seed.
+        assertThat(((Number) repo.getTopicById(TENANT_A, ids.get(0)).get().get("doc_count")).intValue())
+            .isEqualTo(3);
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────

--- a/service/src/test/java/dev/nexus/service/TaxonomyRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/TaxonomyRepositoryTest.java
@@ -435,28 +435,31 @@ class TaxonomyRepositoryTest {
     // ── ETL import ─────────────────────────────────────────────────────────────
 
     @Test @Order(21)
-    void importTopic_preservesIdAndGreatestDocCount() {
+    void importTopic_preservesId_docCountNotEtlMerged() {
+        // RDR-154 P0 (nexus-i7ivk): doc_count is trigger-maintained and is no
+        // longer an ETL ON CONFLICT merge participant. The INSERT branch seeds
+        // the column; re-imports MUST NOT touch it (neither GREATEST nor verbatim).
         long srcId = repo.importTopic(TENANT_A, 9900001L, "imported-topic", null, COL_A,
                                       "centroid-hash-1", 10, PAST_TS, "pending", null);
         assertThat(srcId).isEqualTo(9900001L);
         Optional<Map<String, Object>> row = repo.getTopicById(TENANT_A, 9900001L);
         assertThat(row).isPresent();
         assertThat(row.get().get("label")).isEqualTo("imported-topic");
-        assertThat(((Number) row.get().get("doc_count")).intValue()).isEqualTo(10);
+        assertThat(((Number) row.get().get("doc_count")).intValue()).isEqualTo(10); // seed
 
-        // Re-import with lower doc_count — GREATEST preserves higher value
+        // Re-import with LOWER doc_count — ETL no longer writes doc_count; seed preserved.
         repo.importTopic(TENANT_A, 9900001L, "imported-topic", null, COL_A,
                          "centroid-hash-1", 5, PAST_TS, "accepted", null);
         row = repo.getTopicById(TENANT_A, 9900001L);
-        assertThat(((Number) row.get().get("doc_count")).intValue()).isEqualTo(10); // GREATEST preserved
+        assertThat(((Number) row.get().get("doc_count")).intValue()).isEqualTo(10);
 
-        // Re-import with HIGHER doc_count — must win
+        // Re-import with HIGHER doc_count — still NOT written by the ETL upsert.
         repo.importTopic(TENANT_A, 9900001L, "imported-topic", null, COL_A,
                          "centroid-hash-1", 99, PAST_TS, "pending", null);
         row = repo.getTopicById(TENANT_A, 9900001L);
-        assertThat(((Number) row.get().get("doc_count")).intValue()).isEqualTo(99);
+        assertThat(((Number) row.get().get("doc_count")).intValue()).isEqualTo(10);
 
-        // review_status uses EXCLUDED (verbatim): last import wins
+        // review_status STILL uses EXCLUDED (verbatim): last import wins.
         assertThat(row.get().get("review_status")).isEqualTo("pending");
     }
 
@@ -694,6 +697,71 @@ class TaxonomyRepositoryTest {
         assertThat(ids).isEmpty();
         // Guard fired: still exactly the 3 pre-existing rows, none inserted.
         assertThat(repo.getAllTopics(TENANT_A, COL_DISC)).hasSize(3);
+    }
+
+    // ── RDR-154 P0 (nexus-i7ivk): doc_count trigger as SOLE writer ──────────────
+
+    @Test @Order(40)
+    void docCountTrigger_purgeDeleteLeavesCountCorrect() {
+        // The cascade/purge-delete hole the trigger closes: deleting some of a
+        // topic's assignments must recompute doc_count on the surviving row.
+        final String col = "knowledge__dctrg_purge";
+        long t = repo.insertTopic(TENANT_A, "purge-recount", null, col, 0, PAST_TS, null);
+        repo.assignTopic(TENANT_A, "pd-doc-1", t, "manual", null, col, null);
+        repo.assignTopic(TENANT_A, "pd-doc-2", t, "manual", null, col, null);
+        // AFTER INSERT trigger set the live count.
+        assertThat(((Number) repo.getTopicById(TENANT_A, t).get().get("doc_count")).intValue())
+            .isEqualTo(2);
+
+        // Purge one doc's assignment; topic survives (still has pd-doc-2).
+        repo.purgeAssignmentsForDoc(TENANT_A, col, "pd-doc-1");
+
+        // AFTER DELETE trigger recomputed: exactly 1 remains.
+        assertThat(((Number) repo.getTopicById(TENANT_A, t).get().get("doc_count")).intValue())
+            .isEqualTo(1);
+    }
+
+    @Test @Order(41)
+    void docCountTrigger_etlUpsertDoesNotStompTriggerValue() {
+        // After the trigger has computed a live count, an ETL importTopic upsert
+        // on the same row MUST NOT overwrite doc_count (RDR-154 Decision 1).
+        final String col = "knowledge__dctrg_etl";
+        long t = repo.insertTopic(TENANT_A, "etl-nostomp", null, col, 0, PAST_TS, null);
+        repo.assignTopic(TENANT_A, "es-doc-1", t, "manual", null, col, null);
+        repo.assignTopic(TENANT_A, "es-doc-2", t, "manual", null, col, null);
+        repo.assignTopic(TENANT_A, "es-doc-3", t, "manual", null, col, null);
+        assertThat(((Number) repo.getTopicById(TENANT_A, t).get().get("doc_count")).intValue())
+            .isEqualTo(3);
+
+        // ETL re-import the same id with a wildly different doc_count seed.
+        repo.importTopic(TENANT_A, t, "etl-nostomp", null, col,
+                         null, 99, PAST_TS, "accepted", null);
+
+        // Trigger value survives; the 99 was dropped from the ON CONFLICT merge.
+        assertThat(((Number) repo.getTopicById(TENANT_A, t).get().get("doc_count")).intValue())
+            .isEqualTo(3);
+    }
+
+    @Test @Order(42)
+    void docCountTrigger_crossTenantIsolation() {
+        // SECURITY INVOKER + FORCE RLS: an assignment INSERT in tenant A that
+        // references a topic OWNED BY tenant B (the FK check bypasses RLS, so the
+        // row can be inserted) MUST NOT mutate tenant B's topics.doc_count.
+        final long bTopicId = 9900500L;
+        final String col = "knowledge__dctrg_xtenant";
+        repo.importTopic(TENANT_B, bTopicId, "b-topic", null, col,
+                         null, 7, PAST_TS, "pending", null);
+        assertThat(((Number) repo.getTopicById(TENANT_B, bTopicId).get().get("doc_count")).intValue())
+            .isEqualTo(7);
+
+        // Tenant A inserts an assignment pointing at tenant B's topic id.
+        repo.assignTopic(TENANT_A, "xt-doc-a", bTopicId, "manual", null, col, null);
+
+        // Tenant B's row is untouched (trigger scoped to the session tenant).
+        assertThat(((Number) repo.getTopicById(TENANT_B, bTopicId).get().get("doc_count")).intValue())
+            .isEqualTo(7);
+        // And tenant A owns no such topic id.
+        assertThat(repo.getTopicById(TENANT_A, bTopicId)).isEmpty();
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────

--- a/service/src/test/java/dev/nexus/service/TaxonomySchemaLiquibaseTest.java
+++ b/service/src/test/java/dev/nexus/service/TaxonomySchemaLiquibaseTest.java
@@ -101,6 +101,79 @@ class TaxonomySchemaLiquibaseTest {
         }
     }
 
+    /**
+     * RDR-154 P0 (bead nexus-i7ivk): taxonomy-003 doc_count trigger changeset.
+     * Asserts the two recompute functions exist and are SECURITY INVOKER
+     * (prosecdef=false), both statement-level triggers exist on
+     * topic_assignments, and the trigger-maintained COMMENT is recorded on
+     * topics.doc_count.
+     */
+    @Test
+    void docCountTrigger_functionsTriggersAndComment() throws Exception {
+        try (PostgreSQLContainer<?> pg = PgContainerHelper.start()) {
+
+            try (Connection su = pg.createConnection("")) {
+                su.createStatement().execute(
+                    "DO $$ BEGIN " +
+                    "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
+                    "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass'; " +
+                    "  END IF; " +
+                    "END $$");
+
+                Database db = DatabaseFactory.getInstance()
+                    .findCorrectDatabaseImplementation(new JdbcConnection(su));
+                Liquibase lb = new Liquibase(
+                    "db/changelog/db.changelog-master.xml",
+                    new ClassLoaderResourceAccessor(), db);
+                lb.update(new Contexts());
+            }
+
+            try (Connection c = pg.createConnection("")) {
+                // Both recompute functions exist and are SECURITY INVOKER (prosecdef=false).
+                ResultSet fns = c.createStatement().executeQuery(
+                    "SELECT p.proname, p.prosecdef FROM pg_proc p " +
+                    "JOIN pg_namespace n ON n.oid = p.pronamespace " +
+                    "WHERE n.nspname = 'nexus' AND p.proname IN " +
+                    "('topics_doc_count_recount_ins','topics_doc_count_recount_del') " +
+                    "ORDER BY p.proname");
+                List<String> invokerFns = new ArrayList<>();
+                while (fns.next()) {
+                    assertThat(fns.getBoolean("prosecdef"))
+                        .as("function %s MUST be SECURITY INVOKER (prosecdef=false)",
+                            fns.getString("proname"))
+                        .isFalse();
+                    invokerFns.add(fns.getString("proname"));
+                }
+                assertThat(invokerFns).containsExactly(
+                    "topics_doc_count_recount_del", "topics_doc_count_recount_ins");
+
+                // Both statement-level triggers exist on nexus.topic_assignments.
+                ResultSet trg = c.createStatement().executeQuery(
+                    "SELECT t.tgname FROM pg_trigger t " +
+                    "JOIN pg_class cl ON cl.oid = t.tgrelid " +
+                    "JOIN pg_namespace n ON n.oid = cl.relnamespace " +
+                    "WHERE n.nspname = 'nexus' AND cl.relname = 'topic_assignments' " +
+                    "AND NOT t.tgisinternal ORDER BY t.tgname");
+                List<String> triggers = new ArrayList<>();
+                while (trg.next()) triggers.add(trg.getString("tgname"));
+                assertThat(triggers).contains(
+                    "trg_topic_assignments_doc_count_del",
+                    "trg_topic_assignments_doc_count_ins");
+
+                // Trigger-maintained COMMENT recorded on topics.doc_count.
+                ResultSet cmt = c.createStatement().executeQuery(
+                    "SELECT pgd.description FROM pg_description pgd " +
+                    "JOIN pg_class cl ON cl.oid = pgd.objoid " +
+                    "JOIN pg_namespace n ON n.oid = cl.relnamespace " +
+                    "JOIN pg_attribute a ON a.attrelid = cl.oid AND a.attnum = pgd.objsubid " +
+                    "WHERE n.nspname = 'nexus' AND cl.relname = 'topics' " +
+                    "AND a.attname = 'doc_count'");
+                assertThat(cmt.next()).as("doc_count must carry a COMMENT").isTrue();
+                assertThat(cmt.getString("description")).contains("Trigger-maintained");
+            }
+        }
+    }
+
     private static List<String> columnNames(Connection c, String schema, String table) throws Exception {
         ResultSet rs = c.createStatement().executeQuery(
             "SELECT column_name FROM information_schema.columns " +

--- a/src/nexus/commands/storage_cmd.py
+++ b/src/nexus/commands/storage_cmd.py
@@ -619,7 +619,8 @@ def migrate_taxonomy_cmd(
     topic_links, taxonomy_meta) and writes them through the service HTTP API.
     The ETL is idempotent:
 
-    - topics: GREATEST for doc_count; existing label/created_at preserved;
+    - topics: doc_count is NOT merged on conflict (trigger-maintained since
+      RDR-154 P0, nexus-i7ivk); existing label/created_at preserved;
       review_status/centroid_hash/terms always updated from source.
     - topic_assignments: GREATEST for similarity; other columns from source.
     - topic_links: GREATEST for link_count.

--- a/src/nexus/context.py
+++ b/src/nexus/context.py
@@ -130,27 +130,13 @@ def generate_context_l1(
     if not rows:
         return None
 
-    # nexus-9iw41 defensive dedup: collapse rows with identical
-    # (collection, label, doc_count) to one. Production has surfaced
-    # degenerate clustering states where N root topics in a single
-    # collection share an identical label+count (observed 2026-05-28:
-    # 5 rows all "Project knowledge findings content (144)" in a
-    # phantom docs__1-2188 collection, IDs 3401/3564/3727/3890/4053).
-    # Without dedup those N rows would all show as separate top-N
-    # entries in the Knowledge Map. Dedup is keyed on the exact tuple
-    # so legitimate distinct labels are unaffected.
-    seen: set[tuple[str, str, int]] = set()
-    deduped: list[tuple[str, str, int]] = []
-    for collection, label, doc_count in rows:
-        key = (collection, label, doc_count)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append((collection, label, doc_count))
-
-    # Group by collection prefix, filtered by repo if specified
+    # RDR-154 P0 (nexus-i7ivk): the nexus-9iw41 (collection, label, doc_count)
+    # dedup band-aid is retired. doc_count is now trigger-maintained (the sole
+    # writer is the topic_assignments statement-level trigger), so the read-side
+    # masking that papered over the drifting hand-maintained counter is removed.
+    # Group by collection prefix, filtered by repo if specified.
     prefixes: dict[str, list[tuple[str, int]]] = {}
-    for collection, label, doc_count in deduped:
+    for collection, label, doc_count in rows:
         if allowed is not None and collection not in allowed:
             continue
         prefix = collection.split("__")[0] if "__" in collection else collection

--- a/src/nexus/context.py
+++ b/src/nexus/context.py
@@ -131,9 +131,13 @@ def generate_context_l1(
         return None
 
     # RDR-154 P0 (nexus-i7ivk): the nexus-9iw41 (collection, label, doc_count)
-    # dedup band-aid is retired. doc_count is now trigger-maintained (the sole
-    # writer is the topic_assignments statement-level trigger), so the read-side
-    # masking that papered over the drifting hand-maintained counter is removed.
+    # read-side dedup band-aid is retired now that doc_count is trigger-maintained.
+    # CAVEAT: that band-aid actually masked a CLUSTERING-DUPLICATION state
+    # (multiple distinct topic rows sharing one label+count), which the doc_count
+    # trigger does NOT merge — so removing it can re-expose duplicate Knowledge
+    # Map entries for any DB still carrying that state. The underlying clustering
+    # duplication is tracked separately (nexus-slcn7); read-side re-masking is the
+    # wrong layer to fix it.
     # Group by collection prefix, filtered by repo if specified.
     prefixes: dict[str, list[tuple[str, int]]] = {}
     for collection, label, doc_count in rows:

--- a/src/nexus/db/t2/taxonomy_etl.py
+++ b/src/nexus/db/t2/taxonomy_etl.py
@@ -9,7 +9,11 @@ The SQLite source is NEVER modified (opened ``?mode=ro``).
 
 IDEMPOTENT: relies on the upsert conflict strategies the Java service enforces:
 - ``topics``:           ON CONFLICT (tenant_id, id) DO UPDATE
-    - ``doc_count``       = GREATEST(excluded.doc_count, topics.doc_count)
+    - ``doc_count``       — NOT an ON CONFLICT merge participant. RDR-154 P0
+      (nexus-i7ivk) made doc_count trigger-maintained (the topic_assignments
+      statement-level trigger is the SOLE writer); the INSERT branch seeds it
+      for a brand-new topic and the conflict branch leaves the live value
+      untouched. Do NOT re-add doc_count to the DO UPDATE clause.
     - ``review_status``   = EXCLUDED.review_status  (mutable annotation)
     - ``centroid_hash``   = EXCLUDED.centroid_hash  (mutable annotation)
     - ``terms``           = EXCLUDED.terms          (mutable annotation)
@@ -26,8 +30,9 @@ IDEMPOTENT: relies on the upsert conflict strategies the Java service enforces:
     - ``last_discover_at``        = EXCLUDED.* (more recent is better)
 
 FIDELITY-PRESERVING:
-- Monotonic counters (doc_count, link_count, last_discover_doc_count) use
-  GREATEST so re-runs preserve the high-water mark.
+- Monotonic counters (link_count, last_discover_doc_count) use GREATEST so
+  re-runs preserve the high-water mark. (doc_count is excluded — it is
+  trigger-maintained, not ETL-merged; see the topics note above.)
 - Timestamps and labels are NOT overwritten on conflict — original creation
   state survives re-runs.
 - review_status, centroid_hash, terms ARE overwritten on conflict so

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -104,26 +104,19 @@ class TestGenerateContextL1:
         assert "Code Topic 4" in content
         assert "Code Topic 5" not in content
 
-    def test_dedups_identical_root_topic_rows(self, db: T2Database, tmp_path: Path) -> None:
-        """nexus-9iw41: collapse rows with identical (collection, label, doc_count).
+    def test_no_readside_dedup_after_rdr154(self, db: T2Database, tmp_path: Path) -> None:
+        """RDR-154 P0 (nexus-i7ivk): the nexus-9iw41 read-side dedup is retired.
 
-        Production surfaced a phantom collection ``docs__1-2188`` with 5
-        ROOT topic rows all labelled ``Project knowledge findings content``
-        with ``doc_count=144`` (IDs 3401/3564/3727/3890/4053). Pre-fix the
-        Knowledge Map showed all 5 as separate top-N entries — the docs
-        side of the injected map was literally
-        ``Project knowledge findings content (144), Project knowledge
-        findings content (144), …`` five times.
-
-        Dedup is keyed on the exact tuple ``(collection, label, doc_count)``
-        so legitimate distinct labels (or distinct doc_counts on the same
-        label) are unaffected.
+        doc_count is now trigger-maintained (the topic_assignments statement-level
+        trigger is the sole writer), so ``generate_context_l1`` no longer masks
+        identical root-topic rows. Identical rows pass through verbatim (subject
+        only to the ``_TOPICS_PER_PREFIX`` cap). Any residual duplicate-topic-row
+        state is a separate clustering concern (nexus-9iw41), now surfaced rather
+        than papered over at read time.
         """
+        from nexus.context import _TOPICS_PER_PREFIX
         from nexus.context import generate_context_l1
 
-        # Five identical phantom rows (the production smoking-gun shape) +
-        # one legitimate distinct topic in the same collection so the test
-        # can prove the dedup didn't accidentally drop the real entry.
         for _ in range(5):
             db.taxonomy.conn.execute(
                 "INSERT INTO topics (label, collection, doc_count, created_at, review_status) "
@@ -131,24 +124,14 @@ class TestGenerateContextL1:
                 ("Phantom Duplicate", "docs__phantom", 144,
                  "2026-05-28T00:00:00Z", "accepted"),
             )
-        db.taxonomy.conn.execute(
-            "INSERT INTO topics (label, collection, doc_count, created_at, review_status) "
-            "VALUES (?, ?, ?, ?, ?)",
-            ("Legitimate Distinct", "docs__phantom", 90,
-             "2026-05-28T00:00:00Z", "accepted"),
-        )
         db.taxonomy.conn.commit()
 
         out = tmp_path / "context_l1.txt"
         generate_context_l1(db.taxonomy, output_path=out)
         content = out.read_text()
 
-        # The phantom label appears AT MOST ONCE (the five copies collapsed).
-        assert content.count("Phantom Duplicate") == 1, (
-            "dedup failed: phantom label appears more than once in the output"
-        )
-        # The legitimate distinct row in the same collection is preserved.
-        assert "Legitimate Distinct" in content
+        # No read-side collapse: identical rows appear up to the per-prefix cap.
+        assert content.count("Phantom Duplicate") == _TOPICS_PER_PREFIX
 
     def test_dedups_preserves_same_label_distinct_count(
         self, db: T2Database, tmp_path: Path,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -131,6 +131,9 @@ class TestGenerateContextL1:
         content = out.read_text()
 
         # No read-side collapse: identical rows appear up to the per-prefix cap.
+        # (Assumes _TOPICS_PER_PREFIX >= 5 so all 5 inserted rows are emitted;
+        # if the cap dropped below 5 this would silently under-count.)
+        assert _TOPICS_PER_PREFIX >= 5
         assert content.count("Phantom Duplicate") == _TOPICS_PER_PREFIX
 
     def test_dedups_preserves_same_label_distinct_count(


### PR DESCRIPTION
## RDR-154 P0 — `doc_count` trigger + counter principle

Makes `nexus.topics.doc_count` authoritative-by-construction: two statement-level `SECURITY INVOKER` triggers on `topic_assignments` (AFTER INSERT / AFTER DELETE) recompute `doc_count` for the affected topics as the **sole writer**. Closes the purge/cascade-delete hole that application code structurally cannot see (a surviving `topics` row stranding a stale-high count).

### Changes
- New Liquibase changeset `taxonomy-003-doc-count-trigger.xml`: two `SECURITY INVOKER` recompute functions + statement-level triggers (NEW/OLD transition tables) + `COMMENT ON COLUMN` marking `doc_count` trigger-maintained-do-not-ETL-write.
- Removed competing app-side writers: `updateDocCount`, the `assignTopic` / `mergeTopics` / `persistSplit` resyncs, and the latent `POST /topics/update_doc_count` endpoint.
- Dropped `doc_count` from the `importTopic` `ON CONFLICT DO UPDATE` merge (kept as an INSERT seed). A trigger-maintained column must not be an ETL merge participant.
- Retired the `context.py` nexus-9iw41 read-side dedup band-aid; corrected the stale `taxonomy_etl.py` / `storage_cmd.py` docstrings.

### Why `SECURITY INVOKER`
A `DEFINER` function would bypass `FORCE ROW LEVEL SECURITY` and could cross-tenant-write `topics` when an assignment in tenant A references a topic owned by tenant B (the FK check bypasses RLS). As `INVOKER` the recompute inherits the session tenant GUC and RLS scopes the write.

### Tests (TDD)
- `TaxonomySchemaLiquibaseTest`: functions exist + `prosecdef=false` + triggers + COMMENT.
- `TaxonomyRepositoryTest` Order 40/41/42/43: purge-delete recount, ETL no-stomp, cross-tenant isolation, discovery-seed-override — all exact assertions on real pg17 (Testcontainers).
- Rewrote Order 21 to the no-merge contract; `test_context` reflects band-aid removal.
- Full service suite green (752, fresh jOOQ codegen); `test_context` green.

### Review
- code-review-expert: APPROVED, 0 Critical.
- substantive-critic: 0 Critical / 3 Significant (all doc/test-framing), addressed in 9e0f5797.
- test-validator: PASS. phase-review-gate (P0): PASSED.

### Follow-ons (not P0 blockers)
- nexus-slcn7 — Knowledge Map duplicate root-topic rows resurface after band-aid removal (clustering-duplication, not `doc_count` drift).
- nexus-eh89h — batch per-topic assignment INSERTs (trigger O(N^2) on rebuild/discovery).

Closes #nexus-i7ivk