### PR TITLE
fix(catalog): guard by_file_path against server owner-list leak (GH #1350)

### DIFF
--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -751,14 +751,26 @@ class HttpCatalogClient:
     def by_file_path(
         self, owner: Tumbler | str, file_path: str
     ) -> CatalogEntry | None:
+        # nexus-h9f1w / GH #1350: the service /list ignores file_path when owner
+        # is set and returns the FULL owner list, so a brand-new file's query
+        # yields docs[0] (an unrelated doc). Trusting docs[0] mis-attributed the
+        # new file's chunks to that doc, overwriting its manifest (silent data
+        # corruption). Filter by exact file_path client-side; correct regardless
+        # of the server-side bug (Fix B tracked separately).
         result = self._get("/list", owner=str(owner), file_path=file_path)
         docs = result.get("documents", []) if result else []
-        return _to_entry(docs[0]) if docs else None
+        match = [d for d in docs if d.get("file_path") == file_path]
+        return _to_entry(match[0]) if match else None
 
     def by_source_uri(self, uri: str) -> CatalogEntry | None:
+        # nexus-h9f1w / GH #1350: same docs[0]-trust class as by_file_path.
+        # Defense-in-depth exact-match filter (the server currently filters
+        # source_uri correctly; this guards against an owner-list-leak-style
+        # regression and keeps the sibling lookups consistent).
         result = self._get("/list", source_uri=uri)
         docs = result.get("documents", []) if result else []
-        return _to_entry(docs[0]) if docs else None
+        match = [d for d in docs if d.get("source_uri") == uri]
+        return _to_entry(match[0]) if match else None
 
     def find_by_file_path(self, file_path: str) -> CatalogEntry | None:
         """Return the first document matching file_path (no owner filter).
@@ -767,9 +779,15 @@ class HttpCatalogClient:
         known owner (nexus-xnz0o).  Uses GET /list?file_path=X (owner-agnostic
         form supported by the Java /list endpoint).
         """
+        # nexus-h9f1w / GH #1350: exact-match guard, same class as by_file_path.
+        # The owner-agnostic /list routes to documentsByFilePath (exact eq) so
+        # this is a no-op today; kept for consistency + regression defense. When
+        # a path is shared across owners the server returns >1 match and this
+        # preserves the documented "first match" contract.
         result = self._get("/list", file_path=file_path)
         docs = result.get("documents", []) if result else []
-        return _to_entry(docs[0]) if docs else None
+        match = [d for d in docs if d.get("file_path") == file_path]
+        return _to_entry(match[0]) if match else None
 
     def by_owner(self, owner: Tumbler | str) -> list[CatalogEntry]:
         return self._docs_from(self._get("/list", owner=str(owner)))

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -243,8 +243,12 @@ def _register_or_lookup_doc_id(
             source_mtime=source_mtime,
         )
         return str(tumbler)
-    except Exception:  # noqa: BLE001 — best-effort/telemetry path; failure logged at debug, must not crash caller
-        _log.debug("preflight_register_failed", exc_info=True)
+    except Exception:  # noqa: BLE001 — best-effort/telemetry path; must not crash caller
+        # nexus-h9f1w / GH #1350 Fix C: a preflight registration failure meant a
+        # new file gets no catalog node (orphan chunks) yet the ingest still
+        # reports success. Surface it at warning, not debug, so the operator can
+        # see a non-clean run instead of silent data loss.
+        _log.warning("preflight_register_failed", exc_info=True)
         return ""
     finally:
         if writer is not None:

--- a/tests/catalog/test_http_catalog_client.py
+++ b/tests/catalog/test_http_catalog_client.py
@@ -1052,3 +1052,47 @@ class TestResolveChash:
             assert result is None
         finally:
             server.shutdown()
+
+
+class TestByFilePathExactMatchGuard:
+    """GH #1350 / nexus-h9f1w: by_file_path(owner, fp) must return None for a
+    brand-new file even when the service /list ignores file_path under owner and
+    returns the FULL owner list. Trusting docs[0] mis-attributed a new file's
+    chunks to an unrelated doc, overwriting that doc's manifest (silent data
+    corruption, fired twice in prod). The client MUST filter by exact file_path.
+    """
+
+    def _client_returning(self, fake_server: str, documents: list[dict]):
+        c = HttpCatalogClient(base_url=fake_server, _token="test_tok")
+
+        def _fake_get(path: str, **params: Any) -> dict:
+            # Reproduce the buggy server: owner+file_path ignores file_path and
+            # returns the entire owner list regardless of the file_path param.
+            return {"documents": documents}
+
+        c._get = _fake_get  # type: ignore[method-assign]
+        return c
+
+    def test_new_file_under_populated_owner_returns_none(self, fake_server: str) -> None:
+        """The corruption trigger: querying a NEW path returns None, not docs[0]."""
+        owner_list = [
+            {"tumbler": "1.12.1", "title": "Beyond Similarity Search", "file_path": "existing/a.pdf"},
+            {"tumbler": "1.12.2", "title": "Other", "file_path": "existing/b.pdf"},
+        ]
+        c = self._client_returning(fake_server, owner_list)
+        assert c.by_file_path("1.12", "brand/new/paper.pdf") is None
+
+    def test_existing_file_returns_its_own_entry_not_docs0(self, fake_server: str) -> None:
+        """A real match is selected by exact file_path even when it is NOT docs[0]."""
+        owner_list = [
+            {"tumbler": "1.12.1", "title": "Beyond Similarity Search", "file_path": "existing/a.pdf"},
+            {"tumbler": "1.12.2", "title": "Target", "file_path": "existing/b.pdf"},
+        ]
+        c = self._client_returning(fake_server, owner_list)
+        entry = c.by_file_path("1.12", "existing/b.pdf")
+        assert entry is not None
+        assert str(entry.tumbler) == "1.12.2"
+
+    def test_empty_owner_returns_none(self, fake_server: str) -> None:
+        c = self._client_returning(fake_server, [])
+        assert c.by_file_path("1.12", "any/path.pdf") is None


### PR DESCRIPTION
## Summary

Fixes silent data corruption (#1350). `nx dt index` into an owner that already has documents mis-attributed the new file's chunks to an unrelated doc and **overwrote that doc's chunk manifest**. Fired twice in production, both clobbering `1.12.1`, each repaired by hand in PG.

## Root cause

- Service `GET /v1/catalog/list?owner=X&file_path=Y` ignores `file_path` when `owner` is set (`CatalogHandler.handleList` branches to `documentsByOwner` and drops the predicate) and returns the full owner list.
- `HttpCatalogClient.by_file_path` trusted `docs[0]`, so a brand-new file returned an unrelated doc, treated by `doc_indexer` as "already registered" → chunks written under the wrong tumbler, victim manifest rebuilt (delete-then-insert).
- The failure was swallowed at `debug`; ingest reported success.

## Fix

- **A (client, this PR):** `by_file_path` filters documents by exact `file_path` before selecting a match. Verified correct — the Java service stores `file_path` verbatim (`CatalogRepository` register, no normalization) and its own owner-agnostic list uses exact equality, so the client mirrors the server's comparison. Covers both `doc_indexer` call sites; freeze-independent.
- Same exact-match guard applied to sibling `by_source_uri` / `find_by_file_path` (defense-in-depth against the same `docs[0]`-trust class; no-op under correct server behavior).
- **C (this PR):** preflight-register swallow bumped `debug`→`warning` so orphan-chunk registration failures surface.
- **B (deferred, engine):** `nexus-lc8r5` — Java `/list` must honor `file_path` alongside `owner`.

## Tests

New `TestByFilePathExactMatchGuard` (non-vacuous — fails pre-fix): a new file under a populated owner returns `None`; an existing file resolves to its own entry even when not `docs[0]`. Full `tests/catalog` + `tests/test_doc_indexer` suites green (187 passed).

## Review

Stacked review clean: code-review-expert APPROVED (no blockers); substantive-critic 0 critical / 2 significant, both addressed (sibling-method guards + verbatim-storage verification).

Closes #1350