### PR TITLE
refactor(indexer): lift _doc_id_resolver into indexer_utils (nexus-kgyoz seam 2)

### DIFF
--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -31,6 +31,7 @@ from nexus.corpus import index_model_for_collection
 from nexus.retry import _chroma_with_retry, _voyage_with_retry  # noqa: F401 — re-exported for any existing imports
 from nexus.errors import CredentialsMissingError  # re-exported for backward compatibility
 from nexus.indexer_utils import (
+    build_doc_id_resolver,
     build_staleness_cache,
     check_credentials,
     check_local_path_writable,
@@ -2522,8 +2523,10 @@ def _run_index(
             f"Catalog registration done ({time.monotonic() - _catalog_t0:.1f}s)"
         )
 
-    def _doc_id_resolver(path: Path) -> str:
-        return file_to_doc_id.get(path, "")
+    # nexus-kgyoz seam 2: the resolver closure is lifted to
+    # indexer_utils.build_doc_id_resolver so _run_index stays a thin
+    # orchestrator. Behaviour identical — missing files resolve to "".
+    _doc_id_resolver = build_doc_id_resolver(file_to_doc_id)
 
     # Pre-build the per-collection staleness cache (nexus-rr0u follow-up).
     # One paginated sweep per collection up front replaces N per-file

--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import fnmatch
 import re
 import subprocess
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -533,3 +534,27 @@ def build_context_prefix(
         f"  Class: {class_name}  Method: {method_name}"
         f"  Lines: {line_start}-{line_end}"
     )
+
+
+def build_doc_id_resolver(
+    file_to_doc_id: Mapping[Path, str],
+) -> Callable[[Path], str]:
+    """Return a resolver mapping an indexed file path to its catalog doc_id.
+
+    Lifted from ``indexer._run_index`` (nexus-kgyoz seam 2). The orchestrator
+    builds *file_to_doc_id* from the pre-index catalog registration map, then
+    wires the returned callable into :attr:`IndexContext.doc_id_resolver` so
+    per-file indexers stamp the catalog cross-reference into chunk metadata at
+    chunk-write time. Files absent from the map resolve to ``""`` — the legacy
+    / no-doc_id signal that ``metadata_schema.normalize`` Step 4c then drops.
+
+    Args:
+        file_to_doc_id: Mapping of indexed file path to catalog ``doc_id``.
+
+    Returns:
+        A callable ``(path) -> doc_id`` closing over *file_to_doc_id*.
+    """
+    def _resolver(path: Path) -> str:
+        return file_to_doc_id.get(path, "")
+
+    return _resolver

--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -548,6 +548,12 @@ def build_doc_id_resolver(
     chunk-write time. Files absent from the map resolve to ``""`` — the legacy
     / no-doc_id signal that ``metadata_schema.normalize`` Step 4c then drops.
 
+    The returned callable closes over *file_to_doc_id* by reference (no
+    snapshot): later mutations to the passed mapping are visible through the
+    resolver. The orchestrator builds it once from a finalised registration
+    map and does not mutate afterward, so this is a non-issue at the call
+    site; callers needing a frozen view should pass a copy.
+
     Args:
         file_to_doc_id: Mapping of indexed file path to catalog ``doc_id``.
 

--- a/tests/test_indexer_modules.py
+++ b/tests/test_indexer_modules.py
@@ -186,19 +186,19 @@ def test_build_doc_id_resolver_empty_map():
     assert resolve(Path("/anything")) == ""
 
 
-def test_run_index_uses_lifted_doc_id_resolver():
-    """_run_index threads the lifted free function, not an inline closure.
+def test_run_index_imports_lifted_doc_id_resolver():
+    """_run_index's module imports the lifted free fn as the same object.
 
-    Non-vacuous: would fail if seam 2 regressed by re-inlining the resolver
-    or by not calling indexer_utils.build_doc_id_resolver.
+    Non-vacuous and reformat-robust: asserts the symbol is bound at module
+    level in nexus.indexer and IS indexer_utils.build_doc_id_resolver. Would
+    fail if seam 2 regressed by dropping the import or re-defining a local
+    shadow. Survives whitespace/arg-name churn that a source-text scan would
+    false-fire on.
     """
-    import inspect
-
     from nexus import indexer
+    from nexus.indexer_utils import build_doc_id_resolver
 
-    src = inspect.getsource(indexer._run_index)
-    assert "build_doc_id_resolver(file_to_doc_id)" in src
-    assert "def _doc_id_resolver(path: Path) -> str:" not in src
+    assert getattr(indexer, "build_doc_id_resolver", None) is build_doc_id_resolver
 
 
 # ── _extract_context backward compatibility ───────────────────────────────────

--- a/tests/test_indexer_modules.py
+++ b/tests/test_indexer_modules.py
@@ -166,6 +166,41 @@ def test_build_context_prefix(path, comment, cls, method, ls, le, expected):
     assert build_context_prefix(path, comment, cls, method, ls, le) == expected
 
 
+# ── build_doc_id_resolver (nexus-kgyoz seam 2 contract pins) ──────────────────
+
+def test_build_doc_id_resolver_hit_and_miss():
+    """Resolver returns the mapped doc_id on a hit and "" on a miss."""
+    from nexus.indexer_utils import build_doc_id_resolver
+
+    hit = Path("/repo/src/foo.py")
+    resolve = build_doc_id_resolver({hit: "1.2.3"})
+    assert resolve(hit) == "1.2.3"
+    assert resolve(Path("/repo/src/unregistered.py")) == ""
+
+
+def test_build_doc_id_resolver_empty_map():
+    """An empty registration map resolves every path to "" (legacy signal)."""
+    from nexus.indexer_utils import build_doc_id_resolver
+
+    resolve = build_doc_id_resolver({})
+    assert resolve(Path("/anything")) == ""
+
+
+def test_run_index_uses_lifted_doc_id_resolver():
+    """_run_index threads the lifted free function, not an inline closure.
+
+    Non-vacuous: would fail if seam 2 regressed by re-inlining the resolver
+    or by not calling indexer_utils.build_doc_id_resolver.
+    """
+    import inspect
+
+    from nexus import indexer
+
+    src = inspect.getsource(indexer._run_index)
+    assert "build_doc_id_resolver(file_to_doc_id)" in src
+    assert "def _doc_id_resolver(path: Path) -> str:" not in src
+
+
 # ── _extract_context backward compatibility ───────────────────────────────────
 
 def test_extract_context_importable_from_nexus_indexer():


### PR DESCRIPTION
## Summary

Seam 2 of the **nexus-kgyoz** god-object decomposition (epic nexus-whh61). Behaviour-preserving lift of the `_doc_id_resolver` closure out of the ~677-line `indexer._run_index` orchestrator into a free function `build_doc_id_resolver` in `indexer_utils.py`, mirroring the RDR-032 free-function pattern already established in that module. `_run_index` stays a thin orchestrator that wires the returned callable into `IndexContext.doc_id_resolver`.

This is the smallest cohesive seam by design: the resolver captures only the plain `file_to_doc_id` dict (zero cross-module entanglement). The larger post-processing block (`indexer.py ~2664-2752`) was deliberately **not** chosen — it calls five module-level `nexus.indexer` functions, which would introduce circular-import + monkeypatch entanglement. One cohesive seam per PR; catalog seam 1 already shipped (#1313), commands/catalog.py seam 3 is future.

## Changes

- `src/nexus/indexer_utils.py` — new `build_doc_id_resolver(file_to_doc_id) -> Callable[[Path], str]`; docstring declares the by-reference capture contract.
- `src/nexus/indexer.py` — import the free fn; replace the inline closure with `_doc_id_resolver = build_doc_id_resolver(file_to_doc_id)`.
- `tests/test_indexer_modules.py` — three non-vacuous contract pins: hit/miss, empty-map, and an import-identity regression pin asserting `_run_index`'s module binds the lifted fn.

## Behaviour preservation

Identical: missing files resolve to `""` (the legacy no-doc_id signal). No test monkeypatches the old inline closure (verified). Guard suites green before and after.

## Tests

`tests/test_indexer*.py` + `tests/test_doc_indexer.py`: **303 passed**. `uvx ruff@0.15.18 check src/`: clean.

## Review

Both stacked reviewers ran (code-review-expert + substantive-critic), **0 Critical**. Both flagged the original `inspect.getsource` regression pin as brittle (source-text scan); replaced with a reformat-robust import-identity pin. Docstring tightened to declare the reference-capture contract.

Part of nexus-kgyoz (multi-PR; remains in_progress for seam 3).