### PR TITLE
feat(rdr-161 P1): native-binary acquire + verify (acquire-before-removal)

### DIFF
--- a/.github/workflows/engine-service-release.yml
+++ b/.github/workflows/engine-service-release.yml
@@ -270,14 +270,31 @@ jobs:
           COSIGN_YES: "true"
         run: |
           set -euo pipefail
+          # Two bundle formats, same keyless signature:
+          #  (1) .cosign.bundle      — old JSON format (cosign v2.4.1 default).
+          #      Consumed by conexus deploy's `cosign verify-blob` before docker run.
+          #  (2) .sigstore.json      — new protobuf bundle (--new-bundle-format).
+          #      Consumed by the local `nx daemon service install-binary` path via
+          #      sigstore-python (RDR-161 RF-161-1): offline-verifiable, no 130MB
+          #      cosign binary on the pip user's machine. The old JSON format only
+          #      carries an inclusion *promise* (SET), which sigstore-python cannot
+          #      verify offline; the protobuf format carries the full inclusion
+          #      proof. Both halves of RDR-161 P1 (this publisher + the consumer
+          #      command) land together or local verification is non-functional.
           cosign sign-blob "dist/$ASSET" --bundle "dist/$ASSET.cosign.bundle"
-          # Self-verify before publishing so a malformed bundle fails the build,
-          # not the consumer. Identity = this workflow at this tag ref.
+          cosign sign-blob "dist/$ASSET" --new-bundle-format --bundle "dist/$ASSET.sigstore.json"
+          # Self-verify BOTH before publishing so a malformed bundle fails the
+          # build, not the consumer. Identity = this workflow at this tag ref.
           cosign verify-blob "dist/$ASSET" \
             --bundle "dist/$ASSET.cosign.bundle" \
             --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/engine-service-release.yml@${GITHUB_REF}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
-          echo "cosign signature verified for $ASSET"
+          cosign verify-blob "dist/$ASSET" \
+            --new-bundle-format \
+            --bundle "dist/$ASSET.sigstore.json" \
+            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/engine-service-release.yml@${GITHUB_REF}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+          echo "cosign signatures verified for $ASSET (.cosign.bundle + .sigstore.json)"
 
       - name: Upload Actions artifact (always — dev smoke / non-tag path)
         uses: actions/upload-artifact@v4
@@ -320,11 +337,14 @@ jobs:
             "  curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/tokenizer.json -o \$MODEL_DIR/tokenizer.json" \
             "" \
             "Provenance: each asset carries a sha256 AND a keyless cosign/Sigstore" \
-            "signature bundle (<asset>.cosign.bundle). Verify before use:" \
+            "signature in TWO bundle formats — <asset>.cosign.bundle (old JSON) and" \
+            "<asset>.sigstore.json (new protobuf). Verify before use, either path:" \
             "  cosign verify-blob <asset> --bundle <asset>.cosign.bundle \\" \
             "    --certificate-oidc-issuer https://token.actions.githubusercontent.com \\" \
             "    --certificate-identity-regexp 'https://github.com/${GITHUB_REPOSITORY}/.github/workflows/engine-service-release.yml@refs/tags/engine-service-v.*'" \
-            "conexus deploy verifies this bundle before docker run (see ECR_PUSH.md)." \
+            "conexus deploy verifies the .cosign.bundle before docker run (ECR_PUSH.md)." \
+            "The local 'nx daemon service install-binary' path verifies the protobuf" \
+            ".sigstore.json offline via sigstore-python (no cosign binary required)." \
             > notes.md
           # Matrix-safe: create the release once (whichever arch job wins), then
           # each job uploads its OWN arch assets (--clobber for re-runs). Use
@@ -342,4 +362,5 @@ jobs:
             fi
           fi
           gh release upload "$tag" --clobber \
-            "dist/$ASSET" "dist/$ASSET.sha256" "dist/$ASSET.cosign.bundle"
+            "dist/$ASSET" "dist/$ASSET.sha256" \
+            "dist/$ASSET.cosign.bundle" "dist/$ASSET.sigstore.json"

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -176,6 +176,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-158](rdr-158-retire-sqlite-t2-backend.md) | Retire the SQLite T2 Backend: Make the PG Service the Only T2 Path | Architecture | Accepted | 2026-06-12 |
 | [RDR-159](rdr-159-guided-upgrade-migration.md) | Guided Chroma-to-Service Upgrade Migration: One Survivable Command over the Proven ETL Primitives | Architecture | Accepted | 2026-06-13 |
 | [RDR-160](rdr-160-bge-768-local-service-embedder.md) | bge-768 as the Local-Mode T3 Embedder in the Java Service: Replace MiniLM-384 ONNX, Parity-Gated Against fastembed | Architecture | Closed | 2026-06-15 |
+| [RDR-161](rdr-161-native-only-local-install.md) | Native-Only Local Install: Expunge the JAR Launch Path, Acquire the Signed Native Binary and PG Bundle | Architecture | Accepted | 2026-06-18 |
 
 > **Scrapped 2026-05-19 (RDR-110-119 arc).** Bundled the storage-substrate split with new abstractions (tuplespace, ORB, host-trust, surfaces-as-tuples, UI fabric); scope discipline failed across nine RDRs and 67 stranded beads. Files preserved as tombstones per the "never delete RDR files" rule. Postmortem: [docs/postmortem/2026-05-16-rdr110-113-remediation-chain.md](../postmortem/2026-05-16-rdr110-113-remediation-chain.md). Active substrate work continues as [RDR-120](rdr-120-storage-substrate-split.md) with an explicit moratorium on co-shipped consumers. Numbers RDR-114 through RDR-117 are unused on `main` (drafted on feature branches that never merged).
 

--- a/docs/rdr/rdr-161-native-only-local-install.md
+++ b/docs/rdr/rdr-161-native-only-local-install.md
@@ -99,7 +99,7 @@ the UNSMOKED caveat). mac-amd64 (Intel) is out of scope.
 
 ## Approach (phased)
 
-### Phase 1 — Acquire the signed native binary (unblocks the install before removal)
+**Phase 1: Acquire the signed native binary (unblocks the install before removal)**
 
 - **Publisher sub-task (RF-161-1):** add `--new-bundle-format` to the `cosign sign-blob`
   step in `engine-service-release.yml` so each release also publishes a protobuf
@@ -122,7 +122,7 @@ the UNSMOKED caveat). mac-amd64 (Intel) is out of scope.
   install-binary if no binary is resolvable (idempotent; a present valid binary is a
   no-op).
 
-### Phase 2 — Publish + acquire the PG bundle
+**Phase 2: Publish + acquire the PG bundle**
 
 - Release job that runs `scripts/build_pg_bundle.sh` per target on its native runner,
   signs (`cosign sign-blob --new-bundle-format` → `.sigstore.json`, same format as the
@@ -143,7 +143,7 @@ the UNSMOKED caveat). mac-amd64 (Intel) is out of scope.
 - Add a **published-then-downloaded** bundle round-trip test (current relocation tests
   only exercise a locally-built bundle — RF-161-3 gap).
 
-### Phase 3 — Expunge the JAR launch + install path (native-only)
+**Phase 3: Expunge the JAR launch + install path (native-only)**
 
 - `storage_service_daemon.py`: delete `_find_service_jar` and the `java -jar` spawn arm;
   `StorageServiceSupervisor` requires `binary_path` (drop the `jar_path` param and the
@@ -157,7 +157,7 @@ the UNSMOKED caveat). mac-amd64 (Intel) is out of scope.
 - Inverse-grep gate: `jar` is absent from `src/nexus` non-test launch/install surface
   (mirrors the exhaustive-surface-audit discipline).
 
-### Phase 4 — Docs + deferred Windows bead
+**Phase 4: Docs + deferred Windows bead**
 
 - Update install/runbook docs to the native-only one-command story.
 - Windows-native is tracked by the existing `nexus-f9bgu` (RDR-157 release-N+1 follow-on:

--- a/docs/rdr/rdr-161-native-only-local-install.md
+++ b/docs/rdr/rdr-161-native-only-local-install.md
@@ -1,0 +1,298 @@
+---
+title: "Native-Only Local Install: Expunge the JAR Launch Path, Acquire the Signed Native Binary and PG Bundle"
+id: RDR-161
+type: Architecture
+status: accepted
+accepted_date: 2026-06-18
+priority: high
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-06-18
+related_issues: [nexus-luxe6, nexus-1jt17, nexus-1odsm]
+related: [RDR-157, RDR-155, RDR-152, RDR-160]
+---
+
+# RDR-161: Native-Only Local Install
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+RDR-157 decided the service ships as a per-OS/arch **GraalVM native-image binary**
+(RF-157-6/7, locked 2026-06-14) and that the local distribution ships a relocatable
+**PG + pgvector bundle** alongside it (CA-1/CA-2). The native launch path is already
+the runtime default: `StorageServiceSupervisor` prefers `binary_path` over the JAR
+(`_launch_mode = "native"`), `_find_service_binary` resolves the well-known binary or
+`NEXUS_SERVICE_BIN`, and `engine-service-release.yml` publishes cosign-signed
+`nexus-service-{linux-amd64,linux-arm64,mac-arm64}` assets.
+
+Three gaps stop a fresh local install from working end to end, and they are the
+residue of the JAR-era design that RDR-157 superseded but did not finish removing.
+
+#### Gap 1: The JAR launch path is now vestigial dead weight, still wired
+
+`install-jar` (nexus-pebfx.4) solved the JAR *lifecycle* before the native decision
+landed. Post-decision the JAR is the dev/JVM fallback only, but it is still load-bearing
+in four modules: `daemon/storage_service_daemon.py` (`_find_service_jar`, the
+`java -jar` spawn arm, the `_launch_mode` dual-mode and JVM-specific heartbeat
+handling), `daemon/jar_lifecycle.py` (`well_known_jar_path`, `install_jar`, the
+fat-JAR changelog validation), `commands/daemon.py` (`service install-jar`), and
+`migration/pregate.py`. Keeping two launch artifacts means two acquisition stories,
+two provenance shapes, and a JVM-fallback path that silently masks a missing native
+binary. The decision is **native-only**: one launch artifact, one acquisition path.
+
+#### Gap 2: No acquisition command places the published native binary
+
+The runtime will launch a native binary sitting at `well_known_binary_path` or pointed
+to by `NEXUS_SERVICE_BIN`, but **no code puts it there**. There is `service install-jar`
+and no `service install-binary`; nothing fetches from the `engine-service-v*` release.
+The signed assets (`.cosign.bundle`, `.sha256`) exist and are unverified at the point of
+install. `nx init --service` does not place the binary either. Today a fresh user must
+manually download, `chmod +x`, and set an env var. This is the **local** counterpart to
+the cloud-only cosign verify in `nexus-1jt17` (conexus `deploy/engine`, docker path) —
+which does **not** cover the local install.
+
+#### Gap 3: The PG bundle is built and consumed but never published
+
+`scripts/build_pg_bundle.sh` builds the relocatable `nexus-pg-<target>.txz` and
+`db/pg_bundle.py` (RDR-157 P3.4) locates+extracts+selects it on first run. But
+`engine-service-release.yml` publishes **only** the service binary; `build_pg_bundle.sh`
+is referenced solely by `ci.yml` (build/smoke, no publish). So `_select_bundled_pg`
+finds nothing on a fresh install → host-PG fallback → `PgBinaryNotFoundError` unless the
+user hand-installed PG + pgvector (the brew-wrong-major friction RDR-157 documented).
+The build and consume halves exist; the **publish + acquire** seam does not.
+
+### Evidence
+
+- Native launch is preferred and implemented: `storage_service_daemon.py`
+  `_find_service_binary` / `_spawn_service` (`binary_path` wins over JAR).
+- Release ships native + signatures, not the PG bundle: `engine-service-release.yml`
+  matrix `linux-amd64 / linux-arm64 / mac-arm64`, cosign + sha256 per asset; no
+  `nexus-pg-*` upload step.
+- PG bundle build+consume exist: `scripts/build_pg_bundle.sh`, `src/nexus/db/pg_bundle.py`.
+- `nexus-1jt17` is scoped to conexus docker deploy, explicitly "CONEXUS-REPO work";
+  it does not carry the local `install-binary` fetch.
+
+## Decision
+
+**Native-only local install.** Remove the JAR launch and install paths entirely; make
+the GraalVM native binary the single launch artifact. Add one verified acquisition
+command, `nx daemon service install-binary`, that fetches the platform asset from the
+`engine-service-v*` release and **signature-verifies it before placing it**, failing
+closed on a missing/invalid signature or digest. Per RF-161-1 the verification mechanism
+is **`sigstore-python`** (the PyPI `sigstore` package — a normal dependency, no 130 MB
+cosign binary, offline-capable) consuming a **protobuf `.sigstore.json`** bundle, with
+the cert identity pinned to `Hellblazer/nexus .github/workflows/engine-service-release.yml`
+at an `engine-service-v*` ref and issuer `token.actions.githubusercontent.com`. This
+requires a **publisher-side change** (emit `.sigstore.json` via `--new-bundle-format`),
+so the verification contract is co-owned by Phase 1's publisher and consumer sub-tasks.
+The command also **sha256-verifies**, places the binary at the well-known path with a
+provenance sidecar, and is invoked by `nx init --service`. Publish the PG bundle on the
+same release channel and acquire+verify it through the same seam so `_select_bundled_pg`
+finds it.
+
+**Platform scope now: mac-arm64 (Apple Silicon) + linux-amd64 + linux-arm64** — exactly
+the current release matrix, so no matrix change is required for this RDR. **Windows
+native is deferred** to a follow-on bead (build matrix + `.exe` asset + platform map +
+the UNSMOKED caveat). mac-amd64 (Intel) is out of scope.
+
+## Approach (phased)
+
+### Phase 1 — Acquire the signed native binary (unblocks the install before removal)
+
+- **Publisher sub-task (RF-161-1):** add `--new-bundle-format` to the `cosign sign-blob`
+  step in `engine-service-release.yml` so each release also publishes a protobuf
+  `nexus-service-<arch>.sigstore.json` alongside the existing `.cosign.bundle` and
+  `.sha256`. This is the prerequisite that lets the consumer verify with `sigstore-python`
+  and is part of Phase 1, not a later phase — the publisher and consumer halves land
+  together or verification is non-functional.
+- **Consumer command:** `nx daemon service install-binary TAG [--path PATH]`: TAG is an
+  explicit `engine-service-v*` tag (RF-161-2 — no "latest" resolution in Phase 1).
+  Resolve `platform → nexus-service-<arch>` via the existing `current_platform_tag()`
+  (`pg_bundle.py:54`, same `<target>` tokens as the PG bundle); download the asset, its
+  `.sigstore.json`, and `.sha256`; sha256-verify (fast fail on corrupt download), then
+  **signature-verify with `sigstore-python`** pinning cert-identity-regexp to
+  `Hellblazer/nexus .github/workflows/engine-service-release.yml@refs/tags/engine-service-v[0-9].*`
+  and issuer `token.actions.githubusercontent.com`; **fail closed** on any failure with
+  an actionable message (never a bare exception). Place at `well_known_binary_path`
+  (atomic tmp + `os.replace`), `chmod +x`, write a provenance sidecar (mirroring
+  `install_jar`'s: version-from-tag, sha256, source-url, installed_at).
+- Wire into `nx init --service`: after PG provisioning, before `_start_service_step`,
+  install-binary if no binary is resolvable (idempotent; a present valid binary is a
+  no-op).
+
+### Phase 2 — Publish + acquire the PG bundle
+
+- Release job that runs `scripts/build_pg_bundle.sh` per target on its native runner,
+  signs (`cosign sign-blob --new-bundle-format` → `.sigstore.json`, same format as the
+  binary so the consumer's sigstore-python path is uniform) + sha256s, and uploads
+  `nexus-pg-<target>.txz(+.sigstore.json +.sha256)` as release assets (alongside or
+  sibling to `engine-service-release.yml`).
+- Acquire+verify through the same install seam (extend `install-binary` or a parallel
+  `install-pg-bundle`): fetch `.txz` + `.sigstore.json` + `.sha256`, sha256- then
+  signature-verify (same sigstore-python pin as the binary), atomic-place at
+  `<config_dir>/service/nexus-pg-<tag>.txz` with a provenance sidecar.
+- **Bug fix (RF-161-3):** `_select_bundled_pg` (`init.py:396`) currently calls
+  `ensure_pg_bundle` with no `search_dirs`, so the default `[Path(sys.executable).parent]`
+  (the venv `bin/`) fires instead of `<config_dir>/service/` where the acquire seam
+  places the `.txz` — a correctly published+acquired bundle is never found. Fix: pass
+  `search_dirs=[well_known_binary_path(config_dir).parent]` when the caller supplies none
+  (preserving the `NEXUS_PG_BUNDLE` override and the test-injectable param). Without this
+  the install silently falls back to host-PG — the exact failure this RDR exists to kill.
+- Add a **published-then-downloaded** bundle round-trip test (current relocation tests
+  only exercise a locally-built bundle — RF-161-3 gap).
+
+### Phase 3 — Expunge the JAR launch + install path (native-only)
+
+- `storage_service_daemon.py`: delete `_find_service_jar` and the `java -jar` spawn arm;
+  `StorageServiceSupervisor` requires `binary_path` (drop the `jar_path` param and the
+  dual `_launch_mode`); collapse JVM-specific heartbeat handling to the native case.
+- `jar_lifecycle.py`: remove `install_jar`, `well_known_jar_path`, fat-JAR changelog
+  validation; move the surviving binary helpers (`well_known_binary_path`,
+  `_find_service_binary` support) to a renamed `binary_lifecycle.py` so no JAR-named
+  module remains.
+- `commands/daemon.py`: delete `service install-jar`.
+- `migration/pregate.py`: drop the JAR reference.
+- Inverse-grep gate: `jar` is absent from `src/nexus` non-test launch/install surface
+  (mirrors the exhaustive-surface-audit discipline).
+
+### Phase 4 — Docs + deferred Windows bead
+
+- Update install/runbook docs to the native-only one-command story.
+- Windows-native is tracked by the existing `nexus-f9bgu` (RDR-157 release-N+1 follow-on:
+  native-image + relocatable PG + windows pgvector `.dll`); update it with the
+  install-binary/`.exe` platform-map + smoke-caveat scope rather than filing a new bead.
+  mac-amd64 remains explicitly out of scope.
+
+## Alternatives considered
+
+- **Keep the JAR as a JVM fallback.** Rejected: two acquisition stories and a fallback
+  that silently masks a missing/failed native binary; RDR-157 already chose native as
+  the artifact. A dev who wants the JAR can still `mvn package` and point
+  `NEXUS_SERVICE_BIN`-style at a local build behind a dev-only flag if ever needed —
+  but it leaves the shipped install path.
+- **Fold local cosign verify into `nexus-1jt17`.** Rejected: that bead is conexus-repo
+  docker-deploy scope; the local CLI consumer is a distinct surface in this repo.
+- **Embed PG in the binary (vs ship-alongside `.txz`).** Already decided ship-alongside
+  in RDR-157 CA-2 (nexus-vwvv5.11); not reopened.
+
+## Consequences
+
+- One launch artifact, one verified acquisition path; `pip install` + `nx init --service`
+  becomes a survivable local install for mac-arm64 + linux.
+- Supply-chain verification (sigstore-python signature + sha256, fail-closed) at the
+  point of install for both the binary and the PG bundle. Adds two deps: the `sigstore`
+  PyPI package (consumer) and a `--new-bundle-format` flag (publisher).
+- A dev who relied on `service install-jar` / `java -jar` loses it; mitigated by the
+  native binary being the supported artifact and a possible dev-only local-build flag.
+- Windows users remain unserved until the deferred bead; called out explicitly.
+
+## Open Questions
+
+- **RESOLVED (RF-161-2):** `install-binary` requires an **explicit `engine-service-v*`
+  tag** in Phase 1; "latest" resolution is deferred (no gh-release helper exists, and an
+  explicit tag avoids silent drift against the running schema, `/version` handshake from
+  pebfx.4). A namespace filter is mandatory when "latest" later lands.
+- One command for both artifacts (`install-binary` fetches binary + PG bundle) or two?
+  Leaning one verified seam with a `--pg-bundle/--no-pg-bundle` toggle. (Early-Phase-2
+  implementation decision, not a late refinement.)
+- **RESOLVED (RF-161-1):** verification uses **`sigstore-python`** (PyPI `sigstore`
+  package) consuming a publisher-emitted `.sigstore.json` — no 130 MB cosign binary, no
+  vendored-static-cosign bootstrap, offline-capable. The former "cosign as runtime dep"
+  question is closed in favor of the sigstore-python path.
+
+## Research Findings
+
+### RF-161-1 (CA-1, VERIFIED 2026-06-18, web + local): cosign verify on a clean host — FEASIBLE-WITH-CAVEATS, and it reshapes Phase 1
+
+The publisher signs keyless via cosign **v2.4.1** (`cosign-installer@1aa8e0f` = v3.7.0):
+`cosign sign-blob "$ASSET" --bundle "$ASSET.cosign.bundle"` with `id-token: write`
+(`engine-service-release.yml:252-279`). The self-verify uses the exact ref identity; the
+release notes (line 326) document the consumer regexp form.
+
+Two load-bearing facts:
+
+1. **The `.cosign.bundle` is the OLD JSON format → not fully offline-verifiable.** It
+   carries the signature, Fulcio cert, and a Rekor SET (an *inclusion promise*, not a
+   full Merkle proof). `cosign verify-blob --bundle` reaches `rekor.sigstore.dev:443` at
+   verify time. `--offline` verifies only the SET (weaker posture); `--insecure-ignore-tlog`
+   fails *open* (wrong direction). So a clean-host install needs outbound HTTPS to Rekor,
+   OR the publisher emits the new protobuf bundle for true offline verify.
+2. **`sigstore-python` (pure-Python, no 130 MB cosign binary) CANNOT consume the old
+   JSON bundle** — it speaks the protobuf `.sigstore.json` format only. The cosign CLI is
+   ~130 MB per platform and creates a bootstrap problem (need cosign to verify the
+   binary; need to trust cosign).
+
+**Design implication (new):** the low-friction consumer path for `pip install conexus`
+users is to add `--new-bundle-format` to the publisher's `sign-blob` (cosign v2.4.1
+supports it) so a `.sigstore.json` asset ships alongside `.cosign.bundle`; `install-binary`
+then verifies with **sigstore-python** (a normal PyPI dep, offline-capable, pinned
+cert-identity + issuer) and no 130 MB binary. This is a **publisher-side addition to
+Phase 1**, not just a consumer command. Literal consumer pin (issuer is exact-match,
+identity is regexp):
+`--certificate-oidc-issuer https://token.actions.githubusercontent.com`,
+`--certificate-identity-regexp 'https://github\.com/Hellblazer/nexus/\.github/workflows/engine-service-release\.yml@refs/tags/engine-service-v[0-9].*'`.
+Failure modes (no network, tool absent, identity mismatch, tampered asset) all fail
+**closed** except "tool not installed", which needs an explicit actionable message.
+Stored: T2 `nexus/rdr-161-ca1-cosign-verification-research`.
+
+### RF-161-2 (CA-2, VERIFIED 2026-06-18, local): asset-naming + tag-resolution contract is firm and reuses one platform helper
+
+Per-platform release assets (`engine-service-release.yml:91-99,344-345`), three files
+each: `nexus-service-<arch>`, `nexus-service-<arch>.sha256` (`<hex>  <name>`),
+`nexus-service-<arch>.cosign.bundle`, for `<arch>` ∈ {`linux-amd64`,`linux-arm64`,
+`mac-arm64`}. Release is non-draft/non-prerelease via `gh release create` on
+`push: tags: engine-service-v*` only (a separate namespace from the PyPI `v*` tags;
+`workflow_dispatch` uploads Actions artifacts only). Version = tag minus
+`engine-service-v` (`:149-156`), stamped into the pom (`:169`); the binary self-reports
+`app_version` (= tag suffix) at `/version` (`VersionHandler.java`, pebfx.4 handshake).
+**Reusable platform helper:** `src/nexus/db/pg_bundle.py:54-72 current_platform_tag()`
+emits the *same* `<target>` tokens the binary uses → `install-binary` builds the asset
+name as `f"nexus-service-{current_platform_tag()}"`, one convention for binary + PG
+bundle. No GitHub-release query helper exists (repo uses `urllib.request`, no `requests`);
+**Phase 1 requires an explicit TAG** (defer "latest `engine-service-v*`" resolution to
+avoid silent schema drift) with a mandatory `engine-service-v*` namespace filter.
+Well-known dest: `well_known_binary_path(config_dir)` = `<config_dir>/service/nexus-service`.
+
+### RF-161-3 (CA-3, VERIFIED 2026-06-18, local): PG-bundle round trip is sound; publish + a `_select_bundled_pg` search-dir bug are the only gaps
+
+`scripts/build_pg_bundle.sh` builds PG 17.5 + pg_trgm + pgvector 0.8.2 from source into
+a `bundle/` tree (`bin/include/lib/share` + a `.build_prefix` relocation marker), no
+sign/checksum. `ci.yml` packages it to `nexus-pg-<target>.txz` (top-level `bundle/`) but
+uploads it only as a **7-day Actions artifact** — **no release upload anywhere**
+(`engine-service-release.yml` ships only the service binary). Consumer `db/pg_bundle.py`
+expects exactly `nexus-pg-<current_platform_tag()>.txz`, extracts to
+`<config_dir>/pg-bundle/bundle/bin`, validates the four binaries + `.build_prefix`,
+idempotent via a `.nx_bundle_extracted` marker. Naming matches the build output exactly —
+no drift. Relocation is proven per-target by `tests/db/test_pg_bundle_relocation.py`
+(find_my_exec, glibc/minos floors, end-to-end `CREATE EXTENSION vector`).
+
+**Real bug found:** `_select_bundled_pg` (`init.py:396`) calls `ensure_pg_bundle` with no
+`search_dirs`, so the default `[Path(sys.executable).parent]` (the uv venv `bin/`) fires —
+**not** `<config_dir>/service/` where the acquire seam must place the `.txz` next to the
+binary. Fix: pass `search_dirs=[well_known_binary_path(config_dir).parent]` when the
+caller supplies none (preserving the `NEXUS_PG_BUNDLE` override and test-injectable
+param). Without it, a correctly-published+acquired bundle is never found.
+
+**Gaps Phase 2 must close:** (a) a release publish job running `build_pg_bundle.sh` per
+target → sign (same Sigstore/format decision as RF-161-1) + sha256 → `gh release upload`
+to the `engine-service-v*` tag; (b) the client acquire seam (fetch → sha256 → signature
+verify → atomic place at `<config_dir>/service/nexus-pg-<tag>.txz` + provenance sidecar);
+(c) the `_select_bundled_pg` search-dir fix. No test exercises a *published-then-downloaded*
+bundle (only locally-built) — Phase 2 should add one. linux-arm64 relocation deferred
+(nexus-xqk5r).
+
+### Implications for the Decision / Approach (FOLDED IN at gate, 2026-06-18)
+
+These were folded into the Decision/Approach/Open-Questions bodies during the Layer-3
+gate (substantive-critic, 2026-06-18); retained here as the audit trail:
+
+- Phase 1 gained a **publisher-side** sub-task: emit a protobuf `.sigstore.json` bundle so
+  the consumer verifies with sigstore-python (no 130 MB cosign dep, offline-capable).
+  Open Question 3 resolved in favor of sigstore-python.
+- Phase 1 **requires an explicit TAG** (no "latest" resolution yet); namespace filter
+  added when "latest" later lands. Open Question 1 resolved.
+- Phase 2 carries the `_select_bundled_pg` search-dir bug fix plus a published-bundle
+  round-trip test, alongside the publish job + acquire seam.
+- One platform convention (`current_platform_tag()`) spans binary + PG bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,11 @@ dependencies = [
     "python-pptx>=1.0.0",
     "opencv-python-headless>=4.0.0",
     "httpx>=0.27",
+    # RDR-161: pure-Python keyless-signature verification for
+    # `nx daemon service install-binary`. Replaces a ~130MB/platform cosign
+    # binary; verifies the new protobuf .sigstore.json bundle offline. 4.x and
+    # 3.x both expose Verifier.production(offline=...) + verify_artifact.
+    "sigstore>=3.0,<5",
     "mcp>=1.0",
     "fastapi>=0.115",
     "uvicorn[standard]",

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -1701,6 +1701,57 @@ def service_install_jar_cmd(
                "nx daemon service start")
 
 
+@service_group.command("install-binary")
+@click.argument("tag", required=True)
+@click.option(
+    "--config-dir",
+    "config_dir_str",
+    default=None,
+    help="Config directory override.",
+)
+def service_install_binary_cmd(tag: str, config_dir_str: str | None) -> None:
+    """Download, verify, and install the signed native nexus-service binary.
+
+    TAG is an EXPLICIT engine-service-v* release tag (e.g. engine-service-v0.1.3);
+    there is no "latest" resolution. The per-platform asset, its .sha256, and its
+    .sigstore.json bundle are fetched from the GitHub release, verified
+    (sha256 + keyless Sigstore signature, pinned to this repo's release workflow
+    identity), then placed at <config-dir>/service/nexus-service. Verification
+    fails closed: nothing is installed unless BOTH gates pass.
+    """
+    from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+    from nexus.daemon.binary_install import (
+        BinaryVerificationError,
+        asset_name,
+        install_binary,
+    )
+
+    try:
+        _nx_version = _pkg_version("conexus")
+    except PackageNotFoundError:
+        _nx_version = "unknown"
+
+    config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
+
+    click.echo(f"Resolving {asset_name()} from release {tag}…")
+    try:
+        dest, prov = install_binary(
+            tag, config_dir, installed_by=f"conexus {_nx_version}",
+        )
+    except BinaryVerificationError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
+
+    click.echo(f"Installed {prov['asset']} ({tag})")
+    click.echo(f"  -> {dest}")
+    click.echo(f"  version: {prov['version']}")
+    click.echo(f"  sha256:  {prov['sha256'][:16]}…")
+    click.echo(f"  signature: verified (keyless Sigstore, {prov['source_url']})")
+    click.echo("Restart the service to pick it up: nx daemon service stop && "
+               "nx daemon service start")
+
+
 @service_group.command("stop")
 @click.option(
     "--config-dir",

--- a/src/nexus/commands/init.py
+++ b/src/nexus/commands/init.py
@@ -337,6 +337,79 @@ def _provision_service_embedder_step(embedder: str | None) -> None:
         raise click.ClickException(str(exc)) from exc
 
 
+def _ensure_service_binary_step(config_dir: Path) -> bool:
+    """Acquire the signed native service binary if none is already installed.
+
+    RDR-161 P1: between PG provisioning and starting the service, place the
+    verified native binary so ``_start_service_step`` has something to exec.
+
+    Idempotent: a binary already resolvable at the well-known location (or via
+    ``NEXUS_SERVICE_BIN``) is a no-op — it is NOT re-downloaded. When no binary
+    is present, the explicit ``engine-service-v*`` tag comes from
+    ``resolve_service_tag`` (``NEXUS_SERVICE_TAG`` env, then the build-time
+    pin); there is no "latest" resolution (RF-161-2). When no tag is
+    configured, instruct the user to install one explicitly rather than
+    guessing a tag or downloading silently.
+
+    Returns ``True`` when a native binary is ready to exec, ``False`` when none
+    is available and none could be acquired (no tag configured). The caller
+    MUST NOT start the service on ``False`` — otherwise it falls through to the
+    legacy ``java -jar`` path, defeating the native-only intent (CRE C1).
+    Hard failures (broken ``NEXUS_SERVICE_BIN`` override, a configured tag that
+    fails verification) raise ``SystemExit``.
+    """
+    from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+    from nexus.daemon.binary_install import (
+        BinaryVerificationError,
+        install_binary,
+        resolve_service_tag,
+    )
+    from nexus.daemon.storage_service_daemon import (
+        StorageServiceStartError,
+        _find_service_binary,
+    )
+
+    try:
+        existing = _find_service_binary(config_dir)
+    except StorageServiceStartError as exc:
+        # e.g. NEXUS_SERVICE_BIN set-but-missing — surface, never auto-download
+        # over a deliberate (if broken) operator override.
+        click.echo(f"\nService binary check failed: {exc}", err=True)
+        raise SystemExit(1)
+
+    if existing is not None:
+        click.echo(f"  Native service binary already installed: {existing} (no download).")
+        return True
+
+    tag = resolve_service_tag()
+    if not tag:
+        click.echo(
+            "\n  No native service binary is installed and no service tag is "
+            "pinned for this build.\n"
+            "  Install one explicitly, then re-run `nx init --service`:\n"
+            "    nx daemon service install-binary engine-service-vX.Y.Z\n"
+            "  (or set NEXUS_SERVICE_TAG=engine-service-vX.Y.Z)."
+        )
+        return False
+
+    try:
+        _nx_version = _pkg_version("conexus")
+    except PackageNotFoundError:
+        _nx_version = "unknown"
+
+    click.echo(f"\nInstalling the native service binary ({tag}) …")
+    try:
+        dest, prov = install_binary(
+            tag, config_dir, installed_by=f"conexus {_nx_version}",
+        )
+    except BinaryVerificationError as exc:
+        click.echo(f"\nService binary install failed: {exc}", err=True)
+        raise SystemExit(1)
+    click.echo(f"  Installed {prov['asset']} -> {dest} (sha256+signature verified).")
+    return True
+
+
 def _start_service_step() -> None:
     """Start the local storage service and confirm it is serving (status green).
 
@@ -512,6 +585,21 @@ def init_cmd(embedder: str | None, assume_yes: bool, provision_service: bool) ->
         # collection with bge-768. Lock the embedder + provision the standard
         # ONNX it reads.
         _provision_service_embedder_step(embedder)
+        # RDR-161 P1: acquire the verified native binary before starting (no-op
+        # when one is already installed). Between PG provisioning and start so
+        # _start_service_step has a binary to exec. When no binary is available
+        # and none can be acquired (no tag configured), do NOT start: starting
+        # would fall through to the legacy `java -jar` path and defeat the
+        # native-only intent (CRE C1). PG is provisioned and the step printed an
+        # actionable install instruction; exit non-zero so the incomplete setup
+        # is not mistaken for a serving backend.
+        if not _ensure_service_binary_step(_config.nexus_config_dir()):
+            click.echo(
+                "\nService NOT started: no native binary available. Install one "
+                "(see above), then re-run `nx init --service` to finish.",
+                err=True,
+            )
+            raise SystemExit(1)
         # RDR-157 P4.1: collapse fresh-install -> serving. Start the service and
         # confirm status green before returning, so one command leaves the user
         # with a running backend (idempotent; safe to re-run). The interactive

--- a/src/nexus/daemon/binary_install.py
+++ b/src/nexus/daemon/binary_install.py
@@ -1,0 +1,445 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-161 P1: acquire + verify the signed native ``nexus-service`` binary.
+
+``nx daemon service install-binary TAG`` downloads the per-platform native
+binary published by the ``engine-service-release.yml`` workflow, verifies it,
+and places it at the well-known location the supervisor execs.
+
+Two independent gates, both fail-closed (RF-161-1, fail-closed matrix in T2
+``nexus_rdr/161-research``):
+
+1. **sha256** — the asset's digest must equal the published ``<asset>.sha256``
+   sidecar. Catches a corrupt or truncated download before anything else.
+2. **signature** — the published ``<asset>.sigstore.json`` (new protobuf
+   bundle, emitted by the publisher half nexus-ltjws) is verified with
+   sigstore-python, with the OIDC issuer pinned exactly to GitHub Actions and
+   the signing-certificate identity matched against the RF-161-1 regexp.
+
+Verification NEVER silently skips. A missing bundle, a bad signature, an
+identity that does not match the pin, an unreachable transparency log, or an
+absent ``sigstore`` package all raise :class:`BinaryVerificationError` and the
+binary is not installed (feedback_no_silent_fallbacks_for_correctness).
+
+This module deliberately consumes NO cosign binary (~130MB/platform); the new
+protobuf bundle is verifiable offline by the pure-Python ``sigstore`` package.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+import structlog
+
+from nexus.daemon.jar_lifecycle import well_known_binary_path
+from nexus.db.pg_bundle import current_platform_tag
+
+_log = structlog.get_logger(__name__)
+
+__all__ = [
+    "BinaryVerificationError",
+    "CERT_IDENTITY_REGEXP",
+    "CERT_OIDC_ISSUER",
+    "TAG_NAMESPACE_PREFIX",
+    "asset_name",
+    "binary_sidecar_path",
+    "compute_sha256",
+    "identity_matches",
+    "install_binary",
+    "release_asset_url",
+    "resolve_service_tag",
+    "verify_sha256",
+    "verify_signature",
+    "PINNED_SERVICE_TAG",
+    "SERVICE_TAG_ENV",
+]
+
+#: Exact OIDC issuer for GitHub Actions keyless signing (RF-161-1 pin).
+CERT_OIDC_ISSUER = "https://token.actions.githubusercontent.com"
+
+#: Signing-certificate identity pin (RF-161-1). Anchored to this repo, the exact
+#: release workflow file, and the ``engine-service-v<numeric>`` tag namespace.
+#: ``Identity`` in sigstore-python is exact-match only, so identity is matched
+#: against this regexp by :class:`_RegexpIdentityPolicy` instead.
+CERT_IDENTITY_REGEXP = (
+    r"https://github\.com/Hellblazer/nexus/\.github/workflows/"
+    r"engine-service-release\.yml@refs/tags/engine-service-v[0-9].*"
+)
+
+#: The native-binary release tag namespace. Phase 1 requires an EXPLICIT tag in
+#: this namespace — no "latest" resolution (RF-161-2). Kept as a constant so the
+#: future "latest" helper filters on the same prefix.
+TAG_NAMESPACE_PREFIX = "engine-service-v"
+
+#: The ``engine-service-v*`` tag this conexus build is compatible with. A
+#: BUILD-TIME PIN (bumped per release as the engine-service version advances),
+#: NOT a "latest" lookup — it avoids silent schema drift against the running
+#: service (RF-161-2). ``None`` until the first real ``engine-service-v*``
+#: release exists; while it is ``None``, ``nx init --service`` cannot
+#: auto-install and instructs the user to pass an explicit tag.
+PINNED_SERVICE_TAG: str | None = None
+
+#: Env override for the service tag (operator / CI). Takes precedence over the
+#: build-time pin. Still an explicit tag — no "latest" semantics.
+SERVICE_TAG_ENV = "NEXUS_SERVICE_TAG"
+
+_REPO = "Hellblazer/nexus"
+_RELEASE_DOWNLOAD_BASE = f"https://github.com/{_REPO}/releases/download"
+_BINARY_SIDECAR_NAME = "nexus-service.meta.json"
+_DOWNLOAD_TIMEOUT_S = 120.0
+_HASH_BLOCK = 1 << 20
+
+
+class BinaryVerificationError(Exception):
+    """A verification gate failed. The binary must not be installed."""
+
+
+# ── sha256 gate ─────────────────────────────────────────────────────────────
+
+
+def compute_sha256(path: Path) -> str:
+    """Streaming sha256 hex digest of *path*."""
+    sha = hashlib.sha256()
+    with path.open("rb") as fh:
+        for block in iter(lambda: fh.read(_HASH_BLOCK), b""):
+            sha.update(block)
+    return sha.hexdigest()
+
+
+# A ``sha256sum`` / ``shasum -a 256`` line: 64 hex chars, separator, filename.
+_SHA256_LINE_RE = re.compile(r"^([0-9a-fA-F]{64})\b")
+
+
+def verify_sha256(asset_path: Path, sha256_sidecar: Path) -> str:
+    """Verify *asset_path* against the published ``<asset>.sha256`` sidecar.
+
+    Returns the verified lowercase hex digest. Raises
+    :class:`BinaryVerificationError` (fail closed) when the asset is missing,
+    the sidecar is missing or malformed, or the digests disagree.
+    """
+    if not asset_path.is_file():
+        raise BinaryVerificationError(
+            f"asset {asset_path} is missing; cannot verify its sha256"
+        )
+    if not sha256_sidecar.is_file():
+        raise BinaryVerificationError(
+            f"sha256 sidecar {sha256_sidecar} is missing; refusing to install "
+            "an unverified binary"
+        )
+    raw = sha256_sidecar.read_text(errors="replace").strip()
+    m = _SHA256_LINE_RE.match(raw)
+    if not m:
+        raise BinaryVerificationError(
+            f"sha256 sidecar {sha256_sidecar} is malformed "
+            f"(expected '<64-hex>  <filename>', got {raw[:80]!r})"
+        )
+    expected = m.group(1).lower()
+    actual = compute_sha256(asset_path)
+    if actual != expected:
+        raise BinaryVerificationError(
+            f"sha256 mismatch for {asset_path.name}: published {expected}, "
+            f"computed {actual}. The download is corrupt or tampered; not "
+            "installing."
+        )
+    return actual
+
+
+# ── certificate-identity regexp gate ────────────────────────────────────────
+
+_IDENTITY_RE = re.compile(CERT_IDENTITY_REGEXP)
+
+
+def identity_matches(san: str, *, pattern: str = CERT_IDENTITY_REGEXP) -> bool:
+    """True when a signing-cert SAN matches the pinned release identity.
+
+    Whole-string match (``re.fullmatch``): the pin begins at ``https://github.com``
+    so a forked repo, a branch ref, a different workflow file, the PyPI ``v*``
+    tag namespace, or a non-numeric version segment all fail. ``fullmatch`` (vs
+    ``match``) also rejects a SAN with trailing junk after a newline — ``.*``
+    does not cross ``\\n`` — closing a defense-in-depth gap even though the SAN
+    is GitHub-OIDC-controlled, not attacker-controlled.
+    """
+    compiled = _IDENTITY_RE if pattern == CERT_IDENTITY_REGEXP else re.compile(pattern)
+    return compiled.fullmatch(san) is not None
+
+
+# ── signature gate ──────────────────────────────────────────────────────────
+
+
+class _SignatureChecker(Protocol):
+    """Seam for the cryptographic verify (constructor-injected in tests)."""
+
+    def check(
+        self, *, asset_bytes: bytes, bundle_bytes: bytes, identity_regexp: str, issuer: str
+    ) -> None:
+        """Raise on any verification failure; return ``None`` on success."""
+
+
+class _SigstoreChecker:
+    """Default checker: verifies the protobuf bundle with sigstore-python,
+    offline, pinning the issuer (exact) and the identity (regexp)."""
+
+    def check(
+        self, *, asset_bytes: bytes, bundle_bytes: bytes, identity_regexp: str, issuer: str
+    ) -> None:
+        try:
+            from sigstore.models import Bundle
+            from sigstore.verify import Verifier
+            from sigstore.verify.policy import AllOf, AnyOf, OIDCIssuer, OIDCIssuerV2
+        except ImportError as exc:  # actionable, never a bare ModuleNotFoundError
+            raise BinaryVerificationError(
+                "signature verification requires the 'sigstore' package "
+                "(pip install sigstore). Refusing to install an unverified "
+                "binary; do not bypass verification."
+            ) from exc
+
+        bundle = Bundle.from_json(bundle_bytes)
+        # offline=False: install-binary is inherently online (it just downloaded
+        # the asset), so let sigstore fetch/refresh its TUF trust root if the
+        # local cache is cold — a fresh `pip install` has no ~/.cache/sigstore.
+        # The protobuf bundle still carries the Rekor inclusion PROOF, so
+        # verify_artifact needs no Rekor round-trip regardless of this flag.
+        verifier = Verifier.production(offline=False)
+        # Issuer extension exists as both the v1 OID (1.3.6.1.4.1.57264.1.1) and
+        # the DER-encoded v2 (…1.8) in current GitHub Fulcio certs; accept either
+        # so a CA rotation that drops v1 does not break every install (CRE H1).
+        policy = AllOf(
+            [
+                AnyOf([OIDCIssuer(issuer), OIDCIssuerV2(issuer)]),
+                _RegexpIdentityPolicy(identity_regexp),
+            ]
+        )
+        # Raises sigstore VerificationError on any failure (bad sig, identity
+        # mismatch, issuer mismatch, tlog/inclusion-proof failure).
+        verifier.verify_artifact(asset_bytes, bundle, policy)
+
+
+class _RegexpIdentityPolicy:
+    """sigstore VerificationPolicy matching the cert SAN against a regexp.
+
+    sigstore-python's stock ``Identity`` policy is exact-match only; the
+    RDR-161 contract pins a cert-identity *regexp*, so this custom policy
+    extracts the URI SAN and applies :func:`identity_matches`.
+    """
+
+    def __init__(self, pattern: str) -> None:
+        self._pattern = pattern
+
+    def verify(self, cert) -> None:  # noqa: ANN001 — cryptography x509 cert
+        from cryptography import x509
+        from sigstore.errors import VerificationError
+
+        try:
+            san = cert.extensions.get_extension_for_class(
+                x509.SubjectAlternativeName
+            ).value
+            uris = san.get_values_for_type(x509.UniformResourceIdentifier)
+        except x509.ExtensionNotFound as exc:
+            raise VerificationError(
+                "signing certificate has no SubjectAlternativeName"
+            ) from exc
+        if not any(identity_matches(u, pattern=self._pattern) for u in uris):
+            raise VerificationError(
+                f"signing-cert identity {uris!r} does not match the pinned "
+                f"release identity {self._pattern!r}"
+            )
+
+
+def verify_signature(
+    asset_path: Path,
+    bundle_path: Path,
+    *,
+    identity_regexp: str = CERT_IDENTITY_REGEXP,
+    issuer: str = CERT_OIDC_ISSUER,
+    checker: _SignatureChecker | None = None,
+) -> None:
+    """Verify *asset_path*'s Sigstore signature from *bundle_path*.
+
+    Fail-closed: a missing bundle/asset is rejected before the checker is even
+    consulted, and any exception the checker raises becomes a
+    :class:`BinaryVerificationError`.
+    """
+    if not bundle_path.is_file():
+        raise BinaryVerificationError(
+            f"signature bundle {bundle_path} is missing; refusing to install "
+            "an unverified binary"
+        )
+    if not asset_path.is_file():
+        raise BinaryVerificationError(
+            f"asset {asset_path} is missing; cannot verify its signature"
+        )
+    chk: _SignatureChecker = checker if checker is not None else _SigstoreChecker()
+    try:
+        chk.check(
+            asset_bytes=asset_path.read_bytes(),
+            bundle_bytes=bundle_path.read_bytes(),
+            identity_regexp=identity_regexp,
+            issuer=issuer,
+        )
+    except BinaryVerificationError:
+        raise  # already actionable
+    except Exception as exc:  # fail closed on anything else the checker throws
+        raise BinaryVerificationError(
+            f"signature verification failed for {asset_path.name}: {exc}"
+        ) from exc
+
+
+# ── download + atomic place ─────────────────────────────────────────────────
+
+
+def asset_name() -> str:
+    """Native-binary asset name for this host (``nexus-service-<platform>``).
+
+    Same ``<target>`` tokens as the PG bundle — reuses
+    :func:`nexus.db.pg_bundle.current_platform_tag`.
+    """
+    return f"nexus-service-{current_platform_tag()}"
+
+
+def release_asset_url(tag: str, name: str) -> str:
+    """GitHub release download URL for *name* at *tag*."""
+    return f"{_RELEASE_DOWNLOAD_BASE}/{tag}/{name}"
+
+
+def resolve_service_tag() -> str | None:
+    """The explicit ``engine-service-v*`` tag to install, or ``None``.
+
+    Precedence: ``NEXUS_SERVICE_TAG`` env override, then the build-time
+    :data:`PINNED_SERVICE_TAG`. Never resolves "latest" (RF-161-2). ``None``
+    means no tag is configured and the caller must ask the user for one.
+    """
+    env = os.environ.get(SERVICE_TAG_ENV, "").strip()
+    return env or PINNED_SERVICE_TAG
+
+
+def binary_sidecar_path(config_dir: Path) -> Path:
+    """Provenance sidecar next to the well-known native binary."""
+    return config_dir / "service" / _BINARY_SIDECAR_NAME
+
+
+def _validate_tag(tag: str) -> None:
+    if not tag.startswith(TAG_NAMESPACE_PREFIX):
+        raise BinaryVerificationError(
+            f"refusing tag {tag!r}: native-binary releases live in the "
+            f"{TAG_NAMESPACE_PREFIX!r} namespace. Pass an explicit tag, "
+            f"e.g. {TAG_NAMESPACE_PREFIX}0.1.3 (no 'latest' resolution in "
+            "this release)."
+        )
+
+
+def _download(url: str, dest: Path, *, timeout: float = _DOWNLOAD_TIMEOUT_S) -> None:
+    """Download *url* to *dest* (stdlib urllib — the repo has no ``requests``)."""
+    req = urllib.request.Request(url, headers={"User-Agent": "conexus-install-binary"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp, dest.open("wb") as out:
+            for block in iter(lambda: resp.read(_HASH_BLOCK), b""):
+                out.write(block)
+    except Exception as exc:  # network, 404 for a bad tag/platform, timeout
+        raise BinaryVerificationError(
+            f"failed to download {url}: {exc}. Check the tag exists and the "
+            "asset was published for this platform."
+        ) from exc
+
+
+def install_binary(
+    tag: str,
+    config_dir: Path,
+    *,
+    installed_by: str = "",
+    checker: _SignatureChecker | None = None,
+    download_dir: Path | None = None,
+) -> tuple[Path, dict]:
+    """Download, verify, and atomically place the native binary for *tag*.
+
+    Returns ``(installed_path, provenance)``. Raises
+    :class:`BinaryVerificationError` (fail closed) on any download or
+    verification failure — the well-known location is only ever updated with a
+    binary that passed BOTH gates.
+    """
+    _validate_tag(tag)
+    name = asset_name()
+    asset_url = release_asset_url(tag, name)
+
+    with tempfile.TemporaryDirectory(
+        dir=str(download_dir) if download_dir else None, prefix="nx_install_binary_"
+    ) as td:
+        tmp = Path(td)
+        asset = tmp / name
+        sha_sidecar = tmp / f"{name}.sha256"
+        bundle = tmp / f"{name}.sigstore.json"
+
+        _download(asset_url, asset)
+        _download(f"{asset_url}.sha256", sha_sidecar)
+        _download(f"{asset_url}.sigstore.json", bundle)
+
+        # Gate 1: cheap integrity check first — a corrupt download fails here
+        # before the (heavier) crypto verify.
+        digest = verify_sha256(asset, sha_sidecar)
+        # Gate 2: provenance.
+        verify_signature(asset, bundle, checker=checker)
+
+        dest = well_known_binary_path(config_dir)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        tmp_fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=".binary_install_")
+        try:
+            with os.fdopen(tmp_fd, "wb") as out, asset.open("rb") as src:
+                for block in iter(lambda: src.read(_HASH_BLOCK), b""):
+                    out.write(block)
+            os.chmod(tmp_name, 0o755)
+            os.replace(tmp_name, dest)
+        except Exception:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+
+    provenance = {
+        # _validate_tag guarantees the prefix; strip it to the bare version
+        # (engine-service-v0.1.3 -> 0.1.3).
+        "version": tag[len(TAG_NAMESPACE_PREFIX) :],
+        "tag": tag,
+        "asset": name,
+        "sha256": digest,
+        "source_url": asset_url,
+        "installed_at": datetime.now(UTC).isoformat(),
+        "installed_by": installed_by,
+    }
+    try:
+        _write_sidecar(config_dir, provenance)
+    except OSError as exc:
+        # The binary is already verified AND atomically in place; the sidecar is
+        # informational provenance, not a gate. Don't turn a disk-full/perms
+        # error into a traceback over a successful install (CRE M1).
+        _log.warning("service_binary_sidecar_write_failed", error=str(exc))
+
+    _log.info(
+        "service_binary_installed",
+        dest=str(dest),
+        tag=tag,
+        asset=name,
+        sha256=digest[:12],
+    )
+    return dest, provenance
+
+
+def _write_sidecar(config_dir: Path, provenance: dict) -> None:
+    dest = binary_sidecar_path(config_dir)
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=".binary_meta_")
+    try:
+        with os.fdopen(tmp_fd, "w") as out:
+            json.dump(provenance, out, indent=2)
+        os.replace(tmp_name, dest)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise

--- a/tests/daemon/test_binary_install_verify.py
+++ b/tests/daemon/test_binary_install_verify.py
@@ -1,0 +1,350 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-161 P1 (TDD): verification suite for ``nx daemon service install-binary``.
+
+Tests are written BEFORE the consumer implementation (bead nexus-epz8h precedes
+nexus-ywqza). Until ``nexus.daemon.binary_install`` lands they fail at import;
+that is the intended TDD-RED state.
+
+The verification contract (RF-161-1) the install path MUST honour:
+
+1. **sha256 gate** — the downloaded asset's sha256 must equal the published
+   ``<asset>.sha256`` sidecar. Mismatch / malformed / missing → fail closed.
+2. **signature gate** — the published ``<asset>.sigstore.json`` (new protobuf
+   bundle, emitted by the publisher half nexus-ltjws) is verified with
+   sigstore-python. The OIDC issuer is pinned exactly to GitHub Actions and the
+   signing-cert identity is matched against the literal RF-161-1 regexp. Crypto
+   failure, identity mismatch, issuer mismatch, missing bundle, missing
+   sigstore dependency, or no network all → fail closed. Verification NEVER
+   silently skips (feedback_no_silent_fallbacks_for_correctness).
+
+What is REAL here vs seam-injected, and why (settled via the fail-closed
+matrix, T2 nexus_rdr/161-research):
+
+* sha256 + identity-regexp + the pinned constants + the missing-dependency
+  message are tested with real fixtures and real regex — no mocks.
+* the cryptographic verify itself is sigstore-python's responsibility, not
+  ours to re-test. Our wiring (forwarding the pinned issuer + identity regexp,
+  and wrapping every failure as a fail-closed error) is tested by injecting a
+  fake checker through the ``checker`` seam (constructor injection — project
+  style). This lets the fail-closed/pass wiring be covered WITHOUT sigstore
+  installed and WITHOUT a real release artifact.
+* an end-to-end real verify against a genuine published ``.sigstore.json`` is
+  deferred to an integration test (skip-with-reason) because no real
+  ``engine-service-v*`` release artifact exists yet (RDR-155 P4b freeze
+  window). The gap is declared out loud rather than papered over with a mock
+  pretending to be a real verify.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Direct import (NOT importorskip): the P1 publisher (nexus-ltjws), this TDD
+# suite (nexus-epz8h), and the consumer (nexus-ywqza) land together on one
+# branch behind one stacked review. Until ``binary_install`` exists this suite
+# is TDD-RED by collection error — the intended signal. A module-wide skip
+# would instead let CI stay green-by-skip if the consumer never lands, hiding
+# the gap (feedback_no_silent_fallbacks_for_correctness).
+from nexus.daemon import binary_install as binstall  # noqa: E402
+
+_SIGSTORE_INSTALLED = importlib.util.find_spec("sigstore") is not None
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────
+
+
+def _write_asset(tmp_path: Path, content: bytes = b"native-binary-bytes\n") -> Path:
+    asset = tmp_path / "nexus-service-linux-amd64"
+    asset.write_bytes(content)
+    return asset
+
+
+def _sha256_sidecar(asset: Path) -> Path:
+    """A well-formed ``<hex>  <filename>`` sidecar matching *asset*, as the
+    publisher's ``sha256sum`` / ``shasum -a 256`` emits it (two-space sep)."""
+    digest = hashlib.sha256(asset.read_bytes()).hexdigest()
+    sidecar = asset.with_suffix(asset.suffix + ".sha256")
+    sidecar.write_text(f"{digest}  {asset.name}\n")
+    return sidecar
+
+
+# ── pinned constants (RF-161-1 literal pin — lock as ==) ────────────────────
+
+
+def test_oidc_issuer_pinned_exactly():
+    assert binstall.CERT_OIDC_ISSUER == "https://token.actions.githubusercontent.com"
+
+
+def test_identity_regexp_is_the_rf161_1_pin():
+    # The literal pin from RF-161-1. Anchored to Hellblazer/nexus, the exact
+    # workflow file, the engine-service-v* tag namespace, numeric version only.
+    assert binstall.CERT_IDENTITY_REGEXP == (
+        r"https://github\.com/Hellblazer/nexus/\.github/workflows/"
+        r"engine-service-release\.yml@refs/tags/engine-service-v[0-9].*"
+    )
+
+
+# ── sha256 gate (fully real) ────────────────────────────────────────────────
+
+
+def test_compute_sha256_matches_hashlib(tmp_path):
+    asset = _write_asset(tmp_path)
+    assert binstall.compute_sha256(asset) == hashlib.sha256(asset.read_bytes()).hexdigest()
+
+
+def test_verify_sha256_accepts_matching_sidecar(tmp_path):
+    asset = _write_asset(tmp_path)
+    sidecar = _sha256_sidecar(asset)
+    # returns the verified hex digest, does not raise
+    assert binstall.verify_sha256(asset, sidecar) == hashlib.sha256(
+        asset.read_bytes()
+    ).hexdigest()
+
+
+def test_verify_sha256_rejects_tampered_asset(tmp_path):
+    asset = _write_asset(tmp_path, b"original\n")
+    sidecar = _sha256_sidecar(asset)
+    asset.write_bytes(b"tampered\n")  # change bytes after the sidecar was written
+    with pytest.raises(binstall.BinaryVerificationError):
+        binstall.verify_sha256(asset, sidecar)
+
+
+def test_verify_sha256_rejects_malformed_sidecar(tmp_path):
+    asset = _write_asset(tmp_path)
+    sidecar = asset.with_suffix(asset.suffix + ".sha256")
+    sidecar.write_text("not-a-valid-sha256-line\n")
+    with pytest.raises(binstall.BinaryVerificationError):
+        binstall.verify_sha256(asset, sidecar)
+
+
+def test_verify_sha256_rejects_missing_sidecar(tmp_path):
+    asset = _write_asset(tmp_path)
+    sidecar = asset.with_suffix(asset.suffix + ".sha256")  # never created
+    with pytest.raises(binstall.BinaryVerificationError):
+        binstall.verify_sha256(asset, sidecar)
+
+
+def test_verify_sha256_rejects_missing_asset(tmp_path):
+    asset = tmp_path / "nexus-service-linux-amd64"  # never created
+    sidecar = tmp_path / "nexus-service-linux-amd64.sha256"
+    sidecar.write_text(f"{'0' * 64}  {asset.name}\n")
+    with pytest.raises(binstall.BinaryVerificationError):
+        binstall.verify_sha256(asset, sidecar)
+
+
+# ── cert-identity regexp (fully real, the literal RF-161-1 pin) ─────────────
+
+_VALID_TAG_SAN = (
+    "https://github.com/Hellblazer/nexus/.github/workflows/"
+    "engine-service-release.yml@refs/tags/engine-service-v0.1.3"
+)
+
+
+def test_identity_matches_valid_release_tag():
+    assert binstall.identity_matches(_VALID_TAG_SAN) is True
+
+
+@pytest.mark.parametrize(
+    "san",
+    [
+        # a fork of the repo
+        "https://github.com/attacker/nexus/.github/workflows/"
+        "engine-service-release.yml@refs/tags/engine-service-v0.1.3",
+        # a branch ref instead of a tag ref
+        "https://github.com/Hellblazer/nexus/.github/workflows/"
+        "engine-service-release.yml@refs/heads/main",
+        # a different workflow file in the same repo
+        "https://github.com/Hellblazer/nexus/.github/workflows/"
+        "release.yml@refs/tags/engine-service-v0.1.3",
+        # the PyPI tag namespace, not engine-service-v*
+        "https://github.com/Hellblazer/nexus/.github/workflows/"
+        "engine-service-release.yml@refs/tags/v0.1.3",
+        # non-numeric version segment (the pin requires v[0-9])
+        "https://github.com/Hellblazer/nexus/.github/workflows/"
+        "engine-service-release.yml@refs/tags/engine-service-vX",
+        "",
+        # trailing junk after a newline — fullmatch must reject (`.*` does not
+        # cross \n), where re.match would have accepted the leading prefix.
+        _VALID_TAG_SAN + "\nevil",
+    ],
+)
+def test_identity_rejects_non_release_identities(san):
+    assert binstall.identity_matches(san) is False
+
+
+# ── tag-namespace guard (fully real) ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad_tag",
+    ["v0.1.3", "latest", "engine-service-0.1.3", "0.1.3", "release-v0.1.3", ""],
+)
+def test_validate_tag_rejects_non_namespace(bad_tag, tmp_path):
+    # _validate_tag fires before any network access — install_binary must fail
+    # closed on a tag outside the engine-service-v* namespace.
+    with pytest.raises(binstall.BinaryVerificationError):
+        binstall.install_binary(bad_tag, tmp_path)
+
+
+def test_validate_tag_accepts_namespace_then_reaches_download(tmp_path, monkeypatch):
+    # A well-formed tag passes the namespace guard and proceeds to the download
+    # step. Stub _download (no network) to fail closed; assert it was reached
+    # and that no binary is placed.
+    seen = {"called": False}
+
+    def _stub_download(url, dest, *, timeout=0):
+        seen["called"] = True
+        raise binstall.BinaryVerificationError("simulated download failure")
+
+    monkeypatch.setattr(binstall, "_download", _stub_download)
+    with pytest.raises(binstall.BinaryVerificationError):
+        binstall.install_binary(
+            "engine-service-v0.1.3", tmp_path, download_dir=tmp_path
+        )
+    assert seen["called"] is True  # namespace guard passed, download attempted
+    assert not (tmp_path / "service" / "nexus-service").exists()
+
+
+# ── signature gate: missing sigstore dependency (real) ──────────────────────
+
+
+@pytest.mark.skipif(
+    _SIGSTORE_INSTALLED,
+    reason="sigstore is installed; the missing-dependency path is unreachable here",
+)
+def test_verify_signature_missing_dependency_is_actionable(tmp_path):
+    asset = _write_asset(tmp_path)
+    bundle = asset.with_suffix(asset.suffix + ".sigstore.json")
+    bundle.write_text("{}")  # content irrelevant; the import fails first
+    with pytest.raises(binstall.BinaryVerificationError) as exc:
+        binstall.verify_signature(asset, bundle)
+    msg = str(exc.value).lower()
+    # Actionable: names the package, NOT a bare ModuleNotFoundError, and does
+    # not suggest skipping verification.
+    assert "sigstore" in msg
+    assert "skip" not in msg
+
+
+# ── signature gate: wiring, via the injected checker seam ───────────────────
+
+
+class _FakeChecker:
+    """Stands in for the sigstore-backed checker. Records what the install
+    path forwarded, and either passes or raises on demand."""
+
+    def __init__(self, *, raises: Exception | None = None) -> None:
+        self._raises = raises
+        self.calls: list[dict] = []
+
+    def check(self, *, asset_bytes, bundle_bytes, identity_regexp, issuer) -> None:
+        self.calls.append(
+            {
+                "asset_bytes": asset_bytes,
+                "bundle_bytes": bundle_bytes,
+                "identity_regexp": identity_regexp,
+                "issuer": issuer,
+            }
+        )
+        if self._raises is not None:
+            raise self._raises
+
+
+def test_verify_signature_forwards_pinned_issuer_and_identity(tmp_path):
+    asset = _write_asset(tmp_path)
+    bundle = asset.with_suffix(asset.suffix + ".sigstore.json")
+    bundle.write_text('{"protobuf":"bundle"}')
+    checker = _FakeChecker()
+    binstall.verify_signature(asset, bundle, checker=checker)
+    assert len(checker.calls) == 1
+    call = checker.calls[0]
+    # The pins are forwarded verbatim — not silently relaxed.
+    assert call["identity_regexp"] == binstall.CERT_IDENTITY_REGEXP
+    assert call["issuer"] == binstall.CERT_OIDC_ISSUER
+    assert call["asset_bytes"] == asset.read_bytes()
+
+
+def test_verify_signature_fails_closed_when_checker_raises(tmp_path):
+    asset = _write_asset(tmp_path)
+    bundle = asset.with_suffix(asset.suffix + ".sigstore.json")
+    bundle.write_text('{"protobuf":"bundle"}')
+    checker = _FakeChecker(raises=ValueError("signature does not verify"))
+    with pytest.raises(binstall.BinaryVerificationError):
+        binstall.verify_signature(asset, bundle, checker=checker)
+
+
+def test_verify_signature_fails_closed_on_missing_bundle(tmp_path):
+    asset = _write_asset(tmp_path)
+    bundle = asset.with_suffix(asset.suffix + ".sigstore.json")  # never created
+    checker = _FakeChecker()
+    with pytest.raises(binstall.BinaryVerificationError):
+        binstall.verify_signature(asset, bundle, checker=checker)
+    # Fail-closed BEFORE the checker is consulted: a missing bundle is rejected
+    # outright, never treated as "nothing to verify".
+    assert checker.calls == []
+
+
+# ── CLI command: nx daemon service install-binary (isolated) ────────────────
+
+
+def test_cli_install_binary_happy_path(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+
+    from nexus.commands.daemon import service_install_binary_cmd
+
+    def _fake_install(tag, config_dir, *, installed_by=""):
+        return config_dir / "service" / "nexus-service", {
+            "asset": "nexus-service-linux-amd64",
+            "version": "0.1.3",
+            "sha256": "a" * 64,
+            "source_url": "https://example/nexus-service-linux-amd64",
+        }
+
+    monkeypatch.setattr(binstall, "install_binary", _fake_install)
+    result = CliRunner().invoke(
+        service_install_binary_cmd,
+        ["engine-service-v0.1.3", "--config-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "verified" in result.output.lower()
+
+
+def test_cli_install_binary_fails_closed_exit_2(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+
+    from nexus.commands.daemon import service_install_binary_cmd
+
+    def _fake_install(tag, config_dir, *, installed_by=""):
+        raise binstall.BinaryVerificationError("sha256 mismatch")
+
+    monkeypatch.setattr(binstall, "install_binary", _fake_install)
+    result = CliRunner().invoke(
+        service_install_binary_cmd,
+        ["engine-service-v0.1.3", "--config-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 2
+    assert "sha256 mismatch" in result.output
+
+
+# ── end-to-end real verify (deferred, declared out loud) ────────────────────
+
+_REAL_FIXTURE = (
+    Path(__file__).parent / "fixtures" / "rdr161" / "nexus-service-linux-amd64.sigstore.json"
+)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not (_SIGSTORE_INSTALLED and _REAL_FIXTURE.is_file()),
+    reason=(
+        "no genuine engine-service-v* .sigstore.json fixture exists yet "
+        "(produced by the publisher nexus-ltjws at a real release; blocked by "
+        "the RDR-155 P4b freeze window). Capture one from the first signed "
+        "release and drop it at tests/daemon/fixtures/rdr161/ to arm this."
+    ),
+)
+def test_verify_signature_real_bundle_end_to_end():
+    asset = _REAL_FIXTURE.with_suffix("")  # the binary sits beside the bundle
+    binstall.verify_signature(asset, _REAL_FIXTURE)  # real sigstore verify, no mock

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -734,6 +734,12 @@ class TestServiceLocalEmbedder:
         # so the embedder-focused tests stay hermetic (start coverage is in
         # TestServiceStartStep below).
         monkeypatch.setattr("nexus.commands.init._start_service_step", lambda: None)
+        # RDR-161 P1: init now gates start on a resolvable native binary. These
+        # tests cover the embedder path, not binary acquisition (see
+        # tests/test_init_service_binary.py), so report the binary as ready.
+        monkeypatch.setattr(
+            "nexus.commands.init._ensure_service_binary_step", lambda cd: True
+        )
         calls: list[str] = []
         monkeypatch.setattr(
             "nexus.db.service_bge_model.fetch_service_bge_onnx",
@@ -835,12 +841,16 @@ class TestServiceStartStep:
             lambda **kw: (order.append("embed"), Path("/fake/onnx"))[1],
         )
         monkeypatch.setattr(
+            "nexus.commands.init._ensure_service_binary_step",
+            lambda cd: (order.append("binary"), True)[1],
+        )
+        monkeypatch.setattr(
             "nexus.commands.init._start_service_step",
             lambda: order.append("start"),
         )
         result = CliRunner().invoke(init_cmd, ["--service"])
         assert result.exit_code == 0, result.output
-        assert order == ["pg", "embed", "start"]
+        assert order == ["pg", "embed", "binary", "start"]
 
     def test_auto_service_local_wires_start(
         self, cfg_dir: Path, monkeypatch: pytest.MonkeyPatch
@@ -859,8 +869,12 @@ class TestServiceStartStep:
             lambda **kw: (order.append("embed"), Path("/fake/onnx"))[1],
         )
         monkeypatch.setattr(
+            "nexus.commands.init._ensure_service_binary_step",
+            lambda cd: (order.append("binary"), True)[1],
+        )
+        monkeypatch.setattr(
             "nexus.commands.init._start_service_step", lambda: order.append("start")
         )
         result = CliRunner().invoke(init_cmd, [])
         assert result.exit_code == 0, result.output
-        assert order == ["pg", "embed", "start"]
+        assert order == ["pg", "embed", "binary", "start"]

--- a/tests/test_init_service_binary.py
+++ b/tests/test_init_service_binary.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-161 P1: `nx init --service` wiring of the native-binary acquisition step.
+
+Tests :func:`nexus.commands.init._ensure_service_binary_step` in isolation — a
+throwaway ``config_dir`` (``tmp_path``), ``install_binary`` monkeypatched so no
+network call and no live daemon/state is touched (mem:
+feedback_dont_break_live_nexus_install). The full ``init_cmd`` is not driven
+here: it provisions Postgres and starts the service, which this bead's wiring
+sits between.
+
+Contract (RDR-161 §Approach P1, third bullet):
+- a present, resolvable binary is a NO-OP (never re-downloaded);
+- when absent, an explicit ``engine-service-v*`` tag (env / build pin) drives
+  ``install_binary`` — no "latest" resolution (RF-161-2);
+- when absent AND no tag is configured, the step instructs the user to install
+  one explicitly and does NOT fail init or guess a tag;
+- a broken ``NEXUS_SERVICE_BIN`` override is surfaced, never silently
+  downloaded over.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from nexus.commands import init as init_mod
+from nexus.daemon import binary_install
+from nexus.daemon.jar_lifecycle import well_known_binary_path
+
+
+@pytest.fixture(autouse=True)
+def _clean_service_env(monkeypatch):
+    """No env-sourced binary/tag leaks in from the host."""
+    monkeypatch.delenv("NEXUS_SERVICE_BIN", raising=False)
+    monkeypatch.delenv("NEXUS_SERVICE_TAG", raising=False)
+    monkeypatch.setattr(binary_install, "PINNED_SERVICE_TAG", None, raising=False)
+
+
+def _place_fake_binary(config_dir):
+    dest = well_known_binary_path(config_dir)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(b"#!/bin/sh\nexit 0\n")
+    os.chmod(dest, 0o755)
+    return dest
+
+
+def test_present_binary_is_a_noop(tmp_path, monkeypatch):
+    _place_fake_binary(tmp_path)
+
+    def _boom(*a, **k):  # install must NOT be attempted
+        raise AssertionError("install_binary called for an already-present binary")
+
+    # The step does a function-local `from binary_install import install_binary`,
+    # which resolves the (patched) module attribute at call time.
+    monkeypatch.setattr(binary_install, "install_binary", _boom)
+
+    assert init_mod._ensure_service_binary_step(tmp_path) is True  # ready, no download
+
+
+def test_absent_binary_with_tag_installs(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEXUS_SERVICE_TAG", "engine-service-v0.1.3")
+    calls = {}
+
+    def _fake_install(tag, config_dir, *, installed_by=""):
+        calls["tag"] = tag
+        calls["config_dir"] = config_dir
+        dest = _place_fake_binary(config_dir)
+        return dest, {"asset": "nexus-service-linux-amd64", "version": "0.1.3"}
+
+    monkeypatch.setattr(binary_install, "install_binary", _fake_install)
+
+    assert init_mod._ensure_service_binary_step(tmp_path) is True
+    assert calls["tag"] == "engine-service-v0.1.3"
+    assert calls["config_dir"] == tmp_path
+    assert well_known_binary_path(tmp_path).is_file()
+
+
+def test_second_init_is_a_noop_after_install(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEXUS_SERVICE_TAG", "engine-service-v0.1.3")
+    n = {"installs": 0}
+
+    def _fake_install(tag, config_dir, *, installed_by=""):
+        n["installs"] += 1
+        dest = _place_fake_binary(config_dir)
+        return dest, {"asset": "nexus-service-linux-amd64", "version": "0.1.3"}
+
+    monkeypatch.setattr(binary_install, "install_binary", _fake_install)
+
+    init_mod._ensure_service_binary_step(tmp_path)  # installs
+    init_mod._ensure_service_binary_step(tmp_path)  # idempotent no-op
+    assert n["installs"] == 1
+
+
+def test_absent_binary_no_tag_instructs_without_failing(tmp_path, monkeypatch, capsys):
+    def _boom(*a, **k):
+        raise AssertionError("install_binary called with no tag configured")
+
+    monkeypatch.setattr(binary_install, "install_binary", _boom)
+
+    # Returns False (not ready) without raising; the caller gates start on this.
+    assert init_mod._ensure_service_binary_step(tmp_path) is False
+    out = capsys.readouterr().out.lower()
+    assert "install-binary" in out
+    assert not well_known_binary_path(tmp_path).is_file()
+
+
+def test_build_pin_used_when_env_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(binary_install, "PINNED_SERVICE_TAG", "engine-service-v0.2.0")
+    seen = {}
+
+    def _fake_install(tag, config_dir, *, installed_by=""):
+        seen["tag"] = tag
+        dest = _place_fake_binary(config_dir)
+        return dest, {"asset": "nexus-service-mac-arm64", "version": "0.2.0"}
+
+    monkeypatch.setattr(binary_install, "install_binary", _fake_install)
+    assert init_mod._ensure_service_binary_step(tmp_path) is True
+    assert seen["tag"] == "engine-service-v0.2.0"
+
+
+def test_init_cmd_does_not_start_service_when_no_binary(tmp_path, monkeypatch):
+    """CRE C1: with no binary and no tag, `nx init --service` must NOT fall
+    through to _start_service_step (which would hit the legacy java -jar path).
+    It exits non-zero with an actionable message instead."""
+    from click.testing import CliRunner
+
+    from nexus import config as _config
+
+    monkeypatch.setattr(init_mod, "PINNED_SERVICE_TAG", None, raising=False)
+    monkeypatch.setattr(binary_install, "PINNED_SERVICE_TAG", None)
+    # isolate: throwaway config dir, local mode, PG + embedder steps stubbed.
+    monkeypatch.setattr(_config, "is_local_mode", lambda: True)
+    monkeypatch.setattr(init_mod._config, "nexus_config_dir", lambda: tmp_path)
+    monkeypatch.setattr(init_mod, "_provision_postgres_step", lambda: None)
+    monkeypatch.setattr(init_mod, "_provision_service_embedder_step", lambda e: None)
+
+    started = {"called": False}
+
+    def _start_must_not_run():
+        started["called"] = True
+
+    monkeypatch.setattr(init_mod, "_start_service_step", _start_must_not_run)
+
+    result = CliRunner().invoke(init_mod.init_cmd, ["--service", "--yes"])
+    assert result.exit_code != 0
+    assert started["called"] is False
+    assert "not started" in result.output.lower()
+
+
+def test_broken_override_surfaces_not_downloads(tmp_path, monkeypatch):
+    # NEXUS_SERVICE_BIN set to a missing file: _find_service_binary raises;
+    # the step must surface it (SystemExit), never download over the override.
+    monkeypatch.setenv("NEXUS_SERVICE_BIN", str(tmp_path / "does-not-exist"))
+
+    def _boom(*a, **k):
+        raise AssertionError("install_binary called over a broken override")
+
+    monkeypatch.setattr(binary_install, "install_binary", _boom)
+    with pytest.raises(SystemExit):
+        init_mod._ensure_service_binary_step(tmp_path)
+
+
+def test_resolve_service_tag_precedence(monkeypatch):
+    monkeypatch.setattr(binary_install, "PINNED_SERVICE_TAG", "engine-service-v0.2.0")
+    monkeypatch.delenv("NEXUS_SERVICE_TAG", raising=False)
+    assert binary_install.resolve_service_tag() == "engine-service-v0.2.0"
+    monkeypatch.setenv("NEXUS_SERVICE_TAG", "engine-service-v9.9.9")
+    assert binary_install.resolve_service_tag() == "engine-service-v9.9.9"  # env wins

--- a/uv.lock
+++ b/uv.lock
@@ -535,6 +535,7 @@ dependencies = [
     { name = "python-pptx" },
     { name = "pyyaml" },
     { name = "scikit-learn" },
+    { name = "sigstore" },
     { name = "structlog" },
     { name = "tqdm" },
     { name = "tree-sitter-language-pack" },
@@ -576,6 +577,7 @@ requires-dist = [
     { name = "python-pptx", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "scikit-learn", specifier = ">=1.3" },
+    { name = "sigstore", specifier = ">=3.0,<5" },
     { name = "structlog", specifier = ">=24.0" },
     { name = "tqdm", specifier = ">=4.65" },
     { name = "tree-sitter-language-pack", specifier = ">=0.7.1,<1.0" },
@@ -749,6 +751,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docling"
 version = "2.76.0"
 source = { registry = "https://pypi.org/simple" }
@@ -887,6 +898,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -3060,6 +3084,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
 name = "pybase64"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3176,6 +3209,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -3349,6 +3387,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/5a/23502935b3fc877d7573e743fc3e6c28748f33a45c43851d503bde52cde7/pyobjc_framework_vision-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6b3211d84f3a12aad0cde752cfd43a80d0218960ac9e6b46b141c730e7d655bd", size = 16625, upload-time = "2025-11-14T10:06:44.422Z" },
     { url = "https://files.pythonhosted.org/packages/f5/e4/e87361a31b82b22f8c0a59652d6e17625870dd002e8da75cb2343a84f2f9/pyobjc_framework_vision-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7273e2508db4c2e88523b4b7ff38ac54808756e7ba01d78e6c08ea68f32577d2", size = 16640, upload-time = "2025-11-14T10:06:46.653Z" },
     { url = "https://files.pythonhosted.org/packages/b1/dd/def55d8a80b0817f486f2712fc6243482c3264d373dc5ff75037b3aeb7ea/pyobjc_framework_vision-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:04296f0848cc8cdead66c76df6063720885cbdf24fdfd1900749a6e2297313db", size = 16782, upload-time = "2025-11-14T10:06:48.816Z" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
 ]
 
 [[package]]
@@ -3748,12 +3799,44 @@ wheels = [
 ]
 
 [[package]]
+name = "rfc3161-client"
+version = "1.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a7/be3b086133a87d595e7b11564931d5e5283edeeabba05dfee636a34b4dab/rfc3161_client-1.0.6.tar.gz", hash = "sha256:9969262fe6c08ecce39f9fe3996cf412187793834a022a643803090db5aae6b4", size = 106710, upload-time = "2026-04-08T14:15:05.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b1/262af0901e1507a4e21d268091f1f7b738b44bca424b9bd481981828a7e8/rfc3161_client-1.0.6-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9a98e9c7ff632d9571fcea25fb70bde0e8339b86368aef67a65f6a301f125733", size = 474975, upload-time = "2026-04-08T14:14:31.559Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/b6/da7caa10c2a3e01f244ad116ffe2cc87056fa71a7dd76453faab2fc2c6ad/rfc3161_client-1.0.6-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:0b3920334f7334ec3bb9c319d53a5d08cd43b6883f75e2669cfd869cd264d53a", size = 467442, upload-time = "2026-04-08T14:14:33.556Z" },
+    { url = "https://files.pythonhosted.org/packages/64/dd/5c92004ca167ae182f543aedc7a7a8bebeb0668ade7263b82212e4b4c59d/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1671b1be16480ea54c0d36239efd0fb62c13dd572a9865a5e91fea39f1b95303", size = 2435049, upload-time = "2026-04-08T14:14:35.062Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/19/c44702336aed367c6513493c4df9e880db8c4df37d5cd8d525aac9aad827/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:63355099d932851eac507806bb9d0937dab546a66d5857d888168799ec635f6d", size = 1850399, upload-time = "2026-04-08T14:14:36.707Z" },
+    { url = "https://files.pythonhosted.org/packages/64/fa/5af9bbfd4dcd9926463a95c4de6ea137176252d7a1d0b96533f6c85f2742/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bc9835467f6166edd6f876470484e5b294ee141add6eff6a59f5047937aaa75", size = 2174593, upload-time = "2026-04-08T14:14:38.764Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3c/32a0c7de4d63a69eb97e2564e5f1d51879ec93232b0c5ac1ec444843acba/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3caffaebf43242b000c4a6659d60eaf19c3b161ccbe05b15634a856c9ea7e61", size = 2177997, upload-time = "2026-04-08T14:14:40.641Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8d/4253affe1d1e221369ad3043f5d697fc3f5d7fcb439d21add84c65cafc53/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b7ad54288a49379b01b1d0d9d15167d2b7c6c7f940332ab85eeb4a6e844da8c7", size = 2745033, upload-time = "2026-04-08T14:14:42.82Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f0/eed22d6ed52d36b1eab3dfe56b9f507e22a328e3d018b84d48877ad7abe7/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:85a1d71d1eb2c9bced2b3eb75e96f9fe49732ec2567b5dafa1dd889fff42b7fe", size = 2145631, upload-time = "2026-04-08T14:14:44.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bb/feeacd1859e364080729b9cded1129b740eeea54c6d61ff12daceed4b7dd/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:1be4e1133f0f7fe875629f2c358285503c1cfc79cebfbc3fb4e28b8a57d6f1a4", size = 2328742, upload-time = "2026-04-08T14:14:46.743Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/f5/2df8e402f069a6af2db1f21d1c88d5a929398923265189a0141709a6f25c/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:bc379167238df32cbcc1dc9c324088559c1734331030f5293d75f4fd37b5f4f6", size = 2386899, upload-time = "2026-04-08T14:14:48.59Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/1b/f78c75c6c92a0f5de46a86b7f39cf9bb8fb5980fbd684a56f46f031dbce6/rfc3161_client-1.0.6-cp39-abi3-win32.whl", hash = "sha256:8631f7db7c1327bf87ee6a9a8681b4cd6bc2a90aae651388f29d045cd9ff1ac9", size = 1966796, upload-time = "2026-04-08T14:14:50.215Z" },
+    { url = "https://files.pythonhosted.org/packages/26/10/6e54860ae82e4ed5665fd3f1d798a8f68f7bac321431f444640da6f93600/rfc3161_client-1.0.6-cp39-abi3-win_amd64.whl", hash = "sha256:4ef4b096abe7d55b020526e39932c2721939a6c55e9a5cd3b3e77897a0942937", size = 2386738, upload-time = "2026-04-08T14:14:52.364Z" },
+]
+
+[[package]]
 name = "rfc3986"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
+]
+
+[[package]]
+name = "rfc8785"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/2f/fa1d2e740c490191b572d33dbca5daa180cb423c24396b856f5886371d8b/rfc8785-0.1.4.tar.gz", hash = "sha256:e545841329fe0eee4f6a3b44e7034343100c12b4ec566dc06ca9735681deb4da", size = 14321, upload-time = "2024-09-27T16:33:31.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/78/119878110660b2ad709888c8a1614fce7e2fab39080ab960656dc8605bf6/rfc8785-0.1.4-py3-none-any.whl", hash = "sha256:520d690b448ecf0703691c76e1a34a24ddcd4fc5bc41d589cb7c58ec651bcd48", size = 9240, upload-time = "2024-09-27T16:33:29.683Z" },
 ]
 
 [[package]]
@@ -4026,6 +4109,15 @@ wheels = [
 ]
 
 [[package]]
+name = "securesystemslib"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/11/9623c61604f9b8955248d43fc6a75658bb687c0d3ab65b032b2e43613bd5/securesystemslib-1.4.0.tar.gz", hash = "sha256:faea87be0f9c4b4277a5fa1b54bf9bfd807be9a94ab11be6c557dc8b75c43285", size = 934332, upload-time = "2026-05-27T08:01:53.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/29/3ff76b9d90ce4482dc8e8d216dc3a6b6d0c934c52f68b0738e2c99ca685f/securesystemslib-1.4.0-py3-none-any.whl", hash = "sha256:a0743a3d978cf26e98a70a57e3fbd5a18e0a74c20cabe615f6a55b02ef0272b3", size = 871457, upload-time = "2026-05-27T08:01:51.093Z" },
+]
+
+[[package]]
 name = "semchunk"
 version = "2.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4090,6 +4182,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sigstore"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "id" },
+    { name = "platformdirs" },
+    { name = "pyasn1" },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+    { name = "pyopenssl" },
+    { name = "requests" },
+    { name = "rfc3161-client" },
+    { name = "rfc8785" },
+    { name = "rich" },
+    { name = "sigstore-models" },
+    { name = "sigstore-rekor-types" },
+    { name = "tuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/63/1e44d9964d4f47617e641bdf6ce1b883b893d95b29ff07f97a8901df6b1c/sigstore-4.3.0.tar.gz", hash = "sha256:3c4b566bddfcc53e73d3adc06acf4311d72be0d907a167133abdc815a472a59b", size = 90550, upload-time = "2026-06-03T16:08:58.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/fd/78f361dbe410dac4b4fe091aa3c7be13b711ba0ced7d6961c1d8264f8d6d/sigstore-4.3.0-py3-none-any.whl", hash = "sha256:0f60c46c92fd4e871fbec979c9ae2aa381d7a93fbb774e49c9964550e5e16856", size = 111351, upload-time = "2026-06-03T16:08:57.125Z" },
+]
+
+[[package]]
+name = "sigstore-models"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ed/5c0ff809f90b19f4e971e17c1ed11f4df60082c6010b32a82054087e91e0/sigstore_models-0.0.6.tar.gz", hash = "sha256:c766c09470c2a7e8a4a333c893f07e2001c56a3ff1757b1a246119f53169a849", size = 7037, upload-time = "2025-11-26T19:18:12.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/dc/7a19864a7bc9f43121ab459e12768ab0080590e3e1b60a29b2f2eb01fb85/sigstore_models-0.0.6-py3-none-any.whl", hash = "sha256:5201a68f4d7d0f8bec1e2f4378eb646b084c52609a4e31db8c385095fff68b2e", size = 13213, upload-time = "2025-11-26T19:18:11.365Z" },
+]
+
+[[package]]
+name = "sigstore-rekor-types"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", extra = ["email"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/54/102e772445c5e849b826fbdcd44eb9ad7b3d10fda17b08964658ec7027dc/sigstore_rekor_types-0.0.18.tar.gz", hash = "sha256:19aef25433218ebf9975a1e8b523cc84aaf3cd395ad39a30523b083ea7917ec5", size = 15687, upload-time = "2024-11-22T13:59:54.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/7c/f0b4e19fd424df4cc964f5d454e1d814fd2dc3b386342e6040441024318f/sigstore_rekor_types-0.0.18-py3-none-any.whl", hash = "sha256:b62bf38c5b1a62bc0d7fe0ee51a0709e49311d137c7880c329882a8f4b2d1d78", size = 20610, upload-time = "2024-11-22T13:59:52.684Z" },
 ]
 
 [[package]]
@@ -4718,6 +4860,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },
     { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223, upload-time = "2025-07-30T19:58:44.017Z" },
     { url = "https://files.pythonhosted.org/packages/20/63/8cb444ad5cdb25d999b7d647abac25af0ee37d292afc009940c05b82dda0/triton-3.4.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7936b18a3499ed62059414d7df563e6c163c5e16c3773678a3ee3d417865035d", size = 155659780, upload-time = "2025-07-30T19:58:51.171Z" },
+]
+
+[[package]]
+name = "tuf"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "securesystemslib" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/40/25ceaf7f02e18b0d99150d94e200929351a542479c54abb7b92e1fd74b10/tuf-7.0.0.tar.gz", hash = "sha256:9d2e6723538e0d5a3e482b6de805fcfe64481448d5853039ba6b06ba541efd7f", size = 272032, upload-time = "2026-05-18T08:28:57.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/c7/301f699ad9427bb0e06935ed56850dd26eecb2b3e8e07b80311875eae676/tuf-7.0.0-py3-none-any.whl", hash = "sha256:572bdbdc9ff4a82278a0d4773e6100863b9b33023f27575e84ca65b486dd0d79", size = 55277, upload-time = "2026-05-18T08:28:56.123Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## RDR-161 Phase 1 — Native-binary acquire + verify (acquire-before-removal)

Accepts RDR-161 (Native-Only Local Install) and ships **Phase 1**: a signature-verified acquisition path for the native `nexus-service` binary, so the legacy `java -jar` launch + install path can be removed in P3 without ever breaking the install.

### What's here

**Publisher** (`nexus-ltjws`) — `engine-service-release.yml`
- Second `cosign sign-blob --new-bundle-format` emits a protobuf `nexus-service-<arch>.sigstore.json` alongside the existing `.cosign.bundle`; self-verifies both; uploads the new asset.
- The protobuf bundle is offline-verifiable by `sigstore-python` (no ~130MB cosign binary on the consumer). Flag confirmed present on `sign-blob` and `verify-blob` for the pinned cosign **v2.4.1**.

**Consumer** (`nexus-ywqza`) — `nexus/daemon/binary_install.py` + `nx daemon service install-binary TAG`
- Explicit `engine-service-v*` tag only (no "latest", RF-161-2); reuses `current_platform_tag()`.
- Two fail-closed gates: sha256, then sigstore signature pinned to the release cert-identity regexp + GitHub OIDC issuer (`AnyOf(OIDCIssuer, OIDCIssuerV2)` for CA-rotation resilience). Atomic place + `chmod 0755` + provenance sidecar. **Verification never silently skips.**

**Init wiring** (`nexus-8rze1`) — `nexus/commands/init.py`
- `_ensure_service_binary_step` gates `_start_service_step`, so `nx init --service` never falls through to the JAR path when no native binary is available. Idempotent (present binary = no-op). Tag from `NEXUS_SERVICE_TAG` or the build-time `PINNED_SERVICE_TAG` (`None` until the first real release — freeze-window-safe).

**TDD** (`nexus-epz8h`) — fail-closed matrix (sha256, identity regexp, missing-dep, signature wiring) + init wiring + CLI tests, fully isolated (tmp `config_dir`, monkeypatch, no network/live-daemon).

Adds `sigstore>=3.0,<5`. §Approach phase headers aligned to the gate-parser convention (format-only).

### Quality gates
- **Stacked review** (`nexus-rnylo`): code-review-expert + substantive-critic + test-validator. Round 1 found 1 Critical (init JAR-fallthrough) + 2 Significant + 1 High + 1 Medium + 2 test gaps; all fixed. Round 2 re-review: **JUSTIFIED, 0 Critical / 0 Significant.**
- **Phase-review-gate** (`nexus-i5a25`): **PASSED** — all 3 §Approach P1 items mapped to closing beads, pointers manually verified.
- Full unit suite: **10695 passed, 114 skipped, 1 xfailed** (0 failures).

### Scope notes
- Does **not** lift the release blocker `nexus-luxe6`; no release is cut here.
- The default sigstore crypto path is covered by a deferred `@integration` test (skip-with-reason) until a real `engine-service-v*` release artifact exists.
- P2 (PG bundle publish/acquire + `_select_bundled_pg` fix) and P3 (JAR expunge) follow in subsequent PRs.

### Closes
Closes #nexus-ltjws · Closes #nexus-epz8h · Closes #nexus-ywqza · Closes #nexus-8rze1 · Closes #nexus-rnylo · Closes #nexus-i5a25
