### PR TITLE
RDR-164 P5: remove dead Chroma centroid cleanup; close nexus-5kl1b obsolete; epic closeout (nexus-c6vze)

### DIFF
--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -162,9 +162,12 @@ class CatalogTaxonomy:
     """Owns the ``topics`` and ``topic_assignments`` tables.
 
     RDR-070 (nexus-9k5): topic discovery uses sklearn HDBSCAN on
-    pre-computed embeddings. Centroids stored in ChromaDB
-    ``taxonomy__centroids`` collection. c-TF-IDF labels via
-    CountVectorizer + TfidfTransformer for c-TF-IDF labels.
+    pre-computed embeddings. Centroids historically lived in the Chroma
+    ``taxonomy__centroids`` collection; since RDR-155 P4a.2 the serving path
+    is pgvector via the nexus-service (the discover/rebuild centroid-write
+    helpers retain raw-Chroma access only for injected-client / legacy-ETL
+    paths, slated for removal in RDR-155 P4b). c-TF-IDF labels via
+    CountVectorizer + TfidfTransformer.
 
     Constructor takes a :class:`MemoryStore` reference for
     :meth:`get_topic_docs` JOIN resolution (RDR-063 §Cross-Domain
@@ -1058,15 +1061,23 @@ class CatalogTaxonomy:
             self.conn.commit()
 
     def delete_topic(self, topic_id: int, *, chroma_client: Any = None) -> str | None:
-        """Delete a topic, its assignments, and its centroid.
+        """Delete a topic and its assignments. Returns the collection name.
 
-        Returns the collection name (needed by routed callers for chroma
-        centroid cleanup when ``chroma_client`` is not passed in).  When
-        ``chroma_client`` is provided the cleanup happens internally as
-        before (backward-compatible).  RDR-151 Phase 3 (nexus-uzay8):
-        the T2 DELETE part can now be routed through the daemon; the
-        caller performs the local chroma centroid delete using the
-        returned collection name.
+        RDR-164 P5 (nexus-c6vze, closes nexus-5kl1b obsolete): the old inline
+        Chroma ``taxonomy__centroids`` cleanup is removed. It was dead code:
+        NO caller ever passed ``chroma_client`` (grep-verified across the CLI +
+        MCP paths — review_cmd routes delete/merge through ``t2_index_write``
+        with no client), so the ``if chroma_client and collection`` guard never
+        fired. Removing it is therefore behaviour-preserving in every config,
+        including ``NX_STORAGE_BACKEND=sqlite``, where topic delete/merge already
+        did not clean Chroma centroids (a pre-existing gap, not introduced here).
+
+        Centroid lifecycle is owned by the service-backed taxonomy store
+        (:class:`HttpTaxonomyStore`, which self-cleans via its pgvector centroid
+        port — the cugrk service leg). ``chroma_client`` is retained only for
+        signature parity with that drop-in and is now ignored; the full Chroma
+        deletion (incl. the discover/rebuild centroid-write path) is RDR-155
+        P4b's scope, not this method's.
         """
         # Read collection before deleting the row
         with self._lock:
@@ -1079,15 +1090,6 @@ class CatalogTaxonomy:
             )
             self.conn.execute("DELETE FROM topics WHERE id = ?", (topic_id,))
             self.conn.commit()
-        # Clean up centroid outside the lock
-        if chroma_client and collection:
-            try:
-                coll = chroma_client.get_collection(
-                    "taxonomy__centroids", embedding_function=None,
-                )
-                coll.delete(ids=[f"{collection}:{topic_id}"])
-            except Exception:
-                pass
         return collection
 
     def merge_topics(
@@ -1097,11 +1099,15 @@ class CatalogTaxonomy:
 
         Uses INSERT OR IGNORE to handle docs assigned to both topics
         (dedup). Updates target's doc_count to the actual assignment count.
-        Cleans up source centroid from ChromaDB when chroma_client provided.
+        Returns the source topic's collection name.
 
-        Returns the source topic's collection name (needed by routed callers
-        for chroma centroid cleanup).  RDR-151 Phase 3 (nexus-uzay8): the
-        T2 writes route through the daemon; caller does local centroid delete.
+        RDR-164 P5 (nexus-c6vze, closes nexus-5kl1b obsolete): the old inline
+        Chroma ``taxonomy__centroids`` source-centroid cleanup is removed. Like
+        :meth:`delete_topic`, it was dead code — no caller ever passed
+        ``chroma_client`` (grep-verified), so removal is behaviour-preserving in
+        every config. Centroid lifecycle is owned by the service-backed
+        :class:`HttpTaxonomyStore` drop-in (pgvector). ``chroma_client`` is
+        retained for signature parity and ignored.
         """
         if source_id == target_id:
             return None  # Self-merge is a no-op
@@ -1153,15 +1159,6 @@ class CatalogTaxonomy:
             # Delete source topic
             self.conn.execute("DELETE FROM topics WHERE id = ?", (source_id,))
             self.conn.commit()
-        # Clean up source centroid outside the lock
-        if chroma_client and collection:
-            try:
-                coll = chroma_client.get_collection(
-                    "taxonomy__centroids", embedding_function=None,
-                )
-                coll.delete(ids=[f"{collection}:{source_id}"])
-            except Exception:
-                pass
         return collection
 
     def get_topic_by_id(self, topic_id: int) -> dict[str, Any] | None:

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -2351,6 +2351,53 @@ class TestReviewMethods:
         ).fetchone()[0]
         assert count == 1
 
+    # ── RDR-164 P5 (nexus-c6vze): dead Chroma centroid cleanup removed ────────
+    # nexus-5kl1b closed obsolete: post-RDR-155 P4a the raw-Chroma
+    # taxonomy__centroids path is unreachable (make_t3 -> HttpVectorClient).
+    # delete_topic/merge_topics must NO LONGER touch a passed chroma_client.
+
+    def test_delete_topic_ignores_chroma_client(self, db: T2Database) -> None:
+        from unittest.mock import MagicMock
+
+        db.taxonomy.conn.execute(
+            "INSERT INTO topics (label, collection, doc_count, created_at) VALUES (?, ?, ?, ?)",
+            ("doomed", "proj", 1, "2026-01-01T00:00:00Z"),
+        )
+        tid = db.taxonomy.conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db.taxonomy.conn.commit()
+        mock_chroma = MagicMock()
+
+        db.taxonomy.delete_topic(tid, chroma_client=mock_chroma)
+
+        # Relational delete still happens; the retired Chroma cleanup does not.
+        assert db.taxonomy.conn.execute(
+            "SELECT COUNT(*) FROM topics WHERE id = ?", (tid,)
+        ).fetchone()[0] == 0
+        mock_chroma.get_collection.assert_not_called()
+
+    def test_merge_topics_ignores_chroma_client(self, db: T2Database) -> None:
+        from unittest.mock import MagicMock
+
+        db.taxonomy.conn.execute(
+            "INSERT INTO topics (label, collection, doc_count, created_at) VALUES (?, ?, ?, ?)",
+            ("source", "proj", 1, "2026-01-01T00:00:00Z"),
+        )
+        source_id = db.taxonomy.conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db.taxonomy.conn.execute(
+            "INSERT INTO topics (label, collection, doc_count, created_at) VALUES (?, ?, ?, ?)",
+            ("target", "proj", 1, "2026-01-01T00:00:00Z"),
+        )
+        target_id = db.taxonomy.conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db.taxonomy.conn.commit()
+        mock_chroma = MagicMock()
+
+        db.taxonomy.merge_topics(source_id, target_id, chroma_client=mock_chroma)
+
+        assert db.taxonomy.conn.execute(
+            "SELECT COUNT(*) FROM topics WHERE id = ?", (source_id,)
+        ).fetchone()[0] == 0
+        mock_chroma.get_collection.assert_not_called()
+
     def test_get_topic_by_id(self, db: T2Database) -> None:
         """get_topic_by_id returns a single topic dict or None."""
         db.taxonomy.conn.execute(


### PR DESCRIPTION
## Summary

RDR-164 Phase 5 — **epic closeout**. P5 retires the last SQLite-era client orchestration that P2/P3's atomic in-PG cascades made obsolete. Verification (consistent with P4) showed the bead's three "retire" targets were largely dead or mis-specified; the substantive change is removing genuinely dead code.

> Note: a first attempt (a lazy `make_t3()` centroid handle to "land" nexus-5kl1b) was a **verified no-op** — `make_t3()` returns `HttpVectorClient` (no `_client`) in all production paths since RDR-155 P4a — and was reverted after the stacked review caught it. The corrected disposition is **close obsolete**.

## Changes

- **`CatalogTaxonomy.delete_topic` / `merge_topics`**: remove the inline Chroma `taxonomy__centroids` cleanup blocks. They were **dead code** — no caller ever passed `chroma_client` (grep-verified across CLI + MCP; `review_cmd` routes delete/merge through `t2_index_write` with no client), so the guard never fired. Removal is behaviour-preserving in every config. The `chroma_client` kwarg is kept for signature parity with the `HttpTaxonomyStore` drop-in and is now ignored. Docstrings updated.
- **Tests**: `delete_topic`/`merge_topics` ignore a passed `chroma_client` (`get_collection.assert_not_called`) while the relational delete still happens.

## nexus-5kl1b → closed obsolete

The cugrk LOCAL-mode chroma centroid leak cannot occur: since RDR-155 P4a.2 every T3 vector op routes through the pgvector service (`make_t3()` → `HttpVectorClient`; `is_service_backed == isinstance(_, HttpVectorClient)`), so the raw-Chroma centroid path is unreachable in production, and no caller passed a client. In the supported SERVICE config `db.taxonomy` is `HttpTaxonomyStore` (pgvector self-clean — the cugrk service leg). The full Chroma centroid-write deletion (`_create_centroid_collection`, still used by discover/rebuild/split via injected-chroma / legacy-ETL paths) is **RDR-155 P4b's** scope.

## §Approach item handling (gate PASSED)

- **Item1** (delete dead `failures` accumulation + caller-removes-centroid contract): the caller-removes-centroid contract is **retired** (dead blocks removed). The `failures` accumulation was **examined and kept** — it is shared infra (`CascadeCounts.failures` used by the local fan-out branch + the pipeline-db step + the single service-call failure record), not the non-atomicity scar the bead assumed.
- **Item2** (land or close-obsolete nexus-5kl1b): **closed obsolete** with the P4a-unreachability evidence.

## Review + gate

Stacked review (code-review-expert + substantive-critic): **0 Critical**. Docstring precision + stale class-doc fixes applied. `phase-review-gate RDR-164 --phase 5` **PASSED**. Tests: `test_taxonomy` 201 + boundary-lint; broad sweep 429 green. Python-only (no Java/schema change).

## Known pre-existing gap (not introduced, not closed here)

In the unsupported split config (service-T3 + sqlite-taxonomy, which discover/rebuild already refuse), `review_cmd` delete/merge would not clean a pgvector centroid — `CatalogTaxonomy` has no centroid port. This predates P5 and cannot trigger in a supported steady state; surfaced for the record.

Refs nexus-c6vze
Closes nexus-5kl1b