### PR TITLE
fix(corpus): service+local write token follows the service embedder (bge-768) (nexus-xq8f9)

### DIFF
--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -190,6 +190,16 @@ def effective_embedding_model_for_writes(content_type: str) -> str:
     """
     from nexus.config import is_local_mode  # noqa: PLC0415
     if is_local_mode():
+        # nexus-xq8f9: in service-vector mode (the 6.0 default) the nexus-service
+        # embeds server-side with bge-768 (RDR-160), independent of whether the
+        # CLIENT has the [local]/fastembed extra. Naming the collection from the
+        # client's local-EF tier (which falls back to minilm-384 when fastembed
+        # is absent) makes the service refuse the write (HTTP 422, model
+        # mismatch). Follow the service's embedder token instead.
+        from nexus.db.http_vector_client import is_vector_service_mode  # noqa: PLC0415
+        if is_vector_service_mode():
+            from nexus.db.local_ef import _MODEL_TOKENS, _TIER1_MODEL  # noqa: PLC0415
+            return _MODEL_TOKENS[_TIER1_MODEL]  # bge-base-en-v15-768
         from nexus.db.local_ef import local_model_token  # noqa: PLC0415
         return local_model_token()
     return canonical_embedding_model(content_type)

--- a/tests/test_rdr_109_phase2_dispatch.py
+++ b/tests/test_rdr_109_phase2_dispatch.py
@@ -49,6 +49,27 @@ def test_effective_in_local_mode_returns_local_token(monkeypatch) -> None:
     assert effective_embedding_model_for_writes("code") in LOCAL_EMBEDDING_MODELS
 
 
+def test_effective_local_service_mode_uses_bge_not_client_fastembed_tier(monkeypatch) -> None:
+    # nexus-xq8f9: in local + service-vector mode the service embeds bge-768
+    # server-side, so the write token must be bge-768 even when the CLIENT has
+    # no fastembed extra (which would otherwise resolve minilm-384 and make the
+    # service refuse the write with HTTP 422).
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: True)
+    monkeypatch.setattr("nexus.db.http_vector_client.is_vector_service_mode", lambda: True)
+    # Even if the client falls back to minilm (no fastembed), service path wins.
+    monkeypatch.setattr("nexus.db.local_ef._fastembed_available", lambda: False)
+    monkeypatch.setattr("nexus.config.local_embed_model_choice", lambda: "BAAI/bge-base-en-v1.5")
+    assert effective_embedding_model_for_writes("code") == "bge-base-en-v15-768"
+    assert effective_embedding_model_for_writes("docs") == "bge-base-en-v15-768"
+
+
+def test_effective_local_nonservice_mode_uses_client_token(monkeypatch) -> None:
+    # Raw local (no service vectors): the client's local-EF token is correct.
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: True)
+    monkeypatch.setattr("nexus.db.http_vector_client.is_vector_service_mode", lambda: False)
+    assert effective_embedding_model_for_writes("code") in LOCAL_EMBEDDING_MODELS
+
+
 def test_effective_in_cloud_mode_delegates_to_canonical(cloud_mode) -> None:
     assert (
         effective_embedding_model_for_writes("docs")


### PR DESCRIPTION
In service-vector mode (the 6.0 default) the nexus-service embeds server-side with **bge-768** (RDR-160), independent of whether the *client* has the `[local]`/fastembed extra. But `effective_embedding_model_for_writes` resolved the collection token via the client's local-EF tier, which falls back to **minilm-384** when fastembed is absent. The client then named `code__` collections `…__minilm-l6-v2-384__v1` while the service embeds bge-768 → the service refused the write (**HTTP 422** model mismatch), blocking `nx index repo` in service+local mode.

Fix: when `is_local_mode()` and `is_vector_service_mode()`, the write token follows the service embedder (bge-768) directly.

Surfaced by the 2026-06-20 live CLI smoke. +2 regression tests (incl. the exact bug condition: local+service+no-fastembed → bge, not minilm). Bead: nexus-xq8f9