### PR TITLE
fix(indexing): server-side-embed gate for streaming PDF pipeline in service mode (nexus-9n1u3)

### DIFF
--- a/src/nexus/pipeline_buffer.py
+++ b/src/nexus/pipeline_buffer.py
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS pdf_chunks (
     chunk_text    TEXT NOT NULL,
     chunk_id      TEXT NOT NULL,
     metadata_json TEXT DEFAULT '{}',
-    embedding     BLOB DEFAULT NULL,
+    embedding     BLOB DEFAULT NULL,  -- NULL = not embedded; packed floats = client vectors; b"" = service-mode sentinel (JVM embeds at upload, nexus-9n1u3)
     uploaded      INTEGER DEFAULT 0,
     created_at    TEXT NOT NULL,
     PRIMARY KEY (content_hash, chunk_index)

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -209,9 +209,22 @@ def _embed_and_write_batch(
     write_count = len(embeddings) if embed_fn is not None else len(chunks_to_embed)
     for i in range(write_count):
         chunk = chunks_to_embed[i]
-        emb_bytes = None
+        emb_bytes: bytes | None
         if i < len(embeddings):
             emb_bytes = struct.pack(f"{len(embeddings[i])}f", *embeddings[i])
+        elif embed_fn is None:
+            # nexus-9n1u3: service mode — the JVM embeds server-side at upload.
+            # Write a non-NULL empty-blob sentinel (not None) so
+            # ``read_uploadable_chunks`` (``embedding IS NOT NULL``) still picks
+            # the chunk up; the uploader struct.unpacks ``b""`` to ``[]`` and
+            # ``HttpVectorClient.upsert_chunks_with_embeddings`` discards the
+            # empty vector and embeds from the chunk text. Mirrors the batch
+            # path (doc_indexer server-side-embed branch). embed_fn is None at
+            # this stage ONLY in service mode — the orchestrator raises
+            # otherwise.
+            emb_bytes = b""
+        else:
+            emb_bytes = None
         # RDR-108 D1 / nexus-kmb6: streaming PDF chunk natural ID is
         # chunk_text_hash[:32] (matches code/prose/doc indexer write
         # paths). Identical chunk text in the same collection collapses
@@ -666,15 +679,28 @@ def pipeline_index_pdf(
 
     # Resolve embed_fn from credentials when not provided (matches batch path).
     if embed_fn is None:
-        from nexus.config import get_credential, load_config
-        voyage_key = get_credential("voyage_api_key")
-        if voyage_key:
-            from nexus.doc_indexer import _embed_with_fallback
-            timeout = load_config().get("voyageai", {}).get("read_timeout_seconds", 120.0)
-            embed_fn = lambda texts, model: _embed_with_fallback(texts, model, voyage_key, timeout=timeout)
+        from nexus.db.http_vector_client import is_vector_service_mode  # noqa: PLC0415
+        if is_vector_service_mode():
+            # nexus-9n1u3 / RDR-152 Seam B: leave embed_fn=None — the service
+            # embeds server-side at upload time. The embed stage writes a
+            # non-NULL empty-blob sentinel and the uploader routes through
+            # HttpVectorClient.upsert_chunks_with_embeddings (JVM embeds).
+            # Mirrors the batch path (doc_indexer._index_pdf_document).
+            pass
         else:
-            db.mark_failed(content_hash, error="voyage_api_key not configured")
-            raise RuntimeError("voyage_api_key not configured — cannot embed for streaming pipeline")
+            from nexus.config import get_credential, load_config
+            voyage_key = get_credential("voyage_api_key")
+            if voyage_key:
+                from nexus.doc_indexer import _embed_with_fallback
+                timeout = load_config().get("voyageai", {}).get("read_timeout_seconds", 120.0)
+                embed_fn = lambda texts, model: _embed_with_fallback(texts, model, voyage_key, timeout=timeout)
+            else:
+                db.mark_failed(content_hash, error="voyage_api_key not configured")
+                raise RuntimeError(
+                    "voyage_api_key not configured — cannot embed for streaming "
+                    "pipeline (set a Voyage key, or use service mode for "
+                    "server-side embedding)"
+                )
 
     cancel = threading.Event()
     extraction_done = threading.Event()

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -192,6 +192,8 @@ def _embed_and_write_batch(
     if not chunks_to_embed:
         return 0, target_model
 
+    from nexus.db.http_vector_client import is_vector_service_mode  # noqa: PLC0415
+
     chunk_texts = [c.text for c in chunks_to_embed]
     embeddings: list[list[float]] = []
     actual_model = target_model
@@ -212,16 +214,19 @@ def _embed_and_write_batch(
         emb_bytes: bytes | None
         if i < len(embeddings):
             emb_bytes = struct.pack(f"{len(embeddings[i])}f", *embeddings[i])
-        elif embed_fn is None:
+        elif embed_fn is None and is_vector_service_mode():
             # nexus-9n1u3: service mode — the JVM embeds server-side at upload.
             # Write a non-NULL empty-blob sentinel (not None) so
             # ``read_uploadable_chunks`` (``embedding IS NOT NULL``) still picks
             # the chunk up; the uploader struct.unpacks ``b""`` to ``[]`` and
             # ``HttpVectorClient.upsert_chunks_with_embeddings`` discards the
             # empty vector and embeds from the chunk text. Mirrors the batch
-            # path (doc_indexer server-side-embed branch). embed_fn is None at
-            # this stage ONLY in service mode — the orchestrator raises
-            # otherwise.
+            # path (doc_indexer server-side-embed branch). The service-mode
+            # check is LOCAL (not inferred from embed_fn=None) so a caller that
+            # bypasses the orchestrator and passes embed_fn=None outside service
+            # mode does NOT silently write zero-vector chunks — it falls through
+            # to emb_bytes=None, which read_uploadable_chunks drops, surfacing
+            # the misuse instead of corrupting (review nexus-9n1u3 Sig-1).
             emb_bytes = b""
         else:
             emb_bytes = None

--- a/tests/test_pdf_e2e.py
+++ b/tests/test_pdf_e2e.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import pytest
 from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
 
 from nexus.corpus import index_model_for_collection
@@ -20,6 +21,18 @@ from nexus.doc_indexer import index_pdf
 from nexus.indexer import _git_metadata, _index_pdf_file
 
 _local_ef = DefaultEmbeddingFunction()
+
+
+@pytest.fixture(autouse=True)
+def _legacy_vector_backend(monkeypatch):
+    # nexus-9n1u3: these e2e tests use a raw chromadb EphemeralClient T3 +
+    # DefaultEmbeddingFunction and exercise the CLIENT-embed PDF path. Pin the
+    # vector backend off the 6.0 service default (is_vector_service_mode() is
+    # True by default since RDR-155 P4a) so the streaming pipeline client-embeds
+    # into the fixture instead of writing empty server-side-embed placeholders
+    # that raw chromadb rejects with "IndexError: list index out of range in
+    # upsert". The service-mode PDF path is covered by the live service smoke.
+    monkeypatch.setenv("NX_STORAGE_BACKEND_VECTORS", "local")
 
 
 def _local_embed(chunks, model, api_key, input_type="document", timeout=120.0, on_progress=None):

--- a/tests/test_pdf_subsystem.py
+++ b/tests/test_pdf_subsystem.py
@@ -21,6 +21,16 @@ from nexus.pdf_extractor import PDFExtractor
 from tests.conftest import set_credentials
 
 
+@pytest.fixture(autouse=True)
+def _legacy_vector_backend(monkeypatch):
+    # nexus-9n1u3: these tests use a raw chromadb T3 + client-embed (fake/local
+    # voyage) PDF path. Pin the vector backend off the 6.0 service default so the
+    # streaming pipeline client-embeds into the fixture instead of writing empty
+    # server-side-embed placeholders that raw chromadb rejects (IndexError in
+    # upsert). The service-mode PDF path is covered by the live service smoke.
+    monkeypatch.setenv("NX_STORAGE_BACKEND_VECTORS", "local")
+
+
 def _make_ruled_table_pdf(path: Path) -> None:
     """Create a PDF with a visible ruled table (borders drawn as lines).
 

--- a/tests/test_pipeline_stages.py
+++ b/tests/test_pipeline_stages.py
@@ -158,7 +158,8 @@ class TestServiceModeStreaming:
         t3.upsert_chunks_with_embeddings.assert_called()
         # Forwarded embeddings are empty — the service embeds, client vectors
         # are discarded (HttpVectorClient.upsert_chunks_with_embeddings).
-        embs = t3.upsert_chunks_with_embeddings.call_args[0][3]
+        ca = t3.upsert_chunks_with_embeddings.call_args
+        embs = ca.args[3] if len(ca.args) > 3 else ca.kwargs["embeddings"]
         assert embs and all(e == [] for e in embs)
 
     def test_non_service_no_voyage_still_raises(self, db) -> None:
@@ -331,18 +332,35 @@ class TestChunkerLoop:
         assert calls == []
 
     def test_embed_fn_none_writes_service_mode_sentinel(self, db, done_event) -> None:
-        # nexus-9n1u3: embed_fn=None is the service-mode path (the orchestrator
-        # only leaves it None in service mode). The embed stage writes a
-        # non-NULL empty-blob sentinel so the chunk stays uploadable; the JVM
-        # embeds at upload time.
+        # nexus-9n1u3: in SERVICE mode, embed_fn=None makes the embed stage
+        # write a non-NULL empty-blob sentinel so the chunk stays uploadable;
+        # the JVM embeds at upload time.
         _pop_pages(db, "h1", 2)
-        with patch(_P_CHK) as MC:
+        with patch(_P_CHK) as MC, patch(
+            "nexus.db.http_vector_client.is_vector_service_mode", return_value=True
+        ):
             MC.return_value.chunk.return_value = _tc(("chunk 0", 0, {}))
             chunker_loop("h1", db, threading.Event(), embed_fn=None, extraction_done=done_event)
         out = db.read_ready_chunks("h1")
         assert len(out) == 1 and out[0]["embedding"] == b""
         # non-NULL sentinel -> the uploader will pick it up (was dropped when None)
         assert len(db.read_uploadable_chunks("h1")) == 1
+
+    def test_embed_fn_none_non_service_does_not_write_sentinel(self, db, done_event) -> None:
+        # review Sig-1: the b"" sentinel is gated LOCALLY on is_vector_service_mode().
+        # A caller that bypasses the orchestrator and passes embed_fn=None in
+        # NON-service mode must NOT silently write an uploadable zero-vector
+        # chunk — it falls through to NULL (dropped by read_uploadable_chunks),
+        # surfacing the misuse instead of corrupting.
+        _pop_pages(db, "h1", 2)
+        with patch(_P_CHK) as MC, patch(
+            "nexus.db.http_vector_client.is_vector_service_mode", return_value=False
+        ):
+            MC.return_value.chunk.return_value = _tc(("chunk 0", 0, {}))
+            chunker_loop("h1", db, threading.Event(), embed_fn=None, extraction_done=done_event)
+        out = db.read_ready_chunks("h1")
+        assert len(out) == 1 and out[0]["embedding"] is None
+        assert db.read_uploadable_chunks("h1") == []
 
     def test_incremental_chunking_before_extraction_done(self, db) -> None:
         db.create_pipeline("h1", "/a.pdf", "docs__test")

--- a/tests/test_pipeline_stages.py
+++ b/tests/test_pipeline_stages.py
@@ -127,6 +127,48 @@ def _run_with_col(db, col_get_return, fake_result, fake_chunks,
     return t3, mock_col
 
 
+def _run_service_mode(db, fake_result, fake_chunks, *, service=True, voyage=None,
+                      pdf_path="/a.pdf", content_hash="svc123", collection="docs__test"):
+    """nexus-9n1u3: drive pipeline_index_pdf with embed_fn=None under a patched
+    service-mode flag and Voyage-credential, mirroring _run_with_col."""
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"ids": [], "metadatas": []}
+    t3 = create_autospec(T3Database, instance=True)
+    t3.get_or_create_collection.return_value = mock_col
+    pc = fake_result.metadata["page_count"]
+    with patch(_P_EXT) as ME, patch(_P_CHK) as MC, \
+            patch("nexus.db.http_vector_client.is_vector_service_mode",
+                  return_value=service), \
+            patch("nexus.config.get_credential", return_value=voyage):
+        ME.return_value.extract.side_effect = _fx(pc, fake_result)
+        MC.return_value.chunk.return_value = fake_chunks
+        pipeline_index_pdf(Path(pdf_path), content_hash, collection, t3,
+                           db=db, embed_fn=None)
+    return t3, mock_col
+
+
+class TestServiceModeStreaming:
+    """nexus-9n1u3: PDF streaming pipeline must server-side-embed in service
+    mode instead of demanding a Voyage key (which broke ALL PDF ingestion)."""
+
+    def test_service_mode_no_voyage_completes_and_server_embeds(self, db) -> None:
+        t3, _ = _run_service_mode(
+            db, _er(2), _tc(("chunk a", 0, {}), ("chunk b", 1, {})))
+        # Did NOT raise; the uploader routed to the server-side-embed upsert.
+        t3.upsert_chunks_with_embeddings.assert_called()
+        # Forwarded embeddings are empty — the service embeds, client vectors
+        # are discarded (HttpVectorClient.upsert_chunks_with_embeddings).
+        embs = t3.upsert_chunks_with_embeddings.call_args[0][3]
+        assert embs and all(e == [] for e in embs)
+
+    def test_non_service_no_voyage_still_raises(self, db) -> None:
+        # The legacy (non-service) no-Voyage path must keep failing loud.
+        with pytest.raises(RuntimeError, match="voyage_api_key not configured"):
+            _run_service_mode(
+                db, _er(1), _tc(("chunk x", 0, {})),
+                service=False, voyage=None, content_hash="raw123")
+
+
 
 class TestExtractorLoop:
     def test_writes_pages_to_buffer(self, db: PipelineDB) -> None:
@@ -288,13 +330,19 @@ class TestChunkerLoop:
             chunker_loop("h1", db, threading.Event(), embed_fn=tracking, extraction_done=done_event)
         assert calls == []
 
-    def test_embed_fn_none(self, db, done_event) -> None:
+    def test_embed_fn_none_writes_service_mode_sentinel(self, db, done_event) -> None:
+        # nexus-9n1u3: embed_fn=None is the service-mode path (the orchestrator
+        # only leaves it None in service mode). The embed stage writes a
+        # non-NULL empty-blob sentinel so the chunk stays uploadable; the JVM
+        # embeds at upload time.
         _pop_pages(db, "h1", 2)
         with patch(_P_CHK) as MC:
             MC.return_value.chunk.return_value = _tc(("chunk 0", 0, {}))
             chunker_loop("h1", db, threading.Event(), embed_fn=None, extraction_done=done_event)
         out = db.read_ready_chunks("h1")
-        assert len(out) == 1 and out[0]["embedding"] is None
+        assert len(out) == 1 and out[0]["embedding"] == b""
+        # non-NULL sentinel -> the uploader will pick it up (was dropped when None)
+        assert len(db.read_uploadable_chunks("h1")) == 1
 
     def test_incremental_chunking_before_extraction_done(self, db) -> None:
         db.create_pipeline("h1", "/a.pdf", "docs__test")
@@ -536,6 +584,8 @@ class TestPipelineIndexPdf:
     def test_embed_fn_none_resolves_credentials(self, db, mock_t3) -> None:
         fr, fc = _er(1), _tc(("c0", 0, {"page_number": 1, "chunk_type": "text"}))
         with (patch(_P_EXT) as ME, patch(_P_CHK) as MC,
+              patch("nexus.db.http_vector_client.is_vector_service_mode",
+                    return_value=False),
               patch("nexus.config.get_credential", return_value="fake-key"),
               patch("nexus.config.load_config", return_value={}),
               patch("nexus.doc_indexer._embed_with_fallback") as me):
@@ -547,7 +597,10 @@ class TestPipelineIndexPdf:
         me.assert_called()
 
     def test_embed_fn_none_no_credentials_fails_fast(self, db, mock_t3) -> None:
-        with patch("nexus.config.get_credential", return_value=None):
+        # Legacy (non-service) path: no Voyage key must still fail loud.
+        with (patch("nexus.db.http_vector_client.is_vector_service_mode",
+                    return_value=False),
+              patch("nexus.config.get_credential", return_value=None)):
             with pytest.raises(RuntimeError, match="voyage_api_key not configured"):
                 pipeline_index_pdf(Path("/a.pdf"), "h1", "docs__test", mock_t3, db=db)
 


### PR DESCRIPTION
## Summary

Found by the 2026-06-20 service-mode shakeout (Track A audit #1, High). **`nx index pdf` failed for *every* PDF under the 6.0 service default.** The streaming pipeline is the only PDF path (`_STREAMING_THRESHOLD=0`), and its orchestrator resolved `embed_fn` from `voyage_api_key`, raising `RuntimeError("voyage_api_key not configured")` when absent — with no `is_vector_service_mode()` branch (unlike the batch path, `doc_indexer._index_pdf_document:1411`).

## Fix (mirrors the batch exemplar)

1. **`pipeline_index_pdf`**: `embed_fn=None` + `is_vector_service_mode()` → leave `embed_fn` None (the JVM embeds server-side). Non-service no-Voyage still fails loud.
2. **`_embed_and_write_batch`**: in service mode, write a non-NULL empty-blob sentinel `b""` (not `None`) so `read_uploadable_chunks` (`WHERE embedding IS NOT NULL`) still selects the chunk — previously NULL embeddings would be dropped and the pipeline would **hang**. The uploader's `struct.unpack("0f", b"")` → `[]`, which `HttpVectorClient.upsert_chunks_with_embeddings` discards before server-embedding. The sentinel is gated **locally** on `is_vector_service_mode()` so a caller bypassing the orchestrator can't silently write zero-vector chunks.

## Tests

`TestServiceModeStreaming` (service-mode no-Voyage completes + server-embeds with empty vectors; non-service no-Voyage still raises; non-service `embed_fn=None` writes NULL not a sentinel). Legacy `embed_fn=None` credential tests pinned to `is_vector_service_mode=False`. **44 passed** + 31 adjacent (seam-B/embed-stub/force-ingest/hook-drift) green.

## Review

Stacked gate (code-review-expert + substantive-critic, **0 Critical**). Remediated in commit 2: local service-mode guard on the sentinel (Sig-1/L1), keyword-safe test assertion (M1), schema-comment for the `b""` sentinel (Sig-2). The taxonomy-hook empty-embeddings truthiness gap (Sig-3/L2) is pre-existing (batch path too) and filed separately as **nexus-reskd**.

## Verification

Live service-mode PDF round-trip (JVM server-embed → pgvector → searchable) running against the JAR-launched service.

## Closes
Closes #nexus-9n1u3