### PR TITLE
docs(rdr-165/166): agent lifecycle & operations doc + managed migration journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ migration tool; the Chroma source remains the immutable migration origin
   passthrough (no billed re-embed). Docs:
   [docs/managed-onboarding.md](docs/managed-onboarding.md). pgvector→managed
   cross-deployment migration is a documented limitation (not supported).
-- **`nx guided-upgrade` (RDR-002): one command from a pre-upgrade install to a
+- **`nx guided-upgrade` (RDR-159): one command from a pre-upgrade install to a
   migrated service stack.** Detects the legacy footprint, provisions and starts
   the engine-service, version-pins it (its `/version` `release_version` must be
   present — from engine-service v0.1.6+; the code floor is v0.1.5 but earlier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ migration tool; the Chroma source remains the immutable migration origin
 
 ### Added
 
+- **`nx uninstall` (RDR-165): first-class, service-aware teardown.** Dry-run by
+  default (`--yes` to act); auto-detects both install shapes. A local install
+  stops the engine-service + Postgres stack (`service stop --with-pg`) + the T2
+  daemon, removes the autostart unit and first-run marker, with an opt-in
+  `--remove-data`; a managed-only client clears `service_url`/`service_token`
+  from config.yml and never touches the remote tenant. See
+  [docs/operations/agent-lifecycle.md](docs/operations/agent-lifecycle.md).
+- **Agent Lifecycle & Operations doc (RDR-165).** One operator-facing map of
+  install → provision → run → upgrade → uninstall with a state model and the
+  three operational walkthroughs (`docs/operations/agent-lifecycle.md`).
+- **Managed-service consumer journeys (RDR-166).** Greenfield onboarding
+  (`nx config set service_url/service_token` → probe → first store) and the
+  local→managed migration; same-model voyage collections migrate by vector
+  passthrough (no billed re-embed). Docs:
+  [docs/managed-onboarding.md](docs/managed-onboarding.md). pgvector→managed
+  cross-deployment migration is a documented limitation (not supported).
 - **`nx guided-upgrade` (RDR-002): one command from a pre-upgrade install to a
   migrated service stack.** Detects the legacy footprint, provisions and starts
   the engine-service, version-pins it (its `/version` `release_version` must be

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ When you update the **Claude Code plugin** (`/plugin update`), upgrade the CLI t
 | If you want to... | Read |
 |---|---|
 | Understand the architecture | [Storage Tiers](https://github.com/Hellblazer/nexus/blob/main/docs/storage-tiers.md), [Architecture](https://github.com/Hellblazer/nexus/blob/main/docs/architecture.md) |
+| Install, upgrade, or uninstall the agent | [Agent Lifecycle & Operations](https://github.com/Hellblazer/nexus/blob/main/docs/operations/agent-lifecycle.md) |
+| Use the hosted managed service | [Managed Onboarding](https://github.com/Hellblazer/nexus/blob/main/docs/managed-onboarding.md) |
 | Write an RDR | [RDR: Research-Design-Review](https://github.com/Hellblazer/nexus/blob/main/docs/rdr.md) |
 | Index a repo or PDFs | [Repo Indexing](https://github.com/Hellblazer/nexus/blob/main/docs/repo-indexing.md) |
 | Configure or tune | [Configuration](https://github.com/Hellblazer/nexus/blob/main/docs/configuration.md) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1735,8 +1735,10 @@ nx upgrade --auto                 # Quiet mode for hook invocation (T2 only, exi
 
 ## nx uninstall
 
-First-class agent teardown (RDR-165). Cleanly removes nexus, auto-detecting and
-handling BOTH install shapes — each branch is a no-op when its target is absent:
+First-class agent teardown (RDR-165). See
+[docs/operations/agent-lifecycle.md](operations/agent-lifecycle.md) for the full
+install → upgrade → uninstall lifecycle map. Cleanly removes nexus, auto-detecting
+and handling BOTH install shapes — each branch is a no-op when its target is absent:
 
 - **Local service**: stops the engine-service + Postgres stack
   (`nx daemon service stop --with-pg`), stops the T2 daemon, removes the OS

--- a/docs/managed-onboarding.md
+++ b/docs/managed-onboarding.md
@@ -104,11 +104,13 @@ local source is the rollback origin and is never modified). Notes:
 
 Moving an *already-on-pgvector* local-service install to the managed service
 (pgvector → managed, a cross-deployment data move) is **not supported** — there
-is no `pg_dump`/restore path across deployments in `nx`. Supported migration
-origins are a legacy Chroma install or a local-service install via
-`guided-upgrade`. The pgvector→managed path is tracked as a documented follow-on
-(nexus-wm3t5); for now, a pgvector-local user who wants managed re-indexes from
-source against the managed endpoint.
+is no `pg_dump`/restore path across deployments in `nx`, and `guided-upgrade`'s
+ETL source is always Chroma. The only supported migration origin is a **legacy
+Chroma install** (a local `PersistentClient` store and/or Chroma Cloud); a
+local-service install has no Chroma footprint, so `guided-upgrade` reports
+"nothing to migrate." The pgvector→managed path is tracked as a documented
+follow-on (nexus-wm3t5); for now, a pgvector-local user who wants managed
+re-indexes from source against the managed endpoint.
 
 ## Scope note
 

--- a/docs/managed-onboarding.md
+++ b/docs/managed-onboarding.md
@@ -79,9 +79,40 @@ revoke-and-reissue, operator-side. If a call returns `HTTP 401`, re-fetch a
 fresh token from the operator and re-run `nx config set service_token` (or
 re-export `NX_SERVICE_TOKEN`).
 
+## Migrating an existing local install to the managed service
+
+If you already have a local (Chroma or local-service) install and want to move
+its data to the managed service, that is the migration journey, not greenfield:
+
+```bash
+export NX_SERVICE_TOKEN=<your-bearer-token>          # the operator-provisioned tenant token
+nx guided-upgrade --service-url https://api.conexus-nexus.com
+```
+
+`guided-upgrade` health-gates and version-pins the managed endpoint, then drives
+the ETL (detect → migrate T2/catalog/T3 → validate → unlock), copy-not-move (your
+local source is the rollback origin and is never modified). Notes:
+
+- **Cost:** collections that change embedding model are re-embedded through the
+  managed Voyage key (billed); `guided-upgrade` shows an estimate-and-confirm
+  prompt before proceeding (RDR-166). Same-model voyage collections are copied
+  vector-for-vector with no re-embed (and no charge).
+- **TLS:** the managed `https://…:443` endpoint is handled end-to-end (RDR-166).
+- See [migration-runbook.md](migration-runbook.md) for the full migration detail.
+
+### Known limitation: pgvector → managed is not supported
+
+Moving an *already-on-pgvector* local-service install to the managed service
+(pgvector → managed, a cross-deployment data move) is **not supported** — there
+is no `pg_dump`/restore path across deployments in `nx`. Supported migration
+origins are a legacy Chroma install or a local-service install via
+`guided-upgrade`. The pgvector→managed path is tracked as a documented follow-on
+(nexus-wm3t5); for now, a pgvector-local user who wants managed re-indexes from
+source against the managed endpoint.
+
 ## Scope note
 
-One token maps to one tenant. `pgvector`-to-managed cross-deployment migration is
-a documented limitation, not part of this journey (tracker: nexus-wm3t5); this
-page covers greenfield managed onboarding and the Chroma-source migration path
-covers local-to-managed.
+One token maps to one tenant. This page covers the two managed consumer journeys:
+greenfield onboarding (above) and migrating a local install to managed
+(`guided-upgrade --service-url`). The pgvector→managed cross-deployment move is
+the documented limitation noted above.

--- a/docs/operations/agent-lifecycle.md
+++ b/docs/operations/agent-lifecycle.md
@@ -12,15 +12,15 @@ exclusively through that service stack in both local and cloud mode.
 ## State model
 
 ```
-  uninstalled ──nx init --service──▶ installed ──(provision PG+pgvector)──▶ provisioned
+  uninstalled ──nx init --service──▶ installed ──provision PG+pgvector──▶ provisioned
        ▲                                                                        │
-       │                                                              (supervisor start)
+       │                                                                (supervisor start)
        │                                                                        ▼
-       └──────────── nx uninstall ◀──── running ◀──────────────────────────── running
-                                          │  ▲
-                                  nx upgrade / guided-upgrade
-                                          ▼  │
-                                       upgrading
+       │                                  ┌──── nx upgrade / guided-upgrade ────┐
+       │                                  ▼                                     │
+       └──────── nx uninstall ◀──────── running ───────────────────────────▶ upgrading
+                                                                                │
+                                                          (migration/migrations apply, back to running)
 ```
 
 - **uninstalled** — no autostart unit, no service binary, no provisioned PG.
@@ -32,7 +32,8 @@ exclusively through that service stack in both local and cloud mode.
 The running-state machinery (lease publish/heartbeat/relinquish, single-writer
 discovery, version-skew) is the shared service-registry primitive
 (`src/nexus/daemon/service_registry.py`); its invariants are owned by
-[RDR-149](../rdr/rdr-149-*.md) and enforced by `tests/daemon/test_lifecycle_gate.py`.
+[RDR-149](../rdr/rdr-149-unified-service-registry-substrate.md) and enforced by
+`tests/daemon/test_lifecycle_gate.py`.
 
 ## Coverage matrix (lifecycle surface → authority)
 
@@ -41,7 +42,7 @@ discovery, version-skew) is the shared service-registry primitive
 | Install | `nx init --service`, `nx daemon service install-binary <tag>` | RDR-157 (distribution), RDR-161 (native-only), RDR-144 (`nx init` embedder onboarding) |
 | Provision | bundled PG16 + pgvector, Liquibase migrate, bge-768 ONNX fetch | RDR-155 (pgvector substrate), RDR-160 (bge-768 embedder) |
 | Run | T2 daemon + T3 `nexus-service`; lease lifecycle | RDR-149 (daemon lifecycle), RDR-152 (endpoint discovery) |
-| Upgrade | `nx upgrade` (migrations), `nx guided-upgrade` (Chroma→service) | RDR-002 / RDR-159 (guided upgrade), RDR-162 (cross-model) |
+| Upgrade | `nx upgrade` (migrations), `nx guided-upgrade` (Chroma→service) | RDR-159 (guided upgrade), RDR-162 (cross-model) |
 | Uninstall | `nx uninstall` (CLI), `daemon_uninstall` (MCP) | RDR-165 (this RDR) |
 
 ## Install
@@ -75,7 +76,8 @@ at the endpoint with an operator-provisioned token; no install, no provision.
   [cli-reference.md](../cli-reference.md#nx-upgrade).
 - **`nx guided-upgrade`** — the one-shot Chroma → service migration for a
   pre-6.0 install: detect footprint, provision + version-pin the service, migrate
-  (T2 → catalog → T3), validate, unlock. Copy-not-move (the Chroma source is the
+  (T2, then each T3 leg with its catalog ref-remap), validate, unlock.
+  Copy-not-move (the Chroma source is the
   rollback manifest). See [migration-runbook.md](../migration-runbook.md) and
   RDR-002 / RDR-159. Cross-model collections (e.g. legacy minilm) are re-embedded
   into the target model (RDR-162); same-model voyage collections are copied
@@ -121,4 +123,4 @@ The `daemon_uninstall` MCP tool remains for in-chat teardown of the local daemon
 - [managed-onboarding.md](../managed-onboarding.md) — the hosted-service journey
 - [migration-runbook.md](../migration-runbook.md) — Chroma → service migration
 - [cli-reference.md](../cli-reference.md) — every command + flag
-- RDRs: 165 (this lifecycle), 155 (substrate), 157/161 (distribution), 149 (daemon lifecycle), 002/159 (guided upgrade), 166 (managed journeys)
+- RDRs: 165 (this lifecycle), 155 (substrate), 157/161 (distribution), 149 (daemon lifecycle), 159 (guided upgrade), 162 (cross-model upgrade), 166 (managed journeys)

--- a/docs/operations/agent-lifecycle.md
+++ b/docs/operations/agent-lifecycle.md
@@ -1,0 +1,124 @@
+# Agent Lifecycle & Operations
+
+The one operator-facing map of how the nexus agent is installed, runs, upgrades,
+and is removed. It is a navigator, not a design record: each section links out to
+the authoritative RDR for rationale rather than restating it.
+
+"The agent" here is the local nexus stack: the `nx` CLI, the T2 daemon
+(notes/plans/taxonomy over SQLite), and the T3 storage service (the native
+`nexus-service` binary over Postgres 16 + pgvector). Since RDR-155 P4a, T3 serves
+exclusively through that service stack in both local and cloud mode.
+
+## State model
+
+```
+  uninstalled ──nx init --service──▶ installed ──(provision PG+pgvector)──▶ provisioned
+       ▲                                                                        │
+       │                                                              (supervisor start)
+       │                                                                        ▼
+       └──────────── nx uninstall ◀──── running ◀──────────────────────────── running
+                                          │  ▲
+                                  nx upgrade / guided-upgrade
+                                          ▼  │
+                                       upgrading
+```
+
+- **uninstalled** — no autostart unit, no service binary, no provisioned PG.
+- **installed** — the `nexus-service` binary is fetched + positioned; `nx` resolvable.
+- **provisioned** — Postgres 16 + pgvector provisioned, schema migrated (Liquibase), embedder wired (bge-768 local, or Voyage in cloud mode).
+- **running** — the supervisor publishes a `storage_service` lease; T2 + T3 serve.
+- **upgrading** — a transient state during `nx upgrade` (schema/T3 migrations) or `nx guided-upgrade` (Chroma → service migration).
+
+The running-state machinery (lease publish/heartbeat/relinquish, single-writer
+discovery, version-skew) is the shared service-registry primitive
+(`src/nexus/daemon/service_registry.py`); its invariants are owned by
+[RDR-149](../rdr/rdr-149-*.md) and enforced by `tests/daemon/test_lifecycle_gate.py`.
+
+## Coverage matrix (lifecycle surface → authority)
+
+| Stage | CLI / surface | Authority |
+|-------|---------------|-----------|
+| Install | `nx init --service`, `nx daemon service install-binary <tag>` | RDR-157 (distribution), RDR-161 (native-only), RDR-144 (`nx init` embedder onboarding) |
+| Provision | bundled PG16 + pgvector, Liquibase migrate, bge-768 ONNX fetch | RDR-155 (pgvector substrate), RDR-160 (bge-768 embedder) |
+| Run | T2 daemon + T3 `nexus-service`; lease lifecycle | RDR-149 (daemon lifecycle), RDR-152 (endpoint discovery) |
+| Upgrade | `nx upgrade` (migrations), `nx guided-upgrade` (Chroma→service) | RDR-002 / RDR-159 (guided upgrade), RDR-162 (cross-model) |
+| Uninstall | `nx uninstall` (CLI), `daemon_uninstall` (MCP) | RDR-165 (this RDR) |
+
+## Install
+
+Greenfield local first-run (no prior install):
+
+```bash
+nx daemon service install-binary engine-service-vX.Y.Z   # fetch the cosign-verified native binary + relocatable PG+pgvector bundle
+nx init --service                                         # provision Postgres, fetch the bge-768 ONNX, start the supervisor
+nx doctor                                                 # verify: dependencies, service /health, embedding mode
+```
+
+Pick `engine-service-vX.Y.Z` from the
+[engine-service releases](https://github.com/Hellblazer/nexus/releases) (newest
+`engine-service-v*` tag, an explicit pin, no `latest`). `nx init --service` is
+idempotent (safe to re-run). It embeds with bge-768 locally; in the managed-cloud
+deployment, embeddings run server-side via Voyage with `NX_VOYAGE_API_KEY`
+plumbed from the nexus credential chain. See
+[getting-started.md](../getting-started.md#first-time-setup-the-t2-daemon) for the
+full walkthrough and [container-integration.md](../container-integration.md) for
+reaching the service from a container.
+
+**Managed (no local stack):** to use the hosted service instead of running the
+stack yourself, see [managed-onboarding.md](../managed-onboarding.md) — point `nx`
+at the endpoint with an operator-provisioned token; no install, no provision.
+
+## Upgrade
+
+- **`nx upgrade`** — applies pending T2 + T3 schema/migration steps. Idempotent;
+  runs `--auto` (T2 only) on session start via the plugin hook. See
+  [cli-reference.md](../cli-reference.md#nx-upgrade).
+- **`nx guided-upgrade`** — the one-shot Chroma → service migration for a
+  pre-6.0 install: detect footprint, provision + version-pin the service, migrate
+  (T2 → catalog → T3), validate, unlock. Copy-not-move (the Chroma source is the
+  rollback manifest). See [migration-runbook.md](../migration-runbook.md) and
+  RDR-002 / RDR-159. Cross-model collections (e.g. legacy minilm) are re-embedded
+  into the target model (RDR-162); same-model voyage collections are copied
+  verbatim, skipping the billed re-embed (RDR-166).
+
+When to upgrade: on a version bump (`nx upgrade` runs automatically for T2) or
+when moving a pre-6.0 Chroma install onto the service stack (`nx guided-upgrade`,
+once). Rollback: the Chroma source is never modified; a blocked migration leaves
+reads degraded-loud and offers rollback, never auto-invoked.
+
+## Uninstall
+
+`nx uninstall` is the complete, discoverable teardown (RDR-165). It is **dry-run
+by default** (preview only; `--yes` to act) and auto-detects both install shapes,
+each branch a no-op when its target is absent:
+
+```bash
+nx uninstall                       # DRY RUN: show what would be removed
+nx uninstall --yes                 # perform the teardown
+nx uninstall --yes --remove-data   # ALSO wipe the local data dir (notes + index)
+```
+
+- **Local service present:** stops the engine-service + Postgres stack
+  (`nx daemon service stop --with-pg`), stops the T2 daemon, removes the OS
+  autostart unit, clears the first-run marker. With `--remove-data`, also wipes
+  the local data dir (irreversible; a shallow-path guard refuses a misconfigured
+  `NEXUS_CONFIG_DIR`).
+- **Managed-only client:** clears the managed endpoint config
+  (`service_url` + `service_token`) from `config.yml`. Skips service-stop (no
+  local service) and never touches the remote tenant's data. If
+  `NX_SERVICE_URL` / `NX_SERVICE_TOKEN` are exported in your **shell**, `nx`
+  clears `config.yml` and warns you to `unset` the export (it cannot unset the
+  parent shell).
+
+`--remove-data` is local-only: it never deletes a managed/remote tenant's data.
+The service-stop routes through the shared lease primitive (RDR-149); `nx
+uninstall` orchestrates existing lifecycle commands rather than duplicating them.
+The `daemon_uninstall` MCP tool remains for in-chat teardown of the local daemon.
+
+## See also
+
+- [getting-started.md](../getting-started.md) — install + first-run detail
+- [managed-onboarding.md](../managed-onboarding.md) — the hosted-service journey
+- [migration-runbook.md](../migration-runbook.md) — Chroma → service migration
+- [cli-reference.md](../cli-reference.md) — every command + flag
+- RDRs: 165 (this lifecycle), 155 (substrate), 157/161 (distribution), 149 (daemon lifecycle), 002/159 (guided upgrade), 166 (managed journeys)


### PR DESCRIPTION
Closes the **documentation half** of the 6.0.0 release-readiness audit — the gap I flagged when you asked "are we 100% ready, no whoopsies?"

## What
- **RDR-165 Phase 1+2 (7srul + o5zqd):** new `docs/operations/agent-lifecycle.md` — the operator-facing map of install → provision → run → upgrade → uninstall, with the state model, three walkthroughs, the lifecycle coverage matrix, and links OUT to authoritative RDRs (no duplicated rationale).
- **RDR-165 Phase 4 (8lqrb):** wired into the README task table, the cli-reference `nx uninstall` section, and the CHANGELOG 6.0.0 `[Unreleased]` notes (which now also carry `nx uninstall` + the managed journeys).
- **RDR-166 Phase 4 (fiyv9):** `docs/managed-onboarding.md` gains the local→managed migration journey + the explicit pgvector→managed not-supported limitation.

## Review (c2dma stacked)
substantive-critic caught a real Critical (the migration-origin claim wrongly included a local-service/pgvector origin — guided-upgrade's ETL source is always Chroma) + 2 Significant (RDR-149 glob link → 404; wrong RDR-002 authority for guided-upgrade). **All fixed.** One critic Critical (no cost prompt on guided-upgrade) was **rebutted with verified call-chain evidence** — guided-upgrade delegates to `migrate_cmd._run_migration`, which runs `_confirm_voyage_cost` (cewad, #1291); the prompt fires for billed cross-model→voyage re-embeds. All doc links verified to resolve.

## Follow-up surfaced (code, not docs)
`guided-upgrade --yes` doesn't thread `assume_yes` into `_run_migration`, so a `--yes` user still hits the cost prompt. Minor; will file a bead.

## Closes
Closes #nexus-7srul
Closes #nexus-o5zqd
Closes #nexus-8lqrb
Closes #nexus-fiyv9