### PR TITLE
refactor(catalog-cli): carve backups command family into catalog_cmds (nexus-whh61.4)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -236,10 +236,12 @@ def catalog() -> None:
 from nexus.commands.catalog_cmds import owners as _owners_cmds  # noqa: E402 — must follow the `catalog` group definition above
 from nexus.commands.catalog_cmds import backfill as _backfill_cmds  # noqa: E402 — must follow the `catalog` group definition above
 from nexus.commands.catalog_cmds import links as _links_cmds  # noqa: E402 — must follow the `catalog` group definition above
+from nexus.commands.catalog_cmds import backups as _backups_cmds  # noqa: E402 — must follow the `catalog` group definition above
 
 _owners_cmds.register(catalog)
 _backfill_cmds.register(catalog)
 _links_cmds.register(catalog)
+_backups_cmds.register(catalog)
 
 
 @catalog.command("init")
@@ -5346,110 +5348,6 @@ def _print_t3_doc_id_coverage_text(report: dict) -> None:
 
 
 # ── Backup-before-delete recovery surface (RDR-106 Option A) ─────────────
-
-
-@catalog.command("list-backups")
-def list_backups_cmd() -> None:
-    """List backup snapshots written by destructive catalog verbs.
-
-    Each destructive catalog verb (``delete``, ``gc``, ``prune-stale``,
-    ``link-bulk-delete``) writes a JSONL snapshot of the rows about
-    to be deleted under ``$NEXUS_CONFIG_DIR/catalog/.deleted-backups/``
-    BEFORE the actual delete. This verb shows what's recoverable
-    without inspecting the files manually.
-    """
-    from nexus.catalog.catalog_backup import list_backups  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
-    cat = _get_catalog()
-    records = list_backups(cat)
-    if not records:
-        click.echo("No backups found.")
-        return
-    click.echo(f"{len(records)} backup(s) (newest first):\n")
-    for rec in records:
-        click.echo(
-            f"  {rec.path.name}\n"
-            f"    verb={rec.verb}  ts={rec.timestamp}  "
-            f"rows={rec.rows_count}\n"
-            f"    reason={rec.reason or '<none>'}"
-        )
-
-
-@catalog.command("undelete")
-@click.argument("backup")
-def undelete_cmd(backup: str) -> None:
-    """Restore documents (and their links) from a backup snapshot.
-
-    BACKUP is either a filename inside ``.deleted-backups/`` or an
-    absolute path. Documents are re-emitted as DocumentRegistered
-    events in events.jsonl (event-sourced; full audit trail);
-    inbound and outbound links are re-emitted as LinkCreated events
-    via ``link_if_absent`` (idempotent).
-
-    Documents are restored with their ORIGINAL tumblers — the tumbler
-    minting path is bypassed. Re-running this on an already-restored
-    backup is a no-op (DocumentRegistered on existing tumbler is
-    idempotent via INSERT OR REPLACE).
-    """
-    from nexus.catalog.catalog_backup import restore_documents  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
-    from nexus.catalog.factory import (  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
-        CatalogAdminDaemonLiveError,
-        make_catalog_admin,
-    )
-    # Deep-maintenance: restore_documents re-emits events through the
-    # catalog's low-level event log, not the 22 daemon write ops (RDR-146).
-    try:
-        cat = make_catalog_admin()
-    except CatalogAdminDaemonLiveError as exc:
-        raise click.ClickException(str(exc)) from exc
-    if cat is None:
-        raise click.ClickException(
-            "Catalog not initialized. Run 'nx catalog setup' first."
-        )
-    if backup.startswith("/"):
-        backup_path = Path(backup)
-    else:
-        backup_path = cat._dir / ".deleted-backups" / backup
-    if not backup_path.exists():
-        raise click.ClickException(f"Backup not found: {backup_path}")
-
-    docs, links = restore_documents(cat, backup_path)
-    click.echo(
-        f"Restored {docs} document(s) and {links} link(s) "
-        f"from {backup_path.name}."
-    )
-
-
-@catalog.command("vacuum-backups")
-@click.option(
-    "--older-than-days", default=30, show_default=True,
-    help="Drop backup files older than this many days.",
-)
-@click.option(
-    "--dry-run/--no-dry-run", default=True,
-    help="Report-only (default). Use --no-dry-run to delete.",
-)
-def vacuum_backups_cmd(older_than_days: int, dry_run: bool) -> None:
-    """Drop old backup snapshots past the retention window.
-
-    Default retention is 30 days. Removed files are gone for good —
-    after vacuum, the rows in those backups are no longer recoverable
-    via ``nx catalog undelete``.
-    """
-    from nexus.catalog.catalog_backup import vacuum_old_backups  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
-    cat = _get_catalog()
-    removed, kept = vacuum_old_backups(
-        cat, older_than_days=older_than_days, dry_run=dry_run,
-    )
-    if dry_run:
-        click.echo(
-            f"Would remove {removed} backup file(s) "
-            f"(keeping {kept}). "
-            f"Run with --no-dry-run to actually delete."
-        )
-    else:
-        click.echo(
-            f"Removed {removed} backup file(s); kept {kept}."
-        )
 
 
 @catalog.command("chash-reconcile")

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -5347,9 +5347,6 @@ def _print_t3_doc_id_coverage_text(report: dict) -> None:
         )
 
 
-# ── Backup-before-delete recovery surface (RDR-106 Option A) ─────────────
-
-
 @catalog.command("chash-reconcile")
 @click.option(
     "--apply",

--- a/src/nexus/commands/catalog_cmds/backups.py
+++ b/src/nexus/commands/catalog_cmds/backups.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Backup-snapshot commands for the ``nx catalog`` group (nexus-whh61.4).
+
+Carved verbatim out of ``commands.catalog``: ``list-backups`` / ``undelete`` /
+``vacuum-backups`` — the lifecycle verbs over the JSONL snapshots that
+destructive catalog verbs write before deleting (RDR-106). Behaviour-
+preserving; ``register`` attaches all three to the shared ``catalog`` group so
+``nx catalog list-backups`` (etc.) resolve exactly as before.
+
+``_get_catalog`` is reached through the ``nexus.commands.catalog`` module
+object inside each body — keeping this module's imports acyclic and preserving
+the ``patch("nexus.commands.catalog._get_catalog", …)`` test seam. ``undelete``
+opens an admin catalog directly (``make_catalog_admin``), mirroring the
+original.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+
+@click.command("list-backups")
+def list_backups_cmd() -> None:
+    """List backup snapshots written by destructive catalog verbs.
+
+    Each destructive catalog verb (``delete``, ``gc``, ``prune-stale``,
+    ``link-bulk-delete``) writes a JSONL snapshot of the rows about
+    to be deleted under ``$NEXUS_CONFIG_DIR/catalog/.deleted-backups/``
+    BEFORE the actual delete. This verb shows what's recoverable
+    without inspecting the files manually.
+    """
+    from nexus.catalog.catalog_backup import list_backups  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
+    from nexus.commands import catalog as _cat_cmd  # noqa: PLC0415 — module-routed helper access keeps import acyclic + monkeypatch-visible
+    cat = _cat_cmd._get_catalog()
+    records = list_backups(cat)
+    if not records:
+        click.echo("No backups found.")
+        return
+    click.echo(f"{len(records)} backup(s) (newest first):\n")
+    for rec in records:
+        click.echo(
+            f"  {rec.path.name}\n"
+            f"    verb={rec.verb}  ts={rec.timestamp}  "
+            f"rows={rec.rows_count}\n"
+            f"    reason={rec.reason or '<none>'}"
+        )
+
+
+@click.command("undelete")
+@click.argument("backup")
+def undelete_cmd(backup: str) -> None:
+    """Restore documents (and their links) from a backup snapshot.
+
+    BACKUP is either a filename inside ``.deleted-backups/`` or an
+    absolute path. Documents are re-emitted as DocumentRegistered
+    events in events.jsonl (event-sourced; full audit trail);
+    inbound and outbound links are re-emitted as LinkCreated events
+    via ``link_if_absent`` (idempotent).
+
+    Documents are restored with their ORIGINAL tumblers — the tumbler
+    minting path is bypassed. Re-running this on an already-restored
+    backup is a no-op (DocumentRegistered on existing tumbler is
+    idempotent via INSERT OR REPLACE).
+    """
+    from nexus.catalog.catalog_backup import restore_documents  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
+    from nexus.catalog.factory import (  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
+        CatalogAdminDaemonLiveError,
+        make_catalog_admin,
+    )
+    # Deep-maintenance: restore_documents re-emits events through the
+    # catalog's low-level event log, not the 22 daemon write ops (RDR-146).
+    try:
+        cat = make_catalog_admin()
+    except CatalogAdminDaemonLiveError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if cat is None:
+        raise click.ClickException(
+            "Catalog not initialized. Run 'nx catalog setup' first."
+        )
+    if backup.startswith("/"):
+        backup_path = Path(backup)
+    else:
+        backup_path = cat._dir / ".deleted-backups" / backup
+    if not backup_path.exists():
+        raise click.ClickException(f"Backup not found: {backup_path}")
+
+    docs, links = restore_documents(cat, backup_path)
+    click.echo(
+        f"Restored {docs} document(s) and {links} link(s) "
+        f"from {backup_path.name}."
+    )
+
+
+@click.command("vacuum-backups")
+@click.option(
+    "--older-than-days", default=30, show_default=True,
+    help="Drop backup files older than this many days.",
+)
+@click.option(
+    "--dry-run/--no-dry-run", default=True,
+    help="Report-only (default). Use --no-dry-run to delete.",
+)
+def vacuum_backups_cmd(older_than_days: int, dry_run: bool) -> None:
+    """Drop old backup snapshots past the retention window.
+
+    Default retention is 30 days. Removed files are gone for good —
+    after vacuum, the rows in those backups are no longer recoverable
+    via ``nx catalog undelete``.
+    """
+    from nexus.catalog.catalog_backup import vacuum_old_backups  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
+    from nexus.commands import catalog as _cat_cmd  # noqa: PLC0415 — module-routed helper access keeps import acyclic + monkeypatch-visible
+    cat = _cat_cmd._get_catalog()
+    removed, kept = vacuum_old_backups(
+        cat, older_than_days=older_than_days, dry_run=dry_run,
+    )
+    if dry_run:
+        click.echo(
+            f"Would remove {removed} backup file(s) "
+            f"(keeping {kept}). "
+            f"Run with --no-dry-run to actually delete."
+        )
+    else:
+        click.echo(
+            f"Removed {removed} backup file(s); kept {kept}."
+        )
+
+
+def register(group: click.Group) -> None:
+    """Attach the backup-snapshot commands to the shared ``catalog`` group."""
+    group.add_command(list_backups_cmd)
+    group.add_command(undelete_cmd)
+    group.add_command(vacuum_backups_cmd)

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -1799,3 +1799,42 @@ class TestKgyozLinksCarve:
 
         catalog_group = main.commands["catalog"]
         assert catalog_group.commands["generate-links"] is links_mod.generate_links_cmd
+
+
+class TestWhh61BackupsCarve:
+    """Contract pins for the nexus-whh61.4 backups command carve.
+
+    Non-vacuous: fails on re-inline into ``commands.catalog``, a dropped
+    ``register`` call, or import-bound (non-module-routed) ``_get_catalog``.
+    """
+
+    BACKUP_COMMANDS = ["list-backups", "undelete", "vacuum-backups"]
+
+    def test_backup_commands_registered_on_group(self):
+        from nexus.cli import main
+        catalog_group = main.commands["catalog"]
+        for name in self.BACKUP_COMMANDS:
+            assert name in catalog_group.commands, f"{name} not registered"
+
+    def test_backup_commands_defined_in_carved_module(self):
+        from nexus.cli import main
+        catalog_group = main.commands["catalog"]
+        for name in self.BACKUP_COMMANDS:
+            assert catalog_group.commands[name].callback.__module__ == (
+                "nexus.commands.catalog_cmds.backups"
+            ), f"{name} not in carved module"
+
+    def test_list_backups_routes_get_catalog_through_module(self):
+        """End-to-end: patching commands.catalog._get_catalog is observed by
+        the carved list-backups command — proves module-routed access."""
+        from unittest.mock import MagicMock, patch
+
+        from nexus.cli import main
+
+        fake = MagicMock()
+        with patch("nexus.commands.catalog._get_catalog", return_value=fake), \
+                patch("nexus.catalog.catalog_backup.list_backups", return_value=[]) as lb:
+            result = CliRunner().invoke(main, ["catalog", "list-backups"])
+        assert result.exit_code == 0, result.output
+        assert "No backups found." in result.output
+        lb.assert_called_once_with(fake)

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -1806,6 +1806,12 @@ class TestWhh61BackupsCarve:
 
     Non-vacuous: fails on re-inline into ``commands.catalog``, a dropped
     ``register`` call, or import-bound (non-module-routed) ``_get_catalog``.
+
+    Note the two access paths: ``list-backups`` / ``vacuum-backups`` read via
+    ``_get_catalog()`` (defended by the patch-seam pins below), while
+    ``undelete`` opens an admin catalog via ``make_catalog_admin()`` — pinned
+    here by its daemon-live guard; its full restore round-trip lives in
+    ``test_catalog_backup_and_safety.py`` via ``NEXUS_CATALOG_PATH`` plumbing.
     """
 
     BACKUP_COMMANDS = ["list-backups", "undelete", "vacuum-backups"]
@@ -1838,3 +1844,37 @@ class TestWhh61BackupsCarve:
         assert result.exit_code == 0, result.output
         assert "No backups found." in result.output
         lb.assert_called_once_with(fake)
+
+    def test_vacuum_backups_routes_get_catalog_through_module(self):
+        """Symmetric to list-backups: vacuum-backups also routes _get_catalog
+        through the module object (would fail if bound at import time)."""
+        from unittest.mock import MagicMock, patch
+
+        from nexus.cli import main
+
+        fake = MagicMock()
+        with patch("nexus.commands.catalog._get_catalog", return_value=fake), \
+                patch(
+                    "nexus.catalog.catalog_backup.vacuum_old_backups",
+                    return_value=(0, 0),
+                ) as vac:
+            result = CliRunner().invoke(main, ["catalog", "vacuum-backups"])
+        assert result.exit_code == 0, result.output
+        vac.assert_called_once()
+        assert vac.call_args.args[0] is fake
+
+    def test_undelete_surfaces_daemon_live_guard(self):
+        """undelete uses the admin path (make_catalog_admin), not _get_catalog.
+        Pin the CLI-layer guard: a live daemon surfaces as a ClickException."""
+        from unittest.mock import patch
+
+        from nexus.catalog.factory import CatalogAdminDaemonLiveError
+        from nexus.cli import main
+
+        with patch(
+            "nexus.catalog.factory.make_catalog_admin",
+            side_effect=CatalogAdminDaemonLiveError("daemon is live"),
+        ):
+            result = CliRunner().invoke(main, ["catalog", "undelete", "snap.jsonl"])
+        assert result.exit_code != 0
+        assert "daemon is live" in result.output


### PR DESCRIPTION
## Summary

Continues the catalog-cli decomposition past the closed kgyoz bead (tracked under epic child nexus-whh61.4). Carves the backup-snapshot lifecycle commands — `list-backups`, `undelete`, `vacuum-backups` — out of `commands/catalog.py` into a new `catalog_cmds/backups.py`, mirroring the merged owners/backfill/links carves: plain `@click.command(...)` + `register(group)`. `nx catalog list-backups` (etc.) resolve identically; 47 total catalog commands preserved.

The write side (the destructive verbs `delete`/`gc`/`prune-stale`/`link-bulk-delete` that *create* snapshots) is correctly left in place — this carves only the read/recovery surface.

## Behaviour preservation

Bodies moved verbatim (both reviewers confirmed line-for-line), including `undelete`'s `make_catalog_admin` admin path, its absolute-vs-relative backup-path branch, and `vacuum-backups`'s dry-run default/message. `list-backups`/`vacuum-backups` reach `_get_catalog` via the `nexus.commands.catalog` module object inside the body (acyclic; `_get_catalog` patch seam preserved); `undelete` uses no shared helper. No test imports these by symbol. Removed the now-orphaned section comment that post-carve mislabeled `chash-reconcile`.

## Tests

Five contract pins in `tests/test_catalog_cli.py::TestWhh61BackupsCarve`: registration, callbacks-in-carved-module, behavioural module-routed `_get_catalog` for both `list-backups` and `vacuum-backups`, and an `undelete` admin-path pin (daemon-live guard surfaces as ClickException). Class docstring documents the two-access-path split (undelete's restore round-trip lives in `test_catalog_backup_and_safety.py`). Guard suites green: cli + backup-safety = **115 passed**; `ruff check src/` clean.

## Review

Both stacked reviewers ran, **0 Critical**, approved (verbatim fidelity confirmed). Applied all non-blocking findings (symmetric vacuum pin, undelete admin-path pin + docstring note, orphaned-comment removal).

First family of the post-kgyoz continuation (nexus-whh61.4). ~30 commands remain in commands/catalog.py for future cohesive-family carves.