### PR TITLE
ci: migrate workflows off Node20-deprecated actions to node24 (nexus-knh6t)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
         python-version: ["3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
           # nexus-2ivn: setup-uv's bundled enable-cache only restored
@@ -38,12 +38,12 @@ jobs:
           # missing and torch (~847 MB) re-downloaded on every run.
           # Disable the bundled cache and target the directory setup-uv
           # actually uses (UV_CACHE_DIR = ${{ runner.temp }}/setup-uv-
-          # cache, not ~/.cache/uv) with an explicit actions/cache@v4
+          # cache, not ~/.cache/uv) with an explicit actions/cache@v5
           # step below.
           enable-cache: false
 
       - name: Cache uv wheel cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/setup-uv-cache
           # Key on uv.lock so a dep change rebuilds; restore-keys
@@ -55,7 +55,7 @@ jobs:
             uv-${{ runner.os }}-${{ matrix.python-version }}-
 
       - name: Cache ChromaDB ONNX model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/chroma
           # nexus-8g79.33: include uv.lock hash so a chromadb bump that
@@ -69,7 +69,7 @@ jobs:
             chromadb-onnx-${{ runner.os }}-
 
       - name: Cache HuggingFace models (docling, cross-encoder, MinerU)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # nexus-cxsbs: the docling PDF extractor downloads its layout +
           # TableFormer models from HuggingFace at test time; an unreliable
@@ -165,7 +165,7 @@ jobs:
       MANYLINUX_IMAGE: ${{ matrix.target.image }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Path-gate the expensive PG-from-source build. The job ALWAYS runs (so the
       # required status check always reports), but the build/test/smoke steps run
@@ -176,7 +176,7 @@ jobs:
       # compromised to always emit ca3='false' would skip the PG build + tests
       # while the job still reports green — the exact vacuous gate the
       # always-run-job pattern exists to prevent. de90cc6 == v3.0.2.
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         id: changes
         with:
           filters: |
@@ -198,7 +198,7 @@ jobs:
               - 'uv.lock'
               - 'pyproject.toml'
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         if: steps.changes.outputs.ca3 == 'true'
         with:
           python-version: "3.12"
@@ -206,7 +206,7 @@ jobs:
 
       - name: Cache uv wheel cache
         if: steps.changes.outputs.ca3 == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/setup-uv-cache
           key: uv-${{ runner.os }}-${{ matrix.target.arch }}-3.12-${{ hashFiles('uv.lock') }}
@@ -289,7 +289,7 @@ jobs:
 
       - name: Upload bundle artifact (P3.1, consumed by P3.2/P3.4)
         if: steps.changes.outputs.ca3 == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nexus-pg-${{ matrix.target.arch }}
           path: ${{ runner.temp }}/nexus-pg-${{ matrix.target.arch }}.txz
@@ -322,7 +322,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "13.0"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Path-gate the expensive native PG build (same rationale as the linux CA-3
       # job): the job always runs so the required check reports, but the build/test
@@ -332,7 +332,7 @@ jobs:
       # compromised to always emit ca3='false' would skip the PG build + tests
       # while the job still reports green — the exact vacuous gate the
       # always-run-job pattern exists to prevent. de90cc6 == v3.0.2.
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         id: changes
         with:
           filters: |
@@ -354,7 +354,7 @@ jobs:
               - 'uv.lock'
               - 'pyproject.toml'
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         if: steps.changes.outputs.ca3 == 'true'
         with:
           python-version: "3.12"
@@ -364,7 +364,7 @@ jobs:
         # Mirror the linux CA-3 jobs so a gated mac run reuses wheels instead of
         # re-downloading from scratch (code-review L1).
         if: steps.changes.outputs.ca3 == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/setup-uv-cache
           key: uv-${{ runner.os }}-mac-arm64-3.12-${{ hashFiles('uv.lock') }}
@@ -425,7 +425,7 @@ jobs:
 
       - name: Upload bundle artifact (P3.1, consumed by P3.2/P3.4)
         if: steps.changes.outputs.ca3 == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nexus-pg-mac-arm64
           path: ${{ runner.temp }}/nexus-pg-mac-arm64.txz
@@ -454,9 +454,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         id: changes
         with:
           filters: |

--- a/.github/workflows/cold-install-rehearsal.yml
+++ b/.github/workflows/cold-install-rehearsal.yml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Run the cold-acquire rehearsal
         # run.sh --cold builds the wheel on the host, builds the minimal

--- a/.github/workflows/engine-service-release.yml
+++ b/.github/workflows/engine-service-release.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up GraalVM 25.0.3
         uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f
         with:
@@ -70,7 +70,7 @@ jobs:
         # applies the master changelog, generates into target/generated-sources/jooq).
         run: ./mvnw -q generate-sources
       - name: Upload generated jOOQ sources
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: jooq-sources
           path: service/target/generated-sources/jooq
@@ -99,7 +99,7 @@ jobs:
       ASSET: nexus-service-${{ matrix.target.arch }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up GraalVM 25.0.3
         # SHA-pinned (not @v1): this is a PUBLISH path that creates a GitHub
@@ -118,7 +118,7 @@ jobs:
         # (NOT MiniLM, NOT fastembed's fused optimized export) — the native smoke
         # needs it. STABLE key (immutable upstream export): one cold download per
         # arch, restored thereafter; bump -v only if the model source changes.
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/nexus/onnx_models/bge-base-en-v1.5
           key: bge-onnx-standard-${{ runner.os }}-${{ matrix.target.arch }}-v1
@@ -159,7 +159,7 @@ jobs:
       - name: Download pre-generated jOOQ sources
         # From the jooq-codegen job — compiled by -Pprebuilt-jooq below. No Docker
         # needed to build, which is what lets mac-arm64 build here.
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: jooq-sources
           path: service/target/generated-sources/jooq
@@ -280,7 +280,7 @@ jobs:
         # bead exists to close — same reasoning as the SHA-pinned graalvm action
         # above. SHA backs v3.7.0.
         if: startsWith(github.ref, 'refs/tags/engine-service-v')
-        uses: sigstore/cosign-installer@1aa8e0f2454b781fbf0fbf306a4c9533a0c57409  # v3.7.0
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Sign release asset (cosign keyless, release tag only)
         # nexus-1odsm: the native binary runs with DB credentials in the conexus
@@ -321,7 +321,7 @@ jobs:
           echo "cosign signatures verified for $ASSET (.cosign.bundle + .sigstore.json)"
 
       - name: Upload Actions artifact (always — dev smoke / non-tag path)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.ASSET }}
           path: dist/*
@@ -429,7 +429,7 @@ jobs:
       PGVECTOR_VERSION: "v0.8.2"
       ASSET: nexus-pg-${{ matrix.target.arch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build PG + pgvector bundle and package .txz
         env:
@@ -471,7 +471,7 @@ jobs:
         # SHA-pinned (not @v3.7.0): same supply-chain reasoning as the native-binary
         # job above — the signing primitive must not float.
         if: startsWith(github.ref, 'refs/tags/engine-service-v')
-        uses: sigstore/cosign-installer@1aa8e0f2454b781fbf0fbf306a4c9533a0c57409  # v3.7.0
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Sign PG bundle (cosign keyless, release tag only)
         if: startsWith(github.ref, 'refs/tags/engine-service-v')
@@ -492,7 +492,7 @@ jobs:
           echo "cosign signature verified for $ASSET.txz (.sigstore.json)"
 
       - name: Upload Actions artifact (always — dev smoke / non-tag path)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.ASSET }}
           path: dist/*

--- a/.github/workflows/plan-schema-check.yml
+++ b/.github/workflows/plan-schema-check.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,18 +28,18 @@ jobs:
         python-version: ["3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
           # nexus-2ivn: see ci.yml. Bundled enable-cache caches metadata
           # only; the wheel cache lives at ${{ runner.temp }}/setup-uv-
-          # cache and needs an explicit actions/cache@v4 step.
+          # cache and needs an explicit actions/cache@v5 step.
           enable-cache: false
 
       - name: Cache uv wheel cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/setup-uv-cache
           key: uv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
@@ -47,14 +47,14 @@ jobs:
             uv-${{ runner.os }}-${{ matrix.python-version }}-
 
       - name: Cache ChromaDB ONNX model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/chroma
           # nexus-8g79.33: same lockfile-bound key as ci.yml.
           key: chromadb-onnx-${{ runner.os }}-${{ hashFiles('uv.lock') }}
 
       - name: Cache HuggingFace models (docling, cross-encoder, MinerU)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # nexus-cxsbs: see ci.yml. Cache the whole HF hub dir so docling's
           # layout + TableFormer models persist across runs instead of being
@@ -95,18 +95,18 @@ jobs:
       contents: write   # required to create GitHub release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
           # nexus-2ivn: see ci.yml. Bundled enable-cache caches metadata
-          # only; explicit actions/cache@v4 step below targets the
+          # only; explicit actions/cache@v5 step below targets the
           # wheel-cache directory setup-uv actually uses.
           enable-cache: false
 
       - name: Cache uv wheel cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/setup-uv-cache
           key: uv-${{ runner.os }}-3.12-${{ hashFiles('uv.lock') }}
@@ -188,7 +188,7 @@ jobs:
         # release sub-step failed and was created manually. Pinning to a
         # full-length SHA prevents silent action upgrades from re-introducing
         # the issue. Bump deliberately when validating a newer v2.x.
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
           body_path: /tmp/release_notes.md
           files: |

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up GraalVM JDK 25
         uses: graalvm/setup-graalvm@v1
@@ -43,7 +43,7 @@ jobs:
         # all-MiniLM-L6-v2 model from ~/.cache/chroma. Mirror the SAME
         # cache key as ci.yml (the Python suite) so this Java-only runner
         # restores the model the Python workflow already downloaded.
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/chroma
           key: chromadb-onnx-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -73,7 +73,7 @@ jobs:
         # fp32 bge ONNX; priming it here makes the gate RUN on CI instead of
         # skipping. STABLE key (immutable upstream export) — one cold download,
         # restored thereafter, shared with the native-smoke job.
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/nexus/onnx_models/bge-base-en-v1.5
           key: bge-onnx-standard-${{ runner.os }}-v1
@@ -116,7 +116,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up GraalVM 25.0.3
         uses: graalvm/setup-graalvm@v1
@@ -136,7 +136,7 @@ jobs:
         # STABLE key — the model is an immutable upstream export, so it
         # downloads ONCE on a cold cache and restores on every later run; bump
         # the -v suffix only if the model SOURCE changes.
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/nexus/onnx_models/bge-base-en-v1.5
           key: bge-onnx-standard-${{ runner.os }}-v1


### PR DESCRIPTION
## Summary

GitHub Actions runners now default to Node 24 and emit a deprecation warning for any action pinned to the **node20** runtime ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This bumps every node20-runtime JS action to its node24 release.

## Changes (runtimes verified against each upstream `action.yml`, 2026-06-22)

| action | from | to | note |
|---|---|---|---|
| actions/checkout | v4 | **v5** | |
| actions/cache | v4 | **v5** | |
| actions/upload-artifact | v4 | **v6** | v5 is still node20 |
| actions/download-artifact | v4 | **v7** | v5 & v6 are still node20 |
| astral-sh/setup-uv | v5 | **v7** | v6 is still node20 |
| dorny/paths-filter | v3.0.2 | **v4.0.1** | SHA-pinned; v4 = node24 |
| sigstore/cosign-installer | v3.7.0 | **v4.1.2** | SHA-pinned; v4 is a composite action |
| softprops/action-gh-release | v2.6.2 | **v3.0.1** | SHA-pinned; v3 = node24 |

**No change needed:** `graalvm/setup-graalvm` (both the `@v1` tag and the pinned SHA are already node24) and `pypa/gh-action-pypi-publish` (docker action, exempt).

## Verification
- All 6 workflow YAMLs parse clean.
- Each target version's `runs.using` confirmed `node24` (or composite/docker) directly from the upstream `action.yml` before selecting it — notably `upload-artifact`/`download-artifact`/`setup-uv` needed higher majors than the obvious +1 because their `v5`/`v6` are still node20.
- CI on this PR is the live check that the major bumps don't change behavior.

## Closes
Closes #nexus-knh6t