### PR TITLE
fix(mcp): periodic orphan sweep from the heartbeat loop (nexus-zgqxm)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -93,6 +93,17 @@ _SHUTDOWN_IN_FLIGHT: bool = False
 #: the T2 ``_reassert_task`` discipline). ``None`` when no owned T1 is live.
 _T1_HEARTBEAT_TASK: Any = None
 
+#: nexus-zgqxm: minimum seconds between in-process orphan-sweeps driven by the
+#: heartbeat loop. The startup sweeps (lifespan Branch 3) only reap the
+#: PREVIOUS leak before spawning a new chroma; a host losing many MCPs
+#: ungracefully but spawning few new ones never re-enters the sweep and can
+#: exhaust ``kern.posix.sem.max=10000`` (2026-05-08 shakeout cleared 8,359
+#: semaphores). This periodic sweep closes that gap by reaping PPID=1 orphan
+#: resource-trackers / chromadbs WHILE a long-lived MCP runs, not only at its
+#: next startup. 600 s keeps the ``ps`` cost negligible relative to the leak
+#: timescale (orphans accrue over hours/days, not seconds).
+_PERIODIC_SWEEP_INTERVAL_S: float = 600.0
+
 
 async def _t1_heartbeat_loop(publisher: Any, interval: float) -> None:
     """Re-stamp the T1 lease every ``interval`` seconds and lazily re-key the
@@ -101,17 +112,64 @@ async def _t1_heartbeat_loop(publisher: Any, interval: float) -> None:
     RDR-149 P4: this is T1's self-heal re-assert (the #1114 fix) and its
     RF-2/CA-3 re-key driver. A tick that raises is logged at debug and the
     loop continues; only cancellation (clean shutdown) stops it.
+
+    nexus-zgqxm: the same loop also drives a periodic orphan sweep (every
+    ``_PERIODIC_SWEEP_INTERVAL_S``) so a long-lived MCP reaps PPID=1 orphan
+    resource-trackers / chromadbs continuously, not only at the next startup.
+    The live chroma's own ``server_pid`` is added to ``protected_pids`` so the
+    sweep can never target this session's own process.
     """
     import asyncio
+    import time
 
     import structlog
     _hb_log = structlog.get_logger("nexus.mcp.core")
+    last_sweep = time.monotonic()
     while True:
         await asyncio.sleep(interval)
         try:
             publisher.tick()
         except Exception as exc:  # never let a transient tick failure kill the loop
             _hb_log.debug("t1_heartbeat_tick_failed", error=str(exc))
+        now = time.monotonic()
+        if now - last_sweep >= _PERIODIC_SWEEP_INTERVAL_S:
+            last_sweep = now
+            _periodic_orphan_sweep()
+
+
+def _periodic_orphan_sweep() -> None:
+    """Reap PPID=1 orphan resource-trackers / chromadbs while an MCP is live.
+
+    nexus-zgqxm: the startup sweeps (lifespan Branch 3) run spawn-only and so
+    only ever clean the PREVIOUS leak. Driving the same sweeps from the
+    heartbeat loop closes the "many ungraceful exits, few new spawns" gap that
+    can exhaust the POSIX semaphore namespace. The live chroma's ``server_pid``
+    is protected so the sweep cannot touch this session's own tracker; the
+    parser's PPID=1 + ``min_age_seconds`` gates already exclude live children.
+    Best-effort: every failure is logged at debug and never propagates into the
+    heartbeat loop.
+    """
+    from nexus.session import (
+        sweep_orphan_resource_trackers,
+        sweep_orphan_t1_chromadbs,
+    )
+
+    server_pid = _OWNED_CHROMA.get("server_pid")
+    protected = {server_pid} if isinstance(server_pid, int) else set()
+    import structlog
+    _sweep_log = structlog.get_logger("nexus.mcp.core")
+    try:
+        n_trackers = sweep_orphan_resource_trackers(protected_pids=protected)
+        n_chromas = sweep_orphan_t1_chromadbs(protected_pids=protected)
+        if n_trackers or n_chromas:
+            _sweep_log.info(
+                "periodic_orphan_sweep",
+                trackers_reaped=n_trackers,
+                chromadbs_reaped=n_chromas,
+                protected_pid=server_pid,
+            )
+    except Exception as exc:
+        _sweep_log.debug("periodic_orphan_sweep_failed", error=str(exc))
 
 
 async def _cancel_t1_heartbeat_task() -> None:

--- a/tests/test_mcp_periodic_sweep.py
+++ b/tests/test_mcp_periodic_sweep.py
@@ -1,0 +1,99 @@
+"""nexus-zgqxm: the T1 heartbeat loop drives a periodic orphan sweep so a
+long-lived MCP reaps PPID=1 orphan resource-trackers / chromadbs continuously,
+not only at the next startup (closing the POSIX-semaphore exhaustion gap).
+"""
+import asyncio
+
+import pytest
+
+from nexus.mcp import core
+
+
+def test_periodic_sweep_protects_live_chroma_pid(monkeypatch):
+    """The live chroma ``server_pid`` is passed as ``protected_pids`` so the
+    sweep can never target this session's own tracker."""
+    captured: dict[str, set[int] | None] = {}
+
+    def _fake_trackers(*, protected_pids=None):
+        captured["trackers"] = protected_pids
+        return 0
+
+    def _fake_chromas(*, protected_pids=None):
+        captured["chromas"] = protected_pids
+        return 0
+
+    monkeypatch.setattr(
+        "nexus.session.sweep_orphan_resource_trackers", _fake_trackers
+    )
+    monkeypatch.setattr(
+        "nexus.session.sweep_orphan_t1_chromadbs", _fake_chromas
+    )
+    monkeypatch.setitem(core._OWNED_CHROMA, "server_pid", 424242)
+
+    core._periodic_orphan_sweep()
+
+    assert captured["trackers"] == {424242}
+    assert captured["chromas"] == {424242}
+
+
+def test_periodic_sweep_no_pid_uses_empty_protected(monkeypatch):
+    """No live chroma → empty protected set (still safe; PPID=1 gate applies)."""
+    captured: dict[str, set[int] | None] = {}
+    monkeypatch.setattr(
+        "nexus.session.sweep_orphan_resource_trackers",
+        lambda *, protected_pids=None: captured.setdefault("p", protected_pids) or 0,
+    )
+    monkeypatch.setattr(
+        "nexus.session.sweep_orphan_t1_chromadbs",
+        lambda *, protected_pids=None: 0,
+    )
+    core._OWNED_CHROMA.pop("server_pid", None)
+
+    core._periodic_orphan_sweep()
+
+    assert captured["p"] == set()
+
+
+def test_periodic_sweep_swallows_errors(monkeypatch):
+    """A sweep failure never propagates out of the heartbeat tick."""
+    def _boom(*, protected_pids=None):
+        raise RuntimeError("ps exploded")
+
+    monkeypatch.setattr(
+        "nexus.session.sweep_orphan_resource_trackers", _boom
+    )
+    monkeypatch.setattr(
+        "nexus.session.sweep_orphan_t1_chromadbs",
+        lambda *, protected_pids=None: 0,
+    )
+    # Must not raise.
+    core._periodic_orphan_sweep()
+
+
+def test_heartbeat_loop_triggers_periodic_sweep(monkeypatch):
+    """With the interval forced to 0, the loop runs the sweep on its ticks."""
+    calls = {"sweep": 0, "tick": 0}
+
+    class _Publisher:
+        def tick(self):
+            calls["tick"] += 1
+
+    monkeypatch.setattr(core, "_PERIODIC_SWEEP_INTERVAL_S", 0.0)
+    monkeypatch.setattr(
+        core, "_periodic_orphan_sweep", lambda: calls.__setitem__("sweep", calls["sweep"] + 1)
+    )
+
+    async def _run():
+        loop_task = asyncio.create_task(
+            core._t1_heartbeat_loop(_Publisher(), interval=0.001)
+        )
+        await asyncio.sleep(0.05)
+        loop_task.cancel()
+        try:
+            await loop_task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_run())
+    assert calls["tick"] >= 1
+    assert calls["sweep"] >= 1


### PR DESCRIPTION
POSIX-semaphore reaping was **startup-only** — `sweep_orphan_*` ran from the single MCP-lifespan spawn site (`mcp/core.py`), cleaning only the PREVIOUS leak before spawning a new chroma. A host losing many MCPs ungracefully but spawning few new ones never re-enters the sweep and can exhaust `kern.posix.sem.max=10000` (2026-05-08 shakeout cleared 8,359 semaphores in one batch).

**Fix:** drive the same orphan sweeps periodically (every `_PERIODIC_SWEEP_INTERVAL_S=600s`) from the existing T1 heartbeat loop, so a long-lived MCP reaps PPID=1 orphan resource-trackers / chromadbs continuously rather than only at its next startup.

**Safety:** the live chroma `server_pid` is added to `protected_pids` so the sweep can never target this session's own tracker; the parser's PPID=1 + `min_age_seconds` gates already exclude live children. Best-effort — failures are logged at debug and never break the heartbeat loop.

Extends closed nexus-9h1s (which added `start_new_session=True` + the startup sweeps but not a recurring sweep). Part of epic nexus-whh61.

Tests: `tests/test_mcp_periodic_sweep.py` — protected-pid wiring, empty-pid safety, error-swallowing, and loop-triggers-sweep.