### PR TITLE
feat(doctor): nx doctor --check-t3-legacy-metadata (nexus-1714)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1409,6 +1409,24 @@ nx doctor --check-schema          # Validate T2 database schema and report pendi
 nx doctor --check-plan-library    # Report plan-library dimensional health (RDR-092 Phase 0c)
 ```
 
+```
+nx doctor --check-t3-legacy-metadata                        # Survey T3 for legacy doc_id/source_path chunk metadata
+nx doctor --check-t3-legacy-metadata --strict-legacy-metadata  # Exit non-zero if any collection still carries it
+```
+
+The `--check-t3-legacy-metadata` flag (nexus-1714) surveys local (Chroma)
+T3 collections and reports, per collection, whether any chunk still
+carries `doc_id` or `source_path` metadata — both retired by RDR-108
+Phase 3 in favour of the catalog `document_chunks` manifest. It gates
+removal of the legacy tolerance branches in `mcp/core.py`,
+`indexer_utils.py`, and `search_engine.py`: while any collection reports
+`LEGACY`, those branches must stay. Detection is a single cheap
+`get(where=…, limit=1)` presence probe per field per collection. Default
+behaviour is warn (exit 0); add `--strict-legacy-metadata` to exit
+non-zero when legacy metadata is found (for CI gating). The check is a
+local-Chroma concern and reports *not applicable* in service/cloud mode,
+where chunks use the RDR-155 pgvector schema.
+
 The `--check-plan-library` flag (introduced 4.9.13, nexus-4x9q) buckets
 every row in the `plans` table into **authored** (dimensions populated,
 not `backfill`-tagged), **backfilled** (dimensions populated, tagged

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -687,6 +687,116 @@ def _run_check_aspect_queue() -> None:
         conn.close()
 
 
+# ── --check-t3-legacy-metadata (nexus-1714) ──────────────────────────────────
+
+
+def _legacy_fields_present(collection, fields: tuple[str, ...]) -> set[str]:
+    """Return the subset of *fields* present (non-empty) on any chunk.
+
+    Chroma cannot answer "does any chunk carry key X" via a ``where`` filter:
+    ``{X: {'$ne': ''}}`` also matches chunks that *lack* the key entirely
+    (verified on chromadb 1.5.x), so it cannot distinguish a legacy chunk from
+    a Phase-3-clean one. Instead we page the collection's metadata
+    (``include=["metadatas"]``, ``limit<=300`` per the quota) and inspect the
+    keys Python-side, short-circuiting as soon as every field is found.
+    """
+    found: set[str] = set()
+    offset = 0
+    page = 300  # chroma_quotas._PAGE ceiling
+    while True:
+        res = collection.get(limit=page, offset=offset, include=["metadatas"])
+        metas = res.get("metadatas") or []
+        if not metas:
+            break
+        for m in metas:
+            for f in fields:
+                if f not in found and m.get(f):
+                    found.add(f)
+        if len(found) == len(fields) or len(metas) < page:
+            break
+        offset += page
+    return found
+
+
+def _run_check_t3_legacy_metadata(*, strict: bool = False) -> None:
+    """Report local T3 collections still carrying legacy chunk metadata.
+
+    RDR-108 Phase 3 retired ``doc_id`` / ``source_path`` from chunk metadata
+    (the catalog ``document_chunks`` manifest is authoritative). Tolerance
+    branches in ``mcp/core.py``, ``indexer_utils.py``, and ``search_engine.py``
+    still read those fields for pre-Phase-3 chunks; this check tells an operator
+    whether the corpus is fully pruned so those branches can be removed
+    (nexus-1714).
+
+    Scope (deliberate, not silent): this is a local-Chroma concern. The RDR-155
+    pgvector service path stores chunks under a different schema and does not
+    expose arbitrary-metadata ``where`` filters, so the check reports *not
+    applicable* in service mode rather than producing a misleading result.
+    """
+    from nexus.config import is_local_mode  # noqa: PLC0415 — deferred local import — avoids import-time cost / circular deps
+
+    if not is_local_mode():
+        click.echo(
+            "T3 legacy-metadata check: not applicable in service/cloud mode "
+            "(legacy doc_id/source_path chunk metadata is a local-Chroma "
+            "concern; the pgvector service path uses a different schema)."
+        )
+        return
+
+    from nexus.db import make_t3  # noqa: PLC0415 — deferred local import — avoids import-time cost / circular deps
+
+    try:
+        db = make_t3()
+    except Exception as exc:  # noqa: BLE001 — diagnostic: report unavailability, never crash doctor
+        click.echo(f"T3 legacy-metadata check: T3 unavailable ({exc}).")
+        return
+
+    cols = db.list_collections()
+    if not cols:
+        click.echo("T3 legacy-metadata check: no collections found.")
+        return
+
+    click.echo(
+        "T3 legacy-metadata check (RDR-108 Phase 3 retired doc_id + "
+        "source_path):"
+    )
+    offenders: list[str] = []
+    for c in sorted(cols, key=lambda c: c["name"]):
+        name = c["name"]
+        total = c.get("count", 0)
+        try:
+            col = db.get_collection(name)
+            present = _legacy_fields_present(col, ("doc_id", "source_path"))
+        except Exception as exc:  # noqa: BLE001 — per-collection probe failure is reported, scan continues
+            click.echo(f"  {name}: probe failed ({exc})")
+            continue
+        has_doc_id = "doc_id" in present
+        has_source_path = "source_path" in present
+        legacy = has_doc_id or has_source_path
+        marker = "  ⚠ LEGACY" if legacy else ""
+        click.echo(
+            f"  {name}: {total} chunk(s); "
+            f"doc_id={'yes' if has_doc_id else 'no'} "
+            f"source_path={'yes' if has_source_path else 'no'}{marker}"
+        )
+        if legacy:
+            offenders.append(name)
+
+    if offenders:
+        click.echo(
+            f"\n{len(offenders)} collection(s) still carry legacy chunk "
+            "metadata. These gate removal of the legacy tolerance branches "
+            "(mcp/core.py, indexer_utils.py, search_engine.py)."
+        )
+        if strict:
+            sys.exit(1)
+    else:
+        click.echo(
+            "\nAll collections are Phase-3 clean (no doc_id/source_path "
+            "chunk metadata)."
+        )
+
+
 # ── --check-tier-discipline (nexus-a52i) ─────────────────────────────────────
 
 
@@ -1232,6 +1342,25 @@ def _run_check_mineru() -> None:
          "session-id resolves but the lease is missing or unreachable.",
 )
 @click.option(
+    "--check-t3-legacy-metadata",
+    "check_t3_legacy_metadata",
+    is_flag=True,
+    default=False,
+    help="Survey local (Chroma) T3 collections for chunks still carrying "
+         "legacy doc_id / source_path metadata (RDR-108 Phase 3 retired "
+         "both). Gates removal of the tolerance branches in mcp/core.py, "
+         "indexer_utils.py, search_engine.py. Not applicable in service "
+         "mode. nexus-1714.",
+)
+@click.option(
+    "--strict-legacy-metadata",
+    "strict_legacy_metadata",
+    is_flag=True,
+    default=False,
+    help="Make --check-t3-legacy-metadata exit non-zero when any "
+         "collection still carries legacy metadata (default: warn only).",
+)
+@click.option(
     "--days",
     "days",
     default=30,
@@ -1252,6 +1381,8 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
                check_post_store_hooks: bool,
                check_aspect_queue: bool,
                check_t1: bool,
+               check_t3_legacy_metadata: bool,
+               strict_legacy_metadata: bool,
                check_tier_discipline: bool,
                check_storage_boundary: bool,
                fail_on_violation: bool,
@@ -1310,6 +1441,10 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
 
     if check_aspect_queue:
         _run_check_aspect_queue()
+        return
+
+    if check_t3_legacy_metadata:
+        _run_check_t3_legacy_metadata(strict=strict_legacy_metadata)
         return
 
     if check_t1:

--- a/tests/test_doctor_t3_legacy_metadata.py
+++ b/tests/test_doctor_t3_legacy_metadata.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-1714: ``nx doctor --check-t3-legacy-metadata``.
+
+RDR-108 Phase 3 retired ``doc_id`` and ``source_path`` from T3 chunk
+metadata; the catalog ``document_chunks`` manifest is now authoritative.
+Several deliberate *tolerance* branches still read those fields for
+pre-Phase-3 chunks (``src/nexus/mcp/core.py``, ``indexer_utils.py``,
+``search_engine.py``). Without a check, operators cannot tell whether the
+legacy corpus is fully pruned, so the branches — and the split-identity
+exposure they carry — stay forever.
+
+This check surveys local-mode (Chroma) T3 collections and reports which
+still carry chunks with ``doc_id`` / ``source_path`` metadata. It is a
+local-Chroma concern by design: the RDR-155 pgvector service path stores
+chunks under a different schema and does not expose arbitrary metadata
+``where`` filters, so the check reports *not applicable* in service mode
+rather than producing a misleading result.
+"""
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class _FakeCol:
+    """Chroma-collection stub modelling real ``get(limit, offset, metadatas)``.
+
+    The probe pages metadatas and inspects keys Python-side (Chroma's ``$ne``
+    matches missing keys, so a ``where`` filter cannot isolate legacy chunks).
+    This stub returns one metadata dict per chunk: clean chunks carry only
+    ``chunk_text_hash``; legacy chunks additionally carry the legacy field — so
+    a clean collection must NOT be flagged.
+    """
+
+    def __init__(self, total: int, legacy_fields: set[str]) -> None:
+        self._metas = []
+        for i in range(total):
+            m = {"chunk_text_hash": f"h{i}"}
+            if i == 0:  # only the first chunk carries the legacy field(s)
+                for f in legacy_fields:
+                    m[f] = "legacy-value"
+            self._metas.append(m)
+
+    def get(self, where=None, limit=10, offset=0, include=None):  # noqa: ANN001
+        window = self._metas[offset:offset + limit]
+        return {"ids": [str(i) for i in range(len(window))], "metadatas": window}
+
+
+class _FakeT3:
+    def __init__(self, cols: dict[str, tuple[int, set[str]]]) -> None:
+        self._cols = cols
+
+    def list_collections(self):
+        return [{"name": n, "count": c} for n, (c, _) in self._cols.items()]
+
+    def get_collection(self, name: str):
+        total, legacy = self._cols[name]
+        return _FakeCol(total, legacy)
+
+
+def _patch(monkeypatch, *, local: bool, t3: _FakeT3 | None) -> None:
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: local)
+    if t3 is not None:
+        monkeypatch.setattr("nexus.db.make_t3", lambda: t3)
+
+
+def test_service_mode_reports_not_applicable(runner, monkeypatch):
+    called = {"made": False}
+
+    def _boom():
+        called["made"] = True
+        raise AssertionError("make_t3 must not be called in service mode")
+
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: False)
+    monkeypatch.setattr("nexus.db.make_t3", _boom)
+    res = runner.invoke(main, ["doctor", "--check-t3-legacy-metadata"])
+    assert res.exit_code == 0, res.output
+    assert "not applicable" in res.output.lower()
+    assert called["made"] is False
+
+
+def test_no_collections(runner, monkeypatch):
+    _patch(monkeypatch, local=True, t3=_FakeT3({}))
+    res = runner.invoke(main, ["doctor", "--check-t3-legacy-metadata"])
+    assert res.exit_code == 0, res.output
+    assert "no collections" in res.output.lower()
+
+
+def test_all_clean_collections(runner, monkeypatch):
+    _patch(monkeypatch, local=True, t3=_FakeT3({
+        "code__a": (10, set()),
+        "docs__b": (5, set()),
+    }))
+    res = runner.invoke(main, ["doctor", "--check-t3-legacy-metadata"])
+    assert res.exit_code == 0, res.output
+    assert "clean" in res.output.lower()
+    assert "code__a" in res.output
+    assert "docs__b" in res.output
+
+
+def test_mixed_legacy_doc_id_warns_exit_zero_by_default(runner, monkeypatch):
+    _patch(monkeypatch, local=True, t3=_FakeT3({
+        "code__a": (10, {"doc_id"}),
+        "docs__b": (5, set()),
+    }))
+    res = runner.invoke(main, ["doctor", "--check-t3-legacy-metadata"])
+    assert res.exit_code == 0, res.output  # default warn
+    out = res.output.lower()
+    assert "legacy" in out
+    assert "code__a" in res.output
+
+
+def test_legacy_source_path_detected(runner, monkeypatch):
+    _patch(monkeypatch, local=True, t3=_FakeT3({
+        "docs__b": (5, {"source_path"}),
+    }))
+    res = runner.invoke(main, ["doctor", "--check-t3-legacy-metadata"])
+    assert res.exit_code == 0, res.output
+    assert "source_path" in res.output
+
+
+def test_strict_exits_nonzero_when_legacy_present(runner, monkeypatch):
+    _patch(monkeypatch, local=True, t3=_FakeT3({
+        "code__a": (10, {"doc_id", "source_path"}),
+    }))
+    res = runner.invoke(
+        main, ["doctor", "--check-t3-legacy-metadata", "--strict-legacy-metadata"]
+    )
+    assert res.exit_code != 0, res.output
+    assert "legacy" in res.output.lower()
+
+
+def test_strict_clean_exits_zero(runner, monkeypatch):
+    _patch(monkeypatch, local=True, t3=_FakeT3({"code__a": (10, set())}))
+    res = runner.invoke(
+        main, ["doctor", "--check-t3-legacy-metadata", "--strict-legacy-metadata"]
+    )
+    assert res.exit_code == 0, res.output
+
+
+# ── Real-Chroma semantics (pins the `$ne` trap the fake cannot prove) ─────────
+
+
+def test_probe_against_real_chroma_semantics():
+    """Phase-3-clean chunks (no doc_id key) must NOT be flagged; legacy ones must.
+
+    Guards the exact defect a `where={field: {'$ne': ''}}` probe hits: Chroma
+    returns key-absent documents from a `$ne` query, so such a probe reports
+    every clean collection as legacy. This exercises the real ChromaDB engine.
+    """
+    import chromadb  # noqa: PLC0415
+
+    from nexus.commands.doctor import _legacy_fields_present  # noqa: PLC0415
+
+    client = chromadb.EphemeralClient()
+
+    clean = client.create_collection("clean")
+    clean.add(
+        ids=["c0", "c1"],
+        embeddings=[[0.1, 0.2], [0.3, 0.4]],
+        metadatas=[{"chunk_text_hash": "h0"}, {"chunk_text_hash": "h1"}],
+    )
+    assert _legacy_fields_present(clean, ("doc_id", "source_path")) == set()
+
+    legacy = client.create_collection("legacy")
+    legacy.add(
+        ids=["l0", "l1"],
+        embeddings=[[0.1, 0.2], [0.3, 0.4]],
+        metadatas=[
+            {"chunk_text_hash": "h0", "doc_id": "1.2.3"},
+            {"chunk_text_hash": "h1", "source_path": "/x/a.py"},
+        ],
+    )
+    assert _legacy_fields_present(legacy, ("doc_id", "source_path")) == {
+        "doc_id",
+        "source_path",
+    }


### PR DESCRIPTION
Closes `nexus-1714`.

## What

Adds `nx doctor --check-t3-legacy-metadata` — surveys local (Chroma) T3 collections and reports, per collection, whether any chunk still carries `doc_id` or `source_path` metadata (both retired by RDR-108 Phase 3 in favour of the catalog `document_chunks` manifest).

Purpose: **gate removal of the legacy tolerance branches** in `mcp/core.py`, `indexer_utils.py`, `search_engine.py`. While any collection reports `LEGACY`, those branches must stay; once all clean, they can be removed.

- Default warn (exit 0); `--strict-legacy-metadata` exits 1 when legacy metadata is found (CI gating).

## Design notes

- **Detection is a Python-side metadata scan**, not a `where` filter. A `where={field: {'$ne': ''}}` probe is wrong: Chroma also matches chunks that *lack* the key, so it false-positives every clean collection (caught in stacked review, verified live on chromadb 1.5.x). The probe pages `get(limit<=300, offset, include=["metadatas"])` and short-circuits once all fields are found. A real-`EphemeralClient` test pins these semantics.
- **Scope (deliberate, documented):** local-Chroma concern. The bead predates RDR-155; the pgvector service path uses a different chunk schema (no `doc_id`/`source_path`) and doesn't expose arbitrary-metadata `where` filters, so the check reports *not applicable* in service mode rather than a misleading result.

## Tests / review

8 unit tests (incl. real-Chroma semantics). Stacked review (substantive-critic) caught a Critical `$ne`-trap bug; fixed and re-reviewed clean. Full unit suite green (11154 passed).

## Closes
Closes #nexus-1714