### PR TITLE
refactor: re-home chunk_id() helper to nexus.chunk_identity (nexus-4pvho)

### DIFF
--- a/src/nexus/chunk_identity.py
+++ b/src/nexus/chunk_identity.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Canonical chunk natural-ID derivation (RDR-108 D1).
+
+The T3 chunk natural ID — the Chroma/pgvector record id a chunk collapses to —
+is ``sha256(chunk_text)[:32]`` (RDR-108 D1, bead nexus-kmb6). Identical chunk
+text in the same collection collapses to one record; the catalog
+``document_chunks`` manifest preserves position via ``(doc_id, position)``.
+
+This is the single definition of that derivation. It lives in a neutral module
+(not on the network client ``HttpVectorClient``, where it was a zero-caller
+staticmethod — nexus-4pvho) so every indexer write path imports ONE source of
+truth instead of re-spelling ``sha256(...).hexdigest()[:32]`` inline.
+"""
+from __future__ import annotations
+
+import hashlib
+
+#: Length of the chunk natural ID (hex chars) sliced from the full sha256 digest.
+CHUNK_ID_LEN: int = 32
+
+
+def chunk_id(text: str) -> str:
+    """The canonical chunk natural ID for *text*: ``sha256(text)[:32]``."""
+    return hashlib.sha256(text.encode()).hexdigest()[:CHUNK_ID_LEN]
+
+
+def chunk_id_from_hash(full_hexdigest: str) -> str:
+    """Derive the natural ID from an already-computed full sha256 hexdigest.
+
+    Byte-identical to ``chunk_id(text)`` when ``full_hexdigest ==
+    sha256(text).hexdigest()``. Use this at sites that ALSO need the full
+    64-char hash for other metadata, so the digest is computed exactly once.
+    """
+    return full_hexdigest[:CHUNK_ID_LEN]

--- a/src/nexus/code_indexer.py
+++ b/src/nexus/code_indexer.py
@@ -12,6 +12,8 @@ language tables (_COMMENT_CHARS, DEFINITION_TYPES).
 from __future__ import annotations
 
 import hashlib as _hl
+
+from nexus.chunk_identity import chunk_id_from_hash as _chunk_id_from_hash
 from pathlib import Path
 
 import structlog
@@ -392,7 +394,7 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
         # T3 record; the catalog manifest preserves position via
         # ``(doc_id, position)`` pointing at the shared chash.
         chunk_text_hash_full = _hl.sha256(chunk["text"].encode()).hexdigest()
-        chunk_chroma_id = chunk_text_hash_full[:32]
+        chunk_chroma_id = _chunk_id_from_hash(chunk_text_hash_full)  # nexus-4pvho
         class_ctx, method_ctx = _extract_context(
             source_bytes, language, chunk["line_start"] - 1, chunk["line_end"] - 1
         )

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -1180,14 +1180,6 @@ class HttpVectorClient:
             deleted += int(result.get("deleted", 0))
         return deleted
 
-    # ── Utility ──────────────────────────────────────────────────────────────
-
-    @staticmethod
-    def chunk_id(text: str) -> str:
-        """Compute the canonical chunk natural ID: sha256(text)[:32]."""
-        return hashlib.sha256(text.encode()).hexdigest()[:32]
-
-
 # ── Module-level routing helper ───────────────────────────────────────────────
 
 _vector_client_lock = threading.Lock()

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -7,6 +7,8 @@ override the collection name for other prefixes (e.g. ``rdr__``).
 from __future__ import annotations
 
 import hashlib
+
+from nexus.chunk_identity import chunk_id_from_hash as _chunk_id_from_hash
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -1037,7 +1039,7 @@ def _pdf_chunks(
         # ``chunk_id`` is the per-chunk Chroma natural-id:
         # ``chunk_text_hash[:32]`` per RDR-108 D1 (nexus-kmb6).
         chunk_text_hash_full = hashlib.sha256(chunk.text.encode()).hexdigest()
-        chunk_id = chunk_text_hash_full[:32]
+        chunk_id = _chunk_id_from_hash(chunk_text_hash_full)  # nexus-4pvho
         # RDR-101 Phase 5c dropped corpus, store_type, git_meta. Title kept.
         # RDR-108 Phase 3 dropped chunk_index, chunk_count, doc_id;
         # catalog manifest is authoritative.
@@ -1125,7 +1127,7 @@ def _markdown_chunks(
         # ``chunk_id`` is the per-chunk Chroma natural-id:
         # ``chunk_text_hash[:32]`` per RDR-108 D1 (nexus-kmb6).
         chunk_text_hash_full = hashlib.sha256(chunk.text.encode()).hexdigest()
-        chunk_id = chunk_text_hash_full[:32]
+        chunk_id = _chunk_id_from_hash(chunk_text_hash_full)  # nexus-4pvho
         # RDR-101 Phase 5c dropped corpus, store_type, git_meta. Title kept.
         # RDR-108 Phase 3 dropped chunk_index, chunk_count, doc_id;
         # catalog manifest is authoritative.

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -17,6 +17,8 @@ After all three stages complete, the orchestrator runs post-passes to:
 from __future__ import annotations
 
 import hashlib
+
+from nexus.chunk_identity import chunk_id as _chunk_id
 import json
 import struct
 import threading
@@ -234,7 +236,8 @@ def _embed_and_write_batch(
         # chunk_text_hash[:32] (matches code/prose/doc indexer write
         # paths). Identical chunk text in the same collection collapses
         # to one T3 record; the catalog manifest preserves position.
-        chunk_id = hashlib.sha256(chunk.text.encode()).hexdigest()[:32]
+        # nexus-4pvho: single source of truth in nexus.chunk_identity.
+        chunk_id = _chunk_id(chunk.text)
         meta = _build_chunk_metadata(
             chunk,
             content_hash=content_hash,

--- a/src/nexus/prose_indexer.py
+++ b/src/nexus/prose_indexer.py
@@ -13,6 +13,8 @@ doc_indexer._embed_with_fallback for CCE-aware embedding.
 from __future__ import annotations
 
 import hashlib as _hl
+
+from nexus.chunk_identity import chunk_id_from_hash as _chunk_id_from_hash
 from pathlib import Path
 
 import structlog
@@ -98,7 +100,7 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
             # ``chunk_chroma_id`` is the per-chunk Chroma natural-id:
             # ``chunk_text_hash[:32]`` per RDR-108 D1 (nexus-kmb6).
             chunk_text_hash_full = _hl.sha256(chunk.text.encode()).hexdigest()
-            chunk_chroma_id = chunk_text_hash_full[:32]
+            chunk_chroma_id = _chunk_id_from_hash(chunk_text_hash_full)  # nexus-4pvho
             # RDR-101 Phase 5c dropped corpus, store_type, git_meta. Title kept.
             # RDR-108 Phase 3 dropped chunk_index, chunk_count, doc_id;
             # catalog manifest is authoritative.
@@ -162,7 +164,7 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
             # ``chunk_chroma_id`` is the per-chunk Chroma natural-id:
             # ``chunk_text_hash[:32]`` per RDR-108 D1 (nexus-kmb6).
             chunk_text_hash_full = _hl.sha256(text.encode()).hexdigest()
-            chunk_chroma_id = chunk_text_hash_full[:32]
+            chunk_chroma_id = _chunk_id_from_hash(chunk_text_hash_full)  # nexus-4pvho
             chunk_start_char = _line_offsets[ls - 1] if 0 < ls <= len(_line_offsets) else 0
             chunk_end_char = (
                 _line_offsets[le] if le < len(_line_offsets) else len(content)

--- a/tests/test_chunk_identity.py
+++ b/tests/test_chunk_identity.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-4pvho — canonical chunk natural-ID helper (RDR-108 D1)."""
+from __future__ import annotations
+
+import hashlib
+
+from nexus.chunk_identity import CHUNK_ID_LEN, chunk_id, chunk_id_from_hash
+
+
+def test_chunk_id_is_sha256_first_32() -> None:
+    text = "RDR-108 D1 chunk text"
+    expected = hashlib.sha256(text.encode()).hexdigest()[:32]
+    assert chunk_id(text) == expected
+    assert len(chunk_id(text)) == CHUNK_ID_LEN == 32
+
+
+def test_chunk_id_from_hash_matches_chunk_id() -> None:
+    # The two derivations MUST be byte-identical — the indexer sites that keep
+    # the full hash for other metadata slice it via chunk_id_from_hash.
+    for text in ("", "a", "unicode: café", "x" * 5000):
+        full = hashlib.sha256(text.encode()).hexdigest()
+        assert chunk_id_from_hash(full) == chunk_id(text)
+
+
+def test_identical_text_collapses_to_one_id() -> None:
+    assert chunk_id("dup") == chunk_id("dup")
+    assert chunk_id("a") != chunk_id("b")
+
+
+def test_helper_no_longer_on_http_vector_client() -> None:
+    # nexus-4pvho re-homed the helper off the network client (it was a
+    # zero-caller staticmethod). Guard against re-homing it back.
+    from nexus.db.http_vector_client import HttpVectorClient
+
+    assert not hasattr(HttpVectorClient, "chunk_id"), (
+        "chunk_id must live in nexus.chunk_identity, not on the network client"
+    )


### PR DESCRIPTION
F8 from the synthetic-aperture audit (`nexus-whh61`). The canonical chunk natural-ID derivation (`sha256(text)[:32]`, RDR-108 D1) lived as a **zero-caller** `@staticmethod` on the network client `HttpVectorClient`, while 6 indexer sites recomputed it inline.

- New `src/nexus/chunk_identity.py`: `chunk_id(text)` + `chunk_id_from_hash(full)`.
- `pipeline_stages.py`: standalone recompute → `chunk_id(text)`.
- doc/prose/code indexers (5 sites): keep the full 64-char hash they already need for other metadata, slice the natural ID via `chunk_id_from_hash(full)` — one named definition, no inline `[:32]`.
- Removed the staticmethod from `http_vector_client` (zero callers confirmed).

**Behaviour-preserving**: `chunk_id_from_hash(sha256(text).hexdigest())` is byte-identical to `chunk_id(text)` — `test_chunk_identity` asserts it across edge cases, and a guard test pins that the helper does not return to the network client. Indexer suites green (157 passed). Bead: nexus-4pvho (close post-merge).