### PR TITLE
fix(nexus-0n7uc): pure-voyage cloud engine — no local ONNX embedder (boot segfault)

### DIFF
--- a/service/src/main/java/dev/nexus/service/Main.java
+++ b/service/src/main/java/dev/nexus/service/Main.java
@@ -6,7 +6,6 @@ import dev.nexus.service.db.SchemaMigrator;
 import dev.nexus.service.db.TenantScope;
 import dev.nexus.service.vectors.Bge768Embedder;
 import dev.nexus.service.vectors.EmbedderRouter;
-import dev.nexus.service.vectors.OnnxEmbedder;
 import dev.nexus.service.vectors.PgVectorRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,11 +115,14 @@ public final class Main {
         // mode was invisible; onnx-local now logs at WARN and names the refusal
         // behaviour so a missing key is unmissable in the service log.
         if (voyageKey != null && !voyageKey.isBlank()) {
-            // Cloud mode: Voyage routing. The MiniLM ONNX embedder is retained
-            // ONLY as the non-conformant-prefix fallback (legacy names).
-            OnnxEmbedder onnx = new OnnxEmbedder();
-            docEmbedRouter = new EmbedderRouter(onnx, voyageKey, "document");
-            qryEmbedRouter = new EmbedderRouter(onnx, voyageKey, "query");
+            // Cloud mode: PURE Voyage routing — NO local ONNX embedder (nexus-0n7uc).
+            // The cloud container has no MiniLM model on disk; constructing
+            // OnnxEmbedder would call onnxruntime createSession() on a missing file,
+            // which SEGFAULTS (not throws) and crashed the engine at boot (conexus
+            // STEP-5, conexus-qcn). A voyage-1024 cloud corpus has no use for a local
+            // 384-dim fallback; non-conformant collections are REFUSED (422).
+            docEmbedRouter = new EmbedderRouter(voyageKey, "document");
+            qryEmbedRouter = new EmbedderRouter(voyageKey, "query");
             log.info("event=embedding_mode_banner mode={} models={} backend=pgvector",
                     docEmbedRouter.modeName(), docEmbedRouter.availableModels());
         } else {

--- a/service/src/main/java/dev/nexus/service/vectors/EmbedderRouter.java
+++ b/service/src/main/java/dev/nexus/service/vectors/EmbedderRouter.java
@@ -19,16 +19,24 @@ import java.util.Map;
  *       {@code voyageai.Client.contextualized_embed} (model {@code voyage-context-3})</li>
  *   <li>{@code code__} → standard embed via {@code voyageai.Client.embed}
  *       (model {@code voyage-code-3})</li>
- *   <li>local mode → the local ONNX-runtime embedder (RDR-160: bge-base-en-v1.5,
- *       768d); cloud-mode non-conformant prefix fallback → the same injected
- *       local embedder</li>
+ *   <li>local mode → the local ONNX-runtime embedder (RDR-160: bge-base-en-v1.5, 768d)</li>
  * </ul>
  *
- * <p>The Java service is always in one of two modes:
+ * <p>The Java service runs in one of three modes (by constructor):
  * <ul>
- *   <li><strong>Local mode</strong> ({@code voyageApiKey == null}): all collections
- *       → the injected local embedder (RDR-160 wires bge-768).</li>
- *   <li><strong>Cloud mode</strong> ({@code voyageApiKey != null}): prefix-based routing above.</li>
+ *   <li><strong>Local mode</strong> ({@link #EmbedderRouter(Embedder, String)}): all
+ *       collections → the injected local embedder (RDR-160 wires bge-768); voyage
+ *       collections REFUSED (422).</li>
+ *   <li><strong>Pure-voyage cloud mode</strong> ({@link #EmbedderRouter(String, String)} —
+ *       PRODUCTION cloud, nexus-0n7uc): {@code localEmbedder == null}, NO local ONNX;
+ *       prefix/segment routing to Voyage embedders; a non-conformant or
+ *       {@code minilm-l6-v2-384} collection is REFUSED (422), symmetric with local
+ *       mode refusing voyage. This is what Main boots when {@code NX_VOYAGE_API_KEY}
+ *       is set.</li>
+ *   <li><strong>Onnx-cloud mode</strong> ({@link #EmbedderRouter(OnnxEmbedder, String,
+ *       String)} — TESTS / parity-gate only, NOT production): voyage routing plus a
+ *       local ONNX fallback for non-conformant names. Retained because those callers
+ *       run where the MiniLM model exists on disk.</li>
  * </ul>
  *
  * <p>Thread-safe: all embedder instances are stateless per-call.
@@ -110,6 +118,38 @@ public final class EmbedderRouter implements Embedder {
     }
 
     /**
+     * Cloud-mode, VOYAGE-ONLY constructor (nexus-0n7uc): NO local ONNX embedder.
+     *
+     * <p>The production cloud service embeds exclusively via Voyage; it must not
+     * construct any local ONNX embedder. The cloud container has no MiniLM model
+     * on disk, and {@code OnnxEmbedder} loads it via {@code OrtEnvironment.
+     * createSession(path)} — which onnxruntime SEGFAULTS (does not throw) on a
+     * missing file, crashing the engine at boot (conexus STEP-5, conexus-qcn).
+     * A voyage-1024 cloud corpus has no legitimate use for a local 384-dim
+     * fallback anyway. A non-conformant or {@code minilm-l6-v2-384}-segment
+     * collection is REFUSED ({@link EmbeddingModelUnavailableException} → 422),
+     * symmetric with how local mode refuses voyage collections.
+     *
+     * <p>The {@link #EmbedderRouter(OnnxEmbedder, String, String) onnx cloud
+     * constructor} is retained for tests / the parity-gate, which run where the
+     * MiniLM model exists; production boot (Main) uses THIS constructor.
+     *
+     * @param voyageApiKey Voyage AI API key
+     * @param inputType    {@code "document"} or {@code "query"}
+     */
+    public EmbedderRouter(String voyageApiKey, String inputType) {
+        this.localEmbedder      = null;   // pure-voyage cloud: no local fallback
+        this.voyageCodeEmbedder = new VoyageEmbedder(voyageApiKey, "voyage-code-3", inputType);
+        this.cceEmbedder        = new CceEmbedder(voyageApiKey, inputType);
+        this.inputType          = inputType;
+        VoyageEmbedder voyage3 = new VoyageEmbedder(voyageApiKey, "voyage-3", inputType);
+        this.modelEmbedders     = Map.of(
+                voyageCodeEmbedder.modelToken(), voyageCodeEmbedder,
+                cceEmbedder.modelToken(),        cceEmbedder,
+                voyage3.modelToken(),            voyage3);
+    }
+
+    /**
      * Embedding mode for banners and refusal messages. {@code "onnx-local"} is a
      * cross-language SENTINEL parsed by {@code doctor.py} and
      * {@code storage_service_daemon.py} — do not change the literal. It names the
@@ -145,6 +185,15 @@ public final class EmbedderRouter implements Embedder {
      */
     @Override
     public List<float[]> embed(List<String> texts) {
+        if (localEmbedder == null) {
+            // pure-voyage cloud (nexus-0n7uc): no local default embedder. Callers
+            // must route by collection name (embedForCollection) so the model is
+            // resolved per RDR-103, never embedded with an unintended model.
+            throw new EmbeddingModelUnavailableException(
+                "voyage-only cloud service has no local default embedder; embed via "
+                + "a collection (embedForCollection) so the model is routed by name. "
+                + "Available models: " + availableModels());
+        }
         return localEmbedder.embed(texts);
     }
 
@@ -229,8 +278,11 @@ public final class EmbedderRouter implements Embedder {
      *   <li>any mode + a segment with no embedder wired in this mode → refuse
      *       (e.g. {@code minilm-l6-v2-384} on the RDR-160 bge-768 local service,
      *       or {@code bge-base-en-v15-768} in a MiniLM-wired test router)
-     *   <li>cloud mode + {@code minilm-l6-v2-384} segment → ONNX (the segment
-     *       is the authority; prefix routing wrongly sent these to CCE)
+     *   <li>pure-voyage cloud (PRODUCTION) + {@code minilm-l6-v2-384} segment →
+     *       refuse (422): no ONNX in cloud (nexus-0n7uc)
+     *   <li>onnx-cloud (TESTS / parity-gate only) + {@code minilm-l6-v2-384} segment
+     *       → ONNX (the segment is the authority; prefix routing wrongly sent these
+     *       to CCE)
      * </ul>
      *
      * <p>Non-conformant names keep legacy {@link #resolveEmbedder prefix
@@ -265,10 +317,12 @@ public final class EmbedderRouter implements Embedder {
     /**
      * Resolve the appropriate embedder for a collection name by PREFIX.
      *
-     * <p>Returns the CCE embedder for CCE prefix collections (in cloud mode),
-     * the standard Voyage embedder for {@code code__} (in cloud mode), or the
-     * injected local embedder (RDR-160: bge-768; the MiniLM ONNX fallback in
-     * cloud mode) for everything else / local mode.
+     * <p>Returns the CCE embedder for CCE prefix collections (cloud), the standard
+     * Voyage embedder for {@code code__} (cloud), or the injected local embedder
+     * (local mode: bge-768; onnx-cloud test/parity mode: the MiniLM fallback) for
+     * everything else. In PURE-VOYAGE cloud mode ({@code localEmbedder == null},
+     * production — nexus-0n7uc) there is NO local fallback: an unrecognised-prefix
+     * name is REFUSED ({@link EmbeddingModelUnavailableException} → 422).
      *
      * <p>Legacy fallback for non-conformant names only — production embed
      * paths go through {@link #resolveEmbedderStrict} (model segment is the
@@ -290,14 +344,26 @@ public final class EmbedderRouter implements Embedder {
                 return voyageCodeEmbedder;
             }
         }
-        // Unrecognised prefix — fall back to the local embedder (safe, logged)
+        // Unrecognised prefix.
+        if (localEmbedder == null) {
+            // pure-voyage cloud (nexus-0n7uc): no local fallback — REFUSE, symmetric
+            // with local mode refusing voyage collections. Never silently embed a
+            // non-conformant collection with an unintended model.
+            throw new EmbeddingModelUnavailableException(
+                "voyage-only cloud service has no embedder for non-conformant "
+                + "collection '" + collection + "'. Available models: " + availableModels());
+        }
+        // Cloud-with-local-fallback (tests / parity-gate): fall back, logged.
         log.warn("event=embed_router_fallback collection={} fallback=local", collection);
         return localEmbedder;
     }
 
     @Override
     public void close() {
-        try { localEmbedder.close();      } catch (Exception ignored) {}
+        // localEmbedder is null in pure-voyage cloud mode (nexus-0n7uc).
+        if (localEmbedder != null) {
+            try { localEmbedder.close(); } catch (Exception ignored) {}
+        }
         // VoyageEmbedder and CceEmbedder are stateless HTTP clients; no close needed
     }
 }

--- a/service/src/test/java/dev/nexus/service/vectors/EmbedderRouterVoyageOnlyTest.java
+++ b/service/src/test/java/dev/nexus/service/vectors/EmbedderRouterVoyageOnlyTest.java
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package dev.nexus.service.vectors;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * nexus-0n7uc — the production cloud router is VOYAGE-ONLY: it constructs no local
+ * ONNX embedder, so the cloud engine never loads a MiniLM model (the missing-file
+ * onnxruntime segfault that crashed v0.1.0 at boot — conexus STEP-5 / conexus-qcn).
+ *
+ * <p>Pure construction + routing assertions; no embed calls (so no Voyage network).
+ * The Voyage/CCE embedders are HTTP clients that do nothing at construction.
+ *
+ * <p>Evidence scope (substantive-critic): these assertions prove no ONNX model
+ * TOKEN is advertised and that minilm/non-conformant collections are refused — they
+ * are behavioral proofs, not a construction proof that {@code new OnnxEmbedder()}
+ * is never called. That "no ONNX constructed" guarantee is by inspection: the
+ * voyage-only constructor body references no {@code OnnxEmbedder}, and
+ * {@code OnnxEmbedder} has no static initializer that could load a model on
+ * class-load. Main's voyage branch likewise constructs only this router.
+ */
+class EmbedderRouterVoyageOnlyTest {
+
+    private EmbedderRouter router() {
+        return new EmbedderRouter("dummy-key", "document");  // voyage-only cloud
+    }
+
+    @Test
+    void voyageOnly_modeIsVoyage_andAdvertisesOnlyVoyageModels() {
+        EmbedderRouter r = router();
+        assertThat(r.modeName()).isEqualTo("voyage");
+        assertThat(r.availableModels())
+            .as("voyage-only cloud must NOT advertise any local ONNX model (no minilm)")
+            .containsExactlyInAnyOrder("voyage-3", "voyage-code-3", "voyage-context-3")
+            .doesNotContain("minilm-l6-v2-384");
+    }
+
+    @Test
+    void conformantVoyageCollections_routeToTheirVoyageEmbedder() {
+        EmbedderRouter r = router();
+        assertThat(r.resolveEmbedderStrict("code__nexus__voyage-code-3__v1"))
+            .isInstanceOf(VoyageEmbedder.class);
+        assertThat(r.resolveEmbedderStrict("knowledge__nexus__voyage-context-3__v1"))
+            .isInstanceOf(CceEmbedder.class);
+    }
+
+    @Test
+    void minilmConformantCollection_isRefused_notLocallyEmbedded() {
+        EmbedderRouter r = router();
+        assertThatThrownBy(() ->
+                r.resolveEmbedderStrict("code__nexus__minilm-l6-v2-384__v1"))
+            .as("a minilm collection must be REFUSED in voyage-only cloud, never "
+                + "embedded with a local 384-dim model")
+            .isInstanceOf(EmbeddingModelUnavailableException.class)
+            .hasMessageContaining("minilm-l6-v2-384");
+    }
+
+    @Test
+    void nonConformantName_isRefused_noLocalFallback() {
+        EmbedderRouter r = router();
+        assertThatThrownBy(() -> r.resolveEmbedder("legacy_unprefixed_collection"))
+            .as("non-conformant name has no local fallback in voyage-only cloud")
+            .isInstanceOf(EmbeddingModelUnavailableException.class);
+    }
+
+    @Test
+    void plainEmbed_refuses_thereIsNoLocalDefaultEmbedder() {
+        EmbedderRouter r = router();
+        assertThatThrownBy(() -> r.embed(List.of("x")))
+            .isInstanceOf(EmbeddingModelUnavailableException.class);
+    }
+
+    @Test
+    void close_doesNotThrow_withNoLocalEmbedder() {
+        assertThatCode(() -> router().close()).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Why

conexus's decoupled STEP-5 test-deploy (the directive working as intended — caught with zero production impact) found `engine-service-v0.1.0` segfaulting at boot in onnxruntime `OrtSession.createSession` on the voyage-configured path. **Root cause:** Main's voyage branch eagerly constructed `OnnxEmbedder` (MiniLM-384) as a "non-conformant-prefix legacy fallback"; `OnnxEmbedder` loads `model.onnx` from `~/.cache/chroma/onnx_models/...` — a filesystem path **absent in the cloud container** — and onnxruntime's native `createSession` **segfaults (does not throw)** on the missing file. Not OOM (bge 436MB boots fine in local mode), not a missing voyage key. Regression in `76a22f07..63e095d2` (RDR-160 #1202).

A voyage-1024 cloud corpus has **no legitimate use** for a local 384-dim fallback (it'd be a dim mismatch if it ever fired). So the fix is architectural, not lazy-loading: **the cloud service constructs no local ONNX embedder.**

## Change
- New `EmbedderRouter(String voyageApiKey, String inputType)` — pure-voyage cloud: `localEmbedder == null`, `modelEmbedders = {voyage-code-3, voyage-context-3, voyage-3}`.
- Null-guard the three `localEmbedder` uses: plain `embed()` and the non-conformant prefix fallback now **REFUSE** (`EmbeddingModelUnavailableException` → 422, symmetric with local mode refusing voyage); `close()` is null-safe.
- `Main` voyage branch uses the voyage-only constructor; `OnnxEmbedder` no longer constructed or imported.
- The onnx-cloud constructor is **retained for tests / parity-gate** (they run where the MiniLM model exists); production boot uses the voyage-only path.

Removes ONNX from the cloud boot path entirely: no model load, no segfault, smaller footprint, no wrong-dim hazard.

## Review (stacked, sonnet)
- substantive-critic: **partial → resolved** — verdict "cloud boot provably ONNX-free, no reachable NPE, segfault eliminated"; the 3 Significant were all stale Javadoc/test-comment, fixed.
- code-review-expert: **APPROVED** (0 Critical/High/Medium; 2 Low — one stale doc fixed, one harmless no-op `close()`).
- Full fresh-codegen `mvn` suite green (785).

## Follow-up
`nexus-xx7xp` (P3): log the embedding-mode banner *before* constructing the heavy embedder, so a future OOM/load failure still names the mode (this incident's diagnostic trap). Separate, not blocking.

Re-cut as `engine-service-v0.1.1` after merge.

## Closes
Closes nexus-0n7uc