### PR TITLE
fix(nexus-f1syh): Voyage HttpClient honors egress proxy from env (native-image gap)

### DIFF
--- a/service/src/main/java/dev/nexus/service/vectors/CceEmbedder.java
+++ b/service/src/main/java/dev/nexus/service/vectors/CceEmbedder.java
@@ -83,9 +83,14 @@ public final class CceEmbedder implements Embedder {
     public CceEmbedder(String apiKey, String inputType) {
         this.apiKey    = apiKey;
         this.inputType = inputType;
-        this.http = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .build();
+        // nexus-... egress proxy: java.net.http.HttpClient ignores https.proxyHost
+        // system properties unless a proxy is set explicitly on the client. The cloud
+        // deploy routes api.voyageai.com through squid (private subnet has no NAT), so
+        // set the proxy from env (HTTPS_PROXY / NX_HTTPS_PROXY); absent = direct.
+        var builder = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10));
+        EgressProxy.selector().ifPresent(builder::proxy);
+        this.http = builder.build();
         this.mapper = new ObjectMapper();
     }
 

--- a/service/src/main/java/dev/nexus/service/vectors/ChromaRestClient.java
+++ b/service/src/main/java/dev/nexus/service/vectors/ChromaRestClient.java
@@ -98,6 +98,12 @@ public final class ChromaRestClient {
         this.database = database;
         this.apiKey   = apiKey;
         this.isCloud  = isCloud;
+        // nexus-f1syh NOTE: this client does NOT route through the egress proxy. It is
+        // the Chroma migration-read path and is NOT wired into the cloud serving engine
+        // (Main constructs only PgVectorRepository; Chroma serving retired in RDR-155
+        // P4a). If a cloud/private-subnet path ever calls cloud() (api.trychroma.com is
+        // external), wire EgressProxy.selector() onto this builder as the embedders do —
+        // a bare HttpClient will direct-connect and time out behind squid.
         this.http = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();

--- a/service/src/main/java/dev/nexus/service/vectors/EgressProxy.java
+++ b/service/src/main/java/dev/nexus/service/vectors/EgressProxy.java
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service.vectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.util.Optional;
+
+/**
+ * nexus-... egress-proxy configuration for the Voyage HTTP clients, read from env.
+ *
+ * <p><b>Why this exists.</b> The cloud deploy routes outbound {@code api.voyageai.com}
+ * through an egress proxy (squid) because the private subnet has no NAT/IGW. The IaC
+ * set the proxy via {@code JAVA_TOOL_OPTIONS=-Dhttps.proxyHost=…}. On a standard JVM
+ * that works: {@code HttpClient.newBuilder().build()} with no {@code .proxy(...)} falls
+ * back to {@code ProxySelector.getDefault()} ({@code sun.net.spi.DefaultProxySelector}),
+ * which honors {@code https.proxyHost} — so the old JVM engine proxied correctly. A
+ * GraalVM NATIVE image breaks this two ways: (1) it ignores {@code JAVA_TOOL_OPTIONS}
+ * (a JVM-launcher var), and (2) {@code DefaultProxySelector} is not initialized at
+ * native-image build time, so {@code ProxySelector.getDefault()} resolves to DIRECT and
+ * the system properties are ignored regardless. Same family as the boot segfault
+ * (nexus-0n7uc): the deploy relied on a JVM behavior native-image drops. The robust fix
+ * is to set the proxy ON the client explicitly, from env — independent of JVM-launcher
+ * vars and of the default-selector's native gap.
+ *
+ * <p>Env contract (RDR-157 config-via-env):
+ * <ul>
+ *   <li>{@code NX_HTTPS_PROXY} — {@code host:port} (preferred, explicit; an IPv6
+ *       literal must use bracket notation {@code [::1]:3128}, since a bare IPv6
+ *       address is ambiguous with the host:port split — the cloud squid is IPv4), or</li>
+ *   <li>{@code HTTPS_PROXY} — a URL ({@code http://host:port}; the de-facto standard).</li>
+ * </ul>
+ * Absent / blank → {@link Optional#empty()} → the client connects directly (local mode,
+ * or a cloud deploy with NAT). These clients only ever call {@code api.voyageai.com}
+ * (always external), so no {@code NO_PROXY}/nonProxyHosts handling is needed here.
+ */
+public final class EgressProxy {
+
+    private static final Logger log = LoggerFactory.getLogger(EgressProxy.class);
+
+    private EgressProxy() {
+    }
+
+    /** Resolve the egress proxy from the process environment. */
+    public static Optional<ProxySelector> selector() {
+        return fromEnv(System.getenv("NX_HTTPS_PROXY"), System.getenv("HTTPS_PROXY"));
+    }
+
+    /**
+     * Pure resolver (testable): {@code NX_HTTPS_PROXY} ({@code host:port}) wins, else
+     * the {@code HTTPS_PROXY} URL.
+     *
+     * <p>Failure posture (no-silent-fallbacks-for-correctness): ABSENT (neither set, or
+     * blank) → {@link Optional#empty()} = direct connection (local mode, or a cloud
+     * deploy with NAT). But a var that is PRESENT yet unparseable is FATAL —
+     * {@link IllegalStateException}. An operator who set the proxy needs it; silently
+     * falling back to a direct connection would reproduce the original outage (a 30s
+     * timeout per request to api.voyageai.com on a no-NAT subnet) with no clear cause.
+     * Fail loud at boot instead.
+     *
+     * @param nxHostPort   value of {@code NX_HTTPS_PROXY} (host:port), or null/blank
+     * @param httpsProxyUrl value of {@code HTTPS_PROXY} (URL), or null/blank
+     * @throws IllegalStateException if a present env var cannot be parsed
+     */
+    static Optional<ProxySelector> fromEnv(String nxHostPort, String httpsProxyUrl) {
+        if (nxHostPort != null && !nxHostPort.isBlank()) {
+            return Optional.of(parseHostPort(nxHostPort.trim(), "NX_HTTPS_PROXY"));
+        }
+        if (httpsProxyUrl != null && !httpsProxyUrl.isBlank()) {
+            return Optional.of(parseUrl(httpsProxyUrl.trim()));
+        }
+        return Optional.empty();
+    }
+
+    private static ProxySelector parseHostPort(String hostPort, String source) {
+        int colon = hostPort.lastIndexOf(':');
+        if (colon > 0 && colon < hostPort.length() - 1) {
+            try {
+                return of(hostPort.substring(0, colon),
+                          Integer.parseInt(hostPort.substring(colon + 1)), source);
+            } catch (NumberFormatException ignored) {
+                // fall through to the fatal error below
+            }
+        }
+        throw fatal(source, hostPort, "expected host:port");
+    }
+
+    private static ProxySelector parseUrl(String url) {
+        try {
+            URI u = URI.create(url.contains("://") ? url : "http://" + url);
+            String host = u.getHost();
+            if (host != null && !host.isBlank()) {
+                int port = u.getPort() != -1 ? u.getPort() : 3128;  // squid default
+                return of(host, port, "HTTPS_PROXY");
+            }
+        } catch (IllegalArgumentException ignored) {
+            // fall through to the fatal error below
+        }
+        throw fatal("HTTPS_PROXY", url, "expected a URL like http://host:port");
+    }
+
+    private static IllegalStateException fatal(String source, String value, String hint) {
+        // Loud, not silent: a set-but-broken proxy var would otherwise direct-connect
+        // and reproduce the api.voyageai.com timeout opaquely.
+        return new IllegalStateException(
+            source + "=" + value + " is set but unparseable (" + hint + "). The egress "
+            + "proxy is required wherever it is configured (direct connection to "
+            + "api.voyageai.com on a no-NAT subnet times out); fix the value.");
+    }
+
+    private static ProxySelector of(String host, int port, String source) {
+        log.info("event=egress_proxy_configured source={} host={} port={}", source, host, port);
+        return ProxySelector.of(new InetSocketAddress(host, port));
+    }
+}

--- a/service/src/main/java/dev/nexus/service/vectors/VoyageEmbedder.java
+++ b/service/src/main/java/dev/nexus/service/vectors/VoyageEmbedder.java
@@ -74,9 +74,14 @@ public final class VoyageEmbedder implements Embedder {
         // inputType deliberately NOT stored: production VoyageAIEmbeddingFunction
         // always passes input_type=None (field omitted from request), matching what
         // the Voyage API uses as its "unspecified" default.
-        this.http = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .build();
+        // nexus-... egress proxy: java.net.http.HttpClient ignores https.proxyHost
+        // system properties unless a proxy is set explicitly on the client. The cloud
+        // deploy routes api.voyageai.com through squid (private subnet has no NAT), so
+        // set the proxy from env (HTTPS_PROXY / NX_HTTPS_PROXY); absent = direct.
+        var builder = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10));
+        EgressProxy.selector().ifPresent(builder::proxy);
+        this.http = builder.build();
         this.mapper = new ObjectMapper();
     }
 

--- a/service/src/test/java/dev/nexus/service/vectors/EgressProxyTest.java
+++ b/service/src/test/java/dev/nexus/service/vectors/EgressProxyTest.java
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package dev.nexus.service.vectors;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * nexus-f1syh — the Voyage HTTP clients must route through the egress proxy when env
+ * configures it (cloud squid; private subnet has no NAT), and connect directly when
+ * not. java.net.http.HttpClient ignores https.proxyHost system properties unless a
+ * proxy is set explicitly, so this resolver is the load-bearing piece.
+ *
+ * <p>Tests the pure resolver {@link EgressProxy#fromEnv} (no real env mutation).
+ */
+class EgressProxyTest {
+
+    private static InetSocketAddress addrOf(Optional<ProxySelector> sel) {
+        assertThat(sel).isPresent();
+        List<Proxy> proxies = sel.get().select(URI.create("https://api.voyageai.com/v1/embeddings"));
+        assertThat(proxies).hasSize(1);
+        assertThat(proxies.get(0).type()).isEqualTo(Proxy.Type.HTTP);
+        return (InetSocketAddress) proxies.get(0).address();
+    }
+
+    @Test
+    void nxHttpsProxy_hostPort_resolves() {
+        InetSocketAddress a = addrOf(EgressProxy.fromEnv("10.0.1.5:3128", null));
+        assertThat(a.getHostString()).isEqualTo("10.0.1.5");
+        assertThat(a.getPort()).isEqualTo(3128);
+    }
+
+    @Test
+    void httpsProxy_url_resolves() {
+        InetSocketAddress a = addrOf(EgressProxy.fromEnv(null, "http://squid.internal:3128"));
+        assertThat(a.getHostString()).isEqualTo("squid.internal");
+        assertThat(a.getPort()).isEqualTo(3128);
+    }
+
+    @Test
+    void httpsProxy_url_withoutScheme_resolves() {
+        InetSocketAddress a = addrOf(EgressProxy.fromEnv(null, "squid.internal:8080"));
+        assertThat(a.getHostString()).isEqualTo("squid.internal");
+        assertThat(a.getPort()).isEqualTo(8080);
+    }
+
+    @Test
+    void httpsProxy_url_withoutPort_defaultsToSquid3128() {
+        InetSocketAddress a = addrOf(EgressProxy.fromEnv(null, "http://squid.internal"));
+        assertThat(a.getPort()).isEqualTo(3128);
+    }
+
+    @Test
+    void nxHttpsProxy_winsOverHttpsProxy() {
+        InetSocketAddress a = addrOf(EgressProxy.fromEnv("10.0.1.5:3128", "http://other:9999"));
+        assertThat(a.getHostString()).isEqualTo("10.0.1.5");
+        assertThat(a.getPort()).isEqualTo(3128);
+    }
+
+    @Test
+    void neitherSet_isDirect_empty() {
+        // Absent (or blank) → direct connection (local mode / NAT). Not an error.
+        assertThat(EgressProxy.fromEnv(null, null)).isEmpty();
+        assertThat(EgressProxy.fromEnv("", "  ")).isEmpty();
+    }
+
+    @Test
+    void presentButMalformed_failsLoud_notSilentDirect() {
+        // A proxy var that is SET but unparseable is FATAL — silently direct-connecting
+        // would reproduce the original api.voyageai.com timeout opaquely.
+        assertThat(catchThrowable(() -> EgressProxy.fromEnv("hostonly", null)))
+            .isInstanceOf(IllegalStateException.class).hasMessageContaining("host:port");
+        assertThat(catchThrowable(() -> EgressProxy.fromEnv("host:notaport", null)))
+            .isInstanceOf(IllegalStateException.class);
+        assertThat(catchThrowable(() -> EgressProxy.fromEnv("host:", null)))
+            .isInstanceOf(IllegalStateException.class);
+        assertThat(catchThrowable(() -> EgressProxy.fromEnv(null, "::::not a url")))
+            .isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
## conexus-001 — STEP-6 voyage embed probe 30s-timeouts

Native-image gap, **same family as the nexus-0n7uc segfault**: the cloud deploy relied on a JVM behavior native-image drops.

**Mechanism (corrected from my first relay):** on a standard JVM, `HttpClient.newBuilder().build()` with no `.proxy()` falls back to `ProxySelector.getDefault()` (`DefaultProxySelector`), which **does** honor `https.proxyHost` — so the old JVM engine proxied correctly via `JAVA_TOOL_OPTIONS=-Dhttps.proxyHost`. A GraalVM **native image** breaks it two ways: (1) it ignores `JAVA_TOOL_OPTIONS` (a JVM-launcher var), and (2) `DefaultProxySelector` isn't initialized at native-image build time, so `ProxySelector.getDefault()` resolves to **DIRECT** and the system properties are ignored regardless. Either way the native engine direct-connects to `api.voyageai.com` and the no-NAT private subnet times out.

**Audit** of the conexus engine deploy (`infra/terraform/modules/app-server/main.tf`): the proxy is the **only** JVM-ism — no `JAVA_OPTS`/`-agentlib`/`-XX`/other `-D`. So this completes the native-image-vs-JVM class; no further re-cut lurks.

## Fix
`EgressProxy` reads `NX_HTTPS_PROXY` (host:port) / `HTTPS_PROXY` (URL) and sets `.proxy(ProxySelector.of(addr))` **explicitly** on both embedder clients — independent of JVM-launcher vars and the default-selector's native gap. `ProxySelector.of()` is native-safe (no SPI / system-property dependency). These clients only call `api.voyageai.com` (always external), so no `NO_PROXY` handling.

- **ABSENT** env → direct (local mode / NAT).
- **PRESENT-but-malformed** → **FATAL at boot** (`IllegalStateException`) — a silent direct-connect would reproduce the outage opaquely (no-silent-fallbacks-for-correctness).
- `ChromaRestClient` (migration-read path, not wired into cloud serving) documented as proxy-bypassing so a future cloud caller wires `EgressProxy` too.

## ⚠️ conexus IaC change required
Replace the `JAVA_TOOL_OPTIONS=-Dhttps.proxyHost=…` line in `engine.env` with **`HTTPS_PROXY=http://<edge_ip>:3128`** (or `NX_HTTPS_PROXY=<edge_ip>:3128`).

## Review (stacked, sonnet)
substantive-critic: 3 Significant (Javadoc mechanism corrected; fail-loud on malformed; ChromaRestClient trap documented) — **all resolved, no residuals**. code-review-expert: **APPROVED** (0 Critical/High; 1 Medium = IPv6-bracket doc, added). Full fresh-codegen suite **792 green**.

Re-cut as `engine-service-v0.1.2` after merge.

## Closes
Closes nexus-f1syh