### PR TITLE
chore(e2e): bump migration-rehearsal COLD_TAG to engine-service-v0.1.10

### DIFF
--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -48,7 +48,7 @@ RELEASE_PROPS="service/src/main/resources/META-INF/nexus/release.properties"
 # stale default fail-closes the --cold MVV at the version gate. Kept literal (it
 # names a PUBLISHED release tag, which need not equal the floor) but bumped to
 # track it; override via NEXUS_SERVICE_TAG. (nexus-v0zmv)
-COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.8}"
+COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.10}"
 for a in "$@"; do
   case "$a" in
     --with-cloud) WITH_CLOUD=1 ;;


### PR DESCRIPTION
Track the migration-rehearsal cold-install default to the now-current published + cloud-gated engine tag.

`engine-service-v0.1.10` (RDR-172 P3.1, AspectHandler SQLSTATE class-23 → typed 409) was deployed and STEP-6-gated green in the cloud on 2026-06-28 (conexus relay; recall AC-3 13/13 cloud==local, parity p50 Jaccard 1.0, hybrid p95 1774ms within bound). `COLD_TAG` was stale at v0.1.8. Override still honoured via `NEXUS_SERVICE_TAG`.

Engine-release skill Step 6. `PINNED_SERVICE_TAG` / `REQUIRED_RELEASE_VERSION` deliberately NOT bumped (the `release` skill's job; no PyPI release rode this engine).

Refs nexus-vu9wc