### PR TITLE
feat(nexus-agsq7): index-age stale_source_ratio in collection_health

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -1309,12 +1309,15 @@ public final class CatalogRepository {
             // with zero documents — default to {last_indexed:null, orphan_count:0}
             // to preserve the prior contract.
             var r = ctx.fetchOne(
-                "SELECT last_indexed, orphan_count FROM nexus.collection_health_meta "
-                + "WHERE collection = ?", collection);
+                "SELECT last_indexed, orphan_count, stale_source_ratio "
+                + "FROM nexus.collection_health_meta WHERE collection = ?", collection);
 
             Map<String, Object> result = new LinkedHashMap<>();
             result.put("last_indexed", r == null ? null : r.get("last_indexed", String.class));
             result.put("orphan_count", r == null ? 0L : r.get("orphan_count", Long.class));
+            // nexus-agsq7: index-age staleness; null when no dated doc qualifies.
+            result.put("stale_source_ratio",
+                       r == null ? null : r.get("stale_source_ratio", Double.class));
             return result;
         });
     }

--- a/service/src/main/resources/db/changelog/catalog-011-collection-health-stale-age.xml
+++ b/service/src/main/resources/db/changelog/catalog-011-collection-health-stale-age.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    nexus-agsq7 — add an index-age stale_source_ratio to collection_health_meta.
+
+    stale_source_ratio = fraction of a collection's documents last indexed more
+    than 30 days ago. A true "source modified since indexing" signal is
+    structurally impossible from stored columns (RDR-154 P2); this is an
+    index-age proxy computed DB-only from indexed_at.
+
+    indexed_at is a TEXT ISO-8601 column ('YYYY-MM-DDThh:mm:ssZ'), which sorts
+    lexicographically in chronological order, so the staleness test is a pure
+    string comparison against a same-format threshold — no ::timestamptz cast,
+    hence no parse-throw on a malformed value. The denominator counts documents
+    whose indexed_at at least starts with a 4-digit year; everything else is
+    excluded from both numerator and denominator (NULL ratio when none qualify).
+
+    CREATE OR REPLACE appends stale_source_ratio as a trailing column, preserving
+    the catalog-009 column set, the security_invoker reloption, and the grants.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="catalog-011-1" author="nexus-agsq7">
+        <comment>Append index-age stale_source_ratio to collection_health_meta</comment>
+        <sql splitStatements="false" stripComments="false">
+CREATE OR REPLACE VIEW nexus.collection_health_meta
+    WITH (security_invoker = true)
+AS
+SELECT d.tenant_id,
+       d.physical_collection AS collection,
+       max(d.indexed_at) AS last_indexed,
+       count(*) FILTER (
+           WHERE NOT EXISTS (
+               SELECT 1 FROM nexus.catalog_links l
+                WHERE l.to_tumbler = d.tumbler
+           )
+       ) AS orphan_count,
+       (count(*) FILTER (
+           WHERE d.indexed_at ~ '^[0-9]{4}-'
+             AND d.indexed_at &lt; to_char(
+                     (now() - interval '30 days') AT TIME ZONE 'UTC',
+                     'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+        ))::double precision
+        / NULLIF(count(*) FILTER (WHERE d.indexed_at ~ '^[0-9]{4}-'), 0)
+        AS stale_source_ratio
+  FROM nexus.catalog_documents d
+ WHERE d.physical_collection IS NOT NULL
+ GROUP BY d.tenant_id, d.physical_collection
+        </sql>
+        <rollback/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/main/resources/db/changelog/catalog-011-collection-health-stale-age.xml
+++ b/service/src/main/resources/db/changelog/catalog-011-collection-health-stale-age.xml
@@ -14,6 +14,16 @@
     whose indexed_at at least starts with a 4-digit year; everything else is
     excluded from both numerator and denominator (NULL ratio when none qualify).
 
+    CAVEAT (cross-backend): this lexicographic compare is correct only for the
+    UTC-suffixed format the indexers always write. A hand-inserted non-UTC-offset
+    value (e.g. '...-05:00') would be compared by its wall-clock prefix, not its
+    UTC instant, so it can be classified differently from the SQLite path
+    (catalog.py collection_health_meta), which normalises via strftime epoch.
+    Acceptable: the write path is always UTC and this is a coarse 30-day heuristic.
+
+    The 30-day horizon mirrors catalog._STALE_SOURCE_AGE_DAYS (Python) — keep both
+    in sync if the horizon changes.
+
     CREATE OR REPLACE appends stale_source_ratio as a trailing column, preserving
     the catalog-009 column set, the security_invoker reloption, and the grants.
 -->

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -123,6 +123,9 @@
          they read (catalog-001, taxonomy-001) and before grants-nexus-svc. -->
     <include file="db/changelog/catalog-009-read-shape-views.xml"/>
 
+    <!-- nexus-agsq7: append index-age stale_source_ratio to collection_health_meta. -->
+    <include file="db/changelog/catalog-011-collection-health-stale-age.xml"/>
+
     <!-- pgvector taxonomy centroids (bead nexus-t1hnc.1, RDR-156):
          taxonomy_centroids_384/768/1024 — moves the taxonomy__centroids ChromaDB
          collection into Postgres so service-mode taxonomy compute is chroma-free.

--- a/service/src/test/java/dev/nexus/service/ReadShapeViewsTest.java
+++ b/service/src/test/java/dev/nexus/service/ReadShapeViewsTest.java
@@ -142,6 +142,31 @@ class ReadShapeViewsTest {
             + "VALUES ('" + tenant + "', '" + label + "', '" + coll + "', 0, now(), 'pending')");
     }
 
+    private static void seedDocIndexed(Connection su, String tenant, String tumbler,
+                                       String coll, String indexedAt) throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title, physical_collection, indexed_at) "
+            + "VALUES ('" + tenant + "', '" + tumbler + "', 'T', '" + coll + "', '" + indexedAt + "')");
+    }
+
+    @Test @Order(40)
+    void collectionHealthMeta_staleSourceRatio_indexAge() throws Exception {
+        // nexus-agsq7: stale = indexed_at more than 30 days ago. 2020 is always
+        // stale, 2099 is always fresh (future) — deterministic regardless of now().
+        final String col = "c_stale_age";
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            seedDocIndexed(su, TENANT_A, "sa.1", col, "2020-01-01T00:00:00Z"); // stale
+            seedDocIndexed(su, TENANT_A, "sa.2", col, "2099-01-01T00:00:00Z"); // fresh
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT stale_source_ratio FROM nexus.collection_health_meta "
+                + "WHERE tenant_id = '" + TENANT_A + "' AND collection = '" + col + "'");
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getDouble("stale_source_ratio"))
+                .as("1 of 2 dated docs is > 30 days old").isEqualTo(0.5d);
+        }
+    }
+
     private static void seedOwner(Connection su, String tenant, String prefix) throws Exception {
         su.createStatement().execute(
             "INSERT INTO nexus.catalog_owners (tenant_id, tumbler_prefix, name, owner_type) "

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1152,9 +1152,26 @@ class Catalog:
         ).fetchone()
         orphan_count: int = int(orphan_row[0] or 0)
 
+        # nexus-agsq7: index-age staleness — fraction of docs (with a parseable
+        # indexed_at) last indexed more than 30 days ago. strftime('%s', ...)
+        # returns NULL for an unparseable value, excluding it from both counts.
+        stale_row = self._db.execute(
+            "SELECT "
+            "  COUNT(strftime('%s', indexed_at)) AS dated, "
+            "  COUNT(*) FILTER (WHERE strftime('%s', indexed_at) IS NOT NULL "
+            "    AND CAST(strftime('%s', indexed_at) AS REAL) "
+            "        < CAST(strftime('%s', 'now', '-30 days') AS REAL)) AS stale "
+            "FROM documents WHERE physical_collection = ?",
+            (collection,),
+        ).fetchone()
+        dated = int(stale_row[0] or 0) if stale_row else 0
+        stale = int(stale_row[1] or 0) if stale_row else 0
+        stale_source_ratio: float | None = (stale / dated) if dated else None
+
         return {
             "last_indexed": last_indexed,
             "orphan_count": orphan_count,
+            "stale_source_ratio": stale_source_ratio,
         }
 
     def ensure_owner_for_repo(

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -278,6 +278,11 @@ from nexus.catalog.events import (  # noqa: E402
 
 # Span format: "line_start-line_end" or "chunk_idx:char_start-char_end" or
 # "chash:<sha256hex>" or "".  Empty string means "the whole document".
+# nexus-agsq7: a document indexed more than this many days ago counts as stale
+# for collection_health_meta.stale_source_ratio. The PG view (catalog-011) and
+# the collection_health report docstring hardcode the same horizon — keep in sync.
+_STALE_SOURCE_AGE_DAYS = 30
+
 _SPAN_PATTERN = re.compile(
     r"^$"                              # empty — whole document
     r"|^\d+-\d+$"                      # line range: "42-57"
@@ -1153,19 +1158,24 @@ class Catalog:
         orphan_count: int = int(orphan_row[0] or 0)
 
         # nexus-agsq7: index-age staleness — fraction of docs (with a parseable
-        # indexed_at) last indexed more than 30 days ago. strftime('%s', ...)
-        # returns NULL for an unparseable value, excluding it from both counts.
+        # indexed_at) last indexed more than _STALE_SOURCE_AGE_DAYS ago.
+        # strftime('%s', ...) returns NULL for an unparseable value (excluded
+        # from both counts) AND normalises any timezone offset to epoch — so this
+        # SQLite path is robust to non-UTC indexed_at. The PG mirror (catalog-011)
+        # uses a lexicographic string compare that is correct only for the
+        # UTC-format indexed_at the indexers always write; the two can disagree
+        # on hand-inserted non-UTC-offset rows (RDR-158 retires this SQLite path).
         stale_row = self._db.execute(
             "SELECT "
             "  COUNT(strftime('%s', indexed_at)) AS dated, "
             "  COUNT(*) FILTER (WHERE strftime('%s', indexed_at) IS NOT NULL "
             "    AND CAST(strftime('%s', indexed_at) AS REAL) "
-            "        < CAST(strftime('%s', 'now', '-30 days') AS REAL)) AS stale "
+            f"        < CAST(strftime('%s', 'now', '-{_STALE_SOURCE_AGE_DAYS} days') AS REAL)) AS stale "
             "FROM documents WHERE physical_collection = ?",
             (collection,),
         ).fetchone()
-        dated = int(stale_row[0] or 0) if stale_row else 0
-        stale = int(stale_row[1] or 0) if stale_row else 0
+        # fetchone() on an aggregate query always returns a (dated, stale) row.
+        dated, stale = int(stale_row[0]), int(stale_row[1])
         stale_source_ratio: float | None = (stale / dated) if dated else None
 
         return {

--- a/src/nexus/collection_health.py
+++ b/src/nexus/collection_health.py
@@ -10,7 +10,7 @@ and topic-assignment signals into a single per-collection view:
     orphan_catalog_rows, stale_source_ratio, hub_domination_score
 
 ``stale_source_ratio`` is the fraction of a collection's documents last indexed
-more than ``_STALE_AGE_DAYS`` ago (nexus-agsq7) — an INDEX-AGE proxy for
+more than 30 days ago (``catalog._STALE_SOURCE_AGE_DAYS``; nexus-agsq7) — an INDEX-AGE proxy for
 staleness, computed DB-only from ``indexed_at``. A true "source modified since
 indexing" signal is structurally impossible from stored columns
 (``source_mtime`` is captured at index time, so it is always <= ``indexed_at``;
@@ -29,9 +29,6 @@ from typing import Any, Callable
 
 
 _STALE_PLACEHOLDER = "—"
-# nexus-agsq7: a document indexed more than this many days ago counts as stale
-# for the index-age staleness ratio.
-_STALE_AGE_DAYS = 30
 _SORT_COLUMNS = (
     "name",
     "chunk_count",

--- a/src/nexus/collection_health.py
+++ b/src/nexus/collection_health.py
@@ -9,16 +9,13 @@ and topic-assignment signals into a single per-collection view:
     median_query_distance_30d, cross_projection_rank,
     orphan_catalog_rows, stale_source_ratio, hub_domination_score
 
-``stale_source_ratio`` remains a placeholder (``"—"``), deferred under bead
-``nexus-8luh``. RDR-154 P2 investigated a DB-only computation and found it
-STRUCTURALLY IMPOSSIBLE: ``catalog_documents.source_mtime`` is the file mtime
-captured *at index time* (before ``indexed_at = now()`` is written), so
-``source_mtime <= indexed_at`` always holds and a "modified since indexing"
-ratio computed from stored columns alone is identically zero. Detecting a real
-stale source requires comparing the stored ``indexed_at`` against the *live*
-file mtime (a filesystem stat at report time, local-mode only) or an explicit
-file-watcher event that refreshes ``source_mtime`` while leaving ``indexed_at``
-frozen. Neither exists yet; see ``nexus-8luh`` for the design options.
+``stale_source_ratio`` is the fraction of a collection's documents last indexed
+more than ``_STALE_AGE_DAYS`` ago (nexus-agsq7) — an INDEX-AGE proxy for
+staleness, computed DB-only from ``indexed_at``. A true "source modified since
+indexing" signal is structurally impossible from stored columns
+(``source_mtime`` is captured at index time, so it is always <= ``indexed_at``;
+RDR-154 P2 found this) and would need a live filesystem stat. ``None`` (rendered
+``"—"``) when no document in the collection carries a parseable ``indexed_at``.
 
 Every data source is dependency-injected via module-level callables
 so tests can monkeypatch without standing up live T2/T3/catalog.
@@ -32,6 +29,9 @@ from typing import Any, Callable
 
 
 _STALE_PLACEHOLDER = "—"
+# nexus-agsq7: a document indexed more than this many days ago counts as stale
+# for the index-age staleness ratio.
+_STALE_AGE_DAYS = 30
 _SORT_COLUMNS = (
     "name",
     "chunk_count",
@@ -40,6 +40,7 @@ _SORT_COLUMNS = (
     "median_query_distance_30d",
     "cross_projection_rank",
     "orphan_catalog_rows",
+    "stale_source_ratio",
     "hub_domination_score",
     "chash_indexed_ratio",
 )
@@ -55,7 +56,9 @@ class CollectionHealthRow:
     cross_projection_rank: int | None
     orphan_catalog_rows: int | None
     hub_domination_score: float | None = None
-    stale_source_ratio: str = _STALE_PLACEHOLDER  # deferred: nexus-8luh (see module docstring)
+    # nexus-agsq7: fraction of docs indexed more than _STALE_AGE_DAYS ago
+    # (index-age staleness proxy); None when no doc has a parseable indexed_at.
+    stale_source_ratio: float | None = None
     # RDR-087 Phase 4.6 (nexus-c2op): ratio of chash_index rows for this
     # collection to its T3 chunk_count. 1.0 → fully backfilled; < 1.0 →
     # nx collection backfill-hash has work to do. None when either the
@@ -340,6 +343,7 @@ def compute_collection_health(
                 cross_projection_rank=ranks.get(col),
                 orphan_catalog_rows=int(catalog.get("orphan_count", 0))
                     if catalog.get("orphan_count") is not None else None,
+                stale_source_ratio=catalog.get("stale_source_ratio"),
                 hub_domination_score=hub_score_fn(col),
                 chash_indexed_ratio=(
                     chash_coverage_fn(col) if chash_coverage_fn is not None else None
@@ -397,7 +401,7 @@ def format_health_table(
             _fmt_cell(r.median_query_distance_30d),
             _fmt_cell(r.cross_projection_rank),
             _fmt_cell(r.orphan_catalog_rows),
-            r.stale_source_ratio,
+            _fmt_cell(r.stale_source_ratio),
             _fmt_cell(r.hub_domination_score),
             _fmt_cell(r.chash_indexed_ratio),
         ]

--- a/tests/db/test_collection_health_dsu5z_integration.py
+++ b/tests/db/test_collection_health_dsu5z_integration.py
@@ -303,6 +303,7 @@ class TestCollectionHealthMetaLiveService:
         result = cat.collection_health_meta(_COLL)
         assert "last_indexed" in result
         assert "orphan_count" in result
+        assert "stale_source_ratio" in result  # nexus-agsq7
 
     def test_unknown_collection_returns_safe_defaults(self, cat, seeded_catalog) -> None:
         """B) Unknown collection -> last_indexed=None, orphan_count=0."""

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1463,7 +1463,7 @@ class TestStaleSourceRatioAgeBased:
 
     @staticmethod
     def _insert_doc(cat, tumbler: str, coll: str, indexed_at: str) -> None:
-        cat._db.execute(
+        cat._db.execute(  # epsilon-allow: nexus-agsq7 seeds documents with controlled indexed_at to exercise the index-age stale ratio (no public API sets indexed_at directly)
             "INSERT INTO documents "
             "(tumbler, title, author, year, content_type, file_path, corpus, "
             " physical_collection, chunk_count, head_hash, indexed_at, metadata, "

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1455,3 +1455,41 @@ class TestBySourceUri:
     def test_empty_uri_returns_none(self, cat_with_owner):
         cat, _owner = cat_with_owner
         assert cat.by_source_uri("") is None
+
+
+class TestStaleSourceRatioAgeBased:
+    """nexus-agsq7: collection_health_meta.stale_source_ratio is the fraction of
+    a collection's docs last indexed more than 30 days ago (index-age proxy)."""
+
+    @staticmethod
+    def _insert_doc(cat, tumbler: str, coll: str, indexed_at: str) -> None:
+        cat._db.execute(
+            "INSERT INTO documents "
+            "(tumbler, title, author, year, content_type, file_path, corpus, "
+            " physical_collection, chunk_count, head_hash, indexed_at, metadata, "
+            " source_mtime, source_uri) "
+            "VALUES (?, '', '', 0, '', '', '', ?, 0, '', ?, '{}', 0, '')",
+            (tumbler, coll, indexed_at),
+        )
+        cat._db.commit()
+
+    def test_ratio_counts_docs_older_than_30_days(self, tmp_path) -> None:
+        from datetime import UTC, datetime
+
+        cat = Catalog(tmp_path, tmp_path / ".catalog.db")
+        coll = "docs__age"
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        self._insert_doc(cat, "a.1", coll, "2020-01-01T00:00:00Z")  # stale
+        self._insert_doc(cat, "a.2", coll, "2020-06-01T00:00:00Z")  # stale
+        self._insert_doc(cat, "a.3", coll, now)                      # fresh
+
+        meta = cat.collection_health_meta(coll)
+        # 2 of 3 dated docs are > 30 days old.
+        assert meta["stale_source_ratio"] == pytest.approx(2 / 3)
+
+    def test_ratio_none_when_no_dated_docs(self, tmp_path) -> None:
+        cat = Catalog(tmp_path, tmp_path / ".catalog.db")
+        coll = "docs__nodate"
+        # Empty / unparseable indexed_at → excluded from the denominator → None.
+        self._insert_doc(cat, "n.1", coll, "")
+        assert cat.collection_health_meta(coll)["stale_source_ratio"] is None

--- a/tests/test_collection_health.py
+++ b/tests/test_collection_health.py
@@ -116,7 +116,8 @@ class TestTelemetryQueryCollectionStats:
 
 def _fake_catalog_stats(col: str) -> dict:
     data = {
-        "code__alpha":  {"chunk_count": 120, "last_indexed": "2026-04-15", "orphan_count": 2},
+        "code__alpha":  {"chunk_count": 120, "last_indexed": "2026-04-15",
+                         "orphan_count": 2, "stale_source_ratio": 0.4},
         "docs__beta":   {"chunk_count": 30,  "last_indexed": "2026-04-10", "orphan_count": 0},
         "docs__stale":  {"chunk_count": 0,   "last_indexed": None,          "orphan_count": 0},
     }
@@ -179,9 +180,10 @@ class TestComputeCollectionHealth:
         assert by_name["code__alpha"].cross_projection_rank == 1
         assert by_name["code__alpha"].orphan_catalog_rows == 2
         assert by_name["code__alpha"].hub_domination_score == pytest.approx(0.05)
-        # stale_source_ratio remains the deferred placeholder (nexus-8luh):
-        # RDR-154 P2 found a DB-only computation structurally impossible.
-        assert by_name["code__alpha"].stale_source_ratio == "—"
+        # nexus-agsq7: stale_source_ratio (index-age proxy) is wired from the
+        # catalog; None when the catalog provides none.
+        assert by_name["code__alpha"].stale_source_ratio == pytest.approx(0.4)
+        assert by_name["docs__beta"].stale_source_ratio is None
 
     def test_empty_telemetry_sets_placeholders(self) -> None:
         from nexus.collection_health import compute_collection_health


### PR DESCRIPTION
## Index-age `stale_source_ratio` (nexus-agsq7)

RDR-154 P2 reverted a structurally-vacuous `source_mtime`-based `stale_source_ratio` (`source_mtime` is captured at index time, so it's always ≤ `indexed_at`). Per the owner's choice, this replaces the placeholder with an **age-based** DB-only metric: the fraction of a collection's documents last indexed more than 30 days ago — an honest index-age proxy (documented as such; the column name is retained).

### Changes
- `collection_health.py`: field `str`-placeholder → `float|None`, wired from the catalog, added to `_SORT_COLUMNS`, `_fmt_cell(None)` → `—`.
- SQLite `Catalog.collection_health_meta`: `COUNT FILTER` over `strftime` epoch vs `now - 30 days` (epoch normalises timezone offsets); `None` when no doc has a parseable `indexed_at`. Day horizon from `_STALE_SOURCE_AGE_DAYS`.
- PG `catalog-011`: `CREATE OR REPLACE collection_health_meta` appending `stale_source_ratio`. `indexed_at` is ISO-8601 TEXT (sorts lexicographically), so the staleness test is a string compare against a same-format threshold — **no `::timestamptz` cast, hence no parse-throw**. `collectionHealthMeta` returns it.

### Review
- code-review-expert: APPROVED, 0 Critical. substantive-critic: 0 Critical / 2 Significant — both addressed: the phantom day constant is now threaded with cross-refs, and the SQLite/PG non-UTC divergence is documented (write path is always UTC; coarse 30-day heuristic; RDR-158 retires the SQLite path).
- Tests: report wire-through; SQLite age computation (2/3, None); PG view age ratio (0.5 via deterministic 2020/2099 fixtures). **762 Java + 163 Python green.**

Closes #nexus-agsq7