### PR TITLE
RDR-164 P2: atomic server-side deleteCollection cascade (closes nexus-tquoj)

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -2,6 +2,22 @@
 // Copyright (c) 2026 Hal Hildebrand. All rights reserved.
 package dev.nexus.service.db;
 
+import static dev.nexus.service.jooq.nexus.Tables.ASPECT_EXTRACTION_QUEUE;
+import static dev.nexus.service.jooq.nexus.Tables.CATALOG_COLLECTIONS;
+import static dev.nexus.service.jooq.nexus.Tables.CATALOG_DOCUMENTS;
+import static dev.nexus.service.jooq.nexus.Tables.CHASH_INDEX;
+import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_1024;
+import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_384;
+import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_768;
+import static dev.nexus.service.jooq.nexus.Tables.DOCUMENT_ASPECTS;
+import static dev.nexus.service.jooq.nexus.Tables.DOCUMENT_HIGHLIGHTS;
+import static dev.nexus.service.jooq.nexus.Tables.TAXONOMY_CENTROIDS_1024;
+import static dev.nexus.service.jooq.nexus.Tables.TAXONOMY_CENTROIDS_384;
+import static dev.nexus.service.jooq.nexus.Tables.TAXONOMY_CENTROIDS_768;
+import static dev.nexus.service.jooq.nexus.Tables.TAXONOMY_META;
+import static dev.nexus.service.jooq.nexus.Tables.TOPICS;
+import static dev.nexus.service.jooq.nexus.Tables.TOPIC_ASSIGNMENTS;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jooq.Condition;
@@ -1132,11 +1148,67 @@ public final class CatalogRepository {
         );
     }
 
-    /** Delete a collection projection row. */
-    public int deleteCollection(String tenant, String name) {
-        return tenantScope.withTenant(tenant, ctx ->
-            ctx.deleteFrom(T_COLLS).where(F_COL_NAME.eq(name)).execute()
-        );
+    /**
+     * Atomically delete a collection and ALL its derived in-Postgres state in ONE
+     * tenant-scoped transaction (RDR-164 P2). Replaces the SQLite-era client-side
+     * {@code purge_collection_cascade} fan-out for the service path: the explicit
+     * ordered DELETE removes every lifecycle table's rows in dependency order, with
+     * the {@code catalog_collections} registry row LAST so the {@code ON DELETE
+     * RESTRICT} child FKs (fk-002 / fk-003) act as a safety net rather than a blocker.
+     *
+     * <p>Order (children → registry): chunks_* → chash_index → topic_assignments →
+     * topics → taxonomy_centroids_* → document_aspects → document_highlights →
+     * aspect_extraction_queue → catalog_documents (fk-001 cascades any doc-rooted
+     * aspect/highlight/queue/manifest remainder) → catalog_collections.
+     *
+     * <p>This is where RDR-164 closes <strong>nexus-tquoj</strong> (the client cascade
+     * never purged {@code aspect_extraction_queue}; the explicit DELETE here catches it,
+     * including doc-less {@code doc_id=''} rows the fk-001 document cascade cannot reach)
+     * and the service-mode <strong>nexus-cugrk</strong> centroid leak ({@code
+     * taxonomy_centroids_*} have no FK to {@code topics}, CA-6 — purged by explicit
+     * {@code DELETE WHERE collection=?} in the same txn).
+     *
+     * <p>RLS scopes every DELETE to the caller's tenant via the {@code nexus.tenant}
+     * GUC, so a same-named collection under another tenant is untouched. Returns a
+     * per-table deleted-row count map (preserves the {@code CascadeCounts} / CLI-render
+     * + telemetry contract); no {@code failures} list — the operation is all-or-nothing.
+     *
+     * <p>Out of scope (stays client-side, RDR-164 CA-4/CA-5): the {@code pipeline.db}
+     * streaming buffer and the entire local-mode (sqlite/Chroma) cascade.
+     */
+    public Map<String, Integer> deleteCollection(String tenant, String name) {
+        return tenantScope.withTenant(tenant, ctx -> {
+            Map<String, Integer> counts = new LinkedHashMap<>();
+            // 1. T3 chunk vectors (registry children, fk-002 RESTRICT).
+            counts.put("chunks_384",  ctx.deleteFrom(CHUNKS_384).where(CHUNKS_384.COLLECTION.eq(name)).execute());
+            counts.put("chunks_768",  ctx.deleteFrom(CHUNKS_768).where(CHUNKS_768.COLLECTION.eq(name)).execute());
+            counts.put("chunks_1024", ctx.deleteFrom(CHUNKS_1024).where(CHUNKS_1024.COLLECTION.eq(name)).execute());
+            // 2. chash index (physical_collection; fk-002-4 RESTRICT).
+            counts.put("chash_index", ctx.deleteFrom(CHASH_INDEX).where(CHASH_INDEX.PHYSICAL_COLLECTION.eq(name)).execute());
+            // 3. taxonomy: projection assignments by source_collection (fk-002-5 RESTRICT),
+            //    then topics (fk-003 RESTRICT) — deleting topics cascades any remaining
+            //    assignments via topic_assignments.topic_id -> topics(id) ON DELETE CASCADE.
+            counts.put("topic_assignments", ctx.deleteFrom(TOPIC_ASSIGNMENTS).where(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.eq(name)).execute());
+            counts.put("topics", ctx.deleteFrom(TOPICS).where(TOPICS.COLLECTION.eq(name)).execute());
+            // 3b. taxonomy_meta (fk-003-4 RESTRICT; PK (tenant_id, collection) — explicit DELETE).
+            //     topic_links clears via topics(id) ON DELETE CASCADE in step 3, so it needs no row here.
+            counts.put("taxonomy_meta", ctx.deleteFrom(TAXONOMY_META).where(TAXONOMY_META.COLLECTION.eq(name)).execute());
+            // 4. centroids (CA-6: no FK to topics — explicit DELETE; the cugrk fix).
+            counts.put("taxonomy_centroids_384",  ctx.deleteFrom(TAXONOMY_CENTROIDS_384).where(TAXONOMY_CENTROIDS_384.COLLECTION.eq(name)).execute());
+            counts.put("taxonomy_centroids_768",  ctx.deleteFrom(TAXONOMY_CENTROIDS_768).where(TAXONOMY_CENTROIDS_768.COLLECTION.eq(name)).execute());
+            counts.put("taxonomy_centroids_1024", ctx.deleteFrom(TAXONOMY_CENTROIDS_1024).where(TAXONOMY_CENTROIDS_1024.COLLECTION.eq(name)).execute());
+            // 5. aspect family (fk-003 RESTRICT). Explicit collection delete catches
+            //    doc-less (doc_id='') rows fk-001's document cascade cannot reach — the tquoj fix.
+            counts.put("document_aspects",        ctx.deleteFrom(DOCUMENT_ASPECTS).where(DOCUMENT_ASPECTS.COLLECTION.eq(name)).execute());
+            counts.put("document_highlights",     ctx.deleteFrom(DOCUMENT_HIGHLIGHTS).where(DOCUMENT_HIGHLIGHTS.COLLECTION.eq(name)).execute());
+            counts.put("aspect_extraction_queue", ctx.deleteFrom(ASPECT_EXTRACTION_QUEUE).where(ASPECT_EXTRACTION_QUEUE.COLLECTION.eq(name)).execute());
+            // 6. catalog documents for this physical collection; fk-001 cascades any
+            //    doc-rooted aspect/highlight/queue/manifest rows still present.
+            counts.put("catalog_documents", ctx.deleteFrom(CATALOG_DOCUMENTS).where(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION.eq(name)).execute());
+            // 7. registry row LAST (RESTRICT children are now gone).
+            counts.put("catalog_collections", ctx.deleteFrom(CATALOG_COLLECTIONS).where(CATALOG_COLLECTIONS.NAME.eq(name)).execute());
+            return counts;
+        });
     }
 
     /**

--- a/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
@@ -55,6 +55,7 @@ import java.util.*;
  *   GET   /v1/catalog/collections/get    get collection by name
  *   POST  /v1/catalog/collections/supersede supersede collection
  *   POST  /v1/catalog/collections/rename rename collection (cascade)
+ *   POST  /v1/catalog/collections/delete delete collection + cascade all in-PG lifecycle state (RDR-164 P2)
  *   GET   /v1/catalog/coverage            link coverage by content type (nexus-3cwnx)
  *   POST  /v1/catalog/import/owner       ETL import owner
  *   POST  /v1/catalog/import/document    ETL import document
@@ -144,6 +145,7 @@ public final class CatalogHandler implements HttpHandler {
                 case "/collections/get"       -> handleCollectionGet(exchange, tenant, method);
                 case "/collections/supersede" -> handleCollectionSupersede(exchange, tenant, method);
                 case "/collections/rename"    -> handleCollectionRename(exchange, tenant, method);
+                case "/collections/delete"    -> handleCollectionDelete(exchange, tenant, method);
                 case "/collections/for_tuple" -> handleCollectionForTuple(exchange, tenant, method);
                 case "/collections/health"    -> handleCollectionHealth(exchange, tenant, method);
 
@@ -645,6 +647,23 @@ public final class CatalogHandler implements HttpHandler {
         }
         int updated = repo.renameCollection(tenant, oldName, newName);
         HttpUtil.send(exchange, 200, "{\"updated\":" + updated + "}");
+    }
+
+    /**
+     * RDR-164 P2: atomically delete a collection and all its in-Postgres derived state.
+     * Returns per-table deleted-row counts so the client can preserve its CascadeCounts
+     * contract. {@code pipeline.db} and local-mode cascades remain client-side.
+     */
+    private void handleCollectionDelete(HttpExchange exchange, String tenant, String method) throws IOException {
+        if (!"POST".equals(method)) { HttpUtil.send(exchange, 405, "{\"error\":\"method not allowed\"}"); return; }
+        Map<String, Object> body = readBody(exchange);
+        // Accept both "name" (canonical) and "collection" (client compat).
+        String name = body.get("name") instanceof String s ? s : (String) body.get("collection");
+        if (name == null || name.isBlank()) {
+            HttpUtil.send(exchange, 400, "{\"error\":\"name (or collection) required\"}"); return;
+        }
+        Map<String, Integer> counts = repo.deleteCollection(tenant, name);
+        HttpUtil.send(exchange, 200, MAPPER.writeValueAsString(Map.of("deleted", counts)));
     }
 
     private void handleCollectionForTuple(HttpExchange exchange, String tenant, String method) throws IOException {

--- a/service/src/test/java/dev/nexus/service/CatalogDeleteCollectionCascadeTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogDeleteCollectionCascadeTest.java
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import dev.nexus.service.db.CatalogRepository;
+import dev.nexus.service.db.TenantScope;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RDR-164 P2 (bead nexus-ybdoc) — CatalogRepository.deleteCollection ordered-DELETE cascade.
+ *
+ * <p>Verifies the single transactional service-side collection delete: it purges every
+ * in-Postgres lifecycle table in dependency order (registry row last, RESTRICT FKs as a
+ * safety net), returns per-table counts, leaves no orphans, and is tenant-isolated via RLS.
+ * Two regression anchors: nexus-tquoj (aspect_extraction_queue purged, incl. doc-less
+ * NULL-doc_id rows the fk-001 document cascade cannot reach) and nexus-cugrk
+ * (taxonomy_centroids_* purged by collection — no FK to topics).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CatalogDeleteCollectionCascadeTest {
+
+    private static final String TENANT_A = "del-casc-a";
+    private static final String TENANT_B = "del-casc-b";
+    private static final String COLL = "knowledge__del-casc__voyage-context-3__v1";
+    private static final String SVC_ROLE = "svc_del_casc";
+    private static final String SVC_PASS = "svc_del_casc_pass";
+
+    PostgreSQLContainer<?> pg;
+    com.zaxxer.hikari.HikariDataSource svcDs;
+    CatalogRepository repo;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='nexus_svc') THEN "
+                + "CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='" + SVC_ROLE + "') THEN "
+                + "CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            var lb = new Liquibase("db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(su)));
+            lb.update(new Contexts());
+        }
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute("ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+        }
+        var cfg = new com.zaxxer.hikari.HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(4);
+        cfg.setAutoCommit(true);
+        svcDs = new com.zaxxer.hikari.HikariDataSource(cfg);
+        repo = new CatalogRepository(new TenantScope(svcDs));
+
+        // Seed an identical collection under BOTH tenants (superuser bypasses RLS).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            seedFullCollection(su, TENANT_A);
+            seedFullCollection(su, TENANT_B);
+        }
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (svcDs != null) svcDs.close();
+        if (pg != null) pg.stop();
+    }
+
+    @Test @Order(10)
+    void deleteCollection_returnsExactPerTableCounts() {
+        Map<String, Integer> counts = repo.deleteCollection(TENANT_A, COLL);
+        assertThat(counts.get("chunks_384")).as("chunks_384").isEqualTo(2);
+        assertThat(counts.get("chunks_768")).as("chunks_768").isEqualTo(1);
+        assertThat(counts.get("chunks_1024")).as("chunks_1024").isEqualTo(1);
+        assertThat(counts.get("chash_index")).as("chash_index").isEqualTo(2);
+        assertThat(counts.get("topic_assignments")).as("topic_assignments (by source_collection)").isEqualTo(2);
+        assertThat(counts.get("topics")).as("topics").isEqualTo(1);
+        assertThat(counts.get("taxonomy_meta")).as("taxonomy_meta (RESTRICT child)").isEqualTo(1);
+        assertThat(counts.get("taxonomy_centroids_384")).as("centroids_384 (cugrk)").isEqualTo(1);
+        assertThat(counts.get("taxonomy_centroids_768")).as("centroids_768").isEqualTo(1);
+        assertThat(counts.get("taxonomy_centroids_1024")).as("centroids_1024").isEqualTo(1);
+        assertThat(counts.get("document_aspects")).as("document_aspects (incl doc-less)").isEqualTo(2);
+        assertThat(counts.get("document_highlights")).as("document_highlights").isEqualTo(1);
+        assertThat(counts.get("aspect_extraction_queue")).as("aspect_extraction_queue (tquoj, incl doc-less)").isEqualTo(2);
+        assertThat(counts.get("catalog_documents")).as("catalog_documents").isEqualTo(1);
+        assertThat(counts.get("catalog_collections")).as("registry row").isEqualTo(1);
+    }
+
+    @Test @Order(20)
+    void deleteCollection_leavesNoOrphansForTenantA() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            for (String tbl : List.of("chunks_384", "chunks_768", "chunks_1024", "topics", "taxonomy_meta",
+                    "taxonomy_centroids_384", "taxonomy_centroids_768", "taxonomy_centroids_1024",
+                    "document_aspects", "document_highlights", "aspect_extraction_queue")) {
+                assertThat(rows(su, "SELECT COUNT(*) FROM nexus." + tbl
+                    + " WHERE tenant_id='" + TENANT_A + "' AND collection='" + COLL + "'"))
+                    .as("no orphan rows in " + tbl).isZero();
+            }
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.chash_index WHERE tenant_id='" + TENANT_A
+                + "' AND physical_collection='" + COLL + "'")).as("chash_index orphans").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.topic_assignments WHERE tenant_id='" + TENANT_A
+                + "' AND source_collection='" + COLL + "'")).as("assignment orphans").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_documents WHERE tenant_id='" + TENANT_A
+                + "' AND physical_collection='" + COLL + "'")).as("catalog_documents orphans").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_document_chunks WHERE tenant_id='" + TENANT_A
+                + "' AND doc_id='dc-doc-1'")).as("manifest rows cascaded via catalog_documents").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_A
+                + "' AND name='" + COLL + "'")).as("registry row gone").isZero();
+        }
+    }
+
+    @Test @Order(30)
+    void deleteCollection_isTenantIsolated_tenantBUntouched() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_B
+                + "' AND name='" + COLL + "'")).as("tenant B registry intact").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.chunks_384 WHERE tenant_id='" + TENANT_B
+                + "' AND collection='" + COLL + "'")).as("tenant B chunks intact").isEqualTo(2);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.aspect_extraction_queue WHERE tenant_id='" + TENANT_B
+                + "' AND collection='" + COLL + "'")).as("tenant B queue intact").isEqualTo(2);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.taxonomy_centroids_384 WHERE tenant_id='" + TENANT_B
+                + "' AND collection='" + COLL + "'")).as("tenant B centroids intact").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.taxonomy_meta WHERE tenant_id='" + TENANT_B
+                + "' AND collection='" + COLL + "'")).as("tenant B taxonomy_meta intact").isEqualTo(1);
+        }
+    }
+
+    // ── fixture ──────────────────────────────────────────────────────────────
+
+    /** Seed one full collection (all lifecycle tables) for {@code tenant}. Superuser; bypasses RLS. */
+    private static void seedFullCollection(Connection su, String tenant) throws Exception {
+        var st = su.createStatement();
+        st.execute("INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + tenant + "', '" + COLL + "')");
+        // catalog_documents + manifest
+        st.execute("INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title, physical_collection) "
+            + "VALUES ('" + tenant + "', 'dc-doc-1', 'Doc 1', '" + COLL + "')");
+        st.execute("INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash) "
+            + "VALUES ('" + tenant + "', 'dc-doc-1', 0, '" + chash("dcman1") + "')");
+        // chunks: 2/1/1
+        st.execute(chunkInsert(tenant, "chunks_384", 384, "dc384a"));
+        st.execute(chunkInsert(tenant, "chunks_384", 384, "dc384b"));
+        st.execute(chunkInsert(tenant, "chunks_768", 768, "dc768a"));
+        st.execute(chunkInsert(tenant, "chunks_1024", 1024, "dc1024a"));
+        // chash_index: 2
+        st.execute("INSERT INTO nexus.chash_index (tenant_id, chash, physical_collection, created_at) "
+            + "VALUES ('" + tenant + "', '" + chash("dcci1") + "', '" + COLL + "', NOW())");
+        st.execute("INSERT INTO nexus.chash_index (tenant_id, chash, physical_collection, created_at) "
+            + "VALUES ('" + tenant + "', '" + chash("dcci2") + "', '" + COLL + "', NOW())");
+        // topics: 1 (explicit id)
+        long topicId = Math.abs((long) (tenant + COLL).hashCode());
+        st.execute("INSERT INTO nexus.topics (id, tenant_id, label, collection, doc_count, created_at, review_status) "
+            + "VALUES (" + topicId + ", '" + tenant + "', 'topic-dc', '" + COLL + "', 0, NOW(), 'pending')");
+        // taxonomy_meta: 1 (fk-003-4 RESTRICT — must be purged before the registry row)
+        st.execute("INSERT INTO nexus.taxonomy_meta (tenant_id, collection) VALUES ('" + tenant + "', '" + COLL + "')");
+        // topic_assignments: 2, both with source_collection=COLL, referencing the topic
+        st.execute("INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, assigned_by, source_collection, assigned_at) "
+            + "VALUES ('" + tenant + "', 'dc-doc-1', " + topicId + ", 'projection', '" + COLL + "', NOW())");
+        st.execute("INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, assigned_by, source_collection, assigned_at) "
+            + "VALUES ('" + tenant + "', 'dc-doc-2', " + topicId + ", 'projection', '" + COLL + "', NOW())");
+        // centroids: one per dim (cugrk)
+        st.execute("INSERT INTO nexus.taxonomy_centroids_384 (tenant_id, collection, topic_id, embedding) "
+            + "VALUES ('" + tenant + "', '" + COLL + "', " + topicId + ", " + vec(384) + "::vector)");
+        st.execute("INSERT INTO nexus.taxonomy_centroids_768 (tenant_id, collection, topic_id, embedding) "
+            + "VALUES ('" + tenant + "', '" + COLL + "', " + topicId + ", " + vec(768) + "::vector)");
+        st.execute("INSERT INTO nexus.taxonomy_centroids_1024 (tenant_id, collection, topic_id, embedding) "
+            + "VALUES ('" + tenant + "', '" + COLL + "', " + topicId + ", " + vec(1024) + "::vector)");
+        // document_aspects: 2 — one doc-rooted, one DOC-LESS (doc_id=NULL)
+        st.execute("INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name, doc_id) "
+            + "VALUES ('" + tenant + "', '" + COLL + "', '/p/a1.md', NOW(), 'v1', 'docling', 'dc-doc-1')");
+        st.execute("INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name, doc_id) "
+            + "VALUES ('" + tenant + "', '" + COLL + "', '/p/a2.md', NOW(), 'v1', 'docling', NULL)");
+        // document_highlights: 1 (doc-rooted)
+        st.execute("INSERT INTO nexus.document_highlights (tenant_id, doc_id, collection, highlights_md, ingested_at) "
+            + "VALUES ('" + tenant + "', 'dc-doc-1', '" + COLL + "', 'hi', NOW())");
+        // aspect_extraction_queue: 2 — one doc-rooted, one DOC-LESS (doc_id=NULL) = the tquoj orphan class
+        st.execute("INSERT INTO nexus.aspect_extraction_queue (tenant_id, collection, source_path, status, enqueued_at, doc_id) "
+            + "VALUES ('" + tenant + "', '" + COLL + "', '/p/q1.md', 'pending', NOW(), 'dc-doc-1')");
+        st.execute("INSERT INTO nexus.aspect_extraction_queue (tenant_id, collection, source_path, status, enqueued_at, doc_id) "
+            + "VALUES ('" + tenant + "', '" + COLL + "', '/p/q2.md', 'pending', NOW(), NULL)");
+    }
+
+    private static String chunkInsert(String tenant, String table, int dim, String seed) {
+        return "INSERT INTO nexus." + table + " (tenant_id, collection, chash, chunk_text, embedding) "
+            + "VALUES ('" + tenant + "', '" + COLL + "', '" + chash(seed) + "', 'text', " + vec(dim) + "::vector)";
+    }
+
+    private static String vec(int dim) {
+        return IntStream.range(0, dim).mapToObj(i -> "0.1").collect(Collectors.joining(",", "'[", "]'"));
+    }
+
+    private static String chash(String seed) {
+        return (seed.replaceAll("[^0-9a-f]", "a") + "0".repeat(32)).substring(0, 32);
+    }
+
+    private static int rows(Connection su, String sql) throws Exception {
+        var rs = su.createStatement().executeQuery(sql);
+        rs.next();
+        return rs.getInt(1);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/CatalogHandlerDeleteTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogHandlerDeleteTest.java
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.nexus.service.db.TenantConstants;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.sql.Connection;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RDR-164 P2 — HTTP coverage for {@code POST /v1/catalog/collections/delete}
+ * ({@link dev.nexus.service.http.CatalogHandler#handleCollectionDelete}). The repo-level
+ * ordered DELETE is exhaustively covered by {@link CatalogDeleteCollectionCascadeTest};
+ * this exercises the HTTP glue the repo test cannot: the {@code name|collection} alias,
+ * the 400 blank-name guard, the 405 method guard, and the {@code {"deleted": {...}}} shape.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CatalogHandlerDeleteTest {
+
+    private static final String TOKEN = "catalog-delete-handler-token-abc789";
+    private static final String SVC_ROLE = "svc_cat_del_handler";
+    private static final String SVC_PASS = "svc_cat_del_handler_pass";
+    private static final String TENANT = TenantConstants.DEFAULT_TENANT;
+    private static final TypeReference<Map<String, Object>> MAP_T = new TypeReference<>() {};
+
+    PostgreSQLContainer<?> pg;
+    NexusService service;
+    HttpClient http;
+    com.zaxxer.hikari.HikariDataSource svcDs;
+    ObjectMapper mapper;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        mapper = new ObjectMapper();
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='" + SVC_ROLE + "') THEN "
+                + "CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "'; END IF; END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='nexus_svc') THEN "
+                + "CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass'; END IF; END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            var lb = new Liquibase("db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(su)));
+            lb.update(new Contexts());
+        }
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label) VALUES ('"
+                + dev.nexus.service.db.TokenHashing.sha256Hex(TOKEN)
+                + "', '" + TENANT + "', 'test-bound') ON CONFLICT (token_hash) DO NOTHING");
+            su.createStatement().execute("ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+            // Seed two registry rows to delete (one per route-shape test).
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + TENANT + "', 'hdel__by-name')");
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + TENANT + "', 'hdel__by-alias')");
+        }
+        var cfg = new com.zaxxer.hikari.HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(4);
+        cfg.setAutoCommit(true);
+        svcDs = new com.zaxxer.hikari.HikariDataSource(cfg);
+        service = new NexusService(0, TOKEN, svcDs);
+        service.start();
+        http = HttpClient.newHttpClient();
+    }
+
+    @AfterAll
+    void stopAll() throws Exception {
+        if (service != null) service.stop();
+        if (svcDs != null) svcDs.close();
+        if (pg != null) pg.stop();
+    }
+
+    @Test
+    void post_byName_returns200WithDeletedCounts() throws Exception {
+        var resp = post("/v1/catalog/collections/delete", "{\"name\":\"hdel__by-name\"}");
+        assertThat(resp.statusCode()).isEqualTo(200);
+        var body = mapper.readValue(resp.body(), MAP_T);
+        assertThat(body).containsKey("deleted");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> deleted = (Map<String, Object>) body.get("deleted");
+        assertThat(((Number) deleted.get("catalog_collections")).intValue())
+            .as("registry row deleted via HTTP").isEqualTo(1);
+    }
+
+    @Test
+    void post_collectionAlias_returns200() throws Exception {
+        // The handler accepts "collection" as an alias for "name".
+        var resp = post("/v1/catalog/collections/delete", "{\"collection\":\"hdel__by-alias\"}");
+        assertThat(resp.statusCode()).isEqualTo(200);
+        var body = mapper.readValue(resp.body(), MAP_T);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> deleted = (Map<String, Object>) body.get("deleted");
+        assertThat(((Number) deleted.get("catalog_collections")).intValue())
+            .as("alias 'collection' resolved").isEqualTo(1);
+    }
+
+    @Test
+    void post_blankName_returns400() throws Exception {
+        var resp = post("/v1/catalog/collections/delete", "{\"name\":\"\"}");
+        assertThat(resp.statusCode()).isEqualTo(400);
+    }
+
+    @Test
+    void post_missingName_returns400() throws Exception {
+        var resp = post("/v1/catalog/collections/delete", "{}");
+        assertThat(resp.statusCode()).isEqualTo(400);
+    }
+
+    @Test
+    void get_returns405() throws Exception {
+        var req = HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + service.getPort() + "/v1/catalog/collections/delete"))
+            .header("Authorization", "Bearer " + TOKEN)
+            .header("X-Nexus-Tenant", TENANT)
+            .GET().build();
+        var resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        assertThat(resp.statusCode()).isEqualTo(405);
+    }
+
+    private HttpResponse<String> post(String path, String body) throws Exception {
+        var req = HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + service.getPort() + path))
+            .header("Authorization", "Bearer " + TOKEN)
+            .header("X-Nexus-Tenant", TENANT)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+        return http.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -211,6 +211,20 @@ class HttpCatalogClient:
             return []
         return [_to_entry(d) for d in result.get("documents", []) if d.get("tumbler")]
 
+    def delete_collection(self, name: str) -> dict[str, int]:
+        """RDR-164 P2: atomically delete a collection + all its in-Postgres
+        derived state via the service's single transactional deleteCollection.
+
+        Returns the per-table deleted-row count map (``chunks_384``,
+        ``chash_index``, ``topic_assignments``, ``topics``,
+        ``taxonomy_centroids_*``, ``document_aspects``, ``document_highlights``,
+        ``aspect_extraction_queue``, ``catalog_documents``,
+        ``catalog_collections``). ``pipeline.db`` and the local-mode cascade
+        stay client-side (see ``purge_collection_cascade``).
+        """
+        result = self._post("/collections/delete", {"name": name})
+        return (result or {}).get("deleted", {}) or {}
+
     # ══════════════════════════════════════════════════════════════════════════
     # OWNERS
     # ══════════════════════════════════════════════════════════════════════════

--- a/src/nexus/db/collection_purge.py
+++ b/src/nexus/db/collection_purge.py
@@ -44,6 +44,22 @@ class CascadeCounts:
     failures: list[str] = field(default_factory=list)
 
 
+def _purge_pipeline_db(name: str, counts: CascadeCounts) -> CascadeCounts:
+    """Delete streaming-pipeline rows for *name* (client-side in BOTH modes — the
+    pipeline buffer is local SQLite per RDR-164 CA-4). Best-effort; records the
+    count on success and a failure message otherwise. Returns *counts*."""
+    try:
+        from nexus.pipeline_buffer import PIPELINE_DB_PATH, PipelineDB
+
+        counts.pipeline_rows_deleted = PipelineDB(
+            PIPELINE_DB_PATH
+        ).delete_pipeline_data_for_collection(name)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("purge_cascade_pipeline_failed", collection=name, error=str(exc))
+        counts.failures.append(f"pipeline-state cleanup failed: {exc}")
+    return counts
+
+
 def purge_collection_cascade(db: object, name: str) -> CascadeCounts:
     """Delete T3 collection *name* and cascade-purge all derived state.
 
@@ -52,9 +68,48 @@ def purge_collection_cascade(db: object, name: str) -> CascadeCounts:
     collection (``t3_absent=True``) and still runs the cascade so a prior
     half-delete is cleaned up.
     """
-    from chromadb.errors import NotFoundError as _ChromaNotFoundError
-
     counts = CascadeCounts()
+
+    from nexus.db.storage_mode import StorageBackend, storage_backend_for
+
+    if storage_backend_for("catalog") == StorageBackend.SERVICE:
+        # RDR-164 P2: in service mode the entire in-Postgres cascade (T3 chunks,
+        # chash index, taxonomy topics/assignments/centroids, aspect family, and
+        # the catalog documents + registry row) is ONE atomic transaction on the
+        # Java service. Fold it into a single call instead of fanning out to
+        # per-store endpoints (which left orphans — nexus-tquoj/cugrk). Only
+        # pipeline.db (below) stays client-side (CA-4).
+        try:
+            from nexus.catalog.factory import make_catalog_reader
+
+            client = make_catalog_reader()
+            if client is None:  # service mode always returns a client; guard for a clear error
+                raise RuntimeError("catalog service client unavailable")
+            deleted = client.delete_collection(name)  # type: ignore[attr-defined]
+            # Preserve the local fan-out's taxonomy dict shape ({topics, assignments,
+            # links, meta}) so the CLI render (commands/collection.py) does not KeyError;
+            # add centroids (purged here, absent from the local path).
+            counts.taxonomy = {
+                "topics": deleted.get("topics", 0),
+                "assignments": deleted.get("topic_assignments", 0),
+                "links": 0,
+                "meta": deleted.get("taxonomy_meta", 0),
+                "centroids": (
+                    deleted.get("taxonomy_centroids_384", 0)
+                    + deleted.get("taxonomy_centroids_768", 0)
+                    + deleted.get("taxonomy_centroids_1024", 0)
+                ),
+            }
+            counts.chash_deleted = deleted.get("chash_index", 0)
+            counts.catalog_docs_deleted = deleted.get("catalog_documents", 0)
+            counts.catalog_projection_deleted = deleted.get("catalog_collections", 0)
+        except Exception as exc:  # noqa: BLE001 — best-effort, atomic on the service side
+            _log.warning("purge_cascade_service_failed", collection=name, error=str(exc))
+            counts.failures.append(f"service deleteCollection failed: {exc}")
+        return _purge_pipeline_db(name, counts)
+
+    # ── Local (sqlite/Chroma) mode: client-side fan-out (CA-5) ───────────────
+    from chromadb.errors import NotFoundError as _ChromaNotFoundError
 
     try:
         db.delete_collection(name)  # type: ignore[attr-defined]
@@ -77,15 +132,7 @@ def purge_collection_cascade(db: object, name: str) -> CascadeCounts:
         counts.failures.append(f"taxonomy/chash cascade failed: {exc}")
 
     # Streaming-pipeline rows (otherwise the next index returns skip/0-chunks).
-    try:
-        from nexus.pipeline_buffer import PIPELINE_DB_PATH, PipelineDB
-
-        counts.pipeline_rows_deleted = PipelineDB(
-            PIPELINE_DB_PATH
-        ).delete_pipeline_data_for_collection(name)
-    except Exception as exc:  # noqa: BLE001
-        _log.warning("purge_cascade_pipeline_failed", collection=name, error=str(exc))
-        counts.failures.append(f"pipeline-state cleanup failed: {exc}")
+    _purge_pipeline_db(name, counts)
 
     # Catalog: document rows pointing at the gone collection + projection row.
     try:

--- a/tests/test_collection_purge.py
+++ b/tests/test_collection_purge.py
@@ -12,6 +12,7 @@ import chromadb
 import pytest
 
 from nexus.db.collection_purge import CascadeCounts, purge_collection_cascade
+from nexus.db.storage_mode import StorageBackend
 from nexus.db.t3 import T3Database
 
 
@@ -19,6 +20,18 @@ from nexus.db.t3 import T3Database
 def t3() -> T3Database:
     client = chromadb.EphemeralClient()
     return T3Database(_client=client)
+
+
+def _pin_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the catalog backend to sqlite so the client-side fan-out path runs.
+
+    The hard default is SERVICE (RDR-152); without this the cascade would take
+    the RDR-164 P2 service branch and try to reach a service that is not up in
+    the unit env. (feedback: pin local mode in mode-sensitive tests.)"""
+    monkeypatch.setattr(
+        "nexus.db.storage_mode.storage_backend_for",
+        lambda store: StorageBackend.SQLITE,
+    )
 
 
 def _seed(t3: T3Database, name: str) -> None:
@@ -34,6 +47,7 @@ def _seed(t3: T3Database, name: str) -> None:
 def test_t2_failure_recorded_but_t3_still_deleted(
     t3: T3Database, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _pin_local(monkeypatch)
     name = "docs__purge__minilm-l6-v2-384__v1"
     _seed(t3, name)
 
@@ -52,6 +66,7 @@ def test_t2_failure_recorded_but_t3_still_deleted(
 def test_clean_run_has_no_failures(
     t3: T3Database, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _pin_local(monkeypatch)
     name = "docs__purge2__minilm-l6-v2-384__v1"
     _seed(t3, name)
     # Stub the derived-state steps to succeed quietly.
@@ -67,3 +82,72 @@ def test_clean_run_has_no_failures(
     # we stubbed must not have failed.
     assert all("taxonomy/chash" not in f for f in counts.failures)
     assert isinstance(counts, CascadeCounts)
+
+
+def test_service_mode_uses_single_endpoint_and_maps_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # RDR-164 P2: in service mode the cascade must call the ONE atomic
+    # deleteCollection endpoint and map its per-table counts — NOT fan out to
+    # the local t2_index_write / chroma path.
+    monkeypatch.setattr(
+        "nexus.db.storage_mode.storage_backend_for",
+        lambda store: StorageBackend.SERVICE,
+    )
+    # A db whose delete_collection MUST NOT be called in service mode (the endpoint
+    # owns the chunk delete). If the service branch wrongly fell through to the local
+    # fan-out it would invoke this and fail the test loudly.
+    class _ExplodingDb:
+        def delete_collection(self, _name: str) -> None:
+            raise AssertionError("service mode must not call db.delete_collection (local fan-out)")
+
+    class _FakeClient:
+        def delete_collection(self, name: str) -> dict[str, int]:
+            return {
+                "chunks_384": 5, "chunks_768": 0, "chunks_1024": 0,
+                "chash_index": 5,
+                "topic_assignments": 3, "topics": 2, "taxonomy_meta": 1,
+                "taxonomy_centroids_384": 2, "taxonomy_centroids_768": 0,
+                "taxonomy_centroids_1024": 0,
+                "document_aspects": 4, "document_highlights": 1,
+                "aspect_extraction_queue": 7,
+                "catalog_documents": 6, "catalog_collections": 1,
+            }
+
+    monkeypatch.setattr(
+        "nexus.catalog.factory.make_catalog_reader", lambda: _FakeClient()
+    )
+
+    counts = purge_collection_cascade(_ExplodingDb(), "knowledge__svc__minilm-l6-v2-384__v1")
+
+    assert counts.chash_deleted == 5
+    assert counts.catalog_docs_deleted == 6
+    assert counts.catalog_projection_deleted == 1
+    # Dict shape must match the local fan-out (topics/assignments/links/meta) so the CLI
+    # render does not KeyError; centroids is the service-only addition.
+    assert counts.taxonomy == {
+        "topics": 2, "assignments": 3, "links": 0, "meta": 1, "centroids": 2,
+    }
+    assert counts.failures == []
+
+
+def test_service_mode_endpoint_failure_recorded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "nexus.db.storage_mode.storage_backend_for",
+        lambda store: StorageBackend.SERVICE,
+    )
+
+    class _BoomClient:
+        def delete_collection(self, name: str) -> dict[str, int]:
+            raise RuntimeError("service unreachable")
+
+    monkeypatch.setattr(
+        "nexus.catalog.factory.make_catalog_reader", lambda: _BoomClient()
+    )
+
+    counts = purge_collection_cascade(object(), "knowledge__svc2__minilm-l6-v2-384__v1")
+
+    assert any("service deleteCollection failed" in f for f in counts.failures)
+    assert "service unreachable" in " ".join(counts.failures)


### PR DESCRIPTION
## Summary
RDR-164 P2 — replace the SQLite-era client-side collection-delete fan-out (which left orphans: nexus-tquoj, nexus-cugrk) with ONE transactional Postgres cascade on the service path.

**Release-ordering note:** P1a (#1273, on develop, unreleased) added `ON DELETE RESTRICT` collection FKs; without P2, deleting a collection with aspect/queue/highlight rows RESTRICT-fails. **This PR is the required companion — do not release P1a without it.**

## Java
- `CatalogRepository.deleteCollection(tenant,name)`: registry-only → explicit ordered DELETE in one `TenantScope.withTenant` txn across all in-PG lifecycle tables (chunks_* → chash_index → topic_assignments → topics → **taxonomy_meta** → taxonomy_centroids_* → document_aspects → document_highlights → aspect_extraction_queue → catalog_documents [fk-001 cascades doc-rooted remainder] → catalog_collections LAST). Returns per-table counts; RLS scopes every DELETE; typed jOOQ DSL.
- `CatalogHandler`: `POST /v1/catalog/collections/delete` → returns `{"deleted": {counts}}`; accepts `name|collection`.

## Python
- `HttpCatalogClient.delete_collection` calls the endpoint.
- `purge_collection_cascade` branches: SERVICE mode → single atomic call, maps counts into `CascadeCounts` (preserves the taxonomy dict shape so the CLI render doesn't `KeyError`); SQLITE mode keeps the existing fan-out; `pipeline.db` shared, client-side in both (CA-4).

## Closes
- **nexus-tquoj** — `aspect_extraction_queue` now purged, incl. doc-less `NULL`-doc_id rows the document cascade can't reach. (Service-mode; local-mode leg rides with RDR-158 local retirement.)
- Service-mode **nexus-cugrk** centroid leak — `taxonomy_centroids_*` purged by collection.

## Tests
- `CatalogDeleteCollectionCascadeTest` — exact per-table counts, orphan-free, RLS tenant-isolation, tquoj + cugrk.
- `CatalogHandlerDeleteTest` — HTTP 200+counts, `name|collection` alias, 400 blank/missing, 405.
- `test_collection_purge` — service-mode happy/failure + sqlite-pinned existing tests.
- Java full suite 848/0; Python full suite green.

## Review
Stacked review clean: code-review-expert + substantive-critic both flagged C1 (`taxonomy_meta` missing — RESTRICT-blocker) plus H1 (route test), S1 (CLI KeyError), M1–M3 — all fixed and re-verified.

Refs nexus-ybdoc
Closes #nexus-tquoj