### PR TITLE
feat(migration): estimate-and-confirm Voyage re-embed cost guardrail (nexus-cewad)

### DIFF
--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -70,7 +70,7 @@ DEFAULT_TENANT: str = "default"
 
 # RDR-152 nexus-fjwxh: delegate to the centralized resolver (was an inline
 # copy of the env->lease->fail-loud logic now shared across all clients).
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 
 
 def _to_entry(d: dict) -> CatalogEntry:
@@ -138,8 +138,7 @@ class HttpCatalogClient:
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/commands/migrate_cmd.py
+++ b/src/nexus/commands/migrate_cmd.py
@@ -35,11 +35,40 @@ from nexus.migration.detection import (
     build_dry_run_preview,
     classify_collections,
     open_read_legs,
+    render_cost_confirmation,
     render_dry_run_preview,
     voyage_key_available,
 )
 
 _log = structlog.get_logger(__name__)
+
+
+def _confirm_voyage_cost(
+    preview: Any,
+    *,
+    assume_yes: bool,
+    confirm: Any = None,
+) -> bool:
+    """Estimate-and-confirm gate for a billed Voyage re-embed (nexus-cewad).
+
+    Returns ``True`` when the caller may proceed with the billed migration,
+    ``False`` when the operator declined. A migration that bills nothing
+    proceeds silently; ``assume_yes`` proceeds without prompting (the scripted
+    / CI path). Otherwise the cost + re-run foot-gun is shown and an interactive
+    confirmation gates the call. ``confirm`` is injectable for tests; production
+    uses :func:`click.confirm` (which aborts on a non-interactive stream, so a
+    billed run without ``--yes`` never proceeds unattended).
+    """
+    warning = render_cost_confirmation(preview)
+    if warning is None:
+        return True  # nothing billed — no prompt
+    if assume_yes:
+        click.echo(warning)
+        click.echo("Proceeding (--yes): the operator's Voyage key will be billed.")
+        return True
+    click.echo(warning)
+    _confirm = confirm if confirm is not None else click.confirm
+    return bool(_confirm("Proceed with the billed re-embed?"))
 
 
 @click.command(name="migrate-to-service")
@@ -77,12 +106,22 @@ _log = structlog.get_logger(__name__)
     default=None,
     help="Override the nexus-service base URL (default: the supervisor lease).",
 )
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Skip the Voyage re-embed cost confirmation (scripted / non-interactive "
+    "runs). The operator's Voyage key is billed without a prompt.",
+)
 def migrate_to_service_cmd(
     dry_run: bool,
     local_path: str | None,
     db_path: str | None,
     catalog_db_path: str | None,
     service_url: str | None,
+    assume_yes: bool,
 ) -> None:
     """Guided Chroma-to-service upgrade migration (RDR-159).
 
@@ -92,7 +131,9 @@ def migrate_to_service_cmd(
     if dry_run:
         _run_dry_run(local_path)
         return
-    _run_migration(local_path, db_path, catalog_db_path, service_url)
+    _run_migration(
+        local_path, db_path, catalog_db_path, service_url, assume_yes=assume_yes
+    )
 
 
 def _run_dry_run(local_path: str | None) -> None:
@@ -120,6 +161,8 @@ def _run_migration(
     db_path: str | None,
     catalog_db_path: str | None,
     service_url: str | None,
+    *,
+    assume_yes: bool = False,
 ) -> None:
     """Drive the full guided migration through the nexus engine.
 
@@ -164,6 +207,25 @@ def _run_migration(
             "catalog ETL + manifest validation call the service).\n"
             "Set it to the bearer token configured in the nexus-service."
         )
+
+    # COST GUARDRAIL (nexus-cewad) — a cross-model→voyage re-embed is billed to
+    # the operator's Voyage key. Estimate it from a read-only classify pass and
+    # gate the billed run behind an explicit confirmation. A migration that
+    # bills nothing (byte-for-byte copy / local ONNX re-embed) proceeds silently.
+    local_read, cloud_read = open_read_legs(local_path)
+    try:
+        cost_preview = build_dry_run_preview(
+            classify_collections(
+                local_client=local_read,
+                cloud_client=cloud_read,
+                voyage_key_present=voyage_key_available(),
+            )
+        )
+    finally:
+        for client in (local_read, cloud_read):
+            _close_quietly(client)
+    if not _confirm_voyage_cost(cost_preview, assume_yes=assume_yes):
+        raise click.Abort()
 
     from nexus.catalog.factory import make_catalog_client_for_migration
 

--- a/src/nexus/daemon/binary_lifecycle.py
+++ b/src/nexus/daemon/binary_lifecycle.py
@@ -70,14 +70,27 @@ def read_installed_provenance(config_dir: Path) -> dict | None:
         return None
 
 
-def fetch_service_version(host: str, port: int, timeout: float = 3.0) -> dict | None:
+def fetch_service_version(
+    host: str,
+    port: int | None,
+    timeout: float = 3.0,
+    *,
+    scheme: str = "http",
+) -> dict | None:
     """GET the running service's /version handshake, or ``None`` when
-    unreachable (older service without the endpoint, service down)."""
+    unreachable (older service without the endpoint, service down).
+
+    ``scheme`` defaults to ``http`` (the local-supervisor path). A managed TLS
+    endpoint passes ``scheme="https"`` so the pre-gate handshake reaches the
+    service instead of failing the TLS negotiation (nexus-n3bwh). ``port`` may
+    be ``None`` (scheme-default port, e.g. an ``https://host`` URL with no
+    explicit ``:443``), in which case it is omitted from the authority."""
     import urllib.request
 
+    authority = f"{host}:{port}" if port is not None else host
     try:
         with urllib.request.urlopen(
-            f"http://{host}:{port}/version", timeout=timeout,
+            f"{scheme}://{authority}/version", timeout=timeout,
         ) as resp:
             data = json.loads(resp.read())
             return data if isinstance(data, dict) else None

--- a/src/nexus/db/http_scratch_store.py
+++ b/src/nexus/db/http_scratch_store.py
@@ -66,7 +66,7 @@ _HEADER_T1_SESSION: str = "X-Nexus-T1-Session"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 
 
 # ── HttpScratchStore ───────────────────────────────────────────────────────────
@@ -107,8 +107,7 @@ class HttpScratchStore:
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/service_endpoint.py
+++ b/src/nexus/db/service_endpoint.py
@@ -88,6 +88,14 @@ def recover_endpoint_from_lease(current_base_url: str) -> tuple[str, str | None]
       long-lived service-backed stores (memory/taxonomy/plan/aspect/chash/…) share
       the resolve-once pattern and remain unguarded — tracked for a sweep follow-on.
     """
+    # An explicitly-pinned NX_SERVICE_URL (a managed TLS endpoint, or any URL the
+    # user named) is authoritative — never silently rebind it to a discovered
+    # supervisor lease, which is ALWAYS local http (nexus-n3bwh review H1): the
+    # https managed base_url would compare unequal to the http lease and rebind
+    # every time, routing managed traffic to the wrong (local) service. Lease
+    # recovery is for the lease-discovered path only.
+    if os.environ.get("NX_SERVICE_URL", "").strip():
+        return None
     lease_url, lease_token = discover_lease()
     if lease_url is not None and lease_url.rstrip("/") != (current_base_url or "").rstrip("/"):
         return lease_url.rstrip("/"), lease_token
@@ -97,8 +105,13 @@ def recover_endpoint_from_lease(current_base_url: str) -> tuple[str, str | None]
 def resolve_service_config() -> tuple[str, int, str]:
     """``(host, port, token)`` — env halves, then the lease, then fail loud.
 
-    The shape the T2 domain stores and the catalog client consume (they build
-    ``http://{host}:{port}`` themselves). Restart-safety note: these clients
+    The local-supervisor 3-tuple — ALWAYS ``http`` (env ``NX_SERVICE_HOST``/
+    ``NX_SERVICE_PORT`` carry no scheme; the lease is local http). New HTTP
+    storage clients must NOT build ``http://{host}:{port}`` from this: call
+    :func:`resolve_service_endpoint` instead, which is scheme-correct and also
+    serves managed TLS endpoints (nexus-n3bwh). This function now backs only the
+    non-``NX_SERVICE_URL`` fallback leg of :func:`resolve_service_endpoint`.
+    Restart-safety note: service-backed clients
     resolve ONCE at construction and hold a long-lived ``httpx.Client`` — they
     ride a supervisor restart only because callers construct a fresh client per
     operation (the ``get_catalog()`` / ``t2_ctx()`` pattern). Do not cache a

--- a/src/nexus/db/service_endpoint.py
+++ b/src/nexus/db/service_endpoint.py
@@ -141,11 +141,34 @@ def resolve_service_config() -> tuple[str, int, str]:
 
 
 def resolve_service_endpoint() -> tuple[str, str]:
-    """``(base_url, token)`` — the shape the T3 vector client consumes.
+    """``(base_url, token)`` — the scheme-correct base-url authority.
 
-    Thin adapter over :func:`resolve_service_config` so the vector client and
-    the T2/catalog stores share one resolution path despite their differing
-    return shapes.
+    Every HTTP storage client that builds a base URL (the T2 domain stores, the
+    catalog client, the T1 scratch store, the migration pre-gate) routes through
+    here so a managed TLS endpoint survives end-to-end. Resolution order mirrors
+    the T3 data path (:func:`nexus.db.http_vector_client._resolve_endpoint`):
+
+      1. ``NX_SERVICE_URL`` — the authoritative FULL endpoint, used VERBATIM
+         (scheme + host + port preserved). This is the ONLY scheme source:
+         ``https://api.conexus-nexus.com:443`` stays ``https``; flattening it to
+         ``http://…:443`` (the pre-RDR-166 bug, nexus-n3bwh) broke every managed
+         migration leg. The token half still falls back to lease/env independently.
+      2. Otherwise ``http://{host}:{port}`` from :func:`resolve_service_config`
+         (env halves → lease → fail loud) — the local-supervisor path, always
+         ``http``.
     """
+    env_url = os.environ.get("NX_SERVICE_URL", "").strip().rstrip("/") or None
+    if env_url is not None:
+        env_token = os.environ.get("NX_SERVICE_TOKEN", "").strip() or None
+        token = env_token
+        if token is None:
+            _, token = discover_lease()
+        if not token:
+            raise RuntimeError(
+                "NX_SERVICE_URL is set but no NX_SERVICE_TOKEN is resolvable "
+                "(neither env nor supervisor lease): export NX_SERVICE_TOKEN "
+                "(the service's bearer token) and re-run."
+            )
+        return env_url, token
     host, port, token = resolve_service_config()
     return f"http://{host}:{port}", token

--- a/src/nexus/db/t2/http_aspect_queue.py
+++ b/src/nexus/db/t2/http_aspect_queue.py
@@ -43,7 +43,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -91,8 +91,7 @@ class HttpAspectQueue(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_centroid_store.py
+++ b/src/nexus/db/t2/http_centroid_store.py
@@ -37,7 +37,7 @@ from typing import Any
 import httpx
 import structlog
 
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2.catalog_taxonomy import AssignResult
 from nexus.db.t2.http_taxonomy_store import DEFAULT_TENANT
 
@@ -74,8 +74,7 @@ class HttpCentroidStore:
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_centroid_store.py
+++ b/src/nexus/db/t2/http_centroid_store.py
@@ -10,7 +10,7 @@ the oracle (:class:`~nexus.db.t2.catalog_taxonomy.CatalogTaxonomy`) reached via 
 
 Talks to the RDR-156 ``/v1/taxonomy/centroids/*`` endpoints (bead nexus-t1hnc.3).
 Endpoint discovery is the SAME centralized resolver
-(:func:`nexus.db.service_endpoint.resolve_service_config`) that HttpTaxonomyStore
+(:func:`nexus.db.service_endpoint.resolve_service_endpoint`) that HttpTaxonomyStore
 uses — no per-store env handling.
 
 ERROR-TRANSLATION CONTRACT (Phase-1 gate O2):

--- a/src/nexus/db/t2/http_chash_index.py
+++ b/src/nexus/db/t2/http_chash_index.py
@@ -55,7 +55,7 @@ _BATCH_SIZE: int = 200
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -95,8 +95,7 @@ class HttpChashIndex(RawHandleGuardMixin):
                       resolved from NX_SERVICE_TOKEN env var.
         """
         if base_url is None:
-            host, port, resolved_token = _resolve_config()
-            base_url = f"http://{host}:{port}"
+            base_url, resolved_token = _resolve_endpoint()
         else:
             resolved_token = _token or os.environ.get("NX_SERVICE_TOKEN", "")
             if not resolved_token:

--- a/src/nexus/db/t2/http_document_aspects_store.py
+++ b/src/nexus/db/t2/http_document_aspects_store.py
@@ -37,7 +37,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -131,8 +131,7 @@ class HttpDocumentAspectsStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_document_highlights_store.py
+++ b/src/nexus/db/t2/http_document_highlights_store.py
@@ -32,7 +32,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -83,8 +83,7 @@ class HttpDocumentHighlightsStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_memory_store.py
+++ b/src/nexus/db/t2/http_memory_store.py
@@ -62,7 +62,7 @@ _ALL_PAIRS_MAX_ENTRIES = 1000
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -99,8 +99,7 @@ class HttpMemoryStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_plan_library.py
+++ b/src/nexus/db/t2/http_plan_library.py
@@ -41,7 +41,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -78,8 +78,7 @@ class HttpPlanLibrary(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_taxonomy_store.py
+++ b/src/nexus/db/t2/http_taxonomy_store.py
@@ -68,7 +68,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -122,8 +122,7 @@ class HttpTaxonomyStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_telemetry_store.py
+++ b/src/nexus/db/t2/http_telemetry_store.py
@@ -52,7 +52,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -86,8 +86,7 @@ class HttpTelemetryStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_token_store.py
+++ b/src/nexus/db/t2/http_token_store.py
@@ -34,7 +34,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 
 
 class HttpTokenStore:
@@ -61,8 +61,7 @@ class HttpTokenStore:
                     raise RuntimeError("NX_SERVICE_TOKEN is required for token administration.")
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
         self._tenant = tenant
         self._auth_token = _token or ""

--- a/src/nexus/migration/detection.py
+++ b/src/nexus/migration/detection.py
@@ -538,10 +538,20 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
         migratable_chunks += chunk_count
         total_est_tokens += tokens
         est_seconds += seconds
-        # Billed iff the re-embed runs through a Voyage model (cross-model→voyage).
-        # Byte-for-byte voyage copies (support == supported-voyage-1024, not
-        # cross_model) reuse stored embeddings — no API call, no bill.
-        if is_cross_model and target_model in _VOYAGE_MODELS:
+        # Billed iff the chunk's effective TARGET embedder is a Voyage model.
+        # Seam B re-embeds EVERY migrated chunk server-side (iter_collection_chunks
+        # deliberately discards stored vectors; upsert_chunks ignores any
+        # embeddings arg), so there is no free "byte-for-byte" copy — what
+        # determines the bill is which model the service re-embeds with:
+        #   * cross-model→voyage  → target_model is a Voyage model → BILLED.
+        #   * supported-voyage-1024 → re-embedded with the SAME voyage model → BILLED.
+        #   * supported-onnx / cross-model→bge → local ONNX (bge-768) → free.
+        billed = (
+            target_model in _VOYAGE_MODELS
+            if is_cross_model
+            else support == "supported-voyage-1024"
+        )
+        if billed:
             billed_voyage_tokens += tokens
 
     # Stable order: leg, support, model, then target — deterministic preview text.
@@ -620,6 +630,14 @@ def render_dry_run_preview(preview: DryRunPreview) -> str:
         f"~{preview.total_est_tokens:,} tokens; ~{preview.est_seconds:.1f}s "
         "re-embed time."
     )
+    if preview.billed_voyage_tokens > 0:
+        lines.append(
+            f"Voyage re-embed cost (billed to the operator key): "
+            f"~{preview.billed_voyage_tokens:,} tokens, est. "
+            f"~${preview.est_voyage_cost_usd:.2f} "
+            f"(~${_VOYAGE_COST_USD_PER_1M_TOKENS:.2f}/1M tokens; a re-run re-embeds "
+            "at full cost — not deduplicated)."
+        )
     lines.append(
         "Estimates are coarse planning figures, not a binding commitment; the "
         "live run reports exact counts."
@@ -641,7 +659,7 @@ def render_cost_confirmation(preview: DryRunPreview) -> str | None:
     if preview.billed_voyage_tokens <= 0:
         return None
     return (
-        f"⚠  This migration will RE-EMBED ~{preview.billed_voyage_tokens:,} tokens "
+        f"WARNING: this migration will RE-EMBED ~{preview.billed_voyage_tokens:,} tokens "
         f"through a Voyage model, billed to the operator's Voyage key — an "
         f"estimated ${preview.est_voyage_cost_usd:.2f} (coarse planning figure at "
         f"~${_VOYAGE_COST_USD_PER_1M_TOKENS:.2f}/1M tokens; the real invoice "

--- a/src/nexus/migration/detection.py
+++ b/src/nexus/migration/detection.py
@@ -415,6 +415,14 @@ _EST_TOKENS_PER_CHUNK: int = 512
 _EST_VOYAGE_CHUNKS_PER_SEC: float = 200.0
 _EST_ONNX_CHUNKS_PER_SEC: float = 100.0
 
+#: Coarse Voyage re-embed price (USD per 1M tokens), for the cost guardrail
+#: (nexus-cewad / RDR-166 Gap 4). Order-of-magnitude planning figure across the
+#: voyage-context-3 / voyage-code-3 family — NOT a billing-accurate quote; the
+#: operator's actual invoice is set by Voyage's current pricing. Only the
+#: cross-model→voyage RE-EMBED is billed: byte-for-byte voyage copies reuse
+#: stored embeddings (no API call), and ONNX/bge re-embeds run locally.
+_VOYAGE_COST_USD_PER_1M_TOKENS: float = 0.12
+
 
 @dataclass(frozen=True)
 class ModelGroup:
@@ -451,6 +459,13 @@ class DryRunPreview:
     migratable_chunks: int
     total_est_tokens: int
     est_seconds: float
+    #: nexus-cewad: token volume that will be RE-EMBEDDED through a Voyage model
+    #: (cross-model→voyage groups only) and therefore billed to the operator key.
+    #: Byte-for-byte voyage copies and ONNX/bge re-embeds contribute zero.
+    billed_voyage_tokens: int = 0
+    #: Coarse USD estimate for ``billed_voyage_tokens`` at
+    #: :data:`_VOYAGE_COST_USD_PER_1M_TOKENS`. ``0.0`` when nothing is billed.
+    est_voyage_cost_usd: float = 0.0
 
 
 def _throughput_for_support(support: Support) -> float:
@@ -490,6 +505,7 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
     migratable_chunks = 0
     total_est_tokens = 0
     est_seconds = 0.0
+    billed_voyage_tokens = 0
     for (leg, model, support, target_model), members in buckets.items():
         chunk_count = sum(m.source_count for m in members)
         is_cross_model = target_model is not None
@@ -522,6 +538,11 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
         migratable_chunks += chunk_count
         total_est_tokens += tokens
         est_seconds += seconds
+        # Billed iff the re-embed runs through a Voyage model (cross-model→voyage).
+        # Byte-for-byte voyage copies (support == supported-voyage-1024, not
+        # cross_model) reuse stored embeddings — no API call, no bill.
+        if is_cross_model and target_model in _VOYAGE_MODELS:
+            billed_voyage_tokens += tokens
 
     # Stable order: leg, support, model, then target — deterministic preview text.
     groups.sort(key=lambda g: (g.leg, g.support, g.model or "", g.target_model or ""))
@@ -537,6 +558,8 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
         migratable_chunks=migratable_chunks,
         total_est_tokens=total_est_tokens,
         est_seconds=round(est_seconds, 1),
+        billed_voyage_tokens=billed_voyage_tokens,
+        est_voyage_cost_usd=billed_voyage_tokens / 1_000_000 * _VOYAGE_COST_USD_PER_1M_TOKENS,
     )
 
 
@@ -602,3 +625,28 @@ def render_dry_run_preview(preview: DryRunPreview) -> str:
         "live run reports exact counts."
     )
     return "\n".join(lines)
+
+
+def render_cost_confirmation(preview: DryRunPreview) -> str | None:
+    """Operator-facing cost warning for a billed Voyage re-embed, or ``None``.
+
+    Returns ``None`` when the migration bills nothing (no cross-model→voyage
+    re-embed) — the caller then proceeds without a cost prompt. When there IS a
+    billed re-embed, returns a warning that surfaces (a) the coarse USD estimate
+    and the token volume it is based on, and (b) the re-run-at-full-cost
+    foot-gun (nexus-1sx01): this guardrail WARNS and CONFIRMS; it does NOT
+    deduplicate or avoid re-billing a repeated run (copy-not-move has no
+    server-side cost memory). Pure formatting — no I/O.
+    """
+    if preview.billed_voyage_tokens <= 0:
+        return None
+    return (
+        f"⚠  This migration will RE-EMBED ~{preview.billed_voyage_tokens:,} tokens "
+        f"through a Voyage model, billed to the operator's Voyage key — an "
+        f"estimated ${preview.est_voyage_cost_usd:.2f} (coarse planning figure at "
+        f"~${_VOYAGE_COST_USD_PER_1M_TOKENS:.2f}/1M tokens; the real invoice "
+        f"follows Voyage's current pricing).\n"
+        f"   Re-running this migration re-embeds the same chunks again at full "
+        f"cost — the copy carries no server-side cost memory, so a repeat run is "
+        f"billed in full, not deduplicated."
+    )

--- a/src/nexus/migration/detection.py
+++ b/src/nexus/migration/detection.py
@@ -418,9 +418,11 @@ _EST_ONNX_CHUNKS_PER_SEC: float = 100.0
 #: Coarse Voyage re-embed price (USD per 1M tokens), for the cost guardrail
 #: (nexus-cewad / RDR-166 Gap 4). Order-of-magnitude planning figure across the
 #: voyage-context-3 / voyage-code-3 family — NOT a billing-accurate quote; the
-#: operator's actual invoice is set by Voyage's current pricing. Only the
-#: cross-model→voyage RE-EMBED is billed: byte-for-byte voyage copies reuse
-#: stored embeddings (no API call), and ONNX/bge re-embeds run locally.
+#: operator's actual invoice is set by Voyage's current pricing. Billed whenever
+#: the effective TARGET embedder is a Voyage model — both cross-model→voyage AND
+#: same-model supported-voyage-1024 (Seam B discards stored vectors;
+#: upsert_chunks re-embeds server-side for every migrated chunk). ONNX/bge
+#: re-embeds run locally and are not billed.
 _VOYAGE_COST_USD_PER_1M_TOKENS: float = 0.12
 
 
@@ -460,8 +462,10 @@ class DryRunPreview:
     total_est_tokens: int
     est_seconds: float
     #: nexus-cewad: token volume that will be RE-EMBEDDED through a Voyage model
-    #: (cross-model→voyage groups only) and therefore billed to the operator key.
-    #: Byte-for-byte voyage copies and ONNX/bge re-embeds contribute zero.
+    #: and therefore billed to the operator key — includes BOTH cross-model→voyage
+    #: AND supported-voyage-1024 (same-model) groups. Seam B discards stored
+    #: vectors and re-embeds server-side for every migrated chunk, so there is no
+    #: free byte-for-byte copy. ONNX/bge re-embeds run locally and contribute zero.
     billed_voyage_tokens: int = 0
     #: Coarse USD estimate for ``billed_voyage_tokens`` at
     #: :data:`_VOYAGE_COST_USD_PER_1M_TOKENS`. ``0.0`` when nothing is billed.

--- a/src/nexus/migration/pregate.py
+++ b/src/nexus/migration/pregate.py
@@ -76,11 +76,20 @@ class LiveServiceWiredModels:
 
     def wired_models(self) -> frozenset[str] | None:
         try:
-            from nexus.daemon.binary_lifecycle import fetch_service_version
-            from nexus.db.service_endpoint import resolve_service_config
+            from urllib.parse import urlsplit
 
-            host, port, _token = resolve_service_config()
-            handshake = fetch_service_version(host, port)
+            from nexus.daemon.binary_lifecycle import fetch_service_version
+            from nexus.db.service_endpoint import resolve_service_endpoint
+
+            # Scheme-aware: a managed TLS endpoint (NX_SERVICE_URL=https://…:443)
+            # must reach the service over https; the old (host, port) path
+            # hard-coded http and broke the handshake before the data path ran
+            # (nexus-n3bwh). resolve_service_endpoint preserves the scheme.
+            base_url, _token = resolve_service_endpoint()
+            parsed = urlsplit(base_url)
+            handshake = fetch_service_version(
+                parsed.hostname, parsed.port, scheme=parsed.scheme
+            )
         except Exception as exc:  # noqa: BLE001 - probe must never raise upward
             _log.debug("pregate_live_wired_unreachable", error=str(exc))
             return None

--- a/tests/catalog/test_http_catalog_client.py
+++ b/tests/catalog/test_http_catalog_client.py
@@ -24,7 +24,8 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
-from nexus.catalog.http_catalog_client import HttpCatalogClient, _resolve_config
+from nexus.catalog.http_catalog_client import HttpCatalogClient
+from nexus.db.service_endpoint import resolve_service_config as _resolve_config
 from nexus.daemon.catalog_write_shim import CATALOG_WRITE_OPS
 
 

--- a/tests/commands/test_migrate_cost_guardrail.py
+++ b/tests/commands/test_migrate_cost_guardrail.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-166 Gap 4 (nexus-cewad) — the estimate-and-confirm Voyage cost guardrail.
+
+The guardrail must GATE the billed `run_guided_upgrade` call, not merely echo a
+warning beside it: a declined confirmation aborts before any re-embed runs, and
+`--yes` is the only way to proceed non-interactively. A migration that bills
+nothing (no cross-model→voyage re-embed) is never prompted.
+"""
+from __future__ import annotations
+
+import click
+import pytest
+
+from nexus.commands.migrate_cmd import _confirm_voyage_cost
+from nexus.migration.detection import DryRunPreview
+
+
+def _preview(*, cost: float, tokens: int) -> DryRunPreview:
+    return DryRunPreview(
+        groups=(),
+        unsupported=(),
+        legs_with_data=frozenset(),
+        migratable_chunks=0,
+        total_est_tokens=tokens,
+        est_seconds=0.0,
+        billed_voyage_tokens=tokens,
+        est_voyage_cost_usd=cost,
+    )
+
+
+class TestConfirmVoyageCost:
+    def test_free_migration_proceeds_without_prompting(self) -> None:
+        calls: list[bool] = []
+        proceed = _confirm_voyage_cost(
+            _preview(cost=0.0, tokens=0),
+            assume_yes=False,
+            confirm=lambda msg: calls.append(True) or True,
+        )
+        assert proceed is True
+        assert calls == []  # never prompted — nothing is billed
+
+    def test_assume_yes_bypasses_prompt_on_billed_run(self) -> None:
+        calls: list[bool] = []
+        proceed = _confirm_voyage_cost(
+            _preview(cost=5.0, tokens=1000),
+            assume_yes=True,
+            confirm=lambda msg: calls.append(True) or True,
+        )
+        assert proceed is True
+        assert calls == []  # --yes skips the prompt
+
+    def test_billed_run_prompts_and_proceeds_on_yes(self) -> None:
+        seen: list[str] = []
+        proceed = _confirm_voyage_cost(
+            _preview(cost=5.0, tokens=1000),
+            assume_yes=False,
+            confirm=lambda msg: seen.append(msg) or True,
+        )
+        assert proceed is True
+        assert len(seen) == 1  # prompted exactly once
+
+    def test_billed_run_aborts_on_decline(self) -> None:
+        proceed = _confirm_voyage_cost(
+            _preview(cost=5.0, tokens=1000),
+            assume_yes=False,
+            confirm=lambda msg: False,
+        )
+        assert proceed is False  # declined → caller must not run the billed leg
+
+
+class TestRunMigrationGate:
+    """The gate must precede the billed run_guided_upgrade in _run_migration."""
+
+    def _wire(self, monkeypatch, *, cost: float, tokens: int = 1000):
+        import nexus.commands.migrate_cmd as mc
+
+        ran: list[str] = []
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "tok")
+        monkeypatch.setattr(mc, "open_read_legs", lambda p: (None, None))
+        monkeypatch.setattr(mc, "classify_collections", lambda **k: object())
+        monkeypatch.setattr(mc, "voyage_key_available", lambda: True)
+        monkeypatch.setattr(
+            mc, "build_dry_run_preview", lambda r: _preview(cost=cost, tokens=tokens)
+        )
+        monkeypatch.setattr(mc, "_close_quietly", lambda c: None)
+        # endpoint preflight + client construction
+        monkeypatch.setattr(
+            "nexus.db.http_vector_client._resolve_endpoint",
+            lambda: ("https://api.conexus-nexus.com:443", "tok"),
+        )
+        monkeypatch.setattr(
+            "nexus.db.http_vector_client.HttpVectorClient",
+            lambda **k: object(),
+        )
+        monkeypatch.setattr(
+            "nexus.catalog.factory.make_catalog_client_for_migration",
+            lambda **k: object(),
+        )
+        monkeypatch.setattr(
+            "nexus.migration.driver.run_guided_upgrade",
+            lambda **k: ran.append("billed") or _stub_result(),
+        )
+        monkeypatch.setattr(mc, "_resolve_db_path", lambda p: _existing_path())
+        monkeypatch.setattr(mc, "_resolve_catalog_db_path", lambda p: _existing_path())
+        monkeypatch.setattr(mc, "_render_result", lambda r: None)
+        return mc, ran
+
+    def test_declined_cost_aborts_before_billed_run(self, monkeypatch) -> None:
+        mc, ran = self._wire(monkeypatch, cost=5.0)
+        monkeypatch.setattr("click.confirm", lambda *a, **k: False)
+        with pytest.raises(click.Abort):
+            mc._run_migration(None, None, None, None, assume_yes=False)
+        assert ran == []  # billed run never reached
+
+    def test_assume_yes_reaches_billed_run(self, monkeypatch) -> None:
+        mc, ran = self._wire(monkeypatch, cost=5.0)
+        mc._run_migration(None, None, None, None, assume_yes=True)
+        assert ran == ["billed"]
+
+    def test_free_migration_reaches_billed_run_without_prompt(self, monkeypatch) -> None:
+        mc, ran = self._wire(monkeypatch, cost=0.0, tokens=0)
+        # No confirm patched: a free migration must not call click.confirm.
+        monkeypatch.setattr(
+            "click.confirm",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("prompted on free run")),
+        )
+        mc._run_migration(None, None, None, None, assume_yes=False)
+        assert ran == ["billed"]
+
+
+def _stub_result():
+    class _Seq:
+        phase = "migrated"
+
+    class _R:
+        sequence = _Seq()
+
+    return _R()
+
+
+class _ExistingPath:
+    def exists(self) -> bool:
+        return True
+
+
+def _existing_path() -> _ExistingPath:
+    return _ExistingPath()

--- a/tests/db/test_service_endpoint_discovery.py
+++ b/tests/db/test_service_endpoint_discovery.py
@@ -243,7 +243,7 @@ def _find_dead_port() -> int:
 class TestCatalogClientResolution:
     def test_catalog_resolve_config_falls_back_to_lease(self):
         _publish_lease(port=4243, token="lease-token")
-        from nexus.catalog.http_catalog_client import _resolve_config
+        from nexus.db.service_endpoint import resolve_service_config as _resolve_config
 
         host, port, token = _resolve_config()
         assert (host, port, token) == ("127.0.0.1", 4243, "lease-token")
@@ -251,14 +251,14 @@ class TestCatalogClientResolution:
     def test_catalog_env_halves_override_individually(self, monkeypatch):
         monkeypatch.setenv("NX_SERVICE_PORT", "9999")
         _publish_lease(port=4243, token="lease-token")
-        from nexus.catalog.http_catalog_client import _resolve_config
+        from nexus.db.service_endpoint import resolve_service_config as _resolve_config
 
         host, port, token = _resolve_config()
         assert port == 9999          # env wins
         assert token == "lease-token"  # lease fills the missing half
 
     def test_catalog_fail_loud_when_neither(self):
-        from nexus.catalog.http_catalog_client import _resolve_config
+        from nexus.db.service_endpoint import resolve_service_config as _resolve_config
 
         with pytest.raises(RuntimeError) as exc_info:
             _resolve_config()

--- a/tests/db/test_shared_service_endpoint.py
+++ b/tests/db/test_shared_service_endpoint.py
@@ -96,6 +96,48 @@ class TestResolveServiceEndpoint:
         assert token == "lease-tok"
 
 
+class TestSchemeAwareEndpoint:
+    """RDR-166 nexus-n3bwh — a managed ``https://…:443`` endpoint must survive.
+
+    ``resolve_service_endpoint`` is the ONE base-url authority the T2 stores,
+    the catalog client, and the migration pre-gate build their URLs from. When
+    ``NX_SERVICE_URL`` names a managed TLS endpoint it MUST be honoured verbatim
+    (scheme + host + port), not flattened to ``http://host:port`` — the old
+    behaviour turned ``https://api.conexus-nexus.com:443`` into
+    ``http://…:443`` and broke every managed-TLS migration leg before the data
+    path (already https-capable) ever ran.
+    """
+
+    def test_service_url_https_used_verbatim(self, monkeypatch):
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "managed-tok")
+        assert resolve_service_endpoint() == (
+            "https://api.conexus-nexus.com:443",
+            "managed-tok",
+        )
+
+    def test_service_url_trailing_slash_stripped(self, monkeypatch):
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443/")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "managed-tok")
+        base_url, _ = resolve_service_endpoint()
+        assert base_url == "https://api.conexus-nexus.com:443"
+
+    def test_service_url_token_falls_back_to_lease(self, monkeypatch):
+        # URL from env, token from the lease — each half independent.
+        _publish_lease(port=4242, token="lease-token")
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        base_url, token = resolve_service_endpoint()
+        assert base_url == "https://api.conexus-nexus.com:443"
+        assert token == "lease-token"
+
+    def test_no_service_url_preserves_http_from_env(self, monkeypatch):
+        # Regression: the local supervisor path is unchanged (http).
+        monkeypatch.setenv("NX_SERVICE_HOST", "127.0.0.1")
+        monkeypatch.setenv("NX_SERVICE_PORT", "8123")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "tok")
+        assert resolve_service_endpoint() == ("http://127.0.0.1:8123", "tok")
+
+
 class TestDiscoverLease:
     def test_absent_lease_returns_none(self):
         assert discover_lease() == (None, None)

--- a/tests/db/test_shared_service_endpoint.py
+++ b/tests/db/test_shared_service_endpoint.py
@@ -45,7 +45,7 @@ def _publish_lease(*, host: str = "127.0.0.1", port: int, token: str) -> None:
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
-    for k in ("NX_SERVICE_HOST", "NX_SERVICE_PORT", "NX_SERVICE_TOKEN"):
+    for k in ("NX_SERVICE_HOST", "NX_SERVICE_PORT", "NX_SERVICE_TOKEN", "NX_SERVICE_URL"):
         monkeypatch.delenv(k, raising=False)
     yield
 
@@ -136,6 +136,51 @@ class TestSchemeAwareEndpoint:
         monkeypatch.setenv("NX_SERVICE_PORT", "8123")
         monkeypatch.setenv("NX_SERVICE_TOKEN", "tok")
         assert resolve_service_endpoint() == ("http://127.0.0.1:8123", "tok")
+
+    def test_service_url_wins_over_host_port(self, monkeypatch):
+        # All three set: NX_SERVICE_URL is the authoritative full endpoint and
+        # takes precedence over NX_SERVICE_HOST/PORT (review M2).
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        monkeypatch.setenv("NX_SERVICE_HOST", "127.0.0.1")
+        monkeypatch.setenv("NX_SERVICE_PORT", "8123")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "managed-tok")
+        assert resolve_service_endpoint() == (
+            "https://api.conexus-nexus.com:443",
+            "managed-tok",
+        )
+
+    def test_service_url_set_but_no_token_fails_loud(self, monkeypatch):
+        # NX_SERVICE_URL with no token (env or lease) → RuntimeError, not a
+        # silent token-less request.
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        with pytest.raises(RuntimeError, match="no NX_SERVICE_TOKEN"):
+            resolve_service_endpoint()
+
+
+class TestRecoverEndpointFromLease:
+    """nexus-n3bwh review H1 — lease recovery must never override an explicitly
+    pinned NX_SERVICE_URL with a discovered (always-local-http) lease."""
+
+    def test_pinned_service_url_is_never_rebound_to_lease(self, monkeypatch):
+        from nexus.db.service_endpoint import recover_endpoint_from_lease
+
+        _publish_lease(port=4242, token="lease-token")
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        # current endpoint is the managed https one; a local lease exists and
+        # would compare unequal — but the pin must suppress the rebind.
+        assert (
+            recover_endpoint_from_lease("https://api.conexus-nexus.com:443") is None
+        )
+
+    def test_lease_recovery_still_works_without_service_url(self):
+        from nexus.db.service_endpoint import recover_endpoint_from_lease
+
+        _publish_lease(port=4242, token="lease-token")
+        # No NX_SERVICE_URL: a stale current endpoint rebinds to the fresh lease.
+        assert recover_endpoint_from_lease("http://127.0.0.1:9999") == (
+            "http://127.0.0.1:4242",
+            "lease-token",
+        )
 
 
 class TestDiscoverLease:

--- a/tests/migration/test_detection.py
+++ b/tests/migration/test_detection.py
@@ -45,6 +45,7 @@ from nexus.migration.detection import (
     classify_collections,
     classify_model_support,
     cross_model_remappable,
+    render_cost_confirmation,
     render_dry_run_preview,
     voyage_key_available,
     wired_models,
@@ -511,6 +512,77 @@ class TestDryRunPreview:
         assert "[local]" in text
         assert "[cloud]" in text
         assert "rough estimate" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Voyage re-embed COST estimate (nexus-cewad / RDR-166 Gap 4) — only the
+# cross-model→voyage re-embed is billed to the operator key. Byte-for-byte
+# voyage copies (embeddings already exist) and ONNX/bge local re-embeds are
+# NOT billed.
+# ---------------------------------------------------------------------------
+class TestVoyageCostEstimate:
+    def test_onnx_only_is_free(self) -> None:
+        # bge-768 local re-embed runs on the local ONNX runtime — no Voyage bill.
+        local = _FakeChromaClient({BGE_768: 1000})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=False
+        )
+        preview = build_dry_run_preview(report)
+        assert preview.billed_voyage_tokens == 0
+        assert preview.est_voyage_cost_usd == 0.0
+
+    def test_byte_for_byte_voyage_copy_is_not_billed(self) -> None:
+        # A collection ALREADY on a wired voyage model is migrated by copying its
+        # stored embeddings — no re-embed, no Voyage API call, no bill.
+        cloud = _FakeChromaClient({VOYAGE_CTX_1024: 500})
+        report = classify_collections(
+            local_client=None, cloud_client=cloud, voyage_key_present=True
+        )
+        preview = build_dry_run_preview(report)
+        assert preview.billed_voyage_tokens == 0
+        assert preview.est_voyage_cost_usd == 0.0
+
+    def test_cross_model_to_voyage_is_billed_and_scales(self) -> None:
+        # minilm-384 in cloud mode → voyage-context-3 re-embed → BILLED.
+        local = _FakeChromaClient({ONNX_384: 1000})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=True
+        )
+        preview = build_dry_run_preview(report)
+        # 1000 chunks x 512 tokens/chunk, all voyage-targeted.
+        assert preview.billed_voyage_tokens == 1000 * 512
+        # 512_000 tokens x $0.12 / 1_000_000 = $0.06144 (exact constant rate).
+        assert preview.est_voyage_cost_usd == pytest.approx(512_000 / 1_000_000 * 0.12)
+
+    def test_only_voyage_targeted_tokens_are_billed_in_mixed_footprint(self) -> None:
+        # bge byte-for-byte (free) + minilm→voyage (billed): only the latter bills.
+        local = _FakeChromaClient({BGE_768: 9999, ONNX_384: 1000})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=True
+        )
+        preview = build_dry_run_preview(report)
+        assert preview.billed_voyage_tokens == 1000 * 512  # bge excluded
+        assert preview.est_voyage_cost_usd == pytest.approx(512_000 / 1_000_000 * 0.12)
+
+    def test_render_cost_confirmation_none_when_free(self) -> None:
+        local = _FakeChromaClient({BGE_768: 10})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=False
+        )
+        assert render_cost_confirmation(build_dry_run_preview(report)) is None
+
+    def test_render_cost_confirmation_surfaces_cost_and_rerun_footgun(self) -> None:
+        local = _FakeChromaClient({ONNX_384: 1000})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=True
+        )
+        text = render_cost_confirmation(build_dry_run_preview(report))
+        assert text is not None
+        assert "$" in text
+        assert "512,000" in text or "512000" in text  # the billed token volume
+        # the re-run-at-full-cost foot-gun (nexus-1sx01) must be stated.
+        assert "re-run" in text.lower() or "again" in text.lower()
+        assert "operator" in text.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/migration/test_detection.py
+++ b/tests/migration/test_detection.py
@@ -531,16 +531,17 @@ class TestVoyageCostEstimate:
         assert preview.billed_voyage_tokens == 0
         assert preview.est_voyage_cost_usd == 0.0
 
-    def test_byte_for_byte_voyage_copy_is_not_billed(self) -> None:
-        # A collection ALREADY on a wired voyage model is migrated by copying its
-        # stored embeddings — no re-embed, no Voyage API call, no bill.
+    def test_supported_voyage_collection_is_billed_server_side_reembed(self) -> None:
+        # Seam B discards stored vectors and re-embeds server-side, so a
+        # collection ALREADY on a voyage model is re-embedded with that same
+        # voyage model on migration → a billed Voyage API call, NOT a free copy.
         cloud = _FakeChromaClient({VOYAGE_CTX_1024: 500})
         report = classify_collections(
             local_client=None, cloud_client=cloud, voyage_key_present=True
         )
         preview = build_dry_run_preview(report)
-        assert preview.billed_voyage_tokens == 0
-        assert preview.est_voyage_cost_usd == 0.0
+        assert preview.billed_voyage_tokens == 500 * 512
+        assert preview.est_voyage_cost_usd == pytest.approx(500 * 512 / 1_000_000 * 0.12)
 
     def test_cross_model_to_voyage_is_billed_and_scales(self) -> None:
         # minilm-384 in cloud mode → voyage-context-3 re-embed → BILLED.
@@ -563,6 +564,25 @@ class TestVoyageCostEstimate:
         preview = build_dry_run_preview(report)
         assert preview.billed_voyage_tokens == 1000 * 512  # bge excluded
         assert preview.est_voyage_cost_usd == pytest.approx(512_000 / 1_000_000 * 0.12)
+
+    def test_dry_run_render_surfaces_voyage_cost(self) -> None:
+        # The --dry-run pre-flight (render_dry_run_preview) must show the billed
+        # cost, not only the live-run confirm path (code-review H1).
+        local = _FakeChromaClient({ONNX_384: 1000})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=True
+        )
+        text = render_dry_run_preview(build_dry_run_preview(report))
+        assert "Voyage re-embed cost" in text
+        assert "512,000" in text
+
+    def test_dry_run_render_omits_cost_when_free(self) -> None:
+        local = _FakeChromaClient({BGE_768: 10})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=False
+        )
+        text = render_dry_run_preview(build_dry_run_preview(report))
+        assert "Voyage re-embed cost" not in text
 
     def test_render_cost_confirmation_none_when_free(self) -> None:
         local = _FakeChromaClient({BGE_768: 10})
@@ -782,6 +802,12 @@ class TestMigrateToServiceRun:
             factory, "make_catalog_client_for_migration", lambda **k: object()
         )
         monkeypatch.setattr(driver, "run_guided_upgrade", _fake_run_guided_upgrade)
+        # Isolate the cost-guardrail pre-flight from the real local Chroma store:
+        # these tests exercise result rendering, not the cost gate (covered in
+        # test_migrate_cost_guardrail). A no-data classify → zero billed cost →
+        # no prompt, so --yes below is belt-and-suspenders.
+        monkeypatch.setattr(migrate_cmd, "open_read_legs", lambda p: (None, None))
+        monkeypatch.setattr(migrate_cmd, "_close_quietly", lambda c: None)
         if token is None:
             monkeypatch.delenv("NX_SERVICE_TOKEN", raising=False)
         else:
@@ -793,7 +819,9 @@ class TestMigrateToServiceRun:
         cat.write_text("")
         cli = CliRunner().invoke(
             migrate_cmd.migrate_to_service_cmd,
-            ["--db", str(db), "--catalog-db", str(cat)],
+            # --yes: these exercise post-confirm result rendering, not the cost
+            # gate (which has dedicated coverage in test_migrate_cost_guardrail).
+            ["--db", str(db), "--catalog-db", str(cat), "--yes"],
         )
         return cli, captured
 

--- a/tests/migration/test_detection.py
+++ b/tests/migration/test_detection.py
@@ -515,10 +515,10 @@ class TestDryRunPreview:
 
 
 # ---------------------------------------------------------------------------
-# Voyage re-embed COST estimate (nexus-cewad / RDR-166 Gap 4) — only the
-# cross-model→voyage re-embed is billed to the operator key. Byte-for-byte
-# voyage copies (embeddings already exist) and ONNX/bge local re-embeds are
-# NOT billed.
+# Voyage re-embed COST estimate (nexus-cewad / RDR-166 Gap 4) — billed whenever
+# the effective target embedder is a Voyage model: cross-model→voyage AND
+# supported-voyage-1024 (Seam B re-embeds server-side for every chunk, so a
+# same-model voyage migration is billed too). ONNX/bge local re-embeds are free.
 # ---------------------------------------------------------------------------
 class TestVoyageCostEstimate:
     def test_onnx_only_is_free(self) -> None:

--- a/tests/migration/test_pregate.py
+++ b/tests/migration/test_pregate.py
@@ -249,11 +249,11 @@ def test_all_supported_mixed_proceeds() -> None:
 def test_live_source_returns_none_when_service_unreachable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _boom() -> tuple[str, int, str]:
+    def _boom() -> tuple[str, str]:
         raise RuntimeError("no service lease")
 
     monkeypatch.setattr(
-        "nexus.db.service_endpoint.resolve_service_config", _boom
+        "nexus.db.service_endpoint.resolve_service_endpoint", _boom
     )
     assert LiveServiceWiredModels().wired_models() is None
 
@@ -262,14 +262,43 @@ def test_live_source_parses_version_handshake(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "nexus.db.service_endpoint.resolve_service_config",
-        lambda: ("127.0.0.1", 9999, "tok"),
+        "nexus.db.service_endpoint.resolve_service_endpoint",
+        lambda: ("http://127.0.0.1:9999", "tok"),
     )
     monkeypatch.setattr(
         "nexus.daemon.binary_lifecycle.fetch_service_version",
-        lambda host, port: {"embedding_mode": "cloud", "embedding_models": [_ONNX, _VOYAGE]},
+        lambda host, port, scheme="http": {
+            "embedding_mode": "cloud",
+            "embedding_models": [_ONNX, _VOYAGE],
+        },
     )
     assert LiveServiceWiredModels().wired_models() == frozenset({_ONNX, _VOYAGE})
+
+
+def test_live_source_handshake_over_https_managed_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """nexus-n3bwh — a managed https endpoint must hand off scheme=https,
+    host, and the explicit :443 port to the version handshake (not http)."""
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(
+        "nexus.db.service_endpoint.resolve_service_endpoint",
+        lambda: ("https://api.conexus-nexus.com:443", "managed-tok"),
+    )
+
+    def _fetch(host, port, scheme="http"):
+        seen.update(host=host, port=port, scheme=scheme)
+        return {"embedding_mode": "cloud", "embedding_models": [_ONNX, _VOYAGE]}
+
+    monkeypatch.setattr(
+        "nexus.daemon.binary_lifecycle.fetch_service_version", _fetch
+    )
+    assert LiveServiceWiredModels().wired_models() == frozenset({_ONNX, _VOYAGE})
+    assert seen == {
+        "host": "api.conexus-nexus.com",
+        "port": 443,
+        "scheme": "https",
+    }
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What

RDR-166 Gap 4 / Open Question 5. A managed migration re-embeds chunks through Voyage server-side, billed to the operator's Voyage key — with no warning, and a re-run re-bills at full cost. This adds an estimate-and-confirm guardrail.

## How

- `build_dry_run_preview` computes `billed_voyage_tokens` + a coarse `est_voyage_cost_usd`. **Billed set** = every group whose effective target embedder is a Voyage model: cross-model→voyage **and** supported-voyage-1024 (Seam B discards stored vectors and re-embeds server-side for *every* chunk, so a same-model voyage migration is billed too). Supported-onnx/bge re-embeds run locally → free.
- `_run_migration` runs a read-only classify pre-flight and gates the billed `run_guided_upgrade` behind a confirm prompt surfacing the cost + the re-run-at-full-cost foot-gun (nexus-1sx01). `--yes/-y` skips it for scripted runs; a free migration is never prompted; a non-interactive stream without `--yes` aborts.
- The cost is also surfaced on `--dry-run` (the natural pre-flight).

**Honest scope**: this WARNS and CONFIRMS; it does not deduplicate or avoid re-billing a repeat run (copy-not-move has no server-side cost memory).

## Stacked review (d977b)
- **substantive-critic** caught a **Critical**: the initial cost basis treated supported-voyage-1024 as a free byte-for-byte copy. Verified false against Seam B (`iter_collection_chunks` fetches only documents/metadatas; `upsert_chunks` re-embeds server-side) and corrected — those collections are billed. Re-review: Critical resolved, follow-up stale-docstring Significants fixed.
- **code-review-expert** H1 (dry-run didn't show cost) fixed; billing condition, gate-precedes-billed-call, and non-tty abort confirmed correct.

## Tests
`tests/commands/test_migrate_cost_guardrail.py` (gate proceeds/aborts/--yes/free) + `TestVoyageCostEstimate` / dry-run-render tests in `test_detection.py`, exact assertions scaling with chunk count. 365 migration+command tests green; mode-lint green.

## Closes
Closes #nexus-cewad