### PR TITLE
fix(rdr-154): dedup root topics at the source + uniqueness backstop (nexus-slcn7)

### DIFF
--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -136,6 +136,11 @@
          grants-nexus-svc. -->
     <include file="db/changelog/taxonomy-003-doc-count-trigger.xml"/>
 
+    <!-- nexus-slcn7 (RDR-154 follow-on): merge duplicate root topics + partial
+         unique (tenant_id, collection, label) index. After taxonomy-003 (the
+         doc_count trigger recomputes during the assignment moves). -->
+    <include file="db/changelog/taxonomy-004-dedup-root-topics.xml"/>
+
     <!-- RDR-154 P2 (bead nexus-2zv75): DB-enforced updated_at on document_aspects
          and topics ONLY, via a shared BEFORE UPDATE trigger (SECURITY INVOKER).
          Must come after those tables exist (aspects-001, taxonomy-001) and

--- a/service/src/main/resources/db/changelog/taxonomy-004-dedup-root-topics.xml
+++ b/service/src/main/resources/db/changelog/taxonomy-004-dedup-root-topics.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    nexus-slcn7 (RDR-154 follow-on) — merge duplicate root topics, then enforce
+    uniqueness of (tenant_id, collection, label) among root topics.
+
+    The c-TF-IDF labeler could assign the same label to distinct HDBSCAN clusters
+    and discovery was additive, so a (tenant_id, collection, label) could carry
+    several root-topic (parent_id IS NULL) rows — duplicate Knowledge Map entries
+    once the RDR-154 read-side band-aid was removed. The root-cause prevention is
+    the spec dedup in taxonomy_compute (Python feeds both backends). This changeset
+    repairs any pre-existing PG data (carried over by the SQLite→PG ETL) and
+    installs the partial unique index as the structural backstop.
+
+    Must run after taxonomy-001 (tables) and taxonomy-003 (doc_count trigger): the
+    assignment moves below fire that trigger, which recomputes the kept topic's
+    doc_count automatically. Links touching a dup are deleted (topic_links are
+    recomputable co-occurrence edges) rather than carefully repointed.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <!-- ── Changeset 1: merge duplicate root topics ──────────────────────────── -->
+    <changeSet id="taxonomy-004-1" author="nexus-slcn7">
+        <comment>Merge duplicate (tenant_id, collection, label) root topics onto the lowest id</comment>
+        <sql splitStatements="false" stripComments="false">
+DO $$
+BEGIN
+    CREATE TEMP TABLE _slcn7_dup_map ON COMMIT DROP AS
+    SELECT t.tenant_id, t.id AS dup_id, m.keep_id
+      FROM nexus.topics t
+      JOIN (
+            SELECT tenant_id, collection, label, MIN(id) AS keep_id
+              FROM nexus.topics
+             WHERE parent_id IS NULL
+             GROUP BY tenant_id, collection, label
+            HAVING COUNT(*) > 1
+           ) m
+        ON m.tenant_id = t.tenant_id
+       AND m.collection = t.collection
+       AND m.label = t.label
+     WHERE t.parent_id IS NULL
+       AND t.id &lt;&gt; m.keep_id;
+
+    -- Move assignments onto the kept topic (skip docs already there), then drop
+    -- the redundant rows. Both statements fire the doc_count trigger.
+    INSERT INTO nexus.topic_assignments
+        (tenant_id, doc_id, topic_id, assigned_by, similarity, assigned_at, source_collection)
+    SELECT ta.tenant_id, ta.doc_id, dm.keep_id, ta.assigned_by,
+           ta.similarity, ta.assigned_at, ta.source_collection
+      FROM nexus.topic_assignments ta
+      JOIN _slcn7_dup_map dm
+        ON dm.dup_id = ta.topic_id AND dm.tenant_id = ta.tenant_id
+    ON CONFLICT (tenant_id, doc_id, topic_id) DO NOTHING;
+
+    DELETE FROM nexus.topic_assignments ta
+     USING _slcn7_dup_map dm
+     WHERE dm.dup_id = ta.topic_id AND dm.tenant_id = ta.tenant_id;
+
+    -- Re-parent any children of a dup onto the kept topic.
+    UPDATE nexus.topics t
+       SET parent_id = dm.keep_id
+      FROM _slcn7_dup_map dm
+     WHERE t.parent_id = dm.dup_id AND t.tenant_id = dm.tenant_id;
+
+    -- Drop links touching a dup (recomputable co-occurrence edges).
+    DELETE FROM nexus.topic_links tl
+     USING _slcn7_dup_map dm
+     WHERE (tl.from_topic_id = dm.dup_id OR tl.to_topic_id = dm.dup_id)
+       AND tl.tenant_id = dm.tenant_id;
+
+    -- Finally drop the redundant root topics.
+    DELETE FROM nexus.topics t
+     USING _slcn7_dup_map dm
+     WHERE t.id = dm.dup_id AND t.tenant_id = dm.tenant_id;
+END $$;
+        </sql>
+        <rollback/>
+    </changeSet>
+
+    <!-- ── Changeset 2: partial unique index (structural backstop) ────────────── -->
+    <changeSet id="taxonomy-004-2" author="nexus-slcn7">
+        <comment>Unique (tenant_id, collection, label) among root topics</comment>
+        <sql splitStatements="true" stripComments="false">
+CREATE UNIQUE INDEX IF NOT EXISTS idx_topics_root_tenant_collection_label
+    ON nexus.topics (tenant_id, collection, label)
+ WHERE parent_id IS NULL;
+        </sql>
+        <rollback>DROP INDEX IF EXISTS nexus.idx_topics_root_tenant_collection_label</rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/test/java/dev/nexus/service/TaxonomyRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/TaxonomyRepositoryTest.java
@@ -790,6 +790,29 @@ class TaxonomyRepositoryTest {
             .isEqualTo(3);
     }
 
+    @Test @Order(45)
+    void rootTopicUniqueness_dupRejected_childAndOtherTenantAllowed() {
+        // nexus-slcn7: partial unique index on (tenant_id, collection, label)
+        // WHERE parent_id IS NULL forbids duplicate ROOT topics, while children
+        // and other tenants may reuse the label.
+        final String col = "knowledge__uniq";
+        long root = repo.insertTopic(TENANT_A, "uniq-label", null, col, 0, PAST_TS, null);
+        assertThat(root).isPositive();
+
+        // Duplicate ROOT (same tenant, collection, label) → unique-index violation.
+        assertThatThrownBy(() ->
+            repo.insertTopic(TENANT_A, "uniq-label", null, col, 0, PAST_TS, null))
+            .isInstanceOf(org.jooq.exception.DataAccessException.class);
+
+        // A CHILD topic (parent_id set) with the same label is allowed.
+        long child = repo.insertTopic(TENANT_A, "uniq-label", root, col, 0, PAST_TS, null);
+        assertThat(child).isPositive();
+
+        // A different tenant may reuse the label.
+        long bRoot = repo.insertTopic(TENANT_B, "uniq-label", null, col, 0, PAST_TS, null);
+        assertThat(bRoot).isPositive();
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────────────
 
     /** Build a {@code Map<String,Object>} from alternating key/value varargs (mixed value types). */

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -74,6 +74,80 @@ def _parse_version(ver: str) -> tuple[int, ...]:
 # ── Dataclass ───────────────────────────────────────────────────────────────
 
 
+def migrate_dedup_root_topics(conn: sqlite3.Connection) -> None:
+    """nexus-slcn7: collapse duplicate root topics, then enforce uniqueness.
+
+    The c-TF-IDF labeler could assign the same label to distinct HDBSCAN clusters,
+    and discovery was additive, so a ``(collection, label)`` could end up with
+    several root-topic (``parent_id IS NULL``) rows — surfacing as duplicate
+    Knowledge Map entries once the RDR-154 read-side dedup band-aid was removed
+    (the root-cause prevention is the spec dedup in ``taxonomy_compute``). This
+    migration repairs existing data and installs a partial unique index so the
+    state cannot recur. Idempotent: re-running is a no-op once deduped.
+
+    For each duplicated ``(collection, label)`` group of root topics it keeps the
+    lowest id, moves that group's assignments / child topics / links onto the
+    kept id, deletes the redundant rows, and recomputes the kept topic's
+    ``doc_count`` from its live assignments.
+    """
+    has_topics = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='topics'"
+    ).fetchone()
+    if has_topics is None:
+        return
+
+    groups = conn.execute(
+        """
+        SELECT collection, label, MIN(id) AS keep_id, GROUP_CONCAT(id) AS ids
+        FROM topics
+        WHERE parent_id IS NULL
+        GROUP BY collection, label
+        HAVING COUNT(*) > 1
+        """
+    ).fetchall()
+
+    for collection, label, keep_id, ids in groups:
+        dup_ids = [int(i) for i in str(ids).split(",") if int(i) != keep_id]
+        for dup_id in dup_ids:
+            # Move assignments onto the kept topic (PK (doc_id, topic_id) — a doc
+            # already on keep_id is skipped), then drop the redundant rows.
+            conn.execute(
+                "INSERT OR IGNORE INTO topic_assignments (doc_id, topic_id, assigned_by) "
+                "SELECT doc_id, ?, assigned_by FROM topic_assignments WHERE topic_id = ?",
+                (keep_id, dup_id),
+            )
+            conn.execute("DELETE FROM topic_assignments WHERE topic_id = ?", (dup_id,))
+            # Re-parent any children of the dup onto the kept topic.
+            conn.execute("UPDATE topics SET parent_id = ? WHERE parent_id = ?", (keep_id, dup_id))
+            # Repoint links; UPDATE OR IGNORE drops rows that would collide on the
+            # (from, to) PK, then delete any self-links / leftovers on the dup.
+            conn.execute(
+                "UPDATE OR IGNORE topic_links SET from_topic_id = ? WHERE from_topic_id = ?",
+                (keep_id, dup_id),
+            )
+            conn.execute(
+                "UPDATE OR IGNORE topic_links SET to_topic_id = ? WHERE to_topic_id = ?",
+                (keep_id, dup_id),
+            )
+            conn.execute(
+                "DELETE FROM topic_links WHERE from_topic_id = ? OR to_topic_id = ? "
+                "OR from_topic_id = to_topic_id",
+                (dup_id, dup_id),
+            )
+            conn.execute("DELETE FROM topics WHERE id = ?", (dup_id,))
+        conn.execute(
+            "UPDATE topics SET doc_count = "
+            "(SELECT COUNT(*) FROM topic_assignments WHERE topic_id = ?) WHERE id = ?",
+            (keep_id, keep_id),
+        )
+
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_topics_root_collection_label "
+        "ON topics(collection, label) WHERE parent_id IS NULL"
+    )
+    conn.commit()
+
+
 @dataclass(frozen=True)
 class Migration:
     """A single T2 schema migration, tagged with the version that introduced it.
@@ -2117,6 +2191,11 @@ MIGRATIONS: list[Migration] = [
         "5.5.0",
         "RDR-139 Layer E: add document_highlights table",
         migrate_document_highlights_table,
+    ),
+    Migration(
+        "5.10.7",
+        "nexus-slcn7: merge duplicate root topics + unique (collection,label) index",
+        migrate_dedup_root_topics,
     ),
 ]
 

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -119,19 +119,11 @@ def migrate_dedup_root_topics(conn: sqlite3.Connection) -> None:
             conn.execute("DELETE FROM topic_assignments WHERE topic_id = ?", (dup_id,))
             # Re-parent any children of the dup onto the kept topic.
             conn.execute("UPDATE topics SET parent_id = ? WHERE parent_id = ?", (keep_id, dup_id))
-            # Repoint links; UPDATE OR IGNORE drops rows that would collide on the
-            # (from, to) PK, then delete any self-links / leftovers on the dup.
+            # Drop links touching the dup (recomputable co-occurrence edges) — same
+            # strategy as the PG taxonomy-004 changeset, keeping the two backends
+            # consistent and avoiding a (from, to) PK-collision repoint.
             conn.execute(
-                "UPDATE OR IGNORE topic_links SET from_topic_id = ? WHERE from_topic_id = ?",
-                (keep_id, dup_id),
-            )
-            conn.execute(
-                "UPDATE OR IGNORE topic_links SET to_topic_id = ? WHERE to_topic_id = ?",
-                (keep_id, dup_id),
-            )
-            conn.execute(
-                "DELETE FROM topic_links WHERE from_topic_id = ? OR to_topic_id = ? "
-                "OR from_topic_id = to_topic_id",
+                "DELETE FROM topic_links WHERE from_topic_id = ? OR to_topic_id = ?",
                 (dup_id, dup_id),
             )
             conn.execute("DELETE FROM topics WHERE id = ?", (dup_id,))

--- a/src/nexus/db/t2/taxonomy_compute.py
+++ b/src/nexus/db/t2/taxonomy_compute.py
@@ -361,7 +361,37 @@ def compute_discovered_topics(
             "centroid": [float(x) for x in centroids[cid].tolist()],
             "assigned_by": "hdbscan",
         })
-    return specs
+    return _dedup_specs_by_label(specs)
+
+
+def _dedup_specs_by_label(specs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse discovered specs that share an identical label (nexus-slcn7).
+
+    The c-TF-IDF top-3 labeler can assign the SAME label string to two distinct
+    HDBSCAN clusters (their top-3 terms collide). Persisted as-is, each becomes a
+    separate root topic with an identical ``(collection, label)``, which surfaces
+    as duplicate Knowledge Map rows once the RDR-154 read-side dedup band-aid is
+    removed. Merge same-label specs at the source instead: union their ``doc_ids``,
+    recompute ``doc_count``, keep the first cluster's centroid/terms (order
+    preserved). One root topic per label is then the invariant both T2 backends
+    persist, and the partial unique index is its structural backstop.
+    """
+    merged: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    for spec in specs:
+        label = spec["label"]
+        existing = merged.get(label)
+        if existing is None:
+            merged[label] = {**spec, "doc_ids": list(spec["doc_ids"])}
+            order.append(label)
+            continue
+        seen = set(existing["doc_ids"])
+        for did in spec["doc_ids"]:
+            if did not in seen:
+                existing["doc_ids"].append(did)
+                seen.add(did)
+        existing["doc_count"] = len(existing["doc_ids"])
+    return [merged[label] for label in order]
 
 
 def compute_rebuild_plan(

--- a/src/nexus/db/t2/taxonomy_compute.py
+++ b/src/nexus/db/t2/taxonomy_compute.py
@@ -361,10 +361,13 @@ def compute_discovered_topics(
             "centroid": [float(x) for x in centroids[cid].tolist()],
             "assigned_by": "hdbscan",
         })
-    return _dedup_specs_by_label(specs)
+    specs, _ = _dedup_specs_by_label(specs)
+    return specs
 
 
-def _dedup_specs_by_label(specs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _dedup_specs_by_label(
+    specs: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[int, int]]:
     """Collapse discovered specs that share an identical label (nexus-slcn7).
 
     The c-TF-IDF top-3 labeler can assign the SAME label string to two distinct
@@ -372,26 +375,35 @@ def _dedup_specs_by_label(specs: list[dict[str, Any]]) -> list[dict[str, Any]]:
     separate root topic with an identical ``(collection, label)``, which surfaces
     as duplicate Knowledge Map rows once the RDR-154 read-side dedup band-aid is
     removed. Merge same-label specs at the source instead: union their ``doc_ids``,
-    recompute ``doc_count``, keep the first cluster's centroid/terms (order
-    preserved). One root topic per label is then the invariant both T2 backends
-    persist, and the partial unique index is its structural backstop.
+    recompute ``doc_count``, keep the first cluster's centroid/terms/review_status
+    and (for the rebuild path) its ``assigned_by`` — order preserved. One root
+    topic per label is then the invariant both T2 backends persist, and the
+    partial unique index is its structural backstop.
+
+    Returns ``(deduped_specs, index_map)`` where ``index_map`` maps each ORIGINAL
+    spec index to its index in ``deduped_specs`` — callers that key data on spec
+    position (the rebuild path's ``manual_transfers``) must remap through it.
     """
-    merged: dict[str, dict[str, Any]] = {}
-    order: list[str] = []
-    for spec in specs:
+    label_to_new_idx: dict[str, int] = {}
+    out: list[dict[str, Any]] = []
+    index_map: dict[int, int] = {}
+    for old_idx, spec in enumerate(specs):
         label = spec["label"]
-        existing = merged.get(label)
-        if existing is None:
-            merged[label] = {**spec, "doc_ids": list(spec["doc_ids"])}
-            order.append(label)
-            continue
-        seen = set(existing["doc_ids"])
-        for did in spec["doc_ids"]:
-            if did not in seen:
-                existing["doc_ids"].append(did)
-                seen.add(did)
-        existing["doc_count"] = len(existing["doc_ids"])
-    return [merged[label] for label in order]
+        new_idx = label_to_new_idx.get(label)
+        if new_idx is None:
+            new_idx = len(out)
+            label_to_new_idx[label] = new_idx
+            out.append({**spec, "doc_ids": list(spec["doc_ids"])})
+        else:
+            merged = out[new_idx]
+            seen = set(merged["doc_ids"])
+            for did in spec["doc_ids"]:
+                if did not in seen:
+                    merged["doc_ids"].append(did)
+                    seen.add(did)
+            merged["doc_count"] = len(merged["doc_ids"])
+        index_map[old_idx] = new_idx
+    return out, index_map
 
 
 def compute_rebuild_plan(
@@ -497,5 +509,14 @@ def compute_rebuild_plan(
                 old_topic_id=old_topic_id,
                 collection=collection_name,
             )
+
+    # nexus-slcn7: dedup same-label specs here too — persist_rebuild_topics
+    # inserts root topics with a plain INSERT, so a label collision would hit the
+    # partial unique index. Remap manual_transfers (keyed on spec position)
+    # through the dedup index map so transfers still point at the right topic.
+    specs, index_map = _dedup_specs_by_label(specs)
+    manual_transfers = {
+        doc: index_map[old_idx] for doc, old_idx in manual_transfers.items()
+    }
 
     return {"specs": specs, "manual_transfers": manual_transfers}

--- a/tests/db/test_taxonomy_compute.py
+++ b/tests/db/test_taxonomy_compute.py
@@ -325,7 +325,7 @@ class TestDedupSpecsByLabel:
             {"label": "a b c", "terms": "[]", "doc_count": 2,
              "doc_ids": ["d2", "d4"], "centroid": [0.9], "assigned_by": "hdbscan"},
         ]
-        out = tc._dedup_specs_by_label(specs)
+        out, index_map = tc._dedup_specs_by_label(specs)
         # Two unique labels, original order preserved.
         assert [s["label"] for s in out] == ["a b c", "x y z"]
         merged = out[0]
@@ -334,6 +334,8 @@ class TestDedupSpecsByLabel:
         assert merged["doc_count"] == 3
         # First cluster's centroid/terms kept.
         assert merged["centroid"] == [0.1]
+        # index_map: original idx 0 and 2 collapse to new idx 0; idx 1 → 1.
+        assert index_map == {0: 0, 1: 1, 2: 0}
 
     def test_no_duplicates_is_identity(self) -> None:
         specs = [
@@ -342,6 +344,7 @@ class TestDedupSpecsByLabel:
             {"label": "q", "terms": "[]", "doc_count": 1, "doc_ids": ["d2"],
              "centroid": [0.0], "assigned_by": "hdbscan"},
         ]
-        out = tc._dedup_specs_by_label(specs)
+        out, index_map = tc._dedup_specs_by_label(specs)
         assert [s["label"] for s in out] == ["p", "q"]
         assert out[0]["doc_ids"] == ["d1"]
+        assert index_map == {0: 0, 1: 1}

--- a/tests/db/test_taxonomy_compute.py
+++ b/tests/db/test_taxonomy_compute.py
@@ -311,3 +311,37 @@ def test_catalog_taxonomy_reexports_same_objects() -> None:
     assert CatalogTaxonomy.compute_rebuild_plan is tc.compute_rebuild_plan
     assert CatalogTaxonomy._merge_labels is tc._merge_labels
     assert CatalogTaxonomy._cluster is tc._cluster
+
+
+class TestDedupSpecsByLabel:
+    """nexus-slcn7: same-label discovered specs are merged at the source."""
+
+    def test_merges_same_label_unions_docs(self) -> None:
+        specs = [
+            {"label": "a b c", "terms": "[]", "doc_count": 2,
+             "doc_ids": ["d1", "d2"], "centroid": [0.1], "assigned_by": "hdbscan"},
+            {"label": "x y z", "terms": "[]", "doc_count": 1,
+             "doc_ids": ["d3"], "centroid": [0.2], "assigned_by": "hdbscan"},
+            {"label": "a b c", "terms": "[]", "doc_count": 2,
+             "doc_ids": ["d2", "d4"], "centroid": [0.9], "assigned_by": "hdbscan"},
+        ]
+        out = tc._dedup_specs_by_label(specs)
+        # Two unique labels, original order preserved.
+        assert [s["label"] for s in out] == ["a b c", "x y z"]
+        merged = out[0]
+        # Union of doc_ids (d2 not double-counted); doc_count recomputed.
+        assert merged["doc_ids"] == ["d1", "d2", "d4"]
+        assert merged["doc_count"] == 3
+        # First cluster's centroid/terms kept.
+        assert merged["centroid"] == [0.1]
+
+    def test_no_duplicates_is_identity(self) -> None:
+        specs = [
+            {"label": "p", "terms": "[]", "doc_count": 1, "doc_ids": ["d1"],
+             "centroid": [0.0], "assigned_by": "hdbscan"},
+            {"label": "q", "terms": "[]", "doc_count": 1, "doc_ids": ["d2"],
+             "centroid": [0.0], "assigned_by": "hdbscan"},
+        ]
+        out = tc._dedup_specs_by_label(specs)
+        assert [s["label"] for s in out] == ["p", "q"]
+        assert out[0]["doc_ids"] == ["d1"]

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -2577,3 +2577,95 @@ class TestBackfillBuiltinBindings:
         assert matches[0][0] >= "4.10.2", (
             f"must be introduced at >= 4.10.2, got {matches[0][0]!r}"
         )
+
+
+class TestDedupRootTopics:
+    """nexus-slcn7: migrate_dedup_root_topics merges duplicate root topics and
+    installs the partial unique index."""
+
+    @staticmethod
+    def _schema(conn: sqlite3.Connection) -> None:
+        conn.executescript(
+            """
+            CREATE TABLE topics (
+                id INTEGER PRIMARY KEY, label TEXT NOT NULL,
+                parent_id INTEGER REFERENCES topics(id), collection TEXT NOT NULL,
+                doc_count INTEGER NOT NULL DEFAULT 0, created_at TEXT NOT NULL DEFAULT ''
+            );
+            CREATE TABLE topic_assignments (
+                doc_id TEXT NOT NULL, topic_id INTEGER NOT NULL,
+                assigned_by TEXT NOT NULL DEFAULT 'hdbscan',
+                PRIMARY KEY (doc_id, topic_id)
+            );
+            CREATE TABLE topic_links (
+                from_topic_id INTEGER NOT NULL, to_topic_id INTEGER NOT NULL,
+                link_count INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (from_topic_id, to_topic_id)
+            );
+            """
+        )
+
+    def test_merges_duplicates_and_enforces_uniqueness(self) -> None:
+        from nexus.db.migrations import migrate_dedup_root_topics
+
+        conn = sqlite3.connect(":memory:")
+        self._schema(conn)
+        # Three root topics share (col, label); ids 1,2,3. doc1 on all three,
+        # doc2 only on id 2, doc3 only on id 3.
+        for tid in (1, 2, 3):
+            conn.execute(
+                "INSERT INTO topics (id, label, collection, doc_count, created_at) "
+                "VALUES (?, 'dup', 'docs__c', 99, '')",
+                (tid,),
+            )
+        # A legitimately-distinct root topic (different label) must survive untouched.
+        conn.execute(
+            "INSERT INTO topics (id, label, collection, doc_count, created_at) "
+            "VALUES (4, 'unique', 'docs__c', 7, '')"
+        )
+        conn.executemany(
+            "INSERT INTO topic_assignments (doc_id, topic_id) VALUES (?, ?)",
+            [("doc1", 1), ("doc1", 2), ("doc1", 3), ("doc2", 2), ("doc3", 3)],
+        )
+        conn.commit()
+
+        migrate_dedup_root_topics(conn)
+
+        # Exactly one 'dup' root topic remains (the lowest id, 1) + the distinct one.
+        rows = conn.execute(
+            "SELECT id FROM topics WHERE collection='docs__c' AND label='dup'"
+        ).fetchall()
+        assert [r[0] for r in rows] == [1]
+        assert conn.execute(
+            "SELECT id FROM topics WHERE label='unique'"
+        ).fetchone()[0] == 4
+
+        # All three docs are now on the kept topic; doc_count recomputed to 3.
+        kept = conn.execute(
+            "SELECT doc_id FROM topic_assignments WHERE topic_id=1 ORDER BY doc_id"
+        ).fetchall()
+        assert [r[0] for r in kept] == ["doc1", "doc2", "doc3"]
+        assert conn.execute(
+            "SELECT doc_count FROM topics WHERE id=1"
+        ).fetchone()[0] == 3
+
+        # The partial unique index now forbids a new duplicate root topic.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO topics (id, label, collection, doc_count, created_at) "
+                "VALUES (9, 'dup', 'docs__c', 0, '')"
+            )
+
+    def test_idempotent_rerun_is_noop(self) -> None:
+        from nexus.db.migrations import migrate_dedup_root_topics
+
+        conn = sqlite3.connect(":memory:")
+        self._schema(conn)
+        conn.execute(
+            "INSERT INTO topics (id, label, collection, doc_count, created_at) "
+            "VALUES (1, 'solo', 'docs__c', 1, '')"
+        )
+        conn.commit()
+        migrate_dedup_root_topics(conn)
+        migrate_dedup_root_topics(conn)  # second run must not raise or change rows
+        assert conn.execute("SELECT COUNT(*) FROM topics").fetchone()[0] == 1

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -2627,9 +2627,22 @@ class TestDedupRootTopics:
             "INSERT INTO topic_assignments (doc_id, topic_id) VALUES (?, ?)",
             [("doc1", 1), ("doc1", 2), ("doc1", 3), ("doc2", 2), ("doc3", 3)],
         )
+        # A child of dup id 3 must be re-parented onto the kept id 1.
+        conn.execute(
+            "INSERT INTO topics (id, label, parent_id, collection, doc_count, created_at) "
+            "VALUES (5, 'child', 3, 'docs__c', 0, '')"
+        )
+        # A link touching dup id 2 must be removed (recomputable edge).
+        conn.execute(
+            "INSERT INTO topic_links (from_topic_id, to_topic_id) VALUES (2, 4)"
+        )
         conn.commit()
 
         migrate_dedup_root_topics(conn)
+
+        # Child re-parented onto the kept topic; link touching a dup removed.
+        assert conn.execute("SELECT parent_id FROM topics WHERE id=5").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM topic_links").fetchone()[0] == 0
 
         # Exactly one 'dup' root topic remains (the lowest id, 1) + the distinct one.
         rows = conn.execute(


### PR DESCRIPTION
## Root-cause the duplicate root topics (nexus-slcn7)

RDR-154 P0 removed a read-side dedup band-aid that masked duplicate root topics sharing a `(collection, label)`. Root cause: the c-TF-IDF top-3 labeler can assign the same label to distinct HDBSCAN clusters, and discovery is additive.

### Prevention (root cause, both backends)
`taxonomy_compute._dedup_specs_by_label` merges same-label specs at the source (union `doc_ids`, recompute `doc_count`), applied in BOTH `compute_discovered_topics` and `compute_rebuild_plan` (the latter remaps `manual_transfers` through the index map).

### Repair + backstop
- SQLite `migrate_dedup_root_topics`: merge existing dup root topics + partial unique index on `(collection,label) WHERE parent_id IS NULL` (forward-tagged 5.10.7).
- PG `taxonomy-004`: same merge (P0 trigger recomputes doc_count) + partial unique index on `(tenant_id,collection,label) WHERE parent_id IS NULL`.

### Review
Stacked review caught 2 Criticals (migration version — resolved as correct forward-tag; un-deduped rebuild path — fixed before it could crash `nx taxonomy rebuild`). Iterative re-review: 0 Critical / 0 Significant. 762 Java + 171 Python green.

Closes #nexus-slcn7