### PR TITLE
feat(aspect-queue): RDR-163 P0+P1 — next_retry_at backoff claim gate + mark_retry ladder

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/AspectRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/AspectRepository.java
@@ -754,7 +754,15 @@ public final class AspectRepository {
                     ASPECT_EXTRACTION_QUEUE.RETRY_COUNT,
                     ASPECT_EXTRACTION_QUEUE.DOC_ID)
                 .from(ASPECT_EXTRACTION_QUEUE)
-                .where(ASPECT_EXTRACTION_QUEUE.STATUS.eq("pending"))
+                // RDR-163 P0 (nexus-795gv) backoff gate: a row backed off to a
+                // future next_retry_at must not be claimed early. NULL = ready now.
+                // now() is the server (DB) clock — correct for both the co-located
+                // local deployment and the cloud deployment where the worker host
+                // clock would skew against a client-stamped comparison.
+                .where(ASPECT_EXTRACTION_QUEUE.STATUS.eq("pending")
+                    .and(ASPECT_EXTRACTION_QUEUE.NEXT_RETRY_AT.isNull()
+                        .or(ASPECT_EXTRACTION_QUEUE.NEXT_RETRY_AT.le(
+                            field("now()", OffsetDateTime.class)))))
                 .orderBy(ASPECT_EXTRACTION_QUEUE.ENQUEUED_AT.asc(), ASPECT_EXTRACTION_QUEUE.SOURCE_PATH.asc())
                 .limit(1)
                 .forUpdate().skipLocked()

--- a/service/src/main/java/dev/nexus/service/db/AspectRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/AspectRepository.java
@@ -729,6 +729,12 @@ public final class AspectRepository {
                 .set(ASPECT_EXTRACTION_QUEUE.ENQUEUED_AT,     EX_Q_ENQUEUED_AT)
                 .set(ASPECT_EXTRACTION_QUEUE.LAST_ATTEMPT_AT, (OffsetDateTime) null)
                 .set(ASPECT_EXTRACTION_QUEUE.LAST_ERROR,      (String) null)
+                // RDR-163 P1 (nexus-ztpt6): a re-enqueue is a fresh request — it
+                // resets retry_count to 0, so it must also clear any stale backoff
+                // (next_retry_at) left by a prior mark_retry. Otherwise the claim
+                // gate would silently hold the re-enqueued row until the old
+                // backoff elapses (up to base*2^(cap-1) seconds).
+                .set(ASPECT_EXTRACTION_QUEUE.NEXT_RETRY_AT,   (OffsetDateTime) null)
                 .execute();
             return null;
         });
@@ -854,15 +860,27 @@ public final class AspectRepository {
     }
 
     /**
-     * Reset a row to pending (transient retry).
+     * Reset a row to pending for a transient retry, backing it off for
+     * {@code intervalSeconds} (RDR-163 P1, nexus-ztpt6).
+     *
+     * <p>next_retry_at is stamped {@code now() + intervalSeconds} on the SERVER
+     * (DB) clock — the worker chooses the interval, the service stamps the
+     * absolute instant. This is the cloud clock-skew defense: the worker host is
+     * not the DB host, so a client-computed absolute timestamp would compare
+     * wrongly against the {@code now()}-based claim gate. {@code intervalSeconds
+     * = 0} means "ready immediately". retry_count is incremented (monotonic; the
+     * cap's source of truth); last_attempt_at is cleared.
      */
-    public void markRetry(String tenant, String collection, String sourcePath) {
+    public void markRetry(String tenant, String collection, String sourcePath, long intervalSeconds) {
         tenantScope.withTenant(tenant, ctx -> {
             ctx.update(ASPECT_EXTRACTION_QUEUE)
                .set(ASPECT_EXTRACTION_QUEUE.STATUS, "pending")
                .set(ASPECT_EXTRACTION_QUEUE.RETRY_COUNT,
                    field("retry_count + 1", Integer.class))
                .set(ASPECT_EXTRACTION_QUEUE.LAST_ATTEMPT_AT, (OffsetDateTime) null)
+               .set(ASPECT_EXTRACTION_QUEUE.NEXT_RETRY_AT,
+                   field("now() + make_interval(secs => ?)", OffsetDateTime.class,
+                         (double) intervalSeconds))
                .where(ASPECT_EXTRACTION_QUEUE.COLLECTION.eq(collection)
                    .and(ASPECT_EXTRACTION_QUEUE.SOURCE_PATH.eq(sourcePath)))
                .execute();

--- a/service/src/main/java/dev/nexus/service/http/AspectHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/AspectHandler.java
@@ -477,7 +477,13 @@ public final class AspectHandler implements HttpHandler {
     private void handleQueueMarkRetry(HttpExchange ex, String tenant, String method) throws IOException {
         if (!"POST".equals(method)) { HttpUtil.send(ex, 405, "{\"error\":\"POST required\"}"); return; }
         Map<String, Object> body = readBody(ex);
-        repo.markRetry(tenant, (String) body.get("collection"), (String) body.get("source_path"));
+        // RDR-163 P1 (nexus-ztpt6): worker passes interval_seconds; the service
+        // stamps next_retry_at = now()+interval server-side. Default 0 (ready now)
+        // keeps any legacy caller behaving as the pre-backoff reset.
+        long intervalSeconds = body.containsKey("interval_seconds")
+            ? ((Number) body.get("interval_seconds")).longValue() : 0L;
+        repo.markRetry(tenant, (String) body.get("collection"), (String) body.get("source_path"),
+            intervalSeconds);
         HttpUtil.send(ex, 200, "{\"ok\":true}");
     }
 

--- a/service/src/main/resources/db/changelog/aspects-002-next-retry-at.xml
+++ b/service/src/main/resources/db/changelog/aspects-002-next-retry-at.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    RDR-163 bead nexus-795gv — aspect-extraction-queue bounded backoff-retry ladder, P0.
+
+    Adds nexus.aspect_extraction_queue.next_retry_at (TIMESTAMPTZ, nullable) so the
+    claim path can schedule a retry into the future instead of terminal-failing a
+    transient error. NULL means "claimable now" (the default for freshly enqueued
+    rows); a future timestamp means "do not claim before this instant".
+
+    Sibling additive changeset — the aspects-001 baseline is NEVER edited. The column
+    is written ONLY by markRetry (P1, nexus-ztpt6); P0 lands the column + the
+    claim-query gate (AspectRepository.claimNext) + the reclaimStale invariant
+    (reclaimStale must leave next_retry_at unchanged). No default, no backfill: NULL
+    is the correct "ready" state for every existing row.
+
+    Grants: grants-nexus-svc.xml (runAlways=true, last in the master changelog) issues
+    schema-wide DML grants, so the new column inherits nexus_svc access automatically —
+    no grant changeset needed. RLS: the table already has tenant_isolation
+    ENABLE + FORCE (aspects-001-6); adding a column does not change the policy.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="aspects-002-1" author="nexus-795gv">
+        <comment>Add next_retry_at TIMESTAMPTZ (nullable) for the backoff-retry claim gate</comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.aspect_extraction_queue ADD COLUMN next_retry_at TIMESTAMPTZ;
+        </sql>
+        <rollback>
+            ALTER TABLE nexus.aspect_extraction_queue DROP COLUMN IF EXISTS next_retry_at;
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -35,6 +35,8 @@
 
     <!-- Store 6: aspects / highlights / queue / promotion-log (bead nexus-gmiaf.15) -->
     <include file="db/changelog/aspects-001-baseline.xml"/>
+    <!-- RDR-163 nexus-795gv: aspect_extraction_queue.next_retry_at backoff-retry gate. -->
+    <include file="db/changelog/aspects-002-next-retry-at.xml"/>
 
     <!-- Store 7: chash_index (bead nexus-gmiaf.16) — content-addressed routing table, no FTS -->
     <include file="db/changelog/chash-001-baseline.xml"/>

--- a/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
@@ -552,8 +552,8 @@ class AspectRepositoryTest {
 
         repo.markFailed(TENANT_A, "failretry-coll", "fr.pdf", "extractor crashed");
         // After failed, isDrained excludes failed — still counts as not-done
-        // Now retry: resets to pending
-        repo.markRetry(TENANT_A, "failretry-coll", "fr.pdf");
+        // Now retry with interval 0 (immediately ready): resets to pending
+        repo.markRetry(TENANT_A, "failretry-coll", "fr.pdf", 0L);
         int cnt = repo.pendingCount(TENANT_A);
         assertThat(cnt).isGreaterThanOrEqualTo(1);
     }
@@ -844,6 +844,67 @@ class AspectRepositoryTest {
             .isNull();
         assertThat(repo.claimNext(tenant))
             .as("a reclaimed NULL-next_retry_at row is immediately claimable").isPresent();
+    }
+
+    @Test @Order(46)
+    void markRetry_stampsNextRetryAtServerSide_andBacksOffClaim() throws Exception {
+        String tenant = "markretry-tenant-" + System.nanoTime();
+        var body = new java.util.LinkedHashMap<String, Object>();
+        body.put("collection",  "mr-coll");
+        body.put("source_path", "mr.pdf");
+        repo.enqueue(tenant, body);
+        repo.claimNext(tenant);                       // -> in_progress
+
+        long interval = 600;                          // 10 minutes
+        OffsetDateTime before = OffsetDateTime.now(ZoneOffset.UTC);
+        repo.markRetry(tenant, "mr-coll", "mr.pdf", interval);
+        OffsetDateTime after = OffsetDateTime.now(ZoneOffset.UTC);
+
+        // next_retry_at is stamped now()+interval on the SERVER clock. In testcontainers
+        // the DB shares the host clock, so [before, after] bound the server now() tightly;
+        // a 30s pad absorbs any residual skew without making the assertion vacuous.
+        OffsetDateTime nra = readNextRetryAt(tenant, "mr.pdf");
+        assertThat(nra).as("markRetry must stamp next_retry_at").isNotNull();
+        assertThat(nra.toInstant())
+            .as("next_retry_at must be now()+interval, server-stamped")
+            .isBetween(before.plusSeconds(interval).minusSeconds(30).toInstant(),
+                       after.plusSeconds(interval).plusSeconds(30).toInstant());
+
+        // retry_count incremented to 1 (row is pending; listPending is ungated so it shows).
+        Map<String, Object> row = repo.listPending(tenant, 100).stream()
+            .filter(r -> "mr.pdf".equals(r.get("source_path")))
+            .findFirst().orElseThrow(() -> new AssertionError("retried row not in listPending"));
+        assertThat(((Number) row.get("retry_count")).intValue())
+            .as("markRetry must increment retry_count").isEqualTo(1);
+
+        // The backoff is live: the row is NOT claimable until next_retry_at elapses.
+        assertThat(repo.claimNext(tenant))
+            .as("a just-retried row backed off into the future must not be claimable")
+            .isEmpty();
+    }
+
+    @Test @Order(47)
+    void reEnqueue_clearsStaleBackoff_rowImmediatelyClaimable() throws Exception {
+        // RDR-163 P1 (nexus-ztpt6) H-1: a re-enqueue resets retry_count to 0, so
+        // it must also clear next_retry_at — otherwise a row backed off by a prior
+        // mark_retry stays silently held until the old backoff elapses.
+        String tenant = "reenqueue-backoff-tenant-" + System.nanoTime();
+        var body = new java.util.LinkedHashMap<String, Object>();
+        body.put("collection",  "rb-coll");
+        body.put("source_path", "rb.pdf");
+        repo.enqueue(tenant, body);
+
+        // Back the row off far into the future (simulating a prior mark_retry).
+        setNextRetryAt(tenant, "rb.pdf", OffsetDateTime.now(ZoneOffset.UTC).plusHours(2));
+        assertThat(repo.claimNext(tenant))
+            .as("precondition: a backed-off row is not claimable").isEmpty();
+
+        // Re-enqueue at the same key: must clear the backoff and be claimable now.
+        repo.enqueue(tenant, body);
+        assertThat(readNextRetryAt(tenant, "rb.pdf"))
+            .as("re-enqueue must clear stale next_retry_at").isNull();
+        assertThat(repo.claimNext(tenant))
+            .as("re-enqueued row must be immediately claimable").isPresent();
     }
 
     /** Set next_retry_at on a specific row via a superuser connection (bypasses RLS). */

--- a/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
@@ -742,6 +742,142 @@ class AspectRepositoryTest {
         assertThat(batch).as("claimBatch must return at least 1 row").isNotEmpty();
     }
 
+    // ── next_retry_at backoff gate (RDR-163 P0, nexus-795gv) ────────────────────
+
+    @Test @Order(41)
+    void claimNext_skipsRowWithFutureNextRetryAt() throws Exception {
+        // Isolated tenant so claimNext sees ONLY this row.
+        String tenant = "nra-future-tenant-" + System.nanoTime();
+        var body = new java.util.LinkedHashMap<String, Object>();
+        body.put("collection",  "nra-coll");
+        body.put("source_path", "future.pdf");
+        repo.enqueue(tenant, body);
+
+        // Back the row off one hour into the future (server clock).
+        setNextRetryAt(tenant, "future.pdf",
+            OffsetDateTime.now(ZoneOffset.UTC).plusHours(1));
+
+        Optional<Map<String, Object>> claimed = repo.claimNext(tenant);
+        assertThat(claimed)
+            .as("a row whose next_retry_at is in the future must NOT be claimed")
+            .isEmpty();
+    }
+
+    @Test @Order(42)
+    void claimNext_claimsRowWhenNextRetryAtNullOrElapsed() throws Exception {
+        String tenant = "nra-ready-tenant-" + System.nanoTime();
+
+        // Row 1: next_retry_at elapsed (5 min in the past) -> claimable.
+        var past = new java.util.LinkedHashMap<String, Object>();
+        past.put("collection",  "nra-coll");
+        past.put("source_path", "past.pdf");
+        repo.enqueue(tenant, past);
+        setNextRetryAt(tenant, "past.pdf",
+            OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(5));
+
+        // Row 2: next_retry_at left NULL (the enqueue default) -> claimable.
+        var nul = new java.util.LinkedHashMap<String, Object>();
+        nul.put("collection",  "nra-coll");
+        nul.put("source_path", "null.pdf");
+        repo.enqueue(tenant, nul);
+
+        // Both branches of the gate (IS NULL OR <= now()) must admit a claim.
+        List<Map<String, Object>> claimed = repo.claimBatch(tenant, 10);
+        List<Object> paths = claimed.stream().map(r -> r.get("source_path")).toList();
+        assertThat(paths)
+            .as("both an elapsed-next_retry_at row and a NULL-next_retry_at row must be claimable")
+            .containsExactlyInAnyOrder("past.pdf", "null.pdf");
+    }
+
+    @Test @Order(43)
+    void reclaimStale_leavesNextRetryAtUnchanged_andRowImmediatelyClaimable() throws Exception {
+        String tenant = "nra-reclaim-tenant-" + System.nanoTime();
+        var body = new java.util.LinkedHashMap<String, Object>();
+        body.put("collection",  "nra-coll");
+        body.put("source_path", "reclaim.pdf");
+        repo.enqueue(tenant, body);
+
+        // Stamp a known PAST next_retry_at so the row is claimable, then claim it
+        // (-> in_progress). claimNext must not touch next_retry_at.
+        OffsetDateTime backoff = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(10);
+        setNextRetryAt(tenant, "reclaim.pdf", backoff);
+        assertThat(repo.claimNext(tenant))
+            .as("setup: a past-next_retry_at row must claim into in_progress")
+            .isPresent();
+
+        // Worker dies -> reclaimStale resets in_progress -> pending. It must NOT
+        // write next_retry_at: clearing it would bypass the backoff cap, bumping
+        // it would punish a crash (RDR-163 §Consequences, AspectRepository invariant).
+        int reclaimed = repo.reclaimStale(tenant, 0);
+        assertThat(reclaimed).as("reclaimStale must reclaim the stale row").isGreaterThanOrEqualTo(1);
+
+        OffsetDateTime after = readNextRetryAt(tenant, "reclaim.pdf");
+        assertThat(after).as("reclaimStale must leave next_retry_at populated").isNotNull();
+        assertThat(after.toInstant())
+            .as("reclaimStale must leave next_retry_at UNCHANGED (no cap-bypass, no crash-punish)")
+            .isEqualTo(backoff.toInstant());
+
+        // Because next_retry_at is in the past, the reclaimed row is claimable now.
+        assertThat(repo.claimNext(tenant))
+            .as("a reclaimed row whose next_retry_at is in the past must be immediately claimable")
+            .isPresent();
+    }
+
+    @Test @Order(44)
+    void reclaimStale_leavesNullNextRetryAtNull_andRowClaimable() throws Exception {
+        // Complement to Order(43): the common pre-P1 state is next_retry_at NULL.
+        // reclaimStale must not invent a value (which would back off a crash-victim).
+        String tenant = "nra-reclaim-null-tenant-" + System.nanoTime();
+        var body = new java.util.LinkedHashMap<String, Object>();
+        body.put("collection",  "nra-coll");
+        body.put("source_path", "reclaim-null.pdf");
+        repo.enqueue(tenant, body);                 // next_retry_at left NULL (default)
+
+        assertThat(repo.claimNext(tenant))
+            .as("setup: NULL-next_retry_at row claims into in_progress").isPresent();
+
+        int reclaimed = repo.reclaimStale(tenant, 0);
+        assertThat(reclaimed).as("reclaimStale must reclaim the stale row").isGreaterThanOrEqualTo(1);
+
+        assertThat(readNextRetryAt(tenant, "reclaim-null.pdf"))
+            .as("reclaimStale must leave a NULL next_retry_at NULL (no spurious backoff stamp)")
+            .isNull();
+        assertThat(repo.claimNext(tenant))
+            .as("a reclaimed NULL-next_retry_at row is immediately claimable").isPresent();
+    }
+
+    /** Set next_retry_at on a specific row via a superuser connection (bypasses RLS). */
+    private void setNextRetryAt(String tenant, String sourcePath, OffsetDateTime ts)
+            throws SQLException {
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            try (var ps = su.prepareStatement(
+                    "UPDATE nexus.aspect_extraction_queue SET next_retry_at = ? "
+                    + "WHERE tenant_id = ? AND source_path = ?")) {
+                ps.setObject(1, ts);
+                ps.setString(2, tenant);
+                ps.setString(3, sourcePath);
+                int n = ps.executeUpdate();
+                assertThat(n).as("setNextRetryAt must update exactly one row").isEqualTo(1);
+            }
+        }
+    }
+
+    /** Read next_retry_at for a specific row via a superuser connection (bypasses RLS). */
+    private OffsetDateTime readNextRetryAt(String tenant, String sourcePath) throws SQLException {
+        try (Connection su = pg.createConnection("")) {
+            try (var ps = su.prepareStatement(
+                    "SELECT next_retry_at FROM nexus.aspect_extraction_queue "
+                    + "WHERE tenant_id = ? AND source_path = ?")) {
+                ps.setString(1, tenant);
+                ps.setString(2, sourcePath);
+                ResultSet rs = ps.executeQuery();
+                assertThat(rs.next()).as("row must exist for readNextRetryAt").isTrue();
+                return rs.getObject("next_retry_at", OffsetDateTime.class);
+            }
+        }
+    }
+
     // ── CONCURRENCY: claim_next distinctness ────────────────────────────────────
 
     @Test @Order(45)

--- a/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
@@ -798,8 +798,12 @@ class AspectRepositoryTest {
         repo.enqueue(tenant, body);
 
         // Stamp a known PAST next_retry_at so the row is claimable, then claim it
-        // (-> in_progress). claimNext must not touch next_retry_at.
-        OffsetDateTime backoff = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(10);
+        // (-> in_progress). claimNext must not touch next_retry_at. Truncate to
+        // microseconds: PG TIMESTAMPTZ has microsecond precision, so a nanosecond
+        // Java value would round on store and break the exact round-trip equality
+        // below (passes or fails depending on the random sub-microsecond digits).
+        OffsetDateTime backoff = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(10)
+            .truncatedTo(java.time.temporal.ChronoUnit.MICROS);
         setNextRetryAt(tenant, "reclaim.pdf", backoff);
         assertThat(repo.claimNext(tenant))
             .as("setup: a past-next_retry_at row must claim into in_progress")

--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -53,6 +53,7 @@ worker spawn).
 from __future__ import annotations
 
 import os
+import random
 import threading
 import time
 from pathlib import Path
@@ -70,6 +71,62 @@ from nexus.aspect_extractor import (
 from nexus.config import nexus_config_dir
 
 _log = structlog.get_logger(__name__)
+
+# ── Bounded backoff-retry ladder (RDR-163 P1, nexus-ztpt6) ──────────────────
+#
+# A transient failure re-queues the row with a backoff interval the WORKER
+# chooses; the service stamps the absolute next_retry_at = now()+interval
+# server-side. retry_count is monotonic and is the cap's source of truth, so
+# termination is guaranteed even under the ±1 race of concurrent reclaim.
+_RETRY_MAX_ATTEMPTS: int = 5          # terminal mark_failed once retry_count >= cap
+_RETRY_BASE_SECONDS: float = 30.0     # interval = base * 2**retry_count, jittered
+_RETRY_JITTER_FRACTION: float = 0.2   # ±20% — spreads re-claims when a wide outage clears
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """True if *exc* is a transient failure class worth a backoff retry.
+
+    Reuses BOTH ``retry.py`` transient predicates: the ChromaDB class
+    (sqlite3 'database is locked', transport errors, HTTP 429/502/503/504) AND
+    the Voyage class (API overload/timeout). Everything else — ValueError, type
+    errors, malformed records, programming bugs — is non-retryable and
+    terminal-fails immediately (no wasted retries). A classifier dependency that
+    itself raises (e.g. the lazy ``voyageai`` import) must not break routing, so
+    each predicate is guarded and defaults to "not retryable".
+    """
+    from nexus.retry import (  # noqa: PLC0415 — deferred to avoid import cost at module load
+        _is_retryable_chroma_error,
+        _is_retryable_voyage_error,
+    )
+    for predicate in (_is_retryable_chroma_error, _is_retryable_voyage_error):
+        try:
+            if predicate(exc):
+                return True
+        except Exception as cls_exc:  # noqa: BLE001 — a classifier dependency must not break routing
+            # Observable signal: e.g. voyageai not installed makes the voyage
+            # predicate raise, which would silently route all API-overload
+            # failures to terminal. Log so an operator can see why.
+            _log.debug(
+                "aspect_worker_retry_classifier_unavailable",
+                predicate=getattr(predicate, "__name__", repr(predicate)),
+                error=str(cls_exc),
+            )
+            continue
+    return False
+
+
+def _backoff_interval_seconds(retry_count: int, *, rng=random.random) -> int:
+    """Worker-chosen backoff for the next retry, in integer seconds.
+
+    ``base * 2**retry_count`` with ±``_RETRY_JITTER_FRACTION`` jitter. The
+    service stamps the absolute ``next_retry_at = now()+interval``; only the
+    interval is chosen here. ``rng`` is injectable so the jitter is deterministic
+    under test without patching the global ``random`` module.
+    """
+    raw = _RETRY_BASE_SECONDS * (2 ** max(0, retry_count))
+    jitter = 1.0 + (rng() - 0.5) * 2.0 * _RETRY_JITTER_FRACTION
+    return max(0, int(raw * jitter))
+
 
 # ── Drain protocol exceptions ───────────────────────────────────────────────
 
@@ -446,6 +503,52 @@ class AspectExtractionWorker:
                 exc_info=True,
             )
 
+    def _mark_retry_or_fail_routed(self, row, exc: BaseException) -> None:
+        """Route a failed row to a backed-off retry, or terminal-fail it
+        (RDR-163 P1, nexus-ztpt6).
+
+        Decision:
+        * non-retryable exception (programming bug / malformed record) →
+          terminal ``mark_failed``;
+        * retry budget exhausted (``retry_count >= _RETRY_MAX_ATTEMPTS``) →
+          terminal ``mark_failed``;
+        * otherwise → ``mark_retry`` with a worker-chosen backoff interval; the
+          service stamps ``next_retry_at = now()+interval`` so the claim gate
+          holds the row back until the backoff elapses.
+
+        Routed through ``t2_index_write`` (nexus-zir76) so the worker never opens
+        ``memory.db`` directly. A routing failure is logged and falls to
+        ``reclaim_stale`` rather than killing the worker thread — the same
+        best-effort posture as ``_mark_failed_routed``.
+        """
+        retry_count = getattr(row, "retry_count", 0) or 0
+        if not _is_retryable(exc) or retry_count >= _RETRY_MAX_ATTEMPTS:
+            self._mark_failed_routed(row, str(exc))
+            return
+
+        interval = _backoff_interval_seconds(retry_count)
+        from nexus.mcp_infra import t2_index_write  # noqa: PLC0415 — deferred to avoid circular import (mcp_infra)
+        try:
+            t2_index_write(
+                lambda db: db.aspect_queue.mark_retry(
+                    row.collection, row.source_path, interval_seconds=interval,
+                )
+            )
+            _log.info(
+                "aspect_worker_retry_scheduled",
+                collection=row.collection,
+                source_path=row.source_path,
+                retry_count=retry_count + 1,
+                interval_seconds=interval,
+            )
+        except Exception:  # noqa: BLE001 — retry persist best-effort; reclaim_stale backstops; logged
+            _log.warning(
+                "aspect_worker_mark_retry_persist_failed",
+                collection=row.collection,
+                source_path=row.source_path,
+                exc_info=True,
+            )
+
     def _process_row(self, row) -> None:
         """Run extraction on one queue row and dispatch on the result.
 
@@ -495,7 +598,7 @@ class AspectExtractionWorker:
                 source_path=row.source_path,
                 exc_info=True,
             )
-            self._mark_failed_routed(row, str(exc))
+            self._mark_retry_or_fail_routed(row, exc)
             return
 
         try:
@@ -542,7 +645,7 @@ class AspectExtractionWorker:
                 source_path=row.source_path,
                 exc_info=True,
             )
-            self._mark_failed_routed(row, str(exc))
+            self._mark_retry_or_fail_routed(row, exc)
 
 
 # ── Module-level singleton ──────────────────────────────────────────────────

--- a/src/nexus/db/t2/aspect_extraction_queue.py
+++ b/src/nexus/db/t2/aspect_extraction_queue.py
@@ -458,12 +458,20 @@ class AspectExtractionQueue:
                 )
                 self.conn.commit()
 
-    def mark_retry(self, collection: str, source_path: str) -> None:
+    def mark_retry(self, collection: str, source_path: str,
+                   interval_seconds: int = 0) -> None:
         """Reset the row to ``pending`` and increment ``retry_count``.
 
         Used by the worker when a single attempt failed transiently
         and the retry budget has not been exhausted. The next
         ``claim_next`` call will pick it up.
+
+        ``interval_seconds`` is accepted for signature parity with the
+        strategic PG/Java backend (RDR-163 P1, nexus-ztpt6) but IGNORED
+        here: this SQLite path has no ``next_retry_at`` column and is
+        retired (RDR-158) / deleted (RDR-152 P4.2). It will not gain the
+        backoff ladder — the parameter only keeps the store-contract
+        tripwire green until the class is removed.
         """
         with self.rename_lock:
             with self._lock:

--- a/src/nexus/db/t2/http_aspect_queue.py
+++ b/src/nexus/db/t2/http_aspect_queue.py
@@ -211,11 +211,18 @@ class HttpAspectQueue(RawHandleGuardMixin):
             "error": error[:2000],
         })
 
-    def mark_retry(self, collection: str, source_path: str) -> None:
-        """Reset the row to 'pending' and increment retry_count."""
+    def mark_retry(self, collection: str, source_path: str,
+                   interval_seconds: int = 0) -> None:
+        """Reset the row to 'pending', increment retry_count, and back it off.
+
+        ``interval_seconds`` is the worker-chosen backoff; the service stamps
+        ``next_retry_at = now() + interval_seconds`` server-side (RDR-163 P1,
+        nexus-ztpt6). Default 0 = ready immediately.
+        """
         self._post("/mark_retry", {
             "collection": collection,
             "source_path": source_path,
+            "interval_seconds": interval_seconds,
         })
 
     def reclaim_stale(self, timeout_seconds: int = 300) -> int:

--- a/tests/db/t2_store_contract.py
+++ b/tests/db/t2_store_contract.py
@@ -123,7 +123,7 @@ T2_STORE_CONTRACT: dict[str, dict[str, list[str]]] = {
         'list_pending': ['limit'],
         'mark_done': ['collection', 'source_path', 'doc_id'],
         'mark_failed': ['collection', 'source_path', 'error'],
-        'mark_retry': ['collection', 'source_path'],
+        'mark_retry': ['collection', 'source_path', 'interval_seconds'],
         'pending_count': [],
         'reclaim_stale': ['timeout_seconds'],
         'rename_collection': ['old', 'new'],

--- a/tests/db/test_http_aspects_stores.py
+++ b/tests/db/test_http_aspects_stores.py
@@ -435,6 +435,25 @@ class TestHttpAspectQueue:
         store = self._queue({"/v1/aspects/queue/mark_retry": {"ok": True}})
         store.mark_retry("c", "doc.pdf")
 
+    def test_mark_retry_posts_interval_seconds(self):
+        # RDR-163 P1 (nexus-ztpt6): the worker-chosen backoff must reach the
+        # service so it can stamp next_retry_at = now()+interval server-side.
+        captured = {}
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json={"ok": True})
+
+        store = HttpAspectQueue(base_url="http://test", _token="tok")
+        store._client = httpx.Client(
+            base_url="http://test", headers=store._headers,
+            transport=httpx.MockTransport(handle_request),
+        )
+        store.mark_retry("c", "doc.pdf", interval_seconds=120)
+        assert captured["body"]["interval_seconds"] == 120
+        assert captured["body"]["collection"] == "c"
+        assert captured["body"]["source_path"] == "doc.pdf"
+
     def test_reclaim_stale_returns_count(self):
         store = self._queue({"/v1/aspects/queue/reclaim_stale": {"reclaimed": 3}})
         assert store.reclaim_stale(300) == 3

--- a/tests/test_aspect_worker.py
+++ b/tests/test_aspect_worker.py
@@ -733,3 +733,164 @@ class TestBatchPath:
             "/papers/p0.pdf", "/papers/p1.pdf", "/papers/p2.pdf",
             "/rdrs/r0.md", "/rdrs/r1.md",
         ])
+
+
+# ── Bounded backoff-retry ladder (RDR-163 P1, nexus-ztpt6) ──────────────────
+
+
+class TestRetryClassification:
+    """`_is_retryable` reuses BOTH retry.py transient predicates."""
+
+    def test_db_locked_is_retryable(self) -> None:
+        import sqlite3
+
+        from nexus.aspect_worker import _is_retryable
+        assert _is_retryable(sqlite3.OperationalError("database is locked"))
+
+    def test_transport_error_is_retryable(self) -> None:
+        import httpx
+
+        from nexus.aspect_worker import _is_retryable
+        assert _is_retryable(httpx.ConnectError("connection refused"))
+
+    def test_http_503_message_is_retryable(self) -> None:
+        from nexus.aspect_worker import _is_retryable
+        assert _is_retryable(Exception("upstream returned 503 service unavailable"))
+
+    def test_value_error_is_not_retryable(self) -> None:
+        from nexus.aspect_worker import _is_retryable
+        assert not _is_retryable(ValueError("malformed record"))
+
+    def test_type_error_is_not_retryable(self) -> None:
+        from nexus.aspect_worker import _is_retryable
+        assert not _is_retryable(TypeError("programming bug"))
+
+    def test_plain_exception_is_not_retryable(self) -> None:
+        from nexus.aspect_worker import _is_retryable
+        assert not _is_retryable(Exception("nothing transient here"))
+
+
+class TestBackoffInterval:
+    """`_backoff_interval_seconds` doubles per attempt with deterministic jitter."""
+
+    def test_no_jitter_doubles_per_attempt(self) -> None:
+        from nexus.aspect_worker import _RETRY_BASE_SECONDS, _backoff_interval_seconds
+
+        mid = lambda: 0.5  # jitter factor exactly 1.0  # noqa: E731
+        assert _backoff_interval_seconds(0, rng=mid) == int(_RETRY_BASE_SECONDS)
+        assert _backoff_interval_seconds(1, rng=mid) == int(_RETRY_BASE_SECONDS * 2)
+        assert _backoff_interval_seconds(3, rng=mid) == int(_RETRY_BASE_SECONDS * 8)
+
+    def test_jitter_bounds_are_plus_minus_fraction(self) -> None:
+        from nexus.aspect_worker import (
+            _RETRY_BASE_SECONDS,
+            _RETRY_JITTER_FRACTION,
+            _backoff_interval_seconds,
+        )
+
+        base = _RETRY_BASE_SECONDS * 4  # retry_count=2
+        lo = _backoff_interval_seconds(2, rng=lambda: 0.0)  # factor 1-frac
+        hi = _backoff_interval_seconds(2, rng=lambda: 1.0)  # factor 1+frac
+        assert lo == int(base * (1.0 - _RETRY_JITTER_FRACTION))
+        assert hi == int(base * (1.0 + _RETRY_JITTER_FRACTION))
+
+
+class _FakeQueue:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def mark_failed(self, collection, source_path, error) -> None:  # noqa: ANN001
+        self.calls.append(("failed", collection, source_path, error))
+
+    def mark_retry(self, collection, source_path, interval_seconds=0) -> None:  # noqa: ANN001
+        self.calls.append(("retry", collection, source_path, interval_seconds))
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self.aspect_queue = _FakeQueue()
+
+
+class TestRetryLadderRouting:
+    """`_mark_retry_or_fail_routed` decision: retry vs terminal."""
+
+    def _worker_and_db(self, monkeypatch):  # noqa: ANN001
+        import nexus.mcp_infra as infra
+        from nexus.aspect_worker import AspectExtractionWorker
+
+        fake_db = _FakeDb()
+        monkeypatch.setattr(infra, "t2_index_write", lambda fn: fn(fake_db))
+        return AspectExtractionWorker(poll_interval=10.0), fake_db
+
+    def _row(self, retry_count: int):
+        import types
+        return types.SimpleNamespace(
+            collection="knowledge__delos", source_path="/p.pdf", retry_count=retry_count,
+        )
+
+    def test_retryable_under_cap_marks_retry_with_backoff(self, monkeypatch) -> None:  # noqa: ANN001
+        import sqlite3
+        worker, db = self._worker_and_db(monkeypatch)
+        worker._mark_retry_or_fail_routed(self._row(0), sqlite3.OperationalError("database is locked"))
+        assert len(db.aspect_queue.calls) == 1
+        kind, _coll, _sp, interval = db.aspect_queue.calls[0]
+        assert kind == "retry"
+        assert interval > 0  # backed off (retry_count=0 -> base*1, jittered)
+
+    def test_non_retryable_marks_failed_immediately(self, monkeypatch) -> None:  # noqa: ANN001
+        worker, db = self._worker_and_db(monkeypatch)
+        worker._mark_retry_or_fail_routed(self._row(0), ValueError("malformed"))
+        assert len(db.aspect_queue.calls) == 1
+        assert db.aspect_queue.calls[0][0] == "failed"
+
+    def test_retryable_at_cap_marks_failed(self, monkeypatch) -> None:  # noqa: ANN001
+        import sqlite3
+        from nexus.aspect_worker import _RETRY_MAX_ATTEMPTS
+        worker, db = self._worker_and_db(monkeypatch)
+        worker._mark_retry_or_fail_routed(
+            self._row(_RETRY_MAX_ATTEMPTS), sqlite3.OperationalError("database is locked"),
+        )
+        assert db.aspect_queue.calls[0][0] == "failed"
+
+
+class TestRetryLadderIntegration:
+    """End-to-end: a retryable failure cycles the ladder to terminal at the cap."""
+
+    def test_retryable_failure_climbs_to_terminal_at_cap(self, _isolate_t2: Path) -> None:
+        import sqlite3
+
+        from nexus.aspect_worker import _RETRY_MAX_ATTEMPTS, AspectExtractionWorker
+
+        with T2Database(_isolate_t2) as db:
+            db.aspect_queue.enqueue("knowledge__delos", "/retry.pdf")
+
+        def fake_extract(content, source_path, collection, **_kw):  # noqa: ANN001, ANN202
+            raise sqlite3.OperationalError("database is locked")
+
+        # SQLite stub ignores the backoff interval (no next_retry_at column), so
+        # the row is immediately re-claimable and the worker burns the whole
+        # retry budget quickly before going terminal — proving the ladder ran
+        # (old behaviour was a single-shot terminal fail at retry_count==1).
+        with patch("nexus.aspect_worker._extract_aspects", fake_extract):
+            worker = AspectExtractionWorker(poll_interval=0.02)
+            worker.start()
+            try:
+                _wait_until(
+                    lambda: _row_status(_isolate_t2, "/retry.pdf") == "failed",
+                    timeout=10.0,
+                )
+            finally:
+                worker.stop(timeout=5.0)
+
+        with T2Database(_isolate_t2) as db:
+            row = db.aspect_queue.conn.execute(
+                "SELECT status, retry_count FROM aspect_extraction_queue WHERE source_path = ?",
+                ("/retry.pdf",),
+            ).fetchone()
+        assert row[0] == "failed"
+        # Exact boundary (single worker => deterministic): the row is retried at
+        # claim-time counts 0..cap-1 (cap mark_retry calls, each +1), then the
+        # claim-time count == cap trips terminal mark_failed (+1 more). Final
+        # retry_count is therefore cap+1 — proving the full ladder ran, not a
+        # single-shot fail (which would terminate at retry_count == 1).
+        assert row[1] == _RETRY_MAX_ATTEMPTS + 1

--- a/tests/test_rdr137_followup_batch_sigs2.py
+++ b/tests/test_rdr137_followup_batch_sigs2.py
@@ -38,9 +38,12 @@ class TestSig7BackfillCollectionsPassesOwnerIdForConformantNames:
         # Source-level invariant: the bare cat.register_collection(name)
         # call must be replaced with one that forwards content_type +
         # owner_id when parse_conformant_collection_name succeeds.
+        # nexus-whh61.4 carved the catalog-cli families out of the
+        # commands/catalog.py monolith; backfill_collections (and the
+        # parse helper) now live in commands/catalog_cmds/collections.py.
         src = (
             Path(__file__).resolve().parent.parent
-            / "src" / "nexus" / "commands" / "catalog.py"
+            / "src" / "nexus" / "commands" / "catalog_cmds" / "collections.py"
         )
         text = src.read_text()
         # The bare call without keyword args was the SIG-7 bug.
@@ -49,7 +52,7 @@ class TestSig7BackfillCollectionsPassesOwnerIdForConformantNames:
         assert "parse_conformant_collection_name" in text, (
             "SIG-7: backfill_collections must parse conformant names "
             "and forward owner_id; the parse helper must appear in "
-            "commands/catalog.py."
+            "commands/catalog_cmds/collections.py."
         )
 
 


### PR DESCRIPTION
Implements the vealn sub-epic of RDR-163 (aspect-extraction-queue bounded backoff-retry ladder): wires the dormant `mark_retry` primitive into a transient-failure-surviving drain. Two beads, stacked on one branch.

Strategic target is the **PG/Java service** queue (the SQLite path is retired per RDR-158 / deleted per RDR-152 P4.2 — no `migrations.py` change). The backend-agnostic ladder lives in the Python worker.

## P0 — `nexus-795gv`: schema + claim gate
- New sibling Liquibase changeset `aspects-002-next-retry-at.xml` adds `nexus.aspect_extraction_queue.next_retry_at TIMESTAMPTZ` (nullable; NULL = ready now). Baseline untouched; column inherits `nexus_svc` grants via the runAlways grants changeset; RLS unchanged.
- `AspectRepository.claimNext` FOR UPDATE SKIP LOCKED query gains `AND (next_retry_at IS NULL OR next_retry_at <= now())` — server (DB) clock, correct for both local (co-located) and cloud (worker-host clock skew) deployments.
- `reclaimStale`/`markFailed` unchanged — P0 invariant: `reclaimStale` must NOT touch `next_retry_at` (clearing bypasses the cap; bumping punishes a crash).

## P1 — `nexus-ztpt6`: mark_retry ladder + worker classifier
- Java `markRetry` gains `intervalSeconds`; stamps `next_retry_at = now() + make_interval(secs)` server-side. `AspectHandler` parses `interval_seconds`.
- Python `HttpAspectQueue.mark_retry` posts `interval_seconds`; SQLite stub accepts-and-ignores it (parity only); store-contract snapshot updated.
- Worker (`aspect_worker.py`): `_is_retryable` (reuses both retry.py predicates: chroma db-locked/transport/HTTP-5xx/429 + voyage overload), `_backoff_interval_seconds` (base·2^n ±20% jitter, injectable rng), `_mark_retry_or_fail_routed` (non-retryable OR `retry_count >= cap(5)` → terminal `mark_failed`; else `mark_retry` with backoff). Both worker exception sites route through it via `t2_index_write` (nexus-zir76); a routing failure falls to `reclaim_stale`.

## Review
Both stacked reviewers (code-review-expert + substantive-critic, sonnet) on each commit. Fixes applied:
- **H-1** (P1): `enqueue` ON CONFLICT now clears `next_retry_at` so a re-enqueue of a backed-off row is immediately claimable (was a silent indefinite hold).
- P0 reclaimStale NULL-case invariant test added; P1 integration assertion tightened to exact `cap+1`; classifier-unavailable now logs.
- The end-to-end Python timing assertion (`next_retry_at - claimed_at ≈ interval` against a live service) is explicitly **deferred to the P-GATE `nexus-bsm0p`** (dual-deployment validation) — documented on that bead, not silent. Java `markRetry_stampsNextRetryAtServerSide` already covers server-side stamping.

## Tests
- Full Java suite green: **904 tests, 0 failures** (schema + signature change demands the full run, per project rule).
- `pytest -k aspect` green (587); store-contract parity tripwire green (29).
- 2 pre-existing `tests/db/`→`tests/daemon/` token-test pollution failures reproduce on clean develop (unrelated to this change); filed separately.

Beads: `nexus-795gv`, `nexus-ztpt6` (parent `nexus-vealn`; remaining child = P-GATE `nexus-bsm0p`). Closed via `bd` after merge.