### PR TITLE
RDR-164 P4: verify fk-001 document cascade + correct stale comments (nexus-jcx6w)

### DIFF
--- a/service/src/main/resources/db/changelog/fk-001-catalog-cross-store.xml
+++ b/service/src/main/resources/db/changelog/fk-001-catalog-cross-store.xml
@@ -26,10 +26,15 @@
       non-NULL values are checked against the parent table.
 
     ON DELETE SEMANTICS:
-      topic_assignments → CASCADE:
-        Topic assignments are derived projections of a document onto the taxonomy. If the catalog
-        document is deleted, the assignments have no parent and should be removed. A surviving
-        orphan assignment would point to nothing meaningful.
+      topic_assignments → NO FK (lookup index only; see changeset 1, nexus-sa14p / RDR-164 P4):
+        topic_assignments.doc_id is a CHUNK content-hash (the HDBSCAN taxonomy clusters chunk
+        embeddings), NOT a document tumbler, so a FK to catalog_documents(tumbler) would target
+        the wrong identity space and could never be satisfied. There is therefore NO document-
+        rooted ON DELETE CASCADE for topic_assignments — a catalog_documents delete does NOT
+        remove its assignments via this migration. (Collection-scoped cleanup lives in fk-002 +
+        the taxonomy cascade; the per-memory-entry cascade lives in T2Database.delete ->
+        CatalogTaxonomy.purge_assignments_for_doc, which is orthogonal to fk-001 and must NOT be
+        retired.) Only the supporting (tenant_id, doc_id) index is created.
 
       document_aspects → CASCADE:
         Aspects are extracted annotations on a document. They have no independent existence; their
@@ -52,13 +57,17 @@
         therefore correct both semantically (stale queue items for a deleted doc should be removed)
         and necessary for PG14 compatibility.
 
-    TABLES AFFECTED:
-      nexus.topic_assignments      — (tenant_id, doc_id) → catalog_documents(tenant_id, tumbler) CASCADE
+    TABLES AFFECTED (RDR-164 P4: this summary corrected to match the actual changesets below):
+      nexus.topic_assignments      — NO cross-store FK (changeset 1 = lookup index only; see above)
       nexus.document_aspects       — (tenant_id, doc_id) → catalog_documents(tenant_id, tumbler) CASCADE
                                      + column: doc_id TEXT DEFAULT '' → nullable (NULL when unset)
       nexus.document_highlights    — (tenant_id, doc_id) → catalog_documents(tenant_id, tumbler) CASCADE
-      nexus.aspect_extraction_queue— (tenant_id, doc_id) → catalog_documents(tenant_id, tumbler) SET NULL
+      nexus.aspect_extraction_queue— (tenant_id, doc_id) → catalog_documents(tenant_id, tumbler) CASCADE
+                                     (changeset 4; CASCADE, not SET NULL — PG14 can't column-list
+                                     SET NULL on a composite FK without nulling tenant_id)
                                      + column: doc_id TEXT DEFAULT '' → nullable (NULL when unset)
+      nexus.catalog_document_chunks— (tenant_id, doc_id) → catalog_documents(tenant_id, tumbler) CASCADE
+                                     (changeset 5; the RDR-108 manifest)
 
     TABLES NOT AFFECTED:
       topic_links — references nexus.topics via from_topic_id/to_topic_id (already real FKs); no

--- a/service/src/test/java/dev/nexus/service/CatalogDocumentCascadeTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogDocumentCascadeTest.java
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import dev.nexus.service.db.CatalogRepository;
+import dev.nexus.service.db.TenantScope;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RDR-164 P4 (bead nexus-jcx6w) — verify the document-level fk-001 ON DELETE CASCADE
+ * fires in the service path, and document what it does NOT cover.
+ *
+ * <p>fk-001 (fk-001-catalog-cross-store.xml) makes four child tables cascade-delete when
+ * their parent {@code catalog_documents(tenant_id, tumbler)} row is HARD-deleted:
+ * {@code document_aspects}, {@code document_highlights}, {@code aspect_extraction_queue},
+ * {@code catalog_document_chunks}. {@code topic_assignments} has NO document-rooted FK
+ * (only a lookup index — its {@code doc_id} is a chunk content-hash, not a tumbler), so it
+ * survives a document delete; its collection-scoped cleanup is the taxonomy cascade, not
+ * fk-001. This isolates the FK behaviour from the explicit per-table deletes in
+ * {@link CatalogDeleteCollectionCascadeTest}.
+ *
+ * <p>Three semantics are pinned: (1) a HARD {@code DELETE FROM catalog_documents} cascades to
+ * the four FK children (the path {@code deleteCollection} takes); (2) the service's
+ * {@code deleteDocument} API is a SOFT tombstone ({@code UPDATE deleted_at}) — it does NOT
+ * fire {@code ON DELETE CASCADE}, so children intentionally survive a tombstone; (3) the
+ * composite {@code (tenant_id, doc_id)} FK isolates tenants — deleting one tenant's document
+ * never cascades another tenant's identically-named document's children.
+ *
+ * <p>KNOWN OPEN GAP (RDR-164 P4, NOT closed): because {@code topic_assignments} has no
+ * document-rooted FK, a per-document HARD purge would leave its assignments orphaned. Today
+ * the only hard-delete path is {@code deleteCollection}, which cleans {@code topic_assignments}
+ * explicitly by {@code source_collection} (P2) — so no orphan accumulates in practice. But a
+ * future per-document hard-purge path (e.g. trash-empty) MUST clean assignments explicitly;
+ * fk-001 will not. Tracked as a follow-on bead (see RDR-164 P4 finding).
+ *
+ * <p>SCOPE NOTE (§Approach P4 bullet 2 — "retire redundant service-mode client cleanup"):
+ * confirmed there is nothing to retire at the per-document level. {@code _WriteOps.delete_document}
+ * is the LOCAL-mode SQLite manifest cascade (kept; no FK in sqlite); {@code HttpCatalogClient.
+ * delete_document} is a bare POST that relies on the soft-delete endpoint. No service-mode client
+ * fan-out exists here to remove. Collection-level client-orchestration retirement is P5's scope.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CatalogDocumentCascadeTest {
+
+    private static final String TENANT = "doc-casc";
+    private static final String TENANT_B = "doc-casc-b";
+    private static final String COLL = "knowledge__doc-casc__minilm-l6-v2-384__v1";
+    private static final String SVC_ROLE = "svc_doc_casc";
+    private static final String SVC_PASS = "svc_doc_casc_pass";
+
+    PostgreSQLContainer<?> pg;
+    com.zaxxer.hikari.HikariDataSource svcDs;
+    CatalogRepository repo;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='nexus_svc') THEN "
+                + "CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='" + SVC_ROLE + "') THEN "
+                + "CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "' NOSUPERUSER NOBYPASSRLS; END IF; END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            var lb = new Liquibase("db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(su)));
+            lb.update(new Contexts());
+        }
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute("ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+        }
+        var cfg = new com.zaxxer.hikari.HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(4);
+        cfg.setAutoCommit(true);
+        svcDs = new com.zaxxer.hikari.HikariDataSource(cfg);
+        repo = new CatalogRepository(new TenantScope(svcDs));
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (svcDs != null) svcDs.close();
+        if (pg != null) pg.stop();
+    }
+
+    @Test @Order(10)
+    void softDelete_tombstone_doesNotCascade() throws Exception {
+        // The service's deleteDocument API is a soft tombstone (UPDATE deleted_at). It must
+        // NOT fire fk-001 ON DELETE CASCADE — the doc-rooted children survive the tombstone.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            seedDocument(su, TENANT, "soft-doc-1");
+        }
+        int n = repo.deleteDocument(TENANT, "soft-doc-1");
+        assertThat(n).as("soft delete tombstoned one row").isEqualTo(1);
+
+        try (Connection su = pg.createConnection("")) {
+            assertThat(rows(su, "SELECT deleted_at IS NOT NULL FROM nexus.catalog_documents WHERE tenant_id='"
+                + TENANT + "' AND tumbler='soft-doc-1'")).as("row tombstoned, not removed").isEqualTo(1);
+            // Children survive the tombstone (no cascade on UPDATE deleted_at).
+            assertChildCounts(su, TENANT, "soft-doc-1", 1, 1, 1, 1);
+        }
+    }
+
+    @Test @Order(20)
+    void hardDelete_catalogDocument_cascadesFourChildren_topicAssignmentSurvives() throws Exception {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            seedDocument(su, TENANT, "hard-doc-1");
+            // topic_assignment for the doc — it has NO document-rooted FK, so it must survive.
+            seedTopicAssignment(su, TENANT, "hard-doc-1");
+        }
+        // Sanity: children present before the hard delete.
+        try (Connection su = pg.createConnection("")) {
+            assertChildCounts(su, TENANT, "hard-doc-1", 1, 1, 1, 1);
+        }
+
+        // HARD delete the catalog_documents row (the path deleteCollection takes); fk-001
+        // cascades to the four doc-rooted children. FK checks run as table owner (bypass RLS),
+        // so a superuser DELETE exercises the same constraint the svc-role delete would.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            int n = su.createStatement().executeUpdate(
+                "DELETE FROM nexus.catalog_documents WHERE tenant_id='" + TENANT + "' AND tumbler='hard-doc-1'");
+            assertThat(n).as("one catalog_documents row hard-deleted").isEqualTo(1);
+        }
+
+        try (Connection su = pg.createConnection("")) {
+            // The four fk-001 CASCADE children are gone.
+            assertChildCounts(su, TENANT, "hard-doc-1", 0, 0, 0, 0);
+            // topic_assignments has NO document-rooted FK (fk-001 changeset 1 = index only) — survives.
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.topic_assignments WHERE tenant_id='" + TENANT
+                + "' AND doc_id='hard-doc-1'"))
+                .as("topic_assignments NOT cascaded by document delete (no doc-rooted FK)").isEqualTo(1);
+        }
+    }
+
+    @Test @Order(30)
+    void hardDelete_compositeFkIsolatesTenants() throws Exception {
+        // fk-001's headline property: the FK is composite (tenant_id, doc_id) → catalog_documents
+        // (tenant_id, tumbler). Two tenants can share a tumbler value; deleting tenant A's document
+        // must cascade ONLY tenant A's children — tenant B's identically-named document and its
+        // children are untouched (the composite match requires the same tenant_id).
+        final String shared = "xt-doc";
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            seedDocument(su, TENANT, shared);
+            seedDocument(su, TENANT_B, shared);
+        }
+        try (Connection su = pg.createConnection("")) {
+            assertChildCounts(su, TENANT, shared, 1, 1, 1, 1);
+            assertChildCounts(su, TENANT_B, shared, 1, 1, 1, 1);
+        }
+
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().executeUpdate(
+                "DELETE FROM nexus.catalog_documents WHERE tenant_id='" + TENANT + "' AND tumbler='" + shared + "'");
+        }
+
+        try (Connection su = pg.createConnection("")) {
+            assertChildCounts(su, TENANT, shared, 0, 0, 0, 0);       // tenant A cascaded
+            assertChildCounts(su, TENANT_B, shared, 1, 1, 1, 1);     // tenant B untouched
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /** Assert the four fk-001 child tables hold the expected row counts for {@code tenant}/{@code tumbler}. */
+    private void assertChildCounts(Connection su, String tenant, String tumbler,
+                                   int aspects, int highlights, int queue, int manifest) throws Exception {
+        assertThat(rows(su, "SELECT COUNT(*) FROM nexus.document_aspects WHERE tenant_id='" + tenant
+            + "' AND doc_id='" + tumbler + "'")).as("document_aspects").isEqualTo(aspects);
+        assertThat(rows(su, "SELECT COUNT(*) FROM nexus.document_highlights WHERE tenant_id='" + tenant
+            + "' AND doc_id='" + tumbler + "'")).as("document_highlights").isEqualTo(highlights);
+        assertThat(rows(su, "SELECT COUNT(*) FROM nexus.aspect_extraction_queue WHERE tenant_id='" + tenant
+            + "' AND doc_id='" + tumbler + "'")).as("aspect_extraction_queue").isEqualTo(queue);
+        assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_document_chunks WHERE tenant_id='" + tenant
+            + "' AND doc_id='" + tumbler + "'")).as("catalog_document_chunks manifest").isEqualTo(manifest);
+    }
+
+    /** Seed one document + its four fk-001 child rows (aspects/highlights/queue/manifest) for {@code tenant}. */
+    private static void seedDocument(Connection su, String tenant, String tumbler) throws Exception {
+        var st = su.createStatement();
+        // Register the collection first (document_aspects/queue carry an fk-003 collection FK).
+        st.execute("INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + tenant + "', '" + COLL + "') "
+            + "ON CONFLICT DO NOTHING");
+        st.execute("INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title, physical_collection) "
+            + "VALUES ('" + tenant + "', '" + tumbler + "', 'Doc', '" + COLL + "')");
+        st.execute("INSERT INTO nexus.catalog_document_chunks (tenant_id, doc_id, position, chash) "
+            + "VALUES ('" + tenant + "', '" + tumbler + "', 0, '" + chash("man" + tenant + tumbler) + "')");
+        st.execute("INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name, doc_id) "
+            + "VALUES ('" + tenant + "', '" + COLL + "', '/p/a-" + tenant + "-" + tumbler + ".md', NOW(), 'v1', 'docling', '" + tumbler + "')");
+        st.execute("INSERT INTO nexus.document_highlights (tenant_id, doc_id, collection, highlights_md, ingested_at) "
+            + "VALUES ('" + tenant + "', '" + tumbler + "', '" + COLL + "', 'hi', NOW())");
+        st.execute("INSERT INTO nexus.aspect_extraction_queue (tenant_id, collection, source_path, status, enqueued_at, doc_id) "
+            + "VALUES ('" + tenant + "', '" + COLL + "', '/p/q-" + tenant + "-" + tumbler + ".md', 'pending', NOW(), '" + tumbler + "')");
+    }
+
+    /** Seed a topic + a topic_assignment keyed to {@code docId} for {@code tenant}. */
+    private static void seedTopicAssignment(Connection su, String tenant, String docId) throws Exception {
+        var st = su.createStatement();
+        st.execute("INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + tenant + "', '" + COLL + "') "
+            + "ON CONFLICT DO NOTHING");
+        // Mask to 32 bits before widening so Math.abs cannot overflow on Integer.MIN_VALUE.
+        long topicId = (tenant + docId).hashCode() & 0xFFFFFFFFL;
+        st.execute("INSERT INTO nexus.topics (id, tenant_id, label, collection, doc_count, created_at, review_status) "
+            + "VALUES (" + topicId + ", '" + tenant + "', 'topic-dc', '" + COLL + "', 0, NOW(), 'pending')");
+        st.execute("INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, assigned_by, source_collection, assigned_at) "
+            + "VALUES ('" + tenant + "', '" + docId + "', " + topicId + ", 'projection', '" + COLL + "', NOW())");
+    }
+
+    private static String chash(String seed) {
+        return (seed.replaceAll("[^0-9a-f]", "a") + "0".repeat(32)).substring(0, 32);
+    }
+
+    private static int rows(Connection su, String sql) throws Exception {
+        var rs = su.createStatement().executeQuery(sql);
+        rs.next();
+        // boolean expressions (deleted_at IS NOT NULL) come back as t/f; coerce to 1/0.
+        Object v = rs.getObject(1);
+        if (v instanceof Boolean b) return b ? 1 : 0;
+        return rs.getInt(1);
+    }
+}

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -1070,6 +1070,17 @@ class T2Database:
         the row's project and title first so the cascade can scope
         correctly.
 
+        RDR-164 P4 (nexus-jcx6w): this memory→taxonomy cascade is
+        ORTHOGONAL to the catalog ``fk-001`` document cascade and is NOT
+        made redundant by it. ``fk-001`` is rooted at
+        ``catalog_documents(tenant_id, tumbler)``; this path deletes a
+        ``memory`` row keyed by ``(project, title)`` and purges its
+        ``topic_assignments`` — a relationship no FK covers in either
+        backend (``topic_assignments.doc_id`` is a chunk content-hash,
+        not a tumbler; see fk-001 changeset 1). Do NOT retire
+        ``purge_assignments_for_doc`` here on the assumption that fk-001
+        covers it — it does not.
+
         Lock ordering (storage review I-4): this is the ONLY cross-domain
         cascade in the facade. The order is:
 

--- a/src/nexus/db/t2/document_aspects.py
+++ b/src/nexus/db/t2/document_aspects.py
@@ -697,13 +697,25 @@ class DocumentAspects:
         appears in the catalog ``documents`` table (RDR-108 nexus-urj4).
 
         Aspects are extracted asynchronously after a document is
-        registered. When the document is later deleted (via
-        ``cat.delete_document``, source-file removal, etc.) the
-        corresponding aspect rows are NOT cascaded today (the catalog
-        and T2 live in separate SQLite files; cross-DB FK CASCADE is
-        not supported by SQLite). This method is the periodic-sweep
-        cleanup for the orphans that accumulate between extraction
-        and deletion lifecycle events.
+        registered. Whether a document delete reaches its aspect rows
+        depends on the storage backend (RDR-164 P4):
+
+          * Service mode (single Postgres): ``fk-001`` adds a real
+            ``(tenant_id, doc_id) -> catalog_documents`` FK with
+            ``ON DELETE CASCADE``, so a HARD delete of the parent
+            ``catalog_documents`` row (the path a collection delete
+            takes) removes the aspect rows in the same transaction.
+            BUT the per-document ``cat.delete_document`` API is a SOFT
+            tombstone (``UPDATE deleted_at``), and ``ON DELETE CASCADE``
+            does not fire on an UPDATE — so aspects for soft-deleted
+            (not yet hard-purged) documents still accumulate.
+          * Local mode (catalog and T2 in separate SQLite files):
+            there is no cross-DB FK at all, so no document delete
+            cascades to aspects.
+
+        Either way this method is the periodic-sweep cleanup (and
+        defense-in-depth) for the orphans that accumulate between
+        extraction and deletion lifecycle events.
 
         Behavior:
           - Aspects whose ``source_uri`` is empty are NOT classified


### PR DESCRIPTION
## Summary

RDR-164 Phase 4 (bead `nexus-jcx6w`): **verification + documentation only — no new schema** (per §Approach / CA-3). Pins the `fk-001` `ON DELETE CASCADE` document-level semantics in the service path and corrects three stale/wrong comments the verification exposed.

## What the verification found (the bead's plan rested on wrong premises)

- `fk-001` gives `document_aspects` / `document_highlights` / `aspect_extraction_queue` / `catalog_document_chunks` real `(tenant_id, doc_id) → catalog_documents` FKs with `ON DELETE CASCADE`. **`topic_assignments` has NO document-rooted FK** (changeset 1 is a lookup index only — its `doc_id` is a chunk content-hash, not a tumbler). The fk-001 **header comment** claimed `topic_assignments → CASCADE` and `aspect_extraction_queue → SET NULL`; both were wrong vs the actual SQL.
- `CatalogRepository.deleteDocument` is a **soft tombstone** (`UPDATE deleted_at`); `ON DELETE CASCADE` does not fire on it. The cascade fires only on a **hard** delete (the `deleteCollection` path).
- `purge_assignments_for_doc` (`T2Database.delete` → taxonomy) is the **memory→taxonomy** cascade, keyed by `(project, title)` — orthogonal to fk-001 and **not redundant**. Kept.

## Changes

- **New `CatalogDocumentCascadeTest`** (3 tests): hard-delete cascades the four FK children + `topic_assignments` survives; soft-delete tombstone does not cascade; composite `(tenant_id, doc_id)` FK isolates tenants.
- **Comment corrections**: `document_aspects.py` `prune_orphans` docstring (service/local mode split + soft-vs-hard nuance); `fk-001-catalog-cross-store.xml` header (top-level `<!-- -->` only — no changeset `<comment>`/SQL touched, no liquibase checksum change); `T2Database.delete` docstring (do-not-retire rationale).

## Review

Stacked review (code-review-expert + substantive-critic): **0 Critical**. Both Significant findings addressed:
- The "assignment-orphan gap closed" claim was wrong → reframed as **documented-but-open**; filed follow-on bead **`nexus-7n553`** for any future per-document hard-purge path.
- §Approach bullet 2's "redundant client cleanup" → explicitly concluded **nothing redundant** at the per-document level (checked both delete paths).
- Plus cross-tenant isolation test + `Math.abs` hygiene fix.

`phase-review-gate RDR-164 --phase 4` **PASSED**. Java suite **851 green**.

## Known open gap (not closed)

A future per-document hard-purge path (trash-empty / GC) must clean `topic_assignments` explicitly — fk-001 won't. Today only `deleteCollection` hard-deletes, and it cleans them by `source_collection`, so no orphan accumulates in practice. Tracked: `nexus-7n553`.

Refs nexus-jcx6w