### PR TITLE
perf(catalog): batch manifest/resolve endpoints kill search N+1 (nexus-7lm3q)

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -1090,6 +1090,70 @@ public final class CatalogRepository {
         );
     }
 
+    /**
+     * Batch-fetch manifest rows for multiple doc_ids (nexus-7lm3q).
+     *
+     * <p>Executes {@code SELECT ... FROM catalog_document_chunks WHERE doc_id IN (?)}
+     * once for all requested doc_ids, returning a per-doc-id map of manifest rows.
+     * Doc_ids with no rows are absent from the result map. Mirrors the shape of
+     * {@link #getManifest} but for N docs in one DB round-trip instead of N round-trips.
+     *
+     * @return {@code {docId -> [manifest rows ordered by position]}}
+     */
+    public Map<String, List<Map<String, Object>>> getManifestMany(String tenant, List<String> docIds) {
+        if (docIds == null || docIds.isEmpty()) return Map.of();
+        return tenantScope.withTenant(tenant, ctx -> {
+            var rows = ctx.select(F_CHK_DOC, F_CHK_POS, F_CHK_CHASH, F_CHK_IDX,
+                                  F_CHK_LST, F_CHK_LEN, F_CHK_CST, F_CHK_CEN)
+                          .from(T_CHUNKS)
+                          .where(F_CHK_DOC.in(docIds))
+                          .orderBy(F_CHK_DOC, F_CHK_POS)
+                          .fetch();
+            Map<String, List<Map<String, Object>>> result = new LinkedHashMap<>();
+            for (var r : rows) {
+                String docId = r.value1();
+                Map<String, Object> m = new LinkedHashMap<>();
+                m.put("doc_id",      docId);
+                m.put("position",    r.value2());
+                m.put("chash",       r.value3());
+                m.put("chunk_index", r.value4());
+                m.put("line_start",  r.value5());
+                m.put("line_end",    r.value6());
+                m.put("char_start",  r.value7());
+                m.put("char_end",    r.value8());
+                result.computeIfAbsent(docId, k -> new ArrayList<>()).add(m);
+            }
+            return result;
+        });
+    }
+
+    /**
+     * Batch-resolve multiple doc_ids to full document entries (nexus-7lm3q).
+     *
+     * <p>Executes {@code SELECT ... FROM catalog_documents WHERE tumbler IN (?)}
+     * once for all requested doc_ids, returning a per-doc-id map of document rows
+     * (same shape as {@link #getDocument}). Doc_ids with no matching document are
+     * absent from the result map.
+     *
+     * @return {@code {docId -> document row dict}}
+     */
+    public Map<String, Map<String, Object>> resolveMany(String tenant, List<String> docIds) {
+        if (docIds == null || docIds.isEmpty()) return Map.of();
+        return tenantScope.withTenant(tenant, ctx -> {
+            var rows = ctx.select(documentFields())
+                          .from(T_DOCS)
+                          .where(F_DOC_TUMBLER.in(docIds).and(F_DOC_DELETED_AT.isNull()))
+                          .fetch();
+            Map<String, Map<String, Object>> result = new LinkedHashMap<>();
+            for (var r : rows) {
+                Map<String, Object> doc = docRowFromRecord(r.intoMap());
+                String tumbler = (String) doc.get("tumbler");
+                if (tumbler != null) result.put(tumbler, doc);
+            }
+            return result;
+        });
+    }
+
     /** Resync chunk_count on catalog_documents from manifest row count. */
     public int resyncChunkCount(String tenant, String docId) {
         return tenantScope.withTenant(tenant, ctx -> {

--- a/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
@@ -44,9 +44,11 @@ import java.util.*;
  *   POST  /v1/catalog/manifest/write     replace manifest
  *   POST  /v1/catalog/manifest/append    append chunks
  *   GET   /v1/catalog/manifest/get       get manifest for doc_id
+ *   POST  /v1/catalog/manifest/get_many  batch-fetch manifests for multiple doc_ids (nexus-7lm3q)
  *   POST  /v1/catalog/manifest/purge     purge manifest for doc_id
  *   GET   /v1/catalog/manifest/chashes   chashes for collection
  *   POST  /v1/catalog/manifest/resync    recompute chunk_count from manifest row count
+ *   POST  /v1/catalog/resolve_many       batch-resolve multiple doc_ids to entries (nexus-7lm3q)
  *   POST  /v1/catalog/owners/upsert      upsert owner
  *   GET   /v1/catalog/owners/list        list all owners
  *   GET   /v1/catalog/owners/by_repo     get owner by repo_hash
@@ -123,6 +125,7 @@ public final class CatalogHandler implements HttpHandler {
                 case "/manifest/write"        -> handleManifestWrite(exchange, tenant, method);
                 case "/manifest/append"       -> handleManifestAppend(exchange, tenant, method);
                 case "/manifest/get"          -> handleManifestGet(exchange, tenant, method);
+                case "/manifest/get_many"     -> handleManifestGetMany(exchange, tenant, method);
                 case "/manifest/purge"        -> handleManifestPurge(exchange, tenant, method);
                 case "/manifest/chashes"      -> handleManifestChashes(exchange, tenant, method);
                 case "/manifest/docs_for_chashes" -> handleDocsForChashes(exchange, tenant, method);
@@ -170,6 +173,9 @@ public final class CatalogHandler implements HttpHandler {
                 // ── Scoring hot-path batch endpoints (nexus-qnp5s) ───────────
                 case "/docs/chunk-counts"     -> handleDocChunkCounts(exchange, tenant, method);
                 case "/links/from-batch"      -> handleLinksFromBatch(exchange, tenant, method);
+
+                // ── Batch resolve endpoints (nexus-7lm3q) ────────────────────
+                case "/resolve_many"          -> handleResolveMany(exchange, tenant, method);
 
                 // ── Server-side tumbler assignment ────────────────────────────
                 case "/doc/register"          -> handleDocRegister(exchange, tenant, method);
@@ -514,6 +520,60 @@ public final class CatalogHandler implements HttpHandler {
             : List.of();
         var docs = repo.docsForChashes(tenant, chashes);
         HttpUtil.send(exchange, 200, MAPPER.writeValueAsString(Map.of("tumblers", docs)));
+    }
+
+    /**
+     * POST /v1/catalog/manifest/get_many (nexus-7lm3q)
+     *
+     * <p>Batch-fetch manifest rows for multiple doc_ids in a single round-trip,
+     * replacing the N per-doc {@code /manifest/get} loop issued by
+     * {@code _attach_doc_ids_from_catalog} in {@code search_engine.py}.
+     *
+     * <p>Request body:  {@code {"doc_ids": ["tumbler1", "tumbler2", ...]}}
+     * Response body:   {@code {"manifests": {"tumbler1": [rows...], "tumbler2": [rows...]}}}
+     *
+     * <p>Doc_ids with no manifest rows are absent from the response map.
+     */
+    @SuppressWarnings("unchecked")
+    private void handleManifestGetMany(HttpExchange exchange, String tenant, String method) throws IOException {
+        if (!"POST".equals(method)) { HttpUtil.send(exchange, 405, "{\"error\":\"method not allowed\"}"); return; }
+        Map<String, Object> body = readBody(exchange);
+        Object raw = body.get("doc_ids");
+        List<String> docIds = raw instanceof List<?> l
+            ? l.stream().filter(o -> o instanceof String).map(o -> (String) o).toList()
+            : List.of();
+        if (docIds.isEmpty()) {
+            HttpUtil.send(exchange, 200, "{\"manifests\":{}}"); return;
+        }
+        var manifests = repo.getManifestMany(tenant, docIds);
+        HttpUtil.send(exchange, 200, MAPPER.writeValueAsString(Map.of("manifests", manifests)));
+    }
+
+    /**
+     * POST /v1/catalog/resolve_many (nexus-7lm3q)
+     *
+     * <p>Batch-resolve multiple doc_ids to full document entries in a single
+     * round-trip, replacing the N per-doc {@code /show?tumbler=X} calls issued
+     * by {@code _attach_display_paths} in {@code search_engine.py}.
+     *
+     * <p>Request body:  {@code {"doc_ids": ["tumbler1", "tumbler2", ...]}}
+     * Response body:   {@code {"entries": {"tumbler1": {doc...}, "tumbler2": {doc...}}}}
+     *
+     * <p>Doc_ids with no matching document are absent from the response map.
+     */
+    @SuppressWarnings("unchecked")
+    private void handleResolveMany(HttpExchange exchange, String tenant, String method) throws IOException {
+        if (!"POST".equals(method)) { HttpUtil.send(exchange, 405, "{\"error\":\"method not allowed\"}"); return; }
+        Map<String, Object> body = readBody(exchange);
+        Object raw = body.get("doc_ids");
+        List<String> docIds = raw instanceof List<?> l
+            ? l.stream().filter(o -> o instanceof String).map(o -> (String) o).toList()
+            : List.of();
+        if (docIds.isEmpty()) {
+            HttpUtil.send(exchange, 200, "{\"entries\":{}}"); return;
+        }
+        var entries = repo.resolveMany(tenant, docIds);
+        HttpUtil.send(exchange, 200, MAPPER.writeValueAsString(Map.of("entries", entries)));
     }
 
     /**

--- a/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
@@ -639,6 +639,73 @@ class CatalogRepositoryTest {
         assertThat(doc.get("chunk_count")).isEqualTo(3);
     }
 
+    // ── nexus-7lm3q: batch manifest/resolve endpoints ────────────────────────
+
+    @Test @Order(55)
+    void manifest_getManifestMany_batchFetchesAllDocs() {
+        // Seed two docs each with two chunks
+        repo.upsertDocument(TENANT_A, Map.of("tumbler", "gmm.1", "title", "GMM Doc1",
+            "content_type", "paper", "corpus", "knowledge"));
+        repo.writeManifest(TENANT_A, "gmm.1", List.of(
+            Map.<String, Object>of("position", 0, "chash", "gmm1aa00000000000000000000000000", "chunk_index", 0),
+            Map.<String, Object>of("position", 1, "chash", "gmm1bb00000000000000000000000000", "chunk_index", 1)
+        ));
+        repo.upsertDocument(TENANT_A, Map.of("tumbler", "gmm.2", "title", "GMM Doc2",
+            "content_type", "paper", "corpus", "knowledge"));
+        repo.writeManifest(TENANT_A, "gmm.2", List.of(
+            Map.<String, Object>of("position", 0, "chash", "gmm2cc00000000000000000000000000", "chunk_index", 0)
+        ));
+
+        var result = repo.getManifestMany(TENANT_A, List.of("gmm.1", "gmm.2", "gmm.nonexistent"));
+
+        // Two docs found, one absent (not keyed to empty list)
+        assertThat(result).containsOnlyKeys("gmm.1", "gmm.2");
+        assertThat(result.get("gmm.1")).hasSize(2);
+        assertThat(result.get("gmm.2")).hasSize(1);
+        // Ordered by position within each doc
+        assertThat(result.get("gmm.1").get(0).get("chash")).isEqualTo("gmm1aa00000000000000000000000000");
+        assertThat(result.get("gmm.1").get(1).get("chash")).isEqualTo("gmm1bb00000000000000000000000000");
+        assertThat(result.get("gmm.2").get(0).get("chash")).isEqualTo("gmm2cc00000000000000000000000000");
+    }
+
+    @Test @Order(56)
+    void manifest_getManifestMany_emptyInput_returnsEmptyMap() {
+        var result = repo.getManifestMany(TENANT_A, List.of());
+        assertThat(result).isEmpty();
+    }
+
+    @Test @Order(57)
+    void resolveMany_batchFetchesDocuments() {
+        repo.upsertDocument(TENANT_A, Map.of("tumbler", "rmany.1", "title", "Resolve Many 1",
+            "content_type", "code", "corpus", "code",
+            "file_path", "/src/nexus/search_engine.py"));
+        repo.upsertDocument(TENANT_A, Map.of("tumbler", "rmany.2", "title", "Resolve Many 2",
+            "content_type", "paper", "corpus", "knowledge",
+            "file_path", "/papers/test.pdf"));
+
+        var result = repo.resolveMany(TENANT_A, List.of("rmany.1", "rmany.2", "rmany.absent"));
+
+        assertThat(result).containsOnlyKeys("rmany.1", "rmany.2");
+        assertThat(result.get("rmany.1").get("file_path")).isEqualTo("/src/nexus/search_engine.py");
+        assertThat(result.get("rmany.1").get("content_type")).isEqualTo("code");
+        assertThat(result.get("rmany.2").get("file_path")).isEqualTo("/papers/test.pdf");
+    }
+
+    @Test @Order(58)
+    void resolveMany_emptyInput_returnsEmptyMap() {
+        var result = repo.resolveMany(TENANT_A, List.of());
+        assertThat(result).isEmpty();
+    }
+
+    @Test @Order(59)
+    void resolveMany_tenantIsolation() {
+        // A doc in TENANT_B must not appear when querying TENANT_A
+        repo.upsertDocument(TENANT_B, Map.of("tumbler", "rmiso.1", "title", "Tenant B Doc",
+            "content_type", "paper", "corpus", "knowledge"));
+        var result = repo.resolveMany(TENANT_A, List.of("rmiso.1"));
+        assertThat(result).isEmpty();
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // COLLECTIONS
     // ══════════════════════════════════════════════════════════════════════════

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1987,6 +1987,15 @@ class Catalog:
         """Return ordered manifest rows for ``doc_id`` (nexus-572g K6)."""
         return self._writes.get_manifest(doc_id)
 
+    def get_manifests(self, doc_ids: list[str]) -> "dict[str, list[_ManifestRow]]":
+        """Batch-fetch manifest rows for multiple doc_ids (nexus-7lm3q).
+
+        Returns a dict keyed by doc_id; each value is the ordered list of
+        ManifestRow objects. Doc_ids with no rows are absent from the result.
+        Delegates to ``_CatalogWrites.get_manifests``.
+        """
+        return self._writes.get_manifests(doc_ids)
+
     def get_chunk_chashes(self, doc_id: str) -> list[str]:
         """Return the ordered list of chashes for ``doc_id`` (RDR-108
         Phase 4b / nexus-kosc). Convenience wrapper over ``get_manifest``
@@ -2061,6 +2070,15 @@ class Catalog:
     def by_doc_id(self, doc_id: str) -> CatalogEntry | None:
         """Delegates to ``_DocumentOps.by_doc_id`` (nexus-mbm)."""
         return self._docs.by_doc_id(doc_id)
+
+    def resolve_many(self, doc_ids: list[str]) -> "dict[str, CatalogEntry]":
+        """Batch-resolve multiple doc_ids to CatalogEntry objects (nexus-7lm3q).
+
+        Returns a dict keyed by doc_id; each value is the matching
+        CatalogEntry. Doc_ids with no matching document are absent from
+        the result. Delegates to ``_DocumentOps.resolve_many``.
+        """
+        return self._docs.resolve_many(doc_ids)
 
     def lookup_doc_id_by_collection_and_path(
         self, collection: str, source_path: str,

--- a/src/nexus/catalog/catalog_docs.py
+++ b/src/nexus/catalog/catalog_docs.py
@@ -781,3 +781,55 @@ class _DocumentOps:
             source_uri=row[13] or "",
         )
 
+    def resolve_many(
+        self, doc_ids: list[str],
+    ) -> "dict[str, CatalogEntry]":
+        """Batch-resolve multiple doc_ids to CatalogEntry objects (nexus-7lm3q).
+
+        Executes a single ``SELECT ... WHERE json_extract(metadata,'$.doc_id')
+        IN (?)`` instead of N per-doc ``by_doc_id()`` calls. Returns a dict
+        keyed by doc_id; each value is the matching CatalogEntry. Doc_ids with
+        no matching document are absent from the result. Batched at 200 doc_ids
+        per query to stay safely below SQLite's variable limit while remaining
+        within the JsonExtract overhead tolerance.
+        """
+        if not doc_ids:
+            return {}
+        cat = self._cat
+        from nexus.catalog.catalog import CatalogEntry
+        result: dict[str, CatalogEntry] = {}
+        _BATCH = 200
+        for i in range(0, len(doc_ids), _BATCH):
+            batch = doc_ids[i : i + _BATCH]
+            placeholders = ", ".join(["?"] * len(batch))
+            rows = cat._db.execute(
+                f"SELECT json_extract(metadata, '$.doc_id'), "
+                f"tumbler, title, author, year, content_type, file_path, "
+                f"corpus, physical_collection, chunk_count, head_hash, "
+                f"indexed_at, metadata, source_mtime, source_uri "
+                f"FROM documents "
+                f"WHERE json_extract(metadata, '$.doc_id') IN ({placeholders})",
+                batch,
+            ).fetchall()
+            for row in rows:
+                queried_doc_id = row[0]
+                if not queried_doc_id:
+                    continue
+                result[queried_doc_id] = CatalogEntry(
+                    tumbler=Tumbler.parse(row[1]),
+                    title=row[2],
+                    author=row[3],
+                    year=row[4],
+                    content_type=row[5],
+                    file_path=row[6],
+                    corpus=row[7],
+                    physical_collection=row[8],
+                    chunk_count=row[9],
+                    head_hash=row[10],
+                    indexed_at=row[11],
+                    meta=json.loads(row[12]) if row[12] else {},
+                    source_mtime=row[13] or 0.0,
+                    source_uri=row[14] or "",
+                )
+        return result
+

--- a/src/nexus/catalog/catalog_writes.py
+++ b/src/nexus/catalog/catalog_writes.py
@@ -1021,6 +1021,49 @@ class _WriteOps:
             for row in rows
         ]
 
+    def get_manifests(self, doc_ids: list[str]) -> "dict[str, list[ManifestRow]]":
+        """Batch-fetch manifest rows for multiple doc_ids (nexus-7lm3q).
+
+        Executes a single ``SELECT ... WHERE doc_id IN (?)`` instead of
+        N per-doc ``get_manifest()`` calls. Returns a dict keyed by doc_id;
+        each value is the ordered list of ManifestRow objects (same shape
+        as ``get_manifest()``). Doc_ids with no rows are absent from the
+        result. Batched at 500 doc_ids per query to stay safely under
+        SQLite's ``SQLITE_LIMIT_VARIABLE_NUMBER``.
+        """
+        if not doc_ids:
+            return {}
+        cat = self._cat
+        result: dict[str, list[ManifestRow]] = {}
+        _BATCH = 500
+        for i in range(0, len(doc_ids), _BATCH):
+            batch = doc_ids[i : i + _BATCH]
+            placeholders = ", ".join(["?"] * len(batch))
+            rows = cat._db.execute(
+                f"SELECT doc_id, position, chash, chunk_index, "
+                f"line_start, line_end, char_start, char_end "
+                f"FROM document_chunks "
+                f"WHERE doc_id IN ({placeholders}) "
+                f"ORDER BY doc_id, position",
+                batch,
+            ).fetchall()
+            for row in rows:
+                doc_id = row[0]
+                if doc_id not in result:
+                    result[doc_id] = []
+                result[doc_id].append(
+                    ManifestRow(
+                        position=row[1],
+                        chash=row[2],
+                        chunk_index=row[3],
+                        line_start=row[4],
+                        line_end=row[5],
+                        char_start=row[6],
+                        char_end=row[7],
+                    )
+                )
+        return result
+
     def chashes_for_collection(self, physical_collection: str) -> set[str]:
         """Return the set of chunk natural IDs (chash[:32]) referenced by
         the manifest for documents in ``physical_collection`` (RDR-108

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -746,6 +746,30 @@ class HttpCatalogClient:
     def by_doc_id(self, doc_id: str) -> CatalogEntry | None:
         return self.resolve(doc_id)
 
+    def resolve_many(self, doc_ids: list[str]) -> "dict[str, CatalogEntry]":
+        """Batch-resolve multiple doc_ids to CatalogEntry objects.
+
+        nexus-7lm3q: replaces the N per-doc ``by_doc_id()`` loop in
+        ``_attach_display_paths`` (search_engine.py) so a single search
+        with M distinct docs pays ONE catalog round-trip instead of M.
+        Mirrors ``POST /v1/catalog/resolve_many`` → Java
+        ``CatalogHandler.handleResolveMany`` /
+        ``CatalogRepository.resolveMany``.
+
+        Returns a dict keyed by doc_id; each value is a CatalogEntry.
+        Missing or unresolvable doc_ids are absent from the result.
+        """
+        if not doc_ids:
+            return {}
+        result = self._post("/resolve_many", {"doc_ids": doc_ids})
+        if not result:
+            return {}
+        entries: dict[str, CatalogEntry] = {}
+        for doc_id, raw in result.get("entries", {}).items():
+            if raw and raw.get("tumbler"):
+                entries[doc_id] = _to_entry(raw)
+        return entries
+
     def lookup_doc_id_by_collection_and_path(
         self, collection: str, file_path: str
     ) -> str | None:
@@ -1125,6 +1149,25 @@ class HttpCatalogClient:
     def get_manifest(self, doc_id: str) -> list[Any]:
         result = self._get("/manifest/get", doc_id=doc_id)
         return result.get("rows", []) if result else []
+
+    def get_manifests(self, doc_ids: list[str]) -> dict[str, list[Any]]:
+        """Batch-fetch manifests for multiple doc_ids in one round-trip.
+
+        nexus-7lm3q: replaces the N per-doc ``get_manifest()`` loop in
+        ``_attach_doc_ids_from_catalog`` (search_engine.py) so a single
+        search with M distinct docs pays ONE catalog round-trip instead
+        of M. Mirrors ``POST /v1/catalog/manifest/get_many`` → Java
+        ``CatalogHandler.handleManifestGetMany`` /
+        ``CatalogRepository.getManifestMany``.
+
+        Returns a dict keyed by doc_id; each value is the ordered list
+        of manifest rows (same shape as ``get_manifest()``). Missing
+        doc_ids are absent from the result (not keyed to empty list).
+        """
+        if not doc_ids:
+            return {}
+        result = self._post("/manifest/get_many", {"doc_ids": doc_ids})
+        return result.get("manifests", {}) if result else {}
 
     def get_chunk_chashes(self, doc_id: str) -> list[str]:
         """Return chashes for all chunks of doc_id.

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -136,8 +136,42 @@ def _attach_doc_ids_from_catalog(
             r.metadata["doc_id"] = docs[0]
             resolved_doc_ids[chash] = docs[0]
 
-    # Per-doc manifest cache so multi-chunk docs only fetch once.
+    # Batch-fetch manifests for all resolved doc_ids in one call when the
+    # catalog backend supports get_manifests() (nexus-7lm3q).  Falls back
+    # to the per-doc loop for older/local catalogs that lack that method.
+    distinct_doc_ids = list({
+        did
+        for chash in chashes
+        if chash
+        for did in [resolved_doc_ids.get(chash) or ""]
+        if did
+    })
     manifest_cache: dict[str, list[Any]] = {}
+    _get_manifests_batch = getattr(catalog, "get_manifests", None)
+    if _get_manifests_batch is not None and distinct_doc_ids:
+        try:
+            batch_result = _get_manifests_batch(distinct_doc_ids)
+            if batch_result:
+                manifest_cache.update(batch_result)
+        except Exception:
+            _log.debug(
+                "attach_chunk_count_batch_failed",
+                doc_ids=distinct_doc_ids, exc_info=True,
+            )
+            # Degraded: manifest_cache stays empty; chunk_count/chunk_index
+            # will not be stamped on this search result set.
+    else:
+        # Legacy per-doc loop for catalogs without get_manifests().
+        for doc_id in distinct_doc_ids:
+            try:
+                manifest_cache[doc_id] = catalog.get_manifest(doc_id)
+            except Exception:
+                _log.debug(
+                    "attach_chunk_count_lookup_failed",
+                    doc_id=doc_id, exc_info=True,
+                )
+                manifest_cache[doc_id] = []
+
     for r, chash in zip(results, chashes):
         if not chash:
             continue
@@ -145,16 +179,6 @@ def _attach_doc_ids_from_catalog(
         if not doc_id:
             continue
         manifest = manifest_cache.get(doc_id)
-        if manifest is None:
-            try:
-                manifest = catalog.get_manifest(doc_id)
-            except Exception:
-                _log.debug(
-                    "attach_chunk_count_lookup_failed",
-                    doc_id=doc_id, exc_info=True,
-                )
-                manifest = []
-            manifest_cache[doc_id] = manifest
         if not manifest:
             continue
         # Only inject when absent (legacy chunks may have these).
@@ -162,8 +186,16 @@ def _attach_doc_ids_from_catalog(
             r.metadata["chunk_count"] = len(manifest)
         if "chunk_index" not in r.metadata:
             for row in manifest:
-                if getattr(row, "chash", "") == chash:
-                    r.metadata["chunk_index"] = int(getattr(row, "position", 0))
+                row_chash = (
+                    row.get("chash", "") if isinstance(row, dict)
+                    else getattr(row, "chash", "")
+                )
+                if row_chash == chash:
+                    pos = (
+                        row.get("position", 0) if isinstance(row, dict)
+                        else getattr(row, "position", 0)
+                    )
+                    r.metadata["chunk_index"] = int(pos)
                     break
 
 
@@ -196,16 +228,30 @@ def _attach_display_paths(
     }
     if not doc_ids:
         return
-    # Single-pass cache so repeated doc_ids (multi-chunk results) only
-    # hit the catalog once.
+    # Batch-resolve all doc_ids in one call when the catalog backend
+    # supports resolve_many() (nexus-7lm3q).  Falls back to the per-doc
+    # by_doc_id() loop for older/local catalogs that lack the method.
     cache: dict[str, str] = {}
-    for did in doc_ids:
+    _resolve_many = getattr(catalog, "resolve_many", None)
+    if _resolve_many is not None:
         try:
-            entry = catalog.by_doc_id(did)
+            batch = _resolve_many(list(doc_ids))
+            for did, entry in (batch or {}).items():
+                if entry is not None and entry.file_path:
+                    cache[did] = entry.file_path
         except Exception:
-            continue
-        if entry is not None and entry.file_path:
-            cache[did] = entry.file_path
+            _log.debug("attach_display_paths_batch_failed", exc_info=True)
+            # Degraded: fall through with empty cache; no _display_path
+            # will be stamped on this search result set.
+    else:
+        # Legacy per-doc loop for catalogs without resolve_many().
+        for did in doc_ids:
+            try:
+                entry = catalog.by_doc_id(did)
+            except Exception:
+                continue
+            if entry is not None and entry.file_path:
+                cache[did] = entry.file_path
     if not cache:
         return
     for r in results:

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -626,41 +626,59 @@ class TestAttachDisplayPaths:
     def test_attaches_catalog_resolved_path(self):
         """WITH TEETH: the resolved file_path lands on the metadata
         dict under ``_display_path``. A regression that drops the
-        write or routes through the wrong key fails this test."""
-        catalog = MagicMock()
-        catalog.by_doc_id.return_value = SimpleNamespace(
-            file_path="/abs/from/catalog.py",
-        )
+        write or routes through the wrong key fails this test.
+
+        Updated for nexus-7lm3q batch path: catalogs now expose resolve_many()
+        which is called instead of by_doc_id(). The OldCatalog helper class
+        (without resolve_many) tests the legacy fallback path."""
+        class _Catalog:
+            """Catalog that exposes resolve_many (the new batch path)."""
+            def resolve_many(self, doc_ids):
+                return {
+                    did: SimpleNamespace(file_path="/abs/from/catalog.py")
+                    for did in doc_ids
+                }
+
         r = self._result(doc_id="ART-deadbeef", source_path="src/legacy.py")
-        _attach_display_paths([r], catalog=catalog)
-        catalog.by_doc_id.assert_called_once_with("ART-deadbeef")
+        _attach_display_paths([r], catalog=_Catalog())
         assert r.metadata["_display_path"] == "/abs/from/catalog.py"
         # source_path stays untouched: the prune verb owns its removal.
         assert r.metadata["source_path"] == "src/legacy.py"
 
     def test_doc_id_with_no_catalog_entry_leaves_field_unset(self):
-        catalog = MagicMock()
-        catalog.by_doc_id.return_value = None
+        class _Catalog:
+            def resolve_many(self, doc_ids):
+                return {}  # no entries found
+
         r = self._result(doc_id="ART-orphan", source_path="src/legacy.py")
-        _attach_display_paths([r], catalog=catalog)
+        _attach_display_paths([r], catalog=_Catalog())
         assert "_display_path" not in r.metadata
 
     def test_repeated_doc_id_only_hits_catalog_once(self):
         """Multi-chunk results sharing the same doc_id share one
         catalog lookup. Pre-fix code that loops per result without a
         cache hits the catalog N times (slow on large result sets).
-        """
-        catalog = MagicMock()
-        catalog.by_doc_id.return_value = SimpleNamespace(
-            file_path="/abs/foo.py",
-        )
+
+        Updated for nexus-7lm3q: resolve_many is called ONCE for all
+        distinct doc_ids, even when the same doc_id repeats across results."""
+        call_count = 0
+
+        class _Catalog:
+            def resolve_many(self, doc_ids):
+                nonlocal call_count
+                call_count += 1
+                return {
+                    did: SimpleNamespace(file_path="/abs/foo.py")
+                    for did in doc_ids
+                }
+
         results = [
             self._result(doc_id="ART-shared"),
             self._result(doc_id="ART-shared"),
             self._result(doc_id="ART-shared"),
         ]
-        _attach_display_paths(results, catalog=catalog)
-        assert catalog.by_doc_id.call_count == 1
+        _attach_display_paths(results, catalog=_Catalog())
+        assert call_count == 1
         for r in results:
             assert r.metadata["_display_path"] == "/abs/foo.py"
 
@@ -908,3 +926,196 @@ class TestPerCollectionErrorIsolation:
             and entry["collection"] == "knowledge__seam"
             for entry in logs
         )
+
+
+# ── nexus-7lm3q: batch manifest/resolve, backward-compat fallback ────────────
+
+
+class TestAttachDocIdsBatchManifest:
+    """nexus-7lm3q: _attach_doc_ids_from_catalog uses get_manifests() batch
+    when available, falls back to per-doc get_manifest() loop when the
+    catalog predates the new method."""
+
+    def _result(self, *, chunk_text_hash: str = "", doc_id: str = "") -> SearchResult:
+        meta: dict = {}
+        if chunk_text_hash:
+            meta["chunk_text_hash"] = chunk_text_hash
+        if doc_id:
+            meta["doc_id"] = doc_id
+        return SearchResult(
+            id=f"r-{chunk_text_hash[:8] or doc_id or 'x'}",
+            content="x", distance=0.1, collection="docs__c", metadata=meta,
+        )
+
+    def test_batch_path_uses_get_manifests_when_available(self):
+        """WITH TEETH: catalog with get_manifests() gets ONE batch call,
+        NOT N per-doc get_manifest() calls. Reverting the batch path
+        regresses to N calls and this test fails."""
+        from nexus.search_engine import _attach_doc_ids_from_catalog
+
+        chash_a = "a" * 64
+        chash_b = "b" * 64
+        catalog = MagicMock()
+        catalog.docs_for_chashes.return_value = {
+            chash_a: ["doc-A"],
+            chash_b: ["doc-B"],
+        }
+        # Return one chunk row per doc (position=0, chash matches)
+        catalog.get_manifests.return_value = {
+            "doc-A": [{"chash": chash_a, "position": 0}],
+            "doc-B": [{"chash": chash_b, "position": 0}],
+        }
+        r_a = self._result(chunk_text_hash=chash_a)
+        r_b = self._result(chunk_text_hash=chash_b)
+        _attach_doc_ids_from_catalog([r_a, r_b], catalog=catalog)
+
+        # Exactly one batch call, zero per-doc calls.
+        catalog.get_manifests.assert_called_once()
+        catalog.get_manifest.assert_not_called()
+
+        assert r_a.metadata["chunk_count"] == 1
+        assert r_b.metadata["chunk_count"] == 1
+        assert r_a.metadata["chunk_index"] == 0
+        assert r_b.metadata["chunk_index"] == 0
+
+    def test_fallback_to_per_doc_when_get_manifests_absent(self):
+        """Catalog without get_manifests() must fall through to the existing
+        per-doc loop. Both old and new backends pass."""
+        from nexus.search_engine import _attach_doc_ids_from_catalog
+
+        chash = "c" * 64
+
+        class OldCatalog:
+            """Simulates a pre-batch catalog - no get_manifests attribute."""
+            def docs_for_chashes(self, chashes):
+                return {chash: ["doc-C"]}
+            def get_manifest(self, doc_id):
+                return [{"chash": chash, "position": 0}]
+
+        r = self._result(chunk_text_hash=chash)
+        _attach_doc_ids_from_catalog([r], catalog=OldCatalog())
+
+        assert r.metadata["doc_id"] == "doc-C"
+        assert r.metadata["chunk_count"] == 1
+        assert r.metadata["chunk_index"] == 0
+
+    def test_batch_failure_does_not_poison_search(self):
+        """get_manifests() raising must degrade gracefully (no chunk_count/
+        chunk_index stamped) without aborting the search."""
+        from nexus.search_engine import _attach_doc_ids_from_catalog
+
+        chash = "d" * 64
+        catalog = MagicMock()
+        catalog.docs_for_chashes.return_value = {chash: ["doc-D"]}
+        catalog.get_manifests.side_effect = RuntimeError("service dead")
+        r = self._result(chunk_text_hash=chash)
+        _attach_doc_ids_from_catalog([r], catalog=catalog)
+
+        # doc_id should still be injected; chunk_count/chunk_index absent.
+        assert r.metadata["doc_id"] == "doc-D"
+        assert "chunk_count" not in r.metadata
+        assert "chunk_index" not in r.metadata
+
+    def test_legacy_chunk_count_not_overwritten_by_batch(self):
+        """Legacy pre-Phase-3 chunks that already carry chunk_count must
+        not have it overwritten by the batch manifest path."""
+        from nexus.search_engine import _attach_doc_ids_from_catalog
+
+        chash = "e" * 64
+        catalog = MagicMock()
+        catalog.docs_for_chashes.return_value = {chash: ["doc-E"]}
+        catalog.get_manifests.return_value = {
+            "doc-E": [{"chash": chash, "position": 0}],
+        }
+        r = self._result(chunk_text_hash=chash)
+        r.metadata["chunk_count"] = 99  # legacy field already set
+        _attach_doc_ids_from_catalog([r], catalog=catalog)
+
+        assert r.metadata["chunk_count"] == 99  # must be preserved
+
+
+class TestAttachDisplayPathsBatch:
+    """nexus-7lm3q: _attach_display_paths uses resolve_many() batch
+    when available, falls back to per-doc by_doc_id() loop when absent."""
+
+    def _result(self, doc_id: str) -> SearchResult:
+        return SearchResult(
+            id=f"r-{doc_id}", content="x", distance=0.1,
+            collection="code__c", metadata={"doc_id": doc_id},
+        )
+
+    def test_batch_path_uses_resolve_many_when_available(self):
+        """WITH TEETH: catalog with resolve_many() gets ONE call, no
+        by_doc_id() calls. Reverting regresses to N calls."""
+        from nexus.search_engine import _attach_display_paths
+
+        catalog = MagicMock()
+        catalog.resolve_many.return_value = {
+            "doc-1": SimpleNamespace(file_path="/a/b/one.py"),
+            "doc-2": SimpleNamespace(file_path="/a/b/two.py"),
+        }
+        r1 = self._result("doc-1")
+        r2 = self._result("doc-2")
+        _attach_display_paths([r1, r2], catalog=catalog)
+
+        catalog.resolve_many.assert_called_once()
+        catalog.by_doc_id.assert_not_called()
+
+        assert r1.metadata["_display_path"] == "/a/b/one.py"
+        assert r2.metadata["_display_path"] == "/a/b/two.py"
+
+    def test_fallback_to_by_doc_id_when_resolve_many_absent(self):
+        """Catalog without resolve_many() must use per-doc by_doc_id()."""
+        from nexus.search_engine import _attach_display_paths
+
+        class OldCatalog:
+            def by_doc_id(self, doc_id):
+                return SimpleNamespace(file_path=f"/path/{doc_id}.py")
+
+        r = self._result("old-doc")
+        _attach_display_paths([r], catalog=OldCatalog())
+
+        assert r.metadata["_display_path"] == "/path/old-doc.py"
+
+    def test_batch_failure_does_not_poison_search(self):
+        """resolve_many() raising must degrade gracefully."""
+        from nexus.search_engine import _attach_display_paths
+
+        catalog = MagicMock()
+        catalog.resolve_many.side_effect = RuntimeError("service dead")
+        r = self._result("doc-X")
+        _attach_display_paths([r], catalog=catalog)
+
+        assert "_display_path" not in r.metadata
+
+    def test_partial_batch_response_handled(self):
+        """resolve_many() may return fewer entries than requested
+        (missing doc_ids). Results with no entry remain unpopulated."""
+        from nexus.search_engine import _attach_display_paths
+
+        catalog = MagicMock()
+        catalog.resolve_many.return_value = {
+            "doc-found": SimpleNamespace(file_path="/found.py"),
+            # doc-missing intentionally absent
+        }
+        r_found = self._result("doc-found")
+        r_missing = self._result("doc-missing")
+        _attach_display_paths([r_found, r_missing], catalog=catalog)
+
+        assert r_found.metadata["_display_path"] == "/found.py"
+        assert "_display_path" not in r_missing.metadata
+
+    def test_multi_chunk_results_all_populated(self):
+        """Multiple results with the same doc_id all get the display path."""
+        from nexus.search_engine import _attach_display_paths
+
+        catalog = MagicMock()
+        catalog.resolve_many.return_value = {
+            "shared-doc": SimpleNamespace(file_path="/shared.py"),
+        }
+        results = [self._result("shared-doc") for _ in range(3)]
+        _attach_display_paths(results, catalog=catalog)
+
+        catalog.resolve_many.assert_called_once()
+        for r in results:
+            assert r.metadata["_display_path"] == "/shared.py"


### PR DESCRIPTION
## Summary

Two per-search-result-set N+1 loops in `search_engine.py` eliminated with a single round-trip each:

- `_attach_doc_ids_from_catalog`: replaced N calls to `catalog.get_manifest(doc_id)` with one `catalog.get_manifests(doc_ids)` batch call
- `_attach_display_paths`: replaced N calls to `catalog.by_doc_id(did)` with one `catalog.resolve_many(doc_ids)` batch call

Both use `getattr(catalog, "get_manifests", None)` / `getattr(catalog, "resolve_many", None)` capability checks so old/local catalogs fall back to the per-doc loop automatically.

## New endpoints (Java service)

| Method | Path | Returns |
|--------|------|---------|
| POST | `/v1/catalog/manifest/get_many` | `{"manifests": {docId: [rows...]}}` |
| POST | `/v1/catalog/resolve_many` | `{"entries": {docId: {doc...}}}` |

Both mirror the `handleDocsForChashes` pattern. Repository methods execute one SQL `IN (?)` query per call instead of N queries.

## New Python methods (all three backends)

- `Catalog.get_manifests()` + `Catalog.resolve_many()` — SQLite delegates
- `CatalogWrites.get_manifests()` — batched at 500 doc_ids (SQLite variable limit)
- `CatalogDocs.resolve_many()` — batched at 200 doc_ids
- `HttpCatalogClient.get_manifests()` — posts to `/manifest/get_many`
- `HttpCatalogClient.resolve_many()` — posts to `/resolve_many`

## Backward compatibility

All three catalog backends now expose both batch methods. The `getattr` guard in `search_engine.py` ensures no behavior change against old/local catalogs that lack the methods.

## Test results

- Python: **1618 passed** (9 new tests in `TestAttachDocIdsBatchManifest` + `TestAttachDisplayPathsBatch`; 2 pre-existing tests in `TestAttachDisplayPaths` updated to use concrete catalog helpers instead of `MagicMock` so the batch-path take-over doesn't confuse the assertions)
- Java: **886 passed** (5 new tests `@Order 55–59` in `CatalogRepositoryTest`: `getManifestMany` batch fetch, empty input, `resolveMany` batch fetch, empty input, tenant isolation)

## Closes

Closes nexus-7lm3q

Part of epic nexus-whh61.