### PR TITLE
refactor(catalog): relocate owner lookups to _OwnerOps (nexus-kgyoz deferred cleanup a)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -978,12 +978,12 @@ class Catalog:
         )
 
     def owner_for_repo(self, repo_hash: str) -> Tumbler | None:
-        """Delegates to ``_DocumentOps.owner_for_repo`` (nexus-mbm)."""
-        return self._docs.owner_for_repo(repo_hash)
+        """Delegates to ``_OwnerOps.owner_for_repo`` (nexus-kgyoz)."""
+        return self._owners.owner_for_repo(repo_hash)
 
     def owner_tumblers_by_name(self, name: str) -> list[Tumbler]:
-        """Delegates to ``_DocumentOps.owner_tumblers_by_name`` (nexus-mbm)."""
-        return self._docs.owner_tumblers_by_name(name)
+        """Delegates to ``_OwnerOps.owner_tumblers_by_name`` (nexus-kgyoz)."""
+        return self._owners.owner_tumblers_by_name(name)
 
     def curator_owner_tumbler_by_name(self, name: str) -> "Tumbler | None":
         """Delegates to ``_OwnerOps.curator_owner_tumbler_by_name`` (nexus-kgyoz)."""

--- a/src/nexus/catalog/catalog_docs.py
+++ b/src/nexus/catalog/catalog_docs.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Document / owner / collection lookup ops (nexus-mbm extraction 4/5).
+"""Document / collection lookup ops (nexus-mbm extraction 4/5).
 
 Read-only catalog queries: tumbler resolution, file-path / owner /
 content-type / corpus filters, collection registry lookups, and
-the BFS-like ``descendants`` walk. Writes (``register_owner``,
+the BFS-like ``descendants`` walk. The owner-table lookups
+(``owner_for_repo`` / ``owner_tumblers_by_name``) moved to
+``_OwnerOps`` (nexus-kgyoz); ``register_document`` reaches them via
+the facade. Writes (``register_owner``,
 ``register``, ``register_collection``, ``update``,
 ``delete_document``, alias/collection mutations) stay on
 ``Catalog`` — they touch the event-sourcing + JSONL append
@@ -88,37 +91,6 @@ class _DocumentOps:
 
     def __init__(self, catalog: "Catalog") -> None:
         self._cat = catalog
-
-    def owner_for_repo(self, repo_hash: str) -> Tumbler | None:
-        cat = self._cat
-        row = cat._db.execute(
-            "SELECT tumbler_prefix FROM owners WHERE repo_hash = ?", (repo_hash,)
-        ).fetchone()
-        return Tumbler.parse(row[0]) if row else None
-
-    def owner_tumblers_by_name(self, name: str) -> list[Tumbler]:
-        """Return tumblers of all owners with this name.
-
-        UNIQUE constraint is ``(name, owner_type)`` per nexus-7vuw, so
-        a single name can map to multiple owners across types (e.g.
-        a repo and a curator both named ``nexus``). Callers that need
-        a unique answer should disambiguate on the returned list
-        (typical CLI flow: error when ``len(...) > 1`` and surface
-        the candidates).
-
-        Returns ``[]`` if no owner has this name. Used by the
-        ``--owner`` CLI flags on ``nx catalog list`` (and friends)
-        to resolve operator-typed names to tumblers without leaking
-        the ``Tumbler.parse → int()`` ``ValueError`` (#537,
-        nexus-1lx7).
-        """
-        cat = self._cat
-        rows = cat._db.execute(
-            "SELECT tumbler_prefix FROM owners WHERE name = ? "
-            "ORDER BY tumbler_prefix",
-            (name,),
-        ).fetchall()
-        return [Tumbler.parse(r[0]) for r in rows]
 
     def resolve(self, tumbler: Tumbler, *, follow_alias: bool = True) -> CatalogEntry | None:
         """Return the document entry for ``tumbler``.

--- a/src/nexus/catalog/catalog_owners.py
+++ b/src/nexus/catalog/catalog_owners.py
@@ -25,10 +25,11 @@ both stay single-instance.
 ``owner_for_repo`` / ``owner_tumblers_by_name`` are owner-table
 queries relocated here from ``_DocumentOps`` (nexus-kgyoz deferred
 clean-up, completed once the indexer + commands decomposition PRs
-landed). ``_DocumentOps.register_document`` reaches them through
-the facade (``cat.owner_for_repo``), which now delegates to this
-module — no ``_docs`` -> ``_owners`` cross-_Ops dependency is
-introduced because the call routes through ``Catalog`` itself.
+landed). ``_DocumentOps.register_document`` still needs an owner
+lookup, but reaches it through the facade (``cat.owner_for_repo``)
+rather than calling ``_owners`` directly — the data dependency is
+mediated by ``Catalog``, keeping the ``_Ops`` modules from
+referencing each other directly (the established composition rule).
 """
 from __future__ import annotations
 

--- a/src/nexus/catalog/catalog_owners.py
+++ b/src/nexus/catalog/catalog_owners.py
@@ -3,9 +3,10 @@
 
 Owns the owner write path (``register_owner`` /
 ``ensure_owner_for_repo`` / ``set_owner_head_hash``) and the
-owner-table read surface (``list_owners`` / ``list_owners_by_type``
-/ ``get_owner_by_prefix`` / ``owners_with_roots`` /
-``curator_owner_tumbler_by_name``).
+owner-table read surface (``owner_for_repo`` /
+``owner_tumblers_by_name`` / ``list_owners`` /
+``list_owners_by_type`` / ``get_owner_by_prefix`` /
+``owners_with_roots`` / ``curator_owner_tumbler_by_name``).
 
 Composed onto ``Catalog`` as ``self._owners`` (T2Database-style
 facade pattern, mirroring ``catalog_links._LinkOps`` /
@@ -21,13 +22,13 @@ state duplication — every operation reads ``self._cat.<...>`` so
 the within-process owner-register lock and the directory flock
 both stay single-instance.
 
-Note: ``owner_for_repo`` / ``owner_tumblers_by_name`` are
-owner-table queries that deliberately remain in ``_DocumentOps``
-because ``register_document`` uses them directly via the facade;
-moving them here would introduce a ``_docs`` -> ``_owners``
-cross-_Ops dependency that the facade-routing architecture avoids
-(nexus-kgyoz deferred — a natural clean-up once the indexer and
-commands decomposition PRs land).
+``owner_for_repo`` / ``owner_tumblers_by_name`` are owner-table
+queries relocated here from ``_DocumentOps`` (nexus-kgyoz deferred
+clean-up, completed once the indexer + commands decomposition PRs
+landed). ``_DocumentOps.register_document`` reaches them through
+the facade (``cat.owner_for_repo``), which now delegates to this
+module — no ``_docs`` -> ``_owners`` cross-_Ops dependency is
+introduced because the call routes through ``Catalog`` itself.
 """
 from __future__ import annotations
 
@@ -70,6 +71,37 @@ class _OwnerOps:
     def __init__(self, catalog: "Catalog") -> None:
         self._cat = catalog
 
+    def owner_for_repo(self, repo_hash: str) -> Tumbler | None:
+        cat = self._cat
+        row = cat._db.execute(
+            "SELECT tumbler_prefix FROM owners WHERE repo_hash = ?", (repo_hash,)
+        ).fetchone()
+        return Tumbler.parse(row[0]) if row else None
+
+    def owner_tumblers_by_name(self, name: str) -> list[Tumbler]:
+        """Return tumblers of all owners with this name.
+
+        UNIQUE constraint is ``(name, owner_type)`` per nexus-7vuw, so
+        a single name can map to multiple owners across types (e.g.
+        a repo and a curator both named ``nexus``). Callers that need
+        a unique answer should disambiguate on the returned list
+        (typical CLI flow: error when ``len(...) > 1`` and surface
+        the candidates).
+
+        Returns ``[]`` if no owner has this name. Used by the
+        ``--owner`` CLI flags on ``nx catalog list`` (and friends)
+        to resolve operator-typed names to tumblers without leaking
+        the ``Tumbler.parse → int()`` ``ValueError`` (#537,
+        nexus-1lx7).
+        """
+        cat = self._cat
+        rows = cat._db.execute(
+            "SELECT tumbler_prefix FROM owners WHERE name = ? "
+            "ORDER BY tumbler_prefix",
+            (name,),
+        ).fetchall()
+        return [Tumbler.parse(r[0]) for r in rows]
+
     def register_owner(
         self, name: str, owner_type: str, *, repo_hash: str = "", description: str = "", repo_root: str = ""
     ) -> Tumbler:
@@ -109,7 +141,7 @@ class _OwnerOps:
                 # (no repo_hash) are intentionally exempt: name
                 # collisions across owner_types are allowed.
                 if owner_type == "repo" and repo_hash.strip():
-                    existing = cat._docs.owner_for_repo(repo_hash)
+                    existing = cat.owner_for_repo(repo_hash)
                     if existing is not None:
                         return existing
                 # Compute next owner number. Under event-sourced mode the

--- a/tests/test_catalog_decomposition_contracts.py
+++ b/tests/test_catalog_decomposition_contracts.py
@@ -549,3 +549,35 @@ def test_cat_mod_propagates_make_event_patch_to_owner_ops(
         "_cat_mod indirection failed to propagate the patched "
         "_make_event — _OwnerOps still bound the original factory"
     )
+
+
+def test_owner_lookups_relocated_to_owner_ops(tmp_path: Path) -> None:
+    """``owner_for_repo`` / ``owner_tumblers_by_name`` MUST live on
+    ``_OwnerOps`` and NOT on ``_DocumentOps`` (nexus-kgyoz deferred
+    clean-up). The facade delegates to ``_owners``; behaviour
+    round-trips. Trips the suite if a future change re-homes these
+    owner-table queries back onto ``_DocumentOps``.
+    """
+    from nexus.catalog.catalog_docs import _DocumentOps
+    from nexus.catalog.catalog_owners import _OwnerOps
+
+    assert hasattr(_OwnerOps, "owner_for_repo")
+    assert hasattr(_OwnerOps, "owner_tumblers_by_name")
+    assert not hasattr(_DocumentOps, "owner_for_repo")
+    assert not hasattr(_DocumentOps, "owner_tumblers_by_name")
+
+    Catalog.init(tmp_path)
+    cat = Catalog(tmp_path, tmp_path / ".catalog.db")
+    # Facade delegates to the _OwnerOps instance, not _DocumentOps.
+    assert (
+        cat.owner_for_repo.__func__ is Catalog.owner_for_repo
+    )
+    owner = cat.register_owner(
+        name="r", owner_type="repo", repo_hash="abc123", repo_root="/tmp/r-root",
+    )
+    # owner_for_repo round-trips the just-registered repo owner.
+    assert str(cat.owner_for_repo("abc123")) == str(owner)
+    assert cat.owner_for_repo("no-such-hash") is None
+    # owner_tumblers_by_name finds it by name.
+    assert str(cat.owner_tumblers_by_name("r")[0]) == str(owner)
+    assert cat.owner_tumblers_by_name("nobody") == []

--- a/tests/test_catalog_decomposition_contracts.py
+++ b/tests/test_catalog_decomposition_contracts.py
@@ -568,13 +568,12 @@ def test_owner_lookups_relocated_to_owner_ops(tmp_path: Path) -> None:
 
     Catalog.init(tmp_path)
     cat = Catalog(tmp_path, tmp_path / ".catalog.db")
-    # Facade delegates to the _OwnerOps instance, not _DocumentOps.
-    assert (
-        cat.owner_for_repo.__func__ is Catalog.owner_for_repo
-    )
     owner = cat.register_owner(
         name="r", owner_type="repo", repo_hash="abc123", repo_root="/tmp/r-root",
     )
+    # The facade round-trips through _OwnerOps end-to-end (delegation +
+    # SQL). With the methods gone from _DocumentOps (asserted above), a
+    # passing round-trip proves the facade reaches _OwnerOps.
     # owner_for_repo round-trips the just-registered repo owner.
     assert str(cat.owner_for_repo("abc123")) == str(owner)
     assert cat.owner_for_repo("no-such-hash") is None


### PR DESCRIPTION
## Summary

First of the deferred nexus-kgyoz clean-ups, now unblocked by seams 2+3 landing. Relocates the two owner-table query methods — `owner_for_repo(repo_hash)` and `owner_tumblers_by_name(name)` — out of `_DocumentOps` (`catalog_docs.py`) into `_OwnerOps` (`catalog_owners.py`), where the rest of the owner read/write surface already lives. Seam 1 deliberately left them in `_DocumentOps` with a documented note; this completes that note.

## Changes

- `catalog_owners.py` — methods moved in (verbatim SQL); docstring updated.
- `catalog_docs.py` — methods removed; module docstring updated.
- `catalog.py` — facade `owner_for_repo` / `owner_tumblers_by_name` now delegate to `self._owners` (was `self._docs`).
- The internal `_OwnerOps.register_owner` re-check call moves from `cat._docs.owner_for_repo(...)` to `cat.owner_for_repo(...)` (facade route, matching the two other call sites already in that method).

## Behaviour preservation

SQL and return semantics byte-identical. All external callers already used the facade (`cat.owner_for_repo`) — none touched. `_DocumentOps.register_document` reaches the lookup through the facade, so no `_docs`→`_owners` direct dependency is introduced (the data dependency is *mediated* by `Catalog`, per the `_Ops` composition rule). `http_catalog_client.py` has its own independent owner_for_repo implementation against the remote API — unaffected.

## Tests

Contract pin in `test_catalog_decomposition_contracts.py`: methods live on `_OwnerOps` (not `_DocumentOps`), facade round-trips (register → lookup → same tumbler, hit/miss/empty). Guard suites green: catalog cli/db/etl/decomposition-contracts (301) + owner-backfill/event-sourced/projector/dedupe (51). `uvx ruff@0.15.18 check src/`: clean.

## Review

Both stacked reviewers ran, **0 Critical**. Applied both non-blocking findings: dropped a vacuous `__func__` assertion (kept the real hasattr + round-trip guards) and tightened the docstring to say the owner dependency is *mediated* through the facade, not eliminated.

First of three deferred kgyoz items (this · backfill-owner-id carve · links family carve).