### PR TITLE
test(nexus-5j7pb): run auth tests as nexus_svc, not BYPASSRLS superuser

### DIFF
--- a/service/src/test/java/dev/nexus/service/AuthFilterTest.java
+++ b/service/src/test/java/dev/nexus/service/AuthFilterTest.java
@@ -100,10 +100,20 @@ class AuthFilterTest {
                 new ClassLoaderResourceAccessor(), db).update(new Contexts());
         }
 
+        // nexus-5j7pb: back the code-under-test with nexus_svc (NOSUPERUSER NOBYPASSRLS),
+        // the SAME credential as production, rather than the Postgres superuser (BYPASSRLS).
+        // Scope honesty: these auth-resolution tests touch ONLY the credential tables
+        // (service_tokens/session_tokens), which are RLS-off by design, so this does NOT
+        // itself exercise an RLS boundary. Its value is harness honesty — the auth layer
+        // runs under the production role and its real grants (grants-nexus-svc.xml,
+        // runAlways/LAST), so an RLS policy ever added to a credential table would surface
+        // as a fail-closed break here instead of being masked by BYPASSRLS. Production-role
+        // convention consistent with TokenBoundaryAdversarialTest (which is where actual
+        // cross-tenant RLS enforcement on domain tables is asserted).
         var cfg = new HikariConfig();
         cfg.setJdbcUrl(pg.getJdbcUrl());
-        cfg.setUsername(PgContainerHelper.USERNAME);
-        cfg.setPassword(PgContainerHelper.PASSWORD);
+        cfg.setUsername(PgContainerHelper.SVC_USERNAME);
+        cfg.setPassword(PgContainerHelper.SVC_PASSWORD);
         cfg.setMaximumPoolSize(5);
         cfg.setAutoCommit(true);
         cfg.setConnectionInitSql("SET search_path TO nexus, t1, public");

--- a/service/src/test/java/dev/nexus/service/PgContainerHelper.java
+++ b/service/src/test/java/dev/nexus/service/PgContainerHelper.java
@@ -34,6 +34,16 @@ public final class PgContainerHelper {
     /** Superuser password. */
     public static final String PASSWORD = "postgres";
 
+    /**
+     * Production service role (NOSUPERUSER NOBYPASSRLS) — the credential the app layer
+     * should run under in tests so it is subject to the same RLS as production, rather
+     * than the BYPASSRLS superuser (nexus-5j7pb). The role is created by each test's
+     * startAll() and granted DML by the grants-nexus-svc.xml changeset.
+     */
+    public static final String SVC_USERNAME = "nexus_svc";
+    /** Password for {@link #SVC_USERNAME}. */
+    public static final String SVC_PASSWORD = "nexus_svc_pass";
+
     private PgContainerHelper() {}
 
     /**

--- a/service/src/test/java/dev/nexus/service/TokenAdminHandlerTest.java
+++ b/service/src/test/java/dev/nexus/service/TokenAdminHandlerTest.java
@@ -76,10 +76,18 @@ class TokenAdminHandlerTest {
                 ps.executeUpdate();
             }
         }
+        // nexus-5j7pb: back the service under test with nexus_svc (NOSUPERUSER NOBYPASSRLS),
+        // the SAME credential as production, rather than the Postgres superuser (BYPASSRLS).
+        // Scope honesty: the admin handler / AuthFilter touch ONLY the credential tables
+        // (service_tokens/session_tokens), which are RLS-off by design, so this does NOT
+        // itself exercise an RLS boundary. Its value is harness honesty — the service runs
+        // under the production role and its real grants (grants-nexus-svc.xml), so a future
+        // RLS policy on a credential table would fail-closed here instead of being masked
+        // by BYPASSRLS. Production-role convention consistent with TokenBoundaryAdversarialTest.
         var cfg = new HikariConfig();
         cfg.setJdbcUrl(pg.getJdbcUrl());
-        cfg.setUsername(PgContainerHelper.USERNAME);
-        cfg.setPassword(PgContainerHelper.PASSWORD);
+        cfg.setUsername(PgContainerHelper.SVC_USERNAME);
+        cfg.setPassword(PgContainerHelper.SVC_PASSWORD);
         cfg.setMaximumPoolSize(5);
         cfg.setAutoCommit(true);
         cfg.setConnectionInitSql("SET search_path TO nexus, t1, public");
@@ -242,11 +250,23 @@ class TokenAdminHandlerTest {
     void list_excludesRootToken_andRejectsWildcardFilter() throws Exception {
         // Unfiltered list never surfaces the root token row (excluded by ROOT_TOKEN_LABEL).
         String bootHash = TokenHashing.sha256Hex(BOOT);
+        // Seed a known non-root token so the list is provably non-empty: otherwise (if this
+        // test ran first, with only the excluded root row present) the exclusion loop would
+        // execute zero times and pass vacuously, masking a zero-rows regression.
+        String mineHash = postJson("/v1/service-tokens/issue", "{\"tenant\":\"list-excl-probe\"}")
+            .get("token_hash").asText();
+        boolean sawMine = false;
         for (JsonNode row : postJson("/v1/service-tokens/list", "{}").get("tokens")) {
             assertThat(row.get("tenant").asText()).isNotEqualTo("*");
             assertThat(row.get("token_hash").asText())
                 .as("root token must not be enumerable").isNotEqualTo(bootHash);
+            if (mineHash.equals(row.get("token_hash").asText())) {
+                sawMine = true;
+            }
         }
+        assertThat(sawMine)
+            .as("the unfiltered list must include the seeded non-root token (non-vacuity)")
+            .isTrue();
         // Explicit '*' filter is still rejected as a reserved sentinel name.
         assertThat(status("/v1/service-tokens/list", "{\"tenant\":\"*\"}")).isEqualTo(400);
     }


### PR DESCRIPTION
## What

`AuthFilterTest` and `TokenAdminHandlerTest` backed the code-under-test with a `HikariDataSource` using the Postgres **superuser** (`PgContainerHelper.USERNAME='postgres'`, which has `BYPASSRLS`). This switches the app datasource to `nexus_svc` (`NOSUPERUSER NOBYPASSRLS`) — the role production runs under. Direct test-seeding connections stay on the superuser (setup, not code-under-test).

## Scope honesty (substantive-critic)

These are auth-**resolution** tests that touch only the credential tables (`service_tokens`/`session_tokens`), which are **RLS-off by design**. So this does **not** itself exercise an RLS boundary — switching roles returns identical rows. Its value is **harness honesty**: the auth layer now runs under the production role + its real grants (`grants-nexus-svc.xml`), so an RLS policy ever added to a credential table would fail-closed here instead of being masked by `BYPASSRLS`. Actual cross-tenant RLS enforcement on domain tables is asserted in `TokenBoundaryAdversarialTest` / `ChunksRlsBehavioralTest`, not here. (The original comments overclaimed "makes RLS coverage real"; corrected.)

## Also
- `SVC_USERNAME`/`SVC_PASSWORD` constants on `PgContainerHelper` (dedupe the magic strings).
- Non-vacuity guard on `list_excludesRootToken`: seed a known non-root token and assert the unfiltered list contains it, so a zero-rows regression can't pass the exclusion loop vacuously (order-independent, unlike a blind `isNotEmpty`).

## Review
Stacked: code-review-expert **APPROVED**; substantive-critic raised 2 Significant (both comment-overclaim) — fixed verbatim. Full fresh-codegen `mvn` suite green (774).

## Closes
Closes nexus-5j7pb