### PR TITLE
release: conexus 6.5.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "conexus",
-        "ref": "v6.5.1"
+        "ref": "v6.5.2"
       },
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "6.5.1"
+      "version": "6.5.2"
     },
     {
       "name": "sn",
@@ -22,10 +22,10 @@
         "source": "git-subdir",
         "url": "https://github.com/Hellblazer/nexus.git",
         "path": "sn",
-        "ref": "v6.5.1"
+        "ref": "v6.5.2"
       },
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "6.5.1"
+      "version": "6.5.2"
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -699,7 +699,19 @@ jobs:
               - 'service/src/main/java/dev/nexus/service/http/VectorHandler.java'
               - 'service/src/main/java/dev/nexus/service/http/AuthFilter.java'
               - 'service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java'
+              # nexus-4nflf: combined-query end-to-end tripwire (x6kdz). The
+              # bug shipped through the catalog write path (no manifest writer
+              # stamped document_chunks.collection, the combined-query join
+              # key), not the vector write path above — so the catalog Java
+              # handler/repo AND the Liquibase changelog (the combined-query
+              # SQL functions themselves) must gate this job too, not just
+              # PgVectorRepository.
+              - 'service/src/main/java/dev/nexus/service/db/CatalogRepository.java'
+              - 'service/src/main/java/dev/nexus/service/http/CatalogHandler.java'
+              - 'service/src/main/resources/db/changelog/**'
+              - 'src/nexus/catalog/http_catalog_client.py'
               - 'tests/db/test_write_seam_gate_integration.py'
+              - 'tests/db/test_http_combined_query_integration.py'
               - 'scripts/assert_write_seam_ran.py'
               - '.github/workflows/ci.yml'
               # Dep bump can change the Python env or service contract without
@@ -762,7 +774,7 @@ jobs:
         if: steps.changes.outputs.seam == 'true'
         uses: ./.github/actions/prime-bge-onnx
 
-      - name: Run write-seam gate (>300-record, dup-chash, ON CONFLICT, NUL-sanitize)
+      - name: Run write-seam gate (>300-record, dup-chash, ON CONFLICT, NUL-sanitize, combined-query tripwire)
         if: steps.changes.outputs.seam == 'true'
         env:
           # FAIL (not skip) on missing/stale JAR in CI — the conftest.py autouse
@@ -776,8 +788,13 @@ jobs:
           set -euo pipefail
           # -o addopts="" clears the repo default -m 'not integration' so the
           # integration-marked test module is collected (same pattern as CA-3 jobs).
+          # nexus-4nflf: the combined-query tripwire module shares this job's
+          # JAR+Docker-PG+ONNX boot (same cost profile) — one pytest invocation,
+          # one junit-xml, one assert_write_seam_ran.py call for both modules.
           uv run pytest tests/db/test_write_seam_gate_integration.py \
+            tests/db/test_http_combined_query_integration.py \
             -o addopts="" -m integration -q -rs --junit-xml=write-seam.xml
-          # Non-vacuity gate: asserts the dedup-collapse test actually ran+passed
-          # and no prereq-skip vacuously cleared the run.
+          # Non-vacuity gate: asserts the dedup-collapse AND the combined-query
+          # manifest-rewrite-visibility core tests actually ran+passed, and no
+          # prereq-skip vacuously cleared the run.
           uv run python scripts/assert_write_seam_ran.py write-seam.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.5.2] - 2026-07-09
+
+### Fixed
+
+- **`nx guided-upgrade` no longer demands a Voyage key for mislabeled local collections** (nexus-119p9, GH #1381). 6.5.0's measured-dim classifier fix (nexus-nb7hr) taught detection to sample a stored vector, but the voyage-capability gate still keyed on collection *names* and exited before the migration's auto-remap could run — so voyage-*named* collections holding ordinary local bge-768 vectors (the pre-RDR-109 mislabel class) reproduced the identical "cannot serve voyage" dead end on 6.5.x. The gate now honors the measured dimension: measured-bge collections route to the free local remap; genuinely-voyage collections (measured 1024) still gate; unprobeable collections stay fail-closed.
+- **Multi-model corpus combined queries no longer return empty** (nexus-3l6gz, nexus-hg745). `search_metadata_scoped`, `search_graph_hop`, and `query()`'s catalog-routed service branch passed the full resolved collection list — spanning `voyage-code-3` AND `voyage-context-3` — in ONE service call; the service guards only vector *dimension* (both models are 1024-dim), so the query was embedded with whichever model owned the first collection and ranked across incompatible embedding spaces, silently dropping results (e.g. `corpus="code,docs"` returning "No documents found" while `corpus="code"` returned rows). The MCP layer now groups collections by embedding model, issues one call per group, and merges by distance with global dedup/limit. Documented semantics: all-or-nothing on partial group failure; cross-model distances are not rigorously comparable (accepted caveat, matching `search_topic_scoped`).
+- **Engine pin advanced to engine-service-v0.1.36.** Carries two engine-side hardenings: combined-query endpoints now 400 loudly on a mixed-embedding-model collection list instead of silently mis-embedding (`requireHomogeneousModel`, nexus-9y5om), and the new tenant-locked mint-credential scope (below). `REQUIRED_RELEASE_VERSION` stays (0,1,34).
+
+### Added
+
+- **`nx service token issue --scope mint-locked`** (nexus-xidcq, conexus RDR-005 2a; requires engine-service ≥ 0.1.36). Tenant-locked variant of the data-token mint credential: identical surface confinement to `mint`, but it can mint only for its own bound tenant — a cross-tenant mint attempt gets a 403 and consumes no rate-limit budget. Existing `mint` (cross-tenant) credentials are unchanged.
+- **Combined-query end-to-end tripwire** (nexus-4nflf). A new integration gate walks register → chunk upsert → manifest write/append/import through the public HTTP API against a real service and asserts `search_metadata_scoped` / `search_graph_hop` visibility — the test layer whose absence let the x6kdz collection-stamp bug ship invisibly. Wired into the path-gated write-seam CI job with a fail-loud non-vacuity assert.
+- **FORCE-RLS changelog lint** (nexus-php10). A unit test in the required CI suite parses the whole Liquibase chain and fails on migration-time row-DML against a FORCE ROW LEVEL SECURITY table unless it is toggle-wrapped (the catalog-013-1b pattern), backstopped by a same-changeset RLS-bypassing integrity proof, or explicitly grandfathered — the silent-no-op class behind the v0.1.33 deploy incident (nexus-1wjmq) can no longer grow.
+
 ## [6.5.1] - 2026-07-08
 
 ### Fixed

--- a/conexus/.claude-plugin/plugin.json
+++ b/conexus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conexus",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/conexus/CHANGELOG.md
+++ b/conexus/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the conexus plugin are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.2] - 2026-07-09
+
+- Plugin version aligned with conexus 6.5.2 (guided-upgrade voyage-gate measured-dim fix, multi-model combined-query grouping, engine pin advanced to v0.1.36). No plugin-side changes.
+
 ## [6.5.1] - 2026-07-08
 
 - Plugin version aligned with conexus 6.5.1 (engine pin advanced to v0.1.35 — the combined-query manifest-stamp fix). No plugin-side changes.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2145,12 +2145,12 @@ Record `TAG` (`engine-service-vX.Y.Z`, `vX.Y.Z`, or `X.Y.Z`) as the cloud-deploy
 ### nx service token issue
 
 ```
-nx service token issue --tenant TENANT [--label LABEL] [--ttl SECONDS] [--scope tenant|mint]
+nx service token issue --tenant TENANT [--label LABEL] [--ttl SECONDS] [--scope tenant|mint|mint-locked]
 ```
 
 Issue a new bearer token bound to `TENANT`. Printed once; only the hash is stored. `--ttl` sets an optional lifetime in seconds (default: no expiry). A token bound to a tenant ignores the client `X-Nexus-Tenant` header; the tenant comes from the token.
 
-`--scope` (nexus-868dq / conexus RDR-005): default `tenant` (ordinary bearer). `mint` issues a **data-token mint credential** — it may ONLY call `POST /v1/data-tokens/mint` (minting short-TTL per-tenant data tokens, cross-tenant allowed, rate-limited) and is rejected on every admin and data route. Issuing `--scope mint` requires the operator (root) bearer. `data` tokens are never issued here — only minted by the endpoint; `root` is never issuable. Revoking a mint credential (`nx service token revoke`) stops its mints immediately; outstanding data tokens drain on their own TTL (≤ 3600s ceiling, `NX_DATA_TOKEN_TTL_CEILING_SECONDS`).
+`--scope` (nexus-868dq / conexus RDR-005): default `tenant` (ordinary bearer). `mint` issues a **data-token mint credential** — it may ONLY call `POST /v1/data-tokens/mint` (minting short-TTL per-tenant data tokens, cross-tenant allowed, rate-limited) and is rejected on every admin and data route. `mint-locked` (nexus-xidcq / RDR-005 2a; requires engine-service ≥ 0.1.36) is the tenant-locked variant: identical surface confinement, but it may mint ONLY for its own bound tenant — a cross-tenant mint attempt gets a 403 (and does not consume rate-limit budget). Prefer `mint-locked` when a tenant self-custodies its mint credential; `mint` (cross-tenant) is the control-plane/edge shape. Issuing either mint scope requires the operator (root) bearer. `data` tokens are never issued here — only minted by the endpoint; `root` is never issuable. Revoking a mint credential (`nx service token revoke`) stops its mints immediately; outstanding data tokens drain on their own TTL (≤ 3600s ceiling, `NX_DATA_TOKEN_TTL_CEILING_SECONDS`).
 
 ### nx service token rotate
 

--- a/docs/migration-runbook.md
+++ b/docs/migration-runbook.md
@@ -21,8 +21,11 @@ T2 `nexus_rdr/155-production-migration-complete`).
 nothing to migrate no-ops here, *without* provisioning), **provisions and
 verifies** the service stack (health-gate + version-pin; a not-ready or
 wrong-version service hard-fails with a remedy and NEVER migrates), runs the
-**voyage-capability gate** (refuses to migrate voyage-model collections onto a
-bge-only service, since re-embedding voyage text into bge changes recall),
+**voyage-capability gate** (refuses to migrate GENUINE voyage-model collections
+onto a bge-only service, since re-embedding voyage text into bge changes
+recall; a voyage-*named* collection whose stored vectors MEASURE as local
+bge-768 — the pre-RDR-109 mislabel class — does not trip the gate and is
+auto-remapped locally at no cost, nexus-nb7hr/nexus-119p9),
 self-loads the freshly-provisioned `NX_SERVICE_TOKEN`, then **hands off to
 `nx migrate-to-service`** against the verified URL, and finishes with an
 advisory `nx doctor`. Preview the footprint first; re-running is safe (every

--- a/docs/storage-tiers.md
+++ b/docs/storage-tiers.md
@@ -222,7 +222,7 @@ Conformant collection names (RDR-103) follow a 4-segment shape:
 
 **Legacy shape (fallback, pre-RDR-103)**: 2-segment `<content_type>__<repo>-<hash>`, e.g. `code__myrepo-a1b2c3`. Still present on collections created before the conformance migration; new collections use the 4-segment shape above.
 
-A collection is indexed and queried under the same embedding model — mixing models across one vector space produces near-random similarity scores. The voyage-capability gate (`nx guided-upgrade`) refuses to migrate voyage-model collections onto a bge-only service for exactly this reason.
+A collection is indexed and queried under the same embedding model — mixing models across one vector space produces near-random similarity scores. The voyage-capability gate (`nx guided-upgrade`) refuses to migrate genuine voyage-model collections onto a bge-only service for exactly this reason. The same principle is enforced at query time: multi-collection combined queries are dispatched per embedding-model group by the MCP layer (a corpus spanning `voyage-code-3` and `voyage-context-3` collections issues one query per model and merges results, nexus-3l6gz), and the service rejects a mixed-model collection list outright (`requireHomogeneousModel`, engine-service ≥ 0.1.36).
 
 **TTL and expiry**: `nx store expire` removes expired entries from `knowledge__*` collections only. Code, docs, and RDR collections are never expired — they are refreshed via re-indexing.
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "conexus",
   "display_name": "Conexus",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "description": "Three-tier semantic memory + knowledge management for Claude Desktop chat. Persistent code/docs/RDR indexing, plan-centric retrieval via nx_answer, and a daemon-mediated storage substrate that interoperates with the Claude Code plugin and the nx CLI on the same host.",
   "long_description": "Conexus is the Claude Desktop Extension form of Nexus. Same MCP tools and storage tiers as the Claude Code plugin and the nx CLI, packaged as a .mcpb bundle that uv resolves on first install. On first launch, the host's T2 daemon is auto-installed (LaunchAgent on macOS, systemd user unit on Linux) so the MCP server has a daemon to talk to. State is shared with any other consumer on the same host (Claude Code plugin, nx CLI, Cowork via SDK bridge).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conexus-mcpb"
-version = "6.5.1"
+version = "6.5.2"
 description = "Conexus packaged as Claude Desktop .mcpb (Desktop Extension)"
 requires-python = ">=3.12"
 dependencies = [
@@ -10,7 +10,7 @@ dependencies = [
     # while collections are indexed at 768/1024-dim, so every T3 search hits a
     # dimension mismatch and returns zero results. The .mcpb cannot run the
     # interactive `nx init` embedder choice, so it must pin [local] explicitly.
-    "conexus[local]>=6.5.1",
+    "conexus[local]>=6.5.2",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "6.5.1"
+version = "6.5.2"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/scripts/assert_write_seam_ran.py
+++ b/scripts/assert_write_seam_ran.py
@@ -8,7 +8,10 @@ not set, or docker unavailable). This script fails if that happens, turning
 what would be a green-but-vacuous CI run into a loud failure.
 
 It also asserts that the load-bearing dedup-collapse test (the F1 core assertion)
-actually passed.
+actually passed, AND (nexus-4nflf) that the combined-query manifest-rewrite
+regression test (the x6kdz core assertion) actually passed. The two core tests
+now live in separate modules that share ONE pytest invocation and ONE
+junit-xml (see the ci.yml write-seam-gate job) — this script enforces both.
 
 Usage: ``python scripts/assert_write_seam_ran.py <junit.xml>``
 """
@@ -23,6 +26,10 @@ import xml.etree.ElementTree as ET
 _PREREQ_SKIP_MARKER = "missing jar, java, or docker"
 # The load-bearing test that asserts dedup collapse (F1 core assertion)
 _CORE_TEST = "test_duplicate_chash_dedup_collapse"
+# nexus-4nflf: the load-bearing combined-query regression test (x6kdz core
+# assertion) — manifest writes must leave the doc combined-query-visible
+# (collection stamp present), including across a repeat REPLACE pass.
+_CATALOG_CORE_TEST = "test_manifest_rewrite_keeps_combined_query_visibility"
 
 
 def main(junit_path: str) -> None:
@@ -35,6 +42,7 @@ def main(junit_path: str) -> None:
     root = ET.parse(junit_path).getroot()
     prereq_skips = passed = 0
     core_ok = False
+    catalog_core_ok = False
     for case in root.iter("testcase"):
         skipped = case.find("skipped")
         failed = case.find("failure") is not None or case.find("error") is not None
@@ -45,6 +53,8 @@ def main(junit_path: str) -> None:
             passed += 1
         if case.get("name", "").endswith(_CORE_TEST) and skipped is None and not failed:
             core_ok = True
+        if case.get("name", "").endswith(_CATALOG_CORE_TEST) and skipped is None and not failed:
+            catalog_core_ok = True
 
     assert prereq_skips == 0, (
         f"{prereq_skips} write-seam test(s) skipped for missing prereqs "
@@ -54,9 +64,15 @@ def main(junit_path: str) -> None:
         f"core dedup-collapse test did not pass — write-seam assertion unproven "
         f"(no passing testcase ending in '{_CORE_TEST}')"
     )
+    assert catalog_core_ok, (
+        "core combined-query manifest-rewrite test did not pass — the x6kdz "
+        f"regression tripwire is unproven (no passing testcase ending in "
+        f"'{_CATALOG_CORE_TEST}')"
+    )
     print(
         f"WRITE-SEAM PASS: {passed} passed, 0 prereq-skips, "
-        "dedup-collapse + >300-record + ON CONFLICT verified"
+        "dedup-collapse + >300-record + ON CONFLICT + combined-query "
+        "manifest-rewrite visibility verified"
     )
 
 

--- a/service/src/main/java/dev/nexus/service/db/TokenStore.java
+++ b/service/src/main/java/dev/nexus/service/db/TokenStore.java
@@ -51,7 +51,7 @@ public final class TokenStore {
     // Server-assigned; NEVER derived from the client-supplied label (a label-
     // derived privilege would let any /v1/service-tokens/issue caller
     // self-escalate by crafting a label). The DB CHECK constraint mirrors this
-    // set (service-tokens-003).
+    // set (service-tokens-003, extended by service-tokens-004 for mint-locked).
 
     /** The single operator credential (bootstrap). Cross-tenant admin. */
     public static final String SCOPE_ROOT = "root";
@@ -59,11 +59,14 @@ public final class TokenStore {
     public static final String SCOPE_TENANT = "tenant";
     /** Mint-only credential (conexus edge): may ONLY call POST /v1/data-tokens/mint. */
     public static final String SCOPE_MINT = "mint";
+    /** Tenant-locked mint credential (RDR-005 2a, nexus-xidcq): like SCOPE_MINT but may
+     *  ONLY mint data tokens for its OWN bound tenant — no cross-tenant mint. */
+    public static final String SCOPE_MINT_LOCKED = "mint-locked";
     /** Short-TTL per-tenant data token minted by a mint credential. */
     public static final String SCOPE_DATA = "data";
 
     private static final java.util.Set<String> VALID_SCOPES =
-        java.util.Set.of(SCOPE_ROOT, SCOPE_TENANT, SCOPE_MINT, SCOPE_DATA);
+        java.util.Set.of(SCOPE_ROOT, SCOPE_TENANT, SCOPE_MINT, SCOPE_MINT_LOCKED, SCOPE_DATA);
 
     /**
      * A live (non-revoked) service token: its tenant, optional expiry instant, and

--- a/service/src/main/java/dev/nexus/service/http/AuthFilter.java
+++ b/service/src/main/java/dev/nexus/service/http/AuthFilter.java
@@ -118,7 +118,8 @@ public final class AuthFilter extends Filter {
         // admin handler's own scope guard is defense-in-depth layer 2. Exact
         // segment match ("/v1/data-tokens" or "/v1/data-tokens/..."), not a raw
         // prefix — "/v1/data-tokens-evil" must not slip through.
-        if (dev.nexus.service.db.TokenStore.SCOPE_MINT.equals(scope)) {
+        if (dev.nexus.service.db.TokenStore.SCOPE_MINT.equals(scope)
+                || dev.nexus.service.db.TokenStore.SCOPE_MINT_LOCKED.equals(scope)) {
             String path = exchange.getRequestURI().getPath();
             boolean mintSurface = path.equals("/v1/data-tokens")
                 || path.startsWith("/v1/data-tokens/");

--- a/service/src/main/java/dev/nexus/service/http/DataTokenHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/DataTokenHandler.java
@@ -119,13 +119,13 @@ public final class DataTokenHandler implements HttpHandler {
     }
 
     private void handleMint(HttpExchange ex) throws IOException {
-        // ONLY a mint-scoped credential may mint (plan-author decision 4: root is
-        // deliberately excluded — the operator issues itself a mint credential).
-        if (!TokenStore.SCOPE_MINT.equals(RequestContext.scope())) {
-            log.debug("event=data_token_denied reason=mint_scope_required scope={}",
-                      RequestContext.scope());
+        // ONLY a mint- or mint-locked-scoped credential may mint (plan-author decision 4:
+        // root is deliberately excluded — the operator issues itself a mint credential).
+        String scope = RequestContext.scope();
+        if (!TokenStore.SCOPE_MINT.equals(scope) && !TokenStore.SCOPE_MINT_LOCKED.equals(scope)) {
+            log.debug("event=data_token_denied reason=mint_scope_required scope={}", scope);
             HttpUtil.send(ex, 403, json(Map.of(
-                "error", "forbidden: data-token mint requires a 'mint'-scoped credential")));
+                "error", "forbidden: data-token mint requires a 'mint' or 'mint-locked'-scoped credential")));
             return;
         }
 
@@ -142,6 +142,19 @@ public final class DataTokenHandler implements HttpHandler {
         if (dev.nexus.service.db.TenantConstants.BOOTSTRAP_ANY_TENANT.equals(tenant)) {
             throw new IllegalArgumentException(
                 "tenant '*' is a reserved sentinel and cannot be used");
+        }
+        // nexus-xidcq (RDR-005 2a): a mint-locked credential may ONLY mint data tokens
+        // for its OWN bound tenant — no cross-tenant mint. Enforced as early as tenant
+        // is known (right after wildcard-sentinel validation) and BEFORE the rate-limit
+        // debit (validation-before-debit pin): an invalid cross-tenant request must not
+        // consume the credential's mint budget.
+        if (TokenStore.SCOPE_MINT_LOCKED.equals(scope) && !tenant.equals(RequestContext.tenant())) {
+            log.debug("event=data_token_denied reason=mint_locked_cross_tenant "
+                      + "credential_tenant={} requested_tenant={}", RequestContext.tenant(), tenant);
+            HttpUtil.send(ex, 403, json(Map.of(
+                "error", "forbidden: this mint credential is locked to tenant '" + RequestContext.tenant()
+                    + "' and cannot mint for tenant '" + tenant + "'")));
+            return;
         }
         long ttlSeconds = DEFAULT_TTL_SECONDS;
         Object ttlRaw = body.get("ttl_seconds");

--- a/service/src/main/java/dev/nexus/service/http/TokenAdminHandler.java
+++ b/service/src/main/java/dev/nexus/service/http/TokenAdminHandler.java
@@ -100,7 +100,8 @@ public final class TokenAdminHandler implements HttpHandler {
         // for data routes but must never administer credentials — a leaked data
         // token stays "one tenant's data, one TTL window").
         String callerScope = RequestContext.scope();
-        if (TokenStore.SCOPE_MINT.equals(callerScope) || TokenStore.SCOPE_DATA.equals(callerScope)) {
+        if (TokenStore.SCOPE_MINT.equals(callerScope) || TokenStore.SCOPE_MINT_LOCKED.equals(callerScope)
+                || TokenStore.SCOPE_DATA.equals(callerScope)) {
             log.debug("event=token_admin_denied reason=scope_forbidden_on_admin_surface scope={}",
                       callerScope);
             HttpUtil.send(exchange, 403, json(Map.of(
@@ -161,11 +162,14 @@ public final class TokenAdminHandler implements HttpHandler {
         if (scope == null || scope.isBlank()) {
             scope = TokenStore.SCOPE_TENANT;
         }
-        if (!TokenStore.SCOPE_TENANT.equals(scope) && !TokenStore.SCOPE_MINT.equals(scope)) {
+        if (!TokenStore.SCOPE_TENANT.equals(scope) && !TokenStore.SCOPE_MINT.equals(scope)
+                && !TokenStore.SCOPE_MINT_LOCKED.equals(scope)) {
             throw new IllegalArgumentException(
-                "invalid scope for issue: '" + scope + "' (only 'tenant' and 'mint' are issuable)");
+                "invalid scope for issue: '" + scope
+                    + "' (only 'tenant', 'mint', and 'mint-locked' are issuable)");
         }
-        if (TokenStore.SCOPE_MINT.equals(scope) && !requireOperator(ex)) {
+        if ((TokenStore.SCOPE_MINT.equals(scope) || TokenStore.SCOPE_MINT_LOCKED.equals(scope))
+                && !requireOperator(ex)) {
             return;
         }
         TokenStore.IssuedToken issued = store.issueToken(tenant, label, ttl, scope);

--- a/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
+++ b/service/src/main/java/dev/nexus/service/vectors/PgVectorRepository.java
@@ -1643,6 +1643,7 @@ public final class PgVectorRepository {
             throw new IllegalArgumentException("nResults must be >= 1, got " + nResults);
         }
         int dim = requireHomogeneousDim(collectionNames);
+        requireHomogeneousModel(collectionNames);
         EmbedResult embed = embedQuery(collectionNames.get(0), queryText, dim);
         Vector queryVec = Vector.of(embed.embeddings().get(0));
         JSONB whereJsonb = (where == null || where.isEmpty()) ? null : JSONB.jsonb(toJson(where));
@@ -1776,6 +1777,7 @@ public final class PgVectorRepository {
         }
         int clampedDepth = Math.min(Math.max(depth, 1), 3);  // mirror graphBFS bound
         int dim = requireHomogeneousDim(collectionNames);
+        requireHomogeneousModel(collectionNames);
         EmbedResult embed = embedQuery(collectionNames.get(0), queryText, dim);
         Vector queryVec = Vector.of(embed.embeddings().get(0));
         JSONB whereJsonb = (where == null || where.isEmpty()) ? null : JSONB.jsonb(toJson(where));
@@ -1810,6 +1812,37 @@ public final class PgVectorRepository {
             }
         }
         return dim;
+    }
+
+    /**
+     * Validate every collection dispatches to the same embedding MODEL (nexus-9y5om,
+     * nexus-3l6gz): same-DIM, different-MODEL collections pass requireHomogeneousDim but
+     * silently mis-embed — one query vector embedded against the FIRST collection's model
+     * cannot serve a second collection's different embedding space even at equal
+     * dimensionality (voyage-code-3 and voyage-context-3 are both 1024-dim). Parses the same
+     * 3rd '__' segment {@link #dimForCollection} uses.
+     */
+    private static void requireHomogeneousModel(List<String> collectionNames) {
+        String model = modelSegment(collectionNames.get(0));
+        for (String col : collectionNames) {
+            String colModel = modelSegment(col);
+            if (!colModel.equals(model)) {
+                throw new IllegalArgumentException(
+                    "mixed embedding models in one combined-query call: '" + collectionNames.get(0)
+                    + "' uses '" + model + "' but '" + col + "' uses '" + colModel
+                    + "' - one query vector cannot serve two different embedding spaces");
+            }
+        }
+    }
+
+    private static String modelSegment(String collection) {
+        String[] segments = collection.split("__");
+        if (segments.length != 4) {
+            throw new IllegalArgumentException(
+                "collection '" + collection + "' is not four-segment conformant "
+                + "(<content_type>__<owner>__<model>__v<n>)");
+        }
+        return segments[2];
     }
 
     /**

--- a/service/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.xml
@@ -58,6 +58,8 @@
     <!-- nexus-868dq: server-assigned scope column (root|tenant|mint|data) — the
          mint-scoped edge credential + short-TTL data tokens (conexus RDR-005 A1). -->
     <include file="db/changelog/service-tokens-003-scope-column.xml"/>
+    <!-- nexus-xidcq: tenant-locked mint credential scope (RDR-005 2a). -->
+    <include file="db/changelog/service-tokens-004-mint-locked-scope.xml"/>
 
     <!-- Store 10: pgvector chunks tables + manifest collection column (bead nexus-mf447) -->
     <include file="db/changelog/vectors-001-baseline.xml"/>

--- a/service/src/main/resources/db/changelog/service-tokens-004-mint-locked-scope.xml
+++ b/service/src/main/resources/db/changelog/service-tokens-004-mint-locked-scope.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    nexus-xidcq — tenant-locked mint credential (RDR-005 2a). Adds 'mint-locked' to the
+    scope CHECK constraint service-tokens-003 established (root|tenant|mint|data).
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="service-tokens-004-1" author="nexus-xidcq">
+        <comment>
+            Add 'mint-locked' to the service_tokens scope vocabulary — a tenant-bound
+            mint credential (RDR-005 2a) that may only mint data tokens for its own
+            bound tenant, not cross-tenant like plain 'mint'.
+        </comment>
+        <sql splitStatements="true" stripComments="false">
+ALTER TABLE nexus.service_tokens DROP CONSTRAINT IF EXISTS chk_service_tokens_scope;
+ALTER TABLE nexus.service_tokens ADD CONSTRAINT chk_service_tokens_scope
+    CHECK (scope IN ('root','tenant','mint','data','mint-locked'));
+        </sql>
+        <rollback>
+ALTER TABLE nexus.service_tokens DROP CONSTRAINT IF EXISTS chk_service_tokens_scope;
+ALTER TABLE nexus.service_tokens ADD CONSTRAINT chk_service_tokens_scope
+    CHECK (scope IN ('root','tenant','mint','data'));
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/service/src/test/java/dev/nexus/service/DataTokenHandlerTest.java
+++ b/service/src/test/java/dev/nexus/service/DataTokenHandlerTest.java
@@ -55,6 +55,7 @@ class DataTokenHandlerTest {
     final HttpClient http = HttpClient.newHttpClient();
 
     String mintRaw;   // a scope=mint credential issued by the operator in @BeforeAll
+    String mintLockedRaw;   // a scope=mint-locked credential bound to conexus-edge-locked
 
     @BeforeAll
     void startAll() throws Exception {
@@ -101,6 +102,12 @@ class DataTokenHandlerTest {
             "{\"tenant\":\"conexus-edge\",\"label\":\"edge-mint\",\"scope\":\"mint\"}");
         mintRaw = issued.get("token").asText();
         assertThat(mintRaw).isNotBlank();
+
+        // nexus-xidcq (RDR-005 2a): operator issues a tenant-locked mint credential.
+        JsonNode issuedLocked = postJsonAs(BOOT, "/v1/service-tokens/issue",
+            "{\"tenant\":\"conexus-edge-locked\",\"label\":\"edge-mint-locked\",\"scope\":\"mint-locked\"}");
+        mintLockedRaw = issuedLocked.get("token").asText();
+        assertThat(mintLockedRaw).isNotBlank();
     }
 
     @AfterAll
@@ -199,6 +206,37 @@ class DataTokenHandlerTest {
 
         assertThat(sendAs(BOOT, "/v1/data-tokens/mint",
             "{\"tenant\":\"acme\"}").statusCode()).isEqualTo(403);
+    }
+
+    // ── nexus-xidcq: mint-locked tenant enforcement (RDR-005 2a) ───────────────
+
+    @Test
+    void mintLocked_ownTenant_admitted() throws Exception {
+        var resp = sendAs(mintLockedRaw, "/v1/data-tokens/mint",
+            "{\"tenant\":\"conexus-edge-locked\"}");
+        assertThat(resp.statusCode()).isEqualTo(200);
+        assertThat(tenantOfRaw(MAPPER.readTree(resp.body()).get("data_token").asText()))
+            .isEqualTo("conexus-edge-locked");
+    }
+
+    @Test
+    void mintLocked_otherTenant_403TeachingMessage() throws Exception {
+        var resp = sendAs(mintLockedRaw, "/v1/data-tokens/mint", "{\"tenant\":\"other-tenant\"}");
+        assertThat(resp.statusCode()).isEqualTo(403);
+        assertThat(resp.body())
+            .as("teaching message must name both the credential's bound tenant and the requested tenant")
+            .contains("conexus-edge-locked")
+            .contains("other-tenant");
+    }
+
+    @Test
+    void mint_crossTenant_stillAllowed_byteIdentical() throws Exception {
+        // Regression guard (design's explicit backward-safety requirement): adding the
+        // mint-locked branch must not alter plain scope=mint's cross-tenant behavior.
+        var resp = sendAs(mintRaw, "/v1/data-tokens/mint", "{\"tenant\":\"yet-another-tenant\"}");
+        assertThat(resp.statusCode()).isEqualTo(200);
+        assertThat(tenantOfRaw(MAPPER.readTree(resp.body()).get("data_token").asText()))
+            .isEqualTo("yet-another-tenant");
     }
 
     @Test
@@ -341,6 +379,70 @@ class DataTokenHandlerTest {
             assertThat(mint.getAsInt())
                 .as("the 400s must not have consumed the refilled budget")
                 .isEqualTo(200);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void mintLocked_crossTenantDenials_doNotConsumeRateLimitBudget() throws Exception {
+        // code-review-expert Important finding (post-implementation review): the
+        // mint-locked cross-tenant 403 branch sits BEFORE the rate-limit debit
+        // (validation-before-debit pin) but was unpinned by any test — a refactor
+        // moving the branch after rateLimiter.tryAcquire would silently regress
+        // "denied requests don't burn budget". Same tiny-limiter harness as
+        // mint_rateLimited_429_thenRefills (burst 2, 1/min).
+        var clock = new MutableClock(Instant.parse("2026-07-07T00:00:00Z"));
+        var store = new dev.nexus.service.db.TokenStore(ds, clock);
+        var cache = new dev.nexus.service.db.TokenCache(store, clock);
+        var limiter = new dev.nexus.service.http.MintRateLimiter(clock, 2, 1, 100);
+        var handler = new dev.nexus.service.http.DataTokenHandler(store, limiter, 3600L);
+        var server = com.sun.net.httpserver.HttpServer.create(
+            new java.net.InetSocketAddress("127.0.0.1", 0), 0);
+        var ctx = server.createContext("/v1/data-tokens", handler);
+        ctx.getFilters().add(new dev.nexus.service.http.AuthFilter(cache, store));
+        server.start();
+        int rlPort = server.getAddress().getPort();
+        try {
+            String rlMintLocked = postJsonAs(BOOT, "/v1/service-tokens/issue",
+                "{\"tenant\":\"conexus-edge-locked-rl\",\"label\":\"edge-mint-locked-rl\","
+                + "\"scope\":\"mint-locked\"}")
+                .get("token").asText();
+
+            java.util.function.Function<String, Integer> mintFor = tenant -> {
+                try {
+                    var req = HttpRequest.newBuilder(
+                            URI.create("http://127.0.0.1:" + rlPort + "/v1/data-tokens/mint"))
+                        .header("Authorization", "Bearer " + rlMintLocked)
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(
+                            "{\"tenant\":\"" + tenant + "\"}"))
+                        .build();
+                    return http.send(req, HttpResponse.BodyHandlers.ofString()).statusCode();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+            // Interleave cross-tenant 403 denials with own-tenant mints, up to and past
+            // the burst budget (2). If the 403 branch ever debited budget, the second
+            // own-tenant mint below would come back 429 instead of 200.
+            assertThat(mintFor.apply("other-tenant-rl-1"))
+                .as("cross-tenant #1: denied before the debit").isEqualTo(403);
+            assertThat(mintFor.apply("conexus-edge-locked-rl"))
+                .as("own-tenant mint #1: full burst budget still available").isEqualTo(200);
+            assertThat(mintFor.apply("other-tenant-rl-2"))
+                .as("cross-tenant #2: denied before the debit").isEqualTo(403);
+            assertThat(mintFor.apply("conexus-edge-locked-rl"))
+                .as("own-tenant mint #2: full burst budget still available").isEqualTo(200);
+            assertThat(mintFor.apply("other-tenant-rl-3"))
+                .as("cross-tenant #3: denied before the debit — still not counted").isEqualTo(403);
+            // Burst budget (2) is now genuinely exhausted, but ONLY by the two
+            // legitimate own-tenant mints above — three prior 403s consumed nothing.
+            assertThat(mintFor.apply("conexus-edge-locked-rl"))
+                .as("3rd own-tenant mint within burst window: budget exhausted by "
+                    + "legitimate mints only, not by the interleaved cross-tenant 403s")
+                .isEqualTo(429);
         } finally {
             server.stop(0);
         }

--- a/service/src/test/java/dev/nexus/service/PgVectorCombinedQueryContractTest.java
+++ b/service/src/test/java/dev/nexus/service/PgVectorCombinedQueryContractTest.java
@@ -55,6 +55,8 @@ class PgVectorCombinedQueryContractTest {
     private static final String COLL_T    = "knowledge__cqr-topic__voyage-context-3__v1";   // 1024
     private static final String COLL_MINI = "knowledge__cqr-mini__minilm-l6-v2-384__v1";    // 384
     private static final String COLL_B    = "knowledge__cqr-b__voyage-context-3__v1";       // 1024, tenant B
+    // nexus-9y5om: same-dim (1024), DIFFERENT model than COLL_M — requireHomogeneousModel probe.
+    private static final String COLL_CODE = "code__cqr-code__voyage-code-3__v1";
 
     private static final String TOPIC_VEC = "Vector Search";
     private static final String Q = "combined query probe";
@@ -188,6 +190,41 @@ class PgVectorCombinedQueryContractTest {
         assertThatThrownBy(() ->
             repo.searchMetadataScoped(TENANT_A, Q, List.of(COLL_M, COLL_MINI), null, null, null, null, 10))
             .as("1024 + 384 cannot share one query vector — fail loud")
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void metadataScoped_mixedModelsSameDim_failLoud() {
+        // nexus-9y5om: both 1024-dim but different models — dim guard passes, model
+        // guard must catch it (the silent-mis-embed class, nexus-3l6gz).
+        assertThatThrownBy(() ->
+            repo.searchMetadataScoped(TENANT_A, Q, List.of(COLL_M, COLL_CODE), null, null, null, null, 10))
+            .as("both 1024-dim but different models — dim guard passes, model guard must catch it")
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("voyage-context-3")
+            .hasMessageContaining("voyage-code-3");
+    }
+
+    @Test
+    void graphHop_mixedModelsSameDim_failLoud() {
+        assertThatThrownBy(() ->
+            repo.searchGraphHop(TENANT_A, Q, List.of("1.1"), List.of(COLL_M, COLL_CODE),
+                null, 1, "both", 10))
+            .as("graphHop: same-dim different-model must fail loud before touching seeds/DB")
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("voyage-context-3")
+            .hasMessageContaining("voyage-code-3");
+    }
+
+    @Test
+    void graphHop_mixedDimensions_failLoud() {
+        // Recommended companion (plan Task 3d): graphHop's requireHomogeneousDim had zero
+        // prior test coverage anywhere in the suite. Closes the gap directly adjacent to
+        // the model-guard test above.
+        assertThatThrownBy(() ->
+            repo.searchGraphHop(TENANT_A, Q, List.of("1.1"), List.of(COLL_M, COLL_MINI),
+                null, 1, "both", 10))
+            .as("graphHop: 1024 + 384 cannot share one query vector — fail loud")
             .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/service/src/test/java/dev/nexus/service/TokenAdminHandlerTest.java
+++ b/service/src/test/java/dev/nexus/service/TokenAdminHandlerTest.java
@@ -460,6 +460,22 @@ class TokenAdminHandlerTest {
     }
 
     @Test
+    void issueScope_mintLocked_isOperatorOnly() throws Exception {
+        // nexus-xidcq (RDR-005 2a): mint-locked issuance mirrors mint's operator-only gate.
+        JsonNode r = postJson("/v1/service-tokens/issue",
+            "{\"tenant\":\"edge-868dq-locked\",\"label\":\"edge-cred-locked\",\"scope\":\"mint-locked\"}");
+        assertThat(scopeOf(r.get("token_hash").asText())).isEqualTo("mint-locked");
+
+        String tokA = postJson("/v1/tenants/create", "{\"name\":\"scope-esc-locked-a\"}")
+            .get("token").asText();
+        var resp = sendAs(tokA, "/v1/service-tokens/issue",
+            "{\"tenant\":\"scope-esc-locked-a\",\"scope\":\"mint-locked\"}");
+        assertThat(resp.statusCode())
+            .as("non-operator mint-locked-scope issuance must be 403: %s", resp.body())
+            .isEqualTo(403);
+    }
+
+    @Test
     void issueScope_defaultAndTenant_unchanged() throws Exception {
         // No scope field -> the pre-868dq default.
         JsonNode noScope = postJson("/v1/service-tokens/issue", "{\"tenant\":\"scope-default\"}");
@@ -495,6 +511,23 @@ class TokenAdminHandlerTest {
             var resp = sendAs(mintRaw, route, "{}");
             assertThat(resp.statusCode())
                 .as("mint-scoped bearer on %s must be 403: %s", route, resp.body())
+                .isEqualTo(403);
+        }
+    }
+
+    @Test
+    void mintLockedScopedBearer_rejectedOnEveryAdminRoute() throws Exception {
+        JsonNode r = postJson("/v1/service-tokens/issue",
+            "{\"tenant\":\"edge-lockout-locked\",\"scope\":\"mint-locked\"}");
+        String mintLockedRaw = r.get("token").asText();
+        // Same reasoning as mintScopedBearer_rejectedOnEveryAdminRoute — mint-locked is
+        // rejected on ALL admin routes (AuthFilter choke point + handler layer 2).
+        for (String route : new String[] {"/v1/tenants/create", "/v1/service-tokens/issue",
+                                          "/v1/service-tokens/rotate", "/v1/service-tokens/revoke",
+                                          "/v1/service-tokens/list"}) {
+            var resp = sendAs(mintLockedRaw, route, "{}");
+            assertThat(resp.statusCode())
+                .as("mint-locked-scoped bearer on %s must be 403: %s", route, resp.body())
                 .isEqualTo(403);
         }
     }

--- a/service/src/test/java/dev/nexus/service/VectorHandlerCombinedQueryModelGuardTest.java
+++ b/service/src/test/java/dev/nexus/service/VectorHandlerCombinedQueryModelGuardTest.java
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+package dev.nexus.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.nexus.service.db.TenantScope;
+import dev.nexus.service.db.TokenHashing;
+import dev.nexus.service.vectors.EmbedResult;
+import dev.nexus.service.vectors.Embedder;
+import dev.nexus.service.vectors.PgVectorRepository;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * nexus-9y5om — HTTP-boundary contract for {@code requireHomogeneousModel}: a
+ * mixed-embedding-model {@code collections} list on the combined-query endpoints must
+ * 400, not silently mis-embed (the nexus-3l6gz class). Mirrors the lightweight
+ * {@link VectorHandlerTokenUsageTest} harness (Testcontainers PG, full Liquibase
+ * changelog, a stub {@link Embedder}, {@code PgVectorRepository} injected via the
+ * 5-arg {@link NexusService} overload, port 0, {@code PER_CLASS}).
+ *
+ * <p>The guard throws before any embed call or DB touch (verified in
+ * {@code PgVectorRepository.requireHomogeneousModel} — it is a pure string check over
+ * the {@code collections} list), so no chunk seeding is required for these tests: the
+ * stub embedder never needs to be exercised for the 400 path.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class VectorHandlerCombinedQueryModelGuardTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String TOKEN  = "tok-model-guard-test-0123456789abcdef00";
+    private static final String TENANT = "model-guard-tenant";
+
+    // Both 1024-dim (dim guard passes) but DIFFERENT models (model guard must catch it).
+    private static final String COLL_A = "knowledge__mg-a__voyage-context-3__v1";
+    private static final String COLL_B = "code__mg-b__voyage-code-3__v1";
+
+    PostgreSQLContainer<?> pg;
+    HikariDataSource svcDs;
+    NexusService service;
+    HttpClient http;
+
+    @BeforeAll
+    void startAll() throws Exception {
+        pg = PgContainerHelper.start();
+
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "DO $$ BEGIN " +
+                "  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nexus_svc') THEN " +
+                "    CREATE ROLE nexus_svc LOGIN PASSWORD 'nexus_svc_pass' NOSUPERUSER NOBYPASSRLS; " +
+                "  END IF; " +
+                "END $$");
+        }
+        try (Connection su = pg.createConnection("")) {
+            Database db = DatabaseFactory.getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(su));
+            new Liquibase("db/changelog/db.changelog-master.xml",
+                          new ClassLoaderResourceAccessor(), db)
+                .update(new Contexts());
+        }
+        try (Connection su = pg.createConnection("")) {
+            su.setAutoCommit(true);
+            su.createStatement().execute(
+                "ALTER ROLE nexus_svc SET search_path TO nexus, public");
+        }
+        try (Connection su = pg.createConnection("");
+             var ps = su.prepareStatement(
+                 "INSERT INTO nexus.service_tokens (token_hash, tenant_id, label)"
+                 + " VALUES (?, ?, ?) ON CONFLICT (token_hash) DO NOTHING")) {
+            su.setAutoCommit(true);
+            ps.setString(1, TokenHashing.sha256Hex(TOKEN));
+            ps.setString(2, TENANT);
+            ps.setString(3, "model-guard-test");
+            ps.executeUpdate();
+        }
+
+        var cfg = new HikariConfig();
+        cfg.setJdbcUrl(pg.getJdbcUrl());
+        cfg.setUsername("nexus_svc");
+        cfg.setPassword("nexus_svc_pass");
+        cfg.setMaximumPoolSize(5);
+        cfg.setAutoCommit(true);
+        svcDs = new HikariDataSource(cfg);
+
+        // Stub embedder: the guard throws before this is ever invoked for the 400 tests
+        // below, so any 1024-dim stub suffices.
+        var embedder = new StubEmbedder(1024);
+
+        var pgRepo = new PgVectorRepository(new TenantScope(svcDs), embedder, embedder);
+
+        service = new NexusService(0, TOKEN, svcDs, null, pgRepo);
+        service.start();
+        http = HttpClient.newHttpClient();
+    }
+
+    @AfterAll
+    void stopAll() {
+        if (service != null) service.stop();
+        if (svcDs   != null) svcDs.close();
+        if (pg      != null) pg.stop();
+    }
+
+    private HttpResponse<String> post(String path, Object body) throws Exception {
+        var req = HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + service.getPort() + path))
+            .header("Authorization", "Bearer " + TOKEN)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body)))
+            .build();
+        return http.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    void searchMetadataScoped_mixedModels_returns400NamingBothModels() throws Exception {
+        var resp = post("/v1/vectors/search-metadata-scoped", Map.of(
+            "query",       "probe",
+            "collections", List.of(COLL_A, COLL_B),
+            "n_results",   5));
+
+        assertThat(resp.statusCode())
+            .as("mixed-model collections must 400, not silently mis-embed: %s", resp.body())
+            .isEqualTo(400);
+        assertThat(resp.body())
+            .as("teaching message must name both models found")
+            .contains("voyage-context-3")
+            .contains("voyage-code-3");
+    }
+
+    @Test
+    void searchGraphHop_mixedModels_returns400NamingBothModels() throws Exception {
+        var resp = post("/v1/vectors/search-graph-hop", Map.of(
+            "query",       "probe",
+            "seeds",       List.of("1.1"),
+            "collections", List.of(COLL_A, COLL_B),
+            "n_results",   5));
+
+        assertThat(resp.statusCode())
+            .as("mixed-model collections must 400, not silently mis-embed: %s", resp.body())
+            .isEqualTo(400);
+        assertThat(resp.body())
+            .as("teaching message must name both models found")
+            .contains("voyage-context-3")
+            .contains("voyage-code-3");
+    }
+
+    /** Minimal fixed-vector stub embedder — the model guard never reaches embed() here. */
+    private static final class StubEmbedder implements Embedder {
+        private final int dim;
+
+        StubEmbedder(int dim) {
+            this.dim = dim;
+        }
+
+        @Override
+        public String modelToken() {
+            return "voyage-context-3";
+        }
+
+        @Override
+        public List<float[]> embed(List<String> texts) {
+            List<float[]> out = new java.util.ArrayList<>(texts.size());
+            for (String ignored : texts) {
+                float[] v = new float[dim];
+                v[0] = 1.0f;
+                out.add(v);
+            }
+            return out;
+        }
+
+        @Override
+        public EmbedResult embedWithUsage(List<String> texts) {
+            return new EmbedResult(embed(texts), 0L);
+        }
+    }
+}

--- a/service/src/test/java/dev/nexus/service/http/TokenAdminHandlerScopeGuardTest.java
+++ b/service/src/test/java/dev/nexus/service/http/TokenAdminHandlerScopeGuardTest.java
@@ -49,6 +49,11 @@ class TokenAdminHandlerScopeGuardTest {
         assertScopeRejected("data");
     }
 
+    @Test
+    void mintLockedScope_directDispatch_403OnEveryRoute() throws Exception {
+        assertScopeRejected("mint-locked");
+    }
+
     private void assertScopeRejected(String scope) throws Exception {
         var handler = new TokenAdminHandler(null, null, Clock.systemUTC());
         for (String route : ROUTES) {

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/commands/service_cmd.py
+++ b/src/nexus/commands/service_cmd.py
@@ -171,11 +171,12 @@ def _print_issued(result: dict[str, object]) -> None:
 @click.option("--label", default=None, help="Optional human-readable label.")
 @click.option("--ttl", "ttl_seconds", type=int, default=None,
               help="Optional lifetime in seconds (default: no expiry).")
-@click.option("--scope", type=click.Choice(["tenant", "mint"]), default=None,
+@click.option("--scope", type=click.Choice(["tenant", "mint", "mint-locked"]), default=None,
               help="Token scope (nexus-868dq): default 'tenant'; 'mint' issues the "
-                   "data-token mint credential (operator/root bearer required — the "
-                   "conexus-edge provisioning surface). 'data' tokens are minted only "
-                   "by POST /v1/data-tokens/mint, never issued here.")
+                   "cross-tenant data-token mint credential (operator/root bearer required); "
+                   "'mint-locked' issues a tenant-bound mint credential that may only mint "
+                   "data tokens for the tenant it is bound to (RDR-005 2a, nexus-xidcq). "
+                   "'data' tokens are minted only by POST /v1/data-tokens/mint, never issued here.")
 def issue(tenant: str, label: str | None, ttl_seconds: int | None, scope: str | None) -> None:
     """Issue a new bound token for TENANT. Printed once; only the hash is stored."""
     with HttpTokenStore() as store:

--- a/src/nexus/daemon/binary_install.py
+++ b/src/nexus/daemon/binary_install.py
@@ -87,7 +87,7 @@ TAG_NAMESPACE_PREFIX = "engine-service-v"
 #: service (RF-161-2). ``None`` until the first real ``engine-service-v*``
 #: release exists; while it is ``None``, ``nx init --service`` cannot
 #: auto-install and instructs the user to pass an explicit tag.
-PINNED_SERVICE_TAG: str | None = "engine-service-v0.1.35"
+PINNED_SERVICE_TAG: str | None = "engine-service-v0.1.36"
 
 #: Env override for the service tag (operator / CI). Takes precedence over the
 #: build-time pin. Still an explicit tag — no "latest" semantics.

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from typing import Any
 
 import structlog
@@ -14,6 +15,7 @@ from mcp.server.fastmcp import FastMCP
 
 from nexus.corpus import (
     embedding_model_for_collection,
+    embedding_model_for_collection_name,
     index_model_for_collection,
     resolve_corpus,
     t3_collection_name,
@@ -1161,6 +1163,118 @@ def _resolve_corpus_target(corpus: str, t3: Any) -> list[str]:
     return list(dict.fromkeys(target))
 
 
+def _group_collections_by_model(target: list[str]) -> list[list[str]]:
+    """Group a resolved collection list by embedding model (nexus-3l6gz).
+
+    A combined-query service call embeds the query string ONCE and ranks
+    every listed collection's chunks against that single query vector; the
+    service's ``requireHomogeneousDim`` guard only checks vector DIMENSION,
+    not embedding MODEL, so a multi-prefix corpus spanning two same-dimension
+    models (e.g. ``voyage-code-3`` + ``voyage-context-3``, both 1024-dim)
+    silently embeds the query with only the first collection's model and
+    mis-ranks/drops every other model's chunks (root cause: nexus-3l6gz).
+
+    Groups collections by :func:`embedding_model_for_collection_name` so
+    each combined-query call is model-homogeneous. A collection whose name
+    is not conformant (the parse returns ``None``) is kept in its OWN
+    singleton group keyed by its raw collection name — never guessed into
+    an inferred model group and never silently dropped.
+
+    Preserves ``target``'s relative ordering both across and within groups.
+    """
+    groups: dict[str, list[str]] = {}
+    for name in target:
+        key = embedding_model_for_collection_name(name) or name
+        groups.setdefault(key, []).append(name)
+    return list(groups.values())
+
+
+def _distance_key(row: dict) -> float:
+    """Sort key for combined-query merge rows: missing OR ``None`` -> 0.0.
+
+    ``row.get("distance", 0.0)`` alone only covers a MISSING key — a row
+    carrying an explicit ``None`` distance (server anomaly) would still
+    reach the sort as ``None`` and raise ``TypeError`` when compared against
+    a ``float``. Centralized here so every merge-sort site (the two
+    model-group merges below, and ``search_topic_scoped``'s pre-existing
+    per-collection merge) hardens uniformly instead of drifting per-site.
+    """
+    d = row.get("distance")
+    return d if d is not None else 0.0
+
+
+def _grouped_combined_query(
+    target: list[str],
+    call: Callable[[list[str]], list[dict]],
+) -> list[dict]:
+    """Run *call* once per embedding-model group in *target*, merge the results.
+
+    nexus-3l6gz / nexus-hg745: a combined-query service call embeds the
+    query string ONCE and ranks every listed collection's chunks against
+    that single query vector, so a call spanning collections from more than
+    one embedding model silently mis-ranks/drops the non-first model's
+    chunks. This splits *target* into model-homogeneous groups via
+    :func:`_group_collections_by_model`, invokes *call* once per group (the
+    single shared shape now used by ``search_metadata_scoped``,
+    ``search_graph_hop``, and ``query()``'s service-mode catalog branch —
+    extracted so the loop-and-merge logic has one hardening point instead of
+    drifting across per-site copies), and concatenates the per-group rows
+    ordered distance-ascending across groups. Each group individually
+    arrives distance-ascending from the service, but the concatenation
+    across groups is NOT itself globally sorted, so callers must NOT rely on
+    ordering until after this merge sort.
+
+    All-or-nothing by design: *call* is invoked synchronously per group with
+    no per-iteration try/except, so a later group's exception propagates
+    immediately and the caller gets NO partial result set from only the
+    groups that happened to succeed first — matching
+    ``search_topic_scoped``'s existing (uncaught) per-collection loop.
+
+    CAVEAT: when *target* spans more than one embedding model, the merge
+    ranks rows by raw cosine distance across DIFFERENT embedding-model
+    vector spaces (e.g. ``voyage-code-3`` vs ``voyage-context-3``).
+    Distance values from different models are not a rigorously comparable
+    metric — the merge order can carry a systematic per-model bias. This is
+    the same class of accepted caveat ``search_topic_scoped`` already
+    documents for its own per-collection merge.
+    """
+    rows: list[dict] = []
+    for group in _group_collections_by_model(target):
+        rows.extend(call(group))
+    rows.sort(key=_distance_key)
+    return rows
+
+
+def _dedup_by_id(rows: list[dict]) -> list[dict]:
+    """Collapse *rows* to one row per ``id``, keeping the best (lowest) distance.
+
+    Assumes *rows* is already globally distance-ascending (e.g. the output
+    of :func:`_grouped_combined_query`) so the FIRST occurrence of an id is
+    its best. Does NOT truncate — callers that need the pre-truncation count
+    (e.g. ``query()``'s "N of M documents" footer) call this directly; callers
+    that only need the final page call :func:`_dedup_by_id_keep_best`.
+    """
+    seen: set[str] = set()
+    deduped: list[dict] = []
+    for r in rows:
+        rid = r.get("id", "")
+        if rid in seen:
+            continue
+        seen.add(rid)
+        deduped.append(r)
+    return deduped
+
+
+def _dedup_by_id_keep_best(rows: list[dict], limit: int) -> list[dict]:
+    """:func:`_dedup_by_id` then truncate to *limit*.
+
+    Truncates AFTER the dedup: each model group may independently
+    contribute up to the caller's fetch size, so the merged/deduped set can
+    exceed *limit* even though no single group did.
+    """
+    return _dedup_by_id(rows)[:limit]
+
+
 @mcp.tool(
     title="Metadata-Scoped Combined Search",
     annotations={"readOnlyHint": True},
@@ -1194,6 +1308,19 @@ def search_metadata_scoped(
     content — use a tumbler-aware hydration path (tracked: nexus-zekpl). The
     ``catalog_documents.corpus`` filter the SQL function supports is NOT exposed
     here (``corpus`` is the collection-routing arg); add it explicitly if needed.
+
+    MULTI-MODEL CORPUS (nexus-3l6gz): when *corpus* resolves to collections
+    spanning more than one embedding model (e.g. ``code`` + ``docs`` ->
+    voyage-code-3 + voyage-context-3), this tool issues one combined-query
+    call PER model group and merges the results — see
+    :func:`_grouped_combined_query`. The merge is ALL-OR-NOTHING: if any
+    group's call raises, the whole tool call fails (via the outer
+    try/except -> ``_mcp_tool_error``) and returns NO partial rows from
+    groups that already succeeded. The merge also ranks rows by raw cosine
+    distance across DIFFERENT embedding-model vector spaces when more than
+    one group contributes — those distances are not rigorously comparable
+    across models, so cross-model ordering can carry a systematic per-model
+    bias (same accepted caveat as ``search_topic_scoped``'s merge).
 
     Args:
         query: Search query string.
@@ -1237,28 +1364,27 @@ def search_metadata_scoped(
                         "(KEY=VALUE, comma-separated); comparison operators "
                         "(>=, <=, >, <, !=) are not supported in service mode")
             where_map = parsed or None
-        rows = t3.search_metadata_scoped(
-            query, target,
+        # nexus-3l6gz / nexus-hg745: one combined-query call per
+        # embedding-model group, ALL-OR-NOTHING (a group's exception
+        # propagates and aborts the whole merge — no silent partial
+        # results). Each group is asked for up to `limit` rows (not
+        # limit/n_groups) so a group's true top-N isn't truncated away
+        # before the merge decides the global top-N. See
+        # _grouped_combined_query for the full contract.
+        rows = _grouped_combined_query(target, lambda group: t3.search_metadata_scoped(
+            query, group,
             content_type=content_type or None,
             author=author or None,
             year=(year or None),
             subtree=(subtree or None),
             where=(where_map or None),
             n_results=limit,
-        )
+        ))
         # Metadata-scoped is document-level: the function returns one row per
         # matching CHUNK, so a multi-chunk document repeats its tumbler. Collapse
-        # to one row per id, keeping the best (nearest) distance. Rows arrive
-        # distance-ascending, so the FIRST occurrence of each id is its best.
-        seen_ids: set[str] = set()
-        deduped: list[dict] = []
-        for r in rows:
-            rid = r.get("id", "")
-            if rid in seen_ids:
-                continue
-            seen_ids.add(rid)
-            deduped.append(r)
-        rows = deduped
+        # to one row per id, keeping the best (nearest) distance, and truncate
+        # to `limit` AFTER the merge (see _dedup_by_id_keep_best).
+        rows = _dedup_by_id_keep_best(rows, limit)
         if structured:
             # id IS the document tumbler for metadata-scoped (document-level).
             ids = [r.get("id", "") for r in rows]
@@ -1332,7 +1458,7 @@ def search_topic_scoped(
         merged: list[dict] = []
         for col in target:
             merged.extend(t3.search_topic_scoped(query, topic, col, n_results=limit))
-        merged.sort(key=lambda r: r.get("distance", 0.0))
+        merged.sort(key=_distance_key)
         merged = merged[:limit]
         if structured:
             # Chunk-level: ids are chunk chashes; no document tumbler.
@@ -1389,6 +1515,19 @@ def search_graph_hop(
     Service-mode only — the combined-query functions live in the pgvector Postgres; in
     local/Chroma mode this returns an error.
 
+    MULTI-MODEL CORPUS (nexus-3l6gz): when *corpus* resolves to collections
+    spanning more than one embedding model (e.g. ``code`` + ``docs`` ->
+    voyage-code-3 + voyage-context-3), this tool issues one combined-query
+    call PER model group and merges the results — see
+    :func:`_grouped_combined_query`. The merge is ALL-OR-NOTHING: if any
+    group's call raises, the whole tool call fails (via the outer
+    try/except -> ``_mcp_tool_error``) and returns NO partial rows from
+    groups that already succeeded. The merge also ranks rows by raw cosine
+    distance across DIFFERENT embedding-model vector spaces when more than
+    one group contributes — those distances are not rigorously comparable
+    across models, so cross-model ordering can carry a systematic per-model
+    bias (same accepted caveat as ``search_topic_scoped``'s merge).
+
     Args:
         query: Search query string.
         seeds: Seed document tumbler(s) to traverse from (list, or a single string).
@@ -1429,25 +1568,25 @@ def search_graph_hop(
             return ("Error: search_graph_hop `where` is equality-only "
                     "(KEY=VALUE, comma-separated); comparison operators "
                     "(>=, <=, >, <, !=) are not supported in service mode")
-        rows = t3.search_graph_hop(
-            query, seed_list, target,
+        # nexus-3l6gz / nexus-hg745: one combined-query call per
+        # embedding-model group, ALL-OR-NOTHING (a group's exception
+        # propagates and aborts the whole merge — no silent partial
+        # results). Each group is asked for up to `limit` rows (not
+        # limit/n_groups) so a group's true top-N isn't truncated away
+        # before the merge decides the global top-N. See
+        # _grouped_combined_query for the full contract.
+        rows = _grouped_combined_query(target, lambda group: t3.search_graph_hop(
+            query, seed_list, group,
             link_type=(link_type or None),
             depth=depth,
             direction=direction,
             where=(where_dict or None),
             n_results=limit,
-        )
-        # Document-level: collapse to one row per tumbler, keeping the best (nearest)
-        # distance. Rows arrive distance-ascending, so the FIRST occurrence is best.
-        seen_ids: set[str] = set()
-        deduped: list[dict] = []
-        for r in rows:
-            rid = r.get("id", "")
-            if rid in seen_ids:
-                continue
-            seen_ids.add(rid)
-            deduped.append(r)
-        rows = deduped
+        ))
+        # Document-level: collapse to one row per tumbler, keeping the best
+        # (nearest) distance, and truncate to `limit` AFTER the merge (see
+        # _dedup_by_id_keep_best).
+        rows = _dedup_by_id_keep_best(rows, limit)
         if structured:
             ids = [r.get("id", "") for r in rows]
             return {
@@ -1509,6 +1648,14 @@ def query(
             are ranked by semantic distance across all collections, not separated by source.
         depth: BFS depth for follow_links traversal (default 1)
         subtree: Tumbler prefix — search only documents in this subtree (e.g. "1.1")
+
+    MULTI-MODEL CORPUS (nexus-3l6gz / nexus-hg745): in service mode, when a
+    catalog param is set AND *corpus* resolves to collections spanning more
+    than one embedding model (e.g. ``corpus="all"`` or ``"code,docs"``),
+    this tool's service-mode branch issues one combined-query call PER
+    model group and merges — see :func:`_grouped_combined_query`. Same
+    ALL-OR-NOTHING semantics and cross-model raw-cosine-distance caveat as
+    ``search_metadata_scoped`` / ``search_graph_hop``.
 
     Args:
         question: Natural-language research question
@@ -1620,48 +1767,55 @@ def query(
                         seed_results_svc = cat.find(question)
                         seed_tumblers = [str(r.tumbler) for r in seed_results_svc[:5] if r.tumbler]
 
+                    # nexus-3l6gz / nexus-hg745: route through
+                    # _grouped_combined_query — a single client call cannot
+                    # rank a corpus spanning more than one embedding model
+                    # against one query vector (this branch is query()'s
+                    # canonical entry point and reproduced the exact
+                    # nexus-3l6gz symptom via corpus="all"/"code,docs" +
+                    # author/content_type/follow_links/subtree before this
+                    # fix). ALL-OR-NOTHING: a group's exception aborts the
+                    # whole merge, matching search_metadata_scoped /
+                    # search_graph_hop above.
                     if not seed_tumblers:
                         # No graph seeds resolved — fall through to
                         # search_metadata_scoped over the broad target
                         # (mirrors the dance path's fallback to broad search
                         # when catalog_collections stays None).
-                        rows = t3.search_metadata_scoped(
-                            question, target,
+                        rows = _grouped_combined_query(
+                            target, lambda group: t3.search_metadata_scoped(
+                                question, group,
+                                content_type=content_type or None,
+                                author=author or None,
+                                subtree=(subtree or None),
+                                where=(where_dict or None),
+                                n_results=fetch_n,
+                            ))
+                    else:
+                        rows = _grouped_combined_query(
+                            target, lambda group: t3.search_graph_hop(
+                                question, seed_tumblers, group,
+                                link_type=(follow_links or None),
+                                depth=depth,
+                                where=(where_dict or None),
+                                n_results=fetch_n,
+                            ))
+                else:
+                    # Metadata-scoped path: catalog filters pushed into SQL.
+                    rows = _grouped_combined_query(
+                        target, lambda group: t3.search_metadata_scoped(
+                            question, group,
                             content_type=content_type or None,
                             author=author or None,
                             subtree=(subtree or None),
                             where=(where_dict or None),
                             n_results=fetch_n,
-                        )
-                    else:
-                        rows = t3.search_graph_hop(
-                            question, seed_tumblers, target,
-                            link_type=(follow_links or None),
-                            depth=depth,
-                            where=(where_dict or None),
-                            n_results=fetch_n,
-                        )
-                else:
-                    # Metadata-scoped path: catalog filters pushed into SQL.
-                    rows = t3.search_metadata_scoped(
-                        question, target,
-                        content_type=content_type or None,
-                        author=author or None,
-                        subtree=(subtree or None),
-                        where=(where_dict or None),
-                        n_results=fetch_n,
-                    )
+                        ))
 
                 # Dedup: one row per tumbler, keeping best (lowest) distance.
-                # Rows arrive distance-ascending so first occurrence is best.
-                seen_svc: set[str] = set()
-                deduped_svc: list[dict] = []
-                for r in rows:
-                    rid = r.get("id", "")
-                    if rid in seen_svc:
-                        continue
-                    seen_svc.add(rid)
-                    deduped_svc.append(r)
+                # deduped_svc (pre-truncation) feeds the "N of M documents"
+                # header/footer below; rows is the truncated display page.
+                deduped_svc = _dedup_by_id(rows)
                 rows = deduped_svc[:limit]
 
                 if not rows:

--- a/src/nexus/migration/guided_upgrade.py
+++ b/src/nexus/migration/guided_upgrade.py
@@ -668,7 +668,7 @@ def verify_service_version(
 
 
 def footprint_has_voyage_collections(report: "DetectionReport") -> bool:
-    """True iff the footprint has a data-bearing voyage-model collection.
+    """True iff the footprint has a data-bearing GENUINE-voyage collection.
 
     Voyage collections are NEVER cross-model-remapped to bge (RDR-162:
     re-embedding voyage text into bge silently changes recall), so a voyage
@@ -681,11 +681,29 @@ def footprint_has_voyage_collections(report: "DetectionReport") -> bool:
     ``startswith('voyage')`` prefix: a non-canonical ``voyage-*`` name is an
     unrecognized model (the classifier already gives it the re-index diagnostic),
     not a voyage-capability problem, so it must not mis-fire this gate.
+
+    nexus-119p9 (GH #1381, second bug): a ``voyage-*``-NAMED collection whose
+    stored vector MEASURED as local bge/ONNX (``measured_dim == _ONNX_DIM``,
+    nexus-nb7hr) is a pre-RDR-109 mislabel, not real voyage data — it is
+    ``cross_model_remappable`` (re-embedded locally at no cost, no Voyage key
+    needed) and MUST NOT trip this gate; doing so SystemExits a bge-only
+    target before the migration's auto-remap ever runs. So this predicate
+    excludes any classification :func:`cross_model_remappable` accepts —
+    the same measured-dim ground truth the orchestrator (:mod:`driver`) uses
+    to build ``target_names``. A voyage-named collection with an unprobeable
+    ``measured_dim`` (``None`` — empty or not probed) stays FAIL-CLOSED: it is
+    NOT remappable (``cross_model_remappable`` requires a proven 768-dim
+    measurement), so it still trips the gate — real voyage data would block
+    mid-run otherwise.
     """
-    from nexus.migration.detection import _VOYAGE_MODELS  # noqa: PLC0415 — circular-dep avoidance (nexus.migration.detection)
+    from nexus.migration.detection import (  # noqa: PLC0415 — circular-dep avoidance (nexus.migration.detection)
+        _VOYAGE_MODELS,
+        cross_model_remappable,
+    )
 
     return any(
-        c.has_data and c.model in _VOYAGE_MODELS for c in report.classifications
+        c.has_data and c.model in _VOYAGE_MODELS and not cross_model_remappable(c)
+        for c in report.classifications
     )
 
 

--- a/tests/commands/test_guided_upgrade_cmd.py
+++ b/tests/commands/test_guided_upgrade_cmd.py
@@ -47,6 +47,40 @@ def _preflight_voyage() -> PreflightDetection:
     )
 
 
+def _preflight_mixed_remappable_footprint() -> PreflightDetection:
+    """nexus-119p9 (GH #1381): Steve's exact footprint — 5 voyage-*-NAMED
+    collections whose stored vectors measure 768-dim (local bge/ONNX,
+    pre-RDR-109 mislabel, nexus-nb7hr), 8 non-conformant-named collections
+    ALSO measuring 768-dim, and 5 clean bge-768 collections. Every one of
+    these is ``cross_model_remappable`` — none is genuine voyage data — so
+    against a bge-only target the 2a voyage-capability gate must NOT fire
+    (the auto-remap handles all 18 unsupported-by-name collections locally,
+    at no cost, without ever needing voyage capability)."""
+    classifications = []
+    for i in range(5):
+        classifications.append(CollectionClassification(
+            collection=f"knowledge__o__voyage-context-3__v{i}", leg="local",
+            model="voyage-context-3", dim=None, support="unsupported",
+            source_count=12, has_data=True, measured_dim=768,
+        ))
+    for i in range(8):
+        classifications.append(CollectionClassification(
+            collection=f"legacy_collection_{i}", leg="local",
+            model=None, dim=None, support="unsupported",
+            source_count=12, has_data=True, measured_dim=768,
+        ))
+    for i in range(5):
+        classifications.append(CollectionClassification(
+            collection=f"code__o__bge-base-en-v15-768__v{i}", leg="local",
+            model="bge-base-en-v15-768", dim=768, support="supported-onnx",
+            source_count=12, has_data=True, measured_dim=None,
+        ))
+    return PreflightDetection(
+        report=DetectionReport(classifications=tuple(classifications)),
+        needs_migration=True,
+    )
+
+
 def _ready(url: str = "http://127.0.0.1:8099") -> ServiceReadiness:
     return ServiceReadiness(
         ready=True, service_url=url, reason=None, version_ok=True,
@@ -387,6 +421,23 @@ class TestGuidedUpgradeCmd:
             result = CliRunner().invoke(guided_upgrade_cmd, ["--yes"])
         assert result.exit_code == 0, result.output
         cap.assert_not_called()  # no voyage collections -> no capability probe
+
+    def test_mixed_remappable_footprint_does_not_trigger_capability_gate(self) -> None:
+        # nexus-119p9 regression: a footprint of ONLY measured-bge (remappable)
+        # collections — including 5 voyage-*-NAMED ones — against a bge-only
+        # target must NOT SystemExit at gate 2a; the auto-remap handles them
+        # all locally. Pre-fix, this SystemExit(1)'d before migration ran.
+        with patch(f"{_MOD}.detect_pending_migration",
+                   return_value=_preflight_mixed_remappable_footprint()), \
+             patch(f"{_MOD}.establish_verified_service", return_value=_ready()), \
+             patch(f"{_MOD}.verify_voyage_capability") as cap, \
+             patch("nexus.db.pg_provision.load_service_credentials_into_env",
+                   return_value=True), \
+             patch("nexus.commands.migrate_cmd._run_migration") as mig:
+            result = CliRunner().invoke(guided_upgrade_cmd, ["--yes"])
+        assert result.exit_code == 0, result.output
+        cap.assert_not_called()  # every collection is remappable -> no capability probe
+        mig.assert_called_once()
 
     def test_missing_token_after_provision_fails_before_migrating(self) -> None:
         # The one-command flow self-loads pg_credentials; if no token is available

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -496,6 +496,12 @@ _MODE_LINT_EXCLUDE_FILES: frozenset[str] = frozenset({
     # response body; the gate is a pure data/HTTP predicate that never embeds, so
     # there is no ambient cloud_mode behavior to assert.
     "test_guided_upgrade_voyage_capability.py",
+    # nexus-3l6gz multi-model combined-query grouping: voyage tokens are
+    # collection-NAME fixtures driving _group_collections_by_model against a
+    # fully-fake model-aware T3 stub — no embedder ever runs (the fake resolves
+    # "embedding" by parsing the collection name), so the tests are
+    # deployment-mode-agnostic; nothing asserts cloud-mode behavior.
+    "test_combined_query_multimodel_bug.py",
     # RDR-001 managed-endpoint probe: voyage tokens appear only as
     # embedding_models inside a FAKE /version response body (injected
     # http_get) — the managed service's reported models, not cloud-mode

--- a/tests/db/test_http_combined_query_integration.py
+++ b/tests/db/test_http_combined_query_integration.py
@@ -1,0 +1,760 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-4nflf — Combined-query end-to-end tripwire (write via public API ->
+combined-query visibility via public API, HTTP/MCP layer).
+
+Provenance (nexus-x6kdz): on 2026-07-08 the live 6.5.0 shakeout found ALL
+combined-query SQL functions returning zero rows. Root cause: NO write-time
+writer stamped ``catalog_document_chunks.collection`` (the combined-query
+join key) — the only rows that ever had it were stamped by the migration
+leg's ``manifest_backfill()``, and every subsequent manifest REPLACE write
+(``writeManifestRows``, one shared body for first and Nth call alike)
+recreated the rows without the stamp. Combined queries
+(``search_metadata_scoped`` / ``search_graph_hop``) inner-join on that
+stamp, so re-indexed docs silently vanished from combined-query results on
+a live tenant with every existing gate green:
+
+- Every Python combined-query unit/integration test monkeypatched
+  ``HttpVectorClient._post`` and asserted request SHAPE only — none of them
+  round-tripped through a real Postgres-backed service, so the join could
+  not actually fail in those tests.
+- The Java-side ``ManifestCollectionStampTest`` covers ``CatalogRepository``
+  directly (in-JVM), which proves the SQL is correct in isolation but never
+  crosses the Python HTTP client -> real server -> real Postgres wire the way
+  production traffic does.
+
+This module closes that gap: it boots the real service JAR (full Liquibase,
+including the catalog-006/-007/-008/-012/-014 combined-query SQL functions)
+against a throwaway ``pgvector/pgvector:pg17`` Docker container, with the
+service's application pool bound to ``nexus_svc`` (NOSUPERUSER NOBYPASSRLS —
+production-like FORCE RLS, not the migration/superuser pool), and drives the
+entire write -> read arc through PUBLIC API methods only
+(``HttpCatalogClient.register`` / ``.write_manifest`` / ``.link``,
+``HttpVectorClient.upsert_chunks``). No raw SQL is used for any assertion in
+this module — the fixtures' role-provisioning psql call is the sole SQL
+touch-point, copied verbatim from ``test_write_seam_gate_integration.py``
+because Liquibase's ``grants-nexus-svc.xml`` changeset (runAlways=true)
+requires the ``nexus_svc`` role to exist before the JVM boots.
+
+Fixture strategy: same Docker pgvector/pgvector:pg17 pattern as
+``test_write_seam_gate_integration.py``, own container name
+(``nexus_cq_tripwire_pg17``) so the two gates never collide on a shared
+Docker container when run concurrently.
+
+Prerequisites (identical to the write-seam gate):
+  - ``service/target/nexus-service-1.0-SNAPSHOT.jar`` built and fresh.
+  - Docker available and ``pgvector/pgvector:pg17`` pullable.
+  - Java (>= 17) on PATH or JAVA_HOME set.
+  - No VOYAGE_API_KEY needed (service runs in LOCAL/ONNX bge-768 mode).
+
+Run locally:
+    cd service && mvn package -DskipTests && cd ..
+    uv run pytest tests/db/test_http_combined_query_integration.py \\
+        -o addopts="" -m integration -v -s
+
+Non-vacuity guarantee:
+    - The ``_service_jar_freshness`` autouse fixture in conftest.py SKIPS
+      locally and FAILS in CI when the JAR is missing/stale (same mechanism
+      as the write-seam gate; not duplicated here).
+    - Every positive visibility assertion (a row IS returned) is paired with
+      a negative control in the SAME test (a ``where`` filter that must
+      return EMPTY) so the assertion cannot pass vacuously regardless of
+      whether the combined-query SQL functions are wired correctly.
+    - ``test_metadata_scoped_visible_after_public_api_write`` already trips
+      on the shipped x6kdz defect (pre-fix, the FIRST ``write_manifest``
+      call omitted the ``collection`` column entirely — zero rows from call
+      one). ``test_manifest_rewrite_keeps_combined_query_visibility`` runs
+      the REPLACE write TWICE on top of that: ``writeManifestRows`` is one
+      shared body for first and Nth call today, so the second pass guards
+      against a FUTURE first/second-write asymmetry (e.g. a diff-based
+      short-circuit optimization), not a distinct door in the current code.
+    - The genuinely asymmetric write seams are the ``ON CONFLICT DO
+      UPDATE`` append/import paths (``appendManifestChunks`` /
+      ``doImportChunk``), covered by
+      ``test_append_and_import_seams_stamp_collection``: their INSERT
+      branch stamping is fully falsifiable here; their DO-UPDATE re-stamp
+      line (``.set(COLLECTION, EX_CHK_COLL)``) is only falsifiable when the
+      pre-conflict stamp is wrong, a state the public API cannot construct
+      on a correct tree — that residual is recorded on bead nexus-4nflf and
+      covered in-JVM by ``ManifestCollectionStampTest``.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.db._service_fixture import SERVICE_ROLES_SQL
+
+# ── Prerequisite detection ────────────────────────────────────────────────────
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_JAR = _REPO_ROOT / "service" / "target" / "nexus-service-1.0-SNAPSHOT.jar"
+
+_JAVA_HOME = os.environ.get("JAVA_HOME", "")
+_JAVA = (
+    Path(_JAVA_HOME) / "bin" / "java"
+    if _JAVA_HOME
+    else Path(shutil.which("java") or "java")
+)
+
+_DOCKER = shutil.which("docker")
+
+# JAR check is enforced via the conftest autouse fixture.
+# Docker is the only PG path for this test — no Homebrew fallback.
+_JAVA_OK = _JAVA_HOME and (Path(_JAVA_HOME) / "bin" / "java").exists() or shutil.which("java") is not None
+_DOCKER_OK = _DOCKER is not None
+
+_ALL_PREREQS = _JAR.exists() and _JAVA_OK and _DOCKER_OK
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _ALL_PREREQS,
+        reason=(
+            "skipped: missing jar, java, or docker "
+            f"(jar={_JAR.exists()}, java={_JAVA_OK}, docker={_DOCKER_OK})"
+        ),
+    ),
+]
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_tcp(host: str, port: int, timeout: float = 60.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.3):
+                return
+        except OSError:
+            time.sleep(0.2)
+    raise TimeoutError(f"port {port} on {host} not reachable after {timeout}s")
+
+
+def _stop_service(proc: subprocess.Popen) -> None:
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        proc.wait(timeout=8)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def _chunk_id(text: str) -> str:
+    """sha256(text)[:32] — matches HttpVectorClient's chash convention."""
+    return hashlib.sha256(text.encode()).hexdigest()[:32]
+
+
+# ── Module-scoped Docker pgvector fixture ─────────────────────────────────────
+
+_CONTAINER_NAME = "nexus_cq_tripwire_pg17"
+
+
+@pytest.fixture(scope="module")
+def pg_instance():
+    """Throwaway pgvector/pgvector:pg17 container.
+
+    Copied verbatim (container name + db name changed) from
+    ``test_write_seam_gate_integration.py`` — see that module's docstring
+    for why the role-creation step is a RETRY LOOP and not a fixed sleep.
+    """
+    pg_port = _free_port()
+    pg_user = "nexus_test"
+    pg_pass = "nexus_test_pass"
+    pg_db = "nexus_cq_tripwire"
+
+    subprocess.run(
+        ["docker", "rm", "-f", _CONTAINER_NAME],
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "docker", "run", "-d",
+            "--name", _CONTAINER_NAME,
+            "-e", f"POSTGRES_DB={pg_db}",
+            "-e", f"POSTGRES_USER={pg_user}",
+            "-e", f"POSTGRES_PASSWORD={pg_pass}",
+            "-p", f"{pg_port}:5432",
+            "pgvector/pgvector:pg17",
+        ],
+        check=True, capture_output=True,
+    )
+
+    # Wait for PG to accept connections
+    deadline = time.monotonic() + 60.0
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            [
+                "docker", "exec", _CONTAINER_NAME,
+                "pg_isready", "-U", pg_user, "-d", pg_db,
+            ],
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            break
+        time.sleep(0.5)
+    else:
+        logs = subprocess.run(
+            ["docker", "logs", _CONTAINER_NAME],
+            capture_output=True, text=True,
+        )
+        subprocess.run(["docker", "rm", "-f", _CONTAINER_NAME], capture_output=True)
+        raise RuntimeError(
+            f"pgvector container never became ready:\n{logs.stdout}\n{logs.stderr}"
+        )
+
+    # Create nexus_svc role (required by Liquibase grants-nexus-svc.xml,
+    # runAlways=true). RETRY LOOP, not a fixed sleep: the postgres image's
+    # entrypoint boots a TEMPORARY server for initdb, shuts it down
+    # ("FATAL: the database system is shutting down"), then starts the real
+    # one — and pg_isready can succeed against the temporary server, so a
+    # psql issued in that window dies with exactly that FATAL.
+    psql_deadline = time.monotonic() + 60.0
+    while True:
+        try:
+            _run_psql_in_container(pg_user, pg_db, SERVICE_ROLES_SQL)
+            break
+        except RuntimeError:
+            if time.monotonic() >= psql_deadline:
+                logs = subprocess.run(
+                    ["docker", "logs", _CONTAINER_NAME],
+                    capture_output=True, text=True,
+                )
+                subprocess.run(["docker", "rm", "-f", _CONTAINER_NAME], capture_output=True)
+                raise RuntimeError(
+                    "role-creation psql never succeeded (PG init-restart window "
+                    f"did not close within 60s):\n{logs.stdout[-2000:]}\n{logs.stderr[-2000:]}"
+                ) from None
+            time.sleep(1.0)
+
+    pg = {
+        "host": "127.0.0.1",
+        "port": pg_port,
+        "dbname": pg_db,
+        "user": pg_user,
+        "password": pg_pass,
+    }
+
+    yield pg
+
+    subprocess.run(["docker", "rm", "-f", _CONTAINER_NAME], capture_output=True)
+
+
+def _run_psql_in_container(pg_user: str, pg_db: str, sql: str) -> None:
+    """Execute SQL inside the running container as the superuser.
+
+    Fixture-provisioning only (role creation) — no test assertion in this
+    module uses raw SQL.
+    """
+    result = subprocess.run(
+        [
+            "docker", "exec", "-i", _CONTAINER_NAME,
+            "psql", "-U", pg_user, "-d", pg_db,
+            "-v", "ON_ERROR_STOP=1", "-c", sql,
+        ],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Container psql failed (rc={result.returncode}):\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+
+# ── Module-scoped service fixture ─────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def local_service(pg_instance: dict):
+    """Java service in LOCAL mode (ONNX bge-768 embedder, no Voyage key).
+
+    App pool is ``nexus_svc`` (NOSUPERUSER NOBYPASSRLS) — production-like
+    FORCE RLS, matching the write-seam gate's pool split. Full Liquibase
+    runs at boot, which is what makes the combined-query SQL functions and
+    the catalog-014 changeset real for this test (not a mock).
+
+    Yields ``(base_url, token)`` after the HTTP port is reachable.
+    """
+    token = "cq-tripwire-gate-token"
+    svc_port = _free_port()
+
+    pg = pg_instance
+    pg_jdbc = (
+        f"jdbc:postgresql://{pg['host']}:{pg['port']}/{pg['dbname']}"
+    )
+
+    # App pool: nexus_svc (NOSUPERUSER NOBYPASSRLS) — Liquibase wires DML grants.
+    # Migration pool: container superuser (pg['user']) — has DDL rights.
+    env = {
+        **os.environ,
+        "NX_SERVICE_PORT": str(svc_port),
+        "NX_SERVICE_TOKEN": token,
+        "NX_DB_URL": pg_jdbc,
+        "NX_DB_USER": "nexus_svc",
+        "NX_DB_PASS": "nexus_svc_pass",
+        "NX_POOL_SIZE": "2",
+        "NX_DB_ADMIN_URL": pg_jdbc,
+        "NX_DB_ADMIN_USER": pg["user"],
+        "NX_DB_ADMIN_PASS": pg["password"],
+        "NX_CHROMA_MODE": "local",
+        "NX_CHROMA_PATH": tempfile.mkdtemp(prefix="cq-tripwire-chroma-"),
+    }
+    # Force ONNX / local mode — no Voyage billing
+    env.pop("NX_VOYAGE_API_KEY", None)
+    env.pop("VOYAGE_API_KEY", None)
+    env.pop("NX_STORAGE_BACKEND", None)
+
+    proc = subprocess.Popen(
+        [str(_JAVA), "-jar", str(_JAR)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        preexec_fn=os.setsid,
+    )
+    try:
+        _wait_tcp("127.0.0.1", svc_port, timeout=90.0)
+        yield f"http://127.0.0.1:{svc_port}", token
+    finally:
+        _stop_service(proc)
+        chroma_path = env.get("NX_CHROMA_PATH", "")
+        if chroma_path and Path(chroma_path).exists():
+            shutil.rmtree(chroma_path, ignore_errors=True)
+
+
+@pytest.fixture
+def cat_client(local_service: tuple[str, str]):
+    """HttpCatalogClient bound to the live local_service, closed on teardown."""
+    from nexus.catalog.http_catalog_client import HttpCatalogClient
+
+    base_url, token = local_service
+    with HttpCatalogClient(base_url=base_url, tenant="default", _token=token) as c:
+        yield c
+
+
+@pytest.fixture
+def vec_client(local_service: tuple[str, str], monkeypatch: pytest.MonkeyPatch):
+    """HttpVectorClient singleton re-resolved against the live local_service."""
+    from nexus.db.http_vector_client import (
+        get_http_vector_client,
+        reset_http_vector_client_for_tests,
+    )
+
+    base_url, token = local_service
+    monkeypatch.setenv("NX_STORAGE_BACKEND_VECTORS", "service")
+    monkeypatch.setenv("NX_SERVICE_URL", base_url)
+    monkeypatch.setenv("NX_SERVICE_TOKEN", token)
+    monkeypatch.delenv("NX_LOCAL", raising=False)
+    monkeypatch.delenv("NX_VOYAGE_API_KEY", raising=False)
+    monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+    reset_http_vector_client_for_tests()
+
+    return get_http_vector_client()
+
+
+# ── Integration tests ─────────────────────────────────────────────────────────
+
+# Collection uses bge-base-en-v15-768 (the ONNX local embedder) — service
+# embeds server-side into chunks_768 tables, exercised through the
+# search_*_768 combined-query SQL functions.
+_COLLECTION = "knowledge__cq-tripwire__bge-base-en-v15-768__v1"
+
+
+def test_metadata_scoped_visible_after_public_api_write(
+    cat_client, vec_client
+) -> None:
+    """Register -> upsert -> write_manifest -> search_metadata_scoped, all
+    through public API methods, must make the chunk combined-query-visible.
+
+    Pre-x6kdz-fix this path returned zero rows: the manifest writer never
+    stamped ``document_chunks.collection`` on first write, so
+    ``search_metadata_scoped``'s inner join against the catalog manifest
+    excluded the row entirely.
+
+    Also proves the catalog-012 ``where`` equality shape is a REAL predicate,
+    not a no-op: a matching ``where`` returns the row, a mismatching
+    ``where`` on the SAME query returns empty — the negative control lives
+    in this same test so it cannot pass vacuously.
+    """
+    text = (
+        "cqtripwire test1 alpha unique content about combined query "
+        "visibility through the public catalog and vector client API"
+    )
+    chash = _chunk_id(text)
+
+    t = cat_client.register(
+        "1.1",
+        "CQ Tripwire Doc A",
+        content_type="knowledge",
+        author="cq-tripwire-suite",
+        corpus="cq-tripwire",
+        physical_collection=_COLLECTION,
+        source_uri="file:///cq-tripwire/docA.md",
+    )
+
+    vec_client.upsert_chunks(
+        _COLLECTION,
+        [chash],
+        [text],
+        metadatas=[{"kind": "cq-tripwire"}],
+    )
+
+    cat_client.write_manifest(
+        str(t),
+        [{"position": 0, "chash": chash, "line_start": 1, "line_end": 10}],
+    )
+
+    query = "cqtripwire test1 alpha combined query visibility"
+
+    rows = vec_client.search_metadata_scoped(query, [_COLLECTION])
+    matching = [r for r in rows if r["id"] == str(t)]
+    assert matching, (
+        f"search_metadata_scoped returned no row for tumbler {t!s} after a "
+        "public-API register+upsert+write_manifest write — this is the "
+        "x6kdz zero-rows regression (manifest writer never stamped "
+        "document_chunks.collection, so the combined-query inner join "
+        f"excluded the doc). Rows returned: {rows!r}"
+    )
+    assert matching[0]["chash"] == chash, (
+        f"matched row's chash {matching[0]['chash']!r} does not equal the "
+        f"upserted chunk's chash {chash!r} — combined query matched the "
+        "wrong chunk or a stale row"
+    )
+
+    # Non-vacuity negative control: a mismatching `where` on the identical
+    # query MUST return empty, proving `where` is a live predicate.
+    where_match = vec_client.search_metadata_scoped(
+        query, [_COLLECTION], where={"kind": "cq-tripwire"}
+    )
+    assert any(r["id"] == str(t) for r in where_match), (
+        "matching where={'kind': 'cq-tripwire'} did not return the doc — "
+        "catalog-012 where-equality shape is broken for the positive case"
+    )
+    where_mismatch = vec_client.search_metadata_scoped(
+        query, [_COLLECTION], where={"kind": "no-such-value"}
+    )
+    assert where_mismatch == [], (
+        f"mismatching where={{'kind': 'no-such-value'}} on the SAME query "
+        f"returned {where_mismatch!r} instead of []  — the where filter is "
+        "a no-op server-side, which would let the positive assertion above "
+        "pass vacuously regardless of whether filtering actually works"
+    )
+
+
+def test_manifest_rewrite_keeps_combined_query_visibility(
+    cat_client, vec_client
+) -> None:
+    """The x6kdz core regression test: a repeat ``write_manifest`` REPLACE
+    pass over the same document must NOT wipe combined-query visibility.
+
+    This is self-contained (its own doc, its own chunks) so it does not
+    depend on test execution order. Precision note (substantive-critic,
+    2026-07-09): ``writeManifestRows`` is ONE shared DELETE+re-INSERT body
+    for first and Nth call alike — pre-fix, the FIRST call already omitted
+    the ``collection`` column, so test 1 alone catches the shipped defect.
+    What THIS test adds is a guard against a future first/second-write
+    asymmetry in that shared body (e.g. a diff-based short-circuit that
+    skips the re-INSERT, or a REPLACE variant that clears the stamp a
+    migration-backfill had repaired) — the "visible, then re-write, then
+    invisible" shape the live tenant actually experienced.
+    """
+    texts = [
+        (
+            "cqtripwire test2 first pass unique content about manifest "
+            "rewrite regression chunk zero"
+        ),
+        (
+            "cqtripwire test2 first pass unique content about manifest "
+            "rewrite regression chunk one"
+        ),
+    ]
+    ids = [_chunk_id(t) for t in texts]
+
+    t = cat_client.register(
+        "1.1",
+        "CQ Tripwire Doc Rewrite",
+        content_type="knowledge",
+        author="cq-tripwire-suite",
+        corpus="cq-tripwire",
+        physical_collection=_COLLECTION,
+        source_uri="file:///cq-tripwire/doc-rewrite.md",
+    )
+
+    vec_client.upsert_chunks(_COLLECTION, ids, texts)
+
+    manifest_rows = [
+        {"position": i, "chash": ids[i], "line_start": i * 10 + 1, "line_end": i * 10 + 10}
+        for i in range(len(texts))
+    ]
+
+    # First write_manifest pass.
+    cat_client.write_manifest(str(t), manifest_rows)
+
+    query = "cqtripwire test2 first pass manifest rewrite regression"
+
+    rows_after_first = vec_client.search_metadata_scoped(query, [_COLLECTION])
+    matching_first = [r for r in rows_after_first if r["id"] == str(t)]
+    assert matching_first, (
+        f"search_metadata_scoped returned no row for {t!s} after the FIRST "
+        f"write_manifest call — cannot test the rewrite regression if the "
+        f"baseline write itself is not visible. Rows: {rows_after_first!r}"
+    )
+    assert matching_first[0]["chash"] in ids, (
+        f"first-write matched chash {matching_first[0]['chash']!r} is not "
+        f"one of the upserted chunk ids {ids!r}"
+    )
+
+    # SECOND write_manifest pass — same doc, same rows. Same shared REPLACE
+    # body as the first call today; must keep stamping the collection even
+    # if the two calls ever diverge.
+    cat_client.write_manifest(str(t), manifest_rows)
+
+    rows_after_second = vec_client.search_metadata_scoped(query, [_COLLECTION])
+    matching_second = [r for r in rows_after_second if r["id"] == str(t)]
+    assert matching_second, (
+        f"search_metadata_scoped returned NO row for {t!s} after a SECOND "
+        "write_manifest REPLACE pass over the SAME document — this is "
+        "exactly the x6kdz regression: the manifest REPLACE writer wiped "
+        "document_chunks.collection, silently emptying combined-query "
+        f"results on a live tenant. Rows before second write: "
+        f"{rows_after_first!r}; rows after: {rows_after_second!r}"
+    )
+    assert matching_second[0]["chash"] in ids, (
+        f"post-rewrite matched chash {matching_second[0]['chash']!r} is not "
+        f"one of the upserted chunk ids {ids!r} — visibility survived but "
+        "matched the wrong chunk"
+    )
+
+
+def test_graph_hop_visible_through_link(cat_client, vec_client) -> None:
+    """Register doc A + doc B, link A -> B, then search_graph_hop from seed A
+    must surface doc B — proving the catalog link graph and combined-query
+    hop traversal compose correctly through the public API.
+
+    Also carries the catalog-012 where match/mismatch pair extended to the
+    graph-hop path (non-vacuity: a positive-only assertion here would pass
+    identically whether or not the hop's where filter is wired at all).
+    """
+    text_a = (
+        "cqtripwire test3 doc a seed content about graph hop traversal "
+        "starting from a linked seed document"
+    )
+    text_b = (
+        "cqtripwire test3 doc b linked target content about graph hop "
+        "reachability through a catalog link"
+    )
+    chash_a = _chunk_id(text_a)
+    chash_b = _chunk_id(text_b)
+
+    doc_a = cat_client.register(
+        "1.1",
+        "CQ Tripwire Doc A (hop seed)",
+        content_type="knowledge",
+        author="cq-tripwire-suite",
+        corpus="cq-tripwire",
+        physical_collection=_COLLECTION,
+        source_uri="file:///cq-tripwire/hop-a.md",
+    )
+    doc_b = cat_client.register(
+        "1.1",
+        "CQ Tripwire Doc B (hop target)",
+        content_type="knowledge",
+        author="cq-tripwire-suite",
+        corpus="cq-tripwire",
+        physical_collection=_COLLECTION,
+        source_uri="file:///cq-tripwire/hop-b.md",
+    )
+
+    vec_client.upsert_chunks(_COLLECTION, [chash_a], [text_a])
+    vec_client.upsert_chunks(
+        _COLLECTION, [chash_b], [text_b], metadatas=[{"kind": "cq-tripwire-hop"}]
+    )
+
+    cat_client.write_manifest(
+        str(doc_a),
+        [{"position": 0, "chash": chash_a, "line_start": 1, "line_end": 10}],
+    )
+    cat_client.write_manifest(
+        str(doc_b),
+        [{"position": 0, "chash": chash_b, "line_start": 1, "line_end": 10}],
+    )
+
+    created = cat_client.link(
+        str(doc_a), str(doc_b), "relates", created_by="cq-tripwire-test"
+    )
+    assert created, f"expected a NEW link to be created between {doc_a!s} and {doc_b!s}"
+
+    query = "cqtripwire test3 doc b linked target graph hop reachability"
+
+    hop_rows = vec_client.search_graph_hop(
+        query, seeds=[str(doc_a)], collection_names=[_COLLECTION], depth=1
+    )
+    assert any(r["id"] == str(doc_b) for r in hop_rows), (
+        f"search_graph_hop from seed {doc_a!s} did not surface linked doc "
+        f"{doc_b!s} — graph hop traversal through the public link/search API "
+        f"is broken. Rows: {hop_rows!r}"
+    )
+
+    # Non-vacuity negative control for the graph-hop where shape.
+    hop_where_match = vec_client.search_graph_hop(
+        query,
+        seeds=[str(doc_a)],
+        collection_names=[_COLLECTION],
+        depth=1,
+        where={"kind": "cq-tripwire-hop"},
+    )
+    assert any(r["id"] == str(doc_b) for r in hop_where_match), (
+        "matching where={'kind': 'cq-tripwire-hop'} did not return doc B "
+        "through the graph hop — catalog-012 where-equality shape is broken "
+        "on the graph-hop path for the positive case"
+    )
+    hop_where_mismatch = vec_client.search_graph_hop(
+        query,
+        seeds=[str(doc_a)],
+        collection_names=[_COLLECTION],
+        depth=1,
+        where={"kind": "no-such-value"},
+    )
+    assert hop_where_mismatch == [], (
+        f"mismatching where={{'kind': 'no-such-value'}} on the SAME graph "
+        f"hop returned {hop_where_mismatch!r} instead of [] — the hop's "
+        "where filter is a no-op server-side, which would let the positive "
+        "assertion above pass vacuously regardless of whether filtering "
+        "actually works"
+    )
+
+
+def test_append_and_import_seams_stamp_collection(cat_client, vec_client) -> None:
+    """The other two public write seams the x6kdz fix touched must ALSO
+    stamp ``document_chunks.collection`` (substantive-critic finding 2,
+    2026-07-09): ``appendManifestChunks`` (via
+    ``HttpCatalogClient.append_manifest_chunks``) and ``importChunksBatch``
+    (via ``POST /v1/catalog/import/chunk`` — the exact envelope the
+    migration orchestrator sends, see
+    ``src/nexus/migration/orchestrator.py`` fill_missing_document_chunks
+    import_fn).
+
+    Both are ``ON CONFLICT DO UPDATE`` writers, unlike ``write_manifest``'s
+    DELETE+re-INSERT: dropping ``COLLECTION`` from their INSERT column list
+    is a one-line regression this test trips on (the append/import call is
+    each doc's FIRST manifest write here, so the INSERT branch runs and an
+    unstamped row is combined-query-invisible). Each seam is then re-called
+    with the same rows to walk the DO-UPDATE branch; sensitivity caveat: on
+    a correct tree the pre-conflict stamp is already right, so a dropped
+    DO-UPDATE ``.set(COLLECTION, ...)`` alone would not flip this test —
+    that narrower line is covered in-JVM by ``ManifestCollectionStampTest``
+    and recorded as a residual on bead nexus-4nflf.
+    """
+    # ── Seam 1: append_manifest_chunks (POST /v1/catalog/manifest/append) ──
+    text_app = (
+        "cqtripwire test4 append seam unique content stamped through the "
+        "manifest append on-conflict writer"
+    )
+    chash_app = _chunk_id(text_app)
+
+    doc_app = cat_client.register(
+        "1.1",
+        "CQ Tripwire Doc Append",
+        content_type="knowledge",
+        author="cq-tripwire-suite",
+        corpus="cq-tripwire",
+        physical_collection=_COLLECTION,
+        source_uri="file:///cq-tripwire/doc-append.md",
+    )
+    vec_client.upsert_chunks(_COLLECTION, [chash_app], [text_app])
+
+    append_rows = [
+        {"position": 0, "chash": chash_app, "line_start": 1, "line_end": 10}
+    ]
+    # First append = INSERT branch: must stamp collection or the doc is
+    # combined-query-invisible (the x6kdz defect class on this seam).
+    cat_client.append_manifest_chunks(str(doc_app), append_rows)
+
+    query_app = "cqtripwire test4 append seam manifest on-conflict writer"
+    rows = vec_client.search_metadata_scoped(query_app, [_COLLECTION])
+    matching = [r for r in rows if r["id"] == str(doc_app)]
+    assert matching, (
+        f"search_metadata_scoped returned no row for {doc_app!s} after "
+        "append_manifest_chunks — the append seam's INSERT branch is not "
+        f"stamping document_chunks.collection. Rows: {rows!r}"
+    )
+    assert matching[0]["chash"] == chash_app, (
+        f"append-seam matched chash {matching[0]['chash']!r} != upserted "
+        f"chash {chash_app!r}"
+    )
+
+    # Re-append the same rows = ON CONFLICT DO UPDATE branch. Visibility
+    # must survive (see docstring for what this is and isn't sensitive to).
+    cat_client.append_manifest_chunks(str(doc_app), append_rows)
+    rows2 = vec_client.search_metadata_scoped(query_app, [_COLLECTION])
+    assert any(r["id"] == str(doc_app) for r in rows2), (
+        f"doc {doc_app!s} vanished from combined-query results after a "
+        "REPEAT append_manifest_chunks call — the append seam's ON CONFLICT "
+        f"DO UPDATE branch broke the collection stamp. Rows: {rows2!r}"
+    )
+
+    # ── Seam 2: import chunks (POST /v1/catalog/import/chunk) ─────────────
+    text_imp = (
+        "cqtripwire test4 import seam unique content stamped through the "
+        "migration import chunk batch writer"
+    )
+    chash_imp = _chunk_id(text_imp)
+
+    doc_imp = cat_client.register(
+        "1.1",
+        "CQ Tripwire Doc Import",
+        content_type="knowledge",
+        author="cq-tripwire-suite",
+        corpus="cq-tripwire",
+        physical_collection=_COLLECTION,
+        source_uri="file:///cq-tripwire/doc-import.md",
+    )
+    vec_client.upsert_chunks(_COLLECTION, [chash_imp], [text_imp])
+
+    import_rows = [
+        {"position": 0, "chash": chash_imp, "line_start": 1, "line_end": 10}
+    ]
+    # Same wire envelope the migration orchestrator's verify-fill leg sends.
+    cat_client._post("/import/chunk", {"doc_id": str(doc_imp), "rows": import_rows})
+
+    query_imp = "cqtripwire test4 import seam migration chunk batch writer"
+    rows = vec_client.search_metadata_scoped(query_imp, [_COLLECTION])
+    matching = [r for r in rows if r["id"] == str(doc_imp)]
+    assert matching, (
+        f"search_metadata_scoped returned no row for {doc_imp!s} after "
+        "/import/chunk — the import seam's INSERT branch is not stamping "
+        "document_chunks.collection, so migration-imported manifests would "
+        f"be combined-query-invisible. Rows: {rows!r}"
+    )
+    assert matching[0]["chash"] == chash_imp, (
+        f"import-seam matched chash {matching[0]['chash']!r} != upserted "
+        f"chash {chash_imp!r}"
+    )
+
+    # Re-import the same rows = ON CONFLICT DO UPDATE branch.
+    cat_client._post("/import/chunk", {"doc_id": str(doc_imp), "rows": import_rows})
+    rows2 = vec_client.search_metadata_scoped(query_imp, [_COLLECTION])
+    assert any(r["id"] == str(doc_imp) for r in rows2), (
+        f"doc {doc_imp!s} vanished from combined-query results after a "
+        "REPEAT /import/chunk call — the import seam's ON CONFLICT DO "
+        f"UPDATE branch broke the collection stamp. Rows: {rows2!r}"
+    )

--- a/tests/e2e/migration-rehearsal/run.sh
+++ b/tests/e2e/migration-rehearsal/run.sh
@@ -51,7 +51,7 @@ RELEASE_PROPS="service/src/main/resources/META-INF/nexus/release.properties"
 # stale default fail-closes the --cold MVV at the version gate. Kept literal (it
 # names a PUBLISHED release tag, which need not equal the floor) but bumped to
 # track it; override via NEXUS_SERVICE_TAG. (nexus-v0zmv)
-COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.35}"
+COLD_TAG="${NEXUS_SERVICE_TAG:-engine-service-v0.1.36}"
 for a in "$@"; do
   case "$a" in
     --with-cloud) WITH_CLOUD=1 ;;

--- a/tests/migration/test_guided_upgrade_voyage_capability.py
+++ b/tests/migration/test_guided_upgrade_voyage_capability.py
@@ -25,10 +25,17 @@ from nexus.migration.guided_upgrade import (
 _URL = "http://127.0.0.1:8099"
 
 
-def _cls(collection: str, model: str | None, *, has_data: bool = True) -> CollectionClassification:
+def _cls(
+    collection: str,
+    model: str | None,
+    *,
+    has_data: bool = True,
+    measured_dim: int | None = None,
+) -> CollectionClassification:
     return CollectionClassification(
         collection=collection, leg="local", model=model, dim=None,
         support="unsupported", source_count=12 if has_data else 0, has_data=has_data,
+        measured_dim=measured_dim,
     )
 
 
@@ -92,6 +99,40 @@ class TestFootprintHasVoyage:
         # gives it the re-index diagnostic; this gate must NOT fire on it.
         r = _report(_cls("knowledge__o__voyage-future-9__v1", "voyage-future-9"))
         assert footprint_has_voyage_collections(r) is False
+
+    # nexus-119p9 (GH #1381, second bug): the gate must consult the nb7hr
+    # measured-dim override, not just the name-parsed model. Truth table:
+
+    def test_voyage_named_measured_bge_is_remappable_not_capability_blocked(self) -> None:
+        # Steve's exact footprint: a voyage-*-NAMED collection whose stored
+        # vector measures 768-dim (local bge/ONNX, pre-RDR-109 mislabel) is
+        # cross_model_remappable — it auto-remaps locally at no cost and must
+        # NOT trip the voyage-capability gate. This is the bug: pre-fix, this
+        # asserted True (SystemExit before the auto-remap could run).
+        r = _report(
+            _cls("knowledge__o__voyage-context-3__v1", "voyage-context-3", measured_dim=768)
+        )
+        assert footprint_has_voyage_collections(r) is False
+
+    def test_voyage_named_measured_voyage_dim_is_genuinely_blocked(self) -> None:
+        # A voyage-*-NAMED collection whose stored vector measures 1024-dim
+        # (genuine voyage content) is NOT remappable (re-embedding voyage text
+        # into bge silently changes recall) — the gate must still fire.
+        r = _report(
+            _cls("knowledge__o__voyage-context-3__v1", "voyage-context-3", measured_dim=1024)
+        )
+        assert footprint_has_voyage_collections(r) is True
+
+    def test_voyage_named_unprobed_measured_dim_fails_closed(self) -> None:
+        # measured_dim is None when the collection was never probed (e.g. the
+        # classifier only probes name-unsupported data-bearing collections) or
+        # the probe could not resolve a dim. Un-confirmed means NOT provably
+        # bge, so cross_model_remappable is False and the gate stays FAIL
+        # CLOSED (fires) — real voyage data would otherwise block mid-run.
+        r = _report(
+            _cls("knowledge__o__voyage-context-3__v1", "voyage-context-3", measured_dim=None)
+        )
+        assert footprint_has_voyage_collections(r) is True
 
 
 class TestVerifyVoyageCapability:

--- a/tests/test_changelog_rls_lint.py
+++ b/tests/test_changelog_rls_lint.py
@@ -1,0 +1,1259 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-1wjmq / nexus-php10: FORCE-RLS changelog DML static-lint tripwire.
+
+Provenance: nexus-1wjmq (2026-07-08 v0.1.33 cloud deploy incident). Migration-time
+``<sql>`` row-DML against a FORCE ROW LEVEL SECURITY table silently no-ops for the
+non-BYPASSRLS Liquibase owner role (``nexus_admin``): FORCE applies even to the table
+owner, and with no ``nexus.tenant`` GUC set during migration every RLS predicate
+evaluates false, so the DML's row-security-filtered candidate set is empty. CI never
+caught the class because Testcontainers runs Liquibase as the Postgres superuser
+(implicit BYPASSRLS). catalog-013-0 hit this and took down the v0.1.33 deploy;
+five other historical members were vacuously harmless (their own downstream
+constraint proves the data was already clean). This lint statically enumerates the
+class so it cannot grow silently.
+
+Two approved-safe shapes (design nx memory get -p nexus -t
+design-php10-force-rls-changelog-lint.md, locked 2026-07-09):
+
+1. **Toggle-wrapped** (the catalog-013-1b fix pattern): every FORCE table the DML
+   touches (target OR a table it reads via JOIN/subquery) is toggled
+   ``NO FORCE ROW LEVEL SECURITY`` earlier in the SAME changeset, the DML runs while
+   visible, and ``FORCE ROW LEVEL SECURITY`` is restored before the changeset ends.
+   A toggle that is never restored is its own distinct finding (an isolation-window
+   leak, not a no-op) — reported separately from naked DML.
+
+2. **Same-changeset backstop**: the DML's TARGET table gets an RLS-bypassing
+   integrity proof in the SAME changeset — an immediately-valid (no ``NOT VALID``)
+   ``ADD CONSTRAINT ... FOREIGN KEY``/``UNIQUE``, a ``CREATE UNIQUE INDEX``, or a
+   ``VALIDATE CONSTRAINT``. Postgres referential-integrity / uniqueness checks always
+   bypass row security (full scan, table-owner semantics), so this is "safe-or-loud":
+   either the DML actually ran (RLS was somehow visible) and the backstop trivially
+   passes, or the DML silently no-op'd, stale/orphaned rows remain, and the backstop
+   FAILS the migration LOUDLY. A backstop is only sound on the DML's own target table:
+   the argument relies on the target table's own row-security policy gating the whole
+   statement's candidate row set to all-or-nothing, which does not extend to tables
+   only read via JOIN/subquery — a backstop in a LATER, separate changeset does
+   **NOT** count (this is exactly catalog-013-0's bug shape: naked DML in one
+   changeset, ``VALIDATE CONSTRAINT`` in a later one, silently a no-op with no proof
+   until the later VALIDATE happened to fail).
+
+Function/trigger bodies (``CREATE [OR REPLACE] FUNCTION/TRIGGER ... AS $$...$$``,
+any dollar-quote tag) are EXEMPT: they define code that runs later, at CALL time,
+under the caller's own SECURITY INVOKER context, not under the Liquibase migration
+role. An anonymous ``DO $$ ... $$`` block is DIFFERENT and is **NOT** exempt: it
+executes IMMEDIATELY at migration time under the Liquibase role's own session,
+so DML inside it has the identical no-op exposure as top-level SQL
+(ground-truth finding: taxonomy-004-1's entire dangerous DML sequence lives inside
+a ``DO $$ ... $$`` block). The stripper below special-cases this.
+
+Documented static blind spot: ``SELECT some_fn()`` invoking a function that performs
+DML internally is invisible to this analyzer (it only recognizes literal top-level
+``INSERT``/``UPDATE``/``DELETE`` keywords, not arbitrary function calls). The real
+corpus contains exactly one instance (catalog-014-0's
+``SELECT nexus.manifest_backfill();``), and it happens to be safe by explicit
+toggle-wrap discipline around the SELECT itself, not because the analyzer sees
+inside the function body.
+
+Why Python-side and not the Java/Testcontainers suite: the Java ``service-ci``
+workflow is advisory only (does not gate auto-merge — see AGENTS.md "Java schema
+changes verify with FULL mvn suite"), and Testcontainers itself runs Liquibase as
+the Postgres superuser, which structurally cannot reproduce the RLS-owner no-op this
+lint exists to catch. This test has no such blind spot: it is required, always-on
+Python CI (``pyproject.toml`` addopts only excludes ``integration``/``slow``/
+``stress`` markers; this file carries none of them).
+
+Additional documented static blind spots (substantive-critic review, nexus-fqnii /
+nexus-vtgeq, 2026-07-09):
+
+- **CTE-prefixed DML** (``WITH x AS (DELETE FROM nexus.t ...) INSERT INTO ...``) is
+  invisible to ``_DML_TARGET_RE``: it only recognizes a literal top-level
+  ``INSERT``/``UPDATE``/``DELETE`` keyword at the start of a statement fragment, not
+  a DML statement nested inside a ``WITH`` clause. Absent from the real corpus
+  (grep-verified 2026-07-09); would need its own detector if ever used.
+- **Comment/string-literal stripping order**: ``_strip_comments`` and the ``;``
+  split in ``_split_statements`` both run BEFORE single-quoted string literals are
+  blanked. A hypothetical string literal containing ``--``, ``/*``, or ``;`` would
+  therefore be mis-parsed (a false statement boundary or a swallowed comment
+  delimiter). Grep-verified absent from every ``<sql>`` body in the real corpus
+  today; not a live bug, but a latent one if such a literal is ever introduced.
+- **Schema scope is hardcoded** to ``nexus`` and ``t1`` in every regex (the only two
+  schemas this codebase's changelogs use today). A third schema introduced by a
+  future changelog would be completely invisible to every rule in this file, not
+  just silently missed but with no signal that it happened. The
+  ``CREATE SCHEMA ...`` tripwire below (any schema name other than ``nexus``/``t1``)
+  exists specifically to catch that moment and force this file to be extended
+  rather than silently blind past it.
+
+Same-changeset-backstop ORDER SENSITIVITY (code-review-expert Important #1,
+2026-07-09): a same-changeset backstop is only sound if it runs AFTER the DML it is
+meant to prove-or-fail — a ``VALIDATE CONSTRAINT`` (or immediately-valid
+``ADD CONSTRAINT`` / ``CREATE UNIQUE INDEX``) that appears BEFORE the DML in
+statement order proves nothing about rows the DML has not yet touched. The analyzer
+tracks each statement's index within its changeset and requires
+``backstop_index > dml_index`` on the DML's own target table.
+
+Same-changeset-backstop TARGET-ONLY scope, corrected (substantive-critic Critical,
+nexus-fqnii, 2026-07-09): the target-only-backstop exemption from Approved Shape 2
+above is sound ONLY when the target table itself is the gating risk (its own
+FORCE-RLS state zeroes the whole statement's candidate row set) — it must NEVER be
+allowed to excuse a *referenced* (JOIN/subquery) table that is independently FORCE
+and untoggled, because a backstop on the target proves nothing about a table it
+never touches. The evaluator therefore branches on which table actually gates the
+statement: if the target itself is FORCE-and-untoggled, only a later same-changeset
+backstop on the target can excuse it (reads are irrelevant in this branch — the
+target's own row-security already gates the whole statement to zero-or-full effect,
+exactly the fk-001-2..5 shape); if the target is NOT FORCE (the statement executes
+for real), ANY referenced table that is independently FORCE-and-untoggled is a
+finding on its own — no backstop on the (non-gating) target can excuse it. This is
+the asymmetric mirror of catalog-014-0's own documented incident ("toggling only the
+target table leaves the join yielding zero rows for the non-bypass owner"), caught
+there only by a Java restricted-role replay test, never previously by a Python-side
+static check.
+"""
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parent.parent
+CHANGELOG_DIR = REPO_ROOT / "service" / "src" / "main" / "resources" / "db" / "changelog"
+MASTER_CHANGELOG = CHANGELOG_DIR / "db.changelog-master.xml"
+
+_XSD_NS = "{http://www.liquibase.org/xml/ns/dbchangelog}"
+
+
+# ---------------------------------------------------------------------------
+# Regexes (all operate on already comment-stripped, dollar-body-stripped,
+# single-statement text — see _split_statements)
+# ---------------------------------------------------------------------------
+
+_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_DOLLAR_QUOTE_RE = re.compile(r"\$(\w*)\$(.*?)\$\1\$", re.DOTALL)
+_STRING_LITERAL_RE = re.compile(r"'(?:[^']|'')*'")
+
+_FORCE_TOGGLE_RE = re.compile(
+    r"ALTER\s+TABLE\s+(nexus|t1)\.(\w+)\s+(NO\s+)?FORCE\s+ROW\s+LEVEL\s+SECURITY",
+    re.IGNORECASE,
+)
+_DML_TARGET_RE = re.compile(
+    r"^(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+(nexus|t1)\.(\w+)",
+    re.IGNORECASE,
+)
+_ADD_CONSTRAINT_RE = re.compile(
+    r"ALTER\s+TABLE\s+(nexus|t1)\.(\w+)\s+ADD\s+CONSTRAINT\s+\w+\s+"
+    r"(?:FOREIGN\s+KEY|UNIQUE)",
+    re.IGNORECASE,
+)
+_UNIQUE_INDEX_RE = re.compile(
+    r"CREATE\s+UNIQUE\s+INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?\S+\s+ON\s+(nexus|t1)\.(\w+)",
+    re.IGNORECASE,
+)
+_VALIDATE_CONSTRAINT_RE = re.compile(
+    r"ALTER\s+TABLE\s+(nexus|t1)\.(\w+)\s+VALIDATE\s+CONSTRAINT",
+    re.IGNORECASE,
+)
+_TABLE_MENTION_RE = re.compile(r"\b(nexus|t1)\.(\w+)\b(?!\s*\()", re.IGNORECASE)
+
+# FIX 5(c): CREATE SCHEMA tripwire. The analyzer's schema scope is hardcoded to
+# nexus/t1 everywhere; a third schema would otherwise be silently invisible. The
+# real corpus has exactly two CREATE SCHEMA statements (nexus, t1) — both exempt.
+_CREATE_SCHEMA_RE = re.compile(
+    r"CREATE\s+SCHEMA\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)", re.IGNORECASE
+)
+_KNOWN_SCHEMAS = frozenset({"nexus", "t1"})
+
+# FIX 3: Liquibase element kinds this analyzer cannot see into at all (only
+# <sql> children of <changeSet> are scanned). Zero current usage in the real
+# corpus (grep-verified 2026-07-09) — this is purely defensive.
+_UNSCANNED_ELEMENT_TAGS = ("sqlFile", "customChange", "createProcedure")
+
+# A DO $$ block's FIRST inner statement shares a ``;``-split fragment with the
+# "DO $$\nBEGIN" wrapper tokens (there is no statement-terminating ``;``
+# between BEGIN and the first inner statement). Strip that leading wrapper
+# before anchoring the DML-target match at position 0, so
+# "DO $$\nBEGIN\n    DELETE FROM nexus.widgets ..." still resolves its target
+# — otherwise a DO block's very first statement would silently escape
+# detection while every later inner statement (naturally split by the prior
+# statement's ``;``) is caught, an inconsistency that would be worse than no
+# detection at all (looks caught, isn't, for a corpus-shape-dependent subset).
+_LEADING_DO_BEGIN_RE = re.compile(
+    r"^\s*(?:DO\s+\$\w*\$\s*|BEGIN\s*)+", re.IGNORECASE
+)
+
+
+def _table_key(schema: str, table: str) -> str:
+    # PG folds unquoted identifiers to lowercase; normalize here so every
+    # regex's captured groups (all six funnel through this helper) key
+    # consistently regardless of the source SQL's casing.
+    return f"{schema.lower()}.{table.lower()}"
+
+
+# ---------------------------------------------------------------------------
+# Text preprocessing: comments, exempt dollar-quoted bodies, statement split
+# ---------------------------------------------------------------------------
+
+
+def _strip_comments(sql: str) -> str:
+    """Remove ``--`` line comments and ``/* */`` block comments."""
+    sql = _BLOCK_COMMENT_RE.sub(" ", sql)
+    sql = _LINE_COMMENT_RE.sub("", sql)
+    return sql
+
+
+def _strip_exempt_dollar_bodies(sql: str) -> str:
+    """Remove ``CREATE [OR REPLACE] FUNCTION/TRIGGER ... AS $$...$$`` bodies.
+
+    A ``DO $$ ... $$`` anonymous block is left INTACT: unlike a function/trigger
+    definition (which only executes later, at CALL time, under the caller's own
+    SECURITY INVOKER context), a DO block executes immediately at migration time
+    under the Liquibase role's own session — its DML has the exact same no-op
+    exposure as top-level SQL and must be scanned, not stripped as exempt.
+    """
+    out: list[str] = []
+    pos = 0
+    for m in _DOLLAR_QUOTE_RE.finditer(sql):
+        pre = sql[pos : m.start()]
+        pre_stripped = pre.rstrip()
+        is_do_block = bool(
+            re.search(r"(?<![A-Za-z0-9_])DO\s*$", pre_stripped, re.IGNORECASE)
+        )
+        out.append(pre)
+        out.append(m.group(0) if is_do_block else " ")
+        pos = m.end()
+    out.append(sql[pos:])
+    return "".join(out)
+
+
+def _split_statements(sql: str) -> list[str]:
+    """Comment-strip, exempt-body-strip, then split into ``;``-terminated
+    statement fragments, each stripped of leading/trailing whitespace and with
+    single-quoted string literals blanked out (so a literal like
+    ``current_setting('nexus.tenant', true)`` cannot false-positive as a table
+    reference)."""
+    cleaned = _strip_exempt_dollar_bodies(_strip_comments(sql))
+    fragments = []
+    for raw in cleaned.split(";"):
+        frag = raw.strip()
+        if not frag:
+            continue
+        frag = _STRING_LITERAL_RE.sub("''", frag)
+        fragments.append(frag)
+    return fragments
+
+
+# ---------------------------------------------------------------------------
+# Master include-order walk + per-changeset <sql> extraction
+# ---------------------------------------------------------------------------
+
+
+def parse_master_include_order(master_path: Path) -> list[str]:
+    """Return the ``<include file="...">`` basenames in document order."""
+    tree = ET.parse(master_path)
+    root = tree.getroot()
+    includes = []
+    for el in root.iter(f"{_XSD_NS}include"):
+        file_attr = el.get("file")
+        if file_attr:
+            includes.append(Path(file_attr).name)
+    return includes
+
+
+def iter_changesets(changelog_dir: Path, basename: str):
+    """Yield (changeset_id, sql_text, unscanned_tags) for every ``<changeSet>``
+    in *basename*, in document order. ``<rollback>`` bodies are structurally
+    excluded (they are sibling elements of ``<sql>``, never visited) —
+    rollback SQL never runs at migration time.
+
+    *unscanned_tags* is the list of direct-child tag names matching
+    ``_UNSCANNED_ELEMENT_TAGS`` (``sqlFile`` / ``customChange`` /
+    ``createProcedure``) — Liquibase change-type elements this analyzer has
+    no ability to look inside at all. A changeset may have neither ``<sql>``
+    nor any unscanned element (pure DDL via other Liquibase change types this
+    lint doesn't need to worry about, e.g. ``<createTable>`` — not currently
+    used in this corpus but not itself a blind spot since it carries no DML).
+    """
+    path = changelog_dir / basename
+    tree = ET.parse(path)
+    root = tree.getroot()
+    for cs in root.iter(f"{_XSD_NS}changeSet"):
+        cs_id = cs.get("id", "")
+        sql_texts = [
+            el.text or "" for el in cs.findall(f"{_XSD_NS}sql") if el.text
+        ]
+        unscanned = [
+            tag
+            for tag in _UNSCANNED_ELEMENT_TAGS
+            if cs.find(f"{_XSD_NS}{tag}") is not None
+        ]
+        yield cs_id, "\n".join(sql_texts), unscanned
+
+
+# ---------------------------------------------------------------------------
+# Findings + result shape
+# ---------------------------------------------------------------------------
+
+NAKED_DML = "naked_dml"
+MISSING_RESTORE = "missing_restore"
+UNSCANNED_ELEMENT = "unscanned_element"
+UNSCANNED_SCHEMA = "unscanned_schema"
+
+
+@dataclass(frozen=True)
+class Finding:
+    changeset_id: str
+    file: str
+    table: str
+    kind: str
+    detail: str = ""
+
+
+@dataclass
+class AnalysisResult:
+    walked_files: list[str] = field(default_factory=list)
+    violations: list[Finding] = field(default_factory=list)
+    unused_allowlist: set[tuple[str, str]] = field(default_factory=set)
+
+    @property
+    def total_violations(self) -> int:
+        return len(self.violations)
+
+
+# ---------------------------------------------------------------------------
+# Allowlist — the exact grandfathered dangerous-shape members (nexus-php10
+# ground truth, nx memory get -p nexus -t php10-ground-truth-classification.md).
+# Keyed (changeset_id, "schema.table"). An UNUSED entry fails the real-changelog
+# test (rot detection) — every entry here must be independently re-derivable
+# from a live analyzer run, never hand-waved.
+# ---------------------------------------------------------------------------
+
+ALLOWLIST: tuple[tuple[str, str, str], ...] = (
+    (
+        "catalog-013-0",
+        "nexus.chash_index",
+        "nexus-1wjmq: burned in the v0.1.33 outage. Naked DML, backstop "
+        "(VALIDATE CONSTRAINT) lands in the later, separate catalog-013-2 "
+        "changeset — the exact class this lint exists to catch. Fixed "
+        "forward by catalog-013-1b (toggle-wrapped re-run); 013-0 itself is "
+        "checksum-immutable and already executed on affected tenants.",
+    ),
+    (
+        "taxonomy-004-1",
+        "nexus.topic_assignments",
+        "nexus-slcn7: dedup-root-topics DML lives inside a DO $$ block (not "
+        "toggled), backstop (CREATE UNIQUE INDEX) lands in the later, "
+        "separate taxonomy-004-2 changeset. Checksum-immutable, already "
+        "executed; nexus-php10 bead description's 2026-07-08 audit note "
+        "confirms no production divergence.",
+    ),
+    (
+        "taxonomy-004-1",
+        "nexus.topics",
+        "Same DO $$ block as topic_assignments above (nexus-slcn7); the "
+        "UPDATE/DELETE targeting nexus.topics shares the identical "
+        "later-changeset-backstop shape and disposition.",
+    ),
+    (
+        "taxonomy-004-1",
+        "nexus.topic_links",
+        "Same DO $$ block as topic_assignments above (nexus-slcn7); the "
+        "DELETE targeting nexus.topic_links shares the identical "
+        "later-changeset-backstop shape and disposition.",
+    ),
+    (
+        "fk-002-0-backfill-stubs",
+        "nexus.catalog_collections",
+        "nexus-70r3c.2: stub-register backfill INSERT, no toggle. The FKs "
+        "added in the same file (fk-002-1..5) are deliberately NOT VALID "
+        "(don't count as a backstop) and the real VALIDATE lives in a "
+        "wholly separate later file (fk-002-validate.xml). "
+        "Checksum-immutable; RDR-153 world-block lifted 2026-06-21; "
+        "nexus-php10 bead description's 2026-07-08 audit note confirms no "
+        "production divergence.",
+    ),
+    (
+        "fk-003-0-backfill-stubs",
+        "nexus.catalog_collections",
+        "nexus-dcqml: mirrors fk-002-0-backfill-stubs exactly (five-table "
+        "stub-register INSERT, no toggle, VALIDATE deferred to a separate "
+        "later file fk-003-validate.xml). Same disposition rationale.",
+    ),
+    (
+        "fk-002-6-reconcile",
+        "nexus.catalog_collections",
+        "nexus-70r3c.3: gap-window reconcile re-run of the fk-002-0 "
+        "stub-register INSERT shape. NOT in the original bead's historical "
+        "six-member list — surfaced by the nexus-php10 plan-audit as a "
+        "genuine additional member: its backstop (VALIDATE, fk-002-7..11) "
+        "is in the SAME FILE but LATER, SEPARATE changesets, the literal "
+        "later-changeset-backstop shape. Checksum-immutable, already "
+        "executed on any deployed tenant; same nexus-php10 bead description "
+        "2026-07-08 audit-note rationale.",
+    ),
+    (
+        "fk-003-6-reconcile",
+        "nexus.catalog_collections",
+        "nexus-p9aw6: mirrors fk-002-6-reconcile exactly (gap-window "
+        "reconcile re-run, backstop in later same-file changesets "
+        "fk-003-7..11). Same NEW-finding / disposition rationale.",
+    ),
+)
+
+
+def _allowlist_keys(allowlist: tuple[tuple[str, str, str], ...]) -> set[tuple[str, str]]:
+    return {(cs_id, table) for cs_id, table, _reason in allowlist}
+
+
+# ---------------------------------------------------------------------------
+# The analyzer
+# ---------------------------------------------------------------------------
+
+
+def analyze_changelog(
+    changelog_dir: Path = CHANGELOG_DIR,
+    master_path: Path = MASTER_CHANGELOG,
+    allowlist: tuple[tuple[str, str, str], ...] = ALLOWLIST,
+) -> AnalysisResult:
+    """Walk *master_path*'s include order, classify every DML statement in
+    every changeset's ``<sql>`` body against the per-table FORCE-RLS state at
+    that point, and return the (post-allowlist) violation set.
+
+    Non-vacuity: the walked-file set is asserted equal to the live
+    ``<include>`` list AND to the live glob of ``*.xml`` files (minus the
+    master itself) in *changelog_dir* — self-verifying against the actual
+    directory contents rather than a hardcoded file count, so this cannot
+    silently drift as new changelogs land (nx_plan_audit correction,
+    nexus-php10 2026-07-09: an earlier draft hardcoded 31, the live count
+    is 39).
+    """
+    include_order = parse_master_include_order(master_path)
+
+    on_disk = {
+        p.name for p in changelog_dir.glob("*.xml") if p.name != master_path.name
+    }
+    included = set(include_order)
+    assert included == on_disk, (
+        "db.changelog-master.xml include list drifted from the changelog "
+        f"directory contents: included-not-on-disk={included - on_disk}, "
+        f"on-disk-not-included={on_disk - included}"
+    )
+    assert len(include_order) == len(on_disk), (
+        f"duplicate <include> entries in db.changelog-master.xml: "
+        f"{len(include_order)} includes vs {len(on_disk)} unique files"
+    )
+
+    global_force: dict[str, bool] = {}
+    allow_keys = _allowlist_keys(allowlist)
+    raw_findings: dict[tuple[str, str, str], Finding] = {}
+    # UNSCANNED_ELEMENT / UNSCANNED_SCHEMA findings are never allowlist-
+    # suppressible (they are a defensive "extend the lint" category, not the
+    # DML classification the allowlist is scoped to) — collected separately
+    # so they always survive into violations regardless of allow_keys.
+    hard_findings: list[Finding] = []
+
+    for basename in include_order:
+        for cs_id, sql_text, unscanned_tags in iter_changesets(
+            changelog_dir, basename
+        ):
+            for tag in unscanned_tags:
+                hard_findings.append(
+                    Finding(
+                        changeset_id=cs_id,
+                        file=basename,
+                        table="",
+                        kind=UNSCANNED_ELEMENT,
+                        detail=(
+                            f"changeset {cs_id} contains a <{tag}> element — "
+                            "unscanned Liquibase element, extend the lint "
+                            "before relying on it for FORCE-RLS DML safety."
+                        ),
+                    )
+                )
+
+            live_force = dict(global_force)
+            toggled_off: set[str] = set()
+            # table -> list of statement indices where a valid same-changeset
+            # backstop (immediately-valid ADD CONSTRAINT / CREATE UNIQUE
+            # INDEX / VALIDATE CONSTRAINT) fired on that table.
+            backstop_indices: dict[str, list[int]] = {}
+            # (target, referenced, live_force snapshot AT this statement,
+            #  this statement's index)
+            dml_events: list[tuple[str, set[str], dict[str, bool], int]] = []
+
+            stmt_index = -1
+            for stmt in _split_statements(sql_text):
+                stmt_index += 1
+
+                m = _FORCE_TOGGLE_RE.search(stmt)
+                if m and stmt.upper().lstrip().startswith("ALTER TABLE"):
+                    key = _table_key(m.group(1), m.group(2))
+                    is_no_force = bool(m.group(3))
+                    live_force[key] = not is_no_force
+                    if is_no_force:
+                        toggled_off.add(key)
+                    continue
+
+                stmt_for_dml = _LEADING_DO_BEGIN_RE.sub("", stmt)
+                m = _DML_TARGET_RE.match(stmt_for_dml)
+                if m:
+                    target = _table_key(m.group(1), m.group(2))
+                    referenced = {
+                        _table_key(g[0], g[1])
+                        for g in _TABLE_MENTION_RE.findall(stmt)
+                    }
+                    dml_events.append(
+                        (target, referenced, dict(live_force), stmt_index)
+                    )
+                    continue
+
+                m = _ADD_CONSTRAINT_RE.search(stmt)
+                if m:
+                    if "NOT VALID" not in stmt.upper():
+                        backstop_indices.setdefault(
+                            _table_key(m.group(1), m.group(2)), []
+                        ).append(stmt_index)
+                    continue
+
+                m = _UNIQUE_INDEX_RE.search(stmt)
+                if m:
+                    backstop_indices.setdefault(
+                        _table_key(m.group(1), m.group(2)), []
+                    ).append(stmt_index)
+                    continue
+
+                m = _VALIDATE_CONSTRAINT_RE.search(stmt)
+                if m:
+                    backstop_indices.setdefault(
+                        _table_key(m.group(1), m.group(2)), []
+                    ).append(stmt_index)
+                    continue
+
+                m = _CREATE_SCHEMA_RE.search(stmt)
+                if m and m.group(1).lower() not in _KNOWN_SCHEMAS:
+                    hard_findings.append(
+                        Finding(
+                            changeset_id=cs_id,
+                            file=basename,
+                            table=m.group(1).lower(),
+                            kind=UNSCANNED_SCHEMA,
+                            detail=(
+                                f"changeset {cs_id} creates schema "
+                                f"{m.group(1)!r}, outside the analyzer's "
+                                "hardcoded nexus/t1 scope — extend the lint "
+                                "before trusting it for this schema."
+                            ),
+                        )
+                    )
+                    continue
+                # else: CREATE TABLE / CREATE INDEX (non-unique) / GRANT /
+                # COMMENT ON / etc. — irrelevant to this lint, ignored.
+
+            for table in toggled_off:
+                if not live_force.get(table):
+                    key = (cs_id, table, MISSING_RESTORE)
+                    raw_findings[key] = Finding(
+                        changeset_id=cs_id,
+                        file=basename,
+                        table=table,
+                        kind=MISSING_RESTORE,
+                        detail=(
+                            f"{table} toggled NO FORCE in changeset {cs_id} "
+                            "but never restored to FORCE before the "
+                            "changeset ended (isolation-window leak)"
+                        ),
+                    )
+
+            for target, referenced, snapshot, dml_idx in dml_events:
+                gated_target = bool(snapshot.get(target))
+
+                if gated_target:
+                    # Only a LATER same-changeset backstop on the TARGET can
+                    # excuse this — the target's own row-security gates the
+                    # whole statement to zero-or-full effect, so read-table
+                    # FORCE state is irrelevant in this branch (fk-001-2..5
+                    # shape: FORCE'd subquery-read parent, sound anyway).
+                    later_backstop = any(
+                        idx > dml_idx
+                        for idx in backstop_indices.get(target, [])
+                    )
+                    if later_backstop:
+                        continue
+                    key = (cs_id, target, NAKED_DML)
+                    raw_findings[key] = Finding(
+                        changeset_id=cs_id,
+                        file=basename,
+                        table=target,
+                        kind=NAKED_DML,
+                        detail=(
+                            f"changeset {cs_id}: DML targeting FORCE-RLS "
+                            f"table {target} has no toggle and no LATER "
+                            "same-changeset backstop (immediately-valid ADD "
+                            "CONSTRAINT / CREATE UNIQUE INDEX / VALIDATE "
+                            f"CONSTRAINT, statement index > {dml_idx}) on "
+                            f"{target}. Wrap with NO FORCE / FORCE "
+                            "(catalog-013-1b pattern) or add a same-"
+                            "changeset backstop AFTER this statement; see "
+                            "nexus-1wjmq."
+                        ),
+                    )
+                else:
+                    # Target itself is not currently FORCE — the statement
+                    # executes for real. ANY referenced (JOIN/subquery) table
+                    # that is independently FORCE-and-untoggled is its own
+                    # finding; a backstop on the (non-gating) target CANNOT
+                    # excuse it (nexus-fqnii: the catalog-014-0-mirror gap).
+                    gated_reads = {
+                        t for t in referenced - {target} if snapshot.get(t)
+                    }
+                    if not gated_reads:
+                        continue
+                    key = (cs_id, target, NAKED_DML)
+                    raw_findings[key] = Finding(
+                        changeset_id=cs_id,
+                        file=basename,
+                        table=target,
+                        kind=NAKED_DML,
+                        detail=(
+                            f"changeset {cs_id}: DML targeting "
+                            f"non-FORCE table {target} reads FORCE-RLS "
+                            f"table(s) {sorted(gated_reads)} via JOIN/"
+                            "subquery with no toggle. A same-changeset "
+                            f"backstop on {target} does NOT excuse this — "
+                            "the read table's own visibility, not the "
+                            "target's, gates this statement's correctness "
+                            "(the catalog-014-0 both-tables lesson); see "
+                            "nexus-1wjmq / nexus-fqnii."
+                        ),
+                    )
+
+            global_force = live_force
+
+    violations = [
+        f
+        for key, f in raw_findings.items()
+        if (f.changeset_id, f.table) not in allow_keys
+    ]
+    violations.extend(hard_findings)
+    consumed = {
+        (f.changeset_id, f.table)
+        for f in raw_findings.values()
+        if (f.changeset_id, f.table) in allow_keys
+    }
+    unused = allow_keys - consumed
+
+    return AnalysisResult(
+        walked_files=include_order,
+        violations=violations,
+        unused_allowlist=unused,
+    )
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+def _write_changelog(tmp_path: Path, changesets_xml: str) -> tuple[Path, Path]:
+    """Write a synthetic single-file changelog + a master that includes it.
+    Returns (changelog_dir, master_path)."""
+    changelog_dir = tmp_path / "changelog"
+    changelog_dir.mkdir()
+    child = changelog_dir / "synthetic-001.xml"
+    child.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<databaseChangeLog\n'
+        '    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"\n'
+        '    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n'
+        '    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog '
+        'http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">\n'
+        f"{changesets_xml}\n"
+        "</databaseChangeLog>\n"
+    )
+    master = changelog_dir / "db.changelog-master.xml"
+    master.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<databaseChangeLog\n'
+        '    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"\n'
+        '    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n'
+        '    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog '
+        'http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">\n'
+        '    <include file="synthetic-001.xml"/>\n'
+        "</databaseChangeLog>\n"
+    )
+    return changelog_dir, master
+
+
+def _analyze_synthetic(tmp_path: Path, changesets_xml: str) -> AnalysisResult:
+    changelog_dir, master = _write_changelog(tmp_path, changesets_xml)
+    return analyze_changelog(
+        changelog_dir=changelog_dir, master_path=master, allowlist=()
+    )
+
+
+# ---------------------------------------------------------------------------
+# FLAG cases — must be caught
+# ---------------------------------------------------------------------------
+
+
+def test_naked_dml_on_force_table_is_flagged(tmp_path):
+    """DML against a FORCE table with no toggle and no backstop anywhere."""
+    xml = """
+    <changeSet id="cs-force" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets FORCE ROW LEVEL SECURITY;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-naked" author="t">
+        <sql splitStatements="true">
+DELETE FROM nexus.widgets WHERE stale = true;
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert any(
+        v.changeset_id == "cs-naked" and v.table == "nexus.widgets"
+        and v.kind == NAKED_DML
+        for v in result.violations
+    ), result.violations
+
+
+def test_missing_restore_is_flagged_even_though_dml_ran(tmp_path):
+    """NO FORCE issued, DML runs (visible), but FORCE never restored before
+    changeset end — flagged as a DISTINCT finding from naked DML, per the
+    design's isolation-window-leak framing."""
+    xml = """
+    <changeSet id="cs-force" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets FORCE ROW LEVEL SECURITY;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-leak" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets NO FORCE ROW LEVEL SECURITY;
+DELETE FROM nexus.widgets WHERE stale = true;
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    missing = [
+        v for v in result.violations
+        if v.changeset_id == "cs-leak" and v.kind == MISSING_RESTORE
+    ]
+    assert missing, result.violations
+    assert missing[0].table == "nexus.widgets"
+    # The naked-DML rule must NOT ALSO fire for this DML — it ran while
+    # visible (toggled off), so it is not itself a no-op; only the
+    # missing-restore leak is the finding.
+    naked = [
+        v for v in result.violations
+        if v.changeset_id == "cs-leak" and v.kind == NAKED_DML
+    ]
+    assert naked == [], naked
+
+
+def test_later_changeset_backstop_does_not_count(tmp_path):
+    """The exact catalog-013-0 shape: naked DML in one changeset, its only
+    backstop (VALIDATE CONSTRAINT) lands in a LATER, separate changeset.
+    Must still be flagged — a later-changeset backstop does NOT suppress."""
+    xml = """
+    <changeSet id="cs-force" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets FORCE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets ADD CONSTRAINT widgets_len_check CHECK (length(name) = 8) NOT VALID;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-naked" author="t">
+        <sql splitStatements="true">
+UPDATE nexus.widgets SET name = substr(name, 1, 8) WHERE length(name) = 16;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-later-backstop" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets VALIDATE CONSTRAINT widgets_len_check;
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert any(
+        v.changeset_id == "cs-naked" and v.table == "nexus.widgets"
+        and v.kind == NAKED_DML
+        for v in result.violations
+    ), result.violations
+
+
+def test_unwrapped_join_table_read_is_flagged(tmp_path):
+    """DML targets a NON-force table but its FROM-clause JOINs a DIFFERENT
+    table that IS force and never toggled — must flag on the
+    referenced-table rule, not just the target-table rule (the catalog-014
+    both-tables lesson, inverted)."""
+    xml = """
+    <changeSet id="cs-force" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.gadgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.gadgets FORCE ROW LEVEL SECURITY;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-join-naked" author="t">
+        <sql splitStatements="true">
+UPDATE nexus.widgets w SET label = g.label FROM nexus.gadgets g WHERE g.id = w.gadget_id;
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert any(
+        v.changeset_id == "cs-join-naked" and v.kind == NAKED_DML
+        for v in result.violations
+    ), result.violations
+
+
+# ---------------------------------------------------------------------------
+# ACCEPT cases — must NOT be flagged
+# ---------------------------------------------------------------------------
+
+
+def test_toggle_wrapped_single_table_accepted(tmp_path):
+    xml = """
+    <changeSet id="cs-force" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets FORCE ROW LEVEL SECURITY;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-wrapped" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets NO FORCE ROW LEVEL SECURITY;
+DELETE FROM nexus.widgets WHERE stale = true;
+ALTER TABLE nexus.widgets FORCE ROW LEVEL SECURITY;
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert result.violations == [], result.violations
+
+
+def test_toggle_wrapped_both_tables_accepted(tmp_path):
+    """catalog-014 shape: two tables toggled off / DML (joining both) /
+    both restored, in one changeset."""
+    xml = """
+    <changeSet id="cs-force" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets FORCE ROW LEVEL SECURITY;
+ALTER TABLE nexus.gadgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.gadgets FORCE ROW LEVEL SECURITY;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-both-wrapped" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE nexus.gadgets NO FORCE ROW LEVEL SECURITY;
+UPDATE nexus.widgets w SET label = g.label FROM nexus.gadgets g WHERE g.id = w.gadget_id;
+ALTER TABLE nexus.gadgets FORCE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets FORCE ROW LEVEL SECURITY;
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert result.violations == [], result.violations
+
+
+def test_same_changeset_backstop_accepted(tmp_path):
+    xml = """
+    <changeSet id="cs-force" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets FORCE ROW LEVEL SECURITY;
+ALTER TABLE nexus.owners (id) ADD COLUMN dummy int;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-backstopped" author="t">
+        <sql splitStatements="true">
+DELETE FROM nexus.widgets WHERE owner_id NOT IN (SELECT id FROM nexus.owners);
+ALTER TABLE nexus.widgets ADD CONSTRAINT widgets_owner_fk FOREIGN KEY (owner_id) REFERENCES nexus.owners (id);
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert result.violations == [], result.violations
+
+
+def test_function_body_dml_exempt(tmp_path):
+    """A CREATE FUNCTION ... $$ ... $$ body's internal DML is exempt
+    (SECURITY INVOKER, call-time) regardless of FORCE state — mirrors
+    catalog-003's document_trash/purge_trash class."""
+    xml = """
+    <changeSet id="cs-force" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets FORCE ROW LEVEL SECURITY;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-fn" author="t">
+        <sql splitStatements="false">
+CREATE OR REPLACE FUNCTION nexus.widget_trash(wid text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+    UPDATE nexus.widgets SET deleted_at = NOW() WHERE id = wid;
+END;
+$$
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert result.violations == [], result.violations
+
+
+def test_do_block_dml_is_not_exempt(tmp_path):
+    """The critical negative case: a DO $$ ... $$ anonymous block executes
+    immediately at migration time and must NOT be treated as an exempt
+    function body — its naked DML is flagged exactly like top-level SQL
+    (taxonomy-004-1 ground-truth shape)."""
+    xml = """
+    <changeSet id="cs-force" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets FORCE ROW LEVEL SECURITY;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-do-naked" author="t">
+        <sql splitStatements="false">
+DO $$
+BEGIN
+    DELETE FROM nexus.widgets WHERE stale = true;
+END $$;
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert any(
+        v.changeset_id == "cs-do-naked" and v.table == "nexus.widgets"
+        and v.kind == NAKED_DML
+        for v in result.violations
+    ), (
+        "DO $$ block DML must be flagged, not silently exempted as a "
+        f"function body: {result.violations}"
+    )
+
+
+def test_dml_on_never_force_table_accepted(tmp_path):
+    """A table that never had FORCE ROW LEVEL SECURITY established is never
+    flagged, regardless of DML shape (service_tokens ground-truth case)."""
+    xml = """
+    <changeSet id="cs-plain" author="t">
+        <sql splitStatements="true">
+UPDATE nexus.service_tokens SET scope = 'root' WHERE label = 'bootstrap-legacy-token';
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert result.violations == [], result.violations
+
+
+# ---------------------------------------------------------------------------
+# Regression pins for the code-review-expert / substantive-critic fix round
+# (nexus-fqnii Critical + Important #1): corrected same-changeset-backstop
+# rule, gating-aware and order-sensitive.
+# ---------------------------------------------------------------------------
+
+
+def test_unrelated_target_backstop_does_not_excuse_a_gated_read_table(tmp_path):
+    """nexus-fqnii Critical, corrected: a non-gated target (never FORCE) that
+    JOINs a gated (FORCE, untoggled) read table must be FLAGGED even when the
+    target carries an UNRELATED same-changeset backstop — a backstop on a
+    table the DML doesn't need to prove anything about cannot excuse a
+    different table's visibility risk (the catalog-014-0-mirror gap the
+    critic repro'd: widgets never-FORCE target, gadgets FORCE-and-untoggled
+    referenced via FROM, unrelated ADD CONSTRAINT on widgets)."""
+    xml = """
+    <changeSet id="cs-force" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.gadgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.gadgets FORCE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets (id) ADD COLUMN dummy int;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-join-unrelated-backstop" author="t">
+        <sql splitStatements="true">
+UPDATE nexus.widgets w SET label = g.label FROM nexus.gadgets g WHERE g.id = w.gadget_id;
+ALTER TABLE nexus.widgets ADD CONSTRAINT widgets_dummy_unique UNIQUE (dummy);
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert any(
+        v.changeset_id == "cs-join-unrelated-backstop" and v.kind == NAKED_DML
+        for v in result.violations
+    ), (
+        "an unrelated backstop on the (non-gating) target must NOT suppress "
+        f"a gated referenced-table finding: {result.violations}"
+    )
+
+
+def test_backstop_before_dml_does_not_count(tmp_path):
+    """code-review-expert Important #1: a same-changeset backstop that runs
+    BEFORE the DML it is meant to prove-or-fail proves nothing — order
+    matters. A gated target with only an earlier backstop must still be
+    flagged."""
+    xml = """
+    <changeSet id="cs-force" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets FORCE ROW LEVEL SECURITY;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-backstop-before-dml" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets ADD CONSTRAINT widgets_owner_fk FOREIGN KEY (owner_id) REFERENCES nexus.owners (id);
+DELETE FROM nexus.widgets WHERE stale = true;
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert any(
+        v.changeset_id == "cs-backstop-before-dml" and v.kind == NAKED_DML
+        for v in result.violations
+    ), (
+        "a backstop preceding the DML must NOT count as a safety proof for "
+        f"it: {result.violations}"
+    )
+
+
+def test_gated_target_with_gated_subquery_read_and_later_backstop_accepted(tmp_path):
+    """The fk-001 shape, pinned precisely: a GATED target (FORCE, untoggled)
+    whose DML reads a DIFFERENT, ALSO-gated table only via a WHERE-subquery
+    (not a FROM/USING join), backstopped by a LATER same-changeset
+    immediately-valid ADD CONSTRAINT on the TARGET. Must be ACCEPTED — the
+    read table's FORCE state is irrelevant once the target itself gates the
+    whole statement to zero-or-full effect (verified against fk-001-2..5:
+    document_aspects UPDATE reading FORCE'd catalog_documents via NOT
+    EXISTS, backstopped by an immediately-valid ADD CONSTRAINT FK on
+    document_aspects itself)."""
+    xml = """
+    <changeSet id="cs-force" author="t">
+        <sql splitStatements="true">
+ALTER TABLE nexus.widgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.widgets FORCE ROW LEVEL SECURITY;
+ALTER TABLE nexus.owners ENABLE ROW LEVEL SECURITY;
+ALTER TABLE nexus.owners FORCE ROW LEVEL SECURITY;
+        </sql>
+    </changeSet>
+    <changeSet id="cs-subquery-backstopped" author="t">
+        <sql splitStatements="true">
+DELETE FROM nexus.widgets WHERE owner_id NOT IN (SELECT id FROM nexus.owners);
+ALTER TABLE nexus.widgets ADD CONSTRAINT widgets_owner_fk FOREIGN KEY (owner_id) REFERENCES nexus.owners (id);
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert result.violations == [], result.violations
+
+
+def test_unused_allowlist_entry_is_detected_when_no_matching_finding(tmp_path):
+    """code-review-expert Important #2: a direct test of the unused-allowlist
+    DETECTION MECHANISM itself, not just the real-corpus ``== set()``
+    assertion (which only proves the 8 real entries ARE reproduced, not that
+    a genuinely stale/wrong entry would be caught). A bogus allowlist key
+    that matches no live finding must land in ``unused_allowlist``."""
+    xml = """
+    <changeSet id="cs-plain" author="t">
+        <sql splitStatements="true">
+CREATE TABLE nexus.widgets (id int);
+        </sql>
+    </changeSet>
+    """
+    changelog_dir, master = _write_changelog(tmp_path, xml)
+    bogus_allowlist = (
+        ("nonexistent-changeset", "nexus.nonexistent_table", "stale entry"),
+    )
+    result = analyze_changelog(
+        changelog_dir=changelog_dir, master_path=master, allowlist=bogus_allowlist
+    )
+    assert result.unused_allowlist == {
+        ("nonexistent-changeset", "nexus.nonexistent_table")
+    }
+    assert result.violations == []
+
+
+@pytest.mark.parametrize("tag", ["sqlFile", "customChange", "createProcedure"])
+def test_unscanned_liquibase_element_is_flagged(tmp_path, tag):
+    """code-review-expert / critic Significant 3: a Liquibase change-type
+    element this analyzer cannot see into at all must be flagged as its own
+    finding ("extend the lint"), not silently skipped. Zero current usage in
+    the real corpus (grep-verified) — purely defensive."""
+    changelog_dir = tmp_path / "changelog"
+    changelog_dir.mkdir()
+    if tag == "sqlFile":
+        el = '<sqlFile path="some.sql"/>'
+    elif tag == "customChange":
+        el = '<customChange class="com.example.Thing"/>'
+    else:
+        el = '<createProcedure>CREATE PROCEDURE nexus.p() ...</createProcedure>'
+    child = changelog_dir / "synthetic-001.xml"
+    child.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<databaseChangeLog\n'
+        '    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"\n'
+        '    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n'
+        '    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog '
+        'http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">\n'
+        f'    <changeSet id="cs-unscanned" author="t">\n'
+        f"        {el}\n"
+        "    </changeSet>\n"
+        "</databaseChangeLog>\n"
+    )
+    master = changelog_dir / "db.changelog-master.xml"
+    master.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<databaseChangeLog\n'
+        '    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"\n'
+        '    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n'
+        '    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog '
+        'http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">\n'
+        '    <include file="synthetic-001.xml"/>\n'
+        "</databaseChangeLog>\n"
+    )
+    result = analyze_changelog(
+        changelog_dir=changelog_dir, master_path=master, allowlist=()
+    )
+    assert any(
+        v.changeset_id == "cs-unscanned" and v.kind == UNSCANNED_ELEMENT
+        for v in result.violations
+    ), result.violations
+
+
+def test_create_schema_outside_known_scope_is_flagged(tmp_path):
+    """FIX 5(c): a CREATE SCHEMA for anything other than nexus/t1 is
+    completely invisible to every other rule in this file (hardcoded schema
+    scope) — this tripwire is the one thing that catches that moment. The
+    real corpus's two CREATE SCHEMA statements (nexus, t1) must NOT trip
+    this (see test_real_changelog_zero_violations_and_full_allowlist_consumption)."""
+    xml = """
+    <changeSet id="cs-schema" author="t">
+        <sql splitStatements="true">
+CREATE SCHEMA analytics;
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert any(
+        v.changeset_id == "cs-schema" and v.kind == UNSCANNED_SCHEMA
+        for v in result.violations
+    ), result.violations
+
+
+def test_create_schema_nexus_and_t1_do_not_trip_the_tripwire(tmp_path):
+    xml = """
+    <changeSet id="cs-schema-known" author="t">
+        <sql splitStatements="true">
+CREATE SCHEMA IF NOT EXISTS nexus;
+CREATE SCHEMA IF NOT EXISTS t1;
+        </sql>
+    </changeSet>
+    """
+    result = _analyze_synthetic(tmp_path, xml)
+    assert result.violations == [], result.violations
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity self-checks
+# ---------------------------------------------------------------------------
+
+
+def test_master_include_order_matches_directory_contents():
+    """Self-verifying floor: every non-master ``*.xml`` file in the real
+    changelog directory is included exactly once in
+    ``db.changelog-master.xml``, and vice versa. This is the live version of
+    the 39-file non-vacuity assertion — it is derived from the directory,
+    never a hardcoded constant, so it cannot silently drift (nx_plan_audit
+    correction, nexus-php10 2026-07-09)."""
+    include_order = parse_master_include_order(MASTER_CHANGELOG)
+    on_disk = {
+        p.name for p in CHANGELOG_DIR.glob("*.xml")
+        if p.name != MASTER_CHANGELOG.name
+    }
+    assert set(include_order) == on_disk
+    assert len(include_order) == len(on_disk)
+    # Floor value recorded for human legibility; the assertions above are
+    # what actually guards non-vacuity (a silently-empty glob would make
+    # both sides 0 and vacuously "match" without this explicit floor).
+    assert len(on_disk) >= 30, (
+        f"changelog directory glob returned suspiciously few files "
+        f"({len(on_disk)}) — possible empty/misconfigured CHANGELOG_DIR"
+    )
+
+
+def test_allowlist_has_no_duplicate_keys():
+    keys = [(cs_id, table) for cs_id, table, _ in ALLOWLIST]
+    assert len(keys) == len(set(keys)), "duplicate ALLOWLIST (changeset, table) key"
+
+
+# ---------------------------------------------------------------------------
+# The real changelog — exact-set assertion
+# ---------------------------------------------------------------------------
+
+
+def test_real_changelog_zero_violations_and_full_allowlist_consumption():
+    """The tripwire itself: run the analyzer against the ACTUAL
+    ``service/src/main/resources/db/changelog/`` tree.
+
+    Two exact (``==``, never ``>=``) assertions:
+      1. Zero violations survive the allowlist — every dangerous-shape DML
+         statement in the real changelog is either safe (toggle-wrapped /
+         same-changeset backstop) or an explicitly grandfathered historical
+         member.
+      2. Zero UNUSED allowlist entries — every grandfathered member is
+         independently re-derived by a live analyzer run against the real
+         changelog, not hand-waved. An unused entry means either the
+         changeset was removed/rewritten (checksum-immutable migrations
+         never are) or the analyzer's classification logic drifted and no
+         longer reproduces a known historical finding — either way, a
+         signal worth investigating, not silently dropping.
+
+    Ground truth (nx memory get -p nexus -t
+    php10-ground-truth-classification.md): exactly 8 (changeset, table)
+    dangerous-shape pairs across 6 changesets (catalog-013-0, taxonomy-004-1
+    ×3 tables, fk-002-0-backfill-stubs, fk-003-0-backfill-stubs,
+    fk-002-6-reconcile, fk-003-6-reconcile) — fk-001-2..5 are explicitly
+    NOT grandfathered (verified same-changeset backstop via an
+    immediately-valid ADD CONSTRAINT FK on their own DML target table).
+    """
+    result = analyze_changelog()
+    assert result.total_violations == 0, (
+        "FORCE-RLS migration DML tripwire fired — see nexus-1wjmq for the "
+        f"failure class and the toggle-wrap / same-changeset-backstop "
+        f"remedies: {[(v.changeset_id, v.table, v.kind, v.detail) for v in result.violations]}"
+    )
+    assert result.unused_allowlist == set(), (
+        "ALLOWLIST entries not reproduced by a live analyzer run (rot — "
+        "either the migration changed, which should be impossible for a "
+        "checksum-immutable changeset, or the analyzer's classification "
+        f"logic regressed): {result.unused_allowlist}"
+    )
+
+
+def test_real_changelog_walks_all_39_files():
+    """Non-vacuity floor for the real-changelog run specifically (not just
+    the master/directory parity check above): the analyzer must actually
+    have walked every included file, not silently short-circuited."""
+    result = analyze_changelog()
+    on_disk = {
+        p.name for p in CHANGELOG_DIR.glob("*.xml")
+        if p.name != MASTER_CHANGELOG.name
+    }
+    assert len(result.walked_files) == len(on_disk)
+    assert set(result.walked_files) == on_disk
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_combined_query_multimodel_bug.py
+++ b/tests/test_combined_query_multimodel_bug.py
@@ -1,0 +1,354 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-3l6gz: combined-query MCP tools drop a whole embedding-model group.
+
+Root cause (see the bead / debugger report): ``search_graph_hop`` and
+``search_metadata_scoped`` resolve a multi-prefix corpus (e.g. ``code,docs``)
+to a FLAT collection list that can span two embedding models
+(``voyage-code-3`` + ``voyage-context-3``, both 1024-dim) and pass the whole
+list to the service in ONE call. The service
+(``PgVectorRepository.searchGraphHopWithTokens``) guards only *dimension*
+homogeneity (``requireHomogeneousDim``) and then embeds the query with
+``collectionNames.get(0)``'s model only, using that single vector across BOTH
+vector spaces. There is NO grouping by embedding model anywhere in the stack,
+so a corpus spanning two models is queried in one model's space — the other
+model's chunks are not correctly retrieved and the result collapses to empty.
+
+The correct contract: group the resolved collections by embedding model, issue
+ONE combined-query per model group, and merge — exactly what
+``search_topic_scoped`` already does with its per-collection loop, and what
+graph-hop / metadata-scoped do NOT.
+
+These tests fail on the current (single mixed-model call) code and pass once
+the tool groups by embedding model.
+"""
+from __future__ import annotations
+
+from nexus.corpus import embedding_model_for_collection_name
+from nexus.mcp import core
+
+# Two conformant collections, SAME dimension (1024), DIFFERENT embedding model.
+# This is the exact shape of the live repro: prefix `code` -> voyage-code-3,
+# prefix `docs` -> voyage-context-3.
+CODE_COL = "code__acme-1-1__voyage-code-3__v1"
+DOCS_COL = "docs__acme-1-1__voyage-context-3__v1"
+
+
+def _model(coll: str) -> str:
+    return embedding_model_for_collection_name(coll) or coll
+
+
+class _ModelAwareServiceT3:
+    """Faithful stand-in for the service combined-query path.
+
+    Mirrors ``PgVectorRepository`` semantics that the debugger confirmed by
+    reading the Java source: the query is embedded ONCE with
+    ``collection_names[0]``'s model and every collection's chunks are ranked
+    against that single vector. A chunk is therefore only retrievable when the
+    query is embedded in the chunk's OWN model space. We model that as: a call
+    returns the seeded rows whose ``collection`` is in the requested set AND
+    whose model matches ``model(collection_names[0])``. A call whose collection
+    list spans two models thus retrieves only the first model's rows — the
+    observed multi-model data loss.
+    """
+
+    def __init__(self, rows: list[dict]) -> None:
+        self.rows = rows
+        self.graph_calls: list[list[str]] = []
+        self.meta_calls: list[list[str]] = []
+
+    def _retrieve(self, collection_names: list[str]) -> list[dict]:
+        if not collection_names:
+            return []
+        query_model = _model(collection_names[0])
+        requested = set(collection_names)
+        return [
+            r for r in self.rows
+            if r.get("collection") in requested
+            and _model(r["collection"]) == query_model
+        ]
+
+    def search_graph_hop(self, query, seeds, collection_names, *, link_type=None,
+                         depth=1, direction="both", where=None, n_results=10):
+        self.graph_calls.append(list(collection_names))
+        return self._retrieve(list(collection_names))
+
+    def search_metadata_scoped(self, query, collection_names, *, content_type=None,
+                               author=None, year=None, corpus=None, subtree=None,
+                               where=None, n_results=10):
+        self.meta_calls.append(list(collection_names))
+        return self._retrieve(list(collection_names))
+
+
+def _wire(monkeypatch, t3, target: list[str]) -> None:
+    monkeypatch.setattr(core, "_get_t3", lambda: t3)
+    monkeypatch.setattr(core, "_resolve_corpus_target", lambda corpus, t3: target)
+    monkeypatch.setattr(
+        "nexus.db.http_vector_client.is_service_backed", lambda db: True)
+
+
+def _max_models_per_call(calls: list[list[str]]) -> int:
+    return max((len({_model(c) for c in cols}) for cols in calls), default=0)
+
+
+class TestSearchGraphHopMultiModel:
+    def test_multimodel_corpus_does_not_drop_the_hit(self, monkeypatch):
+        # Seed 1.9.80's reachable hit lives in the DOCS (voyage-context-3) group,
+        # while `_resolve_corpus_target("code,docs")` puts the CODE
+        # (voyage-code-3) collection first -> the single mixed-model call embeds
+        # the query with voyage-code-3 and never retrieves the docs hit.
+        hit = {"id": "1.9.80", "content": "reachable doc", "distance": 0.2,
+               "collection": DOCS_COL, "chash": "a" * 32}
+        t3 = _ModelAwareServiceT3([hit])
+        _wire(monkeypatch, t3, [CODE_COL, DOCS_COL])
+
+        out = core.search_graph_hop("q", ["1.9.80"], corpus="code,docs", depth=2)
+
+        assert "1.9.80" in out, (
+            "multi-model corpus dropped the reachable hit; "
+            f"tool returned {out!r}")
+
+    def test_never_issues_a_mixed_model_client_call(self, monkeypatch):
+        # Contract (assumption-free): each combined-query call must be
+        # embedding-model-homogeneous, because one query vector cannot serve two
+        # vector spaces. The tool must split the resolved corpus by model.
+        hit = {"id": "1.9.80", "content": "reachable doc", "distance": 0.2,
+               "collection": CODE_COL, "chash": "a" * 32}
+        t3 = _ModelAwareServiceT3([hit])
+        _wire(monkeypatch, t3, [CODE_COL, DOCS_COL])
+
+        core.search_graph_hop("q", ["1.9.80"], corpus="code,docs", depth=2)
+
+        assert t3.graph_calls, "graph-hop must be called"
+        assert _max_models_per_call(t3.graph_calls) == 1, (
+            "search_graph_hop passed a mixed-embedding-model collection list to "
+            f"the service in one call: {t3.graph_calls}")
+
+    def test_hits_in_both_model_groups_survive_the_merge(self, monkeypatch):
+        # Positive assertion (debugger-recommended): once each model group is
+        # queried separately, a hit in EITHER group must survive the merge —
+        # not just the group that happens to be collection_names[0].
+        code_hit = {"id": "1.1.1", "content": "code hit", "distance": 0.5,
+                    "collection": CODE_COL, "chash": "b" * 32}
+        docs_hit = {"id": "1.2.2", "content": "docs hit", "distance": 0.1,
+                    "collection": DOCS_COL, "chash": "c" * 32}
+        t3 = _ModelAwareServiceT3([code_hit, docs_hit])
+        _wire(monkeypatch, t3, [CODE_COL, DOCS_COL])
+
+        out = core.search_graph_hop("q", ["1.9.80"], corpus="code,docs", depth=2,
+                                    structured=True)
+
+        assert set(out["ids"]) == {"1.1.1", "1.2.2"}, (
+            f"both model-group hits must survive the merge; got {out['ids']!r}")
+        assert out["distances"] == sorted(out["distances"]), (
+            "graph-hop merge must be distance-ascending across model groups")
+
+
+class TestSearchMetadataScopedMultiModel:
+    """Sibling tool shares the defect: same single mixed-model call shape."""
+
+    def test_multimodel_corpus_does_not_drop_the_hit(self, monkeypatch):
+        hit = {"id": "1.9.80", "content": "reachable doc", "distance": 0.2,
+               "collection": DOCS_COL, "chash": "a" * 32}
+        t3 = _ModelAwareServiceT3([hit])
+        _wire(monkeypatch, t3, [CODE_COL, DOCS_COL])
+
+        out = core.search_metadata_scoped("q", corpus="code,docs")
+
+        assert "1.9.80" in out, (
+            "multi-model corpus dropped the hit; "
+            f"tool returned {out!r}")
+
+    def test_never_issues_a_mixed_model_client_call(self, monkeypatch):
+        hit = {"id": "1.9.80", "content": "reachable doc", "distance": 0.2,
+               "collection": CODE_COL, "chash": "a" * 32}
+        t3 = _ModelAwareServiceT3([hit])
+        _wire(monkeypatch, t3, [CODE_COL, DOCS_COL])
+
+        core.search_metadata_scoped("q", corpus="code,docs")
+
+        assert t3.meta_calls, "metadata-scoped must be called"
+        assert _max_models_per_call(t3.meta_calls) == 1, (
+            "search_metadata_scoped passed a mixed-embedding-model collection "
+            f"list to the service in one call: {t3.meta_calls}")
+
+    def test_hits_in_both_model_groups_survive_merge_distance_ascending(self, monkeypatch):
+        # Positive assertion (debugger-recommended): hits in TWO model groups
+        # both survive the merge, AND the merged order is globally
+        # distance-ascending across groups (not just call-order-ascending) —
+        # the weaker (0.5) code-group hit must NOT precede the stronger (0.1)
+        # docs-group hit just because its group was queried first.
+        code_hit = {"id": "1.1.1", "content": "code hit", "distance": 0.5,
+                    "collection": CODE_COL, "chash": "b" * 32}
+        docs_hit = {"id": "1.2.2", "content": "docs hit", "distance": 0.1,
+                    "collection": DOCS_COL, "chash": "c" * 32}
+        t3 = _ModelAwareServiceT3([code_hit, docs_hit])
+        _wire(monkeypatch, t3, [CODE_COL, DOCS_COL])
+
+        out = core.search_metadata_scoped("q", corpus="code,docs", structured=True)
+
+        assert out["ids"] == ["1.2.2", "1.1.1"], (
+            "both model-group hits must survive the merge, ordered "
+            f"distance-ascending across groups; got {out['ids']!r}")
+        assert out["distances"] == [0.1, 0.5]
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# nexus-hg745: query()'s service-mode catalog-routing branch shares the exact
+# nexus-3l6gz defect at its own 3 raw call sites (metadata-scoped without
+# follow_links, the follow_links-no-seeds metadata-scoped fallback, and
+# graph-hop with resolved seeds) — reachable via
+# query(corpus="all"/"code,docs", author=/content_type=/follow_links=/subtree=)
+# in service mode. All 3 sites now route through the same
+# _grouped_combined_query fix as the two standalone tools.
+# ═════════════════════════════════════════════════════════════════════════════
+
+def _wire_query(monkeypatch, t3, target: list[str]) -> None:
+    """Minimal wiring for query()'s service-mode catalog branch.
+
+    Mirrors tests/test_query_repoint.py's `_wire`, pared to what the
+    service-mode branch touches when the test never falls into text-form
+    re-hydration (structured=True) or subtree/follow_links seed resolution
+    via the catalog object itself: _get_t3, _resolve_corpus_target,
+    is_service_backed, and a non-None catalog stand-in (only its identity
+    is checked — `if cat is None: return Error` — before this branch).
+    """
+    monkeypatch.setattr(core, "_get_t3", lambda: t3)
+    monkeypatch.setattr(core, "_resolve_corpus_target", lambda corpus, _t3: target)
+    monkeypatch.setattr(
+        "nexus.db.http_vector_client.is_service_backed", lambda db: True)
+    monkeypatch.setattr(core, "_get_catalog", lambda: object())
+
+
+class TestQueryServiceModeMultiModel:
+    def test_metadata_scoped_path_does_not_drop_the_hit(self, monkeypatch):
+        # content_type (no follow_links) routes through the "else" branch's
+        # single search_metadata_scoped call site (~1806).
+        hit = {"id": "1.9.80", "content": "reachable doc", "distance": 0.2,
+               "collection": DOCS_COL, "chash": "a" * 32}
+        t3 = _ModelAwareServiceT3([hit])
+        _wire_query(monkeypatch, t3, [CODE_COL, DOCS_COL])
+
+        out = core.query("q", corpus="code,docs", content_type="paper", structured=True)
+
+        assert "1.9.80" in out["ids"], (
+            f"query()'s metadata-scoped branch dropped the multi-model hit; got {out!r}")
+
+    def test_metadata_scoped_path_never_issues_a_mixed_model_call(self, monkeypatch):
+        hit = {"id": "1.9.80", "content": "reachable doc", "distance": 0.2,
+               "collection": CODE_COL, "chash": "a" * 32}
+        t3 = _ModelAwareServiceT3([hit])
+        _wire_query(monkeypatch, t3, [CODE_COL, DOCS_COL])
+
+        core.query("q", corpus="code,docs", content_type="paper", structured=True)
+
+        assert t3.meta_calls, "search_metadata_scoped must be called"
+        assert _max_models_per_call(t3.meta_calls) == 1, (
+            "query()'s metadata-scoped branch passed a mixed-embedding-model "
+            f"collection list to the service in one call: {t3.meta_calls}")
+
+    def test_graph_hop_path_with_seeds_does_not_drop_the_hit(self, monkeypatch):
+        # follow_links + subtree resolves real seeds via cat.descendants() ->
+        # the search_graph_hop call site (~1796). follow_links must be
+        # truthy to enter this branch at all; subtree supplies the seeds.
+        hit = {"id": "1.9.80", "content": "reachable doc", "distance": 0.2,
+               "collection": DOCS_COL, "chash": "a" * 32}
+        t3 = _ModelAwareServiceT3([hit])
+        _wire_query(monkeypatch, t3, [CODE_COL, DOCS_COL])
+        monkeypatch.setattr(
+            core, "_get_catalog",
+            lambda: type("C", (), {
+                "descendants": lambda self, prefix: [{"tumbler": "1.9.80"}],
+            })())
+
+        out = core.query("q", corpus="code,docs", follow_links="cites",
+                         subtree="1.9", structured=True)
+
+        assert t3.graph_calls, "search_graph_hop must be called"
+        assert "1.9.80" in out["ids"], (
+            f"query()'s graph-hop branch dropped the multi-model hit; got {out!r}")
+        assert _max_models_per_call(t3.graph_calls) == 1, (
+            "query()'s graph-hop branch passed a mixed-embedding-model "
+            f"collection list to the service in one call: {t3.graph_calls}")
+
+    def test_follow_links_no_seeds_fallback_never_issues_a_mixed_model_call(self, monkeypatch):
+        # follow_links with NO resolvable seeds falls through to the
+        # metadata-scoped fallback call site (~1786) — the third raw site.
+        hit = {"id": "1.9.80", "content": "reachable doc", "distance": 0.2,
+               "collection": DOCS_COL, "chash": "a" * 32}
+        t3 = _ModelAwareServiceT3([hit])
+        _wire_query(monkeypatch, t3, [CODE_COL, DOCS_COL])
+        monkeypatch.setattr(
+            core, "_get_catalog",
+            lambda: type("C", (), {"find": lambda self, q, content_type=None: []})())
+
+        out = core.query("q", corpus="code,docs", follow_links="cites", structured=True)
+
+        assert t3.graph_calls == [], "no seeds resolved -> graph_hop must NOT be called"
+        assert t3.meta_calls, "the metadata-scoped fallback must be called"
+        assert _max_models_per_call(t3.meta_calls) == 1, (
+            "query()'s follow_links-no-seeds fallback passed a mixed-embedding-model "
+            f"collection list to the service in one call: {t3.meta_calls}")
+        assert "1.9.80" in out["ids"], (
+            f"the fallback dropped the multi-model hit; got {out!r}")
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Partial-group-failure semantics (substantive-critic Significant #1): a
+# later model group's exception must abort the WHOLE tool call — no silent
+# partial result set built only from groups that succeeded first. Matches
+# search_topic_scoped's existing (uncaught) per-collection loop precedent.
+# ═════════════════════════════════════════════════════════════════════════════
+
+class _PartialFailureServiceT3:
+    """First combined-query call succeeds; every call after it raises.
+
+    With two model groups this means: first group's call returns real rows,
+    second group's call raises -- used to prove the merge is all-or-nothing.
+    """
+
+    def __init__(self, first_call_rows: list[dict]) -> None:
+        self.first_call_rows = first_call_rows
+        self.calls = 0
+
+    def search_metadata_scoped(self, query, collection_names, **kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            return self.first_call_rows
+        raise RuntimeError("simulated second-model-group service failure")
+
+    def search_graph_hop(self, query, seeds, collection_names, **kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            return self.first_call_rows
+        raise RuntimeError("simulated second-model-group service failure")
+
+
+class TestPartialGroupFailureIsAllOrNothing:
+    def test_metadata_scoped_second_group_failure_returns_error_not_partial_rows(
+        self, monkeypatch,
+    ):
+        first_group_hit = {"id": "1.1.1", "content": "ok", "distance": 0.1,
+                            "collection": CODE_COL, "chash": "a" * 32}
+        t3 = _PartialFailureServiceT3([first_group_hit])
+        _wire(monkeypatch, t3, [CODE_COL, DOCS_COL])
+
+        out = core.search_metadata_scoped("q", corpus="code,docs")
+
+        assert isinstance(out, str) and out.startswith("Error:"), (
+            "a later model group's failure must abort the whole call and "
+            f"surface as an error, never a partial row set; got {out!r}")
+
+    def test_graph_hop_second_group_failure_returns_error_not_partial_rows(
+        self, monkeypatch,
+    ):
+        first_group_hit = {"id": "1.1.1", "content": "ok", "distance": 0.1,
+                            "collection": CODE_COL, "chash": "a" * 32}
+        t3 = _PartialFailureServiceT3([first_group_hit])
+        _wire(monkeypatch, t3, [CODE_COL, DOCS_COL])
+
+        out = core.search_graph_hop("q", ["1.9.80"], corpus="code,docs", depth=2)
+
+        assert isinstance(out, str) and out.startswith("Error:"), (
+            "a later model group's failure must abort the whole call and "
+            f"surface as an error, never a partial row set; got {out!r}")

--- a/tests/test_service_cmd.py
+++ b/tests/test_service_cmd.py
@@ -74,6 +74,14 @@ def test_issue_passes_scope_flag() -> None:
     assert _FakeStore.calls == [("issue_token", ("conexus-edge", None, None, "mint"))]
 
 
+def test_issue_passes_mint_locked_scope_flag() -> None:
+    # nexus-xidcq (RDR-005 2a): tenant-locked mint credential — the CLI just forwards
+    # the string verbatim; server-side (TokenAdminHandler) is the security boundary.
+    result = _run(["token", "issue", "--tenant", "conexus-edge-locked", "--scope", "mint-locked"])
+    assert result.exit_code == 0, result.output
+    assert _FakeStore.calls == [("issue_token", ("conexus-edge-locked", None, None, "mint-locked"))]
+
+
 def test_issue_omits_scope_by_default() -> None:
     result = _run(["token", "issue", "--tenant", "t-a"])
     assert result.exit_code == 0, result.output

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "6.5.1"
+version = "6.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## conexus 6.5.2

Patch release. Promotes develop to main.

### Fixed
- `nx guided-upgrade` no longer demands a Voyage key for mislabeled local collections (nexus-119p9, GH #1381 second report): the voyage-capability gate now honors the nb7hr measured-dim override — measured-bge collections auto-remap locally; genuine voyage still gates; unprobeable stays fail-closed.
- Multi-model corpus combined queries no longer return empty (nexus-3l6gz, nexus-hg745): the MCP layer groups collections by embedding model across all five combined-query call sites (incl. `query()`'s service branch), one call per group, distance-merged.

### Added
- `nx service token issue --scope mint-locked` (nexus-xidcq, conexus RDR-005 2a; engine ≥ 0.1.36).
- Combined-query end-to-end tripwire in the write-seam CI gate (nexus-4nflf).
- FORCE-RLS changelog lint in the required suite (nexus-php10).

### Engine pin
- `PINNED_SERVICE_TAG` → engine-service-v0.1.36 (deployed + STEP-6 cloud-gated 2026-07-09); floor stays (0,1,34).

### Gate evidence
- Full unit suite 12517 passed / 0 failed; local-service gate 451 passed (vacuity floor met); sandbox smoke [done]; upgrade-shakeout 12/12 PASS (6.5.1 → this branch); engine-freshness gate green (zero service/ drift since the pinned tag, live cloud reads 0.1.36).