### PR TITLE
ci(nexus-h29w1): provision bge-768 ONNX in write-seam gate (fix red develop CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,6 +627,35 @@ jobs:
         working-directory: service
         run: ./mvnw -q package -DskipTests
 
+      - name: Cache bge-768 ONNX model
+        # nexus-h29w1: the JAR boots its local ONNX embedder at startup
+        # (RDR-160 = bge-768). Without the model the service never finishes
+        # booting and never binds its port → the gate timed out ("port not
+        # reachable after 90s"). service-ci.yml + engine-release.yml provision
+        # this same model; the write-seam gate must too. STABLE key (immutable
+        # upstream export) — one cold download, restored thereafter.
+        if: steps.changes.outputs.seam == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        with:
+          path: ~/.cache/nexus/onnx_models/bge-base-en-v1.5
+          key: bge-onnx-standard-${{ runner.os }}-v1
+
+      - name: Prime bge-768 ONNX on cache miss
+        if: steps.changes.outputs.seam == 'true'
+        run: |
+          MODEL_DIR="$HOME/.cache/nexus/onnx_models/bge-base-en-v1.5/onnx"
+          if [ ! -f "$MODEL_DIR/model.onnx" ]; then
+            echo "bge ONNX not in cache; downloading the standard fp32 export (~416MB)."
+            mkdir -p "$MODEL_DIR"
+            curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/onnx/model.onnx \
+              -o "$MODEL_DIR/model.onnx"
+            curl -fsSL https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/tokenizer.json \
+              -o "$MODEL_DIR/tokenizer.json"
+            test -f "$MODEL_DIR/model.onnx" || { echo "bge model.onnx missing after download"; exit 1; }
+          else
+            echo "bge ONNX restored from cache."
+          fi
+
       - name: Run write-seam gate (>300-record, dup-chash, ON CONFLICT, NUL-sanitize)
         if: steps.changes.outputs.seam == 'true'
         env:

--- a/tests/db/test_write_seam_gate_integration.py
+++ b/tests/db/test_write_seam_gate_integration.py
@@ -291,8 +291,8 @@ def local_service(pg_instance: dict):
 # ── Integration tests ─────────────────────────────────────────────────────────
 
 
-# Collection uses minilm-l6-v2-384 (the ONNX local embedder) — same as seam_b.
-_COLLECTION = "knowledge__seam-gate-dedup__minilm-l6-v2-384__v1"
+# Collection uses bge-base-en-v15-768 (the ONNX local embedder) — same as seam_b.
+_COLLECTION = "knowledge__seam-gate-dedup__bge-base-en-v15-768__v1"
 
 
 def _make_chunks(n: int, prefix: str = "chunk") -> tuple[list[str], list[str]]:
@@ -384,7 +384,7 @@ def test_duplicate_chash_dedup_collapse(
     assert len(dup_ids) == 50
     assert len(set(dup_ids)) == 10
 
-    coll = "knowledge__seam-gate-dedup2__minilm-l6-v2-384__v1"
+    coll = "knowledge__seam-gate-dedup2__bge-base-en-v15-768__v1"
 
     # Server must not error on duplicate chash ids in one batch
     client.upsert_chunks(coll, dup_ids, dup_docs)
@@ -422,7 +422,7 @@ def test_on_conflict_idempotency(
     reset_http_vector_client_for_tests()
 
     client = get_http_vector_client()
-    coll = "knowledge__seam-gate-conflict__minilm-l6-v2-384__v1"
+    coll = "knowledge__seam-gate-conflict__bge-base-en-v15-768__v1"
 
     # First upsert
     ids, docs = _make_chunks(5, prefix="conflict_gate")
@@ -499,7 +499,7 @@ def test_nul_bytes_sanitized_server_side(
     reset_http_vector_client_for_tests()
 
     client = get_http_vector_client()
-    coll = "knowledge__seam-gate-nul__minilm-l6-v2-384__v1"
+    coll = "knowledge__seam-gate-nul__bge-base-en-v15-768__v1"
 
     nul_text = "seam_gate_nul\x00\x00payload\x00tail"
     clean_text = "seam_gate_nulpayloadtail"


### PR DESCRIPTION
## What

Fixes the red `write-seam behavioural gate (nexus-h29w1)` job on develop CI.

## Root cause

The gate boots the service JAR in local/ONNX mode, so the service loads its **bge-768 ONNX embedder** (RDR-160) at startup. The job only provisioned the *chromadb MiniLM* model (`~/.cache/chroma`), never the service's bge-768 (`~/.cache/nexus/onnx_models/bge-base-en-v1.5`). With no model, the embedder init never completes, the service never binds its port, and the gate times out: `port not reachable after 90s`, 4 errors — on every develop push since the gate was added (~2026-06-26).

`service-ci.yml` (lines 71-91) and `engine-release.yml` already provision this exact model; this PR mirrors their cache + prime steps into the write-seam-gate job.

## Why it was green on PRs but red on develop

On PRs with no seam-path change the gate *skips* (≈9s, no JAR built) and reports green; the develop-push job builds the JAR and actually runs it → fails. This PR touches `.github/workflows/ci.yml`, which is in the gate's seam-path filter, so the gate **runs on this PR** and self-validates the fix.

## Follow-up (flagged, not in this PR)

Possible secondary: the test collection is `…minilm-l6-v2-384…` vs the post-RDR-160 bge-768 service embedder — once the service boots, that may trip the RDR-109/pebfx.2 model-identity guard. This PR's gate run will reveal it; if it surfaces, a follow-up aligns the collection/embedder.