### PR TITLE
docs(vectors): de-cargo-cult ChromaDB-quota framing on pgvector write path (nexus-57dh4)

### DIFF
--- a/src/nexus/db/chroma_quotas.py
+++ b/src/nexus/db/chroma_quotas.py
@@ -2,7 +2,14 @@
 # Copyright (c) 2026 Hal Hildebrand. All rights reserved.
 """ChromaDB Cloud quota constants, error hierarchy, and validator (RDR-005).
 
-Single source of truth for all ChromaDB Cloud limits.
+Single source of truth for the ChromaDB-Cloud limits that govern the RETIRED
+Chroma backend — scoped to the migration READ source (``nexus.migration``).
+These are ChromaDB-Cloud free-tier quotas and DO NOT apply to the
+pgvector/Postgres service that serves T3 today (RDR-152/155): the service
+enforces dedup + conflict-merge server-side and has no 300-record / 16 KB write
+cap (nexus-57dh4). Do not reintroduce ``QUOTAS`` as a write-path validator on
+the service path; the only legitimate reuse there is a pragmatic request-size
+chunk, clearly labelled as such.
 Source: https://docs.trychroma.com/cloud/quotas-limits
 """
 from __future__ import annotations

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -484,7 +484,14 @@ class HttpVectorClient:
         embeddings: list[list[float]] | None = None,
         skip_existing: bool | None = None,
     ) -> None:
-        """Embed + quota-check + write via the Java service.
+        """Embed + write via the Java service.
+
+        Dedup + conflict-merge are SERVER-ENFORCED (nexus-57dh4): the service's
+        ``PgVectorRepository.upsertChunksInternal`` does first-wins in-batch dedup
+        and ``ON CONFLICT (tenant_id, collection, chash) DO UPDATE``. There is no
+        client-side quota check or 300-record cap on this path — the whole id set
+        is sent in one POST. (The old "quota-check" framing was a ChromaDB-Cloud
+        leftover; Postgres has no such limit.)
 
         CHUNKING STAYS PYTHON — this method is called with pre-chunked text.
         Embeddings are computed server-side by default (Seam B). The ONE
@@ -1012,12 +1019,18 @@ class HttpVectorClient:
         ``/v1/vectors/update-metadata`` endpoint so the frecency_score lands
         in the service's Chroma (the one search reads) — not daemon-Chroma.
 
-        Batches at MAX_RECORDS_PER_WRITE (300) to match the service's quota
-        validator and to mirror :meth:`T3Database.update_chunks` parity.
+        Sends in request-sized batches of 300 ids. NOTE (nexus-57dh4): this is a
+        pragmatic HTTP request-size chunk, NOT a backend quota — the pgvector
+        service has no 300-record limit (300 was a ChromaDB-Cloud free-tier quota,
+        inapplicable to Postgres). Dedup + conflict-merge are server-enforced in
+        ``PgVectorRepository.upsertChunksInternal`` (first-wins in-batch dedup +
+        ``ON CONFLICT DO UPDATE``); clients need not pre-dedup or quota-check.
+        The constant is reused only to keep a sane per-request size.
         """
         if not ids:
             return
         from nexus.db.chroma_quotas import QUOTAS  # noqa: PLC0415
+        # Request-size chunk only (see docstring) — not a backend quota.
         size = QUOTAS.MAX_RECORDS_PER_WRITE
         for start in range(0, len(ids), size):
             batch_ids  = ids[start : start + size]


### PR DESCRIPTION
F1 residue from the synthetic-aperture audit (`nexus-whh61`). The 300-record / 16 KB "quotas" referenced on the service write path are ChromaDB-Cloud free-tier limits — inapplicable to the pgvector/Postgres backend. Pure comment/doc relabel, **no behavioural change**.

- **`update_chunks`**: the 300-id batching is a pragmatic HTTP request-size chunk, not a backend quota validator — comment + docstring corrected (the loop stays; removing it would be a behavioural change the bead explicitly scopes out).
- **`upsert_chunks`**: dropped the "quota-check" framing; documented that dedup + conflict-merge are **server-enforced** (`PgVectorRepository.upsertChunksInternal` — first-wins in-batch dedup + `ON CONFLICT DO UPDATE`) and the whole id set ships in one POST.
- **`chroma_quotas.py`** docstring: narrowed from "all ChromaDB Cloud limits" to the **retired-Chroma migration read-source** scope, with an explicit do-not-reintroduce-as-write-validator note.

Pairs with `nexus-h29w1` (the CI gate that pins server-side enforcement so the cargo-cult can't creep back). Tests: `http_vector_client` parity + combined-query (48 passed). Bead: nexus-57dh4 (close post-merge).