### PR TITLE
docs(nexus-41bso): align on PostgreSQL 17

### DIFF
--- a/docs/rdr/rdr-157-end-user-distribution-and-installation.md
+++ b/docs/rdr/rdr-157-end-user-distribution-and-installation.md
@@ -18,6 +18,13 @@ related: [RDR-144, RDR-152, RDR-155, RDR-076]
 > Revise during planning; lock at implementation.
 > If wrong, abandon code and iterate RDR.
 
+> **2026-06-16 (nexus-41bso):** all "PG16" references below now read as **PG17**.
+> nexus was never pinned to 16 (the only hard floor is pgvector >= 0.8, on both
+> majors); 16 was incidental. The shipped local distribution bundles a relocatable
+> **PG17 + pgvector** (the P3 bundle build landed on PG17.5), and `nx init --service`
+> discovers `postgresql@17` first (16/15 retained as fallbacks). This aligns local
+> and cloud (Crunchy Bridge) on one major. Original wording preserved for the record.
+
 ## Problem Statement
 
 Since RDR-155 P4a, T3 serving routes exclusively through the PG16 + pgvector + Java

--- a/docs/rdr/rdr-159-guided-upgrade-migration.md
+++ b/docs/rdr/rdr-159-guided-upgrade-migration.md
@@ -24,6 +24,12 @@ related_external: [conexus:RDR-001, conexus:RDR-002]
 > `nexus-luxe6` blocker all live here); conexus adds only a thin `conexus upgrade`
 > UX veneer that calls this engine. The conexus draft is superseded by this RDR.
 
+> **2026-06-16 (nexus-41bso):** all "PG16" references below now read as **PG17**.
+> nexus was never pinned to 16; the migration target stack and `nx init --service`
+> provisioning are PG17 + pgvector (16/15 retained only as discovery fallbacks),
+> aligning the upgrade destination with the deployed conexus cloud stack. Original
+> wording preserved for the record.
+
 ## Problem Statement
 
 Since RDR-155 P4a (2026-06-10) T3 vector serving routes exclusively through the

--- a/scripts/validate/integration-stack.sh
+++ b/scripts/validate/integration-stack.sh
@@ -9,7 +9,7 @@
 #   catalog  documents / links / manifest / FTS / RLS             (Python ↔ service)
 #   T3  pgvector serving + collection_vector_stats                (Java contract tests)
 #
-# Each Python suite spins up its own throwaway PG16 + a fresh service JAR
+# Each Python suite spins up its own throwaway PG17 + a fresh service JAR
 # subprocess with an isolated bearer, applies the schema clean, runs, and tears
 # down. The whole thing is hermetic and idempotent.
 #
@@ -27,7 +27,8 @@
 #   --java-only    T3 Java serving contract tests only
 #
 # Prerequisites (darwin/aarch64 dev box): JDK/GraalVM on PATH or JAVA_HOME set,
-# and pg16 binaries at /opt/homebrew/opt/postgresql@16/bin. Suites self-skip
+# and pg17 binaries at /opt/homebrew/opt/postgresql@17/bin (16/15 also work as
+# discover_pg_binaries fallbacks). Suites self-skip
 # (not fail) when prerequisites are absent.
 
 set -euo pipefail
@@ -90,7 +91,7 @@ rc=0
 
 if [[ "$RUN_PYTHON" == "1" ]]; then
     echo "▸ T1/T2/catalog Python integration suites (ephemeral PG + service)…"
-    # Capture so an all-SKIP run (missing pg16/jar → module skipif) is reported
+    # Capture so an all-SKIP run (missing pg/jar → module skipif) is reported
     # as INCONCLUSIVE, not green. Skipped tests exit pytest 0; a gate that prints
     # "green" having run zero assertions is the exact false-confidence a gate
     # must not have.


### PR DESCRIPTION
## Summary

`nexus-41bso` — move nexus off incidental PG16 onto PG17 to match the deployed conexus stack (Crunchy Bridge + all deploy tooling are pg17). Nothing pinned nexus to 16; the only hard floor is pgvector >= 0.8, available on both majors.

The **code/CI/bundle** already shifted to PG17 under RDR-157 P3:
- `pg_provision._CANDIDATE_DIRS` prefers `postgresql@17`, keeps 16/15 as fallbacks; install hint says PostgreSQL 17.
- CA-3 `ci.yml` jobs run `PG_VERSION: "17.5"` (linux-amd64 + mac-arm64).
- `test_pg_provision_ca3_bundle.py` asserts a complete PG17 tree.

This PR closes the remaining **doc surface**:
- `scripts/validate/integration-stack.sh` — comments PG16 → PG17.
- RDR-157, RDR-159 (both **closed**) — dated `nexus-41bso` annotation noting all PG16 references now read PG17. Original wording preserved (never-rewrite-closed-RDR discipline) rather than edited in place.

Historical spike/verification records left untouched (RDR-152 "Spike S0.1 VERIFIED on PostgreSQL 16.13", RDR-156 "2026-06-10 against live prod PG16") — they record what was actually tested.

## Acceptance
- pg_provision discovers pg17 ✓ (already in `_CANDIDATE_DIRS`)
- CA-3 gate on PG17 ✓ (ci.yml already 17.5)
- RDRs updated ✓ (annotated)
- conexus consumer flip opens as pg17 — conexus-side, out of scope here

Comment/markdown only; no code-logic change.

Closes nexus-41bso