### PR TITLE
fix(nexus-lz3f2): storage-service lease robustness — per-tier TTL + optional heap bound

### DIFF
--- a/src/nexus/daemon/service_registry.py
+++ b/src/nexus/daemon/service_registry.py
@@ -63,6 +63,25 @@ _log = structlog.get_logger(__name__)
 DEFAULT_HEARTBEAT_INTERVAL: float = 1.0
 DEFAULT_TTL: float = 3.0
 
+#: Per-tier lease-TTL overrides (nexus-lz3f2). The per-tier TTL is a SUBSTRATE
+#: parameter, so it lives here in the shared primitive — not in any tier's daemon
+#: module (RDR-149: "no tier-specific lifecycle code outside the substrate"). The
+#: 3s default fits the light T1/T2 daemons; the storage-service supervisor's
+#: heartbeat tick can take up to its /health probe timeout + the heartbeat
+#: interval (~3s), grazing a 3s TTL, so it gets a wider 15s window (~15 missed
+#: beats) — a transient stall never false-expires a LIVE service's lease, while a
+#: genuinely dead supervisor is still reaped within 15s. Discoverers honour the
+#: TTL stamped in the record, so this needs setting only where each tier
+#: publishes. Consumers MUST resolve via ``ttl_for_tier`` so the conformance
+#: suite and every publisher track one source of truth.
+TIER_TTLS: dict[str, float] = {"storage_service": 15.0}
+
+
+def ttl_for_tier(tier: str) -> float:
+    """Lease TTL for *tier* — the per-tier override, else the substrate default."""
+    return TIER_TTLS.get(tier, DEFAULT_TTL)
+
+
 _FORMAT_VERSION: int = 1
 
 Clock = Callable[[], float]

--- a/src/nexus/daemon/storage_service_daemon.py
+++ b/src/nexus/daemon/storage_service_daemon.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import contextlib
 import errno
 import os
+import re
 import signal
 import socket
 import subprocess
@@ -68,6 +69,7 @@ from nexus.daemon.service_registry import (
     DEFAULT_HEARTBEAT_INTERVAL,
     ServiceRegistry,
     ServiceSupervisor,
+    ttl_for_tier,
 )
 
 _log = structlog.get_logger(__name__)
@@ -106,17 +108,15 @@ _RESTART_BACKOFF: float = 2.0
 #: Short HTTP timeout for /health probes.
 _HEALTH_TIMEOUT: float = 2.0
 
-#: Lease TTL for the storage-service tier (nexus-lz3f2). The shared default is 3s
-#: (service_registry.DEFAULT_TTL), tuned for the lightweight T1/T2 daemons. The
-#: storage-service supervisor's heartbeat tick can take up to
-#: ``_HEALTH_TIMEOUT`` (2s) + ``DEFAULT_HEARTBEAT_INTERVAL`` (1s) ≈ 3s — exactly
-#: the 3s default — so a single slow tick can graze the TTL and a concurrent
-#: ``discover()`` reads a transiently-stale lease. A 15s TTL gives ~15 missed
-#: beats of margin: a genuinely dead supervisor is still detected within 15s,
-#: but a transient stall (slow /health, GC pause, container contention) never
-#: false-expires a live service's lease. The TTL travels in the published record,
-#: so every discoverer honours it without coordination.
-_STORAGE_SERVICE_LEASE_TTL: float = 15.0
+#: The storage-service lease TTL is a SUBSTRATE parameter — it lives in the shared
+#: primitive (``service_registry.TIER_TTLS["storage_service"]``, resolved via
+#: ``ttl_for_tier``), NOT here, per RDR-149 (no tier-specific lifecycle code
+#: outside the substrate). nexus-lz3f2: the storage-service heartbeat tick can
+#: take up to ``_HEALTH_TIMEOUT`` (2s) + ``DEFAULT_HEARTBEAT_INTERVAL`` (1s) ≈ 3s,
+#: grazing the 3s default; the 15s tier override gives ~15 missed-beats of margin.
+#: TRADE-OFF (nexus-om64x): this also widens the post-restart stale-endpoint
+#: window — the old lease lingers until TTL — from 3s to 15s; the client re-spawn
+#: backstop nexus-03bcg is what closes that window for a dead supervisor.
 
 #: Number of clean heartbeats after a restart before the restart budget resets.
 #: Prevents lifetime-cumulative exhaustion from transient failure clusters.
@@ -446,6 +446,14 @@ class StorageServiceSupervisor:
         # production serving; set NX_SERVICE_MAX_HEAP (e.g. "1g") to bound it.
         max_heap = os.environ.get("NX_SERVICE_MAX_HEAP", "").strip()
         if max_heap:
+            # Validate before injection: a malformed -Xmx makes the native binary
+            # exit immediately, and the supervisor would then blame a /health
+            # timeout (pointing at the log, not the env var). Fail loud + actionable.
+            if not re.fullmatch(r"\d+[kKmMgG]", max_heap):
+                raise StorageServiceStartError(
+                    f"NX_SERVICE_MAX_HEAP={max_heap!r} is not a valid JVM heap size "
+                    "(expected e.g. '512m', '1g', '2048k')."
+                )
             argv.append(f"-Xmx{max_heap}")
         artifact = str(self._binary_path)
         # nexus-ovbr7: route both streams to one file so interleaved output keeps
@@ -560,7 +568,7 @@ class StorageServiceSupervisor:
             dir=self._config_dir,
             tier=_REGISTRY_TIER,
             clock=self._lease_clock,
-            ttl=_STORAGE_SERVICE_LEASE_TTL,
+            ttl=ttl_for_tier(_REGISTRY_TIER),
         )
         self._supervisor = ServiceSupervisor(
             self._registry,

--- a/src/nexus/daemon/storage_service_daemon.py
+++ b/src/nexus/daemon/storage_service_daemon.py
@@ -106,6 +106,18 @@ _RESTART_BACKOFF: float = 2.0
 #: Short HTTP timeout for /health probes.
 _HEALTH_TIMEOUT: float = 2.0
 
+#: Lease TTL for the storage-service tier (nexus-lz3f2). The shared default is 3s
+#: (service_registry.DEFAULT_TTL), tuned for the lightweight T1/T2 daemons. The
+#: storage-service supervisor's heartbeat tick can take up to
+#: ``_HEALTH_TIMEOUT`` (2s) + ``DEFAULT_HEARTBEAT_INTERVAL`` (1s) ≈ 3s — exactly
+#: the 3s default — so a single slow tick can graze the TTL and a concurrent
+#: ``discover()`` reads a transiently-stale lease. A 15s TTL gives ~15 missed
+#: beats of margin: a genuinely dead supervisor is still detected within 15s,
+#: but a transient stall (slow /health, GC pause, container contention) never
+#: false-expires a live service's lease. The TTL travels in the published record,
+#: so every discoverer honours it without coordination.
+_STORAGE_SERVICE_LEASE_TTL: float = 15.0
+
 #: Number of clean heartbeats after a restart before the restart budget resets.
 #: Prevents lifetime-cumulative exhaustion from transient failure clusters.
 #: At DEFAULT_HEARTBEAT_INTERVAL=1s, 300 heartbeats ≈ 5 minutes.
@@ -425,6 +437,16 @@ class StorageServiceSupervisor:
                 )
 
         argv = [str(self._binary_path)]
+        # nexus-lz3f2: optional max-heap bound for memory-constrained hosts
+        # (e.g. the migration-rehearsal container, where an unbounded native-image
+        # heap peak during bge-768 ONNX load + PG + the Python supervisor tripped
+        # the cgroup OOM killer — which SIGKILLed the *supervisor*, not the JVM,
+        # silently vanishing the lease). GraalVM native-image consumes -Xmx as a
+        # runtime option before the app sees argv. Unset by default → no change to
+        # production serving; set NX_SERVICE_MAX_HEAP (e.g. "1g") to bound it.
+        max_heap = os.environ.get("NX_SERVICE_MAX_HEAP", "").strip()
+        if max_heap:
+            argv.append(f"-Xmx{max_heap}")
         artifact = str(self._binary_path)
         # nexus-ovbr7: route both streams to one file so interleaved output keeps
         # its order; O_APPEND means a respawn never truncates the previous
@@ -538,6 +560,7 @@ class StorageServiceSupervisor:
             dir=self._config_dir,
             tier=_REGISTRY_TIER,
             clock=self._lease_clock,
+            ttl=_STORAGE_SERVICE_LEASE_TTL,
         )
         self._supervisor = ServiceSupervisor(
             self._registry,

--- a/tests/daemon/test_rdr149_lifecycle_conformance.py
+++ b/tests/daemon/test_rdr149_lifecycle_conformance.py
@@ -59,6 +59,7 @@ import pytest
 from nexus.daemon.service_registry import (
     ServiceRegistry,
     ServiceSupervisor,
+    ttl_for_tier,
 )
 from nexus.daemon.t1_lease import T1LeasePublisher
 from nexus import session as _sess
@@ -284,9 +285,13 @@ class _LeaseHarness(RecordHarness):
 
     def __init__(self, config_dir: Path, alive: _AliveSet, clock: _FakeClock) -> None:
         super().__init__(config_dir, alive, clock)
+        # nexus-lz3f2: each tier rides its REAL per-tier TTL (storage_service=15s,
+        # t2/t3=3s default) so the conformance battery's reap/self-heal timing
+        # reflects production for every tier, not a hardcoded 3s.
+        self._tier_ttl = ttl_for_tier(self._REGISTRY_TIER)
         self._registry = ServiceRegistry(
             dir=config_dir, tier=self._REGISTRY_TIER, clock=clock,
-            ttl=3.0, heartbeat_interval=1.0,
+            ttl=self._tier_ttl, heartbeat_interval=1.0,
         )
         self._scope = str(os.getuid())
         # One ServiceSupervisor per owner, exactly as the migrated daemon
@@ -323,7 +328,7 @@ class _LeaseHarness(RecordHarness):
         self._supervisors.pop(owner, None)
 
     def advance_to_reap(self) -> None:
-        self._clock.advance(3.1)  # past TTL
+        self._clock.advance(self._tier_ttl + 0.1)  # past this tier's TTL
 
     def reap(self) -> None:
         self._registry.discover(self._scope)  # discovery reaps an expired lease

--- a/tests/daemon/test_storage_service_daemon.py
+++ b/tests/daemon/test_storage_service_daemon.py
@@ -1425,21 +1425,26 @@ class TestLeaseTtlAndHeapBound:
         sup._service_port = 18077
         sup._publish(18077)
 
+        # discover() judges freshness from the RECORD's ttl, not this registry's
+        # ttl arg — so a default-ttl registry still reads the 15s stamped at publish.
         registry = ServiceRegistry(dir=config_dir, tier="storage_service", clock=clock)
         rec = registry.discover(str(os.getuid()))
         assert rec is not None
-        # The published lease carries the storage-service TTL, not the 3s default.
-        assert rec.ttl == ssd_mod._STORAGE_SERVICE_LEASE_TTL == 15.0
+        # The published lease carries the storage-service tier TTL (shared
+        # primitive), not the 3s substrate default.
+        from nexus.daemon.service_registry import ttl_for_tier
+
+        assert rec.ttl == ttl_for_tier("storage_service") == 15.0
 
     def test_ttl_exceeds_worst_case_heartbeat_tick(self) -> None:
         # The margin invariant (debugger RF-1 finding): a heartbeat tick can take
         # up to _HEALTH_TIMEOUT + DEFAULT_HEARTBEAT_INTERVAL; the TTL must exceed
         # that with room, or a single slow tick grazes the TTL.
         import nexus.daemon.storage_service_daemon as ssd_mod
-        from nexus.daemon.service_registry import DEFAULT_HEARTBEAT_INTERVAL
+        from nexus.daemon.service_registry import DEFAULT_HEARTBEAT_INTERVAL, ttl_for_tier
 
         worst_tick = ssd_mod._HEALTH_TIMEOUT + DEFAULT_HEARTBEAT_INTERVAL
-        assert ssd_mod._STORAGE_SERVICE_LEASE_TTL >= 3 * worst_tick
+        assert ttl_for_tier("storage_service") >= 3 * worst_tick
 
     def test_spawn_service_applies_max_heap_when_set(
         self, config_dir: Path, clock: _FakeClock, monkeypatch
@@ -1457,8 +1462,26 @@ class TestLeaseTtlAndHeapBound:
         monkeypatch.setattr(ssd_mod.subprocess, "Popen", _fake_popen)
         monkeypatch.setattr(ssd_mod, "_allocate_free_port", lambda: 18078)
         sup._spawn_service()
+        # -Xmx must immediately follow the binary path (native-image consumes
+        # runtime options before app args).
         assert captured["argv"][0] == str(sup._binary_path)
-        assert "-Xmx1g" in captured["argv"]
+        assert captured["argv"][1] == "-Xmx1g"
+
+    def test_spawn_service_rejects_malformed_max_heap(
+        self, config_dir: Path, clock: _FakeClock, monkeypatch
+    ) -> None:
+        import nexus.daemon.storage_service_daemon as ssd_mod
+        from nexus.daemon.storage_service_daemon import StorageServiceStartError
+
+        monkeypatch.setenv("NX_SERVICE_MAX_HEAP", "abc")
+        sup = _make_supervisor(config_dir, clock)
+        monkeypatch.setattr(ssd_mod, "_allocate_free_port", lambda: 18088)
+        # A malformed heap value fails loud BEFORE spawning (no /health-timeout
+        # misdiagnosis); Popen is never reached.
+        monkeypatch.setattr(ssd_mod.subprocess, "Popen",
+                            lambda *a, **k: (_ for _ in ()).throw(AssertionError("Popen reached")))
+        with pytest.raises(StorageServiceStartError, match="NX_SERVICE_MAX_HEAP"):
+            sup._spawn_service()
 
     def test_spawn_service_no_heap_flag_by_default(
         self, config_dir: Path, clock: _FakeClock, monkeypatch

--- a/tests/daemon/test_storage_service_daemon.py
+++ b/tests/daemon/test_storage_service_daemon.py
@@ -1402,3 +1402,79 @@ class TestEnsureStorageSupervisor:
              patch.object(daemon_mod.subprocess, "Popen", return_value=MagicMock()):
             with pytest.raises(StorageServiceStartError):
                 daemon_mod.ensure_storage_supervisor(config_dir)
+
+
+# ---------------------------------------------------------------------------
+# nexus-lz3f2: lease-TTL margin + optional service heap bound
+# ---------------------------------------------------------------------------
+class TestLeaseTtlAndHeapBound:
+    """nexus-lz3f2: the storage-service supervisor was OOM-killed at the boot
+    memory peak (its lease then vanished silently). Two robustness fixes:
+    (B) a 15s lease TTL so a transient heartbeat stall never false-expires a
+    LIVE service's lease; (C) an optional -Xmx bound so memory-constrained hosts
+    don't trip the OOM killer."""
+
+    def test_lease_published_with_extended_ttl(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        import nexus.daemon.storage_service_daemon as ssd_mod
+        from nexus.daemon.service_registry import ServiceRegistry
+
+        sup = _make_supervisor(config_dir, clock, supervised=True)
+        sup._proc = _FakeProc(pid=49001)
+        sup._service_port = 18077
+        sup._publish(18077)
+
+        registry = ServiceRegistry(dir=config_dir, tier="storage_service", clock=clock)
+        rec = registry.discover(str(os.getuid()))
+        assert rec is not None
+        # The published lease carries the storage-service TTL, not the 3s default.
+        assert rec.ttl == ssd_mod._STORAGE_SERVICE_LEASE_TTL == 15.0
+
+    def test_ttl_exceeds_worst_case_heartbeat_tick(self) -> None:
+        # The margin invariant (debugger RF-1 finding): a heartbeat tick can take
+        # up to _HEALTH_TIMEOUT + DEFAULT_HEARTBEAT_INTERVAL; the TTL must exceed
+        # that with room, or a single slow tick grazes the TTL.
+        import nexus.daemon.storage_service_daemon as ssd_mod
+        from nexus.daemon.service_registry import DEFAULT_HEARTBEAT_INTERVAL
+
+        worst_tick = ssd_mod._HEALTH_TIMEOUT + DEFAULT_HEARTBEAT_INTERVAL
+        assert ssd_mod._STORAGE_SERVICE_LEASE_TTL >= 3 * worst_tick
+
+    def test_spawn_service_applies_max_heap_when_set(
+        self, config_dir: Path, clock: _FakeClock, monkeypatch
+    ) -> None:
+        import nexus.daemon.storage_service_daemon as ssd_mod
+
+        monkeypatch.setenv("NX_SERVICE_MAX_HEAP", "1g")
+        sup = _make_supervisor(config_dir, clock)
+        captured: dict = {}
+
+        def _fake_popen(argv, **kw):
+            captured["argv"] = argv
+            return _FakeProc(pid=49100)
+
+        monkeypatch.setattr(ssd_mod.subprocess, "Popen", _fake_popen)
+        monkeypatch.setattr(ssd_mod, "_allocate_free_port", lambda: 18078)
+        sup._spawn_service()
+        assert captured["argv"][0] == str(sup._binary_path)
+        assert "-Xmx1g" in captured["argv"]
+
+    def test_spawn_service_no_heap_flag_by_default(
+        self, config_dir: Path, clock: _FakeClock, monkeypatch
+    ) -> None:
+        import nexus.daemon.storage_service_daemon as ssd_mod
+
+        monkeypatch.delenv("NX_SERVICE_MAX_HEAP", raising=False)
+        sup = _make_supervisor(config_dir, clock)
+        captured: dict = {}
+
+        def _fake_popen(argv, **kw):
+            captured["argv"] = argv
+            return _FakeProc(pid=49101)
+
+        monkeypatch.setattr(ssd_mod.subprocess, "Popen", _fake_popen)
+        monkeypatch.setattr(ssd_mod, "_allocate_free_port", lambda: 18079)
+        sup._spawn_service()
+        # Production default: no -Xmx — the binary keeps native-image's default heap.
+        assert not any(a.startswith("-Xmx") for a in captured["argv"][1:])

--- a/tests/e2e/migration-rehearsal/rehearse.sh
+++ b/tests/e2e/migration-rehearsal/rehearse.sh
@@ -47,7 +47,13 @@ else
   bad "could not position native binary"
 fi
 
-note "nx init --service — provisioning PG16 + pgvector + nexus DB (bge-768 service embedder, RDR-160)…"
+# nexus-lz3f2: bound the native service's heap so the boot memory peak (bge-768
+# ONNX load + PG + the Python supervisor in this container's shared VM) does not
+# trip the cgroup OOM killer — which previously SIGKILLed the SUPERVISOR (not the
+# JVM), silently vanishing the lease and failing the migrate intermittently. The
+# supervisor inherits this env and passes -Xmx to the native binary.
+export NX_SERVICE_MAX_HEAP="${NX_SERVICE_MAX_HEAP:-1g}"
+note "nx init --service — provisioning PG16 + pgvector + nexus DB (bge-768 service embedder, RDR-160; NX_SERVICE_MAX_HEAP=$NX_SERVICE_MAX_HEAP)…"
 if nx init --service --embedder bge-768 --yes 2>&1 | sed 's/^/       /'; then
   ok "nx init --service (provision)"
 else


### PR DESCRIPTION
## Fix nexus-lz3f2: intermittent storage-service lease-vanish (supervisor OOM)

### Root cause (debugger, hypothesis-tested vs code + run logs)
The migration-rehearsal intermittently failed with `No storage service lease found`. The **storage-service supervisor** (the Python process, not the JVM) was **OOM-killed** at the boot memory peak — DJL `libtokenizers.so` + the bge-768 ONNX model loading into the JVM, alongside PG and the supervisor, in the container's shared VM with no heap cap. SIGKILL → no Python teardown → no exit breadcrumb / crash log (exactly the run-9 evidence). Once the supervisor is dead nothing re-stamps the lease → it ages out → clients hard-fail. Intermittent because OOM victim-selection has a thin margin (run 9 killed it; run 10 didn't).

A container-specific *trigger* exposing a real product gap (supervisor SPOF + clients hard-fail instead of re-spawning).

### Fix
- **(B) Per-tier lease TTL in the shared primitive.** `service_registry.TIER_TTLS["storage_service"] = 15.0` (resolved via `ttl_for_tier`). The 3s substrate default is for the light T1/T2 daemons; a storage-service heartbeat tick can take up to `_HEALTH_TIMEOUT(2s)+interval(1s) ≈ 3s`, grazing the 3s TTL. 15s = ~15 missed-beats of margin; a genuinely dead supervisor is still reaped within 15s. Lives in the primitive per RDR-149 (no tier-specific lifecycle code in daemon modules).
- **(C) Optional `-Xmx` heap bound** (`NX_SERVICE_MAX_HEAP`, format-validated) — unset by default (**production serving unchanged**); the rehearsal sets `1g` so the boot peak fits and the supervisor isn't OOM-killed.

### Validation
- Migration-rehearsal run 12: `NX_SERVICE_MAX_HEAP=1g`, **SOUP-TO-NUTS REHEARSAL PASSED** — `Migration VERIFIED and unlocked`, cross-model parity green, supervisor survived boot.
- 105 daemon + RDR-149 conformance + lifecycle-gate tests green. The conformance harness now rides each tier's real TTL (was hardcoded 3s — vacuous for storage_service).
- Stacked review (code-review-expert + substantive-critic): 0 Critical; all Significant addressed.

### Follow-up (filed)
`nexus-03bcg` — the deeper client re-spawn backstop for a dead supervisor (needs adopt-existing-service semantics to avoid a double-JVM; scoped out here). The 15s TTL also widens the post-restart stale-endpoint residual (nexus-om64x) 3s→15s, which that backstop closes.

Bead: nexus-lz3f2.
