### PR TITLE
test(nexus-luofb): repair HybridParityIntegrationTest bit-rot

### DIFF
--- a/service/src/test/java/dev/nexus/service/HybridParityIntegrationTest.java
+++ b/service/src/test/java/dev/nexus/service/HybridParityIntegrationTest.java
@@ -43,12 +43,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * RDR-155 P3.1 (bead nexus-sbvg0): hybrid-parity seam — engine pgvector hybrid vs the
  * legacy FTS5 + Chroma two-path fusion, fixture scale.
  *
- * <p><strong>TDD-RED:</strong> the parity tests call
- * {@link PgVectorRepository#hybridSearch} and fail with
- * {@link UnsupportedOperationException} until bead nexus-eap5l (P3.2) implements it.
- * The fixture guards (corpus seeding, legacy-leg candidate sets, tie margins) are
- * green now — they verify the COMPARAND is correctly constructed before the engine
- * side exists, exactly like the conexus xr7.8.7 fixture guards.
+ * <p><strong>Now fully green:</strong> {@link PgVectorRepository#hybridSearch} is
+ * implemented (bead nexus-eap5l, P3.2), so both the fixture guards (corpus seeding,
+ * legacy-leg candidate sets, tie margins) AND the parity seam tests pass. The guards
+ * verify the COMPARAND is correctly constructed; the seam tests verify the engine
+ * hybrid matches the legacy fusion within the exactly-pinned tokenizer deltas below.
+ * (Originally authored TDD-RED against an {@code UnsupportedOperationException} stub,
+ * exactly like the conexus xr7.8.7 fixture guards.)
  *
  * <p><strong>The comparand is the real legacy engines, not a reimplementation:</strong>
  * <ul>
@@ -311,7 +312,7 @@ class HybridParityIntegrationTest {
                 .toList();
     }
 
-    /** Engine hybrid top-k IDs (RED until P3.2 implements hybridSearch). */
+    /** Engine hybrid top-k IDs (P3.2 / nexus-eap5l implements hybridSearch). */
     private List<String> engineHybridTopK(String query, int k) {
         return pgRepo.hybridSearch(TENANT, query, List.of(PG_COL), k, null).stream()
                 .map(r -> (String) r.get("id"))
@@ -328,7 +329,7 @@ class HybridParityIntegrationTest {
     }
 
     // ---------------------------------------------------------------------------
-    // Fixture guards (GREEN before P3.2 — they verify the comparand, not the engine)
+    // Fixture guards (verify the comparand, not the engine)
     // ---------------------------------------------------------------------------
 
     @Test
@@ -395,7 +396,7 @@ class HybridParityIntegrationTest {
     }
 
     // ---------------------------------------------------------------------------
-    // Parity seam (RED until P3.2)
+    // Parity seam (engine hybrid vs legacy fusion)
     // ---------------------------------------------------------------------------
 
     @Test

--- a/service/src/test/java/dev/nexus/service/HybridParityIntegrationTest.java
+++ b/service/src/test/java/dev/nexus/service/HybridParityIntegrationTest.java
@@ -118,34 +118,56 @@ class HybridParityIntegrationTest {
     // indexing rows (QB), and fillers share no stem-colliding words.
     // ---------------------------------------------------------------------------
 
+    // Row ids are 32-char chashes (chunks_384_chash_len_check, RDR-156-era). The readable
+    // labels below are padded to 32 chars by {@link #chash}, so failure output stays legible
+    // ('par-t1' → 'par-t10000…') while the ids satisfy the length constraint the pgvector leg
+    // enforces. The SAME id is seeded into all three stores, so cross-store parity by id holds.
+
+    /** 32-char chunk id: readable label zero-padded to satisfy chunks_&lt;dim&gt;_chash_len_check. */
+    private static String chash(String label) {
+        if (label.length() > 32) throw new IllegalArgumentException("label too long: " + label);
+        return label + "0".repeat(32 - label.length());
+    }
+
+    private static final String T1 = chash("par-t1");
+    private static final String T2 = chash("par-t2");
+    private static final String T3 = chash("par-t3");
+    private static final String U1 = chash("par-u1");
+    private static final String U2 = chash("par-u2");
+    private static final String U3 = chash("par-u3");
+    private static final String F1 = chash("par-f1");
+    private static final String F2 = chash("par-f2");
+    private static final String F3 = chash("par-f3");
+    private static final String F4 = chash("par-f4");
+
     private static final Map<String, String> CORPUS = new LinkedHashMap<>();
     static {
         // QA domain — exact word forms 'postgres' + 'transaction' (no variants anywhere
         // else in the corpus): english and unicode61 derive the SAME candidate set.
-        CORPUS.put("par-t1", "postgres transaction semantics with mvcc");
-        CORPUS.put("par-t2", "a postgres transaction can roll back");
-        CORPUS.put("par-t3", "postgres transaction isolation levels explained");
+        CORPUS.put(T1, "postgres transaction semantics with mvcc");
+        CORPUS.put(T2, "a postgres transaction can roll back");
+        CORPUS.put(T3, "postgres transaction isolation levels explained");
         // QB domain — morphological variants: 'indexing strategies' / 'index strategy' /
         // 'indexed strategies'. The english stemmer maps all three to 'index' &
         // 'strategi'; unicode61 FTS5 matches only the exact tokens.
-        CORPUS.put("par-u1", "indexing strategies for large corpora");
-        CORPUS.put("par-u2", "an index strategy for btree lookups");
-        CORPUS.put("par-u3", "indexed strategies guide for analytics");
+        CORPUS.put(U1, "indexing strategies for large corpora");
+        CORPUS.put(U2, "an index strategy for btree lookups");
+        CORPUS.put(U3, "indexed strategies guide for analytics");
         // Fillers — distinct vocabulary, never text-match any probe query.
-        CORPUS.put("par-f1", "chroma etl pipeline with rollback flag");
-        CORPUS.put("par-f2", "tokenizer divergence between engines");
-        CORPUS.put("par-f3", "hybrid retrieval fusion ranking");
-        CORPUS.put("par-f4", "cosine similarity in embedding spaces");
+        CORPUS.put(F1, "chroma etl pipeline with rollback flag");
+        CORPUS.put(F2, "tokenizer divergence between engines");
+        CORPUS.put(F3, "hybrid retrieval fusion ranking");
+        CORPUS.put(F4, "cosine similarity in embedding spaces");
     }
 
     /** QA — aligned: both tokenizers match exactly {t1, t2, t3}. */
     private static final String QA = "postgres transaction";
-    private static final Set<String> QA_LEGACY_CANDIDATES = Set.of("par-t1", "par-t2", "par-t3");
+    private static final Set<String> QA_LEGACY_CANDIDATES = Set.of(T1, T2, T3);
 
     /** QB — stemmer-divergent: english matches {u1, u2, u3}, unicode61 only {u1}. */
     private static final String QB = "indexing strategies";
-    private static final Set<String> QB_LEGACY_CANDIDATES = Set.of("par-u1");
-    private static final Set<String> QB_ENGINE_CANDIDATES = Set.of("par-u1", "par-u2", "par-u3");
+    private static final Set<String> QB_LEGACY_CANDIDATES = Set.of(U1);
+    private static final Set<String> QB_ENGINE_CANDIDATES = Set.of(U1, U2, U3);
 
     /** QC — typo ('transacton'): no FTS lexeme either side; only pg_trgm can rescue. */
     private static final String QC = "transacton isolation";
@@ -191,6 +213,8 @@ class HybridParityIntegrationTest {
             su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
             su.createStatement().execute(
                 "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus.chunks_384 TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT ON nexus.catalog_collections TO " + SVC_ROLE);
             su.createStatement().execute(
                 "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
         }
@@ -400,7 +424,7 @@ class HybridParityIntegrationTest {
 
         assertThat(legacy)
             .as("legacy fused list is exactly the single exact-token row")
-            .containsExactly("par-u1");
+            .containsExactly(U1);
         assertThat(Set.copyOf(engine))
             .as("engine candidate set is exactly the three stemmed-variant rows")
             .isEqualTo(QB_ENGINE_CANDIDATES);
@@ -438,7 +462,7 @@ class HybridParityIntegrationTest {
             .isNotEmpty()
             .as("the row containing both corrected words ('transaction isolation') has "
                 + "the highest text similarity under any sane gate and must be present")
-            .contains("par-t3");
+            .contains(T3);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Repairs two independent pre-existing breakages in the `@Tag("integration")`, CI-excluded `HybridParityIntegrationTest`. Both surfaced while validating nexus-x7z7l; neither is caused by it (x7z7l only touches `hybridSearch`).

1. **Missing grant.** `SVC_ROLE` was granted `chunks_384` but not `nexus.catalog_collections`, into which `PgVectorRepository.upsertChunks` inserts a stub row *first* → `permission denied for table catalog_collections`. Added `GRANT SELECT, INSERT` mirroring `HybridSelectiveGateTest:113`.
2. **Constraint violation.** CORPUS row ids were short labels (`par-t1` etc) that violate `chunks_384_chash_len_check` (`CHECK length(chash)=32`, RDR-156-era). Added a `chash()` helper zero-padding each readable label to 32 chars, rekeyed the CORPUS map + candidate-set constants to `T1..F4`, and updated the two remaining literal id assertions.

## Why it's safe

The id is FTS5-`UNINDEXED` and a PK/chash in pg+chroma, so padding cannot perturb tokenizer behaviour, candidate sets, or the exact delta arithmetic (QA overlap==1.0, QB==1/3, aggregate==2/3). The same padded id is seeded into all three stores, so cross-store parity-by-id holds.

## Verification

All 8 tests green (3 fixture guards + 5 parity seam):
`mvn test -Dtest.excluded.groups="" -Dgroups=integration -Dtest=HybridParityIntegrationTest`

Stacked review (code-review-expert + substantive-critic): zero Critical/High/Significant. Two trivial polish notes applied (helper declaration order, `IllegalArgumentException`).

Production-scale parity remains conexus xr7.8.9-owned per the suite javadoc.

Closes nexus-luofb