### PR TITLE
ci(nexus-9yrus): native-image build perf — quick-build PR path + ParallelGC + tunable heap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,4 +484,10 @@ jobs:
         # jOOQ-apply and GraalVM-reachability regressions on the PR instead of at
         # tag-cut. Do NOT `clean`: generate-sources just populated
         # target/generated-sources/jooq, and -Pprebuilt-jooq compiles it in place.
-        run: ./mvnw -q -Pnative -Pprebuilt-jooq -DskipTests package
+        #
+        # nexus-9yrus: -Dnative.image.opt=-Ob (quick-build) on the PR path. Quick-build
+        # still runs FULL reachability analysis (the regression class this trip-wire
+        # guards) — it only skips the optimization passes — so it cuts the build ~half
+        # and lowers peak memory while preserving the gate's purpose. The RELEASE build
+        # (engine-service-release.yml) keeps the default -O2 full optimization.
+        run: ./mvnw -q -Pnative -Pprebuilt-jooq -DskipTests -Dnative.image.opt=-Ob package

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -162,7 +162,13 @@ jobs:
         # The committed traced reachability-metadata.json + community metadata repo
         # supply the reflection/resource set. This is the authoritative LINUX gate
         # for the native path (the spike verified macOS/arm64; this proves amd64).
-        run: ./mvnw -q -Pnative -DskipTests package
+        #
+        # nexus-9yrus: -Dnative.image.opt=-Ob (quick-build) — this is a per-PR
+        # correctness gate (build reachability + the smoke below: migration + jOOQ
+        # CRUD return 200), not a release artifact. Quick-build keeps full reachability
+        # analysis and a functional binary (slower runtime, irrelevant to the smoke)
+        # while ~halving the build and cutting peak memory. Release stays -O2.
+        run: ./mvnw -q -Pnative -DskipTests -Dnative.image.opt=-Ob package
 
       - name: Native smoke test
         working-directory: service

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -472,6 +472,20 @@
         <!-- -Pnative: opt-in native-image build (S0.4 C2 — CI must add Linux job) -->
         <profile>
             <id>native</id>
+            <properties>
+                <!-- nexus-9yrus (2) optimization level. Default -O2 = full optimization
+                     for RELEASE artifacts. PR-trip-wire + smoke builds override with
+                     -Dnative.image.opt=-Ob (GraalVM quick-build): skips the heavy
+                     optimization passes for ~half the build time and lower peak memory.
+                     Never use -Ob for a published engine-service-v* binary. -->
+                <native.image.opt>-O2</native.image.opt>
+                <!-- nexus-9yrus (3) builder max heap: a deliberate explicit cap (~78% of
+                     the 7GB ubuntu-latest) — single tunable knob, replacing native-image's
+                     implicit auto-size. RAISE to match a larger runner when CI moves off
+                     the 7GB box (-Dnative.image.maxheap=24g): that box over-commits (peak
+                     RSS ~7.86GB > 7GB) and GC-thrashes; more RAM is the real fix. -->
+                <native.image.maxheap>5632m</native.image.maxheap>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -530,6 +544,16 @@
                                         <buildArg>-H:ExcludeResources=.*\.dSYM/.*</buildArg>
                                         <!-- Portability: compatibility march for CI/prod (not native) -->
                                         <buildArg>-march=compatibility</buildArg>
+                                        <!-- nexus-9yrus (3) builder JVM: explicit, runner-tunable heap +
+                                             parallel GC. The 7GB ubuntu-latest over-commits (peak RSS
+                                             ~7.86GB) and GC-thrashes (40.9s/3054 GCs observed); ParallelGC
+                                             collects across all builder cores so GC wall-time drops, and the
+                                             heap is now a single knob to raise on a larger runner. -->
+                                        <buildArg>-J-Xmx${native.image.maxheap}</buildArg>
+                                        <buildArg>-J-XX:+UseParallelGC</buildArg>
+                                        <!-- nexus-9yrus (2) optimization level (see profile properties):
+                                             -O2 for release, -Ob (quick-build) for PR/smoke. -->
+                                        <buildArg>${native.image.opt}</buildArg>
                                     </buildArgs>
                                     <metadataRepository>
                                         <enabled>true</enabled>


### PR DESCRIPTION
## Triage

The engine-service native-image build is slow and GC-thrashing. From a successful linux-amd64 build log:
```
[2/8] Performing analysis...  (86.8s @ 3.59GB)
40.9s (10.6% of total time) in 3054 GCs | Peak RSS: 7.86GB | CPU load: 3.72
Finished generating 'nexus-service' in 6m 23s.
```
**Peak RSS 7.86 GB > ubuntu-latest's 7 GB** (memory over-commit → the GC thrash; a 61%-of-stage GC warning was observed in the wild) and **CPU load 3.72 on 2 vCPU** (CPU-starved). No builder heap/GC/quick-build args were set.

## Changes (the two safe levers; the decisive runner bump is deferred)

**(2) Parameterized optimization** — `native.image.opt` (default `-O2`). The PR trip-wire (`ci.yml`) and the per-PR native gate+smoke (`service-ci.yml`) now pass `-Dnative.image.opt=-Ob` (GraalVM quick-build). Quick-build keeps **full reachability analysis** (the jOOQ/GraalVM-reachability regression class these gates exist to catch) and only skips optimization → ~half the build time and lower peak memory. **The release build is untouched** (`engine-service-release.yml` → default `-O2`), so published `engine-service-v*` binaries are byte-for-byte the same optimization level as today.

**(3) Builder GC + heap** — `-J-XX:+UseParallelGC` (collect on all builder cores → GC wall-time drops even while RAM-pressured) + explicit, runner-tunable `-J-Xmx${native.image.maxheap}` (default `5632m` ≈ 80% of 7 GB; one knob to raise on a larger runner).

## Validation
pom validates; `native.image.opt` resolves `-O2` default / `-Ob` override; `native.image.maxheap`=`5632m`. The native build args are only exercised under `-Pnative`, so the unit suite is unaffected — **this PR's own `service-ci` native build (now `-Ob`) is the empirical proof and should visibly drop the build time.**

## Deferred (owner cost decision)
(1) Move linux native builds to a larger GitHub-hosted runner (4–8 core / 16–32 GB) — the real fix for the RSS>RAM thrash + CPU starvation; then bump `native.image.maxheap`. Tracked in `nexus-9yrus`.

## Closes
Closes nexus-9yrus