### PR TITLE
docs: release-N audit iter4 — remediate ALL remaining user-facing docs (Chroma→pgvector)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,13 @@ Start with [Getting Started](getting-started.md) for installation. Then explore 
 - [Configuration](configuration.md) — Config hierarchy, `.nexus.yml`, environment variables, logging
 - [Container Integration](container-integration.md) — Daemon model for containers and Cowork
 
+## Upgrading to 6.0 (off ChromaDB)
+
+6.0 retires ChromaDB T3 serving for the native nexus-service (Postgres 16 + pgvector). Existing users migrate with one command, `nx guided-upgrade`.
+
+- [Getting Started § Cloud mode](getting-started.md#cloud-mode-optional) and `nx init --service` — stand up the service stack
+- [Migration Runbook](migration-runbook.md) — the operational order of operations, quiescence, rollback, and the two-release deprecation window
+
 ## Workflow
 
 - [RDR: Research-Design-Review](rdr.md) — Lifecycle, workflow, Nexus integration, templates

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,7 +67,7 @@ CLI (cli.py)            MCP Server (mcp_server.py)
     └── Storage tiers (RDR-120 substrate split; T2 daemon-mediated, T3 service-mediated)
           T1: ChromaDB HTTP server (session scratch, shared across agent processes)
           T2: SQLite + FTS5 daemon ── nx daemon t2 start
-                Nine domain stores behind T2Database / T2Client
+                Eight domain stores (incl. catalog) behind T2Database / T2Client
                 Transport: UDS (UID-gated) + 127.0.0.1 loopback TCP
                 memory · plans · chash_index · taxonomy · telemetry ·
                 document_aspects · aspect_queue · document_highlights · catalog
@@ -277,7 +277,7 @@ Pre-existing drift surfaced during Phase 5 verification (filed as separate beads
 
 Taxonomy (RDR-070) builds a topic hierarchy over T3 collections using existing embeddings, without re-embedding. HDBSCAN clusters the vectors already stored in ChromaDB, labels them with c-TF-IDF, and persists topic assignments to T2 SQLite. Every subsequent `store_put` call assigns the new document to the nearest centroid via ANN lookup. Search then uses these assignments to boost same-topic results and group output.
 
-In local mode, `code__*` collections are excluded by default because MiniLM clusters code poorly. Cloud mode uses `voyage-code-3` and is unaffected. `nx index repo` triggers discovery automatically after indexing.
+In local mode, `code__*` collections are excluded by default because the general-purpose local embedder (bge-768) clusters code poorly. Cloud mode uses `voyage-code-3` and is unaffected. (Note: as of 6.0, taxonomy discovery is suspended while the nexus-service is the T3 backend; see the taxonomy command docs.)
 
 ### Data Flow
 
@@ -574,8 +574,8 @@ constructions skip all DB access. Domain stores retain their own
 `_migrated_paths` guards for standalone construction outside `T2Database`.
 
 **T3 Upgrade Steps**: `T3UpgradeStep(introduced, name, fn)` entries in the
-`T3_UPGRADES` list handle ChromaDB operations (backfills, re-indexing) that
-require a `T3Database` client. These run via `nx upgrade` (not `--auto` mode).
+`T3_UPGRADES` list handle T3 vector-store operations (backfills, re-indexing)
+that require a T3 client. These run via `nx upgrade` (not `--auto` mode).
 
 **Auto-upgrade**: `nx upgrade --auto` runs as the first SessionStart hook,
 applying T2 migrations silently. T3 steps are skipped in auto mode.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -224,7 +224,7 @@ In `.nexus.yml`:
 ```yaml
 taxonomy:
   auto_label: true                       # Label with Claude haiku (default)
-  local_exclude_collections: ["code__*"] # Skip code in local mode (MiniLM clusters code poorly)
+  local_exclude_collections: ["code__*"] # Skip code in local mode (general-purpose local embeddings cluster code poorly)
 ```
 
 | Key | Default | Description |
@@ -234,19 +234,27 @@ taxonomy:
 
 ### Local vs cloud quality
 
-| Mode | Embedding model | Code quality | Document quality |
+| Mode | Embedding model (server-side) | Code quality | Document quality |
 |------|----------------|-------------|-----------------|
-| Local | MiniLM 384d (ONNX) | Poor (excluded by default) | Good (8 topics from 120 docs) |
+| Local | bge-768 (ONNX, via nexus-service) | Poor (excluded by default) | Good (8 topics from 120 docs) |
 | Cloud | Voyage 1024d | Excellent (124 topics from 5K chunks) | Excellent (88 topics, 78% assigned) |
 
 ### How it works
+
+> **Note (6.0):** Taxonomy *discovery* is suspended in service mode (the default
+> since 6.0): `nx taxonomy discover` exits with a clear error and `nx index repo`
+> skips the discovery step. Discovery needs a raw Chroma client retired with the
+> Chroma serving paths (RDR-155 P4a); restoring it on the pgvector service is a
+> tracked follow-on (`nexus-gmiaf.21+`). Previously-computed assignments still
+> drive search boosts and `topic=` scoping. The flow below is the pre-6.0 model
+> and the target once discovery is restored.
 
 After `nx index repo` (or `nx taxonomy discover --all`):
 
 1. **Fetch embeddings** from each T3 collection
 2. **Cluster** via HDBSCAN density-based clustering (`min_cluster_size=5`)
 3. **Label** each cluster with c-TF-IDF keywords, refined via Claude haiku
-4. **Store** topics in T2 and centroids in ChromaDB
+4. **Store** topics in T2 and centroids in a local ChromaDB collection (`taxonomy__centroids`, a centroid-only store independent of the retired T3 Chroma serving path)
 
 From then on, every `store_put` auto-assigns the new document to its nearest topic via centroid lookup, every search call boosts results sharing a topic cluster, and operator-curated labels survive rebuilds via centroid-matching merge (similarity > 0.8 transfers the old label).
 
@@ -320,9 +328,9 @@ Over time, JSONL files accumulate overwrites and tombstones. Two compaction mode
 
 ## Durability and remote sync
 
-**Local mode users** (ONNX embeddings, no cloud): the catalog is as durable as your disk. If that's fine, you're done.
+**Local-service users** (local nexus-service, bge-768): both T3 content (the service's Postgres) and the catalog live on your disk, so both are as durable as that disk. If that's fine, you're done.
 
-**Cloud mode users** (ChromaDB Cloud + Voyage AI): your T3 content lives in the cloud, but the catalog — the only record of what's indexed, how documents relate, and what their tumblers are — is local. If you lose the disk, the catalog is gone. T3 content survives but you'd have to `backfill` to reconstruct the registry, and all links would be lost.
+**Managed-cloud users** (a hosted nexus-service with pgvector + Voyage AI): your T3 content lives in the managed service's Postgres, but the catalog — the only record of what's indexed, how documents relate, and what their tumblers are — is still local. If you lose the disk, the catalog is gone. T3 content survives in the managed service, but you'd have to `backfill` to reconstruct the registry, and all links would be lost.
 
 **Fix this by adding a git remote:**
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -744,7 +744,7 @@ Returns non-zero on any check failure. `--json` emits the per-check result for C
 
 ## nx t3
 
-T3 (ChromaDB) maintenance commands. Distinct from `nx catalog gc`: `nx t3` operates on T3 chunks, the catalog command operates on catalog rows.
+T3 vector-store maintenance commands. As of 6.0 the live T3 store is Postgres 16 + pgvector behind the native nexus-service; these commands operate on that store through the vector client. (`nx t3 reidentify` was the RDR-108 ChromaDB natural-ID migration and is retained for legacy collections.) Distinct from `nx catalog gc`: `nx t3` operates on T3 chunks, the catalog command operates on catalog rows.
 
 ### nx t3 prune-stale
 
@@ -875,7 +875,7 @@ taxonomy:
 ```yaml
 taxonomy:
   auto_label: true                    # label with Claude haiku after discover (default: true)
-  local_exclude_collections: []       # default: ["code__*"] — MiniLM clusters poorly on code
+  local_exclude_collections: []       # default: ["code__*"] — local embeddings cluster poorly on code
 ```
 
 **Upgrade path**: Run `nx upgrade` after upgrading to apply pending migrations and T3 upgrade steps (including cross-collection projection backfill). Run `nx taxonomy discover --all` to populate topics for new collections.
@@ -1054,7 +1054,7 @@ nx collection list
 | `verify NAME` | Existence check + document count |
 | `reindex NAME` | Delete and re-index a collection from its source documents |
 | `backfill-hash [NAME]` | Add `chunk_text_hash` metadata to chunks missing it (no re-embedding) |
-| `rename OLD NEW` | In-place rename via ChromaDB `modify(name=)` + T2 + catalog cascade (4.8.0, nexus-1ccq) |
+| `rename OLD NEW` | In-place metadata-only rename in the T3 vector store + T2 + catalog cascade (4.8.0, nexus-1ccq) |
 | `audit NAME` | Deep-dive per-collection report: distance histogram, top-5 cross-projections, orphan chunks, hub topics, chash coverage (RDR-087 Phase 4) |
 | `health` | Composite per-collection health table — chunk counts (T3-sourced), staleness, hub score, chash coverage (RDR-087 Phase 3.4) |
 | `delete NAME` | Delete collection (irreversible) |
@@ -1079,7 +1079,7 @@ The `reindex` command performs a pre-delete safety check before wiping the colle
 |------|-------------|
 | `--all` | Backfill all collections instead of a single named one |
 
-Reads each chunk's stored text from ChromaDB and computes `sha256(text.encode()).hexdigest()`, updating metadata in-place. Embeddings and documents are untouched — no API keys or re-embedding needed. Idempotent: chunks that already have `chunk_text_hash` are skipped. Also runs automatically during `nx catalog setup`.
+Reads each chunk's stored text from the T3 store and computes `sha256(text.encode()).hexdigest()`, updating metadata in-place. Embeddings and documents are untouched — no API keys or re-embedding needed. Idempotent: chunks that already have `chunk_text_hash` are skipped. Also runs automatically during `nx catalog setup`.
 
 **RDR-086 Phase 1.3 — T2 `chash_index` reconciliation.** The same per-chunk
 pass also populates the T2 `chash_index` table so `nx doc cite` and
@@ -1098,7 +1098,7 @@ takes ~25–70 minutes on ChromaDB Cloud. Maintenance-window operation.
 |------|-------------|
 | `--force-prefix-change` | Allow a cross-prefix rename (e.g. `code__foo` → `docs__foo`). Embedding-model spaces differ across prefixes, so the renamed collection is query-incompatible with its old clients — use only when you've deleted every downstream reader |
 
-Uses ChromaDB's native `modify(name=)` for an O(1) metadata update — no embedding re-upload, no Voyage cost, no ChromaDB egress. Cascades the new name through T2 taxonomy, `chash_index`, and catalog (JSONL + SQLite). The cascade is fail-open by design: T3 renames first; a T2 or catalog failure prints a `warn: …` line on stderr but leaves T3 renamed so the operation is recoverable by retrying the cascade alone.
+Renames the collection in the T3 vector store via `t3.rename_collection` (a metadata-only update on the pgvector service path — no embedding re-upload, no Voyage cost, no vector egress), and cascades the new name through T2 taxonomy, `chash_index`, and catalog (JSONL + SQLite). Ordering (SIG-8 / nexus-nhyh): the T2 cascade runs FIRST, then the T3 rename, so a partial failure is recoverable: if the T3 rename fails the T2/catalog rows can be re-pointed or the rename re-run; if T2 fails no T3 rename was attempted.
 
 **`audit` flags:**
 
@@ -1339,7 +1339,7 @@ Health check for all dependencies.
 nx doctor
 ```
 
-Checks: ChromaDB API key, ChromaDB tenant, T3 database (`CHROMA_DATABASE`), Voyage AI key, ripgrep binary, git binary, git hooks status for registered repos, index log last-write time, orphaned PDF checkpoints, orphaned pipeline buffer entries, T2 integrity, T2 daemon singleton (RDR-129: hard error if more than one T2 daemon serves the same `memory.db`), T2 best-effort writes (RDR-129: soft warning with the count of chash dual-writes dropped under WAL contention). The T2 integrity check now reports a transient FTS5 write-lock during active indexing as a soft warning, not a hard failure (RDR-129 B4).
+Checks (live T3 first): the nexus-service vector reachability probe (RDR-155: probed unconditionally — a pgvector install with the service down does NOT doctor all-green), the T3 collection census via the pgvector service, the service bge-768 model in local-service mode, and the legacy on-disk Chroma store (reported as awaiting the migration ETL, not as the live backend). Then: Voyage AI key, ripgrep binary, git binary, git hooks status for registered repos, index log last-write time, orphaned PDF checkpoints, orphaned pipeline buffer entries, T2 integrity, T2 daemon singleton (RDR-129: hard error if more than one T2 daemon serves the same `memory.db`), T2 best-effort writes (RDR-129: soft warning with the count of chash dual-writes dropped under WAL contention). The T2 integrity check reports a transient FTS5 write-lock during active indexing as a soft warning, not a hard failure (RDR-129 B4). The ChromaDB Cloud credential lines (`CHROMA_API_KEY` / `CHROMA_TENANT` / `CHROMA_DATABASE`) are still surfaced, but as of 6.0 they describe migration-source / pre-6.0 cloud config — the live T3 health surface is the vector-service probe above and `nx daemon service status`. A fresh local install with no Chroma keys is healthy.
 
 ```
 nx doctor --clean-checkpoints   # Delete orphaned PDF checkpoint files
@@ -1382,7 +1382,7 @@ nx doctor --check-quotas            # Report ChromaDB Cloud + Voyage AI free-tie
 nx doctor --check-quotas --json     # Structured output for dashboards / CI gates
 ```
 
-The `--check-quotas` flag (introduced 4.9.0, nexus-c590) emits a three-section pre-flight report: (1) ChromaDB Cloud limits drawn from `nexus.db.chroma_quotas.QUOTAS` (`MAX_QUERY_RESULTS`, `MAX_RECORDS_PER_WRITE`, `MAX_CONCURRENT_*`, document size caps) plus a live reachability probe of the configured tenant; (2) Voyage AI per-model token and dimension caps (`voyage-3`, `voyage-code-3`, `voyage-context-3`) with `VOYAGE_API_KEY` presence check; (3) the cumulative retry accumulator from `nexus.retry.get_retry_stats()` so any transient-error backoffs observed in the current process surface alongside the static limits.
+The `--check-quotas` flag (introduced 4.9.0, nexus-c590) emits a three-section pre-flight report: (1) the per-request limits drawn from `nexus.db.chroma_quotas.QUOTAS` (`MAX_QUERY_RESULTS`, `MAX_RECORDS_PER_WRITE`, `MAX_CONCURRENT_*`, document size caps) which the managed-cloud path still honours, plus a reachability probe that fires only when a ChromaDB Cloud migration source is configured; (2) Voyage AI per-model token and dimension caps (`voyage-3`, `voyage-code-3`, `voyage-context-3`) with `VOYAGE_API_KEY` presence check; (3) the cumulative retry accumulator from `nexus.retry.get_retry_stats()` so any transient-error backoffs observed in the current process surface alongside the static limits.
 
 Exit codes:
 - `0` — reachable cloud tenant or local-mode (limits are reference-only).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,22 +34,32 @@ Nexus auto-detects local mode when cloud credentials are absent. The recommended
 
 **Embedding tiers**: Tier 0 (bundled MiniLM-L6-v2, 384d) is always available. Install `uv tool install "conexus[local]"` for tier 1 (bge-base-en-v1.5, 768d, better quality; downloads the model on first embed). To add the extra to an existing install: `uv tool install --reinstall "conexus[local]"`. Upgrade later with `uv tool upgrade conexus`, which preserves the extra — never `uv tool install --force`, which drops it.
 
-**Storage path**: Defaults to `$XDG_DATA_HOME/nexus/chroma` or `~/.local/share/nexus/chroma`. Override with `NX_LOCAL_CHROMA_PATH`.
+**Legacy ChromaDB store path**: Defaults to `$XDG_DATA_HOME/nexus/chroma` or `~/.local/share/nexus/chroma`, overridable with `NX_LOCAL_CHROMA_PATH`. As of 6.0 this path is read only as the **migration source** (`nx guided-upgrade`); live T3 serves from the Postgres+pgvector service.
 
 **Switching embedders or modes**: Changing the embedding model (switching local↔cloud, *or* switching local tiers 384-dim MiniLM ↔ 768-dim bge) makes the existing vectors incompatible (different dimensions/space). On the next `nx index repo .` the staleness check detects the model change and re-embeds into **new** collections under the new model token. **It does NOT automatically delete or migrate the old collections**: they remain behind under the previous token and silently return no results (their dimension no longer matches the active embedder).
 
 When you switch local tiers via `nx init` (the common 384 → bge-768 upgrade), `nx init` detects these stale collections and offers a safe, ordered migration (preview → double-confirm → reindex-first → delete-after-verify; old collections deleted only after the new ones are verified populated, so a failed reindex never loses data). `code__` and manual-note (`store_put`) collections are reported but never auto-deleted. Outside the `nx init` flow you can clean up manually: `nx doctor` flags the dimension mismatch, `nx collection reindex <name>` rebuilds one from source, and `nx collection delete <name>` removes an orphan.
 
-## Cloud Credentials
+## Managed-Cloud Credentials
 
-| Config key | Env var | Required | Notes |
-|---|---|---|---|
-| `chroma_api_key` | `CHROMA_API_KEY` | Cloud mode | ChromaDB Cloud API key |
-| `chroma_database` | `CHROMA_DATABASE` | Cloud mode | ChromaDB Cloud database name (e.g. `nexus`) |
-| `voyage_api_key` | `VOYAGE_API_KEY` | Cloud mode | Voyage AI embeddings key |
-| `chroma_tenant` | `CHROMA_TENANT` | No | Auto-inferred from API key; only needed for multi-workspace setups |
+As of 6.0, managed-cloud mode points `nx` at a hosted nexus service that owns its cloud Postgres + pgvector and embeds with Voyage server-side. The client credentials are the service URL and a bearer token, read **from the environment** (not `nx config set` — these are not config-file credential keys):
 
-Set via `nx config init` (wizard) or `nx config set KEY VALUE`. Stored in `~/.config/nexus/config.yml`.
+| Env var | Required | Notes |
+|---|---|---|
+| `NX_SERVICE_URL` | No | Managed nexus service base URL. Defaults to `https://api.conexus-nexus.com`; override for a self-hosted or staging deployment. |
+| `NX_SERVICE_TOKEN` | Cloud mode | Bearer token for the managed service. |
+
+Export both in your shell profile or process manager. You do not supply a Voyage key in managed-cloud mode (the service owns it).
+
+### Migration-source credentials (pre-6.0 only)
+
+These ChromaDB Cloud keys are **not** used for live T3 serving in 6.0. They are read only when `nx guided-upgrade` / `nx migrate-to-service` needs to read an existing ChromaDB Cloud store as the migration source:
+
+| Config key | Env var | Notes |
+|---|---|---|
+| `chroma_api_key` | `CHROMA_API_KEY` | ChromaDB Cloud API key (migration source) |
+| `chroma_database` | `CHROMA_DATABASE` | ChromaDB Cloud database name, e.g. `nexus` (migration source) |
+| `chroma_tenant` | `CHROMA_TENANT` | Auto-inferred from the API key; only for multi-workspace setups |
 
 ## Semantic Scholar (Enrichment)
 
@@ -59,20 +69,20 @@ Set via `nx config init` (wizard) or `nx config set KEY VALUE`. Stored in `~/.co
 
 Used by `nx enrich bib` to fetch bibliographic metadata (year, venue, authors, citation count). Without the key, enrichment works but is ~50x slower due to rate limiting.
 
-**`chroma_database` is the database name.** Nexus connects to this single database on ChromaDB Cloud. All collection prefixes (`code__*`, `docs__*`, `rdr__*`, `knowledge__*`) coexist in it. Use `nx doctor` to check its status.
+The notes below apply only to a pre-6.0 ChromaDB Cloud store being read as a **migration source**. In 6.0 live T3 serving is the managed nexus service (`service_url` + `service_token` above); these no longer describe the active backend.
+
+**`chroma_database` is the database name** of the ChromaDB Cloud store the migration reads from. All collection prefixes (`code__*`, `docs__*`, `rdr__*`, `knowledge__*`) coexisted in it.
 
 **`chroma_tenant` is optional.** The ChromaDB `CloudClient` infers the tenant UUID directly from your API key. You only need to set it explicitly if you belong to multiple Chroma Cloud workspaces.
 
-**Database creation is automatic.** `nx config init` provisions the database on Chroma Cloud using your API key — no dashboard visit required. If provisioning fails (e.g., plan restrictions), create the database manually in the Chroma Cloud dashboard.
-
-**Single-database architecture.** RDR-037 (2026-03-14) consolidated the legacy four-database layout (`{base}_code` / `{base}_docs` / `{base}_rdr` / `{base}_knowledge`) into a single database with collection prefixes. The transitional auto-detect probe was retired in 4.14.2 once the migration window closed. Anyone still on the legacy layout should pin `conexus<4.14.2`, run the export documented in the 4.x.0 CHANGELOG entries, then upgrade.
+**Single-database architecture (history).** RDR-037 (2026-03-14) consolidated the legacy four-database layout (`{base}_code` / `{base}_docs` / `{base}_rdr` / `{base}_knowledge`) into a single database with collection prefixes. The transitional auto-detect probe was retired in 4.14.2 once the migration window closed.
 
 ## Settings
 
 | YAML path | Env var | Default | Description |
 |---|---|---|---|
 | `embeddings.rerankerModel` | `NX_EMBEDDINGS_RERANKER_MODEL` | `rerank-2.5` | Voyage reranker for multi-corpus merge |
-| `client.host` | `NX_CLIENT_HOST` | `localhost` | Override ChromaDB host URL |
+| `client.host` | `NX_CLIENT_HOST` | `localhost` | Legacy ChromaDB host override; no-op as of 6.0 (the managed/local service URL is `NX_SERVICE_URL`). |
 | `pdf.extractor` | — | `auto` | PDF extraction backend: `auto`, `docling`, or `mineru`. Set globally with `nx config set pdf.extractor=mineru` |
 | `pdf.mineru_server_url` | — | `http://127.0.0.1:8010` | MinerU API server URL. Auto-updated when `nx mineru start` binds a port |
 | `pdf.mineru_table_enable` | — | `false` | Enable table extraction in MinerU. Slower; use when PDFs contain structured tables |
@@ -129,7 +139,7 @@ Topic taxonomy settings. Topics are auto-discovered after `nx index repo`.
 ```yaml
 taxonomy:
   auto_label: true                       # Generate labels via claude -p --model haiku (default)
-  local_exclude_collections: ["code__*"] # Skip code collections in local mode (MiniLM is poor for code)
+  local_exclude_collections: ["code__*"] # Skip code collections in local mode (general-purpose local embeddings are poor for code)
   collection_prefixes: [docs, code, knowledge, rdr]  # Prefixes recognized by nx taxonomy validate-refs (RDR-081)
 ```
 
@@ -142,19 +152,24 @@ taxonomy:
 ## Daemon environment variables
 
 Since conexus 4.34.0 (RDR-120 storage substrate split), the CLI and
-MCP server route through the T2 and (local-mode) T3 daemons. The
-daemons publish their address via discovery files at
-`~/.config/nexus/t2_addr.<uid>` and `t3_addr.<uid>`; clients also
-honour these env-var overrides:
+MCP server route T2 through the T2 daemon. The daemon publishes its
+address via a discovery file at `~/.config/nexus/t2_addr.<uid>`; T3
+routes through the native nexus-service (`nx daemon service`, RDR-155),
+discovered via `~/.config/nexus/storage_service_addr.<uid>` and
+overridden with `NX_SERVICE_URL` (see [Managed-Cloud Credentials](#managed-cloud-credentials)).
+Clients honour these env-var overrides:
 
 | Variable | Effect | Default |
 |----------|--------|---------|
 | `NX_T2_ADDR` | TCP `host:port` for the T2 daemon (e.g. `host.docker.internal:55459`). Used by dev containers reaching the host's loopback. | discovery file |
 | `NX_T2_SOCK` | UDS path for the T2 daemon (Linux-only when bind-mounted from the host into a container). Mutually exclusive with `NX_T2_ADDR`. | discovery file |
-| `NX_T3_ADDR` | TCP `host:port` for the local-mode T3 daemon. Cloud-mode T3 ignores this. | discovery file |
-| `NX_LOCAL` | Force local-mode T3 (ONNX MiniLM) even when cloud credentials exist. Local mode requires the T3 daemon. | unset (cloud mode if credentials present) |
+| `NX_SERVICE_URL` | Full base URL of the nexus-service (T3 vectors over `/v1/vectors`). Used by dev containers and managed-cloud clients. | `storage_service_addr.<uid>` lease, then `https://api.conexus-nexus.com` |
+| `NX_SERVICE_TOKEN` | Bearer token for the nexus-service. | local: from `pg_credentials`; managed: user-supplied |
+| `NX_LOCAL` | Force local mode (local nexus-service, bge-768) even when cloud credentials exist. | unset (cloud mode if credentials present) |
 
-When all env vars are unset, the client falls back to the discovery
+> Note: the retired `nx daemon t3` ChromaDB path and its `NX_T3_ADDR` override no longer route T3 serving; T3 traffic goes to the nexus-service via `NX_SERVICE_URL`.
+
+When the T2 env vars are unset, the client falls back to the discovery
 file. If no daemon is reachable, the CLI raises
 `T2DaemonNotReachableError` with a hint to run
 `nx daemon t2 ensure-running` or `install --autostart`. See

--- a/docs/container-integration.md
+++ b/docs/container-integration.md
@@ -11,8 +11,10 @@ daemon model (RDR-120) makes shared SQLite state real across containers.
 > vector store (T3) no longer runs as a `nx daemon t3` ChromaDB process; it
 > serves through the native nexus-service over Postgres + pgvector in both local
 > and cloud mode. A container reaches it over loopback TCP to the host's service
-> using **`NX_SERVICE_HOST` / `NX_SERVICE_PORT` + `NX_SERVICE_TOKEN`** (the token
-> is now required), not `NX_T3_ADDR`. The T2-daemon transport guidance below is
+> using **`NX_SERVICE_URL` (a full base URL) + `NX_SERVICE_TOKEN`** (the token is
+> now required), not `NX_T3_ADDR`. (`NX_SERVICE_HOST` / `NX_SERVICE_PORT` are a
+> separate resolver for the T2 domain stores and catalog, not T3.) The T2-daemon
+> transport guidance below is
 > unchanged; the T3 sections have been updated accordingly.
 >
 > **This two-process shape is a waypoint, not the destination.** 6.0 migrated T3

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -106,10 +106,14 @@ See [architecture.md](architecture.md) for the full module map.
 
 ## Adding a T2 Domain Feature
 
-T2 is split into four domain stores under `src/nexus/db/t2/`:
-`memory_store.py`, `plan_library.py`, `catalog_taxonomy.py`, and
-`telemetry.py`. See [architecture.md § T2 Domain Stores](architecture.md#t2-domain-stores)
-for the map.
+T2 is split into eight domain stores under `src/nexus/db/t2/`:
+`memory_store.py`, `plan_library.py`, `catalog_taxonomy.py`,
+`telemetry.py`, `chash_index.py`, `document_aspects.py`,
+`aspect_extraction_queue.py`, and `document_highlights.py`. See
+[architecture.md § T2 Domain Stores](architecture.md#t2-domain-stores)
+for the map (note: `chash_index`, `taxonomy`, `document_aspects`, and
+`aspect_queue` are reached directly via their attributes, not through
+facade delegates).
 
 **Adding a method to an existing store** (the common case):
 
@@ -141,7 +145,9 @@ for the map.
 
 1. Create `src/nexus/db/t2/<your_domain>.py` with a store class that
    takes a `Path` and opens its own `sqlite3.Connection` in WAL mode
-   with `PRAGMA busy_timeout = 5000`.
+   with `PRAGMA busy_timeout = 30000` (the canonical serving value,
+   `nexus.db.t2._tuning.SERVING_BUSY_TIMEOUT_MS`, raised from 5000 in
+   RDR-129 B1).
 2. Add a `threading.Lock` on the store and guard every write with it.
 3. Add the store to `T2Database.__init__` in construction order
    (stores created later may depend on earlier ones — `CatalogTaxonomy`
@@ -256,22 +262,34 @@ Every step below is **required**. Missing any one of them has caused problems in
    Add a release entry. If there are no plugin-level changes, write:
    > Plugin version aligned with Nexus CLI X.Y.Z. No plugin-level functional changes.
 
-7. **Update `.claude-plugin/marketplace.json`**
-   Bump the `"version"` field in **both** the `nx` and `sn` plugin entries to match the new version.
-   Also update `conexus/.claude-plugin/plugin.json` and `sn/.claude-plugin/plugin.json` to match.
-   Claude Code uses each plugin's `plugin.json` version to decide whether to refresh the cache — forgetting either one leaves stale skills/agents running.
+7. **Bump every manifest in lock-step (CI enforces parity)**
+   All seven version surfaces must equal the new `X.Y.Z`, and **both** `source.ref` fields must become `vX.Y.Z`:
+   - `pyproject.toml` — `version`
+   - `mcpb/pyproject.toml` — `version`
+   - `mcpb/manifest.json` — `version`
+   - `.claude-plugin/marketplace.json` — both `plugins[].version` (nx + sn) **and both `plugins[].source.ref`** (the pinned tag that decouples installed users from main HEAD; CI test `TestMarketplaceVersion::test_marketplace_source_ref_matches_pyproject` enforces `source.ref == "v" + pyproject.version`)
+   - `conexus/.claude-plugin/plugin.json` — `version` (controls nx plugin cache refresh)
+   - `sn/.claude-plugin/plugin.json` — `version` (controls sn plugin cache refresh)
 
-8. **Commit all release artifacts directly to `main`**
+   Forgetting any one fails CI parity; forgetting `source.ref` ships a release that installed Claude Code users never receive.
+
+8. **Commit on a release branch and PR to `main`** (branch protection requires a PR; do NOT direct-push)
    ```bash
-   git add pyproject.toml uv.lock CHANGELOG.md conexus/CHANGELOG.md conexus/.claude-plugin/plugin.json sn/.claude-plugin/plugin.json .claude-plugin/marketplace.json docs/
-   git commit -m "chore: bump version to X.Y.Z"
-   git push
+   git checkout main && git pull && git checkout -b release/vX.Y.Z
+   git add pyproject.toml mcpb/pyproject.toml mcpb/manifest.json uv.lock \
+           CHANGELOG.md conexus/CHANGELOG.md \
+           conexus/.claude-plugin/plugin.json sn/.claude-plugin/plugin.json \
+           .claude-plugin/marketplace.json docs/
+   git commit -m "chore(release): conexus X.Y.Z"
+   git push -u origin release/vX.Y.Z
+   gh pr create --base main --title "release: conexus X.Y.Z"
    ```
-   Release version-bump commits go directly to `main` (not via PR) because the tag must point to `main`.
+   Wait for CI green, then `gh pr merge <N> --merge` (NOT `--squash` — preserves the release commit SHA). The tag in step 9 points at the merge commit. The human cuts the release; AI prepares the branch.
 
-9. **Tag and push — this triggers the full release pipeline**
+9. **Tag the merge commit and push — this triggers the full release pipeline**
    ```bash
-   git tag vX.Y.Z
+   git checkout main && git pull
+   git tag -a vX.Y.Z -m "conexus X.Y.Z" $(git rev-parse HEAD)
    git push origin vX.Y.Z
    ```
    The `release.yml` workflow:
@@ -297,10 +315,12 @@ Every step below is **required**. Missing any one of them has caused problems in
 | File | What to update |
 |------|----------------|
 | `pyproject.toml` | `version` field |
+| `mcpb/pyproject.toml` | `version` field |
+| `mcpb/manifest.json` | `version` field |
 | `uv.lock` | auto-updated by `uv sync` — **must be committed** |
 | `CHANGELOG.md` | move Unreleased → `[X.Y.Z]`, add empty Unreleased |
 | `conexus/CHANGELOG.md` | add `[X.Y.Z]` entry |
-| `.claude-plugin/marketplace.json` | bump `"version"` in both `nx` and `sn` plugin entries |
+| `.claude-plugin/marketplace.json` | bump both `plugins[].version` (nx + sn) **and both `plugins[].source.ref` to `vX.Y.Z`** (parity-tested) |
 | `conexus/.claude-plugin/plugin.json` | bump `"version"` to match — **controls nx cache refresh** |
 | `sn/.claude-plugin/plugin.json` | bump `"version"` to match — **controls sn cache refresh** |
 | `docs/cli-reference.md` | new/changed CLI flags and subcommands |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -234,7 +234,7 @@ The catalog tracks every indexed document and the relationships between them. It
 
 The enhanced `query` MCP tool uses catalog metadata for scoped search — `query(question="...", author="Fagin")` searches only that author's collections in a single call.
 
-If you use cloud mode (ChromaDB Cloud), add a git remote so the catalog survives disk loss:
+If you use managed-cloud mode (a hosted nexus service), add a git remote so the local catalog survives disk loss:
 
 ```bash
 cd ~/.config/nexus/catalog && git remote add origin git@github.com:you/nexus-catalog.git
@@ -268,32 +268,20 @@ claude --plugin-dir ./nx
 
 Local mode embeds with the on-device bge-768 ONNX model (768-dim) the service provisions; the bundled minilm-384 remains a zero-download fallback. The managed-cloud deployment embeds server-side with Voyage AI (1024d), cross-chunk context (CCE), and reranking.
 
-### 1. Create accounts
+In managed-cloud mode there is no local service and no local Postgres: `nx` talks HTTPS to a hosted nexus service that owns its cloud Postgres + pgvector and embeds with Voyage AI server-side. You do not create a ChromaDB Cloud account or supply a Voyage key yourself (the service owns it).
 
-| Service | Purpose | Free tier |
-|---------|---------|-----------|
-| [ChromaDB Cloud](https://trychroma.com) | Vector storage | Generous for individual use |
-| [Voyage AI](https://voyageai.com) | Embeddings | 200M tokens/month |
+### 1. Point nx at the managed service
 
-Both free tiers cover typical usage at no cost.
-
-### 2. Configure credentials
-
-Interactive wizard:
+Set the service endpoint and your bearer token in the environment:
 
 ```bash
-nx config init
+export NX_SERVICE_URL=https://api.conexus-nexus.com   # or your provider's URL
+export NX_SERVICE_TOKEN=<your-managed-service-token>
 ```
 
-Or set individually:
+`NX_SERVICE_URL` defaults to `https://api.conexus-nexus.com`, so a hosted user on the default deployment only needs `NX_SERVICE_TOKEN`. (These are read from the environment; persist them in your shell profile or your process manager.)
 
-```bash
-nx config set chroma_api_key sk-...
-nx config set chroma_database nexus
-nx config set voyage_api_key pa-...
-```
-
-### 3. Verify
+### 2. Verify
 
 ```bash
 nx doctor
@@ -301,7 +289,7 @@ nx doctor
 
 All items should show `✓`. Fix anything marked `✗` before proceeding.
 
-### 4. Index and search
+### 3. Index and search
 
 ```bash
 nx index repo .
@@ -351,11 +339,9 @@ uv tool install conexus --force --python 3.13   # use "conexus[local]" here if y
 
 Note: `uv tool upgrade` reuses the existing environment's Python — it won't switch from 3.14 to 3.13 automatically. You must use `--force --python 3.13` to rebuild the environment. Because `--force` rebuilds from scratch it drops optional extras, so re-include `[local]` (i.e. install `"conexus[local]"`) if you use the bge-768 embedder.
 
-**`nx doctor` reports credentials not set** — Expected for local mode. Only needed if you want cloud embeddings — run `nx config init`.
+**`nx doctor` reports credentials not set** — Expected for local mode. Only needed for managed-cloud mode — export `NX_SERVICE_URL` + `NX_SERVICE_TOKEN` in the environment.
 
-**Provisioning failed during `nx config init`** — If your ChromaDB plan restricts automatic database creation, create the database manually in the [dashboard](https://trychroma.com) using your `chroma_database` value as the name.
-
-**`nx index repo .` fails with "credentials not set"** — In cloud mode, indexing requires T3 credentials. Run `nx config init` first, or use local mode (no credentials needed).
+**`nx index repo .` fails with a service-auth error** — In managed-cloud mode, indexing requires a reachable service and a valid `NX_SERVICE_TOKEN`. Export the token (`export NX_SERVICE_TOKEN=…`) and confirm the endpoint with `nx doctor`, or use local mode (run `nx daemon service start`, no token needed).
 
 **`import voyageai` or Pydantic v1 error** — The tool is running under Python 3.14. Fix: `uv tool install conexus --force --python 3.13` (install 3.13 first with `uv python install 3.13` if needed; re-include `[local]` — `"conexus[local]"` — if you use the bge-768 embedder, since `--force` drops extras).
 

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -14,7 +14,7 @@ For **when to use which retrieval interface**, see [Querying Guide](querying-gui
 
 The `nexus` and `nexus-catalog` servers register automatically when you install the plugin (`/plugin install conexus@nexus-plugins`) or the `.mcpb` extension. No separate install.
 
-**Substrate dependency**: since conexus 4.34.0 (RDR-120), storage tools route through the T2 daemon (and the T3 daemon in local mode). The Claude Code plugin's SessionStart hook auto-spawns `nx daemon t2 ensure-running`; for a daemon that survives reboots independent of Claude Code, run `nx daemon t2 install --autostart` once. See [Container Integration](container-integration.md) for the multi-process / multi-host model.
+**Substrate dependency**: since conexus 4.34.0 (RDR-120), T2 storage tools route through the T2 daemon; since RDR-155, T3 storage/retrieval tools route through the native nexus-service (`nx daemon service`, Postgres 16 + pgvector), not a ChromaDB daemon. The Claude Code plugin's SessionStart hook auto-spawns `nx daemon t2 ensure-running`; for a daemon that survives reboots independent of Claude Code, run `nx daemon t2 install --autostart` once. The T3 service is a one-time `nx init --service` + `nx daemon service start`. See [Container Integration](container-integration.md) for the multi-process / multi-host model.
 
 ## `nexus` — retrieval + storage (26 tools)
 
@@ -28,7 +28,7 @@ Full tool names follow `mcp__plugin_conexus_nexus__<tool>`.
 | `query` | Document-level catalog-aware retrieval (scope by `author`, `content_type`, `subtree`, `follow_links`, `depth`). Link-aware + topic-aware ranking |
 | `store_put` | Write a document into a T3 collection. Fires post-store hooks: batch chain auto-assigns to nearest topic; document-grain chain enqueues aspect extraction on `knowledge__*` (RDR-089) |
 | `store_get` | Retrieve a document by id from a T3 collection |
-| `store_get_many` | Batch hydration: given N ids, return N contents (with `missing` for not-found). Handles 300+ ids beyond the ChromaDB quota |
+| `store_get_many` | Batch hydration: given N ids, return N contents (with `missing` for not-found). Handles 300+ ids beyond the per-request 300-record limit |
 | `store_list` | Paginate documents in a T3 collection |
 
 ### Memory (T2)

--- a/docs/migration/upgrading-to-4.34.md
+++ b/docs/migration/upgrading-to-4.34.md
@@ -1,5 +1,13 @@
 # Upgrading to conexus 4.34.x — RDR-120 storage substrate split
 
+> **Historical (pre-6.0).** This guide covers the 4.34.0 substrate split, when
+> local-mode T3 still ran as a `nx daemon t3` ChromaDB process. As of 6.0 that
+> T3 daemon is retired: T3 serves through the native nexus-service (Postgres 16
+> + pgvector). If you are upgrading to 6.0, ignore the `nx daemon t3` step below
+> and follow [Getting Started § Cloud mode](../getting-started.md#cloud-mode-optional)
+> + `nx init --service`, then run `nx guided-upgrade` (see the
+> [Migration Runbook](../migration-runbook.md)).
+
 **TL;DR — one new command after upgrading:**
 
 ```bash

--- a/docs/operations/t3-health.md
+++ b/docs/operations/t3-health.md
@@ -18,7 +18,7 @@ T3 has a collection that the catalog `collections` projection table doesn't know
 
 The catalog has a collection row, but T3 doesn't have a matching collection.
 
-**Cause**: a T3 collection was deleted (manual `nx collection delete`, or chromadb-side housekeeping) without going through `Catalog.supersede_collection`.
+**Cause**: a T3 collection was deleted (manual `nx collection delete`, or service-side / migration housekeeping) without going through `Catalog.supersede_collection`.
 
 **Action**: operator decision. If the documents that referenced this collection are still real, re-create the T3 collection by re-indexing the source files. If they're stale, either delete the catalog rows (`nx catalog delete <tumbler>`) or supersede the collection projection row to a known target via the manual Python snippet the doctor prints. There is no automated fix for this class because the right answer depends on whether the source data still exists.
 

--- a/docs/plan-centric-retrieval.md
+++ b/docs/plan-centric-retrieval.md
@@ -250,7 +250,7 @@ reference earlier output via `$stepK.<field>`.
 | `search` | `{ids, tumblers, distances, collections}` |
 | `query` | `{ids, tumblers, collections}` |
 | `traverse` | `{tumblers, ids, collections}` — walks the catalog link graph |
-| `store_get_many` | `{contents, missing}` — batch hydration past the ChromaDB 300-record cap |
+| `store_get_many` | `{contents, missing}` — batch hydration past the per-request 300-record cap |
 | `operator_extract` | schema-conforming dict (e.g. `{extractions: [...]}`) |
 | `operator_rank` | schema-conforming dict (e.g. `{ranked: [...]}`) |
 | `operator_compare` | schema-conforming dict |

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # Privacy Policy — Conexus
 
-_Effective: 2026-05-24_
+_Effective: 2026-06-20_
 
 Conexus is a self-hosted MCP server and Claude Code / Claude Desktop extension that indexes content on your machine and provides semantic search and persistent memory across Claude conversations. This policy describes what data Conexus handles, where it goes, and what is never collected.
 
@@ -8,9 +8,10 @@ Conexus is a self-hosted MCP server and Claude Code / Claude Desktop extension t
 
 All persistent data lives on the host machine running Conexus:
 
-- **Indexed content** — text from files you ask Conexus to index (`nx index repo`, `nx index pdf`), plus structured metadata (file paths, chunk identifiers, taxonomy assignments). Stored in:
-  - `~/.local/share/nexus/chroma/` (local mode — embeddings + chunk text)
-  - ChromaDB Cloud (cloud mode — only if you provide credentials)
+- **Indexed content** — text from files you ask Conexus to index (`nx index repo`, `nx index pdf`), plus structured metadata (file paths, chunk identifiers, taxonomy assignments). As of 6.0 the T3 vector store is the native nexus-service (Postgres 16 + pgvector). Stored in:
+  - the local nexus-service's Postgres cluster on disk (local mode — embeddings + chunk text, embedded server-side with bge-768)
+  - a managed nexus-service's Postgres (managed-cloud mode — only if you point Conexus at a hosted service)
+  - `~/.local/share/nexus/chroma/` (legacy ChromaDB store, read only as the migration source for `nx guided-upgrade`)
 - **Memory entries** — anything you (or an agent) writes via `nx memory put` or the `memory_put` MCP tool. Stored in `~/.config/nexus/memory.db` (SQLite, FTS5).
 - **Catalog** — document registry and typed-link graph. Stored in `~/.config/nexus/catalog/` (JSONL + SQLite cache).
 - **Session scratch** — ephemeral working notes shared across agents within a session. In-memory ChromaDB; wiped at session end.
@@ -20,11 +21,11 @@ All persistent data lives on the host machine running Conexus:
 ## 2. What Conexus sends to third parties
 
 **Local mode** (default — no credentials configured):
-Nothing leaves the machine. Embeddings are computed locally via ONNX MiniLM. All search runs against on-disk ChromaDB.
+Nothing leaves the machine. Embeddings are computed locally by the on-machine nexus-service (bge-768 ONNX), and search runs against the local on-disk Postgres + pgvector store.
 
-**Cloud mode** (you opt in by providing API keys):
-- **Voyage AI** — chunk text is sent to Voyage's embedding API for indexing and to embed query strings at search time. See https://www.voyageai.com/privacy.
-- **ChromaDB Cloud** — embeddings + chunk text are stored in your ChromaDB Cloud tenant for retrieval. See https://www.trychroma.com/privacy.
+**Managed-cloud mode** (you opt in by pointing Conexus at a hosted nexus-service):
+- **The managed nexus-service** — chunk text + embeddings are stored in the managed service's Postgres for retrieval, under that service operator's policy. Your data leaves your machine for whoever hosts the service.
+- **Voyage AI** — in managed-cloud mode the service embeds chunk text and query strings with Voyage's API server-side. See https://www.voyageai.com/privacy.
 - **Semantic Scholar** (only when you run `nx enrich bib`) — bibliographic metadata lookups for PDFs you ask Conexus to enrich. See https://www.semanticscholar.org/about/privacy.
 - **Anthropic Claude** (only when an MCP operator tool fires) — chunks passed to `claude -p` subprocesses run by `operator_*` / `nx_answer` / `nx_tidy` are sent to Anthropic's API per Anthropic's standard data policy.
 
@@ -40,7 +41,7 @@ You control which (if any) of the above are reachable by deciding whether to set
 ## 4. Data retention
 
 - Local-mode data persists on disk until you delete it. There is no automatic purge of T2 memory (`nx memory delete`), T3 collections (`nx store delete`), or the catalog (`nx catalog gc`).
-- Cloud-mode data persists in your ChromaDB Cloud tenant under your account's retention policy.
+- Managed-cloud data persists in the hosted nexus-service's Postgres under that service operator's retention policy.
 - T1 session scratch is wiped automatically when the host process exits.
 
 ## 5. Data export and deletion

--- a/docs/querying-guide.md
+++ b/docs/querying-guide.md
@@ -91,7 +91,7 @@ query(question="database design", follow_links="cites", depth=1)  # + citation g
 | `follow_links` | string | Link type to follow (e.g., `cites`) — enriches with linked documents |
 | `depth` | integer | Hops to follow in the link graph (default 1) |
 | `n` | integer | Maximum results (default 10) |
-| `where` | string | ChromaDB metadata filter |
+| `where` | string | Vector-store metadata filter (e.g. `bib_year>=2020,section_type!=references`) |
 
 ### How catalog routing works
 
@@ -199,6 +199,8 @@ Several mechanisms run automatically across all interfaces.
 
 ### Topic-aware ranking
 
+> **Note (6.0):** Topic *discovery* is suspended in service mode (the default since 6.0) — `nx taxonomy discover` errors and `nx index repo` skips discovery, pending the pgvector follow-on (`nexus-gmiaf.21+`). Ranking against **previously-computed** topics (`topic=`, `cluster_by="semantic"`, distance boosts) still works; only the discovery of new topics is paused.
+
 After `nx index repo` (or `nx taxonomy discover --all`), topics are clustered via HDBSCAN with Claude-Haiku auto-labels. Topic-aware ranking then works three ways:
 
 - **Topic boost** — results sharing a topic cluster get a distance reduction of 0.1; results in adjacent linked topics get 0.05. Automatic on `search` and `query`.
@@ -235,7 +237,7 @@ Knowledge, docs, and RDR collections fetch 4x the requested result count before 
 
 ### Catalog pre-filtering
 
-When metadata filters have high selectivity (<5% of documents match), Nexus pre-fetches matching file paths from the catalog SQLite database and passes them as a `source_path` filter to ChromaDB. Avoids HNSW/SPANN stalling in predicate-sparse graph regions. Automatic when a catalog is available.
+When metadata filters have high selectivity (<5% of documents match), Nexus pre-fetches matching file paths from the catalog SQLite database and passes them as a `source_path` filter to the vector store. This reduces the scan space before retrieval, avoiding the latency cliff an ANN index hits in predicate-sparse regions. Automatic when a catalog is available.
 
 ### Multi-probe collection health
 

--- a/docs/repo-indexing.md
+++ b/docs/repo-indexing.md
@@ -42,16 +42,16 @@ Classification is overridable via `.nexus.yml` (see [Per-Repo Configuration](#ne
 
 ## Dual-Collection Architecture
 
-Each indexed repository produces two T3 collections (local ONNX or cloud Voyage AI):
+Each indexed repository produces two T3 collections. Embedding happens server-side in the nexus-service (local mode: bge-768; managed-cloud: Voyage AI):
 
-| Collection | Cloud Index Model | Cloud Query Model | Contents |
+| Collection | Managed-cloud model | Local model | Contents |
 |---|---|---|---|
-| `code__<name>-<hash8>` | `voyage-code-3` | `voyage-code-3` | Code files |
-| `docs__<name>-<hash8>` | `voyage-context-3` (CCE) | `voyage-context-3` | Prose + PDF files |
+| `code__<name>-<hash8>` | `voyage-code-3` | `bge-768` | Code files |
+| `docs__<name>-<hash8>` | `voyage-context-3` (CCE) | `bge-768` | Prose + PDF files |
 
 `<name>` is the repository basename; `<hash8>` is the first 8 hex characters of the
 SHA-256 digest of the main repository path. Long basenames are truncated to stay within
-ChromaDB's 63-character collection name limit. Collection names are **stable across git
+the 63-character collection name limit (a nexus naming-convention constraint). Collection names are **stable across git
 worktrees** — `git rev-parse --git-common-dir` resolves to the shared `.git` directory,
 so a worktree and its parent produce identical collection names.
 
@@ -113,8 +113,8 @@ Individual lines exceeding the byte limit (12 KB) are pre-split at natural code 
 ### Context Prefix Injection (Embed-Only)
 
 Each code chunk's **embedded text** is prefixed with a one-line context header identifying
-the file, class, method, and line range. The raw chunk text is stored in ChromaDB unchanged
-— the prefix affects only the Voyage AI embedding call, not stored documents or search previews.
+the file, class, method, and line range. The raw chunk text is stored in the T3 vector store unchanged
+— the prefix affects only the server-side embedding call, not stored documents or search previews.
 
 ```
 // File: art-modules/art-core/src/FuzzyART.java  Class: FuzzyART  Method: computeMatch  Lines: 200–350
@@ -239,8 +239,9 @@ Run `nx index repo --force` once to stamp them.
 
 ## Transient Error Resilience
 
-All ChromaDB Cloud network calls (staleness checks, upserts, deletes, queries) are wrapped
-with `_chroma_with_retry` — an exponential backoff helper in `retry.py`. If a call raises a
+All nexus-service network calls (staleness checks, upserts, deletes, queries) are wrapped
+with `_chroma_with_retry` — an exponential backoff helper in `retry.py` (the name is
+historical; it now wraps the `/v1/vectors` HTTP calls to the service). If a call raises a
 transient error (HTTP 502/503/504/429, or a transport-level error such as `ConnectError` or
 `ReadTimeout`), it is retried up to 5 times with delays of 2 → 4 → 8 → 16 → 30 s (capped).
 Non-retryable errors (400, 401, 403, 404) raise immediately without retry.
@@ -249,9 +250,10 @@ Each retry attempt is logged at WARNING level with the event key
 `chroma_transient_error_retry`. After 5 failed attempts the original exception propagates
 and the indexing job fails fast.
 
-This means a single transient 504 from the ChromaDB Cloud gateway no longer aborts a
+This means a single transient 504 from the nexus-service endpoint no longer aborts a
 multi-thousand-file indexing run. See [RDR-019](rdr/rdr-019-chromadb-transient-retry.md)
-for the full decision record.
+for the original (ChromaDB-era) decision record; the retry mechanism was carried forward to
+the service path.
 
 ## Catalog Registration
 
@@ -261,11 +263,22 @@ This means `nx catalog search` and `nx catalog links` work immediately after ind
 
 ## Taxonomy Auto-Discovery
 
+> **Note (6.0):** Taxonomy *discovery* is temporarily suspended while the
+> nexus-service is the T3 backend (service mode, the default since 6.0).
+> Discovery reads embeddings through a raw Chroma client that retired with the
+> Chroma serving paths (RDR-155 P4a); it is a tracked follow-on
+> (`nexus-gmiaf.21+`). In practice: `nx index repo` produces no new topics
+> (the discovery step is skipped silently), and `nx taxonomy discover` exits
+> with a clear error. Search features that read **previously-computed**
+> taxonomy (`topic=`, `cluster_by="semantic"`, topic boosts) continue to work.
+> The behavior described below is the pre-6.0 model and the target once
+> discovery is restored on the pgvector service.
+
 After indexing completes, `nx index repo` automatically runs topic discovery on the new or updated collections. HDBSCAN clusters the collection's embeddings to find natural topic groupings, and each cluster is labeled with a short descriptive phrase using Claude Haiku (when an Anthropic API key is available). The results are stored in T2 and surfaced by `nx search` as topic filters.
 
 To skip this step, pass `--no-taxonomy`. This is useful for fast incremental updates or in CI pipelines where the additional API calls are not wanted.
 
-In **local mode** (ONNX MiniLM embeddings), code collections are excluded from taxonomy discovery by default — MiniLM's 384-dimension general-purpose embeddings produce poorly separated clusters on code. Prose, RDR, and knowledge collections are still discovered. In **cloud mode** (Voyage AI), all collection types including code are included, since `voyage-code-3` embeddings produce well-separated clusters.
+In **local mode** (bge-768 ONNX embeddings, embedded server-side by the nexus-service), code collections are excluded from taxonomy discovery by default — general-purpose embeddings produce poorly separated clusters on code. Prose, RDR, and knowledge collections are still discovered. In **managed-cloud mode** (Voyage AI), all collection types including code are included, since `voyage-code-3` embeddings produce well-separated clusters.
 
 ## Searching Indexed Repos
 


### PR DESCRIPTION
Holistic substantive-critic audit of the **entire** user-facing doc surface (not just the 9 docs iter1–3 touched) found the remainder still presented ChromaDB as the live T3 backend. This remediates **8 Critical + 13 Significant** findings across 15 docs, plus a privacy-policy.md miss the inverse-grep sweep caught.

Bead: `nexus-6xi0f` (under release-N gate `nexus-y5avl`).

## What was wrong
Every doc the iter1–3 arc did not touch was written when "cloud mode = ChromaDB Cloud" and "local mode = MiniLM-on-Chroma-daemon". Since RDR-155, `make_t3()` returns `HttpVectorClient` unconditionally (pgvector via the native nexus-service, server-side bge-768/Voyage), so those docs handed users a wrong model for setup, troubleshooting, and durability.

## Highlights
- **Onboarding (getting-started, configuration):** managed-cloud setup rewritten from ChromaDB-Cloud accounts to `NX_SERVICE_URL`/`NX_SERVICE_TOKEN` (env-read — these are **not** `nx config set` keys), Chroma keys scoped to migration source.
- **Reference (mcp-servers, cli-reference, contributing):** T3-daemon dependency, `nx t3 (ChromaDB)` header, `nx doctor` cred checks, `nx collection rename` framing; contributing fixed 4→8 domain stores, `busy_timeout` 5000→30000, release step 8 direct-push→PR-to-main, 7-manifest + `source.ref` checklist.
- **Feature/usage (repo-indexing, catalog, querying-guide):** ChromaDB-Cloud gateway + MiniLM→bge-768; added the **taxonomy-discovery-suspended-in-service-mode** note (`nexus-gmiaf.21+`) where users hit it — a real functional gap no doc warned about.
- **privacy-policy.md:** data-flow facts corrected (local PG+pgvector / managed service operator + Voyage server-side).

## Gate
Two-pass substantive-critic, code-grounded. First pass found the 21 issues; after fixing, a second pass caught two NEW introduced errors (`nx config set service_url/token` are not valid keys → env export; `marketplace.json` has no `metadata.version`), corrected before this PR. Inverse-grep sweep across the surface is clean. Prep only — does not cut a release (`nexus-luxe6` open).

Bead: nexus-6xi0f