### PR TITLE
fix(daemon): three service-mode gaps found via live incident triage

### DIFF
--- a/src/nexus/commands/catalog_cmds/doctor.py
+++ b/src/nexus/commands/catalog_cmds/doctor.py
@@ -1055,7 +1055,6 @@ def _run_name_vs_embed_dim() -> dict:
             "error": f"Failed to list T3 collections: {exc}",
         }
 
-    client = t3_db._client  # type: ignore[attr-defined]
     for name in cols:
         if not is_conformant_collection_name(name):
             skipped_non_conformant += 1
@@ -1067,14 +1066,22 @@ def _run_name_vs_embed_dim() -> dict:
             unknown_token.append({"collection": name, "token": token})
             continue
         try:
-            coll = client.get_collection(name)
-            sample = coll.get(limit=1, include=["embeddings"])
+            # nexus-pyv0e: sample via the dual-mode-safe public surface
+            # (get_collection + get_embeddings), not client._client — the
+            # service-mode HttpVectorClient has no ._client attribute, only
+            # local T3Database's raw chromadb client does.
+            coll = t3_db.get_collection(name)
+            sample = coll.get(limit=1)
+            ids = sample.get("ids") or []
+            if not ids:
+                empty.append(name)
+                continue
+            embs = t3_db.get_embeddings(name, ids[:1])
         except Exception as exc:  # noqa: BLE001 — boundary catch; third-party raises undocumented types, handled gracefully
             unknown_token.append(
                 {"collection": name, "token": token, "error": str(exc)}
             )
             continue
-        embs = sample.get("embeddings")
         if embs is None or len(embs) == 0:
             empty.append(name)
             continue

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -1071,6 +1071,7 @@ class T2EnsureOutcome(Enum):
     DEFERRED_SIGTERM = "deferred_sigterm"        # stale daemon ALIVE; SIGTERM'd but did not exit in window
     CRASHLOOP_SUPPRESSED = "crashloop_suppressed"  # no live incumbent daemon (never existed, or was fully reaped); crash-loop guard refused respawn
     SPAWN_FAILED = "spawn_failed"                # no daemon: cold-spawned process died or never became reachable
+    SERVICE_MODE_SKIP = "service_mode_skip"      # memory store is in SERVICE mode; the SQLite daemon has no role (RDR-176)
 
 
 def _t2_ensure_running_inner(
@@ -1087,6 +1088,27 @@ def _t2_ensure_running_inner(
     import time as _time  # noqa: PLC0415 — deferred import — CLI startup cost, only needed in this subcommand path
 
     config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
+
+    # RDR-176 Phase 1 (Gap 2): in SERVICE mode the SQLite T2 tier is a frozen
+    # migration source and the Java service is the live substrate — no client
+    # ever connects to this daemon (``run_t2_daemon`` already no-ops for the
+    # same reason). Without this check every caller (nx-mcp's first-run hook,
+    # ``nx upgrade``) cold-spawns a process that exits immediately by design,
+    # and repeated calls across concurrent MCP sessions trip the crash-loop
+    # guard below with a misleading "crash-loop suppressed" error even though
+    # nothing is actually broken (nexus-daemon-6.6.0-service-mode-skip).
+    from nexus.db.storage_mode import (  # noqa: PLC0415 — deferred import — CLI startup cost, only needed in this subcommand path
+        StorageBackend,
+        storage_backend_for,
+    )
+
+    if storage_backend_for("memory") == StorageBackend.SERVICE:
+        if not quiet:
+            click.echo(
+                "T2 daemon not needed: memory store is in service mode "
+                "(Java service is the live substrate)."
+            )
+        return T2EnsureOutcome.SERVICE_MODE_SKIP
 
     def _running_daemon() -> tuple[int, str] | None:
         """Return (pid, daemon_version) of the live daemon, or None.

--- a/src/nexus/daemon/aspect_worker_daemon.py
+++ b/src/nexus/daemon/aspect_worker_daemon.py
@@ -226,10 +226,32 @@ class AspectWorkerDaemon:
         """One reclaim sweep (the loop body; also the main-thread test seam).
         Emits a structured signal when rows are reset (RDR-173 P5 observability,
         nexus-xv5fl) so self-healing is observable, and logs a failure without
-        killing the loop."""
+        killing the loop.
+
+        nexus-64np7: rebuilds ``self._reclaim_queue`` on demand (here, not
+        just once at a failure site) so a rotated/expired credential baked
+        into the handle at construction time self-heals within one interval
+        instead of retrying the same broken client forever — this daemon is
+        long-lived and previously held ONE handle for its whole lifetime,
+        unlike the claim_batch path (mcp_infra._service_t2_write_locked)
+        which already evicts-and-rebuilds on any exception. The
+        2026-07-10 incident (401 every 30s for 23+ hours) had no recovery
+        short of a manual daemon restart before this fix. Retrying the
+        rebuild every call (rather than once at eviction time) also covers
+        a rebuild that itself transiently fails (e.g. the service is briefly
+        unreachable) — it gets another chance next interval instead of
+        going permanently silent.
+        """
+        if self._reclaim_queue is None:
+            try:
+                self._reclaim_queue = self._queue_factory()
+            except Exception as rebuild_exc:  # noqa: BLE001 - rebuild is best-effort; next interval retries
+                _log.warning(
+                    "aspect_worker_daemon.reclaim_queue_rebuild_failed",
+                    tenant=self._tenant, error=str(rebuild_exc),
+                )
+                return
         queue = self._reclaim_queue
-        if queue is None:
-            return
         try:
             n = queue.reclaim_stale(self._stale_timeout)
             if n:
@@ -242,6 +264,14 @@ class AspectWorkerDaemon:
                 "aspect_worker_daemon.reclaim_failed",
                 tenant=self._tenant, error=str(exc),
             )
+            self._reclaim_queue = None
+            try:
+                queue.close()
+            except Exception as close_exc:  # noqa: BLE001 - best-effort teardown of an already-broken client
+                _log.warning(
+                    "aspect_worker_daemon.reclaim_queue_close_failed",
+                    tenant=self._tenant, error=str(close_exc),
+                )
 
     def heartbeat_once(self) -> None:
         """Run a single heartbeat tick (test seam + the loop body)."""

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -323,6 +323,14 @@ def _reassert_t2_daemon() -> bool:
             "t2_index_write_version_skew_spawn_failed",
             "daemon spawn failed; the direct write below is safe (no live daemon)",
         ),
+        T2EnsureOutcome.SERVICE_MODE_SKIP: (
+            "t2_index_write_version_skew_service_mode_skip",
+            "memory store is in SERVICE mode (RDR-176); the SQLite daemon has no "
+            "role here — this path should not normally be reached (t2_index_write "
+            "already short-circuits to the service-backed writer before ever "
+            "constructing a T2Client), but the direct write below is safe "
+            "regardless (no live SQLite daemon to double-write against)",
+        ),
     }
     event, hint = events.get(
         outcome,

--- a/tests/daemon/test_aspect_worker_reclaim.py
+++ b/tests/daemon/test_aspect_worker_reclaim.py
@@ -163,3 +163,52 @@ def test_reclaim_failure_does_not_kill_the_loop(tmp_path: Path) -> None:
         assert len(q.reclaim_calls) >= 2   # survived the first failure, ticked again
     finally:
         d.stop()
+
+
+def test_reclaim_failure_evicts_and_rebuilds_queue(tmp_path: Path) -> None:
+    """nexus-64np7: a reclaim failure must evict the stale queue handle and
+    rebuild via queue_factory, so the NEXT sweep re-resolves credentials
+    instead of retrying the same broken client forever. Root cause of a
+    2026-07-10 incident: a rotated bearer token produced a 401 on
+    reclaim_stale every ~30s for 23+ hours with no recovery short of a
+    manual daemon restart, because this handle (unlike claim_batch's,
+    which already evicts via mcp_infra._service_t2_write_locked) was held
+    for the daemon's entire lifetime with no eviction on error."""
+
+    class _OnceFailingQueue(_FakeQueue):
+        def __init__(self, fail: bool) -> None:
+            super().__init__()
+            self._fail = fail
+
+        def reclaim_stale(self, timeout_seconds: int = 300) -> int:
+            self.reclaim_calls.append(timeout_seconds)
+            if self._fail:
+                raise RuntimeError("401 Unauthorized (stale token)")
+            return 0
+
+    created: list[_OnceFailingQueue] = []
+
+    def factory() -> _OnceFailingQueue:
+        q = _OnceFailingQueue(fail=(len(created) == 0))
+        created.append(q)
+        return q
+
+    d = AspectWorkerDaemon(
+        config_dir=tmp_path, tenant="default",
+        worker_factory=_FakeWorker, queue_factory=factory,
+        reclaim_interval=0.03, stale_timeout_seconds=60,
+    )
+    d.start()
+    try:
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and len(created) < 2:
+            time.sleep(0.02)
+        assert len(created) >= 2, "stale queue was never rebuilt after the failure"
+        assert created[0].reclaim_calls == [60]
+        assert created[0].closed == 1          # the stale (failed) handle was released
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and not created[1].reclaim_calls:
+            time.sleep(0.02)
+        assert created[1].reclaim_calls, "the rebuilt handle never got a chance to reclaim"
+    finally:
+        d.stop()

--- a/tests/daemon/test_t2_ensure_running_inner.py
+++ b/tests/daemon/test_t2_ensure_running_inner.py
@@ -122,6 +122,45 @@ class TestInnerReachable:
         assert outcome == T2EnsureOutcome.REACHABLE
 
 
+class TestInnerServiceModeSkip:
+    """RDR-176 Phase 1 (Gap 2): memory store in SERVICE mode -> no spawn."""
+
+    def test_service_mode_skips_without_spawning(self, tmp_path, monkeypatch) -> None:
+        from nexus.db import storage_mode
+
+        monkeypatch.setattr(
+            storage_mode, "storage_backend_for",
+            lambda store: storage_mode.StorageBackend.SERVICE,
+        )
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda *a, **kw: pytest.fail("must not spawn in service mode"),
+        )
+        outcome = _t2_ensure_running_inner(str(tmp_path), timeout=5.0, quiet=True)
+        assert outcome == T2EnsureOutcome.SERVICE_MODE_SKIP
+
+    def test_service_mode_skip_does_not_touch_crashloop_counter(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """A repeated skip must never accumulate toward the crash-loop guard —
+        that guard exists for genuine spawn failures, not a mode where no
+        spawn is ever attempted."""
+        from nexus.db import storage_mode
+
+        monkeypatch.setattr(
+            storage_mode, "storage_backend_for",
+            lambda store: storage_mode.StorageBackend.SERVICE,
+        )
+        import time as _t
+
+        import nexus.commands.daemon as _daemon
+
+        for _ in range(10):
+            outcome = _t2_ensure_running_inner(str(tmp_path), timeout=5.0, quiet=True)
+            assert outcome == T2EnsureOutcome.SERVICE_MODE_SKIP
+        assert not _daemon._crashloop_tripped(tmp_path, now=_t.time())
+
+
 # ---------------------------------------------------------------------------
 # DEFERRED_WRITE_LOCK path: stale daemon alive, WAL write-lock held
 # ---------------------------------------------------------------------------

--- a/tests/test_catalog_doctor_name_vs_embed_dim.py
+++ b/tests/test_catalog_doctor_name_vs_embed_dim.py
@@ -62,7 +62,43 @@ def _fake_t3(client, names: list[str]):
 
         def list_collections(self):
             return [{"name": n} for n in names]
+
+        def get_collection(self, name):
+            return client.get_collection(name)
+
+        def get_embeddings(self, collection_name, ids):
+            import numpy as np
+            col = client.get_collection(collection_name)
+            result = col.get(ids=ids, include=["embeddings"])
+            by_id = dict(zip(result["ids"], result["embeddings"]))
+            return np.array(
+                [by_id[i] for i in ids if i in by_id], dtype=np.float32,
+            )
     return _FakeT3()
+
+
+def _fake_t3_service_like(client, names: list[str]):
+    """Simulates HttpVectorClient's public surface only — no ``_client``
+    attribute. Regression guard for nexus-pyv0e: the doctor check must not
+    reach into Chroma internals, only the dual-mode-safe public methods
+    (``get_collection`` / ``get_embeddings``) both T3Database and
+    HttpVectorClient expose."""
+    class _FakeServiceT3:
+        def list_collections(self):
+            return [{"name": n} for n in names]
+
+        def get_collection(self, name):
+            return client.get_collection(name)
+
+        def get_embeddings(self, collection_name, ids):
+            import numpy as np
+            col = client.get_collection(collection_name)
+            result = col.get(ids=ids, include=["embeddings"])
+            by_id = dict(zip(result["ids"], result["embeddings"]))
+            return np.array(
+                [by_id[i] for i in ids if i in by_id], dtype=np.float32,
+            )
+    return _FakeServiceT3()
 
 
 class TestNameVsEmbedDim:
@@ -183,6 +219,50 @@ class TestNameVsEmbedDim:
         assert payload["pass"] is True
         assert payload["checked"] == 0
         assert name in payload["empty"]
+
+    def test_service_mode_no_client_attribute_does_not_crash(
+        self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Regression (nexus-pyv0e): HttpVectorClient has no ``_client``
+        attribute — reaching into it raised an unhandled AttributeError in
+        service/cloud mode. A T3 handle exposing only the public
+        get_collection/get_embeddings surface must work identically."""
+        name = "code__myproj__minilm-l6-v2-384__v1"
+        _seed(chroma_client, name)
+        monkeypatch.setattr(
+            "nexus.db.make_t3",
+            lambda: _fake_t3_service_like(chroma_client, [name]),
+        )
+        result = runner.invoke(
+            doctor_cmd, ["--name-vs-embed-dim", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is True
+        assert payload["mismatches"] == []
+        assert payload["checked"] == 1
+
+    def test_service_mode_mismatch_still_detected(
+        self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Same mismatch-detection guarantee holds on the service-like
+        (no ``_client``) path, not just the local-Chroma path."""
+        name = "code__myproj__voyage-code-3__v1"
+        _seed(chroma_client, name)
+        monkeypatch.setattr(
+            "nexus.db.make_t3",
+            lambda: _fake_t3_service_like(chroma_client, [name]),
+        )
+        result = runner.invoke(
+            doctor_cmd, ["--name-vs-embed-dim", "--json"],
+        )
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is False
+        m = payload["mismatches"][0]
+        assert m["collection"] == name
+        assert m["expected_dim"] == 1024
+        assert m["actual_dim"] == 384
 
     def test_text_output_includes_remediation_hint(
         self, runner, chroma_client, monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_rdr141_version_skew_double_writer.py
+++ b/tests/test_rdr141_version_skew_double_writer.py
@@ -206,6 +206,7 @@ def test_reassert_reachable_returns_true_without_warning(monkeypatch) -> None:
         ("DEFERRED_SIGTERM", "t2_index_write_version_skew_cycle_deferred_sigterm"),
         ("CRASHLOOP_SUPPRESSED", "t2_index_write_version_skew_crashloop_down"),
         ("SPAWN_FAILED", "t2_index_write_version_skew_spawn_failed"),
+        ("SERVICE_MODE_SKIP", "t2_index_write_version_skew_service_mode_skip"),
     ],
 )
 def test_reassert_nonreachable_returns_false_with_distinct_event(
@@ -312,6 +313,7 @@ def test_all_nonreachable_outcomes_have_a_distinct_event() -> None:
         T2EnsureOutcome.DEFERRED_SIGTERM,
         T2EnsureOutcome.CRASHLOOP_SUPPRESSED,
         T2EnsureOutcome.SPAWN_FAILED,
+        T2EnsureOutcome.SERVICE_MODE_SKIP,
     }
     non_reachable = set(T2EnsureOutcome) - {T2EnsureOutcome.REACHABLE}
     assert non_reachable == mapped, (


### PR DESCRIPTION
## Summary
Found while diagnosing a live "daemon is broken" report — three related gaps, all stemming from service/cloud mode being the now-primary storage backend (RDR-155) with some code paths never updated for it.

- **`_t2_ensure_running_inner`** (daemon.py): never checked SERVICE mode before spawning, unlike `run_t2_daemon`/`t2_index_write` which already short-circuit. Every caller (nx-mcp first-run hook, `nx upgrade`) cold-spawned a process that exits immediately by design, tripping the crash-loop guard with a misleading "crash-loop suppressed" error across concurrent sessions. Fixed with the same `storage_backend_for("memory") == StorageBackend.SERVICE` short-circuit as a new `SERVICE_MODE_SKIP` outcome.

- **`nx catalog doctor --name-vs-embed-dim`** (nexus-pyv0e): crashed with `AttributeError: 'HttpVectorClient' object has no attribute '_client'` in service/cloud mode — it reached into Chroma-specific internals. Switched to the dual-mode-safe public surface both `T3Database` and `HttpVectorClient` share: `get_collection(name).get(limit=1)` for a sample id, then `get_embeddings(name, ids)` for the vector.

- **aspect-worker `reclaim_stale`** (nexus-64np7): the daemon held one `HttpAspectQueue` handle for its entire lifetime with no eviction on error, unlike the `claim_batch` path which already evicts-and-rebuilds via `mcp_infra._service_t2_write_locked`. Root cause of a real 2026-07-10 incident: a rotated bearer token produced a 401 every ~30s for 23+ hours, only fixed by a manual daemon restart. `_reclaim_once` now rebuilds the queue handle on demand whenever it's `None`.

## Test plan
- [x] `uv run pytest tests/daemon/test_t2_ensure_running_inner.py -q` — 24 passed
- [x] `uv run pytest tests/test_catalog_doctor_name_vs_embed_dim.py -q` — 9 passed (2 new regression tests for the service-mode crash)
- [x] `uv run pytest tests/daemon/test_aspect_worker_reclaim.py -q` — 6 passed (1 new regression test for eviction/rebuild)
- [x] `uv run pytest tests/daemon/ tests/test_catalog_doctor_name_vs_embed_dim.py tests/test_catalog_cli.py tests/test_upgrade_name_vs_embed_dim_advisory.py -q` — 818 passed, 2 skipped, 3 deselected, 2 xfailed