### PR TITLE
fix(aspects): RDR-145 Phase 1 — Gap-3 routing regression test + Gap-2 source_path canonicalization

### DIFF
--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import os
 import random
+import re
 import threading
 import time
 from pathlib import Path
@@ -1014,6 +1015,104 @@ def drain_worker(
 # ── Hook function (wired by hook_registry.install_default_hooks) ────────────
 
 
+#: A 32-char lowercase-hex chunk hash (the Chroma natural id). Note-backed
+#: aspect rows carry this as ``source_path`` by design (RDR-172 owns note
+#: identity via ``doc_id``); it is NOT a filesystem path, so Gap-2
+#: canonicalization skips it.
+_CHASH_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+def _resolve_catalog_reader():
+    """Return a best-effort read catalog (or ``None``). Indirection seam so
+    tests can inject a real tmp ``Catalog`` without env/service-mode coupling.
+    """
+    from nexus.catalog.factory import make_catalog_reader  # noqa: PLC0415 — deferred to avoid circular import (catalog.factory)
+    return make_catalog_reader()
+
+
+def _canonicalize_source_path(collection: str, source_path: str) -> str:
+    """RDR-145 Gap-2: forward-only ``source_path`` canonicalization.
+
+    Resolves ``source_path`` against the catalog for ``collection``. On a
+    hit whose stored ``file_path`` is a *relative* form that differs, returns
+    that canonical relative path; on a miss, returns ``source_path`` unchanged
+    and emits a loud ``aspect_source_path_uncanonical`` warning. It NEVER
+    synthesizes or guesses a path — doing so would re-introduce the
+    ``nexus-3e4s`` CWD-anchoring contamination class. Best-effort and
+    fail-open: any catalog unavailability degrades to a no-op (the document
+    still enqueues; the one-time cleanup, RDR-145 Phase 2, handles legacy
+    rows).
+
+    Only file-backed (path-shaped) ``source_path`` values are considered.
+    Note-backed rows carry a 32-hex chash with no path separator and are
+    returned untouched so the probe never false-warns on a correct chash.
+
+    Reachability of the normalize branch (important — do not oversell this):
+    the catalog probe matches ``physical_collection AND (file_path = source_path
+    OR title = source_path)``. The documented contamination population
+    (RDR-145 Bucket B: ~177 absolute paths that MISMATCH the catalog's stored
+    *relative* ``file_path``) therefore MISSES the probe and lands in the WARN
+    branch — the loud ``aspect_source_path_uncanonical`` tripwire is the real
+    forward-only output for that population, not in-flight rewriting. The
+    normalize branch fires only when ``source_path`` already equals a stored
+    ``file_path``/``title``; correcting those Bucket-B rows is Phase 2's
+    one-time migration cleanup (``nexus-nx9nx``, migration-gated), not this
+    hook. In service mode the catalog reads are HTTP point-queries bounded by
+    the client's 30s timeout and fail-open; batch CLI ingest latency is a
+    tracked follow-up, not a regression.
+    """
+    # Skip note-backed (chash) and any non-path-shaped identifier (e.g. a
+    # bare slug/title) — there is nothing to canonicalize and no contamination
+    # risk for these by design.
+    if _CHASH_RE.match(source_path) or (
+        "/" not in source_path and os.sep not in source_path
+    ):
+        return source_path
+    try:
+        cat = _resolve_catalog_reader()
+    except Exception:  # noqa: BLE001 — best-effort catalog reader; any init failure degrades to no-op
+        cat = None
+    if cat is None:
+        # No catalog to canonicalize against — forward-only defense is a
+        # no-op (do not warn: absence of a catalog is not an uncanonical path).
+        return source_path
+    try:
+        doc_id = cat.lookup_doc_id_by_collection_and_path(collection, source_path)
+    except Exception:  # noqa: BLE001 — best-effort resolve; any query error degrades to no-op
+        doc_id = ""
+    if not doc_id:
+        _log.warning(
+            "aspect_source_path_uncanonical",
+            collection=collection,
+            source_path=source_path,
+        )
+        return source_path
+    # ``lookup_doc_id_by_collection_and_path`` returns either a legacy
+    # ``metadata.doc_id`` or the catalog ``tumbler``; resolve the entry via
+    # whichever the catalog honours (``by_doc_id`` keys on doc_id only).
+    entry = None
+    for getter in ("by_doc_id", "resolve"):
+        fn = getattr(cat, getter, None)
+        if fn is None:
+            continue
+        try:
+            entry = fn(doc_id)
+        except Exception:  # noqa: BLE001 — best-effort entry read; try the next resolver
+            entry = None
+        if entry is not None:
+            break
+    canonical = (getattr(entry, "file_path", "") or "") if entry is not None else ""
+    if canonical and not os.path.isabs(canonical) and canonical != source_path:
+        _log.info(
+            "aspect_source_path_canonicalized",
+            collection=collection,
+            was=source_path,
+            now=canonical,
+        )
+        return canonical
+    return source_path
+
+
 def aspect_extraction_enqueue_hook(
     source_path: str,
     collection: str,
@@ -1052,6 +1151,9 @@ def aspect_extraction_enqueue_hook(
     from nexus.aspect_extractor import select_config  # noqa: PLC0415 — deferred to avoid circular import (aspect_extractor)
     if select_config(collection) is None:
         return  # No extractor for this collection — nothing to enqueue.
+    # RDR-145 Gap-2: canonicalize a file-backed source_path against the
+    # catalog before persisting the queue row (forward-only; never guesses).
+    source_path = _canonicalize_source_path(collection, source_path)
     from nexus.mcp_infra import t2_index_write  # noqa: PLC0415 — deferred to avoid circular import (mcp_infra)
     try:
         # RDR-128 P1 (kg8sj): route the enqueue through the daemon so the

--- a/tests/test_aspect_extractor.py
+++ b/tests/test_aspect_extractor.py
@@ -1442,3 +1442,100 @@ class TestDocumentShapeClassifier:
         assert rec.extractor_name == "general-prose-v1"
         assert rec.experimental_datasets == []
         assert rec.experimental_baselines == []
+
+
+class TestGap3KnowledgeNoteRouting:
+    """RDR-145 Phase 1 (P1.1, nexus-3g0l4): regression test pinning the
+    shipped nexus-kmbys shape-aware routing for the ``knowledge__knowledge``
+    collection — the exact locus of the aspect-orphan bug (nexus-pfzgb).
+
+    MCP-stored notes (``store_put`` with no explicit collection) land in
+    ``knowledge__knowledge``. Before nexus-kmbys these prose notes routed to
+    ``scholarly-paper-v1``, whose prompt invites the model to invent
+    datasets/baselines/venue — the fabrication this fix removed. These tests
+    are the machine-checkable form of "non-fabricated": a representative note
+    must route to ``general-prose-v1`` (NOT ``scholarly-paper-v1``) and the
+    resulting aspect must carry empty experimental fields.
+
+    Note: ``general-prose-v1`` enforces non-fabrication via *routing* (its
+    prose prompt declares datasets/baselines ALWAYS ``[]``), not by stripping
+    values in ``_build_record`` — so the discriminating, non-vacuous assertion
+    is the routing decision plus the prose prompt being the one invoked.
+    """
+
+    #: A representative MCP-stored knowledge note: prose, no paper structure.
+    _NOTE = (
+        "# Session note: plan-match thresholds\n\n"
+        "We settled on a 0.40 confidence floor for the plan-match gate. "
+        "This is a working note captured during a session, not a published "
+        "result. It records a decision, nothing more.\n"
+    )
+
+    def test_knowledge_note_routes_to_general_prose(self):
+        """``knowledge__knowledge`` prose note resolves to general-prose-v1,
+        never scholarly-paper-v1 (the fabricating extractor)."""
+        from nexus.aspect_extractor import (
+            _GENERAL_PROSE_CONFIG,
+            _SCHOLARLY_PAPER_CONFIG,
+            _resolve_config_for_document,
+            select_config,
+        )
+
+        base = select_config("knowledge__knowledge")
+        assert base is _SCHOLARLY_PAPER_CONFIG  # prefix selection unchanged
+        chosen = _resolve_config_for_document(
+            "knowledge__knowledge", self._NOTE, base,
+        )
+        assert chosen is _GENERAL_PROSE_CONFIG
+        assert chosen is not _SCHOLARLY_PAPER_CONFIG
+
+    def test_general_prose_config_does_not_require_experimental_fields(self):
+        """Schema contract: general-prose-v1 requires ONLY the two prose
+        fields, so a prose note never spuriously null-fields for missing
+        datasets/baselines/results."""
+        from nexus.aspect_extractor import _GENERAL_PROSE_CONFIG
+
+        assert _GENERAL_PROSE_CONFIG.required_fields == (
+            "problem_formulation",
+            "proposed_method",
+        )
+        assert "experimental_datasets" not in _GENERAL_PROSE_CONFIG.required_fields
+        assert "experimental_baselines" not in _GENERAL_PROSE_CONFIG.required_fields
+        assert "experimental_results" not in _GENERAL_PROSE_CONFIG.required_fields
+
+    def test_knowledge_note_aspect_has_empty_experimental_fields(self, monkeypatch):
+        """End-to-end: a ``knowledge__knowledge`` note runs through the
+        general-prose prompt and the row carries empty experimental fields.
+
+        Non-vacuity: the fixture ASSERTS the prose prompt was invoked (the
+        prompt that instructs datasets/baselines ``[]``) before returning the
+        prose-contract payload — so the empty fields are tied to the routing
+        under test, not merely echoed."""
+        import subprocess as _sp
+        from nexus.aspect_extractor import extract_aspects
+
+        def fake_run(args, **kwargs):
+            prompt = kwargs.get("input", "")
+            assert "NOT a" in prompt and "scholarly paper" in prompt, (
+                "knowledge__knowledge prose note must use the general-prose prompt"
+            )
+            return _make_completed(_wrap_inner(json.dumps({
+                "problem_formulation": "What confidence floor for plan-match",
+                "proposed_method": "Use a 0.40 floor",
+                "experimental_datasets": [],
+                "experimental_baselines": [],
+                "experimental_results": "",
+                "extras": {},
+                "confidence": 0.6,
+            })))
+
+        monkeypatch.setattr(_sp, "run", fake_run)
+        rec = extract_aspects(
+            content=self._NOTE, source_path="my-note",
+            collection="knowledge__knowledge",
+        )
+        assert rec is not None
+        assert rec.extractor_name == "general-prose-v1"
+        assert rec.experimental_datasets == []
+        assert rec.experimental_baselines == []
+        assert rec.experimental_results in ("", None)

--- a/tests/test_aspect_worker.py
+++ b/tests/test_aspect_worker.py
@@ -500,6 +500,229 @@ class TestEnqueueHook:
             stop_worker(timeout=2.0)
 
 
+class TestGap2SourcePathNormalization:
+    """RDR-145 Phase 1 (P1.2, nexus-syga3): forward-only ``source_path``
+    canonicalization in ``aspect_extraction_enqueue_hook``.
+
+    The hook resolves a file-backed ``source_path`` against the catalog
+    BEFORE writing the queue row. On a hit whose stored ``file_path`` is a
+    cleaner relative form it canonicalizes; on a miss it leaves the path
+    AS-IS and emits a loud ``aspect_source_path_uncanonical`` warning (the
+    tripwire — it NEVER synthesizes a path, which would re-introduce the
+    ``nexus-3e4s`` CWD-anchoring class). Note-backed rows (``source_path``
+    is a 32-hex chash, not a filesystem path) are skipped entirely so the
+    probe never false-warns on a correct chash.
+
+    Forward-only: existing ``document_aspects`` rows are never touched (that
+    is the one-time migration cleanup, RDR-145 Phase 2 / ``nexus-nx9nx``).
+    """
+
+    @staticmethod
+    def _seed_catalog(
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        collection: str,
+        file_path: str,
+        title: str,
+    ) -> None:
+        """Build a real local catalog at a tmp dir, register one document,
+        and inject it into the hook via ``_resolve_catalog_reader``.
+
+        Injection (not env discovery) keeps the test hermetic and immune to
+        the ambient storage backend: ``make_catalog_reader()`` returns an HTTP
+        client to the live service whenever the shell is in service mode, so
+        env-seeding a tmp catalog would be silently ignored. The injected
+        object is a real :class:`Catalog`, so ``lookup_doc_id_by_collection_and_path``
+        and ``by_doc_id`` exercise production code, not a mock."""
+        import hashlib
+
+        import nexus.aspect_worker as mod
+        from nexus.catalog import Catalog
+
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        (cat_dir / "owners.jsonl").touch()
+        (cat_dir / "documents.jsonl").touch()
+        (cat_dir / "links.jsonl").touch()
+        repo_root = str(tmp_path / "repo")
+        (tmp_path / "repo").mkdir()
+        repo_hash = hashlib.sha256(repo_root.encode()).hexdigest()[:8]
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+        owner = cat.register_owner(
+            "seed-repo", "repo", repo_hash=repo_hash, repo_root=repo_root,
+        )
+        cat.register(
+            owner, title, content_type="paper",
+            file_path=file_path, physical_collection=collection,
+        )
+        monkeypatch.setattr(mod, "_resolve_catalog_reader", lambda: cat)
+
+    def test_resolving_absolute_path_normalizes_to_canonical_relative(
+        self, _isolate_t2: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A file-backed absolute ``source_path`` that resolves to a catalog
+        entry whose stored ``file_path`` is the relative canonical form is
+        normalized to that relative form before the queue row is written.
+
+        CONTRIVANCE NOTE: this registers the doc with ``title == abs_path`` so
+        the catalog probe hits on its ``title = ?`` leg. The REAL Bucket-B
+        contamination population does NOT have a title equal to its absolute
+        path, so in production those rows MISS the probe and land in
+        ``test_unresolved_path_left_as_is_and_warns`` (the warn branch is the
+        realistic representative). This test exists to exercise the normalize
+        branch through real Catalog/T2/SQL — it is a branch-coverage test, not
+        evidence that normalization fires on real ingest."""
+        import nexus.aspect_worker as mod
+        from nexus.aspect_worker import aspect_extraction_enqueue_hook
+
+        monkeypatch.setattr(mod, "ensure_worker_started", lambda: None)
+        abs_path = "/Users/somebody/git/nexus-clone/papers/foo.md"
+        self._seed_catalog(
+            tmp_path, monkeypatch,
+            collection="knowledge__delos",
+            file_path="papers/foo.md",  # catalog canonical (relative)
+            title=abs_path,             # contrived: resolver hits on title probe
+        )
+        aspect_extraction_enqueue_hook(
+            source_path=abs_path, collection="knowledge__delos", content="x",
+        )
+        with T2Database(_isolate_t2) as db:
+            rows = db.aspect_queue.list_pending()
+        assert len(rows) == 1
+        assert rows[0].source_path == "papers/foo.md"
+
+    def test_unresolved_path_left_as_is_and_warns(
+        self, _isolate_t2: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A file-backed ``source_path`` that does NOT resolve is left
+        unchanged and a loud ``aspect_source_path_uncanonical`` warning is
+        emitted (never silently rewritten to a guessed path)."""
+        from structlog.testing import capture_logs
+
+        import nexus.aspect_worker as mod
+        from nexus.aspect_worker import aspect_extraction_enqueue_hook
+
+        monkeypatch.setattr(mod, "ensure_worker_started", lambda: None)
+        self._seed_catalog(
+            tmp_path, monkeypatch,
+            collection="knowledge__delos",
+            file_path="papers/known.md",
+            title="papers/known.md",
+        )
+        stray = "/Users/nobody/git/nexus-ghost/papers/stray.md"
+        with capture_logs() as cap:
+            aspect_extraction_enqueue_hook(
+                source_path=stray, collection="knowledge__delos", content="x",
+            )
+        with T2Database(_isolate_t2) as db:
+            rows = db.aspect_queue.list_pending()
+        assert len(rows) == 1
+        assert rows[0].source_path == stray  # unchanged — never guessed
+        assert any(
+            e.get("event") == "aspect_source_path_uncanonical"
+            and e.get("source_path") == stray
+            and e.get("collection") == "knowledge__delos"
+            for e in cap
+        )
+
+    def test_note_backed_chash_source_path_untouched_no_warn(
+        self, _isolate_t2: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A note-backed row whose ``source_path`` is a 32-hex chash is left
+        unchanged with NO uncanonical warning — chashes are not filesystem
+        paths (RDR-172 owns note identity via ``doc_id``)."""
+        from structlog.testing import capture_logs
+
+        import nexus.aspect_worker as mod
+        from nexus.aspect_worker import aspect_extraction_enqueue_hook
+
+        monkeypatch.setattr(mod, "ensure_worker_started", lambda: None)
+        self._seed_catalog(
+            tmp_path, monkeypatch,
+            collection="knowledge__knowledge",
+            file_path="",  # note-backed: no file_path
+            title="A session note",
+        )
+        chash = "a" * 32
+        with capture_logs() as cap:
+            aspect_extraction_enqueue_hook(
+                source_path=chash, collection="knowledge__knowledge", content="x",
+            )
+        with T2Database(_isolate_t2) as db:
+            rows = db.aspect_queue.list_pending()
+        assert len(rows) == 1
+        assert rows[0].source_path == chash
+        assert not any(
+            e.get("event") == "aspect_source_path_uncanonical" for e in cap
+        )
+
+    def test_catalog_reader_unavailable_is_silent_noop(
+        self, _isolate_t2: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If the catalog reader cannot be built (raises), the hook degrades
+        to a no-op: source_path unchanged, NO uncanonical warning (absence of
+        a catalog is not an uncanonical path)."""
+        from structlog.testing import capture_logs
+
+        import nexus.aspect_worker as mod
+        from nexus.aspect_worker import aspect_extraction_enqueue_hook
+
+        monkeypatch.setattr(mod, "ensure_worker_started", lambda: None)
+
+        def _boom():
+            raise RuntimeError("catalog unavailable")
+
+        monkeypatch.setattr(mod, "_resolve_catalog_reader", _boom)
+        path = "/Users/x/git/repo/papers/foo.md"
+        with capture_logs() as cap:
+            aspect_extraction_enqueue_hook(
+                source_path=path, collection="knowledge__delos", content="x",
+            )
+        with T2Database(_isolate_t2) as db:
+            rows = db.aspect_queue.list_pending()
+        assert len(rows) == 1
+        assert rows[0].source_path == path
+        assert not any(
+            e.get("event") == "aspect_source_path_uncanonical" for e in cap
+        )
+
+    def test_resolved_but_canonical_is_absolute_left_as_is(
+        self, _isolate_t2: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A path that resolves but whose catalog file_path is itself absolute
+        is NOT normalized (we only canonicalize toward a relative form) — and
+        no uncanonical warning fires (it did resolve)."""
+        from structlog.testing import capture_logs
+
+        import nexus.aspect_worker as mod
+        from nexus.aspect_worker import aspect_extraction_enqueue_hook
+
+        monkeypatch.setattr(mod, "ensure_worker_started", lambda: None)
+        # Canonical file_path is absolute (but inside repo_root so it clears
+        # the register-time cross-project guard); the stray probe resolves via
+        # the title. canonical is absolute and DIFFERS -> the isabs leg blocks
+        # normalization and the path is left as-is.
+        abs_canonical = str(tmp_path / "repo" / "papers" / "canon.md")
+        stray = "/Users/x/git/clone/papers/stray.md"
+        self._seed_catalog(
+            tmp_path, monkeypatch,
+            collection="knowledge__delos",
+            file_path=abs_canonical, title=stray,
+        )
+        with capture_logs() as cap:
+            aspect_extraction_enqueue_hook(
+                source_path=stray, collection="knowledge__delos", content="x",
+            )
+        with T2Database(_isolate_t2) as db:
+            rows = db.aspect_queue.list_pending()
+        assert len(rows) == 1
+        assert rows[0].source_path == stray  # absolute canonical -> not normalized
+        assert not any(
+            e.get("event") == "aspect_source_path_uncanonical" for e in cap
+        )
+
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## RDR-145 Phase 1 (epic nexus-6lr76) — two forward-only fixes, one PR

Phase 1 of the scope-collapsed RDR-145 aspect-orphan cleanup. Forward-only; no gate. Phase 2 (the migration cleanup `nexus-nx9nx`) stays blocked on the RDR-108 Phase-1c PK migration and is untouched here.

### nexus-3g0l4 — Gap-3 routing regression test (test-only)
Pins the shipped `nexus-kmbys` shape-aware routing for the orphan-producing `knowledge__knowledge` collection. A representative MCP note routes to `general-prose-v1` (NOT `scholarly-paper-v1`) with empty experimental fields — the machine-checkable form of "non-fabricated". Also pins the `general-prose-v1` schema contract (datasets/baselines/results not required). Non-vacuity: the end-to-end test asserts the prose prompt was invoked, tying the empty fields to the routing decision rather than echoing a fixture.

### nexus-syga3 — Gap-2 source_path canonicalization (production)
`aspect_extraction_enqueue_hook` now canonicalizes a file-backed `source_path` against the catalog before writing the queue row:
- Resolves via `lookup_doc_id_by_collection_and_path` → `by_doc_id`/`resolve` to read the entry's canonical `file_path`.
- On a hit whose stored form is relative and differs → normalize.
- On a miss → leave AS-IS + loud `aspect_source_path_uncanonical` warning. **Never synthesizes a path** (would re-introduce the `nexus-3e4s` CWD-anchoring class).
- Note-backed (32-hex chash) and non-path-shaped source_paths are skipped (RDR-172 owns note identity via `doc_id`).
- Best-effort / fail-open; forward-only (existing rows untouched).

**Honest framing (per substantive-critic):** for the documented Bucket-B contamination (177 absolute paths mismatching the catalog's relative `file_path`), the probe MISSES → the **warning tripwire is the real forward-only output**, not in-flight rewriting. Correcting those rows is Phase 2's one-time migration cleanup. This is documented in the `_canonicalize_source_path` docstring and the (deliberately contrived) normalize-branch test.

### Review
- code-review-expert: APPROVED (0 Critical/High).
- substantive-critic: APPROVED-WITH-CONDITIONS (0 Critical, 3 Significant framing/doc issues — all addressed).
- Full unit suite: 11426 passed, 0 failed.

### Follow-ups (noted, not in scope)
- Service-mode batch CLI ingest latency (per-document catalog point-query, bounded by the 30s HTTP timeout + chash-gating + fail-open).
- Bare-filename (no-separator) relative source_paths are skipped — outside the absolute-path contamination class.

Refs nexus-3g0l4 nexus-syga3 nexus-6lr76