### PR TITLE
fix(daemon): TOCTOU reap guard + behaviour-based lifecycle gate (nexus-2mpns, nexus-9nv1d)

### DIFF
--- a/src/nexus/daemon/service_registry.py
+++ b/src/nexus/daemon/service_registry.py
@@ -356,10 +356,34 @@ class ServiceRegistry:
         if record is None:
             return None
         if not record.is_fresh(self._clock()):
-            with contextlib.suppress(OSError):
-                self._record_path(scope_key).unlink()
+            self._reap_if_still_stale(record)
             return None
         return record
+
+    def _reap_if_still_stale(self, stale: LeaseRecord) -> None:
+        """Reap an expired record, but only under the election flock and only
+        if the SAME record is still present and still stale (nexus-2mpns).
+
+        The naive ``unlink`` after an unguarded ``is_fresh`` check is a TOCTOU:
+        a concurrent ``publish``/``heartbeat`` can take the election flock and
+        ``os.replace`` a fresh, higher-generation live record into the window
+        between the freshness check and the unlink — the blind unlink would then
+        delete the *successor's* just-published live record by path. Mirror
+        ``relinquish``: re-read under the lock and only unlink when the record we
+        still see is the same stale lease (owner_token match) AND is still not
+        fresh. If a successor has published, leave it alone — it stays a
+        resolvable endpoint with no transient gap.
+        """
+        with self._elect(stale.scope_key):
+            current = self._read_record(stale.scope_key)
+            if current is None:
+                return
+            if current.owner_token != stale.owner_token:
+                return  # a successor owns it now; not ours to reap
+            if current.is_fresh(self._clock()):
+                return  # re-stamped fresh under the lock; leave the live record
+            with contextlib.suppress(OSError):
+                self._record_path(stale.scope_key).unlink()
 
     def mark_shutting_down(self, record: LeaseRecord) -> None:
         """Publish a shutdown marker so discoverers stop resolving us

--- a/tests/daemon/test_lifecycle_gate.py
+++ b/tests/daemon/test_lifecycle_gate.py
@@ -94,6 +94,53 @@ def test_election_flock_only_in_primitive() -> None:
     )
 
 
+# nexus-9nv1d Part B: behaviour-based companion to the name-based bans above.
+# The name-bans catch the SPECIFIC dead shapes P5 deleted; this catches a NEW
+# bespoke election lock under ANY name by allowlisting the modules that may
+# acquire an advisory flock and tripping on any new one.
+#
+# Why a MODULE allowlist and not "flock only in the primitive": fcntl.flock is
+# used legitimately across the tree for distinct, non-election purposes — the
+# general _locking primitive, per-tier SPAWN locks (t2/t3/storage daemons), the
+# migration serializer, the daemon CLI lock. A "flock => election" test would be
+# false-positive-ridden (the vacuous-gate trap nexus-9nv1d itself warns of).
+# The defensible signal is: a flock acquire in a module NOT on this vetted list
+# is an unreviewed lock — possibly a bespoke election — and must be justified
+# (route election through ServiceRegistry._elect, or add the module here with a
+# reason). Acquires WITHIN an allowed module are already vetted.
+_FLOCK_ALLOWED_MODULES = frozenset({
+    "_locking.py",                       # the general advisory-lock primitive
+    "daemon/service_registry.py",        # the ONLY election flock (_elect)
+    "daemon/storage_service_daemon.py",  # storage-daemon spawn lock
+    "daemon/t2_daemon.py",               # T2 spawn / heartbeat locks
+    "daemon/t3_daemon.py",               # T3 spawn lock
+    "db/migrations.py",                  # migration serialization lock
+    "commands/daemon.py",                # daemon CLI single-instance lock
+})
+
+
+def test_flock_acquire_sites_are_allowlisted() -> None:
+    """A flock acquire in a module not on the vetted list is an unreviewed lock
+    (possibly a bespoke election) — route election through the primitive or
+    justify the lock by adding the module to ``_FLOCK_ALLOWED_MODULES``."""
+    offenders: list[str] = []
+    for path in _py_files():
+        rel = path.relative_to(SRC_ROOT).as_posix()
+        if rel in _FLOCK_ALLOWED_MODULES:
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            stripped = line.lstrip()
+            if stripped.startswith("fcntl.flock(") and _ALLOW_TOKEN not in line:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}")
+    assert not offenders, (
+        "RDR-149 lifecycle gate (nexus-9nv1d): a flock acquire appeared in a "
+        "module not on _FLOCK_ALLOWED_MODULES. If this is daemon-scope election, "
+        "it MUST go through ServiceRegistry._elect, not a bespoke lock. If it is "
+        "a different, legitimate lock, add the module to the allowlist with a "
+        "reason. Offenders:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_gate_doc_exists() -> None:
     """The standing-gate doc itself must exist and name the primitive + the
     conformance suite -- the two artifacts every lifecycle fix must touch."""

--- a/tests/daemon/test_lifecycle_gate.py
+++ b/tests/daemon/test_lifecycle_gate.py
@@ -128,9 +128,8 @@ def test_flock_acquire_sites_are_allowlisted() -> None:
         rel = path.relative_to(SRC_ROOT).as_posix()
         if rel in _FLOCK_ALLOWED_MODULES:
             continue
-        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-            stripped = line.lstrip()
-            if stripped.startswith("fcntl.flock(") and _ALLOW_TOKEN not in line:
+        for lineno, line in _flock_acquire_lines(path.read_text(encoding="utf-8")):
+            if _ALLOW_TOKEN not in line:
                 offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}")
     assert not offenders, (
         "RDR-149 lifecycle gate (nexus-9nv1d): a flock acquire appeared in a "
@@ -139,6 +138,32 @@ def test_flock_acquire_sites_are_allowlisted() -> None:
         "a different, legitimate lock, add the module to the allowlist with a "
         "reason. Offenders:\n  " + "\n  ".join(offenders)
     )
+
+
+def _flock_acquire_lines(text: str) -> list[tuple[int, str]]:
+    """Yield (lineno, line) for every flock ACQUIRE in *text*.
+
+    Matches ``fcntl.flock(`` anywhere on the line (not just at line start, so an
+    assignment form ``x = fcntl.flock(...)`` is caught — HIGH-2) and excludes
+    ``LOCK_UN`` release calls. Gate tests prefer over-matching (a false positive
+    is a visible review prompt) to under-matching (a silent miss)."""
+    out: list[tuple[int, str]] = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        if "fcntl.flock(" in line and "LOCK_UN" not in line:
+            out.append((lineno, line))
+    return out
+
+
+def test_flock_acquire_allowlist_is_non_vacuous(tmp_path: pathlib.Path) -> None:
+    """Prove the scan actually FIRES on a bespoke flock acquire under a novel
+    name (the bead's explicit non-vacuity requirement). A synthetic offender in
+    a non-allowlisted module must be detected by the scan logic."""
+    synthetic = "import fcntl\n\ndef _my_bespoke_election(fd):\n    fcntl.flock(fd, fcntl.LOCK_EX)\n"
+    hits = _flock_acquire_lines(synthetic)
+    assert len(hits) == 1, "the scan must detect a bespoke flock acquire"
+    assert "LOCK_EX" in hits[0][1]
+    # And the release form must NOT be flagged.
+    assert _flock_acquire_lines("    fcntl.flock(fd, fcntl.LOCK_UN)\n") == []
 
 
 def test_gate_doc_exists() -> None:

--- a/tests/daemon/test_rdr149_lifecycle_conformance.py
+++ b/tests/daemon/test_rdr149_lifecycle_conformance.py
@@ -960,3 +960,42 @@ class TestLiveT3SelfHeal:
             shutil.rmtree(cd, ignore_errors=True)
         # stop() relinquished the lease.
         assert not disc.exists()
+
+
+class TestDiscoverReapToctou:
+    """RDR-149 regression (nexus-2mpns): discover()'s reap of an expired lease
+    must not delete a concurrently-published higher-generation live record.
+
+    Conformance-suite home per the CLAUDE.md daemon mandate (lifecycle fixes
+    land in the primitive AND this suite). The race: discover() reads a stale
+    record (unlocked), judges it stale, then a successor publishes a fresh
+    higher-generation record under the election flock; the OLD blind-unlink
+    would delete the successor's live record by path.
+    """
+
+    def _registry(self, config_dir: Path, clock: _FakeClock) -> ServiceRegistry:
+        return ServiceRegistry(
+            dir=config_dir, tier="t2", clock=clock, ttl=3.0, heartbeat_interval=1.0
+        )
+
+    def test_reap_cannot_delete_concurrently_published_successor(
+        self, config_dir: Path, clock: _FakeClock
+    ) -> None:
+        reg = self._registry(config_dir, clock)
+        endpoint = {"host": "127.0.0.1", "port": 5000}
+        stale = reg.publish("scope", endpoint=endpoint, version="1", owner_token="A")
+        clock.advance(10.0)  # A is now stale (ttl=3.0)
+
+        # Successor B publishes a fresh, higher-generation record (the race winner).
+        fresh = reg.publish("scope", endpoint={"host": "127.0.0.1", "port": 6000},
+                            version="1", owner_token="B")
+        assert fresh.generation > stale.generation
+
+        # The reap, fired with the captured stale record, must re-read under the
+        # flock and leave the successor's live record intact.
+        reg._reap_if_still_stale(stale)
+
+        survived = reg.discover("scope")
+        assert survived is not None, "successor's higher-generation record was reaped"
+        assert survived.owner_token == "B"
+        assert survived.generation == fresh.generation

--- a/tests/daemon/test_service_registry.py
+++ b/tests/daemon/test_service_registry.py
@@ -400,3 +400,51 @@ class TestSupervisor:
             start_owner=lambda: calls.append("start"),
         )
         assert calls == ["stop", "start"]
+
+
+# ---------------------------------------------------------------------------
+# discover reap is flock-guarded + ownership-checked (nexus-2mpns TOCTOU)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverReapToctou:
+    def test_discover_reaps_genuinely_stale_record(
+        self, registry: ServiceRegistry, clock: _FakeClock
+    ) -> None:
+        registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        clock.advance(10.0)  # past ttl=3.0 → A is stale
+        assert registry.discover("42") is None
+        assert not registry._record_path("42").exists(), "stale record must be reaped"
+
+    def test_reap_leaves_successors_fresh_record(
+        self, registry: ServiceRegistry, clock: _FakeClock
+    ) -> None:
+        # T0: owner A publishes, then goes stale.
+        stale_a = registry.publish("42", endpoint=_endpoint(5000), version="1", owner_token="A")
+        clock.advance(10.0)  # A now stale
+
+        # Race: a successor B publishes a fresh, higher-generation live record
+        # in the window before the reap fires.
+        fresh_b = registry.publish("42", endpoint=_endpoint(6000), version="1", owner_token="B")
+        assert fresh_b.generation > stale_a.generation
+
+        # The blind-unlink bug would delete B's record by path here. The guarded
+        # reap must re-read under the flock, see owner_token != A, and leave it.
+        registry._reap_if_still_stale(stale_a)
+
+        survived = registry.discover("42")
+        assert survived is not None, "successor's fresh record must NOT be reaped"
+        assert survived.owner_token == "B"
+        assert survived.endpoint["port"] == 6000
+
+    def test_reap_no_op_when_record_re_stamped_fresh_by_same_owner(
+        self, registry: ServiceRegistry, clock: _FakeClock
+    ) -> None:
+        stale_a = registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        clock.advance(10.0)
+        # Same owner heartbeats back to fresh (self-heal) under the lock before the reap.
+        registry.heartbeat(stale_a)
+        registry._reap_if_still_stale(stale_a)
+        live = registry.discover("42")
+        assert live is not None, "a re-stamped-fresh record must not be reaped"
+        assert live.owner_token == "A"

--- a/tests/daemon/test_service_registry.py
+++ b/tests/daemon/test_service_registry.py
@@ -437,6 +437,17 @@ class TestDiscoverReapToctou:
         assert survived.owner_token == "B"
         assert survived.endpoint["port"] == 6000
 
+    def test_reap_removes_shutdown_marked_record(
+        self, registry: ServiceRegistry, clock: _FakeClock
+    ) -> None:
+        # A shutting_down record is never fresh (status check) even within TTL —
+        # the primary signal a stopping daemon sends before relinquish(). The
+        # reap must remove it so discoverers don't skip a dead marker forever.
+        record = registry.publish("42", endpoint=_endpoint(), version="1", owner_token="A")
+        registry.mark_shutting_down(record)
+        assert registry.discover("42") is None
+        assert not registry._record_path("42").exists(), "shutdown-marked record must be reaped"
+
     def test_reap_no_op_when_record_re_stamped_fresh_by_same_owner(
         self, registry: ServiceRegistry, clock: _FakeClock
     ) -> None:


### PR DESCRIPTION
RDR-149 daemon-lifecycle hardening from the synthetic-aperture remediation epic (`nexus-whh61`). Full daemon suite green (560 passed).

## nexus-2mpns — TOCTOU in discover()'s reap
`ServiceRegistry.discover()` reaped an expired record with a blind `unlink` **after** an unguarded `is_fresh()` check. A concurrent `publish`/`heartbeat` takes the election flock and `os.replace`s a fresh, higher-generation live record into the check→unlink window — the blind unlink then deletes the **successor's** just-published live record by path, leaving the endpoint transiently unresolvable until the next heartbeat.

Fix mirrors the existing `relinquish()` template: `_reap_if_still_stale()` re-reads under the election flock and only unlinks when the same stale lease (`owner_token` match) is still present **and** still not fresh. 3 new tests cover: genuine-stale reaped, successor's fresh record survives, same-owner re-stamp survives.

## nexus-9nv1d Part B — behaviour-based lifecycle gate
Added `test_flock_acquire_sites_are_allowlisted`: a **module-allowlist** of flock-acquire sites so a new bespoke election lock under any name trips the RDR-149 gate (the existing name-bans only catch the specific P5-deleted shapes).

Chose a module-allowlist over the bead's "flock only in the primitive" proposal because `fcntl.flock` is used legitimately tree-wide for non-election locks (spawn locks, migration serializer, the `_locking` primitive) — a `flock⇒election` test would be false-positive-ridden, the exact **vacuous-gate trap the bead itself warns of**. Name-based bans kept as defense-in-depth.

**Part A descoped** (obsoleted-by-RDR-152): the T2-daemon `_WRITE_OPS` write-serialization it would invert is a SQLite single-writer property; service/PG is the hard default and has no per-op WAL serialization. Same disposition as essw3/1krqx/e8kx9.

Beads: nexus-2mpns (close post-merge), nexus-9nv1d (close post-merge, Part A descoped).