### PR TITLE
fix(doctor): sweep remaining t3_db._client reach-throughs in catalog doctor

### DIFF
--- a/src/nexus/commands/catalog_cmds/doctor.py
+++ b/src/nexus/commands/catalog_cmds/doctor.py
@@ -664,7 +664,7 @@ def _run_chunk_size_distribution() -> dict:
     tables: dict[str, dict] = {}
     for name in collections:
         try:
-            col = t3._client.get_collection(name=name)
+            col = t3.get_collection(name=name)
         except Exception as exc:  # noqa: BLE001 — best-effort fallback path; failure is non-fatal here
             tables[name] = {"error": f"open: {exc}"}
             overall_pass = False
@@ -780,7 +780,7 @@ def _run_chunk_text_dedup() -> dict:
     chash_to_collections: dict[str, set[str]] = {}
     for name in collections:
         try:
-            col = t3._client.get_collection(name=name)
+            col = t3.get_collection(name=name)
         except Exception as exc:  # noqa: BLE001 — best-effort fallback path; failure is non-fatal here
             within_summary[name] = {"error": f"open: {exc}"}
             overall_pass = False
@@ -912,10 +912,16 @@ def _run_t3_vs_catalog() -> dict:
         # Only flag if the T3 collection actually has chunks; an empty
         # T3 collection with no docs is the zombie class below.
         try:
-            col = t3_db._client.get_collection(name=name)
+            col = t3_db.get_collection(name=name)
             count = col.count()
-        except Exception:  # noqa: BLE001 — boundary catch; third-party raises undocumented types, handled gracefully
-            count = 0
+        except Exception as exc:  # noqa: BLE001 — boundary catch; third-party raises undocumented types, handled gracefully
+            # nexus-pyv0e sibling: this used to reach into t3_db._client
+            # (Chroma-only), which raised AttributeError in service mode
+            # and got silently swallowed here into count=0 — a false PASS
+            # with zero detection capability, not a loud error. Record the
+            # failure instead of pretending the collection is empty.
+            t3_orphans.append({"name": name, "error": str(exc)})
+            continue
         if count > 0:
             t3_orphans.append({"name": name, "chunk_count": count})
 
@@ -925,11 +931,16 @@ def _run_t3_vs_catalog() -> dict:
         r["name"] for r in projection if not r.get("superseded_by")
     }
     zombies = []
+    zombie_errors: list[dict] = []
     for name in sorted(projection_names & t3_names):
         try:
-            col = t3_db._client.get_collection(name=name)
+            col = t3_db.get_collection(name=name)
             count = col.count()
-        except Exception:  # noqa: BLE001 — boundary catch; third-party raises undocumented types, handled gracefully
+        except Exception as exc:  # noqa: BLE001 — boundary catch; third-party raises undocumented types, handled gracefully
+            # nexus-pyv0e sibling: `continue`-past-error here previously
+            # meant a failed check for a candidate zombie silently dropped
+            # it from consideration — a false PASS, not a loud error.
+            zombie_errors.append({"name": name, "error": str(exc)})
             continue
         if count == 0:
             zombies.append(name)
@@ -943,11 +954,13 @@ def _run_t3_vs_catalog() -> dict:
 
     overall_pass = (
         not t3_orphans and not zombies and not docs_missing
+        and not zombie_errors
     )
     return {
         "pass": overall_pass,
         "t3_orphans": t3_orphans,
         "zombies": zombies,
+        "zombie_errors": zombie_errors,
         "docs_pointing_at_missing_t3": docs_missing,
     }
 
@@ -964,7 +977,10 @@ def _print_t3_vs_catalog_text(report: dict) -> None:
             f"({len(report['t3_orphans'])}):"
         )
         for o in report["t3_orphans"][:20]:
-            click.echo(f"    {o['name']}  chunks={o['chunk_count']}")
+            if "error" in o:
+                click.echo(f"    {o['name']}  ERROR: {o['error']}")
+            else:
+                click.echo(f"    {o['name']}  chunks={o['chunk_count']}")
     if report["zombies"]:
         click.echo(
             f"  Zombie collections (registered, 0 chunks in T3) "
@@ -975,6 +991,13 @@ def _print_t3_vs_catalog_text(report: dict) -> None:
         click.echo(
             "  Remediate: nx catalog collection-gc --apply"
         )
+    if report.get("zombie_errors"):
+        click.echo(
+            f"  Collections that could not be checked for zombie status "
+            f"({len(report['zombie_errors'])}):"
+        )
+        for e in report["zombie_errors"][:20]:
+            click.echo(f"    {e['name']}  ERROR: {e['error']}")
     if report["docs_pointing_at_missing_t3"]:
         click.echo(
             f"  Catalog documents whose physical_collection is gone "
@@ -1634,7 +1657,7 @@ def _run_t3_doc_id_coverage(
             continue
         _tc = _time.monotonic()
         try:
-            col = t3._client.get_collection(name=coll_name)
+            col = t3.get_collection(name=coll_name)
         except Exception as exc:  # noqa: BLE001 — best-effort fallback path; failure is non-fatal here
             per_coll[coll_name] = {
                 "error": f"open: {exc}",

--- a/tests/daemon/test_t2_daemon_observability.py
+++ b/tests/daemon/test_t2_daemon_observability.py
@@ -27,6 +27,7 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from nexus.cli import main
@@ -400,6 +401,35 @@ class TestCrashLoopRespawnRefusal:
             )
         assert spawns == []
         assert len(errors) == 1, f"must log once across invocations, saw {errors}"
+
+
+class TestEnsureRunningServiceModeSkipCli:
+    """nexus-daemon-6.6.0-service-mode-skip / critic finding on PR #1392:
+    the earlier tests only asserted ``_t2_ensure_running_inner``'s return
+    value directly. Drive the actual Click command so a future change to
+    ``t2_ensure_running_cmd``'s exit-code mapping (e.g. converting the
+    allowlist tuple to an exhaustive-style construct) has a test that
+    would catch SERVICE_MODE_SKIP landing in the failure branch."""
+
+    def test_service_mode_skip_exits_zero_through_cli(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.db import storage_mode
+
+        monkeypatch.setattr(
+            storage_mode, "storage_backend_for",
+            lambda store: storage_mode.StorageBackend.SERVICE,
+        )
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda *a, **kw: pytest.fail("must not spawn in service mode"),
+        )
+
+        result = CliRunner().invoke(
+            main, ["daemon", "t2", "ensure-running",
+                   "--config-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
 
 
 class _Unreachable:

--- a/tests/test_catalog_doctor_name_vs_embed_dim.py
+++ b/tests/test_catalog_doctor_name_vs_embed_dim.py
@@ -281,3 +281,85 @@ class TestNameVsEmbedDim:
         assert "name-vs-embed-dim: FAIL" in result.output
         assert name in result.output
         assert "rename" in result.output.lower()
+
+
+class TestNameVsEmbedDimRealHttpVectorClient:
+    """nexus-umvh2 doctrine (Wave-review CRITICAL, critic finding on
+    nexus-pyv0e): a hand-rolled duck-typed fake proves the fake's shape
+    doesn't crash, not that the REAL HttpVectorClient's actual
+    get_collection/get_embeddings work through the real doctor command in
+    service mode. Construct the real client; fake only the HTTP transport
+    (``_post``/``_get``) — a missing/renamed method on HttpVectorClient
+    fails HARD here instead of being absorbed by a duck-typed double.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_client(self):
+        from nexus.db.http_vector_client import reset_http_vector_client_for_tests
+        reset_http_vector_client_for_tests()
+        yield
+        reset_http_vector_client_for_tests()
+
+    def test_real_client_pass_when_dim_matches(
+        self, runner, monkeypatch: pytest.MonkeyPatch,
+    ):
+        from nexus.db.http_vector_client import HttpVectorClient
+
+        name = "code__nexus-1-1__voyage-code-3__v1"
+
+        def fake_get(path, **kw):
+            assert path == "/v1/vectors/stats"
+            return [{"name": name, "dim": 1024, "count": 1}]
+
+        def fake_post(path, body, **kw):
+            if path == "/v1/vectors/get":
+                assert body["collection"] == name
+                return {"ids": ["c1"], "documents": ["x"], "metadatas": [{}]}
+            if path == "/v1/vectors/get-embeddings":
+                assert body == {"collection": name, "ids": ["c1"]}
+                return {"embeddings": [[0.1] * 1024]}
+            raise AssertionError(f"unexpected path {path}")
+
+        monkeypatch.setattr("nexus.db.http_vector_client._get", fake_get)
+        monkeypatch.setattr("nexus.db.http_vector_client._post", fake_post)
+        monkeypatch.setattr("nexus.db.make_t3", lambda: HttpVectorClient())
+
+        result = runner.invoke(doctor_cmd, ["--name-vs-embed-dim", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is True
+        assert payload["checked"] == 1
+        assert payload["mismatches"] == []
+
+    def test_real_client_fail_when_dim_mismatches(
+        self, runner, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """The 4.28-era bug shape, reproduced through the REAL
+        HttpVectorClient: name claims voyage-code-3 (1024d) but the
+        service actually holds 384-dim vectors."""
+        from nexus.db.http_vector_client import HttpVectorClient
+
+        name = "code__nexus-1-1__voyage-code-3__v1"
+
+        def fake_get(path, **kw):
+            return [{"name": name, "dim": 384, "count": 1}]
+
+        def fake_post(path, body, **kw):
+            if path == "/v1/vectors/get":
+                return {"ids": ["c1"], "documents": ["x"], "metadatas": [{}]}
+            if path == "/v1/vectors/get-embeddings":
+                return {"embeddings": [[0.1] * 384]}
+            raise AssertionError(f"unexpected path {path}")
+
+        monkeypatch.setattr("nexus.db.http_vector_client._get", fake_get)
+        monkeypatch.setattr("nexus.db.http_vector_client._post", fake_post)
+        monkeypatch.setattr("nexus.db.make_t3", lambda: HttpVectorClient())
+
+        result = runner.invoke(doctor_cmd, ["--name-vs-embed-dim", "--json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout)["name_vs_embed_dim"]
+        assert payload["pass"] is False
+        m = payload["mismatches"][0]
+        assert m["collection"] == name
+        assert m["expected_dim"] == 1024
+        assert m["actual_dim"] == 384

--- a/tests/test_catalog_doctor_new_checks.py
+++ b/tests/test_catalog_doctor_new_checks.py
@@ -105,6 +105,9 @@ class TestChunkSizeDistribution:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
             def list_collections(self):
                 return [{"name": "code__ok"}]
 
@@ -139,6 +142,9 @@ class TestChunkSizeDistribution:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
             def list_collections(self):
                 return [{"name": "code__micros"}]
 
@@ -171,6 +177,9 @@ class TestChunkSizeDistribution:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
             def list_collections(self):
                 return [{"name": "code__big"}]
 
@@ -199,6 +208,9 @@ class TestChunkSizeDistribution:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
             def list_collections(self):
                 return [{"name": "taxonomy__centroids"}]
 
@@ -226,6 +238,9 @@ class TestChunkTextDedup:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
             def list_collections(self):
                 return [{"name": "code__cleanup"}]
@@ -260,6 +275,9 @@ class TestChunkTextDedup:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
             def list_collections(self):
                 return [{"name": "code__bug"}]
 
@@ -291,6 +309,9 @@ class TestChunkTextDedup:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
             def list_collections(self):
                 return [{"name": "code__a"}, {"name": "code__b"}]
@@ -335,6 +356,9 @@ class TestT3VsCatalog:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
             def list_collections(self):
                 return [{"name": "docs__clean"}]
 
@@ -365,6 +389,9 @@ class TestT3VsCatalog:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
             def list_collections(self):
                 return [{"name": "code__orphan"}]
@@ -401,6 +428,9 @@ class TestT3VsCatalog:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
             def list_collections(self):
                 return []  # no T3 collections at all

--- a/tests/test_catalog_doctor_t3_coverage.py
+++ b/tests/test_catalog_doctor_t3_coverage.py
@@ -113,6 +113,9 @@ class TestCoveragePasses:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
@@ -138,6 +141,9 @@ class TestCoveragePasses:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
@@ -169,6 +175,9 @@ class TestCoverageFails:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
@@ -194,6 +203,9 @@ class TestCoverageFails:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
@@ -228,6 +240,9 @@ class TestCoverageFails:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
@@ -268,6 +283,9 @@ class TestCombined:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
@@ -334,6 +352,9 @@ class TestOrphanRatioSurface:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
 
         # Text output assertions
@@ -403,6 +424,9 @@ class TestOrphanRatioSurface:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
 
         text_result = runner.invoke(doctor_cmd, ["--t3-doc-id-coverage"])
@@ -431,6 +455,9 @@ class TestOrphanRatioSurface:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
 
         json_result = runner.invoke(
@@ -498,6 +525,9 @@ class TestPhase3ManifestFallback:
         class _FakeT3:
             _client = chroma_client
 
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
+
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
 
         result = runner.invoke(
@@ -547,6 +577,9 @@ class TestBypassSchemaSkipped:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
@@ -598,6 +631,9 @@ class TestSupersededSkip:
 
         class _FakeT3:
             _client = chroma_client
+
+            def get_collection(self, name):
+                return chroma_client.get_collection(name)
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(


### PR DESCRIPTION
## Summary

Follow-up to #1392, from a stacked-review pass (code-review-expert + substantive-critic) dispatched retroactively after that PR merged without them.

- **`_run_t3_vs_catalog`** (2 sites, code-reviewer HIGH finding): silently swallowed `t3_db._client`'s AttributeError in service mode into a false PASS with zero detection — worse than a crash. Now records the failure explicitly instead of pretending the collection is empty/clean.
- **`_run_chunk_size_distribution`, `_run_chunk_text_dedup`, `_run_t3_doc_id_coverage`** (found via my own audit while fixing the above): same reach-through, but these already failed loud — broken-but-non-functional in service mode rather than dangerous. Switched to the same `t3.get_collection(name)` public surface the rest of the file already uses.
- Updated 22 fake-T3 test doubles across 3 test files that only implemented the old `_client` reach-through — caught by the full suite, not just the directly-touched test files.
- Added a real-`HttpVectorClient`-backed regression test for the original nexus-pyv0e fix (critic MEDIUM: existing tests used a duck-typed fake, violating the nexus-umvh2 doctrine).
- Added a CLI-level exit-code test for `SERVICE_MODE_SKIP` through the actual Click command (critic LOW finding).

The critic's third finding — this credential-staleness pattern (long-lived client bakes token, never rebuilds on 401) has been independently reinvented 3x across the codebase with no shared abstraction — is filed as `nexus-bikit`, not implemented here. That's a design decision spanning 11 classes with 3 existing independent implementations; not incident-cleanup scope.

## Test plan
- [x] `uv run pytest tests/test_catalog_doctor_new_checks.py tests/test_catalog_doctor_name_vs_embed_dim.py tests/test_catalog_cli.py -q` — 161 passed
- [x] `uv run pytest tests/test_catalog_doctor_t3_coverage.py -q` — 16 passed
- [x] `uv run pytest tests/daemon/test_t2_daemon_observability.py -q` — 15 passed
- [x] Full local suite: `uv run pytest tests/ -q` (2 pre-existing environmental-only failures deselected, unrelated to this diff — stale local Chroma Cloud credentials on this dev machine, confirmed clean on CI) — **12721 passed, 0 failed**