### PR TITLE
fix(nexus-aeceu): chunk_count parity in Catalog.stats()

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1100,13 +1100,18 @@ class Catalog:
         Java /stats response used by stats_cmd.
 
         Key parity with Java /stats response:
-          doc_count, link_count, owner_count, collection_count,
+          doc_count, link_count, owner_count, collection_count, chunk_count,
           by_content_type, links_by_type
         """
         doc_count        = self._db.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
         link_count       = self._db.execute("SELECT COUNT(*) FROM links").fetchone()[0]
         owner_count      = self._db.execute("SELECT COUNT(*) FROM owners").fetchone()[0]
         collection_count = self._db.execute("SELECT COUNT(*) FROM collections").fetchone()[0]
+        # nexus-aeceu: chunk_count for Java/PG parity — count the document_chunks
+        # manifest rows, mirroring the catalog_stats view's
+        # count(catalog_document_chunks). (RDR-108 manifest; the same table the
+        # per-collection chunk drift is reconciled against.)
+        chunk_count      = self._db.execute("SELECT COUNT(*) FROM document_chunks").fetchone()[0]
         by_ctype_rows = self._db.execute(
             "SELECT content_type, COUNT(*) FROM documents GROUP BY content_type"
         ).fetchall()
@@ -1121,6 +1126,7 @@ class Catalog:
             "link_count":       link_count,
             "owner_count":      owner_count,
             "collection_count": collection_count,
+            "chunk_count":      chunk_count,
             "by_content_type":  {(r[0] or ""): r[1] for r in by_ctype_rows},
             "links_by_type":    {r[0]: r[1] for r in by_ltype_rows if r[0]},
         }

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -1814,6 +1814,7 @@ def stats_cmd(as_json: bool) -> None:
     owner_count = s.get("owner_count", 0)
     doc_count = s.get("doc_count", 0)
     link_count = s.get("link_count", 0)
+    chunk_count = s.get("chunk_count", 0)  # nexus-aeceu: now present on both backends
     # by_content_type is included in the stats() response (nexus-xnz0o).
     type_counts = s.get("by_content_type", {})
     link_type_counts = s.get("links_by_type", {})
@@ -1823,6 +1824,7 @@ def stats_cmd(as_json: bool) -> None:
             "owners": owner_count,
             "documents": doc_count,
             "links": link_count,
+            "chunks": chunk_count,
             "by_type": type_counts,
             "by_link_type": link_type_counts,
         }
@@ -1833,6 +1835,7 @@ def stats_cmd(as_json: bool) -> None:
         click.echo(f"Owners:    {owner_count}")
         click.echo(f"Documents: {doc_count}")
         click.echo(f"Links:     {link_count}")
+        click.echo(f"Chunks:    {chunk_count}")
         if type_counts:
             click.echo("By type:")
             for t, c in sorted(type_counts.items()):

--- a/src/nexus/mcp/catalog.py
+++ b/src/nexus/mcp/catalog.py
@@ -574,6 +574,7 @@ def catalog_stats() -> dict:
             "documents":    s.get("doc_count",        s.get("documents", 0)),
             "links":        s.get("link_count",       s.get("links",     0)),
             "collections":  s.get("collection_count", s.get("collections", 0)),
+            "chunks":       s.get("chunk_count",      s.get("chunks",    0)),  # nexus-aeceu
             "by_link_type": s.get("links_by_type",    s.get("by_link_type", {})),
         }
     except Exception as e:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1465,7 +1465,7 @@ class TestStatsChunkCount:
         cat = Catalog(tmp_path, tmp_path / ".catalog.db")
         # Parent documents (document_chunks.doc_id references documents.tumbler).
         for tumbler in ("a.1", "a.2"):
-            cat._db.execute(
+            cat._db.execute(  # epsilon-allow: nexus-aeceu seeds FK-parent documents rows so document_chunks manifest inserts satisfy the FK; verifying stats() chunk_count
                 "INSERT INTO documents (tumbler, title, author, year, content_type, "
                 " file_path, corpus, physical_collection, chunk_count, head_hash, "
                 " indexed_at, metadata, source_mtime, source_uri) "
@@ -1474,7 +1474,7 @@ class TestStatsChunkCount:
             )
         # Three manifest rows across two docs.
         for doc_id, pos in [("a.1", 0), ("a.1", 1), ("a.2", 0)]:
-            cat._db.execute(
+            cat._db.execute(  # epsilon-allow: nexus-aeceu seeds document_chunks manifest rows directly to verify stats() chunk_count (no public API writes raw manifest rows)
                 "INSERT INTO document_chunks "
                 "(doc_id, position, chash, chunk_index, line_start, line_end, "
                 " char_start, char_end) VALUES (?, ?, ?, ?, 0, 0, 0, 0)",

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1455,3 +1455,37 @@ class TestBySourceUri:
     def test_empty_uri_returns_none(self, cat_with_owner):
         cat, _owner = cat_with_owner
         assert cat.by_source_uri("") is None
+
+
+class TestStatsChunkCount:
+    """nexus-aeceu: Catalog.stats() reports chunk_count (document_chunks manifest
+    rows) for parity with the Java /stats catalog_stats view."""
+
+    def test_stats_includes_chunk_count(self, tmp_path) -> None:
+        cat = Catalog(tmp_path, tmp_path / ".catalog.db")
+        # Parent documents (document_chunks.doc_id references documents.tumbler).
+        for tumbler in ("a.1", "a.2"):
+            cat._db.execute(
+                "INSERT INTO documents (tumbler, title, author, year, content_type, "
+                " file_path, corpus, physical_collection, chunk_count, head_hash, "
+                " indexed_at, metadata, source_mtime, source_uri) "
+                "VALUES (?, '', '', 0, '', '', '', '', 0, '', '', '{}', 0, '')",
+                (tumbler,),
+            )
+        # Three manifest rows across two docs.
+        for doc_id, pos in [("a.1", 0), ("a.1", 1), ("a.2", 0)]:
+            cat._db.execute(
+                "INSERT INTO document_chunks "
+                "(doc_id, position, chash, chunk_index, line_start, line_end, "
+                " char_start, char_end) VALUES (?, ?, ?, ?, 0, 0, 0, 0)",
+                (doc_id, pos, f"{doc_id}-{pos}".ljust(32, "0"), pos),
+            )
+        cat._db.commit()
+
+        s = cat.stats()
+        assert "chunk_count" in s  # the parity key that was missing
+        assert s["chunk_count"] == 3
+
+    def test_stats_chunk_count_zero_when_empty(self, tmp_path) -> None:
+        cat = Catalog(tmp_path, tmp_path / ".catalog.db")
+        assert cat.stats()["chunk_count"] == 0


### PR DESCRIPTION
## `chunk_count` parity in Python local-mode `Catalog.stats()`

The Java `/stats` (`catalog_stats` view) returns `chunk_count = count(catalog_document_chunks)`, but the Python local-mode `Catalog.stats()` omitted it — a pre-existing Java/PG parity gap flagged by the RDR-154 P1 substantive-critic.

### Fix
- `Catalog.stats()`: add `chunk_count = COUNT(*) FROM document_chunks` — the RDR-108 manifest table, the SQLite analog of the PG `catalog_document_chunks` the view counts. Both are raw, filter-symmetric counts (the drifting per-doc `documents.chunk_count` column was correctly rejected).
- `nx catalog stats`: render it (json `chunks` + human `Chunks:`).
- MCP `catalog_stats` tool: forward `chunks` (the critic caught that the tool re-normalised the dict and dropped the new key).

### Review
- substantive-critic: 0 Critical / 1 Significant (the MCP-tool drop — fixed). Confirmed the parity-table choice is correct (filter symmetry exact; `SUM(documents.chunk_count)` rejected as drifting) and no consumer assumed the key was absent.
- Tests: `Catalog.stats()` includes `chunk_count` (3 manifest rows / 2 docs) + 0-when-empty. 290 catalog/CLI/MCP green.

The last RDR-154 follow-on. Closes #nexus-aeceu