### PR TITLE
docs(rdr-161 P4): native-only install story — install-jar -> install-binary

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1627,19 +1627,21 @@ under launchd / systemd supervision; templates ship as
 
 ### nx daemon service start / stop / status
 
-The storage-service supervisor (RDR-152 P5.1): managed Java service JAR +
-nx-managed Postgres. `start` ensures PG is running, runs the schema-skew
-gate, spawns the JAR (resolving `NX_VOYAGE_API_KEY` through the credential
+The storage-service supervisor (RDR-152 P5.1): the managed native
+nexus-service binary + nx-managed Postgres. `start` ensures PG is running,
+spawns the native binary (resolving `NX_VOYAGE_API_KEY` through the credential
 chain), waits for `/health`, and publishes the endpoint lease that clients
-auto-discover.
+auto-discover. The native binary is the sole launch artifact (RDR-161: the
+`java -jar` path is expunged); acquire it with `install-binary` (below) or
+`nx init --service`, which places and verifies it.
 
 `status` is the single is-the-stack-healthy surface: the lease (host, port,
-JAR pid, generation), supervisor pid, addr-file path, live `/health` probe,
+service pid, generation), supervisor pid, addr-file path, live `/health` probe,
 the PG cluster (port, data dir, up/down, installed pgvector version,
 pg_credentials path), the log-file paths (below), and the running service's
 `/version` handshake (`app_version`, `embedding_mode` voyage|onnx-local with
 the dispatchable models, `schema_latest_id`, `schema_changeset_count`). It
-warns when the running JAR differs from the installed one.
+warns when the running binary differs from the installed one.
 
 **Observability.** Every component of the stack writes a persistent log
 (none of them is ever DEVNULL'd); when the stack dies, the evidence lives
@@ -1647,46 +1649,48 @@ in (all under `~/.config/nexus/` unless noted):
 
 | File | Contents |
 |------|----------|
-| `logs/storage_service.log` | Supervisor lifecycle (rotating): start/exit breadcrumbs, jar exit codes, restart attempts, PG recoveries, crash backstop. |
-| `logs/storage_service_jar.log` | The Java service's stdout/stderr (logback console output, JVM banners, fatal errors). Size-rotated at respawn. |
+| `logs/storage_service.log` | Supervisor lifecycle (rotating): start/exit breadcrumbs, service exit codes, restart attempts, PG recoveries, crash backstop. |
+| `logs/storage_service_native.log` | The native service's stdout/stderr (banners, fatal errors). Size-rotated at respawn. |
 | `logs/storage_service.crash.log` | Pre-startup failures of the detached supervisor (import errors, bad argv) and interpreter-fatal tracebacks. Quiet in healthy operation. |
 | `<pg_data>/pg.log` | The nx-managed Postgres cluster log (`pg_ctl`). |
 
 A supervisor death without a `storage_service_supervisor_exit` breadcrumb
 in `storage_service.log` means it was killed, not that it chose to exit —
-check the jar log tail and `pg.log` next.
+check the service log tail and `pg.log` next.
 
-`stop` stops the supervisor + JAR but **leaves Postgres running by
+`stop` stops the supervisor + service but **leaves Postgres running by
 design** (it is independently managed and may serve other clients) — the
 command says so; pass `--with-pg` to stop the cluster too (`pg_ctl -m
 fast`).
 
 | Flag | Description |
 |------|-------------|
-| `--jar PATH` | Explicit JAR (otherwise: `NEXUS_SERVICE_JAR` env > well-known location > repo `service/target/`). |
 | `--foreground` | Block until SIGTERM (for launchd/systemd supervision). |
 | `--config-dir` | Config directory override. |
 | `--json` | (`status`) Raw JSON output. |
 | `--with-pg` | (`stop`) Also stop the nx-managed Postgres cluster. |
 
-### nx daemon service install-jar
+### nx daemon service install-binary
 
 ```
-nx daemon service install-jar <path-to-jar>
-nx daemon service install-jar --from-repo
+nx daemon service install-binary <engine-service-vX.Y.Z>
+nx daemon service install-binary <engine-service-vX.Y.Z> --no-pg-bundle
 ```
 
-Install a nexus-service fat JAR to the well-known location
-(`~/.config/nexus/service/nexus-service.jar`) with a provenance sidecar
-(version, sha256, build date, bundled Liquibase changesets). Supervisor
-discovery prefers this location, so pip/uv-installed users never need
-`--jar` or a repo checkout. `--from-repo` installs the freshest build from
-the current checkout's `service/target/` (dev convenience).
+Download, verify, and install the signed native nexus-service binary (and,
+by default, the relocatable PostgreSQL bundle) from a GitHub release to the
+well-known location (`~/.config/nexus/service/`) with a provenance sidecar
+(version, tag, sha256, install metadata). Supervisor discovery and
+`nx init --service` use this location.
 
-The recorded changesets feed the **schema-skew gate**: at start, the
-supervisor refuses to spawn a JAR that is older than the database schema
-(Liquibase silently ignores applied changesets it does not know, so the
-old JAR would boot cleanly and fail undiagnosably at runtime).
+TAG is an EXPLICIT `engine-service-v*` release tag (e.g.
+`engine-service-v0.1.3`); there is no "latest" resolution. Each per-platform
+asset, its `.sha256`, and its `.sigstore.json` bundle are fetched and verified
+(sha256 + keyless Sigstore signature, pinned to the engine-service release
+workflow identity), then placed atomically. Verification **fails closed**:
+nothing is installed unless BOTH gates pass. One verified seam covers the
+binary and the PG bundle (RDR-161). `--no-pg-bundle` installs only the
+service binary (e.g. a cloud habitat with a managed Postgres).
 
 ---
 

--- a/docs/migration-runbook.md
+++ b/docs/migration-runbook.md
@@ -164,10 +164,11 @@ Check, in order:
   supervisor logs a WARN naming the consequence; fix with
   `nx config set voyage_api_key` (chain: explicit env > `VOYAGE_API_KEY` >
   `config.yml` credentials).
-- No stale-JAR warning (running JAR differs from the installed sidecar).
-  Install the intended JAR first via `nx daemon service install-jar`; the
-  schema-skew gate refuses a JAR older than the database schema at spawn
-  (nexus-pebfx.4).
+- No stale-binary warning (running binary differs from the installed
+  provenance sidecar). Install the intended binary first via
+  `nx daemon service install-binary <engine-service-vX.Y.Z>` (RDR-161: the
+  native binary is the sole launch artifact; the legacy `java -jar` path and
+  its schema-skew gate are expunged).
 
 The T2 ladder commands read the service endpoint from the environment
 (`NX_SERVICE_PORT` + `NX_SERVICE_TOKEN` are required; the per-store

--- a/tests/e2e/migration-rehearsal/Dockerfile
+++ b/tests/e2e/migration-rehearsal/Dockerfile
@@ -1,8 +1,10 @@
+# syntax=docker/dockerfile:1
 # Soup-to-nuts migration dress-rehearsal box (nexus-* harness).
 #
 # A single ephemeral container that mirrors a fresh user's machine: PG16 +
-# pgvector + a JRE + the conexus wheel + the nexus-service JAR at the well-known
-# location. The driver (rehearse.sh) then runs the full operator path:
+# pgvector + the conexus wheel + the native nexus-service binary (RDR-161: the
+# sole launch artifact; no JRE). The driver (rehearse.sh) then runs the full
+# operator path:
 # init --service (provision PG) -> service start (migrate + serve) -> seed legacy
 # Chroma -> migrate-to-service -> validate parity -> rollback.
 #
@@ -14,9 +16,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
     PYTHONUNBUFFERED=1
 
-# PG16 (PGDG — bookworm ships PG15) + pgvector for PG16, a headless JRE for the
-# service JAR, python + uv for the wheel, and the build basics chromadb's ONNX
-# runtime + tokenizers need at install time.
+# PG16 (PGDG — bookworm ships PG15) + pgvector for PG16, python + uv for the
+# wheel, and the build basics chromadb's ONNX runtime + tokenizers need at
+# install time. No JRE: the native nexus-service binary is self-contained
+# (RDR-161).
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl gnupg lsb-release \
         python3 python3-venv python3-pip \
@@ -27,16 +30,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
 http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
         > /etc/apt/sources.list.d/pgdg.list \
-    # Temurin 25 JRE — the service JAR is compiled for Java 25 (pom
-    # maven.compiler.release=25); bookworm ships no Java 25.
-    && curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public \
-        | gpg --dearmor -o /etc/apt/keyrings/adoptium.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/adoptium.gpg] \
-https://packages.adoptium.net/artifactory/deb bookworm main" \
-        > /etc/apt/sources.list.d/adoptium.list \
     && apt-get update && apt-get install -y --no-install-recommends \
         postgresql-16 postgresql-16-pgvector \
-        temurin-25-jre \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root user — initdb (run by `nx init --service`) refuses to run as root,
@@ -60,15 +55,26 @@ WORKDIR /home/nexus
 # Wheel keeps its real PEP 427 name (uv requires the version in the filename);
 # it's at the context root so the glob resolves without the repo .dockerignore.
 COPY conexus-*.whl /tmp/
-COPY nexus-service.jar /opt/nexus-service.jar
-
 # Install the wheel into a venv (the faithful pip-into-venv user path) so `nx`
 # AND a matching `python` (with chromadb for seed_legacy.py) share one env.
 # Debian bookworm ships Python 3.11; conexus needs 3.12+, so uv fetches a
 # managed standalone 3.12 for the venv.
-RUN uv venv --python 3.12 /home/nexus/nxenv \
+#
+# The BuildKit uv cache mount persists uv's download/build cache across builds:
+# the conexus wheel changes every run, but its heavy dependency closure
+# (chromadb, onnxruntime, tokenizers) is stable, so a fresh wheel reuses the
+# already-downloaded/compiled deps instead of a cold 10-20m install. The mount
+# is keyed by nexus's uid (1000) so the unprivileged install can write it.
+RUN --mount=type=cache,target=/home/nexus/.cache/uv,uid=1000,gid=1000 \
+    uv venv --python 3.12 /home/nexus/nxenv \
     && uv pip install --python /home/nexus/nxenv /tmp/conexus-*.whl \
     && nx --version
+
+# The native binary + its native-image .so siblings, kept together so the
+# executable resolves its dlopen'd JDK libs from its own directory. rehearse.sh
+# positions them at the well-known service location. AFTER the wheel install so a
+# per-run binary change does not invalidate the cached dependency layer above.
+COPY --chown=nexus:nexus native/ /opt/nexus-service-native/
 
 # Driver scripts last: editing them rebuilds only these trivial layers, not the
 # multi-minute wheel install above.

--- a/tests/e2e/migration-rehearsal/rehearse.sh
+++ b/tests/e2e/migration-rehearsal/rehearse.sh
@@ -2,8 +2,9 @@
 # Soup-to-nuts migration dress rehearsal — runs INSIDE the container.
 #
 # Phase A  install + provision + serve   (the fragile legs: nx init --service
-#                                          provisions PG+pgvector; the JAR migrates
-#                                          64 changesets and serves /health)
+#                                          provisions PG+pgvector; the native
+#                                          nexus-service binary migrates 64
+#                                          changesets and serves /health)
 # Phase B  seed legacy Chroma + migrate  (nx migrate-to-service: detect → ETL →
 #                                          validate; parity assertion)
 # Phase C  rollback rehearsal            (Chroma source intact; degrade-loud, no
@@ -26,14 +27,25 @@ note() { printf '       %s\n' "$*"; }
 # ── Phase A: install + provision + serve ─────────────────────────────────────
 say "Phase A — install + provision + serve"
 
-nx --version >/dev/null 2>&1 && ok "nx installed ($(nx --version 2>&1))" || bad "nx --version failed"
-java -version >/dev/null 2>&1 && ok "JRE present ($(java -version 2>&1 | head -1))" || bad "no JRE"
-command -v initdb >/dev/null 2>&1 && ok "PG16 binaries on PATH ($(initdb --version))" || bad "initdb not found"
-test -f /opt/nexus-service.jar && ok "service JAR present ($(du -h /opt/nexus-service.jar | cut -f1))" || bad "JAR missing"
+# RDR-161: the native nexus-service binary is the SOLE launch artifact (no JRE,
+# no java -jar). The image ships it + its native-image .so siblings under
+# /opt/nexus-service-native/; position the whole set at the well-known location
+# (the launcher's job) so the binary resolves its dlopen'd JDK libs co-located.
+SVC_NATIVE_DIR="/opt/nexus-service-native"
+SVC_WELL_KNOWN_DIR="$HOME/.config/nexus/service"
 
-note "installing JAR to the well-known location (pebfx.4)…"
-nx daemon service install-jar /opt/nexus-service.jar 2>&1 | sed 's/^/       /' \
-  && ok "install-jar" || bad "install-jar failed"
+nx --version >/dev/null 2>&1 && ok "nx installed ($(nx --version 2>&1))" || bad "nx --version failed"
+command -v initdb >/dev/null 2>&1 && ok "PG16 binaries on PATH ($(initdb --version))" || bad "initdb not found"
+test -x "$SVC_NATIVE_DIR/nexus-service" && ok "native service binary present ($(du -h "$SVC_NATIVE_DIR/nexus-service" | cut -f1))" || bad "native binary missing at $SVC_NATIVE_DIR"
+
+note "positioning the native binary + libs at the well-known location…"
+if mkdir -p "$SVC_WELL_KNOWN_DIR" \
+   && cp "$SVC_NATIVE_DIR"/* "$SVC_WELL_KNOWN_DIR/" \
+   && chmod +x "$SVC_WELL_KNOWN_DIR/nexus-service"; then
+  ok "native binary positioned ($SVC_WELL_KNOWN_DIR/nexus-service)"
+else
+  bad "could not position native binary"
+fi
 
 note "nx init --service — provisioning PG16 + pgvector + nexus DB…"
 if nx init --service --embedder minilm-384 --yes 2>&1 | sed 's/^/       /'; then
@@ -67,7 +79,7 @@ then :; else
   bad "ONNX warmup failed (nexus-jrrve workaround) — service start will likely fail"
 fi
 
-note "nx daemon service start — spawn JAR, migrate changesets, await /health…"
+note "nx daemon service start — spawn native binary, migrate changesets, await /health…"
 nx daemon service start 2>&1 | sed 's/^/       /' || true
 # Poll the status surface (pebfx.5) for a healthy service.
 healthy=0
@@ -78,7 +90,7 @@ for i in $(seq 1 30); do
   sleep 2
 done
 nx daemon service status 2>&1 | sed 's/^/       /' || true
-[ "$healthy" = 1 ] && ok "service healthy (JAR serving, schema migrated)" || bad "service did not reach healthy"
+[ "$healthy" = 1 ] && ok "service healthy (native binary serving, schema migrated)" || bad "service did not reach healthy"
 
 if [ "$healthy" != 1 ]; then say "ABORT (service never came up — Phase A is the gate)"; exit 1; fi
 

--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -5,10 +5,15 @@
 #   tests/e2e/migration-rehearsal/run.sh --with-cloud # + Voyage leg (reads .env)
 #   tests/e2e/migration-rehearsal/run.sh --no-build   # reuse existing wheel/JAR
 #
-# Builds the wheel + service JAR on the host (fast, cached), bakes them into an
-# ephemeral image with PG16 + pgvector + a JRE, and runs the full operator path
-# (install → provision → serve → seed → migrate → validate → rollback) in one
-# throwaway container. NOT DinD: PG is provisioned inside the box by nx itself.
+# Builds the wheel on the host and the LINUX native nexus-service binary in a
+# GraalVM container (RDR-161: the native binary is the sole launch artifact; the
+# java -jar path is expunged). The native build runs IN a linux container so the
+# binary matches the rehearsal image's platform — a host build would produce the
+# wrong-OS binary. It uses Docker-out-of-Docker (mounted socket) because -Pnative
+# runs jOOQ codegen via a Testcontainers pgvector. Both go into an ephemeral image
+# with PG16 + pgvector (no JRE), running the full operator path (install → provision
+# → serve → seed → migrate → validate → rollback). NOT DinD: PG is provisioned
+# inside the box by nx itself.
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -24,21 +29,34 @@ for a in "$@"; do
   esac
 done
 
+GRAAL_IMAGE="container-registry.oracle.com/graalvm/native-image-community:25"
 if [ "$DO_BUILD" = 1 ]; then
   echo "[1/3] Building the conexus wheel (host)…"
   uv build --wheel >/dev/null 2>&1
-  echo "[2/3] Building the nexus-service JAR (host)…"
-  if ! ls service/target/nexus-service-*.jar >/dev/null 2>&1; then
-    (cd service && mvn -o -q -DskipTests package)
+  echo "[2/3] Building the LINUX native nexus-service binary (GraalVM container, ~2-3m)…"
+  if [ ! -x service/target/nexus-service ]; then
+    # Native build in a linux GraalVM container. The mounted Docker socket lets
+    # -Pnative's Testcontainers jOOQ codegen reach the host daemon (DooD);
+    # TESTCONTAINERS_HOST_OVERRIDE + the host-gateway alias make the build
+    # container reach the sibling pgvector. -Ob = quick-build (correctness gate,
+    # not a perf binary). Output: service/target/nexus-service + its *.so siblings.
+    docker run --rm --entrypoint bash \
+      --add-host=host.docker.internal:host-gateway \
+      -v "$PWD":/src -w /src/service \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      -e TESTCONTAINERS_RYUK_DISABLED=true \
+      -e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal \
+      "$GRAAL_IMAGE" \
+      -c './mvnw -B -Pnative -DskipTests -Dnative.image.opt=-Ob package'
   else
-    echo "      (JAR already built — reusing $(ls service/target/nexus-service-*.jar | head -1))"
+    echo "      (native binary already built — reusing service/target/nexus-service)"
   fi
 else
-  echo "[1-2/3] --no-build: reusing existing wheel + JAR"
+  echo "[1-2/3] --no-build: reusing existing wheel + native binary"
 fi
 
 ls dist/conexus-*.whl >/dev/null 2>&1 || { echo "no wheel in dist/ — drop --no-build" >&2; exit 1; }
-ls service/target/nexus-service-*.jar >/dev/null 2>&1 || { echo "no service JAR — drop --no-build" >&2; exit 1; }
+[ -x service/target/nexus-service ] || { echo "no native binary at service/target/nexus-service — drop --no-build" >&2; exit 1; }
 
 echo "[3/3] Staging a minimal build context + building image (WITH_CLOUD=$WITH_CLOUD)…"
 # Flatten wheel + JAR + driver to fixed names in a tiny throwaway context. The
@@ -47,7 +65,12 @@ echo "[3/3] Staging a minimal build context + building image (WITH_CLOUD=$WITH_C
 STAGE="$(mktemp -d)"
 trap 'rm -rf "$STAGE"' EXIT
 cp "$(ls -t dist/conexus-*.whl | head -1)"            "$STAGE/"   # keep real PEP 427 name
-cp "$(ls -t service/target/nexus-service-*.jar | head -1)" "$STAGE/nexus-service.jar"
+# The native binary + its native-image .so siblings (libjvm/libawt/liblcms/...)
+# must travel together: native-image resolves dlopen'd JDK libs from the
+# executable's own directory, so they are co-located in the image.
+mkdir -p "$STAGE/native"
+cp service/target/nexus-service "$STAGE/native/"
+cp service/target/*.so "$STAGE/native/"
 cp "$HERE/Dockerfile" "$HERE/rehearse.sh" "$HERE/seed_legacy.py" "$STAGE/"
 
 # Docker Desktop's credsStore=desktop helper can't reach a locked login keychain

--- a/tests/e2e/release-sandbox.sh
+++ b/tests/e2e/release-sandbox.sh
@@ -397,26 +397,19 @@ case "$MODE" in
         echo "[3/3] Service E2E (LOCAL mode, fresh sandbox HOME=$SANDBOX):"
         cd /tmp
 
-        # ── Artifact positioning (the launcher's job; P4.1 made the supervisor
-        #    able to launch whatever is positioned here). Native binary wins. ──
+        # ── Artifact positioning. RDR-161: the native binary is the SOLE launch
+        #    artifact — the java -jar fallback is expunged, so there is no
+        #    repo-JAR dev fallback any more. Provide a native binary via
+        #    NEXUS_SERVICE_BIN, the well-known location (e.g. from
+        #    `nx daemon service install-binary <engine-service-v* tag>`), or
+        #    `nx init --service` (which acquires + verifies it). ──
         SVC_WELL_KNOWN="$HOME/.config/nexus/service/nexus-service"
         if [[ -n "${NEXUS_SERVICE_BIN:-}" && -x "${NEXUS_SERVICE_BIN}" ]]; then
             echo "  artifact: native binary (NEXUS_SERVICE_BIN=$NEXUS_SERVICE_BIN)"
         elif [[ -x "$SVC_WELL_KNOWN" ]]; then
             echo "  artifact: native binary (well-known $SVC_WELL_KNOWN)"
         else
-            # Fall back to the repo-built JAR. P4.1 supports both; the native
-            # binary is exercised on CI/release where it is built.
-            JAR=""
-            for cand in "$REPO_ROOT"/service/target/nexus-service-*.jar; do
-                [[ -f "$cand" ]] || continue           # glob did not match
-                [[ "$cand" == *-sources.jar ]] && continue
-                JAR="$cand"
-            done
-            [[ -n "$JAR" ]] || _die "no service artifact: set NEXUS_SERVICE_BIN to a native binary, or build the JAR (cd service && mvn package -DskipTests -Pprebuilt-jooq -q)"
-            echo "  artifact: JAR (dev fallback) $JAR"
-            nx daemon service install-jar "$JAR" 2>&1 | tail -2 | sed 's/^/    /' \
-                || _die "install-jar failed"
+            _die "no native service binary: set NEXUS_SERVICE_BIN to a native nexus-service binary, or install one with 'nx daemon service install-binary <engine-service-v* tag>' (RDR-161: the java -jar path is expunged; there is no repo-JAR fallback)"
         fi
 
         # ── PG source (host PG on PATH, or a ship-alongside bundle). The bundle


### PR DESCRIPTION
## RDR-161 Phase 4 — Docs + Windows-bead scope

Final phase of RDR-161. Documents the native-only one-command install story now that P3 expunged the `java -jar` launch/install path.

### Changes (nexus-qwvmn)
- **`docs/cli-reference.md`**: rewrote the `nx daemon service start/stop/status` section for the native binary as the sole launch artifact; dropped the `--jar` flag row; renamed the log file to `storage_service_native.log`; replaced the `install-jar` section with **`install-binary`** (explicit `engine-service-v*` tag, sha256 + Sigstore verify, fails closed, `--no-pg-bundle`).
- **`docs/migration-runbook.md`**: stale-binary warning + `install-binary`; noted the schema-skew gate is expunged with the JVM path.

### Not changed (verified)
- `docs/architecture.md` and `README.md` carry no JAR-launch instructions.
- `docs/contributing.md`'s "service JAR" refers to the cross-language integration-test harness (still JAR-based), which is accurate.

### Windows scope (nexus-5j5mu)
Appended to the existing `nexus-f9bgu` (no new bead): install-binary/.exe platform-map (windows token + `nexus-service-windows-amd64.exe`), shared signed-acquire seam, and the UNSMOKED caveat. mac-amd64 stays out of scope.

Phase-review-gate PASSED (both §Approach P4 items mapped).