### PR TITLE
fix(service): 409 on plain rename collision; cross_model flag for RDR-162 repoint (nexus-gaou3)

### DIFF
--- a/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
@@ -652,6 +652,17 @@ public final class CatalogHandler implements HttpHandler {
             HttpUtil.send(exchange, 404,
                 "{\"error\":" + MAPPER.writeValueAsString("collection not found: " + oldName) + "}"); return;
         }
+        // nexus-gaou3: if new_name is ALREADY a registered collection, renameCollection silently
+        // takes the RDR-162 cross-model COPY branch (repoints catalog_documents ONLY; chunks/
+        // taxonomy/aspects are NOT moved). That is correct ONLY for the deliberate cross-model
+        // migrate. A plain rename onto an existing collection is a collision: fail loud with 409
+        // unless the caller opts into the COPY branch via cross_model:true.
+        boolean crossModel = Boolean.TRUE.equals(body.get("cross_model"));
+        if (!crossModel && repo.collectionExists(tenant, newName)) {
+            HttpUtil.send(exchange, 409,
+                "{\"error\":" + MAPPER.writeValueAsString("target collection already exists: " + newName
+                    + " (pass cross_model:true only for a deliberate cross-model repoint)") + "}"); return;
+        }
         Map<String, Integer> counts = repo.renameCollection(tenant, oldName, newName);
         HttpUtil.send(exchange, 200, MAPPER.writeValueAsString(Map.of("renamed", counts)));
     }

--- a/service/src/test/java/dev/nexus/service/CatalogHandlerRenameTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogHandlerRenameTest.java
@@ -152,6 +152,50 @@ class CatalogHandlerRenameTest {
     }
 
     @Test
+    void post_renameOntoExistingCollection_returns409() throws Exception {
+        // nexus-gaou3: a plain rename onto an already-registered collection is a collision —
+        // it must 409, not silently take the RDR-162 cross-model COPY branch (repoint-only).
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("INSERT INTO nexus.catalog_collections (tenant_id, name) "
+                + "VALUES ('" + TENANT + "', 'hren__c409-src') ON CONFLICT DO NOTHING");
+            su.createStatement().execute("INSERT INTO nexus.catalog_collections (tenant_id, name) "
+                + "VALUES ('" + TENANT + "', 'hren__c409-tgt') ON CONFLICT DO NOTHING");
+        }
+        var resp = post("/v1/catalog/collections/rename",
+            "{\"old_name\":\"hren__c409-src\",\"new_name\":\"hren__c409-tgt\"}");
+        assertThat(resp.statusCode()).isEqualTo(409);
+        assertThat(resp.body()).contains("target collection already exists");
+    }
+
+    @Test
+    void post_crossModelTrue_ontoExistingTarget_returns200Repoint() throws Exception {
+        // nexus-gaou3: cross_model:true opts into the RDR-162 repoint branch — target already
+        // exists (ETL populated it), only catalog_documents.physical_collection moves.
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("INSERT INTO nexus.catalog_collections (tenant_id, name) "
+                + "VALUES ('" + TENANT + "', 'hren__xm-src') ON CONFLICT DO NOTHING");
+            su.createStatement().execute("INSERT INTO nexus.catalog_collections (tenant_id, name) "
+                + "VALUES ('" + TENANT + "', 'hren__xm-tgt') ON CONFLICT DO NOTHING");
+            su.createStatement().execute("INSERT INTO nexus.catalog_documents "
+                + "(tenant_id, tumbler, title, physical_collection) "
+                + "VALUES ('" + TENANT + "', 'xm-doc-1', 'XM', 'hren__xm-src') ON CONFLICT DO NOTHING");
+        }
+        var resp = post("/v1/catalog/collections/rename",
+            "{\"old_name\":\"hren__xm-src\",\"new_name\":\"hren__xm-tgt\",\"cross_model\":true}");
+        assertThat(resp.statusCode()).isEqualTo(200);
+        var body = mapper.readValue(resp.body(), MAP_T);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> renamed = (Map<String, Object>) body.get("renamed");
+        // cross-model COPY branch returns ONLY catalog_documents (repoint, not full re-home).
+        assertThat(((Number) renamed.get("catalog_documents")).intValue())
+            .as("the doc under the source repoints to the target").isEqualTo(1);
+        assertThat(renamed).as("no full re-home in the cross-model branch")
+            .doesNotContainKey("catalog_collections_inserted");
+    }
+
+    @Test
     void get_returns405() throws Exception {
         var req = HttpRequest.newBuilder()
             .uri(URI.create("http://127.0.0.1:" + service.getPort() + "/v1/catalog/collections/rename"))

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -1061,13 +1061,15 @@ class HttpCatalogClient:
         result = self._post("/collections/supersede", payload)
         return int(result.get("updated", 0) if result else 0)
 
-    def rename_collection(self, old: str, new: str) -> int:
+    def rename_collection(self, old: str, new: str, *, cross_model: bool = False) -> int:
         # RDR-164 P3: the consolidated endpoint returns {"renamed": {per-table counts}}.
         # The int contract reports the re-homed catalog_documents count.
-        renamed = self.rename_collection_cascade(old, new)
+        renamed = self.rename_collection_cascade(old, new, cross_model=cross_model)
         return int(renamed.get("catalog_documents", 0))
 
-    def rename_collection_cascade(self, old: str, new: str) -> dict[str, int]:
+    def rename_collection_cascade(
+        self, old: str, new: str, *, cross_model: bool = False
+    ) -> dict[str, int]:
         """RDR-164 P3: atomically re-home a collection X->Y and all its in-Postgres
         derived state via the service's single transactional renameCollection.
 
@@ -1079,8 +1081,16 @@ class HttpCatalogClient:
         The cross-model COPY branch (target already registered) returns only
         ``catalog_documents``. ``pipeline.db`` and the local-mode fan-out stay
         client-side (see ``rename_collection_data_plane``).
+
+        ``cross_model`` (nexus-gaou3): pass ``True`` ONLY for a deliberate RDR-162
+        cross-model repoint where ``new`` is already a populated target. With the
+        default ``False`` the service rejects an existing ``new`` with 409 (a plain
+        rename onto an existing collection is a collision, not a silent COPY).
         """
-        result = self._post("/collections/rename", {"old_name": old, "new_name": new})
+        body: dict[str, Any] = {"old_name": old, "new_name": new}
+        if cross_model:
+            body["cross_model"] = True
+        result = self._post("/collections/rename", body)
         renamed = (result or {}).get("renamed", {}) or {}
         return {k: int(v) for k, v in renamed.items()}
 

--- a/src/nexus/collection_rename.py
+++ b/src/nexus/collection_rename.py
@@ -261,7 +261,19 @@ def remap_collection_references(
         if catalog is None:
             from nexus.catalog.factory import make_catalog_writer  # noqa: PLC0415
             catalog = make_catalog_writer()
-        counts["catalog_docs"] = catalog.rename_collection(source, target)
+        # nexus-gaou3: this IS the legitimate cross-model repoint (target already
+        # populated by the ETL). In service mode the Java endpoint 409s a rename onto
+        # an existing target UNLESS cross_model=True, so signal it. Only pass the kwarg
+        # in service mode — the local catalog writer's rename_collection has no such
+        # parameter (and local mode has no 409 to bypass).
+        from nexus.db.storage_mode import StorageBackend, storage_backend_for  # noqa: PLC0415
+
+        if storage_backend_for("catalog") == StorageBackend.SERVICE:
+            counts["catalog_docs"] = catalog.rename_collection(
+                source, target, cross_model=True
+            )
+        else:
+            counts["catalog_docs"] = catalog.rename_collection(source, target)
     except Exception as exc:
         on_warn(
             f"warn: T2 reference remap succeeded but catalog cascade failed: {exc}"

--- a/tests/catalog/test_http_catalog_client.py
+++ b/tests/catalog/test_http_catalog_client.py
@@ -49,6 +49,13 @@ def _entry_dict(**kwargs: Any) -> dict:
 class FakeCatalogHandler(BaseHTTPRequestHandler):
     """Routes matching the real CatalogHandler.java switch cases exactly."""
 
+    #: nexus-gaou3: last body POSTed to /collections/rename (for cross_model assertions).
+    last_rename_body: dict[str, Any] = {}
+    #: nexus-gaou3: when True, /collections/rename 409s a plain (cross_model-absent)
+    #: rename, mirroring the server's collision guard so the client's error
+    #: propagation can be asserted.
+    rename_conflicts: bool = False
+
     def log_message(self, *args: Any) -> None:
         pass  # suppress test noise
 
@@ -167,9 +174,14 @@ class FakeCatalogHandler(BaseHTTPRequestHandler):
             self._send_json({"updated": 5})
         elif op == "/collections/rename":
             # RDR-164 P3: consolidated endpoint returns per-table re-home counts.
-            self._send_json({"renamed": {"catalog_documents": 3,
-                                         "catalog_collections_inserted": 1,
-                                         "catalog_collections_deleted": 1}})
+            # nexus-gaou3: stash the body so tests can assert cross_model threading.
+            FakeCatalogHandler.last_rename_body = body
+            if FakeCatalogHandler.rename_conflicts and body.get("cross_model") is not True:
+                self._send_json({"error": "target collection already exists"}, code=409)
+            else:
+                self._send_json({"renamed": {"catalog_documents": 3,
+                                             "catalog_collections_inserted": 1,
+                                             "catalog_collections_deleted": 1}})
         elif op == "/import/owner":
             self._send_json({"imported": 1})
         elif op == "/import/document":
@@ -419,8 +431,45 @@ class TestHttpCatalogClientRoundTrip:
 
     def test_rename_collection(self, client: HttpCatalogClient) -> None:
         # Sends {old_name, new_name} (canonical form)
+        FakeCatalogHandler.last_rename_body = {}
         n = client.rename_collection("old__coll", "new__coll")
         assert n == 3
+        # nexus-gaou3: default rename omits cross_model (server 409s an existing target).
+        assert "cross_model" not in FakeCatalogHandler.last_rename_body
+
+    def test_rename_collection_cross_model_sets_flag(self, client: HttpCatalogClient) -> None:
+        # nexus-gaou3: the deliberate cross-model repoint sends cross_model:true so the
+        # server takes the RDR-162 COPY branch instead of 409ing the existing target.
+        FakeCatalogHandler.last_rename_body = {}
+        client.rename_collection("old__coll", "new__coll", cross_model=True)
+        assert FakeCatalogHandler.last_rename_body.get("cross_model") is True
+
+    def test_rename_collection_cascade_cross_model_in_body(self, client: HttpCatalogClient) -> None:
+        FakeCatalogHandler.last_rename_body = {}
+        client.rename_collection_cascade("old__coll", "new__coll", cross_model=True)
+        assert FakeCatalogHandler.last_rename_body.get("cross_model") is True
+
+    def test_rename_collection_plain_collision_raises(self, client: HttpCatalogClient) -> None:
+        # nexus-gaou3: a plain rename onto an existing target gets a 409 from the
+        # server; the client must surface it (not swallow it into a 0 count).
+        import httpx
+
+        FakeCatalogHandler.rename_conflicts = True
+        try:
+            with pytest.raises(httpx.HTTPStatusError):
+                client.rename_collection("old__coll", "new__coll")
+        finally:
+            FakeCatalogHandler.rename_conflicts = False
+
+    def test_rename_collection_cross_model_bypasses_collision(self, client: HttpCatalogClient) -> None:
+        # nexus-gaou3: cross_model=True takes the RDR-162 repoint branch even when
+        # the server would 409 a plain rename — no exception, repoint count returned.
+        FakeCatalogHandler.rename_conflicts = True
+        try:
+            n = client.rename_collection("old__coll", "new__coll", cross_model=True)
+            assert n == 3
+        finally:
+            FakeCatalogHandler.rename_conflicts = False
 
     def test_bulk_unlink_uses_unlink_route(self, client: HttpCatalogClient) -> None:
         # bulk_unlink POSTs to /unlink (the same handler as unlink)

--- a/tests/test_collection_rename_service_mode.py
+++ b/tests/test_collection_rename_service_mode.py
@@ -17,7 +17,10 @@ from unittest.mock import MagicMock
 import click
 import pytest
 
-from nexus.collection_rename import rename_collection_data_plane
+from nexus.collection_rename import (
+    remap_collection_references,
+    rename_collection_data_plane,
+)
 from nexus.db.storage_mode import StorageBackend
 
 
@@ -131,3 +134,52 @@ def test_service_mode_still_guards_target_collision() -> None:
         )
     assert "already exists" in str(ei.value).lower()
     client.rename_collection_cascade.assert_not_called()
+
+
+# ── remap_collection_references (RDR-162 cross-model repoint, nexus-gaou3) ──────
+
+def _patch_t2_cascade(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the T2 atomic cascade so remap_collection_references reaches the
+    catalog leg without a real T2 database."""
+    monkeypatch.setattr(
+        "nexus.mcp_infra.t2_index_write",
+        lambda fn: {},
+    )
+
+
+def test_remap_service_mode_passes_cross_model_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # nexus-gaou3: in service mode the catalog repoint MUST signal cross_model=True
+    # so the Java endpoint takes the RDR-162 COPY branch instead of 409ing the
+    # (legitimately pre-existing) target.
+    _patch_t2_cascade(monkeypatch)
+    catalog = MagicMock()
+    catalog.rename_collection = MagicMock(return_value=7)
+
+    counts = remap_collection_references("code__old", "code__new", catalog=catalog)
+
+    catalog.rename_collection.assert_called_once_with(
+        "code__old", "code__new", cross_model=True
+    )
+    assert counts["catalog_docs"] == 7
+
+
+def test_remap_sqlite_mode_omits_cross_model_kwarg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # nexus-gaou3: the local catalog writer's rename_collection has no cross_model
+    # parameter, so it must NOT be threaded in sqlite mode. (Overrides the autouse
+    # service pin.)
+    monkeypatch.setattr(
+        "nexus.db.storage_mode.storage_backend_for",
+        lambda store: StorageBackend.SQLITE,
+    )
+    _patch_t2_cascade(monkeypatch)
+    catalog = MagicMock()
+    catalog.rename_collection = MagicMock(return_value=4)
+
+    counts = remap_collection_references("code__old", "code__new", catalog=catalog)
+
+    catalog.rename_collection.assert_called_once_with("code__old", "code__new")
+    assert counts["catalog_docs"] == 4


### PR DESCRIPTION
## Summary

`handleCollectionRename` silently took the RDR-162 cross-model COPY branch whenever `new_name` was already a registered collection — repointing `catalog_documents.physical_collection` only, leaving both registry rows, and returning a map with just the `catalog_documents` key. Chunks, taxonomy, and aspects were NOT moved. For a direct REST / `HttpCatalogClient` caller that reused or mistyped `new_name`, this surfaced as a 200 with a suspiciously short response and a **silent partial rename**. The only guard was the Python shim (`collection_rename.py`), bypassed by any non-shim caller.

## Fix

Add an explicit caller signal rather than blanket-409 on `collectionExists` (which would break the legitimate RDR-162 cross-model migrate path):

- **Handler** reads a `cross_model` body flag (default `false`). If `new_name` exists AND `!cross_model` → **409 Conflict**. The RDR-162 repoint branch is reached only when `cross_model:true`.
- **`HttpCatalogClient`** threads `cross_model` through `rename_collection` / `rename_collection_cascade`; the flag is included in the POST body only when set.
- **`remap_collection_references`** passes `cross_model=True` in **service mode only** (gated on `storage_backend_for("catalog") == StorageBackend.SERVICE`) — the local catalog writer has no such kwarg.
- `CatalogRepository.renameCollection` is **unchanged**; its `targetExists` branch is now reached only via the explicit flag.

## Tests

- `CatalogHandlerRenameTest` 8/8 (+`post_renameOntoExistingCollection_returns409`, +`post_crossModelTrue_ontoExistingTarget_returns200Repoint`)
- `CatalogRenameCollectionTest` 6/6 (RDR-162 `@Order(50)` cross-model branch still green)
- `tests/catalog/test_http_catalog_client.py -k rename` 3/3 (default asserts `cross_model` absent; +flag-set cases)

## Closes

Closes #nexus-gaou3