### PR TITLE
RDR-164 P3: atomic server-side renameCollection coherent re-home (nexus-77vve)

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -2,6 +2,25 @@
 // Copyright (c) 2026 Hal Hildebrand. All rights reserved.
 package dev.nexus.service.db;
 
+import static dev.nexus.service.jooq.nexus.Tables.ASPECT_EXTRACTION_QUEUE;
+import static dev.nexus.service.jooq.nexus.Tables.CATALOG_COLLECTIONS;
+import static dev.nexus.service.jooq.nexus.Tables.CATALOG_DOCUMENTS;
+import static dev.nexus.service.jooq.nexus.Tables.CHASH_INDEX;
+import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_1024;
+import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_384;
+import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_768;
+import static dev.nexus.service.jooq.nexus.Tables.DOCUMENT_ASPECTS;
+import static dev.nexus.service.jooq.nexus.Tables.DOCUMENT_HIGHLIGHTS;
+import static dev.nexus.service.jooq.nexus.Tables.HOOK_FAILURES;
+import static dev.nexus.service.jooq.nexus.Tables.RELEVANCE_LOG;
+import static dev.nexus.service.jooq.nexus.Tables.SEARCH_TELEMETRY;
+import static dev.nexus.service.jooq.nexus.Tables.TAXONOMY_CENTROIDS_1024;
+import static dev.nexus.service.jooq.nexus.Tables.TAXONOMY_CENTROIDS_384;
+import static dev.nexus.service.jooq.nexus.Tables.TAXONOMY_CENTROIDS_768;
+import static dev.nexus.service.jooq.nexus.Tables.TAXONOMY_META;
+import static dev.nexus.service.jooq.nexus.Tables.TOPICS;
+import static dev.nexus.service.jooq.nexus.Tables.TOPIC_ASSIGNMENTS;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jooq.Condition;
@@ -1171,28 +1190,94 @@ public final class CatalogRepository {
         });
     }
 
-    /** Rename a collection across documents + collections. */
-    public int renameCollection(String tenant, String oldName, String newName) {
+    /**
+     * Rename a collection X-&gt;Y, re-homing every in-Postgres denorm-collection table in
+     * one RLS-scoped transaction (RDR-164 P3, bead nexus-77vve). Returns per-table re-home
+     * counts.
+     *
+     * <p><b>Mechanism (canonical rename, target absent).</b> The fk-002/fk-003 collection
+     * FKs are {@code ON UPDATE NO ACTION}, so a bare {@code UPDATE catalog_collections SET
+     * name=Y} is BLOCKED by any child row (proven: CollectionRegistryFkTest group-12). The
+     * coherent re-home therefore never touches {@code catalog_collections.name}; instead it:
+     * <ol>
+     *   <li>INSERTs a new registry row Y, copying X's metadata;</li>
+     *   <li>UPDATEs every child denorm collection X-&gt;Y (Y now exists, FK satisfied);</li>
+     *   <li>DELETEs the old registry row X (no child references X now, RESTRICT satisfied).</li>
+     * </ol>
+     * Telemetry tables (search_telemetry, hook_failures) have no FK but ARE re-homed — a
+     * rename is not a delete, audit rows follow the new name.
+     *
+     * <p><b>Cross-model COPY branch (RDR-162, target already exists).</b> When Y is already
+     * registered (the bge-768 cross-model migrate registers the target via its chunk upsert),
+     * renaming the source registry row would collide on the (tenant_id, name) PK. In that case
+     * we repoint {@code catalog_documents.physical_collection} ONLY and leave both registry
+     * rows untouched — preserving pre-RDR-164 RDR-162 behavior.
+     */
+    public Map<String, Integer> renameCollection(String tenant, String oldName, String newName) {
         return tenantScope.withTenant(tenant, ctx -> {
-            // RDR-162: the cross-model migrate is COPY-not-move — the bge-768 target
-            // is ALREADY registered in catalog_collections by the vector upsert (its
-            // chunks' FK requires the registry row to exist). Renaming the SOURCE
-            // registry row into that name would collide on the (tenant_id, name) PK
-            // (the 500 the cross-model ref-remap hit). So branch on whether the target
-            // row already exists:
-            //   - cross-model copy (target exists): repoint catalog documents only;
-            //     leave the registry alone (renaming it would collide, and the target
-            //     row is already correct).
-            //   - canonical rename (target absent): also rename the registry row
-            //     (unchanged pre-RDR-162 behavior).
+            Map<String, Integer> counts = new LinkedHashMap<>();
             boolean targetExists = ctx.fetchExists(
-                ctx.selectOne().from(T_COLLS).where(F_COL_NAME.eq(newName)));
-            int docs = ctx.update(T_DOCS).set(F_DOC_PCOLL, newName)
-                          .where(F_DOC_PCOLL.eq(oldName)).execute();
-            if (!targetExists) {
-                ctx.update(T_COLLS).set(F_COL_NAME, newName).where(F_COL_NAME.eq(oldName)).execute();
+                ctx.selectOne().from(CATALOG_COLLECTIONS).where(CATALOG_COLLECTIONS.NAME.eq(newName)));
+
+            if (targetExists) {
+                // RDR-162 cross-model COPY branch: repoint catalog_documents only; leave
+                // both registry rows (renaming the source would collide on the name PK).
+                counts.put("catalog_documents",
+                    ctx.update(CATALOG_DOCUMENTS).set(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION, newName)
+                       .where(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION.eq(oldName)).execute());
+                return counts;
             }
-            return docs;
+
+            // 1. New registry row Y, copying X's metadata (so children can re-home onto it).
+            counts.put("catalog_collections_inserted",
+                ctx.insertInto(CATALOG_COLLECTIONS,
+                        CATALOG_COLLECTIONS.TENANT_ID, CATALOG_COLLECTIONS.NAME,
+                        CATALOG_COLLECTIONS.CONTENT_TYPE, CATALOG_COLLECTIONS.OWNER_ID,
+                        CATALOG_COLLECTIONS.EMBEDDING_MODEL, CATALOG_COLLECTIONS.MODEL_VERSION,
+                        CATALOG_COLLECTIONS.DISPLAY_NAME, CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED,
+                        CATALOG_COLLECTIONS.SUPERSEDED_BY, CATALOG_COLLECTIONS.SUPERSEDED_AT,
+                        CATALOG_COLLECTIONS.CREATED_AT)
+                    .select(ctx.select(
+                            CATALOG_COLLECTIONS.TENANT_ID, DSL.val(newName),
+                            CATALOG_COLLECTIONS.CONTENT_TYPE, CATALOG_COLLECTIONS.OWNER_ID,
+                            CATALOG_COLLECTIONS.EMBEDDING_MODEL, CATALOG_COLLECTIONS.MODEL_VERSION,
+                            CATALOG_COLLECTIONS.DISPLAY_NAME, CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED,
+                            CATALOG_COLLECTIONS.SUPERSEDED_BY, CATALOG_COLLECTIONS.SUPERSEDED_AT,
+                            CATALOG_COLLECTIONS.CREATED_AT)
+                        .from(CATALOG_COLLECTIONS).where(CATALOG_COLLECTIONS.NAME.eq(oldName)))
+                    .execute());
+
+            // 2. Re-home every child denorm-collection table X->Y (Y now exists, FK satisfied).
+            //    T3 chunk vectors (fk-002 RESTRICT).
+            counts.put("chunks_384",  ctx.update(CHUNKS_384).set(CHUNKS_384.COLLECTION, newName).where(CHUNKS_384.COLLECTION.eq(oldName)).execute());
+            counts.put("chunks_768",  ctx.update(CHUNKS_768).set(CHUNKS_768.COLLECTION, newName).where(CHUNKS_768.COLLECTION.eq(oldName)).execute());
+            counts.put("chunks_1024", ctx.update(CHUNKS_1024).set(CHUNKS_1024.COLLECTION, newName).where(CHUNKS_1024.COLLECTION.eq(oldName)).execute());
+            //    chash index (physical_collection; fk-002-4 RESTRICT).
+            counts.put("chash_index", ctx.update(CHASH_INDEX).set(CHASH_INDEX.PHYSICAL_COLLECTION, newName).where(CHASH_INDEX.PHYSICAL_COLLECTION.eq(oldName)).execute());
+            //    taxonomy: assignments (source_collection, fk-002-5 RESTRICT), topics (fk-003 RESTRICT), meta (fk-003-4 RESTRICT).
+            counts.put("topic_assignments", ctx.update(TOPIC_ASSIGNMENTS).set(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION, newName).where(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.eq(oldName)).execute());
+            counts.put("topics", ctx.update(TOPICS).set(TOPICS.COLLECTION, newName).where(TOPICS.COLLECTION.eq(oldName)).execute());
+            counts.put("taxonomy_meta", ctx.update(TAXONOMY_META).set(TAXONOMY_META.COLLECTION, newName).where(TAXONOMY_META.COLLECTION.eq(oldName)).execute());
+            //    centroids (no FK to topics — explicit re-home).
+            counts.put("taxonomy_centroids_384",  ctx.update(TAXONOMY_CENTROIDS_384).set(TAXONOMY_CENTROIDS_384.COLLECTION, newName).where(TAXONOMY_CENTROIDS_384.COLLECTION.eq(oldName)).execute());
+            counts.put("taxonomy_centroids_768",  ctx.update(TAXONOMY_CENTROIDS_768).set(TAXONOMY_CENTROIDS_768.COLLECTION, newName).where(TAXONOMY_CENTROIDS_768.COLLECTION.eq(oldName)).execute());
+            counts.put("taxonomy_centroids_1024", ctx.update(TAXONOMY_CENTROIDS_1024).set(TAXONOMY_CENTROIDS_1024.COLLECTION, newName).where(TAXONOMY_CENTROIDS_1024.COLLECTION.eq(oldName)).execute());
+            //    aspect family (fk-003 RESTRICT; incl. doc-less rows).
+            counts.put("document_aspects",        ctx.update(DOCUMENT_ASPECTS).set(DOCUMENT_ASPECTS.COLLECTION, newName).where(DOCUMENT_ASPECTS.COLLECTION.eq(oldName)).execute());
+            counts.put("document_highlights",     ctx.update(DOCUMENT_HIGHLIGHTS).set(DOCUMENT_HIGHLIGHTS.COLLECTION, newName).where(DOCUMENT_HIGHLIGHTS.COLLECTION.eq(oldName)).execute());
+            counts.put("aspect_extraction_queue", ctx.update(ASPECT_EXTRACTION_QUEUE).set(ASPECT_EXTRACTION_QUEUE.COLLECTION, newName).where(ASPECT_EXTRACTION_QUEUE.COLLECTION.eq(oldName)).execute());
+            //    catalog documents (physical_collection).
+            counts.put("catalog_documents", ctx.update(CATALOG_DOCUMENTS).set(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION, newName).where(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION.eq(oldName)).execute());
+            //    audit tables (no FK, but re-homed: audit rows follow the new name — RDR-164
+            //    §Approach Phase 3: relevance_log + search_telemetry + hook_failures).
+            counts.put("relevance_log",     ctx.update(RELEVANCE_LOG).set(RELEVANCE_LOG.COLLECTION, newName).where(RELEVANCE_LOG.COLLECTION.eq(oldName)).execute());
+            counts.put("search_telemetry", ctx.update(SEARCH_TELEMETRY).set(SEARCH_TELEMETRY.COLLECTION, newName).where(SEARCH_TELEMETRY.COLLECTION.eq(oldName)).execute());
+            counts.put("hook_failures",     ctx.update(HOOK_FAILURES).set(HOOK_FAILURES.COLLECTION, newName).where(HOOK_FAILURES.COLLECTION.eq(oldName)).execute());
+
+            // 3. Delete the old registry row X (RESTRICT children are now re-homed onto Y).
+            counts.put("catalog_collections_deleted",
+                ctx.deleteFrom(CATALOG_COLLECTIONS).where(CATALOG_COLLECTIONS.NAME.eq(oldName)).execute());
+            return counts;
         });
     }
 

--- a/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
@@ -643,8 +643,8 @@ public final class CatalogHandler implements HttpHandler {
         if (oldName == null || newName == null) {
             HttpUtil.send(exchange, 400, "{\"error\":\"old_name/new_name (or old/new) required\"}"); return;
         }
-        int updated = repo.renameCollection(tenant, oldName, newName);
-        HttpUtil.send(exchange, 200, "{\"updated\":" + updated + "}");
+        Map<String, Integer> counts = repo.renameCollection(tenant, oldName, newName);
+        HttpUtil.send(exchange, 200, MAPPER.writeValueAsString(Map.of("renamed", counts)));
     }
 
     private void handleCollectionForTuple(HttpExchange exchange, String tenant, String method) throws IOException {

--- a/service/src/test/java/dev/nexus/service/CatalogHandlerRenameTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogHandlerRenameTest.java
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.nexus.service.db.TenantConstants;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.sql.Connection;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RDR-164 P3 — HTTP coverage for {@code POST /v1/catalog/collections/rename}
+ * ({@link dev.nexus.service.http.CatalogHandler#handleCollectionRename}). The repo-level
+ * coherent re-home is exhaustively covered by {@link CatalogRenameCollectionTest}; this
+ * exercises the HTTP glue the repo test cannot: the {@code old_name/new_name} canonical
+ * keys, the {@code old/new} compat alias, the 400 missing-key guard, the 405 method guard,
+ * and the {@code {"renamed": {...}}} response shape.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CatalogHandlerRenameTest {
+
+    private static final String TOKEN = "catalog-rename-handler-token-def456";
+    private static final String SVC_ROLE = "svc_cat_ren_handler";
+    private static final String SVC_PASS = "svc_cat_ren_handler_pass";
+    private static final String TENANT = TenantConstants.DEFAULT_TENANT;
+    private static final TypeReference<Map<String, Object>> MAP_T = new TypeReference<>() {};
+
+    PostgreSQLContainer<?> pg;
+    NexusService service;
+    HttpClient http;
+    com.zaxxer.hikari.HikariDataSource svcDs;
+    ObjectMapper mapper;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        mapper = new ObjectMapper();
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='" + SVC_ROLE + "') THEN "
+                + "CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "'; END IF; END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='nexus_svc') THEN "
+                + "CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass'; END IF; END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            var lb = new Liquibase("db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(su)));
+            lb.update(new Contexts());
+        }
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label) VALUES ('"
+                + dev.nexus.service.db.TokenHashing.sha256Hex(TOKEN)
+                + "', '" + TENANT + "', 'test-bound') ON CONFLICT (token_hash) DO NOTHING");
+            su.createStatement().execute("ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+            // Seed two registry rows to rename (one per route-shape test).
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + TENANT + "', 'hren__old')");
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + TENANT + "', 'hren__old-alias')");
+        }
+        var cfg = new com.zaxxer.hikari.HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(4);
+        cfg.setAutoCommit(true);
+        svcDs = new com.zaxxer.hikari.HikariDataSource(cfg);
+        service = new NexusService(0, TOKEN, svcDs);
+        service.start();
+        http = HttpClient.newHttpClient();
+    }
+
+    @AfterAll
+    void stopAll() throws Exception {
+        if (service != null) service.stop();
+        if (svcDs != null) svcDs.close();
+        if (pg != null) pg.stop();
+    }
+
+    @Test
+    void post_canonicalKeys_returns200WithRenamedCounts() throws Exception {
+        var resp = post("/v1/catalog/collections/rename",
+            "{\"old_name\":\"hren__old\",\"new_name\":\"hren__new\"}");
+        assertThat(resp.statusCode()).isEqualTo(200);
+        var body = mapper.readValue(resp.body(), MAP_T);
+        assertThat(body).containsKey("renamed");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> renamed = (Map<String, Object>) body.get("renamed");
+        assertThat(((Number) renamed.get("catalog_collections_inserted")).intValue())
+            .as("registry Y inserted via HTTP").isEqualTo(1);
+        assertThat(((Number) renamed.get("catalog_collections_deleted")).intValue())
+            .as("registry X deleted via HTTP").isEqualTo(1);
+    }
+
+    @Test
+    void post_oldNewAlias_returns200() throws Exception {
+        // The handler accepts old/new as a compat alias for old_name/new_name.
+        var resp = post("/v1/catalog/collections/rename",
+            "{\"old\":\"hren__old-alias\",\"new\":\"hren__new-alias\"}");
+        assertThat(resp.statusCode()).isEqualTo(200);
+        var body = mapper.readValue(resp.body(), MAP_T);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> renamed = (Map<String, Object>) body.get("renamed");
+        assertThat(((Number) renamed.get("catalog_collections_inserted")).intValue())
+            .as("alias old/new resolved").isEqualTo(1);
+    }
+
+    @Test
+    void post_missingKeys_returns400() throws Exception {
+        var resp = post("/v1/catalog/collections/rename", "{}");
+        assertThat(resp.statusCode()).isEqualTo(400);
+    }
+
+    @Test
+    void post_missingNewName_returns400() throws Exception {
+        var resp = post("/v1/catalog/collections/rename", "{\"old_name\":\"hren__whatever\"}");
+        assertThat(resp.statusCode()).isEqualTo(400);
+    }
+
+    @Test
+    void get_returns405() throws Exception {
+        var req = HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + service.getPort() + "/v1/catalog/collections/rename"))
+            .header("Authorization", "Bearer " + TOKEN)
+            .header("X-Nexus-Tenant", TENANT)
+            .GET().build();
+        var resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        assertThat(resp.statusCode()).isEqualTo(405);
+    }
+
+    private HttpResponse<String> post(String path, String body) throws Exception {
+        var req = HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + service.getPort() + path))
+            .header("Authorization", "Bearer " + TOKEN)
+            .header("X-Nexus-Tenant", TENANT)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+        return http.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/service/src/test/java/dev/nexus/service/CatalogRenameCollectionTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRenameCollectionTest.java
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import dev.nexus.service.db.CatalogRepository;
+import dev.nexus.service.db.TenantScope;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * RDR-164 P3 (bead nexus-77vve) — CatalogRepository.renameCollection coherent re-home.
+ *
+ * <p>Verifies the single transactional service-side collection rename: under the fk-002/fk-003
+ * {@code ON UPDATE NO ACTION} FKs, it re-homes every in-Postgres denorm-collection table X-&gt;Y
+ * by INSERT-new-registry / re-home-children / DELETE-old-registry (never UPDATEs
+ * catalog_collections.name), returns per-table counts, leaves no orphan under the old name,
+ * round-trips X-&gt;Y-&gt;X, is tenant-isolated via RLS, and preserves the RDR-162 cross-model
+ * COPY branch (target already registered → repoint documents only, both registry rows kept).
+ * The chunks-present case is the one the pre-P3 bare-UPDATE rename could not satisfy.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CatalogRenameCollectionTest {
+
+    private static final String TENANT_A = "ren-a";
+    private static final String TENANT_B = "ren-b";
+    private static final String TENANT_C = "ren-c";
+    private static final String OLD  = "knowledge__ren__minilm-l6-v2-384__v1";
+    private static final String NEW  = "knowledge__ren__minilm-l6-v2-384__v2";
+    private static final String SVC_ROLE = "svc_ren_casc";
+    private static final String SVC_PASS = "svc_ren_casc_pass";
+
+    PostgreSQLContainer<?> pg;
+    com.zaxxer.hikari.HikariDataSource svcDs;
+    CatalogRepository repo;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='nexus_svc') THEN "
+                + "CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='" + SVC_ROLE + "') THEN "
+                + "CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            var lb = new Liquibase("db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(su)));
+            lb.update(new Contexts());
+        }
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute("ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+        }
+        var cfg = new com.zaxxer.hikari.HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(4);
+        cfg.setAutoCommit(true);
+        svcDs = new com.zaxxer.hikari.HikariDataSource(cfg);
+        repo = new CatalogRepository(new TenantScope(svcDs));
+
+        // Seed an identical full collection under BOTH tenants (superuser bypasses RLS).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            seedFullCollection(su, TENANT_A, OLD);
+            seedFullCollection(su, TENANT_B, OLD);
+        }
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (svcDs != null) svcDs.close();
+        if (pg != null) pg.stop();
+    }
+
+    @Test @Order(10)
+    void renameCollection_returnsExactPerTableCounts_chunksPresent() {
+        // The chunks-present case: the pre-P3 bare UPDATE catalog_collections.name was blocked
+        // by NO-ACTION children; the coherent re-home must succeed and report every table.
+        Map<String, Integer> c = repo.renameCollection(TENANT_A, OLD, NEW);
+        assertThat(c.get("catalog_collections_inserted")).as("registry Y inserted").isEqualTo(1);
+        assertThat(c.get("chunks_384")).as("chunks_384").isEqualTo(2);
+        assertThat(c.get("chunks_768")).as("chunks_768").isEqualTo(1);
+        assertThat(c.get("chunks_1024")).as("chunks_1024").isEqualTo(1);
+        assertThat(c.get("chash_index")).as("chash_index").isEqualTo(2);
+        assertThat(c.get("topic_assignments")).as("topic_assignments (by source_collection)").isEqualTo(2);
+        assertThat(c.get("topics")).as("topics").isEqualTo(1);
+        assertThat(c.get("taxonomy_meta")).as("taxonomy_meta (RESTRICT child)").isEqualTo(1);
+        assertThat(c.get("taxonomy_centroids_384")).as("centroids_384").isEqualTo(1);
+        assertThat(c.get("taxonomy_centroids_768")).as("centroids_768").isEqualTo(1);
+        assertThat(c.get("taxonomy_centroids_1024")).as("centroids_1024").isEqualTo(1);
+        assertThat(c.get("document_aspects")).as("document_aspects (incl doc-less)").isEqualTo(2);
+        assertThat(c.get("document_highlights")).as("document_highlights").isEqualTo(1);
+        assertThat(c.get("aspect_extraction_queue")).as("aspect_extraction_queue (incl doc-less)").isEqualTo(2);
+        assertThat(c.get("catalog_documents")).as("catalog_documents").isEqualTo(1);
+        assertThat(c.get("relevance_log")).as("relevance_log (re-homed, no FK)").isEqualTo(2);
+        assertThat(c.get("search_telemetry")).as("search_telemetry (re-homed, no FK)").isEqualTo(2);
+        assertThat(c.get("hook_failures")).as("hook_failures (re-homed, no FK)").isEqualTo(1);
+        assertThat(c.get("catalog_collections_deleted")).as("registry X deleted").isEqualTo(1);
+    }
+
+    @Test @Order(20)
+    void renameCollection_noOrphanUnderOldName_allPresentUnderNew() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            for (String tbl : List.of("chunks_384", "chunks_768", "chunks_1024", "topics", "taxonomy_meta",
+                    "taxonomy_centroids_384", "taxonomy_centroids_768", "taxonomy_centroids_1024",
+                    "document_aspects", "document_highlights", "aspect_extraction_queue",
+                    "relevance_log", "search_telemetry")) {
+                assertThat(rows(su, "SELECT COUNT(*) FROM nexus." + tbl
+                    + " WHERE tenant_id='" + TENANT_A + "' AND collection='" + OLD + "'"))
+                    .as("no orphan in " + tbl + " under OLD").isZero();
+            }
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.hook_failures WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + OLD + "'")).as("hook_failures orphans").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.chash_index WHERE tenant_id='" + TENANT_A
+                + "' AND physical_collection='" + OLD + "'")).as("chash_index orphans").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.topic_assignments WHERE tenant_id='" + TENANT_A
+                + "' AND source_collection='" + OLD + "'")).as("assignment orphans").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_documents WHERE tenant_id='" + TENANT_A
+                + "' AND physical_collection='" + OLD + "'")).as("catalog_documents orphans").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_A
+                + "' AND name='" + OLD + "'")).as("old registry row gone").isZero();
+            // Present under NEW.
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_A
+                + "' AND name='" + NEW + "'")).as("new registry row present").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.chunks_384 WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + NEW + "'")).as("chunks under NEW").isEqualTo(2);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.taxonomy_meta WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + NEW + "'")).as("taxonomy_meta under NEW").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.hook_failures WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + NEW + "'")).as("hook_failures under NEW").isEqualTo(1);
+            // Symmetric presence sweep for the remaining re-homed tables.
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.document_highlights WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + NEW + "'")).as("document_highlights under NEW").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.document_aspects WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + NEW + "'")).as("document_aspects under NEW").isEqualTo(2);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.aspect_extraction_queue WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + NEW + "'")).as("aspect_extraction_queue under NEW").isEqualTo(2);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.taxonomy_centroids_384 WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + NEW + "'")).as("centroids_384 under NEW").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.topic_assignments WHERE tenant_id='" + TENANT_A
+                + "' AND source_collection='" + NEW + "'")).as("topic_assignments under NEW").isEqualTo(2);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.chash_index WHERE tenant_id='" + TENANT_A
+                + "' AND physical_collection='" + NEW + "'")).as("chash_index under NEW").isEqualTo(2);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.relevance_log WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + NEW + "'")).as("relevance_log under NEW").isEqualTo(2);
+        }
+    }
+
+    @Test @Order(30)
+    void renameCollection_isTenantIsolated_tenantBUntouched() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_B
+                + "' AND name='" + OLD + "'")).as("tenant B old registry intact").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_B
+                + "' AND name='" + NEW + "'")).as("tenant B has no NEW row").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.chunks_384 WHERE tenant_id='" + TENANT_B
+                + "' AND collection='" + OLD + "'")).as("tenant B chunks intact under OLD").isEqualTo(2);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.taxonomy_meta WHERE tenant_id='" + TENANT_B
+                + "' AND collection='" + OLD + "'")).as("tenant B taxonomy_meta intact").isEqualTo(1);
+        }
+    }
+
+    @Test @Order(40)
+    void renameCollection_roundTrip_newBackToOld() throws Exception {
+        // Y -> X: tenant A currently lives under NEW; rename it back and confirm the inverse.
+        Map<String, Integer> c = repo.renameCollection(TENANT_A, NEW, OLD);
+        assertThat(c.get("catalog_collections_inserted")).as("registry X re-inserted").isEqualTo(1);
+        assertThat(c.get("chunks_384")).as("chunks_384 back").isEqualTo(2);
+        assertThat(c.get("catalog_collections_deleted")).as("registry Y deleted").isEqualTo(1);
+        try (Connection su = pg.createConnection("")) {
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_A
+                + "' AND name='" + NEW + "'")).as("NEW gone after round-trip").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_A
+                + "' AND name='" + OLD + "'")).as("OLD restored").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.chunks_384 WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + OLD + "'")).as("chunks restored under OLD").isEqualTo(2);
+            // Back-direction must restore the derived tables too (not just chunks/registry).
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.taxonomy_meta WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + OLD + "'")).as("taxonomy_meta restored").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.document_highlights WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + OLD + "'")).as("document_highlights restored").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.taxonomy_centroids_384 WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + OLD + "'")).as("centroids_384 restored").isEqualTo(1);
+        }
+    }
+
+    @Test @Order(50)
+    void renameCollection_crossModelCopyBranch_targetExists_repointsDocsOnly() throws Exception {
+        // RDR-162 regression: pre-register the TARGET (simulating the bge-768 cross-model
+        // chunk upsert), then rename. Only catalog_documents.physical_collection must repoint;
+        // both registry rows must remain (the source is NOT deleted, the target NOT collided).
+        final String src = "code__ren-xm__minilm-l6-v2-384__v1";
+        final String tgt = "code__ren-xm__bge-768__v1";
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            // source registry + a document pointing at it
+            su.createStatement().execute("INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + TENANT_A + "', '" + src + "')");
+            su.createStatement().execute("INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title, physical_collection) "
+                + "VALUES ('" + TENANT_A + "', 'xm-doc-1', 'XM Doc', '" + src + "')");
+            // target registry already exists (cross-model copy registered it)
+            su.createStatement().execute("INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + TENANT_A + "', '" + tgt + "')");
+        }
+        Map<String, Integer> c = repo.renameCollection(TENANT_A, src, tgt);
+        assertThat(c).as("cross-model branch returns only catalog_documents").containsOnlyKeys("catalog_documents");
+        assertThat(c.get("catalog_documents")).as("one doc repointed").isEqualTo(1);
+        try (Connection su = pg.createConnection("")) {
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_A
+                + "' AND name='" + src + "'")).as("source registry row KEPT").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_A
+                + "' AND name='" + tgt + "'")).as("target registry row KEPT").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_documents WHERE tenant_id='" + TENANT_A
+                + "' AND physical_collection='" + tgt + "'")).as("doc now under target").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_documents WHERE tenant_id='" + TENANT_A
+                + "' AND physical_collection='" + src + "'")).as("no doc left under source").isZero();
+        }
+    }
+
+    @Test @Order(60)
+    void renameCollection_midTransactionFailure_rollsBackEverything() throws Exception {
+        // Atomicity regression (replaces the old FK-violation test): the whole re-home is
+        // ONE withTenant transaction. Force a mid-sequence failure AFTER the registry INSERT
+        // and child re-homes by colliding the search_telemetry PK (tenant_id, ts, query_hash,
+        // collection): a row pre-seeded under NEW shares (ts, query_hash) with an OLD row, so
+        // UPDATE ...SET collection=NEW collides -> the entire transaction must roll back,
+        // leaving OLD fully intact and NEW absent. search_telemetry has no FK, so the NEW-side
+        // row needs no NEW registry and does not trip the targetExists cross-model branch.
+        final String old = "knowledge__ren-rb__minilm-l6-v2-384__v1";
+        final String neu = "knowledge__ren-rb__minilm-l6-v2-384__v2";
+        final String ts = "2026-01-01 00:00:00+00";
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + TENANT_C + "', '" + old + "')");
+            su.createStatement().execute(chunkInsert(TENANT_C, old, "chunks_384", 384, "rbchunk"));
+            // OLD telemetry row that will try to move to (ts,'collide',NEW)...
+            su.createStatement().execute("INSERT INTO nexus.search_telemetry (tenant_id, ts, query_hash, collection, raw_count, kept_count) "
+                + "VALUES ('" + TENANT_C + "', '" + ts + "', 'collide', '" + old + "', 1, 1)");
+            // ...but that PK already exists under NEW -> UPDATE collision mid-transaction.
+            su.createStatement().execute("INSERT INTO nexus.search_telemetry (tenant_id, ts, query_hash, collection, raw_count, kept_count) "
+                + "VALUES ('" + TENANT_C + "', '" + ts + "', 'collide', '" + neu + "', 9, 9)");
+        }
+
+        assertThatThrownBy(() -> repo.renameCollection(TENANT_C, old, neu))
+            .as("mid-transaction PK collision propagates").isInstanceOf(Exception.class);
+
+        try (Connection su = pg.createConnection("")) {
+            // Everything rolled back: OLD intact, NEW registry never created.
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_C
+                + "' AND name='" + old + "'")).as("OLD registry intact after rollback").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_C
+                + "' AND name='" + neu + "'")).as("NEW registry NOT created (rolled back)").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.chunks_384 WHERE tenant_id='" + TENANT_C
+                + "' AND collection='" + old + "'")).as("chunk NOT re-homed (rolled back)").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.chunks_384 WHERE tenant_id='" + TENANT_C
+                + "' AND collection='" + neu + "'")).as("no chunk under NEW").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.search_telemetry WHERE tenant_id='" + TENANT_C
+                + "' AND collection='" + old + "'")).as("OLD telemetry intact").isEqualTo(1);
+        }
+    }
+
+    // ── fixture ──────────────────────────────────────────────────────────────
+
+    /** Seed one full collection (all re-homed lifecycle tables) for {@code tenant}. Superuser; bypasses RLS. */
+    private static void seedFullCollection(Connection su, String tenant, String coll) throws Exception {
+        var st = su.createStatement();
+        st.execute("INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + tenant + "', '" + coll + "')");
+        st.execute("INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title, physical_collection) "
+            + "VALUES ('" + tenant + "', 'rn-doc-1', 'Doc 1', '" + coll + "')");
+        st.execute("INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash) "
+            + "VALUES ('" + tenant + "', 'rn-doc-1', 0, '" + chash("rnman1") + "')");
+        // chunks: 2/1/1
+        st.execute(chunkInsert(tenant, coll, "chunks_384", 384, "rn384a"));
+        st.execute(chunkInsert(tenant, coll, "chunks_384", 384, "rn384b"));
+        st.execute(chunkInsert(tenant, coll, "chunks_768", 768, "rn768a"));
+        st.execute(chunkInsert(tenant, coll, "chunks_1024", 1024, "rn1024a"));
+        // chash_index: 2
+        st.execute("INSERT INTO nexus.chash_index (tenant_id, chash, physical_collection, created_at) "
+            + "VALUES ('" + tenant + "', '" + chash("rnci1") + "', '" + coll + "', NOW())");
+        st.execute("INSERT INTO nexus.chash_index (tenant_id, chash, physical_collection, created_at) "
+            + "VALUES ('" + tenant + "', '" + chash("rnci2") + "', '" + coll + "', NOW())");
+        // topics: 1 (explicit id)
+        long topicId = Math.abs((long) (tenant + coll).hashCode());
+        st.execute("INSERT INTO nexus.topics (id, tenant_id, label, collection, doc_count, created_at, review_status) "
+            + "VALUES (" + topicId + ", '" + tenant + "', 'topic-rn', '" + coll + "', 0, NOW(), 'pending')");
+        // taxonomy_meta: 1 (fk-003-4 RESTRICT)
+        st.execute("INSERT INTO nexus.taxonomy_meta (tenant_id, collection) VALUES ('" + tenant + "', '" + coll + "')");
+        // topic_assignments: 2 (source_collection=coll)
+        st.execute("INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, assigned_by, source_collection, assigned_at) "
+            + "VALUES ('" + tenant + "', 'rn-doc-1', " + topicId + ", 'projection', '" + coll + "', NOW())");
+        st.execute("INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, assigned_by, source_collection, assigned_at) "
+            + "VALUES ('" + tenant + "', 'rn-doc-2', " + topicId + ", 'projection', '" + coll + "', NOW())");
+        // centroids: one per dim
+        st.execute("INSERT INTO nexus.taxonomy_centroids_384 (tenant_id, collection, topic_id, embedding) "
+            + "VALUES ('" + tenant + "', '" + coll + "', " + topicId + ", " + vec(384) + "::vector)");
+        st.execute("INSERT INTO nexus.taxonomy_centroids_768 (tenant_id, collection, topic_id, embedding) "
+            + "VALUES ('" + tenant + "', '" + coll + "', " + topicId + ", " + vec(768) + "::vector)");
+        st.execute("INSERT INTO nexus.taxonomy_centroids_1024 (tenant_id, collection, topic_id, embedding) "
+            + "VALUES ('" + tenant + "', '" + coll + "', " + topicId + ", " + vec(1024) + "::vector)");
+        // document_aspects: 2 — one doc-rooted, one DOC-LESS
+        st.execute("INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name, doc_id) "
+            + "VALUES ('" + tenant + "', '" + coll + "', '/p/a1.md', NOW(), 'v1', 'docling', 'rn-doc-1')");
+        st.execute("INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name, doc_id) "
+            + "VALUES ('" + tenant + "', '" + coll + "', '/p/a2.md', NOW(), 'v1', 'docling', NULL)");
+        // document_highlights: 1
+        st.execute("INSERT INTO nexus.document_highlights (tenant_id, doc_id, collection, highlights_md, ingested_at) "
+            + "VALUES ('" + tenant + "', 'rn-doc-1', '" + coll + "', 'hi', NOW())");
+        // aspect_extraction_queue: 2 — one doc-rooted, one DOC-LESS
+        st.execute("INSERT INTO nexus.aspect_extraction_queue (tenant_id, collection, source_path, status, enqueued_at, doc_id) "
+            + "VALUES ('" + tenant + "', '" + coll + "', '/p/q1.md', 'pending', NOW(), 'rn-doc-1')");
+        st.execute("INSERT INTO nexus.aspect_extraction_queue (tenant_id, collection, source_path, status, enqueued_at, doc_id) "
+            + "VALUES ('" + tenant + "', '" + coll + "', '/p/q2.md', 'pending', NOW(), NULL)");
+        // search_telemetry: 2 (no FK, but re-homed)
+        st.execute("INSERT INTO nexus.search_telemetry (tenant_id, ts, query_hash, collection, raw_count, kept_count) "
+            + "VALUES ('" + tenant + "', NOW(), 'qh1', '" + coll + "', 10, 5)");
+        st.execute("INSERT INTO nexus.search_telemetry (tenant_id, ts, query_hash, collection, raw_count, kept_count) "
+            + "VALUES ('" + tenant + "', NOW(), 'qh2', '" + coll + "', 8, 4)");
+        // hook_failures: 1 (no FK, but re-homed)
+        st.execute("INSERT INTO nexus.hook_failures (tenant_id, doc_id, collection, hook_name, error, occurred_at) "
+            + "VALUES ('" + tenant + "', 'rn-doc-1', '" + coll + "', 'post_store', 'boom', NOW())");
+        // relevance_log: 2 (no FK, but re-homed — RDR-164 §Approach Phase 3 third audit table)
+        st.execute("INSERT INTO nexus.relevance_log (tenant_id, query, chunk_id, collection, action, session_id, timestamp) "
+            + "VALUES ('" + tenant + "', 'q1', 'ch1', '" + coll + "', 'click', 's1', NOW())");
+        st.execute("INSERT INTO nexus.relevance_log (tenant_id, query, chunk_id, collection, action, session_id, timestamp) "
+            + "VALUES ('" + tenant + "', 'q2', 'ch2', '" + coll + "', 'skip', 's1', NOW())");
+    }
+
+    private static String chunkInsert(String tenant, String coll, String table, int dim, String seed) {
+        return "INSERT INTO nexus." + table + " (tenant_id, collection, chash, chunk_text, embedding) "
+            + "VALUES ('" + tenant + "', '" + coll + "', '" + chash(seed) + "', 'text', " + vec(dim) + "::vector)";
+    }
+
+    private static String vec(int dim) {
+        return IntStream.range(0, dim).mapToObj(i -> "0.1").collect(Collectors.joining(",", "'[", "]'"));
+    }
+
+    private static String chash(String seed) {
+        return (seed.replaceAll("[^0-9a-f]", "a") + "0".repeat(32)).substring(0, 32);
+    }
+
+    private static int rows(Connection su, String sql) throws Exception {
+        var rs = su.createStatement().executeQuery(sql);
+        rs.next();
+        return rs.getInt(1);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
@@ -110,6 +110,10 @@ class CatalogRepositoryTest {
                 su.createStatement().execute(
                     "GRANT SELECT ON nexus." + ct + " TO " + SVC_ROLE);
             }
+            // RDR-164 P3: renameCollection re-homes every denorm-collection table in one txn;
+            // grant write broadly so the coherent rename can move children off the old name.
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA nexus TO " + SVC_ROLE);
             su.createStatement().execute(
                 "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
         }
@@ -750,8 +754,10 @@ class CatalogRepositoryTest {
         repo.upsertDocument(TENANT_A, Map.of("tumbler", "rn.1", "title", "Rename Test",
             "content_type", "paper", "corpus", "knowledge",
             "physical_collection", "knowledge__old__v1"));
-        int updated = repo.renameCollection(TENANT_A, "knowledge__old__v1", "knowledge__new__v1");
-        assertThat(updated).isEqualTo(1); // 1 document updated
+        var counts = repo.renameCollection(TENANT_A, "knowledge__old__v1", "knowledge__new__v1");
+        assertThat(counts.get("catalog_documents")).as("1 document re-homed").isEqualTo(1);
+        assertThat(counts.get("catalog_collections_inserted")).as("registry Y inserted").isEqualTo(1);
+        assertThat(counts.get("catalog_collections_deleted")).as("registry X deleted").isEqualTo(1);
         var doc = repo.getDocument(TENANT_A, "rn.1");
         assertThat(doc.get("physical_collection")).isEqualTo("knowledge__new__v1");
     }
@@ -774,9 +780,11 @@ class CatalogRepositoryTest {
             "name", tgt, "content_type", "knowledge", "owner_id", "nexus-1-1",
             "embedding_model", "bge-base-en-v15-768", "model_version", "v1"));
 
-        // Pre-RDR-162 this threw a 500 (PK collision on the registry rename).
-        int updated = repo.renameCollection(TENANT_A, src, tgt);
-        assertThat(updated).isEqualTo(1);
+        // Pre-RDR-162 this threw a 500 (PK collision on the registry rename). The cross-model
+        // COPY branch (target exists) repoints catalog_documents only and returns just that key.
+        var counts = repo.renameCollection(TENANT_A, src, tgt);
+        assertThat(counts).as("cross-model branch returns only catalog_documents").containsOnlyKeys("catalog_documents");
+        assertThat(counts.get("catalog_documents")).isEqualTo(1);
         assertThat(repo.getDocument(TENANT_A, "xmrn.1").get("physical_collection")).isEqualTo(tgt);
         // The pre-registered target row is intact (not collided, not duplicated).
         assertThat(repo.getCollection(TENANT_A, tgt)).isNotNull();

--- a/service/src/test/java/dev/nexus/service/CollectionRegistryFkTest.java
+++ b/service/src/test/java/dev/nexus/service/CollectionRegistryFkTest.java
@@ -172,6 +172,10 @@ class CollectionRegistryFkTest {
                 su.createStatement().execute(
                     "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus." + tbl + " TO " + SVC_ROLE);
             }
+            // RDR-164 P3: renameCollection re-homes every denorm-collection table in one txn
+            // (taxonomy_meta/centroids, aspects, highlights, queue, telemetry). Grant broadly.
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA nexus TO " + SVC_ROLE);
             su.createStatement().execute(
                 "GRANT USAGE ON SEQUENCE nexus.topics_id_seq TO " + SVC_ROLE);
             su.createStatement().execute(
@@ -1059,29 +1063,24 @@ class CollectionRegistryFkTest {
     }
 
     // ══════════════════════════════════════════════════════════════════════════
-    // GROUP 12 — CatalogRepository.renameCollection FK violation
+    // GROUP 12 — CatalogRepository.renameCollection coherent re-home (RDR-164 P3)
     //
-    // Position: nothing in the service renames pgvector chunk rows today.
-    // Pre-FK, a catalog rename produced SILENT data incoherence: chunks
-    // remained stranded under the old collection name while the catalog
-    // row moved to the new name.  The FK (chunks_384_collection_fk etc.)
-    // converts that silent incoherence into a loud FK violation, which is
-    // an improvement.  The coherent multi-step rename flow (rename chunks
-    // first, then rename the catalog row) is follow-on bead work — see
-    // 'pgvector-coherent collection rename follow-on'.
+    // Position: the chunks FK is ON UPDATE NO ACTION, so a bare
+    // `UPDATE catalog_collections SET name=Y` is blocked while a chunks_384
+    // row still references the old name. Pre-P3 the rename did exactly that
+    // bare UPDATE and this test asserted the resulting FK violation. RDR-164
+    // P3 (bead nexus-77vve) replaced it with the coherent re-home
+    // (INSERT new registry Y → re-home children X→Y → DELETE old registry X),
+    // which never touches catalog_collections.name. The chunks-present case
+    // that used to fail now SUCCEEDS and re-homes the chunk row — this test
+    // now pins that coherent success.
     // ══════════════════════════════════════════════════════════════════════════
 
     @Test @Order(120)
-    void renameCollection_withChunkRows_violatesChunks384Fk() throws Exception {
-        // Register a collection, insert a chunk row, then attempt to rename the catalog row.
-        // The rename updates catalog_collections.name; the existing chunks_384 row still
-        // references the OLD name.  The FK enforces ON DELETE RESTRICT / ON UPDATE RESTRICT
-        // (no CASCADE on the chunks FK), so updating catalog_collections.name from under a
-        // referenced chunks row must fail with chunks_384_collection_fk.
-        //
-        // This demonstrates the FK converts pre-existing silent data incoherence into a loud
-        // failure.  The coherent rename flow (move chunk rows first, then rename catalog row)
-        // is tracked as follow-on work: 'pgvector-coherent collection rename follow-on'.
+    void renameCollection_withChunkRows_reHomesCoherently() throws Exception {
+        // Register a collection, insert a chunk row, then rename the collection. Under the
+        // coherent re-home the chunk row must move from the old name to the new name and the
+        // registry row must move with it — no FK violation, no orphan under the old name.
         String tenant  = "grp12-rename-tenant";
         String oldName = "code__nexus__minilm-l6-v2-384__v1";
         String newName = "code__nexus__minilm-l6-v2-384__v2";
@@ -1099,7 +1098,6 @@ class CollectionRegistryFkTest {
         }
 
         // TenantScope / CatalogRepository via svc role.
-        // jOOQ wraps PSQLException in IntegrityConstraintViolationException — unwrap the cause.
         var cfg = new com.zaxxer.hikari.HikariConfig();
         cfg.setJdbcUrl(pg.getJdbcUrl());
         cfg.setUsername(SVC_ROLE);
@@ -1110,22 +1108,33 @@ class CollectionRegistryFkTest {
             TenantScope scope = new TenantScope(ds);
             var repo = new dev.nexus.service.db.CatalogRepository(scope);
 
-            // renameCollection updates catalog_collections.name — the FK must block this
-            // because chunks_384 still references the old name.
-            Exception thrown = assertThrows(Exception.class, () ->
-                repo.renameCollection(tenant, oldName, newName));
-            // jOOQ wraps the PSQL FK violation in IntegrityConstraintViolationException;
-            // walk the cause chain to find the PSQLException carrying the constraint name.
-            Throwable cause = thrown;
-            while (cause != null && !(cause instanceof PSQLException)) {
-                cause = cause.getCause();
-            }
-            assertThat(cause)
-                .as("FK violation must be present in exception chain")
-                .isInstanceOf(PSQLException.class);
-            assertThat(cause.getMessage())
-                .as("renameCollection with stranded chunk rows must violate chunks_384_collection_fk")
-                .containsIgnoringCase(FK_CHUNKS_384);
+            // The coherent re-home succeeds (no FK violation) and reports the moved chunk.
+            var counts = repo.renameCollection(tenant, oldName, newName);
+            assertThat(counts.get("chunks_384"))
+                .as("the chunks-present case re-homes the chunk row").isEqualTo(1);
+            assertThat(counts.get("catalog_collections_inserted")).as("registry Y inserted").isEqualTo(1);
+            assertThat(counts.get("catalog_collections_deleted")).as("registry X deleted").isEqualTo(1);
+        }
+
+        // Verify the move at the SQL layer: chunk + registry under NEW, nothing under OLD.
+        try (Connection su = pg.createConnection("")) {
+            ResultSet rs;
+            rs = su.createStatement().executeQuery("SELECT COUNT(*) FROM nexus.chunks_384 WHERE tenant_id='"
+                + tenant + "' AND collection='" + oldName + "'");
+            rs.next();
+            assertThat(rs.getInt(1)).as("no chunk orphan under old name").isZero();
+            rs = su.createStatement().executeQuery("SELECT COUNT(*) FROM nexus.chunks_384 WHERE tenant_id='"
+                + tenant + "' AND collection='" + newName + "'");
+            rs.next();
+            assertThat(rs.getInt(1)).as("chunk re-homed under new name").isEqualTo(1);
+            rs = su.createStatement().executeQuery("SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='"
+                + tenant + "' AND name='" + oldName + "'");
+            rs.next();
+            assertThat(rs.getInt(1)).as("old registry row gone").isZero();
+            rs = su.createStatement().executeQuery("SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='"
+                + tenant + "' AND name='" + newName + "'");
+            rs.next();
+            assertThat(rs.getInt(1)).as("new registry row present").isEqualTo(1);
         }
     }
 

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -1048,8 +1048,27 @@ class HttpCatalogClient:
         return int(result.get("updated", 0) if result else 0)
 
     def rename_collection(self, old: str, new: str) -> int:
+        # RDR-164 P3: the consolidated endpoint returns {"renamed": {per-table counts}}.
+        # The int contract reports the re-homed catalog_documents count.
+        renamed = self.rename_collection_cascade(old, new)
+        return int(renamed.get("catalog_documents", 0))
+
+    def rename_collection_cascade(self, old: str, new: str) -> dict[str, int]:
+        """RDR-164 P3: atomically re-home a collection X->Y and all its in-Postgres
+        derived state via the service's single transactional renameCollection.
+
+        Returns the per-table re-home count map (``catalog_collections_inserted``,
+        ``chunks_384/768/1024``, ``chash_index``, ``topic_assignments``, ``topics``,
+        ``taxonomy_meta``, ``taxonomy_centroids_*``, ``document_aspects``,
+        ``document_highlights``, ``aspect_extraction_queue``, ``catalog_documents``,
+        ``search_telemetry``, ``hook_failures``, ``catalog_collections_deleted``).
+        The cross-model COPY branch (target already registered) returns only
+        ``catalog_documents``. ``pipeline.db`` and the local-mode fan-out stay
+        client-side (see ``rename_collection_data_plane``).
+        """
         result = self._post("/collections/rename", {"old_name": old, "new_name": new})
-        return int(result.get("updated", 0) if result else 0)
+        renamed = (result or {}).get("renamed", {}) or {}
+        return {k: int(v) for k, v in renamed.items()}
 
     def update_document_collection(
         self, tumbler: Tumbler | str, collection: str

--- a/src/nexus/collection_rename.py
+++ b/src/nexus/collection_rename.py
@@ -77,14 +77,62 @@ def rename_collection_data_plane(
         "tax_topics": 0,
         "tax_assignments": 0,
         "tax_meta": 0,
+        "tax_centroids": 0,
         "chash": 0,
         "aspects": 0,
         "aspect_queue": 0,
+        "highlights": 0,
+        "relevance_log": 0,
         "search_telemetry": 0,
         "hook_failures": 0,
         "catalog_docs": 0,
     }
 
+    # ── Service mode: ONE atomic server-side re-home (RDR-164 P3) ─────────────
+    # In service mode the entire in-Postgres cascade — T3 pgvector chunks, chash
+    # index, taxonomy topics/assignments/meta/centroids, the aspect family,
+    # telemetry, AND the catalog documents + registry row — is a single
+    # transactional CatalogRepository.renameCollection on the Java service. Fold
+    # it into one call instead of the SQLite-era fan-out (T2 cascade + separate
+    # T3 Chroma rename + catalog cascade). The atomic txn means a failure leaves
+    # the collection fully unchanged, so it raises (not fail-open) just like the
+    # T2-cascade-failure contract below. No separate t3_db.rename_collection:
+    # the pgvector chunks were re-homed inside the same transaction.
+    from nexus.db.storage_mode import StorageBackend, storage_backend_for  # noqa: PLC0415
+
+    if storage_backend_for("catalog") == StorageBackend.SERVICE:
+        client = catalog
+        if client is None or not hasattr(client, "rename_collection_cascade"):
+            from nexus.catalog.factory import make_catalog_reader  # noqa: PLC0415
+            client = make_catalog_reader()
+        if client is None:  # service mode always returns a client; guard for a clear error
+            raise click.ClickException("catalog service client unavailable")
+        try:
+            renamed = client.rename_collection_cascade(old, new)
+        except Exception as exc:
+            raise click.ClickException(
+                f"service rename failed -- collection {old!r} is unchanged "
+                f"(the re-home is atomic). Fix the error and retry:\n  {exc}"
+            ) from exc
+        counts["tax_topics"] = renamed.get("topics", 0)
+        counts["tax_assignments"] = renamed.get("topic_assignments", 0)
+        counts["tax_meta"] = renamed.get("taxonomy_meta", 0)
+        counts["tax_centroids"] = (
+            renamed.get("taxonomy_centroids_384", 0)
+            + renamed.get("taxonomy_centroids_768", 0)
+            + renamed.get("taxonomy_centroids_1024", 0)
+        )
+        counts["chash"] = renamed.get("chash_index", 0)
+        counts["aspects"] = renamed.get("document_aspects", 0)
+        counts["aspect_queue"] = renamed.get("aspect_extraction_queue", 0)
+        counts["highlights"] = renamed.get("document_highlights", 0)
+        counts["relevance_log"] = renamed.get("relevance_log", 0)
+        counts["search_telemetry"] = renamed.get("search_telemetry", 0)
+        counts["hook_failures"] = renamed.get("hook_failures", 0)
+        counts["catalog_docs"] = renamed.get("catalog_documents", 0)
+        return counts
+
+    # ── Local (sqlite/Chroma) mode: client-side fan-out ──────────────────────
     # ── T2 cascade FIRST (reversible) ────────────────────────────────────────
     # Failure here raises ClickException -- T3 rename has not yet run so the
     # system remains fully consistent. Operator can diagnose and retry.
@@ -105,8 +153,12 @@ def rename_collection_data_plane(
         counts["chash"] = cascade.get("chash", 0)
         counts["aspects"] = cascade.get("aspects", 0)
         counts["aspect_queue"] = cascade.get("aspect_queue", 0)
+        counts["highlights"] = cascade.get("highlights", 0)
         counts["search_telemetry"] = cascade.get("search_telemetry", 0)
         counts["hook_failures"] = cascade.get("hook_failures", 0)
+        # tax_centroids stays 0 in local mode: the sqlite taxonomy cascade
+        # re-homes centroids internally without a separate per-table count.
+        # Service mode surfaces them from the server response above.
     except Exception as exc:
         raise click.ClickException(
             f"T2 cascade failed before T3 rename -- collection {old!r} is "

--- a/tests/catalog/test_http_catalog_client.py
+++ b/tests/catalog/test_http_catalog_client.py
@@ -166,7 +166,10 @@ class FakeCatalogHandler(BaseHTTPRequestHandler):
         elif op == "/collections/supersede":
             self._send_json({"updated": 5})
         elif op == "/collections/rename":
-            self._send_json({"updated": 3})
+            # RDR-164 P3: consolidated endpoint returns per-table re-home counts.
+            self._send_json({"renamed": {"catalog_documents": 3,
+                                         "catalog_collections_inserted": 1,
+                                         "catalog_collections_deleted": 1}})
         elif op == "/import/owner":
             self._send_json({"imported": 1})
         elif op == "/import/document":

--- a/tests/test_collection_rename.py
+++ b/tests/test_collection_rename.py
@@ -25,6 +25,24 @@ import pytest
 from click.testing import CliRunner
 
 
+@pytest.fixture(autouse=True)
+def _pin_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the storage backend to SQLITE for the whole module.
+
+    RDR-164 P3 added a SERVICE branch to ``rename_collection_data_plane`` that
+    fans out to the Java service. The hard default is SERVICE (RDR-152), so
+    without this pin these local-path tests (T2Database + fake Chroma) would
+    route into the service branch. Service-mode coverage lives in
+    ``test_collection_rename_service_mode.py``.
+    """
+    from nexus.db.storage_mode import StorageBackend
+
+    monkeypatch.setattr(
+        "nexus.db.storage_mode.storage_backend_for",
+        lambda store: StorageBackend.SQLITE,
+    )
+
+
 @pytest.fixture
 def env_creds(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CHROMA_API_KEY", "test")

--- a/tests/test_collection_rename_service_mode.py
+++ b/tests/test_collection_rename_service_mode.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-164 P3 (nexus-77vve) — service-mode branch of ``rename_collection_data_plane``.
+
+In service mode the entire collection re-home is ONE atomic
+``CatalogRepository.renameCollection`` on the Java service. The client must fold
+the SQLite-era fan-out (T2 cascade + separate Chroma rename + catalog cascade)
+into a single ``rename_collection_cascade`` call, map the per-table counts back,
+and NOT issue a separate local T3 rename (the pgvector chunks moved inside the
+same transaction). A service failure is atomic, so it raises (not fail-open).
+
+Local-mode coverage lives in ``test_collection_rename.py`` (sqlite-pinned).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import click
+import pytest
+
+from nexus.collection_rename import rename_collection_data_plane
+from nexus.db.storage_mode import StorageBackend
+
+
+@pytest.fixture(autouse=True)
+def _pin_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "nexus.db.storage_mode.storage_backend_for",
+        lambda store: StorageBackend.SERVICE,
+    )
+
+
+def _fake_t3(*, old_exists: bool = True, new_exists: bool = False) -> MagicMock:
+    t3 = MagicMock()
+    t3.collection_exists = MagicMock(
+        side_effect=lambda name: old_exists if name == "code__old"
+        else new_exists if name == "code__new" else False
+    )
+    t3.rename_collection = MagicMock()
+    return t3
+
+
+_SERVER_COUNTS = {
+    "catalog_collections_inserted": 1,
+    "chunks_384": 4,
+    "chunks_768": 0,
+    "chunks_1024": 0,
+    "chash_index": 3,
+    "topic_assignments": 2,
+    "topics": 1,
+    "taxonomy_meta": 1,
+    "taxonomy_centroids_384": 1,
+    "document_aspects": 2,
+    "document_highlights": 1,
+    "aspect_extraction_queue": 2,
+    "catalog_documents": 1,
+    "relevance_log": 2,
+    "search_telemetry": 2,
+    "hook_failures": 1,
+    "catalog_collections_deleted": 1,
+}
+
+
+def test_service_mode_uses_single_endpoint_and_maps_counts() -> None:
+    t3 = _fake_t3()
+    client = MagicMock()
+    client.rename_collection_cascade = MagicMock(return_value=dict(_SERVER_COUNTS))
+
+    counts = rename_collection_data_plane(
+        "code__old", "code__new", t3_db=t3, catalog=client
+    )
+
+    # ONE atomic call to the consolidated endpoint with the canonical args.
+    client.rename_collection_cascade.assert_called_once_with("code__old", "code__new")
+    # No separate local T3 rename — the service re-homed the pgvector chunks.
+    t3.rename_collection.assert_not_called()
+
+    # Server per-table counts mapped onto the data-plane's count keys.
+    assert counts["tax_topics"] == 1
+    assert counts["tax_assignments"] == 2
+    assert counts["tax_meta"] == 1
+    assert counts["chash"] == 3
+    assert counts["aspects"] == 2
+    assert counts["aspect_queue"] == 2
+    assert counts["highlights"] == 1
+    assert counts["tax_centroids"] == 1  # 384:1 + 768:0 + 1024:0
+    assert counts["relevance_log"] == 2
+    assert counts["search_telemetry"] == 2
+    assert counts["hook_failures"] == 1
+    assert counts["catalog_docs"] == 1
+
+
+def test_service_mode_failure_raises_clickexception_atomic() -> None:
+    t3 = _fake_t3()
+    client = MagicMock()
+    client.rename_collection_cascade = MagicMock(
+        side_effect=RuntimeError("simulated service outage")
+    )
+
+    with pytest.raises(click.ClickException) as ei:
+        rename_collection_data_plane(
+            "code__old", "code__new", t3_db=t3, catalog=client
+        )
+
+    assert "unchanged" in str(ei.value)
+    assert "simulated service outage" in str(ei.value)
+    # Atomic: no local T3 rename attempted.
+    t3.rename_collection.assert_not_called()
+
+
+def test_service_mode_still_guards_unknown_old() -> None:
+    t3 = _fake_t3(old_exists=False)
+    client = MagicMock()
+    client.rename_collection_cascade = MagicMock()
+
+    with pytest.raises(click.ClickException) as ei:
+        rename_collection_data_plane(
+            "code__old", "code__new", t3_db=t3, catalog=client
+        )
+    assert "not found" in str(ei.value).lower()
+    client.rename_collection_cascade.assert_not_called()
+
+
+def test_service_mode_still_guards_target_collision() -> None:
+    t3 = _fake_t3(new_exists=True)
+    client = MagicMock()
+    client.rename_collection_cascade = MagicMock()
+
+    with pytest.raises(click.ClickException) as ei:
+        rename_collection_data_plane(
+            "code__old", "code__new", t3_db=t3, catalog=client
+        )
+    assert "already exists" in str(ei.value).lower()
+    client.rename_collection_cascade.assert_not_called()


### PR DESCRIPTION
## Summary

RDR-164 Phase 3 (bead `nexus-77vve`): replace the SQLite-era client-side per-store collection-**rename** fan-out with one transactional Postgres re-home on the service path, mirroring P2's `deleteCollection`.

Under the fk-002/fk-003 `ON UPDATE NO ACTION` FKs, a bare `UPDATE catalog_collections.name` is blocked by child rows. The canonical rename (`targetExists=false`) re-homes coherently in **one** `TenantScope.withTenant` transaction:

1. INSERT new registry row Y (copy X's metadata)
2. UPDATE every child denorm-collection table X→Y (Y now exists → FK satisfied)
3. DELETE old registry row X (no child references X → RESTRICT satisfied)

It never touches `catalog_collections.name`. The RDR-162 cross-model COPY branch (`targetExists=true`) is preserved unchanged: repoint `catalog_documents.physical_collection` only, both registry rows kept.

## Changes

**Java**
- `CatalogRepository.renameCollection`: `int` → `Map<String,Integer>`; coherent re-home across chunks_384/768/1024, chash_index, topic_assignments, topics, taxonomy_meta, taxonomy_centroids_*, document_aspects, document_highlights, aspect_extraction_queue, catalog_documents, and the **three audit tables** (`relevance_log`, `search_telemetry`, `hook_failures` — no FK but re-homed; rename ≠ delete). Returns per-table counts; RLS scopes every statement; typed jOOQ DSL.
- `CatalogHandler`: `POST /v1/catalog/collections/rename` returns `{"renamed": {counts}}`; accepts `old_name/new_name` and `old/new`.

**Python**
- `HttpCatalogClient.rename_collection_cascade` returns the full per-table map; `rename_collection` delegates to it (was reading the stale `{"updated"}` shape).
- `rename_collection_data_plane` SERVICE branch: one atomic call, no separate local T3 rename (pgvector chunks re-homed in the same txn), atomic failure raises (not fail-open). SQLITE fan-out preserved (CA-5). Counts dict now surfaces `highlights`/`tax_centroids`/`relevance_log`.

## Tests
- `CatalogRenameCollectionTest`: exact per-table counts (incl. the chunks-present case that used to fail), no-orphan/all-under-NEW sweep, RLS tenant isolation, round-trip X→Y→X, RDR-162 cross-model regression, and a **mid-transaction PK-collision rollback** test proving atomicity.
- `CatalogHandlerRenameTest`: HTTP 200+counts, `old/new` alias, 400×2, 405.
- `CollectionRegistryFkTest` group-12 rewritten from FK-violation to coherent-success.
- `test_collection_rename_service_mode`: single-endpoint + count mapping + atomic-failure + guards. Existing rename tests sqlite-pinned.
- Full Java `mvn -o test` **859 pass**; Python rename/client sweeps green.

## Review + gate
- Stacked review (code-review-expert + substantive-critic + test-validator): 0 Critical; all actionable findings fixed (highlights/centroids mapping, atomicity rollback test, broadened assertions).
- `phase-review-gate RDR-164 --phase 3` **PASSED** — and caught `relevance_log` missing from the audit-table re-home before close (now fixed).

Refs nexus-77vve