### PR TITLE
Service-mode taxonomy + index: discover/split/project on pgvector + 4 index-path fixes (live-verified)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -277,7 +277,7 @@ Pre-existing drift surfaced during Phase 5 verification (filed as separate beads
 
 Taxonomy (RDR-070) builds a topic hierarchy over T3 collections using existing embeddings, without re-embedding. HDBSCAN clusters the vectors already stored in ChromaDB, labels them with c-TF-IDF, and persists topic assignments to T2 SQLite. Every subsequent `store_put` call assigns the new document to the nearest centroid via ANN lookup. Search then uses these assignments to boost same-topic results and group output.
 
-In local mode, `code__*` collections are excluded by default because the general-purpose local embedder (bge-768) clusters code poorly. Cloud mode uses `voyage-code-3` and is unaffected. (Note: as of 6.0, taxonomy discovery is suspended while the nexus-service is the T3 backend; see the taxonomy command docs.)
+In local mode, `code__*` collections are excluded by default because the general-purpose local embedder (bge-768) clusters code poorly. Cloud mode uses `voyage-code-3` and is unaffected. (As of 6.0, discovery/rebuild/assignment run on the nexus-service backend per nexus-7ydks; `nx taxonomy split`/`project` are still being ported.)
 
 ### Data Flow
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -241,13 +241,11 @@ taxonomy:
 
 ### How it works
 
-> **Note (6.0):** Taxonomy *discovery* is suspended in service mode (the default
-> since 6.0): `nx taxonomy discover` exits with a clear error and `nx index repo`
-> skips the discovery step. Discovery needs a raw Chroma client retired with the
-> Chroma serving paths (RDR-155 P4a); restoring it on the pgvector service is a
-> tracked follow-on (`nexus-gmiaf.21+`). Previously-computed assignments still
-> drive search boosts and `topic=` scoping. The flow below is the pre-6.0 model
-> and the target once discovery is restored.
+> **Note (6.0):** Taxonomy *discovery*, *rebuild*, and per-document *assignment*
+> run on the nexus-service backend (the default since 6.0): embeddings are read
+> server-side and topics + centroids persist through the service (nexus-7ydks).
+> Still being ported (`nexus-7ydks`): `nx taxonomy split` / `project` and the
+> automatic cross-collection projection pass refuse cleanly on the service.
 
 After `nx index repo` (or `nx taxonomy discover --all`):
 

--- a/docs/querying-guide.md
+++ b/docs/querying-guide.md
@@ -199,7 +199,7 @@ Several mechanisms run automatically across all interfaces.
 
 ### Topic-aware ranking
 
-> **Note (6.0):** Topic *discovery* is suspended in service mode (the default since 6.0) — `nx taxonomy discover` errors and `nx index repo` skips discovery, pending the pgvector follow-on (`nexus-gmiaf.21+`). Ranking against **previously-computed** topics (`topic=`, `cluster_by="semantic"`, distance boosts) still works; only the discovery of new topics is paused.
+> **Note (6.0):** Topic *discovery*, *rebuild*, and per-document *assignment* run on the nexus-service backend (the default since 6.0) — `nx taxonomy discover` and `nx index repo` work normally (nexus-7ydks). `nx taxonomy split` / `project` and the cross-collection projection pass are still being ported and refuse cleanly on the service.
 
 After `nx index repo` (or `nx taxonomy discover --all`), topics are clustered via HDBSCAN with Claude-Haiku auto-labels. Topic-aware ranking then works three ways:
 

--- a/docs/repo-indexing.md
+++ b/docs/repo-indexing.md
@@ -263,16 +263,13 @@ This means `nx catalog search` and `nx catalog links` work immediately after ind
 
 ## Taxonomy Auto-Discovery
 
-> **Note (6.0):** Taxonomy *discovery* is temporarily suspended while the
-> nexus-service is the T3 backend (service mode, the default since 6.0).
-> Discovery reads embeddings through a raw Chroma client that retired with the
-> Chroma serving paths (RDR-155 P4a); it is a tracked follow-on
-> (`nexus-gmiaf.21+`). In practice: `nx index repo` produces no new topics
-> (the discovery step is skipped silently), and `nx taxonomy discover` exits
-> with a clear error. Search features that read **previously-computed**
-> taxonomy (`topic=`, `cluster_by="semantic"`, topic boosts) continue to work.
-> The behavior described below is the pre-6.0 model and the target once
-> discovery is restored on the pgvector service.
+> **Note (6.0):** Taxonomy *discovery*, *rebuild*, and per-document
+> *assignment* run on the nexus-service backend (service mode, the default
+> since 6.0): they fetch embeddings server-side and persist topics + centroids
+> through the service (nexus-7ydks). `nx index repo` discovers and assigns
+> normally. Two operations are still being ported (`nexus-7ydks`): `nx taxonomy
+> split` / `project` and the automatic cross-collection projection pass — they
+> remain raw-Chroma-only and refuse cleanly on the service.
 
 After indexing completes, `nx index repo` automatically runs topic discovery on the new or updated collections. HDBSCAN clusters the collection's embeddings to find natural topic groupings, and each cluster is labeled with a short descriptive phrase using Claude Haiku (when an Anthropic API key is available). The results are stored in T2 and surfaced by `nx search` as topic filters.
 

--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -241,11 +241,41 @@ public final class CatalogRepository {
                 "tenant '*' is a reserved sentinel and cannot own catalog entries");
         }
         tenantScope.withTenant(tenant, ctx -> {
+            // nexus-0cy4b: tumbler_prefix is NOT NULL. The SQLite catalog
+            // (Catalog.register_owner) assigns the owner prefix server-side; the
+            // HTTP client sends none and expects the same here. Mirror it: reuse
+            // the existing owner's prefix for this repo (idempotent), else
+            // allocate 1.{MAX+1}. An explicit prefix (ETL/import) is honoured.
+            String prefix = s(o, "tumbler_prefix");
+            if (prefix == null || prefix.isBlank()) {
+                String repoHash = s(o, "repo_hash");
+                if (repoHash != null && !repoHash.isBlank()) {
+                    prefix = ctx.select(F_OWN_PREFIX)
+                                .from(T_OWNERS)
+                                .where(F_OWN_REPO.eq(repoHash))
+                                .limit(1)
+                                .fetchOne(F_OWN_PREFIX);
+                }
+                if (prefix == null || prefix.isBlank()) {
+                    // Next owner number: MAX(int after the first dot) + 1 over
+                    // '1.%' owners. RLS scopes this to the tenant.
+                    Integer maxNum = ctx.select(
+                            DSL.coalesce(
+                                DSL.max(DSL.field(
+                                    "CAST(split_part(tumbler_prefix, '.', 2) AS INTEGER)",
+                                    Integer.class)),
+                                DSL.inline(0)))
+                        .from(T_OWNERS)
+                        .where(F_OWN_PREFIX.like("1.%"))
+                        .fetchOne(0, Integer.class);
+                    prefix = "1." + ((maxNum == null ? 0 : maxNum) + 1);
+                }
+            }
             ctx.insertInto(T_OWNERS,
                     F_OWN_TENANT, F_OWN_PREFIX, F_OWN_NAME, F_OWN_TYPE,
                     F_OWN_REPO, F_OWN_DESC, F_OWN_ROOT, F_OWN_HEAD)
                .values(tenant,
-                       s(o,"tumbler_prefix"), s(o,"name"), s(o,"owner_type"),
+                       prefix, s(o,"name"), s(o,"owner_type"),
                        s(o,"repo_hash"), s(o,"description"), nne(s(o,"repo_root")),
                        s(o,"head_hash"))
                .onConflict(F_OWN_TENANT, F_OWN_PREFIX)

--- a/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
@@ -197,6 +197,37 @@ class CatalogRepositoryTest {
         assertThat(found).isNull();
     }
 
+    @Test @Order(99)
+    void owner_serverSideAllocatesPrefix_whenAbsent() {
+        // nexus-0cy4b: the HTTP client (Catalog.ensure_owner_for_repo) sends NO
+        // tumbler_prefix and expects the server to assign one (the column is
+        // NOT NULL). Fresh tenant -> RLS-clean owner space -> deterministic
+        // 1.1, 1.2, and idempotent reuse by repo_hash.
+        final String T = "cat-tenant-alloc";
+        repo.upsertOwner(T, Map.of(
+            "name", "repoA", "owner_type", "repo", "repo_hash", "hashA",
+            "repo_root", "/x/a"));
+        repo.upsertOwner(T, Map.of(
+            "name", "repoB", "owner_type", "repo", "repo_hash", "hashB",
+            "repo_root", "/x/b"));
+
+        var a = repo.ownerByRepoHash(T, "hashA");
+        var b = repo.ownerByRepoHash(T, "hashB");
+        assertThat(a).isNotNull();
+        assertThat(b).isNotNull();
+        assertThat(a.get("tumbler_prefix")).isEqualTo("1.1");
+        assertThat(b.get("tumbler_prefix")).isEqualTo("1.2");
+
+        // Re-register repoA with no prefix -> idempotent (reuses 1.1, not 1.3).
+        repo.upsertOwner(T, Map.of(
+            "name", "repoA-renamed", "owner_type", "repo", "repo_hash", "hashA",
+            "repo_root", "/x/a"));
+        var a2 = repo.ownerByRepoHash(T, "hashA");
+        assertThat(a2.get("tumbler_prefix")).isEqualTo("1.1");
+        assertThat(a2.get("name")).isEqualTo("repoA-renamed");
+        assertThat(repo.listOwners(T)).hasSize(2);
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // DOCUMENTS
     // ══════════════════════════════════════════════════════════════════════════

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -259,8 +259,8 @@ class HttpCatalogClient:
 
     def ensure_owner_for_repo(
         self,
-        *,
         repo: Path | str,
+        *,
         name: str | None = None,
         owner_type: str = "repo",
         head_hash: str | None = None,

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -270,12 +270,28 @@ class HttpCatalogClient:
 
         If ``tumbler_prefix`` is provided (e.g. during ETL migration) it is used
         directly.  Otherwise the server assigns a prefix; we query it back.
+
+        nexus-0cy4b: mirror the canonical ``Catalog.ensure_owner_for_repo`` — key
+        the owner on ``repo_hash`` (from ``_repo_identity_with_main`` so it is
+        stable across worktrees) and send it. The server dedups by repo_hash and
+        assigns the prefix; without repo_hash the server would allocate a fresh
+        prefix per call and collide on the (name, owner_type) unique constraint.
         """
-        effective_name = name or Path(repo).name
+        from nexus.repo_identity import _repo_identity_with_main  # noqa: PLC0415
+
+        derived_name, repo_hash, main_repo = _repo_identity_with_main(Path(repo))
+        effective_name = name or derived_name
+        # Idempotent fast path: an owner already exists for this repo
+        # (owner_for_repo returns None on 404).
+        if owner_type == "repo" and repo_hash:
+            existing = self.owner_for_repo(repo_hash)
+            if existing is not None:
+                return existing
         payload: dict = {
             "name": effective_name,
             "owner_type": owner_type,
-            "repo_root": str(repo),
+            "repo_root": str(main_repo),
+            "repo_hash": repo_hash,
         }
         if tumbler_prefix: payload["tumbler_prefix"] = tumbler_prefix
         if head_hash:      payload["head_hash"] = head_hash
@@ -284,7 +300,11 @@ class HttpCatalogClient:
             return Tumbler.parse(result["tumbler_prefix"])
         if tumbler_prefix:
             return Tumbler.parse(tumbler_prefix)
-        # Query back
+        # Query back — prefer the exact repo_hash lookup over name (ambiguous).
+        if owner_type == "repo" and repo_hash:
+            existing = self.owner_for_repo(repo_hash)
+            if existing is not None:
+                return existing
         owners = self._get("/owners/by_name", name=effective_name)
         rows = owners.get("owners", []) if owners else []
         if rows:

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -198,7 +198,13 @@ def _discover_taxonomy(collection_name, taxonomy, t3, *, force=False):
     nexus-7ydks: now takes the T3 handle (``T3Database`` raw or
     ``HttpVectorClient`` service), not the raw ``_client``.
     """
-    from nexus.commands.taxonomy_cmd import discover_for_collection
+    from nexus.commands.taxonomy_cmd import (
+        _require_supported_taxonomy_backend,
+        discover_for_collection,
+    )
+    # nexus-7ydks S1: close the split-backend hole on the post-index path too
+    # (discover_cmd/rebuild_cmd already guard; this shared wrapper did not).
+    _require_supported_taxonomy_backend(t3, taxonomy)
     return discover_for_collection(
         collection_name, taxonomy, t3, force=force,
     )

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -789,10 +789,12 @@ def run_collection_postprocessing(
                         f"  Review:   {unreviewed} topics pending. "
                         f"Run `nx taxonomy review` to curate."
                     )
-                # Cross-collection projection pass (RDR-075 SC-7)
+                # Cross-collection projection pass (RDR-075 SC-7). nexus-9pqoj:
+                # project_against handles both backends; pass the chroma client
+                # for a raw T3Database or the service handle itself.
                 try:
                     proj_total = _project_cross_collections(
-                        db.taxonomy, collections, t3._client,
+                        db.taxonomy, collections, getattr(t3, "_client", t3),
                     )
                     if proj_total:
                         _say(f"  Project:  {proj_total} cross-collection assignments.")

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -192,11 +192,15 @@ def index() -> None:
         )
 
 
-def _discover_taxonomy(collection_name, taxonomy, chroma_client, *, force=False):
-    """Wrapper for discover_for_collection — importable for patching in tests."""
+def _discover_taxonomy(collection_name, taxonomy, t3, *, force=False):
+    """Wrapper for discover_for_collection — importable for patching in tests.
+
+    nexus-7ydks: now takes the T3 handle (``T3Database`` raw or
+    ``HttpVectorClient`` service), not the raw ``_client``.
+    """
     from nexus.commands.taxonomy_cmd import discover_for_collection
     return discover_for_collection(
-        collection_name, taxonomy, chroma_client, force=force,
+        collection_name, taxonomy, t3, force=force,
     )
 
 
@@ -750,7 +754,7 @@ def run_collection_postprocessing(
         with T2Database(default_db_path()) as db:  # epsilon-allow: read-only: discover/project compute use a local chroma client; all pure-T2 writes routed via t2_index_write (RDR-151 Phase 3, nexus-uzay8)
             for col_name in collections:
                 try:
-                    n = _discover_taxonomy(col_name, db.taxonomy, t3._client)
+                    n = _discover_taxonomy(col_name, db.taxonomy, t3)
                     total_topics += n
                 except Exception:
                     _log.debug("taxonomy_discover_failed", collection=col_name, exc_info=True)

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -156,6 +156,11 @@ def _fetch_service_vectors(
             break
 
     _progress(f"    fetched {len(ids):,} chunks")
+    # Positional-alignment assumption (nexus-7ydks S2): get_embeddings returns
+    # rows in request order (documented contract, http_vector_client.py), so
+    # embeddings[i] pairs with ids[i]/texts[i]. The count-equality check below
+    # is the tripwire; if the service ever returned an id->vector MAP instead,
+    # this would need a by-id realign rather than the positional zip.
     embeddings = t3.get_embeddings(collection_name, ids)
     if embeddings is None or len(embeddings) != len(ids):
         # get_embeddings drops ids the service cannot resolve (N < len(ids)),

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -180,7 +180,8 @@ def _discover_via_service(
     collection_name: str, taxonomy: Any, t3: Any, *, force: bool,
 ) -> int:
     """Service-backed discovery: fetch vectors from the service, persist through
-    the HttpTaxonomyStore drop-in (centroids via the taxonomy port).
+    the HttpTaxonomyStore drop-in (centroids via the service's
+    ``/v1/taxonomy/centroids`` HTTP route).
 
     nexus-7ydks. The store's ``discover_topics`` / ``rebuild_taxonomy`` are
     complete CatalogTaxonomy mirrors and persist through the Java service (the
@@ -251,7 +252,8 @@ def discover_for_collection(
         Number of topics created.
     """
     # nexus-7ydks: service-backed taxonomy store → fetch from the service and
-    # persist through the HttpTaxonomyStore drop-in (centroids via the port).
+    # persist through the HttpTaxonomyStore drop-in (centroids via the service's
+    # /v1/taxonomy/centroids HTTP route).
     if not _has_raw_access(taxonomy):
         return _discover_via_service(collection_name, taxonomy, t3, force=force)
 

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -733,6 +733,12 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
                         result = db.taxonomy.project_against(
                             col_name, others, _proj_handle, threshold=0.85,
                         )
+                        if result.get("incomplete_fetch"):
+                            click.echo(
+                                f"  Projection: skipped {col_name} (incomplete "
+                                "service embedding read; collection may be mid-index)"
+                            )
+                            continue
                         assignments = result.get("chunk_assignments", [])
                         if assignments:
                             _persist_assignments(
@@ -1735,6 +1741,16 @@ def project_cmd(
             icf_map=icf_map,
             progress=True,
         )
+        # nexus-9pqoj S1: a service fetch that could not align embeddings to ids
+        # returns empty-with-flag; surface it loudly instead of looking like
+        # "no matches".
+        if result.get("incomplete_fetch"):
+            raise click.ClickException(
+                f"Could not read all source embeddings for {source_collection} "
+                "from the service (count mismatch). The collection may be mid-"
+                "index; retry once indexing settles, or re-index it."
+            )
+
         # Fall through: display logic uses `threshold` local — rebind
         # to the resolved value so messages reflect what was applied.
         threshold = resolved_threshold
@@ -1865,6 +1881,12 @@ def _run_backfill(
                 icf_map=icf_map,
                 progress=True,
             )
+            if result.get("incomplete_fetch"):
+                click.echo(
+                    f"    Skipped: incomplete service embedding read for {src} "
+                    "(collection may be mid-index; retry later)"
+                )
+                continue
             matched = len(result["matched_topics"])
             novel = len(result["novel_chunks"])
             chunks = result["total_chunks"]

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -45,27 +45,6 @@ if TYPE_CHECKING:
 _log = structlog.get_logger(__name__)
 
 
-def _reject_service_backed_handle(t3: Any) -> None:
-    """Fail loud when the T3 handle has no raw Chroma client.
-
-    Retained for the taxonomy paths NOT yet ported to the service
-    (``nx taxonomy split`` / ``project``): their bodies still cluster + write
-    centroids through a raw Chroma client. ``nx taxonomy discover`` / ``rebuild``
-    ARE ported (nexus-7ydks) and instead use
-    :func:`_require_supported_taxonomy_backend`, so do not add this guard there.
-    """
-    from nexus.db.http_vector_client import is_service_backed
-
-    if is_service_backed(t3):
-        raise click.ClickException(
-            "this taxonomy operation needs a raw Chroma client, which retired "
-            "with the Chroma serving paths (RDR-155 Phase 4a). `nx taxonomy "
-            "discover` and `rebuild` are supported on the service; split / "
-            "project on the pgvector service are a tracked follow-on "
-            "(nexus-7ydks)."
-        )
-
-
 def _require_supported_taxonomy_backend(t3: Any, taxonomy: Any) -> None:
     """Block only the unsupported split: service T3 + raw-SQLite taxonomy.
 
@@ -740,24 +719,19 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
             else:
                 click.echo(f"  {col_name}: skipped")
 
-        # Cross-collection projection pass (RDR-075 SC-7).
-        # nexus-7ydks: project_against still uses a raw Chroma client (not yet
-        # ported to the service), so skip it LOUDLY in service mode rather than
-        # AttributeError on t3._client and swallow it as a generic failure.
-        from nexus.db.http_vector_client import is_service_backed
-        if total_topics and len(targets) > 1 and is_service_backed(t3):
-            click.echo(
-                "  Projection: skipped (cross-collection projection on the "
-                "pgvector service is a tracked follow-on, nexus-7ydks)"
-            )
-        elif total_topics and len(targets) > 1:
+        # Cross-collection projection pass (RDR-075 SC-7). nexus-9pqoj:
+        # project_against handles both backends; pass the raw chroma client for
+        # a raw T3Database (has ._client) or the service handle itself for an
+        # HttpVectorClient (no ._client).
+        _proj_handle = getattr(t3, "_client", t3)
+        if total_topics and len(targets) > 1:
             try:
                 proj_count = 0
                 for col_name in targets:
                     others = [c for c in targets if c != col_name]
                     if others:
                         result = db.taxonomy.project_against(
-                            col_name, others, t3._client, threshold=0.85,
+                            col_name, others, _proj_handle, threshold=0.85,
                         )
                         assignments = result.get("chunk_assignments", [])
                         if assignments:
@@ -1080,7 +1054,26 @@ def split_cmd(topic_label: str, k: int, collection: str) -> None:
 
         collection_name = topic["collection"]
         t3 = make_t3()
-        _reject_service_backed_handle(t3)
+
+        # nexus-9pqoj: service-backed split. The store's split_topic does the
+        # full fetch -> compute -> persist -> centroid round-trip via the service.
+        if not _has_raw_access(db.taxonomy):
+            # service-backed split_topic persists through the Java service (the
+            # single writer for HttpTaxonomyStore), not the SQLite WAL writer the
+            # boundary lint guards, so t2_index_write routing does not apply.
+            child_count = db.taxonomy.split_topic(topic_id, k, t3)  # epsilon-allow: service single-writer persist
+            click.echo(f"Split '{topic_label}' into {child_count} sub-topics.")
+            if child_count:
+                coll_scope = collection_name or collection
+                scope = f" -c {coll_scope}" if coll_scope else ""
+                click.echo(
+                    f"Action: {child_count} new sub-topics have n-gram labels. "
+                    f"Run `nx taxonomy label{scope}` to get human-readable labels."
+                )
+            return
+
+        # Raw path (unchanged): refuse the split-backend config, then inline.
+        _require_supported_taxonomy_backend(t3, db.taxonomy)
         chroma_client = t3._client
 
         # Fetch texts from T3 collection
@@ -1678,6 +1671,11 @@ def project_cmd(
 
     db = _T2Database(_default_db_path())
     t3 = make_t3()
+    # nexus-9pqoj: refuse the split-backend config; project_against handles both
+    # backends, so pass the chroma client (raw T3Database) or the service handle
+    # (HttpVectorClient has no ._client).
+    _require_supported_taxonomy_backend(t3, db.taxonomy)
+    _proj_handle = getattr(t3, "_client", t3)
 
     # Resolve threshold: explicit flag wins; otherwise per-corpus default
     # (defaults applied at the per-source level inside _run_backfill).
@@ -1688,7 +1686,7 @@ def project_cmd(
     try:
         if backfill:
             _run_backfill(
-                db.taxonomy, t3._client,
+                db.taxonomy, _proj_handle,
                 threshold=threshold, top_k=top_k, persist=persist,
                 use_icf=use_icf,
             )
@@ -1732,7 +1730,7 @@ def project_cmd(
             db.taxonomy.compute_icf_map(use_cache=True) if use_icf else None
         )
         result = db.taxonomy.project_against(
-            source_collection, targets, t3._client,
+            source_collection, targets, _proj_handle,
             threshold=resolved_threshold, top_k=top_k,
             icf_map=icf_map,
             progress=True,

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -48,21 +48,150 @@ _log = structlog.get_logger(__name__)
 def _reject_service_backed_handle(t3: Any) -> None:
     """Fail loud when the T3 handle has no raw Chroma client.
 
-    RDR-155 P4a.2 (nexus-1k8s1): taxonomy discovery reads embeddings through
-    the raw Chroma client, which retired with the Chroma serving paths —
-    ``make_t3()`` returns the service-backed handle in production now.
-    Taxonomy on the pgvector service is a tracked follow-on
-    (nexus-gmiaf.21+); until it lands this command refuses cleanly instead
-    of surfacing an AttributeError.
+    Retained for the taxonomy paths NOT yet ported to the service
+    (``nx taxonomy split`` / ``project``): their bodies still cluster + write
+    centroids through a raw Chroma client. ``nx taxonomy discover`` / ``rebuild``
+    ARE ported (nexus-7ydks) and instead use
+    :func:`_require_supported_taxonomy_backend`, so do not add this guard there.
     """
     from nexus.db.http_vector_client import is_service_backed
 
     if is_service_backed(t3):
         raise click.ClickException(
-            "taxonomy discovery needs a raw Chroma client, which retired with "
-            "the Chroma serving paths (RDR-155 Phase 4a). Taxonomy on the "
-            "pgvector service is a tracked follow-on (nexus-gmiaf.21+)."
+            "this taxonomy operation needs a raw Chroma client, which retired "
+            "with the Chroma serving paths (RDR-155 Phase 4a). `nx taxonomy "
+            "discover` and `rebuild` are supported on the service; split / "
+            "project on the pgvector service are a tracked follow-on "
+            "(nexus-7ydks)."
         )
+
+
+def _require_supported_taxonomy_backend(t3: Any, taxonomy: Any) -> None:
+    """Block only the unsupported split: service T3 + raw-SQLite taxonomy.
+
+    nexus-7ydks. Supported: both service-backed (6.0 default) or both raw
+    (legacy / ``NX_STORAGE_BACKEND=sqlite``). The split case has no raw Chroma
+    client for the legacy centroid path, so refuse cleanly.
+    """
+    from nexus.db.http_vector_client import is_service_backed
+
+    if is_service_backed(t3) and _has_raw_access(taxonomy):
+        raise click.ClickException(
+            "taxonomy discovery is not supported with a service-backed T3 vector "
+            "store but a raw-SQLite taxonomy store (NX_STORAGE_BACKEND_TAXONOMY="
+            "sqlite). Use a uniform backend: either let both default to the "
+            "service, or set NX_STORAGE_BACKEND=sqlite for both."
+        )
+
+
+def _enumerate_discoverable_collections(t3: Any, exclude: list[str]) -> list[str]:
+    """Return collection names with >=5 chunks, skipping excludes + taxonomy__.
+
+    Backend-uniform: raw T3 exposes ``_client.list_collections()`` (Chroma
+    Collection objects); service T3 exposes ``list_collections()`` (list of
+    dicts with ``name``/``count``). nexus-7ydks.
+    """
+    from fnmatch import fnmatch
+
+    from nexus.db.http_vector_client import is_service_backed
+
+    names: list[tuple[str, int]] = []
+    if is_service_backed(t3):
+        for c in t3.list_collections():
+            names.append((c.get("name", ""), int(c.get("count", 0) or 0)))
+    else:
+        for c in t3._client.list_collections():
+            names.append((c.name, c.count()))
+    return [
+        name for name, count in names
+        if count >= 5
+        and name
+        and not name.startswith("taxonomy__")
+        and not any(fnmatch(name, pat) for pat in exclude)
+    ]
+
+
+def _fetch_service_vectors(
+    collection_name: str, t3: Any,
+) -> tuple[list[str], list[str], "np.ndarray"] | None:
+    """Fetch (doc_ids, texts, embeddings) for a collection via the nexus-service.
+
+    nexus-7ydks. Enumerates ids + documents through the service collection
+    stub's paginated ``get`` and pulls the stored embeddings server-side via
+    ``t3.get_embeddings`` (no re-embed). Returns ``None`` on a fatal fetch
+    problem (collection missing, or embeddings the service could not align to
+    the requested ids — which would silently corrupt clustering).
+    """
+    try:
+        n = t3.count(collection_name)
+    except Exception:
+        _log.warning("taxonomy_service_count_failed", collection=collection_name)
+        return None
+    if n < 5:
+        return [], [], np.empty((0, 0), dtype=np.float32)
+
+    stub = t3.get_or_create_collection(collection_name)
+    ids: list[str] = []
+    texts: list[str] = []
+    offset = 0
+    page_size = 250  # service quota: Get limit 300
+    _milestone = max(n // 4, 1)
+    _next = _milestone
+    while offset < n:
+        if offset >= _next and _next < n:
+            _progress(f"    fetching {offset:,}/{n:,} chunks ({100 * offset // n}%)")
+            _next += _milestone
+        page = stub.get(include=["documents"], limit=page_size, offset=offset)
+        page_ids = page.get("ids") or []
+        page_docs = page.get("documents") or []
+        if not page_ids:
+            break
+        for i, pid in enumerate(page_ids):
+            doc = page_docs[i] if i < len(page_docs) else None
+            if doc is not None:
+                ids.append(pid)
+                texts.append(doc)
+        offset += len(page_ids)
+        if len(page_ids) < page_size:
+            break
+
+    _progress(f"    fetched {len(ids):,} chunks")
+    embeddings = t3.get_embeddings(collection_name, ids)
+    if embeddings is None or len(embeddings) != len(ids):
+        # get_embeddings drops ids the service cannot resolve (N < len(ids)),
+        # which would desync ids/texts/embeddings. Refuse rather than cluster
+        # misaligned rows (feedback_no_silent_fallbacks_for_correctness).
+        _log.warning(
+            "taxonomy_service_embedding_misalign",
+            collection=collection_name,
+            ids=len(ids),
+            embeddings=0 if embeddings is None else len(embeddings),
+        )
+        return None
+    return ids, texts, np.asarray(embeddings, dtype=np.float32)
+
+
+def _discover_via_service(
+    collection_name: str, taxonomy: Any, t3: Any, *, force: bool,
+) -> int:
+    """Service-backed discovery: fetch vectors from the service, persist through
+    the HttpTaxonomyStore drop-in (centroids via the taxonomy port).
+
+    nexus-7ydks. The store's ``discover_topics`` / ``rebuild_taxonomy`` are
+    complete CatalogTaxonomy mirrors and persist through the Java service (the
+    single writer), so no daemon-routed split is needed here.
+    """
+    fetched = _fetch_service_vectors(collection_name, t3)
+    if fetched is None:
+        return 0
+    doc_ids, texts, embeddings = fetched
+    if len(doc_ids) < 5:
+        _log.info("too_few_docs", collection=collection_name, n=len(doc_ids))
+        return 0
+    _progress(f"    clustering {len(doc_ids):,} x {embeddings.shape[1]}d (service)...")
+    if force:
+        return taxonomy.rebuild_taxonomy(collection_name, doc_ids, embeddings, texts)
+    return taxonomy.discover_topics(collection_name, doc_ids, embeddings, texts)
 
 
 def _progress(msg: str) -> None:
@@ -82,7 +211,7 @@ def _progress(msg: str) -> None:
 def discover_for_collection(
     collection_name: str,
     taxonomy: "CatalogTaxonomy",
-    chroma_client: Any,
+    t3: Any,
     *,
     force: bool = False,
 ) -> int:
@@ -102,9 +231,11 @@ def discover_for_collection(
     collection_name:
         ChromaDB collection to discover topics for.
     taxonomy:
-        :class:`CatalogTaxonomy` instance (owns T2 topic tables).
-    chroma_client:
-        Raw ``chromadb.ClientAPI`` (not ``T3Database``).
+        :class:`CatalogTaxonomy` (raw) or ``HttpTaxonomyStore`` (service).
+    t3:
+        The T3 handle (``T3Database`` raw, or ``HttpVectorClient`` service).
+        nexus-7ydks: service-backed handles route through
+        :func:`_discover_via_service`; raw handles use ``t3._client``.
     force:
         If True, delete existing topics for this collection before
         re-discovering (calls ``rebuild_taxonomy``).
@@ -114,6 +245,15 @@ def discover_for_collection(
     int
         Number of topics created.
     """
+    # nexus-7ydks: service-backed taxonomy store → fetch from the service and
+    # persist through the HttpTaxonomyStore drop-in (centroids via the port).
+    if not _has_raw_access(taxonomy):
+        return _discover_via_service(collection_name, taxonomy, t3, force=force)
+
+    # Raw path (unchanged): daemon-routed persist (RDR-128/151) over a raw
+    # Chroma client. Accept either a ``T3Database`` handle (use ``._client``)
+    # or a raw chroma client passed directly (programmatic / test callers).
+    chroma_client = getattr(t3, "_client", t3)
     try:
         coll = chroma_client.get_collection(
             collection_name, embedding_function=None,
@@ -549,16 +689,11 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
         if is_local_mode() else []
     )
     t3 = make_t3()
-    _reject_service_backed_handle(t3)
 
     if discover_all:
-        colls = t3._client.list_collections()
-        targets = [
-            c.name for c in colls
-            if c.count() >= 5
-            and not any(fnmatch(c.name, pat) for pat in exclude)
-            and not c.name.startswith("taxonomy__")
-        ]
+        # Backend-support is checked per-collection inside the loop below
+        # (authoritative); enumeration itself needs no taxonomy handle.
+        targets = _enumerate_discoverable_collections(t3, exclude)
         if not targets:
             click.echo("No eligible collections found.")
             return
@@ -580,8 +715,9 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
         for i, col_name in enumerate(targets, 1):
             if len(targets) > 1:
                 click.echo(f"[{i}/{len(targets)}] {col_name}")
+            _require_supported_taxonomy_backend(t3, db.taxonomy)
             count = discover_for_collection(
-                col_name, db.taxonomy, t3._client, force=force,
+                col_name, db.taxonomy, t3, force=force,
             )
             if count:
                 click.echo(f"  {col_name}: {count} topics")
@@ -597,8 +733,17 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
             else:
                 click.echo(f"  {col_name}: skipped")
 
-        # Cross-collection projection pass (RDR-075 SC-7)
-        if total_topics and len(targets) > 1:
+        # Cross-collection projection pass (RDR-075 SC-7).
+        # nexus-7ydks: project_against still uses a raw Chroma client (not yet
+        # ported to the service), so skip it LOUDLY in service mode rather than
+        # AttributeError on t3._client and swallow it as a generic failure.
+        from nexus.db.http_vector_client import is_service_backed
+        if total_topics and len(targets) > 1 and is_service_backed(t3):
+            click.echo(
+                "  Projection: skipped (cross-collection projection on the "
+                "pgvector service is a tracked follow-on, nexus-7ydks)"
+            )
+        elif total_topics and len(targets) > 1:
             try:
                 proj_count = 0
                 for col_name in targets:
@@ -661,9 +806,9 @@ def rebuild_cmd(collection: str, project: str, k: int | None) -> None:
 
     with _T2Database(_default_db_path()) as db:
         t3 = make_t3()
-        _reject_service_backed_handle(t3)
+        _require_supported_taxonomy_backend(t3, db.taxonomy)
         count = discover_for_collection(
-            collection, db.taxonomy, t3._client, force=True,
+            collection, db.taxonomy, t3, force=True,
         )
     click.echo(f"Rebuilt {count} topics for collection {collection!r}.")
 

--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -190,6 +190,16 @@ def effective_embedding_model_for_writes(content_type: str) -> str:
     """
     from nexus.config import is_local_mode  # noqa: PLC0415
     if is_local_mode():
+        # nexus-xq8f9: in service-vector mode (the 6.0 default) the nexus-service
+        # embeds server-side with bge-768 (RDR-160), independent of whether the
+        # CLIENT has the [local]/fastembed extra. Naming the collection from the
+        # client's local-EF tier (which falls back to minilm-384 when fastembed
+        # is absent) makes the service refuse the write (HTTP 422, model
+        # mismatch). Follow the service's embedder token instead.
+        from nexus.db.http_vector_client import is_vector_service_mode  # noqa: PLC0415
+        if is_vector_service_mode():
+            from nexus.db.local_ef import _MODEL_TOKENS, _TIER1_MODEL  # noqa: PLC0415
+            return _MODEL_TOKENS[_TIER1_MODEL]  # bge-base-en-v15-768
         from nexus.db.local_ef import local_model_token  # noqa: PLC0415
         return local_model_token()
     return canonical_embedding_model(content_type)

--- a/src/nexus/db/t2/http_taxonomy_store.py
+++ b/src/nexus/db/t2/http_taxonomy_store.py
@@ -924,6 +924,77 @@ class HttpTaxonomyStore:
         self.record_discover_count(collection_name, len(doc_ids))
         return len(topic_ids)
 
+    @staticmethod
+    def _svc_fetch_by_ids(t3: Any, collection: str, doc_ids: list[str]):
+        """Fetch (ids, texts, embeddings) for specific doc_ids via the service.
+
+        nexus-9pqoj. Texts come from the service store-get (`stub.get(ids=...)`),
+        embeddings server-side via `t3.get_embeddings` (the collection's native
+        space). Returns the aligned subset that resolved; ``embeddings`` is
+        ``None`` when the service could not align vectors to the fetched ids
+        (count skew → refuse rather than mis-pair).
+        """
+        stub = t3.get_or_create_collection(collection)
+        ids: list[str] = []
+        texts: list[str] = []
+        _PAGE = 250
+        for i in range(0, len(doc_ids), _PAGE):
+            batch = doc_ids[i:i + _PAGE]
+            res = stub.get(ids=batch, include=["documents"])
+            for fid, fdoc in zip(res.get("ids") or [], res.get("documents") or []):
+                if fdoc:
+                    ids.append(fid)
+                    texts.append(fdoc)
+        if not ids:
+            return [], [], None
+        embs = t3.get_embeddings(collection, ids)
+        if embs is None or len(embs) != len(ids):
+            _log.warning(
+                "taxonomy_svc_fetch_by_ids_misalign",
+                collection=collection, want=len(ids),
+                got=0 if embs is None else len(embs),
+            )
+            return ids, texts, None
+        return ids, texts, np.asarray(embs, dtype=np.float32)
+
+    @staticmethod
+    def _svc_fetch_all_embeddings(t3: Any, collection: str):
+        """Fetch (ids, embeddings) for ALL chunks in a collection via the service.
+
+        nexus-9pqoj — the project source-side equivalent of
+        :meth:`_svc_fetch_by_ids`. Returns ``(ids, None)`` on count skew.
+        """
+        try:
+            n = t3.count(collection)
+        except Exception:
+            return [], None
+        if n == 0:
+            return [], np.empty((0, 0), dtype=np.float32)
+        stub = t3.get_or_create_collection(collection)
+        ids: list[str] = []
+        offset = 0
+        _PAGE = 300
+        while offset < n:
+            page = stub.get(include=[], limit=_PAGE, offset=offset)
+            pids = page.get("ids") or []
+            if not pids:
+                break
+            ids.extend(pids)
+            offset += len(pids)
+            if len(pids) < _PAGE:
+                break
+        if not ids:
+            return [], np.empty((0, 0), dtype=np.float32)
+        embs = t3.get_embeddings(collection, ids)
+        if embs is None or len(embs) != len(ids):
+            _log.warning(
+                "taxonomy_svc_fetch_all_misalign",
+                collection=collection, want=len(ids),
+                got=0 if embs is None else len(embs),
+            )
+            return ids, None
+        return ids, np.asarray(embs, dtype=np.float32)
+
     def split_topic(
         self,
         topic_id: int,
@@ -949,27 +1020,42 @@ class HttpTaxonomyStore:
             return 0
 
         collection_name = topic["collection"]
-        try:
-            coll = chroma_client.get_collection(collection_name, embedding_function=None)
-        except Exception:
-            _log.warning("split_collection_not_found", collection=collection_name)
-            return 0
 
-        _PAGE = 250
-        fetched_ids: list[str] = []
-        texts: list[str] = []
-        for i in range(0, len(doc_ids), _PAGE):
-            batch = doc_ids[i:i + _PAGE]
-            result = coll.get(ids=batch, include=["documents"])
-            for fid, fdoc in zip(result.get("ids") or [], result.get("documents") or []):
-                if fdoc:
-                    fetched_ids.append(fid)
-                    texts.append(fdoc)
-        if len(texts) < k:
-            return 0
+        # nexus-9pqoj: service-backed source reads. When the handle is the
+        # HttpVectorClient (service-mode CLI), pull the topic's STORED vectors
+        # via the service — NOT a MiniLM-384 re-embed, because parent and child
+        # centroids must share the collection's bge-768 / voyage space for ANN
+        # assignment to work. Raw chroma handles keep the legacy re-embed path.
+        from nexus.db.http_vector_client import is_service_backed
 
-        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
-        embeddings = np.array(ef(texts), dtype=np.float32)
+        if is_service_backed(chroma_client):
+            fetched_ids, texts, embeddings = self._svc_fetch_by_ids(
+                chroma_client, collection_name, doc_ids,
+            )
+            if not fetched_ids or len(texts) < k or embeddings is None:
+                return 0
+        else:
+            try:
+                coll = chroma_client.get_collection(collection_name, embedding_function=None)
+            except Exception:
+                _log.warning("split_collection_not_found", collection=collection_name)
+                return 0
+
+            _PAGE = 250
+            fetched_ids = []
+            texts = []
+            for i in range(0, len(doc_ids), _PAGE):
+                batch = doc_ids[i:i + _PAGE]
+                result = coll.get(ids=batch, include=["documents"])
+                for fid, fdoc in zip(result.get("ids") or [], result.get("documents") or []):
+                    if fdoc:
+                        fetched_ids.append(fid)
+                        texts.append(fdoc)
+            if len(texts) < k:
+                return 0
+
+            ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+            embeddings = np.array(ef(texts), dtype=np.float32)
 
         split_result = self.compute_split(
             topic_id, doc_ids, texts, fetched_ids, embeddings, collection_name, k,
@@ -1019,29 +1105,40 @@ class HttpTaxonomyStore:
             "matched_topics": [], "novel_chunks": [],
             "total_chunks": 0, "total_centroids": 0,
         }
-        # 1. Source chunk embeddings from T3 (chroma_client), paginated.
-        try:
-            src_coll = chroma_client.get_collection(source_collection, embedding_function=None)
-        except Exception:
-            return dict(_empty)
-        _PAGE = 300
-        src_ids: list[str] = []
-        src_emb_pages: list[np.ndarray] = []
-        offset = 0
-        while True:
-            page = src_coll.get(include=["embeddings"], limit=_PAGE, offset=offset)
-            page_ids = page.get("ids", [])
-            page_embs = page.get("embeddings")
-            if not page_ids or page_embs is None:
-                break
-            src_ids.extend(page_ids)
-            src_emb_pages.append(np.array(page_embs, dtype=np.float32))
-            if len(page_ids) < _PAGE:
-                break
-            offset += _PAGE
-        if not src_ids:
-            return dict(_empty)
-        src_embs = np.concatenate(src_emb_pages)
+        # 1. Source chunk embeddings. nexus-9pqoj: via the service when the
+        # handle is the HttpVectorClient (the stub's get() drops embeddings, so
+        # we must use get_embeddings); raw chroma keeps the legacy include path.
+        from nexus.db.http_vector_client import is_service_backed
+
+        if is_service_backed(chroma_client):
+            src_ids, src_embs = self._svc_fetch_all_embeddings(
+                chroma_client, source_collection,
+            )
+            if not src_ids or src_embs is None or src_embs.size == 0:
+                return dict(_empty)
+        else:
+            try:
+                src_coll = chroma_client.get_collection(source_collection, embedding_function=None)
+            except Exception:
+                return dict(_empty)
+            _PAGE = 300
+            src_ids = []
+            src_emb_pages: list[np.ndarray] = []
+            offset = 0
+            while True:
+                page = src_coll.get(include=["embeddings"], limit=_PAGE, offset=offset)
+                page_ids = page.get("ids", [])
+                page_embs = page.get("embeddings")
+                if not page_ids or page_embs is None:
+                    break
+                src_ids.extend(page_ids)
+                src_emb_pages.append(np.array(page_embs, dtype=np.float32))
+                if len(page_ids) < _PAGE:
+                    break
+                offset += _PAGE
+            if not src_ids:
+                return dict(_empty)
+            src_embs = np.concatenate(src_emb_pages)
 
         # 2. Target centroids from the centroid-port ($in target_collections).
         ctr_raw: list[list[float]] = []

--- a/src/nexus/db/t2/http_taxonomy_store.py
+++ b/src/nexus/db/t2/http_taxonomy_store.py
@@ -940,6 +940,9 @@ class HttpTaxonomyStore:
         _PAGE = 250
         for i in range(0, len(doc_ids), _PAGE):
             batch = doc_ids[i:i + _PAGE]
+            # The service store-get path ignores `include` and always returns
+            # the full {ids, documents, metadatas} envelope (VectorHandler P4a.2,
+            # nexus-1k8s1); we pass include for intent only.
             res = stub.get(ids=batch, include=["documents"])
             for fid, fdoc in zip(res.get("ids") or [], res.get("documents") or []):
                 if fdoc:
@@ -1114,7 +1117,13 @@ class HttpTaxonomyStore:
             src_ids, src_embs = self._svc_fetch_all_embeddings(
                 chroma_client, source_collection,
             )
-            if not src_ids or src_embs is None or src_embs.size == 0:
+            # nexus-9pqoj S1: distinguish an INCOMPLETE fetch (service could not
+            # align embeddings to ids) from a legitimately empty collection.
+            # Silent-zero on a fetch failure looks like 'no matches' to the user;
+            # flag it so the CLI surfaces it (feedback_no_silent_fallbacks).
+            if src_embs is None:
+                return {**_empty, "incomplete_fetch": True}
+            if not src_ids or src_embs.size == 0:
                 return dict(_empty)
         else:
             try:

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -69,9 +69,19 @@ PIPELINE_VERSION: str = "4"
 
 
 def stamp_collection_version(col: object) -> None:
-    """Write PIPELINE_VERSION to collection metadata, preserving existing keys."""
+    """Write PIPELINE_VERSION to collection metadata, preserving existing keys.
+
+    nexus-kwkkz: collection-level metadata via ``modify`` is Chroma-specific;
+    service-backed collections (``_ServiceCollectionStub``) do not expose it, so
+    pipeline-version stamping is a no-op there. This is a staleness optimization,
+    not a correctness input — the read side (``get_collection_pipeline_version``)
+    already degrades to ``None`` (treated as a fresh collection) for these.
+    """
+    modify = getattr(col, "modify", None)
+    if not callable(modify):
+        return
     existing = getattr(col, "metadata", None) or {}
-    col.modify(metadata={**existing, "pipeline_version": PIPELINE_VERSION})  # type: ignore[attr-defined]
+    modify(metadata={**existing, "pipeline_version": PIPELINE_VERSION})
 
 
 def get_collection_pipeline_version(col: object) -> str | None:

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -681,13 +681,50 @@ def taxonomy_assign_batch_hook(
     # unconditionally while tests inject chroma-backed T3Database fixtures.
     from nexus.db.http_vector_client import is_service_backed
     if is_service_backed(get_t3()):
-        import structlog
-        structlog.get_logger().info(
-            "taxonomy_assign_skipped_service_mode",
-            collection=collection,
-            doc_count=len(doc_ids),
-            note="taxonomy-via-chroma not supported on service backend; tracked in nexus-gmiaf.21+",
-        )
+        # nexus-7ydks: service-backed incremental assignment. Mirrors the raw
+        # path below (compute same + cross, one persist) but persists through
+        # the Java service via the HttpTaxonomyStore drop-in — no raw Chroma
+        # client, no daemon-routed SQLite write.
+        if is_local_mode():
+            exclude = load_config().get("taxonomy", {}).get("local_exclude_collections", [])
+            if any(fnmatch(collection, pat) for pat in exclude):
+                return
+        svc_embeddings = embeddings
+        if not svc_embeddings:
+            try:
+                arr = get_t3().get_embeddings(collection, doc_ids)
+            except Exception:
+                arr = None
+            # get_embeddings drops ids it cannot resolve; a count skew would
+            # mis-pair vectors to docs, so skip rather than assign misaligned.
+            if arr is None or len(arr) != len(doc_ids):
+                import structlog
+                structlog.get_logger().debug(
+                    "taxonomy_assign_service_embed_unavailable",
+                    collection=collection,
+                    want=len(doc_ids),
+                    got=0 if arr is None else len(arr),
+                )
+                return
+            svc_embeddings = arr.tolist()
+        try:
+            def _svc_assign(db):  # noqa: ANN001
+                same = db.taxonomy.compute_assignments(
+                    collection, doc_ids, svc_embeddings, cross_collection=False,
+                )
+                cross = db.taxonomy.compute_assignments(
+                    collection, doc_ids, svc_embeddings, cross_collection=True,
+                )
+                a = same + cross
+                if a:
+                    db.taxonomy.persist_assignments(a)
+                return len(a)
+            t2_index_write(_svc_assign)
+        except Exception:
+            import structlog
+            structlog.get_logger().debug(
+                "taxonomy_assign_batch_service_failed", exc_info=True,
+            )
         return
 
     if is_local_mode():

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -708,18 +708,20 @@ def taxonomy_assign_batch_hook(
                 return
             svc_embeddings = arr.tolist()
         try:
-            def _svc_assign(db):  # noqa: ANN001
-                same = db.taxonomy.compute_assignments(
-                    collection, doc_ids, svc_embeddings, cross_collection=False,
+            # Compute (read: queries centroids via the service) + persist in a
+            # single inline t2_index_write lambda — the storage-boundary lint
+            # recognises this routed form, and in service mode persist lands on
+            # the Java service (the single writer).
+            t2_index_write(
+                lambda db: db.taxonomy.persist_assignments(
+                    db.taxonomy.compute_assignments(
+                        collection, doc_ids, svc_embeddings, cross_collection=False,
+                    )
+                    + db.taxonomy.compute_assignments(
+                        collection, doc_ids, svc_embeddings, cross_collection=True,
+                    )
                 )
-                cross = db.taxonomy.compute_assignments(
-                    collection, doc_ids, svc_embeddings, cross_collection=True,
-                )
-                a = same + cross
-                if a:
-                    db.taxonomy.persist_assignments(a)
-                return len(a)
-            t2_index_write(_svc_assign)
+            )
         except Exception:
             import structlog
             structlog.get_logger().debug(

--- a/tests/test_pipeline_version.py
+++ b/tests/test_pipeline_version.py
@@ -163,3 +163,26 @@ def test_doctor_pipeline_sweep_retired_on_service_handle():
     assert "sweep retired with the Chroma serving path" in result.output
     # The sweep must not report a failure for what is a deliberate retire.
     assert "check failed" not in result.output
+
+
+def test_stamp_collection_version_noop_on_service_stub() -> None:
+    """nexus-kwkkz: a service-backed collection has no Chroma `modify`; stamping
+    must no-op instead of raising AttributeError (it crashed `nx index repo`)."""
+    from nexus.indexer import stamp_collection_version
+
+    class _ServiceStub:  # no `modify`, like _ServiceCollectionStub
+        metadata = {}
+
+    stamp_collection_version(_ServiceStub())  # must not raise
+
+
+def test_stamp_collection_version_calls_modify_when_available() -> None:
+    from unittest.mock import MagicMock
+    from nexus.indexer import stamp_collection_version, PIPELINE_VERSION
+
+    col = MagicMock()
+    col.metadata = {"existing": "v"}
+    stamp_collection_version(col)
+    col.modify.assert_called_once_with(
+        metadata={"existing": "v", "pipeline_version": PIPELINE_VERSION}
+    )

--- a/tests/test_rdr_109_phase2_dispatch.py
+++ b/tests/test_rdr_109_phase2_dispatch.py
@@ -49,6 +49,27 @@ def test_effective_in_local_mode_returns_local_token(monkeypatch) -> None:
     assert effective_embedding_model_for_writes("code") in LOCAL_EMBEDDING_MODELS
 
 
+def test_effective_local_service_mode_uses_bge_not_client_fastembed_tier(monkeypatch) -> None:
+    # nexus-xq8f9: in local + service-vector mode the service embeds bge-768
+    # server-side, so the write token must be bge-768 even when the CLIENT has
+    # no fastembed extra (which would otherwise resolve minilm-384 and make the
+    # service refuse the write with HTTP 422).
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: True)
+    monkeypatch.setattr("nexus.db.http_vector_client.is_vector_service_mode", lambda: True)
+    # Even if the client falls back to minilm (no fastembed), service path wins.
+    monkeypatch.setattr("nexus.db.local_ef._fastembed_available", lambda: False)
+    monkeypatch.setattr("nexus.config.local_embed_model_choice", lambda: "BAAI/bge-base-en-v1.5")
+    assert effective_embedding_model_for_writes("code") == "bge-base-en-v15-768"
+    assert effective_embedding_model_for_writes("docs") == "bge-base-en-v15-768"
+
+
+def test_effective_local_nonservice_mode_uses_client_token(monkeypatch) -> None:
+    # Raw local (no service vectors): the client's local-EF token is correct.
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: True)
+    monkeypatch.setattr("nexus.db.http_vector_client.is_vector_service_mode", lambda: False)
+    assert effective_embedding_model_for_writes("code") in LOCAL_EMBEDDING_MODELS
+
+
 def test_effective_in_cloud_mode_delegates_to_canonical(cloud_mode) -> None:
     assert (
         effective_embedding_model_for_writes("docs")

--- a/tests/test_taxonomy_service_wiring.py
+++ b/tests/test_taxonomy_service_wiring.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-7ydks: `nx taxonomy discover`/`rebuild` route through the
+HttpTaxonomyStore drop-in when the taxonomy store is service-backed.
+
+These are unit tests over the CLI dispatch seam (`discover_for_collection`)
+using fakes — no live service required. The end-to-end exercise against the
+real Java service lives in tests/db/test_http_taxonomy_store_integration.py.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from nexus.commands.taxonomy_cmd import (
+    _enumerate_discoverable_collections,
+    _fetch_service_vectors,
+    discover_for_collection,
+)
+
+
+class _RawColl:
+    def __init__(self, name: str, count: int) -> None:
+        self.name = name
+        self._count = count
+
+    def count(self) -> int:
+        return self._count
+
+
+class _FakeRawClient:
+    def __init__(self, colls) -> None:  # noqa: ANN001
+        self._colls = colls
+
+    def list_collections(self):
+        return self._colls
+
+
+class _FakeRawT3:
+    """T3Database-shaped: exposes ``_client.list_collections()``."""
+
+    def __init__(self, colls) -> None:  # noqa: ANN001
+        self._client = _FakeRawClient(colls)
+
+
+def test_enumerate_discoverable_collections_filters_and_does_not_crash():
+    # nexus-7ydks HIGH-1 regression: the helper referenced module-scope
+    # `fnmatch` that was only imported inside discover_cmd → NameError when
+    # called from the index.py post-processing path. Exercise the filter.
+    t3 = _FakeRawT3([
+        _RawColl("docs__demo", 12),       # kept
+        _RawColl("code__demo", 9),        # excluded by pattern
+        _RawColl("docs__small", 3),       # too few
+        _RawColl("taxonomy__centroids", 50),  # internal, skipped
+    ])
+    got = _enumerate_discoverable_collections(t3, exclude=["code__*"])
+    assert got == ["docs__demo"]
+
+
+class _FakeStub:
+    """Service collection stub: paginated get(documents) over a fixed corpus."""
+
+    def __init__(self, ids: list[str], docs: list[str]) -> None:
+        self._ids = ids
+        self._docs = docs
+
+    def get(self, *, include=None, limit=10, offset=0):  # noqa: ANN001
+        sl = slice(offset, offset + limit)
+        return {"ids": self._ids[sl], "documents": self._docs[sl]}
+
+
+class _FakeServiceT3:
+    """Minimal HttpVectorClient-shaped handle for the discovery fetch path."""
+
+    def __init__(self, ids, docs, embs) -> None:  # noqa: ANN001
+        self._ids = ids
+        self._docs = docs
+        self._embs = np.asarray(embs, dtype=np.float32)
+
+    def count(self, collection: str) -> int:
+        return len(self._ids)
+
+    def get_or_create_collection(self, name: str) -> _FakeStub:
+        return _FakeStub(self._ids, self._docs)
+
+    def get_embeddings(self, collection: str, ids: list[str]):  # noqa: ANN001
+        # Return rows in request order (mirrors the real client contract).
+        index = {i: r for i, r in zip(self._ids, self._embs)}
+        return np.asarray([index[i] for i in ids], dtype=np.float32)
+
+
+class _FakeServiceTaxonomy:
+    """HttpTaxonomyStore-shaped store: no `_lock`/`conn` → not raw-access.
+
+    Records the args it was dispatched so the test can assert the CLI handed
+    over the fetched vectors verbatim.
+    """
+
+    def __init__(self) -> None:
+        self.discover_calls: list[tuple] = []
+        self.rebuild_calls: list[tuple] = []
+
+    def discover_topics(self, collection_name, doc_ids, embeddings, texts, chroma_client=None):  # noqa: ANN001
+        self.discover_calls.append((collection_name, list(doc_ids), np.asarray(embeddings), list(texts)))
+        return len(set(doc_ids)) and 3  # pretend 3 topics
+
+    def rebuild_taxonomy(self, collection_name, doc_ids, embeddings, texts, chroma_client=None):  # noqa: ANN001
+        self.rebuild_calls.append((collection_name, list(doc_ids), np.asarray(embeddings), list(texts)))
+        return 2
+
+
+def _corpus(n: int):
+    ids = [f"c{i}" for i in range(n)]
+    docs = [f"text {i}" for i in range(n)]
+    embs = [[float(i), float(i) + 1.0, 2.0] for i in range(n)]
+    return ids, docs, embs
+
+
+def test_fetch_service_vectors_returns_aligned_arrays():
+    ids, docs, embs = _corpus(6)
+    t3 = _FakeServiceT3(ids, docs, embs)
+    got = _fetch_service_vectors("docs__demo", t3)
+    assert got is not None
+    g_ids, g_texts, g_embs = got
+    assert g_ids == ids
+    assert g_texts == docs
+    assert g_embs.shape == (6, 3)
+
+
+def test_fetch_service_vectors_bails_on_embedding_misalignment():
+    ids, docs, embs = _corpus(6)
+
+    class _Drops(_FakeServiceT3):
+        def get_embeddings(self, collection, ids):  # noqa: ANN001
+            return np.asarray(self._embs[:-1], dtype=np.float32)  # one short
+
+    assert _fetch_service_vectors("docs__demo", _Drops(ids, docs, embs)) is None
+
+
+def test_discover_for_collection_service_routes_to_discover_topics():
+    ids, docs, embs = _corpus(8)
+    t3 = _FakeServiceT3(ids, docs, embs)
+    tax = _FakeServiceTaxonomy()
+
+    n = discover_for_collection("docs__demo", tax, t3, force=False)
+
+    assert n == 3
+    assert len(tax.discover_calls) == 1
+    assert not tax.rebuild_calls
+    col, got_ids, got_embs, got_texts = tax.discover_calls[0]
+    assert col == "docs__demo"
+    assert got_ids == ids
+    assert got_texts == docs
+    assert got_embs.shape == (8, 3)
+
+
+def test_discover_for_collection_service_force_routes_to_rebuild():
+    ids, docs, embs = _corpus(8)
+    t3 = _FakeServiceT3(ids, docs, embs)
+    tax = _FakeServiceTaxonomy()
+
+    n = discover_for_collection("docs__demo", tax, t3, force=True)
+
+    assert n == 2
+    assert len(tax.rebuild_calls) == 1
+    assert not tax.discover_calls
+
+
+def test_discover_for_collection_service_too_few_docs_returns_zero():
+    ids, docs, embs = _corpus(4)  # < 5
+    t3 = _FakeServiceT3(ids, docs, embs)
+    tax = _FakeServiceTaxonomy()
+
+    assert discover_for_collection("docs__demo", tax, t3) == 0
+    assert not tax.discover_calls

--- a/tests/test_taxonomy_service_wiring.py
+++ b/tests/test_taxonomy_service_wiring.py
@@ -220,3 +220,67 @@ def test_assign_batch_hook_routes_through_service_store(monkeypatch):
 
     assert persisted, "service-mode hook did not persist any assignments (regressed to bail)"
     assert len(persisted[0]) == 4
+
+
+# ── split/project service fetch helpers (nexus-9pqoj) ───────────────────────
+
+
+class _StubWithIds:
+    """Service collection stub supporting both ids= (store-get) and paginated get."""
+
+    def __init__(self, ids, docs):  # noqa: ANN001
+        self._ids = ids
+        self._docs = docs
+
+    def get(self, ids=None, where=None, include=None, limit=10, offset=0):  # noqa: ANN001
+        if ids is not None:
+            idx = {i: d for i, d in zip(self._ids, self._docs)}
+            rids = [i for i in ids if i in idx]
+            return {"ids": rids, "documents": [idx[i] for i in rids]}
+        sl = slice(offset, offset + limit)
+        return {"ids": self._ids[sl], "documents": self._docs[sl]}
+
+
+class _SplitT3:
+    def __init__(self, ids, docs, embs):  # noqa: ANN001
+        self._ids, self._docs = ids, docs
+        self._embs = {i: e for i, e in zip(ids, embs)}
+
+    def count(self, collection):  # noqa: ANN001
+        return len(self._ids)
+
+    def get_or_create_collection(self, name):  # noqa: ANN001
+        return _StubWithIds(self._ids, self._docs)
+
+    def get_embeddings(self, collection, ids):  # noqa: ANN001
+        return np.asarray([self._embs[i] for i in ids], dtype=np.float32)
+
+
+def test_svc_fetch_by_ids_aligned():
+    from nexus.db.t2.http_taxonomy_store import HttpTaxonomyStore
+    ids, docs, embs = _corpus(6)
+    t3 = _SplitT3(ids, docs, embs)
+    g_ids, g_texts, g_embs = HttpTaxonomyStore._svc_fetch_by_ids(t3, "docs__d", ids[:4])
+    assert g_ids == ids[:4]
+    assert g_texts == docs[:4]
+    assert g_embs.shape == (4, 3)
+
+
+def test_svc_fetch_by_ids_bails_on_misalign():
+    from nexus.db.t2.http_taxonomy_store import HttpTaxonomyStore
+    ids, docs, embs = _corpus(6)
+
+    class _Drop(_SplitT3):
+        def get_embeddings(self, collection, ids):  # noqa: ANN001
+            return np.asarray(embs[:2], dtype=np.float32)  # short
+
+    g_ids, g_texts, g_embs = HttpTaxonomyStore._svc_fetch_by_ids(_Drop(ids, docs, embs), "docs__d", ids)
+    assert g_embs is None  # refuses misaligned
+
+
+def test_svc_fetch_all_embeddings_paginates():
+    from nexus.db.t2.http_taxonomy_store import HttpTaxonomyStore
+    ids, docs, embs = _corpus(7)
+    g_ids, g_embs = HttpTaxonomyStore._svc_fetch_all_embeddings(_SplitT3(ids, docs, embs), "docs__d")
+    assert g_ids == ids
+    assert g_embs.shape == (7, 3)

--- a/tests/test_taxonomy_service_wiring.py
+++ b/tests/test_taxonomy_service_wiring.py
@@ -284,3 +284,18 @@ def test_svc_fetch_all_embeddings_paginates():
     g_ids, g_embs = HttpTaxonomyStore._svc_fetch_all_embeddings(_SplitT3(ids, docs, embs), "docs__d")
     assert g_ids == ids
     assert g_embs.shape == (7, 3)
+
+
+def test_svc_fetch_all_embeddings_bails_on_misalign():
+    # nexus-9pqoj S1 regression: a count skew between enumerated ids and the
+    # returned embeddings must return (ids, None), NOT a silent partial set.
+    from nexus.db.t2.http_taxonomy_store import HttpTaxonomyStore
+    ids, docs, embs = _corpus(7)
+
+    class _Drop(_SplitT3):
+        def get_embeddings(self, collection, ids):  # noqa: ANN001
+            return np.asarray(embs[:3], dtype=np.float32)  # short
+
+    g_ids, g_embs = HttpTaxonomyStore._svc_fetch_all_embeddings(_Drop(ids, docs, embs), "docs__d")
+    assert g_ids == ids
+    assert g_embs is None

--- a/tests/test_taxonomy_service_wiring.py
+++ b/tests/test_taxonomy_service_wiring.py
@@ -171,3 +171,52 @@ def test_discover_for_collection_service_too_few_docs_returns_zero():
 
     assert discover_for_collection("docs__demo", tax, t3) == 0
     assert not tax.discover_calls
+
+
+# ── Incremental-assignment hook (nexus-7ydks C1) ────────────────────────────
+
+
+def test_assign_batch_hook_routes_through_service_store(monkeypatch):
+    """The per-store_put assignment hook must persist via the service store in
+    service mode, not bail (the Critical the substantive-critic caught)."""
+    import nexus.mcp_infra as mi
+    from nexus.db.http_vector_client import HttpVectorClient
+
+    ids = [f"c{i}" for i in range(4)]
+    embs = [[float(i), 1.0, 2.0] for i in range(4)]
+
+    # A real-typed (isinstance) HttpVectorClient so is_service_backed() is True,
+    # with the two methods the hook calls stubbed.
+    class _SvcT3(HttpVectorClient):
+        def __init__(self):  # noqa: D107
+            pass
+
+        def get_embeddings(self, collection, doc_ids):  # noqa: ANN001
+            import numpy as _np
+            return _np.asarray(embs, dtype=_np.float32)
+
+    persisted: list[list[dict]] = []
+
+    class _SvcTax:
+        def compute_assignments(self, collection, doc_ids, embeddings, *, cross_collection=False):  # noqa: ANN001
+            # one assignment per doc for the same-collection pass, none cross
+            return [] if cross_collection else [{"doc_id": d, "topic_id": 1} for d in doc_ids]
+
+        def persist_assignments(self, assignments):  # noqa: ANN001
+            persisted.append(assignments)
+            return len(assignments)
+
+    class _DB:
+        taxonomy = _SvcTax()
+
+    monkeypatch.setattr(mi, "get_t3", lambda: _SvcT3())
+    # is_local_mode is a local import from nexus.config inside the hook.
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: False)
+    # t2_index_write just runs the fn with our fake db (no daemon).
+    monkeypatch.setattr(mi, "t2_index_write", lambda fn: fn(_DB()))
+
+    # embeddings=None forces the service get_embeddings fetch path.
+    mi.taxonomy_assign_batch_hook(ids, "docs__demo", ["t"] * 4, None, None)
+
+    assert persisted, "service-mode hook did not persist any assignments (regressed to bail)"
+    assert len(persisted[0]) == 4


### PR DESCRIPTION
**Consolidated integration of the service-mode taxonomy arc** (replaces #1256, #1257, #1259, #1260, #1261 — collapsed into one CI cycle). Every fix was surfaced and verified by a live end-to-end smoke against a JAR-launched pgvector service.

## What's included
| Bead | Change |
|---|---|
| `nexus-7ydks` | `nx taxonomy discover`/`rebuild` + the per-store_put assignment hook wired through the pgvector service |
| `nexus-9pqoj` | `nx taxonomy split`/`project` + cross-collection projection ported to the service (store-side `_svc_fetch_*` + CLI) |
| `nexus-0cy4b` | service-mode catalog owner registration: Python `ensure_owner_for_repo` signature + `repo_hash`, Java `upsertOwner` server-side `tumbler_prefix` allocation |
| `nexus-xq8f9` | local+service write token follows the service embedder (bge-768), not the client fastembed tier |
| `nexus-kwkkz` | `stamp_collection_version` no-ops on service-backed collections (Chroma-only `col.modify`) |

## Live verification (JAR-launched pgvector service, darwin)
```
nx init --service (JAR launch) → nx index repo (completes) → nx taxonomy discover
  → 2 labeled topics: "HTTP bearer token 503 errors", "SQLite connection pool WAL busy_timeout"
```
Discover/split/project also verified directly against the live service.

## Tests
Stacked review (code-review-expert + substantive-critic) on the taxonomy work; new regression tests for every fix incl. a real-Testcontainers-PG Java test for the owner allocation. Local sweep green: taxonomy (159), store (72), catalog (106), tripwires+daemon+corpus+indexer (158).

Note: the Java half (`nexus-0cy4b`) needs an `engine-service-v*` build+publish to reach released installs.

Beads: nexus-7ydks, nexus-9pqoj, nexus-0cy4b, nexus-xq8f9, nexus-kwkkz