### PR TITLE
RDR-164 P1a: collection-registry FK spine (second wave) + jOOQ DSL conversion

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/AspectRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/AspectRepository.java
@@ -1,6 +1,7 @@
 package dev.nexus.service.db;
 
 import org.jooq.DSLContext;
+import org.jooq.Field;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +15,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import static dev.nexus.service.jooq.nexus.Tables.*;
+import static org.jooq.impl.DSL.*;
 
 /**
  * RDR-152 bead nexus-gmiaf.15 — repository for aspects, highlights, queue, and promotion-log.
@@ -32,9 +36,6 @@ import java.util.Set;
  * {@code SELECT ... FOR UPDATE SKIP LOCKED LIMIT 1} — atomically claims one
  * pending row per caller with no double-claim risk across concurrent workers.
  * This is the key contention fix that motivated RDR-152 for this store.
- *
- * <p>Uses raw SQL via DSLContext (same pattern as TaxonomyRepository) to avoid
- * dependency on jOOQ-generated classes for new tables not yet in codegen.
  */
 public final class AspectRepository {
 
@@ -51,6 +52,65 @@ public final class AspectRepository {
 
     /** Minimum confidence threshold (mirrors Python _MIN_CONFIDENCE = 0.3). */
     private static final double MIN_CONFIDENCE = 0.3;
+
+    // EXCLUDED pseudo-table fields used in ON CONFLICT DO UPDATE SET.
+    // ⚠ DRIFT RISK (RDR-164 review S4): these field("...") fragments embed literal column
+    // names (EXCLUDED.<col>, and qualified table cols in the COALESCE/GREATEST/LEAST/CASE
+    // constants below) that jOOQ codegen CANNOT type-check — jOOQ has no typed API for the
+    // EXCLUDED pseudo-table. If any referenced column is renamed in a Liquibase changelog
+    // (document_aspects.{problem_formulation,proposed_method,experimental_datasets,
+    // experimental_baselines,experimental_results,extras,confidence,extracted_at,model_version,
+    // extractor_name,source_uri,salient_sentences,doc_id}; aspect_extraction_queue.{status,
+    // retry_count,enqueued_at,last_attempt_at,last_error}), these strings compile but fail at
+    // runtime. Update them HERE when renaming those columns.
+    private static final Field<String>          EX_PROBLEM_FORMULATION    = field("EXCLUDED.problem_formulation",    String.class);
+    private static final Field<String>          EX_PROPOSED_METHOD        = field("EXCLUDED.proposed_method",        String.class);
+    private static final Field<String>          EX_EXPERIMENTAL_DATASETS  = field("EXCLUDED.experimental_datasets",  String.class);
+    private static final Field<String>          EX_EXPERIMENTAL_BASELINES = field("EXCLUDED.experimental_baselines", String.class);
+    private static final Field<String>          EX_EXPERIMENTAL_RESULTS   = field("EXCLUDED.experimental_results",   String.class);
+    private static final Field<String>          EX_EXTRAS                 = field("EXCLUDED.extras",                 String.class);
+    private static final Field<Double>          EX_CONFIDENCE             = field("EXCLUDED.confidence",             Double.class);
+    private static final Field<OffsetDateTime>  EX_EXTRACTED_AT           = field("EXCLUDED.extracted_at",           OffsetDateTime.class);
+    private static final Field<String>          EX_MODEL_VERSION          = field("EXCLUDED.model_version",          String.class);
+    private static final Field<String>          EX_EXTRACTOR_NAME         = field("EXCLUDED.extractor_name",         String.class);
+    private static final Field<String>          EX_SOURCE_URI             = field("EXCLUDED.source_uri",             String.class);
+    private static final Field<String>          EX_SALIENT_SENTENCES      = field("EXCLUDED.salient_sentences",      String.class);
+    private static final Field<String>          EX_DOC_ID                 = field("EXCLUDED.doc_id",                 String.class);
+
+    // COALESCE(EXCLUDED.x, table.x) fields for importAspect path
+    private static final Field<String>          EX_SOURCE_URI_COALESCE =
+        field("COALESCE(EXCLUDED.source_uri, document_aspects.source_uri)", String.class);
+    private static final Field<String>          EX_SALIENT_COALESCE =
+        field("COALESCE(EXCLUDED.salient_sentences, document_aspects.salient_sentences)", String.class);
+    private static final Field<String>          EX_DOC_ID_COALESCE =
+        field("COALESCE(EXCLUDED.doc_id, document_aspects.doc_id)", String.class);
+
+    // document_highlights EXCLUDED fields
+    private static final Field<String>          EX_HL_SOURCE_URI   = field("EXCLUDED.source_uri",    String.class);
+    private static final Field<String>          EX_HL_COLLECTION   = field("EXCLUDED.collection",    String.class);
+    private static final Field<String>          EX_HL_HIGHLIGHTS   = field("EXCLUDED.highlights_md", String.class);
+    private static final Field<String>          EX_HL_MENTIONS     = field("EXCLUDED.mentions_md",   String.class);
+    private static final Field<OffsetDateTime>  EX_HL_INGESTED_AT  = field("EXCLUDED.ingested_at",   OffsetDateTime.class);
+
+    // aspect_extraction_queue EXCLUDED fields
+    private static final Field<String>          EX_Q_DOC_ID          = field("EXCLUDED.doc_id",          String.class);
+    private static final Field<String>          EX_Q_CONTENT_HASH    = field("EXCLUDED.content_hash",    String.class);
+    private static final Field<String>          EX_Q_CONTENT         = field("EXCLUDED.content",         String.class);
+    private static final Field<OffsetDateTime>  EX_Q_ENQUEUED_AT     = field("EXCLUDED.enqueued_at",     OffsetDateTime.class);
+    private static final Field<String>          EX_Q_LAST_ERROR      = field("EXCLUDED.last_error",      String.class);
+    // Complex GREATEST/LEAST/CASE fields for importQueueRow
+    private static final Field<String>          EX_Q_STATUS_CASE =
+        field("CASE WHEN nexus.aspect_extraction_queue.status = 'in_progress' "
+            + "THEN nexus.aspect_extraction_queue.status ELSE EXCLUDED.status END", String.class);
+    private static final Field<Integer>         EX_Q_RETRY_GREATEST =
+        field("GREATEST(EXCLUDED.retry_count, nexus.aspect_extraction_queue.retry_count)", Integer.class);
+    private static final Field<OffsetDateTime>  EX_Q_ENQUEUED_LEAST =
+        field("LEAST(EXCLUDED.enqueued_at, nexus.aspect_extraction_queue.enqueued_at)", OffsetDateTime.class);
+    private static final Field<OffsetDateTime>  EX_Q_ATTEMPT_GREATEST =
+        field("GREATEST(EXCLUDED.last_attempt_at, nexus.aspect_extraction_queue.last_attempt_at)", OffsetDateTime.class);
+    private static final Field<String>          EX_Q_LAST_ERROR_CASE =
+        field("CASE WHEN EXCLUDED.status = 'failed' THEN EXCLUDED.last_error "
+            + "ELSE nexus.aspect_extraction_queue.last_error END", String.class);
 
     private final TenantScope tenantScope;
 
@@ -93,6 +153,23 @@ public final class AspectRepository {
      * <p>Conflict key: (tenant_id, collection, source_path). Returns the
      * surrogate id of the inserted/updated row, or -1 if rejected.
      */
+    /**
+     * RDR-164 P1a: ensure catalog_collections has a stub row for {@code collection}
+     * before any document_aspects / document_highlights / aspect_extraction_queue write,
+     * so the NOT VALID collection FKs (fk-003) cannot reject a live serving write whose
+     * collection has not yet been registered by the catalog ETL or a chunk upsert.
+     * Idempotent (ON CONFLICT DO NOTHING); a no-op for null/blank collection
+     * (document_highlights.collection is nullable — MATCH SIMPLE lets null escape the FK).
+     */
+    private static void ensureCollectionRegistered(DSLContext ctx, String tenant, String collection) {
+        if (collection == null || collection.isBlank()) return;
+        ctx.insertInto(CATALOG_COLLECTIONS, CATALOG_COLLECTIONS.TENANT_ID, CATALOG_COLLECTIONS.NAME)
+           .values(tenant, collection)
+           .onConflict(CATALOG_COLLECTIONS.TENANT_ID, CATALOG_COLLECTIONS.NAME)
+           .doNothing()
+           .execute();
+    }
+
     public long upsertAspect(String tenant, Map<String, Object> body) {
         double confidence = body.containsKey("confidence")
             ? ((Number) body.get("confidence")).doubleValue()
@@ -116,46 +193,62 @@ public final class AspectRepository {
         OffsetDateTime extractedAtTs = parseTs(extractedAt);
 
         return tenantScope.withTenant(tenant, ctx -> {
-            var result = ctx.fetch(
-                "INSERT INTO nexus.document_aspects "
-                + "(tenant_id, collection, source_path, problem_formulation, "
-                + " proposed_method, experimental_datasets, experimental_baselines, "
-                + " experimental_results, extras, confidence, extracted_at, "
-                + " model_version, extractor_name, source_uri, salient_sentences, doc_id) "
-                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::timestamptz, ?, ?, ?, ?, ?) "
-                + "ON CONFLICT (tenant_id, collection, source_path) DO UPDATE SET "
-                + "  problem_formulation    = EXCLUDED.problem_formulation, "
-                + "  proposed_method        = EXCLUDED.proposed_method, "
-                + "  experimental_datasets  = EXCLUDED.experimental_datasets, "
-                + "  experimental_baselines = EXCLUDED.experimental_baselines, "
-                + "  experimental_results   = EXCLUDED.experimental_results, "
-                + "  extras                 = EXCLUDED.extras, "
-                + "  confidence             = EXCLUDED.confidence, "
-                + "  extracted_at           = EXCLUDED.extracted_at, "
-                + "  model_version          = EXCLUDED.model_version, "
-                + "  extractor_name         = EXCLUDED.extractor_name, "
-                + "  source_uri             = EXCLUDED.source_uri, "
-                + "  salient_sentences      = EXCLUDED.salient_sentences, "
-                + "  doc_id                 = EXCLUDED.doc_id "
-                + "RETURNING id",
-                tenant,
-                collection,
-                sourcePath,
-                body.get("problem_formulation"),
-                body.get("proposed_method"),
-                body.get("experimental_datasets"),
-                body.get("experimental_baselines"),
-                body.get("experimental_results"),
-                body.get("extras"),
-                confidence,
-                formatTs(extractedAtTs),
-                modelVersion,
-                extractorName,
-                body.get("source_uri"),
-                body.get("salient_sentences"),
-                nullIfBlank((String) body.get("doc_id"))
-            );
-            return result.isEmpty() ? -1L : result.get(0).get(0, Long.class);
+            ensureCollectionRegistered(ctx, tenant, collection);
+            var result = ctx.insertInto(DOCUMENT_ASPECTS,
+                    DOCUMENT_ASPECTS.TENANT_ID,
+                    DOCUMENT_ASPECTS.COLLECTION,
+                    DOCUMENT_ASPECTS.SOURCE_PATH,
+                    DOCUMENT_ASPECTS.PROBLEM_FORMULATION,
+                    DOCUMENT_ASPECTS.PROPOSED_METHOD,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_DATASETS,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_BASELINES,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_RESULTS,
+                    DOCUMENT_ASPECTS.EXTRAS,
+                    DOCUMENT_ASPECTS.CONFIDENCE,
+                    DOCUMENT_ASPECTS.EXTRACTED_AT,
+                    DOCUMENT_ASPECTS.MODEL_VERSION,
+                    DOCUMENT_ASPECTS.EXTRACTOR_NAME,
+                    DOCUMENT_ASPECTS.SOURCE_URI,
+                    DOCUMENT_ASPECTS.SALIENT_SENTENCES,
+                    DOCUMENT_ASPECTS.DOC_ID)
+                .values(
+                    tenant,
+                    collection,
+                    sourcePath,
+                    (String) body.get("problem_formulation"),
+                    (String) body.get("proposed_method"),
+                    (String) body.get("experimental_datasets"),
+                    (String) body.get("experimental_baselines"),
+                    (String) body.get("experimental_results"),
+                    (String) body.get("extras"),
+                    confidence,
+                    extractedAtTs,
+                    modelVersion,
+                    extractorName,
+                    (String) body.get("source_uri"),
+                    (String) body.get("salient_sentences"),
+                    nullIfBlank((String) body.get("doc_id")))
+                .onConflict(
+                    DOCUMENT_ASPECTS.TENANT_ID,
+                    DOCUMENT_ASPECTS.COLLECTION,
+                    DOCUMENT_ASPECTS.SOURCE_PATH)
+                .doUpdate()
+                .set(DOCUMENT_ASPECTS.PROBLEM_FORMULATION,    EX_PROBLEM_FORMULATION)
+                .set(DOCUMENT_ASPECTS.PROPOSED_METHOD,        EX_PROPOSED_METHOD)
+                .set(DOCUMENT_ASPECTS.EXPERIMENTAL_DATASETS,  EX_EXPERIMENTAL_DATASETS)
+                .set(DOCUMENT_ASPECTS.EXPERIMENTAL_BASELINES, EX_EXPERIMENTAL_BASELINES)
+                .set(DOCUMENT_ASPECTS.EXPERIMENTAL_RESULTS,   EX_EXPERIMENTAL_RESULTS)
+                .set(DOCUMENT_ASPECTS.EXTRAS,                 EX_EXTRAS)
+                .set(DOCUMENT_ASPECTS.CONFIDENCE,             EX_CONFIDENCE)
+                .set(DOCUMENT_ASPECTS.EXTRACTED_AT,           EX_EXTRACTED_AT)
+                .set(DOCUMENT_ASPECTS.MODEL_VERSION,          EX_MODEL_VERSION)
+                .set(DOCUMENT_ASPECTS.EXTRACTOR_NAME,         EX_EXTRACTOR_NAME)
+                .set(DOCUMENT_ASPECTS.SOURCE_URI,             EX_SOURCE_URI)
+                .set(DOCUMENT_ASPECTS.SALIENT_SENTENCES,      EX_SALIENT_SENTENCES)
+                .set(DOCUMENT_ASPECTS.DOC_ID,                 EX_DOC_ID)
+                .returning(DOCUMENT_ASPECTS.ID)
+                .fetch();
+            return result.isEmpty() ? -1L : result.get(0).get(DOCUMENT_ASPECTS.ID);
         });
     }
 
@@ -164,14 +257,26 @@ public final class AspectRepository {
      */
     public Optional<Map<String, Object>> getAspect(String tenant, String collection, String sourcePath) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch(
-                "SELECT collection, source_path, problem_formulation, proposed_method, "
-                + "       experimental_datasets, experimental_baselines, experimental_results, "
-                + "       extras, confidence, extracted_at, model_version, extractor_name, "
-                + "       source_uri, salient_sentences, doc_id "
-                + "FROM nexus.document_aspects "
-                + "WHERE collection = ? AND source_path = ?",
-                collection, sourcePath);
+            var rows = ctx.select(
+                    DOCUMENT_ASPECTS.COLLECTION,
+                    DOCUMENT_ASPECTS.SOURCE_PATH,
+                    DOCUMENT_ASPECTS.PROBLEM_FORMULATION,
+                    DOCUMENT_ASPECTS.PROPOSED_METHOD,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_DATASETS,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_BASELINES,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_RESULTS,
+                    DOCUMENT_ASPECTS.EXTRAS,
+                    DOCUMENT_ASPECTS.CONFIDENCE,
+                    DOCUMENT_ASPECTS.EXTRACTED_AT,
+                    DOCUMENT_ASPECTS.MODEL_VERSION,
+                    DOCUMENT_ASPECTS.EXTRACTOR_NAME,
+                    DOCUMENT_ASPECTS.SOURCE_URI,
+                    DOCUMENT_ASPECTS.SALIENT_SENTENCES,
+                    DOCUMENT_ASPECTS.DOC_ID)
+                .from(DOCUMENT_ASPECTS)
+                .where(DOCUMENT_ASPECTS.COLLECTION.eq(collection)
+                    .and(DOCUMENT_ASPECTS.SOURCE_PATH.eq(sourcePath)))
+                .fetch();
             if (rows.isEmpty()) return Optional.empty();
             return Optional.of(recordToMap(rows.get(0)));
         });
@@ -183,14 +288,25 @@ public final class AspectRepository {
     public Optional<Map<String, Object>> getAspectByDocId(String tenant, String docId) {
         if (docId == null || docId.isBlank()) return Optional.empty();
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch(
-                "SELECT collection, source_path, problem_formulation, proposed_method, "
-                + "       experimental_datasets, experimental_baselines, experimental_results, "
-                + "       extras, confidence, extracted_at, model_version, extractor_name, "
-                + "       source_uri, salient_sentences, doc_id "
-                + "FROM nexus.document_aspects "
-                + "WHERE doc_id = ?",
-                docId);
+            var rows = ctx.select(
+                    DOCUMENT_ASPECTS.COLLECTION,
+                    DOCUMENT_ASPECTS.SOURCE_PATH,
+                    DOCUMENT_ASPECTS.PROBLEM_FORMULATION,
+                    DOCUMENT_ASPECTS.PROPOSED_METHOD,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_DATASETS,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_BASELINES,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_RESULTS,
+                    DOCUMENT_ASPECTS.EXTRAS,
+                    DOCUMENT_ASPECTS.CONFIDENCE,
+                    DOCUMENT_ASPECTS.EXTRACTED_AT,
+                    DOCUMENT_ASPECTS.MODEL_VERSION,
+                    DOCUMENT_ASPECTS.EXTRACTOR_NAME,
+                    DOCUMENT_ASPECTS.SOURCE_URI,
+                    DOCUMENT_ASPECTS.SALIENT_SENTENCES,
+                    DOCUMENT_ASPECTS.DOC_ID)
+                .from(DOCUMENT_ASPECTS)
+                .where(DOCUMENT_ASPECTS.DOC_ID.eq(docId))
+                .fetch();
             if (rows.isEmpty()) return Optional.empty();
             return Optional.of(recordToMap(rows.get(0)));
         });
@@ -201,16 +317,26 @@ public final class AspectRepository {
      */
     public List<Map<String, Object>> listByCollection(String tenant, String collection, int limit, int offset) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch(
-                "SELECT collection, source_path, problem_formulation, proposed_method, "
-                + "       experimental_datasets, experimental_baselines, experimental_results, "
-                + "       extras, confidence, extracted_at, model_version, extractor_name, "
-                + "       source_uri, salient_sentences, doc_id "
-                + "FROM nexus.document_aspects "
-                + "WHERE collection = ? "
-                + "ORDER BY source_path ASC "
-                + (limit > 0 ? "LIMIT " + limit + " OFFSET " + offset : ""),
-                collection);
+            var q = ctx.select(
+                    DOCUMENT_ASPECTS.COLLECTION,
+                    DOCUMENT_ASPECTS.SOURCE_PATH,
+                    DOCUMENT_ASPECTS.PROBLEM_FORMULATION,
+                    DOCUMENT_ASPECTS.PROPOSED_METHOD,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_DATASETS,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_BASELINES,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_RESULTS,
+                    DOCUMENT_ASPECTS.EXTRAS,
+                    DOCUMENT_ASPECTS.CONFIDENCE,
+                    DOCUMENT_ASPECTS.EXTRACTED_AT,
+                    DOCUMENT_ASPECTS.MODEL_VERSION,
+                    DOCUMENT_ASPECTS.EXTRACTOR_NAME,
+                    DOCUMENT_ASPECTS.SOURCE_URI,
+                    DOCUMENT_ASPECTS.SALIENT_SENTENCES,
+                    DOCUMENT_ASPECTS.DOC_ID)
+                .from(DOCUMENT_ASPECTS)
+                .where(DOCUMENT_ASPECTS.COLLECTION.eq(collection))
+                .orderBy(DOCUMENT_ASPECTS.SOURCE_PATH.asc());
+            var rows = (limit > 0 ? q.limit(limit).offset(offset) : q).fetch();
             List<Map<String, Object>> out = new ArrayList<>();
             for (var r : rows) out.add(recordToMap(r));
             return out;
@@ -222,15 +348,27 @@ public final class AspectRepository {
      */
     public List<Map<String, Object>> listByExtractorVersion(String tenant, String extractorName, String maxVersion) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch(
-                "SELECT collection, source_path, problem_formulation, proposed_method, "
-                + "       experimental_datasets, experimental_baselines, experimental_results, "
-                + "       extras, confidence, extracted_at, model_version, extractor_name, "
-                + "       source_uri, salient_sentences, doc_id "
-                + "FROM nexus.document_aspects "
-                + "WHERE extractor_name = ? AND model_version < ? "
-                + "ORDER BY collection, source_path",
-                extractorName, maxVersion);
+            var rows = ctx.select(
+                    DOCUMENT_ASPECTS.COLLECTION,
+                    DOCUMENT_ASPECTS.SOURCE_PATH,
+                    DOCUMENT_ASPECTS.PROBLEM_FORMULATION,
+                    DOCUMENT_ASPECTS.PROPOSED_METHOD,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_DATASETS,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_BASELINES,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_RESULTS,
+                    DOCUMENT_ASPECTS.EXTRAS,
+                    DOCUMENT_ASPECTS.CONFIDENCE,
+                    DOCUMENT_ASPECTS.EXTRACTED_AT,
+                    DOCUMENT_ASPECTS.MODEL_VERSION,
+                    DOCUMENT_ASPECTS.EXTRACTOR_NAME,
+                    DOCUMENT_ASPECTS.SOURCE_URI,
+                    DOCUMENT_ASPECTS.SALIENT_SENTENCES,
+                    DOCUMENT_ASPECTS.DOC_ID)
+                .from(DOCUMENT_ASPECTS)
+                .where(DOCUMENT_ASPECTS.EXTRACTOR_NAME.eq(extractorName)
+                    .and(DOCUMENT_ASPECTS.MODEL_VERSION.lt(maxVersion)))
+                .orderBy(DOCUMENT_ASPECTS.COLLECTION.asc(), DOCUMENT_ASPECTS.SOURCE_PATH.asc())
+                .fetch();
             List<Map<String, Object>> out = new ArrayList<>();
             for (var r : rows) out.add(recordToMap(r));
             return out;
@@ -242,9 +380,10 @@ public final class AspectRepository {
      */
     public int deleteAspect(String tenant, String collection, String sourcePath) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.execute(
-                "DELETE FROM nexus.document_aspects WHERE collection = ? AND source_path = ?",
-                collection, sourcePath));
+            ctx.deleteFrom(DOCUMENT_ASPECTS)
+               .where(DOCUMENT_ASPECTS.COLLECTION.eq(collection)
+                   .and(DOCUMENT_ASPECTS.SOURCE_PATH.eq(sourcePath)))
+               .execute());
     }
 
     /**
@@ -252,15 +391,20 @@ public final class AspectRepository {
      */
     public int renameAspectCollection(String tenant, String oldColl, String newColl) {
         return tenantScope.withTenant(tenant, ctx -> {
+            // RDR-164 P1a: register the new collection before re-pointing the denorm column
+            ensureCollectionRegistered(ctx, tenant, newColl);
             // Collision defense: delete conflicting new-side rows first
-            ctx.execute(
-                "DELETE FROM nexus.document_aspects "
-                + "WHERE collection = ? "
-                + "  AND source_path IN (SELECT source_path FROM nexus.document_aspects WHERE collection = ?)",
-                newColl, oldColl);
-            return ctx.execute(
-                "UPDATE nexus.document_aspects SET collection = ? WHERE collection = ?",
-                newColl, oldColl);
+            ctx.deleteFrom(DOCUMENT_ASPECTS)
+               .where(DOCUMENT_ASPECTS.COLLECTION.eq(newColl)
+                   .and(DOCUMENT_ASPECTS.SOURCE_PATH.in(
+                       select(DOCUMENT_ASPECTS.SOURCE_PATH)
+                           .from(DOCUMENT_ASPECTS)
+                           .where(DOCUMENT_ASPECTS.COLLECTION.eq(oldColl)))))
+               .execute();
+            return ctx.update(DOCUMENT_ASPECTS)
+                .set(DOCUMENT_ASPECTS.COLLECTION, newColl)
+                .where(DOCUMENT_ASPECTS.COLLECTION.eq(oldColl))
+                .execute();
         });
     }
 
@@ -270,9 +414,10 @@ public final class AspectRepository {
     public int setSalientSentences(String tenant, String docId, String sentencesJson) {
         if (docId == null || docId.isBlank()) return 0;
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.execute(
-                "UPDATE nexus.document_aspects SET salient_sentences = ? WHERE doc_id = ?",
-                sentencesJson, docId));
+            ctx.update(DOCUMENT_ASPECTS)
+               .set(DOCUMENT_ASPECTS.SALIENT_SENTENCES, sentencesJson)
+               .where(DOCUMENT_ASPECTS.DOC_ID.eq(docId))
+               .execute());
     }
 
     /**
@@ -280,10 +425,11 @@ public final class AspectRepository {
      */
     public int setSalientSentencesByKey(String tenant, String collection, String sourcePath, String sentencesJson) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.execute(
-                "UPDATE nexus.document_aspects SET salient_sentences = ? "
-                + "WHERE collection = ? AND source_path = ?",
-                sentencesJson, collection, sourcePath));
+            ctx.update(DOCUMENT_ASPECTS)
+               .set(DOCUMENT_ASPECTS.SALIENT_SENTENCES, sentencesJson)
+               .where(DOCUMENT_ASPECTS.COLLECTION.eq(collection)
+                   .and(DOCUMENT_ASPECTS.SOURCE_PATH.eq(sourcePath)))
+               .execute());
     }
 
     /**
@@ -292,9 +438,10 @@ public final class AspectRepository {
     public String getSalientSentences(String tenant, String docId) {
         if (docId == null || docId.isBlank()) return null;
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch(
-                "SELECT salient_sentences FROM nexus.document_aspects WHERE doc_id = ?",
-                docId);
+            var rows = ctx.select(DOCUMENT_ASPECTS.SALIENT_SENTENCES)
+                .from(DOCUMENT_ASPECTS)
+                .where(DOCUMENT_ASPECTS.DOC_ID.eq(docId))
+                .fetch();
             if (rows.isEmpty()) return null;
             Object val = rows.get(0).get(0);
             return val == null ? null : val.toString();
@@ -315,45 +462,62 @@ public final class AspectRepository {
         String extractedAt = (String) body.get("extracted_at");
         OffsetDateTime extractedAtTs = parseTs(extractedAt);
 
-        return tenantScope.withTenant(tenant, ctx ->
-            ctx.execute(
-                "INSERT INTO nexus.document_aspects "
-                + "(tenant_id, collection, source_path, problem_formulation, "
-                + " proposed_method, experimental_datasets, experimental_baselines, "
-                + " experimental_results, extras, confidence, extracted_at, "
-                + " model_version, extractor_name, source_uri, salient_sentences, doc_id) "
-                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::timestamptz, ?, ?, ?, ?, ?) "
-                + "ON CONFLICT (tenant_id, collection, source_path) DO UPDATE SET "
-                + "  problem_formulation    = EXCLUDED.problem_formulation, "
-                + "  proposed_method        = EXCLUDED.proposed_method, "
-                + "  experimental_datasets  = EXCLUDED.experimental_datasets, "
-                + "  experimental_baselines = EXCLUDED.experimental_baselines, "
-                + "  experimental_results   = EXCLUDED.experimental_results, "
-                + "  extras                 = EXCLUDED.extras, "
-                + "  confidence             = EXCLUDED.confidence, "
-                + "  extracted_at           = EXCLUDED.extracted_at, "
-                + "  model_version          = EXCLUDED.model_version, "
-                + "  extractor_name         = EXCLUDED.extractor_name, "
-                + "  source_uri             = COALESCE(EXCLUDED.source_uri, document_aspects.source_uri), "
-                + "  salient_sentences      = COALESCE(EXCLUDED.salient_sentences, document_aspects.salient_sentences), "
-                + "  doc_id                 = COALESCE(EXCLUDED.doc_id, document_aspects.doc_id)",
-                tenant,
-                body.get("collection"),
-                body.get("source_path"),
-                body.get("problem_formulation"),
-                body.get("proposed_method"),
-                body.get("experimental_datasets"),
-                body.get("experimental_baselines"),
-                body.get("experimental_results"),
-                body.get("extras"),
-                confidence,
-                formatTs(extractedAtTs),
-                body.get("model_version"),
-                body.get("extractor_name"),
-                body.get("source_uri"),
-                body.get("salient_sentences"),
-                nullIfBlank((String) body.get("doc_id"))
-            ));
+        return tenantScope.withTenant(tenant, ctx -> {
+            ensureCollectionRegistered(ctx, tenant, (String) body.get("collection"));
+            return ctx.insertInto(DOCUMENT_ASPECTS,
+                    DOCUMENT_ASPECTS.TENANT_ID,
+                    DOCUMENT_ASPECTS.COLLECTION,
+                    DOCUMENT_ASPECTS.SOURCE_PATH,
+                    DOCUMENT_ASPECTS.PROBLEM_FORMULATION,
+                    DOCUMENT_ASPECTS.PROPOSED_METHOD,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_DATASETS,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_BASELINES,
+                    DOCUMENT_ASPECTS.EXPERIMENTAL_RESULTS,
+                    DOCUMENT_ASPECTS.EXTRAS,
+                    DOCUMENT_ASPECTS.CONFIDENCE,
+                    DOCUMENT_ASPECTS.EXTRACTED_AT,
+                    DOCUMENT_ASPECTS.MODEL_VERSION,
+                    DOCUMENT_ASPECTS.EXTRACTOR_NAME,
+                    DOCUMENT_ASPECTS.SOURCE_URI,
+                    DOCUMENT_ASPECTS.SALIENT_SENTENCES,
+                    DOCUMENT_ASPECTS.DOC_ID)
+                .values(
+                    tenant,
+                    (String) body.get("collection"),
+                    (String) body.get("source_path"),
+                    (String) body.get("problem_formulation"),
+                    (String) body.get("proposed_method"),
+                    (String) body.get("experimental_datasets"),
+                    (String) body.get("experimental_baselines"),
+                    (String) body.get("experimental_results"),
+                    (String) body.get("extras"),
+                    confidence,
+                    extractedAtTs,
+                    (String) body.get("model_version"),
+                    (String) body.get("extractor_name"),
+                    (String) body.get("source_uri"),
+                    (String) body.get("salient_sentences"),
+                    nullIfBlank((String) body.get("doc_id")))
+                .onConflict(
+                    DOCUMENT_ASPECTS.TENANT_ID,
+                    DOCUMENT_ASPECTS.COLLECTION,
+                    DOCUMENT_ASPECTS.SOURCE_PATH)
+                .doUpdate()
+                .set(DOCUMENT_ASPECTS.PROBLEM_FORMULATION,    EX_PROBLEM_FORMULATION)
+                .set(DOCUMENT_ASPECTS.PROPOSED_METHOD,        EX_PROPOSED_METHOD)
+                .set(DOCUMENT_ASPECTS.EXPERIMENTAL_DATASETS,  EX_EXPERIMENTAL_DATASETS)
+                .set(DOCUMENT_ASPECTS.EXPERIMENTAL_BASELINES, EX_EXPERIMENTAL_BASELINES)
+                .set(DOCUMENT_ASPECTS.EXPERIMENTAL_RESULTS,   EX_EXPERIMENTAL_RESULTS)
+                .set(DOCUMENT_ASPECTS.EXTRAS,                 EX_EXTRAS)
+                .set(DOCUMENT_ASPECTS.CONFIDENCE,             EX_CONFIDENCE)
+                .set(DOCUMENT_ASPECTS.EXTRACTED_AT,           EX_EXTRACTED_AT)
+                .set(DOCUMENT_ASPECTS.MODEL_VERSION,          EX_MODEL_VERSION)
+                .set(DOCUMENT_ASPECTS.EXTRACTOR_NAME,         EX_EXTRACTOR_NAME)
+                .set(DOCUMENT_ASPECTS.SOURCE_URI,             EX_SOURCE_URI_COALESCE)
+                .set(DOCUMENT_ASPECTS.SALIENT_SENTENCES,      EX_SALIENT_COALESCE)
+                .set(DOCUMENT_ASPECTS.DOC_ID,                 EX_DOC_ID_COALESCE)
+                .execute();
+        });
     }
 
     // ── document_highlights ────────────────────────────────────────────────────
@@ -375,20 +539,31 @@ public final class AspectRepository {
 
         OffsetDateTime ingestedAtTs = parseTs(ingestedAt);
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute(
-                "INSERT INTO nexus.document_highlights "
-                + "(tenant_id, doc_id, source_uri, collection, highlights_md, mentions_md, ingested_at) "
-                + "VALUES (?, ?, ?, ?, ?, ?, ?::timestamptz) "
-                + "ON CONFLICT (tenant_id, doc_id) DO UPDATE SET "
-                + "  source_uri    = EXCLUDED.source_uri, "
-                + "  collection    = EXCLUDED.collection, "
-                + "  highlights_md = EXCLUDED.highlights_md, "
-                + "  mentions_md   = EXCLUDED.mentions_md, "
-                + "  ingested_at   = EXCLUDED.ingested_at",
-                tenant, docId,
-                body.get("source_uri"),
-                body.get("collection"),
-                highlightsMd, mentionsMd, formatTs(ingestedAtTs));
+            ensureCollectionRegistered(ctx, tenant, (String) body.get("collection"));
+            ctx.insertInto(DOCUMENT_HIGHLIGHTS,
+                    DOCUMENT_HIGHLIGHTS.TENANT_ID,
+                    DOCUMENT_HIGHLIGHTS.DOC_ID,
+                    DOCUMENT_HIGHLIGHTS.SOURCE_URI,
+                    DOCUMENT_HIGHLIGHTS.COLLECTION,
+                    DOCUMENT_HIGHLIGHTS.HIGHLIGHTS_MD,
+                    DOCUMENT_HIGHLIGHTS.MENTIONS_MD,
+                    DOCUMENT_HIGHLIGHTS.INGESTED_AT)
+                .values(
+                    tenant,
+                    docId,
+                    (String) body.get("source_uri"),
+                    (String) body.get("collection"),
+                    highlightsMd,
+                    mentionsMd,
+                    ingestedAtTs)
+                .onConflict(DOCUMENT_HIGHLIGHTS.TENANT_ID, DOCUMENT_HIGHLIGHTS.DOC_ID)
+                .doUpdate()
+                .set(DOCUMENT_HIGHLIGHTS.SOURCE_URI,    EX_HL_SOURCE_URI)
+                .set(DOCUMENT_HIGHLIGHTS.COLLECTION,    EX_HL_COLLECTION)
+                .set(DOCUMENT_HIGHLIGHTS.HIGHLIGHTS_MD, EX_HL_HIGHLIGHTS)
+                .set(DOCUMENT_HIGHLIGHTS.MENTIONS_MD,   EX_HL_MENTIONS)
+                .set(DOCUMENT_HIGHLIGHTS.INGESTED_AT,   EX_HL_INGESTED_AT)
+                .execute();
             return null;
         });
         return true;
@@ -399,10 +574,16 @@ public final class AspectRepository {
      */
     public Optional<Map<String, Object>> getHighlight(String tenant, String docId) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch(
-                "SELECT doc_id, source_uri, collection, highlights_md, mentions_md, ingested_at "
-                + "FROM nexus.document_highlights WHERE doc_id = ?",
-                docId);
+            var rows = ctx.select(
+                    DOCUMENT_HIGHLIGHTS.DOC_ID,
+                    DOCUMENT_HIGHLIGHTS.SOURCE_URI,
+                    DOCUMENT_HIGHLIGHTS.COLLECTION,
+                    DOCUMENT_HIGHLIGHTS.HIGHLIGHTS_MD,
+                    DOCUMENT_HIGHLIGHTS.MENTIONS_MD,
+                    DOCUMENT_HIGHLIGHTS.INGESTED_AT)
+                .from(DOCUMENT_HIGHLIGHTS)
+                .where(DOCUMENT_HIGHLIGHTS.DOC_ID.eq(docId))
+                .fetch();
             if (rows.isEmpty()) return Optional.empty();
             return Optional.of(highlightToMap(rows.get(0)));
         });
@@ -413,10 +594,17 @@ public final class AspectRepository {
      */
     public Optional<Map<String, Object>> getHighlightBySourceUri(String tenant, String sourceUri) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch(
-                "SELECT doc_id, source_uri, collection, highlights_md, mentions_md, ingested_at "
-                + "FROM nexus.document_highlights WHERE source_uri = ? LIMIT 1",
-                sourceUri);
+            var rows = ctx.select(
+                    DOCUMENT_HIGHLIGHTS.DOC_ID,
+                    DOCUMENT_HIGHLIGHTS.SOURCE_URI,
+                    DOCUMENT_HIGHLIGHTS.COLLECTION,
+                    DOCUMENT_HIGHLIGHTS.HIGHLIGHTS_MD,
+                    DOCUMENT_HIGHLIGHTS.MENTIONS_MD,
+                    DOCUMENT_HIGHLIGHTS.INGESTED_AT)
+                .from(DOCUMENT_HIGHLIGHTS)
+                .where(DOCUMENT_HIGHLIGHTS.SOURCE_URI.eq(sourceUri))
+                .limit(1)
+                .fetch();
             if (rows.isEmpty()) return Optional.empty();
             return Optional.of(highlightToMap(rows.get(0)));
         });
@@ -427,11 +615,18 @@ public final class AspectRepository {
      */
     public List<Map<String, Object>> listHighlights(String tenant, int limit, int offset) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch(
-                "SELECT doc_id, source_uri, collection, highlights_md, mentions_md, ingested_at "
-                + "FROM nexus.document_highlights "
-                + "ORDER BY ingested_at DESC LIMIT ? OFFSET ?",
-                limit, offset);
+            var rows = ctx.select(
+                    DOCUMENT_HIGHLIGHTS.DOC_ID,
+                    DOCUMENT_HIGHLIGHTS.SOURCE_URI,
+                    DOCUMENT_HIGHLIGHTS.COLLECTION,
+                    DOCUMENT_HIGHLIGHTS.HIGHLIGHTS_MD,
+                    DOCUMENT_HIGHLIGHTS.MENTIONS_MD,
+                    DOCUMENT_HIGHLIGHTS.INGESTED_AT)
+                .from(DOCUMENT_HIGHLIGHTS)
+                .orderBy(DOCUMENT_HIGHLIGHTS.INGESTED_AT.desc())
+                .limit(limit)
+                .offset(offset)
+                .fetch();
             List<Map<String, Object>> out = new ArrayList<>();
             for (var r : rows) out.add(highlightToMap(r));
             return out;
@@ -443,7 +638,9 @@ public final class AspectRepository {
      */
     public boolean deleteHighlight(String tenant, String docId) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.execute("DELETE FROM nexus.document_highlights WHERE doc_id = ?", docId) > 0);
+            ctx.deleteFrom(DOCUMENT_HIGHLIGHTS)
+               .where(DOCUMENT_HIGHLIGHTS.DOC_ID.eq(docId))
+               .execute() > 0);
     }
 
     /**
@@ -455,23 +652,33 @@ public final class AspectRepository {
         String ingestedAt = (String) body.get("ingested_at");
         OffsetDateTime ingestedAtTs = parseTs(ingestedAt);
 
-        return tenantScope.withTenant(tenant, ctx ->
-            ctx.execute(
-                "INSERT INTO nexus.document_highlights "
-                + "(tenant_id, doc_id, source_uri, collection, highlights_md, mentions_md, ingested_at) "
-                + "VALUES (?, ?, ?, ?, ?, ?, ?::timestamptz) "
-                + "ON CONFLICT (tenant_id, doc_id) DO UPDATE SET "
-                + "  source_uri    = EXCLUDED.source_uri, "
-                + "  collection    = EXCLUDED.collection, "
-                + "  highlights_md = EXCLUDED.highlights_md, "
-                + "  mentions_md   = EXCLUDED.mentions_md, "
-                + "  ingested_at   = EXCLUDED.ingested_at",
-                tenant, docId,
-                body.get("source_uri"),
-                body.get("collection"),
-                body.getOrDefault("highlights_md", ""),
-                body.getOrDefault("mentions_md", ""),
-                formatTs(ingestedAtTs)));
+        return tenantScope.withTenant(tenant, ctx -> {
+            ensureCollectionRegistered(ctx, tenant, (String) body.get("collection"));
+            return ctx.insertInto(DOCUMENT_HIGHLIGHTS,
+                    DOCUMENT_HIGHLIGHTS.TENANT_ID,
+                    DOCUMENT_HIGHLIGHTS.DOC_ID,
+                    DOCUMENT_HIGHLIGHTS.SOURCE_URI,
+                    DOCUMENT_HIGHLIGHTS.COLLECTION,
+                    DOCUMENT_HIGHLIGHTS.HIGHLIGHTS_MD,
+                    DOCUMENT_HIGHLIGHTS.MENTIONS_MD,
+                    DOCUMENT_HIGHLIGHTS.INGESTED_AT)
+                .values(
+                    tenant,
+                    docId,
+                    (String) body.get("source_uri"),
+                    (String) body.get("collection"),
+                    (String) body.getOrDefault("highlights_md", ""),
+                    (String) body.getOrDefault("mentions_md", ""),
+                    ingestedAtTs)
+                .onConflict(DOCUMENT_HIGHLIGHTS.TENANT_ID, DOCUMENT_HIGHLIGHTS.DOC_ID)
+                .doUpdate()
+                .set(DOCUMENT_HIGHLIGHTS.SOURCE_URI,    EX_HL_SOURCE_URI)
+                .set(DOCUMENT_HIGHLIGHTS.COLLECTION,    EX_HL_COLLECTION)
+                .set(DOCUMENT_HIGHLIGHTS.HIGHLIGHTS_MD, EX_HL_HIGHLIGHTS)
+                .set(DOCUMENT_HIGHLIGHTS.MENTIONS_MD,   EX_HL_MENTIONS)
+                .set(DOCUMENT_HIGHLIGHTS.INGESTED_AT,   EX_HL_INGESTED_AT)
+                .execute();
+        });
     }
 
     // ── aspect_extraction_queue ────────────────────────────────────────────────
@@ -490,25 +697,39 @@ public final class AspectRepository {
         OffsetDateTime enqueuedAtTs = parseTs(enqueuedAt);
 
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute(
-                "INSERT INTO nexus.aspect_extraction_queue "
-                + "(tenant_id, collection, source_path, doc_id, content_hash, content, "
-                + " status, retry_count, enqueued_at, last_attempt_at, last_error) "
-                + "VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?::timestamptz, NULL, NULL) "
-                + "ON CONFLICT (tenant_id, collection, source_path) DO UPDATE SET "
-                + "  doc_id          = EXCLUDED.doc_id, "
-                + "  content_hash    = EXCLUDED.content_hash, "
-                + "  content         = EXCLUDED.content, "
-                + "  status          = 'pending', "
-                + "  retry_count     = 0, "
-                + "  enqueued_at     = EXCLUDED.enqueued_at, "
-                + "  last_attempt_at = NULL, "
-                + "  last_error      = NULL",
-                tenant, collection, sourcePath,
-                nullIfBlank((String) body.get("doc_id")),
-                body.getOrDefault("content_hash", ""),
-                body.getOrDefault("content", ""),
-                formatTs(enqueuedAtTs));
+            ensureCollectionRegistered(ctx, tenant, collection);
+            ctx.insertInto(ASPECT_EXTRACTION_QUEUE,
+                    ASPECT_EXTRACTION_QUEUE.TENANT_ID,
+                    ASPECT_EXTRACTION_QUEUE.COLLECTION,
+                    ASPECT_EXTRACTION_QUEUE.SOURCE_PATH,
+                    ASPECT_EXTRACTION_QUEUE.DOC_ID,
+                    ASPECT_EXTRACTION_QUEUE.CONTENT_HASH,
+                    ASPECT_EXTRACTION_QUEUE.CONTENT,
+                    ASPECT_EXTRACTION_QUEUE.STATUS,
+                    ASPECT_EXTRACTION_QUEUE.RETRY_COUNT,
+                    ASPECT_EXTRACTION_QUEUE.ENQUEUED_AT,
+                    ASPECT_EXTRACTION_QUEUE.LAST_ATTEMPT_AT,
+                    ASPECT_EXTRACTION_QUEUE.LAST_ERROR)
+                .values(
+                    tenant, collection, sourcePath,
+                    nullIfBlank((String) body.get("doc_id")),
+                    (String) body.getOrDefault("content_hash", ""),
+                    (String) body.getOrDefault("content", ""),
+                    "pending", 0, enqueuedAtTs, null, null)
+                .onConflict(
+                    ASPECT_EXTRACTION_QUEUE.TENANT_ID,
+                    ASPECT_EXTRACTION_QUEUE.COLLECTION,
+                    ASPECT_EXTRACTION_QUEUE.SOURCE_PATH)
+                .doUpdate()
+                .set(ASPECT_EXTRACTION_QUEUE.DOC_ID,          EX_Q_DOC_ID)
+                .set(ASPECT_EXTRACTION_QUEUE.CONTENT_HASH,    EX_Q_CONTENT_HASH)
+                .set(ASPECT_EXTRACTION_QUEUE.CONTENT,         EX_Q_CONTENT)
+                .set(ASPECT_EXTRACTION_QUEUE.STATUS,          "pending")
+                .set(ASPECT_EXTRACTION_QUEUE.RETRY_COUNT,     0)
+                .set(ASPECT_EXTRACTION_QUEUE.ENQUEUED_AT,     EX_Q_ENQUEUED_AT)
+                .set(ASPECT_EXTRACTION_QUEUE.LAST_ATTEMPT_AT, (OffsetDateTime) null)
+                .set(ASPECT_EXTRACTION_QUEUE.LAST_ERROR,      (String) null)
+                .execute();
             return null;
         });
     }
@@ -524,28 +745,39 @@ public final class AspectRepository {
             // PG atomic claim: SELECT FOR UPDATE SKIP LOCKED picks exactly one
             // pending row, locks it, and the subsequent UPDATE is within the same
             // transaction — zero contention between concurrent workers.
-            var rows = ctx.fetch(
-                "SELECT id, collection, source_path, content_hash, content, retry_count, doc_id "
-                + "FROM nexus.aspect_extraction_queue "
-                + "WHERE status = 'pending' "
-                + "ORDER BY enqueued_at ASC, source_path ASC "
-                + "LIMIT 1 FOR UPDATE SKIP LOCKED");
+            var rows = ctx.select(
+                    ASPECT_EXTRACTION_QUEUE.ID,
+                    ASPECT_EXTRACTION_QUEUE.COLLECTION,
+                    ASPECT_EXTRACTION_QUEUE.SOURCE_PATH,
+                    ASPECT_EXTRACTION_QUEUE.CONTENT_HASH,
+                    ASPECT_EXTRACTION_QUEUE.CONTENT,
+                    ASPECT_EXTRACTION_QUEUE.RETRY_COUNT,
+                    ASPECT_EXTRACTION_QUEUE.DOC_ID)
+                .from(ASPECT_EXTRACTION_QUEUE)
+                .where(ASPECT_EXTRACTION_QUEUE.STATUS.eq("pending"))
+                .orderBy(ASPECT_EXTRACTION_QUEUE.ENQUEUED_AT.asc(), ASPECT_EXTRACTION_QUEUE.SOURCE_PATH.asc())
+                .limit(1)
+                .forUpdate().skipLocked()
+                .fetch();
             if (rows.isEmpty()) return Optional.empty();
 
-            long id           = rows.get(0).get(0, Long.class);
-            String collection = (String) rows.get(0).get(1);
-            String sourcePath = (String) rows.get(0).get(2);
-            String contentHash= rows.get(0).get(3) == null ? "" : rows.get(0).get(3).toString();
-            String content    = rows.get(0).get(4) == null ? "" : rows.get(0).get(4).toString();
-            int retryCount    = rows.get(0).get(5, Integer.class);
-            String docId      = rows.get(0).get(6) == null ? "" : rows.get(0).get(6).toString();
+            long id           = rows.get(0).get(ASPECT_EXTRACTION_QUEUE.ID);
+            String collection = rows.get(0).get(ASPECT_EXTRACTION_QUEUE.COLLECTION);
+            String sourcePath = rows.get(0).get(ASPECT_EXTRACTION_QUEUE.SOURCE_PATH);
+            String contentHash= rows.get(0).get(ASPECT_EXTRACTION_QUEUE.CONTENT_HASH);
+            contentHash = contentHash == null ? "" : contentHash;
+            String content    = rows.get(0).get(ASPECT_EXTRACTION_QUEUE.CONTENT);
+            content = content == null ? "" : content;
+            int retryCount    = rows.get(0).get(ASPECT_EXTRACTION_QUEUE.RETRY_COUNT);
+            String docId      = rows.get(0).get(ASPECT_EXTRACTION_QUEUE.DOC_ID);
+            docId = docId == null ? "" : docId;
 
             OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-            ctx.execute(
-                "UPDATE nexus.aspect_extraction_queue "
-                + "SET status = 'in_progress', last_attempt_at = ?::timestamptz "
-                + "WHERE id = ?",
-                formatTs(now), id);
+            ctx.update(ASPECT_EXTRACTION_QUEUE)
+               .set(ASPECT_EXTRACTION_QUEUE.STATUS, "in_progress")
+               .set(ASPECT_EXTRACTION_QUEUE.LAST_ATTEMPT_AT, now)
+               .where(ASPECT_EXTRACTION_QUEUE.ID.eq(id))
+               .execute();
 
             Map<String, Object> result = new LinkedHashMap<>();
             result.put("id", id);
@@ -580,15 +812,16 @@ public final class AspectRepository {
     public int markDone(String tenant, String docId, String collection, String sourcePath) {
         return tenantScope.withTenant(tenant, ctx -> {
             if (docId != null && !docId.isBlank()) {
-                return ctx.execute(
-                    "DELETE FROM nexus.aspect_extraction_queue WHERE doc_id = ?", docId);
+                return ctx.deleteFrom(ASPECT_EXTRACTION_QUEUE)
+                    .where(ASPECT_EXTRACTION_QUEUE.DOC_ID.eq(docId))
+                    .execute();
             }
             if ((collection != null && !collection.isBlank())
                     || (sourcePath != null && !sourcePath.isBlank())) {
-                return ctx.execute(
-                    "DELETE FROM nexus.aspect_extraction_queue "
-                    + "WHERE collection = ? AND source_path = ?",
-                    collection, sourcePath);
+                return ctx.deleteFrom(ASPECT_EXTRACTION_QUEUE)
+                    .where(ASPECT_EXTRACTION_QUEUE.COLLECTION.eq(collection)
+                        .and(ASPECT_EXTRACTION_QUEUE.SOURCE_PATH.eq(sourcePath)))
+                    .execute();
             }
             return 0;
         });
@@ -599,12 +832,15 @@ public final class AspectRepository {
      */
     public void markFailed(String tenant, String collection, String sourcePath, String error) {
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute(
-                "UPDATE nexus.aspect_extraction_queue "
-                + "SET status = 'failed', retry_count = retry_count + 1, last_error = ? "
-                + "WHERE collection = ? AND source_path = ?",
-                error == null ? null : error.substring(0, Math.min(error.length(), 2000)),
-                collection, sourcePath);
+            ctx.update(ASPECT_EXTRACTION_QUEUE)
+               .set(ASPECT_EXTRACTION_QUEUE.STATUS, "failed")
+               .set(ASPECT_EXTRACTION_QUEUE.RETRY_COUNT,
+                   field("retry_count + 1", Integer.class))
+               .set(ASPECT_EXTRACTION_QUEUE.LAST_ERROR,
+                   error == null ? null : error.substring(0, Math.min(error.length(), 2000)))
+               .where(ASPECT_EXTRACTION_QUEUE.COLLECTION.eq(collection)
+                   .and(ASPECT_EXTRACTION_QUEUE.SOURCE_PATH.eq(sourcePath)))
+               .execute();
             return null;
         });
     }
@@ -614,11 +850,14 @@ public final class AspectRepository {
      */
     public void markRetry(String tenant, String collection, String sourcePath) {
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute(
-                "UPDATE nexus.aspect_extraction_queue "
-                + "SET status = 'pending', retry_count = retry_count + 1, last_attempt_at = NULL "
-                + "WHERE collection = ? AND source_path = ?",
-                collection, sourcePath);
+            ctx.update(ASPECT_EXTRACTION_QUEUE)
+               .set(ASPECT_EXTRACTION_QUEUE.STATUS, "pending")
+               .set(ASPECT_EXTRACTION_QUEUE.RETRY_COUNT,
+                   field("retry_count + 1", Integer.class))
+               .set(ASPECT_EXTRACTION_QUEUE.LAST_ATTEMPT_AT, (OffsetDateTime) null)
+               .where(ASPECT_EXTRACTION_QUEUE.COLLECTION.eq(collection)
+                   .and(ASPECT_EXTRACTION_QUEUE.SOURCE_PATH.eq(sourcePath)))
+               .execute();
             return null;
         });
     }
@@ -629,32 +868,33 @@ public final class AspectRepository {
     public int reclaimStale(String tenant, int timeoutSeconds) {
         return tenantScope.withTenant(tenant, ctx -> {
             OffsetDateTime cutoff = OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(timeoutSeconds);
-            return ctx.execute(
-                "UPDATE nexus.aspect_extraction_queue "
-                + "SET status = 'pending', last_attempt_at = NULL "
-                + "WHERE status = 'in_progress' AND last_attempt_at < ?::timestamptz",
-                formatTs(cutoff));
+            return ctx.update(ASPECT_EXTRACTION_QUEUE)
+                .set(ASPECT_EXTRACTION_QUEUE.STATUS, "pending")
+                .set(ASPECT_EXTRACTION_QUEUE.LAST_ATTEMPT_AT, (OffsetDateTime) null)
+                .where(ASPECT_EXTRACTION_QUEUE.STATUS.eq("in_progress")
+                    .and(ASPECT_EXTRACTION_QUEUE.LAST_ATTEMPT_AT.lt(cutoff)))
+                .execute();
         });
     }
 
     /** Count pending rows. */
     public int pendingCount(String tenant) {
-        return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch(
-                "SELECT COUNT(*) FROM nexus.aspect_extraction_queue WHERE status = 'pending'");
-            return rows.get(0).get(0, Integer.class);
-        });
+        return tenantScope.withTenant(tenant, ctx ->
+            ctx.selectCount()
+               .from(ASPECT_EXTRACTION_QUEUE)
+               .where(ASPECT_EXTRACTION_QUEUE.STATUS.eq("pending"))
+               .fetchOne(0, Integer.class));
     }
 
     /**
      * Is queue drained? (no non-failed rows).
      */
     public boolean isDrained(String tenant) {
-        return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch(
-                "SELECT COUNT(*) FROM nexus.aspect_extraction_queue WHERE status != 'failed'");
-            return rows.get(0).get(0, Integer.class) == 0;
-        });
+        return tenantScope.withTenant(tenant, ctx ->
+            ctx.selectCount()
+               .from(ASPECT_EXTRACTION_QUEUE)
+               .where(ASPECT_EXTRACTION_QUEUE.STATUS.ne("failed"))
+               .fetchOne(0, Integer.class) == 0);
     }
 
     /**
@@ -662,21 +902,29 @@ public final class AspectRepository {
      */
     public List<Map<String, Object>> listPending(String tenant, int limit) {
         return tenantScope.withTenant(tenant, ctx -> {
-            String limitClause = limit > 0 ? "LIMIT " + limit : "";
-            var rows = ctx.fetch(
-                "SELECT collection, source_path, content_hash, content, retry_count, doc_id "
-                + "FROM nexus.aspect_extraction_queue "
-                + "WHERE status = 'pending' "
-                + "ORDER BY enqueued_at ASC, source_path ASC " + limitClause);
+            var q = ctx.select(
+                    ASPECT_EXTRACTION_QUEUE.COLLECTION,
+                    ASPECT_EXTRACTION_QUEUE.SOURCE_PATH,
+                    ASPECT_EXTRACTION_QUEUE.CONTENT_HASH,
+                    ASPECT_EXTRACTION_QUEUE.CONTENT,
+                    ASPECT_EXTRACTION_QUEUE.RETRY_COUNT,
+                    ASPECT_EXTRACTION_QUEUE.DOC_ID)
+                .from(ASPECT_EXTRACTION_QUEUE)
+                .where(ASPECT_EXTRACTION_QUEUE.STATUS.eq("pending"))
+                .orderBy(ASPECT_EXTRACTION_QUEUE.ENQUEUED_AT.asc(), ASPECT_EXTRACTION_QUEUE.SOURCE_PATH.asc());
+            var rows = (limit > 0 ? q.limit(limit) : q).fetch();
             List<Map<String, Object>> out = new ArrayList<>();
             for (var r : rows) {
                 Map<String, Object> m = new LinkedHashMap<>();
-                m.put("collection",   r.get(0));
-                m.put("source_path",  r.get(1));
-                m.put("content_hash", r.get(2) == null ? "" : r.get(2).toString());
-                m.put("content",      r.get(3) == null ? "" : r.get(3).toString());
-                m.put("retry_count",  r.get(4, Integer.class));
-                m.put("doc_id",       r.get(5) == null ? "" : r.get(5).toString());
+                m.put("collection",   r.get(ASPECT_EXTRACTION_QUEUE.COLLECTION));
+                m.put("source_path",  r.get(ASPECT_EXTRACTION_QUEUE.SOURCE_PATH));
+                String ch = r.get(ASPECT_EXTRACTION_QUEUE.CONTENT_HASH);
+                m.put("content_hash", ch == null ? "" : ch);
+                String co = r.get(ASPECT_EXTRACTION_QUEUE.CONTENT);
+                m.put("content",      co == null ? "" : co);
+                m.put("retry_count",  r.get(ASPECT_EXTRACTION_QUEUE.RETRY_COUNT));
+                String di = r.get(ASPECT_EXTRACTION_QUEUE.DOC_ID);
+                m.put("doc_id",       di == null ? "" : di);
                 out.add(m);
             }
             return out;
@@ -688,14 +936,18 @@ public final class AspectRepository {
      */
     public int renameQueueCollection(String tenant, String oldColl, String newColl) {
         return tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute(
-                "DELETE FROM nexus.aspect_extraction_queue "
-                + "WHERE collection = ? "
-                + "  AND source_path IN (SELECT source_path FROM nexus.aspect_extraction_queue WHERE collection = ?)",
-                newColl, oldColl);
-            return ctx.execute(
-                "UPDATE nexus.aspect_extraction_queue SET collection = ? WHERE collection = ?",
-                newColl, oldColl);
+            ensureCollectionRegistered(ctx, tenant, newColl);
+            ctx.deleteFrom(ASPECT_EXTRACTION_QUEUE)
+               .where(ASPECT_EXTRACTION_QUEUE.COLLECTION.eq(newColl)
+                   .and(ASPECT_EXTRACTION_QUEUE.SOURCE_PATH.in(
+                       select(ASPECT_EXTRACTION_QUEUE.SOURCE_PATH)
+                           .from(ASPECT_EXTRACTION_QUEUE)
+                           .where(ASPECT_EXTRACTION_QUEUE.COLLECTION.eq(oldColl)))))
+               .execute();
+            return ctx.update(ASPECT_EXTRACTION_QUEUE)
+                .set(ASPECT_EXTRACTION_QUEUE.COLLECTION, newColl)
+                .where(ASPECT_EXTRACTION_QUEUE.COLLECTION.eq(oldColl))
+                .execute();
         });
     }
 
@@ -706,10 +958,13 @@ public final class AspectRepository {
      * and no collision-defense DELETE is needed — a plain UPDATE suffices.
      */
     public int renameHighlightsCollection(String tenant, String oldColl, String newColl) {
-        return tenantScope.withTenant(tenant, ctx ->
-            ctx.execute(
-                "UPDATE nexus.document_highlights SET collection = ? WHERE collection = ?",
-                newColl, oldColl));
+        return tenantScope.withTenant(tenant, ctx -> {
+            ensureCollectionRegistered(ctx, tenant, newColl);
+            return ctx.update(DOCUMENT_HIGHLIGHTS)
+                .set(DOCUMENT_HIGHLIGHTS.COLLECTION, newColl)
+                .where(DOCUMENT_HIGHLIGHTS.COLLECTION.eq(oldColl))
+                .execute();
+        });
     }
 
     /**
@@ -729,35 +984,47 @@ public final class AspectRepository {
         int retryCount = body.containsKey("retry_count")
             ? ((Number) body.get("retry_count")).intValue() : 0;
 
-        return tenantScope.withTenant(tenant, ctx ->
-            ctx.execute(
-                "INSERT INTO nexus.aspect_extraction_queue "
-                + "(tenant_id, collection, source_path, doc_id, content_hash, content, "
-                + " status, retry_count, enqueued_at, last_attempt_at, last_error) "
-                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?::timestamptz, ?::timestamptz, ?) "
-                + "ON CONFLICT (tenant_id, collection, source_path) DO UPDATE SET "
+        return tenantScope.withTenant(tenant, ctx -> {
+            ensureCollectionRegistered(ctx, tenant, collection);
+            return ctx.insertInto(ASPECT_EXTRACTION_QUEUE,
+                    ASPECT_EXTRACTION_QUEUE.TENANT_ID,
+                    ASPECT_EXTRACTION_QUEUE.COLLECTION,
+                    ASPECT_EXTRACTION_QUEUE.SOURCE_PATH,
+                    ASPECT_EXTRACTION_QUEUE.DOC_ID,
+                    ASPECT_EXTRACTION_QUEUE.CONTENT_HASH,
+                    ASPECT_EXTRACTION_QUEUE.CONTENT,
+                    ASPECT_EXTRACTION_QUEUE.STATUS,
+                    ASPECT_EXTRACTION_QUEUE.RETRY_COUNT,
+                    ASPECT_EXTRACTION_QUEUE.ENQUEUED_AT,
+                    ASPECT_EXTRACTION_QUEUE.LAST_ATTEMPT_AT,
+                    ASPECT_EXTRACTION_QUEUE.LAST_ERROR)
+                .values(
+                    tenant, collection, sourcePath,
+                    nullIfBlank((String) body.get("doc_id")),
+                    (String) body.getOrDefault("content_hash", ""),
+                    (String) body.getOrDefault("content", ""),
+                    status, retryCount,
+                    enqueuedAtTs,
+                    lastAttemptAtTs,
+                    (String) body.get("last_error"))
+                .onConflict(
+                    ASPECT_EXTRACTION_QUEUE.TENANT_ID,
+                    ASPECT_EXTRACTION_QUEUE.COLLECTION,
+                    ASPECT_EXTRACTION_QUEUE.SOURCE_PATH)
+                .doUpdate()
                 // Never downgrade in_progress to pending from a stale ETL import
-                + "  status          = CASE WHEN nexus.aspect_extraction_queue.status = 'in_progress' "
-                + "                         THEN nexus.aspect_extraction_queue.status "
-                + "                         ELSE EXCLUDED.status END, "
-                + "  retry_count     = GREATEST(EXCLUDED.retry_count, nexus.aspect_extraction_queue.retry_count), "
+                .set(ASPECT_EXTRACTION_QUEUE.STATUS,          EX_Q_STATUS_CASE)
+                .set(ASPECT_EXTRACTION_QUEUE.RETRY_COUNT,     EX_Q_RETRY_GREATEST)
                 // Preserve earliest enqueue time
-                + "  enqueued_at     = LEAST(EXCLUDED.enqueued_at, nexus.aspect_extraction_queue.enqueued_at), "
+                .set(ASPECT_EXTRACTION_QUEUE.ENQUEUED_AT,     EX_Q_ENQUEUED_LEAST)
                 // Keep latest attempt timestamp
-                + "  last_attempt_at = GREATEST(EXCLUDED.last_attempt_at, nexus.aspect_extraction_queue.last_attempt_at), "
-                + "  doc_id          = EXCLUDED.doc_id, "
-                + "  content_hash    = EXCLUDED.content_hash, "
-                + "  content         = EXCLUDED.content, "
-                + "  last_error      = CASE WHEN EXCLUDED.status = 'failed' THEN EXCLUDED.last_error "
-                + "                         ELSE nexus.aspect_extraction_queue.last_error END",
-                tenant, collection, sourcePath,
-                nullIfBlank((String) body.get("doc_id")),
-                body.getOrDefault("content_hash", ""),
-                body.getOrDefault("content", ""),
-                status, retryCount,
-                formatTs(enqueuedAtTs),
-                lastAttemptAtTs != null ? formatTs(lastAttemptAtTs) : null,
-                body.get("last_error")));
+                .set(ASPECT_EXTRACTION_QUEUE.LAST_ATTEMPT_AT, EX_Q_ATTEMPT_GREATEST)
+                .set(ASPECT_EXTRACTION_QUEUE.DOC_ID,          EX_Q_DOC_ID)
+                .set(ASPECT_EXTRACTION_QUEUE.CONTENT_HASH,    EX_Q_CONTENT_HASH)
+                .set(ASPECT_EXTRACTION_QUEUE.CONTENT,         EX_Q_CONTENT)
+                .set(ASPECT_EXTRACTION_QUEUE.LAST_ERROR,      EX_Q_LAST_ERROR_CASE)
+                .execute();
+        });
     }
 
     // ── aspect_promotion_log ───────────────────────────────────────────────────
@@ -778,11 +1045,17 @@ public final class AspectRepository {
         int pruned         = body.containsKey("pruned") && Boolean.TRUE.equals(body.get("pruned")) ? 1 : 0;
 
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute(
-                "INSERT INTO nexus.aspect_promotion_log "
-                + "(tenant_id, field_name, sql_type, column_added, rows_backfilled, rows_pruned, pruned, promoted_at) "
-                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?::timestamptz)",
-                tenant, fieldName, sqlType, columnAdded, rowsBackfilled, rowsPruned, pruned, formatTs(promotedAtTs));
+            ctx.insertInto(ASPECT_PROMOTION_LOG,
+                    ASPECT_PROMOTION_LOG.TENANT_ID,
+                    ASPECT_PROMOTION_LOG.FIELD_NAME,
+                    ASPECT_PROMOTION_LOG.SQL_TYPE,
+                    ASPECT_PROMOTION_LOG.COLUMN_ADDED,
+                    ASPECT_PROMOTION_LOG.ROWS_BACKFILLED,
+                    ASPECT_PROMOTION_LOG.ROWS_PRUNED,
+                    ASPECT_PROMOTION_LOG.PRUNED,
+                    ASPECT_PROMOTION_LOG.PROMOTED_AT)
+                .values(tenant, fieldName, sqlType, columnAdded, rowsBackfilled, rowsPruned, pruned, promotedAtTs)
+                .execute();
             return null;
         });
     }
@@ -792,20 +1065,27 @@ public final class AspectRepository {
      */
     public List<Map<String, Object>> listPromotions(String tenant) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch(
-                "SELECT field_name, sql_type, column_added, rows_backfilled, rows_pruned, pruned, promoted_at "
-                + "FROM nexus.aspect_promotion_log "
-                + "ORDER BY promoted_at ASC, id ASC");
+            var rows = ctx.select(
+                    ASPECT_PROMOTION_LOG.FIELD_NAME,
+                    ASPECT_PROMOTION_LOG.SQL_TYPE,
+                    ASPECT_PROMOTION_LOG.COLUMN_ADDED,
+                    ASPECT_PROMOTION_LOG.ROWS_BACKFILLED,
+                    ASPECT_PROMOTION_LOG.ROWS_PRUNED,
+                    ASPECT_PROMOTION_LOG.PRUNED,
+                    ASPECT_PROMOTION_LOG.PROMOTED_AT)
+                .from(ASPECT_PROMOTION_LOG)
+                .orderBy(ASPECT_PROMOTION_LOG.PROMOTED_AT.asc(), ASPECT_PROMOTION_LOG.ID.asc())
+                .fetch();
             List<Map<String, Object>> out = new ArrayList<>();
             for (var r : rows) {
                 Map<String, Object> m = new LinkedHashMap<>();
-                m.put("field_name",       r.get(0));
-                m.put("sql_type",         r.get(1));
-                m.put("column_added",     r.get(2, Integer.class) != 0);
-                m.put("rows_backfilled",  r.get(3, Integer.class));
-                m.put("rows_pruned",      r.get(4, Integer.class));
-                m.put("pruned",           r.get(5, Integer.class) != 0);
-                OffsetDateTime ts = r.get(6, OffsetDateTime.class);
+                m.put("field_name",       r.get(ASPECT_PROMOTION_LOG.FIELD_NAME));
+                m.put("sql_type",         r.get(ASPECT_PROMOTION_LOG.SQL_TYPE));
+                m.put("column_added",     r.get(ASPECT_PROMOTION_LOG.COLUMN_ADDED) != 0);
+                m.put("rows_backfilled",  r.get(ASPECT_PROMOTION_LOG.ROWS_BACKFILLED));
+                m.put("rows_pruned",      r.get(ASPECT_PROMOTION_LOG.ROWS_PRUNED));
+                m.put("pruned",           r.get(ASPECT_PROMOTION_LOG.PRUNED) != 0);
+                OffsetDateTime ts = r.get(ASPECT_PROMOTION_LOG.PROMOTED_AT);
                 m.put("promoted_at", ts == null ? null : formatTs(ts));
                 out.add(m);
             }
@@ -827,14 +1107,25 @@ public final class AspectRepository {
         int pruned         = body.containsKey("pruned") && Boolean.TRUE.equals(body.get("pruned")) ? 1 : 0;
 
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.execute(
-                "INSERT INTO nexus.aspect_promotion_log "
-                + "(tenant_id, field_name, sql_type, column_added, rows_backfilled, rows_pruned, pruned, promoted_at) "
-                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?::timestamptz) "
-                + "ON CONFLICT (tenant_id, field_name, promoted_at) DO NOTHING",
-                tenant, fieldName,
-                body.getOrDefault("sql_type", "TEXT"),
-                columnAdded, rowsBackfilled, rowsPruned, pruned, formatTs(promotedAtTs)));
+            ctx.insertInto(ASPECT_PROMOTION_LOG,
+                    ASPECT_PROMOTION_LOG.TENANT_ID,
+                    ASPECT_PROMOTION_LOG.FIELD_NAME,
+                    ASPECT_PROMOTION_LOG.SQL_TYPE,
+                    ASPECT_PROMOTION_LOG.COLUMN_ADDED,
+                    ASPECT_PROMOTION_LOG.ROWS_BACKFILLED,
+                    ASPECT_PROMOTION_LOG.ROWS_PRUNED,
+                    ASPECT_PROMOTION_LOG.PRUNED,
+                    ASPECT_PROMOTION_LOG.PROMOTED_AT)
+                .values(
+                    tenant, fieldName,
+                    (String) body.getOrDefault("sql_type", "TEXT"),
+                    columnAdded, rowsBackfilled, rowsPruned, pruned, promotedAtTs)
+                .onConflict(
+                    ASPECT_PROMOTION_LOG.TENANT_ID,
+                    ASPECT_PROMOTION_LOG.FIELD_NAME,
+                    ASPECT_PROMOTION_LOG.PROMOTED_AT)
+                .doNothing()
+                .execute());
     }
 
     // ── Operator fast-path queries (RDR-152 bead nexus-l9hd8) ──────────────────
@@ -871,21 +1162,21 @@ public final class AspectRepository {
         List<String> result = new ArrayList<>();
         for (int start = 0; start < sourceUris.size(); start += 300) {
             List<String> batch = sourceUris.subList(start, Math.min(start + 300, sourceUris.size()));
-            String placeholders = String.join(",", java.util.Collections.nCopies(batch.size(), "?"));
+            // fieldExpr is validated by fieldExpression() which only emits:
+            //   - a bare column name (from ALLOWED_ASPECT_COLUMNS, no injection risk)
+            //   - COALESCE(extras,'{}')::json#>>'{...}' (keys validated to [A-Za-z0-9_.]+)
             // ILIKE (case-insensitive) mirrors SQLite's default LIKE behaviour for ASCII.
-            String sql = "SELECT source_uri FROM nexus.document_aspects "
-                + "WHERE source_uri IN (" + placeholders + ") "
-                + "  AND " + fieldExpr + " ILIKE ?";
-            Object[] params = new Object[batch.size() + 1];
-            for (int i = 0; i < batch.size(); i++) params[i] = batch.get(i);
-            params[batch.size()] = predicate;
-
+            Field<String> fExpr = field(fieldExpr, String.class);
             List<String> matched = tenantScope.withTenant(tenant, ctx -> {
-                var rows = ctx.fetch(sql, params);
+                var rows = ctx.select(DOCUMENT_ASPECTS.SOURCE_URI)
+                    .from(DOCUMENT_ASPECTS)
+                    .where(DOCUMENT_ASPECTS.SOURCE_URI.in(batch)
+                        .and(condition("{0} ILIKE {1}", fExpr, inline(predicate))))
+                    .fetch();
                 List<String> out = new ArrayList<>();
                 for (var r : rows) {
-                    Object v = r.get(0);
-                    if (v != null) out.add(v.toString());
+                    String v = r.get(DOCUMENT_ASPECTS.SOURCE_URI);
+                    if (v != null) out.add(v);
                 }
                 return out;
             });
@@ -917,19 +1208,19 @@ public final class AspectRepository {
         Map<String, String> result = new java.util.LinkedHashMap<>();
         for (int start = 0; start < sourceUris.size(); start += 300) {
             List<String> batch = sourceUris.subList(start, Math.min(start + 300, sourceUris.size()));
-            String placeholders = String.join(",", java.util.Collections.nCopies(batch.size(), "?"));
-            String sql = "SELECT source_uri, " + fieldExpr
-                + " FROM nexus.document_aspects "
-                + "WHERE source_uri IN (" + placeholders + ")";
-            Object[] params = batch.toArray();
+            // fieldExpr validated by fieldExpression() — safe to embed in DSL.field()
+            Field<String> fExpr = field(fieldExpr, String.class);
 
             tenantScope.withTenant(tenant, ctx -> {
-                var rows = ctx.fetch(sql, params);
+                var rows = ctx.select(DOCUMENT_ASPECTS.SOURCE_URI, fExpr)
+                    .from(DOCUMENT_ASPECTS)
+                    .where(DOCUMENT_ASPECTS.SOURCE_URI.in(batch))
+                    .fetch();
                 for (var r : rows) {
-                    Object uri = r.get(0);
-                    Object val = r.get(1);
+                    String uri = r.get(DOCUMENT_ASPECTS.SOURCE_URI);
+                    Object val = r.get(fExpr);
                     if (uri != null && val != null) {
-                        result.put(uri.toString(), val.toString());
+                        result.put(uri, val.toString());
                     }
                 }
                 return null;
@@ -975,38 +1266,47 @@ public final class AspectRepository {
 
         for (int start = 0; start < sourceUris.size(); start += 300) {
             List<String> batch = sourceUris.subList(start, Math.min(start + 300, sourceUris.size()));
-            String placeholders = String.join(",", java.util.Collections.nCopies(batch.size(), "?"));
-            // For AVG we still need SUM+COUNT to fold across batches correctly.
-            // For MIN/MAX a single pass suffices; use the aggregate directly.
-            final String sql;
-            if ("AVG".equals(aggFunc)) {
-                sql = "SELECT SUM(confidence), COUNT(confidence) "
-                    + "FROM nexus.document_aspects "
-                    + "WHERE source_uri IN (" + placeholders + ") "
-                    + "  AND confidence IS NOT NULL";
-            } else {
-                sql = "SELECT " + aggFunc + "(confidence) "
-                    + "FROM nexus.document_aspects "
-                    + "WHERE source_uri IN (" + placeholders + ") "
-                    + "  AND confidence IS NOT NULL";
-            }
-            final Object[] params = batch.toArray();
 
             final double[] localSum = {0.0};
             final long[]   localCnt = {0L};
             final Double[] localVal = {null};
 
             tenantScope.withTenant(tenant, ctx -> {
-                var rows = ctx.fetch(sql, params);
-                if (rows.isEmpty()) return null;
                 if ("AVG".equals(aggFunc)) {
-                    Object sumVal = rows.get(0).get(0);
-                    Object cntVal = rows.get(0).get(1);
-                    if (sumVal != null) localSum[0] = ((Number) sumVal).doubleValue();
-                    if (cntVal != null) localCnt[0] = ((Number) cntVal).longValue();
+                    // For AVG we need SUM+COUNT to fold across batches correctly.
+                    var rows = ctx.select(
+                            sum(DOCUMENT_ASPECTS.CONFIDENCE),
+                            count(DOCUMENT_ASPECTS.CONFIDENCE))
+                        .from(DOCUMENT_ASPECTS)
+                        .where(DOCUMENT_ASPECTS.SOURCE_URI.in(batch)
+                            .and(DOCUMENT_ASPECTS.CONFIDENCE.isNotNull()))
+                        .fetch();
+                    if (!rows.isEmpty()) {
+                        Object sumVal = rows.get(0).get(0);
+                        Object cntVal = rows.get(0).get(1);
+                        if (sumVal != null) localSum[0] = ((Number) sumVal).doubleValue();
+                        if (cntVal != null) localCnt[0] = ((Number) cntVal).longValue();
+                    }
+                } else if ("MIN".equals(aggFunc)) {
+                    var rows = ctx.select(min(DOCUMENT_ASPECTS.CONFIDENCE))
+                        .from(DOCUMENT_ASPECTS)
+                        .where(DOCUMENT_ASPECTS.SOURCE_URI.in(batch)
+                            .and(DOCUMENT_ASPECTS.CONFIDENCE.isNotNull()))
+                        .fetch();
+                    if (!rows.isEmpty()) {
+                        Object val = rows.get(0).get(0);
+                        if (val != null) localVal[0] = ((Number) val).doubleValue();
+                    }
                 } else {
-                    Object val = rows.get(0).get(0);
-                    if (val != null) localVal[0] = ((Number) val).doubleValue();
+                    var rows = ctx.select(max(DOCUMENT_ASPECTS.CONFIDENCE))
+                        .from(DOCUMENT_ASPECTS)
+                        .where(DOCUMENT_ASPECTS.SOURCE_URI.in(batch)
+                            .and(DOCUMENT_ASPECTS.CONFIDENCE.isNotNull()))
+                        .fetch();
+                    if (!rows.isEmpty()) {
+                        Object val = rows.get(0).get(0);
+                        if (val != null) localVal[0] = ((Number) val).doubleValue();
+                    }
                 }
                 return null;
             });

--- a/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static dev.nexus.service.jooq.nexus.Tables.*;
+import static org.jooq.impl.DSL.*;
+
 /**
  * RDR-152 bead nexus-gmiaf.14 — jOOQ-based taxonomy repository.
  *
@@ -40,13 +43,6 @@ import java.util.Optional;
  *       full-recompute — see that method's javadoc (RDR-152 nexus-1di3r.4).</li>
  *   <li>taxonomy_meta counters: GREATEST(EXCLUDED, existing)</li>
  * </ul>
- *
- * <p>NOTE: Uses raw SQL queries via DSLContext.fetch/execute to avoid a
- * chicken-and-egg compile dependency on jOOQ-generated table classes that
- * are themselves generated from this schema. After {@code mvn -Pcodegen},
- * the generated Tables.* classes are available; future refactors may switch
- * to typed references for IDE navigation. Raw SQL is equivalent and safe
- * under RLS (the GUC stamp is applied by TenantScope before each query).
  */
 public final class TaxonomyRepository {
 
@@ -96,24 +92,34 @@ public final class TaxonomyRepository {
      */
     private static void ensureCollectionRegistered(DSLContext ctx, String tenant, String collection) {
         if (collection == null || collection.isBlank()) return;
-        ctx.execute(
-            "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES (?, ?) " +
-            "ON CONFLICT (tenant_id, name) DO NOTHING",
-            tenant, collection);
+        ctx.insertInto(CATALOG_COLLECTIONS, CATALOG_COLLECTIONS.TENANT_ID, CATALOG_COLLECTIONS.NAME)
+           .values(tenant, collection)
+           .onConflict(CATALOG_COLLECTIONS.TENANT_ID, CATALOG_COLLECTIONS.NAME)
+           .doNothing()
+           .execute();
     }
+
+    // ⚠ DRIFT RISK (RDR-164 review S4): several ON CONFLICT DO UPDATE sites below
+    // (mergeTopics, assignTopic, recordDiscoverCount, importAssignment, importTaxonomyMeta,
+    // computeIcfRows) use inline field("...GREATEST/COALESCE/CASE/EXCLUDED...", Type.class)
+    // fragments that embed literal column names jOOQ codegen cannot type-check (no typed API
+    // for the EXCLUDED pseudo-table or cross-row GREATEST). Referenced columns:
+    // topic_assignments.{similarity,assigned_at,assigned_by,source_collection},
+    // taxonomy_meta.{last_discover_doc_count,last_discover_at}. If any is renamed in a
+    // Liquibase changelog, these strings compile but fail at runtime — update them at each site.
 
     private static Map<String, Object> buildTopicMap(org.jooq.Record r) {
         var m = new LinkedHashMap<String, Object>();
-        m.put("id",            r.get("id",             Long.class));
-        m.put("label",         r.get("label",          String.class));
-        m.put("parent_id",     r.get("parent_id",      Long.class));
-        m.put("collection",    r.get("collection",     String.class));
-        m.put("centroid_hash", r.get("centroid_hash",  String.class));
-        m.put("doc_count",     r.get("doc_count",      Integer.class));
-        Object ca = r.get("created_at");
+        m.put("id",            r.get(TOPICS.ID));
+        m.put("label",         r.get(TOPICS.LABEL));
+        m.put("parent_id",     r.get(TOPICS.PARENT_ID));
+        m.put("collection",    r.get(TOPICS.COLLECTION));
+        m.put("centroid_hash", r.get(TOPICS.CENTROID_HASH));
+        m.put("doc_count",     r.get(TOPICS.DOC_COUNT));
+        Object ca = r.get(TOPICS.CREATED_AT);
         m.put("created_at",    ca instanceof OffsetDateTime odt ? odt.format(UTC_SECOND) : (String) ca);
-        m.put("review_status", r.get("review_status",  String.class));
-        m.put("terms",         r.get("terms",          String.class));
+        m.put("review_status", r.get(TOPICS.REVIEW_STATUS));
+        m.put("terms",         r.get(TOPICS.TERMS));
         return Collections.unmodifiableMap(m);
     }
 
@@ -122,106 +128,129 @@ public final class TaxonomyRepository {
     /** Return root topics (parent_id IS NULL), ordered by doc_count DESC. */
     public List<Map<String, Object>> getRootTopics(String tenant) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("""
-                SELECT id, label, parent_id, collection, centroid_hash,
-                       doc_count, created_at, review_status, terms
-                FROM nexus.topics WHERE parent_id IS NULL ORDER BY doc_count DESC
-                """).map(TaxonomyRepository::buildTopicMap));
+            ctx.select(
+                    TOPICS.ID, TOPICS.LABEL, TOPICS.PARENT_ID, TOPICS.COLLECTION,
+                    TOPICS.CENTROID_HASH, TOPICS.DOC_COUNT, TOPICS.CREATED_AT,
+                    TOPICS.REVIEW_STATUS, TOPICS.TERMS)
+               .from(TOPICS)
+               .where(TOPICS.PARENT_ID.isNull())
+               .orderBy(TOPICS.DOC_COUNT.desc())
+               .fetch()
+               .map(TaxonomyRepository::buildTopicMap));
     }
 
     /** Return children of a topic, ordered by doc_count DESC. */
     public List<Map<String, Object>> getChildTopics(String tenant, long parentId) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("""
-                SELECT id, label, parent_id, collection, centroid_hash,
-                       doc_count, created_at, review_status, terms
-                FROM nexus.topics WHERE parent_id = ? ORDER BY doc_count DESC
-                """, parentId).map(TaxonomyRepository::buildTopicMap));
+            ctx.select(
+                    TOPICS.ID, TOPICS.LABEL, TOPICS.PARENT_ID, TOPICS.COLLECTION,
+                    TOPICS.CENTROID_HASH, TOPICS.DOC_COUNT, TOPICS.CREATED_AT,
+                    TOPICS.REVIEW_STATUS, TOPICS.TERMS)
+               .from(TOPICS)
+               .where(TOPICS.PARENT_ID.eq(parentId))
+               .orderBy(TOPICS.DOC_COUNT.desc())
+               .fetch()
+               .map(TaxonomyRepository::buildTopicMap));
     }
 
     /** Return all topics, optionally filtered by collection, ordered by doc_count DESC. */
     public List<Map<String, Object>> getAllTopics(String tenant, String collection) {
         return tenantScope.withTenant(tenant, ctx -> {
+            var q = ctx.select(
+                    TOPICS.ID, TOPICS.LABEL, TOPICS.PARENT_ID, TOPICS.COLLECTION,
+                    TOPICS.CENTROID_HASH, TOPICS.DOC_COUNT, TOPICS.CREATED_AT,
+                    TOPICS.REVIEW_STATUS, TOPICS.TERMS)
+               .from(TOPICS);
             if (collection != null && !collection.isBlank())
-                return ctx.fetch("""
-                    SELECT id, label, parent_id, collection, centroid_hash,
-                           doc_count, created_at, review_status, terms
-                    FROM nexus.topics WHERE collection = ? ORDER BY doc_count DESC
-                    """, collection).map(TaxonomyRepository::buildTopicMap);
-            return ctx.fetch("""
-                SELECT id, label, parent_id, collection, centroid_hash,
-                       doc_count, created_at, review_status, terms
-                FROM nexus.topics ORDER BY doc_count DESC
-                """).map(TaxonomyRepository::buildTopicMap);
+                return q.where(TOPICS.COLLECTION.eq(collection))
+                        .orderBy(TOPICS.DOC_COUNT.desc())
+                        .fetch()
+                        .map(TaxonomyRepository::buildTopicMap);
+            return q.orderBy(TOPICS.DOC_COUNT.desc())
+                    .fetch()
+                    .map(TaxonomyRepository::buildTopicMap);
         });
     }
 
     /** Return topics with review_status='pending', ordered by doc_count DESC. */
     public List<Map<String, Object>> getUnreviewedTopics(String tenant, String collection, int limit) {
         return tenantScope.withTenant(tenant, ctx -> {
-            if (collection != null && !collection.isBlank())
-                return ctx.fetch("""
-                    SELECT id, label, parent_id, collection, centroid_hash,
-                           doc_count, created_at, review_status, terms
-                    FROM nexus.topics WHERE review_status = 'pending' AND collection = ?
-                    ORDER BY doc_count DESC LIMIT ?
-                    """, collection, limit).map(TaxonomyRepository::buildTopicMap);
-            return ctx.fetch("""
-                SELECT id, label, parent_id, collection, centroid_hash,
-                       doc_count, created_at, review_status, terms
-                FROM nexus.topics WHERE review_status = 'pending'
-                ORDER BY doc_count DESC LIMIT ?
-                """, limit).map(TaxonomyRepository::buildTopicMap);
+            var q = ctx.select(
+                    TOPICS.ID, TOPICS.LABEL, TOPICS.PARENT_ID, TOPICS.COLLECTION,
+                    TOPICS.CENTROID_HASH, TOPICS.DOC_COUNT, TOPICS.CREATED_AT,
+                    TOPICS.REVIEW_STATUS, TOPICS.TERMS)
+               .from(TOPICS)
+               .where(collection != null && !collection.isBlank()
+                   ? TOPICS.REVIEW_STATUS.eq("pending").and(TOPICS.COLLECTION.eq(collection))
+                   : TOPICS.REVIEW_STATUS.eq("pending"))
+               .orderBy(TOPICS.DOC_COUNT.desc())
+               .limit(limit);
+            return q.fetch().map(TaxonomyRepository::buildTopicMap);
         });
     }
 
     /** Return a single topic by id, or empty. */
     public Optional<Map<String, Object>> getTopicById(String tenant, long id) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("""
-                SELECT id, label, parent_id, collection, centroid_hash,
-                       doc_count, created_at, review_status, terms
-                FROM nexus.topics WHERE id = ?
-                """, id).map(TaxonomyRepository::buildTopicMap).stream().findFirst());
+            ctx.select(
+                    TOPICS.ID, TOPICS.LABEL, TOPICS.PARENT_ID, TOPICS.COLLECTION,
+                    TOPICS.CENTROID_HASH, TOPICS.DOC_COUNT, TOPICS.CREATED_AT,
+                    TOPICS.REVIEW_STATUS, TOPICS.TERMS)
+               .from(TOPICS)
+               .where(TOPICS.ID.eq(id))
+               .fetch()
+               .map(TaxonomyRepository::buildTopicMap)
+               .stream().findFirst());
     }
 
     /** Resolve topic label to id (exact match). Optionally scoped by collection. */
     public Optional<Long> resolveLabel(String tenant, String label, String collection) {
         return tenantScope.withTenant(tenant, ctx -> {
-            org.jooq.Result<?> r = (collection != null && !collection.isBlank())
-                ? ctx.fetch("SELECT id FROM nexus.topics WHERE label = ? AND collection = ? LIMIT 1",
-                            label, collection)
-                : ctx.fetch("SELECT id FROM nexus.topics WHERE label = ? LIMIT 1", label);
-            return r.stream().findFirst().map(row -> row.get("id", Long.class));
+            var q = ctx.select(TOPICS.ID)
+                .from(TOPICS)
+                .where(collection != null && !collection.isBlank()
+                    ? TOPICS.LABEL.eq(label).and(TOPICS.COLLECTION.eq(collection))
+                    : TOPICS.LABEL.eq(label))
+                .limit(1);
+            return q.fetch().stream().findFirst().map(r -> r.get(TOPICS.ID));
         });
     }
 
     /** Return distinct collection names that have at least one topic. */
     public List<String> getDistinctCollections(String tenant) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("SELECT DISTINCT collection FROM nexus.topics ORDER BY collection")
-               .map(r -> r.get("collection", String.class)));
+            ctx.selectDistinct(TOPICS.COLLECTION)
+               .from(TOPICS)
+               .orderBy(TOPICS.COLLECTION)
+               .fetch()
+               .map(r -> r.get(TOPICS.COLLECTION)));
     }
 
     /** Insert a new topic row. Returns the generated id. */
     public long insertTopic(String tenant, String label, Long parentId,
                              String collection, int docCount, String createdAt,
                              String terms) {
-        String tsStr = fmtTs(parseTs(createdAt));
-        return tenantScope.withTenant(tenant, ctx ->
-            ctx.fetchOne("""
-                INSERT INTO nexus.topics
-                    (tenant_id, label, parent_id, collection, doc_count, created_at, review_status, terms)
-                VALUES (?, ?, ?, ?, ?, ?::timestamptz, 'pending', ?)
-                RETURNING id
-                """, tenant, label, parentId, collection, docCount, tsStr, terms)
-               .get("id", Long.class));
+        OffsetDateTime createdAtTs = parseTs(createdAt);
+        return tenantScope.withTenant(tenant, ctx -> {
+            ensureCollectionRegistered(ctx, tenant, collection);
+            return ctx.insertInto(TOPICS,
+                    TOPICS.TENANT_ID, TOPICS.LABEL, TOPICS.PARENT_ID,
+                    TOPICS.COLLECTION, TOPICS.DOC_COUNT, TOPICS.CREATED_AT,
+                    TOPICS.REVIEW_STATUS, TOPICS.TERMS)
+                .values(tenant, label, parentId, collection, docCount, createdAtTs, "pending", terms)
+                .returningResult(TOPICS.ID)
+                .fetchOne()
+                .get(TOPICS.ID);
+        });
     }
 
     /** Update topic label without changing review_status. */
     public void updateTopicLabel(String tenant, long topicId, String newLabel) {
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute("UPDATE nexus.topics SET label = ? WHERE id = ?", newLabel, topicId);
+            ctx.update(TOPICS)
+               .set(TOPICS.LABEL, newLabel)
+               .where(TOPICS.ID.eq(topicId))
+               .execute();
             return null;
         });
     }
@@ -229,8 +258,11 @@ public final class TaxonomyRepository {
     /** Rename topic and mark as accepted. */
     public void renameTopic(String tenant, long topicId, String newLabel) {
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute("UPDATE nexus.topics SET label = ?, review_status = 'accepted' WHERE id = ?",
-                        newLabel, topicId);
+            ctx.update(TOPICS)
+               .set(TOPICS.LABEL, newLabel)
+               .set(TOPICS.REVIEW_STATUS, "accepted")
+               .where(TOPICS.ID.eq(topicId))
+               .execute();
             return null;
         });
     }
@@ -238,7 +270,10 @@ public final class TaxonomyRepository {
     /** Update review_status. */
     public void markTopicReviewed(String tenant, long topicId, String status) {
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute("UPDATE nexus.topics SET review_status = ? WHERE id = ?", status, topicId);
+            ctx.update(TOPICS)
+               .set(TOPICS.REVIEW_STATUS, status)
+               .where(TOPICS.ID.eq(topicId))
+               .execute();
             return null;
         });
     }
@@ -255,8 +290,10 @@ public final class TaxonomyRepository {
      */
     public int countAssignments(String tenant, long topicId) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.fetchOne("SELECT COUNT(*) AS c FROM nexus.topic_assignments WHERE topic_id = ?", topicId)
-               .get("c", Integer.class));
+            ctx.selectCount()
+               .from(TOPIC_ASSIGNMENTS)
+               .where(TOPIC_ASSIGNMENTS.TOPIC_ID.eq(topicId))
+               .fetchOne(0, Integer.class));
     }
 
     /**
@@ -265,11 +302,14 @@ public final class TaxonomyRepository {
      */
     public Optional<String> deleteTopic(String tenant, long topicId) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var row = ctx.fetchOne("SELECT collection FROM nexus.topics WHERE id = ?", topicId);
-            if (row == null) return Optional.<String>empty();
-            String collection = row.get("collection", String.class);
+            var rows = ctx.select(TOPICS.COLLECTION)
+                .from(TOPICS)
+                .where(TOPICS.ID.eq(topicId))
+                .fetch();
+            if (rows.isEmpty()) return Optional.<String>empty();
+            String collection = rows.get(0).get(TOPICS.COLLECTION);
             // Assignments cascade via FK ON DELETE CASCADE
-            ctx.execute("DELETE FROM nexus.topics WHERE id = ?", topicId);
+            ctx.deleteFrom(TOPICS).where(TOPICS.ID.eq(topicId)).execute();
             return Optional.of(collection);
         });
     }
@@ -281,39 +321,65 @@ public final class TaxonomyRepository {
     public Optional<String> mergeTopics(String tenant, long sourceId, long targetId) {
         if (sourceId == targetId) return Optional.empty();
         return tenantScope.withTenant(tenant, ctx -> {
-            var row = ctx.fetchOne("SELECT collection FROM nexus.topics WHERE id = ?", sourceId);
-            if (row == null) return Optional.<String>empty();
-            String collection = row.get("collection", String.class);
+            var rows = ctx.select(TOPICS.COLLECTION)
+                .from(TOPICS)
+                .where(TOPICS.ID.eq(sourceId))
+                .fetch();
+            if (rows.isEmpty()) return Optional.<String>empty();
+            String collection = rows.get(0).get(TOPICS.COLLECTION);
 
-            // Move assignments: prefer higher similarity on conflict
-            ctx.execute("""
-                INSERT INTO nexus.topic_assignments
-                    (tenant_id, doc_id, topic_id, assigned_by, similarity, assigned_at, source_collection)
-                SELECT tenant_id, doc_id, ?, assigned_by, similarity, assigned_at, source_collection
-                FROM nexus.topic_assignments WHERE topic_id = ?
-                ON CONFLICT (tenant_id, doc_id, topic_id) DO UPDATE SET
-                    similarity = GREATEST(
-                        COALESCE(nexus.topic_assignments.similarity, -1.0),
-                        COALESCE(EXCLUDED.similarity, -1.0)),
-                    assigned_at = CASE
-                        WHEN COALESCE(EXCLUDED.similarity, -1.0) >
-                             COALESCE(nexus.topic_assignments.similarity, -1.0)
-                        THEN EXCLUDED.assigned_at
-                        ELSE nexus.topic_assignments.assigned_at END,
-                    source_collection = CASE
-                        WHEN COALESCE(EXCLUDED.similarity, -1.0) >
-                             COALESCE(nexus.topic_assignments.similarity, -1.0)
-                        THEN EXCLUDED.source_collection
-                        ELSE nexus.topic_assignments.source_collection END
-                """, targetId, sourceId);
+            // Move assignments: prefer higher similarity on conflict.
+            // GREATEST(COALESCE(...), COALESCE(...)) + CASE WHEN expressions referencing
+            // both EXCLUDED.* and the existing table row are Postgres-specific constructs
+            // with no clean typed DSL equivalent; retained as DSL.field() fragments per spec.
+            ctx.insertInto(TOPIC_ASSIGNMENTS,
+                    TOPIC_ASSIGNMENTS.TENANT_ID,
+                    TOPIC_ASSIGNMENTS.DOC_ID,
+                    TOPIC_ASSIGNMENTS.TOPIC_ID,
+                    TOPIC_ASSIGNMENTS.ASSIGNED_BY,
+                    TOPIC_ASSIGNMENTS.SIMILARITY,
+                    TOPIC_ASSIGNMENTS.ASSIGNED_AT,
+                    TOPIC_ASSIGNMENTS.SOURCE_COLLECTION)
+               .select(
+                    select(
+                        TOPIC_ASSIGNMENTS.TENANT_ID,
+                        TOPIC_ASSIGNMENTS.DOC_ID,
+                        inline(targetId),
+                        TOPIC_ASSIGNMENTS.ASSIGNED_BY,
+                        TOPIC_ASSIGNMENTS.SIMILARITY,
+                        TOPIC_ASSIGNMENTS.ASSIGNED_AT,
+                        TOPIC_ASSIGNMENTS.SOURCE_COLLECTION)
+                    .from(TOPIC_ASSIGNMENTS)
+                    .where(TOPIC_ASSIGNMENTS.TOPIC_ID.eq(sourceId)))
+               .onConflict(
+                    TOPIC_ASSIGNMENTS.TENANT_ID,
+                    TOPIC_ASSIGNMENTS.DOC_ID,
+                    TOPIC_ASSIGNMENTS.TOPIC_ID)
+               .doUpdate()
+               .set(TOPIC_ASSIGNMENTS.SIMILARITY,
+                    field("GREATEST(COALESCE(nexus.topic_assignments.similarity, -1.0),"
+                        + " COALESCE(EXCLUDED.similarity, -1.0))", Double.class))
+               .set(TOPIC_ASSIGNMENTS.ASSIGNED_AT,
+                    field("CASE WHEN COALESCE(EXCLUDED.similarity, -1.0)"
+                        + " > COALESCE(nexus.topic_assignments.similarity, -1.0)"
+                        + " THEN EXCLUDED.assigned_at"
+                        + " ELSE nexus.topic_assignments.assigned_at END", OffsetDateTime.class))
+               .set(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION,
+                    field("CASE WHEN COALESCE(EXCLUDED.similarity, -1.0)"
+                        + " > COALESCE(nexus.topic_assignments.similarity, -1.0)"
+                        + " THEN EXCLUDED.source_collection"
+                        + " ELSE nexus.topic_assignments.source_collection END", String.class))
+               .execute();
 
-            ctx.execute("DELETE FROM nexus.topic_assignments WHERE topic_id = ?", sourceId);
+            ctx.deleteFrom(TOPIC_ASSIGNMENTS)
+               .where(TOPIC_ASSIGNMENTS.TOPIC_ID.eq(sourceId))
+               .execute();
 
             // RDR-154 P0 (nexus-i7ivk): no manual doc_count resync. The assignment
             // move (INSERT) and source purge (DELETE) above each fire the
             // statement-level triggers, which recompute target.doc_count from the
             // live assignment rows; the trigger is the sole writer.
-            ctx.execute("DELETE FROM nexus.topics WHERE id = ?", sourceId);
+            ctx.deleteFrom(TOPICS).where(TOPICS.ID.eq(sourceId)).execute();
 
             return Optional.of(collection);
         });
@@ -333,35 +399,54 @@ public final class TaxonomyRepository {
             if ("projection".equals(assignedBy)) {
                 // RDR-156 P0.2: ensure collection is registered before the assignment write
                 ensureCollectionRegistered(ctx, tenant, sourceCollection);
-                String tsStr = fmtTs(assignedAt != null ? parseTs(assignedAt)
-                                                        : OffsetDateTime.now(ZoneOffset.UTC));
-                ctx.execute("""
-                    INSERT INTO nexus.topic_assignments
-                        (tenant_id, doc_id, topic_id, assigned_by, similarity, assigned_at, source_collection)
-                    VALUES (?, ?, ?, 'projection', ?, ?::timestamptz, ?)
-                    ON CONFLICT (tenant_id, doc_id, topic_id) DO UPDATE SET
-                        similarity = GREATEST(
-                            COALESCE(nexus.topic_assignments.similarity, -1.0),
-                            EXCLUDED.similarity),
-                        assigned_at = CASE
-                            WHEN EXCLUDED.similarity >
-                                 COALESCE(nexus.topic_assignments.similarity, -1.0)
-                            THEN EXCLUDED.assigned_at
-                            ELSE nexus.topic_assignments.assigned_at END,
-                        source_collection = CASE
-                            WHEN EXCLUDED.similarity >
-                                 COALESCE(nexus.topic_assignments.similarity, -1.0)
-                            THEN EXCLUDED.source_collection
-                            ELSE nexus.topic_assignments.source_collection END,
-                        assigned_by = 'projection'
-                    """, tenant, docId, topicId, similarity, tsStr, sourceCollection);
+                OffsetDateTime assignedAtTs = assignedAt != null
+                    ? parseTs(assignedAt)
+                    : OffsetDateTime.now(ZoneOffset.UTC);
+                // GREATEST(COALESCE(...), ...) + CASE WHEN EXCLUDED.similarity > ... patterns
+                // referencing both EXCLUDED.* and the existing table row are Postgres-specific
+                // constructs retained as DSL.field() fragments per spec.
+                ctx.insertInto(TOPIC_ASSIGNMENTS,
+                        TOPIC_ASSIGNMENTS.TENANT_ID,
+                        TOPIC_ASSIGNMENTS.DOC_ID,
+                        TOPIC_ASSIGNMENTS.TOPIC_ID,
+                        TOPIC_ASSIGNMENTS.ASSIGNED_BY,
+                        TOPIC_ASSIGNMENTS.SIMILARITY,
+                        TOPIC_ASSIGNMENTS.ASSIGNED_AT,
+                        TOPIC_ASSIGNMENTS.SOURCE_COLLECTION)
+                   .values(tenant, docId, topicId, "projection", similarity, assignedAtTs, sourceCollection)
+                   .onConflict(
+                        TOPIC_ASSIGNMENTS.TENANT_ID,
+                        TOPIC_ASSIGNMENTS.DOC_ID,
+                        TOPIC_ASSIGNMENTS.TOPIC_ID)
+                   .doUpdate()
+                   .set(TOPIC_ASSIGNMENTS.SIMILARITY,
+                        field("GREATEST(COALESCE(nexus.topic_assignments.similarity, -1.0),"
+                            + " EXCLUDED.similarity)", Double.class))
+                   .set(TOPIC_ASSIGNMENTS.ASSIGNED_AT,
+                        field("CASE WHEN EXCLUDED.similarity"
+                            + " > COALESCE(nexus.topic_assignments.similarity, -1.0)"
+                            + " THEN EXCLUDED.assigned_at"
+                            + " ELSE nexus.topic_assignments.assigned_at END", OffsetDateTime.class))
+                   .set(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION,
+                        field("CASE WHEN EXCLUDED.similarity"
+                            + " > COALESCE(nexus.topic_assignments.similarity, -1.0)"
+                            + " THEN EXCLUDED.source_collection"
+                            + " ELSE nexus.topic_assignments.source_collection END", String.class))
+                   .set(TOPIC_ASSIGNMENTS.ASSIGNED_BY, "projection")
+                   .execute();
             } else {
-                ctx.execute("""
-                    INSERT INTO nexus.topic_assignments
-                        (tenant_id, doc_id, topic_id, assigned_by)
-                    VALUES (?, ?, ?, ?)
-                    ON CONFLICT (tenant_id, doc_id, topic_id) DO NOTHING
-                    """, tenant, docId, topicId, assignedBy);
+                ctx.insertInto(TOPIC_ASSIGNMENTS,
+                        TOPIC_ASSIGNMENTS.TENANT_ID,
+                        TOPIC_ASSIGNMENTS.DOC_ID,
+                        TOPIC_ASSIGNMENTS.TOPIC_ID,
+                        TOPIC_ASSIGNMENTS.ASSIGNED_BY)
+                   .values(tenant, docId, topicId, assignedBy)
+                   .onConflict(
+                       TOPIC_ASSIGNMENTS.TENANT_ID,
+                       TOPIC_ASSIGNMENTS.DOC_ID,
+                       TOPIC_ASSIGNMENTS.TOPIC_ID)
+                   .doNothing()
+                   .execute();
             }
             // RDR-154 P0 (nexus-i7ivk): no manual doc_count resync. A fresh
             // assignment INSERT fires the AFTER INSERT statement-level trigger,
@@ -375,37 +460,36 @@ public final class TaxonomyRepository {
     /** Return doc_ids assigned to a topic. limit=0 means no limit. */
     public List<String> getTopicDocIds(String tenant, long topicId, int limit) {
         return tenantScope.withTenant(tenant, ctx -> {
-            if (limit > 0)
-                return ctx.fetch("SELECT doc_id FROM nexus.topic_assignments WHERE topic_id = ? LIMIT ?",
-                                 topicId, limit)
-                          .map(r -> r.get("doc_id", String.class));
-            return ctx.fetch("SELECT doc_id FROM nexus.topic_assignments WHERE topic_id = ?", topicId)
-                      .map(r -> r.get("doc_id", String.class));
+            var q = ctx.select(TOPIC_ASSIGNMENTS.DOC_ID)
+                .from(TOPIC_ASSIGNMENTS)
+                .where(TOPIC_ASSIGNMENTS.TOPIC_ID.eq(topicId));
+            var rows = (limit > 0 ? q.limit(limit) : q).fetch();
+            return rows.map(r -> r.get(TOPIC_ASSIGNMENTS.DOC_ID));
         });
     }
 
     /** Return {doc_id, topic_id} pairs for given doc_ids. */
     public List<Map<String, Object>> getAssignmentsForDocs(String tenant, List<String> docIds) {
         if (docIds == null || docIds.isEmpty()) return List.of();
-        return tenantScope.withTenant(tenant, ctx -> {
-            String placeholders = "?,".repeat(docIds.size()).replaceAll(",$", "");
-            List<Object> params = new ArrayList<>(docIds);
-            return ctx.fetch(
-                "SELECT doc_id, topic_id FROM nexus.topic_assignments WHERE doc_id IN ("
-                + placeholders + ")", params.toArray())
-               .map(r -> Map.of("doc_id", r.get("doc_id", String.class),
-                                "topic_id", r.get("topic_id", Long.class)));
-        });
+        return tenantScope.withTenant(tenant, ctx ->
+            ctx.select(TOPIC_ASSIGNMENTS.DOC_ID, TOPIC_ASSIGNMENTS.TOPIC_ID)
+               .from(TOPIC_ASSIGNMENTS)
+               .where(TOPIC_ASSIGNMENTS.DOC_ID.in(docIds))
+               .fetch()
+               .map(r -> Map.of(
+                   "doc_id",   r.get(TOPIC_ASSIGNMENTS.DOC_ID),
+                   "topic_id", r.get(TOPIC_ASSIGNMENTS.TOPIC_ID))));
     }
 
     /** Return doc_ids labeled with a given topic label. */
     public List<String> getDocIdsForLabel(String tenant, String label) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("""
-                SELECT ta.doc_id FROM nexus.topic_assignments ta
-                JOIN nexus.topics t ON t.id = ta.topic_id WHERE t.label = ?
-                """, label)
-               .map(r -> r.get("doc_id", String.class)));
+            ctx.select(TOPIC_ASSIGNMENTS.DOC_ID)
+               .from(TOPIC_ASSIGNMENTS)
+               .join(TOPICS).on(TOPICS.ID.eq(TOPIC_ASSIGNMENTS.TOPIC_ID))
+               .where(TOPICS.LABEL.eq(label))
+               .fetch()
+               .map(r -> r.get(TOPIC_ASSIGNMENTS.DOC_ID)));
     }
 
     /**
@@ -414,16 +498,16 @@ public final class TaxonomyRepository {
      */
     public int purgeAssignmentsForDoc(String tenant, String project, String title) {
         return tenantScope.withTenant(tenant, ctx -> {
-            int removed = ctx.execute("""
-                DELETE FROM nexus.topic_assignments
-                WHERE doc_id = ?
-                  AND topic_id IN (SELECT id FROM nexus.topics WHERE collection = ?)
-                """, title, project);
-            ctx.execute("""
-                DELETE FROM nexus.topics
-                WHERE collection = ?
-                  AND id NOT IN (SELECT DISTINCT topic_id FROM nexus.topic_assignments)
-                """, project);
+            int removed = ctx.deleteFrom(TOPIC_ASSIGNMENTS)
+                .where(TOPIC_ASSIGNMENTS.DOC_ID.eq(title)
+                    .and(TOPIC_ASSIGNMENTS.TOPIC_ID.in(
+                        select(TOPICS.ID).from(TOPICS).where(TOPICS.COLLECTION.eq(project)))))
+                .execute();
+            ctx.deleteFrom(TOPICS)
+               .where(TOPICS.COLLECTION.eq(project)
+                   .and(TOPICS.ID.notIn(
+                       selectDistinct(TOPIC_ASSIGNMENTS.TOPIC_ID).from(TOPIC_ASSIGNMENTS))))
+               .execute();
             return removed;
         });
     }
@@ -431,23 +515,30 @@ public final class TaxonomyRepository {
     /** Purge all taxonomy rows for a collection. */
     public Map<String, Integer> purgeCollection(String tenant, String collection) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var doomedIds = ctx.fetch("SELECT id FROM nexus.topics WHERE collection = ?", collection)
-                               .map(r -> r.get("id", Long.class));
+            var doomedIds = ctx.select(TOPICS.ID)
+                .from(TOPICS)
+                .where(TOPICS.COLLECTION.eq(collection))
+                .fetch()
+                .map(r -> r.get(TOPICS.ID));
             int links = 0, assignments = 0;
             if (!doomedIds.isEmpty()) {
-                String ph = "?,".repeat(doomedIds.size()).replaceAll(",$", "");
-                List<Object> ids = new ArrayList<>(doomedIds);
-                List<Object> doubleIds = new ArrayList<>(ids);
-                doubleIds.addAll(ids);
-                links = ctx.execute("DELETE FROM nexus.topic_links WHERE from_topic_id IN ("
-                    + ph + ") OR to_topic_id IN (" + ph + ")", doubleIds.toArray());
-                assignments = ctx.execute("DELETE FROM nexus.topic_assignments WHERE topic_id IN ("
-                    + ph + ")", ids.toArray());
+                links = ctx.deleteFrom(TOPIC_LINKS)
+                    .where(TOPIC_LINKS.FROM_TOPIC_ID.in(doomedIds)
+                        .or(TOPIC_LINKS.TO_TOPIC_ID.in(doomedIds)))
+                    .execute();
+                assignments = ctx.deleteFrom(TOPIC_ASSIGNMENTS)
+                    .where(TOPIC_ASSIGNMENTS.TOPIC_ID.in(doomedIds))
+                    .execute();
             }
-            assignments += ctx.execute("DELETE FROM nexus.topic_assignments WHERE source_collection = ?",
-                                       collection);
-            int topics = ctx.execute("DELETE FROM nexus.topics WHERE collection = ?", collection);
-            int meta   = ctx.execute("DELETE FROM nexus.taxonomy_meta WHERE collection = ?", collection);
+            assignments += ctx.deleteFrom(TOPIC_ASSIGNMENTS)
+                .where(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.eq(collection))
+                .execute();
+            int topics = ctx.deleteFrom(TOPICS)
+                .where(TOPICS.COLLECTION.eq(collection))
+                .execute();
+            int meta = ctx.deleteFrom(TAXONOMY_META)
+                .where(TAXONOMY_META.COLLECTION.eq(collection))
+                .execute();
             return Map.of("topics", topics, "assignments", assignments, "links", links, "meta", meta);
         });
     }
@@ -455,13 +546,23 @@ public final class TaxonomyRepository {
     /** Rename all taxonomy rows from old to new collection. */
     public Map<String, Integer> renameCollection(String tenant, String oldCol, String newCol) {
         return tenantScope.withTenant(tenant, ctx -> {
-            int topics = ctx.execute("UPDATE nexus.topics SET collection = ? WHERE collection = ?",
-                                     newCol, oldCol);
-            int assignments = ctx.execute(
-                "UPDATE nexus.topic_assignments SET source_collection = ? WHERE source_collection = ?",
-                newCol, oldCol);
-            int meta = ctx.execute("UPDATE nexus.taxonomy_meta SET collection = ? WHERE collection = ?",
-                                   newCol, oldCol);
+            // RDR-164 P1a: the new collection name must be registered before the denorm
+            // columns are re-pointed at it (topics/taxonomy_meta carry NOT VALID RESTRICT
+            // FKs to catalog_collections; topic_assignments' FK is ON UPDATE CASCADE but
+            // the child UPDATE to newCol still requires the value to exist in the registry).
+            ensureCollectionRegistered(ctx, tenant, newCol);
+            int topics = ctx.update(TOPICS)
+                .set(TOPICS.COLLECTION, newCol)
+                .where(TOPICS.COLLECTION.eq(oldCol))
+                .execute();
+            int assignments = ctx.update(TOPIC_ASSIGNMENTS)
+                .set(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION, newCol)
+                .where(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.eq(oldCol))
+                .execute();
+            int meta = ctx.update(TAXONOMY_META)
+                .set(TAXONOMY_META.COLLECTION, newCol)
+                .where(TAXONOMY_META.COLLECTION.eq(oldCol))
+                .execute();
             return Map.of("topics", topics, "assignments", assignments, "meta", meta);
         });
     }
@@ -470,19 +571,26 @@ public final class TaxonomyRepository {
 
     /** Record discover count. Matches record_discover_count. */
     public void recordDiscoverCount(String tenant, String collection, int docCount, String discoveredAt) {
-        String tsStr = fmtTs(parseTs(discoveredAt));
+        OffsetDateTime discoveredAtTs = parseTs(discoveredAt);
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute("""
-                INSERT INTO nexus.taxonomy_meta (tenant_id, collection, last_discover_doc_count, last_discover_at)
-                VALUES (?, ?, ?, ?::timestamptz)
-                ON CONFLICT (tenant_id, collection) DO UPDATE SET
-                    last_discover_doc_count = GREATEST(
-                        nexus.taxonomy_meta.last_discover_doc_count,
-                        EXCLUDED.last_discover_doc_count),
-                    last_discover_at = GREATEST(
-                        nexus.taxonomy_meta.last_discover_at,
-                        EXCLUDED.last_discover_at)
-                """, tenant, collection, docCount, tsStr);
+            ensureCollectionRegistered(ctx, tenant, collection);
+            // GREATEST(existing_col, EXCLUDED.col) — references both the table row and
+            // EXCLUDED in the same expression; retained as DSL.field() fragments per spec.
+            ctx.insertInto(TAXONOMY_META,
+                    TAXONOMY_META.TENANT_ID,
+                    TAXONOMY_META.COLLECTION,
+                    TAXONOMY_META.LAST_DISCOVER_DOC_COUNT,
+                    TAXONOMY_META.LAST_DISCOVER_AT)
+               .values(tenant, collection, docCount, discoveredAtTs)
+               .onConflict(TAXONOMY_META.TENANT_ID, TAXONOMY_META.COLLECTION)
+               .doUpdate()
+               .set(TAXONOMY_META.LAST_DISCOVER_DOC_COUNT,
+                    field("GREATEST(nexus.taxonomy_meta.last_discover_doc_count,"
+                        + " EXCLUDED.last_discover_doc_count)", Integer.class))
+               .set(TAXONOMY_META.LAST_DISCOVER_AT,
+                    field("GREATEST(nexus.taxonomy_meta.last_discover_at,"
+                        + " EXCLUDED.last_discover_at)", OffsetDateTime.class))
+               .execute();
             return null;
         });
     }
@@ -490,11 +598,12 @@ public final class TaxonomyRepository {
     /** Get the last discover doc_count for rebalance check. */
     public Optional<Integer> getLastDiscoverDocCount(String tenant, String collection) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var row = ctx.fetchOne(
-                "SELECT last_discover_doc_count FROM nexus.taxonomy_meta WHERE collection = ?",
-                collection);
-            return row == null ? Optional.empty()
-                               : Optional.of(row.get("last_discover_doc_count", Integer.class));
+            var rows = ctx.select(TAXONOMY_META.LAST_DISCOVER_DOC_COUNT)
+                .from(TAXONOMY_META)
+                .where(TAXONOMY_META.COLLECTION.eq(collection))
+                .fetch();
+            return rows.isEmpty() ? Optional.empty()
+                : Optional.of(rows.get(0).get(TAXONOMY_META.LAST_DISCOVER_DOC_COUNT));
         });
     }
 
@@ -503,19 +612,16 @@ public final class TaxonomyRepository {
     /** Get topic link pairs for a set of topic ids. */
     public List<Map<String, Object>> getTopicLinkPairs(String tenant, List<Long> topicIds) {
         if (topicIds == null || topicIds.isEmpty()) return List.of();
-        return tenantScope.withTenant(tenant, ctx -> {
-            String ph = "?,".repeat(topicIds.size()).replaceAll(",$", "");
-            List<Object> doubleIds = new ArrayList<>(topicIds);
-            doubleIds.addAll(topicIds);
-            return ctx.fetch(
-                "SELECT from_topic_id, to_topic_id, link_count FROM nexus.topic_links "
-                + "WHERE from_topic_id IN (" + ph + ") AND to_topic_id IN (" + ph + ")",
-                doubleIds.toArray())
+        return tenantScope.withTenant(tenant, ctx ->
+            ctx.select(TOPIC_LINKS.FROM_TOPIC_ID, TOPIC_LINKS.TO_TOPIC_ID, TOPIC_LINKS.LINK_COUNT)
+               .from(TOPIC_LINKS)
+               .where(TOPIC_LINKS.FROM_TOPIC_ID.in(topicIds)
+                   .and(TOPIC_LINKS.TO_TOPIC_ID.in(topicIds)))
+               .fetch()
                .map(r -> Map.of(
-                   "from_topic_id", r.get("from_topic_id", Long.class),
-                   "to_topic_id",   r.get("to_topic_id",   Long.class),
-                   "link_count",    r.get("link_count",     Integer.class)));
-        });
+                   "from_topic_id", r.get(TOPIC_LINKS.FROM_TOPIC_ID),
+                   "to_topic_id",   r.get(TOPIC_LINKS.TO_TOPIC_ID),
+                   "link_count",    r.get(TOPIC_LINKS.LINK_COUNT))));
     }
 
     /**
@@ -535,13 +641,15 @@ public final class TaxonomyRepository {
      */
     public void upsertTopicLink(String tenant, long fromId, long toId, int linkCount, String linkTypes) {
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute("""
-                INSERT INTO nexus.topic_links (tenant_id, from_topic_id, to_topic_id, link_count, link_types)
-                VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT (tenant_id, from_topic_id, to_topic_id) DO UPDATE SET
-                    link_count = EXCLUDED.link_count,
-                    link_types = EXCLUDED.link_types
-                """, tenant, fromId, toId, linkCount, linkTypes);
+            ctx.insertInto(TOPIC_LINKS,
+                    TOPIC_LINKS.TENANT_ID, TOPIC_LINKS.FROM_TOPIC_ID,
+                    TOPIC_LINKS.TO_TOPIC_ID, TOPIC_LINKS.LINK_COUNT, TOPIC_LINKS.LINK_TYPES)
+               .values(tenant, fromId, toId, linkCount, linkTypes)
+               .onConflict(TOPIC_LINKS.TENANT_ID, TOPIC_LINKS.FROM_TOPIC_ID, TOPIC_LINKS.TO_TOPIC_ID)
+               .doUpdate()
+               .set(TOPIC_LINKS.LINK_COUNT, field("EXCLUDED.link_count", Integer.class))
+               .set(TOPIC_LINKS.LINK_TYPES, field("EXCLUDED.link_types", String.class))
+               .execute();
             return null;
         });
     }
@@ -551,30 +659,37 @@ public final class TaxonomyRepository {
     /** Count distinct source_collections for projection rows (N_effective for ICF). */
     public int countDistinctSourceCollections(String tenant) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.fetchOne("""
-                SELECT COUNT(DISTINCT source_collection) AS n
-                FROM nexus.topic_assignments
-                WHERE assigned_by = 'projection' AND source_collection IS NOT NULL
-                """).get("n", Integer.class));
+            ctx.select(countDistinct(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION))
+               .from(TOPIC_ASSIGNMENTS)
+               .where(TOPIC_ASSIGNMENTS.ASSIGNED_BY.eq("projection")
+                   .and(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.isNotNull()))
+               .fetchOne(0, Integer.class));
     }
 
     /**
      * Return ICF rows {topic_id, icf_raw} for N_effective>=2.
      * icf_raw = N_effective / DF — caller applies log2.
+     *
+     * <p>CAST(? AS DOUBLE PRECISION) / COUNT(DISTINCT ...) — the numeric division of a
+     * bind value cast to double by an aggregate is expressible via jOOQ arithmetic;
+     * retained as a DSL.field() cast fragment for the CAST expression per spec.
      */
     public List<Map<String, Object>> computeIcfRows(String tenant, int nEffective) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("""
-                SELECT topic_id,
-                       CAST(? AS DOUBLE PRECISION) / COUNT(DISTINCT source_collection) AS icf_raw
-                FROM nexus.topic_assignments
-                WHERE assigned_by = 'projection' AND source_collection IS NOT NULL
-                GROUP BY topic_id
-                HAVING COUNT(DISTINCT source_collection) > 0
-                """, nEffective)
+            ctx.select(
+                    TOPIC_ASSIGNMENTS.TOPIC_ID,
+                    field("CAST({0} AS DOUBLE PRECISION)", Double.class, val(nEffective))
+                        .div(countDistinct(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION))
+                        .as("icf_raw"))
+               .from(TOPIC_ASSIGNMENTS)
+               .where(TOPIC_ASSIGNMENTS.ASSIGNED_BY.eq("projection")
+                   .and(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.isNotNull()))
+               .groupBy(TOPIC_ASSIGNMENTS.TOPIC_ID)
+               .having(countDistinct(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION).gt(0))
+               .fetch()
                .map(r -> Map.of(
-                   "topic_id", r.get("topic_id", Long.class),
-                   "icf_raw",  r.get("icf_raw",  Double.class))));
+                   "topic_id", r.get(TOPIC_ASSIGNMENTS.TOPIC_ID),
+                   "icf_raw",  r.get("icf_raw", Double.class))));
     }
 
     // ── Top topics / corpus evidence ───────────────────────────────────────────
@@ -582,35 +697,37 @@ public final class TaxonomyRepository {
     /** Return top-N projection topics for a collection. */
     public List<Map<String, Object>> topTopicsForCollection(String tenant, String collection, int topN) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("""
-                SELECT t.label, COUNT(*) AS chunks, SUM(ta.similarity) AS sum_sim
-                FROM nexus.topic_assignments ta
-                JOIN nexus.topics t ON t.id = ta.topic_id
-                WHERE ta.assigned_by = 'projection'
-                  AND ta.source_collection = ?
-                  AND ta.similarity IS NOT NULL
-                GROUP BY ta.topic_id, t.label
-                ORDER BY sum_sim DESC, chunks DESC
-                LIMIT ?
-                """, collection, topN)
+            ctx.select(
+                    TOPICS.LABEL,
+                    count().as("chunks"),
+                    sum(TOPIC_ASSIGNMENTS.SIMILARITY).as("sum_sim"))
+               .from(TOPIC_ASSIGNMENTS)
+               .join(TOPICS).on(TOPICS.ID.eq(TOPIC_ASSIGNMENTS.TOPIC_ID))
+               .where(TOPIC_ASSIGNMENTS.ASSIGNED_BY.eq("projection")
+                   .and(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.eq(collection))
+                   .and(TOPIC_ASSIGNMENTS.SIMILARITY.isNotNull()))
+               .groupBy(TOPIC_ASSIGNMENTS.TOPIC_ID, TOPICS.LABEL)
+               .orderBy(sum(TOPIC_ASSIGNMENTS.SIMILARITY).desc(), count().desc())
+               .limit(topN)
+               .fetch()
                .map(r -> Map.of(
-                   "label",          r.get("label",   String.class),
-                   "chunks",         r.get("chunks",  Integer.class),
+                   "label",          r.get(TOPICS.LABEL),
+                   "chunks",         r.get("chunks", Integer.class),
                    "sum_similarity", r.get("sum_sim", Double.class))));
     }
 
     /** Return max similarity for a doc's projection into a source_collection. */
     public Optional<Double> chunkGroundedIn(String tenant, String docId, String sourceCollection) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var row = ctx.fetchOne("""
-                SELECT MAX(similarity) AS ms
-                FROM nexus.topic_assignments
-                WHERE assigned_by = 'projection'
-                  AND doc_id = ? AND source_collection = ?
-                  AND similarity IS NOT NULL
-                """, docId, sourceCollection);
-            if (row == null) return Optional.<Double>empty();
-            Double v = row.get("ms", Double.class);
+            var rows = ctx.select(max(TOPIC_ASSIGNMENTS.SIMILARITY).as("ms"))
+                .from(TOPIC_ASSIGNMENTS)
+                .where(TOPIC_ASSIGNMENTS.ASSIGNED_BY.eq("projection")
+                    .and(TOPIC_ASSIGNMENTS.DOC_ID.eq(docId))
+                    .and(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.eq(sourceCollection))
+                    .and(TOPIC_ASSIGNMENTS.SIMILARITY.isNotNull()))
+                .fetch();
+            if (rows.isEmpty()) return Optional.<Double>empty();
+            Double v = rows.get(0).get("ms", Double.class);
             return v == null ? Optional.<Double>empty() : Optional.of(v);
         });
     }
@@ -618,15 +735,15 @@ public final class TaxonomyRepository {
     /** Return projection count by source_collection. */
     public List<Map<String, Object>> getProjectionCountsByCollection(String tenant) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("""
-                SELECT source_collection, COUNT(*) AS cnt
-                FROM nexus.topic_assignments
-                WHERE assigned_by = 'projection'
-                  AND source_collection IS NOT NULL AND source_collection != ''
-                GROUP BY source_collection
-                """)
+            ctx.select(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION, count().as("cnt"))
+               .from(TOPIC_ASSIGNMENTS)
+               .where(TOPIC_ASSIGNMENTS.ASSIGNED_BY.eq("projection")
+                   .and(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.isNotNull())
+                   .and(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.ne("")))
+               .groupBy(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION)
+               .fetch()
                .map(r -> Map.of(
-                   "source_collection", r.get("source_collection", String.class),
+                   "source_collection", r.get(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION),
                    "count",             r.get("cnt", Integer.class))));
     }
 
@@ -643,23 +760,25 @@ public final class TaxonomyRepository {
                              String reviewStatus, String terms) {
         // BIGSERIAL allows explicit ID insertion without OVERRIDING SYSTEM VALUE
         // (that clause only applies to GENERATED ALWAYS identity columns).
-        String tsStr = fmtTs(parseTsStrict(createdAt));
+        OffsetDateTime createdAtTs = parseTsStrict(createdAt);
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute("""
-                INSERT INTO nexus.topics
-                    (id, tenant_id, label, parent_id, collection, centroid_hash,
-                     doc_count, created_at, review_status, terms)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?::timestamptz, ?, ?)
-                ON CONFLICT (id) DO UPDATE SET
-                    -- RDR-154 P0 (nexus-i7ivk): doc_count is trigger-maintained and
-                    -- is NOT an ETL merge participant. The INSERT branch seeds it for
-                    -- a brand-new topic; on conflict the live (trigger-computed) value
-                    -- is left untouched so a lossy snapshot can never clobber it.
-                    review_status = EXCLUDED.review_status,
-                    centroid_hash = EXCLUDED.centroid_hash,
-                    terms         = EXCLUDED.terms
-                """, srcId, tenant, label, parentId, collection, centroidHash,
-                     docCount, tsStr, reviewStatus, terms);
+            ensureCollectionRegistered(ctx, tenant, collection);
+            ctx.insertInto(TOPICS,
+                    TOPICS.ID, TOPICS.TENANT_ID, TOPICS.LABEL, TOPICS.PARENT_ID,
+                    TOPICS.COLLECTION, TOPICS.CENTROID_HASH, TOPICS.DOC_COUNT,
+                    TOPICS.CREATED_AT, TOPICS.REVIEW_STATUS, TOPICS.TERMS)
+               .values(srcId, tenant, label, parentId, collection, centroidHash,
+                       docCount, createdAtTs, reviewStatus, terms)
+               .onConflict(TOPICS.ID)
+               .doUpdate()
+               // RDR-154 P0 (nexus-i7ivk): doc_count is trigger-maintained and
+               // is NOT an ETL merge participant. The INSERT branch seeds it for
+               // a brand-new topic; on conflict the live (trigger-computed) value
+               // is left untouched so a lossy snapshot can never clobber it.
+               .set(TOPICS.REVIEW_STATUS, field("EXCLUDED.review_status", String.class))
+               .set(TOPICS.CENTROID_HASH, field("EXCLUDED.centroid_hash", String.class))
+               .set(TOPICS.TERMS,         field("EXCLUDED.terms",         String.class))
+               .execute();
             return null;
         });
         return srcId;
@@ -681,29 +800,42 @@ public final class TaxonomyRepository {
     public boolean importAssignment(String tenant, String docId, long topicId,
                                      String assignedBy, Double similarity,
                                      String assignedAt, String sourceCollection) {
-        String tsStr = (assignedAt != null && !assignedAt.isBlank())
-            ? fmtTs(parseTsStrict(assignedAt)) : null;
+        OffsetDateTime assignedAtTs = (assignedAt != null && !assignedAt.isBlank())
+            ? parseTsStrict(assignedAt) : null;
         tenantScope.withTenant(tenant, ctx -> {
             // RDR-156 P0.2: ensure collection is registered before the assignment write
             ensureCollectionRegistered(ctx, tenant, sourceCollection);
-            ctx.execute("""
-                INSERT INTO nexus.topic_assignments
-                    (tenant_id, doc_id, topic_id, assigned_by, similarity, assigned_at, source_collection)
-                VALUES (?, ?, ?, ?, ?, ?::timestamptz, ?)
-                ON CONFLICT (tenant_id, doc_id, topic_id) DO UPDATE SET
-                    -- Never downgrade 'projection' to 'hdbscan' or similar:
-                    -- keep existing assigned_by unless the incoming row is 'projection'
-                    -- (the highest-provenance tag).
-                    assigned_by       = CASE
-                                            WHEN EXCLUDED.assigned_by = 'projection' THEN 'projection'
-                                            ELSE nexus.topic_assignments.assigned_by
-                                        END,
-                    similarity        = GREATEST(
-                        COALESCE(nexus.topic_assignments.similarity, -1.0),
-                        COALESCE(EXCLUDED.similarity, -1.0)),
-                    assigned_at       = EXCLUDED.assigned_at,
-                    source_collection = EXCLUDED.source_collection
-                """, tenant, docId, topicId, assignedBy, similarity, tsStr, sourceCollection);
+            // GREATEST(COALESCE(existing, -1.0), COALESCE(EXCLUDED, -1.0)) +
+            // CASE WHEN EXCLUDED.assigned_by = 'projection' referencing the existing table row:
+            // Postgres-specific; retained as DSL.field() fragments per spec.
+            ctx.insertInto(TOPIC_ASSIGNMENTS,
+                    TOPIC_ASSIGNMENTS.TENANT_ID,
+                    TOPIC_ASSIGNMENTS.DOC_ID,
+                    TOPIC_ASSIGNMENTS.TOPIC_ID,
+                    TOPIC_ASSIGNMENTS.ASSIGNED_BY,
+                    TOPIC_ASSIGNMENTS.SIMILARITY,
+                    TOPIC_ASSIGNMENTS.ASSIGNED_AT,
+                    TOPIC_ASSIGNMENTS.SOURCE_COLLECTION)
+               .values(tenant, docId, topicId, assignedBy, similarity, assignedAtTs, sourceCollection)
+               .onConflict(
+                    TOPIC_ASSIGNMENTS.TENANT_ID,
+                    TOPIC_ASSIGNMENTS.DOC_ID,
+                    TOPIC_ASSIGNMENTS.TOPIC_ID)
+               .doUpdate()
+               // Never downgrade 'projection' to 'hdbscan' or similar:
+               // keep existing assigned_by unless the incoming row is 'projection'.
+               .set(TOPIC_ASSIGNMENTS.ASSIGNED_BY,
+                    field("CASE WHEN EXCLUDED.assigned_by = 'projection'"
+                        + " THEN 'projection'"
+                        + " ELSE nexus.topic_assignments.assigned_by END", String.class))
+               .set(TOPIC_ASSIGNMENTS.SIMILARITY,
+                    field("GREATEST(COALESCE(nexus.topic_assignments.similarity, -1.0),"
+                        + " COALESCE(EXCLUDED.similarity, -1.0))", Double.class))
+               .set(TOPIC_ASSIGNMENTS.ASSIGNED_AT,
+                    field("EXCLUDED.assigned_at", OffsetDateTime.class))
+               .set(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION,
+                    field("EXCLUDED.source_collection", String.class))
+               .execute();
             return null;
         });
         return true;
@@ -713,13 +845,19 @@ public final class TaxonomyRepository {
     public void importTopicLink(String tenant, long fromId, long toId,
                                  int linkCount, String linkTypes) {
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute("""
-                INSERT INTO nexus.topic_links (tenant_id, from_topic_id, to_topic_id, link_count, link_types)
-                VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT (tenant_id, from_topic_id, to_topic_id) DO UPDATE SET
-                    link_count = GREATEST(nexus.topic_links.link_count, EXCLUDED.link_count),
-                    link_types = EXCLUDED.link_types
-                """, tenant, fromId, toId, linkCount, linkTypes);
+            // GREATEST(existing.link_count, EXCLUDED.link_count) — ETL path uses GREATEST
+            // to never downgrade a live PG value from a stale SQLite snapshot.
+            // GREATEST over two table references is an irreducible plain-SQL fragment.
+            ctx.insertInto(TOPIC_LINKS,
+                    TOPIC_LINKS.TENANT_ID, TOPIC_LINKS.FROM_TOPIC_ID,
+                    TOPIC_LINKS.TO_TOPIC_ID, TOPIC_LINKS.LINK_COUNT, TOPIC_LINKS.LINK_TYPES)
+               .values(tenant, fromId, toId, linkCount, linkTypes)
+               .onConflict(TOPIC_LINKS.TENANT_ID, TOPIC_LINKS.FROM_TOPIC_ID, TOPIC_LINKS.TO_TOPIC_ID)
+               .doUpdate()
+               .set(TOPIC_LINKS.LINK_COUNT,
+                    field("GREATEST(nexus.topic_links.link_count, EXCLUDED.link_count)", Integer.class))
+               .set(TOPIC_LINKS.LINK_TYPES, field("EXCLUDED.link_types", String.class))
+               .execute();
             return null;
         });
     }
@@ -727,20 +865,27 @@ public final class TaxonomyRepository {
     /** Fidelity-preserving import for a taxonomy_meta row. */
     public void importTaxonomyMeta(String tenant, String collection,
                                     int lastDiscoverDocCount, String lastDiscoverAt) {
-        String tsStr = (lastDiscoverAt != null && !lastDiscoverAt.isBlank())
-            ? fmtTs(parseTsStrict(lastDiscoverAt)) : null;
+        OffsetDateTime lastDiscoverAtTs = (lastDiscoverAt != null && !lastDiscoverAt.isBlank())
+            ? parseTsStrict(lastDiscoverAt) : null;
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute("""
-                INSERT INTO nexus.taxonomy_meta (tenant_id, collection, last_discover_doc_count, last_discover_at)
-                VALUES (?, ?, ?, ?::timestamptz)
-                ON CONFLICT (tenant_id, collection) DO UPDATE SET
-                    last_discover_doc_count =
-                        GREATEST(nexus.taxonomy_meta.last_discover_doc_count,
-                                 EXCLUDED.last_discover_doc_count),
-                    last_discover_at =
-                        GREATEST(nexus.taxonomy_meta.last_discover_at,
-                                 EXCLUDED.last_discover_at)
-                """, tenant, collection, lastDiscoverDocCount, tsStr);
+            ensureCollectionRegistered(ctx, tenant, collection);
+            // GREATEST(existing_col, EXCLUDED.col) — references both the table row and
+            // EXCLUDED in the same expression; retained as DSL.field() fragments per spec.
+            ctx.insertInto(TAXONOMY_META,
+                    TAXONOMY_META.TENANT_ID,
+                    TAXONOMY_META.COLLECTION,
+                    TAXONOMY_META.LAST_DISCOVER_DOC_COUNT,
+                    TAXONOMY_META.LAST_DISCOVER_AT)
+               .values(tenant, collection, lastDiscoverDocCount, lastDiscoverAtTs)
+               .onConflict(TAXONOMY_META.TENANT_ID, TAXONOMY_META.COLLECTION)
+               .doUpdate()
+               .set(TAXONOMY_META.LAST_DISCOVER_DOC_COUNT,
+                    field("GREATEST(nexus.taxonomy_meta.last_discover_doc_count,"
+                        + " EXCLUDED.last_discover_doc_count)", Integer.class))
+               .set(TAXONOMY_META.LAST_DISCOVER_AT,
+                    field("GREATEST(nexus.taxonomy_meta.last_discover_at,"
+                        + " EXCLUDED.last_discover_at)", OffsetDateTime.class))
+               .execute();
             return null;
         });
     }
@@ -753,25 +898,27 @@ public final class TaxonomyRepository {
      */
     public Map<String, Object> computeIcfMapAtomic(String tenant) {
         return tenantScope.withTenant(tenant, ctx -> {
-            // n_effective = count of distinct source_collection values
-            var nRow = ctx.fetchOne(
-                "SELECT COUNT(DISTINCT source_collection) AS n "
-                + "FROM nexus.topic_assignments "
-                + "WHERE assigned_by = 'projection' AND source_collection IS NOT NULL");
-            int nEffective = nRow == null ? 0 : ((Number) nRow.get("n")).intValue();
+            int nEffective = ctx.select(countDistinct(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION))
+                .from(TOPIC_ASSIGNMENTS)
+                .where(TOPIC_ASSIGNMENTS.ASSIGNED_BY.eq("projection")
+                    .and(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.isNotNull()))
+                .fetchOne(0, Integer.class);
 
             List<Map<String, Object>> rows = new ArrayList<>();
             if (nEffective >= 2) {
-                var icfRows = ctx.fetch(
-                    "SELECT topic_id, COUNT(DISTINCT source_collection) AS df "
-                    + "FROM nexus.topic_assignments "
-                    + "WHERE assigned_by = 'projection' AND source_collection IS NOT NULL "
-                    + "GROUP BY topic_id "
-                    + "HAVING COUNT(DISTINCT source_collection) > 0");
+                var icfRows = ctx.select(
+                        TOPIC_ASSIGNMENTS.TOPIC_ID,
+                        countDistinct(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION).as("df"))
+                    .from(TOPIC_ASSIGNMENTS)
+                    .where(TOPIC_ASSIGNMENTS.ASSIGNED_BY.eq("projection")
+                        .and(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.isNotNull()))
+                    .groupBy(TOPIC_ASSIGNMENTS.TOPIC_ID)
+                    .having(countDistinct(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION).gt(0))
+                    .fetch();
                 for (var r : icfRows) {
                     var m = new LinkedHashMap<String, Object>();
-                    m.put("topic_id", ((Number) r.get("topic_id")).longValue());
-                    m.put("df", ((Number) r.get("df")).intValue());
+                    m.put("topic_id", r.get(TOPIC_ASSIGNMENTS.TOPIC_ID));
+                    m.put("df", r.get("df", Integer.class));
                     rows.add(m);
                 }
             }
@@ -790,47 +937,47 @@ public final class TaxonomyRepository {
      */
     public List<Map<String, Object>> detectHubsData(String tenant, int minCollections) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch("""
-                SELECT
-                    t.id           AS topic_id,
-                    t.label,
-                    t.collection,
-                    COUNT(DISTINCT ta.source_collection) AS df,
-                    COUNT(*)                              AS total_chunks,
-                    MAX(ta.assigned_at)                   AS last_assigned_at
-                FROM nexus.topic_assignments ta
-                JOIN nexus.topics t ON t.id = ta.topic_id
-                WHERE ta.assigned_by = 'projection'
-                  AND ta.source_collection IS NOT NULL
-                GROUP BY t.id, t.label, t.collection
-                HAVING COUNT(DISTINCT ta.source_collection) >= ?
-                ORDER BY COUNT(*) DESC
-                """, minCollections);
+            var rows = ctx.select(
+                    TOPICS.ID.as("topic_id"),
+                    TOPICS.LABEL,
+                    TOPICS.COLLECTION,
+                    countDistinct(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION).as("df"),
+                    count().as("total_chunks"),
+                    max(TOPIC_ASSIGNMENTS.ASSIGNED_AT).as("last_assigned_at"))
+               .from(TOPIC_ASSIGNMENTS)
+               .join(TOPICS).on(TOPICS.ID.eq(TOPIC_ASSIGNMENTS.TOPIC_ID))
+               .where(TOPIC_ASSIGNMENTS.ASSIGNED_BY.eq("projection")
+                   .and(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.isNotNull()))
+               .groupBy(TOPICS.ID, TOPICS.LABEL, TOPICS.COLLECTION)
+               .having(countDistinct(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION).ge(minCollections))
+               .orderBy(count().desc())
+               .fetch();
 
             // Per-hub source collection sets
-            var allSources = ctx.fetch(
-                "SELECT topic_id, source_collection "
-                + "FROM nexus.topic_assignments "
-                + "WHERE assigned_by = 'projection' AND source_collection IS NOT NULL "
-                + "ORDER BY topic_id, source_collection");
+            var allSources = ctx.select(TOPIC_ASSIGNMENTS.TOPIC_ID, TOPIC_ASSIGNMENTS.SOURCE_COLLECTION)
+                .from(TOPIC_ASSIGNMENTS)
+                .where(TOPIC_ASSIGNMENTS.ASSIGNED_BY.eq("projection")
+                    .and(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.isNotNull()))
+                .orderBy(TOPIC_ASSIGNMENTS.TOPIC_ID, TOPIC_ASSIGNMENTS.SOURCE_COLLECTION)
+                .fetch();
 
             // Build topic_id -> [source_collection, ...] map
             java.util.Map<Long, List<String>> sourcesMap = new java.util.HashMap<>();
             for (var r : allSources) {
-                long tid = ((Number) r.get("topic_id")).longValue();
-                String sc = (String) r.get("source_collection");
+                long tid = r.get(TOPIC_ASSIGNMENTS.TOPIC_ID);
+                String sc = r.get(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION);
                 sourcesMap.computeIfAbsent(tid, k -> new ArrayList<>()).add(sc);
             }
 
             List<Map<String, Object>> result = new ArrayList<>();
             for (var r : rows) {
-                long tid = ((Number) r.get("topic_id")).longValue();
+                long tid = r.get("topic_id", Long.class);
                 var m = new LinkedHashMap<String, Object>();
                 m.put("topic_id", tid);
-                m.put("label", r.get("label"));
-                m.put("collection", r.get("collection"));
-                m.put("df", ((Number) r.get("df")).intValue());
-                m.put("total_chunks", ((Number) r.get("total_chunks")).intValue());
+                m.put("label", r.get(TOPICS.LABEL));
+                m.put("collection", r.get(TOPICS.COLLECTION));
+                m.put("df", r.get("df", Integer.class));
+                m.put("total_chunks", r.get("total_chunks", Integer.class));
                 Object lastAt = r.get("last_assigned_at");
                 m.put("last_assigned_at", lastAt != null ? lastAt.toString() : null);
                 m.put("source_collections", sourcesMap.getOrDefault(tid, List.of()));
@@ -846,35 +993,38 @@ public final class TaxonomyRepository {
      */
     public Map<String, Object> auditCollectionData(String tenant, String collection, int topN) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var simRows = ctx.fetch(
-                "SELECT similarity FROM nexus.topic_assignments "
-                + "WHERE assigned_by = 'projection' "
-                + "AND source_collection = ? AND similarity IS NOT NULL "
-                + "ORDER BY similarity ASC",
-                collection);
+            var simRows = ctx.select(TOPIC_ASSIGNMENTS.SIMILARITY)
+                .from(TOPIC_ASSIGNMENTS)
+                .where(TOPIC_ASSIGNMENTS.ASSIGNED_BY.eq("projection")
+                    .and(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.eq(collection))
+                    .and(TOPIC_ASSIGNMENTS.SIMILARITY.isNotNull()))
+                .orderBy(TOPIC_ASSIGNMENTS.SIMILARITY.asc())
+                .fetch();
 
             List<Double> sims = new ArrayList<>();
             for (var r : simRows) {
-                sims.add(((Number) r.get("similarity")).doubleValue());
+                sims.add(r.get(TOPIC_ASSIGNMENTS.SIMILARITY));
             }
 
-            var hubRows = ctx.fetch("""
-                SELECT ta.topic_id, t.label, COUNT(*) AS chunks
-                FROM nexus.topic_assignments ta
-                JOIN nexus.topics t ON t.id = ta.topic_id
-                WHERE ta.assigned_by = 'projection'
-                  AND ta.source_collection = ?
-                GROUP BY ta.topic_id, t.label
-                ORDER BY COUNT(*) DESC
-                LIMIT ?
-                """, collection, topN);
+            var hubRows = ctx.select(
+                    TOPIC_ASSIGNMENTS.TOPIC_ID,
+                    TOPICS.LABEL,
+                    count().as("chunks"))
+               .from(TOPIC_ASSIGNMENTS)
+               .join(TOPICS).on(TOPICS.ID.eq(TOPIC_ASSIGNMENTS.TOPIC_ID))
+               .where(TOPIC_ASSIGNMENTS.ASSIGNED_BY.eq("projection")
+                   .and(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.eq(collection)))
+               .groupBy(TOPIC_ASSIGNMENTS.TOPIC_ID, TOPICS.LABEL)
+               .orderBy(count().desc())
+               .limit(topN)
+               .fetch();
 
             List<Map<String, Object>> hubs = new ArrayList<>();
             for (var r : hubRows) {
                 var m = new LinkedHashMap<String, Object>();
-                m.put("topic_id", ((Number) r.get("topic_id")).longValue());
-                m.put("label", r.get("label"));
-                m.put("chunk_count", ((Number) r.get("chunks")).intValue());
+                m.put("topic_id", r.get(TOPIC_ASSIGNMENTS.TOPIC_ID));
+                m.put("label", r.get(TOPICS.LABEL));
+                m.put("chunk_count", r.get("chunks", Integer.class));
                 hubs.add(m);
             }
 
@@ -892,31 +1042,43 @@ public final class TaxonomyRepository {
      */
     public int generateCooccurrenceLinks(String tenant) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var pairs = ctx.fetch("""
-                SELECT LEAST(a.topic_id, b.topic_id) AS from_id,
-                       GREATEST(a.topic_id, b.topic_id) AS to_id,
-                       COUNT(*) AS cnt
-                FROM nexus.topic_assignments a
-                JOIN nexus.topic_assignments b ON a.doc_id = b.doc_id
-                JOIN nexus.topics ta ON a.topic_id = ta.id
-                JOIN nexus.topics tb ON b.topic_id = tb.id
-                WHERE a.topic_id < b.topic_id AND ta.collection != tb.collection
-                GROUP BY LEAST(a.topic_id, b.topic_id), GREATEST(a.topic_id, b.topic_id)
-                """);
+            // LEAST/GREATEST over column references (a.topic_id, b.topic_id) for
+            // canonical pair ordering: these are Postgres-specific aggregate functions
+            // applied to column expressions (not per-row scalar), retained as DSL.sql.
+            var ta = TOPIC_ASSIGNMENTS.as("a");
+            var tb = TOPIC_ASSIGNMENTS.as("b");
+            var ta2 = TOPICS.as("ta");
+            var tb2 = TOPICS.as("tb");
+            var pairs = ctx.select(
+                    field("LEAST(a.topic_id, b.topic_id)", Long.class).as("from_id"),
+                    field("GREATEST(a.topic_id, b.topic_id)", Long.class).as("to_id"),
+                    count().as("cnt"))
+               .from(ta)
+               .join(tb).on(ta.DOC_ID.eq(tb.DOC_ID))
+               .join(ta2).on(ta.TOPIC_ID.eq(ta2.ID))
+               .join(tb2).on(tb.TOPIC_ID.eq(tb2.ID))
+               .where(ta.TOPIC_ID.lt(tb.TOPIC_ID)
+                   .and(ta2.COLLECTION.ne(tb2.COLLECTION)))
+               .groupBy(
+                   field("LEAST(a.topic_id, b.topic_id)", Long.class),
+                   field("GREATEST(a.topic_id, b.topic_id)", Long.class))
+               .fetch();
 
             if (pairs.isEmpty()) return 0;
 
             for (var r : pairs) {
-                long fromId = ((Number) r.get("from_id")).longValue();
-                long toId   = ((Number) r.get("to_id")).longValue();
-                int  cnt    = ((Number) r.get("cnt")).intValue();
-                ctx.execute("""
-                    INSERT INTO nexus.topic_links (tenant_id, from_topic_id, to_topic_id, link_count, link_types)
-                    VALUES (?, ?, ?, ?, '["cooccurrence"]')
-                    ON CONFLICT (tenant_id, from_topic_id, to_topic_id) DO UPDATE SET
-                        link_count = EXCLUDED.link_count,
-                        link_types = '["cooccurrence"]'
-                    """, tenant, fromId, toId, cnt);
+                long fromId = r.get("from_id", Long.class);
+                long toId   = r.get("to_id",   Long.class);
+                int  cnt    = r.get("cnt",      Integer.class);
+                ctx.insertInto(TOPIC_LINKS,
+                        TOPIC_LINKS.TENANT_ID, TOPIC_LINKS.FROM_TOPIC_ID,
+                        TOPIC_LINKS.TO_TOPIC_ID, TOPIC_LINKS.LINK_COUNT, TOPIC_LINKS.LINK_TYPES)
+                   .values(tenant, fromId, toId, cnt, "[\"cooccurrence\"]")
+                   .onConflict(TOPIC_LINKS.TENANT_ID, TOPIC_LINKS.FROM_TOPIC_ID, TOPIC_LINKS.TO_TOPIC_ID)
+                   .doUpdate()
+                   .set(TOPIC_LINKS.LINK_COUNT, field("EXCLUDED.link_count", Integer.class))
+                   .set(TOPIC_LINKS.LINK_TYPES, "[\"cooccurrence\"]")
+                   .execute();
             }
             log.info("cooccurrence_links generated count={}", pairs.size());
             return pairs.size();
@@ -929,29 +1091,32 @@ public final class TaxonomyRepository {
      */
     public int refreshProjectionLinks(String tenant) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.fetch("""
-                SELECT src.topic_id AS src_id, tgt.topic_id AS tgt_id, COUNT(*) AS cnt
-                FROM nexus.topic_assignments tgt
-                JOIN nexus.topic_assignments src
-                  ON src.doc_id = tgt.doc_id
-                 AND src.topic_id != tgt.topic_id
-                 AND src.assigned_by != 'projection'
-                WHERE tgt.assigned_by = 'projection'
-                GROUP BY src.topic_id, tgt.topic_id
-                HAVING COUNT(*) > 0
-                """);
+            var tgt = TOPIC_ASSIGNMENTS.as("tgt");
+            var src = TOPIC_ASSIGNMENTS.as("src");
+            var rows = ctx.select(
+                    src.TOPIC_ID.as("src_id"),
+                    tgt.TOPIC_ID.as("tgt_id"),
+                    count().as("cnt"))
+               .from(tgt)
+               .join(src).on(src.DOC_ID.eq(tgt.DOC_ID)
+                   .and(src.TOPIC_ID.ne(tgt.TOPIC_ID))
+                   .and(src.ASSIGNED_BY.ne("projection")))
+               .where(tgt.ASSIGNED_BY.eq("projection"))
+               .groupBy(src.TOPIC_ID, tgt.TOPIC_ID)
+               .having(count().gt(0))
+               .fetch();
 
             if (rows.isEmpty()) return 0;
 
             // Canonicalize pair ordering
             java.util.Map<String, Integer> aggregated = new java.util.LinkedHashMap<>();
             for (var r : rows) {
-                long s = ((Number) r.get("src_id")).longValue();
-                long t = ((Number) r.get("tgt_id")).longValue();
+                long s = r.get("src_id", Long.class);
+                long t = r.get("tgt_id", Long.class);
                 long fromId = Math.min(s, t);
                 long toId   = Math.max(s, t);
                 String key = fromId + ":" + toId;
-                aggregated.merge(key, ((Number) r.get("cnt")).intValue(), Integer::sum);
+                aggregated.merge(key, r.get("cnt", Integer.class), Integer::sum);
             }
 
             for (var entry : aggregated.entrySet()) {
@@ -960,14 +1125,16 @@ public final class TaxonomyRepository {
                 long toId   = Long.parseLong(parts[1]);
 
                 // Fetch existing link_types to merge 'projection' in
-                var existing = ctx.fetchOne(
-                    "SELECT link_types FROM nexus.topic_links "
-                    + "WHERE tenant_id = ? AND from_topic_id = ? AND to_topic_id = ?",
-                    tenant, fromId, toId);
+                var existing = ctx.select(TOPIC_LINKS.LINK_TYPES)
+                    .from(TOPIC_LINKS)
+                    .where(TOPIC_LINKS.TENANT_ID.eq(tenant)
+                        .and(TOPIC_LINKS.FROM_TOPIC_ID.eq(fromId))
+                        .and(TOPIC_LINKS.TO_TOPIC_ID.eq(toId)))
+                    .fetch();
 
                 String mergedTypes;
-                if (existing != null && existing.get("link_types") != null) {
-                    String lt = (String) existing.get("link_types");
+                if (!existing.isEmpty() && existing.get(0).get(TOPIC_LINKS.LINK_TYPES) != null) {
+                    String lt = existing.get(0).get(TOPIC_LINKS.LINK_TYPES);
                     if (!lt.contains("\"projection\"")) {
                         // Insert projection into the JSON array
                         mergedTypes = lt.replace("]", ", \"projection\"]")
@@ -983,13 +1150,15 @@ public final class TaxonomyRepository {
                     mergedTypes = "[\"projection\"]";
                 }
 
-                ctx.execute("""
-                    INSERT INTO nexus.topic_links (tenant_id, from_topic_id, to_topic_id, link_count, link_types)
-                    VALUES (?, ?, ?, ?, ?)
-                    ON CONFLICT (tenant_id, from_topic_id, to_topic_id) DO UPDATE SET
-                        link_count = EXCLUDED.link_count,
-                        link_types = EXCLUDED.link_types
-                    """, tenant, fromId, toId, entry.getValue(), mergedTypes);
+                ctx.insertInto(TOPIC_LINKS,
+                        TOPIC_LINKS.TENANT_ID, TOPIC_LINKS.FROM_TOPIC_ID,
+                        TOPIC_LINKS.TO_TOPIC_ID, TOPIC_LINKS.LINK_COUNT, TOPIC_LINKS.LINK_TYPES)
+                   .values(tenant, fromId, toId, entry.getValue(), mergedTypes)
+                   .onConflict(TOPIC_LINKS.TENANT_ID, TOPIC_LINKS.FROM_TOPIC_ID, TOPIC_LINKS.TO_TOPIC_ID)
+                   .doUpdate()
+                   .set(TOPIC_LINKS.LINK_COUNT, field("EXCLUDED.link_count", Integer.class))
+                   .set(TOPIC_LINKS.LINK_TYPES,  field("EXCLUDED.link_types",  String.class))
+                   .execute();
             }
 
             log.info("projection_links refreshed count={}", aggregated.size());
@@ -1010,9 +1179,12 @@ public final class TaxonomyRepository {
                                     String collectionName,
                                     List<Map<String, Object>> childSpecs) {
         return tenantScope.withTenant(tenant, ctx -> {
+            ensureCollectionRegistered(ctx, tenant, collectionName);
             // Delete parent assignments
-            ctx.execute("DELETE FROM nexus.topic_assignments WHERE tenant_id = ? AND topic_id = ?",
-                        tenant, topicId);
+            ctx.deleteFrom(TOPIC_ASSIGNMENTS)
+               .where(TOPIC_ASSIGNMENTS.TENANT_ID.eq(tenant)
+                   .and(TOPIC_ASSIGNMENTS.TOPIC_ID.eq(topicId)))
+               .execute();
 
             List<Long> childIds = new ArrayList<>();
             for (var spec : childSpecs) {
@@ -1022,14 +1194,14 @@ public final class TaxonomyRepository {
                 String termsJson  = (String) spec.getOrDefault("terms_json", null);
                 List<String> docIds = (List<String>) spec.getOrDefault("doc_ids", List.of());
 
-                String tsStr = fmtTs(parseTsStrict(createdAt));
-                var row = ctx.fetchOne("""
-                    INSERT INTO nexus.topics
-                        (tenant_id, label, parent_id, collection, doc_count, created_at, terms)
-                    VALUES (?, ?, ?, ?, ?, ?::timestamptz, ?)
-                    RETURNING id
-                    """, tenant, label, topicId, collectionName, docCount, tsStr, termsJson);
-                long childId = row == null ? -1 : ((Number) row.get("id")).longValue();
+                OffsetDateTime createdAtTs = parseTsStrict(createdAt);
+                long childId = ctx.insertInto(TOPICS,
+                        TOPICS.TENANT_ID, TOPICS.LABEL, TOPICS.PARENT_ID,
+                        TOPICS.COLLECTION, TOPICS.DOC_COUNT, TOPICS.CREATED_AT, TOPICS.TERMS)
+                    .values(tenant, label, topicId, collectionName, docCount, createdAtTs, termsJson)
+                    .returningResult(TOPICS.ID)
+                    .fetchOne()
+                    .get(TOPICS.ID);
                 childIds.add(childId);
 
                 batchInsertAssignments(ctx, tenant, childId, docIds, "split");
@@ -1059,23 +1231,29 @@ public final class TaxonomyRepository {
      */
     public Map<String, Object> readRebuildOldState(String tenant, String collection) {
         return tenantScope.withTenant(tenant, ctx -> {
-            List<Map<String, Object>> oldTopicMap = ctx.fetch("""
-                SELECT id, label, review_status FROM nexus.topics WHERE collection = ?
-                """, collection).map(r -> {
+            List<Map<String, Object>> oldTopicMap = ctx.select(
+                    TOPICS.ID, TOPICS.LABEL, TOPICS.REVIEW_STATUS)
+                .from(TOPICS)
+                .where(TOPICS.COLLECTION.eq(collection))
+                .fetch()
+                .map(r -> {
                     Map<String, Object> m = new LinkedHashMap<>();
-                    m.put("id",            r.get("id",            Long.class));
-                    m.put("label",         r.get("label",         String.class));
-                    m.put("review_status", r.get("review_status", String.class));
+                    m.put("id",            r.get(TOPICS.ID));
+                    m.put("label",         r.get(TOPICS.LABEL));
+                    m.put("review_status", r.get(TOPICS.REVIEW_STATUS));
                     return m;
                 });
-            List<Map<String, Object>> manualAssignments = ctx.fetch("""
-                SELECT ta.doc_id, ta.topic_id FROM nexus.topic_assignments ta
-                JOIN nexus.topics t ON t.id = ta.topic_id
-                WHERE ta.assigned_by = 'manual' AND t.collection = ?
-                """, collection).map(r -> {
+            List<Map<String, Object>> manualAssignments = ctx.select(
+                    TOPIC_ASSIGNMENTS.DOC_ID, TOPIC_ASSIGNMENTS.TOPIC_ID)
+                .from(TOPIC_ASSIGNMENTS)
+                .join(TOPICS).on(TOPICS.ID.eq(TOPIC_ASSIGNMENTS.TOPIC_ID))
+                .where(TOPIC_ASSIGNMENTS.ASSIGNED_BY.eq("manual")
+                    .and(TOPICS.COLLECTION.eq(collection)))
+                .fetch()
+                .map(r -> {
                     Map<String, Object> m = new LinkedHashMap<>();
-                    m.put("doc_id",   r.get("doc_id",   String.class));
-                    m.put("topic_id", r.get("topic_id", Long.class));
+                    m.put("doc_id",   r.get(TOPIC_ASSIGNMENTS.DOC_ID));
+                    m.put("topic_id", r.get(TOPIC_ASSIGNMENTS.TOPIC_ID));
                     return m;
                 });
             Map<String, Object> out = new LinkedHashMap<>();
@@ -1107,14 +1285,15 @@ public final class TaxonomyRepository {
         List<Map<String, Object>> safeSpecs = specs == null ? List.of() : specs;
         Map<String, Object> transfers = manualTransfers == null ? Map.of() : manualTransfers;
         return tenantScope.withTenant(tenant, ctx -> {
+            ensureCollectionRegistered(ctx, tenant, collection);
             // REPLACE semantics — clear old rows even when there are no new specs.
-            ctx.execute("""
-                DELETE FROM nexus.topic_assignments WHERE topic_id IN
-                    (SELECT id FROM nexus.topics WHERE collection = ?)
-                """, collection);
-            ctx.execute("DELETE FROM nexus.topics WHERE collection = ?", collection);
+            ctx.deleteFrom(TOPIC_ASSIGNMENTS)
+               .where(TOPIC_ASSIGNMENTS.TOPIC_ID.in(
+                   select(TOPICS.ID).from(TOPICS).where(TOPICS.COLLECTION.eq(collection))))
+               .execute();
+            ctx.deleteFrom(TOPICS).where(TOPICS.COLLECTION.eq(collection)).execute();
 
-            String tsStr = fmtTs(OffsetDateTime.now(ZoneOffset.UTC));
+            OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
             List<Long> topicIds = new ArrayList<>();
             for (var spec : safeSpecs) {
                 String label        = (String) spec.get("label");
@@ -1124,13 +1303,13 @@ public final class TaxonomyRepository {
                 String assignedBy   = (String) spec.getOrDefault("assigned_by", "hdbscan");
                 List<String> docIds = (List<String>) spec.getOrDefault("doc_ids", List.of());
 
-                var row = ctx.fetchOne("""
-                    INSERT INTO nexus.topics
-                        (tenant_id, label, collection, doc_count, created_at, terms, review_status)
-                    VALUES (?, ?, ?, ?, ?::timestamptz, ?, ?)
-                    RETURNING id
-                    """, tenant, label, collection, docCount, tsStr, terms, reviewStatus);
-                long topicId = row == null ? -1 : ((Number) row.get("id")).longValue();
+                long topicId = ctx.insertInto(TOPICS,
+                        TOPICS.TENANT_ID, TOPICS.LABEL, TOPICS.COLLECTION,
+                        TOPICS.DOC_COUNT, TOPICS.CREATED_AT, TOPICS.TERMS, TOPICS.REVIEW_STATUS)
+                    .values(tenant, label, collection, docCount, now, terms, reviewStatus)
+                    .returningResult(TOPICS.ID)
+                    .fetchOne()
+                    .get(TOPICS.ID);
                 topicIds.add(topicId);
 
                 batchInsertAssignments(ctx, tenant, topicId, docIds, assignedBy);
@@ -1144,11 +1323,19 @@ public final class TaxonomyRepository {
             for (var e : transfers.entrySet()) {
                 int specIndex = ((Number) e.getValue()).intValue();
                 if (specIndex >= 0 && specIndex < topicIds.size()) {
-                    ctx.execute("""
-                        INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, assigned_by)
-                        VALUES (?, ?, ?, 'manual')
-                        ON CONFLICT (tenant_id, doc_id, topic_id) DO UPDATE SET assigned_by = 'manual'
-                        """, tenant, e.getKey(), topicIds.get(specIndex));
+                    ctx.insertInto(TOPIC_ASSIGNMENTS,
+                            TOPIC_ASSIGNMENTS.TENANT_ID,
+                            TOPIC_ASSIGNMENTS.DOC_ID,
+                            TOPIC_ASSIGNMENTS.TOPIC_ID,
+                            TOPIC_ASSIGNMENTS.ASSIGNED_BY)
+                       .values(tenant, e.getKey(), topicIds.get(specIndex), "manual")
+                       .onConflict(
+                           TOPIC_ASSIGNMENTS.TENANT_ID,
+                           TOPIC_ASSIGNMENTS.DOC_ID,
+                           TOPIC_ASSIGNMENTS.TOPIC_ID)
+                       .doUpdate()
+                       .set(TOPIC_ASSIGNMENTS.ASSIGNED_BY, "manual")
+                       .execute();
                 }
             }
             log.info("persist_rebuild collection={} topics={}", collection, topicIds.size());
@@ -1173,15 +1360,17 @@ public final class TaxonomyRepository {
                                                List<Map<String, Object>> specs) {
         if (specs == null || specs.isEmpty()) return List.of();
         return tenantScope.withTenant(tenant, ctx -> {
-            int existing = ctx.fetchOne(
-                "SELECT COUNT(*) AS c FROM nexus.topics WHERE collection = ?", collection)
-                .get("c", Integer.class);
+            ensureCollectionRegistered(ctx, tenant, collection);
+            int existing = ctx.selectCount()
+                .from(TOPICS)
+                .where(TOPICS.COLLECTION.eq(collection))
+                .fetchOne(0, Integer.class);
             if (existing > 0) {
                 log.info("discover_skip_existing collection={} existing_topics={}",
                          collection, existing);
                 return List.of();
             }
-            String tsStr = fmtTs(OffsetDateTime.now(ZoneOffset.UTC));
+            OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
             List<Long> topicIds = new ArrayList<>();
             for (var spec : specs) {
                 String label        = (String) spec.get("label");
@@ -1190,13 +1379,13 @@ public final class TaxonomyRepository {
                 String assignedBy   = (String) spec.getOrDefault("assigned_by", "hdbscan");
                 List<String> docIds = (List<String>) spec.getOrDefault("doc_ids", List.of());
 
-                var row = ctx.fetchOne("""
-                    INSERT INTO nexus.topics
-                        (tenant_id, label, collection, doc_count, created_at, terms)
-                    VALUES (?, ?, ?, ?, ?::timestamptz, ?)
-                    RETURNING id
-                    """, tenant, label, collection, docCount, tsStr, terms);
-                long topicId = row == null ? -1 : ((Number) row.get("id")).longValue();
+                long topicId = ctx.insertInto(TOPICS,
+                        TOPICS.TENANT_ID, TOPICS.LABEL, TOPICS.COLLECTION,
+                        TOPICS.DOC_COUNT, TOPICS.CREATED_AT, TOPICS.TERMS)
+                    .values(tenant, label, collection, docCount, now, terms)
+                    .returningResult(TOPICS.ID)
+                    .fetchOne()
+                    .get(TOPICS.ID);
                 topicIds.add(topicId);
 
                 batchInsertAssignments(ctx, tenant, topicId, docIds, assignedBy);
@@ -1220,6 +1409,12 @@ public final class TaxonomyRepository {
      * <p>{@code ON CONFLICT DO NOTHING} preserves the prior idempotency, including
      * for duplicate doc_ids within a single batch (a self-conflict is skipped, not
      * an error — DO NOTHING, not DO UPDATE).
+     *
+     * <p>Dynamic multi-row VALUES with variable count is the sole reason this
+     * method uses raw SQL string building — jOOQ's typed multi-row INSERT requires
+     * a statically-known row count and would require a separate parameter object
+     * per row (losing the batch-statement benefit). This is the minimal irreducible
+     * plain-SQL fragment per spec.
      */
     private static void batchInsertAssignments(org.jooq.DSLContext ctx, String tenant,
                                                long topicId, List<String> docIds,

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -66,6 +66,13 @@
          Must come after vectors-001, chash-001, taxonomy-001, and catalog-001. -->
     <include file="db/changelog/fk-002-collection-registry.xml"/>
 
+    <!-- Collection-registry FKs, second wave (bead nexus-dcqml, RDR-164 P1a):
+         NOT VALID ON DELETE RESTRICT FKs from document_aspects, aspect_extraction_queue,
+         topics, taxonomy_meta, and document_highlights to catalog_collections(tenant_id, name),
+         plus a stub-register backfill. VALIDATE is deferred to P1b (world-blocked).
+         Must come after aspects-001, taxonomy-001, and catalog-001. -->
+    <include file="db/changelog/fk-003-collection-registry-extra.xml"/>
+
     <!-- Catalog hygiene (bead nexus-70r3c.2, RDR-156 P0.2):
          temporal typing for catalog_collections.created_at/superseded_at (TEXT→timestamptz NULL),
          and CHECK constraints for chash length = 32 and position >= 0. -->

--- a/service/src/main/resources/db/changelog/fk-003-collection-registry-extra.xml
+++ b/service/src/main/resources/db/changelog/fk-003-collection-registry-extra.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    fk-003-collection-registry-extra.xml — RDR-164 P1a (bead nexus-dcqml)
+
+    Extends the collection-registry FK spine started by fk-002 (RDR-156 P0.2) to the
+    five remaining FK-eligible collection-level lifecycle tables:
+
+      document_aspects        (collection NOT NULL)
+      aspect_extraction_queue (collection NOT NULL)
+      topics                  (collection NOT NULL)
+      taxonomy_meta           (collection NOT NULL, PK = (tenant_id, collection))
+      document_highlights     (collection NULLABLE — MATCH SIMPLE: null rows escape the FK
+                               and rely on the fk-001 catalog_documents cascade instead)
+
+    Each FK is FOREIGN KEY (tenant_id, collection) REFERENCES catalog_collections(tenant_id, name)
+    ON DELETE RESTRICT NOT VALID — identical shape to fk-002. The composite (tenant_id, *)
+    key keeps every reference tenant-safe.
+
+    Constraint names are a fixed contract (CollectionRegistryFkExtraTest):
+      document_aspects_collection_fk
+      aspect_extraction_queue_collection_fk
+      topics_collection_fk
+      taxonomy_meta_collection_fk
+      document_highlights_collection_fk
+
+    SCOPE (RDR-164 P0 + P1a): this changelog ships the STUB-REGISTER backfill (fk-003-0,
+    mirroring fk-002-0-backfill-stubs) plus the five NOT VALID FKs. It deliberately does
+    NOT add VALIDATE CONSTRAINT — that is the P1b sibling of bead nexus-70r3c.3,
+    world-blocked on the RDR-153 production migration completing with summary.total_failed==0.
+    The Q5 orphan RECONCILE (DELETE genuinely-orphaned / FAIL-LOUD ambiguous) runs in that
+    migration where real data exists; it is not part of this schema changelog.
+
+    Must come after aspects-001 (document_aspects/document_highlights/aspect_extraction_queue),
+    taxonomy-001 (topics/taxonomy_meta), and catalog-001 (catalog_collections).
+
+    ON UPDATE SEMANTICS — INVARIANT FOR RDR-164 P3 (renameCollection). These five FKs are
+    `ON DELETE RESTRICT` with the DEFAULT `ON UPDATE NO ACTION`. This INTENTIONALLY differs
+    from fk-002's topic_assignments_collection_fk, which is `ON UPDATE CASCADE`. Consequence:
+    a bare `UPDATE catalog_collections SET name = ...` (e.g. CatalogRepository.renameCollection's
+    targetExists-false branch) will NOT propagate to document_aspects/aspect_extraction_queue/
+    topics/taxonomy_meta/document_highlights — only topic_assignments.source_collection follows
+    automatically. P3 MUST keep issuing the explicit per-store child-table
+    `UPDATE <table> SET collection = <newName>` calls (TaxonomyRepository.renameCollection,
+    AspectRepository.rename*Collection) and MUST NOT replace them by relying on FK cascade.
+    Leaving these RESTRICT/NO-ACTION (rather than CASCADE) is the gate-settled choice: collection
+    rename is a destructive-admin op handled by an explicit transactional re-home (RDR-164 Q6),
+    not a silent parent-row UPDATE. The P3 phase-review gate must verify all five child tables are
+    explicitly re-homed.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <!-- ── Changeset fk-003-0: backfill stubs into catalog_collections ─────────── -->
+    <!--
+        Same deploy-order landmine fk-002-0 documents: derived rows (aspects, queue,
+        topics, taxonomy_meta, highlights) accumulate before the catalog ETL registers
+        the collection. Without this backfill the NOT VALID FKs added by fk-003-1..5
+        would reject new serving writes at deploy time (NOT VALID still enforces NEW
+        inserts; it only skips retroactive validation of pre-existing rows). Each stub
+        row carries empty metadata fields ('') and is upgradable by importCollection's
+        DO UPDATE WHERE-stub logic once the catalog ETL runs. STUB-REGISTER only — the
+        orphan reconcile (DELETE/FAIL-LOUD, Q5) rides with the RDR-153 migration (P1b).
+        document_highlights contributes only non-null, non-empty collection values.
+    -->
+    <changeSet id="fk-003-0-backfill-stubs" author="nexus-dcqml">
+        <comment>
+            Backfill catalog_collections stub rows for every collection name referenced by
+            document_aspects, aspect_extraction_queue, topics, taxonomy_meta, and
+            document_highlights (non-null) that is not already registered.
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.document_aspects
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.aspect_extraction_queue
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.topics
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.taxonomy_meta
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.document_highlights
+WHERE collection IS NOT NULL AND collection != ''
+ON CONFLICT (tenant_id, name) DO NOTHING;
+        </sql>
+        <rollback>
+            <!-- No rollback: stub rows are inert; the FKs being added next drop via their
+                 own rollbacks. Removing stubs here could break existing references. -->
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset fk-003-1: document_aspects → catalog_collections FK ───────── -->
+    <changeSet id="fk-003-1" author="nexus-dcqml">
+        <comment>
+            document_aspects_collection_fk: FOREIGN KEY (tenant_id, collection)
+            REFERENCES nexus.catalog_collections (tenant_id, name) ON DELETE RESTRICT NOT VALID.
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.document_aspects
+    ADD CONSTRAINT document_aspects_collection_fk
+    FOREIGN KEY (tenant_id, collection)
+    REFERENCES nexus.catalog_collections (tenant_id, name)
+    ON DELETE RESTRICT
+    NOT VALID;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.document_aspects DROP CONSTRAINT IF EXISTS document_aspects_collection_fk;
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset fk-003-2: aspect_extraction_queue → catalog_collections FK ── -->
+    <changeSet id="fk-003-2" author="nexus-dcqml">
+        <comment>
+            aspect_extraction_queue_collection_fk: FOREIGN KEY (tenant_id, collection)
+            REFERENCES nexus.catalog_collections (tenant_id, name) ON DELETE RESTRICT NOT VALID.
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.aspect_extraction_queue
+    ADD CONSTRAINT aspect_extraction_queue_collection_fk
+    FOREIGN KEY (tenant_id, collection)
+    REFERENCES nexus.catalog_collections (tenant_id, name)
+    ON DELETE RESTRICT
+    NOT VALID;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.aspect_extraction_queue DROP CONSTRAINT IF EXISTS aspect_extraction_queue_collection_fk;
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset fk-003-3: topics → catalog_collections FK ─────────────────── -->
+    <changeSet id="fk-003-3" author="nexus-dcqml">
+        <comment>
+            topics_collection_fk: FOREIGN KEY (tenant_id, collection)
+            REFERENCES nexus.catalog_collections (tenant_id, name) ON DELETE RESTRICT NOT VALID.
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.topics
+    ADD CONSTRAINT topics_collection_fk
+    FOREIGN KEY (tenant_id, collection)
+    REFERENCES nexus.catalog_collections (tenant_id, name)
+    ON DELETE RESTRICT
+    NOT VALID;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.topics DROP CONSTRAINT IF EXISTS topics_collection_fk;
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset fk-003-4: taxonomy_meta → catalog_collections FK ──────────── -->
+    <changeSet id="fk-003-4" author="nexus-dcqml">
+        <comment>
+            taxonomy_meta_collection_fk: FOREIGN KEY (tenant_id, collection)
+            REFERENCES nexus.catalog_collections (tenant_id, name) ON DELETE RESTRICT NOT VALID.
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.taxonomy_meta
+    ADD CONSTRAINT taxonomy_meta_collection_fk
+    FOREIGN KEY (tenant_id, collection)
+    REFERENCES nexus.catalog_collections (tenant_id, name)
+    ON DELETE RESTRICT
+    NOT VALID;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.taxonomy_meta DROP CONSTRAINT IF EXISTS taxonomy_meta_collection_fk;
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset fk-003-5: document_highlights → catalog_collections FK ─────── -->
+    <changeSet id="fk-003-5" author="nexus-dcqml">
+        <comment>
+            document_highlights_collection_fk: FOREIGN KEY (tenant_id, collection)
+            REFERENCES nexus.catalog_collections (tenant_id, name) ON DELETE RESTRICT NOT VALID.
+            collection is NULLABLE: MATCH SIMPLE means null-collection rows escape the FK and
+            rely on the fk-001 catalog_documents ON DELETE CASCADE instead.
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.document_highlights
+    ADD CONSTRAINT document_highlights_collection_fk
+    FOREIGN KEY (tenant_id, collection)
+    REFERENCES nexus.catalog_collections (tenant_id, name)
+    ON DELETE RESTRICT
+    NOT VALID;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.document_highlights DROP CONSTRAINT IF EXISTS document_highlights_collection_fk;
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/test/java/dev/nexus/service/AspectOperatorQueryTest.java
+++ b/service/src/test/java/dev/nexus/service/AspectOperatorQueryTest.java
@@ -85,6 +85,10 @@ class AspectOperatorQueryTest {
                 su.createStatement().execute(
                     "GRANT USAGE ON SEQUENCE nexus." + table + "_id_seq TO " + SVC_ROLE);
             }
+            // RDR-164 P1a: aspect writes ensure-register their collection (catalog_collections
+            // stub) to satisfy the new fk-003 collection FKs.
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus.catalog_collections TO " + SVC_ROLE);
             su.createStatement().execute(
                 "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
 

--- a/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
@@ -12,6 +12,7 @@ import liquibase.resource.ClassLoaderResourceAccessor;
 import org.junit.jupiter.api.*;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -113,6 +114,12 @@ class AspectRepositoryTest {
                 su.createStatement().execute(
                     "GRANT USAGE ON SEQUENCE nexus." + table + "_id_seq TO " + SVC_ROLE);
             }
+            // RDR-164 P1a: aspect/highlight/queue writes now ensure-register their collection
+            // (catalog_collections stub) to satisfy the new fk-003 collection FKs, so the
+            // service role needs INSERT on catalog_collections (production grants this via
+            // GRANT ... ON ALL TABLES IN SCHEMA nexus; the test role is scoped explicitly).
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus.catalog_collections TO " + SVC_ROLE);
             su.createStatement().execute(
                 "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
 
@@ -660,8 +667,51 @@ class AspectRepositoryTest {
         importBody.put("retry_count", 1);
         repo.importQueueRow(TENANT_A, importBody);
 
-        // pending_count confirms row is still there
-        assertThat(repo.pendingCount(TENANT_A)).isGreaterThanOrEqualTo(1);
+        // GREATEST(existing, EXCLUDED) must keep retry_count=3, NOT overwrite to 1.
+        // Read the value back (a plain EXCLUDED.retry_count overwrite would yield 1 and
+        // pass a >= 1 assertion — this exact-value check is the non-vacuous guard).
+        Map<String, Object> row = repo.listPending(TENANT_A, 1000).stream()
+            .filter(r -> "gr.pdf".equals(r.get("source_path")))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("imported queue row gr.pdf not found in listPending"));
+        assertThat(((Number) row.get("retry_count")).intValue())
+            .as("GREATEST(retry_count) must preserve the higher existing value (3), not the stale import (1)")
+            .isEqualTo(3);
+    }
+
+    @Test @Order(39)
+    void importQueueRow_least_enqueuedAt_keepsEarliest() {
+        // LEAST(existing.enqueued_at, EXCLUDED.enqueued_at): a later re-import must NOT
+        // push enqueued_at forward. A plain EXCLUDED.enqueued_at overwrite would replace
+        // the earlier value and pass any "row exists" assertion — so read the value back.
+        String tenant = "etl-least-tenant-" + System.nanoTime();
+        String path   = "least.pdf";
+        String early  = "2025-01-01T00:00:00.000000Z";
+        String later  = "2026-06-01T00:00:00.000000Z";
+
+        var seed = new java.util.LinkedHashMap<String, Object>();
+        seed.put("collection",  "least-coll");
+        seed.put("source_path", path);
+        seed.put("status",      "pending");
+        seed.put("retry_count", 0);
+        seed.put("enqueued_at", early);
+        repo.importQueueRow(tenant, seed);
+
+        seed.put("enqueued_at", later);   // stale (later) re-import
+        repo.importQueueRow(tenant, seed);
+
+        try (Connection su = pg.createConnection("")) {
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT enqueued_at FROM nexus.aspect_extraction_queue "
+                + "WHERE tenant_id = '" + tenant + "' AND source_path = '" + path + "'");
+            assertThat(rs.next()).as("queue row must exist").isTrue();
+            var enqueuedAt = rs.getObject("enqueued_at", java.time.OffsetDateTime.class).toInstant();
+            assertThat(enqueuedAt)
+                .as("LEAST(enqueued_at) must keep the EARLIER 2025 timestamp, not the later 2026 re-import")
+                .isEqualTo(java.time.OffsetDateTime.parse(early).toInstant());
+        } catch (Exception e) {
+            throw new AssertionError("failed to read back enqueued_at", e);
+        }
     }
 
     @Test @Order(39)

--- a/service/src/test/java/dev/nexus/service/CollectionRegistryFkExtraTest.java
+++ b/service/src/test/java/dev/nexus/service/CollectionRegistryFkExtraTest.java
@@ -1,0 +1,437 @@
+package dev.nexus.service;
+
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.*;
+import org.postgresql.util.PSQLException;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * RDR-164 P1a bead nexus-dcqml — collection-registry FK spine, second wave.
+ *
+ * <p>RDR-156 P0.2 (fk-002) added NOT VALID {@code ON DELETE RESTRICT} FKs from
+ * {@code chunks_384/768/1024}, {@code chash_index}, and {@code topic_assignments}
+ * to {@code catalog_collections(tenant_id, name)}. This suite covers the FIVE
+ * remaining FK-eligible collection-level lifecycle tables that RDR-164 P1a wires
+ * with the same NOT VALID + RESTRICT shape (changelog {@code fk-003-collection-registry-extra.xml}):
+ *
+ * <ul>
+ *   <li>{@code document_aspects_collection_fk}      (collection NOT NULL)</li>
+ *   <li>{@code aspect_extraction_queue_collection_fk}(collection NOT NULL)</li>
+ *   <li>{@code topics_collection_fk}                (collection NOT NULL)</li>
+ *   <li>{@code taxonomy_meta_collection_fk}         (collection NOT NULL, PK = (tenant_id, collection))</li>
+ *   <li>{@code document_highlights_collection_fk}   (collection NULLABLE — MATCH SIMPLE, null escapes the FK)</li>
+ * </ul>
+ *
+ * <p><strong>Scope boundary (RDR-164 P0 + P1a):</strong> P1a ships the backfill
+ * (STUB-REGISTER, mirroring {@code fk-002-0-backfill-stubs}) plus these five NOT
+ * VALID FKs. {@code VALIDATE CONSTRAINT} is P1b (bead nexus-70r3c.3 sibling),
+ * world-blocked on the RDR-153 production migration completing with
+ * {@code summary.total_failed==0}; until then every FK row carries
+ * {@code convalidated=false} (GROUP C pins this). The orphan RECONCILE
+ * (DELETE genuinely-orphaned / FAIL-LOUD ambiguous, Q5) rides with that
+ * migration where real data exists — it is NOT in P1a.
+ *
+ * <p>Conventions mirror {@link CollectionRegistryFkTest}: {@link PgContainerHelper#start()},
+ * master changelog via Liquibase, PER_CLASS lifecycle, {@code @Order}, AssertJ +
+ * {@code assertThrows(PSQLException.class)}, superuser for direct inserts.
+ *
+ * <p>Verified schema facts (do not re-derive; source = Liquibase baselines):
+ * <ul>
+ *   <li>document_aspects(tenant_id TEXT, collection TEXT NOT NULL, doc_id TEXT NOT NULL DEFAULT '', source_path, ...)
+ *       UNIQUE (tenant_id, collection, source_path) — aspects-001-baseline.xml changeset 1</li>
+ *   <li>aspect_extraction_queue(tenant_id, collection TEXT NOT NULL, doc_id TEXT NOT NULL DEFAULT '', source_path, status, ...)
+ *       UNIQUE (tenant_id, collection, source_path) — aspects-001-baseline.xml changeset 5</li>
+ *   <li>document_highlights(tenant_id, doc_id TEXT NOT NULL, collection TEXT NULLABLE, ...)
+ *       UNIQUE (tenant_id, doc_id) — aspects-001-baseline.xml changeset 3</li>
+ *   <li>topics(id BIGSERIAL PK, tenant_id, collection TEXT NOT NULL, label, doc_count, ...) — taxonomy-001-baseline.xml changeset 1</li>
+ *   <li>taxonomy_meta(tenant_id, collection TEXT NOT NULL, ...; PK (tenant_id, collection)) — taxonomy-001-baseline.xml changeset 2</li>
+ *   <li>catalog_collections PK (tenant_id, name) — catalog-001-baseline.xml changeset 5</li>
+ * </ul>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CollectionRegistryFkExtraTest {
+
+    // ── Constraint names (fixed contract; fk-003 uses exactly these) ───────────
+    private static final String FK_DOC_ASPECTS  = "document_aspects_collection_fk";
+    private static final String FK_ASPECT_QUEUE = "aspect_extraction_queue_collection_fk";
+    private static final String FK_TOPICS       = "topics_collection_fk";
+    private static final String FK_TAX_META     = "taxonomy_meta_collection_fk";
+    private static final String FK_DOC_HL       = "document_highlights_collection_fk";
+
+    private static final List<String> ALL_FIVE_FK_NAMES = List.of(
+            FK_DOC_ASPECTS, FK_ASPECT_QUEUE, FK_TOPICS, FK_TAX_META, FK_DOC_HL);
+
+    private static final String TENANT_A = "crfkx-tenant-a";
+    private static final String TENANT_B = "crfkx-tenant-b";
+
+    PostgreSQLContainer<?> pg;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
+                "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            var lb = new Liquibase(
+                "db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(
+                    new JdbcConnection(su)));
+            lb.update(new Contexts());
+        }
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (pg != null) pg.stop();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP A — FK rejects unregistered (tenant_id, collection)
+    // EXPECTED RED until fk-003 lands.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(10)
+    void documentAspects_unregisteredCollection_rejected() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name) " +
+                    "VALUES ('" + TENANT_A + "', 'unreg-aspect-col', '/p/a.md', NOW(), 'v1', 'test')"));
+            assertThat(ex.getMessage())
+                .as("document_aspects_collection_fk must reject unregistered collection")
+                .containsIgnoringCase(FK_DOC_ASPECTS);
+        }
+    }
+
+    @Test @Order(11)
+    void aspectQueue_unregisteredCollection_rejected() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.aspect_extraction_queue (tenant_id, collection, source_path, status, enqueued_at) " +
+                    "VALUES ('" + TENANT_A + "', 'unreg-queue-col', '/p/q.md', 'pending', NOW())"));
+            assertThat(ex.getMessage())
+                .as("aspect_extraction_queue_collection_fk must reject unregistered collection")
+                .containsIgnoringCase(FK_ASPECT_QUEUE);
+        }
+    }
+
+    @Test @Order(12)
+    void topics_unregisteredCollection_rejected() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.topics (tenant_id, label, collection, doc_count, created_at, review_status) " +
+                    "VALUES ('" + TENANT_A + "', 'topic-x', 'unreg-topic-col', 0, NOW(), 'pending')"));
+            assertThat(ex.getMessage())
+                .as("topics_collection_fk must reject unregistered collection")
+                .containsIgnoringCase(FK_TOPICS);
+        }
+    }
+
+    @Test @Order(13)
+    void taxonomyMeta_unregisteredCollection_rejected() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.taxonomy_meta (tenant_id, collection) " +
+                    "VALUES ('" + TENANT_A + "', 'unreg-meta-col')"));
+            assertThat(ex.getMessage())
+                .as("taxonomy_meta_collection_fk must reject unregistered collection")
+                .containsIgnoringCase(FK_TAX_META);
+        }
+    }
+
+    @Test @Order(14)
+    void documentHighlights_unregisteredCollection_rejected() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            // Parent catalog_documents row so the doc-rooted fk-001 FK is satisfied and the
+            // ONLY remaining violation is the collection FK under test.
+            insertCatalogDocument(su, TENANT_A, "hl-doc-unreg");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.document_highlights (tenant_id, doc_id, collection, ingested_at) " +
+                    "VALUES ('" + TENANT_A + "', 'hl-doc-unreg', 'unreg-hl-col', NOW())"));
+            assertThat(ex.getMessage())
+                .as("document_highlights_collection_fk must reject unregistered non-null collection")
+                .containsIgnoringCase(FK_DOC_HL);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP B — control: registered collection accepted; null highlight collection accepted
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(20)
+    void documentAspects_registeredCollection_accepted() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "ctrl-aspect-col");
+            su.createStatement().execute(
+                "INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name) " +
+                "VALUES ('" + TENANT_A + "', 'ctrl-aspect-col', '/p/ctrl.md', NOW(), 'v1', 'test')");
+            assertThat(count(su,
+                "SELECT COUNT(*) FROM nexus.document_aspects " +
+                "WHERE tenant_id='" + TENANT_A + "' AND collection='ctrl-aspect-col'"))
+                .as("registered document_aspects insert must succeed").isEqualTo(1);
+        }
+    }
+
+    @Test @Order(21)
+    void topics_registeredCollection_accepted() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "ctrl-topic-col");
+            su.createStatement().execute(
+                "INSERT INTO nexus.topics (tenant_id, label, collection, doc_count, created_at, review_status) " +
+                "VALUES ('" + TENANT_A + "', 'topic-ctrl', 'ctrl-topic-col', 0, NOW(), 'pending')");
+            assertThat(count(su,
+                "SELECT COUNT(*) FROM nexus.topics " +
+                "WHERE tenant_id='" + TENANT_A + "' AND collection='ctrl-topic-col'"))
+                .as("registered topics insert must succeed").isEqualTo(1);
+        }
+    }
+
+    @Test @Order(22)
+    void documentHighlights_nullCollection_accepted() throws Exception {
+        // MATCH SIMPLE: a null FK column escapes the constraint. Document-rooted highlights
+        // with no collection tag rely on the fk-001 catalog_documents cascade, not this FK.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCatalogDocument(su, TENANT_A, "hl-doc-null");
+            su.createStatement().execute(
+                "INSERT INTO nexus.document_highlights (tenant_id, doc_id, collection, ingested_at) " +
+                "VALUES ('" + TENANT_A + "', 'hl-doc-null', NULL, NOW())");
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT collection FROM nexus.document_highlights " +
+                "WHERE tenant_id='" + TENANT_A + "' AND doc_id='hl-doc-null'");
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString("collection"))
+                .as("NULL highlight collection must be accepted (MATCH SIMPLE)").isNull();
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP C — NOT VALID pin: all five FK rows exist with convalidated=false.
+    // P1b's VALIDATE CONSTRAINT will flip these to true and update this assertion.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(30)
+    void allFiveExtraCollectionFks_existAndAreNotValid() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            for (String fkName : ALL_FIVE_FK_NAMES) {
+                ResultSet rs = su.createStatement().executeQuery(
+                    "SELECT convalidated FROM pg_constraint c " +
+                    "JOIN pg_namespace n ON n.oid = c.connamespace " +
+                    "WHERE c.contype = 'f' AND c.conname = '" + fkName + "' AND n.nspname = 'nexus'");
+                assertThat(rs.next())
+                    .as("FK constraint " + fkName + " must exist in pg_constraint").isTrue();
+                assertThat(rs.getBoolean("convalidated"))
+                    .as("FK " + fkName + " must be NOT VALID (convalidated=false) until P1b VALIDATE runs")
+                    .isFalse();
+            }
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP D — ON DELETE RESTRICT: collection delete blocked while a child row lives.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(40)
+    void deleteCollection_withLiveAspectRow_isRejected() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "restrict-aspect-col");
+            su.createStatement().execute(
+                "INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name) " +
+                "VALUES ('" + TENANT_A + "', 'restrict-aspect-col', '/p/r.md', NOW(), 'v1', 'test')");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "DELETE FROM nexus.catalog_collections " +
+                    "WHERE tenant_id='" + TENANT_A + "' AND name='restrict-aspect-col'"));
+            assertThat(ex.getMessage())
+                .as("ON DELETE RESTRICT must block deleting a collection with live document_aspects rows")
+                .containsIgnoringCase(FK_DOC_ASPECTS);
+        }
+    }
+
+    @Test @Order(41)
+    void deleteCollection_afterAspectDeleted_succeeds() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_A, "restrict-aspect-after");
+            su.createStatement().execute(
+                "INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name) " +
+                "VALUES ('" + TENANT_A + "', 'restrict-aspect-after', '/p/after.md', NOW(), 'v1', 'test')");
+            su.createStatement().execute(
+                "DELETE FROM nexus.document_aspects " +
+                "WHERE tenant_id='" + TENANT_A + "' AND collection='restrict-aspect-after'");
+            int deleted = su.createStatement().executeUpdate(
+                "DELETE FROM nexus.catalog_collections " +
+                "WHERE tenant_id='" + TENANT_A + "' AND name='restrict-aspect-after'");
+            assertThat(deleted)
+                .as("collection delete must succeed once referencing aspect rows are removed")
+                .isEqualTo(1);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP E — cross-tenant FK isolation (composite (tenant_id, collection)).
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(50)
+    void documentAspects_crossTenantCollection_rejected() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            insertCollection(su, TENANT_B, "xtenant-aspect-col-b");
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name) " +
+                    "VALUES ('" + TENANT_A + "', 'xtenant-aspect-col-b', '/p/x.md', NOW(), 'v1', 'test')"));
+            assertThat(ex.getMessage())
+                .as("composite FK must reject cross-tenant collection reference in document_aspects")
+                .containsIgnoringCase(FK_DOC_ASPECTS);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP F — backfill stub-register (fk-003-0) exact-count behavior.
+    //
+    // The master changelog applies the backfill against an EMPTY DB (no-op), then
+    // adds the NOT VALID FKs. To exercise the backfill SQL against real orphan rows
+    // we DROP the five FKs (so orphan inserts are allowed), seed orphans, then run
+    // the SAME backfill SQL fk-003-0 ships and assert EXACT stub counts:
+    //   - DISTINCT (tenant_id, collection) per source table
+    //   - ON CONFLICT DO NOTHING dedup across tables and against pre-existing rows
+    //   - document_highlights: only non-null, non-empty collection contributes
+    // The SQL below MUST stay identical to changeset fk-003-0-backfill-stubs.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(60)
+    void backfillStubs_registersExactlyTheReferencedCollections() throws Exception {
+        final String T = "crfkx-backfill-tenant";
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+
+            // Drop the five FKs so orphan child rows can be seeded.
+            for (String fk : List.of(
+                    "document_aspects",        // table → constraint <table>_collection_fk
+                    "aspect_extraction_queue",
+                    "topics",
+                    "taxonomy_meta",
+                    "document_highlights")) {
+                su.createStatement().execute(
+                    "ALTER TABLE nexus." + fk + " DROP CONSTRAINT IF EXISTS " + fk + "_collection_fk");
+            }
+
+            // Seed orphan rows referencing collections NOT in catalog_collections.
+            // colA referenced by 3 tables (must dedup to ONE stub). colB by queue only.
+            // colC by topics only. colD by taxonomy_meta only. colE (non-null) by a highlight.
+            // A null-collection highlight must contribute NOTHING.
+            su.createStatement().execute(
+                "INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name) VALUES " +
+                "('" + T + "', 'bf-colA', '/a/1.md', NOW(), 'v1', 'test'), ('" + T + "', 'bf-colA', '/a/2.md', NOW(), 'v1', 'test')");
+            su.createStatement().execute(
+                "INSERT INTO nexus.aspect_extraction_queue (tenant_id, collection, source_path, status, enqueued_at) VALUES " +
+                "('" + T + "', 'bf-colA', '/a/1.md', 'pending', NOW()), ('" + T + "', 'bf-colB', '/b/1.md', 'pending', NOW())");
+            su.createStatement().execute(
+                "INSERT INTO nexus.topics (tenant_id, label, collection, doc_count, created_at, review_status) VALUES " +
+                "('" + T + "', 'tA', 'bf-colA', 0, NOW(), 'pending'), " +
+                "('" + T + "', 'tC', 'bf-colC', 0, NOW(), 'pending')");
+            su.createStatement().execute(
+                "INSERT INTO nexus.taxonomy_meta (tenant_id, collection) VALUES ('" + T + "', 'bf-colD')");
+            // Parent docs for the highlight rows (doc-rooted fk-001 FK).
+            insertCatalogDocument(su, T, "bf-hl-1");
+            insertCatalogDocument(su, T, "bf-hl-2");
+            insertCatalogDocument(su, T, "bf-hl-3");
+            su.createStatement().execute(
+                "INSERT INTO nexus.document_highlights (tenant_id, doc_id, collection, ingested_at) VALUES " +
+                "('" + T + "', 'bf-hl-1', 'bf-colE', NOW()), ('" + T + "', 'bf-hl-2', NULL, NOW()), ('" + T + "', 'bf-hl-3', '', NOW())");
+
+            assertThat(count(su,
+                "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + T + "'"))
+                .as("no stubs registered for backfill tenant before backfill").isEqualTo(0);
+
+            // ── fk-003-0-backfill-stubs SQL (MUST match the changeset verbatim) ──
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+                "SELECT DISTINCT tenant_id, collection FROM nexus.document_aspects " +
+                "ON CONFLICT (tenant_id, name) DO NOTHING");
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+                "SELECT DISTINCT tenant_id, collection FROM nexus.aspect_extraction_queue " +
+                "ON CONFLICT (tenant_id, name) DO NOTHING");
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+                "SELECT DISTINCT tenant_id, collection FROM nexus.topics " +
+                "ON CONFLICT (tenant_id, name) DO NOTHING");
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+                "SELECT DISTINCT tenant_id, collection FROM nexus.taxonomy_meta " +
+                "ON CONFLICT (tenant_id, name) DO NOTHING");
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+                "SELECT DISTINCT tenant_id, collection FROM nexus.document_highlights " +
+                "WHERE collection IS NOT NULL AND collection != '' " +
+                "ON CONFLICT (tenant_id, name) DO NOTHING");
+
+            // Exactly five distinct collections registered: colA, colB, colC, colD, colE.
+            assertThat(count(su,
+                "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + T + "'"))
+                .as("backfill must stub-register exactly 5 distinct collections (colA deduped, null/empty highlight skipped)")
+                .isEqualTo(5);
+            assertThat(count(su,
+                "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + T + "' " +
+                "AND name IN ('bf-colA','bf-colB','bf-colC','bf-colD','bf-colE')"))
+                .as("the 5 expected collection names must each be registered exactly once")
+                .isEqualTo(5);
+        }
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private static void insertCollection(Connection su, String tenantId, String name) throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+            "VALUES ('" + tenantId + "', '" + name + "') " +
+            "ON CONFLICT (tenant_id, name) DO NOTHING");
+    }
+
+    private static void insertCatalogDocument(Connection su, String tenantId, String tumbler) throws Exception {
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title) " +
+            "VALUES ('" + tenantId + "', '" + tumbler + "', 'Test Doc " + tumbler + "') " +
+            "ON CONFLICT (tenant_id, tumbler) DO NOTHING");
+    }
+
+    private static int count(Connection su, String sql) throws Exception {
+        ResultSet rs = su.createStatement().executeQuery(sql);
+        rs.next();
+        return rs.getInt(1);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/CollectionRegistryFkTest.java
+++ b/service/src/test/java/dev/nexus/service/CollectionRegistryFkTest.java
@@ -358,8 +358,12 @@ class CollectionRegistryFkTest {
 
             // Fixture: catalog_documents row (required by fk-001 (tenant_id,doc_id) FK)
             insertCatalogDocument(su, TENANT_A, "casc-doc-1");
-            // Fixture: topics row (required by topic_id FK)
-            insertTopic(su, TENANT_A, 8001L, "casc-topic", "casc__old");
+            // Fixture: topics row (required only for the topic_id FK). Its OWN collection must
+            // NOT be the collection under rename — RDR-164 P1a's topics_collection_fk is
+            // ON UPDATE NO ACTION, so a topic sitting on 'casc__old' would block the parent
+            // rename. The topic's home collection is incidental to this test, which targets
+            // topic_assignments.source_collection's ON UPDATE CASCADE specifically.
+            insertTopic(su, TENANT_A, 8001L, "casc-topic", "casc__topic_home");
             // Fixture: registered collection 'casc__old'
             insertCollection(su, TENANT_A, "casc__old");
             // Fixture: topic_assignment with source_collection='casc__old'
@@ -419,12 +423,15 @@ class CollectionRegistryFkTest {
         try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
             insertCatalogDocument(su, TENANT_A, "unreg-src-doc");
-            insertTopic(su, TENANT_A, 8003L, "unreg-src-topic", "unreg-src-col");
+            // insertTopic registers the topic's own collection (RDR-164 P1a topics_collection_fk),
+            // so the assignment must reference a DISTINCT, still-unregistered source_collection to
+            // preserve this test's intent (non-null source_collection absent from catalog_collections).
+            insertTopic(su, TENANT_A, 8003L, "unreg-src-topic", "unreg-src-topic-col");
             PSQLException ex = assertThrows(PSQLException.class, () ->
                 su.createStatement().execute(
                     "INSERT INTO nexus.topic_assignments " +
                     "(tenant_id, doc_id, topic_id, assigned_by, source_collection, assigned_at) VALUES " +
-                    "('" + TENANT_A + "', 'unreg-src-doc', 8003, 'hdbscan', 'unreg-src-col', NOW())")
+                    "('" + TENANT_A + "', 'unreg-src-doc', 8003, 'hdbscan', 'truly-unreg-src-col', NOW())")
             );
             assertThat(ex.getMessage())
                 .as("topic_assignments_collection_fk must reject non-null source_collection not in catalog_collections")
@@ -1160,6 +1167,12 @@ class CollectionRegistryFkTest {
      */
     private static void insertTopic(Connection su, String tenantId, long id, String label, String collection)
             throws Exception {
+        // RDR-164 P1a: topics now carries topics_collection_fk → catalog_collections.
+        // Register the topic's collection first so the fixture satisfies the NOT VALID FK.
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+            "VALUES ('" + tenantId + "', '" + collection + "') " +
+            "ON CONFLICT (tenant_id, name) DO NOTHING");
         su.createStatement().execute(
             "INSERT INTO nexus.topics (id, tenant_id, label, collection, doc_count, created_at, review_status) " +
             "VALUES (" + id + ", '" + tenantId + "', '" + label + "', '" + collection + "', 0, NOW(), 'pending') " +

--- a/service/src/test/java/dev/nexus/service/ForeignKeyConstraintTest.java
+++ b/service/src/test/java/dev/nexus/service/ForeignKeyConstraintTest.java
@@ -124,6 +124,25 @@ class ForeignKeyConstraintTest {
                 "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
         }
 
+        // Phase 3.5 (RDR-164 P1a): register the collections these fixtures reference so the
+        // new fk-003 collection FKs on document_aspects / aspect_extraction_queue / topics
+        // are satisfied. These tests exercise the fk-001 document-rooted FKs, not collection
+        // registration, so the collections are pre-seeded here rather than per-insert.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            String[][] seeds = {
+                {TENANT_A, "knowledge__a"}, {TENANT_A, "knowledge__b"}, {TENANT_A, "knowledge__c"},
+                {TENANT_A, "knowledge__d"}, {TENANT_A, "knowledge__q"}, {TENANT_A, "knowledge__qq"},
+                {TENANT_A, "knowledge__rls"}, {TENANT_A, "col-a"}, {TENANT_A, "col-rls"},
+                {TENANT_B, "knowledge__x"}, {TENANT_B, "knowledge__y"},
+            };
+            for (String[] s : seeds) {
+                su.createStatement().execute(
+                    "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('"
+                    + s[0] + "', '" + s[1] + "') ON CONFLICT (tenant_id, name) DO NOTHING");
+            }
+        }
+
         // HikariCP as svc role (non-superuser, subject to RLS)
         var config = new com.zaxxer.hikari.HikariConfig();
         config.setJdbcUrl(pg.getJdbcUrl());
@@ -751,6 +770,10 @@ class ForeignKeyConstraintTest {
      */
     private static void insertTopic(Connection su, String tenantId, long id, String label, String collection)
             throws Exception {
+        // RDR-164 P1a: register the topic's collection (topics_collection_fk).
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + tenantId + "', '"
+            + collection + "') ON CONFLICT (tenant_id, name) DO NOTHING");
         // Insert by id using the sequence; supply literal id via nextval override
         su.createStatement().execute(
             "INSERT INTO nexus.topics (id, tenant_id, label, collection, doc_count, created_at, review_status) " +

--- a/service/src/test/java/dev/nexus/service/ReadShapeViewsTest.java
+++ b/service/src/test/java/dev/nexus/service/ReadShapeViewsTest.java
@@ -137,6 +137,10 @@ class ReadShapeViewsTest {
 
 
     private static void seedTopic(Connection su, String tenant, String label, String coll) throws Exception {
+        // RDR-164 P1a: register the collection (topics_collection_fk).
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + tenant + "', '"
+            + coll + "') ON CONFLICT (tenant_id, name) DO NOTHING");
         su.createStatement().execute(
             "INSERT INTO nexus.topics (tenant_id, label, collection, doc_count, created_at, review_status) "
             + "VALUES ('" + tenant + "', '" + label + "', '" + coll + "', 0, now(), 'pending')");
@@ -174,9 +178,10 @@ class ReadShapeViewsTest {
     }
 
     private static void seedColl(Connection su, String tenant, String name) throws Exception {
+        // Idempotent: seedTopic (RDR-164 P1a) may have already stub-registered this collection.
         su.createStatement().execute(
             "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('"
-            + tenant + "', '" + name + "')");
+            + tenant + "', '" + name + "') ON CONFLICT (tenant_id, name) DO NOTHING");
     }
 
     private static void seedChunk(Connection su, String tenant, String docId, int pos, String chash) throws Exception {

--- a/service/src/test/java/dev/nexus/service/SoftDeleteTest.java
+++ b/service/src/test/java/dev/nexus/service/SoftDeleteTest.java
@@ -1122,6 +1122,10 @@ class SoftDeleteTest {
      */
     private static void insertAspectRow(Connection su, String tenantId, String tumbler,
                                          String collection, String sourcePath) throws Exception {
+        // RDR-164 P1a: register the collection (document_aspects_collection_fk).
+        su.createStatement().execute(
+            "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + tenantId + "', '"
+            + collection + "') ON CONFLICT (tenant_id, name) DO NOTHING");
         su.createStatement().execute(
             "INSERT INTO nexus.document_aspects " +
             "(tenant_id, collection, source_path, extracted_at, model_version, extractor_name, doc_id) " +

--- a/service/src/test/java/dev/nexus/service/TaxonomyPersistHandlerTest.java
+++ b/service/src/test/java/dev/nexus/service/TaxonomyPersistHandlerTest.java
@@ -84,6 +84,10 @@ class TaxonomyPersistHandlerTest {
             }
             su.createStatement().execute("GRANT USAGE ON SEQUENCE nexus.topics_id_seq TO " + SVC_ROLE);
             su.createStatement().execute("GRANT SELECT ON nexus.catalog_documents TO " + SVC_ROLE);
+            // RDR-164 P1a: topics/taxonomy_meta writes ensure-register their collection
+            // (catalog_collections stub) to satisfy the new fk-003 collection FKs.
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus.catalog_collections TO " + SVC_ROLE);
             su.createStatement().execute(
                 "GRANT SELECT ON nexus.service_tokens, nexus.session_tokens TO " + SVC_ROLE);
             su.createStatement().execute(

--- a/service/src/test/java/dev/nexus/service/UpdatedAtTriggerTest.java
+++ b/service/src/test/java/dev/nexus/service/UpdatedAtTriggerTest.java
@@ -101,6 +101,10 @@ class UpdatedAtTriggerTest {
             su.setAutoCommit(true);
             // Insert with a deliberately OLD updated_at (INSERT does not fire the
             // BEFORE UPDATE trigger), then UPDATE a single column.
+            // RDR-164 P1a: register collection 'c' (topics_collection_fk).
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + TENANT + "', 'c') "
+                + "ON CONFLICT (tenant_id, name) DO NOTHING");
             su.createStatement().execute(
                 "INSERT INTO nexus.topics (tenant_id, label, collection, doc_count, created_at, review_status, updated_at) "
                 + "VALUES ('" + TENANT + "', 'uat-topic', 'c', 0, now(), 'pending', '" + OLD_TS + "')");
@@ -122,6 +126,10 @@ class UpdatedAtTriggerTest {
     void documentAspects_partialUpdate_movesUpdatedAt() throws Exception {
         try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
+            // RDR-164 P1a: register collection 'c' (document_aspects_collection_fk).
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + TENANT + "', 'c') "
+                + "ON CONFLICT (tenant_id, name) DO NOTHING");
             su.createStatement().execute(
                 "INSERT INTO nexus.document_aspects "
                 + "(tenant_id, collection, source_path, extracted_at, model_version, extractor_name, salient_sentences, updated_at) "


### PR DESCRIPTION
## Summary
RDR-164 P1a — move collection-lifecycle integrity into Postgres for the service path by adding the second wave of collection-registry FKs, and enforce mandatory collection registration on every write/rename path. Also converts the string-SQL "island" in `AspectRepository` + `TaxonomyRepository` to the generated type-safe jOOQ DSL.

`VALIDATE CONSTRAINT` and the Q5 orphan reconcile are **deferred to P1b** (world-blocked on the RDR-153 production migration completing with `total_failed==0` / `nexus-70r3c.3`). This PR ships the deploy-safe NOT-VALID half.

## Schema (`fk-003-collection-registry-extra.xml`, after `fk-002`)
- Stub-register backfill (mirrors `fk-002-0`) across `document_aspects`, `aspect_extraction_queue`, `topics`, `taxonomy_meta`, `document_highlights`.
- Five `(tenant_id, collection) → catalog_collections(tenant_id, name)` FKs, `ON DELETE RESTRICT NOT VALID`. `document_highlights.collection` nullable (MATCH SIMPLE). `ON UPDATE NO ACTION` — header documents the P3 re-home invariant (differs from `fk-002` `topic_assignments` `ON UPDATE CASCADE`).

## Write-path integrity
- `ensureCollectionRegistered` (typed DSL) at all collection-write/rename sites in both repos. The explicit `DELETE WHERE collection` on aspects/queue is retained — doc-less (`doc_id=''`) rows are unreachable by the `fk-001` document cascade (the `nexus-tquoj` orphan class).

## jOOQ DSL conversion
- Full string-SQL → generated typed DSL: `AspectRepository` (39 calls), `TaxonomyRepository` (73 calls). Six `ON CONFLICT DO UPDATE` sites retain minimal `field("…EXCLUDED/GREATEST/CASE…", Type.class)` fragments (no typed jOOQ API for the `EXCLUDED` pseudo-table); annotated as a rename-drift risk. One dynamic multi-row batch insert keeps bound-param SQL.

## Tests
- New `CollectionRegistryFkExtraTest` (reject / accept / NOT-VALID pin / RESTRICT / cross-tenant / backfill exact-count).
- Exact-value `GREATEST(retry_count)` / `LEAST(enqueued_at)` merge assertions (non-vacuous).
- Fixture registration fixes across 8 existing test classes.
- Full `mvn -o test`: **840 tests, 0 failures**.

## Review
Stacked review clean: code-review-expert APPROVED (0 defects); substantive-critic 0 Critical / 4 Significant, all addressed (ON UPDATE invariant doc, two vacuous-test fixes, drift-risk annotations).

Refs nexus-dcqml