### PR TITLE
fix(migration): mode+content-type-aware cross-model remap target (nexus-gilf2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ migration tool; the Chroma source remains the immutable migration origin
   dynamic loader at the bundle's own `lib/` so the bundled `initdb`/`pg_ctl`
   resolve `libpq.so.5` etc. on a stripped image (nexus-4mm24; the durable
   RPATH-in-bundle-build fix is tracked separately).
+- **Guided-upgrade cross-model remap target is embedding-mode-aware** (RDR-162).
+  A guided upgrade onto a voyage-mode (cloud) service now re-embeds legacy
+  local-model collections into the content-type-appropriate voyage model
+  (`voyage-code-3` / `voyage-context-3`) instead of an unconditional bge-768
+  target, which a cloud service cannot serve. This unblocks the mixed migrant
+  (ran locally, migrates onto a voyage service); the dry-run preview names the
+  actual target and estimates its rate (nexus-gilf2).
 
 ### Known limitations / upgrade notes
 

--- a/src/nexus/migration/detection.py
+++ b/src/nexus/migration/detection.py
@@ -46,7 +46,10 @@ from typing import Any, Literal
 
 import structlog
 
-from nexus.corpus import embedding_model_for_collection_name
+from nexus.corpus import (
+    embedding_model_for_collection_name,
+    voyage_model_for_collection,
+)
 from nexus.migration.vector_etl import _dim_for_collection
 
 _log = structlog.get_logger(__name__)
@@ -170,6 +173,35 @@ def cross_model_remappable(c: "CollectionClassification") -> bool:
     return c.support == "unsupported"
 
 
+def cross_model_target_model(source: str, *, voyage_key_present: bool) -> str:
+    """The embedding model a cross-model remap should re-embed *source* into.
+
+    nexus-gilf2: the target must be a model the live deployment actually WIRES,
+    else the upsert hits the ``nexus-pebfx.2`` fail-loud guard (HTTP 422, no
+    embedder for the named model) and the migration blocks 0/N. The old
+    unconditional bge-768 target was correct for local mode but wrong for the
+    MIXED migrant — a deployment that ran local (minilm-384 collections) then
+    migrates onto a voyage-mode (cloud) service, where bge-768 is not wired.
+
+    Mode + content-type aware:
+
+    * cloud mode (``voyage_key_present``) → the content-type-appropriate voyage
+      model (prose ``docs__`` / ``rdr__`` / ``knowledge__`` → ``voyage-context-3``;
+      ``code__`` and any other prefix → ``voyage-code-3``), so the re-embedded
+      chunks land under a served model;
+    * local mode → ONNX (``bge-base-en-v15-768``), the only wired embedder.
+
+    The content-type dispatch reuses the READ-side
+    :func:`nexus.corpus.voyage_model_for_collection`. The remap only swaps the
+    model segment, leaving the content_type prefix intact, so the target's
+    served model equals what the read path will later dispatch for it — no
+    model/recall mismatch (RDR-059).
+    """
+    if voyage_key_present:
+        return voyage_model_for_collection(source)
+    return _ONNX_MODEL
+
+
 @dataclass(frozen=True)
 class CollectionClassification:
     """Per-collection detection result along both axes (RF-2).
@@ -195,6 +227,12 @@ class DetectionReport:
     """The classified Chroma footprint across all detected legs."""
 
     classifications: tuple[CollectionClassification, ...]
+    #: Whether the deployment wires the voyage embedders (cloud mode). Carried
+    #: so the dry-run preview can resolve the cross-model re-embed TARGET and its
+    #: throughput the same way the driver will (nexus-gilf2): voyage models in
+    #: cloud mode, bge-768 in local. Defaults False (local) for the many test
+    #: doubles that construct a report without a live mode signal.
+    voyage_key_present: bool = False
 
     @property
     def legs_with_data(self) -> frozenset[str]:
@@ -272,7 +310,10 @@ def classify_collections(
                 cloud_client, "cloud", voyage_key_present=voyage_key_present
             )
         )
-    report = DetectionReport(classifications=tuple(classifications))
+    report = DetectionReport(
+        classifications=tuple(classifications),
+        voyage_key_present=voyage_key_present,
+    )
     _log.info(
         "migration_detect_classified",
         total=len(report.classifications),
@@ -389,10 +430,15 @@ class ModelGroup:
     est_tokens: int
     est_seconds: float
     #: RDR-162 P2: True when this is an ``unsupported`` group the migrate will
-    #: CROSS-MODEL re-embed into bge-768 (legacy minilm, etc.) rather than block.
-    #: It counts toward the migratable totals; ``support`` stays ``unsupported``
-    #: (its current name is unservable) but it is NOT in ``DryRunPreview.unsupported``.
+    #: CROSS-MODEL re-embed (legacy minilm, etc.) rather than block. It counts
+    #: toward the migratable totals; ``support`` stays ``unsupported`` (its
+    #: current name is unservable) but it is NOT in ``DryRunPreview.unsupported``.
     cross_model: bool = False
+    #: nexus-gilf2: the model the cross-model re-embed targets, resolved from the
+    #: deployment mode + content_type (voyage models in cloud, bge-768 in local).
+    #: ``None`` for non-cross-model groups. Carried so the preview names the
+    #: ACTUAL target (not a hard-coded bge-768) and estimates the right rate.
+    target_model: str | None = None
 
 
 @dataclass(frozen=True)
@@ -421,25 +467,32 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
     contribute nothing to the migratable totals — they would be BLOCKED, not
     migrated.
     """
-    buckets: dict[tuple[Leg, str | None, Support], list[CollectionClassification]] = {}
-    for c in report.classifications:
-        buckets.setdefault((c.leg, c.model, c.support), []).append(c)
+    # RDR-162 P2: a cross-model-remappable collection is migratable (re-embed),
+    # not blocked. nexus-gilf2: bucket cross-model groups by their RESOLVED
+    # target too — in cloud mode a single source model (minilm-384) splits into
+    # voyage-code-3 (code__) and voyage-context-3 (prose) targets, so one bucket
+    # would otherwise name only one of them. ``target`` is None for non-cross-
+    # model classifications, keeping supported/blocked buckets unchanged.
+    def _cross_target(c: CollectionClassification) -> str | None:
+        if not cross_model_remappable(c):
+            return None
+        return cross_model_target_model(
+            c.collection, voyage_key_present=report.voyage_key_present
+        )
 
-    # RDR-162 P2: a cross-model-remappable collection is migratable (re-embed to
-    # bge-768), not blocked. Decide per classification so a bucket is consistent.
-    remappable = {
-        id(c) for c in report.classifications if cross_model_remappable(c)
-    }
+    buckets: dict[
+        tuple[Leg, str | None, Support, str | None], list[CollectionClassification]
+    ] = {}
+    for c in report.classifications:
+        buckets.setdefault((c.leg, c.model, c.support, _cross_target(c)), []).append(c)
 
     groups: list[ModelGroup] = []
     migratable_chunks = 0
     total_est_tokens = 0
     est_seconds = 0.0
-    for (leg, model, support), members in buckets.items():
+    for (leg, model, support, target_model), members in buckets.items():
         chunk_count = sum(m.source_count for m in members)
-        is_cross_model = support == "unsupported" and all(
-            id(m) in remappable for m in members
-        )
+        is_cross_model = target_model is not None
         if support == "unsupported" and not is_cross_model:
             # Genuinely blocked (voyage-no-key, non-conformant) — zero estimate.
             groups.append(
@@ -447,22 +500,31 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
             )
             continue
         # Supported byte-for-byte OR cross-model re-embed: both migratable. The
-        # cross-model re-embed runs through the local ONNX (bge-768) path.
+        # cross-model re-embed runs through whatever embedder serves the TARGET
+        # name (voyage in cloud mode, ONNX in local) — estimate that rate.
         tokens = chunk_count * _EST_TOKENS_PER_CHUNK
-        rate = _EST_ONNX_CHUNKS_PER_SEC if is_cross_model else _throughput_for_support(support)
+        if is_cross_model:
+            rate = (
+                _EST_VOYAGE_CHUNKS_PER_SEC
+                if target_model in _VOYAGE_MODELS
+                else _EST_ONNX_CHUNKS_PER_SEC
+            )
+        else:
+            rate = _throughput_for_support(support)
         seconds = chunk_count / rate
         groups.append(
             ModelGroup(
                 leg, model, support, len(members), chunk_count, tokens, seconds,
                 cross_model=is_cross_model,
+                target_model=target_model,
             )
         )
         migratable_chunks += chunk_count
         total_est_tokens += tokens
         est_seconds += seconds
 
-    # Stable order: leg, then support, then model — deterministic preview text.
-    groups.sort(key=lambda g: (g.leg, g.support, g.model or ""))
+    # Stable order: leg, support, model, then target — deterministic preview text.
+    groups.sort(key=lambda g: (g.leg, g.support, g.model or "", g.target_model or ""))
     # Only GENUINELY-blocked collections remain in unsupported — cross-model
     # collections are migratable and must not gate the dry-run exit.
     blocked = tuple(
@@ -501,7 +563,7 @@ def render_dry_run_preview(preview: DryRunPreview) -> str:
         lines.append("Would migrate (per leg / model):")
         for g in migratable:
             kind = (
-                f"{g.model} -> bge-768 cross-model re-embed"
+                f"{g.model} -> {g.target_model} cross-model re-embed"
                 if g.cross_model
                 else f"{g.model} ({g.support})"
             )

--- a/src/nexus/migration/driver.py
+++ b/src/nexus/migration/driver.py
@@ -34,11 +34,11 @@ from typing import Any, Callable
 import structlog
 
 from nexus.migration.detection import (
-    _ONNX_MODEL,
     DetectionReport,
     classify_collections,
     close_read_client,
     cross_model_remappable,
+    cross_model_target_model,
     open_read_legs,
     voyage_key_available,
 )
@@ -173,12 +173,19 @@ def run_guided_upgrade(
 
     # RDR-162 P2: a legacy collection the service cannot serve under its current
     # name (e.g. minilm-384 after RDR-160) is auto-migrated by re-embedding its
-    # STORED chunk text into a model-remapped target (bge-768) — not blocked with
-    # the re-index diagnostic. Policy lives here (the orchestrator), not in the
-    # ETL: build the source→target map, pass it down, and the sequencer exempts
-    # these from the pre-gate and re-points their references after they verify.
+    # STORED chunk text into a model-remapped target — not blocked with the
+    # re-index diagnostic. Policy lives here (the orchestrator), not in the ETL:
+    # build the source→target map, pass it down, and the sequencer exempts these
+    # from the pre-gate and re-points their references after they verify.
+    # nexus-gilf2: the target model is mode + content-type aware (voyage models
+    # in cloud mode, bge-768 in local) so the MIXED migrant (ran local, migrates
+    # onto a voyage-mode service) re-embeds into a WIRED model instead of hitting
+    # the pebfx.2 fail-loud guard.
     target_names = {
-        c.collection: cross_model_target_name(c.collection, _ONNX_MODEL)
+        c.collection: cross_model_target_name(
+            c.collection,
+            cross_model_target_model(c.collection, voyage_key_present=key_present),
+        )
         for c in detection.classifications
         if cross_model_remappable(c)
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -618,6 +618,14 @@ _MODE_LINT_EXCLUDE_NODEIDS: frozenset[str] = frozenset({
     # mode-dependent path executes ("string-literal-as-name" class).
     "tests/migration/test_driver.py::test_two_leg_composes_collections_and_dims",
     #
+    # nexus-gilf2: the cross-model remap-target test asserts the driver derives
+    # voyage target NAMES (voyage-code-3 / voyage-context-3) in cloud mode. Mode
+    # is pinned explicitly by patching ``voyage_key_available`` (via the
+    # ``voyage_key=True`` engine patch), not the ambient cloud_mode fixture —
+    # the target resolver is a pure deployment-mode function, same rationale as
+    # the ``test_detection.py`` file exclusion ("string-literal-as-name" class).
+    "tests/migration/test_driver.py::test_cross_model_target_is_voyage_in_cloud_mode",
+    #
     # RDR-152 nexus-gmiaf.22 (Seam B): asserts service-mode skips the embed
     # fallback. Voyage tokens appear only as realistic collection-NAME /
     # prepared-chunk-metadata fixtures (real docs collections ARE

--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -55,6 +55,11 @@ _guided_restore() {
 trap '_guided_restore' EXIT
 
 [ "$COLD" = 1 ] && [ "$GUIDED" = 1 ] && { echo "--cold and --guided are different flows; pick one" >&2; exit 2; }
+# nexus-gilf2: --guided seeds local-ONNX (bge-768) cross-model targets, while
+# --with-cloud boots a voyage-only service. The combination is incoherent: the
+# bge-768 targets have no embedder in voyage mode and the pebfx.2 guard 422s the
+# leg. Use --guided alone for the local bge-768 MVV.
+[ "$GUIDED" = 1 ] && [ "$WITH_CLOUD" = 1 ] && { echo "--guided and --with-cloud are incoherent (guided seeds local bge-768 targets; cloud is voyage-only); run --guided alone" >&2; exit 2; }
 [ "$COLD" = 1 ] && [ "$DO_BUILD" = 0 ] && { echo "--cold always rebuilds the wheel + cold-acquires the binary; --no-build is irrelevant" >&2; exit 2; }
 
 if [ "$GUIDED" = 1 ]; then

--- a/tests/migration/test_detection.py
+++ b/tests/migration/test_detection.py
@@ -451,9 +451,43 @@ class TestDryRunPreview:
         assert len(cross) == 1
         assert cross[0].model == "minilm-l6-v2-384"
         assert cross[0].chunk_count == 7
+        # nexus-gilf2: cloud mode (voyage key) → the prose source targets
+        # voyage-context-3, and the preview names that ACTUAL target (not a
+        # hard-coded bge-768) so the operator sees what the migrate will produce.
+        assert cross[0].target_model == "voyage-context-3"
         text = render_dry_run_preview(preview)
-        assert "cross-model re-embed" in text
+        assert "minilm-l6-v2-384 -> voyage-context-3 cross-model re-embed" in text
+        assert "bge-768" not in text
         assert "BLOCKED" not in text
+
+    def test_cross_model_preview_local_mode_targets_bge_768(self) -> None:
+        # nexus-gilf2: local mode (no voyage key) → bge-768 target, named honestly.
+        local = _FakeChromaClient({ONNX_384: 7})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=False
+        )
+        preview = build_dry_run_preview(report)
+        cross = [g for g in preview.groups if g.cross_model]
+        assert len(cross) == 1
+        assert cross[0].target_model == "bge-base-en-v15-768"
+        text = render_dry_run_preview(preview)
+        assert "minilm-l6-v2-384 -> bge-base-en-v15-768 cross-model re-embed" in text
+
+    def test_cross_model_preview_cloud_splits_code_and_prose_targets(self) -> None:
+        # nexus-gilf2: a single source model (minilm-384) spanning code + prose
+        # splits into TWO target buckets in cloud mode — voyage-code-3 for code,
+        # voyage-context-3 for prose — each named in the preview.
+        code_src = "code__acme__minilm-l6-v2-384__v1"
+        local = _FakeChromaClient({ONNX_384: 7, code_src: 3})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=True
+        )
+        preview = build_dry_run_preview(report)
+        targets = {g.target_model for g in preview.groups if g.cross_model}
+        assert targets == {"voyage-context-3", "voyage-code-3"}
+        text = render_dry_run_preview(preview)
+        assert "minilm-l6-v2-384 -> voyage-code-3 cross-model re-embed" in text
+        assert "minilm-l6-v2-384 -> voyage-context-3 cross-model re-embed" in text
 
     def test_all_blocked_render_has_no_dangling_migrate_section(self) -> None:
         # Every collection GENUINELY blocked (voyage, no key) → the "Would
@@ -477,6 +511,51 @@ class TestDryRunPreview:
         assert "[local]" in text
         assert "[cloud]" in text
         assert "rough estimate" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Cross-model remap TARGET derivation (nexus-gilf2): mode-aware, content-type-aware
+# ---------------------------------------------------------------------------
+class TestCrossModelTargetModel:
+    """The cross-model remap target must be a model the live deployment WIRES.
+
+    nexus-gilf2: a flat bge-768 target blocks the mixed migrant (ran local,
+    migrates onto a voyage-mode service) — the service has no bge-768 embedder
+    in cloud mode and the pebfx.2 guard 422s the upsert. The target is
+    derived from the deployment mode and the source's content_type.
+    """
+
+    def test_local_mode_targets_bge_768_regardless_of_content_type(self) -> None:
+        from nexus.migration.detection import cross_model_target_model
+
+        for src in (ONNX_384, "code__acme__minilm-l6-v2-384__v1"):
+            assert (
+                cross_model_target_model(src, voyage_key_present=False)
+                == "bge-base-en-v15-768"
+            )
+
+    def test_cloud_mode_prose_targets_voyage_context_3(self) -> None:
+        from nexus.migration.detection import cross_model_target_model
+
+        for src in (
+            "knowledge__acme__minilm-l6-v2-384__v1",
+            "docs__acme__minilm-l6-v2-384__v1",
+            "rdr__acme__minilm-l6-v2-384__v1",
+        ):
+            assert (
+                cross_model_target_model(src, voyage_key_present=True)
+                == "voyage-context-3"
+            )
+
+    def test_cloud_mode_code_targets_voyage_code_3(self) -> None:
+        from nexus.migration.detection import cross_model_target_model
+
+        assert (
+            cross_model_target_model(
+                "code__acme__minilm-l6-v2-384__v1", voyage_key_present=True
+            )
+            == "voyage-code-3"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/migration/test_driver.py
+++ b/tests/migration/test_driver.py
@@ -120,6 +120,8 @@ def _patch_engine(
     order: list[str],
     validation: ValidationOutcome | None = None,
     compose_capture: dict | None = None,
+    seq_capture: dict | None = None,
+    voyage_key: bool = False,
 ):
     """Patch the driver's engine globals; record the detect→sequence ordering."""
     local = _FakeClient("detect-local", closables=closables)
@@ -139,6 +141,8 @@ def _patch_engine(
         order.append("sequence")
         # The detection legs MUST be closed before the ETL sequence runs.
         assert "detect-local" in closables and "detect-cloud" in closables
+        if seq_capture is not None:
+            seq_capture["cross_model_targets"] = cross_model_targets
         return sequence
 
     def _compose(*, t2_db_path, read_client, vector_client, catalog_client, collections, dims, target_names=None):
@@ -162,7 +166,7 @@ def _patch_engine(
     monkeypatch.setattr(driver, "run_sequenced_migration", _run_sequenced)
     monkeypatch.setattr(driver, "compose_validation_checks", _compose)
     monkeypatch.setattr(driver, "validate_migration", _validate)
-    monkeypatch.setattr(driver, "voyage_key_available", lambda: False)
+    monkeypatch.setattr(driver, "voyage_key_available", lambda: voyage_key)
 
 
 def test_fresh_user_noop_clean_success(monkeypatch, _sources):
@@ -311,6 +315,75 @@ def test_two_leg_composes_collections_and_dims(monkeypatch, _sources):
     assert composite._by_collection["docs__o__voyage-context-3__v1"] is legs_clients["cloud"]
     # Both reopened legs closed.
     assert {"reopen-local", "reopen-cloud"} <= set(closables)
+
+
+def _cross_model_cls(collection: str, leg: str) -> CollectionClassification:
+    """A legacy minilm-384 (unsupported) collection — cross-model-remappable."""
+    return CollectionClassification(
+        collection=collection,
+        leg=leg,  # type: ignore[arg-type]
+        model="minilm-l6-v2-384",
+        dim=384,
+        support="unsupported",
+        source_count=10,
+        has_data=True,
+        reason="wired by no service embedder",
+    )
+
+
+def test_cross_model_target_is_bge_in_local_mode(monkeypatch, _sources):
+    """nexus-gilf2: local mode (no voyage key) remaps minilm-384 → bge-768."""
+    capture: dict = {}
+    _patch_engine(
+        monkeypatch,
+        detection=_detection(
+            _cross_model_cls("knowledge__o__minilm-l6-v2-384__v1", "local"),
+            _cross_model_cls("code__o__minilm-l6-v2-384__v1", "local"),
+        ),
+        sequence=_sequence(ok=False, phase="migrated-failed"),
+        closables=[],
+        order=[],
+        seq_capture=capture,
+        voyage_key=False,
+    )
+    driver.run_guided_upgrade(
+        sources=_sources,
+        vector_client=object(),
+        catalog_client=object(),
+        t2_db_path=_sources.sqlite_path,
+    )
+    assert capture["cross_model_targets"] == {
+        "knowledge__o__minilm-l6-v2-384__v1": "knowledge__o__bge-base-en-v15-768__v1",
+        "code__o__minilm-l6-v2-384__v1": "code__o__bge-base-en-v15-768__v1",
+    }
+
+
+def test_cross_model_target_is_voyage_in_cloud_mode(monkeypatch, _sources):
+    """nexus-gilf2: cloud mode (voyage key) remaps minilm-384 to the
+    content-type-appropriate voyage model — the mixed-migrant fix."""
+    capture: dict = {}
+    _patch_engine(
+        monkeypatch,
+        detection=_detection(
+            _cross_model_cls("knowledge__o__minilm-l6-v2-384__v1", "local"),
+            _cross_model_cls("code__o__minilm-l6-v2-384__v1", "local"),
+        ),
+        sequence=_sequence(ok=False, phase="migrated-failed"),
+        closables=[],
+        order=[],
+        seq_capture=capture,
+        voyage_key=True,
+    )
+    driver.run_guided_upgrade(
+        sources=_sources,
+        vector_client=object(),
+        catalog_client=object(),
+        t2_db_path=_sources.sqlite_path,
+    )
+    assert capture["cross_model_targets"] == {
+        "knowledge__o__minilm-l6-v2-384__v1": "knowledge__o__voyage-context-3__v1",
+        "code__o__minilm-l6-v2-384__v1": "code__o__voyage-code-3__v1",
+    }
 
 
 def test_reopened_legs_closed_when_validation_raises(monkeypatch, _sources):

--- a/tests/migration/test_migration_contract.py
+++ b/tests/migration/test_migration_contract.py
@@ -90,7 +90,7 @@ def test_detection_surface():
     assert _params(d.voyage_key_available) == set()
     assert _params(d.build_dry_run_preview) == {"report"}
     assert _params(d.render_dry_run_preview) == {"preview"}
-    assert _fields(d.DetectionReport) == {"classifications"}
+    assert _fields(d.DetectionReport) == {"classifications", "voyage_key_present"}
     assert _fields(d.CollectionClassification) == {
         "collection",
         "leg",


### PR DESCRIPTION
## Summary

The guided-upgrade driver hardcoded the cross-model remap target to bge-768 (`_ONNX_MODEL`) regardless of embedding mode (`driver.py:181`). A voyage-mode (cloud) service wires no bge-768 embedder, so re-embedding a legacy minilm-384 collection into a bge-768 target name hits the `pebfx.2` fail-loud guard (HTTP 422) and blocks the migration 0/N. This is the **mixed migrant**: ran local (minilm-384), migrates onto a voyage-mode service.

The fail-loud guard behaved correctly (no silent wrong-model vectors), so this is a pre-cutover correctness fix, not a live incident. Surfaced by the `migration-rehearsal --guided --with-cloud` shakeout 2026-06-22.

## Changes

- **Mode + content-type-aware target.** New pure resolver `cross_model_target_model(source, *, voyage_key_present)` in `detection.py`: cloud mode derives the content-type-appropriate voyage model via `corpus.voyage_model_for_collection` (`code__` → `voyage-code-3`, prose → `voyage-context-3`); local mode keeps bge-768. Keyed on the same `voyage_key_present` deployment signal the detection layer already uses (not `is_local_mode()`).
- **Honest dry-run preview.** `DetectionReport` carries `voyage_key_present`; `build_dry_run_preview` buckets cross-model groups by their *resolved* target (a single source model spanning `code__` + prose splits into two voyage targets in cloud mode), `ModelGroup` carries `target_model`, and the throughput estimate uses the voyage rate for voyage targets. `render_dry_run_preview` names the actual target instead of a hardcoded bge-768.
- **Harness guard.** `run.sh` rejects the incoherent `--guided --with-cloud` combo.

## Tests

Resolver matrix (local/cloud × code/prose), driver target-map under both modes, dry-run preview target + split-bucket coverage. Full migration suite: 349 passed.

## Review

Stacked review run: code-review-expert (0 Critical) + substantive-critic (justified, 0 significant). The critic's first pass caught the dry-run preview still claiming bge-768 / ONNX rate in cloud mode; that's fixed and tested, re-review clean.

## Scope note

Per the bead, this stays a local-mode concern until any freeze-gated real-tenant cutover migrates a tenant carrying legacy minilm-384 collections — at which point this fix is the prerequisite. Cloud corpus is voyage-only today (confirmed via the v0.1.7 RLS-aware tenant probe).

Closes #nexus-gilf2