### PR TITLE
fix(aspects): service-aware drain_worker + honest timeout (RDR-173 P4.1)

### DIFF
--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -946,8 +946,6 @@ def drain_worker(
         for.  This handles the quiescent case (e.g., the caller's process
         never ran the worker, or the worker finished and was reset).
     """
-    from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue  # noqa: PLC0415 — deferred to avoid circular import (db.t2 queue)
-
     # SIG-5: detect active MCP-process workers before stopping the local
     # singleton.  A live MCP worker in another process drains its own
     # queue independently; the migration must not run while that worker is
@@ -964,7 +962,22 @@ def drain_worker(
     queue_path = Path(queue_path)
     deadline = time.monotonic() + timeout
 
-    queue = AspectExtractionQueue(queue_path)
+    # RDR-173 P4.1 (nexus-4st62): in SERVICE mode the authoritative
+    # aspect_extraction_queue is PG, reached via ``HttpAspectQueue``. The
+    # local-sqlite ``AspectExtractionQueue`` is empty/stale there, so polling it
+    # yields a spurious "drained" — leaving ``nx aspects drain`` and the
+    # migration drain gate inert in service mode. Poll the SERVICE queue's
+    # ``is_drained()`` instead. (Local/SQLite mode is unchanged.)
+    from nexus.db.storage_mode import (  # noqa: PLC0415 — deferred to avoid circular import (db.storage_mode)
+        StorageBackend,
+        storage_backend_for,
+    )
+    if storage_backend_for("aspect_queue") == StorageBackend.SERVICE:
+        from nexus.db.t2.http_aspect_queue import HttpAspectQueue  # noqa: PLC0415 — deferred (optional service dep)
+        queue = HttpAspectQueue()
+    else:
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue  # noqa: PLC0415 — deferred to avoid circular import (db.t2 queue)
+        queue = AspectExtractionQueue(queue_path)
 
     def _join_worker_thread(w: AspectExtractionWorker) -> None:
         """Join the worker thread; log a warning if it does not exit in 2s.

--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -142,15 +142,24 @@ class DrainTimeoutError(RuntimeError):
     drain after the queue is clear.
     """
 
-    def __init__(self, stuck_count: int, timeout: float) -> None:
+    def __init__(
+        self,
+        stuck_count: int,
+        timeout: float,
+        detail: str | None = None,
+    ) -> None:
         self.stuck_count = stuck_count
         self.timeout = timeout
-        super().__init__(
+        self.detail = detail
+        msg = (
             f"Drain timeout after {timeout:.1f}s: "
             f"{stuck_count} actionable row(s) remain in aspect_extraction_queue "
             f"(status pending or in_progress). "
             "Triage stuck workers before retrying the PK migration."
         )
+        if detail:
+            msg = f"{msg} {detail}"
+        super().__init__(msg)
 
 
 class DrainBlockedByActiveWorker(RuntimeError):
@@ -946,14 +955,32 @@ def drain_worker(
         for.  This handles the quiescent case (e.g., the caller's process
         never ran the worker, or the worker finished and was reset).
     """
+    # RDR-173 P4.1 (nexus-4st62): determine storage backend first so the
+    # lock-check and queue construction can both branch on it.
+    from nexus.db.storage_mode import (  # noqa: PLC0415 — deferred to avoid circular import (db.storage_mode)
+        StorageBackend,
+        storage_backend_for,
+    )
+    _is_service_mode = storage_backend_for("aspect_queue") == StorageBackend.SERVICE
+
     # SIG-5: detect active MCP-process workers before stopping the local
     # singleton.  A live MCP worker in another process drains its own
     # queue independently; the migration must not run while that worker is
     # alive or it will race against in_progress rows it cannot see.
+    #
+    # SERVICE mode: the MCP process writes a local aspect_worker lock via
+    # ensure_worker_started (the enqueue hook auto-spawns the singleton),
+    # but in SERVICE mode ALL workers share the same PG queue with
+    # FOR UPDATE SKIP LOCKED — cross-process claim safety is handled by PG,
+    # not by the file lock.  Checking the lock here would make drain always
+    # raise DrainBlockedByActiveWorker when the MCP server is running, which
+    # defeats the primary use case (drain during migration while MCP is live).
+    # Skip the local file-lock check in SERVICE mode.
     locks_dir = _locks_dir if _locks_dir is not None else (
         nexus_config_dir() / "locks"
     )
-    _check_mcp_worker_lock(locks_dir)
+    if not _is_service_mode:
+        _check_mcp_worker_lock(locks_dir)
 
     worker = get_worker()
     if worker is not None:
@@ -968,11 +995,7 @@ def drain_worker(
     # yields a spurious "drained" — leaving ``nx aspects drain`` and the
     # migration drain gate inert in service mode. Poll the SERVICE queue's
     # ``is_drained()`` instead. (Local/SQLite mode is unchanged.)
-    from nexus.db.storage_mode import (  # noqa: PLC0415 — deferred to avoid circular import (db.storage_mode)
-        StorageBackend,
-        storage_backend_for,
-    )
-    if storage_backend_for("aspect_queue") == StorageBackend.SERVICE:
+    if _is_service_mode:
         from nexus.db.t2.http_aspect_queue import HttpAspectQueue  # noqa: PLC0415 — deferred (optional service dep)
         queue = HttpAspectQueue()
     else:
@@ -1016,11 +1039,41 @@ def drain_worker(
                 return
 
         # Timeout: count stuck rows for the error message.
-        stuck = queue.conn.execute(
-            "SELECT COUNT(*) FROM aspect_extraction_queue WHERE status != 'failed'"
-        ).fetchone()
-        stuck_count = stuck[0] if stuck else 0
-        raise DrainTimeoutError(stuck_count=stuck_count, timeout=timeout)
+        # SERVICE mode: HttpAspectQueue has no .conn; use pending_count() via
+        # HTTP.  pending_count() counts only 'pending' rows — NOT in_progress.
+        # A crashed worker leaves rows in in_progress with NO lock held (FOR
+        # UPDATE locks are transaction-scoped; they are released when the
+        # transaction ends, which happens when the worker process dies).  Those
+        # orphaned rows are recovered by reclaim_stale(), not by a held lock.
+        # Consequence: if the drain times out because rows are stuck
+        # in_progress (the common crashed-worker scenario), pending_count()
+        # returns 0 even though is_drained() is still False.  We detect this
+        # gap and include an honest operator hint in the error detail.
+        # LOCAL mode: keep the existing status != 'failed' count (pending +
+        # in_progress) via a direct SQLite query.
+        if _is_service_mode:
+            pending = queue.pending_count()
+            if pending == 0:
+                # is_drained() returned False at timeout, but pending_count()
+                # is 0 — rows are stuck in in_progress (crashed-worker case).
+                # pending_count() is a pending-only proxy and cannot see them.
+                detail = (
+                    "Note (service mode): pending_count is 0, but is_drained() "
+                    "is still False — rows may be stuck in in_progress from a "
+                    "crashed worker. Run 'nx aspects reclaim-stale' to reset "
+                    "them back to pending, then retry the drain."
+                )
+                stuck_count = 0
+            else:
+                detail = None
+                stuck_count = pending
+        else:
+            stuck = queue.conn.execute(
+                "SELECT COUNT(*) FROM aspect_extraction_queue WHERE status != 'failed'"
+            ).fetchone()
+            stuck_count = stuck[0] if stuck else 0
+            detail = None
+        raise DrainTimeoutError(stuck_count=stuck_count, timeout=timeout, detail=detail)
     finally:
         queue.close()
 

--- a/src/nexus/commands/aspects.py
+++ b/src/nexus/commands/aspects.py
@@ -85,18 +85,27 @@ def aspects_drain(timeout: float, poll_interval: float) -> None:
     """
     from nexus.aspect_worker import DrainTimeoutError, drain_worker  # noqa: PLC0415 — deferred local import — avoids import-time cost / circular deps
     from nexus.commands._helpers import default_db_path  # noqa: PLC0415 — deferred local import — avoids import-time cost / circular deps
+    from nexus.db.storage_mode import StorageBackend, storage_backend_for  # noqa: PLC0415 — deferred local import
 
     mem_path = default_db_path()
-    click.echo(f"Draining aspect queue at {mem_path} (timeout={timeout}s)...")
+    if storage_backend_for("aspect_queue") == StorageBackend.SERVICE:
+        click.echo(f"Draining service aspect queue (timeout={timeout}s)...")
+    else:
+        click.echo(f"Draining aspect queue at {mem_path} (timeout={timeout}s)...")
 
     try:
         drain_worker(mem_path, timeout=timeout, poll_interval=poll_interval)
     except DrainTimeoutError as e:
-        click.echo(
-            f"Drain timeout: {e.stuck_count} row(s) still active after {timeout}s. "
-            "Re-run after the worker processes or times out its in-flight rows.",
-            err=True,
+        base = f"Drain timeout: {e.stuck_count} row(s) still active after {timeout}s."
+        # Honor the honest service-mode hint (e.g. crashed-worker rows stuck
+        # in_progress -> run reclaim-stale). Falls back to the generic re-run
+        # advice when no detail was attached.
+        suffix = (
+            f" {e.detail}"
+            if e.detail
+            else " Re-run after the worker processes or times out its in-flight rows."
         )
+        click.echo(base + suffix, err=True)
         raise SystemExit(1) from e
 
     click.echo("Aspect queue drained. Safe to run 'nx upgrade'.")

--- a/tests/test_aspect_drain_protocol.py
+++ b/tests/test_aspect_drain_protocol.py
@@ -168,6 +168,238 @@ class TestServiceModeDrain:
         queue.mark_failed("knowledge__test", "/doc2.pdf", "err2")
         assert queue.is_drained() is True
 
+    def test_drain_timeout_raises_DrainTimeoutError_with_pending_count(
+        self, monkeypatch, locks_dir: Path, tmp_path: Path,
+    ) -> None:
+        """OBS-1 (timeout path): when is_drained() never returns True, drain_worker
+        must raise DrainTimeoutError with stuck_count from pending_count() -- NOT
+        AttributeError from queue.conn (HttpAspectQueue has no .conn).
+
+        This is the CRITICAL fix: the pre-fix code called queue.conn.execute(...)
+        unconditionally, which raises AttributeError on HttpAspectQueue.
+        """
+        from nexus.aspect_worker import DrainTimeoutError, drain_worker
+        from nexus.db import storage_mode as smod
+        from nexus.db.t2 import http_aspect_queue as hmod
+        from nexus.db.t2 import aspect_extraction_queue as sqmod
+
+        monkeypatch.setattr(
+            smod, "storage_backend_for",
+            lambda key: smod.StorageBackend.SERVICE
+            if key == "aspect_queue" else smod.StorageBackend.SQLITE,
+        )
+        _STUCK = 3
+
+        class _FakeHttpQueue:
+            def __init__(self, *a, **k) -> None:
+                pass
+
+            def is_drained(self) -> bool:
+                return False  # never drains -> timeout fires
+
+            def pending_count(self) -> int:
+                return _STUCK
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr(hmod, "HttpAspectQueue", _FakeHttpQueue)
+        def _boom(*a, **k):
+            raise AssertionError("service mode must not open local AspectExtractionQueue")
+        monkeypatch.setattr(sqmod, "AspectExtractionQueue", _boom)
+
+        with pytest.raises(DrainTimeoutError) as exc_info:
+            drain_worker(
+                tmp_path / "unused.db",
+                _locks_dir=locks_dir,
+                timeout=0.15,
+                poll_interval=0.05,
+            )
+
+        err = exc_info.value
+        assert err.stuck_count == _STUCK, (
+            f"stuck_count must come from pending_count() ({_STUCK}), got {err.stuck_count}"
+        )
+        # Normal timeout path (pending > 0) must NOT attach the in_progress hint.
+        assert err.detail is None, (
+            f"detail must be None on the normal (pending>0) timeout path; got {err.detail!r}"
+        )
+
+    def test_drain_timeout_in_progress_only_gives_honest_message(
+        self, monkeypatch, locks_dir: Path, tmp_path: Path,
+    ) -> None:
+        """Service-mode timeout with pending_count()==0 but is_drained()==False.
+
+        The common crashed-worker scenario: all rows are in_progress (not
+        pending), so pending_count() returns 0 while is_drained() is still
+        False.  DrainTimeoutError must still be raised (timeout fires
+        correctly), and the error message / detail must mention 'in_progress'
+        and 'reclaim-stale' so the operator knows the recovery action.
+        """
+        from nexus.aspect_worker import DrainTimeoutError, drain_worker
+        from nexus.db import storage_mode as smod
+        from nexus.db.t2 import http_aspect_queue as hmod
+        from nexus.db.t2 import aspect_extraction_queue as sqmod
+
+        monkeypatch.setattr(
+            smod, "storage_backend_for",
+            lambda key: smod.StorageBackend.SERVICE
+            if key == "aspect_queue" else smod.StorageBackend.SQLITE,
+        )
+
+        class _FakeHttpQueueInProgressOnly:
+            def __init__(self, *a, **k) -> None:
+                pass
+
+            def is_drained(self) -> bool:
+                return False  # rows stuck in in_progress -> never drains
+
+            def pending_count(self) -> int:
+                return 0  # no pending rows; all stuck in in_progress
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr(hmod, "HttpAspectQueue", _FakeHttpQueueInProgressOnly)
+        def _boom(*a, **k):
+            raise AssertionError("service mode must not open local AspectExtractionQueue")
+        monkeypatch.setattr(sqmod, "AspectExtractionQueue", _boom)
+
+        with pytest.raises(DrainTimeoutError) as exc_info:
+            drain_worker(
+                tmp_path / "unused.db",
+                _locks_dir=locks_dir,
+                timeout=0.15,
+                poll_interval=0.05,
+            )
+
+        err = exc_info.value
+        assert err.stuck_count == 0, (
+            f"stuck_count must be 0 (pending_count() returns 0), got {err.stuck_count}"
+        )
+        msg = str(err)
+        assert "in_progress" in msg, (
+            f"error message must mention 'in_progress' for the crashed-worker hint; got: {msg!r}"
+        )
+        assert "reclaim" in msg, (
+            f"error message must mention 'reclaim' (reclaim-stale recovery); got: {msg!r}"
+        )
+
+    def test_drain_poll_loop_exits_when_is_drained_becomes_true(
+        self, monkeypatch, locks_dir: Path, tmp_path: Path,
+    ) -> None:
+        """OBS-1 (poll loop): drain_worker must keep polling until is_drained()
+        returns True — False x 2 then True must succeed without error."""
+        from nexus.aspect_worker import drain_worker
+        from nexus.db import storage_mode as smod
+        from nexus.db.t2 import http_aspect_queue as hmod
+        from nexus.db.t2 import aspect_extraction_queue as sqmod
+
+        monkeypatch.setattr(
+            smod, "storage_backend_for",
+            lambda key: smod.StorageBackend.SERVICE
+            if key == "aspect_queue" else smod.StorageBackend.SQLITE,
+        )
+        _answers = iter([False, False, True])
+
+        class _FakeHttpQueue:
+            def __init__(self, *a, **k) -> None:
+                pass
+
+            def is_drained(self) -> bool:
+                try:
+                    return next(_answers)
+                except StopIteration:
+                    return True  # safety valve
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr(hmod, "HttpAspectQueue", _FakeHttpQueue)
+        def _boom(*a, **k):
+            raise AssertionError("service mode must not open local AspectExtractionQueue")
+        monkeypatch.setattr(sqmod, "AspectExtractionQueue", _boom)
+
+        # Must NOT raise: the loop should see False, False, True and return.
+        drain_worker(
+            tmp_path / "unused.db",
+            _locks_dir=locks_dir,
+            timeout=5.0,
+            poll_interval=0.05,
+        )
+
+    def test_drain_skips_mcp_lock_check_in_service_mode(
+        self, monkeypatch, locks_dir: Path, tmp_path: Path,
+    ) -> None:
+        """SIG-1: the MCP file-lock check must be skipped in SERVICE mode.
+
+        In service mode the MCP process writes a local aspect_worker lock via
+        ensure_worker_started. If _check_mcp_worker_lock ran, drain_worker would
+        always raise DrainBlockedByActiveWorker while the MCP server is running,
+        defeating the primary migration use case.
+
+        Write a PID-1 lock file (always-alive, always-foreign) — in local mode
+        this would block drain. In SERVICE mode drain must succeed.
+        """
+        from nexus.aspect_worker import drain_worker
+        from nexus.db import storage_mode as smod
+        from nexus.db.t2 import http_aspect_queue as hmod
+        from nexus.db.t2 import aspect_extraction_queue as sqmod
+
+        monkeypatch.setattr(
+            smod, "storage_backend_for",
+            lambda key: smod.StorageBackend.SERVICE
+            if key == "aspect_queue" else smod.StorageBackend.SQLITE,
+        )
+
+        # Place a PID-1 lock file — would block drain in LOCAL mode.
+        (locks_dir / "aspect_worker.1").write_text("1")
+
+        class _FakeHttpQueue:
+            def __init__(self, *a, **k) -> None:
+                pass
+
+            def is_drained(self) -> bool:
+                return True
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr(hmod, "HttpAspectQueue", _FakeHttpQueue)
+        def _boom(*a, **k):
+            raise AssertionError("service mode must not open local AspectExtractionQueue")
+        monkeypatch.setattr(sqmod, "AspectExtractionQueue", _boom)
+
+        # Must NOT raise DrainBlockedByActiveWorker — lock is ignored in SERVICE mode.
+        drain_worker(tmp_path / "unused.db", _locks_dir=locks_dir, timeout=1.0)
+
+    def test_cli_drain_surfaces_detail_hint_on_timeout(self, monkeypatch) -> None:
+        """OBS / Medium-1: `nx aspects drain` must surface DrainTimeoutError.detail
+        (the reclaim-stale hint) to the operator — not swallow it behind the
+        generic 'Re-run...' message. The crashed-worker case (stuck_count==0
+        with a detail hint) is exactly when the operator needs the hint.
+        """
+        from click.testing import CliRunner
+        from nexus.aspect_worker import DrainTimeoutError
+        from nexus.commands import aspects as aspects_mod
+
+        hint = (
+            "Note (service mode): pending_count is 0 ... Run "
+            "'nx aspects reclaim-stale' to reset them back to pending."
+        )
+
+        def _raise(*a, **k):
+            raise DrainTimeoutError(stuck_count=0, timeout=1.0, detail=hint)
+
+        monkeypatch.setattr("nexus.commands._helpers.default_db_path", lambda: "/tmp/x.db")
+        monkeypatch.setattr("nexus.aspect_worker.drain_worker", _raise)
+
+        result = CliRunner().invoke(aspects_mod.aspects_drain, ["--timeout", "1"])
+        assert result.exit_code == 1
+        assert "reclaim-stale" in result.output, (
+            f"CLI must surface the reclaim-stale hint; got: {result.output!r}"
+        )
+
 
 # -- Stop signal --------------------------------------------------------------
 

--- a/tests/test_aspect_drain_protocol.py
+++ b/tests/test_aspect_drain_protocol.py
@@ -110,6 +110,55 @@ class TestIsDrained:
         # doc2 is still pending
         assert queue.is_drained() is False
 
+
+# -- RDR-173 P4.1 (nexus-4st62): service-aware drain ---------------------------
+
+
+class TestServiceModeDrain:
+    """drain_worker must poll the SERVICE queue (HttpAspectQueue.is_drained())
+    when the aspect-queue backend is SERVICE — not a local-sqlite
+    AspectExtractionQueue, which is empty/stale in service mode and yields a
+    spurious 'drained' (the nx aspects drain / migration-gate inertness gap)."""
+
+    def test_drain_polls_http_queue_in_service_mode(
+        self, monkeypatch, locks_dir: Path, tmp_path: Path,
+    ) -> None:
+        from nexus.aspect_worker import drain_worker
+        from nexus.db import storage_mode as smod
+        from nexus.db.t2 import http_aspect_queue as hmod
+        from nexus.db.t2 import aspect_extraction_queue as sqmod
+
+        monkeypatch.setattr(
+            smod, "storage_backend_for",
+            lambda key: smod.StorageBackend.SERVICE
+            if key == "aspect_queue" else smod.StorageBackend.SQLITE,
+        )
+        calls = {"http_is_drained": 0, "http_closed": False, "http_built": 0}
+
+        class _FakeHttpQueue:
+            def __init__(self, *a, **k) -> None:
+                calls["http_built"] += 1
+
+            def is_drained(self) -> bool:
+                calls["http_is_drained"] += 1
+                return True
+
+            def close(self) -> None:
+                calls["http_closed"] = True
+
+        monkeypatch.setattr(hmod, "HttpAspectQueue", _FakeHttpQueue)
+        # Guard: the local sqlite queue must NOT be opened in service mode.
+        def _boom(*a, **k):
+            raise AssertionError("service mode must not open local AspectExtractionQueue")
+        monkeypatch.setattr(sqmod, "AspectExtractionQueue", _boom)
+
+        # queue_path is irrelevant in service mode; pass an unused path.
+        drain_worker(tmp_path / "unused.db", _locks_dir=locks_dir, timeout=1.0)
+
+        assert calls["http_built"] == 1, "service mode must construct HttpAspectQueue"
+        assert calls["http_is_drained"] >= 1, "must poll the SERVICE queue's is_drained()"
+        assert calls["http_closed"] is True, "must close the http queue"
+
     def test_only_failed_rows_is_drained(self, queue) -> None:
         queue.enqueue("knowledge__test", "/doc1.pdf")
         queue.enqueue("knowledge__test", "/doc2.pdf")


### PR DESCRIPTION
## Summary

Makes `drain_worker` service-aware so `nx aspects drain` and the migration drain gate actually poll the authoritative queue in service mode. Previously `drain_worker` unconditionally polled the local-SQLite `AspectExtractionQueue`, returning a spurious "drained" while the real PG queue (via `HttpAspectQueue`) still held rows — leaving the drain gate inert in service mode.

This is the one remaining RDR-173 edge blocking `nexus-luxe6` (6.0.0). Standalone, daemon-independent, **Python-only — no engine change**.

## Changes

- **CRITICAL**: timeout path no longer calls `queue.conn` (`HttpAspectQueue` has none → was `AttributeError` instead of `DrainTimeoutError`). Service mode counts via `pending_count()`; local mode keeps the `status != 'failed'` SQLite count.
- **SIG-1**: `_check_mcp_worker_lock` skipped in SERVICE mode. The MCP file lock does not gate the shared PG queue (PG `FOR UPDATE SKIP LOCKED` handles cross-process; `quiesce.py` SUSPEND handles migration quiescence). Local mode still checks the lock.
- **Honest timeout**: `pending_count()` counts only `pending`; a crashed worker leaves rows in `in_progress`, so `pending_count()==0` while `is_drained()==False`. `DrainTimeoutError` now carries a `detail` hint pointing at `reclaim-stale` for that case.
- **CLI**: `nx aspects drain` surfaces `DrainTimeoutError.detail` to the operator instead of swallowing it; backend-aware echo.

## Tests

`TestServiceModeDrain` covers the timeout path (pending-count source), the `in_progress`-only honest message, the poll loop, the service-mode lock-skip, and CLI detail surfacing. Full unit suite green (11437 passed).

## Review

Stacked review (code-review-expert + substantive-critic): 0 Critical. Code-review Medium-1 (CLI dropped the detail hint) and critic OBS-2 (normal-path `detail is None` assertion) both fixed in this branch.

Closes #nexus-4st62