### PR TITLE
feat(RDR-166): managed-service consumer journeys — TLS + cost guardrail + passthrough + greenfield onboarding

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1241,6 +1241,16 @@ nx config init
 |------|-------------|
 | `--show` | Reveal the full value instead of masking |
 
+**Managed-service credentials** (RDR-166 greenfield onboarding):
+
+| Key | Env var | Purpose |
+|-----|---------|---------|
+| `service_url` | `NX_SERVICE_URL` | Managed endpoint base URL (e.g. `https://api.conexus-nexus.com`) |
+| `service_token` | `NX_SERVICE_TOKEN` | Per-tenant bearer token (operator-provisioned) |
+
+Resolution is env first, then `config.yml`, for both. See
+[managed-onboarding.md](managed-onboarding.md) for the full greenfield journey.
+
 ---
 
 ## nx doc

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,6 +149,14 @@ See [docs/container-integration.md](https://github.com/Hellblazer/nexus/blob/mai
 service from a container, and [docs/migration-runbook.md](https://github.com/Hellblazer/nexus/blob/main/docs/migration-runbook.md) for the
 migration details.
 
+### Using the hosted managed service (no local stack)
+
+Prefer not to run the service stack yourself? Point `nx` at the hosted Conexus
+managed service with an operator-provisioned URL + token — no local service, no
+migration. See [docs/managed-onboarding.md](https://github.com/Hellblazer/nexus/blob/main/docs/managed-onboarding.md)
+for the greenfield journey (`nx config set service_url/service_token` → probe →
+first store/search).
+
 ## Update
 
 ```bash

--- a/docs/managed-onboarding.md
+++ b/docs/managed-onboarding.md
@@ -1,0 +1,87 @@
+# Managed-service onboarding (greenfield)
+
+This is the no-prior-install path: point `nx` at the hosted Conexus managed
+service and reach a working search/store state with **no local service stack and
+no migration**. (Already running a local Chroma install you want to move to the
+managed service? That is the migration path, `nx migrate-to-service` — see
+[migration-runbook.md](migration-runbook.md), not this page.)
+
+The managed service is operator-provisioned: you receive a base URL and a
+per-tenant bearer token out of band (the Conexus operator issues them; `nx` does
+not self-serve signup or mint tokens). `nx` is purely a consumer of that pair.
+
+## 1. Configure the endpoint + token
+
+Two equivalent surfaces; `nx config` persists across shells, env vars are
+per-shell and win when both are set.
+
+```bash
+# Persistent (written to ~/.config/nexus/config.yml, mode 0600):
+nx config set service_url   https://api.conexus-nexus.com
+nx config set service_token <your-bearer-token>
+
+# …or per-shell environment (takes precedence over config.yml):
+export NX_SERVICE_URL=https://api.conexus-nexus.com
+export NX_SERVICE_TOKEN=<your-bearer-token>
+```
+
+Resolution order is **env first, then `config.yml`** for both values, so an
+exported `NX_SERVICE_URL` overrides a persisted one. The token is sent as
+`Authorization: Bearer <token>`; treat it as a secret.
+
+Tell `nx` to use the service backend:
+
+```bash
+export NX_STORAGE_BACKEND=service
+```
+
+> The storage-backend selector is env-only today (`config.yml` persistence for
+> it is a tracked follow-up); the endpoint + token above persist via `nx config`.
+> Put the `export` in your shell profile, or run with it set, until that lands.
+
+## 2. Verify the endpoint (fail-loud capability probe)
+
+```bash
+nx doctor          # includes the managed-service probe when service_url is set
+```
+
+The probe runs **only** when a managed endpoint is configured (it never
+default-probes the public endpoint). It hits the unauthenticated `/version`
+handshake and fails loud on:
+
+- **unreachable** (connect / TLS / DNS / timeout) — check `service_url` and connectivity;
+- **incompatible** (non-200, or an `app_version` below the supported floor) — the
+  endpoint may not be a Conexus managed service, or it is unhealthy.
+
+A healthy probe confirms the URL, the TLS path, and that the service version is
+compatible before you write anything. (The `/version` route is unauthenticated
+by contract, so the probe works before the token is accepted; an **invalid or
+expired token** surfaces at the first authenticated call as an actionable
+`HTTP 401`.)
+
+## 3. First store + search
+
+With a healthy probe you are ready. There is no local index to build and no
+migration to run:
+
+```bash
+nx store "my first managed note" --collection knowledge__<owner>__voyage-context-3__v1
+nx search "first note"
+```
+
+Embeddings are computed server-side (the managed service is Voyage-mode), so no
+local embedder or API key is needed on your machine for search/store.
+
+## Token lifetime + rotation
+
+The bearer is opaque and does not expire on a timer; rotation is
+revoke-and-reissue, operator-side. If a call returns `HTTP 401`, re-fetch a
+fresh token from the operator and re-run `nx config set service_token` (or
+re-export `NX_SERVICE_TOKEN`).
+
+## Scope note
+
+One token maps to one tenant. `pgvector`-to-managed cross-deployment migration is
+a documented limitation, not part of this journey (tracker: nexus-wm3t5); this
+page covers greenfield managed onboarding and the Chroma-source migration path
+covers local-to-managed.

--- a/service/src/main/java/dev/nexus/service/http/VectorHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/VectorHandler.java
@@ -213,10 +213,25 @@ public final class VectorHandler implements HttpHandler {
         List<String> ids            = requireStringList(body, "ids");
         List<String> documents      = requireStringList(body, "documents");
         List<Map<String, Object>> metadatas = optMetadataList(body, "metadatas", ids.size());
+        List<float[]> embeddings = optEmbeddingsList(body, "embeddings");
 
         if (ids.size() != documents.size()) {
             throw new IllegalArgumentException(
                     "ids length " + ids.size() + " != documents length " + documents.size());
+        }
+
+        if (embeddings != null) {
+            // Same-model vector PASSTHROUGH (nexus-hxry2): store the supplied vectors
+            // verbatim, no embedder call (token usage 0). Dimension is validated
+            // against the dispatched table inside the repository (fail loud).
+            if (embeddings.size() != ids.size()) {
+                throw new IllegalArgumentException(
+                        "embeddings length " + embeddings.size() + " != ids length " + ids.size());
+            }
+            repo.upsertChunksWithVectors(tenant, collection, ids, documents, embeddings, metadatas);
+            emitTokenUsage(ex, 0L);
+            HttpUtil.send(ex, 200, json(Map.of("upserted", ids.size(), "tokens", 0)));
+            return;
         }
 
         var upsertResult = repo.upsertChunksWithTokens(tenant, collection, ids, documents, metadatas);
@@ -720,6 +735,37 @@ public final class VectorHandler implements HttpHandler {
         if (!(val instanceof List<?> list)) return null;
         List<String> result = new ArrayList<>(list.size());
         for (Object item : list) result.add(item == null ? "" : item.toString());
+        return result;
+    }
+
+    /**
+     * Optional {@code embeddings} field: a list of numeric vectors (one per id),
+     * for the same-model vector-passthrough path (nexus-hxry2). Returns null when
+     * absent (the default server-side-embed path). Malformed shapes fail loud —
+     * a claimed passthrough that cannot be parsed must NOT silently fall back to
+     * re-embed (that would mask a client bug and re-bill).
+     */
+    private List<float[]> optEmbeddingsList(Map<String, Object> body, String key) {
+        Object val = body.get(key);
+        if (val == null) return null;
+        if (!(val instanceof List<?> rows)) {
+            throw new IllegalArgumentException("field '" + key + "' must be an array of vectors");
+        }
+        List<float[]> result = new ArrayList<>(rows.size());
+        for (Object row : rows) {
+            if (!(row instanceof List<?> nums)) {
+                throw new IllegalArgumentException("field '" + key + "' must be an array of numeric vectors");
+            }
+            float[] vec = new float[nums.size()];
+            for (int i = 0; i < nums.size(); i++) {
+                Object n = nums.get(i);
+                if (!(n instanceof Number num)) {
+                    throw new IllegalArgumentException("field '" + key + "' contains a non-numeric component");
+                }
+                vec[i] = num.floatValue();
+            }
+            result.add(vec);
+        }
         return result;
     }
 

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -226,7 +226,7 @@ public final class PgVectorRepository {
                                                     List<String> documents,
                                                     List<Map<String, Object>> metadatas) {
         long[] tokensOut = {0L};
-        upsertChunksInternal(tenant, collection, ids, documents, metadatas, tokensOut);
+        upsertChunksInternal(tenant, collection, ids, documents, metadatas, tokensOut, null);
         return new Tokened<>(ids.size(), tokensOut[0]);
     }
 
@@ -235,14 +235,42 @@ public final class PgVectorRepository {
                              List<String> ids,
                              List<String> documents,
                              List<Map<String, Object>> metadatas) {
-        upsertChunksInternal(tenant, collection, ids, documents, metadatas, null);
+        upsertChunksInternal(tenant, collection, ids, documents, metadatas, null, null);
+    }
+
+    /**
+     * Same-model vector PASSTHROUGH (nexus-hxry2, RDR-166): store caller-supplied
+     * embeddings VERBATIM, skipping the server-side embedder.
+     *
+     * <p>The migration uses this when the source collection's embedding model
+     * equals the target's wired model: the stored Chroma vectors were produced by
+     * exactly the model the target collection is searched against, so re-embedding
+     * would only re-bill the operator's Voyage key for identical vectors. Each
+     * vector's dimension MUST match the dispatched {@code chunks_<dim>} table — a
+     * mismatch fails loud (the contamination guard; never a silent embed fallback).
+     * No embedder is invoked, so the token count is always 0.
+     *
+     * @param embeddings one vector per id (length must equal {@code ids})
+     */
+    public void upsertChunksWithVectors(String tenant, String collection,
+                                        List<String> ids,
+                                        List<String> documents,
+                                        List<float[]> embeddings,
+                                        List<Map<String, Object>> metadatas) {
+        if (embeddings == null || embeddings.size() != ids.size()) {
+            throw new IllegalArgumentException(
+                "upsertChunksWithVectors requires one embedding per id: ids="
+                + ids.size() + " embeddings=" + (embeddings == null ? "null" : embeddings.size()));
+        }
+        upsertChunksInternal(tenant, collection, ids, documents, metadatas, null, embeddings);
     }
 
     private void upsertChunksInternal(String tenant, String collection,
                                       List<String> ids,
                                       List<String> documents,
                                       List<Map<String, Object>> metadatas,
-                                      long[] tokensOut) {
+                                      long[] tokensOut,
+                                      List<float[]> providedEmbeddings) {
         if (ids.isEmpty()) return;
         int dim = dimForCollection(collection);
 
@@ -259,6 +287,7 @@ public final class PgVectorRepository {
         List<String> dedupIds  = new ArrayList<>();
         List<String> dedupDocs = new ArrayList<>();
         List<Map<String, Object>> dedupMetas = new ArrayList<>();
+        List<float[]> dedupProvided = providedEmbeddings != null ? new ArrayList<>() : null;
         List<String> nulSanitized = new ArrayList<>();
         Set<String> seen = new HashSet<>();
         for (int i = 0; i < ids.size(); i++) {
@@ -271,6 +300,7 @@ public final class PgVectorRepository {
                 dedupIds.add(ids.get(i));
                 dedupDocs.add(clean);
                 dedupMetas.add(sanitizeNulDeep(metadatas.get(i)));
+                if (dedupProvided != null) dedupProvided.add(providedEmbeddings.get(i));
             }
         }
         if (!nulSanitized.isEmpty()) {
@@ -283,19 +313,30 @@ public final class PgVectorRepository {
                     collection, ids.size(), dedupIds.size(), collapsed);
         }
 
-        // Server-side embed - collection-aware routing when wired with the router
-        // (production / Seam B path), identical to the Chroma VectorRepository flow.
-        // Uses *WithUsage variant to capture the token count (bead nexus-ehc4q);
-        // the count is surfaced to VectorHandler via the Tokened<T> return value of
-        // upsertChunksWithTokens (not a ThreadLocal side-channel).
-        EmbedResult embedResult = (docRouter != null)
-                ? docRouter.embedForCollectionWithUsage(collection, dedupDocs)
-                : docEmbedder.embedWithUsage(dedupDocs);
-        if (tokensOut != null) tokensOut[0] = embedResult.tokens();
-        List<float[]> embeddings = embedResult.embeddings();
+        // Embeddings: either caller-supplied (same-model PASSTHROUGH, nexus-hxry2)
+        // or computed server-side (the default Seam B path). When the caller
+        // supplies vectors we skip the embedder entirely — no Voyage call, token
+        // count stays 0 — because the source model equals the target's wired model
+        // (validated client-side) and re-embedding would re-bill for identical
+        // vectors. Collection-aware routing when wired with the router (production /
+        // Seam B path), identical to the Chroma VectorRepository flow. Uses
+        // *WithUsage to capture the token count (bead nexus-ehc4q), surfaced to
+        // VectorHandler via the Tokened<T> return value (not a ThreadLocal).
+        List<float[]> embeddings;
+        if (dedupProvided != null) {
+            embeddings = dedupProvided;  // passthrough — no embed, tokensOut stays 0
+        } else {
+            EmbedResult embedResult = (docRouter != null)
+                    ? docRouter.embedForCollectionWithUsage(collection, dedupDocs)
+                    : docEmbedder.embedWithUsage(dedupDocs);
+            if (tokensOut != null) tokensOut[0] = embedResult.tokens();
+            embeddings = embedResult.embeddings();
+        }
 
-        // Fail loud BEFORE any SQL if the embedder's output does not match the
-        // dispatched table dimension (no truncation, no padding).
+        // Fail loud BEFORE any SQL if a vector's dimension does not match the
+        // dispatched table dimension (no truncation, no padding). For the
+        // passthrough path this is ALSO the contamination guard: a supplied vector
+        // whose dim disagrees with the target table is rejected, never stored.
         for (float[] vec : embeddings) {
             if (vec.length != dim) {
                 throw new IllegalArgumentException(

--- a/service/src/test/java/dev/nexus/service/PgVectorRepositoryContractTest.java
+++ b/service/src/test/java/dev/nexus/service/PgVectorRepositoryContractTest.java
@@ -223,6 +223,56 @@ class PgVectorRepositoryContractTest {
         assertThat(superuserCount(384,  col)).as("nothing in chunks_384").isEqualTo(0L);
     }
 
+    // ---------------------------------------------------------------------------
+    // Contract: same-model vector PASSTHROUGH (nexus-hxry2) — supplied vectors are
+    // stored verbatim, the embedder is NOT invoked, and a dim mismatch fails loud.
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void upsertChunksWithVectors_storesSuppliedVectorsVerbatim_skipsEmbedder() throws Exception {
+        String col = COL_CTX_1024;
+        String chash = "ptvc1024c10000000000000000000000";
+        // A distinctive vector the FakeEmbedder would never produce (its default
+        // is [1,0,...]); proves the stored vector is the SUPPLIED one, not embedded.
+        float[] supplied = new float[1024];
+        supplied[0] = 0.25f;
+        supplied[1] = 0.75f;
+
+        repo1024.upsertChunksWithVectors(TENANT_A, col,
+            List.of(chash), List.of("passthrough text"),
+            List.of(supplied), List.of(Map.of("kind", "pt")));
+
+        assertThat(superuserCount(1024, col)).as("row landed in chunks_1024").isEqualTo(1L);
+        String stored = superuserChunkEmbedding(1024, col, chash);
+        assertThat(stored)
+            .as("the SUPPLIED vector is stored verbatim, not the embedder's [1,0,...] default")
+            .startsWith("[0.25,0.75,");
+    }
+
+    @Test
+    void upsertChunksWithVectors_dimMismatch_failsLoud() {
+        String col = COL_CTX_1024;  // dispatches to chunks_1024
+        float[] wrongDim = new float[768];  // a 768-dim vector for a 1024 collection
+        wrongDim[0] = 1.0f;
+        // The contamination guard: a supplied vector whose dim disagrees with the
+        // target table is rejected before any SQL — never silently stored or embedded.
+        assertThatThrownBy(() -> repo1024.upsertChunksWithVectors(TENANT_A, col,
+            List.of("ptbaddim10240000000000000000000000"), List.of("bad dim text"),
+            List.of(wrongDim), List.of(Map.of())))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void upsertChunksWithVectors_lengthMismatch_failsLoud() {
+        String col = COL_CTX_1024;
+        float[] one = new float[1024];
+        // Two ids, one embedding → fail loud (never misalign vectors to ids).
+        assertThatThrownBy(() -> repo1024.upsertChunksWithVectors(TENANT_A, col,
+            List.of("ptlen1id1000000000000000000000000", "ptlen1id2000000000000000000000000"),
+            List.of("t1", "t2"), List.of(one), List.of(Map.of(), Map.of())))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
     @Test
     void upsert_voyage3_landsInChunks1024Only() throws Exception {
         String col = "knowledge__v3disp__voyage-3__v1";
@@ -1056,6 +1106,21 @@ class PgVectorRepositoryContractTest {
         try (Connection su = pg.createConnection("");
              PreparedStatement ps = su.prepareStatement(
                  "SELECT metadata::text FROM nexus.chunks_" + dim
+                 + " WHERE collection = ? AND chash = ?")) {
+            ps.setString(1, collection);
+            ps.setString(2, chash);
+            try (ResultSet rs = ps.executeQuery()) {
+                assertThat(rs.next()).as("row %s/%s must exist in chunks_%d", collection, chash, dim).isTrue();
+                return rs.getString(1);
+            }
+        }
+    }
+
+    /** Superuser fetch of one chunk's embedding as pgvector text (bypasses RLS). */
+    private String superuserChunkEmbedding(int dim, String collection, String chash) throws SQLException {
+        try (Connection su = pg.createConnection("");
+             PreparedStatement ps = su.prepareStatement(
+                 "SELECT embedding::text FROM nexus.chunks_" + dim
                  + " WHERE collection = ? AND chash = ?")) {
             ps.setString(1, collection);
             ps.setString(2, chash);

--- a/service/src/test/java/dev/nexus/service/VectorHandlerEmbeddingModeTest.java
+++ b/service/src/test/java/dev/nexus/service/VectorHandlerEmbeddingModeTest.java
@@ -159,6 +159,44 @@ class VectorHandlerEmbeddingModeTest {
     }
 
     @Test
+    void upsertChunks_withEmbeddings_passthroughStoresVerbatim_tokensZero() throws Exception {
+        // nexus-hxry2 HTTP-boundary contract: a Python client posting the
+        // `embeddings` field is the same-model passthrough — the service parses
+        // the JSON number vectors, stores them verbatim, and skips the embedder
+        // (tokens:0). Proves the Python→JSON→Java parse seam end-to-end. minilm-384
+        // wired here → a 384-dim supplied vector.
+        var vec = new java.util.ArrayList<Float>(384);
+        for (int i = 0; i < 384; i++) vec.add(0.0f);
+        vec.set(0, 0.25f);
+        vec.set(1, 0.75f);
+        var resp = post("/v1/vectors/upsert-chunks", Map.of(
+            "collection", "knowledge__pebfx2__minilm-l6-v2-384__v1",
+            "ids",        List.of("pthttp3840000000000000000000000a"),
+            "documents",  List.of("passthrough over http"),
+            "metadatas",  List.of(Map.of()),
+            "embeddings", List.of(vec)));
+        assertThat(resp.statusCode())
+            .as("passthrough upsert must succeed (body: %s)", resp.body())
+            .isEqualTo(200);
+        assertThat(resp.body()).contains("\"tokens\":0");
+    }
+
+    @Test
+    void upsertChunks_withEmbeddings_wrongDim_failsLoud() throws Exception {
+        // A supplied vector whose dim != the dispatched table (384) must fail
+        // loud at the HTTP boundary — never silently stored or re-embedded.
+        var resp = post("/v1/vectors/upsert-chunks", Map.of(
+            "collection", "knowledge__pebfx2__minilm-l6-v2-384__v1",
+            "ids",        List.of("ptbaddimhttp00000000000000000000"),
+            "documents",  List.of("bad dim over http"),
+            "metadatas",  List.of(Map.of()),
+            "embeddings", List.of(List.of(1.0f, 0.0f))));  // 2-dim, not 384
+        assertThat(resp.statusCode())
+            .as("dim mismatch must be a 4xx, not a silent 200 (body: %s)", resp.body())
+            .isIn(400, 422);
+    }
+
+    @Test
     void search_voyageCollectionInOnnxMode_is422() throws Exception {
         var resp = post("/v1/vectors/search", Map.of(
             "query",       "anything",

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -70,7 +70,7 @@ DEFAULT_TENANT: str = "default"
 
 # RDR-152 nexus-fjwxh: delegate to the centralized resolver (was an inline
 # copy of the env->lease->fail-loud logic now shared across all clients).
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 
 
 def _to_entry(d: dict) -> CatalogEntry:
@@ -138,8 +138,7 @@ class HttpCatalogClient:
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/commands/guided_upgrade_cmd.py
+++ b/src/nexus/commands/guided_upgrade_cmd.py
@@ -43,6 +43,16 @@ from nexus.migration.guided_upgrade import (
 
 _log = structlog.get_logger(__name__)
 
+
+def _resolve_service_token() -> str:
+    """The managed service token — env (NX_SERVICE_TOKEN) FIRST, then config.yml
+    (`nx config set service_token`), so a config.yml-only managed user is not
+    told to export what they already configured (RDR-166 nexus-v3p0x)."""
+    from nexus.config import get_credential
+
+    return get_credential("service_token") or ""
+
+
 #: Default health-gate deadline. Generous: a cold service (PG provision +
 #: supervisor spawn + migration apply) can take a while to answer /health.
 _DEFAULT_TIMEOUT_S = 120.0
@@ -204,15 +214,17 @@ def guided_upgrade_cmd(
                 err=True,
             )
             raise SystemExit(1)
-    elif not os.environ.get("NX_SERVICE_TOKEN", "").strip():
+    elif not (_resolve_service_token() or "").strip():
         # --service-url path: the external service's token is the user's to
         # supply. Gate here (not deep inside _run_migration's HTTP layer) so the
         # remedy is a guided-upgrade checkpoint, not an opaque auth error
-        # (substantive-critic Sig-2).
+        # (substantive-critic Sig-2). env FIRST, then config.yml — a config.yml-
+        # only managed user (RDR-166 nexus-v3p0x) is already configured.
         click.echo("", err=True)
         click.echo(
-            f"--service-url {service_url} requires NX_SERVICE_TOKEN to be set "
-            "(the managed service's bearer token) — export it and re-run.",
+            f"--service-url {service_url} requires a service token (the managed "
+            "service's bearer) — set it with `nx config set service_token` or "
+            "export NX_SERVICE_TOKEN, then re-run.",
             err=True,
         )
         raise SystemExit(1)

--- a/src/nexus/commands/migrate_cmd.py
+++ b/src/nexus/commands/migrate_cmd.py
@@ -35,11 +35,40 @@ from nexus.migration.detection import (
     build_dry_run_preview,
     classify_collections,
     open_read_legs,
+    render_cost_confirmation,
     render_dry_run_preview,
     voyage_key_available,
 )
 
 _log = structlog.get_logger(__name__)
+
+
+def _confirm_voyage_cost(
+    preview: Any,
+    *,
+    assume_yes: bool,
+    confirm: Any = None,
+) -> bool:
+    """Estimate-and-confirm gate for a billed Voyage re-embed (nexus-cewad).
+
+    Returns ``True`` when the caller may proceed with the billed migration,
+    ``False`` when the operator declined. A migration that bills nothing
+    proceeds silently; ``assume_yes`` proceeds without prompting (the scripted
+    / CI path). Otherwise the cost + re-run foot-gun is shown and an interactive
+    confirmation gates the call. ``confirm`` is injectable for tests; production
+    uses :func:`click.confirm` (which aborts on a non-interactive stream, so a
+    billed run without ``--yes`` never proceeds unattended).
+    """
+    warning = render_cost_confirmation(preview)
+    if warning is None:
+        return True  # nothing billed — no prompt
+    if assume_yes:
+        click.echo(warning)
+        click.echo("Proceeding (--yes): the operator's Voyage key will be billed.")
+        return True
+    click.echo(warning)
+    _confirm = confirm if confirm is not None else click.confirm
+    return bool(_confirm("Proceed with the billed re-embed?"))
 
 
 @click.command(name="migrate-to-service")
@@ -77,12 +106,22 @@ _log = structlog.get_logger(__name__)
     default=None,
     help="Override the nexus-service base URL (default: the supervisor lease).",
 )
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Skip the Voyage re-embed cost confirmation (scripted / non-interactive "
+    "runs). The operator's Voyage key is billed without a prompt.",
+)
 def migrate_to_service_cmd(
     dry_run: bool,
     local_path: str | None,
     db_path: str | None,
     catalog_db_path: str | None,
     service_url: str | None,
+    assume_yes: bool,
 ) -> None:
     """Guided Chroma-to-service upgrade migration (RDR-159).
 
@@ -92,7 +131,9 @@ def migrate_to_service_cmd(
     if dry_run:
         _run_dry_run(local_path)
         return
-    _run_migration(local_path, db_path, catalog_db_path, service_url)
+    _run_migration(
+        local_path, db_path, catalog_db_path, service_url, assume_yes=assume_yes
+    )
 
 
 def _run_dry_run(local_path: str | None) -> None:
@@ -120,6 +161,8 @@ def _run_migration(
     db_path: str | None,
     catalog_db_path: str | None,
     service_url: str | None,
+    *,
+    assume_yes: bool = False,
 ) -> None:
     """Drive the full guided migration through the nexus engine.
 
@@ -164,6 +207,25 @@ def _run_migration(
             "catalog ETL + manifest validation call the service).\n"
             "Set it to the bearer token configured in the nexus-service."
         )
+
+    # COST GUARDRAIL (nexus-cewad) — a cross-model→voyage re-embed is billed to
+    # the operator's Voyage key. Estimate it from a read-only classify pass and
+    # gate the billed run behind an explicit confirmation. A migration that
+    # bills nothing (byte-for-byte copy / local ONNX re-embed) proceeds silently.
+    local_read, cloud_read = open_read_legs(local_path)
+    try:
+        cost_preview = build_dry_run_preview(
+            classify_collections(
+                local_client=local_read,
+                cloud_client=cloud_read,
+                voyage_key_present=voyage_key_available(),
+            )
+        )
+    finally:
+        for client in (local_read, cloud_read):
+            _close_quietly(client)
+    if not _confirm_voyage_cost(cost_preview, assume_yes=assume_yes):
+        raise click.Abort()
 
     from nexus.catalog.factory import make_catalog_client_for_migration
 

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -325,6 +325,13 @@ CREDENTIALS: dict[str, str] = {
     "chroma_database":   "CHROMA_DATABASE",
     "voyage_api_key":    "VOYAGE_API_KEY",
     "migrated":          "NX_MIGRATED",
+    # RDR-166 managed onboarding (nexus-v3p0x): the operator-provisioned managed
+    # endpoint + bearer. `nx config set service_url/service_token` persists them
+    # to config.yml; the service resolvers consume them via get_credential, so
+    # the env var still wins and config.yml is the durable fallback — the single
+    # consume point the conexus issuance contract targets.
+    "service_url":       "NX_SERVICE_URL",
+    "service_token":     "NX_SERVICE_TOKEN",
 }
 
 

--- a/src/nexus/daemon/binary_lifecycle.py
+++ b/src/nexus/daemon/binary_lifecycle.py
@@ -70,14 +70,27 @@ def read_installed_provenance(config_dir: Path) -> dict | None:
         return None
 
 
-def fetch_service_version(host: str, port: int, timeout: float = 3.0) -> dict | None:
+def fetch_service_version(
+    host: str,
+    port: int | None,
+    timeout: float = 3.0,
+    *,
+    scheme: str = "http",
+) -> dict | None:
     """GET the running service's /version handshake, or ``None`` when
-    unreachable (older service without the endpoint, service down)."""
+    unreachable (older service without the endpoint, service down).
+
+    ``scheme`` defaults to ``http`` (the local-supervisor path). A managed TLS
+    endpoint passes ``scheme="https"`` so the pre-gate handshake reaches the
+    service instead of failing the TLS negotiation (nexus-n3bwh). ``port`` may
+    be ``None`` (scheme-default port, e.g. an ``https://host`` URL with no
+    explicit ``:443``), in which case it is omitted from the authority."""
     import urllib.request
 
+    authority = f"{host}:{port}" if port is not None else host
     try:
         with urllib.request.urlopen(
-            f"http://{host}:{port}/version", timeout=timeout,
+            f"{scheme}://{authority}/version", timeout=timeout,
         ) as resp:
             data = json.loads(resp.read())
             return data if isinstance(data, dict) else None

--- a/src/nexus/db/http_scratch_store.py
+++ b/src/nexus/db/http_scratch_store.py
@@ -66,7 +66,7 @@ _HEADER_T1_SESSION: str = "X-Nexus-T1-Session"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 
 
 # ── HttpScratchStore ───────────────────────────────────────────────────────────
@@ -107,8 +107,7 @@ class HttpScratchStore:
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -105,13 +105,15 @@ def _resolve_endpoint() -> tuple[str, str]:
             lease_url, lease_token = _lease_cache or (None, None)
         url = url or lease_url
         token = token or lease_token
+        # "credential" = env-or-config.yml (get_credential precedence); the
+        # source here is "configured" vs "lease", not specifically env.
         if env_url is not None and token is lease_token and token is not None:
             _log.debug(
-                "vector_endpoint_mixed_source", url_source="env", token_source="lease"
+                "vector_endpoint_mixed_source", url_source="credential", token_source="lease"
             )
         elif env_token is not None and url is lease_url and url is not None:
             _log.debug(
-                "vector_endpoint_mixed_source", url_source="lease", token_source="env"
+                "vector_endpoint_mixed_source", url_source="lease", token_source="credential"
             )
     if url is None or token is None:
         raise RuntimeError(
@@ -119,7 +121,8 @@ def _resolve_endpoint() -> tuple[str, str]:
             "routes through the nexus-service HTTP API (RDR-155 Phase 4a — "
             "the direct Chroma serving paths are retired). Either start the "
             "supervisor with 'nx daemon service start' (publishes the "
-            "endpoint lease this client auto-discovers), or export "
+            "endpoint lease this client auto-discovers), set the managed "
+            "endpoint with 'nx config set service_url/service_token', or export "
             "NX_SERVICE_URL / NX_SERVICE_TOKEN explicitly."
         )
     return url, token
@@ -238,7 +241,12 @@ def _managed_remedy() -> str | None:
     — callers that classify transient failures by raw type should catch
     ``VectorServiceError`` for the managed path. Local callers are unaffected.
     """
-    base = os.environ.get("NX_SERVICE_URL", "").strip()
+    from nexus.config import get_credential
+
+    # env FIRST, then config.yml — so a config.yml-only greenfield user gets the
+    # actionable managed remedy on a 401/connection error, not a bare error
+    # (RDR-166 nexus-v3p0x).
+    base = (get_credential("service_url") or "").strip()
     if not base:
         return None
     return (

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -84,8 +84,14 @@ def _discover_lease() -> tuple[str | None, str | None]:
 def _resolve_endpoint() -> tuple[str, str]:
     """Return ``(base_url, token)`` per the resolution order above."""
     global _lease_cache
-    env_url = os.environ.get("NX_SERVICE_URL", "").strip().rstrip("/") or None
-    env_token = os.environ.get("NX_SERVICE_TOKEN", "").strip() or None
+    # env FIRST, then the persisted config.yml credential (RDR-166 nexus-v3p0x:
+    # a greenfield managed user who ran `nx config set service_url/service_token`
+    # must reach a resolvable endpoint with no env exported). get_credential
+    # encodes env>config.yml precedence, so an exported env var still wins.
+    from nexus.config import get_credential
+
+    env_url = (get_credential("service_url") or "").strip().rstrip("/") or None
+    env_token = (get_credential("service_token") or "").strip() or None
     url, token = env_url, env_token
     if url is None or token is None:
         with _endpoint_lock:

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -473,8 +473,14 @@ class HttpVectorClient:
         """Embed + quota-check + write via the Java service.
 
         CHUNKING STAYS PYTHON — this method is called with pre-chunked text.
-        Embeddings are computed server-side; any ``embeddings`` argument is
-        ignored (Seam B contract).
+        Embeddings are computed server-side by default (Seam B). The ONE
+        exception is the same-model migration PASSTHROUGH (nexus-hxry2): when
+        ``embeddings`` is supplied, the vectors are sent and stored verbatim and
+        the server skips the (billed) re-embed — used only when the source
+        collection's model equals the target's wired model, so the vectors are
+        already correct. Every non-migration caller leaves ``embeddings`` None.
+        (Note: :meth:`upsert_chunks_with_embeddings` deliberately still DISCARDS
+        its vectors — indexers re-embed server-side as the single authority.)
 
         ``skip_existing`` (or env ``NX_UPSERT_SKIP_EXISTING=1``): pre-filter
         ids through :meth:`existing_ids` and embed/upsert only the chunks
@@ -507,12 +513,21 @@ class HttpVectorClient:
                 ids = [ids[i] for i in keep]
                 documents = [documents[i] for i in keep]
                 metadatas = [metas[i] for i in keep]
+                if embeddings is not None:
+                    embeddings = [embeddings[i] for i in keep]
         body: dict[str, Any] = {
             "collection": collection,
             "ids": ids,
             "documents": documents,
             "metadatas": metadatas or [{}] * len(ids),
         }
+        # Same-model vector PASSTHROUGH (nexus-hxry2): when the caller supplies
+        # precomputed vectors (source model == target wired model), send them so
+        # the service stores them verbatim and skips the billed re-embed. Absent →
+        # the default Seam B server-side embed. This is the ONE path where
+        # ``embeddings`` is honoured; every other caller leaves it None.
+        if embeddings is not None:
+            body["embeddings"] = embeddings
         _post("/v1/vectors/upsert-chunks", body, tenant=self._tenant, timeout=600)
         _log.debug(
             "http_vector_upsert_chunks",

--- a/src/nexus/db/managed_endpoint.py
+++ b/src/nexus/db/managed_endpoint.py
@@ -103,8 +103,13 @@ class ManagedCapabilities:
 def resolve_managed_endpoint(*, require_token: bool = True) -> tuple[str, str | None]:
     """Return ``(base_url, token)`` for the managed service.
 
-    ``base_url`` is ``NX_SERVICE_URL`` (trailing slash stripped) or
-    :data:`DEFAULT_MANAGED_SERVICE_URL`. ``token`` is ``NX_SERVICE_TOKEN``.
+    ``base_url`` is the resolved ``service_url`` (trailing slash stripped) or
+    :data:`DEFAULT_MANAGED_SERVICE_URL`. ``token`` is the resolved
+    ``service_token``. Both resolve via :func:`nexus.config.get_credential` —
+    env (``NX_SERVICE_URL`` / ``NX_SERVICE_TOKEN``) FIRST, then the persisted
+    ``config.yml`` credential a greenfield user set with ``nx config set``
+    (RDR-166 nexus-v3p0x). Without this the probe would ignore a config.yml-only
+    user's endpoint and silently target the default.
 
     Fails loud (:class:`ManagedServiceIncompatible`) when ``require_token`` and no
     token is configured — a cloud-mode client with no bearer cannot call any
@@ -112,8 +117,10 @@ def resolve_managed_endpoint(*, require_token: bool = True) -> tuple[str, str | 
     opaque 401 later. The unauthenticated ``/version`` probe itself does not need
     the token; ``require_token=False`` supports probe-only callers.
     """
-    base = os.environ.get("NX_SERVICE_URL", "").strip().rstrip("/") or DEFAULT_MANAGED_SERVICE_URL
-    token = os.environ.get("NX_SERVICE_TOKEN", "").strip() or None
+    from nexus.config import get_credential
+
+    base = (get_credential("service_url") or "").strip().rstrip("/") or DEFAULT_MANAGED_SERVICE_URL
+    token = (get_credential("service_token") or "").strip() or None
     if require_token and not token:
         raise ManagedServiceIncompatible(
             "cloud mode is configured but NX_SERVICE_TOKEN is not set — the "

--- a/src/nexus/db/service_endpoint.py
+++ b/src/nexus/db/service_endpoint.py
@@ -94,7 +94,9 @@ def recover_endpoint_from_lease(current_base_url: str) -> tuple[str, str | None]
     # https managed base_url would compare unequal to the http lease and rebind
     # every time, routing managed traffic to the wrong (local) service. Lease
     # recovery is for the lease-discovered path only.
-    if os.environ.get("NX_SERVICE_URL", "").strip():
+    from nexus.config import get_credential
+
+    if (get_credential("service_url") or "").strip():
         return None
     lease_url, lease_token = discover_lease()
     if lease_url is not None and lease_url.rstrip("/") != (current_base_url or "").rstrip("/"):
@@ -161,27 +163,33 @@ def resolve_service_endpoint() -> tuple[str, str]:
     here so a managed TLS endpoint survives end-to-end. Resolution order mirrors
     the T3 data path (:func:`nexus.db.http_vector_client._resolve_endpoint`):
 
-      1. ``NX_SERVICE_URL`` — the authoritative FULL endpoint, used VERBATIM
-         (scheme + host + port preserved). This is the ONLY scheme source:
-         ``https://api.conexus-nexus.com:443`` stays ``https``; flattening it to
-         ``http://…:443`` (the pre-RDR-166 bug, nexus-n3bwh) broke every managed
-         migration leg. The token half still falls back to lease/env independently.
+      1. ``service_url`` — the authoritative FULL endpoint, used VERBATIM
+         (scheme + host + port preserved). Resolved via
+         :func:`nexus.config.get_credential`, i.e. ``NX_SERVICE_URL`` env FIRST,
+         then the persisted ``config.yml`` credential a greenfield user set with
+         ``nx config set service_url`` (RDR-166 nexus-v3p0x). This is the ONLY
+         scheme source: ``https://api.conexus-nexus.com:443`` stays ``https``;
+         flattening it to ``http://…:443`` (the pre-RDR-166 bug, nexus-n3bwh)
+         broke every managed migration leg. The token half (``service_token``)
+         resolves the same way, then falls back to the lease independently.
       2. Otherwise ``http://{host}:{port}`` from :func:`resolve_service_config`
          (env halves → lease → fail loud) — the local-supervisor path, always
          ``http``.
     """
-    env_url = os.environ.get("NX_SERVICE_URL", "").strip().rstrip("/") or None
-    if env_url is not None:
-        env_token = os.environ.get("NX_SERVICE_TOKEN", "").strip() or None
-        token = env_token
+    from nexus.config import get_credential
+
+    url = (get_credential("service_url") or "").strip().rstrip("/") or None
+    if url is not None:
+        token = (get_credential("service_token") or "").strip() or None
         if token is None:
             _, token = discover_lease()
         if not token:
             raise RuntimeError(
-                "NX_SERVICE_URL is set but no NX_SERVICE_TOKEN is resolvable "
-                "(neither env nor supervisor lease): export NX_SERVICE_TOKEN "
-                "(the service's bearer token) and re-run."
+                "service_url is set but no service_token is resolvable (neither "
+                "NX_SERVICE_TOKEN env, config.yml, nor supervisor lease): set it "
+                "with `nx config set service_token <bearer>` (or export "
+                "NX_SERVICE_TOKEN) and re-run."
             )
-        return env_url, token
+        return url, token
     host, port, token = resolve_service_config()
     return f"http://{host}:{port}", token

--- a/src/nexus/db/service_endpoint.py
+++ b/src/nexus/db/service_endpoint.py
@@ -88,6 +88,14 @@ def recover_endpoint_from_lease(current_base_url: str) -> tuple[str, str | None]
       long-lived service-backed stores (memory/taxonomy/plan/aspect/chash/…) share
       the resolve-once pattern and remain unguarded — tracked for a sweep follow-on.
     """
+    # An explicitly-pinned NX_SERVICE_URL (a managed TLS endpoint, or any URL the
+    # user named) is authoritative — never silently rebind it to a discovered
+    # supervisor lease, which is ALWAYS local http (nexus-n3bwh review H1): the
+    # https managed base_url would compare unequal to the http lease and rebind
+    # every time, routing managed traffic to the wrong (local) service. Lease
+    # recovery is for the lease-discovered path only.
+    if os.environ.get("NX_SERVICE_URL", "").strip():
+        return None
     lease_url, lease_token = discover_lease()
     if lease_url is not None and lease_url.rstrip("/") != (current_base_url or "").rstrip("/"):
         return lease_url.rstrip("/"), lease_token
@@ -97,8 +105,13 @@ def recover_endpoint_from_lease(current_base_url: str) -> tuple[str, str | None]
 def resolve_service_config() -> tuple[str, int, str]:
     """``(host, port, token)`` — env halves, then the lease, then fail loud.
 
-    The shape the T2 domain stores and the catalog client consume (they build
-    ``http://{host}:{port}`` themselves). Restart-safety note: these clients
+    The local-supervisor 3-tuple — ALWAYS ``http`` (env ``NX_SERVICE_HOST``/
+    ``NX_SERVICE_PORT`` carry no scheme; the lease is local http). New HTTP
+    storage clients must NOT build ``http://{host}:{port}`` from this: call
+    :func:`resolve_service_endpoint` instead, which is scheme-correct and also
+    serves managed TLS endpoints (nexus-n3bwh). This function now backs only the
+    non-``NX_SERVICE_URL`` fallback leg of :func:`resolve_service_endpoint`.
+    Restart-safety note: service-backed clients
     resolve ONCE at construction and hold a long-lived ``httpx.Client`` — they
     ride a supervisor restart only because callers construct a fresh client per
     operation (the ``get_catalog()`` / ``t2_ctx()`` pattern). Do not cache a

--- a/src/nexus/db/service_endpoint.py
+++ b/src/nexus/db/service_endpoint.py
@@ -141,11 +141,34 @@ def resolve_service_config() -> tuple[str, int, str]:
 
 
 def resolve_service_endpoint() -> tuple[str, str]:
-    """``(base_url, token)`` — the shape the T3 vector client consumes.
+    """``(base_url, token)`` — the scheme-correct base-url authority.
 
-    Thin adapter over :func:`resolve_service_config` so the vector client and
-    the T2/catalog stores share one resolution path despite their differing
-    return shapes.
+    Every HTTP storage client that builds a base URL (the T2 domain stores, the
+    catalog client, the T1 scratch store, the migration pre-gate) routes through
+    here so a managed TLS endpoint survives end-to-end. Resolution order mirrors
+    the T3 data path (:func:`nexus.db.http_vector_client._resolve_endpoint`):
+
+      1. ``NX_SERVICE_URL`` — the authoritative FULL endpoint, used VERBATIM
+         (scheme + host + port preserved). This is the ONLY scheme source:
+         ``https://api.conexus-nexus.com:443`` stays ``https``; flattening it to
+         ``http://…:443`` (the pre-RDR-166 bug, nexus-n3bwh) broke every managed
+         migration leg. The token half still falls back to lease/env independently.
+      2. Otherwise ``http://{host}:{port}`` from :func:`resolve_service_config`
+         (env halves → lease → fail loud) — the local-supervisor path, always
+         ``http``.
     """
+    env_url = os.environ.get("NX_SERVICE_URL", "").strip().rstrip("/") or None
+    if env_url is not None:
+        env_token = os.environ.get("NX_SERVICE_TOKEN", "").strip() or None
+        token = env_token
+        if token is None:
+            _, token = discover_lease()
+        if not token:
+            raise RuntimeError(
+                "NX_SERVICE_URL is set but no NX_SERVICE_TOKEN is resolvable "
+                "(neither env nor supervisor lease): export NX_SERVICE_TOKEN "
+                "(the service's bearer token) and re-run."
+            )
+        return env_url, token
     host, port, token = resolve_service_config()
     return f"http://{host}:{port}", token

--- a/src/nexus/db/t2/http_aspect_queue.py
+++ b/src/nexus/db/t2/http_aspect_queue.py
@@ -43,7 +43,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -91,8 +91,7 @@ class HttpAspectQueue(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_centroid_store.py
+++ b/src/nexus/db/t2/http_centroid_store.py
@@ -37,7 +37,7 @@ from typing import Any
 import httpx
 import structlog
 
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2.catalog_taxonomy import AssignResult
 from nexus.db.t2.http_taxonomy_store import DEFAULT_TENANT
 
@@ -74,8 +74,7 @@ class HttpCentroidStore:
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_centroid_store.py
+++ b/src/nexus/db/t2/http_centroid_store.py
@@ -10,7 +10,7 @@ the oracle (:class:`~nexus.db.t2.catalog_taxonomy.CatalogTaxonomy`) reached via 
 
 Talks to the RDR-156 ``/v1/taxonomy/centroids/*`` endpoints (bead nexus-t1hnc.3).
 Endpoint discovery is the SAME centralized resolver
-(:func:`nexus.db.service_endpoint.resolve_service_config`) that HttpTaxonomyStore
+(:func:`nexus.db.service_endpoint.resolve_service_endpoint`) that HttpTaxonomyStore
 uses — no per-store env handling.
 
 ERROR-TRANSLATION CONTRACT (Phase-1 gate O2):

--- a/src/nexus/db/t2/http_chash_index.py
+++ b/src/nexus/db/t2/http_chash_index.py
@@ -55,7 +55,7 @@ _BATCH_SIZE: int = 200
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -95,8 +95,7 @@ class HttpChashIndex(RawHandleGuardMixin):
                       resolved from NX_SERVICE_TOKEN env var.
         """
         if base_url is None:
-            host, port, resolved_token = _resolve_config()
-            base_url = f"http://{host}:{port}"
+            base_url, resolved_token = _resolve_endpoint()
         else:
             resolved_token = _token or os.environ.get("NX_SERVICE_TOKEN", "")
             if not resolved_token:

--- a/src/nexus/db/t2/http_document_aspects_store.py
+++ b/src/nexus/db/t2/http_document_aspects_store.py
@@ -37,7 +37,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -131,8 +131,7 @@ class HttpDocumentAspectsStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_document_highlights_store.py
+++ b/src/nexus/db/t2/http_document_highlights_store.py
@@ -32,7 +32,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -83,8 +83,7 @@ class HttpDocumentHighlightsStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_memory_store.py
+++ b/src/nexus/db/t2/http_memory_store.py
@@ -62,7 +62,7 @@ _ALL_PAIRS_MAX_ENTRIES = 1000
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -99,8 +99,7 @@ class HttpMemoryStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_plan_library.py
+++ b/src/nexus/db/t2/http_plan_library.py
@@ -41,7 +41,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -78,8 +78,7 @@ class HttpPlanLibrary(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_taxonomy_store.py
+++ b/src/nexus/db/t2/http_taxonomy_store.py
@@ -68,7 +68,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -122,8 +122,7 @@ class HttpTaxonomyStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_telemetry_store.py
+++ b/src/nexus/db/t2/http_telemetry_store.py
@@ -52,7 +52,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 from nexus.db.t2._raw_handle_guard import RawHandleGuardMixin
 
 
@@ -86,8 +86,7 @@ class HttpTelemetryStore(RawHandleGuardMixin):
                     )
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
 
         self._tenant = tenant

--- a/src/nexus/db/t2/http_token_store.py
+++ b/src/nexus/db/t2/http_token_store.py
@@ -34,7 +34,7 @@ DEFAULT_TENANT: str = "default"
 # RDR-152 nexus-fjwxh: env-only resolution replaced by the centralized
 # resolver (env halves -> ServiceRegistry lease -> fail loud), so the
 # T2 service-mode default works wherever the supervisor is running.
-from nexus.db.service_endpoint import resolve_service_config as _resolve_config
+from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 
 
 class HttpTokenStore:
@@ -61,8 +61,7 @@ class HttpTokenStore:
                     raise RuntimeError("NX_SERVICE_TOKEN is required for token administration.")
             self._base_url = base_url.rstrip("/")
         else:
-            host, port, token = _resolve_config()
-            self._base_url = f"http://{host}:{port}"
+            self._base_url, token = _resolve_endpoint()
             _token = token
         self._tenant = tenant
         self._auth_token = _token or ""

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -468,11 +468,15 @@ def _check_managed_service_probe() -> list[HealthResult]:
     warn only — reachability fatals are ``_check_vector_service``'s domain, so this
     surfaces the version/remedy signal without a duplicate fatal on a down service.
     """
-    import os
+    from nexus.config import get_credential
 
-    base = os.environ.get("NX_SERVICE_URL", "").strip()
+    # env (NX_SERVICE_URL) FIRST, then config.yml — so a greenfield user who set
+    # the endpoint with `nx config set service_url` (no shell export) still gets
+    # the probe (RDR-166 nexus-v3p0x). Empty in BOTH → no explicit managed
+    # endpoint, never default-probe the public one.
+    base = (get_credential("service_url") or "").strip()
     if not base:
-        return []  # no explicit managed endpoint — never default-probe the public one
+        return []
 
     from nexus.db.managed_endpoint import (
         ManagedServiceError,

--- a/src/nexus/migration/chroma_read.py
+++ b/src/nexus/migration/chroma_read.py
@@ -107,14 +107,22 @@ def iter_collection_chunks(
     collection_name: str,
     *,
     page_size: int | None = None,
+    include_embeddings: bool = False,
 ) -> Iterator[dict[str, Any]]:
     """Yield every chunk of *collection_name* as ``{id, document, metadata}``.
 
     Pages at ``QUOTAS.MAX_QUERY_RESULTS`` (300) per call — the ChromaCloud
-    free-tier cap that ``chroma_quotas`` still governs for this leg. The
-    embedding vectors are deliberately NOT fetched: the pgvector side
-    re-embeds server-side (Seam B), so dragging legacy vectors through the
-    ETL would only invite cross-model contamination (RDR-109 hazard class).
+    free-tier cap that ``chroma_quotas`` still governs for this leg.
+
+    By default the embedding vectors are NOT fetched: the pgvector side
+    re-embeds server-side (Seam B), so dragging legacy vectors through a
+    cross-model migration would invite contamination (RDR-109 hazard class).
+    The SAME-MODEL passthrough (nexus-hxry2) is the deliberate exception: when
+    the source model equals the target's wired model the stored vectors are
+    already correct, so ``include_embeddings=True`` fetches them and each yielded
+    chunk additionally carries ``"embedding"`` (a ``list[float]``, or ``None`` if
+    the source row has no vector). The caller is responsible for only enabling
+    this on the verified same-model branch.
     """
     page = page_size or QUOTAS.MAX_QUERY_RESULTS
     if page > QUOTAS.MAX_QUERY_RESULTS:
@@ -122,19 +130,26 @@ def iter_collection_chunks(
             f"page_size {page} exceeds the Chroma per-call cap "
             f"{QUOTAS.MAX_QUERY_RESULTS} (chroma_quotas governs this read leg)"
         )
+    include = ["documents", "metadatas"]
+    if include_embeddings:
+        include.append("embeddings")
     col = client.get_collection(collection_name)
     offset = 0
     while True:
-        batch = col.get(
-            include=["documents", "metadatas"], limit=page, offset=offset
-        )
+        batch = col.get(include=include, limit=page, offset=offset)
         ids = batch.get("ids") or []
         if not ids:
             return
         docs = batch.get("documents") or [None] * len(ids)
         metas = batch.get("metadatas") or [None] * len(ids)
-        for chunk_id, doc, meta in zip(ids, docs, metas):
-            yield {"id": chunk_id, "document": doc, "metadata": dict(meta or {})}
+        embs = batch.get("embeddings") if include_embeddings else None
+        if embs is None:
+            embs = [None] * len(ids)
+        for chunk_id, doc, meta, emb in zip(ids, docs, metas, embs):
+            chunk = {"id": chunk_id, "document": doc, "metadata": dict(meta or {})}
+            if include_embeddings:
+                chunk["embedding"] = list(emb) if emb is not None else None
+            yield chunk
         if len(ids) < page:
             return
         offset += len(ids)

--- a/src/nexus/migration/detection.py
+++ b/src/nexus/migration/detection.py
@@ -538,10 +538,20 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
         migratable_chunks += chunk_count
         total_est_tokens += tokens
         est_seconds += seconds
-        # Billed iff the re-embed runs through a Voyage model (cross-model→voyage).
-        # Byte-for-byte voyage copies (support == supported-voyage-1024, not
-        # cross_model) reuse stored embeddings — no API call, no bill.
-        if is_cross_model and target_model in _VOYAGE_MODELS:
+        # Billed iff the chunk's effective TARGET embedder is a Voyage model.
+        # Seam B re-embeds EVERY migrated chunk server-side (iter_collection_chunks
+        # deliberately discards stored vectors; upsert_chunks ignores any
+        # embeddings arg), so there is no free "byte-for-byte" copy — what
+        # determines the bill is which model the service re-embeds with:
+        #   * cross-model→voyage  → target_model is a Voyage model → BILLED.
+        #   * supported-voyage-1024 → re-embedded with the SAME voyage model → BILLED.
+        #   * supported-onnx / cross-model→bge → local ONNX (bge-768) → free.
+        billed = (
+            target_model in _VOYAGE_MODELS
+            if is_cross_model
+            else support == "supported-voyage-1024"
+        )
+        if billed:
             billed_voyage_tokens += tokens
 
     # Stable order: leg, support, model, then target — deterministic preview text.
@@ -620,6 +630,14 @@ def render_dry_run_preview(preview: DryRunPreview) -> str:
         f"~{preview.total_est_tokens:,} tokens; ~{preview.est_seconds:.1f}s "
         "re-embed time."
     )
+    if preview.billed_voyage_tokens > 0:
+        lines.append(
+            f"Voyage re-embed cost (billed to the operator key): "
+            f"~{preview.billed_voyage_tokens:,} tokens, est. "
+            f"~${preview.est_voyage_cost_usd:.2f} "
+            f"(~${_VOYAGE_COST_USD_PER_1M_TOKENS:.2f}/1M tokens; a re-run re-embeds "
+            "at full cost — not deduplicated)."
+        )
     lines.append(
         "Estimates are coarse planning figures, not a binding commitment; the "
         "live run reports exact counts."
@@ -641,7 +659,7 @@ def render_cost_confirmation(preview: DryRunPreview) -> str | None:
     if preview.billed_voyage_tokens <= 0:
         return None
     return (
-        f"⚠  This migration will RE-EMBED ~{preview.billed_voyage_tokens:,} tokens "
+        f"WARNING: this migration will RE-EMBED ~{preview.billed_voyage_tokens:,} tokens "
         f"through a Voyage model, billed to the operator's Voyage key — an "
         f"estimated ${preview.est_voyage_cost_usd:.2f} (coarse planning figure at "
         f"~${_VOYAGE_COST_USD_PER_1M_TOKENS:.2f}/1M tokens; the real invoice "

--- a/src/nexus/migration/detection.py
+++ b/src/nexus/migration/detection.py
@@ -415,6 +415,14 @@ _EST_TOKENS_PER_CHUNK: int = 512
 _EST_VOYAGE_CHUNKS_PER_SEC: float = 200.0
 _EST_ONNX_CHUNKS_PER_SEC: float = 100.0
 
+#: Coarse Voyage re-embed price (USD per 1M tokens), for the cost guardrail
+#: (nexus-cewad / RDR-166 Gap 4). Order-of-magnitude planning figure across the
+#: voyage-context-3 / voyage-code-3 family — NOT a billing-accurate quote; the
+#: operator's actual invoice is set by Voyage's current pricing. Only the
+#: cross-model→voyage RE-EMBED is billed: byte-for-byte voyage copies reuse
+#: stored embeddings (no API call), and ONNX/bge re-embeds run locally.
+_VOYAGE_COST_USD_PER_1M_TOKENS: float = 0.12
+
 
 @dataclass(frozen=True)
 class ModelGroup:
@@ -451,6 +459,13 @@ class DryRunPreview:
     migratable_chunks: int
     total_est_tokens: int
     est_seconds: float
+    #: nexus-cewad: token volume that will be RE-EMBEDDED through a Voyage model
+    #: (cross-model→voyage groups only) and therefore billed to the operator key.
+    #: Byte-for-byte voyage copies and ONNX/bge re-embeds contribute zero.
+    billed_voyage_tokens: int = 0
+    #: Coarse USD estimate for ``billed_voyage_tokens`` at
+    #: :data:`_VOYAGE_COST_USD_PER_1M_TOKENS`. ``0.0`` when nothing is billed.
+    est_voyage_cost_usd: float = 0.0
 
 
 def _throughput_for_support(support: Support) -> float:
@@ -490,6 +505,7 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
     migratable_chunks = 0
     total_est_tokens = 0
     est_seconds = 0.0
+    billed_voyage_tokens = 0
     for (leg, model, support, target_model), members in buckets.items():
         chunk_count = sum(m.source_count for m in members)
         is_cross_model = target_model is not None
@@ -522,6 +538,11 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
         migratable_chunks += chunk_count
         total_est_tokens += tokens
         est_seconds += seconds
+        # Billed iff the re-embed runs through a Voyage model (cross-model→voyage).
+        # Byte-for-byte voyage copies (support == supported-voyage-1024, not
+        # cross_model) reuse stored embeddings — no API call, no bill.
+        if is_cross_model and target_model in _VOYAGE_MODELS:
+            billed_voyage_tokens += tokens
 
     # Stable order: leg, support, model, then target — deterministic preview text.
     groups.sort(key=lambda g: (g.leg, g.support, g.model or "", g.target_model or ""))
@@ -537,6 +558,8 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
         migratable_chunks=migratable_chunks,
         total_est_tokens=total_est_tokens,
         est_seconds=round(est_seconds, 1),
+        billed_voyage_tokens=billed_voyage_tokens,
+        est_voyage_cost_usd=billed_voyage_tokens / 1_000_000 * _VOYAGE_COST_USD_PER_1M_TOKENS,
     )
 
 
@@ -602,3 +625,28 @@ def render_dry_run_preview(preview: DryRunPreview) -> str:
         "live run reports exact counts."
     )
     return "\n".join(lines)
+
+
+def render_cost_confirmation(preview: DryRunPreview) -> str | None:
+    """Operator-facing cost warning for a billed Voyage re-embed, or ``None``.
+
+    Returns ``None`` when the migration bills nothing (no cross-model→voyage
+    re-embed) — the caller then proceeds without a cost prompt. When there IS a
+    billed re-embed, returns a warning that surfaces (a) the coarse USD estimate
+    and the token volume it is based on, and (b) the re-run-at-full-cost
+    foot-gun (nexus-1sx01): this guardrail WARNS and CONFIRMS; it does NOT
+    deduplicate or avoid re-billing a repeated run (copy-not-move has no
+    server-side cost memory). Pure formatting — no I/O.
+    """
+    if preview.billed_voyage_tokens <= 0:
+        return None
+    return (
+        f"⚠  This migration will RE-EMBED ~{preview.billed_voyage_tokens:,} tokens "
+        f"through a Voyage model, billed to the operator's Voyage key — an "
+        f"estimated ${preview.est_voyage_cost_usd:.2f} (coarse planning figure at "
+        f"~${_VOYAGE_COST_USD_PER_1M_TOKENS:.2f}/1M tokens; the real invoice "
+        f"follows Voyage's current pricing).\n"
+        f"   Re-running this migration re-embeds the same chunks again at full "
+        f"cost — the copy carries no server-side cost memory, so a repeat run is "
+        f"billed in full, not deduplicated."
+    )

--- a/src/nexus/migration/detection.py
+++ b/src/nexus/migration/detection.py
@@ -418,11 +418,10 @@ _EST_ONNX_CHUNKS_PER_SEC: float = 100.0
 #: Coarse Voyage re-embed price (USD per 1M tokens), for the cost guardrail
 #: (nexus-cewad / RDR-166 Gap 4). Order-of-magnitude planning figure across the
 #: voyage-context-3 / voyage-code-3 family — NOT a billing-accurate quote; the
-#: operator's actual invoice is set by Voyage's current pricing. Billed whenever
-#: the effective TARGET embedder is a Voyage model — both cross-model→voyage AND
-#: same-model supported-voyage-1024 (Seam B discards stored vectors;
-#: upsert_chunks re-embeds server-side for every migrated chunk). ONNX/bge
-#: re-embeds run locally and are not billed.
+#: operator's actual invoice is set by Voyage's current pricing. Billed only for
+#: a cross-model→voyage RE-EMBED. Same-model voyage migrations use vector
+#: passthrough (nexus-hxry2) — stored vectors are copied, not re-embedded, so
+#: they do not bill. ONNX/bge re-embeds run locally and never bill.
 _VOYAGE_COST_USD_PER_1M_TOKENS: float = 0.12
 
 
@@ -462,10 +461,10 @@ class DryRunPreview:
     total_est_tokens: int
     est_seconds: float
     #: nexus-cewad: token volume that will be RE-EMBEDDED through a Voyage model
-    #: and therefore billed to the operator key — includes BOTH cross-model→voyage
-    #: AND supported-voyage-1024 (same-model) groups. Seam B discards stored
-    #: vectors and re-embeds server-side for every migrated chunk, so there is no
-    #: free byte-for-byte copy. ONNX/bge re-embeds run locally and contribute zero.
+    #: and therefore billed to the operator key — counts cross-model→voyage
+    #: re-embed groups only. Same-model voyage migrations use vector passthrough
+    #: (nexus-hxry2: stored vectors copied, not re-embedded) and contribute zero,
+    #: as do ONNX/bge re-embeds (local).
     billed_voyage_tokens: int = 0
     #: Coarse USD estimate for ``billed_voyage_tokens`` at
     #: :data:`_VOYAGE_COST_USD_PER_1M_TOKENS`. ``0.0`` when nothing is billed.
@@ -542,19 +541,14 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
         migratable_chunks += chunk_count
         total_est_tokens += tokens
         est_seconds += seconds
-        # Billed iff the chunk's effective TARGET embedder is a Voyage model.
-        # Seam B re-embeds EVERY migrated chunk server-side (iter_collection_chunks
-        # deliberately discards stored vectors; upsert_chunks ignores any
-        # embeddings arg), so there is no free "byte-for-byte" copy — what
-        # determines the bill is which model the service re-embeds with:
-        #   * cross-model→voyage  → target_model is a Voyage model → BILLED.
-        #   * supported-voyage-1024 → re-embedded with the SAME voyage model → BILLED.
+        # Billed iff the migration RE-EMBEDS through a Voyage model:
+        #   * cross-model→voyage → re-embedded with the target voyage model → BILLED.
+        #   * same-model voyage (supported-voyage-1024) → vector PASSTHROUGH
+        #     (nexus-hxry2): the stored vectors are copied verbatim, NOT
+        #     re-embedded, so it no longer bills. (Best case: a same-model chunk
+        #     missing its source vector falls back to a billed re-embed per batch.)
         #   * supported-onnx / cross-model→bge → local ONNX (bge-768) → free.
-        billed = (
-            target_model in _VOYAGE_MODELS
-            if is_cross_model
-            else support == "supported-voyage-1024"
-        )
+        billed = is_cross_model and target_model in _VOYAGE_MODELS
         if billed:
             billed_voyage_tokens += tokens
 

--- a/src/nexus/migration/detection.py
+++ b/src/nexus/migration/detection.py
@@ -50,7 +50,7 @@ from nexus.corpus import (
     embedding_model_for_collection_name,
     voyage_model_for_collection,
 )
-from nexus.migration.vector_etl import _dim_for_collection
+from nexus.migration.vector_etl import _VOYAGE_MODELS, _dim_for_collection
 
 _log = structlog.get_logger(__name__)
 
@@ -61,11 +61,9 @@ _log = structlog.get_logger(__name__)
 #: service cannot serve it — such collections are UNSUPPORTED until re-indexed).
 _ONNX_MODEL: str = "bge-base-en-v15-768"
 
-#: The voyage models wired only in cloud mode (``NX_VOYAGE_API_KEY`` present).
-#: Mirrors ``EmbedderRouter``'s cloud-mode ``modelEmbedders`` keys.
-_VOYAGE_MODELS: frozenset[str] = frozenset(
-    {"voyage-code-3", "voyage-context-3", "voyage-3"}
-)
+#: The voyage models (``_VOYAGE_MODELS``) are imported from ``vector_etl`` (single
+#: source) so this module's billing decision and vector_etl's passthrough
+#: eligibility can never silently diverge on a new Voyage model (review).
 
 Leg = Literal["local", "cloud"]
 Support = Literal["supported-onnx", "supported-voyage-1024", "unsupported"]
@@ -469,6 +467,12 @@ class DryRunPreview:
     #: Coarse USD estimate for ``billed_voyage_tokens`` at
     #: :data:`_VOYAGE_COST_USD_PER_1M_TOKENS`. ``0.0`` when nothing is billed.
     est_voyage_cost_usd: float = 0.0
+    #: nexus-hxry2: same-model voyage token volume that migrates FREE via vector
+    #: passthrough (stored vectors copied, not re-embedded). It is NOT billed —
+    #: but the dry-run can't see per-chunk vector presence, and any source chunk
+    #: lacking a stored vector re-embeds that batch (and bills). Surfaced as a
+    #: caveat so the ``$0`` estimate is honest about that fallback (review).
+    passthrough_voyage_tokens: int = 0
 
 
 def _throughput_for_support(support: Support) -> float:
@@ -509,6 +513,7 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
     total_est_tokens = 0
     est_seconds = 0.0
     billed_voyage_tokens = 0
+    passthrough_voyage_tokens = 0
     for (leg, model, support, target_model), members in buckets.items():
         chunk_count = sum(m.source_count for m in members)
         is_cross_model = target_model is not None
@@ -551,6 +556,10 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
         billed = is_cross_model and target_model in _VOYAGE_MODELS
         if billed:
             billed_voyage_tokens += tokens
+        elif not is_cross_model and support == "supported-voyage-1024":
+            # Same-model voyage → vector passthrough (free), barring missing-vector
+            # batch fallback. Tracked so the estimate can caveat the $0 (review).
+            passthrough_voyage_tokens += tokens
 
     # Stable order: leg, support, model, then target — deterministic preview text.
     groups.sort(key=lambda g: (g.leg, g.support, g.model or "", g.target_model or ""))
@@ -568,6 +577,7 @@ def build_dry_run_preview(report: DetectionReport) -> DryRunPreview:
         est_seconds=round(est_seconds, 1),
         billed_voyage_tokens=billed_voyage_tokens,
         est_voyage_cost_usd=billed_voyage_tokens / 1_000_000 * _VOYAGE_COST_USD_PER_1M_TOKENS,
+        passthrough_voyage_tokens=passthrough_voyage_tokens,
     )
 
 
@@ -635,6 +645,14 @@ def render_dry_run_preview(preview: DryRunPreview) -> str:
             f"~${preview.est_voyage_cost_usd:.2f} "
             f"(~${_VOYAGE_COST_USD_PER_1M_TOKENS:.2f}/1M tokens; a re-run re-embeds "
             "at full cost — not deduplicated)."
+        )
+    if preview.passthrough_voyage_tokens > 0:
+        lines.append(
+            f"Voyage passthrough (free): ~{preview.passthrough_voyage_tokens:,} "
+            "tokens migrate same-model by copying stored vectors — no re-embed, "
+            "no charge. Caveat: any source chunk missing its stored vector "
+            "re-embeds that batch (and bills); the estimate assumes all vectors "
+            "are present."
         )
     lines.append(
         "Estimates are coarse planning figures, not a binding commitment; the "

--- a/src/nexus/migration/detection.py
+++ b/src/nexus/migration/detection.py
@@ -418,9 +418,11 @@ _EST_ONNX_CHUNKS_PER_SEC: float = 100.0
 #: Coarse Voyage re-embed price (USD per 1M tokens), for the cost guardrail
 #: (nexus-cewad / RDR-166 Gap 4). Order-of-magnitude planning figure across the
 #: voyage-context-3 / voyage-code-3 family — NOT a billing-accurate quote; the
-#: operator's actual invoice is set by Voyage's current pricing. Only the
-#: cross-model→voyage RE-EMBED is billed: byte-for-byte voyage copies reuse
-#: stored embeddings (no API call), and ONNX/bge re-embeds run locally.
+#: operator's actual invoice is set by Voyage's current pricing. Billed whenever
+#: the effective TARGET embedder is a Voyage model — both cross-model→voyage AND
+#: same-model supported-voyage-1024 (Seam B discards stored vectors;
+#: upsert_chunks re-embeds server-side for every migrated chunk). ONNX/bge
+#: re-embeds run locally and are not billed.
 _VOYAGE_COST_USD_PER_1M_TOKENS: float = 0.12
 
 
@@ -460,8 +462,10 @@ class DryRunPreview:
     total_est_tokens: int
     est_seconds: float
     #: nexus-cewad: token volume that will be RE-EMBEDDED through a Voyage model
-    #: (cross-model→voyage groups only) and therefore billed to the operator key.
-    #: Byte-for-byte voyage copies and ONNX/bge re-embeds contribute zero.
+    #: and therefore billed to the operator key — includes BOTH cross-model→voyage
+    #: AND supported-voyage-1024 (same-model) groups. Seam B discards stored
+    #: vectors and re-embeds server-side for every migrated chunk, so there is no
+    #: free byte-for-byte copy. ONNX/bge re-embeds run locally and contribute zero.
     billed_voyage_tokens: int = 0
     #: Coarse USD estimate for ``billed_voyage_tokens`` at
     #: :data:`_VOYAGE_COST_USD_PER_1M_TOKENS`. ``0.0`` when nothing is billed.

--- a/src/nexus/migration/pregate.py
+++ b/src/nexus/migration/pregate.py
@@ -76,11 +76,20 @@ class LiveServiceWiredModels:
 
     def wired_models(self) -> frozenset[str] | None:
         try:
-            from nexus.daemon.binary_lifecycle import fetch_service_version
-            from nexus.db.service_endpoint import resolve_service_config
+            from urllib.parse import urlsplit
 
-            host, port, _token = resolve_service_config()
-            handshake = fetch_service_version(host, port)
+            from nexus.daemon.binary_lifecycle import fetch_service_version
+            from nexus.db.service_endpoint import resolve_service_endpoint
+
+            # Scheme-aware: a managed TLS endpoint (NX_SERVICE_URL=https://…:443)
+            # must reach the service over https; the old (host, port) path
+            # hard-coded http and broke the handshake before the data path ran
+            # (nexus-n3bwh). resolve_service_endpoint preserves the scheme.
+            base_url, _token = resolve_service_endpoint()
+            parsed = urlsplit(base_url)
+            handshake = fetch_service_version(
+                parsed.hostname, parsed.port, scheme=parsed.scheme
+            )
         except Exception as exc:  # noqa: BLE001 - probe must never raise upward
             _log.debug("pregate_live_wired_unreachable", error=str(exc))
             return None

--- a/src/nexus/migration/vector_etl.py
+++ b/src/nexus/migration/vector_etl.py
@@ -115,6 +115,44 @@ _MODEL_DIMS: dict[str, int] = {
 #: The per-dim physical tables shipped by vectors-001-baseline.xml.
 _KNOWN_DIMS: frozenset[int] = frozenset(_MODEL_DIMS.values())
 
+#: Voyage models — the same-model re-embeds that BILL the operator key. Used by
+#: the cost guardrail (detection.py) to estimate the cross-model→voyage charge.
+_VOYAGE_MODELS: frozenset[str] = frozenset(
+    {"voyage-code-3", "voyage-context-3", "voyage-3"}
+)
+
+#: Models eligible for same-model PASSTHROUGH (nexus-hxry2): the service can embed
+#: QUERIES against them post-migration, so copying stored doc vectors leaves a
+#: queryable collection. bge-768 is wired in every mode; voyage models are wired
+#: when the key is present (and only reach the same-model path when classified
+#: supported-voyage upstream). minilm / unknown models are deliberately ABSENT:
+#: the service wires no embedder for them, so they MUST be cross-model remapped
+#: (orchestrator-owned) — passthrough would leave an unqueryable collection.
+_PASSTHROUGH_MODELS: frozenset[str] = frozenset({"bge-base-en-v15-768"}) | _VOYAGE_MODELS
+
+
+def _is_same_model_passthrough(name: str, target: str) -> bool:
+    """True when this collection migrates SAME-model into a WIRED model.
+
+    Two conditions: (1) target == source (no model change), and (2) the model is
+    in :data:`_PASSTHROUGH_MODELS` — one the service can embed queries against, so
+    the migrated collection stays queryable. The collection name encodes the model
+    (``…__bge-base-en-v15-768__v1``), so a same-name migration into a wired model
+    means the stored vectors were produced by exactly the model the target is
+    searched against — safe to copy verbatim (guarded further by the server-side
+    per-vector dimension check).
+
+    Applies to BOTH deployments: a managed/voyage user avoids the billed Voyage
+    re-embed; a LOCAL user avoids a full ONNX (bge-768) recompute of vectors that
+    already exist — same logical waste, copied instead of recomputed (nexus-hxry2).
+    Cross-model migrations and unsupported-model collections (minilm, which must be
+    remapped) return False and re-embed, as required.
+    """
+    if name != target:
+        return False
+    segments = name.split("__")
+    return len(segments) == 4 and segments[2] in _PASSTHROUGH_MODELS
+
 
 @dataclass(frozen=True)
 class CollectionResult:
@@ -207,11 +245,17 @@ def cross_model_target_name(source: str, target_model: str) -> str:
 
 
 def _iter_id_pages(
-    read_client: Any, collection: str, page: int
+    read_client: Any, collection: str, page: int, *, include_embeddings: bool = False
 ) -> Iterator[list[dict[str, Any]]]:
-    """Group the chunk stream into read-page-aligned batches."""
+    """Group the chunk stream into read-page-aligned batches.
+
+    ``include_embeddings`` flows to :func:`iter_collection_chunks` so the
+    same-model passthrough (nexus-hxry2) carries each chunk's stored vector.
+    """
     batch: list[dict[str, Any]] = []
-    for chunk in iter_collection_chunks(read_client, collection, page_size=page):
+    for chunk in iter_collection_chunks(
+        read_client, collection, page_size=page, include_embeddings=include_embeddings
+    ):
         batch.append(chunk)
         if len(batch) == page:
             yield batch
@@ -275,20 +319,32 @@ def _migrate_one(
             target_collection=target if is_cross_model else None,
         )
 
+    # Same-model migration → PASSTHROUGH: fetch the stored vectors and send them
+    # so the service stores them verbatim, skipping the re-embed (nexus-hxry2) —
+    # avoids a billed Voyage re-embed for a managed user AND a wasted local ONNX
+    # recompute for a local user. Any chunk missing a stored vector falls back to
+    # a server-side re-embed for that batch (correctness over cost — never store a
+    # null vector).
+    passthrough = _is_same_model_passthrough(name, target)
     source_count = 0
     written = 0
     try:
-        for batch in _iter_id_pages(read_client, name, page):
+        for batch in _iter_id_pages(read_client, name, page, include_embeddings=passthrough):
             source_count += len(batch)
             # Read from the SOURCE (*name*); upsert into the TARGET (model-remapped
-            # for cross-model). Server re-embeds the stored text with the target's
-            # model — chash (sha256(text)[:32]) is identical, so re-runs stay
-            # idempotent on (tenant, target, chash).
+            # for cross-model). For the re-embed path the server embeds the stored
+            # text with the target's model; for passthrough it stores the supplied
+            # vectors verbatim. chash (sha256(text)[:32]) is identical either way,
+            # so re-runs stay idempotent on (tenant, target, chash).
+            embeddings = None
+            if passthrough and all(c.get("embedding") is not None for c in batch):
+                embeddings = [c["embedding"] for c in batch]
             vector_client.upsert_chunks(
                 target,
                 [c["id"] for c in batch],
                 [c["document"] for c in batch],
                 [c["metadata"] for c in batch],
+                embeddings=embeddings,
             )
             written += len(batch)
     except Exception as exc:  # noqa: BLE001 — report and continue with the next collection

--- a/src/nexus/migration/vector_etl.py
+++ b/src/nexus/migration/vector_etl.py
@@ -20,10 +20,21 @@ half-migration):
 VECTOR-IDENTITY DECISION (a) (recorded on bead nexus-unp61, 2026-06-10):
 chunk TEXT transfers byte-verbatim and the chash (chunk natural ID,
 ``sha256(text)[:32]``) is preserved verbatim; the pgvector side re-embeds
-server-side. NO source embedding vectors cross the ETL —
-``iter_collection_chunks`` deliberately omits them (RDR-109
-cross-model-contamination guard). Recall equivalence with identical
-embedders was established by the Phase 3 dual-run harness.
+server-side. By default NO source embedding vectors cross the ETL —
+``iter_collection_chunks`` omits them (RDR-109 cross-model-contamination
+guard). Recall equivalence with identical embedders was established by the
+Phase 3 dual-run harness.
+
+SAME-MODEL PASSTHROUGH EXCEPTION (nexus-hxry2): when a collection migrates
+SAME-model into a WIRED model (:data:`_PASSTHROUGH_MODELS` — bge / voyage;
+see :func:`_is_same_model_passthrough`), the stored vectors ARE fetched
+(``include_embeddings=True``) and forwarded so the service stores them
+verbatim, skipping a needless re-embed (a billed Voyage call for a managed
+user, a wasted ONNX recompute for a local user). The contamination guard
+still holds: passthrough fires only when the source model equals the
+target's wired model, and the service rejects any vector whose dimension
+disagrees with the dispatched table. A batch with any missing source vector
+falls back to the server-side re-embed (logged), never a null vector.
 
 COPY-NOT-MOVE: the Chroma source is opened read-only by convention and is
 never modified — not by migration, not by rollback. The source is also the
@@ -337,8 +348,22 @@ def _migrate_one(
             # vectors verbatim. chash (sha256(text)[:32]) is identical either way,
             # so re-runs stay idempotent on (tenant, target, chash).
             embeddings = None
-            if passthrough and all(c.get("embedding") is not None for c in batch):
-                embeddings = [c["embedding"] for c in batch]
+            if passthrough:
+                if all(c.get("embedding") is not None for c in batch):
+                    embeddings = [c["embedding"] for c in batch]
+                else:
+                    # Fallback: a batch with any missing source vector re-embeds
+                    # server-side (never store a null vector) — and that re-embed
+                    # bills. Logged so a mixed passthrough/re-embed run is auditable
+                    # (the dry-run cost caveat warns this is possible).
+                    missing = sum(1 for c in batch if c.get("embedding") is None)
+                    _log.warning(
+                        "vector_etl_passthrough_fallback_reembed",
+                        collection=name,
+                        target=target,
+                        batch_size=len(batch),
+                        missing_vectors=missing,
+                    )
             vector_client.upsert_chunks(
                 target,
                 [c["id"] for c in batch],

--- a/tests/catalog/test_http_catalog_client.py
+++ b/tests/catalog/test_http_catalog_client.py
@@ -24,7 +24,8 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
-from nexus.catalog.http_catalog_client import HttpCatalogClient, _resolve_config
+from nexus.catalog.http_catalog_client import HttpCatalogClient
+from nexus.db.service_endpoint import resolve_service_config as _resolve_config
 from nexus.daemon.catalog_write_shim import CATALOG_WRITE_OPS
 
 

--- a/tests/commands/test_migrate_cost_guardrail.py
+++ b/tests/commands/test_migrate_cost_guardrail.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-166 Gap 4 (nexus-cewad) — the estimate-and-confirm Voyage cost guardrail.
+
+The guardrail must GATE the billed `run_guided_upgrade` call, not merely echo a
+warning beside it: a declined confirmation aborts before any re-embed runs, and
+`--yes` is the only way to proceed non-interactively. A migration that bills
+nothing (no cross-model→voyage re-embed) is never prompted.
+"""
+from __future__ import annotations
+
+import click
+import pytest
+
+from nexus.commands.migrate_cmd import _confirm_voyage_cost
+from nexus.migration.detection import DryRunPreview
+
+
+def _preview(*, cost: float, tokens: int) -> DryRunPreview:
+    return DryRunPreview(
+        groups=(),
+        unsupported=(),
+        legs_with_data=frozenset(),
+        migratable_chunks=0,
+        total_est_tokens=tokens,
+        est_seconds=0.0,
+        billed_voyage_tokens=tokens,
+        est_voyage_cost_usd=cost,
+    )
+
+
+class TestConfirmVoyageCost:
+    def test_free_migration_proceeds_without_prompting(self) -> None:
+        calls: list[bool] = []
+        proceed = _confirm_voyage_cost(
+            _preview(cost=0.0, tokens=0),
+            assume_yes=False,
+            confirm=lambda msg: calls.append(True) or True,
+        )
+        assert proceed is True
+        assert calls == []  # never prompted — nothing is billed
+
+    def test_assume_yes_bypasses_prompt_on_billed_run(self) -> None:
+        calls: list[bool] = []
+        proceed = _confirm_voyage_cost(
+            _preview(cost=5.0, tokens=1000),
+            assume_yes=True,
+            confirm=lambda msg: calls.append(True) or True,
+        )
+        assert proceed is True
+        assert calls == []  # --yes skips the prompt
+
+    def test_billed_run_prompts_and_proceeds_on_yes(self) -> None:
+        seen: list[str] = []
+        proceed = _confirm_voyage_cost(
+            _preview(cost=5.0, tokens=1000),
+            assume_yes=False,
+            confirm=lambda msg: seen.append(msg) or True,
+        )
+        assert proceed is True
+        assert len(seen) == 1  # prompted exactly once
+
+    def test_billed_run_aborts_on_decline(self) -> None:
+        proceed = _confirm_voyage_cost(
+            _preview(cost=5.0, tokens=1000),
+            assume_yes=False,
+            confirm=lambda msg: False,
+        )
+        assert proceed is False  # declined → caller must not run the billed leg
+
+
+class TestRunMigrationGate:
+    """The gate must precede the billed run_guided_upgrade in _run_migration."""
+
+    def _wire(self, monkeypatch, *, cost: float, tokens: int = 1000):
+        import nexus.commands.migrate_cmd as mc
+
+        ran: list[str] = []
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "tok")
+        monkeypatch.setattr(mc, "open_read_legs", lambda p: (None, None))
+        monkeypatch.setattr(mc, "classify_collections", lambda **k: object())
+        monkeypatch.setattr(mc, "voyage_key_available", lambda: True)
+        monkeypatch.setattr(
+            mc, "build_dry_run_preview", lambda r: _preview(cost=cost, tokens=tokens)
+        )
+        monkeypatch.setattr(mc, "_close_quietly", lambda c: None)
+        # endpoint preflight + client construction
+        monkeypatch.setattr(
+            "nexus.db.http_vector_client._resolve_endpoint",
+            lambda: ("https://api.conexus-nexus.com:443", "tok"),
+        )
+        monkeypatch.setattr(
+            "nexus.db.http_vector_client.HttpVectorClient",
+            lambda **k: object(),
+        )
+        monkeypatch.setattr(
+            "nexus.catalog.factory.make_catalog_client_for_migration",
+            lambda **k: object(),
+        )
+        monkeypatch.setattr(
+            "nexus.migration.driver.run_guided_upgrade",
+            lambda **k: ran.append("billed") or _stub_result(),
+        )
+        monkeypatch.setattr(mc, "_resolve_db_path", lambda p: _existing_path())
+        monkeypatch.setattr(mc, "_resolve_catalog_db_path", lambda p: _existing_path())
+        monkeypatch.setattr(mc, "_render_result", lambda r: None)
+        return mc, ran
+
+    def test_declined_cost_aborts_before_billed_run(self, monkeypatch) -> None:
+        mc, ran = self._wire(monkeypatch, cost=5.0)
+        monkeypatch.setattr("click.confirm", lambda *a, **k: False)
+        with pytest.raises(click.Abort):
+            mc._run_migration(None, None, None, None, assume_yes=False)
+        assert ran == []  # billed run never reached
+
+    def test_assume_yes_reaches_billed_run(self, monkeypatch) -> None:
+        mc, ran = self._wire(monkeypatch, cost=5.0)
+        mc._run_migration(None, None, None, None, assume_yes=True)
+        assert ran == ["billed"]
+
+    def test_free_migration_reaches_billed_run_without_prompt(self, monkeypatch) -> None:
+        mc, ran = self._wire(monkeypatch, cost=0.0, tokens=0)
+        # No confirm patched: a free migration must not call click.confirm.
+        monkeypatch.setattr(
+            "click.confirm",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("prompted on free run")),
+        )
+        mc._run_migration(None, None, None, None, assume_yes=False)
+        assert ran == ["billed"]
+
+
+def _stub_result():
+    class _Seq:
+        phase = "migrated"
+
+    class _R:
+        sequence = _Seq()
+
+    return _R()
+
+
+class _ExistingPath:
+    def exists(self) -> bool:
+        return True
+
+
+def _existing_path() -> _ExistingPath:
+    return _ExistingPath()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -457,6 +457,12 @@ _MODE_LINT_EXCLUDE_FILES: frozenset[str] = frozenset({
     # explicitly via the ``voyage_key_present`` argument, never the ambient
     # cloud_mode fixture (the classifier is a pure deployment-mode function).
     "test_detection.py",
+    # RDR-166 nexus-hxry2 vector-ETL: voyage tokens are collection-NAME segments
+    # driving same-model passthrough vs cross-model routing (_is_same_model_
+    # passthrough / _migrate_one). The ETL never embeds — the server does — so
+    # these tests are deployment-mode-agnostic; they pin behavior via explicit
+    # target_name / collection names, never the ambient cloud_mode fixture.
+    "test_vector_etl.py",
     # RDR-159 P1d pre-gate + P1c quiesce: voyage tokens are collection-NAME /
     # wired-model-set fixtures driving the support gate and the count-mismatch
     # attribution message; mode is pinned explicitly via the injected

--- a/tests/db/test_http_vector_client.py
+++ b/tests/db/test_http_vector_client.py
@@ -162,6 +162,50 @@ class TestUpsertChunks:
         )
         assert "embeddings" not in calls[0]
 
+    def test_upsert_chunks_without_embeddings_omits_key(self, monkeypatch):
+        """Default Seam B path: no embeddings field → server embeds."""
+        client = HttpVectorClient()
+        calls = []
+        monkeypatch.setattr(
+            "nexus.db.http_vector_client._post",
+            lambda path, body, **kw: calls.append(body) or {"upserted": 1},
+        )
+        client.upsert_chunks("col", ["id1"], ["text1"])
+        assert "embeddings" not in calls[0]
+
+    def test_upsert_chunks_passthrough_sends_embeddings(self, monkeypatch):
+        """nexus-hxry2 same-model passthrough: supplied vectors ARE sent so the
+        service stores them verbatim and skips the re-embed."""
+        client = HttpVectorClient()
+        calls = []
+        monkeypatch.setattr(
+            "nexus.db.http_vector_client._post",
+            lambda path, body, **kw: calls.append(body) or {"upserted": 2},
+        )
+        vecs = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        client.upsert_chunks(
+            "col", ["id1", "id2"], ["t1", "t2"], embeddings=vecs
+        )
+        assert calls[0]["embeddings"] == vecs
+
+    def test_skip_existing_prunes_embeddings_in_lockstep(self, monkeypatch):
+        """When skip_existing drops already-present ids, the supplied embeddings
+        must be pruned to match — never misaligned to the kept ids."""
+        client = HttpVectorClient()
+        calls = []
+        monkeypatch.setattr(
+            "nexus.db.http_vector_client._post",
+            lambda path, body, **kw: calls.append(body) or {"upserted": 1},
+        )
+        # id1 already present → only id2 survives; its embedding must be vecs[1].
+        monkeypatch.setattr(client, "existing_ids", lambda col, ids: {"id1"})
+        vecs = [[0.1], [0.2]]
+        client.upsert_chunks(
+            "col", ["id1", "id2"], ["t1", "t2"], embeddings=vecs, skip_existing=True
+        )
+        assert calls[0]["ids"] == ["id2"]
+        assert calls[0]["embeddings"] == [[0.2]]
+
 
 class TestSearch:
     def test_returns_list_flat(self, monkeypatch):

--- a/tests/db/test_http_vector_client.py
+++ b/tests/db/test_http_vector_client.py
@@ -15,6 +15,29 @@ from nexus.db.http_vector_client import (
 )
 
 
+class TestDataPathConfigYmlFallback:
+    """RDR-166 nexus-v3p0x — the T3 data path (_resolve_endpoint) must consume
+    config.yml service creds so greenfield store/search works after `nx config
+    set service_url/service_token` (no env, no lease)."""
+
+    def test_resolve_endpoint_reads_config_yml_when_env_absent(self, monkeypatch, tmp_path):
+        import nexus.db.http_vector_client as hvc
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        for k in ("NX_SERVICE_URL", "NX_SERVICE_TOKEN"):
+            monkeypatch.delenv(k, raising=False)
+        hvc._invalidate_endpoint()  # clear any cached lease
+        from nexus.config import set_credential
+        set_credential("service_url", "https://api.conexus-nexus.com")
+        set_credential("service_token", "data-tok")
+        try:
+            assert hvc._resolve_endpoint() == (
+                "https://api.conexus-nexus.com", "data-tok",
+            )
+        finally:
+            hvc._invalidate_endpoint()
+
+
 # ── is_vector_service_mode ────────────────────────────────────────────────────
 
 class TestIsVectorServiceMode:

--- a/tests/db/test_service_endpoint_discovery.py
+++ b/tests/db/test_service_endpoint_discovery.py
@@ -243,7 +243,7 @@ def _find_dead_port() -> int:
 class TestCatalogClientResolution:
     def test_catalog_resolve_config_falls_back_to_lease(self):
         _publish_lease(port=4243, token="lease-token")
-        from nexus.catalog.http_catalog_client import _resolve_config
+        from nexus.db.service_endpoint import resolve_service_config as _resolve_config
 
         host, port, token = _resolve_config()
         assert (host, port, token) == ("127.0.0.1", 4243, "lease-token")
@@ -251,14 +251,14 @@ class TestCatalogClientResolution:
     def test_catalog_env_halves_override_individually(self, monkeypatch):
         monkeypatch.setenv("NX_SERVICE_PORT", "9999")
         _publish_lease(port=4243, token="lease-token")
-        from nexus.catalog.http_catalog_client import _resolve_config
+        from nexus.db.service_endpoint import resolve_service_config as _resolve_config
 
         host, port, token = _resolve_config()
         assert port == 9999          # env wins
         assert token == "lease-token"  # lease fills the missing half
 
     def test_catalog_fail_loud_when_neither(self):
-        from nexus.catalog.http_catalog_client import _resolve_config
+        from nexus.db.service_endpoint import resolve_service_config as _resolve_config
 
         with pytest.raises(RuntimeError) as exc_info:
             _resolve_config()

--- a/tests/db/test_shared_service_endpoint.py
+++ b/tests/db/test_shared_service_endpoint.py
@@ -96,6 +96,48 @@ class TestResolveServiceEndpoint:
         assert token == "lease-tok"
 
 
+class TestSchemeAwareEndpoint:
+    """RDR-166 nexus-n3bwh — a managed ``https://…:443`` endpoint must survive.
+
+    ``resolve_service_endpoint`` is the ONE base-url authority the T2 stores,
+    the catalog client, and the migration pre-gate build their URLs from. When
+    ``NX_SERVICE_URL`` names a managed TLS endpoint it MUST be honoured verbatim
+    (scheme + host + port), not flattened to ``http://host:port`` — the old
+    behaviour turned ``https://api.conexus-nexus.com:443`` into
+    ``http://…:443`` and broke every managed-TLS migration leg before the data
+    path (already https-capable) ever ran.
+    """
+
+    def test_service_url_https_used_verbatim(self, monkeypatch):
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "managed-tok")
+        assert resolve_service_endpoint() == (
+            "https://api.conexus-nexus.com:443",
+            "managed-tok",
+        )
+
+    def test_service_url_trailing_slash_stripped(self, monkeypatch):
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443/")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "managed-tok")
+        base_url, _ = resolve_service_endpoint()
+        assert base_url == "https://api.conexus-nexus.com:443"
+
+    def test_service_url_token_falls_back_to_lease(self, monkeypatch):
+        # URL from env, token from the lease — each half independent.
+        _publish_lease(port=4242, token="lease-token")
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        base_url, token = resolve_service_endpoint()
+        assert base_url == "https://api.conexus-nexus.com:443"
+        assert token == "lease-token"
+
+    def test_no_service_url_preserves_http_from_env(self, monkeypatch):
+        # Regression: the local supervisor path is unchanged (http).
+        monkeypatch.setenv("NX_SERVICE_HOST", "127.0.0.1")
+        monkeypatch.setenv("NX_SERVICE_PORT", "8123")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "tok")
+        assert resolve_service_endpoint() == ("http://127.0.0.1:8123", "tok")
+
+
 class TestDiscoverLease:
     def test_absent_lease_returns_none(self):
         assert discover_lease() == (None, None)

--- a/tests/db/test_shared_service_endpoint.py
+++ b/tests/db/test_shared_service_endpoint.py
@@ -153,8 +153,38 @@ class TestSchemeAwareEndpoint:
         # NX_SERVICE_URL with no token (env or lease) → RuntimeError, not a
         # silent token-less request.
         monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
-        with pytest.raises(RuntimeError, match="no NX_SERVICE_TOKEN"):
+        with pytest.raises(RuntimeError, match="no service_token is resolvable"):
             resolve_service_endpoint()
+
+
+class TestConfigYmlFallback:
+    """RDR-166 nexus-v3p0x — greenfield managed onboarding ergonomics.
+
+    `nx config set service_url/service_token` persists to config.yml; the
+    resolver must CONSUME those (no env, no lease) so a greenfield managed user
+    who ran `nx config set` reaches a resolvable endpoint. Env still wins over
+    config.yml (get_credential precedence) — pinned below.
+    """
+
+    def test_config_yml_service_creds_resolve_when_env_absent(self):
+        from nexus.config import set_credential
+
+        # No env, no lease — only config.yml (written via the public surface).
+        set_credential("service_url", "https://api.conexus-nexus.com")
+        set_credential("service_token", "cfg-token")
+        assert resolve_service_endpoint() == (
+            "https://api.conexus-nexus.com",
+            "cfg-token",
+        )
+
+    def test_env_service_url_wins_over_config_yml(self, monkeypatch):
+        from nexus.config import set_credential
+
+        set_credential("service_url", "https://config.example:443")
+        set_credential("service_token", "cfg-token")
+        monkeypatch.setenv("NX_SERVICE_URL", "https://env.example:443")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "env-token")
+        assert resolve_service_endpoint() == ("https://env.example:443", "env-token")
 
 
 class TestRecoverEndpointFromLease:

--- a/tests/db/test_shared_service_endpoint.py
+++ b/tests/db/test_shared_service_endpoint.py
@@ -212,6 +212,19 @@ class TestRecoverEndpointFromLease:
             "lease-token",
         )
 
+    def test_config_yml_service_url_also_suppresses_rebind(self):
+        # nexus-v3p0x: the guard reads service_url via get_credential, so a
+        # config.yml-pinned managed endpoint (no env) is ALSO never rebound to a
+        # discovered local lease — same protection as the env-pinned case.
+        from nexus.config import set_credential
+        from nexus.db.service_endpoint import recover_endpoint_from_lease
+
+        _publish_lease(port=4242, token="lease-token")
+        set_credential("service_url", "https://api.conexus-nexus.com")
+        assert (
+            recover_endpoint_from_lease("https://api.conexus-nexus.com") is None
+        )
+
 
 class TestDiscoverLease:
     def test_absent_lease_returns_none(self):

--- a/tests/db/test_shared_service_endpoint.py
+++ b/tests/db/test_shared_service_endpoint.py
@@ -45,7 +45,7 @@ def _publish_lease(*, host: str = "127.0.0.1", port: int, token: str) -> None:
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
-    for k in ("NX_SERVICE_HOST", "NX_SERVICE_PORT", "NX_SERVICE_TOKEN"):
+    for k in ("NX_SERVICE_HOST", "NX_SERVICE_PORT", "NX_SERVICE_TOKEN", "NX_SERVICE_URL"):
         monkeypatch.delenv(k, raising=False)
     yield
 
@@ -136,6 +136,51 @@ class TestSchemeAwareEndpoint:
         monkeypatch.setenv("NX_SERVICE_PORT", "8123")
         monkeypatch.setenv("NX_SERVICE_TOKEN", "tok")
         assert resolve_service_endpoint() == ("http://127.0.0.1:8123", "tok")
+
+    def test_service_url_wins_over_host_port(self, monkeypatch):
+        # All three set: NX_SERVICE_URL is the authoritative full endpoint and
+        # takes precedence over NX_SERVICE_HOST/PORT (review M2).
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        monkeypatch.setenv("NX_SERVICE_HOST", "127.0.0.1")
+        monkeypatch.setenv("NX_SERVICE_PORT", "8123")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "managed-tok")
+        assert resolve_service_endpoint() == (
+            "https://api.conexus-nexus.com:443",
+            "managed-tok",
+        )
+
+    def test_service_url_set_but_no_token_fails_loud(self, monkeypatch):
+        # NX_SERVICE_URL with no token (env or lease) → RuntimeError, not a
+        # silent token-less request.
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        with pytest.raises(RuntimeError, match="no NX_SERVICE_TOKEN"):
+            resolve_service_endpoint()
+
+
+class TestRecoverEndpointFromLease:
+    """nexus-n3bwh review H1 — lease recovery must never override an explicitly
+    pinned NX_SERVICE_URL with a discovered (always-local-http) lease."""
+
+    def test_pinned_service_url_is_never_rebound_to_lease(self, monkeypatch):
+        from nexus.db.service_endpoint import recover_endpoint_from_lease
+
+        _publish_lease(port=4242, token="lease-token")
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
+        # current endpoint is the managed https one; a local lease exists and
+        # would compare unequal — but the pin must suppress the rebind.
+        assert (
+            recover_endpoint_from_lease("https://api.conexus-nexus.com:443") is None
+        )
+
+    def test_lease_recovery_still_works_without_service_url(self):
+        from nexus.db.service_endpoint import recover_endpoint_from_lease
+
+        _publish_lease(port=4242, token="lease-token")
+        # No NX_SERVICE_URL: a stale current endpoint rebinds to the fresh lease.
+        assert recover_endpoint_from_lease("http://127.0.0.1:9999") == (
+            "http://127.0.0.1:4242",
+            "lease-token",
+        )
 
 
 class TestDiscoverLease:

--- a/tests/migration/test_chroma_read.py
+++ b/tests/migration/test_chroma_read.py
@@ -87,13 +87,29 @@ class TestIterCollectionChunks:
         assert list(iter_collection_chunks(client, "knowledge__etl_empty_test")) == []
 
     def test_embeddings_deliberately_not_fetched(self, client) -> None:
-        """The read leg transfers TEXT, not vectors — the pgvector side
-        re-embeds server-side (RDR-109 cross-model-contamination guard;
+        """The read leg transfers TEXT, not vectors, BY DEFAULT — the pgvector
+        side re-embeds server-side (RDR-109 cross-model-contamination guard;
         decision recorded in the module docstring and on nexus-unp61)."""
         self._seed(client, "knowledge__etl_noemb_test", 2)
         rows = list(iter_collection_chunks(client, "knowledge__etl_noemb_test"))
         assert rows and all("embedding" not in r for r in rows)
         assert all(set(r) == {"id", "document", "metadata"} for r in rows)
+
+    def test_include_embeddings_opt_in_fetches_vectors(self, client) -> None:
+        """nexus-hxry2: the same-model passthrough opts into fetching the stored
+        vectors — each chunk additionally carries ``embedding`` (the verbatim
+        source vector) so the migration can copy it instead of re-embedding."""
+        self._seed(client, "knowledge__etl_emb_test", 3)
+        rows = list(
+            iter_collection_chunks(
+                client, "knowledge__etl_emb_test", include_embeddings=True
+            )
+        )
+        assert len(rows) == 3
+        assert all(set(r) == {"id", "document", "metadata", "embedding"} for r in rows)
+        by_id = {r["id"]: r for r in rows}
+        # the verbatim seeded vector round-trips (seed: [float(i), 1.0, 0.0])
+        assert by_id["id-0002"]["embedding"] == [2.0, 1.0, 0.0]
 
     def test_page_size_over_quota_fails_loud(self, client) -> None:
         """chroma_quotas still governs this leg — the ONE reason it

--- a/tests/migration/test_detection.py
+++ b/tests/migration/test_detection.py
@@ -45,6 +45,7 @@ from nexus.migration.detection import (
     classify_collections,
     classify_model_support,
     cross_model_remappable,
+    render_cost_confirmation,
     render_dry_run_preview,
     voyage_key_available,
     wired_models,
@@ -511,6 +512,77 @@ class TestDryRunPreview:
         assert "[local]" in text
         assert "[cloud]" in text
         assert "rough estimate" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Voyage re-embed COST estimate (nexus-cewad / RDR-166 Gap 4) — only the
+# cross-model→voyage re-embed is billed to the operator key. Byte-for-byte
+# voyage copies (embeddings already exist) and ONNX/bge local re-embeds are
+# NOT billed.
+# ---------------------------------------------------------------------------
+class TestVoyageCostEstimate:
+    def test_onnx_only_is_free(self) -> None:
+        # bge-768 local re-embed runs on the local ONNX runtime — no Voyage bill.
+        local = _FakeChromaClient({BGE_768: 1000})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=False
+        )
+        preview = build_dry_run_preview(report)
+        assert preview.billed_voyage_tokens == 0
+        assert preview.est_voyage_cost_usd == 0.0
+
+    def test_byte_for_byte_voyage_copy_is_not_billed(self) -> None:
+        # A collection ALREADY on a wired voyage model is migrated by copying its
+        # stored embeddings — no re-embed, no Voyage API call, no bill.
+        cloud = _FakeChromaClient({VOYAGE_CTX_1024: 500})
+        report = classify_collections(
+            local_client=None, cloud_client=cloud, voyage_key_present=True
+        )
+        preview = build_dry_run_preview(report)
+        assert preview.billed_voyage_tokens == 0
+        assert preview.est_voyage_cost_usd == 0.0
+
+    def test_cross_model_to_voyage_is_billed_and_scales(self) -> None:
+        # minilm-384 in cloud mode → voyage-context-3 re-embed → BILLED.
+        local = _FakeChromaClient({ONNX_384: 1000})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=True
+        )
+        preview = build_dry_run_preview(report)
+        # 1000 chunks x 512 tokens/chunk, all voyage-targeted.
+        assert preview.billed_voyage_tokens == 1000 * 512
+        # 512_000 tokens x $0.12 / 1_000_000 = $0.06144 (exact constant rate).
+        assert preview.est_voyage_cost_usd == pytest.approx(512_000 / 1_000_000 * 0.12)
+
+    def test_only_voyage_targeted_tokens_are_billed_in_mixed_footprint(self) -> None:
+        # bge byte-for-byte (free) + minilm→voyage (billed): only the latter bills.
+        local = _FakeChromaClient({BGE_768: 9999, ONNX_384: 1000})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=True
+        )
+        preview = build_dry_run_preview(report)
+        assert preview.billed_voyage_tokens == 1000 * 512  # bge excluded
+        assert preview.est_voyage_cost_usd == pytest.approx(512_000 / 1_000_000 * 0.12)
+
+    def test_render_cost_confirmation_none_when_free(self) -> None:
+        local = _FakeChromaClient({BGE_768: 10})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=False
+        )
+        assert render_cost_confirmation(build_dry_run_preview(report)) is None
+
+    def test_render_cost_confirmation_surfaces_cost_and_rerun_footgun(self) -> None:
+        local = _FakeChromaClient({ONNX_384: 1000})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=True
+        )
+        text = render_cost_confirmation(build_dry_run_preview(report))
+        assert text is not None
+        assert "$" in text
+        assert "512,000" in text or "512000" in text  # the billed token volume
+        # the re-run-at-full-cost foot-gun (nexus-1sx01) must be stated.
+        assert "re-run" in text.lower() or "again" in text.lower()
+        assert "operator" in text.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/migration/test_detection.py
+++ b/tests/migration/test_detection.py
@@ -515,10 +515,10 @@ class TestDryRunPreview:
 
 
 # ---------------------------------------------------------------------------
-# Voyage re-embed COST estimate (nexus-cewad / RDR-166 Gap 4) — billed whenever
-# the effective target embedder is a Voyage model: cross-model→voyage AND
-# supported-voyage-1024 (Seam B re-embeds server-side for every chunk, so a
-# same-model voyage migration is billed too). ONNX/bge local re-embeds are free.
+# Voyage re-embed COST estimate (nexus-cewad / RDR-166 Gap 4) — billed only for a
+# cross-model→voyage RE-EMBED. Same-model voyage migrations use vector passthrough
+# (nexus-hxry2: stored vectors copied, not re-embedded) → free. ONNX/bge local
+# re-embeds are free.
 # ---------------------------------------------------------------------------
 class TestVoyageCostEstimate:
     def test_onnx_only_is_free(self) -> None:
@@ -531,17 +531,17 @@ class TestVoyageCostEstimate:
         assert preview.billed_voyage_tokens == 0
         assert preview.est_voyage_cost_usd == 0.0
 
-    def test_supported_voyage_collection_is_billed_server_side_reembed(self) -> None:
-        # Seam B discards stored vectors and re-embeds server-side, so a
-        # collection ALREADY on a voyage model is re-embedded with that same
-        # voyage model on migration → a billed Voyage API call, NOT a free copy.
+    def test_same_model_voyage_is_free_via_passthrough(self) -> None:
+        # A collection ALREADY on a voyage model migrates SAME-model: the stored
+        # vectors are copied verbatim (vector passthrough, nexus-hxry2), not
+        # re-embedded → no Voyage bill.
         cloud = _FakeChromaClient({VOYAGE_CTX_1024: 500})
         report = classify_collections(
             local_client=None, cloud_client=cloud, voyage_key_present=True
         )
         preview = build_dry_run_preview(report)
-        assert preview.billed_voyage_tokens == 500 * 512
-        assert preview.est_voyage_cost_usd == pytest.approx(500 * 512 / 1_000_000 * 0.12)
+        assert preview.billed_voyage_tokens == 0
+        assert preview.est_voyage_cost_usd == 0.0
 
     def test_cross_model_to_voyage_is_billed_and_scales(self) -> None:
         # minilm-384 in cloud mode → voyage-context-3 re-embed → BILLED.

--- a/tests/migration/test_detection.py
+++ b/tests/migration/test_detection.py
@@ -531,16 +531,17 @@ class TestVoyageCostEstimate:
         assert preview.billed_voyage_tokens == 0
         assert preview.est_voyage_cost_usd == 0.0
 
-    def test_byte_for_byte_voyage_copy_is_not_billed(self) -> None:
-        # A collection ALREADY on a wired voyage model is migrated by copying its
-        # stored embeddings — no re-embed, no Voyage API call, no bill.
+    def test_supported_voyage_collection_is_billed_server_side_reembed(self) -> None:
+        # Seam B discards stored vectors and re-embeds server-side, so a
+        # collection ALREADY on a voyage model is re-embedded with that same
+        # voyage model on migration → a billed Voyage API call, NOT a free copy.
         cloud = _FakeChromaClient({VOYAGE_CTX_1024: 500})
         report = classify_collections(
             local_client=None, cloud_client=cloud, voyage_key_present=True
         )
         preview = build_dry_run_preview(report)
-        assert preview.billed_voyage_tokens == 0
-        assert preview.est_voyage_cost_usd == 0.0
+        assert preview.billed_voyage_tokens == 500 * 512
+        assert preview.est_voyage_cost_usd == pytest.approx(500 * 512 / 1_000_000 * 0.12)
 
     def test_cross_model_to_voyage_is_billed_and_scales(self) -> None:
         # minilm-384 in cloud mode → voyage-context-3 re-embed → BILLED.
@@ -563,6 +564,25 @@ class TestVoyageCostEstimate:
         preview = build_dry_run_preview(report)
         assert preview.billed_voyage_tokens == 1000 * 512  # bge excluded
         assert preview.est_voyage_cost_usd == pytest.approx(512_000 / 1_000_000 * 0.12)
+
+    def test_dry_run_render_surfaces_voyage_cost(self) -> None:
+        # The --dry-run pre-flight (render_dry_run_preview) must show the billed
+        # cost, not only the live-run confirm path (code-review H1).
+        local = _FakeChromaClient({ONNX_384: 1000})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=True
+        )
+        text = render_dry_run_preview(build_dry_run_preview(report))
+        assert "Voyage re-embed cost" in text
+        assert "512,000" in text
+
+    def test_dry_run_render_omits_cost_when_free(self) -> None:
+        local = _FakeChromaClient({BGE_768: 10})
+        report = classify_collections(
+            local_client=local, cloud_client=None, voyage_key_present=False
+        )
+        text = render_dry_run_preview(build_dry_run_preview(report))
+        assert "Voyage re-embed cost" not in text
 
     def test_render_cost_confirmation_none_when_free(self) -> None:
         local = _FakeChromaClient({BGE_768: 10})
@@ -782,6 +802,12 @@ class TestMigrateToServiceRun:
             factory, "make_catalog_client_for_migration", lambda **k: object()
         )
         monkeypatch.setattr(driver, "run_guided_upgrade", _fake_run_guided_upgrade)
+        # Isolate the cost-guardrail pre-flight from the real local Chroma store:
+        # these tests exercise result rendering, not the cost gate (covered in
+        # test_migrate_cost_guardrail). A no-data classify → zero billed cost →
+        # no prompt, so --yes below is belt-and-suspenders.
+        monkeypatch.setattr(migrate_cmd, "open_read_legs", lambda p: (None, None))
+        monkeypatch.setattr(migrate_cmd, "_close_quietly", lambda c: None)
         if token is None:
             monkeypatch.delenv("NX_SERVICE_TOKEN", raising=False)
         else:
@@ -793,7 +819,9 @@ class TestMigrateToServiceRun:
         cat.write_text("")
         cli = CliRunner().invoke(
             migrate_cmd.migrate_to_service_cmd,
-            ["--db", str(db), "--catalog-db", str(cat)],
+            # --yes: these exercise post-confirm result rendering, not the cost
+            # gate (which has dedicated coverage in test_migrate_cost_guardrail).
+            ["--db", str(db), "--catalog-db", str(cat), "--yes"],
         )
         return cli, captured
 

--- a/tests/migration/test_detection.py
+++ b/tests/migration/test_detection.py
@@ -542,6 +542,11 @@ class TestVoyageCostEstimate:
         preview = build_dry_run_preview(report)
         assert preview.billed_voyage_tokens == 0
         assert preview.est_voyage_cost_usd == 0.0
+        # …but tracked as passthrough volume so the $0 can be caveated.
+        assert preview.passthrough_voyage_tokens == 500 * 512
+        text = render_dry_run_preview(preview)
+        assert "Voyage passthrough (free)" in text
+        assert "missing its stored vector" in text
 
     def test_cross_model_to_voyage_is_billed_and_scales(self) -> None:
         # minilm-384 in cloud mode → voyage-context-3 re-embed → BILLED.

--- a/tests/migration/test_detection.py
+++ b/tests/migration/test_detection.py
@@ -515,10 +515,10 @@ class TestDryRunPreview:
 
 
 # ---------------------------------------------------------------------------
-# Voyage re-embed COST estimate (nexus-cewad / RDR-166 Gap 4) — only the
-# cross-model→voyage re-embed is billed to the operator key. Byte-for-byte
-# voyage copies (embeddings already exist) and ONNX/bge local re-embeds are
-# NOT billed.
+# Voyage re-embed COST estimate (nexus-cewad / RDR-166 Gap 4) — billed whenever
+# the effective target embedder is a Voyage model: cross-model→voyage AND
+# supported-voyage-1024 (Seam B re-embeds server-side for every chunk, so a
+# same-model voyage migration is billed too). ONNX/bge local re-embeds are free.
 # ---------------------------------------------------------------------------
 class TestVoyageCostEstimate:
     def test_onnx_only_is_free(self) -> None:

--- a/tests/migration/test_pregate.py
+++ b/tests/migration/test_pregate.py
@@ -249,11 +249,11 @@ def test_all_supported_mixed_proceeds() -> None:
 def test_live_source_returns_none_when_service_unreachable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _boom() -> tuple[str, int, str]:
+    def _boom() -> tuple[str, str]:
         raise RuntimeError("no service lease")
 
     monkeypatch.setattr(
-        "nexus.db.service_endpoint.resolve_service_config", _boom
+        "nexus.db.service_endpoint.resolve_service_endpoint", _boom
     )
     assert LiveServiceWiredModels().wired_models() is None
 
@@ -262,14 +262,43 @@ def test_live_source_parses_version_handshake(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "nexus.db.service_endpoint.resolve_service_config",
-        lambda: ("127.0.0.1", 9999, "tok"),
+        "nexus.db.service_endpoint.resolve_service_endpoint",
+        lambda: ("http://127.0.0.1:9999", "tok"),
     )
     monkeypatch.setattr(
         "nexus.daemon.binary_lifecycle.fetch_service_version",
-        lambda host, port: {"embedding_mode": "cloud", "embedding_models": [_ONNX, _VOYAGE]},
+        lambda host, port, scheme="http": {
+            "embedding_mode": "cloud",
+            "embedding_models": [_ONNX, _VOYAGE],
+        },
     )
     assert LiveServiceWiredModels().wired_models() == frozenset({_ONNX, _VOYAGE})
+
+
+def test_live_source_handshake_over_https_managed_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """nexus-n3bwh — a managed https endpoint must hand off scheme=https,
+    host, and the explicit :443 port to the version handshake (not http)."""
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(
+        "nexus.db.service_endpoint.resolve_service_endpoint",
+        lambda: ("https://api.conexus-nexus.com:443", "managed-tok"),
+    )
+
+    def _fetch(host, port, scheme="http"):
+        seen.update(host=host, port=port, scheme=scheme)
+        return {"embedding_mode": "cloud", "embedding_models": [_ONNX, _VOYAGE]}
+
+    monkeypatch.setattr(
+        "nexus.daemon.binary_lifecycle.fetch_service_version", _fetch
+    )
+    assert LiveServiceWiredModels().wired_models() == frozenset({_ONNX, _VOYAGE})
+    assert seen == {
+        "host": "api.conexus-nexus.com",
+        "port": 443,
+        "scheme": "https",
+    }
 
 
 # --------------------------------------------------------------------------

--- a/tests/migration/test_vector_etl.py
+++ b/tests/migration/test_vector_etl.py
@@ -138,9 +138,10 @@ class _FakeCollectionHandle:
 class FakeVectorClient:
     """Hermetic stand-in for ``HttpVectorClient`` (same surface subset).
 
-    ``upsert_chunks`` deliberately has NO ``embeddings`` parameter: the
-    vector-identity decision (a) pins that no source vectors cross the ETL
-    — an implementation that forwards embeddings TypeErrors here.
+    ``upsert_chunks`` accepts the optional ``embeddings`` kwarg and RECORDS it
+    (``upsert_embeddings``): post-nexus-hxry2, source vectors cross the ETL ONLY
+    for the same-model voyage passthrough; every other path leaves it None. Tests
+    assert the recorded value to pin which path ran.
 
     ``count_delta`` simulates a lossy target (service wrote fewer rows than
     sent) so the ETL's post-write count verification can be proven
@@ -152,6 +153,8 @@ class FakeVectorClient:
         self.store: dict[str, dict[str, tuple[str, dict]]] = {}
         # (collection, [ids]) per upsert call, in call order
         self.upsert_calls: list[tuple[str, list[str]]] = []
+        # embeddings arg per upsert call, in call order (None = re-embed path)
+        self.upsert_embeddings: list[list[list[float]] | None] = []
         self._count_delta = count_delta or {}
 
     def upsert_chunks(
@@ -160,9 +163,12 @@ class FakeVectorClient:
         ids: list[str],
         documents: list[str],
         metadatas: list[dict] | None = None,
+        *,
+        embeddings: list[list[float]] | None = None,
     ) -> None:
         metas = metadatas or [{}] * len(ids)
         self.upsert_calls.append((collection, list(ids)))
+        self.upsert_embeddings.append(embeddings)
         col = self.store.setdefault(collection, {})
         for chunk_id, doc, meta in zip(ids, documents, metas):
             col[chunk_id] = (doc, dict(meta or {}))
@@ -205,7 +211,7 @@ class FailingUpsertClient(FakeVectorClient):
         super().__init__()
         self._fail_for = fail_for
 
-    def upsert_chunks(self, collection, ids, documents, metadatas=None):  # type: ignore[override]
+    def upsert_chunks(self, collection, ids, documents, metadatas=None, *, embeddings=None):  # type: ignore[override]
         if collection == self._fail_for:
             raise VectorServiceError(
                 f"POST /v1/vectors/upsert-chunks → HTTP 400: injected for {collection}"
@@ -308,21 +314,94 @@ class TestMigrateCollectionsUnit:
 
         assert [len(batch) for _, batch in fake.upsert_calls] == [3, 3, 1]
 
-    def test_no_embeddings_cross_the_etl(self, source_client) -> None:
-        """Decision (a) pin: the fake's ``upsert_chunks`` has no
-        ``embeddings`` parameter — an ETL forwarding source vectors would
-        TypeError. The target store holds (text, metadata) only."""
-        name = _coll("etlunit-noemb")
+    def test_cross_model_migration_forwards_no_embeddings(self, source_client) -> None:
+        """A cross-model collection (minilm, remapped) re-embeds server-side: NO
+        source vectors cross the ETL (embeddings stay None on every upsert) — the
+        source vectors are the wrong model. Same-model PASSTHROUGH (nexus-hxry2)
+        is the only path that forwards vectors — pinned separately below."""
+        name = _coll("etlunit-noemb")  # minilm-384 default → cross-model remapped
         _seed_source(source_client, name, 3)
         fake = FakeVectorClient()
 
         report = migrate_collections(source_client, fake, leg="local")
 
         assert report.ok is True
-        assert all(
-            isinstance(doc, str) and isinstance(meta, dict)
-            for doc, meta in fake.store[name].values()
+        assert all(emb is None for emb in fake.upsert_embeddings)
+
+    def test_same_model_bge_passthrough_forwards_vectors(self, source_client) -> None:
+        """nexus-hxry2 (LOCAL user): a bge-768 collection migrating same-model
+        copies its stored vectors instead of a wasted local ONNX recompute —
+        the ETL forwards them on the upsert, exactly like the voyage case."""
+        from nexus.migration.vector_etl import _migrate_one
+
+        name = _coll("ptbge", model=_MODEL_768)
+        ids = _seed_source(source_client, name, 3)
+        fake = FakeVectorClient()
+
+        result = _migrate_one(
+            source_client, fake, name, dry_run=False, page=100, target_name=name
         )
+
+        assert result.status == "migrated"
+        assert len(fake.upsert_embeddings) == 1
+        assert fake.upsert_embeddings[0] is not None
+        assert len(fake.upsert_embeddings[0]) == len(ids) == 3
+
+    def test_same_model_voyage_passthrough_forwards_vectors(self, source_client) -> None:
+        """nexus-hxry2: a voyage collection migrating SAME-model (target == name)
+        copies its stored vectors verbatim — the ETL fetches them and forwards
+        them on the upsert (so the service skips the billed re-embed)."""
+        from nexus.migration.vector_etl import _migrate_one
+
+        name = _coll("ptvoyage", model="voyage-context-3")
+        ids = _seed_source(source_client, name, 3)
+        fake = FakeVectorClient()
+
+        result = _migrate_one(
+            source_client, fake, name, dry_run=False, page=100, target_name=name
+        )
+
+        assert result.status == "migrated"
+        # Exactly one batch; its embeddings were forwarded (passthrough), aligned
+        # 1:1 with the ids, NOT None (which would be the re-embed path).
+        assert len(fake.upsert_embeddings) == 1
+        forwarded = fake.upsert_embeddings[0]
+        assert forwarded is not None
+        assert len(forwarded) == len(ids) == 3
+
+    def test_cross_model_to_voyage_does_not_passthrough(self, source_client) -> None:
+        """A cross-model migration (target != name) MUST re-embed, never copy the
+        source vectors — they were produced by the wrong model. embeddings=None."""
+        from nexus.migration.vector_etl import _migrate_one
+
+        source = _coll("xmvoyage", model=_MODEL_384)  # minilm source
+        target = _coll("xmvoyage", model="voyage-context-3")  # remapped target
+        _seed_source(source_client, source, 2)
+        fake = FakeVectorClient()
+
+        result = _migrate_one(
+            source_client, fake, source, dry_run=False, page=100, target_name=target
+        )
+
+        assert result.status == "migrated"
+        assert fake.upsert_calls[0][0] == target  # upserted into the TARGET
+        assert all(emb is None for emb in fake.upsert_embeddings)  # re-embed, no copy
+
+    def test_is_same_model_passthrough_helper(self) -> None:
+        from nexus.migration.vector_etl import _is_same_model_passthrough
+
+        v = "knowledge__acme__voyage-context-3__v1"
+        bge = "knowledge__acme__bge-base-en-v15-768__v1"
+        minilm = "knowledge__acme__minilm-l6-v2-384__v1"
+        # same-model voyage → passthrough (avoids the billed re-embed)
+        assert _is_same_model_passthrough(v, v) is True
+        # same-model bge → passthrough too (avoids a wasted local ONNX recompute)
+        assert _is_same_model_passthrough(bge, bge) is True
+        # cross-model (target differs) → re-embed, never copy wrong-model vectors
+        assert _is_same_model_passthrough(minilm, v) is False
+        # minilm "same-model" → NOT passthrough: the service wires no minilm
+        # embedder, so it must be remapped; copying would leave it unqueryable.
+        assert _is_same_model_passthrough(minilm, minilm) is False
 
     def test_nonconformant_collection_skipped_loud(self, source_client) -> None:
         """A non-four-segment name cannot dim-dispatch

--- a/tests/migration/test_vector_etl.py
+++ b/tests/migration/test_vector_etl.py
@@ -368,6 +368,9 @@ class TestMigrateCollectionsUnit:
         forwarded = fake.upsert_embeddings[0]
         assert forwarded is not None
         assert len(forwarded) == len(ids) == 3
+        # The VALUES round-trip verbatim — _seed_source stored [float(i), 1.0].
+        # (chroma get order is not the seed order, so compare as a set.)
+        assert sorted(map(list, forwarded)) == [[0.0, 1.0], [1.0, 1.0], [2.0, 1.0]]
 
     def test_cross_model_to_voyage_does_not_passthrough(self, source_client) -> None:
         """A cross-model migration (target != name) MUST re-embed, never copy the

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -52,6 +52,27 @@ def test_config_set_writes(runner, fake_home, args, section, key, expected) -> N
     assert _read_config(fake_home)[section][key] == expected
 
 
+def test_config_set_service_url_and_token_persist(runner, fake_home, monkeypatch) -> None:
+    """RDR-166 nexus-v3p0x: the managed-onboarding ergonomics — `nx config set
+    service_url/service_token` persist to config.yml and resolve back (with no
+    env), so a greenfield managed user reaches a usable endpoint."""
+    for k in ("NX_SERVICE_URL", "NX_SERVICE_TOKEN"):
+        monkeypatch.delenv(k, raising=False)
+    assert runner.invoke(
+        main, ["config", "set", "service_url=https://api.conexus-nexus.com"]
+    ).exit_code == 0
+    assert runner.invoke(
+        main, ["config", "set", "service_token", "tok-abc"]
+    ).exit_code == 0
+    cfg = _read_config(fake_home)["credentials"]
+    assert cfg["service_url"] == "https://api.conexus-nexus.com"
+    assert cfg["service_token"] == "tok-abc"
+    # get_credential resolves them from config.yml (no env).
+    from nexus.config import get_credential
+    assert get_credential("service_url") == "https://api.conexus-nexus.com"
+    assert get_credential("service_token") == "tok-abc"
+
+
 def test_config_set_creates_dir(runner, fake_home) -> None:
     assert not _config_path(fake_home).parent.exists()
     runner.invoke(main, ["config", "set", "voyage_api_key=vk-test"])

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -355,6 +355,34 @@ class TestManagedServiceProbeCheck:
         from nexus.health import _check_managed_service_probe
         assert _check_managed_service_probe() == []
 
+    def test_config_yml_service_url_does_probe(self, monkeypatch):
+        # nexus-v3p0x: a greenfield user who set the endpoint via `nx config set
+        # service_url` (NO shell export) must still get the doctor probe — the
+        # guard resolves via get_credential (env, then config.yml), not bare env.
+        monkeypatch.delenv("NX_SERVICE_URL", raising=False)
+        from nexus.config import set_credential
+        set_credential("service_url", "https://api.conexus-nexus.com")
+        from nexus.db import managed_endpoint as me
+
+        seen = {}
+
+        caps = me.ManagedCapabilities(
+            base_url="https://api.conexus-nexus.com", app_version="1.0",
+            embedding_mode="voyage", embedding_models=[],
+            schema_latest_id=None, schema_changeset_count=None,
+        )
+
+        def _capture(**kw):
+            seen["base_url"] = kw.get("base_url")
+            return caps
+
+        monkeypatch.setattr(me, "probe_managed_service", _capture)
+        from nexus.health import _check_managed_service_probe
+        res = _check_managed_service_probe()
+        # It probed (non-empty result) against the config.yml endpoint, not [].
+        assert res != []
+        assert seen["base_url"] == "https://api.conexus-nexus.com"
+
     def test_probes_explicit_url_never_the_public_default(self, monkeypatch):
         # SAFETY INVARIANT: the probe receives the EXPLICIT NX_SERVICE_URL, never
         # base_url=None (which would default to https://api.conexus-nexus.com).


### PR DESCRIPTION
Single PR for the RDR-166 arc — four beads, one linear branch, one CI cycle, one merge. Supersedes #1289, #1290, #1292.

## 1. Scheme-aware service resolution (nexus-n3bwh)
Managed `https://…:443` no longer flattens to `http://…:443`; `resolve_service_endpoint` honors `NX_SERVICE_URL` verbatim, all 13 base-url builders + the pre-gate route through it. T3 data path untouched.

## 2. Estimate-and-confirm Voyage cost guardrail (nexus-cewad)
A cross-model→voyage re-embed bills the operator key; `_run_migration` now gates the billed run behind a confirm (`--yes` to skip; free migrations never prompt). Surfaced on `--dry-run`.

## 3. Same-model vector passthrough (nexus-hxry2)
A same-model migration (voyage→voyage or bge→bge) copies stored vectors instead of re-embedding — managed users skip the Voyage bill, local users skip a full ONNX recompute. Java `upsertChunksWithVectors` stores supplied vectors verbatim (dim-check = contamination guard); Python routes same-model wired-model collections through passthrough.

## 4. Greenfield managed onboarding (nexus-v3p0x)
`nx config set service_url/service_token` → every managed-client resolution site consumes it (env first, then config.yml): resolver, data path, `nx doctor` probe, 401 remedy, token gate. `docs/managed-onboarding.md` documents the journey.

## Review
Each bead passed the stacked gate (code-review-expert + substantive-critic); the critic caught a real Critical on cewad (Seam B billing), hxry2 (minilm passthrough), and v3p0x (incomplete resolution wiring) — all fixed, all re-reviewed to 0 Critical.

## Live validation (against the managed throwaway tenant)
- n3bwh TLS over `https://…:443` — verified.
- WAF 8KB write blocker (surfaced by the E2E, fixed conexus-side) — a >8KB upsert via the nexus client now lands.
- Re-embed + semantic search round-trip — verified.
- Passthrough fidelity (`tokens:0`) is build-gated: needs a new engine-service build carrying this PR's Java (deploy follow-up).

## Scope follow-ups (tracked beads, not silent)
nexus-oabh4 (migration-surface token via get_credential), nexus-x4hdl (persist NX_STORAGE_BACKEND), nexus-6hoa6 (passthrough-live E2E re-run post-deploy).

## Closes
Closes #nexus-n3bwh
Closes #nexus-cewad
Closes #nexus-hxry2
Closes #nexus-v3p0x