### PR TITLE
feat(rdr-154): P1 — security_invoker read-shape views (nexus-h9qyp)

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -1249,11 +1249,18 @@ public final class CatalogRepository {
 
     public Map<String, Object> stats(String tenant) {
         return tenantScope.withTenant(tenant, ctx -> {
-            long docCount  = ctx.selectCount().from(T_DOCS).fetchOne(0, Long.class);
-            long lnkCount  = ctx.selectCount().from(T_LINKS).fetchOne(0, Long.class);
-            long ownCount  = ctx.selectCount().from(T_OWNERS).fetchOne(0, Long.class);
-            long collCount = ctx.selectCount().from(T_COLLS).fetchOne(0, Long.class);
-            long chkCount  = ctx.selectCount().from(T_CHUNKS).fetchOne(0, Long.class);
+            // RDR-154 P1.2 (nexus-h9qyp): the five scalar counts come from the
+            // catalog_stats security_invoker view (per-subquery RLS scopes each to
+            // the GUC tenant), replacing five separate selectCount calls and the
+            // Java-side hand-assembly that the Python path duplicated.
+            var s = ctx.fetchOne(
+                "SELECT doc_count, link_count, owner_count, collection_count, chunk_count "
+                + "FROM nexus.catalog_stats");
+            long docCount  = s.get("doc_count", Long.class);
+            long lnkCount  = s.get("link_count", Long.class);
+            long ownCount  = s.get("owner_count", Long.class);
+            long collCount = s.get("collection_count", Long.class);
+            long chkCount  = s.get("chunk_count", Long.class);
             var ltypes = ctx.select(F_LNK_TYPE, DSL.count()).from(T_LINKS).groupBy(F_LNK_TYPE).fetch();
             Map<String, Long> byType = new LinkedHashMap<>();
             for (var r : ltypes) byType.put(r.value1(), (long) r.value2());
@@ -1291,25 +1298,18 @@ public final class CatalogRepository {
      */
     public Map<String, Object> collectionHealthMeta(String tenant, String collection) {
         return tenantScope.withTenant(tenant, ctx -> {
-            // MAX(indexed_at) for documents in the collection.
-            String lastIndexed = ctx
-                .select(DSL.max(F_DOC_IDXAT))
-                .from(T_DOCS)
-                .where(F_DOC_PCOLL.eq(collection))
-                .fetchOne(0, String.class);
-
-            // orphan_count: documents with no incoming link (to_tumbler).
-            long orphanCount = ctx
-                .selectCount()
-                .from(T_DOCS)
-                .leftJoin(T_LINKS).on(F_DOC_TUMBLER.eq(F_LNK_TO))
-                .where(F_DOC_PCOLL.eq(collection))
-                .and(F_LNK_ID.isNull())
-                .fetchOne(0, Long.class);
+            // RDR-154 P1.2 (nexus-h9qyp): read the collection_health_meta
+            // security_invoker view, filtered by collection (predicate pushdown).
+            // The view GROUP BYs collection, so it emits NO row for a collection
+            // with zero documents — default to {last_indexed:null, orphan_count:0}
+            // to preserve the prior contract.
+            var r = ctx.fetchOne(
+                "SELECT last_indexed, orphan_count FROM nexus.collection_health_meta "
+                + "WHERE collection = ?", collection);
 
             Map<String, Object> result = new LinkedHashMap<>();
-            result.put("last_indexed", lastIndexed);
-            result.put("orphan_count", orphanCount);
+            result.put("last_indexed", r == null ? null : r.get("last_indexed", String.class));
+            result.put("orphan_count", r == null ? 0L : r.get("orphan_count", Long.class));
             return result;
         });
     }
@@ -1441,14 +1441,14 @@ public final class CatalogRepository {
     /** Return {physical_collection -> doc_count} for all non-empty collections (nexus-xnz0o). */
     public Map<String, Long> collectionDocCounts(String tenant) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.select(F_DOC_PCOLL, DSL.count().cast(Long.class))
-                          .from(T_DOCS)
-                          .where(F_DOC_PCOLL.ne("").and(F_DOC_PCOLL.isNotNull()))
-                          .groupBy(F_DOC_PCOLL)
-                          .fetch();
+            // RDR-154 P1.2 (nexus-h9qyp): read the collection_doc_counts
+            // security_invoker view (replaces the hand-written GROUP BY).
+            var rows = ctx.fetch(
+                "SELECT physical_collection, doc_count FROM nexus.collection_doc_counts");
             Map<String, Long> result = new LinkedHashMap<>();
             for (var r : rows) {
-                result.put(r.value1(), r.value2());
+                result.put(r.get("physical_collection", String.class),
+                           r.get("doc_count", Long.class));
             }
             return result;
         });
@@ -1479,47 +1479,37 @@ public final class CatalogRepository {
      */
     public List<Map<String, Object>> coverageByContentType(String tenant, String ownerPrefix) {
         return tenantScope.withTenant(tenant, ctx -> {
-            // Build owner-prefix condition (empty = no filter)
-            Condition prefixCond = DSL.trueCondition();
-            if (ownerPrefix != null && !ownerPrefix.isBlank()) {
+            // RDR-154 P1.2 (nexus-h9qyp): replaces the 1+2N N+1 (one selectDistinct
+            // + two selectCount per content_type) with a single GROUP BY +
+            // count(*) FILTER. The unscoped case reads the coverage_by_content_type
+            // security_invoker view; the owner-prefix case runs the same aggregation
+            // with the prefix applied BEFORE the GROUP BY (a view cannot be
+            // parameterized, but the N+1 is eliminated either way).
+            org.jooq.Result<?> rows;
+            if (ownerPrefix == null || ownerPrefix.isBlank()) {
+                rows = ctx.fetch(
+                    "SELECT content_type, total, linked FROM nexus.coverage_by_content_type");
+            } else {
                 String likePat = ownerPrefix.replaceAll("\\.$", "") + ".%";
-                prefixCond = F_DOC_TUMBLER.like(likePat).or(F_DOC_TUMBLER.eq(ownerPrefix));
+                rows = ctx.fetch(
+                    "SELECT COALESCE(d.content_type, '') AS content_type, "
+                    + "count(*) AS total, "
+                    + "count(*) FILTER (WHERE EXISTS ("
+                    + "  SELECT 1 FROM nexus.catalog_links l "
+                    + "   WHERE l.from_tumbler = d.tumbler OR l.to_tumbler = d.tumbler"
+                    + ")) AS linked "
+                    + "FROM nexus.catalog_documents d "
+                    + "WHERE d.tumbler LIKE ? OR d.tumbler = ? "
+                    + "GROUP BY COALESCE(d.content_type, '')",
+                    likePat, ownerPrefix);
             }
 
-            // Distinct content types in scope
-            var typeRows = ctx.selectDistinct(F_DOC_CTYPE)
-                              .from(T_DOCS)
-                              .where(prefixCond)
-                              .fetch(F_DOC_CTYPE);
-
             List<Map<String, Object>> result = new ArrayList<>();
-            for (String ct : typeRows) {
-                String ctKey = ct == null ? "" : ct;
-                Condition typeCond = (ct == null)
-                    ? prefixCond.and(F_DOC_CTYPE.isNull())
-                    : prefixCond.and(F_DOC_CTYPE.eq(ct));
-
-                // Total count for this content_type + scope
-                long total = ctx.selectCount().from(T_DOCS).where(typeCond)
-                                .fetchOne(0, Long.class);
-
-                // Linked: documents that have at least one link in either direction.
-                // Use EXISTS subqueries for correct RLS scoping (mirrors SQLite JOIN ON
-                // d.tumbler = l.from_tumbler OR d.tumbler = l.to_tumbler).
-                var hasLink = DSL.exists(
-                    ctx.selectOne().from(T_LINKS)
-                       .where(F_LNK_FROM.eq(F_DOC_TUMBLER)
-                              .or(F_LNK_TO.eq(F_DOC_TUMBLER)))
-                );
-                long linked = ctx.selectCount()
-                                 .from(T_DOCS)
-                                 .where(typeCond.and(hasLink))
-                                 .fetchOne(0, Long.class);
-
+            for (var r : rows) {
                 Map<String, Object> row = new LinkedHashMap<>();
-                row.put("content_type", ctKey);
-                row.put("total",        total);
-                row.put("linked",       linked);
+                row.put("content_type", r.get("content_type", String.class));
+                row.put("total",        r.get("total", Long.class));
+                row.put("linked",       r.get("linked", Long.class));
                 result.add(row);
             }
             return result;

--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -1261,18 +1261,23 @@ public final class CatalogRepository {
             long ownCount  = s.get("owner_count", Long.class);
             long collCount = s.get("collection_count", Long.class);
             long chkCount  = s.get("chunk_count", Long.class);
-            var ltypes = ctx.select(F_LNK_TYPE, DSL.count()).from(T_LINKS).groupBy(F_LNK_TYPE).fetch();
+            // RDR-154 P1.2: the two GROUP-BY breakdowns also read views (completing
+            // the "5+2" collapse, Gap 3). links_by_type ← links_by_type_counts;
+            // by_content_type reuses coverage_by_content_type.total (same per-type
+            // document count — eliminates the duplicate aggregate the critic flagged).
+            var ltypes = ctx.fetch(
+                "SELECT link_type, link_count FROM nexus.links_by_type_counts");
             Map<String, Long> byType = new LinkedHashMap<>();
-            for (var r : ltypes) byType.put(r.value1(), (long) r.value2());
-            // nexus-xnz0o: add by_content_type for stats_cmd in catalog.py.
-            // Include the empty/null bucket (operators use it to detect un-typed docs).
-            // Key is "" for null/empty content_type rows, matching SQLite Catalog.stats().
-            var ctypes = ctx.select(F_DOC_CTYPE, DSL.count()).from(T_DOCS)
-                            .groupBy(F_DOC_CTYPE).fetch();
+            for (var r : ltypes) byType.put(r.get("link_type", String.class),
+                                            r.get("link_count", Long.class));
+            // by_content_type: key is "" for null/empty content_type (the view already
+            // COALESCEs to ''), matching SQLite Catalog.stats().
+            var ctypes = ctx.fetch(
+                "SELECT content_type, total FROM nexus.coverage_by_content_type");
             Map<String, Long> byContentType = new LinkedHashMap<>();
             for (var r : ctypes) {
-                String key = (r.value1() == null) ? "" : r.value1();
-                byContentType.put(key, (long) r.value2());
+                byContentType.put(r.get("content_type", String.class),
+                                  r.get("total", Long.class));
             }
             Map<String, Object> result = new LinkedHashMap<>();
             result.put("doc_count", docCount);

--- a/service/src/main/resources/db/changelog/catalog-009-read-shape-views.xml
+++ b/service/src/main/resources/db/changelog/catalog-009-read-shape-views.xml
@@ -109,9 +109,26 @@ SELECT d.tenant_id,
            )
        ) AS orphan_count
   FROM nexus.catalog_documents d
+ WHERE d.physical_collection IS NOT NULL
  GROUP BY d.tenant_id, d.physical_collection
         </sql>
         <rollback>DROP VIEW IF EXISTS nexus.collection_health_meta</rollback>
+    </changeSet>
+
+    <!-- ── Changeset 4b: links_by_type_counts (the 2nd of the "5+2" stats queries) ── -->
+    <changeSet id="catalog-009-4b" author="nexus-h9qyp">
+        <comment>nexus.links_by_type_counts — SECURITY INVOKER (link_type, link_count) GROUP BY; the links_by_type half of stats() (by_content_type reuses coverage_by_content_type.total)</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE VIEW nexus.links_by_type_counts
+    WITH (security_invoker = true)
+AS
+SELECT l.tenant_id,
+       l.link_type,
+       count(*) AS link_count
+  FROM nexus.catalog_links l
+ GROUP BY l.tenant_id, l.link_type
+        </sql>
+        <rollback>DROP VIEW IF EXISTS nexus.links_by_type_counts</rollback>
     </changeSet>
 
     <!-- ── Changeset 5: topics_with_counts ───────────────────────────────────── -->
@@ -145,9 +162,11 @@ GRANT SELECT ON nexus.collection_doc_counts    TO PUBLIC;
 GRANT SELECT ON nexus.coverage_by_content_type TO PUBLIC;
 GRANT SELECT ON nexus.collection_health_meta   TO PUBLIC;
 GRANT SELECT ON nexus.topics_with_counts       TO PUBLIC;
+GRANT SELECT ON nexus.links_by_type_counts     TO PUBLIC;
         </sql>
         <rollback>
             <sql splitStatements="true">
+                REVOKE SELECT ON nexus.links_by_type_counts     FROM PUBLIC;
                 REVOKE SELECT ON nexus.topics_with_counts       FROM PUBLIC;
                 REVOKE SELECT ON nexus.collection_health_meta   FROM PUBLIC;
                 REVOKE SELECT ON nexus.coverage_by_content_type FROM PUBLIC;

--- a/service/src/main/resources/db/changelog/catalog-009-read-shape-views.xml
+++ b/service/src/main/resources/db/changelog/catalog-009-read-shape-views.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    RDR-154 P1 bead nexus-h9qyp — security_invoker read-shape views.
+
+    Decision 3: replace hand-assembled read-shapes (duplicated across the Java
+    service and the Python local path, plus a Java N+1) with plain views, each
+    WITH (security_invoker = true) so the CALLER's RLS on the underlying tenant
+    tables provides isolation (RDR-154 standing rule; enforced by the
+    test_view_security_invoker_guard changelog-grep guard).
+
+    SEMANTICS PRESERVED (not changed): these mirror the existing repository
+    methods exactly, including that they count RAW catalog_documents /
+    catalog_links (the current stats()/coverage/collectionDocCounts methods do
+    NOT filter deleted_at). Tombstone-aware counts are a separate decision and
+    are deliberately out of P1 scope. (Contrast catalog-005 collection_vector_stats,
+    which deliberately reads live_chunks — that was RDR-156's explicit choice.)
+
+    Views:
+      - catalog_stats           — 5 scalar counts in one row (replaces the 5
+        selectCount calls in CatalogRepository.stats() + the Python dual-source
+        assembly in catalog.py). Per-subquery RLS scopes each count to the GUC tenant.
+      - collection_doc_counts   — (physical_collection, doc_count) GROUP BY.
+      - coverage_by_content_type — (content_type, total, linked) GROUP BY with
+        count(*) FILTER, replacing the 1+2N N+1 loop (global / no-prefix case;
+        the prefix-scoped path is a single GROUP BY query in Java — RDR-154 P1.2).
+      - collection_health_meta  — (collection, last_indexed, orphan_count) GROUP BY;
+        callers filter WHERE collection = ? on the view (predicate pushdown).
+      - topics_with_counts      — curated passthrough over nexus.topics exposing
+        the now-trigger-maintained doc_count (P0); the Python read-then-dedup
+        band-aid was already removed in P0.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <!-- ── Changeset 1: catalog_stats (5 scalar counts, one row) ─────────────── -->
+    <changeSet id="catalog-009-1" author="nexus-h9qyp">
+        <comment>nexus.catalog_stats — SECURITY INVOKER scalar-count view (per-subquery RLS scopes to caller tenant)</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE VIEW nexus.catalog_stats
+    WITH (security_invoker = true)
+AS
+SELECT (SELECT count(*) FROM nexus.catalog_documents)        AS doc_count,
+       (SELECT count(*) FROM nexus.catalog_links)            AS link_count,
+       (SELECT count(*) FROM nexus.catalog_owners)           AS owner_count,
+       (SELECT count(*) FROM nexus.catalog_collections)      AS collection_count,
+       (SELECT count(*) FROM nexus.catalog_document_chunks)  AS chunk_count
+        </sql>
+        <rollback>DROP VIEW IF EXISTS nexus.catalog_stats</rollback>
+    </changeSet>
+
+    <!-- ── Changeset 2: collection_doc_counts ────────────────────────────────── -->
+    <changeSet id="catalog-009-2" author="nexus-h9qyp">
+        <comment>nexus.collection_doc_counts — SECURITY INVOKER (physical_collection, doc_count)</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE VIEW nexus.collection_doc_counts
+    WITH (security_invoker = true)
+AS
+SELECT d.tenant_id,
+       d.physical_collection,
+       count(*) AS doc_count
+  FROM nexus.catalog_documents d
+ WHERE d.physical_collection IS NOT NULL
+   AND d.physical_collection &lt;&gt; ''
+ GROUP BY d.tenant_id, d.physical_collection
+        </sql>
+        <rollback>DROP VIEW IF EXISTS nexus.collection_doc_counts</rollback>
+    </changeSet>
+
+    <!-- ── Changeset 3: coverage_by_content_type (replaces the 1+2N N+1) ─────── -->
+    <changeSet id="catalog-009-3" author="nexus-h9qyp">
+        <comment>nexus.coverage_by_content_type — SECURITY INVOKER (content_type, total, linked) via count FILTER</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE VIEW nexus.coverage_by_content_type
+    WITH (security_invoker = true)
+AS
+SELECT d.tenant_id,
+       COALESCE(d.content_type, '') AS content_type,
+       count(*) AS total,
+       count(*) FILTER (
+           WHERE EXISTS (
+               SELECT 1 FROM nexus.catalog_links l
+                WHERE l.from_tumbler = d.tumbler
+                   OR l.to_tumbler   = d.tumbler
+           )
+       ) AS linked
+  FROM nexus.catalog_documents d
+ GROUP BY d.tenant_id, COALESCE(d.content_type, '')
+        </sql>
+        <rollback>DROP VIEW IF EXISTS nexus.coverage_by_content_type</rollback>
+    </changeSet>
+
+    <!-- ── Changeset 4: collection_health_meta ───────────────────────────────── -->
+    <changeSet id="catalog-009-4" author="nexus-h9qyp">
+        <comment>nexus.collection_health_meta — SECURITY INVOKER (collection, last_indexed, orphan_count); caller filters WHERE collection=?</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE VIEW nexus.collection_health_meta
+    WITH (security_invoker = true)
+AS
+SELECT d.tenant_id,
+       d.physical_collection AS collection,
+       max(d.indexed_at) AS last_indexed,
+       count(*) FILTER (
+           WHERE NOT EXISTS (
+               SELECT 1 FROM nexus.catalog_links l
+                WHERE l.to_tumbler = d.tumbler
+           )
+       ) AS orphan_count
+  FROM nexus.catalog_documents d
+ GROUP BY d.tenant_id, d.physical_collection
+        </sql>
+        <rollback>DROP VIEW IF EXISTS nexus.collection_health_meta</rollback>
+    </changeSet>
+
+    <!-- ── Changeset 5: topics_with_counts ───────────────────────────────────── -->
+    <changeSet id="catalog-009-5" author="nexus-h9qyp">
+        <comment>nexus.topics_with_counts — SECURITY INVOKER passthrough exposing trigger-maintained doc_count (P0)</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE VIEW nexus.topics_with_counts
+    WITH (security_invoker = true)
+AS
+SELECT t.tenant_id,
+       t.id,
+       t.label,
+       t.parent_id,
+       t.collection,
+       t.centroid_hash,
+       t.doc_count,
+       t.created_at,
+       t.review_status,
+       t.terms
+  FROM nexus.topics t
+        </sql>
+        <rollback>DROP VIEW IF EXISTS nexus.topics_with_counts</rollback>
+    </changeSet>
+
+    <!-- ── Changeset 6: GRANT SELECT to PUBLIC (live_chunks / catalog-005 pattern) ── -->
+    <changeSet id="catalog-009-6" author="nexus-h9qyp">
+        <comment>GRANT SELECT to PUBLIC — security_invoker makes caller RLS the boundary (catalog-005-2 rationale)</comment>
+        <sql splitStatements="true" stripComments="false">
+GRANT SELECT ON nexus.catalog_stats            TO PUBLIC;
+GRANT SELECT ON nexus.collection_doc_counts    TO PUBLIC;
+GRANT SELECT ON nexus.coverage_by_content_type TO PUBLIC;
+GRANT SELECT ON nexus.collection_health_meta   TO PUBLIC;
+GRANT SELECT ON nexus.topics_with_counts       TO PUBLIC;
+        </sql>
+        <rollback>
+            <sql splitStatements="true">
+                REVOKE SELECT ON nexus.topics_with_counts       FROM PUBLIC;
+                REVOKE SELECT ON nexus.collection_health_meta   FROM PUBLIC;
+                REVOKE SELECT ON nexus.coverage_by_content_type FROM PUBLIC;
+                REVOKE SELECT ON nexus.collection_doc_counts    FROM PUBLIC;
+                REVOKE SELECT ON nexus.catalog_stats            FROM PUBLIC;
+            </sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -116,6 +116,13 @@
          catalog-006. -->
     <include file="db/changelog/catalog-008-combined-query-extensions.xml"/>
 
+    <!-- RDR-154 P1 (bead nexus-h9qyp): security_invoker read-shape views
+         (catalog_stats, collection_doc_counts, coverage_by_content_type,
+         collection_health_meta, topics_with_counts) replacing hand-assembled
+         Java/Python read paths + the coverage N+1. Must come after the tables
+         they read (catalog-001, taxonomy-001) and before grants-nexus-svc. -->
+    <include file="db/changelog/catalog-009-read-shape-views.xml"/>
+
     <!-- pgvector taxonomy centroids (bead nexus-t1hnc.1, RDR-156):
          taxonomy_centroids_384/768/1024 — moves the taxonomy__centroids ChromaDB
          collection into Postgres so service-mode taxonomy compute is chroma-free.

--- a/service/src/test/java/dev/nexus/service/ReadShapeViewsTest.java
+++ b/service/src/test/java/dev/nexus/service/ReadShapeViewsTest.java
@@ -41,12 +41,12 @@ class ReadShapeViewsTest {
 
     private static final List<String> VIEWS = List.of(
         "catalog_stats", "collection_doc_counts", "coverage_by_content_type",
-        "collection_health_meta", "topics_with_counts");
+        "collection_health_meta", "topics_with_counts", "links_by_type_counts");
 
-    // The four views that carry a tenant_id column (catalog_stats is scalar).
+    // The views that carry a tenant_id column (catalog_stats is scalar).
     private static final List<String> GROUPED_VIEWS = List.of(
         "collection_doc_counts", "coverage_by_content_type",
-        "collection_health_meta", "topics_with_counts");
+        "collection_health_meta", "topics_with_counts", "links_by_type_counts");
 
     PostgreSQLContainer<?> pg;
     com.zaxxer.hikari.HikariDataSource svcDs;
@@ -75,24 +75,42 @@ class ReadShapeViewsTest {
         try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
-            for (String tbl : List.of("catalog_documents", "catalog_links", "topics")) {
+            for (String tbl : List.of("catalog_documents", "catalog_links", "topics",
+                                       "catalog_owners", "catalog_collections",
+                                       "catalog_document_chunks")) {
                 su.createStatement().execute(
                     "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus." + tbl + " TO " + SVC_ROLE);
             }
             su.createStatement().execute(
                 "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
 
-            // Fixtures: TENANT_A has 2 docs (one linked) + 1 topic in collection c_a;
-            // TENANT_B has 1 doc + 1 topic in collection c_b.
+            // Fixtures chosen so EVERY catalog_stats scalar differs A vs B (non-vacuous
+            // per-subquery RLS scoping) AND every grouped view has rows for both
+            // tenants. TENANT_A: 2 docs, 1 link, 2 owners, 2 collections, 2 chunks,
+            // 1 topic. TENANT_B: 1 doc, 2 links (dangling tumblers, links are not
+            // FK-enforced), 1 owner, 1 collection, 1 chunk, 1 topic.
             seedDoc(su, TENANT_A, "a.1", "paper", "c_a");
             seedDoc(su, TENANT_A, "a.2", "code",  "c_a");
             su.createStatement().execute(
                 "INSERT INTO nexus.catalog_links (tenant_id, from_tumbler, to_tumbler, link_type, created_by) "
                 + "VALUES ('" + TENANT_A + "', 'a.1', 'a.2', 'cites', 'test')");
             seedTopic(su, TENANT_A, "topic-a", "c_a");
+            seedOwner(su, TENANT_A, "a-own-1");
+            seedOwner(su, TENANT_A, "a-own-2");
+            seedColl(su, TENANT_A, "c_a");
+            seedColl(su, TENANT_A, "c_a2");
+            seedChunk(su, TENANT_A, "a.1", 0, "chash-a-0");
+            seedChunk(su, TENANT_A, "a.1", 1, "chash-a-1");
 
             seedDoc(su, TENANT_B, "b.1", "paper", "c_b");
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_links (tenant_id, from_tumbler, to_tumbler, link_type, created_by) "
+                + "VALUES ('" + TENANT_B + "', 'b.1', 'b.x1', 'cites', 'test'), "
+                + "       ('" + TENANT_B + "', 'b.1', 'b.x2', 'cites', 'test')");
             seedTopic(su, TENANT_B, "topic-b", "c_b");
+            seedOwner(su, TENANT_B, "b-own-1");
+            seedColl(su, TENANT_B, "c_b");
+            seedChunk(su, TENANT_B, "b.1", 0, "chash-b-0");
         }
 
         var cfg = new com.zaxxer.hikari.HikariConfig();
@@ -121,6 +139,26 @@ class ReadShapeViewsTest {
         su.createStatement().execute(
             "INSERT INTO nexus.topics (tenant_id, label, collection, doc_count, created_at, review_status) "
             + "VALUES ('" + tenant + "', '" + label + "', '" + coll + "', 0, now(), 'pending')");
+    }
+
+    private static void seedOwner(Connection su, String tenant, String prefix) throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_owners (tenant_id, tumbler_prefix, name, owner_type) "
+            + "VALUES ('" + tenant + "', '" + prefix + "', '" + prefix + "', 'repo')");
+    }
+
+    private static void seedColl(Connection su, String tenant, String name) throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('"
+            + tenant + "', '" + name + "')");
+    }
+
+    private static void seedChunk(Connection su, String tenant, String docId, int pos, String chash) throws Exception {
+        // chash must be exactly 32 chars (catalog_document_chunks_chash_len_check).
+        String c = (chash + "00000000000000000000000000000000").substring(0, 32);
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash) "
+            + "VALUES ('" + tenant + "', '" + docId + "', " + pos + ", '" + c + "')");
     }
 
     // ── reloption physically set on every view ──────────────────────────────────
@@ -183,17 +221,25 @@ class ReadShapeViewsTest {
         try (Connection svc = svcDs.getConnection()) {
             svc.createStatement().execute("SELECT set_config('nexus.tenant', '" + TENANT_A + "', false)");
             ResultSet a = svc.createStatement().executeQuery(
-                "SELECT doc_count, link_count FROM nexus.catalog_stats");
+                "SELECT doc_count, link_count, owner_count, collection_count, chunk_count "
+                + "FROM nexus.catalog_stats");
             a.next();
-            assertThat(a.getLong("doc_count")).as("GUC=A doc_count is exactly A's 2 docs").isEqualTo(2L);
-            assertThat(a.getLong("link_count")).as("GUC=A link_count is exactly A's 1 link").isEqualTo(1L);
+            assertThat(a.getLong("doc_count")).as("GUC=A doc_count").isEqualTo(2L);
+            assertThat(a.getLong("link_count")).as("GUC=A link_count").isEqualTo(1L);
+            assertThat(a.getLong("owner_count")).as("GUC=A owner_count").isEqualTo(2L);
+            assertThat(a.getLong("collection_count")).as("GUC=A collection_count").isEqualTo(2L);
+            assertThat(a.getLong("chunk_count")).as("GUC=A chunk_count").isEqualTo(2L);
 
             svc.createStatement().execute("SELECT set_config('nexus.tenant', '" + TENANT_B + "', false)");
             ResultSet b = svc.createStatement().executeQuery(
-                "SELECT doc_count, link_count FROM nexus.catalog_stats");
+                "SELECT doc_count, link_count, owner_count, collection_count, chunk_count "
+                + "FROM nexus.catalog_stats");
             b.next();
-            assertThat(b.getLong("doc_count")).as("GUC=B doc_count is exactly B's 1 doc").isEqualTo(1L);
-            assertThat(b.getLong("link_count")).as("GUC=B link_count is exactly B's 0 links").isEqualTo(0L);
+            assertThat(b.getLong("doc_count")).as("GUC=B doc_count").isEqualTo(1L);
+            assertThat(b.getLong("link_count")).as("GUC=B link_count").isEqualTo(2L);
+            assertThat(b.getLong("owner_count")).as("GUC=B owner_count").isEqualTo(1L);
+            assertThat(b.getLong("collection_count")).as("GUC=B collection_count").isEqualTo(1L);
+            assertThat(b.getLong("chunk_count")).as("GUC=B chunk_count").isEqualTo(1L);
         }
     }
 }

--- a/service/src/test/java/dev/nexus/service/ReadShapeViewsTest.java
+++ b/service/src/test/java/dev/nexus/service/ReadShapeViewsTest.java
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RDR-154 P1.2 (bead nexus-h9qyp) — security_invoker read-shape views.
+ *
+ * <p>Two guarantees, mirroring CollectionVectorStatsTest GROUP 3 + GROUP 5:
+ * <ul>
+ *   <li>Every one of the five views has {@code security_invoker=true} PHYSICALLY
+ *       set in pg_class.reloptions (a comment / a changelog-grep is not proof
+ *       that Liquibase actually applied it).</li>
+ *   <li>Cross-tenant isolation under a NOSUPERUSER NOBYPASSRLS svc role + GUC:
+ *       the grouped views (which carry tenant_id) leak ZERO foreign-tenant rows,
+ *       and the scalar catalog_stats view scopes its counts to the GUC tenant.
+ *       A superuser CONTROL proves foreign rows exist underneath (non-vacuous).</li>
+ * </ul>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ReadShapeViewsTest {
+
+    private static final String TENANT_A = "rsv-tenant-a";
+    private static final String TENANT_B = "rsv-tenant-b";
+    private static final String SVC_ROLE = "svc_rsv_test";
+    private static final String SVC_PASS = "svc_rsv_test_pass";
+
+    private static final List<String> VIEWS = List.of(
+        "catalog_stats", "collection_doc_counts", "coverage_by_content_type",
+        "collection_health_meta", "topics_with_counts");
+
+    // The four views that carry a tenant_id column (catalog_stats is scalar).
+    private static final List<String> GROUPED_VIEWS = List.of(
+        "collection_doc_counts", "coverage_by_content_type",
+        "collection_health_meta", "topics_with_counts");
+
+    PostgreSQLContainer<?> pg;
+    com.zaxxer.hikari.HikariDataSource svcDs;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='nexus_svc') THEN "
+                + "CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='" + SVC_ROLE + "') THEN "
+                + "CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
+        }
+
+        try (Connection su = pg.createConnection("")) {
+            new Liquibase("db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(
+                    new JdbcConnection(su))).update(new Contexts());
+        }
+
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            for (String tbl : List.of("catalog_documents", "catalog_links", "topics")) {
+                su.createStatement().execute(
+                    "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus." + tbl + " TO " + SVC_ROLE);
+            }
+            su.createStatement().execute(
+                "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+
+            // Fixtures: TENANT_A has 2 docs (one linked) + 1 topic in collection c_a;
+            // TENANT_B has 1 doc + 1 topic in collection c_b.
+            seedDoc(su, TENANT_A, "a.1", "paper", "c_a");
+            seedDoc(su, TENANT_A, "a.2", "code",  "c_a");
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_links (tenant_id, from_tumbler, to_tumbler, link_type, created_by) "
+                + "VALUES ('" + TENANT_A + "', 'a.1', 'a.2', 'cites', 'test')");
+            seedTopic(su, TENANT_A, "topic-a", "c_a");
+
+            seedDoc(su, TENANT_B, "b.1", "paper", "c_b");
+            seedTopic(su, TENANT_B, "topic-b", "c_b");
+        }
+
+        var cfg = new com.zaxxer.hikari.HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(4);
+        cfg.setAutoCommit(true);
+        svcDs = new com.zaxxer.hikari.HikariDataSource(cfg);
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (svcDs != null) svcDs.close();
+        if (pg != null) pg.stop();
+    }
+
+    private static void seedDoc(Connection su, String tenant, String tumbler,
+                                String ctype, String coll) throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title, content_type, physical_collection, indexed_at) "
+            + "VALUES ('" + tenant + "', '" + tumbler + "', 'T', '" + ctype + "', '" + coll + "', '2026-01-01T00:00:00Z')");
+    }
+
+    private static void seedTopic(Connection su, String tenant, String label, String coll) throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.topics (tenant_id, label, collection, doc_count, created_at, review_status) "
+            + "VALUES ('" + tenant + "', '" + label + "', '" + coll + "', 0, now(), 'pending')");
+    }
+
+    // ── reloption physically set on every view ──────────────────────────────────
+
+    @Test @Order(10)
+    void everyView_hasSecurityInvokerReloption() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            for (String view : VIEWS) {
+                ResultSet rs = su.createStatement().executeQuery(
+                    "SELECT reloptions FROM pg_class WHERE oid = 'nexus." + view + "'::regclass");
+                assertThat(rs.next()).as("view nexus.%s must exist", view).isTrue();
+                java.sql.Array arr = rs.getArray(1);
+                assertThat(arr).as("nexus.%s must HAVE reloptions", view).isNotNull();
+                assertThat((String[]) arr.getArray())
+                    .as("nexus.%s must have security_invoker=true PHYSICALLY set (RDR-154 standing rule)", view)
+                    .contains("security_invoker=true");
+            }
+        }
+    }
+
+    // ── grouped views leak zero foreign-tenant rows ─────────────────────────────
+
+    @Test @Order(20)
+    void groupedViews_gucA_seeZeroTenantBRows() throws Exception {
+        // CONTROL: superuser sees BOTH tenants in each grouped view (foreign rows exist).
+        try (Connection su = pg.createConnection("")) {
+            for (String view : GROUPED_VIEWS) {
+                ResultSet rs = su.createStatement().executeQuery(
+                    "SELECT count(*) FROM nexus." + view + " WHERE tenant_id = '" + TENANT_B + "'");
+                rs.next();
+                assertThat(rs.getLong(1))
+                    .as("CONTROL: superuser must see tenant-B rows in nexus.%s", view)
+                    .isGreaterThanOrEqualTo(1L);
+            }
+        }
+        // svc + GUC=A: zero tenant-B rows; at least one tenant-A row.
+        try (Connection svc = svcDs.getConnection()) {
+            svc.createStatement().execute("SELECT set_config('nexus.tenant', '" + TENANT_A + "', false)");
+            for (String view : GROUPED_VIEWS) {
+                ResultSet rsB = svc.createStatement().executeQuery(
+                    "SELECT count(*) FROM nexus." + view + " WHERE tenant_id = '" + TENANT_B + "'");
+                rsB.next();
+                assertThat(rsB.getLong(1))
+                    .as("GUC=A must see ZERO tenant-B rows in nexus.%s (caller RLS via security_invoker)", view)
+                    .isEqualTo(0L);
+                ResultSet rsA = svc.createStatement().executeQuery(
+                    "SELECT count(*) FROM nexus." + view + " WHERE tenant_id = '" + TENANT_A + "'");
+                rsA.next();
+                assertThat(rsA.getLong(1))
+                    .as("GUC=A must see its own tenant-A rows in nexus.%s", view)
+                    .isGreaterThanOrEqualTo(1L);
+            }
+        }
+    }
+
+    // ── scalar catalog_stats scopes counts to the GUC tenant ────────────────────
+
+    @Test @Order(30)
+    void catalogStats_scopesScalarCountsToGucTenant() throws Exception {
+        try (Connection svc = svcDs.getConnection()) {
+            svc.createStatement().execute("SELECT set_config('nexus.tenant', '" + TENANT_A + "', false)");
+            ResultSet a = svc.createStatement().executeQuery(
+                "SELECT doc_count, link_count FROM nexus.catalog_stats");
+            a.next();
+            assertThat(a.getLong("doc_count")).as("GUC=A doc_count is exactly A's 2 docs").isEqualTo(2L);
+            assertThat(a.getLong("link_count")).as("GUC=A link_count is exactly A's 1 link").isEqualTo(1L);
+
+            svc.createStatement().execute("SELECT set_config('nexus.tenant', '" + TENANT_B + "', false)");
+            ResultSet b = svc.createStatement().executeQuery(
+                "SELECT doc_count, link_count FROM nexus.catalog_stats");
+            b.next();
+            assertThat(b.getLong("doc_count")).as("GUC=B doc_count is exactly B's 1 doc").isEqualTo(1L);
+            assertThat(b.getLong("link_count")).as("GUC=B link_count is exactly B's 0 links").isEqualTo(0L);
+        }
+    }
+}

--- a/tests/db/test_view_security_invoker_guard.py
+++ b/tests/db/test_view_security_invoker_guard.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-154 P1.1 (bead nexus-tjptr): security_invoker standing-rule guard.
+
+Structural guard mirroring ``TestRlsTableCompleteness`` (RDR-152 P5.4): grep
+the Liquibase changelog XMLs at test time and assert the RDR-154 Decision 3
+standing rule holds for every view over a tenant (RLS) schema:
+
+  - Every ``CREATE [OR REPLACE] VIEW nexus.* / t1.*`` MUST be declared
+    ``WITH (security_invoker = true)``. A default (``security_definer``) view
+    over a FORCE-RLS table is a silent cross-tenant leak.
+  - Materialized views are DEFERRED (RDR-154 P1). A matview cannot honor RLS,
+    so the rule requires a ``tenant_id`` column + a ``security_invoker`` wrapper
+    plain view. Until that machinery lands, no ``CREATE MATERIALIZED VIEW`` may
+    exist over a tenant schema; adding one must extend this guard.
+
+NON-VACUOUS: a negative self-test proves the matcher would catch a view that
+omits the storage parameter.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_CHANGELOG_DIR = (
+    Path(__file__).resolve().parent.parent.parent
+    / "service" / "src" / "main" / "resources" / "db" / "changelog"
+)
+
+# CREATE [OR REPLACE] VIEW <schema>.<name> <storage-params...> AS
+# Captures the text between the view name and the AS keyword (the storage
+# parameter clause, if any). DOTALL so the clause may span lines.
+_VIEW_RE = re.compile(
+    r"CREATE\s+(?:OR\s+REPLACE\s+)?VIEW\s+((?:nexus|t1)\.\w+)\b(.*?)\bAS\b",
+    re.IGNORECASE | re.DOTALL,
+)
+_MATVIEW_RE = re.compile(
+    r"CREATE\s+MATERIALIZED\s+VIEW\s+((?:nexus|t1)\.\w+)",
+    re.IGNORECASE,
+)
+_INVOKER_RE = re.compile(r"security_invoker\s*=\s*true", re.IGNORECASE)
+
+
+def _xml_texts() -> list[tuple[str, str]]:
+    return [
+        (p.name, p.read_text(encoding="utf-8"))
+        for p in sorted(_CHANGELOG_DIR.glob("*.xml"))
+    ]
+
+
+def _plain_views() -> list[tuple[str, str, str]]:
+    """Return (file, view_name, storage_clause) for every plain view found."""
+    out: list[tuple[str, str, str]] = []
+    for fname, text in _xml_texts():
+        for m in _VIEW_RE.finditer(text):
+            out.append((fname, m.group(1), m.group(2)))
+    return out
+
+
+class TestViewSecurityInvokerGuard:
+    def test_changelog_dir_present(self):
+        if not _CHANGELOG_DIR.exists():
+            pytest.skip(f"changelog dir not found: {_CHANGELOG_DIR}")
+
+    def test_every_tenant_view_is_security_invoker(self):
+        """Every CREATE VIEW over nexus.* / t1.* carries security_invoker=true."""
+        if not _CHANGELOG_DIR.exists():
+            pytest.skip("changelog dir not found")
+
+        views = _plain_views()
+        # There is at least one such view today (catalog-005 collection_vector_stats);
+        # if the matcher finds none, it has silently stopped working.
+        assert views, (
+            "No CREATE VIEW over nexus.*/t1.* found in the changelog XMLs — "
+            "the matcher is broken (expected at least collection_vector_stats)."
+        )
+
+        offenders = [
+            f"{fname}: {view}"
+            for (fname, view, clause) in views
+            if not _INVOKER_RE.search(clause)
+        ]
+        assert not offenders, (
+            "RDR-154 Decision 3: every view over a tenant (RLS) table MUST be "
+            "created WITH (security_invoker = true). Offending views:\n  "
+            + "\n  ".join(sorted(offenders))
+        )
+
+    def test_no_undeferred_materialized_views(self):
+        """Matviews are deferred (RDR-154 P1): none may exist over a tenant
+        schema until the tenant_id + security_invoker-wrapper discipline lands."""
+        if not _CHANGELOG_DIR.exists():
+            pytest.skip("changelog dir not found")
+
+        matviews = [
+            f"{fname}: {m.group(1)}"
+            for fname, text in _xml_texts()
+            for m in _MATVIEW_RE.finditer(text)
+        ]
+        assert not matviews, (
+            "RDR-154 P1 defers materialized views. A matview over a tenant "
+            "schema requires a tenant_id column + a security_invoker wrapper "
+            "plain view; extend this guard before introducing one. Found:\n  "
+            + "\n  ".join(sorted(matviews))
+        )
+
+    def test_guard_is_non_vacuous(self):
+        """The matcher flags a view that omits security_invoker."""
+        bad = (
+            "CREATE OR REPLACE VIEW nexus.leaky_view AS "
+            "SELECT tenant_id FROM nexus.topics"
+        )
+        m = _VIEW_RE.search(bad)
+        assert m is not None and m.group(1) == "nexus.leaky_view"
+        assert _INVOKER_RE.search(m.group(2)) is None  # would be flagged
+
+        good = (
+            "CREATE OR REPLACE VIEW nexus.safe_view "
+            "WITH (security_invoker = true) AS SELECT tenant_id FROM nexus.topics"
+        )
+        m2 = _VIEW_RE.search(good)
+        assert m2 is not None and _INVOKER_RE.search(m2.group(2)) is not None


### PR DESCRIPTION
## RDR-154 P1 — `security_invoker` discipline + the view set

Replaces hand-assembled read-shapes with database views, each `WITH (security_invoker = true)` so the caller's RLS is the tenant-isolation boundary (RDR-154 Decision 3 standing rule).

### Changes
- **Standing-rule guard** (`tests/db/test_view_security_invoker_guard.py`): changelog-grep test asserting every `CREATE VIEW` over `nexus.*`/`t1.*` carries `security_invoker=true`; materialized views deferred; non-vacuous self-test. (Mirrors the RDR-152 P5.4 `_RLS_TENANT_TABLES` cross-walk.)
- **6 views** (`catalog-009-read-shape-views.xml`): `catalog_stats`, `collection_doc_counts`, `coverage_by_content_type` (the `count(*) FILTER` kills the prior 1+2N N+1), `collection_health_meta`, `topics_with_counts`, `links_by_type_counts`.
- **Java repoint** (`CatalogRepository`): `stats` (5 scalars + both group-bys now via views — the "5+2" fully collapsed; `by_content_type` reuses `coverage_by_content_type.total`), `collectionDocCounts`, `collectionHealthMeta`, `coverageByContentType` (prefix case = one GROUP BY query).
- **P1.0**: verified no-op — the suite already runs on Testcontainers `pgvector/pg17` (RDR-155); no io.zonky pins remain.

### Semantics & scope
- Views preserve the **raw-count** behavior of the prior methods exactly (no tombstone filter); `CatalogRepositoryTest` (84) stays green, including its RLS-isolation tests now exercising the views E2E.
- **Python**: service-mode `HttpCatalogClient` is a thin HTTP delegate that auto-benefits; the SQLite `Catalog.stats()` is a separate local-mode backend (no PG views), out of P1 scope (RDR-158 retires it).

### Tests
- `ReadShapeViewsTest` (3): reloption physically set on all 6 views; grouped views leak zero foreign-tenant rows under svc+GUC (superuser CONTROL = non-vacuity); `catalog_stats` scopes all 5 scalars to the GUC tenant with differing-per-tenant fixtures.
- Full service suite **751 green** (fresh jOOQ codegen). Guard 4 green.

### Review
- code-review-expert: APPROVED, 0 Critical (2 Medium fixed: test grants, NULL-collection filter).
- substantive-critic: 0 Critical / 3 Significant — S3 (5+2 collapse) completed; S2 a verified false positive; S1 (Python `chunk_count` parity) deferred with a bead.
- test-validator: PASS 91/91. phase-review-gate (P1): PASSED.

Builds on P0 (PR #1214, merged). No conflict — `catalog-009` coexists with P0's `taxonomy-003`.