### PR TITLE
docs: correct T3 env-var in container-integration (nexus-6xi0f residue)

### DIFF
--- a/docs/container-integration.md
+++ b/docs/container-integration.md
@@ -176,8 +176,9 @@ socket's `0o600` permission gate fires `EACCES` (errno 13). The
 CLI's error message names the fix.
 
 T3 has no UDS path; the nexus-service is HTTP-only. Use the TCP path
-(`NX_SERVICE_HOST`/`NX_SERVICE_PORT` + `NX_SERVICE_TOKEN`) for T3 even when T2
-goes through UDS.
+(`NX_SERVICE_URL`, a full base URL, + `NX_SERVICE_TOKEN`) for T3 even when T2
+goes through UDS. (`NX_SERVICE_HOST`/`NX_SERVICE_PORT` are the separate T2
+domain-store + catalog resolver, not T3 — see the intro callout.)
 
 ## Path C: Operator-side forward (fallback)
 


### PR DESCRIPTION
## Summary

Final residue cleanup for the Release-N doc audit (nexus-6xi0f). The bulk shipped via the iter1–4 audit PRs (#1255 etc.); this fixes the one remaining instance of the 6.0.0-onboarding-critique **Sig1** finding.

`docs/container-integration.md` "T3 has no UDS path" paragraph told readers to use `NX_SERVICE_HOST`/`NX_SERVICE_PORT` for T3 — wrong. T3 serves over `NX_SERVICE_URL` (full base URL); `NX_SERVICE_HOST`/`PORT` is the separate T2-domain-store + catalog resolver. The page's intro callout and env-var table already said this correctly; only the UDS-section body contradicted them.

## Verification

Inverse-grep across `docs/` confirms clean:
- no other `NX_SERVICE_HOST/PORT`↔T3 mismatch (remaining hits correctly assign HOST/PORT→T2, URL→T3)
- no `config set service_url/service_token/chroma_api_key` active-setup framing
- no "create a ChromaDB Cloud account" / "connects to this single database on ChromaDB Cloud" active-T3 prose

All other findings from the two T2 critique entries (iter4 correctness-gate C1/C2; 6.0.0 onboarding C1/C2/Sig1–4) were already remediated in develop.

Part of Release-N gate nexus-y5avl (world-blocked on nexus-luxe6 — docs-only, no release cut).