### PR TITLE
fix(engine): /catalog/list honors file_path under owner (GH #1350 Fix B)

### DIFF
--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -779,6 +779,24 @@ public final class CatalogRepository {
         );
     }
 
+    /**
+     * Documents by owner tumbler prefix AND file_path (exact). GH #1350 Fix B.
+     *
+     * <p>The combined predicate is the correct behaviour for
+     * {@code GET /list?owner=X&file_path=Y}: the owner-only path returns the
+     * full owner list, which caused {@code HttpCatalogClient.by_file_path} to
+     * mis-attribute a new file to an unrelated doc (silent manifest overwrite).
+     */
+    public List<Map<String, Object>> documentsByOwnerAndFilePath(
+            String tenant, String ownerPrefix, String filePath) {
+        return tenantScope.withTenant(tenant, ctx ->
+            ctx.select(documentFields()).from(T_DOCS)
+               .where(F_DOC_TUMBLER.like(ownerPrefix + ".%").and(F_DOC_FPATH.eq(filePath)))
+               .orderBy(F_DOC_TUMBLER)
+               .fetch().map(r -> docRowFromRecord(r.intoMap()))
+        );
+    }
+
     /** Documents by content_type. */
     public List<Map<String, Object>> documentsByContentType(String tenant, String contentType) {
         return tenantScope.withTenant(tenant, ctx ->

--- a/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
@@ -259,6 +259,12 @@ public final class CatalogHandler implements HttpHandler {
             docs = repo.documentsByContentType(tenant, contentType);
         } else if (corpus != null && !corpus.isBlank()) {
             docs = repo.documentsByCorpus(tenant, corpus);
+        } else if (owner != null && !owner.isBlank()
+                   && filePath != null && !filePath.isBlank()) {
+            // GH #1350 Fix B: owner+file_path must filter by BOTH. The owner-only
+            // branch below ignored file_path and returned the full owner list,
+            // driving the client's docs[0] mis-attribution (silent corruption).
+            docs = repo.documentsByOwnerAndFilePath(tenant, owner, filePath);
         } else if (owner != null && !owner.isBlank()) {
             docs = repo.documentsByOwner(tenant, owner);
         } else if (filePath != null && !filePath.isBlank()) {

--- a/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
@@ -328,6 +328,32 @@ class CatalogRepositoryTest {
     }
 
     /**
+     * GH #1350 Fix B (nexus-lc8r5): documentsByOwnerAndFilePath must filter by
+     * BOTH owner prefix and exact file_path. The owner-only path returns the
+     * whole owner list, which drove the client's docs[0] mis-attribution
+     * (silent manifest overwrite).
+     */
+    @Test @Order(16)
+    void document_byOwnerAndFilePath_filtersByBoth() {
+        repo.upsertDocument(TENANT_A, Map.of(
+            "tumbler", "7.1", "title", "Owner7 A", "content_type", "paper",
+            "corpus", "knowledge", "file_path", "owner7/a.pdf"));
+        repo.upsertDocument(TENANT_A, Map.of(
+            "tumbler", "7.2", "title", "Owner7 B", "content_type", "paper",
+            "corpus", "knowledge", "file_path", "owner7/b.pdf"));
+
+        // Exact existing path under the owner: exactly one, the right one.
+        var hit = repo.documentsByOwnerAndFilePath(TENANT_A, "7", "owner7/b.pdf");
+        assertThat(hit).hasSize(1);
+        assertThat(hit.get(0).get("tumbler")).isEqualTo("7.2");
+
+        // Brand-new path under a POPULATED owner: zero (this is what stops the
+        // corruption — the client no longer receives docs[0] of the owner).
+        var miss = repo.documentsByOwnerAndFilePath(TENANT_A, "7", "owner7/brand-new.pdf");
+        assertThat(miss).isEmpty();
+    }
+
+    /**
      * RDR-159 P-1a (nexus-0wz93): relationCounts returns tenant-scoped row
      * counts for whitelisted migration-verify relations and OMITS any
      * relation outside the whitelist (no arbitrary relation counts).


### PR DESCRIPTION
## Summary

Server-side half of #1350 (engine). `CatalogHandler.handleList` branched to `documentsByOwner` when `owner` was set and **dropped the `file_path` predicate**, returning the full owner list — the root cause that drove the client's `docs[0]` mis-attribution and silent manifest overwrite.

## Change

- New `CatalogRepository.documentsByOwnerAndFilePath(tenant, ownerPrefix, filePath)` — owner prefix `AND` exact `file_path`, mirroring the existing exact-eq filter.
- `handleList` dispatches to it when **both** `owner` and `file_path` are present, ahead of the owner-only branch.
- `register` stores `file_path` verbatim (no normalization), so exact match is correct on both client and server.

## Tests

`document_byOwnerAndFilePath_filtersByBoth` (CatalogRepositoryTest): owner+file_path returns exactly the match; a new path under a populated owner returns 0. Full `CatalogRepositoryTest` green (98 tests).

## Relationship to Fix A

Client-side Fix A (#1353, `nexus-h9f1w`) already stops the corruption on develop and is freeze-independent. This is the defence-in-depth server fix.

## Deploy note

Engine change — reaches the cloud only on the next `engine-service` cut + deploy (separate lifecycle). Fix A protects the client meanwhile.

Part of #1350.