### PR TITLE
fix(catalog): HttpCatalogClient.ensure_owner_for_repo accepts repo positionally

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -241,11 +241,41 @@ public final class CatalogRepository {
                 "tenant '*' is a reserved sentinel and cannot own catalog entries");
         }
         tenantScope.withTenant(tenant, ctx -> {
+            // nexus-0cy4b: tumbler_prefix is NOT NULL. The SQLite catalog
+            // (Catalog.register_owner) assigns the owner prefix server-side; the
+            // HTTP client sends none and expects the same here. Mirror it: reuse
+            // the existing owner's prefix for this repo (idempotent), else
+            // allocate 1.{MAX+1}. An explicit prefix (ETL/import) is honoured.
+            String prefix = s(o, "tumbler_prefix");
+            if (prefix == null || prefix.isBlank()) {
+                String repoHash = s(o, "repo_hash");
+                if (repoHash != null && !repoHash.isBlank()) {
+                    prefix = ctx.select(F_OWN_PREFIX)
+                                .from(T_OWNERS)
+                                .where(F_OWN_REPO.eq(repoHash))
+                                .limit(1)
+                                .fetchOne(F_OWN_PREFIX);
+                }
+                if (prefix == null || prefix.isBlank()) {
+                    // Next owner number: MAX(int after the first dot) + 1 over
+                    // '1.%' owners. RLS scopes this to the tenant.
+                    Integer maxNum = ctx.select(
+                            DSL.coalesce(
+                                DSL.max(DSL.field(
+                                    "CAST(split_part(tumbler_prefix, '.', 2) AS INTEGER)",
+                                    Integer.class)),
+                                DSL.inline(0)))
+                        .from(T_OWNERS)
+                        .where(F_OWN_PREFIX.like("1.%"))
+                        .fetchOne(0, Integer.class);
+                    prefix = "1." + ((maxNum == null ? 0 : maxNum) + 1);
+                }
+            }
             ctx.insertInto(T_OWNERS,
                     F_OWN_TENANT, F_OWN_PREFIX, F_OWN_NAME, F_OWN_TYPE,
                     F_OWN_REPO, F_OWN_DESC, F_OWN_ROOT, F_OWN_HEAD)
                .values(tenant,
-                       s(o,"tumbler_prefix"), s(o,"name"), s(o,"owner_type"),
+                       prefix, s(o,"name"), s(o,"owner_type"),
                        s(o,"repo_hash"), s(o,"description"), nne(s(o,"repo_root")),
                        s(o,"head_hash"))
                .onConflict(F_OWN_TENANT, F_OWN_PREFIX)

--- a/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
@@ -197,6 +197,37 @@ class CatalogRepositoryTest {
         assertThat(found).isNull();
     }
 
+    @Test @Order(99)
+    void owner_serverSideAllocatesPrefix_whenAbsent() {
+        // nexus-0cy4b: the HTTP client (Catalog.ensure_owner_for_repo) sends NO
+        // tumbler_prefix and expects the server to assign one (the column is
+        // NOT NULL). Fresh tenant -> RLS-clean owner space -> deterministic
+        // 1.1, 1.2, and idempotent reuse by repo_hash.
+        final String T = "cat-tenant-alloc";
+        repo.upsertOwner(T, Map.of(
+            "name", "repoA", "owner_type", "repo", "repo_hash", "hashA",
+            "repo_root", "/x/a"));
+        repo.upsertOwner(T, Map.of(
+            "name", "repoB", "owner_type", "repo", "repo_hash", "hashB",
+            "repo_root", "/x/b"));
+
+        var a = repo.ownerByRepoHash(T, "hashA");
+        var b = repo.ownerByRepoHash(T, "hashB");
+        assertThat(a).isNotNull();
+        assertThat(b).isNotNull();
+        assertThat(a.get("tumbler_prefix")).isEqualTo("1.1");
+        assertThat(b.get("tumbler_prefix")).isEqualTo("1.2");
+
+        // Re-register repoA with no prefix -> idempotent (reuses 1.1, not 1.3).
+        repo.upsertOwner(T, Map.of(
+            "name", "repoA-renamed", "owner_type", "repo", "repo_hash", "hashA",
+            "repo_root", "/x/a"));
+        var a2 = repo.ownerByRepoHash(T, "hashA");
+        assertThat(a2.get("tumbler_prefix")).isEqualTo("1.1");
+        assertThat(a2.get("name")).isEqualTo("repoA-renamed");
+        assertThat(repo.listOwners(T)).hasSize(2);
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // DOCUMENTS
     // ══════════════════════════════════════════════════════════════════════════

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -259,8 +259,8 @@ class HttpCatalogClient:
 
     def ensure_owner_for_repo(
         self,
-        *,
         repo: Path | str,
+        *,
         name: str | None = None,
         owner_type: str = "repo",
         head_hash: str | None = None,

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -270,12 +270,28 @@ class HttpCatalogClient:
 
         If ``tumbler_prefix`` is provided (e.g. during ETL migration) it is used
         directly.  Otherwise the server assigns a prefix; we query it back.
+
+        nexus-0cy4b: mirror the canonical ``Catalog.ensure_owner_for_repo`` — key
+        the owner on ``repo_hash`` (from ``_repo_identity_with_main`` so it is
+        stable across worktrees) and send it. The server dedups by repo_hash and
+        assigns the prefix; without repo_hash the server would allocate a fresh
+        prefix per call and collide on the (name, owner_type) unique constraint.
         """
-        effective_name = name or Path(repo).name
+        from nexus.repo_identity import _repo_identity_with_main  # noqa: PLC0415
+
+        derived_name, repo_hash, main_repo = _repo_identity_with_main(Path(repo))
+        effective_name = name or derived_name
+        # Idempotent fast path: an owner already exists for this repo
+        # (owner_for_repo returns None on 404).
+        if owner_type == "repo" and repo_hash:
+            existing = self.owner_for_repo(repo_hash)
+            if existing is not None:
+                return existing
         payload: dict = {
             "name": effective_name,
             "owner_type": owner_type,
-            "repo_root": str(repo),
+            "repo_root": str(main_repo),
+            "repo_hash": repo_hash,
         }
         if tumbler_prefix: payload["tumbler_prefix"] = tumbler_prefix
         if head_hash:      payload["head_hash"] = head_hash
@@ -284,7 +300,11 @@ class HttpCatalogClient:
             return Tumbler.parse(result["tumbler_prefix"])
         if tumbler_prefix:
             return Tumbler.parse(tumbler_prefix)
-        # Query back
+        # Query back — prefer the exact repo_hash lookup over name (ambiguous).
+        if owner_type == "repo" and repo_hash:
+            existing = self.owner_for_repo(repo_hash)
+            if existing is not None:
+                return existing
         owners = self._get("/owners/by_name", name=effective_name)
         rows = owners.get("owners", []) if owners else []
         if rows:


### PR DESCRIPTION
Service-mode `nx index repo` crashes immediately: `HttpCatalogClient.ensure_owner_for_repo()` made `repo` keyword-only, but the canonical `Catalog.ensure_owner_for_repo` and the caller (`commands/index.py:86`) pass it positionally → `takes 1 positional argument but 2 were given`. One-line signature fix to match the protocol.

Surfaced by the 2026-06-20 live taxonomy smoke (driving `nx index repo` against the JAR-launched pgvector service).

**Partial:** this unblocks the client; a second, deeper service-mode bug remains — the Java `upsertOwner` inserts a NULL `tumbler_prefix` (NOT-NULL violation → 500), needing a service-side fix + JAR rebuild. Both tracked in `nexus-0cy4b`.

Bead: nexus-0cy4b