### PR TITLE
feat(rdr-161 P2): publish + acquire the PG bundle through the verified seam

### DIFF
--- a/.github/workflows/engine-service-release.yml
+++ b/.github/workflows/engine-service-release.yml
@@ -364,3 +364,125 @@ jobs:
           gh release upload "$tag" --clobber \
             "dist/$ASSET" "dist/$ASSET.sha256" \
             "dist/$ASSET.cosign.bundle" "dist/$ASSET.sigstore.json"
+
+  # RDR-161 P2 (nexus-9yt2p): publish the relocatable PostgreSQL+pgvector bundle
+  # as a release asset so `nx daemon service install-binary` / `nx init --service`
+  # can acquire+verify it (RF-161-3). Until now scripts/build_pg_bundle.sh was
+  # exercised only by ci.yml as a 7-day Actions artifact — nothing uploaded it to
+  # a release. Lives in THIS workflow so the cosign cert identity is
+  # `engine-service-release.yml@<tag>` — the SAME pin the consumer already
+  # verifies for the native binary, so one identity-regexp covers both artifacts.
+  build-publish-pg-bundle:
+    name: Build + sign + publish PG bundle (${{ matrix.target.arch }})
+    runs-on: ${{ matrix.target.runner }}
+    # The native-binary job creates the GitHub Release (with the rich notes);
+    # this job uploads the PG-bundle assets onto it. `needs` orders us AFTER it
+    # (release exists, no create-race on notes). `if: !cancelled()` decouples us
+    # from build-publish SUCCESS: build-publish is a 3-arch matrix, and a `needs`
+    # alone would skip ALL PG-bundle publishes if any single arch (e.g. the
+    # unsmoked mac-arm64) failed — leaving the surviving arches with a binary on
+    # the release but no PG bundle (install-binary then 404s on the bundle, a
+    # worse state than a clean failure). With !cancelled() the surviving arches
+    # still get their PG bundle; a TOTAL binary failure means no release exists
+    # and the upload below fails loud, which is correct (substantive-critic S2).
+    needs: build-publish
+    if: ${{ !cancelled() }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { arch: linux-amd64, runner: ubuntu-latest,    image: "quay.io/pypa/manylinux_2_28_x86_64" }
+          # linux-arm64: built + published; full relocation proof is deferred to
+          # nexus-xqk5r (the ci.yml relocation smoke runs on amd64). The bundle
+          # itself builds identically via the aarch64 manylinux image.
+          - { arch: linux-arm64, runner: ubuntu-24.04-arm, image: "quay.io/pypa/manylinux_2_28_aarch64" }
+          - { arch: mac-arm64,   runner: macos-14,         image: "" }
+    env:
+      # Pinned identically to ci.yml's CA-3 job (single source of truth is the
+      # build script; these select versions). PG17 aligns with the deployed stack.
+      PG_VERSION: "17.5"
+      PGVECTOR_VERSION: "v0.8.2"
+      ASSET: nexus-pg-${{ matrix.target.arch }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build PG + pgvector bundle and package .txz
+        env:
+          MANYLINUX_IMAGE: ${{ matrix.target.image }}
+        run: |
+          set -euo pipefail
+          bundle="$GITHUB_WORKSPACE/bundle"
+          mkdir -p "$bundle" dist
+          if [ -n "$MANYLINUX_IMAGE" ]; then
+            # linux: build inside manylinux_2_28 so the binaries' glibc floor is
+            # 2.28 (broad compatibility), exactly as ci.yml's CA-3 gate builds them.
+            docker run --rm \
+              -e PG_VERSION -e PGVECTOR_VERSION -e BUNDLE_PREFIX="$bundle" \
+              -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+              "$MANYLINUX_IMAGE" /bin/bash -c '
+                set -eux
+                bash "'"$GITHUB_WORKSPACE"'/scripts/build_pg_bundle.sh"
+              '
+          else
+            # mac-arm64: native build (the script brew-installs flex/bison and
+            # applies MACOSX_DEPLOYMENT_TARGET). GH macOS runners have no Docker.
+            BUNDLE_PREFIX="$bundle" bash scripts/build_pg_bundle.sh
+          fi
+          # -C parent + basename preserves the relative bin/ lib/ share/ layout
+          # relocation depends on (identical to ci.yml packaging).
+          tar -cJf "dist/$ASSET.txz" -C "$(dirname "$bundle")" "$(basename "$bundle")"
+          sz=$(wc -c < "dist/$ASSET.txz")
+          echo "bundle .txz size: $sz bytes"
+          # CA-2 ship-alongside size tripwire (mirrors ci.yml): the verdict rests
+          # on a small (~5.7 MB) bundle; a configure-flag or contrib change that
+          # doubled it would invalidate the rationale — fail loud, don't ship it.
+          if [ "$sz" -gt $((10 * 1024 * 1024)) ]; then
+            echo "::error::nexus-pg bundle .txz is $sz bytes (> 10 MiB) — CA-2 ship-alongside size assumption breached"
+            exit 1
+          fi
+          ( cd dist && { sha256sum "$ASSET.txz" 2>/dev/null || shasum -a 256 "$ASSET.txz"; } > "$ASSET.txz.sha256" )
+
+      - name: Install cosign (release tag only)
+        # SHA-pinned (not @v3.7.0): same supply-chain reasoning as the native-binary
+        # job above — the signing primitive must not float.
+        if: startsWith(github.ref, 'refs/tags/engine-service-v')
+        uses: sigstore/cosign-installer@1aa8e0f2454b781fbf0fbf306a4c9533a0c57409  # v3.7.0
+
+      - name: Sign PG bundle (cosign keyless, release tag only)
+        if: startsWith(github.ref, 'refs/tags/engine-service-v')
+        env:
+          COSIGN_YES: "true"
+        run: |
+          set -euo pipefail
+          # Protobuf bundle ONLY (.sigstore.json): the PG bundle is a NEW artifact
+          # with no legacy .cosign.bundle consumer, so it ships the single format
+          # the install seam's sigstore-python path verifies. Self-verify before
+          # publishing so a malformed bundle fails the build, not the consumer.
+          cosign sign-blob "dist/$ASSET.txz" --new-bundle-format --bundle "dist/$ASSET.txz.sigstore.json"
+          cosign verify-blob "dist/$ASSET.txz" \
+            --new-bundle-format \
+            --bundle "dist/$ASSET.txz.sigstore.json" \
+            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/engine-service-release.yml@${GITHUB_REF}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+          echo "cosign signature verified for $ASSET.txz (.sigstore.json)"
+
+      - name: Upload Actions artifact (always — dev smoke / non-tag path)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ASSET }}
+          path: dist/*
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Publish PG bundle to GitHub Release (engine-service-v* tag only)
+        if: startsWith(github.ref, 'refs/tags/engine-service-v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          # The release already exists (this job `needs` build-publish). Attach the
+          # PG-bundle assets; --clobber makes re-runs idempotent.
+          gh release upload "$tag" --clobber \
+            "dist/$ASSET.txz" "dist/$ASSET.txz.sha256" "dist/$ASSET.txz.sigstore.json"

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -1709,15 +1709,27 @@ def service_install_jar_cmd(
     default=None,
     help="Config directory override.",
 )
-def service_install_binary_cmd(tag: str, config_dir_str: str | None) -> None:
-    """Download, verify, and install the signed native nexus-service binary.
+@click.option(
+    "--pg-bundle/--no-pg-bundle",
+    "want_pg_bundle",
+    default=True,
+    help="Also acquire+verify the relocatable PostgreSQL bundle from the same "
+         "release (default). --no-pg-bundle installs only the service binary "
+         "(e.g. cloud habitat with a managed Postgres).",
+)
+def service_install_binary_cmd(
+    tag: str, config_dir_str: str | None, want_pg_bundle: bool,
+) -> None:
+    """Download, verify, and install the signed native nexus-service binary
+    (and, by default, the PostgreSQL bundle) from a release.
 
     TAG is an EXPLICIT engine-service-v* release tag (e.g. engine-service-v0.1.3);
-    there is no "latest" resolution. The per-platform asset, its .sha256, and its
+    there is no "latest" resolution. Each per-platform asset, its .sha256, and its
     .sigstore.json bundle are fetched from the GitHub release, verified
     (sha256 + keyless Sigstore signature, pinned to this repo's release workflow
-    identity), then placed at <config-dir>/service/nexus-service. Verification
-    fails closed: nothing is installed unless BOTH gates pass.
+    identity), then placed under <config-dir>/service/. Verification fails closed:
+    nothing is installed unless BOTH gates pass. One verified seam covers the
+    binary and the PG bundle (RDR-161).
     """
     from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
@@ -1725,6 +1737,8 @@ def service_install_binary_cmd(tag: str, config_dir_str: str | None) -> None:
         BinaryVerificationError,
         asset_name,
         install_binary,
+        install_pg_bundle,
+        pg_bundle_asset_name,
     )
 
     try:
@@ -1733,12 +1747,11 @@ def service_install_binary_cmd(tag: str, config_dir_str: str | None) -> None:
         _nx_version = "unknown"
 
     config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
+    installed_by = f"conexus {_nx_version}"
 
     click.echo(f"Resolving {asset_name()} from release {tag}…")
     try:
-        dest, prov = install_binary(
-            tag, config_dir, installed_by=f"conexus {_nx_version}",
-        )
+        dest, prov = install_binary(tag, config_dir, installed_by=installed_by)
     except BinaryVerificationError as exc:
         click.echo(f"Error: {exc}", err=True)
         sys.exit(2)
@@ -1748,7 +1761,32 @@ def service_install_binary_cmd(tag: str, config_dir_str: str | None) -> None:
     click.echo(f"  version: {prov['version']}")
     click.echo(f"  sha256:  {prov['sha256'][:16]}…")
     click.echo(f"  signature: verified (keyless Sigstore, {prov['source_url']})")
-    click.echo("Restart the service to pick it up: nx daemon service stop && "
+
+    if want_pg_bundle:
+        click.echo(f"\nResolving {pg_bundle_asset_name()} from release {tag}…")
+        try:
+            pg_dest, pg_prov = install_pg_bundle(
+                tag, config_dir, installed_by=installed_by,
+            )
+        except BinaryVerificationError as exc:
+            # The binary already installed and verified; only the PG bundle
+            # failed. Say so, and don't print the "restart the service" hint
+            # below (the service can't start without the bundle in local mode).
+            click.echo(
+                f"Error: the native binary installed OK, but the PostgreSQL "
+                f"bundle failed: {exc}\n"
+                "Re-run `nx daemon service install-binary <tag>` to retry the "
+                "bundle (the binary step is idempotent), or pass --no-pg-bundle "
+                "if you run against a managed Postgres.",
+                err=True,
+            )
+            sys.exit(2)
+        click.echo(f"Installed {pg_prov['asset']} ({tag})")
+        click.echo(f"  -> {pg_dest}")
+        click.echo(f"  sha256:  {pg_prov['sha256'][:16]}…")
+        click.echo("  signature: verified (keyless Sigstore)")
+
+    click.echo("\nRestart the service to pick it up: nx daemon service stop && "
                "nx daemon service start")
 
 

--- a/src/nexus/commands/init.py
+++ b/src/nexus/commands/init.py
@@ -464,8 +464,16 @@ def _select_bundled_pg(
     """
     if os.environ.get("NEXUS_PG_BIN", "").strip():
         return None
+    from nexus.daemon.jar_lifecycle import well_known_binary_path
     from nexus.db.pg_bundle import ensure_pg_bundle
 
+    if search_dirs is None:
+        # RF-161-3: default to <config_dir>/service/ — where the P2 acquire seam
+        # (install-binary / install-pg-bundle) places nexus-pg-<tag>.txz — not the
+        # venv bin/ that ensure_pg_bundle/locate_bundle_archive would otherwise
+        # use. The NEXUS_PG_BUNDLE env override still wins (checked first inside
+        # locate_bundle_archive) and an explicitly injected search_dirs is honoured.
+        search_dirs = [well_known_binary_path(config_dir).parent]
     bin_dir = ensure_pg_bundle(config_dir, search_dirs=search_dirs)
     if bin_dir is not None:
         os.environ["NEXUS_PG_BIN"] = str(bin_dir)

--- a/src/nexus/daemon/binary_install.py
+++ b/src/nexus/daemon/binary_install.py
@@ -53,6 +53,9 @@ __all__ = [
     "compute_sha256",
     "identity_matches",
     "install_binary",
+    "install_pg_bundle",
+    "pg_bundle_asset_name",
+    "pg_bundle_dest",
     "release_asset_url",
     "resolve_service_tag",
     "verify_sha256",
@@ -93,6 +96,7 @@ SERVICE_TAG_ENV = "NEXUS_SERVICE_TAG"
 _REPO = "Hellblazer/nexus"
 _RELEASE_DOWNLOAD_BASE = f"https://github.com/{_REPO}/releases/download"
 _BINARY_SIDECAR_NAME = "nexus-service.meta.json"
+_PG_SIDECAR_NAME = "nexus-pg.meta.json"
 _DOWNLOAD_TIMEOUT_S = 120.0
 _HASH_BLOCK = 1 << 20
 
@@ -386,34 +390,11 @@ def install_binary(
         verify_signature(asset, bundle, checker=checker)
 
         dest = well_known_binary_path(config_dir)
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        tmp_fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=".binary_install_")
-        try:
-            with os.fdopen(tmp_fd, "wb") as out, asset.open("rb") as src:
-                for block in iter(lambda: src.read(_HASH_BLOCK), b""):
-                    out.write(block)
-            os.chmod(tmp_name, 0o755)
-            os.replace(tmp_name, dest)
-        except Exception:
-            try:
-                os.unlink(tmp_name)
-            except OSError:
-                pass
-            raise
+        _atomic_copy(asset, dest, executable=True)
 
-    provenance = {
-        # _validate_tag guarantees the prefix; strip it to the bare version
-        # (engine-service-v0.1.3 -> 0.1.3).
-        "version": tag[len(TAG_NAMESPACE_PREFIX) :],
-        "tag": tag,
-        "asset": name,
-        "sha256": digest,
-        "source_url": asset_url,
-        "installed_at": datetime.now(UTC).isoformat(),
-        "installed_by": installed_by,
-    }
+    provenance = _provenance(tag, name, digest, asset_url, installed_by)
     try:
-        _write_sidecar(config_dir, provenance)
+        _atomic_write_json(binary_sidecar_path(config_dir), provenance)
     except OSError as exc:
         # The binary is already verified AND atomically in place; the sidecar is
         # informational provenance, not a gate. Don't turn a disk-full/perms
@@ -430,12 +411,34 @@ def install_binary(
     return dest, provenance
 
 
-def _write_sidecar(config_dir: Path, provenance: dict) -> None:
-    dest = binary_sidecar_path(config_dir)
-    tmp_fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=".binary_meta_")
+def _provenance(
+    tag: str, asset: str, digest: str, source_url: str, installed_by: str
+) -> dict:
+    """Provenance sidecar payload (mirrors install_jar's fields)."""
+    return {
+        # _validate_tag guarantees the prefix; strip it to the bare version
+        # (engine-service-v0.1.3 -> 0.1.3).
+        "version": tag[len(TAG_NAMESPACE_PREFIX) :],
+        "tag": tag,
+        "asset": asset,
+        "sha256": digest,
+        "source_url": source_url,
+        "installed_at": datetime.now(UTC).isoformat(),
+        "installed_by": installed_by,
+    }
+
+
+def _atomic_copy(src: Path, dest: Path, *, executable: bool) -> None:
+    """Copy *src* to *dest* atomically (tmp + os.replace), so a crash never
+    leaves a half-written file where a consumer would find it."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=".nx_place_")
     try:
-        with os.fdopen(tmp_fd, "w") as out:
-            json.dump(provenance, out, indent=2)
+        with os.fdopen(tmp_fd, "wb") as out, src.open("rb") as fh:
+            for block in iter(lambda: fh.read(_HASH_BLOCK), b""):
+                out.write(block)
+        if executable:
+            os.chmod(tmp_name, 0o755)
         os.replace(tmp_name, dest)
     except Exception:
         try:
@@ -443,3 +446,92 @@ def _write_sidecar(config_dir: Path, provenance: dict) -> None:
         except OSError:
             pass
         raise
+
+
+def _atomic_write_json(dest: Path, data: dict) -> None:
+    """Write *data* as pretty JSON to *dest* atomically."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=".nx_meta_")
+    try:
+        with os.fdopen(tmp_fd, "w") as out:
+            json.dump(data, out, indent=2)
+        os.replace(tmp_name, dest)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ── PG bundle acquisition (RDR-161 P2, same verified seam) ──────────────────
+
+
+def pg_bundle_asset_name() -> str:
+    """PG-bundle asset name for this host (``nexus-pg-<platform>.txz``).
+
+    Same ``<target>`` tokens as the binary, and the SAME name
+    :func:`nexus.db.pg_bundle.locate_bundle_archive` /
+    ``_select_bundled_pg`` look for under ``<config_dir>/service/``.
+    """
+    return f"nexus-pg-{current_platform_tag()}.txz"
+
+
+def pg_bundle_dest(config_dir: Path) -> Path:
+    """Where the acquired PG bundle is placed — next to the binary, where the
+    (RF-161-3-fixed) ``_select_bundled_pg`` default search dir looks."""
+    return config_dir / "service" / pg_bundle_asset_name()
+
+
+def install_pg_bundle(
+    tag: str,
+    config_dir: Path,
+    *,
+    installed_by: str = "",
+    checker: _SignatureChecker | None = None,
+    download_dir: Path | None = None,
+) -> tuple[Path, dict]:
+    """Download, verify, and atomically place the PG bundle for *tag*.
+
+    Same two fail-closed gates and sigstore pin as :func:`install_binary`
+    (one verified seam, RDR-161 Open Question 2). Places
+    ``nexus-pg-<platform>.txz`` at ``<config_dir>/service/`` with a provenance
+    sidecar. Returns ``(installed_path, provenance)``.
+    """
+    _validate_tag(tag)
+    name = pg_bundle_asset_name()
+    asset_url = release_asset_url(tag, name)
+
+    with tempfile.TemporaryDirectory(
+        dir=str(download_dir) if download_dir else None, prefix="nx_install_pgbundle_"
+    ) as td:
+        tmp = Path(td)
+        asset = tmp / name
+        sha_sidecar = tmp / f"{name}.sha256"
+        bundle = tmp / f"{name}.sigstore.json"
+
+        _download(asset_url, asset)
+        _download(f"{asset_url}.sha256", sha_sidecar)
+        _download(f"{asset_url}.sigstore.json", bundle)
+
+        digest = verify_sha256(asset, sha_sidecar)
+        verify_signature(asset, bundle, checker=checker)
+
+        dest = pg_bundle_dest(config_dir)
+        _atomic_copy(asset, dest, executable=False)  # a tarball, not an executable
+
+    provenance = _provenance(tag, name, digest, asset_url, installed_by)
+    try:
+        _atomic_write_json(config_dir / "service" / _PG_SIDECAR_NAME, provenance)
+    except OSError as exc:
+        # The bundle is verified + atomically placed; the sidecar is informational.
+        _log.warning("service_pg_bundle_sidecar_write_failed", error=str(exc))
+
+    _log.info(
+        "service_pg_bundle_installed",
+        dest=str(dest),
+        tag=tag,
+        asset=name,
+        sha256=digest[:12],
+    )
+    return dest, provenance

--- a/tests/daemon/test_binary_install_verify.py
+++ b/tests/daemon/test_binary_install_verify.py
@@ -303,9 +303,11 @@ def test_cli_install_binary_happy_path(tmp_path, monkeypatch):
         }
 
     monkeypatch.setattr(binstall, "install_binary", _fake_install)
+    # --no-pg-bundle: this test is scoped to the binary path (the PG-bundle
+    # default is covered in tests/daemon/test_pg_bundle_install.py).
     result = CliRunner().invoke(
         service_install_binary_cmd,
-        ["engine-service-v0.1.3", "--config-dir", str(tmp_path)],
+        ["engine-service-v0.1.3", "--no-pg-bundle", "--config-dir", str(tmp_path)],
     )
     assert result.exit_code == 0, result.output
     assert "verified" in result.output.lower()

--- a/tests/daemon/test_pg_bundle_install.py
+++ b/tests/daemon/test_pg_bundle_install.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-161 P2: PG-bundle acquisition through the shared verified install seam.
+
+Isolated: `_download` stubbed (no network), signature checker injected, tmp
+config_dir. The published-then-downloaded round-trip against a REAL signed
+bundle is the separate integration bead (nexus-3dfjq); here we cover the
+consumer's fail-closed wiring and placement.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from nexus.daemon import binary_install as b
+
+_TAG = "engine-service-v0.1.3"
+_CONTENT = b"a-relocatable-pg-bundle-tarball\n"
+
+
+class _OkChecker:
+    def check(self, **_kw) -> None:  # signature verifies
+        pass
+
+
+def _good_download(url, dest, *, timeout=0):
+    """Stub: materialise a self-consistent asset + sha256 + bundle."""
+    if url.endswith(".sha256"):
+        digest = hashlib.sha256(_CONTENT).hexdigest()
+        dest.write_text(f"{digest}  {b.pg_bundle_asset_name()}\n")
+    elif url.endswith(".sigstore.json"):
+        dest.write_text('{"protobuf":"bundle"}')
+    else:
+        dest.write_bytes(_CONTENT)
+
+
+def test_install_pg_bundle_places_and_writes_sidecar(tmp_path, monkeypatch):
+    monkeypatch.setattr(b, "_download", _good_download)
+    dest, prov = b.install_pg_bundle(
+        _TAG, tmp_path, checker=_OkChecker(), download_dir=tmp_path,
+    )
+    assert dest == b.pg_bundle_dest(tmp_path)
+    assert dest.is_file() and dest.read_bytes() == _CONTENT
+    # placed where the RF-161-3-fixed _select_bundled_pg looks
+    assert dest.parent == tmp_path / "service"
+    sidecar = tmp_path / "service" / "nexus-pg.meta.json"
+    assert sidecar.is_file()
+    meta = json.loads(sidecar.read_text())
+    assert meta["version"] == "0.1.3"
+    assert meta["tag"] == _TAG
+    assert meta["asset"] == b.pg_bundle_asset_name()
+    assert meta["sha256"] == hashlib.sha256(_CONTENT).hexdigest()
+
+
+def test_install_pg_bundle_rejects_non_namespace_tag(tmp_path):
+    with pytest.raises(b.BinaryVerificationError):
+        b.install_pg_bundle("v0.1.3", tmp_path)
+    assert not b.pg_bundle_dest(tmp_path).exists()
+
+
+def test_install_pg_bundle_fails_closed_on_download_error(tmp_path, monkeypatch):
+    def _boom(url, dest, *, timeout=0):
+        raise b.BinaryVerificationError("network down")
+
+    monkeypatch.setattr(b, "_download", _boom)
+    with pytest.raises(b.BinaryVerificationError):
+        b.install_pg_bundle(_TAG, tmp_path, download_dir=tmp_path)
+    assert not b.pg_bundle_dest(tmp_path).exists()
+
+
+def test_install_pg_bundle_fails_closed_on_sha256_mismatch(tmp_path, monkeypatch):
+    def _bad_sha(url, dest, *, timeout=0):
+        if url.endswith(".sha256"):
+            dest.write_text(f"{'0' * 64}  {b.pg_bundle_asset_name()}\n")
+        elif url.endswith(".sigstore.json"):
+            dest.write_text("{}")
+        else:
+            dest.write_bytes(_CONTENT)
+
+    monkeypatch.setattr(b, "_download", _bad_sha)
+    with pytest.raises(b.BinaryVerificationError):
+        b.install_pg_bundle(_TAG, tmp_path, checker=_OkChecker(), download_dir=tmp_path)
+    assert not b.pg_bundle_dest(tmp_path).exists()
+
+
+def test_install_pg_bundle_fails_closed_when_signature_rejected(tmp_path, monkeypatch):
+    class _RejectChecker:
+        def check(self, **_kw):
+            raise ValueError("signature does not verify")
+
+    monkeypatch.setattr(b, "_download", _good_download)
+    with pytest.raises(b.BinaryVerificationError):
+        b.install_pg_bundle(_TAG, tmp_path, checker=_RejectChecker(), download_dir=tmp_path)
+    assert not b.pg_bundle_dest(tmp_path).exists()
+
+
+# ── published -> downloaded -> placed -> located -> extracted round-trip ────
+# (nexus-3dfjq) The pre-existing relocation tests only exercised a LOCALLY-BUILT
+# bundle; this closes the RF-161-3 gap by driving the full acquire-then-select
+# chain — proving the P2 consumer (install_pg_bundle) and the P2 bugfix
+# (_select_bundled_pg default search dir) connect.
+
+
+def test_pg_bundle_publish_download_select_roundtrip(tmp_path, monkeypatch, make_pg_bundle_txz):
+    import os
+
+    from nexus.commands.init import _select_bundled_pg
+    from nexus.db import pg_bundle
+
+    monkeypatch.delenv("NEXUS_PG_BIN", raising=False)
+    monkeypatch.delenv(pg_bundle.BUNDLE_ENV, raising=False)
+
+    # "publish": a real, extractable bundle .txz (the release asset).
+    release_dir = tmp_path / "release"
+    release_dir.mkdir()
+    published = make_pg_bundle_txz(release_dir, b.pg_bundle_asset_name())
+    payload = published.read_bytes()
+
+    def _serve(url, dest, *, timeout=0):
+        if url.endswith(".sha256"):
+            dest.write_text(f"{hashlib.sha256(payload).hexdigest()}  {b.pg_bundle_asset_name()}\n")
+        elif url.endswith(".sigstore.json"):
+            dest.write_text('{"protobuf":"bundle"}')
+        else:
+            dest.write_bytes(payload)
+
+    monkeypatch.setattr(b, "_download", _serve)
+
+    config_dir = tmp_path / "cfg"
+    # Acquire+verify+place via the seam. Signature crypto is exercised separately
+    # (P1 deferred @integration real-verify); inject an ok checker since no real
+    # signed release artifact exists yet (freeze window).
+    dest, _prov = b.install_pg_bundle(
+        _TAG, config_dir, checker=_OkChecker(), download_dir=tmp_path,
+    )
+    assert dest == b.pg_bundle_dest(config_dir)
+    assert dest.is_file()
+
+    # The bugfix half: with no env override and no injected search_dirs,
+    # _select_bundled_pg finds the just-placed bundle under <config_dir>/service/
+    # and extracts it, returning the bin/ dir.
+    bin_dir = _select_bundled_pg(config_dir)
+    assert bin_dir is not None, "acquired bundle must be discovered by _select_bundled_pg"
+    assert os.environ["NEXUS_PG_BIN"] == str(bin_dir)
+    assert str(bin_dir).startswith(str(config_dir))
+
+
+# ── CLI --pg-bundle / --no-pg-bundle toggle ─────────────────────────────────
+
+
+def _stub_binary(tag, config_dir, *, installed_by=""):
+    return config_dir / "service" / "nexus-service", {
+        "asset": "nexus-service-x", "version": "0.1.3",
+        "sha256": "a" * 64, "source_url": "u",
+    }
+
+
+def test_cli_acquires_pg_bundle_by_default(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+
+    from nexus.commands.daemon import service_install_binary_cmd
+
+    calls = []
+    monkeypatch.setattr(b, "install_binary", _stub_binary)
+
+    def _stub_pg(tag, config_dir, *, installed_by=""):
+        calls.append(tag)
+        return config_dir / "service" / "nexus-pg.txz", {
+            "asset": "nexus-pg-x", "version": "0.1.3", "sha256": "b" * 64, "source_url": "u",
+        }
+
+    monkeypatch.setattr(b, "install_pg_bundle", _stub_pg)
+    r = CliRunner().invoke(
+        service_install_binary_cmd, [_TAG, "--config-dir", str(tmp_path)],
+    )
+    assert r.exit_code == 0, r.output
+    assert calls == [_TAG]
+
+
+def test_cli_no_pg_bundle_skips_bundle(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+
+    from nexus.commands.daemon import service_install_binary_cmd
+
+    monkeypatch.setattr(b, "install_binary", _stub_binary)
+
+    def _must_not_run(*a, **k):
+        raise AssertionError("install_pg_bundle called under --no-pg-bundle")
+
+    monkeypatch.setattr(b, "install_pg_bundle", _must_not_run)
+    r = CliRunner().invoke(
+        service_install_binary_cmd, [_TAG, "--no-pg-bundle", "--config-dir", str(tmp_path)],
+    )
+    assert r.exit_code == 0, r.output
+
+
+def test_cli_binary_ok_pg_bundle_fail_exits_2_with_clear_message(tmp_path, monkeypatch):
+    """CRE H1/H2: binary installs, PG bundle fails -> exit 2 AND the message
+    makes clear the binary succeeded (no misleading 'restart' hint)."""
+    from click.testing import CliRunner
+
+    from nexus.commands.daemon import service_install_binary_cmd
+
+    monkeypatch.setattr(b, "install_binary", _stub_binary)
+
+    def _pg_fail(tag, config_dir, *, installed_by=""):
+        raise b.BinaryVerificationError("bundle sha256 mismatch")
+
+    monkeypatch.setattr(b, "install_pg_bundle", _pg_fail)
+    r = CliRunner().invoke(
+        service_install_binary_cmd, [_TAG, "--config-dir", str(tmp_path)],
+    )
+    assert r.exit_code == 2
+    out = r.output.lower()
+    assert "binary installed ok" in out  # binary success surfaced
+    assert "bundle" in out
+    assert "restart the service" not in out  # misleading hint suppressed

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -642,6 +642,31 @@ def test_select_bundled_pg_none_without_bundle(tmp_path, monkeypatch) -> None:
     assert not os.environ.get("NEXUS_PG_BIN")
 
 
+def test_select_bundled_pg_defaults_to_service_dir(tmp_path, monkeypatch, make_pg_bundle_txz) -> None:
+    """RF-161-3 (nexus-06y9e): with no env override and no injected search_dirs,
+    the default search dir must be <config_dir>/service/ — where the P2 acquire
+    seam places the .txz — NOT the venv bin/. Before the fix _select_bundled_pg
+    passed search_dirs=None straight through, so ensure_pg_bundle defaulted to
+    [Path(sys.executable).parent] and a correctly-acquired bundle was never
+    found (silent host-PG fallback)."""
+    from nexus.commands.init import _select_bundled_pg
+    from nexus.db import pg_bundle
+    from nexus.db.pg_bundle import current_platform_tag
+
+    monkeypatch.delenv("NEXUS_PG_BIN", raising=False)
+    monkeypatch.delenv(pg_bundle.BUNDLE_ENV, raising=False)
+    config_dir = tmp_path / "cfg"
+    service_dir = config_dir / "service"
+    service_dir.mkdir(parents=True)
+    make_pg_bundle_txz(service_dir, f"nexus-pg-{current_platform_tag()}.txz")
+
+    # No search_dirs, no env: must still find the bundle under <config_dir>/service.
+    bin_dir = _select_bundled_pg(config_dir)
+    assert bin_dir is not None, "bundle in <config_dir>/service/ must be found"
+    assert os.environ["NEXUS_PG_BIN"] == str(bin_dir)
+    assert str(bin_dir).startswith(str(config_dir))
+
+
 def test_select_bundled_pg_respects_existing_env_override(tmp_path, monkeypatch, make_pg_bundle_txz) -> None:
     from nexus.commands.init import _select_bundled_pg
     from nexus.db import pg_bundle


### PR DESCRIPTION
## RDR-161 Phase 2 — Publish + acquire the PG bundle (verified seam)

Builds on the merged Phase 1. Ships the relocatable PostgreSQL+pgvector bundle as a **signed release asset** and acquires it through the **same verified install seam** as the native binary, plus the RF-161-3 search-dir bug fix.

### What's here

**Publisher** (`nexus-9yt2p`) — `build-publish-pg-bundle` job in `engine-service-release.yml`
- Builds `scripts/build_pg_bundle.sh` per target (linux in `manylinux_2_28`, mac native), packages `nexus-pg-<arch>.txz` with the CA-2 size tripwire, `cosign sign-blob --new-bundle-format → .txz.sigstore.json`, uploads `.txz`/`.sha256`/`.sigstore.json` to the `engine-service-v*` release.
- Same workflow as the binary → cosign cert identity matches the consumer's existing pin (one regexp covers both artifacts).
- `if: ${{ !cancelled() }}` so one binary-arch failure doesn't suppress all PG-bundle publishes (substantive-critic S2).

**Consumer** (`nexus-k80c0`) — `install_pg_bundle` + `--pg-bundle/--no-pg-bundle`
- Reuses `verify_sha256` + `verify_signature` (same sigstore pin, fail-closed), atomic-places `nexus-pg-<tag>.txz` at `<config_dir>/service/` + provenance sidecar.
- `install-binary` acquires binary **then** PG bundle by default (Open Question 2: one verified seam). Shared `_atomic_copy` / `_atomic_write_json` / `_provenance` helpers.

**Bug fix** (`nexus-06y9e`, RF-161-3) — `_select_bundled_pg`
- Now defaults `search_dirs` to `<config_dir>/service/` (where the seam places the `.txz`) instead of the venv `bin/`, so a correctly-acquired bundle is found instead of silently falling back to host PG. `NEXUS_PG_BUNDLE` override + injected param still win.

**Round-trip TDD** (`nexus-3dfjq`) — published → downloaded → placed → located → extracted, proving the consumer and the bugfix connect end to end.

### Quality gates
- **Stacked review** (`nexus-ltav2`): code-review-expert + substantive-critic + test-validator. Round 1: 0 Critical, 2 Significant (workflow coupling, init PG auto-acquire gap) + H1/H2. Fixed S2/H1/H2; S1 deferred to `nexus-r0v7e` (not a P2 §Approach item, inert until the tag pin). Round 2 re-review: **JUSTIFIED, 0/0.**
- **Phase-review-gate** (`nexus-wvue0`): **PASSED** — all 4 §Approach P2 items mapped to closing beads.
- Full unit suite: **10705 passed, 114 skipped, 1 xfailed** (0 failures).

### Scope notes
- No release cut; `nexus-luxe6` untouched. Publisher job validated only at a real release (inherent, like P1).
- **Deferred (tracked):** `nexus-r0v7e` — wire PG-bundle auto-acquire into `nx init --service`; inert today (gated on `PINNED_SERVICE_TAG`, same as the binary).
- linux-arm64 PG bundle is built+published; full relocation proof deferred to `nexus-xqk5r`.
- Phase 3 (JAR expunge) follows next.

### Closes
Closes #nexus-06y9e · Closes #nexus-9yt2p · Closes #nexus-k80c0 · Closes #nexus-3dfjq · Closes #nexus-ltav2 · Closes #nexus-wvue0
