### PR TITLE
ci(engine-service): serialize mac-arm64 native build (max-parallel 2)

### DIFF
--- a/.github/workflows/engine-service-release.yml
+++ b/.github/workflows/engine-service-release.yml
@@ -87,6 +87,12 @@ jobs:
     timeout-minutes: 40
     strategy:
       fail-fast: false
+      # max-parallel: 2 — the two linux builds run in parallel (they schedule
+      # cleanly), and mac-arm64 (ordered last) only starts once a linux slot
+      # frees, so it no longer competes for a runner up front. The scarce macOS
+      # runner was getting starved-then-slammed when all three launched at once;
+      # deferring it keeps linux concurrency while giving mac an uncontended slot.
+      max-parallel: 2
       matrix:
         target:
           - { arch: linux-amd64, runner: ubuntu-latest,    smoke: true }


### PR DESCRIPTION
## What
The engine-service native release matrix launched all three builds (linux-amd64, linux-arm64, mac-arm64) at once. The scarce GH macOS runner got starved-then-slammed competing for a slot up front.

## Fix
`max-parallel: 2` on the `build-publish` matrix. The two linux builds (ordered first) run in parallel as before; mac-arm64 (ordered last) only starts once a linux slot frees — an uncontended macOS runner. No build-logic change; purely scheduling.

Alternative if you'd rather fully serialize: `max-parallel: 1`. This PR keeps linux parallelism per the observation that the linux pair schedules fine together.

Observed during the engine-service-v0.1.8 cut.