### PR TITLE
fix(catalog): cross-model rename 500 — repoint docs when target pre-registered (RDR-162 follow-on)

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -1144,9 +1144,24 @@ public final class CatalogRepository {
     /** Rename a collection across documents + collections. */
     public int renameCollection(String tenant, String oldName, String newName) {
         return tenantScope.withTenant(tenant, ctx -> {
+            // RDR-162: the cross-model migrate is COPY-not-move — the bge-768 target
+            // is ALREADY registered in catalog_collections by the vector upsert (its
+            // chunks' FK requires the registry row to exist). Renaming the SOURCE
+            // registry row into that name would collide on the (tenant_id, name) PK
+            // (the 500 the cross-model ref-remap hit). So branch on whether the target
+            // row already exists:
+            //   - cross-model copy (target exists): repoint catalog documents only;
+            //     leave the registry alone (renaming it would collide, and the target
+            //     row is already correct).
+            //   - canonical rename (target absent): also rename the registry row
+            //     (unchanged pre-RDR-162 behavior).
+            boolean targetExists = ctx.fetchExists(
+                ctx.selectOne().from(T_COLLS).where(F_COL_NAME.eq(newName)));
             int docs = ctx.update(T_DOCS).set(F_DOC_PCOLL, newName)
                           .where(F_DOC_PCOLL.eq(oldName)).execute();
-            ctx.update(T_COLLS).set(F_COL_NAME, newName).where(F_COL_NAME.eq(oldName)).execute();
+            if (!targetExists) {
+                ctx.update(T_COLLS).set(F_COL_NAME, newName).where(F_COL_NAME.eq(oldName)).execute();
+            }
             return docs;
         });
     }

--- a/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
@@ -725,6 +725,32 @@ class CatalogRepositoryTest {
         assertThat(doc.get("physical_collection")).isEqualTo("knowledge__new__v1");
     }
 
+    @Test @Order(66)
+    void collection_rename_crossModel_targetPreRegistered_repointsDocsNoCollision() {
+        // RDR-162 cross-model migrate is COPY-not-move: the bge-768 TARGET is ALREADY
+        // registered in catalog_collections (the vector upsert pre-registers it so its
+        // chunks' FK is satisfied). Renaming the SOURCE registry row into that name
+        // would collide on the (tenant_id, name) PK -> 500 (the bug the cross-model
+        // ref-remap hit). The rename must instead repoint the catalog documents only,
+        // leaving the (already-correct) target registry row untouched.
+        String src = "knowledge__xmrn__minilm-l6-v2-384__v1";
+        String tgt = "knowledge__xmrn__bge-base-en-v15-768__v1";
+        repo.upsertDocument(TENANT_A, Map.of("tumbler", "xmrn.1", "title", "Cross-model Rename",
+            "content_type", "knowledge", "corpus", "knowledge",
+            "physical_collection", src));
+        // The target is pre-registered (simulating the vector upsert's auto-registration).
+        repo.upsertCollection(TENANT_A, Map.of(
+            "name", tgt, "content_type", "knowledge", "owner_id", "nexus-1-1",
+            "embedding_model", "bge-base-en-v15-768", "model_version", "v1"));
+
+        // Pre-RDR-162 this threw a 500 (PK collision on the registry rename).
+        int updated = repo.renameCollection(TENANT_A, src, tgt);
+        assertThat(updated).isEqualTo(1);
+        assertThat(repo.getDocument(TENANT_A, "xmrn.1").get("physical_collection")).isEqualTo(tgt);
+        // The pre-registered target row is intact (not collided, not duplicated).
+        assertThat(repo.getCollection(TENANT_A, tgt)).isNotNull();
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // STATS
     // ══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Fix: cross-model catalog rename 500 (RDR-162 follow-on)

The RDR-162 migration-rehearsal surfaced this. `POST /v1/catalog/collections/rename` returns **500** during the cross-model migrate (minilm-384 → bge-768).

### Root cause
`CatalogRepository.renameCollection` did, in one transaction:
1. `UPDATE catalog_documents SET physical_collection = new WHERE = old`
2. `UPDATE catalog_collections SET name = new WHERE name = old`

A cross-model migrate is **copy-not-move**: the vector upsert has **already registered** the bge-768 target in `catalog_collections` (its chunk FK requires the row). So step 2 collides on the `(tenant_id, name)` PK → constraint violation → 500 → the whole txn (incl. the docs repoint) rolls back, leaving `physical_collection` refs stale.

### Fix
Branch on whether the target registry row already exists:
- **cross-model copy (target exists):** repoint `catalog_documents` only; leave the (already-correct) registry row untouched.
- **canonical rename (target absent):** unchanged prior behavior (docs repoint + registry rename).

The chunk/chash FKs are `ON DELETE RESTRICT` with **no `ON UPDATE CASCADE`** (`fk-002`), and `catalog_documents` has no registry FK, so the explicit docs UPDATE is correct in both branches.

### Test
`collection_rename_crossModel_targetPreRegistered_repointsDocsNoCollision` — the cross-model branch had **zero coverage** (the same first-real-caller gap that hid the sibling taxonomy `old_collection`/`new_collection` field bug, fixed in #1242). The existing canonical-rename test is preserved unchanged.

### Notes
- Was **fail-open** in the nexus migrate cascade (`nx catalog rebuild` repaired it); the migration still verified + unlocked.
- This is a `service/` change — it ships as a deployed native binary only via the **next engine-service release** (engine-service-v0.1.5).
- Pairs with #1242 (RDR-162 P2); independent file, no conflict.
