### PR TITLE
docs: release-N audit iter2 — container-integration + desktop-deployment + configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ Nexus auto-detects local mode when cloud credentials are absent. The recommended
 | Env var | Default | Description |
 |---|---|---|
 | `NX_LOCAL` | (auto) | `1` = force local, `0` = force cloud, unset = auto-detect |
-| `NX_LOCAL_CHROMA_PATH` | `~/.local/share/nexus/chroma` | Override local ChromaDB storage path |
+| `NX_LOCAL_CHROMA_PATH` | `~/.local/share/nexus/chroma` | Path to the legacy ChromaDB store. As of 6.0 this is read only as the **migration source** (`nx guided-upgrade`); T3 serves from the Postgres+pgvector service, not this path. |
 | `NX_LOCAL_EMBED_MODEL` | (auto) | Force a specific local embedding model name |
 | `NEXUS_CATALOG_PATH` | `~/.config/nexus/catalog` | Override catalog git repo location |
 | `NEXUS_CATALOG_ALLOW_CROSS_PROJECT` | unset | Set to `1` to bypass the register-time cross-project source_uri guard. Emergency-only escape hatch for known-good recovery scripts that legitimately need to register rows across project boundaries; never the right answer for normal indexing |
@@ -163,10 +163,17 @@ operator-facing matrix of transport choices per platform.
 
 ## Storage Service (Postgres) Prerequisites
 
+> **Local installs: skip this section.** `nx init --service` provisions the
+> bundled relocatable Postgres + pgvector cluster, creates the roles, and enables
+> the extensions for you — no DBA, no manual `CREATE EXTENSION`. The prerequisites
+> below apply only when you bring your **own** Postgres (an operator pointing the
+> service at a managed/self-hosted cluster via `NX_DB_*`).
+
 The Java storage service (RDR-152/RDR-155) applies its Liquibase changelog at
 startup using the `NX_DB_ADMIN_*` credentials (falling back to `NX_DB_*` in
-single-role development setups). Two prerequisites must be satisfied by a DBA
-(superuser) before the first migration run:
+single-role development setups). When you bring your own Postgres, two
+prerequisites must be satisfied by a DBA (superuser) before the first migration
+run:
 
 1. **Extensions.** `CREATE EXTENSION IF NOT EXISTS vector;` and
    `CREATE EXTENSION IF NOT EXISTS pg_trgm;` — neither is a trusted extension,
@@ -283,7 +290,8 @@ If no marker file is found and no command is configured, the test check is skipp
 | File | Purpose |
 |---|---|
 | `~/.config/nexus/config.yml` | Global config and credentials |
-| `~/.local/share/nexus/chroma/` | Local T3 ChromaDB PersistentClient data (local mode) |
+| `~/.local/share/nexus/chroma/` | Legacy ChromaDB store — migration source only as of 6.0 (`nx guided-upgrade`); not live T3 data |
+| `~/.config/nexus/postgres/` | The nx-provisioned Postgres cluster the service serves T3 from (local `nx init --service`) |
 | `~/.config/nexus/memory.db` | T2 SQLite database |
 | `~/.config/nexus/catalog/.catalog.db` | Catalog: canonical repo→collection registration, documents, and links (`nx index repo` writes here). Replaced `repos.json` as the source of truth in 5.4.0 (RDR-137); a one-shot migration on `nx upgrade` folds any legacy `repos.json` into the catalog and removes it. |
 | `~/.config/nexus/sessions/` | JSON session records (T1 server address, session ID, `created_at`, `tmpdir`) + `session.lock` |

--- a/docs/container-integration.md
+++ b/docs/container-integration.md
@@ -102,17 +102,18 @@ macOS / Windows Docker Desktop.
 
 ```bash
 PORT=$(nx daemon t2 status | grep tcp_port | awk '{print $2}')
-SVC_PORT=$(nx daemon service status | grep -i port | awk '{print $2}')
+SVC_PORT=$(nx daemon service status --json | python3 -c 'import sys,json;print(json.load(sys.stdin)["port"])')
+TOKEN=$(grep '^NX_SERVICE_TOKEN=' ~/.config/nexus/pg_credentials | cut -d= -f2)
 docker run --rm \
     -e NX_T2_ADDR=host.docker.internal:$PORT \
-    -e NX_SERVICE_HOST=host.docker.internal \
-    -e NX_SERVICE_PORT=$SVC_PORT \
-    -e NX_SERVICE_TOKEN=$NX_SERVICE_TOKEN \
+    -e NX_SERVICE_URL=http://host.docker.internal:$SVC_PORT \
+    -e NX_SERVICE_TOKEN=$TOKEN \
     <image-with-conexus>
 ```
 
-The T3 (vector) calls reach the host's nexus-service; `NX_SERVICE_TOKEN` is
-required (read it from `~/.config/nexus/pg_credentials` on the host).
+The T3 (vector) calls reach the host's nexus-service. The T3 client reads the
+full `NX_SERVICE_URL` (not a split host/port) plus `NX_SERVICE_TOKEN`; the token
+is in `~/.config/nexus/pg_credentials` on the host.
 
 `--network=host` does NOT work on macOS Docker Desktop — the
 container's `127.0.0.1` stays in the container's own namespace.
@@ -243,8 +244,9 @@ CLI from the shell.
 |---|---|---|
 | `NX_T2_ADDR` | TCP host:port for the T2 daemon | discovery file |
 | `NX_T2_SOCK` | UDS path for the T2 daemon | discovery file |
-| `NX_SERVICE_HOST` / `NX_SERVICE_PORT` | host:port of the nexus-service (T3 vector store) | discovery lease (`storage_service_addr.<uid>`) |
-| `NX_SERVICE_TOKEN` | bearer token for the nexus-service (required for T3 access) | `~/.config/nexus/pg_credentials` |
+| `NX_SERVICE_URL` | full base URL of the nexus-service for the **T3 vector store** (e.g. `http://host:port`) | discovery lease (`storage_service_addr.<uid>`) |
+| `NX_SERVICE_HOST` / `NX_SERVICE_PORT` | host + port for the **T2 domain stores + catalog** HTTP path (separate resolver from T3) | discovery lease |
+| `NX_SERVICE_TOKEN` | bearer token for the nexus-service (required) | discovery lease, or `~/.config/nexus/pg_credentials` |
 | `NX_T3_ADDR` | *(legacy)* TCP host:port for the retired ChromaDB T3 daemon | discovery file |
 | `NX_PYTEST_DAEMON_MODE` | (tests only) skip the conftest direct-mode pin | unset |
 

--- a/docs/container-integration.md
+++ b/docs/container-integration.md
@@ -4,10 +4,22 @@ Running nexus from inside a container — Docker dev container, Claude
 Cowork VM, CI agent, multi-agent Co-Work session — and sharing T2 /
 T3 state with the host CLI Claude and any other nexus consumers.
 
-This page assumes RDR-120 4.34.1+ is installed on the host. Earlier
-releases ran every consumer against its own SQLite file and silently
-diverged across containers; the daemon model in 4.34.x is what makes
-shared state real.
+This page assumes a 6.0+ install on the host. The T2 (notes/plans/taxonomy)
+daemon model (RDR-120) makes shared SQLite state real across containers.
+
+> **6.0 change — T3 now serves through the nexus-service.** The permanent
+> vector store (T3) no longer runs as a `nx daemon t3` ChromaDB process; it
+> serves through the native nexus-service over Postgres + pgvector in both local
+> and cloud mode. A container reaches it over loopback TCP to the host's service
+> using **`NX_SERVICE_HOST` / `NX_SERVICE_PORT` + `NX_SERVICE_TOKEN`** (the token
+> is now required), not `NX_T3_ADDR`. The T2-daemon transport guidance below is
+> unchanged; the T3 sections have been updated accordingly.
+>
+> **This two-process shape is a waypoint, not the destination.** 6.0 migrated T3
+> to the service; T2 (notes/plans/taxonomy) is still SQLite behind its
+> single-writer daemon. RDR-152 moves T2 (and T1 scratch + the catalog) into the
+> same Postgres service and retires the SQLite daemon class entirely — at which
+> point there is one service to reach, not a daemon + a service.
 
 ## TL;DR
 
@@ -34,19 +46,19 @@ Picking a path:
 For one-shot starts:
 
 ```
-# Always
+# T2 (notes/plans/taxonomy) daemon
 nx daemon t2 start
 
-# Local-mode T3 only (cloud-mode T3 is already HTTP-served; no daemon)
-nx daemon t3 start
+# T3 (vector store) — the nexus-service over Postgres + pgvector
+nx daemon service start
 ```
 
-For durable always-running daemons (recommended for any host that
+For durable always-running services (recommended for any host that
 runs Claude Code regularly):
 
 ```
 nx daemon t2 install --autostart          # writes the LaunchAgent / systemd unit
-nx daemon t3 install --autostart          # local-mode T3 only
+nx init --service                         # provisions + starts the persistent nexus-service supervisor
 ```
 
 This installs `~/Library/LaunchAgents/com.nexus.t2.plist` on macOS or
@@ -90,11 +102,17 @@ macOS / Windows Docker Desktop.
 
 ```bash
 PORT=$(nx daemon t2 status | grep tcp_port | awk '{print $2}')
+SVC_PORT=$(nx daemon service status | grep -i port | awk '{print $2}')
 docker run --rm \
     -e NX_T2_ADDR=host.docker.internal:$PORT \
-    -e NX_T3_ADDR=host.docker.internal:<t3_port>   # local-mode T3 only
+    -e NX_SERVICE_HOST=host.docker.internal \
+    -e NX_SERVICE_PORT=$SVC_PORT \
+    -e NX_SERVICE_TOKEN=$NX_SERVICE_TOKEN \
     <image-with-conexus>
 ```
+
+The T3 (vector) calls reach the host's nexus-service; `NX_SERVICE_TOKEN` is
+required (read it from `~/.config/nexus/pg_credentials` on the host).
 
 `--network=host` does NOT work on macOS Docker Desktop — the
 container's `127.0.0.1` stays in the container's own namespace.
@@ -154,8 +172,9 @@ container runs as UID 0 (root) inside its user namespace, and the
 socket's `0o600` permission gate fires `EACCES` (errno 13). The
 CLI's error message names the fix.
 
-T3 has no UDS path; the T3 daemon is HTTP-only (chromadb upstream
-contract). Use the TCP path for T3 even when T2 goes through UDS.
+T3 has no UDS path; the nexus-service is HTTP-only. Use the TCP path
+(`NX_SERVICE_HOST`/`NX_SERVICE_PORT` + `NX_SERVICE_TOKEN`) for T3 even when T2
+goes through UDS.
 
 ## Path C: Operator-side forward (fallback)
 
@@ -196,8 +215,8 @@ What works:
 1. Install the conexus plugin in your Claude Code installation:
    `/plugin install conexus@nexus-plugins`. The plugin registers
    `nx-mcp` as an MCP server in your Claude Desktop config.
-2. Start the daemons on the host: `nx daemon t2 start` (and
-   `nx daemon t3 start` if local-mode).
+2. Start the host services: `nx daemon t2 start` (T2) and
+   `nx daemon service start` (T3 vector store).
 3. Open a Cowork session. Claude Desktop **passes the configured
    MCP servers into the VM via `--mcp-config` with
    `"type": "sdk"`** — the MCP server itself stays running on the
@@ -224,7 +243,9 @@ CLI from the shell.
 |---|---|---|
 | `NX_T2_ADDR` | TCP host:port for the T2 daemon | discovery file |
 | `NX_T2_SOCK` | UDS path for the T2 daemon | discovery file |
-| `NX_T3_ADDR` | TCP host:port for the T3 daemon | discovery file |
+| `NX_SERVICE_HOST` / `NX_SERVICE_PORT` | host:port of the nexus-service (T3 vector store) | discovery lease (`storage_service_addr.<uid>`) |
+| `NX_SERVICE_TOKEN` | bearer token for the nexus-service (required for T3 access) | `~/.config/nexus/pg_credentials` |
+| `NX_T3_ADDR` | *(legacy)* TCP host:port for the retired ChromaDB T3 daemon | discovery file |
 | `NX_PYTEST_DAEMON_MODE` | (tests only) skip the conftest direct-mode pin | unset |
 
 `NX_T2_ADDR` and `NX_T2_SOCK` are mutually exclusive — set one or

--- a/docs/desktop-deployment.md
+++ b/docs/desktop-deployment.md
@@ -1,6 +1,21 @@
 # Desktop deployment
 
-Nexus runs in three Claude surfaces, all backed by one host daemon so state is shared across them and with the `nx` CLI. This document covers install, first-run behavior, drift detection, and uninstall for each surface. The substrate that makes this work landed in RDR-120 (4.34.0+); the unified-surface design is RDR-126.
+Nexus runs in three Claude surfaces, all backed by shared host state so it round-trips across them and with the `nx` CLI. This document covers install, first-run behavior, drift detection, and uninstall for each surface. The shared-state substrate is RDR-120; the unified-surface design is RDR-126.
+
+> **Upgrading to 6.0.** 6.0 moves the permanent vector store (T3) from ChromaDB to
+> the Postgres + pgvector nexus-service. After upgrading the CLI, run
+> **`nx guided-upgrade`** once to migrate your data (one command: detect →
+> provision + verify the service → migrate → validate → unlock; copy-not-move,
+> rollback-safe). The signed native service binary + relocatable Postgres bundle
+> are acquired automatically by `nx daemon service install-binary <tag>` / `nx
+> init --service`. **macOS note:** that binary is ad-hoc signed (not
+> Developer-ID/notarized) — `install-binary` fetches it without quarantine, but a
+> copy you download from a GitHub release *page* in a browser is Gatekeeper-
+> blocked; clear it with `xattr -d com.apple.quarantine <file>`.
+>
+> **Two-process waypoint.** 6.0 runs the T2 (notes/plans) SQLite daemon **and**
+> the T3 nexus-service. That is transitional: RDR-152 moves T2 into the same
+> Postgres service and retires the SQLite daemon, converging on one service.
 
 ## Surface 1: Claude Code (terminal)
 
@@ -129,8 +144,9 @@ Nothing to uninstall on the Cowork side — sessions inherit whatever Claude Des
 
 ```
 nx daemon t2 uninstall --autostart    # remove autostart unit + stop daemon
-rm -rf ~/.config/nexus                 # remove T2 SQLite + config
-# T3: chromadb cloud accounts persist outside the daemon; manage there.
+nx daemon service stop                 # stop the nexus-service (T3) supervisor
+rm -rf ~/.config/nexus                 # remove T2 SQLite, the provisioned Postgres cluster, service binary + config
+# Managed-cloud: your data lives in the managed service, not locally — manage it there.
 ```
 
 ## Verification
@@ -173,13 +189,18 @@ The first-run banner + `daemon_uninstall` lifecycle is validated in two halves.
 - **uv not on PATH (Claude Desktop chat install)**: `.mcpb` install fails with a cryptic error. Mitigation: README documents `brew install uv` / `pipx install uv` as pre-requisite.
 - **The `.mcpb` reads `config.yml`, NOT your shell env — cloud creds must be persisted, or the extension silently runs local mode** (the single most likely Desktop footgun). Claude Desktop spawns the `.mcpb` as a GUI subprocess that does **not** inherit your interactive shell's environment. `is_local_mode()` resolves creds via `get_credential()`, which checks the process env first and then `~/.config/nexus/config.yml` — it never sees `~/.zshrc`/`~/.bashrc` exports. So a machine where `CHROMA_API_KEY` / `VOYAGE_API_KEY` live only in the shell will run the extension in **local mode** (bge-768 local embedder), even though your CLI in a terminal resolves cloud mode fine. Symptoms: searches return "no results" or feel thin, and `~/Library/Logs/Claude/mcp-server-Conexus.log` shows `collection_dimension_mismatch_skipped` / `search_all_collections_dimension_skipped` — typically `got 768` (local bge query) against collections that expect `1024` (voyage). The bge-768 local query simply cannot match cloud voyage-1024 collections.
 
-  **Fix — persist the creds into `config.yml` with `nx config set` (not just shell exports):**
-  ```bash
-  nx config set chroma_api_key "ck-…"
-  nx config set chroma_tenant   "<tenant-uuid>"
-  nx config set chroma_database "conexus"
-  nx config set voyage_api_key  "pa-…"
-  ```
+  **6.0 cloud creds** are the managed nexus-service endpoint + bearer token
+  (`NX_SERVICE_URL` + `NX_SERVICE_TOKEN`); embedding runs server-side, so you do
+  **not** supply a Voyage key. The legacy `chroma_api_key` / `chroma_tenant` /
+  `chroma_database` keys are the retired pre-6.0 ChromaDB-Cloud surface.
+
+  > **Note (managed-cloud Desktop):** `NX_SERVICE_URL` / `NX_SERVICE_TOKEN` are
+  > currently resolved from the process environment. Because the `.mcpb` does not
+  > inherit your shell env, the persistence path for these in a Desktop install
+  > is being finalized — see the managed-service notes in
+  > [docs/migration-runbook.md](migration-runbook.md). For a **local** install
+  > there is no footgun: `nx init --service` writes the token to
+  > `~/.config/nexus/pg_credentials` and the service is discovered via its lease.
   Then fully quit + relaunch Claude Desktop so the extension re-spawns and re-reads `config.yml`. **Verify** it took: search for something specific and ask for the top `file:line` results with scores; confirm the cited locations are real (a great-sounding answer is not proof — the model can reconstruct from `store_get`/FTS even when vector search is skipping), and confirm the Conexus log shows no `dimension_mismatch_skipped`. On a fresh machine with no CLI, you only get local mode (bge-768) — fine for content you index locally at 768d, but it will not reach pre-existing cloud-1024 collections until the creds are in `config.yml`.
 
   Related: a single name/dim-mismatched collection (e.g. a stale collection named `…minilm-l6-v2-384…` that actually stores 1024-dim vectors) produces the same `dimension_mismatch_skipped` line on every search and should be deleted (`nx collection delete <name>`); an `nx doctor` drift check for this class is tracked separately.


### PR DESCRIPTION
Iteration 2 of the release-N doc audit (nexus-ooaut). Fixes the 6.0 substrate staleness in the deploy/config docs + folds in the 'two-process waypoint' framing (T3 on the service now; T2 SQLite daemon retired by RDR-152). **Correctness-verified by the substantive-critic** — it caught 1 real error (T3 uses `NX_SERVICE_URL`, not the `NX_SERVICE_HOST`/`PORT` T2 pair), now fixed; 2 other flags were verified correct-as-written and left.

- **container-integration**: T3 transport `NX_T3_ADDR`/`nx daemon t3` (retired Chroma daemon) → the nexus-service over `NX_SERVICE_URL` + `NX_SERVICE_TOKEN`; env-reference table corrected; waypoint banner.
- **desktop-deployment**: cred footgun `chroma_*` → managed service `NX_SERVICE_URL`/`TOKEN` (server-side Voyage, no client key); added 6.0 `guided-upgrade` + mac Gatekeeper + waypoint notes; uninstall covers the provisioned PG + service.
- **configuration**: `NX_LOCAL_CHROMA_PATH` + file-locations relabeled as the migration source; PG-prereq section now tells local users `nx init --service` auto-provisions (DBA steps are BYO-Postgres only).

Surfaced + beaded a real gap: managed-cloud Desktop `.mcpb` auth (`nexus-coq1z`). Iter3 (architecture + storage-tiers + migration-runbook + SVG) remains. Refs nexus-ooaut.