### PR TITLE
docs: release-N audit iter3 — architecture + storage-tiers + migration-runbook

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ Three arrows cross downward from the Planning band into the third band: a dashed
 
 The third band (green, "Unified Execution Layer") contains, left to right: a cluster of four colored hexagons connected by lines representing the Execution Plan DAG; an Execution Engine subgroup containing a `plan_run` panel (with a miniature DAG glyph) and a Result Cache cylinder labeled T1, connected by a bidirectional arrow; and a Defined Operator Set box divided into three labeled columns — RETRIEVAL (Search, Query, Traverse, FindNode, Filter, GroupBy), SYNTHESIS (Extract, Summarize, Compare, Rank, Generate, Aggregate), and STATE (`memory_*`, `store_*`, `plan_*`, `scratch_*`, `catalog_link`, `operator_*`).
 
-The fourth band (purple, "Knowledge Representation Layer") flows left to right: a stack-of-documents icon labeled "Source Documents" feeds an Inner-document Content Extractor (classifier, chunker via tree-sitter across 31 languages, `code_indexer`, `prose_indexer`, `pdf_extractor` routing Docling → MinerU → PyMuPDF, `bib_enricher`). An arrow labeled "Scholarly Document Knowledge" continues into Problem/Method Taxonomy Construction (`CatalogTaxonomy`, BERTopic plus HDBSCAN). Below Taxonomy, a Progressive Update box (`auto_linker`, `taxonomy_assign_hook`, `link_generator`) connects bidirectionally upward and receives a dashed "new documents" arrow from Source Documents. A "construct" arrow leads right from Taxonomy to the Nexus Knowledge Graph — rendered as a node-link cluster of orange and white circles — representing the three-tier store (T1 ChromaDB, T2 SQLite+FTS5, T3 ChromaDB Cloud) with tumbler addresses and typed links (`cites`, `implements`, `supersedes`, `relates`).
+The fourth band (purple, "Knowledge Representation Layer") flows left to right: a stack-of-documents icon labeled "Source Documents" feeds an Inner-document Content Extractor (classifier, chunker via tree-sitter across 31 languages, `code_indexer`, `prose_indexer`, `pdf_extractor` routing Docling → MinerU → PyMuPDF, `bib_enricher`). An arrow labeled "Scholarly Document Knowledge" continues into Problem/Method Taxonomy Construction (`CatalogTaxonomy`, BERTopic plus HDBSCAN). Below Taxonomy, a Progressive Update box (`auto_linker`, `taxonomy_assign_hook`, `link_generator`) connects bidirectionally upward and receives a dashed "new documents" arrow from Source Documents. A "construct" arrow leads right from Taxonomy to the Nexus Knowledge Graph — rendered as a node-link cluster of orange and white circles — representing the three-tier store (T1 ChromaDB, T2 SQLite+FTS5, T3 Postgres 16 + pgvector behind the native nexus-service) with tumbler addresses and typed links (`cites`, `implements`, `supersedes`, `relates`).
 </details>
 
 Source: [`architecture-diagram.svg`](architecture-diagram.svg) — edit the SVG directly, then re-render the PNG with `rsvg-convert -z 1.5 docs/architecture-diagram.svg -o docs/architecture-diagram.png`.
@@ -64,44 +64,61 @@ CLI (cli.py)            MCP Server (mcp_server.py)
     │     surfaces: MCP nexus-catalog server (10 tools) + nx catalog CLI
     │
 
-    └── Storage tiers (RDR-120 substrate split, daemon-mediated)
+    └── Storage tiers (RDR-120 substrate split; T2 daemon-mediated, T3 service-mediated)
           T1: ChromaDB HTTP server (session scratch, shared across agent processes)
           T2: SQLite + FTS5 daemon ── nx daemon t2 start
                 Nine domain stores behind T2Database / T2Client
                 Transport: UDS (UID-gated) + 127.0.0.1 loopback TCP
                 memory · plans · chash_index · taxonomy · telemetry ·
                 document_aspects · aspect_queue · document_highlights · catalog
-          T3: ChromaDB daemon ── nx daemon t3 start  (local mode only)
-              OR ChromaDB Cloud + Voyage AI (cloud, higher quality;
-                                              daemon does not apply)
-                code__*       voyage-code-3 index + query
-                docs__*       voyage-context-3 (CCE) index + query
-                rdr__*        voyage-context-3 (CCE) index + query
-                knowledge__*  voyage-context-3 (CCE) index + query
+          T3: Postgres 16 + pgvector behind the native nexus-service ── nx daemon service start
+              Same service in BOTH modes; embedding is server-side
+              (bge-768 in local mode, Voyage in managed-cloud mode).
+              The client is HttpVectorClient over /v1/vectors; the legacy
+              ChromaDB serving path is retired (RDR-155).
+                code__*       voyage-code-3 (managed) / bge-768 (local)
+                docs__*       voyage-context-3 CCE (managed) / bge-768 (local)
+                rdr__*        voyage-context-3 CCE (managed) / bge-768 (local)
+                knowledge__*  voyage-context-3 CCE (managed) / bge-768 (local)
 ```
 
-**Daemon-mediated storage (RDR-120, 4.34.0+).** Local mode now
-requires the T2 + T3 daemons to be running. Cloud mode is
-unaffected (CloudClient is already HTTP-served). The previous
-``NX_STORAGE_MODE=direct`` flag is honoured-as-daemon with a
-``DeprecationWarning`` for one release; the env-var itself is
-removed in the release after.
+**Service-mediated T3 storage (RDR-155).** T3 serving routes through the
+native nexus-service (Postgres 16 + pgvector + server-side embedding) in
+BOTH local and managed-cloud modes. `make_t3()` returns an
+`HttpVectorClient` by default; the client reads `NX_SERVICE_URL` +
+`NX_SERVICE_TOKEN` with supervisor-lease discovery
+(`storage_service_addr.<uid>`). Start it via `nx daemon service start`. The
+older ChromaDB serving path (`nx daemon t3`) still registers but is the
+RETIRED serving route, kept only as the immutable migration source until
+RDR-155 P4b deletes it. T2 is unaffected: it remains SQLite + FTS5 behind
+its own single-writer daemon (RDR-120).
+
+**Two-process waypoint.** This is a way-station, not the destination: T3 is
+on the service now; T2 is still SQLite behind the single-writer daemon.
+RDR-152 (`nexus-gmiaf`) moves T2 into the same Postgres service and retires
+the daemon class (its only remaining job is SQLite single-writer
+arbitration, structurally redundant once Postgres exists), converging on
+ONE service.
 
 For container deployments (Claude Co-Work and similar): containers
-reach the host's daemon via the loopback TCP socket exposed by
-``nx daemon t2 status``. Pattern:
+reach the host's T2 daemon via the loopback TCP socket exposed by
+``nx daemon t2 status``, and the host's nexus-service for T3 via
+``NX_SERVICE_URL`` + ``NX_SERVICE_TOKEN``. Pattern:
 
 ```
 # macOS Docker Desktop:
 docker run --rm \
     -e NX_T2_ADDR=host.docker.internal:<port> \
-    -e NX_T3_ADDR=host.docker.internal:<t3_port> \
+    -e NX_SERVICE_URL=http://host.docker.internal:<service_port> \
+    -e NX_SERVICE_TOKEN=<token> \
     <image-with-conexus>
 
 # Linux (default bridge):
 docker run --rm \
     --add-host=host.docker.internal:host-gateway \
     -e NX_T2_ADDR=host.docker.internal:<port> \
+    -e NX_SERVICE_URL=http://host.docker.internal:<service_port> \
+    -e NX_SERVICE_TOKEN=<token> \
     <image>
 ```
 
@@ -118,17 +135,18 @@ Data flows upward (T1 → T2 → T3).
 
 **Unified daemon-lifecycle substrate (RDR-149).** The three tiers
 differ in storage engine and scope (T1 session-scoped chroma, T2 uid-scoped
-SQLite+FTS5, T3 uid-scoped chroma/cloud) but share **one** lifecycle
-substrate: the leased / fenced / atomic service registry in
+SQLite+FTS5, T3 uid-scoped pgvector behind the nexus-service) but share
+**one** lifecycle substrate: the leased / fenced / atomic service registry in
 [`src/nexus/daemon/service_registry.py`](../src/nexus/daemon/service_registry.py)
 (`ServiceRegistry` + `ServiceSupervisor`). Owner discovery, single-writer
 election, ungraceful-death reap, restart fencing, self-heal re-assert, and
 version-skew cycling all live in that one primitive, parameterized by tier
 and scope. Each tier is a thin consumer: T1 via `daemon/t1_lease.py`
 (MCP-lifespan-owned, re-keyed transient `server_pid` → session-id), T2 via
-`daemon/t2_daemon.py`, T3 via `daemon/t3_daemon.py`. Liveness is **lease
-freshness (TTL), not pid** — a dead owner's lease ages out, giving pid-reuse
-immunity.
+`daemon/t2_daemon.py`, T3 via `daemon/storage_service_daemon.py` (the
+nexus-service supervisor; the retired `daemon/t3_daemon.py` ChromaDB path
+remains only as the migration source). Liveness is **lease freshness (TTL),
+not pid** — a dead owner's lease ages out, giving pid-reuse immunity.
 
 This collapsed a recurring bug class (the same discovery/single-writer/
 self-heal/version-skew defect kept reappearing in whichever tier had not yet
@@ -578,7 +596,8 @@ See `src/nexus/db/t2/__init__.py` for the facade source and
 | **Entry** | `cli.py`, `commands/` | Click CLI, one file per command group |
 | **Command preambles** | `commands/rdr.py` (`preamble` subgroup), `commands/command_context.py`, `conexus/commands/*.md` | RDR-130: slash-command context preambles. Each of the 25 conexus slash commands injects its preamble via a single-line `` !`nx <subcommand> -- "$ARGUMENTS"` `` call — the 9 RDR-lifecycle commands use `nx rdr preamble <name>`, the 16 agent-relay commands use `nx command-context <name>`. Preamble logic lives in the tested `nx` CLI (normal Python, unit-covered) and prints markdown; Claude Code injects that stdout as plain text and does NOT re-parse it, so emitted tables/fences are safe. No command inlines bash, no command depends on `$CLAUDE_PLUGIN_ROOT` (empty in command-bash context); a static guard (`test_migrated_command_uses_single_line_nx`) enforces the single-line form across all 25. Replaced the inlined-bash approach whose fenced-block truncation caused the 5.1.2 regression class |
 | **Catalog** | `catalog/catalog.py`, `catalog/catalog_db.py`, `catalog/tumbler.py`, `catalog/link_generator.py`, `catalog/auto_linker.py`, `catalog/consolidation.py` | Git-backed document registry + typed link graph (JSONL + SQLite). Tumbler addressing, `descendants()`/`ancestors()`/`lca()` hierarchy helpers, `resolve_chunk()` ghost element resolution, idempotent link upsert, composable query, bulk ops, audit. Auto-linker creates links from T1 link-context on every `store_put`. `consolidation.py` merges per-paper collections into corpus-level collections |
-| **Storage** | `db/t1.py`, `db/t2/`, `db/t3.py`, `db/chroma_quotas.py`, `db/local_ef.py` | Tier implementations. T2 is a package split into seven domain stores (see § T2 Domain Stores). Plans table has `ttl` column for auto-expiry. `chroma_quotas.py` is the single source of truth for ChromaDB Cloud quota constants and validators. `local_ef.py` provides the local ONNX embedding function |
+| **Storage** | `db/t1.py`, `db/t2/`, `db/t3.py`, `db/http_vector_client.py`, `db/managed_endpoint.py`, `db/service_endpoint.py`, `db/pg_provision.py`, `db/chroma_quotas.py`, `db/local_ef.py` | Tier implementations. T2 is a package split into domain stores (see § T2 Domain Stores). `make_t3()` (`db/__init__.py`) returns `HttpVectorClient` (T3 over the nexus-service `/v1/vectors`) by default; `db/t3.py` is the retired ChromaDB path kept as migration source. `managed_endpoint.py` / `service_endpoint.py` resolve the service URL/token (T3 reads `NX_SERVICE_URL`; the T2-stores/catalog resolver uses `NX_SERVICE_HOST`/`PORT`); `pg_provision.py` provisions the local PG16 cluster + writes `pg_credentials`. `chroma_quotas.py` is the single source of truth for ChromaDB Cloud quota constants and validators. `local_ef.py` provides the local ONNX embedding function |
+| **Service stack** | `daemon/storage_service_daemon.py`, `daemon/binary_install.py`, `commands/guided_upgrade_cmd.py`, `commands/migrate_cmd.py` | Native nexus-service lifecycle (RDR-155/161): `storage_service_daemon.py` supervises the PG16+pgvector+service binary; `binary_install.py` fetches/installs the engine-service binary (`PINNED_SERVICE_TAG = None` — the user supplies the tag). `guided_upgrade_cmd.py` (`nx guided-upgrade`, RDR-002) provisions + verifies the service then drives `migrate_cmd.py` (`nx migrate-to-service`, RDR-159; cross-model mode RDR-162), the Chroma → pgvector ETL orchestrator |
 | **Indexing** | `indexer.py`, `code_indexer.py`, `prose_indexer.py`, `index_context.py`, `indexer_utils.py`, `classifier.py`, `chunker.py`, `md_chunker.py`, `doc_indexer.py`, `pdf_extractor.py`, `pdf_chunker.py`, `bib_enricher.py`, `languages.py`, `pipeline_buffer.py`, `pipeline_stages.py`, `checkpoint.py` | Repo indexing pipeline (decomposed per RDR-032). `bib_enricher.py` queries Semantic Scholar for bibliographic metadata; `pdf_extractor.py` auto-detects math-heavy PDFs via FormulaItem counting and routes to MinerU (default-installed since nexus-2fyb) for LaTeX extraction; non-math PDFs use Docling. MinerU absence at runtime raises a `RuntimeError` rather than silently falling back to formula-stripped Docling — the prior silent fallback wiped formulas from every PDF indexed for weeks. MinerU processes large PDFs in 5-page subprocess batches for memory isolation (prevents OOM on formula-dense documents). Chunk metadata includes `has_formulas` boolean. `pipeline_buffer.py` provides a WAL-mode SQLite buffer for the three-stage streaming pipeline (RDR-048); `pipeline_stages.py` implements the concurrent extractor/chunker/uploader stages and orchestrator; `checkpoint.py` handles batch-path crash recovery for smaller documents (RDR-047) |
 | **Export** | `exporter.py` | Collection export/import for T3 backup and migration (.nxexp format) |
 | **DEVONthink** | `devonthink.py`, `commands/dt.py` | macOS-only `nx dt` integration verbs (RDR-099). `devonthink.py` exposes 5 selector helpers (`_dt_selection`, `_dt_uuid_record`, `_dt_tag_records`, `_dt_group_records`, `_dt_smart_group_records`) over a centralised `_run_osascript` spawn; the smart-group helper does an sdef-canonical three-property read (`search predicates` PLURAL + `search group` + `exclude subgroups`) and re-executes the search to honour user-authored scope. `commands/dt.py` is the Click surface: `nx dt index` dispatches per-record by extension (.pdf/.md) into the existing `nexus.doc_indexer` entry points, and `nx dt open` round-trips tumblers/UUIDs back to DT via `open(1)`. Substrate `meta.devonthink_uri` reverse-lookup shipped in 4.17.0 (nexus-srck) |
@@ -657,5 +676,5 @@ Grouped by verb:
 | **SeaGOAT** | Git frecency scoring, hybrid search, persistent server |
 | **Arcaneum** | PDF extraction + chunking pipelines, RDR process |
 
-Storage (ChromaDB + Voyage AI) and embedding layers are Nexus's own.
+The storage stack (Postgres 16 + pgvector behind the native nexus-service, with server-side bge-768 / Voyage embedding) and the indexing layers are Nexus's own.
 

--- a/docs/migration-runbook.md
+++ b/docs/migration-runbook.md
@@ -8,31 +8,54 @@ read the artifacts. Precedent: the 2026-06-10 production run (115,716
 chunks, ~10:46 to 15:05 PT, zero lost, est. $4-6 Voyage; permanent record:
 T2 `nexus_rdr/155-production-migration-complete`).
 
-## 0. The guided path: `nx migrate-to-service`
+## 0. The guided path: `nx guided-upgrade`
 
-> **Status (RDR-159 P4).** The guided command exists and runs the full flow.
-> The two-release deprecation-window cadence is documented in the next section.
-> Sections 1-7 below remain the authoritative manual order of operations; the
-> guided command sequences exactly those same primitives. The consumer-facing
-> entry is the conexus `/upgrade` slash-command — a thin veneer over this same
-> `nx migrate-to-service` that owns no migration logic.
+> **Status (RDR-002 / RDR-159 P4).** `nx guided-upgrade` is the validated
+> one-command path and the recommended entry point. The two-release
+> deprecation-window cadence is documented in the next section. Sections 1-7
+> below remain the authoritative manual order of operations; `guided-upgrade`
+> sequences exactly those same primitives.
 
-`nx migrate-to-service` wraps and sequences everything in sections 2-6 into one
-survivable command: detect the Chroma footprint, set the cross-process
-migration sentinel (reads degraded-LOUD, never bare-empty), quiesce background
-indexing, pre-gate per-collection model support, run T2 `migrate all` then T3
-vectors for every detected leg, validate (taxonomy + counts + manifest
-orphans), and unlock on a clean verdict. On a validation block it leaves the
-migrated copy in place (sentinel `migrated-failed`) and OFFERS — never
-auto-invokes — `nx storage migrate vectors --rollback` (§6); the Chroma source
-is untouched. Preview first with `nx migrate-to-service --dry-run`. Flag
-reference: [`cli-reference.md` § nx migrate-to-service](cli-reference.md#nx-migrate-to-service).
+`nx guided-upgrade` (RDR-002) is a thin orchestrator over reused pieces: it
+**pre-flight detects** the pre-RDR-160 Chroma footprint (a fresh user with
+nothing to migrate no-ops here, *without* provisioning), **provisions and
+verifies** the service stack (health-gate + version-pin; a not-ready or
+wrong-version service hard-fails with a remedy and NEVER migrates), runs the
+**voyage-capability gate** (refuses to migrate voyage-model collections onto a
+bge-only service, since re-embedding voyage text into bge changes recall),
+self-loads the freshly-provisioned `NX_SERVICE_TOKEN`, then **hands off to
+`nx migrate-to-service`** against the verified URL, and finishes with an
+advisory `nx doctor`. Preview the footprint first; re-running is safe (every
+step is idempotent) but is NOT a no-op after a successful migration —
+copy-not-move leaves the Chroma source intact, so a re-run re-detects and
+re-copies it.
+
+`nx migrate-to-service` (RDR-159; cross-model mode added in RDR-162) is the
+lower-level primitive that `guided-upgrade` sequences; run it directly when the service is already stood
+up and verified. It wraps everything in sections 2-6 into one survivable
+command: detect the Chroma footprint, set the cross-process migration sentinel
+(reads degraded-LOUD, never bare-empty), quiesce background indexing, pre-gate
+per-collection model support, run T2 `migrate all` then T3 vectors for every
+detected leg, validate (taxonomy + counts + manifest orphans), and unlock on a
+clean verdict. On a validation block it leaves the migrated copy in place
+(sentinel `migrated-failed`) and OFFERS — never auto-invokes —
+`nx storage migrate vectors --rollback` (§6); the Chroma source is untouched.
+Preview first with `nx migrate-to-service --dry-run`. The consumer-facing
+conexus `/upgrade` slash-command is a thin veneer over this same
+`migrate-to-service` that owns no migration logic. Flag references:
+[`cli-reference.md` § nx guided-upgrade](cli-reference.md#nx-guided-upgrade)
+and [§ nx migrate-to-service](cli-reference.md#nx-migrate-to-service).
 
 ## 0.1 The two-release deprecation window (release cadence)
 
 ChromaDB is retired across **two** releases, never one. The ordering is an
 invariant, not a preference: the release that *deletes* the Chroma read path
 can only ship *after* a release that gives users a way off Chroma.
+
+Release N (migration-capable) is **conexus 6.0.0** — the major bump that retires
+Chroma *serving* (RDR-155) while keeping the Chroma read path as the migration
+source. Release N+1 (the Chroma deletion, RDR-155 P4b) is a later release that
+must follow 6.0.0, never collapse into it.
 
 | | **Release N** (migration-capable) | **Release N+1** (Chroma deletion) |
 |---|---|---|

--- a/docs/storage-tiers.md
+++ b/docs/storage-tiers.md
@@ -4,13 +4,13 @@ Nexus organizes data across three tiers with increasing durability. Data flows u
 
 **Two access paths**: Humans use the `nx` CLI. Agents use MCP tools (`mcp__plugin_conexus_nexus__*`) which call the same Python APIs directly — no Bash dependency. MCP tools that return lists (`search`, `store_list`, `memory_search`) are paged — pass `offset=N` for subsequent pages. See [conexus/README.md](../conexus/README.md#mcp-servers) for MCP tool details.
 
-**One arbitrator per tier**: Since conexus 4.34.0 (RDR-120), both T2 and (local-mode) T3 are wrapped in dedicated daemon processes. Every consumer — host CLI, the MCP server, multiple Claude Code sessions, Claude Cowork agents (via SDK transport), dev containers (via TCP loopback or UDS mount) — routes through the same daemon, so the underlying SQLite / ChromaDB instance has exactly one writer. Start the daemons once via `nx daemon t2 install --autostart` (and `nx daemon t3 install --autostart` in local mode); the Claude Code plugin's SessionStart hook also auto-spawns them on each session start.
+**One arbitrator per tier**: Since conexus 4.34.0 (RDR-120), T2 is wrapped in a dedicated daemon process; since RDR-155, T3 serving routes through the native nexus-service (Postgres 16 + pgvector). Every consumer — host CLI, the MCP server, multiple Claude Code sessions, Claude Cowork agents (via SDK transport), dev containers — routes through the same arbitrator, so the underlying SQLite instance has exactly one writer and all vector traffic goes through one service. Start the T2 daemon once via `nx daemon t2 install --autostart`, and the storage service via `nx daemon service start`; the Claude Code plugin's SessionStart hook also auto-spawns the T2 daemon on each session start.
 
-| Tier | Storage | Daemon | Transport | Durability | Use |
-|------|---------|--------|-----------|------------|-----|
-| T1 -- scratch | ChromaDB EphemeralClient (per-MCP-process) | none | Process-local | Session only | Working notes, hypotheses |
+| Tier | Storage | Arbitrator | Transport | Durability | Use |
+|------|---------|------------|-----------|------------|-----|
+| T1 -- scratch | ChromaDB EphemeralClient / per-session HTTP server | none | Process-local | Session only | Working notes, hypotheses |
 | T2 -- memory | SQLite + FTS5 (WAL) | T2 daemon (`nx daemon t2`) | UDS + 127.0.0.1 loopback | Survives restarts | Per-project notes, session context |
-| T3 -- knowledge | Local ChromaDB or ChromaDB Cloud + Voyage AI | local: T3 daemon; cloud: direct HTTPS | local: localhost / cloud: required | Permanent | Semantic search, indexed code/docs |
+| T3 -- knowledge | Postgres 16 + pgvector behind the native nexus-service (both modes); embedding server-side (bge-768 local / Voyage managed-cloud) | storage-service supervisor (`nx daemon service`) | nexus-service HTTP `/v1/vectors` (`NX_SERVICE_URL` + `NX_SERVICE_TOKEN`) | Permanent | Semantic search, indexed code/docs |
 | Catalog | T2-store-backed (eighth domain store; RDR-120 P5.A) + events.jsonl (canonical) | shared with T2 daemon | UDS + 127.0.0.1 loopback | Permanent | Document registry, typed link graph, provenance |
 
 The catalog sits alongside T3 as a metadata layer. While T3 stores document *content* as embeddings, the catalog stores document *metadata* and *relationships*. See [Document Catalog](catalog.md).
@@ -116,7 +116,7 @@ Merges use SQLite's write lock via `with self.conn:` to ensure UPDATE and DELETE
 
 **Relevance log (RDR-061 E2)**: T2 also holds a `relevance_log` table that records `(query, chunk_id, action)` triples when an agent acts on search results (`store_put`, `catalog_link`). This is internal telemetry — not exposed as an MCP tool. Purged by `T2Database.expire(relevance_log_days=90)` alongside memory TTL expiry.
 
-**Domain split (RDR-063)**: T2 is implemented as four domain stores under `src/nexus/db/t2/` — `MemoryStore` (memory table), `PlanLibrary` (plans table), `CatalogTaxonomy` (topics + topic_assignments + taxonomy_meta + topic_links), and `Telemetry` (relevance_log). Each store opens its own `sqlite3.Connection` against the shared SQLite file in WAL mode with `busy_timeout=5000`, so reads in one domain are never blocked by writes in another. `T2Database` is a composing facade: existing `db.put(...)`, `db.search(...)`, `db.save_plan(...)` calls continue to work via method delegation, and new code can reach the domain stores directly as `db.memory`, `db.plans`, `db.taxonomy`, `db.telemetry`. See [Architecture — T2 Domain Stores](architecture.md#t2-domain-stores) for the full map and concurrency model.
+**Domain split (RDR-063)**: T2 is implemented as four domain stores under `src/nexus/db/t2/` — `MemoryStore` (memory table), `PlanLibrary` (plans table), `CatalogTaxonomy` (topics + topic_assignments + taxonomy_meta + topic_links), and `Telemetry` (relevance_log). Each store opens its own `sqlite3.Connection` against the shared SQLite file in WAL mode with `busy_timeout=30000` (raised from 5000 in RDR-129 B1), so reads in one domain are never blocked by writes in another. `T2Database` is a composing facade: existing `db.put(...)`, `db.search(...)`, `db.save_plan(...)` calls continue to work via method delegation, and new code can reach the domain stores directly as `db.memory`, `db.plans`, `db.taxonomy`, `db.telemetry`. See [Architecture — T2 Domain Stores](architecture.md#t2-domain-stores) for the full map and concurrency model.
 
 **Topic taxonomy**: `CatalogTaxonomy` discovers topics from T3 collection embeddings using HDBSCAN, labels them automatically with Claude Haiku, and uses them for search grouping and relevance boosting. Topics are discovered automatically after `nx index repo`. Operator-curated labels are preserved across re-discovery runs. See [CLI Reference — nx taxonomy](cli-reference.md#nx-taxonomy) for the full command set and [taxonomy.md](taxonomy.md) for architecture details.
 
@@ -137,42 +137,47 @@ The taxonomy spans two storage tiers:
 
 ## T3 -- Permanent Knowledge
 
-T3 has two backends: **local** (zero-config) and **cloud** (higher quality).
+Since RDR-155, T3 serving routes through the **native nexus-service** (Postgres
+16 + pgvector) in BOTH modes. The Python client is `HttpVectorClient`
+(`make_t3()` in `db/__init__.py` returns it by default); it talks to the
+service over HTTP `/v1/vectors`, reading `NX_SERVICE_URL` + `NX_SERVICE_TOKEN`
+with supervisor-lease discovery (`~/.config/nexus/storage_service_addr.<uid>`).
+Embedding happens **server-side**, so the choice of model is a property of the
+service, not of the client. The two modes differ only in which embedder the
+service runs:
 
-### Local backend (default when no cloud credentials)
-
-Backed by `chromadb.PersistentClient` with local ONNX embeddings. No API keys or network required. Data stored at `~/.local/share/nexus/chroma`.
-
-| | Tier 0 (bundled) | Tier 1 (`uv tool install conexus --with "conexus[local]" --force`) |
+| | Local mode (default) | Managed-cloud mode |
 |---|---|---|
-| Model | all-MiniLM-L6-v2 | bge-base-en-v1.5 |
-| Dimensions | 384 | 768 |
-| Quality | Basic semantic matching | Better code & prose retrieval |
-| Install | Included | `uv tool install conexus --with "conexus[local]" --force` |
+| Embedder (server-side) | bge-768 (ONNX, RDR-160) | Voyage (`voyage-code-3` / `voyage-context-3`) |
+| Dimensions | 768 | 1024 |
+| Credentials | none required | Voyage API key on the service |
+| Reranking | unavailable | available |
 
-All collection types use the same local model (no per-prefix splitting). Reranking is unavailable in local mode.
+bge-768 is the standard local-mode service embedder (RDR-160 replaced the
+earlier MiniLM-384), not an opt-in extra. Run `nx daemon service start` to
+bring the stack up and `nx daemon service status` to verify health (lease, PG
+cluster, `/version` handshake with `embedding_mode`).
 
-### Cloud backend
-
-Backed by a single `chromadb.CloudClient` with `VoyageAIEmbeddingFunction`. Requires `CHROMA_API_KEY`, `CHROMA_DATABASE`, and `VOYAGE_API_KEY`. `CHROMA_TENANT` is optional — the CloudClient infers the tenant UUID from your API key.
-
-All collections coexist in one ChromaDB Cloud database (`CHROMA_DATABASE` value, e.g. `nexus`). The database is provisioned automatically by `nx config init`. Run `nx doctor` to verify connectivity.
+> **The legacy ChromaDB serving path is retired.** Pre-RDR-155, T3 was backed by
+> `chromadb.PersistentClient` (local) or `chromadb.CloudClient` + Voyage
+> (cloud). That path (`db/t3.py`, `nx daemon t3`) still registers but serves
+> nothing — it survives only as the immutable migration *source* until RDR-155
+> P4b deletes it. Existing Chroma data migrates onto the service via
+> `nx guided-upgrade` (see [Migration Runbook](migration-runbook.md)).
 
 ### Collections
 
-Collections are namespaced by corpus type using `__` (double underscore) as separator:
+Collections are namespaced by corpus type using `__` (double underscore) as separator. Each collection's embedding model is fixed; the service routes by collection name:
 
-| Pattern | Contents | Cloud index model | Cloud query model |
-|---------|----------|-------------------|-------------------|
-| `code__<repo>-<hash>` | Indexed source code | voyage-code-3 | voyage-code-3 |
-| `docs__<repo>-<hash>` | Indexed prose files | voyage-context-3 (CCE) | voyage-context-3 |
-| `rdr__<repo>-<hash>` | Indexed RDR documents | voyage-context-3 (CCE) | voyage-context-3 |
-| `docs__<corpus>` | Indexed PDFs and markdown | voyage-context-3 (CCE) | voyage-context-3 |
-| `knowledge__<topic>` | Stored agent outputs and notes | voyage-context-3 (CCE) | voyage-context-3 |
+| Pattern | Contents | Managed-cloud model | Local model |
+|---------|----------|---------------------|-------------|
+| `code__<repo>-<hash>` | Indexed source code | voyage-code-3 | bge-768 |
+| `docs__<repo>-<hash>` | Indexed prose files | voyage-context-3 (CCE) | bge-768 |
+| `rdr__<repo>-<hash>` | Indexed RDR documents | voyage-context-3 (CCE) | bge-768 |
+| `docs__<corpus>` | Indexed PDFs and markdown | voyage-context-3 (CCE) | bge-768 |
+| `knowledge__<topic>` | Stored agent outputs and notes | voyage-context-3 (CCE) | bge-768 |
 
-All collections use the same embedding model for both index and query. Mixing models across vector spaces produces near-random similarity scores.
-
-In local mode, all collections use the active local model for both index and query.
+A collection is indexed and queried under the same embedding model — mixing models across one vector space produces near-random similarity scores. The voyage-capability gate (`nx guided-upgrade`) refuses to migrate voyage-model collections onto a bge-only service for exactly this reason.
 
 **TTL and expiry**: `nx store expire` removes expired entries from `knowledge__*` collections only. Code, docs, and RDR collections are never expired — they are refreshed via re-indexing.
 


### PR DESCRIPTION
Iteration 3 (final batch) of the release-N / conexus 6.0.0 user-facing doc audit (bead `nexus-ooaut`). Updates the deepest docs for the RDR-155 T3 substrate move (ChromaDB serving → native nexus-service over Postgres 16 + pgvector) and the RDR-002 `nx guided-upgrade` path.

## Changes
- **architecture.md**: T3 tier block; new service-mediated-storage + two-process-waypoint notes; RDR-149 substrate consumer corrected to `storage_service_daemon.py`; Storage + new Service-stack module-map rows; container env switched to `NX_SERVICE_URL`/`NX_SERVICE_TOKEN`; heritage line.
- **storage-tiers.md**: tier table + arbitrator column; full T3 section rewrite (`HttpVectorClient` over `/v1/vectors`, server-side bge-768 local / Voyage managed-cloud, dims table, collections table); `busy_timeout` 5000→30000.
- **migration-runbook.md**: headline `nx guided-upgrade`, demote `migrate-to-service` to the sequenced primitive; Release N = conexus 6.0.0.

## Gate
Substantive-critic correctness-gated against the code. It caught one real defect — `nx migrate-to-service` is **RDR-159**, not RDR-162 (RDR-162 only added cross-model mode) — fixed in both occurrences. All other changed claims verified against `src/nexus/`.

Note: the SVG carries no stale T3 label (verified), so no diagram re-render was needed. Prep only — does not cut a release (`nexus-luxe6` still open).

Bead: nexus-ooaut