### PR TITLE
fix(nexus-e4130): operator-scoped token admin (multitenant security)

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/TokenCache.java
+++ b/service/src/main/java/dev/nexus/service/db/TokenCache.java
@@ -46,7 +46,19 @@ public final class TokenCache {
     /** Default flood backstop. */
     public static final int DEFAULT_MAX_ENTRIES = 10_000;
 
-    private record Entry(String tenantId, Instant expiresAt, Instant cachedAt) {
+    // nexus-e4130: isRoot is cached alongside the tenant. It is safe to cache because a
+    // row's label is immutable for a given token_hash — no API updates the label
+    // (issueToken/rotateTokens never touch it; ensureBootstrapToken is ON CONFLICT DO
+    // NOTHING on the hash). If a future API ever mutates a live row's label it MUST call
+    // invalidate(hash) so the operator bit is re-read.
+    private record Entry(String tenantId, boolean isRoot, Instant expiresAt, Instant cachedAt) {
+    }
+
+    /**
+     * Resolved bearer principal: its tenant and whether it is the root/operator token
+     * (nexus-e4130). The {@code isRoot} bit carries the cross-tenant admin privilege.
+     */
+    public record Resolved(String tenantId, boolean isRoot) {
     }
 
     private final TokenStore store;
@@ -73,6 +85,19 @@ public final class TokenCache {
      * @return the tenant, or empty if missing/revoked/expired
      */
     public Optional<String> resolveTenant(String tokenHash) {
+        return resolve(tokenHash).map(Resolved::tenantId);
+    }
+
+    /**
+     * Resolve a bearer token hash to its {@link Resolved} principal (tenant + root flag),
+     * via cache then store. Same expiry/revocation semantics as {@link #resolveTenant};
+     * the root flag rides along so a single resolution carries the operator privilege
+     * (nexus-e4130) without a second lookup.
+     *
+     * @param tokenHash {@code sha256Hex} of the presented bearer
+     * @return the resolved principal, or empty if missing/revoked/expired
+     */
+    public Optional<Resolved> resolve(String tokenHash) {
         if (tokenHash == null || tokenHash.isBlank()) {
             return Optional.empty();
         }
@@ -85,7 +110,7 @@ public final class TokenCache {
                     map.remove(tokenHash, cached);
                     return Optional.empty();
                 }
-                return Optional.of(cached.tenantId());
+                return Optional.of(new Resolved(cached.tenantId(), cached.isRoot()));
             }
             // Stale by TTL — drop and re-resolve from the store (revocation backstop).
             map.remove(tokenHash, cached);
@@ -103,8 +128,8 @@ public final class TokenCache {
             log.warn("event=token_cache_overflow max={} action=clear", maxEntries);
             map.clear();
         }
-        map.put(tokenHash, new Entry(st.tenantId(), st.expiresAt(), now));
-        return Optional.of(st.tenantId());
+        map.put(tokenHash, new Entry(st.tenantId(), st.isRoot(), st.expiresAt(), now));
+        return Optional.of(new Resolved(st.tenantId(), st.isRoot()));
     }
 
     /** Remove a token from the cache (called on revoke/rotate for immediate effect). */

--- a/service/src/main/java/dev/nexus/service/db/TokenStore.java
+++ b/service/src/main/java/dev/nexus/service/db/TokenStore.java
@@ -46,8 +46,14 @@ public final class TokenStore {
         this.clock = clock;
     }
 
-    /** A live (non-revoked) service token: its tenant and optional expiry instant. */
-    public record ServiceToken(String tenantId, Instant expiresAt) {
+    /**
+     * A live (non-revoked) service token: its tenant, optional expiry instant, and
+     * whether it is the persistent root token (the operator/admin credential, marked by
+     * {@link #ROOT_TOKEN_LABEL}). {@code isRoot} carries the operator privilege up to the
+     * {@link dev.nexus.service.http.AuthFilter} so the admin surface (nexus-e4130) can
+     * scope cross-tenant operations to the root token alone.
+     */
+    public record ServiceToken(String tenantId, Instant expiresAt, boolean isRoot) {
     }
 
     private DSLContext dsl() {
@@ -67,7 +73,7 @@ public final class TokenStore {
             return Optional.empty();
         }
         var rec = dsl()
-            .select(SERVICE_TOKENS.TENANT_ID, SERVICE_TOKENS.EXPIRES_AT)
+            .select(SERVICE_TOKENS.TENANT_ID, SERVICE_TOKENS.EXPIRES_AT, SERVICE_TOKENS.LABEL)
             .from(SERVICE_TOKENS)
             .where(SERVICE_TOKENS.TOKEN_HASH.eq(tokenHash))
             .and(SERVICE_TOKENS.REVOKED_AT.isNull())
@@ -76,9 +82,11 @@ public final class TokenStore {
             return Optional.empty();
         }
         OffsetDateTime exp = rec.get(SERVICE_TOKENS.EXPIRES_AT);
+        boolean isRoot = ROOT_TOKEN_LABEL.equals(rec.get(SERVICE_TOKENS.LABEL));
         return Optional.of(new ServiceToken(
             rec.get(SERVICE_TOKENS.TENANT_ID),
-            exp == null ? null : exp.toInstant()));
+            exp == null ? null : exp.toInstant(),
+            isRoot));
     }
 
     /**
@@ -295,6 +303,24 @@ public final class TokenStore {
      *         the cache for the returned hash)
      */
     public Optional<String> revokeToken(String selector) {
+        return revokeToken(selector, null);
+    }
+
+    /**
+     * Revoke a token by full hash or unique prefix, optionally scoped to a single tenant.
+     *
+     * <p>nexus-e4130: when {@code tenantScope} is non-null the selector must resolve to a
+     * token whose {@code tenant_id} equals it; a selector matching only another tenant's
+     * token returns empty (no cross-tenant revoke). A null scope is the operator path
+     * (root token) and matches across all tenants. The tenant predicate is applied in the
+     * selector resolution so a non-operator cannot even learn that another tenant's prefix
+     * exists.
+     *
+     * @param selector    full token_hash or a unique prefix
+     * @param tenantScope restrict the match to this tenant, or null for any (operator)
+     * @return the full token_hash revoked, or empty if no unique in-scope match
+     */
+    public Optional<String> revokeToken(String selector, String tenantScope) {
         if (selector == null || selector.isBlank()) {
             return Optional.empty();
         }
@@ -303,14 +329,18 @@ public final class TokenStore {
         // re-revoke and prefix-shadowing by a stale revoked token; excluding the root
         // token (by ROOT_TOKEN_LABEL — re-keyed off the retired wildcard sentinel in
         // Phase E) prevents an authenticated caller from revoking the supervisor
-        // credential into a total lockout (review P5.3-C).
-        List<String> matches = dsl()
+        // credential into a total lockout (review P5.3-C). nexus-e4130: a non-null
+        // tenantScope confines the match to the caller's own tenant.
+        var sel = dsl()
             .select(SERVICE_TOKENS.TOKEN_HASH)
             .from(SERVICE_TOKENS)
             .where(SERVICE_TOKENS.TOKEN_HASH.eq(selector)
                 .or(SERVICE_TOKENS.TOKEN_HASH.startsWith(selector)))
             .and(SERVICE_TOKENS.REVOKED_AT.isNull())
-            .and(SERVICE_TOKENS.LABEL.isDistinctFrom(ROOT_TOKEN_LABEL))
+            .and(SERVICE_TOKENS.LABEL.isDistinctFrom(ROOT_TOKEN_LABEL));
+        List<String> matches = (tenantScope == null
+                ? sel
+                : sel.and(SERVICE_TOKENS.TENANT_ID.eq(tenantScope)))
             .fetch(SERVICE_TOKENS.TOKEN_HASH);
         String hash;
         if (matches.contains(selector)) {

--- a/service/src/main/java/dev/nexus/service/http/AuthFilter.java
+++ b/service/src/main/java/dev/nexus/service/http/AuthFilter.java
@@ -96,13 +96,17 @@ public final class AuthFilter extends Filter {
             return;
         }
 
-        // 2. Resolve the token's tenant_id SERVER-SIDE (Decision 1).
-        Optional<String> resolved = tokenCache.resolveTenant(TokenHashing.sha256Hex(rawToken));
+        // 2. Resolve the token's tenant_id SERVER-SIDE (Decision 1). The resolution also
+        // carries the root/operator flag (nexus-e4130) so the admin surface can scope
+        // cross-tenant operations to the root token without a second lookup.
+        Optional<dev.nexus.service.db.TokenCache.Resolved> resolved =
+            tokenCache.resolve(TokenHashing.sha256Hex(rawToken));
         if (resolved.isEmpty()) {
             reject(exchange, "unresolved_token");  // missing / revoked / expired
             return;
         }
-        String tokenTenant = resolved.get();
+        String tokenTenant = resolved.get().tenantId();
+        boolean isOperator = resolved.get().isRoot();
 
         // nexus-45ykb (defense in depth): deny any token that resolves to the wildcard
         // sentinel tenant. '*' is a reserved name that token minting, `nx tenant create`,
@@ -156,7 +160,7 @@ public final class AuthFilter extends Filter {
         }
 
         // 4. Publish the principal thread-confined; clear after dispatch.
-        RequestContext.set(new RequestContext.Principal(tenant, sessionId, mintedSession));
+        RequestContext.set(new RequestContext.Principal(tenant, sessionId, mintedSession, isOperator));
         try {
             chain.doFilter(exchange);
         } finally {

--- a/service/src/main/java/dev/nexus/service/http/RequestContext.java
+++ b/service/src/main/java/dev/nexus/service/http/RequestContext.java
@@ -27,8 +27,14 @@ public final class RequestContext {
      *                      handlers MUST use {@code session} and reject any client-supplied
      *                      session id that differs (Decision 2 cross-session denial). When
      *                      false the session is a transitional bootstrap bare id.
+     * @param isOperator    true iff the bearer is the persistent root token (nexus-e4130).
+     *                      The root token is the cross-tenant admin credential; every other
+     *                      token is confined to its own tenant on the admin surface
+     *                      ({@code TokenAdminHandler}). Resolved server-side from
+     *                      {@code ROOT_TOKEN_LABEL}; never client-asserted.
      */
-    public record Principal(String tenant, String session, boolean mintedSession) {
+    public record Principal(String tenant, String session, boolean mintedSession,
+                            boolean isOperator) {
     }
 
     private static final ThreadLocal<Principal> CURRENT = new ThreadLocal<>();
@@ -65,5 +71,14 @@ public final class RequestContext {
     public static boolean isMintedSession() {
         Principal p = CURRENT.get();
         return p != null && p.mintedSession();
+    }
+
+    /**
+     * @return true iff the current request's bearer is the root/operator token
+     *         (nexus-e4130). False for every ordinary tenant token and outside a request.
+     */
+    public static boolean isOperator() {
+        Principal p = CURRENT.get();
+        return p != null && p.isOperator();
     }
 }

--- a/service/src/main/java/dev/nexus/service/http/TokenAdminHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/TokenAdminHandler.java
@@ -43,9 +43,20 @@ import java.util.Map;
  * cache-TTL window rather than leaving it unbounded. Rotate is atomic (one transaction), so a
  * crash cannot strand a tenant with zero live tokens.
  *
- * <p>AUTHORIZATION NOTE (deferred): any authenticated caller may administer any named tenant
- * (provisioning rides the bootstrap token until per-tenant principals exist). Per-caller
- * admin scoping is out of scope for Phase C; the bootstrap token is the admin credential.
+ * <p>AUTHORIZATION (nexus-e4130): the root token (the operator credential, resolved
+ * server-side via {@code ROOT_TOKEN_LABEL} and surfaced as {@link RequestContext#isOperator()})
+ * may administer any tenant. Every ordinary tenant token is confined to its OWN tenant:
+ * <ul>
+ *   <li>{@code /v1/tenants/create} — OPERATOR ONLY (creating a new tenant is inherently
+ *       cross-tenant; a tenant-bound token cannot provision a different tenant).</li>
+ *   <li>{@code issue} / {@code rotate} — the body {@code tenant} must equal the caller's
+ *       bound tenant (else 403), unless the caller is the operator.</li>
+ *   <li>{@code list} — a non-operator is force-scoped to its own tenant (any body
+ *       {@code tenant} is ignored), so it cannot enumerate another tenant's tokens.</li>
+ *   <li>{@code revoke} — a non-operator's selector is resolved only within its own tenant
+ *       (a selector matching only another tenant's token reads as "not found"), so it can
+ *       neither revoke nor probe for another tenant's tokens.</li>
+ * </ul>
  */
 public final class TokenAdminHandler implements HttpHandler {
 
@@ -101,6 +112,11 @@ public final class TokenAdminHandler implements HttpHandler {
     }
 
     private void handleTenantCreate(HttpExchange ex) throws IOException {
+        // nexus-e4130: provisioning a NEW tenant is inherently cross-tenant — only the
+        // operator (root) token may do it; a tenant-bound token cannot.
+        if (!requireOperator(ex)) {
+            return;
+        }
         Map<String, Object> body = readBody(ex);
         String name = requireString(body, "name");
         TokenStore.IssuedToken issued = store.issueToken(name, "tenant-create-initial", null);
@@ -111,6 +127,9 @@ public final class TokenAdminHandler implements HttpHandler {
     private void handleIssue(HttpExchange ex) throws IOException {
         Map<String, Object> body = readBody(ex);
         String tenant = requireString(body, "tenant");
+        if (!authorizedForTenant(ex, tenant)) {  // nexus-e4130: self-scope non-operators
+            return;
+        }
         String label = optString(body, "label");
         Long ttl = optLong(body, "ttl_seconds");
         TokenStore.IssuedToken issued = store.issueToken(tenant, label, ttl);
@@ -121,6 +140,9 @@ public final class TokenAdminHandler implements HttpHandler {
     private void handleRotate(HttpExchange ex) throws IOException {
         Map<String, Object> body = readBody(ex);
         String tenant = requireString(body, "tenant");
+        if (!authorizedForTenant(ex, tenant)) {  // nexus-e4130: self-scope non-operators
+            return;
+        }
         Long grace = optLong(body, "grace_seconds");
         TokenStore.RotationResult result =
             store.rotateTokens(tenant, grace == null ? DEFAULT_GRACE_SECONDS : grace);
@@ -135,7 +157,11 @@ public final class TokenAdminHandler implements HttpHandler {
     private void handleRevoke(HttpExchange ex) throws IOException {
         Map<String, Object> body = readBody(ex);
         String selector = requireString(body, "selector");
-        var revokedHash = store.revokeToken(selector);
+        // nexus-e4130: a non-operator may only revoke within its own tenant. Passing the
+        // tenant scope into selector resolution means another tenant's prefix reads as
+        // "not found" — no cross-tenant revoke AND no existence probe.
+        String scope = RequestContext.isOperator() ? null : RequestContext.tenant();
+        var revokedHash = store.revokeToken(selector, scope);
         revokedHash.ifPresent(cache::invalidate);  // immediate effect on the live cache
         Map<String, Object> resp = new LinkedHashMap<>();
         resp.put("revoked", revokedHash.isPresent());
@@ -146,6 +172,11 @@ public final class TokenAdminHandler implements HttpHandler {
     private void handleList(HttpExchange ex) throws IOException {
         Map<String, Object> body = readBody(ex);
         String tenant = optString(body, "tenant");
+        // nexus-e4130: a non-operator is force-scoped to its own tenant; any body 'tenant'
+        // is ignored so it cannot enumerate another tenant's tokens (or probe existence).
+        if (!RequestContext.isOperator()) {
+            tenant = RequestContext.tenant();
+        }
         var now = clock.instant();
         List<Map<String, Object>> rows = new ArrayList<>();
         for (TokenStore.TokenInfo t : store.listTokens(tenant)) {
@@ -160,6 +191,40 @@ public final class TokenAdminHandler implements HttpHandler {
             rows.add(row);
         }
         HttpUtil.send(ex, 200, json(Map.of("tokens", rows)));
+    }
+
+    // ── Authorization (nexus-e4130) ──────────────────────────────────────────────
+
+    /**
+     * Allow only the operator (root) token. Sends 403 and returns false otherwise.
+     * Used by routes that are inherently cross-tenant (tenant create).
+     */
+    private boolean requireOperator(HttpExchange ex) throws IOException {
+        if (RequestContext.isOperator()) {
+            return true;
+        }
+        log.debug("event=token_admin_denied reason=operator_required tenant={}",
+                  RequestContext.tenant());
+        HttpUtil.send(ex, 403, json(Map.of(
+            "error", "operator privilege required: this operation needs the root token")));
+        return false;
+    }
+
+    /**
+     * Allow the operator, or a tenant token acting on its OWN tenant. Sends 403 and
+     * returns false when a non-operator targets a different tenant.
+     */
+    private boolean authorizedForTenant(HttpExchange ex, String tenant) throws IOException {
+        String caller = RequestContext.tenant();
+        if (RequestContext.isOperator() || tenant.equals(caller)) {
+            return true;
+        }
+        log.debug("event=token_admin_denied reason=cross_tenant caller={} requested={}",
+                  caller, tenant);
+        HttpUtil.send(ex, 403, json(Map.of(
+            "error", "forbidden: token bound to tenant '" + caller
+                + "' may not administer tenant '" + tenant + "'")));
+        return false;
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -51,6 +51,8 @@
          session_tokens credential-resolution tables. NO RLS (read before tenant
          context exists; the token resolves the tenant). nexus schema. -->
     <include file="db/changelog/service-tokens-001-baseline.xml"/>
+    <!-- nexus-e4130: at-most-one-root-token partial unique index (operator invariant). -->
+    <include file="db/changelog/service-tokens-002-single-root-index.xml"/>
 
     <!-- Store 10: pgvector chunks tables + manifest collection column (bead nexus-mf447) -->
     <include file="db/changelog/vectors-001-baseline.xml"/>

--- a/service/src/main/resources/db/changelog/service-tokens-002-single-root-index.xml
+++ b/service/src/main/resources/db/changelog/service-tokens-002-single-root-index.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    nexus-e4130 — enforce the single-root-token invariant at the DB layer.
+
+    The operator (cross-tenant admin) privilege is keyed entirely on the
+    ROOT_TOKEN_LABEL ('bootstrap-legacy-token') marker: AuthFilter resolves
+    isOperator from it, and TokenAdminHandler grants cross-tenant powers to it.
+    That model assumes EXACTLY ONE root row. ensureBootstrapToken is idempotent
+    on token_hash (ON CONFLICT DO NOTHING on the PK), so a second seed with a
+    ROTATED NX_SERVICE_TOKEN would leave the old hash AND insert a new one — two
+    rows carrying the root label, hence two operator credentials, silently.
+
+    This partial unique index makes "at most one root token" a DB-enforced
+    invariant: a second root-labelled insert fails loud rather than minting a
+    second invisible operator. Partial (WHERE label = ...) so it constrains only
+    the root label and leaves ordinary labels unconstrained (they are free-form).
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="service-tokens-002-1" author="nexus-e4130">
+        <comment>
+            Partial unique index pinning at most one ROOT_TOKEN_LABEL row, so the
+            "operator = the single root token" model cannot be silently violated by
+            a second root-labelled insert (e.g. a rotated NX_SERVICE_TOKEN re-seed).
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+CREATE UNIQUE INDEX idx_service_tokens_single_root
+    ON nexus.service_tokens (label)
+    WHERE label = 'bootstrap-legacy-token';
+        </sql>
+        <rollback>DROP INDEX IF EXISTS nexus.idx_service_tokens_single_root</rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/test/java/dev/nexus/service/ServiceTokenSchemaLiquibaseTest.java
+++ b/service/src/test/java/dev/nexus/service/ServiceTokenSchemaLiquibaseTest.java
@@ -238,6 +238,38 @@ class ServiceTokenSchemaLiquibaseTest {
             .anyMatch(d -> d.contains("(expires_at)"));
     }
 
+    // ── Test 9: single-root partial unique index (nexus-e4130) ───────────────
+
+    @Test
+    void serviceTokens_atMostOneRootToken() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("TRUNCATE nexus.service_tokens");
+            // First root-labelled row inserts fine.
+            su.createStatement().execute(
+                "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label) "
+                + "VALUES ('root-hash-1', 'default', 'bootstrap-legacy-token')");
+            // A SECOND root-labelled row (e.g. a rotated NX_SERVICE_TOKEN re-seed) must be
+            // rejected by the partial unique index — otherwise two operator credentials.
+            boolean rejected = false;
+            try {
+                su.createStatement().execute(
+                    "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label) "
+                    + "VALUES ('root-hash-2', 'default', 'bootstrap-legacy-token')");
+            } catch (java.sql.SQLException expected) {
+                rejected = true;
+            }
+            assertThat(rejected)
+                .as("a second 'bootstrap-legacy-token' row must violate the single-root "
+                    + "unique index (the operator invariant)")
+                .isTrue();
+            // Ordinary (non-root) labels remain unconstrained — many rows may share one.
+            su.createStatement().execute(
+                "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label) VALUES "
+                + "('ord-1', 'tenant-a', 'worker'), ('ord-2', 'tenant-a', 'worker')");
+        }
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private Set<String> columnsOf(String schema, String table) throws Exception {

--- a/service/src/test/java/dev/nexus/service/TokenAdminHandlerTest.java
+++ b/service/src/test/java/dev/nexus/service/TokenAdminHandlerTest.java
@@ -303,7 +303,131 @@ class TokenAdminHandlerTest {
         assertThat(http.send(req, HttpResponse.BodyHandlers.ofString()).statusCode()).isEqualTo(405);
     }
 
+    // ── nexus-e4130: caller-scoped authorization ─────────────────────────────
+    // A tenant token (minted via /v1/tenants/create under the operator BOOT token) is a
+    // non-operator bearer bound to its own tenant. It must not administer other tenants.
+
+    @Test
+    void nonOperator_cannotCreateTenant() throws Exception {
+        String tokA = postJson("/v1/tenants/create", "{\"name\":\"e4130-create-a\"}").get("token").asText();
+        var resp = sendAs(tokA, "/v1/tenants/create", "{\"name\":\"e4130-create-sneaky\"}");
+        assertThat(resp.statusCode()).as("non-operator tenant-create must be 403: %s", resp.body()).isEqualTo(403);
+    }
+
+    @Test
+    void nonOperator_cannotIssueForAnotherTenant() throws Exception {
+        String tokA = postJson("/v1/tenants/create", "{\"name\":\"e4130-issue-a\"}").get("token").asText();
+        postJson("/v1/tenants/create", "{\"name\":\"e4130-issue-victim\"}");  // victim exists
+        var resp = sendAs(tokA, "/v1/service-tokens/issue", "{\"tenant\":\"e4130-issue-victim\"}");
+        assertThat(resp.statusCode()).as("cross-tenant issue must be 403: %s", resp.body()).isEqualTo(403);
+    }
+
+    @Test
+    void nonOperator_canIssueForOwnTenant() throws Exception {
+        String tokA = postJson("/v1/tenants/create", "{\"name\":\"e4130-own\"}").get("token").asText();
+        var resp = sendAs(tokA, "/v1/service-tokens/issue", "{\"tenant\":\"e4130-own\"}");
+        assertThat(resp.statusCode()).as("self-tenant issue must be 200: %s", resp.body()).isEqualTo(200);
+    }
+
+    @Test
+    void nonOperator_cannotRotateAnotherTenant() throws Exception {
+        String tokA = postJson("/v1/tenants/create", "{\"name\":\"e4130-rotate-a\"}").get("token").asText();
+        postJson("/v1/tenants/create", "{\"name\":\"e4130-rotate-victim\"}");
+        var resp = sendAs(tokA, "/v1/service-tokens/rotate", "{\"tenant\":\"e4130-rotate-victim\"}");
+        assertThat(resp.statusCode()).as("cross-tenant rotate must be 403: %s", resp.body()).isEqualTo(403);
+    }
+
+    @Test
+    void nonOperator_listIsForcedToOwnTenant() throws Exception {
+        postJson("/v1/tenants/create", "{\"name\":\"e4130-list-victim\"}");
+        String tokA = postJson("/v1/tenants/create", "{\"name\":\"e4130-list-a\"}").get("token").asText();
+        // A asks to list the victim's tokens; the request is force-scoped to A.
+        var resp = sendAs(tokA, "/v1/service-tokens/list", "{\"tenant\":\"e4130-list-victim\"}");
+        assertThat(resp.statusCode()).isEqualTo(200);
+        JsonNode rows = MAPPER.readTree(resp.body()).get("tokens");
+        // Non-vacuity precondition: A owns at least its create-initial token, so the
+        // for-loop below MUST execute — otherwise a scoping bug returning [] would pass
+        // this leak test vacuously.
+        assertThat(rows).as("A must see at least its own initial token").isNotEmpty();
+        for (JsonNode row : rows) {
+            assertThat(row.get("tenant").asText())
+                .as("non-operator list must never leak another tenant's rows")
+                .isEqualTo("e4130-list-a");
+        }
+    }
+
+    @Test
+    void nonOperator_prefixSelectorCannotRevokeAcrossTenants() throws Exception {
+        // S1: a prefix that could match tokens in BOTH tenants must, under a non-operator's
+        // scope, resolve only within the caller's own tenant. We use the empty-string-free
+        // shortest stable prefix of the victim's hash; the tenant predicate must exclude it.
+        var victim = postJson("/v1/tenants/create", "{\"name\":\"e4130-prefix-victim\"}");
+        String victimRaw = victim.get("token").asText();
+        String victimHash = victim.get("token_hash").asText();
+        String tokA = postJson("/v1/tenants/create", "{\"name\":\"e4130-prefix-a\"}").get("token").asText();
+        // Use a prefix of the victim's hash as the selector.
+        String prefix = victimHash.substring(0, 16);
+        var resp = sendAs(tokA, "/v1/service-tokens/revoke", "{\"selector\":\"" + prefix + "\"}");
+        assertThat(resp.statusCode()).isEqualTo(200);
+        assertThat(MAPPER.readTree(resp.body()).get("revoked").asBoolean())
+            .as("a non-operator prefix selector must not resolve another tenant's token")
+            .isFalse();
+        assertThat(whoami(victimRaw, null)).as("victim token must survive prefix probe").isEqualTo(200);
+    }
+
+    @Test
+    void operator_canRevokeAnyTenantToken() throws Exception {
+        // S2: complete the operator contract — the operator (tenantScope=null) CAN revoke
+        // a foreign tenant's token. Issue a revocable token under a foreign tenant, then
+        // revoke it as BOOT (operator) and confirm it stops authenticating.
+        postJson("/v1/tenants/create", "{\"name\":\"e4130-oprev-target\"}");
+        var issued = postJson("/v1/service-tokens/issue", "{\"tenant\":\"e4130-oprev-target\"}");
+        String hash = issued.get("token_hash").asText();
+        String raw = issued.get("token").asText();
+        assertThat(whoami(raw, null)).isEqualTo(200);  // live before revoke
+        var resp = http.send(req("/v1/service-tokens/revoke", "{\"selector\":\"" + hash + "\"}"),
+            HttpResponse.BodyHandlers.ofString());
+        assertThat(resp.statusCode()).isEqualTo(200);
+        assertThat(MAPPER.readTree(resp.body()).get("revoked").asBoolean())
+            .as("operator must revoke a foreign tenant's token").isTrue();
+    }
+
+    @Test
+    void nonOperator_cannotRevokeOrProbeAnotherTenantToken() throws Exception {
+        var victim = postJson("/v1/tenants/create", "{\"name\":\"e4130-revoke-victim\"}");
+        String victimRaw = victim.get("token").asText();
+        String victimHash = victim.get("token_hash").asText();
+        String tokA = postJson("/v1/tenants/create", "{\"name\":\"e4130-revoke-a\"}").get("token").asText();
+        // A tries to revoke the victim's token by exact hash. Scoped to A -> not found.
+        var resp = sendAs(tokA, "/v1/service-tokens/revoke", "{\"selector\":\"" + victimHash + "\"}");
+        assertThat(resp.statusCode()).isEqualTo(200);
+        assertThat(MAPPER.readTree(resp.body()).get("revoked").asBoolean())
+            .as("cross-tenant revoke must report not-found (no revoke, no existence probe)")
+            .isFalse();
+        // The victim's token still authenticates — it was NOT revoked.
+        assertThat(whoami(victimRaw, null)).as("victim token must survive").isEqualTo(200);
+    }
+
+    @Test
+    void operator_canAdministerAnyTenant() throws Exception {
+        postJson("/v1/tenants/create", "{\"name\":\"e4130-op-target\"}");
+        // BOOT is the operator (ROOT_TOKEN_LABEL): issue/list/rotate for ANY tenant -> 200.
+        assertThat(status("/v1/service-tokens/issue", "{\"tenant\":\"e4130-op-target\"}")).isEqualTo(200);
+        assertThat(status("/v1/service-tokens/list", "{\"tenant\":\"e4130-op-target\"}")).isEqualTo(200);
+        assertThat(status("/v1/service-tokens/rotate", "{\"tenant\":\"e4130-op-target\"}")).isEqualTo(200);
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /** POST as an arbitrary bearer (no X-Nexus-Tenant: the token's bound tenant is authoritative). */
+    private HttpResponse<String> sendAs(String bearer, String path, String body) throws Exception {
+        var req = HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + path))
+            .header("Authorization", "Bearer " + bearer)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+        return http.send(req, HttpResponse.BodyHandlers.ofString());
+    }
 
     private JsonNode postJson(String path, String body) throws Exception {
         var resp = http.send(req(path, body), HttpResponse.BodyHandlers.ofString());


### PR DESCRIPTION
## Security fix (go-live, multitenant)

Closes the hole where **any authenticated bearer could administer any tenant's tokens** via `/v1/tenants/create` + `/v1/service-tokens/{issue,rotate,revoke,list}`. The handler read `tenant` from the request body and acted on it with no caller check.

**Model (Option A, owner-confirmed):** the root token (`ROOT_TOKEN_LABEL`, the `NX_SERVICE_TOKEN` supervisor credential, resolved server-side) is the sole cross-tenant **operator**; every ordinary tenant token is confined to its own bound tenant.

### Enforcement (`TokenAdminHandler`)
- `tenant-create` — **operator only** (provisioning a new tenant is inherently cross-tenant).
- `issue` / `rotate` — `body.tenant` must equal the caller's bound tenant (else 403).
- `list` — non-operator force-scoped to its own tenant (body `tenant` ignored).
- `revoke` — non-operator's selector resolved only within its own tenant (no cross-tenant revoke **and** no existence-probe).

### Plumbing
- `TokenStore.ServiceToken` gains `isRoot` (from `LABEL`); `revokeToken(selector, tenantScope)` overload.
- `TokenCache.resolve() -> Resolved{tenant, isRoot}`; `resolveTenant` delegates. `isRoot` cached (label immutable per hash; documented).
- `RequestContext.Principal.isOperator`, set in `AuthFilter` from the server-resolved root flag — never client-asserted.
- **Schema:** partial unique index `idx_service_tokens_single_root` enforces the at-most-one-root-token invariant the operator model depends on (a rotated re-seed can't mint a second silent operator; idempotent same-hash re-seed unaffected — PK conflict fires first).

### Tests
10 E2E/schema tests: operator vs non-operator across all five routes, prefix-selector cross-tenant probe, operator cross-tenant revoke, single-root index enforcement, non-vacuous list-leak precondition. **Full fresh-codegen `mvn` suite: 774 green.**

### Review
Stacked, sonnet-class (auth boundary): code-review-expert **APPROVED**; substantive-critic raised 2 Significant (no DB single-root enforcement; vacuous list test) — **both fixed**, re-review **justified 0/0**.

### Deferred
Option B (operator-role column + per-human operator attribution) deferred to Phase 6, tracked as a follow-on bead — every operator action is currently attributed to the single shared root token.

## Closes
Closes nexus-e4130