### PR TITLE
feat(daemon): explicit-opt-in JAR launch for nx daemon service (amends RDR-161)

### DIFF
--- a/docs/migration-runbook.md
+++ b/docs/migration-runbook.md
@@ -190,8 +190,10 @@ Check, in order:
 - No stale-binary warning (running binary differs from the installed
   provenance sidecar). Install the intended binary first via
   `nx daemon service install-binary <engine-service-vX.Y.Z>` (RDR-161: the
-  native binary is the sole launch artifact; the legacy `java -jar` path and
-  its schema-skew gate are expunged).
+  cosign-verified native binary is the production launch artifact). For local
+  dev/test on a host without a native binary, set `NEXUS_SERVICE_JAR` to a
+  built `nexus-service-*.jar` — an explicit, never-auto-discovered opt-in that
+  launches the JVM and is logged as UNVERIFIED (RDR-161 amendment, 2026-06-20).
 
 The T2 ladder commands read the service endpoint from the environment
 (`NX_SERVICE_PORT` + `NX_SERVICE_TOKEN` are required; the per-store

--- a/docs/rdr/rdr-161-native-only-local-install.md
+++ b/docs/rdr/rdr-161-native-only-local-install.md
@@ -297,3 +297,33 @@ gate (substantive-critic, 2026-06-18); retained here as the audit trail:
 - Phase 2 carries the `_select_bundled_pg` search-dir bug fix plus a published-bundle
   round-trip test, alongside the publish job + acquire seam.
 - One platform convention (`current_platform_tag()`) spans binary + PG bundle.
+
+## Amendment (2026-06-20): explicit dev/test JAR opt-in (bead nexus follow-on)
+
+The native-only decision held one assumption that bit local development: a host
+without a native binary for its platform (e.g. a darwin dev box where only the
+Linux native binary and the shaded JAR are built) cannot run
+`nx daemon service start` at all, which blocked local live testing (surfaced by
+the 2026-06-20 taxonomy service smoke).
+
+**Amendment, not reversal.** `StorageServiceSupervisor` now accepts an
+**explicit, opt-in** JAR launch via `NEXUS_SERVICE_JAR`
+(`_resolve_launch_artifact` → `launch_kind="jar"`,
+`argv = [java, -Xmx?, -jar, <jar>]` with a `java`-on-PATH guard). It preserves
+every load-bearing property of the original decision:
+
+- **No auto-discovery, no silent fallback.** The JAR launches ONLY when
+  `NEXUS_SERVICE_JAR` is set. With it unset the native binary is still the sole
+  path; a missing native binary still fails loud. The "never silently mask a
+  missing native binary" supply-chain intent is intact.
+- **Native stays the production default and the only verified path.** The JAR is
+  NOT signature-verified; the supervisor logs the launch loudly as
+  `storage_service_jar_launch … verified=False` and stamps `launch_kind` on the
+  spawn record so status/logs show which artifact ran.
+- **The install + release path is unchanged.** Releases still ship only the
+  cosign-signed native binary + signatures; `install-binary` is untouched.
+
+The JVM path RDR-161 *expunged* was the auto-fallback dual-mode (`_launch_mode`,
+JVM heartbeat, `service install-jar`, two provenance shapes). That stays gone.
+This amendment adds back only a single, explicit, transparent escape hatch for
+local dev/test.

--- a/src/nexus/commands/init.py
+++ b/src/nexus/commands/init.py
@@ -359,6 +359,8 @@ def _ensure_service_binary_step(config_dir: Path) -> bool:
     Hard failures (broken ``NEXUS_SERVICE_BIN`` override, a configured tag that
     fails verification) raise ``SystemExit``.
     """
+    import os
+
     from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
     from nexus.daemon.binary_install import (
@@ -370,6 +372,16 @@ def _ensure_service_binary_step(config_dir: Path) -> bool:
         StorageServiceStartError,
         _find_service_binary,
     )
+
+    # Explicit dev/test JAR opt-in (RDR-161 amendment): when NEXUS_SERVICE_JAR is
+    # set the supervisor launches the JVM, so no native binary need be acquired.
+    # The supervisor's own resolution fails loud if the path is set-but-missing.
+    if os.environ.get("NEXUS_SERVICE_JAR", "").strip():
+        click.echo(
+            "  Using NEXUS_SERVICE_JAR (dev/test JVM launch, UNVERIFIED) — "
+            "skipping native binary acquisition."
+        )
+        return True
 
     try:
         existing = _find_service_binary(config_dir)

--- a/src/nexus/daemon/storage_service_daemon.py
+++ b/src/nexus/daemon/storage_service_daemon.py
@@ -12,9 +12,11 @@ logic lives in the shared primitive, not here. This module:
 2. Starts the native nexus-service binary (RDR-157 native-image; acquired via
    ``nx daemon service install-binary``) with the environment variables read
    from ``pg_credentials``, a free ``NX_SERVICE_PORT``, and process-group
-   isolation (``start_new_session=True`` / ``os.killpg`` on stop). The native
-   binary is the SOLE launch artifact — RDR-161 expunged the legacy JVM
-   launch path.
+   isolation (``start_new_session=True`` / ``os.killpg`` on stop). The
+   cosign-verified native binary is the production launch artifact (RDR-161).
+   ``NEXUS_SERVICE_JAR`` is an EXPLICIT dev/test opt-in that launches a JVM
+   (``java -jar``) instead — never auto-discovered, never a silent fallback,
+   and logged loudly as UNVERIFIED (amends RDR-161).
 3. Waits for ``GET /health`` to return HTTP 200 (richer than bare-TCP: the
    HealthHandler returns ``{"status":"ok","db":"up"}`` or ``{"status":"error",
    "db":"down"}`` with a 503 status).
@@ -54,6 +56,7 @@ import contextlib
 import errno
 import os
 import re
+import shutil
 import signal
 import socket
 import subprocess
@@ -215,6 +218,84 @@ def _require_executable(p: Path, label: str) -> Path:
     return p
 
 
+def _find_service_jar() -> Path | None:
+    """Resolve an EXPLICIT, opt-in service JAR, or None.
+
+    Dev/test escape hatch amending RDR-161 (which made the cosign-signed native
+    binary the sole launch artifact). The JAR is **never auto-discovered and
+    never a silent fallback** — it launches ONLY when ``NEXUS_SERVICE_JAR`` is
+    set, preserving RDR-161's "never silently mask a missing native binary"
+    supply-chain intent. The JAR is NOT signature-verified; the caller logs
+    that loudly. Set-but-missing fails loud (an operator who named a JAR that
+    does not exist made a mistake worth surfacing).
+    """
+    override = os.environ.get("NEXUS_SERVICE_JAR", "").strip()
+    if not override:
+        return None
+    p = Path(override)
+    if p.is_file():
+        return p
+    raise StorageServiceStartError(
+        f"NEXUS_SERVICE_JAR is set to {override!r} but the file does not exist. "
+        "Point it at a built nexus-service-*.jar, or unset it to use the "
+        "installed native binary."
+    )
+
+
+def _resolve_java_executable() -> str:
+    """Return the ``java`` launcher for the JAR path, or fail loud with a remedy.
+
+    Honours ``JAVA_HOME`` (``$JAVA_HOME/bin/java``) then falls back to ``java``
+    on ``PATH``. A JAR launch with no JVM available must fail with an actionable
+    message, not a bare ``FileNotFoundError`` from ``Popen``.
+    """
+    java_home = os.environ.get("JAVA_HOME", "").strip()
+    if java_home:
+        cand = Path(java_home) / "bin" / "java"
+        if cand.is_file() and os.access(cand, os.X_OK):
+            return str(cand)
+    found = shutil.which("java")
+    if found:
+        return found
+    raise StorageServiceStartError(
+        "NEXUS_SERVICE_JAR launch requires a Java runtime, but no 'java' was "
+        "found on PATH or via JAVA_HOME. Install a JDK (>= 21), or unset "
+        "NEXUS_SERVICE_JAR to use the native binary."
+    )
+
+
+def _resolve_launch_artifact(config_dir: Path) -> tuple[Path, str]:
+    """Resolve the service launch artifact and its kind.
+
+    Returns ``(path, kind)`` where kind is ``"jar"`` (explicit ``NEXUS_SERVICE_JAR``
+    opt-in, dev/test, UNVERIFIED) or ``"native"`` (the RDR-161 cosign-verified
+    binary, the production default). The JAR is checked first ONLY because it is
+    an explicit override; with it unset the native binary is the sole path.
+    """
+    jar = _find_service_jar()
+    if jar is not None:
+        _log.warning(
+            "storage_service_jar_launch",
+            jar=str(jar),
+            verified=False,
+            note="launching the UNVERIFIED dev/test JAR via NEXUS_SERVICE_JAR, "
+                 "not the cosign-signed native binary (RDR-161). For production "
+                 "use the installed native binary.",
+        )
+        return jar, "jar"
+    binary = _find_service_binary(config_dir)
+    if binary is None:
+        raise StorageServiceStartError(
+            "No nexus-service launch artifact found. Acquire the signed native "
+            "binary:\n"
+            "  nx daemon service install-binary <engine-service tag>\n"
+            "or point NEXUS_SERVICE_BIN at a built native binary. For local "
+            "dev/test you may instead set NEXUS_SERVICE_JAR to a built "
+            "nexus-service-*.jar (unverified; requires a JVM)."
+        )
+    return binary, "native"
+
+
 # ── Port helpers ───────────────────────────────────────────────────────────────
 
 
@@ -314,20 +395,31 @@ class StorageServiceSupervisor:
         service_port: int,
         creds: dict[str, str],
         binary_path: Path,
+        launch_kind: str = "native",
         lease_clock: Callable[[], float] = time.time,
         supervised: bool = False,
     ) -> None:
-        # RDR-161: the native binary is the SOLE launch artifact — the
-        # legacy JVM launch path is expunged. A missing binary is fatal here.
+        # RDR-161: the cosign-verified native binary is the production launch
+        # artifact. ``launch_kind="jar"`` is the explicit dev/test opt-in
+        # (NEXUS_SERVICE_JAR), launched via the JVM — never an auto-fallback.
         if binary_path is None:
             raise StorageServiceStartError(
-                "StorageServiceSupervisor needs a native binary to launch; "
-                "none was provided. Acquire one via "
-                "'nx daemon service install-binary <tag>'."
+                "StorageServiceSupervisor needs a launch artifact; none was "
+                "provided. Acquire the native binary via "
+                "'nx daemon service install-binary <tag>', or set "
+                "NEXUS_SERVICE_JAR for a local dev/test JVM launch."
+            )
+        if launch_kind not in ("native", "jar"):
+            raise StorageServiceStartError(
+                f"launch_kind must be 'native' or 'jar', got {launch_kind!r}."
             )
         self._config_dir = config_dir
         self._binary_path = binary_path
-        self._svc_log_name = "storage_service_native"
+        self._launch_kind = launch_kind
+        self._svc_log_name = (
+            "storage_service_jar" if launch_kind == "jar"
+            else "storage_service_native"
+        )
         self._pg_port = pg_port
         self._service_port = service_port
         self._creds = creds
@@ -436,7 +528,14 @@ class StorageServiceSupervisor:
                     hint="set VOYAGE_API_KEY or `nx config set voyage_api_key <key>`",
                 )
 
-        argv = [str(self._binary_path)]
+        # Launch artifact: native binary (argv[0] = binary) or, when explicitly
+        # opted in via NEXUS_SERVICE_JAR, the JVM (argv = java -jar <jar>). The
+        # -Xmx option below is accepted by both GraalVM native-image and the JVM.
+        if self._launch_kind == "jar":
+            java_exe = _resolve_java_executable()
+            argv = [java_exe]
+        else:
+            argv = [str(self._binary_path)]
         # nexus-lz3f2: optional max-heap bound for memory-constrained hosts
         # (e.g. the migration-rehearsal container, where an unbounded native-image
         # heap peak during bge-768 ONNX load + PG + the Python supervisor tripped
@@ -455,6 +554,11 @@ class StorageServiceSupervisor:
                     "(expected e.g. '512m', '1g', '2048k')."
                 )
             argv.append(f"-Xmx{max_heap}")
+        # JVM launch: the runnable artifact follows as `-jar <jar>` (after any
+        # -Xmx, which the JVM requires before -jar). Native: argv[0] is already
+        # the binary.
+        if self._launch_kind == "jar":
+            argv += ["-jar", str(self._binary_path)]
         artifact = str(self._binary_path)
         # nexus-ovbr7: route both streams to one file so interleaved output keeps
         # its order; O_APPEND means a respawn never truncates the previous
@@ -481,6 +585,8 @@ class StorageServiceSupervisor:
             pid=proc.pid,
             port=port,
             artifact=artifact,
+            launch_kind=self._launch_kind,
+            verified=self._launch_kind == "native",
             service_log=getattr(svc_log, "name", "DEVNULL"),
         )
         return proc, port
@@ -930,21 +1036,6 @@ def _load_credentials(config_dir: Path) -> dict[str, str]:
     return creds
 
 
-def _require_service_binary(config_dir: Path) -> Path:
-    """Resolve the native service binary or fail loud (RDR-161 native-only).
-
-    There is no legacy JVM fallback: a missing binary means the service was
-    never acquired. Direct the operator at the install verb.
-    """
-    binary_path = _find_service_binary(config_dir)
-    if binary_path is None:
-        raise StorageServiceStartError(
-            "No nexus-service native binary found. Acquire one:\n"
-            "  nx daemon service install-binary <engine-service tag>\n"
-            "  (installs to the well-known location under the config dir),\n"
-            "or point NEXUS_SERVICE_BIN at a built native binary."
-        )
-    return binary_path
 
 
 def start_storage_service(
@@ -972,11 +1063,12 @@ def start_storage_service(
         )
     pg_port = int(pg_port_str)
 
-    binary_path = _require_service_binary(config_dir)
+    binary_path, launch_kind = _resolve_launch_artifact(config_dir)
 
     sup = StorageServiceSupervisor(
         config_dir=config_dir,
         binary_path=binary_path,
+        launch_kind=launch_kind,
         pg_port=pg_port,
         service_port=0,  # allocated inside start()
         creds=creds,
@@ -1041,12 +1133,13 @@ def run_storage_supervisor(
         )
     pg_port = int(pg_port_str)
 
-    binary_path = _require_service_binary(config_dir)
+    binary_path, launch_kind = _resolve_launch_artifact(config_dir)
 
     _log.info(
         "storage_service_supervisor_started",
         pid=os.getpid(),
         artifact=str(binary_path),
+        launch_kind=launch_kind,
         pg_port=pg_port,
         config_dir=str(config_dir),
     )
@@ -1054,6 +1147,7 @@ def run_storage_supervisor(
     sup = StorageServiceSupervisor(
         config_dir=config_dir,
         binary_path=binary_path,
+        launch_kind=launch_kind,
         pg_port=pg_port,
         service_port=0,
         creds=creds,

--- a/tests/daemon/test_jar_launch_opt_in.py
+++ b/tests/daemon/test_jar_launch_opt_in.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Explicit-opt-in JAR launch for the storage service (amends RDR-161).
+
+The cosign-verified native binary stays the production default; NEXUS_SERVICE_JAR
+is an explicit dev/test opt-in launched via the JVM. Never auto-discovered,
+never a silent fallback.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from nexus.daemon import storage_service_daemon as ssd
+from nexus.daemon.storage_service_daemon import (
+    StorageServiceStartError,
+    StorageServiceSupervisor,
+    _find_service_jar,
+    _resolve_launch_artifact,
+)
+
+
+# ── _find_service_jar (explicit only) ───────────────────────────────────────
+
+
+def test_find_jar_unset_returns_none(monkeypatch):
+    monkeypatch.delenv("NEXUS_SERVICE_JAR", raising=False)
+    assert _find_service_jar() is None
+
+
+def test_find_jar_set_and_present(monkeypatch, tmp_path):
+    jar = tmp_path / "nexus-service.jar"
+    jar.write_text("x")
+    monkeypatch.setenv("NEXUS_SERVICE_JAR", str(jar))
+    assert _find_service_jar() == jar
+
+
+def test_find_jar_set_but_missing_fails_loud(monkeypatch, tmp_path):
+    monkeypatch.setenv("NEXUS_SERVICE_JAR", str(tmp_path / "nope.jar"))
+    with pytest.raises(StorageServiceStartError, match="does not exist"):
+        _find_service_jar()
+
+
+# ── _resolve_launch_artifact (native default, jar opt-in) ───────────────────
+
+
+def test_resolve_prefers_native_when_no_jar(monkeypatch, tmp_path):
+    monkeypatch.delenv("NEXUS_SERVICE_JAR", raising=False)
+    binary = tmp_path / "nexus-service"
+    monkeypatch.setattr(ssd, "_find_service_binary", lambda cd: binary)
+    path, kind = _resolve_launch_artifact(tmp_path)
+    assert (path, kind) == (binary, "native")
+
+
+def test_resolve_jar_opt_in_wins(monkeypatch, tmp_path):
+    jar = tmp_path / "svc.jar"
+    jar.write_text("x")
+    monkeypatch.setenv("NEXUS_SERVICE_JAR", str(jar))
+    # Even if a native binary exists, the explicit opt-in is honoured.
+    monkeypatch.setattr(ssd, "_find_service_binary", lambda cd: tmp_path / "native")
+    path, kind = _resolve_launch_artifact(tmp_path)
+    assert (path, kind) == (jar, "jar")
+
+
+def test_resolve_no_artifact_fails_loud(monkeypatch, tmp_path):
+    monkeypatch.delenv("NEXUS_SERVICE_JAR", raising=False)
+    monkeypatch.setattr(ssd, "_find_service_binary", lambda cd: None)
+    with pytest.raises(StorageServiceStartError, match="No nexus-service launch artifact"):
+        _resolve_launch_artifact(tmp_path)
+
+
+# ── supervisor launch_kind validation ───────────────────────────────────────
+
+
+def test_supervisor_rejects_bad_launch_kind(tmp_path):
+    with pytest.raises(StorageServiceStartError, match="launch_kind"):
+        StorageServiceSupervisor(
+            config_dir=tmp_path, pg_port=5432, service_port=0,
+            creds={"NX_SERVICE_TOKEN": "tok"}, binary_path=tmp_path / "x",
+            launch_kind="bogus",
+        )
+
+
+# ── argv construction: native vs jvm ────────────────────────────────────────
+
+
+def _spawn_capture(monkeypatch, *, launch_kind, artifact, max_heap=None):
+    """Drive _spawn_service with Popen stubbed; return the captured argv."""
+    captured: dict = {}
+
+    class _FakeProc:
+        pid = 4242
+
+    def _fake_popen(argv, **kw):  # noqa: ANN001
+        captured["argv"] = argv
+        return _FakeProc()
+
+    monkeypatch.setattr(ssd.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(ssd, "_allocate_free_port", lambda host="127.0.0.1": 55000)
+    monkeypatch.setattr(
+        "nexus.logging_setup.open_child_log_or_devnull",
+        lambda name, cfg: os.open(os.devnull, os.O_WRONLY),
+    )
+    if max_heap is not None:
+        monkeypatch.setenv("NX_SERVICE_MAX_HEAP", max_heap)
+    sup = StorageServiceSupervisor(
+        config_dir=Path("/tmp"), pg_port=5432, service_port=0,
+        creds={"NX_SERVICE_TOKEN": "tok"}, binary_path=artifact,
+        launch_kind=launch_kind,
+    )
+    sup._spawn_service()
+    return captured["argv"]
+
+
+def test_native_argv_is_the_binary(monkeypatch):
+    binary = Path("/opt/nexus/nexus-service")
+    argv = _spawn_capture(monkeypatch, launch_kind="native", artifact=binary)
+    assert argv == [str(binary)]
+
+
+def test_jar_argv_is_java_dash_jar(monkeypatch):
+    monkeypatch.setattr(ssd, "_resolve_java_executable", lambda: "/usr/bin/java")
+    jar = Path("/build/nexus-service.jar")
+    argv = _spawn_capture(monkeypatch, launch_kind="jar", artifact=jar)
+    assert argv == ["/usr/bin/java", "-jar", str(jar)]
+
+
+def test_jar_argv_with_heap_orders_xmx_before_jar(monkeypatch):
+    monkeypatch.setattr(ssd, "_resolve_java_executable", lambda: "/usr/bin/java")
+    jar = Path("/build/nexus-service.jar")
+    argv = _spawn_capture(monkeypatch, launch_kind="jar", artifact=jar, max_heap="1g")
+    assert argv == ["/usr/bin/java", "-Xmx1g", "-jar", str(jar)]

--- a/tests/daemon/test_jar_launch_opt_in.py
+++ b/tests/daemon/test_jar_launch_opt_in.py
@@ -131,3 +131,21 @@ def test_jar_argv_with_heap_orders_xmx_before_jar(monkeypatch):
     jar = Path("/build/nexus-service.jar")
     argv = _spawn_capture(monkeypatch, launch_kind="jar", artifact=jar, max_heap="1g")
     assert argv == ["/usr/bin/java", "-Xmx1g", "-jar", str(jar)]
+
+
+# ── nx init --service honours the JAR opt-in (no native binary required) ─────
+
+
+def test_init_service_skips_binary_acquire_with_jar(monkeypatch, tmp_path):
+    """_ensure_service_binary_step returns True (and acquires nothing) when
+    NEXUS_SERVICE_JAR is set — so `nx init --service` works on a host with no
+    native binary."""
+    from nexus.commands.init import _ensure_service_binary_step
+
+    jar = tmp_path / "svc.jar"
+    jar.write_text("x")
+    monkeypatch.setenv("NEXUS_SERVICE_JAR", str(jar))
+    # If it tried to acquire, _find_service_binary would be consulted; make it
+    # explode so a regression that ignores the opt-in fails loudly.
+    monkeypatch.setattr(ssd, "_find_service_binary", lambda cd: (_ for _ in ()).throw(AssertionError("should not check native binary")))
+    assert _ensure_service_binary_step(tmp_path) is True

--- a/tests/daemon/test_rdr161_native_only_gate.py
+++ b/tests/daemon/test_rdr161_native_only_gate.py
@@ -1,26 +1,28 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""RDR-161 P3 inverse-grep gate — the JVM launch/install path stays expunged.
+"""RDR-161 inverse-grep gate — the EXPUNGED JVM dual-mode/install path stays gone.
 
-Mirrors the exhaustive-surface-audit discipline: rather than a blanket ban on
-the substring ``jar`` (which legitimately appears as the ``.jar`` file
-extension in the classifier and in deployment-skew comments describing
-field-deployed JAR services), this gate forbids the specific *launch/install*
-identifiers that would signal the ``java -jar`` path has crept back into the
-non-test surface. A re-introduction anywhere under ``src/nexus`` fails here.
+RDR-161 made the cosign-verified native binary the production launch artifact
+and removed the auto-fallback JVM dual-mode + JAR install path. The 2026-06-20
+amendment then added back a SINGLE, explicit, opt-in JVM launch
+(``NEXUS_SERVICE_JAR`` → ``java -jar``) confined to
+``daemon/storage_service_daemon.py``.
+
+This gate therefore splits the identifiers:
+
+- ``_FORBIDDEN_EVERYWHERE`` — the expunged auto-fallback / install dual-mode.
+  These must never reappear anywhere under ``src/nexus``.
+- ``_OPT_IN_LAUNCH`` — the explicit-opt-in launch identifiers. Allowed ONLY in
+  the sanctioned ``storage_service_daemon.py``; forbidden elsewhere so the
+  java-jar launch cannot creep into other modules.
 """
 from __future__ import annotations
 
 import re
 from pathlib import Path
 
-# Identifiers that only exist if the legacy JVM launch/install path is present.
-_FORBIDDEN = [
-    re.compile(r"java\s+-jar"),          # the actual subprocess launch
-    re.compile(r"-jar\b"),               # the `-jar` argv flag, incl. split argv
-                                         # (["java", "-jar", ...]); zero legit
-                                         # uses under src/nexus
-    re.compile(r"_find_service_jar"),    # JAR discovery (deleted)
-    re.compile(r"well_known_jar_path"),  # JAR well-known location (deleted)
+# The expunged auto-fallback / install dual-mode — forbidden EVERYWHERE.
+_FORBIDDEN_EVERYWHERE = [
+    re.compile(r"well_known_jar_path"),  # JAR well-known auto-location (deleted)
     re.compile(r"\binstall_jar\b"),      # JAR install function (deleted)
     re.compile(r"install-jar"),          # JAR install CLI command (deleted)
     re.compile(r"\bjar_path\b"),         # supervisor jar_path param (dropped)
@@ -28,21 +30,39 @@ _FORBIDDEN = [
     re.compile(r"check_schema_skew"),    # JAR-only schema-skew gate (deleted)
 ]
 
+# The explicit-opt-in launch identifiers — allowed ONLY in the sanctioned file.
+_OPT_IN_LAUNCH = [
+    re.compile(r"java\s+-jar"),
+    re.compile(r"-jar\b"),
+    re.compile(r"_find_service_jar"),
+]
+
 _SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "nexus"
+#: The one module that may carry the explicit NEXUS_SERVICE_JAR opt-in.
+_SANCTIONED = _SRC_ROOT / "daemon" / "storage_service_daemon.py"
 
 
 def test_no_jvm_launch_install_identifiers_in_src() -> None:
-    """No non-test module under src/nexus may reference the expunged JVM
-    launch/install identifiers."""
+    """The expunged dual-mode stays gone everywhere; the explicit opt-in launch
+    is contained to storage_service_daemon.py."""
     offenders: list[str] = []
     for py in _SRC_ROOT.rglob("*.py"):
         text = py.read_text(encoding="utf-8", errors="replace")
+        is_sanctioned = py.resolve() == _SANCTIONED.resolve()
         for line_no, line in enumerate(text.splitlines(), start=1):
-            for pat in _FORBIDDEN:
+            for pat in _FORBIDDEN_EVERYWHERE:
                 if pat.search(line):
                     offenders.append(f"{py}:{line_no}: {pat.pattern!r} -> {line.strip()}")
+            if not is_sanctioned:
+                for pat in _OPT_IN_LAUNCH:
+                    if pat.search(line):
+                        offenders.append(
+                            f"{py}:{line_no}: opt-in launch {pat.pattern!r} outside "
+                            f"the sanctioned storage_service_daemon.py -> {line.strip()}"
+                        )
 
     assert not offenders, (
-        "RDR-161: the java -jar launch/install path must stay expunged from the "
-        "non-test surface. Re-introduced identifiers:\n" + "\n".join(offenders)
+        "RDR-161 (+2026-06-20 amendment): the expunged JVM dual-mode/install path "
+        "must stay gone everywhere, and the explicit NEXUS_SERVICE_JAR opt-in must "
+        "stay confined to storage_service_daemon.py. Offenders:\n" + "\n".join(offenders)
     )


### PR DESCRIPTION
RDR-161 made the cosign-verified native binary the **sole** launch artifact, which blocks local dev/test on a host without a native binary for its platform (e.g. a darwin box where only the Linux native + the shaded JAR are built). This surfaced trying to run the taxonomy service smoke locally.

## Amendment, not reversal
`StorageServiceSupervisor` now accepts an **explicit, opt-in** JVM launch via `NEXUS_SERVICE_JAR`:
- `_resolve_launch_artifact()` → `(path, kind)`: JAR only when `NEXUS_SERVICE_JAR` is set (set-but-missing fails loud); else the native binary; neither → fail loud naming both.
- `_spawn_service` argv branches: jar → `[java, -Xmx?, -jar, <jar>]` with a java-on-PATH guard; native unchanged.
- **Never auto-discovered, never a silent fallback** — preserves RDR-161's 'never silently mask a missing native binary' supply-chain intent.
- **Loud + transparent**: logs `storage_service_jar_launch verified=False`, stamps `launch_kind` on the spawn record. The JAR is not signature-verified; native stays the production default and the only verified path. `install-binary` / release path untouched.

## Gate
The RDR-161 native-only inverse-grep gate is updated to the amended policy: the expunged auto-fallback dual-mode/install identifiers stay forbidden **everywhere**; the explicit opt-in launch identifiers are allowed **only** in `storage_service_daemon.py` (so the java-jar path can't creep elsewhere).

## Tests
`tests/daemon/test_jar_launch_opt_in.py` (10: resolution, fail-loud, argv construction native vs jvm, heap ordering). Daemon suite + boundary lint green.

RDR-161 amendment note added; migration-runbook updated. Enables the deferred discover/split/project live smoke (nexus-7ydks/9pqoj).