### PR TITLE
go-live cleanup batch: clean T2 error UX + StopFailure changelog

### DIFF
--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **StopFailure hook no longer files issues for transient API failures.** The
+  hook previously ran `bd create --type=bug --priority=1` on every `rate_limit`
+  stop, dropping P1 bugs into the `bd ready` queue as if they were actionable
+  work (32 such beads had accumulated). Rate limits, server errors, and auth
+  failures are infra events, not bugs. The hook now records the crash via
+  `bd remember` only (unchanged observability log); it never files an issue.
+
 ## [5.10.6] - 2026-06-07
 
 Plugin version aligned with conexus 5.10.6 (hotfix: RDR-080
@@ -16,15 +25,6 @@ MCP-server approval). No plugin-side changes.
 
 Plugin version aligned with conexus 5.10.5 (RDR-151 daemon CPU-peg hardening:
 cause-agnostic spin backstop + write-serialization root-cause fix).
-
-### Changed
-
-- **StopFailure hook no longer files issues for transient API failures.** The
-  hook previously ran `bd create --type=bug --priority=1` on every `rate_limit`
-  stop, dropping P1 bugs into the `bd ready` queue as if they were actionable
-  work (32 such beads had accumulated). Rate limits, server errors, and auth
-  failures are infra events, not bugs. The hook now records the crash via
-  `bd remember` only (unchanged observability log); it never files an issue.
 
 ## [5.10.4] - 2026-06-06
 

--- a/src/nexus/commands/_helpers.py
+++ b/src/nexus/commands/_helpers.py
@@ -68,18 +68,45 @@ def t2_handle() -> Iterator[Any]:
     from nexus.db.storage_mode import StorageBackend, storage_backend_for
 
     if storage_backend_for("memory") == StorageBackend.SERVICE:
+        import httpx
+
         from nexus.db.t2 import T2Database
 
         # Service mode routes T2Database to the HTTP service (PG arbiter), not a
         # raw SQLite writer, so the RDR-128 single-writer concern does not apply.
-        db = T2Database(default_db_path(), run_migrations=False)  # epsilon-allow: service mode routes to HTTP service, not a raw SQLite writer
+        #
+        # nexus-00en9: two distinct service-down failure points, both of which
+        # would otherwise reach Click as a raw traceback:
+        #  (a) PRE-YIELD construction — HttpMemoryStore resolves its endpoint via
+        #      resolve_service_config(), which raises RuntimeError fail-loud when
+        #      no lease/env is discoverable (the common "service never started"
+        #      case). Its message already names the operator fix.
+        #  (b) POST-YIELD RPC — the endpoint resolved (a lease existed) but the
+        #      service is unreachable/erroring when the actual RPC fires, raising
+        #      an httpx transport or status error.
+        try:
+            db = T2Database(default_db_path(), run_migrations=False)  # epsilon-allow: service mode routes to HTTP service, not a raw SQLite writer
+        except RuntimeError as exc:
+            raise click.ClickException(
+                f"T2 storage service unavailable: {exc}"
+            ) from exc
         try:
             yield db
+        except (httpx.TransportError, httpx.HTTPStatusError) as exc:
+            # Narrow to transport/status failures (unreachable/erroring service).
+            # Decode/redirect/protocol httpx errors are service-side bugs that
+            # should keep their traceback during go-live, not be aliased to a
+            # reachability hint.
+            raise click.ClickException(
+                f"T2 storage service error: {exc}. "
+                "Check the storage service: nx doctor"
+            ) from exc
         finally:
             db.close()
         return
 
     from nexus.daemon.t2_client import (
+        T2ClientError,
         T2DaemonNotReachableError,
         T2SchemaVersionMismatchError,
         make_t2_client,
@@ -88,6 +115,24 @@ def t2_handle() -> Iterator[Any]:
     client = make_t2_client()
     try:
         yield client
+    except T2ClientError as exc:
+        # nexus-00en9: a REACHABLE daemon that returns an error frame mid-RPC
+        # otherwise escapes as a raw traceback. T2ClientError is a sibling of the
+        # discovery errors below (no inheritance), so this catch never shadows
+        # them. Split by error_type so the operator gets the right remedy: a
+        # frame-level ProtocolError signals version skew (same class
+        # T2SchemaVersionMismatchError surfaces at handshake time), NOT transient
+        # contention.
+        if exc.error_type == "ProtocolError":
+            raise click.ClickException(
+                f"T2 protocol error (possible version skew): {exc.message}. "
+                "Check versions: nx --version vs the running daemon, then "
+                "restart it: nx daemon t2 restart"
+            ) from exc
+        raise click.ClickException(
+            f"T2 store error ({exc.error_type}): {exc.message}. "
+            "Retry, or check daemon state: nx daemon t2 status"
+        ) from exc
     except T2DaemonNotReachableError:
         # T2Client connects lazily on first RPC; the error surfaces here,
         # not during make_t2_client() construction. Convert to a clean

--- a/tests/test_nexus_00en9_memory_clean_errors.py
+++ b/tests/test_nexus_00en9_memory_clean_errors.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-00en9: `nx memory` prints a clean one-liner (no raw traceback) when the
+T2 backend errors mid-RPC — for BOTH backends.
+
+GH-1061 E3 already covers daemon *discovery* failures
+(``T2DaemonNotReachableError`` / ``T2SchemaVersionMismatchError``). This pins the
+two gaps it left open, both of which surface as raw tracebacks today:
+
+1. **Daemon/SQLite path** — a reachable-but-contended daemon returns a
+   ``T2ClientError`` (e.g. ``database is locked`` under write contention). The
+   original 00en9 symptom on 5.10.2.
+2. **Service path (go-live)** — in SERVICE mode ``t2_handle`` routes to an
+   ``HttpMemoryStore``; a down/unreachable service raises ``httpx.HTTPError``.
+   The service branch had no error catch at all.
+
+Both are caught in the single choke point ``t2_handle`` so every ``nx memory``
+subcommand benefits.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.daemon.t2_client import T2ClientError
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestDaemonContendedLockError:
+    """SQLite-mode: a reachable daemon returning a locked-DB error must be clean."""
+
+    def _locked_error(self) -> T2ClientError:
+        return T2ClientError(
+            error_type="OperationalError",
+            message="database is locked",
+            op="memory.put",
+        )
+
+    def test_put_locked_db_clean_one_liner(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "sqlite")  # exercise the daemon branch
+        with patch(
+            "nexus.daemon.t2_client.T2Client.call", side_effect=self._locked_error()
+        ):
+            result = runner.invoke(
+                main, ["memory", "put", "hello", "--project", "p", "--title", "t.md"]
+            )
+        assert result.exit_code != 0, result.output
+        assert "Traceback" not in result.output, result.output
+        assert "T2ClientError" not in result.output, result.output
+        # The daemon-side message must survive into the clean one-liner.
+        assert "database is locked" in result.output, result.output
+        # Actionable hint: the daemon is contended/degraded.
+        assert "nx daemon t2 status" in result.output, result.output
+
+    def test_list_locked_db_clean(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "sqlite")
+        with patch(
+            "nexus.daemon.t2_client.T2Client.call", side_effect=self._locked_error()
+        ):
+            result = runner.invoke(main, ["memory", "list"])
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output, result.output
+
+
+class TestServiceUnreachable:
+    """SERVICE-mode (go-live): a down storage service must read as a clean error,
+    not a raw traceback. Two distinct, both-real failure points:
+
+    (a) PRE-YIELD construction — endpoint not resolvable: HttpMemoryStore's
+        resolve_service_config() raises RuntimeError during T2Database.__init__,
+        BEFORE t2_handle yields. This is the common "service never started" case
+        and the one a post-yield-only catch would miss (the structural gap the
+        substantive-critic flagged).
+    (b) POST-YIELD RPC — endpoint resolved (lease existed) but the service is
+        unreachable/erroring when the RPC fires: httpx transport/status error.
+    """
+
+    def _fake_t2db_construct_raises(self, exc: Exception):
+        """A T2Database factory that raises *exc* AT CONSTRUCTION (pre-yield),
+        faithfully reproducing resolve_service_config's fail-loud path."""
+
+        def _factory(*a, **k):
+            raise exc
+
+        return _factory
+
+    def _fake_t2db_rpc_raises(self, exc: Exception):
+        """A stand-in T2Database that constructs fine but whose .memory ops raise
+        *exc* (post-yield RPC failure); .close() is a noop."""
+
+        class _Memory:
+            def list_entries(self, *a, **k):
+                raise exc
+
+            def put(self, *a, **k):
+                raise exc
+
+        class _FakeDB:
+            memory = _Memory()
+
+            def close(self) -> None:
+                pass
+
+        return lambda *a, **k: _FakeDB()
+
+    def test_list_service_endpoint_unresolvable_clean_PRE_YIELD(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The REAL service-never-started path: construction raises RuntimeError.
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
+        exc = RuntimeError(
+            "nexus-service endpoint is not resolvable (NX_STORAGE_BACKEND=service): "
+            "start the supervisor with 'nx daemon service start'"
+        )
+        with patch("nexus.db.t2.T2Database", self._fake_t2db_construct_raises(exc)):
+            result = runner.invoke(main, ["memory", "list"])
+        assert result.exit_code != 0, result.output
+        assert "Traceback" not in result.output, result.output
+        # The fail-loud RuntimeError message must survive into the clean error.
+        assert "not resolvable" in result.output, result.output
+        assert "service" in result.output, result.output
+
+    def test_list_service_down_clean_POST_YIELD(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
+        exc = httpx.ConnectError("All connection attempts failed")  # TransportError
+        with patch("nexus.db.t2.T2Database", self._fake_t2db_rpc_raises(exc)):
+            result = runner.invoke(main, ["memory", "list"])
+        assert result.exit_code != 0, result.output
+        assert "Traceback" not in result.output, result.output
+        assert "ConnectError" not in result.output, result.output
+        assert "nx doctor" in result.output, result.output
+
+    def test_put_service_http_status_error_clean_POST_YIELD(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
+        req = httpx.Request("POST", "http://127.0.0.1:9/memory")
+        resp = httpx.Response(503, request=req, text="service unavailable")
+        exc = httpx.HTTPStatusError("503", request=req, response=resp)
+        with patch("nexus.db.t2.T2Database", self._fake_t2db_rpc_raises(exc)):
+            result = runner.invoke(
+                main, ["memory", "put", "hi", "--project", "p", "--title", "t.md"]
+            )
+        assert result.exit_code != 0, result.output
+        assert "Traceback" not in result.output, result.output
+        assert "nx doctor" in result.output, result.output
+
+    def test_decode_error_is_NOT_swallowed_as_reachability(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # S2: a service-side bug (malformed JSON -> DecodingError) must NOT be
+        # aliased to a "check the service" reachability hint; it is not a
+        # TransportError/HTTPStatusError so it propagates (non-zero, no doctor hint).
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
+        exc = httpx.DecodingError("malformed body")
+        with patch("nexus.db.t2.T2Database", self._fake_t2db_rpc_raises(exc)):
+            result = runner.invoke(main, ["memory", "list"])
+        assert result.exit_code != 0, result.output
+        # Not converted to the reachability ClickException.
+        assert "Check the storage service: nx doctor" not in result.output, result.output
+
+
+class TestProtocolErrorVersionSkew:
+    """S1: a frame-level ProtocolError (version skew) gets the version-skew remedy,
+    not the transient-contention 'retry' hint."""
+
+    def test_protocol_error_points_at_version_skew(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "sqlite")
+        exc = T2ClientError(
+            error_type="ProtocolError",
+            message="unknown op id 7",
+            op="memory.list_entries",
+        )
+        with patch("nexus.daemon.t2_client.T2Client.call", side_effect=exc):
+            result = runner.invoke(main, ["memory", "list"])
+        assert result.exit_code != 0, result.output
+        assert "Traceback" not in result.output, result.output
+        assert "version skew" in result.output, result.output
+        # Must NOT give the plain contention retry hint.
+        assert "nx daemon t2 status" not in result.output, result.output


### PR DESCRIPTION
Batched go-live cleanup (one branch, one PR, one CI cycle) mapped to the survival→remediation→observability→triage ladder. Two commits, both low-risk and Python-only.

## Commits

### `fix(nexus-00en9)` — clean error UX for `nx memory` (remediation / triage)
`t2_handle()` is the single choke point for all 7 `nx memory` subcommands. GH-1061 E3 already caught daemon *discovery* errors but left two raw-traceback gaps:

- **Daemon/SQLite path:** a reachable-but-contended daemon returns `T2ClientError` (e.g. `OperationalError: database is locked`) → now a clean one-liner. Split by `error_type`: a frame-level `ProtocolError` (version skew) gets a version-check remedy, not the transient-contention retry hint.
- **Service path (go-live):** in SERVICE mode `t2_handle` routes to an `HttpMemoryStore`. Two distinct failure points, both previously uncaught:
  - **pre-yield** construction — endpoint not resolvable (`resolve_service_config` fail-loud `RuntimeError`, the common "service never started" case) → clean `ClickException`.
  - **post-yield** RPC — service unreachable/erroring → narrowed `except (httpx.TransportError, httpx.HTTPStatusError)` (decode/redirect/protocol errors keep their traceback as service-side bugs).

Tests pin both backends and both service failure points (8 cases), incl. a non-swallowed-`DecodingError` guard and the `ProtocolError` version-skew branch. GH-1061 E3 regression green.

**Stacked review:** code-review-expert PASS (fixes applied); substantive-critic JUSTIFIED (0 Critical / 0 Significant) — it caught a Critical the first pass missed: the original service test was structurally vacuous (injected a *post-yield* failure while the real service-down path fires *pre-yield* in the constructor). Fixed: construction now caught separately, test exercises the real pre-yield raise.

### `fix(hooks nexus-0kwkq)` — StopFailure CHANGELOG note (triage)
The hook fix (records crashes via `bd remember` only, never files P1 bug spam) shipped in PR #1136; this adds the missing `[Unreleased]` CHANGELOG entry.

## Also closed (already-shipped, stranded-open)
- `nexus-hvykx`, `nexus-gpmf1` — both shipped under RDR-160 (#1205/#1204), verified wired; closed, no code here.

## Closes
Closes nexus-00en9
Closes nexus-0kwkq