### PR TITLE
fix: service-mode correctness fixes from 6.0.0 local validation

### DIFF
--- a/scripts/validate/integration-stack.sh
+++ b/scripts/validate/integration-stack.sh
@@ -85,7 +85,7 @@ PY_SUITES=(
 # The Java tier tests: T3 pgvector serving + the RDR-156 stats view, AND the
 # repo-layer RLS contracts (incl. the unset-GUC fail-closed property that the
 # chash HTTP test_l delegates to — see test_http_chash_integration.py).
-JAVA_TESTS="PgVectorServingContractTest,PgVectorRepositoryContractTest,PgVectorHybridSearchContractTest,CollectionVectorStatsTest,SoftDeleteTest,ManifestFunctionsTest,VectorHybridHttpTest,ChashRepositoryTest,ChunksRlsBehavioralTest"
+JAVA_TESTS="PgVectorServingContractTest,PgVectorRepositoryContractTest,PgVectorHybridSearchContractTest,CollectionVectorStatsTest,SoftDeleteTest,ManifestFunctionsTest,VectorHybridHttpTest,ChashRepositoryTest,ChunksRlsBehavioralTest,PlanHandlerTest"
 
 rc=0
 

--- a/service/src/main/java/dev/nexus/service/http/PlanHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/PlanHandler.java
@@ -148,7 +148,17 @@ public final class PlanHandler implements HttpHandler {
             long id = parseLong(params.get("id"), "id");
             row = repo.getById(tenant, id);
         } else {
-            String project    = requireParam(params, "project");
+            // An EMPTY project is the valid global-scope sentinel (mirrors the
+            // Python _default_project_for_scope("global") -> "" convention and the
+            // nexus.plans.project NOT NULL DEFAULT '' column). Require the key to
+            // be PRESENT but allow a blank value; only an absent key is a 400.
+            // Rejecting blank here (via requireParam) broke `nx catalog setup`
+            // plan seeding in service mode entirely — every global builtin
+            // template queries by-dimensions with project="". (nexus-82ihm)
+            if (!params.containsKey("project")) {
+                throw new IllegalArgumentException("missing required query param: project");
+            }
+            String project    = params.get("project");
             String dimensions = requireParam(params, "dimensions");
             row = repo.getByDimensions(tenant, project, dimensions);
         }

--- a/service/src/test/java/dev/nexus/service/PlanHandlerTest.java
+++ b/service/src/test/java/dev/nexus/service/PlanHandlerTest.java
@@ -42,6 +42,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * if present); only an ABSENT project key is a 400.
  *
  * <p>Hermetic: embedded Postgres (Testcontainers pgvector), port 0, requires Docker.
+ *
+ * <p>Isolation invariant (PER_CLASS shares one DB, no per-test cleanup): each
+ * test keys on a DISTINCT {@code dimensions} value (the unique index is on
+ * {@code (tenant_id, project, dimensions)}), so test order is irrelevant and no
+ * test poisons another. A new test MUST pick its own dimensions marker; do NOT
+ * add a DELETE/reset step without revisiting this invariant.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PlanHandlerTest {

--- a/service/src/test/java/dev/nexus/service/PlanHandlerTest.java
+++ b/service/src/test/java/dev/nexus/service/PlanHandlerTest.java
@@ -1,0 +1,226 @@
+package dev.nexus.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.nexus.service.db.TenantConstants;
+import org.testcontainers.containers.PostgreSQLContainer;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * PlanHandler HTTP endpoint tests (nexus-82ihm).
+ *
+ * <p>Regression coverage for the service-mode plan-library seeding defect found
+ * during the 6.0.0 local validation pass: {@code GET /v1/plans/get} with a blank
+ * {@code project} query param (the valid GLOBAL-SCOPE sentinel — see the Python
+ * {@code _default_project_for_scope("global") -> ""} convention and the
+ * {@code nexus.plans.project TEXT NOT NULL DEFAULT ''} column) was rejected with
+ * HTTP 400 "missing required query param: project". That broke
+ * {@code nx catalog setup} plan seeding entirely in service mode, because every
+ * global builtin template queries by-dimensions with an empty project.
+ *
+ * <p>Contract: an EMPTY project is a valid value (404 if the row is absent, 200
+ * if present); only an ABSENT project key is a 400.
+ *
+ * <p>Hermetic: embedded Postgres (Testcontainers pgvector), port 0, requires Docker.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PlanHandlerTest {
+
+    private static final String TOKEN = "plan-handler-test-token-abc789";
+    private static final String SVC_ROLE = "svc_plan_handler_test";
+    private static final String SVC_PASS = "svc_plan_handler_test_pass";
+    private static final String TENANT = TenantConstants.DEFAULT_TENANT;
+
+    private static final TypeReference<Map<String, Object>> MAP_T = new TypeReference<>() {};
+
+    /** A canonical dimensions JSON of a global-scope builtin plan. */
+    private static final String GLOBAL_DIMS = "{\"scope\":\"global\",\"verb\":\"research\"}";
+
+    PostgreSQLContainer<?> pg;
+    NexusService service;
+    HttpClient http;
+    com.zaxxer.hikari.HikariDataSource svcDs;
+    ObjectMapper mapper;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        mapper = new ObjectMapper();
+        pg = PgContainerHelper.start();
+
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '" + SVC_ROLE + "') THEN " +
+                "    CREATE ROLE " + SVC_ROLE + " LOGIN PASSWORD '" + SVC_PASS + "'; " +
+                "  END IF; " +
+                "END $$");
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
+                "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass'; " +
+                "  END IF; " +
+                "END $$");
+        }
+
+        try (Connection su = pg.createConnection("")) {
+            Database db = DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(su));
+            Liquibase liquibase = new Liquibase(
+                "db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(), db);
+            liquibase.update(new Contexts());
+        }
+
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute("GRANT USAGE ON SCHEMA nexus TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON nexus.plans TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT USAGE ON SEQUENCE nexus.plans_id_seq TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "GRANT SELECT ON nexus.service_tokens, nexus.session_tokens TO " + SVC_ROLE);
+            su.createStatement().execute(
+                "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label) VALUES ('"
+                + dev.nexus.service.db.TokenHashing.sha256Hex(TOKEN)
+                + "', '" + TENANT + "', 'test-bound') ON CONFLICT (token_hash) DO NOTHING");
+            su.createStatement().execute(
+                "ALTER ROLE " + SVC_ROLE + " SET search_path TO nexus, public");
+        }
+
+        var cfg = new com.zaxxer.hikari.HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername(SVC_ROLE);
+        cfg.setPassword(SVC_PASS);
+        cfg.setMaximumPoolSize(5);
+        cfg.setAutoCommit(true);
+        svcDs = new com.zaxxer.hikari.HikariDataSource(cfg);
+
+        service = new NexusService(0, TOKEN, svcDs);
+        service.start();
+        http = HttpClient.newHttpClient();
+    }
+
+    @AfterAll
+    void stopAll() throws Exception {
+        if (service != null) service.stop();
+        if (svcDs != null)   svcDs.close();
+        if (pg != null)      pg.stop();
+    }
+
+    // ── The regression: empty project is the global-scope sentinel ─────────────
+
+    /**
+     * An ABSENT project key is still a 400 — the genuinely-missing case stays
+     * rejected. (Guards against over-correcting the fix into accepting no key.)
+     */
+    @Test
+    void getByDimensions_absentProjectKey_returns400() throws Exception {
+        var resp = get("/v1/plans/get?dimensions=" + enc(GLOBAL_DIMS), TENANT);
+        assertThat(resp.statusCode())
+            .as("absent project key is a genuine 400")
+            .isEqualTo(400);
+    }
+
+    /**
+     * An EMPTY project value with no matching row is 404 (not found), NOT 400.
+     * This is the defect: a blank project is the valid global-scope sentinel, so
+     * the by-dimensions lookup must run and return 404 when absent.
+     */
+    @Test
+    void getByDimensions_emptyProject_noRow_returns404() throws Exception {
+        // Distinct dimensions never saved by any other test (shared PER_CLASS DB,
+        // no per-test cleanup) so this asserts the genuine not-found path.
+        String unsavedDims = "{\"scope\":\"global\",\"verb\":\"never-saved-marker\"}";
+        var resp = get("/v1/plans/get?project=&dimensions=" + enc(unsavedDims), TENANT);
+        assertThat(resp.statusCode())
+            .as("blank project (global scope) with no row must be 404, not 400")
+            .isEqualTo(404);
+    }
+
+    /**
+     * After saving a global-scope plan (project=""), the by-dimensions GET with a
+     * blank project returns 200 and the stored row.
+     */
+    @Test
+    void getByDimensions_emptyProject_afterSave_returns200() throws Exception {
+        var save = post("/v1/plans/save", TENANT,
+            "{\"project\":\"\",\"query\":\"global research plan\","
+            + "\"plan_json\":\"{\\\"steps\\\":[]}\",\"dimensions\":" + jsonString(GLOBAL_DIMS) + "}");
+        assertThat(save.statusCode()).as("save with empty project must succeed").isEqualTo(200);
+
+        var resp = get("/v1/plans/get?project=&dimensions=" + enc(GLOBAL_DIMS), TENANT);
+        assertThat(resp.statusCode())
+            .as("blank project (global scope) with a saved row must be 200")
+            .isEqualTo(200);
+        var body = mapper.readValue(resp.body(), MAP_T);
+        assertThat(body.get("query")).isEqualTo("global research plan");
+    }
+
+    /**
+     * A non-empty project still works (no regression for scoped plans).
+     */
+    @Test
+    void getByDimensions_nonEmptyProject_afterSave_returns200() throws Exception {
+        String dims = "{\"scope\":\"code__nexus\",\"verb\":\"research\"}";
+        var save = post("/v1/plans/save", TENANT,
+            "{\"project\":\"code__nexus\",\"query\":\"scoped plan\","
+            + "\"plan_json\":\"{\\\"steps\\\":[]}\",\"dimensions\":" + jsonString(dims) + "}");
+        assertThat(save.statusCode()).isEqualTo(200);
+
+        var resp = get("/v1/plans/get?project=code__nexus&dimensions=" + enc(dims), TENANT);
+        assertThat(resp.statusCode()).isEqualTo(200);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static String enc(String s) {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+
+    /** Serialize a string as a JSON string literal (for embedding in a body). */
+    private String jsonString(String s) throws Exception {
+        return mapper.writeValueAsString(s);
+    }
+
+    private HttpResponse<String> get(String path, String tenant) throws Exception {
+        var req = HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + service.getPort() + path))
+            .header("Authorization", "Bearer " + TOKEN)
+            .header("X-Nexus-Tenant", tenant)
+            .GET().build();
+        return http.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> post(String path, String tenant, String body) throws Exception {
+        var req = HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + service.getPort() + path))
+            .header("Authorization", "Bearer " + TOKEN)
+            .header("X-Nexus-Tenant", tenant)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+        return http.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/src/nexus/collection_rename.py
+++ b/src/nexus/collection_rename.py
@@ -275,8 +275,14 @@ def remap_collection_references(
         else:
             counts["catalog_docs"] = catalog.rename_collection(source, target)
     except Exception as exc:  # noqa: BLE001 — catalog cascade is best-effort after T2 remap; surfaced via on_warn
+        # The catalog is a derived view (see docstring): a cascade miss here —
+        # e.g. a 404 when the legacy source was never registered as a catalog
+        # collection — is non-fatal and repairable. State the remedy so this
+        # does not read as a data-loss failure (nexus-i6p73).
         on_warn(
-            f"warn: T2 reference remap succeeded but catalog cascade failed: {exc}"
+            f"warn: T2 reference remap succeeded but catalog cascade failed: {exc}\n"
+            f"       (non-fatal: the catalog is a derived view; run "
+            f"`nx catalog rebuild` to reconcile.)"
         )
 
     return counts

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -354,13 +354,9 @@ def setup_cmd(remote: str) -> None:
         click.echo(f"  Backfill incomplete ({type(exc).__name__}: {exc})")
 
     click.echo("Backfilling chunk_text_hash...")
-    from nexus.commands.collection import _backfill_chunk_text_hash  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
     hash_updated = 0
     try:
-        for col_info in t3.list_collections():
-            col = t3._client.get_collection(col_info["name"])
-            updated, _, _ = _backfill_chunk_text_hash(col)
-            hash_updated += updated
+        hash_updated = _backfill_all_chunk_text_hashes(t3)
     except Exception as exc:  # noqa: BLE001 — best-effort; error surfaced via log/echo, must not crash caller
         click.echo(f"  Hash backfill partial ({type(exc).__name__}: {exc})")
     click.echo(f"  {hash_updated} chunks updated")
@@ -1116,6 +1112,36 @@ def _make_t3():
     return make_t3()
 
 
+def _backfill_all_chunk_text_hashes(t3) -> int:
+    """Backfill ``chunk_text_hash`` across every T3 collection; return chunks updated.
+
+    No-op in vector-service mode (nexus-84gbt): the Java service owns chunk
+    identity (chash) via its manifest + post-store path, and the local,
+    Chroma-specific paginate-and-upsert backfill reaches into ``t3._client``
+    (a ``chromadb`` client attribute). In service mode ``t3`` is an
+    ``HttpVectorClient`` with no ``_client`` — calling it there raised
+    ``AttributeError`` and degraded ``nx catalog setup`` to "Hash backfill
+    partial", leaving the manifest empty. Skip cleanly instead.
+    """
+    from nexus.db.http_vector_client import is_vector_service_mode  # noqa: PLC0415 — circular-dep avoidance (nexus.db.http_vector_client)
+
+    if is_vector_service_mode():
+        click.echo(
+            "  (service mode: chunk_text_hash is owned by the service; "
+            "skipping local backfill)"
+        )
+        return 0
+
+    from nexus.commands.collection import _backfill_chunk_text_hash  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
+
+    hash_updated = 0
+    for col_info in t3.list_collections():
+        col = t3._client.get_collection(col_info["name"])
+        updated, _, _ = _backfill_chunk_text_hash(col)
+        hash_updated += updated
+    return hash_updated
+
+
 def _make_registry():
     """RDR-137 Phase 5.3 (nexus-tts0d.20): tiny adapter exposing the
     two methods ``_backfill_repos`` consumes (``all_info``). Reads
@@ -1389,11 +1415,7 @@ def backfill_cmd(
     hash_updated = 0
     if not dry_run:
         click.echo("Pass 4: chunk_text_hash backfill...")
-        from nexus.commands.collection import _backfill_chunk_text_hash  # noqa: PLC0415 — deferred import; rare/branch-local path or circular-dep / startup-cost avoidance
-        for col_info in t3.list_collections():
-            col = t3._client.get_collection(col_info["name"])
-            updated, _, _ = _backfill_chunk_text_hash(col)
-            hash_updated += updated
+        hash_updated = _backfill_all_chunk_text_hashes(t3)
 
     mode = "dry-run" if dry_run else "registered"
     click.echo(f"\nBackfill complete ({mode}):")

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -1123,9 +1123,14 @@ def _backfill_all_chunk_text_hashes(t3) -> int:
     ``AttributeError`` and degraded ``nx catalog setup`` to "Hash backfill
     partial", leaving the manifest empty. Skip cleanly instead.
     """
-    from nexus.db.http_vector_client import is_vector_service_mode  # noqa: PLC0415 — circular-dep avoidance (nexus.db.http_vector_client)
+    from nexus.db.http_vector_client import is_service_backed  # noqa: PLC0415 — circular-dep avoidance (nexus.db.http_vector_client)
 
-    if is_vector_service_mode():
+    # Instance-based guard (NOT env-based is_vector_service_mode): a service-
+    # backed handle is an HttpVectorClient with no chroma ._client. Keying on the
+    # handle keeps injected chroma-backed T3Database test fixtures on the legacy
+    # branch regardless of NX_STORAGE_BACKEND_VECTORS (the documented preference
+    # in http_vector_client.is_service_backed).
+    if is_service_backed(t3):
         click.echo(
             "  (service mode: chunk_text_hash is owned by the service; "
             "skipping local backfill)"

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -46,6 +46,18 @@ def _run_check_schema() -> None:
 
     from nexus.commands._helpers import default_db_path  # noqa: PLC0415 — deferred local import — avoids import-time cost / circular deps
     from nexus.db.migrations import MIGRATIONS, _parse_version  # noqa: PLC0415 — deferred local import — avoids import-time cost / circular deps
+    from nexus.db.storage_mode import StorageBackend, storage_backend_for  # noqa: PLC0415 — deferred local import — avoids import-time cost / circular deps
+
+    # nexus-p0clh: in service mode the T2 schema lives in Postgres and is
+    # Liquibase-managed by the nexus-service (applied at startup), not the local
+    # SQLite migrations checked below. Report N/A honestly instead of the
+    # misleading "T2 database not found" (which reads as an error).
+    if storage_backend_for("memory") == StorageBackend.SERVICE:
+        click.echo(
+            "T2 schema is service-backed (Postgres, Liquibase-managed) — "
+            "local SQLite schema check N/A in service mode."
+        )
+        return
 
     db_path = default_db_path()
     if not db_path.exists():

--- a/tests/db/test_http_plan_library_integration.py
+++ b/tests/db/test_http_plan_library_integration.py
@@ -269,6 +269,31 @@ class TestPlansMVV:
         assert row["tags"]      == "research,rdr"
         assert row["verb"]      == "research"
 
+    def test_a2_get_by_dimensions_empty_project_global_scope(self, plan_store):
+        """a2) get_plan_by_dimensions with an EMPTY project (global-scope sentinel).
+
+        Regression for nexus-82ihm: the Java service rejected a blank ``project``
+        as HTTP 400 'missing required query param', which broke global builtin
+        plan seeding in service mode entirely (every global template queries
+        by-dimensions with project=''). An empty project is the valid
+        global-scope value — absent row must be None (404), present row 200.
+        """
+        dims = '{"scope":"global","verb":"research","name":"integ-empty-proj-marker"}'
+        # Absent row over the HTTP path must be a clean None (404 -> None), NOT a 400.
+        assert plan_store.get_plan_by_dimensions(project="", dimensions=dims) is None
+
+        plan_store.save_plan(
+            query="global plan via empty project",
+            plan_json='{"steps":[]}',
+            project="",
+            verb="research",
+            scope="global",
+            dimensions=dims,
+        )
+        row = plan_store.get_plan_by_dimensions(project="", dimensions=dims)
+        assert row is not None, "empty-project (global) get_by_dimensions must find the row"
+        assert row["query"] == "global plan via empty project"
+
     def test_b_tags_empty_string_default(self, plan_store):
         """b) untagged plan has tags='' (not null/missing)."""
         pid = plan_store.save_plan(

--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -24,8 +24,21 @@ DO_BUILD=1
 GUIDED=0
 COLD=0
 # RDR-002 ez5.13: the release_version the guided MVV stamps into the binary so
-# its /version reports >= v0.1.5 and the guided-upgrade version-pin PASSES.
-GUIDED_STAMP_VERSION="0.1.6"
+# its /version reports >= the guided-upgrade version-pin floor and PASSES.
+# Derived from the product constant (REQUIRED_RELEASE_VERSION) so this stamp can
+# never go stale: a hardcoded "0.1.6" silently fell below the bumped v0.1.8 floor
+# and the MVV fail-closed at the version gate without ever exercising the
+# migration (nexus-... 6.0.0 validation). Falls back to a literal floor if the
+# constant can't be parsed.
+GUIDED_STAMP_VERSION="$(
+  python3 - <<'PY' 2>/dev/null || true
+import re, pathlib
+src = pathlib.Path("src/nexus/migration/guided_upgrade.py").read_text()
+m = re.search(r"REQUIRED_RELEASE_VERSION[^=]*=\s*\((\d+),\s*(\d+),\s*(\d+)\)", src)
+print(".".join(m.groups()) if m else "")
+PY
+)"
+[ -n "$GUIDED_STAMP_VERSION" ] || GUIDED_STAMP_VERSION="0.1.8"
 RELEASE_PROPS="service/src/main/resources/META-INF/nexus/release.properties"
 # nexus-4mm24: the published engine-service tag the COLD box auto-acquires from.
 COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.6}"

--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -41,7 +41,11 @@ PY
 [ -n "$GUIDED_STAMP_VERSION" ] || GUIDED_STAMP_VERSION="0.1.8"
 RELEASE_PROPS="service/src/main/resources/META-INF/nexus/release.properties"
 # nexus-4mm24: the published engine-service tag the COLD box auto-acquires from.
-COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.6}"
+# Must be >= the guided-upgrade version-pin floor (REQUIRED_RELEASE_VERSION); a
+# stale default fail-closes the --cold MVV at the version gate. Kept literal (it
+# names a PUBLISHED release tag, which need not equal the floor) but bumped to
+# track it; override via NEXUS_SERVICE_TAG. (nexus-v0zmv)
+COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.8}"
 for a in "$@"; do
   case "$a" in
     --with-cloud) WITH_CLOUD=1 ;;

--- a/tests/test_catalog_chash_backfill_service_mode.py
+++ b/tests/test_catalog_chash_backfill_service_mode.py
@@ -3,23 +3,34 @@
 Regression coverage for the 6.0.0 local-validation defect: ``nx catalog setup``
 ran a Chroma-specific chunk_text_hash backfill that reached into ``t3._client``.
 In service mode ``t3`` is an ``HttpVectorClient`` (no ``_client`` attribute), so
-the loop raised ``AttributeError`` and degraded to "Hash backfill partial",
-leaving the catalog manifest empty. The backfill must be a clean no-op in
-service mode (the service owns chash via its manifest/post-store path).
+the loop raised ``AttributeError`` and degraded to "Hash backfill partial". The
+backfill must be a clean no-op in service mode (the service owns chash via its
+manifest/post-store path).
+
+The guard keys on the HANDLE (``is_service_backed`` / ``isinstance``), NOT the
+env (``is_vector_service_mode``): these tests use a real ``HttpVectorClient``
+subclass and a plain object so they exercise the actual predicate, not a
+monkeypatch.
 """
 
 from __future__ import annotations
 
-import pytest
-
 from nexus.commands import catalog as catmod
+from nexus.db.http_vector_client import HttpVectorClient
 
 
-class _ExplodingT3:
-    """A T3 stand-in that fails loudly if the Chroma-specific path is touched."""
+class _ServiceT3(HttpVectorClient):
+    """A real service-backed handle (isinstance HttpVectorClient → True).
+
+    __init__ is bypassed (no network); the only members the helper may touch
+    raise loudly to prove the service branch never reaches the Chroma path.
+    """
+
+    def __init__(self) -> None:  # noqa: D401 — test double; bypass network init
+        pass
 
     @property
-    def _client(self):  # noqa: D401 — test double
+    def _client(self):
         raise AssertionError("service mode must not access t3._client")
 
     def list_collections(self):
@@ -32,7 +43,7 @@ class _FakeCol:
 
 
 class _LocalT3:
-    """A local-mode T3 stand-in exposing the chromadb-style ``_client``."""
+    """A local-mode handle (NOT an HttpVectorClient) exposing chromadb _client."""
 
     def __init__(self, names: list[str]) -> None:
         self._names = names
@@ -47,20 +58,14 @@ class _LocalT3:
         return [{"name": n} for n in self._names]
 
 
-def test_backfill_skips_in_service_mode(monkeypatch):
-    """In service mode the helper returns 0 and never touches ``_client``."""
-    monkeypatch.setattr(
-        "nexus.db.http_vector_client.is_vector_service_mode", lambda: True
-    )
-    # Must not raise AttributeError (the original bug) nor touch _client.
-    assert catmod._backfill_all_chunk_text_hashes(_ExplodingT3()) == 0
+def test_backfill_skips_in_service_mode():
+    """A real HttpVectorClient handle no-ops without touching ``_client``."""
+    # No env monkeypatch: the guard must key on the instance type.
+    assert catmod._backfill_all_chunk_text_hashes(_ServiceT3()) == 0
 
 
 def test_backfill_runs_in_local_mode(monkeypatch):
-    """In local mode the helper iterates collections and sums updated counts."""
-    monkeypatch.setattr(
-        "nexus.db.http_vector_client.is_vector_service_mode", lambda: False
-    )
+    """A non-service handle iterates collections and sums updated counts."""
     seen: list[str] = []
 
     def _fake_backfill(col, *args, **kwargs):

--- a/tests/test_catalog_chash_backfill_service_mode.py
+++ b/tests/test_catalog_chash_backfill_service_mode.py
@@ -1,0 +1,76 @@
+"""Service-mode guard for the catalog chunk_text_hash backfill (nexus-84gbt).
+
+Regression coverage for the 6.0.0 local-validation defect: ``nx catalog setup``
+ran a Chroma-specific chunk_text_hash backfill that reached into ``t3._client``.
+In service mode ``t3`` is an ``HttpVectorClient`` (no ``_client`` attribute), so
+the loop raised ``AttributeError`` and degraded to "Hash backfill partial",
+leaving the catalog manifest empty. The backfill must be a clean no-op in
+service mode (the service owns chash via its manifest/post-store path).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.commands import catalog as catmod
+
+
+class _ExplodingT3:
+    """A T3 stand-in that fails loudly if the Chroma-specific path is touched."""
+
+    @property
+    def _client(self):  # noqa: D401 — test double
+        raise AssertionError("service mode must not access t3._client")
+
+    def list_collections(self):
+        raise AssertionError("service mode must not enumerate collections")
+
+
+class _FakeCol:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _LocalT3:
+    """A local-mode T3 stand-in exposing the chromadb-style ``_client``."""
+
+    def __init__(self, names: list[str]) -> None:
+        self._names = names
+
+        class _Client:
+            def get_collection(self_inner, name):  # noqa: N805 — test double
+                return _FakeCol(name)
+
+        self._client = _Client()
+
+    def list_collections(self):
+        return [{"name": n} for n in self._names]
+
+
+def test_backfill_skips_in_service_mode(monkeypatch):
+    """In service mode the helper returns 0 and never touches ``_client``."""
+    monkeypatch.setattr(
+        "nexus.db.http_vector_client.is_vector_service_mode", lambda: True
+    )
+    # Must not raise AttributeError (the original bug) nor touch _client.
+    assert catmod._backfill_all_chunk_text_hashes(_ExplodingT3()) == 0
+
+
+def test_backfill_runs_in_local_mode(monkeypatch):
+    """In local mode the helper iterates collections and sums updated counts."""
+    monkeypatch.setattr(
+        "nexus.db.http_vector_client.is_vector_service_mode", lambda: False
+    )
+    seen: list[str] = []
+
+    def _fake_backfill(col, *args, **kwargs):
+        seen.append(col.name)
+        return (3, 0, 3)  # (updated, skipped, total)
+
+    monkeypatch.setattr(
+        "nexus.commands.collection._backfill_chunk_text_hash", _fake_backfill
+    )
+
+    total = catmod._backfill_all_chunk_text_hashes(_LocalT3(["code__a", "code__b"]))
+    assert total == 6
+    assert seen == ["code__a", "code__b"]

--- a/tests/test_doctor_check_schema_service_mode.py
+++ b/tests/test_doctor_check_schema_service_mode.py
@@ -1,0 +1,39 @@
+"""nx doctor --check-schema service-mode honesty (nexus-p0clh).
+
+In service mode the T2 schema lives in Postgres (Liquibase-managed by the
+nexus-service), not the local SQLite migrations. The check previously printed
+"T2 database not found — nothing to check", which reads as an error. It must
+report N/A for service mode instead.
+"""
+
+from __future__ import annotations
+
+from nexus.commands.doctor import _run_check_schema
+from nexus.db.storage_mode import StorageBackend
+
+
+def test_check_schema_reports_na_in_service_mode(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "nexus.db.storage_mode.storage_backend_for",
+        lambda store: StorageBackend.SERVICE,
+    )
+    _run_check_schema()
+    out = capsys.readouterr().out
+    assert "service-backed" in out
+    assert "N/A in service mode" in out
+    # The misleading "not found" message must NOT appear in service mode.
+    assert "T2 database not found" not in out
+
+
+def test_check_schema_sqlite_mode_unaffected(monkeypatch, tmp_path, capsys):
+    """In SQLite mode with no DB, the existing not-found path still applies."""
+    monkeypatch.setattr(
+        "nexus.db.storage_mode.storage_backend_for",
+        lambda store: StorageBackend.SQLITE,
+    )
+    monkeypatch.setattr(
+        "nexus.commands._helpers.default_db_path", lambda: tmp_path / "absent.db"
+    )
+    _run_check_schema()
+    out = capsys.readouterr().out
+    assert "T2 database not found" in out


### PR DESCRIPTION
Correctness fixes surfaced by a high-fidelity pre-6.0.0 **local service-stack** validation pass (greenfield `nx init --service` + 5.x→6.0 migration on the mac-native GraalVM binary + host PG16/pgvector + onnx-local bge-768). All TDD, stacked-reviewed (code-review-expert + substantive-critic).

## Fixes
- **nexus-82ihm** — `PlanHandler` `/v1/plans/get` by-dimensions accepts an **empty `project`** (the valid global-scope sentinel; mirrors Python `_default_project_for_scope("global")→""` and `nexus.plans.project NOT NULL DEFAULT ''`). It was rejecting blank as `400 missing required query param`, which broke `nx catalog setup` global plan seeding entirely in service mode. New `PlanHandlerTest` pins 400 (absent) / 404 (empty, no row) / 200 (empty, saved).
- **nexus-84gbt** — `nx catalog setup` chash backfill reached into `t3._client`; service-mode `t3` is an `HttpVectorClient` (no `_client`) → `AttributeError`. Guarded behind `is_service_backed(t3)` (handle-based, the documented preference). *Fixes the catalog-setup AttributeError only — not the manifest-empty symptom; see nexus-7y0ab below.*
- **nexus-p0clh** — `nx doctor --check-schema` reports **N/A in service mode** (Postgres/Liquibase-managed) instead of the misleading "T2 database not found".
- **nexus-i6p73** (closed not-a-bug) — the cross-model migration catalog-cascade 404 is **fail-open by design** (catalog is a derived view, repairable via `nx catalog rebuild`); added that remedy to the warn so it doesn't read as data loss.
- **nexus-v0zmv** — `migration-rehearsal --guided` stamped a stale `0.1.6` below the bumped version-pin floor `REQUIRED_RELEASE_VERSION=(0,1,8)`, so the guided MVV fail-closed without ever exercising the migration. Now **derives the stamp from the product constant**; `COLD_TAG` bumped to match.

## Test-gap closers
- Empty-project HTTP integration roundtrip (the test that should have caught nexus-82ihm).
- `PlanHandlerTest` added to the integration-stack Java gate.

## Validation
- Unit: **11158 passed** (+4 new), ruff clean.
- Integration-stack: **174 Python + 166 Java**, 0 failures.
- migration-rehearsal **default**: SOUP-TO-NUTS PASSED (cross-model parity exact, rollback-safe).
- migration-rehearsal **--guided**: GUIDED-UPGRADE MVV PASSED (was failing pre-nexus-v0zmv): detect→provision→**version-pin pass**→migrate→unlock, parity exact, source intact.

## Follow-ups (NOT in this PR)
- **nexus-7y0ab (P1)** — systematic: `HttpCatalogClient` signature parity gaps vs the local catalog interface break service-mode `nx index repo` (Documents:0/manifest-empty; concrete TypeErrors in `collection_for` owner/owner_id and `all_documents` content_type). Invisible to the 173 integration tests (they call the client's own signature, not the caller contract). Needs an interface-conformance test + 94-method audit — its own arc.
- **nexus-c9k22 (P3)** — audit the `requireParam`-rejects-blank pattern (MemoryHandler), not broken today.
- Observability RDR (X-Request-ID cross-tier correlation) — separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)