### PR TITLE
feat(taxonomy): port split/project/projection to the pgvector service (nexus-9pqoj)

### DIFF
--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -789,10 +789,12 @@ def run_collection_postprocessing(
                         f"  Review:   {unreviewed} topics pending. "
                         f"Run `nx taxonomy review` to curate."
                     )
-                # Cross-collection projection pass (RDR-075 SC-7)
+                # Cross-collection projection pass (RDR-075 SC-7). nexus-9pqoj:
+                # project_against handles both backends; pass the chroma client
+                # for a raw T3Database or the service handle itself.
                 try:
                     proj_total = _project_cross_collections(
-                        db.taxonomy, collections, t3._client,
+                        db.taxonomy, collections, getattr(t3, "_client", t3),
                     )
                     if proj_total:
                         _say(f"  Project:  {proj_total} cross-collection assignments.")

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -733,6 +733,12 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
                         result = db.taxonomy.project_against(
                             col_name, others, _proj_handle, threshold=0.85,
                         )
+                        if result.get("incomplete_fetch"):
+                            click.echo(
+                                f"  Projection: skipped {col_name} (incomplete "
+                                "service embedding read; collection may be mid-index)"
+                            )
+                            continue
                         assignments = result.get("chunk_assignments", [])
                         if assignments:
                             _persist_assignments(
@@ -1735,6 +1741,16 @@ def project_cmd(
             icf_map=icf_map,
             progress=True,
         )
+        # nexus-9pqoj S1: a service fetch that could not align embeddings to ids
+        # returns empty-with-flag; surface it loudly instead of looking like
+        # "no matches".
+        if result.get("incomplete_fetch"):
+            raise click.ClickException(
+                f"Could not read all source embeddings for {source_collection} "
+                "from the service (count mismatch). The collection may be mid-"
+                "index; retry once indexing settles, or re-index it."
+            )
+
         # Fall through: display logic uses `threshold` local — rebind
         # to the resolved value so messages reflect what was applied.
         threshold = resolved_threshold
@@ -1865,6 +1881,12 @@ def _run_backfill(
                 icf_map=icf_map,
                 progress=True,
             )
+            if result.get("incomplete_fetch"):
+                click.echo(
+                    f"    Skipped: incomplete service embedding read for {src} "
+                    "(collection may be mid-index; retry later)"
+                )
+                continue
             matched = len(result["matched_topics"])
             novel = len(result["novel_chunks"])
             chunks = result["total_chunks"]

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -45,27 +45,6 @@ if TYPE_CHECKING:
 _log = structlog.get_logger(__name__)
 
 
-def _reject_service_backed_handle(t3: Any) -> None:
-    """Fail loud when the T3 handle has no raw Chroma client.
-
-    Retained for the taxonomy paths NOT yet ported to the service
-    (``nx taxonomy split`` / ``project``): their bodies still cluster + write
-    centroids through a raw Chroma client. ``nx taxonomy discover`` / ``rebuild``
-    ARE ported (nexus-7ydks) and instead use
-    :func:`_require_supported_taxonomy_backend`, so do not add this guard there.
-    """
-    from nexus.db.http_vector_client import is_service_backed
-
-    if is_service_backed(t3):
-        raise click.ClickException(
-            "this taxonomy operation needs a raw Chroma client, which retired "
-            "with the Chroma serving paths (RDR-155 Phase 4a). `nx taxonomy "
-            "discover` and `rebuild` are supported on the service; split / "
-            "project on the pgvector service are a tracked follow-on "
-            "(nexus-7ydks)."
-        )
-
-
 def _require_supported_taxonomy_backend(t3: Any, taxonomy: Any) -> None:
     """Block only the unsupported split: service T3 + raw-SQLite taxonomy.
 
@@ -740,24 +719,19 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
             else:
                 click.echo(f"  {col_name}: skipped")
 
-        # Cross-collection projection pass (RDR-075 SC-7).
-        # nexus-7ydks: project_against still uses a raw Chroma client (not yet
-        # ported to the service), so skip it LOUDLY in service mode rather than
-        # AttributeError on t3._client and swallow it as a generic failure.
-        from nexus.db.http_vector_client import is_service_backed
-        if total_topics and len(targets) > 1 and is_service_backed(t3):
-            click.echo(
-                "  Projection: skipped (cross-collection projection on the "
-                "pgvector service is a tracked follow-on, nexus-7ydks)"
-            )
-        elif total_topics and len(targets) > 1:
+        # Cross-collection projection pass (RDR-075 SC-7). nexus-9pqoj:
+        # project_against handles both backends; pass the raw chroma client for
+        # a raw T3Database (has ._client) or the service handle itself for an
+        # HttpVectorClient (no ._client).
+        _proj_handle = getattr(t3, "_client", t3)
+        if total_topics and len(targets) > 1:
             try:
                 proj_count = 0
                 for col_name in targets:
                     others = [c for c in targets if c != col_name]
                     if others:
                         result = db.taxonomy.project_against(
-                            col_name, others, t3._client, threshold=0.85,
+                            col_name, others, _proj_handle, threshold=0.85,
                         )
                         assignments = result.get("chunk_assignments", [])
                         if assignments:
@@ -1080,7 +1054,26 @@ def split_cmd(topic_label: str, k: int, collection: str) -> None:
 
         collection_name = topic["collection"]
         t3 = make_t3()
-        _reject_service_backed_handle(t3)
+
+        # nexus-9pqoj: service-backed split. The store's split_topic does the
+        # full fetch -> compute -> persist -> centroid round-trip via the service.
+        if not _has_raw_access(db.taxonomy):
+            # service-backed split_topic persists through the Java service (the
+            # single writer for HttpTaxonomyStore), not the SQLite WAL writer the
+            # boundary lint guards, so t2_index_write routing does not apply.
+            child_count = db.taxonomy.split_topic(topic_id, k, t3)  # epsilon-allow: service single-writer persist
+            click.echo(f"Split '{topic_label}' into {child_count} sub-topics.")
+            if child_count:
+                coll_scope = collection_name or collection
+                scope = f" -c {coll_scope}" if coll_scope else ""
+                click.echo(
+                    f"Action: {child_count} new sub-topics have n-gram labels. "
+                    f"Run `nx taxonomy label{scope}` to get human-readable labels."
+                )
+            return
+
+        # Raw path (unchanged): refuse the split-backend config, then inline.
+        _require_supported_taxonomy_backend(t3, db.taxonomy)
         chroma_client = t3._client
 
         # Fetch texts from T3 collection
@@ -1678,6 +1671,11 @@ def project_cmd(
 
     db = _T2Database(_default_db_path())
     t3 = make_t3()
+    # nexus-9pqoj: refuse the split-backend config; project_against handles both
+    # backends, so pass the chroma client (raw T3Database) or the service handle
+    # (HttpVectorClient has no ._client).
+    _require_supported_taxonomy_backend(t3, db.taxonomy)
+    _proj_handle = getattr(t3, "_client", t3)
 
     # Resolve threshold: explicit flag wins; otherwise per-corpus default
     # (defaults applied at the per-source level inside _run_backfill).
@@ -1688,7 +1686,7 @@ def project_cmd(
     try:
         if backfill:
             _run_backfill(
-                db.taxonomy, t3._client,
+                db.taxonomy, _proj_handle,
                 threshold=threshold, top_k=top_k, persist=persist,
                 use_icf=use_icf,
             )
@@ -1732,7 +1730,7 @@ def project_cmd(
             db.taxonomy.compute_icf_map(use_cache=True) if use_icf else None
         )
         result = db.taxonomy.project_against(
-            source_collection, targets, t3._client,
+            source_collection, targets, _proj_handle,
             threshold=resolved_threshold, top_k=top_k,
             icf_map=icf_map,
             progress=True,

--- a/src/nexus/db/t2/http_taxonomy_store.py
+++ b/src/nexus/db/t2/http_taxonomy_store.py
@@ -924,6 +924,77 @@ class HttpTaxonomyStore:
         self.record_discover_count(collection_name, len(doc_ids))
         return len(topic_ids)
 
+    @staticmethod
+    def _svc_fetch_by_ids(t3: Any, collection: str, doc_ids: list[str]):
+        """Fetch (ids, texts, embeddings) for specific doc_ids via the service.
+
+        nexus-9pqoj. Texts come from the service store-get (`stub.get(ids=...)`),
+        embeddings server-side via `t3.get_embeddings` (the collection's native
+        space). Returns the aligned subset that resolved; ``embeddings`` is
+        ``None`` when the service could not align vectors to the fetched ids
+        (count skew → refuse rather than mis-pair).
+        """
+        stub = t3.get_or_create_collection(collection)
+        ids: list[str] = []
+        texts: list[str] = []
+        _PAGE = 250
+        for i in range(0, len(doc_ids), _PAGE):
+            batch = doc_ids[i:i + _PAGE]
+            res = stub.get(ids=batch, include=["documents"])
+            for fid, fdoc in zip(res.get("ids") or [], res.get("documents") or []):
+                if fdoc:
+                    ids.append(fid)
+                    texts.append(fdoc)
+        if not ids:
+            return [], [], None
+        embs = t3.get_embeddings(collection, ids)
+        if embs is None or len(embs) != len(ids):
+            _log.warning(
+                "taxonomy_svc_fetch_by_ids_misalign",
+                collection=collection, want=len(ids),
+                got=0 if embs is None else len(embs),
+            )
+            return ids, texts, None
+        return ids, texts, np.asarray(embs, dtype=np.float32)
+
+    @staticmethod
+    def _svc_fetch_all_embeddings(t3: Any, collection: str):
+        """Fetch (ids, embeddings) for ALL chunks in a collection via the service.
+
+        nexus-9pqoj — the project source-side equivalent of
+        :meth:`_svc_fetch_by_ids`. Returns ``(ids, None)`` on count skew.
+        """
+        try:
+            n = t3.count(collection)
+        except Exception:
+            return [], None
+        if n == 0:
+            return [], np.empty((0, 0), dtype=np.float32)
+        stub = t3.get_or_create_collection(collection)
+        ids: list[str] = []
+        offset = 0
+        _PAGE = 300
+        while offset < n:
+            page = stub.get(include=[], limit=_PAGE, offset=offset)
+            pids = page.get("ids") or []
+            if not pids:
+                break
+            ids.extend(pids)
+            offset += len(pids)
+            if len(pids) < _PAGE:
+                break
+        if not ids:
+            return [], np.empty((0, 0), dtype=np.float32)
+        embs = t3.get_embeddings(collection, ids)
+        if embs is None or len(embs) != len(ids):
+            _log.warning(
+                "taxonomy_svc_fetch_all_misalign",
+                collection=collection, want=len(ids),
+                got=0 if embs is None else len(embs),
+            )
+            return ids, None
+        return ids, np.asarray(embs, dtype=np.float32)
+
     def split_topic(
         self,
         topic_id: int,
@@ -949,27 +1020,42 @@ class HttpTaxonomyStore:
             return 0
 
         collection_name = topic["collection"]
-        try:
-            coll = chroma_client.get_collection(collection_name, embedding_function=None)
-        except Exception:
-            _log.warning("split_collection_not_found", collection=collection_name)
-            return 0
 
-        _PAGE = 250
-        fetched_ids: list[str] = []
-        texts: list[str] = []
-        for i in range(0, len(doc_ids), _PAGE):
-            batch = doc_ids[i:i + _PAGE]
-            result = coll.get(ids=batch, include=["documents"])
-            for fid, fdoc in zip(result.get("ids") or [], result.get("documents") or []):
-                if fdoc:
-                    fetched_ids.append(fid)
-                    texts.append(fdoc)
-        if len(texts) < k:
-            return 0
+        # nexus-9pqoj: service-backed source reads. When the handle is the
+        # HttpVectorClient (service-mode CLI), pull the topic's STORED vectors
+        # via the service — NOT a MiniLM-384 re-embed, because parent and child
+        # centroids must share the collection's bge-768 / voyage space for ANN
+        # assignment to work. Raw chroma handles keep the legacy re-embed path.
+        from nexus.db.http_vector_client import is_service_backed
 
-        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
-        embeddings = np.array(ef(texts), dtype=np.float32)
+        if is_service_backed(chroma_client):
+            fetched_ids, texts, embeddings = self._svc_fetch_by_ids(
+                chroma_client, collection_name, doc_ids,
+            )
+            if not fetched_ids or len(texts) < k or embeddings is None:
+                return 0
+        else:
+            try:
+                coll = chroma_client.get_collection(collection_name, embedding_function=None)
+            except Exception:
+                _log.warning("split_collection_not_found", collection=collection_name)
+                return 0
+
+            _PAGE = 250
+            fetched_ids = []
+            texts = []
+            for i in range(0, len(doc_ids), _PAGE):
+                batch = doc_ids[i:i + _PAGE]
+                result = coll.get(ids=batch, include=["documents"])
+                for fid, fdoc in zip(result.get("ids") or [], result.get("documents") or []):
+                    if fdoc:
+                        fetched_ids.append(fid)
+                        texts.append(fdoc)
+            if len(texts) < k:
+                return 0
+
+            ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+            embeddings = np.array(ef(texts), dtype=np.float32)
 
         split_result = self.compute_split(
             topic_id, doc_ids, texts, fetched_ids, embeddings, collection_name, k,
@@ -1019,29 +1105,40 @@ class HttpTaxonomyStore:
             "matched_topics": [], "novel_chunks": [],
             "total_chunks": 0, "total_centroids": 0,
         }
-        # 1. Source chunk embeddings from T3 (chroma_client), paginated.
-        try:
-            src_coll = chroma_client.get_collection(source_collection, embedding_function=None)
-        except Exception:
-            return dict(_empty)
-        _PAGE = 300
-        src_ids: list[str] = []
-        src_emb_pages: list[np.ndarray] = []
-        offset = 0
-        while True:
-            page = src_coll.get(include=["embeddings"], limit=_PAGE, offset=offset)
-            page_ids = page.get("ids", [])
-            page_embs = page.get("embeddings")
-            if not page_ids or page_embs is None:
-                break
-            src_ids.extend(page_ids)
-            src_emb_pages.append(np.array(page_embs, dtype=np.float32))
-            if len(page_ids) < _PAGE:
-                break
-            offset += _PAGE
-        if not src_ids:
-            return dict(_empty)
-        src_embs = np.concatenate(src_emb_pages)
+        # 1. Source chunk embeddings. nexus-9pqoj: via the service when the
+        # handle is the HttpVectorClient (the stub's get() drops embeddings, so
+        # we must use get_embeddings); raw chroma keeps the legacy include path.
+        from nexus.db.http_vector_client import is_service_backed
+
+        if is_service_backed(chroma_client):
+            src_ids, src_embs = self._svc_fetch_all_embeddings(
+                chroma_client, source_collection,
+            )
+            if not src_ids or src_embs is None or src_embs.size == 0:
+                return dict(_empty)
+        else:
+            try:
+                src_coll = chroma_client.get_collection(source_collection, embedding_function=None)
+            except Exception:
+                return dict(_empty)
+            _PAGE = 300
+            src_ids = []
+            src_emb_pages: list[np.ndarray] = []
+            offset = 0
+            while True:
+                page = src_coll.get(include=["embeddings"], limit=_PAGE, offset=offset)
+                page_ids = page.get("ids", [])
+                page_embs = page.get("embeddings")
+                if not page_ids or page_embs is None:
+                    break
+                src_ids.extend(page_ids)
+                src_emb_pages.append(np.array(page_embs, dtype=np.float32))
+                if len(page_ids) < _PAGE:
+                    break
+                offset += _PAGE
+            if not src_ids:
+                return dict(_empty)
+            src_embs = np.concatenate(src_emb_pages)
 
         # 2. Target centroids from the centroid-port ($in target_collections).
         ctr_raw: list[list[float]] = []

--- a/src/nexus/db/t2/http_taxonomy_store.py
+++ b/src/nexus/db/t2/http_taxonomy_store.py
@@ -940,6 +940,9 @@ class HttpTaxonomyStore:
         _PAGE = 250
         for i in range(0, len(doc_ids), _PAGE):
             batch = doc_ids[i:i + _PAGE]
+            # The service store-get path ignores `include` and always returns
+            # the full {ids, documents, metadatas} envelope (VectorHandler P4a.2,
+            # nexus-1k8s1); we pass include for intent only.
             res = stub.get(ids=batch, include=["documents"])
             for fid, fdoc in zip(res.get("ids") or [], res.get("documents") or []):
                 if fdoc:
@@ -1114,7 +1117,13 @@ class HttpTaxonomyStore:
             src_ids, src_embs = self._svc_fetch_all_embeddings(
                 chroma_client, source_collection,
             )
-            if not src_ids or src_embs is None or src_embs.size == 0:
+            # nexus-9pqoj S1: distinguish an INCOMPLETE fetch (service could not
+            # align embeddings to ids) from a legitimately empty collection.
+            # Silent-zero on a fetch failure looks like 'no matches' to the user;
+            # flag it so the CLI surfaces it (feedback_no_silent_fallbacks).
+            if src_embs is None:
+                return {**_empty, "incomplete_fetch": True}
+            if not src_ids or src_embs.size == 0:
                 return dict(_empty)
         else:
             try:

--- a/tests/test_taxonomy_service_wiring.py
+++ b/tests/test_taxonomy_service_wiring.py
@@ -220,3 +220,67 @@ def test_assign_batch_hook_routes_through_service_store(monkeypatch):
 
     assert persisted, "service-mode hook did not persist any assignments (regressed to bail)"
     assert len(persisted[0]) == 4
+
+
+# ── split/project service fetch helpers (nexus-9pqoj) ───────────────────────
+
+
+class _StubWithIds:
+    """Service collection stub supporting both ids= (store-get) and paginated get."""
+
+    def __init__(self, ids, docs):  # noqa: ANN001
+        self._ids = ids
+        self._docs = docs
+
+    def get(self, ids=None, where=None, include=None, limit=10, offset=0):  # noqa: ANN001
+        if ids is not None:
+            idx = {i: d for i, d in zip(self._ids, self._docs)}
+            rids = [i for i in ids if i in idx]
+            return {"ids": rids, "documents": [idx[i] for i in rids]}
+        sl = slice(offset, offset + limit)
+        return {"ids": self._ids[sl], "documents": self._docs[sl]}
+
+
+class _SplitT3:
+    def __init__(self, ids, docs, embs):  # noqa: ANN001
+        self._ids, self._docs = ids, docs
+        self._embs = {i: e for i, e in zip(ids, embs)}
+
+    def count(self, collection):  # noqa: ANN001
+        return len(self._ids)
+
+    def get_or_create_collection(self, name):  # noqa: ANN001
+        return _StubWithIds(self._ids, self._docs)
+
+    def get_embeddings(self, collection, ids):  # noqa: ANN001
+        return np.asarray([self._embs[i] for i in ids], dtype=np.float32)
+
+
+def test_svc_fetch_by_ids_aligned():
+    from nexus.db.t2.http_taxonomy_store import HttpTaxonomyStore
+    ids, docs, embs = _corpus(6)
+    t3 = _SplitT3(ids, docs, embs)
+    g_ids, g_texts, g_embs = HttpTaxonomyStore._svc_fetch_by_ids(t3, "docs__d", ids[:4])
+    assert g_ids == ids[:4]
+    assert g_texts == docs[:4]
+    assert g_embs.shape == (4, 3)
+
+
+def test_svc_fetch_by_ids_bails_on_misalign():
+    from nexus.db.t2.http_taxonomy_store import HttpTaxonomyStore
+    ids, docs, embs = _corpus(6)
+
+    class _Drop(_SplitT3):
+        def get_embeddings(self, collection, ids):  # noqa: ANN001
+            return np.asarray(embs[:2], dtype=np.float32)  # short
+
+    g_ids, g_texts, g_embs = HttpTaxonomyStore._svc_fetch_by_ids(_Drop(ids, docs, embs), "docs__d", ids)
+    assert g_embs is None  # refuses misaligned
+
+
+def test_svc_fetch_all_embeddings_paginates():
+    from nexus.db.t2.http_taxonomy_store import HttpTaxonomyStore
+    ids, docs, embs = _corpus(7)
+    g_ids, g_embs = HttpTaxonomyStore._svc_fetch_all_embeddings(_SplitT3(ids, docs, embs), "docs__d")
+    assert g_ids == ids
+    assert g_embs.shape == (7, 3)

--- a/tests/test_taxonomy_service_wiring.py
+++ b/tests/test_taxonomy_service_wiring.py
@@ -284,3 +284,18 @@ def test_svc_fetch_all_embeddings_paginates():
     g_ids, g_embs = HttpTaxonomyStore._svc_fetch_all_embeddings(_SplitT3(ids, docs, embs), "docs__d")
     assert g_ids == ids
     assert g_embs.shape == (7, 3)
+
+
+def test_svc_fetch_all_embeddings_bails_on_misalign():
+    # nexus-9pqoj S1 regression: a count skew between enumerated ids and the
+    # returned embeddings must return (ids, None), NOT a silent partial set.
+    from nexus.db.t2.http_taxonomy_store import HttpTaxonomyStore
+    ids, docs, embs = _corpus(7)
+
+    class _Drop(_SplitT3):
+        def get_embeddings(self, collection, ids):  # noqa: ANN001
+            return np.asarray(embs[:3], dtype=np.float32)  # short
+
+    g_ids, g_embs = HttpTaxonomyStore._svc_fetch_all_embeddings(_Drop(ids, docs, embs), "docs__d")
+    assert g_ids == ids
+    assert g_embs is None


### PR DESCRIPTION
**Stacked on #1256 (nexus-7ydks).** Base will retarget to `develop` once #1256 merges. Completes the taxonomy service substrate: `nx taxonomy split`, `project`, and the auto cross-collection projection pass now run on the nexus-service instead of refusing in service mode.

Bead: `nexus-9pqoj` (under RDR-152 epic `nexus-gmiaf`).

## What changed
The store methods were only half-ported (centroids via the service, but chunk reads still via a raw chroma client). This finishes them:
- **`split_topic`**: service-backed handle → fetch the topic's **stored** vectors via the service (`get_embeddings`), **not** a MiniLM-384 re-embed — parent/child centroids must share the collection's bge-768/voyage space.
- **`project_against`**: source chunk embeddings via the service (the stub `get()` drops embeddings).
- Both add a count-equality misalignment bail.
- **CLI**: `split_cmd`/`project_cmd`/the `--all` + post-index projection pass route through the store via `getattr(t3, '_client', t3)` (chroma client for raw `T3Database`, the service handle for `HttpVectorClient`); `_require_supported_taxonomy_backend` guards; the now-dead `_reject_service_backed_handle` removed.

## Tests
+5 service fetch-helper tests (alignment, pagination, misalignment bail). `test_taxonomy.py` (148) + `test_http_taxonomy_store.py` (72) unregressed; boundary lint green (split_topic persist carries an `epsilon-allow`: it persists through the Java service single-writer, not the SQLite WAL writer the lint guards).

## Not yet done
Live end-to-end smoke against a running `nx daemon service` (shared with nexus-7ydks). Prep only — no release cut.

Bead: nexus-9pqoj