### PR TITLE
fix(engine): register jOOQ record constructors for native-image reflection (nexus-i9o37)

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -529,6 +529,20 @@
                                         <buildArg>--enable-https</buildArg>
                                         <!-- Logback/SLF4J: initialize at build time -->
                                         <buildArg>--initialize-at-build-time=org.slf4j,ch.qos.logback</buildArg>
+                                        <!-- org.xml.sax.helpers: build-time-init the SAX helper/data classes
+                                             (LocatorImpl, AttributesImpl, NamespaceSupport, …) that logback's
+                                             build-time-initialized JoranConfigurator / SaxEventInterpreter
+                                             retains in the LoggerContext. Surfaced once
+                                             JooqRecordReflectionFeature.beforeAnalysis() touches the jOOQ
+                                             schema model at image-build time: that triggers jOOQ's slf4j
+                                             logging, which drives logback to parse logback.xml at build time
+                                             and retain SAX-config scaffolding in the build-time heap. Without
+                                             the Feature no logger fires at build time so these objects never
+                                             appear (RDR-173 P7 / nexus-i9o37). Whole package (not one class)
+                                             because the parse retains several of these holders; all are
+                                             stateless build-time-safe. Completes the existing ch.qos.logback
+                                             build-time-init intent. -->
+                                        <buildArg>--initialize-at-build-time=org.xml.sax.helpers</buildArg>
                                         <!-- jOOQ 3.20.11 + GraalVM 25 native-image initialization.
                                              nexus-lp2qo spike (2026-06-12): community metadata now
                                              ships a jOOQ 3.20.0 entry (tested 3.20.0-3.21.5, covers

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -14,6 +14,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jooq.version>3.20.11</jooq.version>
+        <!-- GraalVM SDK: compile-only (provided) API for the native-image build-time
+             Feature (dev.nexus.service.nativeimage.JooqRecordReflectionFeature). Aligned
+             to GraalVM for JDK 25; never bundled into the app jar (build-time only). -->
+        <graalvm.sdk.version>25.0.1</graalvm.sdk.version>
         <hikari.version>6.2.1</hikari.version>
         <postgresql.version>42.7.4</postgresql.version>
         <slf4j.version>2.0.16</slf4j.version>
@@ -88,6 +92,17 @@
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
             <version>${jooq.version}</version>
+        </dependency>
+
+        <!-- GraalVM native-image hosted API (Feature, RuntimeReflection). Compile-only:
+             used solely by JooqRecordReflectionFeature, which the native-image builder
+             runs at image-build time. provided scope keeps it off the app-jar runtime
+             classpath. -->
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
+            <version>${graalvm.sdk.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- JSON -->
@@ -531,6 +546,14 @@
                                              runtime-reflection the community metadata lacked). Both also
                                              ride the jar classpath, but list them explicitly for clarity. -->
                                         <buildArg>-H:ConfigurationFileDirectories=src/main/resources/META-INF/native-image,src/main/resources/META-INF/native-image/traced</buildArg>
+                                        <!-- jOOQ generated records: register their constructors for
+                                             reflection so INSERT…RETURNING can instantiate the returned
+                                             record. Community metadata covers jOOQ's library classes but
+                                             not app-generated records; without this every RETURNING write
+                                             500s with MissingReflectionRegistrationError (RDR-173 P7 /
+                                             nexus-i9o37). The Feature enumerates via jOOQ's schema model so
+                                             it covers all current + future generated records. -->
+                                        <buildArg>--features=dev.nexus.service.nativeimage.JooqRecordReflectionFeature</buildArg>
                                         <!-- Per-platform embedding native libs (nexus-lp2qo). onnxruntime
                                              and djl-tokenizers bundle a .so/.dylib/.dll per <os-arch> in the
                                              jar; native-image only embeds resources it is told to. Rather

--- a/service/src/main/java/dev/nexus/service/nativeimage/JooqRecordReflectionFeature.java
+++ b/service/src/main/java/dev/nexus/service/nativeimage/JooqRecordReflectionFeature.java
@@ -1,0 +1,60 @@
+package dev.nexus.service.nativeimage;
+
+import dev.nexus.service.jooq.nexus.Nexus;
+import java.util.ArrayList;
+import java.util.List;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
+import org.jooq.Table;
+
+/**
+ * GraalVM native-image {@link Feature} that registers the constructors of every
+ * jOOQ generated record type for reflection.
+ *
+ * <p>Why this is necessary: jOOQ's {@code INSERT … RETURNING} path
+ * ({@code org.jooq.impl.Tools.recordFactory} → {@code TableImpl.getRecordConstructor}
+ * → {@code Class.getDeclaredConstructor()}) reflectively instantiates the generated
+ * record class to materialise the returned row. Community reachability metadata
+ * covers jOOQ's own library classes but cannot know about an application's generated
+ * records, so in the native image every {@code RETURNING} write throws
+ * {@code org.graalvm.nativeimage.MissingReflectionRegistrationError} → HTTP 500.
+ * This was discovered by RDR-173 P7 (nexus-i9o37): {@code POST /v1/aspects/upsert}
+ * 500'd on {@code DocumentAspectsRecord.<init>()}, leaving {@code document_aspects}
+ * empty even though the aspect worker extracted correctly.
+ *
+ * <p>Registration is driven by jOOQ's own schema model
+ * ({@link Nexus#NEXUS}{@code .getTables()} → {@link Table#getRecordType()}) so it
+ * covers every current and future generated record with no hand-maintained list to
+ * drift. Only constructors are registered — that is the exact failing mechanism;
+ * jOOQ sets the returned column values through its internal {@code TableField} model,
+ * not by reflecting on record members, so registering methods/fields would be
+ * unevidenced scope (RDR-173 nexus-i9o37).
+ *
+ * <p>Wired via {@code --features=dev.nexus.service.nativeimage.JooqRecordReflectionFeature}
+ * in the {@code native} profile of {@code service/pom.xml}.
+ */
+public final class JooqRecordReflectionFeature implements Feature {
+
+    /**
+     * The record types this Feature registers, derived from jOOQ's schema model.
+     *
+     * <p>This is the SAME discovery path {@link #beforeAnalysis} uses; it is exposed
+     * (package-visible) so the structural guard test exercises the Feature's real
+     * enumeration rather than re-deriving the set independently.
+     */
+    static List<Class<?>> recordTypes() {
+        List<Class<?>> records = new ArrayList<>();
+        for (Table<?> table : Nexus.NEXUS.getTables()) {
+            records.add(table.getRecordType());
+        }
+        return records;
+    }
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        for (Class<?> recordType : recordTypes()) {
+            RuntimeReflection.register(recordType);
+            RuntimeReflection.register(recordType.getDeclaredConstructors());
+        }
+    }
+}

--- a/service/src/test/java/dev/nexus/service/nativeimage/JooqRecordReflectionFeatureTest.java
+++ b/service/src/test/java/dev/nexus/service/nativeimage/JooqRecordReflectionFeatureTest.java
@@ -1,0 +1,48 @@
+package dev.nexus.service.nativeimage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Structural guard for {@link JooqRecordReflectionFeature}.
+ *
+ * <p>This is a GUARD, not proof of the fix. The bug it defends against —
+ * jOOQ {@code INSERT … RETURNING} hitting {@code MissingReflectionRegistrationError}
+ * on an unregistered generated record constructor — manifests ONLY in the GraalVM
+ * native image; on the JVM reflection always succeeds, so no JVM test can reproduce
+ * it or prove the native fix. The real gate is the {@code -Pnative} build plus the
+ * {@code tests/e2e/migration-rehearsal/run.sh --fullstack} run reaching
+ * {@code document_aspects > 0} (nexus-i9o37.3).
+ *
+ * <p>What this test DOES catch cheaply: a Feature that silently enumerates nothing
+ * (vacuous registration) or schema-model drift where {@code Nexus.NEXUS.getTables()}
+ * stops returning some generated tables. It exercises the Feature's OWN discovery
+ * path ({@link JooqRecordReflectionFeature#recordTypes()}) rather than a parallel
+ * re-derivation, so passing means the exact set the Feature registers is the full set.
+ */
+class JooqRecordReflectionFeatureTest {
+
+    /** Generated record count under dev.nexus.service.jooq.nexus.tables.records.* */
+    private static final int EXPECTED_RECORD_TYPES = 50;
+
+    @Test
+    void enumeratesEveryGeneratedRecordTypeViaTheSchemaModel() {
+        List<Class<?>> records = JooqRecordReflectionFeature.recordTypes();
+
+        assertEquals(
+                EXPECTED_RECORD_TYPES,
+                records.size(),
+                "Feature must enumerate every jOOQ generated record type via the schema "
+                        + "model; a different count means the schema grew/shrank (update this "
+                        + "guard deliberately) or the discovery path went vacuous");
+
+        assertTrue(
+                records.stream()
+                        .allMatch(c -> c.getName()
+                                .startsWith("dev.nexus.service.jooq.nexus.tables.records.")),
+                "every enumerated type must be a generated record class");
+    }
+}

--- a/tests/e2e/migration-rehearsal/rehearse_fullstack.sh
+++ b/tests/e2e/migration-rehearsal/rehearse_fullstack.sh
@@ -95,24 +95,46 @@ printf '%s' "$wlout" | grep -qiE "widget|sprocket|gadget" && ok "nx_answer (MCP)
 # and knowledge__* IS extractor-eligible — select_config → scholarly-paper-v1, then
 # per-document shape routing (RDR-145 Gap-3 / nexus-kmbys): a PAPER-shaped doc (the
 # workload's doc (a)) extracts via scholarly-paper-v1, prose via general-prose-v1.
-# So store_put enqueues and the lazy-spawned worker drains it IN the MCP process
-# during the session. Assert the END STATE (document_aspects > 0) as a HARD failure,
-# not a soft note — guarded by the non-vacuity check that store_put actually landed
-# the document (the knowledge-collection assertion above).
+# So store_put enqueues and the leased daemon drains it. Assert the END STATE
+# (document_aspects > 0) as a HARD failure, not a soft note — guarded by the
+# non-vacuity check that store_put actually landed the document (the knowledge-
+# collection assertion above).
 #
-# LIFECYCLE CAVEAT (P2.1 review): the worker is a daemon thread inside nx-mcp; when
-# claude -p exits it tears down nx-mcp and the worker dies WITHOUT a join. So the
-# extraction must complete BEFORE claude -p returns — this post-process poll only
-# absorbs PG read-visibility lag, it canNOT extend the drain window. A hard FAIL
-# here therefore means the in-session drain did not complete (the worker-lifecycle
-# question the prior soft-note dodged) — that is exactly the silent-loss class this
-# RDR makes loud, so it SHOULD fail rather than be excused. P2.5 (nexus-8zog5)
-# characterises whether the in-session drain is reliable on the real container; if
-# it is not, that is a NEW bug to file, not a reason to soften this gate.
-for _ in $(seq 1 12); do
+# RDR-173 LIFECYCLE (supersedes the pre-RDR-173 P2.1 caveat below): the worker is
+# NO LONGER an in-nx-mcp daemon thread. In SERVICE mode the enqueue hook spawns a
+# LEASED aspect-worker DAEMON, DETACHED via start_new_session (aspect_worker_daemon
+# .py), so it OUTLIVES the claude -p / nx-mcp teardown and drains the shared PG
+# queue independently (RF-4 — extraction no longer gated by the storing process's
+# lifetime). This post-teardown poll therefore LEGITIMATELY extends the drain
+# window: nx-mcp is already dead, yet the detached daemon keeps draining as long as
+# the container is alive. Give it real time — real extraction calls `claude -p`
+# per document (cold start, slow); 36s (the old in-process window) was far too
+# short for the 4-doc workload.
+#
+# Non-vacuity is PRESERVED by extending the window: on pre-RDR-173 code the in-
+# process worker dies with nx-mcp and NOTHING drains during this post-teardown poll
+# no matter how long it runs → document_aspects stays 0. Only the detached daemon
+# can move the needle here, so a green is the RF-4 proof, not a softened gate.
+#
+# Diagnostics first: prove the detached daemon actually outlived nx-mcp (RF-4) and
+# surface its crash/daemon logs so a 0-row result distinguishes "daemon never
+# spawned / crashed" (real bug) from "daemon draining, needs more time".
+LOGS_DIR="$HOME/.config/nexus/logs"
+note "leased-daemon liveness after nx-mcp teardown (RF-4 check):"
+if pgrep -af "aspect-worker" >/dev/null 2>&1; then
+  pgrep -af "aspect-worker" | sed 's/^/       proc: /'
+  ok "leased aspect-worker daemon SURVIVED nx-mcp teardown (RF-4: extraction host is process-independent)"
+else
+  note "no live aspect-worker process found post-teardown"
+fi
+for lg in aspect_worker_daemon.crash.log aspect_worker_daemon.log; do
+  if [ -s "$LOGS_DIR/$lg" ]; then note "tail $lg:"; tail -25 "$LOGS_DIR/$lg" | sed 's/^/       /'; fi
+done
+# Extended drain window: up to ~10 min (150 x 4s), break the instant a row lands.
+for _ in $(seq 1 150); do
   asp="$(q "select count(*) from nexus.document_aspects")"
   [ "${asp:-0}" -gt 0 ] 2>/dev/null && break
-  sleep 3
+  sleep 4
 done
 enq="$(q "select count(*) from nexus.aspect_extraction_queue")"
 pend="$(q "select count(*) from nexus.aspect_extraction_queue where status in ('pending','in_progress')")"
@@ -139,7 +161,7 @@ if [ "${asp:-0}" -gt 0 ] 2>/dev/null; then
   ok "SERVICE-MODE aspect pipeline works END-TO-END: store_put → enqueue → worker → document_aspects (${asp} rows, real extraction)"
 elif [ "${STORED_OK:-0}" -eq 1 ] 2>/dev/null; then
   if [ "${enq:-0}" -gt 0 ] 2>/dev/null; then
-    bad "SERVICE-MODE aspect pipeline BROKEN: enqueued=${enq} (pending=${pend:-?}) but document_aspects=0 — worker did not drain in-session before nx-mcp teardown (worker-lifecycle; Approach 5 / P2.2)"
+    bad "SERVICE-MODE aspect pipeline BROKEN: enqueued=${enq} (pending=${pend:-?}) but document_aspects=0 after the extended post-teardown drain window — the leased daemon did not drain the queue (see liveness/log diagnostics above: never spawned, crashed, or extraction stalled; RDR-173 RF-4 / Approach 5 / P2.2)"
   else
     bad "SERVICE-MODE aspect pipeline BROKEN: store_put landed but enqueued=0 AND document_aspects=0 — hook did not enqueue (the silent-loss class; Approach 5 / P2.2)"
   fi


### PR DESCRIPTION
## Summary

Fixes a P0 native-image bug (RDR-173 P7 / `nexus-i9o37`): jOOQ generated `*Record` classes were unregistered for GraalVM reflection, so **every `INSERT…RETURNING` write 500'd** in the native engine-service (`MissingReflectionRegistrationError`). jOOQ's `RETURNING` path reflectively instantiates the generated record via `Class.getDeclaredConstructor()`; community reachability metadata covers jOOQ's library classes but not app-generated records. Discovered when `POST /v1/aspects/upsert` 500'd on `DocumentAspectsRecord.<init>()`, leaving `document_aspects` empty.

## The fix (2 parts)

1. **`JooqRecordReflectionFeature`** — a build-time GraalVM `Feature` that enumerates every generated record type from jOOQ's own schema model (`Nexus.NEXUS.getTables()` → `getRecordType()`) and registers their **constructors** for reflection. Exhaustive-by-construction (covers all current + future tables, drift-proof). Constructors only — jOOQ sets returned columns via its internal `TableField` model, not record-member reflection. Wired via `--features` in the native profile; `provided`-scope `org.graalvm.sdk:nativeimage` for the hosted API (build-time only, never bundled).
2. **`--initialize-at-build-time=org.xml.sax.helpers`** — the Feature's build-time schema access fires jOOQ slf4j logging at build time, which drives the (already build-time-init) logback to parse `logback.xml` and retain SAX config scaffolding (`LocatorImpl`/`AttributesImpl`/…) in the build-time heap. Package-level build-time-init completes the existing `ch.qos.logback` intent. Attribution confirmed via a control native build at the parent commit (no Feature = clean build).

## Validation

- Full `./mvnw test` — **961 tests green**.
- `-Pnative` build green (in `native-image-community:25`; host build blocked by a reachability-metadata schema skew — always build in-container).
- `run.sh --fullstack` — **`document_aspects=4`** (real extraction), aspect queue drained, **zero `RETURNING` 500s**.
- Stacked review (code-review-expert + substantive-critic): both clean, no code changes.

## Follow-up (tracked on `nexus-i9o37.6`)

The cloud re-gate must also exercise `plan_save` (`PlansRecord`) and `memory_upsert` (`MemoryRecord`) — the same `recordFactory` path, structurally fixed here (all 50 records registered) but only `DocumentAspectsRecord` was empirically exercised. `CatalogRepository` RETURNING is exempt (untyped DSL → generic `Record`).

Refs `nexus-i9o37` (`.1`–`.4`). Engine cut + cloud deploy follow as `.5`/`.6`.
