### PR TITLE
feat: nexus-4mm24 cold-acquire fresh-machine validation + PG-bundle lib-path fix

### DIFF
--- a/.github/workflows/cold-install-rehearsal.yml
+++ b/.github/workflows/cold-install-rehearsal.yml
@@ -1,0 +1,48 @@
+name: Cold-acquire fresh-install rehearsal
+
+# nexus-4mm24 — fresh quarantine-machine install + migrate validation.
+#
+# Proves the journey the soup-to-nuts MVV skips by pre-staging: from a bare
+# debian:trixie-slim container with ONLY the conexus wheel, `nx daemon service
+# install-binary <tag>` + `nx init --service` cold-acquire the native binary, the
+# PG+pgvector bundle, and the bge-768 ONNX from the PUBLISHED engine-service
+# release, provision, and migrate via `nx guided-upgrade`.
+#
+# Secret-free (ONNX leg only — the local service embeds with bge-768; no Voyage
+# key). The container is the quarantine: GitHub's hosted runners are pre-loaded
+# (ubuntu ships PostgreSQL), so the bare box is the minimal container, not the
+# runner. Requires the target tag's GitHub Release to be PUBLISHED first.
+#
+# Manual-dispatch only (deferred from CI-required per nexus-myk4e / the luxe6
+# release boundary): run it on demand against a published engine-service tag.
+
+on:
+  workflow_dispatch:
+    inputs:
+      service_tag:
+        description: "Published engine-service tag to cold-acquire from"
+        required: true
+        default: "engine-service-v0.1.6"
+
+permissions:
+  contents: read
+
+jobs:
+  cold-install:
+    name: Cold-acquire + migrate (${{ github.event.inputs.service_tag }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Run the cold-acquire rehearsal
+        # run.sh --cold builds the wheel on the host, builds the minimal
+        # Dockerfile.cold image (no PG, no binary, no ONNX), and runs
+        # rehearse_cold.sh inside it. NEXUS_SERVICE_TAG selects the published
+        # release to acquire from.
+        env:
+          NEXUS_SERVICE_TAG: ${{ github.event.inputs.service_tag }}
+        run: bash tests/e2e/migration-rehearsal/run.sh --cold

--- a/src/nexus/db/pg_provision.py
+++ b/src/nexus/db/pg_provision.py
@@ -245,10 +245,12 @@ def discover_pg_binaries() -> PgBinaries:
 
 def _pg_config_value(pg_config: Path, flag: str) -> str | None:
     """Return a ``pg_config <flag>`` value, or None when indeterminate."""
+    cmd = [str(pg_config), flag]
     try:
         result = subprocess.run(
-            [str(pg_config), flag],
+            cmd,
             capture_output=True, text=True, timeout=10,
+            env=_bundle_lib_env(cmd, None),
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         _log.warning("pgvector_preflight_indeterminate", error=str(exc), flag=flag)
@@ -366,14 +368,37 @@ class ProvisionResult:
 # ── Low-level helpers ──────────────────────────────────────────────────────────
 
 
+def _bundle_lib_env(cmd: list[str], env: dict | None) -> dict:
+    """Build a subprocess env that lets a relocatable PG binary find its own libs.
+
+    The RDR-161 relocatable PG bundle ships its libraries in ``<bundle>/lib`` but
+    its ``bin/`` binaries carry NO RPATH/RUNPATH (nexus-4mm24: caught on a minimal
+    ``debian:trixie-slim`` where ``libpq.so.5`` is absent system-wide — ``initdb``
+    exited 127). Point the dynamic loader at the binary's sibling ``lib/`` so
+    ``initdb`` / ``pg_ctl`` / the started ``postgres`` (which inherits this env)
+    resolve their bundled libs. Harmless for a system PostgreSQL — its lib dir is
+    already on the default search path. The durable fix is an RPATH in the bundle
+    build; this is the consumer-side guard so the published bundle works today.
+    """
+    base = dict(os.environ if env is None else env)
+    try:
+        lib_dir = Path(cmd[0]).resolve().parent.parent / "lib"
+    except (IndexError, OSError):
+        return base
+    if lib_dir.is_dir():
+        existing = base.get("LD_LIBRARY_PATH", "")
+        base["LD_LIBRARY_PATH"] = (
+            f"{lib_dir}{os.pathsep}{existing}" if existing else str(lib_dir)
+        )
+    return base
+
+
 def _run(cmd: list[str], *, check: bool = True, capture: bool = True, env: dict | None = None) -> subprocess.CompletedProcess:
     """Run a subprocess, raising on non-zero exit when *check* is True."""
     _log.debug("pg_provision_run", cmd=cmd)
-    kw: dict = dict(check=check, text=True)
+    kw: dict = dict(check=check, text=True, env=_bundle_lib_env(cmd, env))
     if capture:
         kw["capture_output"] = True
-    if env is not None:
-        kw["env"] = env
     return subprocess.run(cmd, **kw)  # type: ignore[call-overload]
 
 

--- a/src/nexus/db/pg_provision.py
+++ b/src/nexus/db/pg_provision.py
@@ -247,6 +247,10 @@ def _pg_config_value(pg_config: Path, flag: str) -> str | None:
     """Return a ``pg_config <flag>`` value, or None when indeterminate."""
     cmd = [str(pg_config), flag]
     try:
+        # env is now an os.environ SNAPSHOT (was: inherited live by reference).
+        # subprocess.run is synchronous and os.environ is not mutated mid-call,
+        # so this is equivalent in practice — the snapshot is to thread the
+        # bundle lib path (code-review H2).
         result = subprocess.run(
             cmd,
             capture_output=True, text=True, timeout=10,
@@ -376,9 +380,22 @@ def _bundle_lib_env(cmd: list[str], env: dict | None) -> dict:
     ``debian:trixie-slim`` where ``libpq.so.5`` is absent system-wide — ``initdb``
     exited 127). Point the dynamic loader at the binary's sibling ``lib/`` so
     ``initdb`` / ``pg_ctl`` / the started ``postgres`` (which inherits this env)
-    resolve their bundled libs. Harmless for a system PostgreSQL — its lib dir is
-    already on the default search path. The durable fix is an RPATH in the bundle
-    build; this is the consumer-side guard so the published bundle works today.
+    resolve their bundled libs.
+
+    SCOPE (reviewed, not bundle-gated): this fires for ANY ``cmd[0]`` with a
+    sibling ``../lib`` dir, which also includes Homebrew PG on macOS. It is safe
+    in every supported layout because the prepend only exposes the binary's OWN
+    co-located libs earlier on the search path, never a foreign one:
+      * nexus bundle ``<root>/bin/initdb`` → ``<root>/lib`` (the intended fix);
+      * Debian/PGDG ``/usr/bin/initdb`` → resolves (symlink) to
+        ``/usr/lib/postgresql/N/bin`` whose ``../lib`` does NOT exist (libs live
+        in ``/usr/lib/<triplet>/``) → ``is_dir()`` False → no-op;
+      * macOS (Homebrew or system) → ``dyld`` ignores ``LD_LIBRARY_PATH`` → no
+        effect regardless.
+    A non-symlink ``/usr/bin/initdb`` on Linux would prepend ``/usr/lib`` (already
+    the default path) — a benign, persistent env on the started ``postgres``. The
+    durable fix is an RPATH in the bundle build (nexus-iytd3); this consumer-side
+    guard makes the already-published bundle work for nx-managed provisioning.
     """
     base = dict(os.environ if env is None else env)
     try:

--- a/tests/db/test_pg_bundle_lib_env.py
+++ b/tests/db/test_pg_bundle_lib_env.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-4mm24 — relocatable PG bundle binaries have no RPATH; _bundle_lib_env
+points the loader at the bundle's sibling lib/ so initdb/pg_ctl find libpq.so.5
+on a minimal base."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from nexus.db.pg_provision import _bundle_lib_env
+
+
+def _bundle(tmp_path: Path) -> Path:
+    (tmp_path / "bundle" / "bin").mkdir(parents=True)
+    (tmp_path / "bundle" / "lib").mkdir(parents=True)
+    initdb = tmp_path / "bundle" / "bin" / "initdb"
+    initdb.write_text("")
+    return initdb
+
+
+def test_sets_ld_library_path_to_sibling_lib(tmp_path: Path) -> None:
+    initdb = _bundle(tmp_path)
+    env = _bundle_lib_env([str(initdb)], {})
+    assert env["LD_LIBRARY_PATH"] == str(tmp_path / "bundle" / "lib")
+
+
+def test_prepends_to_existing_ld_library_path(tmp_path: Path) -> None:
+    initdb = _bundle(tmp_path)
+    env = _bundle_lib_env([str(initdb)], {"LD_LIBRARY_PATH": "/existing"})
+    parts = env["LD_LIBRARY_PATH"].split(os.pathsep)
+    assert parts[0] == str(tmp_path / "bundle" / "lib")
+    assert "/existing" in parts
+
+
+def test_no_lib_dir_leaves_env_untouched(tmp_path: Path) -> None:
+    # bin with no sibling lib/ (e.g. a system PG layout without ../lib)
+    (tmp_path / "bin").mkdir()
+    initdb = tmp_path / "bin" / "initdb"
+    initdb.write_text("")
+    env = _bundle_lib_env([str(initdb)], {"FOO": "bar"})
+    assert "LD_LIBRARY_PATH" not in env
+    assert env["FOO"] == "bar"
+
+
+def test_defaults_to_os_environ_when_env_none(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SENTINEL_VAR", "present")
+    initdb = _bundle(tmp_path)
+    env = _bundle_lib_env([str(initdb)], None)
+    assert env["SENTINEL_VAR"] == "present"  # inherited os.environ
+    assert env["LD_LIBRARY_PATH"] == str(tmp_path / "bundle" / "lib")

--- a/tests/e2e/migration-rehearsal/Dockerfile.cold
+++ b/tests/e2e/migration-rehearsal/Dockerfile.cold
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1
+# nexus-4mm24 — COLD-ACQUIRE fresh-machine validation box.
+#
+# Unlike the soup-to-nuts MVV (Dockerfile), this is a TRUE quarantine machine:
+# it pre-stages NOTHING the service needs. No system PostgreSQL, no native
+# binary, no PG bundle, no ONNX model. Just the OS, Python, and the conexus
+# wheel — exactly what `pip install conexus` leaves a fresh user with.
+#
+# `nx daemon service install-binary <tag>` then cold-acquires from the PUBLISHED
+# engine-service-v* GitHub Release (cosign-verified): the native binary AND the
+# relocatable PG+pgvector bundle. `nx init --service` extracts the bundle,
+# provisions PG, downloads the bge-768 ONNX, and starts the service. This proves
+# the auto-acquire + auto-provision paths the MVV skips by pre-staging.
+#
+# Base = debian:trixie-slim — conexus's actual runtime deploy base (glibc 2.41),
+# so this ALSO validates the published linux binary's glibc floor + runtime-lib
+# deps against the real target, not a build-matched host.
+FROM debian:trixie-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    PYTHONUNBUFFERED=1
+
+# Deliberately minimal: ca-certificates (TLS for the release + HF downloads),
+# git (Catalog.init runs `git init`), python + uv for the wheel, and libgomp1
+# (the native binary's bundled ONNX runtime dlopens OpenMP). NO postgresql —
+# the relocatable PG bundle is cold-acquired + provisioned by nx itself, which
+# is the whole point of this box.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git \
+        python3 python3-venv python3-pip \
+        libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root user — initdb (run by `nx init --service`) refuses to run as root.
+RUN useradd -m -s /bin/bash nexus
+ENV PATH="/home/nexus/nxenv/bin:${PATH}"
+
+RUN pip3 install --no-cache-dir --break-system-packages uv
+
+USER nexus
+WORKDIR /home/nexus
+
+# The conexus wheel — staged to the context root by run.sh (keeps its real PEP
+# 427 name). This is the ONLY conexus artifact in the image; everything the
+# service needs is cold-acquired at runtime.
+COPY conexus-*.whl /tmp/
+RUN --mount=type=cache,target=/home/nexus/.cache/uv,uid=1000,gid=1000 \
+    uv venv --python 3.12 /home/nexus/nxenv \
+    && uv pip install --python /home/nexus/nxenv /tmp/conexus-*.whl \
+    && nx --version
+
+# Driver + seed last (trivial layers).
+COPY rehearse_cold.sh /home/nexus/rehearse_cold.sh
+COPY seed_legacy.py /home/nexus/seed_legacy.py
+
+ENTRYPOINT ["/bin/bash", "/home/nexus/rehearse_cold.sh"]

--- a/tests/e2e/migration-rehearsal/rehearse_cold.sh
+++ b/tests/e2e/migration-rehearsal/rehearse_cold.sh
@@ -74,15 +74,22 @@ nx daemon service status 2>&1 | sed 's/^/       /' || true
 # The PUBLISHED binary must report release_version == the acquired tag — proves
 # both the Option-B stamp AND that install-binary fetched the right release.
 RV="$(nx daemon service status --json 2>/dev/null | python -c 'import sys,json;print(json.load(sys.stdin).get("service_release_version") or "")' 2>/dev/null)"
-[ "$RV" = "$EXPECT_RELEASE_VERSION" ] \
-  && ok "/version release_version=$RV matches the acquired tag" \
-  || bad "release_version=$RV != expected $EXPECT_RELEASE_VERSION (wrong binary or stamp)"
+if [ "$RV" = "$EXPECT_RELEASE_VERSION" ]; then
+  ok "/version release_version=$RV matches the acquired tag"
+elif [ -z "$RV" ]; then
+  bad "no release_version on /version (service unreachable or field absent), expected $EXPECT_RELEASE_VERSION"
+else
+  bad "release_version=$RV != expected $EXPECT_RELEASE_VERSION (wrong binary or stamp)"
+fi
 
 # ── Seed pre-RDR-160 footprint + guided-upgrade (ONNX leg, secret-free) ───────
 say "Seed pre-RDR-160 footprint + nx guided-upgrade"
 if SEED_RAW="$(python /home/nexus/seed_legacy.py "$CHROMA_LOCAL" --n "$SEED_N")"; then
   SEED_JSON="$(printf '%s\n' "$SEED_RAW" | tail -1)"
-  ok "seeded legacy footprint: $SEED_JSON"
+  case "$SEED_JSON" in
+    '{'*'}') ok "seeded legacy footprint: $SEED_JSON" ;;
+    *) bad "seed produced no JSON manifest (got: '$SEED_JSON')"; say "ABORT"; exit 1 ;;
+  esac
 else
   bad "seed failed"; say "ABORT"; exit 1
 fi

--- a/tests/e2e/migration-rehearsal/rehearse_cold.sh
+++ b/tests/e2e/migration-rehearsal/rehearse_cold.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# nexus-4mm24 — COLD-ACQUIRE fresh-machine validation. Runs INSIDE the container.
+#
+# Proves the fresh-user journey the MVV skips by pre-staging: from a clean box
+# with ONLY the conexus wheel, cold-acquire every service artifact from the
+# PUBLISHED engine-service release, provision, and migrate. Secret-free (ONNX
+# leg only — no Voyage key needed; the local service embeds with bge-768).
+#
+#   install-binary <tag>  cold-acquire native binary + PG bundle (cosign-verified)
+#   init --service        extract bundle -> provision PG -> fetch bge ONNX -> serve
+#   /version              assert release_version == the acquired tag (published stamp)
+#   seed legacy           pre-RDR-160 minilm-384 footprint + sourceless note
+#   guided-upgrade        detect -> verify -> migrate -> "VERIFIED and unlocked"
+#   parity + source-intact
+set -uo pipefail
+
+SERVICE_TAG="${NEXUS_SERVICE_TAG:?NEXUS_SERVICE_TAG must be set (e.g. engine-service-v0.1.6)}"
+EXPECT_RELEASE_VERSION="${SERVICE_TAG#engine-service-v}"
+CHROMA_LOCAL="${CHROMA_LOCAL:-/home/nexus/legacy-chroma}"
+SEED_N="${SEED_N:-12}"
+FAILS=0
+
+say()  { printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
+ok()   { printf '  \033[32mPASS\033[0m %s\n' "$*"; }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$*"; FAILS=$((FAILS+1)); }
+note() { printf '       %s\n' "$*"; }
+
+# Quarantine assertions: prove the box really is bare before we acquire.
+say "Quarantine — nothing pre-staged"
+nx --version >/dev/null 2>&1 && ok "nx installed ($(nx --version 2>&1))" || bad "nx --version failed"
+command -v initdb >/dev/null 2>&1 && bad "system PostgreSQL present — not a cold box" || ok "no system PostgreSQL (bundle must provide it)"
+test ! -e "$HOME/.config/nexus/service/nexus-service" && ok "no native binary pre-staged" || bad "native binary already present — not cold"
+
+export NX_SERVICE_MAX_HEAP="${NX_SERVICE_MAX_HEAP:-1g}"
+git config --global user.email "cold@nexus.local" >/dev/null 2>&1 || true
+git config --global user.name  "nexus cold"       >/dev/null 2>&1 || true
+
+# ── Cold-acquire: native binary + PG bundle from the PUBLISHED release ────────
+say "Cold-acquire — nx daemon service install-binary $SERVICE_TAG"
+note "downloads the native binary AND the PG+pgvector bundle from the release,"
+note "cosign-verified (offline, sigstore-python) — no system PG, no pre-stage."
+if nx daemon service install-binary "$SERVICE_TAG" 2>&1 | sed 's/^/       /'; then
+  ok "install-binary acquired + verified binary + PG bundle"
+else
+  bad "install-binary failed (cold-acquire of binary/bundle)"; say "ABORT"; exit 1
+fi
+test -x "$HOME/.config/nexus/service/nexus-service" \
+  && ok "native binary now present (cold-acquired)" || bad "binary missing after install-binary"
+
+# ── Provision + serve from the cold-acquired artifacts ───────────────────────
+say "Provision + serve — nx init --service (extract bundle, provision PG, fetch bge ONNX)"
+export NEXUS_SERVICE_TAG="$SERVICE_TAG"   # _ensure_service_binary_step no-ops (already installed)
+if nx init --service --embedder bge-768 --yes 2>&1 | sed 's/^/       /'; then
+  ok "nx init --service (bundle-provisioned PG + bge ONNX + service started)"
+else
+  bad "nx init --service failed"; say "ABORT (provision failed)"; exit 1
+fi
+export NX_STORAGE_BACKEND=service
+# shellcheck disable=SC1091
+[ -f "$HOME/.config/nexus/pg_credentials" ] && { set -a; . "$HOME/.config/nexus/pg_credentials"; set +a; }
+unset NX_SERVICE_URL NX_SERVICE_PORT NX_SERVICE_HOST 2>/dev/null || true
+
+healthy=0
+for _ in $(seq 1 30); do
+  if nx daemon service status 2>&1 | grep -qiE "health.*ok|healthy|serving|status.*ok|running"; then
+    healthy=1; break
+  fi
+  sleep 2
+done
+nx daemon service status 2>&1 | sed 's/^/       /' || true
+[ "$healthy" = 1 ] && ok "service healthy (cold-acquired binary serving on the bundled PG)" \
+  || { bad "service did not reach healthy"; say "ABORT"; exit 1; }
+
+# The PUBLISHED binary must report release_version == the acquired tag — proves
+# both the Option-B stamp AND that install-binary fetched the right release.
+RV="$(nx daemon service status --json 2>/dev/null | python -c 'import sys,json;print(json.load(sys.stdin).get("service_release_version") or "")' 2>/dev/null)"
+[ "$RV" = "$EXPECT_RELEASE_VERSION" ] \
+  && ok "/version release_version=$RV matches the acquired tag" \
+  || bad "release_version=$RV != expected $EXPECT_RELEASE_VERSION (wrong binary or stamp)"
+
+# ── Seed pre-RDR-160 footprint + guided-upgrade (ONNX leg, secret-free) ───────
+say "Seed pre-RDR-160 footprint + nx guided-upgrade"
+if SEED_RAW="$(python /home/nexus/seed_legacy.py "$CHROMA_LOCAL" --n "$SEED_N")"; then
+  SEED_JSON="$(printf '%s\n' "$SEED_RAW" | tail -1)"
+  ok "seeded legacy footprint: $SEED_JSON"
+else
+  bad "seed failed"; say "ABORT"; exit 1
+fi
+
+GU_OUT="$(nx guided-upgrade --local-path "$CHROMA_LOCAL" --timeout 180 --yes 2>&1)"
+GU_RC=$?
+printf '%s\n' "$GU_OUT" | sed 's/^/       /'
+[ "$GU_RC" = 0 ] && ok "nx guided-upgrade exited 0" || bad "nx guided-upgrade exited $GU_RC"
+printf '%s' "$GU_OUT" | grep -q "Migration VERIFIED and unlocked" \
+  && ok "migration VERIFIED and unlocked (cold-acquired stack end-to-end)" \
+  || bad "no 'Migration VERIFIED and unlocked' line"
+
+# ── Parity + source intact (reuse the MVV checks) ────────────────────────────
+say "Parity — pgvector serves the migrated collections"
+python - "$SEED_JSON" <<'PY' && ok "cross-model parity validated" || bad "parity mismatch / unverified"
+import json, sys
+m = json.loads(sys.argv[1]); seeded = m.get("collections", {}); cross = m.get("cross_model", {})
+if not seeded:
+    print("       no seed manifest"); sys.exit(1)
+try:
+    from nexus.db import make_t3
+    t3 = make_t3(); bad = 0
+    for name, want in seeded.items():
+        target = cross.get(name, name)
+        try:
+            got = t3.count(target)
+        except Exception as e:
+            print(f"       {target}: count() error: {e}"); bad += 1; continue
+        flag = "ok" if got == want else "MISMATCH"
+        print(f"       {name} -> {target}: service={got} seeded={want} [{flag}]")
+        if got != want:
+            bad += 1
+    sys.exit(1 if bad else 0)
+except Exception as e:
+    print(f"       harness error: {e}"); sys.exit(1)
+PY
+
+say "Rollback safety — legacy Chroma untouched"
+python - "$CHROMA_LOCAL" "$SEED_JSON" <<'PY' && ok "legacy Chroma still intact" || bad "legacy Chroma damaged"
+import json, sys, chromadb
+path, seed = sys.argv[1], json.loads(sys.argv[2]).get("collections", {})
+client = chromadb.PersistentClient(path=path); bad = 0
+for name, want in seed.items():
+    got = client.get_collection(name).count()
+    print(f"       {name}: source still has {got} (seeded {want})")
+    if got != want:
+        bad += 1
+sys.exit(1 if bad else 0)
+PY
+
+say "RESULT"
+if [ "$FAILS" -eq 0 ]; then
+  printf '\033[32mCOLD-ACQUIRE MVV PASSED\033[0m — bare box -> install-binary -> init --service -> guided-upgrade, all artifacts cold-acquired from the published release\n'
+  exit 0
+else
+  printf '\033[31mCOLD-ACQUIRE MVV FAILED — %d check(s) failed\033[0m\n' "$FAILS"
+  exit 1
+fi

--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -22,15 +22,19 @@ IMAGE="nexus-migration-rehearsal"
 WITH_CLOUD=0
 DO_BUILD=1
 GUIDED=0
+COLD=0
 # RDR-002 ez5.13: the release_version the guided MVV stamps into the binary so
 # its /version reports >= v0.1.5 and the guided-upgrade version-pin PASSES.
 GUIDED_STAMP_VERSION="0.1.6"
 RELEASE_PROPS="service/src/main/resources/META-INF/nexus/release.properties"
+# nexus-4mm24: the published engine-service tag the COLD box auto-acquires from.
+COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.6}"
 for a in "$@"; do
   case "$a" in
     --with-cloud) WITH_CLOUD=1 ;;
     --no-build)   DO_BUILD=0 ;;
     --guided)     GUIDED=1 ;;   # RDR-002 ez5.13: drive nx guided-upgrade
+    --cold)       COLD=1 ;;     # nexus-4mm24: cold-acquire from the published release
     *) echo "unknown arg: $a" >&2; exit 2 ;;
   esac
 done
@@ -50,6 +54,8 @@ _guided_restore() {
 }
 trap '_guided_restore' EXIT
 
+[ "$COLD" = 1 ] && [ "$GUIDED" = 1 ] && { echo "--cold and --guided are different flows; pick one" >&2; exit 2; }
+
 if [ "$GUIDED" = 1 ]; then
   # --guided force-rebuilds the native binary with the stamp baked in, so it is
   # incompatible with --no-build (which would reuse a stale/unstamped binary).
@@ -63,7 +69,13 @@ if [ "$GUIDED" = 1 ]; then
 fi
 
 GRAAL_IMAGE="container-registry.oracle.com/graalvm/native-image-community:25"
-if [ "$DO_BUILD" = 1 ]; then
+if [ "$COLD" = 1 ]; then
+  # nexus-4mm24: the cold box acquires the PUBLISHED binary + PG bundle at
+  # runtime — NO local native build, NO stamping. Just the wheel.
+  echo "[1/2] Building the conexus wheel (host)…"
+  uv build --wheel >/dev/null 2>&1
+  ls dist/conexus-*.whl >/dev/null 2>&1 || { echo "no wheel in dist/" >&2; exit 1; }
+elif [ "$DO_BUILD" = 1 ]; then
   echo "[1/3] Building the conexus wheel (host)…"
   uv build --wheel >/dev/null 2>&1
   echo "[2/3] Building the LINUX native nexus-service binary (GraalVM container, ~2-3m)…"
@@ -88,27 +100,37 @@ else
   echo "[1-2/3] --no-build: reusing existing wheel + native binary"
 fi
 
-ls dist/conexus-*.whl >/dev/null 2>&1 || { echo "no wheel in dist/ — drop --no-build" >&2; exit 1; }
-[ -x service/target/nexus-service ] || { echo "no native binary at service/target/nexus-service — drop --no-build" >&2; exit 1; }
+if [ "$COLD" = 0 ]; then
+  ls dist/conexus-*.whl >/dev/null 2>&1 || { echo "no wheel in dist/ — drop --no-build" >&2; exit 1; }
+  [ -x service/target/nexus-service ] || { echo "no native binary at service/target/nexus-service — drop --no-build" >&2; exit 1; }
+fi
 
-echo "[3/3] Staging a minimal build context + building image (WITH_CLOUD=$WITH_CLOUD)…"
+echo "[stage] Staging a minimal build context + building image (COLD=$COLD WITH_CLOUD=$WITH_CLOUD)…"
 # Flatten wheel + JAR + driver to fixed names in a tiny throwaway context. The
 # repo .dockerignore excludes dist/, and the inputs live in three different
 # trees — staging sidesteps both without touching the shared .dockerignore.
 STAGE="$(mktemp -d)"
 trap '_guided_restore; rm -rf "$STAGE"' EXIT
 cp "$(ls -t dist/conexus-*.whl | head -1)"            "$STAGE/"   # keep real PEP 427 name
-# The native binary travels into the image. A LOCAL -Pnative -Ob quick build also
-# emits native-image .so siblings (libjvm/libawt/liblcms/...) that must be
-# co-located (native-image dlopen's JDK libs from the executable's own dir); a
-# RELEASE binary (engine-service-v*) is self-contained with NO .so siblings. So
-# the .so copy is best-effort — present them when they exist, skip when they don't.
-mkdir -p "$STAGE/native"
-cp service/target/nexus-service "$STAGE/native/"
-if compgen -G "service/target/*.so" > /dev/null; then
-  cp service/target/*.so "$STAGE/native/"
+if [ "$COLD" = 1 ]; then
+  # nexus-4mm24: NOTHING the service needs is staged — the cold box acquires the
+  # binary + PG bundle from the published release at runtime. Only the wheel +
+  # the cold driver + seed travel in.
+  cp "$HERE/Dockerfile.cold" "$STAGE/Dockerfile"
+  cp "$HERE/rehearse_cold.sh" "$HERE/seed_legacy.py" "$STAGE/"
+else
+  # The native binary travels into the image. A LOCAL -Pnative -Ob quick build also
+  # emits native-image .so siblings (libjvm/libawt/liblcms/...) that must be
+  # co-located (native-image dlopen's JDK libs from the executable's own dir); a
+  # RELEASE binary (engine-service-v*) is self-contained with NO .so siblings. So
+  # the .so copy is best-effort — present them when they exist, skip when they don't.
+  mkdir -p "$STAGE/native"
+  cp service/target/nexus-service "$STAGE/native/"
+  if compgen -G "service/target/*.so" > /dev/null; then
+    cp service/target/*.so "$STAGE/native/"
+  fi
+  cp "$HERE/Dockerfile" "$HERE/rehearse.sh" "$HERE/rehearse_guided.sh" "$HERE/seed_legacy.py" "$STAGE/"
 fi
-cp "$HERE/Dockerfile" "$HERE/rehearse.sh" "$HERE/rehearse_guided.sh" "$HERE/seed_legacy.py" "$STAGE/"
 
 # Docker Desktop's credsStore=desktop helper can't reach a locked login keychain
 # in a non-interactive session, which fails even cached/anonymous image
@@ -125,6 +147,10 @@ fi
 docker build -q -f "$STAGE/Dockerfile" -t "$IMAGE" "$STAGE" >/dev/null
 
 run_env=(-e "WITH_CLOUD=$WITH_CLOUD")
+if [ "$COLD" = 1 ]; then
+  # nexus-4mm24: tell the cold box which published release to acquire from.
+  run_env+=(-e "NEXUS_SERVICE_TAG=$COLD_TAG")
+fi
 if [ "$WITH_CLOUD" = 1 ]; then
   # Forward the Voyage key from .env (export VOYAGE_API_KEY=…) under both names
   # the code probes. Never echoed.
@@ -138,7 +164,10 @@ fi
 # NOT `exec` — exec replaces this shell and would suppress the EXIT trap that
 # restores ~/.docker/config.json + release.properties and removes the staging
 # dir. Run as a child and propagate its exit code.
-if [ "$GUIDED" = 1 ]; then
+if [ "$COLD" = 1 ]; then
+  # nexus-4mm24: Dockerfile.cold's default entrypoint IS rehearse_cold.sh.
+  docker run --rm "${run_env[@]}" "$IMAGE"
+elif [ "$GUIDED" = 1 ]; then
   # RDR-002 ez5.13: override the default entrypoint to drive the one-command
   # guided-upgrade MVV instead of the full manual rehearsal.
   docker run --rm "${run_env[@]}" --entrypoint /bin/bash "$IMAGE" \

--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -55,6 +55,7 @@ _guided_restore() {
 trap '_guided_restore' EXIT
 
 [ "$COLD" = 1 ] && [ "$GUIDED" = 1 ] && { echo "--cold and --guided are different flows; pick one" >&2; exit 2; }
+[ "$COLD" = 1 ] && [ "$DO_BUILD" = 0 ] && { echo "--cold always rebuilds the wheel + cold-acquires the binary; --no-build is irrelevant" >&2; exit 2; }
 
 if [ "$GUIDED" = 1 ]; then
   # --guided force-rebuilds the native binary with the stamp baked in, so it is


### PR DESCRIPTION
## nexus-4mm24 — cold-acquire fresh-machine validation (release-N readiness gate 2/3)

Proves the fresh-user journey the soup-to-nuts MVV skips by pre-staging. From a bare `debian:trixie-slim` container (conexus's runtime base, glibc 2.41) with **only the conexus wheel**, `nx daemon service install-binary <tag>` + `nx init --service` cold-acquire the native binary, the PG+pgvector bundle, and the bge-768 ONNX from the **published** engine-service release (cosign-verified, offline), provision, and migrate via `nx guided-upgrade`. Secret-free (ONNX leg). The container is the quarantine (GH runners are pre-loaded). Manual-dispatch workflow.

### It caught a real fresh-user bug on first run
The RDR-161 relocatable PG bundle ships `libpq.so.5` in `<bundle>/lib` but its `bin/` binaries carry **no RPATH**, so `initdb` fails `libpq.so.5: cannot open shared object file` (exit 127) on a minimal base without system libpq. **Ships-now consumer guard:** `pg_provision._bundle_lib_env` sets `LD_LIBRARY_PATH` to the binary's sibling `lib/` for every bundled-PG subprocess (initdb/pg_ctl/the inherited postgres/pg_config). Durable RPATH-in-bundle-build fix tracked as `nexus-iytd3` (with the out-of-band-restart scope documented).

### Validated
**COLD-ACQUIRE MVV PASSED end-to-end** against published `engine-service-v0.1.6` linux-arm64: cross-model parity 12=12, source Chroma intact. 4 `_bundle_lib_env` unit tests + 737 db/provision sweep green.

### Reviewed
code-review-expert **APPROVED** (0C/2H), substantive-critic 0 Critical. Both confirmed the fix is safe in every supported PG layout. Docstring/scope accuracy fixes applied; no success-path change.
