### PR TITLE
feat(aspects): RDR-172 P2.1 — enqueue-failure loudness tripwire

### DIFF
--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -1164,13 +1164,39 @@ def aspect_extraction_enqueue_hook(
                 doc_id=doc_id,
             )
         )
-    except Exception:  # noqa: BLE001 — enqueue is best-effort; failure logged via log.warning
+    except Exception as exc:  # noqa: BLE001 — enqueue is best-effort; failure logged via log.warning
         _log.warning(
             "aspect_extraction_enqueue_failed",
             source_path=source_path,
             collection=collection,
             exc_info=True,
         )
+        # RDR-172 P2.1 (nexus-hlkvj): loudness tripwire. Keeping the enqueue
+        # best-effort (never block ingest, RDR-089 P0.1) also hides this
+        # failure from hook_registry's hook_failures recorder — the hook
+        # swallows it here, so fire_document sees success. Persist a structured
+        # hook_failures row directly so CI / --fullstack can assert ZERO
+        # enqueue failures across an ingest E2E (the fail-closed recurrence
+        # guard, RF-7 — the nexus-ov0sw silent-total-failure class). The
+        # persist is itself best-effort: a telemetry-write failure (T2 down,
+        # service 5xx) must never block ingest either.
+        try:
+            t2_index_write(
+                lambda t2: t2.telemetry.record_hook_failure(
+                    doc_id=source_path,
+                    collection=collection,
+                    hook_name="aspect_extraction_enqueue_hook",
+                    error=str(exc)[:2000],  # match hook_registry's truncation
+                    chain="document",
+                )
+            )
+        except Exception:  # noqa: BLE001 — tripwire persist is best-effort; never block ingest
+            _log.warning(
+                "aspect_enqueue_tripwire_persist_failed",
+                source_path=source_path,
+                collection=collection,
+                exc_info=True,
+            )
         # Enqueue failure is non-fatal — ingest is never blocked.
         # The document_aspects row will simply not be populated until
         # a manual re-enqueue triggers extraction.

--- a/tests/e2e/migration-rehearsal/rehearse_fullstack.sh
+++ b/tests/e2e/migration-rehearsal/rehearse_fullstack.sh
@@ -102,6 +102,19 @@ enq="$(q "select count(*) from nexus.aspect_extraction_queue")"
 pend="$(q "select count(*) from nexus.aspect_extraction_queue where status in ('pending','in_progress')")"
 asp="$(q "select count(*) from nexus.document_aspects")"
 note "post-workload: aspect_queue total=${enq:-?} pending=${pend:-?}; document_aspects=${asp:-?}"
+# RDR-172 P2.1 (nexus-hlkvj): enqueue-failure tripwire — the ingest E2E must
+# complete with ZERO swallowed aspect-enqueue failures. The hook persists a
+# hook_failures row on its best-effort swallow (the nexus-ov0sw silent-total-
+# failure class); a non-zero count here means an enqueue silently failed.
+# NOTE: this gate is only NON-VACUOUS if the workload above actually drives
+# store_put through aspect_extraction_enqueue_hook in service mode. That the
+# path is exercised is verified by P2.5 (nexus-8zog5, post-fix --fullstack
+# real-validation run); P2.2 (nexus-jr84c) reconciles the stale comment at the
+# top of this block. Until P2.5 confirms, treat a green assert-zero as
+# necessary-but-not-sufficient.
+enqfail="$(q "select count(*) from nexus.hook_failures where hook_name='aspect_extraction_enqueue_hook'")"
+if [ "${enqfail:-0}" -eq 0 ] 2>/dev/null; then ok "enqueue-failure tripwire: 0 swallowed aspect-enqueue failures"
+else bad "enqueue-failure tripwire FIRED: ${enqfail} swallowed aspect_extraction_enqueue_hook failure(s) — silent-loss class recurred (RF-7)"; fi
 if [ "${asp:-0}" -gt 0 ] 2>/dev/null; then
   ok "SERVICE-MODE aspect pipeline works END-TO-END: store_put → enqueue → worker → document_aspects (${asp} rows, real extraction)"
 elif [ "${enq:-0}" -gt 0 ] 2>/dev/null; then

--- a/tests/test_aspect_worker.py
+++ b/tests/test_aspect_worker.py
@@ -723,6 +723,104 @@ class TestGap2SourcePathNormalization:
         )
 
 
+class TestEnqueueFailureTripwire:
+    """RDR-172 P2.1 (nexus-hlkvj): loudness tripwire on enqueue failure.
+
+    ``aspect_extraction_enqueue_hook`` keeps the enqueue best-effort (never
+    block ingest, RDR-089 P0.1), but that internal swallow also hides the
+    failure from ``hook_registry``'s ``hook_failures`` recorder — the silent-
+    total-failure class (RF-7, the nexus-ov0sw bug). The hook therefore
+    persists its OWN ``hook_failures`` row inside the except block so CI /
+    --fullstack can assert zero enqueue failures across an ingest E2E. The
+    persist is itself best-effort: a telemetry-write failure never blocks
+    ingest.
+    """
+
+    def test_enqueue_failure_records_hook_failures_row(
+        self, _isolate_t2: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """NON-VACUITY (RF-7): a forced enqueue failure WRITES a structured
+        hook_failures row keyed ``hook_name='aspect_extraction_enqueue_hook'``
+        — the tripwire is proven to increment, not just assert-zero on green."""
+        import nexus.aspect_worker as mod
+        from nexus.aspect_worker import aspect_extraction_enqueue_hook
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        monkeypatch.setattr(mod, "ensure_worker_started", lambda: None)
+        monkeypatch.setattr(mod, "_resolve_catalog_reader", lambda: None)
+
+        def _boom(self, *a, **k):
+            raise RuntimeError("enqueue boom")
+
+        monkeypatch.setattr(AspectExtractionQueue, "enqueue", _boom)
+
+        aspect_extraction_enqueue_hook(
+            source_path="/p1.pdf", collection="knowledge__delos", content="x",
+        )
+        with T2Database(_isolate_t2) as db:
+            rows = db.telemetry.conn.execute(
+                "SELECT doc_id, collection, hook_name, error, chain "
+                "FROM hook_failures"
+            ).fetchall()
+        assert len(rows) == 1
+        doc_id, coll, hook_name, error, chain = rows[0]
+        assert doc_id == "/p1.pdf"
+        assert coll == "knowledge__delos"
+        assert hook_name == "aspect_extraction_enqueue_hook"
+        assert "enqueue boom" in error
+        assert chain == "document"
+
+    def test_successful_enqueue_writes_no_hook_failures(
+        self, _isolate_t2: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """ASSERT-ZERO baseline (the CI invariant): a normal enqueue writes a
+        queue row and ZERO hook_failures rows."""
+        import nexus.aspect_worker as mod
+        from nexus.aspect_worker import aspect_extraction_enqueue_hook
+
+        monkeypatch.setattr(mod, "ensure_worker_started", lambda: None)
+        monkeypatch.setattr(mod, "_resolve_catalog_reader", lambda: None)
+
+        aspect_extraction_enqueue_hook(
+            source_path="/p1.pdf", collection="knowledge__delos", content="x",
+        )
+        with T2Database(_isolate_t2) as db:
+            pending = db.aspect_queue.list_pending()
+            failures = db.telemetry.conn.execute(
+                "SELECT count(*) FROM hook_failures "
+                "WHERE hook_name = 'aspect_extraction_enqueue_hook'"
+            ).fetchone()[0]
+        assert len(pending) == 1
+        assert failures == 0
+
+    def test_tripwire_persist_failure_never_blocks_ingest(
+        self, _isolate_t2: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Best-effort: if BOTH the enqueue AND the tripwire persist raise, the
+        hook still returns without propagating (ingest is never blocked)."""
+        import nexus.aspect_worker as mod
+        from nexus.aspect_worker import aspect_extraction_enqueue_hook
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+        from nexus.db.t2.telemetry import Telemetry
+
+        monkeypatch.setattr(mod, "ensure_worker_started", lambda: None)
+        monkeypatch.setattr(mod, "_resolve_catalog_reader", lambda: None)
+
+        def _boom(self, *a, **k):
+            raise RuntimeError("enqueue boom")
+
+        def _boom_telemetry(self, *a, **k):
+            raise RuntimeError("telemetry down")
+
+        monkeypatch.setattr(AspectExtractionQueue, "enqueue", _boom)
+        monkeypatch.setattr(Telemetry, "record_hook_failure", _boom_telemetry)
+
+        # Must not raise.
+        aspect_extraction_enqueue_hook(
+            source_path="/p1.pdf", collection="knowledge__delos", content="x",
+        )
+
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## RDR-172 P2.1 (epic nexus-9oyff) — enqueue-failure loudness tripwire

The `aspect_extraction_enqueue_hook` keeps the enqueue best-effort (never block ingest, RDR-089 P0.1), but that internal swallow also hid the failure from `hook_registry`'s `hook_failures` recorder — the **silent-total-failure class** that produced bug `nexus-ov0sw` (RF-7).

### Change
- The hook now persists its **own** `hook_failures` row (`hook_name='aspect_extraction_enqueue_hook'`, `chain='document'`) inside the except block, via the existing telemetry infra (`record_hook_failure`; no new infra, RF-6).
- The tripwire persist is itself **best-effort** — a telemetry-write failure never blocks ingest. It targets a different table/endpoint than the failing queue write, so a per-row FK rejection (the `nexus-ov0sw` 23503 class) does not silence it.
- The `--fullstack` ingest E2E asserts **zero** swallowed aspect-enqueue failures.

### Non-vacuity (RF-7)
- **Unit dimension — proven here:** a forced enqueue failure increments the tripwire; happy-path asserts zero; both-fail path proves ingest never blocks.
- **E2E dimension — NOT proven by this commit:** the assert-zero is non-vacuous only if the workload drives `store_put → aspect_extraction_enqueue_hook` in service mode. That liveness is validated by **P2.5 (`nexus-8zog5`)**; an inline note in the harness flags this. P2.2 (`nexus-jr84c`) reconciles the stale workload comment.

### Review
- code-review-expert: APPROVED (0 Critical/High; S-1 error truncation + S-2 `telemetry.conn` applied).
- substantive-critic: APPROVED-WITH-CONDITIONS (0 Critical, 1 Significant — E2E non-vacuity scoped to P2.5; commit + harness note corrected). Confirmed: correct FK-class coverage, correct except-path, no double-count vs hook_registry.
- Full unit suite: 11429 passed, 0 failed.

Refs nexus-hlkvj