### PR TITLE
release: conexus 6.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v6.5.0"
+        "ref": "v6.5.1"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "6.5.0"
+      "version": "6.5.1"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v6.5.0"
+        "ref": "v6.5.1"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "6.5.0"
+      "version": "6.5.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.5.1] - 2026-07-08
+
 ### Fixed
 
 - **Engine pin advanced to engine-service-v0.1.35** (nexus-x6kdz). v0.1.34's manifest writers never stamped `catalog_document_chunks.collection` — the combined-query join key — so a fresh install indexing new documents reproduced the silently-empty combined-query state locally. v0.1.35 stamps at every write seam and its catalog-014 boot changeset repairs existing rows (delegating to `nexus.manifest_backfill()`). `REQUIRED_RELEASE_VERSION` stays (0,1,34): the client does not require the new engine, it distributes it. Existing local installs can pull the fixed engine directly: `nx daemon service install-binary engine-service-v0.1.35`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Engine pin advanced to engine-service-v0.1.35** (nexus-x6kdz). v0.1.34's manifest writers never stamped `catalog_document_chunks.collection` — the combined-query join key — so a fresh install indexing new documents reproduced the silently-empty combined-query state locally. v0.1.35 stamps at every write seam and its catalog-014 boot changeset repairs existing rows (delegating to `nexus.manifest_backfill()`). `REQUIRED_RELEASE_VERSION` stays (0,1,34): the client does not require the new engine, it distributes it. Existing local installs can pull the fixed engine directly: `nx daemon service install-binary engine-service-v0.1.35`.
+
 ## [6.5.0] - 2026-07-08
 
 ### Added

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the conexus plugin are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.1] - 2026-07-08
+
+- Plugin version aligned with conexus 6.5.1 (engine pin advanced to v0.1.35 — the combined-query manifest-stamp fix). No plugin-side changes.
+
 ## [6.5.0] - 2026-07-08
 
 - Plugin version aligned with conexus 6.5.0. Plugin-side: the SessionStart hook now surfaces a pending Chroma→PostgreSQL substrate migration into the session context (nexus-0rwwv), so the agent points users at `nx guided-upgrade`.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conexus-mcpb"
-version = "6.5.0"
+version = "6.5.1"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
@@ -10,7 +10,7 @@ dependencies = [
     # while collections are indexed at 768/1024-dim, so every T3 search hits a
     # dimension mismatch and returns zero results. The .mcpb cannot run the
     # interactive `nx init` embedder choice, so it must pin [local] explicitly.
-    "conexus[local]>=6.5.0",
+    "conexus[local]>=6.5.1",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "6.5.0"
+version = "6.5.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
+++ b/service/src/main/java/dev/nexus/service/db/CatalogRepository.java
@@ -174,6 +174,7 @@ public final class CatalogRepository {
 
     private static final Field<String>  EX_META_VAL   = DSL.field("EXCLUDED.value",       String.class);
     private static final Field<String>  EX_CHK_CHASH  = DSL.field("EXCLUDED.chash",       String.class);
+    private static final Field<String>  EX_CHK_COLL   = DSL.field("EXCLUDED.collection",  String.class);
     private static final Field<Integer> EX_CHK_IDX   = DSL.field("EXCLUDED.chunk_index",  Integer.class);
     private static final Field<Integer> EX_CHK_LST   = DSL.field("EXCLUDED.line_start",   Integer.class);
     private static final Field<Integer> EX_CHK_LEN   = DSL.field("EXCLUDED.line_end",     Integer.class);
@@ -1389,15 +1390,38 @@ public final class CatalogRepository {
      * documents.chunk_count — {@code writeManifest}'s public behavior is unchanged;
      * the chunk_count fold-in is {@code writeManifestMany}'s addition.
      */
+    /**
+     * nexus-x6kdz: the doc's physical_collection, stamped onto every manifest
+     * row AT WRITE TIME. The combined-query functions (catalog-006/-008/-012)
+     * join {@code m.collection = c.collection}; before this stamp NO writer
+     * populated the column — only the migration-leg {@code manifest_backfill()}
+     * ever did, and the REPLACE writers wiped it again on re-index, leaving
+     * every post-migration manifest row invisible to the combined queries
+     * (silent-empty, found by the 6.5.0 live shakeout). Returns null when the
+     * doc has no physical_collection (ghost/sourceless docs) — those rows stay
+     * NULL, same as the backfill's own skip semantics.
+     */
+    private static String physicalCollectionOf(DSLContext ctx, String tenant, String docId) {
+        String pc = ctx.select(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION)
+                       .from(CATALOG_DOCUMENTS)
+                       .where(CATALOG_DOCUMENTS.TENANT_ID.eq(tenant))
+                       .and(CATALOG_DOCUMENTS.TUMBLER.eq(docId))
+                       .fetchOne(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION);
+        return (pc == null || pc.isEmpty()) ? null : pc;
+    }
+
     private static void writeManifestRows(DSLContext ctx, String tenant, String docId,
                                           List<Map<String, Object>> rows) {
         ctx.deleteFrom(CATALOG_DOCUMENT_CHUNKS).where(CATALOG_DOCUMENT_CHUNKS.DOC_ID.eq(docId)).execute();
+        String coll = physicalCollectionOf(ctx, tenant, docId);
         for (var row : rows) {
             ctx.insertInto(CATALOG_DOCUMENT_CHUNKS,
                     CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION, CATALOG_DOCUMENT_CHUNKS.CHASH, CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,
-                    CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END)
+                    CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END,
+                    CATALOG_DOCUMENT_CHUNKS.COLLECTION)
                .values(tenant, docId, i(row,"position"), s(row,"chash"), i(row,"chunk_index"),
-                       i(row,"line_start"), i(row,"line_end"), i(row,"char_start"), i(row,"char_end"))
+                       i(row,"line_start"), i(row,"line_end"), i(row,"char_start"), i(row,"char_end"),
+                       coll)
                .execute();
         }
     }
@@ -1519,15 +1543,19 @@ public final class CatalogRepository {
     /** Append manifest rows (upsert by position). */
     public void appendManifestChunks(String tenant, String docId, List<Map<String, Object>> rows) {
         tenantScope.withTenant(tenant, ctx -> {
+            String coll = physicalCollectionOf(ctx, tenant, docId);
             for (var row : rows) {
                 ctx.insertInto(CATALOG_DOCUMENT_CHUNKS,
                         CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION, CATALOG_DOCUMENT_CHUNKS.CHASH, CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,
-                        CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END)
+                        CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END,
+                        CATALOG_DOCUMENT_CHUNKS.COLLECTION)
                    .values(tenant, docId, i(row,"position"), s(row,"chash"), i(row,"chunk_index"),
-                           i(row,"line_start"), i(row,"line_end"), i(row,"char_start"), i(row,"char_end"))
+                           i(row,"line_start"), i(row,"line_end"), i(row,"char_start"), i(row,"char_end"),
+                           coll)
                    .onConflict(CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION)
                    .doUpdate()
                    .set(CATALOG_DOCUMENT_CHUNKS.CHASH, EX_CHK_CHASH)
+                   .set(CATALOG_DOCUMENT_CHUNKS.COLLECTION, EX_CHK_COLL)
                    .execute();
             }
             return null;
@@ -2018,11 +2046,21 @@ public final class CatalogRepository {
                 ctx.selectOne().from(CATALOG_COLLECTIONS).where(CATALOG_COLLECTIONS.NAME.eq(newName)));
 
             if (targetExists) {
-                // RDR-162 cross-model COPY branch: repoint catalog_documents only; leave
+                // RDR-162 cross-model COPY branch: repoint catalog_documents; leave
                 // both registry rows (renaming the source would collide on the name PK).
                 counts.put("catalog_documents",
                     ctx.update(CATALOG_DOCUMENTS).set(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION, newName)
                        .where(CATALOG_DOCUMENTS.PHYSICAL_COLLECTION.eq(oldName)).execute());
+                // nexus-x6kdz (critique HIGH): the manifest's denormalized
+                // collection must re-home HERE TOO — cross-model re-embeds
+                // preserve chunk text, hence chashes, so the target
+                // collection's chunk rows carry the same chashes and the
+                // combined-query join stays live under the new name. Leaving
+                // this out was the THIRD door back into the silent-empty
+                // state (docs pointed at the target, manifests at the source).
+                counts.put("catalog_document_chunks",
+                    ctx.update(CATALOG_DOCUMENT_CHUNKS).set(CATALOG_DOCUMENT_CHUNKS.COLLECTION, newName)
+                       .where(CATALOG_DOCUMENT_CHUNKS.COLLECTION.eq(oldName)).execute());
                 return counts;
             }
 
@@ -2052,6 +2090,12 @@ public final class CatalogRepository {
             counts.put("chunks_1024", ctx.update(CHUNKS_1024).set(CHUNKS_1024.COLLECTION, newName).where(CHUNKS_1024.COLLECTION.eq(oldName)).execute());
             //    chash index (physical_collection; fk-002-4 RESTRICT).
             counts.put("chash_index", ctx.update(CHASH_INDEX).set(CHASH_INDEX.PHYSICAL_COLLECTION, newName).where(CHASH_INDEX.PHYSICAL_COLLECTION.eq(oldName)).execute());
+            // nexus-x6kdz: the manifest's denormalized collection (the
+            // combined-query join key) must re-home too — rename was the
+            // second door back into the silently-empty-join state.
+            counts.put("catalog_document_chunks",
+                ctx.update(CATALOG_DOCUMENT_CHUNKS).set(CATALOG_DOCUMENT_CHUNKS.COLLECTION, newName)
+                   .where(CATALOG_DOCUMENT_CHUNKS.COLLECTION.eq(oldName)).execute());
             //    taxonomy: assignments (source_collection, fk-002-5 RESTRICT), topics (fk-003 RESTRICT), meta (fk-003-4 RESTRICT).
             counts.put("topic_assignments", ctx.update(TOPIC_ASSIGNMENTS).set(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION, newName).where(TOPIC_ASSIGNMENTS.SOURCE_COLLECTION.eq(oldName)).execute());
             counts.put("topics", ctx.update(TOPICS).set(TOPICS.COLLECTION, newName).where(TOPICS.COLLECTION.eq(oldName)).execute());
@@ -2778,15 +2822,21 @@ public final class CatalogRepository {
             for (var row : rows) unique.put(i(row, "position"), row);
             List<Map<String, Object>> deduped = List.copyOf(unique.values());
 
-            final int chunkSize = Math.max(1, MAX_BATCH_PARAMS / 9);
+            // nexus-x6kdz: stamp the doc's physical_collection on every row —
+            // the combined-query join key no writer previously populated.
+            String coll = physicalCollectionOf(ctx, tenant, docId);
+
+            final int chunkSize = Math.max(1, MAX_BATCH_PARAMS / 10);
             for (int start = 0; start < deduped.size(); start += chunkSize) {
                 var batch = deduped.subList(start, Math.min(start + chunkSize, deduped.size()));
                 var insert = ctx.insertInto(CATALOG_DOCUMENT_CHUNKS,
                         CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION, CATALOG_DOCUMENT_CHUNKS.CHASH, CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,
-                        CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END);
+                        CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END,
+                        CATALOG_DOCUMENT_CHUNKS.COLLECTION);
                 for (var row : batch) {
                     insert = insert.values(tenant, docId, i(row,"position"), s(row,"chash"), i(row,"chunk_index"),
-                            i(row,"line_start"), i(row,"line_end"), i(row,"char_start"), i(row,"char_end"));
+                            i(row,"line_start"), i(row,"line_end"), i(row,"char_start"), i(row,"char_end"),
+                            coll);
                 }
                 insert.onConflict(CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION)
                       .doUpdate()
@@ -2796,6 +2846,7 @@ public final class CatalogRepository {
                       .set(CATALOG_DOCUMENT_CHUNKS.LINE_END,   EX_CHK_LEN)
                       .set(CATALOG_DOCUMENT_CHUNKS.CHAR_START,   EX_CHK_CST)
                       .set(CATALOG_DOCUMENT_CHUNKS.CHAR_END,   EX_CHK_CEN)
+                      .set(CATALOG_DOCUMENT_CHUNKS.COLLECTION,   EX_CHK_COLL)
                       .execute();
             }
             return rows.size();
@@ -2803,13 +2854,17 @@ public final class CatalogRepository {
     }
 
     private void doImportChunk(DSLContext ctx, String tenant, String docId, Map<String, Object> row) {
+        String coll = physicalCollectionOf(ctx, tenant, docId);
         ctx.insertInto(CATALOG_DOCUMENT_CHUNKS,
                 CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION, CATALOG_DOCUMENT_CHUNKS.CHASH, CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,
-                CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END)
+                CATALOG_DOCUMENT_CHUNKS.LINE_START, CATALOG_DOCUMENT_CHUNKS.LINE_END, CATALOG_DOCUMENT_CHUNKS.CHAR_START, CATALOG_DOCUMENT_CHUNKS.CHAR_END,
+                CATALOG_DOCUMENT_CHUNKS.COLLECTION)
            .values(tenant, docId, i(row,"position"), s(row,"chash"), i(row,"chunk_index"),
-                   i(row,"line_start"), i(row,"line_end"), i(row,"char_start"), i(row,"char_end"))
+                   i(row,"line_start"), i(row,"line_end"), i(row,"char_start"), i(row,"char_end"),
+                   coll)
            .onConflict(CATALOG_DOCUMENT_CHUNKS.TENANT_ID, CATALOG_DOCUMENT_CHUNKS.DOC_ID, CATALOG_DOCUMENT_CHUNKS.POSITION)
            .doUpdate()
+           .set(CATALOG_DOCUMENT_CHUNKS.COLLECTION, EX_CHK_COLL)
            .set(CATALOG_DOCUMENT_CHUNKS.CHASH, EX_CHK_CHASH)
            .set(CATALOG_DOCUMENT_CHUNKS.CHUNK_INDEX,   EX_CHK_IDX)
            .set(CATALOG_DOCUMENT_CHUNKS.LINE_START,   EX_CHK_LST)

--- a/service/src/main/resources/db/changelog/catalog-014-manifest-collection-stamp.xml
+++ b/service/src/main/resources/db/changelog/catalog-014-manifest-collection-stamp.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    nexus-x6kdz (6.5.0 live-shakeout finding).
+
+    catalog_document_chunks.collection is the combined-query join key
+    (catalog-006/-008/-012: m.collection = c.collection) — and NO writer ever
+    populated it. The only stamper was nexus.manifest_backfill() (catalog-004),
+    invoked solely from the vector-migration leg; the REPLACE manifest writers
+    then wiped the stamp again on every re-index. Net effect on any live
+    tenant: every manifest row written or rewritten since its last migration
+    run has collection NULL, and every combined query silently returns zero
+    rows for those documents (the app-side query() fallback masked it).
+
+    The writers now stamp collection at write time (CatalogRepository:
+    writeManifestRows / appendManifestChunks / importChunk / importChunksBatch).
+    This changeset repairs the existing rows once, using the same derivation
+    as manifest_backfill(): the owning document's physical_collection.
+
+    RLS DISCIPLINE (nexus-1wjmq, the v0.1.33 incident class): this is
+    migration-time row-DML against a FORCE ROW LEVEL SECURITY table with NO
+    integrity backstop — the exact shape that silently no-ops for the
+    non-BYPASSRLS owner (nexus_admin) and the exact shape nexus-php10's
+    tripwire will flag. FORCE is toggled off for the changeset's transaction
+    (the OWNER then bypasses policies; the serving role is not the owner, so
+    tenant isolation is unaffected; a mid-changeset failure rolls the toggle
+    back too). ACCESS EXCLUSIVE for the (brief) toggle, as with catalog-013-1b.
+
+    Idempotent: only rows with collection IS NULL are touched; ghost docs
+    (physical_collection empty) and tombstoned docs are skipped, matching
+    manifest_backfill()'s semantics. Rollback is a no-op: the stamp is a
+    derived denormalization; un-stamping serves nothing.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="catalog-014-0" author="nexus-x6kdz">
+        <comment>catalog_document_chunks: one-time RLS-proof stamp of collection from the owning doc's physical_collection (the combined-query join key no writer populated)</comment>
+        <sql splitStatements="true">
+-- Delegates to the EXISTING repair function (catalog-004's
+-- nexus.manifest_backfill(), the same one POST /manifest/backfill calls) —
+-- one repair predicate, no drift between two hand-copied UPDATEs (critique
+-- finding 4). Why a boot-time changeset instead of ops calling the route
+-- per tenant: unattended fleet-wide repair — every tenant is stamped the
+-- moment the engine boots, no per-tenant choreography, and Liquibase
+-- records it exactly once. Live-tenant scale: ~22k documents, O(100k)
+-- manifest rows — one set-based UPDATE, seconds, inside the boot window
+-- (single-instance rm-then-run deploy: nothing serves during boot).
+--
+-- BOTH tables need the FORCE toggle: manifest_backfill() is SECURITY
+-- INVOKER and its UPDATE joins catalog_documents, which is ALSO
+-- FORCE-RLS — toggling only the target table leaves the join yielding
+-- zero rows for the non-bypass owner (caught by
+-- ManifestCollectionStampTest's replay-as-restricted-role).
+ALTER TABLE nexus.catalog_document_chunks NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE nexus.catalog_documents       NO FORCE ROW LEVEL SECURITY;
+SELECT nexus.manifest_backfill();
+ALTER TABLE nexus.catalog_documents       FORCE ROW LEVEL SECURITY;
+ALTER TABLE nexus.catalog_document_chunks FORCE ROW LEVEL SECURITY;
+        </sql>
+        <!-- Derived denormalization: nothing to restore; the write-time stamp
+             and manifest_backfill() both reproduce it. No-op rollback. -->
+        <rollback/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -164,6 +164,7 @@
          (A-1 residue 0) + ADD the missing fifth on chash_index. Must come
          after catalog-002 (the four constraints) and chash-001 (the table). -->
     <include file="db/changelog/catalog-013-chash-checks-validate.xml"/>
+    <include file="db/changelog/catalog-014-manifest-collection-stamp.xml"/>
 
     <!-- pgvector taxonomy centroids (bead nexus-t1hnc.1, RDR-156):
          taxonomy_centroids_384/768/1024 — moves the taxonomy__centroids ChromaDB

--- a/service/src/test/java/dev/nexus/service/CatalogRenameCollectionTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRenameCollectionTest.java
@@ -218,10 +218,12 @@ class CatalogRenameCollectionTest {
     }
 
     @Test @Order(50)
-    void renameCollection_crossModelCopyBranch_targetExists_repointsDocsOnly() throws Exception {
+    void renameCollection_crossModelCopyBranch_targetExists_repointsDocsAndManifests() throws Exception {
         // RDR-162 regression: pre-register the TARGET (simulating the bge-768 cross-model
-        // chunk upsert), then rename. Only catalog_documents.physical_collection must repoint;
-        // both registry rows must remain (the source is NOT deleted, the target NOT collided).
+        // chunk upsert), then rename. catalog_documents.physical_collection repoints AND
+        // (nexus-x6kdz critique HIGH) the manifest's denormalized collection re-homes with
+        // it — the old docs-only pin actively green-lit the silent-empty combined-query
+        // state (docs at the target, manifests at the source). Both registry rows remain.
         final String src = "code__ren-xm__minilm-l6-v2-384__v1";
         final String tgt = "code__ren-xm__bge-768__v1";
         try (Connection su = pg.createConnection("")) {
@@ -232,10 +234,18 @@ class CatalogRenameCollectionTest {
                 + "VALUES ('" + TENANT_A + "', 'xm-doc-1', 'XM Doc', '" + src + "')");
             // target registry already exists (cross-model copy registered it)
             su.createStatement().execute("INSERT INTO nexus.catalog_collections (tenant_id, name) VALUES ('" + TENANT_A + "', '" + tgt + "')");
+            // a manifest row still homed at the SOURCE (the pre-rename state)
+            su.createStatement().execute("ALTER TABLE nexus.catalog_document_chunks NO FORCE ROW LEVEL SECURITY");
+            su.createStatement().execute("INSERT INTO nexus.catalog_document_chunks "
+                + "(tenant_id, doc_id, position, chash, collection) "
+                + "VALUES ('" + TENANT_A + "', 'xm-doc-1', 0, '" + "e".repeat(32) + "', '" + src + "')");
+            su.createStatement().execute("ALTER TABLE nexus.catalog_document_chunks FORCE ROW LEVEL SECURITY");
         }
         Map<String, Integer> c = repo.renameCollection(TENANT_A, src, tgt);
-        assertThat(c).as("cross-model branch returns only catalog_documents").containsOnlyKeys("catalog_documents");
+        assertThat(c).as("cross-model branch re-homes docs AND manifests")
+            .containsOnlyKeys("catalog_documents", "catalog_document_chunks");
         assertThat(c.get("catalog_documents")).as("one doc repointed").isEqualTo(1);
+        assertThat(c.get("catalog_document_chunks")).as("one manifest row re-homed").isEqualTo(1);
         try (Connection su = pg.createConnection("")) {
             assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_collections WHERE tenant_id='" + TENANT_A
                 + "' AND name='" + src + "'")).as("source registry row KEPT").isEqualTo(1);
@@ -245,6 +255,10 @@ class CatalogRenameCollectionTest {
                 + "' AND physical_collection='" + tgt + "'")).as("doc now under target").isEqualTo(1);
             assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_documents WHERE tenant_id='" + TENANT_A
                 + "' AND physical_collection='" + src + "'")).as("no doc left under source").isZero();
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_document_chunks WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + tgt + "'")).as("manifest row homed at target").isEqualTo(1);
+            assertThat(rows(su, "SELECT COUNT(*) FROM nexus.catalog_document_chunks WHERE tenant_id='" + TENANT_A
+                + "' AND collection='" + src + "'")).as("no manifest row left under source").isZero();
         }
     }
 

--- a/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
+++ b/service/src/test/java/dev/nexus/service/CatalogRepositoryTest.java
@@ -1084,7 +1084,9 @@ class CatalogRepositoryTest {
         // Pre-RDR-162 this threw a 500 (PK collision on the registry rename). The cross-model
         // COPY branch (target exists) repoints catalog_documents only and returns just that key.
         var counts = repo.renameCollection(TENANT_A, src, tgt);
-        assertThat(counts).as("cross-model branch returns only catalog_documents").containsOnlyKeys("catalog_documents");
+        // nexus-x6kdz: the branch now ALSO re-homes the manifest join key.
+        assertThat(counts).as("cross-model branch re-homes docs and manifests")
+            .containsOnlyKeys("catalog_documents", "catalog_document_chunks");
         assertThat(counts.get("catalog_documents")).isEqualTo(1);
         assertThat(repo.getDocument(TENANT_A, "xmrn.1").get("physical_collection")).isEqualTo(tgt);
         // The pre-registered target row is intact (not collided, not duplicated).
@@ -2310,8 +2312,10 @@ class CatalogRepositoryTest {
 
     @Test @Order(200)
     void migration_manifestBackfill_stamps_null_collection_then_orphans_detected() {
-        // A 384-model doc with ONE manifest row whose collection is NULL
-        // (writeManifest leaves it NULL) and NO chunk row in chunks_384.
+        // A 384-model doc with ONE manifest row whose collection is NULL and
+        // NO chunk row in chunks_384. nexus-x6kdz: writeManifest now stamps
+        // collection AT WRITE TIME, so the legacy NULL shape backfill exists
+        // for must be seeded directly (the pre-fix writer's output).
         repo.upsertDocument(TENANT_MIG, Map.of(
             "tumbler", "mforph.1",
             "title", "Orphan Source",
@@ -2324,6 +2328,21 @@ class CatalogRepositoryTest {
                 "position", 0, "chash", "f00d0000000000000000000000000000",
                 "chunk_index", 0)
         ));
+        // The write-time stamp is the new contract:
+        try (var conn = pg.createConnection(""); var st = conn.createStatement()) {
+            var rs = st.executeQuery(
+                "SELECT collection FROM nexus.catalog_document_chunks "
+                + "WHERE tenant_id = '" + TENANT_MIG + "' AND doc_id = 'mforph.1'");
+            rs.next();
+            assertThat(rs.getString(1))
+                .as("nexus-x6kdz: writer stamps collection at write time")
+                .isEqualTo(MIG_COLLECTION_384);
+            // Reset to the legacy NULL shape so backfill has real work:
+            st.execute("UPDATE nexus.catalog_document_chunks SET collection = NULL "
+                + "WHERE tenant_id = '" + TENANT_MIG + "' AND doc_id = 'mforph.1'");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
 
         // EXACTLY one NULL-collection row in this tenant → backfill stamps 1.
         long stamped = repo.manifestBackfill(TENANT_MIG);

--- a/service/src/test/java/dev/nexus/service/ManifestCollectionStampTest.java
+++ b/service/src/test/java/dev/nexus/service/ManifestCollectionStampTest.java
@@ -1,0 +1,236 @@
+package dev.nexus.service;
+
+import dev.nexus.service.db.CatalogRepository;
+import dev.nexus.service.db.TenantScope;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * nexus-x6kdz — the 6.5.0 live-shakeout finding: NO writer populated
+ * {@code catalog_document_chunks.collection}, the combined-query join key
+ * (catalog-006/-008/-012: {@code m.collection = c.collection}). The only
+ * stamper was the migration-leg {@code manifest_backfill()}, and the REPLACE
+ * manifest writers wiped its work on every re-index — so on any live tenant
+ * every post-migration manifest row was invisible to the combined queries
+ * (silent-empty; the app-side {@code query()} fallback masked it). The seeded
+ * parity tests never caught it because they INSERT manifest rows with
+ * {@code collection} set directly, bypassing the writers.
+ *
+ * <p>These tests walk the REAL writers — {@code writeManifest} (REPLACE),
+ * {@code appendManifestChunks}, {@code importChunksBatch} (the catalog-ETL
+ * path) — and assert both the stamped column AND the end-to-end property the
+ * shakeout found broken: {@code search_metadata_scoped_1024} returns the row.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ManifestCollectionStampTest {
+
+    private static final String TENANT = "mcs-tenant";
+    private static final String COLL   = "knowledge__mcs__voyage-context-3__v1";
+    private static final String CH_A   = "a".repeat(32);
+    private static final String CH_B   = "b".repeat(32);
+
+    PostgreSQLContainer<?> pg;
+    com.zaxxer.hikari.HikariDataSource ds;
+    CatalogRepository repo;
+    String docTumbler;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN "
+                + "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN "
+                + "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; "
+                + "  END IF; "
+                + "END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            var lb = new Liquibase(
+                "db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(
+                    new JdbcConnection(su)));
+            lb.update(new Contexts());
+        }
+        ds = PgContainerHelper.superuserDataSource(pg);
+        repo = new CatalogRepository(new TenantScope(ds));
+
+        // One registered document with a physical_collection, plus a matching
+        // 1024-dim chunk row (the combined query joins chunks ⋈ manifest ⋈ docs).
+        docTumbler = repo.registerDocument(TENANT, "9.1", Map.of(
+            "title", "stamp doc", "content_type", "knowledge",
+            "physical_collection", COLL));
+        try (Connection su = pg.createConnection(""); Statement st = su.createStatement()) {
+            st.execute("INSERT INTO nexus.catalog_collections (tenant_id, name) "
+                + "VALUES ('" + TENANT + "', '" + COLL + "') ON CONFLICT DO NOTHING");
+            st.execute("INSERT INTO nexus.chunks_1024 (tenant_id, collection, chash, chunk_text, embedding) "
+                + "VALUES ('" + TENANT + "', '" + COLL + "', '" + CH_A + "', 'alpha text', "
+                + "('[' || repeat('0.1,', 1023) || '0.1]')::vector)");
+        }
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (ds != null) ds.close();
+        if (pg != null) pg.stop();
+    }
+
+    private String collectionOf(String chash) throws Exception {
+        try (Connection su = pg.createConnection(""); Statement st = su.createStatement();
+             ResultSet rs = st.executeQuery(
+                 "SELECT collection FROM nexus.catalog_document_chunks "
+                 + "WHERE tenant_id = '" + TENANT + "' AND chash = '" + chash + "'")) {
+            return rs.next() ? rs.getString(1) : null;
+        }
+    }
+
+    private int combinedQueryHits() throws Exception {
+        try (Connection su = pg.createConnection(""); Statement st = su.createStatement();
+             ResultSet rs = st.executeQuery(
+                 "SELECT count(*) FROM nexus.search_metadata_scoped_1024("
+                 + "('[' || repeat('0.1,', 1023) || '0.1]')::vector, "
+                 + "ARRAY['" + COLL + "'], NULL::text, NULL::text, NULL::int, "
+                 + "NULL::text, NULL::text, NULL::jsonb, 10)")) {
+            rs.next();
+            return rs.getInt(1);
+        }
+    }
+
+    @Test
+    void writeManifest_stampsCollection_andCombinedQuerySeesTheRow() throws Exception {
+        repo.writeManifest(TENANT, docTumbler, List.of(
+            Map.of("position", 0, "chash", CH_A)));
+        assertThat(collectionOf(CH_A))
+            .as("REPLACE writer stamps the doc's physical_collection")
+            .isEqualTo(COLL);
+        assertThat(combinedQueryHits())
+            .as("the exact end-to-end property the live shakeout found broken: "
+                + "a serving-written manifest row is visible to the combined query")
+            .isEqualTo(1);
+
+        // REPLACE again (re-index) — the stamp must SURVIVE, not be wiped
+        // (pre-fix, re-indexing was what erased manifest_backfill's work).
+        repo.writeManifest(TENANT, docTumbler, List.of(
+            Map.of("position", 0, "chash", CH_A)));
+        assertThat(collectionOf(CH_A)).isEqualTo(COLL);
+        assertThat(combinedQueryHits()).isEqualTo(1);
+    }
+
+    @Test
+    void appendAndImport_stampCollection() throws Exception {
+        repo.appendManifestChunks(TENANT, docTumbler, List.of(
+            Map.of("position", 1, "chash", CH_B)));
+        assertThat(collectionOf(CH_B))
+            .as("append writer stamps too").isEqualTo(COLL);
+
+        // The catalog-ETL path (the shape every migrated tenant's rows took).
+        repo.importChunksBatch(TENANT, docTumbler, List.of(
+            Map.of("position", 2, "chash", "c".repeat(32))));
+        assertThat(collectionOf("c".repeat(32)))
+            .as("ETL import stamps too — migrated tenants stop regressing")
+            .isEqualTo(COLL);
+    }
+
+    @Test
+    void renameCollection_reHomesManifestRows() throws Exception {
+        // The second door back into the silently-empty state (critique Q2):
+        // RDR-164 rename re-pointed docs + chunks + chash_index but NOT the
+        // manifest's denormalized collection — post-rename the combined
+        // queries would go empty again for that collection.
+        String renamed = "knowledge__mcs-renamed__voyage-context-3__v1";
+        repo.writeManifest(TENANT, docTumbler, List.of(
+            Map.of("position", 0, "chash", CH_A)));
+        Map<String, Integer> counts = repo.renameCollection(TENANT, COLL, renamed);
+        assertThat(counts.get("catalog_document_chunks"))
+            .as("rename re-homes the manifest join key").isEqualTo(1);
+        try (Connection su = pg.createConnection(""); Statement st = su.createStatement();
+             ResultSet rs = st.executeQuery(
+                 "SELECT count(*) FROM nexus.search_metadata_scoped_1024("
+                 + "('[' || repeat('0.1,', 1023) || '0.1]')::vector, "
+                 + "ARRAY['" + renamed + "'], NULL::text, NULL::text, NULL::int, "
+                 + "NULL::text, NULL::text, NULL::jsonb, 10)")) {
+            rs.next();
+            assertThat(rs.getInt(1))
+                .as("combined query follows the rename end-to-end").isEqualTo(1);
+        }
+        // restore for sibling tests (PER_CLASS lifecycle, shared fixture)
+        repo.renameCollection(TENANT, renamed, COLL);
+    }
+
+    @Test
+    void catalog014_repairsNullRows_asNonBypassRlsOwner() throws Exception {
+        // Reconstruct the live-tenant state: a NULL-collection manifest row
+        // (written by a pre-fix writer), then replay catalog-014 as a
+        // production-shaped NOSUPERUSER NOBYPASSRLS owner — the nexus-1wjmq
+        // class demands the changeset's NO FORCE toggle actually works.
+        String chNull = "d".repeat(32);
+        try (Connection su = pg.createConnection(""); Statement st = su.createStatement()) {
+            st.execute("ALTER TABLE nexus.catalog_document_chunks NO FORCE ROW LEVEL SECURITY");
+            st.execute("INSERT INTO nexus.catalog_document_chunks "
+                + "(tenant_id, doc_id, position, chash, collection) "
+                + "VALUES ('" + TENANT + "', '" + docTumbler + "', 99, '" + chNull + "', NULL)");
+            st.execute("ALTER TABLE nexus.catalog_document_chunks FORCE ROW LEVEL SECURITY");
+            st.execute("DELETE FROM public.databasechangelog WHERE id = 'catalog-014-0'");
+            st.execute("DO $$ BEGIN "
+                + "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'mcs_admin') THEN "
+                + "    CREATE ROLE mcs_admin LOGIN PASSWORD 'mcs_admin_pw' NOSUPERUSER NOBYPASSRLS; "
+                + "  END IF; "
+                + "END $$");
+            st.execute("GRANT USAGE, CREATE ON SCHEMA nexus, t1, public TO mcs_admin");
+            // The runAlways grants changeset GRANTs on ALL tables/sequences —
+            // the replay role must own them (same recipe as Catalog013RlsReplayTest).
+            st.execute("DO $$ DECLARE r record; BEGIN "
+                + "  FOR r IN SELECT schemaname, tablename FROM pg_tables "
+                + "           WHERE schemaname IN ('nexus', 't1') LOOP "
+                + "    EXECUTE format('ALTER TABLE %I.%I OWNER TO mcs_admin', "
+                + "                   r.schemaname, r.tablename); "
+                + "  END LOOP; "
+                + "  FOR r IN SELECT schemaname, sequencename FROM pg_sequences "
+                + "           WHERE schemaname IN ('nexus', 't1') LOOP "
+                + "    EXECUTE format('ALTER SEQUENCE %I.%I OWNER TO mcs_admin', "
+                + "                   r.schemaname, r.sequencename); "
+                + "  END LOOP; "
+                + "END $$");
+            st.execute("GRANT ALL ON TABLE public.databasechangelog, "
+                + "public.databasechangeloglock TO mcs_admin");
+        }
+        try (Connection admin = java.sql.DriverManager.getConnection(
+                pg.getJdbcUrl(), "mcs_admin", "mcs_admin_pw")) {
+            var lb = new Liquibase(
+                "db/changelog/db.changelog-master.xml",
+                new ClassLoaderResourceAccessor(),
+                DatabaseFactory.getInstance().findCorrectDatabaseImplementation(
+                    new JdbcConnection(admin)));
+            lb.update(new Contexts());
+        }
+        assertThat(collectionOf(chNull))
+            .as("catalog-014 stamps NULL rows despite FORCE RLS (toggle pattern)")
+            .isEqualTo(COLL);
+        // FORCE restored by the changeset itself.
+        try (Connection su = pg.createConnection(""); Statement st = su.createStatement();
+             ResultSet rs = st.executeQuery(
+                 "SELECT relforcerowsecurity FROM pg_class "
+                 + "WHERE oid = 'nexus.catalog_document_chunks'::regclass")) {
+            rs.next();
+            assertThat(rs.getBoolean(1)).isTrue();
+        }
+    }
+}

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/daemon/binary_install.py
+++ b/src/nexus/daemon/binary_install.py
@@ -87,7 +87,7 @@ TAG_NAMESPACE_PREFIX = "engine-service-v"
 #: service (RF-161-2). ``None`` until the first real ``engine-service-v*``
 #: release exists; while it is ``None``, ``nx init --service`` cannot
 #: auto-install and instructs the user to pass an explicit tag.
-PINNED_SERVICE_TAG: str | None = "engine-service-v0.1.34"
+PINNED_SERVICE_TAG: str | None = "engine-service-v0.1.35"
 
 #: Env override for the service tag (operator / CI). Takes precedence over the
 #: build-time pin. Still an explicit tag — no "latest" semantics.

--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -51,7 +51,7 @@ RELEASE_PROPS="service/src/main/resources/META-INF/nexus/release.properties"
 # stale default fail-closes the --cold MVV at the version gate. Kept literal (it
 # names a PUBLISHED release tag, which need not equal the floor) but bumped to
 # track it; override via NEXUS_SERVICE_TAG. (nexus-v0zmv)
-COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.34}"
+COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.35}"
 for a in "$@"; do
   case "$a" in
     --with-cloud) WITH_CLOUD=1 ;;

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "6.5.0"
+version = "6.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Patch release: advances the engine pin to **engine-service-v0.1.35** — the combined-query manifest-stamp fix (nexus-x6kdz, found by the 6.5.0 live prod shakeout).

## Why a patch a day after 6.5.0

6.5.0 pins engine v0.1.34, whose manifest writers never stamp `catalog_document_chunks.collection` (the combined-query join key). A fresh install on 6.5.0 auto-acquires v0.1.34 and reproduces the silently-empty combined-query state on newly indexed data. v0.1.35 stamps at every write seam (including both rename branches) and its catalog-014 boot changeset repairs existing rows by delegating to `nexus.manifest_backfill()` inside dual FORCE-RLS toggles.

`REQUIRED_RELEASE_VERSION` stays (0,1,34): the client does not require the new engine — it distributes it.

## Evidence

- engine v0.1.35: full mvn 1209/1209, guided + cold MVVs green, deployed to api.conexus-nexus.com, live re-probe on the production tenant: `search_metadata_scoped` 3 rows / `search_graph_hop` 10 rows through 2 hops (both ZERO pre-fix)
- client: full unit suite 12,477 passed; local-service functional gate PASSED (447/32); sandbox smoke [done]; pin-parity tests green
- both reviewers approved the engine fix with independent re-verification