### PR TITLE
test: remove orphaned TestChunkId (unblocks develop CI)

### DIFF
--- a/tests/db/test_http_vector_client.py
+++ b/tests/db/test_http_vector_client.py
@@ -100,24 +100,6 @@ class TestSingleton:
         assert a is not b
 
 
-# ── chunk_id ─────────────────────────────────────────────────────────────────
-
-class TestChunkId:
-    def test_matches_sha256_prefix(self):
-        import hashlib
-        text = "hello world"
-        expected = hashlib.sha256(text.encode()).hexdigest()[:32]
-        assert HttpVectorClient.chunk_id(text) == expected
-
-    def test_length_is_32(self):
-        cid = HttpVectorClient.chunk_id("some text here")
-        assert len(cid) == 32
-
-    def test_deterministic(self):
-        t = "same text every time"
-        assert HttpVectorClient.chunk_id(t) == HttpVectorClient.chunk_id(t)
-
-
 # ── HttpVectorClient methods (mocked HTTP) ───────────────────────────────────
 
 def _make_mock_post(response_body: dict):


### PR DESCRIPTION
## Summary

`develop` pytest (3.12 + 3.13) is currently **red** on 3 tests in `tests/db/test_http_vector_client.py::TestChunkId`:

```
AttributeError: type object 'HttpVectorClient' has no attribute 'chunk_id'
```

PR #1303 (`538e16a2`, "re-home chunk_id() helper to nexus.chunk_identity") moved `chunk_id()` out of `HttpVectorClient` into `nexus.chunk_identity` and added full coverage in `tests/test_chunk_identity.py`, but left the old `TestChunkId` class behind still calling the removed `HttpVectorClient.chunk_id`. The class is dead; the behaviour is covered at its new home.

This removes the orphaned class, unblocking all PRs to develop.

## Verification

`uv run pytest tests/db/test_http_vector_client.py tests/test_chunk_identity.py` → 76 passed.