### PR TITLE
release: conexus 6.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v6.2.0"
+        "ref": "v6.3.1"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "6.2.0"
+      "version": "6.3.1"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v6.2.0"
+        "ref": "v6.3.1"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "6.2.0"
+      "version": "6.3.1"
     }
   ]
 }

--- a/.github/workflows/engine-service-release.yml
+++ b/.github/workflows/engine-service-release.yml
@@ -423,13 +423,36 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
-      - name: Build PG + pgvector bundle and package .txz
+      # nexus-m8au7: PG_VERSION + PGVECTOR_VERSION are pinned constants that
+      # rarely change across tags, yet every tag recompiled both from source
+      # (~10-20 min/arch). Cache the COMPILED PREFIX keyed on everything that
+      # determines its content: versions, arch, builder image, and the build
+      # script itself (the script does the macOS relocatability fixup — a
+      # script change MUST invalidate the cache, or a stale bundle would ship
+      # the exact 2026-07-01 dyld-abort class again). On a hit the compile is
+      # skipped; packaging, the relocation gate, signing, and upload still run
+      # per release, so the one-cosign-identity contract and per-release
+      # acquisition URLs are unchanged, and the relocation gate stays the
+      # safety net against a stale/poisoned cache entry.
+      # restore-ONLY (review finding): tag-scoped cache saves can never be
+      # restored (tags only read default-branch caches), so a save here is
+      # pure quota waste against the repo's 10GB budget and can evict the
+      # legit main-scoped entries. Only pg-bundle-cache-seed.yml saves.
+      - name: Restore compiled PG bundle cache
+        id: pg-bundle-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        with:
+          path: bundle
+          key: pg-bundle-${{ matrix.target.arch }}-${{ matrix.target.runner }}-pg${{ env.PG_VERSION }}-pgvector${{ env.PGVECTOR_VERSION }}-img-${{ matrix.target.image || 'native' }}-${{ hashFiles('scripts/build_pg_bundle.sh') }}
+
+      - name: Build PG + pgvector bundle (cache miss only)
+        if: steps.pg-bundle-cache.outputs.cache-hit != 'true'
         env:
           MANYLINUX_IMAGE: ${{ matrix.target.image }}
         run: |
           set -euo pipefail
           bundle="$GITHUB_WORKSPACE/bundle"
-          mkdir -p "$bundle" dist
+          mkdir -p "$bundle"
           if [ -n "$MANYLINUX_IMAGE" ]; then
             # linux: build inside manylinux_2_28 so the binaries' glibc floor is
             # 2.28 (broad compatibility), exactly as ci.yml's CA-3 gate builds them.
@@ -445,6 +468,32 @@ jobs:
             # applies MACOSX_DEPLOYMENT_TARGET). GH macOS runners have no Docker.
             BUNDLE_PREFIX="$bundle" bash scripts/build_pg_bundle.sh
           fi
+
+      - name: Package .txz
+        run: |
+          set -euo pipefail
+          bundle="$GITHUB_WORKSPACE/bundle"
+          mkdir -p dist
+          # Cache-hit sanity: a restored prefix must actually contain the PG
+          # toolchain; an empty/partial restore fails loud here rather than
+          # shipping a hollow .txz (the relocation gate below would also catch
+          # it, but this points at the cache instead of at relocation).
+          if [ ! -x "$bundle/bin/initdb" ]; then
+            echo "::error::bundle/bin/initdb missing — cache restored a hollow prefix or the build did not run"
+            exit 1
+          fi
+          # nexus-u30zm (critique Critical): a cache hit skips the build
+          # script's verify_and_mark(), which is the only place contrib
+          # completeness was asserted — a partial restore that kept initdb
+          # and vector but lost pg_trgm would otherwise sign + ship broken
+          # (RDR-155 needs pg_trgm). Mirror verify_and_mark here.
+          sharedir="$("$bundle/bin/pg_config" --sharedir)"
+          for ctl in vector pg_trgm; do
+            if [ ! -f "$sharedir/extension/$ctl.control" ]; then
+              echo "::error::$ctl.control missing from bundle — contrib set incomplete (cache corruption or build regression)"
+              exit 1
+            fi
+          done
           # -C parent + basename preserves the relative bin/ lib/ share/ layout
           # relocation depends on (identical to ci.yml packaging).
           tar -cJf "dist/$ASSET.txz" -C "$(dirname "$bundle")" "$(basename "$bundle")"
@@ -494,6 +543,10 @@ jobs:
           # bare "vector" this assertion originally (incorrectly) expected.
           "$root/bin/psql" -h "$sock" -p 59987 -U "$(id -un)" -d postgres -c \
             "CREATE EXTENSION IF NOT EXISTS vector" >/dev/null
+          # nexus-u30zm: pg_trgm must LOAD, not merely exist on disk — the
+          # cache-hit path has no other executable proof of the contrib set.
+          "$root/bin/psql" -h "$sock" -p 59987 -U "$(id -un)" -d postgres -c \
+            "CREATE EXTENSION IF NOT EXISTS pg_trgm" >/dev/null
           out="$("$root/bin/psql" -h "$sock" -p 59987 -U "$(id -un)" -d postgres -tAc \
             "SELECT extname FROM pg_extension WHERE extname='vector'")"
           if [ "$out" != "vector" ]; then

--- a/.github/workflows/pg-bundle-cache-seed.yml
+++ b/.github/workflows/pg-bundle-cache-seed.yml
@@ -1,0 +1,101 @@
+# nexus-m8au7: seed + keep-warm the compiled PG-bundle cache on MAIN.
+#
+# WHY THIS WORKFLOW EXISTS — GitHub Actions cache isolation: a run triggered
+# by a tag can only RESTORE caches created on the same ref or on the DEFAULT
+# branch (main). Caches saved by one engine-service tag run are invisible to
+# the next tag, so engine-service-release.yml's cache step can only ever hit
+# entries seeded here. Eviction is 7-days-unused; engine tags are often
+# further apart, hence the weekly cron keep-warm.
+#
+# The cache key MUST stay byte-identical to the one in
+# engine-service-release.yml (build-publish-pg-bundle job):
+#   pg-bundle-<arch>-pg<PG_VERSION>-pgvector<PGVECTOR_VERSION>-img-<image|native>-<sha256 of scripts/build_pg_bundle.sh>
+# PG_VERSION / PGVECTOR_VERSION are duplicated across ci.yml, the release
+# workflow, and here (the pre-existing duplication pattern; the build script
+# holds the defaults). Bumping a version in the release workflow WITHOUT
+# bumping it here just means a cache miss at the next tag (graceful — it
+# compiles as before); the versions live in the key precisely so a stale
+# bundle of the WRONG version can never be restored silently.
+name: pg-bundle-cache-seed
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/build_pg_bundle.sh'
+      - '.github/workflows/pg-bundle-cache-seed.yml'
+  schedule:
+    # Weekly keep-warm (Mondays 07:23 UTC — off the hour to dodge cron rush).
+    - cron: '23 7 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  seed:
+    name: Seed PG bundle cache (${{ matrix.target.arch }})
+    runs-on: ${{ matrix.target.runner }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { arch: linux-amd64, runner: ubuntu-latest,    image: "quay.io/pypa/manylinux_2_28_x86_64" }
+          - { arch: linux-arm64, runner: ubuntu-24.04-arm, image: "quay.io/pypa/manylinux_2_28_aarch64" }
+          - { arch: mac-arm64,   runner: macos-14,         image: "" }
+    env:
+      # Pinned identically to engine-service-release.yml + ci.yml (see header).
+      PG_VERSION: "17.5"
+      PGVECTOR_VERSION: "v0.8.2"
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      - name: Restore/claim cache slot
+        id: pg-bundle-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        with:
+          path: bundle
+          key: pg-bundle-${{ matrix.target.arch }}-${{ matrix.target.runner }}-pg${{ env.PG_VERSION }}-pgvector${{ env.PGVECTOR_VERSION }}-img-${{ matrix.target.image || 'native' }}-${{ hashFiles('scripts/build_pg_bundle.sh') }}
+
+      - name: Compile PG + pgvector (cache miss only)
+        if: steps.pg-bundle-cache.outputs.cache-hit != 'true'
+        env:
+          MANYLINUX_IMAGE: ${{ matrix.target.image }}
+        run: |
+          set -euo pipefail
+          bundle="$GITHUB_WORKSPACE/bundle"
+          mkdir -p "$bundle"
+          if [ -n "$MANYLINUX_IMAGE" ]; then
+            # Identical build environment to engine-service-release.yml:
+            # manylinux_2_28 for the glibc-2.28 floor.
+            docker run --rm \
+              -e PG_VERSION -e PGVECTOR_VERSION -e BUNDLE_PREFIX="$bundle" \
+              -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+              "$MANYLINUX_IMAGE" /bin/bash -c '
+                set -eux
+                bash "'"$GITHUB_WORKSPACE"'/scripts/build_pg_bundle.sh"
+              '
+          else
+            BUNDLE_PREFIX="$bundle" bash scripts/build_pg_bundle.sh
+          fi
+
+      - name: Sanity-check the prefix before it becomes the cached artifact
+        if: steps.pg-bundle-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          if [ ! -x "bundle/bin/initdb" ] || [ ! -x "bundle/bin/pg_ctl" ]; then
+            echo "::error::compiled prefix is missing the PG toolchain — refusing to seed a hollow cache"
+            exit 1
+          fi
+          # nexus-u30zm: contrib completeness (mirrors verify_and_mark). The
+          # actions/cache post-save runs with post-if: success() (verified
+          # upstream), so an exit 1 here genuinely prevents the seed.
+          sharedir="$(bundle/bin/pg_config --sharedir)"
+          for ctl in vector pg_trgm; do
+            if [ ! -f "$sharedir/extension/$ctl.control" ]; then
+              echo "::error::$ctl.control missing — refusing to seed an incomplete contrib set"
+              exit 1
+            fi
+          done
+          echo "prefix ok — cache will be saved on job success"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,99 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.3.1] - 2026-07-04
+
+The shakeout-follow-ups release (epic nexus-c0twp). Everything the 6.3.0 live
+shakeout deferred, plus everything the new safety nets caught while building
+them. Pins engine-service-v0.1.22 (cloud-gated 2026-07-04).
+
+### Fixed
+- `nx t3 gc` no longer crashes in service mode — local event-log emission is
+  skipped when the catalog is service-backed (live-shakeout finding #4).
+- `nx store put` no longer loses aspect extraction on fresh notes: the document
+  hook chain carries the catalog doc_id, not the T3 chunk id, so the engine's
+  FK accepts the enqueue (nexus-w8lg1); the enqueue-failure warning is one line
+  (traceback at debug).
+- `nx collection re-embed` and the chash backfill no longer crash on
+  `db._client` (absent from every production handle post-RDR-155); service-mode
+  re-embed is same-model-only via the verbatim vector passthrough, and a
+  cross-model `--to` fails loud with correct guidance instead of silently
+  re-embedding with the wrong model (nexus-c9xr2, nexus-u37lw, nexus-tcvpn).
+- `nx collection rename` rejects same-prefix renames whose embedding-model
+  segment differs — rename never re-embeds, so the vectors would silently stay
+  in the old model space (nexus-tcvpn).
+- HttpCatalogClient shape drifts vs the local catalog fixed across 9 methods:
+  `graph`/`graph_many` return typed entries/links (the service-mode links CLI
+  was silently broken), `collection_health_meta` no longer drops
+  `stale_source_ratio`, `validate_link` returns error lists,
+  `legacy_grandfathered` is a bool, `descendants` rows are normalized, and
+  chunk-address `resolve_chunk` works against the new engine route
+  (nexus-u26b4, nexus-gc2ze).
+
+### Added
+- Bounded per-file indexing concurrency: 2 workers by default when both the
+  vectors and catalog backends are the HTTP service; `NX_INDEX_CONCURRENCY`
+  overrides; hook chains and progress callbacks are serialized;
+  `--debug-timing` gains a `hooks_s` bucket (nexus-cfc72).
+- Mechanized runtime return-shape tripwire across the shared
+  Catalog/HttpCatalogClient surface (72 registered parity entries + audited
+  exclusions + a completeness gate), with a T3-backed leg for span/chash
+  resolution (nexus-8y1tm, nexus-oq0tk).
+
+### Changed
+- Warm `nx index repo` no longer pays ~1,400–2,800 serial catalog round-trips
+  per run: one owner-scoped list + local join in both the registration hook
+  and the frecency map, and unchanged files skip their per-file catalog
+  update entirely (nexus-dst5h).
+- Pinned engine advances to engine-service-v0.1.22: aspect-queue linkage
+  preserved across doc_id-less re-enqueues, `/resolve_chunk`, metadata
+  updates MERGE like the local catalog (previously a silent-replace data-loss
+  class in service mode), and full raw-SQL elimination in the engine
+  (nexus-nyout, nexus-gc2ze, nexus-ke45f, nexus-xtmtf, nexus-mzuj9).
+- Engine release workflow caches the compiled PG bundle across tags
+  (nexus-m8au7).
+
+
+## [6.3.0] - 2026-07-03
+
+The service-mode seam-closure release (epic nexus-h8rf6). The first systematic
+post-consolidation shakeout of the 6.2.0 client against the cloud engine found
+a family of Chroma-era client seams never ported to service mode; this release
+closes all of them, plus the engine hardening that came out of a whole-tree
+Java audit. Pins engine-service-v0.1.21 (deployed + cloud-gated 2026-07-03).
+
+### Fixed
+- Service mode: `nx store expire` no longer crashes — `HttpVectorClient.expire`
+  implemented ($ne-based TTL pre-filter; `is_expired` stays authoritative).
+- Service mode: `nx doctor --fix-paths` no longer crashes —
+  `update_source_path` ported (accumulate-before-update pagination).
+- Service mode: `nx t3 gc` / `prune-stale` no longer silently no-op —
+  `delete_by_chunk_ids`, `list_unique_source_paths`,
+  `list_chunks_with_metadata` ported.
+- Service mode: the doctor model-drift probe no longer reports `error` for
+  every collection — `collection_metadata` ported with full T3 parity.
+- Service mode: distance-threshold filtering was silently disabled on every
+  search (retired `t3._voyage_client` gate); the reranker fix's sibling.
+  Thresholds now apply iff not local mode and a Voyage key is configured.
+- Service mode: `nx store delete --title`, `nx store list`, `nx collection
+  info` crashes — `find_ids_by_title`, `batch_delete`, `list_store`,
+  `collection_info` ported.
+- Cross-corpus reranker silently skipped in service mode
+  (`get_voyage_client()` fallback, now memoized).
+- Incremental indexing restored in service mode: `docs_for_chashes` returns
+  the documented dict shape and sends 32-char chash prefixes on the wire
+  (staleness cache was building empty, degrading every run to a full
+  re-embed).
+- Taxonomy assign hook crashed on every document in service mode (numpy
+  array truthiness).
+- `NX_T1_ISOLATED=1` now wins over service-backend T1 routing; bare-CLI
+  `nx scratch` 401s explain the minted-token design with sanctioned paths.
+- `delete_by_chunk_ids` no longer reports 0 after a partially-successful
+  multi-batch delete.
+
+### Added
+- Chash-existence short-circuit before server-side embedding: full/forced
+
 ## [6.2.0] - 2026-07-02
 
 The unattended-migration release (RDR-178). An incident-shaped migration gap

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "6.2.0",
+  "version": "6.3.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -6,6 +6,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.3.1] - 2026-07-04
+
+Plugin version aligned with conexus 6.3.1. No plugin-side changes.
+
+## [6.3.0] - 2026-07-03
+
+Plugin version aligned with conexus 6.3.0. No plugin-side changes.
+
+
+
 ## [6.2.0] - 2026-07-02
 
 Plugin version aligned with conexus 6.2.0. No conexus-plugin-side changes —

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -82,6 +82,8 @@ nx index repo ./my-project
 | `--frecency-only` | Update frecency scores only; skip re-embedding (faster, for re-ranking refresh). Mutually exclusive with `--force` |
 | `--force-stale` | Re-index only if collection pipeline version is outdated (smart force — skips current collections) |
 | `--on-locked {skip,wait}` | Behavior under contention (default: `wait`). Per-repo advisory lock (two `nx index repo` on the same repo): `skip` exits immediately, `wait` blocks. Catalog-write fairness (RDR-146): when a foreground interactive catalog write is pending, `skip` defers this run's catalog writes to the next idempotent pass, `wait` proceeds after a bounded yield. `NX_WRITE_PRIORITY=interactive|batch` overrides the tty-based priority of a run's catalog writes. |
+
+Per-file indexing runs with bounded concurrency (6.3.1, nexus-cfc72): 2 workers by default when both the vectors and catalog backends are the HTTP service, 1 otherwise. `NX_INDEX_CONCURRENCY=N` overrides (a warning is logged when it forces concurrency past the backend gate). Progress callbacks and post-store hook chains are serialized; `--debug-timing` gains a `hooks_s` bucket so hook-serialization wait is visible separately from upload time.
 | `--no-taxonomy` | Skip automatic topic discovery after indexing |
 | `--debug-timing` | Emit an end-of-run per-stage breakdown to stderr (chunking / embed / upload / retry seconds per file, aggregated with percentages). Instruments code, prose, and PDF per-file paths — silent without the flag. Use when investigating "why did indexing take N minutes?" (introduced 4.9.0, nexus-7niu) |
 
@@ -1094,7 +1096,8 @@ nx collection list
 | `verify NAME` | Existence check + document count |
 | `reindex NAME` | Delete and re-index a collection from its source documents |
 | `backfill-hash [NAME]` | Add `chunk_text_hash` metadata to chunks missing it (no re-embedding) |
-| `rename OLD NEW` | In-place metadata-only rename in the T3 vector store + T2 + catalog cascade (4.8.0, nexus-1ccq) |
+| `rename OLD NEW` | In-place metadata-only rename in the T3 vector store + T2 + catalog cascade (4.8.0, nexus-1ccq). Never re-embeds; same-prefix renames whose embedding-model segment differs are rejected (6.3.1, nexus-tcvpn) |
+| `re-embed NAME --to MODEL` | In-place re-embed for non-CCE Voyage models (nexus-bw65). Service mode: same-model only — the computed vectors ride the verbatim passthrough; a cross-model `--to` fails loud (server-side embedding routes by the collection NAME's model segment; cross-model moves are the migration pipeline's job). `--no-dry-run --yes` to apply (6.3.1, nexus-c9xr2/u37lw) |
 | `audit NAME` | Deep-dive per-collection report: distance histogram, top-5 cross-projections, orphan chunks, hub topics, chash coverage (RDR-087 Phase 4) |
 | `health` | Composite per-collection health table — chunk counts (T3-sourced), staleness, hub score, chash coverage (RDR-087 Phase 3.4) |
 | `delete NAME` | Delete collection (irreversible) |
@@ -1136,7 +1139,7 @@ takes ~25–70 minutes on ChromaDB Cloud. Maintenance-window operation.
 
 | Flag | Description |
 |------|-------------|
-| `--force-prefix-change` | Allow a cross-prefix rename (e.g. `code__foo` → `docs__foo`). Embedding-model spaces differ across prefixes, so the renamed collection is query-incompatible with its old clients — use only when you've deleted every downstream reader |
+| `--force-prefix-change` | Allow a cross-prefix rename (e.g. `code__foo` → `docs__foo`) OR a same-prefix rename whose embedding-model segment differs (6.3.1, nexus-tcvpn). Rename never re-embeds, so either change leaves the vectors in the OLD model space under a name claiming the new one — use only when you know the vectors already match the target name (cross-model moves belong to `nx migrate` / guided-upgrade, the RDR-162 vector ETL) |
 
 Renames the collection in the T3 vector store via `t3.rename_collection` (a metadata-only update on the pgvector service path — no embedding re-upload, no Voyage cost, no vector egress), and cascades the new name through T2 taxonomy, `chash_index`, and catalog (JSONL + SQLite). Ordering (SIG-8 / nexus-nhyh): the T2 cascade runs FIRST, then the T3 rename, so a partial failure is recoverable: if the T3 rename fails the T2/catalog rows can be re-pointed or the rename re-run; if T2 fails no T3 rename was attempted.
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "6.2.0",
+  "version": "6.3.1",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conexus-mcpb"
-version = "6.2.0"
+version = "6.3.1"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
@@ -10,7 +10,7 @@ dependencies = [
     # while collections are indexed at 768/1024-dim, so every T3 search hits a
     # dimension mismatch and returns zero results. The .mcpb cannot run the
     # interactive `nx init` embedder choice, so it must pin [local] explicitly.
-    "conexus[local]>=6.2.0",
+    "conexus[local]>=6.3.1",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "6.2.0"
+version = "6.3.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -94,6 +94,7 @@
             <version>${jooq.version}</version>
         </dependency>
 
+
         <!-- GraalVM native-image hosted API (Feature, RuntimeReflection). Compile-only:
              used solely by JooqRecordReflectionFeature, which the native-image builder
              runs at image-build time. provided scope keeps it off the app-jar runtime
@@ -309,6 +310,24 @@
                                                 <inputSchema>t1</inputSchema>
                                             </schema>
                                         </schemata>
+                                        <!-- nexus-xtmtf: pgvector columns generate as
+                                             TableField<R, Vector> via VectorBinding —
+                                             retires the ?::vector casts + vectorLiteral()
+                                             strings. (jOOQ's own FloatVector types are
+                                             commercial-edition-only; the OSS
+                                             jooq-postgres-extensions jar has no vector
+                                             support, hence the in-repo binding.) The
+                                             binding class is referenced by NAME in
+                                             generated code and compiles in the same
+                                             javac pass — no codegen-classpath dep. -->
+                                        <forcedTypes>
+                                            <forcedType>
+                                                <userType>dev.nexus.service.jooq.binding.Vector</userType>
+                                                <binding>dev.nexus.service.jooq.binding.VectorBinding</binding>
+                                                <includeTypes>vector</includeTypes>
+                                                <priority>-2147483648</priority>
+                                            </forcedType>
+                                        </forcedTypes>
                                     </database>
                                     <generate>
                                         <pojos>true</pojos>

--- a/service/src/main/java/dev/nexus/service/db/AspectRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/AspectRepository.java
@@ -53,64 +53,60 @@ public final class AspectRepository {
     /** Minimum confidence threshold (mirrors Python _MIN_CONFIDENCE = 0.3). */
     private static final double MIN_CONFIDENCE = 0.3;
 
-    // EXCLUDED pseudo-table fields used in ON CONFLICT DO UPDATE SET.
-    // ⚠ DRIFT RISK (RDR-164 review S4): these field("...") fragments embed literal column
-    // names (EXCLUDED.<col>, and qualified table cols in the COALESCE/GREATEST/LEAST/CASE
-    // constants below) that jOOQ codegen CANNOT type-check — jOOQ has no typed API for the
-    // EXCLUDED pseudo-table. If any referenced column is renamed in a Liquibase changelog
-    // (document_aspects.{problem_formulation,proposed_method,experimental_datasets,
-    // experimental_baselines,experimental_results,extras,confidence,extracted_at,model_version,
-    // extractor_name,source_uri,salient_sentences,doc_id}; aspect_extraction_queue.{status,
-    // retry_count,enqueued_at,last_attempt_at,last_error}), these strings compile but fail at
-    // runtime. Update them HERE when renaming those columns.
-    private static final Field<String>          EX_PROBLEM_FORMULATION    = field("EXCLUDED.problem_formulation",    String.class);
-    private static final Field<String>          EX_PROPOSED_METHOD        = field("EXCLUDED.proposed_method",        String.class);
-    private static final Field<String>          EX_EXPERIMENTAL_DATASETS  = field("EXCLUDED.experimental_datasets",  String.class);
-    private static final Field<String>          EX_EXPERIMENTAL_BASELINES = field("EXCLUDED.experimental_baselines", String.class);
-    private static final Field<String>          EX_EXPERIMENTAL_RESULTS   = field("EXCLUDED.experimental_results",   String.class);
-    private static final Field<String>          EX_EXTRAS                 = field("EXCLUDED.extras",                 String.class);
-    private static final Field<Double>          EX_CONFIDENCE             = field("EXCLUDED.confidence",             Double.class);
-    private static final Field<OffsetDateTime>  EX_EXTRACTED_AT           = field("EXCLUDED.extracted_at",           OffsetDateTime.class);
-    private static final Field<String>          EX_MODEL_VERSION          = field("EXCLUDED.model_version",          String.class);
-    private static final Field<String>          EX_EXTRACTOR_NAME         = field("EXCLUDED.extractor_name",         String.class);
-    private static final Field<String>          EX_SOURCE_URI             = field("EXCLUDED.source_uri",             String.class);
-    private static final Field<String>          EX_SALIENT_SENTENCES      = field("EXCLUDED.salient_sentences",      String.class);
-    private static final Field<String>          EX_DOC_ID                 = field("EXCLUDED.doc_id",                 String.class);
+    // EXCLUDED pseudo-table fields used in ON CONFLICT DO UPDATE SET, typed via
+    // DSL.excluded(Field) (nexus-mzuj9: replaces the hand-built field("EXCLUDED.x", ...)
+    // raw-string fragments — jOOQ codegen now type-checks every column reference here
+    // against the generated DOCUMENT_ASPECTS / DOCUMENT_HIGHLIGHTS / ASPECT_EXTRACTION_QUEUE
+    // tables, so a Liquibase column rename fails at COMPILE time instead of at runtime).
+    private static final Field<String>          EX_PROBLEM_FORMULATION    = excluded(DOCUMENT_ASPECTS.PROBLEM_FORMULATION);
+    private static final Field<String>          EX_PROPOSED_METHOD        = excluded(DOCUMENT_ASPECTS.PROPOSED_METHOD);
+    private static final Field<String>          EX_EXPERIMENTAL_DATASETS  = excluded(DOCUMENT_ASPECTS.EXPERIMENTAL_DATASETS);
+    private static final Field<String>          EX_EXPERIMENTAL_BASELINES = excluded(DOCUMENT_ASPECTS.EXPERIMENTAL_BASELINES);
+    private static final Field<String>          EX_EXPERIMENTAL_RESULTS   = excluded(DOCUMENT_ASPECTS.EXPERIMENTAL_RESULTS);
+    private static final Field<String>          EX_EXTRAS                 = excluded(DOCUMENT_ASPECTS.EXTRAS);
+    private static final Field<Double>          EX_CONFIDENCE             = excluded(DOCUMENT_ASPECTS.CONFIDENCE);
+    private static final Field<OffsetDateTime>  EX_EXTRACTED_AT           = excluded(DOCUMENT_ASPECTS.EXTRACTED_AT);
+    private static final Field<String>          EX_MODEL_VERSION          = excluded(DOCUMENT_ASPECTS.MODEL_VERSION);
+    private static final Field<String>          EX_EXTRACTOR_NAME         = excluded(DOCUMENT_ASPECTS.EXTRACTOR_NAME);
+    private static final Field<String>          EX_SOURCE_URI             = excluded(DOCUMENT_ASPECTS.SOURCE_URI);
+    private static final Field<String>          EX_SALIENT_SENTENCES      = excluded(DOCUMENT_ASPECTS.SALIENT_SENTENCES);
+    private static final Field<String>          EX_DOC_ID                 = excluded(DOCUMENT_ASPECTS.DOC_ID);
 
     // COALESCE(EXCLUDED.x, table.x) fields for importAspect path
     private static final Field<String>          EX_SOURCE_URI_COALESCE =
-        field("COALESCE(EXCLUDED.source_uri, document_aspects.source_uri)", String.class);
+        coalesce(excluded(DOCUMENT_ASPECTS.SOURCE_URI), DOCUMENT_ASPECTS.SOURCE_URI);
     private static final Field<String>          EX_SALIENT_COALESCE =
-        field("COALESCE(EXCLUDED.salient_sentences, document_aspects.salient_sentences)", String.class);
+        coalesce(excluded(DOCUMENT_ASPECTS.SALIENT_SENTENCES), DOCUMENT_ASPECTS.SALIENT_SENTENCES);
     private static final Field<String>          EX_DOC_ID_COALESCE =
-        field("COALESCE(EXCLUDED.doc_id, document_aspects.doc_id)", String.class);
+        coalesce(excluded(DOCUMENT_ASPECTS.DOC_ID), DOCUMENT_ASPECTS.DOC_ID);
 
     // document_highlights EXCLUDED fields
-    private static final Field<String>          EX_HL_SOURCE_URI   = field("EXCLUDED.source_uri",    String.class);
-    private static final Field<String>          EX_HL_COLLECTION   = field("EXCLUDED.collection",    String.class);
-    private static final Field<String>          EX_HL_HIGHLIGHTS   = field("EXCLUDED.highlights_md", String.class);
-    private static final Field<String>          EX_HL_MENTIONS     = field("EXCLUDED.mentions_md",   String.class);
-    private static final Field<OffsetDateTime>  EX_HL_INGESTED_AT  = field("EXCLUDED.ingested_at",   OffsetDateTime.class);
+    private static final Field<String>          EX_HL_SOURCE_URI   = excluded(DOCUMENT_HIGHLIGHTS.SOURCE_URI);
+    private static final Field<String>          EX_HL_COLLECTION   = excluded(DOCUMENT_HIGHLIGHTS.COLLECTION);
+    private static final Field<String>          EX_HL_HIGHLIGHTS   = excluded(DOCUMENT_HIGHLIGHTS.HIGHLIGHTS_MD);
+    private static final Field<String>          EX_HL_MENTIONS     = excluded(DOCUMENT_HIGHLIGHTS.MENTIONS_MD);
+    private static final Field<OffsetDateTime>  EX_HL_INGESTED_AT  = excluded(DOCUMENT_HIGHLIGHTS.INGESTED_AT);
 
     // aspect_extraction_queue EXCLUDED fields
-    private static final Field<String>          EX_Q_DOC_ID          = field("EXCLUDED.doc_id",          String.class);
-    private static final Field<String>          EX_Q_CONTENT_HASH    = field("EXCLUDED.content_hash",    String.class);
-    private static final Field<String>          EX_Q_CONTENT         = field("EXCLUDED.content",         String.class);
-    private static final Field<OffsetDateTime>  EX_Q_ENQUEUED_AT     = field("EXCLUDED.enqueued_at",     OffsetDateTime.class);
-    private static final Field<String>          EX_Q_LAST_ERROR      = field("EXCLUDED.last_error",      String.class);
-    // Complex GREATEST/LEAST/CASE fields for importQueueRow
+    private static final Field<String>          EX_Q_DOC_ID          = excluded(ASPECT_EXTRACTION_QUEUE.DOC_ID);
+    private static final Field<String>          EX_Q_CONTENT_HASH    = excluded(ASPECT_EXTRACTION_QUEUE.CONTENT_HASH);
+    private static final Field<String>          EX_Q_CONTENT         = excluded(ASPECT_EXTRACTION_QUEUE.CONTENT);
+    private static final Field<OffsetDateTime>  EX_Q_ENQUEUED_AT     = excluded(ASPECT_EXTRACTION_QUEUE.ENQUEUED_AT);
+    private static final Field<String>          EX_Q_LAST_ERROR      = excluded(ASPECT_EXTRACTION_QUEUE.LAST_ERROR);
+    // Complex GREATEST/LEAST/CASE fields for importQueueRow, typed via DSL.when/.otherwise
+    // and DSL.greatest/DSL.least against the EXCLUDED pseudo-table + the live column.
     private static final Field<String>          EX_Q_STATUS_CASE =
-        field("CASE WHEN nexus.aspect_extraction_queue.status = 'in_progress' "
-            + "THEN nexus.aspect_extraction_queue.status ELSE EXCLUDED.status END", String.class);
+        when(ASPECT_EXTRACTION_QUEUE.STATUS.eq("in_progress"), ASPECT_EXTRACTION_QUEUE.STATUS)
+            .otherwise(excluded(ASPECT_EXTRACTION_QUEUE.STATUS));
     private static final Field<Integer>         EX_Q_RETRY_GREATEST =
-        field("GREATEST(EXCLUDED.retry_count, nexus.aspect_extraction_queue.retry_count)", Integer.class);
+        greatest(excluded(ASPECT_EXTRACTION_QUEUE.RETRY_COUNT), ASPECT_EXTRACTION_QUEUE.RETRY_COUNT);
     private static final Field<OffsetDateTime>  EX_Q_ENQUEUED_LEAST =
-        field("LEAST(EXCLUDED.enqueued_at, nexus.aspect_extraction_queue.enqueued_at)", OffsetDateTime.class);
+        least(excluded(ASPECT_EXTRACTION_QUEUE.ENQUEUED_AT), ASPECT_EXTRACTION_QUEUE.ENQUEUED_AT);
     private static final Field<OffsetDateTime>  EX_Q_ATTEMPT_GREATEST =
-        field("GREATEST(EXCLUDED.last_attempt_at, nexus.aspect_extraction_queue.last_attempt_at)", OffsetDateTime.class);
+        greatest(excluded(ASPECT_EXTRACTION_QUEUE.LAST_ATTEMPT_AT), ASPECT_EXTRACTION_QUEUE.LAST_ATTEMPT_AT);
     private static final Field<String>          EX_Q_LAST_ERROR_CASE =
-        field("CASE WHEN EXCLUDED.status = 'failed' THEN EXCLUDED.last_error "
-            + "ELSE nexus.aspect_extraction_queue.last_error END", String.class);
+        when(excluded(ASPECT_EXTRACTION_QUEUE.STATUS).eq("failed"), excluded(ASPECT_EXTRACTION_QUEUE.LAST_ERROR))
+            .otherwise(ASPECT_EXTRACTION_QUEUE.LAST_ERROR);
 
     private final TenantScope tenantScope;
 

--- a/service/src/main/java/dev/nexus/service/db/AspectRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/AspectRepository.java
@@ -906,7 +906,14 @@ public final class AspectRepository {
                     ASPECT_EXTRACTION_QUEUE.COLLECTION,
                     ASPECT_EXTRACTION_QUEUE.SOURCE_PATH)
                 .doUpdate()
-                .set(ASPECT_EXTRACTION_QUEUE.DOC_ID,          EX_Q_DOC_ID)
+                // nexus-nyout: a doc_id-less re-enqueue (blank -> NULL via
+                // nullIfBlank; e.g. collection re-embed) must not erase an
+                // existing correct tumbler — COALESCE keeps the old linkage;
+                // a real incoming tumbler still overwrites. The queue IMPORT
+                // path stays verbatim EXCLUDED.doc_id: fidelity import
+                // reproduces exported rows exactly, including blanks.
+                .set(ASPECT_EXTRACTION_QUEUE.DOC_ID,
+                     coalesce(EX_Q_DOC_ID, ASPECT_EXTRACTION_QUEUE.DOC_ID))
                 .set(ASPECT_EXTRACTION_QUEUE.CONTENT_HASH,    EX_Q_CONTENT_HASH)
                 .set(ASPECT_EXTRACTION_QUEUE.CONTENT,         EX_Q_CONTENT)
                 .set(ASPECT_EXTRACTION_QUEUE.STATUS,          "pending")

--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -1373,25 +1373,33 @@ public final class CatalogRepository {
     /** Upsert a collection. */
     public void upsertCollection(String tenant, Map<String, Object> coll) {
         tenantScope.withTenant(tenant, ctx -> {
-            // Raw SQL for superseded_at / created_at: these are timestamptz NULL columns after
-            // catalog-002-1-temporal-typing (RDR-156 P0.2).  jOOQ Field<String> would bind as
-            // varchar which PostgreSQL rejects; ?::timestamptz accepts ISO-8601 strings or NULL.
-            ctx.execute(
-                "INSERT INTO nexus.catalog_collections"
-                + " (tenant_id, name, content_type, owner_id, embedding_model, model_version,"
-                + "  display_name, legacy_grandfathered, superseded_by, superseded_at, created_at)"
-                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?::timestamptz, ?::timestamptz)"
-                + " ON CONFLICT (tenant_id, name) DO UPDATE SET"
-                + "  content_type=EXCLUDED.content_type, owner_id=EXCLUDED.owner_id,"
-                + "  embedding_model=EXCLUDED.embedding_model, model_version=EXCLUDED.model_version,"
-                + "  display_name=EXCLUDED.display_name, legacy_grandfathered=EXCLUDED.legacy_grandfathered",
-                tenant,
-                s(coll, "name"), nne(s(coll, "content_type")),
-                nne(s(coll, "owner_id")), nne(s(coll, "embedding_model")),
-                nne(s(coll, "model_version")), nne(s(coll, "display_name")),
-                ni(i(coll, "legacy_grandfathered"), 0),
-                nne(s(coll, "superseded_by")), nz(s(coll, "superseded_at")),
-                nz(s(coll, "created_at")));
+            // nexus-xtmtf: superseded_at / created_at are timestamptz NULL columns after
+            // catalog-002-1-temporal-typing (RDR-156 P0.2). Parse the ISO-8601-or-empty
+            // strings to OffsetDateTime in Java (blank -> NULL) and bind the generated
+            // typed fields — no ?::timestamptz cast, no raw SQL.
+            ctx.insertInto(CATALOG_COLLECTIONS,
+                    CATALOG_COLLECTIONS.TENANT_ID, CATALOG_COLLECTIONS.NAME,
+                    CATALOG_COLLECTIONS.CONTENT_TYPE, CATALOG_COLLECTIONS.OWNER_ID,
+                    CATALOG_COLLECTIONS.EMBEDDING_MODEL, CATALOG_COLLECTIONS.MODEL_VERSION,
+                    CATALOG_COLLECTIONS.DISPLAY_NAME, CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED,
+                    CATALOG_COLLECTIONS.SUPERSEDED_BY, CATALOG_COLLECTIONS.SUPERSEDED_AT,
+                    CATALOG_COLLECTIONS.CREATED_AT)
+               .values(tenant,
+                       s(coll, "name"), nne(s(coll, "content_type")),
+                       nne(s(coll, "owner_id")), nne(s(coll, "embedding_model")),
+                       nne(s(coll, "model_version")), nne(s(coll, "display_name")),
+                       ni(i(coll, "legacy_grandfathered"), 0),
+                       nne(s(coll, "superseded_by")), tsOrNull(s(coll, "superseded_at")),
+                       tsOrNull(s(coll, "created_at")))
+               .onConflict(CATALOG_COLLECTIONS.TENANT_ID, CATALOG_COLLECTIONS.NAME)
+               .doUpdate()
+               .set(CATALOG_COLLECTIONS.CONTENT_TYPE,         DSL.excluded(CATALOG_COLLECTIONS.CONTENT_TYPE))
+               .set(CATALOG_COLLECTIONS.OWNER_ID,             DSL.excluded(CATALOG_COLLECTIONS.OWNER_ID))
+               .set(CATALOG_COLLECTIONS.EMBEDDING_MODEL,      DSL.excluded(CATALOG_COLLECTIONS.EMBEDDING_MODEL))
+               .set(CATALOG_COLLECTIONS.MODEL_VERSION,        DSL.excluded(CATALOG_COLLECTIONS.MODEL_VERSION))
+               .set(CATALOG_COLLECTIONS.DISPLAY_NAME,         DSL.excluded(CATALOG_COLLECTIONS.DISPLAY_NAME))
+               .set(CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED, DSL.excluded(CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED))
+               .execute();
             return null;
         });
     }
@@ -1497,11 +1505,14 @@ public final class CatalogRepository {
      */
     public int supersedeCollection(String tenant, String name, String supersededBy, String supersededAt) {
         return tenantScope.withTenant(tenant, ctx ->
-            // superseded_at is timestamptz NULL after catalog-002-1-temporal-typing; use ?::timestamptz cast.
-            ctx.execute(
-                "UPDATE nexus.catalog_collections SET superseded_by=?, superseded_at=?::timestamptz"
-                + " WHERE tenant_id=? AND name=?",
-                supersededBy, nz(supersededAt), tenant, name)
+            // superseded_at is timestamptz NULL after catalog-002-1-temporal-typing;
+            // nexus-xtmtf: typed OffsetDateTime bind (blank -> NULL), no cast.
+            ctx.update(CATALOG_COLLECTIONS)
+               .set(CATALOG_COLLECTIONS.SUPERSEDED_BY, supersededBy)
+               .set(CATALOG_COLLECTIONS.SUPERSEDED_AT, tsOrNull(supersededAt))
+               .where(CATALOG_COLLECTIONS.TENANT_ID.eq(tenant)
+                   .and(CATALOG_COLLECTIONS.NAME.eq(name)))
+               .execute()
         );
     }
 
@@ -2380,12 +2391,10 @@ public final class CatalogRepository {
     /**
      * nexus-1usso: GUC-once bulk collection import — ONE multi-row
      * {@code INSERT ... ON CONFLICT DO UPDATE ... WHERE} statement per
-     * chunk. Dynamic multi-row VALUES with variable count + the {@code
-     * ::timestamptz} casts on nullable timestamp columns are the reason
-     * this stays raw-SQL string building (same rationale as {@code
-     * TaxonomyRepository.batchInsertAssignments}) rather than jOOQ's typed
-     * multi-row insert — jOOQ's typed API requires a statically-known row
-     * count per statement. Rows are deduped on {@code name} (the conflict
+     * chunk. nexus-xtmtf: jOOQ's chained {@code .values()} supports a
+     * dynamic row count, and the nullable timestamptz columns bind as
+     * OffsetDateTime (blank -> NULL) — zero raw SQL, one statement per
+     * chunk preserved. Rows are deduped on {@code name} (the conflict
      * key) within a chunk, last occurrence wins.
      */
     public int importCollectionsBatch(String tenant, List<Map<String, Object>> rows) {
@@ -2399,71 +2408,75 @@ public final class CatalogRepository {
             final int chunkSize = Math.max(1, MAX_BATCH_PARAMS / cols);
             for (int start = 0; start < deduped.size(); start += chunkSize) {
                 var batch = deduped.subList(start, Math.min(start + chunkSize, deduped.size()));
-                StringBuilder sql = new StringBuilder(
-                    "INSERT INTO nexus.catalog_collections"
-                    + " (tenant_id, name, content_type, owner_id, embedding_model, model_version,"
-                    + "  display_name, legacy_grandfathered, superseded_by, superseded_at, created_at)"
-                    + " VALUES ");
-                List<Object> params = new java.util.ArrayList<>(batch.size() * cols);
-                for (int i = 0; i < batch.size(); i++) {
-                    sql.append(i == 0 ? "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?::timestamptz, ?::timestamptz)"
-                                       : ", (?, ?, ?, ?, ?, ?, ?, ?, ?, ?::timestamptz, ?::timestamptz)");
-                    Map<String, Object> coll = batch.get(i);
-                    params.add(tenant);
-                    params.add(s(coll, "name"));
-                    params.add(nne(s(coll, "content_type")));
-                    params.add(nne(s(coll, "owner_id")));
-                    params.add(nne(s(coll, "embedding_model")));
-                    params.add(nne(s(coll, "model_version")));
-                    params.add(nne(s(coll, "display_name")));
-                    params.add(ni(i(coll, "legacy_grandfathered"), 0));
-                    params.add(nne(s(coll, "superseded_by")));
-                    params.add(nz(s(coll, "superseded_at")));
-                    params.add(nz(s(coll, "created_at")));
+                var insert = ctx.insertInto(CATALOG_COLLECTIONS,
+                        CATALOG_COLLECTIONS.TENANT_ID, CATALOG_COLLECTIONS.NAME,
+                        CATALOG_COLLECTIONS.CONTENT_TYPE, CATALOG_COLLECTIONS.OWNER_ID,
+                        CATALOG_COLLECTIONS.EMBEDDING_MODEL, CATALOG_COLLECTIONS.MODEL_VERSION,
+                        CATALOG_COLLECTIONS.DISPLAY_NAME, CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED,
+                        CATALOG_COLLECTIONS.SUPERSEDED_BY, CATALOG_COLLECTIONS.SUPERSEDED_AT,
+                        CATALOG_COLLECTIONS.CREATED_AT);
+                for (Map<String, Object> coll : batch) {
+                    insert = insert.values(tenant,
+                            s(coll, "name"), nne(s(coll, "content_type")),
+                            nne(s(coll, "owner_id")), nne(s(coll, "embedding_model")),
+                            nne(s(coll, "model_version")), nne(s(coll, "display_name")),
+                            ni(i(coll, "legacy_grandfathered"), 0),
+                            nne(s(coll, "superseded_by")), tsOrNull(s(coll, "superseded_at")),
+                            tsOrNull(s(coll, "created_at")));
                 }
-                sql.append(
-                    " ON CONFLICT (tenant_id, name) DO UPDATE SET"
-                    + "  content_type=EXCLUDED.content_type, owner_id=EXCLUDED.owner_id,"
-                    + "  embedding_model=EXCLUDED.embedding_model, model_version=EXCLUDED.model_version,"
-                    + "  display_name=EXCLUDED.display_name, legacy_grandfathered=EXCLUDED.legacy_grandfathered,"
-                    + "  superseded_by=EXCLUDED.superseded_by,"
-                    + "  superseded_at=EXCLUDED.superseded_at,"
-                    + "  created_at=EXCLUDED.created_at"
-                    + " WHERE catalog_collections.embedding_model='' AND catalog_collections.content_type=''"
-                    + "  AND catalog_collections.owner_id=''");
-                ctx.execute(sql.toString(), params.toArray());
+                insert.onConflict(CATALOG_COLLECTIONS.TENANT_ID, CATALOG_COLLECTIONS.NAME)
+                      .doUpdate()
+                      .set(CATALOG_COLLECTIONS.CONTENT_TYPE,         DSL.excluded(CATALOG_COLLECTIONS.CONTENT_TYPE))
+                      .set(CATALOG_COLLECTIONS.OWNER_ID,             DSL.excluded(CATALOG_COLLECTIONS.OWNER_ID))
+                      .set(CATALOG_COLLECTIONS.EMBEDDING_MODEL,      DSL.excluded(CATALOG_COLLECTIONS.EMBEDDING_MODEL))
+                      .set(CATALOG_COLLECTIONS.MODEL_VERSION,        DSL.excluded(CATALOG_COLLECTIONS.MODEL_VERSION))
+                      .set(CATALOG_COLLECTIONS.DISPLAY_NAME,         DSL.excluded(CATALOG_COLLECTIONS.DISPLAY_NAME))
+                      .set(CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED, DSL.excluded(CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED))
+                      .set(CATALOG_COLLECTIONS.SUPERSEDED_BY,        DSL.excluded(CATALOG_COLLECTIONS.SUPERSEDED_BY))
+                      .set(CATALOG_COLLECTIONS.SUPERSEDED_AT,        DSL.excluded(CATALOG_COLLECTIONS.SUPERSEDED_AT))
+                      .set(CATALOG_COLLECTIONS.CREATED_AT,           DSL.excluded(CATALOG_COLLECTIONS.CREATED_AT))
+                      .where(CATALOG_COLLECTIONS.EMBEDDING_MODEL.eq("")
+                          .and(CATALOG_COLLECTIONS.CONTENT_TYPE.eq(""))
+                          .and(CATALOG_COLLECTIONS.OWNER_ID.eq("")))
+                      .execute();
             }
             return rows.size();
         });
     }
 
     private void doImportCollection(DSLContext ctx, String tenant, Map<String, Object> coll) {
-        {
-            // Raw SQL for superseded_at / created_at: timestamptz NULL after catalog-002-1-temporal-typing.
-            // DO UPDATE WHERE stub: only upgrades rows where all three discriminator columns are empty
-            // (i.e. auto-registered stubs from RDR-156 P0.2 ensure-registration steps).
-            ctx.execute(
-                "INSERT INTO nexus.catalog_collections"
-                + " (tenant_id, name, content_type, owner_id, embedding_model, model_version,"
-                + "  display_name, legacy_grandfathered, superseded_by, superseded_at, created_at)"
-                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?::timestamptz, ?::timestamptz)"
-                + " ON CONFLICT (tenant_id, name) DO UPDATE SET"
-                + "  content_type=EXCLUDED.content_type, owner_id=EXCLUDED.owner_id,"
-                + "  embedding_model=EXCLUDED.embedding_model, model_version=EXCLUDED.model_version,"
-                + "  display_name=EXCLUDED.display_name, legacy_grandfathered=EXCLUDED.legacy_grandfathered,"
-                + "  superseded_by=EXCLUDED.superseded_by,"
-                + "  superseded_at=EXCLUDED.superseded_at,"
-                + "  created_at=EXCLUDED.created_at"
-                + " WHERE catalog_collections.embedding_model='' AND catalog_collections.content_type=''"
-                + "  AND catalog_collections.owner_id=''",
-                tenant,
-                s(coll, "name"), nne(s(coll, "content_type")),
-                nne(s(coll, "owner_id")), nne(s(coll, "embedding_model")),
-                nne(s(coll, "model_version")), nne(s(coll, "display_name")),
-                ni(i(coll, "legacy_grandfathered"), 0),
-                nne(s(coll, "superseded_by")), nz(s(coll, "superseded_at")),
-                nz(s(coll, "created_at")));
-        }
+        // DO UPDATE WHERE stub-guard: only upgrades rows where all three discriminator
+        // columns are empty (auto-registered stubs from RDR-156 P0.2 ensure-registration).
+        // nexus-xtmtf: single-row delegate of the importCollectionsBatch DSL shape.
+        var insert = ctx.insertInto(CATALOG_COLLECTIONS,
+                CATALOG_COLLECTIONS.TENANT_ID, CATALOG_COLLECTIONS.NAME,
+                CATALOG_COLLECTIONS.CONTENT_TYPE, CATALOG_COLLECTIONS.OWNER_ID,
+                CATALOG_COLLECTIONS.EMBEDDING_MODEL, CATALOG_COLLECTIONS.MODEL_VERSION,
+                CATALOG_COLLECTIONS.DISPLAY_NAME, CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED,
+                CATALOG_COLLECTIONS.SUPERSEDED_BY, CATALOG_COLLECTIONS.SUPERSEDED_AT,
+                CATALOG_COLLECTIONS.CREATED_AT)
+           .values(tenant,
+                   s(coll, "name"), nne(s(coll, "content_type")),
+                   nne(s(coll, "owner_id")), nne(s(coll, "embedding_model")),
+                   nne(s(coll, "model_version")), nne(s(coll, "display_name")),
+                   ni(i(coll, "legacy_grandfathered"), 0),
+                   nne(s(coll, "superseded_by")), tsOrNull(s(coll, "superseded_at")),
+                   tsOrNull(s(coll, "created_at")));
+        insert.onConflict(CATALOG_COLLECTIONS.TENANT_ID, CATALOG_COLLECTIONS.NAME)
+              .doUpdate()
+              .set(CATALOG_COLLECTIONS.CONTENT_TYPE,         DSL.excluded(CATALOG_COLLECTIONS.CONTENT_TYPE))
+              .set(CATALOG_COLLECTIONS.OWNER_ID,             DSL.excluded(CATALOG_COLLECTIONS.OWNER_ID))
+              .set(CATALOG_COLLECTIONS.EMBEDDING_MODEL,      DSL.excluded(CATALOG_COLLECTIONS.EMBEDDING_MODEL))
+              .set(CATALOG_COLLECTIONS.MODEL_VERSION,        DSL.excluded(CATALOG_COLLECTIONS.MODEL_VERSION))
+              .set(CATALOG_COLLECTIONS.DISPLAY_NAME,         DSL.excluded(CATALOG_COLLECTIONS.DISPLAY_NAME))
+              .set(CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED, DSL.excluded(CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED))
+              .set(CATALOG_COLLECTIONS.SUPERSEDED_BY,        DSL.excluded(CATALOG_COLLECTIONS.SUPERSEDED_BY))
+              .set(CATALOG_COLLECTIONS.SUPERSEDED_AT,        DSL.excluded(CATALOG_COLLECTIONS.SUPERSEDED_AT))
+              .set(CATALOG_COLLECTIONS.CREATED_AT,           DSL.excluded(CATALOG_COLLECTIONS.CREATED_AT))
+              .where(CATALOG_COLLECTIONS.EMBEDDING_MODEL.eq("")
+                  .and(CATALOG_COLLECTIONS.CONTENT_TYPE.eq(""))
+                  .and(CATALOG_COLLECTIONS.OWNER_ID.eq("")))
+              .execute();
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -2605,6 +2618,29 @@ public final class CatalogRepository {
      * catalog-002-1-temporal-typing (RDR-156 P0.2) converts these columns to timestamptz NULL.
      */
     private static String nz(String v) { return (v != null && !v.isEmpty()) ? v : null; }
+
+    /**
+     * ISO-8601-or-blank to a typed timestamptz bind (nexus-xtmtf): blank/null
+     * -> NULL (the nullable temporal columns' "unset" state after
+     * catalog-002-1-temporal-typing). Accepts the same lenient shapes the
+     * retired {@code ?::timestamptz} cast did — space-separated
+     * ("2026-05-01 12:00:00") and offsetless forms from legacy-SQLite
+     * fidelity imports parse as UTC. Genuinely unparseable input fails loud
+     * (as the cast did) — these are fidelity-preserving import/supersede
+     * timestamps, not event stamps, so never substitute now().
+     */
+    private static java.time.OffsetDateTime tsOrNull(String iso) {
+        if (iso == null || iso.isBlank()) return null;
+        String normalized = iso.trim().replace(' ', 'T');
+        try {
+            return java.time.OffsetDateTime.parse(normalized);
+        } catch (java.time.format.DateTimeParseException e) {
+            // Offsetless (legacy SQLite catalog rows) — timestamptz text input
+            // without a zone resolves in the session TZ; the service runs UTC.
+            return java.time.LocalDateTime.parse(normalized)
+                       .atOffset(java.time.ZoneOffset.UTC);
+        }
+    }
 
     /** Non-null integer: returns def if null. */
     private static int ni(Integer v, int def) { return v != null ? v : def; }

--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -456,6 +456,42 @@ public final class CatalogRepository {
     }
 
     /**
+     * Resolve a 4-segment chunk address to its document + chunk metadata
+     * (nexus-gc2ze). Mirrors the local {@code Catalog._DocumentOps.resolve_chunk}
+     * contract (catalog_docs.py): chunks are implicit addresses — the catalog
+     * tracks document-level rows only, and chunk sub-addresses are resolved on
+     * demand from the document's {@code chunk_count}. This is a pure lookup +
+     * range-check over an existing document row: it delegates entirely to
+     * {@link #getDocument}, so there is no new SQL to audit here.
+     *
+     * <p>{@code chunkCount} of 0 (or absent) means the count is not yet known
+     * — the bounds check is skipped in that case, mirroring the local
+     * Python's {@code if entry.chunk_count and chunk_idx >= entry.chunk_count}.
+     *
+     * @param tenant      tenant identifier
+     * @param docTumbler  the document tumbler (chunk segment already stripped
+     *                    by the caller — {@link dev.nexus.service.http.CatalogHandler})
+     * @param chunkIndex  the chunk's position within the document
+     * @return {@code {document_tumbler, chunk_index, physical_collection,
+     *         title, content_type}} or {@code null} if the document is
+     *         missing or {@code chunkIndex} is out of range
+     */
+    public Map<String, Object> resolveChunk(String tenant, String docTumbler, int chunkIndex) {
+        var doc = getDocument(tenant, docTumbler);
+        if (doc == null) return null;
+        Object rawCount = doc.get("chunk_count");
+        long chunkCount = rawCount instanceof Number ? ((Number) rawCount).longValue() : 0L;
+        if (chunkCount > 0 && chunkIndex >= chunkCount) return null;
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("document_tumbler",    docTumbler);
+        m.put("chunk_index",         chunkIndex);
+        m.put("physical_collection", doc.getOrDefault("physical_collection", ""));
+        m.put("title",               doc.getOrDefault("title", ""));
+        m.put("content_type",        doc.getOrDefault("content_type", ""));
+        return m;
+    }
+
+    /**
      * Update mutable document fields. Only non-null fields in the map are updated.
      * Refuses to update tombstoned documents (returns 0).
      * Silently strips {@code deleted_at} from the input map — callers must use

--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -9,13 +9,19 @@ import static dev.nexus.service.jooq.nexus.Tables.CATALOG_DOCUMENT_CHUNKS;
 import static dev.nexus.service.jooq.nexus.Tables.CATALOG_LINKS;
 import static dev.nexus.service.jooq.nexus.Tables.CATALOG_META;
 import static dev.nexus.service.jooq.nexus.Tables.CATALOG_OWNERS;
+import static dev.nexus.service.jooq.nexus.Tables.CATALOG_STATS;
 import static dev.nexus.service.jooq.nexus.Tables.CHASH_INDEX;
 import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_1024;
 import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_384;
 import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_768;
+import static dev.nexus.service.jooq.nexus.Tables.COLLECTION_DOC_COUNTS;
+import static dev.nexus.service.jooq.nexus.Tables.COLLECTION_HEALTH_META;
+import static dev.nexus.service.jooq.nexus.Tables.COVERAGE_BY_CONTENT_TYPE;
 import static dev.nexus.service.jooq.nexus.Tables.DOCUMENT_ASPECTS;
 import static dev.nexus.service.jooq.nexus.Tables.DOCUMENT_HIGHLIGHTS;
 import static dev.nexus.service.jooq.nexus.Tables.HOOK_FAILURES;
+import static dev.nexus.service.jooq.nexus.Tables.LINKS_BY_TYPE_COUNTS;
+import static dev.nexus.service.jooq.nexus.Tables.MANIFEST_ORPHANS;
 import static dev.nexus.service.jooq.nexus.Tables.RELEVANCE_LOG;
 import static dev.nexus.service.jooq.nexus.Tables.SEARCH_TELEMETRY;
 import static dev.nexus.service.jooq.nexus.Tables.TAXONOMY_CENTROIDS_1024;
@@ -674,8 +680,8 @@ public final class CatalogRepository {
      */
     public long manifestBackfill(String tenant) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rec = ctx.fetchOne("select nexus.manifest_backfill()");
-            return rec != null ? rec.get(0, Long.class) : 0L;
+            Long count = dev.nexus.service.jooq.nexus.Routines.manifestBackfill(ctx.configuration());
+            return count != null ? count : 0L;
         });
     }
 
@@ -709,14 +715,13 @@ public final class CatalogRepository {
                 "limit must be > 0 (the sample is bounded; use count for the gate)");
         }
         return tenantScope.withTenant(tenant, ctx -> {
-            Long count = ctx.fetchOne(
-                "select count(*) from nexus.manifest_orphans(?)", dim
-            ).get(0, Long.class);
-            var sample = ctx.fetch(
-                "select * from nexus.manifest_orphans(?) limit ?", dim, limit
-            ).map(org.jooq.Record::intoMap);
+            long count = ctx.fetchCount(MANIFEST_ORPHANS.call(dim));
+            var sample = ctx.selectFrom(MANIFEST_ORPHANS.call(dim))
+                             .limit(limit)
+                             .fetch()
+                             .map(org.jooq.Record::intoMap);
             Map<String, Object> out = new LinkedHashMap<>();
-            out.put("count", count != null ? count : 0L);
+            out.put("count", count);
             out.put("orphans", sample);
             return out;
         });
@@ -730,11 +735,8 @@ public final class CatalogRepository {
      */
     public long manifestOrphanCount(String tenant, int dim) {
         requireSupportedDim(dim);
-        return tenantScope.withTenant(tenant, ctx -> {
-            var rec = ctx.fetchOne(
-                "select count(*) from nexus.manifest_orphans(?)", dim);
-            return rec != null ? rec.get(0, Long.class) : 0L;
-        });
+        return tenantScope.withTenant(tenant, ctx ->
+            (long) ctx.fetchCount(MANIFEST_ORPHANS.call(dim)));
     }
 
     private static void requireSupportedDim(int dim) {
@@ -1280,34 +1282,40 @@ public final class CatalogRepository {
      */
     public Map<String, Object> resolveChash(String tenant, String chash, String preferCollection) {
         return tenantScope.withTenant(tenant, ctx -> {
-            // Raw SQL: UNION ALL wrapped in a subquery so the outer ORDER BY can
-            // use expressions (PostgreSQL rejects expressions in UNION ORDER BY;
-            // wrapping in FROM avoids that restriction).
-            // prefer_collection is a bind parameter — never inlined into SQL.
+            // UNION ALL across the three dim tables, wrapped as a derived table so the
+            // outer ORDER BY can reference expressions (PostgreSQL rejects expressions
+            // in a bare UNION's ORDER BY; a derived-table FROM avoids that restriction).
+            // prefer_collection is a bind parameter via the typed .eq(pref) predicate below.
             String pref = preferCollection != null ? preferCollection : "";
-            String sql =
-                "SELECT collection, chunk_text, metadata, created_at FROM ("
-                + " SELECT collection, chunk_text, metadata::text AS metadata, created_at FROM nexus.chunks_768"
-                + "  WHERE chash = ?"
-                + " UNION ALL"
-                + " SELECT collection, chunk_text, metadata::text AS metadata, created_at FROM nexus.chunks_384"
-                + "  WHERE chash = ?"
-                + " UNION ALL"
-                + " SELECT collection, chunk_text, metadata::text AS metadata, created_at FROM nexus.chunks_1024"
-                + "  WHERE chash = ?"
-                + ") sub"
-                // Third key `collection ASC` matches the canonical _sort_key
-                // (preferred, newest created_at, deterministic name) so a chash in two
-                // collections with equal created_at resolves stably (njrcn.4 review).
-                + " ORDER BY (collection = ?) DESC, created_at DESC, collection ASC LIMIT 1";
 
-            var result = ctx.fetch(sql, chash, chash, chash, pref);
-            if (result.isEmpty()) return null;
+            var sub = ctx.select(CHUNKS_768.COLLECTION, CHUNKS_768.CHUNK_TEXT, CHUNKS_768.METADATA, CHUNKS_768.CREATED_AT)
+                          .from(CHUNKS_768).where(CHUNKS_768.CHASH.eq(chash))
+                       .unionAll(
+                          ctx.select(CHUNKS_384.COLLECTION, CHUNKS_384.CHUNK_TEXT, CHUNKS_384.METADATA, CHUNKS_384.CREATED_AT)
+                             .from(CHUNKS_384).where(CHUNKS_384.CHASH.eq(chash)))
+                       .unionAll(
+                          ctx.select(CHUNKS_1024.COLLECTION, CHUNKS_1024.CHUNK_TEXT, CHUNKS_1024.METADATA, CHUNKS_1024.CREATED_AT)
+                             .from(CHUNKS_1024).where(CHUNKS_1024.CHASH.eq(chash)))
+                       .asTable("sub");
 
-            var row     = result.get(0);
-            String col  = row.get("collection", String.class);
-            String text = row.get("chunk_text",  String.class);
-            String metaJson = row.get("metadata", String.class);
+            Field<String>         col       = sub.field("collection", String.class);
+            Field<String>         text      = sub.field("chunk_text", String.class);
+            Field<org.jooq.JSONB> meta      = sub.field("metadata", org.jooq.JSONB.class);
+            Field<java.time.OffsetDateTime> createdAt = sub.field("created_at", java.time.OffsetDateTime.class);
+
+            var row = ctx.select(col, text, meta, createdAt)
+                          .from(sub)
+                          // Third key `collection ASC` matches the canonical _sort_key
+                          // (preferred, newest created_at, deterministic name) so a chash in two
+                          // collections with equal created_at resolves stably (njrcn.4 review).
+                          .orderBy(col.eq(pref).desc(), createdAt.desc(), col.asc())
+                          .limit(1)
+                          .fetchOne();
+            if (row == null) return null;
+
+            String colVal      = row.value1();
+            String textVal     = row.value2();
+            org.jooq.JSONB metaVal = row.value3();
 
             // Lookup doc_id from catalog_document_chunks. ORDER BY doc_id for a
             // deterministic winner when a chash is referenced by multiple docs (dedup).
@@ -1320,10 +1328,10 @@ public final class CatalogRepository {
             Map<String, Object> m = new LinkedHashMap<>();
             m.put("chash",               chash);
             m.put("chunk_hash",          chash);
-            m.put("physical_collection", col);
+            m.put("physical_collection", colVal);
             m.put("doc_id",              docId);
-            m.put("chunk_text",          text);
-            m.put("metadata",            metaJson != null ? parseMetaJson(metaJson) : Map.of());
+            m.put("chunk_text",          textVal);
+            m.put("metadata",            metaVal != null ? parseMetaJson(metaVal.data()) : Map.of());
             return m;
         });
     }
@@ -1728,31 +1736,27 @@ public final class CatalogRepository {
             // catalog_stats security_invoker view (per-subquery RLS scopes each to
             // the GUC tenant), replacing five separate selectCount calls and the
             // Java-side hand-assembly that the Python path duplicated.
-            var s = ctx.fetchOne(
-                "SELECT doc_count, link_count, owner_count, collection_count, chunk_count "
-                + "FROM nexus.catalog_stats");
-            long docCount  = s.get("doc_count", Long.class);
-            long lnkCount  = s.get("link_count", Long.class);
-            long ownCount  = s.get("owner_count", Long.class);
-            long collCount = s.get("collection_count", Long.class);
-            long chkCount  = s.get("chunk_count", Long.class);
+            var s = ctx.selectFrom(CATALOG_STATS).fetchOne();
+            long docCount  = s.get(CATALOG_STATS.DOC_COUNT);
+            long lnkCount  = s.get(CATALOG_STATS.LINK_COUNT);
+            long ownCount  = s.get(CATALOG_STATS.OWNER_COUNT);
+            long collCount = s.get(CATALOG_STATS.COLLECTION_COUNT);
+            long chkCount  = s.get(CATALOG_STATS.CHUNK_COUNT);
             // RDR-154 P1.2: the two GROUP-BY breakdowns also read views (completing
             // the "5+2" collapse, Gap 3). links_by_type ← links_by_type_counts;
             // by_content_type reuses coverage_by_content_type.total (same per-type
             // document count — eliminates the duplicate aggregate the critic flagged).
-            var ltypes = ctx.fetch(
-                "SELECT link_type, link_count FROM nexus.links_by_type_counts");
+            var ltypes = ctx.selectFrom(LINKS_BY_TYPE_COUNTS).fetch();
             Map<String, Long> byType = new LinkedHashMap<>();
-            for (var r : ltypes) byType.put(r.get("link_type", String.class),
-                                            r.get("link_count", Long.class));
+            for (var r : ltypes) byType.put(r.get(LINKS_BY_TYPE_COUNTS.LINK_TYPE),
+                                            r.get(LINKS_BY_TYPE_COUNTS.LINK_COUNT));
             // by_content_type: key is "" for null/empty content_type (the view already
             // COALESCEs to ''), matching SQLite Catalog.stats().
-            var ctypes = ctx.fetch(
-                "SELECT content_type, total FROM nexus.coverage_by_content_type");
+            var ctypes = ctx.select(COVERAGE_BY_CONTENT_TYPE.CONTENT_TYPE, COVERAGE_BY_CONTENT_TYPE.TOTAL)
+                            .from(COVERAGE_BY_CONTENT_TYPE).fetch();
             Map<String, Long> byContentType = new LinkedHashMap<>();
             for (var r : ctypes) {
-                byContentType.put(r.get("content_type", String.class),
-                                  r.get("total", Long.class));
+                byContentType.put(r.value1(), r.value2());
             }
             Map<String, Object> result = new LinkedHashMap<>();
             result.put("doc_count", docCount);
@@ -1783,16 +1787,18 @@ public final class CatalogRepository {
             // The view GROUP BYs collection, so it emits NO row for a collection
             // with zero documents — default to {last_indexed:null, orphan_count:0}
             // to preserve the prior contract.
-            var r = ctx.fetchOne(
-                "SELECT last_indexed, orphan_count, stale_source_ratio "
-                + "FROM nexus.collection_health_meta WHERE collection = ?", collection);
+            var r = ctx.select(COLLECTION_HEALTH_META.LAST_INDEXED,
+                               COLLECTION_HEALTH_META.ORPHAN_COUNT,
+                               COLLECTION_HEALTH_META.STALE_SOURCE_RATIO)
+                       .from(COLLECTION_HEALTH_META)
+                       .where(COLLECTION_HEALTH_META.COLLECTION.eq(collection))
+                       .fetchOne();
 
             Map<String, Object> result = new LinkedHashMap<>();
-            result.put("last_indexed", r == null ? null : r.get("last_indexed", String.class));
-            result.put("orphan_count", r == null ? 0L : r.get("orphan_count", Long.class));
+            result.put("last_indexed", r == null ? null : r.value1());
+            result.put("orphan_count", r == null ? 0L : r.value2());
             // nexus-agsq7: index-age staleness; null when no dated doc qualifies.
-            result.put("stale_source_ratio",
-                       r == null ? null : r.get("stale_source_ratio", Double.class));
+            result.put("stale_source_ratio", r == null ? null : r.value3());
             return result;
         });
     }
@@ -1926,12 +1932,12 @@ public final class CatalogRepository {
         return tenantScope.withTenant(tenant, ctx -> {
             // RDR-154 P1.2 (nexus-h9qyp): read the collection_doc_counts
             // security_invoker view (replaces the hand-written GROUP BY).
-            var rows = ctx.fetch(
-                "SELECT physical_collection, doc_count FROM nexus.collection_doc_counts");
+            var rows = ctx.select(COLLECTION_DOC_COUNTS.PHYSICAL_COLLECTION, COLLECTION_DOC_COUNTS.DOC_COUNT)
+                          .from(COLLECTION_DOC_COUNTS)
+                          .fetch();
             Map<String, Long> result = new LinkedHashMap<>();
             for (var r : rows) {
-                result.put(r.get("physical_collection", String.class),
-                           r.get("doc_count", Long.class));
+                result.put(r.value1(), r.value2());
             }
             return result;
         });
@@ -1968,32 +1974,49 @@ public final class CatalogRepository {
             // security_invoker view; the owner-prefix case runs the same aggregation
             // with the prefix applied BEFORE the GROUP BY (a view cannot be
             // parameterized, but the N+1 is eliminated either way).
-            org.jooq.Result<?> rows;
+            List<Map<String, Object>> result = new ArrayList<>();
             if (ownerPrefix == null || ownerPrefix.isBlank()) {
-                rows = ctx.fetch(
-                    "SELECT content_type, total, linked FROM nexus.coverage_by_content_type");
+                var rows = ctx.select(COVERAGE_BY_CONTENT_TYPE.CONTENT_TYPE,
+                                      COVERAGE_BY_CONTENT_TYPE.TOTAL,
+                                      COVERAGE_BY_CONTENT_TYPE.LINKED)
+                              .from(COVERAGE_BY_CONTENT_TYPE)
+                              .fetch();
+                for (var r : rows) {
+                    Map<String, Object> row = new LinkedHashMap<>();
+                    row.put("content_type", r.value1());
+                    row.put("total",        r.value2());
+                    row.put("linked",       r.value3());
+                    result.add(row);
+                }
             } else {
                 String likePat = ownerPrefix.replaceAll("\\.$", "") + ".%";
-                rows = ctx.fetch(
-                    "SELECT COALESCE(d.content_type, '') AS content_type, "
-                    + "count(*) AS total, "
-                    + "count(*) FILTER (WHERE EXISTS ("
-                    + "  SELECT 1 FROM nexus.catalog_links l "
-                    + "   WHERE l.from_tumbler = d.tumbler OR l.to_tumbler = d.tumbler"
-                    + ")) AS linked "
-                    + "FROM nexus.catalog_documents d "
-                    + "WHERE d.tumbler LIKE ? OR d.tumbler = ? "
-                    + "GROUP BY COALESCE(d.content_type, '')",
-                    likePat, ownerPrefix);
-            }
-
-            List<Map<String, Object>> result = new ArrayList<>();
-            for (var r : rows) {
-                Map<String, Object> row = new LinkedHashMap<>();
-                row.put("content_type", r.get("content_type", String.class));
-                row.put("total",        r.get("total", Long.class));
-                row.put("linked",       r.get("linked", Long.class));
-                result.add(row);
+                // DSL.inline("") (a constant, not a bind param) — reusing the SAME Field
+                // object in both the SELECT list and GROUP BY only reads as the same
+                // expression to Postgres's GROUP BY validity check when the fallback is an
+                // inlined literal; a bound "?" parameter renders as a DIFFERENT placeholder
+                // ($N vs $M) at each occurrence, so Postgres sees two distinct expressions
+                // and rejects the query with "must appear in the GROUP BY clause" even
+                // though both bind to "" at runtime (caught by CatalogRepositoryTest
+                // coverageByContentType_ownerPrefixFilter).
+                Field<String> contentType = DSL.coalesce(CATALOG_DOCUMENTS.CONTENT_TYPE, DSL.inline(""));
+                Field<Long> linkedCount = DSL.count().filterWhere(
+                    DSL.exists(DSL.selectOne().from(CATALOG_LINKS)
+                        .where(CATALOG_LINKS.FROM_TUMBLER.eq(CATALOG_DOCUMENTS.TUMBLER)
+                            .or(CATALOG_LINKS.TO_TUMBLER.eq(CATALOG_DOCUMENTS.TUMBLER)))))
+                    .cast(Long.class);
+                var rows = ctx.select(contentType, DSL.count().cast(Long.class), linkedCount)
+                              .from(CATALOG_DOCUMENTS)
+                              .where(CATALOG_DOCUMENTS.TUMBLER.like(likePat)
+                                  .or(CATALOG_DOCUMENTS.TUMBLER.eq(ownerPrefix)))
+                              .groupBy(contentType)
+                              .fetch();
+                for (var r : rows) {
+                    Map<String, Object> row = new LinkedHashMap<>();
+                    row.put("content_type", r.value1());
+                    row.put("total",        r.value2());
+                    row.put("linked",       r.value3());
+                    result.add(row);
+                }
             }
             return result;
         });

--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -2566,7 +2566,8 @@ public final class CatalogRepository {
      * (as the cast did) — these are fidelity-preserving import/supersede
      * timestamps, not event stamps, so never substitute now().
      */
-    private static java.time.OffsetDateTime tsOrNull(String iso) {
+    // Package-private for direct unit testing (CatalogTsOrNullTest).
+    static java.time.OffsetDateTime tsOrNull(String iso) {
         if (iso == null || iso.isBlank()) return null;
         String normalized = iso.trim().replace(' ', 'T');
         try {
@@ -2574,8 +2575,16 @@ public final class CatalogRepository {
         } catch (java.time.format.DateTimeParseException e) {
             // Offsetless (legacy SQLite catalog rows) — timestamptz text input
             // without a zone resolves in the session TZ; the service runs UTC.
-            return java.time.LocalDateTime.parse(normalized)
-                       .atOffset(java.time.ZoneOffset.UTC);
+            try {
+                return java.time.LocalDateTime.parse(normalized)
+                           .atOffset(java.time.ZoneOffset.UTC);
+            } catch (java.time.format.DateTimeParseException e2) {
+                // Date-only ("2026-05-01") — the retired ?::timestamptz cast
+                // accepted bare dates as midnight; preserve that (review
+                // finding: this branch was missing and threw uncaught).
+                return java.time.LocalDate.parse(normalized)
+                           .atStartOfDay().atOffset(java.time.ZoneOffset.UTC);
+            }
         }
     }
 

--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -5,6 +5,10 @@ package dev.nexus.service.db;
 import static dev.nexus.service.jooq.nexus.Tables.ASPECT_EXTRACTION_QUEUE;
 import static dev.nexus.service.jooq.nexus.Tables.CATALOG_COLLECTIONS;
 import static dev.nexus.service.jooq.nexus.Tables.CATALOG_DOCUMENTS;
+import static dev.nexus.service.jooq.nexus.Tables.CATALOG_DOCUMENT_CHUNKS;
+import static dev.nexus.service.jooq.nexus.Tables.CATALOG_LINKS;
+import static dev.nexus.service.jooq.nexus.Tables.CATALOG_META;
+import static dev.nexus.service.jooq.nexus.Tables.CATALOG_OWNERS;
 import static dev.nexus.service.jooq.nexus.Tables.CHASH_INDEX;
 import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_1024;
 import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_384;
@@ -84,100 +88,26 @@ public final class CatalogRepository {
         .configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
-    // ── Table references ───────────────────────────────────────────────────────
+    // ── Retained hand-built fields (type-skew vs generated jOOQ Tables) ────────
+    // nexus-xtmtf: every OTHER plain table/column reference in this class was
+    // deduped onto dev.nexus.service.jooq.nexus.Tables.* (CATALOG_OWNERS,
+    // CATALOG_DOCUMENTS, CATALOG_LINKS, CATALOG_DOCUMENT_CHUNKS,
+    // CATALOG_COLLECTIONS, CATALOG_META — see the static imports above). These
+    // four remain hand-built because the generated column type differs from
+    // the wire-response value type this class already returns, and switching
+    // would either change the JSON shape callers see or force a matching
+    // change to the paired EXCLUDED.* fragment (out of scope: EXCLUDED
+    // fragments are not plain column references). Wire shapes must not change
+    // in this commit — see nexus-xtmtf dedup report.
 
-    static final Table<?> T_OWNERS  = DSL.table(DSL.name("nexus", "catalog_owners"));
-    static final Table<?> T_DOCS    = DSL.table(DSL.name("nexus", "catalog_documents"));
-    static final Table<?> T_LINKS   = DSL.table(DSL.name("nexus", "catalog_links"));
-    static final Table<?> T_CHUNKS  = DSL.table(DSL.name("nexus", "catalog_document_chunks"));
-    static final Table<?> T_COLLS   = DSL.table(DSL.name("nexus", "catalog_collections"));
-    static final Table<?> T_META    = DSL.table(DSL.name("nexus", "catalog_meta"));
-
-    // ── Owners fields ──────────────────────────────────────────────────────────
-
-    static final Field<String> F_OWN_TENANT = DSL.field(DSL.name("catalog_owners","tenant_id"), String.class);
-    static final Field<String> F_OWN_PREFIX = DSL.field(DSL.name("catalog_owners","tumbler_prefix"), String.class);
-    static final Field<String> F_OWN_NAME   = DSL.field(DSL.name("catalog_owners","name"), String.class);
-    static final Field<String> F_OWN_TYPE   = DSL.field(DSL.name("catalog_owners","owner_type"), String.class);
-    static final Field<String> F_OWN_REPO   = DSL.field(DSL.name("catalog_owners","repo_hash"), String.class);
-    static final Field<String> F_OWN_DESC   = DSL.field(DSL.name("catalog_owners","description"), String.class);
-    static final Field<String> F_OWN_ROOT   = DSL.field(DSL.name("catalog_owners","repo_root"), String.class);
-    static final Field<String> F_OWN_HEAD   = DSL.field(DSL.name("catalog_owners","head_hash"), String.class);
-    static final Field<Long>   F_OWN_SEQ    = DSL.field(DSL.name("catalog_owners","next_seq"), Long.class);
-
-    // ── Documents fields ───────────────────────────────────────────────────────
-
-    static final Field<String>  F_DOC_TENANT  = DSL.field(DSL.name("catalog_documents","tenant_id"), String.class);
-    static final Field<String>  F_DOC_TUMBLER = DSL.field(DSL.name("catalog_documents","tumbler"), String.class);
-    static final Field<String>  F_DOC_TITLE   = DSL.field(DSL.name("catalog_documents","title"), String.class);
-    static final Field<String>  F_DOC_AUTHOR  = DSL.field(DSL.name("catalog_documents","author"), String.class);
-    static final Field<Integer> F_DOC_YEAR    = DSL.field(DSL.name("catalog_documents","year"), Integer.class);
-    static final Field<String>  F_DOC_CTYPE   = DSL.field(DSL.name("catalog_documents","content_type"), String.class);
-    static final Field<String>  F_DOC_FPATH   = DSL.field(DSL.name("catalog_documents","file_path"), String.class);
-    static final Field<String>  F_DOC_CORPUS  = DSL.field(DSL.name("catalog_documents","corpus"), String.class);
-    static final Field<String>  F_DOC_PCOLL   = DSL.field(DSL.name("catalog_documents","physical_collection"), String.class);
-    static final Field<Integer> F_DOC_CHUNKS  = DSL.field(DSL.name("catalog_documents","chunk_count"), Integer.class);
-    static final Field<String>  F_DOC_HEAD    = DSL.field(DSL.name("catalog_documents","head_hash"), String.class);
-    static final Field<String>  F_DOC_IDXAT   = DSL.field(DSL.name("catalog_documents","indexed_at"), String.class);
+    // type-skew vs generated (String vs JSONB) — wire shape pinned, see nexus-xtmtf report
     static final Field<String>  F_DOC_META    = DSL.field(DSL.name("catalog_documents","metadata"), String.class);
-    static final Field<Double>  F_DOC_SMTIME  = DSL.field(DSL.name("catalog_documents","source_mtime"), Double.class);
-    static final Field<String>  F_DOC_ALIAS   = DSL.field(DSL.name("catalog_documents","alias_of"), String.class);
-    static final Field<String>  F_DOC_URI     = DSL.field(DSL.name("catalog_documents","source_uri"), String.class);
-    static final Field<Integer> F_DOC_BIBY    = DSL.field(DSL.name("catalog_documents","bib_year"), Integer.class);
-    static final Field<String>  F_DOC_BIAU    = DSL.field(DSL.name("catalog_documents","bib_authors"), String.class);
-    static final Field<String>  F_DOC_BIVE    = DSL.field(DSL.name("catalog_documents","bib_venue"), String.class);
-    static final Field<Integer> F_DOC_BICC    = DSL.field(DSL.name("catalog_documents","bib_citation_count"), Integer.class);
-    static final Field<String>  F_DOC_BIS2    = DSL.field(DSL.name("catalog_documents","bib_semantic_scholar_id"), String.class);
-    static final Field<String>  F_DOC_BIOA    = DSL.field(DSL.name("catalog_documents","bib_openalex_id"), String.class);
-    static final Field<String>  F_DOC_BIDOI   = DSL.field(DSL.name("catalog_documents","bib_doi"), String.class);
-    static final Field<String>  F_DOC_BIAT    = DSL.field(DSL.name("catalog_documents","bib_enriched_at"), String.class);
-    static final Field<java.time.OffsetDateTime> F_DOC_DELETED_AT =
-        DSL.field(DSL.name("catalog_documents","deleted_at"), java.time.OffsetDateTime.class);
-
-    // ── Links fields ───────────────────────────────────────────────────────────
-
-    static final Field<String> F_LNK_TENANT = DSL.field(DSL.name("catalog_links","tenant_id"), String.class);
-    static final Field<Long>   F_LNK_ID     = DSL.field(DSL.name("catalog_links","id"), Long.class);
-    static final Field<String> F_LNK_FROM   = DSL.field(DSL.name("catalog_links","from_tumbler"), String.class);
-    static final Field<String> F_LNK_TO     = DSL.field(DSL.name("catalog_links","to_tumbler"), String.class);
-    static final Field<String> F_LNK_TYPE   = DSL.field(DSL.name("catalog_links","link_type"), String.class);
-    static final Field<String> F_LNK_FSPAN  = DSL.field(DSL.name("catalog_links","from_span"), String.class);
-    static final Field<String> F_LNK_TSPAN  = DSL.field(DSL.name("catalog_links","to_span"), String.class);
-    static final Field<String> F_LNK_CRTBY  = DSL.field(DSL.name("catalog_links","created_by"), String.class);
-    static final Field<String> F_LNK_CRTAT  = DSL.field(DSL.name("catalog_links","created_at"), String.class);
+    // type-skew vs generated (String vs JSONB) — wire shape pinned, see nexus-xtmtf report
     static final Field<String> F_LNK_META   = DSL.field(DSL.name("catalog_links","metadata"), String.class);
-
-    // ── Chunks fields ──────────────────────────────────────────────────────────
-
-    static final Field<String>  F_CHK_TENANT = DSL.field(DSL.name("catalog_document_chunks","tenant_id"), String.class);
-    static final Field<String>  F_CHK_DOC    = DSL.field(DSL.name("catalog_document_chunks","doc_id"), String.class);
-    static final Field<Integer> F_CHK_POS    = DSL.field(DSL.name("catalog_document_chunks","position"), Integer.class);
-    static final Field<String>  F_CHK_CHASH  = DSL.field(DSL.name("catalog_document_chunks","chash"), String.class);
-    static final Field<Integer> F_CHK_IDX    = DSL.field(DSL.name("catalog_document_chunks","chunk_index"), Integer.class);
-    static final Field<Integer> F_CHK_LST    = DSL.field(DSL.name("catalog_document_chunks","line_start"), Integer.class);
-    static final Field<Integer> F_CHK_LEN    = DSL.field(DSL.name("catalog_document_chunks","line_end"), Integer.class);
-    static final Field<Integer> F_CHK_CST    = DSL.field(DSL.name("catalog_document_chunks","char_start"), Integer.class);
-    static final Field<Integer> F_CHK_CEN    = DSL.field(DSL.name("catalog_document_chunks","char_end"), Integer.class);
-
-    // ── Collections fields ─────────────────────────────────────────────────────
-
-    static final Field<String>  F_COL_TENANT = DSL.field(DSL.name("catalog_collections","tenant_id"), String.class);
-    static final Field<String>  F_COL_NAME   = DSL.field(DSL.name("catalog_collections","name"), String.class);
-    static final Field<String>  F_COL_CTYPE  = DSL.field(DSL.name("catalog_collections","content_type"), String.class);
-    static final Field<String>  F_COL_OWNER  = DSL.field(DSL.name("catalog_collections","owner_id"), String.class);
-    static final Field<String>  F_COL_EMBD   = DSL.field(DSL.name("catalog_collections","embedding_model"), String.class);
-    static final Field<String>  F_COL_MVER   = DSL.field(DSL.name("catalog_collections","model_version"), String.class);
-    static final Field<String>  F_COL_DNAME  = DSL.field(DSL.name("catalog_collections","display_name"), String.class);
-    static final Field<Integer> F_COL_LEGCY  = DSL.field(DSL.name("catalog_collections","legacy_grandfathered"), Integer.class);
-    static final Field<String>  F_COL_SUPBY  = DSL.field(DSL.name("catalog_collections","superseded_by"), String.class);
+    // type-skew vs generated (String vs OffsetDateTime) — wire shape pinned, see nexus-xtmtf report
     static final Field<String>  F_COL_SUPAT  = DSL.field(DSL.name("catalog_collections","superseded_at"), String.class);
+    // type-skew vs generated (String vs OffsetDateTime) — wire shape pinned, see nexus-xtmtf report
     static final Field<String>  F_COL_CRTAT  = DSL.field(DSL.name("catalog_collections","created_at"), String.class);
-
-    // ── Meta fields ────────────────────────────────────────────────────────────
-
-    static final Field<String> F_META_TENANT = DSL.field(DSL.name("catalog_meta","tenant_id"), String.class);
-    static final Field<String> F_META_KEY    = DSL.field(DSL.name("catalog_meta","key"), String.class);
-    static final Field<String> F_META_VAL    = DSL.field(DSL.name("catalog_meta","value"), String.class);
 
     // ── EXCLUDED field helpers (avoids the set() overload ambiguity) ───────────
 
@@ -273,11 +203,11 @@ public final class CatalogRepository {
             if (prefix == null || prefix.isBlank()) {
                 String repoHash = s(o, "repo_hash");
                 if (repoHash != null && !repoHash.isBlank()) {
-                    prefix = ctx.select(F_OWN_PREFIX)
-                                .from(T_OWNERS)
-                                .where(F_OWN_REPO.eq(repoHash))
+                    prefix = ctx.select(CATALOG_OWNERS.TUMBLER_PREFIX)
+                                .from(CATALOG_OWNERS)
+                                .where(CATALOG_OWNERS.REPO_HASH.eq(repoHash))
                                 .limit(1)
-                                .fetchOne(F_OWN_PREFIX);
+                                .fetchOne(CATALOG_OWNERS.TUMBLER_PREFIX);
                 }
                 if (prefix == null || prefix.isBlank()) {
                     // Next owner number: MAX(int after the first dot) + 1 over
@@ -288,27 +218,27 @@ public final class CatalogRepository {
                                     "CAST(split_part(tumbler_prefix, '.', 2) AS INTEGER)",
                                     Integer.class)),
                                 DSL.inline(0)))
-                        .from(T_OWNERS)
-                        .where(F_OWN_PREFIX.like("1.%"))
+                        .from(CATALOG_OWNERS)
+                        .where(CATALOG_OWNERS.TUMBLER_PREFIX.like("1.%"))
                         .fetchOne(0, Integer.class);
                     prefix = "1." + ((maxNum == null ? 0 : maxNum) + 1);
                 }
             }
-            ctx.insertInto(T_OWNERS,
-                    F_OWN_TENANT, F_OWN_PREFIX, F_OWN_NAME, F_OWN_TYPE,
-                    F_OWN_REPO, F_OWN_DESC, F_OWN_ROOT, F_OWN_HEAD)
+            ctx.insertInto(CATALOG_OWNERS,
+                    CATALOG_OWNERS.TENANT_ID, CATALOG_OWNERS.TUMBLER_PREFIX, CATALOG_OWNERS.NAME, CATALOG_OWNERS.OWNER_TYPE,
+                    CATALOG_OWNERS.REPO_HASH, CATALOG_OWNERS.DESCRIPTION, CATALOG_OWNERS.REPO_ROOT, CATALOG_OWNERS.HEAD_HASH)
                .values(tenant,
                        prefix, s(o,"name"), s(o,"owner_type"),
                        s(o,"repo_hash"), s(o,"description"), nne(s(o,"repo_root")),
                        s(o,"head_hash"))
-               .onConflict(F_OWN_TENANT, F_OWN_PREFIX)
+               .onConflict(CATALOG_OWNERS.TENANT_ID, CATALOG_OWNERS.TUMBLER_PREFIX)
                .doUpdate()
-               .set(F_OWN_NAME, EX_OWN_NAME)
-               .set(F_OWN_TYPE, EX_OWN_TYPE)
-               .set(F_OWN_REPO, EX_OWN_REPO)
-               .set(F_OWN_DESC, EX_OWN_DESC)
-               .set(F_OWN_ROOT, EX_OWN_ROOT)
-               .set(F_OWN_HEAD, EX_OWN_HEAD)
+               .set(CATALOG_OWNERS.NAME, EX_OWN_NAME)
+               .set(CATALOG_OWNERS.OWNER_TYPE, EX_OWN_TYPE)
+               .set(CATALOG_OWNERS.REPO_HASH, EX_OWN_REPO)
+               .set(CATALOG_OWNERS.DESCRIPTION, EX_OWN_DESC)
+               .set(CATALOG_OWNERS.REPO_ROOT, EX_OWN_ROOT)
+               .set(CATALOG_OWNERS.HEAD_HASH, EX_OWN_HEAD)
                .execute();
             return null;
         });
@@ -317,9 +247,9 @@ public final class CatalogRepository {
     /** Return all owners for tenant as list of maps. */
     public List<Map<String, Object>> listOwners(String tenant) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(F_OWN_PREFIX, F_OWN_NAME, F_OWN_TYPE, F_OWN_REPO,
-                       F_OWN_DESC, F_OWN_ROOT, F_OWN_HEAD)
-               .from(T_OWNERS)
+            ctx.select(CATALOG_OWNERS.TUMBLER_PREFIX, CATALOG_OWNERS.NAME, CATALOG_OWNERS.OWNER_TYPE, CATALOG_OWNERS.REPO_HASH,
+                       CATALOG_OWNERS.DESCRIPTION, CATALOG_OWNERS.REPO_ROOT, CATALOG_OWNERS.HEAD_HASH)
+               .from(CATALOG_OWNERS)
                .fetch()
                .map(r -> ownerRow(r.value1(), r.value2(), r.value3(), r.value4(), r.value5(), r.value6(), r.value7()))
         );
@@ -328,10 +258,10 @@ public final class CatalogRepository {
     /** Find owner by repo_hash. Returns null if not found. */
     public Map<String, Object> ownerByRepoHash(String tenant, String repoHash) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var r = ctx.select(F_OWN_PREFIX, F_OWN_NAME, F_OWN_TYPE, F_OWN_REPO,
-                               F_OWN_DESC, F_OWN_ROOT, F_OWN_HEAD)
-                       .from(T_OWNERS)
-                       .where(F_OWN_REPO.eq(repoHash))
+            var r = ctx.select(CATALOG_OWNERS.TUMBLER_PREFIX, CATALOG_OWNERS.NAME, CATALOG_OWNERS.OWNER_TYPE, CATALOG_OWNERS.REPO_HASH,
+                               CATALOG_OWNERS.DESCRIPTION, CATALOG_OWNERS.REPO_ROOT, CATALOG_OWNERS.HEAD_HASH)
+                       .from(CATALOG_OWNERS)
+                       .where(CATALOG_OWNERS.REPO_HASH.eq(repoHash))
                        .fetchOne();
             return r != null ? ownerRow(r.value1(), r.value2(), r.value3(), r.value4(), r.value5(), r.value6(), r.value7()) : null;
         });
@@ -340,10 +270,10 @@ public final class CatalogRepository {
     /** Find owners by name. */
     public List<Map<String, Object>> ownersByName(String tenant, String name) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(F_OWN_PREFIX, F_OWN_NAME, F_OWN_TYPE, F_OWN_REPO,
-                       F_OWN_DESC, F_OWN_ROOT, F_OWN_HEAD)
-               .from(T_OWNERS)
-               .where(F_OWN_NAME.eq(name))
+            ctx.select(CATALOG_OWNERS.TUMBLER_PREFIX, CATALOG_OWNERS.NAME, CATALOG_OWNERS.OWNER_TYPE, CATALOG_OWNERS.REPO_HASH,
+                       CATALOG_OWNERS.DESCRIPTION, CATALOG_OWNERS.REPO_ROOT, CATALOG_OWNERS.HEAD_HASH)
+               .from(CATALOG_OWNERS)
+               .where(CATALOG_OWNERS.NAME.eq(name))
                .fetch()
                .map(r -> ownerRow(r.value1(), r.value2(), r.value3(), r.value4(), r.value5(), r.value6(), r.value7()))
         );
@@ -352,9 +282,9 @@ public final class CatalogRepository {
     /** Update head_hash for an owner. */
     public int setOwnerHeadHash(String tenant, String tumblerPrefix, String headHash) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.update(T_OWNERS)
-               .set(F_OWN_HEAD, headHash)
-               .where(F_OWN_PREFIX.eq(tumblerPrefix))
+            ctx.update(CATALOG_OWNERS)
+               .set(CATALOG_OWNERS.HEAD_HASH, headHash)
+               .where(CATALOG_OWNERS.TUMBLER_PREFIX.eq(tumblerPrefix))
                .execute()
         );
     }
@@ -367,12 +297,12 @@ public final class CatalogRepository {
     public void upsertDocument(String tenant, Map<String, Object> d) {
         String metaJson = jsonOrNull(d.get("metadata"));
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.insertInto(T_DOCS,
-                    F_DOC_TENANT, F_DOC_TUMBLER, F_DOC_TITLE, F_DOC_AUTHOR, F_DOC_YEAR,
-                    F_DOC_CTYPE, F_DOC_FPATH, F_DOC_CORPUS, F_DOC_PCOLL, F_DOC_CHUNKS,
-                    F_DOC_HEAD, F_DOC_IDXAT, F_DOC_META, F_DOC_SMTIME, F_DOC_ALIAS, F_DOC_URI,
-                    F_DOC_BIBY, F_DOC_BIAU, F_DOC_BIVE, F_DOC_BICC,
-                    F_DOC_BIS2, F_DOC_BIOA, F_DOC_BIDOI, F_DOC_BIAT)
+            ctx.insertInto(CATALOG_DOCUMENTS,
+                    CATALOG_DOCUMENTS.TENANT_ID, CATALOG_DOCUMENTS.TUMBLER, CATALOG_DOCUMENTS.TITLE, CATALOG_DOCUMENTS.AUTHOR, CATALOG_DOCUMENTS.YEAR,
+                    CATALOG_DOCUMENTS.CONTENT_TYPE, CATALOG_DOCUMENTS.FILE_PATH, CATALOG_DOCUMENTS.CORPUS, CATALOG_DOCUMENTS.PHYSICAL_COLLECTION, CATALOG_DOCUMENTS.CHUNK_COUNT,
+                    CATALOG_DOCUMENTS.HEAD_HASH, CATALOG_DOCUMENTS.INDEXED_AT, F_DOC_META, CATALOG_DOCUMENTS.SOURCE_MTIME, CATALOG_DOCUMENTS.ALIAS_OF, CATALOG_DOCUMENTS.SOURCE_URI,
+                    CATALOG_DOCUMENTS.BIB_YEAR, CATALOG_DOCUMENTS.BIB_AUTHORS, CATALOG_DOCUMENTS.BIB_VENUE, CATALOG_DOCUMENTS.BIB_CITATION_COUNT,
+                    CATALOG_DOCUMENTS.BIB_SEMANTIC_SCHOLAR_ID, CATALOG_DOCUMENTS.BIB_OPENALEX_ID, CATALOG_DOCUMENTS.BIB_DOI, CATALOG_DOCUMENTS.BIB_ENRICHED_AT)
                .values(tenant, s(d,"tumbler"), s(d,"title"), s(d,"author"), i(d,"year"),
                        nne(s(d,"content_type")), nne(s(d,"file_path")), nne(s(d,"corpus")),
                        nne(s(d,"physical_collection")), ni(i(d,"chunk_count"), 0),
@@ -383,30 +313,30 @@ public final class CatalogRepository {
                        nne(s(d,"bib_venue")), ni(i(d,"bib_citation_count"), 0),
                        nne(s(d,"bib_semantic_scholar_id")), nne(s(d,"bib_openalex_id")),
                        nne(s(d,"bib_doi")), nne(s(d,"bib_enriched_at")))
-               .onConflict(F_DOC_TENANT, F_DOC_TUMBLER)
+               .onConflict(CATALOG_DOCUMENTS.TENANT_ID, CATALOG_DOCUMENTS.TUMBLER)
                .doUpdate()
-               .set(F_DOC_TITLE,  EX_DOC_TITLE)
-               .set(F_DOC_AUTHOR, EX_DOC_AUTHOR)
-               .set(F_DOC_YEAR,   EX_DOC_YEAR)
-               .set(F_DOC_CTYPE,  EX_DOC_CTYPE)
-               .set(F_DOC_FPATH,  EX_DOC_FPATH)
-               .set(F_DOC_CORPUS, EX_DOC_CORPUS)
-               .set(F_DOC_PCOLL,  EX_DOC_PCOLL)
-               .set(F_DOC_CHUNKS, EX_DOC_CHUNKS)
-               .set(F_DOC_HEAD,   EX_DOC_HEAD)
-               .set(F_DOC_IDXAT,  EX_DOC_IDXAT)
+               .set(CATALOG_DOCUMENTS.TITLE,  EX_DOC_TITLE)
+               .set(CATALOG_DOCUMENTS.AUTHOR, EX_DOC_AUTHOR)
+               .set(CATALOG_DOCUMENTS.YEAR,   EX_DOC_YEAR)
+               .set(CATALOG_DOCUMENTS.CONTENT_TYPE,  EX_DOC_CTYPE)
+               .set(CATALOG_DOCUMENTS.FILE_PATH,  EX_DOC_FPATH)
+               .set(CATALOG_DOCUMENTS.CORPUS, EX_DOC_CORPUS)
+               .set(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION,  EX_DOC_PCOLL)
+               .set(CATALOG_DOCUMENTS.CHUNK_COUNT, EX_DOC_CHUNKS)
+               .set(CATALOG_DOCUMENTS.HEAD_HASH,   EX_DOC_HEAD)
+               .set(CATALOG_DOCUMENTS.INDEXED_AT,  EX_DOC_IDXAT)
                .set(F_DOC_META,   EX_DOC_META)
-               .set(F_DOC_SMTIME, EX_DOC_SMTIME)
-               .set(F_DOC_ALIAS,  EX_DOC_ALIAS)
-               .set(F_DOC_URI,    EX_DOC_URI)
-               .set(F_DOC_BIBY,   EX_DOC_BIBY)
-               .set(F_DOC_BIAU,   EX_DOC_BIAU)
-               .set(F_DOC_BIVE,   EX_DOC_BIVE)
-               .set(F_DOC_BICC,   EX_DOC_BICC)
-               .set(F_DOC_BIS2,   EX_DOC_BIS2)
-               .set(F_DOC_BIOA,   EX_DOC_BIOA)
-               .set(F_DOC_BIDOI,  EX_DOC_BIDOI)
-               .set(F_DOC_BIAT,   EX_DOC_BIAT)
+               .set(CATALOG_DOCUMENTS.SOURCE_MTIME, EX_DOC_SMTIME)
+               .set(CATALOG_DOCUMENTS.ALIAS_OF,  EX_DOC_ALIAS)
+               .set(CATALOG_DOCUMENTS.SOURCE_URI,    EX_DOC_URI)
+               .set(CATALOG_DOCUMENTS.BIB_YEAR,   EX_DOC_BIBY)
+               .set(CATALOG_DOCUMENTS.BIB_AUTHORS,   EX_DOC_BIAU)
+               .set(CATALOG_DOCUMENTS.BIB_VENUE,   EX_DOC_BIVE)
+               .set(CATALOG_DOCUMENTS.BIB_CITATION_COUNT,   EX_DOC_BICC)
+               .set(CATALOG_DOCUMENTS.BIB_SEMANTIC_SCHOLAR_ID,   EX_DOC_BIS2)
+               .set(CATALOG_DOCUMENTS.BIB_OPENALEX_ID,   EX_DOC_BIOA)
+               .set(CATALOG_DOCUMENTS.BIB_DOI,  EX_DOC_BIDOI)
+               .set(CATALOG_DOCUMENTS.BIB_ENRICHED_AT,   EX_DOC_BIAT)
                .execute();
             return null;
         });
@@ -429,13 +359,13 @@ public final class CatalogRepository {
         }
         return tenantScope.withTenant(tenant, ctx -> {
             // Ensure owner row exists (idempotent upsert with minimal fields)
-            ctx.insertInto(T_OWNERS, F_OWN_TENANT, F_OWN_PREFIX, F_OWN_NAME, F_OWN_TYPE,
-                           F_OWN_REPO, F_OWN_DESC, F_OWN_ROOT, F_OWN_HEAD, F_OWN_SEQ)
+            ctx.insertInto(CATALOG_OWNERS, CATALOG_OWNERS.TENANT_ID, CATALOG_OWNERS.TUMBLER_PREFIX, CATALOG_OWNERS.NAME, CATALOG_OWNERS.OWNER_TYPE,
+                           CATALOG_OWNERS.REPO_HASH, CATALOG_OWNERS.DESCRIPTION, CATALOG_OWNERS.REPO_ROOT, CATALOG_OWNERS.HEAD_HASH, CATALOG_OWNERS.NEXT_SEQ)
                .values(tenant, ownerPrefix,
                        s(fields, "owner_name", ownerPrefix),
                        s(fields, "owner_type", "repo"),
                        null, null, "", null, 0L)
-               .onConflict(F_OWN_TENANT, F_OWN_PREFIX)
+               .onConflict(CATALOG_OWNERS.TENANT_ID, CATALOG_OWNERS.TUMBLER_PREFIX)
                .doNothing()
                .execute();
 
@@ -446,45 +376,45 @@ public final class CatalogRepository {
             // the trash entry is left untouched (users can restore or purge it separately).
             String srcUri = s(fields, "source_uri", "");
             if (!srcUri.isEmpty()) {
-                var existing = ctx.select(F_DOC_TUMBLER).from(T_DOCS)
-                                  .where(F_DOC_TENANT.eq(tenant)
-                                         .and(F_DOC_URI.eq(srcUri))
-                                         .and(F_DOC_DELETED_AT.isNull()))
+                var existing = ctx.select(CATALOG_DOCUMENTS.TUMBLER).from(CATALOG_DOCUMENTS)
+                                  .where(CATALOG_DOCUMENTS.TENANT_ID.eq(tenant)
+                                         .and(CATALOG_DOCUMENTS.SOURCE_URI.eq(srcUri))
+                                         .and(CATALOG_DOCUMENTS.DELETED_AT.isNull()))
                                   .fetchOne();
                 if (existing != null) return existing.value1();
             }
             String filePath = s(fields, "file_path", "");
             if (!filePath.isEmpty()) {
-                var existing = ctx.select(F_DOC_TUMBLER).from(T_DOCS)
-                                  .where(F_DOC_TENANT.eq(tenant)
-                                         .and(F_DOC_FPATH.eq(filePath))
-                                         .and(F_DOC_TUMBLER.startsWith(ownerPrefix + "."))
-                                         .and(F_DOC_DELETED_AT.isNull()))
+                var existing = ctx.select(CATALOG_DOCUMENTS.TUMBLER).from(CATALOG_DOCUMENTS)
+                                  .where(CATALOG_DOCUMENTS.TENANT_ID.eq(tenant)
+                                         .and(CATALOG_DOCUMENTS.FILE_PATH.eq(filePath))
+                                         .and(CATALOG_DOCUMENTS.TUMBLER.startsWith(ownerPrefix + "."))
+                                         .and(CATALOG_DOCUMENTS.DELETED_AT.isNull()))
                                   .fetchOne();
                 if (existing != null) return existing.value1();
             }
 
             // No existing document — atomically claim the next sequence number
-            long seq = ctx.select(F_OWN_SEQ).from(T_OWNERS)
-                          .where(F_OWN_TENANT.eq(tenant).and(F_OWN_PREFIX.eq(ownerPrefix)))
+            long seq = ctx.select(CATALOG_OWNERS.NEXT_SEQ).from(CATALOG_OWNERS)
+                          .where(CATALOG_OWNERS.TENANT_ID.eq(tenant).and(CATALOG_OWNERS.TUMBLER_PREFIX.eq(ownerPrefix)))
                           .forUpdate()
-                          .fetchOne(F_OWN_SEQ);
+                          .fetchOne(CATALOG_OWNERS.NEXT_SEQ);
 
-            ctx.update(T_OWNERS)
-               .set(F_OWN_SEQ, seq + 1)
-               .where(F_OWN_TENANT.eq(tenant).and(F_OWN_PREFIX.eq(ownerPrefix)))
+            ctx.update(CATALOG_OWNERS)
+               .set(CATALOG_OWNERS.NEXT_SEQ, seq + 1)
+               .where(CATALOG_OWNERS.TENANT_ID.eq(tenant).and(CATALOG_OWNERS.TUMBLER_PREFIX.eq(ownerPrefix)))
                .execute();
 
             String tumbler = ownerPrefix + "." + (seq + 1);
 
             // Insert document
             String metaJson = jsonOrNull(fields.get("meta"));
-            ctx.insertInto(T_DOCS,
-                    F_DOC_TENANT, F_DOC_TUMBLER, F_DOC_TITLE, F_DOC_AUTHOR, F_DOC_YEAR,
-                    F_DOC_CTYPE, F_DOC_FPATH, F_DOC_CORPUS, F_DOC_PCOLL, F_DOC_CHUNKS,
-                    F_DOC_HEAD, F_DOC_IDXAT, F_DOC_META, F_DOC_SMTIME, F_DOC_ALIAS, F_DOC_URI,
-                    F_DOC_BIBY, F_DOC_BIAU, F_DOC_BIVE, F_DOC_BICC,
-                    F_DOC_BIS2, F_DOC_BIOA, F_DOC_BIDOI, F_DOC_BIAT)
+            ctx.insertInto(CATALOG_DOCUMENTS,
+                    CATALOG_DOCUMENTS.TENANT_ID, CATALOG_DOCUMENTS.TUMBLER, CATALOG_DOCUMENTS.TITLE, CATALOG_DOCUMENTS.AUTHOR, CATALOG_DOCUMENTS.YEAR,
+                    CATALOG_DOCUMENTS.CONTENT_TYPE, CATALOG_DOCUMENTS.FILE_PATH, CATALOG_DOCUMENTS.CORPUS, CATALOG_DOCUMENTS.PHYSICAL_COLLECTION, CATALOG_DOCUMENTS.CHUNK_COUNT,
+                    CATALOG_DOCUMENTS.HEAD_HASH, CATALOG_DOCUMENTS.INDEXED_AT, F_DOC_META, CATALOG_DOCUMENTS.SOURCE_MTIME, CATALOG_DOCUMENTS.ALIAS_OF, CATALOG_DOCUMENTS.SOURCE_URI,
+                    CATALOG_DOCUMENTS.BIB_YEAR, CATALOG_DOCUMENTS.BIB_AUTHORS, CATALOG_DOCUMENTS.BIB_VENUE, CATALOG_DOCUMENTS.BIB_CITATION_COUNT,
+                    CATALOG_DOCUMENTS.BIB_SEMANTIC_SCHOLAR_ID, CATALOG_DOCUMENTS.BIB_OPENALEX_ID, CATALOG_DOCUMENTS.BIB_DOI, CATALOG_DOCUMENTS.BIB_ENRICHED_AT)
                .values(tenant, tumbler,
                        s(fields, "title", ""),
                        nne(s(fields, "author", null)),
@@ -518,8 +448,8 @@ public final class CatalogRepository {
     public Map<String, Object> getDocument(String tenant, String tumbler) {
         return tenantScope.withTenant(tenant, ctx -> {
             var r = ctx.select(documentFields())
-                       .from(T_DOCS)
-                       .where(F_DOC_TUMBLER.eq(tumbler).and(F_DOC_DELETED_AT.isNull()))
+                       .from(CATALOG_DOCUMENTS)
+                       .where(CATALOG_DOCUMENTS.TUMBLER.eq(tumbler).and(CATALOG_DOCUMENTS.DELETED_AT.isNull()))
                        .fetchOne();
             return r != null ? docRowFromRecord(r.intoMap()) : null;
         });
@@ -561,7 +491,7 @@ public final class CatalogRepository {
             }
         }
         return tenantScope.withTenant(tenant, ctx -> {
-            var step = ctx.update(T_DOCS);
+            var step = ctx.update(CATALOG_DOCUMENTS);
             UpdateSetMoreStep<?> more = null;
             for (var e : fields.entrySet()) {
                 if (e.getValue() == null) continue;
@@ -583,9 +513,9 @@ public final class CatalogRepository {
             }
             if (more == null) return 0;
             // AND deleted_at IS NULL: refuse to update tombstoned documents
-            return more.where(F_DOC_TENANT.eq(tenant)
-                              .and(F_DOC_TUMBLER.eq(tumbler))
-                              .and(F_DOC_DELETED_AT.isNull()))
+            return more.where(CATALOG_DOCUMENTS.TENANT_ID.eq(tenant)
+                              .and(CATALOG_DOCUMENTS.TUMBLER.eq(tumbler))
+                              .and(CATALOG_DOCUMENTS.DELETED_AT.isNull()))
                        .execute();
         });
     }
@@ -600,9 +530,9 @@ public final class CatalogRepository {
      */
     public int deleteDocument(String tenant, String tumbler) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.update(T_DOCS)
-               .set(F_DOC_DELETED_AT, DSL.currentOffsetDateTime())
-               .where(F_DOC_TUMBLER.eq(tumbler).and(F_DOC_DELETED_AT.isNull()))
+            ctx.update(CATALOG_DOCUMENTS)
+               .set(CATALOG_DOCUMENTS.DELETED_AT, DSL.currentOffsetDateTime())
+               .where(CATALOG_DOCUMENTS.TUMBLER.eq(tumbler).and(CATALOG_DOCUMENTS.DELETED_AT.isNull()))
                .execute()
         );
     }
@@ -620,10 +550,10 @@ public final class CatalogRepository {
                 DSL.val(query));
             Condition where = ftsMatch;
             if (contentType != null && !contentType.isBlank()) {
-                where = where.and(F_DOC_CTYPE.eq(contentType));
+                where = where.and(CATALOG_DOCUMENTS.CONTENT_TYPE.eq(contentType));
             }
             return ctx.select(documentFields())
-                      .from(T_DOCS)
+                      .from(CATALOG_DOCUMENTS)
                       .where(where)
                       .limit(limit <= 0 ? 200 : limit)
                       .fetch()
@@ -635,8 +565,8 @@ public final class CatalogRepository {
     public List<Map<String, Object>> listDocuments(String tenant, int limit, int offset) {
         return tenantScope.withTenant(tenant, ctx ->
             ctx.select(documentFields())
-               .from(T_DOCS)
-               .orderBy(F_DOC_TUMBLER)
+               .from(CATALOG_DOCUMENTS)
+               .orderBy(CATALOG_DOCUMENTS.TUMBLER)
                .limit(limit <= 0 ? 200 : limit)
                .offset(offset)
                .fetch()
@@ -647,7 +577,7 @@ public final class CatalogRepository {
     /** Count all documents for this tenant. */
     public long countDocuments(String tenant) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.selectCount().from(T_DOCS).fetchOne(0, Long.class)
+            ctx.selectCount().from(CATALOG_DOCUMENTS).fetchOne(0, Long.class)
         );
     }
 
@@ -772,8 +702,8 @@ public final class CatalogRepository {
     /** Documents by physical_collection. */
     public List<Map<String, Object>> documentsByCollection(String tenant, String collection) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(documentFields()).from(T_DOCS)
-               .where(F_DOC_PCOLL.eq(collection)).orderBy(F_DOC_TUMBLER)
+            ctx.select(documentFields()).from(CATALOG_DOCUMENTS)
+               .where(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION.eq(collection)).orderBy(CATALOG_DOCUMENTS.TUMBLER)
                .fetch().map(r -> docRowFromRecord(r.intoMap()))
         );
     }
@@ -781,8 +711,8 @@ public final class CatalogRepository {
     /** Documents by file_path (exact). */
     public List<Map<String, Object>> documentsByFilePath(String tenant, String filePath) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(documentFields()).from(T_DOCS)
-               .where(F_DOC_FPATH.eq(filePath))
+            ctx.select(documentFields()).from(CATALOG_DOCUMENTS)
+               .where(CATALOG_DOCUMENTS.FILE_PATH.eq(filePath))
                .fetch().map(r -> docRowFromRecord(r.intoMap()))
         );
     }
@@ -790,8 +720,8 @@ public final class CatalogRepository {
     /** Documents by source_uri (exact). */
     public List<Map<String, Object>> documentsBySourceUri(String tenant, String uri) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(documentFields()).from(T_DOCS)
-               .where(F_DOC_URI.eq(uri))
+            ctx.select(documentFields()).from(CATALOG_DOCUMENTS)
+               .where(CATALOG_DOCUMENTS.SOURCE_URI.eq(uri))
                .fetch().map(r -> docRowFromRecord(r.intoMap()))
         );
     }
@@ -799,9 +729,9 @@ public final class CatalogRepository {
     /** Documents by owner tumbler prefix. */
     public List<Map<String, Object>> documentsByOwner(String tenant, String ownerPrefix) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(documentFields()).from(T_DOCS)
-               .where(F_DOC_TUMBLER.like(ownerPrefix + ".%"))
-               .orderBy(F_DOC_TUMBLER)
+            ctx.select(documentFields()).from(CATALOG_DOCUMENTS)
+               .where(CATALOG_DOCUMENTS.TUMBLER.like(ownerPrefix + ".%"))
+               .orderBy(CATALOG_DOCUMENTS.TUMBLER)
                .fetch().map(r -> docRowFromRecord(r.intoMap()))
         );
     }
@@ -817,9 +747,9 @@ public final class CatalogRepository {
     public List<Map<String, Object>> documentsByOwnerAndFilePath(
             String tenant, String ownerPrefix, String filePath) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(documentFields()).from(T_DOCS)
-               .where(F_DOC_TUMBLER.like(ownerPrefix + ".%").and(F_DOC_FPATH.eq(filePath)))
-               .orderBy(F_DOC_TUMBLER)
+            ctx.select(documentFields()).from(CATALOG_DOCUMENTS)
+               .where(CATALOG_DOCUMENTS.TUMBLER.like(ownerPrefix + ".%").and(CATALOG_DOCUMENTS.FILE_PATH.eq(filePath)))
+               .orderBy(CATALOG_DOCUMENTS.TUMBLER)
                .fetch().map(r -> docRowFromRecord(r.intoMap()))
         );
     }
@@ -827,9 +757,9 @@ public final class CatalogRepository {
     /** Documents by content_type. */
     public List<Map<String, Object>> documentsByContentType(String tenant, String contentType) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(documentFields()).from(T_DOCS)
-               .where(F_DOC_CTYPE.eq(contentType))
-               .orderBy(F_DOC_TUMBLER)
+            ctx.select(documentFields()).from(CATALOG_DOCUMENTS)
+               .where(CATALOG_DOCUMENTS.CONTENT_TYPE.eq(contentType))
+               .orderBy(CATALOG_DOCUMENTS.TUMBLER)
                .fetch().map(r -> docRowFromRecord(r.intoMap()))
         );
     }
@@ -837,9 +767,9 @@ public final class CatalogRepository {
     /** Documents by corpus. */
     public List<Map<String, Object>> documentsByCorpus(String tenant, String corpus) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(documentFields()).from(T_DOCS)
-               .where(F_DOC_CORPUS.eq(corpus))
-               .orderBy(F_DOC_TUMBLER)
+            ctx.select(documentFields()).from(CATALOG_DOCUMENTS)
+               .where(CATALOG_DOCUMENTS.CORPUS.eq(corpus))
+               .orderBy(CATALOG_DOCUMENTS.TUMBLER)
                .fetch().map(r -> docRowFromRecord(r.intoMap()))
         );
     }
@@ -847,9 +777,9 @@ public final class CatalogRepository {
     /** Descendants: all documents with tumbler starting with prefix + "." */
     public List<Map<String, Object>> descendants(String tenant, String prefix) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(documentFields()).from(T_DOCS)
-               .where(F_DOC_TUMBLER.like(prefix + ".%"))
-               .orderBy(F_DOC_TUMBLER)
+            ctx.select(documentFields()).from(CATALOG_DOCUMENTS)
+               .where(CATALOG_DOCUMENTS.TUMBLER.like(prefix + ".%"))
+               .orderBy(CATALOG_DOCUMENTS.TUMBLER)
                .fetch().map(r -> docRowFromRecord(r.intoMap()))
         );
     }
@@ -857,7 +787,7 @@ public final class CatalogRepository {
     /** Update physical_collection for one document. */
     public int updateDocumentCollection(String tenant, String tumbler, String newCollection) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.update(T_DOCS).set(F_DOC_PCOLL, newCollection).where(F_DOC_TUMBLER.eq(tumbler)).execute()
+            ctx.update(CATALOG_DOCUMENTS).set(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION, newCollection).where(CATALOG_DOCUMENTS.TUMBLER.eq(tumbler)).execute()
         );
     }
 
@@ -865,22 +795,22 @@ public final class CatalogRepository {
     public int updateDocumentsCollectionBatch(String tenant, List<String> tumblers, String newCollection) {
         if (tumblers.isEmpty()) return 0;
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.update(T_DOCS).set(F_DOC_PCOLL, newCollection).where(F_DOC_TUMBLER.in(tumblers)).execute()
+            ctx.update(CATALOG_DOCUMENTS).set(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION, newCollection).where(CATALOG_DOCUMENTS.TUMBLER.in(tumblers)).execute()
         );
     }
 
     /** Set alias_of for a document. */
     public int setAlias(String tenant, String tumbler, String aliasOf) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.update(T_DOCS).set(F_DOC_ALIAS, nne(aliasOf)).where(F_DOC_TUMBLER.eq(tumbler)).execute()
+            ctx.update(CATALOG_DOCUMENTS).set(CATALOG_DOCUMENTS.ALIAS_OF, nne(aliasOf)).where(CATALOG_DOCUMENTS.TUMBLER.eq(tumbler)).execute()
         );
     }
 
     /** Look up tumbler by (physical_collection, file_path). Returns null if not found. */
     public String lookupDocByCollectionAndPath(String tenant, String collection, String filePath) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var r = ctx.select(F_DOC_TUMBLER).from(T_DOCS)
-                       .where(F_DOC_PCOLL.eq(collection).and(F_DOC_FPATH.eq(filePath)))
+            var r = ctx.select(CATALOG_DOCUMENTS.TUMBLER).from(CATALOG_DOCUMENTS)
+                       .where(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION.eq(collection).and(CATALOG_DOCUMENTS.FILE_PATH.eq(filePath)))
                        .fetchOne();
             return r != null ? r.value1() : null;
         });
@@ -900,31 +830,38 @@ public final class CatalogRepository {
     public boolean upsertLink(String tenant, Map<String, Object> lnk) {
         String metaJson = jsonOrNull(lnk.get("metadata"));
         return tenantScope.withTenant(tenant, ctx -> {
-            var rec = ctx.insertInto(T_LINKS,
-                    F_LNK_TENANT, F_LNK_FROM, F_LNK_TO, F_LNK_TYPE,
-                    F_LNK_FSPAN, F_LNK_TSPAN, F_LNK_CRTBY, F_LNK_CRTAT, F_LNK_META)
+            var rec = ctx.insertInto(CATALOG_LINKS,
+                    CATALOG_LINKS.TENANT_ID, CATALOG_LINKS.FROM_TUMBLER, CATALOG_LINKS.TO_TUMBLER, CATALOG_LINKS.LINK_TYPE,
+                    CATALOG_LINKS.FROM_SPAN, CATALOG_LINKS.TO_SPAN, CATALOG_LINKS.CREATED_BY, CATALOG_LINKS.CREATED_AT, F_LNK_META)
                .values(DSL.val(tenant),
                        DSL.val(s(lnk,"from_tumbler")), DSL.val(s(lnk,"to_tumbler")), DSL.val(s(lnk,"link_type")),
                        DSL.val(nne(s(lnk,"from_span"))), DSL.val(nne(s(lnk,"to_span"))),
                        DSL.val(nne(s(lnk,"created_by"))), DSL.val(nne(s(lnk,"created_at"))),
                        jsonbVal(metaJson))
-               .onConflict(F_LNK_TENANT, F_LNK_FROM, F_LNK_TO, F_LNK_TYPE)
+               .onConflict(CATALOG_LINKS.TENANT_ID, CATALOG_LINKS.FROM_TUMBLER, CATALOG_LINKS.TO_TUMBLER, CATALOG_LINKS.LINK_TYPE)
                .doUpdate()
-               .set(F_LNK_FSPAN, EX_LNK_FSPAN)
-               .set(F_LNK_TSPAN, EX_LNK_TSPAN)
-               .set(F_LNK_CRTBY, EX_LNK_CRTBY)
+               .set(CATALOG_LINKS.FROM_SPAN, EX_LNK_FSPAN)
+               .set(CATALOG_LINKS.TO_SPAN, EX_LNK_TSPAN)
+               .set(CATALOG_LINKS.CREATED_BY, EX_LNK_CRTBY)
                .set(F_LNK_META,  EX_LNK_META)
-               .returning(DSL.field("(xmax = 0)", Boolean.class))
+               // nexus-xtmtf: CATALOG_LINKS (generated) carries a real CatalogLinksRecord
+               // shape, unlike the old hand-built Table<?>. .returning(Field...) on a
+               // recognized table returns the table's OWN record shape with the extra
+               // expression appended, so position 0 is no longer our boolean expression
+               // (jOOQ logs "API misuse ... not present in table" and get(0,...) silently
+               // reads the wrong column). .returningResult(...) requests EXACTLY this
+               // field and nothing else, independent of the table's real column list.
+               .returningResult(DSL.field("(xmax = 0)", Boolean.class))
                .fetchOne();
-            return rec != null && Boolean.TRUE.equals(rec.get(0, Boolean.class));
+            return rec != null && Boolean.TRUE.equals(rec.value1());
         });
     }
 
     /** Delete a link by (from, to, type). Returns deleted count. */
     public int deleteLink(String tenant, String fromT, String toT, String linkType) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.deleteFrom(T_LINKS)
-               .where(F_LNK_FROM.eq(fromT).and(F_LNK_TO.eq(toT)).and(F_LNK_TYPE.eq(linkType)))
+            ctx.deleteFrom(CATALOG_LINKS)
+               .where(CATALOG_LINKS.FROM_TUMBLER.eq(fromT).and(CATALOG_LINKS.TO_TUMBLER.eq(toT)).and(CATALOG_LINKS.LINK_TYPE.eq(linkType)))
                .execute()
         );
     }
@@ -938,11 +875,11 @@ public final class CatalogRepository {
      */
     public List<Map<String, Object>> linksFrom(String tenant, String fromTumbler, List<String> linkTypes) {
         return tenantScope.withTenant(tenant, ctx -> {
-            Condition where = F_LNK_FROM.eq(fromTumbler);
-            if (linkTypes != null && !linkTypes.isEmpty()) where = where.and(F_LNK_TYPE.in(linkTypes));
-            return ctx.select(F_LNK_ID, F_LNK_FROM, F_LNK_TO, F_LNK_TYPE,
-                               F_LNK_FSPAN, F_LNK_TSPAN, F_LNK_CRTBY, F_LNK_CRTAT, F_LNK_META)
-                      .from(T_LINKS).where(where).fetch()
+            Condition where = CATALOG_LINKS.FROM_TUMBLER.eq(fromTumbler);
+            if (linkTypes != null && !linkTypes.isEmpty()) where = where.and(CATALOG_LINKS.LINK_TYPE.in(linkTypes));
+            return ctx.select(CATALOG_LINKS.ID, CATALOG_LINKS.FROM_TUMBLER, CATALOG_LINKS.TO_TUMBLER, CATALOG_LINKS.LINK_TYPE,
+                               CATALOG_LINKS.FROM_SPAN, CATALOG_LINKS.TO_SPAN, CATALOG_LINKS.CREATED_BY, CATALOG_LINKS.CREATED_AT, F_LNK_META)
+                      .from(CATALOG_LINKS).where(where).fetch()
                       .map(r -> linkRow(r.value1(), r.value2(), r.value3(), r.value4(),
                                         r.value5(), r.value6(), r.value7(), r.value8(), r.value9()));
         });
@@ -951,11 +888,11 @@ public final class CatalogRepository {
     /** Links to a tumbler, optionally filtered by a SET of link types (RDR-168 njrcn.5). */
     public List<Map<String, Object>> linksTo(String tenant, String toTumbler, List<String> linkTypes) {
         return tenantScope.withTenant(tenant, ctx -> {
-            Condition where = F_LNK_TO.eq(toTumbler);
-            if (linkTypes != null && !linkTypes.isEmpty()) where = where.and(F_LNK_TYPE.in(linkTypes));
-            return ctx.select(F_LNK_ID, F_LNK_FROM, F_LNK_TO, F_LNK_TYPE,
-                               F_LNK_FSPAN, F_LNK_TSPAN, F_LNK_CRTBY, F_LNK_CRTAT, F_LNK_META)
-                      .from(T_LINKS).where(where).fetch()
+            Condition where = CATALOG_LINKS.TO_TUMBLER.eq(toTumbler);
+            if (linkTypes != null && !linkTypes.isEmpty()) where = where.and(CATALOG_LINKS.LINK_TYPE.in(linkTypes));
+            return ctx.select(CATALOG_LINKS.ID, CATALOG_LINKS.FROM_TUMBLER, CATALOG_LINKS.TO_TUMBLER, CATALOG_LINKS.LINK_TYPE,
+                               CATALOG_LINKS.FROM_SPAN, CATALOG_LINKS.TO_SPAN, CATALOG_LINKS.CREATED_BY, CATALOG_LINKS.CREATED_AT, F_LNK_META)
+                      .from(CATALOG_LINKS).where(where).fetch()
                       .map(r -> linkRow(r.value1(), r.value2(), r.value3(), r.value4(),
                                         r.value5(), r.value6(), r.value7(), r.value8(), r.value9()));
         });
@@ -968,28 +905,28 @@ public final class CatalogRepository {
                                                  String direction, String tumbler) {
         return tenantScope.withTenant(tenant, ctx -> {
             Condition cond = DSL.trueCondition();
-            if (fromT != null && !fromT.isBlank())         cond = cond.and(F_LNK_FROM.eq(fromT));
-            if (toT != null && !toT.isBlank())             cond = cond.and(F_LNK_TO.eq(toT));
-            if (linkType != null && !linkType.isBlank())   cond = cond.and(F_LNK_TYPE.eq(linkType));
-            if (createdBy != null && !createdBy.isBlank()) cond = cond.and(F_LNK_CRTBY.eq(createdBy));
+            if (fromT != null && !fromT.isBlank())         cond = cond.and(CATALOG_LINKS.FROM_TUMBLER.eq(fromT));
+            if (toT != null && !toT.isBlank())             cond = cond.and(CATALOG_LINKS.TO_TUMBLER.eq(toT));
+            if (linkType != null && !linkType.isBlank())   cond = cond.and(CATALOG_LINKS.LINK_TYPE.eq(linkType));
+            if (createdBy != null && !createdBy.isBlank()) cond = cond.and(CATALOG_LINKS.CREATED_BY.eq(createdBy));
             if (createdAtBefore != null && !createdAtBefore.isBlank())
-                cond = cond.and(F_LNK_CRTAT.lessThan(createdAtBefore));
+                cond = cond.and(CATALOG_LINKS.CREATED_AT.lessThan(createdAtBefore));
             // direction + tumbler: filter by tumbler in the appropriate column(s)
             if (tumbler != null && !tumbler.isBlank()) {
                 String dir = direction != null ? direction : "both";
                 Condition tCond;
                 if ("out".equals(dir)) {
-                    tCond = F_LNK_FROM.eq(tumbler);
+                    tCond = CATALOG_LINKS.FROM_TUMBLER.eq(tumbler);
                 } else if ("in".equals(dir)) {
-                    tCond = F_LNK_TO.eq(tumbler);
+                    tCond = CATALOG_LINKS.TO_TUMBLER.eq(tumbler);
                 } else {
-                    tCond = F_LNK_FROM.eq(tumbler).or(F_LNK_TO.eq(tumbler));
+                    tCond = CATALOG_LINKS.FROM_TUMBLER.eq(tumbler).or(CATALOG_LINKS.TO_TUMBLER.eq(tumbler));
                 }
                 cond = cond.and(tCond);
             }
-            return ctx.select(F_LNK_ID, F_LNK_FROM, F_LNK_TO, F_LNK_TYPE,
-                               F_LNK_FSPAN, F_LNK_TSPAN, F_LNK_CRTBY, F_LNK_CRTAT, F_LNK_META)
-                      .from(T_LINKS).where(cond).orderBy(F_LNK_ID)
+            return ctx.select(CATALOG_LINKS.ID, CATALOG_LINKS.FROM_TUMBLER, CATALOG_LINKS.TO_TUMBLER, CATALOG_LINKS.LINK_TYPE,
+                               CATALOG_LINKS.FROM_SPAN, CATALOG_LINKS.TO_SPAN, CATALOG_LINKS.CREATED_BY, CATALOG_LINKS.CREATED_AT, F_LNK_META)
+                      .from(CATALOG_LINKS).where(cond).orderBy(CATALOG_LINKS.ID)
                       .limit(limit <= 0 ? 200 : limit).offset(offset).fetch()
                       .map(r -> linkRow(r.value1(), r.value2(), r.value3(), r.value4(),
                                         r.value5(), r.value6(), r.value7(), r.value8(), r.value9()));
@@ -1001,13 +938,13 @@ public final class CatalogRepository {
                                 String linkType, String createdBy, String createdAtBefore) {
         return tenantScope.withTenant(tenant, ctx -> {
             Condition cond = DSL.trueCondition();
-            if (fromT != null && !fromT.isBlank())         cond = cond.and(F_LNK_FROM.eq(fromT));
-            if (toT != null && !toT.isBlank())             cond = cond.and(F_LNK_TO.eq(toT));
-            if (linkType != null && !linkType.isBlank())   cond = cond.and(F_LNK_TYPE.eq(linkType));
-            if (createdBy != null && !createdBy.isBlank()) cond = cond.and(F_LNK_CRTBY.eq(createdBy));
+            if (fromT != null && !fromT.isBlank())         cond = cond.and(CATALOG_LINKS.FROM_TUMBLER.eq(fromT));
+            if (toT != null && !toT.isBlank())             cond = cond.and(CATALOG_LINKS.TO_TUMBLER.eq(toT));
+            if (linkType != null && !linkType.isBlank())   cond = cond.and(CATALOG_LINKS.LINK_TYPE.eq(linkType));
+            if (createdBy != null && !createdBy.isBlank()) cond = cond.and(CATALOG_LINKS.CREATED_BY.eq(createdBy));
             if (createdAtBefore != null && !createdAtBefore.isBlank())
-                cond = cond.and(F_LNK_CRTAT.lessThan(createdAtBefore));
-            return ctx.deleteFrom(T_LINKS).where(cond).execute();
+                cond = cond.and(CATALOG_LINKS.CREATED_AT.lessThan(createdAtBefore));
+            return ctx.deleteFrom(CATALOG_LINKS).where(cond).execute();
         });
     }
 
@@ -1037,19 +974,19 @@ public final class CatalogRepository {
 
                 Condition dirCond;
                 if ("out".equals(direction)) {
-                    dirCond = F_LNK_FROM.in(fl);
+                    dirCond = CATALOG_LINKS.FROM_TUMBLER.in(fl);
                 } else if ("in".equals(direction)) {
-                    dirCond = F_LNK_TO.in(fl);
+                    dirCond = CATALOG_LINKS.TO_TUMBLER.in(fl);
                 } else {
-                    dirCond = F_LNK_FROM.in(fl).or(F_LNK_TO.in(fl));
+                    dirCond = CATALOG_LINKS.FROM_TUMBLER.in(fl).or(CATALOG_LINKS.TO_TUMBLER.in(fl));
                 }
                 if (!linkTypes.isEmpty()) {
-                    dirCond = dirCond.and(F_LNK_TYPE.in(linkTypes));
+                    dirCond = dirCond.and(CATALOG_LINKS.LINK_TYPE.in(linkTypes));
                 }
 
-                var rows = ctx.select(F_LNK_ID, F_LNK_FROM, F_LNK_TO, F_LNK_TYPE,
-                                       F_LNK_FSPAN, F_LNK_TSPAN, F_LNK_CRTBY, F_LNK_CRTAT, F_LNK_META)
-                              .from(T_LINKS).where(dirCond).fetch();
+                var rows = ctx.select(CATALOG_LINKS.ID, CATALOG_LINKS.FROM_TUMBLER, CATALOG_LINKS.TO_TUMBLER, CATALOG_LINKS.LINK_TYPE,
+                                       CATALOG_LINKS.FROM_SPAN, CATALOG_LINKS.TO_SPAN, CATALOG_LINKS.CREATED_BY, CATALOG_LINKS.CREATED_AT, F_LNK_META)
+                              .from(CATALOG_LINKS).where(dirCond).fetch();
                 for (var r : rows) {
                     Map<String, Object> lm = linkRow(r.value1(), r.value2(), r.value3(), r.value4(),
                                                       r.value5(), r.value6(), r.value7(), r.value8(), r.value9());
@@ -1064,8 +1001,8 @@ public final class CatalogRepository {
 
             List<Map<String, Object>> nodes = new ArrayList<>();
             if (!visited.isEmpty()) {
-                nodes = ctx.select(documentFields()).from(T_DOCS)
-                           .where(F_DOC_TUMBLER.in(new ArrayList<>(visited)))
+                nodes = ctx.select(documentFields()).from(CATALOG_DOCUMENTS)
+                           .where(CATALOG_DOCUMENTS.TUMBLER.in(new ArrayList<>(visited)))
                            .fetch().map(r -> docRowFromRecord(r.intoMap()));
             }
             return Map.of("nodes", nodes, "edges", edges);
@@ -1079,11 +1016,11 @@ public final class CatalogRepository {
     /** Replace manifest for docId with the provided rows (atomic delete + insert). */
     public void writeManifest(String tenant, String docId, List<Map<String, Object>> rows) {
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.deleteFrom(T_CHUNKS).where(F_CHK_DOC.eq(docId)).execute();
+            ctx.deleteFrom(CATALOG_DOCUMENT_CHUNKS).where(CATALOG_DOCUMENT_CHUNKS.DOC_ID.eq(docId)).execute();
             for (var row : rows) {
-                ctx.insertInto(T_CHUNKS,
-                        F_CHK_TENANT, F_CHK_DOC, F_CHK_POS, F_CHK_CHASH, F_CHK_IDX,
-                        F_CHK_LST, F_CHK_LEN, F_CHK_CST, F_CHK_CEN)
+                ctx.insertInto(CATALOG_DOCUMENT_CHUNKS,
+                        CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION, CATALOG_DOCUMENT_CHUNKS.CHASH, CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,
+                        CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END)
                    .values(tenant, docId, i(row,"position"), s(row,"chash"), i(row,"chunk_index"),
                            i(row,"line_start"), i(row,"line_end"), i(row,"char_start"), i(row,"char_end"))
                    .execute();
@@ -1096,14 +1033,14 @@ public final class CatalogRepository {
     public void appendManifestChunks(String tenant, String docId, List<Map<String, Object>> rows) {
         tenantScope.withTenant(tenant, ctx -> {
             for (var row : rows) {
-                ctx.insertInto(T_CHUNKS,
-                        F_CHK_TENANT, F_CHK_DOC, F_CHK_POS, F_CHK_CHASH, F_CHK_IDX,
-                        F_CHK_LST, F_CHK_LEN, F_CHK_CST, F_CHK_CEN)
+                ctx.insertInto(CATALOG_DOCUMENT_CHUNKS,
+                        CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION, CATALOG_DOCUMENT_CHUNKS.CHASH, CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,
+                        CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END)
                    .values(tenant, docId, i(row,"position"), s(row,"chash"), i(row,"chunk_index"),
                            i(row,"line_start"), i(row,"line_end"), i(row,"char_start"), i(row,"char_end"))
-                   .onConflict(F_CHK_TENANT, F_CHK_DOC, F_CHK_POS)
+                   .onConflict(CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION)
                    .doUpdate()
-                   .set(F_CHK_CHASH, EX_CHK_CHASH)
+                   .set(CATALOG_DOCUMENT_CHUNKS.CHASH, EX_CHK_CHASH)
                    .execute();
             }
             return null;
@@ -1113,9 +1050,9 @@ public final class CatalogRepository {
     /** Get manifest rows for docId, ordered by position. */
     public List<Map<String, Object>> getManifest(String tenant, String docId) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(F_CHK_DOC, F_CHK_POS, F_CHK_CHASH, F_CHK_IDX,
-                       F_CHK_LST, F_CHK_LEN, F_CHK_CST, F_CHK_CEN)
-               .from(T_CHUNKS).where(F_CHK_DOC.eq(docId)).orderBy(F_CHK_POS)
+            ctx.select(CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION, CATALOG_DOCUMENT_CHUNKS.CHASH, CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,
+                       CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END)
+               .from(CATALOG_DOCUMENT_CHUNKS).where(CATALOG_DOCUMENT_CHUNKS.DOC_ID.eq(docId)).orderBy(CATALOG_DOCUMENT_CHUNKS.POSITION)
                .fetch().map(r -> {
                    Map<String, Object> m = new LinkedHashMap<>();
                    m.put("doc_id",      r.value1());
@@ -1134,18 +1071,18 @@ public final class CatalogRepository {
     /** Purge all manifest rows for a document. */
     public int purgeManifest(String tenant, String docId) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.deleteFrom(T_CHUNKS).where(F_CHK_DOC.eq(docId)).execute()
+            ctx.deleteFrom(CATALOG_DOCUMENT_CHUNKS).where(CATALOG_DOCUMENT_CHUNKS.DOC_ID.eq(docId)).execute()
         );
     }
 
     /** Get chashes for a physical_collection via manifest join. */
     public Set<String> chashesForCollection(String tenant, String collection) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.selectDistinct(F_CHK_CHASH)
-                          .from(T_CHUNKS)
-                          .join(T_DOCS).on(F_CHK_TENANT.eq(F_DOC_TENANT)
-                                           .and(F_CHK_DOC.eq(F_DOC_TUMBLER)))
-                          .where(F_DOC_PCOLL.eq(collection))
+            var rows = ctx.selectDistinct(CATALOG_DOCUMENT_CHUNKS.CHASH)
+                          .from(CATALOG_DOCUMENT_CHUNKS)
+                          .join(CATALOG_DOCUMENTS).on(CATALOG_DOCUMENT_CHUNKS.TENANT_ID.eq(CATALOG_DOCUMENTS.TENANT_ID)
+                                           .and(CATALOG_DOCUMENT_CHUNKS.DOC_ID.eq(CATALOG_DOCUMENTS.TUMBLER)))
+                          .where(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION.eq(collection))
                           .fetch();
             Set<String> result = new LinkedHashSet<>();
             for (var r : rows) result.add(r.value1());
@@ -1157,8 +1094,8 @@ public final class CatalogRepository {
     public List<String> docsForChashes(String tenant, List<String> chashes) {
         if (chashes.isEmpty()) return List.of();
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.selectDistinct(F_CHK_DOC).from(T_CHUNKS)
-               .where(F_CHK_CHASH.in(chashes)).fetch().map(r -> r.value1())
+            ctx.selectDistinct(CATALOG_DOCUMENT_CHUNKS.DOC_ID).from(CATALOG_DOCUMENT_CHUNKS)
+               .where(CATALOG_DOCUMENT_CHUNKS.CHASH.in(chashes)).fetch().map(r -> r.value1())
         );
     }
 
@@ -1175,11 +1112,11 @@ public final class CatalogRepository {
     public Map<String, List<Map<String, Object>>> getManifestMany(String tenant, List<String> docIds) {
         if (docIds == null || docIds.isEmpty()) return Map.of();
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.select(F_CHK_DOC, F_CHK_POS, F_CHK_CHASH, F_CHK_IDX,
-                                  F_CHK_LST, F_CHK_LEN, F_CHK_CST, F_CHK_CEN)
-                          .from(T_CHUNKS)
-                          .where(F_CHK_DOC.in(docIds))
-                          .orderBy(F_CHK_DOC, F_CHK_POS)
+            var rows = ctx.select(CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION, CATALOG_DOCUMENT_CHUNKS.CHASH, CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,
+                                  CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END)
+                          .from(CATALOG_DOCUMENT_CHUNKS)
+                          .where(CATALOG_DOCUMENT_CHUNKS.DOC_ID.in(docIds))
+                          .orderBy(CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION)
                           .fetch();
             Map<String, List<Map<String, Object>>> result = new LinkedHashMap<>();
             for (var r : rows) {
@@ -1213,8 +1150,8 @@ public final class CatalogRepository {
         if (docIds == null || docIds.isEmpty()) return Map.of();
         return tenantScope.withTenant(tenant, ctx -> {
             var rows = ctx.select(documentFields())
-                          .from(T_DOCS)
-                          .where(F_DOC_TUMBLER.in(docIds).and(F_DOC_DELETED_AT.isNull()))
+                          .from(CATALOG_DOCUMENTS)
+                          .where(CATALOG_DOCUMENTS.TUMBLER.in(docIds).and(CATALOG_DOCUMENTS.DELETED_AT.isNull()))
                           .fetch();
             Map<String, Map<String, Object>> result = new LinkedHashMap<>();
             for (var r : rows) {
@@ -1229,9 +1166,9 @@ public final class CatalogRepository {
     /** Resync chunk_count on catalog_documents from manifest row count. */
     public int resyncChunkCount(String tenant, String docId) {
         return tenantScope.withTenant(tenant, ctx -> {
-            int count = ctx.selectCount().from(T_CHUNKS).where(F_CHK_DOC.eq(docId))
+            int count = ctx.selectCount().from(CATALOG_DOCUMENT_CHUNKS).where(CATALOG_DOCUMENT_CHUNKS.DOC_ID.eq(docId))
                            .fetchOne(0, Integer.class);
-            return ctx.update(T_DOCS).set(F_DOC_CHUNKS, count).where(F_DOC_TUMBLER.eq(docId)).execute();
+            return ctx.update(CATALOG_DOCUMENTS).set(CATALOG_DOCUMENTS.CHUNK_COUNT, count).where(CATALOG_DOCUMENTS.TUMBLER.eq(docId)).execute();
         });
     }
 
@@ -1330,9 +1267,9 @@ public final class CatalogRepository {
             // Lookup doc_id from catalog_document_chunks. ORDER BY doc_id for a
             // deterministic winner when a chash is referenced by multiple docs (dedup).
             String docId = "";
-            var docRow = ctx.select(F_CHK_DOC).from(T_CHUNKS)
-                            .where(F_CHK_CHASH.eq(chash))
-                            .orderBy(F_CHK_DOC.asc()).limit(1).fetchOne();
+            var docRow = ctx.select(CATALOG_DOCUMENT_CHUNKS.DOC_ID).from(CATALOG_DOCUMENT_CHUNKS)
+                            .where(CATALOG_DOCUMENT_CHUNKS.CHASH.eq(chash))
+                            .orderBy(CATALOG_DOCUMENT_CHUNKS.DOC_ID.asc()).limit(1).fetchOne();
             if (docRow != null) docId = docRow.value1();
 
             Map<String, Object> m = new LinkedHashMap<>();
@@ -1407,9 +1344,9 @@ public final class CatalogRepository {
     /** Get a collection by name. Returns null if not found. */
     public Map<String, Object> getCollection(String tenant, String name) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var r = ctx.select(F_COL_NAME, F_COL_CTYPE, F_COL_OWNER, F_COL_EMBD, F_COL_MVER,
-                               F_COL_DNAME, F_COL_LEGCY, F_COL_SUPBY, F_COL_SUPAT, F_COL_CRTAT)
-                       .from(T_COLLS).where(F_COL_NAME.eq(name)).fetchOne();
+            var r = ctx.select(CATALOG_COLLECTIONS.NAME, CATALOG_COLLECTIONS.CONTENT_TYPE, CATALOG_COLLECTIONS.OWNER_ID, CATALOG_COLLECTIONS.EMBEDDING_MODEL, CATALOG_COLLECTIONS.MODEL_VERSION,
+                               CATALOG_COLLECTIONS.DISPLAY_NAME, CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED, CATALOG_COLLECTIONS.SUPERSEDED_BY, F_COL_SUPAT, F_COL_CRTAT)
+                       .from(CATALOG_COLLECTIONS).where(CATALOG_COLLECTIONS.NAME.eq(name)).fetchOne();
             return r != null ? collRow(r.value1(), r.value2(), r.value3(), r.value4(), r.value5(),
                                         r.value6(), r.value7(), r.value8(), r.value9(), r.value10()) : null;
         });
@@ -1418,9 +1355,9 @@ public final class CatalogRepository {
     /** List all collections. */
     public List<Map<String, Object>> listCollections(String tenant) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(F_COL_NAME, F_COL_CTYPE, F_COL_OWNER, F_COL_EMBD, F_COL_MVER,
-                       F_COL_DNAME, F_COL_LEGCY, F_COL_SUPBY, F_COL_SUPAT, F_COL_CRTAT)
-               .from(T_COLLS).orderBy(F_COL_NAME).fetch()
+            ctx.select(CATALOG_COLLECTIONS.NAME, CATALOG_COLLECTIONS.CONTENT_TYPE, CATALOG_COLLECTIONS.OWNER_ID, CATALOG_COLLECTIONS.EMBEDDING_MODEL, CATALOG_COLLECTIONS.MODEL_VERSION,
+                       CATALOG_COLLECTIONS.DISPLAY_NAME, CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED, CATALOG_COLLECTIONS.SUPERSEDED_BY, F_COL_SUPAT, F_COL_CRTAT)
+               .from(CATALOG_COLLECTIONS).orderBy(CATALOG_COLLECTIONS.NAME).fetch()
                .map(r -> collRow(r.value1(), r.value2(), r.value3(), r.value4(), r.value5(),
                                   r.value6(), r.value7(), r.value8(), r.value9(), r.value10()))
         );
@@ -1520,15 +1457,15 @@ public final class CatalogRepository {
     public Map<String, Object> collectionForTuple(String tenant, String contentType,
                                                     String ownerId, String embeddingModel) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var r = ctx.select(F_COL_NAME, F_COL_CTYPE, F_COL_OWNER, F_COL_EMBD, F_COL_MVER,
-                               F_COL_DNAME, F_COL_LEGCY, F_COL_SUPBY, F_COL_SUPAT, F_COL_CRTAT)
-                       .from(T_COLLS)
-                       .where(F_COL_CTYPE.eq(contentType)
-                              .and(F_COL_OWNER.eq(ownerId))
-                              .and(F_COL_EMBD.eq(embeddingModel))
-                              .and(F_COL_LEGCY.eq(0))
-                              .and(F_COL_SUPBY.eq("")))
-                       .orderBy(F_COL_NAME.desc()).limit(1).fetchOne();
+            var r = ctx.select(CATALOG_COLLECTIONS.NAME, CATALOG_COLLECTIONS.CONTENT_TYPE, CATALOG_COLLECTIONS.OWNER_ID, CATALOG_COLLECTIONS.EMBEDDING_MODEL, CATALOG_COLLECTIONS.MODEL_VERSION,
+                               CATALOG_COLLECTIONS.DISPLAY_NAME, CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED, CATALOG_COLLECTIONS.SUPERSEDED_BY, F_COL_SUPAT, F_COL_CRTAT)
+                       .from(CATALOG_COLLECTIONS)
+                       .where(CATALOG_COLLECTIONS.CONTENT_TYPE.eq(contentType)
+                              .and(CATALOG_COLLECTIONS.OWNER_ID.eq(ownerId))
+                              .and(CATALOG_COLLECTIONS.EMBEDDING_MODEL.eq(embeddingModel))
+                              .and(CATALOG_COLLECTIONS.LEGACY_GRANDFATHERED.eq(0))
+                              .and(CATALOG_COLLECTIONS.SUPERSEDED_BY.eq("")))
+                       .orderBy(CATALOG_COLLECTIONS.NAME.desc()).limit(1).fetchOne();
             return r != null ? collRow(r.value1(), r.value2(), r.value3(), r.value4(), r.value5(),
                                         r.value6(), r.value7(), r.value8(), r.value9(), r.value10()) : null;
         });
@@ -1650,11 +1587,11 @@ public final class CatalogRepository {
 
     public void setMeta(String tenant, String key, String value) {
         tenantScope.withTenant(tenant, ctx -> {
-            ctx.insertInto(T_META, F_META_TENANT, F_META_KEY, F_META_VAL)
+            ctx.insertInto(CATALOG_META, CATALOG_META.TENANT_ID, CATALOG_META.KEY, CATALOG_META.VALUE)
                .values(tenant, key, value)
-               .onConflict(F_META_TENANT, F_META_KEY)
+               .onConflict(CATALOG_META.TENANT_ID, CATALOG_META.KEY)
                .doUpdate()
-               .set(F_META_VAL, EX_META_VAL)
+               .set(CATALOG_META.VALUE, EX_META_VAL)
                .execute();
             return null;
         });
@@ -1662,7 +1599,7 @@ public final class CatalogRepository {
 
     public String getMeta(String tenant, String key) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var r = ctx.select(F_META_VAL).from(T_META).where(F_META_KEY.eq(key)).fetchOne();
+            var r = ctx.select(CATALOG_META.VALUE).from(CATALOG_META).where(CATALOG_META.KEY.eq(key)).fetchOne();
             return r != null ? r.value1() : null;
         });
     }
@@ -1670,10 +1607,10 @@ public final class CatalogRepository {
     /** Return owners filtered by owner_type. Used by repos.py:list_repos_dual (nexus-qnp5s). */
     public List<Map<String, Object>> ownersByType(String tenant, String ownerType) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(F_OWN_PREFIX, F_OWN_NAME, F_OWN_TYPE, F_OWN_REPO,
-                       F_OWN_DESC, F_OWN_ROOT, F_OWN_HEAD)
-               .from(T_OWNERS)
-               .where(F_OWN_TYPE.eq(ownerType))
+            ctx.select(CATALOG_OWNERS.TUMBLER_PREFIX, CATALOG_OWNERS.NAME, CATALOG_OWNERS.OWNER_TYPE, CATALOG_OWNERS.REPO_HASH,
+                       CATALOG_OWNERS.DESCRIPTION, CATALOG_OWNERS.REPO_ROOT, CATALOG_OWNERS.HEAD_HASH)
+               .from(CATALOG_OWNERS)
+               .where(CATALOG_OWNERS.OWNER_TYPE.eq(ownerType))
                .fetch()
                .map(r -> ownerRow(r.value1(), r.value2(), r.value3(), r.value4(), r.value5(), r.value6(), r.value7()))
         );
@@ -1682,10 +1619,10 @@ public final class CatalogRepository {
     /** Return a single owner by tumbler_prefix. Returns null if not found. */
     public Map<String, Object> ownerByPrefix(String tenant, String tumblerPrefix) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var r = ctx.select(F_OWN_PREFIX, F_OWN_NAME, F_OWN_TYPE, F_OWN_REPO,
-                               F_OWN_DESC, F_OWN_ROOT, F_OWN_HEAD)
-                       .from(T_OWNERS)
-                       .where(F_OWN_PREFIX.eq(tumblerPrefix))
+            var r = ctx.select(CATALOG_OWNERS.TUMBLER_PREFIX, CATALOG_OWNERS.NAME, CATALOG_OWNERS.OWNER_TYPE, CATALOG_OWNERS.REPO_HASH,
+                               CATALOG_OWNERS.DESCRIPTION, CATALOG_OWNERS.REPO_ROOT, CATALOG_OWNERS.HEAD_HASH)
+                       .from(CATALOG_OWNERS)
+                       .where(CATALOG_OWNERS.TUMBLER_PREFIX.eq(tumblerPrefix))
                        .fetchOne();
             return r != null
                 ? ownerRow(r.value1(), r.value2(), r.value3(), r.value4(), r.value5(), r.value6(), r.value7())
@@ -1701,9 +1638,9 @@ public final class CatalogRepository {
     public Map<String, Integer> chunkCountsForDocs(String tenant, List<String> docIds) {
         if (docIds == null || docIds.isEmpty()) return Map.of();
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.select(F_DOC_TUMBLER, F_DOC_CHUNKS)
-                          .from(T_DOCS)
-                          .where(F_DOC_TUMBLER.in(docIds))
+            var rows = ctx.select(CATALOG_DOCUMENTS.TUMBLER, CATALOG_DOCUMENTS.CHUNK_COUNT)
+                          .from(CATALOG_DOCUMENTS)
+                          .where(CATALOG_DOCUMENTS.TUMBLER.in(docIds))
                           .fetch();
             Map<String, Integer> result = new LinkedHashMap<>();
             for (var r : rows) {
@@ -1721,9 +1658,9 @@ public final class CatalogRepository {
     public Map<String, List<Map<String, Object>>> linksFromBatch(String tenant, List<String> tumblers) {
         if (tumblers == null || tumblers.isEmpty()) return Map.of();
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.select(F_LNK_FROM, F_LNK_TYPE)
-                          .from(T_LINKS)
-                          .where(F_LNK_FROM.in(tumblers))
+            var rows = ctx.select(CATALOG_LINKS.FROM_TUMBLER, CATALOG_LINKS.LINK_TYPE)
+                          .from(CATALOG_LINKS)
+                          .where(CATALOG_LINKS.FROM_TUMBLER.in(tumblers))
                           .fetch();
             Map<String, List<Map<String, Object>>> result = new LinkedHashMap<>();
             for (var r : rows) {
@@ -1828,11 +1765,11 @@ public final class CatalogRepository {
      */
     public List<String> distinctDocCollections(String tenant) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.selectDistinct(F_DOC_PCOLL)
-               .from(T_DOCS)
-               .where(F_DOC_PCOLL.ne(""))
-               .orderBy(F_DOC_PCOLL)
-               .fetch(F_DOC_PCOLL)
+            ctx.selectDistinct(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION)
+               .from(CATALOG_DOCUMENTS)
+               .where(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION.ne(""))
+               .orderBy(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION)
+               .fetch(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION)
         );
     }
 
@@ -1846,10 +1783,10 @@ public final class CatalogRepository {
      */
     public List<Map<String, Object>> ownersWithRoots(String tenant) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(F_OWN_PREFIX, F_OWN_NAME, F_OWN_TYPE, F_OWN_REPO,
-                       F_OWN_DESC, F_OWN_ROOT, F_OWN_HEAD)
-               .from(T_OWNERS)
-               .where(F_OWN_ROOT.ne(""))
+            ctx.select(CATALOG_OWNERS.TUMBLER_PREFIX, CATALOG_OWNERS.NAME, CATALOG_OWNERS.OWNER_TYPE, CATALOG_OWNERS.REPO_HASH,
+                       CATALOG_OWNERS.DESCRIPTION, CATALOG_OWNERS.REPO_ROOT, CATALOG_OWNERS.HEAD_HASH)
+               .from(CATALOG_OWNERS)
+               .where(CATALOG_OWNERS.REPO_ROOT.ne(""))
                .fetch()
                .map(r -> ownerRow(r.value1(), r.value2(), r.value3(), r.value4(),
                                   r.value5(), r.value6(), r.value7()))
@@ -1869,15 +1806,15 @@ public final class CatalogRepository {
             // AND no incoming links (to_tumbler not in links).
             // Use NOT EXISTS subqueries for cross-tenant RLS safety.
             var noOut = DSL.notExists(
-                ctx.selectOne().from(T_LINKS).where(F_LNK_FROM.eq(F_DOC_TUMBLER))
+                ctx.selectOne().from(CATALOG_LINKS).where(CATALOG_LINKS.FROM_TUMBLER.eq(CATALOG_DOCUMENTS.TUMBLER))
             );
             var noIn = DSL.notExists(
-                ctx.selectOne().from(T_LINKS).where(F_LNK_TO.eq(F_DOC_TUMBLER))
+                ctx.selectOne().from(CATALOG_LINKS).where(CATALOG_LINKS.TO_TUMBLER.eq(CATALOG_DOCUMENTS.TUMBLER))
             );
-            return ctx.select(F_DOC_TUMBLER, F_DOC_TITLE, F_DOC_CTYPE, F_DOC_FPATH)
-                      .from(T_DOCS)
+            return ctx.select(CATALOG_DOCUMENTS.TUMBLER, CATALOG_DOCUMENTS.TITLE, CATALOG_DOCUMENTS.CONTENT_TYPE, CATALOG_DOCUMENTS.FILE_PATH)
+                      .from(CATALOG_DOCUMENTS)
                       .where(noOut.and(noIn))
-                      .orderBy(F_DOC_TUMBLER)
+                      .orderBy(CATALOG_DOCUMENTS.TUMBLER)
                       .fetch()
                       .map(r -> {
                           Map<String, Object> m = new LinkedHashMap<>();
@@ -1899,10 +1836,10 @@ public final class CatalogRepository {
      */
     public List<Map<String, Object>> docsWithAbsolutePaths(String tenant) {
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.select(F_DOC_TUMBLER, F_DOC_FPATH, F_DOC_PCOLL)
-               .from(T_DOCS)
-               .where(F_DOC_FPATH.startsWith("/"))
-               .orderBy(F_DOC_TUMBLER)
+            ctx.select(CATALOG_DOCUMENTS.TUMBLER, CATALOG_DOCUMENTS.FILE_PATH, CATALOG_DOCUMENTS.PHYSICAL_COLLECTION)
+               .from(CATALOG_DOCUMENTS)
+               .where(CATALOG_DOCUMENTS.FILE_PATH.startsWith("/"))
+               .orderBy(CATALOG_DOCUMENTS.TUMBLER)
                .fetch()
                .map(r -> {
                    Map<String, Object> m = new LinkedHashMap<>();
@@ -1925,11 +1862,11 @@ public final class CatalogRepository {
      */
     public Map<String, Object> collectionOwnerRoot(String tenant, String name) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var r = ctx.select(F_COL_OWNER, F_OWN_ROOT)
-                       .from(T_COLLS)
-                       .leftJoin(T_OWNERS)
-                       .on(F_COL_OWNER.eq(F_OWN_PREFIX))
-                       .where(F_COL_NAME.eq(name))
+            var r = ctx.select(CATALOG_COLLECTIONS.OWNER_ID, CATALOG_OWNERS.REPO_ROOT)
+                       .from(CATALOG_COLLECTIONS)
+                       .leftJoin(CATALOG_OWNERS)
+                       .on(CATALOG_COLLECTIONS.OWNER_ID.eq(CATALOG_OWNERS.TUMBLER_PREFIX))
+                       .where(CATALOG_COLLECTIONS.NAME.eq(name))
                        .fetchOne();
             if (r == null) return null;
             Map<String, Object> m = new LinkedHashMap<>();
@@ -2065,24 +2002,24 @@ public final class CatalogRepository {
             final int chunkSize = Math.max(1, MAX_BATCH_PARAMS / 9);
             for (int start = 0; start < deduped.size(); start += chunkSize) {
                 var batch = deduped.subList(start, Math.min(start + chunkSize, deduped.size()));
-                var insert = ctx.insertInto(T_OWNERS,
-                        F_OWN_TENANT, F_OWN_PREFIX, F_OWN_NAME, F_OWN_TYPE,
-                        F_OWN_REPO, F_OWN_DESC, F_OWN_ROOT, F_OWN_HEAD, F_OWN_SEQ);
+                var insert = ctx.insertInto(CATALOG_OWNERS,
+                        CATALOG_OWNERS.TENANT_ID, CATALOG_OWNERS.TUMBLER_PREFIX, CATALOG_OWNERS.NAME, CATALOG_OWNERS.OWNER_TYPE,
+                        CATALOG_OWNERS.REPO_HASH, CATALOG_OWNERS.DESCRIPTION, CATALOG_OWNERS.REPO_ROOT, CATALOG_OWNERS.HEAD_HASH, CATALOG_OWNERS.NEXT_SEQ);
                 for (var o : batch) {
                     insert = insert.values(tenant,
                             s(o,"tumbler_prefix"), s(o,"name"), s(o,"owner_type"),
                             s(o,"repo_hash"), s(o,"description"), nne(s(o,"repo_root")),
                             s(o,"head_hash"), lng(o,"next_seq", 0L));
                 }
-                insert.onConflict(F_OWN_TENANT, F_OWN_PREFIX)
+                insert.onConflict(CATALOG_OWNERS.TENANT_ID, CATALOG_OWNERS.TUMBLER_PREFIX)
                       .doUpdate()
-                      .set(F_OWN_NAME, EX_OWN_NAME)
-                      .set(F_OWN_TYPE, EX_OWN_TYPE)
-                      .set(F_OWN_REPO, EX_OWN_REPO)
-                      .set(F_OWN_DESC, EX_OWN_DESC)
-                      .set(F_OWN_ROOT, EX_OWN_ROOT)
-                      .set(F_OWN_HEAD, EX_OWN_HEAD)
-                      .set(F_OWN_SEQ,  EX_OWN_SEQ_GREATEST)
+                      .set(CATALOG_OWNERS.NAME, EX_OWN_NAME)
+                      .set(CATALOG_OWNERS.OWNER_TYPE, EX_OWN_TYPE)
+                      .set(CATALOG_OWNERS.REPO_HASH, EX_OWN_REPO)
+                      .set(CATALOG_OWNERS.DESCRIPTION, EX_OWN_DESC)
+                      .set(CATALOG_OWNERS.REPO_ROOT, EX_OWN_ROOT)
+                      .set(CATALOG_OWNERS.HEAD_HASH, EX_OWN_HEAD)
+                      .set(CATALOG_OWNERS.NEXT_SEQ,  EX_OWN_SEQ_GREATEST)
                       .execute();
             }
             return rows.size();
@@ -2093,22 +2030,22 @@ public final class CatalogRepository {
     private static final int MAX_BATCH_PARAMS = 30_000;
 
     private void doImportOwner(DSLContext ctx, String tenant, Map<String, Object> o) {
-        ctx.insertInto(T_OWNERS,
-                F_OWN_TENANT, F_OWN_PREFIX, F_OWN_NAME, F_OWN_TYPE,
-                F_OWN_REPO, F_OWN_DESC, F_OWN_ROOT, F_OWN_HEAD, F_OWN_SEQ)
+        ctx.insertInto(CATALOG_OWNERS,
+                CATALOG_OWNERS.TENANT_ID, CATALOG_OWNERS.TUMBLER_PREFIX, CATALOG_OWNERS.NAME, CATALOG_OWNERS.OWNER_TYPE,
+                CATALOG_OWNERS.REPO_HASH, CATALOG_OWNERS.DESCRIPTION, CATALOG_OWNERS.REPO_ROOT, CATALOG_OWNERS.HEAD_HASH, CATALOG_OWNERS.NEXT_SEQ)
            .values(tenant,
                    s(o,"tumbler_prefix"), s(o,"name"), s(o,"owner_type"),
                    s(o,"repo_hash"), s(o,"description"), nne(s(o,"repo_root")),
                    s(o,"head_hash"), lng(o,"next_seq", 0L))
-           .onConflict(F_OWN_TENANT, F_OWN_PREFIX)
+           .onConflict(CATALOG_OWNERS.TENANT_ID, CATALOG_OWNERS.TUMBLER_PREFIX)
            .doUpdate()
-           .set(F_OWN_NAME, EX_OWN_NAME)
-           .set(F_OWN_TYPE, EX_OWN_TYPE)
-           .set(F_OWN_REPO, EX_OWN_REPO)
-           .set(F_OWN_DESC, EX_OWN_DESC)
-           .set(F_OWN_ROOT, EX_OWN_ROOT)
-           .set(F_OWN_HEAD, EX_OWN_HEAD)
-           .set(F_OWN_SEQ,  EX_OWN_SEQ_GREATEST)
+           .set(CATALOG_OWNERS.NAME, EX_OWN_NAME)
+           .set(CATALOG_OWNERS.OWNER_TYPE, EX_OWN_TYPE)
+           .set(CATALOG_OWNERS.REPO_HASH, EX_OWN_REPO)
+           .set(CATALOG_OWNERS.DESCRIPTION, EX_OWN_DESC)
+           .set(CATALOG_OWNERS.REPO_ROOT, EX_OWN_ROOT)
+           .set(CATALOG_OWNERS.HEAD_HASH, EX_OWN_HEAD)
+           .set(CATALOG_OWNERS.NEXT_SEQ,  EX_OWN_SEQ_GREATEST)
            .execute();
     }
 
@@ -2137,12 +2074,12 @@ public final class CatalogRepository {
             final int chunkSize = Math.max(1, MAX_BATCH_PARAMS / cols);
             for (int start = 0; start < deduped.size(); start += chunkSize) {
                 var batch = deduped.subList(start, Math.min(start + chunkSize, deduped.size()));
-                var insert = ctx.insertInto(T_DOCS,
-                        F_DOC_TENANT, F_DOC_TUMBLER, F_DOC_TITLE, F_DOC_AUTHOR, F_DOC_YEAR,
-                        F_DOC_CTYPE, F_DOC_FPATH, F_DOC_CORPUS, F_DOC_PCOLL, F_DOC_CHUNKS,
-                        F_DOC_HEAD, F_DOC_IDXAT, F_DOC_META, F_DOC_SMTIME, F_DOC_ALIAS, F_DOC_URI,
-                        F_DOC_BIBY, F_DOC_BIAU, F_DOC_BIVE, F_DOC_BICC,
-                        F_DOC_BIS2, F_DOC_BIOA, F_DOC_BIDOI, F_DOC_BIAT);
+                var insert = ctx.insertInto(CATALOG_DOCUMENTS,
+                        CATALOG_DOCUMENTS.TENANT_ID, CATALOG_DOCUMENTS.TUMBLER, CATALOG_DOCUMENTS.TITLE, CATALOG_DOCUMENTS.AUTHOR, CATALOG_DOCUMENTS.YEAR,
+                        CATALOG_DOCUMENTS.CONTENT_TYPE, CATALOG_DOCUMENTS.FILE_PATH, CATALOG_DOCUMENTS.CORPUS, CATALOG_DOCUMENTS.PHYSICAL_COLLECTION, CATALOG_DOCUMENTS.CHUNK_COUNT,
+                        CATALOG_DOCUMENTS.HEAD_HASH, CATALOG_DOCUMENTS.INDEXED_AT, F_DOC_META, CATALOG_DOCUMENTS.SOURCE_MTIME, CATALOG_DOCUMENTS.ALIAS_OF, CATALOG_DOCUMENTS.SOURCE_URI,
+                        CATALOG_DOCUMENTS.BIB_YEAR, CATALOG_DOCUMENTS.BIB_AUTHORS, CATALOG_DOCUMENTS.BIB_VENUE, CATALOG_DOCUMENTS.BIB_CITATION_COUNT,
+                        CATALOG_DOCUMENTS.BIB_SEMANTIC_SCHOLAR_ID, CATALOG_DOCUMENTS.BIB_OPENALEX_ID, CATALOG_DOCUMENTS.BIB_DOI, CATALOG_DOCUMENTS.BIB_ENRICHED_AT);
                 for (var d : batch) {
                     String metaJson = jsonOrNull(d.get("metadata"));
                     insert = insert.values(tenant, s(d,"tumbler"), s(d,"title"), s(d,"author"), i(d,"year"),
@@ -2156,31 +2093,31 @@ public final class CatalogRepository {
                             nne(s(d,"bib_semantic_scholar_id")), nne(s(d,"bib_openalex_id")),
                             nne(s(d,"bib_doi")), nne(s(d,"bib_enriched_at")));
                 }
-                insert.onConflict(F_DOC_TENANT, F_DOC_TUMBLER)
+                insert.onConflict(CATALOG_DOCUMENTS.TENANT_ID, CATALOG_DOCUMENTS.TUMBLER)
                       .doUpdate()
-                      .set(F_DOC_TITLE,  EX_DOC_TITLE)
-                      .set(F_DOC_AUTHOR, EX_DOC_AUTHOR)
-                      .set(F_DOC_YEAR,   EX_DOC_YEAR)
-                      .set(F_DOC_CTYPE,  EX_DOC_CTYPE)
-                      .set(F_DOC_FPATH,  EX_DOC_FPATH)
-                      .set(F_DOC_CORPUS, EX_DOC_CORPUS)
-                      .set(F_DOC_PCOLL,  EX_DOC_PCOLL)
-                      .set(F_DOC_CHUNKS, EX_DOC_CHUNKS)
-                      .set(F_DOC_HEAD,   EX_DOC_HEAD)
-                      .set(F_DOC_IDXAT,  EX_DOC_IDXAT)
+                      .set(CATALOG_DOCUMENTS.TITLE,  EX_DOC_TITLE)
+                      .set(CATALOG_DOCUMENTS.AUTHOR, EX_DOC_AUTHOR)
+                      .set(CATALOG_DOCUMENTS.YEAR,   EX_DOC_YEAR)
+                      .set(CATALOG_DOCUMENTS.CONTENT_TYPE,  EX_DOC_CTYPE)
+                      .set(CATALOG_DOCUMENTS.FILE_PATH,  EX_DOC_FPATH)
+                      .set(CATALOG_DOCUMENTS.CORPUS, EX_DOC_CORPUS)
+                      .set(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION,  EX_DOC_PCOLL)
+                      .set(CATALOG_DOCUMENTS.CHUNK_COUNT, EX_DOC_CHUNKS)
+                      .set(CATALOG_DOCUMENTS.HEAD_HASH,   EX_DOC_HEAD)
+                      .set(CATALOG_DOCUMENTS.INDEXED_AT,  EX_DOC_IDXAT)
                       .set(F_DOC_META,   EX_DOC_META)
                       // GREATEST: never downgrade source_mtime on re-import
-                      .set(F_DOC_SMTIME, EX_DOC_SMTIME_GREATEST)
-                      .set(F_DOC_ALIAS,  EX_DOC_ALIAS)
-                      .set(F_DOC_URI,    EX_DOC_URI)
-                      .set(F_DOC_BIBY,   EX_DOC_BIBY)
-                      .set(F_DOC_BIAU,   EX_DOC_BIAU)
-                      .set(F_DOC_BIVE,   EX_DOC_BIVE)
-                      .set(F_DOC_BICC,   EX_DOC_BICC)
-                      .set(F_DOC_BIS2,   EX_DOC_BIS2)
-                      .set(F_DOC_BIOA,   EX_DOC_BIOA)
-                      .set(F_DOC_BIDOI,  EX_DOC_BIDOI)
-                      .set(F_DOC_BIAT,   EX_DOC_BIAT)
+                      .set(CATALOG_DOCUMENTS.SOURCE_MTIME, EX_DOC_SMTIME_GREATEST)
+                      .set(CATALOG_DOCUMENTS.ALIAS_OF,  EX_DOC_ALIAS)
+                      .set(CATALOG_DOCUMENTS.SOURCE_URI,    EX_DOC_URI)
+                      .set(CATALOG_DOCUMENTS.BIB_YEAR,   EX_DOC_BIBY)
+                      .set(CATALOG_DOCUMENTS.BIB_AUTHORS,   EX_DOC_BIAU)
+                      .set(CATALOG_DOCUMENTS.BIB_VENUE,   EX_DOC_BIVE)
+                      .set(CATALOG_DOCUMENTS.BIB_CITATION_COUNT,   EX_DOC_BICC)
+                      .set(CATALOG_DOCUMENTS.BIB_SEMANTIC_SCHOLAR_ID,   EX_DOC_BIS2)
+                      .set(CATALOG_DOCUMENTS.BIB_OPENALEX_ID,   EX_DOC_BIOA)
+                      .set(CATALOG_DOCUMENTS.BIB_DOI,  EX_DOC_BIDOI)
+                      .set(CATALOG_DOCUMENTS.BIB_ENRICHED_AT,   EX_DOC_BIAT)
                       .execute();
             }
             return rows.size();
@@ -2190,12 +2127,12 @@ public final class CatalogRepository {
     private void doImportDocument(DSLContext ctx, String tenant, Map<String, Object> d) {
         String metaJson = jsonOrNull(d.get("metadata"));
         {
-            ctx.insertInto(T_DOCS,
-                    F_DOC_TENANT, F_DOC_TUMBLER, F_DOC_TITLE, F_DOC_AUTHOR, F_DOC_YEAR,
-                    F_DOC_CTYPE, F_DOC_FPATH, F_DOC_CORPUS, F_DOC_PCOLL, F_DOC_CHUNKS,
-                    F_DOC_HEAD, F_DOC_IDXAT, F_DOC_META, F_DOC_SMTIME, F_DOC_ALIAS, F_DOC_URI,
-                    F_DOC_BIBY, F_DOC_BIAU, F_DOC_BIVE, F_DOC_BICC,
-                    F_DOC_BIS2, F_DOC_BIOA, F_DOC_BIDOI, F_DOC_BIAT)
+            ctx.insertInto(CATALOG_DOCUMENTS,
+                    CATALOG_DOCUMENTS.TENANT_ID, CATALOG_DOCUMENTS.TUMBLER, CATALOG_DOCUMENTS.TITLE, CATALOG_DOCUMENTS.AUTHOR, CATALOG_DOCUMENTS.YEAR,
+                    CATALOG_DOCUMENTS.CONTENT_TYPE, CATALOG_DOCUMENTS.FILE_PATH, CATALOG_DOCUMENTS.CORPUS, CATALOG_DOCUMENTS.PHYSICAL_COLLECTION, CATALOG_DOCUMENTS.CHUNK_COUNT,
+                    CATALOG_DOCUMENTS.HEAD_HASH, CATALOG_DOCUMENTS.INDEXED_AT, F_DOC_META, CATALOG_DOCUMENTS.SOURCE_MTIME, CATALOG_DOCUMENTS.ALIAS_OF, CATALOG_DOCUMENTS.SOURCE_URI,
+                    CATALOG_DOCUMENTS.BIB_YEAR, CATALOG_DOCUMENTS.BIB_AUTHORS, CATALOG_DOCUMENTS.BIB_VENUE, CATALOG_DOCUMENTS.BIB_CITATION_COUNT,
+                    CATALOG_DOCUMENTS.BIB_SEMANTIC_SCHOLAR_ID, CATALOG_DOCUMENTS.BIB_OPENALEX_ID, CATALOG_DOCUMENTS.BIB_DOI, CATALOG_DOCUMENTS.BIB_ENRICHED_AT)
                .values(tenant, s(d,"tumbler"), s(d,"title"), s(d,"author"), i(d,"year"),
                        nne(s(d,"content_type")), nne(s(d,"file_path")), nne(s(d,"corpus")),
                        nne(s(d,"physical_collection")), ni(i(d,"chunk_count"), 0),
@@ -2206,31 +2143,31 @@ public final class CatalogRepository {
                        nne(s(d,"bib_venue")), ni(i(d,"bib_citation_count"), 0),
                        nne(s(d,"bib_semantic_scholar_id")), nne(s(d,"bib_openalex_id")),
                        nne(s(d,"bib_doi")), nne(s(d,"bib_enriched_at")))
-               .onConflict(F_DOC_TENANT, F_DOC_TUMBLER)
+               .onConflict(CATALOG_DOCUMENTS.TENANT_ID, CATALOG_DOCUMENTS.TUMBLER)
                .doUpdate()
-               .set(F_DOC_TITLE,  EX_DOC_TITLE)
-               .set(F_DOC_AUTHOR, EX_DOC_AUTHOR)
-               .set(F_DOC_YEAR,   EX_DOC_YEAR)
-               .set(F_DOC_CTYPE,  EX_DOC_CTYPE)
-               .set(F_DOC_FPATH,  EX_DOC_FPATH)
-               .set(F_DOC_CORPUS, EX_DOC_CORPUS)
-               .set(F_DOC_PCOLL,  EX_DOC_PCOLL)
-               .set(F_DOC_CHUNKS, EX_DOC_CHUNKS)
-               .set(F_DOC_HEAD,   EX_DOC_HEAD)
-               .set(F_DOC_IDXAT,  EX_DOC_IDXAT)
+               .set(CATALOG_DOCUMENTS.TITLE,  EX_DOC_TITLE)
+               .set(CATALOG_DOCUMENTS.AUTHOR, EX_DOC_AUTHOR)
+               .set(CATALOG_DOCUMENTS.YEAR,   EX_DOC_YEAR)
+               .set(CATALOG_DOCUMENTS.CONTENT_TYPE,  EX_DOC_CTYPE)
+               .set(CATALOG_DOCUMENTS.FILE_PATH,  EX_DOC_FPATH)
+               .set(CATALOG_DOCUMENTS.CORPUS, EX_DOC_CORPUS)
+               .set(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION,  EX_DOC_PCOLL)
+               .set(CATALOG_DOCUMENTS.CHUNK_COUNT, EX_DOC_CHUNKS)
+               .set(CATALOG_DOCUMENTS.HEAD_HASH,   EX_DOC_HEAD)
+               .set(CATALOG_DOCUMENTS.INDEXED_AT,  EX_DOC_IDXAT)
                .set(F_DOC_META,   EX_DOC_META)
                // GREATEST: never downgrade source_mtime on re-import
-               .set(F_DOC_SMTIME, EX_DOC_SMTIME_GREATEST)
-               .set(F_DOC_ALIAS,  EX_DOC_ALIAS)
-               .set(F_DOC_URI,    EX_DOC_URI)
-               .set(F_DOC_BIBY,   EX_DOC_BIBY)
-               .set(F_DOC_BIAU,   EX_DOC_BIAU)
-               .set(F_DOC_BIVE,   EX_DOC_BIVE)
-               .set(F_DOC_BICC,   EX_DOC_BICC)
-               .set(F_DOC_BIS2,   EX_DOC_BIS2)
-               .set(F_DOC_BIOA,   EX_DOC_BIOA)
-               .set(F_DOC_BIDOI,  EX_DOC_BIDOI)
-               .set(F_DOC_BIAT,   EX_DOC_BIAT)
+               .set(CATALOG_DOCUMENTS.SOURCE_MTIME, EX_DOC_SMTIME_GREATEST)
+               .set(CATALOG_DOCUMENTS.ALIAS_OF,  EX_DOC_ALIAS)
+               .set(CATALOG_DOCUMENTS.SOURCE_URI,    EX_DOC_URI)
+               .set(CATALOG_DOCUMENTS.BIB_YEAR,   EX_DOC_BIBY)
+               .set(CATALOG_DOCUMENTS.BIB_AUTHORS,   EX_DOC_BIAU)
+               .set(CATALOG_DOCUMENTS.BIB_VENUE,   EX_DOC_BIVE)
+               .set(CATALOG_DOCUMENTS.BIB_CITATION_COUNT,   EX_DOC_BICC)
+               .set(CATALOG_DOCUMENTS.BIB_SEMANTIC_SCHOLAR_ID,   EX_DOC_BIS2)
+               .set(CATALOG_DOCUMENTS.BIB_OPENALEX_ID,   EX_DOC_BIOA)
+               .set(CATALOG_DOCUMENTS.BIB_DOI,  EX_DOC_BIDOI)
+               .set(CATALOG_DOCUMENTS.BIB_ENRICHED_AT,   EX_DOC_BIAT)
                .execute();
         }
     }
@@ -2265,9 +2202,9 @@ public final class CatalogRepository {
             final int chunkSize = Math.max(1, MAX_BATCH_PARAMS / 9);
             for (int start = 0; start < rows.size(); start += chunkSize) {
                 var batch = rows.subList(start, Math.min(start + chunkSize, rows.size()));
-                var insert = ctx.insertInto(T_LINKS,
-                        F_LNK_TENANT, F_LNK_FROM, F_LNK_TO, F_LNK_TYPE,
-                        F_LNK_FSPAN, F_LNK_TSPAN, F_LNK_CRTBY, F_LNK_CRTAT, F_LNK_META);
+                var insert = ctx.insertInto(CATALOG_LINKS,
+                        CATALOG_LINKS.TENANT_ID, CATALOG_LINKS.FROM_TUMBLER, CATALOG_LINKS.TO_TUMBLER, CATALOG_LINKS.LINK_TYPE,
+                        CATALOG_LINKS.FROM_SPAN, CATALOG_LINKS.TO_SPAN, CATALOG_LINKS.CREATED_BY, CATALOG_LINKS.CREATED_AT, F_LNK_META);
                 for (var lnk : batch) {
                     String metaJson = jsonOrNull(lnk.get("metadata"));
                     insert = insert.values(DSL.val(tenant),
@@ -2276,7 +2213,7 @@ public final class CatalogRepository {
                             DSL.val(nne(s(lnk,"created_by"))), DSL.val(nne(s(lnk,"created_at"))),
                             jsonbVal(metaJson));
                 }
-                insert.onConflict(F_LNK_TENANT, F_LNK_FROM, F_LNK_TO, F_LNK_TYPE)
+                insert.onConflict(CATALOG_LINKS.TENANT_ID, CATALOG_LINKS.FROM_TUMBLER, CATALOG_LINKS.TO_TUMBLER, CATALOG_LINKS.LINK_TYPE)
                       .doNothing()
                       .execute();
             }
@@ -2286,15 +2223,15 @@ public final class CatalogRepository {
 
     private void doImportLink(DSLContext ctx, String tenant, Map<String, Object> lnk) {
         String metaJson = jsonOrNull(lnk.get("metadata"));
-        ctx.insertInto(T_LINKS,
-                F_LNK_TENANT, F_LNK_FROM, F_LNK_TO, F_LNK_TYPE,
-                F_LNK_FSPAN, F_LNK_TSPAN, F_LNK_CRTBY, F_LNK_CRTAT, F_LNK_META)
+        ctx.insertInto(CATALOG_LINKS,
+                CATALOG_LINKS.TENANT_ID, CATALOG_LINKS.FROM_TUMBLER, CATALOG_LINKS.TO_TUMBLER, CATALOG_LINKS.LINK_TYPE,
+                CATALOG_LINKS.FROM_SPAN, CATALOG_LINKS.TO_SPAN, CATALOG_LINKS.CREATED_BY, CATALOG_LINKS.CREATED_AT, F_LNK_META)
            .values(DSL.val(tenant),
                    DSL.val(s(lnk,"from_tumbler")), DSL.val(s(lnk,"to_tumbler")), DSL.val(s(lnk,"link_type")),
                    DSL.val(nne(s(lnk,"from_span"))), DSL.val(nne(s(lnk,"to_span"))),
                    DSL.val(nne(s(lnk,"created_by"))), DSL.val(nne(s(lnk,"created_at"))),
                    jsonbVal(metaJson))
-           .onConflict(F_LNK_TENANT, F_LNK_FROM, F_LNK_TO, F_LNK_TYPE)
+           .onConflict(CATALOG_LINKS.TENANT_ID, CATALOG_LINKS.FROM_TUMBLER, CATALOG_LINKS.TO_TUMBLER, CATALOG_LINKS.LINK_TYPE)
            .doNothing()
            .execute();
     }
@@ -2331,21 +2268,21 @@ public final class CatalogRepository {
             final int chunkSize = Math.max(1, MAX_BATCH_PARAMS / 9);
             for (int start = 0; start < deduped.size(); start += chunkSize) {
                 var batch = deduped.subList(start, Math.min(start + chunkSize, deduped.size()));
-                var insert = ctx.insertInto(T_CHUNKS,
-                        F_CHK_TENANT, F_CHK_DOC, F_CHK_POS, F_CHK_CHASH, F_CHK_IDX,
-                        F_CHK_LST, F_CHK_LEN, F_CHK_CST, F_CHK_CEN);
+                var insert = ctx.insertInto(CATALOG_DOCUMENT_CHUNKS,
+                        CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION, CATALOG_DOCUMENT_CHUNKS.CHASH, CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,
+                        CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END);
                 for (var row : batch) {
                     insert = insert.values(tenant, docId, i(row,"position"), s(row,"chash"), i(row,"chunk_index"),
                             i(row,"line_start"), i(row,"line_end"), i(row,"char_start"), i(row,"char_end"));
                 }
-                insert.onConflict(F_CHK_TENANT, F_CHK_DOC, F_CHK_POS)
+                insert.onConflict(CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION)
                       .doUpdate()
-                      .set(F_CHK_CHASH, EX_CHK_CHASH)
-                      .set(F_CHK_IDX,   EX_CHK_IDX)
-                      .set(F_CHK_LST,   EX_CHK_LST)
-                      .set(F_CHK_LEN,   EX_CHK_LEN)
-                      .set(F_CHK_CST,   EX_CHK_CST)
-                      .set(F_CHK_CEN,   EX_CHK_CEN)
+                      .set(CATALOG_DOCUMENT_CHUNKS.CHASH, EX_CHK_CHASH)
+                      .set(CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,   EX_CHK_IDX)
+                      .set(CATALOG_DOCUMENT_CHUNKS.LINE_START,   EX_CHK_LST)
+                      .set(CATALOG_DOCUMENT_CHUNKS.LINE_END,   EX_CHK_LEN)
+                      .set(CATALOG_DOCUMENT_CHUNKS.CHAR_START,   EX_CHK_CST)
+                      .set(CATALOG_DOCUMENT_CHUNKS.CHAR_END,   EX_CHK_CEN)
                       .execute();
             }
             return rows.size();
@@ -2353,19 +2290,19 @@ public final class CatalogRepository {
     }
 
     private void doImportChunk(DSLContext ctx, String tenant, String docId, Map<String, Object> row) {
-        ctx.insertInto(T_CHUNKS,
-                F_CHK_TENANT, F_CHK_DOC, F_CHK_POS, F_CHK_CHASH, F_CHK_IDX,
-                F_CHK_LST, F_CHK_LEN, F_CHK_CST, F_CHK_CEN)
+        ctx.insertInto(CATALOG_DOCUMENT_CHUNKS,
+                CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION, CATALOG_DOCUMENT_CHUNKS.CHASH, CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,
+                CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END)
            .values(tenant, docId, i(row,"position"), s(row,"chash"), i(row,"chunk_index"),
                    i(row,"line_start"), i(row,"line_end"), i(row,"char_start"), i(row,"char_end"))
-           .onConflict(F_CHK_TENANT, F_CHK_DOC, F_CHK_POS)
+           .onConflict(CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION)
            .doUpdate()
-           .set(F_CHK_CHASH, EX_CHK_CHASH)
-           .set(F_CHK_IDX,   EX_CHK_IDX)
-           .set(F_CHK_LST,   EX_CHK_LST)
-           .set(F_CHK_LEN,   EX_CHK_LEN)
-           .set(F_CHK_CST,   EX_CHK_CST)
-           .set(F_CHK_CEN,   EX_CHK_CEN)
+           .set(CATALOG_DOCUMENT_CHUNKS.CHASH, EX_CHK_CHASH)
+           .set(CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,   EX_CHK_IDX)
+           .set(CATALOG_DOCUMENT_CHUNKS.LINE_START,   EX_CHK_LST)
+           .set(CATALOG_DOCUMENT_CHUNKS.LINE_END,   EX_CHK_LEN)
+           .set(CATALOG_DOCUMENT_CHUNKS.CHAR_START,   EX_CHK_CST)
+           .set(CATALOG_DOCUMENT_CHUNKS.CHAR_END,   EX_CHK_CEN)
            .execute();
     }
 
@@ -2486,11 +2423,11 @@ public final class CatalogRepository {
     @SuppressWarnings("unchecked")
     private static SelectField<?>[] documentFields() {
         return new SelectField<?>[]{
-            F_DOC_TUMBLER, F_DOC_TITLE, F_DOC_AUTHOR, F_DOC_YEAR,
-            F_DOC_CTYPE, F_DOC_FPATH, F_DOC_CORPUS, F_DOC_PCOLL, F_DOC_CHUNKS,
-            F_DOC_HEAD, F_DOC_IDXAT, F_DOC_META, F_DOC_SMTIME, F_DOC_ALIAS, F_DOC_URI,
-            F_DOC_BIBY, F_DOC_BIAU, F_DOC_BIVE, F_DOC_BICC,
-            F_DOC_BIS2, F_DOC_BIOA, F_DOC_BIDOI, F_DOC_BIAT
+            CATALOG_DOCUMENTS.TUMBLER, CATALOG_DOCUMENTS.TITLE, CATALOG_DOCUMENTS.AUTHOR, CATALOG_DOCUMENTS.YEAR,
+            CATALOG_DOCUMENTS.CONTENT_TYPE, CATALOG_DOCUMENTS.FILE_PATH, CATALOG_DOCUMENTS.CORPUS, CATALOG_DOCUMENTS.PHYSICAL_COLLECTION, CATALOG_DOCUMENTS.CHUNK_COUNT,
+            CATALOG_DOCUMENTS.HEAD_HASH, CATALOG_DOCUMENTS.INDEXED_AT, F_DOC_META, CATALOG_DOCUMENTS.SOURCE_MTIME, CATALOG_DOCUMENTS.ALIAS_OF, CATALOG_DOCUMENTS.SOURCE_URI,
+            CATALOG_DOCUMENTS.BIB_YEAR, CATALOG_DOCUMENTS.BIB_AUTHORS, CATALOG_DOCUMENTS.BIB_VENUE, CATALOG_DOCUMENTS.BIB_CITATION_COUNT,
+            CATALOG_DOCUMENTS.BIB_SEMANTIC_SCHOLAR_ID, CATALOG_DOCUMENTS.BIB_OPENALEX_ID, CATALOG_DOCUMENTS.BIB_DOI, CATALOG_DOCUMENTS.BIB_ENRICHED_AT
         };
     }
 

--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -537,10 +537,19 @@ public final class CatalogRepository {
                 // string) under "meta"/"metadata". A bare set() of a Map fails with
                 // "LinkedHashMap is not supported in dialect POSTGRES"; JSON-encode and
                 // bind as jsonb, mirroring upsertDocument (RDR-168 nexus-njrcn.7).
+                // nexus-ke45f: MERGE, not replace — local Catalog.update() does
+                // dict.update (add/overwrite keys, never remove), and every
+                // writer.update(meta=...) caller (enrich write-back, catalog
+                // hook, dt stamp, remediation) is written against that
+                // contract; the bare SET silently dropped pre-existing keys
+                // in service mode. jsonb_concat == the || operator.
                 if ("meta".equals(e.getKey()) || "metadata".equals(e.getKey())) {
+                    Field<String> merged = DSL.function("jsonb_concat", String.class,
+                        DSL.coalesce(F_DOC_META, jsonbVal("{}")),
+                        jsonbVal(jsonOrNull(e.getValue())));
                     more = (more == null)
-                        ? step.set(F_DOC_META, jsonbVal(jsonOrNull(e.getValue())))
-                        : more.set(F_DOC_META, jsonbVal(jsonOrNull(e.getValue())));
+                        ? step.set(F_DOC_META, merged)
+                        : more.set(F_DOC_META, merged);
                     continue;
                 }
                 @SuppressWarnings("unchecked")

--- a/service/src/main/java/dev/nexus/service/db/ChashRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/ChashRepository.java
@@ -3,8 +3,7 @@ package dev.nexus.service.db;
 import org.jooq.DSLContext;
 
 import static dev.nexus.service.jooq.nexus.Tables.CATALOG_COLLECTIONS;
-import org.jooq.Field;
-import org.jooq.Record3;
+import static dev.nexus.service.jooq.nexus.Tables.CHASH_INDEX;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,16 +47,6 @@ public final class ChashRepository {
     public static final DateTimeFormatter UTC_SECOND =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
                              .withZone(ZoneOffset.UTC);
-
-    // ── Raw DSL field references (no jOOQ codegen for simple tables) ──────────
-    // Using DSL.field with type params to avoid raw-type warnings.
-
-    private static final Field<String>         F_TENANT     = DSL.field(DSL.name("chash_index", "tenant_id"),           String.class);
-    private static final Field<String>         F_CHASH      = DSL.field(DSL.name("chash_index", "chash"),               String.class);
-    private static final Field<String>         F_COLLECTION = DSL.field(DSL.name("chash_index", "physical_collection"), String.class);
-    private static final Field<OffsetDateTime> F_CREATED_AT = DSL.field(DSL.name("chash_index", "created_at"),          OffsetDateTime.class);
-
-    private static final org.jooq.Table<?> CHASH_INDEX = DSL.table(DSL.name("nexus", "chash_index"));
 
     private final TenantScope tenantScope;
 
@@ -162,11 +151,11 @@ public final class ChashRepository {
         registerCollectionShortTxn(tenant, collection);
         tenantScope.withTenant(tenant, ctx -> {
             ctx.insertInto(CHASH_INDEX,
-                            F_TENANT, F_CHASH, F_COLLECTION, F_CREATED_AT)
+                            CHASH_INDEX.TENANT_ID, CHASH_INDEX.CHASH, CHASH_INDEX.PHYSICAL_COLLECTION, CHASH_INDEX.CREATED_AT)
                .values(tenant, chash, collection, now)
-               .onConflict(F_TENANT, F_CHASH, F_COLLECTION)
+               .onConflict(CHASH_INDEX.TENANT_ID, CHASH_INDEX.CHASH, CHASH_INDEX.PHYSICAL_COLLECTION)
                .doUpdate()
-               .set(F_CREATED_AT, DSL.field("EXCLUDED.created_at", OffsetDateTime.class))
+               .set(CHASH_INDEX.CREATED_AT, DSL.field("EXCLUDED.created_at", OffsetDateTime.class))
                .execute();
             return null;
         });
@@ -194,14 +183,14 @@ public final class ChashRepository {
         registerCollectionShortTxn(tenant, collection);
         tenantScope.withTenant(tenant, ctx -> {
             var insert = ctx.insertInto(CHASH_INDEX,
-                                        F_TENANT, F_CHASH, F_COLLECTION, F_CREATED_AT);
+                                        CHASH_INDEX.TENANT_ID, CHASH_INDEX.CHASH, CHASH_INDEX.PHYSICAL_COLLECTION, CHASH_INDEX.CREATED_AT);
             var step = insert.values(tenant, valid.get(0), collection, now);
             for (int i = 1; i < valid.size(); i++) {
                 step = step.values(tenant, valid.get(i), collection, now);
             }
-            step.onConflict(F_TENANT, F_CHASH, F_COLLECTION)
+            step.onConflict(CHASH_INDEX.TENANT_ID, CHASH_INDEX.CHASH, CHASH_INDEX.PHYSICAL_COLLECTION)
                 .doUpdate()
-                .set(F_CREATED_AT, DSL.field("EXCLUDED.created_at", OffsetDateTime.class))
+                .set(CHASH_INDEX.CREATED_AT, DSL.field("EXCLUDED.created_at", OffsetDateTime.class))
                 .execute();
             return null;
         });
@@ -217,15 +206,15 @@ public final class ChashRepository {
      */
     public List<Map<String, String>> lookup(String tenant, String chash) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.select(F_COLLECTION, F_CREATED_AT)
+            var rows = ctx.select(CHASH_INDEX.PHYSICAL_COLLECTION, CHASH_INDEX.CREATED_AT)
                           .from(CHASH_INDEX)
-                          .where(F_CHASH.eq(chash))
+                          .where(CHASH_INDEX.CHASH.eq(chash))
                           .fetch();
             List<Map<String, String>> result = new ArrayList<>(rows.size());
             for (var r : rows) {
-                OffsetDateTime ts = r.get(F_CREATED_AT);
+                OffsetDateTime ts = r.get(CHASH_INDEX.CREATED_AT);
                 String tsStr = ts != null ? UTC_SECOND.format(ts.atZoneSameInstant(ZoneOffset.UTC)) : "";
-                result.add(Map.of("collection", r.get(F_COLLECTION), "created_at", tsStr));
+                result.add(Map.of("collection", r.get(CHASH_INDEX.PHYSICAL_COLLECTION), "created_at", tsStr));
             }
             return result;
         });
@@ -243,7 +232,7 @@ public final class ChashRepository {
     public int deleteCollection(String tenant, String collection) {
         return tenantScope.withTenant(tenant, ctx ->
                 ctx.deleteFrom(CHASH_INDEX)
-                   .where(F_COLLECTION.eq(collection))
+                   .where(CHASH_INDEX.PHYSICAL_COLLECTION.eq(collection))
                    .execute());
     }
 
@@ -257,12 +246,12 @@ public final class ChashRepository {
      */
     public Set<String> distinctCollections(String tenant) {
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.selectDistinct(F_COLLECTION)
+            var rows = ctx.selectDistinct(CHASH_INDEX.PHYSICAL_COLLECTION)
                           .from(CHASH_INDEX)
                           .fetch();
             Set<String> result = new HashSet<>(rows.size());
             for (var r : rows) {
-                result.add(r.get(F_COLLECTION));
+                result.add(r.get(CHASH_INDEX.PHYSICAL_COLLECTION));
             }
             return result;
         });
@@ -285,17 +274,17 @@ public final class ChashRepository {
             ensureCollectionRegistered(ctx, tenant, newCollection);
             // Drop rows in new that would collide with the rename
             ctx.deleteFrom(CHASH_INDEX)
-               .where(F_COLLECTION.eq(newCollection)
-                   .and(F_CHASH.in(
-                       DSL.select(F_CHASH)
+               .where(CHASH_INDEX.PHYSICAL_COLLECTION.eq(newCollection)
+                   .and(CHASH_INDEX.CHASH.in(
+                       DSL.select(CHASH_INDEX.CHASH)
                           .from(CHASH_INDEX)
-                          .where(F_COLLECTION.eq(oldCollection))
+                          .where(CHASH_INDEX.PHYSICAL_COLLECTION.eq(oldCollection))
                    )))
                .execute();
             // Rename
             return ctx.update(CHASH_INDEX)
-                      .set(F_COLLECTION, newCollection)
-                      .where(F_COLLECTION.eq(oldCollection))
+                      .set(CHASH_INDEX.PHYSICAL_COLLECTION, newCollection)
+                      .where(CHASH_INDEX.PHYSICAL_COLLECTION.eq(oldCollection))
                       .execute();
         });
         // Post-commit (nexus-h8rf6.2): see upsert()'s comment / CollectionRegistry doc.
@@ -314,7 +303,7 @@ public final class ChashRepository {
     public int deleteStale(String tenant, String chash, String collection) {
         return tenantScope.withTenant(tenant, ctx ->
                 ctx.deleteFrom(CHASH_INDEX)
-                   .where(F_CHASH.eq(chash).and(F_COLLECTION.eq(collection)))
+                   .where(CHASH_INDEX.CHASH.eq(chash).and(CHASH_INDEX.PHYSICAL_COLLECTION.eq(collection)))
                    .execute());
     }
 
@@ -343,7 +332,7 @@ public final class ChashRepository {
         return tenantScope.withTenant(tenant, ctx -> {
             var row = ctx.select(DSL.count())
                          .from(CHASH_INDEX)
-                         .where(F_COLLECTION.eq(collection))
+                         .where(CHASH_INDEX.PHYSICAL_COLLECTION.eq(collection))
                          .fetchOne();
             return row != null ? row.value1() : 0;
         });
@@ -371,9 +360,9 @@ public final class ChashRepository {
             throw new IllegalArgumentException("collection must not be empty");
         }
         return tenantScope.withTenant(tenant, ctx -> {
-            var rows = ctx.selectDistinct(DSL.field(DSL.name("chash_index", "chash"), String.class))
+            var rows = ctx.selectDistinct(CHASH_INDEX.CHASH)
                           .from(CHASH_INDEX)
-                          .where(F_COLLECTION.eq(collection))
+                          .where(CHASH_INDEX.PHYSICAL_COLLECTION.eq(collection))
                           .fetch();
             Set<String> result = new HashSet<>(rows.size());
             for (var r : rows) {
@@ -418,11 +407,11 @@ public final class ChashRepository {
         registerCollectionShortTxn(tenant, collection);
         tenantScope.withTenant(tenant, ctx -> {
             ctx.insertInto(CHASH_INDEX,
-                            F_TENANT, F_CHASH, F_COLLECTION, F_CREATED_AT)
+                            CHASH_INDEX.TENANT_ID, CHASH_INDEX.CHASH, CHASH_INDEX.PHYSICAL_COLLECTION, CHASH_INDEX.CREATED_AT)
                .values(tenant, chash, collection, ts)
-               .onConflict(F_TENANT, F_CHASH, F_COLLECTION)
+               .onConflict(CHASH_INDEX.TENANT_ID, CHASH_INDEX.CHASH, CHASH_INDEX.PHYSICAL_COLLECTION)
                .doUpdate()
-               .set(F_CREATED_AT, DSL.field("EXCLUDED.created_at", OffsetDateTime.class))
+               .set(CHASH_INDEX.CREATED_AT, DSL.field("EXCLUDED.created_at", OffsetDateTime.class))
                .execute();
             return null;
         });
@@ -476,7 +465,7 @@ public final class ChashRepository {
         for (String c : collections) registerCollectionShortTxn(tenant, c);
         int landed = tenantScope.withTenant(tenant, ctx -> {
             var insert = ctx.insertInto(CHASH_INDEX,
-                    F_TENANT, F_CHASH, F_COLLECTION, F_CREATED_AT);
+                    CHASH_INDEX.TENANT_ID, CHASH_INDEX.CHASH, CHASH_INDEX.PHYSICAL_COLLECTION, CHASH_INDEX.CREATED_AT);
             for (ImportRow r : deduped) {
                 OffsetDateTime ts;
                 try {
@@ -488,9 +477,9 @@ public final class ChashRepository {
                 }
                 insert = insert.values(tenant, r.chash(), r.collection(), ts);
             }
-            insert.onConflict(F_TENANT, F_CHASH, F_COLLECTION)
+            insert.onConflict(CHASH_INDEX.TENANT_ID, CHASH_INDEX.CHASH, CHASH_INDEX.PHYSICAL_COLLECTION)
                   .doUpdate()
-                  .set(F_CREATED_AT, DSL.field("EXCLUDED.created_at", OffsetDateTime.class))
+                  .set(CHASH_INDEX.CREATED_AT, DSL.field("EXCLUDED.created_at", OffsetDateTime.class))
                   .execute();
             return deduped.size();
         });

--- a/service/src/main/java/dev/nexus/service/db/PgSession.java
+++ b/service/src/main/java/dev/nexus/service/db/PgSession.java
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+package dev.nexus.service.db;
+
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+
+import java.util.Set;
+
+/**
+ * Transaction-scoped PostgreSQL session settings — the ONE sanctioned home
+ * for {@code SET LOCAL}-shaped statements (nexus-xtmtf).
+ *
+ * <p>{@code SET LOCAL x = y} has no jOOQ DSL form, but its exact equivalent
+ * {@code SELECT set_config('x', 'y', true)} does: a plain function call with
+ * real bind parameters, no string-concatenated SQL. Every repository that
+ * needs a transaction-local GUC (HNSW iterative scan, trigram similarity
+ * threshold) routes through {@link #setLocal}; the gate test
+ * ({@code RawSqlGateTest}) forbids {@code ctx.execute(} string-SQL anywhere
+ * in {@code service/src/main}, this class included — there is nothing raw
+ * left to sanction.
+ *
+ * <p>The GUC name is validated against a closed whitelist. set_config binds
+ * the name as a parameter so injection is structurally impossible, but an
+ * unknown GUC at this layer is a programming error worth failing loudly on
+ * rather than shipping to Postgres.
+ */
+public final class PgSession {
+
+    /** GUCs the service is allowed to set transaction-locally. */
+    private static final Set<String> ALLOWED_GUCS = Set.of(
+        "hnsw.iterative_scan",
+        "pg_trgm.word_similarity_threshold"
+    );
+
+    private PgSession() {
+    }
+
+    /**
+     * Set a transaction-local GUC ({@code SET LOCAL} semantics) via
+     * {@code set_config(name, value, is_local=true)}.
+     *
+     * <p>Must be called inside a transaction (jOOQ {@code transaction(...)} /
+     * TenantScope block) — set_config with {@code is_local=true} outside a
+     * transaction is a silent no-op, same as SET LOCAL.
+     *
+     * @param ctx   transaction-bound DSL context
+     * @param guc   GUC name; must be whitelisted in {@link #ALLOWED_GUCS}
+     * @param value value to set for the remainder of the transaction
+     * @throws IllegalArgumentException on a non-whitelisted GUC
+     */
+    public static void setLocal(DSLContext ctx, String guc, String value) {
+        if (!ALLOWED_GUCS.contains(guc)) {
+            throw new IllegalArgumentException(
+                "GUC '" + guc + "' is not whitelisted for SET LOCAL (allowed: "
+                + ALLOWED_GUCS + ")");
+        }
+        ctx.select(DSL.function("set_config", SQLDataType.VARCHAR,
+                DSL.val(guc), DSL.val(value), DSL.inline(true)))
+           .fetch();
+    }
+}

--- a/service/src/main/java/dev/nexus/service/db/PoolerModeCheck.java
+++ b/service/src/main/java/dev/nexus/service/db/PoolerModeCheck.java
@@ -1,13 +1,13 @@
 package dev.nexus.service.db;
 
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -122,12 +122,16 @@ public final class PoolerModeCheck {
         String timedUrl = adminUrl.contains("connectTimeout=") || adminUrl.contains("socketTimeout=")
                 ? adminUrl
                 : adminUrl + (adminUrl.contains("?") ? "&" : "?") + "connectTimeout=10&socketTimeout=10";
-        try (Connection conn = DriverManager.getConnection(timedUrl, user, pass);
-             Statement st = conn.createStatement();
-             ResultSet rs = st.executeQuery("SHOW CONFIG")) {
-            // PgBouncer SHOW CONFIG returns columns: key, value, [changeable].
-            while (rs.next()) {
-                rows.put(rs.getString("key"), rs.getString("value"));
+        // SANCTIONED RAW (nexus-mzuj9): `SHOW CONFIG` is a PgBouncer admin-console meta-command,
+        // not SQL against any table/schema — it has no jOOQ DSL form (no bind params, no known
+        // column set ahead of time; PgBouncer, not Postgres, answers it). Routed through
+        // DSL.using(connection) rather than a bare JDBC Statement so the result is a typed
+        // jOOQ Result<Record> (key/value/[changeable] columns) instead of manual ResultSet
+        // iteration. Registered in RawSqlGateTest's sanctioned method allowlist.
+        try (Connection conn = DriverManager.getConnection(timedUrl, user, pass)) {
+            var result = DSL.using(conn, SQLDialect.POSTGRES).fetch("SHOW CONFIG");
+            for (var rec : result) {
+                rows.put(rec.get("key", String.class), rec.get("value", String.class));
             }
         }
         return rows;

--- a/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/TaxonomyRepository.java
@@ -1637,11 +1637,10 @@ public final class TaxonomyRepository {
      * for duplicate doc_ids within a single batch (a self-conflict is skipped, not
      * an error — DO NOTHING, not DO UPDATE).
      *
-     * <p>Dynamic multi-row VALUES with variable count is the sole reason this
-     * method uses raw SQL string building — jOOQ's typed multi-row INSERT requires
-     * a statically-known row count and would require a separate parameter object
-     * per row (losing the batch-statement benefit). This is the minimal irreducible
-     * plain-SQL fragment per spec.
+     * <p>nexus-xtmtf: jOOQ's chained {@code .values()} supports a dynamic row
+     * count per statement, so the batch stays ONE multi-row INSERT per chunk
+     * (one trigger firing per chunk preserved) with zero raw SQL. The earlier
+     * "jOOQ requires a statically-known row count" rationale was incorrect.
      */
     private static void batchInsertAssignments(org.jooq.DSLContext ctx, String tenant,
                                                long topicId, List<String> docIds,
@@ -1654,18 +1653,16 @@ public final class TaxonomyRepository {
         final int MAX_ROWS = 5000;
         for (int start = 0; start < docIds.size(); start += MAX_ROWS) {
             List<String> batch = docIds.subList(start, Math.min(start + MAX_ROWS, docIds.size()));
-            StringBuilder sql = new StringBuilder(
-                "INSERT INTO nexus.topic_assignments (tenant_id, doc_id, topic_id, assigned_by) VALUES ");
-            List<Object> params = new ArrayList<>(batch.size() * 4);
-            for (int i = 0; i < batch.size(); i++) {
-                sql.append(i == 0 ? "(?, ?, ?, ?)" : ", (?, ?, ?, ?)");
-                params.add(tenant);
-                params.add(batch.get(i));
-                params.add(topicId);
-                params.add(assignedBy);
+            var insert = ctx.insertInto(TOPIC_ASSIGNMENTS,
+                    TOPIC_ASSIGNMENTS.TENANT_ID, TOPIC_ASSIGNMENTS.DOC_ID,
+                    TOPIC_ASSIGNMENTS.TOPIC_ID, TOPIC_ASSIGNMENTS.ASSIGNED_BY);
+            for (String docId : batch) {
+                insert = insert.values(tenant, docId, topicId, assignedBy);
             }
-            sql.append(" ON CONFLICT (tenant_id, doc_id, topic_id) DO NOTHING");
-            ctx.execute(sql.toString(), params.toArray());
+            insert.onConflict(TOPIC_ASSIGNMENTS.TENANT_ID, TOPIC_ASSIGNMENTS.DOC_ID,
+                              TOPIC_ASSIGNMENTS.TOPIC_ID)
+                  .doNothing()
+                  .execute();
         }
     }
 }

--- a/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/CatalogHandler.java
@@ -187,6 +187,7 @@ public final class CatalogHandler implements HttpHandler {
                 // ── Span / chash resolution (nexus-njrcn.4) ──────────────────
                 case "/resolve_span"          -> handleResolveSpan(exchange, tenant, method);
                 case "/resolve_chash"         -> handleResolveChash(exchange, tenant, method);
+                case "/resolve_chunk"         -> handleResolveChunk(exchange, tenant, method);
 
                 // ── Server-side tumbler assignment ────────────────────────────
                 case "/doc/register"          -> handleDocRegister(exchange, tenant, method);
@@ -635,6 +636,48 @@ public final class CatalogHandler implements HttpHandler {
         var result = repo.resolveChash(tenant, chash, preferCollection);
         if (result == null) {
             HttpUtil.send(exchange, 404, "{\"error\":\"chunk not found\"}"); return;
+        }
+        HttpUtil.send(exchange, 200, MAPPER.writeValueAsString(result));
+    }
+
+    /**
+     * GET /v1/catalog/resolve_chunk?tumbler=<4-segment chunk address> (nexus-gc2ze)
+     *
+     * <p>Mirrors the local {@code Catalog.resolve_chunk} contract
+     * (catalog_docs.py): chunks are implicit addresses — the catalog stores
+     * document-level rows only, and chunk sub-addresses are resolved on
+     * demand from the document's {@code chunk_count}. Splits the tumbler
+     * into its document prefix (first 3 segments) and chunk index (4th
+     * segment), then delegates the lookup + range-check to
+     * {@link CatalogRepository#resolveChunk}.
+     *
+     * <p>400 if {@code tumbler} has fewer than 4 segments (not a chunk
+     * address) or the 4th segment is not an integer; 404 if the document is
+     * missing or the chunk index is out of range.
+     *
+     * <p>Response: {@code {"document_tumbler", "chunk_index",
+     * "physical_collection", "title", "content_type"}}.
+     */
+    private void handleResolveChunk(HttpExchange exchange, String tenant, String method) throws IOException {
+        if (!"GET".equals(method)) { HttpUtil.send(exchange, 405, "{\"error\":\"method not allowed\"}"); return; }
+        String tumbler = queryParam(exchange, "tumbler");
+        if (tumbler == null || tumbler.isBlank()) {
+            HttpUtil.send(exchange, 400, "{\"error\":\"tumbler query param required\"}"); return;
+        }
+        String[] segments = tumbler.split("\\.");
+        if (segments.length < 4) {
+            HttpUtil.send(exchange, 400, "{\"error\":\"tumbler is not a chunk address (need >= 4 segments)\"}"); return;
+        }
+        int chunkIndex;
+        try {
+            chunkIndex = Integer.parseInt(segments[3]);
+        } catch (NumberFormatException e) {
+            HttpUtil.send(exchange, 400, "{\"error\":\"invalid chunk segment\"}"); return;
+        }
+        String docTumbler = segments[0] + "." + segments[1] + "." + segments[2];
+        var result = repo.resolveChunk(tenant, docTumbler, chunkIndex);
+        if (result == null) {
+            HttpUtil.send(exchange, 404, "{\"error\":\"not found\"}"); return;
         }
         HttpUtil.send(exchange, 200, MAPPER.writeValueAsString(result));
     }

--- a/service/src/main/java/dev/nexus/service/http/HealthHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/HealthHandler.java
@@ -3,6 +3,8 @@ package dev.nexus.service.http;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import dev.nexus.service.db.TenantScope;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,10 +46,11 @@ public final class HealthHandler implements HttpHandler {
     }
 
     private void checkDb() throws Exception {
-        try (Connection conn = dataSource.getConnection();
-             var stmt = conn.createStatement();
-             var rs = stmt.executeQuery("SELECT 1")) {
-            if (!rs.next()) {
+        try (Connection conn = dataSource.getConnection()) {
+            Integer one = DSL.using(conn, SQLDialect.POSTGRES)
+                             .select(DSL.one())
+                             .fetchOne(0, Integer.class);
+            if (one == null) {
                 throw new RuntimeException("SELECT 1 returned no rows");
             }
         }

--- a/service/src/main/java/dev/nexus/service/http/VersionHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/VersionHandler.java
@@ -5,6 +5,10 @@ package dev.nexus.service.http;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import dev.nexus.service.vectors.EmbedderRouter;
+import org.jooq.Field;
+import org.jooq.SQLDialect;
+import org.jooq.Table;
+import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +58,19 @@ public final class VersionHandler implements HttpHandler {
     /** RDR-002: the release identity, stamped from the git tag at build time. */
     private static final String RELEASE_PROPERTIES =
             "/META-INF/nexus/release.properties";
+
+    // Liquibase's own bookkeeping table lives in `public`, outside the jOOQ codegen's
+    // `nexus`/`t1` inputSchema scope (explicitly excluded — pom.xml codegen <excludes>),
+    // so there is no generated Tables.DATABASECHANGELOG to reference. Typed ad-hoc
+    // DSL.table/DSL.field references (nexus-mzuj9) replace the raw
+    // "SELECT ... FROM public.databasechangelog" JDBC strings below — still zero
+    // embedded SQL text, just no codegen for this one cross-schema table.
+    private static final Table<?> DATABASECHANGELOG =
+            DSL.table(DSL.name("public", "databasechangelog"));
+    private static final Field<String> DBCL_ID =
+            DSL.field(DSL.name("id"), String.class);
+    private static final Field<Integer> DBCL_ORDER_EXECUTED =
+            DSL.field(DSL.name("orderexecuted"), Integer.class);
 
     private final DataSource dataSource;
     private final String appVersion;
@@ -157,21 +174,13 @@ public final class VersionHandler implements HttpHandler {
         String latestId = null;
         long count = 0;
         String schemaError = null;
-        try (Connection conn = dataSource.getConnection();
-             var stmt = conn.createStatement()) {
-            try (var rs = stmt.executeQuery(
-                    "SELECT id FROM public.databasechangelog "
-                    + "ORDER BY orderexecuted DESC LIMIT 1")) {
-                if (rs.next()) {
-                    latestId = rs.getString(1);
-                }
-            }
-            try (var rs = stmt.executeQuery(
-                    "SELECT count(*) FROM public.databasechangelog")) {
-                if (rs.next()) {
-                    count = rs.getLong(1);
-                }
-            }
+        try (Connection conn = dataSource.getConnection()) {
+            var dsl = DSL.using(conn, SQLDialect.POSTGRES);
+            latestId = dsl.select(DBCL_ID).from(DATABASECHANGELOG)
+                          .orderBy(DBCL_ORDER_EXECUTED.desc())
+                          .limit(1)
+                          .fetchOne(DBCL_ID);
+            count = dsl.fetchCount(DATABASECHANGELOG);
         } catch (Exception e) {
             log.warn("event=version_schema_read_failed error={}", e.getMessage());
             schemaError = e.getMessage();

--- a/service/src/main/java/dev/nexus/service/http/WhoamiHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/WhoamiHandler.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import dev.nexus.service.db.TenantScope;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,9 +52,12 @@ public final class WhoamiHandler implements HttpHandler {
 
         // Execute within a GUC-stamped transaction — proves the withTenant path
         String body = tenantScope.withTenant(tenant, ctx -> {
-            // SELECT current_setting proves GUC was applied
-            String stamped = ctx.fetchOne("SELECT current_setting('nexus.tenant', true)")
-                                .get(0, String.class);
+            // SELECT current_setting proves GUC was applied — DSL.function template
+            // (nexus-mzuj9), the current_setting(text, bool) 2-arg PG builtin has no
+            // dedicated jOOQ DSL accessor.
+            Field<String> currentSetting = DSL.function(
+                "current_setting", String.class, DSL.val("nexus.tenant"), DSL.val(true));
+            String stamped = ctx.select(currentSetting).fetchOne(currentSetting);
             try {
                 return MAPPER.writeValueAsString(Map.of(
                     "tenant", tenant,

--- a/service/src/main/java/dev/nexus/service/jooq/binding/Vector.java
+++ b/service/src/main/java/dev/nexus/service/jooq/binding/Vector.java
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+package dev.nexus.service.jooq.binding;
+
+import java.util.Arrays;
+
+/**
+ * Immutable pgvector value (nexus-xtmtf) — the jOOQ user type for the
+ * {@code vector} column type (see {@link VectorBinding}).
+ *
+ * <p>A wrapper class rather than a bare {@code float[]} because jOOQ's
+ * generated POJOs cannot handle primitive-array user types (their
+ * equals/hashCode generation casts to {@code Object[]}); this mirrors the
+ * shape of jOOQ's commercial-only {@code FloatVector}.
+ */
+public final class Vector {
+
+    private final float[] floats;
+
+    private Vector(float[] floats) {
+        this.floats = floats;
+    }
+
+    /** Wrap (no copy — treat the array as frozen after handing it over). */
+    public static Vector of(float[] floats) {
+        return floats == null ? null : new Vector(floats);
+    }
+
+    public float[] floats() {
+        return floats;
+    }
+
+    /** pgvector text form: {@code [f1,f2,...]}. */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(floats.length * 8).append('[');
+        for (int i = 0; i < floats.length; i++) {
+            if (i > 0) sb.append(',');
+            sb.append(floats[i]);
+        }
+        return sb.append(']').toString();
+    }
+
+    /** Parse the pgvector text form. */
+    public static Vector parse(String text) {
+        String body = text.trim();
+        if (body.startsWith("[")) body = body.substring(1);
+        if (body.endsWith("]")) body = body.substring(0, body.length() - 1);
+        if (body.isBlank()) return new Vector(new float[0]);
+        String[] parts = body.split(",");
+        float[] out = new float[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            out[i] = Float.parseFloat(parts[i].trim());
+        }
+        return new Vector(out);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof Vector v && Arrays.equals(floats, v.floats);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(floats);
+    }
+}

--- a/service/src/main/java/dev/nexus/service/jooq/binding/VectorBinding.java
+++ b/service/src/main/java/dev/nexus/service/jooq/binding/VectorBinding.java
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+package dev.nexus.service.jooq.binding;
+
+import org.jooq.Binding;
+import org.jooq.BindingGetResultSetContext;
+import org.jooq.BindingGetSQLInputContext;
+import org.jooq.BindingGetStatementContext;
+import org.jooq.BindingRegisterContext;
+import org.jooq.BindingSQLContext;
+import org.jooq.BindingSetSQLOutputContext;
+import org.jooq.BindingSetStatementContext;
+import org.jooq.Converter;
+import org.jooq.conf.ParamType;
+import org.jooq.impl.DSL;
+
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Types;
+
+/**
+ * jOOQ {@link Binding} for the pgvector {@code vector} type as {@link Vector}
+ * (nexus-xtmtf).
+ *
+ * <p>Registered via the codegen {@code forcedType}, so every generated
+ * {@code chunks_<dim>.embedding} / {@code taxonomy_centroids_<dim>.embedding}
+ * field is a {@code TableField<R, Vector>} and DSL statements bind vectors
+ * directly — this class owns the {@code ::vector} cast and the
+ * {@code [f1,f2,...]} text literal that previously lived as raw-SQL
+ * {@code ?::vector} + {@code vectorLiteral()} string building at every call
+ * site.
+ *
+ * <p>In-repo rather than jOOQ's own {@code FloatVector} because pgvector
+ * support in {@code jooq-postgres-extensions} is commercial-edition-only;
+ * the OSS jar carries no vector classes.
+ */
+public class VectorBinding implements Binding<Object, Vector> {
+
+    private static final Converter<Object, Vector> CONVERTER = new Converter<>() {
+        @Override
+        public Vector from(Object db) {
+            return db == null ? null : Vector.parse(db.toString());
+        }
+
+        @Override
+        public Object to(Vector user) {
+            return user == null ? null : user.toString();
+        }
+
+        @Override
+        public Class<Object> fromType() {
+            return Object.class;
+        }
+
+        @Override
+        public Class<Vector> toType() {
+            return Vector.class;
+        }
+    };
+
+    @Override
+    public Converter<Object, Vector> converter() {
+        return CONVERTER;
+    }
+
+    @Override
+    public void sql(BindingSQLContext<Vector> ctx) {
+        if (ctx.render().paramType() == ParamType.INLINED) {
+            Vector v = ctx.value();
+            ctx.render().visit(DSL.inline(v == null ? null : v.toString()))
+               .sql("::vector");
+        } else {
+            ctx.render().sql(ctx.variable()).sql("::vector");
+        }
+    }
+
+    @Override
+    public void register(BindingRegisterContext<Vector> ctx) throws SQLException {
+        ctx.statement().registerOutParameter(ctx.index(), Types.VARCHAR);
+    }
+
+    @Override
+    public void set(BindingSetStatementContext<Vector> ctx) throws SQLException {
+        Vector v = ctx.value();
+        if (v == null) {
+            ctx.statement().setNull(ctx.index(), Types.OTHER);
+        } else {
+            ctx.statement().setString(ctx.index(), v.toString());
+        }
+    }
+
+    @Override
+    public void get(BindingGetResultSetContext<Vector> ctx) throws SQLException {
+        String s = ctx.resultSet().getString(ctx.index());
+        ctx.value(s == null ? null : Vector.parse(s));
+    }
+
+    @Override
+    public void get(BindingGetStatementContext<Vector> ctx) throws SQLException {
+        String s = ctx.statement().getString(ctx.index());
+        ctx.value(s == null ? null : Vector.parse(s));
+    }
+
+    @Override
+    public void set(BindingSetSQLOutputContext<Vector> ctx) throws SQLException {
+        throw new SQLFeatureNotSupportedException("vector via SQLOutput");
+    }
+
+    @Override
+    public void get(BindingGetSQLInputContext<Vector> ctx) throws SQLException {
+        throw new SQLFeatureNotSupportedException("vector via SQLInput");
+    }
+}

--- a/service/src/main/java/dev/nexus/service/vectors/DimTables.java
+++ b/service/src/main/java/dev/nexus/service/vectors/DimTables.java
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+package dev.nexus.service.vectors;
+
+import dev.nexus.service.jooq.binding.Vector;
+import dev.nexus.service.jooq.nexus.Tables;
+import org.jooq.Field;
+import org.jooq.JSONB;
+import org.jooq.Table;
+import java.util.Map;
+
+/**
+ * Typed accessors for the per-dimension pgvector tables (nexus-xtmtf).
+ *
+ * <p>{@code chunks_<dim>} / {@code taxonomy_centroids_<dim>} are generated as
+ * separate jOOQ classes with no common typed interface; these holders expose
+ * one {@code Table} + its fields per dim so repositories write plain DSL
+ * instead of {@code "INSERT INTO " + chunksTable(dim)} string concatenation.
+ * Fields are pulled FROM the generated table instances, so the pgvector
+ * {@code VectorBinding} (codegen forcedType, {@code Vector} user type)
+ * rides along — no {@code ?::vector} casts, no {@code vectorLiteral()}
+ * strings.
+ *
+ * <p>The dim key set mirrors {@code VALID_DIMS}; an unknown dim returns null
+ * from the maps and callers keep their existing loud validation.
+ */
+public final class DimTables {
+
+    /** chunks_&lt;dim&gt; accessor. */
+    public record ChunkTable(
+        Table<?> table,
+        Field<String> tenantId,
+        Field<String> collection,
+        Field<String> chash,
+        Field<String> chunkText,
+        Field<Vector> embedding,
+        Field<JSONB> metadata
+    ) {
+        @SuppressWarnings("unchecked")
+        static ChunkTable of(Table<?> t) {
+            return new ChunkTable(
+                t,
+                t.field("tenant_id", String.class),
+                t.field("collection", String.class),
+                t.field("chash", String.class),
+                t.field("chunk_text", String.class),
+                (Field<Vector>) t.field("embedding"),
+                t.field("metadata", JSONB.class));
+        }
+    }
+
+    /** taxonomy_centroids_&lt;dim&gt; accessor. */
+    public record CentroidTable(
+        Table<?> table,
+        Field<String> tenantId,
+        Field<String> collection,
+        Field<Long> topicId,
+        Field<Vector> embedding,
+        Field<String> label,
+        Field<Integer> docCount
+    ) {
+        @SuppressWarnings("unchecked")
+        static CentroidTable of(Table<?> t) {
+            return new CentroidTable(
+                t,
+                t.field("tenant_id", String.class),
+                t.field("collection", String.class),
+                t.field("topic_id", Long.class),
+                (Field<Vector>) t.field("embedding"),
+                t.field("label", String.class),
+                t.field("doc_count", Integer.class));
+        }
+    }
+
+    public static final Map<Integer, ChunkTable> CHUNKS = Map.of(
+        384,  ChunkTable.of(Tables.CHUNKS_384),
+        768,  ChunkTable.of(Tables.CHUNKS_768),
+        1024, ChunkTable.of(Tables.CHUNKS_1024));
+
+    public static final Map<Integer, CentroidTable> CENTROIDS = Map.of(
+        384,  CentroidTable.of(Tables.TAXONOMY_CENTROIDS_384),
+        768,  CentroidTable.of(Tables.TAXONOMY_CENTROIDS_768),
+        1024, CentroidTable.of(Tables.TAXONOMY_CENTROIDS_1024));
+
+    private DimTables() {
+    }
+}

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -5,9 +5,13 @@ package dev.nexus.service.vectors;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.nexus.service.db.CollectionRegistry;
+import dev.nexus.service.db.PgSession;
+import dev.nexus.service.jooq.binding.Vector;
 import dev.nexus.service.db.TenantScope;
+import org.jooq.JSONB;
 import org.jooq.Record;
 import org.jooq.Result;
+import org.jooq.impl.DSL;
 
 import static dev.nexus.service.jooq.nexus.Tables.CATALOG_COLLECTIONS;
 import org.slf4j.Logger;
@@ -434,26 +438,25 @@ public final class PgVectorRepository {
             // batch this way. Same ON CONFLICT semantics, same bound values, just
             // one statement.
             if (!dedupIds.isEmpty()) {
-                var sql = new StringBuilder(
-                    "INSERT INTO " + table
-                    + " (tenant_id, collection, chash, chunk_text, embedding, metadata) VALUES ");
-                Object[] params = new Object[dedupIds.size() * 6];
+                // nexus-xtmtf: chained .values() keeps this ONE multi-row
+                // statement (the h8rf6.2 lock-hold rationale); float[] (VectorBinding) +
+                // JSONB typed binds retire the ?::vector / ?::jsonb casts.
+                DimTables.ChunkTable ch = DimTables.CHUNKS.get(dim);
+                var insert = ctx.insertInto(ch.table())
+                    .columns(ch.tenantId(), ch.collection(), ch.chash(),
+                             ch.chunkText(), ch.embedding(), ch.metadata());
                 for (int i = 0; i < dedupIds.size(); i++) {
-                    if (i > 0) sql.append(", ");
-                    sql.append("(?, ?, ?, ?, ?::vector, ?::jsonb)");
-                    int base = i * 6;
-                    params[base]     = tenant;
-                    params[base + 1] = collection;
-                    params[base + 2] = dedupIds.get(i);
-                    params[base + 3] = dedupDocs.get(i);
-                    params[base + 4] = vectorLiteral(embeddings.get(i));
-                    params[base + 5] = toJson(dedupMetas.get(i));
+                    insert = insert.values(tenant, collection, dedupIds.get(i),
+                            dedupDocs.get(i),
+                            Vector.of(embeddings.get(i)),
+                            JSONB.jsonb(toJson(dedupMetas.get(i))));
                 }
-                sql.append(" ON CONFLICT (tenant_id, collection, chash) DO UPDATE SET")
-                   .append("   chunk_text = EXCLUDED.chunk_text,")
-                   .append("   embedding  = EXCLUDED.embedding,")
-                   .append("   metadata   = EXCLUDED.metadata");
-                ctx.execute(sql.toString(), params);
+                insert.onConflict(ch.tenantId(), ch.collection(), ch.chash())
+                      .doUpdate()
+                      .set(ch.chunkText(), DSL.excluded(ch.chunkText()))
+                      .set(ch.embedding(), DSL.excluded(ch.embedding()))
+                      .set(ch.metadata(),  DSL.excluded(ch.metadata()))
+                      .execute();
             }
             return null;
         });
@@ -487,18 +490,34 @@ public final class PgVectorRepository {
      * present) without executing it against the live schema (the {@code retention} column
      * does not exist until Phase B / nexus-dtnpu).
      */
-    static String referenceOnlyInsertSql(String table) {
-        return "INSERT INTO " + table
-             + " (tenant_id, collection, chash, chunk_text, embedding, metadata, retention)"
-             + " VALUES (?, ?, ?, NULL, ?::vector, ?::jsonb, 'reference-only')"
-             + " ON CONFLICT (tenant_id, collection, chash) DO UPDATE SET"
-             + "   embedding  = EXCLUDED.embedding,"
-             + "   metadata   = EXCLUDED.metadata,"
-             + "   retention  = EXCLUDED.retention";
-        // NOTE: chunk_text is intentionally EXCLUDED from the DO UPDATE clause —
-        // reference-only→reference-only rewrites refresh embedding+metadata but must
-        // never overwrite a non-NULL chunk_text (the guard below catches the full→ref
-        // transition before SQL runs; this omission is defense-in-depth).
+    /**
+     * Build the reference-only upsert as a jOOQ query (nexus-xtmtf: DSL form of
+     * the retired {@code referenceOnlyInsertSql} string). ``retention`` is a
+     * Phase-B column absent from the generated schema (the caller is gated OFF
+     * in Phase A, unreachable); the ad-hoc field reference fails at runtime on
+     * the missing column exactly like the raw SQL did, and Phase B's regen
+     * replaces it with the generated field. chunk_text is intentionally
+     * EXCLUDED from the DO UPDATE — reference-only rewrites refresh
+     * embedding+metadata but must never overwrite a non-NULL chunk_text (the
+     * caller's guard catches full→ref before SQL; this omission is
+     * defense-in-depth). Package-private so the SQL-shape test renders it.
+     */
+    static org.jooq.Query referenceOnlyInsertQuery(
+            org.jooq.DSLContext ctx, int dim, String tenant, String collection,
+            String chash, float[] embedding, String metadataJson) {
+        DimTables.ChunkTable ch = DimTables.CHUNKS.get(dim);
+        var retention = DSL.field(DSL.name("retention"), String.class);
+        return ctx.insertInto(ch.table())
+                  .columns(ch.tenantId(), ch.collection(), ch.chash(), ch.chunkText(),
+                           ch.embedding(), ch.metadata(), retention)
+                  .values(tenant, collection, chash, null,
+                          Vector.of(embedding),
+                          JSONB.jsonb(metadataJson), "reference-only")
+                  .onConflict(ch.tenantId(), ch.collection(), ch.chash())
+                  .doUpdate()
+                  .set(ch.embedding(), DSL.excluded(ch.embedding()))
+                  .set(ch.metadata(),  DSL.excluded(ch.metadata()))
+                  .set(retention,      DSL.excluded(retention));
     }
 
     /**
@@ -611,10 +630,11 @@ public final class PgVectorRepository {
                .doNothing()
                .execute();
 
-            // (6) Reference-only chunk INSERT (Phase B — requires retention column).
-            ctx.execute(referenceOnlyInsertSql(table),
-                tenant, collection, chash,
-                vectorLiteral(embedding), toJson(sanitizeNulDeep(metadata)));
+            // (6) Reference-only chunk INSERT (Phase B — requires retention column;
+            // see referenceOnlyInsertQuery for the Phase-A/B contract).
+            referenceOnlyInsertQuery(ctx, dimForCollection(collection), tenant,
+                    collection, chash, embedding,
+                    toJson(sanitizeNulDeep(metadata))).execute();
             return null;
         });
         log.debug("event=upsert_reference_only_done collection={} chash={}", collection, chash);
@@ -708,7 +728,7 @@ public final class PgVectorRepository {
             // Filtered-ANN recall: keep HNSW scanning past ef_search when the RLS +
             // collection + metadata predicates narrow the candidate set. SET LOCAL is
             // txn-scoped (same pool discipline as the TenantScope GUC stamp).
-            ctx.execute("SET LOCAL hnsw.iterative_scan = 'relaxed_order'");
+            PgSession.setLocal(ctx, "hnsw.iterative_scan", "relaxed_order");
             return ctx.fetch(sql.toString(), binds.toArray());
         });
 
@@ -981,7 +1001,7 @@ public final class PgVectorRepository {
             // Trigram gate calibration (contract anchor): word_similarity >= 0.6, pg_trgm's
             // default - typo-probe candidates sit at ~0.9 and pass, no-signal rows at ~0.1
             // do not. Pinned per-transaction so the gate is independent of cluster config.
-            ctx.execute("SET LOCAL pg_trgm.word_similarity_threshold = 0.6");
+            PgSession.setLocal(ctx, "pg_trgm.word_similarity_threshold", "0.6");
 
             List<String> gateChashes = ctx.fetch(
                 "SELECT chash FROM " + table + gateSql + " LIMIT ?", probeBinds.toArray())
@@ -1020,7 +1040,7 @@ public final class PgVectorRepository {
                 return ctx.fetch(sql, b.toArray());
             }
             // HNSW-first for a dense gate: keep HNSW scanning past ef_search.
-            ctx.execute("SET LOCAL hnsw.iterative_scan = 'relaxed_order'");
+            PgSession.setLocal(ctx, "hnsw.iterative_scan", "relaxed_order");
             String sql = "SELECT chash, chunk_text, collection, metadata::text AS metadata_json,"
                 + " (embedding <=> ?::vector) AS distance FROM " + table + gateSql
                 + " ORDER BY distance ASC, chash ASC LIMIT ?";
@@ -1534,7 +1554,7 @@ public final class PgVectorRepository {
     private List<Map<String, Object>> runCombinedQuery(
             String tenant, String sql, List<Object> binds) {
         Result<Record> result = tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute("SET LOCAL hnsw.iterative_scan = 'relaxed_order'");
+            PgSession.setLocal(ctx, "hnsw.iterative_scan", "relaxed_order");
             return ctx.fetch(sql, binds.toArray());
         });
         List<Map<String, Object>> rows = new ArrayList<>(result.size());
@@ -1557,7 +1577,7 @@ public final class PgVectorRepository {
     private List<Map<String, Object>> runCombinedQueryWithChash(
             String tenant, String sql, List<Object> binds) {
         Result<Record> result = tenantScope.withTenant(tenant, ctx -> {
-            ctx.execute("SET LOCAL hnsw.iterative_scan = 'relaxed_order'");
+            PgSession.setLocal(ctx, "hnsw.iterative_scan", "relaxed_order");
             return ctx.fetch(sql, binds.toArray());
         });
         List<Map<String, Object>> rows = new ArrayList<>(result.size());
@@ -1651,13 +1671,11 @@ public final class PgVectorRepository {
     public int delete(String tenant, String collection, List<String> ids) {
         int dim = dimForCollection(collection);
         if (ids == null || ids.isEmpty()) return 0;
-        List<Object> binds = new ArrayList<>();
-        binds.add(collection);
-        binds.addAll(ids);
+        DimTables.ChunkTable ch = DimTables.CHUNKS.get(dim);
         return tenantScope.withTenant(tenant, ctx ->
-            ctx.execute("DELETE FROM " + chunksTable(dim)
-                        + " WHERE collection = ? AND chash IN (" + placeholders(ids.size()) + ")",
-                        binds.toArray()));
+            ctx.deleteFrom(ch.table())
+               .where(ch.collection().eq(collection).and(ch.chash().in(ids)))
+               .execute());
     }
 
     /**
@@ -1693,13 +1711,15 @@ public final class PgVectorRepository {
                 "ids (" + ids.size() + ") and metadatas (" + metadatas.size()
                 + ") must be aligned");
         }
+        DimTables.ChunkTable ch = DimTables.CHUNKS.get(dim);
         tenantScope.withTenant(tenant, ctx -> {
             for (int i = 0; i < ids.size(); i++) {
-                ctx.execute("UPDATE " + chunksTable(dim)
-                            + " SET metadata = ?::jsonb WHERE collection = ? AND chash = ?",
-                            // Same NUL defense as upsertChunks: jsonb rejects NUL just
-                            // like text does (nexus-rvfwj, dual-review M2).
-                            toJson(sanitizeNulDeep(metadatas.get(i))), collection, ids.get(i));
+                ctx.update(ch.table())
+                   // Same NUL defense as upsertChunks: jsonb rejects NUL just
+                   // like text does (nexus-rvfwj, dual-review M2).
+                   .set(ch.metadata(), JSONB.jsonb(toJson(sanitizeNulDeep(metadatas.get(i)))))
+                   .where(ch.collection().eq(collection).and(ch.chash().eq(ids.get(i))))
+                   .execute();
             }
             return null;
         });

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -8,12 +8,19 @@ import dev.nexus.service.db.CollectionRegistry;
 import dev.nexus.service.db.PgSession;
 import dev.nexus.service.jooq.binding.Vector;
 import dev.nexus.service.db.TenantScope;
+import org.jooq.DSLContext;
 import org.jooq.JSONB;
 import org.jooq.Record;
 import org.jooq.Result;
 import org.jooq.impl.DSL;
 
 import static dev.nexus.service.jooq.nexus.Tables.CATALOG_COLLECTIONS;
+import static dev.nexus.service.jooq.nexus.Tables.CATALOG_DOCUMENTS;
+import static dev.nexus.service.jooq.nexus.Tables.CATALOG_DOCUMENT_CHUNKS;
+import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_1024;
+import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_384;
+import static dev.nexus.service.jooq.nexus.Tables.CHUNKS_768;
+import static dev.nexus.service.jooq.nexus.Tables.COLLECTION_VECTOR_STATS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -583,7 +590,6 @@ public final class PgVectorRepository {
                 + " (dim mismatch — no silent truncation)");
         }
 
-        String table = chunksTable(dim);
         String[] collSegs  = collection.split("__");
         boolean conformant = collSegs.length == 4;
 
@@ -591,11 +597,13 @@ public final class PgVectorRepository {
             // (3) full → reference-only guard: SELECT before INSERT.
             // Reads only chunk_text — safe against Phase-A schema (no retention column needed).
             // A previously-full chunk must never be silently NULLed (RDR-169 §Re-index PROHIBITS).
-            var existing = ctx.fetchOne(
-                "SELECT chunk_text FROM " + table
-                + " WHERE tenant_id = ? AND collection = ? AND chash = ?",
-                tenant, collection, chash);
-            if (existing != null && existing.get("chunk_text", String.class) != null) {
+            DimTables.ChunkTable existingCh = DimTables.CHUNKS.get(dim);
+            var existing = ctx.select(existingCh.chunkText()).from(existingCh.table())
+                              .where(existingCh.tenantId().eq(tenant)
+                                  .and(existingCh.collection().eq(collection))
+                                  .and(existingCh.chash().eq(chash)))
+                              .fetchOne();
+            if (existing != null && existing.value1() != null) {
                 throw new IllegalStateException(
                     "upsertReferenceOnlyChunk: chash '" + chash + "' in collection '"
                     + collection + "' already has full content (chunk_text IS NOT NULL). "
@@ -729,7 +737,7 @@ public final class PgVectorRepository {
             // collection + metadata predicates narrow the candidate set. SET LOCAL is
             // txn-scoped (same pool discipline as the TenantScope GUC stamp).
             PgSession.setLocal(ctx, "hnsw.iterative_scan", "relaxed_order");
-            return ctx.fetch(sql.toString(), binds.toArray());
+            return rawVectorFetch(ctx, sql.toString(), binds.toArray());
         });
 
         List<Map<String, Object>> rows = new ArrayList<>(result.size());
@@ -1003,8 +1011,8 @@ public final class PgVectorRepository {
             // do not. Pinned per-transaction so the gate is independent of cluster config.
             PgSession.setLocal(ctx, "pg_trgm.word_similarity_threshold", "0.6");
 
-            List<String> gateChashes = ctx.fetch(
-                "SELECT chash FROM " + table + gateSql + " LIMIT ?", probeBinds.toArray())
+            List<String> gateChashes = rawVectorFetch(
+                ctx, "SELECT chash FROM " + table + gateSql + " LIMIT ?", probeBinds.toArray())
                 .map(r -> r.get("chash", String.class));
 
             if (gateChashes.size() <= selectiveGateMax) {
@@ -1016,7 +1024,7 @@ public final class PgVectorRepository {
                 // chash with NO text gate, so the <% heap-recheck happens once, not twice.
                 if (gateChashes.isEmpty()) {
                     // Empty gate: typed-empty result (chash IN () is invalid SQL).
-                    return ctx.fetch(
+                    return rawVectorFetch(ctx,
                         "SELECT NULL::text AS chash, NULL::text AS chunk_text,"
                         + " NULL::text AS collection, NULL::text AS metadata_json,"
                         + " NULL::float8 AS distance WHERE false");
@@ -1037,7 +1045,7 @@ public final class PgVectorRepository {
                 b.addAll(scopeBinds);
                 b.addAll(inChashes);
                 b.add(nResults);
-                return ctx.fetch(sql, b.toArray());
+                return rawVectorFetch(ctx, sql, b.toArray());
             }
             // HNSW-first for a dense gate: keep HNSW scanning past ef_search.
             PgSession.setLocal(ctx, "hnsw.iterative_scan", "relaxed_order");
@@ -1048,7 +1056,7 @@ public final class PgVectorRepository {
             b.add(vecLit);
             b.addAll(gateBinds);
             b.add(nResults);
-            return ctx.fetch(sql, b.toArray());
+            return rawVectorFetch(ctx, sql, b.toArray());
         });
 
         List<Map<String, Object>> rows = new ArrayList<>(result.size());
@@ -1082,25 +1090,23 @@ public final class PgVectorRepository {
             return Map.of("ids", List.of(), "documents", List.of(), "metadatas", List.of());
         }
 
-        List<Object> binds = new ArrayList<>();
-        binds.add(collection);
-        binds.addAll(ids);
-        binds.add(limit);
-        binds.add(offset);
-        Result<Record> result = tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("SELECT chash, chunk_text, metadata::text AS metadata_json FROM "
-                      + chunksTable(dim)
-                      + " WHERE collection = ? AND chash IN (" + placeholders(ids.size()) + ")"
-                      + " ORDER BY chash ASC LIMIT ? OFFSET ?",
-                      binds.toArray()));
+        DimTables.ChunkTable ch = DimTables.CHUNKS.get(dim);
+        var result = tenantScope.withTenant(tenant, ctx ->
+            ctx.select(ch.chash(), ch.chunkText(), ch.metadata())
+               .from(ch.table())
+               .where(ch.collection().eq(collection).and(ch.chash().in(ids)))
+               .orderBy(ch.chash().asc())
+               .limit(limit).offset(offset)
+               .fetch());
 
         List<String> outIds = new ArrayList<>(result.size());
         List<String> outDocs = new ArrayList<>(result.size());
         List<Map<String, Object>> outMetas = new ArrayList<>(result.size());
-        for (Record rec : result) {
-            outIds.add(rec.get("chash", String.class));
-            outDocs.add(rec.get("chunk_text", String.class));
-            outMetas.add(fromJson(rec.get("metadata_json", String.class)));
+        for (var rec : result) {
+            outIds.add(rec.value1());
+            outDocs.add(rec.value2());
+            JSONB meta = rec.value3();
+            outMetas.add(fromJson(meta != null ? meta.data() : null));
         }
         // RDR-169 G5: surface address triple additively as parallel lists (source_uri opt-in)
         return enrichGetEnvelope(tenant,
@@ -1135,20 +1141,19 @@ public final class PgVectorRepository {
         if (ids == null || ids.isEmpty()) {
             return Map.of("ids", List.of(), "embeddings", List.of());
         }
-        List<Object> binds = new ArrayList<>();
-        binds.add(collection);
-        binds.addAll(ids);
-        Result<Record> result = tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("SELECT chash, embedding::text AS embedding_text FROM "
-                      + chunksTable(dim)
-                      + " WHERE collection = ? AND chash IN ("
-                      + placeholders(ids.size()) + ")",
-                      binds.toArray()));
+        DimTables.ChunkTable ch = DimTables.CHUNKS.get(dim);
+        var result = tenantScope.withTenant(tenant, ctx ->
+            ctx.select(ch.chash(), ch.embedding())
+               .from(ch.table())
+               .where(ch.collection().eq(collection).and(ch.chash().in(ids)))
+               .fetch());
 
         Map<String, List<Float>> byChash = new HashMap<>();
-        for (Record rec : result) {
-            byChash.put(rec.get("chash", String.class),
-                        parseVectorLiteral(rec.get("embedding_text", String.class)));
+        for (var rec : result) {
+            Vector v = rec.value2();
+            List<Float> floats = new ArrayList<>();
+            if (v != null) for (float f : v.floats()) floats.add(f);
+            byChash.put(rec.value1(), floats);
         }
         List<String> outIds = new ArrayList<>();
         List<List<Float>> outEmbeddings = new ArrayList<>();
@@ -1160,28 +1165,6 @@ public final class PgVectorRepository {
             }
         }
         return Map.of("ids", outIds, "embeddings", outEmbeddings);
-    }
-
-    /** Parse a pgvector text literal {@code "[0.1,0.2,...]"} into floats. */
-    private static List<Float> parseVectorLiteral(String literal) {
-        if (literal == null || literal.length() < 2) {
-            // Schema says NOT NULL; a null/short literal means a malformed
-            // row. Return an empty row — the Python caller's ndarray
-            // construction rejects the ragged shape and fails the
-            // collection's fetch (degrade, never misattribute).
-            log.warn("event=embedding_literal_malformed literal={}", literal);
-            return List.of();
-        }
-        String body = literal.substring(1, literal.length() - 1);
-        if (body.isBlank()) {
-            return List.of();
-        }
-        String[] parts = body.split(",");
-        List<Float> out = new ArrayList<>(parts.length);
-        for (String part : parts) {
-            out.add(Float.parseFloat(part.trim()));
-        }
-        return out;
     }
 
     /**
@@ -1237,31 +1220,30 @@ public final class PgVectorRepository {
                                         int limit, int offset,
                                         boolean includeSourceUri) {
         int dim = dimForCollection(collection);
-        StringBuilder sql = new StringBuilder()
-            .append("SELECT chash, chunk_text, metadata::text AS metadata_json FROM ")
-            .append(chunksTable(dim))
-            .append(" WHERE collection = ?");
-        List<Object> binds = new ArrayList<>();
-        binds.add(collection);
+        DimTables.ChunkTable ch = DimTables.CHUNKS.get(dim);
+        org.jooq.Condition cond = ch.collection().eq(collection);
         if (where != null) {
             for (Map.Entry<String, Object> e : where.entrySet()) {
-                appendWherePredicate(sql, binds, e.getKey(), e.getValue());
+                cond = cond.and(metadataCondition(e.getKey(), e.getValue()));
             }
         }
-        sql.append(" ORDER BY chash ASC LIMIT ? OFFSET ?");
-        binds.add(limit);
-        binds.add(offset);
-
-        Result<Record> result = tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch(sql.toString(), binds.toArray()));
+        org.jooq.Condition finalCond = cond;
+        var result = tenantScope.withTenant(tenant, ctx ->
+            ctx.select(ch.chash(), ch.chunkText(), ch.metadata())
+               .from(ch.table())
+               .where(finalCond)
+               .orderBy(ch.chash().asc())
+               .limit(limit).offset(offset)
+               .fetch());
 
         List<String> outIds = new ArrayList<>(result.size());
         List<String> outDocs = new ArrayList<>(result.size());
         List<Map<String, Object>> outMetas = new ArrayList<>(result.size());
-        for (Record rec : result) {
-            outIds.add(rec.get("chash", String.class));
-            outDocs.add(rec.get("chunk_text", String.class));
-            outMetas.add(fromJson(rec.get("metadata_json", String.class)));
+        for (var rec : result) {
+            outIds.add(rec.value1());
+            outDocs.add(rec.value2());
+            JSONB meta = rec.value3();
+            outMetas.add(fromJson(meta != null ? meta.data() : null));
         }
         // RDR-169 G5: surface address triple additively as parallel lists (source_uri opt-in)
         return enrichGetEnvelope(tenant,
@@ -1288,15 +1270,15 @@ public final class PgVectorRepository {
      * @return Chroma-style envelope {@code [{"name": ...}, ...]}, name ascending
      */
     public List<Map<String, Object>> listCollections(String tenant) {
-        Result<Record> result = tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("SELECT collection FROM ("
-                      + "  SELECT DISTINCT collection FROM nexus.chunks_384"
-                      + "  UNION SELECT DISTINCT collection FROM nexus.chunks_768"
-                      + "  UNION SELECT DISTINCT collection FROM nexus.chunks_1024"
-                      + ") cols ORDER BY collection ASC"));
-        List<Map<String, Object>> out = new ArrayList<>(result.size());
-        for (Record rec : result) {
-            out.add(Map.of("name", rec.get("collection", String.class)));
+        var names = tenantScope.withTenant(tenant, ctx ->
+            ctx.selectDistinct(CHUNKS_384.COLLECTION).from(CHUNKS_384)
+               .union(ctx.selectDistinct(CHUNKS_768.COLLECTION).from(CHUNKS_768))
+               .union(ctx.selectDistinct(CHUNKS_1024.COLLECTION).from(CHUNKS_1024))
+               .orderBy(1)
+               .fetch());
+        List<Map<String, Object>> out = new ArrayList<>(names.size());
+        for (var rec : names) {
+            out.add(Map.of("name", rec.value1()));
         }
         return out;
     }
@@ -1550,6 +1532,17 @@ public final class PgVectorRepository {
      * Execute a combined-query function call under the tenant RLS scope with the
      * filtered-ANN session setting, and map the (id, content, collection, distance)
      * rows to the flat search() envelope.
+     *
+     * <p>SANCTIONED RAW (nexus-mzuj9): {@code sql} is caller-built (one per combined-query
+     * family: metadata-scoped, graph-hop, topic-scoped) calling a per-dim stored function
+     * ({@code nexus.search_<kind>_scoped_<dim>(...)}). jOOQ codegen DOES emit typed
+     * table-valued-function wrappers for these (e.g. {@code SearchMetadataScoped_1024}) —
+     * unlike the {@link #hybridSearch}/{@link #searchWithTokens} case this is NOT a hard
+     * DSL-expressiveness wall, but converting it requires a dim-keyed dispatch map (mirroring
+     * {@link DimTables}) across 3 function families × 3 dims with parameter shapes
+     * (ARRAY[...]::text[] collection lists, ::jsonb where-maps) re-verified call-by-call
+     * against each caller. Flagged as a good follow-up mechanical conversion, deferred here
+     * for risk/effort — registered in {@code RawSqlGateTest}'s sanctioned method allowlist.
      */
     private List<Map<String, Object>> runCombinedQuery(
             String tenant, String sql, List<Object> binds) {
@@ -1573,6 +1566,9 @@ public final class PgVectorRepository {
      * Like {@link #runCombinedQuery} but also maps the matched chunk's {@code chash}
      * column (graph-hop, bead nexus-houg9). Kept separate because the metadata/topic
      * functions do not expose chash — {@code rec.get("chash", ...)} would throw there.
+     *
+     * <p>SANCTIONED RAW (nexus-mzuj9): same rationale as {@link #runCombinedQuery} — see
+     * that method's javadoc.
      */
     private List<Map<String, Object>> runCombinedQueryWithChash(
             String tenant, String sql, List<Object> binds) {
@@ -1613,17 +1609,19 @@ public final class PgVectorRepository {
      *         if null. Collections with zero live chunks do not appear.
      */
     public List<Map<String, Object>> collectionStats(String tenant) {
-        Result<Record> result = tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("SELECT collection, dim, chunk_count, last_write"
-                      + " FROM nexus.collection_vector_stats"
-                      + " ORDER BY collection ASC, dim ASC"));
+        var result = tenantScope.withTenant(tenant, ctx ->
+            ctx.select(COLLECTION_VECTOR_STATS.COLLECTION, COLLECTION_VECTOR_STATS.DIM,
+                       COLLECTION_VECTOR_STATS.CHUNK_COUNT, COLLECTION_VECTOR_STATS.LAST_WRITE)
+               .from(COLLECTION_VECTOR_STATS)
+               .orderBy(COLLECTION_VECTOR_STATS.COLLECTION.asc(), COLLECTION_VECTOR_STATS.DIM.asc())
+               .fetch());
         List<Map<String, Object>> out = new ArrayList<>(result.size());
-        for (Record rec : result) {
+        for (var rec : result) {
             Map<String, Object> row = new java.util.LinkedHashMap<>();
-            row.put("name",  rec.get("collection", String.class));
-            row.put("dim",   rec.get("dim", Integer.class));
-            row.put("count", rec.get("chunk_count", Long.class));
-            var lastWrite = rec.get("last_write", java.time.OffsetDateTime.class);
+            row.put("name",  rec.value1());
+            row.put("dim",   rec.value2());
+            row.put("count", rec.value3());
+            var lastWrite = rec.value4();
             if (lastWrite != null) {
                 row.put("last_write", lastWrite.toString());
             }
@@ -1640,16 +1638,21 @@ public final class PgVectorRepository {
     public Map<String, Object> list(String tenant, String collection,
                                     int limit, int offset) {
         int dim = dimForCollection(collection);
-        Result<Record> result = tenantScope.withTenant(tenant, ctx ->
-            ctx.fetch("SELECT chash, metadata::text AS metadata_json FROM " + chunksTable(dim)
-                      + " WHERE collection = ? ORDER BY chash ASC LIMIT ? OFFSET ?",
-                      collection, limit, offset));
+        DimTables.ChunkTable ch = DimTables.CHUNKS.get(dim);
+        var result = tenantScope.withTenant(tenant, ctx ->
+            ctx.select(ch.chash(), ch.metadata())
+               .from(ch.table())
+               .where(ch.collection().eq(collection))
+               .orderBy(ch.chash().asc())
+               .limit(limit).offset(offset)
+               .fetch());
 
         List<String> outIds = new ArrayList<>(result.size());
         List<Map<String, Object>> outMetas = new ArrayList<>(result.size());
-        for (Record rec : result) {
-            outIds.add(rec.get("chash", String.class));
-            outMetas.add(fromJson(rec.get("metadata_json", String.class)));
+        for (var rec : result) {
+            outIds.add(rec.value1());
+            JSONB meta = rec.value2();
+            outMetas.add(fromJson(meta != null ? meta.data() : null));
         }
         return Map.of("ids", outIds, "metadatas", outMetas);
     }
@@ -1683,10 +1686,9 @@ public final class PgVectorRepository {
      */
     public int count(String tenant, String collection) {
         int dim = dimForCollection(collection);
+        DimTables.ChunkTable ch = DimTables.CHUNKS.get(dim);
         long c = tenantScope.withTenant(tenant, ctx ->
-            ctx.fetchOne("SELECT count(*) FROM " + chunksTable(dim) + " WHERE collection = ?",
-                         collection)
-               .get(0, Long.class));
+            (long) ctx.fetchCount(ch.table(), ch.collection().eq(collection)));
         // PG count(*) is bigint; refuse to wrap rather than silently narrow.
         if (c > Integer.MAX_VALUE) {
             throw new IllegalStateException("count overflow for collection '" + collection
@@ -1748,17 +1750,22 @@ public final class PgVectorRepository {
         return tenantScope.withTenant(tenant, ctx -> {
             // 1. The document must be visible under RLS. A foreign tenant's tumbler is
             //    indistinguishable from an unknown one (no existence leak).
-            Record doc = ctx.fetchOne(
-                "SELECT 1 FROM nexus.catalog_documents WHERE tumbler = ?", tumbler);
+            Integer doc = ctx.select(DSL.one()).from(CATALOG_DOCUMENTS)
+                             .where(CATALOG_DOCUMENTS.TUMBLER.eq(tumbler))
+                             .fetchOne(0, Integer.class);
             if (doc == null) {
                 throw new IllegalStateException(
                     "tumbler '" + tumbler + "' does not resolve to a visible catalog document");
             }
 
             // 2. Manifest rows in position order.
-            Result<Record> manifest = ctx.fetch(
-                "SELECT position, chash, collection FROM nexus.catalog_document_chunks"
-                + " WHERE doc_id = ? ORDER BY position ASC", tumbler);
+            var manifest = ctx.select(CATALOG_DOCUMENT_CHUNKS.POSITION,
+                                      CATALOG_DOCUMENT_CHUNKS.CHASH,
+                                      CATALOG_DOCUMENT_CHUNKS.COLLECTION)
+                              .from(CATALOG_DOCUMENT_CHUNKS)
+                              .where(CATALOG_DOCUMENT_CHUNKS.DOC_ID.eq(tumbler))
+                              .orderBy(CATALOG_DOCUMENT_CHUNKS.POSITION.asc())
+                              .fetch();
             if (manifest.isEmpty()) {
                 return List.of();
             }
@@ -1766,55 +1773,52 @@ public final class PgVectorRepository {
             // 3. Resolve chunk text per collection group (each collection dispatches to
             //    its own chunks_<dim> table).
             Map<String, Set<String>> chashesByCollection = new LinkedHashMap<>();
-            for (Record m : manifest) {
-                String col = m.get("collection", String.class);
+            for (var m : manifest) {
+                String col = m.value3();
                 if (col == null || col.isBlank()) {
                     throw new IllegalStateException(
                         "manifest row for doc '" + tumbler + "' position "
-                        + m.get("position", Integer.class)
+                        + m.value1()
                         + " has no collection - cannot dispatch to a chunks_<dim> table"
                         + " (pre-migration manifest rows are resolved by the Phase 5 ETL)");
                 }
                 chashesByCollection.computeIfAbsent(col, k -> new LinkedHashSet<>())
-                                   .add(m.get("chash", String.class));
+                                   .add(m.value2());
             }
 
             Map<String, Map<String, String>> textByColThenChash = new HashMap<>();
             for (Map.Entry<String, Set<String>> e : chashesByCollection.entrySet()) {
                 String col = e.getKey();
                 int dim = dimForCollection(col);
-                List<Object> binds = new ArrayList<>();
-                binds.add(col);
-                binds.addAll(e.getValue());
-                Result<Record> chunks = ctx.fetch(
-                    "SELECT chash, chunk_text FROM " + chunksTable(dim)
-                    + " WHERE collection = ? AND chash IN (" + placeholders(e.getValue().size()) + ")",
-                    binds.toArray());
+                DimTables.ChunkTable ch = DimTables.CHUNKS.get(dim);
+                var chunks = ctx.select(ch.chash(), ch.chunkText()).from(ch.table())
+                                .where(ch.collection().eq(col).and(ch.chash().in(e.getValue())))
+                                .fetch();
                 Map<String, String> byChash =
                     textByColThenChash.computeIfAbsent(col, k -> new HashMap<>());
-                for (Record c : chunks) {
-                    byChash.put(c.get("chash", String.class),
-                                c.get("chunk_text", String.class));
+                for (var c : chunks) {
+                    byChash.put(c.value1(), c.value2());
                 }
             }
 
             // 4. Walk the manifest in position order; any unresolved (collection, chash)
             //    fails loud - never a silently partial document.
             List<Map<String, Object>> rows = new ArrayList<>(manifest.size());
-            for (Record m : manifest) {
-                String col   = m.get("collection", String.class);
-                String chash = m.get("chash", String.class);
+            for (var m : manifest) {
+                Integer position = m.value1();
+                String chash     = m.value2();
+                String col       = m.value3();
                 Map<String, String> byChash = textByColThenChash.get(col);
                 String text  = byChash != null ? byChash.get(chash) : null;
                 if (text == null) {
                     throw new IllegalStateException(
                         "manifest row for doc '" + tumbler + "' position "
-                        + m.get("position", Integer.class) + " references (" + col + ", "
+                        + position + " references (" + col + ", "
                         + chash + ") which has no chunk row - refusing to return a"
                         + " partial document (application-enforced referential check)");
                 }
                 Map<String, Object> row = new LinkedHashMap<>();
-                row.put("position",   m.get("position", Integer.class));
+                row.put("position",   position);
                 row.put("chash",      chash);
                 row.put("chunk_text", text);
                 row.put("collection", col);
@@ -1846,19 +1850,39 @@ public final class PgVectorRepository {
      */
     public String fetchChunkText(String tenant, String collection, String chash) {
         int dim = dimForCollection(collection);
-        return tenantScope.withTenant(tenant, ctx -> {
-            Record row = ctx.fetchOne(
-                "SELECT chunk_text FROM " + chunksTable(dim)
-                + " WHERE collection = ? AND chash = ?",
-                collection, chash);
-            return row != null ? row.get("chunk_text", String.class) : null;
-        });
+        DimTables.ChunkTable ch = DimTables.CHUNKS.get(dim);
+        return tenantScope.withTenant(tenant, ctx ->
+            ctx.select(ch.chunkText()).from(ch.table())
+               .where(ch.collection().eq(collection).and(ch.chash().eq(chash)))
+               .fetchOne(ch.chunkText()));
     }
 
     // -- Internal helpers -------------------------------------------------------
 
     private static String chunksTable(int dim) {
         return "nexus.chunks_" + dim;
+    }
+
+    /**
+     * SANCTIONED RAW (nexus-mzuj9): the single execution chokepoint for every genuinely
+     * raw-SQL fetch left in this class after the fetch-side jOOQ conversion sweep. Callers
+     * ({@link #searchWithTokens} and {@link #hybridSearch}) build the SQL text because it
+     * combines things jOOQ's typed DSL cannot express together in one statement: the
+     * pgvector {@code <=>} distance operator ordering directly off a bind-parameter vector
+     * literal, the {@code pg_trgm} {@code <%} similarity operator, a per-call dynamic-arity
+     * {@code WHERE} (an arbitrary count of caller-supplied metadata predicates plus an
+     * IN-list sized to the collection/chash set), and — for {@code hybridSearch} — a
+     * selectivity-dependent PLAN CHOICE (materialize-then-rank vs. HNSW-first) made in Java
+     * between two structurally different follow-up queries. Rewriting this as nested DSL
+     * would either lose the operator-level control the selectivity dispatch depends on or
+     * require a bespoke dynamic-condition builder whose behavior would need to be
+     * re-verified bit-for-bit against the existing (well-tested) selectivity contract —
+     * not a safe mechanical transform. Registered in {@code RawSqlGateTest}'s sanctioned
+     * method allowlist; this is the ONLY place in the class where a caller-built raw SQL
+     * string reaches {@code ctx.fetch}.
+     */
+    private static Result<Record> rawVectorFetch(DSLContext ctx, String sql, Object... binds) {
+        return ctx.fetch(sql, binds);
     }
 
     /** Strip NUL (0x00) — unstorable in Postgres {@code text}/{@code jsonb} (nexus-rvfwj). */
@@ -2010,6 +2034,56 @@ public final class PgVectorRepository {
         }
     }
 
+    /**
+     * Typed jOOQ sibling of {@link #appendWherePredicate} (nexus-mzuj9): same Chroma
+     * operator-subset ({@code $eq}/{@code $ne}/{@code $in}/{@code $nin}, plain-scalar
+     * shorthand for {@code $eq}), expressed as a {@link org.jooq.Condition} via a
+     * {@code metadata ->> {0}} DSL.field template (bind placeholder, not string
+     * concatenation) instead of hand-built SQL text. Used by the plain-equality
+     * {@link #getWhere} path, which has no vector/trigram operator to entangle with.
+     */
+    static org.jooq.Condition metadataCondition(String key, Object value) {
+        if (key.startsWith("$")) {
+            throw new IllegalArgumentException(
+                "compound where operator '" + key + "' is not supported on the vector "
+                + "bridge; express each field as its own predicate (all fields are ANDed)");
+        }
+        org.jooq.Field<String> mv = DSL.field("metadata ->> {0}", String.class, key);
+        if (!(value instanceof Map<?, ?> ops)) {
+            return mv.eq(String.valueOf(value));
+        }
+        if (ops.size() != 1) {
+            throw new IllegalArgumentException(
+                "where operator map for field '" + key + "' must hold exactly one operator, got "
+                + ops.keySet());
+        }
+        Map.Entry<?, ?> op = ops.entrySet().iterator().next();
+        String operator = String.valueOf(op.getKey());
+        Object operand = op.getValue();
+        return switch (operator) {
+            case "$eq" -> mv.eq(String.valueOf(operand));
+            case "$ne" -> mv.isDistinctFrom(String.valueOf(operand));
+            case "$in", "$nin" -> {
+                if (!(operand instanceof List<?> items)) {
+                    throw new IllegalArgumentException(
+                        operator + " for field '" + key + "' expects a list operand, got "
+                        + (operand == null ? "null" : operand.getClass().getSimpleName()));
+                }
+                if (items.isEmpty()) {
+                    // $in [] matches nothing; $nin [] excludes nothing.
+                    yield "$in".equals(operator) ? DSL.falseCondition() : DSL.trueCondition();
+                }
+                List<String> strItems = items.stream().map(String::valueOf).toList();
+                yield "$in".equals(operator)
+                    ? mv.in(strItems)
+                    : mv.isNull().or(mv.notIn(strItems));
+            }
+            default -> throw new IllegalArgumentException(
+                "unsupported where operator '" + operator + "' for field '" + key
+                + "'; supported: $eq, $ne, $in, $nin");
+        };
+    }
+
     private static String toJson(Map<String, Object> metadata) {
         Map<String, Object> m = metadata != null ? metadata : Map.of();
         try {
@@ -2054,23 +2128,19 @@ public final class PgVectorRepository {
             // adds defense-in-depth on the catalog_documents side (fix #H2).
             // Note: last-writer-wins when a chash appears in multiple catalog_document_chunks
             // rows (shared chunk text across documents) — non-determinism accepted for now.
-            String sql = "SELECT cdc.chash, d.source_uri"
-                       + " FROM nexus.catalog_document_chunks cdc"
-                       + " JOIN nexus.catalog_documents d"
-                       + "   ON d.tumbler = cdc.doc_id AND d.tenant_id = ?"
-                       + " WHERE cdc.tenant_id = ?"
-                       + " AND cdc.chash IN (" + placeholders(batch.size()) + ")";
-            List<Object> binds = new ArrayList<>();
-            binds.add(tenant);   // d.tenant_id
-            binds.add(tenant);   // cdc.tenant_id
-            binds.addAll(batch);
+            var result = tenantScope.withTenant(tenant, ctx ->
+                ctx.select(CATALOG_DOCUMENT_CHUNKS.CHASH, CATALOG_DOCUMENTS.SOURCE_URI)
+                   .from(CATALOG_DOCUMENT_CHUNKS)
+                   .join(CATALOG_DOCUMENTS)
+                   .on(CATALOG_DOCUMENTS.TUMBLER.eq(CATALOG_DOCUMENT_CHUNKS.DOC_ID)
+                       .and(CATALOG_DOCUMENTS.TENANT_ID.eq(tenant)))
+                   .where(CATALOG_DOCUMENT_CHUNKS.TENANT_ID.eq(tenant)
+                       .and(CATALOG_DOCUMENT_CHUNKS.CHASH.in(batch)))
+                   .fetch());
 
-            Result<Record> result = tenantScope.withTenant(tenant, ctx ->
-                ctx.fetch(sql, binds.toArray()));
-
-            for (Record rec : result) {
-                String chash     = rec.get("chash",      String.class);
-                String sourceUri = rec.get("source_uri", String.class);
+            for (var rec : result) {
+                String chash     = rec.value1();
+                String sourceUri = rec.value2();
                 if (chash != null) out.put(chash, sourceUri);
             }
         }

--- a/service/src/main/java/dev/nexus/service/vectors/TaxonomyCentroidRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/TaxonomyCentroidRepository.java
@@ -125,6 +125,10 @@ public final class TaxonomyCentroidRepository {
             throw new IllegalArgumentException("nResults must be >= 1, got " + nResults);
         }
         String op = crossCollection ? "<>" : "=";
+        // SANCTIONED RAW (nexus-mzuj9): the pgvector `<=>` distance operator ordered directly
+        // off a bind-parameter vector literal has no jOOQ DSL form (same category as
+        // PgVectorRepository's search()/hybridSearch() — see that class's rawVectorFetch
+        // javadoc). Registered in RawSqlGateTest's sanctioned method allowlist.
         Result<Record> result = tenantScope.withTenant(tenant, ctx -> {
             // Filtered-ANN recall: the collection predicate + RLS narrow the candidate set;
             // keep HNSW scanning past ef_search so a narrow collection returns its full set
@@ -153,12 +157,10 @@ public final class TaxonomyCentroidRepository {
         long total = tenantScope.withTenant(tenant, ctx -> {
             long sum = 0;
             for (int dim : DIMS) {
-                String sql = "SELECT count(*) FROM " + centroidTable(dim)
-                    + (collection != null ? " WHERE collection = ?" : "");
-                Record rec = collection != null
-                    ? ctx.fetchOne(sql, collection)
-                    : ctx.fetchOne(sql);
-                sum += rec.get(0, Long.class);
+                DimTables.CentroidTable ct = DimTables.CENTROIDS.get(dim);
+                sum += collection != null
+                    ? ctx.fetchCount(ct.table(), ct.collection().eq(collection))
+                    : ctx.fetchCount(ct.table());
             }
             return sum;
         });
@@ -188,8 +190,8 @@ public final class TaxonomyCentroidRepository {
     public int dimensionProbe(String tenant) {
         return tenantScope.withTenant(tenant, ctx -> {
             for (int dim : DIMS) {
-                Record rec = ctx.fetchOne("SELECT 1 FROM " + centroidTable(dim) + " LIMIT 1");
-                if (rec != null) return dim;
+                DimTables.CentroidTable ct = DimTables.CENTROIDS.get(dim);
+                if (ctx.fetchExists(ct.table())) return dim;
             }
             return -1;
         });
@@ -201,7 +203,7 @@ public final class TaxonomyCentroidRepository {
      * shape the rebuild/project paths index into.
      */
     public List<CentroidRecord> getByCollection(String tenant, String collection) {
-        return fetchCentroids(tenant, "collection = ?", collection);
+        return fetchCentroids(tenant, ct -> ct.collection().eq(collection));
     }
 
     /**
@@ -219,27 +221,31 @@ public final class TaxonomyCentroidRepository {
      * embedding is hydrated like {@link #getByCollection}.
      */
     public List<CentroidRecord> getForeignCentroids(String tenant, String collection) {
-        return fetchCentroids(tenant, "collection <> ?", collection);
+        return fetchCentroids(tenant, ct -> ct.collection().ne(collection));
     }
 
-    /** Shared per-dim centroid fetch with a parameterized collection predicate. */
-    private List<CentroidRecord> fetchCentroids(String tenant, String collectionPredicate,
-                                                String collection) {
+    /** Shared per-dim centroid fetch with a typed collection predicate. */
+    private List<CentroidRecord> fetchCentroids(
+            String tenant,
+            java.util.function.Function<DimTables.CentroidTable, org.jooq.Condition> predicate) {
         return tenantScope.withTenant(tenant, ctx -> {
             List<CentroidRecord> out = new ArrayList<>();
             for (int dim : DIMS) {
-                Result<Record> rows = ctx.fetch(
-                    "SELECT collection, topic_id, embedding::text AS embedding_text, label, doc_count FROM "
-                    + centroidTable(dim) + " WHERE " + collectionPredicate
-                    + " ORDER BY collection ASC, topic_id ASC",
-                    collection);
-                for (Record rec : rows) {
+                DimTables.CentroidTable ct = DimTables.CENTROIDS.get(dim);
+                var rows = ctx.select(ct.collection(), ct.topicId(), ct.embedding(),
+                                      ct.label(), ct.docCount())
+                              .from(ct.table())
+                              .where(predicate.apply(ct))
+                              .orderBy(ct.collection().asc(), ct.topicId().asc())
+                              .fetch();
+                for (var rec : rows) {
+                    Vector v = rec.value3();
                     out.add(new CentroidRecord(
-                        rec.get("collection", String.class),
-                        rec.get("topic_id", Long.class),
-                        parseVectorLiteral(rec.get("embedding_text", String.class)),
-                        rec.get("label", String.class),
-                        rec.get("doc_count", Integer.class)));
+                        rec.value1(),
+                        rec.value2(),
+                        v != null ? v.floats() : new float[0],
+                        rec.value4(),
+                        rec.value5()));
                 }
             }
             return out;
@@ -301,27 +307,4 @@ public final class TaxonomyCentroidRepository {
         return sb.append(']').toString();
     }
 
-    /** Parse a pgvector text literal {@code "[0.1,0.2,...]"} into a float array. */
-    private static float[] parseVectorLiteral(String literal) {
-        if (literal == null || literal.length() < 2) {
-            // Schema says NOT NULL; a null/short literal means a malformed row.
-            throw new IllegalStateException("malformed centroid embedding literal: " + literal);
-        }
-        String body = literal.substring(1, literal.length() - 1);
-        if (body.isBlank()) return new float[0];
-        String[] parts = body.split(",");
-        float[] out = new float[parts.length];
-        for (int i = 0; i < parts.length; i++) {
-            out[i] = Float.parseFloat(parts[i].trim());
-        }
-        return out;
-    }
-
-    /** {@code IN}-list placeholder string: {@code ?,?,...} (n >= 1). */
-    private static String placeholders(int n) {
-        if (n <= 0) {
-            throw new IllegalArgumentException("placeholders requires n >= 1, got " + n);
-        }
-        return String.join(",", java.util.Collections.nCopies(n, "?"));
-    }
 }

--- a/service/src/main/java/dev/nexus/service/vectors/TaxonomyCentroidRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/TaxonomyCentroidRepository.java
@@ -2,8 +2,11 @@
 // Copyright (c) 2026 Hal Hildebrand. All rights reserved.
 package dev.nexus.service.vectors;
 
+import dev.nexus.service.db.PgSession;
+import dev.nexus.service.jooq.binding.Vector;
 import dev.nexus.service.db.TenantScope;
 import org.jooq.Record;
+import org.jooq.impl.DSL;
 import org.jooq.Result;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,17 +84,18 @@ public final class TaxonomyCentroidRepository {
         }
         tenantScope.withTenant(tenant, ctx -> {
             for (CentroidRecord r : records) {
-                String table = centroidTable(r.embedding().length);
-                ctx.execute(
-                    "INSERT INTO " + table
-                    + " (tenant_id, collection, topic_id, embedding, label, doc_count)"
-                    + " VALUES (?, ?, ?, ?::vector, ?, ?)"
-                    + " ON CONFLICT (tenant_id, collection, topic_id) DO UPDATE SET"
-                    + "   embedding = EXCLUDED.embedding,"
-                    + "   label     = EXCLUDED.label,"
-                    + "   doc_count = EXCLUDED.doc_count",
-                    tenant, r.collection(), r.topicId(), vectorLiteral(r.embedding()),
-                    r.label(), r.docCount());
+                DimTables.CentroidTable ct = DimTables.CENTROIDS.get(r.embedding().length);
+                ctx.insertInto(ct.table())
+                   .columns(ct.tenantId(), ct.collection(), ct.topicId(),
+                            ct.embedding(), ct.label(), ct.docCount())
+                   .values(tenant, r.collection(), r.topicId(),
+                           Vector.of(r.embedding()), r.label(), r.docCount())
+                   .onConflict(ct.tenantId(), ct.collection(), ct.topicId())
+                   .doUpdate()
+                   .set(ct.embedding(), DSL.excluded(ct.embedding()))
+                   .set(ct.label(),     DSL.excluded(ct.label()))
+                   .set(ct.docCount(),  DSL.excluded(ct.docCount()))
+                   .execute();
             }
             return null;
         });
@@ -126,7 +130,7 @@ public final class TaxonomyCentroidRepository {
             // keep HNSW scanning past ef_search so a narrow collection returns its full set
             // (RDR-156 — without this, filtered HNSW silently under-returns). SET LOCAL is
             // txn-scoped, same pool discipline as the TenantScope GUC stamp.
-            ctx.execute("SET LOCAL hnsw.iterative_scan = 'relaxed_order'");
+            PgSession.setLocal(ctx, "hnsw.iterative_scan", "relaxed_order");
             return ctx.fetch(
                 "SELECT topic_id, (embedding <=> ?::vector) AS distance FROM " + centroidTable(dim)
                 + " WHERE collection " + op + " ?"
@@ -253,13 +257,11 @@ public final class TaxonomyCentroidRepository {
         return tenantScope.withTenant(tenant, ctx -> {
             int deleted = 0;
             for (int dim : DIMS) {
-                List<Object> binds = new ArrayList<>();
-                binds.add(collection);
-                binds.addAll(topicIds);
-                deleted += ctx.execute(
-                    "DELETE FROM " + centroidTable(dim)
-                    + " WHERE collection = ? AND topic_id IN (" + placeholders(topicIds.size()) + ")",
-                    binds.toArray());
+                DimTables.CentroidTable ct = DimTables.CENTROIDS.get(dim);
+                deleted += ctx.deleteFrom(ct.table())
+                              .where(ct.collection().eq(collection)
+                                  .and(ct.topicId().in(topicIds)))
+                              .execute();
             }
             return deleted;
         });
@@ -274,8 +276,10 @@ public final class TaxonomyCentroidRepository {
         return tenantScope.withTenant(tenant, ctx -> {
             int deleted = 0;
             for (int dim : DIMS) {
-                deleted += ctx.execute(
-                    "DELETE FROM " + centroidTable(dim) + " WHERE collection = ?", collection);
+                DimTables.CentroidTable ct = DimTables.CENTROIDS.get(dim);
+                deleted += ctx.deleteFrom(ct.table())
+                              .where(ct.collection().eq(collection))
+                              .execute();
             }
             return deleted;
         });

--- a/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/AspectRepositoryTest.java
@@ -138,7 +138,9 @@ class AspectRepositoryTest {
                     "hl-rename-doc-1", "hl-rename-doc-2", "hl-rls-doc",
                     "q-doc-1", "done-doc-id-unique", "etl-q-doc",
                     // nexus-1usso importHighlightsBatch multi-row conversion tests
-                    "batch-hl-1", "batch-hl-2")) {
+                    "batch-hl-1", "batch-hl-2",
+                    // nexus-nyout doc_id COALESCE-on-NULL tests
+                    "coalesce-doc-1", "coalesce-doc-2")) {
                 su.createStatement().execute(
                     "INSERT INTO nexus.catalog_documents (tenant_id, tumbler, title) " +
                     "VALUES ('" + TENANT_A + "', '" + tumbler + "', 'Test fixture: " + tumbler + "') " +
@@ -529,6 +531,73 @@ class AspectRepositoryTest {
         // Now we must be able to claim it again
         Optional<Map<String, Object>> reclaimed = repo.claimNext(TENANT_A);
         assertThat(reclaimed).as("re-enqueued row must be claimable again").isPresent();
+    }
+
+    @Test @Order(70)
+    void enqueue_blankDocIdReEnqueue_preservesExistingLinkage() {
+        // nexus-nyout: a doc_id-less re-enqueue (collection re-embed passes
+        // catalog_doc_id="" across multi-doc batches; nullIfBlank -> NULL)
+        // must NOT amnesia an existing correct tumbler — same document,
+        // same queue key, identity survives.
+        var body = new java.util.LinkedHashMap<String, Object>();
+        body.put("collection",  "coalesce-coll");
+        body.put("source_path", "coalesce.md");
+        body.put("doc_id",      "coalesce-doc-1");
+        repo.enqueue(TENANT_A, body);
+
+        var blank = new java.util.LinkedHashMap<String, Object>();
+        blank.put("collection",  "coalesce-coll");
+        blank.put("source_path", "coalesce.md");
+        blank.put("doc_id",      "");  // nullIfBlank -> NULL
+        repo.enqueue(TENANT_A, blank);
+
+        Map<String, Object> row = repo.listPending(TENANT_A, 100).stream()
+            .filter(r -> "coalesce.md".equals(r.get("source_path")))
+            .findFirst().orElseThrow();
+        assertThat(row.get("doc_id"))
+            .as("blank re-enqueue must preserve the existing doc_id linkage")
+            .isEqualTo("coalesce-doc-1");
+    }
+
+    @Test @Order(71)
+    void enqueue_realDocIdReEnqueue_stillOverwrites() {
+        var body = new java.util.LinkedHashMap<String, Object>();
+        body.put("collection",  "coalesce-coll");
+        body.put("source_path", "coalesce-overwrite.md");
+        body.put("doc_id",      "coalesce-doc-1");
+        repo.enqueue(TENANT_A, body);
+
+        var newer = new java.util.LinkedHashMap<String, Object>();
+        newer.put("collection",  "coalesce-coll");
+        newer.put("source_path", "coalesce-overwrite.md");
+        newer.put("doc_id",      "coalesce-doc-2");
+        repo.enqueue(TENANT_A, newer);
+
+        Map<String, Object> row = repo.listPending(TENANT_A, 100).stream()
+            .filter(r -> "coalesce-overwrite.md".equals(r.get("source_path")))
+            .findFirst().orElseThrow();
+        assertThat(row.get("doc_id"))
+            .as("a real tumbler on re-enqueue still overwrites")
+            .isEqualTo("coalesce-doc-2");
+    }
+
+    @Test @Order(72)
+    void enqueue_freshBlankDocId_staysNull() {
+        var body = new java.util.LinkedHashMap<String, Object>();
+        body.put("collection",  "coalesce-coll");
+        body.put("source_path", "coalesce-fresh.md");
+        body.put("doc_id",      "");
+        repo.enqueue(TENANT_A, body);
+
+        Map<String, Object> row = repo.listPending(TENANT_A, 100).stream()
+            .filter(r -> "coalesce-fresh.md".equals(r.get("source_path")))
+            .findFirst().orElseThrow();
+        // Stored as NULL (the composite FK would reject a literal ''), and
+        // the read path normalizes NULL -> "" per the QueueRow contract
+        // ("empty doc_id = fall back to source_path").
+        assertThat(row.get("doc_id"))
+            .as("fresh blank enqueue reads back as the empty-doc_id sentinel")
+            .isEqualTo("");
     }
 
     @Test @Order(32)

--- a/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
@@ -307,6 +307,39 @@ class CatalogRepositoryTest {
         assertThat(metaUpdated).isEqualTo(1);
     }
 
+    @Test @Order(12)
+    @SuppressWarnings("unchecked")
+    void document_updateMeta_mergesLikeLocalCatalog() {
+        // nexus-ke45f: local Catalog.update() MERGES meta (dict.update —
+        // add/overwrite keys, never remove); the wire did a bare
+        // SET metadata=<new>, so every service-mode writer.update(meta=...)
+        // silently dropped pre-existing keys (miss_count, content_hash, ...).
+        repo.upsertDocument(TENANT_A, Map.of(
+            "tumbler", "2.15",
+            "title", "Merge Target",
+            "content_type", "paper",
+            "metadata", Map.of("content_hash", "keepme", "miss_count", 1)
+        ));
+
+        int n = repo.updateDocument(
+            TENANT_A, "2.15", Map.of("meta", Map.of("bib_checked", true)));
+        assertThat(n).isEqualTo(1);
+
+        var doc = repo.getDocument(TENANT_A, "2.15");
+        Map<String, Object> meta = (Map<String, Object>) doc.get("metadata");
+        assertThat(meta.get("content_hash"))
+            .as("pre-existing key survives a merge update").isEqualTo("keepme");
+        assertThat(meta.get("miss_count")).isEqualTo(1);
+        assertThat(meta.get("bib_checked")).isEqualTo(true);
+
+        // Overwrite semantics: an incoming key replaces the old value.
+        repo.updateDocument(TENANT_A, "2.15", Map.of("meta", Map.of("miss_count", 0)));
+        var doc2 = repo.getDocument(TENANT_A, "2.15");
+        Map<String, Object> meta2 = (Map<String, Object>) doc2.get("metadata");
+        assertThat(meta2.get("miss_count")).isEqualTo(0);
+        assertThat(meta2.get("content_hash")).isEqualTo("keepme");
+    }
+
     @Test @Order(13)
     void document_update_rejectsNonWhitelistedColumns() {
         // Wave review (SQL audit CRITICAL): request JSON keys become SET targets —

--- a/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
@@ -2360,6 +2360,68 @@ class CatalogRepositoryTest {
     }
 
     // ══════════════════════════════════════════════════════════════════════════
+    // CHUNK RESOLUTION (nexus-gc2ze)
+    // ══════════════════════════════════════════════════════════════════════════
+    // Mirrors the local Catalog._DocumentOps.resolve_chunk contract
+    // (catalog_docs.py): chunks are implicit addresses derived from a
+    // document's chunk_count, not their own catalog rows. resolveChunk()
+    // is a pure lookup + range-check over an existing document row (no new
+    // SQL — it delegates to getDocument()).
+
+    private static final String CHUNK_DOC_TUMBLER = "9.9.101";
+
+    @Test @Order(215)
+    void resolveChunk_returnsDocumentAndChunkMetadata() {
+        repo.upsertDocument(TENANT_A, mapOf(
+            "tumbler", CHUNK_DOC_TUMBLER,
+            "title", "Chunk Resolution Doc",
+            "content_type", "code",
+            "corpus", "code",
+            "physical_collection", "code__nexus__voyage-code-3__v1",
+            "chunk_count", 3
+        ));
+        var result = repo.resolveChunk(TENANT_A, CHUNK_DOC_TUMBLER, 1);
+        assertThat(result).isNotNull();
+        assertThat(result.get("document_tumbler")).isEqualTo(CHUNK_DOC_TUMBLER);
+        assertThat(result.get("chunk_index")).isEqualTo(1);
+        assertThat(result.get("physical_collection")).isEqualTo("code__nexus__voyage-code-3__v1");
+        assertThat(result.get("title")).isEqualTo("Chunk Resolution Doc");
+        assertThat(result.get("content_type")).isEqualTo("code");
+    }
+
+    @Test @Order(216)
+    void resolveChunk_outOfRangeIndex_returnsNull() {
+        // chunk_count=3 seeded in Order 215 -> valid indices are 0, 1, 2.
+        var result = repo.resolveChunk(TENANT_A, CHUNK_DOC_TUMBLER, 3);
+        assertThat(result).isNull();
+    }
+
+    @Test @Order(217)
+    void resolveChunk_missingDocument_returnsNull() {
+        var result = repo.resolveChunk(TENANT_A, "9.9.999", 0);
+        assertThat(result).isNull();
+    }
+
+    @Test @Order(218)
+    void resolveChunk_zeroChunkCount_skipsBoundsCheck() {
+        // chunk_count=0 (unset/unknown): the local Python contract skips the
+        // bounds check entirely in this case (catalog_docs.py: "chunk_count
+        // of 0 or None means count is not yet known") — a large chunk index
+        // must still resolve rather than being rejected as out-of-range.
+        final String tumbler = "9.9.102";
+        repo.upsertDocument(TENANT_A, mapOf(
+            "tumbler", tumbler,
+            "title", "Unknown Chunk Count Doc",
+            "content_type", "code",
+            "corpus", "code",
+            "physical_collection", "code__nexus__voyage-code-3__v1"
+        ));
+        var result = repo.resolveChunk(TENANT_A, tumbler, 999);
+        assertThat(result).isNotNull();
+        assertThat(result.get("chunk_index")).isEqualTo(999);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
     // importXBatch: ONE multi-row INSERT per method (nexus-1usso)
     // ══════════════════════════════════════════════════════════════════════════
     // Plan-audit correction: these endpoints already existed but their repository

--- a/service/src/test/java/dev/nexus/service/db/CatalogTsOrNullTest.java
+++ b/service/src/test/java/dev/nexus/service/db/CatalogTsOrNullTest.java
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * nexus-xtmtf review finding: {@code CatalogRepository.tsOrNull} replaced
+ * the {@code ?::timestamptz} cast in the fidelity-import/supersede paths
+ * and its javadoc claims the same lenient input shapes — but no test
+ * exercised ANY of them, and the date-only shape (which the PG cast
+ * accepted as midnight) originally threw uncaught. Pure unit test — no DB.
+ */
+class CatalogTsOrNullTest {
+
+    @Test
+    void blankAndNull_areNull() {
+        assertThat(CatalogRepository.tsOrNull(null)).isNull();
+        assertThat(CatalogRepository.tsOrNull("")).isNull();
+        assertThat(CatalogRepository.tsOrNull("   ")).isNull();
+    }
+
+    @Test
+    void fullIso_parses() {
+        assertThat(CatalogRepository.tsOrNull("2026-05-01T12:30:45.123456+00:00"))
+            .isEqualTo(OffsetDateTime.of(2026, 5, 1, 12, 30, 45, 123_456_000, ZoneOffset.UTC));
+        assertThat(CatalogRepository.tsOrNull("2026-05-01T12:30:45Z"))
+            .isEqualTo(OffsetDateTime.of(2026, 5, 1, 12, 30, 45, 0, ZoneOffset.UTC));
+    }
+
+    @Test
+    void spaceSeparated_legacySqliteShape_parses() {
+        assertThat(CatalogRepository.tsOrNull("2026-05-01 12:30:45+00:00"))
+            .isEqualTo(OffsetDateTime.of(2026, 5, 1, 12, 30, 45, 0, ZoneOffset.UTC));
+    }
+
+    @Test
+    void offsetless_resolvesAsUtc() {
+        assertThat(CatalogRepository.tsOrNull("2026-05-01 12:30:45"))
+            .isEqualTo(OffsetDateTime.of(2026, 5, 1, 12, 30, 45, 0, ZoneOffset.UTC));
+        assertThat(CatalogRepository.tsOrNull("2026-05-01T12:30:45"))
+            .isEqualTo(OffsetDateTime.of(2026, 5, 1, 12, 30, 45, 0, ZoneOffset.UTC));
+    }
+
+    @Test
+    void bareHourOffset_parses() {
+        // PG accepts "+00" (no minutes); java.time's lenient offset parser does too.
+        assertThat(CatalogRepository.tsOrNull("2026-05-01T12:30:45+00"))
+            .isEqualTo(OffsetDateTime.of(2026, 5, 1, 12, 30, 45, 0, ZoneOffset.UTC));
+    }
+
+    @Test
+    void dateOnly_isMidnightUtc_matchingTheRetiredPgCast() {
+        assertThat(CatalogRepository.tsOrNull("2026-05-01"))
+            .isEqualTo(OffsetDateTime.of(2026, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+    }
+
+    @Test
+    void garbage_failsLoud() {
+        // The PG cast errored on garbage too — never substitute now().
+        assertThatThrownBy(() -> CatalogRepository.tsOrNull("not-a-timestamp"))
+            .isInstanceOf(java.time.format.DateTimeParseException.class);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/db/RawSqlGateTest.java
+++ b/service/src/test/java/dev/nexus/service/db/RawSqlGateTest.java
@@ -69,14 +69,6 @@ class RawSqlGateTest {
         + "|\\.resultQuery\\(\\s*\")",
         Pattern.DOTALL);
 
-    /** Method-declaration scanner: modifier-led, 4-space-indented top-level
-     * method signatures. Deliberately simple (not a full Java parser) —
-     * matches this codebase's consistent formatting; the reluctant prefix
-     * quantifier stops at the first identifier immediately followed by
-     * {@code (}, which is always the method name in valid Java (no
-     * modifier/type keyword is itself followed directly by a paren here). */
-    private static final Pattern METHOD_DECL = Pattern.compile(
-        "(?m)^ {4}(?:public|private|protected)(?:\\s+\\w+)*\\s+[\\w<>\\[\\],.\\s]+?\\b(\\w+)\\s*\\(");
 
     /**
      * Method-scoped escape hatch (nexus-mzuj9): {@code file.java -> {sanctioned method
@@ -106,6 +98,112 @@ class RawSqlGateTest {
             "fetchShowConfig")
     );
 
+    /** Length-preserving blank-out of comment bodies and string/char literal
+     * CONTENTS (delimiters kept): offsets and line numbers stay identical to
+     * the original source, brace counting cannot be confused by braces inside
+     * strings or comments, and the raw-SQL pattern still fires on the kept
+     * opening quote. */
+    static String blank(String src) {
+        char[] out = src.toCharArray();
+        int i = 0;
+        while (i < out.length) {
+            char c = out[i];
+            if (c == '/' && i + 1 < out.length && out[i + 1] == '*') {
+                int end = src.indexOf("*/", i + 2);
+                end = (end < 0) ? out.length : end + 2;
+                for (int j = i; j < end; j++) if (out[j] != '\n') out[j] = ' ';
+                i = end;
+            } else if (c == '/' && i + 1 < out.length && out[i + 1] == '/') {
+                while (i < out.length && out[i] != '\n') out[i++] = ' ';
+            } else if (c == '"' || c == '\'') {
+                char q = c;
+                i++;
+                while (i < out.length && out[i] != q) {
+                    if (out[i] != '\n') out[i] = ' ';
+                    if (src.charAt(i) == '\\' && i + 1 < out.length) {
+                        i++;
+                        if (out[i] != '\n') out[i] = ' ';
+                    }
+                    i++;
+                }
+                i++;  // closing quote kept
+            } else {
+                i++;
+            }
+        }
+        return new String(out);
+    }
+
+    /** [start, end) body regions of each sanctioned method in *blanked*
+     * source: find ``name(`` where the preceding char is not ``.``/ident
+     * (a receiver call or longer name), paren-match the signature, require
+     * a following ``{``, brace-match the body. Brace-depth truth instead of
+     * declaration regexes — nexus-8kbzu: one regex heuristic mis-attributed
+     * nested-class and package-private shapes, the widened one matched call
+     * sites; neither class of error is possible here. */
+    static List<int[]> sanctionedRegions(String blanked, java.util.Set<String> names) {
+        List<int[]> regions = new ArrayList<>();
+        for (String name : names) {
+            Matcher m = Pattern.compile("\\b" + Pattern.quote(name) + "\\s*\\(").matcher(blanked);
+            while (m.find()) {
+                int before = m.start() - 1;
+                if (before >= 0 && (blanked.charAt(before) == '.'
+                        || Character.isJavaIdentifierPart(blanked.charAt(before)))) {
+                    continue;
+                }
+                int i = blanked.indexOf('(', m.start());
+                int depth = 0;
+                while (i < blanked.length()) {
+                    char c = blanked.charAt(i);
+                    if (c == '(') depth++;
+                    else if (c == ')' && --depth == 0) break;
+                    i++;
+                }
+                if (i >= blanked.length()) continue;
+                int j = i + 1;
+                while (j < blanked.length() && (Character.isWhitespace(blanked.charAt(j))
+                        || Character.isJavaIdentifierPart(blanked.charAt(j))
+                        || blanked.charAt(j) == ',')) {
+                    j++;
+                }
+                if (j >= blanked.length() || blanked.charAt(j) != '{') continue;
+                int braces = 0;
+                int k = j;
+                while (k < blanked.length()) {
+                    char c = blanked.charAt(k);
+                    if (c == '{') braces++;
+                    else if (c == '}' && --braces == 0) break;
+                    k++;
+                }
+                regions.add(new int[] {j, Math.min(k + 1, blanked.length())});
+            }
+        }
+        return regions;
+    }
+
+    /** Per-file scan: blank comments/strings -> newline-tolerant raw-SQL
+     * pattern -> brace-region sanction filter. Extracted so the nexus-8kbzu
+     * adversarial meta-tests exercise the excusal logic against synthetic
+     * sources, not just the pattern against the current tree. */
+    static List<String> scan(String fileName, String rawSource) {
+        String blanked = blank(rawSource);
+        List<int[]> regions = sanctionedRegions(
+            blanked, SANCTIONED_METHODS.getOrDefault(fileName, java.util.Set.of()));
+
+        List<String> violations = new ArrayList<>();
+        var m = RAW_EXECUTE.matcher(blanked);
+        while (m.find()) {
+            int at = m.start();
+            boolean excused = regions.stream()
+                .anyMatch(r -> r[0] <= at && at < r[1]);
+            if (excused) continue;
+            int line = 1 + (int) blanked.substring(0, at).chars()
+                .filter(c -> c == '\n').count();
+            violations.add(fileName + ":" + line + "  " + m.group().strip());
+        }
+        return violations;
+    }
+
     @Test
     void noRawExecuteSqlInMainSources() throws IOException {
         Path root = Path.of("src", "main", "java");
@@ -115,46 +213,8 @@ class RawSqlGateTest {
         try (Stream<Path> files = Files.walk(root)) {
             files.filter(p -> p.toString().endsWith(".java")).forEach(p -> {
                 try {
-                    String fileName = p.getFileName().toString();
-                    java.util.Set<String> sanctioned =
-                        SANCTIONED_METHODS.getOrDefault(fileName, java.util.Set.of());
-
-                    // Strip comments FIRST (block + line), then scan the whole
-                    // remaining source with a newline-tolerant pattern — a
-                    // line break after ".execute(" no longer evades the gate.
-                    String src = Files.readString(p)
-                        .replaceAll("(?s)/\\*.*?\\*/", "")
-                        .replaceAll("(?m)//.*$", "");
-
-                    // Pre-index every top-level method declaration's start offset + name,
-                    // in source order, so each violation can be attributed to its nearest
-                    // enclosing method (Java methods never nest, so "last declaration
-                    // before the violation offset" is always the correct enclosing method).
-                    List<int[]> declOffsets = new ArrayList<>();
-                    List<String> declNames = new ArrayList<>();
-                    Matcher dm = METHOD_DECL.matcher(src);
-                    while (dm.find()) {
-                        declOffsets.add(new int[] {dm.start()});
-                        declNames.add(dm.group(1));
-                    }
-
-                    var m = RAW_EXECUTE.matcher(src);
-                    while (m.find()) {
-                        String enclosing = null;
-                        for (int i = declOffsets.size() - 1; i >= 0; i--) {
-                            if (declOffsets.get(i)[0] <= m.start()) {
-                                enclosing = declNames.get(i);
-                                break;
-                            }
-                        }
-                        if (enclosing != null && sanctioned.contains(enclosing)) {
-                            continue;
-                        }
-                        int line = 1 + (int) src.substring(0, m.start()).chars()
-                            .filter(c -> c == '\n').count();
-                        violations.add(p + ":" + line + "  " + m.group().strip()
-                            + (enclosing != null ? "  [in " + enclosing + "]" : ""));
-                    }
+                    violations.addAll(scan(
+                        p.getFileName().toString(), Files.readString(p)));
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -168,5 +228,60 @@ class RawSqlGateTest {
                 + "hoist into a named method and add it to RawSqlGateTest's "
                 + "SANCTIONED_METHODS with a // SANCTIONED RAW comment")
             .isEmpty();
+    }
+
+    // ── nexus-8kbzu: the gate's own attribution logic under adversarial shapes ──
+
+    /** A violation inside a NESTED class positioned after a sanctioned
+     * method must still be flagged — it attributes to the nested method
+     * (never sanctioned), not to the preceding sanctioned declaration. */
+    @Test
+    void attribution_nestedClassAfterSanctionedMethod_isStillFlagged() {
+        String synthetic = String.join("\n",
+            "public final class PgVectorRepository {",
+            "    private void rawVectorFetch() {",
+            "        ctx.fetch(\"SELECT sanctioned\");",
+            "    }",
+            "    static class Sneaky {",
+            "        void hide() {",
+            "            ctx.execute(\"DROP TABLE evil\");",
+            "        }",
+            "    }",
+            "}");
+        // Violation text is blanked (string contents erased by design);
+        // assert on the location: line 7 is the nested-class execute call.
+        List<String> hits = scan("PgVectorRepository.java", synthetic);
+        assertThat(hits)
+            .as("nested-class violation must not inherit the sanction")
+            .anySatisfy(h -> assertThat(h).startsWith("PgVectorRepository.java:7"));
+    }
+
+    /** Package-private (no-modifier) methods are declaration boundaries too. */
+    @Test
+    void attribution_packagePrivateMethod_resetsSanction() {
+        String synthetic = String.join("\n",
+            "public final class TaxonomyCentroidRepository {",
+            "    private void annQuery() {",
+            "        ctx.fetch(\"SELECT sanctioned\");",
+            "    }",
+            "    void plainMethod() {",
+            "        ctx.execute(\"DELETE FROM x\");",
+            "    }",
+            "}");
+        List<String> hits = scan("TaxonomyCentroidRepository.java", synthetic);
+        assertThat(hits)
+            .anySatisfy(h -> assertThat(h).startsWith("TaxonomyCentroidRepository.java:6"));
+    }
+
+    /** Sanctioned methods themselves stay excused. */
+    @Test
+    void attribution_sanctionedMethodViolation_isExcused() {
+        String synthetic = String.join("\n",
+            "public final class PoolerModeCheck {",
+            "    private void fetchShowConfig() {",
+            "        ctx.fetch(\"SHOW CONFIG\");",
+            "    }",
+            "}");
+        assertThat(scan("PoolerModeCheck.java", synthetic)).isEmpty();
     }
 }

--- a/service/src/test/java/dev/nexus/service/db/RawSqlGateTest.java
+++ b/service/src/test/java/dev/nexus/service/db/RawSqlGateTest.java
@@ -29,11 +29,32 @@ import java.util.stream.Stream;
  */
 class RawSqlGateTest {
 
-    /** {@code <receiver>.execute("...")} or {@code .execute(sqlVar, ...)} —
-     * the string-SQL overloads. A bare {@code .execute()} (jOOQ DSL terminal)
-     * does not match. */
+    /** String-SQL execution shapes, matched across line breaks (review
+     * finding: the per-line scan was evadable by a newline after the
+     * paren). Covers {@code .execute("...")}, {@code .execute(sql...)},
+     * {@code .execute(new StringBuilder...)}, {@code ctx.query("...")}
+     * (jOOQ's raw-SQL query builder), and JDBC
+     * {@code executeQuery("...")/executeUpdate("...")}. A bare
+     * {@code .execute()} (jOOQ DSL terminal) does not match.
+     *
+     * KNOWN RESIDUAL (accepted, documented per critique): a raw SQL
+     * string bound to a variable NOT prefixed "sql" and passed to
+     * .execute(var) evades the name heuristic — jOOQ's legitimate
+     * .execute(Query) overload makes a match-any-identifier rule
+     * false-positive on typed DSL usage, so the heuristic stays
+     * name-based. The three pre-existing bootstrap JDBC sites
+     * (HealthHandler, VersionHandler, PoolerModeCheck) run before/
+     * outside the jOOQ context and are whitelisted below. */
     private static final Pattern RAW_EXECUTE = Pattern.compile(
-        "\\.execute\\(\\s*(\"|sql|new StringBuilder)");
+        "(\\.execute\\(\\s*(\"|sql|SQL|new StringBuilder)"
+        + "|\\.query\\(\\s*\""
+        + "|\\.execute(Query|Update)\\(\\s*\")",
+        Pattern.DOTALL);
+
+    /** Bootstrap/health JDBC sites that predate jOOQ context availability. */
+    private static final java.util.Set<String> JDBC_BOOTSTRAP_WHITELIST =
+        java.util.Set.of(
+            "HealthHandler.java", "VersionHandler.java", "PoolerModeCheck.java");
 
     @Test
     void noRawExecuteSqlInMainSources() throws IOException {
@@ -44,17 +65,20 @@ class RawSqlGateTest {
         try (Stream<Path> files = Files.walk(root)) {
             files.filter(p -> p.toString().endsWith(".java")).forEach(p -> {
                 try {
-                    List<String> lines = Files.readAllLines(p);
-                    for (int i = 0; i < lines.size(); i++) {
-                        String line = lines.get(i);
-                        String trimmed = line.trim();
-                        if (trimmed.startsWith("//") || trimmed.startsWith("*")
-                                || trimmed.startsWith("/*")) {
-                            continue;  // comments may cite the forbidden form
-                        }
-                        if (RAW_EXECUTE.matcher(line).find()) {
-                            violations.add(p + ":" + (i + 1) + "  " + trimmed);
-                        }
+                    if (JDBC_BOOTSTRAP_WHITELIST.contains(p.getFileName().toString())) {
+                        return;
+                    }
+                    // Strip comments FIRST (block + line), then scan the whole
+                    // remaining source with a newline-tolerant pattern — a
+                    // line break after ".execute(" no longer evades the gate.
+                    String src = Files.readString(p)
+                        .replaceAll("(?s)/\\*.*?\\*/", "")
+                        .replaceAll("(?m)//.*$", "");
+                    var m = RAW_EXECUTE.matcher(src);
+                    while (m.find()) {
+                        int line = 1 + (int) src.substring(0, m.start()).chars()
+                            .filter(c -> c == '\n').count();
+                        violations.add(p + ":" + line + "  " + m.group().strip());
                     }
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/service/src/test/java/dev/nexus/service/db/RawSqlGateTest.java
+++ b/service/src/test/java/dev/nexus/service/db/RawSqlGateTest.java
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * House-rule gate (nexus-xtmtf): no raw string-SQL through
+ * {@code ctx.execute(...)} anywhere in {@code service/src/main}. jOOQ
+ * generates the DSL for these schemas; write paths use it, full stop.
+ * Transaction-local GUCs route through {@link PgSession#setLocal} (itself
+ * pure DSL via {@code set_config}); the pgvector/dynamic-dim tables route
+ * through {@code DimTables}; timestamptz binds are typed OffsetDateTime.
+ *
+ * <p>Scope: statement EXECUTION only. Read-side {@code ctx.fetch("...")}
+ * raw SQL (vector search, stats views, UNION-ALL reads) is inventoried on
+ * the nexus-h8rf6 audit and converted separately — widening this gate to
+ * fetch requires that conversion first.
+ */
+class RawSqlGateTest {
+
+    /** {@code <receiver>.execute("...")} or {@code .execute(sqlVar, ...)} —
+     * the string-SQL overloads. A bare {@code .execute()} (jOOQ DSL terminal)
+     * does not match. */
+    private static final Pattern RAW_EXECUTE = Pattern.compile(
+        "\\.execute\\(\\s*(\"|sql|new StringBuilder)");
+
+    @Test
+    void noRawExecuteSqlInMainSources() throws IOException {
+        Path root = Path.of("src", "main", "java");
+        assertThat(root).exists();
+
+        List<String> violations = new ArrayList<>();
+        try (Stream<Path> files = Files.walk(root)) {
+            files.filter(p -> p.toString().endsWith(".java")).forEach(p -> {
+                try {
+                    List<String> lines = Files.readAllLines(p);
+                    for (int i = 0; i < lines.size(); i++) {
+                        String line = lines.get(i);
+                        String trimmed = line.trim();
+                        if (trimmed.startsWith("//") || trimmed.startsWith("*")
+                                || trimmed.startsWith("/*")) {
+                            continue;  // comments may cite the forbidden form
+                        }
+                        if (RAW_EXECUTE.matcher(line).find()) {
+                            violations.add(p + ":" + (i + 1) + "  " + trimmed);
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        assertThat(violations)
+            .as("raw string-SQL execute() calls in src/main — use the jOOQ DSL "
+                + "(PgSession.setLocal for GUCs, DimTables for per-dim tables, "
+                + "typed OffsetDateTime binds for timestamptz)")
+            .isEmpty();
+    }
+}

--- a/service/src/test/java/dev/nexus/service/db/RawSqlGateTest.java
+++ b/service/src/test/java/dev/nexus/service/db/RawSqlGateTest.java
@@ -11,50 +11,100 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
- * House-rule gate (nexus-xtmtf): no raw string-SQL through
- * {@code ctx.execute(...)} anywhere in {@code service/src/main}. jOOQ
- * generates the DSL for these schemas; write paths use it, full stop.
- * Transaction-local GUCs route through {@link PgSession#setLocal} (itself
- * pure DSL via {@code set_config}); the pgvector/dynamic-dim tables route
- * through {@code DimTables}; timestamptz binds are typed OffsetDateTime.
+ * House-rule gate (nexus-xtmtf, widened by nexus-mzuj9): NO raw string-SQL
+ * ANYWHERE in {@code service/src/main} — neither statement EXECUTION
+ * ({@code ctx.execute(...)}, JDBC {@code executeQuery}/{@code executeUpdate})
+ * NOR read-side FETCH ({@code ctx.fetch("...")}, {@code ctx.fetchOne("...")},
+ * {@code ctx.fetchAny("...")}, {@code ctx.resultQuery(...)}). jOOQ generates
+ * the DSL for these schemas; every call site uses it, full stop — this is a
+ * house rule (Hal, 2026-07-03/04), not a style preference.
  *
- * <p>Scope: statement EXECUTION only. Read-side {@code ctx.fetch("...")}
- * raw SQL (vector search, stats views, UNION-ALL reads) is inventoried on
- * the nexus-h8rf6 audit and converted separately — widening this gate to
- * fetch requires that conversion first.
+ * <p>The bootstrap-JDBC file-level whitelist that predated this bead is
+ * GONE: {@code HealthHandler}/{@code VersionHandler}/{@code PoolerModeCheck}
+ * now route their reads through {@code DSL.using(connection)} like every
+ * other call site (nexus-mzuj9 phase (c)).
+ *
+ * <p>The ONLY remaining escape is the SANCTIONED_METHODS allowlist below —
+ * method-scoped, not file-scoped. A handful of read sites genuinely cannot
+ * be expressed as typed jOOQ DSL (the pgvector {@code <=>} distance operator
+ * ordered directly off a bind-parameter vector literal combined with a
+ * dynamic-arity {@code WHERE}; a PgBouncer admin-console meta-command with
+ * no fixed column set). Each sanctioned method carries a
+ * {@code // SANCTIONED RAW (nexus-mzuj9): <why>} comment at its definition
+ * site (auditable, not silent) and is named here explicitly.
  */
 class RawSqlGateTest {
 
-    /** String-SQL execution shapes, matched across line breaks (review
+    /** String-SQL execution AND fetch shapes, matched across line breaks (review
      * finding: the per-line scan was evadable by a newline after the
      * paren). Covers {@code .execute("...")}, {@code .execute(sql...)},
      * {@code .execute(new StringBuilder...)}, {@code ctx.query("...")}
-     * (jOOQ's raw-SQL query builder), and JDBC
-     * {@code executeQuery("...")/executeUpdate("...")}. A bare
-     * {@code .execute()} (jOOQ DSL terminal) does not match.
+     * (jOOQ's raw-SQL query builder), JDBC
+     * {@code executeQuery("...")/executeUpdate("...")}, and the fetch-side
+     * siblings {@code .fetch("...")/.fetch(sql...)},
+     * {@code .fetchOne("...")/.fetchOne(sql...)},
+     * {@code .fetchAny("...")/.fetchAny(sql...)}, {@code .resultQuery("...")}.
+     * A bare {@code .execute()}/{@code .fetch()}/{@code .fetchOne()} (jOOQ DSL
+     * terminal, no string/variable argument) does not match.
      *
      * KNOWN RESIDUAL (accepted, documented per critique): a raw SQL
      * string bound to a variable NOT prefixed "sql" and passed to
-     * .execute(var) evades the name heuristic — jOOQ's legitimate
-     * .execute(Query) overload makes a match-any-identifier rule
-     * false-positive on typed DSL usage, so the heuristic stays
-     * name-based. The three pre-existing bootstrap JDBC sites
-     * (HealthHandler, VersionHandler, PoolerModeCheck) run before/
-     * outside the jOOQ context and are whitelisted below. */
+     * .execute(var)/.fetch(var) evades the name heuristic — jOOQ's legitimate
+     * .execute(Query)/.fetch(Field...) overloads make a match-any-identifier
+     * rule false-positive on typed DSL usage, so the heuristic stays
+     * name-based. */
     private static final Pattern RAW_EXECUTE = Pattern.compile(
         "(\\.execute\\(\\s*(\"|sql|SQL|new StringBuilder)"
         + "|\\.query\\(\\s*\""
-        + "|\\.execute(Query|Update)\\(\\s*\")",
+        + "|\\.execute(Query|Update)\\(\\s*\""
+        + "|\\.fetch\\(\\s*(\"|sql|SQL|new StringBuilder)"
+        + "|\\.fetchOne\\(\\s*(\"|sql|SQL|new StringBuilder)"
+        + "|\\.fetchAny\\(\\s*(\"|sql|SQL|new StringBuilder)"
+        + "|\\.resultQuery\\(\\s*\")",
         Pattern.DOTALL);
 
-    /** Bootstrap/health JDBC sites that predate jOOQ context availability. */
-    private static final java.util.Set<String> JDBC_BOOTSTRAP_WHITELIST =
-        java.util.Set.of(
-            "HealthHandler.java", "VersionHandler.java", "PoolerModeCheck.java");
+    /** Method-declaration scanner: modifier-led, 4-space-indented top-level
+     * method signatures. Deliberately simple (not a full Java parser) —
+     * matches this codebase's consistent formatting; the reluctant prefix
+     * quantifier stops at the first identifier immediately followed by
+     * {@code (}, which is always the method name in valid Java (no
+     * modifier/type keyword is itself followed directly by a paren here). */
+    private static final Pattern METHOD_DECL = Pattern.compile(
+        "(?m)^ {4}(?:public|private|protected)(?:\\s+\\w+)*\\s+[\\w<>\\[\\],.\\s]+?\\b(\\w+)\\s*\\(");
+
+    /**
+     * Method-scoped escape hatch (nexus-mzuj9): {@code file.java -> {sanctioned method
+     * names}}. Each entry's definition site carries a
+     * {@code // SANCTIONED RAW (nexus-mzuj9): <why>} comment explaining why jOOQ's typed
+     * DSL cannot express that specific site — see the referenced classes.
+     */
+    private static final Map<String, java.util.Set<String>> SANCTIONED_METHODS = Map.of(
+        "PgVectorRepository.java", java.util.Set.of(
+            // pgvector `<=>` ordered off a bind-parameter vector literal, combined with a
+            // dynamic-arity metadata WHERE and (hybridSearch) a selectivity-dependent plan
+            // choice between structurally different queries — the single execution
+            // chokepoint for search()/hybridSearch().
+            "rawVectorFetch",
+            // nexus.search_<kind>_scoped_<dim>(...) combined-query stored-function calls
+            // (metadata-scoped / graph-hop / topic-scoped); per-dim generated table-valued-
+            // function wrappers exist but a full dispatch-map conversion is deferred
+            // (risk/effort, not a hard DSL wall — see the method javadoc).
+            "runCombinedQuery",
+            "runCombinedQueryWithChash"),
+        "TaxonomyCentroidRepository.java", java.util.Set.of(
+            // Same pgvector `<=>` category as PgVectorRepository.rawVectorFetch.
+            "annQuery"),
+        "PoolerModeCheck.java", java.util.Set.of(
+            // `SHOW CONFIG` is a PgBouncer admin-console meta-command, not SQL against any
+            // table/schema — no jOOQ DSL form exists (no bind params, no fixed column set).
+            "fetchShowConfig")
+    );
 
     @Test
     void noRawExecuteSqlInMainSources() throws IOException {
@@ -65,20 +115,45 @@ class RawSqlGateTest {
         try (Stream<Path> files = Files.walk(root)) {
             files.filter(p -> p.toString().endsWith(".java")).forEach(p -> {
                 try {
-                    if (JDBC_BOOTSTRAP_WHITELIST.contains(p.getFileName().toString())) {
-                        return;
-                    }
+                    String fileName = p.getFileName().toString();
+                    java.util.Set<String> sanctioned =
+                        SANCTIONED_METHODS.getOrDefault(fileName, java.util.Set.of());
+
                     // Strip comments FIRST (block + line), then scan the whole
                     // remaining source with a newline-tolerant pattern — a
                     // line break after ".execute(" no longer evades the gate.
                     String src = Files.readString(p)
                         .replaceAll("(?s)/\\*.*?\\*/", "")
                         .replaceAll("(?m)//.*$", "");
+
+                    // Pre-index every top-level method declaration's start offset + name,
+                    // in source order, so each violation can be attributed to its nearest
+                    // enclosing method (Java methods never nest, so "last declaration
+                    // before the violation offset" is always the correct enclosing method).
+                    List<int[]> declOffsets = new ArrayList<>();
+                    List<String> declNames = new ArrayList<>();
+                    Matcher dm = METHOD_DECL.matcher(src);
+                    while (dm.find()) {
+                        declOffsets.add(new int[] {dm.start()});
+                        declNames.add(dm.group(1));
+                    }
+
                     var m = RAW_EXECUTE.matcher(src);
                     while (m.find()) {
+                        String enclosing = null;
+                        for (int i = declOffsets.size() - 1; i >= 0; i--) {
+                            if (declOffsets.get(i)[0] <= m.start()) {
+                                enclosing = declNames.get(i);
+                                break;
+                            }
+                        }
+                        if (enclosing != null && sanctioned.contains(enclosing)) {
+                            continue;
+                        }
                         int line = 1 + (int) src.substring(0, m.start()).chars()
                             .filter(c -> c == '\n').count();
-                        violations.add(p + ":" + line + "  " + m.group().strip());
+                        violations.add(p + ":" + line + "  " + m.group().strip()
+                            + (enclosing != null ? "  [in " + enclosing + "]" : ""));
                     }
                 } catch (IOException e) {
                     throw new RuntimeException(e);
@@ -87,9 +162,11 @@ class RawSqlGateTest {
         }
 
         assertThat(violations)
-            .as("raw string-SQL execute() calls in src/main — use the jOOQ DSL "
+            .as("raw string-SQL execute()/fetch() calls in src/main — use the jOOQ DSL "
                 + "(PgSession.setLocal for GUCs, DimTables for per-dim tables, "
-                + "typed OffsetDateTime binds for timestamptz)")
+                + "typed OffsetDateTime binds for timestamptz); if genuinely unavoidable, "
+                + "hoist into a named method and add it to RawSqlGateTest's "
+                + "SANCTIONED_METHODS with a // SANCTIONED RAW comment")
             .isEmpty();
     }
 }

--- a/service/src/test/java/dev/nexus/service/jooq/binding/VectorRoundTripTest.java
+++ b/service/src/test/java/dev/nexus/service/jooq/binding/VectorRoundTripTest.java
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service.jooq.binding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * nexus-xtmtf review finding: {@link VectorBinding}'s READ path
+ * ({@link Vector#parse}) had zero direct coverage — every production use
+ * of the typed embedding field is write-side, so a parse bug would only
+ * surface when a future caller wires the field into a SELECT. Pin the
+ * text-form round-trip explicitly, including the scientific-notation and
+ * edge-magnitude forms PG's float4 text output can produce.
+ */
+class VectorRoundTripTest {
+
+    @Test
+    void toString_parse_roundTripsExactly() {
+        float[] v = {1.5f, -2.25f, 0f, 3.14159f};
+        Vector out = Vector.parse(Vector.of(v).toString());
+        assertThat(out.floats()).containsExactly(v);
+    }
+
+    @Test
+    void parse_scientificNotation_fromPgFloat4Text() {
+        // PG float4 text output uses forms like 1e-05 / -3.4028235e+38.
+        Vector out = Vector.parse("[1e-05,-3.4028235e+38,3.4028235e+38]");
+        assertThat(out.floats()).containsExactly(1e-05f, -Float.MAX_VALUE, Float.MAX_VALUE);
+    }
+
+    @Test
+    void parse_toleratesWhitespace() {
+        assertThat(Vector.parse(" [1.0, 2.0 ,3.0] ").floats())
+            .containsExactly(1.0f, 2.0f, 3.0f);
+    }
+
+    @Test
+    void parse_empty_isZeroLength() {
+        assertThat(Vector.parse("[]").floats()).isEmpty();
+    }
+
+    @Test
+    void of_null_isNull() {
+        assertThat(Vector.of(null)).isNull();
+    }
+
+    @Test
+    void equals_isValueBased() {
+        assertThat(Vector.of(new float[]{1f, 2f}))
+            .isEqualTo(Vector.of(new float[]{1f, 2f}))
+            .isNotEqualTo(Vector.of(new float[]{1f, 3f}));
+    }
+
+    @Test
+    void roundTrip_preservesFloatPrecisionAtEdges() {
+        float[] edge = {Float.MIN_VALUE, Float.MIN_NORMAL, 1.0000001f, -0.0f};
+        assertThat(Vector.parse(Vector.of(edge).toString()).floats())
+            .containsExactly(edge);
+    }
+}

--- a/service/src/test/java/dev/nexus/service/vectors/ReferenceOnlySqlShapeTest.java
+++ b/service/src/test/java/dev/nexus/service/vectors/ReferenceOnlySqlShapeTest.java
@@ -4,42 +4,52 @@ package dev.nexus.service.vectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.conf.ParamType;
+import org.jooq.impl.DSL;
 import org.junit.jupiter.api.Test;
 
 /**
- * Phase-A SQL-shape test for {@link PgVectorRepository#referenceOnlyInsertSql}
- * (RDR-169 G4, nexus-xvb6b).
+ * Phase-A SQL-shape test for
+ * {@link PgVectorRepository#referenceOnlyInsertQuery} (RDR-169 G4,
+ * nexus-xvb6b; DSL form since nexus-xtmtf).
  *
  * <p>In the same package as {@link PgVectorRepository} so it can access the
- * package-private {@code referenceOnlyInsertSql} method.  Pure unit test — no
- * DB, no Testcontainers.  Asserts the INSERT SQL fragment is correctly formed
- * (NULL chunk_text, retention column present, chunk_text absent from DO UPDATE)
- * without executing it against the live schema (the {@code retention} column
- * does not exist until Phase B / nexus-dtnpu).
+ * package-private builder. Pure unit test — no DB, no Testcontainers: renders
+ * the jOOQ query against the POSTGRES dialect and asserts the SQL fragment is
+ * correctly formed (NULL chunk_text, retention column present, chunk_text
+ * absent from DO UPDATE) without executing it against the live schema (the
+ * {@code retention} column does not exist until Phase B / nexus-dtnpu).
  */
 class ReferenceOnlySqlShapeTest {
 
     @Test
-    void referenceOnlyInsertSql_hasNullChunkTextAndRetentionColumn() {
-        String sql = PgVectorRepository.referenceOnlyInsertSql("nexus.chunks_1024");
+    void referenceOnlyInsertQuery_hasNullChunkTextAndRetentionColumn() {
+        DSLContext ctx = DSL.using(SQLDialect.POSTGRES);
+        String sql = PgVectorRepository.referenceOnlyInsertQuery(
+                ctx, 1024, "t", "code__x__voyage-code-3__v1", "chash0000",
+                new float[1024], "{}")
+            .getSQL(ParamType.INLINED)
+            .toLowerCase();
 
         assertThat(sql)
-            .as("INSERT targets the correct table")
-            .contains("nexus.chunks_1024");
+            .as("INSERT targets the correct per-dim table")
+            .contains("chunks_1024");
         assertThat(sql)
             .as("column list includes retention")
             .contains("retention");
         assertThat(sql)
-            .as("VALUES binds NULL for chunk_text (no placeholder for content)")
-            .contains("NULL");
+            .as("chunk_text binds NULL (no content stored)")
+            .contains("null");
         assertThat(sql)
             .as("retention value is 'reference-only'")
-            .contains("'reference-only'");
+            .contains("reference-only");
         assertThat(sql)
             .as("DO UPDATE does NOT set chunk_text (defense-in-depth against full→ref clobber)")
-            .doesNotContainPattern("chunk_text\\s*=\\s*EXCLUDED\\.chunk_text");
+            .doesNotContainPattern("chunk_text\"?\\s*=\\s*excluded");
         assertThat(sql)
-            .as("DO UPDATE refreshes embedding")
-            .contains("embedding  = EXCLUDED.embedding");
+            .as("DO UPDATE refreshes embedding from EXCLUDED")
+            .containsPattern("embedding\"?\\s*=\\s*excluded");
     }
 }

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "6.2.0",
+  "version": "6.3.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -1237,8 +1237,17 @@ def aspect_extraction_enqueue_hook(
             )
         )
     except Exception as exc:  # noqa: BLE001 — enqueue is best-effort; failure logged via log.warning
+        # nexus-w8lg1: one-line warning at the CLI surface; the full
+        # traceback goes to debug (it previously spammed raw structlog
+        # tracebacks to the user's terminal on every enqueue failure).
         _log.warning(
             "aspect_extraction_enqueue_failed",
+            source_path=source_path,
+            collection=collection,
+            error=str(exc)[:500],
+        )
+        _log.debug(
+            "aspect_extraction_enqueue_failed_detail",
             source_path=source_path,
             collection=collection,
             exc_info=True,

--- a/src/nexus/catalog/catalog_docs.py
+++ b/src/nexus/catalog/catalog_docs.py
@@ -471,9 +471,48 @@ class _DocumentOps:
 
         Unlike ``by_owner`` which returns only direct children, this returns
         the full subtree.  The prefix itself is excluded.
+
+        Return-shape parity (nexus-u26b4): normalizes each row to the same
+        Java-normalized document-row shape ``HttpCatalogClient.descendants()``
+        returns from ``/list`` — ``metadata`` parsed to a dict (not a raw JSON
+        TEXT string) and the full ``bib_*`` field set present — matching the
+        normalization every other read path applies (``resolve``, ``find``,
+        ...). Was previously a direct ``cat._db.descendants(prefix)``
+        passthrough of the raw un-normalized SQLite row.
         """
         cat = self._cat
-        return cat._db.descendants(prefix)
+        rows = cat._db.execute(
+            "SELECT tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+            "metadata, source_mtime, alias_of, source_uri, "
+            "bib_year, bib_authors, bib_venue, bib_citation_count "
+            "FROM documents WHERE tumbler LIKE ?",
+            (prefix + ".%",),
+        ).fetchall()
+        return [
+            {
+                "tumbler": r[0],
+                "title": r[1] or "",
+                "author": r[2] or "",
+                "year": r[3] or 0,
+                "content_type": r[4] or "",
+                "file_path": r[5] or "",
+                "corpus": r[6] or "",
+                "physical_collection": r[7] or "",
+                "chunk_count": r[8] or 0,
+                "head_hash": r[9] or "",
+                "indexed_at": r[10] or "",
+                "metadata": json.loads(r[11]) if r[11] else {},
+                "source_mtime": r[12] or 0.0,
+                "alias_of": r[13] or "",
+                "source_uri": r[14] or "",
+                "bib_year": r[15] or 0,
+                "bib_authors": r[16] or "",
+                "bib_venue": r[17] or "",
+                "bib_citation_count": r[18] or 0,
+            }
+            for r in rows
+        ]
 
     def resolve_chunk(self, tumbler: Tumbler) -> dict | None:
         """Resolve a 4-segment chunk tumbler to its document + chunk metadata.

--- a/src/nexus/catalog/catalog_protocol.py
+++ b/src/nexus/catalog/catalog_protocol.py
@@ -164,6 +164,9 @@ class CatalogReader(Protocol):
     def resolve_many(self, doc_ids) -> object:  # canonical
         ...
 
+    def resolve_path(self, tumbler) -> object:  # canonical
+        ...
+
     def resolve_span(self, span, physical_collection, t3) -> object:  # canonical DIVERGENT
         ...
 

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -119,6 +119,23 @@ def _link_from_dict(d: dict) -> CatalogLink:
 from nexus.db.service_endpoint import resolve_service_endpoint as _resolve_endpoint
 
 
+def _coerce_legacy_grandfathered(d: dict) -> dict:
+    """Coerce a collection row's ``legacy_grandfathered`` to ``bool`` (nexus-u26b4).
+
+    ``CatalogRepository.collRow()``'s ``legacy_grandfathered`` column is a boxed
+    Integer on the wire (serializes as a JSON number, 0/1); local
+    ``Catalog.list_collections()`` (via ``_row_to_collection_dict``) already casts
+    it to a real Python ``bool``. Mirrors that cast here so raw dict-returning
+    callers (``get_collection``/``list_collections``/``collections_by_owner``) get
+    the same type local gives, not just ``is_legacy_collection()`` which papered
+    over the divergence at its own call site with a local ``bool(...)`` cast.
+    """
+    d = dict(d)
+    if "legacy_grandfathered" in d:
+        d["legacy_grandfathered"] = bool(d["legacy_grandfathered"])
+    return d
+
+
 def _to_entry(d: dict) -> CatalogEntry:
     """Convert a server response dict to a CatalogEntry.
 
@@ -1221,11 +1238,48 @@ class HttpCatalogClient:
         from_t: Tumbler | str,
         to_t: Tumbler | str,
         link_type: str,
-    ) -> bool:
-        return (
-            self.resolve(from_t) is not None and
-            self.resolve(to_t) is not None
+    ) -> list[str]:
+        """Return a list of validation errors (empty = link is valid).
+
+        Return-type parity (nexus-u26b4): mirrors local
+        ``_LinkOps.validate_link``'s errors-list contract exactly (was a
+        ``bool``), reusing existing wire routes — ``self.resolve()`` for
+        the existence checks and ``self.link_query()`` for the duplicate
+        check — rather than a new server endpoint.
+        """
+        errors: list[str] = []
+        if self.resolve(from_t) is None:
+            errors.append(f"from_tumbler {from_t} not found in documents")
+        if self.resolve(to_t) is None:
+            errors.append(f"to_tumbler {to_t} not found in documents")
+        existing = self.link_query(
+            from_t=str(from_t), to_t=str(to_t), link_type=link_type, limit=1,
         )
+        if existing:
+            errors.append(
+                f"duplicate: link ({from_t}, {to_t}, {link_type!r}) "
+                f"already exists"
+            )
+        return errors
+
+    def _traverse(self, payload: dict) -> dict:
+        """POST /v1/catalog/traverse and convert wire dicts to typed objects.
+
+        Return-type parity (nexus-u26b4, the h8rf6.3 incident class): local
+        ``Catalog.graph()``/``graph_many()`` return
+        ``{"nodes": list[CatalogEntry], "edges": list[CatalogLink]}`` (matching
+        the return-type-parity pattern used elsewhere in this module, e.g.
+        ``links_from``/``get_manifest``); this previously returned the RAW wire
+        dict unconverted, so consumers doing attribute access (``node.tumbler``,
+        ``edge.link_type`` — e.g. ``mcp/core.py``'s traverse tool,
+        ``commands/catalog_cmds/links.py``'s ``links`` command) silently
+        degraded or crashed in service mode.
+        """
+        result = self._post("/traverse", payload) or {"nodes": [], "edges": []}
+        return {
+            "nodes": [_to_entry(n) for n in result.get("nodes", [])],
+            "edges": [_link_from_dict(e) for e in result.get("edges", [])],
+        }
 
     def graph(
         self,
@@ -1251,7 +1305,7 @@ class HttpCatalogClient:
         # include_heuristic: forwarded to service for future support; currently informational
         if include_heuristic:
             payload["include_heuristic"] = True
-        return self._post("/traverse", payload) or {"nodes": [], "edges": []}
+        return self._traverse(payload)
 
     def graph_many(
         self,
@@ -1277,7 +1331,7 @@ class HttpCatalogClient:
         # include_heuristic: forwarded to service for future support; currently informational
         if include_heuristic:
             payload["include_heuristic"] = True
-        return self._post("/traverse", payload) or {"nodes": [], "edges": []}
+        return self._traverse(payload)
 
     def link_audit(self, *, t3: Any = None) -> dict:
         return {}  # not supported in initial service-mode implementation
@@ -1318,7 +1372,10 @@ class HttpCatalogClient:
 
     def list_collections(self) -> list[dict]:
         result = self._get("/collections/list")
-        return result.get("collections", []) if result else []
+        return [
+            _coerce_legacy_grandfathered(c)
+            for c in (result.get("collections", []) if result else [])
+        ]
 
     def get_collection(self, name: str) -> dict | None:
         try:
@@ -1327,7 +1384,9 @@ class HttpCatalogClient:
             if exc.response.status_code == 404:
                 return None
             raise
-        return result if result and result.get("name") else None
+        if not result or not result.get("name"):
+            return None
+        return _coerce_legacy_grandfathered(result)
 
     def is_legacy_collection(self, name: str) -> bool:
         coll = self.get_collection(name)
@@ -1667,28 +1726,42 @@ class HttpCatalogClient:
     # ══════════════════════════════════════════════════════════════════════════
 
     def collection_health_meta(self, collection: str) -> dict:
-        """Return ``{last_indexed, orphan_count}`` for *collection* from the service.
+        """Return ``{last_indexed, orphan_count, stale_source_ratio}`` for *collection*.
 
         nexus-dsu5z: public service-mode method replacing the guarded
         ``hasattr(cat, '_db')`` path in ``collection_health._default_catalog_stats_fn``.
         Routes to ``GET /v1/catalog/collections/health?collection=<name>``.
 
-        Returns ``{"last_indexed": None, "orphan_count": 0}`` when the service
-        responds with an empty/absent payload or 404 (collection unknown).
-        Non-404 errors (auth, bad-request, 5xx) propagate — they signal
+        Returns ``{"last_indexed": None, "orphan_count": 0, "stale_source_ratio": None}``
+        when the service responds with an empty/absent payload or 404 (collection
+        unknown). Non-404 errors (auth, bad-request, 5xx) propagate — they signal
         misconfiguration that must not be masked as a healthy-empty result.
+
+        Return-shape parity (nexus-u26b4): ``stale_source_ratio`` is carried by
+        both the wire response (``CatalogRepository.collectionHealthMeta``, the
+        catalog-011 PG view) and local ``Catalog.collection_health_meta()`` — this
+        method previously reconstructed only ``{last_indexed, orphan_count}`` and
+        silently dropped it, leaving ``collection_health.py``'s report always
+        rendering the ``—`` placeholder for service-mode collections.
         """
         try:
             result = self._get("/collections/health", collection=collection)
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 404:
-                return {"last_indexed": None, "orphan_count": 0}
+                return {
+                    "last_indexed": None, "orphan_count": 0,
+                    "stale_source_ratio": None,
+                }
             raise
         if not result:
-            return {"last_indexed": None, "orphan_count": 0}
+            return {
+                "last_indexed": None, "orphan_count": 0,
+                "stale_source_ratio": None,
+            }
         return {
             "last_indexed": result.get("last_indexed"),
             "orphan_count": int(result.get("orphan_count") or 0),
+            "stale_source_ratio": result.get("stale_source_ratio"),
         }
 
     def stats(self) -> dict:

--- a/src/nexus/catalog/http_catalog_client.py
+++ b/src/nexus/catalog/http_catalog_client.py
@@ -1027,8 +1027,33 @@ class HttpCatalogClient:
         return out
 
     def resolve_chunk(self, tumbler: Tumbler | str) -> dict | None:
-        result = self.resolve(tumbler)
-        return result.__dict__ if result else None
+        """Resolve a 4-segment chunk tumbler to its document + chunk metadata.
+
+        Mirrors the local ``Catalog.resolve_chunk`` contract exactly
+        (catalog_docs.py): chunks are implicit addresses, not their own
+        catalog rows. Returns ``None`` immediately (no wire round-trip) when
+        ``tumbler`` is not a chunk address (``tumbler.chunk is None``) — the
+        same short-circuit the local side takes. Otherwise calls
+        ``GET /resolve_chunk`` (nexus-gc2ze).
+        """
+        t = Tumbler.parse(tumbler) if isinstance(tumbler, str) else tumbler
+        if t.chunk is None:
+            return None
+        try:
+            result = self._get("/resolve_chunk", tumbler=str(t))
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return None
+            raise
+        if not result:
+            return None
+        return {
+            "document_tumbler": result.get("document_tumbler", ""),
+            "chunk_index": result.get("chunk_index", 0),
+            "physical_collection": result.get("physical_collection", ""),
+            "title": result.get("title", ""),
+            "content_type": result.get("content_type", ""),
+        }
 
     def resolve_span_text(self, tumbler: Tumbler | str, span: str) -> str | None:
         return None  # not supported in initial service-mode implementation

--- a/src/nexus/catalog/link_generator.py
+++ b/src/nexus/catalog/link_generator.py
@@ -10,18 +10,19 @@ from pathlib import Path
 
 import structlog
 
-from nexus.catalog.catalog import Catalog, CatalogEntry
+from nexus.catalog.catalog import CatalogEntry
+from nexus.catalog.catalog_protocol import CatalogReader, CatalogWriter
 from nexus.catalog.tumbler import Tumbler
 
 _log = structlog.get_logger()
 
 
-def _all_entries(cat: Catalog) -> list[CatalogEntry]:
+def _all_entries(cat: CatalogReader) -> list[CatalogEntry]:
     """Fetch all catalog entries via the public API."""
     return cat.all_documents()
 
 
-def generate_citation_links(cat: Catalog, *, writer: object = None) -> int:
+def generate_citation_links(cat: CatalogReader, *, writer: CatalogWriter | None = None) -> int:
     """Auto-create 'cites' links via bib ID cross-matching.
 
     Uses metadata already on catalog entries — no API calls.
@@ -98,7 +99,7 @@ _PROSE_PATH_RE = re.compile(
 )
 
 
-def generate_rdr_filepath_links(cat: Catalog, *, writer: object = None, new_tumblers: list[Tumbler] | None = None) -> int:
+def generate_rdr_filepath_links(cat: CatalogReader, *, writer: CatalogWriter | None = None, new_tumblers: list[Tumbler] | None = None) -> int:
     """Extract file paths from RDR content and link to matching code entries.
 
     Scans each RDR's file on disk for source file paths (e.g.,
@@ -164,7 +165,7 @@ def generate_rdr_filepath_links(cat: Catalog, *, writer: object = None, new_tumb
 
 
 def generate_prose_filepath_links(
-    cat: Catalog, *, writer: object = None, new_tumblers: list[Tumbler] | None = None,
+    cat: CatalogReader, *, writer: CatalogWriter | None = None, new_tumblers: list[Tumbler] | None = None,
 ) -> int:
     """nexus-sob9: extract file paths from prose / markdown content
     and link to matching code entries.
@@ -252,7 +253,7 @@ def generate_prose_filepath_links(
 
 
 def generate_pdf_corpus_links(
-    cat: Catalog, *, writer: object = None, new_tumblers: list[Tumbler] | None = None,
+    cat: CatalogReader, *, writer: CatalogWriter | None = None, new_tumblers: list[Tumbler] | None = None,
 ) -> int:
     """nexus-sob9: link PDFs that share a content_hash via ``same-as``.
 

--- a/src/nexus/code_indexer.py
+++ b/src/nexus/code_indexer.py
@@ -494,9 +494,12 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
             metadatas=metadatas,
         )
 
+    with _stage("hooks"):
         # Post-store hook chains (RDR-095). Both single-doc and batch
         # chains fire from every storage event; the per-doc loop covers
-        # single-shape consumers on CLI ingest.
+        # single-shape consumers on CLI ingest. Own stage bucket
+        # (nexus-cfc72): under concurrent indexing these serialize on
+        # LockedHookRegistry, and lock-wait must not read as upload time.
         ctx.hooks.fire_batch(
             ids, ctx.corpus, documents, embeddings, metadatas,
             catalog_doc_id=catalog_doc_id,

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -857,12 +857,17 @@ def _reembed_collection(
 
     try:
         col = db.get_collection(col_name)
+        # count() inside the same boundary: the service stub propagates
+        # transient VectorServiceError raw (tail review, nexus-c9xr2) —
+        # surface it as the file's ClickException convention, not a
+        # traceback.
+        total = col.count()
+    except click.ClickException:
+        raise
     except Exception as exc:  # noqa: BLE001 — boundary catch re-raised as ClickException with context
         raise click.ClickException(
             f"collection {col_name!r}: {type(exc).__name__}: {exc}"
         )
-
-    total = col.count()
     if total == 0:
         return 0, 0
 
@@ -1008,8 +1013,13 @@ def reembed_cmd(
 
     db = _t3()
     if dry_run:
-        col = db.get_collection(name)
-        n = col.count()
+        try:
+            col = db.get_collection(name)
+            n = col.count()
+        except Exception as exc:  # noqa: BLE001 — boundary catch re-raised as ClickException (tail review, nexus-c9xr2)
+            raise click.ClickException(
+                f"collection {name!r}: {type(exc).__name__}: {exc}"
+            )
         click.echo(
             f"dry-run: would re-embed {n} chunk(s) in {name!r} with "
             f"{target_model!r}. Pass --no-dry-run --yes to apply."

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -785,7 +785,7 @@ def backfill_hash_cmd(name: str | None, all_collections: bool) -> None:
         grand_updated = 0
         for i, col_name in enumerate(sorted(targets), 1):
             try:
-                col = db._client.get_collection(col_name)
+                col = db.get_collection(col_name)
             except Exception as exc:  # noqa: BLE001 — per-collection resolution failure surfaced via click.echo, loop continues
                 click.echo(f"  [{i}/{len(targets)}] {col_name}: {type(exc).__name__}, skipping", err=True)
                 continue
@@ -856,7 +856,7 @@ def _reembed_collection(
     from nexus.retry import _voyage_with_retry  # noqa: PLC0415 — deferred to avoid import cycle / CLI startup cost
 
     try:
-        col = db._client.get_collection(col_name)
+        col = db.get_collection(col_name)
     except Exception as exc:  # noqa: BLE001 — boundary catch re-raised as ClickException with context
         raise click.ClickException(
             f"collection {col_name!r}: {type(exc).__name__}: {exc}"
@@ -1008,7 +1008,7 @@ def reembed_cmd(
 
     db = _t3()
     if dry_run:
-        col = db._client.get_collection(name)
+        col = db.get_collection(name)
         n = col.count()
         click.echo(
             f"dry-run: would re-embed {n} chunk(s) in {name!r} with "

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -211,6 +211,25 @@ def rename_cmd(old: str, new: str, force_prefix_change: bool) -> None:
             f"is intentional (rare — usually means the caller is resurrecting "
             f"an orphaned collection with the wrong prefix)."
         )
+    # nexus-tcvpn: a SAME-prefix rename whose embedding-model SEGMENT differs
+    # sailed through the prefix guard — but rename is an O(1) identity
+    # re-home with ZERO re-embedding, so the vectors would stay in the old
+    # model space while the name claims the new one (silent staleness/
+    # search corruption, no Voyage call ever fires). Cross-model moves are
+    # the RDR-162 migration pipeline's job (remap_collection_references +
+    # vector ETL), not rename's.
+    old_model = embedding_model_for_collection(old)
+    new_model = embedding_model_for_collection(new)
+    if old_model != new_model and not force_prefix_change:
+        raise click.ClickException(
+            f"embedding-model mismatch: {old!r} encodes {old_model!r} but "
+            f"{new!r} encodes {new_model!r}. rename never re-embeds — the "
+            f"vectors would silently stay {old_model!r} under a name claiming "
+            f"{new_model!r}. Cross-model moves go through the migration "
+            f"pipeline (nx migrate / guided-upgrade, RDR-162 vector ETL). "
+            f"Pass --force-prefix-change ONLY if you know the vectors are "
+            f"already {new_model!r}."
+        )
 
     counts = rename_collection_data_plane(old, new)
 
@@ -1042,10 +1061,14 @@ def reembed_cmd(
         if encoded != target_model:
             raise click.ClickException(
                 f"service mode re-embeds server-side using the model the "
-                f"collection NAME encodes ({encoded!r}); --to {target_model!r} "
-                f"cannot take effect on {name!r}. Use 'nx collection rename' "
-                f"(cross-model) to move to a {target_model}-named collection, "
-                f"which re-embeds under the new name."
+                f"collection NAME encodes — or, for legacy 2-segment names, "
+                f"the prefix-inferred model ({encoded!r}); --to {target_model!r} "
+                f"cannot take effect on {name!r}. Cross-model moves go "
+                f"through the migration pipeline (nx migrate / "
+                f"guided-upgrade — the RDR-162 vector ETL re-embeds into a "
+                f"{target_model}-named collection). Plain 'nx collection "
+                f"rename' does NOT re-embed and would corrupt the "
+                f"name-encoded model contract."
             )
 
     if dry_run:

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -931,13 +931,27 @@ def _reembed_collection(
             for m in v_metas:
                 if isinstance(m, dict):
                     m["embedding_model"] = target_model
-            db.upsert_chunks_with_embeddings(
-                collection_name=col_name,
-                ids=v_ids,
-                documents=v_docs,
-                embeddings=embeddings,
-                metadatas=v_metas,
-            )
+            from nexus.db.http_vector_client import is_service_backed as _isb  # noqa: PLC0415 — deferred to avoid import cycle / CLI startup cost
+            if _isb(db):
+                # nexus-u37lw: on the service handle, upsert_chunks_with_
+                # embeddings DISCARDS caller vectors (server re-embeds by
+                # collection name). The command guard has already pinned
+                # target_model == the name-encoded model here, so the
+                # nexus-hxry2 verbatim passthrough stores our vectors
+                # without a second (billed) server-side embed.
+                db.upsert_chunks(
+                    col_name, v_ids, v_docs,
+                    metadatas=v_metas,
+                    embeddings=embeddings,
+                )
+            else:
+                db.upsert_chunks_with_embeddings(
+                    collection_name=col_name,
+                    ids=v_ids,
+                    documents=v_docs,
+                    embeddings=embeddings,
+                    metadatas=v_metas,
+                )
             # nexus-bw65 / nexus-9099: fire post-store chains so the
             # invariant 'every CLI T3 write also fires the chain'
             # (test_every_cli_t3_write_function_fires_store_chains)
@@ -1012,6 +1026,28 @@ def reembed_cmd(
         )
 
     db = _t3()
+
+    # nexus-u37lw (critique Critical): in service mode, upsert_chunks_with_
+    # embeddings forwards TEXT and the server re-embeds by the model the
+    # COLLECTION NAME encodes (EmbedderRouter routes by name segment) —
+    # client-computed vectors are discarded. A --to that differs from the
+    # encoded model would therefore silently no-op with the OLD model while
+    # stamping the NEW model into metadata (corrupting staleness checks)
+    # and printing false success. Fail loud instead; cross-model moves are
+    # the rename --cross-model flow.
+    from nexus.db.http_vector_client import is_service_backed  # noqa: PLC0415 — deferred to avoid import cycle / CLI startup cost
+
+    if not dry_run and is_service_backed(db):
+        encoded = embedding_model_for_collection(name)
+        if encoded != target_model:
+            raise click.ClickException(
+                f"service mode re-embeds server-side using the model the "
+                f"collection NAME encodes ({encoded!r}); --to {target_model!r} "
+                f"cannot take effect on {name!r}. Use 'nx collection rename' "
+                f"(cross-model) to move to a {target_model}-named collection, "
+                f"which re-embeds under the new name."
+            )
+
     if dry_run:
         try:
             col = db.get_collection(name)

--- a/src/nexus/commands/t3.py
+++ b/src/nexus/commands/t3.py
@@ -510,19 +510,34 @@ def gc_cmd(
     # Operators SHOULD NOT run gc concurrently with active indexing.
     # The window is single-operator-driven and acceptably small in
     # practice.
-    event_log = EventLog(cat._dir)
+    # nexus-h8rf6 live-shakeout finding #4: EventLog is the LOCAL git-backed
+    # catalog's audit trail (needs cat._dir). In service mode the catalog is
+    # an HttpCatalogClient with no local directory — emitting local events
+    # for a server-authoritative delete is neither possible nor meaningful,
+    # so skip emission (logged) rather than crash. The strict order
+    # (event-then-delete) below still holds whenever a local event log exists.
+    cat_dir = getattr(cat, "_dir", None)
+    event_log = EventLog(cat_dir) if cat_dir is not None else None
+    if event_log is None:
+        _log.info(
+            "gc_event_log_skipped",
+            reason="service-backed catalog has no local event log",
+            collection=collection,
+            candidates=len(candidates),
+        )
     pending_chunk_ids: list[str] = []
     for chunk_id, chash in candidates:
-        event = make_event(
-            ChunkOrphanedPayload(
-                chunk_id=chunk_id,
-                reason=(
-                    f"chash {chash} not referenced by any manifest entry "
-                    f"in {collection}"
-                ),
+        if event_log is not None:
+            event = make_event(
+                ChunkOrphanedPayload(
+                    chunk_id=chunk_id,
+                    reason=(
+                        f"chash {chash} not referenced by any manifest entry "
+                        f"in {collection}"
+                    ),
+                )
             )
-        )
-        event_log.append(event)
+            event_log.append(event)
         pending_chunk_ids.append(chunk_id)
 
     deleted_total = 0

--- a/src/nexus/daemon/binary_install.py
+++ b/src/nexus/daemon/binary_install.py
@@ -87,7 +87,7 @@ TAG_NAMESPACE_PREFIX = "engine-service-v"
 #: service (RF-161-2). ``None`` until the first real ``engine-service-v*``
 #: release exists; while it is ``None``, ``nx init --service`` cannot
 #: auto-install and instructs the user to pass an explicit tag.
-PINNED_SERVICE_TAG: str | None = "engine-service-v0.1.19"
+PINNED_SERVICE_TAG: str | None = "engine-service-v0.1.22"
 
 #: Env override for the service tag (operator / CI). Takes precedence over the
 #: build-time pin. Still an explicit tag — no "latest" semantics.

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -418,11 +418,23 @@ class _ServiceCollectionStub:
             )
             return {"ids": [], "documents": [], "metadatas": []}
 
+    @property
+    def name(self) -> str:
+        """Chroma ``Collection.name`` parity — indexer logging does
+        ``getattr(col, "name", "?")`` and logged '?' for every service-mode
+        collection (tail-review suggestion, nexus-c9xr2)."""
+        return self._name
+
     def count(self) -> int:
         """Chunk count for this collection — Chroma ``Collection.count()``
         parity (nexus-c9xr2: the collection re-embed / backfill paths call
         ``col.count()`` on the handle ``get_collection`` returns; without
-        this the stub was the only handle shape missing it)."""
+        this the stub was the only handle shape missing it).
+
+        Unlike ``get``/``delete`` this does NOT catch-and-degrade: a wrong
+        count silently reshapes paging loops, so the caller owns the
+        boundary (re-embed wraps it in its ClickException convention).
+        """
         from urllib.parse import quote  # noqa: PLC0415 — stdlib deferred to call site (urllib.parse)
 
         result = _get(

--- a/src/nexus/db/http_vector_client.py
+++ b/src/nexus/db/http_vector_client.py
@@ -418,6 +418,19 @@ class _ServiceCollectionStub:
             )
             return {"ids": [], "documents": [], "metadatas": []}
 
+    def count(self) -> int:
+        """Chunk count for this collection — Chroma ``Collection.count()``
+        parity (nexus-c9xr2: the collection re-embed / backfill paths call
+        ``col.count()`` on the handle ``get_collection`` returns; without
+        this the stub was the only handle shape missing it)."""
+        from urllib.parse import quote  # noqa: PLC0415 — stdlib deferred to call site (urllib.parse)
+
+        result = _get(
+            "/v1/vectors/count?collection=" + quote(self._name),
+            tenant=self._tenant,
+        )
+        return int(result.get("count", 0))
+
     def delete(self, ids: list[str]) -> None:
         """Delete chunks by ID from the service."""
         if not ids:

--- a/src/nexus/hook_registry.py
+++ b/src/nexus/hook_registry.py
@@ -479,3 +479,45 @@ def _record_document_hook_failure(
         doc_id=source_path, collection=collection, hook_name=hook_name,
         error=error, chain="document",
     )
+
+
+# ── Serializing proxy for concurrent indexing (nexus-cfc72) ──────────────────
+
+
+class LockedHookRegistry:
+    """Serialize the fire methods of a :class:`HookRegistry` under one lock.
+
+    The nexus-cfc72 bounded file-level indexing concurrency runs 2+ file
+    pipelines at once; the hook chains they fire (manifest writes, chash
+    ledger, taxonomy assign, aspect enqueue) were written for the
+    sequential loop and are not audited for interleaving. Hooks are
+    milliseconds against the multi-second embed/upsert work, so
+    serializing them costs ~nothing and removes the question. Everything
+    else (registration, attribute access) delegates to the wrapped
+    registry unchanged.
+    """
+
+    def __init__(self, registry: HookRegistry) -> None:
+        import threading  # noqa: PLC0415 — only needed by this concurrency proxy
+
+        self._registry = registry
+        self._lock = threading.Lock()
+
+    def fire_single(self, *args: Any, **kwargs: Any) -> None:
+        with self._lock:
+            self._registry.fire_single(*args, **kwargs)
+
+    def fire_batch(self, *args: Any, **kwargs: Any) -> None:
+        with self._lock:
+            self._registry.fire_batch(*args, **kwargs)
+
+    def fire_document(self, *args: Any, **kwargs: Any) -> None:
+        with self._lock:
+            self._registry.fire_document(*args, **kwargs)
+
+    def fire_store_chains(self, *args: Any, **kwargs: Any) -> None:
+        with self._lock:
+            self._registry.fire_store_chains(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._registry, name)

--- a/src/nexus/hook_registry.py
+++ b/src/nexus/hook_registry.py
@@ -286,6 +286,14 @@ class HookRegistry:
         (``nx store put``, ``nx memory promote``, ``nx store import``).
         Bulk ``nx index *`` paths still call the three fire methods
         directly to preserve the existing per-batch shape.
+
+        INVARIANT (nexus-w8lg1): ``catalog_doc_id`` is scoped to the
+        WHOLE call — the document chain broadcasts it to every item.
+        One call therefore covers ONE catalog document's chunks (or
+        passes ``""``). Callers with a multi-document batch must group
+        by document first (see ``exporter._fire_store_chains_grouped_by_doc``);
+        passing a nonempty ``catalog_doc_id`` across mixed documents
+        would mis-attribute every document's aspect-queue row.
         """
         n = len(doc_ids)
         if len(contents) != n:
@@ -309,8 +317,17 @@ class HookRegistry:
             catalog_doc_id=catalog_doc_id,
         )
 
-        for did, sp, content in zip(doc_ids, source_paths, contents):
-            self.fire_document(sp, collection, content, doc_id=did)
+        # nexus-w8lg1 (6.3.0 live shakeout finding #1): the document chain
+        # carries the CATALOG doc_id (tumbler), never the T3 chunk id.
+        # Passing ``did`` here shipped chunk_text_hash[:32] to the aspect
+        # enqueue, violating the engine's composite FK
+        # aspect_extraction_queue(tenant_id, doc_id) ->
+        # catalog_documents(tenant_id, tumbler) — typed 409, aspects
+        # silently lost on every CLI store put. "" persists as NULL,
+        # which the nullable FK accepts. ``doc_ids`` is intentionally
+        # unused here — chunk ids belong to the single/batch chains only.
+        for sp, content in zip(source_paths, contents):
+            self.fire_document(sp, collection, content, doc_id=catalog_doc_id)
 
 
 # ── Default-hooks factory ────────────────────────────────────────────────────

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -2637,21 +2637,31 @@ def _run_index(
             f"({time.monotonic() - _staleness_t0:.1f}s)"
         )
 
+    # nexus-cfc72: bounded file-level concurrency. Sequential (exact
+    # legacy loop) unless both the vectors and catalog backends are the
+    # HTTP service (or NX_INDEX_CONCURRENCY overrides). Staleness caches
+    # are read-only after build; on_file/on_stage_timers are serialized
+    # inside run_file_loop; hook chains are serialized via
+    # LockedHookRegistry so the manifest/chash/taxonomy/aspect writes
+    # never interleave.
+    from nexus.indexer_utils import resolve_index_concurrency, run_file_loop  # noqa: PLC0415  — circular-dep avoidance (nexus.indexer_utils)
+    _concurrency = resolve_index_concurrency()
+    if _concurrency > 1 and hooks is not None:
+        # hooks may be None at direct test call sites; wrapping None would
+        # defeat every downstream ``hooks is None`` fallback (review
+        # finding, nexus-cfc72) — leave None alone.
+        from nexus.hook_registry import LockedHookRegistry  # noqa: PLC0415 — deferred to avoid circular import
+        hooks = LockedHookRegistry(hooks)
+        _log.info("index_file_concurrency", workers=_concurrency)
+
     # Index code files → code__ (voyage-code-3, AST chunking)
     # NOTE: calls _index_code_file (the module-level wrapper) so that tests
     # patching nexus.indexer._index_code_file continue to intercept correctly.
     _log.debug("indexing code files", count=len(code_files))
-    for score, file in code_files:
+
+    def _index_one_code(file: Path, score: float, timers: object | None) -> int:
         _log.debug("indexing", file=str(file))
-        t0 = time.monotonic()
-        # nexus-7niu: build a per-file StageTimers only when the caller
-        # subscribed via ``on_stage_timers``. ``None`` short-circuits
-        # every instrumented block inside the indexer to a no-op.
-        timers = None
-        if on_stage_timers is not None:
-            from nexus.stage_timers import StageTimers  # noqa: PLC0415 — deliberate function-scoped import (defer heavy/optional dep, avoid circular import)
-            timers = StageTimers()
-        chunks = _index_code_file(
+        return _index_code_file(
             file, repo, code_collection, code_model, code_col, db,
             voyage_client, git_meta, now_iso, score,
             chunk_lines=effective_chunk_lines,
@@ -2662,23 +2672,19 @@ def _run_index(
             staleness_cache=code_staleness,
             hooks=hooks,
         )
-        if on_file:
-            on_file(file, chunks, time.monotonic() - t0)
-        if on_stage_timers is not None and timers is not None:
-            on_stage_timers(file, timers)
+
+    run_file_loop(
+        code_files, _index_one_code, concurrency=_concurrency,
+        on_file=on_file, on_stage_timers=on_stage_timers,
+    )
 
     # Index prose files → docs__ (voyage-context-3 via CCE)
     # NOTE: calls _index_prose_file (the module-level wrapper) — same reason.
     _log.debug("indexing prose files", count=len(prose_files))
-    for score, file in prose_files:
+
+    def _index_one_prose(file: Path, score: float, timers: object | None) -> int:
         _log.debug("indexing", file=str(file))
-        t0 = time.monotonic()
-        # nexus-7niu: per-file StageTimers when the caller subscribed.
-        timers = None
-        if on_stage_timers is not None:
-            from nexus.stage_timers import StageTimers  # noqa: PLC0415 — deliberate function-scoped import (defer heavy/optional dep, avoid circular import)
-            timers = StageTimers()
-        chunks = _index_prose_file(
+        return _index_prose_file(
             file, repo, docs_collection, docs_model, docs_col, db,
             voyage_key, git_meta, now_iso, score,
             force=force,
@@ -2689,22 +2695,18 @@ def _run_index(
             staleness_cache=docs_staleness,
             hooks=hooks,
         )
-        if on_file:
-            on_file(file, chunks, time.monotonic() - t0)
-        if on_stage_timers is not None and timers is not None:
-            on_stage_timers(file, timers)
+
+    run_file_loop(
+        prose_files, _index_one_prose, concurrency=_concurrency,
+        on_file=on_file, on_stage_timers=on_stage_timers,
+    )
 
     # Index PDF files → docs__ (PDF extraction + voyage-context-3)
     _log.debug("indexing PDF files", count=len(pdf_files))
-    for score, file in pdf_files:
+
+    def _index_one_pdf(file: Path, score: float, timers: object | None) -> int:
         _log.debug("indexing", file=str(file))
-        t0 = time.monotonic()
-        # nexus-7niu: per-file StageTimers when the caller subscribed.
-        timers = None
-        if on_stage_timers is not None:
-            from nexus.stage_timers import StageTimers  # noqa: PLC0415 — deliberate function-scoped import (defer heavy/optional dep, avoid circular import)
-            timers = StageTimers()
-        chunks = _index_pdf_file(
+        return _index_pdf_file(
             file, repo, docs_collection, docs_model, docs_col, db,
             voyage_key, git_meta, now_iso, score,
             force=force,
@@ -2716,10 +2718,11 @@ def _run_index(
             staleness_cache=docs_staleness,
             hooks=hooks,
         )
-        if on_file:
-            on_file(file, chunks, time.monotonic() - t0)
-        if on_stage_timers is not None and timers is not None:
-            on_stage_timers(file, timers)
+
+    run_file_loop(
+        pdf_files, _index_one_pdf, concurrency=_concurrency,
+        on_file=on_file, on_stage_timers=on_stage_timers,
+    )
 
     # Post-processing phase markers (nexus-vatx Gap 2): the per-file
     # progress bar ends at "[N/N]" but the pipeline keeps running for

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -767,6 +767,28 @@ def _catalog_hook(
         import sys  # noqa: PLC0415 — deliberate function-scoped import (defer heavy/optional dep, avoid circular import)
         _progress = sys.stderr.write
         _progress(f"  Catalog: registering {len(indexed_files)} files…\r")
+
+        # nexus-dst5h: ONE owner-scoped fetch + local join instead of a
+        # per-file ``by_file_path`` round-trip. In service mode each
+        # per-file lookup was a WAN HTTPS call (and the server returns the
+        # full owner list per call — GH #1350 class), so a warm run paid
+        # ~len(indexed_files) serial round-trips before indexing anything.
+        # The snapshot is taken once: a file registered by a CONCURRENT
+        # writer after this point is misclassified as new, takes the
+        # register-branch, and register()'s own idempotency check returns
+        # the existing tumbler (fields refresh on the next pass) — same
+        # class the fairness/yield machinery below already acknowledges.
+        # A fetch failure must NOT no-op the whole hook (the nexus-o6aa.10.4
+        # ghost class): fall back to the per-file lookups, loudly.
+        path_to_entry: dict[str, object] | None
+        try:
+            path_to_entry = {e.file_path: e for e in cat.by_owner(owner)}
+        except Exception as exc:  # noqa: BLE001 — degraded path must keep the hook alive
+            path_to_entry = None
+            _log.warning(
+                "catalog_hook_owner_list_failed_falling_back_per_file",
+                repo=repo_name, error=str(exc),
+            )
         new_tumblers = []
         # nexus-o6aa.10.4 follow-up: track per-file failures so the
         # catalog hook stops failing silently. Pre-fix, a single
@@ -833,7 +855,11 @@ def _catalog_hook(
                 file_hash = ""
 
             try:
-                existing = cat.by_file_path(owner, rel_path)
+                existing = (
+                    path_to_entry.get(rel_path)
+                    if path_to_entry is not None
+                    else cat.by_file_path(owner, rel_path)
+                )
                 if existing is None:
                     tumbler = writer.register(
                         owner=owner,
@@ -848,13 +874,32 @@ def _catalog_hook(
                     new_tumblers.append(tumbler)
                     file_to_doc_id[abs_path] = str(tumbler)
                 else:
-                    writer.update(
-                        existing.tumbler,
-                        head_hash=head_hash,
-                        physical_collection=collection_name,
-                        meta={"content_hash": file_hash} if file_hash else None,
-                        source_mtime=source_mtime,
+                    # nexus-dst5h: skip the write when nothing changed —
+                    # a warm re-run otherwise pays one serial update
+                    # round-trip per file. An empty file_hash (read
+                    # failure) is inconclusive, not a change. The mtime
+                    # compare relies on st_mtime round-tripping bit-exact
+                    # through storage (SQLite REAL / PG DOUBLE PRECISION /
+                    # JSON); a storage change that truncates precision
+                    # flips this to always-changed (harmless) — never
+                    # compare with tolerance, drift means changed.
+                    changed = (
+                        existing.head_hash != head_hash
+                        or existing.physical_collection != collection_name
+                        or existing.source_mtime != source_mtime
+                        or (
+                            file_hash
+                            and existing.meta.get("content_hash", "") != file_hash
+                        )
                     )
+                    if changed:
+                        writer.update(
+                            existing.tumbler,
+                            head_hash=head_hash,
+                            physical_collection=collection_name,
+                            meta={"content_hash": file_hash} if file_hash else None,
+                            source_mtime=source_mtime,
+                        )
                     file_to_doc_id[abs_path] = str(existing.tumbler)
             except Exception as exc:  # noqa: BLE001 — best-effort path; error surfaced via log, must not crash caller
                 # Per-file failure must NOT abort the rest of the loop.
@@ -1165,15 +1210,19 @@ def _build_frecency_doc_id_map(
         owner = cat.owner_for_repo(repo_hash)
         if owner is None:
             return file_to_doc_id
+        # nexus-dst5h: ONE owner-scoped fetch + local join instead of a
+        # per-file ``by_file_path`` pass (a second full serial-WAN sweep
+        # in service mode, paid on every warm run). A by_owner failure
+        # raises into the outer except -> empty map, which the documented
+        # contract tolerates (caller falls back to the legacy
+        # source_path filter).
+        path_to_entry = {e.file_path: e for e in cat.by_owner(owner)}
         for abs_path in files:
             try:
                 rel_path = str(abs_path.relative_to(repo))
             except ValueError:
                 rel_path = abs_path.name
-            try:
-                entry = cat.by_file_path(owner, rel_path)
-            except Exception:  # noqa: BLE001 — best-effort cleanup; failure is non-fatal and intentionally swallowed
-                continue
+            entry = path_to_entry.get(rel_path)
             if entry is not None:
                 file_to_doc_id[abs_path] = str(entry.tumbler)
     except Exception:  # noqa: BLE001 — best-effort path; error surfaced via log, must not crash caller

--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -564,3 +564,155 @@ def build_doc_id_resolver(
         return file_to_doc_id.get(path, "")
 
     return _resolver
+
+
+# ── Bounded file-level concurrency (nexus-cfc72) ─────────────────────────────
+
+
+def resolve_index_concurrency() -> int:
+    """Resolve the per-file indexing concurrency for ``nx index repo``.
+
+    ``NX_INDEX_CONCURRENCY`` (>=1) wins when set and parseable. Otherwise
+    the default is 2 when BOTH the vectors and catalog backends are the
+    HTTP service (thread-safe httpx clients; the engine's TenantScope
+    admission control bounds bursts to typed 503s) and 1 everywhere else
+    — the direct-SQLite catalog on the legacy ``=sqlite`` opt-out is not
+    thread-safe. The gate self-retires once nexus-7bomn removes that
+    opt-out.
+
+    The gate deliberately does NOT check the T2 "memory" backend
+    (chash/taxonomy/aspect-queue writes): those routes only run inside
+    the hook chains, which ``LockedHookRegistry`` serializes whenever
+    concurrency > 1 — the lock, not this gate, is what makes a diverging
+    memory backend safe (critique finding, nexus-cfc72). Narrowing the
+    hook lock requires extending this gate. The local bge embedder is
+    also concurrency-safe: onnxruntime ``InferenceSession.run`` supports
+    concurrent calls on a shared session.
+    """
+    import os  # noqa: PLC0415 — leaf module keeps import surface minimal
+
+    def _backend_default() -> int:
+        from nexus.db.http_vector_client import is_vector_service_mode  # noqa: PLC0415 — deferred to avoid circular import (db.http_vector_client)
+        from nexus.db.storage_mode import StorageBackend, storage_backend_for  # noqa: PLC0415 — deferred to avoid circular import (db.storage_mode)
+
+        if (
+            is_vector_service_mode()
+            and storage_backend_for("catalog") == StorageBackend.SERVICE
+        ):
+            return 2
+        return 1
+
+    raw = os.environ.get("NX_INDEX_CONCURRENCY", "").strip()
+    if raw:
+        try:
+            requested = max(1, int(raw))
+        except ValueError:
+            _log.warning(
+                "nx_index_concurrency_invalid", value=raw,
+                hint="expected an integer >= 1; using the backend default",
+            )
+        else:
+            if requested > 1 and _backend_default() == 1:
+                # Review finding (nexus-cfc72): the override wins, but
+                # never silently — forcing concurrency onto a non-service
+                # backend reintroduces the direct-SQLite hazard the
+                # default gate exists to avoid.
+                _log.warning(
+                    "nx_index_concurrency_overrides_backend_gate",
+                    value=requested,
+                    hint="a non-service catalog/vectors backend is not "
+                         "audited for concurrent indexing",
+                )
+            return requested
+    return _backend_default()
+
+
+def run_file_loop(
+    files: list[tuple[float, Path]],
+    index_one: Callable[[Path, float, object | None], int],
+    *,
+    concurrency: int,
+    on_file: Callable[[Path, int, float], None] | None,
+    on_stage_timers: Callable[[Path, object], None] | None,
+) -> None:
+    """Drive one per-file indexing loop, sequentially or with a bounded pool.
+
+    ``index_one(file, score, timers) -> chunk_count`` is the loop body
+    (the ``_index_code_file`` / ``_index_prose_file`` / ``_index_pdf_file``
+    call). Contracts preserved from the legacy inline loops (nexus-cfc72):
+
+    - ``concurrency <= 1`` is a plain sequential loop — identical
+      ordering and error behavior to the pre-concurrency code.
+    - Submission order is the caller's (frecency-descending) order, so
+      high-value files start first even when completion interleaves.
+    - ``on_file`` / ``on_stage_timers`` are invoked under one lock —
+      the CLI progress renderer is not re-entrant. Per-file elapsed is
+      measured inside the worker, so durations stay truthful.
+    - A per-file ``StageTimers`` is built only when ``on_stage_timers``
+      is subscribed, mirroring the nexus-7niu short-circuit.
+    - Error semantics match the sequential loop: the first exception
+      cancels all not-yet-started files and re-raises. In-flight files
+      run to completion (callbacks included) before the raise — the
+      shakeout's count-based assertions are order-independent, so a few
+      extra completed files at failure time are indistinguishable from
+      the sequential "run died at file X" shape.
+    """
+    import threading  # noqa: PLC0415 — leaf module keeps import surface minimal
+    import time  # noqa: PLC0415 — leaf module keeps import surface minimal
+
+    cb_lock = threading.Lock()
+
+    def _make_timers() -> object | None:
+        if on_stage_timers is None:
+            return None
+        from nexus.stage_timers import StageTimers  # noqa: PLC0415 — deliberate function-scoped import (defer heavy/optional dep)
+
+        return StageTimers()
+
+    def _process(score: float, file: Path) -> None:
+        t0 = time.monotonic()
+        timers = _make_timers()
+        chunks = index_one(file, score, timers)
+        with cb_lock:
+            if on_file:
+                on_file(file, chunks, time.monotonic() - t0)
+            if on_stage_timers is not None and timers is not None:
+                on_stage_timers(file, timers)
+
+    if concurrency <= 1:
+        for score, file in files:
+            _process(score, file)
+        return
+
+    from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, wait  # noqa: PLC0415 — leaf module keeps import surface minimal
+
+    with ThreadPoolExecutor(
+        max_workers=concurrency, thread_name_prefix="nx-index",
+    ) as pool:
+        futures = [pool.submit(_process, score, file) for score, file in files]
+        done, not_done = wait(futures, return_when=FIRST_EXCEPTION)
+        if not not_done and not any(f.exception() for f in done):
+            return
+        # A failure (or spurious wake). Cancel everything not yet started,
+        # let in-flight files finish, then harvest EVERY failure — a
+        # concurrent secondary failure must be logged, never silently
+        # dropped (critique finding, nexus-cfc72).
+        for fut in not_done:
+            fut.cancel()
+        wait(futures)
+        failures: list[tuple[Path, BaseException]] = []
+        for (score, file), fut in zip(files, futures):
+            if fut.cancelled():
+                continue
+            exc = fut.exception()
+            if exc is not None:
+                failures.append((file, exc))
+        if not failures:
+            return
+        # Deterministic "first": earliest in submission (frecency) order.
+        for file, exc in failures[1:]:
+            _log.warning(
+                "index_file_concurrent_failure_suppressed",
+                file=str(file), error=str(exc),
+            )
+        raise failures[0][1]

--- a/src/nexus/mcp/catalog.py
+++ b/src/nexus/mcp/catalog.py
@@ -445,12 +445,14 @@ def catalog_links(
         # in service mode (swallowed into {"error": ...}).
         link_types = [link_type] if link_type else None
         result = cat.graph(t, depth=depth, direction=direction, link_types=link_types)
-        # nexus-qtj24: nodes/edges are CatalogEntry/CatalogLink objects on the
-        # SQLite path but plain dicts from the service /traverse path — guard
-        # .to_dict() (mirrors catalog_link_query).
+        # nexus-u26b4: nodes/edges are CatalogEntry/CatalogLink objects on both
+        # the SQLite path and the service /traverse path (HttpCatalogClient.graph
+        # now converts wire dicts to typed objects — the isinstance(n, dict)
+        # guard nexus-qtj24 added here is no longer reachable and has been
+        # dropped; mirrors catalog_link_query's unconditional .to_dict()).
         return {
-            "nodes": [n if isinstance(n, dict) else n.to_dict() for n in result["nodes"]],
-            "edges": [e if isinstance(e, dict) else e.to_dict() for e in result["edges"]],
+            "nodes": [n.to_dict() for n in result["nodes"]],
+            "edges": [e.to_dict() for e in result["edges"]],
         }
     except Exception as e:  # noqa: BLE001 — MCP tool handler: catch-and-return-error-dict so the tool call never crashes the client
         return {"error": str(e)}

--- a/src/nexus/prose_indexer.py
+++ b/src/nexus/prose_indexer.py
@@ -251,9 +251,12 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
             metadatas=metadatas,
         )
 
+    with _stage("hooks"):
         # Post-store hook chains (RDR-095). Both single-doc and batch
         # chains fire from every storage event; the per-doc loop covers
-        # single-shape consumers on CLI ingest.
+        # single-shape consumers on CLI ingest. Own stage bucket
+        # (nexus-cfc72): under concurrent indexing these serialize on
+        # LockedHookRegistry, and lock-wait must not read as upload time.
         ctx.hooks.fire_batch(
             ids, ctx.corpus, documents, embeddings, metadatas,
             catalog_doc_id=catalog_doc_id,

--- a/src/nexus/stage_timers.py
+++ b/src/nexus/stage_timers.py
@@ -32,7 +32,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 
-_STAGE_NAMES: tuple[str, ...] = ("chunking", "embed", "upload")
+_STAGE_NAMES: tuple[str, ...] = ("chunking", "embed", "upload", "hooks")
 
 
 @dataclass
@@ -52,6 +52,10 @@ class StageTimers:
     chunking_s: float = 0.0
     embed_s: float = 0.0
     upload_s: float = 0.0
+    # nexus-cfc72: hook chains get their own bucket so LockedHookRegistry
+    # lock-wait under concurrent indexing shows up as hooks time, not as
+    # a mysteriously slow "upload".
+    hooks_s: float = 0.0
     retry_s: float = 0.0
 
     # Constructed by __post_init__ so the lock does not leak into the
@@ -64,7 +68,7 @@ class StageTimers:
     def stage(self, name: str) -> Iterator[None]:
         """Time the wrapped block and add net-of-retry to *name*.
 
-        ``name`` must be one of ``"chunking"``, ``"embed"``, ``"upload"``.
+        ``name`` must be one of ``"chunking"``, ``"embed"``, ``"upload"``, ``"hooks"``.
         Unknown names raise ``ValueError`` at entry so a typo fails
         loudly at first call, not silently at report time.
         """
@@ -91,22 +95,25 @@ class StageTimers:
                     self.chunking_s += net
                 elif name == "embed":
                     self.embed_s += net
+                elif name == "hooks":
+                    self.hooks_s += net
                 else:  # "upload"
                     self.upload_s += net
                 self.retry_s += retry_delta
 
     def snapshot(self) -> dict[str, float]:
-        """Thread-safe snapshot of the four accumulators."""
+        """Thread-safe snapshot of the accumulators."""
         with self._lock:
             return {
                 "chunking_s": self.chunking_s,
                 "embed_s": self.embed_s,
                 "upload_s": self.upload_s,
+                "hooks_s": self.hooks_s,
                 "retry_s": self.retry_s,
             }
 
     def total_s(self) -> float:
-        """Sum of all four buckets — convenience for reports."""
+        """Sum of all buckets — convenience for reports."""
         s = self.snapshot()
         return sum(s.values())
 
@@ -114,13 +121,14 @@ class StageTimers:
 def aggregate(timers: list[StageTimers]) -> dict[str, float]:
     """Sum a list of per-file :class:`StageTimers` into totals.
 
-    Returns a dict with the same four keys as :meth:`StageTimers.snapshot`
+    Returns a dict with the same keys as :meth:`StageTimers.snapshot`
     plus ``total_s``. Empty input returns all zeros (no files recorded).
     """
     totals = {
         "chunking_s": 0.0,
         "embed_s": 0.0,
         "upload_s": 0.0,
+        "hooks_s": 0.0,
         "retry_s": 0.0,
     }
     for t in timers:
@@ -144,7 +152,7 @@ def format_report(totals: dict[str, float], *, n_files: int) -> str:
     if grand <= 0 or n_files <= 0:
         return "[debug-timing] no per-stage samples recorded"
     lines = [f"[debug-timing] per-stage totals across {n_files} files:"]
-    for stage in ("chunking_s", "embed_s", "upload_s", "retry_s"):
+    for stage in ("chunking_s", "embed_s", "upload_s", "hooks_s", "retry_s"):
         seconds = totals.get(stage, 0.0)
         pct = (seconds / grand * 100) if grand > 0 else 0.0
         lines.append(f"  {stage:12} {seconds:>7.1f}s  ({pct:>4.1f}%)")

--- a/tests/catalog/test_http_catalog_client.py
+++ b/tests/catalog/test_http_catalog_client.py
@@ -55,6 +55,15 @@ def _entry_dict(**kwargs: Any) -> dict:
     (``by_file_path``, ``by_source_uri``, ``find_by_file_path``,
     ``resolve_path``) find a match against the fake server too, without a
     stateful fake.
+
+    nexus-u26b4: ``metadata``/``source_mtime``/``bib_*`` added so the
+    ``/list``-backed ``descendants()`` parity entry (which does NOT go
+    through ``_to_entry()`` — it forwards the raw wire dict) sees the same
+    Java-normalized document-row shape (metadata as a parsed nested dict,
+    the full ``bib_*`` field set) as local ``Catalog.descendants()``'s now
+    -normalized rows. Harmless to every other ``_entry_dict()`` consumer:
+    they all go through ``_to_entry()``, which collapses to a
+    ``CatalogEntry`` dataclass regardless of which wire keys were present.
     """
     base = {
         "tumbler": _fake_tumbler(),
@@ -63,6 +72,12 @@ def _entry_dict(**kwargs: Any) -> dict:
         "chunk_count": 0,
         "file_path": "src/alpha.py",
         "source_uri": "file:///tmp/nexus-test/alpha.py",
+        "metadata": {"key": "value"},
+        "source_mtime": 0.0,
+        "bib_year": 0,
+        "bib_authors": "",
+        "bib_venue": "",
+        "bib_citation_count": 0,
     }
     base.update(kwargs)
     return base
@@ -146,7 +161,20 @@ class FakeCatalogHandler(BaseHTTPRequestHandler):
                 n = FakeCatalogHandler.list_content_type_count
                 self._send_json({"documents": [_entry_dict() for _ in range(n)], "count": n})
             else:
-                self._send_json({"documents": [_entry_dict(), _entry_dict(title="Second")], "count": 2})
+                # nexus-u26b4: second doc has EMPTY metadata (vs the first's
+                # populated dict) — descendants() parity needs this
+                # heterogeneity to mirror local Catalog.descendants()'s
+                # seeded mix (doc_a has a real ``meta=``, every other seeded
+                # descendant does not); _to_entry()-based consumers
+                # (by_content_type, all_documents, ...) are unaffected since
+                # they collapse to a CatalogEntry dataclass regardless.
+                self._send_json({
+                    "documents": [
+                        _entry_dict(),
+                        _entry_dict(title="Second", metadata={}),
+                    ],
+                    "count": 2,
+                })
         elif op == "/search":
             self._send_json({"documents": [_entry_dict()], "count": 1})
         elif op == "/resolve":
@@ -160,14 +188,22 @@ class FakeCatalogHandler(BaseHTTPRequestHandler):
                 requested = {t for t in params["link_types"].split(",") if t}
             elif params.get("link_type"):
                 requested = {params["link_type"]}
-            row = {"from_tumbler": "1.1.1", "to_tumbler": "1.1.2", "link_type": "cites"}
+            out_row = {"from_tumbler": "1.1.1", "to_tumbler": "1.1.2", "link_type": "cites"}
+            # nexus-u26b4: the in-direction row was previously hardcoded empty
+            # (see the links_to EXCLUSIONS/REGISTRY history in
+            # test_shape_parity_tripwire.py) — a real inbound-link row so
+            # direction=in|both are wire-faithful like direction=out already was.
+            in_row = {"from_tumbler": "1.1.3", "to_tumbler": "1.1.2", "link_type": "cites"}
             match = requested is None or "cites" in requested
             if direction == "out":
-                self._send_json({"links_from": [row] if match else [], "links_to": []})
+                self._send_json({"links_from": [out_row] if match else [], "links_to": []})
             elif direction == "in":
-                self._send_json({"links_from": [], "links_to": []})
+                self._send_json({"links_from": [], "links_to": [in_row] if match else []})
             else:
-                self._send_json({"links_from": [], "links_to": []})
+                self._send_json({
+                    "links_from": [out_row] if match else [],
+                    "links_to": [in_row] if match else [],
+                })
         elif op == "/link_query":
             params = self._query_params()
             if params.get("from_tumbler") == FakeCatalogHandler.link_absent_from:
@@ -658,7 +694,10 @@ class TestHttpCatalogClientRoundTrip:
     def test_links_to_uses_direction_in(self, client: HttpCatalogClient) -> None:
         # GET /links?tumbler=X&direction=in
         links = client.links_to("1.1.2")
-        assert links == []
+        assert len(links) == 1
+        # Return-type parity: typed CatalogLink (attribute access), like local Catalog.
+        assert links[0].link_type == "cites"
+        assert str(links[0].from_tumbler) == "1.1.3"
 
     def test_link_query(self, client: HttpCatalogClient) -> None:
         links = client.link_query(link_type="cites")

--- a/tests/catalog/test_http_catalog_client.py
+++ b/tests/catalog/test_http_catalog_client.py
@@ -47,12 +47,22 @@ def _fake_tumbler() -> str:
 
 
 def _entry_dict(**kwargs: Any) -> dict:
-    """Minimal server response dict that _to_entry accepts."""
+    """Minimal server response dict that _to_entry accepts.
+
+    nexus-8y1tm: ``file_path``/``source_uri`` defaults are the literal
+    values ``tests/catalog/test_shape_parity_tripwire.py`` seeds onto its
+    local ``doc_a`` fixture — this lets client-side exact-match filters
+    (``by_file_path``, ``by_source_uri``, ``find_by_file_path``,
+    ``resolve_path``) find a match against the fake server too, without a
+    stateful fake.
+    """
     base = {
         "tumbler": _fake_tumbler(),
         "title": "Test Doc",
         "content_type": "paper",
         "chunk_count": 0,
+        "file_path": "src/alpha.py",
+        "source_uri": "file:///tmp/nexus-test/alpha.py",
     }
     base.update(kwargs)
     return base
@@ -115,7 +125,17 @@ class FakeCatalogHandler(BaseHTTPRequestHandler):
         FakeCatalogHandler.get_ops.append(op)
 
         if op == "/stats":
-            self._send_json({"doc_count": 7, "link_count": 3, "owner_count": 2})
+            # nexus-8y1tm: full CatalogRepository.stats() shape (7 keys) —
+            # doc_count/link_count/owner_count were the only 3 pre-existing
+            # keys here; collection_count/chunk_count/links_by_type/
+            # by_content_type added so HttpCatalogClient.stats() (a pure
+            # passthrough of this response) shape-matches Catalog.stats().
+            self._send_json({
+                "doc_count": 7, "link_count": 3, "owner_count": 2,
+                "collection_count": 2, "chunk_count": 5,
+                "links_by_type": {"cites": 1, "relates": 1},
+                "by_content_type": {"code": 5, "prose": 2},
+            })
         elif op == "/show":
             self._send_json(_entry_dict())
         elif op == "/list":
@@ -172,17 +192,109 @@ class FakeCatalogHandler(BaseHTTPRequestHandler):
                 ],
             })
         elif op == "/collections/list":
-            self._send_json({"collections": [{"name": "code__test__voyage-code-3__v1"}]})
+            # nexus-8y1tm: full CatalogRepository.collRow() shape (10 keys) —
+            # owner_id added so collections_by_owner's client-side filter
+            # (c.get("owner_id") == owner_id) has something to match ("1.1" is
+            # the tumbler_prefix every fixture owner in this file uses).
+            # legacy_grandfathered is an int (0/1) on the wire (collRow's
+            # ``legcy`` param is a boxed Integer column, not a boolean) —
+            # deliberately NOT coerced to a Python bool here (see
+            # nexus-8y1tm KNOWN DRIFT note on get_collection/list_collections).
+            self._send_json({"collections": [{
+                "name": "code__test__voyage-code-3__v1", "content_type": "code",
+                "owner_id": "1.1", "embedding_model": "voyage-code-3",
+                "model_version": "1", "display_name": "code__test__voyage-code-3__v1",
+                "legacy_grandfathered": 0, "superseded_by": "", "superseded_at": "",
+                "created_at": "2026-07-01T00:00:00+00:00",
+            }]})
         elif op == "/collections/get":
-            self._send_json({"name": "code__test__voyage-code-3__v1"})
+            # nexus-8y1tm: echo the requested name; full collRow shape.
+            params = self._query_params()
+            name = params.get("name")
+            if not name:
+                self._send_json({"error": "name required"}, 400)
+            else:
+                self._send_json({
+                    "name": name,
+                    "owner_id": "1.1",
+                    "content_type": "code",
+                    "embedding_model": "voyage-code-3",
+                    "model_version": "1",
+                    "display_name": name,
+                    # legacy_grandfathered: int (0/1) on the wire, matching
+                    # CatalogRepository.collRow's boxed-Integer column — see
+                    # the KNOWN DRIFT note where this is registered/excluded.
+                    "legacy_grandfathered": 0 if "__" in name else 1,
+                    "superseded_by": "", "superseded_at": "",
+                    "created_at": "2026-07-01T00:00:00+00:00",
+                })
         elif op == "/collections/for_tuple":
             self._send_json({"name": "code__test__voyage-code-3__v1"})
+        elif op == "/collections/owner-root":
+            params = self._query_params()
+            name = params.get("name")
+            if not name:
+                self._send_json({"error": "name query param required"}, 400)
+            else:
+                self._send_json({"owner_id": "1.1", "repo_root": "/tmp/nexus-test"})
+        elif op == "/collections/health":
+            params = self._query_params()
+            coll = params.get("collection")
+            if not coll:
+                self._send_json({"error": "collection query param required"}, 400)
+            else:
+                self._send_json({
+                    "last_indexed": "2026-07-01T00:00:00+00:00",
+                    "orphan_count": 1,
+                    "stale_source_ratio": 0.0,
+                })
+        elif op == "/coverage":
+            self._send_json({"coverage": [{"content_type": "code", "total": 1, "linked": 1}]})
+        elif op == "/docs/distinct-collections":
+            self._send_json({"collections": ["code__test__voyage-code-3__v1"]})
+        elif op == "/docs/collection-counts":
+            self._send_json({"counts": {"code__test__voyage-code-3__v1": 2}})
+        elif op == "/docs/orphaned":
+            # nexus-8y1tm: CatalogRepository.orphanedDocs() narrow 4-key shape
+            # (tumbler/title/content_type/file_path, all str) — NOT the full
+            # doc-row shape _entry_dict() produces.
+            self._send_json({"documents": [{
+                "tumbler": "1.1.9", "title": "Orphan",
+                "content_type": "code", "file_path": "src/orphan.py",
+            }]})
+        elif op == "/docs/absolute-paths":
+            self._send_json({"documents": [{
+                "tumbler": "1.1.8",
+                "file_path": "/abs/path/doc.txt",
+                "physical_collection": "code__test__voyage-code-3__v1",
+            }]})
+        elif op == "/owners/all-with-roots":
+            self._send_json({"owners": [{
+                "tumbler_prefix": "1.1", "name": "myrepo", "owner_type": "repo",
+                "repo_hash": "fakehash", "description": "", "repo_root": "/tmp/nexus-test",
+                "head_hash": "",
+            }]})
         elif op == "/owners/list":
             self._send_json({"owners": [{"tumbler_prefix": "1.1", "name": "myrepo"}]})
         elif op == "/owners/by_repo":
             self._send_json({"tumbler_prefix": "1.1", "name": "myrepo"})
         elif op == "/owners/by_name":
-            self._send_json({"owners": [{"tumbler_prefix": "1.1", "name": "myrepo"}]})
+            # nexus-8y1tm: owner_type "curator" so curator_owner_tumbler_by_name's
+            # client-side filter (o.get("owner_type") == "curator") has a match.
+            self._send_json({"owners": [
+                {"tumbler_prefix": "1.1", "name": "myrepo", "owner_type": "curator"},
+            ]})
+        elif op == "/owners/show":
+            params = self._query_params()
+            prefix = params.get("tumbler_prefix")
+            if not prefix:
+                self._send_json({"error": "tumbler_prefix required"}, 400)
+            else:
+                self._send_json({
+                    "tumbler_prefix": prefix, "name": "myrepo", "owner_type": "repo",
+                    "repo_hash": "fakehash", "description": "", "repo_root": "/tmp/nexus-test",
+                    "head_hash": "",
+                })
         elif op == "/resolve_span":
             params = self._query_params()
             chash = params.get("span_chash", "")
@@ -287,6 +399,29 @@ class FakeCatalogHandler(BaseHTTPRequestHandler):
             # echo a count for each requested whitelisted relation
             rels = body.get("relations", [])
             self._send_json({"counts": {r: 42 for r in rels}})
+        elif op == "/docs/chunk-counts":
+            ids = body.get("doc_ids", [])
+            self._send_json({i: 3 for i in ids} if ids else {})
+        elif op == "/links/from-batch":
+            tumblers = body.get("tumblers", [])
+            self._send_json(
+                {t: [{"from_tumbler": t, "link_type": "cites"}] for t in tumblers}
+                if tumblers else {}
+            )
+        elif op == "/resolve_many":
+            ids = body.get("doc_ids", [])
+            if not ids:
+                self._send_json({"entries": {}})
+            else:
+                self._send_json({"entries": {i: _entry_dict(tumbler=i) for i in ids}})
+        elif op == "/owners/by_type":
+            owner_type = body.get("owner_type")
+            if not owner_type:
+                self._send_json({"error": "owner_type required"}, 400)
+            else:
+                self._send_json({"owners": [
+                    {"tumbler_prefix": "1.1", "name": "myrepo", "owner_type": owner_type},
+                ]})
         else:
             self._send_json({"ok": True})
 

--- a/tests/catalog/test_http_catalog_client.py
+++ b/tests/catalog/test_http_catalog_client.py
@@ -365,6 +365,37 @@ class FakeCatalogHandler(BaseHTTPRequestHandler):
                     "chunk_text":          "resolved chunk body",
                     "metadata":            {"source": "test"},
                 })
+        elif op == "/resolve_chunk":
+            # nexus-gc2ze: mirrors CatalogHandler.handleResolveChunk exactly —
+            # split on ".", >= 4 segments required, 4th segment must parse as
+            # an int, doc prefix = first 3 segments. Stateless fake: any
+            # well-formed chunk address "resolves" (real 404/400 semantics
+            # depend on a live Postgres document row, exercised by the Java
+            # integration tests instead); "9.9.999.0" stands in for a missing
+            # document so client-side 404-handling has something to hit.
+            params = self._query_params()
+            tumbler = params.get("tumbler", "")
+            segments = tumbler.split(".")
+            if len(segments) < 4:
+                self._send_json({"error": "tumbler is not a chunk address (need >= 4 segments)"}, 400)
+            else:
+                try:
+                    chunk_index = int(segments[3])
+                except ValueError:
+                    self._send_json({"error": "invalid chunk segment"}, 400)
+                else:
+                    doc_tumbler = ".".join(segments[:3])
+                    if doc_tumbler == "9.9.999":
+                        self.send_response(404)
+                        self.end_headers()
+                    else:
+                        self._send_json({
+                            "document_tumbler": doc_tumbler,
+                            "chunk_index": chunk_index,
+                            "physical_collection": "code__test__voyage-code-3__v1",
+                            "title": "Test Doc",
+                            "content_type": "code",
+                        })
         else:
             self._send_json({"error": f"unknown GET op: {op}"}, 404)
 
@@ -1274,6 +1305,70 @@ class TestResolveChash:
         try:
             client = HttpCatalogClient(base_url=base_url, _token="tok")
             result = client.resolve_chash("chash:not-a-valid-hex")
+            assert result is None
+        finally:
+            server.shutdown()
+
+
+class TestResolveChunk:
+    """nexus-gc2ze: HttpCatalogClient.resolve_chunk() real service-mode
+    chunk-address resolution (replaces the ``resolve(tumbler).__dict__``
+    placeholder that treated any tumbler as a document)."""
+
+    def test_resolve_chunk_returns_full_dict(self) -> None:
+        """Happy path: a real 4-segment chunk tumbler resolves to the
+        document + chunk metadata dict."""
+        from nexus.catalog.catalog import Tumbler
+
+        server, base_url = start_fake_server()
+        try:
+            client = HttpCatalogClient(base_url=base_url, _token="tok")
+            t = Tumbler(segments=(1, 1, 1, 2))
+            result = client.resolve_chunk(t)
+            assert result is not None
+            assert result["document_tumbler"] == "1.1.1"
+            assert result["chunk_index"] == 2
+            assert result["physical_collection"] == "code__test__voyage-code-3__v1"
+            assert result["title"] == "Test Doc"
+            assert result["content_type"] == "code"
+        finally:
+            server.shutdown()
+
+    def test_resolve_chunk_accepts_string_tumbler(self) -> None:
+        """String tumblers are parsed before the chunk-address check."""
+        server, base_url = start_fake_server()
+        try:
+            client = HttpCatalogClient(base_url=base_url, _token="tok")
+            result = client.resolve_chunk("1.1.1.0")
+            assert result is not None
+            assert result["chunk_index"] == 0
+        finally:
+            server.shutdown()
+
+    def test_resolve_chunk_non_chunk_tumbler_returns_none_without_wire_call(self) -> None:
+        """A plain 3-segment document tumbler short-circuits to None locally
+        with no wire round-trip — mirroring the local
+        ``Catalog.resolve_chunk``'s ``if tumbler.chunk is None: return None``."""
+        from nexus.catalog.catalog import Tumbler
+
+        server, base_url = start_fake_server()
+        try:
+            FakeCatalogHandler.reset_log()
+            client = HttpCatalogClient(base_url=base_url, _token="tok")
+            result = client.resolve_chunk(Tumbler(segments=(1, 1, 1)))
+            assert result is None
+            assert "/resolve_chunk" not in FakeCatalogHandler.get_ops
+        finally:
+            server.shutdown()
+
+    def test_resolve_chunk_missing_document_returns_none(self) -> None:
+        """A 404 from the server (document not found) maps to None."""
+        from nexus.catalog.catalog import Tumbler
+
+        server, base_url = start_fake_server()
+        try:
+            client = HttpCatalogClient(base_url=base_url, _token="tok")
+            result = client.resolve_chunk(Tumbler(segments=(9, 9, 999, 0)))
             assert result is None
         finally:
             server.shutdown()

--- a/tests/catalog/test_link_generator_service_mode.py
+++ b/tests/catalog/test_link_generator_service_mode.py
@@ -1,0 +1,500 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-6lfdi: PG-world (service-mode) coverage for the catalog auto-link
+generators in ``src/nexus/catalog/link_generator.py``.
+
+``link_generator``'s four ``generate_*`` functions are typed against a local
+``Catalog`` in their docstrings/history but only structurally require the
+caller-facing subset (``all_documents``, ``resolve_path``, ``link_if_absent``)
+— they have ZERO service-mode integration coverage prior to this file (bead
+finding). This is exactly the dict-vs-typed / wire-shape class of bug this
+repo's ``umvh2``-class recurrence guard chases, so this suite drives the real
+client over a fake transport rather than mocking ``Catalog`` methods.
+
+Wiring mirrors production (``src/nexus/indexer.py`` ``_catalog_hook``,
+lines ~934-948, and ``src/nexus/commands/enrich.py`` ``run_bib_enrichment``):
+reads flow through a real ``HttpCatalogClient`` (the ``reader``/``cat`` arg),
+writes flow through a SEPARATE ``HttpCatalogClient`` instance wrapped in
+``_ServiceCatalogWriter`` (the ``writer`` arg) — never the same object,
+matching the reader/writer split ``factory.make_catalog_reader`` /
+``make_catalog_writer`` enforce in service mode.
+
+Distinct from ``tests/catalog/test_http_catalog_client.py``'s
+``FakeCatalogHandler``: that fixture is stateless/canned (one fixed document
+shape per route, shared across ~90 test classes exercising the full client
+surface). The link generators need a small STATEFUL subset (a documents table
++ a links table) so multi-document citation/filepath/pdf-hash scenarios and
+idempotency (``link_if_absent`` re-run == 0 new links) can be exercised
+faithfully without perturbing that shared fixture. This file therefore runs
+its own local fake server — additive, does not touch
+``tests/catalog/test_http_catalog_client.py`` or
+``tests/catalog/test_shape_parity_tripwire.py`` (owned by a sibling bead).
+
+Route shapes (GET ``/list``, ``/show``, ``/link_query``; POST ``/link``) are
+wire-faithful to ``CatalogHandler.java``'s switch cases per the route table
+in ``http_catalog_client.py``'s module docstring.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from nexus.catalog.factory import _ServiceCatalogWriter
+from nexus.catalog.http_catalog_client import HttpCatalogClient
+from nexus.catalog.link_generator import (
+    generate_citation_links,
+    generate_pdf_corpus_links,
+    generate_prose_filepath_links,
+    generate_rdr_filepath_links,
+)
+from nexus.catalog.tumbler import Tumbler
+
+# ── stateful fake server ──────────────────────────────────────────────────────
+
+
+class _State:
+    """Server-side fixture state (documents + links tables), reset per test."""
+
+    documents: dict[str, dict[str, Any]] = {}
+    links: list[dict[str, Any]] = []
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.documents = {}
+        cls.links = []
+
+    @classmethod
+    def add_document(cls, tumbler: str, **fields: Any) -> str:
+        base: dict[str, Any] = {
+            "tumbler": tumbler,
+            "title": tumbler,
+            "content_type": "",
+            "file_path": "",
+            "source_uri": "",
+            "chunk_count": 0,
+            "head_hash": "",
+            "metadata": {},
+            "source_mtime": 0.0,
+            "bib_year": 0,
+            "bib_authors": "",
+            "bib_venue": "",
+            "bib_citation_count": 0,
+        }
+        base.update(fields)
+        cls.documents[tumbler] = base
+        return tumbler
+
+    @classmethod
+    def links_matching(
+        cls, from_t: str, to_t: str, link_type: str,
+    ) -> list[dict[str, Any]]:
+        out = []
+        for lnk in cls.links:
+            if from_t and lnk["from_tumbler"] != from_t:
+                continue
+            if to_t and lnk["to_tumbler"] != to_t:
+                continue
+            if link_type and lnk["link_type"] != link_type:
+                continue
+            out.append(lnk)
+        return out
+
+
+class FakeLinkGenHandler(BaseHTTPRequestHandler):
+    """Minimal stateful fake — only the routes ``link_generator.py`` touches
+    via ``HttpCatalogClient``: GET ``/list``, ``/show``, ``/link_query``;
+    POST ``/link``. Wire shapes mirror ``CatalogHandler.java``'s switch cases
+    (see the route table in ``http_catalog_client.py``'s module docstring).
+    """
+
+    def log_message(self, *args: Any) -> None:
+        pass  # suppress test noise
+
+    def _send_json(self, body: Any, code: int = 200) -> None:
+        data = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _query_params(self) -> dict[str, str]:
+        qs = urlparse(self.path).query
+        return {k: v[0] for k, v in parse_qs(qs).items()} if qs else {}
+
+    def _read_body(self) -> dict:
+        length = int(self.headers.get("Content-Length", 0))
+        if length:
+            return json.loads(self.rfile.read(length))
+        return {}
+
+    def do_GET(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler contract
+        path = urlparse(self.path).path
+        op = path.removeprefix("/v1/catalog")
+        params = self._query_params()
+
+        if op == "/list":
+            docs = list(_State.documents.values())
+            content_type = params.get("content_type")
+            if content_type:
+                # Mirrors CatalogHandler: the content_type branch ignores
+                # limit/offset and returns ALL matching rows in one response
+                # (HttpCatalogClient.all_documents relies on this for its
+                # single-request content_type-filtered path).
+                matched = [d for d in docs if d.get("content_type") == content_type]
+                self._send_json({"documents": matched, "count": len(matched)})
+                return
+            # Unfiltered: HttpCatalogClient.all_documents(limit=0) paginates
+            # with limit=1000/offset stepping until a short page is seen.
+            limit = int(params.get("limit", 0)) or (len(docs) or 1)
+            offset = int(params.get("offset", 0))
+            page = docs[offset:offset + limit]
+            self._send_json({"documents": page, "count": len(page)})
+        elif op == "/show":
+            tumbler = params.get("tumbler", "")
+            doc = _State.documents.get(tumbler)
+            if doc is None:
+                self.send_response(404)
+                self.end_headers()
+                return
+            self._send_json(doc)
+        elif op == "/link_query":
+            matches = _State.links_matching(
+                params.get("from_tumbler", ""),
+                params.get("to_tumbler", ""),
+                params.get("link_type", ""),
+            )
+            self._send_json({"links": matches, "count": len(matches)})
+        else:
+            self._send_json({"error": f"unknown GET op: {op}"}, 404)
+
+    def do_POST(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler contract
+        path = urlparse(self.path).path
+        op = path.removeprefix("/v1/catalog")
+        body = self._read_body()
+
+        if op == "/link":
+            from_t = body.get("from_tumbler", "")
+            to_t = body.get("to_tumbler", "")
+            link_type = body.get("link_type", "")
+            existing = _State.links_matching(from_t, to_t, link_type)
+            if existing:
+                # Real service semantics: POST /link is an UPSERT
+                # (ON CONFLICT DO UPDATE) — merges fields, created=False.
+                existing[0].update({
+                    "created_by": body.get("created_by", ""),
+                    "from_span": body.get("from_span", ""),
+                    "to_span": body.get("to_span", ""),
+                })
+                self._send_json({"ok": True, "created": False})
+            else:
+                _State.links.append({
+                    "from_tumbler": from_t,
+                    "to_tumbler": to_t,
+                    "link_type": link_type,
+                    "created_by": body.get("created_by", ""),
+                    "from_span": body.get("from_span", ""),
+                    "to_span": body.get("to_span", ""),
+                })
+                self._send_json({"ok": True, "created": True})
+        else:
+            self._send_json({"ok": True})
+
+
+def _start_server() -> tuple[HTTPServer, str]:
+    server = HTTPServer(("127.0.0.1", 0), FakeLinkGenHandler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    time.sleep(0.05)  # brief wait for the thread to reach serve_forever
+    return server, f"http://127.0.0.1:{port}"
+
+
+@pytest.fixture
+def fake_server():
+    _State.reset()
+    server, url = _start_server()
+    yield url
+    server.shutdown()
+
+
+@pytest.fixture
+def reader(fake_server: str):
+    with HttpCatalogClient(base_url=fake_server, tenant="tenant_abc", _token="test_tok") as c:
+        yield c
+
+
+@pytest.fixture
+def writer(fake_server: str):
+    # nexus-6lfdi: mirrors production wiring — a SEPARATE HttpCatalogClient
+    # instance from the reader, wrapped in _ServiceCatalogWriter, exactly as
+    # indexer._catalog_hook and commands/enrich.py wire make_catalog_reader()
+    # + make_catalog_writer() as two distinct client objects pointed at the
+    # same service.
+    client = HttpCatalogClient(base_url=fake_server, tenant="tenant_abc", _token="test_tok")
+    w = _ServiceCatalogWriter(client)
+    yield w
+    w.close()
+
+
+# ── generate_citation_links ──────────────────────────────────────────────────
+
+
+class TestCitationLinksServiceMode:
+    def test_citation_from_ss_id(self, reader, writer) -> None:
+        _State.add_document(
+            "1.1.1", title="Paper A", content_type="paper",
+            metadata={"bib_semantic_scholar_id": "ssA", "references": ["ssB"]},
+        )
+        _State.add_document(
+            "1.1.2", title="Paper B", content_type="paper",
+            metadata={"bib_semantic_scholar_id": "ssB"},
+        )
+        count = generate_citation_links(reader, writer=writer)
+        assert count == 1
+        assert len(_State.links) == 1
+        lnk = _State.links[0]
+        assert lnk["from_tumbler"] == "1.1.1"
+        assert lnk["to_tumbler"] == "1.1.2"
+        assert lnk["link_type"] == "cites"
+        assert lnk["created_by"] == "bib_enricher"
+
+    def test_no_self_citation(self, reader, writer) -> None:
+        _State.add_document(
+            "1.1.1", title="Paper A", content_type="paper",
+            metadata={"bib_semantic_scholar_id": "ssA", "references": ["ssA"]},
+        )
+        count = generate_citation_links(reader, writer=writer)
+        assert count == 0
+        assert _State.links == []
+
+    def test_no_link_when_target_missing(self, reader, writer) -> None:
+        _State.add_document(
+            "1.1.1", title="Paper A", content_type="paper",
+            metadata={"bib_semantic_scholar_id": "ssA", "references": ["ssC"]},
+        )
+        count = generate_citation_links(reader, writer=writer)
+        assert count == 0
+
+    def test_no_duplicate_citations_on_rerun(self, reader, writer) -> None:
+        _State.add_document(
+            "1.1.1", title="Paper A", content_type="paper",
+            metadata={"bib_semantic_scholar_id": "ssA", "references": ["ssB"]},
+        )
+        _State.add_document(
+            "1.1.2", title="Paper B", content_type="paper",
+            metadata={"bib_semantic_scholar_id": "ssB"},
+        )
+        first = generate_citation_links(reader, writer=writer)
+        second = generate_citation_links(reader, writer=writer)
+        assert first == 1
+        assert second == 0  # link_if_absent's pre-flight /link_query hit
+        assert len(_State.links) == 1  # no duplicate row created server-side
+
+    def test_openalex_id_space_also_matches(self, reader, writer) -> None:
+        """nexus-57mk: bib_openalex_id is indexed alongside
+        bib_semantic_scholar_id in the same id_to_tumbler map."""
+        _State.add_document(
+            "1.1.1", title="Paper A", content_type="paper",
+            metadata={"bib_openalex_id": "W1", "references": ["W2"]},
+        )
+        _State.add_document(
+            "1.1.2", title="Paper B", content_type="paper",
+            metadata={"bib_openalex_id": "W2"},
+        )
+        count = generate_citation_links(reader, writer=writer)
+        assert count == 1
+
+
+# ── generate_rdr_filepath_links ───────────────────────────────────────────────
+
+
+class TestRdrFilepathLinksServiceMode:
+    def test_backtick_path_creates_link(self, reader, writer, tmp_path) -> None:
+        rdr_path = tmp_path / "rdr.md"
+        rdr_path.write_text("We modified `src/nexus/catalog/catalog.py` to fix the bug.")
+        _State.add_document(
+            "1.1.1", title="catalog.py", content_type="code",
+            file_path="src/nexus/catalog/catalog.py",
+        )
+        _State.add_document(
+            "1.1.2", title="Fix Catalog Bug", content_type="rdr",
+            file_path=str(rdr_path),
+        )
+        count = generate_rdr_filepath_links(reader, writer=writer)
+        assert count == 1
+        lnk = _State.links[0]
+        assert lnk["from_tumbler"] == "1.1.2"
+        assert lnk["to_tumbler"] == "1.1.1"
+        assert lnk["link_type"] == "implements"
+        assert lnk["created_by"] == "filepath_extractor"
+
+    def test_no_link_for_unindexed_path(self, reader, writer, tmp_path) -> None:
+        rdr_path = tmp_path / "rdr.md"
+        rdr_path.write_text("See `src/nexus/missing_file.py` for details.")
+        _State.add_document(
+            "1.1.1", title="Dangling Ref", content_type="rdr",
+            file_path=str(rdr_path),
+        )
+        count = generate_rdr_filepath_links(reader, writer=writer)
+        assert count == 0
+
+    def test_rdr_without_file_on_disk_skipped(self, reader, writer) -> None:
+        _State.add_document(
+            "1.1.1", title="ghost.py", content_type="code",
+            file_path="src/ghost.py",
+        )
+        _State.add_document(
+            "1.1.2", title="Ghost RDR", content_type="rdr",
+            file_path="/nonexistent/path/rdr.md",
+        )
+        count = generate_rdr_filepath_links(reader, writer=writer)
+        assert count == 0
+
+    def test_no_duplicate_on_rerun(self, reader, writer, tmp_path) -> None:
+        rdr_path = tmp_path / "rdr.md"
+        rdr_path.write_text("Edit `src/catalog.py`.")
+        _State.add_document(
+            "1.1.1", title="catalog.py", content_type="code",
+            file_path="src/catalog.py",
+        )
+        _State.add_document(
+            "1.1.2", title="Catalog Work", content_type="rdr",
+            file_path=str(rdr_path),
+        )
+        generate_rdr_filepath_links(reader, writer=writer)
+        second = generate_rdr_filepath_links(reader, writer=writer)
+        assert second == 0
+        assert len(_State.links) == 1
+
+    def test_incremental_new_tumblers_scopes_scan(self, reader, writer, tmp_path) -> None:
+        a_rdr = tmp_path / "a.md"
+        a_rdr.write_text("See `src/nexus/a.py`.")
+        b_rdr = tmp_path / "b.md"
+        b_rdr.write_text("See `src/nexus/b.py`.")
+        _State.add_document("1.1.1", title="a.py", content_type="code", file_path="src/nexus/a.py")
+        _State.add_document("1.1.2", title="b.py", content_type="code", file_path="src/nexus/b.py")
+        _State.add_document("1.1.3", title="RDR A", content_type="rdr", file_path=str(a_rdr))
+        _State.add_document("1.1.4", title="RDR B", content_type="rdr", file_path=str(b_rdr))
+
+        count = generate_rdr_filepath_links(
+            reader, writer=writer, new_tumblers=[Tumbler.parse("1.1.3")],
+        )
+        assert count == 1
+        assert len(_State.links) == 1
+        assert _State.links[0]["from_tumbler"] == "1.1.3"
+
+
+# ── generate_prose_filepath_links ────────────────────────────────────────────
+
+
+class TestProseFilepathLinksServiceMode:
+    def test_prose_doc_links_to_code(self, reader, writer, tmp_path) -> None:
+        prose_path = tmp_path / "runbook.md"
+        prose_path.write_text("See ``src/nexus/foo.py`` for the impl.\n")
+        _State.add_document(
+            "1.1.1", title="Runbook", content_type="prose",
+            file_path=str(prose_path),
+        )
+        _State.add_document(
+            "1.1.2", title="foo.py", content_type="code",
+            file_path="src/nexus/foo.py",
+        )
+        count = generate_prose_filepath_links(reader, writer=writer)
+        assert count == 1
+        lnk = _State.links[0]
+        assert lnk["from_tumbler"] == "1.1.1"
+        assert lnk["to_tumbler"] == "1.1.2"
+        assert lnk["link_type"] == "implements"
+
+    def test_non_source_root_dir_links(self, reader, writer, tmp_path) -> None:
+        """nexus-sob9 widening contract: docs/ -> conexus/ (no src/ anchor)
+        must link via the wider prose regex."""
+        prose_path = tmp_path / "guide.md"
+        prose_path.write_text("See ``conexus/skills/foo.md`` for usage.\n")
+        _State.add_document(
+            "1.1.1", title="Guide", content_type="prose",
+            file_path=str(prose_path),
+        )
+        _State.add_document(
+            "1.1.2", title="foo.md", content_type="code",
+            file_path="conexus/skills/foo.md",
+        )
+        count = generate_prose_filepath_links(reader, writer=writer)
+        assert count == 1
+
+    def test_bare_filename_does_not_match(self, reader, writer, tmp_path) -> None:
+        prose_path = tmp_path / "loose.md"
+        prose_path.write_text("Run ``foo.py`` to start.\n")
+        _State.add_document(
+            "1.1.1", title="Loose", content_type="prose",
+            file_path=str(prose_path),
+        )
+        _State.add_document(
+            "1.1.2", title="foo.py", content_type="code", file_path="foo.py",
+        )
+        count = generate_prose_filepath_links(reader, writer=writer)
+        assert count == 0
+
+
+# ── generate_pdf_corpus_links ────────────────────────────────────────────────
+
+
+class TestPdfCorpusLinksServiceMode:
+    def test_two_pdfs_with_same_hash_get_linked(self, reader, writer) -> None:
+        _State.add_document(
+            "1.1.1", title="Paper1", content_type="paper",
+            head_hash="abc123", physical_collection="knowledge__delos",
+        )
+        _State.add_document(
+            "1.1.2", title="Paper2", content_type="paper",
+            head_hash="abc123", physical_collection="knowledge__art-papers",
+        )
+        count = generate_pdf_corpus_links(reader, writer=writer)
+        assert count == 1
+        lnk = _State.links[0]
+        # anchor = lexicographically-first tumbler ("1.1.1" < "1.1.2")
+        assert lnk["from_tumbler"] == "1.1.2"
+        assert lnk["to_tumbler"] == "1.1.1"
+        assert lnk["link_type"] == "same-as"
+        assert lnk["created_by"] == "content_hash_dedup"
+
+    def test_no_link_when_hash_unique(self, reader, writer) -> None:
+        _State.add_document(
+            "1.1.1", title="Unique", content_type="paper",
+            head_hash="unique-hash", physical_collection="knowledge__delos",
+        )
+        count = generate_pdf_corpus_links(reader, writer=writer)
+        assert count == 0
+
+    def test_idempotent(self, reader, writer) -> None:
+        _State.add_document(
+            "1.1.1", title="P1", content_type="paper",
+            head_hash="h1", physical_collection="knowledge__delos",
+        )
+        _State.add_document(
+            "1.1.2", title="P2", content_type="paper",
+            head_hash="h1", physical_collection="knowledge__art-papers",
+        )
+        first = generate_pdf_corpus_links(reader, writer=writer)
+        second = generate_pdf_corpus_links(reader, writer=writer)
+        assert first == 1
+        assert second == 0
+        assert len(_State.links) == 1
+
+    def test_pdfs_without_head_hash_skipped(self, reader, writer) -> None:
+        _State.add_document(
+            "1.1.1", title="NoHash1", content_type="paper",
+            head_hash="", physical_collection="knowledge__delos",
+        )
+        _State.add_document(
+            "1.1.2", title="NoHash2", content_type="paper",
+            head_hash="", physical_collection="knowledge__art-papers",
+        )
+        count = generate_pdf_corpus_links(reader, writer=writer)
+        assert count == 0

--- a/tests/catalog/test_shape_parity_t3_leg.py
+++ b/tests/catalog/test_shape_parity_t3_leg.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-oq0tk: T3-backed shape-parity leg for resolve_chash / resolve_span.
+
+``tests/catalog/test_shape_parity_tripwire.py`` (nexus-8y1tm) excludes
+``Catalog.resolve_chash`` and ``Catalog.resolve_span`` from its main
+REGISTRY because both need a live T3 ``ClientAPI`` — ``catalog_spans.py``
+queries a real vector collection (``col.get(where={"chunk_text_hash": ...})``),
+which the catalog-metadata-only harness (SQLite + a fake HTTP server) does
+not stand up. This module is the follow-up leg: it wires a real
+``chromadb.EphemeralClient`` alongside the same paired-assertion pattern
+(reusing ``shape()`` from the tripwire module rather than duplicating it),
+so these two methods get real shape-parity coverage instead of shipping
+their return-shape drift silently.
+
+Two scenarios:
+
+- ``resolve_span``: a chunk seeded directly into an EphemeralClient
+  collection (mirrors ``resolve_span_in_t3``'s ``col.get(where=...)``
+  query) vs ``HttpCatalogClient.resolve_span`` against
+  ``FakeCatalogHandler``'s ``/resolve_span`` route.
+- ``resolve_chash``: a chunk seeded into T3 *and* registered in a real
+  ``ChashIndex`` (T2), plus a real ``Catalog`` doc + manifest referencing
+  the same chash (the "real Catalog scenario" a resolve_chash caller
+  would actually see) vs ``HttpCatalogClient.resolve_chash`` against the
+  ``/resolve_chash`` route.
+
+Both fixture chashes are chosen to land on ``FakeCatalogHandler``'s
+non-empty, non-404 response branches — see the literals' comments below
+for exactly which server-side branch each one drives.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import chromadb
+import pytest
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.http_catalog_client import HttpCatalogClient
+from nexus.db.t2.chash_index import ChashIndex
+from tests.catalog.test_http_catalog_client import start_fake_server
+from tests.catalog.test_shape_parity_tripwire import shape
+
+# ── fixture literals ─────────────────────────────────────────────────────────
+
+# 64-hex chash for the resolve_span scenario. FakeCatalogHandler's /resolve_span
+# route special-cases span_chash == "deadbeef" * 4 (the [:32] prefix the client
+# sends) AND collection == _SPAN_COLLECTION to return a non-empty metadata dict
+# ({"lang": "en"}) — every OTHER chash hits the generic branch, which returns
+# metadata={} (empty dict), a shape MISMATCH against a genuinely-populated local
+# chroma metadata dict. This literal must stay in lockstep with that branch.
+_SPAN_CHASH = "deadbeef" * 8
+_SPAN_COLLECTION = "knowledge__o__bge-768__v1"
+
+# 64-hex chash for the resolve_chash scenario. Any value other than
+# FakeCatalogHandler's 404 sentinel ("00000000" * 4, the [:32] prefix) hits its
+# generic /resolve_chash 200 branch, so this literal is not otherwise special.
+_CHASH_GLOBAL = "c" * 64
+_CHASH_COLLECTION = "code__t3leg-chash__v1"
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def env(tmp_path: Path) -> Iterator[tuple[Catalog, "chromadb.ClientAPI", ChashIndex]]:
+    """Real Catalog (SQLite) + real EphemeralClient T3 + real ChashIndex (T2),
+    seeded with a registered doc+manifest (resolve_chash's "real usage" shape)
+    plus the two raw T3 chunks each method under test actually queries."""
+    catalog_dir = tmp_path / "catalog"
+    catalog_dir.mkdir()
+    cat = Catalog(catalog_dir=catalog_dir, db_path=tmp_path / "catalog.sqlite")
+
+    # chromadb.EphemeralClient instances share an in-memory backend across the
+    # test session — collections leak between tests in the same process.
+    # Clear on entry (same pattern as test_chash_reconcile.py).
+    client = chromadb.EphemeralClient()
+    for c in list(client.list_collections()):
+        name = c if isinstance(c, str) else c.name
+        try:
+            client.delete_collection(name)
+        except Exception:  # noqa: BLE001 — best-effort cleanup of leaked ephemeral state
+            pass
+
+    chash_idx = ChashIndex(tmp_path / "t2-chash.db")
+
+    # A real registered doc + manifest referencing the resolve_chash target —
+    # the scenario a production resolve_chash caller actually sees, even
+    # though the method itself resolves via T2/T3 directly, not the manifest.
+    owner = cat.register_owner("nexus-t3leg", "repo", repo_hash="t3leg-hash")
+    doc = cat.register(
+        owner, "t3leg_doc.py", content_type="code",
+        file_path="src/t3leg_doc.py", physical_collection=_CHASH_COLLECTION,
+    )
+    cat.write_manifest(str(doc), [{"chash": _CHASH_GLOBAL, "position": 0}])
+
+    chash_col = client.get_or_create_collection(_CHASH_COLLECTION)
+    chash_col.add(
+        ids=["t3leg-chash-chunk"],
+        documents=["chunk body text"],
+        metadatas=[{"chunk_text_hash": _CHASH_GLOBAL, "source": "test"}],
+    )
+    chash_idx.upsert(chash=_CHASH_GLOBAL, collection=_CHASH_COLLECTION)
+
+    span_col = client.get_or_create_collection(_SPAN_COLLECTION)
+    span_col.add(
+        ids=["t3leg-span-chunk"],
+        documents=["hello span world"],
+        metadatas=[{"chunk_text_hash": _SPAN_CHASH, "lang": "en"}],
+    )
+
+    yield cat, client, chash_idx
+
+    chash_idx.close()
+    cat.close()
+
+
+@pytest.fixture()
+def http_client() -> Iterator[HttpCatalogClient]:
+    server, url = start_fake_server()
+    try:
+        with HttpCatalogClient(base_url=url, _token="t3-leg-tok") as c:
+            yield c
+    finally:
+        server.shutdown()
+
+
+# ── parity assertions ────────────────────────────────────────────────────────
+
+
+def test_resolve_span_t3_parity(
+    env: tuple[Catalog, "chromadb.ClientAPI", ChashIndex],
+    http_client: HttpCatalogClient,
+) -> None:
+    cat, t3, _chash_idx = env
+
+    local_result = cat.resolve_span(f"chash:{_SPAN_CHASH}", _SPAN_COLLECTION, t3)
+    http_result = http_client.resolve_span(f"chash:{_SPAN_CHASH}", _SPAN_COLLECTION)
+
+    assert local_result, "local resolve_span returned vacuously empty — strengthen the seed"
+    assert http_result, "http resolve_span returned vacuously empty — strengthen the fake route"
+
+    local_shape = shape(local_result)
+    http_shape = shape(http_result)
+    assert local_shape == http_shape, (
+        f"resolve_span: shape mismatch — local={local_shape!r} http={http_shape!r} "
+        f"(local value: {local_result!r}, http value: {http_result!r})"
+    )
+
+
+def test_resolve_chash_t3_parity(
+    env: tuple[Catalog, "chromadb.ClientAPI", ChashIndex],
+    http_client: HttpCatalogClient,
+) -> None:
+    cat, t3, chash_idx = env
+
+    local_result = cat.resolve_chash(_CHASH_GLOBAL, t3, chash_idx)
+    http_result = http_client.resolve_chash(f"chash:{_CHASH_GLOBAL}")
+
+    assert local_result, "local resolve_chash returned vacuously empty — strengthen the seed"
+    assert http_result, "http resolve_chash returned vacuously empty — strengthen the fake route"
+
+    local_shape = shape(local_result)
+    http_shape = shape(http_result)
+    assert local_shape == http_shape, (
+        f"resolve_chash: shape mismatch — local={local_shape!r} http={http_shape!r} "
+        f"(local value: {local_result!r}, http value: {http_result!r})"
+    )

--- a/tests/catalog/test_shape_parity_tripwire.py
+++ b/tests/catalog/test_shape_parity_tripwire.py
@@ -1,0 +1,660 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-8y1tm: mechanized runtime return-SHAPE tripwire for HttpCatalogClient.
+
+The h8rf6.3 incident class: a client method returning a runtime shape that
+differs from the local ``Catalog``'s (flat list vs dict, ``None`` vs ``""``,
+bool vs int) passes the annotation-comparison fidelity test and every
+MagicMock-consumer test, then breaks a production consumer silently.
+``test_docs_for_chashes_shape_conformance.py`` pinned ONE method; this module
+generalizes the paired-assertion pattern across the shared public surface
+and — the mechanized part — FAILS when a shared method is neither registered
+here nor excluded with a documented reason. A new/changed method cannot ship
+without a parity entry.
+
+Three pieces:
+
+1. ``shape(value)`` — recursive runtime-shape descriptor. Exact types
+   (``bool`` is not ``int``), dataclass class names, container element
+   shapes, ``None`` distinct from ``""``.
+2. ``REGISTRY`` — per-method parity entries: call args + which side of the
+   seeded state they exercise. The harness calls the seeded local
+   ``Catalog`` and the real ``HttpCatalogClient`` against the wire-faithful
+   fake server, then asserts ``shape(local) == shape(http)``.
+3. ``EXCLUSIONS`` — shared methods deliberately not parity-tested, each with
+   a reason string. Auditable, never silent.
+
+Vacuity guard: entries must produce a NON-EMPTY result on both sides unless
+``empty_ok=True`` (with the reason in the entry's comment) — empty-vs-empty
+parity proves nothing.
+"""
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+import inspect
+
+import pytest
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.http_catalog_client import HttpCatalogClient
+from tests.catalog.test_http_catalog_client import (
+    CHUNK_SHA_A,
+    CHUNK_SHA_B,
+    start_fake_server,
+)
+
+
+# ── 1. shape descriptor ──────────────────────────────────────────────────────
+
+
+def shape(value: Any, *, _depth: int = 0) -> Any:
+    """Recursive runtime-shape descriptor for return-value parity.
+
+    - exact type() (so bool != int, and None != "")
+    - dataclasses collapse to ("dataclass", ClassName) — field-level drift
+      is a CatalogEntry/QueueRow definition change, caught elsewhere
+    - containers descend into elements; heterogeneous element shapes are
+      preserved as a sorted set of reprs so ordering differences don't flake
+
+    KNOWN LIMITATION (critique, 2026-07-04): container CARDINALITY is
+    deliberately discarded (a 1-item and a 100-item list of the same
+    element shape are identical) — this harness catches type-level drift
+    (the h8rf6.3 incident class), not count drift; per-method tests in
+    test_http_catalog_client.py own cardinality.
+    """
+    if _depth > 6:  # cycles / pathological nesting fail loud
+        raise AssertionError("shape(): nesting too deep")
+    if value is None:
+        return "None"
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return ("dataclass", type(value).__name__)
+    t = type(value)
+    if t in (bool, int, float, str, bytes):
+        return t.__name__
+    if t in (list, tuple, set, frozenset):
+        elems = {repr(shape(v, _depth=_depth + 1)) for v in value}
+        return (t.__name__, tuple(sorted(elems)))
+    if t is dict:
+        entries = {
+            repr((shape(k, _depth=_depth + 1), shape(v, _depth=_depth + 1)))
+            for k, v in value.items()
+        }
+        return ("dict", tuple(sorted(entries)))
+    # Tumbler and other value objects: exact class name.
+    return ("object", t.__name__)
+
+
+def _is_empty(value: Any) -> bool:
+    if isinstance(value, bool):
+        return False  # False is a legitimate result, not vacuity (bool==0 trap)
+    if value is None or value == "" or value == 0:
+        return True
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) == 0
+    return False
+
+
+# ── 2. registry ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Parity:
+    """One method's parity entry.
+
+    ``args``/``kwargs`` may be callables taking the seeded ``Seeds``
+    context (so entries can reference tumblers created at seed time).
+    ``empty_ok`` requires a justification in a trailing comment.
+    """
+
+    method: str
+    args: tuple = ()
+    kwargs: dict = field(default_factory=dict)
+    empty_ok: bool = False
+    #: REQUIRED when empty_ok=True — machine-checked by the completeness gate.
+    empty_reason: str = ""
+
+
+@dataclass
+class Seeds:
+    """Identifiers created by the seed step, shared by both sides."""
+
+    owner: Any = None                 # Tumbler of the seeded repo owner ("1.1")
+    curator_owner: Any = None         # Tumbler of a curator-type owner (no repo_root)
+    doc_a: Any = None                 # Tumbler of doc A (code, has manifest, linked -> B)
+    doc_b: Any = None                 # Tumbler of doc B (prose, linked from A)
+    # Isolated targets for destructive / void operations — kept SEPARATE from
+    # doc_a/doc_b/collection so read-only REGISTRY entries stay valid
+    # regardless of parametrize execution order.
+    doc_c_orphan: Any = None          # zero links -> orphaned_docs
+    doc_abs_path: Any = None          # absolute file_path -> docs_with_absolute_paths
+    doc_delete: Any = None            # delete_document target
+    doc_purge: Any = None             # purge_manifest_for_doc target (has its own manifest)
+    doc_atomic: Any = None            # atomic_manifest_replace target
+    doc_write_manifest: Any = None    # write_manifest target
+    doc_alias_src: Any = None         # set_alias source (aliased -> doc_a)
+    doc_update: Any = None            # update() target
+    doc_update_collection: Any = None       # update_document_collection target
+    doc_update_collection_batch: Any = None # update_documents_collection_batch target
+    doc_append: Any = None                  # append_manifest_chunks/resync target (mutated additively)
+    doc_unlink_a: Any = None
+    doc_unlink_b: Any = None
+    doc_rename_src: Any = None        # rename_collection target doc
+
+    collection: str = "code__nexus-test__voyage-code-3__v1"
+    docs_collection: str = "docs__nexus-test__voyage-context-3__v1"
+    legacy_collection: str = "legacy-collection-name-8y1tm"       # non-conformant -> legacy=True
+    delete_proj_collection: str = "code__delproj-8y1tm__v1"
+    rename_old_collection: str = "code__renameold-8y1tm__v1"
+    rename_new_collection: str = "code__renamenew-8y1tm__v1"
+    supersede_old_collection: str = "code__supold-8y1tm__v1"
+    supersede_new_collection: str = "code__supnew-8y1tm__v1"
+
+    repo_hash: str = "8y1tmhash"
+    # nexus-8y1tm: these MUST be the shared fixture chashes from
+    # test_http_catalog_client.py, not arbitrary literals — the fake's
+    # /manifest/get_many route echoes back CHASH_A unconditionally
+    # (test_http_catalog_client.FakeCatalogHandler.do_POST), so
+    # docs_for_chashes' second-round-trip intersection only produces a
+    # non-empty result when the requested chash matches that literal.
+    chash_a: str = CHUNK_SHA_A
+    chash_b: str = CHUNK_SHA_B
+    file_a: str = "src/alpha.py"
+    file_b: str = "docs/beta.md"
+    # nexus-8y1tm: these two literals MUST match FakeCatalogHandler._entry_dict()'s
+    # defaults (tests/catalog/test_http_catalog_client.py) — by_file_path /
+    # by_source_uri / find_by_file_path / resolve_path exact-match filter
+    # client-side against whatever /list or /show returns, and the fake has no
+    # stateful backing store, so the fixture and the fake must agree on the
+    # literal value up front.
+    source_uri_a: str = "file:///tmp/nexus-test/alpha.py"
+    corpus_a: str = "test-corpus-8y1tm"
+
+
+REGISTRY: list[Parity] = [
+    # ── docs cluster ─────────────────────────────────────────────────────
+    Parity("by_owner", args=(lambda s: s.owner,)),
+    Parity("by_file_path", args=(lambda s: s.owner, lambda s: s.file_a)),
+    Parity("by_content_type", args=("code",)),
+    Parity("resolve", args=(lambda s: s.doc_a,)),
+    Parity("docs_for_chashes", args=(lambda s: [s.chash_a],)),
+    Parity(
+        "lookup_doc_id_by_collection_and_path",
+        args=(lambda s: s.collection, lambda s: s.file_a),
+    ),
+    Parity("all_documents"),
+    Parity("by_corpus", args=(lambda s: s.corpus_a,)),
+    Parity("by_doc_id", args=(lambda s: str(s.doc_a),)),
+    Parity("by_source_uri", args=(lambda s: s.source_uri_a,)),
+    Parity("find", args=("alpha",)),
+    Parity("find_by_file_path", args=(lambda s: s.file_a,)),
+    Parity("list_by_collection", args=(lambda s: s.collection,)),
+    Parity("resolve_many", args=(lambda s: [str(s.doc_a)],)),
+    Parity("resolve_alias", args=(lambda s: s.doc_a,)),
+    Parity("resolve_path", args=(lambda s: s.doc_a,)),
+    Parity("doc_count"),
+    Parity(
+        "register",
+        args=(lambda s: s.owner, "Registered Doc 8y1tm"),
+        kwargs={"content_type": "code", "file_path": "src/registered_8y1tm.py"},
+    ),
+    Parity(
+        "update", args=(lambda s: s.doc_update,), kwargs={"title": "Updated Title 8y1tm"},
+        empty_ok=True, empty_reason="void write: update() returns None on both sides",
+    ),
+    Parity("delete_document", args=(lambda s: s.doc_delete,)),
+    Parity(
+        "set_alias", args=(lambda s: s.doc_alias_src, lambda s: s.doc_a),
+        empty_ok=True, empty_reason="void write: set_alias() returns None on both sides",
+    ),
+
+    # ── owners cluster ───────────────────────────────────────────────────
+    Parity("owner_for_repo", args=(lambda s: s.repo_hash,)),
+    Parity("list_owners"),
+    Parity(
+        "register_owner", args=("nexus-test-owner2-8y1tm", "repo"),
+        kwargs={"repo_hash": "anotherhash8y1tm"},
+    ),
+    Parity(
+        "ensure_owner_for_repo",
+        args=(lambda s: Path("/tmp/nexus-test-ensure-8y1tm"),),
+        kwargs={"repo_name": "nexus-ensure-8y1tm"},
+    ),
+    Parity("owner_tumblers_by_name", args=("nexus-test",)),
+    Parity("curator_owner_tumbler_by_name", args=("nexus-curator-8y1tm",)),
+    Parity("get_owner_by_prefix", args=(lambda s: str(s.owner),)),
+    Parity("list_owners_by_type", args=("repo",)),
+    Parity(
+        "set_owner_head_hash", args=(lambda s: s.owner, "deadbeef8y1tm"),
+    ),
+    Parity("owners_with_roots"),
+    Parity("distinct_doc_collections"),
+    Parity("docs_with_absolute_paths"),
+    Parity("orphaned_docs"),
+    Parity("collection_doc_counts"),
+    Parity("coverage_by_content_type", args=(lambda s: str(s.owner),)),
+    Parity("get_collection_owner_root", args=(lambda s: s.collection,)),
+    Parity("chunk_counts_for_docs", args=(lambda s: [str(s.doc_a)],)),
+    Parity("links_from_batch", args=(lambda s: [str(s.doc_a)],)),
+    Parity("stats"),
+
+    # ── links cluster ────────────────────────────────────────────────────
+    Parity("links_from", args=(lambda s: s.doc_a,)),
+    Parity("link_query", kwargs={"link_type": "cites"}),
+    Parity(
+        "link", args=("9.7.1", "9.7.2", "test-link", "parity-test"),
+        kwargs={"allow_dangling": True},
+    ),
+    Parity(
+        "link_if_absent",
+        args=("9.9.9", "9.9.8", "test-link-if-absent", "parity-test"),
+        kwargs={"allow_dangling": True},
+        # FakeCatalogHandler.link_absent_from == "9.9.9": the fake's
+        # /link_query reports NO existing link for this from_tumbler, driving
+        # the same "insert" branch the local (genuinely new) pair takes.
+    ),
+    Parity(
+        "unlink",
+        args=(lambda s: str(s.doc_unlink_a), lambda s: str(s.doc_unlink_b)),
+        kwargs={"link_type": "relates"},
+    ),
+    Parity(
+        "bulk_unlink", kwargs={"link_type": "cites", "dry_run": True},
+        # dry_run=True: read-only count via link_query, doesn't touch the
+        # doc_a -> doc_b "cites" link other entries depend on.
+    ),
+
+    # ── collections cluster ──────────────────────────────────────────────
+    Parity("is_legacy_collection", args=(lambda s: s.legacy_collection,)),
+    Parity(
+        "collection_for", args=("code", lambda s: s.owner, "voyage-code-3"),
+    ),
+    Parity(
+        "register_collection", args=(lambda s: s.collection,),
+        kwargs={
+            "content_type": "code", "owner_id": "1.1",
+            "embedding_model": "voyage-code-3", "model_version": "v1",
+        },
+        empty_ok=True, empty_reason="void write: register_collection() returns None on both sides",
+    ),
+    Parity(
+        "delete_collection_projection", args=(lambda s: s.delete_proj_collection,),
+        kwargs={"reason": "parity-test"},
+        empty_ok=True,
+        empty_reason=(
+            "HttpCatalogClient ALWAYS returns False (hard delete not "
+            "implemented service-side, guard+track bead nexus-gmiaf.24 per "
+            "its own docstring); shape (bool) still conforms to local's "
+            "real True/False — only the HTTP-side value is falsy by design"
+        ),
+    ),
+    Parity(
+        "supersede_collection",
+        args=(lambda s: s.supersede_old_collection, lambda s: s.supersede_new_collection),
+        empty_ok=True, empty_reason="void write: returns None on both sides",
+    ),
+    Parity(
+        "rename_collection",
+        args=(lambda s: s.rename_old_collection, lambda s: s.rename_new_collection),
+    ),
+    Parity(
+        "update_document_collection",
+        args=(lambda s: str(s.doc_update_collection), "code__updated-8y1tm__v1"),
+    ),
+    Parity(
+        "update_documents_collection_batch",
+        args=(lambda s: [(str(s.doc_update_collection_batch), "code__updated2-8y1tm__v1")],),
+    ),
+
+    # ── manifest cluster ─────────────────────────────────────────────────
+    Parity("chashes_for_collection", args=(lambda s: s.collection,)),
+    Parity("get_manifest", args=(lambda s: str(s.doc_a),)),
+    Parity("get_manifests", args=(lambda s: [str(s.doc_a)],)),
+    Parity("get_chunk_chashes", args=(lambda s: str(s.doc_a),)),
+    Parity(
+        "write_manifest",
+        args=(lambda s: str(s.doc_write_manifest), [{"chash": "e" * 64, "position": 0}]),
+        empty_ok=True, empty_reason="void write: returns None on both sides",
+    ),
+    Parity(
+        "append_manifest_chunks",
+        args=(lambda s: str(s.doc_append), [{"chash": "f" * 64, "position": 1}]),
+        empty_ok=True, empty_reason="void write: returns None on both sides",
+    ),
+    Parity(
+        "atomic_manifest_replace",
+        args=(lambda s: str(s.doc_atomic), [{"chash": "a" * 64, "position": 0}]),
+        empty_ok=True, empty_reason="void write: returns None on both sides",
+    ),
+    Parity(
+        "purge_manifest_for_doc", args=(lambda s: str(s.doc_purge),),
+        empty_ok=True, empty_reason="void write: returns None on both sides",
+    ),
+    Parity(
+        "resync_chunk_count_cache", args=(lambda s: str(s.doc_append),),
+        empty_ok=True, empty_reason="void write: returns None on both sides",
+    ),
+]
+
+
+#: Shared methods deliberately NOT parity-tested. Every entry carries a
+#: reason; the completeness gate treats this list as the only escape hatch.
+EXCLUSIONS: dict[str, str] = {
+    "close": "lifecycle plumbing; no wire round-trip, nothing to compare",
+    "is_initialized": "local filesystem probe vs service liveness — semantically different by design (RDR-168)",
+    # ── pure local-mode semantics (catalog-git-DECISION Option C): Postgres
+    # is the sole write authority in service mode; these are SQLite/git-only
+    # artifacts with NO wire equivalent. HttpCatalogClient deliberately
+    # raises NotImplementedError / returns a fixed empty value for every one
+    # of these — there is no shape to compare against a real service route.
+    "rebuild": "SQLite-projection rebuild; HttpCatalogClient.rebuild() raises NotImplementedError by design (catalog-git-DECISION Option C) — no wire equivalent",
+    "defrag": "JSONL compaction; HttpCatalogClient.defrag() raises NotImplementedError by design (catalog-git-DECISION Option C) — no wire equivalent",
+    "compact": "JSONL compaction; HttpCatalogClient.compact() raises NotImplementedError by design (catalog-git-DECISION Option C) — no wire equivalent",
+    "sync": "git commit operation; HttpCatalogClient.sync() raises NotImplementedError by design — no wire equivalent",
+    "pull": "git pull operation; HttpCatalogClient.pull() raises NotImplementedError by design — no wire equivalent",
+    "jsonl_paths": "pure local event-log filesystem paths; HttpCatalogClient returns a fixed empty tuple — no wire equivalent",
+    "mtime_paths": "pure local event-log filesystem paths; HttpCatalogClient returns a fixed empty tuple — no wire equivalent",
+    # ── documented HttpCatalogClient stubs (not wire-shape bugs): the
+    # docstrings on these methods say outright they are unsupported in
+    # service mode. Comparing local's real result against a permanently
+    # empty/None stub is not a meaningful shape assertion — it would just
+    # encode "the stub is a stub" as a passing test.
+    "link_audit": "HttpCatalogClient.link_audit() unconditionally returns {} per its own docstring ('not supported in initial service-mode implementation') — documented capability gap, not a wire-shape bug",
+    "resolve_span_text": "HttpCatalogClient.resolve_span_text() unconditionally returns None per its own docstring ('not supported in initial service-mode implementation') — documented capability gap, not a wire-shape bug",
+    # ── requires a live T3 (ChromaDB) handle the catalog-only parity
+    # harness does not stand up: both resolve local chunk text via a real
+    # ClientAPI.get_collection(...).get(where=...) call (catalog_spans.py);
+    # HttpCatalogClient's t3 param is accepted-but-unused (resolution is
+    # server-side). Meaningfully exercising the LOCAL side would require
+    # wiring a second storage tier (an EphemeralClient with a real indexed
+    # chunk) into what is otherwise a SQLite+HTTP-only fixture — out of
+    # scope here, tracked as a follow-up rather than excluded silently.
+    "resolve_chash": "requires a live T3 ClientAPI (catalog_spans.resolve_chash_globally queries a real chroma collection); out of scope for this catalog-metadata-only harness (T3-backed parity tracked on bead nexus-oq0tk), not a wire-shape gap",
+    "resolve_span": "requires a live T3 ClientAPI (catalog_spans.resolve_span_in_t3 queries a real chroma collection); out of scope for this catalog-metadata-only harness (T3-backed parity tracked on bead nexus-oq0tk), not a wire-shape gap",
+    # ── fragile / redundant coupling
+    "collection_for_repo": "requires real git-repo identity resolution (_repo_identity/_resolve_main_repo) chained through owner_for_repo(repo_hash); collection_for (registered) already exercises the same /collections/for_tuple wire route and CollectionName rendering without coupling the harness to filesystem/git-subprocess behavior",
+    # ── KNOWN DRIFT (real shape bugs, not fixed here per task scope — see
+    # final report / bead follow-up)
+    "validate_link": "KNOWN DRIFT: local Catalog.validate_link() returns list[str] (validation error messages, empty list == valid) but HttpCatalogClient.validate_link() returns bool (both endpoints resolve) — a genuine return-TYPE divergence, not merely a value difference. Recorded here per task instruction; bead follow-up, not fixed in this pass.",
+    "resolve_chunk": "KNOWN DRIFT: local Catalog.resolve_chunk() requires a 4-segment CHUNK-address tumbler (tumbler.chunk is not None) and returns a purpose-built {document_tumbler, chunk_index, physical_collection, ...} dict, returning None for any plain 3-segment document tumbler; HttpCatalogClient.resolve_chunk() does not implement chunk-address resolution at all — it treats ANY tumbler as a document and returns `self.resolve(tumbler).__dict__` (the full CatalogEntry field set). The two methods do not attempt the same operation; comparable non-empty results on both sides are not achievable via any single input. Recorded as a finding; bead follow-up, not fixed here.",
+    "descendants": "KNOWN DRIFT: local Catalog.descendants() returns RAW un-normalized SQLite row dicts via a direct `cat._db.descendants(prefix)` passthrough — 'metadata' is a JSON-encoded TEXT STRING, and there is no bib_*/alias_of/source_uri field set (bypasses the CatalogEntry/_to_entry normalization every other read path uses). HttpCatalogClient.descendants() returns the Java-normalized document-row shape from a raw /list call, where 'metadata' is a parsed nested JSON OBJECT and the full bib_* field set is present. Two structurally different dict shapes for the same conceptual result (not a test-fixture gap). Recorded as a finding; bead follow-up, not fixed here.",
+    "collection_health_meta": "KNOWN DRIFT: both the wire response (CatalogRepository.collectionHealthMeta) and local Catalog.collection_health_meta() carry a 'stale_source_ratio' field, but HttpCatalogClient.collection_health_meta() reconstructs only {'last_indexed', 'orphan_count'} from the response and silently drops 'stale_source_ratio' — a real missing-field return-shape gap, the same incident class as h8rf6.3. Recorded as a finding; bead follow-up, not fixed here.",
+    "get_collection": "KNOWN DRIFT: CatalogRepository.collRow()'s 'legacy_grandfathered' column is a boxed Integer (serializes as a JSON number, 0/1) on the wire, so HttpCatalogClient.get_collection() (a raw dict passthrough, no coercion) returns it as a Python int; local Catalog.get_collection() returns a real Python bool for the same field (SQLite column read + truthiness). A genuine cross-store type divergence on a shared dict key. is_legacy_collection() (registered) papers over this at its own call site by casting with bool(...), so the divergence is contained there but not at the raw get_collection()/list_collections() surface. Recorded as a finding; bead follow-up, not fixed here.",
+    "list_collections": "KNOWN DRIFT: same 'legacy_grandfathered' int-vs-bool divergence as get_collection() (see that entry) — HttpCatalogClient.list_collections() is a raw dict-list passthrough with no coercion. Recorded as a finding; bead follow-up, not fixed here.",
+    "collections_by_owner": "KNOWN DRIFT: HttpCatalogClient.collections_by_owner() filters the raw list_collections() result client-side, inheriting the same 'legacy_grandfathered' int-vs-bool divergence documented on get_collection()/list_collections(). Recorded as a finding; bead follow-up, not fixed here.",
+    "graph": "KNOWN DRIFT: local Catalog.graph() returns {'nodes': list[CatalogEntry], 'edges': list[CatalogLink]} (typed dataclasses, matching the return-type-parity pattern used by link_query/links_from/get_manifest elsewhere in HttpCatalogClient); HttpCatalogClient.graph() returns the RAW wire dict UNCONVERTED — 'nodes'/'edges' are plain dicts, never turned into CatalogEntry/CatalogLink. The same incident class as h8rf6.3 (docs_for_chashes), just not yet fixed for this method. Recorded as a finding; bead follow-up, not fixed here.",
+    "graph_many": "KNOWN DRIFT: same untyped-passthrough divergence as graph() (see that entry) — HttpCatalogClient.graph_many() also returns raw wire dicts for 'nodes'/'edges' instead of CatalogEntry/CatalogLink objects. Recorded as a finding; bead follow-up, not fixed here.",
+    "links_to": "FakeCatalogHandler's /links direction=in|both branch is hardcoded to links_to=[] (test_http_catalog_client.py's pre-existing test_links_to_uses_direction_in asserts exactly that empty result; changing the fake to be wire-faithful here would break that pre-existing, already-green test). The wire response for links_to is therefore permanently an empty list in this fixture, while local Catalog.links_to() genuinely returns non-empty CatalogLink results for seeded data — shape() distinguishes an empty container from a populated one (different tuple contents), so no assertion form is meaningful here. Not a wire-shape bug; a pre-existing fixture constraint this task must not disturb.",
+}
+
+
+# ── seeding + fixtures ────────────────────────────────────────────────────────
+
+
+def _seed_local(cat: Catalog, s: Seeds) -> None:
+    """Seed the local catalog with the shared state both sides mirror."""
+    cat.register_owner(
+        "nexus-test", "repo", repo_hash=s.repo_hash, repo_root="/tmp/nexus-test",
+    )
+    owner_t = cat.owner_for_repo(s.repo_hash)
+    s.owner = owner_t
+    # Curator owners have no repo_root and skip the cross-project source_uri
+    # guard (_check_source_uri_in_repo_root) — used below for doc_abs_path,
+    # whose absolute file_path would otherwise be rejected as "outside the
+    # owner's repo_root".
+    s.curator_owner = cat.register_owner("nexus-curator-8y1tm", "curator")
+
+    s.doc_a = cat.register(
+        owner_t, "alpha.py", content_type="code", file_path=s.file_a,
+        physical_collection=s.collection, head_hash="h1",
+        # nexus-8y1tm: by_doc_id/resolve_many key on json_extract(metadata,
+        # '$.doc_id') (a legacy T3-doc_id field), NOT the tumbler — "1.1.1" is
+        # the deterministic tumbler this doc gets as the FIRST document
+        # registered under the FIRST owner of a fresh Catalog (mirroring the
+        # same "1.1.1" convention test_http_catalog_client.py's fake hardcodes).
+        meta={"content_hash": "f" * 64, "doc_id": "1.1.1"},
+        source_uri=s.source_uri_a, corpus=s.corpus_a,
+    )
+    s.doc_b = cat.register(
+        owner_t, "beta.md", content_type="prose", file_path=s.file_b,
+        physical_collection=s.docs_collection, head_hash="h1",
+    )
+    cat.link(s.doc_a, s.doc_b, "cites", created_by="seed")
+    cat.write_manifest(str(s.doc_a), [
+        {"chash": s.chash_a, "position": 0},
+        {"chash": s.chash_b, "position": 1},
+    ])
+
+    # Collection projections so collection-scoped lookups (get_collection,
+    # get_collection_owner_root, collections_by_owner, is_legacy_collection)
+    # have a real row to resolve.
+    cat.register_collection(
+        s.collection, content_type="code", owner_id=str(owner_t),
+        embedding_model="voyage-code-3", model_version="v1",
+    )
+    cat.register_collection(s.legacy_collection)  # non-conformant name -> legacy=True
+    cat.register_collection(
+        s.delete_proj_collection, content_type="code", owner_id=str(owner_t),
+        embedding_model="voyage-code-3", model_version="v1",
+    )
+    cat.register_collection(
+        s.supersede_old_collection, content_type="code", owner_id=str(owner_t),
+        embedding_model="voyage-code-3", model_version="v1",
+    )
+    # supersede_collection() requires new_name to ALREADY be registered — a
+    # dangling superseded_by pointer is rejected with ValueError.
+    cat.register_collection(
+        s.supersede_new_collection, content_type="code", owner_id=str(owner_t),
+        embedding_model="voyage-code-3", model_version="v1",
+    )
+
+    # Isolated targets for destructive / void operations — deliberately
+    # SEPARATE from doc_a/doc_b/collection so read-only REGISTRY entries stay
+    # valid regardless of pytest.mark.parametrize execution order.
+    s.doc_c_orphan = cat.register(
+        owner_t, "orphan.py", content_type="code", file_path="src/orphan_8y1tm.py",
+    )
+    s.doc_delete = cat.register(
+        owner_t, "delete_me.py", content_type="code", file_path="src/delete_me_8y1tm.py",
+    )
+    s.doc_purge = cat.register(
+        owner_t, "purge_target.py", content_type="code", file_path="src/purge_target_8y1tm.py",
+    )
+    cat.write_manifest(str(s.doc_purge), [{"chash": "d" * 64, "position": 0}])
+    s.doc_atomic = cat.register(
+        owner_t, "atomic_target.py", content_type="code", file_path="src/atomic_target_8y1tm.py",
+    )
+    s.doc_write_manifest = cat.register(
+        owner_t, "write_manifest_target.py", content_type="code",
+        file_path="src/write_manifest_target_8y1tm.py",
+    )
+    s.doc_alias_src = cat.register(
+        owner_t, "alias_src.py", content_type="code", file_path="src/alias_src_8y1tm.py",
+    )
+    s.doc_update = cat.register(
+        owner_t, "update_target.py", content_type="code", file_path="src/update_target_8y1tm.py",
+    )
+    s.doc_update_collection = cat.register(
+        owner_t, "update_collection_target.py", content_type="code",
+        file_path="src/update_collection_target_8y1tm.py",
+        physical_collection="code__preupdate-8y1tm__v1",
+    )
+    s.doc_update_collection_batch = cat.register(
+        owner_t, "update_collection_batch_target.py", content_type="code",
+        file_path="src/update_collection_batch_target_8y1tm.py",
+        physical_collection="code__preupdate-batch-8y1tm__v1",
+    )
+    s.doc_append = cat.register(
+        owner_t, "append_target.py", content_type="code",
+        file_path="src/append_target_8y1tm.py",
+    )
+    cat.write_manifest(str(s.doc_append), [{"chash": "9" * 64, "position": 0}])
+    s.doc_unlink_a = cat.register(
+        owner_t, "unlink_a.py", content_type="code", file_path="src/unlink_a_8y1tm.py",
+    )
+    s.doc_unlink_b = cat.register(
+        owner_t, "unlink_b.py", content_type="code", file_path="src/unlink_b_8y1tm.py",
+    )
+    cat.link(s.doc_unlink_a, s.doc_unlink_b, "relates", created_by="seed")
+    s.doc_rename_src = cat.register(
+        owner_t, "rename_src.py", content_type="code", file_path="src/rename_src_8y1tm.py",
+        physical_collection=s.rename_old_collection,
+    )
+    # Curator owner (no repo_root) skips the cross-project source_uri guard,
+    # so an absolute file_path is safe to register here.
+    s.doc_abs_path = cat.register(
+        s.curator_owner, "abs_path_doc.txt", content_type="doc",
+        file_path="/abs/path/doc-8y1tm.txt",
+    )
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def local_catalog(tmp_path_factory: pytest.TempPathFactory):
+    base = tmp_path_factory.mktemp("nexus-8y1tm-catalog")
+    catalog_dir = base / "catalog"
+    catalog_dir.mkdir()
+    db_path = base / "catalog.sqlite"
+    cat = Catalog(catalog_dir=catalog_dir, db_path=db_path)
+    yield cat
+    cat.close()
+
+
+@pytest.fixture(scope="module")
+def fake_server_url():
+    server, url = start_fake_server()
+    yield url
+    server.shutdown()
+
+
+@pytest.fixture(scope="module")
+def http_client(fake_server_url: str):
+    with HttpCatalogClient(base_url=fake_server_url, _token="parity-test-tok") as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def seeds(local_catalog: Catalog) -> Seeds:
+    s = Seeds()
+    _seed_local(local_catalog, s)
+    return s
+
+
+def _resolve(value: Any, s: Seeds) -> Any:
+    return value(s) if callable(value) and not isinstance(value, type) else value
+
+
+def _resolve_args(entry: Parity, s: Seeds) -> tuple[tuple, dict]:
+    args = tuple(_resolve(a, s) for a in entry.args)
+    kwargs = {k: _resolve(v, s) for k, v in entry.kwargs.items()}
+    return args, kwargs
+
+
+# ── parity harness ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("entry", REGISTRY, ids=lambda p: p.method)
+def test_shape_parity(
+    entry: Parity, local_catalog: Catalog, http_client: HttpCatalogClient, seeds: Seeds,
+) -> None:
+    """Call the same method+args on the seeded local Catalog and the real
+    HttpCatalogClient (over the wire-faithful fake); assert identical
+    runtime shape, and (unless empty_ok) that neither side is vacuously
+    empty."""
+    args, kwargs = _resolve_args(entry, seeds)
+    local_result = getattr(local_catalog, entry.method)(*args, **kwargs)
+    http_result = getattr(http_client, entry.method)(*args, **kwargs)
+
+    local_shape = shape(local_result)
+    http_shape = shape(http_result)
+    assert local_shape == http_shape, (
+        f"{entry.method}: shape mismatch — local={local_shape!r} http={http_shape!r} "
+        f"(local value: {local_result!r}, http value: {http_result!r})"
+    )
+    if not entry.empty_ok:
+        assert not _is_empty(local_result), (
+            f"{entry.method}: local result is vacuously empty — "
+            f"strengthen the seed fixture or mark empty_ok=True with a reason"
+        )
+        assert not _is_empty(http_result), (
+            f"{entry.method}: http result is vacuously empty — "
+            f"strengthen the FakeCatalogHandler route or mark empty_ok=True with a reason"
+        )
+
+
+# ── 3. completeness gate ─────────────────────────────────────────────────────
+
+
+def _shared_public_surface() -> set[str]:
+    def pub(cls: type) -> set[str]:
+        return {
+            n for n, m in inspect.getmembers(cls, callable)
+            if not n.startswith("_")
+        }
+
+    return pub(HttpCatalogClient) & pub(Catalog)
+
+
+def test_every_shared_method_is_registered_or_excluded() -> None:
+    """The mechanized gate: a shared public method with neither a parity
+    entry nor a documented exclusion fails CI. This is what makes shape
+    drift on a NEW method impossible to ship silently (nexus-8y1tm)."""
+    shared = _shared_public_surface()
+    registered = {p.method for p in REGISTRY}
+    excluded = set(EXCLUSIONS)
+
+    unknown_registered = registered - shared
+    assert not unknown_registered, (
+        f"REGISTRY entries for methods not on the shared surface: "
+        f"{sorted(unknown_registered)}"
+    )
+    overlap = registered & excluded
+    assert not overlap, f"methods both registered and excluded: {sorted(overlap)}"
+
+    lazy = {k: v for k, v in EXCLUSIONS.items() if len(v.strip()) < 20}
+    assert not lazy, (
+        f"EXCLUSIONS entries with trivial reasons (gate-gaming guard): {lazy}"
+    )
+    missing_reason = [
+        p.method for p in REGISTRY if p.empty_ok and not p.empty_reason.strip()
+    ]
+    assert not missing_reason, (
+        f"empty_ok=True entries without empty_reason: {missing_reason}"
+    )
+
+    uncovered = shared - registered - excluded
+    assert not uncovered, (
+        f"{len(uncovered)} shared Catalog/HttpCatalogClient methods have "
+        f"neither a shape-parity entry nor a documented exclusion: "
+        f"{sorted(uncovered)}\n"
+        f"Add a Parity entry to REGISTRY (preferred) or an EXCLUSIONS entry "
+        f"with a reason."
+    )
+
+
+def test_to_entry_covers_every_catalog_entry_field() -> None:
+    """Review suggestion (2026-07-04): shape() collapses dataclasses to
+    their class name, and _to_entry's ``d.get(field) or default`` pattern
+    means a NEW CatalogEntry field with a default that _to_entry forgets
+    stays silently defaulted on the HTTP side — the h8rf6.3 class one
+    layer down, invisible to the parity harness. Pin _to_entry's source
+    against the CatalogEntry field set by reflection."""
+    import dataclasses as _dc
+
+    from nexus.catalog import http_catalog_client as _hcc
+    from nexus.catalog.catalog import CatalogEntry
+
+    src = inspect.getsource(_hcc._to_entry)
+    missing = [
+        f.name for f in _dc.fields(CatalogEntry)
+        if f"{f.name}=" not in src
+    ]
+    assert not missing, (
+        f"CatalogEntry fields not populated by HttpCatalogClient._to_entry: "
+        f"{missing} — every field must be mapped from the wire dict (or the "
+        f"omission documented here)"
+    )

--- a/tests/catalog/test_shape_parity_tripwire.py
+++ b/tests/catalog/test_shape_parity_tripwire.py
@@ -38,7 +38,7 @@ import inspect
 
 import pytest
 
-from nexus.catalog.catalog import Catalog
+from nexus.catalog.catalog import Catalog, Tumbler
 from nexus.catalog.http_catalog_client import HttpCatalogClient
 from tests.catalog.test_http_catalog_client import (
     CHUNK_SHA_A,
@@ -200,6 +200,15 @@ REGISTRY: list[Parity] = [
     Parity("resolve_many", args=(lambda s: [str(s.doc_a)],)),
     Parity("resolve_alias", args=(lambda s: s.doc_a,)),
     Parity("resolve_path", args=(lambda s: s.doc_a,)),
+    Parity(
+        "resolve_chunk",
+        args=(lambda s: Tumbler(segments=(*s.doc_a.segments, 0)),),
+        # nexus-gc2ze: real /resolve_chunk wire route now exists. doc_a's
+        # chunk_count is 0 (unset — write_manifest doesn't touch
+        # documents.chunk_count; only resync_chunk_count_cache does), so the
+        # local bounds check short-circuits (0 is falsy) and any chunk index
+        # resolves — chunk index 0 is the simplest valid chunk address.
+    ),
     Parity("doc_count"),
     Parity(
         "register",
@@ -434,9 +443,8 @@ EXCLUSIONS: dict[str, str] = {
     # nexus-u26b4 fixed the other 5 KNOWN DRIFT findings this bead's parent
     # (nexus-8y1tm) recorded (validate_link, descendants, collection_health_meta,
     # get_collection/list_collections/collections_by_owner, graph/graph_many —
-    # all moved to REGISTRY below) plus the links_to test-infra gap. This one
-    # remains excluded: there is no wire route to build a real fix against.
-    "resolve_chunk": "CAPABILITY GAP (bead nexus-gc2ze): local Catalog.resolve_chunk() requires a 4-segment CHUNK-address tumbler (tumbler.chunk is not None) and returns a purpose-built {document_tumbler, chunk_index, physical_collection, ...} dict, returning None for any plain 3-segment document tumbler. The Java service has NO /resolve_chunk route (CatalogHandler.java's switch has no matching case) — HttpCatalogClient.resolve_chunk() does not implement chunk-address resolution at all; it treats ANY tumbler as a document and returns `self.resolve(tumbler).__dict__` (the full CatalogEntry field set) as a placeholder. The two methods do not attempt the same operation, and there is no wire endpoint to build a real client-side implementation against — comparable non-empty results on both sides are not achievable via any single input without first shipping the service route. nexus-gc2ze tracks adding a /resolve_chunk service route + CatalogHandler.java case + a real client implementation; move this entry to REGISTRY when that lands.",
+    # all moved to REGISTRY below) plus the links_to test-infra gap.
+    # nexus-gc2ze closed the last one (resolve_chunk) — see REGISTRY above.
 }
 
 

--- a/tests/catalog/test_shape_parity_tripwire.py
+++ b/tests/catalog/test_shape_parity_tripwire.py
@@ -185,6 +185,12 @@ REGISTRY: list[Parity] = [
         args=(lambda s: s.collection, lambda s: s.file_a),
     ),
     Parity("all_documents"),
+    Parity(
+        "descendants", args=(lambda s: str(s.owner),),
+        # nexus-u26b4: was KNOWN DRIFT (local raw-row passthrough vs HTTP's
+        # Java-normalized /list rows) — local catalog_docs.py now normalizes
+        # metadata to a parsed dict + full bib_* set, matching the HTTP side.
+    ),
     Parity("by_corpus", args=(lambda s: s.corpus_a,)),
     Parity("by_doc_id", args=(lambda s: str(s.doc_a),)),
     Parity("by_source_uri", args=(lambda s: s.source_uri_a,)),
@@ -239,9 +245,27 @@ REGISTRY: list[Parity] = [
     Parity("chunk_counts_for_docs", args=(lambda s: [str(s.doc_a)],)),
     Parity("links_from_batch", args=(lambda s: [str(s.doc_a)],)),
     Parity("stats"),
+    Parity(
+        "collection_health_meta", args=(lambda s: s.collection,),
+        # nexus-u26b4: was KNOWN DRIFT (HttpCatalogClient silently dropped
+        # 'stale_source_ratio') — now carried through on both sides.
+    ),
 
     # ── links cluster ────────────────────────────────────────────────────
     Parity("links_from", args=(lambda s: s.doc_a,)),
+    Parity(
+        "links_to", args=(lambda s: s.doc_b,),
+        # nexus-u26b4: was excluded (test-infra gap, not a wire-shape bug) —
+        # FakeCatalogHandler's /links direction=in|both branch was hardcoded
+        # to links_to=[]; now populates a real inbound row like direction=out
+        # already did.
+    ),
+    Parity(
+        "validate_link", args=(lambda s: s.doc_a, lambda s: s.doc_b, "cites"),
+        # nexus-u26b4: was KNOWN DRIFT (HttpCatalogClient returned bool, local
+        # returns list[str]) — doc_a->doc_b "cites" is already seeded, so both
+        # sides report the "duplicate" validation error (non-empty list[str]).
+    ),
     Parity("link_query", kwargs={"link_type": "cites"}),
     Parity(
         "link", args=("9.7.1", "9.7.2", "test-link", "parity-test"),
@@ -265,9 +289,39 @@ REGISTRY: list[Parity] = [
         # dry_run=True: read-only count via link_query, doesn't touch the
         # doc_a -> doc_b "cites" link other entries depend on.
     ),
+    Parity(
+        "graph", args=(lambda s: s.doc_a,),
+        # nexus-u26b4: was KNOWN DRIFT (h8rf6.3 incident class) — local
+        # returns {"nodes": list[CatalogEntry], "edges": list[CatalogLink]};
+        # HttpCatalogClient.graph() returned the RAW wire dict unconverted.
+        # Both sides always return the 2-key {"nodes","edges"} dict, so the
+        # vacuity guard (len(dict) == 2) passes structurally; the shape
+        # assertion is what pins the node/edge dataclass conversion.
+    ),
+    Parity(
+        "graph_many", args=(lambda s: [s.doc_a, s.doc_b],),
+        # nexus-u26b4: same fix as graph() (see that entry) applied to the
+        # multi-seed traversal.
+    ),
 
     # ── collections cluster ──────────────────────────────────────────────
     Parity("is_legacy_collection", args=(lambda s: s.legacy_collection,)),
+    Parity(
+        "get_collection", args=(lambda s: s.collection,),
+        # nexus-u26b4: was KNOWN DRIFT ('legacy_grandfathered' int-vs-bool) —
+        # HttpCatalogClient now coerces to bool like local's
+        # _row_to_collection_dict does.
+    ),
+    Parity(
+        "list_collections",
+        # nexus-u26b4: same 'legacy_grandfathered' int-vs-bool fix as
+        # get_collection() (see that entry).
+    ),
+    Parity(
+        "collections_by_owner", args=(lambda s: str(s.owner),),
+        # nexus-u26b4: inherits the get_collection()/list_collections() fix —
+        # filters the now-coerced list_collections() result client-side.
+    ),
     Parity(
         "collection_for", args=("code", lambda s: s.owner, "voyage-code-3"),
     ),
@@ -367,26 +421,22 @@ EXCLUSIONS: dict[str, str] = {
     # harness does not stand up: both resolve local chunk text via a real
     # ClientAPI.get_collection(...).get(where=...) call (catalog_spans.py);
     # HttpCatalogClient's t3 param is accepted-but-unused (resolution is
-    # server-side). Meaningfully exercising the LOCAL side would require
-    # wiring a second storage tier (an EphemeralClient with a real indexed
-    # chunk) into what is otherwise a SQLite+HTTP-only fixture — out of
-    # scope here, tracked as a follow-up rather than excluded silently.
-    "resolve_chash": "requires a live T3 ClientAPI (catalog_spans.resolve_chash_globally queries a real chroma collection); out of scope for this catalog-metadata-only harness (T3-backed parity tracked on bead nexus-oq0tk), not a wire-shape gap",
-    "resolve_span": "requires a live T3 ClientAPI (catalog_spans.resolve_span_in_t3 queries a real chroma collection); out of scope for this catalog-metadata-only harness (T3-backed parity tracked on bead nexus-oq0tk), not a wire-shape gap",
+    # server-side). Still excluded from THIS metadata-only REGISTRY (it has
+    # no T3 handle to exercise), but real shape parity is covered by a
+    # dedicated T3-backed leg — see test_shape_parity_t3_leg.py (nexus-oq0tk),
+    # which wires a real chromadb.EphemeralClient alongside a real ChashIndex
+    # and asserts shape(local) == shape(http) with the same shape() helper.
+    "resolve_chash": "parity covered by test_shape_parity_t3_leg.py (nexus-oq0tk) — requires a live T3 ClientAPI (catalog_spans.resolve_chash_globally queries a real chroma collection), out of scope for this catalog-metadata-only REGISTRY, but shape-parity is real and green in the T3-backed leg, not a wire-shape gap",
+    "resolve_span": "parity covered by test_shape_parity_t3_leg.py (nexus-oq0tk) — requires a live T3 ClientAPI (catalog_spans.resolve_span_in_t3 queries a real chroma collection), out of scope for this catalog-metadata-only REGISTRY, but shape-parity is real and green in the T3-backed leg, not a wire-shape gap",
     # ── fragile / redundant coupling
     "collection_for_repo": "requires real git-repo identity resolution (_repo_identity/_resolve_main_repo) chained through owner_for_repo(repo_hash); collection_for (registered) already exercises the same /collections/for_tuple wire route and CollectionName rendering without coupling the harness to filesystem/git-subprocess behavior",
-    # ── KNOWN DRIFT (real shape bugs, not fixed here per task scope — see
-    # final report / bead follow-up)
-    "validate_link": "KNOWN DRIFT: local Catalog.validate_link() returns list[str] (validation error messages, empty list == valid) but HttpCatalogClient.validate_link() returns bool (both endpoints resolve) — a genuine return-TYPE divergence, not merely a value difference. Recorded here per task instruction; bead follow-up, not fixed in this pass.",
-    "resolve_chunk": "KNOWN DRIFT: local Catalog.resolve_chunk() requires a 4-segment CHUNK-address tumbler (tumbler.chunk is not None) and returns a purpose-built {document_tumbler, chunk_index, physical_collection, ...} dict, returning None for any plain 3-segment document tumbler; HttpCatalogClient.resolve_chunk() does not implement chunk-address resolution at all — it treats ANY tumbler as a document and returns `self.resolve(tumbler).__dict__` (the full CatalogEntry field set). The two methods do not attempt the same operation; comparable non-empty results on both sides are not achievable via any single input. Recorded as a finding; bead follow-up, not fixed here.",
-    "descendants": "KNOWN DRIFT: local Catalog.descendants() returns RAW un-normalized SQLite row dicts via a direct `cat._db.descendants(prefix)` passthrough — 'metadata' is a JSON-encoded TEXT STRING, and there is no bib_*/alias_of/source_uri field set (bypasses the CatalogEntry/_to_entry normalization every other read path uses). HttpCatalogClient.descendants() returns the Java-normalized document-row shape from a raw /list call, where 'metadata' is a parsed nested JSON OBJECT and the full bib_* field set is present. Two structurally different dict shapes for the same conceptual result (not a test-fixture gap). Recorded as a finding; bead follow-up, not fixed here.",
-    "collection_health_meta": "KNOWN DRIFT: both the wire response (CatalogRepository.collectionHealthMeta) and local Catalog.collection_health_meta() carry a 'stale_source_ratio' field, but HttpCatalogClient.collection_health_meta() reconstructs only {'last_indexed', 'orphan_count'} from the response and silently drops 'stale_source_ratio' — a real missing-field return-shape gap, the same incident class as h8rf6.3. Recorded as a finding; bead follow-up, not fixed here.",
-    "get_collection": "KNOWN DRIFT: CatalogRepository.collRow()'s 'legacy_grandfathered' column is a boxed Integer (serializes as a JSON number, 0/1) on the wire, so HttpCatalogClient.get_collection() (a raw dict passthrough, no coercion) returns it as a Python int; local Catalog.get_collection() returns a real Python bool for the same field (SQLite column read + truthiness). A genuine cross-store type divergence on a shared dict key. is_legacy_collection() (registered) papers over this at its own call site by casting with bool(...), so the divergence is contained there but not at the raw get_collection()/list_collections() surface. Recorded as a finding; bead follow-up, not fixed here.",
-    "list_collections": "KNOWN DRIFT: same 'legacy_grandfathered' int-vs-bool divergence as get_collection() (see that entry) — HttpCatalogClient.list_collections() is a raw dict-list passthrough with no coercion. Recorded as a finding; bead follow-up, not fixed here.",
-    "collections_by_owner": "KNOWN DRIFT: HttpCatalogClient.collections_by_owner() filters the raw list_collections() result client-side, inheriting the same 'legacy_grandfathered' int-vs-bool divergence documented on get_collection()/list_collections(). Recorded as a finding; bead follow-up, not fixed here.",
-    "graph": "KNOWN DRIFT: local Catalog.graph() returns {'nodes': list[CatalogEntry], 'edges': list[CatalogLink]} (typed dataclasses, matching the return-type-parity pattern used by link_query/links_from/get_manifest elsewhere in HttpCatalogClient); HttpCatalogClient.graph() returns the RAW wire dict UNCONVERTED — 'nodes'/'edges' are plain dicts, never turned into CatalogEntry/CatalogLink. The same incident class as h8rf6.3 (docs_for_chashes), just not yet fixed for this method. Recorded as a finding; bead follow-up, not fixed here.",
-    "graph_many": "KNOWN DRIFT: same untyped-passthrough divergence as graph() (see that entry) — HttpCatalogClient.graph_many() also returns raw wire dicts for 'nodes'/'edges' instead of CatalogEntry/CatalogLink objects. Recorded as a finding; bead follow-up, not fixed here.",
-    "links_to": "FakeCatalogHandler's /links direction=in|both branch is hardcoded to links_to=[] (test_http_catalog_client.py's pre-existing test_links_to_uses_direction_in asserts exactly that empty result; changing the fake to be wire-faithful here would break that pre-existing, already-green test). The wire response for links_to is therefore permanently an empty list in this fixture, while local Catalog.links_to() genuinely returns non-empty CatalogLink results for seeded data — shape() distinguishes an empty container from a populated one (different tuple contents), so no assertion form is meaningful here. Not a wire-shape bug; a pre-existing fixture constraint this task must not disturb.",
+    # ── documented capability gap (bead follow-up, not a wire-shape bug):
+    # nexus-u26b4 fixed the other 5 KNOWN DRIFT findings this bead's parent
+    # (nexus-8y1tm) recorded (validate_link, descendants, collection_health_meta,
+    # get_collection/list_collections/collections_by_owner, graph/graph_many —
+    # all moved to REGISTRY below) plus the links_to test-infra gap. This one
+    # remains excluded: there is no wire route to build a real fix against.
+    "resolve_chunk": "CAPABILITY GAP (bead nexus-gc2ze): local Catalog.resolve_chunk() requires a 4-segment CHUNK-address tumbler (tumbler.chunk is not None) and returns a purpose-built {document_tumbler, chunk_index, physical_collection, ...} dict, returning None for any plain 3-segment document tumbler. The Java service has NO /resolve_chunk route (CatalogHandler.java's switch has no matching case) — HttpCatalogClient.resolve_chunk() does not implement chunk-address resolution at all; it treats ANY tumbler as a document and returns `self.resolve(tumbler).__dict__` (the full CatalogEntry field set) as a placeholder. The two methods do not attempt the same operation, and there is no wire endpoint to build a real client-side implementation against — comparable non-empty results on both sides are not achievable via any single input without first shipping the service route. nexus-gc2ze tracks adding a /resolve_chunk service route + CatalogHandler.java case + a real client implementation; move this entry to REGISTRY when that lands.",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -649,6 +649,18 @@ _MODE_LINT_EXCLUDE_NODEIDS: frozenset[str] = frozenset({
     # mode-dependent path executes ("string-literal-as-name" class).
     "tests/migration/test_driver.py::test_two_leg_composes_collections_and_dims",
     #
+    # nexus-gc2ze + nexus-c9xr2/u37lw wave (2026-07-04): all
+    # "string-literal-as-name" — a REAL HttpCatalogClient/HttpVectorClient
+    # over a FAKED transport; the voyage token appears only inside
+    # conformant collection-name strings used as opaque identifiers (the
+    # u37lw guard tests additionally assert the NAME-derived model parse,
+    # same rationale as collection_metadata above). No embedder runs; no
+    # mode-dependent path executes.
+    "tests/catalog/test_http_catalog_client.py::TestResolveChunk::test_resolve_chunk_returns_full_dict",
+    "tests/test_service_mode_cli_real_client.py::test_collection_reembed_dry_run_service_mode_real_client",
+    "tests/test_service_mode_cli_real_client.py::test_collection_reembed_cross_model_rejected_service_mode",
+    "tests/test_service_mode_cli_real_client.py::test_collection_reembed_same_model_uses_verbatim_passthrough",
+    #
     # nexus-gilf2: the cross-model remap-target test asserts the driver derives
     # voyage target NAMES (voyage-code-3 / voyage-context-3) in cloud mode. Mode
     # is pinned explicitly by patching ``voyage_key_available`` (via the

--- a/tests/db/test_collection_health_dsu5z_integration.py
+++ b/tests/db/test_collection_health_dsu5z_integration.py
@@ -299,15 +299,25 @@ class TestCollectionHealthMetaLiveService:
         )
 
     def test_result_has_required_keys(self, cat, seeded_catalog) -> None:
-        """Result dict always contains last_indexed and orphan_count."""
+        """Result dict always contains last_indexed, orphan_count, and
+        stale_source_ratio.
+
+        nexus-u26b4: nexus-agsq7's FIRST (source_mtime-based, structurally
+        vacuous) stale_source_ratio wiring was reverted, which is why this
+        test used to assert the key's ABSENCE. A second, index-age-based
+        implementation (``_STALE_SOURCE_AGE_DAYS`` in catalog.py, backed by
+        the catalog-011 PG view service-side) reintroduced the same key on
+        both local ``Catalog.collection_health_meta()`` and the wire
+        response; HttpCatalogClient.collection_health_meta() was silently
+        dropping it when reconstructing its return dict (the h8rf6.3
+        incident class) until this fix — the shape-parity tripwire
+        (tests/catalog/test_shape_parity_tripwire.py) now pins the field
+        present on both sides.
+        """
         result = cat.collection_health_meta(_COLL)
         assert "last_indexed" in result
         assert "orphan_count" in result
-        # nexus-agsq7 CLOSED: the DB-only stale_source_ratio wiring was
-        # structurally vacuous (source_mtime <= indexed_at always) and was
-        # reverted — collection_health_meta no longer emits the key; the
-        # report layer renders the '—' placeholder via its None default.
-        assert "stale_source_ratio" not in result
+        assert "stale_source_ratio" in result
 
     def test_unknown_collection_returns_safe_defaults(self, cat, seeded_catalog) -> None:
         """B) Unknown collection -> last_indexed=None, orphan_count=0."""

--- a/tests/db/test_http_catalog_integration.py
+++ b/tests/db/test_http_catalog_integration.py
@@ -671,14 +671,16 @@ class TestLinkAndTraversal:
         result = cat.graph(a, depth=1)
         assert "nodes" in result
         assert "edges" in result
-        node_tumblers = [n.get("tumbler") for n in result["nodes"]]
+        # nexus-u26b4: nodes are typed CatalogEntry objects (return-type
+        # parity), not raw wire dicts — attribute access, not .get().
+        node_tumblers = [str(n.tumbler) for n in result["nodes"]]
         assert str(b) in node_tumblers
 
     def test_graph_depth_2_reaches_c(self, cat, linked_docs) -> None:
         """graph() with depth=2 follows the chain A->B->C."""
         a, b, c = linked_docs
         result = cat.graph(a, depth=2)
-        node_tumblers = [n.get("tumbler") for n in result["nodes"]]
+        node_tumblers = [str(n.tumbler) for n in result["nodes"]]
         assert str(c) in node_tumblers, (
             f"Expected {c} in depth-2 BFS from {a}; got nodes={node_tumblers}"
         )
@@ -1345,7 +1347,8 @@ class TestCrossTenantGraphRLS:
         nodes = result.get("nodes", [])
         edges = result.get("edges", [])
         a_tumblers = {str(x), str(y)}
-        visible_a_nodes = [n for n in nodes if n.get("tumbler") in a_tumblers]
+        # nexus-u26b4: nodes are typed CatalogEntry objects — attribute access.
+        visible_a_nodes = [n for n in nodes if str(n.tumbler) in a_tumblers]
         assert visible_a_nodes == [], (
             f"RLS BREACH via graph(): tenant B can see tenant A's nodes: {visible_a_nodes}"
         )

--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -51,7 +51,7 @@ RELEASE_PROPS="service/src/main/resources/META-INF/nexus/release.properties"
 # stale default fail-closes the --cold MVV at the version gate. Kept literal (it
 # names a PUBLISHED release tag, which need not equal the floor) but bumped to
 # track it; override via NEXUS_SERVICE_TAG. (nexus-v0zmv)
-COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.21}"
+COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.22}"
 for a in "$@"; do
   case "$a" in
     --with-cloud) WITH_CLOUD=1 ;;

--- a/tests/test_aspect_worker.py
+++ b/tests/test_aspect_worker.py
@@ -1215,3 +1215,49 @@ class TestRetryLadderIntegration:
         # retry_count is therefore cap+1 — proving the full ladder ran, not a
         # single-shot fail (which would terminate at retry_count == 1).
         assert row[1] == _RETRY_MAX_ATTEMPTS + 1
+
+
+# ── nexus-w8lg1: the queue row carries the CATALOG doc_id ────────────────────
+
+
+class TestEnqueueHookDocIdWiring:
+    """nexus-w8lg1 (6.3.0 live shakeout finding #1): the enqueue hook must
+    persist the catalog tumbler it was handed as the row's ``doc_id`` —
+    verbatim, no substitution anywhere between fire_document and the
+    queue write. The live bug shipped the T3 chunk hash instead, which
+    the engine's composite FK rejected (typed 409) on every CLI store
+    put. SQLite has no FK, so this pins the WIRING (the class of bug
+    that actually occurred) on every CI run; the FK itself is exercised
+    by the --fullstack rehearsal."""
+
+    def test_enqueue_persists_catalog_doc_id_verbatim(self, _isolate_t2):
+        from nexus.aspect_worker import aspect_extraction_enqueue_hook
+
+        chunk_id = "bf715bbd" + "0" * 24  # the WRONG identity (T3 chunk hash)
+        aspect_extraction_enqueue_hook(
+            source_path=chunk_id,
+            collection="knowledge__delos",
+            content="note body",
+            doc_id="1.7.42",
+        )
+
+        with T2Database(_isolate_t2) as db:
+            row = db.aspect_queue.claim_next()
+        assert row is not None
+        assert row.doc_id == "1.7.42"
+        assert row.source_path == chunk_id
+
+    def test_enqueue_empty_doc_id_stays_empty(self, _isolate_t2):
+        """catalog absent -> doc_id stays "" (persists NULL service-side,
+        which the nullable FK accepts)."""
+        from nexus.aspect_worker import aspect_extraction_enqueue_hook
+
+        aspect_extraction_enqueue_hook(
+            source_path="c" * 32,
+            collection="knowledge__delos",
+            content="body",
+        )
+        with T2Database(_isolate_t2) as db:
+            row = db.aspect_queue.claim_next()
+        assert row is not None
+        assert row.doc_id == ""

--- a/tests/test_bib_enricher_write_back_service_mode.py
+++ b/tests/test_bib_enricher_write_back_service_mode.py
@@ -19,7 +19,7 @@ transport pattern (the ``umvh2``-class recurrence guard).
 LIVE BUG FOUND while building this coverage (see
 ``TestMetaMergeSemanticsDrift`` below): ``HttpCatalogClient.update()`` passes
 the ``meta=`` kwarg straight through to ``POST /update`` with NO client-side
-merge, and ``CatalogRepository.updateDocument`` (Java) does a bare
+merge, and ``CatalogRepository.updateDocument`` (Java) originally did a bare
 ``SET metadata = <new jsonb>`` — a full REPLACE, not a JSON merge. Local
 ``Catalog.update()`` (``catalog_writes.py`` lines ~447-451) explicitly reads
 the current entry and merges the caller's ``meta`` dict into the existing
@@ -27,12 +27,12 @@ one before writing. Every ``writer.update(tumbler, meta={...})`` call site
 in this codebase (``_enrich_apply`` here, plus ``indexer.py``,
 ``commands/dt.py``, ``commands/catalog_cmds/remediation.py``) is written
 against the LOCAL merge contract; in service mode every one of them silently
-drops any pre-existing metadata key absent from the new dict. This is a
+dropped any pre-existing metadata key absent from the new dict. This is a
 wire-shape/semantics divergence signature-conformance tests cannot see
 (``test_catalog_conformance.py``'s own docstring calls this class out
-explicitly as a known blind spot). Pinned below as ``xfail(strict=True)``
-per this repo's established RDR-168 divergence-tracking convention rather
-than silently working around it.
+explicitly as a known blind spot). FIXED server-side (nexus-ke45f):
+updateDocument now merges via jsonb_concat; TestMetaMergeSemanticsDrift is
+the standing pin.
 """
 from __future__ import annotations
 
@@ -57,9 +57,8 @@ class _State:
     """Server-side fixture state (a documents table), reset per test.
 
     ``/update`` mirrors ``CatalogRepository.updateDocument``'s REAL
-    semantics exactly (including the meta-REPLACE behavior described in the
-    module docstring) so the drift test below is evidence, not a fixture
-    artifact.
+    semantics exactly (including the nexus-ke45f metadata MERGE) so the
+    merge pin below is evidence, not a fixture artifact.
     """
 
     documents: dict[str, dict[str, Any]] = {}
@@ -195,8 +194,10 @@ class FakeBibCatalogHandler(BaseHTTPRequestHandler):
             for key, value in fields.items():
                 if key in ("meta", "metadata"):
                     # REAL semantics (CatalogRepository.java ~540-544):
-                    # SET metadata = <new jsonb> — a REPLACE, not a merge.
-                    doc["metadata"] = value
+                    # nexus-ke45f FIXED: updateDocument now merges —
+                    # jsonb_concat(COALESCE(metadata,'{}'), <new>), the ||
+                    # operator: add/overwrite keys, never remove. Mirror it.
+                    doc["metadata"] = {**doc.get("metadata", {}), **value}
                 else:
                     doc[key] = value
             self._send_json({"updated": 1})
@@ -351,7 +352,8 @@ class TestEnrichApplyServiceModeTitleFallback:
 
 
 class TestMetaMergeSemanticsDrift:
-    """KNOWN DRIFT (nexus-6lfdi live finding) — see module docstring.
+    """FIXED (nexus-ke45f): the standing merge-semantics pin — see module
+    docstring. Historical record of the drift below.
 
     ``HttpCatalogClient.update()`` (http_catalog_client.py) forwards the
     ``meta=`` kwarg to ``POST /update`` verbatim; ``CatalogRepository
@@ -367,24 +369,13 @@ class TestMetaMergeSemanticsDrift:
     orthogonal to signature conformance (both signatures match; this is a
     WIRE-SEMANTICS divergence).
 
-    Filed as bead nexus-ke45f (fix belongs in HttpCatalogClient.update():
-    read-merge-write for the meta/metadata kwarg, mirroring local
-    semantics). This test pins the reproduction; flip to a plain
-    (non-xfail) assertion when the fix lands and remove the xfail mark.
+    FIXED server-side (nexus-ke45f): CatalogRepository.updateDocument now
+    does jsonb_concat(COALESCE(metadata,'{}'), <new>) — merge, not replace
+    — matching local. (Server-side beats the originally-suggested client
+    read-merge-write: no read-modify-write race, and every wire client
+    gets the contract.) This test is the standing pin.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "KNOWN DRIFT (nexus-6lfdi / bead nexus-ke45f): HttpCatalogClient.update() "
-            "does not merge the meta kwarg before POSTing (no read-before-write), and "
-            "the service's updateDocument does a bare metadata REPLACE, not a JSON "
-            "merge. Any writer.update(tumbler, meta={...}) in service mode — including "
-            "every bib-enrichment write-back — clobbers pre-existing metadata keys. "
-            "Local Catalog.update() merges; the client does not. XPASS here means the "
-            "client gained read-merge-write semantics — remove this xfail."
-        ),
-    )
     def test_bib_write_back_preserves_preexisting_metadata_in_service_mode(
         self, reader, writer,
     ) -> None:

--- a/tests/test_bib_enricher_write_back_service_mode.py
+++ b/tests/test_bib_enricher_write_back_service_mode.py
@@ -1,0 +1,407 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-6lfdi: PG-world (service-mode) coverage for the bib-enrichment
+enrich-then-write-back path (``nexus.bib_enricher`` /
+``nexus.bib_enricher_openalex`` produce a bib dict; ``commands/enrich.py``'s
+``_enrich_apply`` writes it back onto the catalog).
+
+The external bib APIs (Semantic Scholar / OpenAlex) are irrelevant to this
+file's purpose — ``_enrich_apply`` takes an already-resolved ``bib_meta``
+dict as input, so the enrichment HTTP calls are never invoked here (no
+mocking needed; the existing ``tests/test_bib_enricher*.py`` files already
+cover ``enrich()`` / ``enrich_by_doi()`` / ``enrich_by_arxiv_id()`` in
+isolation with ``Mock(spec=httpx.Response)``). This file drives the CATALOG
+side of the write-back with a REAL ``HttpCatalogClient`` reader + a real
+``_ServiceCatalogWriter``-wrapped ``HttpCatalogClient`` writer (mirrors
+production wiring in ``commands/enrich.py``'s ``_catalog_enrich_hook``) over
+a wire-faithful stateful fake server, per this repo's real-client-over-fake-
+transport pattern (the ``umvh2``-class recurrence guard).
+
+LIVE BUG FOUND while building this coverage (see
+``TestMetaMergeSemanticsDrift`` below): ``HttpCatalogClient.update()`` passes
+the ``meta=`` kwarg straight through to ``POST /update`` with NO client-side
+merge, and ``CatalogRepository.updateDocument`` (Java) does a bare
+``SET metadata = <new jsonb>`` — a full REPLACE, not a JSON merge. Local
+``Catalog.update()`` (``catalog_writes.py`` lines ~447-451) explicitly reads
+the current entry and merges the caller's ``meta`` dict into the existing
+one before writing. Every ``writer.update(tumbler, meta={...})`` call site
+in this codebase (``_enrich_apply`` here, plus ``indexer.py``,
+``commands/dt.py``, ``commands/catalog_cmds/remediation.py``) is written
+against the LOCAL merge contract; in service mode every one of them silently
+drops any pre-existing metadata key absent from the new dict. This is a
+wire-shape/semantics divergence signature-conformance tests cannot see
+(``test_catalog_conformance.py``'s own docstring calls this class out
+explicitly as a known blind spot). Pinned below as ``xfail(strict=True)``
+per this repo's established RDR-168 divergence-tracking convention rather
+than silently working around it.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from nexus.catalog.factory import _ServiceCatalogWriter
+from nexus.catalog.http_catalog_client import HttpCatalogClient
+from nexus.catalog.tumbler import Tumbler
+from nexus.commands.enrich import _enrich_apply
+
+# ── stateful fake server ──────────────────────────────────────────────────────
+
+
+class _State:
+    """Server-side fixture state (a documents table), reset per test.
+
+    ``/update`` mirrors ``CatalogRepository.updateDocument``'s REAL
+    semantics exactly (including the meta-REPLACE behavior described in the
+    module docstring) so the drift test below is evidence, not a fixture
+    artifact.
+    """
+
+    documents: dict[str, dict[str, Any]] = {}
+    #: POST /update bodies received, in order — lets tests assert exactly
+    #: what wire shape _enrich_apply produced.
+    update_bodies: list[dict[str, Any]] = []
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.documents = {}
+        cls.update_bodies = []
+
+    @classmethod
+    def add_document(cls, tumbler: str, **fields: Any) -> str:
+        base: dict[str, Any] = {
+            "tumbler": tumbler,
+            "title": tumbler,
+            "author": "",
+            "year": 0,
+            "content_type": "",
+            "file_path": "",
+            "source_uri": "",
+            "corpus": "",
+            "physical_collection": "",
+            "chunk_count": 0,
+            "head_hash": "",
+            "metadata": {},
+            "source_mtime": 0.0,
+            "bib_year": 0,
+            "bib_authors": "",
+            "bib_venue": "",
+            "bib_citation_count": 0,
+        }
+        base.update(fields)
+        cls.documents[tumbler] = base
+        return tumbler
+
+
+# Java CatalogRepository.UPDATABLE_DOC_COLUMNS whitelist (CatalogRepository.java
+# ~511-516) — mirrored here so the fake 400s exactly like the real service on
+# an unrecognized top-level update key.
+_UPDATABLE_DOC_COLUMNS = frozenset({
+    "title", "author", "year", "content_type", "file_path", "corpus",
+    "physical_collection", "chunk_count", "head_hash", "indexed_at",
+    "meta", "metadata", "source_mtime", "alias_of", "source_uri",
+    "bib_year", "bib_authors", "bib_venue", "bib_citation_count",
+    "bib_semantic_scholar_id", "bib_openalex_id", "bib_doi", "bib_enriched_at",
+})
+
+
+class FakeBibCatalogHandler(BaseHTTPRequestHandler):
+    """Minimal stateful fake — only the routes ``_enrich_apply`` touches:
+    GET ``/list`` (list_by_collection), GET ``/resolve``
+    (lookup_doc_id_by_collection_and_path), GET ``/search`` (find);
+    POST ``/update``.
+    """
+
+    def log_message(self, *args: Any) -> None:
+        pass  # suppress test noise
+
+    def _send_json(self, body: Any, code: int = 200) -> None:
+        data = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _query_params(self) -> dict[str, str]:
+        qs = urlparse(self.path).query
+        return {k: v[0] for k, v in parse_qs(qs).items()} if qs else {}
+
+    def _read_body(self) -> dict:
+        length = int(self.headers.get("Content-Length", 0))
+        if length:
+            return json.loads(self.rfile.read(length))
+        return {}
+
+    def do_GET(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler contract
+        path = urlparse(self.path).path
+        op = path.removeprefix("/v1/catalog")
+        params = self._query_params()
+
+        if op == "/list":
+            docs = list(_State.documents.values())
+            collection = params.get("collection")
+            if collection:
+                docs = [d for d in docs if d.get("physical_collection") == collection]
+            self._send_json({"documents": docs, "count": len(docs)})
+        elif op == "/resolve":
+            file_path = params.get("file_path", "")
+            collection = params.get("collection", "")
+            matches = [
+                d for d in _State.documents.values()
+                if d.get("file_path") == file_path
+                and (not collection or d.get("physical_collection") == collection)
+            ]
+            self._send_json({"documents": matches})
+        elif op == "/search":
+            q = params.get("q", "")
+            content_type = params.get("content_type")
+            matches = [
+                d for d in _State.documents.values()
+                if d.get("title") == q
+                and (not content_type or d.get("content_type") == content_type)
+            ]
+            self._send_json({"documents": matches, "count": len(matches)})
+        else:
+            self._send_json({"error": f"unknown GET op: {op}"}, 404)
+
+    def do_POST(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler contract
+        path = urlparse(self.path).path
+        op = path.removeprefix("/v1/catalog")
+        body = self._read_body()
+
+        if op == "/update":
+            _State.update_bodies.append(dict(body))
+            tumbler = body.get("tumbler", "")
+            fields = {k: v for k, v in body.items() if k != "tumbler"}
+            # Mirror CatalogRepository.updateDocument's whitelist: an unknown
+            # top-level key 400s exactly like the real service.
+            unknown = [k for k in fields if k not in _UPDATABLE_DOC_COLUMNS]
+            if unknown:
+                self._send_json(
+                    {"error": f"updateDocument: column not updatable: {unknown[0]!r}"},
+                    400,
+                )
+                return
+            doc = _State.documents.get(tumbler)
+            if doc is None:
+                self._send_json({"updated": 0})
+                return
+            for key, value in fields.items():
+                if key in ("meta", "metadata"):
+                    # REAL semantics (CatalogRepository.java ~540-544):
+                    # SET metadata = <new jsonb> — a REPLACE, not a merge.
+                    doc["metadata"] = value
+                else:
+                    doc[key] = value
+            self._send_json({"updated": 1})
+        else:
+            self._send_json({"ok": True})
+
+
+def _start_server() -> tuple[HTTPServer, str]:
+    server = HTTPServer(("127.0.0.1", 0), FakeBibCatalogHandler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    time.sleep(0.05)  # brief wait for the thread to reach serve_forever
+    return server, f"http://127.0.0.1:{port}"
+
+
+@pytest.fixture
+def fake_server():
+    _State.reset()
+    server, url = _start_server()
+    yield url
+    server.shutdown()
+
+
+@pytest.fixture
+def reader(fake_server: str):
+    with HttpCatalogClient(base_url=fake_server, tenant="tenant_abc", _token="test_tok") as c:
+        yield c
+
+
+@pytest.fixture
+def writer(fake_server: str):
+    # Mirrors production wiring (commands/enrich.py's _catalog_enrich_hook):
+    # a SEPARATE HttpCatalogClient instance from the reader, wrapped in
+    # _ServiceCatalogWriter.
+    client = HttpCatalogClient(base_url=fake_server, tenant="tenant_abc", _token="test_tok")
+    w = _ServiceCatalogWriter(client)
+    yield w
+    w.close()
+
+
+_S2_BIB_META = {
+    "year": 2024,
+    "venue": "NeurIPS",
+    "authors": "Alice, Bob",
+    "citation_count": 42,
+    "semantic_scholar_id": "ss123",
+}
+
+_OPENALEX_BIB_META = {
+    "year": 2023,
+    "venue": "ICML",
+    "authors": "Carol",
+    "citation_count": 7,
+    "openalex_id": "W999",
+    "doi": "10.1234/foo",
+}
+
+
+class TestEnrichApplyServiceModeSourcePathMatch:
+    """nexus-tv22: source_paths is the authoritative match path (unambiguous
+    per-document identity, unlike title which drifts across derive_title
+    rewrites)."""
+
+    def test_s2_backend_writes_author_year_and_meta(self, reader, writer) -> None:
+        _State.add_document(
+            "1.1.1", title="Paper One", physical_collection="knowledge__delos",
+            file_path="paper1.pdf",
+        )
+        _enrich_apply(
+            reader, writer, "knowledge__delos", "Paper One", ["paper1.pdf"],
+            _S2_BIB_META, "s2", Tumbler,
+        )
+        assert len(_State.update_bodies) == 1
+        body = _State.update_bodies[0]
+        assert body["tumbler"] == "1.1.1"
+        assert body["author"] == "Alice, Bob"
+        assert body["year"] == 2024
+        assert body["meta"]["venue"] == "NeurIPS"
+        assert body["meta"]["citation_count"] == 42
+        assert body["meta"]["bib_semantic_scholar_id"] == "ss123"
+        # No 400 — every top-level wire key is on CatalogRepository's
+        # UPDATABLE_DOC_COLUMNS whitelist.
+        stored = _State.documents["1.1.1"]
+        assert stored["author"] == "Alice, Bob"
+        assert stored["year"] == 2024
+
+    def test_openalex_backend_writes_bib_openalex_id_and_doi(self, reader, writer) -> None:
+        _State.add_document(
+            "1.1.1", title="Paper Two", physical_collection="knowledge__delos",
+            file_path="paper2.pdf",
+        )
+        _enrich_apply(
+            reader, writer, "knowledge__delos", "Paper Two", ["paper2.pdf"],
+            _OPENALEX_BIB_META, "openalex", Tumbler,
+        )
+        body = _State.update_bodies[0]
+        assert body["meta"]["bib_openalex_id"] == "W999"
+        assert body["meta"]["bib_doi"] == "10.1234/foo"
+        # S2 field must NOT appear for the openalex backend.
+        assert "bib_semantic_scholar_id" not in body["meta"]
+
+    def test_absolute_and_relative_path_variants_both_match(self, reader, writer) -> None:
+        """The lookup tries (sp, sp.lstrip('/')) — an absolute source_path
+        must still resolve against a catalog row storing the relative form."""
+        _State.add_document(
+            "1.1.1", title="Paper Three", physical_collection="knowledge__delos",
+            file_path="paper3.pdf",
+        )
+        _enrich_apply(
+            reader, writer, "knowledge__delos", "Paper Three", ["/paper3.pdf"],
+            _S2_BIB_META, "s2", Tumbler,
+        )
+        assert len(_State.update_bodies) == 1
+        assert _State.update_bodies[0]["tumbler"] == "1.1.1"
+
+    def test_no_match_is_a_silent_noop(self, reader, writer) -> None:
+        """No source_paths match, no collection title match, no FTS hit —
+        _enrich_apply must not raise (best-effort catalog hook contract)."""
+        _enrich_apply(
+            reader, writer, "knowledge__delos", "Nonexistent Paper", ["missing.pdf"],
+            _S2_BIB_META, "s2", Tumbler,
+        )
+        assert _State.update_bodies == []
+
+
+class TestEnrichApplyServiceModeTitleFallback:
+    def test_title_match_within_collection_when_no_source_paths(self, reader, writer) -> None:
+        _State.add_document(
+            "1.1.1", title="Fallback Paper", physical_collection="knowledge__delos",
+            file_path="",
+        )
+        _enrich_apply(
+            reader, writer, "knowledge__delos", "Fallback Paper", [],
+            _S2_BIB_META, "s2", Tumbler,
+        )
+        assert len(_State.update_bodies) == 1
+        assert _State.update_bodies[0]["tumbler"] == "1.1.1"
+
+    def test_last_resort_fts_search_across_catalog(self, reader, writer) -> None:
+        """No collection_name / no source_paths match: falls through to
+        reader.find(title, content_type='paper')."""
+        _State.add_document(
+            "1.1.1", title="Global Paper", content_type="paper",
+        )
+        _enrich_apply(
+            reader, writer, "", "Global Paper", [],
+            _S2_BIB_META, "s2", Tumbler,
+        )
+        assert len(_State.update_bodies) == 1
+        assert _State.update_bodies[0]["tumbler"] == "1.1.1"
+
+
+class TestMetaMergeSemanticsDrift:
+    """KNOWN DRIFT (nexus-6lfdi live finding) — see module docstring.
+
+    ``HttpCatalogClient.update()`` (http_catalog_client.py) forwards the
+    ``meta=`` kwarg to ``POST /update`` verbatim; ``CatalogRepository
+    .updateDocument`` (CatalogRepository.java ~540-544) does
+    ``SET metadata = <new jsonb>`` — a full REPLACE. Local
+    ``Catalog.update()`` (``catalog_writes.py`` ~447-451) explicitly merges
+    the caller's ``meta`` dict into the EXISTING entry's meta before
+    writing. Every bib-enrichment write-back call
+    (``_enrich_apply`` -> ``writer.update(tumbler, meta=meta_update)``)
+    therefore silently drops any pre-existing metadata key not present in
+    the new ``meta_update`` dict when running in service mode — data loss
+    with no error, the exact silent class RDR-168 exists to catch, but
+    orthogonal to signature conformance (both signatures match; this is a
+    WIRE-SEMANTICS divergence).
+
+    Filed as bead nexus-ke45f (fix belongs in HttpCatalogClient.update():
+    read-merge-write for the meta/metadata kwarg, mirroring local
+    semantics). This test pins the reproduction; flip to a plain
+    (non-xfail) assertion when the fix lands and remove the xfail mark.
+    """
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "KNOWN DRIFT (nexus-6lfdi / bead nexus-ke45f): HttpCatalogClient.update() "
+            "does not merge the meta kwarg before POSTing (no read-before-write), and "
+            "the service's updateDocument does a bare metadata REPLACE, not a JSON "
+            "merge. Any writer.update(tumbler, meta={...}) in service mode — including "
+            "every bib-enrichment write-back — clobbers pre-existing metadata keys. "
+            "Local Catalog.update() merges; the client does not. XPASS here means the "
+            "client gained read-merge-write semantics — remove this xfail."
+        ),
+    )
+    def test_bib_write_back_preserves_preexisting_metadata_in_service_mode(
+        self, reader, writer,
+    ) -> None:
+        _State.add_document(
+            "1.1.1", title="Existing Meta Paper",
+            physical_collection="knowledge__delos", file_path="existing.pdf",
+            metadata={"content_hash": "abc123", "custom_field": "keep-me"},
+        )
+        _enrich_apply(
+            reader, writer, "knowledge__delos", "Existing Meta Paper", ["existing.pdf"],
+            _S2_BIB_META, "s2", Tumbler,
+        )
+        stored_meta = _State.documents["1.1.1"]["metadata"]
+        # This is what the LOCAL (merge-semantics) contract guarantees and what
+        # every writer.update(..., meta=...) call site in this codebase assumes.
+        # In service mode it currently does NOT hold — the fields below are gone.
+        assert stored_meta.get("content_hash") == "abc123"
+        assert stored_meta.get("custom_field") == "keep-me"
+        # The new bib fields are of course present (that part works correctly).
+        assert stored_meta.get("venue") == "NeurIPS"

--- a/tests/test_catalog_backfill.py
+++ b/tests/test_catalog_backfill.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 
 from nexus.catalog.catalog import Catalog
 from nexus.cli import main
+from nexus.db.http_vector_client import HttpVectorClient
 
 
 @pytest.fixture(autouse=True)
@@ -51,8 +52,16 @@ def _mock_registry(tmp_path: Path, repos: dict | None = None) -> MagicMock:
 
 
 def _mock_t3(collections: list[dict] | None = None) -> MagicMock:
-    """Create a mock T3Database."""
-    mock = MagicMock()
+    """Create a mock T3 handle.
+
+    make_t3()/_make_t3() return the service-backed HttpVectorClient
+    unconditionally in production since RDR-155 P4a.2. list_collections()
+    returning a dict shape (``{"name":..., "count":...}``, not raw Chroma
+    Collection objects) matches HttpVectorClient.list_collections(), not
+    T3Database's chroma-Collection ``._client.list_collections()`` path --
+    spec= it so a missing method fails the mocked test too.
+    """
+    mock = MagicMock(spec=HttpVectorClient)
     if collections is None:
         collections = [
             {"name": "code__myrepo", "count": 100},
@@ -189,7 +198,12 @@ class TestBackfillFromT3:
     ) -> MagicMock:
         """Build a mock T3 whose ``get_collection().get(...)`` paginates
         chunks tagged with absolute source_paths under ``repo_root``."""
-        mock_t3 = MagicMock()
+        # make_t3()/_make_t3() return the service-backed HttpVectorClient
+        # unconditionally since RDR-155 P4a.2. _backfill_per_file_from_t3
+        # calls t3.get_collection(collection) directly (a method both
+        # T3Database and HttpVectorClient implement) -- it never reaches
+        # ._client, so no raw-chroma stub is needed here.
+        mock_t3 = MagicMock(spec=HttpVectorClient)
         mock_col = MagicMock()
         mock_col.name = collection_name
 
@@ -216,7 +230,6 @@ class TestBackfillFromT3:
 
         mock_col.get.side_effect = _paginated_get
         mock_t3.get_collection.return_value = mock_col
-        mock_t3._client.get_collection.return_value = mock_col
         return mock_t3
 
     def test_per_file_recovery_registers_unique_source_paths(
@@ -327,8 +340,11 @@ class TestBackfillFromT3:
         from nexus.commands.catalog import _backfill_per_file_from_t3
 
         cat = Catalog(catalog_env, catalog_env / ".catalog.db")
-        # No owner registered for this hash.
-        t3 = MagicMock()
+        # No owner registered for this hash. t3 is never touched -- the
+        # owner-lookup ClickException raises before any T3 call -- but
+        # spec= it anyway to match the real unconditional make_t3()
+        # return type (RDR-155 P4a.2).
+        t3 = MagicMock(spec=HttpVectorClient)
 
         with pytest.raises(Exception) as exc_info:
             _backfill_per_file_from_t3(
@@ -392,9 +408,11 @@ class TestBackfillFromT3CLI:
 
         mock_col = MagicMock()
         mock_col.get.side_effect = _paginated_get
-        mock_t3 = MagicMock()
+        # make_t3()/_make_t3() return the service-backed HttpVectorClient
+        # unconditionally since RDR-155 P4a.2; _backfill_per_file_from_t3
+        # calls t3.get_collection(collection) directly (no ._client access).
+        mock_t3 = MagicMock(spec=HttpVectorClient)
         mock_t3.get_collection.return_value = mock_col
-        mock_t3._client.get_collection.return_value = mock_col
         mock_t3_fn.return_value = mock_t3
         mock_reg_fn.return_value = _mock_registry(tmp_path)
 

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -10,6 +10,8 @@ from click.testing import CliRunner
 
 from nexus.catalog.catalog import Catalog
 from nexus.cli import main
+from nexus.daemon.catalog_write_shim import CATALOG_WRITE_OPS
+from nexus.db.http_vector_client import HttpVectorClient
 
 # RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
 # (voyage-* embedder names, canonical-set defaults). The cloud_mode
@@ -920,7 +922,9 @@ class TestVerifyCommand:
         """Patch _make_t3 in commands.catalog so existing_ids returns the seeded set."""
         from unittest.mock import MagicMock
 
-        fake = MagicMock()
+        # Module-wide cloud_mode fixture forces is_local_mode() False, so
+        # the real _make_t3()/make_t3() hands back an HttpVectorClient here.
+        fake = MagicMock(spec=HttpVectorClient)
 
         def _existing_ids(coll, ids):
             present = set(present_ids_by_collection.get(coll, []))
@@ -1672,7 +1676,9 @@ class TestSeam3OwnersCarve:
 
         from nexus.cli import main
 
-        fake = MagicMock()
+        # NX_STORAGE_BACKEND stays pinned to sqlite (autouse fixture), so
+        # _get_catalog() really returns a local Catalog reader here.
+        fake = MagicMock(spec=Catalog)
         fake.list_owners.return_value = [
             {"tumbler_prefix": "1.1", "owner_type": "repo", "name": "sentinel-owner"},
         ]
@@ -1760,7 +1766,9 @@ class TestKgyozLinksCarve:
 
         from nexus.cli import main
 
-        fake = MagicMock()
+        # NX_STORAGE_BACKEND stays pinned to sqlite (autouse fixture), so
+        # _get_catalog() really returns a local Catalog reader here.
+        fake = MagicMock(spec=Catalog)
         fake.link_audit.return_value = {
             "total": 7, "orphaned_count": 0, "duplicate_count": 0,
             "by_type": {}, "by_creator": {}, "orphaned": [],
@@ -1781,7 +1789,9 @@ class TestKgyozLinksCarve:
 
         edge = MagicMock()
         edge.to_dict.return_value = {"from": "1.1.1", "to": "1.2.1", "link_type": "cites"}
-        fake = MagicMock()
+        # NX_STORAGE_BACKEND stays pinned to sqlite (autouse fixture), so
+        # _get_catalog() really returns a local Catalog reader here.
+        fake = MagicMock(spec=Catalog)
         fake.link_query.return_value = [edge]
         with patch("nexus.commands.catalog._get_catalog", return_value=fake):
             result = CliRunner().invoke(
@@ -1837,7 +1847,9 @@ class TestWhh61BackupsCarve:
 
         from nexus.cli import main
 
-        fake = MagicMock()
+        # NX_STORAGE_BACKEND stays pinned to sqlite (autouse fixture), so
+        # _get_catalog() really returns a local Catalog reader here.
+        fake = MagicMock(spec=Catalog)
         with patch("nexus.commands.catalog._get_catalog", return_value=fake), \
                 patch("nexus.catalog.catalog_backup.list_backups", return_value=[]) as lb:
             result = CliRunner().invoke(main, ["catalog", "list-backups"])
@@ -1852,7 +1864,9 @@ class TestWhh61BackupsCarve:
 
         from nexus.cli import main
 
-        fake = MagicMock()
+        # NX_STORAGE_BACKEND stays pinned to sqlite (autouse fixture), so
+        # _get_catalog() really returns a local Catalog reader here.
+        fake = MagicMock(spec=Catalog)
         with patch("nexus.commands.catalog._get_catalog", return_value=fake), \
                 patch(
                     "nexus.catalog.catalog_backup.vacuum_old_backups",
@@ -1914,13 +1928,20 @@ class TestWhh61CollectionsCarve:
 
         from nexus.cli import main
 
-        cat = MagicMock()
+        # NX_STORAGE_BACKEND stays pinned to sqlite (autouse fixture), so
+        # _get_catalog() really returns a local Catalog reader here.
+        cat = MagicMock(spec=Catalog)
         cat.distinct_doc_collections.return_value = []
         cat.list_collections.return_value = []
-        t3 = MagicMock()
+        # cloud_mode (module-wide) forces is_local_mode() False -> real
+        # make_t3() would hand back an HttpVectorClient here.
+        t3 = MagicMock(spec=HttpVectorClient)
         t3.list_collections.return_value = []
         with patch("nexus.commands.catalog._get_catalog", return_value=cat), \
-                patch("nexus.commands.catalog._get_catalog_writer", return_value=MagicMock()), \
+                patch(
+                    "nexus.commands.catalog._get_catalog_writer",
+                    return_value=MagicMock(spec=list(CATALOG_WRITE_OPS)),
+                ), \
                 patch("nexus.db.make_t3", return_value=t3):
             result = CliRunner().invoke(main, ["catalog", "backfill-collections", "--dry-run"])
         assert result.exit_code == 0, result.output
@@ -1953,10 +1974,15 @@ class TestWhh61MigrationCarve:
 
         from nexus.cli import main
 
-        cat = MagicMock()
+        # NX_STORAGE_BACKEND stays pinned to sqlite (autouse fixture), so
+        # _get_catalog() really returns a local Catalog reader here.
+        cat = MagicMock(spec=Catalog)
         cat.get_collection.return_value = None  # -> ClickException before any write
         with patch("nexus.commands.catalog._get_catalog", return_value=cat), \
-                patch("nexus.commands.catalog._get_catalog_writer", return_value=MagicMock()):
+                patch(
+                    "nexus.commands.catalog._get_catalog_writer",
+                    return_value=MagicMock(spec=list(CATALOG_WRITE_OPS)),
+                ):
             result = CliRunner().invoke(main, ["catalog", "migrate-fallback", "docs__default"])
         assert result.exit_code != 0
         assert "not registered in the collections" in result.output
@@ -1972,11 +1998,16 @@ class TestWhh61MigrationCarve:
 
         entry = MagicMock()
         entry.tumbler = "1.1.1"
-        cat = MagicMock()
+        # NX_STORAGE_BACKEND stays pinned to sqlite (autouse fixture), so
+        # _get_catalog() really returns a local Catalog reader here.
+        cat = MagicMock(spec=Catalog)
         cat.get_collection.return_value = {"name": "docs__default"}  # non-None
         cat.list_by_collection.return_value = [entry]
         with patch("nexus.commands.catalog._get_catalog", return_value=cat), \
-                patch("nexus.commands.catalog._get_catalog_writer", return_value=MagicMock()):
+                patch(
+                    "nexus.commands.catalog._get_catalog_writer",
+                    return_value=MagicMock(spec=list(CATALOG_WRITE_OPS)),
+                ):
             result = CliRunner().invoke(
                 main, ["catalog", "migrate-fallback", "docs__default", "--dry-run"],
             )
@@ -2016,10 +2047,15 @@ class TestWhh61MaintenanceCarve:
 
         from nexus.cli import main
 
-        cat = MagicMock()
+        # NX_STORAGE_BACKEND stays pinned to sqlite (autouse fixture), so
+        # _get_catalog() really returns a local Catalog reader here.
+        cat = MagicMock(spec=Catalog)
         cat.all_documents.return_value = []
         with patch("nexus.commands.catalog._get_catalog", return_value=cat), \
-                patch("nexus.commands.catalog._get_catalog_writer", return_value=MagicMock()):
+                patch(
+                    "nexus.commands.catalog._get_catalog_writer",
+                    return_value=MagicMock(spec=list(CATALOG_WRITE_OPS)),
+                ):
             result = CliRunner().invoke(main, ["catalog", "gc"])
         assert result.exit_code == 0, result.output
         assert "No orphan entries found." in result.output
@@ -2073,11 +2109,16 @@ class TestWhh61RemediationCarve:
 
         from nexus.cli import main
 
-        cat = MagicMock()
+        # NX_STORAGE_BACKEND stays pinned to sqlite (autouse fixture), so
+        # _get_catalog() really returns a local Catalog reader here.
+        cat = MagicMock(spec=Catalog)
         cat.all_documents.return_value = []
         cat.owners_with_roots.return_value = {}
         with patch("nexus.commands.catalog._get_catalog", return_value=cat), \
-                patch("nexus.commands.catalog._get_catalog_writer", return_value=MagicMock()):
+                patch(
+                    "nexus.commands.catalog._get_catalog_writer",
+                    return_value=MagicMock(spec=list(CATALOG_WRITE_OPS)),
+                ):
             result = CliRunner().invoke(main, ["catalog", "prune-stale"])
         assert result.exit_code == 0, result.output
         assert "0 stale" in result.output
@@ -2121,7 +2162,9 @@ class TestWhh61ReportCarve:
 
         from nexus.cli import main
 
-        cat = MagicMock()
+        # NX_STORAGE_BACKEND stays pinned to sqlite (autouse fixture), so
+        # _get_catalog() really returns a local Catalog reader here.
+        cat = MagicMock(spec=Catalog)
         cat.stats.return_value = {
             "owner_count": 3, "doc_count": 9, "link_count": 4, "chunk_count": 0,
             "by_content_type": {}, "links_by_type": {},
@@ -2185,10 +2228,15 @@ class TestWhh61IntegrityCarve:
 
         from nexus.cli import main
 
-        cat = MagicMock()
+        # NX_STORAGE_BACKEND stays pinned to sqlite (autouse fixture), so
+        # _get_catalog() really returns a local Catalog reader here.
+        cat = MagicMock(spec=Catalog)
         cat.all_documents.return_value = []  # empty → clean early return
         with patch("nexus.commands.catalog._get_catalog", return_value=cat), \
-                patch("nexus.commands.catalog._get_catalog_writer", return_value=MagicMock()):
+                patch(
+                    "nexus.commands.catalog._get_catalog_writer",
+                    return_value=MagicMock(spec=list(CATALOG_WRITE_OPS)),
+                ):
             result = CliRunner().invoke(main, ["catalog", "verify"])
         assert result.exit_code == 0, result.output
         cat.all_documents.assert_called()

--- a/tests/test_catalog_consolidation.py
+++ b/tests/test_catalog_consolidation.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 
 from nexus.catalog.catalog import Catalog
 from nexus.cli import main
+from nexus.db.http_vector_client import HttpVectorClient
 
 # RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
 # (voyage-* embedder names, canonical-set defaults). The cloud_mode
@@ -183,7 +184,12 @@ class TestConsolidateCommand:
         cat.register(owner, "Paper A", content_type="paper", corpus="test",
                      physical_collection="docs__La")
 
-        mock_t3_fn.return_value = MagicMock()
+        # consolidate_cmd's --dry-run branch calls merge_corpus(cat, None,
+        # ..., dry_run=True) directly -- _make_t3() is never invoked in
+        # this path, so mock_t3_fn.return_value is inert here. spec= it
+        # anyway to match the real unconditional make_t3() return type
+        # (HttpVectorClient, RDR-155 P4a.2) rather than an unspec'd stub.
+        mock_t3_fn.return_value = MagicMock(spec=HttpVectorClient)
 
         runner = CliRunner()
         result = runner.invoke(main, ["catalog", "consolidate", "test", "--dry-run"])

--- a/tests/test_catalog_indexer_hook.py
+++ b/tests/test_catalog_indexer_hook.py
@@ -145,6 +145,354 @@ class TestCatalogHookDocuments:
         assert len(entries) == 2
 
 
+class _SpyProxy:
+    """Counting proxy around a real reader/writer (integration over mocks).
+
+    Delegates everything; records call counts for the methods the
+    nexus-dst5h batching contract pins.
+    """
+
+    def __init__(self, target):
+        self._target = target
+        self.calls: dict[str, int] = {}
+
+    def __getattr__(self, name):
+        attr = getattr(self._target, name)
+        if callable(attr):
+            def counted(*a, **kw):
+                self.calls[name] = self.calls.get(name, 0) + 1
+                return attr(*a, **kw)
+            return counted
+        return attr
+
+
+def _spy_factories(monkeypatch) -> tuple[list["_SpyProxy"], list["_SpyProxy"]]:
+    """Patch the catalog factories to hand out spy-wrapped real objects."""
+    import nexus.catalog.factory as factory
+
+    readers: list[_SpyProxy] = []
+    writers: list[_SpyProxy] = []
+    real_reader, real_writer = factory.make_catalog_reader, factory.make_catalog_writer
+
+    def spy_reader(**kw):
+        spy = _SpyProxy(real_reader(**kw))
+        readers.append(spy)
+        return spy
+
+    def spy_writer(**kw):
+        spy = _SpyProxy(real_writer(**kw))
+        writers.append(spy)
+        return spy
+
+    monkeypatch.setattr(factory, "make_catalog_reader", spy_reader)
+    monkeypatch.setattr(factory, "make_catalog_writer", spy_writer)
+    return readers, writers
+
+
+class TestCatalogHookBatchedLookups:
+    """nexus-dst5h: the pre-index sweep must not do per-file catalog
+    round-trips — one owner-scoped list + local join, and no writes for
+    unchanged files on a warm re-run."""
+
+    def _index(self, tmp_path, files, head_hash="aaa"):
+        from nexus.indexer import _catalog_hook
+
+        return _catalog_hook(
+            repo=tmp_path, repo_name="nexus", repo_hash="571b8edd",
+            head_hash=head_hash,
+            indexed_files=[(f, "code", "code__nexus") for f in files],
+        )
+
+    def test_no_per_file_lookups_single_owner_list(self, tmp_path, monkeypatch):
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+        files = []
+        for i in range(3):
+            f = tmp_path / f"f{i}.py"
+            f.write_text(f"code {i}")
+            files.append(f)
+
+        readers, _ = _spy_factories(monkeypatch)
+        self._index(tmp_path, files)
+
+        reader = readers[0]
+        assert reader.calls.get("by_file_path", 0) == 0
+        # Exactly 2: one hook-level join fetch + housekeeping's fresh fetch.
+        assert reader.calls.get("by_owner", 0) == 2
+
+    def test_warm_rerun_issues_zero_updates(self, tmp_path, monkeypatch):
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+        f = tmp_path / "a.py"
+        f.write_text("stable")
+
+        self._index(tmp_path, [f], head_hash="same")
+        _, writers = _spy_factories(monkeypatch)
+        self._index(tmp_path, [f], head_hash="same")
+
+        writer = writers[0]
+        assert writer.calls.get("update", 0) == 0
+        assert writer.calls.get("register", 0) == 0
+
+    def test_changed_head_hash_still_updates(self, tmp_path, monkeypatch):
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+        f = tmp_path / "a.py"
+        f.write_text("v1")
+
+        self._index(tmp_path, [f], head_hash="aaa")
+        _, writers = _spy_factories(monkeypatch)
+        self._index(tmp_path, [f], head_hash="bbb")
+
+        assert writers[0].calls.get("update", 0) == 1
+        owner = cat.owner_for_repo("571b8edd")
+        assert cat.by_file_path(owner, "a.py").head_hash == "bbb"
+
+    def test_changed_content_still_updates(self, tmp_path, monkeypatch):
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+        f = tmp_path / "a.py"
+        f.write_text("v1")
+
+        self._index(tmp_path, [f], head_hash="same")
+        f.write_text("v2 changed")
+        _, writers = _spy_factories(monkeypatch)
+        self._index(tmp_path, [f], head_hash="same")
+
+        assert writers[0].calls.get("update", 0) == 1
+
+    def test_new_file_still_registers_alongside_warm_files(self, tmp_path, monkeypatch):
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+        old = tmp_path / "old.py"
+        old.write_text("old")
+
+        self._index(tmp_path, [old], head_hash="same")
+        new = tmp_path / "new.py"
+        new.write_text("new")
+        _, writers = _spy_factories(monkeypatch)
+        result = self._index(tmp_path, [old, new], head_hash="same")
+
+        assert writers[0].calls.get("register", 0) == 1
+        assert writers[0].calls.get("update", 0) == 0
+        assert set(result) == {old, new}
+        owner = cat.owner_for_repo("571b8edd")
+        assert cat.by_file_path(owner, "new.py") is not None
+
+
+class TestCatalogHookOwnerListFailure:
+    """nexus-dst5h review Critical: a failing owner-list fetch must not
+    silently no-op the whole hook — it falls back to per-file lookups."""
+
+    def test_by_owner_failure_falls_back_per_file(self, tmp_path, monkeypatch):
+        from nexus.indexer import _catalog_hook
+
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+        f = tmp_path / "a.py"
+        f.write_text("code")
+
+        class _FailingOwnerList(_SpyProxy):
+            def by_owner(self, *a, **kw):
+                raise ConnectionError("service unreachable")
+
+        # Failing variant: housekeeping's by_owner also fails; the hook
+        # must still register the file via the per-file fallback.
+        import nexus.catalog.factory as factory
+        monkeypatch.setattr(
+            factory, "make_catalog_reader",
+            lambda **kw: _FailingOwnerList(cat),
+        )
+
+        result = _catalog_hook(
+            repo=tmp_path, repo_name="nexus", repo_hash="571b8edd",
+            head_hash="aaa",
+            indexed_files=[(f, "code", "code__nexus")],
+        )
+
+        assert set(result) == {f}
+        owner = cat.owner_for_repo("571b8edd")
+        assert cat.by_file_path(owner, "a.py") is not None
+
+    def test_frecency_by_owner_failure_returns_empty_map(self, tmp_path, monkeypatch):
+        from nexus.indexer import _build_frecency_doc_id_map
+
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        class _FailingOwnerList(_SpyProxy):
+            def by_owner(self, *a, **kw):
+                raise ConnectionError("service unreachable")
+
+        import nexus.catalog.factory as factory
+        monkeypatch.setattr(
+            factory, "make_catalog_reader",
+            lambda **kw: _FailingOwnerList(cat),
+        )
+        # Must not raise; documented contract returns an empty map.
+        assert _build_frecency_doc_id_map(tmp_path, [tmp_path / "a.py"]) == {}
+
+
+class TestFrecencyDocIdMapBatched:
+    """nexus-dst5h: _build_frecency_doc_id_map's second per-file
+    by_file_path pass must also become one by_owner + local join."""
+
+    def test_single_by_owner_no_per_file_lookups(self, tmp_path, monkeypatch):
+        from nexus.indexer import _build_frecency_doc_id_map, _catalog_hook
+        from nexus.repo_identity import _repo_identity
+
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+        files = []
+        for i in range(3):
+            f = tmp_path / f"f{i}.py"
+            f.write_text(f"code {i}")
+            files.append(f)
+        _, repo_hash = _repo_identity(tmp_path)
+        _catalog_hook(
+            repo=tmp_path, repo_name="nexus", repo_hash=repo_hash,
+            head_hash="aaa",
+            indexed_files=[(f, "code", "code__nexus") for f in files],
+        )
+
+        readers, _ = _spy_factories(monkeypatch)
+        unknown = tmp_path / "unknown.py"
+        mapping = _build_frecency_doc_id_map(tmp_path, [*files, unknown])
+
+        reader = readers[0]
+        assert reader.calls.get("by_file_path", 0) == 0
+        assert reader.calls.get("by_owner", 0) == 1
+        assert set(mapping) == set(files)  # unknown file absent from map
+
+
+class TestCatalogHookBatchedServiceMode:
+    """nexus-dst5h critic Critical: pin the batching + changed-predicate
+    contract against the REAL HttpCatalogClient, with entries passing
+    through ``_to_entry``'s JSON None→\"\"/0/{} coercion — the boundary the
+    warm-run tax actually lives on. The HTTP transport is mocked
+    (httpx.MockTransport); the client, URL routing, and JSON round-trip
+    are real."""
+
+    class _StubWriter:
+        """Write-side stub with the surface _catalog_hook touches."""
+
+        priority = "interactive"
+
+        def __init__(self):
+            self.register_calls: list[dict] = []
+            self.update_calls: list[dict] = []
+
+        def register(self, **kw):
+            from nexus.catalog.tumbler import Tumbler
+            self.register_calls.append(kw)
+            return Tumbler.parse("1.1.99")
+
+        def update(self, tumbler, **fields):
+            self.update_calls.append({"tumbler": str(tumbler), **fields})
+
+        def is_interactive_write_pending(self) -> bool:
+            return False
+
+        def close(self) -> None:
+            pass
+
+    def _http_client_and_log(self, monkeypatch, docs: list[dict]):
+        """Real HttpCatalogClient over a MockTransport serving *docs*."""
+        import httpx
+
+        from nexus.catalog.http_catalog_client import HttpCatalogClient
+
+        requests: list[tuple[str, dict]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            params = dict(request.url.params)
+            requests.append((request.url.path, params))
+            if request.url.path == "/v1/catalog/owners/by_repo":
+                return httpx.Response(200, json={"tumbler_prefix": "1.1"})
+            if request.url.path == "/v1/catalog/list":
+                return httpx.Response(200, json={"documents": docs})
+            return httpx.Response(200, json={})
+
+        monkeypatch.setenv("NX_SERVICE_TOKEN", "test-token")
+        client = HttpCatalogClient(base_url="http://mock.test")
+        client._client = httpx.Client(
+            base_url="http://mock.test",
+            transport=httpx.MockTransport(handler),
+        )
+        return client, requests
+
+    def _run_hook(self, tmp_path, monkeypatch, docs, head_hash):
+        from nexus.indexer import _catalog_hook
+
+        monkeypatch.setenv("NX_STORAGE_BACKEND_CATALOG", "service")
+        client, requests = self._http_client_and_log(monkeypatch, docs)
+        writer = self._StubWriter()
+
+        import nexus.catalog.factory as factory
+        monkeypatch.setattr(factory, "make_catalog_reader", lambda **kw: client)
+        monkeypatch.setattr(factory, "make_catalog_writer", lambda **kw: writer)
+
+        f = tmp_path / "a.py"
+        result = _catalog_hook(
+            repo=tmp_path, repo_name="nexus", repo_hash="571b8edd",
+            head_hash=head_hash,
+            indexed_files=[(f, "code", "code__nexus")],
+        )
+        return result, writer, requests
+
+    def _doc_for(self, f, *, head_hash) -> dict:
+        import hashlib
+
+        return {
+            "tumbler": "1.1.1",
+            "title": f.name,
+            "content_type": "code",
+            "file_path": f.name,
+            "physical_collection": "code__nexus",
+            "head_hash": head_hash,
+            "source_mtime": f.stat().st_mtime,
+            "meta": {"content_hash": hashlib.sha256(f.read_bytes()).hexdigest()},
+            # Java payloads carry explicit nulls; _to_entry must coerce.
+            "author": None,
+            "year": None,
+            "corpus": None,
+            "source_uri": None,
+        }
+
+    def test_warm_rerun_no_updates_no_per_file_lookups(self, tmp_path, monkeypatch):
+        f = tmp_path / "a.py"
+        f.write_text("stable")
+        doc = self._doc_for(f, head_hash="same")
+
+        result, writer, requests = self._run_hook(
+            tmp_path, monkeypatch, [doc], head_hash="same",
+        )
+
+        assert writer.update_calls == []
+        assert writer.register_calls == []
+        assert set(result) == {f}
+        # No per-file lookups: zero /list calls carrying file_path.
+        assert [p for path, p in requests
+                if path == "/v1/catalog/list" and "file_path" in p] == []
+        # Exactly 2 owner-list fetches: hook join + housekeeping.
+        assert len([p for path, p in requests
+                    if path == "/v1/catalog/list" and "owner" in p]) == 2
+
+    def test_changed_head_hash_updates_through_json_boundary(
+        self, tmp_path, monkeypatch,
+    ):
+        f = tmp_path / "a.py"
+        f.write_text("stable")
+        doc = self._doc_for(f, head_hash="old")
+
+        _, writer, _ = self._run_hook(
+            tmp_path, monkeypatch, [doc], head_hash="new",
+        )
+
+        assert len(writer.update_calls) == 1
+        assert writer.update_calls[0]["head_hash"] == "new"
+
+
 class TestCatalogHookErrorSafe:
     def test_hook_does_not_propagate_errors(self, tmp_path, monkeypatch):
         from nexus.indexer import _catalog_hook

--- a/tests/test_catalog_mcp.py
+++ b/tests/test_catalog_mcp.py
@@ -324,23 +324,44 @@ def test_resolve(cat, resolve_kw) -> None:
     assert "code__test" in catalog_resolve(**resolve_kw)
 
 
-def test_catalog_links_service_mode_plain_dicts_and_link_types(monkeypatch):
-    """nexus-qtj24: catalog_links must (1) pass ``link_types`` (plural) — the
-    only kwarg HttpCatalogClient.graph accepts (it has no singular link_type and
-    is keyword-only) — and (2) handle plain-dict nodes/edges from the service
-    /traverse path instead of calling .to_dict() unconditionally."""
+def test_catalog_links_service_mode_typed_objects_and_link_types(monkeypatch):
+    """nexus-qtj24: catalog_links must pass ``link_types`` (plural) — the only
+    kwarg HttpCatalogClient.graph accepts (it has no singular link_type and is
+    keyword-only).
+
+    nexus-u26b4: HttpCatalogClient.graph()/graph_many() now convert wire dicts
+    to typed CatalogEntry/CatalogLink objects (return-type parity, same fix
+    class as h8rf6.3), so every real backend returns typed nodes/edges here —
+    the isinstance(n, dict) plain-dict fallback this test used to exercise is
+    no longer reachable and was removed from catalog_links(); this fixture now
+    models the real (typed) contract instead of the pre-fix drifted one.
+    """
     import nexus.mcp.catalog as mc
 
     captured: dict = {}
+
+    class _FakeEntry:
+        def __init__(self, tumbler: str) -> None:
+            self.tumbler = tumbler
+
+        def to_dict(self) -> dict:
+            return {"tumbler": self.tumbler}
+
+    class _FakeLink:
+        def __init__(self, from_t: str, to_t: str) -> None:
+            self.from_tumbler = from_t
+            self.to_tumbler = to_t
+
+        def to_dict(self) -> dict:
+            return {"from_tumbler": self.from_tumbler, "to_tumbler": self.to_tumbler}
 
     class _FakeServiceCat:
         def graph(self, tumbler, *, link_types=None, direction="both", depth=1):
             captured["link_types"] = link_types
             captured["depth"] = depth
-            # The service /traverse path returns plain dicts (no .to_dict()).
             return {
-                "nodes": [{"tumbler": "1.1"}],
-                "edges": [{"from_tumbler": "1.1", "to_tumbler": "1.2"}],
+                "nodes": [_FakeEntry("1.1")],
+                "edges": [_FakeLink("1.1", "1.2")],
             }
 
     monkeypatch.setattr(mc, "_require_catalog", lambda: (_FakeServiceCat(), None))
@@ -350,7 +371,7 @@ def test_catalog_links_service_mode_plain_dicts_and_link_types(monkeypatch):
 
     assert "error" not in result, result
     assert captured["link_types"] == ["cites"], "singular link_type not normalized to plural"
-    assert result["nodes"] == [{"tumbler": "1.1"}], "plain-dict node did not survive (.to_dict crash)"
+    assert result["nodes"] == [{"tumbler": "1.1"}]
     assert result["edges"][0]["from_tumbler"] == "1.1"
 
 

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -790,7 +790,12 @@ def test_reembed_no_dry_run_writes_via_voyage(
     import chromadb
     import uuid
 
-    coll_name = f"knowledge__rem_{uuid.uuid4().hex[:12]}"
+    # nexus-u37lw: name ENCODES the target model — service mode only
+    # permits same-model re-embed (cross-model fails loud pre-write),
+    # and same-model routes through the upsert_chunks verbatim
+    # passthrough, never upsert_chunks_with_embeddings (which the
+    # service handle discards vectors on).
+    coll_name = f"code__rem{uuid.uuid4().hex[:10]}__voyage-code-3__v1"
     client = chromadb.EphemeralClient()
     col = client.get_or_create_collection(coll_name)
     col.add(
@@ -807,10 +812,15 @@ def test_reembed_no_dry_run_writes_via_voyage(
 
     upsert_calls: list[dict] = []
 
-    def _capture_upsert(**kw):
-        upsert_calls.append(kw)
+    def _capture_upsert(collection, ids, documents, metadatas=None, *,
+                        embeddings=None, skip_existing=None):
+        upsert_calls.append({
+            "collection_name": collection, "ids": ids,
+            "documents": documents, "metadatas": metadatas,
+            "embeddings": embeddings,
+        })
 
-    fake_db.upsert_chunks_with_embeddings.side_effect = _capture_upsert
+    fake_db.upsert_chunks.side_effect = _capture_upsert
 
     fake_embed_result = MagicMock()
     fake_embed_result.embeddings = [[0.5] * 1024, [0.7] * 1024]
@@ -858,7 +868,8 @@ def test_reembed_skips_empty_documents(
     import chromadb
     import uuid
 
-    coll_name = f"knowledge__rem_{uuid.uuid4().hex[:12]}"
+    # nexus-u37lw: model-encoded name so the same-model service path runs.
+    coll_name = f"code__rem{uuid.uuid4().hex[:10]}__voyage-3__v1"
     client = chromadb.EphemeralClient()
     col = client.get_or_create_collection(coll_name)
     col.add(

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -763,18 +763,13 @@ def test_reembed_dry_run_reports_count(runner, env_creds, tmp_path) -> None:
         ],
     )
 
-    # spec=T3Database + injected _client: pins the phantom pre-155 shape;
-    # convert with nexus-c9xr2. Despite env_creds setting cloud-shaped
-    # creds (which in production now means make_t3() hands back
-    # HttpVectorClient, not T3Database), reembed_cmd's dry-run path
-    # reaches `db._client.get_collection(...)` unconditionally
-    # (collection.py ~line 1011) -- a raw chromadb op HttpVectorClient
-    # deliberately does not expose. That is a live bug (nx collection
-    # re-embed crashes with AttributeError in every real invocation
-    # today); this fixture reproduces the shape the code currently
-    # requires rather than the shape make_t3() currently produces.
-    fake_db = MagicMock(spec=T3Database)
-    fake_db._client = client
+    # nexus-c9xr2 FIXED: re-embed now calls db.get_collection() (the
+    # method both production handles expose) instead of the pre-155
+    # db._client phantom. Spec against the handle make_t3() actually
+    # returns; route get_collection to the real Ephemeral collection so
+    # count()/get() paging behaves like production.
+    fake_db = MagicMock(spec=HttpVectorClient)
+    fake_db.get_collection.side_effect = client.get_collection
 
     result = _invoke(
         runner, fake_db,
@@ -806,11 +801,9 @@ def test_reembed_no_dry_run_writes_via_voyage(
         ],
     )
 
-    # spec=T3Database + injected _client: pins the phantom pre-155 shape;
-    # convert with nexus-c9xr2 (see test_reembed_dry_run_reports_count
-    # above for the full rationale).
-    fake_db = MagicMock(spec=T3Database)
-    fake_db._client = client
+    # nexus-c9xr2 FIXED: see test_reembed_dry_run_reports_count.
+    fake_db = MagicMock(spec=HttpVectorClient)
+    fake_db.get_collection.side_effect = client.get_collection
 
     upsert_calls: list[dict] = []
 
@@ -850,7 +843,7 @@ def test_reembed_rejects_cce_model(runner, env_creds) -> None:
     """nexus-bw65: voyage-context-3 (CCE) is not supported; click.Choice
     rejects at parse time."""
     result = _invoke(
-        runner, MagicMock(spec=T3Database),
+        runner, MagicMock(spec=HttpVectorClient),
         ["re-embed", "knowledge__any", "--to", "voyage-context-3"],
     )
     assert result.exit_code != 0
@@ -877,11 +870,9 @@ def test_reembed_skips_empty_documents(
         ],
     )
 
-    # spec=T3Database + injected _client: pins the phantom pre-155 shape;
-    # convert with nexus-c9xr2 (see test_reembed_dry_run_reports_count
-    # above for the full rationale).
-    fake_db = MagicMock(spec=T3Database)
-    fake_db._client = client
+    # nexus-c9xr2 FIXED: see test_reembed_dry_run_reports_count.
+    fake_db = MagicMock(spec=HttpVectorClient)
+    fake_db.get_collection.side_effect = client.get_collection
 
     fake_embed_result = MagicMock()
     fake_embed_result.embeddings = [[0.5] * 1024]

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -7,6 +7,8 @@ import pytest
 from click.testing import CliRunner
 
 from nexus.cli import main
+from nexus.db.http_vector_client import HttpVectorClient
+from nexus.db.t3 import T3Database
 
 
 @pytest.fixture
@@ -24,7 +26,13 @@ def env_creds(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture
 def mock_db():
-    return MagicMock()
+    # env_creds sets both cloud creds, so is_local_mode()'s legacy
+    # heuristic resolves to cloud/service mode — the real _t3() would
+    # hand back an HttpVectorClient. spec= it so a method missing from
+    # HttpVectorClient (e.g. rename_collection, which HttpVectorClient
+    # does not implement) fails the mocked test too, instead of silently
+    # answering via a bare MagicMock.
+    return MagicMock(spec=HttpVectorClient)
 
 
 def _invoke(runner, mock_db, args, **kwargs):
@@ -353,8 +361,12 @@ def test_reindex_treats_phase3_chunk_with_chash_only_as_reindexable(
     # Stub Catalog.docs_for_chashes to return the manifest mapping.
     # Catalog is lazy-imported inside reindex_cmd (`from nexus.catalog
     # import Catalog`); patch the source module's attribute so the
-    # lazy import resolves to our stub.
-    fake_cat = MagicMock()
+    # lazy import resolves to our stub. The autouse
+    # _pin_storage_backend_sqlite fixture pins the catalog to SQLite
+    # mode by default, so make_catalog_reader() really returns a local
+    # Catalog here (not HttpCatalogClient).
+    from nexus.catalog.catalog import Catalog
+    fake_cat = MagicMock(spec=Catalog)
     fake_cat.docs_for_chashes.return_value = {chash: ["ART-PHASE3"]}
 
     # RDR-146 P1.2: reindex reaches the catalog via make_catalog_reader().
@@ -575,8 +587,15 @@ def test_run_collection_postprocessing_does_not_pass_alias_through(monkeypatch):
 
     monkeypatch.setattr(index_mod, "_discover_taxonomy", _capture)
 
-    fake_t3 = MagicMock()
-    fake_t3._client = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2 -- cloud creds /
+    # is_local_mode() no longer affect the handle type. This test's
+    # _discover_taxonomy is fully mocked (_capture, above) and never
+    # touches t3 beyond passing it through, so no ._client stub is
+    # needed (the "inert" branch code-review flagged: total_topics
+    # stays 0, so the cross-collection projection branch that reads
+    # getattr(t3, "_client", t3) is never reached either).
+    fake_t3 = MagicMock(spec=HttpVectorClient)
     monkeypatch.setattr(index_mod, "make_t3", lambda: fake_t3, raising=False)
     # make_t3 lives in nexus.db; patch at the import site used inside
     # run_collection_postprocessing.
@@ -744,7 +763,17 @@ def test_reembed_dry_run_reports_count(runner, env_creds, tmp_path) -> None:
         ],
     )
 
-    fake_db = MagicMock()
+    # spec=T3Database + injected _client: pins the phantom pre-155 shape;
+    # convert with nexus-c9xr2. Despite env_creds setting cloud-shaped
+    # creds (which in production now means make_t3() hands back
+    # HttpVectorClient, not T3Database), reembed_cmd's dry-run path
+    # reaches `db._client.get_collection(...)` unconditionally
+    # (collection.py ~line 1011) -- a raw chromadb op HttpVectorClient
+    # deliberately does not expose. That is a live bug (nx collection
+    # re-embed crashes with AttributeError in every real invocation
+    # today); this fixture reproduces the shape the code currently
+    # requires rather than the shape make_t3() currently produces.
+    fake_db = MagicMock(spec=T3Database)
     fake_db._client = client
 
     result = _invoke(
@@ -777,7 +806,10 @@ def test_reembed_no_dry_run_writes_via_voyage(
         ],
     )
 
-    fake_db = MagicMock()
+    # spec=T3Database + injected _client: pins the phantom pre-155 shape;
+    # convert with nexus-c9xr2 (see test_reembed_dry_run_reports_count
+    # above for the full rationale).
+    fake_db = MagicMock(spec=T3Database)
     fake_db._client = client
 
     upsert_calls: list[dict] = []
@@ -818,7 +850,7 @@ def test_reembed_rejects_cce_model(runner, env_creds) -> None:
     """nexus-bw65: voyage-context-3 (CCE) is not supported; click.Choice
     rejects at parse time."""
     result = _invoke(
-        runner, MagicMock(),
+        runner, MagicMock(spec=T3Database),
         ["re-embed", "knowledge__any", "--to", "voyage-context-3"],
     )
     assert result.exit_code != 0
@@ -845,7 +877,10 @@ def test_reembed_skips_empty_documents(
         ],
     )
 
-    fake_db = MagicMock()
+    # spec=T3Database + injected _client: pins the phantom pre-155 shape;
+    # convert with nexus-c9xr2 (see test_reembed_dry_run_reports_count
+    # above for the full rationale).
+    fake_db = MagicMock(spec=T3Database)
     fake_db._client = client
 
     fake_embed_result = MagicMock()

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -8,6 +8,7 @@ import pytest
 from click.testing import CliRunner
 
 from nexus.cli import main
+from nexus.db.http_vector_client import HttpVectorClient
 
 SENTINEL_BEGIN = "# >>> nexus managed begin >>>"
 
@@ -467,7 +468,13 @@ class TestFixPaths:
             ("repo", "abc12345", str(tmp_path / "repo"),
              str(tmp_path / "repo" / "src" / "foo.py"), "code__test"),
         ])
-        mock_t3 = MagicMock()
+        # make_t3() returns the service-backed HttpVectorClient
+        # UNCONDITIONALLY in production since RDR-155 P4a.2 -- cloud
+        # creds / is_local_mode() no longer affect the handle type, and
+        # --fix-paths has no isinstance/is_service_backed branch that
+        # would care either way. spec= it so a missing-method bug can't
+        # hide behind an unspec'd stub.
+        mock_t3 = MagicMock(spec=HttpVectorClient)
         with (
             patch("nexus.config.catalog_path", return_value=cat_dir),
             patch("nexus.db.make_t3", return_value=mock_t3),
@@ -487,7 +494,7 @@ class TestFixPaths:
             ("repo", "abc12345", str(repo_dir),
              str(repo_dir / "src" / "foo.py"), "code__test"),
         ])
-        mock_t3 = MagicMock()
+        mock_t3 = MagicMock(spec=HttpVectorClient)
         mock_t3.update_source_path.return_value = 5
         with (
             patch("nexus.config.catalog_path", return_value=cat_dir),
@@ -504,7 +511,7 @@ class TestFixPaths:
         cat, cat_dir = self._make_catalog_with_entries(tmp_path, [
             ("curator", "", "", "/abs/path/paper.pdf", "docs__papers"),
         ])
-        mock_t3 = MagicMock()
+        mock_t3 = MagicMock(spec=HttpVectorClient)
         with (
             patch("nexus.config.catalog_path", return_value=cat_dir),
             patch("nexus.db.make_t3", return_value=mock_t3),
@@ -518,7 +525,7 @@ class TestFixPaths:
             ("repo", "abc12345", str(tmp_path / "repo"),
              "src/foo.py", "code__test"),  # already relative
         ])
-        mock_t3 = MagicMock()
+        mock_t3 = MagicMock(spec=HttpVectorClient)
         with (
             patch("nexus.config.catalog_path", return_value=cat_dir),
             patch("nexus.db.make_t3", return_value=mock_t3),
@@ -553,7 +560,7 @@ class TestCheckQuotas:
     ) -> None:
         with (
             patch("nexus.config.is_local_mode", return_value=False),
-            patch("nexus.db.make_t3", return_value=MagicMock()),
+            patch("nexus.db.make_t3", return_value=MagicMock(spec=HttpVectorClient)),
             patch("nexus.config.get_credential", return_value="sk-voyage-key"),
         ):
             result = runner.invoke(main, ["doctor", "--check-quotas"])
@@ -608,7 +615,7 @@ class TestCheckQuotas:
         glance, even though cloud itself may be reachable."""
         with (
             patch("nexus.config.is_local_mode", return_value=False),
-            patch("nexus.db.make_t3", return_value=MagicMock()),
+            patch("nexus.db.make_t3", return_value=MagicMock(spec=HttpVectorClient)),
             patch("nexus.config.get_credential", return_value=""),
         ):
             result = runner.invoke(main, ["doctor", "--check-quotas"])
@@ -628,7 +635,7 @@ class TestCheckQuotas:
 
         with (
             patch("nexus.config.is_local_mode", return_value=False),
-            patch("nexus.db.make_t3", return_value=MagicMock()),
+            patch("nexus.db.make_t3", return_value=MagicMock(spec=HttpVectorClient)),
             patch("nexus.config.get_credential", return_value="sk-voyage-key"),
         ):
             result = runner.invoke(main, ["doctor", "--check-quotas"])
@@ -652,7 +659,7 @@ class TestCheckQuotas:
 
         with (
             patch("nexus.config.is_local_mode", return_value=False),
-            patch("nexus.db.make_t3", return_value=MagicMock()),
+            patch("nexus.db.make_t3", return_value=MagicMock(spec=HttpVectorClient)),
             patch("nexus.config.get_credential", return_value="sk-voyage-key"),
         ):
             result = runner.invoke(

--- a/tests/test_dt_mcp_fallback.py
+++ b/tests/test_dt_mcp_fallback.py
@@ -27,6 +27,7 @@ import pytest
 
 from nexus.catalog.catalog import Catalog
 from nexus.catalog.dt_link_generator import generate_dt_links
+from nexus.db.http_vector_client import HttpVectorClient
 from nexus.dt_writeback import writeback_record
 
 
@@ -166,6 +167,14 @@ class TestLayerCFallback:
                 {"ids": ["c1"], "metadatas": [dict(meta)]},
                 {"ids": ["c1"], "documents": ["body"], "metadatas": [dict(meta)]},
             ]
+            # make_t3() returns the service-backed HttpVectorClient
+            # unconditionally in production since RDR-155 P4a.2 -- cloud
+            # creds / is_local_mode() no longer affect the handle type.
+            # get_or_create_collection() is a direct call on both
+            # handles and the retry/chroma internals are fully mocked
+            # above, so the code path doesn't care which is which; pin
+            # the real return type anyway.
+            mock_t3.return_value = MagicMock(spec=HttpVectorClient)
             mock_t3.return_value.get_or_create_collection.return_value = MagicMock()
             res = CliRunner().invoke(
                 enrich, ["bib", "knowledge__t", "--delay", "0", "--source", "dt"],

--- a/tests/test_enrich_command.py
+++ b/tests/test_enrich_command.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 
 from nexus.commands.enrich import enrich
+from nexus.db.http_vector_client import HttpVectorClient
 
 
 @patch("nexus.db.make_t3")
@@ -15,7 +16,13 @@ def test_enrich_empty_collection(mock_bib: MagicMock, mock_t3_factory: MagicMock
     """Empty collection prints message and exits cleanly."""
     mock_col = MagicMock()
     mock_col.get.return_value = {"ids": [], "metadatas": []}
-    mock_db = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2.
+    # get_or_create_collection() is a direct call on both handles, and
+    # _chroma_with_retry (patched where used) or the collection mock
+    # itself absorbs the rest, so spec=HttpVectorClient pins the real
+    # return type without changing behavior.
+    mock_db = MagicMock(spec=HttpVectorClient)
     mock_db.get_or_create_collection.return_value = mock_col
     mock_t3_factory.return_value = mock_db
 
@@ -38,7 +45,13 @@ def test_enrich_skips_already_enriched(mock_bib: MagicMock, mock_t3_factory: Mag
             {"title": "Paper A", "bib_semantic_scholar_id": "abc123"},
         ],
     }
-    mock_db = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2.
+    # get_or_create_collection() is a direct call on both handles, and
+    # _chroma_with_retry (patched where used) or the collection mock
+    # itself absorbs the rest, so spec=HttpVectorClient pins the real
+    # return type without changing behavior.
+    mock_db = MagicMock(spec=HttpVectorClient)
     mock_db.get_or_create_collection.return_value = mock_col
     mock_t3_factory.return_value = mock_db
 
@@ -82,7 +95,13 @@ def test_enrich_updates_metadata(
         # Third call: col.update
         None,
     ]
-    mock_db = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2.
+    # get_or_create_collection() is a direct call on both handles, and
+    # _chroma_with_retry (patched where used) or the collection mock
+    # itself absorbs the rest, so spec=HttpVectorClient pins the real
+    # return type without changing behavior.
+    mock_db = MagicMock(spec=HttpVectorClient)
     mock_db.get_or_create_collection.return_value = mock_col
     mock_t3_factory.return_value = mock_db
 
@@ -103,7 +122,13 @@ def test_enrich_no_match_increments_skipped(mock_bib: MagicMock, mock_t3_factory
         "ids": ["c1"],
         "metadatas": [{"title": "Unknown Paper"}],
     }
-    mock_db = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2.
+    # get_or_create_collection() is a direct call on both handles, and
+    # _chroma_with_retry (patched where used) or the collection mock
+    # itself absorbs the rest, so spec=HttpVectorClient pins the real
+    # return type without changing behavior.
+    mock_db = MagicMock(spec=HttpVectorClient)
     mock_db.get_or_create_collection.return_value = mock_col
     mock_t3_factory.return_value = mock_db
 
@@ -128,7 +153,13 @@ def test_enrich_limit_option(mock_bib: MagicMock, mock_t3_factory: MagicMock) ->
             {"title": "Paper C"},
         ],
     }
-    mock_db = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2.
+    # get_or_create_collection() is a direct call on both handles, and
+    # _chroma_with_retry (patched where used) or the collection mock
+    # itself absorbs the rest, so spec=HttpVectorClient pins the real
+    # return type without changing behavior.
+    mock_db = MagicMock(spec=HttpVectorClient)
     mock_db.get_or_create_collection.return_value = mock_col
     mock_t3_factory.return_value = mock_db
 
@@ -159,7 +190,13 @@ def test_enrich_source_openalex_routes_to_openalex_backend(
         "ids": ["c1"],
         "metadatas": [{"title": "Paper Z"}],
     }
-    mock_db = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2.
+    # get_or_create_collection() is a direct call on both handles, and
+    # _chroma_with_retry (patched where used) or the collection mock
+    # itself absorbs the rest, so spec=HttpVectorClient pins the real
+    # return type without changing behavior.
+    mock_db = MagicMock(spec=HttpVectorClient)
     mock_db.get_or_create_collection.return_value = mock_col
     mock_t3_factory.return_value = mock_db
 
@@ -198,7 +235,13 @@ def test_enrich_source_auto_falls_back_to_openalex_without_s2_key(
         "ids": ["c1"],
         "metadatas": [{"title": "Paper Auto"}],
     }
-    mock_db = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2.
+    # get_or_create_collection() is a direct call on both handles, and
+    # _chroma_with_retry (patched where used) or the collection mock
+    # itself absorbs the rest, so spec=HttpVectorClient pins the real
+    # return type without changing behavior.
+    mock_db = MagicMock(spec=HttpVectorClient)
     mock_db.get_or_create_collection.return_value = mock_col
     mock_t3_factory.return_value = mock_db
 
@@ -244,7 +287,13 @@ def test_enrich_openalex_prefers_doi_over_title_search(
             "title": "mfaz", "source_path": "/papers/mfaz.pdf",
         }]},
     ]
-    mock_db = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2.
+    # get_or_create_collection() is a direct call on both handles, and
+    # _chroma_with_retry (patched where used) or the collection mock
+    # itself absorbs the rest, so spec=HttpVectorClient pins the real
+    # return type without changing behavior.
+    mock_db = MagicMock(spec=HttpVectorClient)
     mock_db.get_or_create_collection.return_value = mock_col
     mock_t3_factory.return_value = mock_db
 
@@ -290,7 +339,13 @@ def test_enrich_openalex_falls_back_to_arxiv_when_no_doi(
             "title": "Attention", "source_path": "/papers/1706.03762.pdf",
         }]},
     ]
-    mock_db = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2.
+    # get_or_create_collection() is a direct call on both handles, and
+    # _chroma_with_retry (patched where used) or the collection mock
+    # itself absorbs the rest, so spec=HttpVectorClient pins the real
+    # return type without changing behavior.
+    mock_db = MagicMock(spec=HttpVectorClient)
     mock_db.get_or_create_collection.return_value = mock_col
     mock_t3_factory.return_value = mock_db
 
@@ -324,7 +379,13 @@ def test_enrich_source_auto_uses_s2_when_key_present(
         "ids": ["c1"],
         "metadatas": [{"title": "Paper S2"}],
     }
-    mock_db = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2.
+    # get_or_create_collection() is a direct call on both handles, and
+    # _chroma_with_retry (patched where used) or the collection mock
+    # itself absorbs the rest, so spec=HttpVectorClient pins the real
+    # return type without changing behavior.
+    mock_db = MagicMock(spec=HttpVectorClient)
     mock_db.get_or_create_collection.return_value = mock_col
     mock_t3_factory.return_value = mock_db
 

--- a/tests/test_enrich_dt_crossref.py
+++ b/tests/test_enrich_dt_crossref.py
@@ -21,6 +21,7 @@ from nexus.commands.enrich import (
     _merge_bib_gapfill,
     enrich,
 )
+from nexus.db.http_vector_client import HttpVectorClient
 
 
 # --- _dt_crossref_bib: map the live CrossRef flat dict -> nexus bib dict ----
@@ -165,7 +166,11 @@ def test_source_dt_gapfills_when_primary_misses(
         "authors": ["X", "Y"],
     }
     _two_chunk_collection(mock_retry)
-    mock_db = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2.
+    # get_or_create_collection() is a direct call on both handles;
+    # _chroma_with_retry is patched above so the rest is bypassed.
+    mock_db = MagicMock(spec=HttpVectorClient)
     mock_db.get_or_create_collection.return_value = MagicMock()
     mock_t3.return_value = mock_db
 
@@ -205,7 +210,11 @@ def test_source_dt_unavailable_degrades_to_primary_only(
         {"ids": ["c1"], "metadatas": [dict(_CHUNK_META)]},
         {"ids": ["c1"], "documents": ["body"], "metadatas": [dict(_CHUNK_META)]},
     ]
-    mock_db = MagicMock()
+    # make_t3() returns the service-backed HttpVectorClient
+    # unconditionally in production since RDR-155 P4a.2.
+    # get_or_create_collection() is a direct call on both handles;
+    # _chroma_with_retry is patched above so the rest is bypassed.
+    mock_db = MagicMock(spec=HttpVectorClient)
     mock_db.get_or_create_collection.return_value = MagicMock()
     mock_t3.return_value = mock_db
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
 
+from nexus.db.http_vector_client import HttpVectorClient
 from nexus.db.t3 import T3Database
 from nexus.errors import EmbeddingModelMismatch, FormatVersionError, NexusError
 from nexus.exporter import (
@@ -548,7 +549,8 @@ class TestExportImportCLI:
     def test_export_mutual_exclusion(self, runner, env_creds, args):
         from unittest.mock import MagicMock, patch
         from nexus.cli import main
-        with patch("nexus.commands.store._t3", return_value=MagicMock()):
+        # env_creds sets cloud creds -> real _t3() would be HttpVectorClient.
+        with patch("nexus.commands.store._t3", return_value=MagicMock(spec=HttpVectorClient)):
             result = runner.invoke(main, args)
         assert result.exit_code != 0
 
@@ -561,7 +563,7 @@ class TestExportImportCLI:
         from nexus.cli import main
         dummy = tmp_path / "dummy.nxexp"
         dummy.write_bytes(b"not a real file")
-        with patch("nexus.commands.store._t3", return_value=MagicMock()):
+        with patch("nexus.commands.store._t3", return_value=MagicMock(spec=HttpVectorClient)):
             result = runner.invoke(main, ["store", "import", str(dummy), "--remap", remap_val])
         assert result.exit_code != 0
         output = result.output.lower()

--- a/tests/test_hybrid_boost.py
+++ b/tests/test_hybrid_boost.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from nexus.db.http_vector_client import HttpVectorClient
 from nexus.types import SearchResult
 
 
@@ -68,7 +69,8 @@ def cli_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
 
 @pytest.fixture()
 def mock_t3():
-    t3 = MagicMock()
+    # cli_env sets cloud creds -> real _t3() would be HttpVectorClient.
+    t3 = MagicMock(spec=HttpVectorClient)
     t3.list_collections.return_value = [{"name": "code__repo-abcd1234"}]
     return t3
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1302,7 +1302,7 @@ def test_on_stage_timers_fires_per_code_file_when_subscribed(tmp_path):
     # StageTimers instance with the expected shape
     snapshot = timers.snapshot()
     assert set(snapshot.keys()) == {
-        "chunking_s", "embed_s", "upload_s", "retry_s",
+        "chunking_s", "embed_s", "upload_s", "hooks_s", "retry_s",
     }
 
 

--- a/tests/test_indexer_concurrency.py
+++ b/tests/test_indexer_concurrency.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-cfc72: bounded file-level indexing concurrency.
+
+The three per-file loops in ``_run_index`` (code/prose/pdf) run through
+``run_file_loop`` — sequential at concurrency 1 (exact legacy behavior),
+a bounded ThreadPoolExecutor above that. Callbacks and hook chains are
+serialized; the first worker exception cancels pending files and
+re-raises.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+
+# ── concurrency resolution ───────────────────────────────────────────────────
+
+
+class TestResolveIndexConcurrency:
+    def test_env_override_wins(self, monkeypatch):
+        from nexus.indexer_utils import resolve_index_concurrency
+
+        monkeypatch.setenv("NX_INDEX_CONCURRENCY", "4")
+        assert resolve_index_concurrency() == 4
+
+    def test_env_override_clamped_to_one(self, monkeypatch):
+        from nexus.indexer_utils import resolve_index_concurrency
+
+        monkeypatch.setenv("NX_INDEX_CONCURRENCY", "0")
+        assert resolve_index_concurrency() == 1
+
+    def test_garbage_env_falls_through_to_default(self, monkeypatch):
+        from nexus.indexer_utils import resolve_index_concurrency
+
+        monkeypatch.setenv("NX_INDEX_CONCURRENCY", "two")
+        # Backend envs cleared -> hard defaults are SERVICE for both
+        # vectors (is_vector_service_mode) and catalog -> exactly 2.
+        monkeypatch.delenv("NX_STORAGE_BACKEND", raising=False)
+        monkeypatch.delenv("NX_STORAGE_BACKEND_VECTORS", raising=False)
+        monkeypatch.delenv("NX_STORAGE_BACKEND_CATALOG", raising=False)
+        assert resolve_index_concurrency() == 2
+
+    def test_override_onto_non_service_backend_warns_but_wins(self, monkeypatch):
+        """Forcing concurrency onto a sqlite catalog is allowed but loud."""
+        from nexus.indexer_utils import resolve_index_concurrency
+
+        monkeypatch.setenv("NX_INDEX_CONCURRENCY", "3")
+        monkeypatch.setenv("NX_STORAGE_BACKEND_CATALOG", "sqlite")
+        import structlog.testing
+        with structlog.testing.capture_logs() as logs:
+            assert resolve_index_concurrency() == 3
+        assert any(
+            l["event"] == "nx_index_concurrency_overrides_backend_gate"
+            for l in logs
+        )
+
+    def test_service_backends_default_two(self, monkeypatch):
+        from nexus.indexer_utils import resolve_index_concurrency
+
+        monkeypatch.delenv("NX_INDEX_CONCURRENCY", raising=False)
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
+        assert resolve_index_concurrency() == 2
+
+    def test_non_service_catalog_defaults_one(self, monkeypatch):
+        from nexus.indexer_utils import resolve_index_concurrency
+
+        monkeypatch.delenv("NX_INDEX_CONCURRENCY", raising=False)
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
+        monkeypatch.setenv("NX_STORAGE_BACKEND_CATALOG", "sqlite")
+        assert resolve_index_concurrency() == 1
+
+    def test_vectors_opt_out_defaults_one(self, monkeypatch):
+        from nexus.indexer_utils import resolve_index_concurrency
+
+        monkeypatch.delenv("NX_INDEX_CONCURRENCY", raising=False)
+        monkeypatch.setenv("NX_STORAGE_BACKEND", "service")
+        monkeypatch.setenv("NX_STORAGE_BACKEND_VECTORS", "chroma")
+        assert resolve_index_concurrency() == 1
+
+
+# ── run_file_loop ────────────────────────────────────────────────────────────
+
+
+class TestRunFileLoop:
+    def _files(self, n: int) -> list[tuple[float, Path]]:
+        return [(float(n - i), Path(f"/repo/f{i}.py")) for i in range(n)]
+
+    def test_sequential_preserves_order(self):
+        from nexus.indexer_utils import run_file_loop
+
+        seen: list[str] = []
+
+        def index_one(file, score, timers):
+            seen.append(file.name)
+            return 1
+
+        run_file_loop(
+            self._files(4), index_one, concurrency=1,
+            on_file=None, on_stage_timers=None,
+        )
+        assert seen == ["f0.py", "f1.py", "f2.py", "f3.py"]
+
+    def test_concurrent_processes_all_files(self):
+        from nexus.indexer_utils import run_file_loop
+
+        seen: set[str] = set()
+        lock = threading.Lock()
+
+        def index_one(file, score, timers):
+            with lock:
+                seen.add(file.name)
+            return 2
+
+        run_file_loop(
+            self._files(8), index_one, concurrency=3,
+            on_file=None, on_stage_timers=None,
+        )
+        assert seen == {f"f{i}.py" for i in range(8)}
+
+    def test_workers_actually_overlap(self):
+        """Two slow files at concurrency=2 finish in ~1x the sleep, not 2x —
+        pins that the pool genuinely parallelizes."""
+        from nexus.indexer_utils import run_file_loop
+
+        barrier = threading.Barrier(2, timeout=5)
+
+        def index_one(file, score, timers):
+            barrier.wait()  # deadlocks (-> Barrier timeout) unless 2 run at once
+            return 1
+
+        run_file_loop(
+            self._files(2), index_one, concurrency=2,
+            on_file=None, on_stage_timers=None,
+        )
+
+    def test_on_file_callback_serialized_and_complete(self):
+        from nexus.indexer_utils import run_file_loop
+
+        in_cb = threading.Event()
+        overlaps: list[str] = []
+        calls: list[tuple[str, int]] = []
+
+        def on_file(file, chunks, elapsed):
+            if in_cb.is_set():
+                overlaps.append(file.name)
+            in_cb.set()
+            time.sleep(0.01)
+            in_cb.clear()
+            calls.append((file.name, chunks))
+            assert elapsed >= 0
+
+        def index_one(file, score, timers):
+            return 5
+
+        run_file_loop(
+            self._files(6), index_one, concurrency=3,
+            on_file=on_file, on_stage_timers=None,
+        )
+        assert overlaps == []
+        assert sorted(c[0] for c in calls) == sorted(f"f{i}.py" for i in range(6))
+        assert all(c[1] == 5 for c in calls)
+
+    def test_stage_timers_built_per_file_when_subscribed(self):
+        from nexus.indexer_utils import run_file_loop
+
+        timer_objs: list[object] = []
+        received: list[tuple[str, object]] = []
+
+        def index_one(file, score, timers):
+            timer_objs.append(timers)
+            return 0
+
+        def on_stage_timers(file, timers):
+            received.append((file.name, timers))
+
+        run_file_loop(
+            self._files(3), index_one, concurrency=2,
+            on_file=None, on_stage_timers=on_stage_timers,
+        )
+        assert len(received) == 3
+        assert all(t is not None for t in timer_objs)
+        assert len({id(t) for t in timer_objs}) == 3  # distinct per file
+
+    def test_no_timers_when_not_subscribed(self):
+        from nexus.indexer_utils import run_file_loop
+
+        timer_objs: list[object] = []
+
+        def index_one(file, score, timers):
+            timer_objs.append(timers)
+            return 0
+
+        run_file_loop(
+            self._files(2), index_one, concurrency=2,
+            on_file=None, on_stage_timers=None,
+        )
+        assert timer_objs == [None, None]
+
+    def test_first_exception_propagates_and_cancels_pending(self):
+        from nexus.indexer_utils import run_file_loop
+
+        started: list[str] = []
+        lock = threading.Lock()
+
+        def index_one(file, score, timers):
+            with lock:
+                started.append(file.name)
+            if file.name == "f0.py":
+                raise RuntimeError("boom on f0")
+            time.sleep(0.02)
+            return 1
+
+        with pytest.raises(RuntimeError, match="boom on f0"):
+            run_file_loop(
+                self._files(50), index_one, concurrency=2,
+                on_file=None, on_stage_timers=None,
+            )
+        # Pending futures cancelled: nowhere near all 50 started.
+        assert len(started) < 50
+
+    def test_concurrent_double_failure_raises_first_logs_rest(self):
+        """Two near-simultaneous failures: submission-order-first is
+        raised, the secondary is logged, never silently dropped
+        (critique finding, nexus-cfc72)."""
+        from nexus.indexer_utils import run_file_loop
+
+        barrier = threading.Barrier(2, timeout=5)
+
+        def index_one(file, score, timers):
+            if file.name in ("f0.py", "f1.py"):
+                barrier.wait()  # both fail together
+                raise RuntimeError(f"boom {file.name}")
+            return 1
+
+        import structlog.testing
+        with structlog.testing.capture_logs() as logs, \
+                pytest.raises(RuntimeError, match="boom f0.py"):
+            run_file_loop(
+                self._files(2), index_one, concurrency=2,
+                on_file=None, on_stage_timers=None,
+            )
+        suppressed = [
+            l for l in logs
+            if l["event"] == "index_file_concurrent_failure_suppressed"
+        ]
+        assert len(suppressed) == 1
+        assert "f1.py" in suppressed[0]["file"]
+
+    def test_sequential_exception_propagates_immediately(self):
+        from nexus.indexer_utils import run_file_loop
+
+        started: list[str] = []
+
+        def index_one(file, score, timers):
+            started.append(file.name)
+            raise ValueError("seq boom")
+
+        with pytest.raises(ValueError, match="seq boom"):
+            run_file_loop(
+                self._files(3), index_one, concurrency=1,
+                on_file=None, on_stage_timers=None,
+            )
+        assert started == ["f0.py"]
+
+
+# ── LockedHookRegistry ───────────────────────────────────────────────────────
+
+
+class TestLockedHookRegistry:
+    def test_delegates_and_serializes_fire_methods(self):
+        from nexus.hook_registry import HookRegistry, LockedHookRegistry
+
+        registry = HookRegistry()
+        in_hook = threading.Event()
+        overlaps: list[str] = []
+        fired: list[str] = []
+
+        def slow_hook(source_path, collection, content):
+            if in_hook.is_set():
+                overlaps.append(source_path)
+            in_hook.set()
+            time.sleep(0.01)
+            in_hook.clear()
+            fired.append(source_path)
+
+        registry.register_document(slow_hook)
+        locked = LockedHookRegistry(registry)
+
+        threads = [
+            threading.Thread(
+                target=locked.fire_document, args=(f"/p{i}", "col", "x"),
+            )
+            for i in range(6)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert overlaps == []
+        assert sorted(fired) == [f"/p{i}" for i in range(6)]
+
+    def test_getattr_falls_through_to_registry(self):
+        from nexus.hook_registry import HookRegistry, LockedHookRegistry
+
+        registry = HookRegistry()
+        locked = LockedHookRegistry(registry)
+        assert locked._document is registry._document
+        # register_* passes through so install_default_hooks(locked) works.
+        def probe(sp, col, content):
+            pass
+        locked.register_document(probe)
+        assert probe in registry._document

--- a/tests/test_nexus_lub_collection_delete_cascade.py
+++ b/tests/test_nexus_lub_collection_delete_cascade.py
@@ -23,6 +23,8 @@ from pathlib import Path
 
 import pytest
 
+from nexus.db.http_vector_client import HttpVectorClient
+
 
 @pytest.fixture
 def seeded_taxonomy(tmp_path: Path):
@@ -252,7 +254,11 @@ class TestCollectionDeleteCommandCascades:
         db.taxonomy.conn.commit()
         db.close()
 
-        fake_t3 = MagicMock()
+        # make_t3()/_t3() return the service-backed HttpVectorClient
+        # unconditionally in production since RDR-155 P4a.2 -- cloud
+        # creds / is_local_mode() no longer affect the handle type.
+        # delete_collection is a direct call on both handles.
+        fake_t3 = MagicMock(spec=HttpVectorClient)
         fake_t3.delete_collection = MagicMock(
             side_effect=NotFoundError("Collection [docs__gone] does not exist")
         )
@@ -308,7 +314,11 @@ class TestCollectionDeleteCommandCascades:
         db.taxonomy.conn.commit()
         db.close()
 
-        fake_t3 = MagicMock()
+        # make_t3()/_t3() return the service-backed HttpVectorClient
+        # unconditionally in production since RDR-155 P4a.2 -- cloud
+        # creds / is_local_mode() no longer affect the handle type.
+        # delete_collection is a direct call on both handles.
+        fake_t3 = MagicMock(spec=HttpVectorClient)
         fake_t3.delete_collection = MagicMock()
 
         runner = CliRunner()
@@ -372,7 +382,11 @@ class TestChashIndexDeleteCascade:
                 chash="cc33", collection="code__stays",
             )
 
-        fake_t3 = MagicMock()
+        # make_t3()/_t3() return the service-backed HttpVectorClient
+        # unconditionally in production since RDR-155 P4a.2 -- cloud
+        # creds / is_local_mode() no longer affect the handle type.
+        # delete_collection is a direct call on both handles.
+        fake_t3 = MagicMock(spec=HttpVectorClient)
         fake_t3.delete_collection = MagicMock()
 
         runner = CliRunner()
@@ -417,7 +431,11 @@ class TestChashIndexDeleteCascade:
                 chash="aa11", collection="docs__orphan",
             )
 
-        fake_t3 = MagicMock()
+        # make_t3()/_t3() return the service-backed HttpVectorClient
+        # unconditionally in production since RDR-155 P4a.2 -- cloud
+        # creds / is_local_mode() no longer affect the handle type.
+        # delete_collection is a direct call on both handles.
+        fake_t3 = MagicMock(spec=HttpVectorClient)
         fake_t3.delete_collection = MagicMock(
             side_effect=NotFoundError(
                 "Collection [docs__orphan] does not exist",
@@ -459,7 +477,11 @@ class TestChashIndexDeleteCascade:
                     chash=f"h{i:02d}", collection="code__reported",
                 )
 
-        fake_t3 = MagicMock()
+        # make_t3()/_t3() return the service-backed HttpVectorClient
+        # unconditionally in production since RDR-155 P4a.2 -- cloud
+        # creds / is_local_mode() no longer affect the handle type.
+        # delete_collection is a direct call on both handles.
+        fake_t3 = MagicMock(spec=HttpVectorClient)
         fake_t3.delete_collection = MagicMock()
 
         runner = CliRunner()
@@ -510,7 +532,11 @@ class TestPipelineDeleteCascade:
         pdb.write_chunk("hB", 0, "b", "cid-b")
         pdb.create_pipeline("hC", "/c.pdf", "docs__keep")
 
-        fake_t3 = MagicMock()
+        # make_t3()/_t3() return the service-backed HttpVectorClient
+        # unconditionally in production since RDR-155 P4a.2 -- cloud
+        # creds / is_local_mode() no longer affect the handle type.
+        # delete_collection is a direct call on both handles.
+        fake_t3 = MagicMock(spec=HttpVectorClient)
         fake_t3.delete_collection = MagicMock()
 
         runner = CliRunner()
@@ -559,7 +585,11 @@ class TestPipelineDeleteCascade:
         pdb = PipelineDB(pipe_path)
         pdb.create_pipeline("orphan_h", "/o.pdf", "docs__gone")
 
-        fake_t3 = MagicMock()
+        # make_t3()/_t3() return the service-backed HttpVectorClient
+        # unconditionally in production since RDR-155 P4a.2 -- cloud
+        # creds / is_local_mode() no longer affect the handle type.
+        # delete_collection is a direct call on both handles.
+        fake_t3 = MagicMock(spec=HttpVectorClient)
         fake_t3.delete_collection = MagicMock(
             side_effect=NotFoundError("Collection [docs__gone] does not exist"),
         )

--- a/tests/test_pg_bundle_version_parity.py
+++ b/tests/test_pg_bundle_version_parity.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-m8au7 (review finding): PG_VERSION / PGVECTOR_VERSION are pinned in
+FOUR places — ci.yml (two jobs), engine-service-release.yml, and
+pg-bundle-cache-seed.yml — and the cache handshake between the release
+workflow and the seed workflow depends on the pins (and the whole cache KEY
+line) being identical. A version bump applied to one file but not the others
+would mean permanent cache misses at best (silent compile-per-tag
+regression) or a wrong-version bundle at worst. This is the mechanical
+parity gate; scripts/build_pg_bundle.sh holds the defaults but env pins
+select the version, so the pins are what must agree.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WORKFLOWS = Path(__file__).parent.parent / ".github" / "workflows"
+
+PINNED_FILES = [
+    "ci.yml",
+    "engine-service-release.yml",
+    "pg-bundle-cache-seed.yml",
+]
+
+
+def _pins(name: str, var: str) -> set[str]:
+    text = (WORKFLOWS / name).read_text()
+    return set(re.findall(rf'{var}:\s*"([^"]+)"', text))
+
+
+def test_pg_version_pins_identical_across_workflows() -> None:
+    values = {name: _pins(name, "PG_VERSION") for name in PINNED_FILES}
+    assert all(v for v in values.values()), f"missing PG_VERSION pin: {values}"
+    flat = set().union(*values.values())
+    assert len(flat) == 1, (
+        f"PG_VERSION pins diverge across workflows: {values} — bump ALL "
+        f"files together (see pg-bundle-cache-seed.yml header)"
+    )
+
+
+def test_pgvector_version_pins_identical_across_workflows() -> None:
+    values = {name: _pins(name, "PGVECTOR_VERSION") for name in PINNED_FILES}
+    assert all(v for v in values.values()), f"missing PGVECTOR_VERSION pin: {values}"
+    flat = set().union(*values.values())
+    assert len(flat) == 1, (
+        f"PGVECTOR_VERSION pins diverge across workflows: {values} — bump "
+        f"ALL files together (see pg-bundle-cache-seed.yml header)"
+    )
+
+
+def test_cache_key_lines_byte_identical() -> None:
+    """The seed workflow's save key and the release workflow's restore key
+    must be the SAME expression, or every tag silently misses the cache."""
+    keys: dict[str, set[str]] = {}
+    for name in ("engine-service-release.yml", "pg-bundle-cache-seed.yml"):
+        text = (WORKFLOWS / name).read_text()
+        keys[name] = {
+            line.strip()
+            for line in text.splitlines()
+            if line.strip().startswith("key: pg-bundle-")
+        }
+    assert keys["engine-service-release.yml"] == keys["pg-bundle-cache-seed.yml"] != set(), (
+        f"pg-bundle cache key expressions diverge: {keys}"
+    )

--- a/tests/test_post_document_hooks.py
+++ b/tests/test_post_document_hooks.py
@@ -433,3 +433,45 @@ def test_record_batch_hook_failure_writes_chain_batch(
     assert _json.loads(row[1]) == ["d1", "d2"]
     assert row[2] == 1
     assert row[3] == "batch"
+
+
+# ── nexus-w8lg1: document chain must carry the CATALOG doc_id ────────────────
+
+
+def test_fire_store_chains_forwards_catalog_doc_id_to_document_chain() -> None:
+    """nexus-w8lg1 (6.3.0 live shakeout finding #1): fire_store_chains
+    passed the T3 chunk id (chunk_text_hash[:32]) as the document chain's
+    doc_id instead of the catalog tumbler. The aspect-enqueue hook then
+    shipped that chunk hash to the engine, violating the composite FK
+    aspect_extraction_queue(tenant_id, doc_id) -> catalog_documents
+    (tenant_id, tumbler) — SQLSTATE 23503, surfaced as a typed 409, and
+    the note silently never got aspects."""
+    registry = HookRegistry()
+    seen: list[dict] = []
+
+    def doc_id_aware(source_path, collection, content, *, doc_id=""):
+        seen.append({"source_path": source_path, "doc_id": doc_id})
+
+    registry.register_document(doc_id_aware)
+
+    chunk_id = "bf715bbd" + "0" * 24  # chunk_text_hash[:32] shape
+    registry.fire_store_chains(
+        [chunk_id], "knowledge__delos", ["note body"],
+        catalog_doc_id="1.7.42",
+    )
+
+    assert seen == [{"source_path": chunk_id, "doc_id": "1.7.42"}]
+
+
+def test_fire_store_chains_empty_catalog_doc_id_stays_empty() -> None:
+    """No catalog entry (catalog absent) -> doc_id must stay "" so the
+    enqueue persists NULL, which the nullable FK accepts."""
+    registry = HookRegistry()
+    seen: list[str] = []
+
+    def doc_id_aware(source_path, collection, content, *, doc_id=""):
+        seen.append(doc_id)
+
+    registry.register_document(doc_id_aware)
+    registry.fire_store_chains(["c" * 32], "knowledge__delos", ["body"])
+    assert seen == [""]

--- a/tests/test_search_cmd.py
+++ b/tests/test_search_cmd.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 
 from nexus.cli import main
 from nexus.commands.search_cmd import _parse_where
+from nexus.db.http_vector_client import HttpVectorClient
 from nexus.db.t3 import T3Database
 from nexus.scoring import apply_hybrid_scoring
 from nexus.search_engine import search_cross_corpus
@@ -34,7 +35,13 @@ def _make_result(
 
 
 def _mock_t3(collections: list[str] | None = None) -> MagicMock:
-    mock = MagicMock()
+    # Most call sites here run under cloud_env / is_local_mode=False (see
+    # the nexus-xbw0f reranker tests below), so the real _t3() would hand
+    # back an HttpVectorClient. spec= it so a method HttpVectorClient
+    # doesn't implement fails the mocked test too. Explicit attribute
+    # assignment (e.g. ``mock_t3._voyage_client = None``) still works
+    # under spec= (only get-access is restricted, not set-access).
+    mock = MagicMock(spec=HttpVectorClient)
     col_names = collections or ["knowledge__test"]
     mock.list_collections.return_value = [{"name": n} for n in col_names]
     return mock

--- a/tests/test_service_mode_cli_real_client.py
+++ b/tests/test_service_mode_cli_real_client.py
@@ -278,3 +278,37 @@ def test_model_drift_probe_service_mode_real_client(real_client, monkeypatch):
     # 'error' is the pre-fix service-mode symptom; 'model_drift' would mean
     # collection_metadata resolved the wrong model for a conformant name.
     assert results[0].outcome == "matched", (results[0].outcome, results[0].error)
+
+
+# ── nx collection re-embed (get_collection + stub.count, nexus-c9xr2) ────────
+
+
+def test_collection_reembed_dry_run_service_mode_real_client(
+    runner, real_client, monkeypatch,
+):
+    """nexus-c9xr2: re-embed reached db._client.get_collection — an attr NO
+    production handle has post-RDR-155 — so every real invocation crashed
+    with a raw AttributeError. The command now uses db.get_collection();
+    this drives the dry-run end-to-end through the REAL HttpVectorClient
+    (the _ServiceCollectionStub's new count() included) so the seam can
+    never be mock-masked again."""
+    coll = _KNOWLEDGE
+
+    def fake_get(path, tenant="default"):
+        if path.startswith("/v1/vectors/count"):
+            return {"count": 7}
+        if path.startswith("/v1/vectors/stats"):
+            # list_collections' primary path: /stats returns a BARE LIST of
+            # per-collection stat rows (collection_stats docstring).
+            return [{"name": coll, "dim": 1024, "count": 7}]
+        raise AssertionError(f"unexpected GET {path}")
+
+    monkeypatch.setattr("nexus.db.http_vector_client._get", fake_get)
+
+    with patch("nexus.commands.collection._t3", return_value=real_client):
+        result = runner.invoke(
+            main, ["collection", "re-embed", coll, "--to", "voyage-code-3"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "dry-run" in result.output
+    assert "7" in result.output

--- a/tests/test_service_mode_cli_real_client.py
+++ b/tests/test_service_mode_cli_real_client.py
@@ -183,9 +183,14 @@ def test_t3_gc_service_mode_real_client(tmp_path, runner, real_client, monkeypat
             return {"deleted": len(body["ids"])}
         raise AssertionError(f"unexpected path {path}")
 
-    fake_cat = MagicMock()
+    # Spec'd against the REAL service-mode catalog client so attributes it
+    # doesn't have (like the local catalog's _dir) raise instead of
+    # auto-materializing. Live-shakeout finding #4: the original bare mock
+    # set fake_cat._dir = tmp_path, masking that gc's EventLog(cat._dir)
+    # crashed with AttributeError on every real service-mode --no-dry-run.
+    from nexus.catalog.http_catalog_client import HttpCatalogClient
+    fake_cat = MagicMock(spec=HttpCatalogClient)
     fake_cat.chashes_for_collection.return_value = set()
-    fake_cat._dir = tmp_path  # EventLog(cat._dir) needs a real directory
 
     monkeypatch.setattr("nexus.db.http_vector_client._post", fake_post)
     with (

--- a/tests/test_service_mode_cli_real_client.py
+++ b/tests/test_service_mode_cli_real_client.py
@@ -312,3 +312,93 @@ def test_collection_reembed_dry_run_service_mode_real_client(
     assert result.exit_code == 0, result.output
     assert "dry-run" in result.output
     assert "7" in result.output
+
+
+def test_collection_reembed_cross_model_rejected_service_mode(
+    runner, real_client, monkeypatch,
+):
+    """nexus-u37lw: server-side embedding routes by the COLLECTION NAME's
+    model segment, so a cross-model --to can never take effect in service
+    mode — pre-fix it silently no-opped with the old model, stamped the new
+    model into metadata, and printed success. Must fail loud, post nothing."""
+    posted = []
+
+    def fake_post(path, body, **kw):
+        posted.append(path)
+        if path == "/v1/vectors/collections":
+            return {"collections": [{"name": _KNOWLEDGE}]}
+        raise AssertionError(f"unexpected POST {path}")
+
+    def fake_get(path, tenant="default"):
+        if path.startswith("/v1/vectors/stats"):
+            return [{"name": _KNOWLEDGE, "dim": 1024, "count": 3}]
+        if path.startswith("/v1/vectors/count"):
+            return {"count": 3}
+        raise AssertionError(f"unexpected GET {path}")
+
+    monkeypatch.setattr("nexus.db.http_vector_client._post", fake_post)
+    monkeypatch.setattr("nexus.db.http_vector_client._get", fake_get)
+
+    with patch("nexus.commands.collection._t3", return_value=real_client):
+        # _KNOWLEDGE encodes voyage-context-3; ask for voyage-code-3.
+        result = runner.invoke(
+            main, ["collection", "re-embed", _KNOWLEDGE,
+                   "--to", "voyage-code-3", "--no-dry-run", "--yes"],
+        )
+    assert result.exit_code != 0
+    assert "cannot take effect" in result.output
+    assert "rename" in result.output
+    # Nothing written: no upsert route was ever posted.
+    assert not any("upsert" in p for p in posted)
+
+
+def test_collection_reembed_same_model_uses_verbatim_passthrough(
+    runner, real_client, monkeypatch,
+):
+    """nexus-u37lw: same-model service re-embed stores the client-computed
+    vectors via the nexus-hxry2 verbatim passthrough (embeddings present in
+    the upsert body) — NOT upsert_chunks_with_embeddings, which discards
+    them and re-bills a server-side embed."""
+    coll = _CODE  # encodes voyage-code-3
+    upserts = []
+
+    def fake_post(path, body, **kw):
+        if path == "/v1/vectors/get":
+            if body.get("offset", 0) > 0:
+                return {"ids": [], "documents": [], "metadatas": []}
+            return {
+                "ids": ["c1"],
+                "documents": ["def f(): pass"],
+                "metadatas": [{"embedding_model": "voyage-code-3"}],
+            }
+        if path == "/v1/vectors/upsert-chunks":
+            upserts.append(body)
+            return {"upserted": 1}
+        raise AssertionError(f"unexpected POST {path}")
+
+    def fake_get(path, tenant="default"):
+        if path.startswith("/v1/vectors/stats"):
+            return [{"name": coll, "dim": 1024, "count": 1}]
+        if path.startswith("/v1/vectors/count"):
+            return {"count": 1}
+        raise AssertionError(f"unexpected GET {path}")
+
+    monkeypatch.setattr("nexus.db.http_vector_client._post", fake_post)
+    monkeypatch.setattr("nexus.db.http_vector_client._get", fake_get)
+
+    fake_embed_result = MagicMock()
+    fake_embed_result.embeddings = [[0.25] * 1024]
+    fake_voyage = MagicMock()
+    fake_voyage.embed.return_value = fake_embed_result
+
+    with patch("nexus.commands.collection._t3", return_value=real_client), \
+            patch("voyageai.Client", return_value=fake_voyage), \
+            patch("nexus.config.get_credential", return_value="fake-key"):
+        result = runner.invoke(
+            main, ["collection", "re-embed", coll,
+                   "--to", "voyage-code-3", "--no-dry-run", "--yes"],
+        )
+    assert result.exit_code == 0, result.output
+    assert len(upserts) == 1
+    # The verbatim passthrough: our vectors ride the wire.
+    assert upserts[0].get("embeddings") == [[0.25] * 1024]

--- a/tests/test_stage_timers.py
+++ b/tests/test_stage_timers.py
@@ -119,6 +119,7 @@ class TestAggregate:
             "chunking_s": 0.0,
             "embed_s": 0.0,
             "upload_s": 0.0,
+            "hooks_s": 0.0,
             "retry_s": 0.0,
             "total_s": 0.0,
         }

--- a/tests/test_store_cmd.py
+++ b/tests/test_store_cmd.py
@@ -8,6 +8,7 @@ import pytest
 from click.testing import CliRunner
 
 from nexus.cli import main
+from nexus.db.http_vector_client import HttpVectorClient
 
 
 @pytest.fixture
@@ -25,21 +26,26 @@ def env_creds(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture
 def mock_store(env_creds):
-    db = MagicMock()
+    # env_creds sets both CHROMA_API_KEY and VOYAGE_API_KEY, so
+    # is_local_mode()'s legacy heuristic resolves to cloud/service mode
+    # here — the real _t3() would hand back an HttpVectorClient, not a
+    # T3Database. spec= it so a method missing from HttpVectorClient
+    # (e.g. the gc/_dir class of bug) fails the mocked test too.
+    db = MagicMock(spec=HttpVectorClient)
     with patch("nexus.commands.store._t3", return_value=db):
         yield db
 
 
 @pytest.fixture
 def mock_collection(env_creds):
-    db = MagicMock()
+    db = MagicMock(spec=HttpVectorClient)
     with patch("nexus.commands.collection._t3", return_value=db):
         yield db
 
 
 @pytest.fixture
 def mock_search(env_creds):
-    db = MagicMock()
+    db = MagicMock(spec=HttpVectorClient)
     with patch("nexus.commands.search_cmd._t3", return_value=db):
         yield db
 
@@ -94,7 +100,7 @@ def test_store_put_tenant_optional(runner, monkeypatch, tmp_path):
     src = tmp_path / "f.txt"
     src.write_text("content")
     with patch("nexus.commands.store._t3") as mt3:
-        db = MagicMock()
+        db = MagicMock(spec=HttpVectorClient)
         db.__enter__ = MagicMock(return_value=db)
         db.__exit__ = MagicMock(return_value=False)
         db.put.return_value = "doc-id-1"

--- a/tests/test_t3_hnsw_ef.py
+++ b/tests/test_t3_hnsw_ef.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import chromadb
 import pytest
 
+from nexus.db.http_vector_client import HttpVectorClient
 from nexus.db.t3 import T3Database, apply_hnsw_ef
 from nexus.db.chroma_quotas import QuotaValidator
 
@@ -238,7 +239,15 @@ class TestDoctorFixFlag:
             patch("nexus.db.t3.apply_hnsw_ef", return_value=3),
             patch("nexus.db.make_t3") as MockMakeT3,
         ):
-            MockMakeT3.return_value = MagicMock()
+            # make_t3() returns the service-backed HttpVectorClient
+            # unconditionally in production since RDR-155 P4a.2 --
+            # is_local_mode=True (patched above) no longer changes the
+            # handle type. doctor.py's own --fix code (doctor.py:1522-1526)
+            # documents apply_hnsw_ef as a no-op against this handle;
+            # apply_hnsw_ef itself is patched above too, so the mock's
+            # spec only needs to satisfy "something passed to a fully
+            # mocked function," but pin the real return type anyway.
+            MockMakeT3.return_value = MagicMock(spec=HttpVectorClient)
             result = runner.invoke(doctor_cmd, ["--fix"])
 
         assert result.exit_code == 0

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from nexus.db.t2 import T2Database
+from nexus.db.t3 import T3Database
 from nexus.taxonomy import (
     assign_topic,
     get_topic_docs,
@@ -1842,7 +1843,7 @@ def test_discover_cli_invocation() -> None:
     runner = CliRunner()
     with (
         patch("nexus.commands.taxonomy_cmd.discover_for_collection", return_value=3) as mock_fn,
-        patch("nexus.db.make_t3", return_value=MagicMock()),
+        patch("nexus.db.make_t3", return_value=MagicMock(spec=T3Database)),
     ):
         result = runner.invoke(taxonomy, ["discover", "--collection", "test__coll"])
 
@@ -1864,7 +1865,7 @@ def test_rebuild_cli_is_discover_force_alias() -> None:
     runner = CliRunner()
     with (
         patch("nexus.commands.taxonomy_cmd.discover_for_collection", return_value=2) as mock_fn,
-        patch("nexus.db.make_t3", return_value=MagicMock()),
+        patch("nexus.db.make_t3", return_value=MagicMock(spec=T3Database)),
     ):
         result = runner.invoke(taxonomy, ["rebuild", "--collection", "test__coll"])
 
@@ -3229,7 +3230,7 @@ class TestSplitTopic:
         from nexus.commands.taxonomy_cmd import taxonomy as taxonomy_grp
         from nexus.db.local_ef import LocalEmbeddingFunction
         from click.testing import CliRunner
-        from unittest.mock import patch
+        from unittest.mock import MagicMock, patch
 
         routed = {"calls": 0}
 
@@ -3266,6 +3267,10 @@ class TestSplitTopic:
         with patch(
             "nexus.commands.taxonomy_cmd._default_db_path", return_value=db_path,
         ), patch("nexus.db.make_t3") as mock_t3:
+            # Raw-path exception (see test_split_cli): db.taxonomy here is
+            # real raw SQLite, so t3 must stay raw-backed or
+            # _require_supported_taxonomy_backend refuses.
+            mock_t3.return_value = MagicMock(spec=T3Database)
             mock_t3.return_value._client = chroma
             result = CliRunner().invoke(
                 taxonomy_grp,
@@ -3537,12 +3542,28 @@ class TestManualOpsCLI:
             ],
         }
 
-        mock_t3 = MagicMock()
+        # nx taxonomy split's raw path (taxonomy_cmd.py:1081-1083,
+        # `chroma_client = t3._client`) only runs when db.taxonomy has
+        # raw access (_has_raw_access) -- true here since this test uses
+        # a real T2Database/SQLite taxonomy store. spec=T3Database (not
+        # HttpVectorClient) is deliberate: is_service_backed(t3) must be
+        # False or _require_supported_taxonomy_backend raises "not
+        # supported" against the real raw-SQLite taxonomy.
+        mock_t3 = MagicMock(spec=T3Database)
         mock_coll = MagicMock()
         mock_coll.get.return_value = {
             "ids": [f"doc-{i}" for i in range(30)],
             "documents": [f"text {i}" for i in range(30)],
         }
+        # _client is an instance-only attribute of T3Database (assigned in
+        # __init__), so it is invisible to dir(T3Database) and thus to
+        # MagicMock's spec introspection. Set it explicitly (a plain
+        # attribute set, unrestricted even under spec=) before chaining
+        # into it, so the subsequent GET resolves against the mock's own
+        # __dict__ rather than the spec-restricted __getattr__. spec= the
+        # child too (chromadb.api.ClientAPI) so a method that real Chroma
+        # clients don't have can't hide behind a bare MagicMock.
+        mock_t3._client = MagicMock(spec=chromadb.api.ClientAPI)
         mock_t3._client.get_collection.return_value = mock_coll
         mock_t3._client.get_or_create_collection.return_value = MagicMock()
 
@@ -3637,12 +3658,17 @@ class TestManualOpsCLI:
                 },
             ],
         }
-        mock_t3 = MagicMock()
+        # Same raw-path rationale as test_split_cli above: this test's
+        # T2Database taxonomy store is real raw SQLite, so t3 must stay
+        # raw-backed (spec=T3Database) or _require_supported_taxonomy_backend
+        # raises against is_service_backed(t3)=True + _has_raw_access=True.
+        mock_t3 = MagicMock(spec=T3Database)
         mock_coll = MagicMock()
         mock_coll.get.return_value = {
             "ids": [f"doc-{i}" for i in range(10)],
             "documents": [f"text {i}" for i in range(10)],
         }
+        mock_t3._client = MagicMock(spec=chromadb.api.ClientAPI)
         mock_t3._client.get_collection.return_value = mock_coll
         mock_t3._client.get_or_create_collection.return_value = MagicMock()
         fake_persist = MagicMock(return_value=[201, 202, 203])
@@ -3699,12 +3725,14 @@ class TestManualOpsCLI:
             "collection_name": "test__noop",
             "child_specs": [],
         }
-        mock_t3 = MagicMock()
+        # Same raw-path rationale as test_split_cli above.
+        mock_t3 = MagicMock(spec=T3Database)
         mock_coll = MagicMock()
         mock_coll.get.return_value = {
             "ids": [f"doc-{i}" for i in range(5)],
             "documents": [f"text {i}" for i in range(5)],
         }
+        mock_t3._client = MagicMock(spec=chromadb.api.ClientAPI)
         mock_t3._client.get_collection.return_value = mock_coll
         import numpy as _np
 
@@ -4598,7 +4626,7 @@ class TestProjectCmd:
         self, db: T2Database, chroma_client: chromadb.ClientAPI, tmp_path: Path,
     ) -> None:
         """project command shows matched topics and novel chunks."""
-        from unittest.mock import patch
+        from unittest.mock import MagicMock, patch
 
         from click.testing import CliRunner
 
@@ -4632,6 +4660,10 @@ class TestProjectCmd:
             patch("nexus.commands.taxonomy_cmd._T2Database", return_value=db),
             patch("nexus.db.make_t3") as mock_t3,
         ):
+            # Raw-path exception (see test_split_cli): db.taxonomy here is
+            # real raw SQLite, so t3 must stay raw-backed or
+            # _require_supported_taxonomy_backend refuses.
+            mock_t3.return_value = MagicMock(spec=T3Database)
             mock_t3.return_value._client = chroma_client
             result = runner.invoke(taxonomy, [
                 "project", "src__coll", "--against", "tgt__coll", "--threshold", "0.5",
@@ -4644,7 +4676,7 @@ class TestProjectCmd:
         self, db: T2Database, chroma_client: chromadb.ClientAPI, tmp_path: Path,
     ) -> None:
         """--persist writes assignments with assigned_by='projection'."""
-        from unittest.mock import patch
+        from unittest.mock import MagicMock, patch
 
         from click.testing import CliRunner
 
@@ -4676,6 +4708,10 @@ class TestProjectCmd:
             patch("nexus.commands.taxonomy_cmd._T2Database", return_value=db),
             patch("nexus.db.make_t3") as mock_t3,
         ):
+            # Raw-path exception (see test_split_cli): db.taxonomy here is
+            # real raw SQLite, so t3 must stay raw-backed or
+            # _require_supported_taxonomy_backend refuses.
+            mock_t3.return_value = MagicMock(spec=T3Database)
             mock_t3.return_value._client = chroma_client
             result = runner.invoke(taxonomy, [
                 "project", "psrc__coll", "--against", "ptgt__coll",
@@ -4699,7 +4735,7 @@ class TestProjectCmd:
         collections with topics minus the source. Explicit --against
         still overrides.
         """
-        from unittest.mock import patch
+        from unittest.mock import MagicMock, patch
 
         from click.testing import CliRunner
 
@@ -4738,6 +4774,10 @@ class TestProjectCmd:
             patch("nexus.commands.taxonomy_cmd._T2Database", return_value=db),
             patch("nexus.db.make_t3") as mock_t3,
         ):
+            # Raw-path exception (see test_split_cli): db.taxonomy here is
+            # real raw SQLite, so t3 must stay raw-backed or
+            # _require_supported_taxonomy_backend refuses.
+            mock_t3.return_value = MagicMock(spec=T3Database)
             mock_t3.return_value._client = chroma_client
             result = runner.invoke(taxonomy, ["project", src, "--threshold", "0.5"])
 

--- a/tests/test_tuning_config.py
+++ b/tests/test_tuning_config.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 
 from nexus.config import TuningConfig, _tuning_from_dict, get_tuning_config, load_config
+from nexus.db.http_vector_client import HttpVectorClient
 
 _EXPECTED_DEFAULTS = {
     "vector_weight": 0.7, "frecency_weight": 0.3, "file_size_threshold": 30,
@@ -210,7 +211,12 @@ def test_search_cmd_passes_ripgrep_timeout(tmp_path, monkeypatch) -> None:
         captured.append(timeout)
         return []
 
-    mock_t3 = MagicMock()
+    # cloud-shaped creds are set above -> the real _t3() would hand back
+    # an HttpVectorClient (make_t3() is unconditional post-RDR-155
+    # P4a.2 regardless, but this test also matches is_local_mode()'s
+    # legacy heuristic). Mirrors the sibling test_search_cmd.py::_mock_t3
+    # helper's spec= fix.
+    mock_t3 = MagicMock(spec=HttpVectorClient)
     mock_t3.list_collections.return_value = [{"name": "code__repo-abcd1234"}]
     with (
         patch("nexus.commands.search_cmd._t3", return_value=mock_t3),

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "6.2.0"
+version = "6.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## conexus 6.3.1

The shakeout-follow-ups release (epic nexus-c0twp, 12/12). Pins engine-service-v0.1.22 (cloud-deployed + STEP-6 green 2026-07-04: parity p50 Jaccard 1.0, recall@20 13/13 exact, hybrid p95 1771ms).

### Fixed
- `nx t3 gc` service-mode crash (live-shakeout finding #4)
- `nx store put` aspect-enqueue 409 — document hook chain carries the catalog doc_id (nexus-w8lg1)
- `nx collection re-embed`/backfill `db._client` crash; service-mode re-embed is same-model via verbatim passthrough, cross-model fails loud with honest guidance (nexus-c9xr2, u37lw, tcvpn)
- `nx collection rename` model-segment guard (nexus-tcvpn)
- 9 HttpCatalogClient shape drifts incl. typed graph()/graph_many() — the service-mode links CLI was silently broken (nexus-u26b4, gc2ze)

### Added
- Bounded per-file index concurrency + `NX_INDEX_CONCURRENCY` + `hooks_s` timing bucket (nexus-cfc72)
- Runtime shape-parity tripwire, 72 methods + completeness gate (nexus-8y1tm, oq0tk)

### Changed
- Warm `nx index repo`: one owner-scoped catalog fetch replaces ~1,400-2,800 serial round-trips; unchanged files skip per-file updates (nexus-dst5h)
- Engine pin -> v0.1.22 (aspect-linkage COALESCE, /resolve_chunk, metadata MERGE, raw-SQL elimination)

Gates: unit 12108/0; integration 441/442 (1 Voyage-API nondeterminism flake, passed 2x rerun, nexus-83d6s); smoke [done]; upgrade-shakeout 12/12; both rehearsal legs + shakeout + cold green on the pinned engine.