### PR TITLE
docs: release-N audit iter1 — README + getting-started + cli-reference (service substrate + guided-upgrade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+Target: **6.0.0** — the migration-capable release. The storage substrate moves
+from ChromaDB to Postgres 16 + pgvector behind a native service, and
+`nx guided-upgrade` is the one-command, validated, rollback-safe path that
+carries an existing install across. This is the first of a two-release
+deprecation window: this release ships both the new substrate **and** the
+migration tool; the Chroma source remains the immutable migration origin
+(copy-not-move) and is removed only in the following release.
+
+### Changed (BREAKING)
+
+- **Permanent vector storage (T3) moves from ChromaDB to Postgres 16 + pgvector
+  behind the native nexus-service (RDR-155).** The direct-Chroma serving paths
+  are retired; search/store now route through the service stack. An installed
+  user MUST migrate their existing Chroma data — `nx guided-upgrade` does this in
+  one command. Chroma is kept intact as the migration **source** (copy-not-move)
+  and is not read for serving.
+
+### Added
+
+- **`nx guided-upgrade` (RDR-002): one command from a pre-upgrade install to a
+  migrated service stack.** Detects the legacy footprint, provisions and starts
+  the engine-service, version-pins it (`/version` `release_version >= v0.1.6`),
+  bounded health-gates it, then drives `migrate-to-service` (detect → ETL →
+  validate → unlock) with taxonomy ref-remap and copy-not-move rollback safety.
+  Voyage-capability and version pre-flights fail loud **before** any migration.
+- **One-command service install (RDR-157 / RDR-161).** The native engine-service
+  binary and a relocatable PG16 + pgvector bundle are published and
+  cosign-signed; `nx daemon service install-binary <tag>` cold-acquires and
+  verifies both, and `nx init --service` provisions Postgres, fetches the bge-768
+  ONNX, and starts the service — no hand-assembly of PostgreSQL or a service JAR.
+- **engine-service version handshake.** `/version` exposes a dedicated
+  `release_version` (stamped from the release tag); nx clients pin against it.
+- Supporting substrate work: RDR-152 (Postgres + Java service + thin HTTP
+  bridge), RDR-156 (vector-store capability leverage), RDR-160 (bge-768 local
+  embedder), RDR-162 (cross-model migrate for legacy collections).
+
+### Fixed
+
+- **Relocatable PG bundle on a minimal base.** nx provisioning now points the
+  dynamic loader at the bundle's own `lib/` so the bundled `initdb`/`pg_ctl`
+  resolve `libpq.so.5` etc. on a stripped image (nexus-4mm24; the durable
+  RPATH-in-bundle-build fix is tracked separately).
+
+### Known limitations / upgrade notes
+
+- **Cloud (managed) embedding is server-side** with the operator's Voyage key;
+  tenants supply only `NX_SERVICE_TOKEN`, never a Voyage key (no per-tenant key).
+- **The macOS engine-service binary is ad-hoc signed** (not Developer-ID /
+  notarized). It runs via `nx daemon service install-binary` (no quarantine); a
+  copy downloaded through a browser is Gatekeeper-blocked — clear it with
+  `xattr -d com.apple.quarantine`.
+- **`nx guided-upgrade` is idempotent but not a no-op after success** — re-running
+  re-copies at full cost (the Chroma source is intact, so it is re-detected).
+
 ## [5.10.6] - 2026-06-07
 
 Hotfix: the RDR-080 agent-replacement MCP tools regressed when Claude Code

--- a/README.md
+++ b/README.md
@@ -42,20 +42,22 @@ For the full deployment story across all three surfaces (install, daemon lifecyc
 - **Semantic search** — index your code, docs, RDRs, and PDFs once; search by meaning afterward. Tree-sitter AST chunking across 23 languages, CCE prose chunking, PDF auto-routing.
 - **Typed document catalog** — Xanadu-inspired addressing with typed links (`cites`, `implements`, `supersedes`). Walk from a design doc to the code that implements it.
 - **RDR: Research-Design-Review** — write a spec before you code. Captures the problem, research, alternatives, and chosen approach. The corpus is searchable, so prior decisions surface during new design work.
-- **Local-first** — default install runs entirely on your machine with ONNX MiniLM + local ChromaDB. Voyage AI + ChromaDB Cloud are opt-in for higher-quality embeddings.
+- **Local-first** — runs entirely on your machine: an on-device bge-768 ONNX embedder over a bundled Postgres 16 + pgvector service that `nx init --service` provisions for you. Voyage AI (server-side embeddings) is opt-in for the managed-cloud deployment.
 
 ## CLI quick-start
 
 ```bash
-uv tool install conexus                  # install the nx CLI (built-in ONNX MiniLM embedder)
-nx init                                  # guided: choose your local embedder (384 vs bge-768)
-nx daemon t2 install --autostart         # register the T2 daemon (one-time)
-nx doctor                                # verify installation
+uv tool install conexus                  # install the nx CLI
+nx init --service                        # provision the local Postgres + pgvector service + bge-768 embedder, and start it
+nx daemon t2 install --autostart         # register the T2 (notes/plans) daemon (one-time)
+nx doctor                                # verify the stack
 nx index repo .                          # index your repo + discover topics
 nx search "how does retry work"          # semantic search, fully local
 ```
 
-`nx init` presents the embedder choice (recommended bge-768, ~140 MB one-time download, for materially better local search, vs the bundled 384-dim MiniLM), adds the `[local]` extra for you when you pick bge-768, and migrates any pre-existing 384-dim collections safely. To request the higher-quality embedder directly at install time instead: `uv tool install "conexus[local]"`.
+`nx init --service` provisions the bundled Postgres 16 + pgvector cluster, fetches the bge-768 ONNX model the service embeds with, and starts the persistent service supervisor. The permanent vector store (T3) serves through this native service; the bundled binary + Postgres are cosign-verified and acquired automatically (see [Getting Started](https://github.com/Hellblazer/nexus/blob/main/docs/getting-started.md) for the full service-install flow and the `nx daemon service install-binary` step).
+
+> **Upgrading from a pre-6.0 install?** 6.0 moves the permanent vector store from ChromaDB to the Postgres + pgvector service. After `uv tool upgrade conexus`, run **`nx guided-upgrade`** — one command detects your existing store, provisions and version-pins the service, and migrates your data with validation and copy-not-move rollback safety. Your ChromaDB data is left intact as the migration source.
 
 The `nx` CLI provides direct access to all storage tiers, indexing, search, the catalog, and taxonomy. See [Getting Started](https://github.com/Hellblazer/nexus/blob/main/docs/getting-started.md) for a walkthrough, [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs/cli-reference.md) for every command and flag.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1859,7 +1859,9 @@ Sequence: **pre-flight detect** (if there is no ChromaDB footprint to migrate it
 no-ops without provisioning) → **provision + serve** the local service (the full
 `nx init --service` path: Postgres + bge-768 ONNX + the native binary) — or, with
 `--service-url`, gate an already-running service → **version-pin** (`/version`
-`release_version >= v0.1.6`; fail-closed) → **bounded health-gate** → **voyage-
+`/version` must report a `release_version` — present from engine-service
+v0.1.6+, code floor v0.1.5; older binaries omit it and fail closed) → **bounded
+health-gate** → **voyage-
 capability pre-flight** (if the footprint has voyage collections, the target
 service must be able to serve them — fail loud before migrating) → drive
 **`nx migrate-to-service`** (detect → ETL → validate → unlock) → advisory

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1180,12 +1180,14 @@ provisions the on-device embedding model for local mode.
 nx init                       # interactive: prompt for the embedder
 nx init --yes                 # accept the recommended bge-768, no prompt
 nx init --embedder minilm-384 # pick a specific embedder, no prompt
+nx init --service             # provision the Postgres+pgvector service backend + start it
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--embedder [bge-768\|minilm-384]` | Select the embedder non-interactively (skips the prompt) |
 | `--yes` / `-y` | Accept the recommended default (bge-768) without prompting |
+| `--service` | Provision the local Postgres + pgvector cluster the RDR-152 service backend uses, lock the embedder to bge-768, acquire + verify the native service binary, fetch the bge-768 ONNX, and start the persistent service supervisor. Idempotent. This is the path that stands up T3 serving for a local install. (Also auto-runs when `NX_STORAGE_BACKEND=service` is set.) Acquire the binary + PG bundle first with `nx daemon service install-binary <engine-service-vX.Y.Z>`. |
 
 **Local mode** presents the two on-device embedders and records the choice in
 `~/.config/nexus/config.yml` under `local.embed_model`:
@@ -1452,17 +1454,18 @@ leave them running. For a brand-new install the recommended setup
 sequence is:
 
 ```
-uv tool install conexus                    # or "conexus[local]" for the bge-768 local embedder
-nx daemon t2 install --autostart           # writes LaunchAgent/systemd unit
+uv tool install conexus                    # the nx CLI
+nx daemon t2 install --autostart           # the T2 (notes/plans) daemon: writes LaunchAgent/systemd unit
 nx daemon t2 status                        # confirm running
-# (local-mode T3 only)
-nx daemon t3 install --autostart
+nx daemon service install-binary <engine-service-vX.Y.Z>   # acquire the signed native service binary + PG bundle
+nx init --service                          # provision Postgres+pgvector, fetch bge-768, start the T3 service
 ```
 
 Upgrade later with `uv tool upgrade conexus` (preserves extras like `[local]`); avoid `uv tool install --force`, which resets the environment and drops them.
 
-Cloud-mode T3 uses HTTP transport directly to ChromaDB Cloud and
-has no daemon; only `t2` is needed in that configuration.
+T3 (the permanent vector store) serves through the native nexus-service over
+Postgres + pgvector in **both** local and cloud mode (`nx daemon service`); the
+legacy `nx daemon t3` ChromaDB daemon is a retired serving path.
 
 When the conexus plugin is installed, the plugin's
 SessionStart hook auto-spawns the T2 daemon via
@@ -1616,14 +1619,15 @@ Reverse of `install --autostart`: deactivate via
 
 ### nx daemon t3 start / stop / status / install / uninstall
 
-Same shape as the `t2` subcommands, applies to the T3 daemon.
-**Only used in local mode (`NX_LOCAL=1` or no cloud credentials).**
-Cloud-mode T3 talks directly to ChromaDB Cloud via HTTP and has no
-daemon process — `nx daemon t3` is a no-op there.
+> **Legacy / retired serving path (6.0).** T3 no longer serves from ChromaDB.
+> The permanent vector store now serves through the native nexus-service over
+> Postgres + pgvector — see `nx daemon service` below and `nx init --service`.
+> `nx daemon t3` (the managed `chroma run` subprocess) remains only for reading a
+> pre-6.0 ChromaDB store as the **migration source** (`nx guided-upgrade`).
 
-Local-mode T3 wraps the upstream `chroma run` server lifecycle
-under launchd / systemd supervision; templates ship as
-`com.nexus.t3.plist` / `nexus-t3.service`.
+Same shape as the `t2` subcommands, applies to the legacy T3 ChromaDB daemon.
+It wraps the upstream `chroma run` server lifecycle under launchd / systemd
+supervision (templates `com.nexus.t3.plist` / `nexus-t3.service`).
 
 ### nx daemon service start / stop / status
 
@@ -1840,15 +1844,51 @@ nx service token list [--tenant TENANT]
 
 List service tokens: 12-char id prefix, tenant, status (`active`/`expired`/`revoked`), label, expiry, and revocation time. Never prints the raw token. Use the id prefix with `nx service token revoke`.
 
+## nx guided-upgrade
+
+```
+nx guided-upgrade [--local-path PATH] [--db PATH] [--catalog-db PATH] [--service-url URL] [--timeout SECS] [--yes]
+```
+
+The **one-command upgrade from a pre-6.0 (ChromaDB) install to the service
+stack** (RDR-002). It is the recommended migration entry point — it stands up
+the service and then drives `nx migrate-to-service`, so you never hand-sequence
+provisioning + migration.
+
+Sequence: **pre-flight detect** (if there is no ChromaDB footprint to migrate it
+no-ops without provisioning) → **provision + serve** the local service (the full
+`nx init --service` path: Postgres + bge-768 ONNX + the native binary) — or, with
+`--service-url`, gate an already-running service → **version-pin** (`/version`
+`release_version >= v0.1.6`; fail-closed) → **bounded health-gate** → **voyage-
+capability pre-flight** (if the footprint has voyage collections, the target
+service must be able to serve them — fail loud before migrating) → drive
+**`nx migrate-to-service`** (detect → ETL → validate → unlock) → advisory
+`nx doctor`.
+
+- `--service-url URL` migrates into an already-running service instead of
+  provisioning a local one; requires `NX_SERVICE_TOKEN` to be set.
+- `--timeout SECS` bounds the wait for the service to become healthy (default 120).
+- `--yes` / `-y` skips the confirmation prompt.
+
+A not-ready or wrong-version service **hard-fails before any migration**.
+Idempotent and safe to re-run, but **not a no-op after success** — a re-run
+re-copies at full cost (the ChromaDB source is intact, so it is re-detected). On
+a validation block it leaves the `migrated-failed` sentinel and offers a rollback
+command (copy-not-move; never auto-reverts). Operational narrative:
+[`docs/migration-runbook.md`](migration-runbook.md).
+
 ## nx migrate-to-service
 
 ```
 nx migrate-to-service [--dry-run] [--local-path PATH] [--db PATH] [--catalog-db PATH] [--service-url URL]
 ```
 
-The single guided Chroma-to-service upgrade (RDR-159) — it wraps and sequences
-the proven `nx storage migrate` primitives into one survivable command so a
-user never hand-sequences the ~8-step gauntlet.
+The lower-level Chroma-to-service migration primitive (RDR-159) that
+`nx guided-upgrade` wraps. Use `nx guided-upgrade` for the full one-command
+experience; use this directly when the service is **already provisioned and
+running** and you only need the migration step. It sequences the proven
+`nx storage migrate` primitives into one survivable command so a user never
+hand-sequences the ~8-step gauntlet.
 
 - `--dry-run` ships the read-only front half: it classifies the Chroma
   footprint per collection (source leg × embedding model, resolved against the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -130,6 +130,13 @@ nx daemon service install-binary <engine-service-vX.Y.Z>   # acquire the cosign-
 nx init --service                                          # provision Postgres, fetch the bge-768 ONNX, start the service supervisor
 ```
 
+Pick `<engine-service-vX.Y.Z>` from the
+[engine-service releases](https://github.com/Hellblazer/nexus/releases) (the
+newest `engine-service-v*` tag). There is no `latest` resolution — the tag is
+explicit. You can instead export `NEXUS_SERVICE_TAG=engine-service-vX.Y.Z`, in
+which case `nx init --service` acquires the binary itself and the explicit
+`install-binary` step is optional.
+
 `nx init --service` is idempotent — safe to re-run. The service embeds with
 bge-768 (local) or, in the managed-cloud deployment, server-side via Voyage with
 the operator's key (clients supply only `NX_SERVICE_TOKEN`, never a Voyage key).
@@ -172,7 +179,9 @@ nx guided-upgrade             # detect -> provision+verify the service -> migrat
 ```
 
 `nx guided-upgrade` detects your existing ChromaDB footprint, provisions and
-starts the service, version-pins it (`/version` `release_version >= v0.1.6`),
+starts the service, version-pins it (its `/version` must report a
+`release_version` — present from engine-service v0.1.6+; the code floor is
+v0.1.5 but earlier binaries omit the field and fail closed),
 health-gates it, then migrates your collections into pgvector with validation
 and **copy-not-move** rollback safety — your ChromaDB store is left intact as
 the source. Voyage-capability and version pre-flights fail loud *before* any

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -121,18 +121,26 @@ will auto-spawn the daemon on every session start anyway, so plugin
 users still get a working substrate. The autostart path is recommended
 if you also use `nx` directly from the shell.
 
-**Local-mode T3 only**: the T3 daemon wraps a local ChromaDB process.
-Register it the same way:
+**T3 (the permanent vector store)** is served by the native nexus-service over
+Postgres 16 + pgvector — in **both** local and cloud mode. Provision and start
+it with:
 
 ```bash
-nx daemon t3 install --autostart   # only when NX_LOCAL=1 / no cloud creds
+nx daemon service install-binary <engine-service-vX.Y.Z>   # acquire the cosign-verified native binary + relocatable PG+pgvector bundle
+nx init --service                                          # provision Postgres, fetch the bge-768 ONNX, start the service supervisor
 ```
 
-Cloud-mode T3 talks directly to ChromaDB Cloud over HTTP and has no
-daemon — `nx daemon t3` is a no-op in that configuration.
+`nx init --service` is idempotent — safe to re-run. The service embeds with
+bge-768 (local) or, in the managed-cloud deployment, server-side via Voyage with
+the operator's key (clients supply only `NX_SERVICE_TOKEN`, never a Voyage key).
 
-See [docs/container-integration.md](https://github.com/Hellblazer/nexus/blob/main/docs/container-integration.md) for the full daemon-model story
-including TCP / UDS / Cowork transport details.
+> The legacy `nx daemon t3` (a managed ChromaDB subprocess) is retired as a
+> serving path — T3 no longer serves from ChromaDB. ChromaDB data from a
+> pre-6.0 install is read only as the migration *source* (see Upgrading below).
+
+See [docs/container-integration.md](https://github.com/Hellblazer/nexus/blob/main/docs/container-integration.md) for reaching the
+service from a container, and [docs/migration-runbook.md](https://github.com/Hellblazer/nexus/blob/main/docs/migration-runbook.md) for the
+migration details.
 
 ## Update
 
@@ -152,6 +160,25 @@ nx daemon t2 stop && nx daemon t2 start    # or: launchctl kickstart -k gui/<uid
 The schema-version handshake (RDR-120 P3b) fails loud on
 client/daemon version mismatch, so stale daemons fail closed rather
 than silently corrupting state.
+
+### Upgrading to 6.0 (migrating off ChromaDB)
+
+6.0 moves the permanent vector store (T3) from ChromaDB to the Postgres +
+pgvector service. Existing installs migrate with one command:
+
+```bash
+uv tool upgrade conexus       # get the 6.0 CLI
+nx guided-upgrade             # detect -> provision+verify the service -> migrate -> validate -> unlock
+```
+
+`nx guided-upgrade` detects your existing ChromaDB footprint, provisions and
+starts the service, version-pins it (`/version` `release_version >= v0.1.6`),
+health-gates it, then migrates your collections into pgvector with validation
+and **copy-not-move** rollback safety — your ChromaDB store is left intact as
+the source. Voyage-capability and version pre-flights fail loud *before* any
+migration. It is idempotent (safe to re-run) but not a no-op after success: a
+re-run re-copies at full cost. On a validation block it leaves the migration
+state `migrated-failed` and offers a rollback command rather than auto-reverting.
 
 ## Use it (no API keys needed)
 
@@ -230,7 +257,7 @@ claude --plugin-dir ./nx
 
 ## Cloud mode (optional)
 
-Local mode uses bundled ONNX embeddings (384d MiniLM). Cloud mode upgrades to Voyage AI (1024d), cross-chunk context (CCE), and reranking.
+Local mode embeds with the on-device bge-768 ONNX model (768-dim) the service provisions; the bundled minilm-384 remains a zero-download fallback. The managed-cloud deployment embeds server-side with Voyage AI (1024d), cross-chunk context (CCE), and reranking.
 
 ### 1. Create accounts
 
@@ -281,10 +308,11 @@ Common flags: `-n 20` (result count), `--json`, `--files` (paths only), `-c` (sh
 
 ### Upgrade local embedding quality (optional)
 
-For better local-only embeddings (768d bge-base) without cloud:
+For the Python-side bge-768 embedder (used by non-service local indexing paths;
+the `nx init --service` stack already embeds with bge-768 server-side):
 
 ```bash
-uv tool install conexus --with "conexus[local]" --force
+uv tool install --reinstall "conexus[local]"
 ```
 
 To force local mode even when cloud credentials exist: `NX_LOCAL=1`.

--- a/src/nexus/commands/guided_upgrade_cmd.py
+++ b/src/nexus/commands/guided_upgrade_cmd.py
@@ -7,7 +7,7 @@ Stands up + verifies the bge-768 engine-service, then drives the EXISTING
 
   pre-flight detect (ez5.2) → provision + health-gate + version-pin (ez5.6/5/4,
   via establish_verified_service ez5.7) → migrate-to-service (RDR-162
-  _run_migration) → advisory ``nx catalog rebuild``.
+  _run_migration) → advisory ``nx doctor``.
 
 SERVICE path only (never embed_migrate). A fresh user with nothing to migrate
 no-ops WITHOUT provisioning. A not-ready / wrong-version service hard-fails


### PR DESCRIPTION
Iteration 1 of the release-N doc audit (nexus-ooaut). Fixes the load-bearing 6.0 staleness in the onboarding + reference core, grounded against the code and **correctness-verified by the substantive-critic** (0 Critical; the 2 findings — wrong version floor + unresolved install tag — are fixed in the follow-up commit).

- **README**: local-first/quick-start now describe the bundled Postgres+pgvector service + bge-768 (was 'ONNX MiniLM + local ChromaDB'); added the `nx guided-upgrade` migration callout.
- **getting-started**: T3 section is now the nexus-service stack (was the legacy `nx daemon t3` ChromaDB daemon); added the 'Upgrading to 6.0' guided-upgrade subsection with the tag-resolution guidance; fixed the MiniLM-as-local-default claim + a malformed reinstall command.
- **cli-reference**: NEW `nx guided-upgrade` section (was undocumented — the headline omission); repositioned `migrate-to-service` as the primitive it wraps; documented `nx init --service`; marked the legacy `nx daemon t3` retired; fixed the daemon-overview T3=ChromaDB-Cloud claim.

Deferred to an iter1 follow-up (noted on nexus-ooaut): cli-reference `aspects`/`tier-status`/`command-context` sections + the doctor-quotas ChromaDB framing. Iters 2-3 cover the deploy + architecture docs. Refs nexus-ooaut (parent nexus-y5avl / release N).