### PR TITLE
test(e2e): fix migration-rehearsal cloud + catalog-cascade fidelity (nexus-pi3s3, nexus-qeoxf)

### DIFF
--- a/tests/e2e/migration-rehearsal/rehearse.sh
+++ b/tests/e2e/migration-rehearsal/rehearse.sh
@@ -146,7 +146,11 @@ nx migrate-to-service --dry-run --local-path "$CHROMA_LOCAL" 2>&1 | sed 's/^/   
   && ok "dry-run classified the footprint" || bad "dry-run failed"
 
 note "nx migrate-to-service (detect → ETL → validate → unlock)…"
-if nx migrate-to-service --local-path "$CHROMA_LOCAL" 2>&1 | sed 's/^/       /'; then
+# --yes: skip the Voyage re-embed cost confirmation (nexus-cewad). Harmless on the
+# ONNX leg (nothing billed → no prompt); REQUIRED on --with-cloud where the
+# cross-model→voyage re-embed is billed and click.confirm aborts on the rehearsal's
+# non-interactive stream (else: empty pgvector target → parity MISMATCH).
+if nx migrate-to-service --local-path "$CHROMA_LOCAL" --yes 2>&1 | sed 's/^/       /'; then
   ok "migrate-to-service completed"
 else
   bad "migrate-to-service failed"

--- a/tests/e2e/migration-rehearsal/seed_legacy.py
+++ b/tests/e2e/migration-rehearsal/seed_legacy.py
@@ -150,6 +150,29 @@ def _seed_t2_and_catalog(collections: dict[str, list[str]]) -> dict[str, int]:
     owner = cat.register_owner(
         "rehearsal", "project", repo_hash="rehearsal01", repo_root=repo_root,
     )
+
+    # nexus-qeoxf: register EVERY seeded collection in catalog_collections
+    # (RDR-103, the collection-name authority), mirroring a real pre-cutover
+    # install. The cross-model migrate's reference cascade renames the collection
+    # via POST /v1/catalog/collections/rename, which the service 404s when the
+    # source is absent from catalog_collections (handleCollectionRename ->
+    # repo.collectionExists == false). A real RDR-103 user HAS these rows (the
+    # catalog ETL migrates the `collections` table), so the rehearsal must seed
+    # them too — else it injects a spurious non-fatal cascade 404 that does not
+    # occur in production. Includes _NOTE: sourceless as a DOCUMENT, but still a
+    # registered COLLECTION. Names are conformant 4-segment
+    # (<content_type>__<owner>__<model>__v<n>); supply the segments so they
+    # round-trip exactly.
+    for coll in collections:
+        seg = coll.split("__")
+        cat.register_collection(
+            coll,
+            content_type=seg[0],
+            owner_id=seg[1],
+            embedding_model=seg[2],
+            model_version=seg[3],
+        )
+
     docs = 0
     for coll, chashes in collections.items():
         # _NOTE is the SOURCELESS case: no catalog file document, only the

--- a/tests/e2e/migration-rehearsal/seed_legacy.py
+++ b/tests/e2e/migration-rehearsal/seed_legacy.py
@@ -36,7 +36,13 @@ from pathlib import Path
 import chromadb
 
 _MINILM = "knowledge__rehearsal__minilm-l6-v2-384__v1"
-_VOYAGE = "knowledge__rehearsal__voyage-context-3__v1"
+# nexus-pi3s3: the voyage source is a SAME-MODEL passthrough (copied byte-for-byte
+# into a voyage-mode service). Its name MUST NOT collide with the minilm→voyage
+# cross-model remap target: in voyage mode (--with-cloud, voyage_key_present) the
+# migrate re-embeds _MINILM (knowledge/voyage) into knowledge__rehearsal__voyage-
+# context-3__v1 (detection.cross_model_target_model). A distinct version segment
+# (__v2) keeps a single conformant owner ("rehearsal") while avoiding that clash.
+_VOYAGE = "knowledge__rehearsal__voyage-context-3__v2"
 # RDR-162 P2: a SOURCELESS store_put-style note — a minilm-384 collection with
 # NO backing source file (only a topic_assignment references it). embed_migrate
 # (re-reads source files) cannot upgrade it; the cross-model migrate re-embeds
@@ -44,18 +50,39 @@ _VOYAGE = "knowledge__rehearsal__voyage-context-3__v1"
 # case that motivated RDR-162.
 _NOTE = "knowledge__rehearsal-note__minilm-l6-v2-384__v1"
 
-# The bge-768 targets the cross-model migrate re-embeds the minilm sources into
-# (mirrors vector_etl.cross_model_target_name: only the model segment swaps).
-_MINILM_TARGET = "knowledge__rehearsal__bge-base-en-v15-768__v1"
-_NOTE_TARGET = "knowledge__rehearsal-note__bge-base-en-v15-768__v1"
+# The model the cross-model migrate re-embeds the minilm sources into. This is
+# MODE-AWARE (nexus-pi3s3, mirrors detection.cross_model_target_model): a voyage-
+# mode service (--with-cloud, voyage_key_present) re-embeds knowledge collections
+# into voyage-context-3; a local bge-768 service re-embeds into bge-base-en-v15-768.
+# A stale unconditional bge-768 here made the voyage-mode parity assert the wrong
+# target collection (service=0 [MISMATCH] false negative).
+_BGE_MODEL = "bge-base-en-v15-768"
+_VOYAGE_CTX_MODEL = "voyage-context-3"  # knowledge content-type → voyage-context-3
+
+
+def _remap_model(source: str, model: str) -> str:
+    """Swap the model segment of a conformant 4-segment collection name."""
+    seg = source.split("__")
+    seg[2] = model
+    return "__".join(seg)
 
 
 def _chash(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()[:32]
 
 
-def _seed(client, name: str, n: int, *, prefix: str) -> list[str]:
-    """Seed a legacy Chroma collection; return the chunk chashes (ids)."""
+def _seed(client, name: str, n: int, *, prefix: str, dim: int = 2) -> list[str]:
+    """Seed a legacy Chroma collection; return the chunk chashes (ids).
+
+    ``dim`` (nexus-pi3s3): the CROSS-MODEL re-embed legs (minilm→bge/voyage) never
+    read the source vector — the ETL re-embeds the documents server-side — so a
+    nonsensical 2-dim stub suffices (matches the repo's ETL fixtures). The
+    SAME-MODEL voyage passthrough is different: it COPIES the stored vector
+    byte-for-byte into chunks_1024, so its source vectors must be the real
+    dimension (1024) or the service's RDR-156 schema guard rejects the upsert
+    ("embedder produced a 2-dim vector ... dispatches to chunks_1024"). Values are
+    irrelevant (parity asserts COUNT, not similarity) — only the dim matters.
+    """
     texts = [f"{prefix} {i:04d}" for i in range(n)]
     ids = [_chash(t) for t in texts]
     col = client.get_or_create_collection(name)
@@ -63,10 +90,7 @@ def _seed(client, name: str, n: int, *, prefix: str) -> list[str]:
         ids=ids,
         documents=texts,
         metadatas=[{"position": i, "tag": "rehearsal"} for i in range(n)],
-        # Source vectors are never read by the ETL (it re-embeds the documents
-        # server-side); dim is deliberately nonsensical, matching the repo's
-        # ETL fixtures.
-        embeddings=[[float(i), 1.0] for i in range(n)],
+        embeddings=[[float(i)] + [1.0] * (dim - 1) for i in range(n)],
     )
     return ids
 
@@ -166,13 +190,22 @@ def main() -> int:
     chashes[_MINILM] = _seed(client, _MINILM, n, prefix="onnx chunk")
     chashes[_NOTE] = _seed(client, _NOTE, n, prefix="note chunk")
     if with_cloud:
-        chashes[_VOYAGE] = _seed(client, _VOYAGE, n, prefix="voyage chunk")
+        # 1024-dim source vectors: the voyage same-model passthrough COPIES them
+        # (no re-embed) into chunks_1024 (nexus-pi3s3).
+        chashes[_VOYAGE] = _seed(client, _VOYAGE, n, prefix="voyage chunk", dim=1024)
     t2 = _seed_t2_and_catalog(chashes)
     seeded = {name: len(ids) for name, ids in chashes.items()}
-    # cross_model: source -> bge-768 target the migrate re-embeds into. The
-    # voyage leg (when present) migrates byte-for-byte (servable with a key), so
-    # it is NOT remapped and is absent from this map.
-    cross_model = {_MINILM: _MINILM_TARGET, _NOTE: _NOTE_TARGET}
+    # cross_model: source -> the target the migrate re-embeds into, MODE-AWARE
+    # (nexus-pi3s3). voyage_key_present (== with_cloud here) decides the target
+    # model exactly as detection.cross_model_target_model does: voyage-context-3
+    # in voyage mode, bge-768 in local mode. The voyage source itself is a
+    # SAME-MODEL passthrough (NOT remapped) so it is absent from this map; the
+    # parity check then verifies it under its own name (cross.get(name, name)).
+    _tgt_model = _VOYAGE_CTX_MODEL if with_cloud else _BGE_MODEL
+    cross_model = {
+        _MINILM: _remap_model(_MINILM, _tgt_model),
+        _NOTE: _remap_model(_NOTE, _tgt_model),
+    }
     print(json.dumps({"collections": seeded, "cross_model": cross_model, **t2}))
     return 0
 


### PR DESCRIPTION
## What

Two **test-harness fidelity** fixes to `migration-rehearsal`. The product behaved correctly throughout both — every engine guard (RDR-156 dim rejection, partial-leg refusal, RDR-162/gilf2 mode-aware targets, nexus-hz785 rename fail-loud, rollback-safety) fired by design. Found during a 5x5 isolated rehearsal (green→local, local→local, cloud→cloud).

### nexus-pi3s3 — `--with-cloud` (cloud→cloud) leg failed
1. **`rehearse.sh`** — pass `--yes` to `nx migrate-to-service` (the billed Voyage re-embed cost prompt aborts on the non-interactive stream). Harmless on ONNX legs.
2. **`seed_legacy.py`** — voyage same-model passthrough copies the stored vector into `chunks_1024`, but the fixture seeded 2-dim stubs → RDR-156 guard correctly rejected (HTTP 400). Add a `dim` param; seed voyage at 1024-dim.
3. **`seed_legacy.py`** — parity `cross_model` map hardcoded `bge-768`, but voyage mode re-embeds knowledge → `voyage-context-3` (gilf2) → false MISMATCH. Made mode-aware; renamed the voyage source to `__v2` to avoid colliding with the `minilm→voyage-context-3__v1` remap target.

### nexus-qeoxf — spurious catalog-cascade 404 on every leg
The cross-model migrate's reference cascade renames the collection via `POST /v1/catalog/collections/rename`; the service 404s when the source is absent from `catalog_collections` (`repo.collectionExists == false`, the nexus-hz785 fail-loud). A real RDR-103 user has those rows and the catalog ETL migrates the `collections` table → no 404 in production. The seed registered catalog *documents* but never *collections*, manufacturing a 404 that doesn't occur for real users. Fix: register every seeded collection via `cat.register_collection`.

## Verification

- `run.sh --with-cloud` → `SOUP-TO-NUTS REHEARSAL PASSED`, 3/3 migrated, all parity `[ok]`.
- `run.sh --no-build` (ONNX, exercises the cross-model rename cascade) → PASSED, catalog-cascade 404 + "run nx catalog rebuild" advisory both GONE.

Cold/guided (ONNX) legs unchanged where applicable (`with_cloud=False` path byte-identical).

Closes nexus-pi3s3
Closes nexus-qeoxf