### PR TITLE
chore(ci): eliminate duplicate runs and gate expensive jobs by event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    # develop ONLY (2026-07-06 CI-cost pass): a push to main is always a
+    # release-PR merge whose identical tree just passed this workflow as the
+    # PR's required checks minutes earlier — the post-merge run was pure
+    # duplication (including a live CA-3 hit, since release commits always
+    # touch pyproject/uv.lock). main stays protected by its PR-required
+    # checks; nothing lands on main outside a PR.
+    branches: [develop]
     # Skip the full matrix for changes that cannot affect test outcomes
     # (docs + changelogs). Conservative on purpose: NOT a blanket **/*.md —
     # plugin-structure tests validate skill/agent markdown frontmatter, so
@@ -23,9 +29,13 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  # Only cancel in-progress runs on PRs (stale pushes). Never cancel main —
-  # tag pushes were cancelling version-bump CI, leaving the badge red.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Cancel superseded runs on PRs AND develop pushes (2026-07-06 CI-cost
+  # pass): back-to-back develop pushes were stacking full ~20-min runs for
+  # commits already made stale by the next push. The old "never cancel
+  # main" concern (tag pushes cancelling version-bump CI) is moot now that
+  # main is not a push trigger at all and tags run a different workflow
+  # with its own concurrency group.
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -65,7 +75,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        # 2026-07-06 CI-cost pass: develop pushes run 3.12 only (~20 min of
+        # ubuntu saved per push — the single largest routine CI cost); PRs
+        # run the full matrix, so the 3.13 required checks on main/develop
+        # still gate every merge. 3.13-only regressions surface at the PR
+        # boundary instead of per push — accepted: 3.13 breakage has
+        # historically been GHA-flake (nexus-9eaz family), not real drift.
+        python-version: ${{ github.event_name == 'push' && fromJSON('["3.12"]') || fromJSON('["3.12", "3.13"]') }}
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
@@ -226,7 +242,7 @@ jobs:
         id: changes
         with:
           filters: |
-            ca3:
+            ca3_core:
               - 'src/nexus/db/pg_provision.py'
               - 'tests/db/test_pg_provision_ca3_bundle.py'
               - 'tests/db/test_pg_bundle_relocation.py'
@@ -235,23 +251,38 @@ jobs:
               - 'scripts/liquibase_bundle_smoke.sh'
               - '.github/workflows/ci.yml'
               - 'service/src/main/resources/db/changelog/**'
-              # A dep bump can change test collection / the Python env the CA-3
-              # tests depend on without touching any path above; gate on the
-              # lockfile + manifest so such a change re-runs the gate instead of
-              # passing vacuously green (substantive-critic S1). Deliberate cost:
-              # every dep-bump PR now pays the ~10min PG-from-source build x3 arches
-              # — accepted as the price of a non-vacuous gate (substantive-critic O-A).
+            # A dep bump can change test collection / the Python env the CA-3
+            # tests depend on without touching any path above; gate on the
+            # lockfile + manifest so such a change re-runs the gate instead of
+            # passing vacuously green (substantive-critic S1). 2026-07-06
+            # CI-cost pass: the dep trigger now fires on PULL REQUESTS ONLY
+            # (see the gate step below) — the non-vacuous-gate intent is about
+            # what MERGES, and every merge crosses a PR whose required checks
+            # include CA-3. Direct develop pushes that only bump deps no
+            # longer pay the ~10min PG-from-source build x3 arches per push;
+            # the release/dep PR still pays it exactly once.
+            ca3_deps:
               - 'uv.lock'
               - 'pyproject.toml'
 
+      - name: Decide whether the CA-3 build runs
+        id: gate
+        run: |
+          if [ "${{ steps.changes.outputs.ca3_core }}" = "true" ] || \
+             { [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ steps.changes.outputs.ca3_deps }}" = "true" ]; }; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         with:
           python-version: "3.12"
           enable-cache: false
 
       - name: Cache uv wheel cache
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ${{ runner.temp }}/setup-uv-cache
@@ -260,11 +291,11 @@ jobs:
             uv-${{ runner.os }}-${{ matrix.target.arch }}-3.12-
 
       - name: Install project + dev deps
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         run: uv sync --group dev
 
       - name: Build complete PG + pgvector from source (Strategy B, glibc 2.28)
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         run: |
           set -euo pipefail
           # Single source of truth for the build is scripts/build_pg_bundle.sh
@@ -287,7 +318,7 @@ jobs:
           echo "NEXUS_CA3_BUNDLE=$bundle" >> "$GITHUB_ENV"
 
       - name: Run CA-3 live test (asserts it actually ran, not skipped)
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         run: |
           set -euo pipefail
           # -o addopts="" clears the repo default `-m 'not integration'` so the
@@ -305,7 +336,7 @@ jobs:
         # glibc-2.28-built binaries run on the ubuntu-latest host (glibc ~2.39,
         # forward-compatible) — that the relocated tree runs OUTSIDE its build
         # container is itself part of the portability proof.
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         run: |
           set -euo pipefail
           bundle="$GITHUB_WORKSPACE/bundle"
@@ -334,7 +365,7 @@ jobs:
           uv run python scripts/assert_ca3_ran.py reloc.xml
 
       - name: Upload bundle artifact (P3.1, consumed by P3.2/P3.4)
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: nexus-pg-${{ matrix.target.arch }}
@@ -348,7 +379,7 @@ jobs:
         # uses `docker --network host` to reach the provisioned PG. One arch is
         # enough — the schema is arch-independent; this validates the lean
         # configure flags, not the platform.
-        if: matrix.target.arch == 'linux-amd64' && steps.changes.outputs.ca3 == 'true'
+        if: matrix.target.arch == 'linux-amd64' && steps.gate.outputs.run == 'true'
         run: bash scripts/liquibase_bundle_smoke.sh
 
   ca3-pgvector-bundle-macos:
@@ -384,7 +415,7 @@ jobs:
         id: changes
         with:
           filters: |
-            ca3:
+            ca3_core:
               - 'src/nexus/db/pg_provision.py'
               - 'tests/db/test_pg_provision_ca3_bundle.py'
               - 'tests/db/test_pg_bundle_relocation.py'
@@ -393,17 +424,32 @@ jobs:
               - 'scripts/liquibase_bundle_smoke.sh'
               - '.github/workflows/ci.yml'
               - 'service/src/main/resources/db/changelog/**'
-              # A dep bump can change test collection / the Python env the CA-3
-              # tests depend on without touching any path above; gate on the
-              # lockfile + manifest so such a change re-runs the gate instead of
-              # passing vacuously green (substantive-critic S1). Deliberate cost:
-              # every dep-bump PR now pays the ~10min PG-from-source build x3 arches
-              # — accepted as the price of a non-vacuous gate (substantive-critic O-A).
+            # A dep bump can change test collection / the Python env the CA-3
+            # tests depend on without touching any path above; gate on the
+            # lockfile + manifest so such a change re-runs the gate instead of
+            # passing vacuously green (substantive-critic S1). 2026-07-06
+            # CI-cost pass: the dep trigger now fires on PULL REQUESTS ONLY
+            # (see the gate step below) — the non-vacuous-gate intent is about
+            # what MERGES, and every merge crosses a PR whose required checks
+            # include CA-3. Direct develop pushes that only bump deps no
+            # longer pay the ~10min PG-from-source build x3 arches per push;
+            # the release/dep PR still pays it exactly once.
+            ca3_deps:
               - 'uv.lock'
               - 'pyproject.toml'
 
+      - name: Decide whether the CA-3 build runs
+        id: gate
+        run: |
+          if [ "${{ steps.changes.outputs.ca3_core }}" = "true" ] || \
+             { [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ steps.changes.outputs.ca3_deps }}" = "true" ]; }; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         with:
           python-version: "3.12"
           enable-cache: false
@@ -411,7 +457,7 @@ jobs:
       - name: Cache uv wheel cache
         # Mirror the linux CA-3 jobs so a gated mac run reuses wheels instead of
         # re-downloading from scratch (code-review L1).
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ${{ runner.temp }}/setup-uv-cache
@@ -420,11 +466,11 @@ jobs:
             uv-${{ runner.os }}-mac-arm64-3.12-
 
       - name: Install project + dev deps
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         run: uv sync --group dev
 
       - name: Build complete PG + pgvector from source (native, deployment-target 13.0)
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         env:
           BUNDLE_PREFIX: ${{ github.workspace }}/bundle
         run: |
@@ -437,7 +483,7 @@ jobs:
           echo "NEXUS_CA3_BUNDLE=$BUNDLE_PREFIX" >> "$GITHUB_ENV"
 
       - name: Run CA-3 live test (asserts it actually ran, not skipped)
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         run: |
           set -euo pipefail
           uv run pytest tests/db/test_pg_provision_ca3_bundle.py \
@@ -448,7 +494,7 @@ jobs:
         # Same relocation proof as the linux job: tar the tree, extract to a dir
         # other than the build prefix, prove the relocated tree provisions +
         # loads pgvector (vector.dylib via dyld) from the new location.
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         run: |
           set -euo pipefail
           bundle="$GITHUB_WORKSPACE/bundle"
@@ -472,7 +518,7 @@ jobs:
           uv run python scripts/assert_ca3_ran.py reloc.xml
 
       - name: Upload bundle artifact (P3.1, consumed by P3.2/P3.4)
-        if: steps.changes.outputs.ca3 == 'true'
+        if: steps.gate.outputs.run == 'true'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: nexus-pg-mac-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,89 +6,16 @@ on:
       - "v*"
 
 jobs:
-  test:
-    name: pytest (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
-    # Hanging-test ceiling. Without this, an unreaped multiprocessing
-    # subprocess (fork-with-threads deadlock) would stall the release
-    # job indefinitely, blocking PyPI publish until manually cancelled.
-    # v4.18.0 tag-push hit it: pytest 3.13 ran 36+ min before manual
-    # cancel. 4.32.1 hit a different boundary — Python 3.12 ran 15m22s
-    # while 3.13 ran 11m33s. The suite grew under RDR-109 (cross-
-    # encoder substrate; lazy ONNX-runtime imports). 20m was then too
-    # tight: the v5.4.2 tag-push run passed both pytest matrices (~16m)
-    # but timed out DURING the post-job cache-save upload, which counts
-    # toward this budget. Bumped to 25m, then 30m (nexus-cxsbs) to absorb
-    # the HF/docling model cache save + a cold-cache fetch on the first run
-    # after a uv.lock bump — still under the 36m genuine-hang signature.
-    timeout-minutes: 30
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ["3.12", "3.13"]
-
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
-        with:
-          python-version: ${{ matrix.python-version }}
-          # nexus-2ivn: see ci.yml. Bundled enable-cache caches metadata
-          # only; the wheel cache lives at ${{ runner.temp }}/setup-uv-
-          # cache and needs an explicit actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5 step.
-          enable-cache: false
-
-      - name: Cache uv wheel cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
-        with:
-          path: ${{ runner.temp }}/setup-uv-cache
-          key: uv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ matrix.python-version }}-
-
-      - name: Cache ChromaDB ONNX model
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
-        with:
-          path: ~/.cache/chroma
-          # nexus-8g79.33: same lockfile-bound key as ci.yml.
-          key: chromadb-onnx-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-
-      - name: Cache HuggingFace models (docling, cross-encoder, MinerU)
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
-        with:
-          # nexus-cxsbs: see ci.yml. Cache the whole HF hub dir so docling's
-          # layout + TableFormer models persist across runs instead of being
-          # re-fetched at test time (the LocalEntryNotFoundError "docling
-          # flake"). One cache covers docling, the cross-encoder reranker, and
-          # MinerU's weights (the latter only under -m slow).
-          path: ~/.cache/huggingface
-          key: huggingface-models-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            huggingface-models-${{ runner.os }}-
-
-      - name: Install ripgrep
-        run: sudo apt-get install -y ripgrep
-
-      - name: Install project + dev deps
-        run: uv sync --group dev
-
-      - name: Pre-fetch docling models (deterministic, retryable)
-        # nexus-cxsbs: see ci.yml. Warm the docling models before pytest so the
-        # flaky mid-test HF download becomes a deterministic, retryable
-        # up-front fetch. No-op on a cache hit.
-        run: |
-          for i in 1 2 3; do
-            uv run python -c "from nexus.pdf_extractor import PDFExtractor; e=PDFExtractor(); e._get_converter(enriched=False); e._get_converter(enriched=True); print('docling models warm')" && break
-            echo "docling pre-fetch attempt $i failed; retrying in 10s"; sleep 10
-          done
-
-      - name: Run tests
-        run: uv run pytest tests/ -q --durations=25
-
+  # 2026-07-06 CI-cost pass: the pytest matrix that used to run here was
+  # removed. A v* tag always points at a main merge commit whose identical
+  # tree passed the release PR's required checks (pytest 3.12 + 3.13)
+  # minutes before the tag was pushed — re-running ~40 min of ubuntu per
+  # tag re-tested the same tree a fourth time and made publish hostage to
+  # the nexus-9eaz GHA-flake family. The publish job below still verifies
+  # tag == pyproject version before building.
   publish:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
-    needs: test
     environment: pypi-release
     permissions:
       id-token: write   # required for OIDC trusted publisher

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -90,50 +90,11 @@ jobs:
         working-directory: service
         run: ./mvnw -q test
 
-  native-image-build-and-smoke:
-    name: Native image build + smoke (nexus-lp2qo)
-    runs-on: ubuntu-latest
-    # Native-image build (~2-3m analysis + image) + jOOQ codegen testcontainer
-    # + pgvector pull + native smoke. 40m covers a cold runner.
-    timeout-minutes: 40
-
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-
-      - name: Set up GraalVM 25.0.3
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f  # v1
-        with:
-          # >= 25.0.2 REQUIRED: the bundled jOOQ 3.20.0 / liquibase reachability
-          # metadata use GraalVM's unified reachability-metadata SCHEMA, which
-          # 25.0.1 rejects ("installation does not provide reachability-metadata
-          # schema"). Pinned for native-build determinism (nexus-lp2qo).
-          java-version: '25.0.3'
-          distribution: 'graalvm'
-          cache: 'maven'
-
-      - name: Prime bge-768 ONNX (cache or self-hosted asset)
-        # RDR-160: in local mode the native binary constructs Bge768Embedder,
-        # which loads the STANDARD fp32 bge-base-en-v1.5 ONNX from
-        # ~/.cache/nexus. Centralised in .github/actions/prime-bge-onnx
-        # (self-hosted release asset, no HuggingFace 429 dependency).
-        uses: ./.github/actions/prime-bge-onnx
-
-      - name: Build native image
-        working-directory: service
-        # -Pnative runs jOOQ codegen (testcontainers pgvector) then native-image.
-        # The committed traced reachability-metadata.json + community metadata repo
-        # supply the reflection/resource set. This is the authoritative LINUX gate
-        # for the native path (the spike verified macOS/arm64; this proves amd64).
-        #
-        # nexus-9yrus: -Dnative.image.opt=-Ob (quick-build) — this is a per-PR
-        # correctness gate (build reachability + the smoke below: migration + jOOQ
-        # CRUD return 200), not a release artifact. Quick-build keeps full reachability
-        # analysis and a functional binary (slower runtime, irrelevant to the smoke)
-        # while ~halving the build and cutting peak memory. Release stays -O2.
-        run: ./mvnw -q -Pnative -DskipTests -Dnative.image.opt=-Ob package
-
-      - name: Native smoke test
-        working-directory: service
-        # Boots the native binary against a throwaway pgvector and asserts
-        # liquibase migration + jOOQ INSERT/SELECT/FTS all return 200.
-        run: ./native-smoke.sh
+  # 2026-07-06 CI-cost pass: the native-image-build-and-smoke job that lived
+  # here was removed — every service/** push was building the native image
+  # TWICE (this job's full -O2 build + pgvector smoke, PLUS ci.yml's
+  # engine-service-build -Ob reachability trip-wire on the same events). The
+  # reachability-regression class is covered by ci.yml's trip-wire on every
+  # push/PR; the full-optimization build + boot smoke still runs where the
+  # artifact is actually produced (engine-service-release.yml, on every
+  # engine-service-v* tag, before anything is published or deployed).


### PR DESCRIPTION
Cost pass after the 2026-07-06 billing review (24 CI runs, 3 engine releases, 2 PyPI releases in one day). The same tree was tested up to four times between develop and PyPI, and several expensive jobs ran on events where they could catch nothing new.

## Cuts
- **No push-CI on main** — main is PR-gated; the post-merge run duplicated the release PR (including a live 3-arch CA-3 build, macOS included, since release commits always touch pyproject/uv.lock).
- **release.yml drops its pytest matrix** (~40 ubuntu-min/tag; the tag's tree passed the same checks on the PR minutes earlier). Also removes the known Py3.13-flake-blocks-publish mode.
- **CA-3 dep-bump trigger is PR-only** — preserves the documented non-vacuous-gate intent (what merges is what matters; every merge crosses a PR that pays the gate once) while develop dep-bump pushes stop paying 3x PG-from-source builds.
- **develop pushes run pytest 3.12 only** — PRs keep the full matrix; both versions stay required checks.
- **service-ci's duplicate native build removed** — ci.yml's -Ob reachability trip-wire covers pushes/PRs; the full -O2 build + smoke still gates every engine-service tag.
- **cancel-in-progress for pushes** — superseded develop runs die instead of stacking.

## Validation
All three workflows parse. This PR itself exercises the new CA-3 gate logic live (the workflow edit is in ca3_core, so the 3-arch build must run here and report green).

Estimated steady-state effect: a typical develop push goes from ~7 jobs (2 pytest + 3 CA-3 spins + native trip-wire + write-seam) to 3 live jobs (1 pytest, write-seam, lint) + cheap skips; releases stop paying the post-merge and tag-time duplicate runs entirely.