### PR TITLE
fix(indexer): stamp_collection_version no-ops on service-backed collections (nexus-kwkkz)

### DIFF
--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -69,9 +69,19 @@ PIPELINE_VERSION: str = "4"
 
 
 def stamp_collection_version(col: object) -> None:
-    """Write PIPELINE_VERSION to collection metadata, preserving existing keys."""
+    """Write PIPELINE_VERSION to collection metadata, preserving existing keys.
+
+    nexus-kwkkz: collection-level metadata via ``modify`` is Chroma-specific;
+    service-backed collections (``_ServiceCollectionStub``) do not expose it, so
+    pipeline-version stamping is a no-op there. This is a staleness optimization,
+    not a correctness input — the read side (``get_collection_pipeline_version``)
+    already degrades to ``None`` (treated as a fresh collection) for these.
+    """
+    modify = getattr(col, "modify", None)
+    if not callable(modify):
+        return
     existing = getattr(col, "metadata", None) or {}
-    col.modify(metadata={**existing, "pipeline_version": PIPELINE_VERSION})  # type: ignore[attr-defined]
+    modify(metadata={**existing, "pipeline_version": PIPELINE_VERSION})
 
 
 def get_collection_pipeline_version(col: object) -> str | None:

--- a/tests/test_pipeline_version.py
+++ b/tests/test_pipeline_version.py
@@ -163,3 +163,26 @@ def test_doctor_pipeline_sweep_retired_on_service_handle():
     assert "sweep retired with the Chroma serving path" in result.output
     # The sweep must not report a failure for what is a deliberate retire.
     assert "check failed" not in result.output
+
+
+def test_stamp_collection_version_noop_on_service_stub() -> None:
+    """nexus-kwkkz: a service-backed collection has no Chroma `modify`; stamping
+    must no-op instead of raising AttributeError (it crashed `nx index repo`)."""
+    from nexus.indexer import stamp_collection_version
+
+    class _ServiceStub:  # no `modify`, like _ServiceCollectionStub
+        metadata = {}
+
+    stamp_collection_version(_ServiceStub())  # must not raise
+
+
+def test_stamp_collection_version_calls_modify_when_available() -> None:
+    from unittest.mock import MagicMock
+    from nexus.indexer import stamp_collection_version, PIPELINE_VERSION
+
+    col = MagicMock()
+    col.metadata = {"existing": "v"}
+    stamp_collection_version(col)
+    col.modify.assert_called_once_with(
+        metadata={"existing": "v", "pipeline_version": PIPELINE_VERSION}
+    )


### PR DESCRIPTION
`stamp_collection_version` called `col.modify(metadata=...)` — a Chroma collection method the `_ServiceCollectionStub` doesn't expose → `AttributeError` aborted `nx index repo` at the post-index 'Stamping pipeline version' step in service mode. Guard: no-op when the collection has no callable `modify`. Pipeline-version stamping is a Chroma-only staleness optimization, not a correctness input (the read side already returns None = fresh for service stubs).

The last of the chain surfaced by the 2026-06-20 full CLI live smoke. **With this, the full service-mode CLI path works end-to-end against the JAR-launched pgvector service:** `nx init --service` → `nx index repo` (completes) → `nx taxonomy discover` → 2 labeled topics. +2 regression tests. Bead: nexus-kwkkz