### PR TITLE
fix(service): legible 404 on rename of a non-existent collection (nexus-hz785)

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -1246,6 +1246,12 @@ public final class CatalogRepository {
         });
     }
 
+    /** True if a (tenant, name) collection registry row exists. RLS-scoped. */
+    public boolean collectionExists(String tenant, String name) {
+        return tenantScope.withTenant(tenant, ctx -> ctx.fetchExists(
+            ctx.selectOne().from(CATALOG_COLLECTIONS).where(CATALOG_COLLECTIONS.NAME.eq(name))));
+    }
+
     /**
      * Rename a collection X-&gt;Y, re-homing every in-Postgres denorm-collection table in
      * one RLS-scoped transaction (RDR-164 P3, bead nexus-77vve). Returns per-table re-home

--- a/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
@@ -645,6 +645,13 @@ public final class CatalogHandler implements HttpHandler {
         if (oldName == null || newName == null) {
             HttpUtil.send(exchange, 400, "{\"error\":\"old_name/new_name (or old/new) required\"}"); return;
         }
+        // nexus-hz785: a rename of an unregistered collection used to return 200 with all-zero
+        // counts (insert-select copies 0 rows, every child UPDATE touches 0) — a silent no-op on
+        // a typo. Fail loud with a legible 404 instead.
+        if (!repo.collectionExists(tenant, oldName)) {
+            HttpUtil.send(exchange, 404,
+                "{\"error\":" + MAPPER.writeValueAsString("collection not found: " + oldName) + "}"); return;
+        }
         Map<String, Integer> counts = repo.renameCollection(tenant, oldName, newName);
         HttpUtil.send(exchange, 200, MAPPER.writeValueAsString(Map.of("renamed", counts)));
     }

--- a/service/src/test/java/dev/nexus/service/CatalogHandlerRenameTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogHandlerRenameTest.java
@@ -142,6 +142,16 @@ class CatalogHandlerRenameTest {
     }
 
     @Test
+    void post_renameMissingCollection_returns404() throws Exception {
+        // nexus-hz785: renaming an unregistered collection must fail loud with 404, not
+        // silently return 200 with all-zero counts.
+        var resp = post("/v1/catalog/collections/rename",
+            "{\"old_name\":\"hren__never-registered-xyz\",\"new_name\":\"hren__missing-target\"}");
+        assertThat(resp.statusCode()).isEqualTo(404);
+        assertThat(resp.body()).contains("collection not found");
+    }
+
+    @Test
     void get_returns405() throws Exception {
         var req = HttpRequest.newBuilder()
             .uri(URI.create("http://127.0.0.1:" + service.getPort() + "/v1/catalog/collections/rename"))


### PR DESCRIPTION
## Summary
`nexus-hz785` (pgvector-coherent rename for chunk-owning collections, RDR-156 P0 critic finding S1) is **substantially superseded by RDR-164 P3** (#1275): the coherent multi-step chunk re-home — insert registry Y, UPDATE `chunks_{384,768,1024}.collection` + `chash_index.physical_collection` + all child tables, delete X, in one RLS-scoped transaction (`topic_assignments` follows in the same UPDATE) — already shipped and is proven by `CollectionRegistryFkTest` group-12 (`@Order 120`) and `CatalogRenameCollectionTest`. The handler also already genericizes errors (no raw JDBC/PSQLException leak).

This PR closes the **sole residual**: renaming an unregistered collection returned `200` with all-zero counts (insert-select copies 0 rows; every child UPDATE touches 0) — a silent no-op on a typo. It now fails loud with `404 collection not found`.

## Changes
- `CatalogRepository.collectionExists(tenant, name)` — thin RLS-scoped `fetchExists`.
- `CatalogHandler.handleCollectionRename` — 404 guard before `renameCollection`, matching the handler's existing fetch-then-`null→404` convention. The cross-model RDR-162 branch is unaffected (its source is always registered).
- `CatalogHandlerRenameTest` — `+post_renameMissingCollection_returns404`.

## Verification
CatalogHandlerRenameTest 6/6, CatalogRenameCollectionTest 6/6, CollectionRegistryFkTest 40/40; full `mvn -o test` 881, 0 failures / 0 errors.

## Closes
Closes nexus-hz785