### PR TITLE
refactor(catalog-cli): carve backfill-owner-id into catalog_cmds (nexus-kgyoz deferred cleanup b)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -229,11 +229,12 @@ def catalog() -> None:
 
 # Command families carved out of this module live in catalog_cmds/ and attach
 # themselves to the group via their register() hook (nexus-kgyoz). Imported
-# here (after the group exists) so ``nx catalog owners`` / ``dedupe-owners``
-# resolve identically. catalog_cmds submodules reference this module's helpers
-# lazily, so this import stays acyclic.
-from nexus.commands.catalog_cmds import backfill as _backfill_cmds  # noqa: E402 — must follow the `catalog` group definition above
+# here (after the group exists) so every carved command (`nx catalog owners`,
+# `dedupe-owners`, `backfill-owner-id`, …) resolves identically. catalog_cmds
+# submodules reference this module's helpers lazily, so these imports stay
+# acyclic. Keep import order and register order aligned as families accumulate.
 from nexus.commands.catalog_cmds import owners as _owners_cmds  # noqa: E402 — must follow the `catalog` group definition above
+from nexus.commands.catalog_cmds import backfill as _backfill_cmds  # noqa: E402 — must follow the `catalog` group definition above
 
 _owners_cmds.register(catalog)
 _backfill_cmds.register(catalog)

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -232,9 +232,11 @@ def catalog() -> None:
 # here (after the group exists) so ``nx catalog owners`` / ``dedupe-owners``
 # resolve identically. catalog_cmds submodules reference this module's helpers
 # lazily, so this import stays acyclic.
+from nexus.commands.catalog_cmds import backfill as _backfill_cmds  # noqa: E402 — must follow the `catalog` group definition above
 from nexus.commands.catalog_cmds import owners as _owners_cmds  # noqa: E402 — must follow the `catalog` group definition above
 
 _owners_cmds.register(catalog)
+_backfill_cmds.register(catalog)
 
 
 @catalog.command("init")
@@ -466,84 +468,6 @@ def backfill_collections_cmd(dry_run: bool) -> None:
         f"\nDone: {len(to_register)} new, "
         f"{len(already)} already registered."
     )
-
-
-@catalog.command("backfill-owner-id")
-@click.option(
-    "--dry-run/--no-dry-run",
-    default=True,
-    help="Report-only (default). Use --no-dry-run to actually update. "
-    "Matches the safe-default convention of the other Phase 6 verbs.",
-)
-@click.option(
-    "--from-documents/--no-from-documents",
-    default=True,
-    help="Use the documents-table fallback to recover owner_id for legacy "
-    "2-segment names (default). Disable to restrict the backfill to "
-    "the auto-migration's conformant-name path only.",
-)
-def backfill_owner_id_cmd(dry_run: bool, from_documents: bool) -> None:
-    """Populate ``collections.owner_id`` for empty rows (RDR-137 P1.5a).
-
-    \b
-    The CatalogStore's auto-migration handles conformant RDR-103
-    four-segment names on every DB open. This verb adds the documents-
-    table fallback that recovers owner_id for legacy 2-segment names
-    (e.g. ``knowledge__delos``) by inferring owner from documents that
-    are physically registered against the collection.
-
-    \b
-    Ambiguous rows (documents from multiple distinct owners) are
-    skipped with a warning. The auto-migration is idempotent — running
-    this with ``--from-documents=false`` is equivalent to opening any
-    CatalogStore connection.
-
-    \b
-    Examples:
-      nx catalog backfill-owner-id --dry-run
-      nx catalog backfill-owner-id --no-dry-run
-      nx catalog backfill-owner-id --no-dry-run --no-from-documents
-    """
-    from nexus.catalog.collections_owner_backfill import (  # noqa: PLC0415  — command-local import (nexus.catalog.collections_owner_backfill)
-        backfill_owner_id,
-    )
-    from nexus.catalog.factory import _is_catalog_service_mode  # noqa: PLC0415  — command-local import (nexus.catalog.factory)
-
-    if _is_catalog_service_mode():
-        raise click.ClickException(
-            "nx catalog backfill-owner-id is not supported in service mode — "
-            "this one-time migration runs against the SQLite database directly. "
-            "Run it locally before switching to service mode. "
-            "Tracked in nexus follow-on bead (gated on nexus-gmiaf.24)."
-        )
-
-    cat = _get_catalog()
-    # epsilon-allow: backfill_owner_id() requires a raw SQLite connection by
-    # contract; service mode is guarded above. This pair will remain until
-    # the backfill function is refactored to use the catalog API.
-    with cat._db:  # epsilon-allow: SQLite-only write, service mode guarded above
-        result = backfill_owner_id(
-            cat._db,  # epsilon-allow: SQLite-only write, service mode guarded above
-            include_documents_fallback=from_documents,
-            dry_run=dry_run,
-        )
-
-    verb = "would update" if dry_run else "updated"
-    click.echo(
-        f"{verb} {result.updated_from_name} via name + "
-        f"{result.updated_from_documents} via documents fallback "
-        f"(total empty: {result.total_empty})"
-    )
-    if result.skipped_ambiguous:
-        click.echo(
-            f"  skipped {result.skipped_ambiguous} ambiguous "
-            f"(multi-owner) collection(s)"
-        )
-    if result.skipped_unresolvable:
-        click.echo(
-            f"  skipped {result.skipped_unresolvable} unresolvable "
-            f"collection(s) — manual review required"
-        )
 
 
 @catalog.command("migrate-fallback")

--- a/src/nexus/commands/catalog_cmds/backfill.py
+++ b/src/nexus/commands/catalog_cmds/backfill.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Owner-id backfill command for the ``nx catalog`` group (nexus-kgyoz).
+
+Carved verbatim out of ``commands.catalog``: ``backfill-owner-id`` — the
+one-time RDR-137 P1.5a migration that populates ``collections.owner_id`` for
+legacy 2-segment collection names. Behaviour-preserving; ``register`` attaches
+it to the shared ``catalog`` group so ``nx catalog backfill-owner-id`` resolves
+exactly as before. ``_get_catalog`` is reached through the
+``nexus.commands.catalog`` module object so the import stays acyclic and the
+``patch("nexus.commands.catalog._get_catalog", …)`` test seam keeps working.
+"""
+from __future__ import annotations
+
+import click
+
+
+@click.command("backfill-owner-id")
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=True,
+    help="Report-only (default). Use --no-dry-run to actually update. "
+    "Matches the safe-default convention of the other Phase 6 verbs.",
+)
+@click.option(
+    "--from-documents/--no-from-documents",
+    default=True,
+    help="Use the documents-table fallback to recover owner_id for legacy "
+    "2-segment names (default). Disable to restrict the backfill to "
+    "the auto-migration's conformant-name path only.",
+)
+def backfill_owner_id_cmd(dry_run: bool, from_documents: bool) -> None:
+    """Populate ``collections.owner_id`` for empty rows (RDR-137 P1.5a).
+
+    \b
+    The CatalogStore's auto-migration handles conformant RDR-103
+    four-segment names on every DB open. This verb adds the documents-
+    table fallback that recovers owner_id for legacy 2-segment names
+    (e.g. ``knowledge__delos``) by inferring owner from documents that
+    are physically registered against the collection.
+
+    \b
+    Ambiguous rows (documents from multiple distinct owners) are
+    skipped with a warning. The auto-migration is idempotent — running
+    this with ``--from-documents=false`` is equivalent to opening any
+    CatalogStore connection.
+
+    \b
+    Examples:
+      nx catalog backfill-owner-id --dry-run
+      nx catalog backfill-owner-id --no-dry-run
+      nx catalog backfill-owner-id --no-dry-run --no-from-documents
+    """
+    from nexus.catalog.collections_owner_backfill import (  # noqa: PLC0415  — command-local import (nexus.catalog.collections_owner_backfill)
+        backfill_owner_id,
+    )
+    from nexus.catalog.factory import _is_catalog_service_mode  # noqa: PLC0415  — command-local import (nexus.catalog.factory)
+    from nexus.commands import catalog as _cat_cmd  # noqa: PLC0415 — module-routed helper access keeps import acyclic + monkeypatch-visible
+
+    if _is_catalog_service_mode():
+        raise click.ClickException(
+            "nx catalog backfill-owner-id is not supported in service mode — "
+            "this one-time migration runs against the SQLite database directly. "
+            "Run it locally before switching to service mode. "
+            "Tracked in nexus follow-on bead (gated on nexus-gmiaf.24)."
+        )
+
+    cat = _cat_cmd._get_catalog()
+    # epsilon-allow: backfill_owner_id() requires a raw SQLite connection by
+    # contract; service mode is guarded above. This pair will remain until
+    # the backfill function is refactored to use the catalog API.
+    with cat._db:  # epsilon-allow: SQLite-only write, service mode guarded above
+        result = backfill_owner_id(
+            cat._db,  # epsilon-allow: SQLite-only write, service mode guarded above
+            include_documents_fallback=from_documents,
+            dry_run=dry_run,
+        )
+
+    verb = "would update" if dry_run else "updated"
+    click.echo(
+        f"{verb} {result.updated_from_name} via name + "
+        f"{result.updated_from_documents} via documents fallback "
+        f"(total empty: {result.total_empty})"
+    )
+    if result.skipped_ambiguous:
+        click.echo(
+            f"  skipped {result.skipped_ambiguous} ambiguous "
+            f"(multi-owner) collection(s)"
+        )
+    if result.skipped_unresolvable:
+        click.echo(
+            f"  skipped {result.skipped_unresolvable} unresolvable "
+            f"collection(s) — manual review required"
+        )
+
+
+def register(group: click.Group) -> None:
+    """Attach the owner-id backfill command to the shared ``catalog`` group."""
+    group.add_command(backfill_owner_id_cmd)

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -1681,3 +1681,35 @@ class TestSeam3OwnersCarve:
         assert result.exit_code == 0, result.output
         assert "sentinel-owner" in result.output
         fake.list_owners.assert_called_once()
+
+
+class TestKgyozBackfillCarve:
+    """Contract pins for the nexus-kgyoz backfill-owner-id command carve.
+
+    Non-vacuous: fails if the command is re-inlined into ``commands.catalog``,
+    if the ``register`` wiring is dropped, or if the carved module's lazy
+    service-mode guard / module-routed access regresses.
+    """
+
+    def test_backfill_command_registered_on_group(self):
+        from nexus.cli import main
+        assert "backfill-owner-id" in main.commands["catalog"].commands
+
+    def test_backfill_command_defined_in_carved_module(self):
+        from nexus.cli import main
+        from nexus.commands.catalog_cmds import backfill as backfill_mod
+        cmd = main.commands["catalog"].commands["backfill-owner-id"]
+        assert cmd.callback is backfill_mod.backfill_owner_id_cmd.callback
+
+    def test_backfill_service_mode_guard_fires_through_carved_module(self):
+        """End-to-end through the group: service mode is refused with a clear
+        error. Exercises the carved command's lazy imports and guard before
+        any catalog access — no real catalog needed."""
+        from unittest.mock import patch
+
+        from nexus.cli import main
+
+        with patch("nexus.catalog.factory._is_catalog_service_mode", return_value=True):
+            result = CliRunner().invoke(main, ["catalog", "backfill-owner-id"])
+        assert result.exit_code != 0
+        assert "not supported in service mode" in result.output


### PR DESCRIPTION
## Summary

Second of the deferred nexus-kgyoz CLI carves, mirroring the merged seam-3 owners pattern. Lifts the one-time RDR-137 P1.5a migration command `backfill-owner-id` out of `commands/catalog.py` into a new `catalog_cmds/backfill.py` as a plain `@click.command(...)` plus a `register(group)` hook. `commands/catalog.py` now calls `_backfill_cmds.register(catalog)` alongside the owners registration. `nx catalog backfill-owner-id` resolves identically — name, both options, help, output, and the service-mode guard unchanged.

`backfill-owner-id` was deliberately excluded from the seam-3 owners carve (it's a migration command, not owner-management); this takes it as its own cohesive carve.

## Behaviour preservation

Body moved verbatim, including the `epsilon-allow` SQLite markers, the `with cat._db:` block, the service-mode guard, and all output branches. `_get_catalog` is reached through the `nexus.commands.catalog` module object (lazy, in-body) so the import stays acyclic and the `patch("nexus.commands.catalog._get_catalog", …)` seam holds. No test imports the command by symbol.

## Tests

Three contract pins in `tests/test_catalog_cli.py::TestKgyozBackfillCarve`: group-registration, callback-identity-in-carved-module (anti-re-inline), and a behavioural pin that drives the command end-to-end through the group with service mode patched on, asserting the guard fires. Guard suites green: `test_collections_owner_backfill` + `test_xnz0o_commands_integration` + `test_catalog_cli` = **99 passed**. `uvx ruff@0.15.18 check src/`: clean.

## Review

Both stacked reviewers ran, **0 Critical**, approved. Applied the two cosmetic wiring-block follow-ups (align import/register order, generalize the carve comment) so the block stays coherent as the links-family carve adds a third register pair.

Second of three deferred kgyoz items (owner-relocate #1317 · this · links family carve next).