### PR TITLE
test(nexus-4pz86): tenant RLS isolation under transaction-mode pooling

### DIFF
--- a/service/src/test/java/dev/nexus/service/PgBouncerTenantIsolationTest.java
+++ b/service/src/test/java/dev/nexus/service/PgBouncerTenantIsolationTest.java
@@ -1,0 +1,189 @@
+package dev.nexus.service;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.nexus.service.db.MemoryRepository;
+import dev.nexus.service.db.TenantScope;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.sql.Connection;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * nexus-4pz86 (conexus RDR-001): prove the engine works correctly through a REAL
+ * transaction-mode PgBouncer with the server-connection pool capped at one, AND that
+ * tenant context does not bleed across the reused server backend. This is the production
+ * topology (Crunchy Standard fronts PostgreSQL with PgBouncer); the engine-side analog of
+ * the conexus GucLeakTripwire.
+ *
+ * <p>Complements {@link TenantPoolingIsolationTest} (which proves the leak property
+ * deterministically via a 1-connection HikariCP pool, no external pooler). This class
+ * adds the two things only a real txn-mode pooler can exercise:
+ * <ul>
+ *   <li><b>(a) functional correctness</b> — multiple transactions multiplexed by
+ *       PgBouncer onto a single server backend must succeed. A reliance on session-scoped
+ *       server state that txn-mode pooling resets between transactions (server-prepared
+ *       statements, session {@code SET}, advisory locks, LISTEN/NOTIFY) would surface as
+ *       errors here.</li>
+ *   <li><b>(b) leak-safety</b> — a second tenant's transaction on the reused backend sees
+ *       none of the first's rows.</li>
+ * </ul>
+ *
+ * <p><b>Sensitivity note.</b> Like {@code TenantPoolingIsolationTest}'s isolation tests,
+ * the leak test here re-stamps the GUC each transaction, so it would not detect a
+ * session-scoped {@code set_config} regression on its own (and PgBouncer's
+ * {@code server_reset_query} would mask it too). The assertion actually sensitive to the
+ * transaction-local property is {@code TenantPoolingIsolationTest#tenantGucIsResetAfter
+ * TransactionCommit}, which reads the GUC on a raw, un-pooler-mediated borrow.
+ *
+ * <p>Topology: PG (pgvector) and PgBouncer share a Docker network; PgBouncer runs in
+ * {@code transaction} mode with {@code default_pool_size=1} + {@code max_db_connections=1}
+ * so every client transaction is forced onto the one server backend. The app
+ * {@link TenantScope}/{@link MemoryRepository} connect through PgBouncer's mapped port.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PgBouncerTenantIsolationTest {
+
+    // Pinned by digest for reproducibility (edoburu/pgbouncer:latest at 2026-06-16).
+    private static final DockerImageName PGBOUNCER_IMAGE = DockerImageName.parse(
+        "edoburu/pgbouncer@sha256:4c1ca296ef525f108f5d3552cc337c0c09587cf8dae7f0067fd93349e47dc1cd");
+
+    private static final String PG_ALIAS = "pgdb";
+    private static final String TENANT_A = "pgb-tenant-a";
+    private static final String TENANT_B = "pgb-tenant-b";
+    private static final String PROJECT = "pgb-isolation";
+
+    Network net;
+    PostgreSQLContainer<?> pg;
+    GenericContainer<?> pgbouncer;
+    HikariDataSource ds;
+    MemoryRepository repo;
+
+    @BeforeAll
+    @SuppressWarnings("resource")
+    void startAll() throws Exception {
+        net = Network.newNetwork();
+        pg = new PostgreSQLContainer<>(
+                DockerImageName.parse(PgContainerHelper.IMAGE).asCompatibleSubstituteFor("postgres"))
+            .withDatabaseName(PgContainerHelper.DATABASE)
+            .withUsername(PgContainerHelper.USERNAME)
+            .withPassword(PgContainerHelper.PASSWORD)
+            .withNetwork(net)
+            .withNetworkAliases(PG_ALIAS);
+        pg.start();
+
+        // Create the production service role + apply the schema (grants-nexus-svc.xml
+        // grants nexus_svc DML), exactly as the other PG tests do.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='"
+                + PgContainerHelper.SVC_USERNAME + "') THEN CREATE ROLE "
+                + PgContainerHelper.SVC_USERNAME + " LOGIN PASSWORD '"
+                + PgContainerHelper.SVC_PASSWORD + "' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            Database db = DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(su));
+            try (var lq = new Liquibase("db/changelog/db.changelog-master.xml",
+                    new ClassLoaderResourceAccessor(), db)) {
+                lq.update(new Contexts());
+            }
+        }
+
+        pgbouncer = new GenericContainer<>(PGBOUNCER_IMAGE)
+            .withNetwork(net)
+            .withEnv("DB_HOST", PG_ALIAS)
+            .withEnv("DB_PORT", "5432")
+            .withEnv("DB_NAME", PgContainerHelper.DATABASE)
+            .withEnv("DB_USER", PgContainerHelper.SVC_USERNAME)
+            .withEnv("DB_PASSWORD", PgContainerHelper.SVC_PASSWORD)
+            .withEnv("AUTH_TYPE", "plain")
+            .withEnv("POOL_MODE", "transaction")   // the production / leak-relevant mode
+            .withEnv("DEFAULT_POOL_SIZE", "1")      // one server backend...
+            .withEnv("MAX_DB_CONNECTIONS", "1")     // ...forced, so reuse is guaranteed
+            .withEnv("MAX_CLIENT_CONN", "20")
+            .withExposedPorts(5432)
+            .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(60)));
+        pgbouncer.start();
+
+        String jdbc = "jdbc:postgresql://" + pgbouncer.getHost() + ":"
+            + pgbouncer.getMappedPort(5432) + "/" + PgContainerHelper.DATABASE;
+        var cfg = new HikariConfig();
+        cfg.setJdbcUrl(jdbc);
+        cfg.setUsername(PgContainerHelper.SVC_USERNAME);
+        cfg.setPassword(PgContainerHelper.SVC_PASSWORD);
+        cfg.setMaximumPoolSize(4);   // several CLIENT conns; PgBouncer multiplexes onto 1 server
+        cfg.setAutoCommit(true);
+        cfg.setConnectionInitSql("SET search_path TO nexus, t1, public");
+        // PgBouncer transaction mode is incompatible with JDBC server-side prepared
+        // statements that outlive a transaction; disable them so the driver uses the
+        // simple/unnamed path (the documented client setting for txn-mode pooling, what a
+        // correct production deployment configures).
+        // SCOPE BOUNDARY (substantive-critic 2026-06-16): this test verifies the engine
+        // works WHEN correctly configured; it does NOT assert that OMITTING
+        // prepareThreshold=0 fails. Catching a deployment that forgets this flag is a
+        // deployment-config concern, not covered here (a negative test would be
+        // JDBC-driver-version-brittle).
+        cfg.addDataSourceProperty("prepareThreshold", "0");
+        ds = new HikariDataSource(cfg);
+
+        repo = new MemoryRepository(new TenantScope(ds));
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (ds != null) ds.close();
+        if (pgbouncer != null) pgbouncer.stop();
+        if (pg != null) pg.stop();
+        if (net != null) net.close();
+    }
+
+    @BeforeEach
+    void cleanMemory() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("TRUNCATE nexus.memory");
+        }
+    }
+
+    @Test
+    void functionsCorrectlyThroughTransactionModePgBouncer() {
+        // (a) Multiple transactions multiplexed onto the single server backend must work.
+        for (int i = 0; i < 6; i++) {
+            long id = repo.upsert(TENANT_A, PROJECT, "fn-" + i, "v-" + i, "", null, null, null);
+            assertThat(id).as("upsert %s through PgBouncer must succeed", i).isPositive();
+        }
+        assertThat(repo.findByProject(TENANT_A, PROJECT))
+            .as("all writes are visible to their tenant through the pooler").hasSize(6);
+    }
+
+    @Test
+    void tenantContextDoesNotBleedThroughPgBouncer() {
+        // (b) Tenant A writes; tenant B (its txn multiplexed onto the SAME server backend
+        // by PgBouncer) must see none of A's rows.
+        repo.upsert(TENANT_A, PROJECT, "secret", "A-only", "", null, null, null);
+        assertThat(repo.findByProject(TENANT_B, PROJECT))
+            .as("tenant B must not see tenant A's rows through txn-mode PgBouncer")
+            .isEmpty();
+        assertThat(repo.findByProject(TENANT_A, PROJECT))
+            .as("tenant A sees its own row (positive control)").hasSize(1);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/TenantPoolingIsolationTest.java
+++ b/service/src/test/java/dev/nexus/service/TenantPoolingIsolationTest.java
@@ -1,0 +1,169 @@
+package dev.nexus.service;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.nexus.service.db.MemoryRepository;
+import dev.nexus.service.db.TenantScope;
+import org.testcontainers.containers.PostgreSQLContainer;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.sql.Connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * nexus-4pz86 (conexus RDR-001 consumer requirement): prove the engine's tenant
+ * isolation is leak-safe when a single PostgreSQL <em>server</em> connection is reused
+ * across transactions belonging to different tenants — the exact condition a
+ * transaction-mode connection pooler (PgBouncer, as in Crunchy production) creates.
+ *
+ * <p><b>Why a {@code maximumPoolSize=1} HikariCP pool is a faithful test of the leak
+ * property.</b> {@link TenantScope} stamps {@code nexus.tenant} with
+ * {@code set_config(..., true)} (transaction-local / {@code SET LOCAL} semantics) and
+ * commits before returning the connection to the pool. With the pool capped at ONE
+ * connection, the second {@code withTenant} call necessarily borrows the SAME physical
+ * server connection the first call just used — identical to a txn-mode pooler routing a
+ * second client's transaction onto a reused server backend.
+ *
+ * <p><b>Sensitivity note (substantive-critic 2026-06-16).</b> {@code withTenant} re-stamps
+ * the GUC at the start of EVERY transaction, so the cross-tenant isolation tests below
+ * would pass even if the GUC were session-scoped (tenant B re-stamps to itself before its
+ * SELECT). Those tests therefore prove RLS FILTERING holds under connection reuse (still
+ * worth guarding), but NOT the transaction-local reset property. The test sensitive to
+ * THAT property is {@link #tenantGucIsResetAfterTransactionCommit()}: it reads the GUC on a
+ * raw, un-stamped borrow of the reused connection and asserts it is empty, so it fails if
+ * the {@code set_config(..., true)} locality flag ever regresses to {@code false}.
+ *
+ * <p>Together these cover acceptance criterion (b) deterministically and hermetically (no
+ * external pooler). Criterion (a) "operates correctly under a real transaction-mode
+ * PgBouncer" is covered by {@code PgBouncerTenantIsolationTest}.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TenantPoolingIsolationTest {
+
+    private static final String TENANT_A = "pool-tenant-a";
+    private static final String TENANT_B = "pool-tenant-b";
+    private static final String PROJECT = "isolation-probe";
+
+    PostgreSQLContainer<?> pg;
+    HikariDataSource ds;          // capped at ONE connection — forces server-conn reuse
+    MemoryRepository repo;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+        // grants-nexus-svc.xml fail-fasts if the role is absent; create it first.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='"
+                + PgContainerHelper.SVC_USERNAME + "') THEN CREATE ROLE "
+                + PgContainerHelper.SVC_USERNAME + " LOGIN PASSWORD '"
+                + PgContainerHelper.SVC_PASSWORD + "' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            Database db = DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(su));
+            try (var lq = new Liquibase("db/changelog/db.changelog-master.xml",
+                    new ClassLoaderResourceAccessor(), db)) {
+                lq.update(new Contexts());
+            }
+        }
+
+        var cfg = new HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(PgContainerHelper.SVC_USERNAME);   // NOSUPERUSER NOBYPASSRLS: RLS applies
+        cfg.setPassword(PgContainerHelper.SVC_PASSWORD);
+        cfg.setMaximumPoolSize(1);                          // one server connection, reused
+        cfg.setMinimumIdle(1);
+        cfg.setAutoCommit(true);
+        cfg.setConnectionInitSql("SET search_path TO nexus, t1, public");
+        ds = new HikariDataSource(cfg);
+
+        repo = new MemoryRepository(new TenantScope(ds));
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (ds != null) ds.close();
+        if (pg != null) pg.stop();
+    }
+
+    @BeforeEach
+    void cleanMemory() throws Exception {
+        // PER_CLASS shares one container; reset the table so per-test row counts are
+        // deterministic (the isolation property is independent of this, but the
+        // positive-control counts are not).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("TRUNCATE nexus.memory");
+        }
+    }
+
+    @Test
+    void tenantGucIsResetAfterTransactionCommit() throws Exception {
+        // THE tripwire actually sensitive to the transaction-local property (the
+        // re-stamping isolation tests below are NOT — every withTenant call re-stamps
+        // the GUC before its query, so a session-scoped GUC would still filter correctly
+        // and pass them). Here we read the GUC on a RAW borrow with NO re-stamp:
+        // after a withTenant txn commits and returns its connection to the size-1 pool,
+        // the SAME server backend must carry NO lingering nexus.tenant. If set_config's
+        // is_local arg were changed true->false, the GUC would persist here and fail.
+        repo.upsert(TENANT_A, PROJECT, "g", "v", "", null, null, null);  // stamps + commits as A
+        try (Connection raw = ds.getConnection();
+             var st = raw.createStatement();
+             var rs = st.executeQuery("SELECT current_setting('nexus.tenant', true) AS t")) {
+            assertThat(rs.next()).isTrue();
+            String guc = rs.getString("t");
+            assertThat(guc)
+                .as("nexus.tenant must be reset after the txn commits (transaction-local "
+                    + "GUC); a session-scoped GUC would leak to the next pooled borrower")
+                .isNullOrEmpty();
+        }
+    }
+
+    @Test
+    void tenantContextDoesNotBleedAcrossReusedConnection() {
+        // Tenant A writes a row.
+        long id = repo.upsert(TENANT_A, PROJECT, "secret", "tenant-A-only", "", null, null, null);
+        assertThat(id).isPositive();
+
+        // Tenant B, reusing the SAME pooled server connection (pool size 1), must see
+        // NONE of tenant A's rows. A leaked session GUC would surface A's row here.
+        assertThat(repo.findByProject(TENANT_B, PROJECT))
+            .as("tenant B must not see tenant A's rows across a reused server connection")
+            .isEmpty();
+
+        // Positive control / non-vacuity: tenant A still sees its own row, so B's empty
+        // result is real RLS isolation, not a mis-seeded fixture or a broken connection.
+        assertThat(repo.findByProject(TENANT_A, PROJECT))
+            .as("tenant A must see its own row (positive control)")
+            .hasSize(1);
+    }
+
+    @Test
+    void repeatedInterleavingDoesNotAccumulateLeak() {
+        // Exercise many A/B handoffs on the single connection to catch any stamp that
+        // survives only intermittently (e.g. reset depending on prior statement).
+        for (int i = 0; i < 5; i++) {
+            repo.upsert(TENANT_A, PROJECT, "row-" + i, "A-" + i, "", null, null, null);
+            assertThat(repo.findByProject(TENANT_B, PROJECT))
+                .as("iteration %s: tenant B must stay isolated", i)
+                .isEmpty();
+        }
+        // Tenant A accumulated exactly its 5 rows (row-0..4; @BeforeEach truncated first);
+        // tenant B still sees zero.
+        assertThat(repo.findByProject(TENANT_B, PROJECT)).isEmpty();
+        assertThat(repo.findByProject(TENANT_A, PROJECT)).hasSize(5);
+    }
+}


### PR DESCRIPTION
## What

conexus RDR-001 consumer requirement: the engine's tenant isolation relies on `set_config('nexus.tenant', ?, true)` (transaction-local) inside an explicit transaction; its leak-safety under a real connection pool (PgBouncer, as in Crunchy production) had never been regression-tested. Adds two test classes:

### `TenantPoolingIsolationTest` (deterministic, hermetic — HikariCP `maxPoolSize=1`)
A 1-connection pool forces the second tenant's `withTenant` transaction onto the **same physical server connection** the first just used — the exact condition a txn-mode pooler creates.
- **`tenantGucIsResetAfterTransactionCommit`** — the locality tripwire: after a `withTenant` txn commits, borrows the **raw** pooled connection (no re-stamp) and asserts `current_setting('nexus.tenant')` is empty. **Mutation-verified**: flipping `set_config`'s `is_local` `true→false` makes it FAIL.
- cross-tenant isolation + repeated interleaving — prove RLS **filtering** holds under reuse.

### `PgBouncerTenantIsolationTest` (real `edoburu/pgbouncer`, digest-pinned, `POOL_MODE=transaction`, `default_pool_size=1`, `max_db_connections=1`)
App connects through PgBouncer on a shared network. Proves **(a)** the engine functions correctly with transactions multiplexed onto one server backend (`prepareThreshold=0`, the documented txn-mode client setting; scope boundary documented) and **(b)** no cross-tenant bleed at the production topology.

Both run under `nexus_svc` (NOSUPERUSER NOBYPASSRLS) so RLS applies.

## Review (stacked)
substantive-critic caught a **Critical** the green tests hid: because `withTenant` re-stamps the GUC each transaction, the isolation tests would pass *even if the GUC were session-scoped* — they prove RLS filtering, not the transaction-local reset. Fixed with the mutation-verified raw-GUC tripwire + corrected Javadoc. Re-review **justified 0/0**. code-review-expert **APPROVED** (exact-count assertion, `isNullOrEmpty`, Liquibase TWR addressed).

Full fresh-codegen `mvn` suite green (779).

## Closes
Closes nexus-4pz86