### PR TITLE
fix: service-mode shakeout follow-ups (catalog/taxonomy/scratch/tier-status/migration-test)

### DIFF
--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -716,6 +716,19 @@ def _run_check_tier_discipline() -> None:
         click.echo(f"  T2 database not found at {db_path} (skip).")
         return
 
+    from nexus.db.storage_mode import StorageBackend, storage_backend_for
+    if storage_backend_for("telemetry") == StorageBackend.SERVICE:
+        # nexus-wyu1g: in service mode tier_writes go to the service-backed
+        # telemetry store (Postgres), not local SQLite. Reading the empty local
+        # table here reported a false-clean "no writes seen"; report the
+        # backend honestly instead.
+        click.echo("Tier-discipline check:")
+        click.echo(
+            "  service-backed telemetry (Postgres) — local inspection N/A; "
+            "tier writes are recorded in the nexus-service, not local SQLite."
+        )
+        return
+
     conn = _sqlite3.connect(str(db_path))  # epsilon-allow: nx doctor diagnostic — must operate when daemon offline; read-only tier_writes inspection
     try:
         has_table = conn.execute(

--- a/src/nexus/commands/scratch.py
+++ b/src/nexus/commands/scratch.py
@@ -17,9 +17,11 @@ def _t1():
       (Postgres UNLOGGED, RDR-152 bead nexus-gmiaf.13).
     * Default → :class:`~nexus.db.t1.T1Database` (ChromaDB path, unchanged).
 
-    On ``T1ServerNotFoundError`` (Chroma path only), surface a clean actionable
-    message via ``click.ClickException`` (exit 1, no traceback) rather than a
-    wall of traceback (nexus-gff3g).
+    On ``T1ServerNotFoundError`` (Chroma path) or a service-endpoint
+    ``RuntimeError`` (service path, ``NX_STORAGE_BACKEND=service`` with no
+    reachable nexus-service — nexus-0l5ym), surface a clean actionable message
+    via ``click.ClickException`` (exit 1, no traceback) rather than a wall of
+    traceback (nexus-gff3g).
     """
     try:
         return get_t1_database()
@@ -30,6 +32,18 @@ def _t1():
             "in-process ephemeral scratch (not shared with the MCP server), or "
             "reconnect the conexus MCP/extension so a session-id lease is "
             "published for this session."
+        ) from exc
+    except RuntimeError as exc:
+        # nexus-0l5ym: service-mode T1 (HttpScratchStore) raises a raw
+        # RuntimeError from resolve_service_config when no nexus-service
+        # endpoint resolves. Convert it to the same clean guidance instead of
+        # dumping a traceback on `nx scratch`.
+        raise click.ClickException(
+            f"{exc}\n\n"
+            "Quick fix: prefix the command with NX_T1_ISOLATED=1 for an "
+            "in-process ephemeral scratch, start the service with "
+            "'nx daemon service start', or export NX_SERVICE_URL / "
+            "NX_SERVICE_TOKEN so the service-backed T1 endpoint resolves."
         ) from exc
 
 

--- a/src/nexus/commands/tier_status.py
+++ b/src/nexus/commands/tier_status.py
@@ -152,7 +152,8 @@ def tier_status_cmd(
         # service-backed telemetry store (Postgres), not local SQLite. Reading
         # the local table would silently report 0 writes; say so honestly
         # instead (and don't require a local T2 db). Full service-side read
-        # parity — a GET /v1/telemetry/tier_writes endpoint — is deferred.
+        # parity — a GET /v1/telemetry/tier_writes endpoint — is deferred to
+        # nexus-59wjj.
         msg = (
             "tier_writes are recorded in the service-backed telemetry store "
             "(Postgres); local inspection is not available in service mode."

--- a/src/nexus/commands/tier_status.py
+++ b/src/nexus/commands/tier_status.py
@@ -146,6 +146,23 @@ def tier_status_cmd(
             "--session, --last, and --since are mutually exclusive"
         )
 
+    from nexus.db.storage_mode import StorageBackend, storage_backend_for
+    if storage_backend_for("telemetry") == StorageBackend.SERVICE:
+        # nexus-wyu1g: in service mode tier_writes are recorded in the
+        # service-backed telemetry store (Postgres), not local SQLite. Reading
+        # the local table would silently report 0 writes; say so honestly
+        # instead (and don't require a local T2 db). Full service-side read
+        # parity — a GET /v1/telemetry/tier_writes endpoint — is deferred.
+        msg = (
+            "tier_writes are recorded in the service-backed telemetry store "
+            "(Postgres); local inspection is not available in service mode."
+        )
+        if json_out:
+            click.echo(_json.dumps({"service_backed": True, "message": msg}, indent=2))
+        else:
+            click.echo(msg)
+        return
+
     db_path = default_db_path()
     if not Path(db_path).exists():
         if json_out:

--- a/src/nexus/mcp/catalog.py
+++ b/src/nexus/mcp/catalog.py
@@ -439,10 +439,18 @@ def catalog_links(
         t, err = _resolve_tumbler_mcp(cat, tumbler)
         if err:
             return {"error": err}
-        result = cat.graph(t, depth=depth, direction=direction, link_type=link_type)
+        # nexus-qtj24: normalize to the plural ``link_types`` both backends
+        # accept. HttpCatalogClient.graph is keyword-only and has NO singular
+        # ``link_type`` param, so the old ``link_type=`` kwarg raised TypeError
+        # in service mode (swallowed into {"error": ...}).
+        link_types = [link_type] if link_type else None
+        result = cat.graph(t, depth=depth, direction=direction, link_types=link_types)
+        # nexus-qtj24: nodes/edges are CatalogEntry/CatalogLink objects on the
+        # SQLite path but plain dicts from the service /traverse path — guard
+        # .to_dict() (mirrors catalog_link_query).
         return {
-            "nodes": [n.to_dict() for n in result["nodes"]],
-            "edges": [e.to_dict() for e in result["edges"]],
+            "nodes": [n if isinstance(n, dict) else n.to_dict() for n in result["nodes"]],
+            "edges": [e if isinstance(e, dict) else e.to_dict() for e in result["edges"]],
         }
     except Exception as e:
         return {"error": str(e)}

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -691,7 +691,14 @@ def taxonomy_assign_batch_hook(
             if any(fnmatch(collection, pat) for pat in exclude):
                 return
         svc_embeddings = embeddings
-        if not svc_embeddings:
+        # nexus-reskd: re-fetch when embeddings are absent OR all-empty. The
+        # server-side-embed paths (doc_indexer / streaming PDF) pass
+        # ``[[], [], ...]`` placeholders — a non-empty OUTER list, so the old
+        # ``if not svc_embeddings`` was False and zero-dim vectors reached
+        # compute_assignments, silently producing no taxonomy assignments.
+        # ``not any(...)`` catches the all-empty-inner case; the ``not
+        # svc_embeddings`` short-circuit guards None / [] (any(None) raises).
+        if not svc_embeddings or not any(svc_embeddings):
             try:
                 arr = get_t3().get_embeddings(collection, doc_ids)
             except Exception:

--- a/tests/migration/test_vector_etl.py
+++ b/tests/migration/test_vector_etl.py
@@ -1209,9 +1209,6 @@ class TestVectorEtlIntegration:
         assert client.get_collection(name).count() == 6
 
 
-@pytest.mark.skip(
-    reason="nexus-wrfiy: the cross-dim orphan-detection logic needs rework for bge-768. The migrated collection is now 768 (service only embeds bge-768), but the test also needs a 384 collection (inserted via direct SQL, not migrate) to prove 384/768 orphan-scoping isolation. Distinct from the model-token conversion done for the other ETL integration classes."
-)
 @pytest.mark.integration
 @_SKIP_INTEGRATION
 class TestManifestFkIntegration:
@@ -1224,14 +1221,21 @@ class TestManifestFkIntegration:
         self, vec_etl_pg_instance, vec_etl_vector_client, tmp_path
     ) -> None:
         pg = vec_etl_pg_instance
-        name = _coll("etlmanifest")
+        # nexus-l84aj: the MIGRATED collection is bge-768 (the service only
+        # embeds bge-768 since RDR-160). The cross-dim 384 collection is
+        # inserted via DIRECT SQL (not migrated) so the 384/768 orphan-scoping
+        # isolation stays non-vacuous.
+        name = _coll("etlmanifest", model=_MODEL_768)
+        name384 = f"docs__etlv__{_MODEL_384}__v1"
         store, ids, _ = _make_local_store(tmp_path, name, 5)
         try:
-            self._run_manifest_flow(pg, name, ids, store, vec_etl_vector_client)
+            self._run_manifest_flow(
+                pg, name, name384, ids, store, vec_etl_vector_client
+            )
         finally:
-            # The PG instance is module-scoped: clear the seeded catalog +
-            # 768-lane rows so the deliberate orphan cannot leak into any
-            # test added to this module later.
+            # The PG instance is module-scoped: clear the seeded catalog + both
+            # the migrated 768 rows and the direct-SQL 384 rows so the
+            # deliberate orphan cannot leak into a later test in this module.
             _psql_exec(
                 pg,
                 "DELETE FROM nexus.catalog_document_chunks"
@@ -1240,11 +1244,12 @@ class TestManifestFkIntegration:
                 " WHERE tumbler IN ('9000.1', '9000.2');"
                 " DELETE FROM nexus.catalog_owners"
                 " WHERE tumbler_prefix = '9000';"
-                " DELETE FROM nexus.chunks_768"
-                f" WHERE collection = 'docs__etlv__{_MODEL_768}__v1'",
+                f" DELETE FROM nexus.chunks_768 WHERE collection = '{name}';"
+                f" DELETE FROM nexus.chunks_384 WHERE collection = '{name384}';"
+                f" DELETE FROM nexus.catalog_collections WHERE name = '{name384}'",
             )
 
-    def _run_manifest_flow(self, pg, name, ids, store, vec_etl_vector_client) -> None:
+    def _run_manifest_flow(self, pg, name, name384, ids, store, vec_etl_vector_client) -> None:
         # Manifest fixture: owner -> document (physical_collection = the
         # migrated collection) -> 5 chunk rows, collection NOT yet
         # backfilled (NULL — the pre-Phase-5 state).
@@ -1279,39 +1284,48 @@ class TestManifestFkIntegration:
         )
         assert backfilled == ["5"]
 
-        # Clean state: zero orphans at 384.
-        assert _psql_rows(pg, manifest_orphan_sql(384)) == []
+        # Clean state: zero orphans at 768 (the migrated bge-768 dim).
+        assert _psql_rows(pg, manifest_orphan_sql(768)) == []
 
-        # Cross-dim scoping: a 768-collection manifest row resolved by a
-        # chunks_768 row must NOT appear as a 384 orphan (and is clean at
-        # its own dim).
-        name768 = f"docs__etlv__{_MODEL_768}__v1"
-        chash768 = _chash("a 768-lane chunk")
-        vec768 = "[" + ",".join(["0"] * 768) + "]"
+        # Cross-dim scoping: a 384-collection manifest row resolved by a
+        # chunks_384 row must NOT appear as a 768 orphan (and is clean at its
+        # own dim). The 384 lane is seeded by DIRECT SQL — the bge-768 service
+        # cannot embed a 384 collection (nexus-l84aj).
+        chash384 = _chash("a 384-lane chunk")
+        vec384 = "[" + ",".join(["0"] * 384) + "]"
+        # chunks_384 has an FK on (tenant_id, collection) -> catalog_collections.
+        # The migrated bge-768 collection's registry row is created by the
+        # service; the direct-SQL 384 lane needs it stamped manually.
+        _psql_exec(
+            pg,
+            "INSERT INTO nexus.catalog_collections (tenant_id, name)"
+            f" VALUES ('default', '{name384}')",
+        )
         _psql_exec(
             pg,
             "INSERT INTO nexus.catalog_documents"
             " (tenant_id, tumbler, title, physical_collection)"
-            f" VALUES ('default', '9000.2', 'ETL Doc 768', '{name768}')",
+            f" VALUES ('default', '9000.2', 'ETL Doc 384', '{name384}')",
         )
         _psql_exec(
             pg,
             "INSERT INTO nexus.catalog_document_chunks"
             " (tenant_id, doc_id, position, chash, collection)"
-            f" VALUES ('default', '9000.2', 0, '{chash768}', '{name768}')",
+            f" VALUES ('default', '9000.2', 0, '{chash384}', '{name384}')",
         )
         _psql_exec(
             pg,
-            "INSERT INTO nexus.chunks_768"
+            "INSERT INTO nexus.chunks_384"
             " (tenant_id, collection, chash, chunk_text, embedding)"
-            f" VALUES ('default', '{name768}', '{chash768}',"
-            f" 'a 768-lane chunk', '{vec768}')",
+            f" VALUES ('default', '{name384}', '{chash384}',"
+            f" 'a 384-lane chunk', '{vec384}')",
         )
-        assert _psql_rows(pg, manifest_orphan_sql(384)) == []
         assert _psql_rows(pg, manifest_orphan_sql(768)) == []
+        assert _psql_rows(pg, manifest_orphan_sql(384)) == []
 
         # Deliberate orphan: a manifest row whose chash was never migrated
-        # MUST be detected (non-vacuous validation).
+        # MUST be detected (non-vacuous validation) — in the migrated bge-768
+        # collection, so it surfaces at dim 768.
         bogus = "feedfacefeedfacefeedfacefeedface"
         _psql_exec(
             pg,
@@ -1319,7 +1333,7 @@ class TestManifestFkIntegration:
             " (tenant_id, doc_id, position, chash, collection)"
             f" VALUES ('default', '9000.1', 99, '{bogus}', '{name}')",
         )
-        orphans = _psql_rows(pg, manifest_orphan_sql(384))
+        orphans = _psql_rows(pg, manifest_orphan_sql(768))
         assert len(orphans) == 1
         assert bogus in orphans[0]
 

--- a/tests/migration/test_vector_etl.py
+++ b/tests/migration/test_vector_etl.py
@@ -1337,6 +1337,23 @@ class TestManifestFkIntegration:
         assert len(orphans) == 1
         assert bogus in orphans[0]
 
+        # Symmetric true-positive (review): a never-migrated chash in the 384
+        # lane MUST be detected at dim 384 — proving 384 orphan detection is
+        # non-vacuous (the other half of cross-dim scoping), not just that 384
+        # ignores 768-lane rows.
+        bogus384 = "0123456789abcdef0123456789abcdef"
+        _psql_exec(
+            pg,
+            "INSERT INTO nexus.catalog_document_chunks"
+            " (tenant_id, doc_id, position, chash, collection)"
+            f" VALUES ('default', '9000.2', 99, '{bogus384}', '{name384}')",
+        )
+        orphans384 = _psql_rows(pg, manifest_orphan_sql(384))
+        assert len(orphans384) == 1
+        assert bogus384 in orphans384[0]
+        # And each dim's query still surfaces only its own lane's orphan.
+        assert len(_psql_rows(pg, manifest_orphan_sql(768))) == 1
+
 
 @pytest.mark.integration
 @_SKIP_INTEGRATION

--- a/tests/test_catalog_mcp.py
+++ b/tests/test_catalog_mcp.py
@@ -322,3 +322,50 @@ def test_link_audit(cat, monkeypatch) -> None:
 def test_resolve(cat, resolve_kw) -> None:
     catalog_register(title="A", owner="1.1", physical_collection="code__test")
     assert "code__test" in catalog_resolve(**resolve_kw)
+
+
+def test_catalog_links_service_mode_plain_dicts_and_link_types(monkeypatch):
+    """nexus-qtj24: catalog_links must (1) pass ``link_types`` (plural) — the
+    only kwarg HttpCatalogClient.graph accepts (it has no singular link_type and
+    is keyword-only) — and (2) handle plain-dict nodes/edges from the service
+    /traverse path instead of calling .to_dict() unconditionally."""
+    import nexus.mcp.catalog as mc
+
+    captured: dict = {}
+
+    class _FakeServiceCat:
+        def graph(self, tumbler, *, link_types=None, direction="both", depth=1):
+            captured["link_types"] = link_types
+            captured["depth"] = depth
+            # The service /traverse path returns plain dicts (no .to_dict()).
+            return {
+                "nodes": [{"tumbler": "1.1"}],
+                "edges": [{"from_tumbler": "1.1", "to_tumbler": "1.2"}],
+            }
+
+    monkeypatch.setattr(mc, "_require_catalog", lambda: (_FakeServiceCat(), None))
+    monkeypatch.setattr(mc, "_resolve_tumbler_mcp", lambda cat, t: (t, None))
+
+    result = mc.catalog_links(tumbler="1.1", link_type="cites")
+
+    assert "error" not in result, result
+    assert captured["link_types"] == ["cites"], "singular link_type not normalized to plural"
+    assert result["nodes"] == [{"tumbler": "1.1"}], "plain-dict node did not survive (.to_dict crash)"
+    assert result["edges"][0]["from_tumbler"] == "1.1"
+
+
+def test_catalog_links_no_link_type_passes_none(monkeypatch):
+    """Empty link_type -> link_types=None (traverse all link types)."""
+    import nexus.mcp.catalog as mc
+
+    captured: dict = {}
+
+    class _FakeCat:
+        def graph(self, tumbler, *, link_types=None, direction="both", depth=1):
+            captured["link_types"] = link_types
+            return {"nodes": [], "edges": []}
+
+    monkeypatch.setattr(mc, "_require_catalog", lambda: (_FakeCat(), None))
+    monkeypatch.setattr(mc, "_resolve_tumbler_mcp", lambda cat, t: (t, None))
+    mc.catalog_links(tumbler="1.1")
+    assert captured["link_types"] is None

--- a/tests/test_scratch_cmd.py
+++ b/tests/test_scratch_cmd.py
@@ -189,3 +189,23 @@ def test_scratch_list_friendly_error_when_t1_unresolvable(
     assert "Traceback" not in result.output
     assert "NX_T1_ISOLATED=1" in result.output
     assert "T1 not configured" in result.output
+
+
+def test_scratch_put_service_mode_no_endpoint_clean_error(
+    runner: CliRunner, fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """nexus-0l5ym: in service mode (NX_STORAGE_BACKEND=service) with no
+    reachable nexus-service, `nx scratch put` must give a clean ClickException
+    (exit 1, no raw RuntimeError traceback) with NX_T1_ISOLATED guidance."""
+    monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
+    for var in ("NX_SERVICE_URL", "NX_SERVICE_PORT", "NX_SERVICE_TOKEN",
+                "NX_T1_HOST", "NX_T1_PORT", "NX_T1_ISOLATED"):
+        monkeypatch.delenv(var, raising=False)
+
+    result = runner.invoke(main, ["scratch", "put", "hello"])
+
+    assert result.exit_code == 1
+    # The fix converts HttpScratchStore's raw RuntimeError into a clean
+    # ClickException — no RuntimeError should escape to the CLI runner.
+    assert not isinstance(result.exception, RuntimeError), result.exception
+    assert "NX_T1_ISOLATED" in result.output

--- a/tests/test_taxonomy_service_wiring.py
+++ b/tests/test_taxonomy_service_wiring.py
@@ -222,6 +222,53 @@ def test_assign_batch_hook_routes_through_service_store(monkeypatch):
     assert len(persisted[0]) == 4
 
 
+def test_assign_batch_hook_refetches_on_empty_placeholder_embeddings(monkeypatch):
+    """nexus-reskd: the server-side-embed paths (doc_indexer / streaming PDF)
+    pass ``[[], [], ...]`` placeholder embeddings. The hook must RE-FETCH real
+    vectors via get_embeddings — the old ``if not svc_embeddings`` was False for
+    a non-empty outer list, so zero-dim vectors reached compute_assignments and
+    silently produced no assignments."""
+    import nexus.mcp_infra as mi
+    from nexus.db.http_vector_client import HttpVectorClient
+
+    ids = [f"c{i}" for i in range(3)]
+    real = [[float(i), 1.0, 2.0] for i in range(3)]
+    fetched: list[list[str]] = []
+    seen_embeddings: list = []
+
+    class _SvcT3(HttpVectorClient):
+        def __init__(self):  # noqa: D107
+            pass
+
+        def get_embeddings(self, collection, doc_ids):  # noqa: ANN001
+            import numpy as _np
+            fetched.append(list(doc_ids))
+            return _np.asarray(real, dtype=_np.float32)
+
+    class _SvcTax:
+        def compute_assignments(self, collection, doc_ids, embeddings, *, cross_collection=False):  # noqa: ANN001
+            seen_embeddings.append(embeddings)
+            return []
+
+        def persist_assignments(self, assignments):  # noqa: ANN001
+            return 0
+
+    class _DB:
+        taxonomy = _SvcTax()
+
+    monkeypatch.setattr(mi, "get_t3", lambda: _SvcT3())
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: False)
+    monkeypatch.setattr(mi, "t2_index_write", lambda fn: fn(_DB()))
+
+    # The empty-placeholder shape ([[], [], []]) MUST trigger the re-fetch.
+    mi.taxonomy_assign_batch_hook(ids, "docs__demo", ["t"] * 3, [[] for _ in ids], None)
+
+    assert fetched == [ids], "empty-placeholder embeddings did not trigger get_embeddings re-fetch"
+    assert seen_embeddings, "compute_assignments was never called"
+    # compute_assignments saw the REAL re-fetched 3-dim vectors, not the empties.
+    assert all(len(v) == 3 for v in seen_embeddings[0])
+
+
 # ── split/project service fetch helpers (nexus-9pqoj) ───────────────────────
 
 

--- a/tests/test_tier_status_cli.py
+++ b/tests/test_tier_status_cli.py
@@ -192,3 +192,61 @@ class TestEmptyOrMissing:
         )
         assert result.exit_code == 0, result.output
         assert "no writes" in result.output
+
+
+class TestServiceModeReadParity:
+    """nexus-wyu1g: in service mode tier_writes live in Postgres, not local
+    SQLite. The diagnostics must report that honestly instead of silently
+    showing 0 (false wrong-result)."""
+
+    def test_tier_status_service_mode_reports_service_backed(
+        self, isolated_t2: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from nexus.commands.tier_status import tier_status_cmd
+
+        # Seed a local row — service mode must NOT read it (it would falsely
+        # report counts; in real service mode the local table is empty/stale).
+        _seed_t2(isolated_t2, [("sess-A", "memory_put", "T2", None, "nexus", "x")])
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
+        monkeypatch.setenv("NX_SESSION_ID", "sess-A")
+
+        result = CliRunner().invoke(tier_status_cmd, [])
+        assert result.exit_code == 0, result.output
+        assert "service-backed" in result.output
+        assert "total: 1" not in result.output  # did not read the local row
+
+    def test_tier_status_service_mode_json(
+        self, isolated_t2: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from nexus.commands.tier_status import tier_status_cmd
+
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
+        monkeypatch.setenv("NX_SESSION_ID", "sess-A")
+        result = CliRunner().invoke(tier_status_cmd, ["--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload.get("service_backed") is True
+
+    def test_doctor_tier_discipline_service_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from click.testing import CliRunner as _CR
+        import nexus.commands.doctor as doc
+
+        db = tmp_path / "t.db"
+        db.touch()
+        monkeypatch.setattr("nexus.commands._helpers.default_db_path", lambda: db)
+        monkeypatch.setenv("NX_SESSION_ID", "sess-A")
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
+
+        # _run_check_tier_discipline prints via click.echo; capture with a runner.
+        import click
+
+        @click.command()
+        def _wrap() -> None:
+            doc._run_check_tier_discipline()
+
+        result = _CR().invoke(_wrap, [])
+        assert result.exit_code == 0, result.output
+        assert "service-backed" in result.output and "N/A" in result.output
+        assert "no writes seen" not in result.output

--- a/tests/test_tier_status_cli.py
+++ b/tests/test_tier_status_cli.py
@@ -224,7 +224,7 @@ class TestServiceModeReadParity:
         monkeypatch.setenv("NX_SESSION_ID", "sess-A")
         result = CliRunner().invoke(tier_status_cmd, ["--json"])
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert payload.get("service_backed") is True
 
     def test_doctor_tier_discipline_service_mode(


### PR DESCRIPTION
Five service-mode follow-up fixes surfaced by the 6.0 Chroma→pgvector shakeout, where the default storage backend routes T2 stores + T3 vectors through the Java HTTP service.

## Fixes
- **nexus-qtj24** (`mcp/catalog.py`): `catalog_links` MCP tool passed singular `link_type=` to `cat.graph()`, but `HttpCatalogClient.graph` is keyword-only with plural `link_types`, and the service `/traverse` path returns plain dicts (not objects with `.to_dict()`). Normalized to `link_types=[...]` and guarded the dict/obj conversion. Service-mode `links` no longer errors.
- **nexus-reskd** (`mcp_infra.py`): `taxonomy_assign_batch_hook` re-fetch guard treated server-side-embed placeholders `[[], [], ...]` as present embeddings (truthy outer list). Changed to `if not svc_embeddings or not any(svc_embeddings)` so placeholders trigger the JVM re-fetch. Genuine all-zero vectors (`[[0.0, ...]]`) still pass through — `any()` tests inner-list non-emptiness.
- **nexus-0l5ym** (`commands/scratch.py`): `_t1()` now also catches the raw `RuntimeError` that service-mode `HttpScratchStore` raises when no endpoint resolves, converting it to a clean actionable `ClickException` (NX_T1_ISOLATED / `nx daemon service start` / NX_SERVICE_URL guidance) instead of a traceback.
- **nexus-wyu1g** (`commands/tier_status.py`, `commands/doctor.py`): in service mode `tier_writes` live in the service-backed telemetry store (Postgres), not local SQLite — reading the local table silently reported 0. Both surfaces now branch on `storage_backend_for("telemetry") == SERVICE` and emit an honest "service-backed; local inspection N/A". Full service-side read parity (a `GET /v1/telemetry/tier_writes` endpoint) is **deferred to nexus-59wjj**.
- **nexus-l84aj** (`tests/migration/test_vector_etl.py`): reworked the manifest cross-dim orphan test for the RDR-160 bge-768 local model; the 384 lane is seeded via direct SQL (catalog_collections registry row + chunks_384). Review remediation added a 384-lane orphan **true-positive** so cross-dim isolation is proven in both directions, not just that 384 ignores 768-lane rows.

## Verification
- Touched-file unit suite: 173 passed.
- `TestManifestFkIntegration` (l84aj) live-verified against a launched nexus-service JAR: 1 passed (both the FK-seeding path and the new 384 true-positive).
- Stacked review (code-review-expert + substantive-critic): 0 Critical; both Significant findings (untracked wyu1g deferral, half-covered l84aj cross-dim) remediated in this branch.

## Closes
Closes #nexus-qtj24
Closes #nexus-reskd
Closes #nexus-0l5ym
Closes #nexus-wyu1g
Closes #nexus-l84aj