### PR TITLE
docs: close done-but-not-closed RDRs (161 native-only install, 096 URI source identity)

### DIFF
--- a/docs/rdr/rdr-096-uri-source-identity.md
+++ b/docs/rdr/rdr-096-uri-source-identity.md
@@ -2,12 +2,13 @@
 title: "RDR-096: URI-Based Source Identity for Aspect Extraction"
 id: RDR-096
 type: Architecture
-status: accepted
+status: closed
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-04-27
 accepted_date: 2026-04-27
+closed_date: 2026-06-19
 related_issues:
   - "#331 — nx enrich aspects writes null-field rows when extractor fails to read source"
   - "#332 — Source identity should be a URI, not a filesystem path"

--- a/docs/rdr/rdr-161-native-only-local-install.md
+++ b/docs/rdr/rdr-161-native-only-local-install.md
@@ -2,8 +2,9 @@
 title: "Native-Only Local Install: Expunge the JAR Launch Path, Acquire the Signed Native Binary and PG Bundle"
 id: RDR-161
 type: Architecture
-status: accepted
+status: closed
 accepted_date: 2026-06-18
+closed_date: 2026-06-19
 priority: high
 author: Hal Hildebrand
 reviewed-by: self


### PR DESCRIPTION
Audit found RDR-161 done-but-not-closed. Epic `nexus-ea2to` CLOSED (21/21), P1-P4 merged (#1202/#1203 + native-build), gate PASSED 0 Critical/0 Significant, no open beads. The cosign N+1 deferral (`nexus-1odsm`) that held the close is now closed (and v0.1.4/v0.1.5 binaries were cosign-verified this session). Flips `status: accepted -> closed`, `closed_date: 2026-06-19`. RDR files are never deleted — frontmatter flip only.