### PR TITLE
feat(cli): first-class nx uninstall — service-aware + managed-only teardown (RDR-165 P3)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1733,6 +1733,35 @@ nx upgrade --auto                 # Quiet mode for hook invocation (T2 only, exi
 
 ---
 
+## nx uninstall
+
+First-class agent teardown (RDR-165). Cleanly removes nexus, auto-detecting and
+handling BOTH install shapes — each branch is a no-op when its target is absent:
+
+- **Local service**: stops the engine-service + Postgres stack
+  (`nx daemon service stop --with-pg`), stops the T2 daemon, removes the OS
+  autostart unit, and clears the first-run marker.
+- **Managed-only client**: clears the managed endpoint config
+  (`service_url` + `service_token`) from `config.yml`. Skips service-stop (no
+  local service) and never touches the remote tenant's data.
+
+```
+nx uninstall                  # DRY RUN (default): preview what would be removed
+nx uninstall --yes            # Perform the teardown
+nx uninstall --yes --remove-data   # ALSO wipe the local data dir (notes + index)
+```
+
+| Flag | Description |
+|------|-------------|
+| `--yes` | Perform the teardown. Without it, `nx uninstall` only previews (dry-run default). |
+| `--remove-data` | Also wipe the local nexus data dir (notes + search index). Irreversible; only acts with `--yes`. **Does NOT touch a managed/remote tenant's data.** |
+
+**Managed env override:** if `NX_SERVICE_URL` / `NX_SERVICE_TOKEN` are exported in
+your shell (not just `config.yml`), `nx uninstall` clears `config.yml` and warns
+you to `unset` the shell export — it cannot unset the parent shell itself.
+
+---
+
 ## nx console
 
 Embedded web UI for monitoring agentic Nexus activity.

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -42,6 +42,7 @@ from nexus.commands.command_context import command_context
 from nexus.commands.console import console
 from nexus.commands.context_cmd import context
 from nexus.commands.config_cmd import config_group
+from nexus.commands.uninstall import uninstall_cmd
 from nexus.commands.daemon import daemon_group
 from nexus.commands.doc import doc
 from nexus.commands.doctor import doctor_cmd
@@ -127,6 +128,7 @@ main.add_command(tenant, name="tenant")
 main.add_command(tier_status_cmd, name="tier-status")
 main.add_command(aspects_group, name="aspects")
 main.add_command(upgrade)
+main.add_command(uninstall_cmd, name="uninstall")
 
 
 if __name__ == "__main__":

--- a/src/nexus/commands/uninstall.py
+++ b/src/nexus/commands/uninstall.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""``nx uninstall`` — first-class agent teardown (RDR-165 Phase 3).
+
+The complete teardown a user needs to cleanly remove nexus, covering BOTH
+install shapes (auto-detected; each branch is a no-op when its target is absent):
+
+* **Local service** (eu4u4): stop the engine-service + Postgres stack, stop the
+  T2 daemon, remove the OS autostart unit, clear the first-run marker, and
+  (only with ``--remove-data``) wipe the local data dir. Orchestrated through
+  ``installer.uninstall_daemon`` which shells the existing
+  ``nx daemon service stop --with-pg`` (RDR-149: no duplicated lifecycle).
+* **Managed-only client** (wigzi): clear the managed endpoint + token from
+  ``config.yml`` and reset the capability-probe cache. SKIPs service-stop (no
+  local service) and SKIPs data-wipe (the data lives in the remote tenant).
+
+``nx uninstall`` is DRY-RUN by default — it prints what would be removed and
+touches nothing; pass ``--yes`` to perform the teardown (mirrors the
+``daemon_uninstall`` MCP tool's ``confirm`` semantics).
+"""
+from __future__ import annotations
+
+import os
+
+import click
+
+from nexus.config import get_credential, unset_credential
+from nexus.daemon.installer import uninstall_daemon
+
+#: The managed-client credentials cleared by the managed-only teardown branch.
+_MANAGED_CREDENTIALS = ("service_url", "service_token")
+
+
+def _teardown_managed(*, confirm: bool) -> tuple[list[str], list[str]]:
+    """Clear the managed endpoint config (wigzi). Returns (lines, warnings).
+
+    Idempotent: a no-op (empty lines/warnings) when no managed endpoint is
+    configured. On ``confirm`` it removes ``service_url``/``service_token`` from
+    config.yml; on dry-run it only reports. A SHELL-env override
+    (``NX_SERVICE_URL``/``NX_SERVICE_TOKEN``) cannot be unset from the parent
+    shell — that is surfaced as a loud warning, never silently "cleared".
+    SKIPs service-stop (no local service) and never touches the remote tenant.
+    """
+    if not (get_credential("service_url") or "").strip():
+        return [], []  # no managed endpoint configured — nothing to tear down
+
+    lines: list[str] = []
+    warnings: list[str] = []
+    if confirm:
+        cleared = [name for name in _MANAGED_CREDENTIALS if unset_credential(name)]
+        lines.append(
+            "Managed client: cleared the managed endpoint config from config.yml"
+            + (f" ({', '.join(cleared)})." if cleared else " (nothing persisted).")
+        )
+    else:
+        lines.append(
+            "Managed client: would clear the managed endpoint config "
+            "(service_url + service_token) from config.yml."
+        )
+    # Honesty guard: a shell-exported env var overrides config.yml and survives.
+    env_overrides = [e for e in ("NX_SERVICE_URL", "NX_SERVICE_TOKEN") if os.environ.get(e, "").strip()]
+    if env_overrides:
+        warnings.append(
+            f"{' and '.join(env_overrides)} {'is' if len(env_overrides) == 1 else 'are'} set in "
+            "your shell environment and override config.yml — `nx` cannot unset the parent "
+            f"shell; unset {'it' if len(env_overrides) == 1 else 'them'} manually "
+            f"(e.g. `unset {' '.join(env_overrides)}`)."
+        )
+    return lines, warnings
+
+
+@click.command("uninstall")
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Perform the teardown. Without this, uninstall only PREVIEWS what would "
+    "be removed (dry-run default).",
+)
+@click.option(
+    "--remove-data",
+    "remove_data",
+    is_flag=True,
+    default=False,
+    help="ALSO wipe the local nexus data dir (notes + search index). Irreversible; "
+    "only acts with --yes. Does NOT touch a managed (remote) tenant's data.",
+)
+def uninstall_cmd(assume_yes: bool, remove_data: bool) -> None:
+    """Cleanly remove the local nexus service stack and/or managed client config.
+
+    Dry-run by default: shows what would be removed. Use --yes to proceed.
+    """
+    # Managed-only branch (wigzi) — clear the managed endpoint config if present.
+    managed_lines, managed_warnings = _teardown_managed(confirm=assume_yes)
+    for line in managed_lines:
+        click.echo(line)
+
+    # Local branch (eu4u4) — stop the service stack + daemon, remove autostart +
+    # marker, optionally wipe local data. Idempotent: no-op when no local service.
+    report = uninstall_daemon(confirm=assume_yes, remove_data=remove_data)
+    click.echo(report.message)
+
+    for w in (*managed_warnings, *report.warnings):
+        click.echo(f"  warning: {w}", err=True)
+    if not assume_yes:
+        click.echo("\nDry run — nothing was removed. Re-run with --yes to proceed.")

--- a/src/nexus/commands/uninstall.py
+++ b/src/nexus/commands/uninstall.py
@@ -31,6 +31,31 @@ from nexus.daemon.installer import uninstall_daemon
 _MANAGED_CREDENTIALS = ("service_url", "service_token")
 
 
+def _local_service_present() -> bool:
+    """True when a LOCAL nexus service/daemon footprint exists.
+
+    The design's local-presence signals (any one → run the local teardown):
+    the T2 autostart unit, an installed service-binary dir, or a discoverable
+    ``storage_service`` lease. When NONE are present (a managed-only or fresh
+    install) the local branch is skipped entirely — so a managed-only user gets
+    no spurious "service stop … not running" noise (review Sig-1), and no stop
+    subprocess is ever spawned (review Sig-2).
+    """
+    from nexus.commands import daemon as _daemon
+    from nexus.config import nexus_config_dir
+    from nexus.db.service_endpoint import discover_lease
+
+    try:
+        if (_daemon._autostart_install_dir() / _daemon._autostart_filename_t2()).exists():
+            return True
+    except Exception:  # noqa: BLE001 — detection is best-effort; absence is the safe default
+        pass
+    if (nexus_config_dir() / "service").exists():
+        return True
+    url, _ = discover_lease()
+    return url is not None
+
+
 def _teardown_managed(*, confirm: bool) -> tuple[list[str], list[str]]:
     """Clear the managed endpoint config (wigzi). Returns (lines, warnings).
 
@@ -97,11 +122,29 @@ def uninstall_cmd(assume_yes: bool, remove_data: bool) -> None:
         click.echo(line)
 
     # Local branch (eu4u4) — stop the service stack + daemon, remove autostart +
-    # marker, optionally wipe local data. Idempotent: no-op when no local service.
-    report = uninstall_daemon(confirm=assume_yes, remove_data=remove_data)
-    click.echo(report.message)
+    # marker, optionally wipe local data. GATED on local presence (auto-detect):
+    # skipped entirely for a managed-only / fresh install so no spurious
+    # "not running" noise and no stop subprocess fires (review Sig-1/Sig-2).
+    warnings: tuple[str, ...] = managed_warnings
+    if _local_service_present():
+        report = uninstall_daemon(confirm=assume_yes, remove_data=remove_data)
+        click.echo(report.message)
+        warnings = (*managed_warnings, *report.warnings)
+    else:
+        click.echo(
+            "Local service: none detected — skipping local teardown "
+            "(service stop / autostart / marker / data)."
+        )
+        if remove_data:
+            click.echo(
+                "  note: --remove-data has no local data dir to wipe for a "
+                "managed-only client; the remote tenant's data is untouched."
+            )
 
-    for w in (*managed_warnings, *report.warnings):
+    if not managed_lines and not _local_service_present():
+        click.echo("Nothing to uninstall — no managed config and no local service found.")
+
+    for w in warnings:
         click.echo(f"  warning: {w}", err=True)
     if not assume_yes:
         click.echo("\nDry run — nothing was removed. Re-run with --yes to proceed.")

--- a/src/nexus/commands/uninstall.py
+++ b/src/nexus/commands/uninstall.py
@@ -125,8 +125,11 @@ def uninstall_cmd(assume_yes: bool, remove_data: bool) -> None:
     # marker, optionally wipe local data. GATED on local presence (auto-detect):
     # skipped entirely for a managed-only / fresh install so no spurious
     # "not running" noise and no stop subprocess fires (review Sig-1/Sig-2).
+    # Probe local presence ONCE — a second call could disagree under a concurrent
+    # install (lease appears mid-run) and would re-pay the stat/SQLite cost.
+    local_present = _local_service_present()
     warnings: tuple[str, ...] = managed_warnings
-    if _local_service_present():
+    if local_present:
         report = uninstall_daemon(confirm=assume_yes, remove_data=remove_data)
         click.echo(report.message)
         warnings = (*managed_warnings, *report.warnings)
@@ -141,7 +144,7 @@ def uninstall_cmd(assume_yes: bool, remove_data: bool) -> None:
                 "managed-only client; the remote tenant's data is untouched."
             )
 
-    if not managed_lines and not _local_service_present():
+    if not managed_lines and not local_present:
         click.echo("Nothing to uninstall — no managed config and no local service found.")
 
     for w in warnings:

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -786,6 +786,52 @@ def set_credential(name: str, value: str) -> None:
             raise
 
 
+def unset_credential(name: str) -> bool:
+    """Remove credential *name* from ``~/.config/nexus/config.yml``.
+
+    The teardown counterpart of :func:`set_credential` (RDR-165 nexus-a11ge —
+    the managed-config clear in ``nx uninstall``). Returns ``True`` when the key
+    was present and removed, ``False`` when it was already absent (idempotent —
+    a teardown must not error on an already-clean config). Raises ``ValueError``
+    for an unknown credential name, mirroring :func:`set_credential`.
+
+    NOTE: this clears only the persisted ``config.yml`` value. An environment
+    variable (e.g. ``NX_SERVICE_TOKEN``) overrides config.yml in
+    :func:`get_credential` and CANNOT be unset from the parent shell here — the
+    caller is responsible for warning the user to unset the export.
+    """
+    if name not in CREDENTIALS:
+        known = ", ".join(sorted(CREDENTIALS))
+        raise ValueError(f"Unknown credential '{name}'. Known: {known}")
+    path = _global_config_path()
+    if not path.exists():
+        return False
+    with _config_lock:
+        data: dict[str, Any] = yaml.safe_load(path.read_text()) or {}
+        creds = data.get("credentials")
+        if not isinstance(creds, dict) or name not in creds:
+            return False
+        del creds[name]
+        if not creds:
+            data.pop("credentials", None)
+        content = yaml.dump(data, default_flow_style=False)
+        # Atomic write: unique temp file → os.replace() (0o600), mirroring
+        # set_credential so a torn write never leaves a half-cleared config.
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=path.parent, prefix=".config_")
+        try:
+            with os.fdopen(tmp_fd, "w") as fh:
+                fh.write(content)
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass  # intentional: cleanup after re-raise
+            raise
+    return True
+
+
 def load_config(repo_root: Path | None = None) -> dict[str, Any]:
     """Load and merge configuration.
 

--- a/src/nexus/daemon/installer.py
+++ b/src/nexus/daemon/installer.py
@@ -225,6 +225,10 @@ class DaemonUninstallReport:
     daemon_stopped: bool
     warnings: tuple[str, ...]
     message: str
+    #: RDR-165 eu4u4: whether the engine-service/PG stack was stopped
+    #: (`nx daemon service stop --with-pg`). Best-effort, like ``daemon_stopped``.
+    #: Defaulted so the MCP daemon_uninstall dry-run path needn't set it.
+    service_stopped: bool = False
 
 
 def _stop_daemon_best_effort() -> tuple[bool, str | None]:
@@ -249,6 +253,31 @@ def _stop_daemon_best_effort() -> tuple[bool, str | None]:
     return True, None
 
 
+def _stop_service_stack_best_effort() -> tuple[bool, str | None]:
+    """Best-effort ``nx daemon service stop --with-pg``. Returns (stopped, warning).
+
+    RDR-165 eu4u4: the complete teardown must stop the engine-service + embedded
+    Postgres, not only the T2 daemon (the installer.py gap where uninstall only
+    ran ``nx daemon t2 stop``). Same shell-out rationale as
+    :func:`_stop_daemon_best_effort` (lifecycle is daemon-command territory, not
+    installer logic; RDR-126 §2) and routes through the existing service-stop
+    command, which relinquishes the storage_service lease via the shared
+    ``service_registry.py`` primitive (RDR-149 — no duplicated lifecycle here).
+    A no-running-service exit is reported as a warning, never raised.
+    """
+    from nexus.commands import daemon as _daemon
+
+    cmd = [*_daemon._resolve_nx_bin(), "daemon", "service", "stop", "--with-pg"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
+    except Exception as exc:  # noqa: BLE001 — stop is best-effort
+        return False, f"service stop failed: {type(exc).__name__}: {exc}"
+    if result.returncode != 0:
+        detail = (result.stderr or "").strip() or (result.stdout or "").strip()
+        return False, f"service stop exited {result.returncode}: {detail}"
+    return True, None
+
+
 def uninstall_daemon(*, confirm: bool = False, remove_data: bool = False) -> DaemonUninstallReport:
     """Orchestrate full daemon removal for the ``daemon_uninstall`` MCP tool.
 
@@ -267,7 +296,11 @@ def uninstall_daemon(*, confirm: bool = False, remove_data: bool = False) -> Dae
     marker = _first_run_marker_path()
 
     if not confirm:
-        parts = [f"the autostart unit at {unit_dest}", "stop the running daemon"]
+        parts = [
+            f"the autostart unit at {unit_dest}",
+            "stop the engine-service + Postgres stack (service stop --with-pg)",
+            "stop the running T2 daemon",
+        ]
         if marker.exists():
             parts.append(f"the first-run marker at {marker}")
         if remove_data:
@@ -296,7 +329,14 @@ def uninstall_daemon(*, confirm: bool = False, remove_data: bool = False) -> Dae
     unit_result = uninstall_autostart()
     warnings.extend(unit_result.warnings)
 
-    # 2. Stop the running daemon (best-effort).
+    # 2. Stop the engine-service + Postgres stack (best-effort) — RDR-165 eu4u4.
+    #    Stop the service BEFORE the T2 daemon so a complete teardown leaves no
+    #    running storage backend; both are best-effort and never raise.
+    service_stopped, service_warning = _stop_service_stack_best_effort()
+    if service_warning:
+        warnings.append(service_warning)
+
+    # 3. Stop the running T2 daemon (best-effort).
     daemon_stopped, stop_warning = _stop_daemon_best_effort()
     if stop_warning:
         warnings.append(stop_warning)
@@ -338,6 +378,7 @@ def uninstall_daemon(*, confirm: bool = False, remove_data: bool = False) -> Dae
                 warnings.append(f"could not remove data dir {data_dir}: {exc}")
 
     summary = [f"autostart unit: {unit_result.status.value}"]
+    summary.append("service stack stopped" if service_stopped else "service stop not confirmed")
     summary.append("daemon stopped" if daemon_stopped else "daemon stop not confirmed")
     if marker_removed:
         summary.append("first-run marker removed")
@@ -351,6 +392,7 @@ def uninstall_daemon(*, confirm: bool = False, remove_data: bool = False) -> Dae
         data_removed=data_removed,
         data_dir=data_dir,
         daemon_stopped=daemon_stopped,
+        service_stopped=service_stopped,
         warnings=tuple(warnings),
         message="Daemon uninstall complete: " + "; ".join(summary) + ".",
     )

--- a/src/nexus/daemon/installer.py
+++ b/src/nexus/daemon/installer.py
@@ -341,7 +341,7 @@ def uninstall_daemon(*, confirm: bool = False, remove_data: bool = False) -> Dae
     if stop_warning:
         warnings.append(stop_warning)
 
-    # 3. Remove the first-run marker so a reinstall re-shows the banner.
+    # 4. Remove the first-run marker so a reinstall re-shows the banner.
     marker_removed = False
     if marker.exists():
         try:
@@ -350,7 +350,7 @@ def uninstall_daemon(*, confirm: bool = False, remove_data: bool = False) -> Dae
         except OSError as exc:
             warnings.append(f"could not remove first-run marker: {exc}")
 
-    # 4. Optionally wipe all nexus data.
+    # 5. Optionally wipe all nexus data.
     data_removed = False
     if remove_data and data_dir.exists():
         import shutil

--- a/tests/commands/test_uninstall.py
+++ b/tests/commands/test_uninstall.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from nexus.cli import main
@@ -36,6 +37,12 @@ def _report(**kw):
 
 
 class TestUninstallCommand:
+    @pytest.fixture(autouse=True)
+    def _local_present(self):
+        # These exercise the LOCAL branch — pin local presence True.
+        with patch("nexus.commands.uninstall._local_service_present", return_value=True):
+            yield
+
     def test_dry_run_is_default_no_yes(self) -> None:
         """No --yes → confirm=False (preview only), nothing is torn down."""
         with patch("nexus.commands.uninstall.uninstall_daemon") as m:
@@ -78,18 +85,18 @@ class TestManagedBranch:
     warn on a shell-env override, never stop a (nonexistent) local service or
     touch the remote tenant's data."""
 
-    def _patch_local_noop(self):
-        # The local branch is exercised separately; here it is a clean no-op report.
-        return patch("nexus.commands.uninstall.uninstall_daemon", return_value=_report(
-            confirmed=True, service_stopped=False, daemon_stopped=False,
-            message="Daemon uninstall complete: service stop not confirmed; daemon stop not confirmed.",
-        ))
+    @pytest.fixture(autouse=True)
+    def _no_local(self):
+        # Managed-only persona: NO local service present. The local branch must
+        # be skipped entirely (Sig-1: no spurious noise; Sig-2: no stop subprocess).
+        with patch("nexus.commands.uninstall._local_service_present", return_value=False):
+            yield
 
     def test_managed_config_cleared_with_yes(self, monkeypatch) -> None:
         for k in ("NX_SERVICE_URL", "NX_SERVICE_TOKEN"):
             monkeypatch.delenv(k, raising=False)
         cleared: list[str] = []
-        with self._patch_local_noop(), \
+        with patch("nexus.commands.uninstall.uninstall_daemon") as m_local, \
              patch("nexus.commands.uninstall.get_credential",
                    side_effect=lambda n: "https://api.conexus-nexus.com" if n == "service_url" else "tok"), \
              patch("nexus.commands.uninstall.unset_credential",
@@ -98,12 +105,15 @@ class TestManagedBranch:
         assert res.exit_code == 0, res.output
         assert cleared == ["service_url", "service_token"]
         assert "managed" in res.output.lower()
+        # Sig-1/Sig-2: managed-only → the local teardown is NEVER invoked.
+        assert m_local.call_count == 0
+        assert "not running" not in res.output
 
     def test_managed_dry_run_does_not_clear(self, monkeypatch) -> None:
         for k in ("NX_SERVICE_URL", "NX_SERVICE_TOKEN"):
             monkeypatch.delenv(k, raising=False)
         cleared: list[str] = []
-        with self._patch_local_noop(), \
+        with patch("nexus.commands.uninstall.uninstall_daemon") as m_local, \
              patch("nexus.commands.uninstall.get_credential",
                    side_effect=lambda n: "https://api.conexus-nexus.com" if n == "service_url" else "tok"), \
              patch("nexus.commands.uninstall.unset_credential",
@@ -111,24 +121,27 @@ class TestManagedBranch:
             res = CliRunner().invoke(main, ["uninstall"])
         assert res.exit_code == 0, res.output
         assert cleared == []  # dry run touches nothing
+        assert m_local.call_count == 0
         assert "managed" in res.output.lower()
 
-    def test_no_managed_config_is_silent_noop(self, monkeypatch) -> None:
+    def test_no_managed_no_local_reports_nothing_to_uninstall(self, monkeypatch) -> None:
         for k in ("NX_SERVICE_URL", "NX_SERVICE_TOKEN"):
             monkeypatch.delenv(k, raising=False)
         cleared: list[str] = []
-        with self._patch_local_noop(), \
+        with patch("nexus.commands.uninstall.uninstall_daemon") as m_local, \
              patch("nexus.commands.uninstall.get_credential", return_value=""), \
              patch("nexus.commands.uninstall.unset_credential",
                    side_effect=lambda n: cleared.append(n) or True):
             res = CliRunner().invoke(main, ["uninstall", "--yes"])
         assert res.exit_code == 0, res.output
         assert cleared == []
+        assert m_local.call_count == 0
+        assert "nothing to uninstall" in res.output.lower()
 
     def test_env_override_warns_cannot_unset_shell(self, monkeypatch) -> None:
         monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com")
         monkeypatch.setenv("NX_SERVICE_TOKEN", "tok")
-        with self._patch_local_noop(), \
+        with patch("nexus.commands.uninstall.uninstall_daemon"), \
              patch("nexus.commands.uninstall.get_credential",
                    side_effect=lambda n: "https://api.conexus-nexus.com" if n == "service_url" else "tok"), \
              patch("nexus.commands.uninstall.unset_credential", return_value=False):

--- a/tests/commands/test_uninstall.py
+++ b/tests/commands/test_uninstall.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-165 Phase 3 (nexus-eu4u4) — the first-class `nx uninstall` command.
+
+The CLI surface over `installer.uninstall_daemon` (the complete local teardown:
+engine-service + PG + T2 daemon + autostart + marker + optional data wipe).
+Dry-run is the DEFAULT (mirrors the daemon_uninstall MCP tool's confirm=false);
+`--yes` confirms. `--remove-data` is gated and only meaningful with `--yes`.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from nexus.cli import main
+
+
+def _report(**kw):
+    from nexus.daemon.installer import DaemonUninstallReport, UninstallStatus
+
+    defaults = dict(
+        confirmed=True,
+        unit_status=UninstallStatus.REMOVED,
+        unit_dest="/x/unit",
+        marker_removed=True,
+        data_removed=False,
+        data_dir="/x/cfg",
+        daemon_stopped=True,
+        service_stopped=True,
+        warnings=(),
+        message="Daemon uninstall complete: service stack stopped; daemon stopped.",
+    )
+    defaults.update(kw)
+    return DaemonUninstallReport(**defaults)
+
+
+class TestUninstallCommand:
+    def test_dry_run_is_default_no_yes(self) -> None:
+        """No --yes → confirm=False (preview only), nothing is torn down."""
+        with patch("nexus.commands.uninstall.uninstall_daemon") as m:
+            m.return_value = _report(confirmed=False, message="This would remove: ...")
+            res = CliRunner().invoke(main, ["uninstall"])
+        assert res.exit_code == 0, res.output
+        assert m.call_count == 1
+        _, kw = m.call_args
+        assert kw.get("confirm") is False
+        assert "would remove" in res.output.lower()
+
+    def test_yes_confirms_teardown(self) -> None:
+        with patch("nexus.commands.uninstall.uninstall_daemon") as m:
+            m.return_value = _report()
+            res = CliRunner().invoke(main, ["uninstall", "--yes"])
+        assert res.exit_code == 0, res.output
+        _, kw = m.call_args
+        assert kw.get("confirm") is True
+        assert kw.get("remove_data") is False
+
+    def test_remove_data_flag_threads_through_with_yes(self) -> None:
+        with patch("nexus.commands.uninstall.uninstall_daemon") as m:
+            m.return_value = _report(data_removed=True)
+            res = CliRunner().invoke(main, ["uninstall", "--yes", "--remove-data"])
+        assert res.exit_code == 0, res.output
+        _, kw = m.call_args
+        assert kw.get("confirm") is True
+        assert kw.get("remove_data") is True
+
+    def test_warnings_surfaced(self) -> None:
+        with patch("nexus.commands.uninstall.uninstall_daemon") as m:
+            m.return_value = _report(warnings=("service stop exited 1: not running",))
+            res = CliRunner().invoke(main, ["uninstall", "--yes"])
+        assert res.exit_code == 0, res.output
+        assert "not running" in res.output
+
+
+class TestManagedBranch:
+    """wigzi: the managed-only teardown — clear service_url/token from config.yml,
+    warn on a shell-env override, never stop a (nonexistent) local service or
+    touch the remote tenant's data."""
+
+    def _patch_local_noop(self):
+        # The local branch is exercised separately; here it is a clean no-op report.
+        return patch("nexus.commands.uninstall.uninstall_daemon", return_value=_report(
+            confirmed=True, service_stopped=False, daemon_stopped=False,
+            message="Daemon uninstall complete: service stop not confirmed; daemon stop not confirmed.",
+        ))
+
+    def test_managed_config_cleared_with_yes(self, monkeypatch) -> None:
+        for k in ("NX_SERVICE_URL", "NX_SERVICE_TOKEN"):
+            monkeypatch.delenv(k, raising=False)
+        cleared: list[str] = []
+        with self._patch_local_noop(), \
+             patch("nexus.commands.uninstall.get_credential",
+                   side_effect=lambda n: "https://api.conexus-nexus.com" if n == "service_url" else "tok"), \
+             patch("nexus.commands.uninstall.unset_credential",
+                   side_effect=lambda n: cleared.append(n) or True):
+            res = CliRunner().invoke(main, ["uninstall", "--yes"])
+        assert res.exit_code == 0, res.output
+        assert cleared == ["service_url", "service_token"]
+        assert "managed" in res.output.lower()
+
+    def test_managed_dry_run_does_not_clear(self, monkeypatch) -> None:
+        for k in ("NX_SERVICE_URL", "NX_SERVICE_TOKEN"):
+            monkeypatch.delenv(k, raising=False)
+        cleared: list[str] = []
+        with self._patch_local_noop(), \
+             patch("nexus.commands.uninstall.get_credential",
+                   side_effect=lambda n: "https://api.conexus-nexus.com" if n == "service_url" else "tok"), \
+             patch("nexus.commands.uninstall.unset_credential",
+                   side_effect=lambda n: cleared.append(n) or True):
+            res = CliRunner().invoke(main, ["uninstall"])
+        assert res.exit_code == 0, res.output
+        assert cleared == []  # dry run touches nothing
+        assert "managed" in res.output.lower()
+
+    def test_no_managed_config_is_silent_noop(self, monkeypatch) -> None:
+        for k in ("NX_SERVICE_URL", "NX_SERVICE_TOKEN"):
+            monkeypatch.delenv(k, raising=False)
+        cleared: list[str] = []
+        with self._patch_local_noop(), \
+             patch("nexus.commands.uninstall.get_credential", return_value=""), \
+             patch("nexus.commands.uninstall.unset_credential",
+                   side_effect=lambda n: cleared.append(n) or True):
+            res = CliRunner().invoke(main, ["uninstall", "--yes"])
+        assert res.exit_code == 0, res.output
+        assert cleared == []
+
+    def test_env_override_warns_cannot_unset_shell(self, monkeypatch) -> None:
+        monkeypatch.setenv("NX_SERVICE_URL", "https://api.conexus-nexus.com")
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "tok")
+        with self._patch_local_noop(), \
+             patch("nexus.commands.uninstall.get_credential",
+                   side_effect=lambda n: "https://api.conexus-nexus.com" if n == "service_url" else "tok"), \
+             patch("nexus.commands.uninstall.unset_credential", return_value=False):
+            res = CliRunner().invoke(main, ["uninstall", "--yes"])
+        assert res.exit_code == 0, res.output
+        out = res.output.lower()
+        assert "nx_service_url" in out and ("unset" in out or "export" in out)

--- a/tests/daemon/test_uninstall_daemon.py
+++ b/tests/daemon/test_uninstall_daemon.py
@@ -97,6 +97,25 @@ class TestConfirmedUninstall:
         stop_cmds = [c.args[0] for c in mock_run.call_args_list]
         assert ["/opt/conexus/bin/nx", "daemon", "t2", "stop"] in stop_cmds
 
+    def test_stops_engine_service_stack_with_pg(self, _env: Path) -> None:
+        # RDR-165 eu4u4: uninstall_daemon must tear down the engine-service/PG
+        # stack, not only `nx daemon t2 stop` (the installer.py:241 gap). Assert
+        # the exact `service stop --with-pg` argv is issued AND reported.
+        with patch.object(installer.subprocess, "run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stderr = ""
+            mock_run.return_value.stdout = ""
+            report = installer.uninstall_daemon(confirm=True)
+
+        stop_cmds = [c.args[0] for c in mock_run.call_args_list]
+        assert ["/opt/conexus/bin/nx", "daemon", "service", "stop", "--with-pg"] in stop_cmds
+        assert report.service_stopped is True
+
+    def test_dry_run_plan_mentions_service_stack(self, _env: Path) -> None:
+        report = installer.uninstall_daemon(confirm=False)
+        assert report.confirmed is False
+        assert "service" in report.message.lower()
+
     def test_remove_data_wipes_config_dir(self, _env: Path) -> None:
         config_dir = _env / "cfg"
         assert config_dir.exists()

--- a/tests/daemon/test_uninstall_daemon.py
+++ b/tests/daemon/test_uninstall_daemon.py
@@ -114,7 +114,9 @@ class TestConfirmedUninstall:
     def test_dry_run_plan_mentions_service_stack(self, _env: Path) -> None:
         report = installer.uninstall_daemon(confirm=False)
         assert report.confirmed is False
-        assert "service" in report.message.lower()
+        # Tight: the plan must name the engine-service/PG stop explicitly, not
+        # merely contain the substring "service" (which appears in unit paths).
+        assert "service stop --with-pg" in report.message
 
     def test_remove_data_wipes_config_dir(self, _env: Path) -> None:
         config_dir = _env / "cfg"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,6 +114,38 @@ def test_set_credential_unknown_name_raises(home: Path) -> None:
         set_credential("totally_unknown_credential", "some-value")
 
 
+# ── unset_credential (RDR-165 nexus-a11ge: nx uninstall managed-config clear) ──
+
+
+def test_unset_credential_removes_from_config(home: Path) -> None:
+    from nexus.config import get_credential, set_credential, unset_credential
+
+    set_credential("service_url", "https://api.conexus-nexus.com")
+    set_credential("service_token", "tok-abc")
+    # unset one → it's gone; the other survives.
+    assert unset_credential("service_url") is True  # was present
+    assert get_credential("service_url") == ""
+    assert get_credential("service_token") == "tok-abc"
+    # config.yml no longer carries the removed key.
+    import yaml
+    data = yaml.safe_load((home / ".config" / "nexus" / "config.yml").read_text())
+    assert "service_url" not in data.get("credentials", {})
+    assert data["credentials"]["service_token"] == "tok-abc"
+
+
+def test_unset_credential_absent_is_noop(home: Path) -> None:
+    from nexus.config import unset_credential
+
+    # Never set → unset reports not-present, raises nothing (idempotent teardown).
+    assert unset_credential("service_token") is False
+
+
+def test_unset_credential_unknown_name_raises(home: Path) -> None:
+    from nexus.config import unset_credential
+    with pytest.raises(ValueError, match="Unknown credential"):
+        unset_credential("totally_unknown_credential")
+
+
 # ── Indexing config ──────────────────────────────────────────────────────────
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,12 @@ from nexus.config import (
 @pytest.fixture
 def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("HOME", str(tmp_path))
+    # Clear ambient credential env so get_credential reads config.yml, not a
+    # value CI exports (NX_SERVICE_TOKEN=test-token is set on the runners and
+    # overrides config.yml — env-first precedence). Without this, the
+    # service_url/service_token credential tests pass locally and fail in CI.
+    for _ev in ("NX_SERVICE_URL", "NX_SERVICE_TOKEN"):
+        monkeypatch.delenv(_ev, raising=False)
     return tmp_path
 
 


### PR DESCRIPTION
RDR-165 Phase 3. A first-class `nx uninstall` honoring the RDR-166 onboarding↔teardown co-ship. One auto-detecting, idempotent command; **dry-run by default**, `--yes` to act.

## Branches (each a no-op when its target is absent)
- **Local service (eu4u4 — 6.0.0 BLOCKER, blocks nexus-y5avl):** stops the engine-service + Postgres stack via `_stop_service_stack_best_effort` (shells the existing `nx daemon service stop --with-pg`), not only `nx daemon t2 stop` (the installer.py gap) — then autostart removal + marker clear + optional `--remove-data`. Gated on a local-presence probe (autostart unit | service-binary dir | storage_service lease).
- **Managed-only (wigzi — RDR-166 co-ship):** clears `service_url`/`service_token` from config.yml (new `config.unset_credential`); skips service-stop (no local service) and never touches the remote tenant. Honesty guard: a shell-env `NX_SERVICE_URL/TOKEN` export can't be unset from the parent shell → loud warning, never a false "cleared".
- A no-managed + no-local invocation reports "nothing to uninstall."

## RDR-149 compliance
Mechanically proven by the green lifecycle gate — uninstall adds no bespoke lifecycle defs; it *calls* the shared primitive (`service stop --with-pg` → `service_registry.py`). Full-stack-teardown behavioral proof: `test_stops_engine_service_stack_with_pg` (exact argv); no-local→no-subprocess proof: managed-only asserts `uninstall_daemon.call_count == 0`.

## Stacked review (jyw2j) — 0 Critical
substantive-critic caught real Significants across two rounds — missing local-presence guard (managed-only saw spurious "not running" noise), untested negative path, and a double-probe of `_local_service_present` — **all fixed + re-reviewed clean**. code-review-expert: 0 Critical/High.

## Tests
`config.unset_credential` (atomic/idempotent/unknown-raises), `uninstall_daemon` service-stack teardown, the `nx uninstall` command (local + managed + dry-run + nothing-to-uninstall + env-override warn). 1139 passed in the affected sweep; lifecycle gate green.

## Closes
Closes #nexus-a11ge
Closes #nexus-eu4u4
Closes #nexus-wigzi