### PR TITLE
ci(gate): register the weekly guided-upgrade MVV workflow (nexus-myk4e)

### DIFF
--- a/.github/workflows/guided-upgrade-mvv.yml
+++ b/.github/workflows/guided-upgrade-mvv.yml
@@ -1,0 +1,103 @@
+name: Guided-upgrade MVV (weekly + on migration-path changes)
+
+# nexus-myk4e (RDR-002 ez5.14/15 deferral; escalated as the release-N+1 hard
+# gate): the one-command `nx guided-upgrade` MVV
+# (tests/e2e/migration-rehearsal/run.sh --guided) is the ONLY layer that
+# exercises the composed provision-sequence / credential-load / migration
+# journey — the unit suite mocks the composed steps (the
+# mock-collaborator-blindness class that hid the bge-ONNX-fetch and
+# cred-self-load bugs, and on 2026-07-07 the GH #1381 default-path no-op +
+# Path(None) provision-then-crash, both caught by this harness's bare
+# invocation the day it gained one). The migration tool ships in release N
+# and is DELETED in release N+1 (RDR-155 P4b) — this gate is what protects
+# the deprecation window users cross.
+#
+# CI-cost discipline: the guided leg builds the candidate native binary
+# (GraalVM -Ob in Docker, the expensive part), so it runs ONLY when its
+# inputs change (path-gated push), on a WEEKLY heartbeat (the migration
+# path's change velocity is low — a nightly would re-test the same tree
+# most days), and on manual dispatch. ubuntu-only. No cloud secrets: the
+# guided journey is local bge-768 mode end-to-end.
+#
+# The container image's bge model fetch uses the SELF-HOSTED release asset
+# (ci-assets-bge-768-v1) instead of anonymous HuggingFace — runners have no
+# persistent docker layer cache, so the 416MB fetch runs every build and
+# anonymous HF 429s chronically (same flake prime-bge-onnx retired for
+# host-side jobs).
+
+on:
+  schedule:
+    - cron: "41 10 * * 1"   # Mondays 10:41 UTC — off the nightly-gate + release-hour paths
+  workflow_dispatch:
+  push:
+    branches: [develop]
+    paths:
+      - "src/nexus/migration/**"
+      - "src/nexus/commands/guided_upgrade_cmd.py"
+      - "src/nexus/commands/migrate_cmd.py"
+      - "src/nexus/commands/storage_cmd.py"
+      - "src/nexus/db/pg_provision.py"
+      - "src/nexus/db/pg_bundle.py"
+      - "src/nexus/daemon/binary_install.py"
+      - "src/nexus/daemon/storage_service_daemon.py"
+      - "tests/e2e/migration-rehearsal/**"
+      - ".github/workflows/guided-upgrade-mvv.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: guided-upgrade-mvv
+  cancel-in-progress: true
+
+jobs:
+  guided-mvv:
+    name: nx guided-upgrade MVV (bare default-path journey, container-isolated)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # Scheduled workflows execute from the DEFAULT branch (main); the
+          # tree worth gating is develop, where migration-path changes land.
+          # Push-triggered runs fire on develop directly; dispatch defaults
+          # here too.
+          ref: develop
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+        with:
+          python-version: "3.12"
+          enable-cache: false
+
+      - name: Cache uv wheel cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        with:
+          path: ${{ runner.temp }}/setup-uv-cache
+          key: uv-${{ runner.os }}-3.12-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-3.12-
+
+      - name: Install project (wheel build needs the project deps)
+        run: uv sync --group dev
+
+      - name: Run the guided-upgrade MVV
+        env:
+          # Point the rehearsal image's bge fetch at the self-hosted release
+          # asset (same tag prime-bge-onnx uses) — no HuggingFace dependency.
+          NEXUS_BGE_MODEL_URL: https://github.com/${{ github.repository }}/releases/download/ci-assets-bge-768-v1/model.onnx
+          NEXUS_BGE_TOKENIZER_URL: https://github.com/${{ github.repository }}/releases/download/ci-assets-bge-768-v1/tokenizer.json
+        run: |
+          set -euo pipefail
+          tests/e2e/migration-rehearsal/run.sh --guided 2>&1 | tee guided-mvv.log
+          # Belt on the harness's own exit code: the success marker must be
+          # present (a truncated/killed run must not read as green).
+          grep -q "GUIDED-UPGRADE MVV PASSED" guided-mvv.log
+
+      - name: Upload run log
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        with:
+          name: guided-mvv-log
+          path: guided-mvv.log
+          retention-days: 14


### PR DESCRIPTION
Registers .github/workflows/guided-upgrade-mvv.yml on main (scheduled runs execute the default-branch copy; the job checks out develop). Weekly Mon 10:41 UTC + workflow_dispatch + develop-push path-gated on migration inputs. No secrets required (local bge-768 journey); the rehearsal image's model fetch uses the self-hosted ci-assets-bge-768-v1 release assets via build ARGs (develop 1decccd3).

Validated locally end to end with the CI asset URLs: GUIDED-UPGRADE MVV PASSED. This is the release-N+1 hard gate protecting the RDR-155 deprecation window — its bare invocation caught both GH #1381 criticals on its maiden run (2026-07-07).

Refs nexus-myk4e.