### PR TITLE
test(migration-rehearsal): support a self-contained release binary (enables release-pinned E2E)

### DIFF
--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -65,12 +65,16 @@ echo "[3/3] Staging a minimal build context + building image (WITH_CLOUD=$WITH_C
 STAGE="$(mktemp -d)"
 trap 'rm -rf "$STAGE"' EXIT
 cp "$(ls -t dist/conexus-*.whl | head -1)"            "$STAGE/"   # keep real PEP 427 name
-# The native binary + its native-image .so siblings (libjvm/libawt/liblcms/...)
-# must travel together: native-image resolves dlopen'd JDK libs from the
-# executable's own directory, so they are co-located in the image.
+# The native binary travels into the image. A LOCAL -Pnative -Ob quick build also
+# emits native-image .so siblings (libjvm/libawt/liblcms/...) that must be
+# co-located (native-image dlopen's JDK libs from the executable's own dir); a
+# RELEASE binary (engine-service-v*) is self-contained with NO .so siblings. So
+# the .so copy is best-effort — present them when they exist, skip when they don't.
 mkdir -p "$STAGE/native"
 cp service/target/nexus-service "$STAGE/native/"
-cp service/target/*.so "$STAGE/native/"
+if compgen -G "service/target/*.so" > /dev/null; then
+  cp service/target/*.so "$STAGE/native/"
+fi
 cp "$HERE/Dockerfile" "$HERE/rehearse.sh" "$HERE/seed_legacy.py" "$STAGE/"
 
 # Docker Desktop's credsStore=desktop helper can't reach a locked login keychain


### PR DESCRIPTION
Makes the rehearsal's `.so` staging best-effort (compgen guard). A local `-Pnative -Ob` build emits native-image `.so` siblings; a **release** binary (`engine-service-v*`) is self-contained with none, so the unconditional `cp service/target/*.so` failed under `set -e`.

This enables the **release-pinned E2E**: drop a verified `engine-service-v<X>` `nexus-service` into `service/target/` and run. Used today to confirm the signed **engine-service-v0.1.4** binary (sha256 + cosign `Verified OK`) boots, loads the bge-768 embedder, and re-embeds with **no SIGABRT** in-container — i.e. the nexus-pqatt native fix is real in the published artifact. (The full cross-model migrate needs v0.1.5, which adds the taxonomy + catalog rename fixes; tracked by nexus-eum97.)