### PR TITLE
test(release): release-N readiness tripwires (nexus-3rq00, nexus-5uvag)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -48,6 +48,8 @@ CI enforces parity. Missing any one of these fails the marketplace-version-match
 
 Optional but recommended: also bump `plugins[].source.sha` to the 40-char SHA of the release commit, for protection against tag force-push. Add post-commit (Step 8a, see below).
 
+**Engine-service pin (conditional 8th target — nexus-3rq00).** The Python/Java boundary rides one more hand-edited constant that sits OUTSIDE the seven-manifest parity gate: `PINNED_SERVICE_TAG` in `src/nexus/daemon/binary_install.py`, the `engine-service-vX.Y.Z` release this build auto-installs. It is NOT bumped every release — only when the compatible engine-service version advances. When this release ships a new engine, bump `PINNED_SERVICE_TAG` in lock-step. Two invariants the `TestEnginePinParity` test enforces: (1) `PINNED_SERVICE_TAG`'s numeric version must be `>= REQUIRED_RELEASE_VERSION` (`src/nexus/migration/guided_upgrade.py`) — never ship a client that auto-installs an engine it then refuses as too old; (2) at the 6.0 release boundary the pin must be non-None (it is intentionally `None` pre-6.0). A release that bumps pyproject to 6.x without setting a real pin trips CI.
+
 Semver: MAJOR for breaking, MINOR for new features, PATCH for bug fixes.
 
 ### 4. Update both changelogs

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -840,6 +840,111 @@ class TestMarketplaceVersion:
         assert m.group(1) == pv, f"uv.lock {m.group(1)!r} != pyproject.toml {pv!r}"
 
 
+#: The release boundary at which ``PINNED_SERVICE_TAG`` must become non-None.
+#: Pre-6.0 the pin is intentionally ``None`` (no engine-service release exists
+#: yet); the first major that ships the service stack must carry a real pin.
+#: NOTE: this fires on ANY 6.x pyproject version, including dev/pre-release
+#: strings like ``6.0.0.dev0`` — ``_pyproject_major()`` parses the leading
+#: integer, so 6.x feature-branch work must carry a real pin from the first
+#: 6.x version bump, not only at the final release commit (substantive-critic
+#: SIG-2, 2026-06-23).
+_ENGINE_PIN_REQUIRED_MAJOR = 6
+
+
+def _pyproject_major() -> int:
+    with PYPROJECT_PATH.open("rb") as f:
+        version = tomllib.load(f)["project"]["version"]
+    return int(version.split(".", 1)[0])
+
+
+class TestEnginePinParity:
+    """nexus-3rq00 — extend the release parity gate across the Python/Java boundary.
+
+    conexus↔engine compatibility rides two hand-edited constants that sit
+    OUTSIDE the 7-manifest parity gate, with no cross-check between them:
+
+    * ``PINNED_SERVICE_TAG`` (``src/nexus/daemon/binary_install.py``) — the
+      ``engine-service-vX.Y.Z`` GitHub release tag this build auto-installs.
+      ``None`` by design pre-6.0 (no real engine-service release exists yet).
+    * ``REQUIRED_RELEASE_VERSION`` (``src/nexus/migration/guided_upgrade.py``)
+      — the minimum engine version the guided upgrade hands off to (RDR-002).
+
+    Without a cross-check, a release could ship a client pinned to an engine
+    tag whose numeric version is BELOW ``REQUIRED_RELEASE_VERSION`` — a client
+    that auto-installs an engine it then refuses as too old. These assertions
+    catch that, and gate the "pin must be set" requirement on the 6.0 release
+    boundary so the suite stays green pre-6.0 while the pin is legitimately
+    ``None``.
+    """
+
+    def test_pinned_tag_at_or_above_required_release(self) -> None:
+        """If a pin is set, its numeric version must be >= REQUIRED_RELEASE_VERSION.
+
+        Skipped only while ``PINNED_SERVICE_TAG is None`` (no engine-service
+        release pinned yet) — NOT keyed on the major version, so a pin set
+        during 5.x dev work is validated too. The ``engine-service-v``
+        namespace prefix is stripped before parsing — the pin format is
+        ``engine-service-vX.Y.Z``, not ``vX.Y.Z``.
+        """
+        from nexus.daemon.binary_install import PINNED_SERVICE_TAG, TAG_NAMESPACE_PREFIX
+        from nexus.migration.guided_upgrade import (
+            REQUIRED_RELEASE_VERSION,
+            _parse_semver,
+        )
+
+        if PINNED_SERVICE_TAG is None:
+            pytest.skip(
+                "PINNED_SERVICE_TAG is None — no engine-service-v* release pinned "
+                "yet (set when the first engine-service tag is cut)"
+            )
+
+        tag = PINNED_SERVICE_TAG
+        assert tag.startswith(TAG_NAMESPACE_PREFIX), (
+            f"PINNED_SERVICE_TAG {tag!r} must carry the "
+            f"{TAG_NAMESPACE_PREFIX!r} namespace prefix"
+        )
+        parsed = _parse_semver(tag[len(TAG_NAMESPACE_PREFIX):])
+        assert parsed is not None, (
+            f"PINNED_SERVICE_TAG {tag!r} is not a clean release semver "
+            f"(blank/SNAPSHOT/dev/pre-release are rejected fail-closed)"
+        )
+        assert parsed >= REQUIRED_RELEASE_VERSION, (
+            f"PINNED_SERVICE_TAG {tag!r} -> {parsed} is BELOW "
+            f"REQUIRED_RELEASE_VERSION {REQUIRED_RELEASE_VERSION}: the client "
+            f"would auto-install an engine it then refuses as too old. Bump "
+            f"PINNED_SERVICE_TAG to an engine-service release >= "
+            f"v{'.'.join(map(str, REQUIRED_RELEASE_VERSION))}."
+        )
+
+    @pytest.mark.xfail(
+        condition=_pyproject_major() < _ENGINE_PIN_REQUIRED_MAJOR,
+        reason=(
+            "nexus-3rq00: PINNED_SERVICE_TAG intentionally None on pre-6.0 builds "
+            "— no engine-service-v* release exists until 6.0. strict=True trips "
+            "this xfail if a pin gets set early (XPASS) so the deferral stays visible."
+        ),
+        strict=True,
+    )
+    def test_pin_is_set_at_release_boundary(self) -> None:
+        """At the 6.0 cut (and beyond), ``PINNED_SERVICE_TAG`` must be non-None.
+
+        xfail(strict=True) below ``_ENGINE_PIN_REQUIRED_MAJOR`` rather than a
+        plain skip: a skip is invisible in CI summaries, an xfail is a tracked,
+        searchable expected-failure that self-trips if the condition stops
+        holding. At 6.x the xfail lifts and this becomes a hard assertion — a
+        release that bumps pyproject to 6.x without a real pin trips it.
+        (nexus-3rq00 / blocks the Release-N readiness gate nexus-h3ilf;
+        substantive-critic SIG-1, 2026-06-23.)
+        """
+        from nexus.daemon.binary_install import PINNED_SERVICE_TAG
+
+        assert PINNED_SERVICE_TAG is not None, (
+            "PINNED_SERVICE_TAG must be a real engine-service-vX.Y.Z tag at the "
+            "6.0 release boundary — a release cut from develop with the service "
+            "stack must pin a compatible engine. See binary_install.py."
+        )
+
+
 # ── Plugin root manifest ─────────────────────────────────────────────────────
 
 REQUIRED_ROOT_FILES = ["registry.yaml", "README.md", "CHANGELOG.md", "hooks/hooks.json"]

--- a/tests/test_rdr155_p4a_serving_retire.py
+++ b/tests/test_rdr155_p4a_serving_retire.py
@@ -215,6 +215,12 @@ class TestRdr155P4bDeprecationWindowGate:
     a file can exist but be half-deleted / broken. ``chroma_read`` imports
     ``chromadb`` lazily (inside its functions), so importing the module is
     lightweight and has no heavyweight client side effects.
+
+    Incidental coverage (do NOT "simplify" away): ``chroma_read`` keeps a
+    TOP-LEVEL ``from nexus.db.chroma_quotas import QUOTAS``, so a mis-sequenced
+    partial P4b that deletes ``chroma_quotas.py`` before ``chroma_read.py``
+    makes the import below raise and trips this gate too (substantive-critic
+    O2, 2026-06-23).
     """
 
     def test_migration_package_importable(self) -> None:

--- a/tests/test_rdr155_p4a_serving_retire.py
+++ b/tests/test_rdr155_p4a_serving_retire.py
@@ -191,3 +191,56 @@ class TestPhase4aSurvivalPins:
         assert offenders == [], (
             f"the superseded skp06 app-layer Chroma tenant guard surfaced in: {offenders}"
         )
+
+
+class TestRdr155P4bDeprecationWindowGate:
+    """nexus-5uvag — two-release deprecation-window release-N tripwire.
+
+    The single irreversible step of the migration arc is RDR-155 P4b, which
+    deletes the migration ETL AND the surviving Chroma read leg (and the
+    migration tool itself: beads nexus-19svb / nexus-g37fr / nexus-8zpmf).
+    The two-release deprecation window requires that release N — the first
+    migration-capable release that lets nexus-luxe6 lift — STILL ships those
+    modules, with P4b's deletion landing only in release N+1.
+
+    Today that ordering is held only by bead dependencies + human discipline.
+    The intended hard E2E gate (nexus-myk4e) is deferred until AFTER the
+    boundary lifts, so it cannot guard the very release it protects. This
+    class fills the gap with a mechanical, NOW-running assertion: a
+    mis-sequenced P4b that deletes (or breaks) the migration modules trips
+    this gate on the PR that would merge it into release N.
+
+    Stronger than the P4a presence pins above (which assert the file exists
+    and matches a source regex): these assert the modules actually IMPORT —
+    a file can exist but be half-deleted / broken. ``chroma_read`` imports
+    ``chromadb`` lazily (inside its functions), so importing the module is
+    lightweight and has no heavyweight client side effects.
+    """
+
+    def test_migration_package_importable(self) -> None:
+        import importlib
+
+        try:
+            importlib.import_module("nexus.migration")
+        except Exception as exc:  # pragma: no cover - failure path is the signal
+            raise AssertionError(
+                "nexus.migration must remain present AND importable through the "
+                "two-release deprecation window — its deletion is RDR-155 P4b and "
+                "must not land before release N+1 (nexus-5uvag / blocks nexus-h3ilf). "
+                f"Import failed: {exc!r}"
+            ) from exc
+
+    def test_chroma_read_leg_importable(self) -> None:
+        import importlib
+
+        try:
+            importlib.import_module("nexus.migration.chroma_read")
+        except Exception as exc:  # pragma: no cover - failure path is the signal
+            raise AssertionError(
+                "nexus.migration.chroma_read (the surviving Chroma read leg) must "
+                "remain present AND importable through the two-release deprecation "
+                "window. RDR-155 P4b deletes it (nexus-19svb / nexus-g37fr); that "
+                "deletion must land only in release N+1, never in the "
+                "migration-capable release N. Import failed: "
+                f"{exc!r}"
+            ) from exc


### PR DESCRIPTION
Two mechanical release-N tripwires from the synthetic-aperture remediation epic (`nexus-whh61`). Both block the Release-N readiness gate `nexus-h3ilf`. Pure test/CI additions — no runtime behaviour change.

## nexus-3rq00 — engine-service version-pin parity gate
`conexus↔engine` compatibility rides two hand-edited constants that sit OUTSIDE the 7-manifest parity gate, with no cross-check:
- `PINNED_SERVICE_TAG` (`src/nexus/daemon/binary_install.py`) — the `engine-service-vX.Y.Z` release this build auto-installs (`None` by design pre-6.0).
- `REQUIRED_RELEASE_VERSION` (`src/nexus/migration/guided_upgrade.py`) — the minimum engine the guided upgrade hands off to (RDR-002).

New `TestEnginePinParity`:
- When a pin is set, asserts its numeric version (prefix-stripped, fail-closed `_parse_semver`) `>= REQUIRED_RELEASE_VERSION` — never ship a client that auto-installs an engine it then refuses as too old.
- `strict` xfail below pyproject major 6 → hard `is not None` assertion at the 6.0 boundary. A 6.x bump without a real pin trips CI.
- Adds the engine pin as a conditional 8th target in `.claude/skills/release/SKILL.md`.

## nexus-5uvag — two-release deprecation-window tripwire
RDR-155 P4b is the single irreversible step (it deletes the migration ETL + the surviving Chroma read leg, and the migration tool itself). The two-release window requires release N to still ship those modules. The intended hard gate (`nexus-myk4e`) is deferred past the boundary, so it can't guard release N.

New `TestRdr155P4bDeprecationWindowGate` asserts `nexus.migration` and `nexus.migration.chroma_read` are **importable** — stronger than the existing P4a file-exists pins; catches a half-deleted/broken module. A mis-sequenced P4b trips it on the PR that would merge it into release N.

## Review
Stacked review (code-review-expert + substantive-critic): 0 Critical. Adopted SIG-1 (skip→strict-xfail for boundary visibility) and the O-level clarifications (skip messages, major-6 footgun comment, incidental chroma_quotas guard note). Kept `_parse_semver` reuse per the bead's explicit instruction.

## Tests
`517 passed, 107 skipped, 1 xfailed` across both affected files.

Beads: nexus-3rq00, nexus-5uvag (closed post-merge via `bd close`).