### PR TITLE
perf(rdr-154): batch per-topic assignment INSERTs (nexus-eh89h)

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
@@ -1032,13 +1032,7 @@ public final class TaxonomyRepository {
                 long childId = row == null ? -1 : ((Number) row.get("id")).longValue();
                 childIds.add(childId);
 
-                for (String docId : docIds) {
-                    ctx.execute("""
-                        INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, assigned_by)
-                        VALUES (?, ?, ?, 'split')
-                        ON CONFLICT (tenant_id, doc_id, topic_id) DO NOTHING
-                        """, tenant, docId, childId);
-                }
+                batchInsertAssignments(ctx, tenant, childId, docIds, "split");
             }
 
             // RDR-154 P0 (nexus-i7ivk): no manual parent zero-out. The parent's
@@ -1139,13 +1133,7 @@ public final class TaxonomyRepository {
                 long topicId = row == null ? -1 : ((Number) row.get("id")).longValue();
                 topicIds.add(topicId);
 
-                for (String did : docIds) {
-                    ctx.execute("""
-                        INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, assigned_by)
-                        VALUES (?, ?, ?, ?)
-                        ON CONFLICT (tenant_id, doc_id, topic_id) DO NOTHING
-                        """, tenant, did, topicId, assignedBy);
-                }
+                batchInsertAssignments(ctx, tenant, topicId, docIds, assignedBy);
             }
 
             for (var e : transfers.entrySet()) {
@@ -1206,16 +1194,48 @@ public final class TaxonomyRepository {
                 long topicId = row == null ? -1 : ((Number) row.get("id")).longValue();
                 topicIds.add(topicId);
 
-                for (String did : docIds) {
-                    ctx.execute("""
-                        INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, assigned_by)
-                        VALUES (?, ?, ?, ?)
-                        ON CONFLICT (tenant_id, doc_id, topic_id) DO NOTHING
-                        """, tenant, did, topicId, assignedBy);
-                }
+                batchInsertAssignments(ctx, tenant, topicId, docIds, assignedBy);
             }
             log.info("persist_discovered collection={} topics={}", collection, topicIds.size());
             return topicIds;
         });
+    }
+
+    /**
+     * Insert a topic's assignments in a single multi-row statement (chunked under
+     * the PostgreSQL parameter limit) instead of one INSERT per doc_id.
+     *
+     * <p>RDR-154 P0 follow-on (nexus-eh89h): the {@code doc_count} trigger is
+     * statement-level and recomputes a full {@code COUNT(*)} for the affected
+     * topic on every firing. A per-row insert loop therefore fired the trigger
+     * once per doc_id, each scanning the topic's growing assignment set — O(N^2)
+     * per topic on the bulk rebuild / discovery / split paths. Batching collapses
+     * that to one trigger firing per chunk (one per topic for any realistic size).
+     *
+     * <p>{@code ON CONFLICT DO NOTHING} preserves the prior idempotency, including
+     * for duplicate doc_ids within a single batch (a self-conflict is skipped, not
+     * an error — DO NOTHING, not DO UPDATE).
+     */
+    private static void batchInsertAssignments(org.jooq.DSLContext ctx, String tenant,
+                                               long topicId, List<String> docIds,
+                                               String assignedBy) {
+        if (docIds == null || docIds.isEmpty()) return;
+        // 4 bind params per row → 5000 rows = 20000 params, well under PG's 65535.
+        final int MAX_ROWS = 5000;
+        for (int start = 0; start < docIds.size(); start += MAX_ROWS) {
+            List<String> batch = docIds.subList(start, Math.min(start + MAX_ROWS, docIds.size()));
+            StringBuilder sql = new StringBuilder(
+                "INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, assigned_by) VALUES ");
+            List<Object> params = new ArrayList<>(batch.size() * 4);
+            for (int i = 0; i < batch.size(); i++) {
+                sql.append(i == 0 ? "(?, ?, ?, ?)" : ", (?, ?, ?, ?)");
+                params.add(tenant);
+                params.add(batch.get(i));
+                params.add(topicId);
+                params.add(assignedBy);
+            }
+            sql.append(" ON CONFLICT (tenant_id, doc_id, topic_id) DO NOTHING");
+            ctx.execute(sql.toString(), params.toArray());
+        }
     }
 }

--- a/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
@@ -1136,6 +1136,11 @@ public final class TaxonomyRepository {
                 batchInsertAssignments(ctx, tenant, topicId, docIds, assignedBy);
             }
 
+            // Manual transfers are intentionally NOT batched (nexus-eh89h): they
+            // use ON CONFLICT DO UPDATE (distinct from the helper's DO NOTHING) and
+            // are sparse (curated reassignments, expected well under ~100 per
+            // rebuild), so the per-row trigger cost is immaterial. If a bulk
+            // manual-transfer path ever emerges, batch it with a DO UPDATE variant.
             for (var e : transfers.entrySet()) {
                 int specIndex = ((Number) e.getValue()).intValue();
                 if (specIndex >= 0 && specIndex < topicIds.size()) {
@@ -1220,7 +1225,10 @@ public final class TaxonomyRepository {
                                                long topicId, List<String> docIds,
                                                String assignedBy) {
         if (docIds == null || docIds.isEmpty()) return;
-        // 4 bind params per row → 5000 rows = 20000 params, well under PG's 65535.
+        // 4 bind params per row → 5000 rows = 20000 params, under PG's Int16
+        // Bind-message parameter-count limit of 32767. (A topic with >5000 docs
+        // fires the trigger ceil(N/5000) times — still vastly better than per-row;
+        // realistic topics are hundreds to low-thousands.)
         final int MAX_ROWS = 5000;
         for (int start = 0; start < docIds.size(); start += MAX_ROWS) {
             List<String> batch = docIds.subList(start, Math.min(start + MAX_ROWS, docIds.size()));

--- a/service/src/test/java/dev/nexus/service/TaxonomyRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/TaxonomyRepositoryTest.java
@@ -790,6 +790,28 @@ class TaxonomyRepositoryTest {
             .isEqualTo(3);
     }
 
+    @Test @Order(44)
+    void batchedAssignmentInsert_largeTopic_exactCountAndAllDocs() {
+        // nexus-eh89h: the per-topic assignments are now inserted in one multi-row
+        // statement. Exercise a large doc set to guard the VALUES builder and
+        // confirm the doc_count trigger computes the exact live count.
+        final String col = "knowledge__batch_large";
+        List<String> docIds = new java.util.ArrayList<>();
+        for (int i = 0; i < 50; i++) docIds.add("bl-doc-" + i);
+        var specs = List.of(
+            m("label", "batch-large", "doc_count", 0, "terms", "[\"p\"]",
+              "assigned_by", "hdbscan", "doc_ids", docIds));
+        List<Long> ids = repo.persistDiscoveredTopics(TENANT_A, col, specs);
+        assertThat(ids).hasSize(1);
+
+        assertThat(((Number) repo.getTopicById(TENANT_A, ids.get(0)).get().get("doc_count")).intValue())
+            .as("trigger computes exact count over the batched multi-row insert")
+            .isEqualTo(50);
+        assertThat(repo.getTopicDocIds(TENANT_A, ids.get(0), 0))
+            .as("all 50 assignments present")
+            .hasSize(50);
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────────────
 
     /** Build a {@code Map<String,Object>} from alternating key/value varargs (mixed value types). */


### PR DESCRIPTION
## Batch per-topic assignment INSERTs — collapse the P0 trigger O(N²)

The P0 `doc_count` trigger (RDR-154) is statement-level and recomputes a full `COUNT(*)` for the affected topic on every firing. `persistSplit` / `persistRebuildTopics` / `persistDiscoveredTopics` inserted a topic's assignments **one row per statement**, so the trigger fired once per `doc_id` — each scanning the topic's growing assignment set, making the bulk rebuild/discovery/split path **O(N²) per topic**.

### Fix
A shared `batchInsertAssignments()` helper emits a **single multi-row `INSERT ... VALUES`** (chunked at 5000 rows / 20000 bind params, under PG's Int16 limit) with `ON CONFLICT DO NOTHING`. The trigger now fires **once per chunk — once per topic** for any realistic size, collapsing the quadratic.

Behavior-preserving: idempotency and `assigned_by` semantics unchanged; duplicate `doc_id`s within a batch are skipped (`DO NOTHING` self-conflict, not an error). The manual-transfers loop is intentionally left per-row (distinct `DO UPDATE` semantics + sparse cardinality — documented).

### Tests / review
- `TaxonomyRepositoryTest` **37 green** (incl. a new 50-doc batch test asserting the trigger computes the exact count over the multi-row insert). Full service suite **757 green**.
- code-review-expert: APPROVED, 0 Critical (M1 comment fixed). substantive-critic: justified, 0 Critical / 1 Significant (manual-transfers exception documented).

Follow-on to RDR-154 P0 (`nexus-i7ivk`, #1214 merged).

Closes #nexus-eh89h