### PR TITLE
perf(search): parallelize cross-corpus fan-out (nexus-o51et)

### DIFF
--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -479,13 +479,25 @@ def search_cross_corpus(
     # Per-collection raw min-distance accumulator for search_telemetry rows.
     # Distinct from ``min_dropped_distance`` which covers only dropped items.
     min_raw_per_collection: dict[str, float | None] = {}
-    for col in collections:
+    # nexus-o51et: parallelize the per-collection fan-out. The previous serial
+    # loop issued one blocking ``t3.search`` round-trip per collection; for
+    # ``corpus=all`` (~thousands of collections) that serialized the dominant
+    # p95 network cost. Mirror the ThreadPoolExecutor(max_workers<=8) pattern
+    # already used by ``T3Database.list_collections`` for the count fan-out,
+    # staying within the ChromaDB ``MAX_CONCURRENT_READS=10`` quota. Each
+    # collection's result processing runs inside the worker; the merge below
+    # walks the deterministic ``collections`` order so result ordering and the
+    # diagnostic/telemetry accumulators are independent of completion order.
+    from concurrent.futures import ThreadPoolExecutor
+
+    from nexus.db.chroma_quotas import QUOTAS
+
+    def _search_one(col: str) -> dict:
         mult = _overfetch_multiplier(col)
         # Search review I-3: cap per_k at MAX_QUERY_RESULTS=300. Without
         # this, a large ``offset`` fed into ``fetch_n = offset + limit``
         # upstream multiplies by ``mult`` (up to 4×) and the per-collection
         # n_results punches through the ChromaDB Cloud quota.
-        from nexus.db.chroma_quotas import QUOTAS
         per_k = min(max(5, n_results * mult), QUOTAS.MAX_QUERY_RESULTS)
         if not apply_thresholds:
             threshold = None
@@ -499,13 +511,8 @@ def search_cross_corpus(
             # nexus-pebfx.8: one unservable collection (embedding-space
             # mismatch → service-side HTTP 400) must not sink the whole
             # cross-corpus search. Skip it, keep the rest.
-            failed_collections[col] = str(exc)
-            _log.warning(
-                "collection_search_failed",
-                collection=col,
-                error=str(exc),
-            )
-            continue
+            return {"col": col, "error": str(exc)}
+        results: list[SearchResult] = []
         dropped = 0
         # Minimum distance among dropped items — best-of-dropped, used by
         # SearchDiagnostics.worst_offender() for the "threshold bump" hint.
@@ -524,7 +531,7 @@ def search_cross_corpus(
                 if min_dropped_distance is None or distance < min_dropped_distance:
                     min_dropped_distance = distance
                 continue
-            all_results.append(SearchResult(
+            results.append(SearchResult(
                 id=r["id"],
                 content=r["content"],
                 distance=distance,
@@ -532,16 +539,51 @@ def search_cross_corpus(
                 metadata={k: v for k, v in r.items()
                           if k not in {"id", "content", "distance"}},
             ))
-        diag_per_collection[col] = (len(raw), dropped, threshold, min_dropped_distance)
-        min_raw_per_collection[col] = min_raw_distance
-        total_raw += len(raw)
-        total_dropped += dropped
-        if dropped:
+        return {
+            "col": col,
+            "error": None,
+            "results": results,
+            "raw_count": len(raw),
+            "dropped": dropped,
+            "threshold": threshold,
+            "min_dropped_distance": min_dropped_distance,
+            "min_raw_distance": min_raw_distance,
+        }
+
+    # ThreadPoolExecutor.map preserves input order and re-raises any
+    # non-``VectorServiceError`` from a worker (fail-loud, matching the prior
+    # serial behaviour where such errors bubbled out of the loop).
+    workers = min(8, len(collections))
+    if workers <= 1:
+        partials = [_search_one(c) for c in collections]
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            partials = list(pool.map(_search_one, collections))
+
+    for part in partials:
+        col = part["col"]
+        if part.get("error") is not None:
+            failed_collections[col] = part["error"]
+            _log.warning(
+                "collection_search_failed",
+                collection=col,
+                error=part["error"],
+            )
+            continue
+        all_results.extend(part["results"])
+        diag_per_collection[col] = (
+            part["raw_count"], part["dropped"], part["threshold"],
+            part["min_dropped_distance"],
+        )
+        min_raw_per_collection[col] = part["min_raw_distance"]
+        total_raw += part["raw_count"]
+        total_dropped += part["dropped"]
+        if part["dropped"]:
             _log.debug(
                 "threshold_filtered",
                 collection=col,
-                dropped=dropped,
-                threshold=threshold,
+                dropped=part["dropped"],
+                threshold=part["threshold"],
             )
 
     if failed_collections and len(failed_collections) == len(collections):

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -303,6 +303,96 @@ class TestThresholdOverride:
         )
         assert {r.id for r in results} == {"a"}
 
+
+class _ConcurrentFakeT3:
+    """T3 stand-in that records concurrency and lets per-collection latency be
+    tuned so completion order can be forced to differ from input order.
+
+    ``delays`` maps a collection name to the seconds its ``search`` sleeps.
+    ``raises`` is a set of collections that raise ``VectorServiceError``.
+    """
+
+    def __init__(self, results_by_col, delays=None, raises=None):
+        import threading
+        self._results = results_by_col
+        self._delays = delays or {}
+        self._raises = raises or set()
+        self._voyage_client = "fake-voyage"
+        self._lock = threading.Lock()
+        self._inflight = 0
+        self.max_inflight = 0
+
+    def search(self, query, collection_names, n_results=10, where=None):
+        import time
+        from nexus.db.http_vector_client import VectorServiceError
+        name = collection_names[0]
+        with self._lock:
+            self._inflight += 1
+            self.max_inflight = max(self.max_inflight, self._inflight)
+        try:
+            time.sleep(self._delays.get(name, 0.0))
+            if name in self._raises:
+                raise VectorServiceError(f"{name} unservable")
+            return self._results.get(name, [])
+        finally:
+            with self._lock:
+                self._inflight -= 1
+
+
+class TestParallelFanOut:
+    """nexus-o51et: the per-collection fan-out runs concurrently but the merge
+    is deterministic in ``collections`` order regardless of completion order,
+    and a single unservable collection does not sink the whole search.
+    """
+
+    def test_result_order_independent_of_completion_order(self):
+        # Earlier collections sleep longer, so they complete LAST. If the merge
+        # depended on completion order the per-collection blocks would be
+        # reversed; assert they follow input order instead.
+        cols = ["knowledge__a", "knowledge__b", "knowledge__c"]
+        t3 = _ConcurrentFakeT3(
+            {
+                "knowledge__a": [{"id": "a", "content": "x", "distance": 0.10}],
+                "knowledge__b": [{"id": "b", "content": "x", "distance": 0.10}],
+                "knowledge__c": [{"id": "c", "content": "x", "distance": 0.10}],
+            },
+            delays={"knowledge__a": 0.06, "knowledge__b": 0.03, "knowledge__c": 0.0},
+            raises=set(),
+        )
+        results = search_cross_corpus(
+            "test", cols, 10, t3, threshold_override=float("inf"),
+            cluster_by=None,
+        )
+        assert [r.collection for r in results] == cols
+        assert [r.id for r in results] == ["a", "b", "c"]
+
+    def test_fan_out_runs_concurrently(self):
+        cols = [f"knowledge__c{i}" for i in range(5)]
+        t3 = _ConcurrentFakeT3(
+            {c: [{"id": c, "content": "x", "distance": 0.10}] for c in cols},
+            delays={c: 0.05 for c in cols},
+        )
+        search_cross_corpus(
+            "test", cols, 10, t3, threshold_override=float("inf"),
+            cluster_by=None,
+        )
+        assert t3.max_inflight > 1  # genuinely parallel, not serialized
+
+    def test_one_failed_collection_does_not_sink_search(self):
+        cols = ["knowledge__ok", "knowledge__bad", "knowledge__ok2"]
+        t3 = _ConcurrentFakeT3(
+            {
+                "knowledge__ok": [{"id": "ok", "content": "x", "distance": 0.10}],
+                "knowledge__ok2": [{"id": "ok2", "content": "x", "distance": 0.10}],
+            },
+            raises={"knowledge__bad"},
+        )
+        results = search_cross_corpus(
+            "test", cols, 10, t3, threshold_override=float("inf"),
+            cluster_by=None,
+        )
+        assert {r.id for r in results} == {"ok", "ok2"}
+
     def test_override_applies_uniformly_across_collections(self):
         """One override replaces the per-corpus threshold for every collection."""
         t3 = _ThresholdFakeT3({


### PR DESCRIPTION
Parallelizes the per-collection fan-out in `search_cross_corpus` (was serial, one blocking round-trip per collection — the dominant p95 contributor for `corpus=all`). Uses `ThreadPoolExecutor(max_workers<=8)`, mirroring the existing `list_collections` count fan-out and staying within `MAX_CONCURRENT_READS=10`.

Determinism preserved: the merge walks the input `collections` order, so result ordering + diagnostic/telemetry accumulators are independent of completion order. Non-`VectorServiceError` failures still bubble (fail-loud); a single unservable collection degrades gracefully.

Scope note (service/PG-default lens, RDR-152): the bead also mentioned dropping the redundant per-collection `col.count()` and embed-once-per-model-group. Those live in the legacy Chroma `T3Database.search` path; under the service default the Java service owns embedding, so the high-value, backend-agnostic fix is the fan-out parallelization done here.

Tests: `TestParallelFanOut` asserts (1) result order independent of completion order, (2) genuine concurrency (max_inflight>1), (3) one failed collection does not sink the search.

Part of epic nexus-whh61.