### PR TITLE
RDR-164 P1b: VALIDATE the five fk-003 collection FKs (nexus-p9aw6)

### DIFF
--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -73,6 +73,12 @@
          Must come after aspects-001, taxonomy-001, and catalog-001. -->
     <include file="db/changelog/fk-003-collection-registry-extra.xml"/>
 
+    <!-- RDR-164 P1b (bead nexus-p9aw6): gap-window stub-register reconcile +
+         VALIDATE CONSTRAINT for the five fk-003 NOT VALID collection FKs.
+         Separate changelog so VALIDATE stays off the P2->P5 critical path and
+         runs only after the reconcile. Must come after fk-003-collection-registry-extra. -->
+    <include file="db/changelog/fk-003-validate.xml"/>
+
     <!-- Catalog hygiene (bead nexus-70r3c.2, RDR-156 P0.2):
          temporal typing for catalog_collections.created_at/superseded_at (TEXT→timestamptz NULL),
          and CHECK constraints for chash length = 32 and position >= 0. -->

--- a/service/src/main/resources/db/changelog/fk-003-validate.xml
+++ b/service/src/main/resources/db/changelog/fk-003-validate.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    fk-003-validate.xml — RDR-164 P1b (bead nexus-p9aw6)
+
+    Completes the fk-003 collection-registry FK spine by VALIDATEing the five
+    NOT VALID FKs that fk-003-collection-registry-extra.xml (P1a, nexus-dcqml)
+    added in the deliberately-deferred-validation shape:
+
+      document_aspects_collection_fk
+      aspect_extraction_queue_collection_fk
+      topics_collection_fk
+      taxonomy_meta_collection_fk
+      document_highlights_collection_fk
+
+    Why this is a SEPARATE changelog from P1a (RDR-164 plan-audit finding S1, and
+    the fk-002 sibling nexus-70r3c.3): VALIDATE CONSTRAINT must not sit on the
+    P2->P5 critical path, and it has a hard data prerequisite that P1a does not —
+    the P1a mandatory-registration guard for these five tables only takes effect
+    once P1a DEPLOYS. Any production write to these tables between the RDR-153
+    migrate-all run (2026-06-11, migration-c67ae289, total_failed==0) and the P1a
+    deploy had NO registration guard, so it may have created rows referencing an
+    unregistered collection. NOT VALID skipped retroactive validation of those
+    rows; VALIDATE CONSTRAINT does NOT — it would error loudly on any such orphan.
+
+    Therefore this changelog does TWO things, in order:
+
+      1. fk-003-6-reconcile: re-run the idempotent STUB-REGISTER backfill (the same
+         five INSERT ... ON CONFLICT DO NOTHING statements fk-003-0 ran) against
+         CURRENT data. This catches the gap-window rows: every collection name
+         still referenced by a child table but not yet registered is stub-registered
+         now, so the subsequent VALIDATE has a valid parent for it. This is the
+         no-data-loss arm of the Q5 reconcile (stub-register live references).
+
+         The Q5 "DELETE genuinely-orphaned / FAIL-LOUD on ambiguous" arm is NOT a
+         blind DELETE here: after the stub-register every non-null collection has a
+         parent row, so VALIDATE cannot see an orphan to fail on. If a future schema
+         state somehow leaves a row whose (tenant_id, collection) the stub-register
+         cannot satisfy (it can, for any non-null value — the INSERT is unconditional
+         over DISTINCT child values), VALIDATE FAILS LOUD by design rather than
+         silently dropping data. document_highlights null-collection rows escape the
+         FK (MATCH SIMPLE) and are validated by the fk-001 catalog_documents cascade
+         instead, exactly as in P1a.
+
+      2. fk-003-7..11: VALIDATE CONSTRAINT for each of the five FKs. Each takes a
+         SHARE UPDATE EXCLUSIVE lock on its table (concurrent reads/writes proceed),
+         scans existing rows once, and on success flips pg_constraint.convalidated
+         to true. Idempotent: VALIDATE on an already-validated constraint is a no-op.
+
+    Deploy note (NOT a release gate — the luxe6 freeze gates user-facing PyPI/plugin
+    distribution, not applying liquibase migrations to the engine's own PG): this
+    changelog is safe to ship to develop now. It runs on the next migration of any
+    service. On a fresh DB (CI / testcontainers) there are no rows, so reconcile is
+    a no-op and VALIDATE trivially passes. On live prod it should be applied
+    deliberately with the migration report in hand, because a genuinely-orphaned,
+    stub-unsatisfiable row would (correctly) fail the migration loudly.
+
+    Must come after fk-003-collection-registry-extra.xml (the NOT VALID FKs it
+    validates) in db.changelog-master.xml.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <!-- ── Changeset fk-003-6-reconcile: fresh idempotent stub-register ────────── -->
+    <!--
+        Mirrors fk-003-0-backfill-stubs exactly, re-run against current data to catch
+        any collection referenced by a child table between the 2026-06-11 migration
+        and the P1a registration-guard deploy. ON CONFLICT DO NOTHING keeps it
+        idempotent and safe to re-apply. document_highlights contributes only
+        non-null, non-empty collection values (null rows escape the FK).
+    -->
+    <changeSet id="fk-003-6-reconcile" author="nexus-p9aw6">
+        <comment>
+            Re-stub-register catalog_collections rows for every collection referenced by
+            document_aspects, aspect_extraction_queue, topics, taxonomy_meta, and
+            document_highlights (non-null) that is not already registered — the gap-window
+            reconcile that precedes VALIDATE. Idempotent (ON CONFLICT DO NOTHING).
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.document_aspects
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.aspect_extraction_queue
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.topics
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.taxonomy_meta
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+INSERT INTO nexus.catalog_collections (tenant_id, name)
+SELECT DISTINCT tenant_id, collection
+FROM nexus.document_highlights
+WHERE collection IS NOT NULL AND collection != ''
+ON CONFLICT (tenant_id, name) DO NOTHING;
+        </sql>
+        <rollback>
+            <!-- No rollback: stub rows are inert and may now be referenced. The FKs being
+                 validated next own their own DROP CONSTRAINT rollbacks in fk-003. -->
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset fk-003-7: VALIDATE document_aspects_collection_fk ──────────── -->
+    <changeSet id="fk-003-7" author="nexus-p9aw6">
+        <comment>
+            VALIDATE document_aspects_collection_fk — retroactively check pre-existing rows
+            now that the gap-window reconcile has registered their collections.
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.document_aspects VALIDATE CONSTRAINT document_aspects_collection_fk;
+        </sql>
+        <rollback>
+            <!-- VALIDATE cannot be un-done (no INVALIDATE in PG); the constraint itself is
+                 dropped by fk-003-1's rollback. No-op here. -->
+        </rollback>
+    </changeSet>
+
+    <!-- ── Changeset fk-003-8: VALIDATE aspect_extraction_queue_collection_fk ───── -->
+    <changeSet id="fk-003-8" author="nexus-p9aw6">
+        <comment>VALIDATE aspect_extraction_queue_collection_fk.</comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.aspect_extraction_queue VALIDATE CONSTRAINT aspect_extraction_queue_collection_fk;
+        </sql>
+        <rollback/>
+    </changeSet>
+
+    <!-- ── Changeset fk-003-9: VALIDATE topics_collection_fk ────────────────────── -->
+    <changeSet id="fk-003-9" author="nexus-p9aw6">
+        <comment>VALIDATE topics_collection_fk.</comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.topics VALIDATE CONSTRAINT topics_collection_fk;
+        </sql>
+        <rollback/>
+    </changeSet>
+
+    <!-- ── Changeset fk-003-10: VALIDATE taxonomy_meta_collection_fk ────────────── -->
+    <changeSet id="fk-003-10" author="nexus-p9aw6">
+        <comment>VALIDATE taxonomy_meta_collection_fk.</comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.taxonomy_meta VALIDATE CONSTRAINT taxonomy_meta_collection_fk;
+        </sql>
+        <rollback/>
+    </changeSet>
+
+    <!-- ── Changeset fk-003-11: VALIDATE document_highlights_collection_fk ──────── -->
+    <changeSet id="fk-003-11" author="nexus-p9aw6">
+        <comment>
+            VALIDATE document_highlights_collection_fk. Null-collection rows are skipped by
+            MATCH SIMPLE and remain governed by the fk-001 catalog_documents cascade.
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.document_highlights VALIDATE CONSTRAINT document_highlights_collection_fk;
+        </sql>
+        <rollback/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/test/java/dev/nexus/service/CollectionRegistryFkExtraTest.java
+++ b/service/src/test/java/dev/nexus/service/CollectionRegistryFkExtraTest.java
@@ -416,72 +416,174 @@ class CollectionRegistryFkExtraTest {
     }
 
     // ══════════════════════════════════════════════════════════════════════════
-    // GROUP G — RDR-164 P1b (nexus-p9aw6): the reconcile→VALIDATE flow.
+    // GROUP G — RDR-164 P1b (nexus-p9aw6): the reconcile→VALIDATE flow, per FK.
     //
     // Proves the gap-window reconcile is LOAD-BEARING for VALIDATE: a row referencing
     // an unregistered collection (the gap-window orphan class) makes VALIDATE FAIL;
     // re-running the stub-register reconcile registers the collection so VALIDATE then
-    // SUCCEEDS and flips convalidated=true. Self-contained: re-creates the FK itself
-    // (GROUP F @Order(60) dropped it) and seeds the orphan while the FK is ABSENT
-    // (NOT VALID still enforces NEW inserts, so the orphan cannot be inserted under it).
-    // The SQL mirrors fk-003-validate.xml changesets fk-003-6-reconcile + fk-003-7.
+    // SUCCEEDS and flips convalidated=true. Self-contained per test: re-creates the FK
+    // itself (GROUP F @Order(60) dropped all five) and seeds the orphan while the FK is
+    // ABSENT (NOT VALID still enforces NEW inserts, so the orphan cannot be inserted
+    // under it). Each test uses a distinct tenant so the "not registered before
+    // reconcile" precondition holds independently.
+    //
+    // Coverage spans ALL FIVE FKs, mirroring fk-003-validate.xml changesets
+    // fk-003-6-reconcile (the five INSERT-SELECT arms) + fk-003-7..11 (VALIDATE). The
+    // four tables beyond document_aspects have materially distinct shapes — topics
+    // (BIGSERIAL PK), taxonomy_meta (PK = (tenant_id, collection)), document_highlights
+    // (NULLABLE collection + the reconcile's WHERE collection IS NOT NULL AND != ''
+    // filter) — so each gets its own causal proof rather than relying on SQL similarity.
+    //
+    // Teardown is container-scoped: @AfterAll pg.stop() drops the whole DB, so the
+    // re-added FKs and orphan rows these tests leave behind do not leak. Any future
+    // @Order(>74) group must account for that residual state explicitly.
     // ══════════════════════════════════════════════════════════════════════════
 
     @Test @Order(70)
-    void reconcileThenValidate_registersGapWindowOrphan_soValidateSucceeds() throws Exception {
-        final String T = "crfkx-p1b-tenant";
-        final String ORPHAN_COL = "p1b-orphan-col";
+    void reconcileThenValidate_documentAspects_gapWindowOrphan() throws Exception {
+        final String T = "crfkx-p1b-aspects";
+        final String ORPHAN_COL = "p1b-orphan-aspects";
         try (Connection su = pg.createConnection("")) {
             su.setAutoCommit(true);
-
-            // FK absent (dropped by GROUP F); seed an orphan row while it is absent.
-            su.createStatement().execute(
-                "ALTER TABLE nexus.document_aspects DROP CONSTRAINT IF EXISTS document_aspects_collection_fk");
-            su.createStatement().execute(
+            assertReconcileLoadBearing(su, "document_aspects", FK_DOC_ASPECTS, T, ORPHAN_COL,
                 "INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name) " +
-                "VALUES ('" + T + "', '" + ORPHAN_COL + "', '/p1b/o.md', NOW(), 'v1', 'test')");
-            assertThat(count(su, "SELECT COUNT(*) FROM nexus.catalog_collections " +
-                "WHERE tenant_id='" + T + "' AND name='" + ORPHAN_COL + "'"))
-                .as("orphan collection is NOT registered before reconcile").isZero();
-
-            // Re-add the FK as NOT VALID — succeeds (NOT VALID skips existing-row validation).
-            su.createStatement().execute(
-                "ALTER TABLE nexus.document_aspects " +
-                "ADD CONSTRAINT document_aspects_collection_fk " +
-                "FOREIGN KEY (tenant_id, collection) " +
-                "REFERENCES nexus.catalog_collections (tenant_id, name) " +
-                "ON DELETE RESTRICT NOT VALID");
-
-            // VALIDATE must FAIL while the orphan is unregistered — proves it is load-bearing.
-            PSQLException ex = assertThrows(PSQLException.class, () ->
-                su.createStatement().execute(
-                    "ALTER TABLE nexus.document_aspects VALIDATE CONSTRAINT document_aspects_collection_fk"));
-            assertThat(ex.getMessage())
-                .as("VALIDATE must fail loud on a gap-window orphan before reconcile")
-                .containsIgnoringCase("document_aspects_collection_fk");
-
-            // Reconcile: re-run the document_aspects stub-register (fk-003-6-reconcile arm).
-            su.createStatement().execute(
+                "VALUES ('" + T + "', '" + ORPHAN_COL + "', '/p1b/o.md', NOW(), 'v1', 'test')",
                 "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
                 "SELECT DISTINCT tenant_id, collection FROM nexus.document_aspects " +
                 "ON CONFLICT (tenant_id, name) DO NOTHING");
-            assertThat(count(su, "SELECT COUNT(*) FROM nexus.catalog_collections " +
-                "WHERE tenant_id='" + T + "' AND name='" + ORPHAN_COL + "'"))
-                .as("reconcile stub-registers the gap-window collection").isEqualTo(1);
+        }
+    }
 
-            // VALIDATE now SUCCEEDS and flips convalidated=true.
+    @Test @Order(71)
+    void reconcileThenValidate_aspectQueue_gapWindowOrphan() throws Exception {
+        final String T = "crfkx-p1b-queue";
+        final String ORPHAN_COL = "p1b-orphan-queue";
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            assertReconcileLoadBearing(su, "aspect_extraction_queue", FK_ASPECT_QUEUE, T, ORPHAN_COL,
+                "INSERT INTO nexus.aspect_extraction_queue (tenant_id, collection, source_path, status, enqueued_at) " +
+                "VALUES ('" + T + "', '" + ORPHAN_COL + "', '/p1b/q.md', 'pending', NOW())",
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+                "SELECT DISTINCT tenant_id, collection FROM nexus.aspect_extraction_queue " +
+                "ON CONFLICT (tenant_id, name) DO NOTHING");
+        }
+    }
+
+    @Test @Order(72)
+    void reconcileThenValidate_topics_gapWindowOrphan() throws Exception {
+        final String T = "crfkx-p1b-topics";
+        final String ORPHAN_COL = "p1b-orphan-topic";
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            assertReconcileLoadBearing(su, "topics", FK_TOPICS, T, ORPHAN_COL,
+                "INSERT INTO nexus.topics (tenant_id, label, collection, doc_count, created_at, review_status) " +
+                "VALUES ('" + T + "', 'topic-p1b', '" + ORPHAN_COL + "', 0, NOW(), 'pending')",
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+                "SELECT DISTINCT tenant_id, collection FROM nexus.topics " +
+                "ON CONFLICT (tenant_id, name) DO NOTHING");
+        }
+    }
+
+    @Test @Order(73)
+    void reconcileThenValidate_taxonomyMeta_gapWindowOrphan() throws Exception {
+        final String T = "crfkx-p1b-meta";
+        final String ORPHAN_COL = "p1b-orphan-meta";
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            assertReconcileLoadBearing(su, "taxonomy_meta", FK_TAX_META, T, ORPHAN_COL,
+                "INSERT INTO nexus.taxonomy_meta (tenant_id, collection) " +
+                "VALUES ('" + T + "', '" + ORPHAN_COL + "')",
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+                "SELECT DISTINCT tenant_id, collection FROM nexus.taxonomy_meta " +
+                "ON CONFLICT (tenant_id, name) DO NOTHING");
+        }
+    }
+
+    @Test @Order(74)
+    void reconcileThenValidate_documentHighlights_gapWindowOrphan() throws Exception {
+        final String T = "crfkx-p1b-hl";
+        final String ORPHAN_COL = "p1b-orphan-hl";
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            // GROUP F @Order(60) deliberately left an empty-string-collection highlight row
+            // (bf-hl-3, collection='') and proved the reconcile's WHERE collection != '' filter
+            // refuses to register it. Such a row is a STUB-UNSATISFIABLE orphan: it is non-null
+            // (MATCH SIMPLE enforces it) yet the reconcile will never give it a parent, so
+            // VALIDATE fails LOUD on it by design (arm-c, the intended safety property; the
+            // non-registration is already asserted by GROUP F). Remove it here so this case can
+            // isolate the happy-path gap-window reconcile proof for a real (non-empty) collection.
             su.createStatement().execute(
-                "ALTER TABLE nexus.document_aspects VALIDATE CONSTRAINT document_aspects_collection_fk");
-            ResultSet rs = su.createStatement().executeQuery(
-                "SELECT convalidated FROM pg_constraint c JOIN pg_namespace n ON n.oid = c.connamespace " +
-                "WHERE c.contype='f' AND c.conname='document_aspects_collection_fk' AND n.nspname='nexus'");
-            assertThat(rs.next()).isTrue();
-            assertThat(rs.getBoolean("convalidated"))
-                .as("VALIDATE succeeds after reconcile → convalidated=true").isTrue();
+                "DELETE FROM nexus.document_highlights WHERE collection = ''");
+            // document_highlights is doc-rooted (fk-001): seed the parent catalog_documents
+            // row so the ONLY remaining VALIDATE failure is the collection FK under test.
+            insertCatalogDocument(su, T, "hl-doc-p1b");
+            // The document_highlights reconcile arm carries the WHERE collection IS NOT NULL
+            // AND collection != '' filter (collection is NULLABLE here, MATCH SIMPLE) — this
+            // is the materially-distinct arm; proving it still registers a real gap-window
+            // collection is the point of this case.
+            assertReconcileLoadBearing(su, "document_highlights", FK_DOC_HL, T, ORPHAN_COL,
+                "INSERT INTO nexus.document_highlights (tenant_id, doc_id, collection, ingested_at) " +
+                "VALUES ('" + T + "', 'hl-doc-p1b', '" + ORPHAN_COL + "', NOW())",
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+                "SELECT DISTINCT tenant_id, collection FROM nexus.document_highlights " +
+                "WHERE collection IS NOT NULL AND collection != '' " +
+                "ON CONFLICT (tenant_id, name) DO NOTHING");
         }
     }
 
     // ── helpers ────────────────────────────────────────────────────────────────
+
+    /**
+     * Drives the RDR-164 P1b reconcile→VALIDATE causal proof for one collection FK:
+     * the FK is absent (GROUP F dropped all five), an orphan row referencing an
+     * unregistered collection is seeded while absent, the FK is re-added NOT VALID,
+     * VALIDATE FAILS on the orphan, the reconcile stub-registers the collection, and
+     * VALIDATE then SUCCEEDS with convalidated=true. {@code orphanInsertSql} and
+     * {@code reconcileInsertSql} are the table-specific arms mirroring
+     * fk-003-validate.xml fk-003-6-reconcile.
+     */
+    private void assertReconcileLoadBearing(
+            Connection su, String table, String fkName, String tenant, String orphanCol,
+            String orphanInsertSql, String reconcileInsertSql) throws Exception {
+        // FK absent (dropped by GROUP F); seed an orphan row while it is absent.
+        su.createStatement().execute(
+            "ALTER TABLE nexus." + table + " DROP CONSTRAINT IF EXISTS " + fkName);
+        su.createStatement().execute(orphanInsertSql);
+        assertThat(count(su, "SELECT COUNT(*) FROM nexus.catalog_collections " +
+            "WHERE tenant_id='" + tenant + "' AND name='" + orphanCol + "'"))
+            .as(table + ": orphan collection is NOT registered before reconcile").isZero();
+
+        // Re-add the FK as NOT VALID — succeeds (NOT VALID skips existing-row validation).
+        su.createStatement().execute(
+            "ALTER TABLE nexus." + table + " ADD CONSTRAINT " + fkName + " " +
+            "FOREIGN KEY (tenant_id, collection) " +
+            "REFERENCES nexus.catalog_collections (tenant_id, name) " +
+            "ON DELETE RESTRICT NOT VALID");
+
+        // VALIDATE must FAIL while the orphan is unregistered — proves reconcile is load-bearing.
+        PSQLException ex = assertThrows(PSQLException.class, () ->
+            su.createStatement().execute(
+                "ALTER TABLE nexus." + table + " VALIDATE CONSTRAINT " + fkName));
+        assertThat(ex.getMessage())
+            .as(table + ": VALIDATE must fail loud on a gap-window orphan before reconcile")
+            .containsIgnoringCase(fkName);
+
+        // Reconcile: re-run this table's stub-register arm (fk-003-6-reconcile).
+        su.createStatement().execute(reconcileInsertSql);
+        assertThat(count(su, "SELECT COUNT(*) FROM nexus.catalog_collections " +
+            "WHERE tenant_id='" + tenant + "' AND name='" + orphanCol + "'"))
+            .as(table + ": reconcile stub-registers the gap-window collection").isEqualTo(1);
+
+        // VALIDATE now SUCCEEDS and flips convalidated=true.
+        su.createStatement().execute(
+            "ALTER TABLE nexus." + table + " VALIDATE CONSTRAINT " + fkName);
+        ResultSet rs = su.createStatement().executeQuery(
+            "SELECT convalidated FROM pg_constraint c JOIN pg_namespace n ON n.oid = c.connamespace " +
+            "WHERE c.contype='f' AND c.conname='" + fkName + "' AND n.nspname='nexus'");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getBoolean("convalidated"))
+            .as(table + ": VALIDATE succeeds after reconcile → convalidated=true").isTrue();
+    }
 
     private static void insertCollection(Connection su, String tenantId, String name) throws Exception {
         su.createStatement().execute(

--- a/service/src/test/java/dev/nexus/service/CollectionRegistryFkExtraTest.java
+++ b/service/src/test/java/dev/nexus/service/CollectionRegistryFkExtraTest.java
@@ -237,12 +237,14 @@ class CollectionRegistryFkExtraTest {
     }
 
     // ══════════════════════════════════════════════════════════════════════════
-    // GROUP C — NOT VALID pin: all five FK rows exist with convalidated=false.
-    // P1b's VALIDATE CONSTRAINT will flip these to true and update this assertion.
+    // GROUP C — VALIDATED pin: after RDR-164 P1b (fk-003-validate.xml) the five FKs
+    // are convalidated=true. The full master changelog applied by this test includes
+    // P1b's gap-window reconcile + VALIDATE CONSTRAINT, so on a freshly-migrated DB
+    // (no orphan rows) all five validate cleanly.
     // ══════════════════════════════════════════════════════════════════════════
 
     @Test @Order(30)
-    void allFiveExtraCollectionFks_existAndAreNotValid() throws Exception {
+    void allFiveExtraCollectionFks_existAndAreValidated() throws Exception {
         try (Connection su = pg.createConnection("")) {
             for (String fkName : ALL_FIVE_FK_NAMES) {
                 ResultSet rs = su.createStatement().executeQuery(
@@ -252,8 +254,8 @@ class CollectionRegistryFkExtraTest {
                 assertThat(rs.next())
                     .as("FK constraint " + fkName + " must exist in pg_constraint").isTrue();
                 assertThat(rs.getBoolean("convalidated"))
-                    .as("FK " + fkName + " must be NOT VALID (convalidated=false) until P1b VALIDATE runs")
-                    .isFalse();
+                    .as("FK " + fkName + " must be VALIDATED (convalidated=true) after P1b VALIDATE runs")
+                    .isTrue();
             }
         }
     }
@@ -410,6 +412,72 @@ class CollectionRegistryFkExtraTest {
                 "AND name IN ('bf-colA','bf-colB','bf-colC','bf-colD','bf-colE')"))
                 .as("the 5 expected collection names must each be registered exactly once")
                 .isEqualTo(5);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GROUP G — RDR-164 P1b (nexus-p9aw6): the reconcile→VALIDATE flow.
+    //
+    // Proves the gap-window reconcile is LOAD-BEARING for VALIDATE: a row referencing
+    // an unregistered collection (the gap-window orphan class) makes VALIDATE FAIL;
+    // re-running the stub-register reconcile registers the collection so VALIDATE then
+    // SUCCEEDS and flips convalidated=true. Self-contained: re-creates the FK itself
+    // (GROUP F @Order(60) dropped it) and seeds the orphan while the FK is ABSENT
+    // (NOT VALID still enforces NEW inserts, so the orphan cannot be inserted under it).
+    // The SQL mirrors fk-003-validate.xml changesets fk-003-6-reconcile + fk-003-7.
+    // ══════════════════════════════════════════════════════════════════════════
+
+    @Test @Order(70)
+    void reconcileThenValidate_registersGapWindowOrphan_soValidateSucceeds() throws Exception {
+        final String T = "crfkx-p1b-tenant";
+        final String ORPHAN_COL = "p1b-orphan-col";
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+
+            // FK absent (dropped by GROUP F); seed an orphan row while it is absent.
+            su.createStatement().execute(
+                "ALTER TABLE nexus.document_aspects DROP CONSTRAINT IF EXISTS document_aspects_collection_fk");
+            su.createStatement().execute(
+                "INSERT INTO nexus.document_aspects (tenant_id, collection, source_path, extracted_at, model_version, extractor_name) " +
+                "VALUES ('" + T + "', '" + ORPHAN_COL + "', '/p1b/o.md', NOW(), 'v1', 'test')");
+            assertThat(count(su, "SELECT COUNT(*) FROM nexus.catalog_collections " +
+                "WHERE tenant_id='" + T + "' AND name='" + ORPHAN_COL + "'"))
+                .as("orphan collection is NOT registered before reconcile").isZero();
+
+            // Re-add the FK as NOT VALID — succeeds (NOT VALID skips existing-row validation).
+            su.createStatement().execute(
+                "ALTER TABLE nexus.document_aspects " +
+                "ADD CONSTRAINT document_aspects_collection_fk " +
+                "FOREIGN KEY (tenant_id, collection) " +
+                "REFERENCES nexus.catalog_collections (tenant_id, name) " +
+                "ON DELETE RESTRICT NOT VALID");
+
+            // VALIDATE must FAIL while the orphan is unregistered — proves it is load-bearing.
+            PSQLException ex = assertThrows(PSQLException.class, () ->
+                su.createStatement().execute(
+                    "ALTER TABLE nexus.document_aspects VALIDATE CONSTRAINT document_aspects_collection_fk"));
+            assertThat(ex.getMessage())
+                .as("VALIDATE must fail loud on a gap-window orphan before reconcile")
+                .containsIgnoringCase("document_aspects_collection_fk");
+
+            // Reconcile: re-run the document_aspects stub-register (fk-003-6-reconcile arm).
+            su.createStatement().execute(
+                "INSERT INTO nexus.catalog_collections (tenant_id, name) " +
+                "SELECT DISTINCT tenant_id, collection FROM nexus.document_aspects " +
+                "ON CONFLICT (tenant_id, name) DO NOTHING");
+            assertThat(count(su, "SELECT COUNT(*) FROM nexus.catalog_collections " +
+                "WHERE tenant_id='" + T + "' AND name='" + ORPHAN_COL + "'"))
+                .as("reconcile stub-registers the gap-window collection").isEqualTo(1);
+
+            // VALIDATE now SUCCEEDS and flips convalidated=true.
+            su.createStatement().execute(
+                "ALTER TABLE nexus.document_aspects VALIDATE CONSTRAINT document_aspects_collection_fk");
+            ResultSet rs = su.createStatement().executeQuery(
+                "SELECT convalidated FROM pg_constraint c JOIN pg_namespace n ON n.oid = c.connamespace " +
+                "WHERE c.contype='f' AND c.conname='document_aspects_collection_fk' AND n.nspname='nexus'");
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getBoolean("convalidated"))
+                .as("VALIDATE succeeds after reconcile → convalidated=true").isTrue();
         }
     }
 


### PR DESCRIPTION
## Summary

Completes the fk-003 collection-registry FK spine by **VALIDATEing** the five `NOT VALID` `ON DELETE RESTRICT` collection FKs that P1a (`nexus-dcqml`) added in the deferred-validation shape — `document_aspects` / `aspect_extraction_queue` / `topics` / `taxonomy_meta` / `document_highlights` `_collection_fk`. This is the final phase child of the RDR-164 epic (`nexus-y07vh`).

## Changes

New `service/src/main/resources/db/changelog/fk-003-validate.xml`, registered after `fk-003-collection-registry-extra`:

- **`fk-003-6-reconcile`**: re-runs the idempotent **stub-register** backfill (the same five `INSERT ... ON CONFLICT DO NOTHING` statements as `fk-003-0`, verified verbatim) against current data. Catches **gap-window rows** — any collection referenced by a child table between the RDR-153 migrate-all run (2026-06-11, `total_failed==0`) and the P1a registration-guard deploy — and registers it so VALIDATE has a parent. This is the no-data-loss arm of the Q5 reconcile; the FAIL-LOUD arm is VALIDATE itself.
- **`fk-003-7..11`**: `VALIDATE CONSTRAINT` per FK. Idempotent (re-run = no-op); empty rollback (VALIDATE can't be un-done — the `DROP CONSTRAINT` lives in fk-003).

## Design note (Q5 reconcile)

Implemented the **stub-register** arm + rely on VALIDATE's own fail-loud, rather than a `DELETE genuinely-orphaned` arm. A collection referenced by a child row has live derived state *by construction* — it isn't a dead collection to delete; choosing DELETE would be silent data loss. Stubs are inert and cleaned by the normal P2 collection-delete cascade (no phantom-row accumulation). A genuinely-orphaned, stub-unsatisfiable row fails the migration loudly — the intended safety property, not a regression.

## Why separate from P1a

VALIDATE must stay off the P2→P5 critical path (plan-audit S1; fk-002 sibling `nexus-70r3c.3`), and its data prerequisite (P1a's registration guard live) is satisfied only after P1a deploys. On an existing prod DB liquibase runs only these new changesets; on a fresh DB (CI) the reconcile is a no-op and VALIDATE trivially passes.

## Tests

- `CollectionRegistryFkExtraTest` GROUP C @Order(30) flipped → asserts `convalidated=TRUE`.
- New GROUP G @Order(70) proves the reconcile is **load-bearing**: seed an orphan while the FK is absent (NOT VALID still enforces new inserts) → VALIDATE **fails** → reconcile → VALIDATE **succeeds** + `convalidated=true`.
- `fk-003-collection-registry-extra.xml` untouched (no liquibase checksum change). **Full `mvn -o test`: 849 green.**

## ⚠️ Review status

The stacked review (`code-review-expert` + `substantive-critic`) is **pending** — the review subagents were blocked by a sustained upstream API 529 outage at author time. I performed an inline verification of the full checklist (reconcile-SQL-verbatim, changeset-id uniqueness + ordering, VALIDATE idempotency/rollback, GROUP G self-containment, GROUP C flip, no checksum risk) and the Q5 design crux, all clean. **Do not merge until the formal stacked review runs** — auto-merge is intentionally NOT armed.

## Live-prod note

The `luxe6` freeze gates user-facing PyPI/plugin distribution, not applying liquibase migrations to the engine's own PG. Applying this to live prod is a deliberate ops step (apply with the migration report in hand; a corrupt row would correctly fail the migration).

Refs nexus-p9aw6