### PR TITLE
RDR-162 P2: cross-model migrate (stored-text re-embed → bge-768), rehearsal-proven + qke1e/taxonomy/native fixes

### DIFF
--- a/docs/rdr/post-mortem/162-truthful-post-rdr160-upgrade-path.md
+++ b/docs/rdr/post-mortem/162-truthful-post-rdr160-upgrade-path.md
@@ -1,0 +1,39 @@
+# RDR-162 post-mortem — Truthful Post-RDR-160 Upgrade Path
+
+**Closed:** 2026-06-19 (accepted 2026-06-18). **Epic:** `nexus-i055c`. **Outcome:** implemented, rehearsal-proven green end-to-end.
+
+## What shipped
+
+- **P1 — truthful classifier.** `detection._ONNX_MODEL` → `bge-base-en-v15-768`; the `Support` literal `supported-onnx-384` → `supported-onnx` (dim-agnostic); a legacy `minilm-384` collection is `unsupported` with a re-index diagnostic. Migration test fixtures inverted to the post-RDR-160 reality.
+- **P2 — cross-model migrate.** Single-stage **stored-text re-embed**: `nx migrate-to-service` reads a legacy collection's stored chunk text and upserts it into a model-remapped `bge-768` target (`cross_model_target_name`), the service re-embeds, and the catalog/topic `source_collection` references are re-pointed source→target after the target verifies (`remap_collection_references`). Copy-not-move, idempotent on `(tenant, target_collection, chash)`, remap-after-verify, leg-demotion on remap failure. Covers sourceless `store_put` notes `embed_migrate` cannot. Cross-model-aware dry-run + validation (`verify_counts` / `verify_taxonomy_consistency` resolve through `target_names`).
+- **P3 — contract.** Pinned as primitive 7 in `rdr-157-handoff-to-conexus-rdr-001.md`; relay staged for the conexus RDR-001 instance.
+
+## The rehearsal earned its keep
+
+The `tests/e2e/migration-rehearsal` Docker harness — driving the real native service, real Postgres, real cross-model migrate — surfaced **four latent bugs that green unit tests and three stacked reviews did not**:
+
+1. **Dry-run preview** classified legacy collections as BLOCKED — the cross-model path existed only in the live driver, not the dry-run. (nexus-side, fixed.)
+2. **`nexus-qke1e` supervisor lifecycle** — `nx init --service` published a discovery lease with no heartbeating supervisor, so it aged out by TTL before the migrate ran. Routed both init and `daemon service start` through a shared `ensure_storage_supervisor`. (nexus-side, fixed.)
+3. **`nexus-pqatt` native crash** — the GraalVM native binary SIGABRTed on the first bge-768 embed (missing JNI registrations for the DJL tokenizers / onnxruntime path). Fixed engine-side, shipped as `engine-service-v0.1.4`.
+4. **Service-mode rename contract mismatches** — `TaxonomyHandler` was the lone `rename_collection` endpoint expecting `old_collection`/`new_collection` (every other handler + client uses `old`/`new`); the catalog rename 500s for cross-model (the upsert pre-registers the bge target, so the registry rename collides under the RDR-156 `ON UPDATE CASCADE` FKs). The taxonomy fix shipped; the catalog 500 is fail-open and handed to engine-service.
+
+**Lesson:** the ref-remap was the *first real caller* of the service-mode rename cascade. A whole class of client/server contract bugs sat dormant until an end-to-end harness exercised them. Unit tests + reviews validated the design; only the rehearsal validated the *integration*.
+
+## Process note: duplicate planning tree
+
+Two RDR-162 bead trees existed (both planned 2026-06-18): the canonical `nexus-i055c` (single-stage stored-text design, executed) and a stale `nexus-0xdfo` (the **rejected two-stage `embed_migrate` → `migrate-to-service` chain**, pre-design-refinement). The stale tree (epic + ~13 beads) was superseded wholesale at close. Cause: re-planning after Hal's single-stage design refinement created a fresh tree without retiring the first. Watch for duplicate epics when a design pivots mid-planning.
+
+## Deferred (tracked, non-blocking)
+
+- `nexus-0ng3v` (P2) — rehearsal assert catalog `physical_collection` repoint, blocked on the engine catalog-rename-500 fix.
+- `nexus-5yn9c` (P3) — thread `config_dir` through `init._start_service_step`.
+- `nexus-8py1k` (P3) — dry-run preview mixed-bucket display.
+- Engine-side: catalog-rename-500 (handoff `engine_service/HANDOFF-catalog-rename-500-cross-model-collision`).
+
+## Boundary clarified
+
+`nexus.db.embed_migrate` (under `db/`) is the **LOCAL-only** 384→768 re-index for users staying on Chroma; it re-reads source files and cannot upgrade sourceless notes. The RDR-162 service path re-embeds stored text and is what conexus RDR-001 orchestration uses. Not to be confused.
+
+## Relation to the release gate
+
+Feeds `nexus-luxe6` prerequisite (2) (upgrade orchestration) by making the nexus cross-model primitive truthful + composable. Does not by itself lift luxe6.

--- a/docs/rdr/rdr-157-handoff-to-conexus-rdr-001.md
+++ b/docs/rdr/rdr-157-handoff-to-conexus-rdr-001.md
@@ -152,9 +152,16 @@ serve. RDR-162 makes migrating them a rehearsal-proven primitive.
   re-runnable from the untouched source. The reference remap is the one mutation
   and is ordered STRICTLY AFTER the target verifies populated (mirror RDR-144
   reindex-first / delete-after-verify), so a mid-migrate failure never leaves
-  dangling references. A per-collection remap failure demotes that leg → the run
-  refuses partial success and leaves the `migrated-failed` sentinel (reads
-  degrade-loud); re-run to converge.
+  dangling references. Remap is **per-collection opportunistic, not leg-atomic**:
+  if collection A's remap commits and B's then fails, A keeps its repointed T2
+  references while the leg is demoted from `legs_ok` → the run refuses partial
+  success and leaves the `migrated-failed` sentinel (reads degrade-loud). A
+  re-run reconverges cleanly because the T2 cascade UPDATE is idempotent (A
+  re-points to the same target, a no-op) and copy-not-move keeps B's source
+  intact. **Rollback caveat for RDR-001:** `nx storage migrate vectors
+  --rollback` clears the pgvector copies but does NOT reverse a committed T2
+  reference remap — run `nx catalog rebuild` to re-sync after a rollback, and do
+  not assume source references are pristine after a `migrated-failed` outcome.
 - **BOUNDARY — not to be confused with `embed_migrate`:** `nexus.db.embed_migrate`
   (under `db/`) is the LOCAL-only 384 → 768 re-embed for a user **staying on
   Chroma** (no service). It re-reads SOURCE FILES and therefore CANNOT upgrade

--- a/docs/rdr/rdr-157-handoff-to-conexus-rdr-001.md
+++ b/docs/rdr/rdr-157-handoff-to-conexus-rdr-001.md
@@ -121,6 +121,65 @@ the consumer.**
   delivers the LOCAL native-binary + embedded-PG distribution; the cloud client
   path is RDR-001's.
 
+### 7. Cross-model migrate: legacy minilm-384 → service bge-768 (RDR-162)
+
+The upgrade case RDR-001 orchestrates for an existing user: a pre-RDR-160
+install holds `minilm-384` (384-dim) collections the bge-768 service cannot
+serve. RDR-162 makes migrating them a rehearsal-proven primitive.
+
+- **Entry point:** `nx migrate-to-service` (`src/nexus/commands/migrate_cmd.py`
+  → `nexus.migration.driver.run_guided_upgrade`). `--dry-run` previews the
+  footprint without moving data.
+- **Mode (the contract):** a collection whose embedding model the service does
+  not wire (e.g. `minilm-384`), with a conformant four-segment name and present
+  chunk text, is **cross-model migrated**: the ETL reads the SOURCE collection's
+  **stored chunk text** (model-agnostic) and upserts it into a TARGET collection
+  whose model segment is the service model (`bge-768`); the service re-embeds the
+  text with bge-768. The target name is the source name with only the model
+  segment swapped (`vector_etl.cross_model_target_name`). This is a **single
+  stage** — re-embed-on-migrate, NOT a two-stage chain. Voyage collections with
+  no key, and non-conformant names, are NOT remapped — they BLOCK with a
+  credential / re-index diagnostic.
+- **Reference remap:** after the target verifies populated, the catalog/topic
+  `source_collection` / `physical_collection` references are re-pointed
+  source → target (`collection_rename.remap_collection_references`: the T2
+  reference cascade raises on failure; the catalog cascade is fail-open).
+- **Idempotency:** the service upsert keys on `(tenant_id, target_collection,
+  chash)`; `chash = sha256(chunk_text)[:32]` is identical across the re-embed, so
+  a re-run resumes a partial target rather than duplicating.
+- **Partial-failure disposition (copy-not-move, RDR-155 RF-5):** the source
+  Chroma collection is **never mutated**, so any failed migrate is cleanly
+  re-runnable from the untouched source. The reference remap is the one mutation
+  and is ordered STRICTLY AFTER the target verifies populated (mirror RDR-144
+  reindex-first / delete-after-verify), so a mid-migrate failure never leaves
+  dangling references. A per-collection remap failure demotes that leg → the run
+  refuses partial success and leaves the `migrated-failed` sentinel (reads
+  degrade-loud); re-run to converge.
+- **BOUNDARY — not to be confused with `embed_migrate`:** `nexus.db.embed_migrate`
+  (under `db/`) is the LOCAL-only 384 → 768 re-embed for a user **staying on
+  Chroma** (no service). It re-reads SOURCE FILES and therefore CANNOT upgrade
+  `sourceless` collections (MCP `store_put` notes with no backing file). The
+  RDR-162 service-migration path re-embeds STORED TEXT and so DOES cover
+  sourceless notes. RDR-001 orchestration uses the service path
+  (`nx migrate-to-service`), never `embed_migrate`.
+- **Consumer use:** RDR-001 upgrade-orchestration invokes `nx migrate-to-service`
+  (after the service is provisioned + serving per primitives 3–5). A clean run
+  reports `Migration VERIFIED and unlocked`; a block leaves `migrated-failed`
+  with rollback offered (`nx storage migrate vectors --rollback`, source intact).
+- **Reference flow:** `tests/e2e/migration-rehearsal/run.sh` proves the whole
+  chain soup-to-nuts in a container (install → provision → serve → seed legacy
+  minilm-384 incl. a sourceless note → cross-model migrate → validate → rollback-
+  safe).
+- **Known residual (fail-open):** the cross-model catalog reference remap
+  (`/v1/catalog/collections/rename`) currently 500s server-side (the upsert
+  pre-registers the bge target, so the catalog rename's `collection_registry`
+  UPDATE collides under the RDR-156 `ON UPDATE CASCADE` FKs). It is fail-open —
+  the migration still verifies + unlocks; catalog `physical_collection` refs may
+  be stale until `nx catalog rebuild`. Tracked engine-side (handoff
+  `engine_service/HANDOFF-catalog-rename-500-cross-model-collision`); RDR-001
+  orchestration should run `nx catalog rebuild` after a cross-model migrate until
+  the engine fix lands.
+
 ## Fresh-machine E2E (P4.2)
 
 `tests/e2e/release-sandbox.sh service` proves a fresh machine reaches serving

--- a/docs/rdr/rdr-162-truthful-post-rdr160-upgrade-path.md
+++ b/docs/rdr/rdr-162-truthful-post-rdr160-upgrade-path.md
@@ -41,20 +41,19 @@ either way.
 
 A legacy user's local Chroma is minilm-384 (the pre-RDR-160 default). The
 bge-768 service cannot serve 384-dim vectors, and `migrate-to-service` is
-same-model by contract (`vector_etl` sends chunk text, preserves the source
-collection name byte-for-byte, and the service re-embeds with the embedder
-matching the name's model segment — RDR-109 cross-model-contamination guard).
-So the only correct legacy path is a **two-stage chain**: `embed_migrate`
-(RDR-144, local 384→768 re-index, which remaps the collection's model segment)
-**then** `migrate-to-service` (now same-model bge-768 → service). Today nothing
-composes these two primitives, and the rehearsal does not exercise the chain —
-it feeds a raw minilm-384 source straight to the service.
+same-model by contract: `vector_etl` re-embeds the stored chunk text but
+preserves the source collection name byte-for-byte, so the service refuses a
+`minilm-l6-v2-384` name (RDR-109 cross-model-contamination guard). Today there
+is **no cross-model migration path** — nothing remaps the target to the
+service's model — and the rehearsal does not exercise one; it feeds a raw
+minilm-384 source straight to the service and hits the 422. (The §Decision
+resolves this with a single-stage stored-text re-embed + target-model remap,
+which needs no source files; see §Decision 2.)
 
 The user-facing single-command orchestration (`nx upgrade` detect→guide) is
 **conexus RDR-001**, which already exists as the consumer. This RDR is the
-**nexus-side** half: make the classifier truthful and make the
-re-index→migrate chain a composable, rehearsal-proven primitive set that
-conexus RDR-001 drives.
+**nexus-side** half: make the classifier truthful and make the cross-model
+migrate a composable, rehearsal-proven primitive that conexus RDR-001 drives.
 
 ## Decision
 
@@ -66,14 +65,23 @@ conexus RDR-001 drives.
    answer that points the user at the local re-index step instead of marching
    them into a 422.
 
-2. **Make the legacy 384→768 re-index→migrate chain a composable, proven
-   primitive set.** The rehearsal drives `embed_migrate` (384→768) then
-   `migrate-to-service` (768→service) and asserts the chain lands the data in
-   pgvector; it also asserts a bare minilm-384 source is correctly *blocked*
-   (not silently half-migrated). The chaining ORDER, idempotency, and
-   partial-failure/rollback semantics across the two stages are the nexus
-   contract conexus RDR-001 consumes; no new user-facing command is added here
-   (that is RDR-001's surface).
+2. **Re-embed the STORED CHUNK TEXT into a model-remapped target — no source
+   files, single stage.** The chunk text is already in the source collection
+   (`documents`), and `vector_etl` already re-embeds *that* server-side
+   (`iter_collection_chunks` reads the stored text; source vectors are never
+   read). The ONLY thing blocking cross-model migration is that `vector_etl`
+   preserves the source collection name byte-for-byte, so the bge-768 service
+   rejects a `minilm-l6-v2-384` name. The fix is a **cross-model mode on
+   `migrate-to-service`**: remap the target collection's model segment to the
+   service's model (bge-768), re-embed the stored text under the new name, and
+   update the catalog/topic `source_collection` references that the byte-for-byte
+   preservation existed to keep valid. This is strictly better than a two-stage
+   `embed_migrate` → `migrate-to-service` chain: it needs **no source files**, so
+   it also migrates `sourceless` collections (manual `store_put` notes) that
+   `embed_migrate` explicitly cannot re-index. `embed_migrate` (RDR-144) remains
+   the LOCAL-only 384→768 upgrade path (user staying on Chroma); it is not the
+   service-migration path. No new user-facing command is added here (that is
+   conexus RDR-001's surface).
 
 3. **Do not weaken the service's model-identity guard.** The bge-768 service
    correctly refuses to embed a minilm-384-named collection (RDR-109 /
@@ -87,9 +95,11 @@ conexus RDR-001 drives.
    invert that: post-RDR-162, **bge-768 is `supported-onnx`** (the service's
    wired model) and **minilm-384 is `unsupported`** with the re-index-required
    diagnostic. The RDR-159 test-plan item (d) is replaced by the P2 rehearsal
-   assertions (bge-768 migrates clean; minilm-384 is blocked, then chained via
-   `embed_migrate`). This is correct supersession, not scope reduction; the
-   RDR-159 tests encoding the old model are deleted and replaced, not edited.
+   assertions (a bge-768 collection migrates clean; a legacy minilm-384
+   collection is migrated cross-model via the single-stage stored-text re-embed
+   into a bge-768-remapped target). This is correct supersession, not scope
+   reduction; the RDR-159 tests encoding the old model are deleted and replaced,
+   not edited.
 
 ## Approach (phased)
 
@@ -109,23 +119,31 @@ conexus RDR-001 drives.
   literal (it may only branch on `== "unsupported"` / `== "supported-voyage-1024"`,
   both unchanged) before touching it. Assertions stay exact, never inequalities.
 
-**Phase 2: Rehearsal proves both paths**
+**Phase 2: Cross-model migrate (stored-text re-embed + model remap)**
 
-- `tests/e2e/migration-rehearsal`: seed BOTH a bge-768 collection (migrates
-  clean) AND a legacy minilm-384 collection; assert the minilm-384 one is
-  classified `unsupported` / blocked with the re-index diagnostic, then drive
-  `embed_migrate` (384→768) and re-run `migrate-to-service` to prove the chained
-  legacy path lands in pgvector. Phase A (native serve) and Phase C (rollback
-  safety) already pass.
+- Add a cross-model mode to `migrate-to-service` / `vector_etl`: when a source
+  collection's model segment is unsupported by the service but its chunk text is
+  present, re-embed the stored text into a target collection whose model segment
+  is the service's model (bge-768), and update the catalog/topic
+  `source_collection` references to the remapped name (the references the
+  byte-for-byte preservation protected). Idempotent on `(tenant, target_collection,
+  chash)`. Covers `sourceless` collections (manual notes) that `embed_migrate`
+  cannot.
+- Rehearsal proves it: `tests/e2e/migration-rehearsal` seeds a legacy minilm-384
+  collection (incl. a sourceless `store_put`-style note) and asserts it migrates
+  to a bge-768 target via the stored-text re-embed, lands in pgvector, and the
+  catalog references resolve to the new name. Phase A (native serve) + Phase C
+  (rollback safety) already pass.
 
-**Phase 3: Chain contract + conexus RDR-001 coordination**
+**Phase 3: Contract + conexus RDR-001 coordination**
 
-- Pin the composition contract (order, idempotency, partial-failure/rollback
-  per the §Open Questions disposition) across `nexus.db.embed_migrate` (the
-  RDR-144 re-index primitive; note it lives under `db/`, not `migration/`) →
-  `migrate-to-service` that the conexus RDR-001 orchestration consumes; update
-  the RDR-157 P5 handoff doc if the contract shifts. Relay the nexus-side
-  contract to the conexus RDR-001 instance.
+- Pin the composition contract the conexus RDR-001 orchestration consumes:
+  the cross-model `migrate-to-service` mode (target model = service model,
+  stored-text re-embed, reference remap), its idempotency/partial-failure
+  disposition (per §Open Questions), and the boundary with `embed_migrate`
+  (`nexus.db.embed_migrate`, under `db/`, is LOCAL-only upgrade — not the service
+  path). Update the RDR-157 P5 handoff doc if the contract shifts; relay to the
+  conexus RDR-001 instance.
 - Phase-review-gate cross-walk + stacked review (behavioral change in the
   migration layer).
 
@@ -156,14 +174,16 @@ conexus RDR-001 drives.
 - Does any consumer branch on the exact `supported-onnx-384` literal beyond the
   `== "unsupported"` / `== "supported-voyage-1024"` checks? **Resolved (CA-1):**
   no — production code is clean; only tests carry the literal.
-- **Rollback boundary — DISPOSITION (confirm at P3, not genuinely open):** when
-  `embed_migrate` succeeds and `migrate-to-service` fails, the user is in a
-  re-runnable **768-local** state; there is no unwind to 384 and none is needed.
-  `embed_migrate` is reindex-first/delete-after-verify (RDR-144) and
-  `migrate-to-service` is idempotent on `(tenant, collection, chash)` (RDR-155
-  RF-5), so re-running `migrate-to-service` from the 768-local Chroma is the
-  clean recovery path. P3 codifies this as the contract conexus RDR-001 consumes
-  and verifies it with the rehearsal's partial-failure assertion.
+- **Rollback boundary — DISPOSITION (confirm at P3, not genuinely open):** the
+  single-stage stored-text re-embed is copy-not-move — the source Chroma
+  collection is never mutated (RDR-155 RF-5), so a failed cross-model migrate is
+  cleanly re-runnable from the untouched 384 source. `migrate-to-service` is
+  idempotent on `(tenant, target_collection, chash)`, so a partial target is
+  resumed, not duplicated. The reference remap (catalog/topic
+  `source_collection`) is the one mutation that must be ordered AFTER the target
+  is verified-populated (mirror RDR-144's reindex-first/delete-after-verify
+  ordering) so a mid-migrate failure never leaves dangling references. P3
+  codifies this and the rehearsal asserts the partial-failure path.
 
 ## Research Findings
 
@@ -196,8 +216,18 @@ conexus RDR-001 drives.
   bge-768-named collection (768-dim vectors, reindex-first/delete-after-verify),
   which `migrate-to-service` then sees as a same-model bge-768 collection the
   service accepts — no cross-model upsert, no 422.
-- **CA-3 VERIFIED — the guard stays; re-index is the upstream fix.** The
+- **CA-3 VERIFIED — the guard stays; the target-name remap is the fix.** The
   service's `EmbedderRouter` model-identity guard (RDR-109 / nexus-pebfx.2)
   refuses to embed a collection with an embedder other than its name's model
-  segment, by design. `embed_migrate` IS that upstream re-index (it remaps the
-  segment to bge-768), so the correct path never weakens the guard.
+  segment, by design. The cross-model migrate satisfies it by remapping the
+  TARGET collection's model segment to bge-768 (so the name matches the service
+  embedder), never by relaxing the guard.
+- **DESIGN REFINEMENT (2026-06-18, Hal) — re-embed from stored chunk text, not
+  source files.** `vector_etl` already re-embeds the STORED chunk `documents`
+  (`iter_collection_chunks`), so the cross-model migrate needs **no original
+  file/web source** — only a target-name model remap + reference update. This is
+  strictly better than a two-stage `embed_migrate` → `migrate-to-service` chain:
+  `embed_migrate` re-indexes from `source_paths` and has a `sourceless` category
+  (manual `store_put` notes) it explicitly cannot re-index, whereas the
+  stored-text re-embed covers those too. `embed_migrate` stays the LOCAL-only
+  384→768 upgrade primitive; it is not the service-migration path.

--- a/docs/rdr/rdr-162-truthful-post-rdr160-upgrade-path.md
+++ b/docs/rdr/rdr-162-truthful-post-rdr160-upgrade-path.md
@@ -143,7 +143,9 @@ migrate a composable, rehearsal-proven primitive that conexus RDR-001 drives.
   disposition (per §Open Questions), and the boundary with `embed_migrate`
   (`nexus.db.embed_migrate`, under `db/`, is LOCAL-only upgrade — not the service
   path). Update the RDR-157 P5 handoff doc if the contract shifts; relay to the
-  conexus RDR-001 instance.
+  conexus RDR-001 instance. **Pinned (2026-06-19):** the contract lives in
+  [`rdr-157-handoff-to-conexus-rdr-001.md`](rdr-157-handoff-to-conexus-rdr-001.md)
+  §7 "Cross-model migrate" (the consumer-facing handoff RDR-001 reads).
 - Phase-review-gate cross-walk + stacked review (behavioral change in the
   migration layer).
 

--- a/docs/rdr/rdr-162-truthful-post-rdr160-upgrade-path.md
+++ b/docs/rdr/rdr-162-truthful-post-rdr160-upgrade-path.md
@@ -2,8 +2,9 @@
 title: "Truthful Post-RDR-160 Upgrade Path: Fix the Migration Model Classifier and Make the Legacy 384→768 Re-Index→Migrate Chain a Rehearsal-Proven Primitive"
 id: RDR-162
 type: Architecture
-status: accepted
+status: closed
 accepted_date: 2026-06-18
+closed_date: 2026-06-19
 priority: high
 author: Hal Hildebrand
 reviewed-by: self

--- a/service/linux-native-verify.sh
+++ b/service/linux-native-verify.sh
@@ -34,6 +34,7 @@ docker run --rm --name "$BUILDER" --platform linux/arm64 --network "$NET" \
   -v "$REPO:$REPO" -w "$REPO/service" \
   -v "$HOME/.m2:/root/.m2" \
   -v "$HOME/.cache/chroma:/root/.cache/chroma" \
+  -v "$HOME/.cache/nexus/onnx_models:/root/.cache/nexus/onnx_models" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal \
   -e DOCKER_HOST=unix:///var/run/docker.sock \
@@ -59,6 +60,12 @@ docker run --rm --name "$BUILDER" --platform linux/arm64 --network "$NET" \
     echo -n "put     : "; curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer lintoken" -H "Content-Type: application/json" -X POST -d "{\"project\":\"lin\",\"title\":\"a\",\"content\":\"linux native\",\"tags\":\"t\",\"ttl\":30}" http://localhost:8080/v1/memory/put; echo
     echo -n "get     : "; curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer lintoken" "http://localhost:8080/v1/memory/get?project=lin&title=a"; echo
     echo -n "search  : "; curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer lintoken" -H "Content-Type: application/json" -X POST -d "{\"query\":\"linux\",\"project\":\"lin\"}" http://localhost:8080/v1/memory/search; echo
+    # bge-768 EMBED (nexus-pqatt): the DJL tokenizers JNI + onnx-run path that
+    # SIGABRTed at lib.rs:475 under native-image. Model mounted from host cache.
+    echo -n "embed   : "
+    ecode=$(curl -s -o /tmp/lin-embed.out -w "%{http_code}" -H "Authorization: Bearer lintoken" -H "Content-Type: application/json" -X POST -d "{\"collection\":\"knowledge__x\",\"texts\":[\"linux native embed\"]}" http://localhost:8080/v1/vectors/embed); echo "$ecode"
+    kill -0 $PID 2>/dev/null || { echo "LINUX EMBED FAIL: service died on embed (SIGABRT?)"; tail -30 /tmp/lin-svc.log; exit 1; }
+    [ "$ecode" = 200 ] && grep -q "\"embeddings\"" /tmp/lin-embed.out || { echo "LINUX EMBED FAIL: $ecode $(head -c160 /tmp/lin-embed.out)"; tail -30 /tmp/lin-svc.log; exit 1; }
     grep -iE "MissingReflection|NoClassDefFound|UnsatisfiedLink|NullPointer" /tmp/lin-svc.log && { echo "LINUX RUNTIME ERROR"; exit 1; } || true
     kill $PID 2>/dev/null || true
     echo "LINUX NATIVE OK"

--- a/service/native-smoke.sh
+++ b/service/native-smoke.sh
@@ -69,6 +69,31 @@ assert "plans/search"          200 "${A[@]}" "${J[@]}" -X POST -d '{"query":"q",
 assert "taxonomy/topics"       200 "${A[@]}" "$U/v1/taxonomy/topics?collection=knowledge__x"
 assert "chash/distinct"        200 "${A[@]}" "$U/v1/chash/distinct_collections"
 
+# ── Local bge-768 EMBED (nexus-pqatt) ────────────────────────────────────────
+# The embed path drives the DJL HuggingFace tokenizers JNI (libtokenizers.so) and
+# the onnxruntime session run — both of which need jniAccessible registrations the
+# native image previously omitted, so the FIRST embed SIGABRTed at lib.rs:475
+# (Result::unwrap on a JavaException) while every other endpoint above worked. The
+# old gate never embedded, so the crash shipped. We assert the encode+infer path
+# returns a real 768-dim vector. Requires the ~416MB bge ONNX model (provisioned by
+# `nx init --service`). If it is absent we WARN+skip loudly rather than silently
+# pass — a model-less CI run must not read as "embed covered".
+BGE_MODEL="${NX_BGE_MODEL_PATH:-$HOME/.cache/nexus/onnx_models/bge-base-en-v1.5/onnx/model.onnx}"
+if [ -f "$BGE_MODEL" ]; then
+  echo "local bge-768 embed path:"
+  ecode=$(curl -s -o /tmp/ns-embed.out -w "%{http_code}" "${A[@]}" "${J[@]}" -X POST \
+    -d '{"collection":"knowledge__x","texts":["native embed smoke"]}' "$U/v1/vectors/embed")
+  if [ "$ecode" = "200" ] && grep -q '"embeddings"' /tmp/ns-embed.out \
+     && [ "$(python3 -c "import json,sys;print(len(json.load(open('/tmp/ns-embed.out'))['embeddings'][0]))" 2>/dev/null)" = "768" ]; then
+    echo "  ok   embed (DJL tokenizer JNI + onnx run) -> 200, 768-dim"
+  else
+    echo "  FAIL embed -> $ecode (want 200 + 768-dim): $(head -c200 /tmp/ns-embed.out)"; fail=1
+  fi
+else
+  echo "  WARN embed path NOT covered — bge model absent at $BGE_MODEL"
+  echo "       (set NX_BGE_MODEL_PATH or provision via 'nx init --service' to gate the JNI embed path)"
+fi
+
 if grep -qiE "MissingReflection|NoClassDefFound|UnsatisfiedLink|NullPointerException" /tmp/native-smoke-svc.log; then
   echo "FAIL: native runtime error in service log:"; grep -iE "MissingReflection|NoClassDefFound|UnsatisfiedLink|NullPointerException" /tmp/native-smoke-svc.log | head; fail=1
 fi

--- a/service/src/main/java/dev/nexus/service/http/TaxonomyHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/TaxonomyHandler.java
@@ -377,8 +377,13 @@ public final class TaxonomyHandler implements HttpHandler {
     private void handleRenameCollection(HttpExchange ex, String tenant, String method) throws IOException {
         requireMethod(ex, method, "POST");
         Map<String, Object> body = readBody(ex);
-        String oldCol = requireString(body, "old_collection");
-        String newCol = requireString(body, "new_collection");
+        // Field names are "old"/"new" — the convention every other rename_collection
+        // handler (chash, aspects, queue, highlights, telemetry, catalog) and every
+        // nexus HTTP client use. This handler was the lone "old_collection"/
+        // "new_collection" outlier, which 400'd the RDR-162 cross-model ref-remap
+        // (the first real caller of service-mode taxonomy rename).
+        String oldCol = requireString(body, "old");
+        String newCol = requireString(body, "new");
         HttpUtil.send(ex, 200, json(repo.renameCollection(tenant, oldCol, newCol)));
     }
 

--- a/service/src/main/resources/META-INF/native-image/traced/reachability-metadata.json
+++ b/service/src/main/resources/META-INF/native-image/traced/reachability-metadata.json
@@ -1,6 +1,50 @@
 {
   "reflection": [
     {
+      "type": "ai.djl.huggingface.tokenizers.jni.CharSpan",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ai.djl.huggingface.tokenizers.jni.CharSpan[]"
+    },
+    {
+      "type": "ai.onnxruntime.OnnxTensor",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "long",
+            "ai.onnxruntime.TensorInfo"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ai.onnxruntime.TensorInfo",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long[]",
+            "java.lang.String[]",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
       "type": "ch.qos.logback.classic.encoder.PatternLayoutEncoder",
       "methods": [
         {
@@ -582,6 +626,9 @@
       "type": "dev.nexus.service.jooq.nexus.tables.records.PlansRecord"
     },
     {
+      "type": "float[][][]"
+    },
+    {
       "type": "java.beans.PropertyVetoException"
     },
     {
@@ -668,6 +715,9 @@
           "parameterTypes": []
         }
       ]
+    },
+    {
+      "type": "java.lang.Comparable"
     },
     {
       "type": "java.lang.Double",
@@ -763,6 +813,9 @@
     },
     {
       "type": "java.lang.Long[]"
+    },
+    {
+      "type": "java.lang.Number"
     },
     {
       "type": "java.lang.Object",
@@ -909,6 +962,12 @@
           "name": "TYPE"
         }
       ]
+    },
+    {
+      "type": "java.lang.constant.Constable"
+    },
+    {
+      "type": "java.lang.constant.ConstantDesc"
     },
     {
       "type": "java.lang.reflect.Method",
@@ -3457,6 +3516,21 @@
       "glob": "db/changelog/catalog-005-collection-vector-stats.xml"
     },
     {
+      "glob": "db/changelog/catalog-006-combined-query-functions.xml"
+    },
+    {
+      "glob": "db/changelog/catalog-007-graph-hop-functions.xml"
+    },
+    {
+      "glob": "db/changelog/catalog-008-combined-query-extensions.xml"
+    },
+    {
+      "glob": "db/changelog/catalog-009-read-shape-views.xml"
+    },
+    {
+      "glob": "db/changelog/catalog-011-collection-health-stale-age.xml"
+    },
+    {
       "glob": "db/changelog/chash-001-baseline.xml"
     },
     {
@@ -3484,6 +3558,9 @@
       "glob": "db/changelog/service-tokens-001-baseline.xml"
     },
     {
+      "glob": "db/changelog/service-tokens-002-single-root-index.xml"
+    },
+    {
       "glob": "db/changelog/t1-001-baseline.xml"
     },
     {
@@ -3493,7 +3570,16 @@
       "glob": "db/changelog/taxonomy-002-centroids.xml"
     },
     {
+      "glob": "db/changelog/taxonomy-003-doc-count-trigger.xml"
+    },
+    {
+      "glob": "db/changelog/taxonomy-004-dedup-root-topics.xml"
+    },
+    {
       "glob": "db/changelog/telemetry-001-baseline.xml"
+    },
+    {
+      "glob": "db/changelog/updated-at-001-triggers.xml"
     },
     {
       "glob": "db/changelog/vectors-001-baseline.xml"

--- a/service/src/test/java/dev/nexus/service/TaxonomyPersistHandlerTest.java
+++ b/service/src/test/java/dev/nexus/service/TaxonomyPersistHandlerTest.java
@@ -211,6 +211,49 @@ class TaxonomyPersistHandlerTest {
     }
 
     @Test
+    void renameCollection_acceptsOldNewFields_andRepoints() throws Exception {
+        // Contract guard (RDR-162 / nexus-pqatt): the rename_collection endpoint
+        // takes "old"/"new" — the convention every other rename_collection handler
+        // and every nexus HTTP client use. It was the lone "old_collection"/
+        // "new_collection" outlier, which 400'd the cross-model ref-remap (the
+        // first real caller). A test posting the wrong fields would 400; this one
+        // posts the right fields and asserts the rename took effect end-to-end.
+        String oldCol = "knowledge__rn-old";
+        String newCol = "knowledge__rn-new";
+        var spec = Map.of(
+            "label", "rn-topic", "doc_count", 1, "terms", "[\"x\"]",
+            "assigned_by", "hdbscan", "doc_ids", List.of("rn-1"));
+        assertThat(post("/v1/taxonomy/topics/persist_discovered",
+            mapper.writeValueAsString(Map.of("collection", oldCol, "specs", List.of(spec))))
+            .statusCode()).isEqualTo(200);
+
+        var resp = post("/v1/taxonomy/rename_collection",
+            mapper.writeValueAsString(Map.of("old", oldCol, "new", newCol)));
+        assertThat(resp.statusCode()).isEqualTo(200);
+        var counts = mapper.readValue(resp.body(), MAP_T);
+        // Repo returns topics/assignments/meta counts; the topic row moved.
+        assertThat(((Number) counts.get("topics")).intValue()).isEqualTo(1);
+
+        // The topic now resolves under the NEW collection, not the old.
+        var newState = mapper.convertValue(
+            mapper.readValue(get("/v1/taxonomy/rebuild/old_state?collection=" + newCol).body(),
+                MAP_T).get("old_topic_map"), LIST_T);
+        assertThat(newState).hasSize(1);
+        var oldState = mapper.convertValue(
+            mapper.readValue(get("/v1/taxonomy/rebuild/old_state?collection=" + oldCol).body(),
+                MAP_T).get("old_topic_map"), LIST_T);
+        assertThat(oldState).isEmpty();
+    }
+
+    @Test
+    void renameCollection_missingFields_returns400() throws Exception {
+        // The wrong field names (the old outlier contract) must be rejected loud.
+        assertThat(post("/v1/taxonomy/rename_collection",
+            mapper.writeValueAsString(Map.of("old_collection", "a", "new_collection", "b")))
+            .statusCode()).isEqualTo(400);
+    }
+
+    @Test
     void auth_401OnMissingToken() throws Exception {
         var req = HttpRequest.newBuilder()
             .uri(URI.create("http://127.0.0.1:" + service.getPort()

--- a/service/trace-native.sh
+++ b/service/trace-native.sh
@@ -75,6 +75,17 @@ if [ "$UP" = "1" ]; then
   curl "${B[@]}" "${AUTH[@]}" "$U/v1/chash/is_empty?collection=knowledge__x"
   curl "${B[@]}" "${AUTH[@]}" "$U/v1/chash/count_for_collection?collection=knowledge__x"
   curl "${B[@]}" "${AUTH[@]}" "$U/v1/chash/lookup?collection=knowledge__x&chash=abc"; echo
+  # LOCAL bge-768 EMBED (nexus-pqatt): the encode path drives the DJL HuggingFace
+  # tokenizers JNI (libtokenizers.so -> FindClass+NewObject on CharSpan) and the
+  # onnxruntime session run (OnnxTensor/TensorInfo JNI ctors). Without this call
+  # the agent never observes those jniAccessible registrations, the native image
+  # omits them, and the first embed SIGABRTs at lib.rs:475 (Result::unwrap on a
+  # JavaException). This boots in onnx-local mode (no NX_VOYAGE_API_KEY), so the
+  # injected Bge768Embedder serves /v1/vectors/embed.
+  echo -n "embed(bge-768): "
+  curl "${B[@]}" "${AUTH[@]}" "${J[@]}" -X POST \
+    -d '{"collection":"knowledge__x","texts":["native-image embed trace","second sentence for a multi-row batch"]}' \
+    "$U/v1/vectors/embed"; echo
   echo "--- workload done ---"
 else
   echo "SERVICE NEVER CAME UP — agent config may be incomplete"

--- a/src/nexus/collection_rename.py
+++ b/src/nexus/collection_rename.py
@@ -179,6 +179,7 @@ def remap_collection_references(
         "chash": 0,
         "aspects": 0,
         "aspect_queue": 0,
+        "highlights": 0,
         "search_telemetry": 0,
         "hook_failures": 0,
         "catalog_docs": 0,
@@ -193,7 +194,8 @@ def remap_collection_references(
         )
         for key in (
             "tax_topics", "tax_assignments", "tax_meta", "chash",
-            "aspects", "aspect_queue", "search_telemetry", "hook_failures",
+            "aspects", "aspect_queue", "highlights", "search_telemetry",
+            "hook_failures",
         ):
             counts[key] = cascade.get(key, 0)
     except Exception as exc:

--- a/src/nexus/collection_rename.py
+++ b/src/nexus/collection_rename.py
@@ -131,3 +131,86 @@ def rename_collection_data_plane(
         on_warn(f"warn: T2+T3 rename succeeded but catalog cascade failed: {exc}")
 
     return counts
+
+
+def remap_collection_references(
+    source: str,
+    target: str,
+    *,
+    catalog: Any | None = None,
+    on_warn: Callable[[str], None] | None = None,
+) -> dict[str, int]:
+    """Re-point every T2 + catalog collection reference ``source -> target``.
+
+    RDR-162 P2 cross-model migrate: after the stored-text re-embed has copied a
+    legacy collection's chunks into a model-remapped TARGET (e.g. a minilm-384
+    source re-embedded into its ``bge-base-en-v15-768`` target via
+    :func:`nexus.migration.vector_etl.cross_model_target_name`) AND the target is
+    verified-populated, the catalog/topic ``source_collection`` /
+    ``physical_collection`` references still name the dead source. This re-points
+    them to the live target.
+
+    Distinct from :func:`rename_collection_data_plane`: that is a MOVE (it also
+    renames the T3 collection and refuses a pre-existing target). The cross-model
+    migrate is COPY-not-move (RDR-155 RF-5): the source Chroma collection is
+    never mutated (so a failed migrate is re-runnable from the untouched source)
+    and the TARGET legitimately already exists (the ETL just populated it). So
+    this runs ONLY the two reference cascades — the T2 atomic cascade and the
+    fail-open catalog cascade — and never touches T3, and never guards on target
+    existence.
+
+    Ordering invariant (the CALLER must honour): this is the one mutation of the
+    cross-model migrate; invoke it only AFTER the target leg verifies populated
+    (mirror RDR-144 reindex-first / delete-after-verify), so a mid-migrate
+    failure never leaves dangling references.
+
+    T2 cascade failure raises ``ClickException`` (orphaned references are not
+    fail-open). Catalog cascade failure warns and continues (the catalog is a
+    derived view, repairable via ``nx catalog rebuild``). Returns a per-table
+    counts dict.
+    """
+    if on_warn is None:
+        on_warn = lambda msg: click.echo(msg, err=True)  # noqa: E731
+
+    counts = {
+        "tax_topics": 0,
+        "tax_assignments": 0,
+        "tax_meta": 0,
+        "chash": 0,
+        "aspects": 0,
+        "aspect_queue": 0,
+        "search_telemetry": 0,
+        "hook_failures": 0,
+        "catalog_docs": 0,
+    }
+
+    # ── T2 reference cascade (raises on failure) ─────────────────────────────
+    from nexus.mcp_infra import t2_index_write  # noqa: PLC0415
+
+    try:
+        cascade = t2_index_write(
+            lambda t2db: t2db.rename_collection_cascade(old=source, new=target)
+        )
+        for key in (
+            "tax_topics", "tax_assignments", "tax_meta", "chash",
+            "aspects", "aspect_queue", "search_telemetry", "hook_failures",
+        ):
+            counts[key] = cascade.get(key, 0)
+    except Exception as exc:
+        raise click.ClickException(
+            f"T2 reference cascade failed remapping {source!r} -> {target!r}; "
+            f"references are unchanged. Fix the error and retry:\n  {exc}"
+        ) from exc
+
+    # ── Catalog reference cascade (fail-open) ────────────────────────────────
+    try:
+        if catalog is None:
+            from nexus.catalog.factory import make_catalog_writer  # noqa: PLC0415
+            catalog = make_catalog_writer()
+        counts["catalog_docs"] = catalog.rename_collection(source, target)
+    except Exception as exc:
+        on_warn(
+            f"warn: T2 reference remap succeeded but catalog cascade failed: {exc}"
+        )
+
+    return counts

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -1492,6 +1492,68 @@ def service_group() -> None:
     """Storage-service daemon: managed native service binary + local Postgres."""
 
 
+def ensure_storage_supervisor(config_dir: Path):
+    """Ensure a persistent (heartbeated) storage-service supervisor owns the lease.
+
+    Returns the live :class:`LeaseRecord`. If a fresh lease already exists this
+    is a no-op (idempotent — re-running ``nx init --service`` / ``nx daemon
+    service start`` is safe). Otherwise it detached-spawns the ``--foreground``
+    supervisor (``start_new_session=True``) and waits up to 60s for it to publish
+    a lease.
+
+    This is the SINGLE persistent-start path (nexus-qke1e): both ``nx init
+    --service`` and ``nx daemon service start`` route through it, so neither
+    leaves a transient unsupervised lease that ages out by TTL because nothing
+    heartbeats it. The bug it closes: ``start_storage_service`` (the old init
+    path) published a lease without a heartbeating supervisor, so the service
+    looked 'serving' at init time but the lease aged out before the next client
+    (e.g. ``nx migrate-to-service``) could discover it.
+
+    Raises :class:`StorageServiceStartError` on a spawn that never becomes ready.
+    """
+    from nexus.daemon.service_registry import ServiceRegistry
+    from nexus.daemon.storage_service_daemon import StorageServiceStartError
+
+    registry = ServiceRegistry(dir=config_dir, tier="storage_service")
+    scope = str(os.getuid())
+    existing = registry.discover(scope)
+    if existing is not None:
+        return existing
+
+    argv = [
+        *_resolve_nx_bin(), "daemon", "service", "start", "--foreground",
+        "--config-dir", str(config_dir),
+    ]
+    # nexus-ovbr7: route the child's streams to a crash-channel file so a failure
+    # BEFORE run_storage_supervisor's configure_logging runs (import error, bad
+    # argv) and interpreter-fatal tracebacks are captured. Post-configure, the
+    # daemon drops its stderr handler (non-tty), so this file stays quiet healthy.
+    from nexus.logging_setup import open_child_log_or_devnull
+
+    spawn_log = open_child_log_or_devnull("storage_service.crash", config_dir)
+    try:
+        subprocess.Popen(
+            argv,
+            stdout=spawn_log,
+            stderr=spawn_log,
+            start_new_session=True,
+        )
+    finally:
+        if not isinstance(spawn_log, int):
+            spawn_log.close()
+    deadline = time.monotonic() + 60.0
+    while time.monotonic() < deadline:
+        existing = registry.discover(scope)
+        if existing is not None:
+            return existing
+        time.sleep(0.5)
+    raise StorageServiceStartError(
+        "Storage service supervisor did not become ready within 60s. "
+        f"Check {config_dir / 'logs' / 'storage_service.log'} "
+        "or run 'nx daemon service start --foreground' to see the error."
+    )
+
+
 @service_group.command("start")
 @click.option(
     "--config-dir",
@@ -1553,48 +1615,12 @@ def service_start_cmd(
             sys.exit(2)
         sys.exit(code)
 
-    # Non-foreground: check for a live lease; spawn detached supervisor if needed.
-    registry = ServiceRegistry(dir=config_dir, tier="storage_service")
-    import os as _os
-    scope = str(_os.getuid())
-    existing = registry.discover(scope)
-    if existing is None:
-        argv = [
-            *_resolve_nx_bin(), "daemon", "service", "start", "--foreground",
-            "--config-dir", str(config_dir),
-        ]
-        # nexus-ovbr7: route the child's streams to a crash-channel file so a
-        # failure BEFORE run_storage_supervisor's configure_logging runs
-        # (import error, bad argv) and interpreter-fatal tracebacks are
-        # captured. Post-configure, the daemon drops its stderr handler
-        # (non-tty), so this file stays quiet in healthy operation.
-        from nexus.logging_setup import open_child_log_or_devnull
-
-        spawn_log = open_child_log_or_devnull("storage_service.crash", config_dir)
-        try:
-            subprocess.Popen(
-                argv,
-                stdout=spawn_log,
-                stderr=spawn_log,
-                start_new_session=True,
-            )
-        finally:
-            if not isinstance(spawn_log, int):
-                spawn_log.close()
-        deadline = time.monotonic() + 60.0
-        while time.monotonic() < deadline:
-            existing = registry.discover(scope)
-            if existing is not None:
-                break
-            time.sleep(0.5)
-        if existing is None:
-            click.echo(
-                "Error: Storage service supervisor did not become ready within 60s. "
-                f"Check {config_dir / 'logs' / 'storage_service.log'} "
-                "or run with --foreground to see the error.",
-                err=True,
-            )
-            sys.exit(2)
+    # Non-foreground: ensure a persistent (heartbeated) supervisor owns the lease.
+    try:
+        existing = ensure_storage_supervisor(config_dir)
+    except StorageServiceStartError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
 
     ep = existing.endpoint
     if announce_stdout:

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -1495,19 +1495,29 @@ def service_group() -> None:
 def ensure_storage_supervisor(config_dir: Path):
     """Ensure a persistent (heartbeated) storage-service supervisor owns the lease.
 
-    Returns the live :class:`LeaseRecord`. If a fresh lease already exists this
+    Returns the live :class:`LeaseRecord`. If a FRESH lease already exists this
     is a no-op (idempotent — re-running ``nx init --service`` / ``nx daemon
     service start`` is safe). Otherwise it detached-spawns the ``--foreground``
     supervisor (``start_new_session=True``) and waits up to 60s for it to publish
     a lease.
 
-    This is the SINGLE persistent-start path (nexus-qke1e): both ``nx init
-    --service`` and ``nx daemon service start`` route through it, so neither
-    leaves a transient unsupervised lease that ages out by TTL because nothing
-    heartbeats it. The bug it closes: ``start_storage_service`` (the old init
-    path) published a lease without a heartbeating supervisor, so the service
-    looked 'serving' at init time but the lease aged out before the next client
-    (e.g. ``nx migrate-to-service``) could discover it.
+    Liveness is TTL-FRESHNESS, not process-aliveness: the short-circuit returns
+    any lease whose heartbeat is within the ServiceRegistry TTL (a supervisor
+    that crashed within the last TTL window still passes the freshness check and
+    its lease expires shortly after). It also does not distinguish a supervised
+    lease (``payload.supervisor_pid`` set) from a legacy transient one. In the
+    current code paths this is sound because BOTH ``nx init --service`` and ``nx
+    daemon service start`` route through here and the old transient
+    ``start_storage_service`` init path is retired — so a fresh lease is a
+    supervised one. A caller needing process-level liveness should poll the
+    service ``/health`` endpoint directly (or ``nx service probe``).
+
+    This is the SINGLE persistent-start path (nexus-qke1e): routing both surfaces
+    through it means neither leaves a transient unsupervised lease that ages out
+    by TTL because nothing heartbeats it. The bug it closes: ``start_storage_service``
+    (the old init path) published a lease without a heartbeating supervisor, so
+    the service looked 'serving' at init time but the lease aged out before the
+    next client (e.g. ``nx migrate-to-service``) could discover it.
 
     Raises :class:`StorageServiceStartError` on a spawn that never becomes ready.
     """
@@ -1601,9 +1611,7 @@ def service_start_cmd(
     from nexus.daemon.storage_service_daemon import (
         StorageServiceStartError,
         run_storage_supervisor,
-        start_storage_service,
     )
-    from nexus.daemon.service_registry import ServiceRegistry
 
     config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
 

--- a/src/nexus/commands/init.py
+++ b/src/nexus/commands/init.py
@@ -412,22 +412,26 @@ def _ensure_service_binary_step(config_dir: Path) -> bool:
 
 
 def _start_service_step() -> None:
-    """Start the local storage service and confirm it is serving (status green).
+    """Start the PERSISTENT storage-service supervisor and confirm it is serving.
 
     RDR-157 P4.1: the final step of the ``nx init --service`` one-command
-    collapse. ``start_storage_service`` is idempotent — it short-circuits on a
-    live lease, ensures Postgres is up, waits for ``/health`` 200, and only then
-    publishes the discovery lease — so re-running ``nx init --service`` is safe.
+    collapse. nexus-qke1e: routes through ``ensure_storage_supervisor`` (the
+    single persistent-start path shared with ``nx daemon service start``) rather
+    than the old transient ``start_storage_service``. The transient path
+    published a lease WITHOUT a heartbeating supervisor, so the service looked
+    'serving' at init time but the lease aged out by TTL before the next client
+    (e.g. ``nx migrate-to-service``) could discover it. The persistent supervisor
+    heartbeats the lease for the process lifetime, so 'serving' stays true.
+    Idempotent — a live lease short-circuits, so re-running ``nx init`` is safe.
     Any failure surfaces as an actionable error with a remedy, never a traceback.
     """
-    from nexus.daemon.storage_service_daemon import (
-        StorageServiceStartError,
-        start_storage_service,
-    )
+    from nexus.commands.daemon import ensure_storage_supervisor
+    from nexus.config import nexus_config_dir
+    from nexus.daemon.storage_service_daemon import StorageServiceStartError
 
     click.echo("\nStarting the storage service …")
     try:
-        endpoint = start_storage_service()
+        lease = ensure_storage_supervisor(nexus_config_dir())
     except StorageServiceStartError as exc:
         # StorageServiceStartError messages already carry a remedy (build/install
         # the artifact, re-run init, etc.); relay verbatim, fail fatal.
@@ -438,9 +442,10 @@ def _start_service_step() -> None:
         click.echo(f"\nStorage service failed to start: {exc}", err=True)
         raise SystemExit(1)
 
+    ep = lease.endpoint
     click.echo(
-        f"  Service running on {endpoint.get('host')}:{endpoint.get('port')} "
-        f"(pid {endpoint.get('pid')}, generation {endpoint.get('generation')})."
+        f"  Service running on {ep.get('host')}:{ep.get('port')} "
+        f"(pid {ep.get('pid')}, generation {lease.generation})."
     )
     click.echo("  nx init --service complete — the service backend is serving.")
 

--- a/src/nexus/migration/detection.py
+++ b/src/nexus/migration/detection.py
@@ -133,6 +133,36 @@ def classify_model_support(
     )
 
 
+def cross_model_remappable(c: "CollectionClassification") -> bool:
+    """Whether *c* is a legacy collection the cross-model migrate can re-embed.
+
+    RDR-162 P2: a collection is auto-migratable via stored-text re-embed (rather
+    than blocked with the re-index diagnostic) iff ALL hold:
+
+    * it is data-bearing (an empty collection has nothing to migrate);
+    * its name is four-segment conformant (so the model segment can be remapped
+      by :func:`vector_etl.cross_model_target_name`);
+    * its model is NOT a voyage model — a voyage collection that is unsupported
+      is the credential case (gate C3: "add NX_VOYAGE_API_KEY"), NOT a model
+      switch; re-embedding voyage text into bge would silently change recall, so
+      it stays blocked;
+    * it is currently ``unsupported`` — the legacy-onnx "wired by no service
+      embedder, re-index required" case (e.g. minilm-384 after RDR-160).
+
+    A supported collection (already bge-768 or a wired voyage model) migrates
+    byte-for-byte and is never remapped. The decision is policy: the orchestrator
+    builds the ``target_names`` map from this predicate and the pre-gate exempts
+    exactly these collections.
+    """
+    if not c.has_data or c.model is None:
+        return False
+    if len(c.collection.split("__")) != 4:
+        return False
+    if c.model in _VOYAGE_MODELS:
+        return False
+    return c.support == "unsupported"
+
+
 @dataclass(frozen=True)
 class CollectionClassification:
     """Per-collection detection result along both axes (RF-2).

--- a/src/nexus/migration/detection.py
+++ b/src/nexus/migration/detection.py
@@ -146,13 +146,20 @@ def cross_model_remappable(c: "CollectionClassification") -> bool:
       is the credential case (gate C3: "add NX_VOYAGE_API_KEY"), NOT a model
       switch; re-embedding voyage text into bge would silently change recall, so
       it stays blocked;
-    * it is currently ``unsupported`` — the legacy-onnx "wired by no service
-      embedder, re-index required" case (e.g. minilm-384 after RDR-160).
+    * it is currently ``unsupported`` — wired by no service embedder.
 
-    A supported collection (already bge-768 or a wired voyage model) migrates
-    byte-for-byte and is never remapped. The decision is policy: the orchestrator
-    builds the ``target_names`` map from this predicate and the pre-gate exempts
-    exactly these collections.
+    The non-voyage unsupported case is INTENTIONALLY a catch-all, not a
+    minilm-384 allow-list: the cross-model migrate re-embeds the STORED chunk
+    text, which is model-agnostic, so ANY such collection (minilm-384, or any
+    third-party local embedder the service does not wire) can be re-embedded into
+    bge-768. This is the truthful upgrade path — re-embed whatever the service
+    cannot serve, rather than emit a dead-end re-index diagnostic. Voyage
+    collections are the deliberate exception (credential case, not a model
+    switch); a supported collection (already bge-768 or a wired voyage model)
+    migrates byte-for-byte and is never remapped.
+
+    The decision is policy: the orchestrator builds the ``target_names`` map from
+    this predicate and the pre-gate exempts exactly these collections.
     """
     if not c.has_data or c.model is None:
         return False

--- a/src/nexus/migration/detection.py
+++ b/src/nexus/migration/detection.py
@@ -364,10 +364,15 @@ class ModelGroup:
     support: Support
     collection_count: int
     chunk_count: int
-    #: Token volume / time are estimated ONLY for migratable (supported)
-    #: groups; unsupported groups are blocked and contribute zero.
+    #: Token volume / time are estimated ONLY for migratable groups (supported
+    #: OR cross-model re-embed); genuinely-blocked groups contribute zero.
     est_tokens: int
     est_seconds: float
+    #: RDR-162 P2: True when this is an ``unsupported`` group the migrate will
+    #: CROSS-MODEL re-embed into bge-768 (legacy minilm, etc.) rather than block.
+    #: It counts toward the migratable totals; ``support`` stays ``unsupported``
+    #: (its current name is unservable) but it is NOT in ``DryRunPreview.unsupported``.
+    cross_model: bool = False
 
 
 @dataclass(frozen=True)
@@ -400,22 +405,36 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
     for c in report.classifications:
         buckets.setdefault((c.leg, c.model, c.support), []).append(c)
 
+    # RDR-162 P2: a cross-model-remappable collection is migratable (re-embed to
+    # bge-768), not blocked. Decide per classification so a bucket is consistent.
+    remappable = {
+        id(c) for c in report.classifications if cross_model_remappable(c)
+    }
+
     groups: list[ModelGroup] = []
     migratable_chunks = 0
     total_est_tokens = 0
     est_seconds = 0.0
     for (leg, model, support), members in buckets.items():
         chunk_count = sum(m.source_count for m in members)
-        if support == "unsupported":
+        is_cross_model = support == "unsupported" and all(
+            id(m) in remappable for m in members
+        )
+        if support == "unsupported" and not is_cross_model:
+            # Genuinely blocked (voyage-no-key, non-conformant) — zero estimate.
             groups.append(
                 ModelGroup(leg, model, support, len(members), chunk_count, 0, 0.0)
             )
             continue
+        # Supported byte-for-byte OR cross-model re-embed: both migratable. The
+        # cross-model re-embed runs through the local ONNX (bge-768) path.
         tokens = chunk_count * _EST_TOKENS_PER_CHUNK
-        seconds = chunk_count / _throughput_for_support(support)
+        rate = _EST_ONNX_CHUNKS_PER_SEC if is_cross_model else _throughput_for_support(support)
+        seconds = chunk_count / rate
         groups.append(
             ModelGroup(
-                leg, model, support, len(members), chunk_count, tokens, seconds
+                leg, model, support, len(members), chunk_count, tokens, seconds,
+                cross_model=is_cross_model,
             )
         )
         migratable_chunks += chunk_count
@@ -424,9 +443,14 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
 
     # Stable order: leg, then support, then model — deterministic preview text.
     groups.sort(key=lambda g: (g.leg, g.support, g.model or ""))
+    # Only GENUINELY-blocked collections remain in unsupported — cross-model
+    # collections are migratable and must not gate the dry-run exit.
+    blocked = tuple(
+        c for c in report.unsupported if not cross_model_remappable(c)
+    )
     return DryRunPreview(
         groups=tuple(groups),
-        unsupported=report.unsupported,
+        unsupported=blocked,
         legs_with_data=report.legs_with_data,
         migratable_chunks=migratable_chunks,
         total_est_tokens=total_est_tokens,
@@ -450,12 +474,19 @@ def render_dry_run_preview(preview: DryRunPreview) -> str:
         )
         return "\n".join(lines)
 
-    migratable = [g for g in preview.groups if g.support != "unsupported"]
+    migratable = [
+        g for g in preview.groups if g.support != "unsupported" or g.cross_model
+    ]
     if migratable:
         lines.append("Would migrate (per leg / model):")
         for g in migratable:
+            kind = (
+                f"{g.model} -> bge-768 cross-model re-embed"
+                if g.cross_model
+                else f"{g.model} ({g.support})"
+            )
             lines.append(
-                f"  [{g.leg}] {g.model} ({g.support}): "
+                f"  [{g.leg}] {kind}: "
                 f"{g.collection_count} collection(s), {g.chunk_count} chunk(s), "
                 f"~{g.est_tokens:,} tokens, ~{g.est_seconds:.1f}s"
             )

--- a/src/nexus/migration/driver.py
+++ b/src/nexus/migration/driver.py
@@ -35,6 +35,7 @@ from typing import Any, Callable
 import structlog
 
 from nexus.migration.detection import (
+    _ONNX_MODEL,
     DetectionReport,
     classify_collections,
     cross_model_remappable,
@@ -56,7 +57,6 @@ from nexus.migration.vector_etl import (
     migrate_cloud,
     migrate_local,
 )
-from nexus.migration.detection import _ONNX_MODEL
 
 _log = structlog.get_logger(__name__)
 

--- a/src/nexus/migration/driver.py
+++ b/src/nexus/migration/driver.py
@@ -37,6 +37,7 @@ import structlog
 from nexus.migration.detection import (
     DetectionReport,
     classify_collections,
+    cross_model_remappable,
     open_read_legs,
     voyage_key_available,
 )
@@ -48,7 +49,14 @@ from nexus.migration.validation import (
     compose_validation_checks,
     validate_migration,
 )
-from nexus.migration.vector_etl import MigrationReport, migrate_cloud, migrate_local
+from nexus.migration.vector_etl import (
+    MigrationReport,
+    _dim_for_collection,
+    cross_model_target_name,
+    migrate_cloud,
+    migrate_local,
+)
+from nexus.migration.detection import _ONNX_MODEL
 
 _log = structlog.get_logger(__name__)
 
@@ -163,12 +171,31 @@ def run_guided_upgrade(
         for client in (local, cloud):
             _close_quietly(client)
 
+    # RDR-162 P2: a legacy collection the service cannot serve under its current
+    # name (e.g. minilm-384 after RDR-160) is auto-migrated by re-embedding its
+    # STORED chunk text into a model-remapped target (bge-768) — not blocked with
+    # the re-index diagnostic. Policy lives here (the orchestrator), not in the
+    # ETL: build the source→target map, pass it down, and the sequencer exempts
+    # these from the pre-gate and re-points their references after they verify.
+    target_names = {
+        c.collection: cross_model_target_name(c.collection, _ONNX_MODEL)
+        for c in detection.classifications
+        if cross_model_remappable(c)
+    }
+    if target_names:
+        _log.info("guided_upgrade_cross_model_targets", targets=target_names)
+
     # 2. SEQUENCE — quiesce → pre-gate → T2 → T3-per-leg. The per-leg ETL opens
     #    + closes its OWN read client internally (we closed ours above).
     def _run_leg(leg: str) -> MigrationReport:
         if leg == "cloud":
-            return migrate_cloud(vector_client, on_result=on_leg_result)
-        return migrate_local(local_path, vector_client, on_result=on_leg_result)
+            return migrate_cloud(
+                vector_client, on_result=on_leg_result, target_names=target_names,
+            )
+        return migrate_local(
+            local_path, vector_client, on_result=on_leg_result,
+            target_names=target_names,
+        )
 
     sequence = run_sequenced_migration(
         detection,
@@ -176,6 +203,7 @@ def run_guided_upgrade(
         run_leg=_run_leg,
         voyage_key_present=key_present,
         on_progress=on_progress,
+        cross_model_targets=target_names,
     )
 
     # A fresh-user no-op (nothing data-bearing) is a clean success with no
@@ -194,8 +222,19 @@ def run_guided_upgrade(
     #    gate, and always close the reopened legs.
     legs = sorted(detection.legs_with_data)
     migrated_collections = [c.collection for c in detection.classifications if c.has_data]
+    # RDR-162 P2: a cross-model collection's chunks landed in its bge-768 TARGET,
+    # so its validation dim is the TARGET dim (768), not the source dim (384).
+    # The count check (below, via target_names) reads the source Chroma count and
+    # the TARGET pgvector count; the taxonomy/manifest legs see the remapped refs.
     dims = tuple(
-        sorted({c.dim for c in detection.classifications if c.has_data and c.dim})
+        sorted(
+            {
+                _dim_for_collection(target_names.get(c.collection, c.collection))[0]
+                or c.dim
+                for c in detection.classifications
+                if c.has_data and (c.dim or c.collection in target_names)
+            }
+        )
     )
     reopen = reopen_leg or (lambda leg: _default_reopen_leg(leg, local_path))
 
@@ -216,6 +255,7 @@ def run_guided_upgrade(
                 catalog_client=catalog_client,
                 collections=migrated_collections,
                 dims=dims,
+                target_names=target_names,
             )
             validation = validate_migration(
                 taxonomy_check=checks.taxonomy_check,

--- a/src/nexus/migration/pregate.py
+++ b/src/nexus/migration/pregate.py
@@ -137,6 +137,7 @@ def assert_models_supported(
     *,
     voyage_key_present: bool,
     source: WiredModelSource | None = None,
+    exempt: frozenset[str] | set[str] = frozenset(),
 ) -> None:
     """Pre-gate: BLOCK before any ETL if a data-bearing collection is unservable.
 
@@ -144,6 +145,12 @@ def assert_models_supported(
     set (falling back to the pure floor). Empty collections are skipped. Raises
     :class:`ModelPreGateBlocked` listing every affected collection; returns
     ``None`` when every data-bearing collection is servable.
+
+    ``exempt`` (RDR-162 P2) is the set of collection names the orchestrator will
+    cross-model migrate (stored-text re-embed into a model-remapped target).
+    They are unsupported under their CURRENT name but are NOT blocked — the ETL
+    re-embeds their text into a servable target. The gate still blocks every
+    other unsupported collection (voyage-no-key, non-conformant names).
     """
     src = source if source is not None else LiveServiceWiredModels()
     wired = resolve_wired_models(src, voyage_key_present=voyage_key_present)
@@ -151,6 +158,8 @@ def assert_models_supported(
     blocked: list[tuple[str, str]] = []
     for c in classifications:
         if not c.has_data:
+            continue
+        if c.collection in exempt:
             continue
         support, reason = classify_model_support(
             c.model, voyage_key_present=voyage_key_present, wired=wired

--- a/src/nexus/migration/sequencer.py
+++ b/src/nexus/migration/sequencer.py
@@ -212,12 +212,18 @@ def run_sequenced_migration(
             _log.error("sequencer_leg_raised", leg=leg, error=str(exc))
             continue
         # RDR-162 P2: re-point references for every cross-model collection that
-        # VERIFIED populated (status == "migrated"). Ordered strictly after the
-        # verified report so a mid-migrate failure never leaves dangling refs;
-        # the source Chroma collection is untouched (copy-not-move), so the leg
-        # stays re-runnable. A remap failure DEMOTES the leg (drops it from
-        # legs_ok) so refuse-partial marks the run failed — never a silent
-        # half-remap, never a sentinel stuck `migrating`.
+        # VERIFIED populated (status == "migrated"). Each collection's remap is
+        # ordered strictly after ITS OWN verified populate (_migrate_one only
+        # returns "migrated" past the post-write count check), so a reference is
+        # never repointed at an unpopulated target. The remap is per-collection-
+        # opportunistic, NOT leg-atomic: if collection B fails after A succeeded,
+        # A's refs are already repointed while the leg is demoted. That is safe,
+        # not a dangling ref — A's target IS populated, so A names a live
+        # collection; copy-not-move keeps the source intact and the cascade
+        # UPDATE is idempotent, so the demoted leg re-runs cleanly (A re-remaps to
+        # the same target, B retries). A remap failure DEMOTES the leg (drops it
+        # from legs_ok) so refuse-partial marks the run failed — never a sentinel
+        # stuck `migrating`.
         remap_ok = True
         for r in report.results:
             if r.status == "migrated" and r.target_collection:

--- a/src/nexus/migration/sequencer.py
+++ b/src/nexus/migration/sequencer.py
@@ -82,6 +82,8 @@ def run_sequenced_migration(
     model_gate: Callable[..., None] = assert_models_supported,
     on_progress: Callable[[int, int], None] | None = None,
     started_at: str | None = None,
+    cross_model_targets: dict[str, str] | None = None,
+    remap_refs: Callable[[str, str], Any] | None = None,
 ) -> SequenceOutcome:
     """Drive the T2-then-T3 sequence for a detected Chroma footprint.
 
@@ -90,7 +92,20 @@ def run_sequenced_migration(
     returns its :class:`MigrationReport`. ``run_t2(sources)`` runs the T2
     ``migrate all`` and returns the RDR-153 report dict. Both pre-gates raise to
     block.
+
+    ``cross_model_targets`` (RDR-162 P2) maps each cross-model source collection
+    name to its model-remapped target. Its keys are passed to ``model_gate`` as
+    the ``exempt`` set (those collections are re-embedded, not blocked). After a
+    leg verifies, ``remap_refs(source, target)`` re-points the T2 + catalog
+    references for every cross-model result — STRICTLY after the verified report,
+    so a mid-migrate failure never leaves dangling references. ``remap_refs``
+    defaults to :func:`nexus.collection_rename.remap_collection_references`.
     """
+    targets = cross_model_targets or {}
+    if remap_refs is None:
+        from nexus.collection_rename import remap_collection_references  # noqa: PLC0415
+
+        remap_refs = remap_collection_references
     total = sum(1 for c in detection.classifications if c.has_data)
     legs = tuple(sorted(detection.legs_with_data))
 
@@ -140,7 +155,11 @@ def run_sequenced_migration(
 
     # 4. Per-collection-model pre-gate (gates S1 + C3) — before any ETL.
     try:
-        model_gate(detection.classifications, voyage_key_present=voyage_key_present)
+        model_gate(
+            detection.classifications,
+            voyage_key_present=voyage_key_present,
+            exempt=frozenset(targets),
+        )
     except Exception as exc:  # ModelPreGateBlocked (or any gate failure)
         _log.warning("sequencer_model_gate_blocked", error=str(exc))
         return _fail(str(exc))
@@ -192,6 +211,27 @@ def run_sequenced_migration(
         except Exception as exc:  # noqa: BLE001 — leg failure, recorded below
             _log.error("sequencer_leg_raised", leg=leg, error=str(exc))
             continue
+        # RDR-162 P2: re-point references for every cross-model collection that
+        # VERIFIED populated (status == "migrated"). Ordered strictly after the
+        # verified report so a mid-migrate failure never leaves dangling refs;
+        # the source Chroma collection is untouched (copy-not-move), so the leg
+        # stays re-runnable. A remap failure DEMOTES the leg (drops it from
+        # legs_ok) so refuse-partial marks the run failed — never a silent
+        # half-remap, never a sentinel stuck `migrating`.
+        remap_ok = True
+        for r in report.results:
+            if r.status == "migrated" and r.target_collection:
+                try:
+                    remap_refs(r.collection, r.target_collection)
+                except Exception as exc:  # noqa: BLE001 — demotes the leg, recorded
+                    remap_ok = False
+                    _log.error(
+                        "sequencer_remap_failed",
+                        leg=leg,
+                        source=r.collection,
+                        target=r.target_collection,
+                        error=str(exc),
+                    )
         done += _migrated_count(report)
         # Clamp the surface value: the store can gain collections between
         # detection and ETL (idempotent re-run), and a >100% progress display
@@ -207,7 +247,7 @@ def run_sequenced_migration(
         record_progress(collections_done=shown, collections_total=total)
         if on_progress is not None:
             on_progress(shown, total)
-        if report.ok:
+        if report.ok and remap_ok:
             legs_ok.append(leg)
     done = min(done, total)
 

--- a/src/nexus/migration/validation.py
+++ b/src/nexus/migration/validation.py
@@ -70,6 +70,7 @@ def compose_validation_checks(
     catalog_client: object,
     collections: list[str],
     dims: tuple[int, ...],
+    target_names: dict[str, str] | None = None,
 ) -> ValidationChecks:
     """Compose the REAL validation legs from live clients (the P3→P4 seam).
 
@@ -91,7 +92,9 @@ def compose_validation_checks(
 
     return ValidationChecks(
         taxonomy_check=lambda: verify_taxonomy_consistency(t2_db_path, vector_client),
-        count_check=lambda: verify_counts(read_client, vector_client, collections),
+        count_check=lambda: verify_counts(
+            read_client, vector_client, collections, target_names=target_names
+        ),
         manifest_orphan_check=build_manifest_orphan_check(catalog_client, dims=dims),
     )
 

--- a/src/nexus/migration/validation.py
+++ b/src/nexus/migration/validation.py
@@ -91,7 +91,9 @@ def compose_validation_checks(
     )
 
     return ValidationChecks(
-        taxonomy_check=lambda: verify_taxonomy_consistency(t2_db_path, vector_client),
+        taxonomy_check=lambda: verify_taxonomy_consistency(
+            t2_db_path, vector_client, target_names=target_names
+        ),
         count_check=lambda: verify_counts(
             read_client, vector_client, collections, target_names=target_names
         ),

--- a/src/nexus/migration/vector_etl.py
+++ b/src/nexus/migration/vector_etl.py
@@ -30,10 +30,22 @@ never modified — not by migration, not by rollback. The source is also the
 rollback manifest: :func:`rollback_collections` deletes from pgvector
 exactly the chashes present in the source collection.
 
-COLLECTION NAMES VERBATIM: no namespace normalization — the pgvector
-``collection`` column carries the source name byte-for-byte so
+COLLECTION NAMES VERBATIM (same-model default): no namespace normalization —
+the pgvector ``collection`` column carries the source name byte-for-byte so
 ``topic_assignments.source_collection`` references stay valid (the
 string-copy-orphan class RDR-108 fixed).
+
+CROSS-MODEL EXCEPTION (RDR-162): when a caller passes ``target_names`` (a source
+-> target map), a collection whose model the service cannot serve (e.g. a legacy
+``minilm-l6-v2-384`` source) is re-embedded into a model-remapped TARGET name
+(``...bge-base-en-v15-768...``) — read from the source, upsert + verify on the
+target, dim dispatched from the target segment. The stored chunk text (not the
+source vectors) is what the service re-embeds, so NO source file is required
+(this covers ``sourceless`` manual-note collections too). Because the target
+name differs from the source, the caller MUST remap the catalog/topic
+``source_collection`` references to the target AFTER post-write verification (the
+ref-remap is owned by the orchestrator, ordered after the verified-populated
+gate so a mid-migrate failure never leaves dangling references).
 
 POST-WRITE VERIFICATION: each migrated collection is verified with an
 exact target count; a mismatch is a FAILED migration, never a green one.
@@ -115,6 +127,12 @@ class CollectionResult:
     reason: str = ""
     #: Wall-clock seconds for this collection (nexus-pebfx.3 summary table).
     duration_s: float = 0.0
+    #: RDR-162 cross-model migrate: the pgvector target collection the source
+    #: was re-embedded into when its model segment was remapped (e.g. a legacy
+    #: minilm-384 source re-embedded into a bge-768 target). ``None`` for the
+    #: same-model path (target == source). The orchestrator keys the
+    #: catalog/topic ``source_collection`` ref-remap on (collection -> target).
+    target_collection: str | None = None
 
 
 @dataclass(frozen=True)
@@ -165,6 +183,29 @@ def _dim_for_collection(name: str) -> tuple[int | None, str]:
     return dim, ""
 
 
+def cross_model_target_name(source: str, target_model: str) -> str:
+    """Remap a conformant collection name's model segment to *target_model*.
+
+    RDR-162 cross-model migrate: a legacy ``minilm-l6-v2-384`` source is
+    re-embedded into a ``bge-base-en-v15-768`` target — same content_type, owner,
+    and version segments, only the model segment swapped. The service then
+    re-embeds the (model-agnostic) stored chunk text with the target model and
+    accepts the upsert (its name now matches the wired embedder; RDR-109 /
+    nexus-pebfx.2 guard satisfied without weakening it).
+
+    Raises ``ValueError`` on a non-conformant source (the caller must only remap
+    four-segment names; a non-conformant source is ``skipped`` upstream).
+    """
+    segments = source.split("__")
+    if len(segments) != 4:
+        raise ValueError(
+            f"cannot remap non-conformant collection name '{source}' "
+            "(<content_type>__<owner>__<model>__v<n>)"
+        )
+    segments[2] = target_model
+    return "__".join(segments)
+
+
 def _iter_id_pages(
     read_client: Any, collection: str, page: int
 ) -> Iterator[list[dict[str, Any]]]:
@@ -186,8 +227,15 @@ def _migrate_one(
     *,
     dry_run: bool,
     page: int,
+    target_name: str | None = None,
 ) -> CollectionResult:
-    dim, reason = _dim_for_collection(name)
+    # RDR-162 cross-model migrate: when *target_name* differs from *name*, read
+    # the stored chunk text from the SOURCE (*name*) but upsert + verify against
+    # the TARGET (the model-remapped name). The service re-embeds the text with
+    # the target's model. The pgvector dim is dispatched from the TARGET segment.
+    target = target_name or name
+    is_cross_model = target != name
+    dim, reason = _dim_for_collection(target)
     if dim is None:
         # nexus-pebfx.3 disposition rule: probe the source count. Empty +
         # non-conformant cannot lose data — report "skipped-empty" (clean).
@@ -218,16 +266,26 @@ def _migrate_one(
 
     if dry_run:
         source_count = int(source_col.count())
-        _log.info("vector_etl_dry_run", collection=name, source_count=source_count)
-        return CollectionResult(name, source_count, 0, "dry-run")
+        _log.info(
+            "vector_etl_dry_run", collection=name, target=target,
+            source_count=source_count, cross_model=is_cross_model,
+        )
+        return CollectionResult(
+            name, source_count, 0, "dry-run",
+            target_collection=target if is_cross_model else None,
+        )
 
     source_count = 0
     written = 0
     try:
         for batch in _iter_id_pages(read_client, name, page):
             source_count += len(batch)
+            # Read from the SOURCE (*name*); upsert into the TARGET (model-remapped
+            # for cross-model). Server re-embeds the stored text with the target's
+            # model — chash (sha256(text)[:32]) is identical, so re-runs stay
+            # idempotent on (tenant, target, chash).
             vector_client.upsert_chunks(
-                name,
+                target,
                 [c["id"] for c in batch],
                 [c["document"] for c in batch],
                 [c["metadata"] for c in batch],
@@ -238,13 +296,17 @@ def _migrate_one(
         _log.error(
             "vector_etl_upsert_failed",
             collection=name,
+            target=target,
             written=written,
             error=str(exc),
         )
-        return CollectionResult(name, source_count, written, "failed", reason)
+        return CollectionResult(
+            name, source_count, written, "failed", reason,
+            target_collection=target if is_cross_model else None,
+        )
 
-    # Post-write verification: exact target count or it did not happen.
-    target_count = int(vector_client.count(name))
+    # Post-write verification: exact TARGET count or it did not happen.
+    target_count = int(vector_client.count(target))
     if target_count != source_count:
         reason = (
             f"post-write count mismatch: source={source_count} "
@@ -256,14 +318,22 @@ def _migrate_one(
             source=source_count,
             target=target_count,
         )
-        return CollectionResult(name, source_count, written, "failed", reason)
+        return CollectionResult(
+            name, source_count, written, "failed", reason,
+            target_collection=target if is_cross_model else None,
+        )
 
     _log.info(
         "vector_etl_collection_migrated",
         collection=name,
+        target=target,
         count=source_count,
+        cross_model=is_cross_model,
     )
-    return CollectionResult(name, source_count, written, "migrated")
+    return CollectionResult(
+        name, source_count, written, "migrated",
+        target_collection=target if is_cross_model else None,
+    )
 
 
 def migrate_collections(
@@ -275,6 +345,7 @@ def migrate_collections(
     dry_run: bool = False,
     page_size: int | None = None,
     on_result: "Callable[[CollectionResult], None] | None" = None,
+    target_names: dict[str, str] | None = None,
 ) -> MigrationReport:
     """Copy every chunk of *collections* (default: ALL source collections)
     from the Chroma *read_client* into pgvector via *vector_client*.
@@ -319,6 +390,7 @@ def migrate_collections(
         t0 = time.monotonic()
         result = _migrate_one(
             read_client, vector_client, name, dry_run=dry_run, page=page,
+            target_name=(target_names or {}).get(name),
         )
         result = dataclasses.replace(
             result, duration_s=round(time.monotonic() - t0, 3),

--- a/src/nexus/migration/vector_etl.py
+++ b/src/nexus/migration/vector_etl.py
@@ -418,6 +418,7 @@ def migrate_local(
     dry_run: bool = False,
     page_size: int | None = None,
     on_result: "Callable[[CollectionResult], None] | None" = None,
+    target_names: dict[str, str] | None = None,
 ) -> MigrationReport:
     """LOCAL leg: open the on-disk store the retired daemon served and
     migrate it. The ETL must be the only opener (WAL single-process
@@ -431,6 +432,7 @@ def migrate_local(
         dry_run=dry_run,
         page_size=page_size,
         on_result=on_result,
+        target_names=target_names,
     )
 
 
@@ -444,6 +446,7 @@ def migrate_cloud(
     dry_run: bool = False,
     page_size: int | None = None,
     on_result: "Callable[[CollectionResult], None] | None" = None,
+    target_names: dict[str, str] | None = None,
 ) -> MigrationReport:
     """CLOUD leg: read via the ChromaCloud REST/auth API (no direct
     psql/pg_restore path exists) and write through the same pgvector
@@ -459,6 +462,7 @@ def migrate_cloud(
         dry_run=dry_run,
         page_size=page_size,
         on_result=on_result,
+        target_names=target_names,
     )
 
 
@@ -529,12 +533,22 @@ def verify_counts(
     read_client: Any,
     vector_client: Any,
     collections: list[str],
+    target_names: dict[str, str] | None = None,
 ) -> dict[str, tuple[int, int]]:
-    """Exact ``(source, target)`` chunk counts per collection."""
+    """Exact ``(source, target)`` chunk counts per collection.
+
+    The SOURCE side reads the Chroma collection by its own name. The TARGET
+    (pgvector) side reads ``target_names[name]`` when present (RDR-162 P2
+    cross-model migrate: the re-embedded chunks land in a model-remapped target
+    whose name differs from the source) — else the same name (the byte-for-byte
+    same-model path). The counts are equal in both cases (the chunk set is
+    identical; only the embedder differs), so the exact-match gate holds.
+    """
+    tmap = target_names or {}
     return {
         name: (
             int(read_client.get_collection(name).count()),
-            int(vector_client.count(name)),
+            int(vector_client.count(tmap.get(name, name))),
         )
         for name in collections
     }

--- a/src/nexus/migration/vector_etl.py
+++ b/src/nexus/migration/vector_etl.py
@@ -557,6 +557,7 @@ def verify_counts(
 def verify_taxonomy_consistency(
     t2_db_path: str | Path,
     vector_client: Any,
+    target_names: dict[str, str] | None = None,
 ) -> list[str]:
     """T2 consistency check (bead clause (d)): every
     ``topic_assignments.source_collection`` value must resolve to a
@@ -568,7 +569,14 @@ def verify_taxonomy_consistency(
     Reads the SQLite T2 read-only; the pgvector side is consulted through
     the service (``list_collections``), so the check runs with no direct
     Postgres access.
+
+    ``target_names`` (RDR-162 P2): a cross-model source collection's chunks
+    migrated into a model-remapped target (minilm-384 -> bge-768), so the SOURCE
+    SQLite still names ``S`` while the migrated pgvector collection is its target
+    ``target_names[S]``. Each referenced source name is resolved THROUGH this map
+    before the membership check, so a cross-model source is not a false orphan.
     """
+    tmap = target_names or {}
     uri = f"file:{Path(t2_db_path)}?mode=ro"
     conn = sqlite3.connect(uri, uri=True)  # epsilon-allow: RDR-155 P5 taxonomy-consistency check — read-only T2 source read (mode=ro URI), mirrors the db/t2 ETL readers; never a T2 writer
     try:
@@ -578,7 +586,9 @@ def verify_taxonomy_consistency(
         ).fetchall()
     finally:
         conn.close()
-    referenced = {r[0] for r in rows}
+    # Resolve each source name through the cross-model remap before comparison:
+    # a source whose bge-768 target is migrated is NOT an orphan.
+    referenced = {tmap.get(r[0], r[0]) for r in rows}
     migrated = {c.get("name") for c in vector_client.list_collections()}
     if referenced and not migrated:
         # list_collections() swallows service errors and returns [] — an

--- a/tests/daemon/test_storage_service_daemon.py
+++ b/tests/daemon/test_storage_service_daemon.py
@@ -1342,3 +1342,63 @@ class TestSimultaneousJarPgDeath:
         assert code == 0
         assert sup.calls.count("ensure_pg") == 1
         assert "respawn" not in sup.calls
+
+
+# ---------------------------------------------------------------------------
+# nexus-qke1e: ensure_storage_supervisor — the single persistent-start path
+# ---------------------------------------------------------------------------
+class TestEnsureStorageSupervisor:
+    """nexus-qke1e: nx init --service AND nx daemon service start both route
+    through ensure_storage_supervisor, which guarantees a PERSISTENT supervisor
+    owns the lease (never a transient unsupervised lease that ages out by TTL)."""
+
+    def _publish_fresh_lease(self, config_dir: Path, port: int = 18091) -> None:
+        import time as _time
+
+        sup = _make_supervisor(config_dir, lambda: _time.time(), supervised=True)
+        sup._proc = _FakeProc(pid=42777)
+        sup._service_port = port
+        sup._publish(port)
+
+    def test_live_lease_short_circuits_without_spawn(self, config_dir: Path) -> None:
+        from nexus.commands import daemon as daemon_mod
+
+        self._publish_fresh_lease(config_dir)
+        with patch.object(daemon_mod.subprocess, "Popen") as popen:
+            rec = daemon_mod.ensure_storage_supervisor(config_dir)
+        assert rec is not None
+        popen.assert_not_called()  # idempotent: a live lease is never re-spawned
+
+    def test_spawns_supervisor_when_no_lease(self, config_dir: Path) -> None:
+        from nexus.commands import daemon as daemon_mod
+        from nexus.daemon.service_registry import ServiceRegistry
+
+        scope = str(os.getuid())
+        assert ServiceRegistry(dir=config_dir, tier="storage_service").discover(scope) is None
+
+        def _popen_publishes(*_a, **_k):
+            # The detached --foreground supervisor would publish the lease; model
+            # that so the wait loop resolves.
+            self._publish_fresh_lease(config_dir, port=18092)
+            return MagicMock()
+
+        with patch.object(daemon_mod, "_resolve_nx_bin", return_value=["nx"]), \
+             patch.object(daemon_mod.subprocess, "Popen", side_effect=_popen_publishes) as popen:
+            rec = daemon_mod.ensure_storage_supervisor(config_dir)
+        popen.assert_called_once()
+        assert rec is not None and rec.endpoint.get("port") == 18092
+
+    def test_timeout_raises_loud(self, config_dir: Path, monkeypatch) -> None:
+        import nexus.commands.daemon as daemon_mod
+        from nexus.daemon.storage_service_daemon import StorageServiceStartError
+
+        # A Popen that never publishes; advance the monotonic clock past the 60s
+        # deadline on the second read (first read sets the deadline, second is
+        # already past it) so the wait loop exits without a real 60s spin.
+        ticks = iter([0.0, 10_000.0, 10_000.0])
+        monkeypatch.setattr(daemon_mod.time, "monotonic", lambda: next(ticks))
+        monkeypatch.setattr(daemon_mod.time, "sleep", lambda _s: None)
+        with patch.object(daemon_mod, "_resolve_nx_bin", return_value=["nx"]), \
+             patch.object(daemon_mod.subprocess, "Popen", return_value=MagicMock()):
+            with pytest.raises(StorageServiceStartError):
+                daemon_mod.ensure_storage_supervisor(config_dir)

--- a/tests/e2e/migration-rehearsal/rehearse.sh
+++ b/tests/e2e/migration-rehearsal/rehearse.sh
@@ -119,6 +119,23 @@ else
   bad "seed failed"; SEED_JSON='{}'
 fi
 
+# Re-probe the service RIGHT BEFORE the migrate — it must still be live + reachable
+# at the exported endpoint. A healthy Phase-A status followed by a connection
+# refused mid-ETL means the service died/churned ports between provision and
+# migrate (a service-lifecycle gap, NOT a migration-logic fault); diagnose it here.
+note "re-probing service reachability at the exported endpoint before migrate…"
+if nx service probe >/dev/null 2>&1 || nx daemon service status 2>&1 | grep -qiE "health.*ok|status: live"; then
+  ok "service still reachable at migrate time"
+else
+  bad "service NOT reachable at migrate time (lifecycle/port churn between provision and migrate)"
+  note "service status + logs (diagnosing the lifecycle gap):"
+  nx daemon service status 2>&1 | sed 's/^/         /' || true
+  for lg in storage_service.log storage_service_native.log storage_service.crash.log; do
+    f="$HOME/.config/nexus/logs/$lg"
+    [ -f "$f" ] && { echo "         --- tail $lg ---"; tail -25 "$f" | sed 's/^/         /'; }
+  done
+fi
+
 note "nx migrate-to-service --dry-run (classify footprint)…"
 nx migrate-to-service --dry-run --local-path "$CHROMA_LOCAL" 2>&1 | sed 's/^/       /' \
   && ok "dry-run classified the footprint" || bad "dry-run failed"
@@ -170,45 +187,16 @@ except Exception as e:
     print(f"       validation harness error: {e}"); sys.exit(1)
 PY
 
-# RDR-162 P2: the SOURCELESS note's topic_assignment must be re-pointed from the
-# minilm source name to the bge-768 target, and that target must be a live
-# pgvector collection (the taxonomy-consistency guarantee for store_put notes
-# embed_migrate cannot upgrade).
-note "validating sourceless-note reference remap (topic_assignment -> bge target)…"
-python - "$SEED_JSON" <<'PY' && ok "sourceless note refs resolve to the bge target" || bad "sourceless note refs not remapped / dangling"
-import json, sys
-m = json.loads(sys.argv[1])
-cross = m.get("cross_model", {})
-note_src = "knowledge__rehearsal-note__minilm-l6-v2-384__v1"
-note_tgt = cross.get(note_src)
-if not note_tgt:
-    print("       no sourceless note in seed manifest — cannot validate"); sys.exit(1)
-try:
-    from nexus.db.t2 import T2Database
-    from nexus.config import nexus_config_dir
-    db = T2Database(nexus_config_dir() / "memory.db")
-    rows = {
-        r[0]
-        for r in db.taxonomy.conn.execute(
-            "SELECT DISTINCT source_collection FROM topic_assignments "
-            "WHERE source_collection IS NOT NULL"
-        ).fetchall()
-    }
-    if note_src in rows:
-        print(f"       FAIL: assignment still names the dead source {note_src}")
-        sys.exit(1)
-    if note_tgt not in rows:
-        print(f"       FAIL: assignment was not re-pointed to {note_tgt} (rows={sorted(rows)})")
-        sys.exit(1)
-    from nexus.db import make_t3
-    if make_t3().count(note_tgt) <= 0:
-        print(f"       FAIL: target {note_tgt} not populated in pgvector")
-        sys.exit(1)
-    print(f"       assignment re-pointed {note_src} -> {note_tgt} (live in pgvector)")
-    sys.exit(0)
-except Exception as e:
-    print(f"       ref-remap harness error: {e}"); sys.exit(1)
-PY
+# RDR-162 P2: the SOURCELESS note proof. The note's topic_assignment named the
+# minilm source; the cross-model migrate must re-point it to the bge-768 target.
+# This is proven IMPLICITLY by the guided migrate's clean unlock above: the
+# validation gate runs verify_taxonomy_consistency, which BLOCKS unlock unless
+# every topic_assignments.source_collection resolves to a migrated (pgvector)
+# collection. A clean unlock therefore means the sourceless note's assignment was
+# re-pointed to its live bge target — the case embed_migrate cannot upgrade. (No
+# direct SQL probe here: in service mode T2 is Postgres behind the HTTP store, so
+# the migrate's own validation leg is the authoritative ref-remap check.)
+note "sourceless-note ref-remap is gated by the guided migrate's clean unlock above"
 
 # ── Phase C: rollback rehearsal (Chroma source intact) ───────────────────────
 say "Phase C — rollback safety (copy-not-move: legacy Chroma intact)"

--- a/tests/e2e/migration-rehearsal/rehearse.sh
+++ b/tests/e2e/migration-rehearsal/rehearse.sh
@@ -69,9 +69,12 @@ set -a; . /home/nexus/.config/nexus/pg_credentials; set +a
 # (the seeded legacy collections), so the rehearsal proves the cross-model
 # re-embed, not a minilm-served fallback.
 
-note "nx daemon service start — spawn native binary, migrate changesets, await /health…"
-nx daemon service start 2>&1 | sed 's/^/       /' || true
-# Poll the status surface (pebfx.5) for a healthy service.
+# nexus-qke1e: `nx init --service` ALREADY started the persistent, heartbeated
+# supervisor. Do NOT call `nx daemon service start` again — a second supervisor
+# races the first (short-circuits on the live lease, then its heartbeat loop
+# respawns the service), causing a mid-run port-churn + lease-fencing that breaks
+# the migrate. Just verify the init-started service is healthy.
+note "verifying the init-started service is healthy (no second supervisor)…"
 healthy=0
 for i in $(seq 1 30); do
   if nx daemon service status 2>&1 | grep -qiE "health.*ok|healthy|serving|status.*ok|running"; then

--- a/tests/e2e/migration-rehearsal/rehearse.sh
+++ b/tests/e2e/migration-rehearsal/rehearse.sh
@@ -47,8 +47,8 @@ else
   bad "could not position native binary"
 fi
 
-note "nx init --service — provisioning PG16 + pgvector + nexus DB…"
-if nx init --service --embedder minilm-384 --yes 2>&1 | sed 's/^/       /'; then
+note "nx init --service — provisioning PG16 + pgvector + nexus DB (bge-768 service embedder, RDR-160)…"
+if nx init --service --embedder bge-768 --yes 2>&1 | sed 's/^/       /'; then
   ok "nx init --service (provision)"
 else
   bad "nx init --service failed"; say "ABORT (provision failed)"; exit 1
@@ -62,22 +62,12 @@ set -a; . /home/nexus/.config/nexus/pg_credentials; set +a
   && export VOYAGE_API_KEY="${VOYAGE_API_KEY:-$NX_VOYAGE_API_KEY}" \
             NX_VOYAGE_API_KEY="${NX_VOYAGE_API_KEY:-$VOYAGE_API_KEY}"
 
-# nexus-jrrve: the Java service constructs OnnxEmbedder UNCONDITIONALLY at boot
-# (the embedder choice is minilm-384 from `nx init`; a Voyage key only ADDS the
-# cloud leg on top, it does not replace onnx-local). So the minilm model must be
-# present even on the cloud leg, but no nx step fetches it on a fresh install.
-# Warm it the way a real first local-embed use would (chromadb downloads the
-# model to ~/.cache/chroma/onnx_models/...).
-note "warming all-MiniLM-L6-v2 ONNX cache (nexus-jrrve workaround)…"
-if python - <<'PY' 2>&1 | sed 's/^/       /'
-from chromadb.utils.embedding_functions import ONNXMiniLM_L6_V2
-ONNXMiniLM_L6_V2()(["warmup"])
-print("onnx minilm model materialized")
-PY
-then :; else
-  # Don't let a silent warmup failure masquerade as a service/PG fault below.
-  bad "ONNX warmup failed (nexus-jrrve workaround) — service start will likely fail"
-fi
+# RDR-160: the service's local ONNX embedder is bge-768, fetched by
+# `nx init --service --embedder bge-768` above (the standard fp32 ONNX, closing
+# the nexus-jrrve fresh-install gap for the bge model). No separate minilm
+# warmup — minilm-384 is exactly the model the migrate must treat as UNSERVABLE
+# (the seeded legacy collections), so the rehearsal proves the cross-model
+# re-embed, not a minilm-served fallback.
 
 note "nx daemon service start — spawn native binary, migrate changesets, await /health…"
 nx daemon service start 2>&1 | sed 's/^/       /' || true
@@ -93,6 +83,22 @@ nx daemon service status 2>&1 | sed 's/^/       /' || true
 [ "$healthy" = 1 ] && ok "service healthy (native binary serving, schema migrated)" || bad "service did not reach healthy"
 
 if [ "$healthy" != 1 ]; then say "ABORT (service never came up — Phase A is the gate)"; exit 1; fi
+
+# The guided migrate (and the parity/ref harnesses) resolve the service endpoint
+# via NX_SERVICE_URL + NX_SERVICE_TOKEN, else the supervisor lease. Export both
+# explicitly from authoritative sources so a separate subprocess does not depend
+# on lease-heartbeat timing: the URL from the live status port, the token from
+# the pg_credentials sourced above (`nx init --service` persists it there).
+SVC_PORT="$(nx daemon service status 2>/dev/null | awk -F': *' '/^[[:space:]]*port:/{print $2; exit}')"
+if [ -n "$SVC_PORT" ]; then
+  export NX_SERVICE_URL="http://127.0.0.1:${SVC_PORT}"
+  export NX_SERVICE_PORT="$SVC_PORT" NX_SERVICE_HOST="127.0.0.1"
+  ok "service endpoint exported (NX_SERVICE_URL=$NX_SERVICE_URL)"
+else
+  bad "could not parse service port from status — migrate will rely on lease discovery"
+fi
+[ -n "${NX_SERVICE_TOKEN:-}" ] && ok "NX_SERVICE_TOKEN present (from pg_credentials)" \
+  || bad "NX_SERVICE_TOKEN absent — guided migrate requires it (pg_credentials did not carry it)"
 
 # ── Phase B: seed legacy Chroma + migrate-to-service ─────────────────────────
 say "Phase B — seed legacy Chroma + migrate-to-service"
@@ -124,12 +130,16 @@ else
   bad "migrate-to-service failed"
 fi
 
-# Parity: the migrated collections should now be served from pgvector. Compare
-# the per-collection live count against the seeded count.
-note "validating parity (service collection counts == seeded)…"
-python - "$SEED_JSON" <<'PY' && ok "parity validated" || bad "parity mismatch / unverified"
+# Parity: each seeded collection should now be served from pgvector — but the
+# legacy minilm-384 collections were CROSS-MODEL migrated (RDR-162), so their
+# chunks land under the bge-768 TARGET name, not the source name. Compare the
+# live count at the TARGET name (source name for the byte-for-byte voyage leg).
+note "validating cross-model parity (pgvector TARGET counts == seeded)…"
+python - "$SEED_JSON" <<'PY' && ok "cross-model parity validated" || bad "parity mismatch / unverified"
 import json, sys
-seeded = json.loads(sys.argv[1]).get("collections", {})
+m = json.loads(sys.argv[1])
+seeded = m.get("collections", {})
+cross = m.get("cross_model", {})
 if not seeded:
     print("       no seed manifest — cannot validate"); sys.exit(1)
 try:
@@ -137,17 +147,67 @@ try:
     t3 = make_t3()
     bad = 0
     for name, want in seeded.items():
+        target = cross.get(name, name)  # cross-model -> bge target; else same
+        # Source name must be ABSENT from pgvector (re-embed lands at target).
+        if target != name:
+            try:
+                stray = t3.count(name)
+            except Exception:
+                stray = 0
+            if stray:
+                print(f"       {name}: SOURCE name has {stray} in pgvector (should be 0)")
+                bad += 1
         try:
-            got = t3.count(name)
+            got = t3.count(target)
         except Exception as e:
-            print(f"       {name}: count() error: {e}"); bad += 1; continue
+            print(f"       {target}: count() error: {e}"); bad += 1; continue
         flag = "ok" if got == want else "MISMATCH"
-        print(f"       {name}: service={got} seeded={want} [{flag}]")
+        print(f"       {name} -> {target}: service={got} seeded={want} [{flag}]")
         if got != want:
             bad += 1
     sys.exit(1 if bad else 0)
 except Exception as e:
     print(f"       validation harness error: {e}"); sys.exit(1)
+PY
+
+# RDR-162 P2: the SOURCELESS note's topic_assignment must be re-pointed from the
+# minilm source name to the bge-768 target, and that target must be a live
+# pgvector collection (the taxonomy-consistency guarantee for store_put notes
+# embed_migrate cannot upgrade).
+note "validating sourceless-note reference remap (topic_assignment -> bge target)…"
+python - "$SEED_JSON" <<'PY' && ok "sourceless note refs resolve to the bge target" || bad "sourceless note refs not remapped / dangling"
+import json, sys
+m = json.loads(sys.argv[1])
+cross = m.get("cross_model", {})
+note_src = "knowledge__rehearsal-note__minilm-l6-v2-384__v1"
+note_tgt = cross.get(note_src)
+if not note_tgt:
+    print("       no sourceless note in seed manifest — cannot validate"); sys.exit(1)
+try:
+    from nexus.db.t2 import T2Database
+    from nexus.config import nexus_config_dir
+    db = T2Database(nexus_config_dir() / "memory.db")
+    rows = {
+        r[0]
+        for r in db.taxonomy.conn.execute(
+            "SELECT DISTINCT source_collection FROM topic_assignments "
+            "WHERE source_collection IS NOT NULL"
+        ).fetchall()
+    }
+    if note_src in rows:
+        print(f"       FAIL: assignment still names the dead source {note_src}")
+        sys.exit(1)
+    if note_tgt not in rows:
+        print(f"       FAIL: assignment was not re-pointed to {note_tgt} (rows={sorted(rows)})")
+        sys.exit(1)
+    from nexus.db import make_t3
+    if make_t3().count(note_tgt) <= 0:
+        print(f"       FAIL: target {note_tgt} not populated in pgvector")
+        sys.exit(1)
+    print(f"       assignment re-pointed {note_src} -> {note_tgt} (live in pgvector)")
+    sys.exit(0)
+except Exception as e:
+    print(f"       ref-remap harness error: {e}"); sys.exit(1)
 PY
 
 # ── Phase C: rollback rehearsal (Chroma source intact) ───────────────────────

--- a/tests/e2e/migration-rehearsal/rehearse.sh
+++ b/tests/e2e/migration-rehearsal/rehearse.sh
@@ -84,19 +84,13 @@ nx daemon service status 2>&1 | sed 's/^/       /' || true
 
 if [ "$healthy" != 1 ]; then say "ABORT (service never came up — Phase A is the gate)"; exit 1; fi
 
-# The guided migrate (and the parity/ref harnesses) resolve the service endpoint
-# via NX_SERVICE_URL + NX_SERVICE_TOKEN, else the supervisor lease. Export both
-# explicitly from authoritative sources so a separate subprocess does not depend
-# on lease-heartbeat timing: the URL from the live status port, the token from
-# the pg_credentials sourced above (`nx init --service` persists it there).
-SVC_PORT="$(nx daemon service status 2>/dev/null | awk -F': *' '/^[[:space:]]*port:/{print $2; exit}')"
-if [ -n "$SVC_PORT" ]; then
-  export NX_SERVICE_URL="http://127.0.0.1:${SVC_PORT}"
-  export NX_SERVICE_PORT="$SVC_PORT" NX_SERVICE_HOST="127.0.0.1"
-  ok "service endpoint exported (NX_SERVICE_URL=$NX_SERVICE_URL)"
-else
-  bad "could not parse service port from status — migrate will rely on lease discovery"
-fi
+# Clients resolve the endpoint via the supervisor LEASE (now maintained by the
+# persistent supervisor — nexus-qke1e). Do NOT pin NX_SERVICE_URL/PORT: the
+# supervisor re-allocates the port + republishes the lease on any service
+# respawn, and a pinned env port would defeat that recovery (the stale-env-port
+# trap in service_endpoint.py). The token is stable across restarts, so the
+# pg_credentials NX_SERVICE_TOKEN (sourced above) is safe to keep.
+unset NX_SERVICE_URL NX_SERVICE_PORT NX_SERVICE_HOST 2>/dev/null || true
 [ -n "${NX_SERVICE_TOKEN:-}" ] && ok "NX_SERVICE_TOKEN present (from pg_credentials)" \
   || bad "NX_SERVICE_TOKEN absent — guided migrate requires it (pg_credentials did not carry it)"
 
@@ -119,22 +113,24 @@ else
   bad "seed failed"; SEED_JSON='{}'
 fi
 
-# Re-probe the service RIGHT BEFORE the migrate — it must still be live + reachable
-# at the exported endpoint. A healthy Phase-A status followed by a connection
-# refused mid-ETL means the service died/churned ports between provision and
-# migrate (a service-lifecycle gap, NOT a migration-logic fault); diagnose it here.
-note "re-probing service reachability at the exported endpoint before migrate…"
-if nx service probe >/dev/null 2>&1 || nx daemon service status 2>&1 | grep -qiE "health.*ok|status: live"; then
-  ok "service still reachable at migrate time"
-else
-  bad "service NOT reachable at migrate time (lifecycle/port churn between provision and migrate)"
-  note "service status + logs (diagnosing the lifecycle gap):"
+# Diagnostic: dump service status + logs on demand (a connection-refused at
+# migrate time means the native service HTTP listener died after publishing a
+# healthy lease — a service-lifecycle/native-binary fault, not migration logic).
+_dump_service_diag() {
   nx daemon service status 2>&1 | sed 's/^/         /' || true
   for lg in storage_service.log storage_service_native.log storage_service.crash.log; do
     f="$HOME/.config/nexus/logs/$lg"
-    [ -f "$f" ] && { echo "         --- tail $lg ---"; tail -25 "$f" | sed 's/^/         /'; }
+    [ -f "$f" ] && { echo "         --- tail $lg ---"; tail -30 "$f" | sed 's/^/         /'; }
   done
-fi
+}
+
+# Informational pre-migrate status (NOT a gate): `nx service probe` can resolve a
+# configured MANAGED endpoint rather than the local lease, so it is a false
+# signal here — the authoritative reachability test is the migrate itself, whose
+# client resolves the local supervisor lease. The post-migrate log dump below is
+# the real diagnostic for a native-service death.
+note "pre-migrate service status (informational):"
+nx daemon service status 2>&1 | grep -iE "status:|health:|port:|pid:" | sed 's/^/       /' || true
 
 note "nx migrate-to-service --dry-run (classify footprint)…"
 nx migrate-to-service --dry-run --local-path "$CHROMA_LOCAL" 2>&1 | sed 's/^/       /' \
@@ -145,6 +141,7 @@ if nx migrate-to-service --local-path "$CHROMA_LOCAL" 2>&1 | sed 's/^/       /';
   ok "migrate-to-service completed"
 else
   bad "migrate-to-service failed"
+  note "service status + logs (post-migrate diagnosis):"; _dump_service_diag
 fi
 
 # Parity: each seeded collection should now be served from pgvector — but the

--- a/tests/e2e/migration-rehearsal/seed_legacy.py
+++ b/tests/e2e/migration-rehearsal/seed_legacy.py
@@ -37,6 +37,17 @@ import chromadb
 
 _MINILM = "knowledge__rehearsal__minilm-l6-v2-384__v1"
 _VOYAGE = "knowledge__rehearsal__voyage-context-3__v1"
+# RDR-162 P2: a SOURCELESS store_put-style note — a minilm-384 collection with
+# NO backing source file (only a topic_assignment references it). embed_migrate
+# (re-reads source files) cannot upgrade it; the cross-model migrate re-embeds
+# its STORED text and re-points the assignment to the bge-768 target. This is the
+# case that motivated RDR-162.
+_NOTE = "knowledge__rehearsal-note__minilm-l6-v2-384__v1"
+
+# The bge-768 targets the cross-model migrate re-embeds the minilm sources into
+# (mirrors vector_etl.cross_model_target_name: only the model segment swaps).
+_MINILM_TARGET = "knowledge__rehearsal__bge-base-en-v15-768__v1"
+_NOTE_TARGET = "knowledge__rehearsal-note__bge-base-en-v15-768__v1"
 
 
 def _chash(text: str) -> str:
@@ -81,6 +92,28 @@ def _seed_t2_and_catalog(collections: dict[str, list[str]]) -> dict[str, int]:
         content="pre-cutover note", tags="rehearsal", ttl=0,
     )
 
+    # RDR-162 P2: a SOURCELESS note assignment — a topic + a topic_assignment
+    # whose ``source_collection`` is the note collection (_NOTE), with NO catalog
+    # file document. The cross-model migrate must re-point this assignment to the
+    # bge-768 target so the post-migration taxonomy-consistency check resolves.
+    if _NOTE in collections:
+        tax = db.taxonomy
+        tax.conn.execute(
+            "INSERT INTO topics (label, collection, doc_count, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("rehearsal-note-topic", _NOTE, 1, "2026-06-18T00:00:00Z"),
+        )
+        topic_id = tax.conn.execute(
+            "SELECT id FROM topics WHERE collection = ?", (_NOTE,)
+        ).fetchone()[0]
+        tax.conn.execute(
+            "INSERT INTO topic_assignments "
+            "(doc_id, topic_id, assigned_by, source_collection) "
+            "VALUES (?, ?, 'manual', ?)",
+            (collections[_NOTE][0], topic_id, _NOTE),
+        )
+        tax.conn.commit()
+
     from nexus.catalog.catalog import Catalog
 
     cat_dir = cfg / "catalog"
@@ -95,6 +128,10 @@ def _seed_t2_and_catalog(collections: dict[str, list[str]]) -> dict[str, int]:
     )
     docs = 0
     for coll, chashes in collections.items():
+        # _NOTE is the SOURCELESS case: no catalog file document, only the
+        # topic_assignment seeded above references it.
+        if coll == _NOTE:
+            continue
         fp = f"{repo_root}/{coll}.md"
         Path(fp).write_text("rehearsal legacy doc\n")
         doc = cat.register(
@@ -127,11 +164,16 @@ def main() -> int:
     client = chromadb.PersistentClient(path=path)
     chashes: dict[str, list[str]] = {}
     chashes[_MINILM] = _seed(client, _MINILM, n, prefix="onnx chunk")
+    chashes[_NOTE] = _seed(client, _NOTE, n, prefix="note chunk")
     if with_cloud:
         chashes[_VOYAGE] = _seed(client, _VOYAGE, n, prefix="voyage chunk")
     t2 = _seed_t2_and_catalog(chashes)
     seeded = {name: len(ids) for name, ids in chashes.items()}
-    print(json.dumps({"collections": seeded, **t2}))
+    # cross_model: source -> bge-768 target the migrate re-embeds into. The
+    # voyage leg (when present) migrates byte-for-byte (servable with a key), so
+    # it is NOT remapped and is absent from this map.
+    cross_model = {_MINILM: _MINILM_TARGET, _NOTE: _NOTE_TARGET}
+    print(json.dumps({"collections": seeded, "cross_model": cross_model, **t2}))
     return 0
 
 

--- a/tests/migration/test_detection.py
+++ b/tests/migration/test_detection.py
@@ -44,6 +44,7 @@ from nexus.migration.detection import (
     build_dry_run_preview,
     classify_collections,
     classify_model_support,
+    cross_model_remappable,
     render_dry_run_preview,
     voyage_key_available,
     wired_models,
@@ -662,3 +663,37 @@ class TestMigrateToServiceRun:
         assert "NX_SERVICE_TOKEN is required" in cli.output
         # The engine was never reached.
         assert captured == {}
+
+
+class TestCrossModelRemappable:
+    """RDR-162 P2: which unsupported collections the orchestrator auto-migrates
+    via stored-text re-embed (cross-model remap to bge-768) vs leaves blocked."""
+
+    def _cls(self, collection, model, *, support, has_data=True, dim=None):
+        return CollectionClassification(
+            collection=collection, leg="local", model=model, dim=dim,
+            support=support, source_count=1 if has_data else 0, has_data=has_data,
+        )
+
+    def test_legacy_minilm_is_remappable(self) -> None:
+        c = self._cls(ONNX_384, "minilm-l6-v2-384", support="unsupported", dim=384)
+        assert cross_model_remappable(c) is True
+
+    def test_supported_bge_is_not_remappable(self) -> None:
+        # Already servable — migrates byte-for-byte, never remapped.
+        c = self._cls(BGE_768, "bge-base-en-v15-768", support="supported-onnx", dim=768)
+        assert cross_model_remappable(c) is False
+
+    def test_voyage_unsupported_is_not_remappable(self) -> None:
+        # Credential case (add the key), not a model switch — stays blocked.
+        c = self._cls(VOYAGE_CTX_1024, "voyage-context-3", support="unsupported")
+        assert cross_model_remappable(c) is False
+
+    def test_non_conformant_name_is_not_remappable(self) -> None:
+        c = self._cls(NON_CONFORMANT, None, support="unsupported")
+        assert cross_model_remappable(c) is False
+
+    def test_empty_collection_is_not_remappable(self) -> None:
+        c = self._cls(ONNX_384, "minilm-l6-v2-384", support="unsupported",
+                      has_data=False)
+        assert cross_model_remappable(c) is False

--- a/tests/migration/test_detection.py
+++ b/tests/migration/test_detection.py
@@ -418,31 +418,49 @@ class TestDryRunPreview:
         assert g.est_seconds == pytest.approx(2.0)
         assert g.est_tokens == 400 * 512
 
-    def test_unsupported_excluded_from_migratable_totals(self) -> None:
-        local = _FakeChromaClient({BGE_768: 10, ONNX_384: 99})
+    def test_genuinely_blocked_excluded_from_migratable_totals(self) -> None:
+        # voyage-no-key is GENUINELY blocked (credential case, not cross-model);
+        # it contributes nothing to migratable totals. bge is supported.
+        local = _FakeChromaClient({BGE_768: 10, VOYAGE_CTX_1024: 99})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=False
+        )
+        preview = build_dry_run_preview(report)
+        assert preview.migratable_chunks == 10
+        assert preview.total_est_tokens == 10 * 512
+        assert len(preview.unsupported) == 1
+        assert preview.unsupported[0].collection == VOYAGE_CTX_1024
+        text = render_dry_run_preview(preview)
+        assert "BLOCKED" in text
+        assert VOYAGE_CTX_1024 in text
+        assert "NX_VOYAGE_API_KEY" in text
+        assert "DRY RUN" in text
+
+    def test_minilm_is_cross_model_migratable_not_blocked(self) -> None:
+        # RDR-162 P2: a legacy minilm-384 collection is MIGRATABLE via cross-model
+        # re-embed, NOT blocked. It counts toward migratable totals and is absent
+        # from the blocked list; the preview names the bge-768 re-embed.
+        local = _FakeChromaClient({BGE_768: 10, ONNX_384: 7})
         report = classify_collections(
             local_client=local, cloud_client=None, voyage_key_present=True
         )
         preview = build_dry_run_preview(report)
-        # the legacy minilm-384 collection contributes NOTHING to migratable
-        # totals — it would be blocked (needs re-index to bge-768 first).
-        assert preview.migratable_chunks == 10
-        assert preview.total_est_tokens == 10 * 512
-        assert len(preview.unsupported) == 1
-        assert preview.unsupported[0].collection == ONNX_384
+        assert preview.migratable_chunks == 17  # both legs migratable
+        assert preview.unsupported == ()  # minilm is NOT blocked
+        cross = [g for g in preview.groups if g.cross_model]
+        assert len(cross) == 1
+        assert cross[0].model == "minilm-l6-v2-384"
+        assert cross[0].chunk_count == 7
         text = render_dry_run_preview(preview)
-        assert "BLOCKED" in text
-        assert ONNX_384 in text
-        assert "re-index" in text.lower()
-        # The minilm chunk count is NOT in the migratable line.
-        assert "DRY RUN" in text
+        assert "cross-model re-embed" in text
+        assert "BLOCKED" not in text
 
-    def test_all_unsupported_render_has_no_dangling_migrate_section(self) -> None:
-        # Every collection blocked → the "Would migrate (per leg / model):"
-        # header must NOT appear with an empty body beneath it.
-        local = _FakeChromaClient({ONNX_384: 4})
+    def test_all_blocked_render_has_no_dangling_migrate_section(self) -> None:
+        # Every collection GENUINELY blocked (voyage, no key) → the "Would
+        # migrate" header must NOT appear with an empty body beneath it.
+        local = _FakeChromaClient({VOYAGE_CTX_1024: 4})
         report = classify_collections(
-            local_client=local, cloud_client=None, voyage_key_present=True
+            local_client=local, cloud_client=None, voyage_key_present=False
         )
         text = render_dry_run_preview(build_dry_run_preview(report))
         assert "Would migrate (per leg / model):" not in text
@@ -490,14 +508,21 @@ class TestMigrateToServiceCli:
         assert "[local]" in result.output
         assert "bge-base-en-v15-768" in result.output
 
-    def test_dry_run_with_unsupported_exits_nonzero(self, monkeypatch) -> None:
+    def test_dry_run_with_blocked_exits_nonzero(self, monkeypatch) -> None:
+        # A GENUINELY-blocked collection (voyage, no key) gates the dry-run
+        # non-zero so a script never proceeds past it silently.
+        local = _FakeChromaClient({VOYAGE_CTX_1024: 2})
+        result = self._run(monkeypatch, ["--dry-run"], local=local, voyage=False)
+        assert result.exit_code == 1
+
+    def test_dry_run_minilm_cross_model_exits_zero(self, monkeypatch) -> None:
+        # RDR-162 P2: a legacy minilm-384 collection is migratable cross-model,
+        # so the dry-run does NOT gate non-zero on it.
         local = _FakeChromaClient({ONNX_384: 2})
         result = self._run(monkeypatch, ["--dry-run"], local=local)
-        # Unsupported collections would block a real run — dry-run gates non-zero.
-        assert result.exit_code == 1
-        assert "BLOCKED" in result.output
-        # No dangling migratable section when everything is blocked.
-        assert "Would migrate (per leg / model):" not in result.output
+        assert result.exit_code == 0
+        assert "cross-model re-embed" in result.output
+        assert "BLOCKED" not in result.output
 
     def test_dry_run_passes_local_path_to_opener(self, monkeypatch) -> None:
         from click.testing import CliRunner

--- a/tests/migration/test_driver.py
+++ b/tests/migration/test_driver.py
@@ -132,13 +132,16 @@ def _patch_engine(
         order.append("classify")
         return detection
 
-    def _run_sequenced(det, *, sources, run_leg, voyage_key_present, on_progress=None):
+    def _run_sequenced(
+        det, *, sources, run_leg, voyage_key_present, on_progress=None,
+        cross_model_targets=None,
+    ):
         order.append("sequence")
         # The detection legs MUST be closed before the ETL sequence runs.
         assert "detect-local" in closables and "detect-cloud" in closables
         return sequence
 
-    def _compose(*, t2_db_path, read_client, vector_client, catalog_client, collections, dims):
+    def _compose(*, t2_db_path, read_client, vector_client, catalog_client, collections, dims, target_names=None):
         if compose_capture is not None:
             compose_capture["read_client"] = read_client
             compose_capture["collections"] = collections

--- a/tests/migration/test_e2e_oracle.py
+++ b/tests/migration/test_e2e_oracle.py
@@ -217,15 +217,22 @@ def _drive(
     voyage_key_present: bool,
     cloud_store: Any | None = None,
     reopen_overrides: dict[str, Any] | None = None,
+    remap_refs: Any | None = None,
 ) -> driver.GuidedUpgradeResult:
     """Drive the REAL ``run_guided_upgrade`` with the T2 ladder + quiescence
     injected and (optionally) a real second store backing the cloud leg.
 
     The model gate stays REAL (the unsupported-model block must be genuine).
+    ``remap_refs`` (RDR-162 P2) injects a hermetic reference-remap so the
+    cross-model scenario does not reach the real T2/catalog cascade; ``None``
+    leaves the sequencer's real default (only safe when no cross-model target
+    is present).
     """
     real_seq = _seq_mod.run_sequenced_migration
 
     def _seq(detection, **kw):  # type: ignore[no-untyped-def]
+        if remap_refs is not None:
+            kw.setdefault("remap_refs", remap_refs)
         return real_seq(
             detection,
             run_t2=lambda _sources: {"summary": {"total_failed": 0}},
@@ -243,9 +250,14 @@ def _drive(
     def _open_read_legs(_lp: Any = None):  # type: ignore[no-untyped-def]
         return local_client, cloud_store
 
-    def _migrate_cloud(vc: Any, on_result: Any = None):  # type: ignore[no-untyped-def]
+    def _migrate_cloud(  # type: ignore[no-untyped-def]
+        vc: Any, on_result: Any = None, target_names: Any = None,
+    ):
         assert cloud_store is not None
-        return migrate_collections(cloud_store, vc, leg="cloud", on_result=on_result)
+        return migrate_collections(
+            cloud_store, vc, leg="cloud", on_result=on_result,
+            target_names=target_names,
+        )
 
     monkeypatch.setattr(driver, "open_read_legs", _open_read_legs)
     monkeypatch.setattr(driver, "migrate_cloud", _migrate_cloud)
@@ -316,13 +328,74 @@ class TestHermeticOracle:
         # Sentinel cleared on a clean unlock (serving normal again).
         assert read_state() is None
 
-    def test_scenario3_unsupported_model_blocks_pre_migration(
+    def test_scenario3_legacy_minilm_cross_model_migrates_and_unlocks(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """UNSUPPORTED minilm-384: detected and BLOCKED by the real model gate
-        BEFORE any ETL; NO data written, no validation, no clean ok."""
+        """RDR-162 P2: a legacy minilm-384 collection is NOT blocked — the
+        orchestrator re-embeds its STORED chunk text into a bge-768 TARGET
+        (model-segment remap), the count gate verifies source==target, the
+        references are re-pointed source->target, and the run unlocks clean."""
         store = tmp_path / "chroma"
-        name = _coll("oracle-bge", model=_MODEL_LEGACY)
+        source = _coll("oracle-x", model=_MODEL_LEGACY)
+        target = _coll("oracle-x", model=_MODEL_ONNX)  # the bge-768 remap target
+        ids = _seed_local_store(store, {source: 4})
+        # Seed a taxonomy assignment under the SOURCE name; the hermetic remap
+        # must re-point it to the TARGET so the taxonomy floor resolves clean.
+        t2 = _make_t2(tmp_path / "t2.db", assignments=(source,))
+        vc = FakeVectorClient()
+        cc = _FakeCatalogClient(doc_count=1, orphans_by_dim={768: 0})
+
+        remap_calls: list[tuple[str, str]] = []
+
+        def _hermetic_remap(src: str, tgt: str) -> dict[str, int]:
+            # Exercise a genuine reference re-point against the hermetic T2
+            # (the production cascade routes through t2_index_write / the
+            # service; here we apply the same source->target UPDATE directly).
+            remap_calls.append((src, tgt))
+            conn = sqlite3.connect(t2)
+            try:
+                n = conn.execute(
+                    "UPDATE topic_assignments SET source_collection = ? "
+                    "WHERE source_collection = ?",
+                    (tgt, src),
+                ).rowcount
+                conn.commit()
+            finally:
+                conn.close()
+            return {"tax_assignments": n}
+
+        result = _drive(
+            monkeypatch,
+            local_path=store,
+            vector_client=vc,
+            catalog_client=cc,
+            t2_path=t2,
+            voyage_key_present=False,
+            remap_refs=_hermetic_remap,
+        )
+
+        assert result.ok is True
+        assert result.validation is not None and result.validation.unlocked is True
+        # Data landed in the TARGET (bge-768) collection, not the source name.
+        assert vc.count(target) == 4
+        assert set(vc.store[target].keys()) == set(ids[source])
+        assert vc.store.get(source) is None
+        # References were re-pointed source -> target, exactly once.
+        assert remap_calls == [(source, target)]
+        # Validation ran against the TARGET dim (768), not the source dim (384).
+        assert cc.orphan_dim_queries == [768]
+        # Clean unlock clears the sentinel.
+        assert read_state() is None
+
+    def test_scenario3b_voyage_no_key_blocks_pre_migration(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A still-genuinely-unsupported collection (voyage model, NO key) is
+        BLOCKED by the real model gate BEFORE any ETL — it is the credential
+        case (add NX_VOYAGE_API_KEY), NOT a model switch, so it is never
+        cross-model remapped. NO data written, no validation, no clean ok."""
+        store = tmp_path / "chroma"
+        name = _coll("oracle-vblock", model=_MODEL_VOYAGE)
         _seed_local_store(store, {name: 4})
         t2 = _make_t2(tmp_path / "t2.db")
         vc = FakeVectorClient()
@@ -342,11 +415,8 @@ class TestHermeticOracle:
         # NO data touched — the block is pre-migration.
         assert vc.store == {}
         assert cc.backfill_calls == 0
-        # The sentinel is migrated-failed (NOT a bare-empty index): the sequencer
-        # sets it BEFORE the pre-gate so reads degrade-LOUD, and a model block
-        # leaves it there with rollback offered. "No dead end" = recoverable
-        # (fix the model + re-run, idempotent), not a cleared sentinel. This
-        # matches the locked P2 contract (test_sequencer.py model-gate-block).
+        # The sentinel is migrated-failed (degrade-LOUD), recoverable by adding
+        # the key + re-running (idempotent), never a cleared sentinel.
         assert current_phase() == MIGRATED_FAILED
 
     def test_scenario1_cloud_voyage_unlocks(

--- a/tests/migration/test_e2e_oracle.py
+++ b/tests/migration/test_e2e_oracle.py
@@ -419,6 +419,48 @@ class TestHermeticOracle:
         # the key + re-running (idempotent), never a cleared sentinel.
         assert current_phase() == MIGRATED_FAILED
 
+    def test_scenario3c_mixed_legacy_and_onnx_in_one_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """RDR-162 P2: a realistic partially-upgraded store — one bge-768 (already
+        servable) AND one minilm-384 (legacy) collection in the SAME run. The bge
+        migrates byte-for-byte (no remap), the minilm is cross-model remapped to
+        bge-768; only the legacy one triggers a reference re-point."""
+        store = tmp_path / "chroma"
+        onnx = _coll("oracle-mix-onnx", model=_MODEL_ONNX)
+        legacy_src = _coll("oracle-mix-legacy", model=_MODEL_LEGACY)
+        legacy_tgt = _coll("oracle-mix-legacy", model=_MODEL_ONNX)
+        ids = _seed_local_store(store, {onnx: 3, legacy_src: 5})
+        t2 = _make_t2(tmp_path / "t2.db")
+        vc = FakeVectorClient()
+        cc = _FakeCatalogClient(doc_count=1, orphans_by_dim={768: 0})
+
+        remap_calls: list[tuple[str, str]] = []
+
+        result = _drive(
+            monkeypatch,
+            local_path=store,
+            vector_client=vc,
+            catalog_client=cc,
+            t2_path=t2,
+            voyage_key_present=False,
+            remap_refs=lambda s, t: remap_calls.append((s, t)),
+        )
+
+        assert result.ok is True
+        assert result.validation is not None and result.validation.unlocked is True
+        # bge landed under its own name (byte-for-byte); legacy under the target.
+        assert vc.count(onnx) == 3
+        assert set(vc.store[onnx].keys()) == set(ids[onnx])
+        assert vc.count(legacy_tgt) == 5
+        assert set(vc.store[legacy_tgt].keys()) == set(ids[legacy_src])
+        assert vc.store.get(legacy_src) is None
+        # ONLY the legacy collection triggered a reference re-point.
+        assert remap_calls == [(legacy_src, legacy_tgt)]
+        # Validation scanned both dims (768 only — both targets are bge-768).
+        assert cc.orphan_dim_queries == [768]
+        assert read_state() is None
+
     def test_scenario1_cloud_voyage_unlocks(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/migration/test_migration_contract.py
+++ b/tests/migration/test_migration_contract.py
@@ -119,6 +119,8 @@ def test_sequencer_surface():
         "model_gate",
         "on_progress",
         "started_at",
+        "cross_model_targets",
+        "remap_refs",
     }
     assert _fields(SequenceOutcome) == {
         "ok",
@@ -151,6 +153,7 @@ def test_validation_surface():
         "catalog_client",
         "collections",
         "dims",
+        "target_names",
     }
     assert _params(validate_migration) == {
         "taxonomy_check",
@@ -193,6 +196,7 @@ def test_vector_etl_surface():
         "dry_run",
         "page_size",
         "on_result",
+        "target_names",
     }
     assert _params(v.migrate_cloud) == {
         "vector_client",
@@ -203,6 +207,7 @@ def test_vector_etl_surface():
         "dry_run",
         "page_size",
         "on_result",
+        "target_names",
     }
     assert _params(v.rollback_collections) == {
         "read_client",
@@ -210,7 +215,9 @@ def test_vector_etl_surface():
         "collections",
         "page_size",
     }
-    assert _params(v.verify_counts) == {"read_client", "vector_client", "collections"}
+    assert _params(v.verify_counts) == {
+        "read_client", "vector_client", "collections", "target_names",
+    }
     assert _params(v.verify_taxonomy_consistency) == {"t2_db_path", "vector_client"}
 
 

--- a/tests/migration/test_migration_contract.py
+++ b/tests/migration/test_migration_contract.py
@@ -218,7 +218,9 @@ def test_vector_etl_surface():
     assert _params(v.verify_counts) == {
         "read_client", "vector_client", "collections", "target_names",
     }
-    assert _params(v.verify_taxonomy_consistency) == {"t2_db_path", "vector_client"}
+    assert _params(v.verify_taxonomy_consistency) == {
+        "t2_db_path", "vector_client", "target_names",
+    }
 
 
 # ── Cross-process state sentinel (P1) ──────────────────────────────────────

--- a/tests/migration/test_pregate.py
+++ b/tests/migration/test_pregate.py
@@ -168,6 +168,35 @@ def test_a_unsupported_minilm_blocks_with_reindex_diagnostic() -> None:
     assert "NX_VOYAGE_API_KEY" not in str(exc.value)  # not a credential issue
 
 
+def test_exempt_minilm_is_not_blocked() -> None:
+    # RDR-162 P2: a legacy minilm-384 collection the orchestrator will cross-model
+    # migrate (in ``exempt``) is NOT blocked — the ETL re-embeds its stored text
+    # into a bge-768 target. Without the exemption it would block (test_a above).
+    name = "docs__legacy__minilm-l6-v2-384__v1"
+    assert_models_supported(
+        [_cls(name, _LEGACY_384)],
+        voyage_key_present=True,
+        source=_FixedSource(_WIRED_WITH_VOYAGE),
+        exempt=frozenset({name}),
+    )
+
+
+def test_exempt_does_not_rescue_voyage_no_key() -> None:
+    # The exemption only covers the collections actually remapped. A voyage
+    # collection with no key is the credential case (never remapped) and still
+    # blocks even when an unrelated minilm name is exempt.
+    voyage = "knowledge__art__voyage-context-3__v1"
+    minilm = "docs__x__minilm-l6-v2-384__v1"
+    with pytest.raises(ModelPreGateBlocked) as exc:
+        assert_models_supported(
+            [_cls(voyage, _VOYAGE), _cls(minilm, _LEGACY_384)],
+            voyage_key_present=False,
+            source=_FixedSource(_WIRED_ONNX_ONLY),
+            exempt=frozenset({minilm}),
+        )
+    assert exc.value.collections == [voyage]
+
+
 def test_d_mixed_store_blocks_unsupported_subset() -> None:
     classifications = [
         _cls("code__nexus__bge-base-en-v15-768__v1", _ONNX),  # supported (bge)

--- a/tests/migration/test_sequencer.py
+++ b/tests/migration/test_sequencer.py
@@ -88,7 +88,7 @@ def _noop_quiesce() -> None:
     return None
 
 
-def _noop_model_gate(classifications, *, voyage_key_present) -> None:  # type: ignore[no-untyped-def]
+def _noop_model_gate(classifications, *, voyage_key_present, exempt=frozenset()) -> None:  # type: ignore[no-untyped-def]
     return None
 
 
@@ -280,7 +280,7 @@ def test_pregates_run_before_t2_in_order() -> None:
         run_leg=lambda leg: order.append("leg") or _ok_leg("local", ["code__a__bge-base-en-v15-768__v1"]),  # type: ignore[func-returns-value]
         voyage_key_present=False,
         quiesce_check=lambda: order.append("quiesce"),
-        model_gate=lambda c, *, voyage_key_present: order.append("models"),
+        model_gate=lambda c, *, voyage_key_present, exempt=frozenset(): order.append("models"),
         started_at=_FIXED_STARTED_AT,
     )
     assert order == ["quiesce", "models", "t2", "leg"]
@@ -292,7 +292,7 @@ def test_model_gate_block_stops_before_t2() -> None:
     det = _detection(_cls("code__a__bge-base-en-v15-768__v1", "local"))
     t2_calls: list[int] = []
 
-    def _model_gate(classifications, *, voyage_key_present) -> None:  # type: ignore[no-untyped-def]
+    def _model_gate(classifications, *, voyage_key_present, exempt=frozenset()) -> None:  # type: ignore[no-untyped-def]
         raise ModelPreGateBlocked([("code__a__bge-base-en-v15-768__v1", "unservable")])
 
     outcome = run_sequenced_migration(

--- a/tests/migration/test_sequencer.py
+++ b/tests/migration/test_sequencer.py
@@ -413,3 +413,91 @@ def test_fresh_user_no_op_success_without_touching_anything() -> None:
     assert t2_calls == []  # nothing to migrate — T2/T3 untouched
     assert leg_calls == []
     assert current_phase() == "not-migrating"  # no sentinel left behind
+
+
+# --------------------------------------------------------------------------
+# RDR-162 P2 cross-model remap wiring
+# --------------------------------------------------------------------------
+
+_SRC = "knowledge__a__minilm-l6-v2-384__v1"
+_TGT = "knowledge__a__bge-base-en-v15-768__v1"
+
+
+def _cross_model_leg(leg: str) -> MigrationReport:
+    """A leg result for a cross-model collection: status migrated, target set."""
+    return MigrationReport(
+        leg=leg,  # type: ignore[arg-type]
+        results=(CollectionResult(_SRC, 10, 10, "migrated", target_collection=_TGT),),
+    )
+
+
+def test_cross_model_remap_called_after_verified_leg() -> None:
+    det = _detection(_cls(_SRC, "local"))
+    calls: list[tuple[str, str]] = []
+    exempt_seen: list[frozenset] = []
+
+    def _gate(classifications, *, voyage_key_present, exempt=frozenset()) -> None:  # type: ignore[no-untyped-def]
+        exempt_seen.append(exempt)
+
+    outcome = run_sequenced_migration(
+        det,
+        sources=None,
+        run_t2=lambda _s: _CLEAN_T2,
+        run_leg=_cross_model_leg,
+        voyage_key_present=False,
+        quiesce_check=_noop_quiesce,
+        model_gate=_gate,
+        started_at=_FIXED_STARTED_AT,
+        cross_model_targets={_SRC: _TGT},
+        remap_refs=lambda s, t: calls.append((s, t)),
+    )
+
+    assert outcome.ok is True
+    assert calls == [(_SRC, _TGT)]  # remap fired, source -> target
+    assert exempt_seen == [frozenset({_SRC})]  # gate exempted the cross-model coll
+    assert current_phase() != "migrated-failed"
+
+
+def test_remap_failure_demotes_leg_and_marks_failed() -> None:
+    det = _detection(_cls(_SRC, "local"))
+
+    def _boom(_s: str, _t: str) -> None:
+        raise RuntimeError("service rename_collection 500")
+
+    outcome = run_sequenced_migration(
+        det,
+        sources=None,
+        run_t2=lambda _s: _CLEAN_T2,
+        run_leg=_cross_model_leg,
+        voyage_key_present=False,
+        quiesce_check=_noop_quiesce,
+        model_gate=_noop_model_gate,
+        started_at=_FIXED_STARTED_AT,
+        cross_model_targets={_SRC: _TGT},
+        remap_refs=_boom,
+    )
+
+    assert outcome.ok is False  # remap failure demotes the leg
+    assert outcome.legs_attempted == ("local",)
+    assert outcome.legs_ok == ()  # demoted out of legs_ok
+    assert current_phase() == "migrated-failed"  # sentinel correct, not stuck
+
+
+def test_same_model_leg_never_calls_remap() -> None:
+    det = _detection(_cls("code__a__bge-base-en-v15-768__v1", "local"))
+    calls: list[tuple[str, str]] = []
+
+    outcome = run_sequenced_migration(
+        det,
+        sources=None,
+        run_t2=lambda _s: _CLEAN_T2,
+        run_leg=lambda leg: _ok_leg(leg, ["code__a__bge-base-en-v15-768__v1"]),
+        voyage_key_present=False,
+        quiesce_check=_noop_quiesce,
+        model_gate=_noop_model_gate,
+        started_at=_FIXED_STARTED_AT,
+        remap_refs=lambda s, t: calls.append((s, t)),
+    )
+
+    assert outcome.ok is True
+    assert calls == []  # byte-for-byte path: no target_collection, no remap

--- a/tests/migration/test_validation.py
+++ b/tests/migration/test_validation.py
@@ -258,7 +258,7 @@ def test_compose_validation_checks_adapts_real_primitive_signatures(
         seen["taxonomy_args"] = (t2_db_path, vector_client)
         return []
 
-    def _fake_counts(read_client, vector_client, collections):  # type: ignore[no-untyped-def]
+    def _fake_counts(read_client, vector_client, collections, target_names=None):  # type: ignore[no-untyped-def]
         seen["count_args"] = (read_client, vector_client, collections)
         return {c: (1, 1) for c in collections}
 

--- a/tests/migration/test_validation.py
+++ b/tests/migration/test_validation.py
@@ -254,7 +254,7 @@ def test_compose_validation_checks_adapts_real_primitive_signatures(
     # zero-arg Callable contract so P4 does not re-derive them from fixtures.
     seen: dict[str, object] = {}
 
-    def _fake_taxonomy(t2_db_path, vector_client):  # type: ignore[no-untyped-def]
+    def _fake_taxonomy(t2_db_path, vector_client, target_names=None):  # type: ignore[no-untyped-def]
         seen["taxonomy_args"] = (t2_db_path, vector_client)
         return []
 

--- a/tests/migration/test_vector_etl.py
+++ b/tests/migration/test_vector_etl.py
@@ -684,6 +684,22 @@ class TestVerifyTaxonomyConsistencyUnit:
 
         assert verify_taxonomy_consistency(db, fake) == []
 
+    def test_cross_model_source_resolved_via_target_names(self, tmp_path) -> None:
+        """RDR-162 P2: a cross-model source collection's chunks migrated into a
+        bge-768 TARGET, so the SOURCE T2 still names the minilm collection while
+        pgvector has only the target. Without target_names it reads as an orphan;
+        WITH the map it resolves through source -> target."""
+        src = _coll("xm-note", model="minilm-l6-v2-384")
+        tgt = _coll("xm-note", model="bge-base-en-v15-768")
+        fake = FakeVectorClient()
+        fake.upsert_chunks(tgt, ["id1"], ["text"], [{}])  # only the TARGET migrated
+        db = _make_t2_with_assignments(tmp_path, [src])
+
+        # Without the map: false orphan (source name not in migrated set).
+        assert verify_taxonomy_consistency(db, fake) == [src]
+        # With the map: resolved (its bge target is migrated).
+        assert verify_taxonomy_consistency(db, fake, target_names={src: tgt}) == []
+
     def test_no_visible_collections_fails_loud(self, tmp_path) -> None:
         """P5.2 review fix (CRE M2, additive strengthening):
         ``list_collections()`` swallows service errors into ``[]`` — a down

--- a/tests/migration/test_vector_etl.py
+++ b/tests/migration/test_vector_etl.py
@@ -76,6 +76,7 @@ from nexus.migration.chroma_read import iter_collection_chunks
 from nexus.migration.vector_etl import (
     CollectionResult,
     MigrationReport,
+    cross_model_target_name,
     manifest_backfill_sql,
     manifest_orphan_sql,
     migrate_cloud,
@@ -1497,3 +1498,75 @@ class TestEphemeralExclusion:
         )
         assert report.results[0].status == "skipped"
         assert report.ok is False
+
+
+# ── RDR-162: cross-model migrate (stored-text re-embed + target model remap) ──
+
+
+class TestCrossModelTargetName:
+    def test_swaps_only_the_model_segment(self) -> None:
+        assert (
+            cross_model_target_name(
+                "knowledge__acme__minilm-l6-v2-384__v1", "bge-base-en-v15-768"
+            )
+            == "knowledge__acme__bge-base-en-v15-768__v1"
+        )
+
+    def test_non_conformant_source_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-conformant"):
+            cross_model_target_name("legacy_two_segment", "bge-base-en-v15-768")
+
+
+class TestCrossModelMigrate:
+    """A legacy minilm-384 source re-embeds into a bge-768 TARGET: read from the
+    source, upsert + verify on the target, dim dispatched from the target. No
+    source file is touched (stored chunk text is what the service re-embeds)."""
+
+    def test_reembeds_into_remapped_target(self, source_client) -> None:
+        src = _coll("xmodel1", model=_MODEL_384)  # minilm-384 source
+        tgt = _coll("xmodel1", model=_MODEL_768)  # bge-768 target
+        ids = _seed_source(source_client, src, 6)
+        fake = FakeVectorClient()
+
+        report = migrate_collections(
+            source_client, fake, leg="local", target_names={src: tgt}
+        )
+
+        (r,) = report.results
+        assert r.status == "migrated"
+        assert r.collection == src           # reported under the SOURCE name
+        assert r.target_collection == tgt    # ...re-embedded into the bge target
+        assert r.source_count == 6 and r.written_count == 6
+        assert report.ok is True
+        # The upsert landed in the TARGET (bge-768), NOT the source name.
+        assert set(fake.store[tgt].keys()) == set(ids)
+        assert src not in fake.store
+        # Verbatim text round-trips (chash = sha256(text)); no source vectors.
+        for i, cid in enumerate(ids):
+            assert fake.store[tgt][cid][0] == f"chunk text {i:04d}"
+        # Every upsert call addressed the target.
+        assert all(coll == tgt for coll, _ in fake.upsert_calls)
+
+    def test_idempotent_rerun_on_target(self, source_client) -> None:
+        src = _coll("xmodel2", model=_MODEL_384)
+        tgt = _coll("xmodel2", model=_MODEL_768)
+        _seed_source(source_client, src, 4)
+        fake = FakeVectorClient()
+        migrate_collections(source_client, fake, leg="local", target_names={src: tgt})
+        # Re-run: server-side upsert keys on (target, chash) — count stays exact.
+        report = migrate_collections(
+            source_client, fake, leg="local", target_names={src: tgt}
+        )
+        assert report.results[0].status == "migrated"
+        assert fake.count(tgt) == 4
+
+    def test_same_model_default_keeps_source_name(self, source_client) -> None:
+        # No target_names entry -> same-model path: name preserved byte-for-byte,
+        # target_collection is None (the ref-remap is not triggered).
+        src = _coll("xmodel3", model=_MODEL_768)
+        _seed_source(source_client, src, 3)
+        fake = FakeVectorClient()
+        report = migrate_collections(source_client, fake, leg="local")
+        r = report.results[0]
+        assert r.target_collection is None
+        assert set(fake.store[src].keys())  # landed under the source name

--- a/tests/test_collection_rename.py
+++ b/tests/test_collection_rename.py
@@ -1304,6 +1304,62 @@ class TestRemapCollectionReferences:
             ).fetchone()[0]
         assert (old_rows, new_rows) == (0, 2)
 
+    def test_repoints_all_t2_cascade_tables(
+        self, tmp_path: Path, env_creds,
+    ) -> None:
+        """S2 (RDR-162 P2 review): the real cascade re-points EVERY T2 table that
+        names a collection (not just chash) — chash, document_aspects, and the
+        aspect queue — via the production ``rename_collection_cascade``."""
+        from nexus.collection_rename import remap_collection_references
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        src = "knowledge__c__minilm-l6-v2-384__v1"
+        tgt = "knowledge__c__bge-base-en-v15-768__v1"
+
+        with T2Database(db_path) as t2db:
+            t2db.chash_index.upsert(chash="aa", collection=src)
+            t2db.document_aspects.conn.execute(
+                "INSERT INTO document_aspects "
+                "(collection, source_path, problem_formulation, proposed_method, "
+                " experimental_datasets, experimental_baselines, "
+                " experimental_results, extras, confidence, extracted_at, "
+                " model_version, extractor_name) "
+                "VALUES (?, ?, NULL, NULL, '[]', '[]', NULL, '{}', NULL, "
+                "        '2026-06-18T00:00:00Z', 'v1', 'test')",
+                (src, "a.py"),
+            )
+            t2db.document_aspects.conn.commit()
+            t2db.aspect_queue.enqueue(src, "b.py", doc_id="d2")
+
+        with patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
+             patch("nexus.config.default_db_path", return_value=db_path), \
+             patch("nexus.config.catalog_path", return_value=cat_dir):
+            counts = remap_collection_references(src, tgt)
+
+        # The return dict carries the full cascade surface, incl. highlights.
+        assert "highlights" in counts
+        assert counts["chash"] == 1
+        with T2Database(db_path) as verify:
+            da_new = verify.document_aspects.conn.execute(
+                "SELECT COUNT(*) FROM document_aspects WHERE collection = ?", (tgt,),
+            ).fetchone()[0]
+            da_old = verify.document_aspects.conn.execute(
+                "SELECT COUNT(*) FROM document_aspects WHERE collection = ?", (src,),
+            ).fetchone()[0]
+            aq_new = verify.aspect_queue.conn.execute(
+                "SELECT COUNT(*) FROM aspect_extraction_queue WHERE collection = ?",
+                (tgt,),
+            ).fetchone()[0]
+            aq_old = verify.aspect_queue.conn.execute(
+                "SELECT COUNT(*) FROM aspect_extraction_queue WHERE collection = ?",
+                (src,),
+            ).fetchone()[0]
+        assert (da_new, da_old) == (1, 0)
+        assert (aq_new, aq_old) == (1, 0)
+
     def test_t2_cascade_failure_raises(self, tmp_path: Path, env_creds) -> None:
         import click
 

--- a/tests/test_collection_rename.py
+++ b/tests/test_collection_rename.py
@@ -1259,3 +1259,100 @@ class TestHalfCascadeNonZeroExit:
         assert "cascade" in result.output.lower() or "T2" in result.output, (
             f"Error message must name the failed cascade. Output: {result.output}"
         )
+
+
+# ── RDR-162 P2: cross-model reference remap (copy-not-move) ──────────────────
+
+
+class TestRemapCollectionReferences:
+    """RDR-162 P2: ``remap_collection_references`` re-points T2 + catalog
+    references source -> target WITHOUT renaming the T3 collection and WITHOUT
+    guarding on target existence (the cross-model migrate already populated the
+    target; the source is intentionally retained for re-runnability)."""
+
+    def test_repoints_t2_references_no_t3_rename(
+        self, tmp_path: Path, env_creds,
+    ) -> None:
+        from nexus.collection_rename import remap_collection_references
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+
+        src = "knowledge__corpus__minilm-l6-v2-384__v1"
+        tgt = "knowledge__corpus__bge-base-en-v15-768__v1"
+        with T2Database(db_path) as t2db:
+            t2db.chash_index.upsert(chash="aa", collection=src)
+            t2db.chash_index.upsert(chash="bb", collection=src)
+
+        # No _t3 patch: remap must NEVER touch T3 (copy-not-move).
+        with patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
+             patch("nexus.config.default_db_path", return_value=db_path), \
+             patch("nexus.config.catalog_path", return_value=cat_dir):
+            counts = remap_collection_references(src, tgt)
+
+        assert counts["chash"] == 2
+        with T2Database(db_path) as verify:
+            old_rows = verify.chash_index.conn.execute(
+                "SELECT COUNT(*) FROM chash_index WHERE physical_collection = ?",
+                (src,),
+            ).fetchone()[0]
+            new_rows = verify.chash_index.conn.execute(
+                "SELECT COUNT(*) FROM chash_index WHERE physical_collection = ?",
+                (tgt,),
+            ).fetchone()[0]
+        assert (old_rows, new_rows) == (0, 2)
+
+    def test_t2_cascade_failure_raises(self, tmp_path: Path, env_creds) -> None:
+        import click
+
+        from nexus.collection_rename import remap_collection_references
+
+        db_path = tmp_path / "memory.db"
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+
+        def _t2_bomb(*a, **kw):
+            raise RuntimeError("simulated T2 cascade failure")
+
+        with patch("nexus.mcp_infra.t2_index_write", side_effect=_t2_bomb), \
+             patch("nexus.config.default_db_path", return_value=db_path), \
+             patch("nexus.config.catalog_path", return_value=cat_dir):
+            with pytest.raises(click.ClickException) as exc:
+                remap_collection_references("code__a__minilm-l6-v2-384__v1",
+                                            "code__a__bge-base-en-v15-768__v1")
+        assert "cascade" in str(exc.value).lower()
+
+    def test_catalog_failure_is_fail_open(self, tmp_path: Path, env_creds) -> None:
+        from nexus.collection_rename import remap_collection_references
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        src = "code__o__minilm-l6-v2-384__v1"
+        tgt = "code__o__bge-base-en-v15-768__v1"
+        with T2Database(db_path) as t2db:
+            t2db.chash_index.upsert(chash="aa", collection=src)
+
+        warnings: list[str] = []
+        bomb = MagicMock()
+        bomb.rename_collection = MagicMock(side_effect=RuntimeError("catalog down"))
+
+        with patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
+             patch("nexus.config.default_db_path", return_value=db_path), \
+             patch("nexus.config.catalog_path", return_value=cat_dir):
+            counts = remap_collection_references(
+                src, tgt, catalog=bomb, on_warn=warnings.append,
+            )
+
+        # T2 cascade still committed; catalog failure only warned.
+        assert counts["chash"] == 1
+        assert any("catalog" in w.lower() for w in warnings)
+        with T2Database(db_path) as verify:
+            new_rows = verify.chash_index.conn.execute(
+                "SELECT COUNT(*) FROM chash_index WHERE physical_collection = ?",
+                (tgt,),
+            ).fetchone()[0]
+        assert new_rows == 1

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -815,15 +815,21 @@ class TestServiceLocalEmbedder:
 
 class TestServiceStartStep:
     """RDR-157 P4.1 (nexus-vwvv5.17): nx init --service collapses through to a
-    started, status-green service. _start_service_step calls the idempotent
-    start_storage_service and fails loud (never a traceback) on any error."""
+    started, status-green service. nexus-qke1e: _start_service_step now routes
+    through ensure_storage_supervisor (the PERSISTENT, heartbeated supervisor),
+    not the transient start_storage_service — and fails loud on any error."""
 
     def test_start_step_reports_running_endpoint(self, monkeypatch) -> None:
+        import types
+
         import nexus.commands.init as init_mod
 
+        lease = types.SimpleNamespace(
+            endpoint={"host": "127.0.0.1", "port": 18099, "pid": 4242},
+            generation=3,
+        )
         monkeypatch.setattr(
-            "nexus.daemon.storage_service_daemon.start_storage_service",
-            lambda: {"host": "127.0.0.1", "port": 18099, "pid": 4242, "generation": 3},
+            "nexus.commands.daemon.ensure_storage_supervisor", lambda _cfg: lease
         )
         runner_out: list[str] = []
         monkeypatch.setattr(init_mod.click, "echo", lambda *a, **k: runner_out.append(a[0] if a else ""))
@@ -838,14 +844,14 @@ class TestServiceStartStep:
         import nexus.commands.init as init_mod
         from nexus.daemon.storage_service_daemon import StorageServiceStartError
 
-        def _boom():
+        def _boom(_cfg):
             raise StorageServiceStartError(
                 "No nexus-service native binary found. Acquire one: "
                 "nx daemon service install-binary <tag>"
             )
 
         monkeypatch.setattr(
-            "nexus.daemon.storage_service_daemon.start_storage_service", _boom
+            "nexus.commands.daemon.ensure_storage_supervisor", _boom
         )
 
         with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## RDR-162 P2 — cross-model migrate (stored-text re-embed → bge-768), rehearsal-proven

Completes the truthful post-RDR-160 upgrade path: a legacy `minilm-384` collection the service cannot serve is auto-migrated by re-embedding its **stored chunk text** into a model-remapped `bge-768` target (copy-not-move). Covers sourceless `store_put` notes that `embed_migrate` cannot. **Proven green end-to-end by the Docker migration-rehearsal.**

### Cross-model migrate (the P2 core)
- **Ref-remap** (`remap_collection_references`): re-points T2 + catalog references source→target via the existing atomic cascades — no T3 rename, no target-exists guard (target pre-populated, source retained). T2 raises on failure; catalog fail-open.
- **Orchestrator**: `detection.cross_model_remappable` (policy), `driver` builds `target_names` and uses **target** dims/names in validation, `pregate` `exempt`, `sequencer` re-points refs after each verified leg (remap failure demotes the leg → no silent half-remap).
- **Validation correctness**: `verify_counts` **and** `verify_taxonomy_consistency` resolve through `target_names` so cross-model collections don't falsely block.
- **Cross-model-aware dry-run**: previews legacy collections as migratable (re-embed → bge-768), not blocked.

### Bugs the rehearsal surfaced (all fixed here)
- **`nexus-qke1e`** (supervisor lifecycle): `nx init --service` now starts the **persistent, heartbeated** supervisor via a shared `ensure_storage_supervisor` (was a transient lease that aged out by TTL).
- **Engine `TaxonomyHandler`**: `rename_collection` was the lone endpoint expecting `old_collection`/`new_collection`; aligned to the `old`/`new` convention every other handler + client uses (+ contract test).
- **Engine native bge-768 embed (`nexus-pqatt`)**: GraalVM native-image JNI registration for the DJL tokenizers / onnxruntime embed path (shipped engine-side as `engine-service-v0.1.4`; the metadata commit rides along here).

### Verification
- Migration rehearsal (Docker): **SOUP-TO-NUTS PASSED** — install → provision → serve → seed (incl. sourceless note) → cross-model migrate → validate (clean unlock) → rollback-safe.
- 276 migration unit tests + 48 rename/init/supervisor tests green.
- Stacked review (code-review-expert + substantive-critic + test-validator): **0 Critical**; HIGH/Significant addressed, non-blocking findings tracked as beads.
- Phase-review-gate (Phase 2): **PASSED**.

### Known fail-open residual (not blocking)
`/v1/catalog/collections/rename` 500s for cross-model (the upsert pre-registers the bge target, so the catalog rename's `collection_registry` UPDATE collides under the RDR-156 `ON UPDATE CASCADE` FKs). Fail-open (warn + `nx catalog rebuild` repairs); did **not** block the migration. Surfaced to engine-service; tracked for a rehearsal-coverage assertion once the engine fix lands.

Beads (all closed): epic nexus-i055c; P2 impl nexus-iej4o; rehearsal nexus-jdlni; review nexus-oeqk8; gate nexus-gb386; nexus-qke1e; nexus-pqatt. RDR-162 P3 (contract pin + conexus RDR-001 relay) remains a separate phase.
