### PR TITLE
fix(mcp): store_put forwards catalog tumbler as aspect-enqueue doc_id (RDR-172 P1.1)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -2060,12 +2060,25 @@ def store_put(
         # store_put is `def`, not `async def`, so no await/to_thread).
         # content is the full document text already in scope; pass it
         # through literally per the P0.1 content-sourcing contract.
-        # source_path is doc_id here — there is no on-disk file at the
-        # MCP boundary, so the doc_id serves as the stable identifier
-        # the hook uses for failure attribution.
-        # nexus-tdgc: forward doc_id explicitly so the aspect-queue
-        # hook can store it on the queue row alongside source_path.
-        _hooks.fire_document(doc_id, col_name, content, doc_id=doc_id)
+        # source_path (1st positional) is the chunk natural-id here — there
+        # is no on-disk file at the MCP boundary, so it serves as the stable
+        # per-doc queue key + the identifier the hook uses for failure
+        # attribution. It is NOT foreign-keyed (RDR-156 fk-001: aspect_
+        # extraction_queue.source_path is a storage path, not a tumbler).
+        # nexus-tdgc: forward an explicit doc_id so the aspect-queue hook can
+        # stamp it on the queue row.
+        # RDR-172 / nexus-pyn35 (closes nexus-ov0sw): the queue row's doc_id
+        # carries a composite FK -> catalog_documents(tumbler) (RDR-156
+        # fk-001), so it MUST be the catalog tumbler (catalog_doc_id), NOT
+        # the t3.put chunk natural-id (sha256(content)[:32]) — a chunk hash
+        # is never a tumbler and 500s the service enqueue, which the best-
+        # effort hook then swallows (silent, total loss of RDR-089 aspects in
+        # service mode). When no tumbler was minted, catalog_doc_id is '' —
+        # the blank sentinel the service NULL-coerces (nullIfBlank), which
+        # satisfies the FK and still extracts from the queued content. This
+        # matches every other fire_document caller (doc_indexer, pipeline_
+        # stages, code_indexer, prose_indexer), which all pass catalog_doc_id.
+        _hooks.fire_document(doc_id, col_name, content, doc_id=catalog_doc_id)
         # RDR-061 E2: log relevance correlation for the most recent search in
         # this session. Only the newest trace is used to minimize noise —
         # older traces are unlikely to have driven this store_put.

--- a/tests/test_mcp_store_put_doc_id.py
+++ b/tests/test_mcp_store_put_doc_id.py
@@ -219,7 +219,23 @@ def test_mcp_store_put_forwards_blank_doc_id_when_no_catalog(
     ) -> None:
         captured["doc_id"] = doc_id
 
-    with patch("nexus.mcp.core._get_t3", return_value=local_t3), \
+    # Spy on the real hook so we can distinguish the LEGITIMATE no-catalog
+    # return ('' because Catalog.is_initialized is False) from a swallowed
+    # exception that would ALSO leave catalog_doc_id='' (substantive-critic
+    # finding): both forward doc_id='', so without this spy a future refactor
+    # that broke the hook would pass vacuously.
+    from nexus.catalog.store_hook import catalog_store_hook as _real_hook
+    spy: dict[str, object] = {}
+
+    def _spy_hook(*a, **k):
+        rv = _real_hook(*a, **k)
+        spy["calls"] = spy.get("calls", 0) + 1  # type: ignore[operator]
+        spy["ret"] = rv
+        return rv
+
+    with patch("nexus.catalog.store_hook.catalog_store_hook",
+               side_effect=_spy_hook), \
+         patch("nexus.mcp.core._get_t3", return_value=local_t3), \
          patch("nexus.mcp.core._hooks.fire_single", side_effect=_no_op), \
          patch("nexus.mcp.core._hooks.fire_batch", side_effect=_no_op), \
          patch("nexus.mcp.core._hooks.fire_document",
@@ -233,6 +249,13 @@ def test_mcp_store_put_forwards_blank_doc_id_when_no_catalog(
         )
     assert "Stored" in result, f"store_put failed: {result}"
 
+    # The hook actually RAN and RETURNED '' — this is the no-catalog path,
+    # not a never-called or raised path that defaulted to '' by accident.
+    assert spy.get("calls") == 1, "catalog_store_hook must actually run once"
+    assert spy.get("ret") == "", (
+        f"hook must return '' on the no-catalog path, got {spy.get('ret')!r}"
+    )
+
     chunk_id = hashlib.sha256(content.encode()).hexdigest()[:32]
     assert captured.get("doc_id") == "", (
         "no-catalog path must forward an empty doc_id (the blank->NULL "
@@ -240,6 +263,60 @@ def test_mcp_store_put_forwards_blank_doc_id_when_no_catalog(
     )
     assert captured.get("doc_id") != chunk_id, (
         "must not fall back to the chunk natural-id when no tumbler exists"
+    )
+
+
+def test_mcp_store_put_forwards_blank_doc_id_when_catalog_hook_raises(
+    inject_local_t3: T3Database,
+    catalog_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RDR-172 / nexus-pyn35: when ``catalog_store_hook`` RAISES (the
+    best-effort boundary catch in store_put), ``catalog_doc_id`` stays the
+    pre-initialized '' and store_put forwards ``doc_id=''`` — never the
+    chunk natural-id, never a crash. Distinct from the no-catalog path
+    (LOW-2 / substantive-critic Significant: the swallow must degrade to
+    the blank sentinel, which the service NULL-coerces).
+    """
+    import hashlib
+
+    from nexus.mcp.core import store_put
+    local_t3 = inject_local_t3
+
+    content = "# Hook-raises finding\n\nThe catalog hook will blow up."
+    captured: dict[str, str] = {}
+
+    def _capture_fire_document(
+        source_path: str, collection: str, doc_content: str,
+        *, doc_id: str = "", **_kw,
+    ) -> None:
+        captured["doc_id"] = doc_id
+
+    with patch("nexus.catalog.store_hook.catalog_store_hook",
+               side_effect=RuntimeError("catalog boom")), \
+         patch("nexus.mcp.core._get_t3", return_value=local_t3), \
+         patch("nexus.mcp.core._hooks.fire_single", side_effect=_no_op), \
+         patch("nexus.mcp.core._hooks.fire_batch", side_effect=_no_op), \
+         patch("nexus.mcp.core._hooks.fire_document",
+               side_effect=_capture_fire_document), \
+         patch("nexus.mcp.core._catalog_auto_link", return_value=0):
+        result = store_put(
+            content=content,
+            collection="knowledge",
+            title="pyn35-hook-raises",
+            tags="test",
+        )
+    assert "Stored" in result, (
+        f"store_put must not crash when catalog_store_hook raises: {result}"
+    )
+
+    chunk_id = hashlib.sha256(content.encode()).hexdigest()[:32]
+    assert captured.get("doc_id") == "", (
+        "swallowed catalog_store_hook exception must degrade to doc_id='' "
+        f"(blank->NULL sentinel), got {captured.get('doc_id')!r}"
+    )
+    assert captured.get("doc_id") != chunk_id, (
+        "must not fall back to the chunk natural-id on hook failure"
     )
 
 

--- a/tests/test_mcp_store_put_doc_id.py
+++ b/tests/test_mcp_store_put_doc_id.py
@@ -126,6 +126,123 @@ def test_mcp_store_put_writes_catalog_doc_id_into_t3_chunk_metadata(
     assert expected_doc_id, "expected catalog tumbler for the mcp-stored doc"
 
 
+def test_mcp_store_put_forwards_catalog_tumbler_as_fire_document_doc_id(
+    inject_local_t3: T3Database,
+    catalog_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RDR-172 / nexus-pyn35 (closes nexus-ov0sw): MCP ``store_put`` must
+    forward the catalog tumbler (``catalog_doc_id``) as ``fire_document``'s
+    ``doc_id`` kwarg — the value the aspect-queue row stamps and the
+    RDR-156 FK ``aspect_extraction_queue.doc_id -> catalog_documents``
+    checks. Pre-fix it forwarded the ``t3.put`` chunk natural-id
+    (``sha256(content)[:32]``, never a tumbler), which 500s the service
+    enqueue while the best-effort hook swallows it — silent, total loss of
+    RDR-089 aspects in service mode.
+    """
+    import hashlib
+
+    from nexus.mcp.core import store_put
+    local_t3 = inject_local_t3
+
+    content = "# Paper: BFT consensus\n\nIntroduces a new approach to consensus."
+    captured: dict[str, str] = {}
+
+    def _capture_fire_document(
+        source_path: str, collection: str, doc_content: str,
+        *, doc_id: str = "", **_kw,
+    ) -> None:
+        captured["source_path"] = source_path
+        captured["doc_id"] = doc_id
+
+    with patch("nexus.mcp.core._get_t3", return_value=local_t3), \
+         patch("nexus.mcp.core._hooks.fire_single", side_effect=_no_op), \
+         patch("nexus.mcp.core._hooks.fire_batch", side_effect=_no_op), \
+         patch("nexus.mcp.core._hooks.fire_document",
+               side_effect=_capture_fire_document), \
+         patch("nexus.mcp.core._catalog_auto_link", return_value=0):
+        result = store_put(
+            content=content,
+            collection="knowledge",
+            title="pyn35-tumbler-forward",
+            tags="rdr-172,test",
+        )
+    assert "Stored" in result, f"store_put failed: {result}"
+
+    # The catalog tumbler the store hook minted for this doc.
+    cat = Catalog(catalog_env, catalog_env / ".catalog.db")
+    rows = cat._db.execute(
+        "SELECT tumbler FROM documents WHERE title = 'pyn35-tumbler-forward'"
+    ).fetchall()
+    assert rows, "expected a catalog entry for the mcp-stored doc"
+    expected_tumbler = rows[0][0]
+    assert expected_tumbler, "expected a non-empty catalog tumbler"
+
+    # The t3.put chunk natural-id — the value the pre-fix code (wrongly)
+    # forwarded; it can never satisfy the doc_id -> catalog_documents FK.
+    chunk_id = hashlib.sha256(content.encode()).hexdigest()[:32]
+
+    assert captured.get("doc_id") == expected_tumbler, (
+        "store_put must forward the catalog tumbler as fire_document's "
+        f"doc_id kwarg; got {captured.get('doc_id')!r}, expected the tumbler "
+        f"{expected_tumbler!r}"
+    )
+    assert captured["doc_id"] != chunk_id, (
+        "regression guard (nexus-ov0sw): forwarding the t3.put chunk "
+        "natural-id as doc_id violates the RDR-156 FK and 500s the enqueue"
+    )
+
+
+def test_mcp_store_put_forwards_blank_doc_id_when_no_catalog(
+    inject_local_t3: T3Database,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RDR-172 / nexus-pyn35: when no catalog tumbler was minted, store_put
+    forwards ``doc_id=''`` — the blank sentinel the service NULL-coerces
+    (``nullIfBlank``), which satisfies the FK and still extracts from the
+    queued content. It must NOT fall back to the chunk natural-id.
+    """
+    import hashlib
+
+    from nexus.mcp.core import store_put
+    local_t3 = inject_local_t3
+
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "no-catalog"))
+
+    content = "# No-catalog finding\n\nNo tumbler should be minted here."
+    captured: dict[str, str] = {}
+
+    def _capture_fire_document(
+        source_path: str, collection: str, doc_content: str,
+        *, doc_id: str = "", **_kw,
+    ) -> None:
+        captured["doc_id"] = doc_id
+
+    with patch("nexus.mcp.core._get_t3", return_value=local_t3), \
+         patch("nexus.mcp.core._hooks.fire_single", side_effect=_no_op), \
+         patch("nexus.mcp.core._hooks.fire_batch", side_effect=_no_op), \
+         patch("nexus.mcp.core._hooks.fire_document",
+               side_effect=_capture_fire_document), \
+         patch("nexus.mcp.core._catalog_auto_link", return_value=0):
+        result = store_put(
+            content=content,
+            collection="knowledge",
+            title="pyn35-no-catalog",
+            tags="test",
+        )
+    assert "Stored" in result, f"store_put failed: {result}"
+
+    chunk_id = hashlib.sha256(content.encode()).hexdigest()[:32]
+    assert captured.get("doc_id") == "", (
+        "no-catalog path must forward an empty doc_id (the blank->NULL "
+        f"sentinel), got {captured.get('doc_id')!r}"
+    )
+    assert captured.get("doc_id") != chunk_id, (
+        "must not fall back to the chunk natural-id when no tumbler exists"
+    )
+
+
 def test_mcp_store_put_doc_id_absent_when_catalog_uninitialized(
     inject_local_t3: T3Database,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Phase 1 of RDR-172 — the **client correctness fix** for `nexus-ov0sw` (P1): in 6.0.0 service mode every MCP `store_put` silently skips aspect enqueue.

`store_put` forwarded the `t3.put` chunk natural-id (`sha256(content)[:32]`) as `fire_document`'s `doc_id` kwarg. The service `aspect_extraction_queue.doc_id` carries a composite FK → `catalog_documents(tumbler)` (RDR-156 `fk-001`); a chunk hash is never a tumbler, so the enqueue 500s and the best-effort hook swallows it → RDR-089 extraction inert for the store_put path, with no test or log surfacing it.

**Fix:** forward `catalog_doc_id` (the tumbler) instead — `''` when no tumbler was minted (the blank sentinel the service NULL-coerces, FK-satisfied, still extracts from queued content). This matches every other `fire_document` caller (`doc_indexer`, `pipeline_stages`, `code_indexer`, `prose_indexer`). `source_path` (1st positional) stays the chunk id — it is not FK'd.

Per RF-8 (gate-verified: catalog row eager-commits before the enqueue, no visibility race) this client fix is **correctness-complete for `nexus-ov0sw` with no engine cut**. The server typed-4xx hardening (Phase 3) and the loudness tripwire (Phase 2) are separate beads.

## Tests (TDD)

`tests/test_mcp_store_put_doc_id.py` — written red-first, confirmed failing on the pre-fix chunk-hash forwarding:
- forwards the catalog tumbler as `doc_id` (exact `==`, + regression guard `!=` chunk id)
- `doc_id=''` on the no-catalog path (spies the real hook to prove it ran and returned `''`, not a swallowed-exception false-green)
- `catalog_store_hook` raising degrades to `doc_id=''` (no crash, no chunk-id fallback)

111 pass across `test_aspect_worker` + `test_mcp_server` + `test_mcp_store_put_doc_id` + `test_phase3_structured_chash`; no regressions.

## Review

Stacked review (RDR-172 P1.2 / `nexus-vj81r`): code-review-expert APPROVE (0 Critical/High); substantive-critic — 1 Significant (no-catalog vs swallowed-exception ambiguity) resolved by the test hardening in this PR.

Beads: `nexus-pyn35` (impl), `nexus-vj81r` (review). Bug: `nexus-ov0sw`. RDR: `docs/rdr/rdr-172-service-mode-aspect-enqueue-silent-failure.md`.