### PR TITLE
refactor(catalog-cli): carve owners command family into catalog_cmds (nexus-kgyoz seam 3)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -227,6 +227,16 @@ def catalog() -> None:
     """
 
 
+# Command families carved out of this module live in catalog_cmds/ and attach
+# themselves to the group via their register() hook (nexus-kgyoz). Imported
+# here (after the group exists) so ``nx catalog owners`` / ``dedupe-owners``
+# resolve identically. catalog_cmds submodules reference this module's helpers
+# lazily, so this import stays acyclic.
+from nexus.commands.catalog_cmds import owners as _owners_cmds  # noqa: E402 — must follow the `catalog` group definition above
+
+_owners_cmds.register(catalog)
+
+
 @catalog.command("init")
 @click.option("--remote", default="", help="Optional git remote URL")
 def init_cmd(remote: str) -> None:
@@ -1600,33 +1610,6 @@ def link_audit_cmd(as_json: bool) -> None:
                 click.echo(f"  {o['from']} → {o['to']} ({o['type']})")
 
 
-@catalog.command("owners")
-@click.option("--json", "as_json", is_flag=True)
-def owners_cmd(as_json: bool) -> None:
-    """List registered owners."""
-    cat = _get_catalog()
-    owners = cat.list_owners()
-    if as_json:
-        data = [
-            {
-                "tumbler": o.get("tumbler_prefix"),
-                "name": o.get("name"),
-                "type": o.get("owner_type"),
-                "repo_hash": o.get("repo_hash"),
-                "description": o.get("description"),
-            }
-            for o in owners
-        ]
-        click.echo(json.dumps(data, indent=2))
-    else:
-        for o in owners:
-            click.echo(
-                f"{o.get('tumbler_prefix', ''):<8} "
-                f"{o.get('owner_type', ''):<10} "
-                f"{o.get('name', '')}"
-            )
-
-
 @catalog.command("sync")
 @click.option("--message", "-m", default="catalog update")
 def sync_cmd(message: str) -> None:
@@ -1637,104 +1620,6 @@ def sync_cmd(message: str) -> None:
     finally:
         cat.close()
     click.echo("Catalog synced.")
-
-
-@catalog.command("dedupe-owners")
-@click.option("--apply", is_flag=True, default=False,
-              help="Commit the plan. Default is dry-run.")
-@click.option("--json", "as_json", is_flag=True,
-              help="Emit the plan as JSON instead of a human summary.")
-def dedupe_owners_cmd(apply: bool, as_json: bool) -> None:
-    """Consolidate orphan owners (nexus-tmbh, part of nexus-b34f).
-
-    Classifies each curator owner as:
-
-    \b
-      • alias   — synthetic ``<repo>-<hash>`` names map to a canonical
-                  repo owner. Each doc is aliased via documents.alias_of
-                  to its canonical equivalent (matched by file_path).
-                  Rows stay so external references keep resolving.
-      • remove  — ``int-cce-*`` / ``int-prov-*`` / ``pdf-e2e-*`` test
-                  leakage predating RDR-060's autouse fixture. Documents,
-                  links, and the owner row are all deleted with JSONL
-                  tombstones.
-      • skip    — everything else (papers, knowledge, standalone-docs …).
-
-    Dry-run by default. Use ``--apply`` to commit, then ``nx catalog
-    sync`` to push the audit trail.
-    """
-    # Deep-maintenance: _dedupe.apply_plan mutates through the catalog's
-    # low-level event log / _db transactions, not the 22 daemon write ops
-    # (RDR-146). Use the full admin Catalog for both the plan read and the
-    # apply write.
-    from nexus.catalog.factory import (  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
-        CatalogAdminDaemonLiveError,
-        make_catalog_admin,
-    )
-    try:
-        cat = make_catalog_admin()
-    except CatalogAdminDaemonLiveError as exc:
-        raise click.ClickException(str(exc)) from exc
-    if cat is None:
-        raise click.ClickException(
-            "Catalog not initialized. Run 'nx catalog setup' first."
-        )
-    from nexus.catalog import dedupe as _dedupe  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
-
-    plan = _dedupe.plan_dedupe(cat)
-    summary = plan.summary()
-
-    if as_json:
-        payload = {
-            "dry_run": not apply,
-            "summary": summary,
-            "alias": [op.to_dict() for op in plan.alias],
-            "remove": [op.to_dict() for op in plan.remove],
-            "skip": [op.to_dict() for op in plan.skip],
-        }
-        if apply:
-            payload["applied"] = _dedupe.apply_plan(cat, plan)
-        click.echo(json.dumps(payload, indent=2))
-        return
-
-    label = "Would apply" if not apply else "Applying"
-    click.echo(f"{label} dedupe plan:")
-    click.echo(f"  alias:  {summary['alias']} owners, {summary['alias_docs']} docs")
-    click.echo(f"  remove: {summary['remove']} owners, {summary['remove_docs']} docs")
-    click.echo(f"  skip:   {summary['skip']} owners, {summary['skip_docs']} docs")
-
-    def _section(title: str, items: list, show_canonical: bool = False) -> None:
-        if not items:
-            return
-        click.echo(f"\n{title}:")
-        for op in items:
-            if show_canonical:
-                click.echo(
-                    f"  {op.orphan_prefix:<8} {op.orphan_name} "
-                    f"({op.doc_count} docs) → {op.canonical_prefix} {op.canonical_name}"
-                )
-            else:
-                click.echo(
-                    f"  {op.orphan_prefix:<8} {op.orphan_name} "
-                    f"({op.doc_count} docs)  — {op.reason}"
-                )
-
-    _section("Alias consolidation", plan.alias, show_canonical=True)
-    _section("Unconditional removal", plan.remove)
-    _section("Skipped (manual review)", plan.skip)
-
-    if not apply:
-        click.echo("\nDry-run only. Re-run with --apply to commit, "
-                   "then `nx catalog sync` to push the audit trail.")
-        return
-
-    totals = _dedupe.apply_plan(cat, plan)
-    click.echo("\nApplied:")
-    click.echo(f"  orphans aliased:  {totals['orphans_aliased']} "
-               f"({totals['aliased_docs']} docs, {totals['unmatched_docs']} unmatched)")
-    click.echo(f"  orphans removed:  {totals['orphans_removed']} "
-               f"({totals['removed_docs']} docs, {totals['removed_links']} links)")
-    click.echo("\nRun `nx catalog sync` to commit and push the audit trail.")
 
 
 @catalog.command("pull")

--- a/src/nexus/commands/catalog_cmds/__init__.py
+++ b/src/nexus/commands/catalog_cmds/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Command families carved out of the ``nx catalog`` group (nexus-kgyoz).
+
+Each submodule defines a cohesive family of ``nx catalog <cmd>`` commands as
+plain ``click`` commands plus a ``register(group)`` hook. ``commands.catalog``
+imports each module and calls its ``register`` against the shared ``catalog``
+group, so command names and the ``nx catalog …`` invocation surface are
+unchanged. Submodules reference shared helpers (e.g. ``_get_catalog``) lazily
+through the ``nexus.commands.catalog`` module object so import stays acyclic
+and test monkeypatches on those helpers continue to take effect.
+"""

--- a/src/nexus/commands/catalog_cmds/__init__.py
+++ b/src/nexus/commands/catalog_cmds/__init__.py
@@ -9,4 +9,10 @@ group, so command names and the ``nx catalog …`` invocation surface are
 unchanged. Submodules reference shared helpers (e.g. ``_get_catalog``) lazily
 through the ``nexus.commands.catalog`` module object so import stays acyclic
 and test monkeypatches on those helpers continue to take effect.
+
+Do NOT import the submodules from this ``__init__`` (keep it side-effect free):
+``commands.catalog`` is the single site that imports each family and calls its
+``register`` exactly once. Adding a convenience import here would risk a second
+``register`` call and silently double-attach commands (Click overwrites a
+duplicate ``add_command`` name without error).
 """

--- a/src/nexus/commands/catalog_cmds/owners.py
+++ b/src/nexus/commands/catalog_cmds/owners.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Owner-management commands for the ``nx catalog`` group (nexus-kgyoz seam 3).
+
+Carved verbatim out of ``commands.catalog`` (the ~6.9k-line god module):
+``owners`` (list registered owners) and ``dedupe-owners`` (consolidate orphan
+owners). Behaviour-preserving — the command names, options, and output are
+identical; only the definition site moved. ``register`` attaches both to the
+shared ``catalog`` group so ``nx catalog owners`` / ``nx catalog dedupe-owners``
+resolve exactly as before.
+
+Shared helpers stay in ``commands.catalog``; ``owners_cmd`` reaches
+``_get_catalog`` through the module object (not a bound import) so the existing
+``patch("nexus.commands.catalog._get_catalog", …)`` test seam keeps working.
+"""
+from __future__ import annotations
+
+import json
+
+import click
+
+
+@click.command("owners")
+@click.option("--json", "as_json", is_flag=True)
+def owners_cmd(as_json: bool) -> None:
+    """List registered owners."""
+    from nexus.commands import catalog as _cat_cmd  # noqa: PLC0415 — module-routed helper access keeps import acyclic + monkeypatch-visible
+
+    cat = _cat_cmd._get_catalog()
+    owners = cat.list_owners()
+    if as_json:
+        data = [
+            {
+                "tumbler": o.get("tumbler_prefix"),
+                "name": o.get("name"),
+                "type": o.get("owner_type"),
+                "repo_hash": o.get("repo_hash"),
+                "description": o.get("description"),
+            }
+            for o in owners
+        ]
+        click.echo(json.dumps(data, indent=2))
+    else:
+        for o in owners:
+            click.echo(
+                f"{o.get('tumbler_prefix', ''):<8} "
+                f"{o.get('owner_type', ''):<10} "
+                f"{o.get('name', '')}"
+            )
+
+
+@click.command("dedupe-owners")
+@click.option("--apply", is_flag=True, default=False,
+              help="Commit the plan. Default is dry-run.")
+@click.option("--json", "as_json", is_flag=True,
+              help="Emit the plan as JSON instead of a human summary.")
+def dedupe_owners_cmd(apply: bool, as_json: bool) -> None:
+    """Consolidate orphan owners (nexus-tmbh, part of nexus-b34f).
+
+    Classifies each curator owner as:
+
+    \b
+      • alias   — synthetic ``<repo>-<hash>`` names map to a canonical
+                  repo owner. Each doc is aliased via documents.alias_of
+                  to its canonical equivalent (matched by file_path).
+                  Rows stay so external references keep resolving.
+      • remove  — ``int-cce-*`` / ``int-prov-*`` / ``pdf-e2e-*`` test
+                  leakage predating RDR-060's autouse fixture. Documents,
+                  links, and the owner row are all deleted with JSONL
+                  tombstones.
+      • skip    — everything else (papers, knowledge, standalone-docs …).
+
+    Dry-run by default. Use ``--apply`` to commit, then ``nx catalog
+    sync`` to push the audit trail.
+    """
+    # Deep-maintenance: _dedupe.apply_plan mutates through the catalog's
+    # low-level event log / _db transactions, not the 22 daemon write ops
+    # (RDR-146). Use the full admin Catalog for both the plan read and the
+    # apply write.
+    from nexus.catalog.factory import (  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
+        CatalogAdminDaemonLiveError,
+        make_catalog_admin,
+    )
+    try:
+        cat = make_catalog_admin()
+    except CatalogAdminDaemonLiveError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if cat is None:
+        raise click.ClickException(
+            "Catalog not initialized. Run 'nx catalog setup' first."
+        )
+    from nexus.catalog import dedupe as _dedupe  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
+
+    plan = _dedupe.plan_dedupe(cat)
+    summary = plan.summary()
+
+    if as_json:
+        payload = {
+            "dry_run": not apply,
+            "summary": summary,
+            "alias": [op.to_dict() for op in plan.alias],
+            "remove": [op.to_dict() for op in plan.remove],
+            "skip": [op.to_dict() for op in plan.skip],
+        }
+        if apply:
+            payload["applied"] = _dedupe.apply_plan(cat, plan)
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    label = "Would apply" if not apply else "Applying"
+    click.echo(f"{label} dedupe plan:")
+    click.echo(f"  alias:  {summary['alias']} owners, {summary['alias_docs']} docs")
+    click.echo(f"  remove: {summary['remove']} owners, {summary['remove_docs']} docs")
+    click.echo(f"  skip:   {summary['skip']} owners, {summary['skip_docs']} docs")
+
+    def _section(title: str, items: list, show_canonical: bool = False) -> None:
+        if not items:
+            return
+        click.echo(f"\n{title}:")
+        for op in items:
+            if show_canonical:
+                click.echo(
+                    f"  {op.orphan_prefix:<8} {op.orphan_name} "
+                    f"({op.doc_count} docs) → {op.canonical_prefix} {op.canonical_name}"
+                )
+            else:
+                click.echo(
+                    f"  {op.orphan_prefix:<8} {op.orphan_name} "
+                    f"({op.doc_count} docs)  — {op.reason}"
+                )
+
+    _section("Alias consolidation", plan.alias, show_canonical=True)
+    _section("Unconditional removal", plan.remove)
+    _section("Skipped (manual review)", plan.skip)
+
+    if not apply:
+        click.echo("\nDry-run only. Re-run with --apply to commit, "
+                   "then `nx catalog sync` to push the audit trail.")
+        return
+
+    totals = _dedupe.apply_plan(cat, plan)
+    click.echo("\nApplied:")
+    click.echo(f"  orphans aliased:  {totals['orphans_aliased']} "
+               f"({totals['aliased_docs']} docs, {totals['unmatched_docs']} unmatched)")
+    click.echo(f"  orphans removed:  {totals['orphans_removed']} "
+               f"({totals['removed_docs']} docs, {totals['removed_links']} links)")
+    click.echo("\nRun `nx catalog sync` to commit and push the audit trail.")
+
+
+def register(group: click.Group) -> None:
+    """Attach the owner-management commands to the shared ``catalog`` group."""
+    group.add_command(owners_cmd)
+    group.add_command(dedupe_owners_cmd)

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -1640,6 +1640,12 @@ class TestSeam3OwnersCarve:
     commands into ``commands.catalog``, dropping the ``register`` wiring, or
     binding ``_get_catalog`` at import time (which would break the
     ``patch("nexus.commands.catalog._get_catalog", …)`` test seam).
+
+    Note the two commands take different catalog-access paths: ``owners``
+    reads via ``_get_catalog()`` (defended by the patch seam below), while
+    ``dedupe-owners`` opens an admin catalog via ``make_catalog_admin()`` and
+    is NOT covered by that patch target — its behavioural coverage lives in
+    ``test_catalog_dedupe.py`` through ``NEXUS_CATALOG_PATH`` env plumbing.
     """
 
     def test_owner_commands_registered_on_group(self):
@@ -1663,6 +1669,8 @@ class TestSeam3OwnersCarve:
         """Patching commands.catalog._get_catalog is observed by the carved
         ``owners`` command — proves module-routed (not import-bound) access."""
         from unittest.mock import MagicMock, patch
+
+        from nexus.cli import main
 
         fake = MagicMock()
         fake.list_owners.return_value = [

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -1631,3 +1631,45 @@ class TestCollectionNameCommand:
         ])
         assert result.exit_code == 0, result.output
         assert result.output.strip() == "rdr__1-1__voyage-context-3__v1"
+
+
+class TestSeam3OwnersCarve:
+    """Contract pins for the nexus-kgyoz seam 3 owners command carve.
+
+    Non-vacuous: each pin fails if the carve regresses — by re-inlining the
+    commands into ``commands.catalog``, dropping the ``register`` wiring, or
+    binding ``_get_catalog`` at import time (which would break the
+    ``patch("nexus.commands.catalog._get_catalog", …)`` test seam).
+    """
+
+    def test_owner_commands_registered_on_group(self):
+        from nexus.cli import main
+        catalog_group = main.commands["catalog"]
+        assert "owners" in catalog_group.commands
+        assert "dedupe-owners" in catalog_group.commands
+
+    def test_owner_commands_defined_in_carved_module(self):
+        """The callbacks live in catalog_cmds.owners, not commands.catalog."""
+        from nexus.cli import main
+        from nexus.commands.catalog_cmds import owners as owners_mod
+        catalog_group = main.commands["catalog"]
+        assert catalog_group.commands["owners"].callback is owners_mod.owners_cmd.callback
+        assert (
+            catalog_group.commands["dedupe-owners"].callback
+            is owners_mod.dedupe_owners_cmd.callback
+        )
+
+    def test_owners_command_routes_get_catalog_through_module(self):
+        """Patching commands.catalog._get_catalog is observed by the carved
+        ``owners`` command — proves module-routed (not import-bound) access."""
+        from unittest.mock import MagicMock, patch
+
+        fake = MagicMock()
+        fake.list_owners.return_value = [
+            {"tumbler_prefix": "1.1", "owner_type": "repo", "name": "sentinel-owner"},
+        ]
+        with patch("nexus.commands.catalog._get_catalog", return_value=fake):
+            result = CliRunner().invoke(main, ["catalog", "owners"])
+        assert result.exit_code == 0, result.output
+        assert "sentinel-owner" in result.output
+        fake.list_owners.assert_called_once()


### PR DESCRIPTION
## Summary

Seam 3 of the **nexus-kgyoz** god-object decomposition (epic nexus-whh61), and the **first split** of `src/nexus/commands/catalog.py` (~6931 lines, 53 commands, never previously decomposed). Carves the owner-management commands — `owners` and `dedupe-owners` — into a new `src/nexus/commands/catalog_cmds/` package (`owners.py`).

Commands are defined as plain `@click.command(...)` plus a `register(group)` hook. `commands/catalog.py` imports the submodule **after** the `catalog` click group is defined and calls `register(catalog)`, so `nx catalog owners` / `nx catalog dedupe-owners` resolve identically — names, options, help, and output unchanged. Net **-125 lines** from the god module.

`backfill-owner-id` was deliberately **not** included: it is a one-shot SQLite migration command sitting in the backfill/migrate cluster, not owner-management. A future seam carving that cluster picks it up naturally.

## Behaviour preservation

- Command bodies moved verbatim (names, options, docstrings, `\b` blocks, output format strings, `_section` closure, lazy factory imports all identical).
- `owners_cmd` reaches the shared `_get_catalog` helper through the `nexus.commands.catalog` module object (lazy, in-body) — not an import-time binding — so the existing `patch("nexus.commands.catalog._get_catalog", …)` test seam keeps working and the import stays acyclic (seam-1 `_cat_mod` lesson).
- No test imports the carved command functions by symbol; all invoke via the registered group.

## Tests

Three contract pins in `tests/test_catalog_cli.py::TestSeam3OwnersCarve`: group-registration, callbacks-live-in-carved-module (anti-re-inline, by identity), and a behavioural pin proving module-routed `_get_catalog` access. Guard suites green: `test_catalog_cli` + `test_catalog_dedupe` + `test_collections_owner_backfill` + `test_catalog_db` + `test_catalog_etl` = **178 passed**. Broader owners-invoking sweep (projector/etl/event-sourced/doctor/consumer-service) green. `uvx ruff@0.15.18 check src/`: clean.

## Review

Both stacked reviewers ran (code-review-expert + substantive-critic), **0 Critical**. Applied the documentation/clarity follow-ups (double-registration warning in `__init__.py`, `dedupe-owners` access-asymmetry note, local test import). Declined one proposed anti-fragmentation pin with rationale (its assertion is false against the 44 commands still resident in `catalog.py`; pin 2 already locks the carved commands by callback identity).

Completes the three planned kgyoz seams (catalog facade · indexer · catalog CLI). nexus-kgyoz can close once seams 2 (#1315) and 3 land.