### PR TITLE
fix(migration): scheme-aware service endpoint resolution for managed TLS (nexus-n3bwh)

### DIFF
--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -70,7 +70,7 @@ DEFAULT_TENANT: str = "default"
 
 # RDR-152 nexus-fjwxh: delegate to the centralized resolver (was an inline
 # copy of the env->lease->fail-loud logic now shared across all clients).
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 
 
 def _to_entry(d: dict) -> CatalogEntry:
@@ -138,8 +138,7 @@ class HttpCatalogClient:
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/daemon/binary_lifecycle.py
+++ b/src/nexus/daemon/binary_lifecycle.py
@@ -70,14 +70,27 @@ def read_installed_provenance(config_dir: Path) -> dict | None:
         return None
 
 
-def fetch_service_version(host: str, port: int, timeout: float = 3.0) -> dict | None:
+def fetch_service_version(
+    host: str,
+    port: int | None,
+    timeout: float = 3.0,
+    *,
+    scheme: str = "http",
+) -> dict | None:
     """GET the running service's /version handshake, or ``None`` when
-    unreachable (older service without the endpoint, service down)."""
+    unreachable (older service without the endpoint, service down).
+
+    ``scheme`` defaults to ``http`` (the local-supervisor path). A managed TLS
+    endpoint passes ``scheme="https"`` so the pre-gate handshake reaches the
+    service instead of failing the TLS negotiation (nexus-n3bwh). ``port`` may
+    be ``None`` (scheme-default port, e.g. an ``https://host`` URL with no
+    explicit ``:443``), in which case it is omitted from the authority."""
     import urllib.request
 
+    authority = f"{host}:{port}" if port is not None else host
     try:
         with urllib.request.urlopen(
-            f"http://{host}:{port}/version", timeout=timeout,
+            f"{scheme}://{authority}/version", timeout=timeout,
         ) as resp:
             data = json.loads(resp.read())
             return data if isinstance(data, dict) else None

--- a/src/nexus/db/http_scratch_store.py
+++ b/src/nexus/db/http_scratch_store.py
@@ -66,7 +66,7 @@ _HEADER_T1_SESSION: str = "X-Nexus-T1-Session"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 
 
 # ── HttpScratchStore ───────────────────────────────────────────────────────────
@@ -107,8 +107,7 @@ class HttpScratchStore:
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/service_endpoint.py
+++ b/src/nexus/db/service_endpoint.py
@@ -88,6 +88,14 @@ def recover_endpoint_from_lease(current_base_url: str) -> tuple[str, str | None]
       long-lived service-backed stores (memory/taxonomy/plan/aspect/chash/…) share
       the resolve-once pattern and remain unguarded — tracked for a sweep follow-on.
     """
+    # An explicitly-pinned NX_SERVICE_URL (a managed TLS endpoint, or any URL the
+    # user named) is authoritative — never silently rebind it to a discovered
+    # supervisor lease, which is ALWAYS local http (nexus-n3bwh review H1): the
+    # https managed base_url would compare unequal to the http lease and rebind
+    # every time, routing managed traffic to the wrong (local) service. Lease
+    # recovery is for the lease-discovered path only.
+    if os.environ.get("NX_SERVICE_URL", "").strip():
+        return None
     lease_url, lease_token = discover_lease()
     if lease_url is not None and lease_url.rstrip("/") != (current_base_url or "").rstrip("/"):
         return lease_url.rstrip("/"), lease_token
@@ -97,8 +105,13 @@ def recover_endpoint_from_lease(current_base_url: str) -> tuple[str, str | None]
 def resolve_service_config() -> tuple[str, int, str]:
     """``(host, port, token)`` — env halves, then the lease, then fail loud.
 
-    The shape the T2 domain stores and the catalog client consume (they build
-    ``http://{host}:{port}`` themselves). Restart-safety note: these clients
+    The local-supervisor 3-tuple — ALWAYS ``http`` (env ``NX_SERVICE_HOST``/
+    ``NX_SERVICE_PORT`` carry no scheme; the lease is local http). New HTTP
+    storage clients must NOT build ``http://{host}:{port}`` from this: call
+    :func:`resolve_service_endpoint` instead, which is scheme-correct and also
+    serves managed TLS endpoints (nexus-n3bwh). This function now backs only the
+    non-``NX_SERVICE_URL`` fallback leg of :func:`resolve_service_endpoint`.
+    Restart-safety note: service-backed clients
     resolve ONCE at construction and hold a long-lived ``httpx.Client`` — they
     ride a supervisor restart only because callers construct a fresh client per
     operation (the ``get_catalog()`` / ``t2_ctx()`` pattern). Do not cache a

--- a/src/nexus/db/service_endpoint.py
+++ b/src/nexus/db/service_endpoint.py
@@ -141,11 +141,34 @@ def resolve_service_config() -> tuple[str, int, str]:
 
 
 def resolve_service_endpoint() -> tuple[str, str]:
-    """``(base_url, token)`` — the shape the T3 vector client consumes.
+    """``(base_url, token)`` — the scheme-correct base-url authority.
 
-    Thin adapter over :func:`resolve_service_config` so the vector client and
-    the T2/catalog stores share one resolution path despite their differing
-    return shapes.
+    Every HTTP storage client that builds a base URL (the T2 domain stores, the
+    catalog client, the T1 scratch store, the migration pre-gate) routes through
+    here so a managed TLS endpoint survives end-to-end. Resolution order mirrors
+    the T3 data path (:func:`nexus.db.http_vector_client._resolve_endpoint`):
+
+      1. ``NX_SERVICE_URL`` — the authoritative FULL endpoint, used VERBATIM
+         (scheme + host + port preserved). This is the ONLY scheme source:
+         ``https://api.conexus-nexus.com:443`` stays ``https``; flattening it to
+         ``http://…:443`` (the pre-RDR-166 bug, nexus-n3bwh) broke every managed
+         migration leg. The token half still falls back to lease/env independently.
+      2. Otherwise ``http://{host}:{port}`` from :func:`resolve_service_config`
+         (env halves → lease → fail loud) — the local-supervisor path, always
+         ``http``.
     """
+    env_url = os.environ.get("NX_SERVICE_URL", "").strip().rstrip("/") or None
+    if env_url is not None:
+        env_token = os.environ.get("NX_SERVICE_TOKEN", "").strip() or None
+        token = env_token
+        if token is None:
+            _, token = discover_lease()
+        if not token:
+            raise RuntimeError(
+                "NX_SERVICE_URL is set but no NX_SERVICE_TOKEN is resolvable "
+                "(neither env nor supervisor lease): export NX_SERVICE_TOKEN "
+                "(the service's bearer token) and re-run."
+            )
+        return env_url, token
     host, port, token = resolve_service_config()
     return f"http://{host}:{port}", token

--- a/src/nexus/db/t2/http_aspect_queue.py
+++ b/src/nexus/db/t2/http_aspect_queue.py
@@ -43,7 +43,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -91,8 +91,7 @@ class HttpAspectQueue(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_centroid_store.py
+++ b/src/nexus/db/t2/http_centroid_store.py
@@ -37,7 +37,7 @@ from typing import Any
 import httpx
 import structlog
 
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2.catalog_taxonomy import AssignResult
 from nexus.db.t2.http_taxonomy_store import DEFAULT_TENANT
 
@@ -74,8 +74,7 @@ class HttpCentroidStore:
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_centroid_store.py
+++ b/src/nexus/db/t2/http_centroid_store.py
@@ -10,7 +10,7 @@ the oracle (:class:`~nexus.db.t2.catalog_taxonomy.CatalogTaxonomy`) reached via 
 
 Talks to the RDR-156 ``/v1/taxonomy/centroids/*`` endpoints (bead nexus-t1hnc.3).
 Endpoint discovery is the SAME centralized resolver
-(:func:`nexus.db.service_endpoint.resolve_service_config`) that HttpTaxonomyStore
+(:func:`nexus.db.service_endpoint.resolve_service_endpoint`) that HttpTaxonomyStore
 uses — no per-store env handling.
 
 ERROR-TRANSLATION CONTRACT (Phase-1 gate O2):

--- a/src/nexus/db/t2/http_chash_index.py
+++ b/src/nexus/db/t2/http_chash_index.py
@@ -55,7 +55,7 @@ _BATCH_SIZE: int = 200
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -95,8 +95,7 @@ class HttpChashIndex(RawHandleGuardMixin):
                       resolved from NX_SERVICE_TOKEN env var.
         """
         if base_url is None:
-            host, port, resolved_token = _resolve_config()
-            base_url = f"http://{host}:{port}"
+            base_url, resolved_token = _resolve_endpoint()
         else:
             resolved_token = _token or os.environ.get("NX_SERVICE_TOKEN", "")
             if not resolved_token:

--- a/src/nexus/db/t2/http_document_aspects_store.py
+++ b/src/nexus/db/t2/http_document_aspects_store.py
@@ -37,7 +37,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -131,8 +131,7 @@ class HttpDocumentAspectsStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_document_highlights_store.py
+++ b/src/nexus/db/t2/http_document_highlights_store.py
@@ -32,7 +32,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -83,8 +83,7 @@ class HttpDocumentHighlightsStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_memory_store.py
+++ b/src/nexus/db/t2/http_memory_store.py
@@ -62,7 +62,7 @@ _ALL_PAIRS_MAX_ENTRIES = 1000
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -99,8 +99,7 @@ class HttpMemoryStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_plan_library.py
+++ b/src/nexus/db/t2/http_plan_library.py
@@ -41,7 +41,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -78,8 +78,7 @@ class HttpPlanLibrary(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_taxonomy_store.py
+++ b/src/nexus/db/t2/http_taxonomy_store.py
@@ -68,7 +68,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -122,8 +122,7 @@ class HttpTaxonomyStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_telemetry_store.py
+++ b/src/nexus/db/t2/http_telemetry_store.py
@@ -52,7 +52,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -86,8 +86,7 @@ class HttpTelemetryStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_token_store.py
+++ b/src/nexus/db/t2/http_token_store.py
@@ -34,7 +34,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 
 
 class HttpTokenStore:
@@ -61,8 +61,7 @@ class HttpTokenStore:
                     raise RuntimeError("NX_SERVICE_TOKEN is required for token administration.")
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
         self._tenant = tenant
         self._auth_token = _token or ""

--- a/src/nexus/migration/pregate.py
+++ b/src/nexus/migration/pregate.py
@@ -76,11 +76,20 @@ class LiveServiceWiredModels:
 
     def wired_models(self) -> frozenset[str] | None:
         try:
-            from nexus.daemon.binary_lifecycle import fetch_service_version
-            from nexus.db.service_endpoint import resolve_service_config
+            from urllib.parse import urlsplit
 
-            host, port, _token = resolve_service_config()
-            handshake = fetch_service_version(host, port)
+            from nexus.daemon.binary_lifecycle import fetch_service_version
+            from nexus.db.service_endpoint import resolve_service_endpoint
+
+            # Scheme-aware: a managed TLS endpoint (NX_SERVICE_URL=https://…:443)
+            # must reach the service over https; the old (host, port) path
+            # hard-coded http and broke the handshake before the data path ran
+            # (nexus-n3bwh). resolve_service_endpoint preserves the scheme.
+            base_url, _token = resolve_service_endpoint()
+            parsed = urlsplit(base_url)
+            handshake = fetch_service_version(
+                parsed.hostname, parsed.port, scheme=parsed.scheme
+            )
         except Exception as exc:  # noqa: BLE001 - probe must never raise upward
             _log.debug("pregate_live_wired_unreachable", error=str(exc))
             return None

--- a/tests/catalog/test_http_catalog_client.py
+++ b/tests/catalog/test_http_catalog_client.py
@@ -24,7 +24,8 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
-from nexus.catalog.http_catalog_client import HttpCatalogClient, _resolve_config
+from nexus.catalog.http_catalog_client import HttpCatalogClient
+from nexus.db.service_endpoint import resolve_service_config as _resolve_config
 from nexus.daemon.catalog_write_shim import CATALOG_WRITE_OPS
 
 

--- a/tests/db/test_service_endpoint_discovery.py
+++ b/tests/db/test_service_endpoint_discovery.py
@@ -243,7 +243,7 @@ def _find_dead_port() -> int:
 class TestCatalogClientResolution:
     def test_catalog_resolve_config_falls_back_to_lease(self):
         _publish_lease(port=4243, token="lease-token")
-        from nexus.catalog.http_catalog_client import _resolve_config
+        from nexus.db.service_endpoint import resolve_service_config as _resolve_config
 
         host, port, token = _resolve_config()
         assert (host, port, token) == ("127.0.0.1", 4243, "lease-token")
@@ -251,14 +251,14 @@ class TestCatalogClientResolution:
     def test_catalog_env_halves_override_individually(self, monkeypatch):
         monkeypatch.setenv("NX_SERVICE_PORT", "9999")
         _publish_lease(port=4243, token="lease-token")
-        from nexus.catalog.http_catalog_client import _resolve_config
+        from nexus.db.service_endpoint import resolve_service_config as _resolve_config
 
         host, port, token = _resolve_config()
         assert port == 9999          # env wins
         assert token == "lease-token"  # lease fills the missing half
 
     def test_catalog_fail_loud_when_neither(self):
-        from nexus.catalog.http_catalog_client import _resolve_config
+        from nexus.db.service_endpoint import resolve_service_config as _resolve_config
 
         with pytest.raises(RuntimeError) as exc_info:
             _resolve_config()

--- a/tests/db/test_shared_service_endpoint.py
+++ b/tests/db/test_shared_service_endpoint.py
@@ -96,6 +96,48 @@ class TestResolveServiceEndpoint:
         assert token == "lease-tok"
 
 
+class TestSchemeAwareEndpoint:
+    """RDR-166 nexus-n3bwh — a managed ``https://…:443`` endpoint must survive.
+
+    ``resolve_service_endpoint`` is the ONE base-url authority the T2 stores,
+    the catalog client, and the migration pre-gate build their URLs from. When
+    ``NX_SERVICE_URL`` names a managed TLS endpoint it MUST be honoured verbatim
+    (scheme + host + port), not flattened to ``http://host:port`` — the old
+    behaviour turned ``https://api.conexus-nexus.com:443`` into
+    ``http://…:443`` and broke every managed-TLS migration leg before the data
+    path (already https-capable) ever ran.
+    """
+
+    def test_service_url_https_used_verbatim(self, monkeypatch):
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "managed-tok")
+        assert resolve_service_endpoint() == (
+            "https://api.conexus-nexus.com:443",
+            "managed-tok",
+        )
+
+    def test_service_url_trailing_slash_stripped(self, monkeypatch):
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443/")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "managed-tok")
+        base_url, _ = resolve_service_endpoint()
+        assert base_url == "https://api.conexus-nexus.com:443"
+
+    def test_service_url_token_falls_back_to_lease(self, monkeypatch):
+        # URL from env, token from the lease — each half independent.
+        _publish_lease(port=4242, token="lease-token")
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        base_url, token = resolve_service_endpoint()
+        assert base_url == "https://api.conexus-nexus.com:443"
+        assert token == "lease-token"
+
+    def test_no_service_url_preserves_http_from_env(self, monkeypatch):
+        # Regression: the local supervisor path is unchanged (http).
+        monkeypatch.setenv("NX_SERVICE_HOST", "127.0.0.1")
+        monkeypatch.setenv("NX_SERVICE_PORT", "8123")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "tok")
+        assert resolve_service_endpoint() == ("http://127.0.0.1:8123", "tok")
+
+
 class TestDiscoverLease:
     def test_absent_lease_returns_none(self):
         assert discover_lease() == (None, None)

--- a/tests/db/test_shared_service_endpoint.py
+++ b/tests/db/test_shared_service_endpoint.py
@@ -45,7 +45,7 @@ def _publish_lease(*, host: str = "127.0.0.1", port: int, token: str) -> None:
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
-    for k in ("NX_SERVICE_HOST", "NX_SERVICE_PORT", "NX_SERVICE_TOKEN"):
+    for k in ("NX_SERVICE_HOST", "NX_SERVICE_PORT", "NX_SERVICE_TOKEN", "NX_SERVICE_URL"):
         monkeypatch.delenv(k, raising=False)
     yield
 
@@ -136,6 +136,51 @@ class TestSchemeAwareEndpoint:
         monkeypatch.setenv("NX_SERVICE_PORT", "8123")
         monkeypatch.setenv("NX_SERVICE_TOKEN", "tok")
         assert resolve_service_endpoint() == ("http://127.0.0.1:8123", "tok")
+
+    def test_service_url_wins_over_host_port(self, monkeypatch):
+        # All three set: NX_SERVICE_URL is the authoritative full endpoint and
+        # takes precedence over NX_SERVICE_HOST/PORT (review M2).
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        monkeypatch.setenv("NX_SERVICE_HOST", "127.0.0.1")
+        monkeypatch.setenv("NX_SERVICE_PORT", "8123")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "managed-tok")
+        assert resolve_service_endpoint() == (
+            "https://api.conexus-nexus.com:443",
+            "managed-tok",
+        )
+
+    def test_service_url_set_but_no_token_fails_loud(self, monkeypatch):
+        # NX_SERVICE_URL with no token (env or lease) → RuntimeError, not a
+        # silent token-less request.
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        with pytest.raises(RuntimeError, match="no NX_SERVICE_TOKEN"):
+            resolve_service_endpoint()
+
+
+class TestRecoverEndpointFromLease:
+    """nexus-n3bwh review H1 — lease recovery must never override an explicitly
+    pinned NX_SERVICE_URL with a discovered (always-local-http) lease."""
+
+    def test_pinned_service_url_is_never_rebound_to_lease(self, monkeypatch):
+        from nexus.db.service_endpoint import recover_endpoint_from_lease
+
+        _publish_lease(port=4242, token="lease-token")
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        # current endpoint is the managed https one; a local lease exists and
+        # would compare unequal — but the pin must suppress the rebind.
+        assert (
+            recover_endpoint_from_lease("https://api.conexus-nexus.com:443") is None
+        )
+
+    def test_lease_recovery_still_works_without_service_url(self):
+        from nexus.db.service_endpoint import recover_endpoint_from_lease
+
+        _publish_lease(port=4242, token="lease-token")
+        # No NX_SERVICE_URL: a stale current endpoint rebinds to the fresh lease.
+        assert recover_endpoint_from_lease("http://127.0.0.1:9999") == (
+            "http://127.0.0.1:4242",
+            "lease-token",
+        )
 
 
 class TestDiscoverLease:

--- a/tests/migration/test_pregate.py
+++ b/tests/migration/test_pregate.py
@@ -249,11 +249,11 @@ def test_all_supported_mixed_proceeds() -> None:
 def test_live_source_returns_none_when_service_unreachable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _boom() -> tuple[str, int, str]:
+    def _boom() -> tuple[str, str]:
         raise RuntimeError("no service lease")
 
     monkeypatch.setattr(
-        "nexus.db.service_endpoint.resolve_service_config", _boom
+        "nexus.db.service_endpoint.resolve_service_endpoint", _boom
     )
     assert LiveServiceWiredModels().wired_models() is None
 
@@ -262,14 +262,43 @@ def test_live_source_parses_version_handshake(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "nexus.db.service_endpoint.resolve_service_config",
-        lambda: ("127.0.0.1", 9999, "tok"),
+        "nexus.db.service_endpoint.resolve_service_endpoint",
+        lambda: ("http://127.0.0.1:9999", "tok"),
     )
     monkeypatch.setattr(
         "nexus.daemon.binary_lifecycle.fetch_service_version",
-        lambda host, port: {"embedding_mode": "cloud", "embedding_models": [_ONNX, _VOYAGE]},
+        lambda host, port, scheme="http": {
+            "embedding_mode": "cloud",
+            "embedding_models": [_ONNX, _VOYAGE],
+        },
     )
     assert LiveServiceWiredModels().wired_models() == frozenset({_ONNX, _VOYAGE})
+
+
+def test_live_source_handshake_over_https_managed_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """nexus-n3bwh — a managed https endpoint must hand off scheme=https,
+    host, and the explicit :443 port to the version handshake (not http)."""
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(
+        "nexus.db.service_endpoint.resolve_service_endpoint",
+        lambda: ("https://api.conexus-nexus.com:443", "managed-tok"),
+    )
+
+    def _fetch(host, port, scheme="http"):
+        seen.update(host=host, port=port, scheme=scheme)
+        return {"embedding_mode": "cloud", "embedding_models": [_ONNX, _VOYAGE]}
+
+    monkeypatch.setattr(
+        "nexus.daemon.binary_lifecycle.fetch_service_version", _fetch
+    )
+    assert LiveServiceWiredModels().wired_models() == frozenset({_ONNX, _VOYAGE})
+    assert seen == {
+        "host": "api.conexus-nexus.com",
+        "port": 443,
+        "scheme": "https",
+    }
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What

RDR-166 Research Finding 2 — a correctness defect. The service-endpoint resolver flattened a managed `https://api.conexus-nexus.com:443` endpoint to `http://...:443`, breaking the guided-upgrade migration **pre-gate / version-pin legs** *and* the **T2 store ETL legs** (per the qvemn #1284 finding, both resolve via the same path) before the already-https-capable T3 data path ever ran.

## Fix

`resolve_service_endpoint()` is now the single scheme-correct base-url authority: it honors `NX_SERVICE_URL` verbatim (scheme + host + port), mirroring the T3 data path (`http_vector_client._resolve_endpoint`). All 13 base-url builders (11 T2/catalog/scratch stores + chash index + the migration pre-gate) route through it instead of building `http://{host}:{port}` themselves — collapsing 13 duplicated literals into one authority. `fetch_service_version` gains a back-compatible `scheme` kwarg + `None`-port handling.

The T3 data path is untouched (it was already https-capable). `resolve_service_config()` (the `(host,port,token)` 3-tuple) remains as the local-http fallback leg.

## Stacked review (both clean, 0 Critical)
- **code-review-expert** H1: `recover_endpoint_from_lease()` could silently rebind a managed https endpoint to a discovered local-http lease → guarded (returns `None` when `NX_SERVICE_URL` is pinned). M1 fixture gap + M2 coexistence test addressed.
- **substantive-critic** Sig-1/Sig-2: stale docstrings refreshed so the next developer is pointed at `resolve_service_endpoint`, not the http-only 3-tuple. Scope-broadening (13 files) judged **justified**, not creep — the T2 ETL legs share the identical break.

## Tests
New: scheme-verbatim, trailing-slash, token-from-lease, URL-wins-over-host/port, fail-loud-without-token, https pre-gate handshake, lease-recovery guard. Full affected surface green (1180 passed). Local-http path unchanged.

## Closes
Closes #nexus-n3bwh