### PR TITLE
fix(aspects): HttpAspectQueue.claim_batch parses the service's bare-array response (service-mode worker was claiming nothing)

### DIFF
--- a/src/nexus/db/t2/http_aspect_queue.py
+++ b/src/nexus/db/t2/http_aspect_queue.py
@@ -177,7 +177,14 @@ class HttpAspectQueue(RawHandleGuardMixin):
         if limit <= 0:
             return []
         r = self._post("/claim_batch", {"limit": limit})
-        rows = r.get("rows", [])
+        # nexus-575kd: the Java service sends a BARE JSON ARRAY here
+        # (AspectHandler.handleQueueClaimBatch -> writeValueAsString(rows)),
+        # unlike claim_next which is enveloped. Accept the array directly;
+        # tolerate a future {"rows":[...]} envelope defensively. The prior
+        # ``r.get("rows", [])`` raised AttributeError on the list every poll,
+        # so the service-mode worker claimed nothing and document_aspects never
+        # populated (all service-mode aspect extraction was dead).
+        rows = r if isinstance(r, list) else r.get("rows", [])
         return [_body_to_queue_row(row) for row in rows]
 
     def mark_done(

--- a/tests/db/test_http_aspects_stores.py
+++ b/tests/db/test_http_aspects_stores.py
@@ -403,17 +403,38 @@ class TestHttpAspectQueue:
         assert store.claim_next() is None
 
     def test_claim_batch_returns_list(self):
+        # nexus-575kd: the Java service's /queue/claim_batch sends a BARE JSON
+        # ARRAY (AspectHandler.handleQueueClaimBatch -> writeValueAsString(rows)),
+        # NOT a {"rows":[...]} envelope. The prior version of this test mocked
+        # the envelope — i.e. the client's wrong assumption — so it stayed green
+        # while the real service-mode worker claimed nothing (claim_batch raised
+        # on every poll -> document_aspects=0). Mock what the service ACTUALLY
+        # sends so this pins the real contract.
         rows = [
             {"collection": "c", "source_path": f"doc{i}.pdf",
              "content_hash": "", "content": "", "retry_count": 0, "doc_id": ""}
             for i in range(3)
         ]
         store = self._queue({
-            "/v1/aspects/queue/claim_batch": {"rows": rows}
+            "/v1/aspects/queue/claim_batch": rows  # bare array, as the service sends
         })
         result = store.claim_batch(5)
         assert len(result) == 3
         assert all(isinstance(r, QueueRow) for r in result)
+        assert [r.source_path for r in result] == ["doc0.pdf", "doc1.pdf", "doc2.pdf"]
+
+    def test_claim_batch_tolerates_rows_envelope(self):
+        # Defensive: if a future engine ever wraps as {"rows":[...]} (matching
+        # claim_next's envelope), the client must still parse it. Locks the
+        # isinstance fallback branch.
+        rows = [{"collection": "c", "source_path": "d.pdf",
+                 "content_hash": "", "content": "", "retry_count": 0, "doc_id": ""}]
+        store = self._queue({
+            "/v1/aspects/queue/claim_batch": {"rows": rows}
+        })
+        result = store.claim_batch(5)
+        assert len(result) == 1
+        assert result[0].source_path == "d.pdf"
 
     def test_claim_batch_zero_limit_returns_empty(self):
         store = self._queue({})

--- a/tests/db/test_http_aspects_stores_integration.py
+++ b/tests/db/test_http_aspects_stores_integration.py
@@ -549,6 +549,33 @@ class TestQueueMVV:
             }))
             assert done.status_code == 200
 
+    def test_claim_batch_client_roundtrip_real_service(self, service) -> None:
+        """nexus-575kd boundary guard: HttpAspectQueue.claim_batch (the CLIENT
+        method the aspect worker polls with) must parse the real service's
+        BARE-ARRAY /claim_batch response.
+
+        The pre-fix unit mock returned a {"rows":[...]} envelope the service
+        never sends, so it stayed green while the live service-mode worker
+        claimed nothing (claim_batch raised every poll -> document_aspects=0,
+        ALL service-mode aspect extraction dead). Only a real round-trip
+        through the client catches the contract — exactly the 'integration over
+        mocks' lesson. Isolated tenant so claim_batch is deterministic."""
+        import time as _time
+        from nexus.db.t2.http_aspect_queue import HttpAspectQueue
+
+        base_url, token, _ = service
+        tenant = f"queue-claimbatch-{_time.time_ns()}"
+        q = HttpAspectQueue(base_url=base_url, tenant=tenant, _token=token)
+        coll = "knowledge__claimbatch-inttest"
+        for i in range(3):
+            q.enqueue(coll, f"/cb/doc{i}.pdf", content_hash=f"h{i}", content="x")
+
+        rows = q.claim_batch(10)
+        assert len(rows) == 3, f"client claim_batch must return the 3 enqueued rows, got {rows}"
+        assert sorted(r.source_path for r in rows) == [
+            "/cb/doc0.pdf", "/cb/doc1.pdf", "/cb/doc2.pdf",
+        ]
+
     def test_j_etl_never_downgrade_in_progress(self, service) -> None:
         """j) import_queue_row never downgrades in_progress rows; GREATEST retry_count.
 


### PR DESCRIPTION
## Root cause of the dead service-mode aspect pipeline (nexus-575kd)

The Java service's `POST /v1/aspects/queue/claim_batch` returns a **bare JSON array**; the Python client did `r.get("rows", [])` expecting a `{"rows":[...]}` envelope. `_post` returns the parsed JSON verbatim, so `r` was a `list` and `.get` raised `AttributeError` on **every aspect-worker poll** → in service mode the worker claimed **nothing** → `document_aspects` never populated. `claim_next` is correctly enveloped on both sides (Java comment: *"to match Python protocol"*), which is why it — and every service-mode test, all of which use `claim_next` — stayed green.

**Why it hid:** the unit test mocked the `{"rows":...}` envelope — the client's *wrong assumption* validated against itself. The only `claim_batch` tests were local sqlite, never the HTTP client. Textbook mocks-hide-boundary-bugs.

## Fix
`rows = r if isinstance(r, list) else r.get("rows", [])` — accept the bare array (tolerate a future envelope defensively). **No engine cut**: the deployed `engine-service-v0.1.10` already returns the bare array; this aligns the client to it.

## Tests
- Unit: corrected to mock the **bare array the service actually sends** (now reproduces the `AttributeError`, then passes) + an envelope-tolerance test.
- Integration: drives the real `HttpAspectQueue.claim_batch` against the live Java service — the boundary coverage that was missing.

## Scope — what this does and does NOT do (precise, per review)
- **Validated:** claims now work. A `--fullstack` run with this fix moved the queue from `pending=4` (pre-fix, 0 claimed) to `pending=3` (1 claimed). This proves `claim_batch` no longer raises.
- **NOT validated / still broken:** full end-to-end extraction in service mode. `--fullstack` still fails `document_aspects=0` because of a **separate** gap — `nexus-tih7j`: the service-mode aspect worker has **no persistent host** (the only `ensure_worker_started` caller is the enqueue hook; it dies with the process), so short-lived store paths enqueue rows that never extract. **Do not close P2.5 / the RDR-172 epic on this PR** — that's blocked on the worker-hosting gap.
- **CI caveat:** the integration test is `@pytest.mark.integration` (needs the JAR + PG + JVM), so **CI runs only the now-corrected mock**. The real boundary guard runs in integration, not CI.

## Review
- code-review-expert: APPROVED (0 Critical/High).
- substantive-critic: APPROVED-WITH-CONDITIONS (0 Critical, 3 Significant — all framing/follow-up; fix sound). Follow-ups filed: Java contract-consistency cleanup; reclaim_stale-in-service-mode added to `nexus-tih7j`.

Refs nexus-575kd