### PR TITLE
feat(taxonomy): restore discover/rebuild/assignment on the pgvector service (nexus-7ydks)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -277,7 +277,7 @@ Pre-existing drift surfaced during Phase 5 verification (filed as separate beads
 
 Taxonomy (RDR-070) builds a topic hierarchy over T3 collections using existing embeddings, without re-embedding. HDBSCAN clusters the vectors already stored in ChromaDB, labels them with c-TF-IDF, and persists topic assignments to T2 SQLite. Every subsequent `store_put` call assigns the new document to the nearest centroid via ANN lookup. Search then uses these assignments to boost same-topic results and group output.
 
-In local mode, `code__*` collections are excluded by default because the general-purpose local embedder (bge-768) clusters code poorly. Cloud mode uses `voyage-code-3` and is unaffected. (Note: as of 6.0, taxonomy discovery is suspended while the nexus-service is the T3 backend; see the taxonomy command docs.)
+In local mode, `code__*` collections are excluded by default because the general-purpose local embedder (bge-768) clusters code poorly. Cloud mode uses `voyage-code-3` and is unaffected. (As of 6.0, discovery/rebuild/assignment run on the nexus-service backend per nexus-7ydks; `nx taxonomy split`/`project` are still being ported.)
 
 ### Data Flow
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -241,13 +241,11 @@ taxonomy:
 
 ### How it works
 
-> **Note (6.0):** Taxonomy *discovery* is suspended in service mode (the default
-> since 6.0): `nx taxonomy discover` exits with a clear error and `nx index repo`
-> skips the discovery step. Discovery needs a raw Chroma client retired with the
-> Chroma serving paths (RDR-155 P4a); restoring it on the pgvector service is a
-> tracked follow-on (`nexus-gmiaf.21+`). Previously-computed assignments still
-> drive search boosts and `topic=` scoping. The flow below is the pre-6.0 model
-> and the target once discovery is restored.
+> **Note (6.0):** Taxonomy *discovery*, *rebuild*, and per-document *assignment*
+> run on the nexus-service backend (the default since 6.0): embeddings are read
+> server-side and topics + centroids persist through the service (nexus-7ydks).
+> Still being ported (`nexus-7ydks`): `nx taxonomy split` / `project` and the
+> automatic cross-collection projection pass refuse cleanly on the service.
 
 After `nx index repo` (or `nx taxonomy discover --all`):
 

--- a/docs/querying-guide.md
+++ b/docs/querying-guide.md
@@ -199,7 +199,7 @@ Several mechanisms run automatically across all interfaces.
 
 ### Topic-aware ranking
 
-> **Note (6.0):** Topic *discovery* is suspended in service mode (the default since 6.0) — `nx taxonomy discover` errors and `nx index repo` skips discovery, pending the pgvector follow-on (`nexus-gmiaf.21+`). Ranking against **previously-computed** topics (`topic=`, `cluster_by="semantic"`, distance boosts) still works; only the discovery of new topics is paused.
+> **Note (6.0):** Topic *discovery*, *rebuild*, and per-document *assignment* run on the nexus-service backend (the default since 6.0) — `nx taxonomy discover` and `nx index repo` work normally (nexus-7ydks). `nx taxonomy split` / `project` and the cross-collection projection pass are still being ported and refuse cleanly on the service.
 
 After `nx index repo` (or `nx taxonomy discover --all`), topics are clustered via HDBSCAN with Claude-Haiku auto-labels. Topic-aware ranking then works three ways:
 

--- a/docs/repo-indexing.md
+++ b/docs/repo-indexing.md
@@ -263,16 +263,13 @@ This means `nx catalog search` and `nx catalog links` work immediately after ind
 
 ## Taxonomy Auto-Discovery
 
-> **Note (6.0):** Taxonomy *discovery* is temporarily suspended while the
-> nexus-service is the T3 backend (service mode, the default since 6.0).
-> Discovery reads embeddings through a raw Chroma client that retired with the
-> Chroma serving paths (RDR-155 P4a); it is a tracked follow-on
-> (`nexus-gmiaf.21+`). In practice: `nx index repo` produces no new topics
-> (the discovery step is skipped silently), and `nx taxonomy discover` exits
-> with a clear error. Search features that read **previously-computed**
-> taxonomy (`topic=`, `cluster_by="semantic"`, topic boosts) continue to work.
-> The behavior described below is the pre-6.0 model and the target once
-> discovery is restored on the pgvector service.
+> **Note (6.0):** Taxonomy *discovery*, *rebuild*, and per-document
+> *assignment* run on the nexus-service backend (service mode, the default
+> since 6.0): they fetch embeddings server-side and persist topics + centroids
+> through the service (nexus-7ydks). `nx index repo` discovers and assigns
+> normally. Two operations are still being ported (`nexus-7ydks`): `nx taxonomy
+> split` / `project` and the automatic cross-collection projection pass — they
+> remain raw-Chroma-only and refuse cleanly on the service.
 
 After indexing completes, `nx index repo` automatically runs topic discovery on the new or updated collections. HDBSCAN clusters the collection's embeddings to find natural topic groupings, and each cluster is labeled with a short descriptive phrase using Claude Haiku (when an Anthropic API key is available). The results are stored in T2 and surfaced by `nx search` as topic filters.
 

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -198,7 +198,13 @@ def _discover_taxonomy(collection_name, taxonomy, t3, *, force=False):
     nexus-7ydks: now takes the T3 handle (``T3Database`` raw or
     ``HttpVectorClient`` service), not the raw ``_client``.
     """
-    from nexus.commands.taxonomy_cmd import discover_for_collection
+    from nexus.commands.taxonomy_cmd import (
+        _require_supported_taxonomy_backend,
+        discover_for_collection,
+    )
+    # nexus-7ydks S1: close the split-backend hole on the post-index path too
+    # (discover_cmd/rebuild_cmd already guard; this shared wrapper did not).
+    _require_supported_taxonomy_backend(t3, taxonomy)
     return discover_for_collection(
         collection_name, taxonomy, t3, force=force,
     )

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -192,11 +192,15 @@ def index() -> None:
         )
 
 
-def _discover_taxonomy(collection_name, taxonomy, chroma_client, *, force=False):
-    """Wrapper for discover_for_collection — importable for patching in tests."""
+def _discover_taxonomy(collection_name, taxonomy, t3, *, force=False):
+    """Wrapper for discover_for_collection — importable for patching in tests.
+
+    nexus-7ydks: now takes the T3 handle (``T3Database`` raw or
+    ``HttpVectorClient`` service), not the raw ``_client``.
+    """
     from nexus.commands.taxonomy_cmd import discover_for_collection
     return discover_for_collection(
-        collection_name, taxonomy, chroma_client, force=force,
+        collection_name, taxonomy, t3, force=force,
     )
 
 
@@ -750,7 +754,7 @@ def run_collection_postprocessing(
         with T2Database(default_db_path()) as db:  # epsilon-allow: read-only: discover/project compute use a local chroma client; all pure-T2 writes routed via t2_index_write (RDR-151 Phase 3, nexus-uzay8)
             for col_name in collections:
                 try:
-                    n = _discover_taxonomy(col_name, db.taxonomy, t3._client)
+                    n = _discover_taxonomy(col_name, db.taxonomy, t3)
                     total_topics += n
                 except Exception:
                     _log.debug("taxonomy_discover_failed", collection=col_name, exc_info=True)

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -156,6 +156,11 @@ def _fetch_service_vectors(
             break
 
     _progress(f"    fetched {len(ids):,} chunks")
+    # Positional-alignment assumption (nexus-7ydks S2): get_embeddings returns
+    # rows in request order (documented contract, http_vector_client.py), so
+    # embeddings[i] pairs with ids[i]/texts[i]. The count-equality check below
+    # is the tripwire; if the service ever returned an id->vector MAP instead,
+    # this would need a by-id realign rather than the positional zip.
     embeddings = t3.get_embeddings(collection_name, ids)
     if embeddings is None or len(embeddings) != len(ids):
         # get_embeddings drops ids the service cannot resolve (N < len(ids)),

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -180,7 +180,8 @@ def _discover_via_service(
     collection_name: str, taxonomy: Any, t3: Any, *, force: bool,
 ) -> int:
     """Service-backed discovery: fetch vectors from the service, persist through
-    the HttpTaxonomyStore drop-in (centroids via the taxonomy port).
+    the HttpTaxonomyStore drop-in (centroids via the service's
+    ``/v1/taxonomy/centroids`` HTTP route).
 
     nexus-7ydks. The store's ``discover_topics`` / ``rebuild_taxonomy`` are
     complete CatalogTaxonomy mirrors and persist through the Java service (the
@@ -251,7 +252,8 @@ def discover_for_collection(
         Number of topics created.
     """
     # nexus-7ydks: service-backed taxonomy store → fetch from the service and
-    # persist through the HttpTaxonomyStore drop-in (centroids via the port).
+    # persist through the HttpTaxonomyStore drop-in (centroids via the service's
+    # /v1/taxonomy/centroids HTTP route).
     if not _has_raw_access(taxonomy):
         return _discover_via_service(collection_name, taxonomy, t3, force=force)
 

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -48,21 +48,150 @@ _log = structlog.get_logger(__name__)
 def _reject_service_backed_handle(t3: Any) -> None:
     """Fail loud when the T3 handle has no raw Chroma client.
 
-    RDR-155 P4a.2 (nexus-1k8s1): taxonomy discovery reads embeddings through
-    the raw Chroma client, which retired with the Chroma serving paths —
-    ``make_t3()`` returns the service-backed handle in production now.
-    Taxonomy on the pgvector service is a tracked follow-on
-    (nexus-gmiaf.21+); until it lands this command refuses cleanly instead
-    of surfacing an AttributeError.
+    Retained for the taxonomy paths NOT yet ported to the service
+    (``nx taxonomy split`` / ``project``): their bodies still cluster + write
+    centroids through a raw Chroma client. ``nx taxonomy discover`` / ``rebuild``
+    ARE ported (nexus-7ydks) and instead use
+    :func:`_require_supported_taxonomy_backend`, so do not add this guard there.
     """
     from nexus.db.http_vector_client import is_service_backed
 
     if is_service_backed(t3):
         raise click.ClickException(
-            "taxonomy discovery needs a raw Chroma client, which retired with "
-            "the Chroma serving paths (RDR-155 Phase 4a). Taxonomy on the "
-            "pgvector service is a tracked follow-on (nexus-gmiaf.21+)."
+            "this taxonomy operation needs a raw Chroma client, which retired "
+            "with the Chroma serving paths (RDR-155 Phase 4a). `nx taxonomy "
+            "discover` and `rebuild` are supported on the service; split / "
+            "project on the pgvector service are a tracked follow-on "
+            "(nexus-7ydks)."
         )
+
+
+def _require_supported_taxonomy_backend(t3: Any, taxonomy: Any) -> None:
+    """Block only the unsupported split: service T3 + raw-SQLite taxonomy.
+
+    nexus-7ydks. Supported: both service-backed (6.0 default) or both raw
+    (legacy / ``NX_STORAGE_BACKEND=sqlite``). The split case has no raw Chroma
+    client for the legacy centroid path, so refuse cleanly.
+    """
+    from nexus.db.http_vector_client import is_service_backed
+
+    if is_service_backed(t3) and _has_raw_access(taxonomy):
+        raise click.ClickException(
+            "taxonomy discovery is not supported with a service-backed T3 vector "
+            "store but a raw-SQLite taxonomy store (NX_STORAGE_BACKEND_TAXONOMY="
+            "sqlite). Use a uniform backend: either let both default to the "
+            "service, or set NX_STORAGE_BACKEND=sqlite for both."
+        )
+
+
+def _enumerate_discoverable_collections(t3: Any, exclude: list[str]) -> list[str]:
+    """Return collection names with >=5 chunks, skipping excludes + taxonomy__.
+
+    Backend-uniform: raw T3 exposes ``_client.list_collections()`` (Chroma
+    Collection objects); service T3 exposes ``list_collections()`` (list of
+    dicts with ``name``/``count``). nexus-7ydks.
+    """
+    from fnmatch import fnmatch
+
+    from nexus.db.http_vector_client import is_service_backed
+
+    names: list[tuple[str, int]] = []
+    if is_service_backed(t3):
+        for c in t3.list_collections():
+            names.append((c.get("name", ""), int(c.get("count", 0) or 0)))
+    else:
+        for c in t3._client.list_collections():
+            names.append((c.name, c.count()))
+    return [
+        name for name, count in names
+        if count >= 5
+        and name
+        and not name.startswith("taxonomy__")
+        and not any(fnmatch(name, pat) for pat in exclude)
+    ]
+
+
+def _fetch_service_vectors(
+    collection_name: str, t3: Any,
+) -> tuple[list[str], list[str], "np.ndarray"] | None:
+    """Fetch (doc_ids, texts, embeddings) for a collection via the nexus-service.
+
+    nexus-7ydks. Enumerates ids + documents through the service collection
+    stub's paginated ``get`` and pulls the stored embeddings server-side via
+    ``t3.get_embeddings`` (no re-embed). Returns ``None`` on a fatal fetch
+    problem (collection missing, or embeddings the service could not align to
+    the requested ids — which would silently corrupt clustering).
+    """
+    try:
+        n = t3.count(collection_name)
+    except Exception:
+        _log.warning("taxonomy_service_count_failed", collection=collection_name)
+        return None
+    if n < 5:
+        return [], [], np.empty((0, 0), dtype=np.float32)
+
+    stub = t3.get_or_create_collection(collection_name)
+    ids: list[str] = []
+    texts: list[str] = []
+    offset = 0
+    page_size = 250  # service quota: Get limit 300
+    _milestone = max(n // 4, 1)
+    _next = _milestone
+    while offset < n:
+        if offset >= _next and _next < n:
+            _progress(f"    fetching {offset:,}/{n:,} chunks ({100 * offset // n}%)")
+            _next += _milestone
+        page = stub.get(include=["documents"], limit=page_size, offset=offset)
+        page_ids = page.get("ids") or []
+        page_docs = page.get("documents") or []
+        if not page_ids:
+            break
+        for i, pid in enumerate(page_ids):
+            doc = page_docs[i] if i < len(page_docs) else None
+            if doc is not None:
+                ids.append(pid)
+                texts.append(doc)
+        offset += len(page_ids)
+        if len(page_ids) < page_size:
+            break
+
+    _progress(f"    fetched {len(ids):,} chunks")
+    embeddings = t3.get_embeddings(collection_name, ids)
+    if embeddings is None or len(embeddings) != len(ids):
+        # get_embeddings drops ids the service cannot resolve (N < len(ids)),
+        # which would desync ids/texts/embeddings. Refuse rather than cluster
+        # misaligned rows (feedback_no_silent_fallbacks_for_correctness).
+        _log.warning(
+            "taxonomy_service_embedding_misalign",
+            collection=collection_name,
+            ids=len(ids),
+            embeddings=0 if embeddings is None else len(embeddings),
+        )
+        return None
+    return ids, texts, np.asarray(embeddings, dtype=np.float32)
+
+
+def _discover_via_service(
+    collection_name: str, taxonomy: Any, t3: Any, *, force: bool,
+) -> int:
+    """Service-backed discovery: fetch vectors from the service, persist through
+    the HttpTaxonomyStore drop-in (centroids via the taxonomy port).
+
+    nexus-7ydks. The store's ``discover_topics`` / ``rebuild_taxonomy`` are
+    complete CatalogTaxonomy mirrors and persist through the Java service (the
+    single writer), so no daemon-routed split is needed here.
+    """
+    fetched = _fetch_service_vectors(collection_name, t3)
+    if fetched is None:
+        return 0
+    doc_ids, texts, embeddings = fetched
+    if len(doc_ids) < 5:
+        _log.info("too_few_docs", collection=collection_name, n=len(doc_ids))
+        return 0
+    _progress(f"    clustering {len(doc_ids):,} x {embeddings.shape[1]}d (service)...")
+    if force:
+        return taxonomy.rebuild_taxonomy(collection_name, doc_ids, embeddings, texts)
+    return taxonomy.discover_topics(collection_name, doc_ids, embeddings, texts)
 
 
 def _progress(msg: str) -> None:
@@ -82,7 +211,7 @@ def _progress(msg: str) -> None:
 def discover_for_collection(
     collection_name: str,
     taxonomy: "CatalogTaxonomy",
-    chroma_client: Any,
+    t3: Any,
     *,
     force: bool = False,
 ) -> int:
@@ -102,9 +231,11 @@ def discover_for_collection(
     collection_name:
         ChromaDB collection to discover topics for.
     taxonomy:
-        :class:`CatalogTaxonomy` instance (owns T2 topic tables).
-    chroma_client:
-        Raw ``chromadb.ClientAPI`` (not ``T3Database``).
+        :class:`CatalogTaxonomy` (raw) or ``HttpTaxonomyStore`` (service).
+    t3:
+        The T3 handle (``T3Database`` raw, or ``HttpVectorClient`` service).
+        nexus-7ydks: service-backed handles route through
+        :func:`_discover_via_service`; raw handles use ``t3._client``.
     force:
         If True, delete existing topics for this collection before
         re-discovering (calls ``rebuild_taxonomy``).
@@ -114,6 +245,15 @@ def discover_for_collection(
     int
         Number of topics created.
     """
+    # nexus-7ydks: service-backed taxonomy store → fetch from the service and
+    # persist through the HttpTaxonomyStore drop-in (centroids via the port).
+    if not _has_raw_access(taxonomy):
+        return _discover_via_service(collection_name, taxonomy, t3, force=force)
+
+    # Raw path (unchanged): daemon-routed persist (RDR-128/151) over a raw
+    # Chroma client. Accept either a ``T3Database`` handle (use ``._client``)
+    # or a raw chroma client passed directly (programmatic / test callers).
+    chroma_client = getattr(t3, "_client", t3)
     try:
         coll = chroma_client.get_collection(
             collection_name, embedding_function=None,
@@ -549,16 +689,11 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
         if is_local_mode() else []
     )
     t3 = make_t3()
-    _reject_service_backed_handle(t3)
 
     if discover_all:
-        colls = t3._client.list_collections()
-        targets = [
-            c.name for c in colls
-            if c.count() >= 5
-            and not any(fnmatch(c.name, pat) for pat in exclude)
-            and not c.name.startswith("taxonomy__")
-        ]
+        # Backend-support is checked per-collection inside the loop below
+        # (authoritative); enumeration itself needs no taxonomy handle.
+        targets = _enumerate_discoverable_collections(t3, exclude)
         if not targets:
             click.echo("No eligible collections found.")
             return
@@ -580,8 +715,9 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
         for i, col_name in enumerate(targets, 1):
             if len(targets) > 1:
                 click.echo(f"[{i}/{len(targets)}] {col_name}")
+            _require_supported_taxonomy_backend(t3, db.taxonomy)
             count = discover_for_collection(
-                col_name, db.taxonomy, t3._client, force=force,
+                col_name, db.taxonomy, t3, force=force,
             )
             if count:
                 click.echo(f"  {col_name}: {count} topics")
@@ -597,8 +733,17 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
             else:
                 click.echo(f"  {col_name}: skipped")
 
-        # Cross-collection projection pass (RDR-075 SC-7)
-        if total_topics and len(targets) > 1:
+        # Cross-collection projection pass (RDR-075 SC-7).
+        # nexus-7ydks: project_against still uses a raw Chroma client (not yet
+        # ported to the service), so skip it LOUDLY in service mode rather than
+        # AttributeError on t3._client and swallow it as a generic failure.
+        from nexus.db.http_vector_client import is_service_backed
+        if total_topics and len(targets) > 1 and is_service_backed(t3):
+            click.echo(
+                "  Projection: skipped (cross-collection projection on the "
+                "pgvector service is a tracked follow-on, nexus-7ydks)"
+            )
+        elif total_topics and len(targets) > 1:
             try:
                 proj_count = 0
                 for col_name in targets:
@@ -661,9 +806,9 @@ def rebuild_cmd(collection: str, project: str, k: int | None) -> None:
 
     with _T2Database(_default_db_path()) as db:
         t3 = make_t3()
-        _reject_service_backed_handle(t3)
+        _require_supported_taxonomy_backend(t3, db.taxonomy)
         count = discover_for_collection(
-            collection, db.taxonomy, t3._client, force=True,
+            collection, db.taxonomy, t3, force=True,
         )
     click.echo(f"Rebuilt {count} topics for collection {collection!r}.")
 

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -681,13 +681,50 @@ def taxonomy_assign_batch_hook(
     # unconditionally while tests inject chroma-backed T3Database fixtures.
     from nexus.db.http_vector_client import is_service_backed
     if is_service_backed(get_t3()):
-        import structlog
-        structlog.get_logger().info(
-            "taxonomy_assign_skipped_service_mode",
-            collection=collection,
-            doc_count=len(doc_ids),
-            note="taxonomy-via-chroma not supported on service backend; tracked in nexus-gmiaf.21+",
-        )
+        # nexus-7ydks: service-backed incremental assignment. Mirrors the raw
+        # path below (compute same + cross, one persist) but persists through
+        # the Java service via the HttpTaxonomyStore drop-in — no raw Chroma
+        # client, no daemon-routed SQLite write.
+        if is_local_mode():
+            exclude = load_config().get("taxonomy", {}).get("local_exclude_collections", [])
+            if any(fnmatch(collection, pat) for pat in exclude):
+                return
+        svc_embeddings = embeddings
+        if not svc_embeddings:
+            try:
+                arr = get_t3().get_embeddings(collection, doc_ids)
+            except Exception:
+                arr = None
+            # get_embeddings drops ids it cannot resolve; a count skew would
+            # mis-pair vectors to docs, so skip rather than assign misaligned.
+            if arr is None or len(arr) != len(doc_ids):
+                import structlog
+                structlog.get_logger().debug(
+                    "taxonomy_assign_service_embed_unavailable",
+                    collection=collection,
+                    want=len(doc_ids),
+                    got=0 if arr is None else len(arr),
+                )
+                return
+            svc_embeddings = arr.tolist()
+        try:
+            def _svc_assign(db):  # noqa: ANN001
+                same = db.taxonomy.compute_assignments(
+                    collection, doc_ids, svc_embeddings, cross_collection=False,
+                )
+                cross = db.taxonomy.compute_assignments(
+                    collection, doc_ids, svc_embeddings, cross_collection=True,
+                )
+                a = same + cross
+                if a:
+                    db.taxonomy.persist_assignments(a)
+                return len(a)
+            t2_index_write(_svc_assign)
+        except Exception:
+            import structlog
+            structlog.get_logger().debug(
+                "taxonomy_assign_batch_service_failed", exc_info=True,
+            )
         return
 
     if is_local_mode():

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -708,18 +708,20 @@ def taxonomy_assign_batch_hook(
                 return
             svc_embeddings = arr.tolist()
         try:
-            def _svc_assign(db):  # noqa: ANN001
-                same = db.taxonomy.compute_assignments(
-                    collection, doc_ids, svc_embeddings, cross_collection=False,
+            # Compute (read: queries centroids via the service) + persist in a
+            # single inline t2_index_write lambda — the storage-boundary lint
+            # recognises this routed form, and in service mode persist lands on
+            # the Java service (the single writer).
+            t2_index_write(
+                lambda db: db.taxonomy.persist_assignments(
+                    db.taxonomy.compute_assignments(
+                        collection, doc_ids, svc_embeddings, cross_collection=False,
+                    )
+                    + db.taxonomy.compute_assignments(
+                        collection, doc_ids, svc_embeddings, cross_collection=True,
+                    )
                 )
-                cross = db.taxonomy.compute_assignments(
-                    collection, doc_ids, svc_embeddings, cross_collection=True,
-                )
-                a = same + cross
-                if a:
-                    db.taxonomy.persist_assignments(a)
-                return len(a)
-            t2_index_write(_svc_assign)
+            )
         except Exception:
             import structlog
             structlog.get_logger().debug(

--- a/tests/test_taxonomy_service_wiring.py
+++ b/tests/test_taxonomy_service_wiring.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-7ydks: `nx taxonomy discover`/`rebuild` route through the
+HttpTaxonomyStore drop-in when the taxonomy store is service-backed.
+
+These are unit tests over the CLI dispatch seam (`discover_for_collection`)
+using fakes — no live service required. The end-to-end exercise against the
+real Java service lives in tests/db/test_http_taxonomy_store_integration.py.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from nexus.commands.taxonomy_cmd import (
+    _enumerate_discoverable_collections,
+    _fetch_service_vectors,
+    discover_for_collection,
+)
+
+
+class _RawColl:
+    def __init__(self, name: str, count: int) -> None:
+        self.name = name
+        self._count = count
+
+    def count(self) -> int:
+        return self._count
+
+
+class _FakeRawClient:
+    def __init__(self, colls) -> None:  # noqa: ANN001
+        self._colls = colls
+
+    def list_collections(self):
+        return self._colls
+
+
+class _FakeRawT3:
+    """T3Database-shaped: exposes ``_client.list_collections()``."""
+
+    def __init__(self, colls) -> None:  # noqa: ANN001
+        self._client = _FakeRawClient(colls)
+
+
+def test_enumerate_discoverable_collections_filters_and_does_not_crash():
+    # nexus-7ydks HIGH-1 regression: the helper referenced module-scope
+    # `fnmatch` that was only imported inside discover_cmd → NameError when
+    # called from the index.py post-processing path. Exercise the filter.
+    t3 = _FakeRawT3([
+        _RawColl("docs__demo", 12),       # kept
+        _RawColl("code__demo", 9),        # excluded by pattern
+        _RawColl("docs__small", 3),       # too few
+        _RawColl("taxonomy__centroids", 50),  # internal, skipped
+    ])
+    got = _enumerate_discoverable_collections(t3, exclude=["code__*"])
+    assert got == ["docs__demo"]
+
+
+class _FakeStub:
+    """Service collection stub: paginated get(documents) over a fixed corpus."""
+
+    def __init__(self, ids: list[str], docs: list[str]) -> None:
+        self._ids = ids
+        self._docs = docs
+
+    def get(self, *, include=None, limit=10, offset=0):  # noqa: ANN001
+        sl = slice(offset, offset + limit)
+        return {"ids": self._ids[sl], "documents": self._docs[sl]}
+
+
+class _FakeServiceT3:
+    """Minimal HttpVectorClient-shaped handle for the discovery fetch path."""
+
+    def __init__(self, ids, docs, embs) -> None:  # noqa: ANN001
+        self._ids = ids
+        self._docs = docs
+        self._embs = np.asarray(embs, dtype=np.float32)
+
+    def count(self, collection: str) -> int:
+        return len(self._ids)
+
+    def get_or_create_collection(self, name: str) -> _FakeStub:
+        return _FakeStub(self._ids, self._docs)
+
+    def get_embeddings(self, collection: str, ids: list[str]):  # noqa: ANN001
+        # Return rows in request order (mirrors the real client contract).
+        index = {i: r for i, r in zip(self._ids, self._embs)}
+        return np.asarray([index[i] for i in ids], dtype=np.float32)
+
+
+class _FakeServiceTaxonomy:
+    """HttpTaxonomyStore-shaped store: no `_lock`/`conn` → not raw-access.
+
+    Records the args it was dispatched so the test can assert the CLI handed
+    over the fetched vectors verbatim.
+    """
+
+    def __init__(self) -> None:
+        self.discover_calls: list[tuple] = []
+        self.rebuild_calls: list[tuple] = []
+
+    def discover_topics(self, collection_name, doc_ids, embeddings, texts, chroma_client=None):  # noqa: ANN001
+        self.discover_calls.append((collection_name, list(doc_ids), np.asarray(embeddings), list(texts)))
+        return len(set(doc_ids)) and 3  # pretend 3 topics
+
+    def rebuild_taxonomy(self, collection_name, doc_ids, embeddings, texts, chroma_client=None):  # noqa: ANN001
+        self.rebuild_calls.append((collection_name, list(doc_ids), np.asarray(embeddings), list(texts)))
+        return 2
+
+
+def _corpus(n: int):
+    ids = [f"c{i}" for i in range(n)]
+    docs = [f"text {i}" for i in range(n)]
+    embs = [[float(i), float(i) + 1.0, 2.0] for i in range(n)]
+    return ids, docs, embs
+
+
+def test_fetch_service_vectors_returns_aligned_arrays():
+    ids, docs, embs = _corpus(6)
+    t3 = _FakeServiceT3(ids, docs, embs)
+    got = _fetch_service_vectors("docs__demo", t3)
+    assert got is not None
+    g_ids, g_texts, g_embs = got
+    assert g_ids == ids
+    assert g_texts == docs
+    assert g_embs.shape == (6, 3)
+
+
+def test_fetch_service_vectors_bails_on_embedding_misalignment():
+    ids, docs, embs = _corpus(6)
+
+    class _Drops(_FakeServiceT3):
+        def get_embeddings(self, collection, ids):  # noqa: ANN001
+            return np.asarray(self._embs[:-1], dtype=np.float32)  # one short
+
+    assert _fetch_service_vectors("docs__demo", _Drops(ids, docs, embs)) is None
+
+
+def test_discover_for_collection_service_routes_to_discover_topics():
+    ids, docs, embs = _corpus(8)
+    t3 = _FakeServiceT3(ids, docs, embs)
+    tax = _FakeServiceTaxonomy()
+
+    n = discover_for_collection("docs__demo", tax, t3, force=False)
+
+    assert n == 3
+    assert len(tax.discover_calls) == 1
+    assert not tax.rebuild_calls
+    col, got_ids, got_embs, got_texts = tax.discover_calls[0]
+    assert col == "docs__demo"
+    assert got_ids == ids
+    assert got_texts == docs
+    assert got_embs.shape == (8, 3)
+
+
+def test_discover_for_collection_service_force_routes_to_rebuild():
+    ids, docs, embs = _corpus(8)
+    t3 = _FakeServiceT3(ids, docs, embs)
+    tax = _FakeServiceTaxonomy()
+
+    n = discover_for_collection("docs__demo", tax, t3, force=True)
+
+    assert n == 2
+    assert len(tax.rebuild_calls) == 1
+    assert not tax.discover_calls
+
+
+def test_discover_for_collection_service_too_few_docs_returns_zero():
+    ids, docs, embs = _corpus(4)  # < 5
+    t3 = _FakeServiceT3(ids, docs, embs)
+    tax = _FakeServiceTaxonomy()
+
+    assert discover_for_collection("docs__demo", tax, t3) == 0
+    assert not tax.discover_calls

--- a/tests/test_taxonomy_service_wiring.py
+++ b/tests/test_taxonomy_service_wiring.py
@@ -171,3 +171,52 @@ def test_discover_for_collection_service_too_few_docs_returns_zero():
 
     assert discover_for_collection("docs__demo", tax, t3) == 0
     assert not tax.discover_calls
+
+
+# ── Incremental-assignment hook (nexus-7ydks C1) ────────────────────────────
+
+
+def test_assign_batch_hook_routes_through_service_store(monkeypatch):
+    """The per-store_put assignment hook must persist via the service store in
+    service mode, not bail (the Critical the substantive-critic caught)."""
+    import nexus.mcp_infra as mi
+    from nexus.db.http_vector_client import HttpVectorClient
+
+    ids = [f"c{i}" for i in range(4)]
+    embs = [[float(i), 1.0, 2.0] for i in range(4)]
+
+    # A real-typed (isinstance) HttpVectorClient so is_service_backed() is True,
+    # with the two methods the hook calls stubbed.
+    class _SvcT3(HttpVectorClient):
+        def __init__(self):  # noqa: D107
+            pass
+
+        def get_embeddings(self, collection, doc_ids):  # noqa: ANN001
+            import numpy as _np
+            return _np.asarray(embs, dtype=_np.float32)
+
+    persisted: list[list[dict]] = []
+
+    class _SvcTax:
+        def compute_assignments(self, collection, doc_ids, embeddings, *, cross_collection=False):  # noqa: ANN001
+            # one assignment per doc for the same-collection pass, none cross
+            return [] if cross_collection else [{"doc_id": d, "topic_id": 1} for d in doc_ids]
+
+        def persist_assignments(self, assignments):  # noqa: ANN001
+            persisted.append(assignments)
+            return len(assignments)
+
+    class _DB:
+        taxonomy = _SvcTax()
+
+    monkeypatch.setattr(mi, "get_t3", lambda: _SvcT3())
+    # is_local_mode is a local import from nexus.config inside the hook.
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: False)
+    # t2_index_write just runs the fn with our fake db (no daemon).
+    monkeypatch.setattr(mi, "t2_index_write", lambda fn: fn(_DB()))
+
+    # embeddings=None forces the service get_embeddings fetch path.
+    mi.taxonomy_assign_batch_hook(ids, "docs__demo", ["t"] * 4, None, None)
+
+    assert persisted, "service-mode hook did not persist any assignments (regressed to bail)"
+    assert len(persisted[0]) == 4


### PR DESCRIPTION
Restores `nx taxonomy discover` / `rebuild` and per-document topic assignment under the RDR-155 service substrate. Before this they hard-failed (`ClickException`) in service mode (the 6.0 default) because discovery read embeddings through a raw ChromaDB client that retired with Chroma serving — the gap surfaced while auditing the user-facing docs.

Bead: `nexus-7ydks` (under RDR-152 epic `nexus-gmiaf`).

## What changed
The store side was already complete (`HttpTaxonomyStore.discover_topics`/`rebuild_taxonomy`/`compute_assignments`/`persist_assignments` are CatalogTaxonomy drop-ins that persist through the Java service and upsert centroids via `/v1/taxonomy/centroids`). This is the CLI + hook last mile:

- **`discover_for_collection`** branches on `_has_raw_access(taxonomy)`: service → fetch via `t3.get_embeddings` + paginated stub, persist via the store drop-in; raw → existing daemon-routed path (unchanged; now accepts a `T3Database` handle or a raw chroma client).
- **`taxonomy_assign_batch_hook`** (per-`store_put` incremental assignment): ported to the service store instead of bailing — newly-indexed docs now get assigned.
- Backend-uniform collection enumeration; `_require_supported_taxonomy_backend` rejects only the split config (service T3 + sqlite taxonomy) on all paths incl. post-index.
- Embedding-misalignment guard (get_embeddings drops unresolved ids → refuse rather than cluster misaligned rows).

## Still raw-only (tracked, nexus-7ydks)
`nx taxonomy split` / `project` and the automatic cross-collection projection pass — they refuse cleanly on the service. Docs updated to say so.

## Gate (stacked review, both passes)
- **code-review-expert** caught 2 HIGH (fnmatch NameError in the enumerate helper; silent AttributeError on the service-mode projection pass) — both fixed.
- **substantive-critic** caught a **Critical silent scope reduction**: the first cut restored batch discovery but left the assignment hook bailing (docs indexed after discover never assigned). Fixed by porting the hook; +regression test.

Tests: `tests/test_taxonomy_service_wiring.py` (7, incl. hook-path + fnmatch regression); `test_taxonomy.py` (148) unregressed; cli-registration + mode-lint green.

## Not yet done (follow-up)
Live end-to-end verification against a running local `nx daemon service` (the integration test needs the JAR built; embedding-equivalence was already proven by the gmiaf.21 parity gate). Prep only — no release cut (`nexus-luxe6` open).

Bead: nexus-7ydks