### PR TITLE
fix(migration): pin verified endpoint into env for guided-upgrade migration legs (nexus-qvemn)

### DIFF
--- a/src/nexus/commands/guided_upgrade_cmd.py
+++ b/src/nexus/commands/guided_upgrade_cmd.py
@@ -222,18 +222,39 @@ def guided_upgrade_cmd(
     #    block (sentinel migrated-failed + rollback offer), exits 0 on success.
     from nexus.commands.migrate_cmd import _run_migration  # noqa: PLC0415
 
-    # _run_migration sets os.environ["NX_SERVICE_URL"] as a process-level side
-    # effect (its own contract assumes subprocess-exit cleanup). We call it as a
-    # library function in-process, so save/restore to avoid leaking the url into
-    # anything that runs after this command in the same process (code-review M1).
+    # nexus-qvemn: _run_migration sets NX_SERVICE_URL, but the migration's legs
+    # (the 8 T2 store ETLs + the service count-source) resolve the endpoint via
+    # resolve_service_config(), which reads NX_SERVICE_HOST/PORT-or-lease and
+    # NEVER NX_SERVICE_URL. The just-provisioned port is allocated AFTER
+    # pg_credentials is written, so load_service_credentials_into_env (2b) leaves
+    # HOST/PORT unset and those legs fall back to lease discovery — which races
+    # the 15s lease TTL and intermittently fails ("endpoint is not resolvable")
+    # mid-migration. Pin HOST/PORT from the VERIFIED url (health-gated +
+    # version-pinned above, so authoritative) so every leg resolves through env
+    # priority-1 with no lease dependency. Save/restore to avoid leaking into the
+    # process after this command (mirrors the NX_SERVICE_URL handling, code-review M1).
+    from urllib.parse import urlsplit  # noqa: PLC0415
+
+    _verified = urlsplit(readiness.service_url)
     _prev_url = os.environ.get("NX_SERVICE_URL")
+    _prev_host = os.environ.get("NX_SERVICE_HOST")
+    _prev_port = os.environ.get("NX_SERVICE_PORT")
+    if _verified.hostname:
+        os.environ["NX_SERVICE_HOST"] = _verified.hostname
+    if _verified.port is not None:
+        os.environ["NX_SERVICE_PORT"] = str(_verified.port)
     try:
         _run_migration(local_path, db_path, catalog_db_path, readiness.service_url)
     finally:
-        if _prev_url is None:
-            os.environ.pop("NX_SERVICE_URL", None)
-        else:
-            os.environ["NX_SERVICE_URL"] = _prev_url
+        for _var, _prev in (
+            ("NX_SERVICE_URL", _prev_url),
+            ("NX_SERVICE_HOST", _prev_host),
+            ("NX_SERVICE_PORT", _prev_port),
+        ):
+            if _prev is None:
+                os.environ.pop(_var, None)
+            else:
+                os.environ[_var] = _prev
 
     # 4. ADVISORY post-step — verify the migrated stack end-to-end.
     click.echo("")

--- a/src/nexus/commands/guided_upgrade_cmd.py
+++ b/src/nexus/commands/guided_upgrade_cmd.py
@@ -28,7 +28,7 @@ pgvector count probe) is tracked separately, not part of this wiring.
 from __future__ import annotations
 
 import os
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit
 
 import click
 import structlog
@@ -233,8 +233,9 @@ def guided_upgrade_cmd(
     # version-pinned above, so authoritative) so every leg resolves through env
     # priority-1 with no lease dependency. Save/restore to avoid leaking into the
     # process after this command (mirrors the NX_SERVICE_URL handling, code-review M1).
-    from urllib.parse import urlsplit  # noqa: PLC0415
-
+    # On the --service-url path, HOST/PORT are derived from the supplied (verified)
+    # URL and take precedence over any pre-set NX_SERVICE_HOST/PORT for the duration
+    # of the migration; the originals are restored in the finally below.
     _verified = urlsplit(readiness.service_url)
     _prev_url = os.environ.get("NX_SERVICE_URL")
     _prev_host = os.environ.get("NX_SERVICE_HOST")

--- a/tests/commands/test_guided_upgrade_cmd.py
+++ b/tests/commands/test_guided_upgrade_cmd.py
@@ -139,6 +139,40 @@ class TestGuidedUpgradeCmd:
         # restored after the command — no leak of the pinned port into the process.
         assert _os.environ.get("NX_SERVICE_PORT") != "52203"
 
+    def test_service_url_pins_supplied_endpoint_over_preset_env_and_restores(self) -> None:
+        # nexus-qvemn (critic Sig-1): on the --service-url path, HOST/PORT derive from
+        # the supplied (verified) URL and take precedence over a user's pre-set
+        # NX_SERVICE_HOST/PORT for the migration's duration, then restore.
+        import os as _os
+
+        captured: dict[str, object] = {}
+
+        def _capture(*_a, **_k) -> None:
+            captured["host"] = _os.environ.get("NX_SERVICE_HOST")
+            captured["port"] = _os.environ.get("NX_SERVICE_PORT")
+
+        with patch(f"{_MOD}.detect_pending_migration",
+                   return_value=_preflight(True, 1)), \
+             patch(f"{_MOD}.establish_verified_service",
+                   return_value=_ready("http://svc:9000")), \
+             patch.dict(_os.environ,
+                        {"NX_SERVICE_TOKEN": "user-tok",
+                         "NX_SERVICE_HOST": "stale-host",
+                         "NX_SERVICE_PORT": "9999"}, clear=False), \
+             patch("nexus.commands.migrate_cmd._run_migration", side_effect=_capture):
+            result = CliRunner().invoke(
+                guided_upgrade_cmd, ["--yes", "--service-url", "http://svc:9000"]
+            )
+            # Assert INSIDE the patch.dict block so the pre-set values are still the
+            # baseline (patch.dict reverts os.environ on exit).
+            assert result.exit_code == 0, result.output
+            # during migration: pinned to the supplied URL, not the stale pre-set env.
+            assert captured["host"] == "svc"
+            assert captured["port"] == "9000"
+            # after the command: the user's pre-set values are restored (no leak/clobber).
+            assert _os.environ.get("NX_SERVICE_HOST") == "stale-host"
+            assert _os.environ.get("NX_SERVICE_PORT") == "9999"
+
     def test_abort_at_confirm_does_not_provision(self) -> None:
         with patch(f"{_MOD}.detect_pending_migration",
                    return_value=_preflight(True, 1)), \

--- a/tests/commands/test_guided_upgrade_cmd.py
+++ b/tests/commands/test_guided_upgrade_cmd.py
@@ -102,6 +102,43 @@ class TestGuidedUpgradeCmd:
         # wiring: the VERIFIED url + path overrides are handed to _run_migration.
         mig.assert_called_once_with(None, None, None, "http://127.0.0.1:8099")
 
+    def test_pins_verified_endpoint_into_env_for_migration_legs(self) -> None:
+        # nexus-qvemn: the migration's T2 store ETLs + count-source resolve the
+        # endpoint via resolve_service_config() (NX_SERVICE_HOST/PORT-or-lease,
+        # NEVER NX_SERVICE_URL). guided-upgrade must pin HOST/PORT from the VERIFIED
+        # url so those legs resolve from env alone — no lease dependency, no 15s-TTL
+        # race. Use a distinctive port to prove it derives from service_url.
+        import os as _os
+        from nexus.db.service_endpoint import resolve_service_config
+
+        captured: dict[str, object] = {}
+
+        def _capture(*_a, **_k) -> None:
+            # At migration time the verified endpoint must resolve from env with NO
+            # lease available (the failure mode was a reaped/expired lease).
+            with patch("nexus.db.service_endpoint.discover_lease",
+                       return_value=(None, None)), \
+                 patch.dict(_os.environ, {"NX_SERVICE_TOKEN": "tok"}, clear=False):
+                captured["host"] = _os.environ.get("NX_SERVICE_HOST")
+                captured["port"] = _os.environ.get("NX_SERVICE_PORT")
+                captured["resolved"] = resolve_service_config()
+
+        with patch(f"{_MOD}.detect_pending_migration",
+                   return_value=_preflight(True, 2)), \
+             patch(f"{_MOD}.establish_verified_service",
+                   return_value=_ready("http://127.0.0.1:52203")), \
+             patch("nexus.db.pg_provision.load_service_credentials_into_env",
+                   return_value=True), \
+             patch("nexus.commands.migrate_cmd._run_migration", side_effect=_capture):
+            result = CliRunner().invoke(guided_upgrade_cmd, ["--yes"])
+        assert result.exit_code == 0, result.output
+        assert captured["host"] == "127.0.0.1"
+        assert captured["port"] == "52203"
+        # resolve_service_config() resolves the verified endpoint from env, no lease.
+        assert captured["resolved"] == ("127.0.0.1", 52203, "tok")
+        # restored after the command — no leak of the pinned port into the process.
+        assert _os.environ.get("NX_SERVICE_PORT") != "52203"
+
     def test_abort_at_confirm_does_not_provision(self) -> None:
         with patch(f"{_MOD}.detect_pending_migration",
                    return_value=_preflight(True, 1)), \


### PR DESCRIPTION
## Summary

`nx guided-upgrade` (the RDR-002 one-command migration UX, the luxe6 **(b)** gate) provisioned + health-gated the service, then handed off to `_run_migration`. But the migration's **8 T2 store ETLs + the service count-source** resolve the endpoint via `resolve_service_config()`, which reads `NX_SERVICE_HOST/PORT`-or-lease and **never `NX_SERVICE_URL`**. The provisioned port is allocated *after* `pg_credentials` is written, so `HOST/PORT` were unset in env → those legs fell back to lease discovery → raced the **15s lease TTL** → `"nexus-service endpoint is not resolvable"` ~19s in → migration **BLOCKED** (`total_failed=8`, sentinel `migrated-failed`, T3 never ran).

Found by the local migration-rehearsal shakeout; root-caused via `/conexus:debug` (T2 `nexus/qvemn-debug-2026-06-22`).

## Fix

Pin `NX_SERVICE_HOST/PORT` from the **verified** `readiness.service_url` (health-gated + version-pinned, so authoritative) before the hand-off, so every leg resolves through `resolve_service_config()`'s env priority with no lease dependency. Save/restore all three vars (mirrors the existing `NX_SERVICE_URL` handling) so nothing leaks into the process. Covers the provisioned and `--service-url` paths.

The T3 vector leg + catalog client are unaffected (they resolve via `NX_SERVICE_URL` / explicit `base_url`).

## Verification

- **End-to-end:** `tests/e2e/migration-rehearsal/run.sh --guided` now PASSES — *"Migration VERIFIED and unlocked — 2 collection(s) migrated and validated; serving from pgvector"*, cross-model parity validated.
- **Unit:** 16/16 in `test_guided_upgrade_cmd.py` (incl. a regression-coupled test that `resolve_service_config()` resolves the verified endpoint with **no lease present**, and a `--service-url` env-precedence/restore test); 341 migration suite green.

## Stacked review
code-review-expert APPROVED (after the inline-import cleanup); substantive-critic partial → both Significant items addressed (added `--service-url` test; filed `nexus-f9y78` for the secondary supervisor-lease-heartbeat-stall root cause this env-pin sidesteps).

## Closes
Closes #nexus-qvemn