### PR TITLE
feat(aspects): nx aspects requeue-failed bulk-recovery CLI (nexus-2c51v)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -509,6 +509,31 @@ The promotion is logged to `aspect_promotion_log` (registry-managed) for audit. 
 
 ---
 
+## nx aspects
+
+Aspect-extraction queue management (the async queue feeding the aspect-extraction worker). The group also provides `drain` (drain before a PK migration), `gc`, and `gc-fixtures`.
+
+### nx aspects requeue-failed
+
+Bulk re-enqueue terminal-`failed` aspect-queue rows. A row reaches `failed` after exhausting the backoff-retry ladder (RDR-163) or on a non-retryable error. Once the root cause is fixed (e.g. restored API quota, repaired source identity), this verb re-enqueues every failed row at its `(collection, source_path)` key — resetting it to `pending` with `retry_count=0` and clearing any stale backoff — so the worker picks it up again. The write is daemon-routed; the failed-backlog visibility counterpart is `nx doctor --check-aspect-queue`.
+
+| Flag | Description |
+|------|-------------|
+| `--collection NAME` | Only re-enqueue failed rows in this collection. Default: all collections |
+| `--limit N` | Re-enqueue at most N rows (oldest-`enqueued_at` first). Paces recovery of a large backlog so a burst of newly-pending rows doesn't immediately re-hammer a just-restored API quota |
+| `--dry-run` | Report the rows that would be re-enqueued without writing anything |
+
+Rows are processed oldest-`enqueued_at`-first (enqueue order, not most-recently-failed); re-enqueue resets `retry_count` to 0. This is a single-operator recovery verb — safe to re-run (it only touches the terminal `failed` state), but do not run two instances concurrently.
+
+```bash
+nx aspects requeue-failed                        # re-enqueue all failed rows
+nx aspects requeue-failed --collection knowledge__x
+nx aspects requeue-failed --limit 100            # pace a large backlog
+nx aspects requeue-failed --dry-run              # report only, no writes
+```
+
+---
+
 ## nx catalog
 
 Document catalog — track indexed documents and the relationships between them.

--- a/service/src/main/java/dev/nexus/service/db/AspectRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/AspectRepository.java
@@ -958,6 +958,47 @@ public final class AspectRepository {
     }
 
     /**
+     * List terminal-{@code failed} rows, optionally scoped to one collection
+     * (mirrors AspectExtractionQueue.list_failed). Drives the
+     * {@code nx aspects requeue-failed} bulk-recovery CLI (nexus-2c51v).
+     * doc_id is included so a re-enqueue preserves the catalog identity.
+     */
+    public List<Map<String, Object>> listFailed(String tenant, String collection) {
+        return tenantScope.withTenant(tenant, ctx -> {
+            var cond = ASPECT_EXTRACTION_QUEUE.STATUS.eq("failed");
+            if (collection != null && !collection.isBlank()) {
+                cond = cond.and(ASPECT_EXTRACTION_QUEUE.COLLECTION.eq(collection));
+            }
+            var rows = ctx.select(
+                    ASPECT_EXTRACTION_QUEUE.COLLECTION,
+                    ASPECT_EXTRACTION_QUEUE.SOURCE_PATH,
+                    ASPECT_EXTRACTION_QUEUE.CONTENT_HASH,
+                    ASPECT_EXTRACTION_QUEUE.CONTENT,
+                    ASPECT_EXTRACTION_QUEUE.RETRY_COUNT,
+                    ASPECT_EXTRACTION_QUEUE.DOC_ID)
+                .from(ASPECT_EXTRACTION_QUEUE)
+                .where(cond)
+                .orderBy(ASPECT_EXTRACTION_QUEUE.ENQUEUED_AT.asc(), ASPECT_EXTRACTION_QUEUE.SOURCE_PATH.asc())
+                .fetch();
+            List<Map<String, Object>> out = new ArrayList<>();
+            for (var r : rows) {
+                Map<String, Object> m = new LinkedHashMap<>();
+                m.put("collection",   r.get(ASPECT_EXTRACTION_QUEUE.COLLECTION));
+                m.put("source_path",  r.get(ASPECT_EXTRACTION_QUEUE.SOURCE_PATH));
+                String ch = r.get(ASPECT_EXTRACTION_QUEUE.CONTENT_HASH);
+                m.put("content_hash", ch == null ? "" : ch);
+                String co = r.get(ASPECT_EXTRACTION_QUEUE.CONTENT);
+                m.put("content",      co == null ? "" : co);
+                m.put("retry_count",  r.get(ASPECT_EXTRACTION_QUEUE.RETRY_COUNT));
+                String di = r.get(ASPECT_EXTRACTION_QUEUE.DOC_ID);
+                m.put("doc_id",       di == null ? "" : di);
+                out.add(m);
+            }
+            return out;
+        });
+    }
+
+    /**
      * Rename collection in queue (mirrors AspectExtractionQueue.rename_collection).
      */
     public int renameQueueCollection(String tenant, String oldColl, String newColl) {

--- a/service/src/main/java/dev/nexus/service/http/AspectHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/AspectHandler.java
@@ -55,6 +55,7 @@ import java.util.Optional;
  *   GET   /v1/aspects/queue/pending_count         count pending rows
  *   GET   /v1/aspects/queue/is_drained            check drained
  *   GET   /v1/aspects/queue/list_pending          list pending (limit= optional)
+ *   GET   /v1/aspects/queue/list_failed           list terminal-failed (collection= optional)
  *   POST  /v1/aspects/queue/rename_collection     rename collection in queue
  *   POST  /v1/aspects/queue/import                ETL import of queue row
  *
@@ -129,6 +130,7 @@ public final class AspectHandler implements HttpHandler {
                 case "/queue/pending_count"             -> handleQueuePendingCount(exchange, tenant, method);
                 case "/queue/is_drained"                -> handleQueueIsDrained(exchange, tenant, method);
                 case "/queue/list_pending"              -> handleQueueListPending(exchange, tenant, method);
+                case "/queue/list_failed"               -> handleQueueListFailed(exchange, tenant, method);
                 case "/queue/rename_collection"         -> handleQueueRenameCollection(exchange, tenant, method);
                 case "/queue/import"                    -> handleQueueImport(exchange, tenant, method);
                 // ── aspect_promotion_log ──────────────────────────────────────
@@ -511,6 +513,12 @@ public final class AspectHandler implements HttpHandler {
         String limitStr = parseQuery(ex.getRequestURI()).get("limit");
         int limit = limitStr != null ? Integer.parseInt(limitStr) : 0;
         HttpUtil.send(ex, 200, MAPPER.writeValueAsString(repo.listPending(tenant, limit)));
+    }
+
+    private void handleQueueListFailed(HttpExchange ex, String tenant, String method) throws IOException {
+        if (!"GET".equals(method)) { HttpUtil.send(ex, 405, "{\"error\":\"GET required\"}"); return; }
+        String collection = parseQuery(ex.getRequestURI()).get("collection");
+        HttpUtil.send(ex, 200, MAPPER.writeValueAsString(repo.listFailed(tenant, collection)));
     }
 
     private void handleQueueRenameCollection(HttpExchange ex, String tenant, String method) throws IOException {

--- a/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
@@ -911,6 +911,41 @@ class AspectRepositoryTest {
             .as("re-enqueued row must be immediately claimable").isPresent();
     }
 
+    @Test @Order(48)
+    void listFailed_returnsOnlyFailedRows_collectionScoped() {
+        // Isolated tenant so listFailed sees only this test's rows. doc_id omitted
+        // (NULL) to avoid the catalog_documents FK; doc_id round-trip is covered by
+        // the SQLite/HTTP list_failed tests and is structurally identical to the
+        // already-tested listPending map.
+        String tenant = "list-failed-tenant-" + System.nanoTime();
+        for (String[] cs : new String[][]{
+                {"lf-a", "a1.pdf"}, {"lf-a", "a2.pdf"}, {"lf-b", "b1.pdf"}}) {
+            var body = new java.util.LinkedHashMap<String, Object>();
+            body.put("collection", cs[0]);
+            body.put("source_path", cs[1]);
+            repo.enqueue(tenant, body);
+            repo.markFailed(tenant, cs[0], cs[1], "boom");
+        }
+        var pending = new java.util.LinkedHashMap<String, Object>();
+        pending.put("collection", "lf-a");
+        pending.put("source_path", "ok.pdf");
+        repo.enqueue(tenant, pending);   // stays pending
+
+        // All failed (pending excluded), FIFO by enqueued_at.
+        var all = repo.listFailed(tenant, null);
+        assertThat(all.stream().map(r -> r.get("source_path")).toList())
+            .as("listFailed returns only failed rows, FIFO")
+            .containsExactly("a1.pdf", "a2.pdf", "b1.pdf");
+
+        // Collection-scoped.
+        var scoped = repo.listFailed(tenant, "lf-a");
+        assertThat(scoped.stream().map(r -> r.get("source_path")).toList())
+            .as("listFailed honors the collection filter")
+            .containsExactly("a1.pdf", "a2.pdf");
+        assertThat(scoped).allSatisfy(r ->
+            assertThat(r.get("collection")).isEqualTo("lf-a"));
+    }
+
     /** Set next_retry_at on a specific row via a superuser connection (bypasses RLS). */
     private void setNextRetryAt(String tenant, String sourcePath, OffsetDateTime ts)
             throws SQLException {

--- a/src/nexus/commands/aspects.py
+++ b/src/nexus/commands/aspects.py
@@ -518,3 +518,106 @@ def aspects_gc_pre_rdr096(apply: bool) -> None:
             )
     finally:
         conn.close()
+
+
+@aspects_group.command(name="requeue-failed")
+@click.option(
+    "--collection",
+    default=None,
+    help="Only re-enqueue failed rows in this collection (default: all).",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=None,
+    help="Re-enqueue at most this many rows (oldest-enqueued first). Use to "
+    "pace recovery of a large backlog and avoid a thundering herd of workers "
+    "hammering a just-restored API quota.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Report the rows that would be re-enqueued without writing.",
+)
+def aspects_requeue_failed(
+    collection: str | None, limit: int | None, dry_run: bool,
+) -> None:
+    """Bulk re-enqueue terminal-``failed`` aspect-queue rows (nexus-2c51v).
+
+    A row reaches ``failed`` after exhausting the backoff-retry ladder
+    (RDR-163) or on a non-retryable error. Once the operator fixes the
+    root cause (restored API quota, repaired source identity), this verb
+    re-enqueues each failed row at its ``(collection, source_path)`` key,
+    resetting it to ``pending`` with ``retry_count=0`` (the exhaustion depth
+    shown in ``--dry-run`` is discarded) so the worker picks it up again.
+    The write is daemon-routed (nexus-zir76); reads use the active backend
+    (SQLite or the PG service).
+
+    \b
+    Rows are processed oldest-``enqueued_at``-first (enqueue order, NOT
+    most-recently-failed). ``--limit`` caps how many are re-enqueued.
+
+    \b
+    Examples:
+      nx aspects requeue-failed                       # all failed rows
+      nx aspects requeue-failed --collection knowledge__x
+      nx aspects requeue-failed --limit 100           # pace a large backlog
+      nx aspects requeue-failed --dry-run             # report only, no writes
+
+    \b
+    Operator note: single-operator recovery verb. It only touches ``failed``
+    rows (a terminal state no worker writes), so it is safe to re-run; but do
+    not run two instances concurrently — the read-snapshot / per-row-write
+    split has no cross-row transaction, so concurrent runs could redundantly
+    re-enqueue the same rows.
+
+    \b
+    Pairs with the RDR-163 ladder: the ladder reduces how often rows reach
+    terminal; this clears the ones that still do. Failed-backlog visibility
+    is ``nx doctor --check-aspect-queue``.
+    """
+    from nexus.commands._helpers import default_db_path  # noqa: PLC0415 — deferred local import — avoids import-time cost / circular deps
+    from nexus.db.t2 import T2Database  # noqa: PLC0415 — deferred local import — avoids import-time cost / circular deps
+    from nexus.mcp_infra import t2_index_write  # noqa: PLC0415 — deferred local import — avoids import-time cost / circular deps
+
+    if limit is not None and limit <= 0:
+        click.echo("--limit must be a positive integer.", err=True)
+        raise SystemExit(1)
+
+    mem_path = default_db_path()
+    if not mem_path.exists():
+        click.echo("aspect_extraction_queue: T2 database not found.")
+        return
+
+    # Read is concurrent-safe (no single-writer concern); the facade routes
+    # to the active backend (SQLite reader or the PG-service HTTP client).
+    with T2Database(mem_path) as db:  # epsilon-allow: read-only failed-row inspection for requeue-failed; routes to active backend, no WAL writer contention
+        failed = db.aspect_queue.list_failed(collection)
+
+    if limit is not None:
+        failed = failed[:limit]
+
+    scope = f" in {collection}" if collection else ""
+    if not failed:
+        click.echo(f"aspect_extraction_queue: no failed rows{scope}.")
+        return
+
+    if dry_run:
+        click.echo(f"Would re-enqueue {len(failed)} failed row(s){scope}:")
+        for row in failed:
+            click.echo(f"  {row.collection}  {row.source_path}  (retry_count={row.retry_count})")
+        click.echo("Re-run without --dry-run to re-enqueue.")
+        return
+
+    for row in failed:
+        # Daemon-routed write (nexus-zir76); INSERT OR REPLACE resets the row
+        # to pending / retry_count=0 / clears any stale next_retry_at backoff.
+        t2_index_write(
+            lambda db, _r=row: db.aspect_queue.enqueue(
+                _r.collection, _r.source_path,
+                content_hash=_r.content_hash, content=_r.content,
+                doc_id=_r.doc_id,
+            )
+        )
+    click.echo(f"Re-enqueued {len(failed)} failed row(s){scope} to pending.")

--- a/src/nexus/db/t2/aspect_extraction_queue.py
+++ b/src/nexus/db/t2/aspect_extraction_queue.py
@@ -609,6 +609,34 @@ class AspectExtractionQueue:
             for c, sp, ch, co, rc in rows
         ]
 
+    def list_failed(self, collection: str | None = None) -> list[QueueRow]:
+        """Return terminal-``failed`` rows, optionally scoped to one collection.
+
+        Drives ``nx aspects requeue-failed`` (nexus-2c51v): the operator
+        inspects/bulk-recovers rows that exhausted the retry ladder or hit a
+        non-retryable error. ``doc_id`` is selected so a re-enqueue preserves
+        the catalog identity. Ordered oldest-first for stable output.
+        """
+        sql = (
+            "SELECT collection, source_path, content_hash, content, retry_count, doc_id "
+            "FROM aspect_extraction_queue "
+            "WHERE status = 'failed'"
+        )
+        params: tuple = ()
+        if collection:
+            sql += " AND collection = ?"
+            params = (collection,)
+        sql += " ORDER BY enqueued_at ASC, source_path ASC"
+        with self._lock:
+            rows = self.conn.execute(sql, params).fetchall()
+        return [
+            QueueRow(
+                collection=c, source_path=sp, content_hash=ch,
+                content=co, retry_count=rc, doc_id=did or "",
+            )
+            for c, sp, ch, co, rc, did in rows
+        ]
+
     def rename_collection(self, *, old: str, new: str) -> int:
         """Re-point every row's denorm ``collection`` cache from ``old`` to ``new``.
 

--- a/src/nexus/db/t2/http_aspect_queue.py
+++ b/src/nexus/db/t2/http_aspect_queue.py
@@ -251,6 +251,14 @@ class HttpAspectQueue(RawHandleGuardMixin):
         rows: list[dict] = self._get("/list_pending", params)
         return [_body_to_queue_row(r) for r in rows]
 
+    def list_failed(self, collection: str | None = None) -> list[QueueRow]:
+        """Return terminal-failed rows, optionally scoped to one collection."""
+        params: dict[str, Any] = {}
+        if collection:
+            params["collection"] = collection
+        rows: list[dict] = self._get("/list_failed", params)
+        return [_body_to_queue_row(r) for r in rows]
+
     def rename_collection(self, *, old: str, new: str) -> int:
         """Re-point every row's collection from *old* to *new*."""
         r = self._post("/rename_collection", {"old": old, "new": new})

--- a/tests/db/t2_store_contract.py
+++ b/tests/db/t2_store_contract.py
@@ -120,6 +120,7 @@ T2_STORE_CONTRACT: dict[str, dict[str, list[str]]] = {
         'claim_next': [],
         'enqueue': ['collection', 'source_path', 'content_hash', 'content', 'doc_id'],
         'is_drained': [],
+        'list_failed': ['collection'],
         'list_pending': ['limit'],
         'mark_done': ['collection', 'source_path', 'doc_id'],
         'mark_failed': ['collection', 'source_path', 'error'],

--- a/tests/db/test_http_aspects_stores.py
+++ b/tests/db/test_http_aspects_stores.py
@@ -480,6 +480,34 @@ class TestHttpAspectQueue:
         assert len(result) == 1
         assert isinstance(result[0], QueueRow)
 
+    def test_list_failed_returns_rows_and_preserves_doc_id(self):
+        rows = [
+            {"collection": "c", "source_path": "f.pdf",
+             "content_hash": "h", "content": "x", "retry_count": 6, "doc_id": "1.2"}
+        ]
+        store = self._queue({"/v1/aspects/queue/list_failed": rows})
+        result = store.list_failed()
+        assert len(result) == 1
+        assert isinstance(result[0], QueueRow)
+        assert result[0].doc_id == "1.2"
+        assert result[0].retry_count == 6
+
+    def test_list_failed_forwards_collection_param(self):
+        # nexus-2c51v: --collection scope must reach the service as a query param.
+        captured = {}
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            captured["params"] = dict(request.url.params)
+            return httpx.Response(200, json=[])
+
+        store = HttpAspectQueue(base_url="http://test", _token="tok")
+        store._client = httpx.Client(
+            base_url="http://test", headers=store._headers,
+            transport=httpx.MockTransport(handle_request),
+        )
+        store.list_failed(collection="knowledge__x")
+        assert captured["params"].get("collection") == "knowledge__x"
+
     def test_list_pending_with_limit(self):
         rows = [
             {"collection": "c", "source_path": f"doc{i}.pdf",

--- a/tests/test_aspect_extraction_queue.py
+++ b/tests/test_aspect_extraction_queue.py
@@ -696,3 +696,47 @@ class TestMigration:
         migrate_aspect_extraction_queue_table(raw)
         migrate_aspect_extraction_queue_table(raw)  # no-op
         raw.close()
+
+
+# ── list_failed (nexus-2c51v: requeue-failed bulk recovery) ──────────────────
+
+
+class TestListFailed:
+    def _failed_store(self, tmp_path: Path):
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        # Two failed rows in coll-a, one in coll-b, one still pending.
+        for coll, sp, did in [
+            ("coll-a", "a1.pdf", "1.1"),
+            ("coll-a", "a2.pdf", ""),
+            ("coll-b", "b1.pdf", "2.2"),
+        ]:
+            store.enqueue(coll, sp, content_hash="h", content="c", doc_id=did)
+            store.mark_failed(coll, sp, "boom")
+        store.enqueue("coll-a", "pending.pdf")  # stays pending
+        return store
+
+    def test_list_failed_returns_only_failed_rows(self, tmp_path: Path) -> None:
+        store = self._failed_store(tmp_path)
+        rows = store.list_failed()
+        paths = sorted(r.source_path for r in rows)
+        assert paths == ["a1.pdf", "a2.pdf", "b1.pdf"]  # pending.pdf excluded
+
+    def test_list_failed_collection_scope(self, tmp_path: Path) -> None:
+        store = self._failed_store(tmp_path)
+        rows = store.list_failed(collection="coll-a")
+        assert sorted(r.source_path for r in rows) == ["a1.pdf", "a2.pdf"]
+        assert all(r.collection == "coll-a" for r in rows)
+
+    def test_list_failed_carries_doc_id_and_content(self, tmp_path: Path) -> None:
+        store = self._failed_store(tmp_path)
+        a1 = next(r for r in store.list_failed() if r.source_path == "a1.pdf")
+        assert a1.doc_id == "1.1"          # preserved for re-enqueue identity
+        assert a1.content_hash == "h"
+        assert a1.content == "c"
+
+    def test_list_failed_empty_when_none_failed(self, tmp_path: Path) -> None:
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        store.enqueue("coll", "only-pending.pdf")
+        assert store.list_failed() == []

--- a/tests/test_aspects_consumer_verbs.py
+++ b/tests/test_aspects_consumer_verbs.py
@@ -409,3 +409,105 @@ class TestGcPreRdr096:
 
     def test_verb_registered(self) -> None:
         assert "gc-pre-rdr096" in aspects_group.commands
+
+
+# ── nx aspects requeue-failed (nexus-2c51v) ──────────────────────────────────
+
+
+class TestRequeueFailed:
+    """`nx aspects requeue-failed` bulk-recovers terminal-failed queue rows."""
+
+    @pytest.fixture
+    def _sqlite_t2(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Pin the aspect queue to SQLite on a tmp DB and route the CLI's read
+        (default_db_path) + daemon write (t2_index_write) at it."""
+        from nexus.db.t2 import T2Database
+
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "sqlite")
+        db_path = tmp_path / "t2.db"
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: db_path,
+        )
+
+        import nexus.mcp_infra as infra
+
+        def _direct_index_write(write_fn):  # noqa: ANN001
+            with T2Database(db_path) as db:
+                return write_fn(db)
+
+        monkeypatch.setattr(infra, "t2_index_write", _direct_index_write)
+        return db_path
+
+    def _seed_failed(self, db_path: Path) -> None:
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+        store = AspectExtractionQueue(db_path)
+        for coll, sp in [("knowledge__a", "x.pdf"), ("knowledge__a", "y.pdf"),
+                         ("knowledge__b", "z.pdf")]:
+            store.enqueue(coll, sp, content="c")
+            store.mark_failed(coll, sp, "boom")
+        store.enqueue("knowledge__a", "ok.pdf")  # stays pending
+        store.close()
+
+    def _status(self, db_path: Path, source_path: str) -> str:
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+        store = AspectExtractionQueue(db_path)
+        try:
+            row = store.conn.execute(
+                "SELECT status FROM aspect_extraction_queue WHERE source_path = ?",
+                (source_path,),
+            ).fetchone()
+            return row[0] if row else "<absent>"
+        finally:
+            store.close()
+
+    def test_dry_run_reports_without_writing(self, _sqlite_t2: Path) -> None:
+        self._seed_failed(_sqlite_t2)
+        res = CliRunner().invoke(aspects_group, ["requeue-failed", "--dry-run"])
+        assert res.exit_code == 0, res.output
+        assert "Would re-enqueue 3 failed row(s)" in res.output
+        # Dry-run writes nothing: the rows stay failed.
+        assert self._status(_sqlite_t2, "x.pdf") == "failed"
+
+    def test_requeue_resets_failed_to_pending(self, _sqlite_t2: Path) -> None:
+        self._seed_failed(_sqlite_t2)
+        res = CliRunner().invoke(aspects_group, ["requeue-failed"])
+        assert res.exit_code == 0, res.output
+        assert "Re-enqueued 3 failed row(s)" in res.output
+        for sp in ("x.pdf", "y.pdf", "z.pdf"):
+            assert self._status(_sqlite_t2, sp) == "pending"
+
+    def test_collection_scope(self, _sqlite_t2: Path) -> None:
+        self._seed_failed(_sqlite_t2)
+        res = CliRunner().invoke(
+            aspects_group, ["requeue-failed", "--collection", "knowledge__a"],
+        )
+        assert res.exit_code == 0, res.output
+        assert "Re-enqueued 2 failed row(s) in knowledge__a" in res.output
+        assert self._status(_sqlite_t2, "x.pdf") == "pending"   # knowledge__a
+        assert self._status(_sqlite_t2, "z.pdf") == "failed"    # knowledge__b untouched
+
+    def test_limit_caps_requeue_count(self, _sqlite_t2: Path) -> None:
+        self._seed_failed(_sqlite_t2)  # 3 failed rows
+        res = CliRunner().invoke(aspects_group, ["requeue-failed", "--limit", "2"])
+        assert res.exit_code == 0, res.output
+        assert "Re-enqueued 2 failed row(s)" in res.output
+        # Exactly 2 of the 3 flip to pending (oldest-enqueued first); 1 stays failed.
+        statuses = [self._status(_sqlite_t2, sp) for sp in ("x.pdf", "y.pdf", "z.pdf")]
+        assert statuses.count("pending") == 2
+        assert statuses.count("failed") == 1
+
+    def test_limit_rejects_nonpositive(self, _sqlite_t2: Path) -> None:
+        self._seed_failed(_sqlite_t2)
+        res = CliRunner().invoke(aspects_group, ["requeue-failed", "--limit", "0"])
+        assert res.exit_code == 1
+        assert "--limit must be a positive integer" in res.output
+        assert self._status(_sqlite_t2, "x.pdf") == "failed"  # nothing written
+
+    def test_no_failed_rows_message(self, _sqlite_t2: Path) -> None:
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+        store = AspectExtractionQueue(_sqlite_t2)
+        store.enqueue("knowledge__a", "only-pending.pdf")
+        store.close()
+        res = CliRunner().invoke(aspects_group, ["requeue-failed"])
+        assert res.exit_code == 0, res.output
+        assert "no failed rows" in res.output

--- a/tests/test_indexer_seam_b_cutover.py
+++ b/tests/test_indexer_seam_b_cutover.py
@@ -450,7 +450,9 @@ def test_lint_baseline_unchanged_after_voyageai_extension():
     )
     # RDR-152 nexus-fjwxh: 31 -> 33 (CLI t2_handle + MCP t2_index_write service-
     # mode branches; both route to the HTTP service, not a raw SQLite writer).
-    assert result.t2database_constructions == 33, (
+    # nexus-2c51v: 33 -> 34 (`nx aspects requeue-failed` epsilon-allow'd
+    # read-only T2Database open, mirrors `aspects gc`).
+    assert result.t2database_constructions == 34, (
         f"t2database_constructions baseline changed: {result.t2database_constructions}"
     )
 

--- a/tests/test_storage_boundary_lint.py
+++ b/tests/test_storage_boundary_lint.py
@@ -510,7 +510,12 @@ def test_dual_population_baseline_locked():
     # T2Database routes to the HTTP service (PG arbiter), NOT a raw SQLite
     # writer, so the single-writer concern this lint guards does not apply.
     # Both carry an ``# epsilon-allow:`` reason saying exactly that.
-    assert result.t2database_constructions == 33, (
+    #
+    # nexus-2c51v: 33 -> 34. The `nx aspects requeue-failed` read path opens a
+    # direct `T2Database(mem_path)` for a read-only failed-row inspection
+    # (mirrors `aspects gc`); reads are WAL-concurrent-safe so no single-writer
+    # concern. Carries an `# epsilon-allow:` reason.
+    assert result.t2database_constructions == 34, (
         f"T2Database documented-construction baseline moved: {result.t2database_constructions}"
     )
 


### PR DESCRIPTION
Closes the last non-MinerU child of the async/queue-hardening epic (`nexus-cgu27`). Adds operator-facing bulk recovery for terminal-`failed` aspect-queue rows — pairs with the RDR-163 backoff ladder (which reduces how often rows reach terminal; this clears the ones that still do).

## What
- **`list_failed(collection=None)` primitive across all 3 queue layers** — SQLite `AspectExtractionQueue`, `HttpAspectQueue` (`GET /list_failed?collection=`), and Java `AspectRepository.listFailed` + `AspectHandler` route. Includes `doc_id` so a re-enqueue preserves catalog identity. (Chose the both-backends primitive over the doctor-style raw-sqlite read, which has a service-mode hole.)
- **`t2_store_contract` snapshot** gains `list_failed`; parity tripwire green.
- **`nx aspects requeue-failed [--collection X] [--limit N] [--dry-run]`** on the existing `aspects` group: reads failed rows via the backend-routed facade, re-enqueues each via `t2_index_write` (daemon, nexus-zir76) — `INSERT OR REPLACE` resets `pending`/`retry_count=0` and clears any stale `next_retry_at` backoff. `--dry-run` reports without writing.
- **docs/cli-reference.md** — new `## nx aspects` section.

## Review
Both stacked reviewers (sonnet). code-review-expert **APPROVED** (0 Critical/High; verified `list_failed` 3-layer parity, the `_r=row` default-arg capture, daemon-routed write, `next_retry_at` clearance, side-effect-free dry-run). substantive-critic **partial** (0 Critical, 2 Significant), both addressed:
- **No rate-limit** → added `--limit N` (oldest-first) to pace recovery of a large backlog (thundering-herd avoidance).
- **TOCTOU** (snapshot → per-row writes, no cross-row txn) → documented as a single-operator recovery verb in the help text + cli-reference. The proper status-guarded fix would need a new store method across 3 backends + daemon allowlist + HTTP parity, which the bead deliberately scoped against ("reuse enqueue"); the practical window is concurrent-operators only (`failed` is terminal, no worker writes it), so documenting is proportionate.
- Observations folded in: retry_count-reset and enqueue-order are now called out in help + docs.

## Tests
- SQLite `list_failed` (filter / doc_id / empty), HTTP parity + collection-param forwarding, Java `listFailed` (FIFO + collection scope), CLI (dry-run vs apply, collection scope, `--limit` cap + nonpositive reject, no-failed message).
- Full mvn suite green (905); `pytest -k aspect` green (597); src/ ruff clean.

Bead `nexus-2c51v` (epic `nexus-cgu27`). Remaining epic work after this: MinerU `nexus-m26oq` / `nexus-yrlbd` (separate subsystem).