### PR TITLE
fix(taxonomy): service-mode delete/merge self-clean the topic centroid (nexus-cugrk)

### DIFF
--- a/src/nexus/db/t2/http_taxonomy_store.py
+++ b/src/nexus/db/t2/http_taxonomy_store.py
@@ -14,19 +14,17 @@ CHROMA INTERACTION NOTE (RDR-152 P2.4):
     The taxonomy PG migration handles only the *relational* tables: topics,
     taxonomy_meta, topic_assignments, topic_links.
 
-    Chroma operations remain Python-side:
-    - The ``taxonomy__centroids`` ChromaDB collection (centroid vectors) is
-      NOT migrated to PG in this bead.  Phase 3 (Seam B) will address the
-      vector-store surface.
-    - ``delete_topic`` and ``merge_topics`` return the collection name so the
-      *caller* (CatalogTaxonomy or the orchestrator) can still call
-      ``chroma_client.get_collection(name).delete(...)`` against the centroid
-      collection locally.
-    - ``assign_topic`` never touches Chroma — centroid assignment is purely
-      relational (doc_id ↔ topic_id + similarity score).
-    - All callers that need to clean Chroma centroid rows after a delete/merge
-      must continue to do so from Python.  This store does NOT suppress the
-      Chroma half; it simply does not duplicate it.
+    Centroid vectors live in the service-backed centroid store (the pgvector
+    ``/v1/taxonomy/centroids`` routes, RDR-156 nexus-t1hnc), reached lazily via
+    ``self._centroid``:
+    - ``delete_topic`` and ``merge_topics`` self-clean the affected topic's
+      centroid via ``self._centroid.delete_ids(collection, [topic_id])`` after
+      the relational write (nexus-cugrk). This replaces the earlier "return the
+      collection name so the caller removes the centroid" contract, which leaked
+      orphan centroids that kept attracting chunks (ghost assignments to deleted
+      topics). The collection name is still returned for compatibility.
+    - ``assign_topic`` never touches the centroid store — centroid assignment is
+      purely relational (doc_id ↔ topic_id + similarity score).
 
 Interface parity (bead nexus-gmiaf.14, RDR-152 P2.4):
     get_topics, get_all_topics, get_topic_by_id, resolve_label,
@@ -283,29 +281,60 @@ class HttpTaxonomyStore(RawHandleGuardMixin):
         """Update review_status."""
         self._post("/topics/mark_reviewed", {"topic_id": topic_id, "status": status})
 
+    def _delete_centroid(self, collection: str, topic_id: int) -> None:
+        """Best-effort removal of a topic's centroid from the service-backed
+        centroid store (nexus-cugrk).
+
+        Leaving the orphan centroid behind keeps it attracting chunks in
+        ``project_against`` / ``assign_single`` until the next full rebuild —
+        persistent ghost assignments to a topic the user just deleted/merged.
+        Self-cleaning here closes that leak for every caller, replacing the
+        Chroma-era "caller removes the centroid" contract.
+
+        Failures are logged, never raised: the relational delete/merge has
+        already committed, and raising post-commit would surface a confusing
+        error for a non-authoritative side effect. The trade-off is that a
+        centroid-store outage during this window silently leaks the orphan —
+        it is cleared only by a subsequent full rebuild that purges-then-
+        recomputes the collection's centroids (not guaranteed to run soon), so
+        the failure is logged at WARNING with a traceback to keep the leak
+        detectable via log scraping.
+        """
+        try:
+            deleted = self._centroid.delete_ids(collection, [topic_id])
+            _log.debug(
+                "http_taxonomy_store.centroid_cleanup",
+                collection=collection, topic_id=topic_id, deleted=deleted,
+            )
+        except Exception as exc:  # noqa: BLE001 - best-effort side effect
+            _log.warning(
+                "http_taxonomy_store.centroid_cleanup_failed",
+                collection=collection, topic_id=topic_id, error=str(exc),
+                exc_info=True,
+            )
+
     def delete_topic(self, topic_id: int, *, chroma_client: Any = None) -> str | None:
-        """Delete a topic (relational tables only).
+        """Delete a topic, its assignments, and its centroid.
 
-        Returns the collection name for chroma centroid cleanup.
+        Deletes the relational rows via the service, then removes the topic's
+        centroid from the service-backed centroid store (nexus-cugrk) so it
+        stops attracting chunks. Returns the collection name.
 
-        CHROMA BOUNDARY: the caller is responsible for removing centroid
-        vectors from the ``taxonomy__centroids`` ChromaDB collection using
-        the returned collection name.  This store only handles the PG side.
+        The ``chroma_client`` parameter is retained for signature parity with
+        :class:`CatalogTaxonomy` but is unused on the service path — the
+        centroid lives in the pgvector centroid store, not Chroma.
         """
         try:
             r = self._post("/topics/delete", {"topic_id": topic_id})
             collection = r.get("collection")
-            _log.debug(
-                "http_taxonomy_store.delete_topic",
-                topic_id=topic_id,
-                collection=collection,
-                chroma_cleanup_required=chroma_client is not None,
-            )
-            return collection
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
                 return None
             raise
+        _log.debug("http_taxonomy_store.delete_topic", topic_id=topic_id, collection=collection)
+        if collection:
+            self._delete_centroid(collection, topic_id)
+        return collection
 
     def merge_topics(
         self,
@@ -314,19 +343,32 @@ class HttpTaxonomyStore(RawHandleGuardMixin):
         *,
         chroma_client: Any = None,
     ) -> str | None:
-        """Merge source topic into target (relational tables only).
+        """Merge source topic into target, deleting the source and its centroid.
 
-        Returns the source topic's collection name for chroma centroid cleanup.
+        Reassigns the source's docs to the target via the service, then removes
+        the SOURCE topic's centroid from the service-backed centroid store
+        (nexus-cugrk) — the source no longer exists, so its centroid must not
+        keep attracting chunks. The target's centroid is left untouched,
+        matching the local-store behaviour: it still reflects the target's
+        pre-merge doc set and is only recomputed on the next full rebuild, so
+        the merged target is in a stale attract-state until then. Not
+        recomputing here is the accepted trade-off (cheap, consistent with the
+        existing design) — an immediate recompute would need the merged
+        embeddings this relational-only path does not have.
 
-        CHROMA BOUNDARY: same as ``delete_topic``.
+        Returns the source topic's collection name. ``chroma_client`` is unused
+        on the service path (see :meth:`delete_topic`).
         """
         try:
             r = self._post("/topics/merge", {"source_id": source_id, "target_id": target_id})
-            return r.get("collection")
+            collection = r.get("collection")
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
                 return None
             raise
+        if collection:
+            self._delete_centroid(collection, source_id)
+        return collection
 
     # ── Assignments ────────────────────────────────────────────────────────────
 

--- a/tests/db/test_http_taxonomy_store.py
+++ b/tests/db/test_http_taxonomy_store.py
@@ -566,10 +566,16 @@ def reset_stores():
 
 @pytest.fixture
 def client(fake_server: str) -> HttpTaxonomyStore:
-    """HttpTaxonomyStore pointed at the fake server."""
+    """HttpTaxonomyStore pointed at the fake server.
+
+    Injects an in-memory ``_FakeCentroidStore`` so delete_topic/merge_topics
+    centroid self-cleaning (nexus-cugrk) does not fire a real HTTP round-trip
+    at the fake taxonomy server (which has no centroid route).
+    """
     return HttpTaxonomyStore(
         base_url=fake_server,
         _token=TOKEN,
+        centroid_store=_FakeCentroidStore([]),
     )
 
 
@@ -811,6 +817,69 @@ class TestDeleteAndMerge:
         assert client.get_topic_by_id(10) is None
         # Target topic still exists
         assert client.get_topic_by_id(20) is not None
+
+    # ── nexus-cugrk: delete/merge self-clean the centroid ──────────────────────
+    # (_FakeCentroidStore — defined later in this module — records delete_ids in
+    #  .calls as ("delete_ids", collection, [topic_ids]).)
+
+    def test_delete_topic_cleans_its_centroid(self, fake_server: str) -> None:
+        centroid = _FakeCentroidStore([])
+        store = HttpTaxonomyStore(base_url=fake_server, _token=TOKEN, centroid_store=centroid)
+        store.import_topic(
+            src_id=1, label="t", parent_id=None, collection="knowledge__papers",
+            centroid_hash=None, doc_count=1, created_at="2026-01-01T00:00:00Z",
+            review_status="pending", terms=None,
+        )
+        store.delete_topic(1)
+        assert centroid.calls == [("delete_ids", "knowledge__papers", [1])], (
+            "delete_topic must remove the topic's centroid from the centroid store, "
+            "not leak it as a chunk-attracting orphan"
+        )
+
+    def test_merge_topics_cleans_source_centroid_only(self, fake_server: str) -> None:
+        centroid = _FakeCentroidStore([])
+        store = HttpTaxonomyStore(base_url=fake_server, _token=TOKEN, centroid_store=centroid)
+        for tid, label in ((10, "source"), (20, "target")):
+            store.import_topic(
+                src_id=tid, label=label, parent_id=None, collection="knowledge__papers",
+                centroid_hash=None, doc_count=1, created_at="2026-01-01T00:00:00Z",
+                review_status="pending", terms=None,
+            )
+        store.merge_topics(10, 20)
+        assert centroid.calls == [("delete_ids", "knowledge__papers", [10])], (
+            "merge removes only the SOURCE centroid (10); the surviving target (20) "
+            "keeps its centroid until the next rebuild"
+        )
+
+    def test_delete_topic_not_found_skips_centroid(self, fake_server: str) -> None:
+        centroid = _FakeCentroidStore([])
+        store = HttpTaxonomyStore(base_url=fake_server, _token=TOKEN, centroid_store=centroid)
+        assert store.delete_topic(9999) is None
+        assert centroid.calls == [], "a 404 (no such topic) must not touch the centroid store"
+
+    def test_merge_topics_not_found_skips_centroid(self, fake_server: str) -> None:
+        centroid = _FakeCentroidStore([])
+        store = HttpTaxonomyStore(base_url=fake_server, _token=TOKEN, centroid_store=centroid)
+        assert store.merge_topics(9998, 9999) is None
+        assert centroid.calls == [], "a 404 source must not touch the centroid store"
+
+    def test_delete_topic_centroid_failure_is_swallowed(self, fake_server: str) -> None:
+        # The relational delete already committed; a centroid-store hiccup must not
+        # raise (stale centroid is recoverable on rebuild, post-commit raise is worse).
+        centroid = _FakeCentroidStore([])
+
+        def _boom(collection: str, topic_ids: list[int]) -> int:
+            raise RuntimeError("centroid store unreachable")
+
+        centroid.delete_ids = _boom  # type: ignore[method-assign]
+        store = HttpTaxonomyStore(base_url=fake_server, _token=TOKEN, centroid_store=centroid)
+        store.import_topic(
+            src_id=1, label="t", parent_id=None, collection="c",
+            centroid_hash=None, doc_count=1, created_at="2026-01-01T00:00:00Z",
+            review_status="pending", terms=None,
+        )
+        assert store.delete_topic(1) == "c"
+        assert store.get_topic_by_id(1) is None
 
     def test_merge_reassigns_docs_to_target(self, client: HttpTaxonomyStore) -> None:
         client.import_topic(


### PR DESCRIPTION
## Problem
`nx taxonomy review` delete (`d`) and merge (`m`) called `db.taxonomy.delete_topic`/`merge_topics` but never cleaned up the topic's centroid. In service mode the orphan centroid stays in the pgvector centroid store and keeps attracting chunks in `project_against`/`assign_single` — **persistent ghost assignments to a deleted topic** until the next full rebuild. (Filed P2, "pre-existing in raw mode; worse in service mode".)

## Fix
`HttpTaxonomyStore.delete_topic`/`merge_topics` now self-clean the affected centroid via `self._centroid.delete_ids(collection, [topic_id])` **after** the relational write, replacing the Chroma-era "caller removes the centroid" contract (every caller benefits, not just `review_cmd`):
- **delete** removes the topic's own centroid
- **merge** removes only the deleted **source**'s centroid; the surviving target is recomputed on the next rebuild (matches the local-store behaviour — docstring notes the stale-target window as the accepted trade-off)
- cleanup is **best-effort**: a centroid-store failure is logged at WARNING with a traceback (`exc_info`), never raised, because the relational write already committed. A 404 (no such topic) skips the centroid entirely.

## Scope
The local `CatalogTaxonomy` (chroma) leg cannot self-clean — it holds no centroid handle and its `taxonomy__centroids` path is deleted at RDR-155 P4b. Tracked separately in **nexus-5kl1b** (with an explicit P4b resolution condition) rather than invasively plumbing a dying path. In the 6.0 service-mode default, `db.taxonomy` is the http store fixed here.

## Tests (77 passed)
- delete cleans `[topic_id]`; merge cleans only `[source_id]`
- delete/merge 404 → centroid untouched
- centroid-store failure is swallowed (relational delete still succeeds)
- `client` fixture injects a fake centroid store so the existing relational tests don't fire spurious HTTP round-trips

## Review
Stacked review (code-review-expert + substantive-critic): 0 Critical. Remediated in-branch: fixture HTTP-spuriousness (IMPORTANT-1), merge-404 test (IMPORTANT-2), `exc_info` + accurate swallow docstring (SUGGESTION-1/S2), target-stale-window doc (S3), and the nexus-5kl1b P4b resolution condition (S1).

## Closes
Closes #nexus-cugrk