### PR TITLE
fix(service): tenant-isolation hardening — GUC allowlist + pooler-mode assertion (nexus-utnjt, nexus-bhzuv)

### DIFF
--- a/service/deploy/pgbouncer.ini
+++ b/service/deploy/pgbouncer.ini
@@ -1,0 +1,38 @@
+; nexus managed-service PgBouncer configuration (nexus-bhzuv, RDR-152 / RDR-166).
+;
+; LOAD-BEARING INVARIANT: pool_mode MUST be `transaction`.
+;
+; TenantScope.withTenant stamps the tenant with `SELECT set_config('nexus.tenant', ?, true)`
+; — the trailing `true` is SET LOCAL (transaction-local) semantics. Every tenant table runs
+; FORCE ROW LEVEL SECURITY with `USING (tenant_id = current_setting('nexus.tenant', true))`.
+;
+; Under SESSION-mode pooling the GUC is NOT reset at transaction boundary: the backend is
+; returned to the pool still carrying the previous tenant's `nexus.tenant`, and the next
+; borrower inherits it → CROSS-TENANT READ. Only transaction-mode pooling resets the GUC
+; (server_reset_query / per-transaction backend assignment) so the leak cannot occur.
+;
+; This file is the version-controlled source of truth for the deployed pooler config.
+; The service ALSO fail-closed asserts the live pooler's pool_mode at startup when
+; NX_PGBOUNCER_ADMIN_URL is set (PoolerModeCheck, invoked from Main before HTTP bind).
+
+[databases]
+; Map the application database through the pooler. Adjust host/dbname per deployment;
+; the pool_mode setting below is the part that must not change.
+nexus = host=127.0.0.1 port=5432 dbname=nexus
+
+[pgbouncer]
+listen_addr = 127.0.0.1
+listen_port = 6432
+
+; ── The invariant ──────────────────────────────────────────────────────────
+pool_mode = transaction
+
+; Defence in depth: reset any session state at transaction end so a stray
+; session-scoped GUC cannot survive even if pool_mode were ever loosened.
+server_reset_query = DISCARD ALL
+
+auth_type = scram-sha-256
+auth_file = /etc/pgbouncer/userlist.txt
+admin_users = pgbouncer
+max_client_conn = 200
+default_pool_size = 20

--- a/service/deploy/pgbouncer.ini
+++ b/service/deploy/pgbouncer.ini
@@ -14,6 +14,13 @@
 ; This file is the version-controlled source of truth for the deployed pooler config.
 ; The service ALSO fail-closed asserts the live pooler's pool_mode at startup when
 ; NX_PGBOUNCER_ADMIN_URL is set (PoolerModeCheck, invoked from Main before HTTP bind).
+;
+; ⚠ OPERATOR REQUIREMENT — any deployment that interposes a pooler MUST set
+; NX_PGBOUNCER_ADMIN_URL (JDBC URL of the PgBouncer admin pseudo-DB, e.g.
+; jdbc:postgresql://127.0.0.1:6432/pgbouncer) so the startup probe can enforce
+; transaction mode. With it unset the probe is DISABLED (safe only for the direct-PG,
+; no-pooler path). Wiring this env var into the managed install (nx init --service /
+; RDR-166) is the install epic's responsibility — until then it is operator-set.
 
 [databases]
 ; Map the application database through the pooler. Adjust host/dbname per deployment;

--- a/service/src/main/java/dev/nexus/service/Main.java
+++ b/service/src/main/java/dev/nexus/service/Main.java
@@ -141,6 +141,19 @@ public final class Main {
         var pgVectorRepo = new PgVectorRepository(new TenantScope(ds), docEmbedRouter,
                                                   qryEmbedRouter);
 
+        // Pooler-mode backstop (nexus-bhzuv): if a PgBouncer is interposed
+        // (NX_PGBOUNCER_ADMIN_URL set), refuse to bind unless it reports
+        // pool_mode=transaction. SET LOCAL tenant GUCs leak across borrows under
+        // session-mode pooling → cross-tenant read. No-op on the direct-PG path.
+        // Runs BEFORE service.start(), mirroring the schema-migration fail-fast ordering.
+        try {
+            dev.nexus.service.db.PoolerModeCheck.verifyAtStartup();
+        } catch (dev.nexus.service.db.PoolerModeCheck.PoolerModeException e) {
+            ds.close();
+            log.error("event=pooler_mode_check_failed error=\"{}\"", e.getMessage(), e);
+            System.exit(1);
+        }
+
         var service = new NexusService(port, token, ds, docEmbedRouter, pgVectorRepo);
         service.start();
 

--- a/service/src/main/java/dev/nexus/service/db/PoolerModeCheck.java
+++ b/service/src/main/java/dev/nexus/service/db/PoolerModeCheck.java
@@ -89,8 +89,15 @@ public final class PoolerModeCheck {
     /** Testable form of {@link #verifyAtStartup()} with explicit admin connection params. */
     public static void verifyAtStartup(String adminUrl, String adminUser, String adminPass) {
         if (adminUrl == null || adminUrl.isBlank()) {
-            log.info("event=pooler_mode_check_skipped reason=no_pgbouncer_admin_url "
-                    + "note=\"direct-PG path, no interposed pooler\"");
+            // HONEST phrasing (nexus-bhzuv review HIGH-3): absence of the admin URL means
+            // the probe is DISABLED, not that no pooler exists. If a deployment interposes
+            // PgBouncer but omits NX_PGBOUNCER_ADMIN_URL, the transaction-mode invariant
+            // goes unenforced — the env var is REQUIRED for any pooled deployment.
+            log.warn("event=pooler_mode_check_skipped reason=no_pgbouncer_admin_url "
+                    + "note=\"NX_PGBOUNCER_ADMIN_URL unset — pooler-mode probe DISABLED. "
+                    + "Safe only for the direct-PG (no pooler) path. If PgBouncer is "
+                    + "interposed you MUST set NX_PGBOUNCER_ADMIN_URL or a session-mode "
+                    + "pooler can leak the tenant GUC across borrows (nexus-bhzuv).\"");
             return;
         }
         Map<String, String> config;
@@ -109,7 +116,13 @@ public final class PoolerModeCheck {
     private static Map<String, String> fetchShowConfig(String adminUrl, String user, String pass)
             throws SQLException {
         Map<String, String> rows = new LinkedHashMap<>();
-        try (Connection conn = DriverManager.getConnection(adminUrl, user, pass);
+        // Bound the connect/socket time (nexus-bhzuv review HIGH-1): without this a dead or
+        // firewalled admin endpoint hangs the main thread at startup forever, turning a
+        // fail-fast check into fail-never. Append driver timeouts unless the URL sets its own.
+        String timedUrl = adminUrl.contains("connectTimeout=") || adminUrl.contains("socketTimeout=")
+                ? adminUrl
+                : adminUrl + (adminUrl.contains("?") ? "&" : "?") + "connectTimeout=10&socketTimeout=10";
+        try (Connection conn = DriverManager.getConnection(timedUrl, user, pass);
              Statement st = conn.createStatement();
              ResultSet rs = st.executeQuery("SHOW CONFIG")) {
             // PgBouncer SHOW CONFIG returns columns: key, value, [changeable].

--- a/service/src/main/java/dev/nexus/service/db/PoolerModeCheck.java
+++ b/service/src/main/java/dev/nexus/service/db/PoolerModeCheck.java
@@ -1,0 +1,122 @@
+package dev.nexus.service.db;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * nexus-bhzuv — fail-closed startup assertion that an interposed PgBouncer is in
+ * {@code transaction} pool mode.
+ *
+ * <p>{@link TenantScope#withTenant} stamps the tenant with {@code set_config('nexus.tenant',
+ * ?, true)} — SET LOCAL (transaction-local) semantics. Under a SESSION-mode pooler the GUC
+ * is not reset at transaction boundary, so the backend returns to the pool still carrying
+ * the previous tenant's {@code nexus.tenant}; the next borrower inherits it and FORCE RLS
+ * evaluates as the wrong tenant → cross-tenant read. Only transaction-mode pooling is safe.
+ *
+ * <p>The checked-in {@code service/deploy/pgbouncer.ini} is the source of truth for the
+ * deployed config; this is the runtime backstop that refuses to serve against a pooler that
+ * does not actually report {@code pool_mode = transaction}.
+ *
+ * <p>NO-OP on the direct-PG (v1, no pooler) path: when {@code NX_PGBOUNCER_ADMIN_URL} is
+ * unset the check returns immediately, so local/dev {@code nx init --service} is unaffected.
+ */
+public final class PoolerModeCheck {
+
+    private static final Logger log = LoggerFactory.getLogger(PoolerModeCheck.class);
+
+    /** JDBC URL of the PgBouncer admin pseudo-database. Unset ⇒ no pooler ⇒ check no-ops. */
+    public static final String ADMIN_URL_ENV = "NX_PGBOUNCER_ADMIN_URL";
+    public static final String ADMIN_USER_ENV = "NX_PGBOUNCER_ADMIN_USER";
+    public static final String ADMIN_PASS_ENV = "NX_PGBOUNCER_ADMIN_PASS";
+
+    private static final String REQUIRED_POOL_MODE = "transaction";
+
+    private PoolerModeCheck() { }
+
+    /** Raised when the live pooler is not in transaction mode (or cannot be probed). */
+    public static final class PoolerModeException extends RuntimeException {
+        public PoolerModeException(String message) { super(message); }
+        public PoolerModeException(String message, Throwable cause) { super(message, cause); }
+    }
+
+    /**
+     * Pure extraction: pull the {@code pool_mode} value out of a {@code SHOW CONFIG}
+     * key→value map. Returns {@code null} when the key is absent (older/unknown pooler).
+     */
+    public static String extractPoolMode(Map<String, String> showConfig) {
+        return showConfig == null ? null : showConfig.get("pool_mode");
+    }
+
+    /**
+     * Pure assertion: throw unless {@code poolMode} is exactly {@code "transaction"}.
+     * Fail-closed — a null/blank/unknown value is a refusal, never a warn-and-continue.
+     */
+    public static void assertTransactionMode(String poolMode) {
+        if (poolMode == null || poolMode.isBlank()) {
+            throw new PoolerModeException(
+                    "pgbouncer pool_mode could not be determined (SHOW CONFIG had no pool_mode "
+                    + "row); refusing to serve — a session-mode pooler leaks the tenant GUC "
+                    + "across borrows (nexus-bhzuv)");
+        }
+        if (!REQUIRED_POOL_MODE.equals(poolMode)) {
+            throw new PoolerModeException(
+                    "pgbouncer pool_mode=" + poolMode + " but '" + REQUIRED_POOL_MODE
+                    + "' is required: SET LOCAL tenant GUC leaks across borrows under "
+                    + poolMode + "-mode pooling → cross-tenant read (nexus-bhzuv). Fix the "
+                    + "deployed pooler (see service/deploy/pgbouncer.ini)");
+        }
+    }
+
+    /**
+     * Startup backstop. No-op when {@link #ADMIN_URL_ENV} is unset (direct-PG path).
+     * Otherwise probes the PgBouncer admin console and throws {@link PoolerModeException}
+     * unless {@code pool_mode = transaction}. Reads env via {@link System#getenv}.
+     */
+    public static void verifyAtStartup() {
+        verifyAtStartup(System.getenv(ADMIN_URL_ENV),
+                        System.getenv(ADMIN_USER_ENV),
+                        System.getenv(ADMIN_PASS_ENV));
+    }
+
+    /** Testable form of {@link #verifyAtStartup()} with explicit admin connection params. */
+    public static void verifyAtStartup(String adminUrl, String adminUser, String adminPass) {
+        if (adminUrl == null || adminUrl.isBlank()) {
+            log.info("event=pooler_mode_check_skipped reason=no_pgbouncer_admin_url "
+                    + "note=\"direct-PG path, no interposed pooler\"");
+            return;
+        }
+        Map<String, String> config;
+        try {
+            config = fetchShowConfig(adminUrl, adminUser, adminPass);
+        } catch (SQLException e) {
+            throw new PoolerModeException(
+                    "could not probe PgBouncer admin console at " + adminUrl
+                    + " to verify pool_mode (nexus-bhzuv)", e);
+        }
+        String poolMode = extractPoolMode(config);
+        assertTransactionMode(poolMode);
+        log.info("event=pooler_mode_check_ok pool_mode={}", poolMode);
+    }
+
+    private static Map<String, String> fetchShowConfig(String adminUrl, String user, String pass)
+            throws SQLException {
+        Map<String, String> rows = new LinkedHashMap<>();
+        try (Connection conn = DriverManager.getConnection(adminUrl, user, pass);
+             Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery("SHOW CONFIG")) {
+            // PgBouncer SHOW CONFIG returns columns: key, value, [changeable].
+            while (rs.next()) {
+                rows.put(rs.getString("key"), rs.getString("value"));
+            }
+        }
+        return rows;
+    }
+}

--- a/service/src/main/java/dev/nexus/service/db/ScratchRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/ScratchRepository.java
@@ -58,8 +58,11 @@ public final class ScratchRepository {
      * GUC name for T1 tenant isolation.
      * Distinct from {@code nexus.tenant} (T2) to avoid conflating contexts
      * when T1 and T2 connections share a pool or sequential transactions.
+     * Aliases {@link TenantScope#T1_TENANT_GUC} so the allowlist (nexus-utnjt)
+     * stays the single source of truth — this must be a member of
+     * {@code TenantScope.PERMITTED_GUCS}.
      */
-    public static final String T1_TENANT_GUC = "nexus.t1_tenant";
+    public static final String T1_TENANT_GUC = TenantScope.T1_TENANT_GUC;
 
     private final TenantScope tenantScope;
 

--- a/service/src/main/java/dev/nexus/service/db/TenantScope.java
+++ b/service/src/main/java/dev/nexus/service/db/TenantScope.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -40,6 +41,28 @@ public final class TenantScope {
 
     private static final Logger log = LoggerFactory.getLogger(TenantScope.class);
 
+    /**
+     * Default tenant GUC (T2 / catalog RLS context). Derived from
+     * {@link TenantConstants#GUC_NAME} so the allowlist and the RLS policies can
+     * never drift to different literals (a drift is a silent RLS miss — see the
+     * class comment on {@link TenantConstants}).
+     */
+    public static final String DEFAULT_TENANT_GUC = TenantConstants.GUC_NAME;
+
+    /** T1-scratch tenant GUC (kept distinct so T1 and T2 RLS contexts never conflate). */
+    public static final String T1_TENANT_GUC = "nexus.t1_tenant";
+
+    /**
+     * Allowlist of GUC names {@link #withTenant(String, String, Function)} may stamp
+     * (nexus-utnjt). The GUC name is interpolated into the {@code set_config(...)} SQL
+     * (PostgreSQL does not accept a bind parameter for the setting name), so it is NOT
+     * injection-safe by parameterization the way the tenant VALUE is. Today every caller
+     * passes a {@code static final} literal, but an allowlist is the only durable guard
+     * against a future caller passing a request-derived name. This set is the single
+     * source of truth — the two literals above are members of it.
+     */
+    private static final Set<String> PERMITTED_GUCS = Set.of(DEFAULT_TENANT_GUC, T1_TENANT_GUC);
+
     private final DataSource dataSource;
 
     public TenantScope(DataSource dataSource) {
@@ -47,7 +70,8 @@ public final class TenantScope {
     }
 
     /**
-     * Execute {@code work} within a transaction stamped with {@code tenant}.
+     * Execute {@code work} within a transaction stamped with {@code tenant} using the
+     * default {@code nexus.tenant} GUC.
      *
      * <p>EAGER COMPLETION: the transaction is committed and the connection returned to the
      * pool before this method returns. Callers that need to stream results across the txn
@@ -66,15 +90,10 @@ public final class TenantScope {
      * @throws IllegalArgumentException if {@code tenant} is null or blank
      * @throws RuntimeException         if a {@link SQLException} occurs (wraps it) or
      *                                  if {@code work} throws (propagated after rollback)
-     */
-    /**
-     * Execute {@code work} within a transaction stamped with {@code tenant} using the
-     * default {@code nexus.tenant} GUC.
-     *
      * @see #withTenant(String, String, Function) for an overload with a custom GUC name
      */
     public <T> T withTenant(String tenant, Function<DSLContext, T> work) {
-        return withTenant(tenant, "nexus.tenant", work);
+        return withTenant(tenant, DEFAULT_TENANT_GUC, work);
     }
 
     /**
@@ -97,6 +116,13 @@ public final class TenantScope {
         if (gucName == null || gucName.isBlank()) {
             throw new IllegalArgumentException("gucName must not be null or blank");
         }
+        // nexus-utnjt: the GUC name is interpolated into the set_config SQL (PG takes no
+        // bind parameter for the setting name), so reject anything not on the allowlist
+        // BEFORE borrowing a connection. Blocks SQL injection into the session-GUC namespace.
+        if (!PERMITTED_GUCS.contains(gucName)) {
+            throw new IllegalArgumentException(
+                    "gucName not permitted: " + gucName + " (allowed: " + PERMITTED_GUCS + ")");
+        }
 
         Connection conn = null;
         try {
@@ -106,8 +132,9 @@ public final class TenantScope {
             conn.setAutoCommit(false);
 
             // Stamp the GUC — bind-safe parameterized call (S0.1 pattern verbatim).
-            // Use string concatenation only for the GUC name (a validated internal
-            // constant from code, not user input); value is always parameterized.
+            // The GUC name is concatenated (PG takes no bind param for the setting name)
+            // but has been validated against PERMITTED_GUCS above (nexus-utnjt), so it is
+            // an allowlisted name, not arbitrary input; the value is always parameterized.
             try (var ps = conn.prepareStatement("SELECT set_config('" + gucName + "', ?, true)")) {
                 ps.setString(1, tenant);
                 ps.execute();

--- a/service/src/test/java/dev/nexus/service/db/PoolerModeCheckTest.java
+++ b/service/src/test/java/dev/nexus/service/db/PoolerModeCheckTest.java
@@ -1,0 +1,76 @@
+package dev.nexus.service.db;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * nexus-bhzuv — pooler-mode fail-closed assertion + the shipped pgbouncer.ini artifact.
+ *
+ * <p>Pure-logic tests (no live pooler): the {@code transaction}-mode requirement and the
+ * fail-closed handling of session/missing modes. Plus a structural pin on the checked-in
+ * {@code service/deploy/pgbouncer.ini} so the version-controlled config can't drift to a
+ * session-mode setting unnoticed.
+ */
+class PoolerModeCheckTest {
+
+    @Test
+    void transactionModePasses() {
+        assertDoesNotThrow(() -> PoolerModeCheck.assertTransactionMode("transaction"));
+    }
+
+    @Test
+    void sessionModeFailsClosed() {
+        var ex = assertThrows(PoolerModeCheck.PoolerModeException.class,
+                () -> PoolerModeCheck.assertTransactionMode("session"));
+        assertTrue(ex.getMessage().contains("session"));
+    }
+
+    @Test
+    void statementAndUnknownModesFailClosed() {
+        assertThrows(PoolerModeCheck.PoolerModeException.class,
+                () -> PoolerModeCheck.assertTransactionMode("statement"));
+        assertThrows(PoolerModeCheck.PoolerModeException.class,
+                () -> PoolerModeCheck.assertTransactionMode(null));
+        assertThrows(PoolerModeCheck.PoolerModeException.class,
+                () -> PoolerModeCheck.assertTransactionMode("  "));
+    }
+
+    @Test
+    void extractPoolModeReadsTheRow() {
+        Map<String, String> cfg = new LinkedHashMap<>();
+        cfg.put("max_client_conn", "200");
+        cfg.put("pool_mode", "transaction");
+        assertEquals("transaction", PoolerModeCheck.extractPoolMode(cfg));
+        assertEquals(null, PoolerModeCheck.extractPoolMode(new LinkedHashMap<>()));
+        assertEquals(null, PoolerModeCheck.extractPoolMode(null));
+    }
+
+    @Test
+    void verifyAtStartupNoOpsWhenNoAdminUrl() {
+        // The direct-PG (no-pooler) v1 path must not require a pooler probe.
+        assertDoesNotThrow(() -> PoolerModeCheck.verifyAtStartup(null, null, null));
+        assertDoesNotThrow(() -> PoolerModeCheck.verifyAtStartup("  ", null, null));
+    }
+
+    @Test
+    void shippedPgbouncerIniPinsTransactionMode() throws Exception {
+        // service/ is the test working dir; the artifact lives at service/deploy/pgbouncer.ini.
+        Path ini = Path.of("deploy", "pgbouncer.ini");
+        assertTrue(Files.isRegularFile(ini),
+                "service/deploy/pgbouncer.ini must ship as a version-controlled artifact (nexus-bhzuv)");
+        String text = Files.readString(ini);
+        assertTrue(text.matches("(?s).*(?m)^\\s*pool_mode\\s*=\\s*transaction\\s*$.*"),
+                "pgbouncer.ini must set pool_mode = transaction");
+        assertTrue(!text.matches("(?s).*(?m)^\\s*pool_mode\\s*=\\s*session\\s*$.*"),
+                "pgbouncer.ini must NOT set pool_mode = session");
+    }
+}

--- a/service/src/test/java/dev/nexus/service/db/TenantScopeGucAllowlistTest.java
+++ b/service/src/test/java/dev/nexus/service/db/TenantScopeGucAllowlistTest.java
@@ -1,0 +1,105 @@
+package dev.nexus.service.db;
+
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * nexus-utnjt — the GUC-name allowlist in {@link TenantScope#withTenant(String, String,
+ * java.util.function.Function)} must reject any non-allowlisted GUC name (a future
+ * request-derived name is a SQL-injection vector into the session-GUC namespace, since
+ * the name is interpolated into {@code set_config(...)} not bound as a parameter).
+ *
+ * <p>Pure unit test, no live DB: the {@link DataSource} is a stub that increments a
+ * counter on {@code getConnection()} and otherwise throws. A rejected GUC name must
+ * throw {@link IllegalArgumentException} BEFORE any connection is borrowed, so the
+ * counter must stay at zero for every rejection case.
+ */
+class TenantScopeGucAllowlistTest {
+
+    /** Counts connection borrows; getConnection always throws so a borrow is also a failure. */
+    private static final class CountingDataSource implements DataSource {
+        final AtomicInteger borrows = new AtomicInteger();
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            borrows.incrementAndGet();
+            throw new SQLException("getConnection must not be reached for a rejected GUC name");
+        }
+
+        @Override public Connection getConnection(String username, String password) throws SQLException {
+            return getConnection();
+        }
+        @Override public PrintWriter getLogWriter() { return null; }
+        @Override public void setLogWriter(PrintWriter out) { }
+        @Override public void setLoginTimeout(int seconds) { }
+        @Override public int getLoginTimeout() { return 0; }
+        @Override public Logger getParentLogger() { return Logger.getAnonymousLogger(); }
+        @Override public <T> T unwrap(Class<T> iface) { return null; }
+        @Override public boolean isWrapperFor(Class<?> iface) { return false; }
+    }
+
+    private CountingDataSource ds;
+    private TenantScope scope;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        ds = new CountingDataSource();
+        scope = new TenantScope(ds);
+    }
+
+    @Test
+    void injectionShapedGucNameIsRejectedBeforeBorrow() {
+        String evil = "x', 'y', true); DROP TABLE memory; SELECT set_config('z";
+        assertThrows(IllegalArgumentException.class,
+                () -> scope.withTenant("tenant-a", evil, dsl -> null));
+        assertEquals(0, ds.borrows.get(),
+                "rejection must happen before a connection is borrowed");
+    }
+
+    @Test
+    void unknownButHarmlessGucNameIsRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> scope.withTenant("tenant-a", "nexus.not_a_real_guc", dsl -> null));
+        assertEquals(0, ds.borrows.get());
+    }
+
+    @Test
+    void nullAndBlankGucNamesStillRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> scope.withTenant("tenant-a", null, dsl -> null));
+        assertThrows(IllegalArgumentException.class,
+                () -> scope.withTenant("tenant-a", "  ", dsl -> null));
+        assertEquals(0, ds.borrows.get());
+    }
+
+    @Test
+    void permittedGucNamesPassValidationAndProceedToBorrow() {
+        // An allowlisted name passes the guard and proceeds to borrow a connection —
+        // our stub then throws, surfacing as a Runtime.. (wrapped SQLException). The
+        // borrow counter proving we got PAST the allowlist is the non-vacuous assertion.
+        for (String guc : new String[]{TenantScope.DEFAULT_TENANT_GUC, TenantScope.T1_TENANT_GUC}) {
+            ds.borrows.set(0);
+            assertThrows(RuntimeException.class,
+                    () -> scope.withTenant("tenant-a", guc, dsl -> null));
+            assertEquals(1, ds.borrows.get(),
+                    "allowlisted GUC '" + guc + "' must pass validation and borrow a connection");
+        }
+    }
+
+    @Test
+    void scratchRepositoryGucIsAMemberOfTheAllowlist() {
+        // Single-source-of-truth pin: ScratchRepository's public constant must alias
+        // TenantScope's, so it cannot drift out of the allowlist.
+        assertSame(TenantScope.T1_TENANT_GUC, ScratchRepository.T1_TENANT_GUC);
+    }
+}


### PR DESCRIPTION
Two tenant-isolation security hardenings in the `service/` Java module, from the synthetic-aperture remediation epic (`nexus-whh61`). Full `mvn` suite green (892 tests, 0 failures).

## nexus-utnjt — GUC-name allowlist
`TenantScope.withTenant(tenant, gucName, work)` interpolates `gucName` into `SELECT set_config('<name>', ?, true)` (PostgreSQL takes no bind parameter for a setting name). Only a null/blank guard existed; a future caller passing a request-derived name would reopen SQL injection into the session-GUC namespace.

- `PERMITTED_GUCS = {nexus.tenant, nexus.t1_tenant}`, rejected with `IllegalArgumentException` **before** a connection is borrowed.
- `DEFAULT_TENANT_GUC` now derives from `TenantConstants.GUC_NAME`; `ScratchRepository.T1_TENANT_GUC` aliases `TenantScope.T1_TENANT_GUC` — allowlist and RLS policies can't drift to different literals.
- `TenantScopeGucAllowlistTest` proves rejection is pre-borrow (counting `DataSource` stub: 0 borrows on rejection, exactly 1 for allowlisted names).

## nexus-bhzuv — fail-closed pooler-mode assertion
`set_config(..., true)` is SET LOCAL — only safe under transaction-mode pooling. Session-mode PgBouncer leaks the tenant GUC to the next borrower → cross-tenant read under FORCE RLS.

- `service/deploy/pgbouncer.ini` (`pool_mode = transaction` + `server_reset_query = DISCARD ALL`) as version-controlled pooler config.
- `PoolerModeCheck` probes the PgBouncer admin console (`SHOW CONFIG`) and `System.exit(1)`s unless `pool_mode=transaction`. Env-gated on `NX_PGBOUNCER_ADMIN_URL`, no-op on the direct-PG path, bounded JDBC connect/socket timeout (fail-fast, not hang). Wired into `Main` before HTTP bind.

## Review (stacked, sonnet — security/auth boundary)
code-review-expert + substantive-critic: 0 confirmed Critical after fixes. Applied: JDBC timeout (HIGH-1), orphaned-Javadoc removal (HIGH-2), honest skip-log wording (HIGH-3), `TenantConstants.GUC_NAME` drift-alias. The critic's scope finding — the probe is armed only when the env is set, with no mandated set point in the managed install — is **honestly scoped out** to follow-up `nexus-whh61.1` (install-epic / conexus RDR-166), since the bead forbids a hard default-fail (must no-op for local/dev) and defers the install home to RDR-166. Documented loudly in the `.ini`.

Beads: nexus-utnjt, nexus-bhzuv (closed post-merge). Relay: conexus RDR-166 must set `NX_PGBOUNCER_ADMIN_URL` in the managed install (nexus-whh61.1).