### PR TITLE
ci(nexus-c7gnx): hard-fail docling pre-fetch + ONNX cache restore-keys + skip-not-fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
           # ships a new ONNX model invalidates the cache; pre-fix the
           # bare runner-OS key reused stale models across upgrades.
           key: chromadb-onnx-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          # nexus-c7gnx: fall back to the last ONNX cache for this OS so a
+          # routine uv.lock bump (which rarely changes the bundled ONNX model)
+          # re-seeds it instead of re-downloading from scratch every time.
+          restore-keys: |
+            chromadb-onnx-${{ runner.os }}-
 
       - name: Cache HuggingFace models (docling, cross-encoder, MinerU)
         uses: actions/cache@v4
@@ -92,13 +97,26 @@ jobs:
         # nexus-cxsbs: warm the docling models BEFORE pytest so the flaky
         # mid-test HF download becomes a deterministic up-front fetch that is
         # allowed to retry. No-op on a cache hit; on a cold cache it downloads
-        # once (then the post-job cache-save persists it). Both converter modes
-        # (plain + enriched) cover every model the integration tests exercise.
+        # once (then the post-job cache-save persists it).
+        #
+        # nexus-c7gnx: the probe now runs a REAL extraction (docling loads its
+        # models lazily at convert() time, so merely building the converter does
+        # NOT download them). And it HARD-FAILS after 3 attempts: a cold cache +
+        # transient HF outage then fails LOUDLY here ("docling models could not
+        # be fetched") instead of silently falling back to PyMuPDF mid-suite and
+        # producing ~21 baffling extraction_method=='docling' assertion failures.
+        # A real extraction must yield extraction_method=='docling' (a one-line
+        # python -c; no heredoc, so YAML indentation stays intact). Probe lives in
+        # scripts/ci_warm_docling.py for readability.
         run: |
+          set -euo pipefail
           for i in 1 2 3; do
-            uv run python -c "from nexus.pdf_extractor import PDFExtractor; e=PDFExtractor(); e._get_converter(enriched=False); e._get_converter(enriched=True); print('docling models warm')" && break
-            echo "docling pre-fetch attempt $i failed; retrying in 10s"; sleep 10
+            if uv run python scripts/ci_warm_docling.py; then echo "docling models warm"; exit 0; fi
+            echo "docling pre-fetch attempt $i did not yield docling extraction"
+            if [ "$i" -lt 3 ]; then echo "retrying in 10s"; sleep 10; fi
           done
+          echo "::error::docling models could not be fetched after 3 attempts (cold HF cache + HuggingFace unavailable). Failing the job here rather than letting the PDF integration tests fall back to PyMuPDF and fail with confusing assertions." >&2
+          exit 1
 
       - name: Run tests
         run: uv run pytest tests/ -q --durations=25

--- a/scripts/ci_warm_docling.py
+++ b/scripts/ci_warm_docling.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""CI pre-fetch / warm-and-verify probe for the docling PDF-extraction models.
+
+nexus-c7gnx: docling loads its layout + TableFormer models lazily at convert()
+time, so merely building the converter does NOT download them. This runs a REAL
+extraction on a tiny generated PDF and exits non-zero unless docling actually
+performed it (extraction_method == 'docling'). The CI step retries this a few
+times and HARD-FAILS, so a cold HuggingFace cache plus a transient HF outage
+fails loudly here instead of silently falling back to PyMuPDF mid-suite and
+producing confusing extraction_method=='docling' assertion failures.
+
+Exit codes: 0 = docling extraction succeeded (models warm); 1 = otherwise.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+
+
+def main() -> int:
+    import pymupdf
+
+    from nexus.pdf_extractor import PDFExtractor
+
+    with tempfile.TemporaryDirectory() as td:
+        probe = pathlib.Path(td) / "warm.pdf"
+        doc = pymupdf.open()
+        page = doc.new_page()
+        page.insert_text((72, 72), "docling warm probe")
+        doc.save(str(probe))
+        doc.close()
+
+        method = PDFExtractor().extract(probe).metadata.get("extraction_method")
+        print(f"extraction_method={method}")
+        return 0 if method == "docling" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -833,3 +833,70 @@ def make_pg_bundle_txz():
         return archive
 
     return _factory
+
+
+# ── docling model availability (nexus-c7gnx) ─────────────────────────────────
+#
+# The docling PDF extractor loads its layout + TableFormer models from the
+# HuggingFace cache; when they are absent (offline, cold cache) docling raises
+# LocalEntryNotFoundError and the extractor SILENTLY falls back to PyMuPDF
+# (extraction_method='pymupdf_normalized'). Tests that assert
+# extraction_method=='docling' then fail with a confusing assertion rather than
+# a clear "models unavailable" signal. CI pre-fetches the models and HARD-FAILS
+# if it cannot (see .github/workflows/ci.yml), so in CI the models are always
+# present and these guards never skip. The skip only fires on a local run with a
+# cold HF cache — turning a baffling fallback-assertion failure into a clean skip.
+
+
+@pytest.fixture(scope="session")
+def docling_available(tmp_path_factory: pytest.TempPathFactory) -> bool:
+    """True iff docling actually performs the extraction (models present).
+
+    Faithful probe: docling loads models lazily at convert() time, so we run a
+    real extraction on a tiny generated PDF and check the SAME signal the tests
+    assert (extraction_method == 'docling'). A cold/offline model cache makes the
+    extractor fall back to PyMuPDF, which this detects as unavailable.
+
+    Known limitation: the probe CANNOT distinguish "models unavailable"
+    (environmental, skipping is correct) from "docling regressed in CODE so the
+    extractor fell back" (a real bug) — both surface as extraction_method !=
+    'docling'. This is acceptable because CI does NOT rely on the skip: the
+    pre-fetch step (scripts/ci_warm_docling.py) runs this same probe and
+    HARD-FAILS the job, so a docling code regression goes CI-red at pre-fetch.
+    The skip is a local-developer convenience only; see require_docling.
+    """
+    try:
+        import pymupdf
+
+        probe = tmp_path_factory.mktemp("docling-probe") / "probe.pdf"
+        doc = pymupdf.open()
+        page = doc.new_page()
+        page.insert_text((72, 72), "docling availability probe")
+        doc.save(str(probe))
+        doc.close()
+
+        from nexus.pdf_extractor import PDFExtractor
+
+        result = PDFExtractor().extract(probe)
+        return result.metadata.get("extraction_method") == "docling"
+    except Exception:
+        return False
+
+
+@pytest.fixture
+def require_docling(docling_available: bool) -> None:
+    """Skip the requesting test when docling did not perform the extraction.
+
+    Composes with the CI pre-fetch hard-fail: in CI the models are guaranteed
+    present so this never skips; locally it skips cleanly instead of failing on
+    the silent PyMuPDF fallback.
+    """
+    if not docling_available:
+        pytest.skip(
+            "docling did not perform the extraction. Locally this almost always "
+            "means a cold/offline HuggingFace model cache; it can ALSO indicate a "
+            "docling regression. CI does not rely on this skip — its pre-fetch step "
+            "runs the same probe and HARD-FAILS (red), which is what distinguishes a "
+            "genuine regression from a missing local cache. This skip only fires on "
+            "a local run."
+        )

--- a/tests/test_pdf_extractor_integration.py
+++ b/tests/test_pdf_extractor_integration.py
@@ -8,7 +8,17 @@ RDR-021: replaces 3-tier stack with Docling primary + pymupdf_normalized fallbac
 """
 from pathlib import Path
 
+import pytest
+
 from nexus.pdf_extractor import PDFExtractor
+
+
+@pytest.fixture(autouse=True)
+def _require_docling(require_docling: None) -> None:
+    """nexus-c7gnx: every test here exercises the docling extraction path and
+    asserts extraction_method=='docling'. Skip cleanly when the models are
+    unavailable (local cold HF cache) instead of failing on the PyMuPDF
+    fallback. No-op in CI, which pre-fetches the models (ci.yml)."""
 
 
 class TestExtractSimple:

--- a/tests/test_pdf_subsystem.py
+++ b/tests/test_pdf_subsystem.py
@@ -311,6 +311,12 @@ class TestDoclingRegressionGuard:
     (no pdfplumber rescue tier, no Type3 detection, no 3-tier routing).
     """
 
+    @pytest.fixture(autouse=True)
+    def _require_docling(self, require_docling: None) -> None:
+        """nexus-c7gnx: these assert extraction_method=='docling'; skip cleanly
+        when the models are unavailable (local cold HF cache) instead of failing
+        on the silent PyMuPDF fallback. No-op in CI (models pre-fetched)."""
+
     def test_ruled_table_pdf_uses_docling(self, ruled_table_pdf: Path) -> None:
         """Ruled-table PDF (formerly pdfplumber rescue path) now uses Docling."""
         result = PDFExtractor().extract(ruled_table_pdf)


### PR DESCRIPTION
## Why

The 2026-06-17 docling flake (PR #1227, pytest 3.13 only): a cold HF cache + a transient HuggingFace outage raised `LocalEntryNotFoundError`, the extractor **silently fell back to PyMuPDF**, and ~6 `extraction_method=='docling'` assertions failed with no clear cause. Three CI-hygiene fixes.

## Fixes

**1. Pre-fetch hard-fails** (`scripts/ci_warm_docling.py` + retry loop). The probe runs a **real extraction** and requires `extraction_method=='docling'` — docling loads models lazily at `convert()`, so the old `_get_converter()`-only probe never actually downloaded them. After 3 attempts the step **exits 1** with a clear `::error::`, so a cold-cache + HF-outage fails *loudly at pre-fetch* instead of as baffling mid-suite assertion failures.

**2. ChromaDB ONNX cache gains `restore-keys`** — it was keyed on `uv.lock` with **no fallback**, so every dep bump re-downloaded the ONNX model. Now re-seeds from the last cache (matching the uv + HF caches). Direct answer to "are we leveraging caching effectively?" — this was the one cache missing a fallback.

**3. Docling-asserting tests skip-not-fallback** — a session-scoped `docling_available` probe + `require_docling` fixture skip cleanly when docling didn't perform the extraction, instead of running → hitting the PyMuPDF fallback → failing the assertion. Scoped to exactly the surfaces that failed (the `test_pdf_extractor_integration` module + `TestDoclingRegressionGuard`), not the MinerU/pymupdf tests.

These **compose**: in CI the pre-fetch guarantees the models (or goes red), so the skip never fires there; it only helps local runs with a cold cache.

## Review (stacked)
- code-review-expert **APPROVED** — applied M1 (`TemporaryDirectory`), L1 (no sleep after the final attempt); also caught + fixed a `set -e` early-exit the L1 change briefly introduced (the `::error::` line now reliably runs).
- substantive-critic **partial, 1 Significant** — the probe can't distinguish "models unavailable" from "docling regressed in code" (both yield non-docling). Confirmed CI is the real gate (the pre-fetch hard-fail catches a code regression CI-red); the blind spot is local-only. Addressed by softening the skip message and documenting the limitation (the critic's recommended option).

## Validation
Happy path: 24 passed (guards no-op when docling present). Skip path: **mutation-verified** (forcing the probe False → both docling tests SKIP with the actionable reason). Probe exits 0 locally; ci.yml valid YAML; all-fail loop dry-run reaches the `::error::`+`exit 1`.

Test/CI only — no production extractor behavior change.

## Closes
Closes nexus-c7gnx