### PR TITLE
docs: correct architecture staleness — store count, T2 service-default, PG17, storage diagram

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,15 +6,17 @@ Start with [Getting Started](getting-started.md) for installation. Then explore 
 
 - [Getting Started](getting-started.md) — Install, local usage, Claude Code plugin
 - [Desktop Deployment](desktop-deployment.md) — All three Claude surfaces (chat, Cowork, Code) and the host daemon lifecycle
+- [Agent Lifecycle & Operations](operations/agent-lifecycle.md) — Install → provision → run → upgrade → uninstall: the state model + the three walkthroughs
 - [Architecture](architecture.md) — Reference architecture, module map, design decisions
-- [Storage Tiers](storage-tiers.md) — T1/T2/T3 model, data flow, daemon substrate
+- [Storage Tiers](storage-tiers.md) — T1/T2/T3 model, data flow, service substrate
 - [Document Catalog](catalog.md) — Document registry, typed links, purposes, topic taxonomy
+- [Managed Onboarding](managed-onboarding.md) — Use the hosted managed service (no local stack)
 - [Configuration](configuration.md) — Config hierarchy, `.nexus.yml`, environment variables, logging
 - [Container Integration](container-integration.md) — Daemon model for containers and Cowork
 
 ## Upgrading to 6.0 (off ChromaDB)
 
-6.0 retires ChromaDB T3 serving for the native nexus-service (Postgres 16 + pgvector). Existing users migrate with one command, `nx guided-upgrade`.
+6.0 retires ChromaDB T3 serving for the native nexus-service (Postgres 17 + pgvector). Existing users migrate with one command, `nx guided-upgrade`.
 
 - [Getting Started § Cloud mode](getting-started.md#cloud-mode-optional) and `nx init --service` — stand up the service stack
 - [Migration Runbook](migration-runbook.md) — the operational order of operations, quiescence, rollback, and the two-release deprecation window
@@ -31,6 +33,7 @@ Start with [Getting Started](getting-started.md) for installation. Then explore 
 - [CLI Reference](cli-reference.md) — Every command, every flag
 - [MCP Servers](mcp-servers.md) — The two bundled MCP servers and their tools
 - [Querying Guide](querying-guide.md) — When to use which retrieval interface
+- [Privacy Policy](privacy-policy.md) — What data nexus stores and where
 
 ## Contributing
 
@@ -55,4 +58,4 @@ Start with [Getting Started](getting-started.md) for installation. Then explore 
 
 ## Origins
 
-Nexus synthesizes patterns from mgrep (UX, citation format), SeaGOAT (git frecency scoring, hybrid search), Arcaneum (PDF extraction pipeline), and Mixedbread (cloud vector store, now replaced by self-hosted ChromaDB). Three storage tiers, no raw content storage outside the source repos, and a specification-before-code workflow recorded across 125+ RDRs.
+Nexus synthesizes patterns from mgrep (UX, citation format), SeaGOAT (git frecency scoring, hybrid search), Arcaneum (PDF extraction pipeline), and Mixedbread (cloud vector store, succeeded by self-hosted ChromaDB and now by the native nexus-service over Postgres 17 + pgvector). Three storage tiers, no raw content storage outside the source repos, and a specification-before-code workflow recorded across 160+ RDRs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ Three arrows cross downward from the Planning band into the third band: a dashed
 
 The third band (green, "Unified Execution Layer") contains, left to right: a cluster of four colored hexagons connected by lines representing the Execution Plan DAG; an Execution Engine subgroup containing a `plan_run` panel (with a miniature DAG glyph) and a Result Cache cylinder labeled T1, connected by a bidirectional arrow; and a Defined Operator Set box divided into three labeled columns — RETRIEVAL (Search, Query, Traverse, FindNode, Filter, GroupBy), SYNTHESIS (Extract, Summarize, Compare, Rank, Generate, Aggregate), and STATE (`memory_*`, `store_*`, `plan_*`, `scratch_*`, `catalog_link`, `operator_*`).
 
-The fourth band (purple, "Knowledge Representation Layer") flows left to right: a stack-of-documents icon labeled "Source Documents" feeds an Inner-document Content Extractor (classifier, chunker via tree-sitter across 31 languages, `code_indexer`, `prose_indexer`, `pdf_extractor` routing Docling → MinerU → PyMuPDF, `bib_enricher`). An arrow labeled "Scholarly Document Knowledge" continues into Problem/Method Taxonomy Construction (`CatalogTaxonomy`, BERTopic plus HDBSCAN). Below Taxonomy, a Progressive Update box (`auto_linker`, `taxonomy_assign_hook`, `link_generator`) connects bidirectionally upward and receives a dashed "new documents" arrow from Source Documents. A "construct" arrow leads right from Taxonomy to the Nexus Knowledge Graph — rendered as a node-link cluster of orange and white circles — representing the three-tier store (T1 ChromaDB, T2 SQLite+FTS5, T3 Postgres 16 + pgvector behind the native nexus-service) with tumbler addresses and typed links (`cites`, `implements`, `supersedes`, `relates`).
+The fourth band (purple, "Knowledge Representation Layer") flows left to right: a stack-of-documents icon labeled "Source Documents" feeds an Inner-document Content Extractor (classifier, chunker via tree-sitter across 31 languages, `code_indexer`, `prose_indexer`, `pdf_extractor` routing Docling → MinerU → PyMuPDF, `bib_enricher`). An arrow labeled "Scholarly Document Knowledge" continues into Problem/Method Taxonomy Construction (`CatalogTaxonomy`, BERTopic plus HDBSCAN). Below Taxonomy, a Progressive Update box (`auto_linker`, `taxonomy_assign_hook`, `link_generator`) connects bidirectionally upward and receives a dashed "new documents" arrow from Source Documents. A "construct" arrow leads right from Taxonomy to the Nexus Knowledge Graph — rendered as a node-link cluster of orange and white circles — representing the three-tier store (T1 ChromaDB, T2 SQLite+FTS5, T3 Postgres 17 + pgvector behind the native nexus-service) with tumbler addresses and typed links (`cites`, `implements`, `supersedes`, `relates`).
 </details>
 
 Source: [`architecture-diagram.svg`](architecture-diagram.svg) — edit the SVG directly, then re-render the PNG with `rsvg-convert -z 1.5 docs/architecture-diagram.svg -o docs/architecture-diagram.png`.
@@ -67,11 +67,11 @@ CLI (cli.py)            MCP Server (mcp_server.py)
     └── Storage tiers (RDR-120 substrate split; T2 daemon-mediated, T3 service-mediated)
           T1: ChromaDB HTTP server (session scratch, shared across agent processes)
           T2: SQLite + FTS5 daemon ── nx daemon t2 start
-                Eight domain stores (incl. catalog) behind T2Database / T2Client
+                Nine domain stores (eight share nexus.db + catalog) behind T2Database / T2Client
                 Transport: UDS (UID-gated) + 127.0.0.1 loopback TCP
                 memory · plans · chash_index · taxonomy · telemetry ·
                 document_aspects · aspect_queue · document_highlights · catalog
-          T3: Postgres 16 + pgvector behind the native nexus-service ── nx daemon service start
+          T3: Postgres 17 + pgvector behind the native nexus-service ── nx daemon service start
               Same service in BOTH modes; embedding is server-side
               (bge-768 in local mode, Voyage in managed-cloud mode).
               The client is HttpVectorClient over /v1/vectors; the legacy
@@ -83,22 +83,23 @@ CLI (cli.py)            MCP Server (mcp_server.py)
 ```
 
 **Service-mediated T3 storage (RDR-155).** T3 serving routes through the
-native nexus-service (Postgres 16 + pgvector + server-side embedding) in
+native nexus-service (Postgres 17 + pgvector + server-side embedding) in
 BOTH local and managed-cloud modes. `make_t3()` returns an
 `HttpVectorClient` by default; the client reads `NX_SERVICE_URL` +
 `NX_SERVICE_TOKEN` with supervisor-lease discovery
 (`storage_service_addr.<uid>`). Start it via `nx daemon service start`. The
 older ChromaDB serving path (`nx daemon t3`) still registers but is the
 RETIRED serving route, kept only as the immutable migration source until
-RDR-155 P4b deletes it. T2 is unaffected: it remains SQLite + FTS5 behind
-its own single-writer daemon (RDR-120).
+RDR-155 P4b deletes it. T2 domain stores hard-default to the same service
+backend (RDR-152); the SQLite + FTS5 single-writer daemon (RDR-120) remains
+only as the `NX_STORAGE_BACKEND=sqlite` opt-out path.
 
-**Two-process waypoint.** This is a way-station, not the destination: T3 is
-on the service now; T2 is still SQLite behind the single-writer daemon.
-RDR-152 (`nexus-gmiaf`) moves T2 into the same Postgres service and retires
-the daemon class (its only remaining job is SQLite single-writer
-arbitration, structurally redundant once Postgres exists), converging on
-ONE service.
+**One-service convergence.** Both tiers now serve through the native
+`nexus-service`: T3 vectors on Postgres + pgvector, and the T2 domain stores
+**hard-default to the service backend** as of RDR-152 (`nexus-gmiaf`).
+`NX_STORAGE_BACKEND[_<store>]=sqlite` is the explicit opt-out; the single-writer
+SQLite daemon remains only as that fallback path. One service backs both tiers,
+with SQLite retained as the local opt-out.
 
 For container deployments (Claude Co-Work and similar): containers
 reach the host's T2 daemon via the loopback TCP socket exposed by
@@ -249,6 +250,15 @@ Properties:
 
 ### Migration runbook (RDR-108 Phase 4 -> Phase 5)
 
+> **Historical — pre-RDR-155 (ChromaDB-era) only.** The `nx collection
+> backfill-hash` / `nx t3 reidentify` steps below operate on **ChromaDB**
+> collections and apply only to a deployment still on the Chroma serving path
+> (pre-6.0). Post-RDR-155, T3 serves through pgvector + `nexus-service` and the
+> upgrade path is **`nx guided-upgrade`** (Chroma → service migration; see
+> [migration-runbook.md](migration-runbook.md) and
+> [operations/agent-lifecycle.md](operations/agent-lifecycle.md)). This section
+> is retained for the chunk-identity history (RDR-053/108).
+
 For operators upgrading an existing nexus deployment to the post-RDR-108 storage shape:
 
 1. **Deploy the new code + restart the MCP server** so the indexer / GC / retrieval paths use the manifest-aware code paths.
@@ -275,7 +285,7 @@ Pre-existing drift surfaced during Phase 5 verification (filed as separate beads
 
 ## Taxonomy
 
-Taxonomy (RDR-070) builds a topic hierarchy over T3 collections using existing embeddings, without re-embedding. HDBSCAN clusters the vectors already stored in ChromaDB, labels them with c-TF-IDF, and persists topic assignments to T2 SQLite. Every subsequent `store_put` call assigns the new document to the nearest centroid via ANN lookup. Search then uses these assignments to boost same-topic results and group output.
+Taxonomy (RDR-070) builds a topic hierarchy over T3 collections using existing embeddings, without re-embedding. HDBSCAN clusters the vectors already stored in T3 (pgvector via `nexus-service`), labels them with c-TF-IDF, and persists topic assignments to T2. Every subsequent `store_put` call assigns the new document to the nearest centroid via ANN lookup. Search then uses these assignments to boost same-topic results and group output.
 
 In local mode, `code__*` collections are excluded by default because the general-purpose local embedder (bge-768) clusters code poorly. Cloud mode uses `voyage-code-3` and is unaffected. (As of 6.0, discovery/rebuild/assignment run on the nexus-service backend per nexus-7ydks; `nx taxonomy split`/`project` are still being ported.)
 
@@ -287,13 +297,13 @@ nx index repo / nx taxonomy discover
   ▼
 discover_for_collection()          # taxonomy_cmd.py
   │  fetch ids + texts + embeddings from T3 (page_size=250)
-  │  fall back to MiniLM re-embed only when T3 embeddings absent
+  │  fall back to the local ONNX embedder (bge-768) re-embed only when T3 embeddings absent
   ▼
 CatalogTaxonomy.discover_topics()  # db/t2/catalog_taxonomy.py
   │  sklearn HDBSCAN on N×D float32
   │  c-TF-IDF labels (CountVectorizer + TfidfTransformer)
   │  persist: topics, topic_assignments → T2 SQLite
-  │  upsert cluster centroids → ChromaDB taxonomy__centroids (cosine/HNSW)
+  │  upsert cluster centroids → pgvector via nexus-service (HttpCentroidStore)
   ▼
 taxonomy_assign_hook()             # mcp_infra.py  (fires on every store_put)
   │  fetch new doc's T3 embedding
@@ -318,7 +328,7 @@ search_cross_corpus()              # search_engine.py
 | `taxonomy_meta` | Per-collection discover stats (last_discover_at, last_discover_doc_count) |
 | `topic_links` | Aggregated inter-topic link counts derived from catalog link graph |
 
-**T3 ChromaDB collection** (`taxonomy__centroids`): created with `embedding_function=None` and `hnsw:space=cosine`. One entry per topic holds the centroid vector, collection, topic_id, and label. Used exclusively by `assign_single()` for ANN lookup. Never goes through `t3.get_or_create_collection()` (that path would inject the wrong embedding function and L2 space).
+**Centroid storage** (`taxonomy_centroids_{384,768,1024}`, one per embedding dim): served through pgvector via `nexus-service` (`HttpCentroidStore`) since RDR-155 P4a.2. One row per topic holds the centroid vector, collection, topic_id, and label; `assign_single()` does the ANN lookup. (The discover/rebuild centroid-WRITE helpers retain raw-Chroma access only for injected-client / legacy-ETL paths, slated for removal in RDR-155 P4b.)
 
 ### Centroid Lifecycle
 
@@ -379,7 +389,7 @@ Three parallel hook contracts in `src/nexus/mcp_infra.py` cover the three real w
 
 The batch contract exists because some enrichments collapse N dependency calls into one batched call (e.g. `taxonomy.assign_batch` issues one ChromaDB Cloud `query()` for N nearest-centroid lookups; the per-doc path issues N sequential queries). For corpus-scale ingest the difference is roughly 1000x. The single-document chain serves work that does not benefit from batching but keys on `doc_id`. The document-grain chain serves work that needs the source document boundary as a stable identity (RDR-089 aspect extraction, where each paper is one extraction regardless of chunk count) — its key is `source_path`, not `doc_id`, and the chain fires once per source document at every CLI ingest entry point as well as at MCP `store_put`.
 
-`taxonomy_assign_batch_hook` accepts `embeddings=None` from the MCP path and fetches them from T3 inline (with a local-MiniLM fallback when the T3 row is unavailable). One hook body covers both the bulk path and the single-document path; there is no separate single-doc taxonomy hook to keep in sync.
+`taxonomy_assign_batch_hook` accepts `embeddings=None` from the MCP path and fetches them from T3 inline (with a local bge-768 ONNX fallback when the T3 row is unavailable). One hook body covers both the bulk path and the single-document path; there is no separate single-doc taxonomy hook to keep in sync.
 
 `aspect_extraction_enqueue_hook` is the document-grain consumer. The hook persists `(collection, source_path, content)` to `aspect_extraction_queue` (microsecond-scale T2 INSERT) and lazy-spawns a daemon worker that drains the queue and invokes the synchronous `extract_aspects` extractor. The async dispatch is necessary because Critical Assumption #2 in RDR-089 (per-document extraction <3 s) was invalidated by the P1.3 spike (median 26.5 s, p95 38.1 s) — synchronous-inline would block the ingest path for ~25 s per document.
 
@@ -568,7 +578,7 @@ and the current CLI version. Each migration function is idempotent via
 `PRAGMA table_info()` or `sqlite_master` guards.
 
 `T2Database.__init__()` opens a transient connection, calls `apply_pending()`,
-closes it, then constructs the four domain stores. The `_upgrade_done` set
+closes it, then constructs the eight domain stores. The `_upgrade_done` set
 (guarded by `_upgrade_lock`) provides a process-level fast path — subsequent
 constructions skip all DB access. Domain stores retain their own
 `_migrated_paths` guards for standalone construction outside `T2Database`.
@@ -582,7 +592,7 @@ applying T2 migrations silently. T3 steps are skipped in auto mode.
 
 **In-memory SQLite**: Tests that want an ephemeral database should use
 a temp file path, not `":memory:"` -- `:memory:` databases are
-per-connection, so the four stores would each see a distinct empty
+per-connection, so the eight stores would each see a distinct empty
 database and `test_t2_concurrency.py` would no longer exercise the
 cross-domain WAL path.
 
@@ -596,8 +606,8 @@ See `src/nexus/db/t2/__init__.py` for the facade source and
 | **Entry** | `cli.py`, `commands/` | Click CLI, one file per command group |
 | **Command preambles** | `commands/rdr.py` (`preamble` subgroup), `commands/command_context.py`, `conexus/commands/*.md` | RDR-130: slash-command context preambles. Each of the 25 conexus slash commands injects its preamble via a single-line `` !`nx <subcommand> -- "$ARGUMENTS"` `` call — the 9 RDR-lifecycle commands use `nx rdr preamble <name>`, the 16 agent-relay commands use `nx command-context <name>`. Preamble logic lives in the tested `nx` CLI (normal Python, unit-covered) and prints markdown; Claude Code injects that stdout as plain text and does NOT re-parse it, so emitted tables/fences are safe. No command inlines bash, no command depends on `$CLAUDE_PLUGIN_ROOT` (empty in command-bash context); a static guard (`test_migrated_command_uses_single_line_nx`) enforces the single-line form across all 25. Replaced the inlined-bash approach whose fenced-block truncation caused the 5.1.2 regression class |
 | **Catalog** | `catalog/catalog.py`, `catalog/catalog_db.py`, `catalog/tumbler.py`, `catalog/link_generator.py`, `catalog/auto_linker.py`, `catalog/consolidation.py` | Git-backed document registry + typed link graph (JSONL + SQLite). Tumbler addressing, `descendants()`/`ancestors()`/`lca()` hierarchy helpers, `resolve_chunk()` ghost element resolution, idempotent link upsert, composable query, bulk ops, audit. Auto-linker creates links from T1 link-context on every `store_put`. `consolidation.py` merges per-paper collections into corpus-level collections |
-| **Storage** | `db/t1.py`, `db/t2/`, `db/t3.py`, `db/http_vector_client.py`, `db/managed_endpoint.py`, `db/service_endpoint.py`, `db/pg_provision.py`, `db/chroma_quotas.py`, `db/local_ef.py` | Tier implementations. T2 is a package split into domain stores (see § T2 Domain Stores). `make_t3()` (`db/__init__.py`) returns `HttpVectorClient` (T3 over the nexus-service `/v1/vectors`) by default; `db/t3.py` is the retired ChromaDB path kept as migration source. `managed_endpoint.py` / `service_endpoint.py` resolve the service URL/token (T3 reads `NX_SERVICE_URL`; the T2-stores/catalog resolver uses `NX_SERVICE_HOST`/`PORT`); `pg_provision.py` provisions the local PG16 cluster + writes `pg_credentials`. `chroma_quotas.py` is the single source of truth for ChromaDB Cloud quota constants and validators. `local_ef.py` provides the local ONNX embedding function |
-| **Service stack** | `daemon/storage_service_daemon.py`, `daemon/binary_install.py`, `commands/guided_upgrade_cmd.py`, `commands/migrate_cmd.py` | Native nexus-service lifecycle (RDR-155/161): `storage_service_daemon.py` supervises the PG16+pgvector+service binary; `binary_install.py` fetches/installs the engine-service binary (`PINNED_SERVICE_TAG = None` — the user supplies the tag). `guided_upgrade_cmd.py` (`nx guided-upgrade`, RDR-002) provisions + verifies the service then drives `migrate_cmd.py` (`nx migrate-to-service`, RDR-159; cross-model mode RDR-162), the Chroma → pgvector ETL orchestrator |
+| **Storage** | `db/t1.py`, `db/t2/`, `db/t3.py`, `db/http_vector_client.py`, `db/managed_endpoint.py`, `db/service_endpoint.py`, `db/pg_provision.py`, `db/chroma_quotas.py`, `db/local_ef.py` | Tier implementations. T2 is a package split into domain stores (see § T2 Domain Stores). `make_t3()` (`db/__init__.py`) returns `HttpVectorClient` (T3 over the nexus-service `/v1/vectors`) by default; `db/t3.py` is the retired ChromaDB path kept as migration source. `managed_endpoint.py` / `service_endpoint.py` resolve the service URL/token (T3 reads `NX_SERVICE_URL`; the T2-stores/catalog resolver uses `NX_SERVICE_HOST`/`PORT`); `pg_provision.py` provisions the local PG17 cluster + writes `pg_credentials`. `chroma_quotas.py` is the single source of truth for ChromaDB Cloud quota constants and validators. `local_ef.py` provides the local ONNX embedding function |
+| **Service stack** | `daemon/storage_service_daemon.py`, `daemon/binary_install.py`, `commands/guided_upgrade_cmd.py`, `commands/migrate_cmd.py`, `commands/uninstall.py`, `db/storage_mode.py` | Native nexus-service lifecycle (RDR-155/161): `storage_service_daemon.py` supervises the PG17+pgvector+service binary; `binary_install.py` fetches/installs the engine-service binary (`PINNED_SERVICE_TAG = None` — the user supplies the tag). `guided_upgrade_cmd.py` (`nx guided-upgrade`, RDR-159) provisions + verifies the service then drives `migrate_cmd.py` (`nx migrate-to-service`, RDR-159; cross-model mode RDR-162), the Chroma → pgvector ETL orchestrator. `uninstall.py` (`nx uninstall`, RDR-165) is the first-class teardown for both local-service and managed-only installs. `storage_mode.py` routes each T2/T1 store to the service backend (hard default) or SQLite (`NX_STORAGE_BACKEND` opt-out, RDR-152) |
 | **Indexing** | `indexer.py`, `code_indexer.py`, `prose_indexer.py`, `index_context.py`, `indexer_utils.py`, `classifier.py`, `chunker.py`, `md_chunker.py`, `doc_indexer.py`, `pdf_extractor.py`, `pdf_chunker.py`, `bib_enricher.py`, `languages.py`, `pipeline_buffer.py`, `pipeline_stages.py`, `checkpoint.py` | Repo indexing pipeline (decomposed per RDR-032). `bib_enricher.py` queries Semantic Scholar for bibliographic metadata; `pdf_extractor.py` auto-detects math-heavy PDFs via FormulaItem counting and routes to MinerU (default-installed since nexus-2fyb) for LaTeX extraction; non-math PDFs use Docling. MinerU absence at runtime raises a `RuntimeError` rather than silently falling back to formula-stripped Docling — the prior silent fallback wiped formulas from every PDF indexed for weeks. MinerU processes large PDFs in 5-page subprocess batches for memory isolation (prevents OOM on formula-dense documents). Chunk metadata includes `has_formulas` boolean. `pipeline_buffer.py` provides a WAL-mode SQLite buffer for the three-stage streaming pipeline (RDR-048); `pipeline_stages.py` implements the concurrent extractor/chunker/uploader stages and orchestrator; `checkpoint.py` handles batch-path crash recovery for smaller documents (RDR-047) |
 | **Export** | `exporter.py` | Collection export/import for T3 backup and migration (.nxexp format) |
 | **DEVONthink** | `devonthink.py`, `commands/dt.py` | macOS-only `nx dt` integration verbs (RDR-099). `devonthink.py` exposes 5 selector helpers (`_dt_selection`, `_dt_uuid_record`, `_dt_tag_records`, `_dt_group_records`, `_dt_smart_group_records`) over a centralised `_run_osascript` spawn; the smart-group helper does an sdef-canonical three-property read (`search predicates` PLURAL + `search group` + `exclude subgroups`) and re-executes the search to honour user-authored scope. `commands/dt.py` is the Click surface: `nx dt index` dispatches per-record by extension (.pdf/.md) into the existing `nexus.doc_indexer` entry points, and `nx dt open` round-trips tumblers/UUIDs back to DT via `open(1)`. Substrate `meta.devonthink_uri` reverse-lookup shipped in 4.17.0 (nexus-srck) |
@@ -605,7 +615,7 @@ See `src/nexus/db/t2/__init__.py` for the facade source and
 | **Console** | `console/` (`app.py`, `watchers.py`, `config.py`, `routes/`), `commands/console.py` | Embedded web UI for monitoring agentic Nexus activity (`nx console`). FastAPI/uvicorn server with live-updating routes for activity, campaigns, health, and partials. `commands/console.py` handles start/stop lifecycle and PID file management |
 | **Search** | `search_engine.py`, `search_clusterer.py`, `scoring.py`, `frecency.py`, `ripgrep_cache.py`, `filters.py` | Query, rank, rerank. `scoring.py` applies topic boost (`apply_topic_boost`: same-topic -0.1, linked-topic -0.05). `search_engine.py` does topic grouping (T2 assignments when >50% coverage) with fallback to Ward hierarchical clustering. `filters.py` also contains `sanitize_query()` (RDR-071) which strips LLM prompt contamination from search queries before embedding |
 | **Context** | `context.py`, `commands/context_cmd.py` | L1 project context cache (RDR-072). `generate_context_l1()` builds a ~200 token topic map from taxonomy, cached as flat file at `~/.config/nexus/context/<repo>-<hash>.txt`. Injected by SessionStart hook for agent cold-start acceleration. Auto-refreshed after `taxonomy discover` and `index repo` |
-| **Taxonomy** | `db/t2/catalog_taxonomy.py`, `commands/taxonomy_cmd.py`, `taxonomy.py` (shim) | HDBSCAN topic discovery from T3 embeddings (RDR-070). T2 tables: `topics`, `topic_assignments`, `taxonomy_meta`, `topic_links`. ChromaDB `taxonomy__centroids` (cosine/HNSW) for centroid ANN. `discover_for_collection()` is the shared entry point for CLI and `nx index repo`. `taxonomy_assign_hook` in `mcp_infra.py` fires on every `store_put` for incremental assignment. `taxonomy.py` is a backward-compatibility shim that forwards old call sites to `db.taxonomy` |
+| **Taxonomy** | `db/t2/catalog_taxonomy.py`, `commands/taxonomy_cmd.py`, `taxonomy.py` (shim) | HDBSCAN topic discovery from T3 embeddings (RDR-070). T2 tables: `topics`, `topic_assignments`, `taxonomy_meta`, `topic_links`. Centroids on pgvector (`taxonomy_centroids_{384,768,1024}`) via nexus-service (`HttpCentroidStore`) for centroid ANN, since RDR-155 P4a.2. `discover_for_collection()` is the shared entry point for CLI and `nx index repo`. `taxonomy_assign_hook` in `mcp_infra.py` fires on every `store_put` for incremental assignment. `taxonomy.py` is a backward-compatibility shim that forwards old call sites to `db.taxonomy` |
 | **Hooks** | `commands/hooks.py`, `commands/hook.py` | `hooks.py`: Git hook install/uninstall/status, sentinel-bounded stanza management. `hook.py`: Claude Code SessionStart/SessionEnd lifecycle runners |
 | **Verification** | `config.py` (verification section), `conexus/hooks/scripts/stop_verification_hook.sh`, `conexus/hooks/scripts/pre_close_verification_hook.sh`, `conexus/hooks/scripts/read_verification_config.py` | Opt-in mechanical enforcement: Stop hook (session-end checks), PreToolUse hook (bd-close gate), standalone config reader. See [Verification config](configuration.md#verification) |
 | **MCP Servers** | `mcp/core.py`, `mcp/catalog.py`, `mcp/devonthink.py`, `mcp_infra.py`, `mcp_server.py` (shim) | Multi-server FastMCP architecture (RDR-062, RDR-139). `nexus` core server (26 tools: storage, retrieval, operators, orchestration) + `nexus-catalog` (10 tools: catalog and link graph) + `devonthink` (RDR-139 Layer A': the `nx-mcp-devonthink` agent-surface server, ~17 curated DEVONthink tools + the `dt_incorporate` composite). The devonthink server **always spawns** and gates internally on `available()`: DT present → the curated surface; DT absent → only a `devonthink_status` stub (zero DT tools, no spawn error). Declared `alwaysLoad:false` in `conexus/.mcp.json` as a tool-search startup optimization, not the optionality mechanism. Tools surface as `mcp__plugin_conexus_devonthink__*`. Short-name convention: catalog tools drop the redundant `catalog_` prefix since the server namespace already provides context. Six destructive / maintenance operations are intentionally kept CLI-only. Backward-compat shim at `mcp_server.py` re-exports every function. `query()` has catalog-aware routing (author, content_type, subtree, follow_links, depth); singletons and test injection live in `mcp_infra.py`. **For the full tool catalog see [MCP Servers](mcp-servers.md).** |
@@ -676,5 +686,5 @@ Grouped by verb:
 | **SeaGOAT** | Git frecency scoring, hybrid search, persistent server |
 | **Arcaneum** | PDF extraction + chunking pipelines, RDR process |
 
-The storage stack (Postgres 16 + pgvector behind the native nexus-service, with server-side bge-768 / Voyage embedding) and the indexing layers are Nexus's own.
+The storage stack (Postgres 17 + pgvector behind the native nexus-service, with server-side bge-768 / Voyage embedding) and the indexing layers are Nexus's own.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -744,7 +744,7 @@ Returns non-zero on any check failure. `--json` emits the per-check result for C
 
 ## nx t3
 
-T3 vector-store maintenance commands. As of 6.0 the live T3 store is Postgres 16 + pgvector behind the native nexus-service; these commands operate on that store through the vector client. (`nx t3 reidentify` was the RDR-108 ChromaDB natural-ID migration and is retained for legacy collections.) Distinct from `nx catalog gc`: `nx t3` operates on T3 chunks, the catalog command operates on catalog rows.
+T3 vector-store maintenance commands. As of 6.0 the live T3 store is Postgres 17 + pgvector behind the native nexus-service; these commands operate on that store through the vector client. (`nx t3 reidentify` was the RDR-108 ChromaDB natural-ID migration and is retained for legacy collections.) Distinct from `nx catalog gc`: `nx t3` operates on T3 chunks, the catalog command operates on catalog rows.
 
 ### nx t3 prune-stale
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,7 +58,7 @@ uv run pytest -m integration
 
 The HTTP storage-tier suites (`tests/db/test_http_*_integration.py` and the Java
 serving contract tests) run entirely in-sandbox: each spins up its own ephemeral
-PG16 + a fresh service JAR with an isolated bearer — no production data, no live
+PG17 + a fresh service JAR with an isolated bearer — no production data, no live
 daemon, no API keys. Because they are `@pytest.mark.integration` (excluded from the
 default CI/unit run), storage-stack regressions can rot unseen. One button-press
 runs the whole tier stack:
@@ -71,7 +71,7 @@ scripts/validate/integration-stack.sh --java-only   # T3 + repo-layer Java tests
 ```
 
 Run it after any change to the HTTP stores, the Java service handlers/schema, or
-the token/RLS model. Prereqs (dev box): a JDK/GraalVM and pg16 binaries. When the
+the token/RLS model. Prereqs (dev box): a JDK/GraalVM and pg17 binaries. When the
 prereqs are absent the suites self-skip and the gate reports **inconclusive**
 (non-zero exit), never a false green.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,7 +122,7 @@ users still get a working substrate. The autostart path is recommended
 if you also use `nx` directly from the shell.
 
 **T3 (the permanent vector store)** is served by the native nexus-service over
-Postgres 16 + pgvector — in **both** local and cloud mode. Provision and start
+Postgres 17 + pgvector — in **both** local and cloud mode. Provision and start
 it with:
 
 ```bash

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -14,7 +14,7 @@ For **when to use which retrieval interface**, see [Querying Guide](querying-gui
 
 The `nexus` and `nexus-catalog` servers register automatically when you install the plugin (`/plugin install conexus@nexus-plugins`) or the `.mcpb` extension. No separate install.
 
-**Substrate dependency**: since conexus 4.34.0 (RDR-120), T2 storage tools route through the T2 daemon; since RDR-155, T3 storage/retrieval tools route through the native nexus-service (`nx daemon service`, Postgres 16 + pgvector), not a ChromaDB daemon. The Claude Code plugin's SessionStart hook auto-spawns `nx daemon t2 ensure-running`; for a daemon that survives reboots independent of Claude Code, run `nx daemon t2 install --autostart` once. The T3 service is a one-time `nx init --service` + `nx daemon service start`. See [Container Integration](container-integration.md) for the multi-process / multi-host model.
+**Substrate dependency**: since conexus 4.34.0 (RDR-120), T2 storage tools route through the T2 daemon; since RDR-155, T3 storage/retrieval tools route through the native nexus-service (`nx daemon service`, Postgres 17 + pgvector), not a ChromaDB daemon. The Claude Code plugin's SessionStart hook auto-spawns `nx daemon t2 ensure-running`; for a daemon that survives reboots independent of Claude Code, run `nx daemon t2 install --autostart` once. The T3 service is a one-time `nx init --service` + `nx daemon service start`. See [Container Integration](container-integration.md) for the multi-process / multi-host model.
 
 ## `nexus` — retrieval + storage (26 tools)
 

--- a/docs/migration-runbook.md
+++ b/docs/migration-runbook.md
@@ -1,7 +1,7 @@
 # Migration-Window Operations Runbook (SQLite/Chroma to Postgres)
 
 Operational narrative for the operator running the next T2 + T3 migration
-onto the PG16 + pgvector + nexus-service stack (RDR-152/153/155). The flag
+onto the PG17 + pgvector + nexus-service stack (RDR-152/153/155). The flag
 reference lives in [`docs/cli-reference.md` § nx storage](cli-reference.md#nx-storage);
 this document is the order of operations, the failure playbook, and how to
 read the artifacts. Precedent: the 2026-06-10 production run (115,716

--- a/docs/operations/agent-lifecycle.md
+++ b/docs/operations/agent-lifecycle.md
@@ -6,7 +6,7 @@ the authoritative RDR for rationale rather than restating it.
 
 "The agent" here is the local nexus stack: the `nx` CLI, the T2 daemon
 (notes/plans/taxonomy over SQLite), and the T3 storage service (the native
-`nexus-service` binary over Postgres 16 + pgvector). Since RDR-155 P4a, T3 serves
+`nexus-service` binary over Postgres 17 + pgvector). Since RDR-155 P4a, T3 serves
 exclusively through that service stack in both local and cloud mode.
 
 ## State model
@@ -25,7 +25,7 @@ exclusively through that service stack in both local and cloud mode.
 
 - **uninstalled** — no autostart unit, no service binary, no provisioned PG.
 - **installed** — the `nexus-service` binary is fetched + positioned; `nx` resolvable.
-- **provisioned** — Postgres 16 + pgvector provisioned, schema migrated (Liquibase), embedder wired (bge-768 local, or Voyage in cloud mode).
+- **provisioned** — Postgres 17 + pgvector provisioned, schema migrated (Liquibase), embedder wired (bge-768 local, or Voyage in cloud mode).
 - **running** — the supervisor publishes a `storage_service` lease; T2 + T3 serve.
 - **upgrading** — a transient state during `nx upgrade` (schema/T3 migrations) or `nx guided-upgrade` (Chroma → service migration).
 
@@ -40,7 +40,7 @@ discovery, version-skew) is the shared service-registry primitive
 | Stage | CLI / surface | Authority |
 |-------|---------------|-----------|
 | Install | `nx init --service`, `nx daemon service install-binary <tag>` | RDR-157 (distribution), RDR-161 (native-only), RDR-144 (`nx init` embedder onboarding) |
-| Provision | bundled PG16 + pgvector, Liquibase migrate, bge-768 ONNX fetch | RDR-155 (pgvector substrate), RDR-160 (bge-768 embedder) |
+| Provision | bundled PG17 + pgvector, Liquibase migrate, bge-768 ONNX fetch | RDR-155 (pgvector substrate), RDR-160 (bge-768 embedder) |
 | Run | T2 daemon + T3 `nexus-service`; lease lifecycle | RDR-149 (daemon lifecycle), RDR-152 (endpoint discovery) |
 | Upgrade | `nx upgrade` (migrations), `nx guided-upgrade` (Chroma→service) | RDR-159 (guided upgrade), RDR-162 (cross-model) |
 | Uninstall | `nx uninstall` (CLI), `daemon_uninstall` (MCP) | RDR-165 (this RDR) |

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -8,7 +8,7 @@ Conexus is a self-hosted MCP server and Claude Code / Claude Desktop extension t
 
 All persistent data lives on the host machine running Conexus:
 
-- **Indexed content** — text from files you ask Conexus to index (`nx index repo`, `nx index pdf`), plus structured metadata (file paths, chunk identifiers, taxonomy assignments). As of 6.0 the T3 vector store is the native nexus-service (Postgres 16 + pgvector). Stored in:
+- **Indexed content** — text from files you ask Conexus to index (`nx index repo`, `nx index pdf`), plus structured metadata (file paths, chunk identifiers, taxonomy assignments). As of 6.0 the T3 vector store is the native nexus-service (Postgres 17 + pgvector). Stored in:
   - the local nexus-service's Postgres cluster on disk (local mode — embeddings + chunk text, embedded server-side with bge-768)
   - a managed nexus-service's Postgres (managed-cloud mode — only if you point Conexus at a hosted service)
   - `~/.local/share/nexus/chroma/` (legacy ChromaDB store, read only as the migration source for `nx guided-upgrade`)

--- a/docs/storage-tiers.md
+++ b/docs/storage-tiers.md
@@ -4,16 +4,55 @@ Nexus organizes data across three tiers with increasing durability. Data flows u
 
 **Two access paths**: Humans use the `nx` CLI. Agents use MCP tools (`mcp__plugin_conexus_nexus__*`) which call the same Python APIs directly — no Bash dependency. MCP tools that return lists (`search`, `store_list`, `memory_search`) are paged — pass `offset=N` for subsequent pages. See [conexus/README.md](../conexus/README.md#mcp-servers) for MCP tool details.
 
-**One arbitrator per tier**: Since conexus 4.34.0 (RDR-120), T2 is wrapped in a dedicated daemon process; since RDR-155, T3 serving routes through the native nexus-service (Postgres 16 + pgvector). Every consumer — host CLI, the MCP server, multiple Claude Code sessions, Claude Cowork agents (via SDK transport), dev containers — routes through the same arbitrator, so the underlying SQLite instance has exactly one writer and all vector traffic goes through one service. Start the T2 daemon once via `nx daemon t2 install --autostart`, and the storage service via `nx daemon service start`; the Claude Code plugin's SessionStart hook also auto-spawns the T2 daemon on each session start.
+**One arbitrator per tier**: Since conexus 4.34.0 (RDR-120), T2 is wrapped in a dedicated daemon process; since RDR-155, T3 serving routes through the native nexus-service (Postgres 17 + pgvector). Every consumer — host CLI, the MCP server, multiple Claude Code sessions, Claude Cowork agents (via SDK transport), dev containers — routes through the same arbitrator, so the underlying SQLite instance has exactly one writer and all vector traffic goes through one service. Start the T2 daemon once via `nx daemon t2 install --autostart`, and the storage service via `nx daemon service start`; the Claude Code plugin's SessionStart hook also auto-spawns the T2 daemon on each session start.
 
 | Tier | Storage | Arbitrator | Transport | Durability | Use |
 |------|---------|------------|-----------|------------|-----|
 | T1 -- scratch | ChromaDB EphemeralClient / per-session HTTP server | none | Process-local | Session only | Working notes, hypotheses |
 | T2 -- memory | SQLite + FTS5 (WAL) | T2 daemon (`nx daemon t2`) | UDS + 127.0.0.1 loopback | Survives restarts | Per-project notes, session context |
-| T3 -- knowledge | Postgres 16 + pgvector behind the native nexus-service (both modes); embedding server-side (bge-768 local / Voyage managed-cloud) | storage-service supervisor (`nx daemon service`) | nexus-service HTTP `/v1/vectors` (`NX_SERVICE_URL` + `NX_SERVICE_TOKEN`) | Permanent | Semantic search, indexed code/docs |
-| Catalog | T2-store-backed (eighth domain store; RDR-120 P5.A) + events.jsonl (canonical) | shared with T2 daemon | UDS + 127.0.0.1 loopback | Permanent | Document registry, typed link graph, provenance |
+| T3 -- knowledge | Postgres 17 + pgvector behind the native nexus-service (both modes); embedding server-side (bge-768 local / Voyage managed-cloud) | storage-service supervisor (`nx daemon service`) | nexus-service HTTP `/v1/vectors` (`NX_SERVICE_URL` + `NX_SERVICE_TOKEN`) | Permanent | Semantic search, indexed code/docs |
+| Catalog | T2-store-backed (ninth domain store, separate `.catalog.db`; RDR-120 P5.A) + events.jsonl (canonical) | shared with T2 daemon | UDS + 127.0.0.1 loopback | Permanent | Document registry, typed link graph, provenance |
 
 The catalog sits alongside T3 as a metadata layer. While T3 stores document *content* as embeddings, the catalog stores document *metadata* and *relationships*. See [Document Catalog](catalog.md).
+
+### Storage / service-stack architecture
+
+How the access paths reach each substrate today (post-RDR-155). Both T3 and (by hard default) T2 serve through the one native `nexus-service`; SQLite is the T2 opt-out; ChromaDB survives only as the read-only migration source.
+
+```mermaid
+flowchart TD
+  CLI["nx CLI"]
+  MCP["MCP tools<br/>(mcp__plugin_conexus_nexus__*)"]
+
+  CLI --> T1[("T1 scratch<br/>ephemeral · per-session")]
+  MCP --> T1
+  CLI --> T3OPS
+  MCP --> T3OPS
+  CLI --> T2OPS
+  MCP --> T2OPS
+
+  T3OPS["T3 vector ops<br/>(search · store · index)"]
+  T2OPS["T2 store ops<br/>(memory · plans · taxonomy · …)"]
+
+  T3OPS -->|"always service"| REG
+  T2OPS -->|"service backend<br/>HARD DEFAULT (RDR-152)"| REG
+  T2OPS -.->|"NX_STORAGE_BACKEND=sqlite<br/>(T2 opt-out)"| T2D
+
+  REG["ServiceRegistry lease<br/>storage_service_addr.&lt;uid&gt;<br/>(host · port · token)"]
+  REG --> SVC
+
+  SVC["native nexus-service<br/>(one binary · both tiers)"]
+  SVC -->|"server-side embed<br/>bge-768 ONNX (local) / Voyage (cloud)<br/>+ ANN search"| PG[("Postgres 17 + pgvector<br/>T3 vectors")]
+  SVC --> PGT2[("Postgres<br/>T2 domain stores")]
+
+  T2D["T2 daemon<br/>SQLite single-writer"]
+  T2D --> SQL[("nexus.db (SQLite + FTS5, WAL)<br/>+ .catalog.db")]
+
+  CHROMA[("legacy ChromaDB<br/>migration source · read-only")]
+  CHROMA -.->|"nx guided-upgrade<br/>one-time ETL"| SVC
+```
+
+(The [reference architecture diagram](architecture-diagram.svg) covers the *retrieval / planning* layer — query decomposition, the operator DAG, taxonomy, the knowledge graph — which is substrate-agnostic; the diagram above is its storage-plane complement.)
 
 ## Progressive Formalization (RDR-057)
 
@@ -116,9 +155,9 @@ Merges use SQLite's write lock via `with self.conn:` to ensure UPDATE and DELETE
 
 **Relevance log (RDR-061 E2)**: T2 also holds a `relevance_log` table that records `(query, chunk_id, action)` triples when an agent acts on search results (`store_put`, `catalog_link`). This is internal telemetry — not exposed as an MCP tool. Purged by `T2Database.expire(relevance_log_days=90)` alongside memory TTL expiry.
 
-**Domain split (RDR-063)**: T2 is implemented as four domain stores under `src/nexus/db/t2/` — `MemoryStore` (memory table), `PlanLibrary` (plans table), `CatalogTaxonomy` (topics + topic_assignments + taxonomy_meta + topic_links), and `Telemetry` (relevance_log). Each store opens its own `sqlite3.Connection` against the shared SQLite file in WAL mode with `busy_timeout=30000` (raised from 5000 in RDR-129 B1), so reads in one domain are never blocked by writes in another. `T2Database` is a composing facade: existing `db.put(...)`, `db.search(...)`, `db.save_plan(...)` calls continue to work via method delegation, and new code can reach the domain stores directly as `db.memory`, `db.plans`, `db.taxonomy`, `db.telemetry`. See [Architecture — T2 Domain Stores](architecture.md#t2-domain-stores) for the full map and concurrency model.
+**Domain split (RDR-063)**: T2 is implemented as **eight** domain stores under `src/nexus/db/t2/`, all sharing the one `nexus.db` — `MemoryStore` (memory), `PlanLibrary` (plans), `CatalogTaxonomy` (topics + topic_assignments + taxonomy_meta + topic_links), `Telemetry` (relevance_log), `ChashIndex` (RDR-086), `DocumentAspects` (RDR-089), `AspectExtractionQueue`, and `DocumentHighlights` (RDR-139 Layer E) — plus `CatalogStore`, a ninth store that uniquely opens its own separate `.catalog.db`. Each store opens its own `sqlite3.Connection` in WAL mode with `busy_timeout=30000` (raised from 5000 in RDR-129 B1), so reads in one domain are never blocked by writes in another. **Backend routing (RDR-152):** each store hard-defaults to the **service backend** (the `nexus-service` over Postgres); `NX_STORAGE_BACKEND[_<store>]=sqlite` is the opt-out. `T2Database` is a composing facade: existing `db.put(...)`, `db.search(...)`, `db.save_plan(...)` calls work via delegation, and new code reaches the stores directly as `db.memory`, `db.plans`, `db.taxonomy`, `db.telemetry`, `db.chash_index`, `db.document_aspects`, `db.aspect_queue`, `db.document_highlights`, `db.catalog`. See [Architecture — T2 Domain Stores](architecture.md#t2-domain-stores) for the full map and concurrency model.
 
-**Topic taxonomy**: `CatalogTaxonomy` discovers topics from T3 collection embeddings using HDBSCAN, labels them automatically with Claude Haiku, and uses them for search grouping and relevance boosting. Topics are discovered automatically after `nx index repo`. Operator-curated labels are preserved across re-discovery runs. See [CLI Reference — nx taxonomy](cli-reference.md#nx-taxonomy) for the full command set and [taxonomy.md](taxonomy.md) for architecture details.
+**Topic taxonomy**: `CatalogTaxonomy` discovers topics from T3 collection embeddings using HDBSCAN, labels them automatically with Claude Haiku, and uses them for search grouping and relevance boosting. Topics are discovered automatically after `nx index repo`. Operator-curated labels are preserved across re-discovery runs. See [CLI Reference — nx taxonomy](cli-reference.md#nx-taxonomy) for the full command set and [Architecture — Taxonomy](architecture.md#taxonomy) for architecture details.
 
 The taxonomy spans two storage tiers:
 
@@ -131,9 +170,9 @@ The taxonomy spans two storage tiers:
 | `taxonomy_meta` | Per-collection watermark used to decide whether re-discovery is needed |
 | `topic_links` | Aggregated link counts between topics, derived from the catalog link graph |
 
-*T3 centroid collection* — `taxonomy__centroids` holds one embedding per live topic (cosine space). The vector is the cluster centroid computed during `discover_topics`. `discover_topics` creates the collection, `rebuild_taxonomy` clears and rebuilds it wholesale, and `split_topic` replaces one centroid with two.
+*T3 centroids* — `taxonomy_centroids_{384,768,1024}` (one table per embedding dimension) hold one vector per live topic (cosine space), the cluster centroid computed during `discover_topics`. **Served through pgvector via `nexus-service` (`HttpCentroidStore`) since RDR-155 P4a.2.** Note the transition asymmetry until RDR-155 P4b: centroid **reads** (ANN assignment) go through pgvector, but the discover/rebuild centroid-**write** helpers still use a raw-Chroma client for injected-client / legacy-ETL paths. `discover_topics` populates the centroids, `rebuild_taxonomy` clears and rebuilds wholesale, `split_topic` replaces one with two.
 
-*Tier interaction*: Discovery reads embeddings from T3, clusters in memory, then writes topics to T2 and centroids back to T3. Incremental assignment (for new documents) queries centroids via ANN and writes a `topic_assignments` row to T2, without re-running the full clustering algorithm.
+*Tier interaction*: Discovery reads embeddings from T3, clusters in memory, then writes topics to T2 and centroids to T3 (pgvector). Incremental assignment (for new documents) queries centroids via ANN and writes a `topic_assignments` row to T2, without re-running the full clustering algorithm.
 
 ## T3 -- Permanent Knowledge
 
@@ -184,6 +223,13 @@ A collection is indexed and queried under the same embedding model — mixing mo
 **Use for**: semantic search across sessions, institutional knowledge.
 
 ## T3 Backup and Migration (Export/Import)
+
+> **Scope: legacy ChromaDB only.** `nx store export` / `import` operate on the
+> **ChromaDB migration source** (pre-6.0 data), not the live pgvector T3 store.
+> On a migrated 6.0 install they will read/write the Chroma source (which may be
+> empty or stale after migration), **not** your live knowledge. To back up live
+> 6.0 T3 data, use a Postgres `pg_dump` of the `nexus` database; the `.nxexp`
+> format is not compatible with the pgvector serving path.
 
 Collections can be exported to portable `.nxexp` files that preserve all documents, metadata, and embeddings. Importing restores the collection without re-embedding — saving Voyage AI API costs and time.
 


### PR DESCRIPTION
Fine-tooth-comb audit of the architecture docs against the post-RDR-152/155/160 storage reality, followed by a `substantive-critic` re-review of the fixes themselves (the audit had only covered the pre-fix docs).

## What changed
- **T2 backend**: now described as hard-defaulting to the `nexus-service` backend (RDR-152), with the SQLite single-writer daemon as the `NX_STORAGE_BACKEND=sqlite` opt-out. Removed the stale "T2 remains SQLite" wording that contradicted the new paragraph.
- **Store count**: corrected to eight domain stores sharing `nexus.db` (now including `DocumentHighlights`, RDR-139 Layer E — previously omitted), with `CatalogStore` the ninth in its own `.catalog.db`. Fixes the ASCII diagram, the tier table, and the domain-split prose.
- **Taxonomy / centroids**: ChromaDB → pgvector via `nexus-service` (`HttpCentroidStore`); tables `taxonomy_centroids_{384,768,1024}`; read/write asymmetry until RDR-155 P4b documented.
- **Local embedder**: MiniLM → bge-768 (RDR-160).
- **Export/import scope banner**: clarifies the commands operate on the legacy Chroma migration source, not live pgvector (data-safety note).
- **RDR-108 migration runbook**: marked historical (pre-RDR-155 Chroma-era).
- **New Mermaid storage/service-stack diagram** in storage-tiers.md; the registry brokers only the service path, the T2 SQLite opt-out is the `storage_mode` fork.
- **Full corpus PG16 → PG17 sweep** (code is PG17 per `pg_provision.py:153`, nexus-41bso / RDR-159), excluding the historical `upgrading-to-4.34` doc.
- **docs/README index**: added agent-lifecycle, managed-onboarding, privacy-policy.

## Review
substantive-critic re-review of the staged diff caught four issues, all code-verified and fixed: a line-93 self-contradiction, the missed `DocumentHighlights` store, a wrong Mermaid registry edge, and the corpus-wide PG16→PG17 staleness. Docs-only change.

nexus-r8egi