### PR TITLE
feat: nexus-8o9pm voyage-capability pre-flight for nx guided-upgrade

### DIFF
--- a/src/nexus/commands/guided_upgrade_cmd.py
+++ b/src/nexus/commands/guided_upgrade_cmd.py
@@ -37,6 +37,8 @@ from nexus.migration.guided_upgrade import (
     ProvisionResult,
     detect_pending_migration,
     establish_verified_service,
+    footprint_has_voyage_collections,
+    verify_voyage_capability,
 )
 
 _log = structlog.get_logger(__name__)
@@ -152,6 +154,34 @@ def guided_upgrade_cmd(
         f"  Service verified at {readiness.service_url} "
         "(healthy + version-pinned)."
     )
+
+    # 2a. VOYAGE-CAPABILITY GATE (nexus-8o9pm) — if the footprint has voyage-model
+    #     collections, the target MUST be voyage-capable. Voyage collections are
+    #     NOT cross-model-remapped to bge (re-embedding voyage text into bge
+    #     changes recall), so a bge-only target would block them mid-migration.
+    #     Catch it HERE with a precise message, keyed on the service's ACTUAL
+    #     /version capability (the authoritative server-side signal), not the
+    #     client's voyage-key probe.
+    # NOTE (substantive-critic Sig-1): this gate reads /version at
+    # readiness.service_url; the migration's own pre-gate (RDR-159 P1) re-reads
+    # /version via resolve_service_config() (NX_SERVICE_URL env). They converge
+    # because _run_migration below sets NX_SERVICE_URL = readiness.service_url
+    # BEFORE the pre-gate runs, so both observe the same service. The coupling is
+    # implicit; making it explicit (thread the verified url to run_guided_upgrade)
+    # is tracked as a follow-up.
+    if footprint_has_voyage_collections(pre.report):
+        cap = verify_voyage_capability(readiness.service_url)
+        if not cap.ok:
+            click.echo("", err=True)
+            click.echo(
+                f"Your footprint includes voyage-model collection(s), but the "
+                f"target service cannot serve voyage: {cap.reason}. Configure "
+                "voyage on the service (NX_VOYAGE_API_KEY / nx config set "
+                "voyage_api_key) and restart it, then re-run — or migrate "
+                "elsewhere; these collections cannot be re-embedded into bge.",
+                err=True,
+            )
+            raise SystemExit(1)
 
     # 2b. SELF-LOAD CREDENTIALS — the manual path sources pg_credentials between
     #     `nx init --service` and `nx migrate-to-service`; this is ONE process, so

--- a/src/nexus/migration/guided_upgrade.py
+++ b/src/nexus/migration/guided_upgrade.py
@@ -232,6 +232,91 @@ def verify_service_version(
     return VersionPinOutcome(ok=True, reason=None)
 
 
+# ── nexus-8o9pm: voyage-capability pre-flight ──────────────────────────────
+
+
+def footprint_has_voyage_collections(report: "DetectionReport") -> bool:
+    """True iff the footprint has a data-bearing voyage-model collection.
+
+    Voyage collections are NEVER cross-model-remapped to bge (RDR-162:
+    re-embedding voyage text into bge silently changes recall), so a voyage
+    collection can only migrate into a voyage-capable target — otherwise the
+    migration blocks it. Empty/non-conformant/bge/minilm collections do not
+    trigger the capability gate.
+
+    Keys on the canonical :data:`detection._VOYAGE_MODELS` set (the same
+    membership the classifier and ``cross_model_remappable`` use), NOT a
+    ``startswith('voyage')`` prefix: a non-canonical ``voyage-*`` name is an
+    unrecognized model (the classifier already gives it the re-index diagnostic),
+    not a voyage-capability problem, so it must not mis-fire this gate.
+    """
+    from nexus.migration.detection import _VOYAGE_MODELS  # noqa: PLC0415
+
+    return any(
+        c.has_data and c.model in _VOYAGE_MODELS for c in report.classifications
+    )
+
+
+@dataclass(frozen=True)
+class VoyageCapabilityOutcome:
+    """Whether the target service can serve voyage-model collections."""
+
+    ok: bool
+    reason: str | None
+
+
+def verify_voyage_capability(
+    service_url: str,
+    *,
+    http_get: Callable[[str, float], Any] | None = None,
+    timeout_s: float = 5.0,
+) -> VoyageCapabilityOutcome:
+    """Assert the target service embeds with a voyage model (its actual capability).
+
+    GETs ``{service_url}/version`` and checks ``embedding_models`` for any
+    ``voyage-*`` token — the AUTHORITATIVE server-side signal (not the client's
+    voyage-key probe, which is wrong in service mode). FAIL-CLOSED on transport
+    error, non-200, or a missing/empty/voyage-absent ``embedding_models``: if we
+    cannot confirm voyage capability, the voyage collections would block, so the
+    caller must surface that early.
+    """
+    if http_get is not None:
+        _get = http_get
+    else:
+
+        def _get(url: str, timeout: float) -> Any:
+            import httpx  # noqa: PLC0415
+
+            return httpx.get(url, timeout=timeout)
+
+    url = service_url.rstrip("/") + "/version"
+    try:
+        resp = _get(url, timeout_s)
+    except Exception as exc:  # noqa: BLE001 — any probe failure is fail-closed
+        return VoyageCapabilityOutcome(
+            ok=False, reason=f"could not reach {url} to check voyage capability: {exc}"
+        )
+    if getattr(resp, "status_code", None) != 200:
+        return VoyageCapabilityOutcome(
+            ok=False, reason=f"{url} returned HTTP {getattr(resp, 'status_code', '?')}"
+        )
+    try:
+        body = resp.json()
+    except Exception:  # noqa: BLE001
+        body = {}
+    models = body.get("embedding_models") or []
+    if any(isinstance(m, str) and m.startswith("voyage") for m in models):
+        return VoyageCapabilityOutcome(ok=True, reason=None)
+    return VoyageCapabilityOutcome(
+        ok=False,
+        reason=(
+            f"target service embeds with {list(models)} and cannot serve voyage "
+            "collections (voyage vectors are not re-embeddable into bge without "
+            "changing recall)"
+        ),
+    )
+
+
 @dataclass(frozen=True)
 class ServiceReadiness:
     """Outcome of the Stage 2->3 readiness contract.

--- a/tests/commands/test_guided_upgrade_cmd.py
+++ b/tests/commands/test_guided_upgrade_cmd.py
@@ -18,8 +18,9 @@ from nexus.migration.guided_upgrade import (
     PreflightDetection,
     ProvisionResult,
     ServiceReadiness,
+    VoyageCapabilityOutcome,
 )
-from nexus.migration.detection import DetectionReport
+from nexus.migration.detection import CollectionClassification, DetectionReport
 
 _MOD = "nexus.commands.guided_upgrade_cmd"
 
@@ -28,6 +29,19 @@ def _preflight(needs: bool, data_bearing: int = 0) -> PreflightDetection:
     # A report whose legs_with_data drives needs_migration; we patch the
     # function anyway, so the report contents only feed the echo counts.
     return PreflightDetection(report=DetectionReport(classifications=()), needs_migration=needs)
+
+
+def _preflight_voyage() -> PreflightDetection:
+    # support="unsupported" is irrelevant to the gate (it keys on model+has_data),
+    # included only to construct a valid classification.
+    c = CollectionClassification(
+        collection="knowledge__o__voyage-context-3__v1", leg="local",
+        model="voyage-context-3", dim=None, support="unsupported",
+        source_count=12, has_data=True,
+    )
+    return PreflightDetection(
+        report=DetectionReport(classifications=(c,)), needs_migration=True
+    )
 
 
 def _ready(url: str = "http://127.0.0.1:8099") -> ServiceReadiness:
@@ -170,6 +184,66 @@ class TestGuidedUpgradeCmd:
         assert result.exit_code == 1
         assert "nx storage migrate vectors --rollback" in result.output
         assert "FAILED validation" in result.output
+
+    def test_voyage_footprint_incapable_service_fails_before_migrating(self) -> None:
+        with patch(f"{_MOD}.detect_pending_migration",
+                   return_value=_preflight_voyage()), \
+             patch(f"{_MOD}.establish_verified_service", return_value=_ready()), \
+             patch(f"{_MOD}.verify_voyage_capability",
+                   return_value=VoyageCapabilityOutcome(
+                       ok=False, reason="target service embeds with ['bge-base-en-v15-768']")), \
+             patch("nexus.db.pg_provision.load_service_credentials_into_env",
+                   return_value=True), \
+             patch("nexus.commands.migrate_cmd._run_migration") as mig:
+            result = CliRunner().invoke(guided_upgrade_cmd, ["--yes"])
+        assert result.exit_code == 1
+        assert "cannot serve voyage" in result.output
+        mig.assert_not_called()
+
+    def test_voyage_footprint_capable_service_proceeds(self) -> None:
+        with patch(f"{_MOD}.detect_pending_migration",
+                   return_value=_preflight_voyage()), \
+             patch(f"{_MOD}.establish_verified_service", return_value=_ready()), \
+             patch(f"{_MOD}.verify_voyage_capability",
+                   return_value=VoyageCapabilityOutcome(ok=True, reason=None)) as cap, \
+             patch("nexus.db.pg_provision.load_service_credentials_into_env",
+                   return_value=True), \
+             patch("nexus.commands.migrate_cmd._run_migration") as mig:
+            result = CliRunner().invoke(guided_upgrade_cmd, ["--yes"])
+        assert result.exit_code == 0, result.output
+        cap.assert_called_once()
+        mig.assert_called_once()
+
+    def test_service_url_voyage_footprint_incapable_fails(self) -> None:
+        # The --service-url path runs the SAME voyage gate (it is not gated on
+        # service_url) — exercise the combination explicitly (CR-L1).
+        import os as _os
+        with patch(f"{_MOD}.detect_pending_migration",
+                   return_value=_preflight_voyage()), \
+             patch(f"{_MOD}.establish_verified_service",
+                   return_value=_ready("http://svc:9000")), \
+             patch(f"{_MOD}.verify_voyage_capability",
+                   return_value=VoyageCapabilityOutcome(
+                       ok=False, reason="target service embeds with ['bge-base-en-v15-768']")), \
+             patch.dict(_os.environ, {"NX_SERVICE_TOKEN": "tok"}, clear=False), \
+             patch("nexus.commands.migrate_cmd._run_migration") as mig:
+            result = CliRunner().invoke(
+                guided_upgrade_cmd, ["--yes", "--service-url", "http://svc:9000"])
+        assert result.exit_code == 1
+        assert "cannot serve voyage" in result.output
+        mig.assert_not_called()
+
+    def test_no_voyage_footprint_skips_capability_check(self) -> None:
+        with patch(f"{_MOD}.detect_pending_migration",
+                   return_value=_preflight(True, 2)), \
+             patch(f"{_MOD}.establish_verified_service", return_value=_ready()), \
+             patch(f"{_MOD}.verify_voyage_capability") as cap, \
+             patch("nexus.db.pg_provision.load_service_credentials_into_env",
+                   return_value=True), \
+             patch("nexus.commands.migrate_cmd._run_migration"):
+            result = CliRunner().invoke(guided_upgrade_cmd, ["--yes"])
+        assert result.exit_code == 0, result.output
+        cap.assert_not_called()  # no voyage collections -> no capability probe
 
     def test_missing_token_after_provision_fails_before_migrating(self) -> None:
         # The one-command flow self-loads pg_credentials; if no token is available

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -464,6 +464,11 @@ _MODE_LINT_EXCLUDE_FILES: frozenset[str] = frozenset({
     # cloud_mode fixture.
     "test_pregate.py",
     "test_quiesce.py",
+    # nexus-8o9pm voyage-capability gate: voyage tokens are collection-NAME
+    # fixtures (footprint detection) and embedding_models inside a FAKE /version
+    # response body; the gate is a pure data/HTTP predicate that never embeds, so
+    # there is no ambient cloud_mode behavior to assert.
+    "test_guided_upgrade_voyage_capability.py",
     # RDR-001 managed-endpoint probe: voyage tokens appear only as
     # embedding_models inside a FAKE /version response body (injected
     # http_get) — the managed service's reported models, not cloud-mode

--- a/tests/migration/test_guided_upgrade_voyage_capability.py
+++ b/tests/migration/test_guided_upgrade_voyage_capability.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""ez5.4-adjacent (nexus-8o9pm) — voyage-capability pre-flight for guided-upgrade.
+
+If the footprint has voyage-model collections, the migration target MUST be a
+voyage-capable service (its /version embedding_models lists a voyage-* model) —
+voyage collections are NOT cross-model-remapped to bge (re-embedding voyage text
+into bge silently changes recall), so a bge-only target cannot serve them. The
+existing migration pre-gate blocks them, but LATE and via the client voyage
+probe; this gate catches it EARLY with a precise message, keyed on the target
+service's ACTUAL capability (server-side, the authoritative signal).
+"""
+
+from __future__ import annotations
+
+from nexus.migration.detection import (
+    CollectionClassification,
+    DetectionReport,
+)
+from nexus.migration.guided_upgrade import (
+    VoyageCapabilityOutcome,
+    footprint_has_voyage_collections,
+    verify_voyage_capability,
+)
+
+_URL = "http://127.0.0.1:8099"
+
+
+def _cls(collection: str, model: str | None, *, has_data: bool = True) -> CollectionClassification:
+    return CollectionClassification(
+        collection=collection, leg="local", model=model, dim=None,
+        support="unsupported", source_count=12 if has_data else 0, has_data=has_data,
+    )
+
+
+def _report(*classifications: CollectionClassification) -> DetectionReport:
+    return DetectionReport(classifications=tuple(classifications))
+
+
+class _Resp:
+    def __init__(self, status_code: int, body) -> None:  # noqa: ANN001
+        self.status_code = status_code
+        self._body = body
+
+    def json(self):  # noqa: ANN202
+        if isinstance(self._body, Exception):
+            raise self._body
+        return self._body
+
+
+def _get_returning(resp_or_exc):  # noqa: ANN001, ANN202
+    def _get(url: str, timeout: float):  # noqa: ANN202
+        if isinstance(resp_or_exc, Exception):
+            raise resp_or_exc
+        return resp_or_exc
+    return _get
+
+
+def _vbody(models: list[str]) -> dict:
+    return {"app_version": "1.0-SNAPSHOT", "release_version": "0.1.6",
+            "embedding_mode": "voyage", "embedding_models": models}
+
+
+class TestFootprintHasVoyage:
+    def test_voyage_data_bearing_is_true(self) -> None:
+        r = _report(_cls("knowledge__o__voyage-context-3__v1", "voyage-context-3"))
+        assert footprint_has_voyage_collections(r) is True
+
+    def test_voyage_empty_is_false(self) -> None:
+        r = _report(_cls("knowledge__o__voyage-context-3__v1", "voyage-context-3", has_data=False))
+        assert footprint_has_voyage_collections(r) is False
+
+    def test_bge_and_minilm_only_is_false(self) -> None:
+        r = _report(
+            _cls("code__o__bge-base-en-v15-768__v1", "bge-base-en-v15-768"),
+            _cls("knowledge__o__minilm-l6-v2-384__v1", "minilm-l6-v2-384"),
+        )
+        assert footprint_has_voyage_collections(r) is False
+
+    def test_mixed_with_one_voyage_is_true(self) -> None:
+        r = _report(
+            _cls("knowledge__o__minilm-l6-v2-384__v1", "minilm-l6-v2-384"),
+            _cls("knowledge__o__voyage-code-3__v1", "voyage-code-3"),
+        )
+        assert footprint_has_voyage_collections(r) is True
+
+    def test_nonconformant_none_model_is_false(self) -> None:
+        assert footprint_has_voyage_collections(_report(_cls("legacy", None))) is False
+
+    def test_non_canonical_voyage_name_does_not_misfire(self) -> None:
+        # A voyage-*-PREFIXED but non-canonical model (not in _VOYAGE_MODELS) is
+        # an unrecognized model, not a voyage-capability problem — the classifier
+        # gives it the re-index diagnostic; this gate must NOT fire on it.
+        r = _report(_cls("knowledge__o__voyage-future-9__v1", "voyage-future-9"))
+        assert footprint_has_voyage_collections(r) is False
+
+
+class TestVerifyVoyageCapability:
+    def test_service_with_voyage_is_capable(self) -> None:
+        out = verify_voyage_capability(
+            _URL, http_get=_get_returning(_Resp(200, _vbody(["voyage-context-3", "voyage-3"]))))
+        assert isinstance(out, VoyageCapabilityOutcome)
+        assert out.ok is True
+        assert out.reason is None
+
+    def test_bge_only_service_is_not_capable(self) -> None:
+        out = verify_voyage_capability(
+            _URL, http_get=_get_returning(_Resp(200, _vbody(["bge-base-en-v15-768"]))))
+        assert out.ok is False
+        assert "voyage" in out.reason and "bge-base-en-v15-768" in out.reason
+
+    def test_empty_models_is_not_capable(self) -> None:
+        out = verify_voyage_capability(
+            _URL, http_get=_get_returning(_Resp(200, _vbody([]))))
+        assert out.ok is False
+
+    def test_missing_models_field_is_not_capable(self) -> None:
+        out = verify_voyage_capability(
+            _URL, http_get=_get_returning(_Resp(200, {"app_version": "x"})))
+        assert out.ok is False
+
+    def test_non_200_fails_closed(self) -> None:
+        out = verify_voyage_capability(
+            _URL, http_get=_get_returning(_Resp(503, {})))
+        assert out.ok is False
+
+    def test_transport_error_fails_closed(self) -> None:
+        out = verify_voyage_capability(
+            _URL, http_get=_get_returning(ConnectionError("refused")))
+        assert out.ok is False
+        assert "refused" in out.reason
+
+    def test_probes_version_endpoint(self) -> None:
+        seen: list[str] = []
+
+        def _get(url: str, timeout: float):  # noqa: ANN202
+            seen.append(url)
+            return _Resp(200, _vbody(["voyage-3"]))
+
+        verify_voyage_capability(_URL, http_get=_get)
+        assert seen == [f"{_URL}/version"]


### PR DESCRIPTION
## nexus-8o9pm — voyage-capability pre-flight for `nx guided-upgrade`

Release-N readiness gate 1/3 (parent `nexus-h3ilf`). Surfaced by the substantive-critic; **corrected** after Hal caught a premise error (it is *not* a client-voyage-key check).

### What it does
If the migration footprint has **voyage-model collections**, the target service must be **voyage-capable**. Voyage collections are never cross-model-remapped to bge (`detection.cross_model_remappable` excludes them — re-embedding voyage text into bge changes recall), so a bge-only target would block them. The existing migration pre-gate already blocks them, but **late** (post-provision, `migrated-failed` sentinel) and via the **client** voyage-key probe. This gate catches it **early**, keyed on the target service's **actual `/version` `embedding_models`** — the authoritative server-side signal. Tenants never supply a Voyage key (the engine holds the operator key); this is purely a server-capability check. Fail-closed.

### Reviewed
Stacked code-review-expert (**APPROVED**, 0C/0H) + substantive-critic (0 Critical). Fixes applied: footprint predicate keys on the canonical `_VOYAGE_MODELS` set (not `startswith`, avoiding mis-fire on non-canonical names); implicit gate↔pre-gate endpoint-convergence documented inline. Deferred follow-ups: `nexus-o9jwf` (thread the verified url explicitly to the pre-gate), `nexus-vdteg` (combine the two `/version` fetches).

### Tests
13 lib + 14 command tests (incl. `--service-url`+voyage, non-canonical voyage name, capable/incapable/skip paths); 340-test migration+command sweep green.
