### PR TITLE
feat(config): greenfield managed onboarding — nx config service_url/service_token (nexus-v3p0x)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1241,6 +1241,16 @@ nx config init
 |------|-------------|
 | `--show` | Reveal the full value instead of masking |
 
+**Managed-service credentials** (RDR-166 greenfield onboarding):
+
+| Key | Env var | Purpose |
+|-----|---------|---------|
+| `service_url` | `NX_SERVICE_URL` | Managed endpoint base URL (e.g. `https://api.conexus-nexus.com`) |
+| `service_token` | `NX_SERVICE_TOKEN` | Per-tenant bearer token (operator-provisioned) |
+
+Resolution is env first, then `config.yml`, for both. See
+[managed-onboarding.md](managed-onboarding.md) for the full greenfield journey.
+
 ---
 
 ## nx doc

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,6 +149,14 @@ See [docs/container-integration.md](https://github.com/Hellblazer/nexus/blob/mai
 service from a container, and [docs/migration-runbook.md](https://github.com/Hellblazer/nexus/blob/main/docs/migration-runbook.md) for the
 migration details.
 
+### Using the hosted managed service (no local stack)
+
+Prefer not to run the service stack yourself? Point `nx` at the hosted Conexus
+managed service with an operator-provisioned URL + token — no local service, no
+migration. See [docs/managed-onboarding.md](https://github.com/Hellblazer/nexus/blob/main/docs/managed-onboarding.md)
+for the greenfield journey (`nx config set service_url/service_token` → probe →
+first store/search).
+
 ## Update
 
 ```bash

--- a/docs/managed-onboarding.md
+++ b/docs/managed-onboarding.md
@@ -1,0 +1,87 @@
+# Managed-service onboarding (greenfield)
+
+This is the no-prior-install path: point `nx` at the hosted Conexus managed
+service and reach a working search/store state with **no local service stack and
+no migration**. (Already running a local Chroma install you want to move to the
+managed service? That is the migration path, `nx migrate-to-service` — see
+[migration-runbook.md](migration-runbook.md), not this page.)
+
+The managed service is operator-provisioned: you receive a base URL and a
+per-tenant bearer token out of band (the Conexus operator issues them; `nx` does
+not self-serve signup or mint tokens). `nx` is purely a consumer of that pair.
+
+## 1. Configure the endpoint + token
+
+Two equivalent surfaces; `nx config` persists across shells, env vars are
+per-shell and win when both are set.
+
+```bash
+# Persistent (written to ~/.config/nexus/config.yml, mode 0600):
+nx config set service_url   https://api.conexus-nexus.com
+nx config set service_token <your-bearer-token>
+
+# …or per-shell environment (takes precedence over config.yml):
+export NX_SERVICE_URL=https://api.conexus-nexus.com
+export NX_SERVICE_TOKEN=<your-bearer-token>
+```
+
+Resolution order is **env first, then `config.yml`** for both values, so an
+exported `NX_SERVICE_URL` overrides a persisted one. The token is sent as
+`Authorization: Bearer <token>`; treat it as a secret.
+
+Tell `nx` to use the service backend:
+
+```bash
+export NX_STORAGE_BACKEND=service
+```
+
+> The storage-backend selector is env-only today (`config.yml` persistence for
+> it is a tracked follow-up); the endpoint + token above persist via `nx config`.
+> Put the `export` in your shell profile, or run with it set, until that lands.
+
+## 2. Verify the endpoint (fail-loud capability probe)
+
+```bash
+nx doctor          # includes the managed-service probe when service_url is set
+```
+
+The probe runs **only** when a managed endpoint is configured (it never
+default-probes the public endpoint). It hits the unauthenticated `/version`
+handshake and fails loud on:
+
+- **unreachable** (connect / TLS / DNS / timeout) — check `service_url` and connectivity;
+- **incompatible** (non-200, or an `app_version` below the supported floor) — the
+  endpoint may not be a Conexus managed service, or it is unhealthy.
+
+A healthy probe confirms the URL, the TLS path, and that the service version is
+compatible before you write anything. (The `/version` route is unauthenticated
+by contract, so the probe works before the token is accepted; an **invalid or
+expired token** surfaces at the first authenticated call as an actionable
+`HTTP 401`.)
+
+## 3. First store + search
+
+With a healthy probe you are ready. There is no local index to build and no
+migration to run:
+
+```bash
+nx store "my first managed note" --collection knowledge__<owner>__voyage-context-3__v1
+nx search "first note"
+```
+
+Embeddings are computed server-side (the managed service is Voyage-mode), so no
+local embedder or API key is needed on your machine for search/store.
+
+## Token lifetime + rotation
+
+The bearer is opaque and does not expire on a timer; rotation is
+revoke-and-reissue, operator-side. If a call returns `HTTP 401`, re-fetch a
+fresh token from the operator and re-run `nx config set service_token` (or
+re-export `NX_SERVICE_TOKEN`).
+
+## Scope note
+
+One token maps to one tenant. `pgvector`-to-managed cross-deployment migration is
+a documented limitation, not part of this journey (tracker: nexus-wm3t5); this
+page covers greenfield managed onboarding and the Chroma-source migration path
+covers local-to-managed.

--- a/src/nexus/commands/guided_upgrade_cmd.py
+++ b/src/nexus/commands/guided_upgrade_cmd.py
@@ -43,6 +43,16 @@ from nexus.migration.guided_upgrade import (
 
 _log = structlog.get_logger(__name__)
 
+
+def _resolve_service_token() -> str:
+    """The managed service token — env (NX_SERVICE_TOKEN) FIRST, then config.yml
+    (`nx config set service_token`), so a config.yml-only managed user is not
+    told to export what they already configured (RDR-166 nexus-v3p0x)."""
+    from nexus.config import get_credential
+
+    return get_credential("service_token") or ""
+
+
 #: Default health-gate deadline. Generous: a cold service (PG provision +
 #: supervisor spawn + migration apply) can take a while to answer /health.
 _DEFAULT_TIMEOUT_S = 120.0
@@ -204,15 +214,17 @@ def guided_upgrade_cmd(
                 err=True,
             )
             raise SystemExit(1)
-    elif not os.environ.get("NX_SERVICE_TOKEN", "").strip():
+    elif not (_resolve_service_token() or "").strip():
         # --service-url path: the external service's token is the user's to
         # supply. Gate here (not deep inside _run_migration's HTTP layer) so the
         # remedy is a guided-upgrade checkpoint, not an opaque auth error
-        # (substantive-critic Sig-2).
+        # (substantive-critic Sig-2). env FIRST, then config.yml — a config.yml-
+        # only managed user (RDR-166 nexus-v3p0x) is already configured.
         click.echo("", err=True)
         click.echo(
-            f"--service-url {service_url} requires NX_SERVICE_TOKEN to be set "
-            "(the managed service's bearer token) — export it and re-run.",
+            f"--service-url {service_url} requires a service token (the managed "
+            "service's bearer) — set it with `nx config set service_token` or "
+            "export NX_SERVICE_TOKEN, then re-run.",
             err=True,
         )
         raise SystemExit(1)

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -325,6 +325,13 @@ CREDENTIALS: dict[str, str] = {
     "chroma_database":   "CHROMA_DATABASE",
     "voyage_api_key":    "VOYAGE_API_KEY",
     "migrated":          "NX_MIGRATED",
+    # RDR-166 managed onboarding (nexus-v3p0x): the operator-provisioned managed
+    # endpoint + bearer. `nx config set service_url/service_token` persists them
+    # to config.yml; the service resolvers consume them via get_credential, so
+    # the env var still wins and config.yml is the durable fallback — the single
+    # consume point the conexus issuance contract targets.
+    "service_url":       "NX_SERVICE_URL",
+    "service_token":     "NX_SERVICE_TOKEN",
 }
 
 

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -105,13 +105,15 @@ def _resolve_endpoint() -> tuple[str, str]:
             lease_url, lease_token = _lease_cache or (None, None)
         url = url or lease_url
         token = token or lease_token
+        # "credential" = env-or-config.yml (get_credential precedence); the
+        # source here is "configured" vs "lease", not specifically env.
         if env_url is not None and token is lease_token and token is not None:
             _log.debug(
-                "vector_endpoint_mixed_source", url_source="env", token_source="lease"
+                "vector_endpoint_mixed_source", url_source="credential", token_source="lease"
             )
         elif env_token is not None and url is lease_url and url is not None:
             _log.debug(
-                "vector_endpoint_mixed_source", url_source="lease", token_source="env"
+                "vector_endpoint_mixed_source", url_source="lease", token_source="credential"
             )
     if url is None or token is None:
         raise RuntimeError(
@@ -119,7 +121,8 @@ def _resolve_endpoint() -> tuple[str, str]:
             "routes through the nexus-service HTTP API (RDR-155 Phase 4a — "
             "the direct Chroma serving paths are retired). Either start the "
             "supervisor with 'nx daemon service start' (publishes the "
-            "endpoint lease this client auto-discovers), or export "
+            "endpoint lease this client auto-discovers), set the managed "
+            "endpoint with 'nx config set service_url/service_token', or export "
             "NX_SERVICE_URL / NX_SERVICE_TOKEN explicitly."
         )
     return url, token
@@ -238,7 +241,12 @@ def _managed_remedy() -> str | None:
     — callers that classify transient failures by raw type should catch
     ``VectorServiceError`` for the managed path. Local callers are unaffected.
     """
-    base = os.environ.get("NX_SERVICE_URL", "").strip()
+    from nexus.config import get_credential
+
+    # env FIRST, then config.yml — so a config.yml-only greenfield user gets the
+    # actionable managed remedy on a 401/connection error, not a bare error
+    # (RDR-166 nexus-v3p0x).
+    base = (get_credential("service_url") or "").strip()
     if not base:
         return None
     return (

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -84,8 +84,14 @@ def _discover_lease() -> tuple[str | None, str | None]:
 def _resolve_endpoint() -> tuple[str, str]:
     """Return ``(base_url, token)`` per the resolution order above."""
     global _lease_cache
-    env_url = os.environ.get("NX_SERVICE_URL", "").strip().rstrip("/") or None
-    env_token = os.environ.get("NX_SERVICE_TOKEN", "").strip() or None
+    # env FIRST, then the persisted config.yml credential (RDR-166 nexus-v3p0x:
+    # a greenfield managed user who ran `nx config set service_url/service_token`
+    # must reach a resolvable endpoint with no env exported). get_credential
+    # encodes env>config.yml precedence, so an exported env var still wins.
+    from nexus.config import get_credential
+
+    env_url = (get_credential("service_url") or "").strip().rstrip("/") or None
+    env_token = (get_credential("service_token") or "").strip() or None
     url, token = env_url, env_token
     if url is None or token is None:
         with _endpoint_lock:

--- a/src/nexus/db/managed_endpoint.py
+++ b/src/nexus/db/managed_endpoint.py
@@ -103,8 +103,13 @@ class ManagedCapabilities:
 def resolve_managed_endpoint(*, require_token: bool = True) -> tuple[str, str | None]:
     """Return ``(base_url, token)`` for the managed service.
 
-    ``base_url`` is ``NX_SERVICE_URL`` (trailing slash stripped) or
-    :data:`DEFAULT_MANAGED_SERVICE_URL`. ``token`` is ``NX_SERVICE_TOKEN``.
+    ``base_url`` is the resolved ``service_url`` (trailing slash stripped) or
+    :data:`DEFAULT_MANAGED_SERVICE_URL`. ``token`` is the resolved
+    ``service_token``. Both resolve via :func:`nexus.config.get_credential` —
+    env (``NX_SERVICE_URL`` / ``NX_SERVICE_TOKEN``) FIRST, then the persisted
+    ``config.yml`` credential a greenfield user set with ``nx config set``
+    (RDR-166 nexus-v3p0x). Without this the probe would ignore a config.yml-only
+    user's endpoint and silently target the default.
 
     Fails loud (:class:`ManagedServiceIncompatible`) when ``require_token`` and no
     token is configured — a cloud-mode client with no bearer cannot call any
@@ -112,8 +117,10 @@ def resolve_managed_endpoint(*, require_token: bool = True) -> tuple[str, str | 
     opaque 401 later. The unauthenticated ``/version`` probe itself does not need
     the token; ``require_token=False`` supports probe-only callers.
     """
-    base = os.environ.get("NX_SERVICE_URL", "").strip().rstrip("/") or DEFAULT_MANAGED_SERVICE_URL
-    token = os.environ.get("NX_SERVICE_TOKEN", "").strip() or None
+    from nexus.config import get_credential
+
+    base = (get_credential("service_url") or "").strip().rstrip("/") or DEFAULT_MANAGED_SERVICE_URL
+    token = (get_credential("service_token") or "").strip() or None
     if require_token and not token:
         raise ManagedServiceIncompatible(
             "cloud mode is configured but NX_SERVICE_TOKEN is not set — the "

--- a/src/nexus/db/service_endpoint.py
+++ b/src/nexus/db/service_endpoint.py
@@ -94,7 +94,9 @@ def recover_endpoint_from_lease(current_base_url: str) -> tuple[str, str | None]
     # https managed base_url would compare unequal to the http lease and rebind
     # every time, routing managed traffic to the wrong (local) service. Lease
     # recovery is for the lease-discovered path only.
-    if os.environ.get("NX_SERVICE_URL", "").strip():
+    from nexus.config import get_credential
+
+    if (get_credential("service_url") or "").strip():
         return None
     lease_url, lease_token = discover_lease()
     if lease_url is not None and lease_url.rstrip("/") != (current_base_url or "").rstrip("/"):
@@ -161,27 +163,33 @@ def resolve_service_endpoint() -> tuple[str, str]:
     here so a managed TLS endpoint survives end-to-end. Resolution order mirrors
     the T3 data path (:func:`nexus.db.http_vector_client._resolve_endpoint`):
 
-      1. ``NX_SERVICE_URL`` — the authoritative FULL endpoint, used VERBATIM
-         (scheme + host + port preserved). This is the ONLY scheme source:
-         ``https://api.conexus-nexus.com:443`` stays ``https``; flattening it to
-         ``http://…:443`` (the pre-RDR-166 bug, nexus-n3bwh) broke every managed
-         migration leg. The token half still falls back to lease/env independently.
+      1. ``service_url`` — the authoritative FULL endpoint, used VERBATIM
+         (scheme + host + port preserved). Resolved via
+         :func:`nexus.config.get_credential`, i.e. ``NX_SERVICE_URL`` env FIRST,
+         then the persisted ``config.yml`` credential a greenfield user set with
+         ``nx config set service_url`` (RDR-166 nexus-v3p0x). This is the ONLY
+         scheme source: ``https://api.conexus-nexus.com:443`` stays ``https``;
+         flattening it to ``http://…:443`` (the pre-RDR-166 bug, nexus-n3bwh)
+         broke every managed migration leg. The token half (``service_token``)
+         resolves the same way, then falls back to the lease independently.
       2. Otherwise ``http://{host}:{port}`` from :func:`resolve_service_config`
          (env halves → lease → fail loud) — the local-supervisor path, always
          ``http``.
     """
-    env_url = os.environ.get("NX_SERVICE_URL", "").strip().rstrip("/") or None
-    if env_url is not None:
-        env_token = os.environ.get("NX_SERVICE_TOKEN", "").strip() or None
-        token = env_token
+    from nexus.config import get_credential
+
+    url = (get_credential("service_url") or "").strip().rstrip("/") or None
+    if url is not None:
+        token = (get_credential("service_token") or "").strip() or None
         if token is None:
             _, token = discover_lease()
         if not token:
             raise RuntimeError(
-                "NX_SERVICE_URL is set but no NX_SERVICE_TOKEN is resolvable "
-                "(neither env nor supervisor lease): export NX_SERVICE_TOKEN "
-                "(the service's bearer token) and re-run."
+                "service_url is set but no service_token is resolvable (neither "
+                "NX_SERVICE_TOKEN env, config.yml, nor supervisor lease): set it "
+                "with `nx config set service_token <bearer>` (or export "
+                "NX_SERVICE_TOKEN) and re-run."
             )
-        return env_url, token
+        return url, token
     host, port, token = resolve_service_config()
     return f"http://{host}:{port}", token

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -468,11 +468,15 @@ def _check_managed_service_probe() -> list[HealthResult]:
     warn only — reachability fatals are ``_check_vector_service``'s domain, so this
     surfaces the version/remedy signal without a duplicate fatal on a down service.
     """
-    import os
+    from nexus.config import get_credential
 
-    base = os.environ.get("NX_SERVICE_URL", "").strip()
+    # env (NX_SERVICE_URL) FIRST, then config.yml — so a greenfield user who set
+    # the endpoint with `nx config set service_url` (no shell export) still gets
+    # the probe (RDR-166 nexus-v3p0x). Empty in BOTH → no explicit managed
+    # endpoint, never default-probe the public one.
+    base = (get_credential("service_url") or "").strip()
     if not base:
-        return []  # no explicit managed endpoint — never default-probe the public one
+        return []
 
     from nexus.db.managed_endpoint import (
         ManagedServiceError,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -457,6 +457,12 @@ _MODE_LINT_EXCLUDE_FILES: frozenset[str] = frozenset({
     # explicitly via the ``voyage_key_present`` argument, never the ambient
     # cloud_mode fixture (the classifier is a pure deployment-mode function).
     "test_detection.py",
+    # RDR-166 nexus-hxry2 vector-ETL: voyage tokens are collection-NAME segments
+    # driving same-model passthrough vs cross-model routing (_is_same_model_
+    # passthrough / _migrate_one). The ETL never embeds — the server does — so
+    # these tests are deployment-mode-agnostic; they pin behavior via explicit
+    # target_name / collection names, never the ambient cloud_mode fixture.
+    "test_vector_etl.py",
     # RDR-159 P1d pre-gate + P1c quiesce: voyage tokens are collection-NAME /
     # wired-model-set fixtures driving the support gate and the count-mismatch
     # attribution message; mode is pinned explicitly via the injected

--- a/tests/db/test_http_vector_client.py
+++ b/tests/db/test_http_vector_client.py
@@ -15,6 +15,29 @@ from nexus.db.http_vector_client import (
 )
 
 
+class TestDataPathConfigYmlFallback:
+    """RDR-166 nexus-v3p0x — the T3 data path (_resolve_endpoint) must consume
+    config.yml service creds so greenfield store/search works after `nx config
+    set service_url/service_token` (no env, no lease)."""
+
+    def test_resolve_endpoint_reads_config_yml_when_env_absent(self, monkeypatch, tmp_path):
+        import nexus.db.http_vector_client as hvc
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        for k in ("NX_SERVICE_URL", "NX_SERVICE_TOKEN"):
+            monkeypatch.delenv(k, raising=False)
+        hvc._invalidate_endpoint()  # clear any cached lease
+        from nexus.config import set_credential
+        set_credential("service_url", "https://api.conexus-nexus.com")
+        set_credential("service_token", "data-tok")
+        try:
+            assert hvc._resolve_endpoint() == (
+                "https://api.conexus-nexus.com", "data-tok",
+            )
+        finally:
+            hvc._invalidate_endpoint()
+
+
 # ── is_vector_service_mode ────────────────────────────────────────────────────
 
 class TestIsVectorServiceMode:

--- a/tests/db/test_shared_service_endpoint.py
+++ b/tests/db/test_shared_service_endpoint.py
@@ -153,8 +153,38 @@ class TestSchemeAwareEndpoint:
         # NX_SERVICE_URL with no token (env or lease) → RuntimeError, not a
         # silent token-less request.
         monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com:443")
-        with pytest.raises(RuntimeError, match="no NX_SERVICE_TOKEN"):
+        with pytest.raises(RuntimeError, match="no service_token is resolvable"):
             resolve_service_endpoint()
+
+
+class TestConfigYmlFallback:
+    """RDR-166 nexus-v3p0x — greenfield managed onboarding ergonomics.
+
+    `nx config set service_url/service_token` persists to config.yml; the
+    resolver must CONSUME those (no env, no lease) so a greenfield managed user
+    who ran `nx config set` reaches a resolvable endpoint. Env still wins over
+    config.yml (get_credential precedence) — pinned below.
+    """
+
+    def test_config_yml_service_creds_resolve_when_env_absent(self):
+        from nexus.config import set_credential
+
+        # No env, no lease — only config.yml (written via the public surface).
+        set_credential("service_url", "https://api.conexus-nexus.com")
+        set_credential("service_token", "cfg-token")
+        assert resolve_service_endpoint() == (
+            "https://api.conexus-nexus.com",
+            "cfg-token",
+        )
+
+    def test_env_service_url_wins_over_config_yml(self, monkeypatch):
+        from nexus.config import set_credential
+
+        set_credential("service_url", "https://config.example:443")
+        set_credential("service_token", "cfg-token")
+        monkeypatch.setenv("NX_SERVICE_URL", "https://env.example:443")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "env-token")
+        assert resolve_service_endpoint() == ("https://env.example:443", "env-token")
 
 
 class TestRecoverEndpointFromLease:

--- a/tests/db/test_shared_service_endpoint.py
+++ b/tests/db/test_shared_service_endpoint.py
@@ -212,6 +212,19 @@ class TestRecoverEndpointFromLease:
             "lease-token",
         )
 
+    def test_config_yml_service_url_also_suppresses_rebind(self):
+        # nexus-v3p0x: the guard reads service_url via get_credential, so a
+        # config.yml-pinned managed endpoint (no env) is ALSO never rebound to a
+        # discovered local lease — same protection as the env-pinned case.
+        from nexus.config import set_credential
+        from nexus.db.service_endpoint import recover_endpoint_from_lease
+
+        _publish_lease(port=4242, token="lease-token")
+        set_credential("service_url", "https://api.conexus-nexus.com")
+        assert (
+            recover_endpoint_from_lease("https://api.conexus-nexus.com") is None
+        )
+
 
 class TestDiscoverLease:
     def test_absent_lease_returns_none(self):

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -52,6 +52,27 @@ def test_config_set_writes(runner, fake_home, args, section, key, expected) -> N
     assert _read_config(fake_home)[section][key] == expected
 
 
+def test_config_set_service_url_and_token_persist(runner, fake_home, monkeypatch) -> None:
+    """RDR-166 nexus-v3p0x: the managed-onboarding ergonomics — `nx config set
+    service_url/service_token` persist to config.yml and resolve back (with no
+    env), so a greenfield managed user reaches a usable endpoint."""
+    for k in ("NX_SERVICE_URL", "NX_SERVICE_TOKEN"):
+        monkeypatch.delenv(k, raising=False)
+    assert runner.invoke(
+        main, ["config", "set", "service_url=https://api.conexus-nexus.com"]
+    ).exit_code == 0
+    assert runner.invoke(
+        main, ["config", "set", "service_token", "tok-abc"]
+    ).exit_code == 0
+    cfg = _read_config(fake_home)["credentials"]
+    assert cfg["service_url"] == "https://api.conexus-nexus.com"
+    assert cfg["service_token"] == "tok-abc"
+    # get_credential resolves them from config.yml (no env).
+    from nexus.config import get_credential
+    assert get_credential("service_url") == "https://api.conexus-nexus.com"
+    assert get_credential("service_token") == "tok-abc"
+
+
 def test_config_set_creates_dir(runner, fake_home) -> None:
     assert not _config_path(fake_home).parent.exists()
     runner.invoke(main, ["config", "set", "voyage_api_key=vk-test"])

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -355,6 +355,34 @@ class TestManagedServiceProbeCheck:
         from nexus.health import _check_managed_service_probe
         assert _check_managed_service_probe() == []
 
+    def test_config_yml_service_url_does_probe(self, monkeypatch):
+        # nexus-v3p0x: a greenfield user who set the endpoint via `nx config set
+        # service_url` (NO shell export) must still get the doctor probe — the
+        # guard resolves via get_credential (env, then config.yml), not bare env.
+        monkeypatch.delenv("NX_SERVICE_URL", raising=False)
+        from nexus.config import set_credential
+        set_credential("service_url", "https://api.conexus-nexus.com")
+        from nexus.db import managed_endpoint as me
+
+        seen = {}
+
+        caps = me.ManagedCapabilities(
+            base_url="https://api.conexus-nexus.com", app_version="1.0",
+            embedding_mode="voyage", embedding_models=[],
+            schema_latest_id=None, schema_changeset_count=None,
+        )
+
+        def _capture(**kw):
+            seen["base_url"] = kw.get("base_url")
+            return caps
+
+        monkeypatch.setattr(me, "probe_managed_service", _capture)
+        from nexus.health import _check_managed_service_probe
+        res = _check_managed_service_probe()
+        # It probed (non-empty result) against the config.yml endpoint, not [].
+        assert res != []
+        assert seen["base_url"] == "https://api.conexus-nexus.com"
+
     def test_probes_explicit_url_never_the_public_default(self, monkeypatch):
         # SAFETY INVARIANT: the probe receives the EXPLICIT NX_SERVICE_URL, never
         # base_url=None (which would default to https://api.conexus-nexus.com).


### PR DESCRIPTION
RDR-166 Phase 2. A greenfield user points `nx` at the hosted managed service with an operator-provisioned `(url, token)` — **no local stack, no migration**. Stacks on #1291 (it uses the n3bwh scheme-aware resolver); retarget to `develop` once #1291 merges.

## What
- Register `service_url`→`NX_SERVICE_URL` and `service_token`→`NX_SERVICE_TOKEN` credentials, so `nx config set/get` persist them to `config.yml` (0600).
- **Every managed-client resolution site** now resolves via `get_credential` (env FIRST, then config.yml) so a config.yml-only user (no shell export) is fully served: `resolve_service_endpoint`, the T3 data path `_resolve_endpoint`, `recover_endpoint_from_lease`, `resolve_managed_endpoint`, `health._check_managed_service_probe` (the `nx doctor` step), `_managed_remedy` (401 guidance), and the guided-upgrade token gate.
- `docs/managed-onboarding.md`: the greenfield journey (config set → probe → first store/search), linked from getting-started + cli-reference.
- The `NX_STORAGE_BACKEND` selector stays env-only (documented, not silently claimed).

## Stacked review (both clean)
- **substantive-critic** caught a **Critical**: my first pass migrated only the two resolvers, leaving four onboarding-path sites on bare `os.environ` — so a config.yml-only user got no `nx doctor` probe and no 401 remedy. **Fixed**; re-review confirmed 0 Critical and the journey fully reachable. **code-review-expert** flagged the same as High + test-isolation items — all addressed.

## Scope deferrals (tracked, not silent)
- **nexus-oabh4** — managed token/url via `get_credential` across the MIGRATION command surface (migrate_cmd/orchestrator/storage_cmd); out of greenfield scope.
- **nexus-x4hdl** — persist `NX_STORAGE_BACKEND` via config.yml.

## Tests
config.yml-fallback resolution (control + T3 data path), env-wins precedence, `nx config` round-trip, `nx doctor` probes a config.yml-only endpoint, lease-recovery suppressed for a config.yml-pinned endpoint. mode-lint green; 1184 in the affected sweep.

## Note
The live first store/search validation is the WAF-blocked path (nexus-6hoa6); this PR's first-run flow is validated against fixtures (config → resolve → probe). The managed-endpoint **write** blocker is relayed to conexus (AWS WAF 8KB body limit).

## Closes
Closes #nexus-v3p0x